### PR TITLE
fix: harden components query and history flows

### DIFF
--- a/ts/packages/components/src/AnswerResults.test.tsx
+++ b/ts/packages/components/src/AnswerResults.test.tsx
@@ -140,6 +140,7 @@ describe("AnswerResults", () => {
         { timeout: 1000 }
       );
     });
+
   });
 
   describe("eval configuration", () => {

--- a/ts/packages/components/src/Antfly.tsx
+++ b/ts/packages/components/src/Antfly.tsx
@@ -1,6 +1,6 @@
-import { type ReactNode, useEffect } from "react";
+import { type ReactNode, useEffect, useMemo } from "react";
 import Listener from "./Listener";
-import type { SharedAction, SharedState } from "./SharedContext";
+import { useSharedContext, type SharedAction, type SharedState } from "./SharedContext";
 import { SharedContextProvider } from "./SharedContextProvider";
 import { initializeAntflyClient } from "./utils";
 
@@ -12,18 +12,44 @@ export interface AntflyProps {
   headers?: Record<string, string>;
 }
 
+function SharedConfigSync({
+  url,
+  table,
+  headers,
+}: {
+  url: string;
+  table: string;
+  headers: Record<string, string>;
+}) {
+  const [, dispatch] = useSharedContext();
+
+  useEffect(() => {
+    dispatch({
+      type: "setSharedConfig",
+      url,
+      table,
+      headers,
+    });
+  }, [dispatch, url, table, headers]);
+
+  return null;
+}
+
 export default function Antfly({ children, url, table, onChange, headers = {} }: AntflyProps) {
+  const headersKey = JSON.stringify(headers);
+  const stableHeaders = useMemo(() => headers, [headersKey]);
+
   const initialState: SharedState = {
     url,
     table,
     listenerEffect: null,
     widgets: new Map(),
-    headers,
+    headers: stableHeaders,
   };
 
   useEffect(() => {
-    initializeAntflyClient(url, headers);
-  }, [url, headers]);
+    initializeAntflyClient(url, stableHeaders);
+  }, [url, stableHeaders]);
 
   const reducer = (state: SharedState, action: SharedAction): SharedState => {
     switch (action.type) {
@@ -81,6 +107,13 @@ export default function Antfly({ children, url, table, onChange, headers = {} }:
       }
       case "setListenerEffect":
         return { ...state, listenerEffect: action.value };
+      case "setSharedConfig":
+        return {
+          ...state,
+          url: action.url,
+          table: action.table,
+          headers: action.headers,
+        };
       default:
         return state;
     }
@@ -88,6 +121,7 @@ export default function Antfly({ children, url, table, onChange, headers = {} }:
 
   return (
     <SharedContextProvider initialState={initialState} reducer={reducer}>
+      <SharedConfigSync url={url} table={table} headers={stableHeaders} />
       <Listener onChange={onChange}>{children}</Listener>
     </SharedContextProvider>
   );

--- a/ts/packages/components/src/Integration.test.tsx
+++ b/ts/packages/components/src/Integration.test.tsx
@@ -180,6 +180,37 @@ describe("Integration Tests", () => {
         expect(container.querySelector(".react-af-results")).toBeTruthy();
       });
     });
+
+    it("should call onResults when query results arrive", async () => {
+      const hits: QueryHit[] = [
+        { _id: "1", _score: 1.0, _source: { title: "First result" } },
+        { _id: "2", _score: 0.8, _source: { title: "Second result" } },
+      ];
+      const msearchSpy = mockMultiquery(hits);
+      const onResults = vi.fn();
+
+      const { container } = render(
+        <TestWrapper>
+          <QueryBox id="search" mode="live" />
+          <Results
+            id="results"
+            searchBoxId="search"
+            fields={["title"]}
+            onResults={onResults}
+            items={() => <div />}
+          />
+        </TestWrapper>
+      );
+
+      const input = container.querySelector("input") as HTMLInputElement;
+      await userEvent.type(input, "test");
+
+      await waitFor(() => {
+        expect(onResults).toHaveBeenCalledWith(hits, hits.length);
+      });
+
+      msearchSpy.mockRestore();
+    });
   });
 
   describe("Full search workflow", () => {

--- a/ts/packages/components/src/Listener.test.tsx
+++ b/ts/packages/components/src/Listener.test.tsx
@@ -337,6 +337,186 @@ describe("Listener", () => {
       expect(input.value).toBe("semantic test");
     });
 
+    it("should omit full_text_search for semantic-only Results queries", async () => {
+      const utils = await import("./utils");
+      const msearchSpy = vi.spyOn(utils, "multiquery").mockResolvedValue({
+        responses: [
+          {
+            status: 200,
+            took: 10,
+            hits: { hits: [], total: 0 },
+          },
+        ],
+      });
+
+      const { container } = render(
+        <TestWrapper>
+          <QueryBox id="main" mode="live" />
+          <Results
+            id="results-sem"
+            searchBoxId="main"
+            semanticIndexes={["main_semantic_index"]}
+            limit={20}
+            items={() => <div />}
+          />
+        </TestWrapper>
+      );
+
+      const input = container.querySelector("input") as HTMLInputElement;
+      expect(input).toBeTruthy();
+
+      await userEvent.type(input, "what's");
+
+      await waitFor(() => {
+        expect(msearchSpy).toHaveBeenCalled();
+      });
+
+      const queries = msearchSpy.mock.calls.flatMap((call) => call[1] || []);
+      const semanticQuery = queries.find(
+        (request: { query?: { semantic_search?: string; indexes?: string[] } }) =>
+          request.query?.semantic_search === "what's"
+      );
+
+      expect(semanticQuery?.query?.indexes).toEqual(["main_semantic_index"]);
+      expect(semanticQuery?.query).not.toHaveProperty("full_text_search");
+
+      msearchSpy.mockRestore();
+    });
+
+    it("should refetch autosuggest queries when autosuggest configuration changes", async () => {
+      const utils = await import("./utils");
+      const msearchSpy = vi.spyOn(utils, "multiquery").mockImplementation(async (_url, requests) => ({
+        responses: requests.map(() => ({
+          status: 200,
+          took: 10,
+          hits: { hits: [], total: 0 },
+        })),
+      }));
+
+      const { container, rerender } = render(
+        <TestWrapper>
+          <QueryBox id="main" mode="live">
+            <Autosuggest fields={["title__keyword"]} minChars={1} debounceMs={0} />
+          </QueryBox>
+          <Results
+            id="results-main"
+            searchBoxId="main"
+            fields={["title__keyword"]}
+            items={() => <div />}
+          />
+        </TestWrapper>
+      );
+
+      const input = container.querySelector("input") as HTMLInputElement;
+      expect(input).toBeTruthy();
+
+      await userEvent.type(input, "foo");
+
+      await waitFor(() => {
+        expect(msearchSpy).toHaveBeenCalled();
+      });
+
+      const callCountBeforeRerender = msearchSpy.mock.calls.length;
+
+      rerender(
+        <TestWrapper>
+          <QueryBox id="main" mode="live">
+            <Autosuggest fields={["name__keyword"]} minChars={1} debounceMs={0} />
+          </QueryBox>
+          <Results
+            id="results-main"
+            searchBoxId="main"
+            fields={["title__keyword"]}
+            items={() => <div />}
+          />
+        </TestWrapper>
+      );
+
+      await waitFor(() => {
+        expect(msearchSpy.mock.calls.length).toBeGreaterThan(callCountBeforeRerender);
+      });
+
+      const latestQueries = msearchSpy.mock.calls[msearchSpy.mock.calls.length - 1][1];
+      const autosuggestQuery = latestQueries.find(
+        (request: { query?: { fields?: string[] } }) => request.query?.fields?.[0] === "name__keyword"
+      );
+
+      expect(autosuggestQuery).toBeTruthy();
+
+      msearchSpy.mockRestore();
+    });
+
+    it("should refetch existing queries when Antfly backend context changes", async () => {
+      const utils = await import("./utils");
+      const msearchSpy = vi.spyOn(utils, "multiquery").mockResolvedValue({
+        responses: [
+          {
+            status: 200,
+            took: 10,
+            hits: { hits: [], total: 0 },
+          },
+        ],
+      });
+
+      const { container, rerender } = render(
+        <Antfly
+          url="http://localhost:8082/api/v1"
+          table="docs"
+          headers={{ Authorization: "ApiKey one" }}
+        >
+          <QueryBox id="main" mode="live" />
+          <Results
+            id="results-main"
+            searchBoxId="main"
+            fields={["title__keyword"]}
+            items={() => <div />}
+          />
+        </Antfly>
+      );
+
+      const input = container.querySelector("input") as HTMLInputElement;
+      expect(input).toBeTruthy();
+
+      await userEvent.type(input, "foo");
+
+      await waitFor(() => {
+        expect(msearchSpy).toHaveBeenCalled();
+      });
+
+      const initialCallCount = msearchSpy.mock.calls.length;
+      const firstCall = msearchSpy.mock.calls[initialCallCount - 1];
+      expect(firstCall[0]).toBe("http://localhost:8082/api/v1");
+      expect(firstCall[2]).toEqual({ Authorization: "ApiKey one" });
+      expect(firstCall[1][0].query.table).toBe("docs");
+
+      rerender(
+        <Antfly
+          url="http://localhost:8083/api/v1"
+          table="docs_v2"
+          headers={{ Authorization: "ApiKey two" }}
+        >
+          <QueryBox id="main" mode="live" />
+          <Results
+            id="results-main"
+            searchBoxId="main"
+            fields={["title__keyword"]}
+            items={() => <div />}
+          />
+        </Antfly>
+      );
+
+      await waitFor(() => {
+        expect(msearchSpy.mock.calls.length).toBeGreaterThan(initialCallCount);
+      });
+
+      const latestCall = msearchSpy.mock.calls[msearchSpy.mock.calls.length - 1];
+      expect(latestCall[0]).toBe("http://localhost:8083/api/v1");
+      expect(latestCall[2]).toEqual({ Authorization: "ApiKey two" });
+      expect(latestCall[1][0].query.table).toBe("docs_v2");
+
+      msearchSpy.mockRestore();
+    });
+
     it("should include autosuggest's own semantic query when autosuggest queries for results", async () => {
       // Regression test for bug where:
       // - Autosuggest has semanticIndexes configured and wantResults: true

--- a/ts/packages/components/src/Listener.tsx
+++ b/ts/packages/components/src/Listener.tsx
@@ -99,10 +99,35 @@ export default function Listener({ children, onChange }: ListenerProps) {
   const configurations = mapFrom("configuration");
   const values = mapFrom("value");
 
-  // Create stable keys for dependency comparison
-  const queriesKey = JSON.stringify(Array.from(queries.entries()).sort());
-  const semanticQueriesKey = JSON.stringify(Array.from(semanticQueries.entries()).sort());
-  const configurationsKey = JSON.stringify(Array.from(configurations.entries()).sort());
+  const isAutosuggestWidget = (widgetId: string) => widgets.get(widgetId)?.isAutosuggest === true;
+
+  function entriesForGroup<T>(entries: Iterable<[string, T]>, autosuggestOnly: boolean): Array<[string, T]> {
+    return Array.from(entries)
+      .filter(([widgetId]) => isAutosuggestWidget(widgetId) === autosuggestOnly)
+      .sort();
+  }
+
+  // Track change groups using the actual widget inputs that drive requests.
+  // This keeps autosuggest keystrokes isolated from submitted search widgets
+  // while still invalidating correctly when configuration or backend context changes.
+  const autosuggestGroupKey = JSON.stringify({
+    context: { url, table, headers },
+    queries: entriesForGroup(queries.entries(), true),
+    semanticQueries: entriesForGroup(semanticQueries.entries(), true),
+    configurations: entriesForGroup(configurations.entries(), true),
+  });
+  const nonAutosuggestGroupKey = JSON.stringify({
+    context: { url, table, headers },
+    queries: entriesForGroup(queries.entries(), false),
+    semanticQueries: entriesForGroup(semanticQueries.entries(), false),
+    configurations: entriesForGroup(configurations.entries(), false),
+  });
+
+  // Track previous group keys to determine which request families changed.
+  const prevGroupKeysRef = useRef({
+    autosuggest: "",
+    nonAutosuggest: "",
+  });
 
   useEffect(() => {
     // Apply custom callback effect on every change, useful for query params.
@@ -146,8 +171,22 @@ export default function Listener({ children, onChange }: ListenerProps) {
           dispatch({
             type: "setListenerEffect",
             value: () => {
+              // Determine which request groups changed to avoid re-sending stale queries.
+              // Autosuggest updates should not invalidate submitted search results unless the
+              // non-autosuggest request inputs actually changed.
+              const prev = prevGroupKeysRef.current;
+              const autosuggestChanged = autosuggestGroupKey !== prev.autosuggest;
+              const nonAutosuggestChanged = nonAutosuggestGroupKey !== prev.nonAutosuggest;
+              prevGroupKeysRef.current = {
+                autosuggest: autosuggestGroupKey,
+                nonAutosuggest: nonAutosuggestGroupKey,
+              };
+
               const multiqueryData: MSSearchItem[] = [];
               resultWidgets.forEach((r, id) => {
+                // Skip widgets whose query group hasn't changed
+                if (r.isAutosuggest && !autosuggestChanged) return;
+                if (!r.isAutosuggest && !nonAutosuggestChanged) return;
                 const config = r.configuration;
                 // Type guard to ensure configuration has required SearchWidgetConfig properties
                 if (!isSearchWidgetConfig(config)) {
@@ -168,6 +207,7 @@ export default function Listener({ children, onChange }: ListenerProps) {
 
                 const nonAutosuggestSemanticQueries = filteredSemanticQueries.map(([, v]) => v);
                 const semanticQuery = nonAutosuggestSemanticQueries.map((v) => v.query).join(" ");
+                const hasSemanticQuery = semanticQuery.length > 0;
                 // Get the first indexes configured for the widget
                 const indexes = nonAutosuggestSemanticQueries
                   .map((v) => v.indexes)
@@ -201,13 +241,15 @@ export default function Listener({ children, onChange }: ListenerProps) {
                 // Build the query object
                 const queryObj: Record<string, unknown> = {
                   table: tableName,
-                  semantic_search: semanticQuery || undefined,
-                  indexes: semanticQuery ? indexes : undefined,
-                  full_text_search: conjunctsFrom(filteredQueries),
+                  semantic_search: hasSemanticQuery ? semanticQuery : undefined,
+                  indexes: hasSemanticQuery ? indexes : undefined,
                   limit: itemsPerPage,
                   offset: (page - 1) * itemsPerPage,
                   order_by: sort,
                 };
+                if (filteredQueries.size > 0 || !hasSemanticQuery) {
+                  queryObj.full_text_search = conjunctsFrom(filteredQueries);
+                }
                 if (config.fields) {
                   queryObj.fields = config.fields;
                 }
@@ -233,7 +275,6 @@ export default function Listener({ children, onChange }: ListenerProps) {
                   queryObj.aggregations = aggregations;
                 }
 
-                // If there is no indexes, use the default one.
                 multiqueryData.push({
                   query: queryObj,
                   data: (result: QueryResult) => result.hits?.hits || [],
@@ -252,8 +293,9 @@ export default function Listener({ children, onChange }: ListenerProps) {
                 });
               });
 
-              // Fetch data for internal facet components.
+              // Fetch data for internal facet components (non-autosuggest only).
               facetWidgets.forEach((f, id) => {
+                if (!nonAutosuggestChanged) return;
                 // Resolve table for this widget
                 const tableName = resolveTable(f.table, table);
 
@@ -483,11 +525,10 @@ export default function Listener({ children, onChange }: ListenerProps) {
     headers,
     searchWidgets.size,
     configurableWidgets.size,
-    configurationsKey,
     facetWidgets.size,
-    queriesKey,
     resultWidgets.size,
-    semanticQueriesKey,
+    autosuggestGroupKey,
+    nonAutosuggestGroupKey,
     semanticQueries.size,
     table,
     widgets.size,

--- a/ts/packages/components/src/QueryBox.test.tsx
+++ b/ts/packages/components/src/QueryBox.test.tsx
@@ -246,6 +246,126 @@ describe("QueryBox", () => {
         expect(capturedWidget?.submittedAt).not.toBe(beforeSubmit);
       });
     });
+
+    it("should auto-submit an initial value when requested", async () => {
+      let capturedWidget: Widget | undefined;
+      const onWidgetUpdate = vi.fn((widget: Widget | undefined) => {
+        capturedWidget = widget;
+      });
+      const onSubmit = vi.fn();
+
+      render(
+        <TestWrapper>
+          <QueryBox
+            id="test-search"
+            mode="submit"
+            initialValue="retry me"
+            autoSubmit={true}
+            onSubmit={onSubmit}
+          />
+          <WidgetSpy widgetId="test-search" onWidgetUpdate={onWidgetUpdate} />
+        </TestWrapper>
+      );
+
+      await waitFor(() => {
+        expect(onSubmit).toHaveBeenCalledWith("retry me");
+        expect(capturedWidget?.value).toBe("retry me");
+        expect(capturedWidget?.submittedAt).toBeDefined();
+      });
+    });
+
+    it("should re-submit the same initial value when submitSignal changes", async () => {
+      const onSubmit = vi.fn();
+
+      const { rerender } = render(
+        <TestWrapper>
+          <QueryBox
+            id="test-search"
+            mode="submit"
+            initialValue="retry me"
+            autoSubmit={true}
+            submitSignal={1}
+            onSubmit={onSubmit}
+          />
+        </TestWrapper>
+      );
+
+      await waitFor(() => {
+        expect(onSubmit).toHaveBeenCalledTimes(1);
+      });
+
+      rerender(
+        <TestWrapper>
+          <QueryBox
+            id="test-search"
+            mode="submit"
+            initialValue="retry me"
+            autoSubmit={true}
+            submitSignal={2}
+            onSubmit={onSubmit}
+          />
+        </TestWrapper>
+      );
+
+      await waitFor(() => {
+        expect(onSubmit).toHaveBeenCalledTimes(2);
+      });
+    });
+
+    it("should clear the visible input after submit when clearOnSubmit is enabled", async () => {
+      let capturedWidget: Widget | undefined;
+      const onWidgetUpdate = vi.fn((widget: Widget | undefined) => {
+        capturedWidget = widget;
+      });
+      const onSubmit = vi.fn();
+
+      const { container } = render(
+        <TestWrapper>
+          <QueryBox id="test-search" mode="submit" clearOnSubmit={true} onSubmit={onSubmit} />
+          <WidgetSpy widgetId="test-search" onWidgetUpdate={onWidgetUpdate} />
+        </TestWrapper>
+      );
+
+      const input = container.querySelector("input") as HTMLInputElement;
+      await userEvent.type(input, "clear me");
+
+      const form = container.querySelector("form");
+      expect(form).toBeTruthy();
+
+      if (form) {
+        await act(async () => {
+          fireEvent.submit(form);
+        });
+      }
+
+      await waitFor(() => {
+        expect(onSubmit).toHaveBeenCalledWith("clear me");
+        expect(input.value).toBe("");
+        expect(capturedWidget?.value).toBe("clear me");
+        expect(capturedWidget?.submittedAt).toBeDefined();
+      });
+    });
+
+    it("should auto-submit for custom inputs without relying on a form wrapper", async () => {
+      const onSubmit = vi.fn();
+
+      render(
+        <TestWrapper>
+          <QueryBox
+            id="test-search"
+            mode="submit"
+            initialValue="custom retry"
+            autoSubmit={true}
+            renderInput={({ value }) => <textarea aria-label="Custom Query" value={value} readOnly />}
+            onSubmit={onSubmit}
+          />
+        </TestWrapper>
+      );
+
+      await waitFor(() => {
+        expect(onSubmit).toHaveBeenCalledWith("custom retry");
+      });
+    });
   });
 
   describe("live mode behavior", () => {

--- a/ts/packages/components/src/QueryBox.tsx
+++ b/ts/packages/components/src/QueryBox.tsx
@@ -31,12 +31,15 @@ export interface QueryBoxProps {
   id: string;
   mode?: "live" | "submit";
   initialValue?: string;
+  autoSubmit?: boolean;
+  submitSignal?: string | number;
   placeholder?: string;
   children?: ReactNode;
   buttonLabel?: string;
   onSubmit?: (value: string) => void;
   onInputChange?: (value: string) => void;
   onEscape?: (clearInput: () => void) => boolean; // Return true to prevent default clear behavior
+  clearOnSubmit?: boolean;
   /**
    * Custom input renderer. When provided, replaces the default <input> element.
    * The custom component receives props for value management, submission, and keyboard handling.
@@ -50,17 +53,22 @@ export default function QueryBox({
   id,
   mode = "live",
   initialValue,
+  autoSubmit = false,
+  submitSignal,
   placeholder,
   children,
   buttonLabel = "Submit",
   onSubmit,
   onInputChange,
   onEscape,
+  clearOnSubmit = false,
   renderInput,
 }: QueryBoxProps) {
   const [{ widgets }, dispatch] = useSharedContext();
   const [value, setValue] = useState(initialValue || "");
   const isExternalUpdate = useRef(false);
+  const lastAppliedInitialValueRef = useRef<string | undefined>(initialValue);
+  const lastAutoSubmitKeyRef = useRef<string | null>(null);
   const [isSuggestOpen, setIsSuggestOpen] = useState(false);
   const [containerRefObject] = useState<{ current: HTMLDivElement | null }>({ current: null });
   const containerRef = useCallback(
@@ -91,10 +99,51 @@ export default function QueryBox({
 
   // Initialize on mount
   useEffect(() => {
-    const valueToSet = initialValue || "";
-    setValue(valueToSet);
-    updateWidget(valueToSet);
-  }, [initialValue, updateWidget]); // eslint-disable-line react-hooks/exhaustive-deps
+    updateWidget(initialValue || "");
+  }, [updateWidget]);
+
+  useEffect(() => {
+    if (initialValue === undefined || initialValue === lastAppliedInitialValueRef.current) {
+      return;
+    }
+    lastAppliedInitialValueRef.current = initialValue;
+    setValue(initialValue);
+    updateWidget(initialValue);
+  }, [initialValue, updateWidget]);
+
+  const submitValue = useCallback(
+    (submittedValue: string) => {
+      setIsSuggestOpen(false);
+
+      if (onSubmit) {
+        onSubmit(submittedValue);
+      }
+
+      updateWidget(submittedValue, true);
+
+      if (clearOnSubmit) {
+        setValue("");
+        onInputChange?.("");
+      }
+    },
+    [clearOnSubmit, onInputChange, onSubmit, updateWidget]
+  );
+
+  useEffect(() => {
+    if (!autoSubmit || mode !== "submit" || initialValue === undefined || !initialValue.trim()) {
+      return;
+    }
+
+    const autoSubmitKey = `${String(submitSignal ?? "__default__")}::${initialValue}`;
+    if (autoSubmitKey === lastAutoSubmitKeyRef.current) {
+      return;
+    }
+
+    lastAutoSubmitKeyRef.current = autoSubmitKey;
+    lastAppliedInitialValueRef.current = initialValue;
+    setValue(initialValue);
+    submitValue(initialValue);
+  }, [autoSubmit, initialValue, mode, submitSignal, submitValue]);
 
   // Sync with external updates (e.g., from ActiveFilters)
   // NOTE: Only sync in "live" mode - in "submit" mode, local state is authoritative until form submission
@@ -139,19 +188,9 @@ export default function QueryBox({
   const handleSubmit = useCallback(
     (e: React.FormEvent) => {
       e.preventDefault();
-
-      // Close autosuggest dropdown on submit
-      setIsSuggestOpen(false);
-
-      // Call custom onSubmit callback if provided
-      if (onSubmit) {
-        onSubmit(value);
-      }
-
-      // Update widget state with submission timestamp
-      updateWidget(value, true);
+      submitValue(value);
     },
-    [value, updateWidget, onSubmit]
+    [submitValue, value]
   );
 
   // Handle clear button click
@@ -185,17 +224,7 @@ export default function QueryBox({
       // For custom inputs like PromptInput, Shift+Enter is used for newlines
       if (e.key === "Enter" && !e.shiftKey && mode === "submit") {
         e.preventDefault();
-
-        // Close autosuggest dropdown on submit
-        setIsSuggestOpen(false);
-
-        // Call custom onSubmit callback if provided
-        if (onSubmit) {
-          onSubmit(value);
-        }
-
-        // Update widget state and trigger query
-        updateWidget(value, true);
+        submitValue(value);
       } else if (e.key === "Escape") {
         e.preventDefault();
 
@@ -220,7 +249,7 @@ export default function QueryBox({
         }
       }
     },
-    [mode, value, isSuggestOpen, onSubmit, onEscape, updateWidget, clearInputOnly, handleClear]
+    [mode, value, isSuggestOpen, onEscape, clearInputOnly, handleClear, submitValue]
   );
 
   // Handle suggestion selection from Autosuggest
@@ -321,15 +350,9 @@ export default function QueryBox({
   // Handler for custom input onSubmit
   const handleCustomInputSubmit = useCallback(
     (submittedValue: string) => {
-      setIsSuggestOpen(false);
-
-      if (onSubmit) {
-        onSubmit(submittedValue);
-      }
-
-      updateWidget(submittedValue, true);
+      submitValue(submittedValue);
     },
-    [onSubmit, updateWidget]
+    [submitValue]
   );
 
   // Build props for custom input

--- a/ts/packages/components/src/Results.tsx
+++ b/ts/packages/components/src/Results.tsx
@@ -1,5 +1,5 @@
 import type { QueryHit } from "@antfly/sdk";
-import React, { type ReactNode, useCallback, useEffect, useState } from "react";
+import React, { type ReactNode, useCallback, useEffect, useRef, useState } from "react";
 import Pagination from "./Pagination";
 import { useSharedContext } from "./SharedContext";
 import { disjunctsFrom } from "./utils";
@@ -25,6 +25,7 @@ export interface ResultsProps {
   ) => ReactNode;
   stats?: (total: number) => ReactNode;
   items: (data: QueryHit[]) => ReactNode;
+  onResults?: (data: QueryHit[], total: number) => void;
 
   // Optional overrides
   sort?: unknown;
@@ -45,6 +46,7 @@ export default function Results({
   pagination,
   stats,
   items,
+  onResults,
   sort,
   table,
   filterQuery,
@@ -54,6 +56,7 @@ export default function Results({
   const [page, setPage] = useState(initialPage);
   const [lastQueryHash, setLastQueryHash] = useState<string | null>(null);
   const [isInitialized, setIsInitialized] = useState(false);
+  const lastNotifiedResultRef = useRef<unknown>(undefined);
 
   const widget = widgets.get(id);
   const data = widget?.result?.data ? widget.result.data : [];
@@ -184,6 +187,17 @@ export default function Results({
 
   // Destroy widget from context (remove from the list to unapply its effects)
   useEffect(() => () => dispatch({ type: "deleteWidget", key: id }), [dispatch, id]);
+
+  useEffect(() => {
+    if (!onResults || !widget?.result || widget.result.error) {
+      return;
+    }
+    if (lastNotifiedResultRef.current === widget.result) {
+      return;
+    }
+    lastNotifiedResultRef.current = widget.result;
+    onResults(data, total);
+  }, [data, onResults, total, widget?.result]);
 
   const defaultPagination = () => (
     <Pagination

--- a/ts/packages/components/src/SharedContext.tsx
+++ b/ts/packages/components/src/SharedContext.tsx
@@ -80,6 +80,12 @@ export type SharedAction =
   | {
       type: "setListenerEffect";
       value: (() => void) | null;
+    }
+  | {
+      type: "setSharedConfig";
+      url?: string;
+      table: string;
+      headers?: Record<string, string>;
     };
 
 export type SharedContextType = [SharedState, Dispatch<SharedAction>] | null;

--- a/ts/packages/components/src/hooks/useSearchHistory.test.tsx
+++ b/ts/packages/components/src/hooks/useSearchHistory.test.tsx
@@ -25,6 +25,7 @@ describe("useSearchHistory", () => {
   it("should load existing history from localStorage", () => {
     const existingHistory: SearchResult[] = [
       {
+        id: "existing-1",
         query: "test query",
         timestamp: Date.now(),
         summary: "test summary",
@@ -43,6 +44,7 @@ describe("useSearchHistory", () => {
     const { result } = renderHook(() => useSearchHistory(10));
 
     const searchResult: SearchResult = {
+      id: "search-1",
       query: "how does raft work",
       timestamp: Date.now(),
       summary: "Raft is a consensus algorithm",
@@ -66,6 +68,7 @@ describe("useSearchHistory", () => {
     const { result } = renderHook(() => useSearchHistory(10));
 
     const firstResult: SearchResult = {
+      id: "first-1",
       query: "first",
       timestamp: 1,
       summary: "first summary",
@@ -73,6 +76,7 @@ describe("useSearchHistory", () => {
     };
 
     const secondResult: SearchResult = {
+      id: "second-1",
       query: "second",
       timestamp: 2,
       summary: "second summary",
@@ -98,6 +102,7 @@ describe("useSearchHistory", () => {
     const results: SearchResult[] = [];
     for (let i = 0; i < 5; i++) {
       results.push({
+        id: `result-${i}`,
         query: `query ${i}`,
         timestamp: i,
         summary: `summary ${i}`,
@@ -122,6 +127,7 @@ describe("useSearchHistory", () => {
     const { result } = renderHook(() => useSearchHistory(10));
 
     const searchResult: SearchResult = {
+      id: "clear-1",
       query: "test",
       timestamp: Date.now(),
       summary: "test",
@@ -146,6 +152,7 @@ describe("useSearchHistory", () => {
     const { result } = renderHook(() => useSearchHistory(0));
 
     const searchResult: SearchResult = {
+      id: "disabled-1",
       query: "test",
       timestamp: Date.now(),
       summary: "test",
@@ -181,6 +188,7 @@ describe("useSearchHistory", () => {
     };
 
     const searchResult: SearchResult = {
+      id: "quota-1",
       query: "test",
       timestamp: Date.now(),
       summary: "test",
@@ -208,6 +216,7 @@ describe("useSearchHistory", () => {
     act(() => {
       for (let i = 0; i < 5; i++) {
         result.current.saveSearch({
+          id: `dynamic-${i}`,
           query: `query ${i}`,
           timestamp: i,
           summary: `summary ${i}`,
@@ -224,6 +233,7 @@ describe("useSearchHistory", () => {
     // Add one more result
     act(() => {
       result.current.saveSearch({
+        id: "dynamic-5",
         query: "query 5",
         timestamp: 5,
         summary: "summary 5",

--- a/ts/packages/components/src/hooks/useSearchHistory.ts
+++ b/ts/packages/components/src/hooks/useSearchHistory.ts
@@ -14,9 +14,10 @@ export interface CitationMetadata {
  * Represents a single search result in history
  */
 export interface SearchResult {
+  id: string;
   query: string;
   timestamp: number;
-  summary: string;
+  summary?: string;
   hits: QueryHit[];
   citations?: CitationMetadata[];
 }
@@ -39,10 +40,11 @@ export interface SearchHistory {
  *
  * @example
  * ```typescript
- * const { history, isReady, saveSearch, clearHistory } = useSearchHistory(10);
+ * const { history, isReady, upsertSearch, clearHistory } = useSearchHistory(10);
  *
  * // Save a search result
- * saveSearch({
+ * upsertSearch({
+ *   id: "search-123",
  *   query: "how does raft work",
  *   timestamp: Date.now(),
  *   summary: "Raft is a consensus algorithm...",
@@ -75,13 +77,14 @@ export function useSearchHistory(maxResults = 10) {
   // History is loaded synchronously via lazy initializer, so always ready
   const isReady = true;
 
-  // Save search result
-  const saveSearch = useCallback(
+  // Insert or update a search result by id
+  const upsertSearch = useCallback(
     (result: SearchResult) => {
       if (maxResults === 0) return; // History disabled
 
       setHistory((prev) => {
-        const updated = [result, ...prev].slice(0, maxResults);
+        const existingWithoutCurrent = prev.filter((entry) => entry.id !== result.id);
+        const updated = [result, ...existingWithoutCurrent].slice(0, maxResults);
 
         if (typeof window === "undefined") return updated;
 
@@ -96,6 +99,9 @@ export function useSearchHistory(maxResults = 10) {
     [maxResults]
   );
 
+  // Backward-compatible alias
+  const saveSearch = upsertSearch;
+
   // Clear history
   const clearHistory = useCallback(() => {
     setHistory([]);
@@ -109,5 +115,5 @@ export function useSearchHistory(maxResults = 10) {
     }
   }, []);
 
-  return { history, isReady, saveSearch, clearHistory };
+  return { history, isReady, saveSearch, upsertSearch, clearHistory };
 }


### PR DESCRIPTION
## Summary
- fix semantic-only results queries so they omit  instead of sending 
- add explicit QueryBox submit controls for auto-submit, retry, follow-up submission, and clear-on-submit
- keep Antfly shared backend config live, add , and make history persistence two-phase so search entries save before answer generation

## Testing
- pnpm test -- Integration Listener QueryBox AnswerResults hooks/useSearchHistory
- pnpm build
