### PR TITLE
fix: wrap render prop callbacks in SafeRender to prevent React error

### DIFF
--- a/ts/packages/components/src/AnswerResults.test.tsx
+++ b/ts/packages/components/src/AnswerResults.test.tsx
@@ -538,6 +538,66 @@ describe("AnswerResults", () => {
   });
 
   describe("renderAnswer with hooks (regression: React error #310)", () => {
+    it("should not throw when renderLoading itself uses hooks before the first answer chunk", async () => {
+      const mockStreamAnswer = vi.mocked(utils.streamAnswer);
+      let generateCallback: ((chunk: string) => void) | undefined;
+
+      mockStreamAnswer.mockImplementation(async (_url, _request, _headers, callbacks) => {
+        generateCallback = callbacks.onGeneration;
+        return new AbortController();
+      });
+
+      const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      const renderLoading = () => {
+        // eslint-disable-next-line react-hooks/rules-of-hooks
+        const loadingText = useMemo(() => "Custom loading", []);
+        return <div data-testid="custom-loading">{loadingText}</div>;
+      };
+
+      render(
+        <TestWrapper>
+          <QueryBox id="question" mode="submit" />
+          <AnswerResults
+            id="answer"
+            searchBoxId="question"
+            generator={mockGenerator}
+            fields={["content"]}
+            renderLoading={renderLoading}
+          />
+        </TestWrapper>
+      );
+
+      const input = screen.getByPlaceholderText(/ask a question/i);
+      const button = screen.getByRole("button", { name: /submit/i });
+
+      await act(async () => {
+        await userEvent.type(input, "test question");
+        await userEvent.click(button);
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId("custom-loading")).toBeTruthy();
+      });
+
+      await act(async () => {
+        generateCallback?.("Hello world");
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText("Hello world")).toBeTruthy();
+      });
+
+      const reactHookErrors = consoleErrorSpy.mock.calls.filter(
+        (call) =>
+          typeof call[0] === "string" &&
+          (call[0].includes("Rendered more hooks") || call[0].includes("error #310"))
+      );
+      expect(reactHookErrors).toHaveLength(0);
+
+      consoleErrorSpy.mockRestore();
+    });
+
     it("should not throw when renderAnswer itself uses hooks and answer streams progressively", async () => {
       const mockStreamAnswer = vi.mocked(utils.streamAnswer);
       let generateCallback: ((chunk: string) => void) | undefined;

--- a/ts/packages/components/src/AnswerResults.tsx
+++ b/ts/packages/components/src/AnswerResults.tsx
@@ -11,6 +11,7 @@ import type {
 } from "@antfly/sdk";
 import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { AnswerResultsContext, type AnswerResultsContextValue } from "./AnswerResultsContext";
+import { SafeRender } from "./SafeRender";
 import { useSharedContext } from "./SharedContext";
 import { resolveTable, streamAnswer } from "./utils";
 
@@ -80,7 +81,7 @@ function CustomAnswerRenderer({
   hits,
   renderAnswer,
 }: CustomAnswerRendererProps) {
-  return <>{renderAnswer(answer, isStreaming, hits)}</>;
+  return <SafeRender render={renderAnswer} args={[answer, isStreaming, hits] as const} />;
 }
 
 export default function AnswerResults({
@@ -575,7 +576,7 @@ export default function AnswerResults({
           !reasoning &&
           isStreaming &&
           (renderLoading ? (
-            renderLoading()
+            <SafeRender render={renderLoading} args={[] as const} />
           ) : (
             <div className="react-af-answer-loading">Loading answer...</div>
           ))}
@@ -583,7 +584,7 @@ export default function AnswerResults({
           !answer &&
           !isStreaming &&
           (renderEmpty ? (
-            renderEmpty()
+            <SafeRender render={renderEmpty} args={[] as const} />
           ) : (
             <div className="react-af-answer-empty">
               No results yet. Submit a question to get started.
@@ -592,12 +593,12 @@ export default function AnswerResults({
         {showClassification &&
           classification &&
           (renderClassification
-            ? renderClassification(classification)
+            ? <SafeRender render={renderClassification} args={[classification] as const} />
             : defaultRenderClassification(classification))}
         {showReasoning &&
           reasoning &&
           (renderReasoning
-            ? renderReasoning(reasoning, isStreaming)
+            ? <SafeRender render={renderReasoning} args={[reasoning, isStreaming] as const} />
             : defaultRenderReasoning(reasoning, isStreaming))}
         {!error &&
           answer &&
@@ -614,18 +615,30 @@ export default function AnswerResults({
         {showConfidence &&
           confidence &&
           !isStreaming &&
-          (renderConfidence ? renderConfidence(confidence) : defaultRenderConfidence(confidence))}
+          (renderConfidence ? (
+            <SafeRender render={renderConfidence} args={[confidence] as const} />
+          ) : (
+            defaultRenderConfidence(confidence)
+          ))}
         {showFollowUpQuestions &&
           followUpQuestions.length > 0 &&
           !isStreaming &&
-          (renderFollowUpQuestions
-            ? renderFollowUpQuestions(followUpQuestions)
-            : defaultRenderFollowUpQuestions(followUpQuestions))}
-        {showHits && hits.length > 0 && (renderHits ? renderHits(hits) : defaultRenderHits(hits))}
+          (renderFollowUpQuestions ? (
+            <SafeRender render={renderFollowUpQuestions} args={[followUpQuestions] as const} />
+          ) : (
+            defaultRenderFollowUpQuestions(followUpQuestions)
+          ))}
+        {showHits &&
+          hits.length > 0 &&
+          (renderHits ? <SafeRender render={renderHits} args={[hits] as const} /> : defaultRenderHits(hits))}
         {evalConfig &&
           evalResult &&
           !isStreaming &&
-          (renderEvalResult ? renderEvalResult(evalResult) : defaultRenderEvalResult(evalResult))}
+          (renderEvalResult ? (
+            <SafeRender render={renderEvalResult} args={[evalResult] as const} />
+          ) : (
+            defaultRenderEvalResult(evalResult)
+          ))}
       </div>
       {children}
     </AnswerResultsContext.Provider>

--- a/ts/packages/components/src/ChatInput.tsx
+++ b/ts/packages/components/src/ChatInput.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 import { useCallback, useState } from "react";
 import { useChatContext } from "./ChatContext";
+import { SafeRender } from "./SafeRender";
 
 export interface ChatInputProps {
   /** Placeholder text for the input */
@@ -44,14 +45,10 @@ export default function ChatInput({
   if (renderInput) {
     return (
       <div className="react-af-chat-input">
-        {renderInput({
-          value,
-          onChange: setValue,
-          onSubmit: handleSubmit,
-          isStreaming,
-          placeholder,
-          abort,
-        })}
+        <SafeRender
+          render={renderInput}
+          args={[{ value, onChange: setValue, onSubmit: handleSubmit, isStreaming, placeholder, abort }] as const}
+        />
       </div>
     );
   }

--- a/ts/packages/components/src/ChatMessages.test.tsx
+++ b/ts/packages/components/src/ChatMessages.test.tsx
@@ -1,0 +1,100 @@
+import { render, screen } from "@testing-library/react";
+import { useMemo } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { ChatContext, type ChatContextValue } from "./ChatContext";
+import ChatMessages from "./ChatMessages";
+import type { ChatTurn } from "./hooks/useChatStream";
+
+function createTurn(overrides: Partial<ChatTurn> = {}): ChatTurn {
+  return {
+    id: "turn-1",
+    userMessage: "What is Antfly?",
+    assistantMessage: "",
+    hits: [],
+    followUpQuestions: [],
+    classification: null,
+    confidence: null,
+    clarification: null,
+    appliedFilters: [],
+    reasoningText: "",
+    reasoningChain: [],
+    activeSteps: [],
+    toolCallsMade: 0,
+    error: null,
+    isStreaming: true,
+    ...overrides,
+  };
+}
+
+function TestProvider({
+  turns,
+  children,
+}: {
+  turns: ChatTurn[];
+  children: React.ReactNode;
+}) {
+  const value: ChatContextValue = {
+    turns,
+    isStreaming: turns.some((turn) => turn.isStreaming),
+    sendMessage: () => {},
+    sendFollowUp: () => {},
+    respondToClarification: () => {},
+    abort: () => {},
+    reset: () => {},
+    config: {
+      url: "http://localhost:8082/api/v1",
+      table: "test",
+    },
+  };
+
+  return <ChatContext.Provider value={value}>{children}</ChatContext.Provider>;
+}
+
+describe("ChatMessages", () => {
+  it("does not throw when renderStreamingIndicator uses hooks and then stops rendering", () => {
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const scrollIntoViewMock = vi.fn();
+    Element.prototype.scrollIntoView = scrollIntoViewMock;
+
+    const renderStreamingIndicator = () => {
+      // eslint-disable-next-line react-hooks/rules-of-hooks
+      const label = useMemo(() => "Custom thinking...", []);
+      return <div data-testid="custom-streaming-indicator">{label}</div>;
+    };
+
+    const view = render(
+      <TestProvider turns={[createTurn()]}>
+        <ChatMessages renderStreamingIndicator={renderStreamingIndicator} />
+      </TestProvider>
+    );
+
+    expect(screen.getByTestId("custom-streaming-indicator").textContent).toContain(
+      "Custom thinking"
+    );
+
+    view.rerender(
+      <TestProvider
+        turns={[
+          createTurn({
+            assistantMessage: "Antfly is a search system.",
+            isStreaming: false,
+          }),
+        ]}
+      >
+        <ChatMessages renderStreamingIndicator={renderStreamingIndicator} />
+      </TestProvider>
+    );
+
+    expect(screen.getByText("Antfly is a search system.")).toBeTruthy();
+
+    const reactHookErrors = consoleErrorSpy.mock.calls.filter(
+      (call) =>
+        typeof call[0] === "string" &&
+        (call[0].includes("Rendered more hooks") || call[0].includes("error #310"))
+    );
+    expect(reactHookErrors).toHaveLength(0);
+    expect(scrollIntoViewMock).toHaveBeenCalled();
+
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/ts/packages/components/src/ChatMessages.tsx
+++ b/ts/packages/components/src/ChatMessages.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from "react";
 import { useEffect, useRef } from "react";
 import { useChatContext } from "./ChatContext";
 import type { ChatTurn } from "./hooks/useChatStream";
+import { SafeRender } from "./SafeRender";
 
 export interface ChatMessagesProps {
   /** Show search hits for each turn */
@@ -154,56 +155,83 @@ export default function ChatMessages({
         <div key={turn.id} className="react-af-chat-turn">
           {/* User message */}
           {renderUserMessage
-            ? renderUserMessage(turn.userMessage, turn)
+            ? <SafeRender render={renderUserMessage} args={[turn.userMessage, turn] as const} />
             : defaultRenderUserMessage(turn.userMessage)}
 
           {/* Error */}
           {turn.error &&
-            (renderError ? renderError(turn.error, turn) : defaultRenderError(turn.error))}
+            (renderError ? (
+              <SafeRender render={renderError} args={[turn.error, turn] as const} />
+            ) : (
+              defaultRenderError(turn.error)
+            ))}
 
           {/* Streaming indicator (before any content appears) */}
           {turn.isStreaming && !turn.assistantMessage && !turn.error && (
             <div role="status">
-              {renderStreamingIndicator
-                ? renderStreamingIndicator()
-                : defaultRenderStreamingIndicator()}
+              {renderStreamingIndicator ? (
+                <SafeRender render={renderStreamingIndicator} args={[] as const} />
+              ) : (
+                defaultRenderStreamingIndicator()
+              )}
             </div>
           )}
 
           {/* Assistant message */}
           {turn.assistantMessage &&
-            (renderAssistantMessage
-              ? renderAssistantMessage(turn.assistantMessage, turn.isStreaming, turn)
-              : defaultRenderAssistantMessage(turn.assistantMessage, turn.isStreaming))}
+            (renderAssistantMessage ? (
+              <SafeRender
+                render={renderAssistantMessage}
+                args={[turn.assistantMessage, turn.isStreaming, turn] as const}
+              />
+            ) : (
+              defaultRenderAssistantMessage(turn.assistantMessage, turn.isStreaming)
+            ))}
 
           {/* Confidence */}
           {showConfidence &&
             turn.confidence &&
             !turn.isStreaming &&
-            (renderConfidence
-              ? renderConfidence(turn.confidence, turn)
-              : defaultRenderConfidence(turn.confidence))}
+            (renderConfidence ? (
+              <SafeRender render={renderConfidence} args={[turn.confidence, turn] as const} />
+            ) : (
+              defaultRenderConfidence(turn.confidence)
+            ))}
 
           {/* Hits */}
           {showHits &&
             turn.hits.length > 0 &&
-            (renderHits ? renderHits(turn.hits, turn) : defaultRenderHits(turn.hits))}
+            (renderHits ? (
+              <SafeRender render={renderHits} args={[turn.hits, turn] as const} />
+            ) : (
+              defaultRenderHits(turn.hits)
+            ))}
 
           {/* Clarification */}
           {turn.clarification &&
             !turn.isStreaming &&
-            (renderClarification
-              ? renderClarification(turn.clarification, respondToClarification, turn)
-              : defaultRenderClarification(turn.clarification, respondToClarification))}
+            (renderClarification ? (
+              <SafeRender
+                render={renderClarification}
+                args={[turn.clarification, respondToClarification, turn] as const}
+              />
+            ) : (
+              defaultRenderClarification(turn.clarification, respondToClarification)
+            ))}
 
           {/* Follow-up questions (only on last turn) */}
           {showFollowUpQuestions &&
             index === lastTurnIndex &&
             turn.followUpQuestions.length > 0 &&
             !turn.isStreaming &&
-            (renderFollowUpQuestions
-              ? renderFollowUpQuestions(turn.followUpQuestions, sendFollowUp, turn)
-              : defaultRenderFollowUpQuestions(turn.followUpQuestions, sendFollowUp))}
+            (renderFollowUpQuestions ? (
+              <SafeRender
+                render={renderFollowUpQuestions}
+                args={[turn.followUpQuestions, sendFollowUp, turn] as const}
+              />
+            ) : (
+              defaultRenderFollowUpQuestions(turn.followUpQuestions, sendFollowUp)
+            ))}
         </div>
       ))}
       <div ref={messagesEndRef} />

--- a/ts/packages/components/src/Results.tsx
+++ b/ts/packages/components/src/Results.tsx
@@ -1,6 +1,7 @@
 import type { QueryHit } from "@antfly/sdk";
 import React, { type ReactNode, useCallback, useEffect, useRef, useState } from "react";
 import Pagination from "./Pagination";
+import { SafeRender } from "./SafeRender";
 import { useSharedContext } from "./SharedContext";
 import { disjunctsFrom } from "./utils";
 
@@ -211,7 +212,7 @@ export default function Results({
   return (
     <div className="react-af-results">
       {stats ? (
-        stats(total)
+        <SafeRender render={stats} args={[total] as const} />
       ) : isSemanticEnabled ? (
         <>
           {data.length} out of {total} results
@@ -219,9 +220,15 @@ export default function Results({
       ) : (
         <>{total} results</>
       )}
-      <div className="react-af-results-items">{items(data)}</div>
+      <div className="react-af-results-items">
+        <SafeRender render={items} args={[data] as const} />
+      </div>
       {!isSemanticEnabled &&
-        (pagination ? pagination(total, itemsPerPage, page, setPage) : defaultPagination())}
+        (pagination ? (
+          <SafeRender render={pagination} args={[total, itemsPerPage, page, setPage] as const} />
+        ) : (
+          defaultPagination()
+        ))}
     </div>
   );
 }

--- a/ts/packages/components/src/SafeRender.tsx
+++ b/ts/packages/components/src/SafeRender.tsx
@@ -1,0 +1,18 @@
+import type { ReactNode } from "react";
+
+/**
+ * Wraps a render prop callback so it is invoked as a React component
+ * (via JSX), not as a plain function call. This guarantees that any
+ * hooks the caller uses inside the callback follow the Rules of Hooks
+ * and avoids React error #310 ("Rendered more hooks than during the
+ * previous render").
+ */
+export function SafeRender<TArgs extends readonly unknown[]>({
+  render,
+  args,
+}: {
+  render: (...args: TArgs) => ReactNode;
+  args: TArgs;
+}) {
+  return <>{render(...args)}</>;
+}


### PR DESCRIPTION
## Summary

- Extracts a shared `SafeRender<TArgs>` component (`src/SafeRender.tsx`) that wraps render prop callbacks so they're invoked as React components via JSX, not as plain function calls — preventing React error #310 when users pass render props containing hooks
- Applies `SafeRender` to all render prop call sites in `AnswerResults`, `ChatMessages`, `ChatInput`, and `Results`
- Adds regression tests for `renderLoading` with hooks (`AnswerResults.test.tsx`) and `renderStreamingIndicator` with hooks (`ChatMessages.test.tsx`)

## Test plan

- [x] All 342 existing tests pass (14 test files)
- [x] New test: `renderLoading` with `useMemo` hook doesn't trigger error #310
- [x] New test: `renderStreamingIndicator` with `useMemo` hook doesn't trigger error #310 when streaming stops
- [x] Manual: verify render props with hooks work in Storybook