### PR TITLE
fix(metadata): replace ReadTimeout with ReadHeaderTimeout on metadata server

### DIFF
--- a/e2e/swarm.go
+++ b/e2e/swarm.go
@@ -286,7 +286,7 @@ func startSwarmWithLocalBypass(
 	// Start metadata HTTP server.
 	go func() {
 		u, _ := url.Parse(metaConf.ApiURL)
-		srv := &http.Server{Addr: u.Host, Handler: metaRuntime.HTTPHandler(), ReadTimeout: 10 * time.Second}
+		srv := &http.Server{Addr: u.Host, Handler: metaRuntime.HTTPHandler(), ReadHeaderTimeout: 30 * time.Second}
 		go func() {
 			<-ctx.Done()
 			shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)

--- a/src/metadata/runner.go
+++ b/src/metadata/runner.go
@@ -71,9 +71,9 @@ func RunAsMetadataServer(
 	// Combined API server replaces both internal and public API servers
 	eg.Go(func() error {
 		srv := http.Server{
-			Addr:        u.Host,
-			Handler:     runtime.HTTPHandler(),
-			ReadTimeout: 10 * time.Second,
+			Addr:              u.Host,
+			Handler:           runtime.HTTPHandler(),
+			ReadHeaderTimeout: 30 * time.Second,
 		}
 
 		// Graceful shutdown


### PR DESCRIPTION
## Summary

Replace `ReadTimeout: 10 * time.Second` with `ReadHeaderTimeout: 30 * time.Second` on the metadata HTTP server. This fixes large Linear Merge payloads failing with JSON decode errors.

Fixes #37

## Problem

The metadata server's `ReadTimeout` applies to the **entire HTTP request** (headers + body). Large Linear Merge payloads (~7MB for 6,000 records) can't be fully transmitted within 10 seconds, causing the server to close the connection mid-read:

```
decoding request: json: string unexpected end of JSON input
```

## Fix

`ReadHeaderTimeout` limits only **header reading** (protection against slowloris attacks) while allowing request bodies to take as long as needed. This matches the pattern already used by:
- Raft server: `ReadHeaderTimeout: 30 * time.Second` (`src/raft/multiraft.go:268`)
- Health server: `ReadHeaderTimeout: 40 * time.Second` (`pkg/libaf/healthserver/healthserver.go:63`)

Linear Merge still enforces `MaxRecordsPerRequest = 10,000` — no size protection is removed.

## Changes

| File | Change |
|------|--------|
| `src/metadata/runner.go:76` | `ReadTimeout: 10s` → `ReadHeaderTimeout: 30s` |
| `e2e/swarm.go:289` | Same fix for E2E test server |
| `src/metadata/api_linear_merge_test.go` | 2 new tests: large payload encoding (5k records), key sorting at scale |

## Testing

- All 17 Linear Merge tests pass (15 existing + 2 new)
- Manual: indexed [cli/cli](https://github.com/cli/cli) (830 Go files, 5,933 components) using [dev-agent](https://github.com/prosdevlab/dev-agent) — succeeded where it previously failed