### PR TITLE
test: harden antfarm coverage

### DIFF
--- a/ts/apps/antfarm/src/components/api-config-provider.test.tsx
+++ b/ts/apps/antfarm/src/components/api-config-provider.test.tsx
@@ -1,0 +1,153 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useApiConfig } from "@/hooks/use-api-config";
+import { ApiConfigProvider } from "./api-config-provider";
+
+const { antflyClientMock, isProductEnabledMock } = vi.hoisted(() => ({
+  antflyClientMock: vi.fn(function thisMock(this: { baseUrl?: string }, {
+    baseUrl,
+  }: {
+    baseUrl: string;
+  }) {
+    this.baseUrl = baseUrl;
+  }),
+  isProductEnabledMock: vi.fn((product: string) => product === "antfly"),
+}));
+
+vi.mock("@antfly/sdk", () => ({
+  AntflyClient: antflyClientMock,
+}));
+
+vi.mock("@/config/products", () => ({
+  isProductEnabled: isProductEnabledMock,
+}));
+
+const originalLocalStorageDescriptor = Object.getOwnPropertyDescriptor(window, "localStorage");
+
+function createLocalStorageMock() {
+  const store = new Map<string, string>();
+  return {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      store.set(key, value);
+    },
+    removeItem: (key: string) => {
+      store.delete(key);
+    },
+    clear: () => {
+      store.clear();
+    },
+  };
+}
+
+function Consumer() {
+  const {
+    apiUrl,
+    termiteApiUrl,
+    client,
+    setApiUrl,
+    setTermiteApiUrl,
+    resetToDefault,
+    resetTermiteApiUrl,
+  } = useApiConfig();
+
+  return (
+    <>
+      <div data-testid="api-url">{apiUrl}</div>
+      <div data-testid="termite-url">{termiteApiUrl}</div>
+      <div data-testid="client-url">{String((client as { baseUrl?: string }).baseUrl)}</div>
+      <button type="button" onClick={() => setApiUrl("  http://localhost:9000/api  ")}>
+        Set API URL
+      </button>
+      <button type="button" onClick={() => setTermiteApiUrl("  https://cloud.example/termite  ")}>
+        Set Termite URL
+      </button>
+      <button type="button" onClick={resetToDefault}>
+        Reset API URL
+      </button>
+      <button type="button" onClick={resetTermiteApiUrl}>
+        Reset Termite URL
+      </button>
+    </>
+  );
+}
+
+describe("ApiConfigProvider", () => {
+  beforeEach(() => {
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      value: createLocalStorageMock(),
+    });
+    window.localStorage.clear();
+    antflyClientMock.mockClear();
+    isProductEnabledMock.mockReset();
+    isProductEnabledMock.mockImplementation((product: string) => product === "antfly");
+  });
+
+  afterEach(() => {
+    cleanup();
+    if (originalLocalStorageDescriptor) {
+      Object.defineProperty(window, "localStorage", originalLocalStorageDescriptor);
+    }
+  });
+
+  it("uses embedded-dashboard defaults when antfly is enabled", () => {
+    render(
+      <ApiConfigProvider>
+        <Consumer />
+      </ApiConfigProvider>
+    );
+
+    expect(screen.getByTestId("api-url").textContent).toBe("/api/v1");
+    expect(screen.getByTestId("termite-url").textContent).toBe("/termite");
+    expect(screen.getByTestId("client-url").textContent).toBe("/api/v1");
+  });
+
+  it("uses a same-origin termite URL in termite-only mode", () => {
+    isProductEnabledMock.mockReturnValue(false);
+
+    render(
+      <ApiConfigProvider>
+        <Consumer />
+      </ApiConfigProvider>
+    );
+
+    expect(screen.getByTestId("termite-url").textContent).toBe("");
+  });
+
+  it("persists trimmed URLs and updates the sdk client", () => {
+    render(
+      <ApiConfigProvider>
+        <Consumer />
+      </ApiConfigProvider>
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Set API URL" }));
+    fireEvent.click(screen.getByRole("button", { name: "Set Termite URL" }));
+
+    expect(screen.getByTestId("api-url").textContent).toBe("http://localhost:9000/api");
+    expect(screen.getByTestId("termite-url").textContent).toBe("https://cloud.example/termite");
+    expect(screen.getByTestId("client-url").textContent).toBe("http://localhost:9000/api");
+    expect(localStorage.getItem("antfarm-api-url")).toBe("http://localhost:9000/api");
+    expect(localStorage.getItem("antfarm-termite-api-url")).toBe("https://cloud.example/termite");
+  });
+
+  it("resets persisted URLs back to defaults", () => {
+    render(
+      <ApiConfigProvider>
+        <Consumer />
+      </ApiConfigProvider>
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Set API URL" }));
+    fireEvent.click(screen.getByRole("button", { name: "Set Termite URL" }));
+    fireEvent.click(screen.getByRole("button", { name: "Reset API URL" }));
+    fireEvent.click(screen.getByRole("button", { name: "Reset Termite URL" }));
+
+    expect(screen.getByTestId("api-url").textContent).toBe("/api/v1");
+    expect(screen.getByTestId("termite-url").textContent).toBe("/termite");
+    expect(screen.getByTestId("client-url").textContent).toBe("/api/v1");
+    expect(localStorage.getItem("antfarm-api-url")).toBeNull();
+    expect(localStorage.getItem("antfarm-termite-api-url")).toBeNull();
+  });
+});

--- a/ts/apps/antfarm/src/components/private-route.test.tsx
+++ b/ts/apps/antfarm/src/components/private-route.test.tsx
@@ -1,0 +1,128 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { PrivateRoute } from "./private-route";
+
+const useAuthMock = vi.fn();
+
+vi.mock("../hooks/use-auth", () => ({
+  useAuth: () => useAuthMock(),
+}));
+
+function renderRoute(element: React.ReactNode) {
+  return render(
+    <MemoryRouter initialEntries={["/protected"]}>
+      <Routes>
+        <Route path="/login" element={<div>Login page</div>} />
+        <Route path="/protected" element={element} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe("PrivateRoute", () => {
+  beforeEach(() => {
+    useAuthMock.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("shows a loading state while auth is initializing", () => {
+    useAuthMock.mockReturnValue({
+      isAuthenticated: false,
+      isLoading: true,
+      hasPermission: vi.fn(),
+      authEnabled: null,
+    });
+
+    renderRoute(
+      <PrivateRoute>
+        <div>Protected content</div>
+      </PrivateRoute>
+    );
+
+    expect(screen.getByText("Loading...")).toBeTruthy();
+  });
+
+  it("renders children when auth is disabled", () => {
+    useAuthMock.mockReturnValue({
+      isAuthenticated: false,
+      isLoading: false,
+      hasPermission: vi.fn(),
+      authEnabled: false,
+    });
+
+    renderRoute(
+      <PrivateRoute>
+        <div>Protected content</div>
+      </PrivateRoute>
+    );
+
+    expect(screen.getByText("Protected content")).toBeTruthy();
+  });
+
+  it("redirects unauthenticated users to login", () => {
+    useAuthMock.mockReturnValue({
+      isAuthenticated: false,
+      isLoading: false,
+      hasPermission: vi.fn(),
+      authEnabled: true,
+    });
+
+    renderRoute(
+      <PrivateRoute>
+        <div>Protected content</div>
+      </PrivateRoute>
+    );
+
+    expect(screen.getByText("Login page")).toBeTruthy();
+  });
+
+  it("shows access denied when a required permission is missing", () => {
+    useAuthMock.mockReturnValue({
+      isAuthenticated: true,
+      isLoading: false,
+      hasPermission: vi.fn(() => false),
+      authEnabled: true,
+    });
+
+    renderRoute(
+      <PrivateRoute
+        requiredPermission={{
+          resource: "users",
+          resourceType: "user",
+          permissionType: "admin",
+        }}
+      >
+        <div>Protected content</div>
+      </PrivateRoute>
+    );
+
+    expect(screen.getByText("Access Denied")).toBeTruthy();
+  });
+
+  it("renders children when the required permission is present", () => {
+    useAuthMock.mockReturnValue({
+      isAuthenticated: true,
+      isLoading: false,
+      hasPermission: vi.fn(() => true),
+      authEnabled: true,
+    });
+
+    renderRoute(
+      <PrivateRoute
+        requiredPermission={{
+          resource: "users",
+          resourceType: "user",
+          permissionType: "admin",
+        }}
+      >
+        <div>Protected content</div>
+      </PrivateRoute>
+    );
+
+    expect(screen.getAllByText("Protected content")).toHaveLength(1);
+  });
+});

--- a/ts/apps/antfarm/src/config/products.test.ts
+++ b/ts/apps/antfarm/src/config/products.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import {
+  defaultProduct,
+  enabledProducts,
+  getDefaultRoute,
+  productForPath,
+  showProductSwitcher,
+} from "./products";
+
+describe("products config", () => {
+  it("enables both products by default", () => {
+    expect(enabledProducts).toEqual(["antfly", "termite"]);
+    expect(defaultProduct).toBe("antfly");
+    expect(showProductSwitcher).toBe(true);
+    expect(getDefaultRoute()).toBe("/");
+  });
+
+  it("maps antfly routes to the antfly product", () => {
+    expect(productForPath("/")).toBe("antfly");
+    expect(productForPath("/create")).toBe("antfly");
+    expect(productForPath("/tables/example")).toBe("antfly");
+    expect(productForPath("/playground/chat")).toBe("antfly");
+    expect(productForPath("/playground/chunking")).toBe("antfly");
+  });
+
+  it("maps termite routes to the termite product", () => {
+    expect(productForPath("/models")).toBe("termite");
+    expect(productForPath("/playground/chunk")).toBe("termite");
+    expect(productForPath("/playground/recognize")).toBe("termite");
+    expect(productForPath("/playground/transcribe")).toBe("termite");
+  });
+
+  it("prefers the most specific route prefix", () => {
+    expect(productForPath("/playground/chunk")).toBe("termite");
+    expect(productForPath("/playground/chunking")).toBe("antfly");
+  });
+
+  it("returns undefined for unknown routes", () => {
+    expect(productForPath("/does-not-exist")).toBeUndefined();
+  });
+});

--- a/ts/apps/antfarm/tests/helpers/antfly-api.ts
+++ b/ts/apps/antfarm/tests/helpers/antfly-api.ts
@@ -1,0 +1,144 @@
+import type { Page, Route } from "@playwright/test";
+
+type MockIndex = {
+  config: {
+    name: string;
+    type: string;
+    [key: string]: unknown;
+  };
+  status?: Record<string, unknown>;
+};
+
+type MockTable = {
+  name: string;
+  description?: string;
+  shards?: Record<string, unknown>;
+  indexes?: Record<string, unknown>;
+  storage_status?: {
+    empty?: boolean;
+    disk_usage?: number;
+  };
+  schema?: Record<string, unknown>;
+  migration?: {
+    read_schema: {
+      version: number;
+    };
+  };
+  indexesList?: MockIndex[];
+};
+
+type MockAntflyApiOptions = {
+  tables?: MockTable[];
+};
+
+const defaultTables: MockTable[] = [
+  {
+    name: "books",
+    description: "Book catalog",
+    shards: { "0": {} },
+    indexes: { title_embedding: {}, full_text_index_v0: {} },
+    storage_status: { disk_usage: 2048 },
+    schema: {
+      version: 1,
+      document_schemas: {
+        default: {
+          schema: {
+            type: "object",
+            properties: {
+              title: { type: "string" },
+              body: { type: "string" },
+            },
+          },
+        },
+      },
+    },
+    indexesList: [
+      {
+        config: {
+          name: "title_embedding",
+          type: "embeddings",
+          embedder: { provider: "openai", model: "text-embedding-3-small" },
+        },
+        status: { total_indexed: 42 },
+      },
+      {
+        config: {
+          name: "full_text_index_v0",
+          type: "full_text",
+        },
+        status: { total_indexed: 42, disk_usage: 2048 },
+      },
+    ],
+  },
+  {
+    name: "authors",
+    description: "Author directory",
+    shards: { "0": {} },
+    indexes: {},
+    storage_status: { empty: true },
+    schema: { version: 1, document_schemas: {} },
+    indexesList: [],
+  },
+];
+
+function json(route: Route, body: unknown, status = 200) {
+  return route.fulfill({
+    status,
+    contentType: "application/json",
+    body: JSON.stringify(body),
+  });
+}
+
+export async function installAntflyApiMocks(
+  page: Page,
+  options: MockAntflyApiOptions = {}
+): Promise<void> {
+  const tables = options.tables ?? defaultTables;
+
+  await page.route("**/api/v1/**", async (route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+    const path = url.pathname;
+
+    if (request.method() === "GET" && path === "/api/v1/status") {
+      return json(route, { auth_enabled: false });
+    }
+
+    if (request.method() === "GET" && path === "/api/v1/tables") {
+      const prefix = url.searchParams.get("prefix");
+      const pattern = url.searchParams.get("pattern");
+      let filtered = tables;
+
+      if (prefix) {
+        filtered = filtered.filter((table) => table.name.startsWith(prefix));
+      } else if (pattern) {
+        const regex = new RegExp(pattern);
+        filtered = filtered.filter((table) => regex.test(table.name));
+      }
+
+      return json(route, filtered);
+    }
+
+    const tableMatch = path.match(/^\/api\/v1\/tables\/([^/]+)$/);
+    if (request.method() === "GET" && tableMatch) {
+      const tableName = decodeURIComponent(tableMatch[1]);
+      const table = tables.find((entry) => entry.name === tableName);
+      if (!table) return json(route, { error: "not found" }, 404);
+      return json(route, {
+        name: table.name,
+        schema: table.schema ?? {},
+        migration: table.migration,
+      });
+    }
+
+    const indexesMatch = path.match(/^\/api\/v1\/tables\/([^/]+)\/indexes$/);
+    if (request.method() === "GET" && indexesMatch) {
+      const tableName = decodeURIComponent(indexesMatch[1]);
+      const table = tables.find((entry) => entry.name === tableName);
+      if (!table) return json(route, { error: "not found" }, 404);
+      return json(route, table.indexesList ?? []);
+    }
+
+    return json(route, { error: `Unhandled mock for ${request.method()} ${path}` }, 404);
+  });
+}

--- a/ts/apps/antfarm/tests/tables.spec.ts
+++ b/ts/apps/antfarm/tests/tables.spec.ts
@@ -1,0 +1,43 @@
+import { expect, test } from "@playwright/test";
+import { installAntflyApiMocks } from "./helpers/antfly-api";
+
+test.describe("tables flows", () => {
+  test.beforeEach(async ({ page }) => {
+    await installAntflyApiMocks(page);
+  });
+
+  test("shows the table list and applies a prefix filter", async ({ page }) => {
+    await page.goto("/");
+
+    await expect(page.getByRole("heading", { name: "Tables" })).toBeVisible();
+    await expect(page.getByRole("link", { name: "books" })).toBeVisible();
+    await expect(page.getByRole("link", { name: "authors" })).toBeVisible();
+
+    await page.getByLabel("Filter by Prefix").fill("book");
+    await page.getByRole("button", { name: "Apply" }).click();
+
+    await expect(page.getByRole("link", { name: "books" })).toBeVisible();
+    await expect(page.getByRole("link", { name: "authors" })).toHaveCount(0);
+  });
+
+  test("navigates from the tables list into a table details page", async ({ page }) => {
+    await page.goto("/");
+
+    await page.getByRole("link", { name: "books" }).click();
+
+    await expect(page).toHaveURL(/\/tables\/books$/);
+    await expect(page.getByRole("button", { name: "Create Index" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Vector Indexes" })).toBeVisible();
+    await expect(page.getByRole("cell", { name: "title_embedding" })).toBeVisible();
+  });
+
+  test("loads an existing table page directly", async ({ page }) => {
+    await page.goto("/tables/books");
+
+    await expect(page).toHaveURL(/\/tables\/books$/);
+    await expect(page.getByRole("navigation").getByText("books")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Create Index" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Full Text Index" })).toBeVisible();
+    await expect(page.getByRole("cell", { name: "0" })).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
- add route ownership tests for antfarm product selection and default routing
- add auth shell tests for PrivateRoute loading, redirect, and permission cases
- add ApiConfigProvider tests for embedded vs termite-only URL defaults and persistence
- add mocked Playwright coverage for tables list filtering, table navigation, and direct table-page loading

## Validation
- pnpm exec vitest run --project=unit
- BASE_URL=http://127.0.0.1:4173 pnpm exec playwright test --project=chromium --reporter=line

## Notes
- Chromium Playwright coverage is now 4 passing tests and 3 skipped tests.
- Browser coverage currently uses API mocks for the new tables flow tests so frontend behavior can be exercised without a live Antfly process.
- This PR is focused on legacy Antfarm test hardening for Antfarm Cloud work, not UI refactoring.
