### PR TITLE
fix(sdk): bundle openapi-fetch to fix CJS interop crash

### DIFF
--- a/ts/packages/sdk/package.json
+++ b/ts/packages/sdk/package.json
@@ -19,8 +19,8 @@
     "LICENSE"
   ],
   "scripts": {
-    "build": "tsup src/index.ts --format cjs,esm --dts --clean",
-    "dev": "tsup src/index.ts --format cjs,esm --dts --watch",
+    "build": "tsup",
+    "dev": "tsup --watch",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:ui": "vitest --ui",
@@ -31,7 +31,7 @@
     "generate": "openapi-typescript ../../../openapi.yaml -o ./src/antfly-api.d.ts --default-non-nullable=false && openapi-typescript ../../../bleve-query-openapi.yaml --client fetch -o ./src/bleve-query.d.ts --default-non-nullable=false",
     "clean": "rm -rf dist",
     "prepare": "pnpm run build",
-    "prepublishOnly": "pnpm run typecheck && pnpm run lint && pnpm run test && pnpm run build",
+    "prepublishOnly": "pnpm run typecheck && pnpm run lint && pnpm run build && pnpm run test",
     "example:node": "tsx examples/node-example.ts"
   },
   "keywords": [

--- a/ts/packages/sdk/test/dist.test.ts
+++ b/ts/packages/sdk/test/dist.test.ts
@@ -1,0 +1,33 @@
+import { createRequire } from "node:module"
+import { existsSync, readFileSync } from "node:fs"
+import { resolve } from "node:path"
+import { describe, it, expect } from "vitest"
+
+// Guards the CJS/ESM interop fix in tsup.config.ts (noExternal: ["openapi-fetch"]).
+// openapi-fetch is ESM-first; if tsup emits `__toESM(require("openapi-fetch"), 1)`
+// into the CJS bundle, the default export gets double-nested and
+// `new AntflyClient(...)` throws "is not a function" in any CJS consumer.
+// These tests fail loudly if noExternal is removed or openapi-fetch stops being inlined.
+
+const cjsPath = resolve(__dirname, "../dist/index.cjs")
+const hasBuild = existsSync(cjsPath)
+
+describe.skipIf(!hasBuild)("CJS dist bundle", () => {
+  it("does not emit require(\"openapi-fetch\") (openapi-fetch must be inlined)", () => {
+    const src = readFileSync(cjsPath, "utf8")
+    expect(src).not.toMatch(/require\("openapi-fetch"\)/)
+    expect(src).not.toMatch(/import_openapi_fetch/)
+  })
+
+  it("instantiates AntflyClient from the CJS bundle without throwing", () => {
+    const req = createRequire(import.meta.url)
+    const { AntflyClient } = req(cjsPath)
+    expect(() => new AntflyClient({ baseUrl: "http://localhost" })).not.toThrow()
+  })
+})
+
+describe.skipIf(hasBuild)("CJS dist bundle — skipped", () => {
+  it("skipped: run `pnpm build` first to validate the CJS bundle", () => {
+    expect(hasBuild).toBe(false)
+  })
+})

--- a/ts/packages/sdk/tsup.config.ts
+++ b/ts/packages/sdk/tsup.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from "tsup"
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["cjs", "esm"],
+  dts: true,
+  clean: true,
+  // Bundle openapi-fetch into the output to avoid a CJS/ESM interop crash.
+  // openapi-fetch is ESM-first; when tsup emits CJS that does
+  // `__toESM(require("openapi-fetch"), 1)`, the default export gets
+  // double-nested (`.default` becomes an object, not the createClient
+  // function), so `(0, import_openapi_fetch.default)(...)` throws
+  // "is not a function" under tsx/ts-node in any CJS consumer project.
+  // Inlining sidesteps the interop entirely.
+  noExternal: ["openapi-fetch"],
+})


### PR DESCRIPTION
## Summary

`@antfly/sdk@0.0.14` crashes on `new AntflyClient(...)` in any CJS consumer project loaded via tsx, ts-node, or plain `require()`:

```
TypeError: (0 , import_openapi_fetch.default) is not a function
    at AntflyClient.buildClient (dist/index.cjs:423:45)
    at new AntflyClient     (dist/index.cjs:390:24)
```

This fix inlines `openapi-fetch` into the SDK's bundle so the broken CJS/ESM interop path disappears. ESM consumers are unaffected; CJS consumers go from hard crash on first call to working.

## Root cause

`openapi-fetch@0.17` is ESM-first. When `tsup` emits the SDK's CJS bundle, it wraps the dependency as:

```js
var import_openapi_fetch = __toESM(require("openapi-fetch"), 1);
// ...
return (0, import_openapi_fetch.default)({ ... });  // dist/index.cjs:423
```

The `__toESM` interop wrapper produces a shape where `.default` is a module object (containing `.default = createClient`) rather than the `createClient` function itself. Calling it throws.

The ESM build was unaffected — native ESM `import` has no interop shim.

## Who hits this

Any project where Node resolves `@antfly/sdk` through the `require` export condition, which includes:

- Projects without `"type": "module"` in their `package.json` (this is the default — hit by Next.js apps, most server projects, anything with a CJS heritage).
- Projects using plain `require("@antfly/sdk")`.
- Bundlers that pick the CJS entry.

ESM-native projects (`"type": "module"` + native `import`) were never affected.

Discovered in production via [`madeinwyo/bakin`](https://github.com/madeinwyo/bakin) (Node 22.13.1 + tsx). Bakin has been shipping a `pnpm patch` workaround (`patches/@antfly__sdk@0.0.14.patch`) since the bug surfaced, which rewrites the failing line at install time.

## The fix

Introduce `ts/packages/sdk/tsup.config.ts` with:

```ts
noExternal: ["openapi-fetch"],
```

This tells tsup to inline `openapi-fetch`'s source into both the CJS and ESM outputs. After the change, `dist/index.cjs` no longer contains `require("openapi-fetch")` or the `__toESM` wrapper — `createClient` is inlined and called directly. The interop bug is eliminated by construction, not by defensive coding.

## Additional changes

- **`ts/packages/sdk/package.json`**: `build` / `dev` scripts simplified to `tsup` / `tsup --watch` since flags now live in the config file. `prepublishOnly` reordered (`build` before `test`) so the new dist-guard test below can run against a fresh build.
- **`ts/packages/sdk/test/dist.test.ts`** (new): a regression guard that loads `dist/index.cjs` after build and asserts:
  1. The broken `require("openapi-fetch")` / `import_openapi_fetch` patterns are absent.
  2. `new AntflyClient({...})` does not throw.

  The test skips gracefully when `dist/` is missing (keeps the dev loop fast) and runs as part of `prepublishOnly`, so it also gates future publishes. **Proven to fail** when `noExternal` is removed — this isn't a paper-only assertion.

## Verification

Reproduced the crash against stock `0.0.14` from npm using a minimal CJS harness matching bakin's setup (named import, `new AntflyClient({ baseUrl })`, Node 22.13.1, tsx 4.21.0). Exact TypeError observed at `dist/index.cjs:423:45`.

After the fix, the same harness passes. Tested across four consumer shapes — all green:

| Consumer | Loader | Result |
|---|---|---|
| CJS project (no `"type"`) | tsx | OK |
| CJS project (no `"type"`) | `node ./file.cjs` (require) | OK |
| ESM project (`"type": "module"`) | tsx | OK |
| ESM project (`"type": "module"`) | `node ./file.mjs` (import) | OK |

Existing SDK tests: 43/44 pass, 1 expected skip in the new dist guard's sibling describe block. Typecheck clean.

Bundle size: `dist/index.cjs` 30 KB → 45 KB, `dist/index.js` 28 KB → 43 KB (openapi-fetch inlined, ~15 KB each). `dist/index.d.cts` still `import { Client } from 'openapi-fetch'`, so `openapi-fetch` remains a runtime `dependency` for consumer typecheck resolution.

## Test plan

- [x] Reproduce the original `TypeError` against stock `0.0.14` from npm in a fresh CJS consumer project
- [x] Same consumer project passes against the fixed build (tarball produced via `pnpm pack` on this branch)
- [x] Confirm CJS-from-`require()`, CJS-from-tsx, ESM-from-`import`, ESM-from-tsx all instantiate cleanly
- [x] `pnpm --filter @antfly/sdk test` — all existing tests still pass
- [x] `pnpm exec tsc --noEmit` — typecheck clean
- [x] `dist.test.ts` fails as designed when `noExternal` is removed (guard proven effective, not paper-only)
- [x] `dist.test.ts` skips cleanly when `dist/` is absent (no false failures in dev loop)