### PR TITLE
fix(termite-sdk): bundle openapi-fetch to fix CJS interop crash

### DIFF
--- a/ts/packages/termite-sdk/package.json
+++ b/ts/packages/termite-sdk/package.json
@@ -19,8 +19,8 @@
     "LICENSE"
   ],
   "scripts": {
-    "build": "tsup src/index.ts --format cjs,esm --dts --clean",
-    "dev": "tsup src/index.ts --format cjs,esm --dts --watch",
+    "build": "tsup",
+    "dev": "tsup --watch",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:ui": "vitest --ui",
@@ -31,7 +31,7 @@
     "generate": "openapi-typescript ../../../termite/openapi.yaml -o ./src/termite-api.d.ts --default-non-nullable=false",
     "clean": "rm -rf dist",
     "prepare": "pnpm run build",
-    "prepublishOnly": "pnpm run typecheck && pnpm run lint && pnpm run test && pnpm run build"
+    "prepublishOnly": "pnpm run typecheck && pnpm run lint && pnpm run build && pnpm run test"
   },
   "keywords": [
     "termite",

--- a/ts/packages/termite-sdk/test/dist.test.ts
+++ b/ts/packages/termite-sdk/test/dist.test.ts
@@ -1,0 +1,33 @@
+import { createRequire } from "node:module"
+import { existsSync, readFileSync } from "node:fs"
+import { resolve } from "node:path"
+import { describe, it, expect } from "vitest"
+
+// Guards the CJS/ESM interop fix in tsup.config.ts (noExternal: ["openapi-fetch"]).
+// openapi-fetch is ESM-first; if tsup emits `__toESM(require("openapi-fetch"), 1)`
+// into the CJS bundle, the default export gets double-nested and
+// `new TermiteClient(...)` throws "is not a function" in any CJS consumer.
+// These tests fail loudly if noExternal is removed or openapi-fetch stops being inlined.
+
+const cjsPath = resolve(__dirname, "../dist/index.cjs")
+const hasBuild = existsSync(cjsPath)
+
+describe.skipIf(!hasBuild)("CJS dist bundle", () => {
+  it("does not emit require(\"openapi-fetch\") (openapi-fetch must be inlined)", () => {
+    const src = readFileSync(cjsPath, "utf8")
+    expect(src).not.toMatch(/require\("openapi-fetch"\)/)
+    expect(src).not.toMatch(/import_openapi_fetch/)
+  })
+
+  it("instantiates TermiteClient from the CJS bundle without throwing", () => {
+    const req = createRequire(import.meta.url)
+    const { TermiteClient } = req(cjsPath)
+    expect(() => new TermiteClient({ baseUrl: "http://localhost" })).not.toThrow()
+  })
+})
+
+describe.skipIf(hasBuild)("CJS dist bundle — skipped", () => {
+  it("skipped: run `pnpm build` first to validate the CJS bundle", () => {
+    expect(hasBuild).toBe(false)
+  })
+})

--- a/ts/packages/termite-sdk/tsup.config.ts
+++ b/ts/packages/termite-sdk/tsup.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "tsup"
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["cjs", "esm"],
+  dts: true,
+  clean: true,
+  // Bundle openapi-fetch into the output to avoid a CJS/ESM interop crash.
+  // openapi-fetch is ESM-first; when tsup emits CJS that does
+  // `__toESM(require("openapi-fetch"), 1)`, the default export gets
+  // double-nested (`.default` becomes an object, not the createClient
+  // function), so `(0, import_openapi_fetch.default)(...)` throws
+  // "is not a function" under tsx/ts-node in any CJS consumer project.
+  // Inlining sidesteps the interop entirely.
+  // Same fix as @antfly/sdk (see ../sdk/tsup.config.ts, PR #45).
+  noExternal: ["openapi-fetch"],
+})


### PR DESCRIPTION
## Summary

Same root cause and fix as `@antfly/sdk` in #45 — applied to `@antfly/termite-sdk`.

`@antfly/termite-sdk` CJS bundle (`dist/index.cjs`) crashes on `new TermiteClient(...)` in any CJS consumer project loaded via tsx, ts-node, or plain `require()`:

```
TypeError: (0 , import_openapi_fetch.default) is not a function
    at new TermiteClient (dist/index.cjs:97:52)
```

## Root cause

`openapi-fetch@0.17` is ESM-first. When `tsup` emits the CJS bundle, it wraps the dependency as:

```js
var import_openapi_fetch = __toESM(require("openapi-fetch"), 1);
```

The `__toESM` interop wrapper double-nests the default export — `.default` resolves to a module object rather than the `createClient` function. The ESM build was unaffected.

## The fix

Introduce `ts/packages/termite-sdk/tsup.config.ts` with:

```ts
noExternal: ["openapi-fetch"],
```

This inlines `openapi-fetch` into both CJS and ESM outputs. No `require()` call, no `__toESM` wrapper, no interop to go wrong. The bug is eliminated by construction.

## Additional changes

- **`ts/packages/termite-sdk/package.json`**: `build` / `dev` scripts simplified to `tsup` / `tsup --watch`. `prepublishOnly` reordered (`build` before `test`) so the dist-guard test runs against a fresh build.
- **`ts/packages/termite-sdk/test/dist.test.ts`** (new): regression guard that loads `dist/index.cjs` after build and asserts:
  1. The broken `require("openapi-fetch")` / `import_openapi_fetch` patterns are absent.
  2. `new TermiteClient({...})` does not throw.

  **Proven to fail** when `noExternal` is removed. Skips gracefully when `dist/` is absent.

## Verification

Reproduced the crash against the unfixed build from current `main` (packed via `pnpm pack`, installed in a CJS consumer project, Node 22.13.1 + tsx 4.21.0). Exact `TypeError` observed at `dist/index.cjs:97:52`.

After the fix, the same harness passes. All 52 existing tests pass (50 pre-existing + 2 new guard tests), 1 expected skip. Typecheck clean.

## Test plan

- [x] Reproduce the original `TypeError` against unfixed build from `main`
- [x] Same consumer project passes against the fixed build
- [x] `pnpm --filter @antfly/termite-sdk test` — all existing tests still pass
- [x] Typecheck clean
- [x] `dist.test.ts` fails as designed when `noExternal` is removed (guard proven effective)
- [x] `dist.test.ts` skips cleanly when `dist/` is absent