### PR TITLE
fix antflycluster phase calculation

### DIFF
--- a/pkg/operator/controllers/antflycluster_controller.go
+++ b/pkg/operator/controllers/antflycluster_controller.go
@@ -1811,8 +1811,18 @@ func (r *AntflyClusterReconciler) updateStatus(ctx context.Context, cluster *ant
 		}
 	}
 
-	// Determine phase
-	if cluster.Status.MetadataNodesReady >= 3 && cluster.Status.DataNodesReady >= 3 {
+	// Determine phase based on the configured replica counts rather than a
+	// hardcoded production-sized cluster. Local dev intentionally runs 1+1.
+	metadataReplicas := int32(3)
+	if cluster.Spec.MetadataNodes.Replicas > 0 {
+		metadataReplicas = cluster.Spec.MetadataNodes.Replicas
+	}
+	dataReplicas := int32(3)
+	if cluster.Spec.DataNodes.Replicas > 0 {
+		dataReplicas = cluster.Spec.DataNodes.Replicas
+	}
+
+	if cluster.Status.MetadataNodesReady >= metadataReplicas && cluster.Status.DataNodesReady >= dataReplicas {
 		cluster.Status.Phase = "Running"
 	} else {
 		cluster.Status.Phase = "Pending"


### PR DESCRIPTION
 ## Summary

  Fix `AntflyCluster` phase calculation to use the configured metadata/data replica counts instead of a
  hardcoded `3x3` threshold.

  ## Why

  The operator was only marking clusters as `Running` when both metadata and data ready counts reached
  `3`, regardless of the replica counts configured on the cluster spec.

  That is incorrect for any non-`3x3` topology, as clusters may legitimately run smaller or larger topologies than the default 3x3

  As a result, healthy reduced-topology clusters could remain stuck in `Pending` even when all
  configured pods were ready.

  ## Changes

  - read expected replica counts from:
    - `cluster.Spec.MetadataNodes.Replicas`
    - `cluster.Spec.DataNodes.Replicas`
  - compare ready counts against those configured values
  - retain `3` as a fallback default if a replica count is unset

  ## Impact

  - local-dev clusters can now reach `Running` correctly
  - non-default topologies are reported accurately
  - downstream provisioning flows that wait on `Running` no longer block on an impossible readiness
  threshold