### PR TITLE
Propagate AntflyCluster labels to pods

### DIFF
--- a/pkg/antfly-operator/controllers/antflycluster_controller.go
+++ b/pkg/antfly-operator/controllers/antflycluster_controller.go
@@ -60,16 +60,34 @@ type AntflyClusterReconciler struct {
 //+kubebuilder:rbac:groups=policy,resources=poddisruptionbudgets,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=storage.k8s.io,resources=storageclasses,verbs=get;list;watch
 
+var reservedPodLabelPrefixes = []string{"app.kubernetes.io/"}
+
 // podLabels returns the standard labels for pod templates including the instance identifier.
 // These are a superset of serviceSelectorLabels — they include managed-by labels
 // that MUST NOT be added to StatefulSet spec.selector.matchLabels (immutable after creation).
-func podLabels(clusterName, component string) map[string]string {
-	return map[string]string{
+func podLabels(cluster *antflyv1.AntflyCluster, component string) map[string]string {
+	labels := map[string]string{
 		"app.kubernetes.io/name":       "antfly-database",
 		"app.kubernetes.io/component":  component,
-		"app.kubernetes.io/instance":   clusterName,
+		"app.kubernetes.io/instance":   cluster.Name,
 		"app.kubernetes.io/managed-by": "antfly-operator",
 	}
+
+	for k, v := range cluster.Labels {
+		reserved := false
+		for _, prefix := range reservedPodLabelPrefixes {
+			if strings.HasPrefix(k, prefix) {
+				reserved = true
+				break
+			}
+		}
+		if reserved {
+			continue
+		}
+		labels[k] = v
+	}
+
+	return labels
 }
 
 // serviceSelectorLabels returns the labels used for Service and StatefulSet selectors.
@@ -1541,7 +1559,7 @@ func (r *AntflyClusterReconciler) reconcileSwarmStatefulSet(ctx context.Context,
 		statefulSet.Spec.PersistentVolumeClaimRetentionPolicy = buildPVCRetentionPolicy(cluster.Spec.Storage.PVCRetentionPolicy)
 		statefulSet.Spec.Template = corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
-				Labels:      podLabels(cluster.Name, "swarm"),
+				Labels:      podLabels(cluster, "swarm"),
 				Annotations: r.buildPodAnnotations(ctx, cache, cluster, envFromSources),
 			},
 			Spec: corev1.PodSpec{
@@ -1778,7 +1796,7 @@ func (r *AntflyClusterReconciler) reconcileMetadataStatefulSet(ctx context.Conte
 		statefulSet.Spec.PersistentVolumeClaimRetentionPolicy = buildPVCRetentionPolicy(cluster.Spec.Storage.PVCRetentionPolicy)
 		statefulSet.Spec.Template = corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
-				Labels:      podLabels(cluster.Name, "metadata"),
+				Labels:      podLabels(cluster, "metadata"),
 				Annotations: r.buildPodAnnotations(ctx, cache, cluster, cluster.Spec.MetadataNodes.EnvFrom),
 			},
 			Spec: corev1.PodSpec{
@@ -1991,7 +2009,7 @@ func (r *AntflyClusterReconciler) reconcileDataStatefulSet(ctx context.Context, 
 		statefulSet.Spec.PersistentVolumeClaimRetentionPolicy = buildPVCRetentionPolicy(cluster.Spec.Storage.PVCRetentionPolicy)
 		statefulSet.Spec.Template = corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
-				Labels:      podLabels(cluster.Name, "data"),
+				Labels:      podLabels(cluster, "data"),
 				Annotations: r.buildPodAnnotations(ctx, cache, cluster, cluster.Spec.DataNodes.EnvFrom),
 			},
 			Spec: corev1.PodSpec{

--- a/pkg/antfly-operator/controllers/antflycluster_controller_test.go
+++ b/pkg/antfly-operator/controllers/antflycluster_controller_test.go
@@ -1013,12 +1013,91 @@ func TestDetectSidecarInjectionStatus_ScopedToClusterInstance(t *testing.T) {
 func TestPodLabels(t *testing.T) {
 	g := NewWithT(t)
 
-	labels := podLabels("my-cluster", "metadata")
+	cluster := &antflyv1.AntflyCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "my-cluster",
+			Labels: map[string]string{
+				"cloud.antfly.io/purpose":        "cloud-instance",
+				"cloud.antfly.io/instance-id":    "instance-123",
+				"app.kubernetes.io/managed-by":   "external-controller",
+				"app.kubernetes.io/part-of":      "cloudaf",
+				"kubernetes.io/metadata.name":    "default",
+				"operator.antfly.io/owned-label": "true",
+			},
+		},
+	}
+
+	labels := podLabels(cluster, "metadata")
 
 	g.Expect(labels).To(HaveKeyWithValue("app.kubernetes.io/name", "antfly-database"))
 	g.Expect(labels).To(HaveKeyWithValue("app.kubernetes.io/component", "metadata"))
 	g.Expect(labels).To(HaveKeyWithValue("app.kubernetes.io/instance", "my-cluster"))
 	g.Expect(labels).To(HaveKeyWithValue("app.kubernetes.io/managed-by", "antfly-operator"))
+	g.Expect(labels).To(HaveKeyWithValue("cloud.antfly.io/purpose", "cloud-instance"))
+	g.Expect(labels).To(HaveKeyWithValue("cloud.antfly.io/instance-id", "instance-123"))
+	g.Expect(labels).To(HaveKeyWithValue("kubernetes.io/metadata.name", "default"))
+	g.Expect(labels).To(HaveKeyWithValue("operator.antfly.io/owned-label", "true"))
+	g.Expect(labels).NotTo(HaveKey("app.kubernetes.io/part-of"))
+}
+
+func TestPodTemplateLabelsUpdateWhenClusterLabelsChange(t *testing.T) {
+	g := NewWithT(t)
+
+	s := runtime.NewScheme()
+	g.Expect(antflyv1.AddToScheme(s)).To(Succeed())
+	g.Expect(appsv1.AddToScheme(s)).To(Succeed())
+	g.Expect(corev1.AddToScheme(s)).To(Succeed())
+
+	cluster := &antflyv1.AntflyCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "label-update-cluster",
+			Namespace: "default",
+			Labels: map[string]string{
+				"cloud.antfly.io/instance-id": "instance-before",
+			},
+		},
+		Spec: antflyv1.AntflyClusterSpec{
+			Image: "antfly:latest",
+			MetadataNodes: antflyv1.MetadataNodesSpec{
+				MetadataAPI:  antflyv1.APISpec{Port: 12377},
+				MetadataRaft: antflyv1.APISpec{Port: 9017},
+				Health:       antflyv1.APISpec{Port: 4200},
+			},
+			Storage: antflyv1.StorageSpec{
+				StorageClass:    "standard",
+				MetadataStorage: "1Gi",
+			},
+			Config: "{}",
+		},
+	}
+
+	client := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(cluster).
+		Build()
+
+	reconciler := &AntflyClusterReconciler{
+		Client: client,
+		Scheme: s,
+	}
+
+	g.Expect(reconciler.reconcileMetadataStatefulSet(context.Background(), &envFromCache{}, cluster)).To(Succeed())
+
+	sts := &appsv1.StatefulSet{}
+	key := types.NamespacedName{Name: cluster.Name + "-metadata", Namespace: cluster.Namespace}
+	g.Expect(client.Get(context.Background(), key, sts)).To(Succeed())
+	g.Expect(sts.Spec.Template.Labels).To(HaveKeyWithValue("cloud.antfly.io/instance-id", "instance-before"))
+
+	cluster.Labels = map[string]string{
+		"cloud.antfly.io/instance-id": "instance-after",
+		"cloud.antfly.io/org-id":      "org-123",
+	}
+
+	g.Expect(reconciler.reconcileMetadataStatefulSet(context.Background(), &envFromCache{}, cluster)).To(Succeed())
+	g.Expect(client.Get(context.Background(), key, sts)).To(Succeed())
+	g.Expect(sts.Spec.Template.Labels).To(HaveKeyWithValue("cloud.antfly.io/instance-id", "instance-after"))
+	g.Expect(sts.Spec.Template.Labels).To(HaveKeyWithValue("cloud.antfly.io/org-id", "org-123"))
+	g.Expect(sts.Spec.Template.Labels).To(HaveKeyWithValue("app.kubernetes.io/managed-by", "antfly-operator"))
 }
 
 // TestSelectorLabels tests that selectorLabels includes instance but not managed-by


### PR DESCRIPTION
## Summary
- merge non-reserved AntflyCluster metadata labels into operator-managed pod templates
- keep app.kubernetes.io/* labels reserved so CR labels cannot override operator selector/identity labels
- add unit coverage for label merging and StatefulSet pod-template updates after CR label changes

## Tests
- env GOWORK=off GOCACHE=/tmp/go-build go test ./controllers

Note: the test command emits an existing local linker warning about a missing onnxruntime search path, but the package passes.