### PR TITLE
Add index query latency metrics

### DIFF
--- a/devops/docker-compose-s3/grafana/dashboards/indexes.json
+++ b/devops/docker-compose-s3/grafana/dashboards/indexes.json
@@ -184,6 +184,41 @@
       ],
       "title": "Embedding Persist Rate",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": null
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 8
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": null
+          },
+          "expr": "histogram_quantile(0.95, sum by (Name, query_type, le) (rate(antfly_indexes_query_duration_seconds_bucket[5m])))",
+          "legendFormat": "{{Name}} {{query_type}} p95",
+          "refId": "A"
+        }
+      ],
+      "title": "Query Latency p95",
+      "type": "timeseries"
     }
   ],
   "refresh": "10s",

--- a/devops/docker-compose/grafana/dashboards/indexes.json
+++ b/devops/docker-compose/grafana/dashboards/indexes.json
@@ -184,6 +184,41 @@
       ],
       "title": "Embedding Persist Rate",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": null
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 8
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": null
+          },
+          "expr": "histogram_quantile(0.95, sum by (Name, query_type, le) (rate(antfly_indexes_query_duration_seconds_bucket[5m])))",
+          "legendFormat": "{{Name}} {{query_type}} p95",
+          "refId": "A"
+        }
+      ],
+      "title": "Query Latency p95",
+      "type": "timeseries"
     }
   ],
   "refresh": "10s",

--- a/src/store/db/indexes/embeddings_index.go
+++ b/src/store/db/indexes/embeddings_index.go
@@ -480,6 +480,7 @@ func (s *EmbeddingIndex) IsChunked() bool {
 
 func (s *EmbeddingIndex) Search(ctx context.Context, query any) (any, error) {
 	queryOps.WithLabelValues(s.name).Inc()
+	defer observeQueryDuration(s.name, "vector", time.Now())
 	if query == nil {
 		return nil, storeutils.ErrEmptyRequest
 	}

--- a/src/store/db/indexes/full_text_index.go
+++ b/src/store/db/indexes/full_text_index.go
@@ -927,6 +927,7 @@ func (bb *BleveBatchV2) Commit() error {
 // The result is a JSON marshaled remoteindex.RemoteIndexSearchResponse containing the bleve.SearchResult.
 func (bi *BleveIndexV2) Search(ctx context.Context, query any) (any, error) {
 	queryOps.WithLabelValues(bi.name).Inc()
+	defer observeQueryDuration(bi.name, "search", time.Now())
 	if query == nil {
 		return nil, storeutils.ErrEmptyRequest
 	}

--- a/src/store/db/indexes/metrics.go
+++ b/src/store/db/indexes/metrics.go
@@ -15,6 +15,8 @@
 package indexes
 
 import (
+	"time"
+
 	"github.com/antflydb/antfly/lib/inflight"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -46,6 +48,16 @@ var (
 			Help:      "The total number of queries.",
 		},
 		[]string{"Name"},
+	)
+	queryDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: "antfly",
+			Subsystem: "indexes",
+			Name:      "query_duration_seconds",
+			Help:      "Index query latency in seconds.",
+			Buckets:   []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10},
+		},
+		[]string{"Name", "query_type"},
 	)
 	embeddingCreationOps = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
@@ -138,6 +150,7 @@ func init() {
 	prometheus.MustRegister(writeOps)
 	prometheus.MustRegister(deleteOps)
 	prometheus.MustRegister(queryOps)
+	prometheus.MustRegister(queryDuration)
 	prometheus.MustRegister(embeddingCreationOps)
 	prometheus.MustRegister(embeddingPersistOps)
 	prometheus.MustRegister(walDequeueAttempts)
@@ -147,6 +160,10 @@ func init() {
 	prometheus.MustRegister(backfillProgress)
 	prometheus.MustRegister(backfillItemsProcessed)
 	prometheus.MustRegister(enricherWALBacklog)
+}
+
+func observeQueryDuration(name, queryType string, start time.Time) {
+	queryDuration.WithLabelValues(name, queryType).Observe(time.Since(start).Seconds())
 }
 
 // PrometheusWALMetrics implements inflight.WALBufferMetrics using Prometheus.


### PR DESCRIPTION
## Summary
- add an index query latency histogram labeled by index name and query type
- record latency for full-text and vector index searches
- add p95 query latency panels to the local Grafana dashboards

## Tests
- GOWORK=off go test ./src/store/db/indexes