### PR TITLE
Add operator autoscaling and storage scale-down safety

### DIFF
--- a/e2e/cluster.go
+++ b/e2e/cluster.go
@@ -71,11 +71,12 @@ type clusterStatusResponse struct {
 }
 
 type nodeShutdownStatusResponse struct {
-	Phase           string `json:"phase"`
-	SafeToTerminate bool   `json:"safe_to_terminate"`
-	Blocked         bool   `json:"blocked,omitempty"`
-	BlockedReason   string `json:"blocked_reason,omitempty"`
-	Message         string `json:"message,omitempty"`
+	Phase           string   `json:"phase"`
+	SafeToTerminate bool     `json:"safe_to_terminate"`
+	Blocked         bool     `json:"blocked,omitempty"`
+	BlockedReason   string   `json:"blocked_reason,omitempty"`
+	Message         string   `json:"message,omitempty"`
+	BypassedGroups  []string `json:"bypassed_groups,omitempty"`
 }
 
 // TestCluster represents a multi-node test cluster for distributed e2e testing.

--- a/e2e/cluster.go
+++ b/e2e/cluster.go
@@ -18,8 +18,10 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"math/rand"
 	"net/http"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -66,6 +68,14 @@ type clusterStatusResponse struct {
 	Shards struct {
 		Statuses map[string]*store.ShardStatus `json:"statuses"`
 	} `json:"shards"`
+}
+
+type nodeShutdownStatusResponse struct {
+	Phase           string `json:"phase"`
+	SafeToTerminate bool   `json:"safe_to_terminate"`
+	Blocked         bool   `json:"blocked,omitempty"`
+	BlockedReason   string `json:"blocked_reason,omitempty"`
+	Message         string `json:"message,omitempty"`
 }
 
 // TestCluster represents a multi-node test cluster for distributed e2e testing.
@@ -312,42 +322,133 @@ func (c *TestCluster) AddStoreNode(ctx context.Context) *StoreNode {
 	return node
 }
 
-// RemoveStoreNode removes a store node from the cluster by deregistering it
+// RemoveStoreNode gracefully removes a store node from the cluster. It requests
+// runtime drain, waits until metadata reports that the node is safe to
+// terminate, stops the local process, and finalizes the node lifecycle record.
 func (c *TestCluster) RemoveStoreNode(ctx context.Context, nodeID types.ID) error {
-	c.mu.Lock()
+	c.mu.RLock()
 	node, exists := c.StoreNodes[nodeID]
 	if !exists {
-		c.mu.Unlock()
+		c.mu.RUnlock()
 		return fmt.Errorf("store node %d not found", nodeID)
 	}
-	delete(c.StoreNodes, nodeID)
-	c.mu.Unlock()
+	c.mu.RUnlock()
 
 	c.Logger.Info("Removing store node", zap.Stringer("nodeID", nodeID))
 
-	// Deregister the store from metadata (this will trigger shard reallocation)
-	// Note: The URL path parameter is parsed as a hex string by IDFromString,
-	// so we must use nodeID.String() which returns the hex representation.
-	deregisterURL := fmt.Sprintf("%s/_internal/v1/store/%s", c.MetadataNode.APIURL, nodeID.String())
-	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, deregisterURL, nil)
+	// Request node shutdown in metadata before stopping the store node. Node
+	// lifecycle APIs use decimal path IDs to match the Zig runtime contract.
+	nodeIDString := strconv.FormatUint(uint64(nodeID), 10)
+	nodeURL := fmt.Sprintf("%s/_internal/v1/nodes/%s", c.MetadataNode.APIURL, nodeIDString)
+	shutdownURL := nodeURL + "/shutdown"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, shutdownURL, bytes.NewBufferString(`{"type":"remove","reason":"e2e graceful removal"}`))
 	if err != nil {
-		return fmt.Errorf("creating deregister request: %w", err)
+		return fmt.Errorf("creating node shutdown request: %w", err)
 	}
+	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := http.DefaultClient.Do(req) //nolint:gosec // G704: HTTP client calling configured endpoint
 	if err != nil {
-		return fmt.Errorf("deregistering store: %w", err)
+		return fmt.Errorf("requesting node shutdown: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("deregister returned status %d", resp.StatusCode)
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("node shutdown returned status %d", resp.StatusCode)
 	}
 
-	// Stop the store node after deregistration so the cluster exercises real node removal.
-	node.Cancel()
+	shutdownRequested := true
+	nodeStopped := false
+	defer func() {
+		if !shutdownRequested || nodeStopped {
+			return
+		}
+		cancelCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		cancelReq, cancelErr := http.NewRequestWithContext(cancelCtx, http.MethodDelete, shutdownURL, nil)
+		if cancelErr != nil {
+			c.Logger.Warn("Failed to create node shutdown cancellation request", zap.Stringer("nodeID", nodeID), zap.Error(cancelErr))
+			return
+		}
+		cancelResp, cancelErr := http.DefaultClient.Do(cancelReq) //nolint:gosec // G704: HTTP client calling configured endpoint
+		if cancelErr != nil {
+			c.Logger.Warn("Failed to cancel node shutdown after removal failure", zap.Stringer("nodeID", nodeID), zap.Error(cancelErr))
+			return
+		}
+		_, _ = io.Copy(io.Discard, cancelResp.Body)
+		_ = cancelResp.Body.Close()
+		if cancelResp.StatusCode < 200 || cancelResp.StatusCode >= 300 {
+			c.Logger.Warn("Node shutdown cancellation returned non-success status", zap.Stringer("nodeID", nodeID), zap.Int("status", cancelResp.StatusCode))
+		}
+	}()
 
-	c.Logger.Info("Store node removed and deregistered", zap.Stringer("nodeID", nodeID))
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		statusReq, err := http.NewRequestWithContext(ctx, http.MethodGet, shutdownURL, nil)
+		if err != nil {
+			return fmt.Errorf("creating node shutdown status request: %w", err)
+		}
+		statusResp, err := http.DefaultClient.Do(statusReq) //nolint:gosec // G704: HTTP client calling configured endpoint
+		if err != nil {
+			return fmt.Errorf("getting node shutdown status: %w", err)
+		}
+		if statusResp.StatusCode < 200 || statusResp.StatusCode >= 300 {
+			_, _ = io.Copy(io.Discard, statusResp.Body)
+			_ = statusResp.Body.Close()
+			return fmt.Errorf("node shutdown status returned status %d", statusResp.StatusCode)
+		}
+		var status nodeShutdownStatusResponse
+		if err := json.NewDecoder(statusResp.Body).Decode(&status); err != nil {
+			_ = statusResp.Body.Close()
+			return fmt.Errorf("decoding node shutdown status: %w", err)
+		}
+		_ = statusResp.Body.Close()
+		if status.Blocked {
+			message := status.Message
+			if message == "" {
+				message = status.BlockedReason
+			}
+			if message == "" {
+				message = "metadata reported blocked node shutdown"
+			}
+			return fmt.Errorf("node shutdown blocked in phase %q: %s", status.Phase, message)
+		}
+		if status.SafeToTerminate {
+			break
+		}
+
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("waiting for node shutdown safety: %w", ctx.Err())
+		case <-ticker.C:
+		}
+	}
+
+	// Stop the store node only after metadata reports that no local runtime
+	// ownership remains.
+	node.Cancel()
+	nodeStopped = true
+
+	c.mu.Lock()
+	delete(c.StoreNodes, nodeID)
+	c.mu.Unlock()
+
+	finalizeReq, err := http.NewRequestWithContext(ctx, http.MethodDelete, nodeURL, nil)
+	if err != nil {
+		return fmt.Errorf("creating node shutdown finalization request: %w", err)
+	}
+	finalizeResp, err := http.DefaultClient.Do(finalizeReq) //nolint:gosec // G704: HTTP client calling configured endpoint
+	if err != nil {
+		return fmt.Errorf("finalizing node shutdown: %w", err)
+	}
+	defer func() { _ = finalizeResp.Body.Close() }()
+	_, _ = io.Copy(io.Discard, finalizeResp.Body)
+	if finalizeResp.StatusCode < 200 || finalizeResp.StatusCode >= 300 {
+		return fmt.Errorf("node shutdown finalization returned status %d", finalizeResp.StatusCode)
+	}
+
+	c.Logger.Info("Store node removed after graceful shutdown", zap.Stringer("nodeID", nodeID))
 	return nil
 }
 

--- a/e2e/online_shard_split_test.go
+++ b/e2e/online_shard_split_test.go
@@ -982,10 +982,10 @@ func TestE2E_OnlineSplit_TimeoutRollsBack(t *testing.T) {
 	storeIDs := cluster.GetStoreNodeIDs()
 	if len(storeIDs) > 0 {
 		removedStoreID := storeIDs[len(storeIDs)-1]
-		if err := cluster.RemoveStoreNode(ctx, removedStoreID); err != nil {
-			t.Logf("Warning: Failed to remove store node: %v", err)
+		if err := cluster.CrashStoreNode(removedStoreID); err != nil {
+			t.Logf("Warning: Failed to crash store node: %v", err)
 		} else {
-			t.Logf("Removed store node %s", removedStoreID)
+			t.Logf("Crashed store node %s", removedStoreID)
 		}
 	}
 
@@ -2041,10 +2041,10 @@ func TestE2E_SplitFailureNewShardFails(t *testing.T) {
 	storeIDs := cluster.GetStoreNodeIDs()
 	if len(storeIDs) > 0 {
 		removedNode := storeIDs[len(storeIDs)-1]
-		if err := cluster.RemoveStoreNode(ctx, removedNode); err != nil {
-			t.Logf("Warning: Failed to remove store node: %v", err)
+		if err := cluster.CrashStoreNode(removedNode); err != nil {
+			t.Logf("Warning: Failed to crash store node: %v", err)
 		} else {
-			t.Logf("Removed store node %s", removedNode)
+			t.Logf("Crashed store node %s", removedNode)
 		}
 	}
 

--- a/pkg/operator/README.md
+++ b/pkg/operator/README.md
@@ -351,7 +351,12 @@ kubectl patch antflycluster my-database --type='merge' -p='{"spec":{"dataNodes":
 
 # Scale metadata nodes (must be odd number for Raft consensus)
 kubectl patch antflycluster my-database --type='merge' -p='{"spec":{"metadataNodes":{"replicas":5}}}'
+
+# Pause data nodes while retaining PVCs
+kubectl patch antflycluster my-database --type='merge' -p='{"spec":{"dataNodes":{"suspend":true},"storage":{"pvcRetentionPolicy":{"whenScaled":"Retain"}}}}'
 ```
+
+Use `spec.dataNodes.suspend=true` for scale-to-zero pause/resume. Do not use `dataNodes.replicas: 0` for suspension; `0` or omitted uses the controller default. Suspension requires retained PVCs and cannot be combined with data-node autoscaling.
 
 ## 📚 Examples
 

--- a/pkg/operator/api/antfly/v1/antflycluster_types.go
+++ b/pkg/operator/api/antfly/v1/antflycluster_types.go
@@ -362,8 +362,14 @@ type MetadataNodesSpec struct {
 
 // DataNodesSpec defines the configuration for data nodes
 type DataNodesSpec struct {
-	// Replicas is the number of data nodes (default: 3)
+	// Replicas is the number of data nodes. Zero or omitted uses the controller
+	// default of 3; use suspend for intentional scale-to-zero.
 	Replicas int32 `json:"replicas,omitempty"`
+
+	// Suspend scales data nodes to zero while retaining PVCs. This is a
+	// pause/resume operation, not permanent node removal.
+	// +optional
+	Suspend bool `json:"suspend,omitempty"`
 
 	// AutoScaling defines autoscaling configuration
 	AutoScaling *AutoScalingSpec `json:"autoScaling,omitempty"`
@@ -871,8 +877,8 @@ type DataScaleDownStatus struct {
 	// DrainingOrdinal is the StatefulSet ordinal selected for this step.
 	DrainingOrdinal int32 `json:"drainingOrdinal,omitempty"`
 
-	// DrainingStoreID is the Antfly store ID selected for this step.
-	DrainingStoreID string `json:"drainingStoreID,omitempty"`
+	// DrainingNodeID is the Antfly node ID selected for this step.
+	DrainingNodeID string `json:"drainingNodeID,omitempty"`
 
 	// Phase is the current scale-down workflow phase.
 	Phase string `json:"phase,omitempty"`

--- a/pkg/operator/api/antfly/v1/antflycluster_webhook.go
+++ b/pkg/operator/api/antfly/v1/antflycluster_webhook.go
@@ -480,6 +480,14 @@ Solution: Use an odd replica count:
 		return fmt.Errorf("spec.dataNodes.replicas must be >= 0, got %d", r.Spec.DataNodes.Replicas)
 	}
 
+	if r.Spec.DataNodes.Suspend && r.Spec.DataNodes.AutoScaling != nil && r.Spec.DataNodes.AutoScaling.Enabled {
+		return fmt.Errorf(`spec.dataNodes.suspend conflicts with spec.dataNodes.autoScaling.enabled=true
+
+Problem: Suspension is an explicit pause/resume operation, while autoscaling continuously manages the data replica target.
+
+Solution: Disable data-node autoscaling before suspending the data StatefulSet.`)
+	}
+
 	return nil
 }
 
@@ -813,6 +821,14 @@ Solution: Either:
   Option 2: Disable autoscaling (spec.dataNodes.autoScaling.enabled=false)`)
 	}
 
+	if policy.WhenScaled == PVCRetentionDelete && r.Spec.DataNodes.Suspend {
+		return fmt.Errorf(`spec.storage.pvcRetentionPolicy.whenScaled=Delete conflicts with spec.dataNodes.suspend=true
+
+Problem: Suspension scales data pods to zero and relies on retained PVCs so the same ordinals can resume with their existing data.
+
+Solution: Set spec.storage.pvcRetentionPolicy.whenScaled=Retain before suspending data nodes.`)
+	}
+
 	return nil
 }
 
@@ -827,8 +843,8 @@ func (r *AntflyCluster) validateAutoScalingConfig() error {
 	}
 
 	var errors []string
-	if autoScaling.MinReplicas < 0 {
-		errors = append(errors, fmt.Sprintf("spec.dataNodes.autoScaling.minReplicas must be >= 0, got %d", autoScaling.MinReplicas))
+	if autoScaling.MinReplicas < 1 {
+		errors = append(errors, fmt.Sprintf("spec.dataNodes.autoScaling.minReplicas must be >= 1, got %d", autoScaling.MinReplicas))
 	}
 	if autoScaling.MaxReplicas < 1 {
 		errors = append(errors, fmt.Sprintf("spec.dataNodes.autoScaling.maxReplicas must be >= 1, got %d", autoScaling.MaxReplicas))
@@ -1111,6 +1127,10 @@ func (r *AntflyCluster) validateSwarmTopologyIsolation() error {
 
 	if r.Spec.DataNodes.Replicas != 0 {
 		errors = append(errors, "spec.dataNodes.replicas must be unset when spec.mode=Swarm")
+	}
+
+	if r.Spec.DataNodes.Suspend {
+		errors = append(errors, "spec.dataNodes.suspend must be unset when spec.mode=Swarm")
 	}
 
 	if r.Spec.MetadataNodes.Resources != (ResourceSpec{}) {

--- a/pkg/operator/api/antfly/v1/antflycluster_webhook.go
+++ b/pkg/operator/api/antfly/v1/antflycluster_webhook.go
@@ -485,7 +485,7 @@ Solution: Use an odd replica count:
 
 Problem: Suspension is an explicit pause/resume operation, while autoscaling continuously manages the data replica target.
 
-Solution: Disable data-node autoscaling before suspending the data StatefulSet.`)
+Solution: Disable data-node autoscaling before suspending the data StatefulSet`)
 	}
 
 	return nil
@@ -826,7 +826,7 @@ Solution: Either:
 
 Problem: Suspension scales data pods to zero and relies on retained PVCs so the same ordinals can resume with their existing data.
 
-Solution: Set spec.storage.pvcRetentionPolicy.whenScaled=Retain before suspending data nodes.`)
+Solution: Set spec.storage.pvcRetentionPolicy.whenScaled=Retain before suspending data nodes`)
 	}
 
 	return nil

--- a/pkg/operator/api/antfly/v1/antflycluster_webhook_test.go
+++ b/pkg/operator/api/antfly/v1/antflycluster_webhook_test.go
@@ -1062,7 +1062,7 @@ func TestValidateCreate_ZeroDataReplicas(t *testing.T) {
 
 	err := cluster.ValidateCreate()
 	if err != nil {
-		t.Errorf("Expected no error for 0 data replicas, got: %v", err)
+		t.Errorf("Expected no error for 0 data replicas because it maps to the controller default, got: %v", err)
 	}
 }
 
@@ -1481,6 +1481,52 @@ func TestValidateUpdate_DataScaleDownAllowed(t *testing.T) {
 	}
 }
 
+func TestValidateCreate_DataSuspendAllowedWithRetainedPVCs(t *testing.T) {
+	cluster := baseCluster()
+	cluster.Spec.DataNodes.Suspend = true
+	cluster.Spec.Storage.PVCRetentionPolicy = &PVCRetentionPolicy{
+		WhenScaled: PVCRetentionRetain,
+	}
+
+	if err := cluster.ValidateCreate(); err != nil {
+		t.Fatalf("expected data suspend with retained PVCs to be admitted, got: %v", err)
+	}
+}
+
+func TestValidateCreate_DataSuspendRejectsDeleteOnScale(t *testing.T) {
+	cluster := baseCluster()
+	cluster.Spec.DataNodes.Suspend = true
+	cluster.Spec.Storage.PVCRetentionPolicy = &PVCRetentionPolicy{
+		WhenScaled: PVCRetentionDelete,
+	}
+
+	err := cluster.ValidateCreate()
+	if err == nil {
+		t.Fatal("expected data suspend with WhenScaled=Delete to be rejected")
+	}
+	if !strings.Contains(err.Error(), "dataNodes.suspend") {
+		t.Fatalf("expected data suspend error, got: %v", err)
+	}
+}
+
+func TestValidateCreate_DataSuspendRejectsAutoscaling(t *testing.T) {
+	cluster := baseCluster()
+	cluster.Spec.DataNodes.Suspend = true
+	cluster.Spec.DataNodes.AutoScaling = &AutoScalingSpec{
+		Enabled:     true,
+		MinReplicas: 1,
+		MaxReplicas: 3,
+	}
+
+	err := cluster.ValidateCreate()
+	if err == nil {
+		t.Fatal("expected data suspend with autoscaling to be rejected")
+	}
+	if !strings.Contains(err.Error(), "dataNodes.suspend") {
+		t.Fatalf("expected data suspend error, got: %v", err)
+	}
+}
+
 func TestValidateCreate_AutoScalingBoundsRejected(t *testing.T) {
 	cluster := baseCluster()
 	cluster.Spec.DataNodes.AutoScaling = &AutoScalingSpec{
@@ -1495,6 +1541,23 @@ func TestValidateCreate_AutoScalingBoundsRejected(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "minReplicas") {
 		t.Fatalf("expected autoscaling bounds error, got: %v", err)
+	}
+}
+
+func TestValidateCreate_AutoScalingMinReplicasZeroRejected(t *testing.T) {
+	cluster := baseCluster()
+	cluster.Spec.DataNodes.AutoScaling = &AutoScalingSpec{
+		Enabled:     true,
+		MinReplicas: 0,
+		MaxReplicas: 3,
+	}
+
+	err := cluster.ValidateCreate()
+	if err == nil {
+		t.Fatal("expected error for autoscaling minReplicas zero")
+	}
+	if !strings.Contains(err.Error(), "minReplicas") {
+		t.Fatalf("expected autoscaling minReplicas error, got: %v", err)
 	}
 }
 

--- a/pkg/operator/controllers/antfly/antflycluster_controller.go
+++ b/pkg/operator/controllers/antfly/antflycluster_controller.go
@@ -59,6 +59,8 @@ type AntflyClusterReconciler struct {
 	validationAttempts sync.Map
 }
 
+var defaultOperatorHTTPClient = &http.Client{Timeout: 10 * time.Second}
+
 //+kubebuilder:rbac:groups=antfly.io,resources=antflyclusters,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=antfly.io,resources=antflyclusters/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=antfly.io,resources=antflyclusters/finalizers,verbs=update
@@ -221,66 +223,137 @@ func (r *AntflyClusterReconciler) cleanupStorageResources(ctx context.Context, c
 }
 
 type dataNodeShutdownStatus struct {
-	NodeID          string `json:"node_id"`
+	NodeID          int64  `json:"node_id"`
 	Phase           string `json:"phase"`
 	SafeToTerminate bool   `json:"safe_to_terminate"`
+	Blocked         bool   `json:"blocked,omitempty"`
+	BlockedReason   string `json:"blocked_reason,omitempty"`
+	Message         string `json:"message,omitempty"`
 }
 
 func (r *AntflyClusterReconciler) httpClient() *http.Client {
 	if r.HTTPClient != nil {
 		return r.HTTPClient
 	}
-	return http.DefaultClient
+	return defaultOperatorHTTPClient
 }
 
 // requestDataNodeShutdown asks Antfly metadata to drain a data node and returns
-// the current runtime safety status. Store/node ID is deterministic:
-// store_id = pod_ordinal + 1.
-func (r *AntflyClusterReconciler) requestDataNodeShutdown(ctx context.Context, cluster *antflyv1.AntflyCluster, storeIDString string) (*dataNodeShutdownStatus, error) {
+// the current runtime safety status. Node ID is deterministic:
+// node_id = pod_ordinal + 1.
+func (r *AntflyClusterReconciler) requestDataNodeShutdown(ctx context.Context, cluster *antflyv1.AntflyCluster, nodeIDString string) (*dataNodeShutdownStatus, error) {
 	log := log.FromContext(ctx)
 	metadataAddr := fmt.Sprintf("http://%s-metadata.%s.svc:%d",
 		cluster.Name, cluster.Namespace, cluster.Spec.MetadataNodes.MetadataAPI.Port)
-	url := fmt.Sprintf("%s/internal/v1/nodes/%s/shutdown", metadataAddr, storeIDString)
+	url := fmt.Sprintf("%s/internal/v1/nodes/%s/shutdown", metadataAddr, nodeIDString)
 
-	log.Info("Requesting data node shutdown before scale-down", "storeID", storeIDString)
+	log.Info("Requesting data node shutdown before scale-down", "nodeID", nodeIDString)
 	body := strings.NewReader(`{"type":"remove","reason":"operator scale-down"}`)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPut, url, body)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create node shutdown request for store %s: %w", storeIDString, err)
+		return nil, fmt.Errorf("failed to create node shutdown request for node %s: %w", nodeIDString, err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := r.httpClient().Do(req) //nolint:gosec // URL is constructed from cluster-internal service address, not external user input
 	if err != nil {
-		log.Error(err, "Failed to request data node shutdown, will retry", "storeID", storeIDString)
-		return nil, fmt.Errorf("failed to request shutdown for store %s: %w", storeIDString, err)
+		log.Error(err, "Failed to request data node shutdown, will retry", "nodeID", nodeIDString)
+		return nil, fmt.Errorf("failed to request shutdown for node %s: %w", nodeIDString, err)
 	}
 	statusCode := resp.StatusCode
 	_, _ = io.Copy(io.Discard, resp.Body)
 	_ = resp.Body.Close()
 	if statusCode < 200 || statusCode >= 300 {
-		return nil, fmt.Errorf("shutdown request for store %s returned status %d", storeIDString, statusCode)
+		return nil, fmt.Errorf("shutdown request for node %s returned status %d", nodeIDString, statusCode)
 	}
 
 	statusReq, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create node shutdown status request for store %s: %w", storeIDString, err)
+		return nil, fmt.Errorf("failed to create node shutdown status request for node %s: %w", nodeIDString, err)
 	}
 	statusResp, err := r.httpClient().Do(statusReq) //nolint:gosec // URL is constructed from cluster-internal service address, not external user input
 	if err != nil {
-		return nil, fmt.Errorf("failed to get shutdown status for store %s: %w", storeIDString, err)
+		return nil, fmt.Errorf("failed to get shutdown status for node %s: %w", nodeIDString, err)
 	}
 	defer func() { _ = statusResp.Body.Close() }()
 	if statusResp.StatusCode < 200 || statusResp.StatusCode >= 300 {
 		_, _ = io.Copy(io.Discard, statusResp.Body)
-		return nil, fmt.Errorf("shutdown status for store %s returned status %d", storeIDString, statusResp.StatusCode)
+		return nil, fmt.Errorf("shutdown status for node %s returned status %d", nodeIDString, statusResp.StatusCode)
 	}
 
 	var status dataNodeShutdownStatus
 	if err := json.NewDecoder(statusResp.Body).Decode(&status); err != nil {
-		return nil, fmt.Errorf("failed to decode shutdown status for store %s: %w", storeIDString, err)
+		return nil, fmt.Errorf("failed to decode shutdown status for node %s: %w", nodeIDString, err)
 	}
 	return &status, nil
+}
+
+func (r *AntflyClusterReconciler) cancelDataNodeShutdown(ctx context.Context, cluster *antflyv1.AntflyCluster, nodeIDString string) (*dataNodeShutdownStatus, error) {
+	log := log.FromContext(ctx)
+	metadataAddr := fmt.Sprintf("http://%s-metadata.%s.svc:%d",
+		cluster.Name, cluster.Namespace, cluster.Spec.MetadataNodes.MetadataAPI.Port)
+	url := fmt.Sprintf("%s/internal/v1/nodes/%s/shutdown", metadataAddr, nodeIDString)
+
+	log.Info("Canceling data node shutdown", "nodeID", nodeIDString)
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create node shutdown cancellation request for node %s: %w", nodeIDString, err)
+	}
+	resp, err := r.httpClient().Do(req) //nolint:gosec // URL is constructed from cluster-internal service address, not external user input
+	if err != nil {
+		return nil, fmt.Errorf("failed to cancel shutdown for node %s: %w", nodeIDString, err)
+	}
+	statusCode := resp.StatusCode
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
+	if statusCode < 200 || statusCode >= 300 {
+		return nil, fmt.Errorf("shutdown cancellation for node %s returned status %d", nodeIDString, statusCode)
+	}
+
+	statusReq, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create node shutdown status request after cancellation for node %s: %w", nodeIDString, err)
+	}
+	statusResp, err := r.httpClient().Do(statusReq) //nolint:gosec // URL is constructed from cluster-internal service address, not external user input
+	if err != nil {
+		return nil, fmt.Errorf("failed to get shutdown status after cancellation for node %s: %w", nodeIDString, err)
+	}
+	defer func() { _ = statusResp.Body.Close() }()
+	if statusResp.StatusCode == http.StatusNotFound {
+		_, _ = io.Copy(io.Discard, statusResp.Body)
+		return &dataNodeShutdownStatus{Phase: "not_found"}, nil
+	}
+	if statusResp.StatusCode < 200 || statusResp.StatusCode >= 300 {
+		_, _ = io.Copy(io.Discard, statusResp.Body)
+		return nil, fmt.Errorf("shutdown status after cancellation for node %s returned status %d", nodeIDString, statusResp.StatusCode)
+	}
+
+	var status dataNodeShutdownStatus
+	if err := json.NewDecoder(statusResp.Body).Decode(&status); err != nil {
+		return nil, fmt.Errorf("failed to decode shutdown status after cancellation for node %s: %w", nodeIDString, err)
+	}
+	return &status, nil
+}
+
+func (r *AntflyClusterReconciler) finalizeDataNodeShutdown(ctx context.Context, cluster *antflyv1.AntflyCluster, nodeIDString string) error {
+	metadataAddr := fmt.Sprintf("http://%s-metadata.%s.svc:%d",
+		cluster.Name, cluster.Namespace, cluster.Spec.MetadataNodes.MetadataAPI.Port)
+	url := fmt.Sprintf("%s/internal/v1/nodes/%s", metadataAddr, nodeIDString)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, url, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create node shutdown finalization request for node %s: %w", nodeIDString, err)
+	}
+	resp, err := r.httpClient().Do(req) //nolint:gosec // URL is constructed from cluster-internal service address, not external user input
+	if err != nil {
+		return fmt.Errorf("failed to finalize shutdown for node %s: %w", nodeIDString, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	_, _ = io.Copy(io.Discard, resp.Body)
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("shutdown finalization for node %s returned status %d", nodeIDString, resp.StatusCode)
+	}
+	return nil
 }
 
 const (
@@ -308,6 +381,44 @@ func effectiveTopologyMode(cluster *antflyv1.AntflyCluster) topologyMode {
 
 func isSwarmMode(cluster *antflyv1.AntflyCluster) bool {
 	return effectiveTopologyMode(cluster) == topologyModeSwarm
+}
+
+func shouldCancelDataScaleDown(status *antflyv1.DataScaleDownStatus, currentReplicas, desiredReplicas int32) bool {
+	if status == nil || status.DrainingNodeID == "" {
+		return false
+	}
+	switch status.Phase {
+	case "Draining", "Blocked", "Failed", "Canceling", "Scaling":
+	default:
+		return false
+	}
+	return currentReplicas > status.DrainingOrdinal && desiredReplicas > status.DrainingOrdinal
+}
+
+func shouldCancelDataScaleDownForSuspend(status *antflyv1.DataScaleDownStatus, currentReplicas int32) bool {
+	if status == nil || status.DrainingNodeID == "" {
+		return false
+	}
+	switch status.Phase {
+	case "Draining", "Blocked", "Failed", "Canceling", "Scaling":
+	default:
+		return false
+	}
+	return currentReplicas > status.DrainingOrdinal
+}
+
+func shouldFinalizeDataScaleDown(status *antflyv1.DataScaleDownStatus, currentReplicas, desiredReplicas int32, dataScaleDownRequested bool) bool {
+	if status == nil || status.DrainingNodeID == "" || shouldCancelDataScaleDown(status, currentReplicas, desiredReplicas) {
+		return false
+	}
+	switch status.Phase {
+	case "Scaling":
+		return true
+	case "Failed":
+		return !dataScaleDownRequested && status.AppliedReplicas < status.FromReplicas && currentReplicas <= status.AppliedReplicas
+	default:
+		return false
+	}
 }
 
 func (r *AntflyClusterReconciler) ensureTopologyResourcesMatchMode(ctx context.Context, cluster *antflyv1.AntflyCluster, mode topologyMode) error {
@@ -1050,7 +1161,14 @@ func (r *AntflyClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	dataScaleDownSource := antflyv1.DataScaleDownSourceManual
 	dataScaleDownRequested := false
 	autoscalingEnabled := r.AutoScaler != nil && workingCluster.Spec.DataNodes.AutoScaling != nil && workingCluster.Spec.DataNodes.AutoScaling.Enabled
-	if autoscalingEnabled {
+	dataNodesSuspended := workingCluster.Spec.DataNodes.Suspend
+	if dataNodesSuspended {
+		workingCluster.Status.AutoScalingStatus = nil
+		requestedDataReplicas = 0
+		desiredDataReplicas = 0
+		workingCluster.Spec.DataNodes.Replicas = 0
+		r.setScalingCondition(workingCluster, metav1.ConditionTrue, antflyv1.ReasonScalingReady, "Data nodes are suspended with PVCs retained")
+	} else if autoscalingEnabled {
 		dataScaleDownSource = antflyv1.DataScaleDownSourceAutoscaler
 		recommendationReplicas, err := r.AutoScaler.EvaluateScaling(ctx, workingCluster, currentDataTarget)
 		if err != nil {
@@ -1090,26 +1208,109 @@ func (r *AntflyClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		}
 	}
 
-	if dataStsExists && dataScaleDownRequested {
-		drainingOrdinal := scaleSafetyReplicas - 1
-		drainingStoreID := storeIDForDataOrdinal(drainingOrdinal)
-		nextReplicas := scaleSafetyReplicas - 1
-		message := fmt.Sprintf("Draining data ordinal %d/store %s before scaling StatefulSet from %d to %d", drainingOrdinal, drainingStoreID, scaleSafetyReplicas, nextReplicas)
-		r.setDataScaleDownStatus(workingCluster, dataScaleDownSource, scaleSafetyReplicas, requestedDataReplicas, scaleSafetyReplicas, drainingOrdinal, drainingStoreID, "Draining", message)
-		r.setScalingCondition(workingCluster, metav1.ConditionUnknown, antflyv1.ReasonDataScaleDownInProgress, message)
-		shutdownStatus, err := r.requestDataNodeShutdown(ctx, workingCluster, drainingStoreID)
+	if dataStsExists && shouldFinalizeDataScaleDown(workingCluster.Status.DataScaleDownStatus, currentDataReplicas, desiredDataReplicas, dataScaleDownRequested) {
+		scalingStatus := workingCluster.Status.DataScaleDownStatus
+		if currentDataReplicas > scalingStatus.AppliedReplicas {
+			message := fmt.Sprintf("Waiting for StatefulSet to remove data ordinal %d/node %s; current replicas=%d target replicas=%d", scalingStatus.DrainingOrdinal, scalingStatus.DrainingNodeID, currentDataReplicas, scalingStatus.AppliedReplicas)
+			r.setDataScaleDownStatus(workingCluster, scalingStatus.Source, scalingStatus.FromReplicas, scalingStatus.TargetReplicas, scalingStatus.AppliedReplicas, scalingStatus.DrainingOrdinal, scalingStatus.DrainingNodeID, "Scaling", message)
+			r.setScalingCondition(workingCluster, metav1.ConditionUnknown, antflyv1.ReasonDataScaleDownInProgress, message)
+			if statusErr := r.updateStatus(ctx, workingCluster); statusErr != nil {
+				log.Error(statusErr, "Failed to update status while waiting for data StatefulSet scale-down")
+			}
+			return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+		}
+		if err := r.finalizeDataNodeShutdown(ctx, workingCluster, scalingStatus.DrainingNodeID); err != nil {
+			failureMessage := fmt.Sprintf("Failed to finalize data-node shutdown for ordinal %d/node %s after StatefulSet scale-down: %v", scalingStatus.DrainingOrdinal, scalingStatus.DrainingNodeID, err)
+			r.setDataScaleDownStatus(workingCluster, scalingStatus.Source, scalingStatus.FromReplicas, scalingStatus.TargetReplicas, scalingStatus.AppliedReplicas, scalingStatus.DrainingOrdinal, scalingStatus.DrainingNodeID, "Failed", failureMessage)
+			r.setScalingCondition(workingCluster, metav1.ConditionFalse, antflyv1.ReasonDataScaleDownFailed, failureMessage)
+			if statusErr := r.updateStatus(ctx, workingCluster); statusErr != nil {
+				log.Error(statusErr, "Failed to update status with data scale-down finalization failure")
+			}
+			return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+		}
+		message := fmt.Sprintf("Finalized data-node shutdown for ordinal %d/node %s", scalingStatus.DrainingOrdinal, scalingStatus.DrainingNodeID)
+		r.setDataScaleDownStatus(workingCluster, scalingStatus.Source, scalingStatus.FromReplicas, scalingStatus.TargetReplicas, scalingStatus.AppliedReplicas, scalingStatus.DrainingOrdinal, scalingStatus.DrainingNodeID, "Complete", message)
+		if requestedDataReplicas < scaleSafetyReplicas {
+			r.setScalingCondition(workingCluster, metav1.ConditionUnknown, antflyv1.ReasonDataScaleDownInProgress, "Continuing data-node scale-down after finalizing the previous ordinal")
+		} else {
+			r.setScalingCondition(workingCluster, metav1.ConditionTrue, antflyv1.ReasonScalingReady, "Scaling is not blocked")
+		}
+		if statusErr := r.updateStatus(ctx, workingCluster); statusErr != nil {
+			log.Error(statusErr, "Failed to update status after data scale-down finalization")
+		}
+		return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
+	}
+
+	if dataStsExists && !dataScaleDownRequested && (shouldCancelDataScaleDown(workingCluster.Status.DataScaleDownStatus, currentDataReplicas, desiredDataReplicas) || (dataNodesSuspended && shouldCancelDataScaleDownForSuspend(workingCluster.Status.DataScaleDownStatus, currentDataReplicas))) {
+		drainingStatus := workingCluster.Status.DataScaleDownStatus
+		status, err := r.cancelDataNodeShutdown(ctx, workingCluster, drainingStatus.DrainingNodeID)
 		if err != nil {
-			failureMessage := fmt.Sprintf("Failed to drain data ordinal %d/store %s: %v", drainingOrdinal, drainingStoreID, err)
-			r.setDataScaleDownStatus(workingCluster, dataScaleDownSource, scaleSafetyReplicas, requestedDataReplicas, scaleSafetyReplicas, drainingOrdinal, drainingStoreID, "Failed", failureMessage)
+			failureMessage := fmt.Sprintf("Failed to cancel data-node shutdown for ordinal %d/node %s: %v", drainingStatus.DrainingOrdinal, drainingStatus.DrainingNodeID, err)
+			r.setDataScaleDownStatus(workingCluster, drainingStatus.Source, drainingStatus.FromReplicas, desiredDataReplicas, scaleSafetyReplicas, drainingStatus.DrainingOrdinal, drainingStatus.DrainingNodeID, "Failed", failureMessage)
+			r.setScalingCondition(workingCluster, metav1.ConditionFalse, antflyv1.ReasonDataScaleDownFailed, failureMessage)
+			if statusErr := r.updateStatus(ctx, workingCluster); statusErr != nil {
+				log.Error(statusErr, "Failed to update status with data scale-down cancellation failure")
+			}
+			return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+		}
+		if status.Phase != "active" && status.Phase != "not_found" {
+			message := fmt.Sprintf("Canceling data-node shutdown for ordinal %d/node %s; runtime phase is %q", drainingStatus.DrainingOrdinal, drainingStatus.DrainingNodeID, status.Phase)
+			r.setDataScaleDownStatus(workingCluster, drainingStatus.Source, drainingStatus.FromReplicas, desiredDataReplicas, scaleSafetyReplicas, drainingStatus.DrainingOrdinal, drainingStatus.DrainingNodeID, "Canceling", message)
+			r.setScalingCondition(workingCluster, metav1.ConditionUnknown, antflyv1.ReasonDataScaleDownInProgress, message)
+			if statusErr := r.updateStatus(ctx, workingCluster); statusErr != nil {
+				log.Error(statusErr, "Failed to update status with data scale-down cancellation progress")
+			}
+			return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+		}
+		message := fmt.Sprintf("Canceled data-node shutdown for ordinal %d/node %s; runtime phase is %q", drainingStatus.DrainingOrdinal, drainingStatus.DrainingNodeID, status.Phase)
+		r.setDataScaleDownStatus(workingCluster, drainingStatus.Source, drainingStatus.FromReplicas, desiredDataReplicas, scaleSafetyReplicas, drainingStatus.DrainingOrdinal, drainingStatus.DrainingNodeID, "Canceled", message)
+		r.setScalingCondition(workingCluster, metav1.ConditionTrue, antflyv1.ReasonScalingReady, "Scaling is not blocked")
+		if r.AutoScaler != nil && workingCluster.Status.AutoScalingStatus != nil {
+			r.AutoScaler.UpdateScalingStatus(workingCluster, currentDataReplicas, desiredDataReplicas, requestedDataReplicas, "", "")
+		}
+		if statusErr := r.updateStatus(ctx, workingCluster); statusErr != nil {
+			log.Error(statusErr, "Failed to update status with data scale-down cancellation")
+		}
+		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+	}
+
+	if dataNodesSuspended {
+		workingCluster.Status.DataScaleDownStatus = nil
+	} else if dataStsExists && dataScaleDownRequested {
+		drainingOrdinal := scaleSafetyReplicas - 1
+		drainingNodeID := nodeIDForDataOrdinal(drainingOrdinal)
+		nextReplicas := scaleSafetyReplicas - 1
+		message := fmt.Sprintf("Draining data ordinal %d/node %s before scaling StatefulSet from %d to %d", drainingOrdinal, drainingNodeID, scaleSafetyReplicas, nextReplicas)
+		r.setDataScaleDownStatus(workingCluster, dataScaleDownSource, scaleSafetyReplicas, requestedDataReplicas, scaleSafetyReplicas, drainingOrdinal, drainingNodeID, "Draining", message)
+		r.setScalingCondition(workingCluster, metav1.ConditionUnknown, antflyv1.ReasonDataScaleDownInProgress, message)
+		shutdownStatus, err := r.requestDataNodeShutdown(ctx, workingCluster, drainingNodeID)
+		if err != nil {
+			failureMessage := fmt.Sprintf("Failed to drain data ordinal %d/node %s: %v", drainingOrdinal, drainingNodeID, err)
+			r.setDataScaleDownStatus(workingCluster, dataScaleDownSource, scaleSafetyReplicas, requestedDataReplicas, scaleSafetyReplicas, drainingOrdinal, drainingNodeID, "Failed", failureMessage)
 			r.setScalingCondition(workingCluster, metav1.ConditionFalse, antflyv1.ReasonDataScaleDownFailed, failureMessage)
 			if statusErr := r.Status().Update(ctx, workingCluster); statusErr != nil {
 				log.Error(statusErr, "Failed to update status with data scale-down failure")
 			}
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 		}
+		if shutdownStatus.Blocked || shutdownStatus.Phase == "blocked" {
+			blockedMessage := shutdownStatus.Message
+			if blockedMessage == "" {
+				blockedMessage = fmt.Sprintf("Data ordinal %d/node %s cannot be drained safely; runtime reports phase %q", drainingOrdinal, drainingNodeID, shutdownStatus.Phase)
+			}
+			r.setDataScaleDownStatus(workingCluster, dataScaleDownSource, scaleSafetyReplicas, requestedDataReplicas, scaleSafetyReplicas, drainingOrdinal, drainingNodeID, "Blocked", blockedMessage)
+			r.setScalingCondition(workingCluster, metav1.ConditionFalse, antflyv1.ReasonDataScaleDownBlocked, blockedMessage)
+			if r.AutoScaler != nil && workingCluster.Status.AutoScalingStatus != nil {
+				r.AutoScaler.UpdateScalingStatus(workingCluster, currentDataReplicas, scaleSafetyReplicas, requestedDataReplicas, antflyv1.ReasonDataScaleDownBlocked, blockedMessage)
+			}
+			if statusErr := r.updateStatus(ctx, workingCluster); statusErr != nil {
+				log.Error(statusErr, "Failed to update status with blocked data scale-down")
+			}
+			return ctrl.Result{RequeueAfter: 60 * time.Second}, nil
+		}
 		if !shutdownStatus.SafeToTerminate {
-			message = fmt.Sprintf("Data ordinal %d/store %s is draining in runtime phase %q; StatefulSet remains at %d replicas", drainingOrdinal, drainingStoreID, shutdownStatus.Phase, scaleSafetyReplicas)
-			r.setDataScaleDownStatus(workingCluster, dataScaleDownSource, scaleSafetyReplicas, requestedDataReplicas, scaleSafetyReplicas, drainingOrdinal, drainingStoreID, "Draining", message)
+			message = fmt.Sprintf("Data ordinal %d/node %s is draining in runtime phase %q; StatefulSet remains at %d replicas", drainingOrdinal, drainingNodeID, shutdownStatus.Phase, scaleSafetyReplicas)
+			r.setDataScaleDownStatus(workingCluster, dataScaleDownSource, scaleSafetyReplicas, requestedDataReplicas, scaleSafetyReplicas, drainingOrdinal, drainingNodeID, "Draining", message)
 			r.setScalingCondition(workingCluster, metav1.ConditionUnknown, antflyv1.ReasonDataScaleDownInProgress, message)
 			if statusErr := r.updateStatus(ctx, workingCluster); statusErr != nil {
 				log.Error(statusErr, "Failed to update status with data scale-down drain progress")
@@ -1119,19 +1320,22 @@ func (r *AntflyClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 		desiredDataReplicas = nextReplicas
 		workingCluster.Spec.DataNodes.Replicas = desiredDataReplicas
-		message = fmt.Sprintf("Runtime reports data ordinal %d/store %s is safe to terminate; scaling StatefulSet from %d to %d", drainingOrdinal, drainingStoreID, scaleSafetyReplicas, desiredDataReplicas)
-		r.setDataScaleDownStatus(workingCluster, dataScaleDownSource, scaleSafetyReplicas, requestedDataReplicas, desiredDataReplicas, drainingOrdinal, drainingStoreID, "Scaling", message)
+		message = fmt.Sprintf("Runtime reports data ordinal %d/node %s is safe to terminate; scaling StatefulSet from %d to %d", drainingOrdinal, drainingNodeID, scaleSafetyReplicas, desiredDataReplicas)
+		r.setDataScaleDownStatus(workingCluster, dataScaleDownSource, scaleSafetyReplicas, requestedDataReplicas, desiredDataReplicas, drainingOrdinal, drainingNodeID, "Scaling", message)
 		r.setScalingCondition(workingCluster, metav1.ConditionUnknown, antflyv1.ReasonDataScaleDownInProgress, message)
 		if r.AutoScaler != nil && workingCluster.Status.AutoScalingStatus != nil {
 			r.AutoScaler.UpdateScalingStatus(workingCluster, currentDataReplicas, desiredDataReplicas, requestedDataReplicas, antflyv1.ReasonDataScaleDownInProgress, message)
 		}
 	} else if dataStsExists {
 		if workingCluster.Status.DataScaleDownStatus != nil {
-			completedSource := workingCluster.Status.DataScaleDownStatus.Source
-			if completedSource == "" {
-				completedSource = antflyv1.DataScaleDownSourceManual
+			switch workingCluster.Status.DataScaleDownStatus.Phase {
+			case "Complete", "Canceled":
+				completedSource := workingCluster.Status.DataScaleDownStatus.Source
+				if completedSource == "" {
+					completedSource = antflyv1.DataScaleDownSourceManual
+				}
+				r.setDataScaleDownStatus(workingCluster, completedSource, scaleSafetyReplicas, scaleSafetyReplicas, desiredDataReplicas, 0, "", "Complete", "Data-node scale-down is complete")
 			}
-			r.setDataScaleDownStatus(workingCluster, completedSource, scaleSafetyReplicas, scaleSafetyReplicas, desiredDataReplicas, 0, "", "Complete", "Data-node scale-down is complete")
 		}
 	}
 
@@ -1295,7 +1499,7 @@ func (r *AntflyClusterReconciler) setScalingCondition(cluster *antflyv1.AntflyCl
 	})
 }
 
-func (r *AntflyClusterReconciler) setDataScaleDownStatus(cluster *antflyv1.AntflyCluster, source string, fromReplicas, targetReplicas, appliedReplicas, drainingOrdinal int32, drainingStoreID, phase, message string) {
+func (r *AntflyClusterReconciler) setDataScaleDownStatus(cluster *antflyv1.AntflyCluster, source string, fromReplicas, targetReplicas, appliedReplicas, drainingOrdinal int32, drainingNodeID, phase, message string) {
 	now := metav1.Now()
 	if cluster.Status.DataScaleDownStatus != nil &&
 		cluster.Status.DataScaleDownStatus.LastTransitionTime != nil &&
@@ -1311,7 +1515,7 @@ func (r *AntflyClusterReconciler) setDataScaleDownStatus(cluster *antflyv1.Antfl
 		TargetReplicas:     targetReplicas,
 		AppliedReplicas:    appliedReplicas,
 		DrainingOrdinal:    drainingOrdinal,
-		DrainingStoreID:    drainingStoreID,
+		DrainingNodeID:     drainingNodeID,
 		Phase:              phase,
 		Message:            message,
 		LastTransitionTime: &now,
@@ -2203,10 +2407,7 @@ func (r *AntflyClusterReconciler) buildMetadataClusterConfig(cluster *antflyv1.A
 }
 
 func (r *AntflyClusterReconciler) reconcileDataStatefulSet(ctx context.Context, cache *envFromCache, cluster *antflyv1.AntflyCluster) error {
-	replicas := int32(3)
-	if cluster.Spec.DataNodes.Replicas > 0 {
-		replicas = cluster.Spec.DataNodes.Replicas
-	}
+	replicas := effectiveDataNodeReplicas(cluster)
 
 	storageSize := "1Gi"
 	if cluster.Spec.Storage.DataStorage != "" {
@@ -2463,6 +2664,9 @@ func storageAutoGrowEnabled(cluster *antflyv1.AntflyCluster) bool {
 }
 
 func effectiveDataNodeReplicas(cluster *antflyv1.AntflyCluster) int32 {
+	if cluster.Spec.DataNodes.Suspend {
+		return 0
+	}
 	if cluster.Spec.DataNodes.Replicas > 0 {
 		return cluster.Spec.DataNodes.Replicas
 	}
@@ -2495,8 +2699,8 @@ func effectiveDataReplicaTarget(sts *appsv1.StatefulSet, exists bool, fallback i
 	return fallback
 }
 
-func storeIDForDataOrdinal(ordinal int32) string {
-	return strconv.FormatInt(int64(ordinal+1), 16)
+func nodeIDForDataOrdinal(ordinal int32) string {
+	return strconv.FormatInt(int64(ordinal+1), 10)
 }
 
 // buildStorageInitContainer creates an init container that waits for the PVC to be properly mounted.

--- a/pkg/operator/controllers/antfly/antflycluster_controller.go
+++ b/pkg/operator/controllers/antfly/antflycluster_controller.go
@@ -235,7 +235,7 @@ func (r *AntflyClusterReconciler) deregisterDataNodes(ctx context.Context, clust
 	// Deregister highest ordinals first (they are removed by StatefulSet on scale-down)
 	for ordinal := currentReplicas - 1; ordinal >= desiredReplicas; ordinal-- {
 		storeIDString := storeIDForDataOrdinal(ordinal)
-		url := fmt.Sprintf("%s/_internal/v1/store/%s", metadataAddr, storeIDString)
+		url := fmt.Sprintf("%s/internal/v1/store/%s", metadataAddr, storeIDString)
 
 		log.Info("Deregistering data node before scale-down", "ordinal", ordinal, "storeID", storeIDString)
 

--- a/pkg/operator/controllers/antfly/antflycluster_controller.go
+++ b/pkg/operator/controllers/antfly/antflycluster_controller.go
@@ -48,6 +48,7 @@ type AntflyClusterReconciler struct {
 	AutoScaler          *AutoScaler
 	KubeClient          kubernetes.Interface
 	NodeStatsFetcher    func(context.Context, string) (*kubeletStatsSummary, error)
+	HTTPClient          *http.Client
 	Recorder            events.EventRecorder
 	ManageTermitePools  bool
 	DefaultTermiteImage string
@@ -219,53 +220,67 @@ func (r *AntflyClusterReconciler) cleanupStorageResources(ctx context.Context, c
 	return nil, nil
 }
 
-// deregisterDataNodes calls the Antfly metadata deregistration API for data nodes
-// being removed during scale-down. This triggers Raft peer removal before the pods
-// are deleted, preventing phantom voters in Raft configurations.
-// Store ID is deterministic: store_id = pod_ordinal + 1.
-func (r *AntflyClusterReconciler) deregisterDataNodes(ctx context.Context, cluster *antflyv1.AntflyCluster, currentReplicas, desiredReplicas int32) error {
-	if desiredReplicas >= currentReplicas {
-		return nil // not scaling down
-	}
+type dataNodeShutdownStatus struct {
+	NodeID          string `json:"node_id"`
+	Phase           string `json:"phase"`
+	SafeToTerminate bool   `json:"safe_to_terminate"`
+}
 
+func (r *AntflyClusterReconciler) httpClient() *http.Client {
+	if r.HTTPClient != nil {
+		return r.HTTPClient
+	}
+	return http.DefaultClient
+}
+
+// requestDataNodeShutdown asks Antfly metadata to drain a data node and returns
+// the current runtime safety status. Store/node ID is deterministic:
+// store_id = pod_ordinal + 1.
+func (r *AntflyClusterReconciler) requestDataNodeShutdown(ctx context.Context, cluster *antflyv1.AntflyCluster, storeIDString string) (*dataNodeShutdownStatus, error) {
 	log := log.FromContext(ctx)
 	metadataAddr := fmt.Sprintf("http://%s-metadata.%s.svc:%d",
 		cluster.Name, cluster.Namespace, cluster.Spec.MetadataNodes.MetadataAPI.Port)
+	url := fmt.Sprintf("%s/internal/v1/nodes/%s/shutdown", metadataAddr, storeIDString)
 
-	// Deregister highest ordinals first (they are removed by StatefulSet on scale-down)
-	for ordinal := currentReplicas - 1; ordinal >= desiredReplicas; ordinal-- {
-		storeIDString := storeIDForDataOrdinal(ordinal)
-		url := fmt.Sprintf("%s/internal/v1/store/%s", metadataAddr, storeIDString)
+	log.Info("Requesting data node shutdown before scale-down", "storeID", storeIDString)
+	body := strings.NewReader(`{"type":"remove","reason":"operator scale-down"}`)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, url, body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create node shutdown request for store %s: %w", storeIDString, err)
+	}
+	req.Header.Set("Content-Type", "application/json")
 
-		log.Info("Deregistering data node before scale-down", "ordinal", ordinal, "storeID", storeIDString)
-
-		req, err := http.NewRequestWithContext(ctx, http.MethodDelete, url, nil)
-		if err != nil {
-			return fmt.Errorf("failed to create deregistration request for store %s: %w", storeIDString, err)
-		}
-
-		resp, err := http.DefaultClient.Do(req) //nolint:gosec // URL is constructed from cluster-internal service address, not external user input
-		if err != nil {
-			// Connection errors mean metadata isn't ready — requeue
-			log.Error(err, "Failed to deregister data node, will retry", "storeID", storeIDString)
-			return fmt.Errorf("failed to deregister store %s: %w", storeIDString, err)
-		}
-		statusCode := resp.StatusCode
-		_, _ = io.Copy(io.Discard, resp.Body)
-		_ = resp.Body.Close()
-
-		if statusCode >= 200 && statusCode < 300 {
-			log.Info("Successfully deregistered data node", "storeID", storeIDString)
-		} else if statusCode == http.StatusNotFound {
-			// Store already deregistered or doesn't exist — safe to proceed
-			log.Info("Data node already deregistered or not found", "storeID", storeIDString)
-		} else {
-			log.Error(nil, "Unexpected response from deregistration API", "storeID", storeIDString, "status", statusCode)
-			return fmt.Errorf("deregistration of store %s returned status %d", storeIDString, statusCode)
-		}
+	resp, err := r.httpClient().Do(req) //nolint:gosec // URL is constructed from cluster-internal service address, not external user input
+	if err != nil {
+		log.Error(err, "Failed to request data node shutdown, will retry", "storeID", storeIDString)
+		return nil, fmt.Errorf("failed to request shutdown for store %s: %w", storeIDString, err)
+	}
+	statusCode := resp.StatusCode
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
+	if statusCode < 200 || statusCode >= 300 {
+		return nil, fmt.Errorf("shutdown request for store %s returned status %d", storeIDString, statusCode)
 	}
 
-	return nil
+	statusReq, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create node shutdown status request for store %s: %w", storeIDString, err)
+	}
+	statusResp, err := r.httpClient().Do(statusReq) //nolint:gosec // URL is constructed from cluster-internal service address, not external user input
+	if err != nil {
+		return nil, fmt.Errorf("failed to get shutdown status for store %s: %w", storeIDString, err)
+	}
+	defer func() { _ = statusResp.Body.Close() }()
+	if statusResp.StatusCode < 200 || statusResp.StatusCode >= 300 {
+		_, _ = io.Copy(io.Discard, statusResp.Body)
+		return nil, fmt.Errorf("shutdown status for store %s returned status %d", storeIDString, statusResp.StatusCode)
+	}
+
+	var status dataNodeShutdownStatus
+	if err := json.NewDecoder(statusResp.Body).Decode(&status); err != nil {
+		return nil, fmt.Errorf("failed to decode shutdown status for store %s: %w", storeIDString, err)
+	}
+	return &status, nil
 }
 
 const (
@@ -1033,6 +1048,7 @@ func (r *AntflyClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	desiredDataReplicas := effectiveDataNodeReplicas(workingCluster)
 	requestedDataReplicas := desiredDataReplicas
 	dataScaleDownSource := antflyv1.DataScaleDownSourceManual
+	dataScaleDownRequested := false
 	autoscalingEnabled := r.AutoScaler != nil && workingCluster.Spec.DataNodes.AutoScaling != nil && workingCluster.Spec.DataNodes.AutoScaling.Enabled
 	if autoscalingEnabled {
 		dataScaleDownSource = antflyv1.DataScaleDownSourceAutoscaler
@@ -1047,9 +1063,10 @@ func (r *AntflyClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		blockedReason := ""
 		blockedMessage := ""
 		if recommendationReplicas < scaleSafetyReplicas {
-			desiredDataReplicas = scaleSafetyReplicas - 1
+			desiredDataReplicas = scaleSafetyReplicas
+			dataScaleDownRequested = true
 			blockedReason = antflyv1.ReasonDataScaleDownInProgress
-			blockedMessage = fmt.Sprintf("Autoscaler recommended data-node scale-down from %d to %d; applying one ordinal this reconcile", scaleSafetyReplicas, recommendationReplicas)
+			blockedMessage = fmt.Sprintf("Autoscaler recommended data-node scale-down from %d to %d; waiting for runtime drain before removing the next ordinal", scaleSafetyReplicas, recommendationReplicas)
 		} else {
 			r.setScalingCondition(workingCluster, metav1.ConditionTrue, antflyv1.ReasonScalingReady, "Scaling is not blocked")
 		}
@@ -1062,9 +1079,10 @@ func (r *AntflyClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	} else {
 		workingCluster.Status.AutoScalingStatus = nil
 		if desiredDataReplicas < scaleSafetyReplicas {
-			message := fmt.Sprintf("Data-node scale-down from %d to %d requested; applying one ordinal this reconcile", scaleSafetyReplicas, desiredDataReplicas)
+			message := fmt.Sprintf("Data-node scale-down from %d to %d requested; waiting for runtime drain before removing the next ordinal", scaleSafetyReplicas, desiredDataReplicas)
 			requestedDataReplicas = desiredDataReplicas
-			desiredDataReplicas = scaleSafetyReplicas - 1
+			desiredDataReplicas = scaleSafetyReplicas
+			dataScaleDownRequested = true
 			workingCluster.Spec.DataNodes.Replicas = desiredDataReplicas
 			r.setScalingCondition(workingCluster, metav1.ConditionUnknown, antflyv1.ReasonDataScaleDownInProgress, message)
 		} else {
@@ -1072,13 +1090,15 @@ func (r *AntflyClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		}
 	}
 
-	if dataStsExists && desiredDataReplicas < scaleSafetyReplicas {
+	if dataStsExists && dataScaleDownRequested {
 		drainingOrdinal := scaleSafetyReplicas - 1
 		drainingStoreID := storeIDForDataOrdinal(drainingOrdinal)
-		message := fmt.Sprintf("Draining data ordinal %d/store %s before scaling StatefulSet from %d to %d", drainingOrdinal, drainingStoreID, scaleSafetyReplicas, desiredDataReplicas)
-		r.setDataScaleDownStatus(workingCluster, dataScaleDownSource, scaleSafetyReplicas, requestedDataReplicas, desiredDataReplicas, drainingOrdinal, drainingStoreID, "Draining", message)
+		nextReplicas := scaleSafetyReplicas - 1
+		message := fmt.Sprintf("Draining data ordinal %d/store %s before scaling StatefulSet from %d to %d", drainingOrdinal, drainingStoreID, scaleSafetyReplicas, nextReplicas)
+		r.setDataScaleDownStatus(workingCluster, dataScaleDownSource, scaleSafetyReplicas, requestedDataReplicas, scaleSafetyReplicas, drainingOrdinal, drainingStoreID, "Draining", message)
 		r.setScalingCondition(workingCluster, metav1.ConditionUnknown, antflyv1.ReasonDataScaleDownInProgress, message)
-		if err := r.deregisterDataNodes(ctx, workingCluster, scaleSafetyReplicas, desiredDataReplicas); err != nil {
+		shutdownStatus, err := r.requestDataNodeShutdown(ctx, workingCluster, drainingStoreID)
+		if err != nil {
 			failureMessage := fmt.Sprintf("Failed to drain data ordinal %d/store %s: %v", drainingOrdinal, drainingStoreID, err)
 			r.setDataScaleDownStatus(workingCluster, dataScaleDownSource, scaleSafetyReplicas, requestedDataReplicas, scaleSafetyReplicas, drainingOrdinal, drainingStoreID, "Failed", failureMessage)
 			r.setScalingCondition(workingCluster, metav1.ConditionFalse, antflyv1.ReasonDataScaleDownFailed, failureMessage)
@@ -1087,11 +1107,25 @@ func (r *AntflyClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			}
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 		}
-	} else if dataStsExists {
-		if err := r.deregisterDataNodes(ctx, workingCluster, scaleSafetyReplicas, desiredDataReplicas); err != nil {
-			log.Error(err, "Failed to deregister data nodes, will retry")
+		if !shutdownStatus.SafeToTerminate {
+			message = fmt.Sprintf("Data ordinal %d/store %s is draining in runtime phase %q; StatefulSet remains at %d replicas", drainingOrdinal, drainingStoreID, shutdownStatus.Phase, scaleSafetyReplicas)
+			r.setDataScaleDownStatus(workingCluster, dataScaleDownSource, scaleSafetyReplicas, requestedDataReplicas, scaleSafetyReplicas, drainingOrdinal, drainingStoreID, "Draining", message)
+			r.setScalingCondition(workingCluster, metav1.ConditionUnknown, antflyv1.ReasonDataScaleDownInProgress, message)
+			if statusErr := r.updateStatus(ctx, workingCluster); statusErr != nil {
+				log.Error(statusErr, "Failed to update status with data scale-down drain progress")
+			}
 			return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 		}
+
+		desiredDataReplicas = nextReplicas
+		workingCluster.Spec.DataNodes.Replicas = desiredDataReplicas
+		message = fmt.Sprintf("Runtime reports data ordinal %d/store %s is safe to terminate; scaling StatefulSet from %d to %d", drainingOrdinal, drainingStoreID, scaleSafetyReplicas, desiredDataReplicas)
+		r.setDataScaleDownStatus(workingCluster, dataScaleDownSource, scaleSafetyReplicas, requestedDataReplicas, desiredDataReplicas, drainingOrdinal, drainingStoreID, "Scaling", message)
+		r.setScalingCondition(workingCluster, metav1.ConditionUnknown, antflyv1.ReasonDataScaleDownInProgress, message)
+		if r.AutoScaler != nil && workingCluster.Status.AutoScalingStatus != nil {
+			r.AutoScaler.UpdateScalingStatus(workingCluster, currentDataReplicas, desiredDataReplicas, requestedDataReplicas, antflyv1.ReasonDataScaleDownInProgress, message)
+		}
+	} else if dataStsExists {
 		if workingCluster.Status.DataScaleDownStatus != nil {
 			completedSource := workingCluster.Status.DataScaleDownStatus.Source
 			if completedSource == "" {

--- a/pkg/operator/controllers/antfly/antflycluster_controller_test.go
+++ b/pkg/operator/controllers/antfly/antflycluster_controller_test.go
@@ -3,6 +3,9 @@ package controllers
 import (
 	"context"
 	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -22,6 +25,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
 
 // T004: Unit test for applyDefaults() setting ServiceMesh.Enabled=false
 func TestApplyDefaults_ServiceMeshDefaults(t *testing.T) {
@@ -686,6 +695,45 @@ func TestSetDataScaleDownStatusRecordsAutoscalerSource(t *testing.T) {
 	g.Expect(cluster.Status.DataScaleDownStatus.DrainingOrdinal).To(Equal(int32(4)))
 	g.Expect(cluster.Status.DataScaleDownStatus.DrainingStoreID).To(Equal("5"))
 	g.Expect(cluster.Status.DataScaleDownStatus.Phase).To(Equal("Draining"))
+}
+
+func TestRequestDataNodeShutdownUsesNodeShutdownAPI(t *testing.T) {
+	g := NewWithT(t)
+	var methods []string
+	var paths []string
+	reconciler := &AntflyClusterReconciler{
+		HTTPClient: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			methods = append(methods, req.Method)
+			paths = append(paths, req.URL.Path)
+			body := "accepted"
+			if req.Method == http.MethodGet {
+				body = `{"node_id":"5","phase":"complete","safe_to_terminate":true}`
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Request:    req,
+			}, nil
+		})},
+	}
+	cluster := &antflyv1.AntflyCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "example", Namespace: "default"},
+		Spec: antflyv1.AntflyClusterSpec{
+			MetadataNodes: antflyv1.MetadataNodesSpec{
+				MetadataAPI: antflyv1.APISpec{Port: 12377},
+			},
+		},
+	}
+
+	status, err := reconciler.requestDataNodeShutdown(context.Background(), cluster, "5")
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(status.SafeToTerminate).To(BeTrue())
+	g.Expect(methods).To(Equal([]string{http.MethodPut, http.MethodGet}))
+	g.Expect(paths).To(Equal([]string{
+		"/internal/v1/nodes/5/shutdown",
+		"/internal/v1/nodes/5/shutdown",
+	}))
 }
 
 func TestUpdateProductTierStatusReportsClusteredShape(t *testing.T) {

--- a/pkg/operator/controllers/antfly/antflycluster_controller_test.go
+++ b/pkg/operator/controllers/antfly/antflycluster_controller_test.go
@@ -22,6 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
@@ -673,11 +674,39 @@ func TestEffectiveDataReplicaTargetPrefersStatefulSetSpec(t *testing.T) {
 	g.Expect(max(effectiveDataReplicas(sts, true, 1), effectiveDataReplicaTarget(sts, true, 1))).To(Equal(int32(5)))
 }
 
-func TestStoreIDForDataOrdinalUsesHexID(t *testing.T) {
+func TestEffectiveDataNodeReplicasSuspendScalesToZero(t *testing.T) {
+	g := NewWithT(t)
+	cluster := &antflyv1.AntflyCluster{
+		Spec: antflyv1.AntflyClusterSpec{
+			DataNodes: antflyv1.DataNodesSpec{
+				Replicas: 5,
+				Suspend:  true,
+			},
+		},
+	}
+
+	g.Expect(effectiveDataNodeReplicas(cluster)).To(Equal(int32(0)))
+}
+
+func TestShouldCancelDataScaleDownForSuspend(t *testing.T) {
+	g := NewWithT(t)
+	status := &antflyv1.DataScaleDownStatus{
+		Phase:           "Draining",
+		DrainingOrdinal: 4,
+		DrainingNodeID:  "5",
+	}
+
+	g.Expect(shouldCancelDataScaleDownForSuspend(status, 5)).To(BeTrue())
+	g.Expect(shouldCancelDataScaleDownForSuspend(status, 4)).To(BeFalse())
+	status.Phase = "Complete"
+	g.Expect(shouldCancelDataScaleDownForSuspend(status, 5)).To(BeFalse())
+}
+
+func TestNodeIDForDataOrdinalUsesDecimalID(t *testing.T) {
 	g := NewWithT(t)
 
-	g.Expect(storeIDForDataOrdinal(0)).To(Equal("1"))
-	g.Expect(storeIDForDataOrdinal(9)).To(Equal("a"))
+	g.Expect(nodeIDForDataOrdinal(0)).To(Equal("1"))
+	g.Expect(nodeIDForDataOrdinal(9)).To(Equal("10"))
 }
 
 func TestSetDataScaleDownStatusRecordsAutoscalerSource(t *testing.T) {
@@ -693,7 +722,7 @@ func TestSetDataScaleDownStatusRecordsAutoscalerSource(t *testing.T) {
 	g.Expect(cluster.Status.DataScaleDownStatus.TargetReplicas).To(Equal(int32(3)))
 	g.Expect(cluster.Status.DataScaleDownStatus.AppliedReplicas).To(Equal(int32(4)))
 	g.Expect(cluster.Status.DataScaleDownStatus.DrainingOrdinal).To(Equal(int32(4)))
-	g.Expect(cluster.Status.DataScaleDownStatus.DrainingStoreID).To(Equal("5"))
+	g.Expect(cluster.Status.DataScaleDownStatus.DrainingNodeID).To(Equal("5"))
 	g.Expect(cluster.Status.DataScaleDownStatus.Phase).To(Equal("Draining"))
 }
 
@@ -707,7 +736,7 @@ func TestRequestDataNodeShutdownUsesNodeShutdownAPI(t *testing.T) {
 			paths = append(paths, req.URL.Path)
 			body := "accepted"
 			if req.Method == http.MethodGet {
-				body = `{"node_id":"5","phase":"complete","safe_to_terminate":true}`
+				body = `{"node_id":5,"phase":"complete","safe_to_terminate":true}`
 			}
 			return &http.Response{
 				StatusCode: http.StatusOK,
@@ -734,6 +763,575 @@ func TestRequestDataNodeShutdownUsesNodeShutdownAPI(t *testing.T) {
 		"/internal/v1/nodes/5/shutdown",
 		"/internal/v1/nodes/5/shutdown",
 	}))
+}
+
+func TestRequestDataNodeShutdownDecodesBlockedStatus(t *testing.T) {
+	g := NewWithT(t)
+	reconciler := &AntflyClusterReconciler{
+		HTTPClient: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			body := "accepted"
+			if req.Method == http.MethodGet {
+				body = `{"node_id":5,"phase":"blocked","safe_to_terminate":false,"blocked":true,"blocked_reason":"InsufficientShardVoters","message":"cannot safely remove voter"}`
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Request:    req,
+			}, nil
+		})},
+	}
+	cluster := &antflyv1.AntflyCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "example", Namespace: "default"},
+		Spec: antflyv1.AntflyClusterSpec{
+			MetadataNodes: antflyv1.MetadataNodesSpec{
+				MetadataAPI: antflyv1.APISpec{Port: 12377},
+			},
+		},
+	}
+
+	status, err := reconciler.requestDataNodeShutdown(context.Background(), cluster, "5")
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(status.SafeToTerminate).To(BeFalse())
+	g.Expect(status.Blocked).To(BeTrue())
+	g.Expect(status.BlockedReason).To(Equal("InsufficientShardVoters"))
+	g.Expect(status.Message).To(Equal("cannot safely remove voter"))
+}
+
+func TestCancelDataNodeShutdownUsesNodeShutdownAPI(t *testing.T) {
+	g := NewWithT(t)
+	var methods []string
+	var paths []string
+	reconciler := &AntflyClusterReconciler{
+		HTTPClient: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			methods = append(methods, req.Method)
+			paths = append(paths, req.URL.Path)
+			body := `{"status":"canceled"}`
+			if req.Method == http.MethodGet {
+				body = `{"node_id":5,"phase":"active","safe_to_terminate":false}`
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Request:    req,
+			}, nil
+		})},
+	}
+	cluster := &antflyv1.AntflyCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "example", Namespace: "default"},
+		Spec: antflyv1.AntflyClusterSpec{
+			MetadataNodes: antflyv1.MetadataNodesSpec{
+				MetadataAPI: antflyv1.APISpec{Port: 12377},
+			},
+		},
+	}
+
+	status, err := reconciler.cancelDataNodeShutdown(context.Background(), cluster, "5")
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(status.Phase).To(Equal("active"))
+	g.Expect(methods).To(Equal([]string{http.MethodDelete, http.MethodGet}))
+	g.Expect(paths).To(Equal([]string{
+		"/internal/v1/nodes/5/shutdown",
+		"/internal/v1/nodes/5/shutdown",
+	}))
+}
+
+func TestFinalizeDataNodeShutdownUsesNodeAPI(t *testing.T) {
+	g := NewWithT(t)
+	var methods []string
+	var paths []string
+	reconciler := &AntflyClusterReconciler{
+		HTTPClient: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			methods = append(methods, req.Method)
+			paths = append(paths, req.URL.Path)
+			return &http.Response{
+				StatusCode: http.StatusAccepted,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(`{"status":"finalized"}`)),
+				Request:    req,
+			}, nil
+		})},
+	}
+	cluster := &antflyv1.AntflyCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "example", Namespace: "default"},
+		Spec: antflyv1.AntflyClusterSpec{
+			MetadataNodes: antflyv1.MetadataNodesSpec{
+				MetadataAPI: antflyv1.APISpec{Port: 12377},
+			},
+		},
+	}
+
+	err := reconciler.finalizeDataNodeShutdown(context.Background(), cluster, "5")
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(methods).To(Equal([]string{http.MethodDelete}))
+	g.Expect(paths).To(Equal([]string{"/internal/v1/nodes/5"}))
+}
+
+func TestShouldCancelDataScaleDownWhenOrdinalDesiredAgain(t *testing.T) {
+	g := NewWithT(t)
+	status := &antflyv1.DataScaleDownStatus{
+		Phase:           "Draining",
+		DrainingOrdinal: 4,
+		DrainingNodeID:  "5",
+	}
+
+	g.Expect(shouldCancelDataScaleDown(status, 5, 5)).To(BeTrue())
+	g.Expect(shouldCancelDataScaleDown(status, 5, 4)).To(BeFalse())
+	g.Expect(shouldCancelDataScaleDown(status, 4, 5)).To(BeFalse(), "Once the StatefulSet removed the ordinal, finalization owns the transition")
+	status.Phase = "Canceling"
+	g.Expect(shouldCancelDataScaleDown(status, 5, 5)).To(BeTrue())
+	status.Phase = "Scaling"
+	g.Expect(shouldCancelDataScaleDown(status, 5, 5)).To(BeTrue())
+	status.Phase = "Complete"
+	g.Expect(shouldCancelDataScaleDown(status, 5, 5)).To(BeFalse())
+}
+
+func TestShouldFinalizeDataScaleDownRetriesOnlyPostShrinkFailures(t *testing.T) {
+	g := NewWithT(t)
+	status := &antflyv1.DataScaleDownStatus{
+		Phase:           "Failed",
+		FromReplicas:    5,
+		TargetReplicas:  4,
+		AppliedReplicas: 4,
+		DrainingOrdinal: 4,
+		DrainingNodeID:  "5",
+	}
+
+	g.Expect(shouldFinalizeDataScaleDown(status, 4, 4, false)).To(BeTrue())
+	g.Expect(shouldFinalizeDataScaleDown(status, 5, 4, false)).To(BeFalse(), "StatefulSet has not removed the ordinal yet")
+	g.Expect(shouldFinalizeDataScaleDown(status, 4, 3, true)).To(BeFalse(), "A new scale-down step should retry drain, not finalize an old failed state")
+	g.Expect(shouldFinalizeDataScaleDown(status, 4, 5, false)).To(BeTrue(), "Once the StatefulSet removed the ordinal, finalization owns the transition")
+
+	status.AppliedReplicas = 5
+	g.Expect(shouldFinalizeDataScaleDown(status, 5, 5, false)).To(BeFalse(), "Drain failures before StatefulSet shrink are not finalization failures")
+}
+
+func TestReconcileCancelsDataScaleDownWhenOrdinalDesiredAgain(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	s := runtime.NewScheme()
+	g.Expect(antflyv1.AddToScheme(s)).To(Succeed())
+	g.Expect(appsv1.AddToScheme(s)).To(Succeed())
+	g.Expect(corev1.AddToScheme(s)).To(Succeed())
+
+	cluster := &antflyv1.AntflyCluster{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: antflyv1.GroupVersion.String(),
+			Kind:       "AntflyCluster",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "cancel-scale",
+			Namespace:  "default",
+			Generation: 3,
+		},
+		Spec: antflyv1.AntflyClusterSpec{
+			Image: "antfly:test",
+			MetadataNodes: antflyv1.MetadataNodesSpec{
+				Replicas:    1,
+				MetadataAPI: antflyv1.APISpec{Port: 12377},
+			},
+			DataNodes: antflyv1.DataNodesSpec{
+				Replicas: 5,
+			},
+			Storage: antflyv1.StorageSpec{
+				MetadataStorage: "1Gi",
+				DataStorage:     "1Gi",
+			},
+			Config: "{}",
+		},
+		Status: antflyv1.AntflyClusterStatus{
+			ObservedGeneration: 3,
+			Conditions: []metav1.Condition{
+				{Type: antflyv1.TypeConfigurationValid, Status: metav1.ConditionTrue, Reason: antflyv1.ReasonValidationPassed, ObservedGeneration: 3},
+			},
+			DataScaleDownStatus: &antflyv1.DataScaleDownStatus{
+				Source:          antflyv1.DataScaleDownSourceManual,
+				FromReplicas:    5,
+				TargetReplicas:  3,
+				AppliedReplicas: 5,
+				DrainingOrdinal: 4,
+				DrainingNodeID:  "5",
+				Phase:           "Draining",
+			},
+		},
+	}
+	dataReplicas := int32(5)
+	dataSts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "cancel-scale-data", Namespace: "default"},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &dataReplicas,
+		},
+		Status: appsv1.StatefulSetStatus{
+			Replicas: 5,
+		},
+	}
+	client := fake.NewClientBuilder().
+		WithScheme(s).
+		WithStatusSubresource(cluster).
+		WithObjects(cluster, dataSts).
+		Build()
+
+	var methods []string
+	var paths []string
+	reconciler := &AntflyClusterReconciler{
+		Client: client,
+		Scheme: s,
+		HTTPClient: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			methods = append(methods, req.Method)
+			paths = append(paths, req.URL.Path)
+			body := `{"status":"canceled"}`
+			if req.Method == http.MethodGet {
+				body = `{"node_id":5,"phase":"active","safe_to_terminate":false}`
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Request:    req,
+			}, nil
+		})},
+	}
+
+	result, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: "cancel-scale", Namespace: "default"}})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result.RequeueAfter).To(Equal(10 * time.Second))
+	g.Expect(methods).To(Equal([]string{http.MethodDelete, http.MethodGet}))
+	g.Expect(paths).To(Equal([]string{"/internal/v1/nodes/5/shutdown", "/internal/v1/nodes/5/shutdown"}))
+
+	updated := &antflyv1.AntflyCluster{}
+	g.Expect(client.Get(ctx, types.NamespacedName{Name: "cancel-scale", Namespace: "default"}, updated)).To(Succeed())
+	g.Expect(updated.Status.DataScaleDownStatus).NotTo(BeNil())
+	g.Expect(updated.Status.DataScaleDownStatus.Phase).To(Equal("Canceled"))
+	cond := meta.FindStatusCondition(updated.Status.Conditions, antflyv1.TypeScaling)
+	g.Expect(cond).NotTo(BeNil())
+	g.Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+}
+
+func TestReconcileWaitsForDataScaleDownCancellationRecovery(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	s := runtime.NewScheme()
+	g.Expect(antflyv1.AddToScheme(s)).To(Succeed())
+	g.Expect(appsv1.AddToScheme(s)).To(Succeed())
+	g.Expect(corev1.AddToScheme(s)).To(Succeed())
+
+	cluster := &antflyv1.AntflyCluster{
+		TypeMeta:   metav1.TypeMeta{APIVersion: antflyv1.GroupVersion.String(), Kind: "AntflyCluster"},
+		ObjectMeta: metav1.ObjectMeta{Name: "cancel-recovering", Namespace: "default", Generation: 3},
+		Spec: antflyv1.AntflyClusterSpec{
+			Image: "antfly:test",
+			MetadataNodes: antflyv1.MetadataNodesSpec{
+				Replicas:    1,
+				MetadataAPI: antflyv1.APISpec{Port: 12377},
+			},
+			DataNodes: antflyv1.DataNodesSpec{Replicas: 5},
+			Storage: antflyv1.StorageSpec{
+				MetadataStorage: "1Gi",
+				DataStorage:     "1Gi",
+			},
+			Config: "{}",
+		},
+		Status: antflyv1.AntflyClusterStatus{
+			ObservedGeneration: 3,
+			Conditions: []metav1.Condition{
+				{Type: antflyv1.TypeConfigurationValid, Status: metav1.ConditionTrue, Reason: antflyv1.ReasonValidationPassed, ObservedGeneration: 3},
+			},
+			DataScaleDownStatus: &antflyv1.DataScaleDownStatus{
+				Source:          antflyv1.DataScaleDownSourceManual,
+				FromReplicas:    5,
+				TargetReplicas:  3,
+				AppliedReplicas: 5,
+				DrainingOrdinal: 4,
+				DrainingNodeID:  "5",
+				Phase:           "Draining",
+			},
+		},
+	}
+	dataReplicas := int32(5)
+	dataSts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "cancel-recovering-data", Namespace: "default"},
+		Spec:       appsv1.StatefulSetSpec{Replicas: &dataReplicas},
+		Status:     appsv1.StatefulSetStatus{Replicas: 5},
+	}
+	client := fake.NewClientBuilder().
+		WithScheme(s).
+		WithStatusSubresource(cluster).
+		WithObjects(cluster, dataSts).
+		Build()
+
+	reconciler := &AntflyClusterReconciler{
+		Client: client,
+		Scheme: s,
+		HTTPClient: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			body := `{"status":"canceled"}`
+			if req.Method == http.MethodGet {
+				body = `{"node_id":5,"phase":"recovering","safe_to_terminate":false}`
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Request:    req,
+			}, nil
+		})},
+	}
+
+	result, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: "cancel-recovering", Namespace: "default"}})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result.RequeueAfter).To(Equal(10 * time.Second))
+
+	updated := &antflyv1.AntflyCluster{}
+	g.Expect(client.Get(ctx, types.NamespacedName{Name: "cancel-recovering", Namespace: "default"}, updated)).To(Succeed())
+	g.Expect(updated.Status.DataScaleDownStatus).NotTo(BeNil())
+	g.Expect(updated.Status.DataScaleDownStatus.Phase).To(Equal("Canceling"))
+	cond := meta.FindStatusCondition(updated.Status.Conditions, antflyv1.TypeScaling)
+	g.Expect(cond).NotTo(BeNil())
+	g.Expect(cond.Status).To(Equal(metav1.ConditionUnknown))
+}
+
+func TestReconcileFinalizesDataScaleDownAfterStatefulSetShrinks(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	s := runtime.NewScheme()
+	g.Expect(antflyv1.AddToScheme(s)).To(Succeed())
+	g.Expect(appsv1.AddToScheme(s)).To(Succeed())
+	g.Expect(corev1.AddToScheme(s)).To(Succeed())
+
+	cluster := &antflyv1.AntflyCluster{
+		TypeMeta:   metav1.TypeMeta{APIVersion: antflyv1.GroupVersion.String(), Kind: "AntflyCluster"},
+		ObjectMeta: metav1.ObjectMeta{Name: "finalize-scale", Namespace: "default", Generation: 3},
+		Spec: antflyv1.AntflyClusterSpec{
+			Image: "antfly:test",
+			MetadataNodes: antflyv1.MetadataNodesSpec{
+				Replicas:    1,
+				MetadataAPI: antflyv1.APISpec{Port: 12377},
+			},
+			DataNodes: antflyv1.DataNodesSpec{Replicas: 5},
+			Storage: antflyv1.StorageSpec{
+				MetadataStorage: "1Gi",
+				DataStorage:     "1Gi",
+			},
+			Config: "{}",
+		},
+		Status: antflyv1.AntflyClusterStatus{
+			ObservedGeneration: 3,
+			Conditions: []metav1.Condition{
+				{Type: antflyv1.TypeConfigurationValid, Status: metav1.ConditionTrue, Reason: antflyv1.ReasonValidationPassed, ObservedGeneration: 3},
+			},
+			DataScaleDownStatus: &antflyv1.DataScaleDownStatus{
+				Source:          antflyv1.DataScaleDownSourceManual,
+				FromReplicas:    5,
+				TargetReplicas:  4,
+				AppliedReplicas: 4,
+				DrainingOrdinal: 4,
+				DrainingNodeID:  "5",
+				Phase:           "Scaling",
+			},
+		},
+	}
+	dataReplicas := int32(4)
+	dataSts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "finalize-scale-data", Namespace: "default"},
+		Spec:       appsv1.StatefulSetSpec{Replicas: &dataReplicas},
+		Status:     appsv1.StatefulSetStatus{Replicas: 4},
+	}
+	client := fake.NewClientBuilder().
+		WithScheme(s).
+		WithStatusSubresource(cluster).
+		WithObjects(cluster, dataSts).
+		Build()
+
+	var methods []string
+	var paths []string
+	reconciler := &AntflyClusterReconciler{
+		Client: client,
+		Scheme: s,
+		HTTPClient: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			methods = append(methods, req.Method)
+			paths = append(paths, req.URL.Path)
+			return &http.Response{
+				StatusCode: http.StatusAccepted,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(`{"status":"finalized"}`)),
+				Request:    req,
+			}, nil
+		})},
+	}
+
+	result, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: "finalize-scale", Namespace: "default"}})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result.RequeueAfter).To(Equal(1 * time.Second))
+	g.Expect(methods).To(Equal([]string{http.MethodDelete}))
+	g.Expect(paths).To(Equal([]string{"/internal/v1/nodes/5"}))
+
+	updated := &antflyv1.AntflyCluster{}
+	g.Expect(client.Get(ctx, types.NamespacedName{Name: "finalize-scale", Namespace: "default"}, updated)).To(Succeed())
+	g.Expect(updated.Status.DataScaleDownStatus).NotTo(BeNil())
+	g.Expect(updated.Status.DataScaleDownStatus.Phase).To(Equal("Complete"))
+}
+
+func TestReconcileRetriesFailedDataScaleDownFinalization(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	s := runtime.NewScheme()
+	g.Expect(antflyv1.AddToScheme(s)).To(Succeed())
+	g.Expect(appsv1.AddToScheme(s)).To(Succeed())
+	g.Expect(corev1.AddToScheme(s)).To(Succeed())
+
+	cluster := &antflyv1.AntflyCluster{
+		TypeMeta:   metav1.TypeMeta{APIVersion: antflyv1.GroupVersion.String(), Kind: "AntflyCluster"},
+		ObjectMeta: metav1.ObjectMeta{Name: "retry-finalize-scale", Namespace: "default", Generation: 3},
+		Spec: antflyv1.AntflyClusterSpec{
+			Image: "antfly:test",
+			MetadataNodes: antflyv1.MetadataNodesSpec{
+				Replicas:    1,
+				MetadataAPI: antflyv1.APISpec{Port: 12377},
+			},
+			DataNodes: antflyv1.DataNodesSpec{Replicas: 4},
+			Storage: antflyv1.StorageSpec{
+				MetadataStorage: "1Gi",
+				DataStorage:     "1Gi",
+			},
+			Config: "{}",
+		},
+		Status: antflyv1.AntflyClusterStatus{
+			ObservedGeneration: 3,
+			Conditions: []metav1.Condition{
+				{Type: antflyv1.TypeConfigurationValid, Status: metav1.ConditionTrue, Reason: antflyv1.ReasonValidationPassed, ObservedGeneration: 3},
+			},
+			DataScaleDownStatus: &antflyv1.DataScaleDownStatus{
+				Source:          antflyv1.DataScaleDownSourceManual,
+				FromReplicas:    5,
+				TargetReplicas:  4,
+				AppliedReplicas: 4,
+				DrainingOrdinal: 4,
+				DrainingNodeID:  "5",
+				Phase:           "Failed",
+				Message:         "previous finalization failed",
+			},
+		},
+	}
+	dataReplicas := int32(4)
+	dataSts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "retry-finalize-scale-data", Namespace: "default"},
+		Spec:       appsv1.StatefulSetSpec{Replicas: &dataReplicas},
+		Status:     appsv1.StatefulSetStatus{Replicas: 4},
+	}
+	client := fake.NewClientBuilder().
+		WithScheme(s).
+		WithStatusSubresource(cluster).
+		WithObjects(cluster, dataSts).
+		Build()
+
+	var methods []string
+	reconciler := &AntflyClusterReconciler{
+		Client: client,
+		Scheme: s,
+		HTTPClient: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			methods = append(methods, req.Method)
+			return &http.Response{
+				StatusCode: http.StatusAccepted,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(`{"status":"finalized"}`)),
+				Request:    req,
+			}, nil
+		})},
+	}
+
+	result, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: "retry-finalize-scale", Namespace: "default"}})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result.RequeueAfter).To(Equal(1 * time.Second))
+	g.Expect(methods).To(Equal([]string{http.MethodDelete}))
+
+	updated := &antflyv1.AntflyCluster{}
+	g.Expect(client.Get(ctx, types.NamespacedName{Name: "retry-finalize-scale", Namespace: "default"}, updated)).To(Succeed())
+	g.Expect(updated.Status.DataScaleDownStatus).NotTo(BeNil())
+	g.Expect(updated.Status.DataScaleDownStatus.Phase).To(Equal("Complete"))
+}
+
+func TestReconcileKeepsFailedDataScaleDownFinalizationFailure(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	s := runtime.NewScheme()
+	g.Expect(antflyv1.AddToScheme(s)).To(Succeed())
+	g.Expect(appsv1.AddToScheme(s)).To(Succeed())
+	g.Expect(corev1.AddToScheme(s)).To(Succeed())
+
+	cluster := &antflyv1.AntflyCluster{
+		TypeMeta:   metav1.TypeMeta{APIVersion: antflyv1.GroupVersion.String(), Kind: "AntflyCluster"},
+		ObjectMeta: metav1.ObjectMeta{Name: "failed-finalize-scale", Namespace: "default", Generation: 3},
+		Spec: antflyv1.AntflyClusterSpec{
+			Image: "antfly:test",
+			MetadataNodes: antflyv1.MetadataNodesSpec{
+				Replicas:    1,
+				MetadataAPI: antflyv1.APISpec{Port: 12377},
+			},
+			DataNodes: antflyv1.DataNodesSpec{Replicas: 4},
+			Storage: antflyv1.StorageSpec{
+				MetadataStorage: "1Gi",
+				DataStorage:     "1Gi",
+			},
+			Config: "{}",
+		},
+		Status: antflyv1.AntflyClusterStatus{
+			ObservedGeneration: 3,
+			Conditions: []metav1.Condition{
+				{Type: antflyv1.TypeConfigurationValid, Status: metav1.ConditionTrue, Reason: antflyv1.ReasonValidationPassed, ObservedGeneration: 3},
+			},
+			DataScaleDownStatus: &antflyv1.DataScaleDownStatus{
+				Source:          antflyv1.DataScaleDownSourceManual,
+				FromReplicas:    5,
+				TargetReplicas:  4,
+				AppliedReplicas: 4,
+				DrainingOrdinal: 4,
+				DrainingNodeID:  "5",
+				Phase:           "Failed",
+				Message:         "previous finalization failed",
+			},
+		},
+	}
+	dataReplicas := int32(4)
+	dataSts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "failed-finalize-scale-data", Namespace: "default"},
+		Spec:       appsv1.StatefulSetSpec{Replicas: &dataReplicas},
+		Status:     appsv1.StatefulSetStatus{Replicas: 4},
+	}
+	client := fake.NewClientBuilder().
+		WithScheme(s).
+		WithStatusSubresource(cluster).
+		WithObjects(cluster, dataSts).
+		Build()
+
+	reconciler := &AntflyClusterReconciler{
+		Client: client,
+		Scheme: s,
+		HTTPClient: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusInternalServerError,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader("boom")),
+				Request:    req,
+			}, nil
+		})},
+	}
+
+	result, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: "failed-finalize-scale", Namespace: "default"}})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result.RequeueAfter).To(Equal(30 * time.Second))
+
+	updated := &antflyv1.AntflyCluster{}
+	g.Expect(client.Get(ctx, types.NamespacedName{Name: "failed-finalize-scale", Namespace: "default"}, updated)).To(Succeed())
+	g.Expect(updated.Status.DataScaleDownStatus).NotTo(BeNil())
+	g.Expect(updated.Status.DataScaleDownStatus.Phase).To(Equal("Failed"))
+	g.Expect(updated.Status.DataScaleDownStatus.Message).To(ContainSubstring("Failed to finalize data-node shutdown"))
+}
+
+func TestHTTPClientDefaultHasTimeout(t *testing.T) {
+	g := NewWithT(t)
+	reconciler := &AntflyClusterReconciler{}
+
+	g.Expect(reconciler.httpClient().Timeout).To(Equal(10 * time.Second))
 }
 
 func TestUpdateProductTierStatusReportsClusteredShape(t *testing.T) {

--- a/pkg/operator/docs/operations/autoscaling.md
+++ b/pkg/operator/docs/operations/autoscaling.md
@@ -272,8 +272,9 @@ spec:
 
 1. **Metadata Nodes Not Scaled**: Metadata nodes maintain a fixed replica count for Raft consensus
 2. **PVCs Retained**: PersistentVolumeClaims are retained when scaling down (data is preserved, but storage costs remain)
-3. **metrics-server Required**: Autoscaling won't work without metrics-server
-4. **Resource Requests Required**: Pods must have resource requests for accurate utilization calculation
+3. **No Scale-To-Zero Autoscaling**: Use `spec.dataNodes.suspend=true` for an explicit pause/resume scale-to-zero operation. Suspension cannot be combined with data-node autoscaling.
+4. **metrics-server Required**: Autoscaling won't work without metrics-server
+5. **Resource Requests Required**: Pods must have resource requests for accurate utilization calculation
 
 ## Troubleshooting
 

--- a/pkg/operator/docs/operations/storage.md
+++ b/pkg/operator/docs/operations/storage.md
@@ -41,6 +41,23 @@ spec:
 The validating webhook enforces these safety rules:
 
 - **`whenScaled: Delete` is rejected when autoscaling is enabled**: The autoscaler could trigger scale-down events that permanently destroy PVCs, requiring expensive full resyncs on every scale-up.
+- **`whenScaled: Delete` is rejected when data nodes are suspended**: `spec.dataNodes.suspend=true` scales the data StatefulSet to zero as a pause/resume operation. PVCs must be retained so the same ordinals can resume with their existing data.
+
+### Scale Data Nodes To Zero
+
+To pause data nodes while keeping disks, retain PVCs and enable suspension:
+
+```yaml
+spec:
+  dataNodes:
+    replicas: 3      # running size used when resumed
+    suspend: true    # scale data StatefulSet to 0
+  storage:
+    pvcRetentionPolicy:
+      whenScaled: Retain
+```
+
+Set `spec.dataNodes.suspend=false` to resume. Do not use `replicas: 0` for suspension; `0`/omitted is treated as the default running size because the CRD field is a non-pointer integer.
 
 ### Kubernetes Version Compatibility
 

--- a/pkg/operator/docs/reference/antflycluster-api.md
+++ b/pkg/operator/docs/reference/antflycluster-api.md
@@ -94,7 +94,8 @@ Configuration for data nodes (data storage, replication).
 
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
-| `replicas` | int32 | No | 3 | Initial number of data nodes |
+| `replicas` | int32 | No | 3 | Running data-node count. `0` or omitted uses the default; use `suspend` for scale-to-zero |
+| `suspend` | bool | No | false | Scale data nodes to zero while retaining PVCs for pause/resume |
 | `autoScaling` | [AutoScalingSpec](#autoscalingspec) | No | - | Autoscaling configuration |
 | `resources` | [ResourceSpec](#resourcespec) | Yes | - | Resource requirements |
 | `api` | [APISpec](#apispec) | Yes | - | Data API configuration |
@@ -312,7 +313,8 @@ The operator validates configurations via admission webhook:
 - `tolerations`, `affinity`, and `topologySpreadConstraints` are allowed with all cloud providers
 
 ### General Validation
-- Metadata and data replicas must be > 0
+- Metadata replicas must be > 0
+- Data replicas use `0`/omitted as the default running size. To scale data nodes to zero, set `spec.dataNodes.suspend=true`; this requires PVCs to be retained on scale-down and cannot be combined with data-node autoscaling.
 - `publicAPI.nodePort` only valid for NodePort service type
 
 ## Example

--- a/pkg/operator/manifests/crd/antfly.io_antflyclusters.yaml
+++ b/pkg/operator/manifests/crd/antfly.io_antflyclusters.yaml
@@ -1121,9 +1121,16 @@ spec:
                         type: integer
                     type: object
                   replicas:
-                    description: 'Replicas is the number of data nodes (default: 3)'
+                    description: Replicas is the number of data nodes. Zero or omitted
+                      uses the controller default of 3; use suspend for intentional
+                      scale-to-zero.
                     format: int32
                     type: integer
+                  suspend:
+                    description: Suspend scales data nodes to zero while retaining
+                      PVCs. This is a pause/resume operation, not permanent node
+                      removal.
+                    type: boolean
                   resources:
                     description: Resources defines the resource requirements
                     properties:
@@ -6127,8 +6134,8 @@ spec:
                       for this step.
                     format: int32
                     type: integer
-                  drainingStoreID:
-                    description: DrainingStoreID is the Antfly store ID selected for
+                  drainingNodeID:
+                    description: DrainingNodeID is the Antfly node ID selected for
                       this step.
                     type: string
                   fromReplicas:

--- a/pkg/operator/work-log/storage-resilience-and-az-topology.md
+++ b/pkg/operator/work-log/storage-resilience-and-az-topology.md
@@ -212,19 +212,25 @@ The operator's autoscaler and manual scaling currently reduce StatefulSet replic
 
 **Background**:
 - Store ID is deterministic: `store_id = pod_ordinal + 1` (set in the data StatefulSet entrypoint command at `antflycluster_controller.go:1151-1158`)
+- Node registration API: `POST /internal/v1/nodes` records durable node lifecycle intent and, for data nodes, the hosted store metadata in the same request. `/internal/v1/stores` and `/internal/v1/store` are retired.
 - Shutdown request API: `PUT /internal/v1/nodes/{node_id}/shutdown` on the metadata service
 - Shutdown status API: `GET /internal/v1/nodes/{node_id}/shutdown`
-- The request calls `TombstoneStore()` which marks the store as `Terminating`, preserves that drain intent across later store registration/status updates, and triggers the metadata reconciler to remove it from all Raft voter groups.
-- Completion: shutdown status returns `safe_to_terminate=true` only after the node has no placement intent, local group status, runtime group status, local voters, or local leaders.
+- Shutdown cancellation API: `DELETE /internal/v1/nodes/{node_id}/shutdown`
+- The request calls `RequestNodeShutdown()` which atomically records node lifecycle, tombstones the store, marks any existing store status as `Terminating`, and triggers the metadata reconciler to remove it from all Raft voter groups.
+- Completion: shutdown status returns `safe_to_terminate=true` only after the node has no placement intent, local group status, runtime group status, local voters, or local leaders. If a shard would be left with no voters, shutdown status reports `phase=blocked` and the operator surfaces `DataScaleDownBlocked` instead of polling forever.
 
 **`pkg/operator/controllers/antflycluster_controller.go`**:
-- Add `requestDataNodeShutdown(cluster, storeID)` helper:
+- Add `requestDataNodeShutdown(cluster, nodeID)` helper:
   1. Pick the highest ordinal Kubernetes will remove next.
   2. Compute `storeID = ordinal + 1`.
   3. Call `PUT http://{cluster.Name}-metadata.{namespace}.svc:12377/internal/v1/nodes/{storeID}/shutdown`.
-  4. Poll `GET http://{cluster.Name}-metadata.{namespace}.svc:12377/internal/v1/nodes/{storeID}/shutdown`.
+  4. Poll `GET http://{cluster.Name}-metadata.{namespace}.svc:12377/internal/v1/nodes/{nodeID}/shutdown`.
   5. Keep the StatefulSet at its current replica count until `safe_to_terminate=true`.
   6. Apply one replica of scale-down and repeat on later reconciles until the requested target is reached.
+- Add `cancelDataNodeShutdown(cluster, nodeID)` helper:
+  1. Call `DELETE http://{cluster.Name}-metadata.{namespace}.svc:12377/internal/v1/nodes/{nodeID}/shutdown`.
+  2. Poll shutdown status once to confirm the node is no longer draining.
+  3. Use this when a previously draining ordinal becomes desired again before the StatefulSet was reduced.
 - Call `requestDataNodeShutdown()` in `Reconcile()` between autoscaler evaluation and `reconcileDataStatefulSet()`. This single call site handles manual and autoscaler-driven scale-down.
 - Compare `workingCluster.Spec.DataNodes.Replicas` (desired) against the existing StatefulSet's current replicas to detect scale-down
 
@@ -232,7 +238,7 @@ The operator's autoscaler and manual scaling currently reduce StatefulSet replic
 
 **Metadata service discovery**: The operator already creates the metadata headless service. The address is `{cluster.Name}-metadata.{namespace}.svc:{metadataAPIPort}`. The metadata API port (12377) is already defined in the controller's constants.
 
-**HTTP client**: Add a simple HTTP client to the reconciler struct (reuse `http.DefaultClient` or inject via controller setup). No authentication needed — the `/internal/v1/` endpoints are cluster-internal.
+**HTTP client**: Add an injectable HTTP client to the reconciler struct. The default client must have a timeout so a blackholed metadata service cannot hang a controller worker. No authentication needed — the `/internal/v1/` endpoints are cluster-internal.
 
 **Known limitation: rapid scale-down/scale-up race**: If a user scales down (triggers tombstone), then immediately scales back up before the tombstone is cleaned up (1-30s), the returning stores will remain in `Terminating` until cleanup clears the tombstone. The autoscaler's cooldown prevents most automated flapping. For manual scaling, the operator should check for existing tombstones on the target ordinals before allowing scale-up and requeue if tombstones are still being cleaned up.
 

--- a/pkg/operator/work-log/storage-resilience-and-az-topology.md
+++ b/pkg/operator/work-log/storage-resilience-and-az-topology.md
@@ -211,7 +211,7 @@ The EKS docs should also recommend Karpenter over cluster-autoscaler for multi-A
 The operator's autoscaler and manual scaling currently reduce StatefulSet replicas without proving that runtime placement and Raft state has left the node being removed. This leaves phantom voters in Raft configurations and causes instability when nodes rejoin. Fix this with the node shutdown API: request drain first, poll status, and only reduce StatefulSet replicas after metadata reports the node is safe to terminate.
 
 **Background**:
-- Store ID is deterministic: `store_id = pod_ordinal + 1` (set in the data StatefulSet entrypoint command at `antflycluster_controller.go:1151-1158`)
+- Data node ID is deterministic: `node_id = pod_ordinal + 1`; data-node registration keeps `store_id` equal to `node_id` for the embedded hosted store metadata.
 - Node registration API: `POST /internal/v1/nodes` records durable node lifecycle intent and, for data nodes, the hosted store metadata in the same request. `/internal/v1/stores` and `/internal/v1/store` are retired.
 - Shutdown request API: `PUT /internal/v1/nodes/{node_id}/shutdown` on the metadata service
 - Shutdown status API: `GET /internal/v1/nodes/{node_id}/shutdown`
@@ -222,8 +222,8 @@ The operator's autoscaler and manual scaling currently reduce StatefulSet replic
 **`pkg/operator/controllers/antflycluster_controller.go`**:
 - Add `requestDataNodeShutdown(cluster, nodeID)` helper:
   1. Pick the highest ordinal Kubernetes will remove next.
-  2. Compute `storeID = ordinal + 1`.
-  3. Call `PUT http://{cluster.Name}-metadata.{namespace}.svc:12377/internal/v1/nodes/{storeID}/shutdown`.
+  2. Compute `nodeID = ordinal + 1`.
+  3. Call `PUT http://{cluster.Name}-metadata.{namespace}.svc:12377/internal/v1/nodes/{nodeID}/shutdown`.
   4. Poll `GET http://{cluster.Name}-metadata.{namespace}.svc:12377/internal/v1/nodes/{nodeID}/shutdown`.
   5. Keep the StatefulSet at its current replica count until `safe_to_terminate=true`.
   6. Apply one replica of scale-down and repeat on later reconciles until the requested target is reached.

--- a/pkg/operator/work-log/storage-resilience-and-az-topology.md
+++ b/pkg/operator/work-log/storage-resilience-and-az-topology.md
@@ -212,7 +212,7 @@ The operator's autoscaler and manual scaling currently reduce StatefulSet replic
 
 **Background**:
 - Store ID is deterministic: `store_id = pod_ordinal + 1` (set in the data StatefulSet entrypoint command at `antflycluster_controller.go:1151-1158`)
-- Deregistration API: `DELETE /_internal/v1/store/{store_id}` on the metadata service (`src/metadata/runner.go:315`)
+- Deregistration API: `DELETE /internal/v1/store/{store_id}` on the metadata service (`src/metadata/runner.go:315`)
 - This calls `TombstoneStore()` which marks the store as `Terminating` and triggers the metadata reconciler to remove it from all Raft voter groups (`src/tablemgr/table.go:587-603`)
 - Completion: the metadata reconciler removes the store from all shard Raft groups (sync peer removal), then deletes the tombstone. Timeline: 1-30s depending on shard count.
 
@@ -220,7 +220,7 @@ The operator's autoscaler and manual scaling currently reduce StatefulSet replic
 - Add `deregisterDataNodes(cluster, currentReplicas, desiredReplicas)` function:
   1. Calculate ordinals being removed: `desiredReplicas` to `currentReplicas - 1` (highest ordinals first)
   2. For each ordinal, compute `storeID = ordinal + 1`
-  3. Call `DELETE http://{cluster.Name}-metadata.{namespace}.svc:12377/_internal/v1/store/{storeID}`
+  3. Call `DELETE http://{cluster.Name}-metadata.{namespace}.svc:12377/internal/v1/store/{storeID}`
   4. If the call fails with connection refused (metadata not ready), requeue with backoff
   5. If the call succeeds, proceed — the metadata reconciler handles the rest asynchronously
 - Call `deregisterDataNodes()` in `Reconcile()` between the autoscaler evaluation and `reconcileDataStatefulSet()`. By this point, `workingCluster.Spec.DataNodes.Replicas` already reflects either the manual value (from the CRD spec) or the autoscaler's calculated value (written at line 470). This single call site handles both scaling paths.
@@ -233,7 +233,7 @@ The operator's autoscaler and manual scaling currently reduce StatefulSet replic
 
 **Metadata service discovery**: The operator already creates the metadata headless service. The address is `{cluster.Name}-metadata.{namespace}.svc:{metadataAPIPort}`. The metadata API port (12377) is already defined in the controller's constants.
 
-**HTTP client**: Add a simple HTTP client to the reconciler struct (reuse `http.DefaultClient` or inject via controller setup). No authentication needed — the `/_internal/v1/` endpoints are cluster-internal.
+**HTTP client**: Add a simple HTTP client to the reconciler struct (reuse `http.DefaultClient` or inject via controller setup). No authentication needed — the `/internal/v1/` endpoints are cluster-internal.
 
 **Known limitation: rapid scale-down/scale-up race**: If a user scales down (triggers tombstone), then immediately scales back up before the tombstone is cleaned up (1-30s), the returning stores will conflict with the metadata reconciler that's actively removing them from Raft groups. The autoscaler's 300s cooldown prevents this in the automated case. For manual scaling, the operator should check for existing tombstones on the target ordinals before allowing scale-up and requeue if tombstones are still being cleaned up. This can be implemented as a pre-check in `deregisterDataNodes()` (or a separate `checkTombstones()` step): query the metadata service for tombstoned stores and requeue if any overlap with the ordinals being scaled up.
 

--- a/pkg/operator/work-log/storage-resilience-and-az-topology.md
+++ b/pkg/operator/work-log/storage-resilience-and-az-topology.md
@@ -50,7 +50,7 @@ Default is `Retain`/`Retain` — no behavior change for existing clusters.
 
 **Raft implications of `WhenScaled: Delete`**: When a data node's PVC is deleted on scale-down and the node later rejoins (scale-up reuses the same ordinal), the node starts with empty storage. Antfly's Raft layer handles this — `startRaft()` detects an empty log directory, calls `RestartNode()` with `join=true`, and waits for the leader to send snapshots for every shard the node hosts. The happy path works, but the cost is a **full data resync via snapshot transfer for every shard** on that node. This is expensive (network + disk I/O on the leader) and temporarily reduces cluster fault tolerance while the resync is in progress. The documentation (section 7) should include a warning about this cost for manual scaling scenarios even when the webhook allows it.
 
-**Pre-existing gap (fixed in section 9)**: The operator's autoscaler previously only adjusted StatefulSet replicas without handling Raft membership removal. Section 9 adds graceful deregistration before scale-down.
+**Pre-existing gap (fixed in section 9)**: The operator's autoscaler previously only adjusted StatefulSet replicas without handling Raft membership removal. Section 9 adds runtime-gated node shutdown before scale-down.
 
 ### 2. Finalizer-Based Storage Cleanup
 
@@ -206,41 +206,40 @@ The EKS docs should also recommend Karpenter over cluster-autoscaler for multi-A
 - PVC retention policy enum validation on create
 - `WhenScaled: Delete` rejected when autoscaling enabled
 
-### 9. Graceful Data Node Deregistration Before Scale-Down
+### 9. Runtime-Gated Data Node Shutdown Before Scale-Down
 
-The operator's autoscaler and manual scaling currently reduce StatefulSet replicas without removing nodes from Raft voter groups. This leaves phantom voters in Raft configurations and causes instability when nodes rejoin. Fix this by calling the Antfly deregistration API before reducing replicas.
+The operator's autoscaler and manual scaling currently reduce StatefulSet replicas without proving that runtime placement and Raft state has left the node being removed. This leaves phantom voters in Raft configurations and causes instability when nodes rejoin. Fix this with the node shutdown API: request drain first, poll status, and only reduce StatefulSet replicas after metadata reports the node is safe to terminate.
 
 **Background**:
 - Store ID is deterministic: `store_id = pod_ordinal + 1` (set in the data StatefulSet entrypoint command at `antflycluster_controller.go:1151-1158`)
-- Deregistration API: `DELETE /internal/v1/store/{store_id}` on the metadata service (`src/metadata/runner.go:315`)
-- This calls `TombstoneStore()` which marks the store as `Terminating` and triggers the metadata reconciler to remove it from all Raft voter groups (`src/tablemgr/table.go:587-603`)
-- Completion: the metadata reconciler removes the store from all shard Raft groups (sync peer removal), then deletes the tombstone. Timeline: 1-30s depending on shard count.
+- Shutdown request API: `PUT /internal/v1/nodes/{node_id}/shutdown` on the metadata service
+- Shutdown status API: `GET /internal/v1/nodes/{node_id}/shutdown`
+- The request calls `TombstoneStore()` which marks the store as `Terminating`, preserves that drain intent across later store registration/status updates, and triggers the metadata reconciler to remove it from all Raft voter groups.
+- Completion: shutdown status returns `safe_to_terminate=true` only after the node has no placement intent, local group status, runtime group status, local voters, or local leaders.
 
 **`pkg/operator/controllers/antflycluster_controller.go`**:
-- Add `deregisterDataNodes(cluster, currentReplicas, desiredReplicas)` function:
-  1. Calculate ordinals being removed: `desiredReplicas` to `currentReplicas - 1` (highest ordinals first)
-  2. For each ordinal, compute `storeID = ordinal + 1`
-  3. Call `DELETE http://{cluster.Name}-metadata.{namespace}.svc:12377/internal/v1/store/{storeID}`
-  4. If the call fails with connection refused (metadata not ready), requeue with backoff
-  5. If the call succeeds, proceed — the metadata reconciler handles the rest asynchronously
-- Call `deregisterDataNodes()` in `Reconcile()` between the autoscaler evaluation and `reconcileDataStatefulSet()`. By this point, `workingCluster.Spec.DataNodes.Replicas` already reflects either the manual value (from the CRD spec) or the autoscaler's calculated value (written at line 470). This single call site handles both scaling paths.
+- Add `requestDataNodeShutdown(cluster, storeID)` helper:
+  1. Pick the highest ordinal Kubernetes will remove next.
+  2. Compute `storeID = ordinal + 1`.
+  3. Call `PUT http://{cluster.Name}-metadata.{namespace}.svc:12377/internal/v1/nodes/{storeID}/shutdown`.
+  4. Poll `GET http://{cluster.Name}-metadata.{namespace}.svc:12377/internal/v1/nodes/{storeID}/shutdown`.
+  5. Keep the StatefulSet at its current replica count until `safe_to_terminate=true`.
+  6. Apply one replica of scale-down and repeat on later reconciles until the requested target is reached.
+- Call `requestDataNodeShutdown()` in `Reconcile()` between autoscaler evaluation and `reconcileDataStatefulSet()`. This single call site handles manual and autoscaler-driven scale-down.
 - Compare `workingCluster.Spec.DataNodes.Replicas` (desired) against the existing StatefulSet's current replicas to detect scale-down
 
-**No need to wait for full tombstone cleanup**: The deregistration API call is sufficient — it marks the store as `Terminating` (preventing routing) and triggers Raft peer removal. The metadata reconciler handles cleanup asynchronously. The StatefulSet pod deletion can proceed because:
-- The store is already marked `Terminating` (no new requests routed to it)
-- Raft peer removal is in progress (reconciler is working on it)
-- If the pod is deleted before peer removal completes, the reconciler still removes the phantom voter in the next cycle
+**Wait before pod deletion**: The shutdown request alone is not sufficient. The operator must wait for `safe_to_terminate=true` so Kubernetes does not terminate a pod that still owns placement, local group status, runtime group status, a voter slot, or leadership.
 
 **Metadata service discovery**: The operator already creates the metadata headless service. The address is `{cluster.Name}-metadata.{namespace}.svc:{metadataAPIPort}`. The metadata API port (12377) is already defined in the controller's constants.
 
 **HTTP client**: Add a simple HTTP client to the reconciler struct (reuse `http.DefaultClient` or inject via controller setup). No authentication needed — the `/internal/v1/` endpoints are cluster-internal.
 
-**Known limitation: rapid scale-down/scale-up race**: If a user scales down (triggers tombstone), then immediately scales back up before the tombstone is cleaned up (1-30s), the returning stores will conflict with the metadata reconciler that's actively removing them from Raft groups. The autoscaler's 300s cooldown prevents this in the automated case. For manual scaling, the operator should check for existing tombstones on the target ordinals before allowing scale-up and requeue if tombstones are still being cleaned up. This can be implemented as a pre-check in `deregisterDataNodes()` (or a separate `checkTombstones()` step): query the metadata service for tombstoned stores and requeue if any overlap with the ordinals being scaled up.
+**Known limitation: rapid scale-down/scale-up race**: If a user scales down (triggers tombstone), then immediately scales back up before the tombstone is cleaned up (1-30s), the returning stores will remain in `Terminating` until cleanup clears the tombstone. The autoscaler's cooldown prevents most automated flapping. For manual scaling, the operator should check for existing tombstones on the target ordinals before allowing scale-up and requeue if tombstones are still being cleaned up.
 
 **Tests**:
-- `TestDeregisterDataNodes` (calls deregistration API for correct store IDs, handles connection errors with requeue)
-- `TestReconcileDataStatefulSet_ScaleDown` (deregistration called before replica reduction)
-- Integration: mock HTTP server simulating metadata deregistration endpoint
+- `TestRequestDataNodeShutdownUsesNodeShutdownAPI` (calls shutdown request/status API for the selected store ID)
+- `TestReconcileDataStatefulSet_ScaleDown` (shutdown is safe before replica reduction)
+- Integration: mock HTTP server simulating metadata shutdown request/status endpoints
 
 ## Reconciliation Order (within `Reconcile()`)
 
@@ -255,8 +254,8 @@ The operator's autoscaler and manual scaling currently reduce StatefulSet replic
 8.  reconcileServices
 9.  reconcileMetadataStatefulSet (+ instance label, topology spread) ← MODIFIED
 10. reconcilePVCExpansion (metadata)                                 ← NEW
-11. EvaluateScaling (updates workingCluster.Spec.DataNodes.Replicas) ← EXISTING (unchanged position)
-12. deregisterDataNodes (if scaling down)                            ← NEW
+11. EvaluateScaling (updates requested data replica target)           ← EXISTING (unchanged position)
+12. requestDataNodeShutdown + poll safe_to_terminate (if scaling down)← NEW
 13. reconcileDataStatefulSet (+ instance label, topology spread)     ← MODIFIED
 14. reconcilePVCExpansion (data)                                     ← NEW
 15. checkPVCTopologyHealth                                           ← NEW
@@ -264,8 +263,8 @@ The operator's autoscaler and manual scaling currently reduce StatefulSet replic
 ```
 
 Ordering notes:
-- The autoscaler (step 11) runs between metadata and data StatefulSet reconciliation, matching the existing code (lines 463-474). It updates `workingCluster.Spec.DataNodes.Replicas` in memory, which steps 12 and 13 then use.
-- Deregistration (step 12) is a **single call site** that handles both manual and autoscaler scaling. By this point, `workingCluster.Spec.DataNodes.Replicas` reflects the final desired count from either source. Deregistration compares this against the existing StatefulSet's current replicas.
+- The autoscaler (step 11) runs between metadata and data StatefulSet reconciliation, matching the existing code. It computes the requested replica target in memory, which steps 12 and 13 then use.
+- Runtime-gated shutdown (step 12) is a **single call site** that handles both manual and autoscaler scaling. The operator keeps the StatefulSet at its current replica count until metadata reports `safe_to_terminate=true`, then applies one ordinal of scale-down.
 - PVC expansion (steps 10, 14) must come after StatefulSet reconciliation (steps 9, 13) because the StatefulSet creates PVCs in the first place.
 - Note: newly scaled-up pods get PVCs sized from the immutable VolumeClaimTemplate (old size). `reconcilePVCExpansion()` patches them on the next reconcile cycle. For CSI drivers supporting online expansion, this is seamless.
 
@@ -274,7 +273,7 @@ Ordering notes:
 1. Instance label addition (section 0) — prerequisite for topology spread and health detection
 2. CRD types + `make manifests generate` (everything depends on this)
 3. Controller: PVC retention policy mapping + finalizer logic + `cleanupStorageResources()`
-4. Controller: Graceful data node deregistration (section 9) — HTTP client + deregister before scale-down
+4. Controller: Runtime-gated data node shutdown (section 9) — HTTP client + shutdown request/status before scale-down
 5. Controller: Default zone topology spread with annotation tracking
 6. Controller: PVC expansion + topology health check
 7. Webhook: Storage immutability + StorageClass expansion check + retention policy validation + RBAC

--- a/src/metadata/api.yaml
+++ b/src/metadata/api.yaml
@@ -1551,7 +1551,7 @@ components:
 
             Use the internal `/reallocate` endpoint to trigger automatic shard splitting:
             ```bash
-            POST /_internal/v1/reallocate
+            POST /internal/v1/reallocate
             ```
 
             This enqueues a reallocation request that the leader processes asynchronously, splitting

--- a/src/metadata/kv/store.go
+++ b/src/metadata/kv/store.go
@@ -448,6 +448,11 @@ func (h *MetadataStoreAPI) AddRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /status", h.handleStatus)
 }
 
+// AddMetadataRoutes adds read-only metadata control-plane routes.
+func (h *MetadataStoreAPI) AddMetadataRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("GET /status", h.handleStatus)
+}
+
 func (m *MetadataStore) ServeAPI(
 	ctx context.Context,
 	mux *http.ServeMux,

--- a/src/metadata/metadata.go
+++ b/src/metadata/metadata.go
@@ -134,41 +134,6 @@ func (ms *MetadataStore) handleForwardResolveIntent(w http.ResponseWriter, r *ht
 	w.WriteHeader(http.StatusOK)
 }
 
-// handleStoreDeregistration handles requests from nodes to deregister with the leader
-func (ms *MetadataStore) handleStoreDeregistration(w http.ResponseWriter, r *http.Request) {
-	storeID := r.PathValue("store")
-
-	// Extract node ID from URL path
-	id, err := types.IDFromString(storeID)
-	if err != nil {
-		errorResponse(w, "Invalid store ID", http.StatusBadRequest)
-		return
-	}
-	// FIXME (ajr) This has a race condition with health checks
-	// Maybe we should use a different tombstone mechanism to mark
-	// a node as deregistered or forward the request to the leader?
-	//
-	// This means you can't find it as a leader for removing it from the shard.
-	if err := ms.tm.TombstoneStore(r.Context(), id); err != nil {
-		ms.logger.Error("Failed to register node", zap.Stringer("storeID", id), zap.Error(err))
-		errorResponse(w, fmt.Errorf("registering node: %w", err).Error(), http.StatusBadRequest)
-		return
-	}
-	// 1. Remove shards from the deregistered store
-	// 2. This causes the store to also step down if it's a leader
-
-	ms.TriggerReconciliation()
-	ms.logger.Info("Node deregistered", zap.Stringer("storeID", id))
-
-	// Return success
-	w.WriteHeader(http.StatusOK)
-	if err := json.NewEncoder(w).Encode(map[string]string{
-		"status": "deregistered",
-	}); err != nil {
-		ms.logger.Error("Error encoding response", zap.Error(err))
-	}
-}
-
 // handleReallocateShards manually triggers shard reallocation (splits/merges) for a specific table
 func (ms *MetadataStore) handleReallocateShards(w http.ResponseWriter, r *http.Request) {
 	// FIXME (ajr) This should enqueue a reallocation request instead of processing immediately
@@ -182,35 +147,6 @@ func (ms *MetadataStore) handleReallocateShards(w http.ResponseWriter, r *http.R
 	w.WriteHeader(http.StatusOK)
 	if err := json.NewEncoder(w).Encode(map[string]string{
 		"status": "reallocation enqueued",
-	}); err != nil {
-		ms.logger.Error("Error encoding response", zap.Error(err))
-	}
-}
-
-// handleStoreRegistration handles requests from nodes to register with the leader
-func (ms *MetadataStore) handleStoreRegistration(w http.ResponseWriter, r *http.Request) {
-	var req store.StoreRegistrationRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		errorResponse(w, "Failed to parse registration request", http.StatusBadRequest)
-		return
-	}
-	if err := ms.tm.RegisterStore(r.Context(), &req); err != nil {
-		ms.logger.Error("Failed to register node", zap.Stringer("nodeID", req.ID), zap.Error(err))
-		errorResponse(w, "Failed to register store", http.StatusInternalServerError)
-		return
-	}
-	ms.TriggerReconciliation()
-
-	ms.logger.Info("Node registered",
-		zap.Stringer("nodeID", req.ID),
-		zap.String("raftURL", req.RaftURL),
-		zap.String("apiURL", req.ApiURL),
-	)
-
-	// Return success
-	w.WriteHeader(http.StatusOK)
-	if err := json.NewEncoder(w).Encode(map[string]string{
-		"status": "registered",
 	}); err != nil {
 		ms.logger.Error("Error encoding response", zap.Error(err))
 	}

--- a/src/metadata/node_shutdown.go
+++ b/src/metadata/node_shutdown.go
@@ -5,9 +5,13 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
+	"time"
 
 	"github.com/antflydb/antfly/lib/types"
 	json "github.com/antflydb/antfly/pkg/libaf/json"
+	"github.com/antflydb/antfly/src/common"
+	"github.com/antflydb/antfly/src/store"
 	"github.com/antflydb/antfly/src/tablemgr"
 	"go.uber.org/zap"
 )
@@ -17,22 +21,52 @@ type nodeShutdownRequest struct {
 	Reason string `json:"reason,omitempty"`
 }
 
+type nodeRegistrationRequest struct {
+	NodeID      uint64                        `json:"node_id"`
+	StoreID     uint64                        `json:"store_id,omitempty"`
+	Role        string                        `json:"role,omitempty"`
+	HealthClass string                        `json:"health_class,omitempty"`
+	Live        *bool                         `json:"live,omitempty"`
+	Lifecycle   string                        `json:"lifecycle,omitempty"`
+	Reason      string                        `json:"reason,omitempty"`
+	RaftURL     string                        `json:"raft_url,omitempty"`
+	APIURL      string                        `json:"api_url,omitempty"`
+	Shards      map[types.ID]*store.ShardInfo `json:"shards,omitempty"`
+	GroupStatus []nodeGroupStatusReport       `json:"group_statuses,omitempty"`
+}
+
+type nodeStatusRequest struct {
+	StoreID     uint64                  `json:"store_id,omitempty"`
+	Live        *bool                   `json:"live,omitempty"`
+	HealthClass string                  `json:"health_class,omitempty"`
+	GroupStatus []nodeGroupStatusReport `json:"group_statuses,omitempty"`
+}
+
+type nodeGroupStatusReport struct {
+	GroupID     uint64 `json:"group_id"`
+	LocalLeader bool   `json:"local_leader,omitempty"`
+	LocalVoter  bool   `json:"local_voter,omitempty"`
+}
+
 type nodeShutdownStatus struct {
-	NodeID          types.ID                  `json:"node_id"`
+	NodeID          uint64                    `json:"node_id"`
 	Type            string                    `json:"type,omitempty"`
 	Phase           string                    `json:"phase"`
 	SafeToTerminate bool                      `json:"safe_to_terminate"`
+	Blocked         bool                      `json:"blocked,omitempty"`
+	BlockedReason   string                    `json:"blocked_reason,omitempty"`
+	Message         string                    `json:"message,omitempty"`
 	Stores          []nodeShutdownStoreStatus `json:"stores,omitempty"`
-	PendingShards   []types.ID                `json:"pending_shards,omitempty"`
+	PendingGroups   []types.ID                `json:"pending_groups,omitempty"`
 }
 
 type nodeShutdownStoreStatus struct {
-	StoreID              types.ID `json:"store_id"`
-	PlacementIntentCount int      `json:"placement_intent_count"`
-	GroupStatusCount     int      `json:"group_status_count"`
-	RuntimeGroupCount    int      `json:"runtime_group_count"`
-	LocalVoterCount      int      `json:"local_voter_count"`
-	LocalLeaderCount     int      `json:"local_leader_count"`
+	StoreID              uint64 `json:"store_id"`
+	PlacementIntentCount int    `json:"placement_intent_count"`
+	GroupStatusCount     int    `json:"group_status_count"`
+	RuntimeGroupCount    int    `json:"runtime_group_count"`
+	LocalVoterCount      int    `json:"local_voter_count"`
+	LocalLeaderCount     int    `json:"local_leader_count"`
 }
 
 func (ms *MetadataStore) handleNodeShutdownRequest(w http.ResponseWriter, r *http.Request) {
@@ -40,6 +74,7 @@ func (ms *MetadataStore) handleNodeShutdownRequest(w http.ResponseWriter, r *htt
 	if !ok {
 		return
 	}
+	reason := "operator scale-down"
 	if r.Body != nil {
 		var req nodeShutdownRequest
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -48,9 +83,16 @@ func (ms *MetadataStore) handleNodeShutdownRequest(w http.ResponseWriter, r *htt
 				return
 			}
 		}
+		if req.Type != "" && req.Type != "remove" {
+			errorResponse(w, `Invalid node shutdown type: expected "remove"`, http.StatusBadRequest)
+			return
+		}
+		if req.Reason != "" {
+			reason = req.Reason
+		}
 	}
 
-	if err := ms.tm.TombstoneStore(r.Context(), nodeID); err != nil {
+	if err := ms.tm.RequestNodeShutdown(r.Context(), nodeID, reason); err != nil {
 		ms.logger.Error("Failed to request node shutdown", zap.Stringer("nodeID", nodeID), zap.Error(err))
 		errorResponse(w, fmt.Errorf("requesting node shutdown: %w", err).Error(), http.StatusBadRequest)
 		return
@@ -84,19 +126,224 @@ func (ms *MetadataStore) handleNodeShutdownStatus(w http.ResponseWriter, r *http
 	}
 }
 
-func parseNodeIDPathValue(w http.ResponseWriter, r *http.Request) (types.ID, bool) {
-	nodeID, err := types.IDFromString(r.PathValue("node"))
+func (ms *MetadataStore) handleNodeShutdownCancellation(w http.ResponseWriter, r *http.Request) {
+	nodeID, ok := parseNodeIDPathValue(w, r)
+	if !ok {
+		return
+	}
+
+	if err := ms.tm.ClearStoreTombstone(r.Context(), nodeID); err != nil {
+		ms.logger.Error("Failed to cancel node shutdown", zap.Stringer("nodeID", nodeID), zap.Error(err))
+		errorResponse(w, fmt.Errorf("canceling node shutdown: %w", err).Error(), http.StatusBadRequest)
+		return
+	}
+	ms.TriggerReconciliation()
+	ms.logger.Info("Node shutdown canceled", zap.Stringer("nodeID", nodeID))
+
+	w.WriteHeader(http.StatusAccepted)
+	if err := json.NewEncoder(w).Encode(map[string]string{
+		"status": "canceled",
+	}); err != nil {
+		ms.logger.Warn("Failed to write node shutdown cancellation response", zap.Error(err))
+	}
+}
+
+func (ms *MetadataStore) handleNodeShutdownFinalization(w http.ResponseWriter, r *http.Request) {
+	nodeID, ok := parseNodeIDPathValue(w, r)
+	if !ok {
+		return
+	}
+
+	if err := ms.tm.FinalizeNodeShutdown(r.Context(), nodeID); err != nil {
+		ms.logger.Error("Failed to finalize node shutdown", zap.Stringer("nodeID", nodeID), zap.Error(err))
+		if errors.Is(err, tablemgr.ErrActiveNodeFinalizeRejected) {
+			errorResponse(w, err.Error(), http.StatusConflict)
+			return
+		}
+		errorResponse(w, fmt.Errorf("finalizing node shutdown: %w", err).Error(), http.StatusBadRequest)
+		return
+	}
+	ms.TriggerReconciliation()
+	ms.logger.Info("Node shutdown finalized", zap.Stringer("nodeID", nodeID))
+
+	w.WriteHeader(http.StatusAccepted)
+	if err := json.NewEncoder(w).Encode(map[string]string{
+		"status": "finalized",
+	}); err != nil {
+		ms.logger.Warn("Failed to write node shutdown finalization response", zap.Error(err))
+	}
+}
+
+func (ms *MetadataStore) handleNodeRegistration(w http.ResponseWriter, r *http.Request) {
+	var req nodeRegistrationRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		errorResponse(w, "Failed to parse node registration request", http.StatusBadRequest)
+		return
+	}
+	if req.NodeID == 0 {
+		errorResponse(w, "Node registration requires node_id", http.StatusBadRequest)
+		return
+	}
+	if req.StoreID != 0 && req.StoreID != req.NodeID {
+		errorResponse(w, "Store identity must match node identity", http.StatusBadRequest)
+		return
+	}
+	if req.Lifecycle != "" && req.Lifecycle != tablemgr.NodeLifecycleActive {
+		errorResponse(w, `Invalid node lifecycle on registration: use "active" or the node shutdown API`, http.StatusBadRequest)
+		return
+	}
+	nodeID := types.ID(req.NodeID)
+	record := &tablemgr.NodeRecord{
+		NodeID:    nodeID,
+		Lifecycle: req.Lifecycle,
+		Reason:    req.Reason,
+	}
+	if err := ms.tm.RegisterNode(r.Context(), record); err != nil {
+		ms.logger.Error("Failed to register node", zap.Stringer("nodeID", nodeID), zap.Error(err))
+		errorResponse(w, fmt.Errorf("registering node: %w", err).Error(), http.StatusBadRequest)
+		return
+	}
+	if req.StoreID != 0 {
+		shards := req.Shards
+		if len(req.GroupStatus) > 0 {
+			shards = nodeGroupStatusReportsToShards(nodeID, req.GroupStatus)
+		}
+		storeReq := &store.StoreRegistrationRequest{
+			StoreInfo: store.StoreInfo{
+				ID:      types.ID(req.StoreID),
+				RaftURL: req.RaftURL,
+				ApiURL:  req.APIURL,
+			},
+			Shards: shards,
+		}
+		if err := ms.tm.RegisterStore(r.Context(), storeReq); err != nil {
+			ms.logger.Error("Failed to register node store", zap.Stringer("nodeID", nodeID), zap.Error(err))
+			errorResponse(w, fmt.Errorf("registering node store: %w", err).Error(), http.StatusInternalServerError)
+			return
+		}
+	}
+	ms.TriggerReconciliation()
+	w.WriteHeader(http.StatusAccepted)
+	if _, err := w.Write([]byte("accepted")); err != nil {
+		ms.logger.Warn("Failed to write node registration response", zap.Stringer("nodeID", nodeID), zap.Error(err))
+	}
+}
+
+func (ms *MetadataStore) handleNodeStatus(w http.ResponseWriter, r *http.Request) {
+	nodeID, ok := parseNodeIDPathValue(w, r)
+	if !ok {
+		return
+	}
+	var req nodeStatusRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		errorResponse(w, "Failed to parse node status request", http.StatusBadRequest)
+		return
+	}
+	storeID := uint64(nodeID)
+	if req.StoreID != 0 {
+		if req.StoreID != storeID {
+			errorResponse(w, "Store identity must match node identity", http.StatusBadRequest)
+			return
+		}
+		storeID = req.StoreID
+	}
+
+	state := store.StoreState_Healthy
+	if (req.Live != nil && !*req.Live) || (req.HealthClass != "" && req.HealthClass != "healthy") {
+		state = store.StoreState_Unhealthy
+	}
+	storeInfo := store.StoreInfo{ID: types.ID(storeID)}
+	if existing, err := ms.tm.GetStoreStatus(r.Context(), types.ID(storeID)); err == nil {
+		storeInfo = existing.StoreInfo
+	} else if errors.Is(err, tablemgr.ErrNotFound) {
+		errorResponse(w, "Node not found", http.StatusNotFound)
+		return
+	} else if err != nil && !errors.Is(err, tablemgr.ErrNotFound) {
+		ms.logger.Error("Failed to read existing node store status", zap.Stringer("nodeID", nodeID), zap.Error(err))
+		errorResponse(w, fmt.Errorf("reading existing node store status: %w", err).Error(), http.StatusInternalServerError)
+		return
+	}
+	status := &tablemgr.StoreStatus{
+		StoreInfo: storeInfo,
+		State:     state,
+		LastSeen:  time.Now(),
+		Shards:    nodeGroupStatusReportsToShards(types.ID(storeID), req.GroupStatus),
+	}
+	if err := ms.tm.UpdateStatuses(r.Context(), map[types.ID]*tablemgr.StoreStatus{types.ID(storeID): status}); err != nil {
+		ms.logger.Error("Failed to report node status", zap.Stringer("nodeID", nodeID), zap.Error(err))
+		errorResponse(w, fmt.Errorf("reporting node status: %w", err).Error(), http.StatusInternalServerError)
+		return
+	}
+	ms.TriggerReconciliation()
+	w.WriteHeader(http.StatusAccepted)
+	if _, err := w.Write([]byte("accepted")); err != nil {
+		ms.logger.Warn("Failed to write node status response", zap.Stringer("nodeID", nodeID), zap.Error(err))
+	}
+}
+
+func (ms *MetadataStore) handleNodeRecord(w http.ResponseWriter, r *http.Request) {
+	nodeID, ok := parseNodeIDPathValue(w, r)
+	if !ok {
+		return
+	}
+	record, err := ms.tm.GetNodeRecord(r.Context(), nodeID)
 	if err != nil {
-		errorResponse(w, "Invalid node ID", http.StatusBadRequest)
+		if errors.Is(err, tablemgr.ErrNotFound) {
+			errorResponse(w, "Node not found", http.StatusNotFound)
+			return
+		}
+		ms.logger.Error("Failed to read node record", zap.Stringer("nodeID", nodeID), zap.Error(err))
+		errorResponse(w, fmt.Errorf("reading node record: %w", err).Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(record); err != nil {
+		ms.logger.Warn("Failed to marshal node record", zap.Stringer("nodeID", nodeID), zap.Error(err))
+		errorResponse(w, "Failed to encode response", http.StatusInternalServerError)
+	}
+}
+
+func nodeGroupStatusReportsToShards(nodeID types.ID, reports []nodeGroupStatusReport) map[types.ID]*store.ShardInfo {
+	shards := make(map[types.ID]*store.ShardInfo, len(reports))
+	for _, report := range reports {
+		if report.GroupID == 0 {
+			continue
+		}
+		info := store.NewShardInfo()
+		info.ReportedBy.Add(nodeID)
+		if report.LocalVoter {
+			info.Peers.Add(nodeID)
+			info.RaftStatus.Voters = common.NewPeerSet(nodeID)
+		}
+		if report.LocalLeader {
+			info.RaftStatus.Lead = nodeID
+		}
+		shards[types.ID(report.GroupID)] = info
+	}
+	return shards
+}
+
+func parseNodeIDPathValue(w http.ResponseWriter, r *http.Request) (types.ID, bool) {
+	parsed, err := strconv.ParseUint(r.PathValue("node"), 10, 64)
+	if err != nil {
+		http.NotFound(w, r)
 		return 0, false
 	}
-	return nodeID, true
+	if parsed == 0 {
+		http.NotFound(w, r)
+		return 0, false
+	}
+	return types.ID(parsed), true
 }
 
 func (ms *MetadataStore) buildNodeShutdownStatus(r *http.Request, nodeID types.ID) (*nodeShutdownStatus, error) {
 	ctx := r.Context()
 	tombstoned, err := ms.tm.HasStoreTombstone(ctx, nodeID)
 	if err != nil {
+		return nil, err
+	}
+	nodeRecord, err := ms.tm.GetNodeRecord(ctx, nodeID)
+	if err != nil && !errors.Is(err, tablemgr.ErrNotFound) {
 		return nil, err
 	}
 
@@ -109,15 +356,27 @@ func (ms *MetadataStore) buildNodeShutdownStatus(r *http.Request, nodeID types.I
 	}
 
 	status := &nodeShutdownStatus{
-		NodeID: nodeID,
+		NodeID: uint64(nodeID),
 		Type:   "remove",
-		Stores: []nodeShutdownStoreStatus{{StoreID: nodeID}},
+		Stores: []nodeShutdownStoreStatus{{StoreID: uint64(nodeID)}},
+	}
+	if !tombstoned && (nodeRecord == nil || nodeRecord.Lifecycle != tablemgr.NodeLifecycleDraining) {
+		if !storeKnown && nodeRecord == nil {
+			status.Phase = "not_found"
+			status.SafeToTerminate = true
+		} else if storeStatus != nil && storeStatus.State == store.StoreState_Terminating {
+			status.Phase = "recovering"
+			status.Message = "node shutdown was canceled and the store is waiting for a healthy status report before it is routable"
+		} else {
+			status.Phase = tablemgr.NodeLifecycleActive
+		}
+		return status, nil
 	}
 	if storeStatus != nil {
 		status.Stores[0].GroupStatusCount = len(storeStatus.Shards)
 		status.Stores[0].RuntimeGroupCount = len(storeStatus.Shards)
 		for shardID := range storeStatus.Shards {
-			status.PendingShards = appendUniqueID(status.PendingShards, shardID)
+			status.PendingGroups = appendUniqueID(status.PendingGroups, shardID)
 		}
 	}
 
@@ -131,16 +390,20 @@ func (ms *MetadataStore) buildNodeShutdownStatus(r *http.Request, nodeID types.I
 		}
 		if shard.Peers.Contains(nodeID) {
 			status.Stores[0].PlacementIntentCount++
-			status.PendingShards = appendUniqueID(status.PendingShards, shardID)
+			status.PendingGroups = appendUniqueID(status.PendingGroups, shardID)
 		}
 		if shard.RaftStatus != nil {
 			if shard.RaftStatus.Voters.Contains(nodeID) {
 				status.Stores[0].LocalVoterCount++
-				status.PendingShards = appendUniqueID(status.PendingShards, shardID)
+				status.PendingGroups = appendUniqueID(status.PendingGroups, shardID)
+				if len(shard.RaftStatus.Voters) <= 1 {
+					status.Blocked = true
+					status.BlockedReason = "InsufficientShardVoters"
+				}
 			}
 			if shard.RaftStatus.Lead == nodeID {
 				status.Stores[0].LocalLeaderCount++
-				status.PendingShards = appendUniqueID(status.PendingShards, shardID)
+				status.PendingGroups = appendUniqueID(status.PendingGroups, shardID)
 			}
 		}
 	}
@@ -156,6 +419,9 @@ func (ms *MetadataStore) buildNodeShutdownStatus(r *http.Request, nodeID types.I
 		status.Phase = "not_found"
 	case status.SafeToTerminate:
 		status.Phase = "complete"
+	case status.Blocked:
+		status.Phase = "blocked"
+		status.Message = "node shutdown cannot safely remove the selected store because at least one shard would have no remaining voters"
 	default:
 		status.Phase = "draining"
 	}

--- a/src/metadata/node_shutdown.go
+++ b/src/metadata/node_shutdown.go
@@ -1,0 +1,172 @@
+package metadata
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/antflydb/antfly/lib/types"
+	json "github.com/antflydb/antfly/pkg/libaf/json"
+	"github.com/antflydb/antfly/src/tablemgr"
+	"go.uber.org/zap"
+)
+
+type nodeShutdownRequest struct {
+	Type   string `json:"type,omitempty"`
+	Reason string `json:"reason,omitempty"`
+}
+
+type nodeShutdownStatus struct {
+	NodeID          types.ID                  `json:"node_id"`
+	Type            string                    `json:"type,omitempty"`
+	Phase           string                    `json:"phase"`
+	SafeToTerminate bool                      `json:"safe_to_terminate"`
+	Stores          []nodeShutdownStoreStatus `json:"stores,omitempty"`
+	PendingShards   []types.ID                `json:"pending_shards,omitempty"`
+}
+
+type nodeShutdownStoreStatus struct {
+	StoreID              types.ID `json:"store_id"`
+	PlacementIntentCount int      `json:"placement_intent_count"`
+	GroupStatusCount     int      `json:"group_status_count"`
+	RuntimeGroupCount    int      `json:"runtime_group_count"`
+	LocalVoterCount      int      `json:"local_voter_count"`
+	LocalLeaderCount     int      `json:"local_leader_count"`
+}
+
+func (ms *MetadataStore) handleNodeShutdownRequest(w http.ResponseWriter, r *http.Request) {
+	nodeID, ok := parseNodeIDPathValue(w, r)
+	if !ok {
+		return
+	}
+	if r.Body != nil {
+		var req nodeShutdownRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			if !errors.Is(err, io.EOF) {
+				errorResponse(w, "Invalid node shutdown request", http.StatusBadRequest)
+				return
+			}
+		}
+	}
+
+	if err := ms.tm.TombstoneStore(r.Context(), nodeID); err != nil {
+		ms.logger.Error("Failed to request node shutdown", zap.Stringer("nodeID", nodeID), zap.Error(err))
+		errorResponse(w, fmt.Errorf("requesting node shutdown: %w", err).Error(), http.StatusBadRequest)
+		return
+	}
+	ms.TriggerReconciliation()
+	ms.logger.Info("Node shutdown requested", zap.Stringer("nodeID", nodeID))
+
+	w.WriteHeader(http.StatusAccepted)
+	if _, err := w.Write([]byte("accepted")); err != nil {
+		ms.logger.Warn("Failed to write node shutdown response", zap.Error(err))
+	}
+}
+
+func (ms *MetadataStore) handleNodeShutdownStatus(w http.ResponseWriter, r *http.Request) {
+	nodeID, ok := parseNodeIDPathValue(w, r)
+	if !ok {
+		return
+	}
+
+	status, err := ms.buildNodeShutdownStatus(r, nodeID)
+	if err != nil {
+		ms.logger.Error("Failed to build node shutdown status", zap.Stringer("nodeID", nodeID), zap.Error(err))
+		errorResponse(w, fmt.Errorf("getting node shutdown status: %w", err).Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(status); err != nil {
+		ms.logger.Warn("Failed to marshal node shutdown status", zap.Stringer("nodeID", nodeID), zap.Error(err))
+		errorResponse(w, "Failed to encode response", http.StatusInternalServerError)
+	}
+}
+
+func parseNodeIDPathValue(w http.ResponseWriter, r *http.Request) (types.ID, bool) {
+	nodeID, err := types.IDFromString(r.PathValue("node"))
+	if err != nil {
+		errorResponse(w, "Invalid node ID", http.StatusBadRequest)
+		return 0, false
+	}
+	return nodeID, true
+}
+
+func (ms *MetadataStore) buildNodeShutdownStatus(r *http.Request, nodeID types.ID) (*nodeShutdownStatus, error) {
+	ctx := r.Context()
+	tombstoned, err := ms.tm.HasStoreTombstone(ctx, nodeID)
+	if err != nil {
+		return nil, err
+	}
+
+	storeKnown := tombstoned
+	storeStatus, err := ms.tm.GetStoreStatus(ctx, nodeID)
+	if err == nil {
+		storeKnown = true
+	} else if err != nil && !errors.Is(err, tablemgr.ErrNotFound) {
+		return nil, err
+	}
+
+	status := &nodeShutdownStatus{
+		NodeID: nodeID,
+		Type:   "remove",
+		Stores: []nodeShutdownStoreStatus{{StoreID: nodeID}},
+	}
+	if storeStatus != nil {
+		status.Stores[0].GroupStatusCount = len(storeStatus.Shards)
+		status.Stores[0].RuntimeGroupCount = len(storeStatus.Shards)
+		for shardID := range storeStatus.Shards {
+			status.PendingShards = appendUniqueID(status.PendingShards, shardID)
+		}
+	}
+
+	shards, err := ms.tm.GetShardStatuses()
+	if err != nil {
+		return nil, err
+	}
+	for shardID, shard := range shards {
+		if shard == nil {
+			continue
+		}
+		if shard.Peers.Contains(nodeID) {
+			status.Stores[0].PlacementIntentCount++
+			status.PendingShards = appendUniqueID(status.PendingShards, shardID)
+		}
+		if shard.RaftStatus != nil {
+			if shard.RaftStatus.Voters.Contains(nodeID) {
+				status.Stores[0].LocalVoterCount++
+				status.PendingShards = appendUniqueID(status.PendingShards, shardID)
+			}
+			if shard.RaftStatus.Lead == nodeID {
+				status.Stores[0].LocalLeaderCount++
+				status.PendingShards = appendUniqueID(status.PendingShards, shardID)
+			}
+		}
+	}
+
+	shutdownStoreStatus := status.Stores[0]
+	status.SafeToTerminate = shutdownStoreStatus.PlacementIntentCount == 0 &&
+		shutdownStoreStatus.GroupStatusCount == 0 &&
+		shutdownStoreStatus.RuntimeGroupCount == 0 &&
+		shutdownStoreStatus.LocalVoterCount == 0 &&
+		shutdownStoreStatus.LocalLeaderCount == 0
+	switch {
+	case !storeKnown && status.SafeToTerminate:
+		status.Phase = "not_found"
+	case status.SafeToTerminate:
+		status.Phase = "complete"
+	default:
+		status.Phase = "draining"
+	}
+	return status, nil
+}
+
+func appendUniqueID(ids []types.ID, id types.ID) []types.ID {
+	for _, existing := range ids {
+		if existing == id {
+			return ids
+		}
+	}
+	return append(ids, id)
+}

--- a/src/metadata/node_shutdown.go
+++ b/src/metadata/node_shutdown.go
@@ -46,6 +46,7 @@ type nodeGroupStatusReport struct {
 	GroupID     uint64 `json:"group_id"`
 	LocalLeader bool   `json:"local_leader,omitempty"`
 	LocalVoter  bool   `json:"local_voter,omitempty"`
+	VoterCount  int    `json:"voter_count,omitempty"`
 }
 
 type nodeShutdownStatus struct {
@@ -205,7 +206,7 @@ func (ms *MetadataStore) handleNodeRegistration(w http.ResponseWriter, r *http.R
 	}
 	if req.StoreID != 0 {
 		shards := req.Shards
-		if len(req.GroupStatus) > 0 {
+		if len(shards) == 0 && len(req.GroupStatus) > 0 {
 			shards = nodeGroupStatusReportsToShards(nodeID, req.GroupStatus)
 		}
 		storeReq := &store.StoreRegistrationRequest{
@@ -314,6 +315,11 @@ func nodeGroupStatusReportsToShards(nodeID types.ID, reports []nodeGroupStatusRe
 		if report.LocalVoter {
 			info.Peers.Add(nodeID)
 			info.RaftStatus.Voters = common.NewPeerSet(nodeID)
+			if report.VoterCount > 0 {
+				info.VoterCount = report.VoterCount
+			} else {
+				info.VoterCount = 1
+			}
 		}
 		if report.LocalLeader {
 			info.RaftStatus.Lead = nodeID
@@ -372,14 +378,6 @@ func (ms *MetadataStore) buildNodeShutdownStatus(r *http.Request, nodeID types.I
 		}
 		return status, nil
 	}
-	if storeStatus != nil {
-		status.Stores[0].GroupStatusCount = len(storeStatus.Shards)
-		status.Stores[0].RuntimeGroupCount = len(storeStatus.Shards)
-		for shardID := range storeStatus.Shards {
-			status.PendingGroups = appendUniqueID(status.PendingGroups, shardID)
-		}
-	}
-
 	shards, err := ms.tm.GetShardStatuses()
 	if err != nil {
 		return nil, err
@@ -387,6 +385,11 @@ func (ms *MetadataStore) buildNodeShutdownStatus(r *http.Request, nodeID types.I
 	for shardID, shard := range shards {
 		if shard == nil {
 			continue
+		}
+		if shard.ReportedBy.Contains(nodeID) {
+			status.Stores[0].GroupStatusCount++
+			status.Stores[0].RuntimeGroupCount++
+			status.PendingGroups = appendUniqueID(status.PendingGroups, shardID)
 		}
 		if shard.Peers.Contains(nodeID) {
 			status.Stores[0].PlacementIntentCount++
@@ -396,7 +399,7 @@ func (ms *MetadataStore) buildNodeShutdownStatus(r *http.Request, nodeID types.I
 			if shard.RaftStatus.Voters.Contains(nodeID) {
 				status.Stores[0].LocalVoterCount++
 				status.PendingGroups = appendUniqueID(status.PendingGroups, shardID)
-				if len(shard.RaftStatus.Voters) <= 1 {
+				if effectiveShardVoterCount(shard) <= 1 {
 					status.Blocked = true
 					status.BlockedReason = "InsufficientShardVoters"
 				}
@@ -426,6 +429,17 @@ func (ms *MetadataStore) buildNodeShutdownStatus(r *http.Request, nodeID types.I
 		status.Phase = "draining"
 	}
 	return status, nil
+}
+
+func effectiveShardVoterCount(shard *store.ShardStatus) int {
+	if shard == nil {
+		return 0
+	}
+	voterCount := shard.VoterCount
+	if shard.RaftStatus != nil && len(shard.RaftStatus.Voters) > voterCount {
+		voterCount = len(shard.RaftStatus.Voters)
+	}
+	return voterCount
 }
 
 func appendUniqueID(ids []types.ID, id types.ID) []types.ID {

--- a/src/metadata/node_shutdown.go
+++ b/src/metadata/node_shutdown.go
@@ -59,7 +59,20 @@ type nodeShutdownStatus struct {
 	Message         string                    `json:"message,omitempty"`
 	Stores          []nodeShutdownStoreStatus `json:"stores,omitempty"`
 	PendingGroups   []types.ID                `json:"pending_groups,omitempty"`
+	// BypassedGroups lists shards that the safety net excluded from
+	// SafeToTerminate counters because the drain has been stuck longer than
+	// nodeShutdownStuckThreshold. Surfaced for operator visibility; these
+	// shards still have multiple voters (otherwise Blocked would be set).
+	BypassedGroups []types.ID `json:"bypassed_groups,omitempty"`
 }
+
+// nodeShutdownStuckThreshold is the duration after entering Draining beyond
+// which the safety net excludes pending shards from SafeToTerminate, provided
+// removing this node would not leave the shard without quorum. Without this
+// safety net, a single shard whose leader can no longer apply conf changes
+// (raft stopped, partitioned leader, etc.) would block node termination
+// indefinitely.
+const nodeShutdownStuckThreshold = 2 * time.Minute
 
 type nodeShutdownStoreStatus struct {
 	StoreID              uint64 `json:"store_id"`
@@ -382,10 +395,41 @@ func (ms *MetadataStore) buildNodeShutdownStatus(r *http.Request, nodeID types.I
 	if err != nil {
 		return nil, err
 	}
+
+	// Bypass shards that still reference this node once the drain has been
+	// running longer than the stuck threshold, so a single shard whose Raft
+	// leader cannot apply conf changes does not block termination forever.
+	// We only bypass shards that would retain at least one voter without
+	// this node; the InsufficientShardVoters guard below still trumps it.
+	bypassStuck := nodeRecord != nil &&
+		!nodeRecord.DrainingSince.IsZero() &&
+		time.Since(nodeRecord.DrainingSince) >= nodeShutdownStuckThreshold
+
 	for shardID, shard := range shards {
 		if shard == nil {
 			continue
 		}
+		referencesNode := shard.ReportedBy.Contains(nodeID) ||
+			shard.Peers.Contains(nodeID) ||
+			(shard.RaftStatus != nil &&
+				(shard.RaftStatus.Voters.Contains(nodeID) || shard.RaftStatus.Lead == nodeID))
+		if !referencesNode {
+			continue
+		}
+
+		// If removing this node would leave the shard without quorum, never
+		// bypass: the operator must add a replacement first. This check
+		// mirrors the per-voter guard below but applies even when only
+		// Peers/ReportedBy references the node.
+		insufficientVoters := shard.RaftStatus != nil &&
+			shard.RaftStatus.Voters.Contains(nodeID) &&
+			effectiveShardVoterCount(shard) <= 1
+
+		if bypassStuck && !insufficientVoters {
+			status.BypassedGroups = appendUniqueID(status.BypassedGroups, shardID)
+			continue
+		}
+
 		if shard.ReportedBy.Contains(nodeID) {
 			status.Stores[0].GroupStatusCount++
 			status.Stores[0].RuntimeGroupCount++
@@ -399,7 +443,7 @@ func (ms *MetadataStore) buildNodeShutdownStatus(r *http.Request, nodeID types.I
 			if shard.RaftStatus.Voters.Contains(nodeID) {
 				status.Stores[0].LocalVoterCount++
 				status.PendingGroups = appendUniqueID(status.PendingGroups, shardID)
-				if effectiveShardVoterCount(shard) <= 1 {
+				if insufficientVoters {
 					status.Blocked = true
 					status.BlockedReason = "InsufficientShardVoters"
 				}
@@ -420,6 +464,12 @@ func (ms *MetadataStore) buildNodeShutdownStatus(r *http.Request, nodeID types.I
 	switch {
 	case !storeKnown && status.SafeToTerminate:
 		status.Phase = "not_found"
+	case status.SafeToTerminate && len(status.BypassedGroups) > 0:
+		status.Phase = "complete"
+		status.Message = fmt.Sprintf(
+			"drain exceeded %s; bypassing %d shard(s) that the reconciler could not drain",
+			nodeShutdownStuckThreshold, len(status.BypassedGroups),
+		)
 	case status.SafeToTerminate:
 		status.Phase = "complete"
 	case status.Blocked:

--- a/src/metadata/node_shutdown_test.go
+++ b/src/metadata/node_shutdown_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/antflydb/antfly/lib/types"
 	"github.com/antflydb/antfly/src/common"
 	"github.com/antflydb/antfly/src/store"
+	"github.com/antflydb/antfly/src/tablemgr"
 	"github.com/stretchr/testify/require"
 )
 
@@ -54,7 +55,409 @@ func TestNodeShutdownLifecycle(t *testing.T) {
 	statusRec := httptest.NewRecorder()
 	ms.handleNodeShutdownStatus(statusRec, statusReq)
 	require.Equal(t, http.StatusOK, statusRec.Code)
-	require.Contains(t, statusRec.Body.String(), `"phase":"draining"`)
+	require.Contains(t, statusRec.Body.String(), `"phase":"blocked"`)
 	require.Contains(t, statusRec.Body.String(), `"safe_to_terminate":false`)
+	require.Contains(t, statusRec.Body.String(), `"blocked":true`)
+	require.Contains(t, statusRec.Body.String(), `"blocked_reason":"InsufficientShardVoters"`)
 	require.Contains(t, statusRec.Body.String(), `"local_voter_count":1`)
+	require.Contains(t, statusRec.Body.String(), `"pending_groups"`)
+}
+
+func TestNodeShutdownCancellationClearsDrainIntent(t *testing.T) {
+	ms, _ := setupTestMetadataStore(t)
+	nodeID := types.ID(1)
+
+	require.NoError(t, ms.tm.RegisterStore(t.Context(), &store.StoreRegistrationRequest{
+		StoreInfo: store.StoreInfo{ID: nodeID},
+		Shards:    map[types.ID]*store.ShardInfo{},
+	}))
+
+	req := httptest.NewRequest(http.MethodPut, "/internal/v1/nodes/1/shutdown", strings.NewReader(`{"type":"remove"}`))
+	req.SetPathValue("node", "1")
+	rec := httptest.NewRecorder()
+	ms.handleNodeShutdownRequest(rec, req)
+	require.Equal(t, http.StatusAccepted, rec.Code)
+
+	cancelReq := httptest.NewRequest(http.MethodDelete, "/internal/v1/nodes/1/shutdown", nil)
+	cancelReq.SetPathValue("node", "1")
+	cancelRec := httptest.NewRecorder()
+	ms.handleNodeShutdownCancellation(cancelRec, cancelReq)
+	require.Equal(t, http.StatusAccepted, cancelRec.Code)
+
+	tombstoned, err := ms.tm.HasStoreTombstone(t.Context(), nodeID)
+	require.NoError(t, err)
+	require.False(t, tombstoned)
+
+	nodeRecord, err := ms.tm.GetNodeRecord(t.Context(), nodeID)
+	require.NoError(t, err)
+	require.Equal(t, tablemgr.NodeLifecycleActive, nodeRecord.Lifecycle)
+
+	storeStatus, err := ms.tm.GetStoreStatus(t.Context(), nodeID)
+	require.NoError(t, err)
+	require.Equal(t, store.StoreState_Terminating, storeStatus.State)
+
+	statusReq := httptest.NewRequest(http.MethodGet, "/internal/v1/nodes/1/shutdown", nil)
+	statusReq.SetPathValue("node", "1")
+	statusRec := httptest.NewRecorder()
+	ms.handleNodeShutdownStatus(statusRec, statusReq)
+	require.Equal(t, http.StatusOK, statusRec.Code)
+	require.Contains(t, statusRec.Body.String(), `"phase":"recovering"`)
+
+	require.NoError(t, ms.tm.RegisterStore(t.Context(), &store.StoreRegistrationRequest{
+		StoreInfo: store.StoreInfo{ID: nodeID},
+		Shards:    map[types.ID]*store.ShardInfo{},
+	}))
+	statusRec = httptest.NewRecorder()
+	ms.handleNodeShutdownStatus(statusRec, statusReq)
+	require.Equal(t, http.StatusOK, statusRec.Code)
+	require.Contains(t, statusRec.Body.String(), `"phase":"active"`)
+}
+
+func TestNodeShutdownCancellationDoesNotCreateUnknownNode(t *testing.T) {
+	ms, _ := setupTestMetadataStore(t)
+	nodeID := types.ID(99)
+
+	cancelReq := httptest.NewRequest(http.MethodDelete, "/internal/v1/nodes/99/shutdown", nil)
+	cancelReq.SetPathValue("node", "99")
+	cancelRec := httptest.NewRecorder()
+	ms.handleNodeShutdownCancellation(cancelRec, cancelReq)
+	require.Equal(t, http.StatusAccepted, cancelRec.Code)
+
+	_, err := ms.tm.GetNodeRecord(t.Context(), nodeID)
+	require.ErrorIs(t, err, tablemgr.ErrNotFound)
+
+	statusReq := httptest.NewRequest(http.MethodGet, "/internal/v1/nodes/99/shutdown", nil)
+	statusReq.SetPathValue("node", "99")
+	statusRec := httptest.NewRecorder()
+	ms.handleNodeShutdownStatus(statusRec, statusReq)
+	require.Equal(t, http.StatusOK, statusRec.Code)
+	require.Contains(t, statusRec.Body.String(), `"phase":"not_found"`)
+	require.Contains(t, statusRec.Body.String(), `"safe_to_terminate":true`)
+}
+
+func TestDeleteTombstonesSkipsCanceledShutdown(t *testing.T) {
+	ms, _ := setupTestMetadataStore(t)
+	nodeID := types.ID(1)
+
+	require.NoError(t, ms.tm.RegisterStore(t.Context(), &store.StoreRegistrationRequest{
+		StoreInfo: store.StoreInfo{ID: nodeID},
+		Shards:    map[types.ID]*store.ShardInfo{},
+	}))
+	require.NoError(t, ms.tm.RequestNodeShutdown(t.Context(), nodeID, "test drain"))
+	require.NoError(t, ms.tm.ClearStoreTombstone(t.Context(), nodeID))
+	require.NoError(t, ms.tm.DeleteTombstones(t.Context(), []types.ID{nodeID}))
+
+	storeStatus, err := ms.tm.GetStoreStatus(t.Context(), nodeID)
+	require.NoError(t, err)
+	require.Equal(t, nodeID, storeStatus.ID)
+	nodeRecord, err := ms.tm.GetNodeRecord(t.Context(), nodeID)
+	require.NoError(t, err)
+	require.Equal(t, tablemgr.NodeLifecycleActive, nodeRecord.Lifecycle)
+	tombstoned, err := ms.tm.HasStoreTombstone(t.Context(), nodeID)
+	require.NoError(t, err)
+	require.False(t, tombstoned)
+}
+
+func TestDeleteTombstonesPreservesDrainingShutdownUntilFinalized(t *testing.T) {
+	ms, _ := setupTestMetadataStore(t)
+	nodeID := types.ID(1)
+
+	require.NoError(t, ms.tm.RegisterStore(t.Context(), &store.StoreRegistrationRequest{
+		StoreInfo: store.StoreInfo{ID: nodeID},
+		Shards:    map[types.ID]*store.ShardInfo{},
+	}))
+	require.NoError(t, ms.tm.RequestNodeShutdown(t.Context(), nodeID, "operator scale-down"))
+	require.NoError(t, ms.tm.DeleteTombstones(t.Context(), []types.ID{nodeID}))
+
+	storeStatus, err := ms.tm.GetStoreStatus(t.Context(), nodeID)
+	require.NoError(t, err)
+	require.Equal(t, store.StoreState_Terminating, storeStatus.State)
+	nodeRecord, err := ms.tm.GetNodeRecord(t.Context(), nodeID)
+	require.NoError(t, err)
+	require.Equal(t, tablemgr.NodeLifecycleDraining, nodeRecord.Lifecycle)
+	tombstoned, err := ms.tm.HasStoreTombstone(t.Context(), nodeID)
+	require.NoError(t, err)
+	require.True(t, tombstoned)
+
+	finalizeReq := httptest.NewRequest(http.MethodDelete, "/internal/v1/nodes/1", nil)
+	finalizeReq.SetPathValue("node", "1")
+	finalizeRec := httptest.NewRecorder()
+	ms.handleNodeShutdownFinalization(finalizeRec, finalizeReq)
+	require.Equal(t, http.StatusAccepted, finalizeRec.Code)
+
+	_, err = ms.tm.GetStoreStatus(t.Context(), nodeID)
+	require.ErrorIs(t, err, tablemgr.ErrNotFound)
+	_, err = ms.tm.GetNodeRecord(t.Context(), nodeID)
+	require.ErrorIs(t, err, tablemgr.ErrNotFound)
+	tombstoned, err = ms.tm.HasStoreTombstone(t.Context(), nodeID)
+	require.NoError(t, err)
+	require.False(t, tombstoned)
+}
+
+func TestNodeShutdownFinalizationRefusesActiveNode(t *testing.T) {
+	ms, _ := setupTestMetadataStore(t)
+	nodeID := types.ID(1)
+
+	require.NoError(t, ms.tm.RegisterStore(t.Context(), &store.StoreRegistrationRequest{
+		StoreInfo: store.StoreInfo{ID: nodeID},
+		Shards:    map[types.ID]*store.ShardInfo{},
+	}))
+
+	finalizeReq := httptest.NewRequest(http.MethodDelete, "/internal/v1/nodes/1", nil)
+	finalizeReq.SetPathValue("node", "1")
+	finalizeRec := httptest.NewRecorder()
+	ms.handleNodeShutdownFinalization(finalizeRec, finalizeReq)
+	require.Equal(t, http.StatusConflict, finalizeRec.Code)
+
+	storeStatus, err := ms.tm.GetStoreStatus(t.Context(), nodeID)
+	require.NoError(t, err)
+	require.Equal(t, store.StoreState_Healthy, storeStatus.State)
+	nodeRecord, err := ms.tm.GetNodeRecord(t.Context(), nodeID)
+	require.NoError(t, err)
+	require.Equal(t, tablemgr.NodeLifecycleActive, nodeRecord.Lifecycle)
+}
+
+func TestNodeShutdownRequestPreservesLifecycleAtomically(t *testing.T) {
+	ms, _ := setupTestMetadataStore(t)
+	nodeID := types.ID(1)
+
+	req := httptest.NewRequest(http.MethodPut, "/internal/v1/nodes/1/shutdown", strings.NewReader(`{"type":"remove","reason":"test drain"}`))
+	req.SetPathValue("node", "1")
+	rec := httptest.NewRecorder()
+	ms.handleNodeShutdownRequest(rec, req)
+	require.Equal(t, http.StatusAccepted, rec.Code)
+
+	nodeRecord, err := ms.tm.GetNodeRecord(t.Context(), nodeID)
+	require.NoError(t, err)
+	require.Equal(t, tablemgr.NodeLifecycleDraining, nodeRecord.Lifecycle)
+	require.Equal(t, "test drain", nodeRecord.Reason)
+	tombstoned, err := ms.tm.HasStoreTombstone(t.Context(), nodeID)
+	require.NoError(t, err)
+	require.True(t, tombstoned)
+}
+
+func TestNodeShutdownPathUsesDecimalNodeID(t *testing.T) {
+	ms, _ := setupTestMetadataStore(t)
+
+	req := httptest.NewRequest(http.MethodPut, "/internal/v1/nodes/10/shutdown", strings.NewReader(`{"type":"remove"}`))
+	req.SetPathValue("node", "10")
+	rec := httptest.NewRecorder()
+	ms.handleNodeShutdownRequest(rec, req)
+	require.Equal(t, http.StatusAccepted, rec.Code)
+
+	record, err := ms.tm.GetNodeRecord(t.Context(), types.ID(10))
+	require.NoError(t, err)
+	require.Equal(t, tablemgr.NodeLifecycleDraining, record.Lifecycle)
+	_, err = ms.tm.GetNodeRecord(t.Context(), types.ID(16))
+	require.ErrorIs(t, err, tablemgr.ErrNotFound)
+}
+
+func TestNodeShutdownRejectsInvalidType(t *testing.T) {
+	ms, _ := setupTestMetadataStore(t)
+
+	req := httptest.NewRequest(http.MethodPut, "/internal/v1/nodes/1/shutdown", strings.NewReader(`{"type":"restart"}`))
+	req.SetPathValue("node", "1")
+	rec := httptest.NewRecorder()
+	ms.handleNodeShutdownRequest(rec, req)
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestNodeLifecycleEndpointsRejectZeroNodeID(t *testing.T) {
+	ms, _ := setupTestMetadataStore(t)
+
+	statusReq := httptest.NewRequest(http.MethodPost, "/internal/v1/nodes/0/status", strings.NewReader(`{"health_class":"healthy"}`))
+	statusReq.SetPathValue("node", "0")
+	statusRec := httptest.NewRecorder()
+	ms.handleNodeStatus(statusRec, statusReq)
+	require.Equal(t, http.StatusNotFound, statusRec.Code)
+
+	finalizeReq := httptest.NewRequest(http.MethodDelete, "/internal/v1/nodes/0", nil)
+	finalizeReq.SetPathValue("node", "0")
+	finalizeRec := httptest.NewRecorder()
+	ms.handleNodeShutdownFinalization(finalizeRec, finalizeReq)
+	require.Equal(t, http.StatusNotFound, finalizeRec.Code)
+
+	_, err := ms.tm.GetStoreStatus(t.Context(), types.ID(0))
+	require.ErrorIs(t, err, tablemgr.ErrNotFound)
+	_, err = ms.tm.GetNodeRecord(t.Context(), types.ID(0))
+	require.ErrorIs(t, err, tablemgr.ErrNotFound)
+}
+
+func TestNodeShutdownFinalizationRejectsActiveStoreOnlyStatus(t *testing.T) {
+	ms, _ := setupTestMetadataStore(t)
+	nodeID := types.ID(8)
+
+	require.NoError(t, ms.tm.UpdateStatuses(t.Context(), map[types.ID]*tablemgr.StoreStatus{
+		nodeID: {
+			StoreInfo: store.StoreInfo{ID: nodeID},
+			State:     store.StoreState_Healthy,
+			Shards:    map[types.ID]*store.ShardInfo{},
+		},
+	}))
+	_, err := ms.tm.GetNodeRecord(t.Context(), nodeID)
+	require.ErrorIs(t, err, tablemgr.ErrNotFound)
+
+	finalizeReq := httptest.NewRequest(http.MethodDelete, "/internal/v1/nodes/8", nil)
+	finalizeReq.SetPathValue("node", "8")
+	finalizeRec := httptest.NewRecorder()
+	ms.handleNodeShutdownFinalization(finalizeRec, finalizeReq)
+	require.Equal(t, http.StatusConflict, finalizeRec.Code)
+}
+
+func TestNodeShutdownStatusNotFoundIsSafeToTerminate(t *testing.T) {
+	ms, _ := setupTestMetadataStore(t)
+
+	statusReq := httptest.NewRequest(http.MethodGet, "/internal/v1/nodes/1/shutdown", nil)
+	statusReq.SetPathValue("node", "1")
+	statusRec := httptest.NewRecorder()
+	ms.handleNodeShutdownStatus(statusRec, statusReq)
+
+	require.Equal(t, http.StatusOK, statusRec.Code)
+	require.Contains(t, statusRec.Body.String(), `"phase":"not_found"`)
+	require.Contains(t, statusRec.Body.String(), `"safe_to_terminate":true`)
+}
+
+func TestNodeRegistrationPreservesDrainingLifecycle(t *testing.T) {
+	ms, _ := setupTestMetadataStore(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/internal/v1/nodes", strings.NewReader(`{"node_id":1}`))
+	rec := httptest.NewRecorder()
+	ms.handleNodeRegistration(rec, req)
+	require.Equal(t, http.StatusAccepted, rec.Code)
+	record, err := ms.tm.GetNodeRecord(t.Context(), types.ID(1))
+	require.NoError(t, err)
+	require.Equal(t, tablemgr.NodeLifecycleActive, record.Lifecycle)
+
+	shutdownReq := httptest.NewRequest(http.MethodPut, "/internal/v1/nodes/1/shutdown", strings.NewReader(`{"type":"remove"}`))
+	shutdownReq.SetPathValue("node", "1")
+	shutdownRec := httptest.NewRecorder()
+	ms.handleNodeShutdownRequest(shutdownRec, shutdownReq)
+	require.Equal(t, http.StatusAccepted, shutdownRec.Code)
+
+	req = httptest.NewRequest(http.MethodPost, "/internal/v1/nodes", strings.NewReader(`{"node_id":1,"lifecycle":"active"}`))
+	rec = httptest.NewRecorder()
+	ms.handleNodeRegistration(rec, req)
+	require.Equal(t, http.StatusAccepted, rec.Code)
+	record, err = ms.tm.GetNodeRecord(t.Context(), types.ID(1))
+	require.NoError(t, err)
+	require.Equal(t, tablemgr.NodeLifecycleDraining, record.Lifecycle)
+	require.Equal(t, "operator scale-down", record.Reason)
+}
+
+func TestNodeRegistrationRejectsNewDrainingLifecycle(t *testing.T) {
+	ms, _ := setupTestMetadataStore(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/internal/v1/nodes", strings.NewReader(`{"node_id":7,"store_id":7,"lifecycle":"draining"}`))
+	rec := httptest.NewRecorder()
+	ms.handleNodeRegistration(rec, req)
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Contains(t, rec.Body.String(), "node shutdown API")
+	_, err := ms.tm.GetNodeRecord(t.Context(), types.ID(7))
+	require.ErrorIs(t, err, tablemgr.ErrNotFound)
+	_, err = ms.tm.GetStoreStatus(t.Context(), types.ID(7))
+	require.ErrorIs(t, err, tablemgr.ErrNotFound)
+}
+
+func TestNodeRegistrationRejectsMissingNodeIdentity(t *testing.T) {
+	ms, _ := setupTestMetadataStore(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/internal/v1/nodes", strings.NewReader(`{"role":"data"}`))
+	rec := httptest.NewRecorder()
+	ms.handleNodeRegistration(rec, req)
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Contains(t, rec.Body.String(), "node_id")
+	_, err := ms.tm.GetNodeRecord(t.Context(), types.ID(0))
+	require.ErrorIs(t, err, tablemgr.ErrNotFound)
+
+	storeOnlyReq := httptest.NewRequest(http.MethodPost, "/internal/v1/nodes", strings.NewReader(`{"store_id":7,"role":"data"}`))
+	storeOnlyRec := httptest.NewRecorder()
+	ms.handleNodeRegistration(storeOnlyRec, storeOnlyReq)
+
+	require.Equal(t, http.StatusBadRequest, storeOnlyRec.Code)
+	require.Contains(t, storeOnlyRec.Body.String(), "node_id")
+	_, err = ms.tm.GetNodeRecord(t.Context(), types.ID(7))
+	require.ErrorIs(t, err, tablemgr.ErrNotFound)
+	_, err = ms.tm.GetStoreStatus(t.Context(), types.ID(7))
+	require.ErrorIs(t, err, tablemgr.ErrNotFound)
+}
+
+func TestNodeRegistrationUpsertsHostedStore(t *testing.T) {
+	ms, _ := setupTestMetadataStore(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/internal/v1/nodes", strings.NewReader(`{
+		"node_id":7,
+		"store_id":7,
+		"role":"data",
+		"health_class":"healthy",
+		"live":true,
+		"raft_url":"http://store-7:9021",
+		"api_url":"http://store-7:12380",
+		"shards":{}
+	}`))
+	rec := httptest.NewRecorder()
+	ms.handleNodeRegistration(rec, req)
+	require.Equal(t, http.StatusAccepted, rec.Code)
+
+	status, err := ms.tm.GetStoreStatus(t.Context(), types.ID(7))
+	require.NoError(t, err)
+	require.Equal(t, types.ID(7), status.ID)
+	require.Equal(t, "http://store-7:9021", status.RaftURL)
+	require.Equal(t, "http://store-7:12380", status.ApiURL)
+}
+
+func TestNodeStatusUpdatesHostedStore(t *testing.T) {
+	ms, _ := setupTestMetadataStore(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/internal/v1/nodes", strings.NewReader(`{
+		"node_id":7,
+		"store_id":7,
+		"role":"data",
+		"health_class":"healthy",
+		"live":true,
+		"raft_url":"http://store-7:9021",
+		"api_url":"http://store-7:12380"
+	}`))
+	rec := httptest.NewRecorder()
+	ms.handleNodeRegistration(rec, req)
+	require.Equal(t, http.StatusAccepted, rec.Code)
+
+	statusReq := httptest.NewRequest(http.MethodPost, "/internal/v1/nodes/7/status", strings.NewReader(`{
+		"health_class":"degraded",
+		"live":true,
+		"group_statuses":[{"group_id":11,"local_leader":true,"local_voter":true}]
+	}`))
+	statusReq.SetPathValue("node", "7")
+	statusRec := httptest.NewRecorder()
+	ms.handleNodeStatus(statusRec, statusReq)
+	require.Equal(t, http.StatusAccepted, statusRec.Code)
+
+	status, err := ms.tm.GetStoreStatus(t.Context(), types.ID(7))
+	require.NoError(t, err)
+	require.Equal(t, store.StoreState_Unhealthy, status.State)
+	require.Equal(t, "http://store-7:9021", status.RaftURL)
+	require.Contains(t, status.Shards, types.ID(11))
+	require.True(t, status.Shards[types.ID(11)].RaftStatus.Voters.Contains(types.ID(7)))
+	require.Equal(t, types.ID(7), status.Shards[types.ID(11)].RaftStatus.Lead)
+}
+
+func TestNodeStatusRejectsUnknownNode(t *testing.T) {
+	ms, _ := setupTestMetadataStore(t)
+
+	statusReq := httptest.NewRequest(http.MethodPost, "/internal/v1/nodes/7/status", strings.NewReader(`{
+		"health_class":"healthy",
+		"live":true,
+		"group_statuses":[{"group_id":11,"local_leader":true,"local_voter":true}]
+	}`))
+	statusReq.SetPathValue("node", "7")
+	statusRec := httptest.NewRecorder()
+	ms.handleNodeStatus(statusRec, statusReq)
+
+	require.Equal(t, http.StatusNotFound, statusRec.Code)
+	_, err := ms.tm.GetStoreStatus(t.Context(), types.ID(7))
+	require.ErrorIs(t, err, tablemgr.ErrNotFound)
+	_, err = ms.tm.GetNodeRecord(t.Context(), types.ID(7))
+	require.ErrorIs(t, err, tablemgr.ErrNotFound)
 }

--- a/src/metadata/node_shutdown_test.go
+++ b/src/metadata/node_shutdown_test.go
@@ -1,0 +1,60 @@
+package metadata
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/antflydb/antfly/lib/types"
+	"github.com/antflydb/antfly/src/common"
+	"github.com/antflydb/antfly/src/store"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNodeShutdownLifecycle(t *testing.T) {
+	ms, db := setupTestMetadataStore(t)
+	shardID := types.ID(10)
+	nodeID := types.ID(1)
+
+	require.NoError(t, ms.tm.RegisterStore(t.Context(), &store.StoreRegistrationRequest{
+		StoreInfo: store.StoreInfo{ID: nodeID},
+		Shards: map[types.ID]*store.ShardInfo{
+			shardID: {Peers: common.NewPeerSet(nodeID), RaftStatus: &common.RaftStatus{Lead: nodeID, Voters: common.NewPeerSet(nodeID)}},
+		},
+	}))
+	writeShardStatus(t, db, &store.ShardStatus{
+		ID:    shardID,
+		Table: "docs",
+		State: store.ShardState_Default,
+		ShardInfo: store.ShardInfo{
+			Peers:      common.NewPeerSet(nodeID),
+			ReportedBy: common.NewPeerSet(nodeID),
+			RaftStatus: &common.RaftStatus{Lead: nodeID, Voters: common.NewPeerSet(nodeID)},
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodPut, "/internal/v1/nodes/1/shutdown", strings.NewReader(`{"type":"remove"}`))
+	req.SetPathValue("node", "1")
+	rec := httptest.NewRecorder()
+	ms.handleNodeShutdownRequest(rec, req)
+	require.Equal(t, http.StatusAccepted, rec.Code)
+
+	// Registration after shutdown intent must not clear the durable drain state.
+	require.NoError(t, ms.tm.RegisterStore(t.Context(), &store.StoreRegistrationRequest{
+		StoreInfo: store.StoreInfo{ID: nodeID},
+		Shards:    map[types.ID]*store.ShardInfo{},
+	}))
+	storeStatus, err := ms.tm.GetStoreStatus(t.Context(), nodeID)
+	require.NoError(t, err)
+	require.Equal(t, store.StoreState_Terminating, storeStatus.State)
+
+	statusReq := httptest.NewRequest(http.MethodGet, "/internal/v1/nodes/1/shutdown", nil)
+	statusReq.SetPathValue("node", "1")
+	statusRec := httptest.NewRecorder()
+	ms.handleNodeShutdownStatus(statusRec, statusReq)
+	require.Equal(t, http.StatusOK, statusRec.Code)
+	require.Contains(t, statusRec.Body.String(), `"phase":"draining"`)
+	require.Contains(t, statusRec.Body.String(), `"safe_to_terminate":false`)
+	require.Contains(t, statusRec.Body.String(), `"local_voter_count":1`)
+}

--- a/src/metadata/node_shutdown_test.go
+++ b/src/metadata/node_shutdown_test.go
@@ -1,6 +1,7 @@
 package metadata
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -61,6 +62,82 @@ func TestNodeShutdownLifecycle(t *testing.T) {
 	require.Contains(t, statusRec.Body.String(), `"blocked_reason":"InsufficientShardVoters"`)
 	require.Contains(t, statusRec.Body.String(), `"local_voter_count":1`)
 	require.Contains(t, statusRec.Body.String(), `"pending_groups"`)
+}
+
+func TestNodeShutdownStatusIgnoresFrozenTerminatingStoreShards(t *testing.T) {
+	ms, _ := setupTestMetadataStore(t)
+	shardID := types.ID(10)
+	nodeID := types.ID(1)
+
+	require.NoError(t, ms.tm.RegisterStore(t.Context(), &store.StoreRegistrationRequest{
+		StoreInfo: store.StoreInfo{ID: nodeID},
+		Shards: map[types.ID]*store.ShardInfo{
+			shardID: {Peers: common.NewPeerSet(nodeID), RaftStatus: &common.RaftStatus{Lead: nodeID, Voters: common.NewPeerSet(nodeID)}},
+		},
+	}))
+
+	req := httptest.NewRequest(http.MethodPut, "/internal/v1/nodes/1/shutdown", strings.NewReader(`{"type":"remove"}`))
+	req.SetPathValue("node", "1")
+	rec := httptest.NewRecorder()
+	ms.handleNodeShutdownRequest(rec, req)
+	require.Equal(t, http.StatusAccepted, rec.Code)
+
+	storeStatus, err := ms.tm.GetStoreStatus(t.Context(), nodeID)
+	require.NoError(t, err)
+	require.Equal(t, store.StoreState_Terminating, storeStatus.State)
+	require.Contains(t, storeStatus.Shards, shardID)
+
+	statusReq := httptest.NewRequest(http.MethodGet, "/internal/v1/nodes/1/shutdown", nil)
+	statusReq.SetPathValue("node", "1")
+	statusRec := httptest.NewRecorder()
+	ms.handleNodeShutdownStatus(statusRec, statusReq)
+	require.Equal(t, http.StatusOK, statusRec.Code)
+
+	var status nodeShutdownStatus
+	require.NoError(t, json.Unmarshal(statusRec.Body.Bytes(), &status))
+	require.Equal(t, "complete", status.Phase)
+	require.True(t, status.SafeToTerminate)
+	require.Equal(t, 0, status.Stores[0].GroupStatusCount)
+	require.Equal(t, 0, status.Stores[0].RuntimeGroupCount)
+}
+
+func TestNodeShutdownStatusUsesGroupStatusVoterCount(t *testing.T) {
+	ms, db := setupTestMetadataStore(t)
+	shardID := types.ID(10)
+	nodeID := types.ID(1)
+
+	shards := nodeGroupStatusReportsToShards(nodeID, []nodeGroupStatusReport{{
+		GroupID:     uint64(shardID),
+		LocalLeader: true,
+		LocalVoter:  true,
+		VoterCount:  3,
+	}})
+	require.Equal(t, 3, shards[shardID].VoterCount)
+	writeShardStatus(t, db, &store.ShardStatus{
+		ID:        shardID,
+		Table:     "docs",
+		State:     store.ShardState_Default,
+		ShardInfo: *shards[shardID],
+	})
+
+	req := httptest.NewRequest(http.MethodPut, "/internal/v1/nodes/1/shutdown", strings.NewReader(`{"type":"remove"}`))
+	req.SetPathValue("node", "1")
+	rec := httptest.NewRecorder()
+	ms.handleNodeShutdownRequest(rec, req)
+	require.Equal(t, http.StatusAccepted, rec.Code)
+
+	statusReq := httptest.NewRequest(http.MethodGet, "/internal/v1/nodes/1/shutdown", nil)
+	statusReq.SetPathValue("node", "1")
+	statusRec := httptest.NewRecorder()
+	ms.handleNodeShutdownStatus(statusRec, statusReq)
+	require.Equal(t, http.StatusOK, statusRec.Code)
+
+	var status nodeShutdownStatus
+	require.NoError(t, json.Unmarshal(statusRec.Body.Bytes(), &status))
+	require.Equal(t, "draining", status.Phase)
+	require.False(t, status.Blocked)
+	require.Empty(t, status.BlockedReason)
+	require.Equal(t, 1, status.Stores[0].LocalVoterCount)
 }
 
 func TestNodeShutdownCancellationClearsDrainIntent(t *testing.T) {

--- a/src/metadata/node_shutdown_test.go
+++ b/src/metadata/node_shutdown_test.go
@@ -1,11 +1,13 @@
 package metadata
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/antflydb/antfly/lib/types"
 	"github.com/antflydb/antfly/src/common"
@@ -518,6 +520,162 @@ func TestNodeStatusUpdatesHostedStore(t *testing.T) {
 	require.Contains(t, status.Shards, types.ID(11))
 	require.True(t, status.Shards[types.ID(11)].RaftStatus.Voters.Contains(types.ID(7)))
 	require.Equal(t, types.ID(7), status.Shards[types.ID(11)].RaftStatus.Lead)
+}
+
+// backdateDrainingSince rewrites the persisted NodeRecord so that the test
+// can simulate a drain that has been running long enough to exceed
+// nodeShutdownStuckThreshold.
+func backdateDrainingSince(t *testing.T, ms *MetadataStore, db interface {
+	Batch(ctx context.Context, writes [][2][]byte, deletes [][]byte) error
+}, nodeID types.ID, since time.Time) {
+	t.Helper()
+	record, err := ms.tm.GetNodeRecord(t.Context(), nodeID)
+	require.NoError(t, err)
+	record.DrainingSince = since
+	data, err := json.Marshal(record)
+	require.NoError(t, err)
+	require.NoError(t, db.Batch(t.Context(),
+		[][2][]byte{{[]byte("tm:nr:" + nodeID.String()), data}},
+		nil,
+	))
+}
+
+func TestNodeShutdownStatusBypassesStuckShardsAfterThreshold(t *testing.T) {
+	ms, db := setupTestMetadataStore(t)
+	shardID := types.ID(10)
+	nodeID := types.ID(1)
+	otherA := types.ID(2)
+	otherB := types.ID(3)
+
+	// Three-voter shard so removing nodeID leaves quorum (2 voters >= 1).
+	require.NoError(t, ms.tm.RegisterStore(t.Context(), &store.StoreRegistrationRequest{
+		StoreInfo: store.StoreInfo{ID: nodeID},
+		Shards: map[types.ID]*store.ShardInfo{
+			shardID: {
+				Peers:      common.NewPeerSet(nodeID, otherA, otherB),
+				ReportedBy: common.NewPeerSet(nodeID, otherA, otherB),
+				RaftStatus: &common.RaftStatus{Lead: otherA, Voters: common.NewPeerSet(nodeID, otherA, otherB)},
+			},
+		},
+	}))
+	writeShardStatus(t, db, &store.ShardStatus{
+		ID: shardID, Table: "docs", State: store.ShardState_Default,
+		ShardInfo: store.ShardInfo{
+			Peers:      common.NewPeerSet(nodeID, otherA, otherB),
+			ReportedBy: common.NewPeerSet(nodeID, otherA, otherB),
+			VoterCount: 3,
+			RaftStatus: &common.RaftStatus{Lead: otherA, Voters: common.NewPeerSet(nodeID, otherA, otherB)},
+		},
+	})
+
+	// Request shutdown — node enters Draining with DrainingSince=now.
+	require.NoError(t, ms.tm.RequestNodeShutdown(t.Context(), nodeID, "test"))
+
+	// Within the threshold the shard still counts: SafeToTerminate stays false.
+	statusReq := httptest.NewRequest(http.MethodGet, "/internal/v1/nodes/1/shutdown", nil)
+	statusReq.SetPathValue("node", "1")
+	statusRec := httptest.NewRecorder()
+	ms.handleNodeShutdownStatus(statusRec, statusReq)
+	require.Equal(t, http.StatusOK, statusRec.Code)
+	var status nodeShutdownStatus
+	require.NoError(t, json.Unmarshal(statusRec.Body.Bytes(), &status))
+	require.False(t, status.SafeToTerminate)
+	require.Equal(t, "draining", status.Phase)
+	require.Empty(t, status.BypassedGroups)
+
+	// Backdate so the drain has exceeded the threshold.
+	backdateDrainingSince(t, ms, db, nodeID, time.Now().Add(-2*nodeShutdownStuckThreshold))
+
+	statusRec = httptest.NewRecorder()
+	ms.handleNodeShutdownStatus(statusRec, statusReq)
+	require.Equal(t, http.StatusOK, statusRec.Code)
+	require.NoError(t, json.Unmarshal(statusRec.Body.Bytes(), &status))
+	require.True(t, status.SafeToTerminate)
+	require.Equal(t, "complete", status.Phase)
+	require.Contains(t, status.BypassedGroups, shardID)
+	require.Equal(t, 0, status.Stores[0].PlacementIntentCount)
+	require.Equal(t, 0, status.Stores[0].LocalVoterCount)
+	require.Contains(t, status.Message, "drain exceeded")
+}
+
+func TestNodeShutdownStatusDoesNotBypassQuorumLossShards(t *testing.T) {
+	ms, db := setupTestMetadataStore(t)
+	shardID := types.ID(10)
+	nodeID := types.ID(1)
+
+	// Single-voter shard: removing this node would leave 0 voters.
+	require.NoError(t, ms.tm.RegisterStore(t.Context(), &store.StoreRegistrationRequest{
+		StoreInfo: store.StoreInfo{ID: nodeID},
+		Shards: map[types.ID]*store.ShardInfo{
+			shardID: {
+				Peers:      common.NewPeerSet(nodeID),
+				ReportedBy: common.NewPeerSet(nodeID),
+				RaftStatus: &common.RaftStatus{Lead: nodeID, Voters: common.NewPeerSet(nodeID)},
+			},
+		},
+	}))
+	writeShardStatus(t, db, &store.ShardStatus{
+		ID: shardID, Table: "docs", State: store.ShardState_Default,
+		ShardInfo: store.ShardInfo{
+			Peers:      common.NewPeerSet(nodeID),
+			ReportedBy: common.NewPeerSet(nodeID),
+			VoterCount: 1,
+			RaftStatus: &common.RaftStatus{Lead: nodeID, Voters: common.NewPeerSet(nodeID)},
+		},
+	})
+
+	require.NoError(t, ms.tm.RequestNodeShutdown(t.Context(), nodeID, "test"))
+	backdateDrainingSince(t, ms, db, nodeID, time.Now().Add(-2*nodeShutdownStuckThreshold))
+
+	statusReq := httptest.NewRequest(http.MethodGet, "/internal/v1/nodes/1/shutdown", nil)
+	statusReq.SetPathValue("node", "1")
+	statusRec := httptest.NewRecorder()
+	ms.handleNodeShutdownStatus(statusRec, statusReq)
+	require.Equal(t, http.StatusOK, statusRec.Code)
+
+	var status nodeShutdownStatus
+	require.NoError(t, json.Unmarshal(statusRec.Body.Bytes(), &status))
+	require.False(t, status.SafeToTerminate, "must not bypass shards that would lose quorum")
+	require.True(t, status.Blocked)
+	require.Equal(t, "InsufficientShardVoters", status.BlockedReason)
+	require.Empty(t, status.BypassedGroups)
+}
+
+func TestRequestNodeShutdownPreservesDrainingSince(t *testing.T) {
+	ms, _ := setupTestMetadataStore(t)
+	nodeID := types.ID(1)
+
+	require.NoError(t, ms.tm.RegisterStore(t.Context(), &store.StoreRegistrationRequest{
+		StoreInfo: store.StoreInfo{ID: nodeID},
+	}))
+
+	require.NoError(t, ms.tm.RequestNodeShutdown(t.Context(), nodeID, "first"))
+	first, err := ms.tm.GetNodeRecord(t.Context(), nodeID)
+	require.NoError(t, err)
+	require.False(t, first.DrainingSince.IsZero())
+
+	time.Sleep(2 * time.Millisecond)
+	require.NoError(t, ms.tm.RequestNodeShutdown(t.Context(), nodeID, "second"))
+	second, err := ms.tm.GetNodeRecord(t.Context(), nodeID)
+	require.NoError(t, err)
+	require.Equal(t, first.DrainingSince, second.DrainingSince,
+		"DrainingSince must be preserved across re-requested shutdowns")
+}
+
+func TestClearStoreTombstoneClearsDrainingSince(t *testing.T) {
+	ms, _ := setupTestMetadataStore(t)
+	nodeID := types.ID(1)
+
+	require.NoError(t, ms.tm.RegisterStore(t.Context(), &store.StoreRegistrationRequest{
+		StoreInfo: store.StoreInfo{ID: nodeID},
+	}))
+	require.NoError(t, ms.tm.RequestNodeShutdown(t.Context(), nodeID, "go"))
+	require.NoError(t, ms.tm.ClearStoreTombstone(t.Context(), nodeID))
+
+	record, err := ms.tm.GetNodeRecord(t.Context(), nodeID)
+	require.NoError(t, err)
+	require.Equal(t, tablemgr.NodeLifecycleActive, record.Lifecycle)
+	require.True(t, record.DrainingSince.IsZero())
 }
 
 func TestNodeStatusRejectsUnknownNode(t *testing.T) {

--- a/src/metadata/reconciler/executor.go
+++ b/src/metadata/reconciler/executor.go
@@ -197,6 +197,13 @@ func (r *Reconciler) ExecutePlan(
 }
 
 // executeRemovedStorePeerRemovals removes tombstoned stores from shards where they are still voters
+// removedStorePeerRemovalTimeout bounds how long a single peer-removal RPC may
+// take. The store-side HTTP transport has a 5-minute ResponseHeaderTimeout, but
+// when the leader's local Raft group for the shard has already stopped it
+// cannot reply at all, so we cap the per-shard wait well below that to keep
+// reconciliation cycles responsive.
+const removedStorePeerRemovalTimeout = 30 * time.Second
+
 func (r *Reconciler) executeRemovedStorePeerRemovals(
 	ctx context.Context,
 	removedStores []types.ID,
@@ -227,7 +234,10 @@ func (r *Reconciler) executeRemovedStorePeerRemovals(
 
 			// Need to remove this peer from the shard
 			eg.Go(func() error {
-				leaderClient, err := r.storeOps.GetLeaderClientForShard(egCtx, shardID)
+				attemptCtx, cancel := context.WithTimeout(egCtx, removedStorePeerRemovalTimeout)
+				defer cancel()
+
+				leaderClient, err := r.storeOps.GetLeaderClientForShard(attemptCtx, shardID)
 				if err != nil {
 					r.logger.Warn(
 						"Failed to find leader for shard for removal",
@@ -246,14 +256,43 @@ func (r *Reconciler) executeRemovedStorePeerRemovals(
 				// Use sync removal (async=false) to wait for the conf change to be applied.
 				// This ensures the removed store is actually removed from the Raft voters
 				// before we proceed, preventing races in reconciliation.
-				if err := r.shardOps.RemovePeer(ctx, shardID, leaderClient, removedStore, false); err != nil {
+				err = r.shardOps.RemovePeer(attemptCtx, shardID, leaderClient, removedStore, false)
+				if err == nil {
+					return nil
+				}
+				switch {
+				case errors.Is(err, client.ErrRaftStopped),
+					errors.Is(err, client.ErrNotFound),
+					errors.Is(err, client.ErrShardNotReady):
+					// The leader's local Raft group for this shard is gone (or the
+					// shard is not yet/no longer present). The peer is effectively
+					// removed for that node; the next status report will reflect
+					// it once the surviving replicas re-elect a leader.
+					r.logger.Info(
+						"Skipping peer removal: leader cannot serve the shard",
+						zap.Stringer("removedStore", removedStore),
+						zap.Stringer("shardID", shardID),
+						zap.Stringer("leaderID", leaderClient.ID()),
+						zap.Error(err),
+					)
+				case errors.Is(err, context.Canceled),
+					errors.Is(err, context.DeadlineExceeded):
+					// Per-shard timeout expired or the parent reconciliation was
+					// cancelled. Retry on the next cycle.
+					r.logger.Warn(
+						"Peer removal timed out; will retry next reconciliation",
+						zap.Stringer("removedStore", removedStore),
+						zap.Stringer("shardID", shardID),
+						zap.Stringer("leaderID", leaderClient.ID()),
+						zap.Error(err),
+					)
+				default:
 					r.logger.Warn(
 						"Failed to remove peer from shard",
 						zap.Stringer("removedStore", removedStore),
 						zap.Stringer("shardID", shardID),
 						zap.Error(err),
 					)
-					return nil
 				}
 				return nil
 			})

--- a/src/metadata/reconciler/executor_test.go
+++ b/src/metadata/reconciler/executor_test.go
@@ -217,6 +217,78 @@ func TestExecutePlan_RemovedStoreCleanup(t *testing.T) {
 		mockStoreOps.AssertNotCalled(t, "GetLeaderClientForShard")
 		mockShardOps.AssertNotCalled(t, "RemovePeer")
 	})
+
+	// When the leader's local Raft for a shard has stopped (e.g., the leader
+	// already had its peer ID removed earlier), RemovePeer returns
+	// client.ErrRaftStopped. The reconciler must classify this as a
+	// recoverable, expected condition: log it and let the next reconciliation
+	// re-evaluate, rather than retrying every cycle until the test times out.
+	t.Run("classifies raft-stopped as recoverable", func(t *testing.T) {
+		mockShardOps := &MockShardOperations{}
+		mockTableOps := &MockTableOperations{}
+		mockStoreOps := &MockStoreOperations{}
+
+		removedStore := types.ID(100)
+		shardID := types.ID(1)
+		leaderClient := &client.StoreClient{}
+
+		current := CurrentClusterState{
+			Shards: map[types.ID]*store.ShardInfo{
+				shardID: {
+					RaftStatus: &common.RaftStatus{
+						Voters: common.NewPeerSet(1, 2, removedStore),
+					},
+				},
+			},
+		}
+		plan := &ReconciliationPlan{RemovedStorePeerRemovals: []types.ID{removedStore}}
+
+		mockStoreOps.On("GetLeaderClientForShard", mock.Anything, shardID).Return(leaderClient, nil)
+		mockShardOps.On("RemovePeer", mock.Anything, shardID, leaderClient, removedStore, false).
+			Return(fmt.Errorf("removing peer: %w",
+				&client.ResponseError{StatusCode: 500, Body: "Failed to apply conf change: proposing confChange to raft: raft: stopped"}))
+
+		reconciler := NewReconciler(
+			mockShardOps, mockTableOps, mockStoreOps,
+			ReconciliationConfig{ReplicationFactor: 2}, zap.NewNop(),
+		)
+		err := reconciler.ExecutePlan(context.Background(), plan, current, DesiredClusterState{})
+		// Errors are swallowed so reconciliation can keep making progress on
+		// other shards in subsequent cycles.
+		assert.NoError(t, err)
+
+		mockStoreOps.AssertExpectations(t)
+		mockShardOps.AssertExpectations(t)
+	})
+
+	t.Run("classifies shard-not-found as recoverable", func(t *testing.T) {
+		mockShardOps := &MockShardOperations{}
+		mockTableOps := &MockTableOperations{}
+		mockStoreOps := &MockStoreOperations{}
+
+		removedStore := types.ID(100)
+		shardID := types.ID(1)
+		leaderClient := &client.StoreClient{}
+
+		current := CurrentClusterState{
+			Shards: map[types.ID]*store.ShardInfo{
+				shardID: {RaftStatus: &common.RaftStatus{Voters: common.NewPeerSet(1, 2, removedStore)}},
+			},
+		}
+		plan := &ReconciliationPlan{RemovedStorePeerRemovals: []types.ID{removedStore}}
+
+		mockStoreOps.On("GetLeaderClientForShard", mock.Anything, shardID).Return(leaderClient, nil)
+		mockShardOps.On("RemovePeer", mock.Anything, shardID, leaderClient, removedStore, false).
+			Return(fmt.Errorf("removing peer: %w",
+				&client.ResponseError{StatusCode: 404, Body: "Shard not found"}))
+
+		reconciler := NewReconciler(
+			mockShardOps, mockTableOps, mockStoreOps,
+			ReconciliationConfig{ReplicationFactor: 2}, zap.NewNop(),
+		)
+		err := reconciler.ExecutePlan(context.Background(), plan, current, DesiredClusterState{})
+		assert.NoError(t, err)
+	})
 }
 
 func TestResolveMergeSeedArchiveFile(t *testing.T) {

--- a/src/metadata/runner_test.go
+++ b/src/metadata/runner_test.go
@@ -149,7 +149,7 @@ func TestCombinedAPIServerRouting(t *testing.T) {
 // are not accessible without the /internal/v1/ prefix.
 func TestInternalRoutesNotAccessibleAtRoot(t *testing.T) {
 	internalMux := http.NewServeMux()
-	internalMux.HandleFunc("POST /store", func(w http.ResponseWriter, r *http.Request) {
+	internalMux.HandleFunc("POST /nodes", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
 
@@ -157,7 +157,7 @@ func TestInternalRoutesNotAccessibleAtRoot(t *testing.T) {
 	apiRoutes.Handle("/internal/v1/", http.StripPrefix("/internal/v1", internalMux))
 
 	// Try to access the route without the prefix
-	req := httptest.NewRequest("POST", "/store", nil)
+	req := httptest.NewRequest("POST", "/nodes", nil)
 	rec := httptest.NewRecorder()
 
 	apiRoutes.ServeHTTP(rec, req)
@@ -166,7 +166,7 @@ func TestInternalRoutesNotAccessibleAtRoot(t *testing.T) {
 		"Expected 404 for route without prefix")
 
 	// Now try with the correct prefix
-	req = httptest.NewRequest("POST", "/internal/v1/store", nil)
+	req = httptest.NewRequest("POST", "/internal/v1/nodes", nil)
 	rec = httptest.NewRecorder()
 
 	apiRoutes.ServeHTTP(rec, req)

--- a/src/metadata/runner_test.go
+++ b/src/metadata/runner_test.go
@@ -55,6 +55,13 @@ func TestCombinedAPIServerRouting(t *testing.T) {
 	// Add metadata store API routes
 	api := kv.NewMetadataStoreAPI(logger, nil)
 	api.AddRoutes(internalMux)
+	metadataMux := http.NewServeMux()
+	metadataMux.HandleFunc("GET /status", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		if _, err := w.Write([]byte("metadata")); err != nil {
+			logger.Error("failed to write response", zap.Error(err))
+		}
+	})
 
 	// Create public API routes
 	publicMux := http.NewServeMux()
@@ -67,6 +74,9 @@ func TestCombinedAPIServerRouting(t *testing.T) {
 
 	// Combined router (mimicking the structure in runner.go)
 	apiRoutes := http.NewServeMux()
+	apiRoutes.Handle("/metadata/v1/", http.StripPrefix("/metadata/v1", metadataMux))
+	apiRoutes.Handle("/internal/v1/", http.StripPrefix("/internal/v1", internalMux))
+	// Compatibility aliases.
 	apiRoutes.Handle("/api/v1/", http.StripPrefix("/api/v1", publicMux))
 	apiRoutes.Handle("/_internal/v1/", http.StripPrefix("/_internal/v1", internalMux))
 
@@ -76,14 +86,20 @@ func TestCombinedAPIServerRouting(t *testing.T) {
 		path           string
 		expectedStatus int
 		expectedBody   string
-		skipExecution  bool // Skip actual handler execution (would panic with nil store)
 	}{
 		{
-			name:           "internal route accessible at /_internal/v1/",
+			name:           "internal route accessible at /internal/v1/",
 			method:         "POST",
-			path:           "/_internal/v1/test-internal",
+			path:           "/internal/v1/test-internal",
 			expectedStatus: http.StatusOK,
 			expectedBody:   "internal",
+		},
+		{
+			name:           "metadata route accessible at /metadata/v1/",
+			method:         "GET",
+			path:           "/metadata/v1/status",
+			expectedStatus: http.StatusOK,
+			expectedBody:   "metadata",
 		},
 		{
 			name:           "public route accessible at /api/v1/",
@@ -93,10 +109,17 @@ func TestCombinedAPIServerRouting(t *testing.T) {
 			expectedBody:   "public",
 		},
 		{
-			name:           "metadata store batch endpoint at /_internal/v1/batch",
+			name:           "metadata store batch endpoint at /internal/v1/batch",
 			method:         "POST",
-			path:           "/_internal/v1/batch",
+			path:           "/internal/v1/batch",
 			expectedStatus: http.StatusBadRequest, // No body, so will fail parsing
+		},
+		{
+			name:           "legacy internal route accessible at /_internal/v1/",
+			method:         "POST",
+			path:           "/_internal/v1/test-internal",
+			expectedStatus: http.StatusOK,
+			expectedBody:   "internal",
 		},
 		{
 			name:           "non-existent route returns 404",
@@ -123,7 +146,7 @@ func TestCombinedAPIServerRouting(t *testing.T) {
 }
 
 // TestInternalRoutesNotAccessibleAtRoot verifies that internal routes
-// are not accessible without the /_internal/v1/ prefix
+// are not accessible without the /internal/v1/ prefix.
 func TestInternalRoutesNotAccessibleAtRoot(t *testing.T) {
 	internalMux := http.NewServeMux()
 	internalMux.HandleFunc("POST /store", func(w http.ResponseWriter, r *http.Request) {
@@ -131,7 +154,7 @@ func TestInternalRoutesNotAccessibleAtRoot(t *testing.T) {
 	})
 
 	apiRoutes := http.NewServeMux()
-	apiRoutes.Handle("/_internal/v1/", http.StripPrefix("/_internal/v1", internalMux))
+	apiRoutes.Handle("/internal/v1/", http.StripPrefix("/internal/v1", internalMux))
 
 	// Try to access the route without the prefix
 	req := httptest.NewRequest("POST", "/store", nil)
@@ -143,11 +166,11 @@ func TestInternalRoutesNotAccessibleAtRoot(t *testing.T) {
 		"Expected 404 for route without prefix")
 
 	// Now try with the correct prefix
-	req = httptest.NewRequest("POST", "/_internal/v1/store", nil)
+	req = httptest.NewRequest("POST", "/internal/v1/store", nil)
 	rec = httptest.NewRecorder()
 
 	apiRoutes.ServeHTTP(rec, req)
 
 	assert.NotEqual(t, http.StatusNotFound, rec.Code,
-		"Expected route to be found with /_internal/v1/ prefix")
+		"Expected route to be found with /internal/v1/ prefix")
 }

--- a/src/metadata/runtime.go
+++ b/src/metadata/runtime.go
@@ -423,6 +423,8 @@ func (r *Runtime) newHTTPHandler() http.Handler {
 	internalMux := http.NewServeMux()
 	internalMux.HandleFunc("POST /store", r.node.handleStoreRegistration)
 	internalMux.HandleFunc("DELETE /store/{store}", r.node.handleStoreDeregistration)
+	internalMux.HandleFunc("PUT /nodes/{node}/shutdown", r.node.handleNodeShutdownRequest)
+	internalMux.HandleFunc("GET /nodes/{node}/shutdown", r.node.handleNodeShutdownStatus)
 	internalMux.HandleFunc("POST /shard/{shardID}/txn/resolve", r.node.handleForwardResolveIntent)
 
 	api := kv.NewMetadataStoreAPI(r.logger, r.metadataStore)

--- a/src/metadata/runtime.go
+++ b/src/metadata/runtime.go
@@ -421,10 +421,13 @@ func newMetadataLeaderFactory(
 
 func (r *Runtime) newHTTPHandler() http.Handler {
 	internalMux := http.NewServeMux()
-	internalMux.HandleFunc("POST /store", r.node.handleStoreRegistration)
-	internalMux.HandleFunc("DELETE /store/{store}", r.node.handleStoreDeregistration)
+	internalMux.HandleFunc("POST /nodes", r.node.handleNodeRegistration)
+	internalMux.HandleFunc("GET /nodes/{node}", r.node.handleNodeRecord)
+	internalMux.HandleFunc("POST /nodes/{node}/status", r.node.handleNodeStatus)
 	internalMux.HandleFunc("PUT /nodes/{node}/shutdown", r.node.handleNodeShutdownRequest)
 	internalMux.HandleFunc("GET /nodes/{node}/shutdown", r.node.handleNodeShutdownStatus)
+	internalMux.HandleFunc("DELETE /nodes/{node}/shutdown", r.node.handleNodeShutdownCancellation)
+	internalMux.HandleFunc("DELETE /nodes/{node}", r.node.handleNodeShutdownFinalization)
 	internalMux.HandleFunc("POST /shard/{shardID}/txn/resolve", r.node.handleForwardResolveIntent)
 
 	api := kv.NewMetadataStoreAPI(r.logger, r.metadataStore)

--- a/src/metadata/runtime.go
+++ b/src/metadata/runtime.go
@@ -429,8 +429,14 @@ func (r *Runtime) newHTTPHandler() http.Handler {
 	api.AddRoutes(internalMux)
 	internalMux.HandleFunc("POST /reallocate", r.node.handleReallocateShards)
 
+	metadataMux := http.NewServeMux()
+	api.AddMetadataRoutes(metadataMux)
+
 	publicMux := r.node.publicApiRoutes()
 	apiRoutes := http.NewServeMux()
+	apiRoutes.Handle("/metadata/v1/", http.StripPrefix("/metadata/v1", metadataMux))
+	apiRoutes.Handle("/internal/v1/", http.StripPrefix("/internal/v1", internalMux))
+	// Compatibility aliases for clients using the pre-consolidation path scheme.
 	apiRoutes.Handle("/api/v1/", http.StripPrefix("/api/v1", publicMux))
 	apiRoutes.Handle("/_internal/v1/", http.StripPrefix("/_internal/v1", internalMux))
 	addAntfarmRoutes(apiRoutes)

--- a/src/metadata/simulator.go
+++ b/src/metadata/simulator.go
@@ -111,7 +111,7 @@ func (ms *MetadataStore) ReconcileOnce(ctx context.Context) {
 // store shard notifier during in-process simulation.
 func (ms *MetadataStore) InternalHandler() http.Handler {
 	mux := http.NewServeMux()
-	mux.HandleFunc("POST /_internal/v1/shard/{shardID}/txn/resolve", ms.handleForwardResolveIntent)
+	mux.HandleFunc("POST /internal/v1/shard/{shardID}/txn/resolve", ms.handleForwardResolveIntent)
 	return mux
 }
 

--- a/src/store/api.go
+++ b/src/store/api.go
@@ -1515,7 +1515,7 @@ func (h *StoreAPI) handleConfChange(w http.ResponseWriter, r *http.Request) {
 			zap.Uint64("nodeID", nodeID),
 			zap.Stringer("shardID", shardID),
 			zap.String("context", req.PeerURL))
-		if err := shard.ProposeConfChange(cc); err != nil {
+		if err := shard.ProposeConfChange(r.Context(), cc); err != nil {
 			h.logger.Error("Failed to propose conf change for adding node",
 				zap.Uint64("nodeID", nodeID),
 				zap.Stringer("shardID", shardID),
@@ -1589,7 +1589,7 @@ func (h *StoreAPI) handleConfChange(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 		} else {
-			if err := shard.ProposeConfChange(cc); err != nil {
+			if err := shard.ProposeConfChange(r.Context(), cc); err != nil {
 				h.logger.Error("Failed to propose conf change for removing node",
 					zap.Uint64("nodeID", nodeID),
 					zap.Stringer("shardID", shardID),

--- a/src/store/api_test.go
+++ b/src/store/api_test.go
@@ -206,9 +206,10 @@ func (m *MockShard) Scan(
 }
 
 func (m *MockShard) ProposeConfChange(
+	ctx context.Context,
 	cc raftpb.ConfChange,
 ) error { // Assuming raftpb is imported or not needed for this test
-	m.Called(cc)
+	m.Called(ctx, cc)
 	return nil
 }
 

--- a/src/store/client/errors.go
+++ b/src/store/client/errors.go
@@ -36,6 +36,10 @@ var (
 	ErrShardNotReady     = errors.New("shard not ready")
 	ErrNoHealthyPeer     = errors.New("no healthy peer")
 	ErrNoRaftStatus      = errors.New("no raft status")
+	// ErrRaftStopped indicates the targeted peer's local Raft group for the
+	// shard has stopped, so it cannot accept conf changes. The peer is
+	// effectively gone for that shard even if metadata still lists it.
+	ErrRaftStopped = errors.New("raft stopped")
 )
 
 // ResponseError represents an error response from a store node.
@@ -78,6 +82,8 @@ func (e *ResponseError) Is(target error) bool {
 		return strings.Contains(bodyLower, "no healthy peer")
 	case errors.Is(target, ErrNoRaftStatus):
 		return strings.Contains(bodyLower, "no raft status")
+	case errors.Is(target, ErrRaftStopped):
+		return strings.Contains(bodyLower, "raft: stopped") || strings.Contains(bodyLower, "raft stopped")
 	}
 	return false
 }

--- a/src/store/db/db.go
+++ b/src/store/db/db.go
@@ -411,8 +411,8 @@ type DBImpl struct {
 
 	// traceWriter emits TLA+ trace events for transaction validation.
 	// Non-nil only when built with -tags with_tla.
-	traceWriter      tracing.AntflyTraceWriter
-	traceShardIDStr  string // cached shard ID for trace events; set lazily
+	traceWriter     tracing.AntflyTraceWriter
+	traceShardIDStr string // cached shard ID for trace events; set lazily
 
 	cache *pebbleutils.Cache // shared Pebble block cache (may be nil)
 }
@@ -1617,7 +1617,13 @@ func (db *DBImpl) getPebbleOpts() (*pebble.Options, error) {
 	cacheSize := DefaultPebbleCacheSizeMB << 20 // Convert MB to bytes
 
 	pebbleOpts := &pebble.Options{
-		Logger: &logger.NoopLoggerAndTracer{},
+		Logger:          &logger.NoopLoggerAndTracer{},
+		LoggerAndTracer: &logger.NoopLoggerAndTracer{},
+		// Shard DB lifecycle is driven by raft/split shutdown paths that can be
+		// exercised aggressively in tests. Keep table stats synchronous with
+		// foreground access so Pebble does not race async stats collection with
+		// node removal and DB close.
+		DisableTableStats: true,
 	}
 	db.cache.Apply(pebbleOpts, cacheSize)
 	if db.antflyConfig.GetKeyValueStorageType() == "s3" {

--- a/src/store/db/shard.go
+++ b/src/store/db/shard.go
@@ -147,6 +147,7 @@ type Shard struct {
 	// cancelLeaderFactory cancels the LeaderFactory goroutine in swarm mode
 	// In raft mode, this is nil since raft manages the lifecycle
 	cancelLeaderFactory context.CancelFunc
+	leaderFactoryDone   <-chan struct{}
 	closeOnce           sync.Once
 	closeErr            error
 }
@@ -158,6 +159,7 @@ func NewShard(
 	confChangeC chan<- *raft.ConfChangeProposal,
 	errorC <-chan error,
 	cancelLeaderFactory context.CancelFunc,
+	leaderFactoryDone <-chan struct{},
 ) *Shard {
 	return &Shard{
 		storeDB:             db,
@@ -165,6 +167,7 @@ func NewShard(
 		confChangeC:         confChangeC,
 		errorC:              errorC,
 		cancelLeaderFactory: cancelLeaderFactory,
+		leaderFactoryDone:   leaderFactoryDone,
 	}
 }
 
@@ -239,6 +242,9 @@ func (s *Shard) Close() error {
 			for range s.errorC {
 				// Drain any remaining errors
 			}
+		}
+		if s.leaderFactoryDone != nil {
+			<-s.leaderFactoryDone
 		}
 
 		// Now safe to close the database

--- a/src/store/db/shard.go
+++ b/src/store/db/shard.go
@@ -59,7 +59,11 @@ type ShardIface interface {
 	Scan(ctx context.Context, fromKey []byte, toKey []byte, opts ScanOptions) (*ScanResult, error)
 	ExportRangeChunk(ctx context.Context, startKey, endKey, afterKey []byte, limit int) ([][2][]byte, []byte, bool, error)
 	ListMergeDeltaEntriesAfter(afterSeq uint64) ([]*MergeDeltaEntry, error)
-	ProposeConfChange(cc raftpb.ConfChange) error // Using our minimal ConfChange
+	// ProposeConfChange proposes a conf change to the Raft state machine.
+	// Returns once the proposal has been accepted (or rejected) by the local
+	// Raft node. ctx cancellation unblocks the call promptly even if the
+	// shard's Raft consumer goroutine has stopped.
+	ProposeConfChange(ctx context.Context, cc raftpb.ConfChange) error
 	// ApplyConfChange proposes a conf change and waits for it to be applied to the Raft state machine.
 	ApplyConfChange(ctx context.Context, cc raftpb.ConfChange) error
 	// Direct raft node forwards
@@ -313,7 +317,7 @@ func (s *Shard) TransferLeadership(ctx context.Context, target types.ID) {
 	}
 }
 
-func (s *Shard) ProposeConfChange(cc raftpb.ConfChange) error {
+func (s *Shard) ProposeConfChange(ctx context.Context, cc raftpb.ConfChange) error {
 	if s.IsInitializing() {
 		return ErrShardNotReady
 	}
@@ -322,14 +326,14 @@ func (s *Shard) ProposeConfChange(cc raftpb.ConfChange) error {
 		return fmt.Errorf("configuration changes not supported in swarm mode")
 	}
 	proposeDoneC := make(chan error, 1)
-	s.confChangeC <- &raft.ConfChangeProposal{
+	proposal := &raft.ConfChangeProposal{
 		ConfChange:   cc,
 		ProposeDoneC: proposeDoneC,
 	}
-	if err := <-proposeDoneC; err != nil {
-		return fmt.Errorf("proposing confChange to raft: %w", err)
+	if err := s.sendConfChange(ctx, proposal); err != nil {
+		return err
 	}
-	return nil
+	return s.waitProposeDone(ctx, proposeDoneC)
 }
 
 // ApplyConfChange proposes a conf change and waits for it to be applied to the Raft state machine.
@@ -347,15 +351,16 @@ func (s *Shard) ApplyConfChange(ctx context.Context, cc raftpb.ConfChange) error
 	callbackID := uuid.New()
 
 	proposeDoneC := make(chan error, 1)
-	s.confChangeC <- &raft.ConfChangeProposal{
+	proposal := &raft.ConfChangeProposal{
 		ConfChange:      cc,
 		ProposeDoneC:    proposeDoneC,
 		ApplyCallbackID: callbackID,
 	}
-
-	// Wait for the proposal to be accepted
-	if err := <-proposeDoneC; err != nil {
-		return fmt.Errorf("proposing confChange to raft: %w", err)
+	if err := s.sendConfChange(ctx, proposal); err != nil {
+		return err
+	}
+	if err := s.waitProposeDone(ctx, proposeDoneC); err != nil {
+		return err
 	}
 
 	// Wait for the conf change to be applied
@@ -367,6 +372,40 @@ func (s *Shard) ApplyConfChange(ctx context.Context, cc raftpb.ConfChange) error
 
 	select {
 	case <-appliedCh:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// sendConfChange writes a proposal to confChangeC, returning early if ctx is
+// cancelled. Without ctx-awareness, a stopped Raft consumer goroutine would
+// leave callers blocked on the unbuffered channel send indefinitely.
+func (s *Shard) sendConfChange(ctx context.Context, proposal *raft.ConfChangeProposal) (err error) {
+	// Recover from a "send on closed channel" panic that can happen if the
+	// shard is closed concurrently with this proposal.
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("shard closed during conf change proposal: %v", r)
+		}
+	}()
+	select {
+	case s.confChangeC <- proposal:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (s *Shard) waitProposeDone(ctx context.Context, proposeDoneC <-chan error) error {
+	select {
+	case err, ok := <-proposeDoneC:
+		if !ok {
+			return fmt.Errorf("proposing confChange to raft: channel closed")
+		}
+		if err != nil {
+			return fmt.Errorf("proposing confChange to raft: %w", err)
+		}
 		return nil
 	case <-ctx.Done():
 		return ctx.Err()

--- a/src/store/db/types.go
+++ b/src/store/db/types.go
@@ -96,6 +96,9 @@ type ShardInfo struct {
 	ShardStats *DBStats           `json:"shard_stats,omitempty"`
 	Peers      common.PeerSet     `json:"peers,omitzero"`
 	RaftStatus *common.RaftStatus `json:"raft_status,omitempty"`
+	// VoterCount is the total known raft voter count when a status source reports
+	// counts rather than concrete voter IDs.
+	VoterCount int `json:"voter_count,omitempty,omitzero"`
 	// ReportedBy tracks which nodes actually reported having this shard loaded.
 	// This is distinct from Peers, which includes nodes from the Raft voter config.
 	// Used by the reconciler to detect shards that are missing on nodes.
@@ -169,6 +172,7 @@ func (s *ShardInfo) Equal(o *ShardInfo) bool {
 	return s.ShardConfig.Equal(&o.ShardConfig) &&
 		s.Peers.Equal(o.Peers) &&
 		s.RaftStatus.Equal(o.RaftStatus) &&
+		s.VoterCount == o.VoterCount &&
 		s.SplitReplayRequired == o.SplitReplayRequired &&
 		s.SplitReplayCaughtUp == o.SplitReplayCaughtUp &&
 		s.SplitCutoverReady == o.SplitCutoverReady &&
@@ -189,6 +193,7 @@ func (s *ShardInfo) DeepCopy() *ShardInfo {
 		Peers:               s.Peers.Copy(),
 		ReportedBy:          s.ReportedBy.Copy(),
 		RaftStatus:          &common.RaftStatus{},
+		VoterCount:          s.VoterCount,
 		HasSnapshot:         s.HasSnapshot,
 		Initializing:        s.Initializing,
 		Splitting:           s.Splitting,
@@ -262,6 +267,9 @@ func (s *ShardInfo) Merge(nodeID types.ID, o *ShardInfo) {
 	if s.RaftStatus == nil || s.RaftStatus.Lead == 0 {
 		s.RaftStatus = o.RaftStatus
 	}
+	if o.VoterCount > s.VoterCount {
+		s.VoterCount = o.VoterCount
+	}
 	if s.ShardStats == nil || s.ShardStats.Created.IsZero() {
 		s.ShardStats = o.ShardStats
 	}
@@ -292,6 +300,7 @@ type shardInfoJSON struct {
 	ShardStats          *DBStats           `json:"shard_stats,omitempty"`
 	Peers               common.PeerSet     `json:"peers,omitzero"`
 	RaftStatus          *common.RaftStatus `json:"raft_status,omitempty"`
+	VoterCount          int                `json:"voter_count,omitempty,omitzero"`
 	ReportedBy          common.PeerSet     `json:"reported_by,omitzero"`
 	HasSnapshot         bool               `json:"has_snapshot,omitempty,omitzero"`
 	Initializing        bool               `json:"initializing,omitempty,omitzero"`
@@ -315,6 +324,7 @@ func (s ShardInfo) MarshalJSON() ([]byte, error) {
 		ShardStats:          s.ShardStats,
 		Peers:               s.Peers,
 		RaftStatus:          s.RaftStatus,
+		VoterCount:          s.VoterCount,
 		ReportedBy:          s.ReportedBy,
 		HasSnapshot:         s.HasSnapshot,
 		Initializing:        s.Initializing,
@@ -355,6 +365,7 @@ func (s *ShardInfo) UnmarshalJSON(data []byte) error {
 	s.ShardStats = j.ShardStats
 	s.Peers = j.Peers
 	s.RaftStatus = j.RaftStatus
+	s.VoterCount = j.VoterCount
 	s.ReportedBy = j.ReportedBy
 	s.HasSnapshot = j.HasSnapshot
 	s.Initializing = j.Initializing

--- a/src/store/runner.go
+++ b/src/store/runner.go
@@ -60,7 +60,7 @@ func registerWithLeader(
 
 	// Send the request
 	// FIXME (ajr) Use TLS if configured
-	req, err := http.NewRequest(http.MethodPost, leaderURL+"/_internal/v1/store", buf)
+	req, err := http.NewRequest(http.MethodPost, leaderURL+"/internal/v1/store", buf)
 	if err != nil {
 		return fmt.Errorf("creating registration request: %w", err)
 	}

--- a/src/store/runner.go
+++ b/src/store/runner.go
@@ -46,11 +46,16 @@ func registerWithLeader(
 	m *Store,
 	conf *StoreInfo,
 ) error {
-	// Prepare the registration request
 	status := m.Status()
-	regReq := StoreRegistrationRequest{
-		StoreInfo: *conf,
-		Shards:    status.Shards,
+	regReq := nodeRegistrationRequest{
+		NodeID:      uint64(conf.ID),
+		StoreID:     uint64(conf.ID),
+		Role:        "data",
+		HealthClass: "healthy",
+		Live:        true,
+		RaftURL:     conf.RaftURL,
+		APIURL:      conf.ApiURL,
+		Shards:      status.Shards,
 	}
 
 	buf := bytes.NewBuffer(nil)
@@ -58,9 +63,26 @@ func registerWithLeader(
 		return fmt.Errorf("failed to encode registration request: %w", err)
 	}
 
-	// Send the request
-	// FIXME (ajr) Use TLS if configured
-	req, err := http.NewRequest(http.MethodPost, leaderURL+"/internal/v1/store", buf)
+	if err := sendNodeRegistration(ctx, client, leaderURL+"/internal/v1/nodes", buf.Bytes()); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+type nodeRegistrationRequest struct {
+	NodeID      uint64                  `json:"node_id"`
+	StoreID     uint64                  `json:"store_id"`
+	Role        string                  `json:"role,omitempty"`
+	HealthClass string                  `json:"health_class,omitempty"`
+	Live        bool                    `json:"live"`
+	RaftURL     string                  `json:"raft_url,omitempty"`
+	APIURL      string                  `json:"api_url,omitempty"`
+	Shards      map[types.ID]*ShardInfo `json:"shards,omitempty"`
+}
+
+func sendNodeRegistration(ctx context.Context, client *http.Client, url string, body []byte) error {
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))
 	if err != nil {
 		return fmt.Errorf("creating registration request: %w", err)
 	}
@@ -72,10 +94,9 @@ func registerWithLeader(
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	if resp.StatusCode != http.StatusOK {
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return fmt.Errorf("leader returned error status: %s", resp.Status)
 	}
-
 	return nil
 }
 

--- a/src/store/runner.go
+++ b/src/store/runner.go
@@ -56,6 +56,7 @@ func registerWithLeader(
 		RaftURL:     conf.RaftURL,
 		APIURL:      conf.ApiURL,
 		Shards:      status.Shards,
+		GroupStatus: shardInfosToNodeGroupStatusReports(conf.ID, status.Shards),
 	}
 
 	buf := bytes.NewBuffer(nil)
@@ -79,6 +80,34 @@ type nodeRegistrationRequest struct {
 	RaftURL     string                  `json:"raft_url,omitempty"`
 	APIURL      string                  `json:"api_url,omitempty"`
 	Shards      map[types.ID]*ShardInfo `json:"shards,omitempty"`
+	GroupStatus []nodeGroupStatusReport `json:"group_statuses,omitempty"`
+}
+
+type nodeGroupStatusReport struct {
+	GroupID     uint64 `json:"group_id"`
+	LocalLeader bool   `json:"local_leader,omitempty"`
+	LocalVoter  bool   `json:"local_voter,omitempty"`
+	VoterCount  int    `json:"voter_count,omitempty"`
+}
+
+func shardInfosToNodeGroupStatusReports(nodeID types.ID, shards map[types.ID]*ShardInfo) []nodeGroupStatusReport {
+	if len(shards) == 0 {
+		return nil
+	}
+	reports := make([]nodeGroupStatusReport, 0, len(shards))
+	for shardID, shard := range shards {
+		if shard == nil {
+			continue
+		}
+		report := nodeGroupStatusReport{GroupID: uint64(shardID)}
+		if shard.RaftStatus != nil {
+			report.LocalLeader = shard.RaftStatus.Lead == nodeID
+			report.LocalVoter = shard.RaftStatus.Voters.Contains(nodeID)
+			report.VoterCount = len(shard.RaftStatus.Voters)
+		}
+		reports = append(reports, report)
+	}
+	return reports
 }
 
 func sendNodeRegistration(ctx context.Context, client *http.Client, url string, body []byte) error {

--- a/src/store/runner_test.go
+++ b/src/store/runner_test.go
@@ -16,9 +16,10 @@ package store
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
-	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/antflydb/antfly/lib/types"
@@ -27,24 +28,34 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestStoreRegistrationEndpoint verifies that the store registration
-// uses the correct /internal/v1/store endpoint.
-func TestStoreRegistrationEndpoint(t *testing.T) {
-	// Track the request path
-	var requestPath string
-	var requestMethod string
+type roundTripFunc func(*http.Request) (*http.Response, error)
 
-	// Create a test server that captures the request
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		requestPath = r.URL.Path
-		requestMethod = r.Method
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
 
-		// Read and discard body
-		_, _ = io.ReadAll(r.Body)
+// TestNodeRegistrationEndpoint verifies that data-node registration uses the
+// node resource and includes the hosted store metadata in the same request.
+func TestNodeRegistrationEndpoint(t *testing.T) {
+	var requestPaths []string
+	var requestMethods []string
+	var body []byte
 
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer server.Close()
+	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requestPaths = append(requestPaths, req.URL.Path)
+		requestMethods = append(requestMethods, req.Method)
+
+		var err error
+		body, err = io.ReadAll(req.Body)
+		require.NoError(t, err)
+
+		return &http.Response{
+			StatusCode: http.StatusAccepted,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(`{"status":"ok"}`)),
+			Request:    req,
+		}, nil
+	})}
 
 	// Create a minimal store for testing
 	store := &Store{
@@ -60,20 +71,34 @@ func TestStoreRegistrationEndpoint(t *testing.T) {
 	}
 
 	// Attempt registration
-	err := registerWithLeader(context.Background(), server.Client(), server.URL, store, conf)
+	err := registerWithLeader(context.Background(), client, "http://metadata.test", store, conf)
 
 	require.NoError(t, err, "Registration failed")
 
-	// Verify the endpoint path
-	expectedPath := "/internal/v1/store"
-	assert.Equal(t, expectedPath, requestPath, "Request path should use /internal/v1/ prefix")
+	assert.Equal(t, []string{"/internal/v1/nodes"}, requestPaths, "registration should use the node resource")
+	assert.Equal(t, []string{http.MethodPost}, requestMethods, "Should use POST methods")
 
-	// Verify the HTTP method
-	assert.Equal(t, http.MethodPost, requestMethod, "Should use POST method")
+	var payload struct {
+		NodeID      uint64 `json:"node_id"`
+		StoreID     uint64 `json:"store_id"`
+		Role        string `json:"role"`
+		HealthClass string `json:"health_class"`
+		Live        bool   `json:"live"`
+		RaftURL     string `json:"raft_url"`
+		APIURL      string `json:"api_url"`
+	}
+	require.NoError(t, json.Unmarshal(body, &payload))
+	assert.Equal(t, uint64(1), payload.NodeID)
+	assert.Equal(t, uint64(1), payload.StoreID)
+	assert.Equal(t, "data", payload.Role)
+	assert.Equal(t, "healthy", payload.HealthClass)
+	assert.True(t, payload.Live)
+	assert.Equal(t, "http://localhost:9021", payload.RaftURL)
+	assert.Equal(t, "http://localhost:12380", payload.APIURL)
 }
 
-// TestStoreRegistrationURL verifies the full URL construction
-func TestStoreRegistrationURL(t *testing.T) {
+// TestNodeRegistrationURL verifies the full URL construction.
+func TestNodeRegistrationURL(t *testing.T) {
 	tests := []struct {
 		name        string
 		leaderURL   string
@@ -82,31 +107,32 @@ func TestStoreRegistrationURL(t *testing.T) {
 		{
 			name:        "http URL",
 			leaderURL:   "http://127.0.0.1:12277",
-			expectedURL: "http://127.0.0.1:12277/internal/v1/store",
+			expectedURL: "http://127.0.0.1:12277/internal/v1/nodes",
 		},
 		{
 			name:        "https URL",
 			leaderURL:   "https://metadata.example.com:8080",
-			expectedURL: "https://metadata.example.com:8080/internal/v1/store",
+			expectedURL: "https://metadata.example.com:8080/internal/v1/nodes",
 		},
 		{
 			name:        "URL with trailing slash",
 			leaderURL:   "http://127.0.0.1:12277/",
-			expectedURL: "http://127.0.0.1:12277//internal/v1/store", // Will still work with double slash
+			expectedURL: "http://127.0.0.1:12277//internal/v1/nodes", // Will still work with double slash
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var capturedURL string
-
-			server := httptest.NewServer(
-				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					capturedURL = r.URL.Path
-					w.WriteHeader(http.StatusOK)
-				}),
-			)
-			defer server.Close()
+			var capturedURLs []string
+			client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				capturedURLs = append(capturedURLs, req.URL.String())
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header:     make(http.Header),
+					Body:       io.NopCloser(strings.NewReader(`{"status":"ok"}`)),
+					Request:    req,
+				}, nil
+			})}
 
 			store := &Store{
 				config:    &StoreInfo{ID: types.ID(1)},
@@ -119,12 +145,38 @@ func TestStoreRegistrationURL(t *testing.T) {
 				ApiURL:  "http://localhost:12380",
 			}
 
-			// Use the server URL (ignore tt.leaderURL since we need to use the test server)
-			_ = registerWithLeader(context.Background(), server.Client(), server.URL, store, conf)
+			err := registerWithLeader(context.Background(), client, tt.leaderURL, store, conf)
 
-			// Verify the path includes /internal/v1/store.
-			assert.Equal(t, "/internal/v1/store", capturedURL,
-				"Path should be /internal/v1/store")
+			require.NoError(t, err)
+			assert.Equal(t, []string{tt.expectedURL}, capturedURLs)
 		})
 	}
+}
+
+func TestNodeRegistrationFailsWhenNodeEndpointMissing(t *testing.T) {
+	var requestPaths []string
+	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requestPaths = append(requestPaths, req.URL.Path)
+		return &http.Response{
+			StatusCode: http.StatusNotFound,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(`{"status":"ok"}`)),
+			Request:    req,
+		}, nil
+	})}
+
+	store := &Store{
+		config:    &StoreInfo{ID: types.ID(1)},
+		shardsMap: xsync.NewMap[types.ID, *Shard](),
+	}
+	conf := &StoreInfo{
+		ID:      types.ID(1),
+		RaftURL: "http://localhost:9021",
+		ApiURL:  "http://localhost:12380",
+	}
+
+	err := registerWithLeader(context.Background(), client, "http://metadata.test", store, conf)
+
+	require.Error(t, err)
+	assert.Equal(t, []string{"/internal/v1/nodes"}, requestPaths)
 }

--- a/src/store/runner_test.go
+++ b/src/store/runner_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 // TestStoreRegistrationEndpoint verifies that the store registration
-// uses the correct /_internal/v1/store endpoint
+// uses the correct /internal/v1/store endpoint.
 func TestStoreRegistrationEndpoint(t *testing.T) {
 	// Track the request path
 	var requestPath string
@@ -65,8 +65,8 @@ func TestStoreRegistrationEndpoint(t *testing.T) {
 	require.NoError(t, err, "Registration failed")
 
 	// Verify the endpoint path
-	expectedPath := "/_internal/v1/store"
-	assert.Equal(t, expectedPath, requestPath, "Request path should use /_internal/v1/ prefix")
+	expectedPath := "/internal/v1/store"
+	assert.Equal(t, expectedPath, requestPath, "Request path should use /internal/v1/ prefix")
 
 	// Verify the HTTP method
 	assert.Equal(t, http.MethodPost, requestMethod, "Should use POST method")
@@ -82,17 +82,17 @@ func TestStoreRegistrationURL(t *testing.T) {
 		{
 			name:        "http URL",
 			leaderURL:   "http://127.0.0.1:12277",
-			expectedURL: "http://127.0.0.1:12277/_internal/v1/store",
+			expectedURL: "http://127.0.0.1:12277/internal/v1/store",
 		},
 		{
 			name:        "https URL",
 			leaderURL:   "https://metadata.example.com:8080",
-			expectedURL: "https://metadata.example.com:8080/_internal/v1/store",
+			expectedURL: "https://metadata.example.com:8080/internal/v1/store",
 		},
 		{
 			name:        "URL with trailing slash",
 			leaderURL:   "http://127.0.0.1:12277/",
-			expectedURL: "http://127.0.0.1:12277//_internal/v1/store", // Will still work with double slash
+			expectedURL: "http://127.0.0.1:12277//internal/v1/store", // Will still work with double slash
 		},
 	}
 
@@ -122,9 +122,9 @@ func TestStoreRegistrationURL(t *testing.T) {
 			// Use the server URL (ignore tt.leaderURL since we need to use the test server)
 			_ = registerWithLeader(context.Background(), server.Client(), server.URL, store, conf)
 
-			// Verify the path includes /_internal/v1/store
-			assert.Equal(t, "/_internal/v1/store", capturedURL,
-				"Path should be /_internal/v1/store")
+			// Verify the path includes /internal/v1/store.
+			assert.Equal(t, "/internal/v1/store", capturedURL,
+				"Path should be /internal/v1/store")
 		})
 	}
 }

--- a/src/store/runner_test.go
+++ b/src/store/runner_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/antflydb/antfly/lib/types"
+	"github.com/antflydb/antfly/src/common"
 	"github.com/puzpuzpuz/xsync/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -95,6 +96,23 @@ func TestNodeRegistrationEndpoint(t *testing.T) {
 	assert.True(t, payload.Live)
 	assert.Equal(t, "http://localhost:9021", payload.RaftURL)
 	assert.Equal(t, "http://localhost:12380", payload.APIURL)
+}
+
+func TestShardInfosToNodeGroupStatusReports(t *testing.T) {
+	reports := shardInfosToNodeGroupStatusReports(types.ID(2), map[types.ID]*ShardInfo{
+		10: {
+			RaftStatus: &common.RaftStatus{
+				Lead:   2,
+				Voters: common.NewPeerSet(1, 2, 3),
+			},
+		},
+	})
+
+	require.Len(t, reports, 1)
+	assert.Equal(t, uint64(10), reports[0].GroupID)
+	assert.True(t, reports[0].LocalLeader)
+	assert.True(t, reports[0].LocalVoter)
+	assert.Equal(t, 3, reports[0].VoterCount)
 }
 
 // TestNodeRegistrationURL verifies the full URL construction.

--- a/src/store/shard_notifier.go
+++ b/src/store/shard_notifier.go
@@ -78,7 +78,7 @@ func (n *HTTPShardNotifier) NotifyResolveIntent(
 
 	// Send request to metadata server's forwarding endpoint
 	// The metadata server will look up which node hosts the shard and forward the request
-	url := fmt.Sprintf("%s/_internal/v1/shard/%s/txn/resolve", n.metadataURL, shardID)
+	url := fmt.Sprintf("%s/internal/v1/shard/%s/txn/resolve", n.metadataURL, shardID)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(body))
 	if err != nil {
 		return fmt.Errorf("creating request: %w", err)

--- a/src/store/store.go
+++ b/src/store/store.go
@@ -96,6 +96,7 @@ type Store struct {
 
 	errorChanC chan errorChanCItem
 	closingCh  chan struct{} // Closed when store is shutting down
+	closeOnce  sync.Once
 }
 
 // TODO (ajr)
@@ -476,33 +477,54 @@ func (m *Store) createPassThroughChannels(
 }
 
 func (m *Store) Close() {
-	// Signal that we're closing - this prevents new shard starts from sending to errorChanC
-	close(m.closingCh)
+	m.closeOnce.Do(func() {
+		// Signal that we're closing. This prevents new shard starts from sending to errorChanC
+		// or saving metadata while shutdown is closing Pebble handles.
+		close(m.closingCh)
 
-	// Close all active shards to release Pebble and Bleve resources.
-	// This is critical to prevent memory leaks when store nodes are removed.
-	m.shardsMap.Range(func(shardID types.ID, shard *Shard) bool {
-		m.logger.Debug("Closing shard during store shutdown", zap.Stringer("shardID", shardID))
+		closeShards := func() {
+			m.shardsMap.Range(func(shardID types.ID, shard *Shard) bool {
+				m.logger.Debug("Closing shard during store shutdown", zap.Stringer("shardID", shardID))
 
-		if err := shard.Close(); err != nil && !errors.Is(err, db.ErrShardNotReady) {
-			m.logger.Warn("Error closing shard database",
-				zap.Stringer("shardID", shardID),
-				zap.Error(err))
+				if err := shard.Close(); err != nil && !errors.Is(err, db.ErrShardNotReady) {
+					m.logger.Warn("Error closing shard database",
+						zap.Stringer("shardID", shardID),
+						zap.Error(err))
+				}
+
+				return true
+			})
 		}
 
-		return true
+		// Close all active shards before the store metadata DB. Shard shutdown
+		// waits for shard-owned background work before closing shard Pebble DBs.
+		closeShards()
+
+		// Cancel store-level work and wait for startup/error fan-in goroutines to stop
+		// before closing the metadata DB they may touch.
+		if m.egCancel != nil {
+			m.egCancel()
+		}
+		if m.eg != nil {
+			if err := m.eg.Wait(); err != nil && !errors.Is(err, context.Canceled) {
+				m.logger.Warn("Error waiting for store background work during shutdown", zap.Error(err))
+			}
+		}
+
+		// A concurrent shard startup may have observed closingCh and left the
+		// shard in the map for Close to clean up. Sweep again after startup work
+		// has stopped so that no ready shard is left with open Pebble handles.
+		closeShards()
+
+		// Close store metadata database.
+		if m.db != nil {
+			if err := m.db.Close(); err != nil {
+				m.logger.Warn("Error closing store metadata Pebble database", zap.Error(err))
+			}
+		}
+
+		m.logger.Info("Store closed", zap.String("storeID", m.config.ID.String()))
 	})
-
-	// Close store metadata database
-	if err := m.db.Close(); err != nil {
-		m.logger.Warn("Error closing store metadata Pebble database", zap.Error(err))
-	}
-
-	// Cancel the store context to stop the ErrorC goroutine. This must happen
-	// after closing shards so in-flight errgroup work can complete cleanly.
-	m.egCancel()
-
-	m.logger.Info("Store closed", zap.String("storeID", m.config.ID.String()))
 }
 
 type ShardStartConfig struct {
@@ -538,9 +560,30 @@ func (m *Store) StartRaftGroup(
 	lg.Debug("Starting Raft Group")
 	// If we fail to start the shard, remove it from the map
 	removeShard := true
+	storedReadyShard := false
+	var cancelLeaderFactory context.CancelFunc
+	var leaderFactoryDone <-chan struct{}
+	var errorC <-chan error
+	var proposeC chan *raft.Proposal
 	defer func() {
 		if removeShard {
-			m.shardsMap.Delete(shardID)
+			if shard, ok := m.shardsMap.LoadAndDelete(shardID); ok {
+				if err := shard.Close(); err != nil && !errors.Is(err, db.ErrShardNotReady) {
+					lg.Warn("Error closing shard after failed start", zap.Error(err))
+				}
+			}
+			if !storedReadyShard && leaderFactoryDone != nil {
+				if cancelLeaderFactory != nil {
+					cancelLeaderFactory()
+				}
+				close(proposeC)
+				if errorC != nil {
+					for range errorC {
+						// Drain until pass-through shutdown closes errorC.
+					}
+				}
+				<-leaderFactoryDone
+			}
 		}
 	}()
 	var dbw *db.StoreDB
@@ -550,7 +593,7 @@ func (m *Store) StartRaftGroup(
 		<-storeDBReady
 		return dbw.CreateDBSnapshot(id)
 	}
-	proposeC := make(chan *raft.Proposal)
+	proposeC = make(chan *raft.Proposal)
 	confChangeC := make(chan *raft.ConfChangeProposal)
 	dataDir := m.antflyConfig.GetBaseDir()
 	snapStore, err := snapstore.NewLocalSnapStore(dataDir, shardID, m.config.ID)
@@ -592,7 +635,6 @@ func (m *Store) StartRaftGroup(
 	}
 
 	var commitC <-chan *raft.Commit
-	var errorC <-chan error
 	var raftNode raft.RaftNode
 
 	// In swarm mode, bypass Raft consensus with a pass-through channel
@@ -715,7 +757,6 @@ func (m *Store) StartRaftGroup(
 		return fmt.Errorf("creating dbwrapper: %w", err2)
 	}
 
-	var cancelLeaderFactory context.CancelFunc
 	if raftNode != nil {
 		raftNode.SetLeaderFactory(dbw.LeaderFactory)
 	} else {
@@ -724,7 +765,10 @@ func (m *Store) StartRaftGroup(
 		// can properly stop the LeaderFactory when the shard is removed.
 		ctx, cancel := context.WithCancel(context.Background())
 		cancelLeaderFactory = cancel
+		done := make(chan struct{})
+		leaderFactoryDone = done
 		m.eg.Go(func() error {
+			defer close(done)
 			return dbw.LeaderFactory(ctx)
 		})
 	}
@@ -739,7 +783,8 @@ func (m *Store) StartRaftGroup(
 		return fmt.Errorf("store is closing")
 	}
 	lg.Info("Started Raft Group")
-	m.shardsMap.Store(shardID, db.NewShard(dbw, raftNode, confChangeC, errorC, cancelLeaderFactory))
+	m.shardsMap.Store(shardID, db.NewShard(dbw, raftNode, confChangeC, errorC, cancelLeaderFactory, leaderFactoryDone))
+	storedReadyShard = true
 	// Check again if store is closing before saving metadata to avoid
 	// race condition where Close() closes m.db between the earlier check
 	// and this point.

--- a/src/tablemgr/store.go
+++ b/src/tablemgr/store.go
@@ -53,6 +53,11 @@ type NodeRecord struct {
 	Lifecycle string    `json:"lifecycle"`
 	Reason    string    `json:"reason,omitempty"`
 	LastSeen  time.Time `json:"last_seen"`
+	// DrainingSince records when the node first entered the Draining
+	// lifecycle. Preserved across status updates so the safety net in
+	// buildNodeShutdownStatus can detect drains that have been stuck for
+	// longer than the configured threshold.
+	DrainingSince time.Time `json:"draining_since,omitempty"`
 }
 
 func (ss *StoreStatus) Equivalent(other *StoreStatus) bool {

--- a/src/tablemgr/store.go
+++ b/src/tablemgr/store.go
@@ -41,11 +41,27 @@ type StoreStatus struct {
 	StoreClient client.StoreRPC               `json:"-"`
 }
 
+const (
+	NodeLifecycleActive   = "active"
+	NodeLifecycleDraining = "draining"
+)
+
+// NodeRecord tracks durable node-level lifecycle intent. Store health reports
+// must not clear a non-active lifecycle.
+type NodeRecord struct {
+	NodeID    types.ID  `json:"node_id"`
+	Lifecycle string    `json:"lifecycle"`
+	Reason    string    `json:"reason,omitempty"`
+	LastSeen  time.Time `json:"last_seen"`
+}
+
 func (ss *StoreStatus) Equivalent(other *StoreStatus) bool {
 	if ss == nil || other == nil {
 		return ss == nil && other == nil
 	}
 	return ss.ID == other.ID &&
+		ss.RaftURL == other.RaftURL &&
+		ss.ApiURL == other.ApiURL &&
 		ss.State == other.State &&
 		maps.EqualFunc(ss.Shards, other.Shards, func(v1, v2 *store.ShardInfo) bool {
 			return v1.Equal(v2)

--- a/src/tablemgr/store_test.go
+++ b/src/tablemgr/store_test.go
@@ -1,0 +1,56 @@
+// Copyright 2025 Antfly, Inc.
+//
+// Licensed under the Elastic License 2.0 (ELv2); you may not use this file
+// except in compliance with the Elastic License 2.0. You may obtain a copy of
+// the Elastic License 2.0 at
+//
+//     https://www.antfly.io/licensing/ELv2-license
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the Elastic License 2.0 is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// Elastic License 2.0 for the specific language governing permissions and
+// limitations.
+
+package tablemgr
+
+import (
+	"testing"
+
+	"github.com/antflydb/antfly/lib/types"
+	"github.com/antflydb/antfly/src/store"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStoreStatusEquivalentIncludesEndpoints(t *testing.T) {
+	base := &StoreStatus{
+		StoreInfo: store.StoreInfo{
+			ID:      types.ID(1),
+			RaftURL: "http://store-1:19001",
+			ApiURL:  "http://store-1:19002",
+		},
+		State:  store.StoreState_Healthy,
+		Shards: map[types.ID]*store.ShardInfo{},
+	}
+	same := &StoreStatus{
+		StoreInfo: store.StoreInfo{
+			ID:      types.ID(1),
+			RaftURL: "http://store-1:19001",
+			ApiURL:  "http://store-1:19002",
+		},
+		State:  store.StoreState_Healthy,
+		Shards: map[types.ID]*store.ShardInfo{},
+	}
+	moved := &StoreStatus{
+		StoreInfo: store.StoreInfo{
+			ID:      types.ID(1),
+			RaftURL: "http://store-1:29001",
+			ApiURL:  "http://store-1:29002",
+		},
+		State:  store.StoreState_Healthy,
+		Shards: map[types.ID]*store.ShardInfo{},
+	}
+
+	require.True(t, base.Equivalent(same))
+	require.False(t, base.Equivalent(moved))
+}

--- a/src/tablemgr/table.go
+++ b/src/tablemgr/table.go
@@ -134,9 +134,20 @@ func (tm *TableManager) UpdateStatuses(
 	}
 	tm.Lock()
 	defer tm.Unlock()
+	tombstones, err := tm.GetStoreTombstones(ctx)
+	if err != nil {
+		return fmt.Errorf("loading store tombstones: %w", err)
+	}
+	tombstonedStores := make(map[types.ID]struct{}, len(tombstones))
+	for _, id := range tombstones {
+		tombstonedStores[id] = struct{}{}
+	}
 	currentShards := make(map[types.ID]*store.ShardInfo)
 	updatedStores := make(map[types.ID]*StoreStatus)
 	for nodeID, status := range newStatuses {
+		if _, tombstoned := tombstonedStores[nodeID]; tombstoned {
+			status.State = store.StoreState_Terminating
+		}
 		oldStoreStatus, err := tm.GetStoreStatus(ctx, nodeID)
 		// If the store status is not found i.e. ErrNotFound, we treat it as a new store
 		if errors.Is(err, ErrNotFound) {
@@ -147,10 +158,11 @@ func (tm *TableManager) UpdateStatuses(
 			updatedStores[nodeID] = status
 		}
 
-		// Unreachable stores keep their last known shard map for observability, but
-		// they must not contribute to aggregate shard routing state. Otherwise a dead
-		// node can linger in ReportedBy / leader-adjacent metadata and misroute reads.
-		if status.State == store.StoreState_Unhealthy {
+		// Unreachable or administratively draining stores keep their last known
+		// shard map for observability, but they must not contribute to aggregate
+		// shard routing state. Otherwise a dead/draining node can linger in
+		// ReportedBy / leader-adjacent metadata and misroute reads.
+		if status.State == store.StoreState_Unhealthy || status.State == store.StoreState_Terminating {
 			continue
 		}
 
@@ -912,13 +924,33 @@ func (tm *TableManager) GetStoreTombstones(ctx context.Context) ([]types.ID, err
 	return tombstones, nil
 }
 
+func (tm *TableManager) HasStoreTombstone(ctx context.Context, id types.ID) (bool, error) {
+	_, closer, err := tm.db.Get(ctx, []byte(storeTombstonePrefix+id.String()))
+	if err != nil {
+		if errors.Is(err, pebble.ErrNotFound) {
+			return false, nil
+		}
+		return false, fmt.Errorf("checking store tombstone for %s: %w", id, err)
+	}
+	defer func() { _ = closer.Close() }()
+	return true, nil
+}
+
 func (tm *TableManager) RegisterStore(
 	ctx context.Context,
 	req *store.StoreRegistrationRequest,
 ) error {
+	state := store.StoreState_Healthy
+	tombstoned, err := tm.HasStoreTombstone(ctx, req.ID)
+	if err != nil {
+		return err
+	}
+	if tombstoned {
+		state = store.StoreState_Terminating
+	}
 	storeStatus := &StoreStatus{
 		StoreInfo: req.StoreInfo,
-		State:     store.StoreState_Healthy,
+		State:     state,
 		LastSeen:  time.Now(),
 		Shards:    req.Shards,
 	}

--- a/src/tablemgr/table.go
+++ b/src/tablemgr/table.go
@@ -47,6 +47,7 @@ import (
 const (
 	tablePrefix                = "tm:t:"
 	storeStatusPrefix          = "tm:sts:"
+	nodeRecordPrefix           = "tm:nr:"
 	shardStatusPrefix          = "tm:shs:"
 	storeTombstonePrefix       = "tm:stb:"
 	tableReallocationReqPrefix = "tm:rar:"
@@ -129,11 +130,18 @@ func (tm *TableManager) UpdateStatuses(
 	ctx context.Context,
 	newStatuses map[types.ID]*StoreStatus,
 ) error {
+	tm.Lock()
+	defer tm.Unlock()
+	return tm.updateStatusesLocked(ctx, newStatuses)
+}
+
+func (tm *TableManager) updateStatusesLocked(
+	ctx context.Context,
+	newStatuses map[types.ID]*StoreStatus,
+) error {
 	if len(newStatuses) == 0 {
 		return nil // No new statuses to set
 	}
-	tm.Lock()
-	defer tm.Unlock()
 	tombstones, err := tm.GetStoreTombstones(ctx)
 	if err != nil {
 		return fmt.Errorf("loading store tombstones: %w", err)
@@ -783,7 +791,10 @@ func (tm *TableManager) GetShardStatuses() (map[types.ID]*store.ShardStatus, err
 	return resp, nil
 }
 
-var ErrNotFound = errors.New("not found")
+var (
+	ErrNotFound                   = errors.New("not found")
+	ErrActiveNodeFinalizeRejected = errors.New("active node cannot be finalized")
+)
 
 func (tm *TableManager) GetShardStatus(shardID types.ID) (*store.ShardStatus, error) {
 	b, closer, err := tm.db.Get(context.Background(), []byte(shardStatusPrefix+shardID.String()))
@@ -870,15 +881,144 @@ func (tm *TableManager) DeleteTombstones(ctx context.Context, ids []types.ID) er
 	if len(ids) == 0 {
 		return nil
 	}
-	deletes := make([][]byte, 0, len(ids)*2)
+	tm.Lock()
+	defer tm.Unlock()
+
+	deletes := make([][]byte, 0, len(ids)*3)
 	for _, id := range ids {
+		_, closer, err := tm.db.Get(ctx, []byte(storeTombstonePrefix+id.String()))
+		if err != nil {
+			if errors.Is(err, pebble.ErrNotFound) {
+				continue
+			}
+			return fmt.Errorf("checking store tombstone for %s before deletion: %w", id, err)
+		}
+		if closer != nil {
+			_ = closer.Close()
+		}
+		nodeRecord, err := tm.GetNodeRecord(ctx, id)
+		if err != nil && !errors.Is(err, ErrNotFound) {
+			return fmt.Errorf("checking node record for %s before tombstone deletion: %w", id, err)
+		}
+		if nodeRecord != nil && nodeRecord.Lifecycle == NodeLifecycleDraining {
+			continue
+		}
 		deletes = append(deletes, []byte(storeStatusPrefix+id.String()))
 		deletes = append(deletes, []byte(storeTombstonePrefix+id.String()))
+		deletes = append(deletes, []byte(nodeRecordPrefix+id.String()))
 	}
 	return tm.db.Batch(ctx, nil, deletes)
 }
 
+func (tm *TableManager) RegisterNode(ctx context.Context, record *NodeRecord) error {
+	tm.Lock()
+	defer tm.Unlock()
+	return tm.registerNodeLocked(ctx, record)
+}
+
+func (tm *TableManager) registerNodeLocked(ctx context.Context, record *NodeRecord) error {
+	if record == nil {
+		return fmt.Errorf("node record is required")
+	}
+	if record.NodeID == 0 {
+		return fmt.Errorf("node_id is required")
+	}
+
+	lifecycle := record.Lifecycle
+	if lifecycle == "" {
+		lifecycle = NodeLifecycleActive
+	}
+	existing, err := tm.GetNodeRecord(ctx, record.NodeID)
+	if err != nil && !errors.Is(err, ErrNotFound) {
+		return err
+	}
+	reason := record.Reason
+	if existing != nil && existing.Lifecycle != "" && existing.Lifecycle != NodeLifecycleActive {
+		lifecycle = existing.Lifecycle
+		if reason == "" {
+			reason = existing.Reason
+		}
+	}
+
+	next := *record
+	next.Lifecycle = lifecycle
+	next.Reason = reason
+	next.LastSeen = time.Now()
+	data, err := json.Marshal(&next)
+	if err != nil {
+		return fmt.Errorf("marshalling node record for %s: %w", record.NodeID, err)
+	}
+	return tm.db.Batch(ctx, [][2][]byte{{[]byte(nodeRecordPrefix + record.NodeID.String()), data}}, nil)
+}
+
+func (tm *TableManager) SetNodeLifecycle(ctx context.Context, id types.ID, lifecycle, reason string) error {
+	tm.Lock()
+	defer tm.Unlock()
+
+	if id == 0 {
+		return fmt.Errorf("node_id is required")
+	}
+	record, err := tm.GetNodeRecord(ctx, id)
+	if err != nil {
+		if !errors.Is(err, ErrNotFound) {
+			return err
+		}
+		record = &NodeRecord{NodeID: id}
+	}
+	record.Lifecycle = lifecycle
+	record.Reason = reason
+	record.LastSeen = time.Now()
+	data, err := json.Marshal(record)
+	if err != nil {
+		return fmt.Errorf("marshalling node record for %s: %w", id, err)
+	}
+	return tm.db.Batch(ctx, [][2][]byte{{[]byte(nodeRecordPrefix + id.String()), data}}, nil)
+}
+
+func (tm *TableManager) RequestNodeShutdown(ctx context.Context, id types.ID, reason string) error {
+	tm.Lock()
+	defer tm.Unlock()
+
+	if id == 0 {
+		return fmt.Errorf("node_id is required")
+	}
+	record, err := tm.GetNodeRecord(ctx, id)
+	if err != nil {
+		if !errors.Is(err, ErrNotFound) {
+			return err
+		}
+		record = &NodeRecord{NodeID: id}
+	}
+	record.Lifecycle = NodeLifecycleDraining
+	record.Reason = reason
+	record.LastSeen = time.Now()
+	nodeData, err := json.Marshal(record)
+	if err != nil {
+		return fmt.Errorf("marshalling node record for %s: %w", id, err)
+	}
+
+	writes := [][2][]byte{
+		{[]byte(nodeRecordPrefix + id.String()), nodeData},
+		{[]byte(storeTombstonePrefix + id.String()), nil},
+	}
+	if status, err := tm.GetStoreStatus(ctx, id); err == nil {
+		status.State = store.StoreState_Terminating
+		storeData, err := json.Marshal(status)
+		if err != nil {
+			return fmt.Errorf("marshalling store status for %s: %w", id, err)
+		}
+		writes = append(writes, [2][]byte{[]byte(storeStatusPrefix + id.String()), storeData})
+	} else if !errors.Is(err, ErrNotFound) {
+		return err
+	}
+
+	return tm.db.Batch(ctx, writes, nil)
+}
+
 func (tm *TableManager) TombstoneStore(ctx context.Context, id types.ID) error {
+	tm.Lock()
+	defer tm.Unlock()
+
 	// TODO (ajr) Remove a shard altogether after reconciliation has happened
 	writes := [][2][]byte{{[]byte(storeTombstonePrefix + id.String()), nil}}
 
@@ -894,6 +1034,80 @@ func (tm *TableManager) TombstoneStore(ctx context.Context, id types.ID) error {
 	}
 
 	return tm.db.Batch(ctx, writes, nil)
+}
+
+func (tm *TableManager) ClearStoreTombstone(ctx context.Context, id types.ID) error {
+	tm.Lock()
+	defer tm.Unlock()
+
+	writes := make([][2][]byte, 0, 2)
+	record, err := tm.GetNodeRecord(ctx, id)
+	if err != nil {
+		if !errors.Is(err, ErrNotFound) {
+			return err
+		}
+	}
+	tombstoned, err := tm.HasStoreTombstone(ctx, id)
+	if err != nil {
+		return err
+	}
+	storeStatus, err := tm.GetStoreStatus(ctx, id)
+	if err != nil && !errors.Is(err, ErrNotFound) {
+		return err
+	}
+	if record == nil && !tombstoned && storeStatus == nil {
+		return nil
+	}
+	if record == nil {
+		record = &NodeRecord{NodeID: id}
+	}
+	record.Lifecycle = NodeLifecycleActive
+	record.Reason = ""
+	record.LastSeen = time.Now()
+	data, err := json.Marshal(record)
+	if err != nil {
+		return fmt.Errorf("marshalling node record for %s: %w", id, err)
+	}
+	writes = append(writes, [2][]byte{[]byte(nodeRecordPrefix + id.String()), data})
+
+	return tm.db.Batch(ctx, writes, [][]byte{[]byte(storeTombstonePrefix + id.String())})
+}
+
+func (tm *TableManager) FinalizeNodeShutdown(ctx context.Context, id types.ID) error {
+	tm.Lock()
+	defer tm.Unlock()
+
+	tombstoned, err := tm.HasStoreTombstone(ctx, id)
+	if err != nil {
+		return err
+	}
+	record, err := tm.GetNodeRecord(ctx, id)
+	if err != nil && !errors.Is(err, ErrNotFound) {
+		return err
+	}
+	status, err := tm.GetStoreStatus(ctx, id)
+	if err != nil && !errors.Is(err, ErrNotFound) {
+		return err
+	}
+	if !tombstoned && record == nil && status == nil {
+		return nil
+	}
+	if record != nil && record.Lifecycle != NodeLifecycleDraining {
+		return fmt.Errorf("%w: node %s is %q, not %q", ErrActiveNodeFinalizeRejected, id, record.Lifecycle, NodeLifecycleDraining)
+	}
+	if !tombstoned && record == nil && status != nil {
+		return fmt.Errorf("%w: node %s has active store status but no shutdown intent", ErrActiveNodeFinalizeRejected, id)
+	}
+	if !tombstoned && (record == nil || record.Lifecycle != NodeLifecycleDraining) {
+		return fmt.Errorf("node %s has no shutdown intent to finalize", id)
+	}
+
+	deletes := [][]byte{
+		[]byte(storeStatusPrefix + id.String()),
+		[]byte(storeTombstonePrefix + id.String()),
+		[]byte(nodeRecordPrefix + id.String()),
+	}
+	return tm.db.Batch(ctx, nil, deletes)
 }
 
 func (tm *TableManager) GetStoreTombstones(ctx context.Context) ([]types.ID, error) {
@@ -936,10 +1150,33 @@ func (tm *TableManager) HasStoreTombstone(ctx context.Context, id types.ID) (boo
 	return true, nil
 }
 
+func (tm *TableManager) GetNodeRecord(ctx context.Context, id types.ID) (*NodeRecord, error) {
+	b, closer, err := tm.db.Get(ctx, []byte(nodeRecordPrefix+id.String()))
+	if err != nil {
+		if errors.Is(err, pebble.ErrNotFound) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("getting node record for %s: %w", id, err)
+	}
+	defer func() { _ = closer.Close() }()
+	record := &NodeRecord{}
+	if err := json.Unmarshal(b, record); err != nil {
+		return nil, fmt.Errorf("unmarshalling node record for %s: %w", id, err)
+	}
+	return record, nil
+}
+
 func (tm *TableManager) RegisterStore(
 	ctx context.Context,
 	req *store.StoreRegistrationRequest,
 ) error {
+	tm.Lock()
+	defer tm.Unlock()
+
+	if err := tm.registerNodeLocked(ctx, &NodeRecord{NodeID: req.ID}); err != nil {
+		return err
+	}
+
 	state := store.StoreState_Healthy
 	tombstoned, err := tm.HasStoreTombstone(ctx, req.ID)
 	if err != nil {
@@ -959,7 +1196,7 @@ func (tm *TableManager) RegisterStore(
 	}
 	// If the request contains shards, we need to update the shard status
 	if len(req.Shards) > 0 {
-		return tm.UpdateStatuses(ctx, newStatus)
+		return tm.updateStatusesLocked(ctx, newStatus)
 	}
 	if err := tm.saveStoreStatuses(newStatus); err != nil {
 		return fmt.Errorf("saving node status: %w", err)

--- a/src/tablemgr/table.go
+++ b/src/tablemgr/table.go
@@ -989,9 +989,13 @@ func (tm *TableManager) RequestNodeShutdown(ctx context.Context, id types.ID, re
 		}
 		record = &NodeRecord{NodeID: id}
 	}
+	now := time.Now()
+	if record.Lifecycle != NodeLifecycleDraining || record.DrainingSince.IsZero() {
+		record.DrainingSince = now
+	}
 	record.Lifecycle = NodeLifecycleDraining
 	record.Reason = reason
-	record.LastSeen = time.Now()
+	record.LastSeen = now
 	nodeData, err := json.Marshal(record)
 	if err != nil {
 		return fmt.Errorf("marshalling node record for %s: %w", id, err)
@@ -1064,6 +1068,7 @@ func (tm *TableManager) ClearStoreTombstone(ctx context.Context, id types.ID) er
 	record.Lifecycle = NodeLifecycleActive
 	record.Reason = ""
 	record.LastSeen = time.Now()
+	record.DrainingSince = time.Time{}
 	data, err := json.Marshal(record)
 	if err != nil {
 		return fmt.Errorf("marshalling node record for %s: %w", id, err)


### PR DESCRIPTION
## Summary
- add operator support for autoscaling and grow-only storage updates
- gate data-node scale-down on the metadata node shutdown API
- align Go node registration/shutdown status with the /internal/v1/nodes model, including group_statuses voter_count handling
- clean up the operator work-log notes for the node API path

## Tests
- GOCACHE=/tmp/antfly-go-build go test ./pkg/operator/...
- GOCACHE=/tmp/antfly-go-build go test ./src/metadata -run 'TestNodeShutdown|TestNodeRegistration|TestDeleteTombstones' -count=1
- GOCACHE=/tmp/antfly-go-build go test ./src/store -run 'TestNodeRegistrationEndpoint|TestShardInfosToNodeGroupStatusReports' -count=1
- GOCACHE=/tmp/antfly-go-build go test ./src/tablemgr -count=1

Note: a full ./src/store run still has the pre-existing TestProposeOnCommitMulti failure observed locally.