### PR TITLE
Apply TypeScript private deps patch

### DIFF
--- a/ts/packages/design-system/package.json
+++ b/ts/packages/design-system/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antfly/design-system",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Antfly's shared shadcn/ui component library: primitives, compound components, brand blocks, design tokens, and Aeonik.",
   "author": "Antfly, Inc. <contact@antfly.io>",
   "license": "MIT",

--- a/ts/packages/design-system/src/components/brand/anty/anty.tsx
+++ b/ts/packages/design-system/src/components/brand/anty/anty.tsx
@@ -371,6 +371,7 @@ export const Anty = forwardRef<AntyHandle, AntyProps>((props, ref) => {
 
   // Memoize so the idle-animation effect doesn't restart on every parent render.
   // eslint-disable-next-line react-hooks/exhaustive-deps
+  // biome-ignore lint/correctness/useExhaustiveDependencies: refsReady triggers recapture of DOM refs after mount
   const elements = useMemo(
     () => ({
       container: containerRef.current,
@@ -387,7 +388,7 @@ export const Anty = forwardRef<AntyHandle, AntyProps>((props, ref) => {
       innerGlow: innerGlowRef.current,
       outerGlow: outerGlowRef.current,
     }),
-    []
+    [refsReady]
   );
 
   // Animation controller

--- a/ts/packages/graph/package.json
+++ b/ts/packages/graph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antfly/graph",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "private": false,
   "description": "Force-directed graph component for the Antfly design system",
   "type": "module",


### PR DESCRIPTION
## Summary
- Bump `@antfly/design-system` to `0.0.5`
- Bump `@antfly/graph` to `0.0.2`
- Recompute Anty refs when `refsReady` changes and suppress the Biome exhaustive-deps warning with context

## Verification
- `pnpm --filter @antfly/design-system lint` (exits 0; existing Biome warnings remain)
- `pnpm --filter @antfly/design-system typecheck`
- `pnpm --filter @antfly/graph lint`
- `pnpm --filter @antfly/graph typecheck`
- `git diff --check`