### PR TITLE
Fix operator PVC ownership for non-root Antfly runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,12 @@ LABEL org.opencontainers.image.source=https://github.com/antflydb/antfly
 LABEL org.opencontainers.image.description="AntflyDB - Distributed document database with vector search for AI applications"
 LABEL org.opencontainers.image.licenses=Elastic-2.0
 
-# Create non-root user with home directory (needed for default ~/.antfly storage)
-RUN addgroup -S antfly && adduser -S -G antfly -h /home/antfly antfly
+# Create non-root user with a stable UID/GID so Kubernetes fsGroup and init
+# container ownership fixes match the runtime user across images.
+ARG ANTFLY_UID=10001
+ARG ANTFLY_GID=10001
+RUN addgroup -S -g ${ANTFLY_GID} antfly && \
+    adduser -S -u ${ANTFLY_UID} -G antfly -h /home/antfly antfly
 
 # Copy the built binary from the builder stage
 COPY --from=builder /app/antfly /antfly

--- a/Dockerfile.omni
+++ b/Dockerfile.omni
@@ -142,8 +142,12 @@ RUN curl -fsSL "https://storage.googleapis.com/cloud-tpu-tpuvm-artifacts/libtpu/
     ln -s /usr/local/lib/go-xla/libtpu.so /usr/local/lib/go-xla/pjrt_plugin_tpu.so || \
     echo "Warning: Could not download libtpu.so. TPU support requires GKE TPU nodes."
 
-# Create non-root user with home directory (needed for default ~/.antfly storage)
-RUN groupadd -r antfly && useradd -r -g antfly -m antfly
+# Create non-root user with a stable UID/GID so Kubernetes fsGroup and init
+# container ownership fixes match the runtime user across images.
+ARG ANTFLY_UID=10001
+ARG ANTFLY_GID=10001
+RUN groupadd --system --gid ${ANTFLY_GID} antfly && \
+    useradd --system --uid ${ANTFLY_UID} --gid ${ANTFLY_GID} --create-home antfly
 
 # Copy binary from builder
 COPY --from=builder /antfly /antfly

--- a/pkg/operator/controllers/antfly/antflycluster_controller.go
+++ b/pkg/operator/controllers/antfly/antflycluster_controller.go
@@ -61,6 +61,11 @@ type AntflyClusterReconciler struct {
 
 var defaultOperatorHTTPClient = &http.Client{Timeout: 10 * time.Second}
 
+const (
+	antflyRuntimeUID int64 = 10001
+	antflyRuntimeGID int64 = 10001
+)
+
 //+kubebuilder:rbac:groups=antfly.io,resources=antflyclusters,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=antfly.io,resources=antflyclusters/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=antfly.io,resources=antflyclusters/finalizers,verbs=update
@@ -81,6 +86,21 @@ var defaultOperatorHTTPClient = &http.Client{Timeout: 10 * time.Second}
 //+kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch;create;update;patch
 
 var reservedPodLabelPrefixes = []string{"app.kubernetes.io/"}
+
+func int64Ptr(v int64) *int64 {
+	return &v
+}
+
+func podFSGroupChangePolicyPtr(v corev1.PodFSGroupChangePolicy) *corev1.PodFSGroupChangePolicy {
+	return &v
+}
+
+func antflyPodSecurityContext() *corev1.PodSecurityContext {
+	return &corev1.PodSecurityContext{
+		FSGroup:             int64Ptr(antflyRuntimeGID),
+		FSGroupChangePolicy: podFSGroupChangePolicyPtr(corev1.FSGroupChangeOnRootMismatch),
+	}
+}
 
 // podLabels returns the standard labels for pod templates including the instance identifier.
 // These are a superset of serviceSelectorLabels — they include managed-by labels
@@ -2029,6 +2049,7 @@ func (r *AntflyClusterReconciler) reconcileSwarmStatefulSet(ctx context.Context,
 			},
 			Spec: corev1.PodSpec{
 				ServiceAccountName: cluster.Spec.ServiceAccountName,
+				SecurityContext:    antflyPodSecurityContext(),
 				InitContainers: []corev1.Container{
 					r.buildStorageInitContainer("swarm-storage"),
 				},
@@ -2266,6 +2287,7 @@ func (r *AntflyClusterReconciler) reconcileMetadataStatefulSet(ctx context.Conte
 			},
 			Spec: corev1.PodSpec{
 				ServiceAccountName: cluster.Spec.ServiceAccountName,
+				SecurityContext:    antflyPodSecurityContext(),
 				InitContainers: []corev1.Container{
 					r.buildStorageInitContainer("metadata-storage"),
 				},
@@ -2476,6 +2498,7 @@ func (r *AntflyClusterReconciler) reconcileDataStatefulSet(ctx context.Context, 
 			},
 			Spec: corev1.PodSpec{
 				ServiceAccountName: cluster.Spec.ServiceAccountName,
+				SecurityContext:    antflyPodSecurityContext(),
 				InitContainers: []corev1.Container{
 					r.buildStorageInitContainer("data-storage"),
 				},
@@ -2703,15 +2726,18 @@ func nodeIDForDataOrdinal(ordinal int32) string {
 	return strconv.FormatInt(int64(ordinal+1), 10)
 }
 
-// buildStorageInitContainer creates an init container that waits for the PVC to be properly mounted.
-// This prevents a race condition where the main container starts before the PVC is attached,
-// which could cause Antfly to bootstrap a fresh cluster instead of recovering from existing data.
+// buildStorageInitContainer creates an init container that waits for the PVC to
+// be mounted and prepares ownership for the non-root Antfly runtime user. This
+// prevents a race where the main container starts before the PVC is attached,
+// and recovers existing PVCs that were created with root-owned directories.
 func (r *AntflyClusterReconciler) buildStorageInitContainer(volumeName string) corev1.Container {
 	return corev1.Container{
 		Name:    "wait-for-storage",
 		Image:   "busybox:1.36",
 		Command: []string{"/bin/sh", "-c"},
-		Args: []string{`
+		Args: []string{fmt.Sprintf(`
+set -eu
+
 echo "Checking PVC mount status..."
 timeout=120
 while [ $timeout -gt 0 ]; do
@@ -2723,6 +2749,19 @@ while [ $timeout -gt 0 ]; do
         else
             echo "No existing data - fresh cluster"
         fi
+        marker=/antflydb/.antflydb-storage-prepared
+        echo "Preparing PVC directories for antfly runtime user %d:%d"
+        mkdir -p /antflydb/metadata /antflydb/store
+        if [ ! -f "$marker" ]; then
+            chown -R %d:%d /antflydb
+            chmod -R ug+rwX /antflydb
+            touch "$marker"
+            chown %d:%d "$marker"
+            chmod ug+rw "$marker"
+        else
+            chown %d:%d /antflydb /antflydb/metadata /antflydb/store
+            chmod ug+rwX /antflydb /antflydb/metadata /antflydb/store
+        fi
         exit 0
     fi
     echo "Waiting for PVC mount... ($timeout seconds remaining)"
@@ -2731,7 +2770,19 @@ while [ $timeout -gt 0 ]; do
 done
 echo "ERROR: PVC mount timeout after 120 seconds"
 exit 1
-`},
+`,
+			antflyRuntimeUID,
+			antflyRuntimeGID,
+			antflyRuntimeUID,
+			antflyRuntimeGID,
+			antflyRuntimeUID,
+			antflyRuntimeGID,
+			antflyRuntimeUID,
+			antflyRuntimeGID,
+		)},
+		SecurityContext: &corev1.SecurityContext{
+			RunAsUser: int64Ptr(0),
+		},
 		VolumeMounts: []corev1.VolumeMount{
 			{
 				Name:      volumeName,

--- a/pkg/operator/controllers/antfly/antflycluster_controller_test.go
+++ b/pkg/operator/controllers/antfly/antflycluster_controller_test.go
@@ -2235,6 +2235,68 @@ func TestPodTemplateLabelsUpdateWhenClusterLabelsChange(t *testing.T) {
 	g.Expect(sts.Spec.Template.Labels).To(HaveKeyWithValue("app.kubernetes.io/managed-by", "antfly-operator"))
 }
 
+func TestMetadataStatefulSetPreparesPersistentStorageForNonRootRuntime(t *testing.T) {
+	g := NewWithT(t)
+
+	s := runtime.NewScheme()
+	g.Expect(antflyv1.AddToScheme(s)).To(Succeed())
+	g.Expect(appsv1.AddToScheme(s)).To(Succeed())
+	g.Expect(corev1.AddToScheme(s)).To(Succeed())
+
+	cluster := &antflyv1.AntflyCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "storage-security-cluster",
+			Namespace: "default",
+		},
+		Spec: antflyv1.AntflyClusterSpec{
+			Image: "antfly:latest",
+			MetadataNodes: antflyv1.MetadataNodesSpec{
+				MetadataAPI:  antflyv1.APISpec{Port: 12377},
+				MetadataRaft: antflyv1.APISpec{Port: 9017},
+				Health:       antflyv1.APISpec{Port: 4200},
+			},
+			Storage: antflyv1.StorageSpec{
+				StorageClass:    "standard",
+				MetadataStorage: "1Gi",
+			},
+			Config: "{}",
+		},
+	}
+
+	client := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(cluster).
+		Build()
+
+	reconciler := &AntflyClusterReconciler{
+		Client: client,
+		Scheme: s,
+	}
+
+	g.Expect(reconciler.reconcileMetadataStatefulSet(context.Background(), &envFromCache{}, cluster)).To(Succeed())
+
+	sts := &appsv1.StatefulSet{}
+	key := types.NamespacedName{Name: cluster.Name + "-metadata", Namespace: cluster.Namespace}
+	g.Expect(client.Get(context.Background(), key, sts)).To(Succeed())
+
+	podSecurityContext := sts.Spec.Template.Spec.SecurityContext
+	g.Expect(podSecurityContext).NotTo(BeNil())
+	g.Expect(podSecurityContext.FSGroup).NotTo(BeNil())
+	g.Expect(*podSecurityContext.FSGroup).To(Equal(antflyRuntimeGID))
+	g.Expect(podSecurityContext.FSGroupChangePolicy).NotTo(BeNil())
+	g.Expect(*podSecurityContext.FSGroupChangePolicy).To(Equal(corev1.FSGroupChangeOnRootMismatch))
+
+	g.Expect(sts.Spec.Template.Spec.InitContainers).To(HaveLen(1))
+	initContainer := sts.Spec.Template.Spec.InitContainers[0]
+	g.Expect(initContainer.SecurityContext).NotTo(BeNil())
+	g.Expect(initContainer.SecurityContext.RunAsUser).NotTo(BeNil())
+	g.Expect(*initContainer.SecurityContext.RunAsUser).To(Equal(int64(0)))
+	g.Expect(initContainer.Args).To(HaveLen(1))
+	g.Expect(initContainer.Args[0]).To(ContainSubstring("mkdir -p /antflydb/metadata /antflydb/store"))
+	g.Expect(initContainer.Args[0]).To(ContainSubstring("chown -R 10001:10001 /antflydb"))
+	g.Expect(initContainer.Args[0]).To(ContainSubstring("chmod -R ug+rwX /antflydb"))
+}
+
 // TestSelectorLabels tests that selectorLabels includes instance but not managed-by
 // TestServiceSelectorLabels tests that serviceSelectorLabels includes instance but not managed-by
 func TestServiceSelectorLabels(t *testing.T) {


### PR DESCRIPTION
## Summary
- pin Antfly runtime UID/GID to 10001 in standard and omni images
- set operator-managed StatefulSet fsGroup with OnRootMismatch
- prepare mounted PVC directories in the storage init container so non-root Antfly can write existing and new volumes

## Test
- env GOCACHE=/tmp/colony-go-build-cache go test ./pkg/operator/controllers/antfly

Note: local test emits the existing Darwin ONNX runtime linker warning, but passes.