### PR TITLE
Add structured record mapping utilities

### DIFF
--- a/pkg/docsaf/registry.go
+++ b/pkg/docsaf/registry.go
@@ -61,9 +61,9 @@ func DefaultRegistry(opts ...RegistryOption) ProcessorRegistry {
 		opt(&cfg)
 	}
 
-	capacity := 6
+	capacity := 7
 	if cfg.imageReader != nil {
-		capacity = 7
+		capacity = 8
 	}
 	r := &registry{
 		processors: make([]ContentProcessor, 0, capacity),
@@ -71,6 +71,7 @@ func DefaultRegistry(opts ...RegistryOption) ProcessorRegistry {
 	r.Register(&MarkdownProcessor{})
 	r.Register(&OpenAPIProcessor{})
 	r.Register(&HTMLProcessor{})
+	r.Register(&XMLProcessor{})
 	r.Register(&PDFProcessor{OCR: cfg.ocr})
 	r.Register(&DocxProcessor{})
 	r.Register(&PptxProcessor{})

--- a/pkg/docsaf/xml.go
+++ b/pkg/docsaf/xml.go
@@ -1,0 +1,383 @@
+package docsaf
+
+import (
+	"bytes"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"maps"
+	"path/filepath"
+	"strings"
+)
+
+// XMLProcessor processes generic XML documents.
+// It prefers article-like elements as sections and falls back to one whole-document section.
+type XMLProcessor struct{}
+
+type xmlNode struct {
+	name     xml.Name
+	attrs    []xml.Attr
+	text     string
+	children []*xmlNode
+	parent   *xmlNode
+}
+
+var xmlSectionElementNames = map[string]bool{
+	"article":  true,
+	"content":  true,
+	"document": true,
+	"entry":    true,
+	"item":     true,
+	"page":     true,
+	"post":     true,
+	"record":   true,
+	"section":  true,
+	"story":    true,
+}
+
+var xmlTitleElementNames = []string{"title", "headline", "heading", "name", "subject"}
+var xmlBodyElementNames = []string{"body", "content", "articlebody", "description", "summary", "text"}
+var xmlURLElementNames = []string{"url", "link", "canonical_url", "canonicalurl", "permalink"}
+var xmlDateElementNames = []string{"published_at", "publishedat", "pubdate", "date", "updated_at", "updatedat", "lastmod"}
+
+// CanProcess returns true for XML content types or .xml extensions.
+func (xp *XMLProcessor) CanProcess(contentType, path string) bool {
+	lowerContentType := strings.ToLower(contentType)
+	if strings.Contains(lowerContentType, "xml") && !strings.Contains(lowerContentType, "html") {
+		return true
+	}
+	return strings.HasSuffix(strings.ToLower(path), ".xml")
+}
+
+// Process processes XML content and returns document sections.
+func (xp *XMLProcessor) Process(path, sourceURL, baseURL string, content []byte) ([]DocumentSection, error) {
+	root, err := parseXMLNodeTree(content)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse XML: %w", err)
+	}
+	if root == nil {
+		return nil, fmt.Errorf("XML document is empty")
+	}
+
+	docMetadata := xp.extractDocumentMetadata(root, path)
+	if sourceURL != "" {
+		docMetadata["source_url"] = sourceURL
+	}
+
+	sectionNodes := xp.findSectionNodes(root)
+	if len(sectionNodes) == 0 {
+		sectionNodes = []*xmlNode{root}
+	}
+
+	sections := make([]DocumentSection, 0, len(sectionNodes))
+	totalSections := len(sectionNodes)
+	slugs := newSlugCounter()
+	for i, node := range sectionNodes {
+		section := xp.buildSection(node, path, baseURL, docMetadata, i+1, totalSections, slugs)
+		if strings.TrimSpace(section.Content) == "" {
+			continue
+		}
+		sections = append(sections, section)
+	}
+
+	return sections, nil
+}
+
+func parseXMLNodeTree(content []byte) (*xmlNode, error) {
+	decoder := xml.NewDecoder(bytes.NewReader(content))
+	var stack []*xmlNode
+	var root *xmlNode
+
+	for {
+		tok, err := decoder.Token()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return nil, err
+		}
+
+		switch t := tok.(type) {
+		case xml.StartElement:
+			node := &xmlNode{name: t.Name, attrs: append([]xml.Attr(nil), t.Attr...)}
+			if len(stack) > 0 {
+				node.parent = stack[len(stack)-1]
+				node.parent.children = append(node.parent.children, node)
+			} else {
+				root = node
+			}
+			stack = append(stack, node)
+
+		case xml.EndElement:
+			if len(stack) > 0 {
+				stack = stack[:len(stack)-1]
+			}
+
+		case xml.CharData:
+			if len(stack) > 0 {
+				text := strings.TrimSpace(string(t))
+				if text != "" {
+					current := stack[len(stack)-1]
+					if current.text != "" {
+						current.text += " "
+					}
+					current.text += text
+				}
+			}
+		}
+	}
+
+	return root, nil
+}
+
+func (xp *XMLProcessor) findSectionNodes(root *xmlNode) []*xmlNode {
+	var sections []*xmlNode
+	collectXMLSectionNodes(root, root, &sections)
+
+	if len(sections) > 0 {
+		return sections
+	}
+
+	repeated := repeatedChildSections(root)
+	if len(repeated) > 1 {
+		return repeated
+	}
+
+	return nil
+}
+
+func collectXMLSectionNodes(root, node *xmlNode, sections *[]*xmlNode) {
+	if node != root && xmlSectionElementNames[normalizeXMLName(node.name.Local)] && strings.TrimSpace(node.collectText()) != "" {
+		*sections = append(*sections, node)
+		return
+	}
+	for _, child := range node.children {
+		collectXMLSectionNodes(root, child, sections)
+	}
+}
+
+func repeatedChildSections(root *xmlNode) []*xmlNode {
+	counts := make(map[string]int)
+	for _, child := range root.children {
+		if strings.TrimSpace(child.collectText()) == "" {
+			continue
+		}
+		counts[normalizeXMLName(child.name.Local)]++
+	}
+
+	var sectionName string
+	for name, count := range counts {
+		if count > 1 {
+			sectionName = name
+			break
+		}
+	}
+	if sectionName == "" {
+		return nil
+	}
+
+	var sections []*xmlNode
+	for _, child := range root.children {
+		if normalizeXMLName(child.name.Local) == sectionName {
+			sections = append(sections, child)
+		}
+	}
+	return sections
+}
+
+func (xp *XMLProcessor) buildSection(node *xmlNode, path, baseURL string, docMetadata map[string]any, ordinal, totalSections int, slugs *slugCounter) DocumentSection {
+	title := firstNonEmpty(
+		node.findFirstText(xmlTitleElementNames...),
+		node.attrValue("title"),
+		node.attrValue("name"),
+	)
+	if title == "" {
+		if ordinal == 1 {
+			if docTitle, ok := docMetadata["title"].(string); ok && docTitle != "" {
+				title = docTitle
+			}
+		}
+	}
+	if title == "" {
+		title = fmt.Sprintf("%s %d", node.name.Local, ordinal)
+	}
+
+	content := node.findFirstText(xmlBodyElementNames...)
+	if content == "" {
+		content = node.collectText()
+	}
+
+	sectionPath := node.path()
+	identifier := strings.Join(append(sectionPath, title), " > ")
+	slug := slugs.unique(generateSlug(title))
+
+	url := node.findFirstText(xmlURLElementNames...)
+	if url == "" && baseURL != "" {
+		url = baseURL + "/" + transformXMLPath(path)
+		if slug != "" {
+			url += "#" + slug
+		}
+	}
+
+	metadata := make(map[string]any)
+	maps.Copy(metadata, docMetadata)
+	maps.Copy(metadata, node.simpleChildMetadata())
+	maps.Copy(metadata, map[string]any{
+		"element_name":   node.name.Local,
+		"element_path":   strings.Join(sectionPath, "/"),
+		"section_number": ordinal,
+		"total_sections": totalSections,
+	})
+	if len(node.attrs) > 0 {
+		metadata["attributes"] = attrsToMap(node.attrs)
+	}
+	if date := node.findFirstText(xmlDateElementNames...); date != "" {
+		metadata["date"] = date
+	}
+
+	docType := "xml_element"
+	if node.parent == nil {
+		docType = "xml_document"
+	}
+
+	return DocumentSection{
+		ID:          generateID(path, identifier),
+		FilePath:    path,
+		Title:       title,
+		Content:     strings.TrimSpace(content),
+		Type:        docType,
+		URL:         url,
+		SectionPath: sectionPath,
+		Metadata:    metadata,
+	}
+}
+
+func (xp *XMLProcessor) extractDocumentMetadata(root *xmlNode, path string) map[string]any {
+	metadata := map[string]any{
+		"root_element": root.name.Local,
+		"title":        filepath.Base(path),
+	}
+	if title := root.findFirstText(xmlTitleElementNames...); title != "" {
+		metadata["title"] = title
+	}
+	if date := root.findFirstText(xmlDateElementNames...); date != "" {
+		metadata["date"] = date
+	}
+	return metadata
+}
+
+func (n *xmlNode) collectText() string {
+	var parts []string
+	n.collectTextParts(&parts)
+	return strings.Join(parts, "\n\n")
+}
+
+func (n *xmlNode) collectTextParts(parts *[]string) {
+	if n.text != "" {
+		*parts = append(*parts, n.text)
+	}
+	for _, child := range n.children {
+		child.collectTextParts(parts)
+	}
+}
+
+func (n *xmlNode) findFirstText(names ...string) string {
+	wanted := make(map[string]bool, len(names))
+	for _, name := range names {
+		wanted[normalizeXMLName(name)] = true
+	}
+
+	var found string
+	walkXML(n, func(node *xmlNode) {
+		if found != "" {
+			return
+		}
+		if wanted[normalizeXMLName(node.name.Local)] {
+			found = strings.TrimSpace(node.collectText())
+		}
+	})
+	return found
+}
+
+func (n *xmlNode) attrValue(name string) string {
+	normalized := normalizeXMLName(name)
+	for _, attr := range n.attrs {
+		if normalizeXMLName(attr.Name.Local) == normalized {
+			return strings.TrimSpace(attr.Value)
+		}
+	}
+	return ""
+}
+
+func (n *xmlNode) path() []string {
+	var reversed []string
+	for current := n; current != nil; current = current.parent {
+		reversed = append(reversed, current.name.Local)
+	}
+	path := make([]string, len(reversed))
+	for i := range reversed {
+		path[i] = reversed[len(reversed)-1-i]
+	}
+	return path
+}
+
+func (n *xmlNode) simpleChildMetadata() map[string]any {
+	metadata := make(map[string]any)
+	for _, child := range n.children {
+		if len(child.children) > 0 {
+			continue
+		}
+		value := strings.TrimSpace(child.text)
+		if value == "" || len(value) > 512 {
+			continue
+		}
+		key := "xml_" + normalizeXMLName(child.name.Local)
+		if _, exists := metadata[key]; !exists {
+			metadata[key] = value
+		}
+	}
+	return metadata
+}
+
+func attrsToMap(attrs []xml.Attr) map[string]string {
+	result := make(map[string]string, len(attrs))
+	for _, attr := range attrs {
+		key := attr.Name.Local
+		if attr.Name.Space != "" {
+			key = attr.Name.Space + ":" + attr.Name.Local
+		}
+		result[key] = attr.Value
+	}
+	return result
+}
+
+func walkXML(node *xmlNode, fn func(*xmlNode)) {
+	if node == nil {
+		return
+	}
+	fn(node)
+	for _, child := range node.children {
+		walkXML(child, fn)
+	}
+}
+
+func normalizeXMLName(name string) string {
+	name = strings.ToLower(strings.TrimSpace(name))
+	name = strings.ReplaceAll(name, "-", "")
+	name = strings.ReplaceAll(name, "_", "")
+	return name
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+
+// transformXMLPath removes .xml extensions from the path for cleaner URLs.
+func transformXMLPath(path string) string {
+	return strings.TrimSuffix(path, ".xml")
+}

--- a/pkg/docsaf/xml_test.go
+++ b/pkg/docsaf/xml_test.go
@@ -1,0 +1,137 @@
+package docsaf
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestXMLProcessor_CanProcess(t *testing.T) {
+	xp := &XMLProcessor{}
+
+	tests := []struct {
+		name        string
+		contentType string
+		path        string
+		want        bool
+	}{
+		{"XML MIME", "application/xml", "feed", true},
+		{"Text XML MIME", "text/xml; charset=utf-8", "feed", true},
+		{"RSS MIME", "application/rss+xml", "feed", true},
+		{"XML extension", "", "articles.xml", true},
+		{"HTML excluded", "text/html", "page.html", false},
+		{"Markdown", "text/markdown", "doc.md", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := xp.CanProcess(tt.contentType, tt.path); got != tt.want {
+				t.Fatalf("CanProcess(%q, %q) = %v, want %v", tt.contentType, tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestXMLProcessor_ProcessArticleElements(t *testing.T) {
+	xp := &XMLProcessor{}
+	content := []byte(`<?xml version="1.0" encoding="UTF-8"?>
+<archive>
+  <article id="a1">
+    <title>New resorts in Cancun</title>
+    <url>https://example.com/cancun</url>
+    <published_at>2026-04-12</published_at>
+    <brand>Travel Weekly</brand>
+    <body>
+      <p>Luxury resorts are opening in Cancun.</p>
+      <p>Several brands are expanding all-inclusive offerings.</p>
+    </body>
+  </article>
+  <article id="a2">
+    <headline>Airline trends</headline>
+    <content>Airlines are changing routes for business travel demand.</content>
+  </article>
+</archive>`)
+
+	sections, err := xp.Process("northstar/articles.xml", "", "https://feeds.example.com", content)
+	if err != nil {
+		t.Fatalf("Process returned error: %v", err)
+	}
+	if len(sections) != 2 {
+		t.Fatalf("got %d sections, want 2", len(sections))
+	}
+
+	first := sections[0]
+	if first.Type != "xml_element" {
+		t.Fatalf("first.Type = %q, want xml_element", first.Type)
+	}
+	if first.Title != "New resorts in Cancun" {
+		t.Fatalf("first.Title = %q", first.Title)
+	}
+	if first.URL != "https://example.com/cancun" {
+		t.Fatalf("first.URL = %q", first.URL)
+	}
+	if !strings.Contains(first.Content, "Luxury resorts are opening") {
+		t.Fatalf("first.Content = %q", first.Content)
+	}
+	if got := first.Metadata["root_element"]; got != "archive" {
+		t.Fatalf("root_element metadata = %v", got)
+	}
+	if got := first.Metadata["xml_brand"]; got != "Travel Weekly" {
+		t.Fatalf("xml_brand metadata = %v", got)
+	}
+	if got := first.Metadata["date"]; got != "2026-04-12" {
+		t.Fatalf("date metadata = %v", got)
+	}
+	attrs, ok := first.Metadata["attributes"].(map[string]string)
+	if !ok || attrs["id"] != "a1" {
+		t.Fatalf("attributes metadata = %#v", first.Metadata["attributes"])
+	}
+
+	second := sections[1]
+	if second.Title != "Airline trends" {
+		t.Fatalf("second.Title = %q", second.Title)
+	}
+	if second.URL != "https://feeds.example.com/northstar/articles#airline-trends" {
+		t.Fatalf("second.URL = %q", second.URL)
+	}
+}
+
+func TestXMLProcessor_ProcessFallbackWholeDocument(t *testing.T) {
+	xp := &XMLProcessor{}
+	content := []byte(`<profile><title>Supplier Profile</title><summary>Important supplier details.</summary></profile>`)
+
+	sections, err := xp.Process("profiles/supplier.xml", "s3://bucket/profiles/supplier.xml", "https://example.com/docs", content)
+	if err != nil {
+		t.Fatalf("Process returned error: %v", err)
+	}
+	if len(sections) != 1 {
+		t.Fatalf("got %d sections, want 1", len(sections))
+	}
+
+	section := sections[0]
+	if section.Type != "xml_document" {
+		t.Fatalf("section.Type = %q, want xml_document", section.Type)
+	}
+	if section.Title != "Supplier Profile" {
+		t.Fatalf("section.Title = %q", section.Title)
+	}
+	if section.URL != "https://example.com/docs/profiles/supplier#supplier-profile" {
+		t.Fatalf("section.URL = %q", section.URL)
+	}
+	if got := section.Metadata["source_url"]; got != "s3://bucket/profiles/supplier.xml" {
+		t.Fatalf("source_url metadata = %v", got)
+	}
+}
+
+func TestXMLProcessor_RegisteredInDefaultRegistry(t *testing.T) {
+	registry := DefaultRegistry()
+	processor := registry.GetProcessor("application/xml", "articles.xml")
+	if _, ok := processor.(*XMLProcessor); !ok {
+		t.Fatalf("processor = %T, want *XMLProcessor", processor)
+	}
+}
+
+func TestTransformXMLPath(t *testing.T) {
+	if got := transformXMLPath("feeds/articles.xml"); got != "feeds/articles" {
+		t.Fatalf("transformXMLPath() = %q", got)
+	}
+}

--- a/pkg/libaf/structured/structured.go
+++ b/pkg/libaf/structured/structured.go
@@ -1,0 +1,816 @@
+package structured
+
+import (
+	"bytes"
+	"context"
+	"encoding/csv"
+	"encoding/json"
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"io"
+	"slices"
+	"strconv"
+	"strings"
+
+	"go.yaml.in/yaml/v3"
+)
+
+// Format identifies the source document format for a mapping.
+type Format string
+
+const (
+	FormatJSON   Format = "json"
+	FormatYAML   Format = "yaml"
+	FormatXML    Format = "xml"
+	FormatCSV    Format = "csv"
+	FormatNDJSON Format = "ndjson"
+)
+
+// FieldType controls optional value coercion for mapped fields.
+type FieldType string
+
+const (
+	FieldTypeString FieldType = ""
+	FieldTypeBool   FieldType = "bool"
+	FieldTypeInt    FieldType = "int"
+	FieldTypeFloat  FieldType = "float"
+	FieldTypeRaw    FieldType = "raw"
+)
+
+// MappingConfig describes how to convert structured input records into Antfly-ready documents.
+type MappingConfig struct {
+	Format         Format                  `json:"format" yaml:"format"`
+	RecordSelector string                  `json:"record_selector" yaml:"record_selector"`
+	Fields         map[string]FieldMapping `json:"fields" yaml:"fields"`
+	Options        MappingOptions          `json:"options,omitempty" yaml:"options,omitempty"`
+}
+
+// MappingOptions contains format-specific mapping controls.
+type MappingOptions struct {
+	CSVHasHeader bool   `json:"csv_has_header,omitempty" yaml:"csv_has_header,omitempty"`
+	CSVDelimiter string `json:"csv_delimiter,omitempty" yaml:"csv_delimiter,omitempty"`
+	IDField      string `json:"id_field,omitempty" yaml:"id_field,omitempty"`
+}
+
+// FieldMapping describes how to extract one output field.
+type FieldMapping struct {
+	Path     string    `json:"path,omitempty" yaml:"path,omitempty"`
+	Paths    []string  `json:"paths,omitempty" yaml:"paths,omitempty"`
+	Fallback []string  `json:"fallback,omitempty" yaml:"fallback,omitempty"`
+	Multiple bool      `json:"multiple,omitempty" yaml:"multiple,omitempty"`
+	Required bool      `json:"required,omitempty" yaml:"required,omitempty"`
+	Join     string    `json:"join,omitempty" yaml:"join,omitempty"`
+	Type     FieldType `json:"type,omitempty" yaml:"type,omitempty"`
+	Default  any       `json:"default,omitempty" yaml:"default,omitempty"`
+}
+
+// Record is one mapped source record.
+type Record struct {
+	ID       string         `json:"id"`
+	Document map[string]any `json:"document"`
+}
+
+// DiagnosticLevel describes diagnostic severity.
+type DiagnosticLevel string
+
+const (
+	DiagnosticInfo    DiagnosticLevel = "info"
+	DiagnosticWarning DiagnosticLevel = "warning"
+	DiagnosticError   DiagnosticLevel = "error"
+)
+
+// MappingDiagnostic describes a mapping problem or noteworthy fallback.
+type MappingDiagnostic struct {
+	Level  DiagnosticLevel `json:"level"`
+	Field  string          `json:"field,omitempty"`
+	Record int             `json:"record,omitempty"`
+	Path   string          `json:"path,omitempty"`
+	Code   string          `json:"code"`
+	Detail string          `json:"detail"`
+}
+
+// Preview is a bounded mapping result with diagnostics for UI inspection.
+type Preview struct {
+	Records      []Record            `json:"records"`
+	Diagnostics  []MappingDiagnostic `json:"diagnostics"`
+	TotalRecords int                 `json:"total_records"`
+	Skipped      int                 `json:"skipped"`
+}
+
+// RecordMapper maps structured inputs into records.
+type RecordMapper interface {
+	Validate(MappingConfig) error
+	Preview(context.Context, []byte, MappingConfig, int) (*Preview, error)
+	Map(context.Context, []byte, MappingConfig) ([]Record, error)
+}
+
+// Mapper is the default RecordMapper implementation.
+type Mapper struct{}
+
+// NewMapper creates a structured record mapper.
+func NewMapper() *Mapper {
+	return &Mapper{}
+}
+
+// Validate validates a mapping config.
+func (m *Mapper) Validate(config MappingConfig) error {
+	if !slices.Contains([]Format{FormatJSON, FormatYAML, FormatXML, FormatCSV, FormatNDJSON}, config.Format) {
+		return fmt.Errorf("unsupported format %q", config.Format)
+	}
+	if strings.TrimSpace(config.RecordSelector) == "" && config.Format != FormatCSV && config.Format != FormatNDJSON {
+		return errors.New("record_selector is required")
+	}
+	if len(config.Fields) == 0 {
+		return errors.New("at least one field mapping is required")
+	}
+	for name, field := range config.Fields {
+		if strings.TrimSpace(name) == "" {
+			return errors.New("field names cannot be empty")
+		}
+		if strings.Contains(name, ".") {
+			return fmt.Errorf("field %q cannot contain dots", name)
+		}
+		if len(field.selectorCandidates()) == 0 && field.Default == nil {
+			return fmt.Errorf("field %q must define path, paths, fallback, or default", name)
+		}
+	}
+	return nil
+}
+
+// Map maps all records from input.
+func (m *Mapper) Map(ctx context.Context, input []byte, config MappingConfig) ([]Record, error) {
+	result, err := m.mapWithDiagnostics(ctx, input, config, 0)
+	if err != nil {
+		return nil, err
+	}
+	return result.Records, nil
+}
+
+// Preview maps records up to limit and returns diagnostics.
+func (m *Mapper) Preview(ctx context.Context, input []byte, config MappingConfig, limit int) (*Preview, error) {
+	if limit <= 0 {
+		limit = 10
+	}
+	return m.mapWithDiagnostics(ctx, input, config, limit)
+}
+
+func (m *Mapper) mapWithDiagnostics(ctx context.Context, input []byte, config MappingConfig, limit int) (*Preview, error) {
+	if err := m.Validate(config); err != nil {
+		return nil, err
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	source, err := parseSource(input, config)
+	if err != nil {
+		return nil, err
+	}
+	recordNodes, err := source.selectRecords(config.RecordSelector)
+	if err != nil {
+		return nil, err
+	}
+
+	preview := &Preview{TotalRecords: len(recordNodes)}
+	for i, node := range recordNodes {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		record, diagnostics, skip := mapRecord(source, node, i+1, config)
+		preview.Diagnostics = append(preview.Diagnostics, diagnostics...)
+		if skip {
+			preview.Skipped++
+			continue
+		}
+		if limit == 0 || len(preview.Records) < limit {
+			preview.Records = append(preview.Records, record)
+		}
+	}
+
+	return preview, nil
+}
+
+func mapRecord(source parsedSource, node any, ordinal int, config MappingConfig) (Record, []MappingDiagnostic, bool) {
+	doc := make(map[string]any, len(config.Fields))
+	var diagnostics []MappingDiagnostic
+	skip := false
+
+	fieldNames := make([]string, 0, len(config.Fields))
+	for name := range config.Fields {
+		fieldNames = append(fieldNames, name)
+	}
+	slices.Sort(fieldNames)
+
+	for _, name := range fieldNames {
+		mapping := config.Fields[name]
+		value, found, usedPath, err := extractFieldValue(source, node, mapping)
+		if err != nil {
+			diagnostics = append(diagnostics, MappingDiagnostic{
+				Level:  DiagnosticError,
+				Field:  name,
+				Record: ordinal,
+				Path:   usedPath,
+				Code:   "coercion_failed",
+				Detail: err.Error(),
+			})
+			if mapping.Required {
+				skip = true
+			}
+			continue
+		}
+		if !found {
+			if mapping.Default != nil {
+				value = mapping.Default
+				found = true
+				diagnostics = append(diagnostics, MappingDiagnostic{
+					Level:  DiagnosticInfo,
+					Field:  name,
+					Record: ordinal,
+					Code:   "default_used",
+					Detail: "field default was used",
+				})
+			} else if mapping.Required {
+				diagnostics = append(diagnostics, MappingDiagnostic{
+					Level:  DiagnosticError,
+					Field:  name,
+					Record: ordinal,
+					Code:   "required_missing",
+					Detail: "required field did not match any value",
+				})
+				skip = true
+			}
+		}
+		if found {
+			doc[name] = value
+		}
+	}
+
+	idField := config.Options.IDField
+	if idField == "" {
+		idField = "id"
+	}
+	id, ok := stringify(doc[idField])
+	if !ok || strings.TrimSpace(id) == "" {
+		id = fmt.Sprintf("record-%d", ordinal)
+		doc[idField] = id
+		diagnostics = append(diagnostics, MappingDiagnostic{
+			Level:  DiagnosticWarning,
+			Field:  idField,
+			Record: ordinal,
+			Code:   "generated_id",
+			Detail: "record ID was generated because no usable ID field was mapped",
+		})
+	}
+
+	return Record{ID: id, Document: doc}, diagnostics, skip
+}
+
+func extractFieldValue(source parsedSource, node any, mapping FieldMapping) (any, bool, string, error) {
+	if len(mapping.Paths) > 0 {
+		values, usedPath, err := extractPathGroup(source, node, mapping.Paths, mapping.Type)
+		if err != nil {
+			return nil, false, usedPath, err
+		}
+		values = compactEmpty(values)
+		if len(values) > 0 {
+			if mapping.Join != "" {
+				return joinValues(values, mapping.Join), true, usedPath, nil
+			}
+			return values, true, usedPath, nil
+		}
+	}
+
+	var alternatives []string
+	if mapping.Path != "" {
+		alternatives = append(alternatives, mapping.Path)
+	}
+	alternatives = append(alternatives, mapping.Fallback...)
+	for _, selector := range alternatives {
+		values, err := source.selectValues(node, selector)
+		if err != nil {
+			return nil, false, selector, err
+		}
+		values = compactEmpty(values)
+		if len(values) == 0 {
+			continue
+		}
+
+		if mapping.Multiple || len(mapping.Paths) > 0 {
+			coerced := make([]any, 0, len(values))
+			for _, value := range values {
+				v, err := coerceValue(value, mapping.Type)
+				if err != nil {
+					return nil, false, selector, err
+				}
+				coerced = append(coerced, v)
+			}
+			if mapping.Join != "" {
+				return joinValues(coerced, mapping.Join), true, selector, nil
+			}
+			return coerced, true, selector, nil
+		}
+
+		value, err := coerceValue(values[0], mapping.Type)
+		if err != nil {
+			return nil, false, selector, err
+		}
+		return value, true, selector, nil
+	}
+	return nil, false, "", nil
+}
+
+func extractPathGroup(source parsedSource, node any, paths []string, typ FieldType) ([]any, string, error) {
+	var out []any
+	var used []string
+	for _, selector := range paths {
+		values, err := source.selectValues(node, selector)
+		if err != nil {
+			return nil, selector, err
+		}
+		values = compactEmpty(values)
+		if len(values) == 0 {
+			continue
+		}
+		used = append(used, selector)
+		for _, value := range values {
+			coerced, err := coerceValue(value, typ)
+			if err != nil {
+				return nil, selector, err
+			}
+			out = append(out, coerced)
+		}
+	}
+	return out, strings.Join(used, ","), nil
+}
+
+func (m FieldMapping) selectorCandidates() []string {
+	var selectors []string
+	selectors = append(selectors, m.Paths...)
+	if m.Path != "" {
+		selectors = append(selectors, m.Path)
+	}
+	selectors = append(selectors, m.Fallback...)
+	return selectors
+}
+
+func parseSource(input []byte, config MappingConfig) (parsedSource, error) {
+	switch config.Format {
+	case FormatJSON:
+		var value any
+		if err := json.Unmarshal(input, &value); err != nil {
+			return nil, fmt.Errorf("parse JSON: %w", err)
+		}
+		return objectSource{root: value}, nil
+	case FormatYAML:
+		var value any
+		if err := yaml.Unmarshal(input, &value); err != nil {
+			return nil, fmt.Errorf("parse YAML: %w", err)
+		}
+		return objectSource{root: normalizeYAML(value)}, nil
+	case FormatXML:
+		root, err := parseXML(input)
+		if err != nil {
+			return nil, err
+		}
+		return xmlSource{root: root}, nil
+	case FormatCSV:
+		rows, err := parseCSV(input, config.Options)
+		if err != nil {
+			return nil, err
+		}
+		return csvSource{rows: rows}, nil
+	case FormatNDJSON:
+		rows, err := parseNDJSON(input)
+		if err != nil {
+			return nil, err
+		}
+		return csvSource{rows: rows}, nil
+	default:
+		return nil, fmt.Errorf("unsupported format %q", config.Format)
+	}
+}
+
+type parsedSource interface {
+	selectRecords(selector string) ([]any, error)
+	selectValues(record any, selector string) ([]any, error)
+}
+
+type objectSource struct {
+	root any
+}
+
+func (s objectSource) selectRecords(selector string) ([]any, error) {
+	values, err := selectObjectPath(s.root, selector)
+	if err != nil {
+		return nil, err
+	}
+	return flattenRecordValues(values), nil
+}
+
+func (s objectSource) selectValues(record any, selector string) ([]any, error) {
+	root := record
+	if strings.HasPrefix(selector, "$") {
+		root = s.root
+	}
+	return selectObjectPath(root, selector)
+}
+
+func selectObjectPath(root any, selector string) ([]any, error) {
+	selector = strings.TrimSpace(selector)
+	if selector == "" || selector == "." || selector == "$" {
+		return []any{root}, nil
+	}
+	selector = strings.TrimPrefix(selector, "$.")
+	selector = strings.TrimPrefix(selector, "$")
+	selector = strings.TrimPrefix(selector, "./")
+	selector = strings.TrimPrefix(selector, ".")
+	if selector == "" {
+		return []any{root}, nil
+	}
+
+	current := []any{root}
+	for _, part := range strings.Split(selector, ".") {
+		if part == "" {
+			continue
+		}
+		name := part
+		wantAll := false
+		if strings.HasSuffix(part, "[*]") {
+			wantAll = true
+			name = strings.TrimSuffix(part, "[*]")
+		}
+
+		var next []any
+		for _, item := range current {
+			value, ok := objectChild(item, name)
+			if !ok {
+				continue
+			}
+			if wantAll {
+				if arr, ok := value.([]any); ok {
+					next = append(next, arr...)
+				}
+				continue
+			}
+			next = append(next, value)
+		}
+		current = next
+	}
+	return current, nil
+}
+
+func objectChild(value any, name string) (any, bool) {
+	if name == "" {
+		return value, true
+	}
+	switch typed := value.(type) {
+	case map[string]any:
+		v, ok := typed[name]
+		return v, ok
+	case []any:
+		idx, err := strconv.Atoi(name)
+		if err != nil || idx < 0 || idx >= len(typed) {
+			return nil, false
+		}
+		return typed[idx], true
+	default:
+		return nil, false
+	}
+}
+
+func flattenRecordValues(values []any) []any {
+	var records []any
+	for _, value := range values {
+		if arr, ok := value.([]any); ok {
+			records = append(records, arr...)
+			continue
+		}
+		records = append(records, value)
+	}
+	return records
+}
+
+type xmlSource struct {
+	root *xmlNode
+}
+
+type xmlNode struct {
+	name     xml.Name
+	attrs    []xml.Attr
+	text     string
+	children []*xmlNode
+	parent   *xmlNode
+}
+
+func parseXML(input []byte) (*xmlNode, error) {
+	decoder := xml.NewDecoder(bytes.NewReader(input))
+	var stack []*xmlNode
+	var root *xmlNode
+
+	for {
+		tok, err := decoder.Token()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return nil, fmt.Errorf("parse XML: %w", err)
+		}
+		switch t := tok.(type) {
+		case xml.StartElement:
+			node := &xmlNode{name: t.Name, attrs: append([]xml.Attr(nil), t.Attr...)}
+			if len(stack) > 0 {
+				node.parent = stack[len(stack)-1]
+				node.parent.children = append(node.parent.children, node)
+			} else {
+				root = node
+			}
+			stack = append(stack, node)
+		case xml.EndElement:
+			if len(stack) > 0 {
+				stack = stack[:len(stack)-1]
+			}
+		case xml.CharData:
+			if len(stack) > 0 {
+				text := strings.TrimSpace(string(t))
+				if text != "" {
+					current := stack[len(stack)-1]
+					if current.text != "" {
+						current.text += " "
+					}
+					current.text += text
+				}
+			}
+		}
+	}
+	if root == nil {
+		return nil, errors.New("parse XML: document is empty")
+	}
+	return root, nil
+}
+
+func (s xmlSource) selectRecords(selector string) ([]any, error) {
+	nodes := selectXMLPath([]*xmlNode{s.root}, selector)
+	result := make([]any, len(nodes))
+	for i, node := range nodes {
+		result[i] = node
+	}
+	return result, nil
+}
+
+func (s xmlSource) selectValues(record any, selector string) ([]any, error) {
+	node, ok := record.(*xmlNode)
+	if !ok {
+		return nil, fmt.Errorf("expected XML record node, got %T", record)
+	}
+	selected := selectXMLPath([]*xmlNode{node}, selector)
+	values := make([]any, 0, len(selected))
+	for _, item := range selected {
+		values = append(values, item.textValue())
+	}
+	return values, nil
+}
+
+func selectXMLPath(nodes []*xmlNode, selector string) []*xmlNode {
+	selector = strings.TrimSpace(selector)
+	if selector == "" || selector == "." {
+		return nodes
+	}
+	if strings.HasPrefix(selector, "./") {
+		selector = strings.TrimPrefix(selector, "./")
+	} else if strings.HasPrefix(selector, "/") {
+		selector = strings.TrimPrefix(selector, "/")
+		for len(nodes) > 0 && selector != "" {
+			first, rest, _ := strings.Cut(selector, "/")
+			if normalizeName(nodes[0].name.Local) == normalizeName(first) {
+				selector = rest
+				break
+			}
+			break
+		}
+	}
+
+	current := nodes
+	for _, part := range strings.Split(selector, "/") {
+		if part == "" || part == "." {
+			continue
+		}
+		var next []*xmlNode
+		for _, node := range current {
+			if strings.HasPrefix(part, "@") {
+				attr := node.attr(strings.TrimPrefix(part, "@"))
+				if attr != nil {
+					next = append(next, attr)
+				}
+				continue
+			}
+			for _, child := range node.children {
+				if part == "*" || normalizeName(child.name.Local) == normalizeName(part) {
+					next = append(next, child)
+				}
+			}
+		}
+		current = next
+	}
+	return current
+}
+
+func (n *xmlNode) attr(name string) *xmlNode {
+	for _, attr := range n.attrs {
+		if normalizeName(attr.Name.Local) == normalizeName(name) {
+			return &xmlNode{name: attr.Name, text: attr.Value}
+		}
+	}
+	return nil
+}
+
+func (n *xmlNode) textValue() string {
+	var parts []string
+	n.collectText(&parts)
+	return strings.Join(parts, "\n\n")
+}
+
+func (n *xmlNode) collectText(parts *[]string) {
+	if n.text != "" {
+		*parts = append(*parts, n.text)
+	}
+	for _, child := range n.children {
+		child.collectText(parts)
+	}
+}
+
+type csvSource struct {
+	rows []map[string]any
+}
+
+func (s csvSource) selectRecords(string) ([]any, error) {
+	records := make([]any, len(s.rows))
+	for i := range s.rows {
+		records[i] = s.rows[i]
+	}
+	return records, nil
+}
+
+func (s csvSource) selectValues(record any, selector string) ([]any, error) {
+	return objectSource{root: s.rows}.selectValues(record, selector)
+}
+
+func parseCSV(input []byte, opts MappingOptions) ([]map[string]any, error) {
+	reader := csv.NewReader(bytes.NewReader(input))
+	if opts.CSVDelimiter != "" {
+		runes := []rune(opts.CSVDelimiter)
+		if len(runes) != 1 {
+			return nil, errors.New("csv_delimiter must be one character")
+		}
+		reader.Comma = runes[0]
+	}
+	allRows, err := reader.ReadAll()
+	if err != nil {
+		return nil, fmt.Errorf("parse CSV: %w", err)
+	}
+	if len(allRows) == 0 {
+		return nil, nil
+	}
+
+	var headers []string
+	start := 0
+	if opts.CSVHasHeader {
+		headers = allRows[0]
+		start = 1
+	} else {
+		headers = make([]string, len(allRows[0]))
+		for i := range headers {
+			headers[i] = fmt.Sprintf("col%d", i+1)
+		}
+	}
+
+	rows := make([]map[string]any, 0, len(allRows)-start)
+	for _, row := range allRows[start:] {
+		item := make(map[string]any, len(headers))
+		for i, header := range headers {
+			if i < len(row) {
+				item[header] = row[i]
+			}
+		}
+		rows = append(rows, item)
+	}
+	return rows, nil
+}
+
+func parseNDJSON(input []byte) ([]map[string]any, error) {
+	decoder := json.NewDecoder(bytes.NewReader(input))
+	var rows []map[string]any
+	for {
+		var item map[string]any
+		if err := decoder.Decode(&item); err != nil {
+			if err == io.EOF {
+				break
+			}
+			return nil, fmt.Errorf("parse NDJSON: %w", err)
+		}
+		rows = append(rows, item)
+	}
+	return rows, nil
+}
+
+func compactEmpty(values []any) []any {
+	var out []any
+	for _, value := range values {
+		if str, ok := stringify(value); ok && strings.TrimSpace(str) == "" {
+			continue
+		}
+		out = append(out, value)
+	}
+	return out
+}
+
+func coerceValue(value any, typ FieldType) (any, error) {
+	if typ == FieldTypeRaw {
+		return value, nil
+	}
+	str, ok := stringify(value)
+	if !ok {
+		return value, nil
+	}
+	switch typ {
+	case FieldTypeString:
+		return str, nil
+	case FieldTypeBool:
+		return strconv.ParseBool(str)
+	case FieldTypeInt:
+		return strconv.Atoi(str)
+	case FieldTypeFloat:
+		return strconv.ParseFloat(str, 64)
+	default:
+		return nil, fmt.Errorf("unsupported field type %q", typ)
+	}
+}
+
+func stringify(value any) (string, bool) {
+	switch typed := value.(type) {
+	case nil:
+		return "", false
+	case string:
+		return strings.TrimSpace(typed), true
+	case json.Number:
+		return typed.String(), true
+	case bool:
+		return strconv.FormatBool(typed), true
+	case int:
+		return strconv.Itoa(typed), true
+	case int64:
+		return strconv.FormatInt(typed, 10), true
+	case float64:
+		return strconv.FormatFloat(typed, 'f', -1, 64), true
+	case float32:
+		return strconv.FormatFloat(float64(typed), 'f', -1, 32), true
+	default:
+		data, err := json.Marshal(typed)
+		if err != nil {
+			return "", false
+		}
+		return string(data), true
+	}
+}
+
+func joinValues(values []any, separator string) string {
+	parts := make([]string, 0, len(values))
+	for _, value := range values {
+		if str, ok := stringify(value); ok {
+			parts = append(parts, str)
+		}
+	}
+	return strings.Join(parts, separator)
+}
+
+func normalizeYAML(value any) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(typed))
+		for k, v := range typed {
+			out[k] = normalizeYAML(v)
+		}
+		return out
+	case map[any]any:
+		out := make(map[string]any, len(typed))
+		for k, v := range typed {
+			out[fmt.Sprint(k)] = normalizeYAML(v)
+		}
+		return out
+	case []any:
+		out := make([]any, len(typed))
+		for i, v := range typed {
+			out[i] = normalizeYAML(v)
+		}
+		return out
+	default:
+		return value
+	}
+}
+
+func normalizeName(name string) string {
+	name = strings.ToLower(strings.TrimSpace(name))
+	name = strings.ReplaceAll(name, "-", "")
+	name = strings.ReplaceAll(name, "_", "")
+	return name
+}

--- a/pkg/libaf/structured/structured_test.go
+++ b/pkg/libaf/structured/structured_test.go
@@ -1,0 +1,209 @@
+package structured
+
+import (
+	"context"
+	"testing"
+)
+
+func TestMapperMapsXML(t *testing.T) {
+	mapper := NewMapper()
+	config := MappingConfig{
+		Format:         FormatXML,
+		RecordSelector: "/archive/article",
+		Fields: map[string]FieldMapping{
+			"id": {
+				Path: "./@id",
+			},
+			"title": {
+				Path: "./headline",
+				Fallback: []string{
+					"./title",
+				},
+				Required: true,
+			},
+			"body": {
+				Paths: []string{"./body/p"},
+				Join:  "\n\n",
+			},
+			"brand": {
+				Path: "./brand",
+			},
+			"tags": {
+				Path:     "./tags/tag",
+				Multiple: true,
+			},
+			"published_at": {
+				Path: "./published_at",
+			},
+		},
+	}
+
+	input := []byte(`<archive>
+  <article id="a1">
+    <headline>New resorts in Cancun</headline>
+    <brand>Travel Weekly</brand>
+    <published_at>2026-04-12</published_at>
+    <body>
+      <p>Luxury resorts are opening in Cancun.</p>
+      <p>Several brands are expanding.</p>
+    </body>
+    <tags><tag>Mexico</tag><tag>Luxury</tag></tags>
+  </article>
+</archive>`)
+
+	records, err := mapper.Map(context.Background(), input, config)
+	if err != nil {
+		t.Fatalf("Map returned error: %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("got %d records, want 1", len(records))
+	}
+	record := records[0]
+	if record.ID != "a1" {
+		t.Fatalf("record.ID = %q", record.ID)
+	}
+	if got := record.Document["title"]; got != "New resorts in Cancun" {
+		t.Fatalf("title = %#v", got)
+	}
+	if got := record.Document["body"]; got != "Luxury resorts are opening in Cancun.\n\nSeveral brands are expanding." {
+		t.Fatalf("body = %#v", got)
+	}
+	tags, ok := record.Document["tags"].([]any)
+	if !ok || len(tags) != 2 || tags[0] != "Mexico" || tags[1] != "Luxury" {
+		t.Fatalf("tags = %#v", record.Document["tags"])
+	}
+}
+
+func TestMapperMapsJSON(t *testing.T) {
+	mapper := NewMapper()
+	config := MappingConfig{
+		Format:         FormatJSON,
+		RecordSelector: "$.articles[*]",
+		Fields: map[string]FieldMapping{
+			"id":    {Path: "./id"},
+			"title": {Path: "./headline"},
+			"body":  {Path: "./body"},
+			"tags": {
+				Path:     "./tags[*]",
+				Multiple: true,
+			},
+		},
+	}
+	input := []byte(`{"articles":[{"id":"a1","headline":"Airline trends","body":"Routes are changing.","tags":["air","business"]}]}`)
+
+	preview, err := mapper.Preview(context.Background(), input, config, 10)
+	if err != nil {
+		t.Fatalf("Preview returned error: %v", err)
+	}
+	if preview.TotalRecords != 1 || len(preview.Records) != 1 {
+		t.Fatalf("preview = %#v", preview)
+	}
+	if preview.Records[0].Document["title"] != "Airline trends" {
+		t.Fatalf("title = %#v", preview.Records[0].Document["title"])
+	}
+}
+
+func TestMapperMapsYAML(t *testing.T) {
+	mapper := NewMapper()
+	config := MappingConfig{
+		Format:         FormatYAML,
+		RecordSelector: "$.articles[*]",
+		Fields: map[string]FieldMapping{
+			"id":    {Path: "./id"},
+			"title": {Path: "./title"},
+			"views": {
+				Path: "./views",
+				Type: FieldTypeInt,
+			},
+		},
+	}
+	input := []byte(`articles:
+  - id: a1
+    title: Meetings rebound
+    views: "42"
+`)
+
+	records, err := mapper.Map(context.Background(), input, config)
+	if err != nil {
+		t.Fatalf("Map returned error: %v", err)
+	}
+	if got := records[0].Document["views"]; got != 42 {
+		t.Fatalf("views = %#v", got)
+	}
+}
+
+func TestMapperDiagnosticsAndGeneratedID(t *testing.T) {
+	mapper := NewMapper()
+	config := MappingConfig{
+		Format:         FormatJSON,
+		RecordSelector: "$.articles[*]",
+		Fields: map[string]FieldMapping{
+			"title": {Path: "./headline", Required: true},
+			"body":  {Path: "./body"},
+		},
+	}
+	input := []byte(`{"articles":[{"headline":"No ID","body":"Generated ID expected."},{"body":"missing title"}]}`)
+
+	preview, err := mapper.Preview(context.Background(), input, config, 10)
+	if err != nil {
+		t.Fatalf("Preview returned error: %v", err)
+	}
+	if preview.TotalRecords != 2 {
+		t.Fatalf("TotalRecords = %d", preview.TotalRecords)
+	}
+	if preview.Skipped != 1 {
+		t.Fatalf("Skipped = %d", preview.Skipped)
+	}
+	if len(preview.Records) != 1 || preview.Records[0].ID != "record-1" {
+		t.Fatalf("records = %#v", preview.Records)
+	}
+
+	var generatedID, requiredMissing bool
+	for _, diag := range preview.Diagnostics {
+		if diag.Code == "generated_id" {
+			generatedID = true
+		}
+		if diag.Code == "required_missing" {
+			requiredMissing = true
+		}
+	}
+	if !generatedID || !requiredMissing {
+		t.Fatalf("diagnostics = %#v", preview.Diagnostics)
+	}
+}
+
+func TestMapperMapsCSVAndNDJSON(t *testing.T) {
+	mapper := NewMapper()
+	csvConfig := MappingConfig{
+		Format: FormatCSV,
+		Options: MappingOptions{
+			CSVHasHeader: true,
+		},
+		Fields: map[string]FieldMapping{
+			"id":    {Path: "./id"},
+			"title": {Path: "./title"},
+		},
+	}
+	csvRecords, err := mapper.Map(context.Background(), []byte("id,title\na1,CSV article\n"), csvConfig)
+	if err != nil {
+		t.Fatalf("CSV Map returned error: %v", err)
+	}
+	if len(csvRecords) != 1 || csvRecords[0].Document["title"] != "CSV article" {
+		t.Fatalf("csvRecords = %#v", csvRecords)
+	}
+
+	ndjsonConfig := MappingConfig{
+		Format: FormatNDJSON,
+		Fields: map[string]FieldMapping{
+			"id":    {Path: "./id"},
+			"title": {Path: "./title"},
+		},
+	}
+	ndjsonRecords, err := mapper.Map(context.Background(), []byte("{\"id\":\"n1\",\"title\":\"NDJSON article\"}\n"), ndjsonConfig)
+	if err != nil {
+		t.Fatalf("NDJSON Map returned error: %v", err)
+	}
+	if len(ndjsonRecords) != 1 || ndjsonRecords[0].Document["title"] != "NDJSON article" {
+		t.Fatalf("ndjsonRecords = %#v", ndjsonRecords)
+	}
+}


### PR DESCRIPTION
## Summary
- add pkg/libaf/structured for mapping XML, JSON, YAML, CSV, and NDJSON inputs into generic records
- add preview diagnostics, generated IDs, required-field handling, fallbacks, joins, multi-value fields, and basic type coercion
- add a generic DocsAF XML processor and register it in the default DocsAF registry

## Tests
- env GOWORK=off GOCACHE=/tmp/antfly-libaf-go-build-cache go test ./... (from pkg/libaf)
- env GOWORK=off GOCACHE=/tmp/antfly-docsaf-go-build-cache go test ./... -skip TestGitSource_Clone_Integration (from pkg/docsaf)