### PR TITLE
Fix Termite embedded health routes

### DIFF
--- a/pkg/termite/termite.go
+++ b/pkg/termite/termite.go
@@ -668,16 +668,14 @@ func (n *TermiteNode) APIHandler() http.Handler {
 	return corsMiddleware(rootMux)
 }
 
-// APIMLHandler returns a handler that serves only the /ml/v1/* surface
-// (plus /healthz, /readyz). Intended for embedding in an antfly metadata
-// HTTP server where OpenAI/Anthropic-compat and dashboard surfaces are
+// APIMLHandler returns a handler that serves only the /ml/v1/* surface.
+// Intended for embedding in an antfly metadata HTTP server where
+// OpenAI/Anthropic-compat, dashboard, and operational probe surfaces are
 // undesirable.
 func (n *TermiteNode) APIMLHandler() http.Handler {
 	apiHandler := NewTermiteAPI(n.logger, n)
 
 	mux := http.NewServeMux()
-	mux.HandleFunc("GET /healthz", n.handleHealthz)
-	mux.HandleFunc("GET /readyz", n.handleReadyz)
 	mux.HandleFunc("POST /ml/v1/generate", n.handleApiGenerate)
 	mux.Handle("/ml/v1/", apiHandler)
 

--- a/pkg/termite/termite_test.go
+++ b/pkg/termite/termite_test.go
@@ -64,6 +64,54 @@ func (m *MockEmbedder) GetCallCount() int32 {
 	return m.callCount.Load()
 }
 
+func TestAPIHandlerServesRootOperationalRoutesOutsideMLPrefix(t *testing.T) {
+	node := &TermiteNode{
+		logger: zaptest.NewLogger(t),
+	}
+	handler := node.APIHandler()
+
+	for _, path := range []string{"/healthz", "/readyz"} {
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		assert.True(t, w.Code == http.StatusOK || w.Code == http.StatusServiceUnavailable, "%s returned %d", path, w.Code)
+	}
+
+	for _, path := range []string{"/ml/v1/healthz", "/ml/v1/readyz"} {
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusNotFound, w.Code, path)
+	}
+}
+
+func TestAPIMLHandlerDoesNotExposeOperationalRoutes(t *testing.T) {
+	node := &TermiteNode{
+		logger: zaptest.NewLogger(t),
+	}
+	handler := node.APIMLHandler()
+
+	versionReq := httptest.NewRequest(http.MethodGet, "/ml/v1/version", nil)
+	versionRec := httptest.NewRecorder()
+	handler.ServeHTTP(versionRec, versionReq)
+	require.Equal(t, http.StatusOK, versionRec.Code)
+
+	for _, path := range []string{"/healthz", "/readyz", "/ml/v1/healthz", "/ml/v1/readyz"} {
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusNotFound, w.Code, path)
+	}
+
+	termiteMount := http.StripPrefix("/termite", handler)
+	for _, path := range []string{"/termite/healthz", "/termite/readyz"} {
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		w := httptest.NewRecorder()
+		termiteMount.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusNotFound, w.Code, path)
+	}
+}
+
 func TestTermiteNode_HandleApiEmbed_NoRegistry(t *testing.T) {
 	logger := zaptest.NewLogger(t)
 

--- a/src/metadata/runtime.go
+++ b/src/metadata/runtime.go
@@ -73,8 +73,8 @@ type Runtime struct {
 type RuntimeOptions struct {
 	ExecutionProvider ExecutionProvider
 	// TermiteMLHandler is an optional in-process Termite handler. When set, it
-	// is mounted at /ml/v1/ (and also handles /healthz, /readyz, and
-	// /ml/v1/generate as exposed by pkg/termite.TermiteNode.APIMLHandler).
+	// is mounted at /ml/v1/ and also handles /ml/v1/generate as exposed by
+	// pkg/termite.TermiteNode.APIMLHandler.
 	// When nil and config.Termite.ApiUrl is set, the metadata server instead
 	// reverse-proxies /termite/* to that URL.
 	TermiteMLHandler http.Handler


### PR DESCRIPTION
## Summary
- keep embedded Termite APIMLHandler limited to /ml/v1/*
- remove embedded /healthz and /readyz aliases from Antfly /termite mount
- add regression coverage for standalone and embedded route behavior

## Tests
- env GOCACHE=/tmp/colony-go-build-cache go test ./pkg/termite -run 'Test(APIHandlerServesRootOperationalRoutesOutsideMLPrefix|APIMLHandlerDoesNotExposeOperationalRoutes)$'