### PR TITLE
Add GLiNER2 relation extraction direct quant support

### DIFF
--- a/zig/pkg/termite/src/api/generated/termite_api/types.zig
+++ b/zig/pkg/termite/src/api/generated/termite_api/types.zig
@@ -581,7 +581,7 @@ pub const RecognizeRequest = struct {
     texts: []const []const u8,
     /// Custom entity labels to extract (GLiNER models only). When using a GLiNER model, you can specify any entity types to extract, enabling zero-shot NER without model retraining. If not provided, the model's default labels are used.
     labels: ?[]const []const u8 = null,
-    /// Relation types to extract (for models with 'relations' capability). Only used when the model supports relation extraction (GLiNER multitask, REBEL). If not provided, the model extracts all relations it can detect.
+    /// Relation types to extract (for models with 'relations' capability). Only used when the model supports relation extraction (GLiNER multitask, REBEL). Relation extraction runs only when this array is provided and non-empty. GLiNER labels may be relation names (works_for), head-qualified labels (person::works_for), or head/tail-qualified labels (person::works_for::organization).
     relation_labels: ?[]const []const u8 = null,
     resolver: ?ResolverConfig = null,
 };

--- a/zig/pkg/termite/src/api/openapi.yaml
+++ b/zig/pkg/termite/src/api/openapi.yaml
@@ -1485,7 +1485,10 @@ components:
           description: |
             Relation types to extract (for models with 'relations' capability).
             Only used when the model supports relation extraction (GLiNER multitask, REBEL).
-            If not provided, the model extracts all relations it can detect.
+            Relation extraction runs only when this array is provided and non-empty.
+            GLiNER labels may be relation names (works_for), head-qualified
+            labels (person::works_for), or head/tail-qualified labels
+            (person::works_for::organization).
           example:
             - founded
             - works_at

--- a/zig/pkg/termite/src/architectures/gliner_head.zig
+++ b/zig/pkg/termite/src/architectures/gliner_head.zig
@@ -49,6 +49,16 @@ pub const ForwardCtResult = struct {
     num_labels: usize,
 };
 
+pub const LabelMarkerTokens = struct {
+    classification: i64 = 0,
+    entity: i64,
+    relation: i64 = 0,
+
+    pub fn fromEntityToken(entity_token_id: i64) LabelMarkerTokens {
+        return .{ .entity = entity_token_id };
+    }
+};
+
 pub const ForwardProfile = struct {
     materialize_hidden_ns: u64 = 0,
     extract_words_ns: u64 = 0,
@@ -128,7 +138,22 @@ pub fn forwardCt(
     hidden_size: u32,
     entity_token_id: i64,
 ) !ForwardCtResult {
-    return forwardCtProfiled(cb, allocator, hidden, input_ids, words_mask, span_idx, batch, seq_len, hidden_size, entity_token_id, null);
+    return forwardCtProfiledWithLabelMarkers(cb, allocator, hidden, input_ids, words_mask, span_idx, batch, seq_len, hidden_size, LabelMarkerTokens.fromEntityToken(entity_token_id), null);
+}
+
+pub fn forwardCtWithLabelMarkers(
+    cb: *const ComputeBackend,
+    allocator: std.mem.Allocator,
+    hidden: CT,
+    input_ids: []const i64,
+    words_mask: []const i64,
+    span_idx: []const i64,
+    batch: usize,
+    seq_len: usize,
+    hidden_size: u32,
+    label_markers: LabelMarkerTokens,
+) !ForwardCtResult {
+    return forwardCtProfiledWithLabelMarkers(cb, allocator, hidden, input_ids, words_mask, span_idx, batch, seq_len, hidden_size, label_markers, null);
 }
 
 pub fn forwardCtProfiled(
@@ -144,10 +169,26 @@ pub fn forwardCtProfiled(
     entity_token_id: i64,
     profile: ?*ForwardProfile,
 ) !ForwardCtResult {
+    return forwardCtProfiledWithLabelMarkers(cb, allocator, hidden, input_ids, words_mask, span_idx, batch, seq_len, hidden_size, LabelMarkerTokens.fromEntityToken(entity_token_id), profile);
+}
+
+pub fn forwardCtProfiledWithLabelMarkers(
+    cb: *const ComputeBackend,
+    allocator: std.mem.Allocator,
+    hidden: CT,
+    input_ids: []const i64,
+    words_mask: []const i64,
+    span_idx: []const i64,
+    batch: usize,
+    seq_len: usize,
+    hidden_size: u32,
+    label_markers: LabelMarkerTokens,
+    profile: ?*ForwardProfile,
+) !ForwardCtResult {
     const H: usize = hidden_size;
 
     const num_words = countWords(words_mask);
-    const label_positions = try collectLabelPositions(allocator, input_ids, seq_len, entity_token_id);
+    const label_positions = try collectLabelPositions(allocator, input_ids, seq_len, label_markers);
     defer allocator.free(label_positions);
     const num_labels = label_positions.len;
 
@@ -207,7 +248,7 @@ pub fn forwardCtProfiled(
     if (profile) |p| p.extract_words_ns += profileElapsed(timer);
 
     timer = profileStart(profile);
-    const label_result = try extractLabelEmbeddings(allocator, hidden_f32, input_ids, batch, seq_len, H, entity_token_id);
+    const label_result = try extractLabelEmbeddings(allocator, hidden_f32, input_ids, batch, seq_len, H, label_markers);
     defer allocator.free(label_result.embeddings);
     if (profile) |p| p.extract_labels_ns += profileElapsed(timer);
 
@@ -240,11 +281,11 @@ fn countWords(words_mask: []const i64) usize {
     return @intCast(max_word_id);
 }
 
-fn collectLabelPositions(allocator: std.mem.Allocator, input_ids: []const i64, seq_len: usize, entity_token_id: i64) ![]u32 {
+fn collectLabelPositions(allocator: std.mem.Allocator, input_ids: []const i64, seq_len: usize, label_markers: LabelMarkerTokens) ![]u32 {
     var label_positions = std.ArrayListUnmanaged(u32).empty;
     defer label_positions.deinit(allocator);
     for (0..@min(seq_len, input_ids.len)) |t| {
-        if (input_ids[t] == entity_token_id) {
+        if (isGlinerLabelMarkerToken(input_ids[t], label_markers)) {
             try label_positions.append(allocator, @intCast(t));
         }
     }
@@ -266,11 +307,26 @@ pub fn forward(
     hidden_size: u32,
     entity_token_id: i64,
 ) !ForwardResult {
+    return forwardWithLabelMarkers(cb, allocator, hidden_f32, input_ids, words_mask, span_idx, batch, seq_len, hidden_size, LabelMarkerTokens.fromEntityToken(entity_token_id));
+}
+
+pub fn forwardWithLabelMarkers(
+    cb: *const ComputeBackend,
+    allocator: std.mem.Allocator,
+    hidden_f32: []const f32,
+    input_ids: []const i64,
+    words_mask: []const i64,
+    span_idx: []const i64,
+    batch: usize,
+    seq_len: usize,
+    hidden_size: u32,
+    label_markers: LabelMarkerTokens,
+) !ForwardResult {
     const total = batch * seq_len;
     const shape = [_]i32{ @intCast(total), @intCast(hidden_size) };
     const hidden = try cb.fromFloat32Shape(hidden_f32, &shape);
     defer cb.free(hidden);
-    const ct_result = try forwardCt(cb, allocator, hidden, input_ids, words_mask, span_idx, batch, seq_len, hidden_size, entity_token_id);
+    const ct_result = try forwardCtWithLabelMarkers(cb, allocator, hidden, input_ids, words_mask, span_idx, batch, seq_len, hidden_size, label_markers);
     defer cb.free(ct_result.logits);
     const logits_f32 = if (ct_result.num_labels == 0)
         try allocator.alloc(f32, 0)
@@ -374,19 +430,18 @@ fn extractLabelEmbeddings(
     batch: usize,
     seq_len: usize,
     H: usize,
-    entity_token_id: i64,
+    label_markers: LabelMarkerTokens,
 ) !LabelEmbResult {
     _ = batch;
-    // GLiNER2 uses [E] tokens to mark label positions in the input.
+    // GLiNER2 uses [E]/[C]/[R] tokens to mark label positions in the input.
     // Extract hidden states at those positions.
-    const E_TOKEN = entity_token_id;
 
     var label_positions = std.ArrayListUnmanaged(usize).empty;
     defer label_positions.deinit(allocator);
 
     // Only look at first batch item (labels are same across batch)
     for (0..seq_len) |t| {
-        if (input_ids[t] == E_TOKEN) {
+        if (isGlinerLabelMarkerToken(input_ids[t], label_markers)) {
             try label_positions.append(allocator, t);
         }
     }
@@ -403,6 +458,12 @@ fn extractLabelEmbeddings(
     }
 
     return .{ .embeddings = output, .num_labels = num_labels };
+}
+
+fn isGlinerLabelMarkerToken(token_id: i64, label_markers: LabelMarkerTokens) bool {
+    return token_id == label_markers.entity or
+        (label_markers.classification != 0 and token_id == label_markers.classification) or
+        (label_markers.relation != 0 and token_id == label_markers.relation);
 }
 
 const SpanInfo = struct {
@@ -1065,11 +1126,33 @@ test "extractLabelEmbeddings uses entity marker positions" {
     };
     const input_ids = [_]i64{ 7, 99, 5, 99 };
 
-    const result = try extractLabelEmbeddings(allocator, &hidden, &input_ids, 1, 4, 2, 99);
+    const result = try extractLabelEmbeddings(allocator, &hidden, &input_ids, 1, 4, 2, .{ .entity = 99 });
     defer allocator.free(result.embeddings);
 
     try std.testing.expectEqual(@as(usize, 2), result.num_labels);
     try std.testing.expectEqualSlices(f32, &.{ 2, 20, 4, 40 }, result.embeddings);
+}
+
+test "extractLabelEmbeddings accepts GLiNER classification and relation markers" {
+    const allocator = std.testing.allocator;
+    const hidden = [_]f32{
+        1, 10,
+        2, 20,
+        3, 30,
+        4, 40,
+        5, 50,
+    };
+    const input_ids = [_]i64{ 52, 7, 51, 8, 53 };
+
+    const result = try extractLabelEmbeddings(allocator, &hidden, &input_ids, 1, 5, 2, .{
+        .classification = 52,
+        .entity = 51,
+        .relation = 53,
+    });
+    defer allocator.free(result.embeddings);
+
+    try std.testing.expectEqual(@as(usize, 3), result.num_labels);
+    try std.testing.expectEqualSlices(f32, &.{ 1, 10, 3, 30, 5, 50 }, result.embeddings);
 }
 
 test "collectLabelPositions mirrors first-batch label extraction" {
@@ -1079,7 +1162,7 @@ test "collectLabelPositions mirrors first-batch label extraction" {
         99, 8,  99, 9,
     };
 
-    const positions = try collectLabelPositions(allocator, &input_ids, 4, 99);
+    const positions = try collectLabelPositions(allocator, &input_ids, 4, .{ .entity = 99 });
     defer allocator.free(positions);
 
     try std.testing.expectEqualSlices(u32, &.{ 1, 3 }, positions);

--- a/zig/pkg/termite/src/architectures/gliner_head_graph.zig
+++ b/zig/pkg/termite/src/architectures/gliner_head_graph.zig
@@ -83,12 +83,14 @@ const deberta_config = @import("../models/deberta.zig");
 
 /// Configuration for the GLiNER2 head graph.  Mirrors the runtime
 /// `gliner_head.zig` parameters and reuses `deberta_config.Config`'s
-/// hidden_size + entity_token_id fields directly.
+/// hidden size and GLiNER label-marker token ids directly.
 pub const Config = struct {
     /// DeBERTa hidden dim (H).  Span/label embeddings are sized H.
     hidden_size: u32,
-    /// Special token marking labels in the input prompt.
+    /// Special tokens marking labels in the input prompt.
+    classification_token_id: i64 = 0,
     entity_token_id: i64,
+    relation_token_id: i64 = 0,
     /// Downscaled-transformer hidden dim (D=128 in stock GLiNER2).
     downscaled_dim: u32 = 128,
     /// FFN inner dim of the downscaled transformer (D_FFN=256).
@@ -97,6 +99,24 @@ pub const Config = struct {
     downscaled_num_layers: u32 = 2,
     /// Number of attention heads in the mini-transformer (4).
     downscaled_num_heads: u32 = 4,
+};
+
+pub const LabelMarkerTokens = struct {
+    classification: i64 = 0,
+    entity: i64,
+    relation: i64 = 0,
+
+    fn fromEntityToken(entity_token_id: i64) LabelMarkerTokens {
+        return .{ .entity = entity_token_id };
+    }
+
+    fn fromConfig(config: Config) LabelMarkerTokens {
+        return .{
+            .classification = config.classification_token_id,
+            .entity = config.entity_token_id,
+            .relation = config.relation_token_id,
+        };
+    }
 };
 
 /// Result of `buildForwardGraph`.  All node IDs are graph placeholders
@@ -865,6 +885,19 @@ pub fn prepGlinerInputs(
     H: u32,
     entity_token_id: i64,
 ) !PreparedInputs {
+    return prepGlinerInputsWithLabelMarkers(allocator, input_ids, words_mask, span_idx, batch, seq_len, H, LabelMarkerTokens.fromEntityToken(entity_token_id));
+}
+
+pub fn prepGlinerInputsWithLabelMarkers(
+    allocator: std.mem.Allocator,
+    input_ids: []const i64,
+    words_mask: []const i64,
+    span_idx: []const i64,
+    batch: usize,
+    seq_len: usize,
+    H: u32,
+    label_markers: LabelMarkerTokens,
+) !PreparedInputs {
     // 1. Walk words_mask once to derive num_words + count valid tokens.
     var max_word_id: i64 = 0;
     var num_valid: usize = 0;
@@ -892,13 +925,13 @@ pub fn prepGlinerInputs(
         }
     }
 
-    // 3. Label positions: token offsets where input_ids == entity_token_id.
+    // 3. Label positions: token offsets where input_ids is a GLiNER label marker.
     //    Eager `extractLabelEmbeddings` only checks the first batch item
     //    (labels are shared across batch); we follow that.
     var label_pos: std.ArrayListUnmanaged(i64) = .empty;
     errdefer label_pos.deinit(allocator);
     for (0..seq_len) |t| {
-        if (input_ids[t] == entity_token_id) {
+        if (isGlinerLabelMarkerToken(input_ids[t], label_markers)) {
             try label_pos.append(allocator, @intCast(t));
         }
     }
@@ -961,6 +994,12 @@ pub fn prepGlinerInputs(
     };
 }
 
+fn isGlinerLabelMarkerToken(token_id: i64, label_markers: LabelMarkerTokens) bool {
+    return token_id == label_markers.entity or
+        (label_markers.classification != 0 and token_id == label_markers.classification) or
+        (label_markers.relation != 0 and token_id == label_markers.relation);
+}
+
 // ── Head-only graph executor ─────────────────────────────────────────
 //
 // Runs the GLiNER head as a graph, given an already-computed encoder
@@ -1007,7 +1046,7 @@ pub fn runHeadGraph(
     batch: usize,
     seq_len: usize,
 ) !HeadGraphResult {
-    var prep = try prepGlinerInputs(allocator, input_ids, words_mask, span_idx, batch, seq_len, config.hidden_size, config.entity_token_id);
+    var prep = try prepGlinerInputsWithLabelMarkers(allocator, input_ids, words_mask, span_idx, batch, seq_len, config.hidden_size, LabelMarkerTokens.fromConfig(config));
     errdefer prep.deinit(allocator);
 
     var graph = ml.graph.Graph.init(allocator);
@@ -1170,7 +1209,7 @@ pub fn runFullGraph(
     seq_len: usize,
     strategy: graph_runtime.Strategy,
 ) !FullGraphResult {
-    var prep = try prepGlinerInputs(allocator, input_ids, words_mask, span_idx, batch, seq_len, head_cfg.hidden_size, head_cfg.entity_token_id);
+    var prep = try prepGlinerInputsWithLabelMarkers(allocator, input_ids, words_mask, span_idx, batch, seq_len, head_cfg.hidden_size, LabelMarkerTokens.fromConfig(head_cfg));
     errdefer prep.deinit(allocator);
 
     var graph = ml.graph.Graph.init(allocator);
@@ -1403,4 +1442,26 @@ test "prepGlinerInputs derives the right index slices for a tiny case" {
     try std.testing.expectEqualSlices(i64, &.{ 0, 0 }, prep.start_indices);
     try std.testing.expectEqualSlices(i64, &.{ 0, 1 }, prep.end_indices);
     try std.testing.expectEqualSlices(i64, &.{0}, prep.pos_zero_indices);
+}
+
+test "prepGlinerInputs accepts GLiNER classification and relation markers" {
+    const allocator = std.testing.allocator;
+    const input_ids = [_]i64{ 52, 11, 51, 12, 53 };
+    const words_mask = [_]i64{ 0, 1, 0, 2, 0 };
+    const span_idx = [_]i64{ 0, 0, 0, 1 };
+
+    var prep = try prepGlinerInputsWithLabelMarkers(
+        allocator,
+        &input_ids,
+        &words_mask,
+        &span_idx,
+        1,
+        5,
+        4,
+        .{ .classification = 52, .entity = 51, .relation = 53 },
+    );
+    defer prep.deinit(allocator);
+
+    try std.testing.expectEqual(@as(u32, 3), prep.num_labels);
+    try std.testing.expectEqualSlices(i64, &.{ 0, 2, 4 }, prep.label_positions);
 }

--- a/zig/pkg/termite/src/architectures/session_factory.zig
+++ b/zig/pkg/termite/src/architectures/session_factory.zig
@@ -1282,14 +1282,14 @@ fn detectArchitecture(allocator: std.mem.Allocator, model_path: []const u8, mf: 
                 // config.json and use termite_bundle/gliner_config sidecars
                 // to identify the GLiNER wrapper.
                 var cfg = try deberta_mod.parseConfig(allocator, config_bytes);
-                try applyGlinerEntityTokenId(allocator, model_path, &cfg);
+                try applyGlinerLabelTokenIds(allocator, model_path, mf, &cfg);
                 return .{ .gliner = cfg };
             }
             if (std.mem.eql(u8, model_type, "extractor")) {
                 // GLiNER2: DeBERTa encoder + span classification head
                 var cfg = deberta_mod.Config{};
 
-                try applyGlinerEntityTokenId(allocator, model_path, &cfg);
+                try applyGlinerLabelTokenIds(allocator, model_path, mf, &cfg);
 
                 return .{ .gliner = cfg };
             }
@@ -1339,15 +1339,25 @@ fn detectArchitecture(allocator: std.mem.Allocator, model_path: []const u8, mf: 
     return .{ .bert = makeBertConfig(mf) };
 }
 
-fn applyGlinerEntityTokenId(allocator: std.mem.Allocator, model_path: []const u8, cfg: *deberta_mod.Config) !void {
+fn applyGlinerLabelTokenIds(allocator: std.mem.Allocator, model_path: []const u8, mf: manifest_mod.ModelManifest, cfg: *deberta_mod.Config) !void {
+    if (mf.gliner_token_c != 0) cfg.classification_token_id = mf.gliner_token_c;
+    if (mf.gliner_token_e != 0) cfg.entity_token_id = mf.gliner_token_e;
+    if (mf.gliner_token_r != 0) cfg.relation_token_id = mf.gliner_token_r;
+
     const at_path = try std.fmt.allocPrint(allocator, "{s}/added_tokens.json", .{model_path});
     defer allocator.free(at_path);
     if (c_file.readFile(allocator, at_path)) |at_bytes| {
         defer allocator.free(at_bytes);
         const at_parsed = try std.json.parseFromSlice(std.json.Value, allocator, at_bytes, .{});
         defer at_parsed.deinit();
+        if (at_parsed.value.object.get("[C]")) |v| {
+            if (v == .integer) cfg.classification_token_id = v.integer;
+        }
         if (at_parsed.value.object.get("[E]")) |v| {
             if (v == .integer) cfg.entity_token_id = v.integer;
+        }
+        if (at_parsed.value.object.get("[R]")) |v| {
+            if (v == .integer) cfg.relation_token_id = v.integer;
         }
     } else |_| {}
 }
@@ -3438,7 +3448,7 @@ test "detectArchitecture treats split gliner bundle encoder config as gliner" {
     });
     try tmp.dir.writeFile(std.testing.io, .{
         .sub_path = "added_tokens.json",
-        .data = "{\"[E]\":128005}",
+        .data = "{\"[C]\":51,\"[E]\":52,\"[R]\":53}",
     });
 
     const model_dir = try std.fmt.allocPrint(allocator, ".zig-cache/tmp/{s}", .{tmp.sub_path});
@@ -3455,7 +3465,9 @@ test "detectArchitecture treats split gliner bundle encoder config as gliner" {
     switch (arch) {
         .gliner => |cfg| {
             try std.testing.expectEqual(@as(u32, 128011), cfg.vocab_size);
-            try std.testing.expectEqual(@as(i64, 128005), cfg.entity_token_id);
+            try std.testing.expectEqual(@as(i64, 51), cfg.classification_token_id);
+            try std.testing.expectEqual(@as(i64, 52), cfg.entity_token_id);
+            try std.testing.expectEqual(@as(i64, 53), cfg.relation_token_id);
         },
         else => return error.TestUnexpectedResult,
     }
@@ -4784,7 +4796,9 @@ fn archRun(ptr: *anyopaque, inputs: []const Tensor, allocator: std.mem.Allocator
             if (use_graph_runtime) {
                 const head_cfg = gliner_head_graph.Config{
                     .hidden_size = cfg.hidden_size,
+                    .classification_token_id = cfg.classification_token_id,
                     .entity_token_id = cfg.entity_token_id,
+                    .relation_token_id = cfg.relation_token_id,
                 };
                 const graph_result = try gliner_head_graph.runFullGraph(
                     &cb,
@@ -4830,7 +4844,11 @@ fn archRun(ptr: *anyopaque, inputs: []const Tensor, allocator: std.mem.Allocator
             // Eager head path -- keeps the encoder/head boundary on the
             // backend (CT) so we skip the toFloat32 + fromFloat32Shape
             // round-trip the legacy []f32-typed APIs do.
-            const head_result = try gliner_head.forwardCt(&cb, allocator, hidden, input_ids, words_mask, span_idx, batch, seq_len, cfg.hidden_size, cfg.entity_token_id);
+            const head_result = try gliner_head.forwardCtWithLabelMarkers(&cb, allocator, hidden, input_ids, words_mask, span_idx, batch, seq_len, cfg.hidden_size, .{
+                .classification = cfg.classification_token_id,
+                .entity = cfg.entity_token_id,
+                .relation = cfg.relation_token_id,
+            });
             defer cb.free(head_result.logits);
 
             const logits_f32 = if (head_result.num_labels == 0)

--- a/zig/pkg/termite/src/bench/gliner2_e2e.zig
+++ b/zig/pkg/termite/src/bench/gliner2_e2e.zig
@@ -26,6 +26,7 @@ const termite = @import("termite_internal");
 const backends = termite.backends;
 const graph_runtime = termite.graph.runtime;
 const model_manager_mod = termite.server.model_manager;
+const native_compute = termite.native_compute.native;
 
 const BackendChoice = enum {
     auto,
@@ -39,28 +40,55 @@ const OutputFormat = enum {
     csv,
 };
 
+const BenchTask = enum {
+    entities,
+    relations,
+    both,
+};
+
 const Options = struct {
     model_dir: []const u8 = "",
-    text: []const u8 = "Apple hired John Smith in Paris.",
+    text: []const u8 = "John Smith works for Apple Inc. and lives in San Francisco. Apple Inc. is located in Cupertino.",
     backend: BackendChoice = .native,
     graph_runtime_strategy: ?graph_runtime.Strategy = null,
     warmup_iters: usize = 1,
     measure_iters: usize = 5,
     format: OutputFormat = .text,
+    task: BenchTask = .entities,
     labels: std.ArrayListUnmanaged([]const u8) = .empty,
+    relation_labels: std.ArrayListUnmanaged([]const u8) = .empty,
 
     fn deinit(self: *Options, allocator: std.mem.Allocator) void {
         self.labels.deinit(allocator);
+        self.relation_labels.deinit(allocator);
     }
+};
+
+const QuantCounters = struct {
+    q4q5: u64 = 0,
+    q4q5_pair: u64 = 0,
+    q4q5_triple: u64 = 0,
+    q4q5_panel: u64 = 0,
+    dequant: u64 = 0,
+    dequant_pair: u64 = 0,
+    dequant_triple: u64 = 0,
+    q8_0: u64 = 0,
+    q8_0_pair: u64 = 0,
+    q8_0_triple: u64 = 0,
 };
 
 const Sample = struct {
     elapsed_ns: u64,
     entity_count: usize,
+    relation_count: usize = 0,
     score_sum: f64,
+    relation_score_sum: f64 = 0.0,
+    quant: QuantCounters = .{},
+    native_quant_stats_enabled: bool = false,
 };
 
 const Result = struct {
+    task: BenchTask,
     mode: []const u8,
     avg_ms: f64,
     p50_ms: f64,
@@ -68,7 +96,16 @@ const Result = struct {
     min_ms: f64,
     max_ms: f64,
     entity_count: usize,
+    relation_count: usize,
     score_sum: f64,
+    relation_score_sum: f64,
+    quant: QuantCounters,
+    native_quant_stats_enabled: bool,
+};
+
+const TaskResult = struct {
+    first: Result,
+    warm: Result,
 };
 
 pub fn main(init: std.process.Init) !void {
@@ -94,11 +131,50 @@ pub fn main(init: std.process.Init) !void {
 
     const texts = [_][]const u8{opts.text};
     const labels: ?[]const []const u8 = if (opts.labels.items.len > 0) opts.labels.items else null;
+    const relation_labels: ?[]const []const u8 = if (opts.relation_labels.items.len > 0) opts.relation_labels.items else null;
 
     var pipeline = model.glinerPipeline(allocator);
 
-    const first = try runRecognize(&pipeline, &texts, labels);
+    var rows = std.ArrayListUnmanaged(Result).empty;
+    defer rows.deinit(allocator);
+
+    if (opts.task == .entities or opts.task == .both) {
+        const task_result = try runBenchmarkTask(allocator, &pipeline, &texts, labels, relation_labels, .entities, load_elapsed_ns, opts.warmup_iters, opts.measure_iters);
+        try rows.append(allocator, task_result.first);
+        try rows.append(allocator, task_result.warm);
+    }
+
+    if (opts.task == .relations or opts.task == .both) {
+        const task_result = try runBenchmarkTask(allocator, &pipeline, &texts, labels, relation_labels, .relations, load_elapsed_ns, opts.warmup_iters, opts.measure_iters);
+        try rows.append(allocator, task_result.first);
+        try rows.append(allocator, task_result.warm);
+    }
+
+    switch (opts.format) {
+        .text => {
+            for (rows.items) |row| printText(opts, row);
+        },
+        .csv => {
+            printCsvHeader();
+            for (rows.items) |row| printCsv(opts, row);
+        },
+    }
+}
+
+fn runBenchmarkTask(
+    allocator: std.mem.Allocator,
+    pipeline: anytype,
+    texts: []const []const u8,
+    labels: ?[]const []const u8,
+    relation_labels: ?[]const []const u8,
+    task: BenchTask,
+    load_elapsed_ns: u64,
+    warmup_iters: usize,
+    measure_iters: usize,
+) !TaskResult {
+    const first = try runTask(pipeline, texts, labels, relation_labels, task);
     const first_run = Result{
+        .task = task,
         .mode = "first_run",
         .avg_ms = nsToMs(load_elapsed_ns + first.elapsed_ns),
         .p50_ms = nsToMs(load_elapsed_ns + first.elapsed_ns),
@@ -106,49 +182,90 @@ pub fn main(init: std.process.Init) !void {
         .min_ms = nsToMs(load_elapsed_ns + first.elapsed_ns),
         .max_ms = nsToMs(load_elapsed_ns + first.elapsed_ns),
         .entity_count = first.entity_count,
+        .relation_count = first.relation_count,
         .score_sum = first.score_sum,
+        .relation_score_sum = first.relation_score_sum,
+        .quant = first.quant,
+        .native_quant_stats_enabled = first.native_quant_stats_enabled,
     };
 
-    for (0..opts.warmup_iters) |_| {
-        _ = try runRecognize(&pipeline, &texts, labels);
+    for (0..warmup_iters) |_| {
+        _ = try runTask(pipeline, texts, labels, relation_labels, task);
     }
 
-    const samples = try allocator.alloc(Sample, opts.measure_iters);
+    const samples = try allocator.alloc(Sample, measure_iters);
     defer allocator.free(samples);
     for (samples) |*sample| {
-        sample.* = try runRecognize(&pipeline, &texts, labels);
+        sample.* = try runTask(pipeline, texts, labels, relation_labels, task);
     }
-    const warm = try resultFromSamples(allocator, "warm_loaded_session", samples);
+    const warm = try resultFromSamples(allocator, task, "warm_loaded_session", samples);
 
-    switch (opts.format) {
-        .text => {
-            printText(opts, first_run);
-            printText(opts, warm);
-        },
-        .csv => {
-            std.debug.print("mode,model_dir,backend,avg_ms,p50_ms,p95_ms,min_ms,max_ms,entity_count,score_sum\n", .{});
-            printCsv(opts, first_run);
-            printCsv(opts, warm);
-        },
-    }
+    return .{ .first = first_run, .warm = warm };
 }
 
-fn runRecognize(pipeline: anytype, texts: []const []const u8, labels: ?[]const []const u8) !Sample {
+fn runTask(
+    pipeline: anytype,
+    texts: []const []const u8,
+    labels: ?[]const []const u8,
+    relation_labels: ?[]const []const u8,
+    task: BenchTask,
+) !Sample {
+    native_compute.resetNativeQuantDispatchStats();
     const start = nowNs();
-    const entities = try pipeline.recognizeBatch(texts, labels);
-    const elapsed_ns = nowNs() - start;
-    defer freeEntities(pipeline.allocator, entities);
 
-    var entity_count: usize = 0;
-    var score_sum: f64 = 0.0;
-    for (entities) |row| {
-        entity_count += row.len;
-        for (row) |entity| score_sum += entity.score;
+    switch (task) {
+        .entities => {
+            const entities = try pipeline.recognizeBatch(texts, labels);
+            const elapsed_ns = nowNs() - start;
+            defer freeEntities(pipeline.allocator, entities);
+
+            var entity_count: usize = 0;
+            var score_sum: f64 = 0.0;
+            for (entities) |row| {
+                entity_count += row.len;
+                for (row) |entity| score_sum += entity.score;
+            }
+            return .{
+                .elapsed_ns = elapsed_ns,
+                .entity_count = entity_count,
+                .score_sum = score_sum,
+                .quant = quantCountersFromStats(native_compute.nativeQuantDispatchStats()),
+                .native_quant_stats_enabled = native_compute.nativeQuantDispatchStatsEnabled(),
+            };
+        },
+        .relations => {
+            const extracted = try pipeline.extractRelationsBatch(texts, labels, relation_labels);
+            const elapsed_ns = nowNs() - start;
+            defer freeEntities(pipeline.allocator, extracted.entities);
+            defer freeRelations(pipeline.allocator, extracted.relations);
+
+            var entity_count: usize = 0;
+            var relation_count: usize = 0;
+            var score_sum: f64 = 0.0;
+            var relation_score_sum: f64 = 0.0;
+            for (extracted.entities) |row| {
+                entity_count += row.len;
+                for (row) |entity| score_sum += entity.score;
+            }
+            for (extracted.relations) |row| {
+                relation_count += row.len;
+                for (row) |relation| relation_score_sum += relation.score;
+            }
+            return .{
+                .elapsed_ns = elapsed_ns,
+                .entity_count = entity_count,
+                .relation_count = relation_count,
+                .score_sum = score_sum,
+                .relation_score_sum = relation_score_sum,
+                .quant = quantCountersFromStats(native_compute.nativeQuantDispatchStats()),
+                .native_quant_stats_enabled = native_compute.nativeQuantDispatchStatsEnabled(),
+            };
+        },
+        .both => unreachable,
     }
-    return .{ .elapsed_ns = elapsed_ns, .entity_count = entity_count, .score_sum = score_sum };
 }
 
-fn resultFromSamples(allocator: std.mem.Allocator, mode: []const u8, samples: []const Sample) !Result {
+fn resultFromSamples(allocator: std.mem.Allocator, task: BenchTask, mode: []const u8, samples: []const Sample) !Result {
     if (samples.len == 0) return error.InvalidMeasureIters;
     const sorted = try allocator.dupe(Sample, samples);
     defer allocator.free(sorted);
@@ -165,6 +282,7 @@ fn resultFromSamples(allocator: std.mem.Allocator, mode: []const u8, samples: []
     const p95_idx = @min(samples.len - 1, (samples.len * 95 + 99) / 100 - 1);
     const last = samples[samples.len - 1];
     return .{
+        .task = task,
         .mode = mode,
         .avg_ms = nsToMs(avg_ns),
         .p50_ms = nsToMs(sorted[p50_idx].elapsed_ns),
@@ -172,7 +290,11 @@ fn resultFromSamples(allocator: std.mem.Allocator, mode: []const u8, samples: []
         .min_ms = nsToMs(sorted[0].elapsed_ns),
         .max_ms = nsToMs(sorted[sorted.len - 1].elapsed_ns),
         .entity_count = last.entity_count,
+        .relation_count = last.relation_count,
         .score_sum = last.score_sum,
+        .relation_score_sum = last.relation_score_sum,
+        .quant = last.quant,
+        .native_quant_stats_enabled = last.native_quant_stats_enabled,
     };
 }
 
@@ -182,6 +304,29 @@ fn freeEntities(allocator: std.mem.Allocator, all_entities: anytype) void {
         allocator.free(entities);
     }
     allocator.free(all_entities);
+}
+
+fn freeRelations(allocator: std.mem.Allocator, all_relations: anytype) void {
+    for (all_relations) |relations| {
+        for (relations) |*relation| relation.deinit(allocator);
+        allocator.free(relations);
+    }
+    allocator.free(all_relations);
+}
+
+fn quantCountersFromStats(stats: native_compute.NativeQuantDispatchStats) QuantCounters {
+    return .{
+        .q4q5 = stats.q4_q5_k_q8k_activation,
+        .q4q5_pair = stats.q4_q5_k_q8k_activation_pair,
+        .q4q5_triple = stats.q4_q5_k_q8k_activation_triple,
+        .q4q5_panel = stats.q4_q5_k_prepared_panel,
+        .dequant = stats.dequant_sgemm,
+        .dequant_pair = stats.dequant_sgemm_pair,
+        .dequant_triple = stats.dequant_sgemm_triple,
+        .q8_0 = stats.q8_0_direct,
+        .q8_0_pair = stats.q8_0_pair,
+        .q8_0_triple = stats.q8_0_triple,
+    };
 }
 
 fn configureBackendPreference(session_manager: *backends.SessionManager, choice: BackendChoice) void {
@@ -195,6 +340,7 @@ fn configureBackendPreference(session_manager: *backends.SessionManager, choice:
 
 fn parseArgs(allocator: std.mem.Allocator, init: std.process.Init) !Options {
     var opts = Options{};
+    errdefer opts.deinit(allocator);
     var args = std.process.Args.Iterator.init(init.minimal.args);
     _ = args.next();
     while (args.next()) |arg| {
@@ -202,8 +348,12 @@ fn parseArgs(allocator: std.mem.Allocator, init: std.process.Init) !Options {
             opts.model_dir = args.next() orelse return error.MissingModelDir;
         } else if (std.mem.eql(u8, arg, "--text")) {
             opts.text = args.next() orelse return error.MissingText;
+        } else if (std.mem.eql(u8, arg, "--task")) {
+            opts.task = parseTask(args.next() orelse return error.MissingTask) orelse return error.InvalidTask;
         } else if (std.mem.eql(u8, arg, "--label")) {
             try opts.labels.append(allocator, args.next() orelse return error.MissingLabel);
+        } else if (std.mem.eql(u8, arg, "--relation-label")) {
+            try opts.relation_labels.append(allocator, args.next() orelse return error.MissingRelationLabel);
         } else if (std.mem.eql(u8, arg, "--backend")) {
             opts.backend = parseBackend(args.next() orelse return error.MissingBackend) orelse return error.InvalidBackend;
         } else if (std.mem.eql(u8, arg, "--graph-runtime")) {
@@ -225,6 +375,13 @@ fn parseArgs(allocator: std.mem.Allocator, init: std.process.Init) !Options {
     return opts;
 }
 
+fn parseTask(value: []const u8) ?BenchTask {
+    if (std.ascii.eqlIgnoreCase(value, "entities")) return .entities;
+    if (std.ascii.eqlIgnoreCase(value, "relations")) return .relations;
+    if (std.ascii.eqlIgnoreCase(value, "both")) return .both;
+    return null;
+}
+
 fn parseBackend(value: []const u8) ?BackendChoice {
     if (std.ascii.eqlIgnoreCase(value, "auto")) return .auto;
     if (std.ascii.eqlIgnoreCase(value, "native")) return .native;
@@ -241,21 +398,75 @@ fn parseFormat(value: []const u8) ?OutputFormat {
 
 fn printText(opts: Options, result: Result) void {
     std.debug.print(
-        "{s}: model_dir={s} backend={s} avg_ms={d:.3} p50_ms={d:.3} p95_ms={d:.3} min_ms={d:.3} max_ms={d:.3} entity_count={} score_sum={d:.6}\n",
-        .{ result.mode, opts.model_dir, @tagName(opts.backend), result.avg_ms, result.p50_ms, result.p95_ms, result.min_ms, result.max_ms, result.entity_count, result.score_sum },
+        "{s}/{s}: model_dir={s} backend={s} avg_ms={d:.3} p50_ms={d:.3} p95_ms={d:.3} min_ms={d:.3} max_ms={d:.3} entity_count={} relation_count={} score_sum={d:.6} relation_score_sum={d:.6} native_quant_stats={s} q4q5={} q4q5_pair={} q4q5_triple={} q4q5_panel={} dequant={} dequant_pair={} dequant_triple={} q8_0={} q8_0_pair={} q8_0_triple={}\n",
+        .{
+            @tagName(result.task),
+            result.mode,
+            opts.model_dir,
+            @tagName(opts.backend),
+            result.avg_ms,
+            result.p50_ms,
+            result.p95_ms,
+            result.min_ms,
+            result.max_ms,
+            result.entity_count,
+            result.relation_count,
+            result.score_sum,
+            result.relation_score_sum,
+            if (result.native_quant_stats_enabled) "enabled" else "disabled",
+            result.quant.q4q5,
+            result.quant.q4q5_pair,
+            result.quant.q4q5_triple,
+            result.quant.q4q5_panel,
+            result.quant.dequant,
+            result.quant.dequant_pair,
+            result.quant.dequant_triple,
+            result.quant.q8_0,
+            result.quant.q8_0_pair,
+            result.quant.q8_0_triple,
+        },
     );
+}
+
+fn printCsvHeader() void {
+    std.debug.print("task,mode,model_dir,backend,avg_ms,p50_ms,p95_ms,min_ms,max_ms,entity_count,relation_count,score_sum,relation_score_sum,native_quant_stats_enabled,q4q5,q4q5_pair,q4q5_triple,q4q5_panel,dequant,dequant_pair,dequant_triple,q8_0,q8_0_pair,q8_0_triple\n", .{});
 }
 
 fn printCsv(opts: Options, result: Result) void {
     std.debug.print(
-        "{s},{s},{s},{d:.3},{d:.3},{d:.3},{d:.3},{d:.3},{},{d:.6}\n",
-        .{ result.mode, opts.model_dir, @tagName(opts.backend), result.avg_ms, result.p50_ms, result.p95_ms, result.min_ms, result.max_ms, result.entity_count, result.score_sum },
+        "{s},{s},{s},{s},{d:.3},{d:.3},{d:.3},{d:.3},{d:.3},{},{},{d:.6},{d:.6},{},{},{},{},{},{},{},{},{},{},{}\n",
+        .{
+            @tagName(result.task),
+            result.mode,
+            opts.model_dir,
+            @tagName(opts.backend),
+            result.avg_ms,
+            result.p50_ms,
+            result.p95_ms,
+            result.min_ms,
+            result.max_ms,
+            result.entity_count,
+            result.relation_count,
+            result.score_sum,
+            result.relation_score_sum,
+            result.native_quant_stats_enabled,
+            result.quant.q4q5,
+            result.quant.q4q5_pair,
+            result.quant.q4q5_triple,
+            result.quant.q4q5_panel,
+            result.quant.dequant,
+            result.quant.dequant_pair,
+            result.quant.dequant_triple,
+            result.quant.q8_0,
+            result.quant.q8_0_pair,
+            result.quant.q8_0_triple,
+        },
     );
 }
 
 fn printUsage() void {
     std.debug.print(
-        \\usage: zig build bench-gliner2-e2e -- --model-dir <dir> [--text TEXT] [--label NAME]... [--backend native] [--graph-runtime partitioned] [--warmup-iters N] [--measure-iters N] [--format text|csv]
+        \\usage: zig build bench-gliner2-e2e -- --model-dir <dir> [--task entities|relations|both] [--text TEXT] [--label NAME]... [--relation-label NAME]... [--backend auto|native|metal|mlx] [--graph-runtime partitioned] [--warmup-iters N] [--measure-iters N] [--format text|csv]
         \\
     , .{});
 }

--- a/zig/pkg/termite/src/models/deberta.zig
+++ b/zig/pkg/termite/src/models/deberta.zig
@@ -29,8 +29,10 @@ pub const Config = struct {
     max_position_embeddings: u32 = 512,
     position_buckets: u32 = 256,
     layer_norm_eps: f32 = 1e-7,
-    // GLiNER entity marker token ID (from added_tokens.json "[E]")
+    // GLiNER label marker token IDs (from added_tokens.json).
+    classification_token_id: i64 = 128004,
     entity_token_id: i64 = 128005,
+    relation_token_id: i64 = 128006,
     num_labels: u32 = 1,
 };
 

--- a/zig/pkg/termite/src/models/tensor_access.zig
+++ b/zig/pkg/termite/src/models/tensor_access.zig
@@ -439,17 +439,27 @@ pub const OnnxInitializerAccess = struct {
     }
 };
 
+pub fn isOnnxInitializerAccess(access: TensorAccess) bool {
+    return access.vtable == &OnnxInitializerAccess.vtable;
+}
+
 fn inferInitializerExportName(
     allocator: std.mem.Allocator,
     graph: *const onnx_graph.proto.GraphProto,
     initializer_name: []const u8,
 ) !?[]const u8 {
     if (try inferPyTorchParameterExportName(allocator, initializer_name)) |name| return name;
+    if (try inferGlinerCountEmbedExportName(allocator, graph, initializer_name)) |name| return name;
     if (try inferDownsampleReductionExportName(allocator, graph, initializer_name)) |name| return name;
     const matmul_output = findMatMulOutputForInitializer(graph, initializer_name) orelse return null;
     const bias_name = findAddBiasForMatMulOutput(graph, matmul_output) orelse return null;
-    if (!std.mem.endsWith(u8, bias_name, ".bias")) return null;
-    return try std.fmt.allocPrint(allocator, "{s}.weight", .{bias_name[0 .. bias_name.len - ".bias".len]});
+    if (std.mem.endsWith(u8, bias_name, ".bias")) {
+        return try std.fmt.allocPrint(allocator, "{s}.weight", .{bias_name[0 .. bias_name.len - ".bias".len]});
+    }
+    if (std.mem.endsWith(u8, bias_name, "_bias")) {
+        return try std.fmt.allocPrint(allocator, "{s}_weight", .{bias_name[0 .. bias_name.len - "_bias".len]});
+    }
+    return null;
 }
 
 fn inferPyTorchParameterExportName(
@@ -486,6 +496,55 @@ fn inferDownsampleReductionExportName(
     const next_stage = findLayerNormBeforeStageForInput(graph, matmul_output) orelse return null;
     if (next_stage == 0) return null;
     return try std.fmt.allocPrint(allocator, "audio_encoder.layers.{d}.downsample.reduction.weight", .{next_stage - 1});
+}
+
+fn inferGlinerCountEmbedExportName(
+    allocator: std.mem.Allocator,
+    graph: *const onnx_graph.proto.GraphProto,
+    initializer_name: []const u8,
+) !?[]const u8 {
+    for (graph.nodes) |node| {
+        if (std.mem.eql(u8, node.op_type, "Expand")) {
+            if (node.inputs.len > 0 and node.outputs.len > 0 and
+                std.mem.eql(u8, node.inputs[0], initializer_name) and
+                expandOutputFeedsGlinerCountGru(graph, node.outputs[0]))
+            {
+                return try allocator.dupe(u8, "count_embed.pos_embedding.weight");
+            }
+        }
+
+        if (!std.mem.eql(u8, node.op_type, "GRU")) continue;
+        if (!nodeReferencesFragment(node, "count_embed")) continue;
+        if (node.inputs.len > 1 and std.mem.eql(u8, node.inputs[1], initializer_name)) {
+            return try allocator.dupe(u8, "count_embed.gru.weight_ih_l0");
+        }
+        if (node.inputs.len > 2 and std.mem.eql(u8, node.inputs[2], initializer_name)) {
+            return try allocator.dupe(u8, "count_embed.gru.weight_hh_l0");
+        }
+        if (node.inputs.len > 3 and std.mem.eql(u8, node.inputs[3], initializer_name)) {
+            return try allocator.dupe(u8, "count_embed.gru.bias");
+        }
+    }
+    return null;
+}
+
+fn expandOutputFeedsGlinerCountGru(graph: *const onnx_graph.proto.GraphProto, expand_output: []const u8) bool {
+    for (graph.nodes) |node| {
+        if (!std.mem.eql(u8, node.op_type, "GRU")) continue;
+        if (!nodeReferencesFragment(node, "count_embed")) continue;
+        if (node.inputs.len > 0 and std.mem.eql(u8, node.inputs[0], expand_output)) return true;
+    }
+    return false;
+}
+
+fn nodeReferencesFragment(node: onnx_graph.proto.NodeProto, fragment: []const u8) bool {
+    for (node.inputs) |input| {
+        if (std.mem.indexOf(u8, input, fragment) != null) return true;
+    }
+    for (node.outputs) |output| {
+        if (std.mem.indexOf(u8, output, fragment) != null) return true;
+    }
+    return false;
 }
 
 fn findLayerNormBeforeStageForInput(graph: *const onnx_graph.proto.GraphProto, input_name: []const u8) ?usize {
@@ -533,6 +592,51 @@ test "infers no-bias CLAP downsample reduction MatMul names" {
     try std.testing.expectEqualStrings("audio_encoder.layers.0.downsample.reduction.weight", name);
 }
 
+test "infers ONNX MatMul names with underscore bias" {
+    const allocator = std.testing.allocator;
+    var matmul_inputs = [_][]const u8{ "hidden", "onnx::MatMul_1" };
+    var matmul_outputs = [_][]const u8{"matmul_out"};
+    var add_inputs = [_][]const u8{ "matmul_out", "count_embed.transformer.transformer.layers.0.self_attn.in_proj_bias" };
+    var add_outputs = [_][]const u8{"add_out"};
+    var nodes = [_]onnx_graph.proto.NodeProto{
+        .{ .inputs = &matmul_inputs, .outputs = &matmul_outputs, .op_type = "MatMul" },
+        .{ .inputs = &add_inputs, .outputs = &add_outputs, .op_type = "Add" },
+    };
+    const graph = onnx_graph.proto.GraphProto{ .nodes = &nodes };
+    const name = try inferInitializerExportName(allocator, &graph, "onnx::MatMul_1") orelse return error.TestUnexpectedResult;
+    defer allocator.free(name);
+    try std.testing.expectEqualStrings("count_embed.transformer.transformer.layers.0.self_attn.in_proj_weight", name);
+}
+
+test "infers GLiNER count embedding ONNX helper names" {
+    const allocator = std.testing.allocator;
+    var expand_inputs = [_][]const u8{ "onnx::Expand_1", "shape" };
+    var expand_outputs = [_][]const u8{"/count_embed/Expand_output_0"};
+    var gru_inputs = [_][]const u8{ "/count_embed/Expand_output_0", "onnx::GRU_W", "onnx::GRU_R", "onnx::GRU_B", "", "h0" };
+    var gru_outputs = [_][]const u8{"/count_embed/gru/GRU_output_0"};
+    var nodes = [_]onnx_graph.proto.NodeProto{
+        .{ .inputs = &expand_inputs, .outputs = &expand_outputs, .op_type = "Expand" },
+        .{ .inputs = &gru_inputs, .outputs = &gru_outputs, .op_type = "GRU" },
+    };
+    const graph = onnx_graph.proto.GraphProto{ .nodes = &nodes };
+
+    const pos_name = try inferInitializerExportName(allocator, &graph, "onnx::Expand_1") orelse return error.TestUnexpectedResult;
+    defer allocator.free(pos_name);
+    try std.testing.expectEqualStrings("count_embed.pos_embedding.weight", pos_name);
+
+    const w_name = try inferInitializerExportName(allocator, &graph, "onnx::GRU_W") orelse return error.TestUnexpectedResult;
+    defer allocator.free(w_name);
+    try std.testing.expectEqualStrings("count_embed.gru.weight_ih_l0", w_name);
+
+    const r_name = try inferInitializerExportName(allocator, &graph, "onnx::GRU_R") orelse return error.TestUnexpectedResult;
+    defer allocator.free(r_name);
+    try std.testing.expectEqualStrings("count_embed.gru.weight_hh_l0", r_name);
+
+    const b_name = try inferInitializerExportName(allocator, &graph, "onnx::GRU_B") orelse return error.TestUnexpectedResult;
+    defer allocator.free(b_name);
+    try std.testing.expectEqualStrings("count_embed.gru.bias", b_name);
+}
+
 fn findMatMulOutputForInitializer(graph: *const onnx_graph.proto.GraphProto, initializer_name: []const u8) ?[]const u8 {
     for (graph.nodes) |node| {
         if (!std.mem.eql(u8, node.op_type, "MatMul")) continue;
@@ -548,10 +652,14 @@ fn findAddBiasForMatMulOutput(graph: *const onnx_graph.proto.GraphProto, matmul_
     for (graph.nodes) |node| {
         if (!std.mem.eql(u8, node.op_type, "Add")) continue;
         if (node.inputs.len < 2) continue;
-        if (std.mem.eql(u8, node.inputs[0], matmul_output) and std.mem.endsWith(u8, node.inputs[1], ".bias")) return node.inputs[1];
-        if (std.mem.eql(u8, node.inputs[1], matmul_output) and std.mem.endsWith(u8, node.inputs[0], ".bias")) return node.inputs[0];
+        if (std.mem.eql(u8, node.inputs[0], matmul_output) and isOnnxBiasInputName(node.inputs[1])) return node.inputs[1];
+        if (std.mem.eql(u8, node.inputs[1], matmul_output) and isOnnxBiasInputName(node.inputs[0])) return node.inputs[0];
     }
     return null;
+}
+
+fn isOnnxBiasInputName(name: []const u8) bool {
+    return std.mem.endsWith(u8, name, ".bias") or std.mem.endsWith(u8, name, "_bias");
 }
 
 pub fn openFromManifest(allocator: std.mem.Allocator, manifest: manifest_mod.ModelManifest) !TensorAccess {

--- a/zig/pkg/termite/src/native_export_gguf.zig
+++ b/zig/pkg/termite/src/native_export_gguf.zig
@@ -89,6 +89,7 @@ const QuantizationFilter = struct {
 const TensorTransform = enum {
     none,
     transpose_2d_dense,
+    onnx_gru_zrh_to_rzn,
 };
 
 const TensorPlan = struct {
@@ -948,6 +949,7 @@ fn writeGlinerEncoderGguf(
 
     const names = try access.listNames(allocator);
     defer allocator.free(names);
+    const source_is_onnx = tensor_access_mod.isOnnxInitializerAccess(access);
 
     var tensors = std.ArrayListUnmanaged(TensorPlan).empty;
     defer {
@@ -963,9 +965,13 @@ fn writeGlinerEncoderGguf(
         const output_name_result = try mapGlinerEncoderTensorNameToDebertaGguf(allocator, record.descriptor.name);
         defer if (output_name_result.owned) allocator.free(output_name_result.name);
 
-        const dimensions = try reversedDimsFromShape(allocator, record.descriptor.shape);
+        const transform = if (source_is_onnx)
+            glinerOnnxLinearWeightTransform(record.descriptor.name, record.descriptor.shape)
+        else
+            .none;
+        const dimensions = try dimsForTransform(allocator, record.descriptor.shape, transform);
         errdefer allocator.free(dimensions);
-        const tensor_quantization = supportedQuantizationForDescriptor(false, quantization, record.descriptor, .none);
+        const tensor_quantization = supportedQuantizationForDescriptor(false, quantization, record.descriptor, transform);
         const filtered_quantization = if (quantizationFilterMatches(filter, record.descriptor.name, output_name_result.name))
             tensor_quantization
         else
@@ -981,6 +987,7 @@ fn writeGlinerEncoderGguf(
             .dimensions = dimensions,
             .tensor_type = tensor_type,
             .quantization = filtered_quantization,
+            .transform = transform,
         });
     }
 
@@ -1103,6 +1110,7 @@ fn writeGlinerHeadGguf(
 ) !void {
     const names = try access.listNames(allocator);
     defer allocator.free(names);
+    const source_is_onnx = tensor_access_mod.isOnnxInitializerAccess(access);
 
     var head_tensors = std.ArrayListUnmanaged(TensorPlan).empty;
     defer {
@@ -1114,9 +1122,13 @@ fn writeGlinerHeadGguf(
         if (isGlinerEncoderTensorName(name)) continue;
         var record = try access.getRecord(allocator, name);
         defer record.deinit();
-        const dimensions = try reversedDimsFromShape(allocator, record.descriptor.shape);
+
+        if (try appendGlinerSpecialHeadTensorPlans(allocator, &head_tensors, record, source_is_onnx)) continue;
+
+        const transform = glinerHeadTransform(record.descriptor.name, record.descriptor.shape, source_is_onnx);
+        const dimensions = try glinerHeadDimsForRecord(allocator, record.descriptor.name, record.descriptor.shape, transform);
         errdefer allocator.free(dimensions);
-        const tensor_quantization = supportedQuantizationForDescriptor(false, quantization, record.descriptor, .none);
+        const tensor_quantization = supportedQuantizationForDescriptor(false, quantization, record.descriptor, transform);
         const filtered_quantization = if (quantizationFilterMatches(filter, record.descriptor.name, record.descriptor.name))
             tensor_quantization
         else
@@ -1131,6 +1143,7 @@ fn writeGlinerHeadGguf(
             .dimensions = dimensions,
             .tensor_type = tensor_type,
             .quantization = filtered_quantization,
+            .transform = transform,
         });
     }
 
@@ -1171,6 +1184,122 @@ fn buildGlinerHeadMetadataEntries(allocator: std.mem.Allocator) ![]gguf_mod.form
         .value = .{ .u32 = 32 },
     });
     return try entries.toOwnedSlice(allocator);
+}
+
+fn appendGlinerSpecialHeadTensorPlans(
+    allocator: std.mem.Allocator,
+    tensors: *std.ArrayListUnmanaged(TensorPlan),
+    record: tensor_access_mod.Record,
+    source_is_onnx: bool,
+) !bool {
+    if (!std.mem.eql(u8, record.descriptor.name, "count_embed.gru.bias")) return false;
+    const dtype = switch (record.descriptor.encoding) {
+        .dense => |value| value,
+        else => return error.UnsupportedDenseTensorTypeForGgufExport,
+    };
+    const elem_size = denseElementSize(dtype);
+    if (elem_size == 0) return error.UnsupportedDenseTensorTypeForGgufExport;
+    if (record.descriptor.shape.len == 0) return error.InvalidTensorShape;
+    const last_dim = record.descriptor.shape[record.descriptor.shape.len - 1];
+    if (last_dim <= 0 or @mod(last_dim, 2) != 0) return error.InvalidTensorShape;
+
+    const split_elements: usize = @intCast(@divExact(last_dim, 2));
+    const split_bytes = split_elements * elem_size;
+    if (record.descriptor.byte_len < split_bytes * 2) return error.InvalidTensorShape;
+
+    const transform: TensorTransform = if (source_is_onnx) .onnx_gru_zrh_to_rzn else .none;
+    try appendGlinerGruBiasTensorPlan(allocator, tensors, record.descriptor.name, "count_embed.gru.bias_ih_l0", split_elements, split_bytes, 0, dtype, transform);
+    try appendGlinerGruBiasTensorPlan(allocator, tensors, record.descriptor.name, "count_embed.gru.bias_hh_l0", split_elements, split_bytes, split_bytes, dtype, transform);
+    return true;
+}
+
+fn appendGlinerGruBiasTensorPlan(
+    allocator: std.mem.Allocator,
+    tensors: *std.ArrayListUnmanaged(TensorPlan),
+    source_name: []const u8,
+    output_name: []const u8,
+    split_elements: usize,
+    split_bytes: usize,
+    start: usize,
+    dtype: @import("backends/tensor.zig").DType,
+    transform: TensorTransform,
+) !void {
+    const dimensions = try allocator.alloc(u64, 1);
+    errdefer allocator.free(dimensions);
+    dimensions[0] = @intCast(split_elements);
+
+    const source_name_owned = try allocator.dupe(u8, source_name);
+    errdefer allocator.free(source_name_owned);
+    const output_name_owned = try allocator.dupe(u8, output_name);
+    errdefer allocator.free(output_name_owned);
+
+    try tensors.append(allocator, .{
+        .source_name = source_name_owned,
+        .output_name = output_name_owned,
+        .dimensions = dimensions,
+        .tensor_type = try denseTensorType(dtype),
+        .quantization = .none,
+        .transform = transform,
+        .source_byte_range = .{ .start = start, .len = split_bytes },
+    });
+}
+
+fn glinerHeadDimsForRecord(
+    allocator: std.mem.Allocator,
+    name: []const u8,
+    shape: []const i64,
+    transform: TensorTransform,
+) ![]u64 {
+    if (glinerHeadDropsLeadingSingletonDim(name, shape)) {
+        return reversedDimsFromShape(allocator, shape[1..]);
+    }
+    return dimsForTransform(allocator, shape, transform);
+}
+
+fn glinerHeadDropsLeadingSingletonDim(name: []const u8, shape: []const i64) bool {
+    if (shape.len != 3 or shape[0] != 1) return false;
+    return std.mem.eql(u8, name, "count_embed.gru.weight_ih_l0") or
+        std.mem.eql(u8, name, "count_embed.gru.weight_hh_l0");
+}
+
+fn dimsForTransform(allocator: std.mem.Allocator, shape: []const i64, transform: TensorTransform) ![]u64 {
+    return switch (transform) {
+        .none => reversedDimsFromShape(allocator, shape),
+        .transpose_2d_dense => dimsFromShape(allocator, shape),
+        .onnx_gru_zrh_to_rzn => reversedDimsFromShape(allocator, shape),
+    };
+}
+
+fn glinerHeadTransform(name: []const u8, shape: []const i64, source_is_onnx: bool) TensorTransform {
+    if (!source_is_onnx) return .none;
+    if (isGlinerOnnxGruGateTensorName(name, shape)) return .onnx_gru_zrh_to_rzn;
+    return glinerOnnxLinearWeightTransform(name, shape);
+}
+
+fn glinerOnnxLinearWeightTransform(name: []const u8, shape: []const i64) TensorTransform {
+    if (shape.len != 2) return .none;
+    if (isGlinerEncoderOnnxLinearWeightName(name) or isGlinerHeadOnnxLinearWeightName(name)) return .transpose_2d_dense;
+    return .none;
+}
+
+fn isGlinerOnnxGruGateTensorName(name: []const u8, shape: []const i64) bool {
+    if (shape.len != 3 or shape[0] != 1) return false;
+    return std.mem.eql(u8, name, "count_embed.gru.weight_ih_l0") or
+        std.mem.eql(u8, name, "count_embed.gru.weight_hh_l0");
+}
+
+fn isGlinerEncoderOnnxLinearWeightName(name: []const u8) bool {
+    var trimmed = name;
+    if (std.mem.startsWith(u8, trimmed, "deberta.")) trimmed = trimmed["deberta.".len..];
+    if (std.mem.startsWith(u8, trimmed, "encoder.")) trimmed = trimmed["encoder.".len..];
+    return std.mem.startsWith(u8, trimmed, "encoder.layer.") and std.mem.endsWith(u8, trimmed, ".weight");
+}
+
+fn isGlinerHeadOnnxLinearWeightName(name: []const u8) bool {
+    if (std.mem.startsWith(u8, name, "span_rep.") and std.mem.endsWith(u8, name, ".weight")) return true;
+    if (!std.mem.startsWith(u8, name, "count_embed.transformer.")) return false;
+    if (std.mem.indexOf(u8, name, ".norm") != null) return false;
+    return std.mem.endsWith(u8, name, ".weight") or std.mem.endsWith(u8, name, "_weight");
 }
 
 fn copyGlinerBundleAssets(
@@ -2099,6 +2228,7 @@ fn buildClipPlannedExportFiltered(
         const dimensions = switch (transform) {
             .none => try reversedDimsFromShape(allocator, record.descriptor.shape),
             .transpose_2d_dense => try dimsFromShape(allocator, record.descriptor.shape),
+            .onnx_gru_zrh_to_rzn => return error.UnsupportedDenseArchitectureForGgufExport,
         };
         errdefer allocator.free(dimensions);
 
@@ -2219,6 +2349,7 @@ fn buildClapPlannedExportFiltered(
         const dimensions = switch (transform) {
             .none => try reversedDimsFromShape(allocator, record.descriptor.shape),
             .transpose_2d_dense => try dimsFromShape(allocator, record.descriptor.shape),
+            .onnx_gru_zrh_to_rzn => return error.UnsupportedDenseArchitectureForGgufExport,
         };
         errdefer allocator.free(dimensions);
 
@@ -2985,6 +3116,7 @@ fn denseExportDimsForTensor(
     return switch (denseExportTransformForTensor(config, source_name, shape)) {
         .none => reversedDimsFromShape(allocator, shape),
         .transpose_2d_dense => dimsFromShape(allocator, shape),
+        .onnx_gru_zrh_to_rzn => error.UnsupportedDenseArchitectureForGgufExport,
     };
 }
 
@@ -4608,7 +4740,12 @@ fn writeExportFile(
         if (tensor.quantization != .none) {
             try writeDenseRecordQuantized(allocator, io, &file, record, tensor.quantization, tensor.transform);
         } else if (tensor.source_byte_range) |byte_range| {
-            try file.writeStreamingAll(io, record.raw_bytes[byte_range.start .. byte_range.start + byte_range.len]);
+            if (byte_range.start > record.raw_bytes.len or byte_range.len > record.raw_bytes.len - byte_range.start) return error.InvalidTensorShape;
+            if (tensor.transform != .none) {
+                try writeTransformedDenseRecordRange(allocator, io, &file, record, tensor.transform, byte_range);
+            } else {
+                try file.writeStreamingAll(io, record.raw_bytes[byte_range.start .. byte_range.start + byte_range.len]);
+            }
         } else if (tensor.transform != .none) {
             try writeTransformedDenseRecord(allocator, io, &file, record, tensor.transform);
         } else {
@@ -4742,7 +4879,62 @@ fn writeTransformedDenseRecord(
     switch (transform) {
         .none => try file.writeStreamingAll(io, record.raw_bytes),
         .transpose_2d_dense => try writeDenseRecordTransposed2d(allocator, io, file, record),
+        .onnx_gru_zrh_to_rzn => try writeDenseRecordOnnxGruGateOrder(allocator, io, file, record.raw_bytes, try denseElementSizeForRecord(record)),
     }
+}
+
+fn writeTransformedDenseRecordRange(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    file: anytype,
+    record: tensor_access_mod.Record,
+    transform: TensorTransform,
+    byte_range: SourceByteRange,
+) !void {
+    const bytes = record.raw_bytes[byte_range.start .. byte_range.start + byte_range.len];
+    switch (transform) {
+        .none => try file.writeStreamingAll(io, bytes),
+        .onnx_gru_zrh_to_rzn => try writeDenseRecordOnnxGruGateOrder(allocator, io, file, bytes, try denseElementSizeForRecord(record)),
+        .transpose_2d_dense => return error.UnsupportedDenseArchitectureForGgufExport,
+    }
+}
+
+fn denseElementSizeForRecord(record: tensor_access_mod.Record) !usize {
+    const dense_dtype = switch (record.descriptor.encoding) {
+        .dense => |dtype| dtype,
+        else => return error.UnsupportedTensorType,
+    };
+    const elem_size = denseElementSize(dense_dtype);
+    if (elem_size == 0) return error.UnsupportedDenseTensorTypeForGgufExport;
+    return elem_size;
+}
+
+fn writeDenseRecordOnnxGruGateOrder(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    file: anytype,
+    bytes: []const u8,
+    elem_size: usize,
+) !void {
+    const reordered = try allocator.alloc(u8, bytes.len);
+    defer allocator.free(reordered);
+    try reorderOnnxGruZrhToRznBytes(reordered, bytes, elem_size);
+    try file.writeStreamingAll(io, reordered);
+}
+
+fn reorderOnnxGruZrhToRznBytes(output: []u8, input: []const u8, elem_size: usize) !void {
+    if (elem_size == 0 or input.len != output.len or input.len % (3 * elem_size) != 0) return error.InvalidTensorShape;
+    const gate_bytes = input.len / 3;
+    @memcpy(output[0..gate_bytes], input[gate_bytes .. 2 * gate_bytes]);
+    @memcpy(output[gate_bytes .. 2 * gate_bytes], input[0..gate_bytes]);
+    @memcpy(output[2 * gate_bytes .. 3 * gate_bytes], input[2 * gate_bytes .. 3 * gate_bytes]);
+}
+
+test "gliner ONNX GRU gate transform reorders zrh to rzn" {
+    const input = "zzzzrrrrhhhh".*;
+    var output: [input.len]u8 = undefined;
+    try reorderOnnxGruZrhToRznBytes(&output, &input, 1);
+    try std.testing.expectEqualStrings("rrrrzzzzhhhh", &output);
 }
 
 fn writeDenseRecordTransposed2d(
@@ -4809,6 +5001,7 @@ fn quantizedRowWidth(shape: []const i64, transform: TensorTransform) ?usize {
             if (rows <= 0) return null;
             break :blk @intCast(rows);
         },
+        .onnx_gru_zrh_to_rzn => null,
     };
 }
 
@@ -4830,6 +5023,7 @@ fn quantizedRowCount(shape: []const i64, transform: TensorTransform, row_width: 
             if (rows == 0 or cols == 0 or row_width != rows) return null;
             break :blk cols;
         },
+        .onnx_gru_zrh_to_rzn => null,
     };
 }
 
@@ -4885,6 +5079,7 @@ fn decodeDenseRowTyped(
                 output[i] = decodeDenseElemAsF32(T, raw_bytes, i * source_cols + row_index);
             }
         },
+        .onnx_gru_zrh_to_rzn => return error.UnsupportedQuantizedTensorShape,
     }
 }
 

--- a/zig/pkg/termite/src/native_extract.zig
+++ b/zig/pkg/termite/src/native_extract.zig
@@ -16,6 +16,7 @@ const std = @import("std");
 const build_options = @import("build_options");
 const backends = @import("backends/backends.zig");
 const model_manager_mod = @import("server/model_manager.zig");
+const gliner_mod = @import("pipelines/gliner.zig");
 const ner_mod = @import("pipelines/ner.zig");
 
 const print = std.debug.print;
@@ -32,10 +33,16 @@ const Options = struct {
     text: []const u8,
     schema_json: []const u8,
     backend: BackendChoice = .auto,
+    relation_labels: std.ArrayListUnmanaged([]const u8) = .empty,
+
+    fn deinit(self: *Options, allocator: std.mem.Allocator) void {
+        self.relation_labels.deinit(allocator);
+    }
 };
 
 pub fn main(allocator: std.mem.Allocator, io: std.Io, args: []const []const u8) !void {
-    const opts = try parseArgs(args);
+    var opts = try parseArgs(allocator, args);
+    defer opts.deinit(allocator);
 
     const parsed = try std.json.parseFromSlice(std.json.Value, allocator, opts.schema_json, .{});
     defer parsed.deinit();
@@ -57,19 +64,28 @@ pub fn main(allocator: std.mem.Allocator, io: std.Io, args: []const []const u8) 
         try schema_labels.append(allocator, entry.key_ptr.*);
     }
 
-    const entities = if (model.isGlinerModel()) blk: {
+    if (model.isGlinerModel()) {
         var gliner = model.glinerPipeline(allocator);
-        break :blk try gliner.recognizeBatch(&texts, schema_labels.items);
-    } else blk: {
+        if (opts.relation_labels.items.len > 0) {
+            const extracted = try gliner.extractRelationsBatch(&texts, schema_labels.items, opts.relation_labels.items);
+            defer freeEntities(allocator, extracted.entities);
+            defer freeRelations(allocator, extracted.relations);
+            try writeExtractJson(allocator, opts.model_dir, parsed.value.object, extracted.entities, extracted.relations);
+        } else {
+            const entities = try gliner.recognizeBatch(&texts, schema_labels.items);
+            defer freeEntities(allocator, entities);
+            try writeExtractJson(allocator, opts.model_dir, parsed.value.object, entities, null);
+        }
+    } else {
+        if (opts.relation_labels.items.len > 0) return error.RelationExtractionNotSupported;
         var pipeline = model.nerPipeline(allocator);
-        break :blk try pipeline.recognizeBatch(&texts);
-    };
-    defer freeEntities(allocator, entities);
-
-    try writeExtractJson(allocator, opts.model_dir, parsed.value.object, entities);
+        const entities = try pipeline.recognizeBatch(&texts);
+        defer freeEntities(allocator, entities);
+        try writeExtractJson(allocator, opts.model_dir, parsed.value.object, entities, null);
+    }
 }
 
-fn parseArgs(args: []const []const u8) !Options {
+fn parseArgs(allocator: std.mem.Allocator, args: []const []const u8) !Options {
     if (args.len < 3) {
         printUsage();
         return error.InvalidArguments;
@@ -80,6 +96,7 @@ fn parseArgs(args: []const []const u8) !Options {
         .text = args[1],
         .schema_json = args[2],
     };
+    errdefer opts.deinit(allocator);
 
     var i: usize = 3;
     while (i < args.len) : (i += 1) {
@@ -88,6 +105,10 @@ fn parseArgs(args: []const []const u8) !Options {
             i += 1;
             if (i >= args.len) return error.MissingBackendValue;
             opts.backend = parseBackendChoice(args[i]) orelse return error.InvalidBackend;
+        } else if (std.mem.eql(u8, arg, "--relation-label")) {
+            i += 1;
+            if (i >= args.len) return error.MissingRelationLabelValue;
+            try opts.relation_labels.append(allocator, args[i]);
         } else {
             printUsage();
             return error.InvalidArguments;
@@ -102,6 +123,7 @@ fn writeExtractJson(
     model_name: []const u8,
     schema: std.json.ObjectMap,
     all_entities: []const []const ner_mod.Entity,
+    all_relations: ?[]const []const gliner_mod.Relation,
 ) !void {
     var buf = std.ArrayListUnmanaged(u8).empty;
     defer buf.deinit(allocator);
@@ -143,6 +165,24 @@ fn writeExtractJson(
             try buf.append(allocator, ']');
         }
 
+        if (all_relations) |rels_by_text| {
+            const relations = if (ti < rels_by_text.len) rels_by_text[ti] else &.{};
+            try buf.appendSlice(allocator, ",\"relations\":[");
+            for (relations, 0..) |relation, ri| {
+                if (ri > 0) try buf.append(allocator, ',');
+                try buf.appendSlice(allocator, "{\"head\":");
+                try writeRelationEntityJson(&buf, allocator, relation.head);
+                try buf.appendSlice(allocator, ",\"tail\":");
+                try writeRelationEntityJson(&buf, allocator, relation.tail);
+                try buf.appendSlice(allocator, ",\"label\":");
+                try jsonEncodeString(&buf, allocator, relation.label);
+                const meta = try std.fmt.allocPrint(allocator, ",\"score\":{d}}}", .{relation.score});
+                defer allocator.free(meta);
+                try buf.appendSlice(allocator, meta);
+            }
+            try buf.append(allocator, ']');
+        }
+
         try buf.append(allocator, '}');
     }
     try buf.appendSlice(allocator, "]}\n");
@@ -158,6 +198,14 @@ fn freeEntities(allocator: std.mem.Allocator, all_entities: [][]ner_mod.Entity) 
     allocator.free(all_entities);
 }
 
+fn freeRelations(allocator: std.mem.Allocator, all_relations: [][]gliner_mod.Relation) void {
+    for (all_relations) |relations| {
+        for (relations) |*relation| relation.deinit(allocator);
+        allocator.free(relations);
+    }
+    allocator.free(all_relations);
+}
+
 fn labelMatchesSchema(label: []const u8, schema_name: []const u8) bool {
     if (label.len == 0 or schema_name.len == 0) return false;
     if (std.ascii.eqlIgnoreCase(label, schema_name)) return true;
@@ -165,6 +213,20 @@ fn labelMatchesSchema(label: []const u8, schema_name: []const u8) bool {
         if (std.ascii.eqlIgnoreCase(label[2..], schema_name)) return true;
     }
     return false;
+}
+
+fn writeRelationEntityJson(buf: *std.ArrayListUnmanaged(u8), allocator: std.mem.Allocator, entity: ner_mod.Entity) !void {
+    try buf.appendSlice(allocator, "{\"text\":");
+    try jsonEncodeString(buf, allocator, entity.text);
+    try buf.appendSlice(allocator, ",\"label\":");
+    try jsonEncodeString(buf, allocator, entity.label);
+    const meta = try std.fmt.allocPrint(
+        allocator,
+        ",\"start\":{d},\"end\":{d},\"score\":{d}}}",
+        .{ entity.start, entity.end, entity.score },
+    );
+    defer allocator.free(meta);
+    try buf.appendSlice(allocator, meta);
 }
 
 fn jsonEncodeString(buf: *std.ArrayListUnmanaged(u8), allocator: std.mem.Allocator, s: []const u8) !void {
@@ -216,23 +278,41 @@ fn configureBackendPreference(session_manager: *backends.SessionManager, choice:
 
 fn printUsage() void {
     print(
-        \\usage: termite extract <model-dir> <text> <schema-json> [--backend auto|native|metal|mlx]
+        \\usage: termite extract <model-dir> <text> <schema-json> [--backend auto|native|metal|mlx] [--relation-label LABEL]...
         \\  Runs native local extraction and prints a JSON response to stdout.
         \\
     , .{});
 }
 
 test "parseArgs accepts schema json and backend" {
-    const opts = try parseArgs(&.{
+    var opts = try parseArgs(std.testing.allocator, &.{
         "/tmp/model",
         "John works at Google",
         "{\"person\":[\"name::str\"]}",
         "--backend",
         "native",
     });
+    defer opts.deinit(std.testing.allocator);
 
     try std.testing.expectEqualStrings("/tmp/model", opts.model_dir);
     try std.testing.expectEqualStrings("John works at Google", opts.text);
     try std.testing.expectEqualStrings("{\"person\":[\"name::str\"]}", opts.schema_json);
     try std.testing.expectEqual(BackendChoice.native, opts.backend);
+}
+
+test "parseArgs accepts repeated relation labels" {
+    var opts = try parseArgs(std.testing.allocator, &.{
+        "/tmp/model",
+        "John works at Google",
+        "{\"person\":[\"name::str\"]}",
+        "--relation-label",
+        "works_for",
+        "--relation-label",
+        "located_in",
+    });
+    defer opts.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), opts.relation_labels.items.len);
+    try std.testing.expectEqualStrings("works_for", opts.relation_labels.items[0]);
+    try std.testing.expectEqualStrings("located_in", opts.relation_labels.items[1]);
 }

--- a/zig/pkg/termite/src/pipelines/gliner.zig
+++ b/zig/pkg/termite/src/pipelines/gliner.zig
@@ -510,10 +510,12 @@ pub const GlinerPipeline = struct {
             for (composite_labels.items) |label| alloc.free(label);
             composite_labels.deinit(alloc);
         }
-        for (entity_labels) |entity_label| {
-            for (relation_labels) |relation_label| {
-                try composite_labels.append(alloc, try std.fmt.allocPrint(alloc, "{s}::{s}", .{ entity_label, relation_label }));
-            }
+        try appendRelationCandidateLabels(alloc, &composite_labels, entity_labels, relation_labels);
+        if (composite_labels.items.len == 0) {
+            return .{
+                .entities = entities,
+                .relations = try alloc.alloc(Relation, 0),
+            };
         }
 
         const relation_token = if (self.config.token_r != 0) self.config.token_r else self.config.token_e;
@@ -784,20 +786,27 @@ pub const GlinerPipeline = struct {
         }
 
         for (relation_heads) |head_span| {
-            const sep_index = std.mem.indexOf(u8, head_span.label, "::") orelse continue;
-            const relation_label = head_span.label[sep_index + 2 ..];
+            const candidate = parseRelationCandidateLabel(head_span.label) orelse continue;
 
             var head_entity: ?Entity = null;
+            var exact_span_mismatched_label = false;
             for (entities) |entity| {
                 if (entity.start == head_span.start and entity.end == head_span.end) {
-                    head_entity = entity;
-                    break;
+                    if (std.ascii.eqlIgnoreCase(entity.label, candidate.head_label)) {
+                        head_entity = entity;
+                        break;
+                    }
+                    exact_span_mismatched_label = true;
                 }
             }
+            if (head_entity == null and exact_span_mismatched_label) continue;
 
             var best_tail: ?Entity = null;
             var best_distance: usize = std.math.maxInt(usize);
             for (entities) |entity| {
+                if (candidate.tail_label) |tail_label| {
+                    if (!std.ascii.eqlIgnoreCase(entity.label, tail_label)) continue;
+                }
                 if (overlapsSpan(head_span.start, head_span.end, entity.start, entity.end)) continue;
                 const distance = charDistance(head_span.start, head_span.end, entity.start, entity.end);
                 if (distance < best_distance) {
@@ -811,7 +820,7 @@ pub const GlinerPipeline = struct {
             const head_copy = if (head_entity) |entity|
                 try duplicateEntity(alloc, entity)
             else blk: {
-                owned_head_label = try alloc.dupe(u8, head_span.label[0..sep_index]);
+                owned_head_label = try alloc.dupe(u8, candidate.head_label);
                 break :blk Entity{
                     .text = try alloc.dupe(u8, head_span.text),
                     .label = owned_head_label.?,
@@ -821,12 +830,12 @@ pub const GlinerPipeline = struct {
                 };
             };
             errdefer alloc.free(head_copy.text);
-            errdefer if (owned_head_label) |head_label| alloc.free(head_label);
+            errdefer if (owned_head_label) |owned_label| alloc.free(owned_label);
 
             const tail_copy = try duplicateEntity(alloc, best_tail.?);
             errdefer alloc.free(tail_copy.text);
 
-            const relation_label_copy = try alloc.dupe(u8, relation_label);
+            const relation_label_copy = try alloc.dupe(u8, candidate.relation_label);
             errdefer alloc.free(relation_label_copy);
 
             try relations.append(alloc, .{
@@ -841,6 +850,73 @@ pub const GlinerPipeline = struct {
         return try relations.toOwnedSlice(alloc);
     }
 };
+
+fn appendRelationCandidateLabels(
+    alloc: std.mem.Allocator,
+    out: *std.ArrayListUnmanaged([]const u8),
+    entity_labels: []const []const u8,
+    relation_labels: []const []const u8,
+) !void {
+    for (relation_labels) |relation_label| {
+        if (parseRelationCandidateLabel(relation_label)) |candidate| {
+            if (candidate.tail_label) |tail_label| {
+                if (!containsLabel(entity_labels, tail_label)) continue;
+            }
+            for (entity_labels) |entity_label| {
+                if (!std.ascii.eqlIgnoreCase(entity_label, candidate.head_label)) continue;
+                try appendOwnedRelationCandidateLabel(alloc, out, entity_label, candidate.relation_label, candidate.tail_label);
+                break;
+            }
+            continue;
+        }
+
+        for (entity_labels) |entity_label| {
+            try appendOwnedRelationCandidateLabel(alloc, out, entity_label, relation_label, null);
+        }
+    }
+}
+
+const RelationCandidateLabel = struct {
+    head_label: []const u8,
+    relation_label: []const u8,
+    tail_label: ?[]const u8 = null,
+};
+
+fn parseRelationCandidateLabel(label: []const u8) ?RelationCandidateLabel {
+    const first_sep = std.mem.indexOf(u8, label, "::") orelse return null;
+    const head_label = label[0..first_sep];
+    const rest = label[first_sep + 2 ..];
+    if (head_label.len == 0 or rest.len == 0) return null;
+    if (std.mem.indexOf(u8, rest, "::")) |second_sep| {
+        const relation_label = rest[0..second_sep];
+        const tail_label = rest[second_sep + 2 ..];
+        if (relation_label.len == 0 or tail_label.len == 0) return null;
+        return .{ .head_label = head_label, .relation_label = relation_label, .tail_label = tail_label };
+    }
+    return .{ .head_label = head_label, .relation_label = rest };
+}
+
+fn containsLabel(labels: []const []const u8, wanted: []const u8) bool {
+    for (labels) |label| {
+        if (std.ascii.eqlIgnoreCase(label, wanted)) return true;
+    }
+    return false;
+}
+
+fn appendOwnedRelationCandidateLabel(
+    alloc: std.mem.Allocator,
+    out: *std.ArrayListUnmanaged([]const u8),
+    head_label: []const u8,
+    relation_label: []const u8,
+    tail_label: ?[]const u8,
+) !void {
+    const owned_label = if (tail_label) |tail|
+        try std.fmt.allocPrint(alloc, "{s}::{s}::{s}", .{ head_label, relation_label, tail })
+    else
+        try std.fmt.allocPrint(alloc, "{s}::{s}", .{ head_label, relation_label });
+    errdefer alloc.free(owned_label);
+    try out.append(alloc, owned_label);
+}
 
 fn scoreLabelsFromLogits(alloc: std.mem.Allocator, logits: []const f32, num_labels: usize) ![]f32 {
     const scores = try alloc.alloc(f32, num_labels);
@@ -978,6 +1054,149 @@ test "gliner supportsRelationExtraction checks model type and capabilities" {
 
     pipeline.config = .{};
     try std.testing.expect(!pipeline.supportsRelationExtraction());
+}
+
+test "gliner relation matching keeps labels scores and nearest non-overlapping tail" {
+    const allocator = std.testing.allocator;
+    var pipeline = GlinerPipeline{
+        .allocator = allocator,
+        .session = undefined,
+        .tok = undefined,
+        .config = .{},
+    };
+
+    const entities = [_]Entity{
+        .{ .text = "John Smith", .label = "person", .start = 0, .end = 10, .score = 0.91 },
+        .{ .text = "Acme", .label = "organization", .start = 20, .end = 24, .score = 0.88 },
+        .{ .text = "Paris", .label = "location", .start = 27, .end = 32, .score = 0.82 },
+    };
+    const relation_heads = [_]Entity{
+        .{ .text = "John Smith", .label = "person::works_for", .start = 0, .end = 10, .score = 0.73 },
+        .{ .text = "Acme", .label = "organization::located_in", .start = 20, .end = 24, .score = 0.64 },
+    };
+
+    const relations = try pipeline.matchRelations(&entities, &relation_heads);
+    defer {
+        for (relations) |*relation| relation.deinit(allocator);
+        allocator.free(relations);
+    }
+
+    try std.testing.expectEqual(@as(usize, 2), relations.len);
+    try std.testing.expectEqualStrings("John Smith", relations[0].head.text);
+    try std.testing.expectEqualStrings("Acme", relations[0].tail.text);
+    try std.testing.expectEqualStrings("works_for", relations[0].label);
+    try std.testing.expectApproxEqAbs(@as(f32, 0.73), relations[0].score, 1e-6);
+    try std.testing.expect(relations[0].owned_head_label == null);
+
+    try std.testing.expectEqualStrings("Acme", relations[1].head.text);
+    try std.testing.expectEqualStrings("Paris", relations[1].tail.text);
+    try std.testing.expectEqualStrings("located_in", relations[1].label);
+}
+
+test "gliner relation matching preserves synthetic head label for unmatched head span" {
+    const allocator = std.testing.allocator;
+    var pipeline = GlinerPipeline{
+        .allocator = allocator,
+        .session = undefined,
+        .tok = undefined,
+        .config = .{},
+    };
+
+    const entities = [_]Entity{
+        .{ .text = "John", .label = "person", .start = 0, .end = 4, .score = 0.91 },
+        .{ .text = "Acme", .label = "organization", .start = 15, .end = 19, .score = 0.88 },
+    };
+    const relation_heads = [_]Entity{
+        .{ .text = "employee", .label = "person::works_for", .start = 6, .end = 14, .score = 0.71 },
+    };
+
+    const relations = try pipeline.matchRelations(&entities, &relation_heads);
+    defer {
+        for (relations) |*relation| relation.deinit(allocator);
+        allocator.free(relations);
+    }
+
+    try std.testing.expectEqual(@as(usize, 1), relations.len);
+    try std.testing.expectEqualStrings("employee", relations[0].head.text);
+    try std.testing.expectEqualStrings("person", relations[0].head.label);
+    try std.testing.expectEqualStrings("person", relations[0].owned_head_label.?);
+    try std.testing.expectEqualStrings("Acme", relations[0].tail.text);
+    try std.testing.expectEqualStrings("works_for", relations[0].label);
+}
+
+test "gliner relation matching skips exact head span with mismatched entity label" {
+    const allocator = std.testing.allocator;
+    var pipeline = GlinerPipeline{
+        .allocator = allocator,
+        .tok = undefined,
+        .session = undefined,
+        .config = .{},
+    };
+
+    const entities = [_]Entity{
+        .{ .text = "Boston", .label = "location", .start = 0, .end = 6, .score = 0.91 },
+        .{ .text = "Acme", .label = "organization", .start = 20, .end = 24, .score = 0.88 },
+    };
+    const relation_heads = [_]Entity{
+        .{ .text = "Boston", .label = "organization::located_in", .start = 0, .end = 6, .score = 0.73 },
+    };
+
+    const relations = try pipeline.matchRelations(&entities, &relation_heads);
+    defer allocator.free(relations);
+
+    try std.testing.expectEqual(@as(usize, 0), relations.len);
+}
+
+test "gliner relation matching honors qualified tail labels" {
+    const allocator = std.testing.allocator;
+    var pipeline = GlinerPipeline{
+        .allocator = allocator,
+        .tok = undefined,
+        .session = undefined,
+        .config = .{},
+    };
+
+    const entities = [_]Entity{
+        .{ .text = "Alice", .label = "person", .start = 0, .end = 5, .score = 0.91 },
+        .{ .text = "Bob", .label = "person", .start = 12, .end = 15, .score = 0.88 },
+        .{ .text = "Acme", .label = "organization", .start = 30, .end = 34, .score = 0.87 },
+    };
+    const relation_heads = [_]Entity{
+        .{ .text = "Alice", .label = "person::works_for::organization", .start = 0, .end = 5, .score = 0.73 },
+    };
+
+    const relations = try pipeline.matchRelations(&entities, &relation_heads);
+    defer {
+        for (relations) |*relation| relation.deinit(allocator);
+        allocator.free(relations);
+    }
+
+    try std.testing.expectEqual(@as(usize, 1), relations.len);
+    try std.testing.expectEqualStrings("Acme", relations[0].tail.text);
+    try std.testing.expectEqualStrings("works_for", relations[0].label);
+}
+
+test "gliner relation candidate labels support qualified head labels" {
+    const allocator = std.testing.allocator;
+    var labels = std.ArrayListUnmanaged([]const u8).empty;
+    defer {
+        for (labels.items) |label| allocator.free(label);
+        labels.deinit(allocator);
+    }
+
+    try appendRelationCandidateLabels(
+        allocator,
+        &labels,
+        &.{ "person", "organization", "location" },
+        &.{ "person::works_for::organization", "organization::located_in::location", "person::mentors::team", "founded" },
+    );
+
+    try std.testing.expectEqual(@as(usize, 5), labels.items.len);
+    try std.testing.expectEqualStrings("person::works_for::organization", labels.items[0]);
+    try std.testing.expectEqualStrings("organization::located_in::location", labels.items[1]);
+    try std.testing.expectEqualStrings("person::founded", labels.items[2]);
+    try std.testing.expectEqualStrings("organization::founded", labels.items[3]);
+    try std.testing.expectEqualStrings("location::founded", labels.items[4]);
 }
 
 test "gliner distributed mlx helpers mirror pipeline/session state" {


### PR DESCRIPTION
## Summary

  Adds native Zig GLiNER2 relationship extraction support and validates it on direct Q4_K CPU kernels.

  ## Changes

  - Added GLiNER2 relation extraction for labels like `works_for`, `person::works_for`, and
  `person::works_for::organization`.
  - Added `--relation-label` support to native `extract`.
  - Wired `[C]`, `[E]`, and `[R]` GLiNER marker tokens through config, eager head execution, graph
  prep, and manifest/token parsing.
  - Fixed GLiNER2 ONNX-to-GGUF export for count-embedding GRU tensors by converting ONNX `z,r,h` gate
  order to native `r,z,n`.
  - Extended `bench-gliner2-e2e` to benchmark entities, relations, or both with native quant dispatch
  counters.
  - Added focused tests for relation matching, marker handling, graph prep, tensor access, native
  extract args, GLiNER detection, GRU export reorder, and Q4_K export.

  ## Validation

  - `zig build -Dskip-openapi=true -Dmlx=false -Donnx=false -Dmetal=false`
  - `zig build -Dmlx=false -Donnx=false -Dmetal=false`
  - Focused GLiNER/native export/native extract tests all pass.

  ## CPU Benchmark

  Native Q4_K GLiNER2, direct quant kernels enabled:

  | Task | Avg | P50 | P95 | Output |
  |---|---:|---:|---:|---|
  | Entities | `97.616ms` | `96.856ms` | `101.405ms` | 3 entities |
  | Relations | `218.532ms` | `205.235ms` | `285.351ms` | 3 entities, 2 relations |

  Direct quant counters showed `dequant=0`, confirming the Q4_K path stayed on direct CPU kernels. The
  relation pass is roughly 2x entity extraction, as expected, since it runs entity extraction plus a
  relation-head pass.