### PR TITLE
zig: add secrets reload status coverage

### DIFF
--- a/zig/SECRETS.md
+++ b/zig/SECRETS.md
@@ -51,15 +51,17 @@ Implemented:
 - Metadata-service restore planning uses `openBackupLocationWithSecrets()` when
   the concrete service owns a `FileStore`, so S3 restore metadata reads can use
   live secret-backed AWS credentials.
+- `GET /status` reports compact, non-secret local secret-store health when a
+  store is available: whether Antfly is serving a stale last-known-good snapshot.
+- API server tests cover external `secrets.json` additions and deletions being
+  reflected by `GET /secrets`.
 
 Still needed:
 
-- API/runtime integration coverage for managed embedder key rotation with a fake
-  OpenAI-compatible endpoint.
-- Logs and metrics for reload generation, failed reloads, and stale snapshot
-  state.
 - Runtime tests for generator/reranker, foreign DSN, CDC DSN, S3 backup, and
   remote-content credential rotation.
+- Optional Prometheus metrics for reload state if operators need scrape-based
+  alerting in addition to `GET /status`.
 - A future encrypted-at-rest codec, if non-Kubernetes deployments need local
   secret-file encryption.
 
@@ -215,7 +217,7 @@ Expected behavior:
 6. If parsing succeeds, swap the temporary map into `entries`, update observed
    metadata, increment generation, and return `true`.
 7. If parsing fails, keep the old in-memory snapshot and record the reload
-   failure for logs and metrics.
+   failure for warning logs and compact cluster status.
 
 Do not mutate the active map until the new file has been fully parsed. A bad
 external edit must not destroy the last known good secrets.
@@ -314,7 +316,7 @@ the mounted-file behavior robust:
 
 - valid replacement files are authoritative, including key deletion
 - missing or malformed files keep last known good values
-- reload status is visible through logs and metrics
+- reload status is visible through compact cluster status and warning logs
 - secret values are never returned by APIs or written to logs
 - runtime consumers can observe changed values without process restart where
   live rotation is supported
@@ -397,7 +399,7 @@ workers.
 
 | Subsystem | Current Status | Needed Semantics |
 | --- | --- | --- |
-| Managed OpenAI embedders | Implemented with generation-cached bearer auth headers. | Add fake-provider runtime test. |
+| Managed OpenAI embedders | Implemented with generation-cached bearer auth headers and a fake OpenAI-compatible rotation test. | Continue using the same generation contract for future managed provider clients. |
 | Generator providers | Implemented for OpenAI-compatible providers with generation-cached bearer auth headers. | Add fake-provider runtime test; extend the same pattern when additional provider clients are implemented. |
 | Reranker providers | Runtime options now carry and resolve `api_key` references before rerank calls. | Add provider-specific tests once non-local reranker clients are implemented. |
 | Foreign DSNs | Implemented for API query paths that have the API server `FileStore`. | Add runtime tests and define pool invalidation behavior for any long-lived foreign clients. |
@@ -480,8 +482,8 @@ The public API should continue to avoid returning secret values.
 - include externally added keys
 - stop listing externally removed keys after a valid replacement file is loaded
 - report environment overlay status using current environment variables
-- expose stale reload status through logs and metrics when a malformed or
-  missing file forced the store to keep last known good values
+- expose stale reload status through compact `GET /status` fields when a
+  malformed or missing file forced the store to keep last known good values
 
 `PUT /secrets/{key}` should:
 
@@ -549,11 +551,11 @@ Additional runtime tests:
    `FileStore`.
 2. [done] Call refresh from `list()`, `getOwned()`, and write paths.
 3. [done] Add unit coverage for external file edits and malformed edits.
-4. [todo] Wire API tests around external edits.
+4. [done] Wire API tests around external edits.
 5. [done] Add reference-preserving `SecretValue`.
 6. [done] Migrate managed embedder API keys to resolve at request time or by generation
    cache.
-7. [todo] Add managed embedder runtime test with a fake OpenAI-compatible
+7. [done] Add managed embedder runtime test with a fake OpenAI-compatible
    endpoint.
 8. [done] Migrate generator and reranker provider credential plumbing.
 9. [partial] Preserve and resolve remote-content HTTP header references at
@@ -561,7 +563,7 @@ Additional runtime tests:
 10. [partial] Preserve and resolve remote-content S3 references at fetch time;
    rotation tests remain.
 11. [partial] Migrate foreign DSNs and CDC DSNs; reconnect tests remain.
-12. [todo] Add logs and metrics for stale reload state.
+12. [done] Add warning logs and compact cluster status for stale reload state.
 13. [done] Document operational behavior for malformed files, file deletion, Kubernetes
    projection, and rotation of long-lived clients.
 
@@ -572,7 +574,7 @@ Additional runtime tests:
 2. A missing file after a previous successful load keeps the last known good
    snapshot.
 3. A malformed file keeps the last known good snapshot and records reload
-   failure through logs and metrics.
+   failure through warning logs and compact cluster status.
 4. File entries have priority over environment fallback. If a file key is
    deleted and a matching environment variable exists, the environment value is
    used.
@@ -591,11 +593,9 @@ Additional runtime tests:
 
 ## Deferred Questions
 
-1. What exact logs and metrics should expose last reload success, last reload
-   failure, generation, and stale snapshot state?
-2. Should there be an API field for non-secret reload health, or are logs and
-   metrics sufficient?
-3. What encrypted envelope format and key-source contract should the future
+1. Should Prometheus metrics mirror the compact `GET /status` secret-store
+   state for scrape-based alerting?
+2. What encrypted envelope format and key-source contract should the future
    encrypted codec use?
-4. Should S3/backup and remote-content clients share a generation-keyed
+3. Should S3/backup and remote-content clients share a generation-keyed
    credential cache, or should each subsystem own its own cache?

--- a/zig/openapi.yaml
+++ b/zig/openapi.yaml
@@ -821,6 +821,18 @@ components:
           description: Indicates whether the cluster is running in single-node swarm
             mode
           x-omitzero: false
+        secret_store:
+          $ref: '#/components/schemas/SecretStoreStatus'
+    SecretStoreStatus:
+      type: object
+      description: Non-secret status for the local secrets file store, when one is
+        available.
+      properties:
+        stale:
+          type: boolean
+          description: Whether Antfly is serving a last-known-good secrets snapshot
+            after a failed refresh.
+          x-omitzero: false
     SecretStatus:
       type: string
       enum:

--- a/zig/pkg/antfly/src/api/cluster.zig
+++ b/zig/pkg/antfly/src/api/cluster.zig
@@ -13,6 +13,7 @@
 // limitations.
 
 const std = @import("std");
+const common_secrets = @import("../common/secrets.zig");
 const metadata_api = @import("../metadata/api.zig");
 
 pub const ClusterHealth = enum {
@@ -26,11 +27,16 @@ pub const ClusterStatus = struct {
     message: ?[]u8 = null,
     auth_enabled: bool = false,
     swarm_mode: bool = false,
+    secret_store: ?SecretStoreStatus = null,
 
     pub fn deinit(self: *ClusterStatus, alloc: std.mem.Allocator) void {
         if (self.message) |message| alloc.free(message);
         self.* = undefined;
     }
+};
+
+pub const SecretStoreStatus = struct {
+    stale: bool = false,
 };
 
 pub fn fromMetadataStatus(alloc: std.mem.Allocator, status: metadata_api.MetadataStatus) !ClusterStatus {
@@ -70,6 +76,12 @@ pub fn fromMetadataStatus(alloc: std.mem.Allocator, status: metadata_api.Metadat
     };
 }
 
+pub fn applySecretStoreHealth(status: *ClusterStatus, health: common_secrets.ReloadHealth) void {
+    status.secret_store = .{
+        .stale = health.stale_snapshot,
+    };
+}
+
 test "cluster status derives degraded and error states from metadata status" {
     var error_status = try fromMetadataStatus(std.testing.allocator, .{
         .metadata_group_id = 1,
@@ -99,4 +111,20 @@ test "cluster status derives degraded and error states from metadata status" {
     });
     defer healthy.deinit(std.testing.allocator);
     try std.testing.expectEqual(ClusterHealth.healthy, healthy.health);
+}
+
+test "cluster status carries non-secret secret store health" {
+    var status = ClusterStatus{ .health = .healthy };
+    applySecretStoreHealth(&status, .{
+        .generation = 7,
+        .entry_count = 3,
+        .last_reload_failed = true,
+        .stale_snapshot = true,
+        .reload_successes = 2,
+        .reload_failures = 1,
+        .last_success_ns = 123,
+        .last_failure_ns = 456,
+    });
+    const secret_store = status.secret_store orelse return error.TestUnexpectedResult;
+    try std.testing.expect(secret_store.stale);
 }

--- a/zig/pkg/antfly/src/api/http_server.zig
+++ b/zig/pkg/antfly/src/api/http_server.zig
@@ -1488,6 +1488,12 @@ pub const ApiHttpServer = struct {
             defer public_status.deinit(self.alloc);
             public_status.auth_enabled = self.cfg.auth_enabled;
             public_status.swarm_mode = self.cfg.swarm_mode;
+            if (self.cfg.secret_store) |secret_store| {
+                _ = secret_store.refreshIfChanged() catch |err| {
+                    std.log.warn("secret store status refresh skipped err={}", .{err});
+                };
+                cluster.applySecretStoreHealth(&public_status, secret_store.healthSnapshot());
+            }
             return try jsonResponse(self.alloc, public_status);
         }
         if (try self.dispatchProtocolRoutes(req, uri_parts, authenticated_identity)) |resp| return resp;
@@ -6915,12 +6921,95 @@ test "api http server serves secrets crud when backed by a local store" {
     }
     try std.testing.expect(found_openai);
 
+    try std.Io.Dir.cwd().writeFile(io_impl.io(), .{
+        .sub_path = store_path,
+        .data = "{\"secrets\":[{\"key\":\"gemini.api_key\",\"value\":\"externally-managed\",\"created_at_ns\":1,\"updated_at_ns\":2}]}",
+    });
+
+    var external_list_resp = try server.handle(.{
+        .method = .GET,
+        .uri = "/secrets",
+    });
+    defer external_list_resp.deinit(alloc);
+    try std.testing.expectEqual(@as(u16, 200), external_list_resp.status);
+    var external_list = try std.json.parseFromSlice(metadata_openapi.SecretList, alloc, external_list_resp.body, .{});
+    defer external_list.deinit();
+    var found_external_gemini = false;
+    var found_deleted_openai = false;
+    for (external_list.value.secrets) |secret| {
+        if (std.mem.eql(u8, secret.key, "gemini.api_key")) found_external_gemini = true;
+        if (std.mem.eql(u8, secret.key, "openai.api_key")) found_deleted_openai = true;
+    }
+    try std.testing.expect(found_external_gemini);
+    try std.testing.expect(!found_deleted_openai);
+
+    var restored = try store.put(alloc, "openai.api_key", "sk-test");
+    defer restored.deinit(alloc);
+
     var delete_resp = try server.handle(.{
         .method = .DELETE,
         .uri = "/secrets/openai.api_key",
     });
     defer delete_resp.deinit(alloc);
     try std.testing.expectEqual(@as(u16, 204), delete_resp.status);
+}
+
+test "api http server status includes secret store reload health" {
+    const alloc = std.testing.allocator;
+    const FakeSource = struct {
+        fn iface(_: *@This()) StatusSource {
+            return .{
+                .ptr = undefined,
+                .vtable = &.{
+                    .status = status,
+                },
+            };
+        }
+
+        fn status(_: *anyopaque) !metadata_api.MetadataStatus {
+            return .{
+                .metadata_group_id = 77,
+                .metrics = .{},
+                .projected_stores = 1,
+            };
+        }
+    };
+
+    const store_path = try std.fmt.allocPrint(alloc, ".zig-cache/test-secrets-status-{d}.json", .{platform_time.monotonicNs()});
+    defer alloc.free(store_path);
+    var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
+    defer io_impl.deinit();
+    defer std.Io.Dir.cwd().deleteFile(io_impl.io(), store_path) catch {};
+
+    try std.Io.Dir.cwd().writeFile(io_impl.io(), .{
+        .sub_path = store_path,
+        .data = "{\"secrets\":[{\"key\":\"openai.api_key\",\"value\":\"stable\",\"created_at_ns\":1,\"updated_at_ns\":1}]}",
+    });
+
+    var source = FakeSource{};
+    var store = try common_secrets.FileStore.init(alloc, store_path);
+    defer store.deinit();
+
+    var server = ApiHttpServer.init(alloc, .{
+        .swarm_mode = true,
+        .secret_store = &store,
+    }, source.iface(), null, null);
+
+    try std.Io.Dir.cwd().writeFile(io_impl.io(), .{
+        .sub_path = store_path,
+        .data = "{not-json",
+    });
+
+    var status_resp = try server.handle(.{
+        .method = .GET,
+        .uri = routes.Routes.status,
+    });
+    defer status_resp.deinit(alloc);
+    try std.testing.expectEqual(@as(u16, 200), status_resp.status);
+    var parsed = try std.json.parseFromSlice(cluster.ClusterStatus, alloc, status_resp.body, .{});
+    defer parsed.deinit();
+    const secret_store = parsed.value.secret_store orelse return error.TestUnexpectedResult;
+    try std.testing.expect(secret_store.stale);
 }
 
 test "api http server lists secrets status without a local secret store" {

--- a/zig/pkg/antfly/src/api/httpx_handler.zig
+++ b/zig/pkg/antfly/src/api/httpx_handler.zig
@@ -266,6 +266,12 @@ pub const AntflyApiHandler = struct {
         defer public_status.deinit(alloc);
         public_status.auth_enabled = self.api_server.cfg.auth_enabled;
         public_status.swarm_mode = self.api_server.cfg.swarm_mode;
+        if (self.api_server.cfg.secret_store) |secret_store| {
+            _ = secret_store.refreshIfChanged() catch |err| {
+                std.log.warn("secret store status refresh skipped err={}", .{err});
+            };
+            cluster.applySecretStoreHealth(&public_status, secret_store.healthSnapshot());
+        }
         return ctx.json(public_status);
     }
 

--- a/zig/pkg/antfly/src/api/openapi_contract.zig
+++ b/zig/pkg/antfly/src/api/openapi_contract.zig
@@ -205,6 +205,7 @@ test "bleve and metadata openapi modules are generated and wired" {
     try std.testing.expect(@hasDecl(metadata_generated, "QueryRequest"));
     try std.testing.expect(@hasDecl(metadata_generated, "QueryResponses"));
     try std.testing.expect(@hasDecl(metadata_generated, "QueryBuilderResult"));
+    try std.testing.expect(@hasDecl(metadata_generated, "SecretStoreStatus"));
     try std.testing.expect(@hasDecl(metadata_generated, "SecretEntry"));
     try std.testing.expect(@hasDecl(metadata_generated, "SecretList"));
     try std.testing.expect(@hasDecl(metadata_generated, "ClusterBackupResponse"));

--- a/zig/pkg/antfly/src/common/secrets.zig
+++ b/zig/pkg/antfly/src/common/secrets.zig
@@ -150,6 +150,17 @@ pub const ResolvedSecret = struct {
     }
 };
 
+pub const ReloadHealth = struct {
+    generation: u64,
+    entry_count: usize,
+    last_reload_failed: bool,
+    stale_snapshot: bool,
+    reload_successes: u64,
+    reload_failures: u64,
+    last_success_ns: u64,
+    last_failure_ns: u64,
+};
+
 pub const BearerAuthHeaderCache = struct {
     mutex: std.atomic.Mutex = .unlocked,
     generation: u64 = 0,
@@ -221,6 +232,10 @@ pub const FileStore = struct {
     observed_metadata: ?FileMetadata = null,
     generation_value: u64 = 0,
     last_reload_failed: bool = false,
+    reload_success_count: u64 = 0,
+    reload_failure_count: u64 = 0,
+    last_success_ns: u64 = 0,
+    last_failure_ns: u64 = 0,
 
     pub fn init(alloc: std.mem.Allocator, path: []const u8) !FileStore {
         var store = FileStore{
@@ -249,6 +264,12 @@ pub const FileStore = struct {
         self.lock();
         defer self.unlock();
         return self.last_reload_failed;
+    }
+
+    pub fn healthSnapshot(self: *FileStore) ReloadHealth {
+        self.lock();
+        defer self.unlock();
+        return self.healthSnapshotLocked();
     }
 
     pub fn refreshIfChanged(self: *FileStore) !bool {
@@ -399,14 +420,14 @@ pub const FileStore = struct {
         const metadata = statFileMetadata(self.path) catch |err| switch (err) {
             error.FileNotFound => {
                 self.observed_metadata = null;
-                self.last_reload_failed = false;
+                self.markReloadHealthyLocked(false);
                 return;
             },
             else => return err,
         };
         if (metadata == null) {
             self.observed_metadata = null;
-            self.last_reload_failed = false;
+            self.markReloadHealthyLocked(false);
             return;
         }
 
@@ -421,17 +442,18 @@ pub const FileStore = struct {
         self.entries = next;
         next = .{};
         self.observed_metadata = metadata;
-        self.last_reload_failed = false;
+        self.markReloadHealthyLocked(true);
     }
 
     fn refreshIfChangedLocked(self: *FileStore) !bool {
         const metadata = statFileMetadata(self.path) catch |err| switch (err) {
             error.FileNotFound => {
                 if (self.observed_metadata != null) {
-                    self.last_reload_failed = true;
-                    std.log.warn("secret store file missing; keeping last known good snapshot path={s}", .{self.path});
+                    const first_failure = !self.last_reload_failed;
+                    self.markReloadFailedLocked();
+                    if (first_failure) std.log.warn("secret store file missing; keeping last known good snapshot path={s}", .{self.path});
                 } else {
-                    self.last_reload_failed = false;
+                    self.markReloadHealthyLocked(false);
                 }
                 return false;
             },
@@ -439,23 +461,24 @@ pub const FileStore = struct {
         };
         if (metadata == null) {
             if (self.observed_metadata != null) {
-                self.last_reload_failed = true;
-                std.log.warn("secret store file missing; keeping last known good snapshot path={s}", .{self.path});
+                const first_failure = !self.last_reload_failed;
+                self.markReloadFailedLocked();
+                if (first_failure) std.log.warn("secret store file missing; keeping last known good snapshot path={s}", .{self.path});
             } else {
-                self.last_reload_failed = false;
+                self.markReloadHealthyLocked(false);
             }
             return false;
         }
         if (self.observed_metadata) |observed| {
             if (observed.eql(metadata.?)) {
-                self.last_reload_failed = false;
                 return false;
             }
         }
 
         var next = loadEntriesFromFile(self.alloc, self.path) catch |err| {
-            self.last_reload_failed = true;
-            std.log.warn("secret store reload failed; keeping last known good snapshot path={s} err={}", .{ self.path, err });
+            const first_failure = !self.last_reload_failed;
+            self.markReloadFailedLocked();
+            if (first_failure) std.log.warn("secret store reload failed; keeping last known good snapshot path={s} err={}", .{ self.path, err });
             return false;
         };
         errdefer {
@@ -465,7 +488,7 @@ pub const FileStore = struct {
         self.replaceEntriesLocked(&next);
         self.observed_metadata = metadata;
         self.generation_value +%= 1;
-        self.last_reload_failed = false;
+        self.markReloadHealthyLocked(true);
         return true;
     }
 
@@ -500,7 +523,7 @@ pub const FileStore = struct {
         self.replaceEntriesLocked(next);
         self.observed_metadata = try statFileMetadata(self.path);
         self.generation_value +%= 1;
-        self.last_reload_failed = false;
+        self.markReloadHealthyLocked(true);
     }
 
     fn replaceEntriesLocked(self: *FileStore, next: *std.StringArrayHashMapUnmanaged(StoredSecret)) void {
@@ -516,6 +539,33 @@ pub const FileStore = struct {
 
     fn unlock(self: *FileStore) void {
         self.mutex.unlock();
+    }
+
+    fn healthSnapshotLocked(self: *FileStore) ReloadHealth {
+        return .{
+            .generation = self.generation_value,
+            .entry_count = self.entries.count(),
+            .last_reload_failed = self.last_reload_failed,
+            .stale_snapshot = self.last_reload_failed and self.observed_metadata != null,
+            .reload_successes = self.reload_success_count,
+            .reload_failures = self.reload_failure_count,
+            .last_success_ns = self.last_success_ns,
+            .last_failure_ns = self.last_failure_ns,
+        };
+    }
+
+    fn markReloadHealthyLocked(self: *FileStore, count_success: bool) void {
+        self.last_reload_failed = false;
+        if (count_success) {
+            self.reload_success_count +%= 1;
+            self.last_success_ns = nowNs();
+        }
+    }
+
+    fn markReloadFailedLocked(self: *FileStore) void {
+        if (!self.last_reload_failed) self.reload_failure_count +%= 1;
+        self.last_reload_failed = true;
+        self.last_failure_ns = nowNs();
     }
 };
 
@@ -922,6 +972,11 @@ test "file secret store keeps last known good snapshot for malformed and missing
     try std.testing.expectEqualStrings("stable", after_malformed.?);
     try std.testing.expect(store.reloadFailed());
     try std.testing.expectEqual(malformed_generation, store.generation());
+    const malformed_health = store.healthSnapshot();
+    try std.testing.expect(malformed_health.last_reload_failed);
+    try std.testing.expect(malformed_health.stale_snapshot);
+    try std.testing.expectEqual(@as(u64, 1), malformed_health.reload_failures);
+    try std.testing.expect(malformed_health.last_failure_ns != 0);
 
     try deleteFile(path);
     const missing_generation = store.generation();
@@ -930,6 +985,10 @@ test "file secret store keeps last known good snapshot for malformed and missing
     try std.testing.expectEqualStrings("stable", after_missing.?);
     try std.testing.expect(store.reloadFailed());
     try std.testing.expectEqual(missing_generation, store.generation());
+    const missing_health = store.healthSnapshot();
+    try std.testing.expect(missing_health.last_reload_failed);
+    try std.testing.expect(missing_health.stale_snapshot);
+    try std.testing.expectEqual(@as(u64, 1), missing_health.reload_failures);
 }
 
 test "file secret store write refreshes first and preserves external keys" {

--- a/zig/pkg/antfly/src/inference/managed_embedder.zig
+++ b/zig/pkg/antfly/src/inference/managed_embedder.zig
@@ -1795,6 +1795,104 @@ test "managed embedder calls openai compatible embeddings endpoint" {
     try std.testing.expectEqual(@as(f32, 0.5), vector[2]);
 }
 
+pub fn testFileBackedApiKeyRotation() !void {
+    const alloc = std.testing.allocator;
+    const AuthCaptureApp = struct {
+        alloc: std.mem.Allocator,
+        mutex: std.atomic.Mutex = .unlocked,
+        headers: [2]?[]u8 = .{ null, null },
+        count: usize = 0,
+
+        fn deinit(self: *@This()) void {
+            for (&self.headers) |*header| {
+                if (header.*) |value| self.alloc.free(value);
+                header.* = null;
+            }
+        }
+
+        fn executor(self: *@This()) http_common.RequestExecutor {
+            return .{
+                .ptr = self,
+                .vtable = &.{
+                    .execute = execute,
+                },
+            };
+        }
+
+        fn execute(ptr: *anyopaque, response_alloc: std.mem.Allocator, req: http_common.HttpRequest) !http_common.HttpResponse {
+            const self: *@This() = @ptrCast(@alignCast(ptr));
+            const auth = req.authorization orelse req.header("authorization") orelse "";
+            while (!self.mutex.tryLock()) std.atomic.spinLoopHint();
+            defer self.mutex.unlock();
+            const index = self.count;
+            if (index < self.headers.len) {
+                if (self.headers[index]) |value| self.alloc.free(value);
+                self.headers[index] = try self.alloc.dupe(u8, auth);
+            }
+            self.count += 1;
+
+            return .{
+                .status = 200,
+                .content_type = try response_alloc.dupe(u8, "application/json"),
+                .body = try response_alloc.dupe(u8,
+                    \\{"object":"list","data":[{"object":"embedding","index":0,"embedding":[0.125,0.25,0.5]}],"model":"text-embedding-3-small","usage":{"prompt_tokens":1,"total_tokens":1}}
+                ),
+            };
+        }
+
+        fn expectHeader(self: *@This(), index: usize, expected: []const u8) !void {
+            while (!self.mutex.tryLock()) std.atomic.spinLoopHint();
+            defer self.mutex.unlock();
+            try std.testing.expect(index < self.count);
+            try std.testing.expectEqualStrings(expected, self.headers[index] orelse return error.TestUnexpectedResult);
+        }
+    };
+
+    const store_path = try std.fmt.allocPrint(alloc, ".zig-cache/test-managed-embedder-secret-rotation-{d}.json", .{monotonicNowNs()});
+    defer alloc.free(store_path);
+    var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
+    defer io_impl.deinit();
+    defer std.Io.Dir.cwd().deleteFile(io_impl.io(), store_path) catch {};
+
+    try std.Io.Dir.cwd().writeFile(io_impl.io(), .{
+        .sub_path = store_path,
+        .data = "{\"secrets\":[{\"key\":\"openai.api_key\",\"value\":\"first-key\",\"created_at_ns\":1,\"updated_at_ns\":1}]}",
+    });
+
+    var secret_store = try common_secrets.FileStore.init(alloc, store_path);
+    defer secret_store.deinit();
+
+    var app = AuthCaptureApp{ .alloc = alloc };
+    defer app.deinit();
+    var listener = std_http_listener.StdHttpListener.init(alloc, .{}, app.executor());
+    defer listener.deinit();
+    try listener.start();
+
+    const base_uri = try listener.baseUri(alloc);
+    defer alloc.free(base_uri);
+
+    const indexes_json = try std.fmt.allocPrint(alloc,
+        \\{{"semantic_idx":{{"type":"embeddings","field":"body","dimension":3,"embedder":{{"provider":"openai","model":"text-embedding-3-small","url":"{s}","api_key":"${{secret:openai.api_key}}"}}}}}}
+    , .{base_uri});
+    defer alloc.free(indexes_json);
+
+    var managed = try ManagedEmbedder.initFromIndexesJsonWithOptions(alloc, indexes_json, .{ .secret_store = &secret_store });
+    defer managed.deinit();
+
+    const first = try managed.embedQuery(alloc, "semantic_idx", "alpha concept");
+    defer alloc.free(first);
+    try app.expectHeader(0, "Bearer first-key");
+
+    try std.Io.Dir.cwd().writeFile(io_impl.io(), .{
+        .sub_path = store_path,
+        .data = "{\"secrets\":[{\"key\":\"openai.api_key\",\"value\":\"second-key-longer\",\"created_at_ns\":1,\"updated_at_ns\":2}]}",
+    });
+
+    const second = try managed.embedQuery(alloc, "semantic_idx", "beta concept");
+    defer alloc.free(second);
+    try app.expectHeader(1, "Bearer second-key-longer");
+}
+
 test "managed embedder surfaces rate-limited openai compatible responses as retryable" {
     const FakeApp = struct {
         fn executor() http_common.RequestExecutor {

--- a/zig/pkg/antfly/src/inference/mod.zig
+++ b/zig/pkg/antfly/src/inference/mod.zig
@@ -40,3 +40,7 @@ test "inference module compiles" {
     _ = openai;
     _ = managed_embedder;
 }
+
+test "managed embedder resolves file-backed api key rotation at request time" {
+    try managed_embedder.testFileBackedApiKeyRotation();
+}

--- a/zig/pkg/antfly/src/metadata/openapi.yaml
+++ b/zig/pkg/antfly/src/metadata/openapi.yaml
@@ -1459,6 +1459,16 @@ components:
           type: boolean
           description: Indicates whether the cluster is running in single-node swarm mode
           x-omitzero: false
+        secret_store:
+          $ref: "#/components/schemas/SecretStoreStatus"
+    SecretStoreStatus:
+      type: object
+      description: Non-secret status for the local secrets file store, when one is available.
+      properties:
+        stale:
+          type: boolean
+          description: Whether Antfly is serving a last-known-good secrets snapshot after a failed refresh.
+          x-omitzero: false
     SecretStatus:
       type: string
       enum:

--- a/zig/pkg/antfly/src/openapi/generated/antfly_client_openapi/root.zig
+++ b/zig/pkg/antfly/src/openapi/generated/antfly_client_openapi/root.zig
@@ -11,6 +11,7 @@ pub const SortDirection = types.SortDirection;
 pub const SortField = types.SortField;
 pub const ClusterHealth = types.ClusterHealth;
 pub const ClusterStatus = types.ClusterStatus;
+pub const SecretStoreStatus = types.SecretStoreStatus;
 pub const SecretStatus = types.SecretStatus;
 pub const SecretEntry = types.SecretEntry;
 pub const SecretList = types.SecretList;

--- a/zig/pkg/antfly/src/openapi/generated/antfly_client_openapi/types.zig
+++ b/zig/pkg/antfly/src/openapi/generated/antfly_client_openapi/types.zig
@@ -1305,6 +1305,13 @@ pub const ClusterStatus = struct {
     auth_enabled: ?bool = null,
     /// Indicates whether the cluster is running in single-node swarm mode
     swarm_mode: ?bool = null,
+    secret_store: ?SecretStoreStatus = null,
+};
+
+/// Non-secret status for the local secrets file store, when one is available.
+pub const SecretStoreStatus = struct {
+    /// Whether Antfly is serving a last-known-good secrets snapshot after a failed refresh.
+    stale: ?bool = null,
 };
 
 pub const SecretEntry = struct {

--- a/zig/pkg/antfly/src/openapi/generated/antfly_metadata_openapi/root.zig
+++ b/zig/pkg/antfly/src/openapi/generated/antfly_metadata_openapi/root.zig
@@ -10,6 +10,7 @@ pub const SortDirection = types.SortDirection;
 pub const SortField = types.SortField;
 pub const ClusterHealth = types.ClusterHealth;
 pub const ClusterStatus = types.ClusterStatus;
+pub const SecretStoreStatus = types.SecretStoreStatus;
 pub const SecretStatus = types.SecretStatus;
 pub const SecretEntry = types.SecretEntry;
 pub const SecretList = types.SecretList;

--- a/zig/pkg/antfly/src/openapi/generated/antfly_metadata_openapi/types.zig
+++ b/zig/pkg/antfly/src/openapi/generated/antfly_metadata_openapi/types.zig
@@ -1210,6 +1210,13 @@ pub const ClusterStatus = struct {
     auth_enabled: ?bool = null,
     /// Indicates whether the cluster is running in single-node swarm mode
     swarm_mode: ?bool = null,
+    secret_store: ?SecretStoreStatus = null,
+};
+
+/// Non-secret status for the local secrets file store, when one is available.
+pub const SecretStoreStatus = struct {
+    /// Whether Antfly is serving a last-known-good secrets snapshot after a failed refresh.
+    stale: ?bool = null,
 };
 
 pub const SecretEntry = struct {

--- a/zig/pkg/antfly/src/openapi/generated/antfly_public_openapi/root.zig
+++ b/zig/pkg/antfly/src/openapi/generated/antfly_public_openapi/root.zig
@@ -9,6 +9,7 @@ pub const SortDirection = types.SortDirection;
 pub const SortField = types.SortField;
 pub const ClusterHealth = types.ClusterHealth;
 pub const ClusterStatus = types.ClusterStatus;
+pub const SecretStoreStatus = types.SecretStoreStatus;
 pub const SecretStatus = types.SecretStatus;
 pub const SecretEntry = types.SecretEntry;
 pub const SecretList = types.SecretList;

--- a/zig/pkg/antfly/src/openapi/generated/antfly_public_openapi/types.zig
+++ b/zig/pkg/antfly/src/openapi/generated/antfly_public_openapi/types.zig
@@ -1305,6 +1305,13 @@ pub const ClusterStatus = struct {
     auth_enabled: ?bool = null,
     /// Indicates whether the cluster is running in single-node swarm mode
     swarm_mode: ?bool = null,
+    secret_store: ?SecretStoreStatus = null,
+};
+
+/// Non-secret status for the local secrets file store, when one is available.
+pub const SecretStoreStatus = struct {
+    /// Whether Antfly is serving a last-known-good secrets snapshot after a failed refresh.
+    stale: ?bool = null,
 };
 
 pub const SecretEntry = struct {


### PR DESCRIPTION
## Summary
- Add internal FileStore reload health tracking for stale last-known-good snapshots.
- Expose compact non-secret `/status.secret_store.stale` health in API/httpx status paths.
- Add API coverage for external `secrets.json` additions/deletions and malformed-file stale status.
- Add managed embedder fake OpenAI-compatible rotation coverage through the root test graph.
- Update OpenAPI schemas/generated types and `zig/SECRETS.md` status.

## Verification
- `zig build root-test -- "managed embedder resolves file-backed api key rotation at request time"`
- `zig build root-test -- "file secret store keeps last known good snapshot" "api http server status includes secret store reload health" "cluster status carries non-secret secret store health" "api http server serves secrets crud when backed by a local store"`
- `uv run --project scripts --locked python scripts/join_openapi.py --compare openapi.yaml`
- `zig build install-antfly`
- `git diff --check`