### PR TITLE
Remove Codecov from Python CI

### DIFF
--- a/.github/workflows/py-ci.yml
+++ b/.github/workflows/py-ci.yml
@@ -46,9 +46,4 @@ jobs:
 
       - name: Run tests
         working-directory: py
-        run: uv run pytest tests --cov=antfly --cov-report=xml
-
-      - name: Upload coverage
-        uses: codecov/codecov-action@v3
-        with:
-          file: py/coverage.xml
+        run: uv run pytest tests


### PR DESCRIPTION
## Summary
- remove the Codecov upload step from Python CI
- stop generating `coverage.xml` during CI tests

## Verification
- `rg "codecov|Codecov|CODECOV" .github py` returns no matches
- `git diff --check` passes