### PR TITLE
Require authentication for MCP public endpoint

### DIFF
--- a/src/metadata/runtime.go
+++ b/src/metadata/runtime.go
@@ -469,6 +469,8 @@ func (r *Runtime) newHTTPHandler() http.Handler {
 	mcpAdapter := newMCPAdapter(NewTableApi(r.logger, r.node, r.tableManager))
 	mcpServer := antflymcp.NewMCPServer(mcpAdapter)
 	mcpHandler := antflymcp.NewMCPHandler(mcpServer)
+	// Ensure MCP routes receive the same authentication gate as other public APIs.
+	mcpHandler = r.node.authnMiddleware(mcpHandler)
 	apiRoutes.Handle("/mcp/v1/", http.StripPrefix("/mcp/v1", mcpHandler))
 	r.logger.Info("MCP server mounted", zap.String("path", "/mcp/v1/"))
 


### PR DESCRIPTION
(Generated with Codex Security)

---

### Motivation
- The MCP HTTP handler was mounted at `/mcp/v1/` on the public mux without Antfly authentication, exposing privileged tools (create_table, drop_table, query, backup, restore, batch) to unauthenticated clients when `EnableAuth` is enabled.

### Description
- Wrap the MCP handler with the existing authentication middleware by applying `r.node.authnMiddleware` to the `mcpHandler` before mounting it at `/mcp/v1/` in `src/metadata/runtime.go`, ensuring MCP requests go through the same auth gate as other public APIs.

### Testing
- Attempted to run `go test ./src/metadata -run TestRunner -count=1` (and a `timeout 60` variant), but automated tests could not complete in this environment due to local dependency/runtime constraints, so no tests were executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d1bf28c648321b4c84ac7fefede76)