### PR TITLE
Harden A2A and internal retrieval routes with admin-only requirement

### DIFF
--- a/zig/pkg/antfly/src/api/http_server.zig
+++ b/zig/pkg/antfly/src/api/http_server.zig
@@ -5425,6 +5425,7 @@ fn unauthorizedResponse(alloc: std.mem.Allocator) !http_common.HttpResponse {
 pub fn requiresAdminPermission(path: []const u8) bool {
     if (std.mem.eql(u8, path, routes.Routes.secrets) or std.mem.startsWith(u8, path, routes.Routes.secrets_prefix)) return true;
     if (std.mem.eql(u8, path, routes.Routes.backup) or std.mem.eql(u8, path, routes.Routes.restore) or std.mem.eql(u8, path, routes.Routes.backups)) return true;
+    if (std.mem.eql(u8, path, routes.Routes.a2a) or std.mem.eql(u8, path, routes.Routes.agents_retrieval)) return true;
     if (std.mem.eql(u8, path, routes.Routes.users_me)) return false;
     if (std.mem.eql(u8, path, routes.Routes.auth_subjects) or std.mem.startsWith(u8, path, routes.Routes.auth_subjects_prefix)) return true;
     return std.mem.eql(u8, path, routes.Routes.users) or std.mem.startsWith(u8, path, routes.Routes.users_prefix);


### PR DESCRIPTION
### Motivation
- Prevent low-privileged authenticated principals from reaching A2A/retrieval code paths that can read table data without RBAC or row-filter enforcement.

### Description
- Mark `/a2a` and `/agents/retrieval` as admin-only by adding them to `requiresAdminPermission` in `zig/pkg/antfly/src/api/http_server.zig`, ensuring the existing auth gate enforces an admin permission check before those routes are dispatched.
- This is a minimal change that reuses the existing authorization flow and does not alter retrieval runtime logic or table read APIs.

### Testing
- Attempted to run Zig-based tests but the Zig toolchain is not available in this environment (`zig: command not found`), so automated runtime tests could not be executed and therefore failed to run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ceac8c1a08321bc1e9d47c30abe6c)