### PR TITLE
Fix remote content credential resolution for non-S3 URLs

### DIFF
--- a/lib/template/remotehelpers.go
+++ b/lib/template/remotehelpers.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"net/url"
 	"strings"
 	"time"
 
@@ -39,10 +40,15 @@ func errorToDirective(err error) raymond.SafeString {
 
 // resolveCredentials resolves S3 credentials and security config for a URL,
 // falling back to defaults on error.
-func resolveCredentials(url, credentials string) (*scraping.S3Credentials, *scraping.ContentSecurityConfig) {
-	s3Creds, securityConfig, err := scraping.ResolveS3Credentials(url, credentials)
+func resolveCredentials(rawURL, credentials string) (*scraping.S3Credentials, *scraping.ContentSecurityConfig) {
+	parsed, err := url.Parse(rawURL)
+	if err != nil || !strings.EqualFold(parsed.Scheme, "s3") {
+		return nil, scraping.GetEffectiveSecurity()
+	}
+
+	s3Creds, securityConfig, err := scraping.ResolveS3Credentials(rawURL, credentials)
 	if err != nil {
-		log.Printf("credential resolution failed for %s: %v", url, err)
+		log.Printf("S3 credential resolution failed for %s: %v", rawURL, err)
 		s3Creds = scraping.GetDefaultS3Credentials()
 		securityConfig = scraping.GetDefaultSecurityConfig()
 	}

--- a/lib/template/remotehelpers_test.go
+++ b/lib/template/remotehelpers_test.go
@@ -15,9 +15,11 @@
 package template
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"fmt"
+	"log"
 	"os"
 	"strings"
 	"testing"
@@ -145,4 +147,39 @@ func TestErrorToDirective(t *testing.T) {
 		assert.Equal(t, 0, directives[0].Status)
 		assert.Equal(t, "connection refused", directives[0].Message)
 	})
+}
+
+func TestResolveCredentialsDoesNotResolveS3ForHTTPURL(t *testing.T) {
+	scraping.SetDefaultS3Credentials(nil)
+	scraping.SetDefaultSecurityConfig(nil)
+	scraping.InitRemoteContentConfig(&scraping.RemoteContentConfig{
+		S3: map[string]scraping.S3CredentialConfig{
+			"github": {
+				Endpoint:        "s3.amazonaws.com",
+				AccessKeyId:     "github-key",
+				SecretAccessKey: "github-secret",
+				Buckets:         []string{"antflydb"},
+			},
+		},
+		DefaultS3: "github",
+	})
+	defer scraping.InitRemoteContentConfig(nil)
+
+	var logs bytes.Buffer
+	oldWriter := log.Writer()
+	oldFlags := log.Flags()
+	oldPrefix := log.Prefix()
+	log.SetOutput(&logs)
+	log.SetFlags(0)
+	log.SetPrefix("")
+	defer func() {
+		log.SetOutput(oldWriter)
+		log.SetFlags(oldFlags)
+		log.SetPrefix(oldPrefix)
+	}()
+
+	s3Creds, securityConfig := resolveCredentials("https://raw.githubusercontent.com/antflydb/antfly/HEAD/README.md", "")
+	require.Nil(t, s3Creds)
+	require.NotNil(t, securityConfig)
+	require.NotContains(t, logs.String(), "credential resolution failed")
 }

--- a/zig/pkg/antfly/src/template_remote.zig
+++ b/zig/pkg/antfly/src/template_remote.zig
@@ -312,7 +312,7 @@ fn resolveRemoteContentFetchOptions(
 ) !ResolvedRemoteContentFetchOptions {
     const cfg = remote_content orelse return .{};
     const parsed = std.Uri.parse(url) catch return .{ .security = if (cfg.security) |*security| security else null };
-    if (std.mem.eql(u8, parsed.scheme, "s3")) {
+    if (isUriScheme(parsed, "s3")) {
         const credential = selectS3Credential(cfg, parsed, credential_name);
         return .{
             .security = if (credential) |creds|
@@ -321,7 +321,7 @@ fn resolveRemoteContentFetchOptions(
             .s3_credentials = if (credential) |creds| try resolveS3Credential(alloc, secret_store, creds) else null,
         };
     }
-    if (std.mem.eql(u8, parsed.scheme, "http") or std.mem.eql(u8, parsed.scheme, "https")) {
+    if (isUriScheme(parsed, "http") or isUriScheme(parsed, "https")) {
         const credential = selectHttpCredential(cfg, url, credential_name);
         return .{
             .security = if (credential) |creds|
@@ -331,6 +331,10 @@ fn resolveRemoteContentFetchOptions(
         };
     }
     return .{ .security = if (cfg.security) |*security| security else null };
+}
+
+fn isUriScheme(parsed: std.Uri, scheme: []const u8) bool {
+    return std.ascii.eqlIgnoreCase(parsed.scheme, scheme);
 }
 
 fn selectS3Credential(
@@ -416,6 +420,42 @@ fn bucketPatternMatches(pattern: []const u8, bucket: []const u8) bool {
     const prefix = pattern[0..star];
     const suffix = pattern[star + 1 ..];
     return std.mem.startsWith(u8, bucket, prefix) and std.mem.endsWith(u8, bucket, suffix);
+}
+
+test "template remote does not apply s3 credentials to http urls" {
+    const alloc = std.testing.allocator;
+
+    var cfg = scraping.RemoteContentConfig{};
+    defer cfg.deinit(alloc);
+    cfg.default_s3 = try alloc.dupe(u8, "primary");
+
+    {
+        const key = try alloc.dupe(u8, "primary");
+        errdefer alloc.free(key);
+        const endpoint = try alloc.dupe(u8, "s3.amazonaws.com");
+        errdefer alloc.free(endpoint);
+        const access_key_id = try alloc.dupe(u8, "primary-key");
+        errdefer alloc.free(access_key_id);
+        const secret_access_key = try alloc.dupe(u8, "primary-secret");
+        errdefer alloc.free(secret_access_key);
+
+        try cfg.s3.put(alloc, key, .{
+            .endpoint = endpoint,
+            .access_key_id = access_key_id,
+            .secret_access_key = secret_access_key,
+        });
+    }
+
+    var resolved = try resolveRemoteContentFetchOptions(
+        alloc,
+        &cfg,
+        null,
+        "https://raw.githubusercontent.com/antflydb/antfly/HEAD/README.md",
+        null,
+    );
+    defer resolved.deinit(alloc);
+
+    try std.testing.expect(resolved.s3_credentials == null);
 }
 
 test "template remote renders remotePDF extract with injected pdf backend" {

--- a/zig/pkg/antfly/src/template_test_root.zig
+++ b/zig/pkg/antfly/src/template_test_root.zig
@@ -13,7 +13,9 @@
 // limitations.
 
 pub const template = @import("template.zig");
+pub const template_remote = @import("template_remote.zig");
 
 test {
     _ = template;
+    _ = template_remote;
 }


### PR DESCRIPTION
## Summary
- avoid S3 credential resolution for non-S3 remote helper URLs in Go
- keep Zig remote content fetch option resolution scoped by URL scheme
- include regression coverage for HTTP(S) URLs with S3 defaults configured

Fixes #66

## Tests
- `env GOWORK=off GOCACHE=/tmp/antfly-issue-66-go-build-cache go test -count=1 ./lib/template`
- `zig build lib-template-test`