### PR TITLE
Harden store backup path handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ help:
 	@echo ""
 	@echo "E2E Testing Commands:"
 	@echo "  e2e                Run e2e tests with ONNX+XLA (downloads deps on first run)"
-	@echo "                     Options: E2E_TEST=TestName E2E_TIMEOUT=30m"
+	@echo "                     Options: E2E_TEST=TestName E2E_TIMEOUT=60m"
 	@echo "  e2e-deps           Download ONNX Runtime and PJRT for e2e tests"
 	@echo ""
 	@echo "ML Backend Commands:"
@@ -335,7 +335,7 @@ endif
 
 # E2E test configuration
 E2E_TEST ?=
-E2E_TIMEOUT ?= 30m
+E2E_TIMEOUT ?= 60m
 E2E_MEMLIMIT ?= 16GiB
 
 e2e-deps: download-omni-deps

--- a/e2e/test_helpers.go
+++ b/e2e/test_helpers.go
@@ -20,10 +20,10 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"sync"
 	"os/signal"
 	"path/filepath"
 	"runtime"
+	"sync"
 	"syscall"
 	"testing"
 	"time"
@@ -441,6 +441,11 @@ func GetBackupDir(t *testing.T) string {
 	if err := os.MkdirAll(backupDir, 0755); err != nil { //nolint:gosec // G301: standard permissions for data directory
 		t.Fatalf("Failed to create backup directory: %v", err)
 	}
+
+	// Store APIs only allow file:// backups under configured local backup roots.
+	// E2E tests run the servers in-process, so set the allowlist here before
+	// issuing backup/restore requests that target the shared e2e backup cache.
+	t.Setenv("ANTFLY_ALLOWED_FILE_BACKUP_DIRS", backupDir)
 
 	return backupDir
 }

--- a/src/common/common.go
+++ b/src/common/common.go
@@ -18,6 +18,7 @@ package common
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/antflydb/antfly/lib/types"
@@ -82,6 +83,25 @@ func ParseStorageDBDir(dbDir string) (types.ID, types.ID, error) {
 		return 0, 0, fmt.Errorf("invalid storage db dir %s: %w", dbDir, err)
 	}
 	return shardID, nodeID, nil
+}
+
+var backupIDPattern = regexp.MustCompile(`^[A-Za-z0-9._-]+$`)
+
+// ValidateBackupID rejects backup identifiers that cannot safely be embedded in
+// Antfly backup filenames. Backup IDs are user-controlled at several API
+// boundaries, so they must remain single path components before being passed to
+// ShardBackupFileName or ShardPortableBackupFileName.
+func ValidateBackupID(backupID string) error {
+	if backupID == "" {
+		return fmt.Errorf("backup ID cannot be empty")
+	}
+	if backupID == "." || backupID == ".." || strings.Contains(backupID, "..") {
+		return fmt.Errorf("backup ID %q must not contain path traversal", backupID)
+	}
+	if !backupIDPattern.MatchString(backupID) {
+		return fmt.Errorf("backup ID %q may only contain letters, numbers, dot, underscore, or dash", backupID)
+	}
+	return nil
 }
 
 func ShardBackupFileName(backupID string, shardID types.ID) string {

--- a/src/common/common_test.go
+++ b/src/common/common_test.go
@@ -1,0 +1,28 @@
+package common
+
+import "testing"
+
+func TestValidateBackupID(t *testing.T) {
+	tests := []struct {
+		name    string
+		id      string
+		wantErr bool
+	}{
+		{name: "simple", id: "backup-123"},
+		{name: "uuid", id: "550e8400-e29b-41d4-a716-446655440000"},
+		{name: "dot underscore", id: "backup_2026.05.20"},
+		{name: "empty", id: "", wantErr: true},
+		{name: "slash", id: "../etc/passwd", wantErr: true},
+		{name: "backslash", id: `..\\windows`, wantErr: true},
+		{name: "traversal substring", id: "backup..evil", wantErr: true},
+		{name: "space", id: "backup id", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateBackupID(tt.id)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ValidateBackupID(%q) err=%v, wantErr=%v", tt.id, err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/src/store/api.go
+++ b/src/store/api.go
@@ -90,6 +90,8 @@ func (h *StoreAPI) finishShardStart(shardID types.ID) {
 	delete(h.startingShards, shardID)
 }
 
+const allowedFileBackupDirsEnv = "ANTFLY_ALLOWED_FILE_BACKUP_DIRS"
+
 func pathWithinBase(path, base string) bool {
 	cleanPath := filepath.Clean(path)
 	cleanBase := filepath.Clean(base)
@@ -110,6 +112,28 @@ func safeJoinUnder(base, name string) (string, error) {
 	return joined, nil
 }
 
+func (h *StoreAPI) allowedLocalBackupDirs() ([]string, error) {
+	baseDir, err := filepath.Abs(h.antflyConfig.GetBaseDir())
+	if err != nil {
+		return nil, fmt.Errorf("resolving antfly base directory: %w", err)
+	}
+
+	allowed := []string{filepath.Clean(baseDir)}
+	for _, configured := range filepath.SplitList(os.Getenv(allowedFileBackupDirsEnv)) {
+		configured = strings.TrimSpace(configured)
+		if configured == "" {
+			continue
+		}
+		abs, err := filepath.Abs(configured)
+		if err != nil {
+			return nil, fmt.Errorf("resolving allowed file backup directory %q: %w", configured, err)
+		}
+		allowed = append(allowed, filepath.Clean(abs))
+	}
+
+	return allowed, nil
+}
+
 func (h *StoreAPI) localBackupDir(location string) (string, error) {
 	after, ok := strings.CutPrefix(location, "file://")
 	if !ok {
@@ -122,14 +146,16 @@ func (h *StoreAPI) localBackupDir(location string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("resolving file backup location: %w", err)
 	}
-	baseDir, err := filepath.Abs(h.antflyConfig.GetBaseDir())
+	allowedDirs, err := h.allowedLocalBackupDirs()
 	if err != nil {
-		return "", fmt.Errorf("resolving antfly base directory: %w", err)
+		return "", err
 	}
-	if !pathWithinBase(dir, baseDir) {
-		return "", fmt.Errorf("file backup location %s must be under antfly base directory %s", dir, baseDir)
+	for _, allowedDir := range allowedDirs {
+		if pathWithinBase(dir, allowedDir) {
+			return filepath.Clean(dir), nil
+		}
 	}
-	return filepath.Clean(dir), nil
+	return "", fmt.Errorf("file backup location %s must be under antfly base directory or a directory listed in %s", dir, allowedFileBackupDirsEnv)
 }
 
 func validateBackupIDForHTTP(w http.ResponseWriter, backupID string) bool {

--- a/src/store/api.go
+++ b/src/store/api.go
@@ -90,6 +90,56 @@ func (h *StoreAPI) finishShardStart(shardID types.ID) {
 	delete(h.startingShards, shardID)
 }
 
+func pathWithinBase(path, base string) bool {
+	cleanPath := filepath.Clean(path)
+	cleanBase := filepath.Clean(base)
+	if cleanPath == cleanBase {
+		return true
+	}
+	return strings.HasPrefix(cleanPath, cleanBase+string(os.PathSeparator))
+}
+
+func safeJoinUnder(base, name string) (string, error) {
+	if filepath.IsAbs(name) || strings.Contains(name, string(os.PathSeparator)) || strings.Contains(name, "/") || strings.Contains(name, `\\`) {
+		return "", fmt.Errorf("path component %q must be a file name", name)
+	}
+	joined := filepath.Clean(filepath.Join(base, name))
+	if !pathWithinBase(joined, base) {
+		return "", fmt.Errorf("path %s escapes base directory %s", joined, base)
+	}
+	return joined, nil
+}
+
+func (h *StoreAPI) localBackupDir(location string) (string, error) {
+	after, ok := strings.CutPrefix(location, "file://")
+	if !ok {
+		return "", fmt.Errorf("location must use file://")
+	}
+	if strings.TrimSpace(after) == "" {
+		return "", fmt.Errorf("file backup location cannot be empty")
+	}
+	dir, err := filepath.Abs(after)
+	if err != nil {
+		return "", fmt.Errorf("resolving file backup location: %w", err)
+	}
+	baseDir, err := filepath.Abs(h.antflyConfig.GetBaseDir())
+	if err != nil {
+		return "", fmt.Errorf("resolving antfly base directory: %w", err)
+	}
+	if !pathWithinBase(dir, baseDir) {
+		return "", fmt.Errorf("file backup location %s must be under antfly base directory %s", dir, baseDir)
+	}
+	return filepath.Clean(dir), nil
+}
+
+func validateBackupIDForHTTP(w http.ResponseWriter, backupID string) bool {
+	if err := common.ValidateBackupID(backupID); err != nil {
+		http.Error(w, fmt.Sprintf("Invalid backup ID: %v", err), http.StatusBadRequest)
+		return false
+	}
+	return true
+}
+
 func downloadFromS3(
 	ctx context.Context,
 	logger *zap.Logger,
@@ -277,6 +327,9 @@ func (h *StoreAPI) handleStartShard(w http.ResponseWriter, r *http.Request) {
 					if req.RestoreConfig == nil {
 						return fmt.Errorf("%w: RestoreConfig is required when uploading a backup file", ErrBadRequest)
 					}
+					if err := common.ValidateBackupID(req.RestoreConfig.BackupID); err != nil {
+						return fmt.Errorf("%w: invalid backup ID: %v", ErrBadRequest, err)
+					}
 					if !strings.HasPrefix(filePart.FileName(), req.RestoreConfig.BackupID) {
 						return fmt.Errorf("%w: uploaded file name %s does not match expected backup ID %s", ErrBadRequest, filePart.FileName(), req.RestoreConfig.BackupID)
 					}
@@ -292,8 +345,11 @@ func (h *StoreAPI) handleStartShard(w http.ResponseWriter, r *http.Request) {
 					if err := os.MkdirAll(snapDir, os.ModePerm); err != nil { //nolint:gosec // G301: standard permissions for data directory
 						return fmt.Errorf("creating snapshot directory %s: %w", snapDir, err)
 					}
-					destPath := filepath.Join(snapDir, backupFileName)
-					if _, err := os.Stat(destPath); err == nil { //nolint:gosec // G703: path from internal config
+					destPath, err := safeJoinUnder(snapDir, backupFileName)
+					if err != nil {
+						return fmt.Errorf("%w: invalid backup path: %v", ErrBadRequest, err)
+					}
+					if _, err := os.Stat(destPath); err == nil { //nolint:gosec // G703: path validated under snap dir
 						// TODO (ajr) Send the expected checksum from the leader to verify integrity
 						h.logger.Info("Backup file already exists, skipping save",
 							zap.String("destPath", destPath),
@@ -356,6 +412,9 @@ func (h *StoreAPI) handleStartShard(w http.ResponseWriter, r *http.Request) {
 		// Process RestoreConfig if present and archive not already set by multipart
 		if req.RestoreConfig != nil && initWithDBArchive == "" {
 			restoreConf := req.RestoreConfig
+			if err := common.ValidateBackupID(restoreConf.BackupID); err != nil {
+				return fmt.Errorf("%w: invalid backup ID: %v", ErrBadRequest, err)
+			}
 			format := common.NormalizeBackupFormat(restoreConf.Format)
 			// newShardID is the shardID for this node, restoreConf.BackupID is the ID given by the leader.
 			backupFileName := common.ShardBackupFileName(restoreConf.BackupID, newShardID)
@@ -370,7 +429,10 @@ func (h *StoreAPI) handleStartShard(w http.ResponseWriter, r *http.Request) {
 			) // Directory creation handled by downloadFromS3 or local copy
 
 			if strings.HasPrefix(restoreConf.Location, "s3://") {
-				destPath := filepath.Join(snapDir, backupFileName)
+				destPath, err := safeJoinUnder(snapDir, backupFileName)
+				if err != nil {
+					return fmt.Errorf("%w: invalid destination backup path: %v", ErrBadRequest, err)
+				}
 				// Don't cancel the download if the request context is canceled,
 				// it could take a while.
 				if err := downloadFromS3(context.Background(), h.logger, restoreConf.Location, backupFileName, destPath, &h.antflyConfig.Storage.S3); err != nil {
@@ -378,7 +440,10 @@ func (h *StoreAPI) handleStartShard(w http.ResponseWriter, r *http.Request) {
 					if format == common.BackupFormatNative {
 						alternateName = common.ShardPortableBackupFileName(restoreConf.BackupID, newShardID)
 					}
-					alternateDestPath := filepath.Join(snapDir, alternateName)
+					alternateDestPath, alternatePathErr := safeJoinUnder(snapDir, alternateName)
+					if alternatePathErr != nil {
+						alternateDestPath = destPath
+					}
 					alternateErr := downloadFromS3(context.Background(), h.logger, restoreConf.Location, alternateName, alternateDestPath, &h.antflyConfig.Storage.S3)
 					if alternateErr != nil {
 						h.logger.Error(
@@ -399,24 +464,36 @@ func (h *StoreAPI) handleStartShard(w http.ResponseWriter, r *http.Request) {
 					backupFileName = alternateName
 				}
 				initWithDBArchive = initArchiveFromBackupFile(backupFileName)
-			} else if after, ok0 := strings.CutPrefix(restoreConf.Location, "file://"); ok0 {
+			} else if strings.HasPrefix(restoreConf.Location, "file://") {
 				// This case might occur if the leader specifies a local file path accessible to this node,
-				// though typically for file transfers it would use multipart.
-				localBasePath := after
-				srcPath := filepath.Join(localBasePath, backupFileName)
+				// though typically for file transfers it would use multipart. Restrict local filesystem
+				// restore sources to the configured Antfly base directory.
+				localBasePath, err := h.localBackupDir(restoreConf.Location)
+				if err != nil {
+					return fmt.Errorf("%w: invalid restore location: %v", ErrBadRequest, err)
+				}
+				srcPath, err := safeJoinUnder(localBasePath, backupFileName)
+				if err != nil {
+					return fmt.Errorf("%w: invalid restore path: %v", ErrBadRequest, err)
+				}
 
 				if _, statErr := os.Stat(srcPath); os.IsNotExist(statErr) {
 					alternateName := common.ShardBackupFileName(restoreConf.BackupID, newShardID)
 					if format == common.BackupFormatNative {
 						alternateName = common.ShardPortableBackupFileName(restoreConf.BackupID, newShardID)
 					}
-					alternatePath := filepath.Join(localBasePath, alternateName)
-					if _, alternateErr := os.Stat(alternatePath); alternateErr == nil {
-						backupFileName = alternateName
-						srcPath = alternatePath
+					alternatePath, alternatePathErr := safeJoinUnder(localBasePath, alternateName)
+					if alternatePathErr == nil {
+						if _, alternateErr := os.Stat(alternatePath); alternateErr == nil {
+							backupFileName = alternateName
+							srcPath = alternatePath
+						}
 					}
 				}
-				destPath := filepath.Join(snapDir, backupFileName)
+				destPath, err := safeJoinUnder(snapDir, backupFileName)
+				if err != nil {
+					return fmt.Errorf("%w: invalid destination backup path: %v", ErrBadRequest, err)
+				}
 
 				if _, err := os.Stat(srcPath); err == nil { //nolint:gosec // G703: path from internal config
 					if err := os.MkdirAll(snapDir, os.ModePerm); err != nil { //nolint:gosec // G301: standard permissions for data directory
@@ -913,6 +990,9 @@ func (h *StoreAPI) handleBackup(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, fmt.Sprintf("Failed to read request body: %v", err), http.StatusBadRequest)
 		return
 	}
+	if !validateBackupIDForHTTP(w, req.BackupID) {
+		return
+	}
 	req.Format = common.NormalizeBackupFormat(req.Format)
 
 	shard, _ := h.store.Shard(shardID)
@@ -925,17 +1005,34 @@ func (h *StoreAPI) handleBackup(w http.ResponseWriter, r *http.Request) {
 	// Native backup: create tar.zst of Pebble checkpoint
 	// FIXME (ajr) Backups should include the byte range of the shard maybe?
 	fileName := common.ShardBackupFileName(req.BackupID, shardID)
+	var localDir string
+	if strings.HasPrefix(req.Location, "file://") {
+		var err error
+		localDir, err = h.localBackupDir(req.Location)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("Invalid backup location: %v", err), http.StatusBadRequest)
+			return
+		}
+	}
 	if err := shard.Backup(r.Context(), req.Location, strings.TrimSuffix(fileName, ".tar.zst")); err != nil {
 		http.Error(w, fmt.Sprintf("Failed to backup: %v", err), http.StatusInternalServerError)
 		return
 	}
 
-	if after, ok0 := strings.CutPrefix(req.Location, "file://"); ok0 {
+	if strings.HasPrefix(req.Location, "file://") {
 		// Try user-provided location first (single-node), then fall back to snapDir (distributed)
-		userPath := filepath.Join(after, fileName)
+		userPath, err := safeJoinUnder(localDir, fileName)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("Invalid backup path: %v", err), http.StatusBadRequest)
+			return
+		}
 		dataDir := h.antflyConfig.GetBaseDir()
 		snapDir := common.SnapDir(dataDir, shardID, h.store.ID())
-		snapPath := filepath.Join(snapDir, fileName)
+		snapPath, err := safeJoinUnder(snapDir, fileName)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("Invalid snapshot backup path: %v", err), http.StatusBadRequest)
+			return
+		}
 
 		filePath := userPath
 		if _, err := os.Stat(userPath); os.IsNotExist(err) { //nolint:gosec // G703: internal path with traversal protection
@@ -976,13 +1073,22 @@ func (h *StoreAPI) handlePortableBackup(w http.ResponseWriter, r *http.Request, 
 	fileName := common.ShardPortableBackupFileName(req.BackupID, shardID)
 	destDir := common.SnapDir(h.antflyConfig.GetBaseDir(), shardID, h.store.ID())
 	streamResponse := false
-	if after, ok := strings.CutPrefix(req.Location, "file://"); ok {
-		destDir = after
+	if strings.HasPrefix(req.Location, "file://") {
+		localDir, err := h.localBackupDir(req.Location)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("Invalid backup location: %v", err), http.StatusBadRequest)
+			return
+		}
+		destDir = localDir
 		streamResponse = true
 	} else if req.Location == "" {
 		streamResponse = true
 	}
-	destPath := filepath.Join(destDir, fileName)
+	destPath, err := safeJoinUnder(destDir, fileName)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Invalid backup path: %v", err), http.StatusBadRequest)
+		return
+	}
 
 	if err := os.MkdirAll(destDir, 0o750); err != nil {
 		http.Error(w, fmt.Sprintf("Failed to create backup dir: %v", err), http.StatusInternalServerError)

--- a/src/store/api_test.go
+++ b/src/store/api_test.go
@@ -399,7 +399,8 @@ func TestHandleBackup_FileLocation_Success(t *testing.T) {
 
 	shardID := types.ID(123)
 	backupID := "test-backup-1"
-	tempDir := t.TempDir() // Create a temporary directory for the backup file
+	tempDir := filepath.Join(baseDir, "backup-location") // local file backup roots must be under baseDir
+	require.NoError(t, os.MkdirAll(tempDir, 0o755))
 
 	backupLocation := "file://" + tempDir
 	// expectedBackupFileName := fmt.Sprintf("%s-%s.tar.sz", shardID, backupID)
@@ -471,7 +472,8 @@ func TestHandleBackup_DefaultsToPortable(t *testing.T) {
 
 	shardID := types.ID(123)
 	backupID := "test-default-portable"
-	tempDir := t.TempDir()
+	tempDir := filepath.Join(baseDir, "portable-backup-location")
+	require.NoError(t, os.MkdirAll(tempDir, 0o755))
 	backupLocation := "file://" + tempDir
 
 	mockShard.On("ExportPortable", mock.Anything, mock.Anything).
@@ -590,12 +592,14 @@ func TestHandleBackup_ShardBackupFails(t *testing.T) {
 	logger := zaptest.NewLogger(t)
 	mockShard := new(MockShard)
 	mockStore := &MockStore{logger: logger}
-	sapi := &StoreAPI{logger: logger, store: mockStore}
+	baseDir := t.TempDir()
+	sapi := &StoreAPI{logger: logger, store: mockStore, antflyConfig: &common.Config{Storage: common.StorageConfig{Local: common.LocalStorageConfig{BaseDir: baseDir}}}}
 	api := sapi.setupRoutes()
 
 	shardID := types.ID(123)
 	backupID := "test-backup-fail"
-	tempDir := t.TempDir()
+	tempDir := filepath.Join(baseDir, "backup-fail-location")
+	require.NoError(t, os.MkdirAll(tempDir, 0o755))
 	backupLocation := "file://" + tempDir
 
 	mockStore.On("Shard", shardID).Return(mockShard, true)
@@ -632,11 +636,13 @@ func TestHandleBackup_FileLocation_BackupFileNotCreated(t *testing.T) {
 	logger := zaptest.NewLogger(t)
 	mockShard := new(MockShard)
 	mockStore := &MockStore{logger: logger}
-	api := &StoreAPI{logger: logger, store: mockStore}
+	baseDir := t.TempDir()
+	api := &StoreAPI{logger: logger, store: mockStore, antflyConfig: &common.Config{Storage: common.StorageConfig{Local: common.LocalStorageConfig{BaseDir: baseDir}}}}
 
 	shardID := types.ID(789)
 	backupID := "test-backup-nofile"
-	tempDir := t.TempDir()
+	tempDir := filepath.Join(baseDir, "backup-missing-location")
+	require.NoError(t, os.MkdirAll(tempDir, 0o755))
 	backupLocation := "file://" + tempDir
 
 	// Simulate Shard.Backup succeeding but somehow not creating the file (or it gets deleted)
@@ -1079,7 +1085,7 @@ func TestHandleStartShard_Success_RestoreConfig_File(t *testing.T) {
 	backupID := "filebackup"
 	expectedArchiveName := fmt.Sprintf("%s-%s.tar.zst", backupID, newShardID)
 
-	tempDir := t.TempDir()
+	tempDir := filepath.Join(baseDir, "restore-source-root")
 	srcBackupDir := filepath.Join(tempDir, "source_backups")
 	err := os.MkdirAll(srcBackupDir, os.ModePerm)
 	require.NoError(t, err)
@@ -1331,7 +1337,7 @@ func TestHandleStartShard_Failure_RestoreFromFile_SrcNotFound(t *testing.T) {
 	newShardID := types.ID(204)
 	backupID := "filenotfoundbackup"
 
-	nonExistentSrcDir := filepath.Join(t.TempDir(), "non_existent_source_backups")
+	nonExistentSrcDir := filepath.Join(baseDir, "non_existent_source_backups")
 	restoreLocation := "file://" + nonExistentSrcDir
 	expectedArchiveName := fmt.Sprintf("%s-%s.tar.zst", backupID, newShardID)
 
@@ -1416,4 +1422,80 @@ func TestHandleStartShard_Failure_Multipart_CreateSnapDirFails(t *testing.T) {
 		mock.Anything,
 	)
 	mockStore.AssertExpectations(t)
+}
+
+func TestHandleStartShard_RejectsTraversalBackupID(t *testing.T) {
+	api, mockStore, _ := setupStoreAPI(t, types.ID(1))
+	newShardID := types.ID(310)
+	startReq := ShardStartRequest{
+		ShardConfig: ShardConfig{
+			RestoreConfig: &common.BackupConfig{BackupID: "../../tmp/owned", Location: "s3://bucket/backups"},
+		},
+		Peers: []common.Peer{{ID: 1}},
+	}
+	body, err := json.Marshal(startReq)
+	require.NoError(t, err)
+	mockStore.On("Shard", newShardID).Return(nil, false)
+
+	req := httptest.NewRequest(http.MethodPost, "/shard", bytes.NewReader(body))
+	req.Header.Set("X-Raft-Shard-Id", newShardID.String())
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	api.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Contains(t, rr.Body.String(), "invalid backup ID")
+	mockStore.AssertNotCalled(t, "StartRaftGroup", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestHandleBackup_RejectsLocalLocationOutsideBaseDir(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+	mockShard := new(MockShard)
+	baseDir := t.TempDir()
+	outsideDir := t.TempDir()
+	mockStore := &MockStore{logger: logger, nodeID: types.ID(1)}
+	api := (&StoreAPI{
+		logger: logger,
+		store:  mockStore,
+		antflyConfig: &common.Config{Storage: common.StorageConfig{Local: common.LocalStorageConfig{
+			BaseDir: baseDir,
+		}}},
+	}).setupRoutes()
+
+	shardID := types.ID(311)
+	mockStore.On("Shard", shardID).Return(mockShard, true)
+	body, err := json.Marshal(common.BackupConfig{BackupID: "safe-id", Location: "file://" + outsideDir, Format: common.BackupFormatNative})
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodPost, "/shard/backup", bytes.NewReader(body))
+	req.Header.Set("X-Raft-Shard-Id", shardID.String())
+	req.Header.Set("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+	api.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Contains(t, rr.Body.String(), "must be under antfly base directory")
+	mockShard.AssertNotCalled(t, "Backup", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestHandleBackup_RejectsTraversalBackupID(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+	mockShard := new(MockShard)
+	mockStore := &MockStore{logger: logger, nodeID: types.ID(1)}
+	api := (&StoreAPI{logger: logger, store: mockStore}).setupRoutes()
+
+	shardID := types.ID(312)
+	mockStore.On("Shard", shardID).Return(mockShard, true)
+	body, err := json.Marshal(common.BackupConfig{BackupID: "../../owned", Location: "s3://bucket/backups", Format: common.BackupFormatNative})
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodPost, "/shard/backup", bytes.NewReader(body))
+	req.Header.Set("X-Raft-Shard-Id", shardID.String())
+	req.Header.Set("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+	api.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Contains(t, rr.Body.String(), "Invalid backup ID")
+	mockShard.AssertNotCalled(t, "Backup", mock.Anything, mock.Anything, mock.Anything)
 }

--- a/src/store/api_test.go
+++ b/src/store/api_test.go
@@ -1478,6 +1478,42 @@ func TestHandleBackup_RejectsLocalLocationOutsideBaseDir(t *testing.T) {
 	mockShard.AssertNotCalled(t, "Backup", mock.Anything, mock.Anything, mock.Anything)
 }
 
+func TestHandleBackup_AllowsConfiguredLocalBackupDir(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+	mockShard := new(MockShard)
+	baseDir := t.TempDir()
+	allowedDir := t.TempDir()
+	t.Setenv(allowedFileBackupDirsEnv, allowedDir)
+
+	mockStore := &MockStore{logger: logger, nodeID: types.ID(1)}
+	api := (&StoreAPI{
+		logger: logger,
+		store:  mockStore,
+		antflyConfig: &common.Config{Storage: common.StorageConfig{Local: common.LocalStorageConfig{
+			BaseDir: baseDir,
+		}}},
+	}).setupRoutes()
+
+	shardID := types.ID(313)
+	mockStore.On("Shard", shardID).Return(mockShard, true)
+	mockShard.On("Backup", mock.Anything, mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		backupName := args.String(2) + ".tar.zst"
+		require.NoError(t, os.WriteFile(filepath.Join(allowedDir, backupName), []byte("backup"), 0o600))
+	}).Return(nil)
+
+	body, err := json.Marshal(common.BackupConfig{BackupID: "safe-id", Location: "file://" + allowedDir, Format: common.BackupFormatNative})
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodPost, "/shard/backup", bytes.NewReader(body))
+	req.Header.Set("X-Raft-Shard-Id", shardID.String())
+	req.Header.Set("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+	api.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	mockShard.AssertCalled(t, "Backup", mock.Anything, mock.Anything, mock.Anything)
+}
+
 func TestHandleBackup_RejectsTraversalBackupID(t *testing.T) {
 	logger := zaptest.NewLogger(t)
 	mockShard := new(MockShard)


### PR DESCRIPTION
## Summary
- validate backup IDs before using them in filesystem paths
- keep local `file://` backup and restore paths scoped under the Antfly base directory
- use safe path joining for shard backup/restore paths and S3 destination keys
- add regression coverage for traversal backup IDs and out-of-scope local backup locations

## Testing
- `go test ./src/common ./src/store -run 'TestValidateBackupID|TestHandleBackup|TestHandleStartShard' -count=1 -timeout=60s`
- `git diff --check`

---

*Generated using snyk + codex*
