### PR TITLE
Fix SearchAF swarm query and health binding

### DIFF
--- a/zig/build.zig
+++ b/zig/build.zig
@@ -1030,20 +1030,12 @@ pub fn build(b: *std.Build) void {
     const termite_mlx_root = termite_mlx_root_opt orelse detected_termite_mlx_root;
     const termite_onnx_root_opt = b.option([]const u8, "onnx-root", "Path to ONNX Runtime root for embedded Termite");
     const termite_onnx_root = termite_onnx_root_opt orelse defaultTermiteOnnxRoot(b, target);
-    const termite_onnx_available = pathExists(b, b.fmt("{s}/include/onnxruntime_c_api.h", .{termite_onnx_root})) and
-        pathExists(b, b.fmt("{s}/lib", .{termite_onnx_root}));
-    const termite_mlx_available = if (termite_mlx_root) |root|
-        target.result.os.tag == .macos and
-            pathExists(b, b.fmt("{s}/include/mlx/c/mlx.h", .{root})) and
-            pathExists(b, b.fmt("{s}/lib/libmlxc.dylib", .{root}))
-    else
-        false;
     const termite_mlx_requested = if (link_libc)
-        b.option(bool, "mlx", "Enable MLX termite support when available") orelse termite_mlx_available
+        b.option(bool, "mlx", "Enable MLX termite support (default: false)") orelse false
     else
         false;
     const termite_enable_onnx = if (link_libc)
-        b.option(bool, "onnx", "Enable ONNX Runtime support for embedded Termite") orelse termite_onnx_available
+        b.option(bool, "onnx", "Enable ONNX Runtime support for embedded Termite (default: false)") orelse false
     else
         false;
     const termite_enable_metal = if (link_libc)

--- a/zig/pkg/antfly/src/api/httpx_handler.zig
+++ b/zig/pkg/antfly/src/api/httpx_handler.zig
@@ -57,6 +57,24 @@ const db_mod = @import("../storage/db/mod.zig");
 const metadata_openapi = @import("antfly_metadata_openapi");
 const usermgr_openapi = @import("antfly_usermgr_openapi");
 
+const ParsedGlobalQueryTable = struct {
+    parsed: std.json.Parsed(metadata_openapi.QueryRequest),
+    table_name: []const u8,
+
+    fn deinit(self: *@This()) void {
+        self.parsed.deinit();
+    }
+};
+
+fn parseGlobalQueryTable(alloc: std.mem.Allocator, body: []const u8) !ParsedGlobalQueryTable {
+    var parsed = metadata_openapi.server.parseGlobalQueryBody(alloc, body) catch return error.InvalidQueryRequest;
+    errdefer parsed.deinit();
+    return .{
+        .parsed = parsed,
+        .table_name = parsed.value.table orelse "",
+    };
+}
+
 pub const AntflyApiHandler = struct {
     api_server: *ApiHttpServer,
 
@@ -1052,8 +1070,13 @@ pub const AntflyApiHandler = struct {
             _ = ctx.status(400);
             return ctx.text("missing body");
         };
+        var parsed_table = parseGlobalQueryTable(ctx.allocator, body_data) catch {
+            _ = ctx.status(400);
+            return ctx.text("invalid query request");
+        };
+        defer parsed_table.deinit();
         var resp = try self.api_server.handlePublicTableQuery(
-            "",
+            parsed_table.table_name,
             body_data,
             authenticated_identity,
         );
@@ -2992,6 +3015,15 @@ test "httpx antfly schema update returns full table status after projection" {
     try std.testing.expectEqualStrings("docs", parsed.value.name);
     try std.testing.expect(parsed.value.schema != null);
     try std.testing.expectEqual(@as(u32, 1), source.projection_wait_calls.load(.monotonic));
+}
+
+test "httpx global query table name comes from request body" {
+    var parsed_table = try parseGlobalQueryTable(std.testing.allocator,
+        \\{"table":"files","limit":5}
+    );
+    defer parsed_table.deinit();
+
+    try std.testing.expectEqualStrings("files", parsed_table.table_name);
 }
 
 test "httpx antfly cluster restore preserves backup location validation" {

--- a/zig/pkg/antfly/src/common/health_server.zig
+++ b/zig/pkg/antfly/src/common/health_server.zig
@@ -150,8 +150,22 @@ pub const HealthServer = struct {
         ready: ?ReadinessChecker,
         metrics: ?MetricsWriter,
     ) !?*HealthServer {
+        return try startIfConfiguredOnHost(alloc, label, null, port, ready, metrics);
+    }
+
+    pub fn startIfConfiguredOnHost(
+        alloc: std.mem.Allocator,
+        label: []const u8,
+        bind_host: ?[]const u8,
+        port: ?u16,
+        ready: ?ReadinessChecker,
+        metrics: ?MetricsWriter,
+    ) !?*HealthServer {
         const p = port orelse return null;
-        const hs = try HealthServer.init(alloc, .{ .bind_port = p }, ready, metrics);
+        const hs = try HealthServer.init(alloc, .{
+            .bind_host = bind_host orelse "0.0.0.0",
+            .bind_port = p,
+        }, ready, metrics);
         errdefer hs.deinit();
         try hs.start();
         const uri = try hs.baseUri(alloc);
@@ -516,6 +530,14 @@ test "health server metrics request path does not refresh stale cache" {
 
     try testing.expectEqual(@as(u16, 200), resp.status);
     try testing.expectEqual(@as(usize, 1), fake.call_count);
+}
+
+test "health server startIfConfiguredOnHost uses provided bind host" {
+    const alloc = testing.allocator;
+    const hs = (try HealthServer.startIfConfiguredOnHost(alloc, "test", "127.0.0.1", 0, null, null)).?;
+    defer hs.deinit();
+
+    try testing.expectEqualStrings("127.0.0.1", hs.listener.cfg.bind_host);
 }
 
 test "health server unknown path returns 404" {

--- a/zig/pkg/antfly/src/swarm/runtime.zig
+++ b/zig/pkg/antfly/src/swarm/runtime.zig
@@ -699,9 +699,10 @@ pub fn runFromIterator(
         .data_server = &data_server,
     };
     const health_port = cli.health_port orelse if (loaded_config) |*cfg| cfg.health_port else null;
-    const health_server = antfly.common.health_server.HealthServer.startIfConfigured(
+    const health_server = antfly.common.health_server.HealthServer.startIfConfiguredOnHost(
         alloc,
         "swarm",
+        public_listener.bind_host,
         health_port,
         swarm_health.readiness(),
         swarm_health.metricsWriter(),
@@ -1308,7 +1309,7 @@ fn printUsage() void {
         \\  --host <host>                         Public API host (default: 127.0.0.1)
         \\  --port <port>                         Public API port (default: 0)
         \\  --id <node-id>                        Local node id (default: 1)
-        \\  --health-port <port>                  Dedicated health/metrics bind port (default: unset)
+        \\  --health-port <port>                  Dedicated health/metrics port on --host (default: unset)
         \\  --tick-ms <ms>                        Sleep interval while serving (default: 25)
         \\  --models-dir <path>                   Embedded termite models directory (default: ~/.termite/models)
         \\  --termite-host-budget-mb <n>          Embedded termite native generation host budget override

--- a/zig/pkg/termite/build.zig
+++ b/zig/pkg/termite/build.zig
@@ -172,16 +172,11 @@ pub fn build(b: *std.Build) void {
     const onnx_root_opt = b.option([]const u8, "onnx-root", "Path to ONNX Runtime root (default: ./onnxruntime/<platform>)");
     const default_onnx_root = defaultOnnxRuntimeRoot(b, target);
     const effective_onnx_root = onnx_root_opt orelse default_onnx_root;
-    const onnx_runtime_available = !enable_wasm and link_libc and
-        pathExists(b, b.fmt("{s}/include/onnxruntime_c_api.h", .{effective_onnx_root})) and
-        pathExists(b, b.fmt("{s}/lib", .{effective_onnx_root}));
-    const enable_onnx = if (enable_wasm or !link_libc) false else (b.option(bool, "onnx", "Enable ONNX Runtime backend") orelse onnx_runtime_available);
+    const enable_onnx = if (enable_wasm or !link_libc) false else (b.option(bool, "onnx", "Enable ONNX Runtime backend (default: false)") orelse false);
     const mlx_root_opt = b.option([]const u8, "mlx-root", "Path to MLX C root with lib/libmlxc.dylib");
     const default_mlx_root = defaultMlxRoot(b);
     const effective_mlx_root = mlx_root_opt orelse default_mlx_root;
-    const mlx_runtime_available = !enable_wasm and link_libc and target.result.os.tag == .macos and
-        if (effective_mlx_root) |root| pathExists(b, b.fmt("{s}/lib/libmlxc.dylib", .{root})) else false;
-    const mlx_requested = if (enable_wasm or !link_libc) false else (b.option(bool, "mlx", "Enable MLX backend (macOS only)") orelse mlx_runtime_available);
+    const mlx_requested = if (enable_wasm or !link_libc) false else (b.option(bool, "mlx", "Enable MLX backend (macOS only, default: false)") orelse false);
     // Metal kernels are independent of MLX, but MLX decoder paths currently
     // dispatch through Metal kernels. Disabling Metal therefore disables MLX.
     const enable_metal = if (enable_wasm or !link_libc) false else (b.option(bool, "metal", "Enable Apple Metal kernels (macOS only)") orelse (mlx_requested or target.result.os.tag == .macos));


### PR DESCRIPTION
## Summary
- Make `POST /api/v1/query` honor the request body `table` field before dispatching through public table query handling.
- Add a host-aware health server startup helper and use it for swarm health listeners so `--health-port` inherits the resolved swarm `--host`.
- Keep ONNX Runtime and MLX backends opt-in for default Antfly/Termite builds; use `-Donnx=true` or `-Dmlx=true` to link them explicitly.
- Update swarm help text for the health port binding behavior.

## Tests
- `zig build install-antfly`
- `otool -L zig-out/bin/antfly` (confirmed no `onnxruntime` or `libmlx` links in the default build)
- `zig build lib-common-test lib-swarm-runtime-test root-test`
- `git diff --check`