### PR TITLE
Jina v5 direct metal embeddings

### DIFF
--- a/zig/e2e/antfly/test_scaling.py
+++ b/zig/e2e/antfly/test_scaling.py
@@ -638,19 +638,29 @@ class MultiNodeScalingCluster:
     def create_table(self, table_name: str, *, num_shards: int) -> None:
         last_error: str | None = None
 
+        def table_created_in_metadata() -> bool:
+            try:
+                group_ids = _table_group_ids(self, table_name)
+            except (AssertionError, requests.RequestException, ValueError):
+                return False
+            return group_ids is not None and len(group_ids) >= num_shards
+
         def create_once() -> bool | None:
             nonlocal last_error
-            try:
-                response = requests.post(
-                    f"{self.data_api_urls[0]}/tables/{table_name}",
-                    json={"num_shards": num_shards},
-                    timeout=10,
-                )
-                if response.ok:
+            for api_url in self.live_data_api_urls or self.data_api_urls:
+                try:
+                    response = requests.post(
+                        f"{api_url}/tables/{table_name}",
+                        json={"num_shards": num_shards},
+                        timeout=10,
+                    )
+                    if response.ok:
+                        return True
+                    last_error = f"{response.status_code}: {response.text}"
+                except requests.RequestException as exc:
+                    last_error = repr(exc)
+                if table_created_in_metadata():
                     return True
-                last_error = f"{response.status_code}: {response.text}"
-            except requests.RequestException as exc:
-                last_error = repr(exc)
             return None
 
         created = wait_until(create_once, timeout_s=60.0, interval_s=0.5)
@@ -808,19 +818,70 @@ def _lookup_from_any_data_node(
     return None
 
 
-def _insert_docs(cluster: MultiNodeScalingCluster, table_name: str, docs: dict[str, dict[str, Any]]) -> None:
-    api_url = wait_until(lambda: _data_api_url_for_table(cluster, table_name), timeout_s=30.0, interval_s=0.5)
-    if api_url is None:
-        api_url = cluster.live_data_api_urls[0]
-    response = requests.post(
-        f"{api_url}/tables/{table_name}/batch",
-        json={"inserts": docs, "sync_level": "write"},
-        timeout=30,
+def _insert_docs(
+    cluster: MultiNodeScalingCluster,
+    table_name: str,
+    docs: dict[str, dict[str, Any]],
+    *,
+    min_group_count: int = 1,
+) -> None:
+    last_error: str | None = None
+
+    def route_ready() -> str | None:
+        try:
+            return _data_api_url_for_table(
+                cluster,
+                table_name,
+                require_all_group_leaders=True,
+                min_group_count=min_group_count,
+            )
+        except (AssertionError, requests.RequestException, ValueError):
+            return None
+
+    api_url = wait_until(route_ready, timeout_s=60.0, interval_s=0.5)
+    assert api_url is not None, (
+        f"table {table_name} never became write-routable before seed batch\n"
+        f"metadata statuses: {json.dumps(cluster.metadata_statuses(), indent=2, sort_keys=True)}\n"
+        f"snapshot: {cluster.metadata_snapshot()}\n"
+        f"{cluster.debug_logs()}"
     )
-    response.raise_for_status()
+
+    def post_once() -> bool | None:
+        nonlocal api_url, last_error
+        api_url = route_ready() or api_url
+        try:
+            response = requests.post(
+                f"{api_url}/tables/{table_name}/batch",
+                json={"inserts": docs, "sync_level": "write"},
+                timeout=30,
+            )
+        except requests.RequestException as exc:
+            last_error = repr(exc)
+            return None
+        if response.ok:
+            return True
+        last_error = f"{response.status_code}: {response.text}"
+        if response.status_code in {429, 500, 503}:
+            return None
+        response.raise_for_status()
+        return None
+
+    inserted = wait_until(post_once, timeout_s=90.0, interval_s=0.5)
+    assert inserted is True, (
+        f"failed to insert seed docs for {table_name}: {last_error}\n"
+        f"metadata statuses: {json.dumps(cluster.metadata_statuses(), indent=2, sort_keys=True)}\n"
+        f"snapshot: {cluster.metadata_snapshot()}\n"
+        f"{cluster.debug_logs()}"
+    )
 
 
-def _data_api_url_for_table(cluster: MultiNodeScalingCluster, table_name: str) -> str | None:
+def _data_api_url_for_table(
+    cluster: MultiNodeScalingCluster,
+    table_name: str,
+    *,
+    require_all_group_leaders: bool = False,
+    min_group_count: int = 1,
+) -> str | None:
     snapshot = cluster.metadata_snapshot()
     table_id: int | None = None
     for table in snapshot.get("tables", []):
@@ -829,20 +890,31 @@ def _data_api_url_for_table(cluster: MultiNodeScalingCluster, table_name: str) -
             break
     if table_id is None:
         return None
-    group_id: int | None = None
+    group_ids: list[int] = []
     for table_range in snapshot.get("ranges", []):
         if isinstance(table_range, dict) and int(table_range.get("table_id", 0)) == table_id:
-            group_id = int(table_range.get("group_id", 0))
-            break
-    if group_id is None:
+            group_ids.append(int(table_range.get("group_id", 0)))
+    if len(group_ids) < min_group_count:
         return None
-    leader_store_id: int | None = None
+    group_ids.sort()
+
+    leader_store_by_group: dict[int, int] = {}
     for status in snapshot.get("merged_group_statuses", []):
-        if isinstance(status, dict) and int(status.get("group_id", 0)) == group_id:
-            raw_leader = int(status.get("leader_store_id", 0))
-            if raw_leader != 0:
-                leader_store_id = raw_leader
-            break
+        if not isinstance(status, dict):
+            continue
+        group_id = int(status.get("group_id", 0))
+        if group_id not in group_ids:
+            continue
+        raw_leader = int(status.get("leader_store_id", 0))
+        if raw_leader != 0:
+            leader_store_by_group[group_id] = raw_leader
+    if require_all_group_leaders and any(group_id not in leader_store_by_group for group_id in group_ids):
+        return None
+
+    group_id = group_ids[0]
+    leader_store_id: int | None = None
+    if group_id in leader_store_by_group:
+        leader_store_id = leader_store_by_group[group_id]
     if leader_store_id is not None:
         for store in snapshot.get("stores", []):
             if not isinstance(store, dict) or int(store.get("store_id", 0)) != leader_store_id:
@@ -1133,7 +1205,7 @@ def test_autoscaling_drains_stops_and_finalizes_data_node_without_losing_reads(
     cluster.create_table(table_name, num_shards=5)
 
     docs = {f"doc-{i:02d}": {"title": f"doc {i}", "rank": i} for i in range(12)}
-    _insert_docs(cluster, table_name, docs)
+    _insert_docs(cluster, table_name, docs, min_group_count=5)
 
     group_ids = _wait_for_group_count(cluster, table_name, min_count=5)
     initial_nodes = wait_until(
@@ -1194,7 +1266,7 @@ def test_autoscaling_finalizes_shard_split_from_size_threshold(
         }
         for i in range(48)
     }
-    _insert_docs(cluster, table_name, docs)
+    _insert_docs(cluster, table_name, docs, min_group_count=1)
 
     def split_completed() -> set[int] | None:
         try:
@@ -1224,7 +1296,7 @@ def test_autoscaling_node_churn_keeps_reads_available(
     cluster.create_table(table_name, num_shards=6)
 
     docs = {f"doc-{i:02d}": {"title": f"churn doc {i}", "rank": i} for i in range(18)}
-    _insert_docs(cluster, table_name, docs)
+    _insert_docs(cluster, table_name, docs, min_group_count=6)
     _assert_docs_readable(cluster, table_name, docs)
 
     group_ids = _wait_for_group_count(cluster, table_name, min_count=6)

--- a/zig/pkg/termite/src/api/generated/termite_api/types.zig
+++ b/zig/pkg/termite/src/api/generated/termite_api/types.zig
@@ -993,6 +993,10 @@ pub const EmbedRequest = struct {
     encoding_format: ?[]const u8 = null,
     /// Optional truncation size for dense embeddings. Must be a positive integer no larger than the model embedding size. Not supported for sparse models.
     dimensions: ?i64 = null,
+    /// Optional model-specific embedding task. Jina v5 currently supports retrieval in this runtime.
+    task: ?[]const u8 = null,
+    /// Optional model-specific prompt role. For Jina v5 retrieval embeddings, use "query" or "document".
+    prompt_name: ?[]const u8 = null,
 };
 
 /// Message content. Supports two formats: - Simple string: "Hello, how are you?" - Array of content parts (OpenAI multimodal format): [{"type": "text", "text": "Hello"}]

--- a/zig/pkg/termite/src/api/generated/termite_api/types.zig
+++ b/zig/pkg/termite/src/api/generated/termite_api/types.zig
@@ -993,7 +993,9 @@ pub const EmbedRequest = struct {
     encoding_format: ?[]const u8 = null,
     /// Optional truncation size for dense embeddings. Must be a positive integer no larger than the model embedding size. Not supported for sparse models.
     dimensions: ?i64 = null,
-    /// Optional embedding input role. Uses Cohere-style retrieval values; query/document are accepted aliases for Jina-style callers.
+    /// Optional embedding task type using Google embedding task-type names. For Jina v5 text embeddings, query-side tasks use the query prefix and RETRIEVAL_DOCUMENT uses the document prefix.
+    task_type: ?[]const u8 = null,
+    /// Deprecated compatibility alias for task_type. search_query/query map to RETRIEVAL_QUERY; search_document/document map to RETRIEVAL_DOCUMENT; classification and clustering map to their Google task_type equivalents.
     input_type: ?[]const u8 = null,
 };
 

--- a/zig/pkg/termite/src/api/generated/termite_api/types.zig
+++ b/zig/pkg/termite/src/api/generated/termite_api/types.zig
@@ -993,10 +993,8 @@ pub const EmbedRequest = struct {
     encoding_format: ?[]const u8 = null,
     /// Optional truncation size for dense embeddings. Must be a positive integer no larger than the model embedding size. Not supported for sparse models.
     dimensions: ?i64 = null,
-    /// Optional model-specific embedding task. Jina v5 currently supports retrieval in this runtime.
-    task: ?[]const u8 = null,
-    /// Optional model-specific prompt role. For Jina v5 retrieval embeddings, use "query" or "document".
-    prompt_name: ?[]const u8 = null,
+    /// Optional embedding input role. Uses Cohere-style retrieval values; query/document are accepted aliases for Jina-style callers.
+    input_type: ?[]const u8 = null,
 };
 
 /// Message content. Supports two formats: - Simple string: "Hello, how are you?" - Array of content parts (OpenAI multimodal format): [{"type": "text", "text": "Hello"}]

--- a/zig/pkg/termite/src/api/openapi.yaml
+++ b/zig/pkg/termite/src/api/openapi.yaml
@@ -1121,14 +1121,29 @@ components:
         dimensions:
           type: integer
           description: Optional truncation size for dense embeddings. Must be a positive integer no larger than the model embedding size. Not supported for sparse models.
+        task_type:
+          type: string
+          description: Optional embedding task type using Google embedding task-type names. For Jina v5 text embeddings, query-side tasks use the query prefix and RETRIEVAL_DOCUMENT uses the document prefix.
+          enum:
+            - RETRIEVAL_QUERY
+            - RETRIEVAL_DOCUMENT
+            - QUESTION_ANSWERING
+            - FACT_VERIFICATION
+            - CODE_RETRIEVAL_QUERY
+            - CLASSIFICATION
+            - CLUSTERING
+            - SEMANTIC_SIMILARITY
         input_type:
           type: string
-          description: Optional embedding input role. Uses Cohere-style retrieval values; query/document are accepted aliases for Jina-style callers.
+          deprecated: true
+          description: Deprecated compatibility alias for task_type. search_query/query map to RETRIEVAL_QUERY; search_document/document map to RETRIEVAL_DOCUMENT; classification and clustering map to their Google task_type equivalents.
           enum:
             - search_query
             - search_document
             - query
             - document
+            - classification
+            - clustering
     EmbedResponse:
       type: object
       description: OpenAI-compatible embedding response with a polymorphic `embedding` field for dense or sparse vectors

--- a/zig/pkg/termite/src/api/openapi.yaml
+++ b/zig/pkg/termite/src/api/openapi.yaml
@@ -1121,6 +1121,15 @@ components:
         dimensions:
           type: integer
           description: Optional truncation size for dense embeddings. Must be a positive integer no larger than the model embedding size. Not supported for sparse models.
+        task:
+          type: string
+          description: Optional model-specific embedding task. Jina v5 currently supports retrieval in this runtime.
+        prompt_name:
+          type: string
+          description: Optional model-specific prompt role. For Jina v5 retrieval embeddings, use "query" or "document".
+          enum:
+            - query
+            - document
     EmbedResponse:
       type: object
       description: OpenAI-compatible embedding response with a polymorphic `embedding` field for dense or sparse vectors

--- a/zig/pkg/termite/src/api/openapi.yaml
+++ b/zig/pkg/termite/src/api/openapi.yaml
@@ -1121,13 +1121,12 @@ components:
         dimensions:
           type: integer
           description: Optional truncation size for dense embeddings. Must be a positive integer no larger than the model embedding size. Not supported for sparse models.
-        task:
+        input_type:
           type: string
-          description: Optional model-specific embedding task. Jina v5 currently supports retrieval in this runtime.
-        prompt_name:
-          type: string
-          description: Optional model-specific prompt role. For Jina v5 retrieval embeddings, use "query" or "document".
+          description: Optional embedding input role. Uses Cohere-style retrieval values; query/document are accepted aliases for Jina-style callers.
           enum:
+            - search_query
+            - search_document
             - query
             - document
     EmbedResponse:

--- a/zig/pkg/termite/src/architectures/gpt.zig
+++ b/zig/pkg/termite/src/architectures/gpt.zig
@@ -1257,6 +1257,33 @@ pub fn hiddenForward(
     seq_len: usize,
     decode_context: ?*const DecodeContext,
 ) ![]f32 {
+    const hidden = try hiddenForwardResident(cb, allocator, config, input_ids, batch, seq_len, decode_context);
+    defer cb.free(hidden);
+    return cb.toFloat32(hidden, allocator);
+}
+
+pub fn hiddenForwardResident(
+    cb: *const ComputeBackend,
+    allocator: std.mem.Allocator,
+    config: Config,
+    input_ids: []const i64,
+    batch: usize,
+    seq_len: usize,
+    decode_context: ?*const DecodeContext,
+) !CT {
+    return hiddenForwardResidentWithOverrides(cb, allocator, config, input_ids, batch, seq_len, decode_context, .{});
+}
+
+pub fn hiddenForwardResidentWithOverrides(
+    cb: *const ComputeBackend,
+    allocator: std.mem.Allocator,
+    config: Config,
+    input_ids: []const i64,
+    batch: usize,
+    seq_len: usize,
+    decode_context: ?*const DecodeContext,
+    raw_overrides: Layer0DecoderOverrides,
+) !CT {
     const hidden_size = config.hidden_size;
     const query_seq_len = actualQuerySeqLen(seq_len, decode_context);
     const total = batch * query_seq_len;
@@ -1271,7 +1298,7 @@ pub fn hiddenForward(
     const ple_vectors = try computePleVectors(cb, allocator, config, input_ids, hidden, total);
     defer if (ple_vectors) |pv| cb.free(pv);
 
-    return hiddenForwardFromEmbeddings(cb, allocator, config, hidden, batch, seq_len, decode_context, ple_vectors);
+    return hiddenForwardFromEmbeddingsResidentWithOverrides(cb, allocator, config, hidden, batch, seq_len, decode_context, ple_vectors, raw_overrides);
 }
 
 pub fn hiddenForwardFromEmbeddings(
@@ -1284,6 +1311,35 @@ pub fn hiddenForwardFromEmbeddings(
     decode_context: ?*const DecodeContext,
     ple_vectors: ?CT,
 ) ![]f32 {
+    const hidden = try hiddenForwardFromEmbeddingsResident(cb, allocator, config, hidden_input, batch, seq_len, decode_context, ple_vectors);
+    defer cb.free(hidden);
+    return cb.toFloat32(hidden, allocator);
+}
+
+pub fn hiddenForwardFromEmbeddingsResident(
+    cb: *const ComputeBackend,
+    allocator: std.mem.Allocator,
+    config: Config,
+    hidden_input: CT,
+    batch: usize,
+    seq_len: usize,
+    decode_context: ?*const DecodeContext,
+    ple_vectors: ?CT,
+) !CT {
+    return hiddenForwardFromEmbeddingsResidentWithOverrides(cb, allocator, config, hidden_input, batch, seq_len, decode_context, ple_vectors, .{});
+}
+
+pub fn hiddenForwardFromEmbeddingsResidentWithOverrides(
+    cb: *const ComputeBackend,
+    allocator: std.mem.Allocator,
+    config: Config,
+    hidden_input: CT,
+    batch: usize,
+    seq_len: usize,
+    decode_context: ?*const DecodeContext,
+    ple_vectors: ?CT,
+    raw_overrides: Layer0DecoderOverrides,
+) !CT {
     const hidden_size = config.hidden_size;
     const query_seq_len = actualQuerySeqLen(seq_len, decode_context);
     const total = batch * query_seq_len;
@@ -1325,7 +1381,7 @@ pub fn hiddenForwardFromEmbeddings(
             layer,
             decode_context,
             ple_vectors,
-            .{},
+            raw_overrides,
             null,
             null,
             null,
@@ -1349,10 +1405,7 @@ pub fn hiddenForwardFromEmbeddings(
     if (final_hidden != hidden) cb.free(hidden);
     hidden = final_hidden;
 
-    // 5. Return hidden states
-    const result = try cb.toFloat32(hidden, allocator);
-    cb.free(hidden);
-    return result;
+    return hidden;
 }
 
 // --- Decoder block ---
@@ -3120,7 +3173,7 @@ fn decoderBlock(
     const kv_dim: usize = @as(usize, num_kv_heads) * head_dim;
     const q_dim: usize = @as(usize, num_heads) * head_dim;
     if (!disableDecoderRuntimeActivationDebug() and !shares_kv and config.family != .gpt2 and
-        config.family != .qwen3_5 and
+        config.family != .qwen3 and config.family != .qwen3_5 and
         attn_q_slot != null and attn_k_slot != null and attn_v_slot != null and
         attn_out_proj_linear_slot != null and mlp_gate_slot != null and
         mlp_up_slot != null and mlp_down_slot != null)
@@ -3283,7 +3336,24 @@ fn decoderBlock(
         };
         const k: CT, const v_omitted_local: bool, const v_local: CT = if (shares_kv)
             .{ try createZeroCT(cb, allocator, total * kv_dim), false, try createZeroCT(cb, allocator, total * kv_dim) }
-        else if (attn_k_slot != null and attn_v_slot != null and config.family != .gemma) blk_kv: {
+        else if (attn_k_slot != null and attn_v_slot != null and config.family == .qwen3) blk_kv: {
+            // The dense K/V pair slot path is not Qwen3-correct for Jina v5;
+            // individual prepared slots match the dynamic Metal projections.
+            const k_local = (try cb.decoderRuntimeApplyLinear(&.{
+                .slot = attn_k_slot.?,
+                .input = normed,
+                .in_dim = hidden_size,
+                .out_dim = num_kv_heads * head_dim,
+            })) orelse try attnProject(cb, allocator, config, normed, total, hidden_size, num_kv_heads * head_dim, layer, "k", &name_buf);
+            errdefer cb.free(k_local);
+            const v_local = (try cb.decoderRuntimeApplyLinear(&.{
+                .slot = attn_v_slot.?,
+                .input = normed,
+                .in_dim = hidden_size,
+                .out_dim = num_kv_heads * head_dim,
+            })) orelse try attnProject(cb, allocator, config, normed, total, hidden_size, num_kv_heads * head_dim, layer, "v", &name_buf);
+            break :blk_kv .{ k_local, false, v_local };
+        } else if (attn_k_slot != null and attn_v_slot != null and config.family != .gemma) blk_kv: {
             const kv = (try cb.decoderRuntimeApplyLinearPair(&.{
                 .slot_a = attn_k_slot.?,
                 .slot_b = attn_v_slot.?,
@@ -3438,7 +3508,7 @@ fn decoderBlock(
                     }
                 }
             },
-            .llama, .mistral, .qwen2, .bitnet => {
+            .llama, .mistral, .qwen2, .qwen3, .bitnet => {
                 if (mlp_gate_slot != null and mlp_up_slot != null and mlp_down_slot != null) {
                     const block_started_at = monotonicNowNs();
                     debug_timing_stats.gated_block_attempts += 1;
@@ -7409,7 +7479,7 @@ pub fn applyActivation(cb: *const ComputeBackend, config: Config, input: CT) !CT
     };
 }
 
-fn decoderRuntimeActivationKind(activation: ActivationType) ops.DecoderRuntimeActivationKind {
+pub fn decoderRuntimeActivationKind(activation: ActivationType) ops.DecoderRuntimeActivationKind {
     return switch (activation) {
         .gelu => .gelu,
         .gelu_new => .gelu_new,

--- a/zig/pkg/termite/src/architectures/gpt.zig
+++ b/zig/pkg/termite/src/architectures/gpt.zig
@@ -5394,14 +5394,16 @@ fn feedForward(
             // Gated FFN: gate = silu(x @ gate_w), up = x @ up_w, out = (gate * up) @ down_w
             const gate_w = try getFFNWeight(cb, config, layer, "gate", name_buf);
             defer cb.free(gate_w);
-            const gate_proj = try cb.linearNoBias(input, gate_w, total, hidden_size, inter_size);
+            const up_w = try getFFNWeight(cb, config, layer, "up", name_buf);
+            defer cb.free(up_w);
+            debug_timing_stats.ffn_project_pair_calls += 1;
+            const gate_up = try cb.linearNoBiasPair(input, gate_w, up_w, total, hidden_size, inter_size);
+            const gate_proj = gate_up.first;
             defer cb.free(gate_proj);
             const gate_act = try applyActivation(cb, config, gate_proj);
             defer cb.free(gate_act);
 
-            const up_w = try getFFNWeight(cb, config, layer, "up", name_buf);
-            defer cb.free(up_w);
-            const up_proj = try cb.linearNoBias(input, up_w, total, hidden_size, inter_size);
+            const up_proj = gate_up.second;
             defer cb.free(up_proj);
 
             const gated = try cb.multiply(gate_act, up_proj);

--- a/zig/pkg/termite/src/architectures/gpt.zig
+++ b/zig/pkg/termite/src/architectures/gpt.zig
@@ -7004,11 +7004,29 @@ pub fn getModelWeight(cb: *const ComputeBackend, config: Config, name: []const u
         var buf: [256]u8 = undefined;
         const prefixed = try maybePrefixedModelName(config, name, &buf);
         return cb.getWeight(prefixed) catch |err| switch (err) {
-            error.MissingWeight => cb.getWeight(name),
+            error.MissingWeight => getModelWeightUnprefixedFallback(cb, name),
             else => err,
         };
     }
-    return cb.getWeight(name);
+    return getModelWeightUnprefixedFallback(cb, name);
+}
+
+fn getModelWeightUnprefixedFallback(cb: *const ComputeBackend, name: []const u8) !CT {
+    return cb.getWeight(name) catch |err| switch (err) {
+        error.MissingWeight => if (modelPrefixStrippedName(name)) |stripped| cb.getWeight(stripped) else err,
+        else => err,
+    };
+}
+
+fn modelPrefixStrippedName(name: []const u8) ?[]const u8 {
+    if (!std.mem.startsWith(u8, name, "model.")) return null;
+    return name["model.".len..];
+}
+
+test "model weight fallback strips model prefix for bare Jina/Qwen backbones" {
+    try std.testing.expectEqualStrings("embed_tokens.weight", modelPrefixStrippedName("model.embed_tokens.weight") orelse return error.MissingFallback);
+    try std.testing.expectEqualStrings("layers.0.self_attn.q_proj.weight", modelPrefixStrippedName("model.layers.0.self_attn.q_proj.weight") orelse return error.MissingFallback);
+    try std.testing.expect(modelPrefixStrippedName("embed_tokens.weight") == null);
 }
 
 pub fn getFFNWeight(cb: *const ComputeBackend, config: Config, layer: usize, proj: []const u8, buf: *[256]u8) !CT {

--- a/zig/pkg/termite/src/architectures/session_factory.zig
+++ b/zig/pkg/termite/src/architectures/session_factory.zig
@@ -544,6 +544,7 @@ pub fn createNativeSessionWithTaskOverride(allocator: std.mem.Allocator, model_p
         if (arch_config == .gpt and arch_config.gpt.family == .gpt2) {
             try transposeGpt2Conv1dWeights(allocator, &resident_weights);
         }
+        try applyJinaV5RetrievalAdapterIfPresent(allocator, model_path, mf, &resident_weights);
     }
 
     const keep_store = shouldRetainTensorStore(store.kind(), lazy_weights.count());
@@ -794,6 +795,10 @@ pub fn createPjrtSessionWithTaskOverride(allocator: std.mem.Allocator, model_pat
 
     if (store.kind() != .gguf) {
         refineArchConfigFromWeights(&arch_config, &resident_weights);
+    }
+
+    if (store.kind() == .safetensors) {
+        try applyJinaV5RetrievalAdapterIfPresent(allocator, model_path, mf, &resident_weights);
     }
 
     const keep_store = shouldRetainTensorStore(store.kind(), lazy_weights.count());
@@ -1061,6 +1066,15 @@ fn createGpuHostedSessionWithTaskOverride(
 
     var mf = try manifest_mod.loadFromDir(allocator, model_path);
     defer mf.deinit();
+    var gpu_jina_lora_adapter: ?*gpu_hosted_store_mod.JinaLoraAdapter = null;
+    errdefer if (gpu_jina_lora_adapter) |adapter| adapter.destroy();
+    if (std.mem.eql(u8, mf.config_model_arch, "jina_embeddings_v5") and backend_type == .mlx) {
+        if (try jinaRetrievalAdapterPaths(allocator, model_path)) |paths| {
+            allocator.free(paths.config);
+            allocator.free(paths.weights);
+            return error.JinaV5AdapterMergeRequiresNativeBackend;
+        }
+    }
 
     const model_weight_bytes = estimateNativeWeightBytes(allocator, mf) catch 0;
 
@@ -1207,6 +1221,14 @@ fn createGpuHostedSessionWithTaskOverride(
             if (tensor_store.?.kind() != .gguf) {
                 try refineArchConfigFromStore(allocator, tensor_store.?, all_names, &arch_config);
             }
+            if (backend_type == .metal and std.mem.eql(u8, mf.config_model_arch, "jina_embeddings_v5")) {
+                if (try jinaRetrievalAdapterPaths(allocator, model_path)) |paths| {
+                    defer allocator.free(paths.config);
+                    defer allocator.free(paths.weights);
+                    const cfg = try parseJinaLoraConfig(allocator, paths.config);
+                    gpu_jina_lora_adapter = try gpu_hosted_store_mod.JinaLoraAdapter.create(allocator, paths.weights, cfg.scale());
+                }
+            }
         }
         break :blk "";
     } else return error.NoSafetensorsFile;
@@ -1259,8 +1281,10 @@ fn createGpuHostedSessionWithTaskOverride(
             .allow_direct_quant = direct_quant_enabled,
             .quant_execution_mode = quant_mode,
             .prefer_f32_dense_tensors = prefer_f32_dense_tensors,
+            .jina_lora_adapter = gpu_jina_lora_adapter,
         }),
     };
+    gpu_jina_lora_adapter = null;
     errdefer archClose(impl);
     try initGpuHostedPrefetch(impl);
     return .{ .ptr = impl, .vtable = &arch_vtable };
@@ -1299,7 +1323,10 @@ fn detectArchitecture(allocator: std.mem.Allocator, model_path: []const u8, mf: 
             if (t5_mod.isT5Model(model_type)) {
                 return .{ .t5 = try t5_mod.parseConfig(allocator, config_bytes) };
             }
-            if (gpt_mod.isGenerativeModel(model_type) or std.mem.eql(u8, model_type, "colqwen2")) {
+            if (gpt_mod.isGenerativeModel(model_type) or
+                std.mem.eql(u8, model_type, "colqwen2") or
+                std.mem.eql(u8, model_type, "jina_embeddings_v5"))
+            {
                 var cfg = try gpt_mod.parseConfig(allocator, config_bytes);
                 if (mf.gguf_path) |gguf_path| {
                     if (try detectArchitectureFromGguf(allocator, gguf_path)) |gguf_config| {
@@ -2987,6 +3014,7 @@ const GpuHostedBackendInit = struct {
     allow_direct_quant: bool,
     quant_execution_mode: MlxQuantExecutionMode,
     prefer_f32_dense_tensors: bool,
+    jina_lora_adapter: ?*gpu_hosted_store_mod.JinaLoraAdapter = null,
 };
 
 fn makeGpuHostedBackendData(
@@ -3018,6 +3046,7 @@ fn makeGpuHostedBackendData(
         .native_quant = native_quant,
         .prefer_f32_dense_tensors = init.prefer_f32_dense_tensors,
         .mirror_kv_to_manager = false,
+        .jina_lora_adapter = init.jina_lora_adapter,
     };
     return switch (backend_type) {
         .mlx => if (comptime build_options.enable_mlx) .{ .mlx = data } else unreachable,
@@ -3245,6 +3274,82 @@ fn transposeGpt2Conv1dLoadedWeightInPlace(
     if (w.owns_shape) allocator.free(w.shape);
     w.shape = new_shape;
     w.owns_shape = true;
+}
+
+const JinaLoraConfig = struct {
+    rank: usize = 32,
+    alpha: f32 = 32.0,
+
+    fn scale(self: JinaLoraConfig) f32 {
+        return self.alpha / @as(f32, @floatFromInt(self.rank));
+    }
+};
+
+fn parseJinaLoraConfig(allocator: std.mem.Allocator, path: []const u8) !JinaLoraConfig {
+    const bytes = try c_file.readFile(allocator, path);
+    defer allocator.free(bytes);
+    const parsed = try std.json.parseFromSlice(std.json.Value, allocator, bytes, .{});
+    defer parsed.deinit();
+    if (parsed.value != .object) return error.InvalidAdapterConfig;
+    const obj = parsed.value.object;
+
+    var cfg = JinaLoraConfig{};
+    if (obj.get("r")) |value| {
+        if (value == .integer and value.integer > 0) cfg.rank = @intCast(value.integer);
+    }
+    if (obj.get("lora_alpha")) |value| {
+        cfg.alpha = switch (value) {
+            .integer => |i| @floatFromInt(i),
+            .float => |f| @floatCast(f),
+            else => cfg.alpha,
+        };
+    }
+    return cfg;
+}
+
+fn jinaRetrievalAdapterPaths(
+    allocator: std.mem.Allocator,
+    model_path: []const u8,
+) !?struct { config: []const u8, weights: []const u8 } {
+    const config_path = try std.fs.path.join(allocator, &.{ model_path, "adapters", "retrieval", "adapter_config.json" });
+    errdefer allocator.free(config_path);
+    const weights_path = try std.fs.path.join(allocator, &.{ model_path, "adapters", "retrieval", "adapter_model.safetensors" });
+    errdefer allocator.free(weights_path);
+
+    if (!c_file.fileExists(allocator, config_path) and !c_file.fileExists(allocator, weights_path)) {
+        allocator.free(config_path);
+        allocator.free(weights_path);
+        return null;
+    }
+    if (!c_file.fileExists(allocator, config_path) or !c_file.fileExists(allocator, weights_path)) {
+        allocator.free(config_path);
+        allocator.free(weights_path);
+        return error.IncompleteJinaV5Adapter;
+    }
+
+    return .{ .config = config_path, .weights = weights_path };
+}
+
+fn applyJinaV5RetrievalAdapterIfPresent(
+    allocator: std.mem.Allocator,
+    model_path: []const u8,
+    mf: manifest_mod.ModelManifest,
+    resident_weights: *std.StringHashMapUnmanaged(LoadedWeight),
+) !void {
+    if (!std.mem.eql(u8, mf.config_model_arch, "jina_embeddings_v5")) return;
+
+    const paths = try jinaRetrievalAdapterPaths(allocator, model_path) orelse return;
+    defer allocator.free(paths.config);
+    defer allocator.free(paths.weights);
+
+    const cfg = try parseJinaLoraConfig(allocator, paths.config);
+    var adapter = try gpu_hosted_store_mod.JinaLoraAdapter.create(allocator, paths.weights, cfg.scale());
+    defer adapter.destroy();
+
+    var it = resident_weights.iterator();
+    while (it.next()) |entry| {
+        try adapter.mergeIntoLoadedWeight(entry.key_ptr.*, entry.value_ptr);
+    }
 }
 
 fn transposeGpt2Conv1dResidentMlxWeights(
@@ -5208,6 +5313,7 @@ fn archClose(ptr: *anyopaque) void {
                 mlx_compute_mod.deinitPrefetchQueue(gpu_data);
                 if (gpu_data.residency) |*residency| residency.deinit();
                 gpu_data.native_quant.deinit();
+                if (gpu_data.jina_lora_adapter) |adapter| adapter.destroy();
                 if (gpu_data.tensor_store) |store| store.deinit();
                 var resident_transposed_it = gpu_data.resident_transposed_weights.iterator();
                 while (resident_transposed_it.next()) |entry| {
@@ -5243,6 +5349,7 @@ fn archClose(ptr: *anyopaque) void {
                 if (comptime build_options.enable_mlx) {
                     gpu_data.native_quant.deinit();
                 }
+                if (gpu_data.jina_lora_adapter) |adapter| adapter.destroy();
                 if (gpu_data.tensor_store) |store| store.deinit();
             }
         },

--- a/zig/pkg/termite/src/backends/decoder_gated_runtime.zig
+++ b/zig/pkg/termite/src/backends/decoder_gated_runtime.zig
@@ -885,6 +885,56 @@ fn kHeadNormSlot(configured_layer_count: usize, layer: usize) usize {
     return gemma4_runtime.kHeadNormSlot(configured_layer_count, layer);
 }
 
+fn layerRopeThetaForActiveDim(gpt_config: gpt_mod.Config, layer: usize) f32 {
+    const rope_dim: usize = gpt_config.layerRopeActiveDim(layer);
+    const base_theta = gpt_config.layerRopeTheta(layer);
+    const freq_dim: f32 = @floatFromInt(gpt_config.layerRopeFrequencyDim(layer));
+    const active_dim: f32 = @floatFromInt(rope_dim);
+    if (active_dim < freq_dim) {
+        return std.math.pow(f32, base_theta, active_dim / freq_dim);
+    }
+    return base_theta;
+}
+
+pub fn fillDenseQwen3LayerSpecs(
+    gpt_config: gpt_mod.Config,
+    configured_layer_count: usize,
+    out: []ops.DecoderRuntimeLayerSpec,
+) ![]const ops.DecoderRuntimeLayerSpec {
+    if (gpt_config.family != .qwen3) return error.UnsupportedModelFamily;
+    const layer_count = @min(configured_layer_count, gpt_config.num_hidden_layers);
+    if (layer_count > out.len) return error.OutOfMemory;
+    for (0..layer_count) |layer| {
+        const head_dim = gpt_config.effectiveHeadDimForLayer(layer);
+        const kv_heads = gpt_config.effectiveKVHeadsForLayer(layer);
+        out[layer] = .{
+            .kv_heads = kv_heads,
+            .head_dim = head_dim,
+            .intermediate_size = gpt_config.intermediateSize(layer),
+            .kv_layer_index = layer,
+            .shares_kv = false,
+            .sliding_window = 0,
+            .rope_dim = @intCast(gpt_config.layerRopeDim(layer)),
+            .rope_active_dim = @intCast(gpt_config.layerRopeActiveDim(layer)),
+            .rope_theta = layerRopeThetaForActiveDim(gpt_config, layer),
+            .attn_pre_norm_slot = normSlot(layer, .attn_pre),
+            .attn_post_norm_slot = normSlot(layer, .ffn_pre),
+            .ffn_pre_norm_slot = normSlot(layer, .ffn_pre),
+            .ffn_post_norm_slot = normSlot(layer, .ffn_pre),
+            .q_head_norm_slot = qHeadNormSlot(configured_layer_count, layer),
+            .k_head_norm_slot = kHeadNormSlot(configured_layer_count, layer),
+            .q_linear_slot = linearSlot(layer, .attn_q),
+            .k_linear_slot = linearSlot(layer, .attn_k),
+            .v_linear_slot = linearSlot(layer, .attn_v),
+            .attention_linear_slot = linearSlot(layer, .attn_out_proj),
+            .gate_ffn_linear_slot = linearSlot(layer, .mlp_gate),
+            .up_ffn_linear_slot = linearSlot(layer, .mlp_up),
+            .down_ffn_linear_slot = linearSlot(layer, .mlp_down),
+        };
+    }
+    return out[0..layer_count];
+}
+
 const DirectHiddenResult = struct {
     hidden: ops.CT,
     total_rows: usize,
@@ -1208,7 +1258,7 @@ pub fn supportsConfig(gpt_config: gpt_mod.Config) bool {
         // path after prefill because vision/PLE state is already reflected in
         // the retained KV. The remaining unsupported cases are the extra
         // decoder-side sublayers that still branch the block structure.
-        .llama, .mistral, .qwen2 => !gpt_config.usesMoe() and !gpt_config.hasPle(),
+        .llama, .mistral, .qwen2, .qwen3 => !gpt_config.usesMoe() and !gpt_config.hasPle(),
         .gemma => gemma4_runtime.supportsRuntimeConfig(gpt_config),
         else => false,
     };
@@ -1560,6 +1610,7 @@ fn forwardFinalHiddenTensorGemmaDirect(
             .num_attention_heads = gpt_config.num_attention_heads,
             .global_head_dim = gpt_config.global_head_dim,
             .ple_hidden_size = gpt_config.ple_hidden_size,
+            .final_norm_slot = finalNormSlot(configured_layer_count),
             .norm_eps = gpt_config.norm_eps,
             .rope_freq_scale = gpt_config.rope_freq_scale,
             .rope_consecutive_pairs = gpt_config.rope_layout == .consecutive_pairs,
@@ -1742,12 +1793,12 @@ fn forwardFinalHiddenTensorGemmaDirect(
                 .rope_consecutive_pairs = gpt_config.rope_layout == .consecutive_pairs,
                 .global_head_dim = gpt_config.global_head_dim,
                 .attention_linear_slot = linearSlot(layer, .attn_out_proj),
-                .attention_post_linear_rms_norm_slot = normSlot(layer, .attn_post),
+                .attention_post_linear_rms_norm_slot = if (gpt_config.family == .qwen3) null else normSlot(layer, .attn_post),
                 .hidden_size = gpt_config.hidden_size,
                 .eps = gpt_config.norm_eps,
                 .ffn_rms_norm_slot = normSlot(layer, .ffn_pre),
                 .ffn_post_gate_rms_norm_slot = null,
-                .ffn_post_down_rms_norm_slot = normSlot(layer, .ffn_post),
+                .ffn_post_down_rms_norm_slot = if (gpt_config.family == .qwen3) null else normSlot(layer, .ffn_post),
                 .gate_ffn_linear_slot = linearSlot(layer, .mlp_gate),
                 .up_ffn_linear_slot = linearSlot(layer, .mlp_up),
                 .down_ffn_linear_slot = linearSlot(layer, .mlp_down),
@@ -4025,9 +4076,12 @@ fn forwardFinalHiddenLastRowDirect(
     return last_hidden;
 }
 
-pub fn buildOverrides(gpt_config: gpt_mod.Config, configured_layer_count: usize) gpt_arch.Layer0DecoderOverrides {
+pub fn buildOverridesWithLevel(
+    gpt_config: gpt_mod.Config,
+    configured_layer_count: usize,
+    configured_override_level: usize,
+) gpt_arch.Layer0DecoderOverrides {
     const prepared_layer_count = preparedLayers(@min(configured_layer_count, gpt_config.num_hidden_layers));
-    const configured_override_level = overrideLevel();
     var overrides = gpt_arch.Layer0DecoderOverrides{};
     for (0..prepared_layer_count) |layer| {
         if (configured_override_level >= 1) {
@@ -4052,6 +4106,37 @@ pub fn buildOverrides(gpt_config: gpt_mod.Config, configured_layer_count: usize)
         }
     }
     return overrides;
+}
+
+pub fn buildOverrides(gpt_config: gpt_mod.Config, configured_layer_count: usize) gpt_arch.Layer0DecoderOverrides {
+    return buildOverridesWithLevel(gpt_config, configured_layer_count, overrideLevel());
+}
+
+fn prepareLinearNoBiasSlotForConfig(
+    cb: *const ops.ComputeBackend,
+    allocator: std.mem.Allocator,
+    gpt_config: gpt_mod.Config,
+    slot: usize,
+    weight: ops.CT,
+    in_dim: usize,
+    out_dim: usize,
+) !bool {
+    if (gpt_config.family != .qwen3) {
+        return decoder_rms_runtime.prepareLinearNoBiasSlot(cb, allocator, slot, weight, in_dim, out_dim);
+    }
+
+    // Jina v5 applies a LoRA retrieval adapter into the loaded f32 tensor.
+    // Preparing from raw bf16 bytes would bypass that merge for resident slots.
+    const shape = try cb.tensorShape(weight, allocator);
+    defer allocator.free(shape);
+    const shape_i32 = try allocator.alloc(i32, shape.len);
+    defer allocator.free(shape_i32);
+    for (shape, 0..) |dim, i| shape_i32[i] = @intCast(dim);
+    const values = try cb.toFloat32(weight, allocator);
+    defer allocator.free(values);
+    const dense = try cb.fromFloat32Shape(values, shape_i32);
+    defer cb.free(dense);
+    return decoder_rms_runtime.prepareLinearNoBiasDenseSlot(cb, allocator, slot, dense, in_dim, out_dim, true);
 }
 
 pub fn prepareDecodeRuntime(
@@ -4133,39 +4218,41 @@ pub fn prepareDecodeRuntime(
         finished_at = monotonicNowNs();
         if (finished_at > started_at) timing_stats.norm_prep_nanos += finished_at - started_at;
 
-        if (gpt_config.family == .gemma) {
+        if (gpt_config.family == .gemma or gpt_config.family == .qwen3) {
             var primary_buf: [256]u8 = undefined;
 
-            started_at = monotonicNowNs();
-            const ffn_pre_norm_name = std.fmt.bufPrint(&primary_buf, "model.layers.{d}.pre_feedforward_layernorm.weight", .{layer}) catch return error.NameTooLong;
-            const ffn_pre_norm_w = gpt_arch.getModelWeight(cb, gpt_config, ffn_pre_norm_name) catch attn_post_norm_w;
-            const owns_ffn_pre = ffn_pre_norm_w != attn_post_norm_w;
-            defer if (owns_ffn_pre) cb.free(ffn_pre_norm_w);
-            finished_at = monotonicNowNs();
-            if (finished_at > started_at) timing_stats.lookup_nanos += finished_at - started_at;
-            started_at = monotonicNowNs();
-            if (!(try decoder_rms_runtime.prepareRmsNormSlot(cb, allocator, gpt_config, normSlot(layer, .ffn_pre), ffn_pre_norm_w, gpt_config.hidden_size))) {
-                timing_stats.prepare_ffn_pre_norm_failures += 1;
-                tracePrepareLayerFailure(layer, "ffn_pre_norm", normSlot(layer, .ffn_pre), gpt_config.hidden_size, gpt_config.hidden_size);
-                return false;
-            }
-            finished_at = monotonicNowNs();
-            if (finished_at > started_at) timing_stats.norm_prep_nanos += finished_at - started_at;
+            if (gpt_config.family == .gemma) {
+                started_at = monotonicNowNs();
+                const ffn_pre_norm_name = std.fmt.bufPrint(&primary_buf, "model.layers.{d}.pre_feedforward_layernorm.weight", .{layer}) catch return error.NameTooLong;
+                const ffn_pre_norm_w = gpt_arch.getModelWeight(cb, gpt_config, ffn_pre_norm_name) catch attn_post_norm_w;
+                const owns_ffn_pre = ffn_pre_norm_w != attn_post_norm_w;
+                defer if (owns_ffn_pre) cb.free(ffn_pre_norm_w);
+                finished_at = monotonicNowNs();
+                if (finished_at > started_at) timing_stats.lookup_nanos += finished_at - started_at;
+                started_at = monotonicNowNs();
+                if (!(try decoder_rms_runtime.prepareRmsNormSlot(cb, allocator, gpt_config, normSlot(layer, .ffn_pre), ffn_pre_norm_w, gpt_config.hidden_size))) {
+                    timing_stats.prepare_ffn_pre_norm_failures += 1;
+                    tracePrepareLayerFailure(layer, "ffn_pre_norm", normSlot(layer, .ffn_pre), gpt_config.hidden_size, gpt_config.hidden_size);
+                    return false;
+                }
+                finished_at = monotonicNowNs();
+                if (finished_at > started_at) timing_stats.norm_prep_nanos += finished_at - started_at;
 
-            started_at = monotonicNowNs();
-            const ffn_post_norm_name = try std.fmt.bufPrint(&name_buf, "model.layers.{d}.post_feedforward_layernorm.weight", .{layer});
-            const ffn_post_norm_w = try gpt_arch.getModelWeight(cb, gpt_config, ffn_post_norm_name);
-            defer cb.free(ffn_post_norm_w);
-            finished_at = monotonicNowNs();
-            if (finished_at > started_at) timing_stats.lookup_nanos += finished_at - started_at;
-            started_at = monotonicNowNs();
-            if (!(try decoder_rms_runtime.prepareRmsNormSlot(cb, allocator, gpt_config, normSlot(layer, .ffn_post), ffn_post_norm_w, gpt_config.hidden_size))) {
-                timing_stats.prepare_ffn_post_norm_failures += 1;
-                tracePrepareLayerFailure(layer, "ffn_post_norm", normSlot(layer, .ffn_post), gpt_config.hidden_size, gpt_config.hidden_size);
-                return false;
+                started_at = monotonicNowNs();
+                const ffn_post_norm_name = try std.fmt.bufPrint(&name_buf, "model.layers.{d}.post_feedforward_layernorm.weight", .{layer});
+                const ffn_post_norm_w = try gpt_arch.getModelWeight(cb, gpt_config, ffn_post_norm_name);
+                defer cb.free(ffn_post_norm_w);
+                finished_at = monotonicNowNs();
+                if (finished_at > started_at) timing_stats.lookup_nanos += finished_at - started_at;
+                started_at = monotonicNowNs();
+                if (!(try decoder_rms_runtime.prepareRmsNormSlot(cb, allocator, gpt_config, normSlot(layer, .ffn_post), ffn_post_norm_w, gpt_config.hidden_size))) {
+                    timing_stats.prepare_ffn_post_norm_failures += 1;
+                    tracePrepareLayerFailure(layer, "ffn_post_norm", normSlot(layer, .ffn_post), gpt_config.hidden_size, gpt_config.hidden_size);
+                    return false;
+                }
+                finished_at = monotonicNowNs();
+                if (finished_at > started_at) timing_stats.norm_prep_nanos += finished_at - started_at;
             }
-            finished_at = monotonicNowNs();
-            if (finished_at > started_at) timing_stats.norm_prep_nanos += finished_at - started_at;
 
             started_at = monotonicNowNs();
             const q_head_norm_name = try std.fmt.bufPrint(&name_buf, "model.layers.{d}.self_attn.q_norm.weight", .{layer});
@@ -4205,7 +4292,7 @@ pub fn prepareDecodeRuntime(
         finished_at = monotonicNowNs();
         if (finished_at > started_at) timing_stats.lookup_nanos += finished_at - started_at;
         started_at = monotonicNowNs();
-        if (!(try decoder_rms_runtime.prepareLinearNoBiasSlot(cb, allocator, linearSlot(layer, .attn_q), q_w, gpt_config.hidden_size, attention_input_size))) {
+        if (!(try prepareLinearNoBiasSlotForConfig(cb, allocator, gpt_config, linearSlot(layer, .attn_q), q_w, gpt_config.hidden_size, attention_input_size))) {
             timing_stats.prepare_attn_q_failures += 1;
             tracePrepareLayerFailure(layer, "attn_q", linearSlot(layer, .attn_q), gpt_config.hidden_size, attention_input_size);
             return false;
@@ -4220,7 +4307,7 @@ pub fn prepareDecodeRuntime(
         finished_at = monotonicNowNs();
         if (finished_at > started_at) timing_stats.lookup_nanos += finished_at - started_at;
         started_at = monotonicNowNs();
-        if (!(try decoder_rms_runtime.prepareLinearNoBiasSlot(cb, allocator, linearSlot(layer, .attn_k), k_w, gpt_config.hidden_size, layer_kv_heads * layer_head_dim))) {
+        if (!(try prepareLinearNoBiasSlotForConfig(cb, allocator, gpt_config, linearSlot(layer, .attn_k), k_w, gpt_config.hidden_size, layer_kv_heads * layer_head_dim))) {
             timing_stats.prepare_attn_k_failures += 1;
             tracePrepareLayerFailure(layer, "attn_k", linearSlot(layer, .attn_k), gpt_config.hidden_size, layer_kv_heads * layer_head_dim);
             return false;
@@ -4235,7 +4322,7 @@ pub fn prepareDecodeRuntime(
         finished_at = monotonicNowNs();
         if (finished_at > started_at) timing_stats.lookup_nanos += finished_at - started_at;
         started_at = monotonicNowNs();
-        if (!(try decoder_rms_runtime.prepareLinearNoBiasSlot(cb, allocator, linearSlot(layer, .attn_v), v_w, gpt_config.hidden_size, layer_kv_heads * layer_head_dim))) {
+        if (!(try prepareLinearNoBiasSlotForConfig(cb, allocator, gpt_config, linearSlot(layer, .attn_v), v_w, gpt_config.hidden_size, layer_kv_heads * layer_head_dim))) {
             timing_stats.prepare_attn_v_failures += 1;
             tracePrepareLayerFailure(layer, "attn_v", linearSlot(layer, .attn_v), gpt_config.hidden_size, layer_kv_heads * layer_head_dim);
             return false;
@@ -4257,9 +4344,10 @@ pub fn prepareDecodeRuntime(
         finished_at = monotonicNowNs();
         if (finished_at > started_at) timing_stats.lookup_nanos += finished_at - started_at;
         started_at = monotonicNowNs();
-        const prepared_attn_out = try decoder_rms_runtime.prepareLinearNoBiasSlot(
+        const prepared_attn_out = try prepareLinearNoBiasSlotForConfig(
             cb,
             allocator,
+            gpt_config,
             linearSlot(layer, .attn_out_proj),
             attn_out_w,
             attention_input_size,
@@ -4279,7 +4367,7 @@ pub fn prepareDecodeRuntime(
         finished_at = monotonicNowNs();
         if (finished_at > started_at) timing_stats.lookup_nanos += finished_at - started_at;
         started_at = monotonicNowNs();
-        if (!(try decoder_rms_runtime.prepareLinearNoBiasSlot(cb, allocator, linearSlot(layer, .mlp_gate), gate_w, gpt_config.hidden_size, gpt_config.intermediateSize(layer)))) {
+        if (!(try prepareLinearNoBiasSlotForConfig(cb, allocator, gpt_config, linearSlot(layer, .mlp_gate), gate_w, gpt_config.hidden_size, gpt_config.intermediateSize(layer)))) {
             timing_stats.prepare_mlp_gate_failures += 1;
             tracePrepareLayerFailure(layer, "mlp_gate", linearSlot(layer, .mlp_gate), gpt_config.hidden_size, gpt_config.intermediateSize(layer));
             return false;
@@ -4293,7 +4381,7 @@ pub fn prepareDecodeRuntime(
         finished_at = monotonicNowNs();
         if (finished_at > started_at) timing_stats.lookup_nanos += finished_at - started_at;
         started_at = monotonicNowNs();
-        if (!(try decoder_rms_runtime.prepareLinearNoBiasSlot(cb, allocator, linearSlot(layer, .mlp_up), up_w, gpt_config.hidden_size, gpt_config.intermediateSize(layer)))) {
+        if (!(try prepareLinearNoBiasSlotForConfig(cb, allocator, gpt_config, linearSlot(layer, .mlp_up), up_w, gpt_config.hidden_size, gpt_config.intermediateSize(layer)))) {
             timing_stats.prepare_mlp_up_failures += 1;
             tracePrepareLayerFailure(layer, "mlp_up", linearSlot(layer, .mlp_up), gpt_config.hidden_size, gpt_config.intermediateSize(layer));
             return false;
@@ -4307,7 +4395,7 @@ pub fn prepareDecodeRuntime(
         finished_at = monotonicNowNs();
         if (finished_at > started_at) timing_stats.lookup_nanos += finished_at - started_at;
         started_at = monotonicNowNs();
-        if (!(try decoder_rms_runtime.prepareLinearNoBiasSlot(cb, allocator, linearSlot(layer, .mlp_down), down_w, gpt_config.intermediateSize(layer), gpt_config.hidden_size))) {
+        if (!(try prepareLinearNoBiasSlotForConfig(cb, allocator, gpt_config, linearSlot(layer, .mlp_down), down_w, gpt_config.intermediateSize(layer), gpt_config.hidden_size))) {
             timing_stats.prepare_mlp_down_failures += 1;
             tracePrepareLayerFailure(layer, "mlp_down", linearSlot(layer, .mlp_down), gpt_config.intermediateSize(layer), gpt_config.hidden_size);
             return false;

--- a/zig/pkg/termite/src/backends/metal_kernels.m
+++ b/zig/pkg/termite/src/backends/metal_kernels.m
@@ -898,7 +898,7 @@ static int termite_metal_encode_q8_0_linear_raw_on_encoder(termite_metal_decode_
 static int termite_metal_encode_q8_0_linear_raw_on_encoder_planned(termite_metal_decode_runtime *runtime, id<MTLComputeCommandEncoder> encoder, id<MTLBuffer> input_buffer, size_t input_offset, id<MTLBuffer> weight_buffer, id<MTLBuffer> output_buffer, size_t output_offset, size_t rows, size_t in_dim, size_t out_dim, uint8_t planned_dispatch, int failure_code);
 static int termite_metal_encode_q8_0_linear_raw_on_encoder_planned_family(termite_metal_decode_runtime *runtime, id<MTLComputeCommandEncoder> encoder, id<MTLBuffer> input_buffer, size_t input_offset, id<MTLBuffer> weight_buffer, id<MTLBuffer> output_buffer, size_t output_offset, size_t rows, size_t in_dim, size_t out_dim, uint8_t planned_dispatch, termite_metal_q8_0_linear_family_kind q8_family, int failure_code);
 static int termite_metal_encode_argmax_logits_on_encoder(termite_metal_decode_runtime *runtime, id<MTLComputeCommandEncoder> encoder, id<MTLBuffer> logits_buffer, size_t logits_offset, size_t out_dim, int failure_code);
-static int termite_metal_encode_head_rms_rope_on_encoder(termite_metal_decode_runtime *runtime, id<MTLComputeCommandEncoder> encoder, id<MTLBuffer> input_buffer, size_t input_offset, size_t norm_slot, size_t total_heads, size_t head_dim, size_t rope_dim, size_t position, float theta, float freq_scale, float eps, float value_scale, uint32_t consecutive_pairs, size_t heads_per_row, id<MTLBuffer> output_buffer, size_t output_offset, int failure_code);
+static int termite_metal_encode_head_rms_rope_on_encoder(termite_metal_decode_runtime *runtime, id<MTLComputeCommandEncoder> encoder, id<MTLBuffer> input_buffer, size_t input_offset, size_t norm_slot, size_t total_heads, size_t head_dim, size_t rope_dim, size_t position, float theta, float freq_scale, float eps, float value_scale, uint32_t consecutive_pairs, size_t heads_per_row, size_t position_period, id<MTLBuffer> output_buffer, size_t output_offset, int failure_code);
 static int termite_metal_encode_attention_f32_on_encoder(termite_metal_decode_runtime *runtime, id<MTLComputeCommandEncoder> encoder, id<MTLBuffer> q_buffer, size_t q_offset, id<MTLBuffer> k_buffer, size_t k_offset, id<MTLBuffer> v_buffer, size_t v_offset, id<MTLBuffer> output_buffer, size_t output_offset, size_t q_len, size_t kv_tokens, size_t num_heads, size_t num_kv_heads, size_t head_dim, size_t query_position_offset, size_t kv_position_offset, size_t sliding_window, size_t total_sequence_len, int failure_code);
 static int termite_metal_encode_dense_linear_on_encoder(termite_metal_decode_runtime *runtime, id<MTLComputeCommandEncoder> encoder, size_t slot, id<MTLBuffer> input_buffer, size_t input_offset, size_t in_dim, size_t out_dim, id<MTLBuffer> output_buffer, size_t output_offset, int failure_code);
 static int termite_metal_decode_runtime_encode_attention_paged_update_from_f32_key_device_slot(termite_metal_decode_runtime *runtime, id<MTLCommandBuffer> command_buffer, size_t slot, uint32_t format, void *k_handle, size_t k_offset, void *v_handle, size_t v_offset, size_t total_tokens, size_t suffix_tokens, size_t num_kv_heads, size_t head_dim, size_t key_row_bytes, size_t base_key_row_bytes, size_t v_row_stride, size_t kv_position_offset, const uint32_t *block_table, size_t block_count, size_t page_size);
@@ -1360,6 +1360,7 @@ typedef struct termite_metal_head_rms_rope_params {
     float value_scale;
     uint32_t consecutive_pairs;
     uint32_t heads_per_row;
+    uint32_t position_period;
 } termite_metal_head_rms_rope_params;
 
 typedef struct termite_metal_attention_f32_params {
@@ -1685,7 +1686,7 @@ static NSString *termite_metal_shader_source(void) {
            "struct termite_metal_linear_params { uint rows; uint in_dim; uint out_dim; uint row_blocks; };\n"
            "struct termite_metal_qkv_linear_params { uint rows; uint in_dim; uint q_out_dim; uint kv_out_dim; uint row_blocks; };\n"
            "struct termite_metal_key_scores_params { uint q_len; uint block_tokens; uint num_heads; uint num_kv_heads; uint head_dim; uint key_row_bytes; };\n"
-           "struct termite_metal_head_rms_rope_params { uint total_heads; uint head_dim; uint rope_dim; uint position; float theta; float freq_scale; float eps; float value_scale; uint consecutive_pairs; uint heads_per_row; };\n"
+           "struct termite_metal_head_rms_rope_params { uint total_heads; uint head_dim; uint rope_dim; uint position; float theta; float freq_scale; float eps; float value_scale; uint consecutive_pairs; uint heads_per_row; uint position_period; };\n"
            "struct termite_metal_tl1_params { uint rows; uint in_dim; uint out_dim; uint packed_len; uint bm; uint cfg_by; uint bmm; };\n"
            "struct termite_metal_tl2_params { uint rows; uint in_dim; uint out_dim; uint scale_off; uint three_value_len; uint three_sign_len; uint bm; uint cfg_by; uint bmm; uint three_cols; uint two_cols; };\n"
            "struct termite_metal_embed_absolute_position_params { uint token_id; uint position_id; uint hidden_size; };\n"
@@ -2314,6 +2315,7 @@ static NSString *termite_metal_shader_source(void) {
            "        float x1 = input[base + idx1] * inv_rms * weight[idx1] * p.value_scale;\n"
            "        float freq = 1.0f / pow(p.theta, float(2u * j) / float(p.rope_dim));\n"
            "        uint row = p.heads_per_row == 0u ? 0u : head / p.heads_per_row;\n"
+           "        if (p.position_period != 0u) row = row % p.position_period;\n"
            "        float angle = float(p.position + row) * p.freq_scale * freq;\n"
            "        float c = cos(angle); float s = sin(angle);\n"
            "        if (d == idx0) output[base + d] = x0 * c - x1 * s;\n"
@@ -9668,6 +9670,7 @@ termite_metal_provider *termite_metal_provider_create(void) {
 
 void termite_metal_provider_destroy(termite_metal_provider *provider) {
     if (provider == NULL) return;
+    @autoreleasepool {
     provider->q4_0_pipeline = nil;
     provider->q4_1_pipeline = nil;
     provider->q5_0_pipeline = nil;
@@ -9692,6 +9695,7 @@ void termite_metal_provider_destroy(termite_metal_provider *provider) {
     provider->queue = nil;
     provider->device = nil;
     free(provider);
+    }
 }
 
 termite_metal_decode_runtime *termite_metal_decode_runtime_create(void) {
@@ -10062,6 +10066,7 @@ termite_metal_decode_runtime *termite_metal_decode_runtime_create(void) {
 
 void termite_metal_decode_runtime_destroy(termite_metal_decode_runtime *runtime) {
     if (runtime == NULL) return;
+    @autoreleasepool {
     if (runtime->submitted_frame_cb != nil) {
         (void)termite_metal_decode_runtime_wait_frame(runtime);
     }
@@ -10420,6 +10425,7 @@ void termite_metal_decode_runtime_destroy(termite_metal_decode_runtime *runtime)
     runtime->attention_span_v_row_stride = 0;
     runtime->attention_span_position_offset = 0;
     free(runtime);
+    }
 }
 
 int termite_metal_decode_runtime_prepare_absolute_embeddings(
@@ -11764,7 +11770,51 @@ int termite_metal_decode_runtime_apply_head_rms_rope_device(
             encoder = termite_metal_tracked_compute_command_encoder_for(command_buffer, TERMITE_METAL_COMPUTE_SOURCE_HEAD_ROPE);
             if (encoder == nil) return -9;
         }
-        const int encode_rc = termite_metal_encode_head_rms_rope_on_encoder(runtime, encoder, input_buffer, input_offset, norm_slot, total_heads, head_dim, rope_dim, position, theta, freq_scale, eps, value_scale, consecutive_pairs, total_heads, output_buffer, output_offset, -9);
+        const int encode_rc = termite_metal_encode_head_rms_rope_on_encoder(runtime, encoder, input_buffer, input_offset, norm_slot, total_heads, head_dim, rope_dim, position, theta, freq_scale, eps, value_scale, consecutive_pairs, total_heads, 0, output_buffer, output_offset, -9);
+        if (!planned_encoder) [encoder endEncoding];
+        if (encode_rc != 0) return encode_rc;
+        return termite_metal_decode_runtime_finish_command_buffer(command_buffer, frame_owned, -10);
+    }
+}
+
+int termite_metal_decode_runtime_apply_head_rms_rope_batched_device(
+    termite_metal_decode_runtime *runtime,
+    void *input_handle,
+    size_t input_offset,
+    size_t norm_slot,
+    size_t total_heads,
+    size_t head_dim,
+    size_t rope_dim,
+    size_t position,
+    float theta,
+    float freq_scale,
+    float eps,
+    float value_scale,
+    uint32_t consecutive_pairs,
+    size_t heads_per_row,
+    size_t position_period,
+    void *output_handle,
+    size_t output_offset
+) {
+    if (runtime == NULL || input_handle == NULL || output_handle == NULL) return -1;
+    if (norm_slot >= TERMITE_METAL_RMS_NORM_SLOT_CAPACITY || total_heads == 0 || head_dim == 0 || rope_dim == 0 || heads_per_row == 0) return -3;
+    if (total_heads > UINT32_MAX || head_dim > UINT32_MAX || rope_dim > UINT32_MAX || position > UINT32_MAX || heads_per_row > UINT32_MAX || position_period > UINT32_MAX) return -5;
+    @autoreleasepool {
+        id<MTLBuffer> input_buffer = (__bridge id<MTLBuffer>)input_handle;
+        id<MTLBuffer> output_buffer = (__bridge id<MTLBuffer>)output_handle;
+        const size_t bytes = total_heads * head_dim * sizeof(float);
+        if (input_offset + bytes > input_buffer.length) return -6;
+        if (output_offset + bytes > output_buffer.length) return -7;
+        bool frame_owned = (runtime->active_frame_cb == nil);
+        id<MTLCommandBuffer> command_buffer = termite_metal_decode_runtime_command_buffer(runtime, __func__, &frame_owned);
+        if (command_buffer == nil) return -8;
+        id<MTLComputeCommandEncoder> encoder = runtime->active_planned_compute_encoder;
+        const BOOL planned_encoder = (encoder != nil);
+        if (!planned_encoder) {
+            encoder = termite_metal_tracked_compute_command_encoder_for(command_buffer, TERMITE_METAL_COMPUTE_SOURCE_HEAD_ROPE);
+            if (encoder == nil) return -9;
+        }
+        const int encode_rc = termite_metal_encode_head_rms_rope_on_encoder(runtime, encoder, input_buffer, input_offset, norm_slot, total_heads, head_dim, rope_dim, position, theta, freq_scale, eps, value_scale, consecutive_pairs, heads_per_row, position_period, output_buffer, output_offset, -9);
         if (!planned_encoder) [encoder endEncoding];
         if (encode_rc != 0) return encode_rc;
         return termite_metal_decode_runtime_finish_command_buffer(command_buffer, frame_owned, -10);
@@ -11808,7 +11858,7 @@ int termite_metal_decode_runtime_apply_head_rms_rope_scratch_device(
             encoder = termite_metal_tracked_compute_command_encoder_for(command_buffer, TERMITE_METAL_COMPUTE_SOURCE_HEAD_ROPE);
             if (encoder == nil) return -9;
         }
-        const int encode_rc = termite_metal_encode_head_rms_rope_on_encoder(runtime, encoder, input_buffer, input_offset, norm_slot, total_heads, head_dim, rope_dim, position, theta, freq_scale, eps, value_scale, consecutive_pairs, heads_per_row, output_buffer, 0, -9);
+        const int encode_rc = termite_metal_encode_head_rms_rope_on_encoder(runtime, encoder, input_buffer, input_offset, norm_slot, total_heads, head_dim, rope_dim, position, theta, freq_scale, eps, value_scale, consecutive_pairs, heads_per_row, 0, output_buffer, 0, -9);
         if (!planned_encoder) [encoder endEncoding];
         if (encode_rc != 0) return encode_rc;
         const int rc = termite_metal_decode_runtime_finish_command_buffer(command_buffer, frame_owned, -10);
@@ -13413,6 +13463,7 @@ static int termite_metal_encode_head_rms_rope_on_encoder(
     float value_scale,
     uint32_t consecutive_pairs,
     size_t heads_per_row,
+    size_t position_period,
     id<MTLBuffer> output_buffer,
     size_t output_offset,
     int failure_code
@@ -13421,7 +13472,7 @@ static int termite_metal_encode_head_rms_rope_on_encoder(
     if (runtime->head_rms_rope_pipeline == nil) return failure_code;
     if (norm_slot >= TERMITE_METAL_RMS_NORM_SLOT_CAPACITY || total_heads == 0 || head_dim == 0 || rope_dim == 0 || heads_per_row == 0) return failure_code;
     if (runtime->rms_norm_slot_prepared[norm_slot] == 0 || runtime->rms_norm_hidden_sizes[norm_slot] != head_dim) return failure_code;
-    if (total_heads > UINT32_MAX || head_dim > UINT32_MAX || rope_dim > UINT32_MAX || position > UINT32_MAX || heads_per_row > UINT32_MAX) return failure_code;
+    if (total_heads > UINT32_MAX || head_dim > UINT32_MAX || rope_dim > UINT32_MAX || position > UINT32_MAX || heads_per_row > UINT32_MAX || position_period > UINT32_MAX) return failure_code;
     size_t elems = 0;
     size_t bytes = 0;
     if (!termite_metal_size_mul(total_heads, head_dim, &elems) ||
@@ -13453,6 +13504,7 @@ static int termite_metal_encode_head_rms_rope_on_encoder(
         .value_scale = value_scale,
         .consecutive_pairs = consecutive_pairs,
         .heads_per_row = (uint32_t)heads_per_row,
+        .position_period = (uint32_t)position_period,
     };
     [encoder setComputePipelineState:runtime->head_rms_rope_pipeline];
     [encoder setBuffer:input_buffer offset:input_offset atIndex:0];
@@ -14664,13 +14716,13 @@ int termite_metal_decode_runtime_apply_prefill_quantized_setup_device(
 
         if (rc == 0) rc = termite_metal_planned_layer_cursor_before_op(&planned_cursor, TERMITE_METAL_PLAN_OP_DECODE_Q_HEAD_NORM_ROPE);
         if (rc == 0) {
-            rc = termite_metal_encode_head_rms_rope_on_encoder(runtime, encoder, q_projected_buffer, 0, q_norm_slot, rows * num_heads, head_dim, rope_dim, position, theta, freq_scale, 0.0f, query_value_scale, consecutive_pairs, num_heads, q_ready_buffer, 0, -27);
+            rc = termite_metal_encode_head_rms_rope_on_encoder(runtime, encoder, q_projected_buffer, 0, q_norm_slot, rows * num_heads, head_dim, rope_dim, position, theta, freq_scale, 0.0f, query_value_scale, consecutive_pairs, num_heads, 0, q_ready_buffer, 0, -27);
         }
         if (rc == 0) rc = termite_metal_planned_layer_cursor_fallback_barrier_after_op(&planned_cursor);
 
         if (rc == 0 && !shares_kv) rc = termite_metal_planned_layer_cursor_before_op(&planned_cursor, TERMITE_METAL_PLAN_OP_DECODE_K_HEAD_NORM_ROPE);
         if (rc == 0 && !shares_kv) {
-            rc = termite_metal_encode_head_rms_rope_on_encoder(runtime, encoder, k_projected_buffer, 0, k_norm_slot, rows * num_kv_heads, head_dim, rope_dim, position, theta, freq_scale, 0.0f, 1.0f, consecutive_pairs, num_kv_heads, k_ready_buffer, 0, -28);
+            rc = termite_metal_encode_head_rms_rope_on_encoder(runtime, encoder, k_projected_buffer, 0, k_norm_slot, rows * num_kv_heads, head_dim, rope_dim, position, theta, freq_scale, 0.0f, 1.0f, consecutive_pairs, num_kv_heads, 0, k_ready_buffer, 0, -28);
         }
         if (rc == 0 && !shares_kv) rc = termite_metal_planned_layer_cursor_fallback_barrier_after_op(&planned_cursor);
 

--- a/zig/pkg/termite/src/backends/metal_native_provider.zig
+++ b/zig/pkg/termite/src/backends/metal_native_provider.zig
@@ -93,6 +93,10 @@ pub const MetalNativeProvider = if (build_options.enable_metal) struct {
     }
 
     pub fn deinitOwned(self: *MetalNativeProvider) void {
+        metal_runtime.flushActiveFrame(self.raw_decode_runtime) catch {};
+        if (metal_runtime.hasActiveFrame(self.raw_decode_runtime)) {
+            metal_runtime.waitFrame(self.raw_decode_runtime) catch {};
+        }
         metal_runtime.resetGatheredSpans(self);
         for (0..decoder_runtime_linear_slot_capacity) |slot| metal_runtime.clearRawLinearSlot(self, slot);
         for (0..decoder_runtime_layer_norm_slot_capacity) |slot| {

--- a/zig/pkg/termite/src/backends/metal_runtime.zig
+++ b/zig/pkg/termite/src/backends/metal_runtime.zig
@@ -651,7 +651,7 @@ pub fn decoderRuntimePreparedSlotsMatchFamily(self: anytype, gpt_config: anytype
             return decoderRuntimeRmsNormSlotPrepared(self, decoder_bitnet_runtime.finalNormSlot(gpt_config.num_hidden_layers), gpt_config.hidden_size) and
                 decoderRuntimeLinearSlotPrepared(self, decoder_bitnet_runtime.finalLmHeadSlot(gpt_config.num_hidden_layers), gpt_config.hidden_size, gpt_config.vocab_size);
         },
-        .llama, .mistral, .qwen2, .gemma => {
+        .llama, .mistral, .qwen2, .qwen3, .gemma => {
             for (0..gpt_config.num_hidden_layers) |layer| {
                 const layer_head_dim = gpt_config.effectiveHeadDimForLayer(layer);
                 const layer_kv_heads = gpt_config.effectiveKVHeadsForLayer(layer);
@@ -735,7 +735,7 @@ pub fn supportsDecoderRuntimeConfig(gpt_config: anytype) bool {
     return switch (gpt_config.family) {
         .gpt2 => decoder_gpt_runtime.supportsConfig(gpt_config),
         .bitnet => decoder_bitnet_runtime.supportsConfig(gpt_config),
-        .llama, .mistral, .qwen2 => decoder_gated_runtime.supportsConfig(gpt_config),
+        .llama, .mistral, .qwen2, .qwen3 => decoder_gated_runtime.supportsConfig(gpt_config),
         // The Metal whole-model executor can still own text-only runs for
         // multimodal/PLE Gemma variants even when the deepest family-local
         // decoder-runtime fast path declines and falls back to the generic GPT
@@ -767,7 +767,7 @@ pub fn prepareDecodeRuntimeFamily(
             kv_tokens,
             configured_layer_count,
         ),
-        .llama, .mistral, .qwen2, .gemma => try decoder_gated_runtime.prepareDecodeRuntime(
+        .llama, .mistral, .qwen2, .qwen3, .gemma => try decoder_gated_runtime.prepareDecodeRuntime(
             cb,
             allocator,
             gpt_config,
@@ -1410,6 +1410,40 @@ pub fn decoderRuntimeApplyHeadRmsNormRope(self: anytype, request: anytype) !?Met
         request.eps,
         request.value_scale,
         if (request.consecutive_pairs) 1 else 0,
+        output.deviceHandle(),
+        output.deviceByteOffset(),
+    );
+    if (rc != 0) return null;
+    return output;
+}
+
+pub fn decoderRuntimeApplyHeadRmsNormRopeBatched(self: anytype, request: anytype, heads_per_row: usize, position_period: usize) !?MetalTensor {
+    const runtime = self.raw_decode_runtime orelse return null;
+    if (termite_metal_decode_runtime_ready(runtime) == 0) return null;
+    if (request.total_heads == 0 or request.head_dim == 0 or request.rope_dim == 0 or heads_per_row == 0 or position_period == 0) return null;
+    if (request.position > std.math.maxInt(u32) or heads_per_row > std.math.maxInt(u32) or position_period > std.math.maxInt(u32)) return null;
+    if (!request.input.isDevice()) return null;
+    const total_values = request.input.elemCount();
+    if (total_values != request.total_heads * request.head_dim) return null;
+
+    var output = try MetalTensor.deviceAllocate(runtime, total_values * @sizeOf(f32), .private, request.input.shape());
+    errdefer output.deinit();
+    const rc = termite_metal_decode_runtime_apply_head_rms_rope_batched_device(
+        runtime,
+        request.input.deviceHandle(),
+        request.input.deviceByteOffset(),
+        request.slot,
+        request.total_heads,
+        request.head_dim,
+        request.rope_dim,
+        request.position,
+        request.theta,
+        request.freq_scale,
+        request.eps,
+        request.value_scale,
+        if (request.consecutive_pairs) 1 else 0,
+        heads_per_row,
+        position_period,
         output.deviceHandle(),
         output.deviceByteOffset(),
     );
@@ -5634,6 +5668,25 @@ pub extern fn termite_metal_decode_runtime_apply_head_rms_rope_device(
     eps: f32,
     value_scale: f32,
     consecutive_pairs: u32,
+    output_handle: ?*anyopaque,
+    output_offset: usize,
+) c_int;
+pub extern fn termite_metal_decode_runtime_apply_head_rms_rope_batched_device(
+    runtime: ?*RawMetalDecodeRuntime,
+    input_handle: ?*anyopaque,
+    input_offset: usize,
+    norm_slot: usize,
+    total_heads: usize,
+    head_dim: usize,
+    rope_dim: usize,
+    position: usize,
+    theta: f32,
+    freq_scale: f32,
+    eps: f32,
+    value_scale: f32,
+    consecutive_pairs: u32,
+    heads_per_row: usize,
+    position_period: usize,
     output_handle: ?*anyopaque,
     output_offset: usize,
 ) c_int;

--- a/zig/pkg/termite/src/graph/backend_contracts.zig
+++ b/zig/pkg/termite/src/graph/backend_contracts.zig
@@ -894,7 +894,6 @@ pub const DecoderRuntimeGraphCommandPlanFrameRequest = struct {
     ple_vectors: ?CT = null,
     layers: []const DecoderRuntimeLayerSpec,
     output_hidden: *?CT,
-    output_embeddings: ?*?CT = null,
 };
 
 test "tensor storage classes classify host and device residency" {

--- a/zig/pkg/termite/src/graph/backend_contracts.zig
+++ b/zig/pkg/termite/src/graph/backend_contracts.zig
@@ -776,6 +776,7 @@ pub const DecoderRuntimePrepareReuseResult = struct {
 
 pub const DecoderRuntimeDecodeContract = enum(u8) {
     gemma4_gated_ple_shared_kv,
+    qwen3_dense_text_embedding,
 };
 
 pub const DecoderRuntimeDecodeMode = enum(u8) {
@@ -859,6 +860,8 @@ pub const DecoderRuntimePrefillFramePlanRequest = struct {
     contract: DecoderRuntimeDecodeContract,
     layer_count: usize,
     rows: usize,
+    batch: usize = 1,
+    seq_len: usize = 0,
     hidden_size: usize,
     vocab_size: usize,
     num_attention_heads: usize,
@@ -874,11 +877,14 @@ pub const DecoderRuntimeGraphCommandPlanFrameRequest = struct {
     contract: DecoderRuntimeDecodeContract,
     layer_count: usize,
     rows: usize,
+    batch: usize = 1,
+    seq_len: usize = 0,
     hidden_size: usize,
     vocab_size: usize,
     num_attention_heads: usize,
     global_head_dim: usize,
     ple_hidden_size: usize,
+    final_norm_slot: usize = 0,
     norm_eps: f32,
     rope_freq_scale: f32,
     rope_consecutive_pairs: bool,
@@ -888,6 +894,7 @@ pub const DecoderRuntimeGraphCommandPlanFrameRequest = struct {
     ple_vectors: ?CT = null,
     layers: []const DecoderRuntimeLayerSpec,
     output_hidden: *?CT,
+    output_embeddings: ?*?CT = null,
 };
 
 test "tensor storage classes classify host and device residency" {

--- a/zig/pkg/termite/src/graph/metal_command_planner.zig
+++ b/zig/pkg/termite/src/graph/metal_command_planner.zig
@@ -577,6 +577,8 @@ pub const GatedFramePlanCursor = struct {
         options: struct {
             shares_kv: bool,
             value_norm: bool,
+            kv_seed: bool = true,
+            include_ple: bool = true,
         },
     ) ?GatedFrameLayerWindow {
         const layer_start = self.next_index;
@@ -589,7 +591,7 @@ pub const GatedFramePlanCursor = struct {
         if (!options.shares_kv) {
             if (!self.consume(&index, .k_head_norm_rope)) return null;
             if (options.value_norm and !self.consume(&index, .v_norm)) return null;
-            if (!self.consume(&index, .kv_seed)) return null;
+            if (options.kv_seed and !self.consume(&index, .kv_seed)) return null;
         }
         const block_start = index;
 
@@ -600,9 +602,11 @@ pub const GatedFramePlanCursor = struct {
         if (!self.consume(&index, .ffn_gate_up_activation)) return null;
         if (!self.consume(&index, .ffn_down_linear)) return null;
         if (!self.consume(&index, .ffn_post_norm_residual)) return null;
-        if (!self.consume(&index, .ple_gate_activation)) return null;
-        if (!self.consume(&index, .ple_projection)) return null;
-        if (!self.consume(&index, .ple_post_norm_residual)) return null;
+        if (options.include_ple) {
+            if (!self.consume(&index, .ple_gate_activation)) return null;
+            if (!self.consume(&index, .ple_projection)) return null;
+            if (!self.consume(&index, .ple_post_norm_residual)) return null;
+        }
 
         self.next_index = index;
         return .{
@@ -1133,9 +1137,10 @@ pub const GatedLayerCommandLowerer = struct {
         up_linear_slot: usize,
         down_linear_slot: usize,
         ffn_post_norm_slot: usize,
-        ple_gate_linear_slot: usize,
-        ple_proj_linear_slot: usize,
-        ple_post_norm_slot: usize,
+        include_ple: bool = true,
+        ple_gate_linear_slot: usize = 0,
+        ple_proj_linear_slot: usize = 0,
+        ple_post_norm_slot: usize = 0,
         source: usize,
         region: usize,
         rows: usize = 1,
@@ -1275,8 +1280,8 @@ pub const GatedLayerCommandLowerer = struct {
         const attn_output_op = quantOp(options.quant_formats.attention_output, rows, options.attention_input_size, options.hidden_size);
         const ffn_gate_op = quantOp(options.quant_formats.gate, rows, options.hidden_size, options.intermediate_size);
         const ffn_down_op = quantOp(options.quant_formats.down, rows, options.intermediate_size, options.hidden_size);
-        const ple_gate_op = quantOp(options.quant_formats.ple_gate, rows, options.hidden_size, options.ple_hidden_size);
-        const ple_projection_op = quantOp(options.quant_formats.ple_projection, rows, options.ple_hidden_size, options.hidden_size);
+        const ple_gate_op = if (options.include_ple) quantOp(options.quant_formats.ple_gate, rows, options.hidden_size, options.ple_hidden_size) else quantOp(.unknown, rows, options.hidden_size, options.ple_hidden_size);
+        const ple_projection_op = if (options.include_ple) quantOp(options.quant_formats.ple_projection, rows, options.ple_hidden_size, options.hidden_size) else quantOp(.unknown, rows, options.ple_hidden_size, options.hidden_size);
         const attention_kv_len = if (options.kv_len != 0) options.kv_len else rows;
         const attention_plan = quant_matmul.attentionPlanWithStorage(rows, attention_kv_len, options.head_dim, options.attention_kv_format, options.attention_storage);
         self.ops[self.op_count] = .{
@@ -1343,26 +1348,28 @@ pub const GatedLayerCommandLowerer = struct {
         self.op_count += 1;
         self.ops[self.op_count] = .{ .kind = .ffn_post_norm_residual, .source = options.source, .region = options.region, .resources = &self.ffn_post_resources };
         self.op_count += 1;
-        self.ops[self.op_count] = .{
-            .kind = .ple_gate_activation,
-            .source = options.source,
-            .region = options.region,
-            .resources = &self.ple_gate_resources,
-            .quant_matmul = ple_gate_op.quant_matmul,
-            .operator_plan = ple_gate_op.operator_plan,
-        };
-        self.op_count += 1;
-        self.ops[self.op_count] = .{
-            .kind = .ple_projection,
-            .source = options.source,
-            .region = options.region,
-            .resources = &self.ple_proj_resources,
-            .quant_matmul = ple_projection_op.quant_matmul,
-            .operator_plan = ple_projection_op.operator_plan,
-        };
-        self.op_count += 1;
-        self.ops[self.op_count] = .{ .kind = .ple_post_norm_residual, .source = options.source, .region = options.region, .resources = &self.ple_post_resources };
-        self.op_count += 1;
+        if (options.include_ple) {
+            self.ops[self.op_count] = .{
+                .kind = .ple_gate_activation,
+                .source = options.source,
+                .region = options.region,
+                .resources = &self.ple_gate_resources,
+                .quant_matmul = ple_gate_op.quant_matmul,
+                .operator_plan = ple_gate_op.operator_plan,
+            };
+            self.op_count += 1;
+            self.ops[self.op_count] = .{
+                .kind = .ple_projection,
+                .source = options.source,
+                .region = options.region,
+                .resources = &self.ple_proj_resources,
+                .quant_matmul = ple_projection_op.quant_matmul,
+                .operator_plan = ple_projection_op.operator_plan,
+            };
+            self.op_count += 1;
+            self.ops[self.op_count] = .{ .kind = .ple_post_norm_residual, .source = options.source, .region = options.region, .resources = &self.ple_post_resources };
+            self.op_count += 1;
+        }
 
         const ffn_gated_dtype = resolveFfnActivationDType(
             options.activation_dtype,
@@ -1386,9 +1393,11 @@ pub const GatedLayerCommandLowerer = struct {
         self.addScratchSize(@intFromEnum(Resource.ffn_gated), rows * options.intermediate_size * ffn_gated_dtype.byteSize(), ffn_gated_dtype);
         self.addScratchSize(@intFromEnum(Resource.ffn_projected), rows * options.hidden_size * @sizeOf(f32), .f32);
         self.addScratchSize(@intFromEnum(Resource.ffn_output), rows * options.hidden_size * @sizeOf(f32), .f32);
-        self.addScratchSize(@intFromEnum(Resource.ple_input), rows * options.ple_hidden_size * @sizeOf(f32), .f32);
-        self.addScratchSize(@intFromEnum(Resource.ple_gated), rows * options.ple_hidden_size * @sizeOf(f32), .f32);
-        self.addScratchSize(@intFromEnum(Resource.ple_projected), rows * options.hidden_size * @sizeOf(f32), .f32);
+        if (options.include_ple) {
+            self.addScratchSize(@intFromEnum(Resource.ple_input), rows * options.ple_hidden_size * @sizeOf(f32), .f32);
+            self.addScratchSize(@intFromEnum(Resource.ple_gated), rows * options.ple_hidden_size * @sizeOf(f32), .f32);
+            self.addScratchSize(@intFromEnum(Resource.ple_projected), rows * options.hidden_size * @sizeOf(f32), .f32);
+        }
 
         self.command_view = try self.command_storage.build(self.ops[0..self.op_count], .{}, self.scratch_sizes[0..self.scratch_size_count]);
         self.plan_view = self.command_view.planView();
@@ -1613,9 +1622,10 @@ pub const GatedFrameCommandLowerer = struct {
         for (options.layers) |layer| {
             const attention_input_size = std.math.mul(usize, options.num_attention_heads, layer.head_dim) catch return error.InvalidPrefillFrame;
             const kv_dim = std.math.mul(usize, layer.kv_heads, layer.head_dim) catch return error.InvalidPrefillFrame;
-            const ple_gate_slot = layer.ple_gate_linear_slot orelse return error.UnsupportedPrefillFrame;
-            const ple_proj_slot = layer.ple_proj_linear_slot orelse return error.UnsupportedPrefillFrame;
-            const ple_post_slot = layer.ple_post_norm_slot orelse return error.UnsupportedPrefillFrame;
+            const include_ple = options.ple_hidden_size != 0;
+            const ple_gate_slot = if (include_ple) layer.ple_gate_linear_slot orelse return error.UnsupportedPrefillFrame else 0;
+            const ple_proj_slot = if (include_ple) layer.ple_proj_linear_slot orelse return error.UnsupportedPrefillFrame else 0;
+            const ple_post_slot = if (include_ple) layer.ple_post_norm_slot orelse return error.UnsupportedPrefillFrame else 0;
             var layer_plan = PrefillGatedLayerCommandLowerer{};
             try layer_plan.build(.{
                 .shares_kv = layer.shares_kv,
@@ -1628,7 +1638,7 @@ pub const GatedFrameCommandLowerer = struct {
                 .k_head_norm_slot = layer.k_head_norm_slot orelse 0,
                 .attention_layer_index = layer.kv_layer_index,
                 .value_norm = options.global_head_dim != 0 and !layer.shares_kv,
-                .kv_seed = !layer.shares_kv,
+                .kv_seed = options.attention_storage == .paged and !layer.shares_kv,
                 .quant_formats = layer.quant_formats,
                 .activation_dtype = frame_descriptor.activation_dtype,
                 .attention_linear_slot = layer.attention_linear_slot,
@@ -1638,6 +1648,7 @@ pub const GatedFrameCommandLowerer = struct {
                 .up_linear_slot = layer.up_linear_slot,
                 .down_linear_slot = layer.down_linear_slot,
                 .ffn_post_norm_slot = layer.ffn_post_norm_slot,
+                .include_ple = include_ple,
                 .ple_gate_linear_slot = ple_gate_slot,
                 .ple_proj_linear_slot = ple_proj_slot,
                 .ple_post_norm_slot = ple_post_slot,

--- a/zig/pkg/termite/src/models/gpt.zig
+++ b/zig/pkg/termite/src/models/gpt.zig
@@ -1224,6 +1224,7 @@ fn detectFamily(model_type: []const u8) ModelFamily {
         .{ "qwen2_vl", ModelFamily.qwen2 },
         .{ "colqwen2", ModelFamily.qwen2 },
         .{ "qwen3", ModelFamily.qwen3 },
+        .{ "jina_embeddings_v5", ModelFamily.qwen3 },
         .{ "qwen3_5", ModelFamily.qwen3_5 },
         .{ "qwen3_5_text", ModelFamily.qwen3_5 },
         .{ "deepseek_v4", ModelFamily.deepseek_v4 },
@@ -1341,6 +1342,7 @@ fn applyFamilyDefaults(config: *Config) void {
 
 /// Detect if a model_type string is a decoder-only generative model.
 pub fn isGenerativeModel(model_type: []const u8) bool {
+    if (std.mem.eql(u8, model_type, "jina_embeddings_v5")) return false;
     return detectFamily(model_type) != .other;
 }
 
@@ -1523,6 +1525,36 @@ test "parse mistral config" {
     try std.testing.expectEqual(ModelFamily.mistral, config.family);
     try std.testing.expectEqual(@as(u32, 8), config.effectiveKVHeads());
     try std.testing.expectEqual(PositionEncoding.rope, config.position_encoding);
+}
+
+test "parse jina embeddings v5 config as qwen3 backbone" {
+    const allocator = std.testing.allocator;
+    const json =
+        \\{
+        \\  "model_type": "jina_embeddings_v5",
+        \\  "hidden_size": 1024,
+        \\  "num_hidden_layers": 28,
+        \\  "num_attention_heads": 16,
+        \\  "num_key_value_heads": 8,
+        \\  "head_dim": 128,
+        \\  "intermediate_size": 3072,
+        \\  "max_position_embeddings": 32768,
+        \\  "rms_norm_eps": 1e-06,
+        \\  "rope_theta": 3500000,
+        \\  "tie_word_embeddings": true,
+        \\  "vocab_size": 151936
+        \\}
+    ;
+    const config = try parseConfig(allocator, json);
+    try std.testing.expectEqual(ModelFamily.qwen3, config.family);
+    try std.testing.expectEqual(@as(u32, 1024), config.hidden_size);
+    try std.testing.expectEqual(@as(u32, 28), config.num_hidden_layers);
+    try std.testing.expectEqual(@as(u32, 8), config.effectiveKVHeads());
+    try std.testing.expectEqual(@as(u32, 128), config.headDim());
+    try std.testing.expectEqual(NormType.rms_norm, config.norm_type);
+    try std.testing.expectEqual(PositionEncoding.rope, config.position_encoding);
+    try std.testing.expectApproxEqAbs(@as(f32, 3_500_000.0), config.rope_theta, 1.0);
+    try std.testing.expect(config.weight_tying);
 }
 
 test "parse gemma3 multimodal config" {
@@ -1893,6 +1925,7 @@ test "isGenerativeModel" {
     try std.testing.expect(isGenerativeModel("bitnet-b1.58"));
     try std.testing.expect(isGenerativeModel("deepseek_v4"));
     try std.testing.expect(isGenerativeModel("deepseek-v4-flash"));
+    try std.testing.expect(!isGenerativeModel("jina_embeddings_v5"));
     try std.testing.expect(!isGenerativeModel("bert"));
     try std.testing.expect(!isGenerativeModel("t5"));
 }

--- a/zig/pkg/termite/src/models/manifest.zig
+++ b/zig/pkg/termite/src/models/manifest.zig
@@ -91,6 +91,7 @@ pub const PoolingStrategy = enum {
     mean,
     cls,
     max,
+    last,
 };
 
 pub const Sparse3DOutputLayout = enum {
@@ -162,6 +163,7 @@ pub const ModelManifest = struct {
     // Pipeline config
     pooling: PoolingStrategy = .mean,
     normalize: bool = true,
+    embedding_text_prefix: []const u8 = "",
     sparse_3d_output_layout: ?Sparse3DOutputLayout = null,
     native_arch_hint: NativeArchHint = .none,
 
@@ -229,6 +231,7 @@ pub const ModelManifest = struct {
             self.allocator.free(labels);
         }
         if (self.chat_template) |t| self.allocator.free(t);
+        if (self.embedding_text_prefix.len > 0) self.allocator.free(self.embedding_text_prefix);
         if (self.gliner_model_type.len > 0) self.allocator.free(self.gliner_model_type);
         if (self.config_model_arch.len > 0) self.allocator.free(self.config_model_arch);
         if (self.gliner_default_labels.len > 0) {
@@ -867,6 +870,7 @@ fn parseConfigJson(manifest: *ModelManifest, allocator: std.mem.Allocator, json_
     defer parsed.deinit();
 
     const obj = parsed.value.object;
+    const jina_v5_embedding_config = isJinaV5TextEmbeddingConfig(&obj);
 
     if (obj.get("hidden_size")) |v| {
         if (jsonU32(v)) |val| manifest.hidden_size = val;
@@ -966,8 +970,18 @@ fn parseConfigJson(manifest: *ModelManifest, allocator: std.mem.Allocator, json_
             } else if (std.mem.eql(u8, s, "layoutlmv3")) {
                 manifest.native_arch_hint = .layoutlmv3;
                 if (manifest.model_type == .embedder) manifest.model_type = .classifier;
+            } else if (std.mem.eql(u8, s, "jina_embeddings_v5")) {
+                manifest.model_type = .embedder;
             }
         }
+    }
+
+    if (jina_v5_embedding_config) {
+        manifest.model_type = .embedder;
+        manifest.pooling = .last;
+        manifest.normalize = true;
+        if (manifest.embedding_text_prefix.len > 0) allocator.free(manifest.embedding_text_prefix);
+        manifest.embedding_text_prefix = try allocator.dupe(u8, "Document: ");
     }
 
     // For CLIP/CLAP/multimodal models, text_config contains the text encoder's
@@ -980,6 +994,32 @@ fn parseConfigJson(manifest: *ModelManifest, allocator: std.mem.Allocator, json_
             }
         }
     }
+}
+
+fn jsonStringArrayContains(value: std.json.Value, needle: []const u8) bool {
+    if (value != .array) return false;
+    for (value.array.items) |item| {
+        if (item == .string and std.mem.eql(u8, item.string, needle)) return true;
+    }
+    return false;
+}
+
+fn isJinaV5TextEmbeddingConfig(obj: *const std.json.ObjectMap) bool {
+    if (obj.get("model_type")) |v| {
+        if (v == .string and std.mem.eql(u8, v.string, "jina_embeddings_v5")) return true;
+    }
+
+    const task_names = obj.get("task_names") orelse return false;
+    if (!jsonStringArrayContains(task_names, "retrieval") or
+        !jsonStringArrayContains(task_names, "text-matching") or
+        !jsonStringArrayContains(task_names, "clustering"))
+    {
+        return false;
+    }
+
+    const arch = obj.get("architectures") orelse return false;
+    return jsonStringArrayContains(arch, "Qwen3Model") or
+        jsonStringArrayContains(arch, "JinaEmbeddingsV5Model");
 }
 
 fn parseModelManifestJson(manifest: *ModelManifest, allocator: std.mem.Allocator, json_bytes: []const u8) !void {
@@ -1482,6 +1522,52 @@ test "manifest from config.json" {
     try std.testing.expectEqual(@as(u32, 6), manifest.num_hidden_layers);
     try std.testing.expectEqual(bert.ModelType.bert, manifest.bert_model_type);
     try std.testing.expectEqualStrings("bert", manifest.config_model_arch);
+}
+
+test "manifest treats jina embeddings v5 as qwen3 embedder with last pooling" {
+    const allocator = std.testing.allocator;
+    var manifest = ModelManifest{ .allocator = allocator };
+    defer manifest.deinit();
+
+    const config_json =
+        \\{
+        \\  "architectures": ["JinaEmbeddingsV5Model"],
+        \\  "task_names": ["retrieval", "text-matching", "clustering", "classification"],
+        \\  "model_type": "jina_embeddings_v5",
+        \\  "hidden_size": 1024,
+        \\  "max_position_embeddings": 32768,
+        \\  "num_hidden_layers": 28,
+        \\  "num_attention_heads": 16
+        \\}
+    ;
+    try parseConfigJson(&manifest, allocator, config_json);
+
+    try std.testing.expectEqual(ModelType.embedder, manifest.model_type);
+    try std.testing.expectEqual(PoolingStrategy.last, manifest.pooling);
+    try std.testing.expect(manifest.normalize);
+    try std.testing.expectEqualStrings("Document: ", manifest.embedding_text_prefix);
+    try std.testing.expectEqualStrings("jina_embeddings_v5", manifest.config_model_arch);
+    try std.testing.expectEqual(@as(u32, 32768), manifest.max_position_embeddings);
+}
+
+test "manifest treats merged jina qwen3 task repo as embedder" {
+    const allocator = std.testing.allocator;
+    var manifest = ModelManifest{ .allocator = allocator };
+    defer manifest.deinit();
+
+    const config_json =
+        \\{
+        \\  "architectures": ["Qwen3Model"],
+        \\  "task_names": ["retrieval", "text-matching", "clustering", "classification"],
+        \\  "model_type": "qwen3",
+        \\  "hidden_size": 1024
+        \\}
+    ;
+    try parseConfigJson(&manifest, allocator, config_json);
+
+    try std.testing.expectEqual(ModelType.embedder, manifest.model_type);
+    try std.testing.expectEqual(PoolingStrategy.last, manifest.pooling);
+    try std.testing.expectEqualStrings("Document: ", manifest.embedding_text_prefix);
 }
 
 test "load sparse fixture preserves max position embeddings" {

--- a/zig/pkg/termite/src/ops/gpu_hosted_store.zig
+++ b/zig/pkg/termite/src/ops/gpu_hosted_store.zig
@@ -17,6 +17,7 @@ const build_options = @import("build_options");
 const runtime = @import("../runtime/root.zig");
 const tensor_store_mod = @import("../models/tensor_store.zig");
 const weight_source_mod = @import("../models/weight_source.zig");
+const safetensors_mod = @import("../models/safetensors.zig");
 const tier_planner = runtime.tier.planner;
 const tier_cache_mod = runtime.tier.cache;
 const prefetch_mod = runtime.tier.prefetch;
@@ -45,6 +46,8 @@ const mlx_quant = if (build_options.enable_mlx) @import("../backends/mlx_quant.z
 
 const c = mlx.c;
 const QuantizedStorage = weight_source_mod.QuantizedStorage;
+const LoadedWeight = weight_source_mod.LoadedWeight;
+const Tensor = @import("../backends/tensor.zig").Tensor;
 const ExpertCoord = moe_residency.ExpertCoord;
 const ResidencyTier = tier_planner.ResidencyTier;
 const PlacementPlan = tier_planner.PlacementPlan;
@@ -96,6 +99,128 @@ pub const LazyWeightEntry = struct {
 
 pub const PrefetchQueue = prefetch_mod.Queue(*LazyWeightEntry);
 
+pub const JinaLoraAdapter = struct {
+    allocator: std.mem.Allocator,
+    reader: safetensors_mod.MMapReader,
+    scale: f32,
+
+    pub fn create(allocator: std.mem.Allocator, adapter_weights_path: []const u8, scale: f32) !*JinaLoraAdapter {
+        const self = try allocator.create(JinaLoraAdapter);
+        errdefer allocator.destroy(self);
+        self.* = .{
+            .allocator = allocator,
+            .reader = try safetensors_mod.MMapReader.openFileAbsolute(allocator, adapter_weights_path),
+            .scale = scale,
+        };
+        return self;
+    }
+
+    pub fn destroy(self: *JinaLoraAdapter) void {
+        const allocator = self.allocator;
+        self.reader.deinit();
+        allocator.destroy(self);
+    }
+
+    pub fn mergeIntoLoadedWeight(self: *const JinaLoraAdapter, base_name: []const u8, loaded: *LoadedWeight) !void {
+        if (!std.mem.endsWith(u8, base_name, ".weight")) return;
+
+        const adapter_a_name = try jinaAdapterANameForBaseWeight(self.allocator, base_name);
+        defer self.allocator.free(adapter_a_name);
+        if (!self.reader.header.tensors.contains(adapter_a_name)) return;
+
+        const adapter_b_name = try jinaAdapterBNameForAdapterA(self.allocator, adapter_a_name);
+        defer self.allocator.free(adapter_b_name);
+        if (!self.reader.header.tensors.contains(adapter_b_name)) return error.IncompleteJinaV5Adapter;
+
+        try ensureLoadedWeightIsOwnedF32(self.allocator, loaded);
+
+        var adapter_a = try readSafetensorAsF32(self.allocator, &self.reader, adapter_a_name);
+        defer adapter_a.deinit();
+        var adapter_b = try readSafetensorAsF32(self.allocator, &self.reader, adapter_b_name);
+        defer adapter_b.deinit();
+
+        try mergeLoraPairIntoWeight(loaded, adapter_a.tensor, adapter_b.tensor, self.scale);
+    }
+};
+
+fn jinaAdapterANameForBaseWeight(allocator: std.mem.Allocator, base_name: []const u8) ![]const u8 {
+    const suffix = ".weight";
+    if (!std.mem.endsWith(u8, base_name, suffix)) return error.InvalidAdapterTensorName;
+    return try std.fmt.allocPrint(allocator, "base_model.model.{s}.lora_A.weight", .{base_name[0 .. base_name.len - suffix.len]});
+}
+
+fn jinaAdapterBNameForAdapterA(allocator: std.mem.Allocator, adapter_a_name: []const u8) ![]const u8 {
+    const suffix = ".lora_A.weight";
+    if (!std.mem.endsWith(u8, adapter_a_name, suffix)) return error.InvalidAdapterTensorName;
+    return try std.fmt.allocPrint(allocator, "{s}.lora_B.weight", .{adapter_a_name[0 .. adapter_a_name.len - suffix.len]});
+}
+
+fn readSafetensorAsF32(
+    allocator: std.mem.Allocator,
+    reader: *const safetensors_mod.MMapReader,
+    name: []const u8,
+) !LoadedWeight {
+    var tensor = try reader.readTensor(name);
+    if (tensor.dtype == .f16 or tensor.dtype == .bf16) {
+        const converted = try weight_source_mod.convertToF32(allocator, &tensor);
+        tensor.deinit();
+        tensor = converted;
+    } else if (tensor.dtype == .f32 and !tensor.owns_data) {
+        const converted = try Tensor.initFloat32(allocator, tensor.name, tensor.shape, tensor.asFloat32());
+        tensor.deinit();
+        tensor = converted;
+    }
+    if (tensor.dtype != .f32) {
+        tensor.deinit();
+        return error.UnsupportedAdapterTensorType;
+    }
+    return .{ .tensor = tensor, .quantized = false };
+}
+
+fn ensureLoadedWeightIsOwnedF32(allocator: std.mem.Allocator, loaded: *LoadedWeight) !void {
+    if (loaded.quantized_storage) |*storage| {
+        storage.deinit();
+        loaded.quantized_storage = null;
+        loaded.quantized = false;
+    }
+
+    if (loaded.tensor.dtype == .f32 and loaded.tensor.owns_data) return;
+
+    const converted = switch (loaded.tensor.dtype) {
+        .f16, .bf16 => try weight_source_mod.convertToF32(allocator, &loaded.tensor),
+        .f32 => try Tensor.initFloat32(allocator, loaded.tensor.name, loaded.tensor.shape, loaded.tensor.asFloat32()),
+        else => return error.UnsupportedJinaV5AdapterBaseWeight,
+    };
+    loaded.tensor.deinit();
+    loaded.tensor = converted;
+}
+
+fn mergeLoraPairIntoWeight(base_weight: *LoadedWeight, adapter_a: Tensor, adapter_b: Tensor, scale: f32) !void {
+    if (base_weight.quantized or base_weight.tensor.dtype != .f32) return error.UnsupportedJinaV5AdapterBaseWeight;
+    if (base_weight.tensor.shape.len != 2 or adapter_a.shape.len != 2 or adapter_b.shape.len != 2) return error.InvalidAdapterTensorShape;
+
+    const out_dim: usize = @intCast(base_weight.tensor.shape[0]);
+    const in_dim: usize = @intCast(base_weight.tensor.shape[1]);
+    const rank: usize = @intCast(adapter_a.shape[0]);
+    if (rank == 0) return error.InvalidAdapterTensorShape;
+    if (@as(usize, @intCast(adapter_a.shape[1])) != in_dim) return error.AdapterInputDimMismatch;
+    if (@as(usize, @intCast(adapter_b.shape[0])) != out_dim) return error.AdapterOutputDimMismatch;
+    if (@as(usize, @intCast(adapter_b.shape[1])) != rank) return error.AdapterRankMismatch;
+
+    const base = base_weight.tensor.asFloat32Mut();
+    const a = adapter_a.asFloat32();
+    const b = adapter_b.asFloat32();
+    for (0..out_dim) |out_idx| {
+        for (0..in_dim) |in_idx| {
+            var sum: f32 = 0.0;
+            for (0..rank) |r| {
+                sum += b[out_idx * rank + r] * a[r * in_dim + in_idx];
+            }
+            base[out_idx * in_dim + in_idx] += sum * scale;
+        }
+    }
+}
+
 pub const WeightStore = struct {
     allocator: std.mem.Allocator,
     resident_weights: if (build_options.enable_mlx) c.mlx_map_string_to_array else void,
@@ -126,6 +251,7 @@ pub const WeightStore = struct {
         if (supports_native_metal_provider) null else {},
     shared_metal_native_provider_lock: if (supports_native_metal_provider) std.Io.Mutex else void =
         if (supports_native_metal_provider) .init else {},
+    jina_lora_adapter: ?*JinaLoraAdapter = null,
 };
 
 pub fn touchLazyWeight(data: *WeightStore, entry: *LazyWeightEntry) void {
@@ -222,9 +348,149 @@ pub fn ensureHostLazyWeightLoadedSimple(data: *WeightStore, entry: *LazyWeightEn
         entry.host_loaded.?.quantized_storage = null;
         entry.host_loaded.?.quantized = false;
     }
+    if (data.jina_lora_adapter) |adapter| {
+        try adapter.mergeIntoLoadedWeight(entry.tensor_ref.name, &entry.host_loaded.?);
+    }
     entry.loaded_bytes = entry.host_loaded.?.tensor.data.len;
     entry.active_tier = if (entry.loaded_bytes == 0) .disk else .host;
     if (entry.loaded_bytes != 0) {
         if (data.tier_cache) |*tier_cache| tier_cache.noteResident(.host, entry.loaded_bytes);
     }
+}
+
+test "jina adapter names map base weight to PEFT LoRA tensors" {
+    const allocator = std.testing.allocator;
+    const adapter_a = try jinaAdapterANameForBaseWeight(allocator, "layers.0.self_attn.q_proj.weight");
+    defer allocator.free(adapter_a);
+    try std.testing.expectEqualStrings("base_model.model.layers.0.self_attn.q_proj.lora_A.weight", adapter_a);
+
+    const adapter_b = try jinaAdapterBNameForAdapterA(allocator, adapter_a);
+    defer allocator.free(adapter_b);
+    try std.testing.expectEqualStrings("base_model.model.layers.0.self_attn.q_proj.lora_B.weight", adapter_b);
+}
+
+test "jina adapter merge ignores non-weight tensor names" {
+    const allocator = std.testing.allocator;
+    const adapter_path = try std.fmt.allocPrint(allocator, "/tmp/termite_jina_lora_empty_{d}.safetensors", .{std.posix.system.getpid()});
+    defer allocator.free(adapter_path);
+    defer std.Io.Dir.deleteFileAbsolute(std.testing.io, adapter_path) catch {};
+
+    const raw_header = "{}";
+    const header_len = std.mem.alignForward(usize, raw_header.len, 8);
+    const file_bytes = try allocator.alloc(u8, 8 + header_len);
+    defer allocator.free(file_bytes);
+    std.mem.writeInt(u64, file_bytes[0..8], header_len, .little);
+    @memcpy(file_bytes[8 .. 8 + raw_header.len], raw_header);
+    @memset(file_bytes[8 + raw_header.len ..], ' ');
+    {
+        var file = try std.Io.Dir.createFileAbsolute(std.testing.io, adapter_path, .{ .truncate = true });
+        defer file.close(std.testing.io);
+        try file.writeStreamingAll(std.testing.io, file_bytes);
+    }
+
+    var adapter = try JinaLoraAdapter.create(allocator, adapter_path, 1.0);
+    defer adapter.destroy();
+
+    const shape = [_]i64{1};
+    const values = [_]f32{42.0};
+    var base_weight = LoadedWeight{
+        .tensor = try Tensor.initFloat32(allocator, "rotary_emb.inv_freq", &shape, &values),
+    };
+    defer base_weight.deinit();
+
+    try adapter.mergeIntoLoadedWeight("rotary_emb.inv_freq", &base_weight);
+    try std.testing.expectEqual(@as(f32, 42.0), base_weight.tensor.asFloat32()[0]);
+}
+
+test "gpu hosted jina lora merge applies scaled adapter update" {
+    const allocator = std.testing.allocator;
+    const base_shape = [_]i64{ 2, 3 };
+    const a_shape = [_]i64{ 2, 3 };
+    const b_shape = [_]i64{ 2, 2 };
+    const base_values = [_]f32{
+        1.0, 2.0, 3.0,
+        4.0, 5.0, 6.0,
+    };
+    const a_values = [_]f32{
+        1.0, 0.0, 2.0,
+        0.0, 3.0, 1.0,
+    };
+    const b_values = [_]f32{
+        2.0, 1.0,
+        0.0, 4.0,
+    };
+
+    var base_weight = LoadedWeight{
+        .tensor = try Tensor.initFloat32(allocator, "base", &base_shape, &base_values),
+    };
+    defer base_weight.deinit();
+    var adapter_a = try Tensor.initFloat32(allocator, "a", &a_shape, &a_values);
+    defer adapter_a.deinit();
+    var adapter_b = try Tensor.initFloat32(allocator, "b", &b_shape, &b_values);
+    defer adapter_b.deinit();
+
+    try mergeLoraPairIntoWeight(&base_weight, adapter_a, adapter_b, 0.5);
+
+    try std.testing.expectEqualSlices(f32, &.{
+        2.0, 3.5,  5.5,
+        4.0, 11.0, 8.0,
+    }, base_weight.tensor.asFloat32());
+}
+
+test "jina lora adapter merges matching safetensors sidecar into loaded base weight" {
+    const allocator = std.testing.allocator;
+    const adapter_path = try std.fmt.allocPrint(allocator, "/tmp/termite_jina_lora_adapter_{d}.safetensors", .{std.posix.system.getpid()});
+    defer allocator.free(adapter_path);
+    defer std.Io.Dir.deleteFileAbsolute(std.testing.io, adapter_path) catch {};
+
+    const a_values = [_]f32{
+        1.0, 0.0, 2.0,
+        0.0, 3.0, 1.0,
+    };
+    const b_values = [_]f32{
+        2.0, 1.0,
+        0.0, 4.0,
+    };
+    const a_bytes = std.mem.sliceAsBytes(&a_values);
+    const b_bytes = std.mem.sliceAsBytes(&b_values);
+    const raw_header = try std.fmt.allocPrint(
+        allocator,
+        "{{\"base_model.model.layers.0.self_attn.q_proj.lora_A.weight\":{{\"dtype\":\"F32\",\"shape\":[2,3],\"data_offsets\":[0,{d}]}},\"base_model.model.layers.0.self_attn.q_proj.lora_B.weight\":{{\"dtype\":\"F32\",\"shape\":[2,2],\"data_offsets\":[{d},{d}]}}}}",
+        .{ a_bytes.len, a_bytes.len, a_bytes.len + b_bytes.len },
+    );
+    defer allocator.free(raw_header);
+    const header_len = std.mem.alignForward(usize, raw_header.len, 8);
+    const file_bytes = try allocator.alloc(u8, 8 + header_len + a_bytes.len + b_bytes.len);
+    defer allocator.free(file_bytes);
+    std.mem.writeInt(u64, file_bytes[0..8], header_len, .little);
+    @memcpy(file_bytes[8 .. 8 + raw_header.len], raw_header);
+    @memset(file_bytes[8 + raw_header.len .. 8 + header_len], ' ');
+    @memcpy(file_bytes[8 + header_len .. 8 + header_len + a_bytes.len], a_bytes);
+    @memcpy(file_bytes[8 + header_len + a_bytes.len ..], b_bytes);
+
+    {
+        var file = try std.Io.Dir.createFileAbsolute(std.testing.io, adapter_path, .{ .truncate = true });
+        defer file.close(std.testing.io);
+        try file.writeStreamingAll(std.testing.io, file_bytes);
+    }
+
+    var adapter = try JinaLoraAdapter.create(allocator, adapter_path, 0.5);
+    defer adapter.destroy();
+
+    const base_shape = [_]i64{ 2, 3 };
+    const base_values = [_]f32{
+        1.0, 2.0, 3.0,
+        4.0, 5.0, 6.0,
+    };
+    var base_weight = LoadedWeight{
+        .tensor = try Tensor.initFloat32(allocator, "layers.0.self_attn.q_proj.weight", &base_shape, &base_values),
+    };
+    defer base_weight.deinit();
+
+    try adapter.mergeIntoLoadedWeight("layers.0.self_attn.q_proj.weight", &base_weight);
+
+    try std.testing.expectEqualSlices(f32, &.{
+        2.0, 3.5,  5.5,
+        4.0, 11.0, 8.0,
+    }, base_weight.tensor.asFloat32());
 }

--- a/zig/pkg/termite/src/ops/gpu_hosted_store.zig
+++ b/zig/pkg/termite/src/ops/gpu_hosted_store.zig
@@ -18,6 +18,7 @@ const runtime = @import("../runtime/root.zig");
 const tensor_store_mod = @import("../models/tensor_store.zig");
 const weight_source_mod = @import("../models/weight_source.zig");
 const safetensors_mod = @import("../models/safetensors.zig");
+const native_linalg = @import("../backends/native.zig");
 const tier_planner = runtime.tier.planner;
 const tier_cache_mod = runtime.tier.cache;
 const prefetch_mod = runtime.tier.prefetch;
@@ -207,18 +208,16 @@ fn mergeLoraPairIntoWeight(base_weight: *LoadedWeight, adapter_a: Tensor, adapte
     if (@as(usize, @intCast(adapter_b.shape[0])) != out_dim) return error.AdapterOutputDimMismatch;
     if (@as(usize, @intCast(adapter_b.shape[1])) != rank) return error.AdapterRankMismatch;
 
-    const base = base_weight.tensor.asFloat32Mut();
-    const a = adapter_a.asFloat32();
-    const b = adapter_b.asFloat32();
-    for (0..out_dim) |out_idx| {
-        for (0..in_dim) |in_idx| {
-            var sum: f32 = 0.0;
-            for (0..rank) |r| {
-                sum += b[out_idx * rank + r] * a[r * in_dim + in_idx];
-            }
-            base[out_idx * in_dim + in_idx] += sum * scale;
-        }
-    }
+    native_linalg.sgemmSync(
+        out_dim,
+        in_dim,
+        rank,
+        scale,
+        adapter_b.asFloat32(),
+        adapter_a.asFloat32(),
+        1.0,
+        base_weight.tensor.asFloat32Mut(),
+    );
 }
 
 pub const WeightStore = struct {

--- a/zig/pkg/termite/src/ops/metal_compute.zig
+++ b/zig/pkg/termite/src/ops/metal_compute.zig
@@ -17064,12 +17064,14 @@ pub const MetalCompute = if (build_options.enable_metal) struct {
         const self: *MetalCompute = @ptrCast(@alignCast(ctx));
         var input = try self.ownedMetalTensorFromCt(request.input);
         defer input.deinit();
-        const rows: usize = @intCast(input.dim(0));
+        var linear_input = try retainedLinearInputView(&input, request.in_dim);
+        defer linear_input.deinit();
+        const rows: usize = @intCast(linear_input.dim(0));
         if (try metal_runtime.tryApplyQuantizedRuntimeLinearPair(
             self.provider_impl,
             request.slot_a,
             request.slot_b,
-            input,
+            linear_input,
             rows,
             request.in_dim,
             request.out_dim,
@@ -17083,7 +17085,7 @@ pub const MetalCompute = if (build_options.enable_metal) struct {
             self.provider_impl,
             request.slot_a,
             request.slot_b,
-            input,
+            linear_input,
             rows,
             request.in_dim,
             request.out_dim,

--- a/zig/pkg/termite/src/ops/metal_compute.zig
+++ b/zig/pkg/termite/src/ops/metal_compute.zig
@@ -406,6 +406,8 @@ pub const MetalCompute = if (build_options.enable_metal) struct {
         contract: ops.DecoderRuntimeDecodeContract,
         layer_count: usize,
         rows: usize,
+        batch: usize,
+        seq_len: usize,
         hidden_size: usize,
         vocab_size: usize,
         num_attention_heads: usize,
@@ -8384,6 +8386,21 @@ pub const MetalCompute = if (build_options.enable_metal) struct {
 
         const h_q = num_heads * head_dim;
         const total = batch * seq_len;
+        if (attn_bias == null) {
+            if (try self.applyBatchedDenseCausalAttentionDevice(
+                Q,
+                K,
+                V,
+                batch,
+                seq_len,
+                num_heads,
+                num_kv_heads,
+                head_dim,
+                null,
+            )) |tensor| {
+                return self.ctFromOwnedMetalTensor(tensor);
+            }
+        }
         if (batch == 1) {
             var q_mt = try self.ownedMetalTensorFromCt(Q);
             defer q_mt.deinit();
@@ -8438,6 +8455,82 @@ pub const MetalCompute = if (build_options.enable_metal) struct {
         errdefer self.allocator.free(output);
         const out_shape = [_]i32{ @intCast(total), @intCast(h_q) };
         return denseBuf(self.allocator, output, true, &out_shape);
+    }
+
+    fn applyBatchedDenseCausalAttentionDevice(
+        self: *MetalCompute,
+        q_ct: CT,
+        k_ct: CT,
+        v_ct: CT,
+        batch: usize,
+        seq_len: usize,
+        num_heads: usize,
+        num_kv_heads: usize,
+        head_dim: usize,
+        planned_layer_contract: ?ops.PlannedLayerContract,
+    ) !?MetalTensor {
+        if (batch == 0 or seq_len == 0 or num_heads == 0 or num_kv_heads == 0 or head_dim == 0) return null;
+        if (num_heads % num_kv_heads != 0) return null;
+        const total = batch * seq_len;
+        const q_width = num_heads * head_dim;
+        const kv_width = num_kv_heads * head_dim;
+
+        var q_mt = try self.ownedDeviceMetalTensorFromCt(q_ct);
+        defer q_mt.deinit();
+        var k_mt = try self.ownedDeviceMetalTensorFromCt(k_ct);
+        defer k_mt.deinit();
+        var v_mt = try self.ownedDeviceMetalTensorFromCt(v_ct);
+        defer v_mt.deinit();
+        if (q_mt.ndim() != 2 or k_mt.ndim() != 2 or v_mt.ndim() != 2) return null;
+        if (@as(usize, @intCast(q_mt.dim(0))) != total or @as(usize, @intCast(k_mt.dim(0))) != total or @as(usize, @intCast(v_mt.dim(0))) != total) return null;
+        if (@as(usize, @intCast(q_mt.dim(1))) != q_width or @as(usize, @intCast(k_mt.dim(1))) != kv_width or @as(usize, @intCast(v_mt.dim(1))) != kv_width) return null;
+
+        var output: ?MetalTensor = null;
+        errdefer if (output) |*tensor| tensor.deinit();
+        for (0..batch) |b| {
+            const q_offset = b * seq_len * q_width * @sizeOf(f32);
+            const kv_offset = b * seq_len * kv_width * @sizeOf(f32);
+            const q_bytes = seq_len * q_width * @sizeOf(f32);
+            const kv_bytes = seq_len * kv_width * @sizeOf(f32);
+            const q_shape = [_]i32{ @intCast(seq_len), @intCast(q_width) };
+            const kv_shape = [_]i32{ @intCast(seq_len), @intCast(kv_width) };
+            var q_view = try q_mt.retainedView(q_offset, q_bytes, &q_shape);
+            defer q_view.deinit();
+            var k_view = try k_mt.retainedView(kv_offset, kv_bytes, &kv_shape);
+            defer k_view.deinit();
+            var v_view = try v_mt.retainedView(kv_offset, kv_bytes, &kv_shape);
+            defer v_view.deinit();
+
+            const chunk = (try metal_runtime.decoderRuntimeApplyAttentionF32(self.provider_impl, .{
+                .q = q_view,
+                .k = k_view,
+                .v = v_view,
+                .bias = @as(?MetalTensor, null),
+                .attn_or_mask = @as(?[]const u8, null),
+                .q_len = seq_len,
+                .kv_len = seq_len,
+                .num_heads = num_heads,
+                .num_kv_heads = num_kv_heads,
+                .head_dim = head_dim,
+                .query_position_offset = @as(usize, 0),
+                .kv_position_offset = @as(usize, 0),
+                .sliding_window = @as(usize, 0),
+                .total_sequence_len = seq_len,
+                .planned_layer_contract = planned_layer_contract orelse ops.PlannedLayerContract{},
+            })) orelse return null;
+            if (output) |prior| {
+                var prior_mut = prior;
+                defer prior_mut.deinit();
+                var chunk_mut = chunk;
+                defer chunk_mut.deinit();
+                output = try metal_runtime.concatenateRows(self.provider_impl, prior_mut, chunk_mut);
+            } else {
+                output = chunk;
+            }
+        }
+        const result = output orelse return null;
+        output = null;
+        return result;
     }
 
     fn runAttentionOp(ctx: *anyopaque, request: *const ops.RunAttentionRequest) anyerror!?CT {
@@ -12189,9 +12282,255 @@ pub const MetalCompute = if (build_options.enable_metal) struct {
         return staged_result;
     }
 
+    fn denseCausalBatchShape(self: *MetalCompute, request: *const ops.RunGatedDecoderBlockRequest) ?struct { rows: usize, batch: usize, seq_len: usize } {
+        const residual_buf = toBuf(request.residual);
+        if (residual_buf.quantized_storage != null) return null;
+        const shape = residual_buf.logical_shape orelse return null;
+        if (shape.len != 2 or shape[0] <= 0 or shape[1] <= 0) return null;
+        const rows: usize = @intCast(shape[0]);
+        if (@as(usize, @intCast(shape[1])) != request.hidden_size) return null;
+        const attention = request.attention;
+        if (attention.mode != .dense_causal or attention.attn_or_mask != null or attention.kv_batch != null) return null;
+        if (attention.query_sequence_len == 0 or attention.query_sequence_len != attention.kv_sequence_len) return null;
+        if (attention.total_sequence_len != attention.query_sequence_len or attention.kv_position_offset != 0 or attention.sliding_window != 0) return null;
+        if (rows % attention.query_sequence_len != 0) return null;
+        _ = self;
+        return .{
+            .rows = rows,
+            .batch = rows / attention.query_sequence_len,
+            .seq_len = attention.query_sequence_len,
+        };
+    }
+
+    fn applyBatchedHeadNormRopeDevice(
+        self: *MetalCompute,
+        input: MetalTensor,
+        batch: usize,
+        seq_len: usize,
+        heads: usize,
+        head_dim: usize,
+        slot: usize,
+        rope_dim: usize,
+        theta: f32,
+        freq_scale: f32,
+        consecutive_pairs: bool,
+        value_scale: f32,
+        output_index: usize,
+    ) !?MetalTensor {
+        if (batch == 0 or seq_len == 0 or heads == 0 or head_dim == 0 or rope_dim == 0) return null;
+        const row_width = heads * head_dim;
+        if (!input.isDevice() or input.ndim() != 2) return null;
+        if (@as(usize, @intCast(input.dim(0))) != batch * seq_len or @as(usize, @intCast(input.dim(1))) != row_width) return null;
+        _ = output_index;
+        return metal_runtime.decoderRuntimeApplyHeadRmsNormRopeBatched(self.provider_impl, .{
+            .slot = slot,
+            .input = input,
+            .total_heads = batch * seq_len * heads,
+            .head_dim = head_dim,
+            .rope_dim = rope_dim,
+            .position = 0,
+            .theta = theta,
+            .freq_scale = freq_scale,
+            .eps = 0.0,
+            .value_scale = value_scale,
+            .consecutive_pairs = consecutive_pairs,
+        }, heads, seq_len);
+    }
+
+    fn runDenseCausalGatedDecoderBlockOp(
+        ctx: *anyopaque,
+        self: *MetalCompute,
+        request: *const ops.RunGatedDecoderBlockRequest,
+    ) anyerror!?CT {
+        const trace = metalPrefillTraceRequested();
+        const shape = self.denseCausalBatchShape(request) orelse return null;
+        if (request.ple != null) {
+            if (trace) std.debug.print("prefill-trace: dense-qwen3-block-null layer={d} reason=ple\n", .{request.attention.layer_index});
+            return null;
+        }
+        if (request.global_head_dim != 0) {
+            if (trace) std.debug.print("prefill-trace: dense-qwen3-block-null layer={d} reason=global-head-dim\n", .{request.attention.layer_index});
+            return null;
+        }
+        if (request.rope_active_dim == 0) {
+            if (trace) std.debug.print("prefill-trace: dense-qwen3-block-null layer={d} reason=rope-dim\n", .{request.attention.layer_index});
+            return null;
+        }
+        const q_slot = request.q_linear_slot;
+        const k_slot = request.k_linear_slot;
+        const v_slot = request.v_linear_slot;
+        const q_norm_slot = request.q_head_norm_slot;
+        const k_norm_slot = request.k_head_norm_slot;
+        const attention_input_size = request.num_heads * request.head_dim;
+        const kv_dim = request.num_kv_heads * request.head_dim;
+        if (!metal_runtime.decoderRuntimeReservePrefillLayerScratch(
+            self.provider_impl,
+            shape.rows,
+            request.num_heads,
+            request.num_kv_heads,
+            request.head_dim,
+            request.hidden_size,
+            request.intermediate_size,
+            request.graph_plan_tail_vocab_size,
+        )) {
+            if (trace) std.debug.print("prefill-trace: dense-qwen3-block-null layer={d} reason=reserve-scratch rows={d}\n", .{ request.attention.layer_index, shape.rows });
+            return null;
+        }
+
+        var q_ct: CT = undefined;
+        var q_owned = false;
+        defer if (q_owned) freeOp(ctx, q_ct);
+        var k_ct: CT = undefined;
+        var k_owned = false;
+        defer if (k_owned) freeOp(ctx, k_ct);
+        var v_ct: CT = undefined;
+        var v_owned = false;
+        defer if (v_owned) freeOp(ctx, v_ct);
+
+        if (request.attention_input) |attention_input| {
+            const q_slot_value = q_slot orelse return null;
+            const k_slot_value = k_slot orelse return null;
+            const v_slot_value = v_slot orelse return null;
+            q_ct = (try decoderRuntimeApplyLinearOp(ctx, &.{
+                .slot = q_slot_value,
+                .input = attention_input,
+                .in_dim = request.hidden_size,
+                .out_dim = attention_input_size,
+            })) orelse {
+                if (trace) std.debug.print("prefill-trace: dense-qwen3-block-null layer={d} reason=q-linear slot={d}\n", .{ request.attention.layer_index, q_slot_value });
+                return null;
+            };
+            q_owned = true;
+            k_ct = (try decoderRuntimeApplyLinearOp(ctx, &.{
+                .slot = k_slot_value,
+                .input = attention_input,
+                .in_dim = request.hidden_size,
+                .out_dim = kv_dim,
+            })) orelse {
+                if (trace) std.debug.print("prefill-trace: dense-qwen3-block-null layer={d} reason=k-linear slot={d}\n", .{ request.attention.layer_index, k_slot_value });
+                return null;
+            };
+            k_owned = true;
+            v_ct = (try decoderRuntimeApplyLinearOp(ctx, &.{
+                .slot = v_slot_value,
+                .input = attention_input,
+                .in_dim = request.hidden_size,
+                .out_dim = kv_dim,
+            })) orelse {
+                if (trace) std.debug.print("prefill-trace: dense-qwen3-block-null layer={d} reason=v-linear slot={d}\n", .{ request.attention.layer_index, v_slot_value });
+                return null;
+            };
+            v_owned = true;
+        } else {
+            q_ct = request.q orelse return null;
+            k_ct = request.k orelse return null;
+            v_ct = request.v orelse return null;
+        }
+        const frame_active = metal_runtime.hasActiveFrame(self.provider_impl.raw_decode_runtime);
+        self.activePlannedComputeBarrier(frame_active);
+
+        const q_norm_value = q_norm_slot orelse return null;
+        const k_norm_value = k_norm_slot orelse return null;
+        var q_projected_mt = try self.ownedDeviceMetalTensorFromCt(q_ct);
+        defer q_projected_mt.deinit();
+        var k_projected_mt = try self.ownedDeviceMetalTensorFromCt(k_ct);
+        defer k_projected_mt.deinit();
+
+        var q_rope_mt = (try self.applyBatchedHeadNormRopeDevice(
+            q_projected_mt,
+            shape.batch,
+            shape.seq_len,
+            request.num_heads,
+            request.head_dim,
+            q_norm_value,
+            request.rope_active_dim,
+            request.rope_theta,
+            request.rope_freq_scale,
+            request.rope_consecutive_pairs,
+            1.0,
+            3,
+        )) orelse {
+            if (trace) std.debug.print("prefill-trace: dense-qwen3-block-null layer={d} reason=q-rope rows={d} batch={d} seq={d} heads={d} head_dim={d} rope={d}\n", .{ request.attention.layer_index, shape.rows, shape.batch, shape.seq_len, request.num_heads, request.head_dim, request.rope_active_dim });
+            return null;
+        };
+        defer q_rope_mt.deinit();
+        var k_rope_mt = (try self.applyBatchedHeadNormRopeDevice(
+            k_projected_mt,
+            shape.batch,
+            shape.seq_len,
+            request.num_kv_heads,
+            request.head_dim,
+            k_norm_value,
+            request.rope_active_dim,
+            request.rope_theta,
+            request.rope_freq_scale,
+            request.rope_consecutive_pairs,
+            1.0,
+            4,
+        )) orelse {
+            if (trace) std.debug.print("prefill-trace: dense-qwen3-block-null layer={d} reason=k-rope rows={d} batch={d} seq={d} heads={d} head_dim={d} rope={d}\n", .{ request.attention.layer_index, shape.rows, shape.batch, shape.seq_len, request.num_kv_heads, request.head_dim, request.rope_active_dim });
+            return null;
+        };
+        defer k_rope_mt.deinit();
+        self.activePlannedComputeBarrier(frame_active);
+        const q_ready = try self.ctFromOwnedMetalTensor(try q_rope_mt.retainedCopy());
+        defer freeOp(ctx, q_ready);
+        const k_ready = try self.ctFromOwnedMetalTensor(try k_rope_mt.retainedCopy());
+        defer freeOp(ctx, k_ready);
+
+        var attention_output_mt = (try self.applyBatchedDenseCausalAttentionDevice(
+            q_ready,
+            k_ready,
+            v_ct,
+            shape.batch,
+            shape.seq_len,
+            request.num_heads,
+            request.num_kv_heads,
+            request.head_dim,
+            null,
+        )) orelse {
+            if (trace) std.debug.print("prefill-trace: dense-qwen3-block-null layer={d} reason=attention batch={d} seq={d}\n", .{ request.attention.layer_index, shape.batch, shape.seq_len });
+            return null;
+        };
+        defer attention_output_mt.deinit();
+        self.activePlannedComputeBarrier(frame_active);
+
+        var residual_mt = try self.ownedDeviceMetalTensorFromCt(request.residual);
+        defer residual_mt.deinit();
+        var block_mt = (try self.finishGatedDecoderBlockFromAttentionOutputMt(
+            request,
+            request.attention.layer_index,
+            attention_output_mt,
+            residual_mt,
+            null,
+        )) orelse {
+            if (trace) std.debug.print("prefill-trace: dense-qwen3-block-null layer={d} reason=finish-block\n", .{request.attention.layer_index});
+            return null;
+        };
+        errdefer block_mt.deinit();
+        var result = try self.ctFromOwnedMetalTensor(block_mt);
+
+        if (request.output_scale_value) |scale| {
+            const scale_ct = try self.scalarDecodeCt(scale);
+            defer freeOp(ctx, scale_ct);
+            const scaled = try multiplyOp(ctx, result, scale_ct);
+            freeOp(ctx, result);
+            result = scaled;
+        } else if (request.output_scale) |scale_ct| {
+            const scaled = try multiplyOp(ctx, result, scale_ct);
+            freeOp(ctx, result);
+            result = scaled;
+        }
+
+        return result;
+    }
+
     fn runGatedDecoderBlockOp(ctx: *anyopaque, request: *const ops.RunGatedDecoderBlockRequest) anyerror!?CT {
         const self: *MetalCompute = @ptrCast(@alignCast(ctx));
         const attention = request.attention;
+        if (attention.mode == .dense_causal) {
+            return try runDenseCausalGatedDecoderBlockOp(ctx, self, request);
+        }
         if (attention.mode != .paged_decode and attention.mode != .paged_prefill) return null;
         if (attention.mode == .paged_decode and attention.query_sequence_len != 1) return null;
         if (attention.query_sequence_len == 0 or attention.attn_or_mask != null) return null;
@@ -15591,6 +15930,7 @@ pub const MetalCompute = if (build_options.enable_metal) struct {
                 const ple_token_embedding_weight = request.ple_token_embedding_weight orelse return false;
                 if (!(try validateDecodeEmbeddingWeight(ctx, self, ple_token_embedding_weight, request.vocab_size, request.ple_hidden_size * request.layer_count))) return false;
             },
+            .qwen3_dense_text_embedding => return false,
         }
         if (!metal_runtime.decoderRuntimeReserveGreedyTailScratch(self.provider_impl, request.vocab_size)) {
             self.timing_stats.active_decode_frame_scratch_failures += 1;
@@ -15786,6 +16126,9 @@ pub const MetalCompute = if (build_options.enable_metal) struct {
     }
 
     fn declinePrefillFrameExecute(self: *MetalCompute, reason: PrefillFrameExecuteDeclineReason) bool {
+        if (metalPrefillTraceRequested()) {
+            std.debug.print("prefill-trace: metal-prefill-frame-execute decline={s}\n", .{@tagName(reason)});
+        }
         switch (reason) {
             .no_runtime => self.timing_stats.prefill_frame_execute_no_runtime += 1,
             .no_active_frame => self.timing_stats.prefill_frame_execute_no_active_frame += 1,
@@ -15860,6 +16203,8 @@ pub const MetalCompute = if (build_options.enable_metal) struct {
             .contract = request.contract,
             .layer_count = request.layer_count,
             .rows = request.rows,
+            .batch = request.batch,
+            .seq_len = request.seq_len,
             .hidden_size = request.hidden_size,
             .vocab_size = request.vocab_size,
             .num_attention_heads = request.num_attention_heads,
@@ -15891,7 +16236,7 @@ pub const MetalCompute = if (build_options.enable_metal) struct {
         defer {
             if (!plan_success) self.timing_stats.prefill_frame_plan_failures += 1;
         }
-        if (request.contract != .gemma4_gated_ple_shared_kv) {
+        if (request.contract != .gemma4_gated_ple_shared_kv and request.contract != .qwen3_dense_text_embedding) {
             traceMetalPrefillFramePlan("decline=contract", .{});
             return false;
         }
@@ -15913,8 +16258,14 @@ pub const MetalCompute = if (build_options.enable_metal) struct {
             traceMetalPrefillFramePlan("decline=tail-vocab", .{});
             return false;
         }
-        if (request.ple_hidden_size == 0) {
+        if (request.contract == .gemma4_gated_ple_shared_kv and request.ple_hidden_size == 0) {
             traceMetalPrefillFramePlan("decline=ple-hidden", .{});
+            return false;
+        }
+        if (request.contract == .qwen3_dense_text_embedding and
+            (request.batch == 0 or request.seq_len == 0 or request.rows != request.batch * request.seq_len or request.ple_hidden_size != 0 or request.include_tail))
+        {
+            traceMetalPrefillFramePlan("decline=qwen3-shape batch={d} seq={d} rows={d} ple={d} tail={}", .{ request.batch, request.seq_len, request.rows, request.ple_hidden_size, request.include_tail });
             return false;
         }
         const plan_key = prefillFramePlanKey(request);
@@ -15954,7 +16305,7 @@ pub const MetalCompute = if (build_options.enable_metal) struct {
                     return false;
                 }
             }
-            if (layer.ple_gate_linear_slot == null or layer.ple_proj_linear_slot == null or layer.ple_post_norm_slot == null) {
+            if (request.contract == .gemma4_gated_ple_shared_kv and (layer.ple_gate_linear_slot == null or layer.ple_proj_linear_slot == null or layer.ple_post_norm_slot == null)) {
                 traceMetalPrefillFramePlan("decline=ple-slot layer={d}", .{index});
                 return false;
             }
@@ -15992,14 +16343,20 @@ pub const MetalCompute = if (build_options.enable_metal) struct {
                 traceMetalPrefillFramePlan("decline=down-format layer={d} slot={d} in={d} out={d}", .{ index, layer.down_ffn_linear_slot, layer.intermediate_size, request.hidden_size });
                 return false;
             };
-            const ple_gate_format = self.preparedLinearMatmulFormatForLinearSlot(layer.ple_gate_linear_slot.?, request.hidden_size, request.ple_hidden_size) orelse {
-                traceMetalPrefillFramePlan("decline=ple-gate-format layer={d} slot={d} in={d} out={d}", .{ index, layer.ple_gate_linear_slot.?, request.hidden_size, request.ple_hidden_size });
-                return false;
-            };
-            const ple_projection_format = self.preparedLinearMatmulFormatForLinearSlot(layer.ple_proj_linear_slot.?, request.ple_hidden_size, request.hidden_size) orelse {
-                traceMetalPrefillFramePlan("decline=ple-proj-format layer={d} slot={d} in={d} out={d}", .{ index, layer.ple_proj_linear_slot.?, request.ple_hidden_size, request.hidden_size });
-                return false;
-            };
+            const ple_gate_format = if (request.ple_hidden_size != 0)
+                self.preparedLinearMatmulFormatForLinearSlot(layer.ple_gate_linear_slot.?, request.hidden_size, request.ple_hidden_size) orelse {
+                    traceMetalPrefillFramePlan("decline=ple-gate-format layer={d} slot={d} in={d} out={d}", .{ index, layer.ple_gate_linear_slot.?, request.hidden_size, request.ple_hidden_size });
+                    return false;
+                }
+            else
+                metal_command_planner.QuantMatmulFormat.unknown;
+            const ple_projection_format = if (request.ple_hidden_size != 0)
+                self.preparedLinearMatmulFormatForLinearSlot(layer.ple_proj_linear_slot.?, request.ple_hidden_size, request.hidden_size) orelse {
+                    traceMetalPrefillFramePlan("decline=ple-proj-format layer={d} slot={d} in={d} out={d}", .{ index, layer.ple_proj_linear_slot.?, request.ple_hidden_size, request.hidden_size });
+                    return false;
+                }
+            else
+                metal_command_planner.QuantMatmulFormat.unknown;
             layers[index] = .{
                 .shares_kv = layer.shares_kv,
                 .kv_layer_index = layer.kv_layer_index,
@@ -16063,7 +16420,8 @@ pub const MetalCompute = if (build_options.enable_metal) struct {
                 .lm_head_slot = request.final_lm_head_slot,
                 .tail_quant_format = tail_quant_format,
                 .include_tail = request.include_tail,
-                .activation_dtype = .f16,
+                .activation_dtype = if (request.contract == .qwen3_dense_text_embedding) .f32 else .f16,
+                .attention_storage = if (request.contract == .qwen3_dense_text_embedding) .dense else .paged,
                 .layers = layers,
                 .source = @intFromEnum(metal_runtime.ComputeSource.layer),
                 .layer_region = @intFromEnum(metal_runtime.ComputeRegion.layer),
@@ -16097,6 +16455,11 @@ pub const MetalCompute = if (build_options.enable_metal) struct {
         }
         const runtime = self.provider_impl.raw_decode_runtime orelse return self.declinePrefillFrameExecute(.no_runtime);
         if (!metal_runtime.hasActiveFrame(runtime)) return self.declinePrefillFrameExecute(.no_active_frame);
+        if (request.contract == .qwen3_dense_text_embedding) {
+            const ok = try self.executeQwen3DenseEmbeddingFrame(ctx, request);
+            execute_success = ok;
+            return ok;
+        }
         if (request.contract != .gemma4_gated_ple_shared_kv) return self.declinePrefillFrameExecute(.invalid_contract);
         if (request.rows <= 1 or request.layer_count == 0 or request.layers.len != request.layer_count) return self.declinePrefillFrameExecute(.invalid_shape);
         if (request.hidden_size == 0 or request.vocab_size == 0 or request.num_attention_heads == 0) return self.declinePrefillFrameExecute(.invalid_shape);
@@ -16120,6 +16483,8 @@ pub const MetalCompute = if (build_options.enable_metal) struct {
             const layer_window = frame_cursor.nextLayer(.{
                 .shares_kv = layer.shares_kv,
                 .value_norm = request.global_head_dim != 0 and !layer.shares_kv,
+                .kv_seed = true,
+                .include_ple = true,
             }) orelse return self.declinePrefillFrameExecute(.plan_mismatch);
             const layer_dispatch = self.activePrefillFrameLayerDispatch(layer_window, full_frame_contract) orelse return self.declinePrefillFrameExecute(.plan_mismatch);
 
@@ -16164,12 +16529,12 @@ pub const MetalCompute = if (build_options.enable_metal) struct {
                 .rope_consecutive_pairs = request.rope_consecutive_pairs,
                 .global_head_dim = request.global_head_dim,
                 .attention_linear_slot = layer.attention_linear_slot,
-                .attention_post_linear_rms_norm_slot = layer.attn_post_norm_slot,
+                .attention_post_linear_rms_norm_slot = null,
                 .hidden_size = request.hidden_size,
                 .eps = request.norm_eps,
                 .ffn_rms_norm_slot = layer.ffn_pre_norm_slot,
                 .ffn_post_gate_rms_norm_slot = null,
-                .ffn_post_down_rms_norm_slot = layer.ffn_post_norm_slot,
+                .ffn_post_down_rms_norm_slot = null,
                 .gate_ffn_linear_slot = layer.gate_ffn_linear_slot,
                 .up_ffn_linear_slot = layer.up_ffn_linear_slot,
                 .down_ffn_linear_slot = layer.down_ffn_linear_slot,
@@ -16204,6 +16569,140 @@ pub const MetalCompute = if (build_options.enable_metal) struct {
         request.output_hidden.* = hidden;
         owns_hidden = false;
         execute_success = true;
+        self.timing_stats.prefill_frame_execute_successes += 1;
+        return true;
+    }
+
+    fn executeQwen3DenseEmbeddingFrame(
+        self: *MetalCompute,
+        ctx: *anyopaque,
+        request: *const ops.DecoderRuntimeGraphCommandPlanFrameRequest,
+    ) anyerror!bool {
+        if (request.contract != .qwen3_dense_text_embedding) return self.declinePrefillFrameExecute(.invalid_contract);
+        if (request.rows <= 1 or request.layer_count == 0 or request.layers.len != request.layer_count) return self.declinePrefillFrameExecute(.invalid_shape);
+        if (request.batch == 0 or request.seq_len == 0 or request.rows != request.batch * request.seq_len) return self.declinePrefillFrameExecute(.invalid_shape);
+        if (request.hidden_size == 0 or request.num_attention_heads == 0 or request.global_head_dim != 0 or request.ple_hidden_size != 0) return self.declinePrefillFrameExecute(.invalid_shape);
+        if (request.output_hidden.* != null) return self.declinePrefillFrameExecute(.output_hidden_set);
+        const frame_plan = &(self.active_prefill_frame_plan orelse return self.declinePrefillFrameExecute(.missing_plan));
+
+        var hidden = request.hidden;
+        var owns_hidden = false;
+        errdefer if (owns_hidden) freeOp(ctx, hidden);
+
+        const full_frame_contract = self.activePrefillFrameFullContract() orelse {
+            if (metalPrefillTraceRequested()) std.debug.print("prefill-trace: qwen3-embed-frame decline=full-contract\n", .{});
+            return self.declinePrefillFrameExecute(.plan_mismatch);
+        };
+        var frame_cursor = metal_command_planner.GatedFramePlanCursor.init(frame_plan.view());
+        for (request.layers, 0..) |layer, layer_index| {
+            if (layer.shares_kv or layer.sliding_window != 0) return self.declinePrefillFrameExecute(.invalid_shape);
+            const head_dim = layer.head_dim;
+            if (head_dim == 0 or layer.kv_heads == 0 or layer.intermediate_size == 0) return self.declinePrefillFrameExecute(.invalid_shape);
+            const layer_window = frame_cursor.nextLayer(.{
+                .shares_kv = false,
+                .value_norm = false,
+                .kv_seed = false,
+                .include_ple = false,
+            }) orelse {
+                if (metalPrefillTraceRequested()) std.debug.print("prefill-trace: qwen3-embed-frame decline=cursor layer={d} next={d} ops={d}\n", .{ layer_index, frame_cursor.next_index, frame_plan.view().ops.len });
+                return self.declinePrefillFrameExecute(.plan_mismatch);
+            };
+            const layer_dispatch = self.activePrefillFrameLayerDispatch(layer_window, full_frame_contract) orelse {
+                if (metalPrefillTraceRequested()) std.debug.print("prefill-trace: qwen3-embed-frame decline=dispatch layer={d} start={d} end={d}\n", .{ layer_index, layer_window.layer_start, layer_window.layer_end });
+                return self.declinePrefillFrameExecute(.plan_mismatch);
+            };
+
+            const attn_normed = (try decoderRuntimeApplyRmsNormOp(ctx, &.{
+                .slot = layer.attn_pre_norm_slot,
+                .input = hidden,
+                .hidden_size = request.hidden_size,
+                .eps = request.norm_eps,
+            })) orelse {
+                if (metalPrefillTraceRequested()) std.debug.print("prefill-trace: qwen3-embed-frame decline=attn-rms layer={d}\n", .{layer_index});
+                return self.declinePrefillFrameExecute(.plan_mismatch);
+            };
+            defer freeOp(ctx, attn_normed);
+
+            var attention = request.attention;
+            attention.mode = .dense_causal;
+            attention.layer_index = layer_index;
+            attention.query_sequence_len = request.seq_len;
+            attention.kv_sequence_len = request.seq_len;
+            attention.total_sequence_len = request.seq_len;
+            attention.kv_position_offset = 0;
+            attention.sliding_window = 0;
+            attention.skip_kv_write = false;
+            attention.attn_or_mask = null;
+            attention.kv_batch = null;
+            attention.kv_cache = null;
+            attention.kv_manager = null;
+            attention.kv_storage = null;
+
+            const prev_hidden = hidden;
+            const block_hidden = (try runGatedDecoderBlockOp(ctx, &.{
+                .attention_input = attn_normed,
+                .residual = hidden,
+                .attention = attention,
+                .num_heads = request.num_attention_heads,
+                .num_kv_heads = layer.kv_heads,
+                .head_dim = head_dim,
+                .q_linear_slot = layer.q_linear_slot,
+                .k_linear_slot = layer.k_linear_slot,
+                .v_linear_slot = layer.v_linear_slot,
+                .q_head_norm_slot = layer.q_head_norm_slot,
+                .k_head_norm_slot = layer.k_head_norm_slot,
+                .rope_active_dim = layer.rope_active_dim,
+                .rope_theta = layer.rope_theta,
+                .rope_freq_scale = request.rope_freq_scale,
+                .rope_consecutive_pairs = request.rope_consecutive_pairs,
+                .global_head_dim = request.global_head_dim,
+                .attention_linear_slot = layer.attention_linear_slot,
+                .attention_post_linear_rms_norm_slot = null,
+                .hidden_size = request.hidden_size,
+                .eps = request.norm_eps,
+                .ffn_rms_norm_slot = layer.ffn_pre_norm_slot,
+                .ffn_post_gate_rms_norm_slot = null,
+                .ffn_post_down_rms_norm_slot = null,
+                .gate_ffn_linear_slot = layer.gate_ffn_linear_slot,
+                .up_ffn_linear_slot = layer.up_ffn_linear_slot,
+                .down_ffn_linear_slot = layer.down_ffn_linear_slot,
+                .intermediate_size = layer.intermediate_size,
+                .activation = request.activation,
+                .output_scale_value = layer.output_scale_value,
+                .planned_setup_contract = .{},
+                .planned_layer_contract = .{},
+                .planned_frame_contract = layer_dispatch.full_contract,
+                .planned_frame_layer_window = .{
+                    .layer_start = layer_dispatch.window.layer_start,
+                    .setup_start = layer_dispatch.window.setup_start,
+                    .block_start = layer_dispatch.window.block_start,
+                    .layer_end = layer_dispatch.window.layer_end,
+                },
+            })) orelse {
+                if (metalPrefillTraceRequested()) std.debug.print("prefill-trace: qwen3-embed-frame decline=block layer={d}\n", .{layer_index});
+                return self.declinePrefillFrameExecute(.plan_mismatch);
+            };
+            if (owns_hidden) freeOp(ctx, prev_hidden);
+            hidden = block_hidden;
+            owns_hidden = true;
+        }
+
+        if (!frame_cursor.complete()) {
+            if (metalPrefillTraceRequested()) std.debug.print("prefill-trace: qwen3-embed-frame decline=incomplete next={d} ops={d}\n", .{ frame_cursor.next_index, frame_plan.view().ops.len });
+            return self.declinePrefillFrameExecute(.plan_mismatch);
+        }
+        const final_hidden = (try decoderRuntimeApplyRmsNormOp(ctx, &.{
+            .slot = request.final_norm_slot,
+            .input = hidden,
+            .hidden_size = request.hidden_size,
+            .eps = request.norm_eps,
+        })) orelse {
+            if (metalPrefillTraceRequested()) std.debug.print("prefill-trace: qwen3-embed-frame decline=final-rms\n", .{});
+            return self.declinePrefillFrameExecute(.plan_mismatch);
+        };
+        if (owns_hidden) freeOp(ctx, hidden);
+        request.output_hidden.* = final_hidden;
+        owns_hidden = false;
         self.timing_stats.prefill_frame_execute_successes += 1;
         return true;
     }

--- a/zig/pkg/termite/src/pipelines/embedding.zig
+++ b/zig/pkg/termite/src/pipelines/embedding.zig
@@ -35,6 +35,8 @@ const gpt_arch = @import("../architectures/gpt.zig");
 const decoder_gated_runtime = @import("../backends/decoder_gated_runtime.zig");
 const resident_ops = @import("../graph/resident_ops.zig");
 
+const qwen3_embedding_resident_override_level = 4;
+
 pub const PoolingStrategy = enum {
     mean,
     cls,
@@ -271,7 +273,7 @@ pub const EmbeddingPipeline = struct {
             if (try self.tryEmbedTextResidentProjection(inputs, all_mask, batch, effective_len, proj)) |resident_embeddings| {
                 return resident_embeddings;
             }
-        } else if (try self.tryEmbedTextResidentQwen3(inputs, all_mask, ids_i64, batch, effective_len)) |resident_embeddings| {
+        } else if (try self.tryEmbedTextResidentQwen3(all_mask, ids_i64, batch, effective_len)) |resident_embeddings| {
             return resident_embeddings;
         }
 
@@ -890,27 +892,19 @@ pub const EmbeddingPipeline = struct {
 
     fn tryEmbedTextResidentQwen3(
         self: *EmbeddingPipeline,
-        inputs: []const Tensor,
         mask: []const i32,
         input_ids: []const i64,
         batch: usize,
         seq_len: usize,
     ) !?[][]f32 {
-        _ = inputs;
-        if (residentQwen3EmbeddingDisabled()) {
-            if (residentQwen3EmbeddingRequired()) {
-                return self.residentProjectionFallback(.text, "text.encoder.qwen3.resident", batch, "disabled");
-            }
-            return null;
-        }
         const cfg = session_factory.getGptConfig(self.session) orelse {
-            if (residentQwen3EmbeddingRequired()) {
+            if (self.residentProjectionRequired()) {
                 return self.residentProjectionFallback(.text, "text.encoder.qwen3.resident", batch, "not_gpt_session");
             }
             return null;
         };
         if (!residentQwen3EmbeddingEligible(self.session, cfg, self.config)) {
-            if (residentQwen3EmbeddingRequired()) {
+            if (self.residentProjectionRequired()) {
                 return self.residentProjectionFallback(.text, "text.encoder.qwen3.resident", batch, "ineligible");
             }
             return null;
@@ -935,14 +929,11 @@ pub const EmbeddingPipeline = struct {
         if (try self.tryEmbedTextResidentQwen3Graph(&cb, cfg, mask, input_ids, batch, seq_len)) |graph_embeddings| {
             return graph_embeddings;
         }
-        if (residentQwen3EmbeddingGraphRequired()) {
-            return self.residentProjectionFallback(.text, "text.encoder.qwen3.graph", batch, "graph_fallback");
-        }
 
         const overrides = decoder_gated_runtime.buildOverridesWithLevel(
             cfg,
             cfg.num_hidden_layers,
-            residentQwen3EmbeddingOverrideLevel(),
+            qwen3_embedding_resident_override_level,
         );
         const encoder_start = embedTimingStart(self.print_timing);
         const hidden = try gpt_arch.hiddenForwardResidentWithOverrides(
@@ -999,16 +990,7 @@ pub const EmbeddingPipeline = struct {
         batch: usize,
         seq_len: usize,
     ) !?[][]f32 {
-        if (residentQwen3EmbeddingGraphDisabled()) {
-            if (residentQwen3EmbeddingGraphRequired()) {
-                return self.residentProjectionFallback(.text, "text.encoder.qwen3.graph", batch, "disabled");
-            }
-            return null;
-        }
         if (cfg.num_hidden_layers == 0 or cfg.num_hidden_layers > 256) {
-            if (residentQwen3EmbeddingGraphRequired()) {
-                return self.residentProjectionFallback(.text, "text.encoder.qwen3.graph", batch, "unsupported_layer_count");
-            }
             return null;
         }
         if (input_ids.len != batch * seq_len) return error.ShapeMismatch;
@@ -1018,10 +1000,7 @@ pub const EmbeddingPipeline = struct {
             cfg,
             cfg.num_hidden_layers,
             &layer_storage,
-        ) catch |err| {
-            if (residentQwen3EmbeddingGraphRequired()) {
-                return self.residentProjectionFallback(.text, "text.encoder.qwen3.graph", batch, @errorName(err));
-            }
+        ) catch {
             return null;
         };
 
@@ -1042,9 +1021,6 @@ pub const EmbeddingPipeline = struct {
             .layers = layers,
         });
         if (!planned) {
-            if (residentQwen3EmbeddingGraphRequired()) {
-                return self.residentProjectionFallback(.text, "text.encoder.qwen3.graph", batch, "plan_failed");
-            }
             return null;
         }
 
@@ -1055,9 +1031,6 @@ pub const EmbeddingPipeline = struct {
 
         var active = try cb.decoderRuntimeBeginFrame();
         if (!active) {
-            if (residentQwen3EmbeddingGraphRequired()) {
-                return self.residentProjectionFallback(.text, "text.encoder.qwen3.graph", batch, "begin_frame_failed");
-            }
             return null;
         }
         errdefer if (active) cb.decoderRuntimeCancelFrame() catch {};
@@ -1095,9 +1068,6 @@ pub const EmbeddingPipeline = struct {
         if (!executed) {
             try cb.decoderRuntimeCancelFrame();
             active = false;
-            if (residentQwen3EmbeddingGraphRequired()) {
-                return self.residentProjectionFallback(.text, "text.encoder.qwen3.graph", batch, "execute_failed");
-            }
             return null;
         }
         try cb.decoderRuntimeSubmitAndWaitFrame();
@@ -1120,12 +1090,7 @@ pub const EmbeddingPipeline = struct {
             error.UnsupportedPrimitiveOp,
             error.UnsupportedOperation,
             error.UnsupportedShape,
-            => {
-                if (residentQwen3EmbeddingGraphRequired()) {
-                    return self.residentProjectionFallback(.text, "text.pool.qwen3.graph", batch, @errorName(err));
-                }
-                return null;
-            },
+            => return null,
             else => return err,
         };
         defer pooled.deinit();
@@ -1564,45 +1529,7 @@ fn embedResidentFailClosedEnabled() bool {
     if (platform.env.getenvSlice("TERMITE_EMBED_RESIDENT_REQUIRED")) |value| {
         if (envFlagEnabled(value)) return true;
     }
-    if (platform.env.getenvSlice("TERMITE_REQUIRE_RESIDENT_QWEN3_EMBED")) |value| {
-        if (envFlagEnabled(value)) return true;
-    }
-    if (platform.env.getenvSlice("TERMITE_REQUIRE_QWEN3_EMBED_GRAPH")) |value| {
-        if (envFlagEnabled(value)) return true;
-    }
     return false;
-}
-
-fn residentQwen3EmbeddingDisabled() bool {
-    if (platform.env.getenvSlice("TERMITE_DISABLE_RESIDENT_QWEN3_EMBED")) |value| {
-        return envFlagEnabled(value);
-    }
-    return false;
-}
-
-fn residentQwen3EmbeddingRequired() bool {
-    if (platform.env.getenvSlice("TERMITE_REQUIRE_RESIDENT_QWEN3_EMBED")) |value| {
-        return envFlagEnabled(value);
-    }
-    return false;
-}
-
-fn residentQwen3EmbeddingGraphDisabled() bool {
-    if (platform.env.getenvSlice("TERMITE_DISABLE_QWEN3_EMBED_GRAPH")) |value| {
-        return envFlagEnabled(value);
-    }
-    return false;
-}
-
-fn residentQwen3EmbeddingGraphRequired() bool {
-    if (platform.env.getenvSlice("TERMITE_REQUIRE_QWEN3_EMBED_GRAPH")) |value| {
-        return envFlagEnabled(value);
-    }
-    return false;
-}
-
-fn residentQwen3EmbeddingOverrideLevel() usize {
-    return 4;
 }
 
 fn residentQwen3EmbeddingEligible(session: backends.Session, cfg: gpt_arch.Config, embedding_config: EmbeddingConfig) bool {

--- a/zig/pkg/termite/src/pipelines/embedding.zig
+++ b/zig/pkg/termite/src/pipelines/embedding.zig
@@ -35,6 +35,7 @@ pub const PoolingStrategy = enum {
     mean,
     cls,
     max,
+    last,
 };
 
 pub const EmbeddingConfig = struct {
@@ -45,6 +46,9 @@ pub const EmbeddingConfig = struct {
     /// When true, resident encoder/projection paths fail instead of silently
     /// falling back to host-session projection.
     resident_projection_required: bool = false,
+    /// Optional text prefix applied before tokenization. Jina v5 text models
+    /// default to document embeddings by encoding "Document: " + text.
+    text_prefix: []const u8 = "",
     /// For CLIP/SigLIP multimodal models: image size for vision encoder.
     image_size: u32 = 224,
     /// For CLAP audio models: mel spectrogram configuration.
@@ -187,7 +191,13 @@ pub const EmbeddingPipeline = struct {
         defer alloc.free(all_mask);
 
         for (texts, 0..) |text, i| {
-            var result = try self.tok.encodeForModel(alloc, text, max_len);
+            const token_text = if (self.config.text_prefix.len > 0)
+                try std.fmt.allocPrint(alloc, "{s}{s}", .{ self.config.text_prefix, text })
+            else
+                text;
+            defer if (self.config.text_prefix.len > 0) alloc.free(token_text);
+
+            var result = try self.tok.encodeForModel(alloc, token_text, max_len);
             defer result.deinit();
 
             @memcpy(all_ids[i * max_len .. (i + 1) * max_len], result.ids);
@@ -316,6 +326,14 @@ pub const EmbeddingPipeline = struct {
                             }
                         }
                     }
+                },
+                .last => {
+                    var last_idx: usize = 0;
+                    for (0..seq_len) |s| {
+                        if (mask[b * seq_len + s] > 0) last_idx = s;
+                    }
+                    const offset = (b * seq_len + last_idx) * hidden;
+                    @memcpy(emb, data[offset .. offset + hidden]);
                 },
             }
 
@@ -975,6 +993,7 @@ pub const EmbeddingPipeline = struct {
         return switch (self.config.pooling) {
             .mean => try residentMaskedMeanPool(outputs.allocator, backend, output, mask, batch, seq_len, @intCast(shape[2])),
             .cls => try residentClsPool(backend, output, batch, @intCast(shape[2])),
+            .last => try residentLastTokenPool(outputs.allocator, backend, output, mask, batch, seq_len, @intCast(shape[2])),
             .max => error.UnsupportedResidentTextPooling,
         };
     }
@@ -1034,6 +1053,53 @@ pub const EmbeddingPipeline = struct {
         const sliced = try backend.primSlice(output, &starts, &limits, &strides, &input_shape);
         defer backend.free(sliced);
         const pooled = try backend.primReshape(sliced, &pooled_shape);
+        return .{ .value = pooled, .backend = backend, .owns_value = true };
+    }
+
+    fn residentLastTokenPool(
+        allocator: std.mem.Allocator,
+        backend: *const ops_mod.ComputeBackend,
+        output: ops_mod.CT,
+        mask: []const i32,
+        batch: usize,
+        seq_len: usize,
+        hidden: usize,
+    ) !ResidentPooled {
+        if (mask.len != batch * seq_len) return error.ShapeMismatch;
+
+        const row_ids = try allocator.alloc(u32, batch);
+        defer allocator.free(row_ids);
+        for (0..batch) |b| {
+            var last_idx: usize = 0;
+            for (0..seq_len) |s| {
+                if (mask[b * seq_len + s] > 0) last_idx = s;
+            }
+            row_ids[b] = @intCast(b * seq_len + last_idx);
+        }
+
+        const flat_shape = [_]i64{ @intCast(batch * seq_len), @intCast(hidden) };
+        const flat = backend.primReshape(output, &flat_shape) catch null;
+        if (flat) |flat_output| {
+            defer backend.free(flat_output);
+            if (try backend.takeRows(flat_output, row_ids, batch, hidden)) |pooled| {
+                return .{ .value = pooled, .backend = backend, .owns_value = true };
+            }
+        }
+
+        const host = try backend.toFloat32(output, allocator);
+        defer allocator.free(host);
+        if (host.len != batch * seq_len * hidden) return error.ShapeMismatch;
+
+        const pooled_values = try allocator.alloc(f32, batch * hidden);
+        errdefer allocator.free(pooled_values);
+        for (0..batch) |b| {
+            const src_offset = @as(usize, row_ids[b]) * hidden;
+            const dst_offset = b * hidden;
+            @memcpy(pooled_values[dst_offset .. dst_offset + hidden], host[src_offset .. src_offset + hidden]);
+        }
+
+        const pooled = try backend.fromFloat32Shape(pooled_values, &.{ @intCast(batch), @intCast(hidden) });
+        allocator.free(pooled_values);
         return .{ .value = pooled, .backend = backend, .owns_value = true };
     }
 
@@ -1388,6 +1454,38 @@ test "resident masked mean pooling uses backend primitives" {
     const host = try cb.toFloat32(pooled.value, allocator);
     defer allocator.free(host);
     try std.testing.expectEqualSlices(f32, &.{ 2.0, 3.0, 7.0, 8.0 }, host);
+}
+
+test "pool3D last uses final non-padding token and normalizes" {
+    const allocator = std.testing.allocator;
+
+    const shape = [_]i64{ 2, 3, 2 };
+    const values = [_]f32{
+        1.0, 0.0,
+        3.0, 4.0,
+        9.0, 9.0,
+        0.0, 2.0,
+        8.0, 8.0,
+        0.0, 5.0,
+    };
+    var output = try Tensor.initFloat32(allocator, "last_hidden_state", &shape, &values);
+    defer output.deinit();
+
+    var pipeline = EmbeddingPipeline{
+        .allocator = allocator,
+        .session = undefined,
+        .tok = undefined,
+        .config = .{ .pooling = .last, .normalize = true },
+    };
+
+    const mask = [_]i32{ 1, 1, 0, 1, 0, 1 };
+    const embeddings = try pipeline.pool3D(&output, &mask, 2, 3, true);
+    defer freeEmbeddingSlices(allocator, embeddings);
+
+    try std.testing.expectApproxEqAbs(@as(f32, 0.6), embeddings[0][0], 1e-6);
+    try std.testing.expectApproxEqAbs(@as(f32, 0.8), embeddings[0][1], 1e-6);
+    try std.testing.expectApproxEqAbs(@as(f32, 0.0), embeddings[1][0], 1e-6);
+    try std.testing.expectApproxEqAbs(@as(f32, 1.0), embeddings[1][1], 1e-6);
 }
 
 test "resident projected input selection supports 3d cls pooling" {

--- a/zig/pkg/termite/src/pipelines/embedding.zig
+++ b/zig/pkg/termite/src/pipelines/embedding.zig
@@ -31,6 +31,8 @@ const ops_mod = @import("../ops/ops.zig");
 const image = @import("image.zig");
 const audio = @import("audio.zig");
 const session_factory = @import("../architectures/session_factory.zig");
+const gpt_arch = @import("../architectures/gpt.zig");
+const decoder_gated_runtime = @import("../backends/decoder_gated_runtime.zig");
 const resident_ops = @import("../graph/resident_ops.zig");
 
 pub const PoolingStrategy = enum {
@@ -55,6 +57,9 @@ pub const EmbeddingConfig = struct {
     /// before encoder execution. Useful for decoder-style embedders where
     /// padding to the architectural context window is prohibitively expensive.
     trim_padding_to_batch_max: bool = false,
+    /// Enable the direct resident Qwen3/Jina embedding encoder. This is set
+    /// from Jina/Qwen3 embedding manifests, not merely from the backbone family.
+    resident_qwen3_embedding: bool = false,
     /// For CLIP/SigLIP multimodal models: image size for vision encoder.
     image_size: u32 = 224,
     /// For CLAP audio models: mel spectrogram configuration.
@@ -266,6 +271,8 @@ pub const EmbeddingPipeline = struct {
             if (try self.tryEmbedTextResidentProjection(inputs, all_mask, batch, effective_len, proj)) |resident_embeddings| {
                 return resident_embeddings;
             }
+        } else if (try self.tryEmbedTextResidentQwen3(inputs, all_mask, ids_i64, batch, effective_len)) |resident_embeddings| {
+            return resident_embeddings;
         }
 
         // Run inference
@@ -881,6 +888,261 @@ pub const EmbeddingPipeline = struct {
         return self.config.resident_projection_required or embedResidentFailClosedEnabled();
     }
 
+    fn tryEmbedTextResidentQwen3(
+        self: *EmbeddingPipeline,
+        inputs: []const Tensor,
+        mask: []const i32,
+        input_ids: []const i64,
+        batch: usize,
+        seq_len: usize,
+    ) !?[][]f32 {
+        _ = inputs;
+        if (residentQwen3EmbeddingDisabled()) {
+            if (residentQwen3EmbeddingRequired()) {
+                return self.residentProjectionFallback(.text, "text.encoder.qwen3.resident", batch, "disabled");
+            }
+            return null;
+        }
+        const cfg = session_factory.getGptConfig(self.session) orelse {
+            if (residentQwen3EmbeddingRequired()) {
+                return self.residentProjectionFallback(.text, "text.encoder.qwen3.resident", batch, "not_gpt_session");
+            }
+            return null;
+        };
+        if (!residentQwen3EmbeddingEligible(self.session, cfg, self.config)) {
+            if (residentQwen3EmbeddingRequired()) {
+                return self.residentProjectionFallback(.text, "text.encoder.qwen3.resident", batch, "ineligible");
+            }
+            return null;
+        }
+
+        var cb = try session_factory.getComputeBackend(self.session, self.allocator);
+        defer cb.deinit();
+        if (cb.kind() != .metal) {
+            return self.residentProjectionFallback(.text, "text.encoder.qwen3.resident", batch, "not_metal_backend");
+        }
+
+        const prepare = try cb.decoderRuntimePrepareOrReuseFamily(
+            self.allocator,
+            cfg,
+            0,
+            cfg.num_hidden_layers,
+        );
+        if (!prepare.prepared) {
+            return self.residentProjectionFallback(.text, "text.prepare.qwen3.resident", batch, "prepare_failed");
+        }
+
+        if (try self.tryEmbedTextResidentQwen3Graph(&cb, cfg, mask, input_ids, batch, seq_len)) |graph_embeddings| {
+            return graph_embeddings;
+        }
+        if (residentQwen3EmbeddingGraphRequired()) {
+            return self.residentProjectionFallback(.text, "text.encoder.qwen3.graph", batch, "graph_fallback");
+        }
+
+        const overrides = decoder_gated_runtime.buildOverridesWithLevel(
+            cfg,
+            cfg.num_hidden_layers,
+            residentQwen3EmbeddingOverrideLevel(),
+        );
+        const encoder_start = embedTimingStart(self.print_timing);
+        const hidden = try gpt_arch.hiddenForwardResidentWithOverrides(
+            &cb,
+            self.allocator,
+            cfg,
+            input_ids,
+            batch,
+            seq_len,
+            null,
+            overrides,
+        );
+        logEmbedTiming("text.encoder.qwen3.resident", batch, encoder_start);
+
+        const output_storage = try self.allocator.alloc(ops_mod.CT, 1);
+        defer self.allocator.free(output_storage);
+        output_storage[0] = hidden;
+        var encoder_outputs = session_mod.ResidentOutputs{
+            .outputs = output_storage,
+            .backend = &cb,
+            .allocator = self.allocator,
+        };
+        defer encoder_outputs.deinit();
+
+        var pooled = self.residentPoolTextOutput(&encoder_outputs, mask, batch, seq_len) catch |err| switch (err) {
+            error.UnsupportedResidentTextPooling,
+            error.UnsupportedPrimitiveOp,
+            error.UnsupportedOperation,
+            error.UnsupportedShape,
+            => return self.residentProjectionFallback(.text, "text.pool.qwen3.resident", batch, @errorName(err)),
+            else => return err,
+        };
+        defer pooled.deinit();
+
+        const pooled_storage = try self.allocator.alloc(ops_mod.CT, 1);
+        defer self.allocator.free(pooled_storage);
+        pooled_storage[0] = pooled.value;
+        var pooled_outputs = session_mod.ResidentOutputs{
+            .outputs = pooled_storage,
+            .backend = pooled.backend,
+            .allocator = self.allocator,
+        };
+        const embeddings = try self.resident2DToEmbeddings(&pooled_outputs, batch);
+        self.recordResidentProjection(.text, .success, "text.encoder.qwen3.resident", batch, null);
+        return embeddings;
+    }
+
+    fn tryEmbedTextResidentQwen3Graph(
+        self: *EmbeddingPipeline,
+        cb: *const ops_mod.ComputeBackend,
+        cfg: gpt_arch.Config,
+        mask: []const i32,
+        input_ids: []const i64,
+        batch: usize,
+        seq_len: usize,
+    ) !?[][]f32 {
+        if (residentQwen3EmbeddingGraphDisabled()) {
+            if (residentQwen3EmbeddingGraphRequired()) {
+                return self.residentProjectionFallback(.text, "text.encoder.qwen3.graph", batch, "disabled");
+            }
+            return null;
+        }
+        if (cfg.num_hidden_layers == 0 or cfg.num_hidden_layers > 256) {
+            if (residentQwen3EmbeddingGraphRequired()) {
+                return self.residentProjectionFallback(.text, "text.encoder.qwen3.graph", batch, "unsupported_layer_count");
+            }
+            return null;
+        }
+        if (input_ids.len != batch * seq_len) return error.ShapeMismatch;
+
+        var layer_storage: [256]ops_mod.DecoderRuntimeLayerSpec = undefined;
+        const layers = decoder_gated_runtime.fillDenseQwen3LayerSpecs(
+            cfg,
+            cfg.num_hidden_layers,
+            &layer_storage,
+        ) catch |err| {
+            if (residentQwen3EmbeddingGraphRequired()) {
+                return self.residentProjectionFallback(.text, "text.encoder.qwen3.graph", batch, @errorName(err));
+            }
+            return null;
+        };
+
+        const planned = try cb.decoderRuntimePlanPrefillFrame(&.{
+            .contract = .qwen3_dense_text_embedding,
+            .layer_count = layers.len,
+            .rows = batch * seq_len,
+            .batch = batch,
+            .seq_len = seq_len,
+            .hidden_size = cfg.hidden_size,
+            .vocab_size = cfg.vocab_size,
+            .num_attention_heads = cfg.num_attention_heads,
+            .global_head_dim = cfg.global_head_dim,
+            .ple_hidden_size = 0,
+            .final_norm_slot = decoder_gated_runtime.finalNormSlot(cfg.num_hidden_layers),
+            .final_lm_head_slot = 0,
+            .include_tail = false,
+            .layers = layers,
+        });
+        if (!planned) {
+            if (residentQwen3EmbeddingGraphRequired()) {
+                return self.residentProjectionFallback(.text, "text.encoder.qwen3.graph", batch, "plan_failed");
+            }
+            return null;
+        }
+
+        const embed_w = try gpt_arch.getEmbeddingWeight(cb, cfg);
+        defer cb.free(embed_w);
+        const hidden = try cb.embeddingLookup(embed_w, input_ids, batch * seq_len, cfg.hidden_size);
+        defer cb.free(hidden);
+
+        var active = try cb.decoderRuntimeBeginFrame();
+        if (!active) {
+            if (residentQwen3EmbeddingGraphRequired()) {
+                return self.residentProjectionFallback(.text, "text.encoder.qwen3.graph", batch, "begin_frame_failed");
+            }
+            return null;
+        }
+        errdefer if (active) cb.decoderRuntimeCancelFrame() catch {};
+
+        var graph_hidden: ?ops_mod.CT = null;
+        const attention = ops_mod.AttentionContext{
+            .mode = .dense_causal,
+            .total_sequence_len = seq_len,
+            .query_sequence_len = seq_len,
+            .kv_sequence_len = seq_len,
+        };
+        const encoder_start = embedTimingStart(self.print_timing);
+        const executed = try cb.decoderRuntimeExecuteGraphCommandPlanFrame(&.{
+            .contract = .qwen3_dense_text_embedding,
+            .layer_count = layers.len,
+            .rows = batch * seq_len,
+            .batch = batch,
+            .seq_len = seq_len,
+            .hidden_size = cfg.hidden_size,
+            .vocab_size = cfg.vocab_size,
+            .num_attention_heads = cfg.num_attention_heads,
+            .global_head_dim = cfg.global_head_dim,
+            .ple_hidden_size = 0,
+            .final_norm_slot = decoder_gated_runtime.finalNormSlot(cfg.num_hidden_layers),
+            .norm_eps = cfg.norm_eps,
+            .rope_freq_scale = cfg.rope_freq_scale,
+            .rope_consecutive_pairs = cfg.rope_layout == .consecutive_pairs,
+            .activation = gpt_arch.decoderRuntimeActivationKind(cfg.activation),
+            .attention = attention,
+            .hidden = hidden,
+            .ple_vectors = null,
+            .layers = layers,
+            .output_hidden = &graph_hidden,
+        });
+        if (!executed) {
+            try cb.decoderRuntimeCancelFrame();
+            active = false;
+            if (residentQwen3EmbeddingGraphRequired()) {
+                return self.residentProjectionFallback(.text, "text.encoder.qwen3.graph", batch, "execute_failed");
+            }
+            return null;
+        }
+        try cb.decoderRuntimeSubmitAndWaitFrame();
+        active = false;
+        logEmbedTiming("text.encoder.qwen3.graph", batch, encoder_start);
+
+        const output = graph_hidden orelse return error.NoOutputTensors;
+        const output_storage = try self.allocator.alloc(ops_mod.CT, 1);
+        defer self.allocator.free(output_storage);
+        output_storage[0] = output;
+        var encoder_outputs = session_mod.ResidentOutputs{
+            .outputs = output_storage,
+            .backend = cb,
+            .allocator = self.allocator,
+        };
+        defer encoder_outputs.deinit();
+
+        var pooled = self.residentPoolTextOutput(&encoder_outputs, mask, batch, seq_len) catch |err| switch (err) {
+            error.UnsupportedResidentTextPooling,
+            error.UnsupportedPrimitiveOp,
+            error.UnsupportedOperation,
+            error.UnsupportedShape,
+            => {
+                if (residentQwen3EmbeddingGraphRequired()) {
+                    return self.residentProjectionFallback(.text, "text.pool.qwen3.graph", batch, @errorName(err));
+                }
+                return null;
+            },
+            else => return err,
+        };
+        defer pooled.deinit();
+
+        const pooled_storage = try self.allocator.alloc(ops_mod.CT, 1);
+        defer self.allocator.free(pooled_storage);
+        pooled_storage[0] = pooled.value;
+        var pooled_outputs = session_mod.ResidentOutputs{
+            .outputs = pooled_storage,
+            .backend = pooled.backend,
+            .allocator = self.allocator,
+        };
+        const embeddings = try self.resident2DToEmbeddings(&pooled_outputs, batch);
+        self.recordResidentProjection(.text, .success, "text.encoder.qwen3.graph", batch, null);
+        return embeddings;
+    }
+
     fn tryEmbedTextResidentProjection(
         self: *EmbeddingPipeline,
         inputs: []const Tensor,
@@ -1013,7 +1275,22 @@ pub const EmbeddingPipeline = struct {
         defer outputs.allocator.free(shape);
 
         if (shape.len == 2) {
-            return .{ .value = output, .backend = backend, .owns_value = false };
+            if (shape[0] == @as(i64, @intCast(batch)) and shape[1] > 0) {
+                return .{ .value = output, .backend = backend, .owns_value = false };
+            }
+            if (shape[0] == @as(i64, @intCast(batch * seq_len)) and shape[1] > 0) {
+                const hidden: usize = @intCast(shape[1]);
+                const output_shape = [_]i64{ @intCast(batch), @intCast(seq_len), @intCast(hidden) };
+                const reshaped = try backend.primReshape(output, &output_shape);
+                defer backend.free(reshaped);
+                return switch (self.config.pooling) {
+                    .mean => try residentMaskedMeanPool(outputs.allocator, backend, reshaped, mask, batch, seq_len, hidden),
+                    .cls => try residentClsPool(backend, reshaped, batch, hidden),
+                    .last => try residentLastTokenPool(outputs.allocator, backend, reshaped, mask, batch, seq_len, hidden),
+                    .max => error.UnsupportedResidentTextPooling,
+                };
+            }
+            return error.ShapeMismatch;
         }
         if (shape.len != 3) return error.UnexpectedOutputShape;
         if (shape[0] != @as(i64, @intCast(batch)) or shape[1] != @as(i64, @intCast(seq_len)) or shape[2] <= 0) {
@@ -1287,7 +1564,60 @@ fn embedResidentFailClosedEnabled() bool {
     if (platform.env.getenvSlice("TERMITE_EMBED_RESIDENT_REQUIRED")) |value| {
         if (envFlagEnabled(value)) return true;
     }
+    if (platform.env.getenvSlice("TERMITE_REQUIRE_RESIDENT_QWEN3_EMBED")) |value| {
+        if (envFlagEnabled(value)) return true;
+    }
+    if (platform.env.getenvSlice("TERMITE_REQUIRE_QWEN3_EMBED_GRAPH")) |value| {
+        if (envFlagEnabled(value)) return true;
+    }
     return false;
+}
+
+fn residentQwen3EmbeddingDisabled() bool {
+    if (platform.env.getenvSlice("TERMITE_DISABLE_RESIDENT_QWEN3_EMBED")) |value| {
+        return envFlagEnabled(value);
+    }
+    return false;
+}
+
+fn residentQwen3EmbeddingRequired() bool {
+    if (platform.env.getenvSlice("TERMITE_REQUIRE_RESIDENT_QWEN3_EMBED")) |value| {
+        return envFlagEnabled(value);
+    }
+    return false;
+}
+
+fn residentQwen3EmbeddingGraphDisabled() bool {
+    if (platform.env.getenvSlice("TERMITE_DISABLE_QWEN3_EMBED_GRAPH")) |value| {
+        return envFlagEnabled(value);
+    }
+    return false;
+}
+
+fn residentQwen3EmbeddingGraphRequired() bool {
+    if (platform.env.getenvSlice("TERMITE_REQUIRE_QWEN3_EMBED_GRAPH")) |value| {
+        return envFlagEnabled(value);
+    }
+    return false;
+}
+
+fn residentQwen3EmbeddingOverrideLevel() usize {
+    return 4;
+}
+
+fn residentQwen3EmbeddingEligible(session: backends.Session, cfg: gpt_arch.Config, embedding_config: EmbeddingConfig) bool {
+    return residentQwen3EmbeddingEligibleForBackend(session.backend(), cfg, embedding_config);
+}
+
+fn residentQwen3EmbeddingEligibleForBackend(backend: backends.BackendType, cfg: gpt_arch.Config, embedding_config: EmbeddingConfig) bool {
+    if (!embedding_config.resident_qwen3_embedding) return false;
+    if (backend != .metal) return false;
+    if (cfg.family != .qwen3) return false;
+    if (cfg.usesMoe() or cfg.hasPle() or cfg.isMultimodal()) return false;
+    if (cfg.num_kv_shared_layers != 0) return false;
+    if (cfg.global_head_dim != 0 or cfg.num_global_key_value_heads != 0) return false;
+    if (cfg.sliding_window != 0) return false;
+    return true;
 }
 
 fn envFlagEnabled(value: []const u8) bool {
@@ -1486,6 +1816,61 @@ test "resident masked mean pooling uses backend primitives" {
     try std.testing.expectEqualSlices(f32, &.{ 2.0, 3.0, 7.0, 8.0 }, host);
 }
 
+test "resident text pooling handles flattened batch sequence hidden states" {
+    const allocator = std.testing.allocator;
+    const native_mod = @import("../ops/native_compute.zig");
+
+    var weight_store = native_mod.WeightStore{
+        .allocator = allocator,
+        .resident_weights = .empty,
+        .lazy_weights = .empty,
+    };
+    defer {
+        weight_store.resident_weights.deinit(allocator);
+        weight_store.lazy_weights.deinit(allocator);
+        native_mod.deinitPrefetchQueue(&weight_store);
+    }
+    var compute = native_mod.NativeCompute.init(allocator, &weight_store, null);
+    var cb = compute.computeBackend();
+
+    const values = [_]f32{
+        1.0,  2.0,
+        3.0,  4.0,
+        5.0,  6.0,
+        7.0,  8.0,
+        9.0,  10.0,
+        11.0, 12.0,
+    };
+    const output_ct = try cb.fromFloat32Shape(&values, &.{ 6, 2 });
+    const output_storage = try allocator.alloc(ops_mod.CT, 1);
+    output_storage[0] = output_ct;
+    var resident_outputs = session_mod.ResidentOutputs{
+        .outputs = output_storage,
+        .backend = &cb,
+        .allocator = allocator,
+    };
+    defer resident_outputs.deinit();
+
+    var pipeline = EmbeddingPipeline{
+        .allocator = allocator,
+        .session = undefined,
+        .tok = undefined,
+        .config = .{ .pooling = .last, .normalize = false },
+    };
+
+    const mask = [_]i32{ 1, 1, 0, 1, 0, 0 };
+    const pooled = try pipeline.residentPoolTextOutput(&resident_outputs, &mask, 2, 3);
+    defer pooled.deinit();
+
+    const shape = try cb.tensorShape(pooled.value, allocator);
+    defer allocator.free(shape);
+    try std.testing.expectEqualSlices(i64, &.{ 2, 2 }, shape);
+
+    const host = try cb.toFloat32(pooled.value, allocator);
+    defer allocator.free(host);
+    try std.testing.expectEqualSlices(f32, &.{ 3.0, 4.0, 7.0, 8.0 }, host);
+}
+
 test "pool3D last uses final non-padding token and normalizes" {
     const allocator = std.testing.allocator;
 
@@ -1522,6 +1907,51 @@ test "active token length trims trailing padding but keeps at least one token" {
     try std.testing.expectEqual(@as(usize, 3), EmbeddingPipeline.activeTokenLength(&.{ 1, 1, 1, 0, 0 }));
     try std.testing.expectEqual(@as(usize, 4), EmbeddingPipeline.activeTokenLength(&.{ 1, 0, 0, 1, 0 }));
     try std.testing.expectEqual(@as(usize, 1), EmbeddingPipeline.activeTokenLength(&.{ 0, 0, 0 }));
+}
+
+test "resident qwen3 embedding eligibility accepts dense metal qwen3 only" {
+    var cfg = gpt_arch.Config{
+        .family = .qwen3,
+        .hidden_size = 1024,
+        .num_hidden_layers = 28,
+        .num_attention_heads = 16,
+        .num_key_value_heads = 8,
+        .intermediate_size = 3072,
+    };
+
+    const embedding_cfg = EmbeddingConfig{
+        .pooling = .last,
+        .text_prefix = "Document: ",
+        .trim_padding_to_batch_max = true,
+        .resident_qwen3_embedding = true,
+    };
+
+    try std.testing.expect(residentQwen3EmbeddingEligibleForBackend(.metal, cfg, embedding_cfg));
+    try std.testing.expect(!residentQwen3EmbeddingEligibleForBackend(.metal, cfg, .{}));
+    try std.testing.expect(!residentQwen3EmbeddingEligibleForBackend(.native, cfg, embedding_cfg));
+
+    cfg.family = .qwen3_5;
+    try std.testing.expect(!residentQwen3EmbeddingEligibleForBackend(.metal, cfg, embedding_cfg));
+    cfg.family = .qwen3;
+
+    cfg.num_local_experts = 4;
+    cfg.num_experts_per_tok = 2;
+    try std.testing.expect(!residentQwen3EmbeddingEligibleForBackend(.metal, cfg, embedding_cfg));
+    cfg.num_local_experts = 0;
+    cfg.num_experts_per_tok = 0;
+
+    cfg.image_token_index = 151655;
+    cfg.mm_tokens_per_image = 256;
+    try std.testing.expect(!residentQwen3EmbeddingEligibleForBackend(.metal, cfg, embedding_cfg));
+    cfg.image_token_index = -1;
+    cfg.mm_tokens_per_image = 0;
+
+    cfg.ple_hidden_size = 1024;
+    try std.testing.expect(!residentQwen3EmbeddingEligibleForBackend(.metal, cfg, embedding_cfg));
+    cfg.ple_hidden_size = 0;
+
+    cfg.sliding_window = 4096;
+    try std.testing.expect(!residentQwen3EmbeddingEligibleForBackend(.metal, cfg, embedding_cfg));
 }
 
 test "resident projected input selection supports 3d cls pooling" {

--- a/zig/pkg/termite/src/pipelines/embedding.zig
+++ b/zig/pkg/termite/src/pipelines/embedding.zig
@@ -22,7 +22,9 @@ const std = @import("std");
 const platform = @import("antfly_platform");
 const backends = @import("../backends/backends.zig");
 const linalg = @import("termite_linalg");
-const Tokenizer = @import("termite_tokenizer").Tokenizer;
+const tokenizer_mod = @import("termite_tokenizer");
+const Tokenizer = tokenizer_mod.Tokenizer;
+const EncodeResult = tokenizer_mod.EncodeResult;
 const Tensor = backends.Tensor;
 const session_mod = @import("../backends/session.zig");
 const ops_mod = @import("../ops/ops.zig");
@@ -49,6 +51,10 @@ pub const EmbeddingConfig = struct {
     /// Optional text prefix applied before tokenization. Jina v5 text models
     /// default to document embeddings by encoding "Document: " + text.
     text_prefix: []const u8 = "",
+    /// Trim padded text batches to the longest active sequence in the batch
+    /// before encoder execution. Useful for decoder-style embedders where
+    /// padding to the architectural context window is prohibitively expensive.
+    trim_padding_to_batch_max: bool = false,
     /// For CLIP/SigLIP multimodal models: image size for vision encoder.
     image_size: u32 = 224,
     /// For CLAP audio models: mel spectrogram configuration.
@@ -184,12 +190,14 @@ pub const EmbeddingPipeline = struct {
         const max_len = self.config.max_length;
         const batch = texts.len;
 
-        // Tokenize all texts with [CLS] + tokens + [SEP] + padding
-        const all_ids = try alloc.alloc(i32, batch * max_len);
-        defer alloc.free(all_ids);
-        const all_mask = try alloc.alloc(i32, batch * max_len);
-        defer alloc.free(all_mask);
+        const encoded = try alloc.alloc(EncodeResult, batch);
+        defer alloc.free(encoded);
+        var encoded_count: usize = 0;
+        defer {
+            for (encoded[0..encoded_count]) |*result| result.deinit();
+        }
 
+        var effective_len: usize = if (self.config.trim_padding_to_batch_max) 1 else max_len;
         for (texts, 0..) |text, i| {
             const token_text = if (self.config.text_prefix.len > 0)
                 try std.fmt.allocPrint(alloc, "{s}{s}", .{ self.config.text_prefix, text })
@@ -197,26 +205,36 @@ pub const EmbeddingPipeline = struct {
                 text;
             defer if (self.config.text_prefix.len > 0) alloc.free(token_text);
 
-            var result = try self.tok.encodeForModel(alloc, token_text, max_len);
-            defer result.deinit();
+            encoded[i] = try self.tok.encodeForModel(alloc, token_text, max_len);
+            encoded_count += 1;
+            if (self.config.trim_padding_to_batch_max) {
+                effective_len = @max(effective_len, activeTokenLength(encoded[i].attention_mask));
+            }
+        }
 
-            @memcpy(all_ids[i * max_len .. (i + 1) * max_len], result.ids);
-            @memcpy(all_mask[i * max_len .. (i + 1) * max_len], result.attention_mask);
+        const all_ids = try alloc.alloc(i32, batch * effective_len);
+        defer alloc.free(all_ids);
+        const all_mask = try alloc.alloc(i32, batch * effective_len);
+        defer alloc.free(all_mask);
+
+        for (encoded[0..batch], 0..) |result, i| {
+            @memcpy(all_ids[i * effective_len .. (i + 1) * effective_len], result.ids[0..effective_len]);
+            @memcpy(all_mask[i * effective_len .. (i + 1) * effective_len], result.attention_mask[0..effective_len]);
         }
 
         // Convert i32 token IDs to i64 for ONNX Runtime (expects int64 tensors)
-        const ids_i64 = try alloc.alloc(i64, batch * max_len);
+        const ids_i64 = try alloc.alloc(i64, batch * effective_len);
         defer alloc.free(ids_i64);
-        const mask_i64 = try alloc.alloc(i64, batch * max_len);
+        const mask_i64 = try alloc.alloc(i64, batch * effective_len);
         defer alloc.free(mask_i64);
 
-        for (0..batch * max_len) |j| {
+        for (0..batch * effective_len) |j| {
             ids_i64[j] = @intCast(all_ids[j]);
             mask_i64[j] = @intCast(all_mask[j]);
         }
 
         // Build input tensors
-        const shape = [_]i64{ @intCast(batch), @intCast(max_len) };
+        const shape = [_]i64{ @intCast(batch), @intCast(effective_len) };
         var input_ids_tensor = try Tensor.initInt64(alloc, "input_ids", &shape, ids_i64);
         defer input_ids_tensor.deinit();
         var attention_mask_tensor = try Tensor.initInt64(alloc, "attention_mask", &shape, mask_i64);
@@ -237,7 +255,7 @@ pub const EmbeddingPipeline = struct {
 
         const inputs = if (needs_token_type) blk: {
             // Create zeros tensor for token_type_ids
-            const zeros = try alloc.alloc(i64, batch * max_len);
+            const zeros = try alloc.alloc(i64, batch * effective_len);
             defer alloc.free(zeros);
             @memset(zeros, 0);
             token_type_tensor = try Tensor.initInt64(alloc, "token_type_ids", &shape, zeros);
@@ -245,7 +263,7 @@ pub const EmbeddingPipeline = struct {
         } else &[_]Tensor{ input_ids_tensor, attention_mask_tensor };
 
         if (self.text_projection) |proj| {
-            if (try self.tryEmbedTextResidentProjection(inputs, all_mask, batch, max_len, proj)) |resident_embeddings| {
+            if (try self.tryEmbedTextResidentProjection(inputs, all_mask, batch, effective_len, proj)) |resident_embeddings| {
                 return resident_embeddings;
             }
         }
@@ -266,7 +284,7 @@ pub const EmbeddingPipeline = struct {
         const output_shape = output.shape;
 
         const embeddings = switch (output_shape.len) {
-            3 => try self.pool3D(output, all_mask, batch, max_len, self.text_projection == null),
+            3 => try self.pool3D(output, all_mask, batch, effective_len, self.text_projection == null),
             2 => try self.extract2D(output, batch, self.text_projection == null),
             else => return error.UnexpectedOutputShape,
         };
@@ -277,6 +295,18 @@ pub const EmbeddingPipeline = struct {
         }
 
         return embeddings;
+    }
+
+    fn activeTokenLength(mask: []const i32) usize {
+        var last_active: usize = 0;
+        var found = false;
+        for (mask, 0..) |value, idx| {
+            if (value > 0) {
+                last_active = idx;
+                found = true;
+            }
+        }
+        return if (found) last_active + 1 else 1;
     }
 
     /// Pool 3D output [batch, seq, hidden] -> [batch][hidden]
@@ -1486,6 +1516,12 @@ test "pool3D last uses final non-padding token and normalizes" {
     try std.testing.expectApproxEqAbs(@as(f32, 0.8), embeddings[0][1], 1e-6);
     try std.testing.expectApproxEqAbs(@as(f32, 0.0), embeddings[1][0], 1e-6);
     try std.testing.expectApproxEqAbs(@as(f32, 1.0), embeddings[1][1], 1e-6);
+}
+
+test "active token length trims trailing padding but keeps at least one token" {
+    try std.testing.expectEqual(@as(usize, 3), EmbeddingPipeline.activeTokenLength(&.{ 1, 1, 1, 0, 0 }));
+    try std.testing.expectEqual(@as(usize, 4), EmbeddingPipeline.activeTokenLength(&.{ 1, 0, 0, 1, 0 }));
+    try std.testing.expectEqual(@as(usize, 1), EmbeddingPipeline.activeTokenLength(&.{ 0, 0, 0 }));
 }
 
 test "resident projected input selection supports 3d cls pooling" {

--- a/zig/pkg/termite/src/registry/download.zig
+++ b/zig/pkg/termite/src/registry/download.zig
@@ -583,6 +583,27 @@ fn appendPreferredSafetensorsPayload(
     return appendFirstMatchingFile(allocator, to_download, files, &safetensors_candidates);
 }
 
+fn isAdapterArtifact(path: []const u8) bool {
+    if (!std.mem.startsWith(u8, path, "adapters/")) return false;
+    return std.mem.endsWith(u8, path, "/adapter_config.json") or
+        std.mem.endsWith(u8, path, "/adapter_model.safetensors");
+}
+
+fn appendAdapterArtifacts(
+    allocator: std.mem.Allocator,
+    to_download: *std.ArrayListUnmanaged(HubFile),
+    files: []const HubFile,
+) !usize {
+    var appended: usize = 0;
+    for (files) |file| {
+        if (!isAdapterArtifact(file.name)) continue;
+        if (try appendMatchingFileIfMissing(allocator, to_download, files, file.name)) {
+            appended += 1;
+        }
+    }
+    return appended;
+}
+
 fn hasFile(files: []const HubFile, candidate: []const u8) bool {
     for (files) |file| {
         if (std.mem.eql(u8, file.name, candidate)) return true;
@@ -817,6 +838,7 @@ pub fn downloadModel(
                 }
             }
         }
+        _ = try appendAdapterArtifacts(allocator, &to_download, files);
     }
 
     var found_model_payload = false;
@@ -1511,6 +1533,28 @@ test "safetensors selection falls back to single file without usable index" {
 
     try std.testing.expectEqual(@as(usize, 1), to_download.items.len);
     try std.testing.expectEqualStrings("model.safetensors", to_download.items[0].name);
+}
+
+test "adapter artifact selection includes jina task adapter sidecars" {
+    const allocator = std.testing.allocator;
+
+    const files = [_]HubFile{
+        .{ .name = "config.json" },
+        .{ .name = "adapters/retrieval/adapter_config.json" },
+        .{ .name = "adapters/retrieval/adapter_model.safetensors" },
+        .{ .name = "adapters/retrieval/README.md" },
+        .{ .name = "model.safetensors" },
+    };
+
+    var to_download = std.ArrayListUnmanaged(HubFile).empty;
+    defer to_download.deinit(allocator);
+
+    const count = try appendAdapterArtifacts(allocator, &to_download, &files);
+
+    try std.testing.expectEqual(@as(usize, 2), count);
+    try std.testing.expectEqual(@as(usize, 2), to_download.items.len);
+    try std.testing.expectEqualStrings("adapters/retrieval/adapter_config.json", to_download.items[0].name);
+    try std.testing.expectEqualStrings("adapters/retrieval/adapter_model.safetensors", to_download.items[1].name);
 }
 
 test "verify file sha256 matches expected digest" {

--- a/zig/pkg/termite/src/server/model_manager.zig
+++ b/zig/pkg/termite/src/server/model_manager.zig
@@ -736,6 +736,7 @@ pub const LoadedModel = struct {
             },
             .text_prefix = self.manifest.embedding_text_prefix,
             .trim_padding_to_batch_max = isJinaStyleEmbeddingManifest(&self.manifest),
+            .resident_qwen3_embedding = isJinaStyleEmbeddingManifest(&self.manifest),
         });
         if (session_factory.getClipConfig(self.session)) |cfg| {
             pipeline.config.image_size = cfg.image_size;

--- a/zig/pkg/termite/src/server/model_manager.zig
+++ b/zig/pkg/termite/src/server/model_manager.zig
@@ -735,6 +735,7 @@ pub const LoadedModel = struct {
                 .last => .last,
             },
             .text_prefix = self.manifest.embedding_text_prefix,
+            .trim_padding_to_batch_max = isJinaStyleEmbeddingManifest(&self.manifest),
         });
         if (session_factory.getClipConfig(self.session)) |cfg| {
             pipeline.config.image_size = cfg.image_size;
@@ -895,6 +896,11 @@ pub const LoadedModel = struct {
         self.allocator.free(self.model_dir);
     }
 };
+
+fn isJinaStyleEmbeddingManifest(manifest: *const manifest_mod.ModelManifest) bool {
+    return std.mem.eql(u8, manifest.config_model_arch, "jina_embeddings_v5") or
+        (manifest.pooling == .last and std.mem.eql(u8, manifest.embedding_text_prefix, "Document: "));
+}
 
 pub const ModelManager = struct {
     allocator: std.mem.Allocator,

--- a/zig/pkg/termite/src/server/model_manager.zig
+++ b/zig/pkg/termite/src/server/model_manager.zig
@@ -732,7 +732,9 @@ pub const LoadedModel = struct {
                 .mean => .mean,
                 .cls => .cls,
                 .max => .max,
+                .last => .last,
             },
+            .text_prefix = self.manifest.embedding_text_prefix,
         });
         if (session_factory.getClipConfig(self.session)) |cfg| {
             pipeline.config.image_size = cfg.image_size;

--- a/zig/pkg/termite/src/server/server.zig
+++ b/zig/pkg/termite/src/server/server.zig
@@ -1140,6 +1140,12 @@ pub const Node = struct {
             return ctx.status(500).json(.{ .@"error" = "INFERENCE_FAILED", .message = @errorName(err) });
 
         var pipeline = model.embeddingPipeline(ctx.allocator);
+        applyDenseEmbeddingRequestOptions(&pipeline, &model.manifest, request) catch |err| {
+            return ctx.status(400).json(.{
+                .@"error" = "INVALID_REQUEST",
+                .message = embedRequestOptionErrorMessage(err),
+            });
+        };
         const pipeline_start = embedTimingStart();
         const embeddings = embedDenseInputs(ctx.allocator, &pipeline, &inputs) catch |err|
             return ctx.status(500).json(.{ .@"error" = "INFERENCE_FAILED", .message = @errorName(err) });
@@ -5067,6 +5073,8 @@ const ParsedEmbedRequest = struct {
     input: std.json.Value,
     encoding_format: ?[]const u8,
     dimensions: ?i64,
+    task: ?[]const u8,
+    prompt_name: ?[]const u8,
 };
 
 const ParsedTextEmbedInput = struct {
@@ -5114,11 +5122,23 @@ fn parseEmbedRequest(body: std.json.Value) !ParsedEmbedRequest {
         break :blk value.integer;
     } else null;
 
+    const task: ?[]const u8 = if (obj.get("task")) |value| blk: {
+        if (value != .string) return error.TaskMustBeString;
+        break :blk value.string;
+    } else null;
+
+    const prompt_name: ?[]const u8 = if (obj.get("prompt_name")) |value| blk: {
+        if (value != .string) return error.PromptNameMustBeString;
+        break :blk value.string;
+    } else null;
+
     return .{
         .model = model_value.string,
         .input = input_value,
         .encoding_format = encoding_format,
         .dimensions = dimensions,
+        .task = task,
+        .prompt_name = prompt_name,
     };
 }
 
@@ -5129,7 +5149,43 @@ fn embedRequestParseErrorMessage(err: anyerror) []const u8 {
         error.InputRequired => "input is required",
         error.EncodingFormatMustBeString => "encoding_format must be a string",
         error.DimensionsMustBeInteger => "dimensions must be an integer",
+        error.TaskMustBeString => "task must be a string",
+        error.PromptNameMustBeString => "prompt_name must be a string",
         else => "invalid embedding request",
+    };
+}
+
+fn isJinaV5EmbeddingManifest(manifest: *const manifest_mod.ModelManifest) bool {
+    return std.mem.eql(u8, manifest.config_model_arch, "jina_embeddings_v5") or
+        (manifest.pooling == .last and
+            std.mem.eql(u8, manifest.embedding_text_prefix, "Document: "));
+}
+
+fn applyDenseEmbeddingRequestOptions(
+    pipeline: *embedding_mod.EmbeddingPipeline,
+    manifest: *const manifest_mod.ModelManifest,
+    request: ParsedEmbedRequest,
+) !void {
+    if (!isJinaV5EmbeddingManifest(manifest)) return;
+
+    const task = request.task orelse "retrieval";
+    if (!std.mem.eql(u8, task, "retrieval")) return error.UnsupportedEmbeddingTask;
+
+    const prompt_name = request.prompt_name orelse "document";
+    if (std.mem.eql(u8, prompt_name, "query")) {
+        pipeline.config.text_prefix = "Query: ";
+    } else if (std.mem.eql(u8, prompt_name, "document")) {
+        pipeline.config.text_prefix = "Document: ";
+    } else {
+        return error.UnsupportedEmbeddingPromptName;
+    }
+}
+
+fn embedRequestOptionErrorMessage(err: anyerror) []const u8 {
+    return switch (err) {
+        error.UnsupportedEmbeddingTask => "only task=\"retrieval\" is supported for this embedding model in this runtime",
+        error.UnsupportedEmbeddingPromptName => "prompt_name must be \"query\" or \"document\"",
+        else => "invalid embedding options",
     };
 }
 
@@ -5434,6 +5490,74 @@ test "termite embeddings validates encoding format and dimensions" {
     try std.testing.expectEqual(@as(?usize, 128), try parseRequestedEmbeddingDimensions(128));
     try std.testing.expectError(error.InvalidEmbeddingDimensions, parseRequestedEmbeddingDimensions(0));
     try std.testing.expectError(error.InvalidEmbeddingDimensions, parseRequestedEmbeddingDimensions(-1));
+}
+
+test "jina embedding request options switch query and document prefixes" {
+    const allocator = std.testing.allocator;
+    var manifest = manifest_mod.ModelManifest{
+        .allocator = allocator,
+        .pooling = .last,
+    };
+    defer manifest.deinit();
+    manifest.embedding_text_prefix = try allocator.dupe(u8, "Document: ");
+    manifest.tasks = try allocator.alloc([]const u8, 1);
+    manifest.tasks[0] = try allocator.dupe(u8, "retrieval");
+
+    var pipeline = embedding_mod.EmbeddingPipeline{
+        .allocator = allocator,
+        .session = undefined,
+        .tok = undefined,
+        .config = .{},
+    };
+
+    const query_request = ParsedEmbedRequest{
+        .model = "jina",
+        .input = .{ .string = "hello" },
+        .encoding_format = null,
+        .dimensions = null,
+        .task = "retrieval",
+        .prompt_name = "query",
+    };
+    try applyDenseEmbeddingRequestOptions(&pipeline, &manifest, query_request);
+    try std.testing.expectEqualStrings("Query: ", pipeline.config.text_prefix);
+
+    const bad_task = ParsedEmbedRequest{
+        .model = "jina",
+        .input = .{ .string = "hello" },
+        .encoding_format = null,
+        .dimensions = null,
+        .task = "classification",
+        .prompt_name = "document",
+    };
+    try std.testing.expectError(error.UnsupportedEmbeddingTask, applyDenseEmbeddingRequestOptions(&pipeline, &manifest, bad_task));
+}
+
+test "jina embedding request options support merged qwen3 task repos without manifest tasks" {
+    const allocator = std.testing.allocator;
+    var manifest = manifest_mod.ModelManifest{
+        .allocator = allocator,
+        .pooling = .last,
+    };
+    defer manifest.deinit();
+    manifest.embedding_text_prefix = try allocator.dupe(u8, "Document: ");
+
+    var pipeline = embedding_mod.EmbeddingPipeline{
+        .allocator = allocator,
+        .session = undefined,
+        .tok = undefined,
+        .config = .{},
+    };
+
+    const request = ParsedEmbedRequest{
+        .model = "jina-merged",
+        .input = .{ .string = "hello" },
+        .encoding_format = null,
+        .dimensions = null,
+        .task = "retrieval",
+        .prompt_name = "query",
+    };
+    try applyDenseEmbeddingRequestOptions(&pipeline, &manifest, request);
+    try std.testing.expectEqualStrings("Query: ", pipeline.config.text_prefix);
 }
 
 fn expectJsonNumber(expected: f64, value: std.json.Value) !void {

--- a/zig/pkg/termite/src/server/server.zig
+++ b/zig/pkg/termite/src/server/server.zig
@@ -5073,8 +5073,57 @@ const ParsedEmbedRequest = struct {
     input: std.json.Value,
     encoding_format: ?[]const u8,
     dimensions: ?i64,
-    input_type: ?[]const u8,
+    task_type: ?EmbeddingTaskType,
 };
+
+const EmbeddingTaskType = enum {
+    RETRIEVAL_QUERY,
+    RETRIEVAL_DOCUMENT,
+    QUESTION_ANSWERING,
+    FACT_VERIFICATION,
+    CODE_RETRIEVAL_QUERY,
+    CLASSIFICATION,
+    CLUSTERING,
+    SEMANTIC_SIMILARITY,
+
+    fn usesQueryPrefix(self: EmbeddingTaskType) bool {
+        return switch (self) {
+            .RETRIEVAL_QUERY,
+            .QUESTION_ANSWERING,
+            .FACT_VERIFICATION,
+            .CODE_RETRIEVAL_QUERY,
+            => true,
+            else => false,
+        };
+    }
+
+    fn usesDocumentPrefix(self: EmbeddingTaskType) bool {
+        return switch (self) {
+            .RETRIEVAL_DOCUMENT => true,
+            else => false,
+        };
+    }
+};
+
+fn parseEmbeddingTaskType(value: []const u8) ?EmbeddingTaskType {
+    if (std.mem.eql(u8, value, "RETRIEVAL_QUERY")) return .RETRIEVAL_QUERY;
+    if (std.mem.eql(u8, value, "RETRIEVAL_DOCUMENT")) return .RETRIEVAL_DOCUMENT;
+    if (std.mem.eql(u8, value, "QUESTION_ANSWERING")) return .QUESTION_ANSWERING;
+    if (std.mem.eql(u8, value, "FACT_VERIFICATION")) return .FACT_VERIFICATION;
+    if (std.mem.eql(u8, value, "CODE_RETRIEVAL_QUERY")) return .CODE_RETRIEVAL_QUERY;
+    if (std.mem.eql(u8, value, "CLASSIFICATION")) return .CLASSIFICATION;
+    if (std.mem.eql(u8, value, "CLUSTERING")) return .CLUSTERING;
+    if (std.mem.eql(u8, value, "SEMANTIC_SIMILARITY")) return .SEMANTIC_SIMILARITY;
+    return null;
+}
+
+fn parseLegacyEmbeddingInputType(value: []const u8) ?EmbeddingTaskType {
+    if (std.mem.eql(u8, value, "search_query") or std.mem.eql(u8, value, "query")) return .RETRIEVAL_QUERY;
+    if (std.mem.eql(u8, value, "search_document") or std.mem.eql(u8, value, "document")) return .RETRIEVAL_DOCUMENT;
+    if (std.mem.eql(u8, value, "classification")) return .CLASSIFICATION;
+    if (std.mem.eql(u8, value, "clustering")) return .CLUSTERING;
+    return null;
+}
 
 const ParsedTextEmbedInput = struct {
     index: usize,
@@ -5121,17 +5170,26 @@ fn parseEmbedRequest(body: std.json.Value) !ParsedEmbedRequest {
         break :blk value.integer;
     } else null;
 
-    const input_type: ?[]const u8 = if (obj.get("input_type")) |value| blk: {
-        if (value != .string) return error.InputTypeMustBeString;
-        break :blk value.string;
+    const task_type: ?EmbeddingTaskType = if (obj.get("task_type")) |value| blk: {
+        if (value != .string) return error.TaskTypeMustBeString;
+        break :blk parseEmbeddingTaskType(value.string) orelse return error.UnsupportedEmbeddingTaskType;
     } else null;
+
+    const legacy_task_type: ?EmbeddingTaskType = if (obj.get("input_type")) |value| blk: {
+        if (value != .string) return error.InputTypeMustBeString;
+        break :blk parseLegacyEmbeddingInputType(value.string) orelse return error.UnsupportedEmbeddingInputType;
+    } else null;
+
+    if (task_type != null and legacy_task_type != null and task_type.? != legacy_task_type.?) {
+        return error.ConflictingEmbeddingTaskTypes;
+    }
 
     return .{
         .model = model_value.string,
         .input = input_value,
         .encoding_format = encoding_format,
         .dimensions = dimensions,
-        .input_type = input_type,
+        .task_type = task_type orelse legacy_task_type,
     };
 }
 
@@ -5142,7 +5200,11 @@ fn embedRequestParseErrorMessage(err: anyerror) []const u8 {
         error.InputRequired => "input is required",
         error.EncodingFormatMustBeString => "encoding_format must be a string",
         error.DimensionsMustBeInteger => "dimensions must be an integer",
+        error.TaskTypeMustBeString => "task_type must be a string",
+        error.UnsupportedEmbeddingTaskType => "task_type must be one of RETRIEVAL_QUERY, RETRIEVAL_DOCUMENT, QUESTION_ANSWERING, FACT_VERIFICATION, CODE_RETRIEVAL_QUERY, CLASSIFICATION, CLUSTERING, or SEMANTIC_SIMILARITY",
         error.InputTypeMustBeString => "input_type must be a string",
+        error.UnsupportedEmbeddingInputType => "input_type must be a legacy alias for a supported embedding task type",
+        error.ConflictingEmbeddingTaskTypes => "task_type and input_type specify different embedding task types",
         else => "invalid embedding request",
     };
 }
@@ -5160,19 +5222,19 @@ fn applyDenseEmbeddingRequestOptions(
 ) !void {
     if (!isJinaV5EmbeddingManifest(manifest)) return;
 
-    const input_type = request.input_type orelse "search_document";
-    if (std.mem.eql(u8, input_type, "search_query") or std.mem.eql(u8, input_type, "query")) {
+    const task_type = request.task_type orelse EmbeddingTaskType.RETRIEVAL_DOCUMENT;
+    if (task_type.usesQueryPrefix()) {
         pipeline.config.text_prefix = "Query: ";
-    } else if (std.mem.eql(u8, input_type, "search_document") or std.mem.eql(u8, input_type, "document")) {
+    } else if (task_type.usesDocumentPrefix()) {
         pipeline.config.text_prefix = "Document: ";
     } else {
-        return error.UnsupportedEmbeddingInputType;
+        return error.UnsupportedEmbeddingTaskType;
     }
 }
 
 fn embedRequestOptionErrorMessage(err: anyerror) []const u8 {
     return switch (err) {
-        error.UnsupportedEmbeddingInputType => "input_type must be \"search_query\" or \"search_document\" (\"query\"/\"document\" aliases are also accepted)",
+        error.UnsupportedEmbeddingTaskType => "task_type must be a query/document retrieval task for this embedding model",
         else => "invalid embedding options",
     };
 }
@@ -5503,9 +5565,19 @@ test "jina embedding request options switch query and document prefixes" {
         .input = .{ .string = "hello" },
         .encoding_format = null,
         .dimensions = null,
-        .input_type = "search_query",
+        .task_type = .RETRIEVAL_QUERY,
     };
     try applyDenseEmbeddingRequestOptions(&pipeline, &manifest, query_request);
+    try std.testing.expectEqualStrings("Query: ", pipeline.config.text_prefix);
+
+    const qa_request = ParsedEmbedRequest{
+        .model = "jina",
+        .input = .{ .string = "hello" },
+        .encoding_format = null,
+        .dimensions = null,
+        .task_type = .QUESTION_ANSWERING,
+    };
+    try applyDenseEmbeddingRequestOptions(&pipeline, &manifest, qa_request);
     try std.testing.expectEqualStrings("Query: ", pipeline.config.text_prefix);
 
     const document_request = ParsedEmbedRequest{
@@ -5513,22 +5585,22 @@ test "jina embedding request options switch query and document prefixes" {
         .input = .{ .string = "hello" },
         .encoding_format = null,
         .dimensions = null,
-        .input_type = "document",
+        .task_type = .RETRIEVAL_DOCUMENT,
     };
     try applyDenseEmbeddingRequestOptions(&pipeline, &manifest, document_request);
     try std.testing.expectEqualStrings("Document: ", pipeline.config.text_prefix);
 
-    const bad_input_type = ParsedEmbedRequest{
+    const bad_task_type = ParsedEmbedRequest{
         .model = "jina",
         .input = .{ .string = "hello" },
         .encoding_format = null,
         .dimensions = null,
-        .input_type = "classification",
+        .task_type = .CLASSIFICATION,
     };
-    try std.testing.expectError(error.UnsupportedEmbeddingInputType, applyDenseEmbeddingRequestOptions(&pipeline, &manifest, bad_input_type));
+    try std.testing.expectError(error.UnsupportedEmbeddingTaskType, applyDenseEmbeddingRequestOptions(&pipeline, &manifest, bad_task_type));
 }
 
-test "jina embedding request options support merged qwen3 task repos without manifest tasks" {
+test "jina embedding request options support legacy input_type aliases" {
     const allocator = std.testing.allocator;
     var manifest = manifest_mod.ModelManifest{
         .allocator = allocator,
@@ -5544,15 +5616,52 @@ test "jina embedding request options support merged qwen3 task repos without man
         .config = .{},
     };
 
-    const request = ParsedEmbedRequest{
-        .model = "jina-merged",
-        .input = .{ .string = "hello" },
-        .encoding_format = null,
-        .dimensions = null,
-        .input_type = "query",
-    };
+    const body =
+        \\{
+        \\  "model": "jina-merged",
+        \\  "input": "hello",
+        \\  "input_type": "query"
+        \\}
+    ;
+    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, body, .{});
+    defer parsed.deinit();
+
+    const request = try parseEmbedRequest(parsed.value);
+    try std.testing.expectEqual(EmbeddingTaskType.RETRIEVAL_QUERY, request.task_type.?);
     try applyDenseEmbeddingRequestOptions(&pipeline, &manifest, request);
     try std.testing.expectEqualStrings("Query: ", pipeline.config.text_prefix);
+}
+
+test "embedding request parser uses Google task_type as canonical field" {
+    const allocator = std.testing.allocator;
+    const body =
+        \\{
+        \\  "model": "jina",
+        \\  "input": "hello",
+        \\  "task_type": "RETRIEVAL_DOCUMENT"
+        \\}
+    ;
+    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, body, .{});
+    defer parsed.deinit();
+
+    const request = try parseEmbedRequest(parsed.value);
+    try std.testing.expectEqual(EmbeddingTaskType.RETRIEVAL_DOCUMENT, request.task_type.?);
+}
+
+test "embedding request parser rejects conflicting task aliases" {
+    const allocator = std.testing.allocator;
+    const body =
+        \\{
+        \\  "model": "jina",
+        \\  "input": "hello",
+        \\  "task_type": "RETRIEVAL_QUERY",
+        \\  "input_type": "search_document"
+        \\}
+    ;
+    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, body, .{});
+    defer parsed.deinit();
+
+    try std.testing.expectError(error.ConflictingEmbeddingTaskTypes, parseEmbedRequest(parsed.value));
 }
 
 fn expectJsonNumber(expected: f64, value: std.json.Value) !void {

--- a/zig/pkg/termite/src/server/server.zig
+++ b/zig/pkg/termite/src/server/server.zig
@@ -5073,8 +5073,7 @@ const ParsedEmbedRequest = struct {
     input: std.json.Value,
     encoding_format: ?[]const u8,
     dimensions: ?i64,
-    task: ?[]const u8,
-    prompt_name: ?[]const u8,
+    input_type: ?[]const u8,
 };
 
 const ParsedTextEmbedInput = struct {
@@ -5122,13 +5121,8 @@ fn parseEmbedRequest(body: std.json.Value) !ParsedEmbedRequest {
         break :blk value.integer;
     } else null;
 
-    const task: ?[]const u8 = if (obj.get("task")) |value| blk: {
-        if (value != .string) return error.TaskMustBeString;
-        break :blk value.string;
-    } else null;
-
-    const prompt_name: ?[]const u8 = if (obj.get("prompt_name")) |value| blk: {
-        if (value != .string) return error.PromptNameMustBeString;
+    const input_type: ?[]const u8 = if (obj.get("input_type")) |value| blk: {
+        if (value != .string) return error.InputTypeMustBeString;
         break :blk value.string;
     } else null;
 
@@ -5137,8 +5131,7 @@ fn parseEmbedRequest(body: std.json.Value) !ParsedEmbedRequest {
         .input = input_value,
         .encoding_format = encoding_format,
         .dimensions = dimensions,
-        .task = task,
-        .prompt_name = prompt_name,
+        .input_type = input_type,
     };
 }
 
@@ -5149,8 +5142,7 @@ fn embedRequestParseErrorMessage(err: anyerror) []const u8 {
         error.InputRequired => "input is required",
         error.EncodingFormatMustBeString => "encoding_format must be a string",
         error.DimensionsMustBeInteger => "dimensions must be an integer",
-        error.TaskMustBeString => "task must be a string",
-        error.PromptNameMustBeString => "prompt_name must be a string",
+        error.InputTypeMustBeString => "input_type must be a string",
         else => "invalid embedding request",
     };
 }
@@ -5168,23 +5160,19 @@ fn applyDenseEmbeddingRequestOptions(
 ) !void {
     if (!isJinaV5EmbeddingManifest(manifest)) return;
 
-    const task = request.task orelse "retrieval";
-    if (!std.mem.eql(u8, task, "retrieval")) return error.UnsupportedEmbeddingTask;
-
-    const prompt_name = request.prompt_name orelse "document";
-    if (std.mem.eql(u8, prompt_name, "query")) {
+    const input_type = request.input_type orelse "search_document";
+    if (std.mem.eql(u8, input_type, "search_query") or std.mem.eql(u8, input_type, "query")) {
         pipeline.config.text_prefix = "Query: ";
-    } else if (std.mem.eql(u8, prompt_name, "document")) {
+    } else if (std.mem.eql(u8, input_type, "search_document") or std.mem.eql(u8, input_type, "document")) {
         pipeline.config.text_prefix = "Document: ";
     } else {
-        return error.UnsupportedEmbeddingPromptName;
+        return error.UnsupportedEmbeddingInputType;
     }
 }
 
 fn embedRequestOptionErrorMessage(err: anyerror) []const u8 {
     return switch (err) {
-        error.UnsupportedEmbeddingTask => "only task=\"retrieval\" is supported for this embedding model in this runtime",
-        error.UnsupportedEmbeddingPromptName => "prompt_name must be \"query\" or \"document\"",
+        error.UnsupportedEmbeddingInputType => "input_type must be \"search_query\" or \"search_document\" (\"query\"/\"document\" aliases are also accepted)",
         else => "invalid embedding options",
     };
 }
@@ -5515,21 +5503,29 @@ test "jina embedding request options switch query and document prefixes" {
         .input = .{ .string = "hello" },
         .encoding_format = null,
         .dimensions = null,
-        .task = "retrieval",
-        .prompt_name = "query",
+        .input_type = "search_query",
     };
     try applyDenseEmbeddingRequestOptions(&pipeline, &manifest, query_request);
     try std.testing.expectEqualStrings("Query: ", pipeline.config.text_prefix);
 
-    const bad_task = ParsedEmbedRequest{
+    const document_request = ParsedEmbedRequest{
         .model = "jina",
         .input = .{ .string = "hello" },
         .encoding_format = null,
         .dimensions = null,
-        .task = "classification",
-        .prompt_name = "document",
+        .input_type = "document",
     };
-    try std.testing.expectError(error.UnsupportedEmbeddingTask, applyDenseEmbeddingRequestOptions(&pipeline, &manifest, bad_task));
+    try applyDenseEmbeddingRequestOptions(&pipeline, &manifest, document_request);
+    try std.testing.expectEqualStrings("Document: ", pipeline.config.text_prefix);
+
+    const bad_input_type = ParsedEmbedRequest{
+        .model = "jina",
+        .input = .{ .string = "hello" },
+        .encoding_format = null,
+        .dimensions = null,
+        .input_type = "classification",
+    };
+    try std.testing.expectError(error.UnsupportedEmbeddingInputType, applyDenseEmbeddingRequestOptions(&pipeline, &manifest, bad_input_type));
 }
 
 test "jina embedding request options support merged qwen3 task repos without manifest tasks" {
@@ -5553,8 +5549,7 @@ test "jina embedding request options support merged qwen3 task repos without man
         .input = .{ .string = "hello" },
         .encoding_format = null,
         .dimensions = null,
-        .task = "retrieval",
-        .prompt_name = "query",
+        .input_type = "query",
     };
     try applyDenseEmbeddingRequestOptions(&pipeline, &manifest, request);
     try std.testing.expectEqualStrings("Query: ", pipeline.config.text_prefix);


### PR DESCRIPTION
## Summary

Adds a resident direct-Metal graph execution path for Jina v5 / Qwen3-style text embeddings. Eligible embedding models now run token lookup, dense Qwen3 layers, final norm, pooling, and normalization on Metal, materializing only final vectors to host.

## What Changed

- Added `qwen3_dense_text_embedding` graph-frame contract.
- Added Jina/Qwen3 embedding pipeline path:
  - graph-frame Metal execution
  - resident Metal fallback
  - existing `session.run` fallback
- Added dense causal no-KV Qwen3 execution on direct Metal.
- Added batched head RMSNorm + RoPE with per-sequence position reset.
- Prepared resident slots for Qwen3/Jina weights, including LoRA-merged Jina retrieval adapter weights.
- Added resident pooling for flattened `[batch * seq, hidden]` outputs.
- Manifest-gated the path to Jina/Qwen3 embedding models only.
- Removed development-only Qwen3 env toggles and unused graph fields.

## Validation

- `zig fmt`
- `git diff --check`
- `zig build termite-test -Dmlx=false -Dmetal=true -Donnx=false -Dcuda=false`
- Real Jina v5 Metal smoke:
  - batch 1 graph success
  - batch 8 graph success
  - graph path confirmed via `text.encoder.qwen3.graph`
- Observed graph encoder timing:
  - batch 1 ~`216ms`
  - batch 8 ~`660-730ms`

## Notes

Scoped to direct Metal dense Jina/Qwen3 embedding manifests. Qwen3.5, MoE, PLE, multimodal, sparse, MLX, ONNX, CUDA, and generic Qwen3 generation remain on existing paths.