### PR TITLE
Fix SearchAF Zig runtime response contracts

### DIFF
--- a/zig/pkg/antfly/src/api/query_contract.zig
+++ b/zig/pkg/antfly/src/api/query_contract.zig
@@ -1685,13 +1685,14 @@ fn applySearchRequestFields(
     generated_fields: ?[]const []const u8,
     req: *db_mod.types.SearchRequest,
 ) ![][]const u8 {
+    const include_all_fields = generated_fields == null;
     const fields: [][]const u8 = if (generated_fields) |items|
         try cloneFields(alloc, items)
     else
         &.{};
     req.fields = fields;
-    req.include_all_fields = false;
-    req.include_stored = fields.len > 0 or req.reranker != null;
+    req.include_all_fields = include_all_fields;
+    req.include_stored = include_all_fields or fields.len > 0 or req.reranker != null;
     req.defer_stored_projection = canDeferStoredProjection(fields);
     return fields;
 }
@@ -4876,6 +4877,41 @@ test "api query contract treats canonical typed scalar term as structured filter
     try std.testing.expect(parsed.req.full_text.? == .match_all);
     try std.testing.expectEqualStrings("{\"term\":{\"path\":\"/published\",\"value\":true}}", parsed.req.filter_query_json);
     try std.testing.expectEqualStrings("", parsed.req.exclusion_query_json);
+}
+
+test "api query contract includes stored source when fields are omitted" {
+    const alloc = std.testing.allocator;
+    const body =
+        \\{"full_text_search":{"match":"needle","field":"content"}}
+    ;
+
+    var parsed = try parseQueryRequest(alloc, null, "docs", body);
+    defer parsed.deinit(alloc);
+
+    try std.testing.expect(parsed.req.include_all_fields);
+    try std.testing.expect(parsed.req.include_stored);
+    try std.testing.expect(!parsed.req.defer_stored_projection);
+    try std.testing.expectEqual(@as(usize, 0), parsed.req.fields.len);
+}
+
+test "api query contract projects stored source when explicit fields are supplied" {
+    const alloc = std.testing.allocator;
+    const body =
+        \\{
+        \\  "full_text_search": {"match": "needle", "field": "content"},
+        \\  "fields": ["path", "filename"]
+        \\}
+    ;
+
+    var parsed = try parseQueryRequest(alloc, null, "docs", body);
+    defer parsed.deinit(alloc);
+
+    try std.testing.expect(!parsed.req.include_all_fields);
+    try std.testing.expect(parsed.req.include_stored);
+    try std.testing.expect(parsed.req.defer_stored_projection);
+    try std.testing.expectEqual(@as(usize, 2), parsed.req.fields.len);
+    try std.testing.expectEqualStrings("path", parsed.req.fields[0]);
+    try std.testing.expectEqualStrings("filename", parsed.req.fields[1]);
 }
 
 test "api query contract accepts internal normalized filter json on internal query route" {

--- a/zig/pkg/antfly/src/storage/db/aggregations.zig
+++ b/zig/pkg/antfly/src/storage/db/aggregations.zig
@@ -415,6 +415,11 @@ fn computeAlgebraicAggregation(
 
     if (std.mem.eql(u8, request.type, "terms")) {
         const maybe_result = computeAlgebraicTermsAggregation(alloc, index, store, request, ctx.algebraic_constraints) catch |err| switch (err) {
+            error.UnsupportedAggregation => {
+                try recordAlgebraicBucketObservation(alloc, index, store, request, ctx.algebraic_constraints, "terms_unsupported");
+                index.recordPlannerFallback("terms_unsupported", null, null);
+                return null;
+            },
             error.AlgebraicPlannerScanTooLarge => {
                 try recordAlgebraicBucketObservation(alloc, index, store, request, ctx.algebraic_constraints, "terms_too_many_rows");
                 index.recordPlannerFallback("terms_too_many_rows", null, null);
@@ -5976,7 +5981,7 @@ fn computeTermsAggregation(
             }, ctx, false);
         };
         buckets[idx] = .{
-            .key_json = try std.fmt.allocPrint(alloc, "\"{s}\"", .{entry.key}),
+            .key_json = try std.json.Stringify.valueAlloc(alloc, entry.key, .{}),
             .count = entry.count,
             .aggregations = nested,
         };
@@ -10021,6 +10026,45 @@ test "terms aggregation computes multi field composite fallback" {
     try std.testing.expectEqualStrings("[\"bob\",\"pen\"]", aggregations[0].buckets[2].key_json);
     try std.testing.expectEqual(@as(i64, 1), aggregations[0].buckets[2].count);
     try std.testing.expectEqualStrings("7", aggregations[0].buckets[2].aggregations[0].value_json.?);
+}
+
+test "terms aggregation escapes string bucket keys in fallback" {
+    const alloc = std.testing.allocator;
+
+    const docs = [_][]const u8{
+        "{\"extension\":\".go\",\"file_type\":\"source\\\"code\"}",
+        "{\"extension\":\".go\",\"file_type\":\"source\\\"code\"}",
+    };
+    var hits = try alloc.alloc(types.SearchHit, docs.len);
+    defer {
+        for (hits) |*hit| hit.deinit(alloc);
+        alloc.free(hits);
+    }
+    for (docs, 0..) |doc, i| {
+        hits[i] = .{
+            .id = try std.fmt.allocPrint(alloc, "doc:{d}", .{i}),
+            .stored_data = try alloc.dupe(u8, doc),
+        };
+    }
+
+    const requests = [_]SearchAggregationRequest{.{
+        .name = "file_types",
+        .type = "terms",
+        .field = "file_type",
+        .size = 10,
+    }};
+    const result = types.SearchResult{
+        .alloc = alloc,
+        .hits = hits,
+        .total_hits = @intCast(hits.len),
+    };
+    const aggregations = try computeSearchAggregations(alloc, &requests, result, .{});
+    defer deinitResults(alloc, aggregations);
+
+    try std.testing.expectEqual(@as(usize, 1), aggregations.len);
+    try std.testing.expectEqual(@as(usize, 1), aggregations[0].buckets.len);
+    try std.testing.expectEqualStrings("\"source\\\"code\"", aggregations[0].buckets[0].key_json);
+    try std.testing.expectEqual(@as(i64, 2), aggregations[0].buckets[0].count);
 }
 
 test "algebraic aggregation planner answers schemaless structural path terms" {

--- a/zig/pkg/termite/src/server/server.zig
+++ b/zig/pkg/termite/src/server/server.zig
@@ -4059,8 +4059,9 @@ pub const Node = struct {
         try buf.appendSlice(a, body.items);
         try buf.append(a, '}');
 
-        try ctx.setHeader("Content-Type", "application/json");
-        return ctx.text(buf.items);
+        try ctx.setHeader("content-type", "application/json");
+        _ = ctx.response.body(buf.items);
+        return ctx.response.build();
     }
 
     pub fn getVersion(_: *Node, ctx: *httpx.Context) !httpx.Response {


### PR DESCRIPTION
## Summary
- return stored `_source` by default when query `fields` is omitted
- fall back from unsupported algebraic terms aggregation planning to stored-hit terms aggregation instead of surfacing HTTP 500
- return `/ml/v1/models` with `content-type: application/json`

## Verification
- `zig fmt zig/pkg/antfly/src/api/query_contract.zig zig/pkg/antfly/src/storage/db/aggregations.zig zig/pkg/termite/src/server/server.zig`
- `zig build db-test -- --test-filter "terms aggregation escapes string bucket keys in fallback"`
- `zig build root-test`
- `zig build termite-test`
- `zig build install-antfly`