### PR TITLE
Repair stale swarm StatefulSet rollouts

### DIFF
--- a/pkg/operator/api/antfly/v1/antflycluster_types.go
+++ b/pkg/operator/api/antfly/v1/antflycluster_types.go
@@ -134,6 +134,9 @@ const (
 	// ReasonRolloutInProgress indicates StatefulSet changes are still rolling out
 	ReasonRolloutInProgress = "RolloutInProgress"
 
+	// ReasonRolloutBlocked indicates StatefulSet changes are blocked by stale unhealthy pods
+	ReasonRolloutBlocked = "RolloutBlocked"
+
 	// ReasonRolloutComplete indicates StatefulSet changes have rolled out
 	ReasonRolloutComplete = "RolloutComplete"
 

--- a/pkg/operator/controllers/antfly/antflycluster_controller.go
+++ b/pkg/operator/controllers/antfly/antflycluster_controller.go
@@ -1096,6 +1096,11 @@ func (r *AntflyClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		if err := r.reconcileSwarmStatefulSet(ctx, efCache, workingCluster); err != nil {
 			return ctrl.Result{}, err
 		}
+		if repaired, err := r.repairBlockedStatefulSetRollouts(ctx, workingCluster); err != nil {
+			return ctrl.Result{}, err
+		} else if repaired {
+			return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+		}
 
 		r.setPVCExpansionCondition(workingCluster, []pvcExpansionResult{
 			r.reconcilePVCExpansion(ctx, workingCluster, "swarm", "swarm-storage", workingCluster.Name+"-swarm", chooseSwarmStorageSize(workingCluster)),
@@ -3111,6 +3116,7 @@ func (r *AntflyClusterReconciler) updateStatus(ctx context.Context, cluster *ant
 
 func (r *AntflyClusterReconciler) updateRolloutCondition(cluster *antflyv1.AntflyCluster, statefulSets ...*appsv1.StatefulSet) {
 	var waiting []string
+	var blocked []string
 	for _, sts := range statefulSets {
 		if sts == nil || sts.Name == "" {
 			waiting = append(waiting, "StatefulSet is not observed yet")
@@ -3125,7 +3131,12 @@ func (r *AntflyClusterReconciler) updateRolloutCondition(cluster *antflyv1.Antfl
 			continue
 		}
 		if sts.Status.UpdatedReplicas < replicas {
-			waiting = append(waiting, fmt.Sprintf("%s has %d/%d updated replicas", sts.Name, sts.Status.UpdatedReplicas, replicas))
+			message := fmt.Sprintf("%s has %d/%d updated replicas", sts.Name, sts.Status.UpdatedReplicas, replicas)
+			if statefulSetRolloutAppearsBlocked(sts, replicas) {
+				blocked = append(blocked, message)
+			} else {
+				waiting = append(waiting, message)
+			}
 			continue
 		}
 		if sts.Status.ReadyReplicas < replicas {
@@ -3137,7 +3148,11 @@ func (r *AntflyClusterReconciler) updateRolloutCondition(cluster *antflyv1.Antfl
 		Type:               antflyv1.TypeRollout,
 		ObservedGeneration: cluster.Generation,
 	}
-	if len(waiting) > 0 {
+	if len(blocked) > 0 {
+		condition.Status = metav1.ConditionFalse
+		condition.Reason = antflyv1.ReasonRolloutBlocked
+		condition.Message = strings.Join(blocked, "; ")
+	} else if len(waiting) > 0 {
 		condition.Status = metav1.ConditionUnknown
 		condition.Reason = antflyv1.ReasonRolloutInProgress
 		condition.Message = strings.Join(waiting, "; ")
@@ -3150,7 +3165,28 @@ func (r *AntflyClusterReconciler) updateRolloutCondition(cluster *antflyv1.Antfl
 	meta.SetStatusCondition(&cluster.Status.Conditions, condition)
 }
 
+func statefulSetRolloutAppearsBlocked(sts *appsv1.StatefulSet, replicas int32) bool {
+	if sts == nil || replicas <= 0 {
+		return false
+	}
+	if sts.Status.UpdateRevision == "" || sts.Status.CurrentRevision == "" || sts.Status.UpdateRevision == sts.Status.CurrentRevision {
+		return false
+	}
+	return sts.Status.UpdatedReplicas == 0 && sts.Status.ReadyReplicas == 0
+}
+
 func (r *AntflyClusterReconciler) repairBlockedStatefulSetRollouts(ctx context.Context, cluster *antflyv1.AntflyCluster) (bool, error) {
+	if effectiveTopologyMode(cluster) == topologyModeSwarm {
+		swarmSts := &appsv1.StatefulSet{}
+		if err := r.Get(ctx, types.NamespacedName{Name: cluster.Name + "-swarm", Namespace: cluster.Namespace}, swarmSts); err != nil {
+			if !errors.IsNotFound(err) {
+				return false, err
+			}
+			return false, nil
+		}
+		return r.repairBlockedStatefulSetRollout(ctx, cluster, swarmSts, "swarm")
+	}
+
 	metadataSts := &appsv1.StatefulSet{}
 	if err := r.Get(ctx, types.NamespacedName{Name: cluster.Name + "-metadata", Namespace: cluster.Namespace}, metadataSts); err != nil {
 		if !errors.IsNotFound(err) {

--- a/pkg/operator/controllers/antfly/antflycluster_controller_test.go
+++ b/pkg/operator/controllers/antfly/antflycluster_controller_test.go
@@ -740,6 +740,34 @@ func TestUpdateRolloutConditionReportsMissingStatefulSet(t *testing.T) {
 	g.Expect(cond.Message).To(ContainSubstring("not observed"))
 }
 
+func TestUpdateRolloutConditionReportsBlockedRevision(t *testing.T) {
+	g := NewWithT(t)
+	cluster := &antflyv1.AntflyCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-cluster", Namespace: "default", Generation: 4},
+	}
+	reconciler := &AntflyClusterReconciler{}
+	replicas := int32(1)
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-cluster-swarm", Generation: 2},
+		Spec:       appsv1.StatefulSetSpec{Replicas: &replicas},
+		Status: appsv1.StatefulSetStatus{
+			ObservedGeneration: 2,
+			CurrentRevision:    "swarm-old",
+			UpdateRevision:     "swarm-new",
+			UpdatedReplicas:    0,
+			ReadyReplicas:      0,
+		},
+	}
+
+	reconciler.updateRolloutCondition(cluster, sts)
+
+	cond := meta.FindStatusCondition(cluster.Status.Conditions, antflyv1.TypeRollout)
+	g.Expect(cond).NotTo(BeNil())
+	g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+	g.Expect(cond.Reason).To(Equal(antflyv1.ReasonRolloutBlocked))
+	g.Expect(cond.Message).To(ContainSubstring("test-cluster-swarm has 0/1 updated replicas"))
+}
+
 func TestRepairBlockedStatefulSetRolloutDeletesStaleUnhealthyPod(t *testing.T) {
 	g := NewWithT(t)
 	ctx := context.Background()
@@ -796,6 +824,73 @@ func TestRepairBlockedStatefulSetRolloutDeletesStaleUnhealthyPod(t *testing.T) {
 	}
 
 	repaired, err := reconciler.repairBlockedStatefulSetRollout(ctx, cluster, sts, "metadata")
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(repaired).To(BeTrue())
+
+	deleted := &corev1.Pod{}
+	err = reconciler.Get(ctx, types.NamespacedName{Name: staleUnreadyPod.Name, Namespace: staleUnreadyPod.Namespace}, deleted)
+	g.Expect(errors.IsNotFound(err)).To(BeTrue())
+}
+
+func TestRepairBlockedStatefulSetRolloutsDeletesStaleUnhealthySwarmPod(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	s := runtime.NewScheme()
+	g.Expect(corev1.AddToScheme(s)).To(Succeed())
+	g.Expect(appsv1.AddToScheme(s)).To(Succeed())
+	g.Expect(antflyv1.AddToScheme(s)).To(Succeed())
+
+	cluster := &antflyv1.AntflyCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-cluster", Namespace: "default"},
+		Spec: antflyv1.AntflyClusterSpec{
+			Mode: antflyv1.ClusterModeSwarm,
+		},
+	}
+	replicas := int32(1)
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-cluster-swarm", Namespace: "default"},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &replicas,
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "antfly", Image: "antfly:new"}},
+				},
+			},
+		},
+		Status: appsv1.StatefulSetStatus{
+			UpdateRevision:  "swarm-new",
+			UpdatedReplicas: 0,
+		},
+	}
+	staleUnreadyPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "test-cluster-swarm-0",
+			Namespace:       "default",
+			OwnerReferences: []metav1.OwnerReference{statefulSetOwnerRef(sts.Name)},
+			Labels: mergeStringMaps(
+				serviceSelectorLabels("test-cluster", "swarm"),
+				map[string]string{"controller-revision-hash": "swarm-old"},
+			),
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "antfly", Image: "antfly:old"}},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			Conditions: []corev1.PodCondition{{
+				Type:   corev1.PodReady,
+				Status: corev1.ConditionFalse,
+				Reason: "ContainersNotReady",
+			}},
+		},
+	}
+
+	reconciler := &AntflyClusterReconciler{
+		Client: fake.NewClientBuilder().WithScheme(s).WithObjects(sts, staleUnreadyPod).Build(),
+		Scheme: s,
+	}
+
+	repaired, err := reconciler.repairBlockedStatefulSetRollouts(ctx, cluster)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(repaired).To(BeTrue())
 


### PR DESCRIPTION
## Summary
- delete stale unhealthy swarm StatefulSet pods when the operator has already advanced the desired template
- surface RolloutBlocked when a StatefulSet has an update revision but no updated/ready replicas
- add coverage for blocked rollout status and stale swarm pod repair

## Tests
- go test ./... (from pkg/operator)