### PR TITLE
Hide local Antfarm admin routes in hosted mode

### DIFF
--- a/pkg/antfly-proxy/backend.go
+++ b/pkg/antfly-proxy/backend.go
@@ -87,7 +87,7 @@ func (ServerlessBackendAdapter) Kind() BackendKind {
 }
 
 func (ServerlessBackendAdapter) BaseURL(req RequestContext, route NamespaceRoute) (string, error) {
-	if req.Operation == OperationWrite || req.Operation == OperationAdmin {
+	if isMutatingOperation(req.Operation) {
 		if strings.TrimSpace(route.ServerlessAPIURL) == "" {
 			return "", fmt.Errorf("table %q has no serverless api URL", route.TableName())
 		}

--- a/pkg/antfly-proxy/gateway.go
+++ b/pkg/antfly-proxy/gateway.go
@@ -299,10 +299,10 @@ func parsePublicAPIPath(path string) (tenant string, table string, backendPath s
 }
 
 func resolveRequestOperation(method, path, hint string) (OperationKind, error) {
-	required := inferOperationFromBackendPath(method, path)
-	if required == "" {
-		required = inferOperationFromMethod(method)
+	if inferred := inferOperationFromBackendPath(method, path); inferred != "" {
+		return inferred, nil
 	}
+	required := inferOperationFromMethod(method)
 	if strings.TrimSpace(hint) == "" {
 		return required, nil
 	}

--- a/pkg/antfly-proxy/gateway.go
+++ b/pkg/antfly-proxy/gateway.go
@@ -260,22 +260,11 @@ func requestContextFromHTTP(r *http.Request) (RequestContext, error) {
 	}
 
 	operationHint := firstNonEmpty(r.Header.Get("X-Antfly-Operation"), r.URL.Query().Get("operation"))
-	switch strings.ToLower(operationHint) {
-	case "", "read":
-		if inferred := inferOperationFromBackendPath(req.BackendPath); inferred != "" {
-			req.Operation = inferred
-		} else if r.Method == http.MethodPost || r.Method == http.MethodPut || r.Method == http.MethodPatch || r.Method == http.MethodDelete {
-			req.Operation = OperationWrite
-		} else {
-			req.Operation = OperationRead
-		}
-	case "write":
-		req.Operation = OperationWrite
-	case "admin":
-		req.Operation = OperationAdmin
-	default:
-		return RequestContext{}, fmt.Errorf("unsupported operation %q", firstNonEmpty(r.Header.Get("X-Antfly-Operation"), r.URL.Query().Get("operation")))
+	operation, err := resolveRequestOperation(r.Method, req.BackendPath, operationHint)
+	if err != nil {
+		return RequestContext{}, err
 	}
+	req.Operation = operation
 
 	if req.Tenant == "" || req.ResourceName() == "" {
 		return RequestContext{}, fmt.Errorf("tenant and table are required")
@@ -309,14 +298,68 @@ func parsePublicAPIPath(path string) (tenant string, table string, backendPath s
 	return tenant, table, canonicalPublicBackendPath(suffix)
 }
 
-func inferOperationFromBackendPath(path string) OperationKind {
+func resolveRequestOperation(method, path, hint string) (OperationKind, error) {
+	required := inferOperationFromBackendPath(method, path)
+	if required == "" {
+		required = inferOperationFromMethod(method)
+	}
+	if strings.TrimSpace(hint) == "" {
+		return required, nil
+	}
+	hinted, err := parseOperationHint(hint)
+	if err != nil {
+		return "", err
+	}
+	if operationRank(hinted) < operationRank(required) {
+		return required, nil
+	}
+	return hinted, nil
+}
+
+func parseOperationHint(raw string) (OperationKind, error) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "read":
+		return OperationRead, nil
+	case "write":
+		return OperationWrite, nil
+	case "admin":
+		return OperationAdmin, nil
+	default:
+		return "", fmt.Errorf("unsupported operation %q", raw)
+	}
+}
+
+func inferOperationFromMethod(method string) OperationKind {
+	if method == http.MethodPost || method == http.MethodPut || method == http.MethodPatch || method == http.MethodDelete {
+		return OperationWrite
+	}
+	return OperationRead
+}
+
+func inferOperationFromBackendPath(method, path string) OperationKind {
+	path = canonicalPublicBackendPath(path)
 	switch {
+	case path == "/" && (method == http.MethodPost || method == http.MethodPut || method == http.MethodPatch || method == http.MethodDelete):
+		return OperationAdmin
 	case strings.HasPrefix(path, "/query"), strings.HasPrefix(path, "/graph"), strings.HasPrefix(path, "/versions/"):
 		return OperationRead
 	case strings.HasPrefix(path, "/admin"):
 		return OperationAdmin
 	default:
 		return ""
+	}
+}
+
+func operationRank(operation OperationKind) int {
+	switch operation {
+	case OperationRead:
+		return 1
+	case OperationWrite:
+		return 2
+	case OperationAdmin:
+		return 3
+	default:
+		return 0
 	}
 }
 

--- a/pkg/antfly-proxy/gateway_test.go
+++ b/pkg/antfly-proxy/gateway_test.go
@@ -112,6 +112,101 @@ func TestGatewayRejectsNonTablePublicPath(t *testing.T) {
 	}
 }
 
+func TestResolveRequestOperationEnforcesInferredMinimum(t *testing.T) {
+	tests := []struct {
+		name   string
+		method string
+		path   string
+		hint   string
+		want   OperationKind
+	}{
+		{
+			name:   "table root mutations require admin",
+			method: http.MethodPost,
+			path:   "/",
+			hint:   "write",
+			want:   OperationAdmin,
+		},
+		{
+			name:   "admin paths cannot be downgraded",
+			method: http.MethodDelete,
+			path:   "/admin/indexes/title",
+			hint:   "write",
+			want:   OperationAdmin,
+		},
+		{
+			name:   "query post remains read",
+			method: http.MethodPost,
+			path:   "/query/search",
+			want:   OperationRead,
+		},
+		{
+			name:   "hints can request stricter auth",
+			method: http.MethodPost,
+			path:   "/query/search",
+			hint:   "admin",
+			want:   OperationAdmin,
+		},
+		{
+			name:   "generic mutating paths cannot be downgraded",
+			method: http.MethodPut,
+			path:   "/ingest-batch",
+			hint:   "read",
+			want:   OperationWrite,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveRequestOperation(tt.method, tt.path, tt.hint)
+			if err != nil {
+				t.Fatalf("resolve operation: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("got %q want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGatewayRequiresAdminForTableRootMutation(t *testing.T) {
+	gateway := NewGateway(NewRouter([]NamespaceRoute{
+		{
+			Tenant:        "t1",
+			Table:         "docs",
+			Namespace:     "docs",
+			AllowStateful: true,
+			StatefulURL:   "http://stateful.invalid/api/v1/tables/docs",
+		},
+	}))
+	gateway.authenticator = StaticBearerAuthenticator{
+		Required: true,
+		Tokens: map[string]Principal{
+			"test-token": {
+				Subject:           "user-1",
+				Tenant:            "t1",
+				AllowedTables:     []string{"docs"},
+				AllowedOperations: []OperationKind{OperationWrite},
+			},
+		},
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/proxy/", strings.NewReader(`{"columns":[]}`))
+	req.Header.Set("Authorization", "Bearer test-token")
+	req.Header.Set("X-Antfly-Tenant", "t1")
+	req.Header.Set("X-Antfly-Table", "docs")
+	req.Header.Set("X-Antfly-Operation", "write")
+	rec := httptest.NewRecorder()
+	gateway.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("got status %d body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `cannot perform operation "admin"`) {
+		t.Fatalf("unexpected body %q", rec.Body.String())
+	}
+}
+
 func TestGatewayServeHTTPProxyForward(t *testing.T) {
 	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/tables/docs/query/search" {

--- a/pkg/antfly-proxy/gateway_test.go
+++ b/pkg/antfly-proxy/gateway_test.go
@@ -141,9 +141,16 @@ func TestResolveRequestOperationEnforcesInferredMinimum(t *testing.T) {
 			want:   OperationRead,
 		},
 		{
-			name:   "hints can request stricter auth",
+			name:   "known read paths ignore stricter hints",
 			method: http.MethodPost,
 			path:   "/query/search",
+			hint:   "admin",
+			want:   OperationRead,
+		},
+		{
+			name:   "hints can request stricter auth for generic paths",
+			method: http.MethodPost,
+			path:   "/ingest-batch",
 			hint:   "admin",
 			want:   OperationAdmin,
 		},

--- a/pkg/antfly-proxy/router.go
+++ b/pkg/antfly-proxy/router.go
@@ -86,7 +86,7 @@ func (r *Router) ResolveBackend(ctx context.Context, req RequestContext) (Backen
 		return kind, adapter, route, nil
 	}
 
-	if req.Operation == OperationWrite {
+	if isMutatingOperation(req.Operation) {
 		if route.AllowStateful {
 			return resolve(BackendStateful)
 		}
@@ -131,6 +131,10 @@ func (r *Router) ResolveBackend(ctx context.Context, req RequestContext) (Backen
 
 func (req RequestContext) ResourceName() string {
 	return firstNonEmpty(req.Table, req.Namespace)
+}
+
+func isMutatingOperation(operation OperationKind) bool {
+	return operation == OperationWrite || operation == OperationAdmin
 }
 
 func (route NamespaceRoute) TableName() string {

--- a/pkg/antfly-proxy/router_test.go
+++ b/pkg/antfly-proxy/router_test.go
@@ -78,6 +78,24 @@ func TestRouterResolve(t *testing.T) {
 			want: BackendServerless,
 		},
 		{
+			name: "admin mutations prefer stateful when available",
+			req: RequestContext{
+				Tenant:    "t1",
+				Table:     "docs",
+				Operation: OperationAdmin,
+			},
+			want: BackendStateful,
+		},
+		{
+			name: "admin mutations use serverless api when stateful is unavailable",
+			req: RequestContext{
+				Tenant:    "t1",
+				Table:     "logs",
+				Operation: OperationAdmin,
+			},
+			want: BackendServerless,
+		},
+		{
 			name: "graph reads prefer serverless when allowed",
 			req: RequestContext{
 				Tenant:       "t1",

--- a/src/metadata/antfarm/index.html
+++ b/src/metadata/antfarm/index.html
@@ -5,7 +5,7 @@
         <link rel="icon" type="image/png" href="/favicon.png" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>Antfly Dashboard</title>
-      <script type="module" crossorigin src="/assets/index-DDSIfo3v.js"></script>
+      <script type="module" crossorigin src="/assets/index-DAV9LNnr.js"></script>
       <link rel="stylesheet" crossorigin href="/assets/index-CrXSTZkd.css">
     </head>
     <body>

--- a/src/metadata/antfarm/index.html
+++ b/src/metadata/antfarm/index.html
@@ -5,7 +5,7 @@
         <link rel="icon" type="image/png" href="/favicon.png" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>Antfly Dashboard</title>
-      <script type="module" crossorigin src="/assets/index-Ch4Zfxoz.js"></script>
+      <script type="module" crossorigin src="/assets/index-DDSIfo3v.js"></script>
       <link rel="stylesheet" crossorigin href="/assets/index-CrXSTZkd.css">
     </head>
     <body>

--- a/ts/apps/antfarm/src/App.tsx
+++ b/ts/apps/antfarm/src/App.tsx
@@ -19,6 +19,7 @@ import {
   productForPath,
 } from "@/config/products";
 import { ThemeProvider } from "@/hooks/use-theme";
+import { isExternalAuthMode } from "@/runtime-config";
 import AntflyChunkingPlaygroundPage from "./pages/AntflyChunkingPlaygroundPage";
 import AntflyEmbeddingPlaygroundPage from "./pages/AntflyEmbeddingPlaygroundPage";
 import AntflyRerankingPlaygroundPage from "./pages/AntflyRerankingPlaygroundPage";
@@ -46,6 +47,7 @@ function AppContent() {
   const [currentSection, setCurrentSection] = useState("indexes");
   const [currentProduct, setCurrentProduct] = useState<ProductId>(defaultProduct);
   const location = useLocation();
+  const showLocalAdminRoutes = !isExternalAuthMode();
 
   // Sync currentProduct with the current route so direct navigation
   // (bookmarks, refresh, shared links) shows the correct sidebar.
@@ -84,8 +86,10 @@ function AppContent() {
                           path="/tables/:tableName"
                           element={<TableDetailsPage currentSection={currentSection} />}
                         />
-                        <Route path="/users" element={<UsersPage />} />
-                        <Route path="/secrets" element={<SecretsPage />} />
+                        {showLocalAdminRoutes && <Route path="/users" element={<UsersPage />} />}
+                        {showLocalAdminRoutes && (
+                          <Route path="/secrets" element={<SecretsPage />} />
+                        )}
                         <Route path="/cluster" element={<ClusterPage />} />
                         <Route path="/playground/evals" element={<EvalsPlaygroundPage />} />
                         <Route path="/playground/rag" element={<RagPlaygroundPage />} />

--- a/ts/apps/antfarm/src/components/command-palette-provider.tsx
+++ b/ts/apps/antfarm/src/components/command-palette-provider.tsx
@@ -119,16 +119,22 @@ export function CommandPaletteProvider({ children }: { children: React.ReactNode
     return commands;
   }, [showLocalAdminRoutes]);
 
-  const playgroundCommands = [
-    { icon: Scissors, label: "Chunking Playground", href: "/playground/chunking" },
-    { icon: Tag, label: "Recognize Playground", href: "/playground/recognize" },
-    { icon: Repeat2, label: "Rewriting Playground", href: "/playground/rewrite" },
-    { icon: ArrowUpDown, label: "Reranking Playground", href: "/playground/rerank" },
-    { icon: Network, label: "Knowledge Graph", href: "/playground/kg" },
-    { icon: ClipboardCheck, label: "Evals", href: "/playground/evals" },
-  ];
+  const playgroundCommands = React.useMemo(
+    () => [
+      { icon: Scissors, label: "Chunking Playground", href: "/playground/chunking" },
+      { icon: Tag, label: "Recognize Playground", href: "/playground/recognize" },
+      { icon: Repeat2, label: "Rewriting Playground", href: "/playground/rewrite" },
+      { icon: ArrowUpDown, label: "Reranking Playground", href: "/playground/rerank" },
+      { icon: Network, label: "Knowledge Graph", href: "/playground/kg" },
+      { icon: ClipboardCheck, label: "Evals", href: "/playground/evals" },
+    ],
+    []
+  );
 
-  const quickActionCommands = [{ icon: Moon, label: "Toggle Theme", action: "toggle-theme" }];
+  const quickActionCommands = React.useMemo(
+    () => [{ icon: Moon, label: "Toggle Theme", action: "toggle-theme" }],
+    []
+  );
 
   // All command items for string matching check
   const allItems = React.useMemo(

--- a/ts/apps/antfarm/src/components/command-palette-provider.tsx
+++ b/ts/apps/antfarm/src/components/command-palette-provider.tsx
@@ -32,6 +32,7 @@ import { useNavigate } from "react-router-dom";
 import { useApiConfig } from "@/hooks/use-api-config";
 import { useTheme } from "@/hooks/use-theme";
 import { type SemanticResult, semanticSearch } from "@/lib/semantic-search";
+import { isExternalAuthMode } from "@/runtime-config";
 
 // Map icon names to components
 const iconMap: Record<string, React.ComponentType<{ className?: string }>> = {
@@ -95,12 +96,17 @@ export function CommandPaletteProvider({ children }: { children: React.ReactNode
     return () => document.removeEventListener("keydown", down);
   }, [toggle]);
 
-  const navigationCommands = [
-    { icon: Table, label: "Tables", href: "/" },
-    { icon: Plus, label: "Create Table", href: "/create" },
-    { icon: Library, label: "Models", href: "/models" },
-    { icon: Users, label: "Users", href: "/users" },
-  ];
+  const navigationCommands = React.useMemo(() => {
+    const commands = [
+      { icon: Table, label: "Tables", href: "/" },
+      { icon: Plus, label: "Create Table", href: "/create" },
+      { icon: Library, label: "Models", href: "/models" },
+    ];
+    if (!isExternalAuthMode()) {
+      commands.push({ icon: Users, label: "Users", href: "/users" });
+    }
+    return commands;
+  }, []);
 
   const playgroundCommands = [
     { icon: Scissors, label: "Chunking Playground", href: "/playground/chunking" },
@@ -120,7 +126,7 @@ export function CommandPaletteProvider({ children }: { children: React.ReactNode
       ...playgroundCommands.map((c) => c.label),
       ...quickActionCommands.map((c) => c.label),
     ],
-    [navigationCommands.map, playgroundCommands.map, quickActionCommands.map]
+    [navigationCommands, playgroundCommands, quickActionCommands]
   );
 
   // Check if cmdk's string filter would find any matches

--- a/ts/apps/antfarm/src/components/command-palette-provider.tsx
+++ b/ts/apps/antfarm/src/components/command-palette-provider.tsx
@@ -68,11 +68,22 @@ export function CommandPaletteProvider({ children }: { children: React.ReactNode
 
   const { theme, setTheme } = useTheme();
   const { termiteApiUrl } = useApiConfig();
+  const showLocalAdminRoutes = !isExternalAuthMode();
 
   // Create TermiteClient for semantic search
   const termiteClient = React.useMemo(
     () => new TermiteClient({ baseUrl: termiteApiUrl }),
     [termiteApiUrl]
+  );
+
+  const isCommandAvailable = React.useCallback(
+    (item: { href?: string }) => {
+      if (showLocalAdminRoutes) {
+        return true;
+      }
+      return item.href !== "/users" && item.href !== "/secrets";
+    },
+    [showLocalAdminRoutes]
   );
 
   React.useEffect(() => {
@@ -102,11 +113,11 @@ export function CommandPaletteProvider({ children }: { children: React.ReactNode
       { icon: Plus, label: "Create Table", href: "/create" },
       { icon: Library, label: "Models", href: "/models" },
     ];
-    if (!isExternalAuthMode()) {
+    if (showLocalAdminRoutes) {
       commands.push({ icon: Users, label: "Users", href: "/users" });
     }
     return commands;
-  }, []);
+  }, [showLocalAdminRoutes]);
 
   const playgroundCommands = [
     { icon: Scissors, label: "Chunking Playground", href: "/playground/chunking" },
@@ -147,7 +158,8 @@ export function CommandPaletteProvider({ children }: { children: React.ReactNode
     const timer = setTimeout(async () => {
       try {
         const results = await semanticSearch(searchValue, termiteClient);
-        setSemanticResults(results);
+        const filteredResults = results.filter((result) => isCommandAvailable(result.item));
+        setSemanticResults(filteredResults);
       } catch (e) {
         console.error("Semantic search failed:", e);
         setSemanticResults([]);
@@ -156,7 +168,7 @@ export function CommandPaletteProvider({ children }: { children: React.ReactNode
     }, 300);
 
     return () => clearTimeout(timer);
-  }, [searchValue, hasStringMatches, termiteClient]);
+  }, [searchValue, hasStringMatches, termiteClient, isCommandAvailable]);
 
   // Reset search state when dialog closes
   React.useEffect(() => {

--- a/ts/apps/antfarm/src/components/sidebar.tsx
+++ b/ts/apps/antfarm/src/components/sidebar.tsx
@@ -55,6 +55,7 @@ import type { ProductId } from "@/config/products";
 import { useAuth } from "@/hooks/use-auth";
 import { useTable } from "@/hooks/use-table";
 import { cn } from "@/lib/utils";
+import { isExternalAuthMode } from "@/runtime-config";
 
 interface AppSidebarProps extends React.ComponentProps<typeof Sidebar> {
   currentSection?: string;
@@ -75,6 +76,7 @@ export function AppSidebar({
   const { state: sidebarState, toggleSidebar, isMobile } = useSidebar();
   const { hasPermission } = useAuth();
   const { tables, selectedTable, setSelectedTable } = useTable();
+  const showLocalAdminRoutes = !isExternalAuthMode();
 
   const [comboboxOpen, setComboboxOpen] = React.useState(false);
   const [tooltipOpen, setTooltipOpen] = React.useState(false);
@@ -198,7 +200,7 @@ export function AppSidebar({
                 </SidebarMenuItem>
 
                 {/* Users Link - only show if user has admin permission */}
-                {hasPermission("*", "*", "admin") && (
+                {showLocalAdminRoutes && hasPermission("*", "*", "admin") && (
                   <SidebarMenuItem>
                     <SidebarMenuButton
                       asChild
@@ -220,7 +222,7 @@ export function AppSidebar({
                 )}
 
                 {/* Secrets Link - only show if user has admin permission */}
-                {hasPermission("*", "*", "admin") && (
+                {showLocalAdminRoutes && hasPermission("*", "*", "admin") && (
                   <SidebarMenuItem>
                     <SidebarMenuButton
                       asChild

--- a/ts/apps/antfarm/src/hooks/use-connection-status.ts
+++ b/ts/apps/antfarm/src/hooks/use-connection-status.ts
@@ -19,26 +19,29 @@ export function useConnectionStatus(): ConnectionStatus {
   const [termiteStatus, setTermiteStatus] = useState<ServerStatus>("checking");
   const isMountedRef = useRef(true);
 
-  const checkAntfly = useCallback(async (signal?: AbortSignal) => {
-    if (!isProductEnabled("antfly")) {
-      setAntflyStatus("connected"); // Skip check if product disabled
-      return;
-    }
+  const checkAntfly = useCallback(
+    async (signal?: AbortSignal) => {
+      if (!isProductEnabled("antfly")) {
+        setAntflyStatus("connected"); // Skip check if product disabled
+        return;
+      }
 
-    try {
-      const response = await fetch(`${apiUrl}/status`, {
-        method: "GET",
-        signal: signal ?? AbortSignal.timeout(CONNECTION_CHECK_TIMEOUT),
-      });
-      if (isMountedRef.current) {
-        setAntflyStatus(response.ok ? "connected" : "disconnected");
+      try {
+        const response = await fetch(`${apiUrl}/status`, {
+          method: "GET",
+          signal: signal ?? AbortSignal.timeout(CONNECTION_CHECK_TIMEOUT),
+        });
+        if (isMountedRef.current) {
+          setAntflyStatus(response.ok ? "connected" : "disconnected");
+        }
+      } catch {
+        if (isMountedRef.current) {
+          setAntflyStatus("disconnected");
+        }
       }
-    } catch {
-      if (isMountedRef.current) {
-        setAntflyStatus("disconnected");
-      }
-    }
-  }, [apiUrl]);
+    },
+    [apiUrl]
+  );
 
   const checkTermite = useCallback(
     async (signal?: AbortSignal) => {


### PR DESCRIPTION
## Summary
- hide Antfarm Users and Secrets navigation in external auth mode
- skip registering `/users` and `/secrets` routes when Antfarm is hosted behind Colony auth
- filter semantic command palette results through the same hosted-mode route availability rules
- enforce proxy operation floors so table lifecycle/admin routes cannot be downgraded via `X-Antfly-Operation` or `operation=` hints
- keep recognized read routes authoritative so write/admin hints cannot bypass read authorization or row-filter injection
- route admin proxy operations through the same mutating backend selection path as writes
- rebuild embedded Antfarm dashboard assets with the hosted-mode UI update

## Verification
- `pnpm --filter antfarm... typecheck`
- `make build-antfarm`
- `env GOCACHE=/tmp/antfly-go-build-cache go test -run 'TestResolveRequestOperationEnforcesInferredMinimum|TestRouterResolve|TestRouterResolveBackend' .` from `pkg/antfly-proxy`
- `env GOCACHE=/tmp/antfly-go-build-cache go test ./...` from `pkg/antfly-proxy`