### PR TITLE
Fix Zig container root-context build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -65,3 +65,17 @@ datasets/
 *.py
 laion-400m-images/
 data/
+
+# Zig local build artifacts
+zig/.zig-cache/
+zig/zig-out/
+zig/e2e/
+zig/testdata/
+zig/bench/
+zig/deps/antfly-zig
+!zig/lib/pjrt/
+!zig/lib/pjrt/**
+!zig/pkg/antfly/src/data/
+!zig/pkg/antfly/src/data/**
+!zig/pkg/termite/src/models/
+!zig/pkg/termite/src/models/**

--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,0 +1,8 @@
+# Use Docker build ignores for Cloud Build source uploads.
+#!include:.dockerignore
+
+# Keep Docker ignore rules available to docker build inside Cloud Build.
+!.dockerignore
+
+# Cloud Build metadata
+.gcloudignore

--- a/.github/workflows/zig-container.yml
+++ b/.github/workflows/zig-container.yml
@@ -65,12 +65,12 @@ jobs:
           if [[ "$VERSION" == *-* ]]; then
             ALIAS_TAG=__skip_alias__
           fi
-          submit_cloud_build zig \
+          submit_cloud_build . \
             --project="${GCP_PROJECT}" \
             --region="${GCP_REGION}" \
             --worker-pool="${CLOUD_BUILD_WORKER_POOL}" \
             --config=zig/cloudbuild.yaml \
-            --substitutions="_IMAGE_NAME=antfly,_DOCKERFILE=Dockerfile,_CONTEXT=.,_ALIAS_TAG=${ALIAS_TAG},_VERSION_TAG=zig-${VERSION},_CACHE_TAG=zig-buildcache,_DESCRIPTION=AntflyDB Zig runtime image"
+            --substitutions="_IMAGE_NAME=antfly,_DOCKERFILE=zig/Dockerfile,_CONTEXT=.,_ALIAS_TAG=${ALIAS_TAG},_VERSION_TAG=zig-${VERSION},_CACHE_TAG=zig-buildcache,_DESCRIPTION=AntflyDB Zig runtime image"
 
       - name: Install crane
         uses: imjasonh/setup-crane@v0.4

--- a/zig/Dockerfile
+++ b/zig/Dockerfile
@@ -32,6 +32,7 @@ RUN case "${TARGETARCH}" in \
         arm64) zig_target="aarch64-linux-musl" ;; \
         *) echo "unsupported TARGETARCH=${TARGETARCH}" >&2; exit 1 ;; \
     esac && \
+    cd zig && \
     zig build -Dtarget="${zig_target}" -Doptimize=ReleaseFast install-antfly --prefix /out
 
 FROM --platform=$TARGETPLATFORM alpine:3.21
@@ -44,6 +45,7 @@ RUN addgroup -S antfly && adduser -S -G antfly -h /home/antfly antfly
 
 WORKDIR /
 COPY --from=builder /out/bin/antfly /antfly
+COPY --from=builder /out/share/antfly /usr/share/antfly
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
     CMD wget -qO- http://localhost:4200/readyz || exit 1

--- a/zig/cloudbuild.yaml
+++ b/zig/cloudbuild.yaml
@@ -46,11 +46,11 @@ steps:
 options:
   logging: CLOUD_LOGGING_ONLY
 
-timeout: 2400s
+timeout: 7200s
 
 substitutions:
   _IMAGE_NAME: antfly
-  _DOCKERFILE: Dockerfile
+  _DOCKERFILE: zig/Dockerfile
   _CONTEXT: "."
   _ALIAS_TAG: zig
   _VERSION_TAG: zig-latest


### PR DESCRIPTION
## Summary
- Build Zig runtime images from the repository root so Antfarm assets are available.
- Copy installed Antfarm assets into the final image.
- Add Cloud Build upload ignores for local Zig caches and unignore Zig source directories hidden by broad Docker ignore patterns.

## Validation
- git diff --check
- Manual Cloud Build in progress: 59491f95-ceec-4a08-ab9f-7ded66507669, _PLATFORMS=linux/amd64, tag zig-dev-2b6e8a8f.