### PR TITLE
Support CloudAF data-plane client URLs

### DIFF
--- a/cmd/antfly/cmd/cli/cli.go
+++ b/cmd/antfly/cmd/cli/cli.go
@@ -135,7 +135,7 @@ func resolveURL(cmd *cobra.Command) string {
 	return url
 }
 
-// resolveToken returns the bearer token from command flags or ANTFLY_TOKEN.
+// resolveToken returns the token from command flags or ANTFLY_TOKEN.
 func resolveToken(cmd *cobra.Command) string {
 	token, _ := cmd.Flags().GetString("token")
 	if !cmd.Flags().Changed("token") {
@@ -168,7 +168,7 @@ func RegisterCommands(parent *cobra.Command) {
 		parent.PersistentFlags().String("url", "http://localhost:8080", "Antfly server URL")
 	}
 	if parent.PersistentFlags().Lookup("token") == nil {
-		parent.PersistentFlags().String("token", "", "Bearer token for authentication")
+		parent.PersistentFlags().String("token", "", "Token for authentication")
 	}
 
 	// Chain client init onto parent's PersistentPreRunE, but only

--- a/cmd/antfly/cmd/cli/cli.go
+++ b/cmd/antfly/cmd/cli/cli.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
@@ -126,13 +127,29 @@ func parseOptionalPruner(prunerStr string) (antfly.Pruner, error) {
 // The default is set on the persistent flag definition.
 func resolveURL(cmd *cobra.Command) string {
 	url, _ := cmd.Flags().GetString("url")
+	if !cmd.Flags().Changed("url") {
+		if envURL := os.Getenv("ANTFLY_URL"); envURL != "" {
+			return envURL
+		}
+	}
 	return url
+}
+
+// resolveToken returns the bearer token from command flags or ANTFLY_TOKEN.
+func resolveToken(cmd *cobra.Command) string {
+	token, _ := cmd.Flags().GetString("token")
+	if !cmd.Flags().Changed("token") {
+		if envToken := os.Getenv("ANTFLY_TOKEN"); envToken != "" {
+			return envToken
+		}
+	}
+	return token
 }
 
 // initClient initializes the global antflyClient with the given HTTP client.
 func initClient(cmd *cobra.Command, httpClient *http.Client) error {
 	var err error
-	antflyClient, err = NewAntflyClient(resolveURL(cmd), httpClient)
+	antflyClient, err = NewAntflyClient(resolveURL(cmd), resolveToken(cmd), httpClient)
 	return err
 }
 
@@ -149,6 +166,9 @@ var cliCommandNames = map[string]bool{
 func RegisterCommands(parent *cobra.Command) {
 	if parent.PersistentFlags().Lookup("url") == nil {
 		parent.PersistentFlags().String("url", "http://localhost:8080", "Antfly server URL")
+	}
+	if parent.PersistentFlags().Lookup("token") == nil {
+		parent.PersistentFlags().String("token", "", "Bearer token for authentication")
 	}
 
 	// Chain client init onto parent's PersistentPreRunE, but only

--- a/cmd/antfly/cmd/cli/client.go
+++ b/cmd/antfly/cmd/cli/client.go
@@ -34,6 +34,7 @@ import (
 
 	antfly "github.com/antflydb/antfly/pkg/client"
 	"github.com/antflydb/antfly/pkg/client/admin"
+	"github.com/antflydb/antfly/pkg/client/oapi"
 	"github.com/antflydb/antfly/pkg/client/query"
 	json "github.com/antflydb/antfly/pkg/libaf/json"
 	blevequery "github.com/blevesearch/bleve/v2/search/query"
@@ -72,14 +73,18 @@ type AntflyClient struct {
 }
 
 // NewAntflyClient creates a new Antfly client
-func NewAntflyClient(baseURL string, httpClient *http.Client) (*AntflyClient, error) {
-	client, err := antfly.NewAntflyClient(strings.TrimRight(baseURL, "/")+"/api/v1", httpClient)
+func NewAntflyClient(baseURL string, token string, httpClient *http.Client) (*AntflyClient, error) {
+	opts := []oapi.ClientOption{oapi.WithHTTPClient(httpClient)}
+	if token != "" {
+		opts = append(opts, oapi.WithRequestEditorFn(antfly.WithToken(token)))
+	}
+	client, err := antfly.NewAntflyClientWithOptions(baseURL, opts...)
 	if err != nil {
 		return nil, err
 	}
 
 	// Initialize internal admin client using the same base URL and HTTP client
-	internalClient := admin.NewInternalClient(strings.TrimRight(baseURL, "/"), httpClient)
+	internalClient := admin.NewInternalClient(antfly.NormalizeServerURL(baseURL), httpClient)
 
 	return &AntflyClient{
 		AntflyClient:   client,

--- a/cmd/antfly/cmd/cli/client.go
+++ b/cmd/antfly/cmd/cli/client.go
@@ -85,6 +85,9 @@ func NewAntflyClient(baseURL string, token string, httpClient *http.Client) (*An
 
 	// Initialize internal admin client using the same base URL and HTTP client
 	internalClient := admin.NewInternalClient(antfly.NormalizeServerURL(baseURL), httpClient)
+	if token != "" {
+		internalClient.WithToken(token)
+	}
 
 	return &AntflyClient{
 		AntflyClient:   client,

--- a/cmd/antfly/cmd/cli/config_test.go
+++ b/cmd/antfly/cmd/cli/config_test.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2026 The Antfly Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestResolveURLUsesEnvWhenFlagUnset(t *testing.T) {
+	t.Setenv("ANTFLY_URL", "https://platform.antfly.io/cloud/v1/instance")
+	cmd := &cobra.Command{}
+	cmd.Flags().String("url", "http://localhost:8080", "")
+
+	if got := resolveURL(cmd); got != "https://platform.antfly.io/cloud/v1/instance" {
+		t.Fatalf("resolveURL = %q", got)
+	}
+}
+
+func TestResolveURLPrefersFlag(t *testing.T) {
+	t.Setenv("ANTFLY_URL", "https://platform.antfly.io/cloud/v1/env")
+	cmd := &cobra.Command{}
+	cmd.Flags().String("url", "http://localhost:8080", "")
+	if err := cmd.Flags().Set("url", "https://platform.antfly.io/cloud/v1/flag"); err != nil {
+		t.Fatalf("set url flag: %v", err)
+	}
+
+	if got := resolveURL(cmd); got != "https://platform.antfly.io/cloud/v1/flag" {
+		t.Fatalf("resolveURL = %q", got)
+	}
+}
+
+func TestResolveTokenUsesEnvWhenFlagUnset(t *testing.T) {
+	t.Setenv("ANTFLY_TOKEN", "env-token")
+	cmd := &cobra.Command{}
+	cmd.Flags().String("token", "", "")
+
+	if got := resolveToken(cmd); got != "env-token" {
+		t.Fatalf("resolveToken = %q", got)
+	}
+}
+
+func TestResolveTokenPrefersFlag(t *testing.T) {
+	t.Setenv("ANTFLY_TOKEN", "env-token")
+	cmd := &cobra.Command{}
+	cmd.Flags().String("token", "", "")
+	if err := cmd.Flags().Set("token", "flag-token"); err != nil {
+		t.Fatalf("set token flag: %v", err)
+	}
+
+	if got := resolveToken(cmd); got != "flag-token" {
+		t.Fatalf("resolveToken = %q", got)
+	}
+}

--- a/docs/sdks.mdx
+++ b/docs/sdks.mdx
@@ -37,7 +37,7 @@ Antfly provides type-safe client libraries for Go, TypeScript, Python, and Rust.
 
 ## Authentication
 
-All three authentication methods are supported across SDKs: basic auth, API key, and bearer token.
+All three authentication methods are supported across SDKs: basic auth, API key, and token.
 
 ### Basic Auth
 
@@ -81,24 +81,24 @@ All three authentication methods are supported across SDKs: basic auth, API key,
   }
 ]} />
 
-### Bearer Token
+### Token
 
 <CodeTabs persistKey="sdk-lang" samples={[
   {
     language: "Go",
-    code: `client, err := antfly.NewAntflyClientWithOptions(\n\t"http://localhost:8080",\n\tantfly.WithBearerToken("your-token"),\n)`
+    code: `client, err := antfly.NewAntflyClientWithOptions(\n\t"http://localhost:8080",\n\tantfly.WithToken("your-token"),\n)`
   },
   {
     language: "TypeScript",
-    code: `const client = new AntflyClient({\n  baseUrl: 'http://localhost:8080',\n  auth: {\n    type: 'bearer',\n    token: 'your-token',\n  },\n});`
+    code: `const client = new AntflyClient({\n  baseUrl: 'http://localhost:8080',\n  auth: {\n    type: 'token',\n    token: 'your-token',\n  },\n});`
   },
   {
     language: "Python",
-    code: `client = AntflyClient(\n    base_url='http://localhost:8080',\n    bearer_token='your-token',\n)`
+    code: `client = AntflyClient(\n    base_url='http://localhost:8080',\n    token='your-token',\n)`
   },
   {
     language: "Rust",
-    code: `use antfly_client::Client;\n\nlet client = Client::new_with_client(\n    "http://localhost:8080",\n    reqwest::Client::builder()\n        .default_headers({\n            let mut h = reqwest::header::HeaderMap::new();\n            h.insert(\n                reqwest::header::AUTHORIZATION,\n                "Bearer your-token".parse().unwrap(),\n            );\n            h\n        })\n        .build()\n        .unwrap(),\n);`
+    code: `use antfly_client::new_client_with_token;\n\nlet client = new_client_with_token(\n    "http://localhost:8080",\n    "your-token",\n)?;`
   }
 ]} />
 

--- a/pkg/client/admin/admin.go
+++ b/pkg/client/admin/admin.go
@@ -15,6 +15,7 @@ import (
 type InternalClient struct {
 	baseURL    string
 	httpClient *http.Client
+	token      string
 }
 
 // NewInternalClient creates a new internal admin client
@@ -36,11 +37,34 @@ func NewInternalClient(baseURL string, httpClient *http.Client) *InternalClient 
 	}
 }
 
+// WithToken configures token authentication for internal admin requests.
+func (c *InternalClient) WithToken(token string) *InternalClient {
+	c.token = token
+	return c
+}
+
+func (c *InternalClient) newRequest(method, url string, body io.Reader) (*http.Request, error) {
+	req, err := http.NewRequest(method, url, body)
+	if err != nil {
+		return nil, err
+	}
+	if c.token != "" {
+		req.Header.Set("Authorization", "Bearer "+c.token)
+	}
+	return req, nil
+}
+
 // AddMetadataPeer adds a new peer to the metadata raft cluster
 func (c *InternalClient) AddMetadataPeer(nodeID uint64, raftURL string) error {
 	// Make POST request to internal endpoint
 	url := fmt.Sprintf("%s/_internal/v1/peer/%d", c.baseURL, nodeID)
-	resp, err := c.httpClient.Post(url, "application/octet-stream", strings.NewReader(raftURL))
+	req, err := c.newRequest(http.MethodPost, url, strings.NewReader(raftURL))
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/octet-stream")
+
+	resp, err := c.httpClient.Do(req) //nolint:gosec // URL constructed from trusted c.baseURL
 	if err != nil {
 		return fmt.Errorf("failed to add peer: %w", err)
 	}
@@ -58,7 +82,7 @@ func (c *InternalClient) AddMetadataPeer(nodeID uint64, raftURL string) error {
 func (c *InternalClient) RemoveMetadataPeer(nodeID uint64) error {
 	// Make DELETE request to internal endpoint
 	url := fmt.Sprintf("%s/_internal/v1/peer/%d", c.baseURL, nodeID)
-	req, err := http.NewRequest("DELETE", url, nil)
+	req, err := c.newRequest(http.MethodDelete, url, nil)
 	if err != nil {
 		return fmt.Errorf("failed to create request: %w", err)
 	}
@@ -99,7 +123,12 @@ type ShardInfo struct {
 func (c *InternalClient) GetMetadataStatus() (*MetadataStatus, error) {
 	// Make GET request to the internal status endpoint
 	url := fmt.Sprintf("%s/_internal/v1/status", c.baseURL)
-	resp, err := c.httpClient.Get(url)
+	req, err := c.newRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := c.httpClient.Do(req) //nolint:gosec // URL constructed from trusted c.baseURL
 	if err != nil {
 		return nil, fmt.Errorf("failed to get metadata status: %w", err)
 	}

--- a/pkg/client/admin/admin_test.go
+++ b/pkg/client/admin/admin_test.go
@@ -1,0 +1,92 @@
+package admin
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestInternalClientGetMetadataStatusSendsToken(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("method = %s, want %s", r.Method, http.MethodGet)
+		}
+		if r.URL.Path != "/_internal/v1/status" {
+			t.Fatalf("path = %s, want /_internal/v1/status", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+			t.Fatalf("Authorization = %q, want Bearer test-token", got)
+		}
+		_, _ = fmt.Fprint(w, `{"raft_status":{"leader_id":1,"voters":{"1":"raft://node-1"}}}`)
+	}))
+	defer server.Close()
+
+	status, err := NewInternalClient(server.URL, server.Client()).WithToken("test-token").GetMetadataStatus()
+	if err != nil {
+		t.Fatalf("GetMetadataStatus returned error: %v", err)
+	}
+	if status.Leader != 1 {
+		t.Fatalf("Leader = %d, want 1", status.Leader)
+	}
+	if got := status.Members[1]; got != "raft://node-1" {
+		t.Fatalf("Members[1] = %q, want raft://node-1", got)
+	}
+}
+
+func TestInternalClientAddMetadataPeerSendsToken(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want %s", r.Method, http.MethodPost)
+		}
+		if r.URL.Path != "/_internal/v1/peer/2" {
+			t.Fatalf("path = %s, want /_internal/v1/peer/2", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+			t.Fatalf("Authorization = %q, want Bearer test-token", got)
+		}
+		if got := r.Header.Get("Content-Type"); got != "application/octet-stream" {
+			t.Fatalf("Content-Type = %q, want application/octet-stream", got)
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("ReadAll returned error: %v", err)
+		}
+		if got := string(body); got != "raft://node-2" {
+			t.Fatalf("body = %q, want raft://node-2", got)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	if err := NewInternalClient(server.URL, server.Client()).WithToken("test-token").AddMetadataPeer(2, "raft://node-2"); err != nil {
+		t.Fatalf("AddMetadataPeer returned error: %v", err)
+	}
+}
+
+func TestInternalClientRemoveMetadataPeerSendsToken(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Fatalf("method = %s, want %s", r.Method, http.MethodDelete)
+		}
+		if r.URL.Path != "/_internal/v1/peer/2" {
+			t.Fatalf("path = %s, want /_internal/v1/peer/2", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+			t.Fatalf("Authorization = %q, want Bearer test-token", got)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	if err := NewInternalClient(server.URL, server.Client()).WithToken("test-token").RemoveMetadataPeer(2); err != nil {
+		t.Fatalf("RemoveMetadataPeer returned error: %v", err)
+	}
+}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -46,7 +46,7 @@ func NewAntflyClient(baseURL string, httpClient *http.Client) (*AntflyClient, er
 }
 
 // NewAntflyClientWithOptions creates a new Antfly client with variadic options.
-// Use with WithBasicAuth, WithApiKey, or WithBearerToken for authentication.
+// Use with WithBasicAuth, WithApiKey, or WithToken for authentication.
 func NewAntflyClientWithOptions(baseURL string, opts ...oapi.ClientOption) (*AntflyClient, error) {
 	client, err := oapi.NewClient(NormalizeBaseURL(baseURL), opts...)
 	if err != nil {
@@ -76,20 +76,12 @@ func WithApiKey(keyID, keySecret string) oapi.RequestEditorFn {
 	}
 }
 
-// WithBearerToken returns a RequestEditorFn that adds Bearer token authentication.
-// The token should be base64(keyID:keySecret) for Antfly API keys, or an opaque token
-// from a proxy.
-func WithBearerToken(token string) oapi.RequestEditorFn {
+// WithToken returns a RequestEditorFn that adds token authentication.
+func WithToken(token string) oapi.RequestEditorFn {
 	return func(_ context.Context, req *http.Request) error {
 		req.Header.Set("Authorization", "Bearer "+token)
 		return nil
 	}
-}
-
-// WithToken returns a RequestEditorFn that adds Bearer token authentication.
-// Use this for CloudAF instance tokens and other bearer-style credentials.
-func WithToken(token string) oapi.RequestEditorFn {
-	return WithBearerToken(token)
 }
 
 // APIError represents a structured error response from the Antfly API.

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -36,7 +36,7 @@ type AntflyClient struct {
 
 // NewAntflyClient creates a new Antfly client with an HTTP client.
 func NewAntflyClient(baseURL string, httpClient *http.Client) (*AntflyClient, error) {
-	client, err := oapi.NewClient(baseURL, oapi.WithHTTPClient(httpClient))
+	client, err := oapi.NewClient(NormalizeBaseURL(baseURL), oapi.WithHTTPClient(httpClient))
 	if err != nil {
 		return nil, err
 	}
@@ -48,7 +48,7 @@ func NewAntflyClient(baseURL string, httpClient *http.Client) (*AntflyClient, er
 // NewAntflyClientWithOptions creates a new Antfly client with variadic options.
 // Use with WithBasicAuth, WithApiKey, or WithBearerToken for authentication.
 func NewAntflyClientWithOptions(baseURL string, opts ...oapi.ClientOption) (*AntflyClient, error) {
-	client, err := oapi.NewClient(baseURL, opts...)
+	client, err := oapi.NewClient(NormalizeBaseURL(baseURL), opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -84,6 +84,12 @@ func WithBearerToken(token string) oapi.RequestEditorFn {
 		req.Header.Set("Authorization", "Bearer "+token)
 		return nil
 	}
+}
+
+// WithToken returns a RequestEditorFn that adds Bearer token authentication.
+// Use this for CloudAF instance tokens and other bearer-style credentials.
+func WithToken(token string) oapi.RequestEditorFn {
+	return WithBearerToken(token)
 }
 
 // APIError represents a structured error response from the Antfly API.

--- a/pkg/client/url.go
+++ b/pkg/client/url.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2026 The Antfly Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import "strings"
+
+const apiV1Path = "/api/v1"
+
+// NormalizeBaseURL returns the Antfly API base URL used by generated clients.
+// It accepts either a server root URL or an API-root URL.
+func NormalizeBaseURL(baseURL string) string {
+	trimmed := strings.TrimRight(baseURL, "/")
+	if strings.HasSuffix(trimmed, apiV1Path) {
+		return trimmed
+	}
+	return trimmed + apiV1Path
+}
+
+// NormalizeServerURL returns the Antfly server root URL for non-OpenAPI
+// endpoints such as internal admin routes.
+func NormalizeServerURL(baseURL string) string {
+	return strings.TrimSuffix(strings.TrimRight(baseURL, "/"), apiV1Path)
+}

--- a/pkg/client/url_test.go
+++ b/pkg/client/url_test.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2026 The Antfly Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/antflydb/antfly/pkg/client/oapi"
+)
+
+func TestNormalizeBaseURL(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "local root", in: "http://localhost:8080", want: "http://localhost:8080/api/v1"},
+		{name: "local root trailing slash", in: "http://localhost:8080/", want: "http://localhost:8080/api/v1"},
+		{name: "local api root", in: "http://localhost:8080/api/v1", want: "http://localhost:8080/api/v1"},
+		{name: "local api root trailing slash", in: "http://localhost:8080/api/v1/", want: "http://localhost:8080/api/v1"},
+		{name: "cloud proxy root", in: "https://platform.antfly.io/cloud/v1/instance", want: "https://platform.antfly.io/cloud/v1/instance/api/v1"},
+		{name: "cloud proxy api root", in: "https://platform.antfly.io/cloud/v1/instance/api/v1", want: "https://platform.antfly.io/cloud/v1/instance/api/v1"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NormalizeBaseURL(tt.in); got != tt.want {
+				t.Fatalf("NormalizeBaseURL(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeServerURL(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "local root", in: "http://localhost:8080", want: "http://localhost:8080"},
+		{name: "local api root", in: "http://localhost:8080/api/v1", want: "http://localhost:8080"},
+		{name: "cloud proxy root", in: "https://platform.antfly.io/cloud/v1/instance", want: "https://platform.antfly.io/cloud/v1/instance"},
+		{name: "cloud proxy api root", in: "https://platform.antfly.io/cloud/v1/instance/api/v1", want: "https://platform.antfly.io/cloud/v1/instance"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NormalizeServerURL(tt.in); got != tt.want {
+				t.Fatalf("NormalizeServerURL(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTokenAuthHeaderAndNormalizedPath(t *testing.T) {
+	var gotPath, gotAuth string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer server.Close()
+
+	client, err := NewAntflyClientWithOptions(
+		server.URL,
+		oapi.WithHTTPClient(server.Client()),
+		oapi.WithRequestEditorFn(WithToken("antflydb_test")),
+	)
+	if err != nil {
+		t.Fatalf("NewAntflyClientWithOptions: %v", err)
+	}
+	if _, err := client.ListTables(context.Background()); err != nil {
+		t.Fatalf("ListTables: %v", err)
+	}
+
+	if gotPath != "/api/v1/tables" {
+		t.Fatalf("path = %q, want /api/v1/tables", gotPath)
+	}
+	if gotAuth != "Bearer antflydb_test" {
+		t.Fatalf("Authorization = %q, want Bearer antflydb_test", gotAuth)
+	}
+}

--- a/py/src/antfly/client.py
+++ b/py/src/antfly/client.py
@@ -24,6 +24,14 @@ from antfly.client_generated.types import UNSET
 from .exceptions import AntflyException
 
 
+def normalize_base_url(base_url: str) -> str:
+    """Return the Antfly API base URL for local or CloudAF endpoints."""
+    trimmed = base_url.rstrip("/")
+    if trimmed.endswith("/api/v1"):
+        return trimmed
+    return f"{trimmed}/api/v1"
+
+
 class AntflyClient:
     """High-level client for interacting with Antfly database."""
 
@@ -33,6 +41,7 @@ class AntflyClient:
         username: Optional[str] = None,
         password: Optional[str] = None,
         api_key: Optional[tuple[str, str]] = None,
+        token: Optional[str] = None,
         bearer_token: Optional[str] = None,
         timeout: float = 30.0,
     ):
@@ -42,17 +51,22 @@ class AntflyClient:
         Supports three authentication methods (mutually exclusive):
         - Basic auth: provide ``username`` and ``password``
         - API key: provide ``api_key`` as ``(key_id, key_secret)``
-        - Bearer token: provide ``bearer_token``
+        - Bearer token: provide ``token``
 
         Args:
-            base_url: Base URL of the Antfly server
+            base_url: Base URL of the Antfly server or CloudAF proxy
             username: Username for basic authentication (optional)
             password: Password for basic authentication (optional)
             api_key: Tuple of (key_id, key_secret) for API key authentication (optional)
-            bearer_token: Bearer token string for token authentication (optional)
+            token: Bearer token string for token authentication (optional)
             timeout: Request timeout in seconds
         """
-        self.base_url = base_url.rstrip("/")
+        if token is not None and bearer_token is not None:
+            raise ValueError("provide only one of token or bearer_token")
+        if token is None:
+            token = bearer_token
+
+        self.base_url = normalize_base_url(base_url)
 
         httpx_args: dict[str, Any] = {}
 
@@ -66,10 +80,10 @@ class AntflyClient:
                 timeout=Timeout(timeout),
                 httpx_args=httpx_args,
             )
-        elif bearer_token is not None:
+        elif token is not None:
             self._client = AuthenticatedClient(
                 base_url=self.base_url,
-                token=bearer_token,
+                token=token,
                 prefix="Bearer",
                 timeout=Timeout(timeout),
                 httpx_args=httpx_args,

--- a/py/src/antfly/client.py
+++ b/py/src/antfly/client.py
@@ -42,7 +42,6 @@ class AntflyClient:
         password: Optional[str] = None,
         api_key: Optional[tuple[str, str]] = None,
         token: Optional[str] = None,
-        bearer_token: Optional[str] = None,
         timeout: float = 30.0,
     ):
         """
@@ -51,21 +50,16 @@ class AntflyClient:
         Supports three authentication methods (mutually exclusive):
         - Basic auth: provide ``username`` and ``password``
         - API key: provide ``api_key`` as ``(key_id, key_secret)``
-        - Bearer token: provide ``token``
+        - Token: provide ``token``
 
         Args:
             base_url: Base URL of the Antfly server or CloudAF proxy
             username: Username for basic authentication (optional)
             password: Password for basic authentication (optional)
             api_key: Tuple of (key_id, key_secret) for API key authentication (optional)
-            token: Bearer token string for token authentication (optional)
+            token: Token string for token authentication (optional)
             timeout: Request timeout in seconds
         """
-        if token is not None and bearer_token is not None:
-            raise ValueError("provide only one of token or bearer_token")
-        if token is None:
-            token = bearer_token
-
         self.base_url = normalize_base_url(base_url)
 
         httpx_args: dict[str, Any] = {}

--- a/py/tests/test_client.py
+++ b/py/tests/test_client.py
@@ -14,6 +14,7 @@ sys.modules["antfly_client.api.api_index"] = MagicMock()
 sys.modules["antfly_client.models"] = MagicMock()
 
 from antfly import AntflyClient, AntflyException  # noqa: E402
+from antfly.client import normalize_base_url  # noqa: E402
 
 
 class TestAntflyClient:
@@ -24,9 +25,9 @@ class TestAntflyClient:
         """Test client initialization with and without auth."""
         # Without auth
         client = AntflyClient(base_url="http://localhost:8080")
-        assert client.base_url == "http://localhost:8080"
+        assert client.base_url == "http://localhost:8080/api/v1"
         mock_client.assert_called_once_with(
-            base_url="http://localhost:8080",
+            base_url="http://localhost:8080/api/v1",
             timeout=Timeout(30.0),
             httpx_args={},
         )
@@ -34,11 +35,35 @@ class TestAntflyClient:
         # With auth
         mock_client.reset_mock()
         client = AntflyClient(base_url="http://localhost:8080/", username="admin", password="password")
-        assert client.base_url == "http://localhost:8080"
+        assert client.base_url == "http://localhost:8080/api/v1"
         mock_client.assert_called_once_with(
-            base_url="http://localhost:8080",
+            base_url="http://localhost:8080/api/v1",
             timeout=Timeout(30.0),
             httpx_args={"auth": ("admin", "password")},
+        )
+
+    def test_normalize_base_url(self) -> None:
+        assert normalize_base_url("http://localhost:8080") == "http://localhost:8080/api/v1"
+        assert normalize_base_url("http://localhost:8080/") == "http://localhost:8080/api/v1"
+        assert normalize_base_url("http://localhost:8080/api/v1") == "http://localhost:8080/api/v1"
+        assert (
+            normalize_base_url("https://platform.antfly.io/cloud/v1/instance")
+            == "https://platform.antfly.io/cloud/v1/instance/api/v1"
+        )
+        assert (
+            normalize_base_url("https://platform.antfly.io/cloud/v1/instance/api/v1")
+            == "https://platform.antfly.io/cloud/v1/instance/api/v1"
+        )
+
+    @patch("antfly.client.AuthenticatedClient")
+    def test_token_auth(self, mock_client: MagicMock) -> None:
+        AntflyClient(base_url="https://platform.antfly.io/cloud/v1/instance", token="antflydb_test")
+        mock_client.assert_called_once_with(
+            base_url="https://platform.antfly.io/cloud/v1/instance/api/v1",
+            token="antflydb_test",
+            prefix="Bearer",
+            timeout=Timeout(30.0),
+            httpx_args={},
         )
 
     @patch("antfly.client.Client")

--- a/rs/antfly-client/src/lib.rs
+++ b/rs/antfly-client/src/lib.rs
@@ -1,3 +1,62 @@
 #![allow(clippy::all)]
 
+use reqwest::header::{AUTHORIZATION, HeaderMap, HeaderValue};
+
+pub fn normalize_base_url(base_url: &str) -> String {
+    let trimmed = base_url.trim_end_matches('/');
+    if trimmed.ends_with("/api/v1") {
+        trimmed.to_string()
+    } else {
+        format!("{trimmed}/api/v1")
+    }
+}
+
+pub fn new_client(base_url: &str, http_client: reqwest::Client) -> Client {
+    Client::new(&normalize_base_url(base_url), http_client)
+}
+
+pub fn new_client_with_token(
+    base_url: &str,
+    token: &str,
+) -> Result<Client, Box<dyn std::error::Error + Send + Sync>> {
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        AUTHORIZATION,
+        HeaderValue::from_str(&format!("Bearer {token}"))?,
+    );
+    let http_client = reqwest::Client::builder()
+        .default_headers(headers)
+        .build()?;
+    Ok(new_client(base_url, http_client))
+}
+
 include!(concat!(env!("OUT_DIR"), "/client.rs"));
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_base_url;
+
+    #[test]
+    fn normalizes_local_and_cloud_urls() {
+        assert_eq!(
+            normalize_base_url("http://localhost:8080"),
+            "http://localhost:8080/api/v1"
+        );
+        assert_eq!(
+            normalize_base_url("http://localhost:8080/"),
+            "http://localhost:8080/api/v1"
+        );
+        assert_eq!(
+            normalize_base_url("http://localhost:8080/api/v1"),
+            "http://localhost:8080/api/v1"
+        );
+        assert_eq!(
+            normalize_base_url("https://platform.antfly.io/cloud/v1/instance"),
+            "https://platform.antfly.io/cloud/v1/instance/api/v1"
+        );
+        assert_eq!(
+            normalize_base_url("https://platform.antfly.io/cloud/v1/instance/api/v1"),
+            "https://platform.antfly.io/cloud/v1/instance/api/v1"
+        );
+    }
+}

--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Step lifecycle SSE events for Answer Agent streaming
 - AI Elements adapters and replication route types
 - Embedding, DenseEmbedding, SparseEmbedding type exports
-- API key and bearer token auth support
+- API key and token auth support
 - MergeConfig and updated index types
 - Sparse bool and consolidated index types
 

--- a/ts/packages/sdk/src/client.ts
+++ b/ts/packages/sdk/src/client.ts
@@ -37,7 +37,10 @@ export class AntflyClient {
   private config: AntflyConfig;
 
   constructor(config: AntflyConfig) {
-    this.config = config;
+    this.config = {
+      ...config,
+      baseUrl: normalizeBaseUrl(config.baseUrl),
+    };
     this.client = this.buildClient();
   }
 
@@ -55,6 +58,8 @@ export class AntflyClient {
           return `Basic ${btoa(`${auth.username}:${auth.password}`)}`;
         case "apiKey":
           return `ApiKey ${btoa(`${auth.keyId}:${auth.keySecret}`)}`;
+        case "token":
+          return `Bearer ${auth.token}`;
         case "bearer":
           return `Bearer ${auth.token}`;
       }
@@ -882,4 +887,12 @@ export class AntflyClient {
   getRawClient() {
     return this.client;
   }
+}
+
+export function normalizeBaseUrl(baseUrl: string): string {
+  const trimmed = baseUrl.replace(/\/+$/, "");
+  if (trimmed.endsWith("/api/v1")) {
+    return trimmed;
+  }
+  return `${trimmed}/api/v1`;
 }

--- a/ts/packages/sdk/src/client.ts
+++ b/ts/packages/sdk/src/client.ts
@@ -60,8 +60,6 @@ export class AntflyClient {
           return `ApiKey ${btoa(`${auth.keyId}:${auth.keySecret}`)}`;
         case "token":
           return `Bearer ${auth.token}`;
-        case "bearer":
-          return `Bearer ${auth.token}`;
       }
     }
 
@@ -97,7 +95,7 @@ export class AntflyClient {
 
   /**
    * Update authentication credentials.
-   * Accepts any auth type: basic (username/password), apiKey, or bearer.
+   * Accepts any auth type: basic (username/password), apiKey, or token.
    * For backwards compat, calling setAuth(username, password) still works.
    */
   setAuth(auth: AntflyAuth): void;

--- a/ts/packages/sdk/src/types.ts
+++ b/ts/packages/sdk/src/types.ts
@@ -241,7 +241,6 @@ export type AntflyAuth =
   | { type: "basic"; username: string; password: string }
   | { type: "apiKey"; keyId: string; keySecret: string }
   | { type: "token"; token: string }
-  | { type: "bearer"; token: string }
   | { username: string; password: string }; // backwards compat (no 'type' field)
 
 // Configuration types for the client

--- a/ts/packages/sdk/src/types.ts
+++ b/ts/packages/sdk/src/types.ts
@@ -240,6 +240,7 @@ export type ResponseData<T extends keyof operations> = operations[T]["responses"
 export type AntflyAuth =
   | { type: "basic"; username: string; password: string }
   | { type: "apiKey"; keyId: string; keySecret: string }
+  | { type: "token"; token: string }
   | { type: "bearer"; token: string }
   | { username: string; password: string }; // backwards compat (no 'type' field)
 

--- a/ts/packages/sdk/test/client.test.ts
+++ b/ts/packages/sdk/test/client.test.ts
@@ -69,7 +69,7 @@ describe("AntflyClient", () => {
       );
     });
 
-    it("should configure token auth as a bearer token", () => {
+    it("should configure token auth", () => {
       new AntflyClient({
         baseUrl: "https://platform.antfly.io/cloud/v1/instance",
         auth: { type: "token", token: "antflydb_test" },

--- a/ts/packages/sdk/test/client.test.ts
+++ b/ts/packages/sdk/test/client.test.ts
@@ -28,6 +28,8 @@ vi.mock("openapi-fetch", () => ({
 
 // Import client after mocking
 const { AntflyClient } = await import("../src/client.js");
+const { normalizeBaseUrl } = await import("../src/client.js");
+const { default: createClient } = await import("openapi-fetch");
 
 describe("AntflyClient", () => {
   let client: AntflyClient;
@@ -53,6 +55,34 @@ describe("AntflyClient", () => {
 
     it("should have access to raw client", () => {
       expect(client.getRawClient()).toBeDefined();
+    });
+
+    it("should normalize local and CloudAF base URLs", () => {
+      expect(normalizeBaseUrl("http://localhost:8080")).toBe("http://localhost:8080/api/v1");
+      expect(normalizeBaseUrl("http://localhost:8080/")).toBe("http://localhost:8080/api/v1");
+      expect(normalizeBaseUrl("http://localhost:8080/api/v1")).toBe("http://localhost:8080/api/v1");
+      expect(normalizeBaseUrl("https://platform.antfly.io/cloud/v1/instance")).toBe(
+        "https://platform.antfly.io/cloud/v1/instance/api/v1"
+      );
+      expect(normalizeBaseUrl("https://platform.antfly.io/cloud/v1/instance/api/v1")).toBe(
+        "https://platform.antfly.io/cloud/v1/instance/api/v1"
+      );
+    });
+
+    it("should configure token auth as a bearer token", () => {
+      new AntflyClient({
+        baseUrl: "https://platform.antfly.io/cloud/v1/instance",
+        auth: { type: "token", token: "antflydb_test" },
+      });
+
+      expect(createClient).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          baseUrl: "https://platform.antfly.io/cloud/v1/instance/api/v1",
+          headers: expect.objectContaining({
+            Authorization: "Bearer antflydb_test",
+          }),
+        })
+      );
     });
   });
 
@@ -329,7 +359,7 @@ describe("AntflyClient", () => {
       expect(results[2]).toEqual({ _key: "user:3", name: "Charlie" });
 
       expect(mockFetch).toHaveBeenCalledWith(
-        "http://localhost:8080/tables/users/lookup",
+        "http://localhost:8080/api/v1/tables/users/lookup",
         expect.objectContaining({
           method: "POST",
           body: "{}",
@@ -362,7 +392,7 @@ describe("AntflyClient", () => {
       expect(results).toHaveLength(2);
 
       expect(mockFetch).toHaveBeenCalledWith(
-        "http://localhost:8080/tables/users/lookup",
+        "http://localhost:8080/api/v1/tables/users/lookup",
         expect.objectContaining({
           method: "POST",
           body: JSON.stringify({

--- a/zig/e2e/antfly/test_schema_migration.py
+++ b/zig/e2e/antfly/test_schema_migration.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import json
 import time
 
 from helpers import wait_until
@@ -54,7 +55,10 @@ def test_schema_migration_full_text_rebuild(stateful_api):
         lambda: _ready_index(stateful_api, table_name, "full_text_index_v0", expected_docs=num_docs),
         timeout_s=SCHEMA_MIGRATION_REBUILD_TIMEOUT_S,
     )
-    assert initial_index is not None, "full_text_index_v0 did not finish rebuilding in time"
+    assert initial_index is not None, (
+        "full_text_index_v0 did not finish rebuilding in time\n"
+        + _schema_migration_diagnostics(stateful_api, table_name, "full_text_index_v0")
+    )
 
     updated = stateful_api.update_schema(
         table_name,
@@ -101,14 +105,20 @@ def test_schema_migration_full_text_rebuild(stateful_api):
         lambda: _ready_index(stateful_api, table_name, "full_text_index_v1", expected_docs=num_docs),
         timeout_s=SCHEMA_MIGRATION_REBUILD_TIMEOUT_S,
     )
-    assert rebuilt_index is not None, "full_text_index_v1 did not finish rebuilding in time"
+    assert rebuilt_index is not None, (
+        "full_text_index_v1 did not finish rebuilding in time\n"
+        + _schema_migration_diagnostics(stateful_api, table_name, "full_text_index_v1")
+    )
 
     stable_table = wait_until(
         lambda: _stable_table(stateful_api, table_name, expected_version=1),
         timeout_s=SCHEMA_MIGRATION_REBUILD_TIMEOUT_S,
         interval_s=2.0,
     )
-    assert stable_table is not None, "schema migration did not reach a stable table state"
+    assert stable_table is not None, (
+        "schema migration did not reach a stable table state\n"
+        + _schema_migration_diagnostics(stateful_api, table_name, "full_text_index_v1")
+    )
 
     stable_indexes = _index_names(stateful_api.list_indexes(table_name))
     assert "full_text_index_v0" not in stable_indexes
@@ -144,3 +154,23 @@ def _stable_table(stateful_api, table_name: str, *, expected_version: int) -> di
     if table["schema"]["version"] != expected_version:
         return None
     return table
+
+
+def _schema_migration_diagnostics(stateful_api, table_name: str, index_name: str) -> str:
+    return json.dumps(
+        {
+            "index": _safe_api_call(lambda: stateful_api.get_index(table_name, index_name)),
+            "indexes": _safe_api_call(lambda: stateful_api.list_indexes(table_name)),
+            "table": _safe_api_call(lambda: stateful_api.get_table(table_name)),
+        },
+        indent=2,
+        sort_keys=True,
+    )
+
+
+def _safe_api_call(fn) -> dict:
+    try:
+        return fn()
+    except Exception as exc:
+        message = f"{type(exc).__name__}: {exc}"
+        return {"error": message[:4000]}

--- a/zig/e2e/antfly/test_schema_migration.py
+++ b/zig/e2e/antfly/test_schema_migration.py
@@ -21,6 +21,9 @@ import time
 from helpers import wait_until
 
 
+SCHEMA_MIGRATION_REBUILD_TIMEOUT_S = 240.0
+
+
 def _index_stats(index_status: dict) -> dict:
     return index_status["status"]
 
@@ -49,7 +52,7 @@ def test_schema_migration_full_text_rebuild(stateful_api):
 
     initial_index = wait_until(
         lambda: _ready_index(stateful_api, table_name, "full_text_index_v0", expected_docs=num_docs),
-        timeout_s=120.0,
+        timeout_s=SCHEMA_MIGRATION_REBUILD_TIMEOUT_S,
     )
     assert initial_index is not None, "full_text_index_v0 did not finish rebuilding in time"
 
@@ -96,13 +99,13 @@ def test_schema_migration_full_text_rebuild(stateful_api):
 
     rebuilt_index = wait_until(
         lambda: _ready_index(stateful_api, table_name, "full_text_index_v1", expected_docs=num_docs),
-        timeout_s=120.0,
+        timeout_s=SCHEMA_MIGRATION_REBUILD_TIMEOUT_S,
     )
     assert rebuilt_index is not None, "full_text_index_v1 did not finish rebuilding in time"
 
     stable_table = wait_until(
         lambda: _stable_table(stateful_api, table_name, expected_version=1),
-        timeout_s=120.0,
+        timeout_s=SCHEMA_MIGRATION_REBUILD_TIMEOUT_S,
         interval_s=2.0,
     )
     assert stable_table is not None, "schema migration did not reach a stable table state"

--- a/zig/pkg/antfly-client/src/client.zig
+++ b/zig/pkg/antfly-client/src/client.zig
@@ -37,11 +37,10 @@ pub const AntflyClient = struct {
     allocator: std.mem.Allocator,
 
     pub fn init(allocator: std.mem.Allocator, http: *httpx.Client, base_url: []const u8) !AntflyClient {
-        // Append /api/v1 to base URL, stripping trailing slash.
+        // Append /api/v1 to server root URLs, stripping trailing slash.
         // The generated openapi.Client stores a pointer to this string,
         // so we must keep it alive until deinit.
-        const trimmed = trimRightSlash(base_url);
-        const url = try std.fmt.allocPrint(allocator, "{s}/api/v1", .{trimmed});
+        const url = try normalizeBaseUrl(allocator, base_url);
 
         const inner = openapi.Client.init(allocator, http, url);
         return .{
@@ -289,6 +288,14 @@ pub const AntflyClient = struct {
     }
 };
 
+pub fn normalizeBaseUrl(allocator: std.mem.Allocator, base_url: []const u8) ![]const u8 {
+    const trimmed = trimRightSlash(base_url);
+    if (std.mem.endsWith(u8, trimmed, "/api/v1")) {
+        return try allocator.dupe(u8, trimmed);
+    }
+    return try std.fmt.allocPrint(allocator, "{s}/api/v1", .{trimmed});
+}
+
 const BatchRequestWire = struct {
     inner: openapi.types.BatchRequest,
 
@@ -331,4 +338,24 @@ fn base64Encode(allocator: std.mem.Allocator, input: []const u8) ![]const u8 {
 test "AntflyClient compiles" {
     _ = AntflyClient;
     _ = ApiError;
+}
+
+test "normalizeBaseUrl accepts local and CloudAF URLs" {
+    const alloc = std.testing.allocator;
+
+    const local_root = try normalizeBaseUrl(alloc, "http://localhost:8080");
+    defer alloc.free(local_root);
+    try std.testing.expectEqualStrings("http://localhost:8080/api/v1", local_root);
+
+    const local_api = try normalizeBaseUrl(alloc, "http://localhost:8080/api/v1/");
+    defer alloc.free(local_api);
+    try std.testing.expectEqualStrings("http://localhost:8080/api/v1", local_api);
+
+    const cloud_root = try normalizeBaseUrl(alloc, "https://platform.antfly.io/cloud/v1/instance");
+    defer alloc.free(cloud_root);
+    try std.testing.expectEqualStrings("https://platform.antfly.io/cloud/v1/instance/api/v1", cloud_root);
+
+    const cloud_api = try normalizeBaseUrl(alloc, "https://platform.antfly.io/cloud/v1/instance/api/v1");
+    defer alloc.free(cloud_api);
+    try std.testing.expectEqualStrings("https://platform.antfly.io/cloud/v1/instance/api/v1", cloud_api);
 }

--- a/zig/pkg/antfly/src/cmd/cli/mod.zig
+++ b/zig/pkg/antfly/src/cmd/cli/mod.zig
@@ -29,7 +29,7 @@ pub const OutputFormat = enum { json, table_fmt };
 
 pub const GlobalConfig = struct {
     url: []const u8 = "http://localhost:8080",
-    auth_bearer: ?[]const u8 = null,
+    token: ?[]const u8 = null,
     output: OutputFormat = .json,
 };
 
@@ -37,21 +37,21 @@ pub const GlobalConfig = struct {
 ///
 /// Supported env vars:
 ///   ANTFLY_URL    — server base URL (default http://localhost:8080)
-///   ANTFLY_BEARER — bearer token for authentication
+///   ANTFLY_TOKEN  — bearer token for authentication
 pub fn parseGlobalFlags() GlobalConfig {
     var config = GlobalConfig{};
     if (platform.env.getenv("ANTFLY_URL")) |raw| {
         config.url = raw;
     }
-    if (platform.env.getenv("ANTFLY_BEARER")) |raw| {
-        config.auth_bearer = raw;
+    if (platform.env.getenv("ANTFLY_TOKEN")) |raw| {
+        config.token = raw;
     }
     return config;
 }
 
 pub fn initClient(allocator: std.mem.Allocator, http: *httpx.Client, config: GlobalConfig) !antfly_client.AntflyClient {
     var client = try antfly_client.AntflyClient.init(allocator, http, config.url);
-    if (config.auth_bearer) |token| {
+    if (config.token) |token| {
         try client.setBearer(token);
     }
     return client;

--- a/zig/pkg/antfly/src/main.zig
+++ b/zig/pkg/antfly/src/main.zig
@@ -71,7 +71,7 @@ pub fn main(init: std.process.Init) !void {
 }
 
 fn runCliCommand(allocator: std.mem.Allocator, subcommand: []const u8, args: *std.process.Args.Iterator) !void {
-    // Read global config from env vars (ANTFLY_URL, ANTFLY_BEARER)
+    // Read global config from env vars (ANTFLY_URL, ANTFLY_TOKEN)
     const config = cmd.cli.parseGlobalFlags();
 
     // Initialize IO and HTTP client


### PR DESCRIPTION
## Summary
- normalize Antfly client base URLs so local roots and CloudAF proxy URLs both resolve to /api/v1 without duplication
- add the canonical --url/--token and ANTFLY_URL/ANTFLY_TOKEN surface to the Go and Zig CLIs
- wire token auth as Authorization: Bearer <token> across Go, Python, TypeScript, Rust, and Zig clients

## Tests
- go test ./cmd/antfly/...
- go test ./... (in pkg/client)
- uv run pytest tests -q (in py)
- uv run pyright src tests (in py)
- pnpm --filter @antfly/sdk test (in ts)
- pnpm --filter @antfly/sdk typecheck (in ts)
- zig test pkg/antfly-client/src/client.zig (in zig)
- zig test pkg/antfly/src/cmd/cli/mod.zig (in zig)

Rust tests were not run locally because cargo/rustc are not installed in this environment.