### PR TITLE
Avoid creating legacy storage dirs for Zig swarm

### DIFF
--- a/pkg/operator/controllers/antfly/antflycluster_controller.go
+++ b/pkg/operator/controllers/antfly/antflycluster_controller.go
@@ -2814,8 +2814,7 @@ while [ $timeout -gt 0 ]; do
             echo "No existing data - fresh cluster"
         fi
         marker=/antflydb/.antflydb-storage-prepared
-        echo "Preparing PVC directories for antfly runtime user %d:%d"
-        mkdir -p /antflydb/metadata /antflydb/store
+        echo "Preparing PVC root for antfly runtime user %d:%d"
         if [ ! -f "$marker" ]; then
             chown -R %d:%d /antflydb
             chmod -R ug+rwX /antflydb
@@ -2823,8 +2822,8 @@ while [ $timeout -gt 0 ]; do
             chown %d:%d "$marker"
             chmod ug+rw "$marker"
         else
-            chown %d:%d /antflydb /antflydb/metadata /antflydb/store
-            chmod ug+rwX /antflydb /antflydb/metadata /antflydb/store
+            chown %d:%d /antflydb
+            chmod ug+rwX /antflydb
         fi
         exit 0
     fi

--- a/pkg/operator/controllers/antfly/antflycluster_controller_test.go
+++ b/pkg/operator/controllers/antfly/antflycluster_controller_test.go
@@ -2731,7 +2731,7 @@ func TestMetadataStatefulSetPreparesPersistentStorageForNonRootRuntime(t *testin
 	g.Expect(initContainer.SecurityContext.RunAsUser).NotTo(BeNil())
 	g.Expect(*initContainer.SecurityContext.RunAsUser).To(Equal(int64(0)))
 	g.Expect(initContainer.Args).To(HaveLen(1))
-	g.Expect(initContainer.Args[0]).To(ContainSubstring("mkdir -p /antflydb/metadata /antflydb/store"))
+	g.Expect(initContainer.Args[0]).NotTo(ContainSubstring("mkdir -p /antflydb/metadata /antflydb/store"))
 	g.Expect(initContainer.Args[0]).To(ContainSubstring("chown -R 10001:10001 /antflydb"))
 	g.Expect(initContainer.Args[0]).To(ContainSubstring("chmod -R ug+rwX /antflydb"))
 }


### PR DESCRIPTION
## Summary
- stop the operator storage init container from creating `/antflydb/metadata` and `/antflydb/store` on fresh PVCs
- continue preparing PVC root ownership for the non-root Antfly runtime user
- update the controller test to assert the legacy directory creation stays out of the init script

## Validation
- `go test ./controllers/antfly` from `pkg/operator`