### PR TITLE
Rebuild Antfarm assets without conflict markers

### DIFF
--- a/src/metadata/antfarm/index.html
+++ b/src/metadata/antfarm/index.html
@@ -5,7 +5,7 @@
         <link rel="icon" type="image/png" href="/favicon.png" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>Antfly Dashboard</title>
-      <script type="module" crossorigin src="/assets/index-DAV9LNnr.js"></script>
+      <script type="module" crossorigin src="/assets/index-P9I19un4.js"></script>
       <link rel="stylesheet" crossorigin href="/assets/index-CrXSTZkd.css">
     </head>
     <body>


### PR DESCRIPTION
## Summary
- rebuild the Antfarm frontend bundle from `ts/apps/antfarm`
- replace the broken generated JS asset that contained unresolved conflict markers
- update `index.html` to reference the rebuilt bundle

## Validation
- `make build-antfarm`
- `node --check src/metadata/antfarm/assets/index-P9I19un4.js`
- `go test ./controllers/antfly` from `pkg/operator`