### PR TITLE
Fix TTL metadata for local document writes

### DIFF
--- a/go/pkg/antfly/src/store/db/db.go
+++ b/go/pkg/antfly/src/store/db/db.go
@@ -2841,6 +2841,73 @@ func shouldWriteTimestamp(key []byte) bool {
 	return true
 }
 
+func (db *DBImpl) defaultWriteTimestamp(timestamp uint64) uint64 {
+	if timestamp != 0 {
+		return timestamp
+	}
+	if db.cachedTTLDuration == 0 {
+		return 0
+	}
+	return uint64(time.Now().UTC().UnixNano()) //nolint:gosec // UnixNano is positive for supported wall-clock dates.
+}
+
+func (db *DBImpl) resolveWriteTimestamp(docJSON []byte, fallback uint64) uint64 {
+	if db.schema == nil || db.cachedTTLDuration == 0 {
+		return fallback
+	}
+
+	var doc map[string]any
+	if err := json.Unmarshal(docJSON, &doc); err != nil {
+		db.logger.Warn("could not parse document for TTL timestamp",
+			zap.Error(err))
+		return fallback
+	}
+
+	value, ok := doc[db.schema.GetTTLField()]
+	if !ok {
+		return fallback
+	}
+
+	timestamp, ok := ttlTimestampFromValue(value)
+	if !ok {
+		db.logger.Warn("could not parse TTL field timestamp",
+			zap.String("ttl_field", db.schema.GetTTLField()))
+		return fallback
+	}
+	return timestamp
+}
+
+func ttlTimestampFromValue(value any) (uint64, bool) {
+	switch v := value.(type) {
+	case string:
+		if ts, err := time.Parse(time.RFC3339Nano, v); err == nil {
+			return unixNanoToUint64(ts)
+		}
+		if ts, err := time.Parse(time.RFC3339, v); err == nil {
+			return unixNanoToUint64(ts)
+		}
+	case float64:
+		if v >= 0 {
+			return uint64(v), true
+		}
+	case int64:
+		if v >= 0 {
+			return uint64(v), true
+		}
+	case uint64:
+		return v, true
+	}
+	return 0, false
+}
+
+func unixNanoToUint64(ts time.Time) (uint64, bool) {
+	nanos := ts.UnixNano()
+	if nanos < 0 {
+		return 0, false
+	}
+	return uint64(nanos), true //nolint:gosec // negative values are handled above.
+}
+
 func (db *DBImpl) Batch(
 	ctx context.Context,
 	writes [][2][]byte,
@@ -2859,8 +2926,10 @@ func (db *DBImpl) Batch(
 		return pebble.ErrClosed
 	}
 
-	// Get HLC timestamp from context (set by metadata layer for consistent timestamps)
-	timestamp := storeutils.GetTimestampFromContext(ctx)
+	// Get HLC timestamp from context (set by metadata layer for consistent timestamps).
+	// Single-node/local apply paths may not carry one; TTL still needs a side-key
+	// timestamp so query-time filtering and cleanup can see new writes.
+	timestamp := db.defaultWriteTimestamp(storeutils.GetTimestampFromContext(ctx))
 	splitState := db.splitState
 	mergeState := db.mergeState
 
@@ -3019,7 +3088,9 @@ func (db *DBImpl) Batch(
 		valueToCompress := kv[1]
 		shouldWriteDocument := true
 
-		sfResult, err := db.extractAndWriteSpecialFields(batch, kv[1], kv[0], timestamp)
+		writeTimestamp := db.resolveWriteTimestamp(kv[1], timestamp)
+
+		sfResult, err := db.extractAndWriteSpecialFields(batch, kv[1], kv[0], writeTimestamp)
 		if err != nil {
 			return fmt.Errorf("extracting special fields for key %s: %w", kv[0], err)
 		}
@@ -3047,9 +3118,9 @@ func (db *DBImpl) Batch(
 			}
 
 			// Write timestamp for document if timestamp is available
-			if timestamp > 0 && shouldWriteTimestamp(key) {
+			if writeTimestamp > 0 && shouldWriteTimestamp(key) {
 				txnKey := slices.Concat(key, storeutils.TransactionSuffix)
-				timestampBytes := encoding.EncodeUint64Ascending(nil, timestamp)
+				timestampBytes := encoding.EncodeUint64Ascending(nil, writeTimestamp)
 				if err := batch.Set(txnKey, timestampBytes, nil); err != nil {
 					db.logger.Warn("could not write timestamp for document",
 						zap.String("key", types.FormatKey(key)),

--- a/go/pkg/antfly/src/store/db/ttl.go
+++ b/go/pkg/antfly/src/store/db/ttl.go
@@ -195,8 +195,7 @@ func (tc *TTLCleaner) cleanupExpiredDocuments(
 
 		scannedTimestampKeys++
 
-		// Extract the base key (remove :t suffix)
-		baseKey := bytes.TrimSuffix(key, storeutils.TransactionSuffix)
+		baseKey := documentKeyFromTimestampKey(key)
 
 		// Read the timestamp value (uint64 encoded with EncodeUint64Ascending)
 		timestampBytes := iter.Value()
@@ -218,7 +217,7 @@ func (tc *TTLCleaner) cleanupExpiredDocuments(
 
 		// Check if document is expired
 		if timestamp < expirationThreshold {
-			expiredKeys = append(expiredKeys, bytes.Clone(baseKey))
+			expiredKeys = append(expiredKeys, baseKey)
 
 			// Process batch if we've hit the limit
 			if len(expiredKeys) >= TTLBatchSize {
@@ -337,6 +336,23 @@ func (tc *TTLCleaner) Stats() map[string]any {
 	}
 }
 
+func documentKeyFromTimestampKey(key []byte) []byte {
+	baseKey := bytes.TrimSuffix(key, storeutils.TransactionSuffix)
+	if bytes.HasSuffix(baseKey, storeutils.DBRangeStart) {
+		return bytes.Clone(baseKey[:len(baseKey)-len(storeutils.DBRangeStart)])
+	}
+	return bytes.Clone(baseKey)
+}
+
+func documentTimestampKey(key []byte) []byte {
+	if bytes.HasSuffix(key, storeutils.DBRangeStart) {
+		return append(bytes.Clone(key), storeutils.TransactionSuffix...)
+	}
+
+	normalizedKey := storeutils.KeyRangeStart(key)
+	return append(normalizedKey, storeutils.TransactionSuffix...)
+}
+
 // isDocumentExpiredByTimestamp checks if a document is expired by reading its HLC timestamp.
 // This is used for query filtering. Returns true if expired, false otherwise.
 func (db *DBImpl) isDocumentExpiredByTimestamp(ctx context.Context, key []byte) (bool, error) {
@@ -354,11 +370,16 @@ func (db *DBImpl) isDocumentExpiredByTimestamp(ctx context.Context, key []byte) 
 		return false, fmt.Errorf("database is closed or not initialized")
 	}
 
-	// Build timestamp key: <baseKey>:t
-	timestampKey := append(bytes.Clone(key), storeutils.TransactionSuffix...)
+	timestampKey := documentTimestampKey(key)
 
 	// Read the timestamp value
 	timestampBytes, closer, err := pdb.Get(timestampKey)
+	if errors.Is(err, pebble.ErrNotFound) {
+		legacyTimestampKey := append(bytes.Clone(key), storeutils.TransactionSuffix...)
+		if !bytes.Equal(legacyTimestampKey, timestampKey) {
+			timestampBytes, closer, err = pdb.Get(legacyTimestampKey)
+		}
+	}
 	if err != nil {
 		if errors.Is(err, pebble.ErrNotFound) {
 			// No timestamp key means document was inserted before timestamps were enabled

--- a/go/pkg/antfly/src/store/db/ttl_test.go
+++ b/go/pkg/antfly/src/store/db/ttl_test.go
@@ -469,9 +469,6 @@ func TestTTLQueryFiltering(t *testing.T) {
 func createTestDBWithTTL(t *testing.T, ttlDuration string) (*DBImpl, func()) {
 	t.Helper()
 
-	// Create temporary directory for test DB
-	tempDir := t.TempDir()
-
 	// Create schema with TTL
 	tableSchema := &schema.TableSchema{
 		TtlDuration: ttlDuration,
@@ -485,6 +482,14 @@ func createTestDBWithTTL(t *testing.T, ttlDuration string) (*DBImpl, func()) {
 			},
 		},
 	}
+	return createTestDBWithSchema(t, tableSchema)
+}
+
+func createTestDBWithSchema(t *testing.T, tableSchema *schema.TableSchema) (*DBImpl, func()) {
+	t.Helper()
+
+	// Create temporary directory for test DB
+	tempDir := t.TempDir()
 
 	// Create DBImpl with proper initialization
 	dbImpl := &DBImpl{
@@ -505,6 +510,53 @@ func createTestDBWithTTL(t *testing.T, ttlDuration string) (*DBImpl, func()) {
 	}
 
 	return dbImpl, cleanup
+}
+
+func TestBatchWritesTTLTimestampsWithoutContextTimestamp(t *testing.T) {
+	dbImpl, cleanup := createTestDBWithTTL(t, "1h")
+	defer cleanup()
+
+	require.NoError(t, dbImpl.Batch(
+		context.Background(),
+		[][2][]byte{{[]byte("doc:local"), []byte(`{"data":"local write"}`)}},
+		nil,
+		Op_SyncLevelWrite,
+	))
+
+	timestamp, err := dbImpl.GetTimestamp([]byte("doc:local"))
+	require.NoError(t, err)
+	require.NotZero(t, timestamp, "TTL-enabled writes without a context timestamp must still write :t metadata")
+}
+
+func TestBatchDerivesTTLTimestampsFromCustomField(t *testing.T) {
+	tableSchema := &schema.TableSchema{
+		TtlDuration: "1h",
+		TtlField:    "written_at",
+		DefaultType: "default",
+		DocumentSchemas: map[string]schema.DocumentSchema{
+			"default": {
+				Schema: map[string]any{
+					"type": "object",
+				},
+			},
+		},
+	}
+	dbImpl, cleanup := createTestDBWithSchema(t, tableSchema)
+	defer cleanup()
+
+	require.NoError(t, dbImpl.Batch(
+		context.Background(),
+		[][2][]byte{{[]byte("doc:old"), []byte(`{"written_at":"2020-01-01T00:00:00Z","data":"stale"}`)}},
+		nil,
+		Op_SyncLevelWrite,
+	))
+
+	timestamp, err := dbImpl.GetTimestamp([]byte("doc:old"))
+	require.NoError(t, err)
+	require.Equal(t, uint64(1577836800000000000), timestamp)
+
+	_, err = dbImpl.Get(context.Background(), []byte("doc:old"))
+	require.ErrorIs(t, err, ErrNotFound)
 }
 
 func compressJSON(jsonBytes []byte) ([]byte, error) {


### PR DESCRIPTION
Fixes #120.

## Summary
- write TTL `:t` metadata for TTL-enabled document writes even when the context does not carry a timestamp
- derive document TTL metadata from custom `ttl_field` values when present
- normalize document timestamp side-key lookup/cleanup so query filtering and TTL cleanup use the same key shape as writes, with fallback support for legacy `key:t` metadata
- add regressions for local writes without context timestamps and custom TTL fields

## Tests
- `env GOWORK=off go test ./src/store/db -run 'TestBatchWritesTTLTimestampsWithoutContextTimestamp|TestBatchDerivesTTLTimestampsFromCustomField|TestTTLCleanup|TestTTLQueryFiltering|TestTTLDocumentUpdateTimestamp'`
- `env GOWORK=off go test ./src/store/db`
- `git diff --check`