### PR TITLE
Speed up Zig Termite models listing

### DIFF
--- a/zig/pkg/termite/src/models/manifest.zig
+++ b/zig/pkg/termite/src/models/manifest.zig
@@ -514,6 +514,108 @@ pub fn loadFromDir(allocator: std.mem.Allocator, model_dir_path: []const u8) !Mo
     return manifest;
 }
 
+/// Load only the metadata needed to list a model in server discovery results.
+///
+/// This intentionally avoids tokenizer parsing and GGUF metadata inspection. It
+/// still records enough artifact paths to hide obviously unloadable bundles and
+/// to expose text/image/audio listing metadata.
+pub fn loadListingFromDir(allocator: std.mem.Allocator, model_dir_path: []const u8) !ModelManifest {
+    var manifest = ModelManifest{ .allocator = allocator };
+
+    if (std.mem.endsWith(u8, model_dir_path, ".gguf")) {
+        manifest.gguf_path = try allocator.dupe(u8, model_dir_path);
+        return manifest;
+    }
+
+    if (inferModelTypeFromPath(model_dir_path)) |model_type| {
+        manifest.model_type = model_type;
+    }
+
+    if (c_file.readFileFromDir(allocator, model_dir_path, "config.json")) |config_bytes| {
+        defer allocator.free(config_bytes);
+        parseListingConfigJson(&manifest, allocator, config_bytes) catch {};
+    } else |_| {}
+    if (manifest.native_arch_hint == .none and manifest.config_model_arch.len == 0) {
+        if (c_file.readFileFromDir(allocator, model_dir_path, "clip_config.json")) |config_bytes| {
+            defer allocator.free(config_bytes);
+            parseListingConfigJson(&manifest, allocator, config_bytes) catch {};
+        } else |_| {}
+    }
+
+    if (c_file.readFileFromDir(allocator, model_dir_path, "model_manifest.json")) |manifest_bytes| {
+        defer allocator.free(manifest_bytes);
+        parseModelManifestJson(&manifest, allocator, manifest_bytes) catch {};
+    } else |_| {}
+
+    if (c_file.readFileFromDir(allocator, model_dir_path, "termite_bundle.json")) |bundle_bytes| {
+        defer allocator.free(bundle_bytes);
+        parseTermiteBundleJson(&manifest, allocator, model_dir_path, bundle_bytes) catch {};
+    } else |_| {}
+    if (c_file.readFileFromDir(allocator, model_dir_path, "termite_variants.json")) |variants_bytes| {
+        defer allocator.free(variants_bytes);
+        parseTermiteVariantsJson(&manifest, allocator, model_dir_path, variants_bytes) catch {};
+    } else |_| {}
+
+    if (c_file.readFileFromDir(allocator, model_dir_path, "gliner_config.json")) |gliner_bytes| {
+        defer allocator.free(gliner_bytes);
+        parseGlinerConfig(&manifest, allocator, gliner_bytes) catch {};
+    } else |_| {}
+    if (c_file.readFileFromDir(allocator, model_dir_path, "added_tokens.json")) |at_bytes| {
+        defer allocator.free(at_bytes);
+        parseAddedTokens(&manifest, at_bytes) catch {};
+    } else |_| {}
+    applyListingGlinerHint(&manifest, allocator, model_dir_path);
+
+    if (!manifest.isClipclapGgufBundle()) {
+        if (manifest.onnx_path == null) manifest.onnx_path = try findFileInSubdirs(allocator, model_dir_path, &onnx_candidates, &onnx_subdirs);
+        if (manifest.visual_model_path == null) manifest.visual_model_path = try findFileInSubdirs(allocator, model_dir_path, &visual_model_candidates, &onnx_subdirs);
+        if (manifest.audio_model_path == null) manifest.audio_model_path = try findFileInSubdirs(allocator, model_dir_path, &audio_model_candidates, &onnx_subdirs);
+        if (manifest.text_projection_path == null) manifest.text_projection_path = try findFileInSubdirs(allocator, model_dir_path, &text_projection_candidates, &onnx_subdirs);
+        if (manifest.visual_projection_path == null) manifest.visual_projection_path = try findFileInSubdirs(allocator, model_dir_path, &visual_projection_candidates, &onnx_subdirs);
+        if (manifest.audio_projection_path == null) manifest.audio_projection_path = try findFileInSubdirs(allocator, model_dir_path, &audio_projection_candidates, &onnx_subdirs);
+    }
+
+    if (manifest.safetensors_path == null) manifest.safetensors_path = try findFileInSubdirs(allocator, model_dir_path, &safetensors_candidates, &.{""});
+    if (manifest.safetensors_index_path == null) manifest.safetensors_index_path = try findFileInSubdirs(allocator, model_dir_path, &safetensors_index_candidates, &.{""});
+    if (manifest.gliner_head_gguf_path == null) manifest.gliner_head_gguf_path = try findFileInSubdirs(allocator, model_dir_path, &.{"gliner_head.gguf"}, &.{""});
+    if (manifest.gliner_head_safetensors_path == null) manifest.gliner_head_safetensors_path = try findFileInSubdirs(allocator, model_dir_path, &.{"gliner_head.safetensors"}, &.{""});
+    if (manifest.config_path == null) manifest.config_path = try findFileInSubdirs(allocator, model_dir_path, &.{"config.json"}, &.{""});
+    if (manifest.model_manifest_path == null) manifest.model_manifest_path = try findFileInSubdirs(allocator, model_dir_path, &.{"model_manifest.json"}, &.{""});
+    if (manifest.tokenizer_json_path == null) manifest.tokenizer_json_path = try findFileInSubdirs(allocator, model_dir_path, &.{"tokenizer.json"}, &.{""});
+    if (manifest.tokenizer_config_path == null) manifest.tokenizer_config_path = try findFileInSubdirs(allocator, model_dir_path, &.{"tokenizer_config.json"}, &.{""});
+    if (manifest.preprocessor_config_path == null) manifest.preprocessor_config_path = try findFileInSubdirs(allocator, model_dir_path, &.{"preprocessor_config.json"}, &.{""});
+    if (manifest.processor_config_path == null) manifest.processor_config_path = try findFileInSubdirs(allocator, model_dir_path, &.{"processor_config.json"}, &.{""});
+    if (manifest.gguf_path == null) manifest.gguf_path = try findFirstGgufInDir(allocator, model_dir_path, false);
+    if (manifest.gguf_projector_path == null) manifest.gguf_projector_path = try findFirstGgufInDir(allocator, model_dir_path, true);
+
+    applyImplicitSparseOutputLayout(&manifest, model_dir_path);
+    applyImplicitModelTypeHints(&manifest, model_dir_path);
+
+    return manifest;
+}
+
+fn applyListingGlinerHint(manifest: *ModelManifest, allocator: std.mem.Allocator, model_dir_path: []const u8) void {
+    if (manifest.gliner_model_type.len > 0) return;
+    if (!std.mem.eql(u8, manifest.config_model_arch, "extractor") and !hasGlinerPathHint(model_dir_path)) return;
+
+    if (c_file.readFileFromDir(allocator, model_dir_path, "special_tokens_map.json")) |tokens_bytes| {
+        defer allocator.free(tokens_bytes);
+        if (!listingSpecialTokensMapHasGlinerMarkers(tokens_bytes)) return;
+    } else |_| {
+        return;
+    }
+
+    manifest.gliner_model_type = allocator.dupe(u8, "gliner2") catch "";
+}
+
+fn listingSpecialTokensMapHasGlinerMarkers(json_bytes: []const u8) bool {
+    return std.mem.indexOf(u8, json_bytes, "\"[P]\"") != null and
+        std.mem.indexOf(u8, json_bytes, "\"[C]\"") != null and
+        std.mem.indexOf(u8, json_bytes, "\"[E]\"") != null and
+        std.mem.indexOf(u8, json_bytes, "\"[R]\"") != null and
+        std.mem.indexOf(u8, json_bytes, "\"[SEP_TEXT]\"") != null;
+}
+
 fn applyImplicitSparseOutputLayout(manifest: *ModelManifest, model_dir_path: []const u8) void {
     if (manifest.sparse_3d_output_layout != null) return;
     if (c_file.fileExistsInDir(manifest.allocator, model_dir_path, "1_SpladePooling/config.json")) {
@@ -997,6 +1099,59 @@ fn parseConfigJson(manifest: *ModelManifest, allocator: std.mem.Allocator, json_
                 if (jsonU32(v)) |val| manifest.max_position_embeddings = val;
             }
         }
+    }
+}
+
+fn parseListingConfigJson(manifest: *ModelManifest, allocator: std.mem.Allocator, json_bytes: []const u8) !void {
+    const parsed = try std.json.parseFromSlice(std.json.Value, allocator, json_bytes, .{});
+    defer parsed.deinit();
+
+    const obj = parsed.value.object;
+
+    if (obj.get("architectures")) |v| {
+        if (v == .array) {
+            for (v.array.items) |item| {
+                if (item != .string) continue;
+                if (inferModelTypeFromArchitectureName(item.string)) |inferred| {
+                    manifest.model_type = inferred;
+                    break;
+                }
+            }
+        }
+    }
+
+    if (obj.get("model_type")) |v| {
+        if (v == .string) {
+            const s = v.string;
+            if (manifest.config_model_arch.len > 0) allocator.free(manifest.config_model_arch);
+            manifest.config_model_arch = allocator.dupe(u8, s) catch "";
+            if (std.mem.eql(u8, s, "whisper")) {
+                manifest.native_arch_hint = .whisper;
+            } else if (std.mem.eql(u8, s, "florence2") or
+                std.mem.eql(u8, s, "florence-2") or
+                std.mem.startsWith(u8, s, "florence"))
+            {
+                manifest.native_arch_hint = .florence;
+            } else if (std.mem.eql(u8, s, "clip") or
+                std.mem.eql(u8, s, "clip_text_model") or
+                std.mem.eql(u8, s, "clip_vision_model") or
+                std.mem.eql(u8, s, "siglip") or
+                std.mem.eql(u8, s, "siglip_text_model"))
+            {
+                manifest.native_arch_hint = .clip;
+            } else if (std.mem.eql(u8, s, "clap")) {
+                manifest.native_arch_hint = .clap;
+            } else if (std.mem.eql(u8, s, "layoutlmv3")) {
+                manifest.native_arch_hint = .layoutlmv3;
+                if (manifest.model_type == .embedder) manifest.model_type = .classifier;
+            } else if (std.mem.eql(u8, s, "jina_embeddings_v5")) {
+                manifest.model_type = .embedder;
+            }
+        }
+    }
+
+    if (isJinaV5TextEmbeddingConfig(&obj)) {
+        manifest.model_type = .embedder;
     }
 }
 
@@ -2137,6 +2292,35 @@ test "manifest does not treat projector-only gguf as decoder weights" {
     try std.testing.expect(manifest.gguf_path == null);
     try std.testing.expect(manifest.gguf_projector_path != null);
     try std.testing.expect(std.mem.endsWith(u8, manifest.gguf_projector_path.?, "mmproj.gguf"));
+}
+
+test "listing manifest detects gguf assets without gguf metadata parse" {
+    const allocator = std.testing.allocator;
+    const io = std.testing.io;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.writeFile(io, .{
+        .sub_path = "model_manifest.json",
+        .data =
+        \\{"type":"generator","tasks":["generate"],"inputs":["text","image"]}
+        ,
+    });
+    try tmp.dir.writeFile(io, .{ .sub_path = "gemma-4-e2b-it-Q8_0.gguf", .data = "" });
+    try tmp.dir.writeFile(io, .{ .sub_path = "mmproj-gemma-4-e2b-it-bf16.gguf", .data = "" });
+
+    const model_dir = try std.fs.path.join(allocator, &.{ ".zig-cache", "tmp", tmp.sub_path[0..] });
+    defer allocator.free(model_dir);
+
+    var manifest = try loadListingFromDir(allocator, model_dir);
+    defer manifest.deinit();
+
+    try std.testing.expectEqual(ModelType.generator, manifest.model_type);
+    try std.testing.expect(manifest.hasTask("generate"));
+    try std.testing.expect(manifest.hasInput("image"));
+    try std.testing.expect(manifest.gguf_path != null);
+    try std.testing.expect(manifest.gguf_projector_path != null);
 }
 
 test "manifest infers huggingface tokenizer from gguf gpt2 metadata" {

--- a/zig/pkg/termite/src/registry/registry.zig
+++ b/zig/pkg/termite/src/registry/registry.zig
@@ -41,6 +41,11 @@ pub const ModelEntry = struct {
     variant: []const u8,
 };
 
+const DiscoverKindMode = enum {
+    manifest,
+    path,
+};
+
 test {
     _ = download;
 }
@@ -93,6 +98,17 @@ pub const ModelRegistry = struct {
 
     /// Discover models in the models directory.
     pub fn discover(self: *ModelRegistry, io: Io) ![]ModelEntry {
+        return self.discoverWithKindMode(io, .manifest);
+    }
+
+    /// Discover model paths without loading manifests to classify model kind.
+    /// Callers that already load manifests should prefer this to avoid parsing
+    /// every manifest twice on listing-style paths.
+    pub fn discoverShallow(self: *ModelRegistry, io: Io) ![]ModelEntry {
+        return self.discoverWithKindMode(io, .path);
+    }
+
+    fn discoverWithKindMode(self: *ModelRegistry, io: Io, kind_mode: DiscoverKindMode) ![]ModelEntry {
         var entries = std.ArrayListUnmanaged(ModelEntry).empty;
         var seen = std.StringHashMapUnmanaged(void){};
         defer {
@@ -101,8 +117,8 @@ pub const ModelRegistry = struct {
             seen.deinit(self.allocator);
         }
 
-        try self.discoverFlat(io, &entries, &seen);
-        try self.discoverLegacy(io, &entries, &seen);
+        try self.discoverFlat(io, &entries, &seen, kind_mode);
+        try self.discoverLegacy(io, &entries, &seen, kind_mode);
 
         return try entries.toOwnedSlice(self.allocator);
     }
@@ -112,6 +128,7 @@ pub const ModelRegistry = struct {
         io: Io,
         entries: *std.ArrayListUnmanaged(ModelEntry),
         seen: *std.StringHashMapUnmanaged(void),
+        kind_mode: DiscoverKindMode,
     ) !void {
         var dir = Dir.cwd().openDir(io, self.models_dir, .{ .iterate = true }) catch return;
         defer dir.close(io);
@@ -125,7 +142,7 @@ pub const ModelRegistry = struct {
             defer self.allocator.free(entry_path);
 
             if (isModelDir(io, entry_path)) {
-                try self.appendDiscoveredModel(io, entries, seen, entry_path, entry.name);
+                try self.appendDiscoveredModel(io, entries, seen, entry_path, entry.name, kind_mode, null);
                 continue;
             }
 
@@ -140,7 +157,7 @@ pub const ModelRegistry = struct {
                 if (!isModelDir(io, model_path)) continue;
                 const model_name = try std.fmt.allocPrint(self.allocator, "{s}/{s}", .{ entry.name, model_entry.name });
                 defer self.allocator.free(model_name);
-                try self.appendDiscoveredModel(io, entries, seen, model_path, model_name);
+                try self.appendDiscoveredModel(io, entries, seen, model_path, model_name, kind_mode, null);
             }
         }
     }
@@ -150,6 +167,7 @@ pub const ModelRegistry = struct {
         io: Io,
         entries: *std.ArrayListUnmanaged(ModelEntry),
         seen: *std.StringHashMapUnmanaged(void),
+        kind_mode: DiscoverKindMode,
     ) !void {
         const subdirs = [_]struct { dir: []const u8, kind: ModelKind }{
             .{ .dir = "embedders", .kind = .embedder },
@@ -177,7 +195,7 @@ pub const ModelRegistry = struct {
                     const entry_path = try std.fs.path.join(self.allocator, &.{ path, entry.name });
                     defer self.allocator.free(entry_path);
                     if (isModelDir(io, entry_path)) {
-                        try self.appendDiscoveredModel(io, entries, seen, entry_path, entry.name);
+                        try self.appendDiscoveredModel(io, entries, seen, entry_path, entry.name, kind_mode, subdir.kind);
                     } else {
                         var owner_dir = Dir.cwd().openDir(io, entry_path, .{ .iterate = true }) catch {
                             continue;
@@ -194,7 +212,7 @@ pub const ModelRegistry = struct {
                                 }
                                 const model_name = try std.fmt.allocPrint(self.allocator, "{s}/{s}", .{ entry.name, model_entry.name });
                                 defer self.allocator.free(model_name);
-                                try self.appendDiscoveredModel(io, entries, seen, model_path, model_name);
+                                try self.appendDiscoveredModel(io, entries, seen, model_path, model_name, kind_mode, subdir.kind);
                             }
                         }
                     }
@@ -237,6 +255,8 @@ pub const ModelRegistry = struct {
         seen: *std.StringHashMapUnmanaged(void),
         model_path: []const u8,
         display_name: []const u8,
+        kind_mode: DiscoverKindMode,
+        kind_hint: ?ModelKind,
     ) !void {
         if (seen.contains(model_path)) return;
 
@@ -244,10 +264,13 @@ pub const ModelRegistry = struct {
         errdefer self.allocator.free(seen_path);
         try seen.put(self.allocator, seen_path, {});
 
-        const kind = blk: {
-            var manifest = manifest_mod.loadFromDir(self.allocator, model_path) catch break :blk inferModelKindFromPath(model_path);
-            defer manifest.deinit();
-            break :blk modelKindFromManifestType(manifest.model_type);
+        const kind = switch (kind_mode) {
+            .manifest => blk: {
+                var manifest = manifest_mod.loadFromDir(self.allocator, model_path) catch break :blk inferModelKindFromPath(model_path);
+                defer manifest.deinit();
+                break :blk modelKindFromManifestType(manifest.model_type);
+            },
+            .path => kind_hint orelse inferModelKindFromPath(model_path),
         };
 
         try entries.append(self.allocator, .{

--- a/zig/pkg/termite/src/server/server.zig
+++ b/zig/pkg/termite/src/server/server.zig
@@ -312,6 +312,73 @@ fn appendOpenAiModelEntry(
     try buf.appendSlice(allocator, metadata);
 }
 
+const model_listing_tasks = [_][]const u8{
+    "embedders",  "rerankers",   "chunkers",
+    "generators", "recognizers", "classifiers",
+    "rewriters",  "readers",     "transcribers",
+    "extractors",
+};
+
+const DiscoveredModelListing = struct {
+    entry: registry_mod.ModelEntry,
+    manifest: manifest_mod.ModelManifest,
+    reader_supported: bool,
+
+    fn deinit(self: *@This()) void {
+        self.manifest.deinit();
+    }
+
+    fn kindName(self: @This()) []const u8 {
+        return @tagName(self.entry.kind);
+    }
+};
+
+fn buildDiscoveredModelListings(
+    allocator: std.mem.Allocator,
+    discovered: []const registry_mod.ModelEntry,
+) ![]DiscoveredModelListing {
+    var listings = std.ArrayListUnmanaged(DiscoveredModelListing).empty;
+    errdefer {
+        for (listings.items) |*listing| listing.deinit();
+        listings.deinit(allocator);
+    }
+
+    for (discovered) |entry| {
+        var manifest = manifest_mod.loadFromDir(allocator, entry.path) catch continue;
+
+        if (!model_manager_mod.isManifestPotentiallyLoadableInCurrentBuild(manifest)) {
+            manifest.deinit();
+            continue;
+        }
+
+        const kind_name = @tagName(entry.kind);
+        const reader_candidate = taskMatchesModelListing(
+            "readers",
+            kind_name,
+            manifest.gliner_model_type,
+            manifest.tasks,
+            manifest.capabilities,
+        );
+        const reader_supported = !reader_candidate or readers_mod.isSupportedModelDir(allocator, entry.path);
+
+        listings.append(allocator, .{
+            .entry = entry,
+            .manifest = manifest,
+            .reader_supported = reader_supported,
+        }) catch |err| {
+            manifest.deinit();
+            return err;
+        };
+    }
+
+    return try listings.toOwnedSlice(allocator);
+}
+
+fn deinitDiscoveredModelListings(allocator: std.mem.Allocator, listings: []DiscoveredModelListing) void {
+    for (listings) |*listing| listing.deinit();
+    allocator.free(listings);
+}
+
 const ModelCounts = struct {
     embedders: usize = 0,
     rerankers: usize = 0,
@@ -343,12 +410,6 @@ fn incrementModelCount(counts: *ModelCounts, task: []const u8) void {
 }
 
 fn collectModelCounts(node: *Node, allocator: std.mem.Allocator, io: std.Io) ModelCounts {
-    const task_names = [_][]const u8{
-        "embedders",  "rerankers",   "chunkers",
-        "generators", "recognizers", "classifiers",
-        "rewriters",  "readers",     "transcribers",
-        "extractors",
-    };
     var counts = ModelCounts{};
 
     const ra = node.registry.allocator;
@@ -361,20 +422,14 @@ fn collectModelCounts(node: *Node, allocator: std.mem.Allocator, io: std.Io) Mod
         if (discovered.len > 0) ra.free(discovered);
     }
 
-    for (discovered) |entry| {
-        if (!model_manager_mod.isModelDirPotentiallyLoadableInCurrentBuild(allocator, entry.path)) continue;
+    const listings = buildDiscoveredModelListings(allocator, discovered) catch return counts;
+    defer deinitDiscoveredModelListings(allocator, listings);
 
-        var maybe_manifest: ?manifest_mod.ModelManifest = manifest_mod.loadFromDir(allocator, entry.path) catch null;
-        defer if (maybe_manifest) |*man| man.deinit();
-
-        const tasks = if (maybe_manifest) |*man| man.tasks else &.{};
-        const capabilities = if (maybe_manifest) |*man| man.capabilities else &.{};
-        const gliner_model_type = if (maybe_manifest) |*man| man.gliner_model_type else "";
-
-        for (task_names) |task| {
+    for (listings) |listing| {
+        for (model_listing_tasks) |task| {
             if (std.mem.eql(u8, task, "chunkers")) continue;
-            if (std.mem.eql(u8, task, "readers") and !readers_mod.isSupportedModelDir(allocator, entry.path)) continue;
-            if (taskMatchesModelListing(task, @tagName(entry.kind), gliner_model_type, tasks, capabilities)) {
+            if (std.mem.eql(u8, task, "readers") and !listing.reader_supported) continue;
+            if (taskMatchesModelListing(task, listing.kindName(), listing.manifest.gliner_model_type, listing.manifest.tasks, listing.manifest.capabilities)) {
                 incrementModelCount(&counts, task);
             }
         }
@@ -393,7 +448,7 @@ fn collectModelCounts(node: *Node, allocator: std.mem.Allocator, io: std.Io) Mod
 
         const model = entry.value_ptr.*;
         const model_task = @tagName(model.manifest.model_type);
-        for (task_names) |task| {
+        for (model_listing_tasks) |task| {
             if (std.mem.eql(u8, task, "chunkers")) continue;
             if (taskMatchesModelListing(task, model_task, model.manifest.gliner_model_type, model.manifest.tasks, model.manifest.capabilities)) {
                 incrementModelCount(&counts, task);
@@ -405,12 +460,6 @@ fn collectModelCounts(node: *Node, allocator: std.mem.Allocator, io: std.Io) Mod
 }
 
 fn collectDiscoveredModelCounts(models_dir: []const u8, allocator: std.mem.Allocator, io: std.Io) ModelCounts {
-    const task_names = [_][]const u8{
-        "embedders",  "rerankers",   "chunkers",
-        "generators", "recognizers", "classifiers",
-        "rewriters",  "readers",     "transcribers",
-        "extractors",
-    };
     var counts = ModelCounts{};
 
     var registry = registry_mod.ModelRegistry.init(allocator, models_dir);
@@ -424,20 +473,14 @@ fn collectDiscoveredModelCounts(models_dir: []const u8, allocator: std.mem.Alloc
         if (discovered.len > 0) allocator.free(discovered);
     }
 
-    for (discovered) |entry| {
-        if (!model_manager_mod.isModelDirPotentiallyLoadableInCurrentBuild(allocator, entry.path)) continue;
+    const listings = buildDiscoveredModelListings(allocator, discovered) catch return counts;
+    defer deinitDiscoveredModelListings(allocator, listings);
 
-        var maybe_manifest: ?manifest_mod.ModelManifest = manifest_mod.loadFromDir(allocator, entry.path) catch null;
-        defer if (maybe_manifest) |*man| man.deinit();
-
-        const tasks = if (maybe_manifest) |*man| man.tasks else &.{};
-        const capabilities = if (maybe_manifest) |*man| man.capabilities else &.{};
-        const gliner_model_type = if (maybe_manifest) |*man| man.gliner_model_type else "";
-
-        for (task_names) |task| {
+    for (listings) |listing| {
+        for (model_listing_tasks) |task| {
             if (std.mem.eql(u8, task, "chunkers")) continue;
-            if (std.mem.eql(u8, task, "readers") and !readers_mod.isSupportedModelDir(allocator, entry.path)) continue;
-            if (taskMatchesModelListing(task, @tagName(entry.kind), gliner_model_type, tasks, capabilities)) {
+            if (std.mem.eql(u8, task, "readers") and !listing.reader_supported) continue;
+            if (taskMatchesModelListing(task, listing.kindName(), listing.manifest.gliner_model_type, listing.manifest.tasks, listing.manifest.capabilities)) {
                 incrementModelCount(&counts, task);
             }
         }
@@ -3970,14 +4013,10 @@ pub const Node = struct {
             if (discovered.len > 0) ra.free(discovered);
         }
 
-        const task_names = [_][]const u8{
-            "embedders",  "rerankers",   "chunkers",
-            "generators", "recognizers", "classifiers",
-            "rewriters",  "readers",     "transcribers",
-            "extractors",
-        };
+        const listings = try buildDiscoveredModelListings(a, discovered);
+        defer deinitDiscoveredModelListings(a, listings);
 
-        for (task_names, 0..) |task, task_idx| {
+        for (model_listing_tasks, 0..) |task, task_idx| {
             if (task_idx > 0) try body.append(a, ',');
             try body.append(a, '"');
             try body.appendSlice(a, task);
@@ -3992,28 +4031,26 @@ pub const Node = struct {
             }
 
             // Add discovered models matching this task
-            for (discovered) |entry| {
-                if (!model_manager_mod.isModelDirPotentiallyLoadableInCurrentBuild(a, entry.path)) continue;
-                if (std.mem.eql(u8, task, "readers") and !readers_mod.isSupportedModelDir(a, entry.path)) continue;
-
-                var maybe_manifest: ?manifest_mod.ModelManifest = manifest_mod.loadFromDir(a, entry.path) catch null;
-                defer if (maybe_manifest) |*man| man.deinit();
-
-                const tasks = if (maybe_manifest) |*man| man.tasks else &.{};
-                const capabilities = if (maybe_manifest) |*man| man.capabilities else &.{};
-                const gliner_model_type = if (maybe_manifest) |*man| man.gliner_model_type else "";
-                const inputs = if (maybe_manifest) |*man| man.inputs else &.{};
-                const has_visual = if (maybe_manifest) |*man| man.visual_model_path != null or man.visual_projection_path != null else false;
-                const has_audio = if (maybe_manifest) |*man| man.audio_model_path != null or man.audio_projection_path != null else false;
-                if (!taskMatchesModelListing(task, @tagName(entry.kind), gliner_model_type, tasks, capabilities)) continue;
+            for (listings) |listing| {
+                if (std.mem.eql(u8, task, "readers") and !listing.reader_supported) continue;
+                if (!taskMatchesModelListing(task, listing.kindName(), listing.manifest.gliner_model_type, listing.manifest.tasks, listing.manifest.capabilities)) continue;
 
                 if (model_count > 0) try body.append(a, ',');
-                try jsonEncodeString(&body, a, entry.name);
+                try jsonEncodeString(&body, a, listing.entry.name);
                 try body.append(a, ':');
-                try appendModelInfo(&body, a, @tagName(entry.kind), gliner_model_type, capabilities, inputs, has_visual, has_audio);
+                try appendModelInfo(
+                    &body,
+                    a,
+                    listing.kindName(),
+                    listing.manifest.gliner_model_type,
+                    listing.manifest.capabilities,
+                    listing.manifest.inputs,
+                    listing.manifest.visual_model_path != null or listing.manifest.visual_projection_path != null,
+                    listing.manifest.audio_model_path != null or listing.manifest.audio_projection_path != null,
+                );
                 if (isOpenAiListTask(task)) {
                     if (openai_data_count > 0) try openai_data.append(a, ',');
-                    try appendOpenAiModelEntry(&openai_data, a, entry.name, list_created);
+                    try appendOpenAiModelEntry(&openai_data, a, listing.entry.name, list_created);
                     openai_data_count += 1;
                 }
                 model_count += 1;
@@ -4913,6 +4950,61 @@ test "taskMatchesModelListing prefers explicit tasks when present" {
     try std.testing.expect(taskMatchesModelListing("generators", "generator", "", &.{"generate"}, &.{}));
     try std.testing.expect(taskMatchesModelListing("extractors", "generator", "", &.{"extract"}, &.{}));
     try std.testing.expect(!taskMatchesModelListing("recognizers", "generator", "", &.{"generate"}, &.{"extraction"}));
+}
+
+test "buildDiscoveredModelListings parses reusable model listing metadata" {
+    const allocator = std.testing.allocator;
+    const io = std.testing.io;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.createDirPath(io, "models/owner/embedder/onnx");
+    try tmp.dir.writeFile(io, .{
+        .sub_path = "models/owner/embedder/model_manifest.json",
+        .data =
+        \\{"type":"embedder","tasks":["embed"],"capabilities":["sparse"],"inputs":["text"]}
+        ,
+    });
+    try tmp.dir.writeFile(io, .{
+        .sub_path = "models/owner/embedder/onnx/model.onnx",
+        .data = "",
+    });
+    try tmp.dir.createDirPath(io, "models/owner/not-loadable");
+    try tmp.dir.writeFile(io, .{
+        .sub_path = "models/owner/not-loadable/model_manifest.json",
+        .data =
+        \\{"type":"generator","tasks":["generate"]}
+        ,
+    });
+
+    const models_dir = try std.fs.path.join(allocator, &.{ ".zig-cache", "tmp", tmp.sub_path[0..], "models" });
+    defer allocator.free(models_dir);
+    const embedder_path = try std.fs.path.join(allocator, &.{ models_dir, "owner", "embedder" });
+    defer allocator.free(embedder_path);
+    const not_loadable_path = try std.fs.path.join(allocator, &.{ models_dir, "owner", "not-loadable" });
+    defer allocator.free(not_loadable_path);
+
+    const discovered = [_]registry_mod.ModelEntry{
+        .{ .name = "owner/embedder", .kind = .embedder, .path = embedder_path, .variant = "f32" },
+        .{ .name = "owner/not-loadable", .kind = .generator, .path = not_loadable_path, .variant = "f32" },
+    };
+
+    const listings = try buildDiscoveredModelListings(allocator, &discovered);
+    defer deinitDiscoveredModelListings(allocator, listings);
+
+    try std.testing.expectEqual(@as(usize, 1), listings.len);
+    try std.testing.expectEqualStrings("owner/embedder", listings[0].entry.name);
+    try std.testing.expect(listings[0].manifest.hasTask("embed"));
+    try std.testing.expect(listings[0].manifest.hasCapability("sparse"));
+    try std.testing.expect(listings[0].manifest.hasInput("text"));
+    try std.testing.expect(taskMatchesModelListing(
+        "embedders",
+        listings[0].kindName(),
+        listings[0].manifest.gliner_model_type,
+        listings[0].manifest.tasks,
+        listings[0].manifest.capabilities,
+    ));
 }
 
 test "modelSupportsCapability infers gliner2 extraction and classification" {

--- a/zig/pkg/termite/src/server/server.zig
+++ b/zig/pkg/termite/src/server/server.zig
@@ -345,7 +345,7 @@ fn buildDiscoveredModelListings(
     }
 
     for (discovered) |entry| {
-        var manifest = manifest_mod.loadFromDir(allocator, entry.path) catch continue;
+        var manifest = manifest_mod.loadListingFromDir(allocator, entry.path) catch continue;
 
         if (!model_manager_mod.isManifestPotentiallyLoadableInCurrentBuild(manifest)) {
             manifest.deinit();

--- a/zig/pkg/termite/src/server/server.zig
+++ b/zig/pkg/termite/src/server/server.zig
@@ -328,8 +328,9 @@ const DiscoveredModelListing = struct {
         self.manifest.deinit();
     }
 
-    fn kindName(self: @This()) []const u8 {
-        return @tagName(self.entry.kind);
+    fn listingKindName(self: @This()) []const u8 {
+        if (self.entry.kind == .extractor) return @tagName(self.entry.kind);
+        return @tagName(self.manifest.model_type);
     }
 };
 
@@ -351,7 +352,7 @@ fn buildDiscoveredModelListings(
             continue;
         }
 
-        const kind_name = @tagName(entry.kind);
+        const kind_name = if (entry.kind == .extractor) @tagName(entry.kind) else @tagName(manifest.model_type);
         const reader_candidate = taskMatchesModelListing(
             "readers",
             kind_name,
@@ -413,7 +414,7 @@ fn collectModelCounts(node: *Node, allocator: std.mem.Allocator, io: std.Io) Mod
     var counts = ModelCounts{};
 
     const ra = node.registry.allocator;
-    const discovered = node.registry.discover(io) catch &[_]registry_mod.ModelEntry{};
+    const discovered = node.registry.discoverShallow(io) catch &[_]registry_mod.ModelEntry{};
     defer {
         for (discovered) |entry| {
             ra.free(entry.name);
@@ -429,7 +430,7 @@ fn collectModelCounts(node: *Node, allocator: std.mem.Allocator, io: std.Io) Mod
         for (model_listing_tasks) |task| {
             if (std.mem.eql(u8, task, "chunkers")) continue;
             if (std.mem.eql(u8, task, "readers") and !listing.reader_supported) continue;
-            if (taskMatchesModelListing(task, listing.kindName(), listing.manifest.gliner_model_type, listing.manifest.tasks, listing.manifest.capabilities)) {
+            if (taskMatchesModelListing(task, listing.listingKindName(), listing.manifest.gliner_model_type, listing.manifest.tasks, listing.manifest.capabilities)) {
                 incrementModelCount(&counts, task);
             }
         }
@@ -464,7 +465,7 @@ fn collectDiscoveredModelCounts(models_dir: []const u8, allocator: std.mem.Alloc
 
     var registry = registry_mod.ModelRegistry.init(allocator, models_dir);
     defer registry.deinit();
-    const discovered = registry.discover(io) catch &[_]registry_mod.ModelEntry{};
+    const discovered = registry.discoverShallow(io) catch &[_]registry_mod.ModelEntry{};
     defer {
         for (discovered) |entry| {
             allocator.free(entry.name);
@@ -480,7 +481,7 @@ fn collectDiscoveredModelCounts(models_dir: []const u8, allocator: std.mem.Alloc
         for (model_listing_tasks) |task| {
             if (std.mem.eql(u8, task, "chunkers")) continue;
             if (std.mem.eql(u8, task, "readers") and !listing.reader_supported) continue;
-            if (taskMatchesModelListing(task, listing.kindName(), listing.manifest.gliner_model_type, listing.manifest.tasks, listing.manifest.capabilities)) {
+            if (taskMatchesModelListing(task, listing.listingKindName(), listing.manifest.gliner_model_type, listing.manifest.tasks, listing.manifest.capabilities)) {
                 incrementModelCount(&counts, task);
             }
         }
@@ -4004,7 +4005,7 @@ pub const Node = struct {
 
         // Discover models from filesystem registry
         const ra = self.registry.allocator;
-        const discovered = self.registry.discover(ctx.io) catch &[_]registry_mod.ModelEntry{};
+        const discovered = self.registry.discoverShallow(ctx.io) catch &[_]registry_mod.ModelEntry{};
         defer {
             for (discovered) |entry| {
                 ra.free(entry.name);
@@ -4033,7 +4034,7 @@ pub const Node = struct {
             // Add discovered models matching this task
             for (listings) |listing| {
                 if (std.mem.eql(u8, task, "readers") and !listing.reader_supported) continue;
-                if (!taskMatchesModelListing(task, listing.kindName(), listing.manifest.gliner_model_type, listing.manifest.tasks, listing.manifest.capabilities)) continue;
+                if (!taskMatchesModelListing(task, listing.listingKindName(), listing.manifest.gliner_model_type, listing.manifest.tasks, listing.manifest.capabilities)) continue;
 
                 if (model_count > 0) try body.append(a, ',');
                 try jsonEncodeString(&body, a, listing.entry.name);
@@ -4041,7 +4042,7 @@ pub const Node = struct {
                 try appendModelInfo(
                     &body,
                     a,
-                    listing.kindName(),
+                    listing.listingKindName(),
                     listing.manifest.gliner_model_type,
                     listing.manifest.capabilities,
                     listing.manifest.inputs,
@@ -5000,7 +5001,7 @@ test "buildDiscoveredModelListings parses reusable model listing metadata" {
     try std.testing.expect(listings[0].manifest.hasInput("text"));
     try std.testing.expect(taskMatchesModelListing(
         "embedders",
-        listings[0].kindName(),
+        listings[0].listingKindName(),
         listings[0].manifest.gliner_model_type,
         listings[0].manifest.tasks,
         listings[0].manifest.capabilities,


### PR DESCRIPTION
## Summary
- keep `/ml/v1/models` dynamic by continuing filesystem discovery on each request
- avoid repeatedly parsing each discovered model manifest across every task bucket
- add shallow registry discovery for listing/counting paths so discovery does not pre-parse manifests that the listing code already loads
- add a lightweight listing manifest loader that skips tokenizer parsing and GGUF metadata inspection while preserving listing fields, loadability checks, and GGUF/projector detection
- share the same per-request discovered model listing metadata with health/readiness model counts
- add focused coverage for reusable model listing metadata and GGUF listing detection

## Testing
- `zig fmt zig/pkg/termite/src/server/server.zig zig/pkg/termite/src/registry/registry.zig zig/pkg/termite/src/models/manifest.zig`
- `zig build termite-test --summary all`
- `cd zig/pkg/termite && zig build test --summary all` (`1761/1771 tests passed`, `10 skipped`)

## Wall Time
Measured locally against `/Users/ajroetker/.termite/models` (~58G, ~43 top-level/owner-model dirs) with `antfly termite run` on `127.0.0.1:18191`:
- before this PR: `/ml/v1/models` ~10.2s
- after shallow discovery only: `/ml/v1/models` ~5.25s
- after lightweight listing manifests: `/ml/v1/models` ~16ms cold, ~8ms warm

The lightweight-loader response was compared against the previous full-loader response with volatile `created` timestamps ignored; the response shape matched, including GGUF models with image inputs and inferred GLiNER capabilities.

## Review Notes
- This removes the `10 task buckets * discovered models * repeated manifest/loadability parse` pattern from `/models`.
- Listing/count endpoints now use shallow discovery and parse lightweight listing metadata once for response metadata and task matching.
- Discovery still runs per request, so newly pulled/copied models still appear without restart.
- GGUF support remains: listing still detects main `.gguf` files and projector `.gguf` files, but no longer mmap/parses GGUF tokenizer metadata on the `/models` path.