### PR TITLE
Fix query aggregation response label lifetime

### DIFF
--- a/zig/pkg/antfly/src/api/http_server.zig
+++ b/zig/pkg/antfly/src/api/http_server.zig
@@ -8352,6 +8352,82 @@ test "api http server serves table query response envelope" {
     try std.testing.expectEqualStrings("doc:a", parsed.value.responses.?[0].hits.?.hits.?[0]._id);
 }
 
+test "api http server serves table query with SearchAF-shaped terms aggregations" {
+    const alloc = std.testing.allocator;
+    const path = "/tmp/antfly-api-http-searchaf-aggregations";
+    var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
+    defer io_impl.deinit();
+    std.Io.Dir.cwd().deleteTree(io_impl.io(), path) catch {};
+
+    var db = try db_mod.DB.open(alloc, path, .{});
+    defer {
+        db.close();
+        std.Io.Dir.cwd().deleteTree(io_impl.io(), path) catch {};
+    }
+    try db.addIndex(.{ .name = "full_text_index_v0", .kind = .full_text, .config_json = "{}" });
+    try db.batch(.{
+        .writes = &.{
+            .{ .key = "doc:a", .value = "{\"filename\":\"main.go\",\"content\":\"hello alpha\",\"extension\":\".go\",\"file_type\":\"source\"}" },
+            .{ .key = "doc:b", .value = "{\"filename\":\"notes.txt\",\"content\":\"hello beta\",\"extension\":\".txt\",\"file_type\":\"text\"}" },
+        },
+        .sync_level = .full_index,
+    });
+
+    var table_source = table_reads.BoundTableReadSource.init("files", 77, &db, raft_mod.read_gate.noopReadableLeaseRequester());
+
+    const FakeSource = struct {
+        fn iface(_: *@This()) StatusSource {
+            return .{
+                .ptr = undefined,
+                .vtable = &.{
+                    .status = status,
+                },
+            };
+        }
+
+        fn status(_: *anyopaque) !metadata_api.MetadataStatus {
+            return .{ .metadata_group_id = 1, .metrics = .{}, .projected_stores = 1 };
+        }
+    };
+
+    var source = FakeSource{};
+    var server = ApiHttpServer.init(std.testing.allocator, .{}, source.iface(), table_source.source(), null);
+    var resp = try server.handle(.{
+        .method = .POST,
+        .uri = "/tables/files/query",
+        .content_type = "application/json",
+        .body =
+        \\{
+        \\  "full_text_search": {
+        \\    "disjuncts": [
+        \\      {"match": "hello", "field": "content"},
+        \\      {"match": "hello", "field": "filename", "boost": 3}
+        \\    ],
+        \\    "min": 1
+        \\  },
+        \\  "filter_query": {"term": ".go", "field": "extension"},
+        \\  "fields": ["path", "directory", "extension", "file_type", "filename", "content"],
+        \\  "limit": 5,
+        \\  "aggregations": {
+        \\    "file_types": {"type": "terms", "field": "file_type", "size": 10},
+        \\    "extensions": {"type": "terms", "field": "extension", "size": 20}
+        \\  }
+        \\}
+        ,
+    });
+    defer resp.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(u16, 200), resp.status);
+    try std.testing.expectEqualStrings("application/json", resp.content_type.?);
+    var parsed = try std.json.parseFromSlice(metadata_openapi.QueryResponses, std.testing.allocator, resp.body, .{});
+    defer parsed.deinit();
+    const aggregations = parsed.value.responses.?[0].aggregations.?;
+    try std.testing.expectEqual(@as(usize, 2), aggregations.map.count());
+    try std.testing.expectEqualStrings("source", aggregations.map.get("file_types").?.buckets.?[0].key);
+    try std.testing.expectEqual(@as(i64, 1), aggregations.map.get("file_types").?.buckets.?[0].doc_count);
+    try std.testing.expectEqualStrings(".go", aggregations.map.get("extensions").?.buckets.?[0].key);
+    try std.testing.expectEqual(@as(i64, 1), aggregations.map.get("extensions").?.buckets.?[0].doc_count);
+}
+
 test "api http server serves retrieval agent response envelope" {
     const alloc = std.testing.allocator;
     const path = "/tmp/antfly-api-http-retrieval";

--- a/zig/pkg/antfly/src/api/table_reads.zig
+++ b/zig/pkg/antfly/src/api/table_reads.zig
@@ -7865,7 +7865,12 @@ fn applyAggregationResults(
         aggregation_ctx.algebraic_scope = .root;
         aggregation_ctx.algebraic_constraints = items;
     };
-    meta.aggregation_results = try db_mod.aggregations.computeSearchAggregations(alloc, requests, result, aggregation_ctx);
+    const aggregation_results = try db_mod.aggregations.computeSearchAggregations(alloc, requests, result, aggregation_ctx);
+    errdefer db_mod.aggregations.deinitResults(alloc, aggregation_results);
+    for (aggregation_results) |*aggregation| {
+        try db_mod.aggregations.cloneSearchAggregationResultLabelsDeep(alloc, aggregation);
+    }
+    meta.aggregation_results = aggregation_results;
 }
 
 fn applyBoundQueryAggregations(

--- a/zig/pkg/antfly/src/storage/db/aggregations.zig
+++ b/zig/pkg/antfly/src/storage/db/aggregations.zig
@@ -105,11 +105,17 @@ pub const SearchAggregationResult = struct {
     name: []const u8,
     field: []const u8,
     type: []const u8,
+    owns_labels: bool = false,
     value_json: ?[]const u8 = null,
     metadata_json: ?[]const u8 = null,
     buckets: []SearchAggregationBucket = &.{},
 
     pub fn deinit(self: *SearchAggregationResult, alloc: Allocator) void {
+        if (self.owns_labels) {
+            if (self.name.len > 0) alloc.free(self.name);
+            if (self.field.len > 0) alloc.free(self.field);
+            if (self.type.len > 0) alloc.free(self.type);
+        }
         if (self.value_json) |value_json| alloc.free(value_json);
         if (self.metadata_json) |metadata_json| alloc.free(metadata_json);
         for (self.buckets) |*bucket| bucket.deinit(alloc);
@@ -149,6 +155,25 @@ pub fn deinitDistributedBackgroundTextStats(
 pub fn deinitResults(alloc: Allocator, results: []SearchAggregationResult) void {
     for (results) |*result| result.deinit(alloc);
     if (results.len > 0) alloc.free(results);
+}
+
+pub fn cloneSearchAggregationResultLabelsDeep(alloc: Allocator, result: *SearchAggregationResult) !void {
+    if (!result.owns_labels) {
+        const name = try alloc.dupe(u8, result.name);
+        errdefer alloc.free(name);
+        const field = try alloc.dupe(u8, result.field);
+        errdefer alloc.free(field);
+        const agg_type = try alloc.dupe(u8, result.type);
+        errdefer alloc.free(agg_type);
+
+        result.name = name;
+        result.field = field;
+        result.type = agg_type;
+        result.owns_labels = true;
+    }
+    for (result.buckets) |*bucket| {
+        for (bucket.aggregations) |*child| try cloneSearchAggregationResultLabelsDeep(alloc, child);
+    }
 }
 
 pub const Context = struct {


### PR DESCRIPTION
## Summary
- Clone aggregation result labels before storing them in query response metadata so response encoding does not read freed request-parser memory
- Add a SearchAF-shaped HTTP regression covering full text + filter + `terms` aggregations on `file_type` and `extension`

## Tests
- `zig build -Dmetal=false lib-db-test -- --test-filter "api http server serves table query with SearchAF-shaped terms aggregations"`
- `zig build -Dmetal=false lib-db-test -- --test-filter "api http server serves table query response envelope"`
- `zig build -Dmetal=false lib-db-test -- --test-filter "terms aggregation escapes string bucket keys in fallback"`
- `zig build -Dmetal=false lib-db-test -- --test-filter "terms aggregation computes multi field composite fallback"`
- `zig fmt pkg/antfly/src/api/http_server.zig pkg/antfly/src/api/table_reads.zig pkg/antfly/src/storage/db/aggregations.zig`
- `git diff --check`