### PR TITLE
Make Termite readyz independent of model inventory

### DIFF
--- a/go/pkg/termite/health.go
+++ b/go/pkg/termite/health.go
@@ -75,17 +75,8 @@ func (ln *TermiteNode) handleReadyz(w http.ResponseWriter, r *http.Request) {
 		resp.Models.Generators = len(ln.generatorRegistry.List())
 	}
 
-	// Service is ready if at least one model type is available
-	// (chunker always has "fixed" built-in, so we're always ready)
-	totalModels := resp.Models.Embedders + resp.Models.Chunkers + resp.Models.Rerankers + resp.Models.Generators
-	if totalModels == 0 {
-		resp.Status = "not_ready"
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusServiceUnavailable)
-		_ = json.NewEncoder(w).Encode(resp)
-		return
-	}
-
+	// Model availability is workload-specific. Readiness means the API is
+	// initialized and able to accept requests; /ml/v1/models reports inventory.
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	_ = json.NewEncoder(w).Encode(resp)

--- a/go/pkg/termite/termite_test.go
+++ b/go/pkg/termite/termite_test.go
@@ -74,7 +74,7 @@ func TestAPIHandlerServesRootOperationalRoutesOutsideMLPrefix(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, path, nil)
 		w := httptest.NewRecorder()
 		handler.ServeHTTP(w, req)
-		assert.True(t, w.Code == http.StatusOK || w.Code == http.StatusServiceUnavailable, "%s returned %d", path, w.Code)
+		assert.Equal(t, http.StatusOK, w.Code, path)
 	}
 
 	for _, path := range []string{"/ml/v1/healthz", "/ml/v1/readyz"} {

--- a/zig/pkg/termite/src/server/server.zig
+++ b/zig/pkg/termite/src/server/server.zig
@@ -391,19 +391,6 @@ const ModelCounts = struct {
     readers: usize = 0,
     transcribers: usize = 0,
     extractors: usize = 0,
-
-    fn total(self: @This()) usize {
-        return self.embedders +
-            self.rerankers +
-            self.chunkers +
-            self.generators +
-            self.recognizers +
-            self.classifiers +
-            self.rewriters +
-            self.readers +
-            self.transcribers +
-            self.extractors;
-    }
 };
 
 fn incrementModelCount(counts: *ModelCounts, task: []const u8) void {
@@ -4213,10 +4200,8 @@ pub const Node = struct {
             },
         });
         const counts = collectDiscoveredModelCounts(models_dir, ctx.allocator, ctx.io);
-        const status_text = if (counts.total() > 0) "ready" else "not_ready";
-        const status_code: u16 = if (counts.total() > 0) 200 else 503;
-        return ctx.status(status_code).json(.{
-            .status = status_text,
+        return ctx.status(200).json(.{
+            .status = "ready",
             .models = .{
                 .embedders = counts.embedders,
                 .rerankers = counts.rerankers,
@@ -4897,6 +4882,30 @@ test "root operational routes stay outside termite API prefix" {
     try std.testing.expect(server.hasRoute(.get, "/readyz"));
     try std.testing.expect(!server.hasRoute(.get, public_api_prefix ++ "/healthz"));
     try std.testing.expect(!server.hasRoute(.get, public_api_prefix ++ "/readyz"));
+}
+
+test "readyz reports ready with empty model inventory" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const models_dir = try std.fs.path.join(allocator, &.{ ".zig-cache", "tmp", tmp.sub_path[0..] });
+    defer allocator.free(models_dir);
+
+    active_models_dir = models_dir;
+    defer active_models_dir = null;
+
+    var req = try httpx.Request.init(allocator, .GET, "/readyz");
+    defer req.deinit();
+
+    var ctx = httpx.Context.init(allocator, std.testing.io, &req);
+    defer ctx.deinit();
+
+    var response = try Node.readyzHandler(&ctx);
+    defer response.deinit();
+
+    try std.testing.expectEqual(@as(u16, 200), response.status.code);
+    try std.testing.expect(std.mem.indexOf(u8, response.body orelse "", "\"status\":\"ready\"") != null);
 }
 
 test "registerRoutesOn supports alternate prefixes through the shared router" {


### PR DESCRIPTION
## Summary
- Stop Go Termite `/readyz` from returning 503 when model inventory is empty
- Match the Zig Termite server behavior so `/readyz` reports API readiness even with zero discovered models
- Add coverage for empty-inventory readiness in both runtimes

## Tests
- `env GOWORK=off go test ./...` from `go/pkg/termite`
- `zig build test --summary none` from `zig/pkg/termite`