### PR TITLE
Fix bool must+filter clause handling in structured filter parser

### DIFF
--- a/zig/pkg/antfly/src/capi/db.zig
+++ b/zig/pkg/antfly/src/capi/db.zig
@@ -3841,8 +3841,16 @@ fn parseTextQueryJson(alloc: std.mem.Allocator, value: std.json.Value) anyerror!
     if (value.object.get("bool")) |bool_query| {
         if (bool_query != .object) return error.InvalidArgument;
 
-        const must = if (bool_query.object.get("must")) |must_value|
-            try parseTextQueryArrayJson(alloc, must_value)
+        var must_list = std.ArrayListUnmanaged(db_mod.types.TextQuery).empty;
+        errdefer must_list.deinit(alloc);
+        if (bool_query.object.get("filter")) |filter_value| {
+            try appendTextQueryArrayJson(alloc, &must_list, filter_value);
+        }
+        if (bool_query.object.get("must")) |must_value| {
+            try appendTextQueryArrayJson(alloc, &must_list, must_value);
+        }
+        const must = if (must_list.items.len > 0)
+            try must_list.toOwnedSlice(alloc)
         else
             &.{};
         const should = if (bool_query.object.get("should")) |should_value|
@@ -4003,6 +4011,38 @@ fn parseTextQueryArrayJson(alloc: std.mem.Allocator, value: std.json.Value) anye
         clauses[i] = try parseTextQueryJson(alloc, item);
     }
     return clauses;
+}
+
+fn appendTextQueryArrayJson(
+    alloc: std.mem.Allocator,
+    out: *std.ArrayListUnmanaged(db_mod.types.TextQuery),
+    value: std.json.Value,
+) anyerror!void {
+    if (value != .array or value.array.items.len == 0) return error.InvalidArgument;
+    try out.ensureUnusedCapacity(alloc, value.array.items.len);
+    for (value.array.items) |item| {
+        out.appendAssumeCapacity(try parseTextQueryJson(alloc, item));
+    }
+}
+
+test "c api bool text parser treats filter clauses as required" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    const parsed = try std.json.parseFromSlice(std.json.Value, alloc,
+        \\{"bool":{"must":[{"term":{"field":"body","term":"invoice"}}],"filter":[{"term":{"field":"tenant","term":"acme"}}]}}
+    , .{});
+    const query = try parseTextQueryJson(alloc, parsed.value);
+
+    try std.testing.expect(query == .bool_query);
+    try std.testing.expectEqual(@as(usize, 2), query.bool_query.must.len);
+    try std.testing.expect(query.bool_query.must[0] == .term);
+    try std.testing.expectEqualStrings("tenant", query.bool_query.must[0].term.field);
+    try std.testing.expectEqualStrings("acme", query.bool_query.must[0].term.term);
+    try std.testing.expect(query.bool_query.must[1] == .term);
+    try std.testing.expectEqualStrings("body", query.bool_query.must[1].term.field);
+    try std.testing.expectEqualStrings("invoice", query.bool_query.must[1].term.term);
 }
 
 pub export fn antfly_db_execute_graph_queries_json(

--- a/zig/pkg/antfly/src/metadata/replication_backfill.zig
+++ b/zig/pkg/antfly/src/metadata/replication_backfill.zig
@@ -1250,7 +1250,7 @@ fn normalizeRouteFilterQueryAlloc(alloc: Allocator, value: std.json.Value) !std.
             }
             inner.deinit(alloc);
         }
-        inline for (.{ "must", "should", "must_not" }) |field_name| {
+        inline for (.{ "must", "filter", "should", "must_not" }) |field_name| {
             if (bool_query.object.get(field_name)) |items_value| {
                 if (items_value != .array) return error.InvalidReplicationSourceConfig;
                 var items = std.json.Array.init(alloc);
@@ -1299,6 +1299,29 @@ fn normalizeRouteFilterQueryAlloc(alloc: Allocator, value: std.json.Value) !std.
     }
 
     return try cloneJsonValueAllocLocal(alloc, value);
+}
+
+test "metadata replication route bool filter clauses are required with must clauses" {
+    const alloc = std.testing.allocator;
+
+    var active = try std.json.parseFromSlice(std.json.Value, alloc,
+        \\{"tenant":"acme","status":"active"}
+    , .{});
+    defer active.deinit();
+    var inactive = try std.json.parseFromSlice(std.json.Value, alloc,
+        \\{"tenant":"acme","status":"inactive"}
+    , .{});
+    defer inactive.deinit();
+
+    const route = ParsedReplicationRouteConfig{
+        .target_table = @constCast("target"[0..]),
+        .where_json = @constCast(
+            \\{"bool":{"must":[{"term":{"tenant":"acme"}}],"filter":[{"term":{"status":"active"}}]}}
+        [0..]),
+    };
+
+    try std.testing.expect(try routeMatchesRow(alloc, route, "doc:active", active.value));
+    try std.testing.expect(!(try routeMatchesRow(alloc, route, "doc:inactive", inactive.value)));
 }
 
 fn resolveConfiguredTransformOpsAlloc(

--- a/zig/pkg/antfly/src/search/pattern_filter.zig
+++ b/zig/pkg/antfly/src/search/pattern_filter.zig
@@ -58,6 +58,12 @@ pub fn jsonDocMatchesPatternFilter(alloc: Allocator, key: []const u8, doc: std.j
                 if (!(try jsonDocMatchesPatternFilter(alloc, key, doc, item))) return false;
             }
         }
+        if (bool_query.object.get("filter")) |filter| {
+            if (filter != .array or filter.array.items.len == 0) return error.InvalidArgument;
+            for (filter.array.items) |item| {
+                if (!(try jsonDocMatchesPatternFilter(alloc, key, doc, item))) return false;
+            }
+        }
 
         var saw_should = false;
         if (bool_query.object.get("should")) |should| {
@@ -81,7 +87,7 @@ pub fn jsonDocMatchesPatternFilter(alloc: Allocator, key: []const u8, doc: std.j
         }
 
         if (bool_query.object.count() == 0) return error.InvalidArgument;
-        if (!saw_should and bool_query.object.get("must") == null and bool_query.object.get("must_not") == null) {
+        if (!saw_should and bool_query.object.get("must") == null and bool_query.object.get("filter") == null and bool_query.object.get("must_not") == null) {
             return error.InvalidArgument;
         }
         return true;
@@ -596,5 +602,20 @@ test "stored doc matches conjunctive filters including doc id" {
         "doc:silver",
         "{\"title\":\"silver doc\",\"tier\":\"gold\"}",
         "{\"conjuncts\":[{\"doc_id\":{\"ids\":[\"doc:gold\"]}},{\"term\":{\"tier\":\"gold\"}}]}",
+    )));
+}
+
+test "stored doc bool filter clauses are required with must clauses" {
+    try std.testing.expect(try storedDocMatchesPatternFilter(
+        std.testing.allocator,
+        "doc:gold",
+        "{\"tenant\":\"acme\",\"tier\":\"gold\"}",
+        "{\"bool\":{\"must\":[{\"term\":{\"tenant\":\"acme\"}}],\"filter\":[{\"term\":{\"tier\":\"gold\"}}]}}",
+    ));
+    try std.testing.expect(!(try storedDocMatchesPatternFilter(
+        std.testing.allocator,
+        "doc:silver",
+        "{\"tenant\":\"acme\",\"tier\":\"silver\"}",
+        "{\"bool\":{\"must\":[{\"term\":{\"tenant\":\"acme\"}}],\"filter\":[{\"term\":{\"tier\":\"gold\"}}]}}",
     )));
 }

--- a/zig/pkg/antfly/src/storage/db/algebraic/index.zig
+++ b/zig/pkg/antfly/src/storage/db/algebraic/index.zig
@@ -7066,8 +7066,16 @@ pub const Index = struct {
                 else => return false,
             };
             if (bool_object.get("should") != null or bool_object.get("must_not") != null) return false;
-            if (bool_object.get("must")) |must_value| return try self.collectConstraintArrayAlloc(must_value, out);
-            return false;
+            var collected = false;
+            if (bool_object.get("must")) |must_value| {
+                if (!(try self.collectConstraintArrayAlloc(must_value, out))) return false;
+                collected = true;
+            }
+            if (bool_object.get("filter")) |filter_value| {
+                if (!(try self.collectConstraintArrayAlloc(filter_value, out))) return false;
+                collected = true;
+            }
+            return collected;
         }
         return false;
     }
@@ -20688,6 +20696,21 @@ test "algebraic doc facts expose doc id candidate sets for symbolic constraints"
     defer idx.freeDocIds(filter_ids);
     try std.testing.expectEqual(@as(usize, 1), filter_ids.len);
     try std.testing.expectEqualStrings("o1", filter_ids[0]);
+
+    const required_filter_ids = (try idx.docIdsForFilterJsonAlloc(&store,
+        \\{"bool":{"must":[{"term":{"customer":"alice"}}],"filter":[{"term":{"region":"east"}}]}}
+    )).?;
+    defer idx.freeDocIds(required_filter_ids);
+    try std.testing.expectEqual(@as(usize, 1), required_filter_ids.len);
+    try std.testing.expectEqualStrings("o2", required_filter_ids[0]);
+
+    var required_filter_set = (try idx.docIdSetForFilterJsonAlloc(&store,
+        \\{"bool":{"must":[{"term":{"customer":"alice"}}],"filter":[{"term":{"region":"east"}}]}}
+    )).?;
+    defer required_filter_set.deinit(&idx);
+    const required_filter_include = required_filter_set.include orelse return error.TestUnexpectedResult;
+    try std.testing.expectEqual(@as(usize, 1), required_filter_include.len);
+    try std.testing.expectEqualStrings("o2", required_filter_include[0]);
 
     var filter_resolved = (try idx.resolvedDocFilterForFilterJsonAlloc(&store,
         \\{"bool":{"must":[{"term":{"customer":"alice"}},{"term":{"region":"west"}}]}}

--- a/zig/pkg/antfly/src/storage/db/planning_stats.zig
+++ b/zig/pkg/antfly/src/storage/db/planning_stats.zig
@@ -18,6 +18,7 @@ const distributed_stats = @import("../../search/distributed_stats.zig");
 const types = @import("types.zig");
 
 const preflight_structured_filter_exact_count_limit: u64 = 1024;
+const bool_filter_clause_keys = [_][]const u8{ "must", "filter", "should", "must_not" };
 
 pub const PlanningStatsSummary = query_search.RuntimePreflightSummary;
 
@@ -419,7 +420,7 @@ fn appendPreflightStructuredFilterValueEstimate(
             .object => |inner| inner,
             else => return,
         };
-        for ([_][]const u8{ "must", "should", "must_not" }) |key| {
+        for (bool_filter_clause_keys) |key| {
             const items = bool_object.get(key) orelse continue;
             const array = switch (items) {
                 .array => |array| array,
@@ -588,7 +589,7 @@ fn preflightFilterValueSupportsExactStructuredFilterCount(value: std.json.Value)
             .object => |inner| inner,
             else => return false,
         };
-        for ([_][]const u8{ "must", "should", "must_not" }) |key| {
+        for (bool_filter_clause_keys) |key| {
             const items = bool_object.get(key) orelse continue;
             const array = switch (items) {
                 .array => |array| array,
@@ -655,6 +656,11 @@ fn positiveIdUpperBoundForFilterValue(value: std.json.Value) ?u32 {
         if (bool_object.get("must")) |must_value| {
             if (positiveIdUpperBoundForFilterArray(must_value, .all)) |bound| {
                 must_bound = bound;
+            }
+        }
+        if (bool_object.get("filter")) |filter_value| {
+            if (positiveIdUpperBoundForFilterArray(filter_value, .all)) |bound| {
+                must_bound = if (must_bound) |existing| @min(existing, bound) else bound;
             }
         }
 
@@ -837,4 +843,97 @@ test "exact structured filter counts tighten derived estimates without budget-li
     if (summary.selectivity_upper_bound_ratio) |ratio| {
         try std.testing.expectApproxEqAbs(@as(f32, 0.0), ratio, 0.0001);
     }
+}
+
+test "planning stats treats bool filter clauses as required structured filters" {
+    const alloc = std.testing.allocator;
+
+    const MockCollector = struct {
+        fn resolveTextIndexEstimate(
+            _: *anyopaque,
+            test_alloc: std.mem.Allocator,
+            _: ?[]const u8,
+            _: types.SearchRequest,
+        ) !?query_search.TextIndexEstimate {
+            return .{
+                .name = try test_alloc.dupe(u8, "ft_v1"),
+                .doc_count = 100,
+            };
+        }
+
+        fn resolveEmbeddingIndexEstimate(
+            _: *anyopaque,
+            _: std.mem.Allocator,
+            _: ?[]const u8,
+        ) !?query_search.EmbeddingIndexEstimate {
+            return null;
+        }
+
+        fn resolveGraphIndexEstimate(
+            _: *anyopaque,
+            _: std.mem.Allocator,
+            _: []const u8,
+        ) !?query_search.GraphIndexEstimate {
+            return null;
+        }
+
+        fn collectTextQueryStats(
+            _: *anyopaque,
+            _: std.mem.Allocator,
+            _: types.SearchRequest,
+        ) ![]const distributed_stats.TextFieldStats {
+            return &.{};
+        }
+
+        fn appendDenseQueryCost(
+            _: *anyopaque,
+            _: *PlanningStatsSummary,
+            _: types.SearchRequest,
+            _: ?[]const u8,
+            _: types.DenseKnnQuery,
+        ) !void {}
+
+        fn estimateStructuredFilterSample(
+            _: *anyopaque,
+            _: std.mem.Allocator,
+            _: types.SearchRequest,
+            _: u32,
+            _: u64,
+        ) !?PlanningStatsCollector.StructuredFilterSampleEstimate {
+            return null;
+        }
+
+        fn searchRequest(
+            _: *anyopaque,
+            test_alloc: std.mem.Allocator,
+            _: types.SearchRequest,
+        ) !types.SearchResult {
+            return try query_search.emptySearchResult(test_alloc);
+        }
+    };
+
+    const collector = PlanningStatsCollector{
+        .ptr = undefined,
+        .vtable = &.{
+            .resolve_text_index_estimate = MockCollector.resolveTextIndexEstimate,
+            .resolve_dense_index_estimate = MockCollector.resolveEmbeddingIndexEstimate,
+            .resolve_sparse_index_estimate = MockCollector.resolveEmbeddingIndexEstimate,
+            .resolve_graph_index_estimate = MockCollector.resolveGraphIndexEstimate,
+            .collect_text_query_stats = MockCollector.collectTextQueryStats,
+            .append_dense_query_cost = MockCollector.appendDenseQueryCost,
+            .estimate_structured_filter_sample = MockCollector.estimateStructuredFilterSample,
+            .search_request = MockCollector.searchRequest,
+        },
+    };
+
+    var summary = try collectSearchRequestStatsAlloc(alloc, collector, .{
+        .index_name = "ft_v1",
+        .filter_query_json = "{\"bool\":{\"must\":[{\"doc_id\":[\"doc:a\",\"doc:b\",\"doc:c\"]}],\"filter\":[{\"doc_id\":[\"doc:a\"]},{\"numeric_range\":{\"field\":\"score\",\"min\":1}}]}}",
+    }, 0);
+    defer summary.deinit(alloc);
+
+    try std.testing.expectEqual(@as(u32, 4), summary.doc_id_value_count);
+    try std.testing.expectEqual(@as(u32, 1), summary.numeric_range_clause_count);
+    try std.testing.expectEqual(@as(?u32, 1), summary.positive_id_result_upper_bound);
+    try std.testing.expect(summary.structured_filter_count_exact);
 }

--- a/zig/pkg/antfly/src/storage/db/query/graph_exec.zig
+++ b/zig/pkg/antfly/src/storage/db/query/graph_exec.zig
@@ -1297,6 +1297,12 @@ pub fn jsonDocMatchesPatternFilter(alloc: Allocator, key: []const u8, doc: std.j
                 if (!(try jsonDocMatchesPatternFilter(alloc, key, doc, item))) return false;
             }
         }
+        if (bool_query.object.get("filter")) |filter| {
+            if (filter != .array or filter.array.items.len == 0) return error.InvalidArgument;
+            for (filter.array.items) |item| {
+                if (!(try jsonDocMatchesPatternFilter(alloc, key, doc, item))) return false;
+            }
+        }
 
         var saw_should = false;
         if (bool_query.object.get("should")) |should| {
@@ -1320,7 +1326,7 @@ pub fn jsonDocMatchesPatternFilter(alloc: Allocator, key: []const u8, doc: std.j
         }
 
         if (bool_query.object.count() == 0) return error.InvalidArgument;
-        if (!saw_should and bool_query.object.get("must") == null and bool_query.object.get("must_not") == null) {
+        if (!saw_should and bool_query.object.get("must") == null and bool_query.object.get("filter") == null and bool_query.object.get("must_not") == null) {
             return error.InvalidArgument;
         }
         return true;
@@ -1395,6 +1401,12 @@ pub fn patternFilterNeedsStoredDoc(filter_query: std.json.Value) !bool {
                 if (try patternFilterNeedsStoredDoc(item)) return true;
             }
         }
+        if (bool_query.object.get("filter")) |filter| {
+            if (filter != .array or filter.array.items.len == 0) return error.InvalidArgument;
+            for (filter.array.items) |item| {
+                if (try patternFilterNeedsStoredDoc(item)) return true;
+            }
+        }
 
         var saw_should = false;
         if (bool_query.object.get("should")) |should| {
@@ -1413,7 +1425,7 @@ pub fn patternFilterNeedsStoredDoc(filter_query: std.json.Value) !bool {
         }
 
         if (bool_query.object.count() == 0) return error.InvalidArgument;
-        if (!saw_should and bool_query.object.get("must") == null and bool_query.object.get("must_not") == null) {
+        if (!saw_should and bool_query.object.get("must") == null and bool_query.object.get("filter") == null and bool_query.object.get("must_not") == null) {
             return error.InvalidArgument;
         }
         return false;
@@ -1590,7 +1602,11 @@ pub fn compilePatternFilter(alloc: Allocator, filter_query: std.json.Value) anye
     if (filter_query.object.get("bool")) |bool_query| {
         if (bool_query != .object) return error.InvalidArgument;
         var compiled = CompiledPatternFilter.BoolQuery{};
-        if (bool_query.object.get("must")) |must| compiled.must = try compilePatternFilterArray(alloc, must);
+        var must = std.ArrayListUnmanaged(CompiledPatternFilter).empty;
+        errdefer must.deinit(alloc);
+        if (bool_query.object.get("filter")) |filter| try appendCompiledPatternFilterArray(alloc, &must, filter);
+        if (bool_query.object.get("must")) |must_value| try appendCompiledPatternFilterArray(alloc, &must, must_value);
+        if (must.items.len > 0) compiled.must = try must.toOwnedSlice(alloc);
         if (bool_query.object.get("should")) |should| compiled.should = try compilePatternFilterArray(alloc, should);
         if (bool_query.object.get("must_not")) |must_not| compiled.must_not = try compilePatternFilterArray(alloc, must_not);
         if (bool_query.object.count() == 0) return error.InvalidArgument;
@@ -1628,6 +1644,18 @@ fn compilePatternFilterArray(alloc: Allocator, items: std.json.Value) anyerror![
         compiled[i] = try compilePatternFilter(alloc, item);
     }
     return compiled;
+}
+
+fn appendCompiledPatternFilterArray(
+    alloc: Allocator,
+    out: *std.ArrayListUnmanaged(CompiledPatternFilter),
+    items: std.json.Value,
+) anyerror!void {
+    if (items != .array or items.array.items.len == 0) return error.InvalidArgument;
+    try out.ensureUnusedCapacity(alloc, items.array.items.len);
+    for (items.array.items) |item| {
+        out.appendAssumeCapacity(try compilePatternFilter(alloc, item));
+    }
 }
 
 fn compilePatternFieldPath(alloc: Allocator, field: []const u8) !CompiledPatternFilter.FieldPath {
@@ -2868,6 +2896,16 @@ test "jsonDocMatchesPatternFilter supports stored structured filters" {
     , .{});
     defer parsed_terms_with_null.deinit();
 
+    var parsed_bool_with_filter = try std.json.parseFromSlice(std.json.Value, alloc,
+        \\{"bool":{"must":[{"term":{"published":"true"}}],"filter":[{"term":{"tag":"mango"}}]}}
+    , .{});
+    defer parsed_bool_with_filter.deinit();
+
+    var parsed_bool_with_filter_miss = try std.json.parseFromSlice(std.json.Value, alloc,
+        \\{"bool":{"must":[{"term":{"published":"true"}}],"filter":[{"term":{"tag":"missing"}}]}}
+    , .{});
+    defer parsed_bool_with_filter_miss.deinit();
+
     var parsed_geo_doc = try std.json.parseFromSlice(std.json.Value, alloc,
         \\{"published":true,"tag":"mango","score":5.0,"ip":"10.1.2.3","location":{"lon":-122.4194,"lat":37.7749},"meta":{"deleted_at":"2026-01-01T00:00:00Z","archived":false,"optional":null}}
     , .{});
@@ -2888,6 +2926,15 @@ test "jsonDocMatchesPatternFilter supports stored structured filters" {
     try std.testing.expect(try jsonDocMatchesPatternFilter(alloc, "doc:b", parsed_geo_doc.value, parsed_path_exists.value));
     try std.testing.expect(try jsonDocMatchesPatternFilter(alloc, "doc:b", parsed_geo_doc.value, parsed_path_term_bool.value));
     try std.testing.expect(try jsonDocMatchesPatternFilter(alloc, "doc:b", parsed_geo_doc.value, parsed_terms_with_null.value));
+    try std.testing.expect(try jsonDocMatchesPatternFilter(alloc, "doc:b", parsed_geo_doc.value, parsed_bool_with_filter.value));
+    try std.testing.expect(!(try jsonDocMatchesPatternFilter(alloc, "doc:b", parsed_geo_doc.value, parsed_bool_with_filter_miss.value)));
+
+    var compiled_arena = std.heap.ArenaAllocator.init(alloc);
+    defer compiled_arena.deinit();
+    const compiled = try compilePatternFilter(compiled_arena.allocator(), parsed_bool_with_filter.value);
+    try std.testing.expect(compiled == .bool_query);
+    try std.testing.expectEqual(@as(usize, 2), compiled.bool_query.must.len);
+    try std.testing.expect(try compiled.matches(alloc, "doc:b", parsed_geo_doc.value));
 }
 
 test "executeSingleNonPatternQueryWithSets hydrates graph documents from include_documents" {

--- a/zig/pkg/antfly/src/storage/db/query/search_exec.zig
+++ b/zig/pkg/antfly/src/storage/db/query/search_exec.zig
@@ -2663,14 +2663,22 @@ fn patternBoolFilterToSearchQuery(
     runtime_schema: ?runtime_schema_mod.TableSchema,
 ) !search_mod.SearchQuery {
     if (value != .object) return error.InvalidArgument;
+    var must_out = std.ArrayListUnmanaged(search_mod.SearchQuery).empty;
+    errdefer must_out.deinit(alloc);
+    if (value.object.get("filter")) |filter| {
+        const filter_queries = try patternFilterArrayToSearchQueries(alloc, filter, text_analysis, runtime_schema);
+        try must_out.appendSlice(alloc, filter_queries);
+    }
+    if (value.object.get("must")) |must| {
+        const must_queries = try patternFilterArrayToSearchQueries(alloc, must, text_analysis, runtime_schema);
+        try must_out.appendSlice(alloc, must_queries);
+    }
     const has_must = value.object.get("must") != null or value.object.get("filter") != null;
     const has_should = value.object.get("should") != null;
     const only_must_not = !has_must and !has_should and value.object.get("must_not") != null;
     return .{ .bool_query = .{
-        .must = if (value.object.get("must")) |must|
-            try patternFilterArrayToSearchQueries(alloc, must, text_analysis, runtime_schema)
-        else if (value.object.get("filter")) |filter|
-            try patternFilterArrayToSearchQueries(alloc, filter, text_analysis, runtime_schema)
+        .must = if (must_out.items.len > 0)
+            try must_out.toOwnedSlice(alloc)
         else if (only_must_not)
             &.{.{ .match_all = {} }}
         else

--- a/zig/pkg/antfly/src/storage/db/query/search_exec.zig
+++ b/zig/pkg/antfly/src/storage/db/query/search_exec.zig
@@ -2666,12 +2666,10 @@ fn patternBoolFilterToSearchQuery(
     var must_out = std.ArrayListUnmanaged(search_mod.SearchQuery).empty;
     errdefer must_out.deinit(alloc);
     if (value.object.get("filter")) |filter| {
-        const filter_queries = try patternFilterArrayToSearchQueries(alloc, filter, text_analysis, runtime_schema);
-        try must_out.appendSlice(alloc, filter_queries);
+        try appendPatternFilterArrayToSearchQueries(alloc, &must_out, filter, text_analysis, runtime_schema);
     }
     if (value.object.get("must")) |must| {
-        const must_queries = try patternFilterArrayToSearchQueries(alloc, must, text_analysis, runtime_schema);
-        try must_out.appendSlice(alloc, must_queries);
+        try appendPatternFilterArrayToSearchQueries(alloc, &must_out, must, text_analysis, runtime_schema);
     }
     const has_must = value.object.get("must") != null or value.object.get("filter") != null;
     const has_should = value.object.get("should") != null;
@@ -2693,6 +2691,20 @@ fn patternBoolFilterToSearchQuery(
             &.{},
         .min_should = if (!has_must and has_should) 1 else 0,
     } };
+}
+
+fn appendPatternFilterArrayToSearchQueries(
+    alloc: Allocator,
+    out: *std.ArrayListUnmanaged(search_mod.SearchQuery),
+    value: std.json.Value,
+    text_analysis: introducer_mod.TextAnalysisConfig,
+    runtime_schema: ?runtime_schema_mod.TableSchema,
+) !void {
+    if (value != .array or value.array.items.len == 0) return error.InvalidArgument;
+    try out.ensureUnusedCapacity(alloc, value.array.items.len);
+    for (value.array.items) |item| {
+        out.appendAssumeCapacity(try patternFilterValueToSearchQuery(alloc, item, text_analysis, runtime_schema));
+    }
 }
 
 fn patternFilterArrayToSearchQueries(
@@ -2864,6 +2876,24 @@ test "pattern filter single-field helpers accept explicit path alias" {
     try std.testing.expectEqualStrings("/tier", fuzzy.field);
     try std.testing.expectEqualStrings("gild", fuzzy.term);
     try std.testing.expectEqual(@as(u8, 1), fuzzy.prefix_len);
+}
+
+test "pattern bool filter clauses are merged into required search clauses" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    const parsed = try std.json.parseFromSlice(std.json.Value, alloc,
+        \\{"bool":{"must":[{"doc_id":["doc:must"]}],"filter":[{"doc_id":["doc:filter"]}]}}
+    , .{});
+    const query = try patternFilterValueToSearchQuery(alloc, parsed.value, .{}, null);
+
+    try std.testing.expect(query == .bool_query);
+    try std.testing.expectEqual(@as(usize, 2), query.bool_query.must.len);
+    try std.testing.expect(query.bool_query.must[0] == .doc_id);
+    try std.testing.expectEqualStrings("doc:filter", query.bool_query.must[0].doc_id.ids[0]);
+    try std.testing.expect(query.bool_query.must[1] == .doc_id);
+    try std.testing.expectEqualStrings("doc:must", query.bool_query.must[1].doc_id.ids[0]);
 }
 
 fn parseFuzzyOptions(object: anytype, out: *FieldFuzzy) !void {
@@ -4226,7 +4256,7 @@ fn collectPatternFilterValueTerms(
             .object => |inner| inner,
             else => return,
         };
-        for ([_][]const u8{ "must", "should", "must_not" }) |key| {
+        for ([_][]const u8{ "must", "filter", "should", "must_not" }) |key| {
             const items = bool_object.get(key) orelse continue;
             const array = switch (items) {
                 .array => |array| array,


### PR DESCRIPTION
### Motivation

- The structured-filter parser treated the presence of `filter` as if it were part of the required (`must`) clauses but then only parsed `filter` when `must` was absent, which caused `bool` queries containing both `must` and `filter` to drop the `filter` clauses and allowed under-enforcement of row-level policies.

### Description

- In `zig/pkg/antfly/src/storage/db/query/search_exec.zig`, the converter now builds one required clause list by appending parsed `filter` entries followed by parsed `must` entries.
- The conversion path now appends directly into the output list, avoiding the intermediate slice leak from the first revision.
- The sibling structured-filter paths in `zig/pkg/antfly/src/storage/db/query/graph_exec.zig` and `zig/pkg/antfly/src/search/pattern_filter.zig` now enforce `bool.filter` clauses as required clauses instead of ignoring them.
- The C API text query parser in `zig/pkg/antfly/src/capi/db.zig` now merges `bool.filter` into required clauses.
- Replication route filter normalization in `zig/pkg/antfly/src/metadata/replication_backfill.zig` now preserves `bool.filter` clauses.
- Pattern-filter text-stat collection now also walks `bool.filter` clauses.
- Planning stats now treats `bool.filter` as a required structured-filter clause for clause counts, exact-count eligibility, and positive doc-id upper bounds.
- Algebraic constraint collection now includes `bool.filter` as a required clause when resolving doc-id candidate sets through the constraint fast path.
- Existing `should`, `must_not`, `only_must_not`, and `min_should` behavior is preserved.

### Testing

- `zig build root-test -- "metadata replication route bool filter clauses are required with must clauses" "pattern bool filter clauses are merged into required search clauses" "jsonDocMatchesPatternFilter supports stored structured filters" "stored doc bool filter clauses are required with must clauses" "planning stats treats bool filter clauses as required structured filters" "algebraic doc facts expose doc id candidate sets for symbolic constraints"`
- `zig build capi-test -- "c api bool text parser treats filter clauses as required"`
- `zig build root-test`
- `zig build capi-test`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a164877b69c8321bde4bbe5e5fc7cc5)