### PR TITLE
Consolidate Go unit and omni CI

### DIFF
--- a/.github/workflows/antfly-go.yml
+++ b/.github/workflows/antfly-go.yml
@@ -39,7 +39,9 @@ jobs:
     # Runs on heavy because the standard runner's 10Gi ephemeral cap was
     # being exhausted by go build + module cache + workspace + Pebble dbs
     # written during "Test swarm startup", leading to silent SIGTERM.
-    # Heavy provides /mnt/cache (50Gi PVC) for GOCACHE/GOMODCACHE.
+    # Heavy provides /mnt/cache (50Gi PVC) for GOCACHE/GOMODCACHE. Termite
+    # omni also runs here so regular Go CI and omni consume one heavy runner
+    # slot instead of two.
     runs-on: arc-antfly-heavy
     env:
       GOCACHE: /mnt/cache/go-build
@@ -50,12 +52,21 @@ jobs:
           set -eux
           mkdir -p "$GOCACHE" "$GOMODCACHE"
 
+      - name: Verify runner image
+        run: |
+          cat /etc/os-release
+          ldd --version
+          sudo -n true
+
       - name: Install build tools
-        run: sudo apt-get update && sudo apt-get install -y build-essential
+        run: sudo apt-get update && sudo apt-get install -y build-essential pkg-config git ca-certificates curl
 
       - uses: actions/checkout@v6
         with:
           submodules: true
+
+      - name: Configure Git safe directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: Set up Go
         uses: actions/setup-go@v6
@@ -67,15 +78,17 @@ jobs:
         uses: astral-sh/setup-uv@v8.1.0
 
       - name: Set Go experiment
-        run: echo "GOEXPERIMENT=simd" >> $GITHUB_ENV
+        run: echo "GOEXPERIMENT=simd" >> "$GITHUB_ENV"
 
       - name: Verify Go version
         run: go version
 
       - name: Configure Go for private modules
         run: |
-          echo "GONOPROXY=github.com/antflydb/antfly" >> $GITHUB_ENV
-          echo "GOPRIVATE=github.com/antflydb/antfly" >> $GITHUB_ENV
+          {
+            echo "GONOPROXY=github.com/antflydb/antfly"
+            echo "GOPRIVATE=github.com/antflydb/antfly"
+          } >> "$GITHUB_ENV"
 
       - name: Verify Go module tidiness
         run: make tidy-check
@@ -169,7 +182,62 @@ jobs:
             (cd $mod && GOWORK=off go test -v ./...)
           done
 
+      - name: Download libtokenizers
+        run: |
+          ARCH=$([ "$(uname -m)" = "aarch64" ] && echo "arm64" || echo "amd64")
+          curl -fsSL "https://github.com/daulet/tokenizers/releases/download/v${TOKENIZERS_VERSION}/libtokenizers.linux-${ARCH}.tar.gz" \
+            | sudo tar -xzf - -C /usr/local/lib
+          sudo ldconfig
+
+      - name: Download ONNX Runtime
+        run: |
+          ARCH=$([ "$(uname -m)" = "aarch64" ] && echo "aarch64" || echo "x64")
+          mkdir -p "$RUNNER_TEMP/onnxruntime"
+          curl -fsSL "https://github.com/microsoft/onnxruntime/releases/download/v${ONNXRUNTIME_VERSION}/onnxruntime-linux-${ARCH}-${ONNXRUNTIME_VERSION}.tgz" \
+            | tar -xzf - --strip-components=1 -C "$RUNNER_TEMP/onnxruntime"
+          {
+            echo "CGO_CFLAGS=-I$RUNNER_TEMP/onnxruntime/include"
+            echo "CGO_LDFLAGS=-L$RUNNER_TEMP/onnxruntime/lib -lonnxruntime"
+            echo "LD_LIBRARY_PATH=$RUNNER_TEMP/onnxruntime/lib:/usr/local/lib"
+            echo "ORT_DYLIB_PATH=$RUNNER_TEMP/onnxruntime/lib/libonnxruntime.so"
+          } >> "$GITHUB_ENV"
+
+      - name: Download ONNX Runtime GenAI
+        run: |
+          ARCH=$([ "$(uname -m)" = "aarch64" ] && echo "arm64" || echo "x64")
+          mkdir -p "$RUNNER_TEMP/onnxruntime-genai"
+          curl -fsSL "https://github.com/microsoft/onnxruntime-genai/releases/download/v${GENAI_VERSION}/onnxruntime-genai-${GENAI_VERSION}-linux-${ARCH}.tar.gz" \
+            | tar -xzf - --strip-components=1 -C "$RUNNER_TEMP/onnxruntime-genai"
+          cp "$RUNNER_TEMP/onnxruntime-genai/lib"/libonnxruntime-genai*.so* "$RUNNER_TEMP/onnxruntime/lib/" 2>/dev/null || true
+          echo "ORTGENAI_DYLIB_PATH=$RUNNER_TEMP/onnxruntime/lib/libonnxruntime-genai.so" >> "$GITHUB_ENV"
+
+      - name: Download PJRT CPU plugin
+        run: |
+          sudo mkdir -p /usr/local/lib/go-xla
+          curl -fsSL "https://github.com/gomlx/pjrt-cpu-binaries/releases/download/v${PJRT_CPU_VERSION}/pjrt_cpu_linux_amd64.tar.gz" \
+            | sudo tar -xzf - -C /usr/local/lib/go-xla
+          sudo ldconfig
+          {
+            echo "LD_LIBRARY_PATH=/usr/local/lib/go-xla:$RUNNER_TEMP/onnxruntime/lib:/usr/local/lib"
+            echo "GOMLX_BACKEND=xla:cpu"
+          } >> "$GITHUB_ENV"
+
+      - name: Download termite dependencies
+        run: cd go/pkg/termite && GOWORK=off go mod download
+
+      - name: Build termite (omni)
+        env:
+          CGO_ENABLED: "1"
+        run: cd go/pkg/termite && GOWORK=off go build -v -tags="onnx,ORT,xla,XLA" ./...
+
+      - name: Test termite (omni)
+        env:
+          CGO_ENABLED: "1"
+        run: cd go/pkg/termite && GOWORK=off go test -v -tags="onnx,ORT,xla,XLA" ./...
+
   sim-validate:
+    # Temporarily disabled while heavy runners are constrained.
+    if: vars.ENABLE_GO_SIM_VALIDATE == 'true'
     runs-on: arc-antfly-heavy
     # sim-validate runs `go test ./go/pkg/antfly/src/sim` under a wrapper; on the 4-cpu
     # standard runner with no /mnt/cache, it tipped past the 10Gi ephemeral
@@ -199,12 +267,14 @@ jobs:
           cache: false
 
       - name: Set Go experiment
-        run: echo "GOEXPERIMENT=simd" >> $GITHUB_ENV
+        run: echo "GOEXPERIMENT=simd" >> "$GITHUB_ENV"
 
       - name: Configure Go for private modules
         run: |
-          echo "GONOPROXY=github.com/antflydb/antfly" >> $GITHUB_ENV
-          echo "GOPRIVATE=github.com/antflydb/antfly" >> $GITHUB_ENV
+          {
+            echo "GONOPROXY=github.com/antflydb/antfly"
+            echo "GOPRIVATE=github.com/antflydb/antfly"
+          } >> "$GITHUB_ENV"
 
       - name: Verify Go modules
         run: cd go/pkg/antfly && GOWORK=off go mod download
@@ -254,7 +324,7 @@ jobs:
           cache: false
 
       - name: Set Go experiment
-        run: echo "GOEXPERIMENT=simd" >> $GITHUB_ENV
+        run: echo "GOEXPERIMENT=simd" >> "$GITHUB_ENV"
 
       - name: Verify Go version
         run: go version
@@ -296,99 +366,3 @@ jobs:
           ANTFLY_E2E_PG_DSN: postgres://antfly:antfly_dev@127.0.0.1:5432/antfly_test?sslmode=disable
         run: |
           make e2e E2E_TIMEOUT=45m
-
-  omni:
-    # Omni combines ONNX (CGO) and XLA (CGO) backends and needs GLIBC 2.38+.
-    # ARC's actions-runner image now runs on Ubuntu 24.04, so this can run
-    # directly on the heavy runner without a kubernetesMode job container.
-    runs-on: arc-antfly-heavy
-    env:
-      GOCACHE: /mnt/cache/go-build
-      GOMODCACHE: /mnt/cache/go-mod
-    steps:
-      - name: Prepare cache directories
-        run: |
-          set -eux
-          mkdir -p "$GOCACHE" "$GOMODCACHE"
-
-      - name: Verify runner image
-        run: |
-          cat /etc/os-release
-          ldd --version
-          sudo -n true
-
-      - name: Install container prerequisites
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y git ca-certificates curl
-
-      - uses: actions/checkout@v6
-
-      - name: Configure Git safe directory
-        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
-
-      - name: Set up Go
-        uses: actions/setup-go@v6
-        with:
-          go-version: "1.26"
-          cache: false
-
-      - name: Set GOEXPERIMENT
-        run: echo "GOEXPERIMENT=simd" >> $GITHUB_ENV
-
-      - name: Verify Go version
-        run: go version
-
-      - name: Install build dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y build-essential pkg-config curl git ca-certificates
-
-      - name: Download libtokenizers
-        run: |
-          ARCH=$([ "$(uname -m)" = "aarch64" ] && echo "arm64" || echo "amd64")
-          curl -fsSL "https://github.com/daulet/tokenizers/releases/download/v${TOKENIZERS_VERSION}/libtokenizers.linux-${ARCH}.tar.gz" \
-            | sudo tar -xzf - -C /usr/local/lib
-          sudo ldconfig
-
-      - name: Download ONNX Runtime
-        run: |
-          ARCH=$([ "$(uname -m)" = "aarch64" ] && echo "aarch64" || echo "x64")
-          mkdir -p "$RUNNER_TEMP/onnxruntime"
-          curl -fsSL "https://github.com/microsoft/onnxruntime/releases/download/v${ONNXRUNTIME_VERSION}/onnxruntime-linux-${ARCH}-${ONNXRUNTIME_VERSION}.tgz" \
-            | tar -xzf - --strip-components=1 -C "$RUNNER_TEMP/onnxruntime"
-          echo "CGO_CFLAGS=-I$RUNNER_TEMP/onnxruntime/include" >> $GITHUB_ENV
-          echo "CGO_LDFLAGS=-L$RUNNER_TEMP/onnxruntime/lib -lonnxruntime" >> $GITHUB_ENV
-          echo "LD_LIBRARY_PATH=$RUNNER_TEMP/onnxruntime/lib:/usr/local/lib" >> $GITHUB_ENV
-          echo "ORT_DYLIB_PATH=$RUNNER_TEMP/onnxruntime/lib/libonnxruntime.so" >> $GITHUB_ENV
-
-      - name: Download ONNX Runtime GenAI
-        run: |
-          ARCH=$([ "$(uname -m)" = "aarch64" ] && echo "arm64" || echo "x64")
-          mkdir -p "$RUNNER_TEMP/onnxruntime-genai"
-          curl -fsSL "https://github.com/microsoft/onnxruntime-genai/releases/download/v${GENAI_VERSION}/onnxruntime-genai-${GENAI_VERSION}-linux-${ARCH}.tar.gz" \
-            | tar -xzf - --strip-components=1 -C "$RUNNER_TEMP/onnxruntime-genai"
-          cp "$RUNNER_TEMP/onnxruntime-genai/lib"/libonnxruntime-genai*.so* "$RUNNER_TEMP/onnxruntime/lib/" 2>/dev/null || true
-          echo "ORTGENAI_DYLIB_PATH=$RUNNER_TEMP/onnxruntime/lib/libonnxruntime-genai.so" >> $GITHUB_ENV
-
-      - name: Download PJRT CPU plugin
-        run: |
-          sudo mkdir -p /usr/local/lib/go-xla
-          curl -fsSL "https://github.com/gomlx/pjrt-cpu-binaries/releases/download/v${PJRT_CPU_VERSION}/pjrt_cpu_linux_amd64.tar.gz" \
-            | sudo tar -xzf - -C /usr/local/lib/go-xla
-          sudo ldconfig
-          echo "LD_LIBRARY_PATH=/usr/local/lib/go-xla:$RUNNER_TEMP/onnxruntime/lib:/usr/local/lib" >> $GITHUB_ENV
-          echo "GOMLX_BACKEND=xla:cpu" >> $GITHUB_ENV
-
-      - name: Download dependencies
-        run: cd go/pkg/termite && GOWORK=off go mod download
-
-      - name: Build termite (omni)
-        env:
-          CGO_ENABLED: "1"
-        run: cd go/pkg/termite && GOWORK=off go build -v -tags="onnx,ORT,xla,XLA" ./...
-
-      - name: Test termite (omni)
-        env:
-          CGO_ENABLED: "1"
-        run: cd go/pkg/termite && GOWORK=off go test -v -tags="onnx,ORT,xla,XLA" ./...

--- a/.github/workflows/zig-tests.yml
+++ b/.github/workflows/zig-tests.yml
@@ -133,45 +133,6 @@ jobs:
             echo "trace_validate=true" >> "$GITHUB_OUTPUT"
           fi
 
-  generated:
-    needs: changes
-    if: github.event_name != 'schedule' && needs.changes.outputs.zig_tests == 'true'
-    runs-on: arc-antfly-standard
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          submodules: true
-
-      - name: Install build tools
-        run: sudo apt-get update && sudo apt-get install -y build-essential pkg-config ca-certificates git curl xz-utils
-
-      - name: Set up Zig
-        uses: mlugg/setup-zig@v2
-        with:
-          version: 0.16.0
-          use-cache: false
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v8.1.0
-
-      - name: Restore Zig build cache
-        id: zig-cache
-        uses: actions/cache/restore@v5
-        with:
-          path: |
-            ${{ env.ZIG_LOCAL_CACHE_DIR }}
-            ${{ env.ZIG_GLOBAL_CACHE_DIR }}
-          key: zig-${{ runner.os }}-${{ runner.arch }}-0.16.0-main-${{ github.sha }}
-          restore-keys: |
-            zig-${{ runner.os }}-${{ runner.arch }}-0.16.0-main-
-            zig-${{ runner.os }}-${{ runner.arch }}-0.16.0-
-
-      - name: Check Snowball generated sources
-        run: make zig-snowball-check
-
-      - name: Check OpenAPI generated sources
-        run: make zig-openapi-check
-
   unit:
     needs: changes
     if: github.event_name != 'schedule' && needs.changes.outputs.zig_tests == 'true'
@@ -183,6 +144,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          submodules: true
 
       - name: Install build tools
         run: sudo apt-get update && sudo apt-get install -y build-essential pkg-config ca-certificates git curl xz-utils
@@ -201,6 +163,12 @@ jobs:
 
       - name: Verify Zig version
         run: zig version
+
+      - name: Check Snowball generated sources
+        run: make zig-snowball-check
+
+      - name: Check OpenAPI generated sources
+        run: make zig-openapi-check
 
       - name: Run hermetic Antfly unit tests
         run: make zig-unit-test


### PR DESCRIPTION
## Summary
- move termite omni setup/build/test into the existing Go `unit` heavy job
- remove the separate `omni` heavy job so Go unit + omni consume one heavy runner slot
- temporarily skip Go `sim-validate` unless `ENABLE_GO_SIM_VALIDATE=true`
- move Zig generated-source checks into the Zig `unit` job and remove the separate `generated` job
- clean up `$GITHUB_ENV` writes so `actionlint` passes

## Validation
- `actionlint .github/workflows/antfly-go.yml .github/workflows/zig-tests.yml`
- `git diff --check`
- YAML parse check