### PR TITLE
Run Playwright CI on ARC with local browser installs

### DIFF
--- a/.github/workflows/ts-ci.yml
+++ b/.github/workflows/ts-ci.yml
@@ -66,11 +66,20 @@ jobs:
   playwright:
     needs: [test]
     timeout-minutes: 60
-    runs-on: ubuntu-latest
+    runs-on: arc-antfly-heavy
+    env:
+      PNPM_STORE_PATH: /mnt/cache/pnpm-store
+      PLAYWRIGHT_BROWSERS_PATH: ${{ runner.temp }}/playwright-browsers
+      XDG_CACHE_HOME: ${{ runner.temp }}/xdg
+      TMPDIR: ${{ runner.temp }}/tmp
     defaults:
       run:
         working-directory: ts
     steps:
+      - name: Prepare cache directories
+        run: mkdir -p "$PNPM_STORE_PATH" "$PLAYWRIGHT_BROWSERS_PATH" "$XDG_CACHE_HOME" "$TMPDIR"
+        working-directory: .
+
       - uses: actions/checkout@v6
 
       - name: Install pnpm
@@ -84,6 +93,9 @@ jobs:
           cache: 'pnpm'
           cache-dependency-path: ts/pnpm-lock.yaml
 
+      - name: Configure pnpm cache
+        run: pnpm config set store-dir "$PNPM_STORE_PATH"
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
@@ -92,7 +104,8 @@ jobs:
 
       - name: Install Playwright Browsers
         working-directory: ts/apps/antfarm
-        run: pnpm exec playwright install --with-deps
+        timeout-minutes: 10
+        run: DEBUG=pw:install,pw:download pnpm exec playwright install --with-deps chromium
 
       - name: Preview server
         working-directory: ts/apps/antfarm


### PR DESCRIPTION
## Summary
- Move the Antfly TS Playwright job onto `arc-antfly-heavy`
- Keep pnpm packages on the shared `/mnt/cache` store
- Install Playwright Chromium into `${{ runner.temp }}` with a 10 minute install timeout to avoid shared browser-cache extraction hangs

## Validation
- `git diff --check`