### PR TITLE
antfarm: visual sweep to design-system 0.1.0 (square, flat, amber, mono)

### DIFF
--- a/ts/apps/antfarm/src/components/AIQueryAssistant.tsx
+++ b/ts/apps/antfarm/src/components/AIQueryAssistant.tsx
@@ -190,7 +190,7 @@ const AIQueryAssistant: React.FC<AIQueryAssistantProps> = ({
         )}
 
         {result && proposedQuery && (
-          <div className="rounded-lg border p-3 space-y-3 bg-muted/30">
+          <div className="rounded-none border p-3 space-y-3 bg-muted/30">
             <div className="flex items-center justify-between">
               <span className="text-sm font-medium truncate flex-1 mr-2">"{intent}"</span>
               <div className="flex items-center gap-2">

--- a/ts/apps/antfarm/src/components/AggregationCard.tsx
+++ b/ts/apps/antfarm/src/components/AggregationCard.tsx
@@ -53,7 +53,7 @@ const AggregationCard: React.FC<AggregationCardProps> = ({
   })();
 
   return (
-    <div className="flex items-start justify-between p-2.5 bg-muted/30 rounded-lg border group">
+    <div className="flex items-start justify-between p-2.5 bg-muted/30 rounded-none border group">
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-2 mb-1">
           <span className="font-medium text-sm truncate">{name}</span>
@@ -62,7 +62,7 @@ const AggregationCard: React.FC<AggregationCardProps> = ({
           </Badge>
         </div>
         <div className="text-xs text-muted-foreground flex items-center gap-1.5">
-          <code className="bg-muted px-1 py-0.5 rounded">{aggregation.field || "none"}</code>
+          <code className="bg-muted px-1 py-0.5 rounded-none">{aggregation.field || "none"}</code>
           {details && <span>· {details}</span>}
         </div>
       </div>

--- a/ts/apps/antfarm/src/components/AggregationResults.tsx
+++ b/ts/apps/antfarm/src/components/AggregationResults.tsx
@@ -62,9 +62,9 @@ const BarChart: React.FC<{
             <span className="w-28 truncate text-right text-muted-foreground shrink-0" title={label}>
               {label}
             </span>
-            <div className="flex-1 h-5 bg-muted rounded-sm overflow-hidden relative">
+            <div className="flex-1 h-5 bg-muted rounded-none overflow-hidden relative">
               <div
-                className="h-full rounded-sm transition-all"
+                className="h-full rounded-none transition-all"
                 style={{ width: `${pct}%`, backgroundColor: chartSeries[0] }}
               />
             </div>

--- a/ts/apps/antfarm/src/components/DocumentBuilder.tsx
+++ b/ts/apps/antfarm/src/components/DocumentBuilder.tsx
@@ -250,7 +250,7 @@ const DocumentBuilder: React.FC<DocumentBuilderProps> = ({ tableName, schema }) 
               <select
                 value={selectedSchemaType}
                 onChange={(e) => setSelectedSchemaType(e.target.value)}
-                className="rounded-md border border-input bg-background px-3 py-2 text-sm"
+                className="rounded-none border border-input bg-background px-3 py-2 text-sm"
               >
                 <option value="">Select a document type</option>
                 {Object.keys(schema.document_schemas).map((schemaName) => (

--- a/ts/apps/antfarm/src/components/Insert.tsx
+++ b/ts/apps/antfarm/src/components/Insert.tsx
@@ -226,7 +226,7 @@ const BulkInsert: React.FC<BulkInsertProps> = ({ tableName }) => {
             <p className="text-muted-foreground">
               Upload a newline-delimited JSON file. Each line should be a valid JSON object. The ID
               field supports Handlebars-style templates like{" "}
-              <code className="text-xs bg-muted px-1 py-0.5 rounded">
+              <code className="text-xs bg-muted px-1 py-0.5 rounded-none">
                 {"{{category}}-{{slug}}"}
               </code>{" "}
               to compose IDs from multiple fields.

--- a/ts/apps/antfarm/src/components/QueryBuilderAgent.tsx
+++ b/ts/apps/antfarm/src/components/QueryBuilderAgent.tsx
@@ -191,7 +191,7 @@ const QueryBuilderAgent: React.FC<QueryBuilderAgentProps> = ({
               )}
             </div>
 
-            <div className="rounded-md border">
+            <div className="rounded-none border">
               <JsonViewer json={result.query} />
             </div>
 
@@ -208,7 +208,7 @@ const QueryBuilderAgent: React.FC<QueryBuilderAgentProps> = ({
                   </Button>
                 </CollapsibleTrigger>
                 <CollapsibleContent>
-                  <p className="text-sm text-muted-foreground p-3 bg-muted/30 rounded-md">
+                  <p className="text-sm text-muted-foreground p-3 bg-muted/30 rounded-none">
                     {result.explanation}
                   </p>
                 </CollapsibleContent>

--- a/ts/apps/antfarm/src/components/QueryDiffView.tsx
+++ b/ts/apps/antfarm/src/components/QueryDiffView.tsx
@@ -29,7 +29,7 @@ export const QueryDiffView: React.FC<QueryDiffViewProps> = ({
     <div className={cn("grid grid-cols-2 gap-3", className)}>
       <div className="space-y-1.5">
         <span className="text-xs font-medium text-muted-foreground">Current Query</span>
-        <div className="rounded-md border overflow-hidden">
+        <div className="rounded-none border overflow-hidden">
           <SyntaxHighlighter
             language="json"
             style={style}
@@ -42,7 +42,7 @@ export const QueryDiffView: React.FC<QueryDiffViewProps> = ({
       </div>
       <div className="space-y-1.5">
         <span className="text-xs font-medium text-muted-foreground">Proposed Query</span>
-        <div className="af-status-border-success rounded-md border overflow-hidden">
+        <div className="af-status-border-success rounded-none border overflow-hidden">
           <SyntaxHighlighter
             language="json"
             style={style}

--- a/ts/apps/antfarm/src/components/SearchBoxBuilder.tsx
+++ b/ts/apps/antfarm/src/components/SearchBoxBuilder.tsx
@@ -324,7 +324,7 @@ export default function SearchBoxBuilder({
                   {/* Thumbnail */}
                   {useThumbnails && thumbnailField && (
                     <div
-                      className={`shrink-0 ${getThumbnailSizeClass()} bg-muted rounded overflow-hidden flex items-center justify-center`}
+                      className={`shrink-0 ${getThumbnailSizeClass()} bg-muted rounded-none overflow-hidden flex items-center justify-center`}
                     >
                       {thumbnailUrl ? (
                         <img
@@ -468,7 +468,7 @@ export default function SearchBoxBuilder({
                       useThumbnails && thumbnailField
                         ? `
                       {/* Thumbnail */}
-                      <div className="shrink-0 ${thumbnailSizeClass} bg-muted rounded overflow-hidden flex items-center justify-center">
+                      <div className="shrink-0 ${thumbnailSizeClass} bg-muted rounded-none overflow-hidden flex items-center justify-center">
                         {thumbnailUrl ? (
                           <img
                             src={String(thumbnailUrl)}
@@ -1326,7 +1326,7 @@ ${facetsCode}${resultsCode}
                         {facets.map((facet) => (
                           <div
                             key={facet.id}
-                            className="flex items-center justify-between p-2 border rounded"
+                            className="flex items-center justify-between p-2 border rounded-none"
                           >
                             <div>
                               <strong>{facet.title}</strong>

--- a/ts/apps/antfarm/src/components/SettingsDialog.tsx
+++ b/ts/apps/antfarm/src/components/SettingsDialog.tsx
@@ -84,11 +84,15 @@ export function SettingsDialog({ trigger }: SettingsDialogProps = {}) {
                   <Input placeholder="http://localhost:8082/api/v1" {...field} />
                 </FormControl>
                 <FormDescription>
-                  Current: <code className="text-xs bg-muted px-1 py-0.5 rounded">{apiUrl}</code>
+                  Current:{" "}
+                  <code className="text-xs bg-muted px-1 py-0.5 rounded-none">{apiUrl}</code>
                 </FormDescription>
                 <FormDescription className="text-xs">
-                  Examples: <code className="bg-muted px-1 py-0.5 rounded">/api/v1</code> (default),{" "}
-                  <code className="bg-muted px-1 py-0.5 rounded">http://server:8082/api/v1</code>
+                  Examples: <code className="bg-muted px-1 py-0.5 rounded-none">/api/v1</code>{" "}
+                  (default),{" "}
+                  <code className="bg-muted px-1 py-0.5 rounded-none">
+                    http://server:8082/api/v1
+                  </code>
                 </FormDescription>
               </FormItem>
             )}
@@ -105,13 +109,15 @@ export function SettingsDialog({ trigger }: SettingsDialogProps = {}) {
                 </FormControl>
                 <FormDescription>
                   Current:{" "}
-                  <code className="text-xs bg-muted px-1 py-0.5 rounded">{termiteApiUrl}</code>
+                  <code className="text-xs bg-muted px-1 py-0.5 rounded-none">{termiteApiUrl}</code>
                 </FormDescription>
                 <FormDescription className="text-xs">
                   Examples:{" "}
-                  <code className="bg-muted px-1 py-0.5 rounded">http://localhost:11433</code>{" "}
+                  <code className="bg-muted px-1 py-0.5 rounded-none">http://localhost:11433</code>{" "}
                   (default),{" "}
-                  <code className="bg-muted px-1 py-0.5 rounded">https://termite.company.com</code>
+                  <code className="bg-muted px-1 py-0.5 rounded-none">
+                    https://termite.company.com
+                  </code>
                 </FormDescription>
               </FormItem>
             )}

--- a/ts/apps/antfarm/src/components/ai-elements/message.tsx
+++ b/ts/apps/antfarm/src/components/ai-elements/message.tsx
@@ -40,7 +40,7 @@ export const MessageContent = ({ children, className, ...props }: MessageContent
   <div
     className={cn(
       "is-user:dark flex w-fit min-w-0 max-w-full flex-col gap-2 overflow-hidden text-sm",
-      "group-[.is-user]:ml-auto group-[.is-user]:rounded-lg group-[.is-user]:bg-secondary group-[.is-user]:px-4 group-[.is-user]:py-3 group-[.is-user]:text-foreground",
+      "group-[.is-user]:ml-auto group-[.is-user]:rounded-none group-[.is-user]:bg-secondary group-[.is-user]:px-4 group-[.is-user]:py-3 group-[.is-user]:text-foreground",
       "group-[.is-assistant]:text-foreground",
       className
     )}

--- a/ts/apps/antfarm/src/components/error-boundary.tsx
+++ b/ts/apps/antfarm/src/components/error-boundary.tsx
@@ -60,7 +60,7 @@ export class ErrorBoundary extends Component<Props, State> {
               </CardHeader>
               <CardContent className="space-y-4 text-center">
                 {this.state.error && (
-                  <p className="rounded bg-muted p-2 font-mono text-xs text-muted-foreground">
+                  <p className="rounded-none bg-muted p-2 font-mono text-xs text-muted-foreground">
                     {this.state.error.message}
                   </p>
                 )}

--- a/ts/apps/antfarm/src/components/input-group.tsx
+++ b/ts/apps/antfarm/src/components/input-group.tsx
@@ -10,7 +10,7 @@ export type InputGroupProps = HTMLAttributes<HTMLDivElement>;
 export const InputGroup = ({ className, ...props }: InputGroupProps) => (
   <div
     className={cn(
-      "flex w-full flex-col rounded-lg border bg-background shadow-xs focus-within:ring-2 focus-within:ring-ring/50",
+      "flex w-full flex-col rounded-none border bg-background shadow-xs focus-within:ring-2 focus-within:ring-ring/50",
       className
     )}
     {...props}

--- a/ts/apps/antfarm/src/components/playground/BackendInfoBar.tsx
+++ b/ts/apps/antfarm/src/components/playground/BackendInfoBar.tsx
@@ -85,7 +85,7 @@ export function BackendInfoBar() {
 
   if (status === "checking") {
     return (
-      <div className="flex items-center gap-2 mb-4 p-3 rounded-lg border bg-muted/30">
+      <div className="flex items-center gap-2 mb-4 p-3 rounded-none border bg-muted/30">
         <Skeleton className="h-4 w-4 rounded-full" />
         <Skeleton className="h-4 w-32" />
         <Skeleton className="h-4 w-24" />
@@ -95,11 +95,11 @@ export function BackendInfoBar() {
 
   if (status === "disconnected") {
     return (
-      <div className="flex items-center justify-between mb-4 p-3 rounded-lg border border-destructive/30 bg-destructive/5">
+      <div className="flex items-center justify-between mb-4 p-3 rounded-none border border-destructive/30 bg-destructive/5">
         <div className="flex items-center gap-2 text-sm text-destructive">
           <WifiOff className="h-4 w-4" />
           <span>Termite disconnected</span>
-          <code className="text-xs bg-muted px-1.5 py-0.5 rounded">{termiteApiUrl}</code>
+          <code className="text-xs bg-muted px-1.5 py-0.5 rounded-none">{termiteApiUrl}</code>
         </div>
         <div className="flex items-center gap-2">
           <SettingsDialog
@@ -119,7 +119,7 @@ export function BackendInfoBar() {
   }
 
   return (
-    <div className="flex items-center gap-2 mb-4 p-3 rounded-lg border bg-muted/30 flex-wrap">
+    <div className="flex items-center gap-2 mb-4 p-3 rounded-none border bg-muted/30 flex-wrap">
       {/* Connection status */}
       <div className="flex items-center gap-1.5">
         <span className="relative flex h-2.5 w-2.5">

--- a/ts/apps/antfarm/src/components/playground/GeneratorSelector.tsx
+++ b/ts/apps/antfarm/src/components/playground/GeneratorSelector.tsx
@@ -152,7 +152,7 @@ export function GeneratorSelector({
       <RadioGroup value={mode} onValueChange={handleModeChange} className="gap-2">
         <label
           htmlFor={defaultId}
-          className="flex items-start gap-3 rounded-lg border p-3 cursor-pointer hover:bg-muted/30"
+          className="flex items-start gap-3 rounded-none border p-3 cursor-pointer hover:bg-muted/30"
         >
           <RadioGroupItem value="default" id={defaultId} className="mt-0.5" />
           <div className="space-y-1">
@@ -164,7 +164,7 @@ export function GeneratorSelector({
         </label>
         <label
           htmlFor={customId}
-          className="flex items-start gap-3 rounded-lg border p-3 cursor-pointer hover:bg-muted/30"
+          className="flex items-start gap-3 rounded-none border p-3 cursor-pointer hover:bg-muted/30"
         >
           <RadioGroupItem value="custom" id={customId} className="mt-0.5" />
           <div className="space-y-1">

--- a/ts/apps/antfarm/src/components/playground/NoModelsGuide.tsx
+++ b/ts/apps/antfarm/src/components/playground/NoModelsGuide.tsx
@@ -24,7 +24,7 @@ function CopyCommandButton({ command }: { command: string }) {
     <button
       type="button"
       onClick={handleCopy}
-      className="shrink-0 p-1.5 rounded hover:bg-black/10 dark:hover:bg-white/10 transition-colors"
+      className="shrink-0 p-1.5 rounded-none hover:bg-black/10 dark:hover:bg-white/10 transition-colors"
       title="Copy command"
     >
       {copied ? (
@@ -65,8 +65,8 @@ export function NoModelsGuide({
   const suggestions = recommended.slice(0, 2);
 
   const containerClasses = soft
-    ? "mb-4 p-4 rounded-lg border bg-muted/30 border-border"
-    : "mb-4 p-4 rounded-lg border af-status-badge-warning";
+    ? "mb-4 p-4 rounded-none border bg-muted/30 border-border"
+    : "mb-4 p-4 rounded-none border af-status-badge-warning";
 
   const titleClasses = soft ? "text-sm font-medium text-foreground" : "text-sm font-medium";
 
@@ -93,7 +93,7 @@ export function NoModelsGuide({
                 return (
                   <div
                     key={model.id}
-                    className="flex items-center gap-2 rounded-md border bg-background/80 p-2"
+                    className="flex items-center gap-2 rounded-none border bg-background/80 p-2"
                   >
                     <div className="flex-1 min-w-0">
                       <div className="flex items-center gap-2 mb-1">

--- a/ts/apps/antfarm/src/components/playground/ReasoningChainCollapsible.tsx
+++ b/ts/apps/antfarm/src/components/playground/ReasoningChainCollapsible.tsx
@@ -96,7 +96,7 @@ function StepItem({ step, defaultOpen = false }: { step: AgentStep; defaultOpen?
           </button>
         )}
         {open && hasDetails && (
-          <pre className="text-xs bg-muted p-2 rounded mt-1 overflow-auto max-h-40">
+          <pre className="text-xs bg-muted p-2 rounded-none mt-1 overflow-auto max-h-40">
             {JSON.stringify(step.details, null, 2)}
           </pre>
         )}
@@ -163,7 +163,7 @@ export function ReasoningChainCollapsible({
             <ActiveStepItem key={step.id} step={step} />
           ))}
           {reasoningText && (
-            <div className="mt-2 p-2 bg-muted/50 rounded text-xs text-muted-foreground whitespace-pre-wrap">
+            <div className="mt-2 p-2 bg-muted/50 rounded-none text-xs text-muted-foreground whitespace-pre-wrap">
               {reasoningText}
             </div>
           )}

--- a/ts/apps/antfarm/src/components/querybuilder/QueryBuilder.tsx
+++ b/ts/apps/antfarm/src/components/querybuilder/QueryBuilder.tsx
@@ -167,7 +167,7 @@ const QueryBuilder: React.FC<QueryBuilderProps> = ({
       )}
       {showOrderByAndFacets && (
         <Accordion type="multiple" className="space-y-2">
-          <AccordionItem value="orderby" className="border rounded-lg bg-card/50 px-3">
+          <AccordionItem value="orderby" className="border rounded-none bg-card/50 px-3">
             <AccordionTrigger className="py-2.5 hover:no-underline">
               <span className="font-medium text-sm">Order By</span>
             </AccordionTrigger>
@@ -175,7 +175,7 @@ const QueryBuilder: React.FC<QueryBuilderProps> = ({
               {orderBy.map((sortField, index) => (
                 <div
                   key={`orderby-${sortField.field}-${sortField.desc}`}
-                  className="flex items-center gap-2 p-2 bg-muted/30 rounded border"
+                  className="flex items-center gap-2 p-2 bg-muted/30 rounded-none border"
                 >
                   <Input
                     placeholder="Field name"
@@ -216,7 +216,7 @@ const QueryBuilder: React.FC<QueryBuilderProps> = ({
             </AccordionContent>
           </AccordionItem>
 
-          <AccordionItem value="aggregations" className="border rounded-lg bg-card/50 px-3">
+          <AccordionItem value="aggregations" className="border rounded-none bg-card/50 px-3">
             <AccordionTrigger className="py-2.5 hover:no-underline">
               <div className="flex items-center gap-2">
                 <span className="font-medium text-sm">Aggregations</span>

--- a/ts/apps/antfarm/src/components/querybuilder/QueryNode.tsx
+++ b/ts/apps/antfarm/src/components/querybuilder/QueryNode.tsx
@@ -286,7 +286,7 @@ const QueryNode: React.FC<QueryNodeProps> = ({
         const q = query as query_components["schemas"]["BooleanQuery"];
         return (
           <div className="mt-2 flex flex-col gap-2">
-            <div className="bg-muted/50 rounded-lg p-2 space-y-2">
+            <div className="bg-muted/50 rounded-none p-2 space-y-2">
               <h4 className="font-semibold text-xs text-foreground uppercase tracking-wide">
                 Must
               </h4>
@@ -297,7 +297,7 @@ const QueryNode: React.FC<QueryNodeProps> = ({
                 availableFields={availableFields}
               />
             </div>
-            <div className="bg-muted/50 rounded-lg p-2 space-y-2">
+            <div className="bg-muted/50 rounded-none p-2 space-y-2">
               <h4 className="font-semibold text-xs text-foreground uppercase tracking-wide">
                 Should
               </h4>
@@ -308,7 +308,7 @@ const QueryNode: React.FC<QueryNodeProps> = ({
                 availableFields={availableFields}
               />
             </div>
-            <div className="bg-muted/50 rounded-lg p-2 space-y-2">
+            <div className="bg-muted/50 rounded-none p-2 space-y-2">
               <h4 className="font-semibold text-xs text-foreground uppercase tracking-wide">
                 Must Not
               </h4>
@@ -354,7 +354,7 @@ const QueryNode: React.FC<QueryNodeProps> = ({
   };
 
   return (
-    <div className="p-3 mb-2 border rounded-lg bg-card shadow-sm space-y-2">
+    <div className="p-3 mb-2 border rounded-none bg-card space-y-2">
       <div className="flex items-start gap-2 flex-wrap">
         <div className="shrink-0 w-44">
           <Label className="text-xs mb-1 block">Query Type</Label>
@@ -412,7 +412,7 @@ const QueryGroup: React.FC<QueryGroupProps> = ({
   };
 
   return (
-    <div className="bg-background/50 rounded-lg p-3 space-y-2 border">
+    <div className="bg-background/50 rounded-none p-3 space-y-2 border">
       <h4 className="font-semibold text-xs text-muted-foreground uppercase tracking-wide">
         {title}
       </h4>

--- a/ts/apps/antfarm/src/components/querybuilder/QuerySection.tsx
+++ b/ts/apps/antfarm/src/components/querybuilder/QuerySection.tsx
@@ -24,8 +24,8 @@ const QuerySection: React.FC<QuerySectionProps> = ({
     return (
       <div
         className={cn(
-          "border rounded-lg p-6 space-y-4",
-          variant === "default" && "bg-card shadow-sm",
+          "border rounded-none p-6 space-y-4",
+          variant === "default" && "bg-card",
           variant === "muted" && "bg-muted/30",
           className
         )}
@@ -37,7 +37,7 @@ const QuerySection: React.FC<QuerySectionProps> = ({
 
   // With title - use Card components
   return (
-    <Card className={cn("shadow-sm", className)}>
+    <Card className={className}>
       <CardHeader className="pb-4">
         <CardTitle className="text-lg">{title}</CardTitle>
       </CardHeader>

--- a/ts/apps/antfarm/src/components/rag/PipelineDetailPanel.tsx
+++ b/ts/apps/antfarm/src/components/rag/PipelineDetailPanel.tsx
@@ -27,7 +27,7 @@ export const PipelineDetailPanel: React.FC<PipelineDetailPanelProps> = ({
     <Collapsible open={open && step !== null}>
       <CollapsibleContent>
         {step && (
-          <div className="mt-4 p-4 rounded-lg border border-border/50 bg-muted/10">
+          <div className="mt-4 p-4 rounded-none border border-border/50 bg-muted/10">
             <div className="flex items-center gap-2 mb-3">
               <h4 className="text-sm font-medium">{step.label}</h4>
               {step.startTime && step.endTime && (
@@ -51,7 +51,7 @@ function renderStepContent(
 ): React.ReactNode {
   if (step.status === "error" && typeof step.data === "string") {
     return (
-      <div className="af-status-text-error af-status-surface-error text-sm p-2 rounded">
+      <div className="af-status-text-error af-status-surface-error text-sm p-2 rounded-none">
         {step.data}
       </div>
     );
@@ -83,7 +83,7 @@ function renderStepContent(
             </div>
           )}
           {c.reasoning && (
-            <div className="p-2 bg-muted/50 rounded text-muted-foreground">{c.reasoning}</div>
+            <div className="p-2 bg-muted/50 rounded-none text-muted-foreground">{c.reasoning}</div>
           )}
         </div>
       );
@@ -97,7 +97,7 @@ function renderStepContent(
           {data.filterApplied && (
             <div>
               <span className="text-muted-foreground">Filter:</span>{" "}
-              <code className="bg-muted px-1 rounded">{data.filterApplied}</code>
+              <code className="bg-muted px-1 rounded-none">{data.filterApplied}</code>
             </div>
           )}
           <div className="flex items-center gap-2">
@@ -108,7 +108,7 @@ function renderStepContent(
           {data.hits.length > 0 && (
             <div className="space-y-1 max-h-48 overflow-y-auto">
               {data.hits.map((hit, i) => (
-                <div key={hit._id || i} className="p-2 rounded border bg-background text-xs">
+                <div key={hit._id || i} className="p-2 rounded-none border bg-background text-xs">
                   <div className="flex items-center justify-between">
                     <span className="font-medium truncate">{hit._id}</span>
                     <Badge variant="secondary" className="text-[10px]">
@@ -237,7 +237,7 @@ function renderStepContent(
               key={q}
               type="button"
               onClick={() => onFollowupClick?.(q)}
-              className="w-full text-left text-sm p-2 rounded hover:bg-muted/50 transition-colors text-muted-foreground hover:text-foreground"
+              className="w-full text-left text-sm p-2 rounded-none hover:bg-muted/50 transition-colors text-muted-foreground hover:text-foreground"
             >
               {q}
             </button>

--- a/ts/apps/antfarm/src/components/rag/PipelineEdge.tsx
+++ b/ts/apps/antfarm/src/components/rag/PipelineEdge.tsx
@@ -39,16 +39,16 @@ export const PipelineEdge: React.FC<PipelineEdgeProps> = ({
         markerEnd="url(#arrowhead)"
         className={cn(
           edgeState === "pending" && "stroke-muted-foreground/30",
-          edgeState === "active" && "stroke-blue-500 pipeline-edge-active",
-          edgeState === "complete" && "stroke-green-500/60",
-          edgeState === "error" && "stroke-red-500/60"
+          edgeState === "active" && "stroke-primary pipeline-edge-active",
+          edgeState === "complete" && "stroke-muted-foreground/60",
+          edgeState === "error" && "stroke-destructive/60"
         )}
         strokeDasharray={edgeState === "pending" ? "4 4" : undefined}
       />
       {edgeState === "active" && (
         <circle
           r={3}
-          className="fill-blue-500 pipeline-edge-pulse-dot"
+          className="fill-primary pipeline-edge-pulse-dot"
           style={{ offsetPath: `path('${d}')` }}
         />
       )}

--- a/ts/apps/antfarm/src/components/rag/PipelineNode.tsx
+++ b/ts/apps/antfarm/src/components/rag/PipelineNode.tsx
@@ -64,7 +64,7 @@ export const PipelineNode: React.FC<PipelineNodeProps> = ({
       type="button"
       onClick={onClick}
       className={cn(
-        "absolute flex items-center gap-2 rounded-xl border px-3 transition-all cursor-pointer select-none",
+        "absolute flex items-center gap-2 rounded-none border px-3 transition-all cursor-pointer select-none",
         // Status-dependent styles
         status === "pending" && "border-border/50 bg-muted/30 opacity-50",
         status === "running" &&

--- a/ts/apps/antfarm/src/components/rag/PipelineStep.tsx
+++ b/ts/apps/antfarm/src/components/rag/PipelineStep.tsx
@@ -92,7 +92,7 @@ export const PipelineStep: React.FC<PipelineStepProps> = ({
           <button
             type="button"
             className={cn(
-              "w-full flex items-center gap-3 p-3 rounded-lg border transition-colors text-left",
+              "w-full flex items-center gap-3 p-3 rounded-none border transition-colors text-left",
               statusColor(),
               step.status !== "pending" && "hover:bg-muted/50 cursor-pointer"
             )}
@@ -153,7 +153,7 @@ function renderStepContent(
             </div>
           )}
           {c.reasoning && (
-            <div className="p-2 bg-muted/50 rounded text-muted-foreground">{c.reasoning}</div>
+            <div className="p-2 bg-muted/50 rounded-none text-muted-foreground">{c.reasoning}</div>
           )}
         </div>
       );
@@ -167,7 +167,7 @@ function renderStepContent(
           {data.filterApplied && (
             <div>
               <span className="text-muted-foreground">Filter:</span>{" "}
-              <code className="bg-muted px-1 rounded">{data.filterApplied}</code>
+              <code className="bg-muted px-1 rounded-none">{data.filterApplied}</code>
             </div>
           )}
           <div className="flex items-center gap-2">
@@ -178,7 +178,7 @@ function renderStepContent(
           {data.hits.length > 0 && (
             <div className="space-y-1 max-h-48 overflow-y-auto">
               {data.hits.map((hit, i) => (
-                <div key={hit._id || i} className="p-2 rounded border bg-background text-xs">
+                <div key={hit._id || i} className="p-2 rounded-none border bg-background text-xs">
                   <div className="flex items-center justify-between">
                     <span className="font-medium truncate">{hit._id}</span>
                     <Badge variant="secondary" className="text-[10px]">
@@ -307,7 +307,7 @@ function renderStepContent(
               key={q}
               type="button"
               onClick={() => onFollowupClick?.(q)}
-              className="w-full text-left text-sm p-2 rounded hover:bg-muted/50 transition-colors text-muted-foreground hover:text-foreground"
+              className="w-full text-left text-sm p-2 rounded-none hover:bg-muted/50 transition-colors text-muted-foreground hover:text-foreground"
             >
               {q}
             </button>

--- a/ts/apps/antfarm/src/components/rag/pipeline-graph.css
+++ b/ts/apps/antfarm/src/components/rag/pipeline-graph.css
@@ -7,21 +7,21 @@
   }
 }
 
-/* Running node: pulsing glow */
+/* Running node: pulsing amber ring (the single accent) */
 @keyframes pipeline-node-glow {
   0%,
   100% {
-    box-shadow: 0 0 0px var(--color-blue-300, #93c5fd);
+    box-shadow: 0 0 0px var(--primary);
   }
   50% {
-    box-shadow: 0 0 8px var(--color-blue-300, #93c5fd);
+    box-shadow: 0 0 8px var(--primary);
   }
 }
 
-/* Complete node: brief green flash */
+/* Complete node: brief success-tinted flash */
 @keyframes pipeline-node-complete {
   from {
-    background-color: var(--color-green-100, #dcfce7);
+    background-color: color-mix(in oklch, var(--success-100, var(--muted)) 70%, transparent);
   }
   to {
     background-color: transparent;

--- a/ts/apps/antfarm/src/components/results/FieldValueDisplay.tsx
+++ b/ts/apps/antfarm/src/components/results/FieldValueDisplay.tsx
@@ -121,7 +121,7 @@ const FieldValueDisplay: React.FC<FieldValueDisplayProps> = ({
             <img
               src={value}
               alt={fieldName}
-              className="w-12 h-12 object-cover rounded border"
+              className="w-12 h-12 object-cover rounded-none border"
               onError={(e) => {
                 e.currentTarget.style.display = "none";
               }}
@@ -358,7 +358,7 @@ const FieldValueDisplay: React.FC<FieldValueDisplayProps> = ({
   }
 
   // Fallback for unknown types
-  return <code className="text-xs bg-muted px-1 py-0.5 rounded">{String(value)}</code>;
+  return <code className="text-xs bg-muted px-1 py-0.5 rounded-none">{String(value)}</code>;
 };
 
 export default FieldValueDisplay;

--- a/ts/apps/antfarm/src/components/results/QueryResultItem.tsx
+++ b/ts/apps/antfarm/src/components/results/QueryResultItem.tsx
@@ -101,7 +101,7 @@ const QueryResultItem: React.FC<QueryResultItemProps> = ({
     <Collapsible
       open={isExpanded}
       onOpenChange={onToggle}
-      className="border rounded-lg bg-card hover:bg-accent/50 transition-colors"
+      className="border rounded-none bg-card hover:bg-accent/50 transition-colors"
     >
       <CollapsibleTrigger asChild>
         <Button variant="ghost" className="w-full h-auto p-4 hover:bg-transparent justify-start">
@@ -119,7 +119,7 @@ const QueryResultItem: React.FC<QueryResultItemProps> = ({
             <div className="flex-1 min-w-0 space-y-1">
               {/* Header: ID and Score */}
               <div className="flex items-center gap-2 flex-wrap">
-                <code className="text-sm font-mono bg-muted px-2 py-0.5 rounded">
+                <code className="text-sm font-mono bg-muted px-2 py-0.5 rounded-none">
                   {_id || `Result #${index + 1}`}
                 </code>
 

--- a/ts/apps/antfarm/src/components/results/QueryResultsList.tsx
+++ b/ts/apps/antfarm/src/components/results/QueryResultsList.tsx
@@ -209,7 +209,7 @@ const QueryResultsList: React.FC<QueryResultsListProps> = ({ result, className }
 
         {/* Table View */}
         {viewMode === "table" && (
-          <div className="border rounded-lg overflow-auto max-h-[600px]">
+          <div className="border rounded-none overflow-auto max-h-[600px]">
             <Table>
               <TableHeader>
                 <TableRow>

--- a/ts/apps/antfarm/src/components/results/ResultsToolbar.tsx
+++ b/ts/apps/antfarm/src/components/results/ResultsToolbar.tsx
@@ -85,7 +85,7 @@ const ResultsToolbar: React.FC<ResultsToolbarProps> = ({
   };
 
   return (
-    <div className="flex flex-col gap-3 p-4 bg-muted/30 rounded-lg border">
+    <div className="flex flex-col gap-3 p-4 bg-muted/30 rounded-none border">
       {/* Top Row: Stats and View Mode */}
       <div className="flex items-center justify-between flex-wrap gap-2">
         {/* Stats */}
@@ -103,7 +103,7 @@ const ResultsToolbar: React.FC<ResultsToolbarProps> = ({
         </div>
 
         {/* View Mode Toggle */}
-        <div className="flex items-center gap-1 bg-background rounded-md border p-1">
+        <div className="flex items-center gap-1 bg-background rounded-none border p-1">
           <Button
             variant={viewMode === "cards" ? "secondary" : "ghost"}
             size="sm"

--- a/ts/apps/antfarm/src/components/schema-builder/IndexField.tsx
+++ b/ts/apps/antfarm/src/components/schema-builder/IndexField.tsx
@@ -11,7 +11,7 @@ interface IndexFieldProps {
 
 const IndexField: React.FC<IndexFieldProps> = ({ index, onRemove, schemaFields }) => {
   return (
-    <div className="flex flex-col gap-4 mb-4 p-4 border rounded-md bg-card">
+    <div className="flex flex-col gap-4 mb-4 p-4 border rounded-none bg-card">
       <div className="flex justify-between items-center">
         <h4 className="font-semibold">Index {index + 1}</h4>
         <Button onClick={onRemove} aria-label="delete index" variant="ghost" size="icon">

--- a/ts/apps/antfarm/src/components/schema-builder/SchemaEditor.tsx
+++ b/ts/apps/antfarm/src/components/schema-builder/SchemaEditor.tsx
@@ -131,7 +131,7 @@ const SchemaEditor: React.FC<SchemaEditorProps> = ({
   };
 
   return (
-    <div className="p-4 border border-border rounded-md mb-4">
+    <div className="p-4 border border-border rounded-none mb-4">
       <div className="flex justify-between items-center mb-4">
         <div className="flex gap-4">
           <FormField
@@ -244,7 +244,7 @@ const SchemaEditor: React.FC<SchemaEditorProps> = ({
       </div>
 
       {fields.length > 0 ? (
-        <div className="border rounded-md">
+        <div className="border rounded-none">
           <Table>
             <TableHeader>
               <TableRow>
@@ -275,7 +275,7 @@ const SchemaEditor: React.FC<SchemaEditorProps> = ({
           </Table>
         </div>
       ) : (
-        <div className="border rounded-md p-8 text-center text-muted-foreground">
+        <div className="border rounded-none p-8 text-center text-muted-foreground">
           <p>No fields defined yet.</p>
           <p className="text-sm mt-1">Add fields manually or import from JSON.</p>
         </div>

--- a/ts/apps/antfarm/src/components/schema-builder/SchemaFieldRow.tsx
+++ b/ts/apps/antfarm/src/components/schema-builder/SchemaFieldRow.tsx
@@ -236,7 +236,7 @@ const SchemaFieldRow: React.FC<SchemaFieldRowProps> = ({
                 <div className="col-span-2 text-sm text-muted-foreground border-t pt-3 mt-1">
                   <p>
                     <span className="font-medium">Example:</span>{" "}
-                    <code className="bg-muted px-1.5 py-0.5 rounded text-xs">
+                    <code className="bg-muted px-1.5 py-0.5 rounded-none text-xs">
                       {truncateValue(detectionInfo.exampleValue)}
                     </code>
                   </p>

--- a/ts/apps/antfarm/src/components/sidebar-user.tsx
+++ b/ts/apps/antfarm/src/components/sidebar-user.tsx
@@ -43,7 +43,7 @@ export function SidebarUser(): React.JSX.Element | null {
       <SidebarMenu>
         <SidebarMenuItem>
           <div className="flex items-center gap-2 p-2">
-            <Skeleton className="h-8 w-8 rounded-lg" />
+            <Skeleton className="h-8 w-8 rounded-none" />
             <div className="flex-1 space-y-2">
               <Skeleton className="h-4 w-24" />
               <Skeleton className="h-3 w-32" />
@@ -82,9 +82,9 @@ export function SidebarUser(): React.JSX.Element | null {
                   "group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-0! relative z-50 pointer-events-auto"
               )}
             >
-              <Avatar className="h-8 w-8 rounded-lg">
+              <Avatar className="h-8 w-8 rounded-none">
                 <AvatarImage src={undefined} alt={displayName} />
-                <AvatarFallback className="rounded-lg bg-primary text-primary-foreground text-xs font-bold">
+                <AvatarFallback className="rounded-none bg-primary text-primary-foreground text-xs font-bold">
                   {initials}
                 </AvatarFallback>
               </Avatar>
@@ -98,7 +98,7 @@ export function SidebarUser(): React.JSX.Element | null {
             </SidebarMenuButton>
           </DropdownMenuTrigger>
           <DropdownMenuContent
-            className="w-(--radix-dropdown-menu-trigger-width) min-w-56 rounded-lg"
+            className="w-(--radix-dropdown-menu-trigger-width) min-w-56 rounded-none"
             side={isMobile ? "bottom" : "right"}
             align="end"
             sideOffset={4}
@@ -106,9 +106,9 @@ export function SidebarUser(): React.JSX.Element | null {
             {/* Menu header with user info */}
             <DropdownMenuLabel className="p-0 font-normal">
               <div className="flex items-center gap-2 px-1 py-1.5 text-left text-sm">
-                <Avatar className="h-8 w-8 rounded-lg">
+                <Avatar className="h-8 w-8 rounded-none">
                   <AvatarImage src={undefined} alt={displayName} />
-                  <AvatarFallback className="rounded-lg bg-primary text-primary-foreground text-xs font-bold">
+                  <AvatarFallback className="rounded-none bg-primary text-primary-foreground text-xs font-bold">
                     {initials}
                   </AvatarFallback>
                 </Avatar>

--- a/ts/apps/antfarm/src/global.css
+++ b/ts/apps/antfarm/src/global.css
@@ -62,7 +62,7 @@ select::placeholder {
 /* @antfly/components SDK styles — autosuggest, querybox, pagination, results, facets */
 
 .react-af-autosuggest {
-  @apply bg-popover border border-border rounded-md shadow-md mt-1 max-h-64 overflow-y-auto max-w-md;
+  @apply bg-popover border border-border mt-1 max-h-64 overflow-y-auto max-w-md;
 }
 
 .react-af-autosuggest-item {
@@ -82,7 +82,7 @@ select::placeholder {
 }
 
 .react-af-querybox input {
-  @apply w-full px-3 py-2 bg-background text-foreground border border-border rounded-md focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent placeholder:text-muted-foreground;
+  @apply w-full px-3 py-2 bg-background text-foreground border border-border focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent placeholder:text-muted-foreground;
 }
 
 .react-af-querybox form {
@@ -94,7 +94,7 @@ select::placeholder {
 }
 
 .react-af-querybox-submit {
-  @apply px-4 py-2 bg-primary text-primary-foreground rounded-md hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed transition-colors;
+  @apply px-4 py-2 bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed transition-colors;
 }
 
 .react-af-pagination {
@@ -106,7 +106,7 @@ select::placeholder {
 }
 
 .react-af-pagination li button {
-  @apply px-3 py-1.5 min-w-10 text-sm font-medium rounded-md bg-background text-foreground border border-border hover:bg-accent hover:text-accent-foreground transition-colors cursor-pointer;
+  @apply px-3 py-1.5 min-w-10 text-sm font-medium bg-background text-foreground border border-border hover:bg-accent hover:text-accent-foreground transition-colors cursor-pointer;
 }
 
 .react-af-pagination li.react-af-pagination-active-page button {
@@ -122,23 +122,23 @@ select::placeholder {
 }
 
 .react-af-facet {
-  @apply flex flex-col gap-2 p-3 bg-card border border-border rounded-md;
+  @apply flex flex-col gap-2 p-3 bg-card border border-border;
 }
 
 .react-af-facet input[type="text"] {
-  @apply w-full px-3 py-1.5 text-sm bg-background text-foreground border border-border rounded-md mb-2 focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent placeholder:text-muted-foreground;
+  @apply w-full px-3 py-1.5 text-sm bg-background text-foreground border border-border mb-2 focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent placeholder:text-muted-foreground;
 }
 
 .react-af-facet label {
-  @apply flex items-center gap-2 px-2 py-1.5 text-sm cursor-pointer hover:bg-accent rounded transition-colors;
+  @apply flex items-center gap-2 px-2 py-1.5 text-sm cursor-pointer hover:bg-accent transition-colors;
 }
 
 .react-af-facet input[type="checkbox"] {
-  @apply w-4 h-4 rounded border-border cursor-pointer text-primary focus:ring-2 focus:ring-ring focus:ring-offset-0;
+  @apply w-4 h-4 border-border cursor-pointer text-primary focus:ring-2 focus:ring-ring focus:ring-offset-0;
 }
 
 .react-af-facet button:not([type="checkbox"]) {
-  @apply mt-2 px-3 py-1.5 text-sm font-medium text-primary hover:text-primary-foreground hover:bg-primary border border-border rounded-md transition-colors;
+  @apply mt-2 px-3 py-1.5 text-sm font-medium text-primary hover:text-primary-foreground hover:bg-primary border border-border transition-colors;
 }
 
 /* Antfarm-local visual utilities */

--- a/ts/apps/antfarm/src/pages/AntflyChunkingPlaygroundPage.tsx
+++ b/ts/apps/antfarm/src/pages/AntflyChunkingPlaygroundPage.tsx
@@ -302,7 +302,7 @@ const AntflyChunkingPlaygroundPage: React.FC = () => {
       elements.push(
         <span
           key={`chunk-${chunk.id}`}
-          className={`${CHUNK_COLORS[colorIndex]} rounded px-0.5 border`}
+          className={`${CHUNK_COLORS[colorIndex]} rounded-none px-0.5 border`}
           title={`Chunk ${chunk.id}`}
         >
           {inputText.slice(chunk.start_char, chunk.end_char)}
@@ -494,7 +494,7 @@ const AntflyChunkingPlaygroundPage: React.FC = () => {
 
       {/* Error Display */}
       {error && (
-        <div className="rounded-lg border border-destructive/30 bg-destructive/10 p-4 text-sm text-destructive">
+        <div className="rounded-none border border-destructive/30 bg-destructive/10 p-4 text-sm text-destructive">
           {error}
         </div>
       )}
@@ -562,7 +562,7 @@ const AntflyChunkingPlaygroundPage: React.FC = () => {
 
             {/* Table document picker */}
             {docSource === "table" && selectedTable && (
-              <div className="space-y-2 p-3 bg-muted/30 rounded-lg border">
+              <div className="space-y-2 p-3 bg-muted/30 rounded-none border">
                 {/* Search for documents */}
                 <div className="flex gap-2">
                   <Input
@@ -619,7 +619,7 @@ const AntflyChunkingPlaygroundPage: React.FC = () => {
                       <button
                         key={sr.id}
                         type="button"
-                        className="w-full text-left p-2 rounded hover:bg-accent text-sm space-y-0.5 transition-colors"
+                        className="w-full text-left p-2 rounded-none hover:bg-accent text-sm space-y-0.5 transition-colors"
                         onClick={() => handleFetchDocument(sr.id)}
                       >
                         <span className="font-mono text-xs text-muted-foreground">{sr.id}</span>
@@ -657,7 +657,7 @@ const AntflyChunkingPlaygroundPage: React.FC = () => {
             {result ? (
               <div className="h-100 overflow-y-auto space-y-4">
                 {/* Highlighted text view */}
-                <div className="p-3 bg-muted/50 rounded-lg border max-h-37.5 overflow-y-auto">
+                <div className="p-3 bg-muted/50 rounded-none border max-h-37.5 overflow-y-auto">
                   {renderHighlightedText()}
                 </div>
 
@@ -670,7 +670,7 @@ const AntflyChunkingPlaygroundPage: React.FC = () => {
                     return (
                       <div
                         key={chunk.id}
-                        className={`p-3 rounded-lg border ${CHUNK_COLORS[colorIndex]}`}
+                        className={`p-3 rounded-none border ${CHUNK_COLORS[colorIndex]}`}
                       >
                         <div className="flex items-center justify-between mb-2">
                           <span

--- a/ts/apps/antfarm/src/pages/AntflyEmbeddingPlaygroundPage.tsx
+++ b/ts/apps/antfarm/src/pages/AntflyEmbeddingPlaygroundPage.tsx
@@ -276,7 +276,7 @@ const AntflyEmbeddingPlaygroundPage: React.FC = () => {
 
       {/* Error Display */}
       {error && (
-        <div className="rounded-lg border border-destructive/30 bg-destructive/10 p-4 text-sm text-destructive">
+        <div className="rounded-none border border-destructive/30 bg-destructive/10 p-4 text-sm text-destructive">
           {error}
         </div>
       )}

--- a/ts/apps/antfarm/src/pages/AntflyRerankingPlaygroundPage.tsx
+++ b/ts/apps/antfarm/src/pages/AntflyRerankingPlaygroundPage.tsx
@@ -431,7 +431,7 @@ const AntflyRerankingPlaygroundPage: React.FC = () => {
 
       {/* Error Display */}
       {error && (
-        <div className="rounded-lg border border-destructive/30 bg-destructive/10 p-4 text-sm text-destructive">
+        <div className="rounded-none border border-destructive/30 bg-destructive/10 p-4 text-sm text-destructive">
           {error}
         </div>
       )}
@@ -503,7 +503,7 @@ const AntflyRerankingPlaygroundPage: React.FC = () => {
             </CardHeader>
             <CardContent className="flex-1 max-h-[600px] overflow-y-auto space-y-2">
               {searchResults.map((hit, rank) => (
-                <div key={hit.id} className="p-3 bg-muted/30 rounded-lg border space-y-1.5">
+                <div key={hit.id} className="p-3 bg-muted/30 rounded-none border space-y-1.5">
                   <div className="flex items-center gap-2">
                     <span className="flex items-center justify-center w-5 h-5 rounded-full bg-primary/10 text-primary text-xs font-bold shrink-0">
                       {rank + 1}
@@ -539,7 +539,7 @@ const AntflyRerankingPlaygroundPage: React.FC = () => {
               </CardHeader>
               <CardContent className="flex-1 max-h-[600px] overflow-y-auto space-y-2">
                 {rerankedResults.map((hit) => (
-                  <div key={hit.id} className="p-3 bg-muted/30 rounded-lg border space-y-1.5">
+                  <div key={hit.id} className="p-3 bg-muted/30 rounded-none border space-y-1.5">
                     <div className="flex items-center gap-2">
                       <span className="flex items-center justify-center w-5 h-5 rounded-full bg-primary/10 text-primary text-xs font-bold shrink-0">
                         {hit.newRank}

--- a/ts/apps/antfarm/src/pages/ChatPlaygroundPage.tsx
+++ b/ts/apps/antfarm/src/pages/ChatPlaygroundPage.tsx
@@ -232,7 +232,7 @@ const ChatPlaygroundPage: React.FC = () => {
                       <Label className="text-sm font-medium">Pipeline Steps</Label>
 
                       {/* Classification */}
-                      <div className="flex items-center justify-between p-3 rounded-lg border">
+                      <div className="flex items-center justify-between p-3 rounded-none border">
                         <div className="flex items-center gap-3">
                           <Sparkles className="h-4 w-4 text-muted-foreground" />
                           <div>
@@ -252,7 +252,7 @@ const ChatPlaygroundPage: React.FC = () => {
                       </div>
 
                       {/* Follow-up */}
-                      <div className="flex items-center justify-between p-3 rounded-lg border">
+                      <div className="flex items-center justify-between p-3 rounded-none border">
                         <div className="flex items-center gap-3">
                           <HelpCircle className="h-4 w-4 text-muted-foreground" />
                           <div>
@@ -297,7 +297,7 @@ const ChatPlaygroundPage: React.FC = () => {
                       </div>
 
                       {/* Confidence */}
-                      <div className="flex items-center justify-between p-3 rounded-lg border">
+                      <div className="flex items-center justify-between p-3 rounded-none border">
                         <div className="flex items-center gap-3">
                           <Target className="h-4 w-4 text-muted-foreground" />
                           <div>
@@ -321,7 +321,7 @@ const ChatPlaygroundPage: React.FC = () => {
 
                     {/* Agentic Mode */}
                     <div className="space-y-4">
-                      <div className="flex items-center justify-between p-3 rounded-lg border">
+                      <div className="flex items-center justify-between p-3 rounded-none border">
                         <div className="flex items-center gap-3">
                           <Bot className="h-4 w-4 text-muted-foreground" />
                           <div>
@@ -359,7 +359,7 @@ const ChatPlaygroundPage: React.FC = () => {
                               {AVAILABLE_TOOLS.map((tool) => (
                                 <label
                                   key={tool.name}
-                                  className="flex items-center gap-2 text-xs p-1.5 rounded hover:bg-muted cursor-pointer"
+                                  className="flex items-center gap-2 text-xs p-1.5 rounded-none hover:bg-muted cursor-pointer"
                                 >
                                   <input
                                     type="checkbox"
@@ -371,7 +371,7 @@ const ChatPlaygroundPage: React.FC = () => {
                                         setEnabledTools((t) => t.filter((n) => n !== tool.name));
                                       }
                                     }}
-                                    className="rounded"
+                                    className="rounded-none"
                                   />
                                   <span className="font-medium">{tool.label}</span>
                                   <span className="text-muted-foreground">— {tool.desc}</span>
@@ -498,7 +498,7 @@ const ChatPlaygroundPage: React.FC = () => {
                   </PromptInput>
                 )}
                 renderError={(error) => (
-                  <div className="mb-3 mx-1 p-3 bg-destructive/10 border border-destructive/30 rounded-lg text-destructive text-sm">
+                  <div className="mb-3 mx-1 p-3 bg-destructive/10 border border-destructive/30 rounded-none text-destructive text-sm">
                     {error}
                   </div>
                 )}

--- a/ts/apps/antfarm/src/pages/ChunkingPlaygroundPage.tsx
+++ b/ts/apps/antfarm/src/pages/ChunkingPlaygroundPage.tsx
@@ -313,7 +313,7 @@ const ChunkingPlaygroundPage: React.FC = () => {
       elements.push(
         <span
           key={`chunk-${chunk.id}`}
-          className={`${CHUNK_COLORS[colorIndex]} rounded px-0.5 border`}
+          className={`${CHUNK_COLORS[colorIndex]} rounded-none px-0.5 border`}
           title={`Chunk ${chunk.id}`}
         >
           {inputText.slice(chunk.start_char, chunk.end_char)}
@@ -533,7 +533,7 @@ const ChunkingPlaygroundPage: React.FC = () => {
 
       {/* Error Display */}
       {error && (
-        <div className="rounded-lg border border-destructive/30 bg-destructive/10 p-4 text-sm text-destructive">
+        <div className="rounded-none border border-destructive/30 bg-destructive/10 p-4 text-sm text-destructive">
           {error}
         </div>
       )}
@@ -603,7 +603,7 @@ const ChunkingPlaygroundPage: React.FC = () => {
             ) : result ? (
               <div className="h-100 overflow-y-auto space-y-4">
                 {/* Highlighted text view */}
-                <div className="p-3 bg-muted/50 rounded-lg border max-h-37.5 overflow-y-auto">
+                <div className="p-3 bg-muted/50 rounded-none border max-h-37.5 overflow-y-auto">
                   {renderHighlightedText()}
                 </div>
 
@@ -616,7 +616,7 @@ const ChunkingPlaygroundPage: React.FC = () => {
                     return (
                       <div
                         key={chunk.id}
-                        className={`p-3 rounded-lg border ${CHUNK_COLORS[colorIndex]}`}
+                        className={`p-3 rounded-none border ${CHUNK_COLORS[colorIndex]}`}
                       >
                         <div className="flex items-center justify-between mb-2">
                           <span

--- a/ts/apps/antfarm/src/pages/ClusterPage.tsx
+++ b/ts/apps/antfarm/src/pages/ClusterPage.tsx
@@ -202,7 +202,7 @@ function ShardBlock({ shard, storeId }: { shard: ShardStatus; storeId: string })
         <button
           type="button"
           className={cn(
-            "inline-flex items-center justify-center min-w-[28px] h-6 px-1.5 rounded text-[10px] font-mono font-medium border cursor-default transition-colors",
+            "inline-flex items-center justify-center min-w-[28px] h-6 px-1.5 rounded-none text-[10px] font-mono font-medium border cursor-default transition-colors",
             roleStyles[role]
           )}
         >
@@ -317,7 +317,7 @@ function ShardLegend() {
     <div className="flex flex-wrap items-center gap-3 text-[11px] text-muted-foreground">
       {items.map((item) => (
         <div key={item.label} className="flex items-center gap-1.5">
-          <span className={cn("inline-block w-4 h-3 rounded border", item.className)} />
+          <span className={cn("inline-block w-4 h-3 rounded-none border", item.className)} />
           <span>{item.label}</span>
         </div>
       ))}
@@ -362,7 +362,7 @@ const ClusterPage: React.FC = () => {
     <DashboardPage>
       {/* Section A: Cluster Health Header */}
       <div className="relative isolate">
-        <GraphPaperBg className="absolute inset-0 -z-10 rounded-xl" />
+        <GraphPaperBg className="absolute inset-0 -z-10 rounded-none" />
         <DashboardPageHeader>
           <div>
             <div className="flex items-center gap-3">
@@ -403,7 +403,11 @@ const ClusterPage: React.FC = () => {
       </div>
 
       <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
-        <StatCard label="Data Nodes" value={storeList.length} icon={<Network className="w-4 h-4" />} />
+        <StatCard
+          label="Data Nodes"
+          value={storeList.length}
+          icon={<Network className="w-4 h-4" />}
+        />
         <StatCard label="Tables" value={uniqueTables} icon={<Database className="w-4 h-4" />} />
         <StatCard label="Ranges" value={totalShards} />
         {totalDisk > 0 && <StatCard label="Disk" value={formatBytes(totalDisk)} />}
@@ -444,7 +448,7 @@ const ClusterPage: React.FC = () => {
             <ShardLegend />
           </div>
 
-          <div className="border rounded-lg overflow-x-auto">
+          <div className="border rounded-none overflow-x-auto">
             <table className="w-full text-sm">
               <thead>
                 <tr className="border-b bg-muted/30">
@@ -510,7 +514,7 @@ const ClusterPage: React.FC = () => {
       ) : (
         !cluster.isLoading &&
         storeList.length > 0 && (
-          <div className="flex flex-col items-center justify-center py-16 gap-3 border rounded-lg bg-muted/20">
+          <div className="flex flex-col items-center justify-center py-16 gap-3 border rounded-none bg-muted/20">
             <Database className="w-8 h-8 text-muted-foreground" />
             <p className="text-muted-foreground">No tables yet</p>
             <Button variant="outline" size="sm" asChild>

--- a/ts/apps/antfarm/src/pages/CreateTablePage.tsx
+++ b/ts/apps/antfarm/src/pages/CreateTablePage.tsx
@@ -48,7 +48,7 @@ const CreateTablePage: React.FC = () => {
   return (
     <DashboardPage>
       <div className="relative isolate">
-        <GraphPaperBg className="absolute inset-0 -z-10 rounded-xl" />
+        <GraphPaperBg className="absolute inset-0 -z-10 rounded-none" />
         <DashboardPageHeader>
           <div>
             <DashboardPageTitle className="font-aeonik">Create New Table</DashboardPageTitle>

--- a/ts/apps/antfarm/src/pages/EmbeddingPlaygroundPage.tsx
+++ b/ts/apps/antfarm/src/pages/EmbeddingPlaygroundPage.tsx
@@ -104,7 +104,7 @@ function EmbeddingSparkline({
     <svg
       width={width}
       height={height}
-      className="shrink-0 rounded"
+      className="shrink-0 rounded-none"
       aria-label="Embedding vector preview"
     >
       <rect width={width} height={height} className="fill-muted/50" rx={2} />
@@ -399,7 +399,7 @@ const EmbeddingPlaygroundPage: React.FC = () => {
 
       {/* Error Display */}
       {error && (
-        <div className="rounded-lg border border-destructive/30 bg-destructive/10 p-4 text-sm text-destructive">
+        <div className="rounded-none border border-destructive/30 bg-destructive/10 p-4 text-sm text-destructive">
           {error}
         </div>
       )}
@@ -489,7 +489,7 @@ const EmbeddingPlaygroundPage: React.FC = () => {
               <div className="max-h-[600px] overflow-y-auto space-y-3">
                 {/* Query embedding preview */}
                 {queryEmbedding && showSparklines && (
-                  <div className="p-3 bg-muted/30 rounded-lg border border-dashed space-y-2">
+                  <div className="p-3 bg-muted/30 rounded-none border border-dashed space-y-2">
                     <div className="flex items-center gap-2">
                       <span className="text-xs font-medium text-muted-foreground">
                         Query vector
@@ -500,7 +500,7 @@ const EmbeddingPlaygroundPage: React.FC = () => {
                 )}
 
                 {results.map((doc, rank) => (
-                  <div key={doc.index} className="p-3 bg-muted/30 rounded-lg border space-y-2">
+                  <div key={doc.index} className="p-3 bg-muted/30 rounded-none border space-y-2">
                     <div className="flex items-center gap-2">
                       <span className="flex items-center justify-center w-6 h-6 rounded-full bg-primary/10 text-primary text-xs font-bold shrink-0">
                         {rank + 1}

--- a/ts/apps/antfarm/src/pages/EvalsPlaygroundPage.tsx
+++ b/ts/apps/antfarm/src/pages/EvalsPlaygroundPage.tsx
@@ -625,7 +625,7 @@ const EvalsPlaygroundPage: React.FC = () => {
 
       {/* Error Display */}
       {error && (
-        <div className="rounded-lg border border-destructive/30 bg-destructive/10 p-4 text-sm text-destructive">
+        <div className="rounded-none border border-destructive/30 bg-destructive/10 p-4 text-sm text-destructive">
           {error}
         </div>
       )}
@@ -721,7 +721,7 @@ const EvalsPlaygroundPage: React.FC = () => {
                       onOpenChange={() => toggleResultExpanded(result.itemId)}
                     >
                       <CollapsibleTrigger asChild>
-                        <div className="flex items-center gap-2 p-2 rounded-lg border hover:bg-muted/50 cursor-pointer">
+                        <div className="flex items-center gap-2 p-2 rounded-none border hover:bg-muted/50 cursor-pointer">
                           {expandedResults.has(result.itemId) ? (
                             <ChevronDown className="h-4 w-4" />
                           ) : (
@@ -742,7 +742,7 @@ const EvalsPlaygroundPage: React.FC = () => {
                         </div>
                       </CollapsibleTrigger>
                       <CollapsibleContent>
-                        <div className="ml-6 mt-2 p-3 rounded-lg bg-muted/30 space-y-3 text-sm">
+                        <div className="ml-6 mt-2 p-3 rounded-none bg-muted/30 space-y-3 text-sm">
                           {result.error ? (
                             <div className="af-status-text-warning">
                               <span className="font-medium">Error:</span> {result.error}
@@ -880,7 +880,7 @@ const EvalsPlaygroundPage: React.FC = () => {
             </div>
             <div className="space-y-2 flex-1 min-h-0">
               <Label>Preview</Label>
-              <div className="p-3 bg-muted rounded-lg text-xs max-h-40 overflow-auto">
+              <div className="p-3 bg-muted rounded-none text-xs max-h-40 overflow-auto">
                 {(() => {
                   try {
                     const parsed = JSON.parse(importJson);
@@ -898,7 +898,7 @@ const EvalsPlaygroundPage: React.FC = () => {
                             <div
                               // biome-ignore lint/suspicious/noArrayIndexKey: preview items don't have stable IDs
                               key={i}
-                              className="p-2 bg-background rounded border"
+                              className="p-2 bg-background rounded-none border"
                             >
                               <p className="font-medium truncate">
                                 Q: {entry.vars?.question || "—"}
@@ -928,7 +928,7 @@ const EvalsPlaygroundPage: React.FC = () => {
                                 <div
                                   // biome-ignore lint/suspicious/noArrayIndexKey: preview items don't have stable IDs
                                   key={i}
-                                  className="p-2 bg-background rounded border"
+                                  className="p-2 bg-background rounded-none border"
                                 >
                                   <p className="font-medium truncate">Q: {item.question || "—"}</p>
                                   <p className="text-muted-foreground truncate">
@@ -1049,7 +1049,7 @@ const EvalsPlaygroundPage: React.FC = () => {
 // Sub-component for eval item display
 function EvalItemCard({ item, onRemove }: { item: EvalItem; onRemove: () => void }) {
   return (
-    <div className="p-3 border rounded-lg group relative">
+    <div className="p-3 border rounded-none group relative">
       <Button
         variant="ghost"
         size="icon"

--- a/ts/apps/antfarm/src/pages/KnowledgeGraphPlaygroundPage.tsx
+++ b/ts/apps/antfarm/src/pages/KnowledgeGraphPlaygroundPage.tsx
@@ -105,15 +105,17 @@ interface ResolverConfig {
 const DEFAULT_ENTITY_LABELS = ["person", "organization", "location", "date"];
 const DEFAULT_RELATION_LABELS = ["founded", "works_at", "located_in", "ceo_of", "acquired"];
 
-// Entity type colors
+// Entity type colors — routed through the design-system categorical chart
+// palette so node types stay distinguishable without inventing new hues
+// (color is the only channel available in the SVG graph).
 const ENTITY_TYPE_COLORS: Record<string, string> = {
-  person: "#3b82f6", // blue
-  organization: "#22c55e", // green
-  location: "#a855f7", // purple
-  date: "#f59e0b", // amber
-  product: "#ec4899", // pink
-  event: "#06b6d4", // cyan
-  default: "#6b7280", // gray
+  person: "var(--chart-series-1)",
+  organization: "var(--chart-series-2)",
+  location: "var(--chart-series-3)",
+  date: "var(--chart-series-4)",
+  product: "var(--chart-series-5)",
+  event: "var(--chart-series-6)",
+  default: "var(--muted-foreground)",
 };
 
 const STORAGE_KEY = "antfarm-playground-knowledge-graph";
@@ -521,7 +523,7 @@ const KnowledgeGraphPlaygroundPage: React.FC = () => {
     });
 
     return (
-      <svg viewBox={`0 0 ${width} ${height}`} className="w-full h-80 bg-muted/30 rounded-lg">
+      <svg viewBox={`0 0 ${width} ${height}`} className="w-full h-80 bg-muted/30 rounded-none">
         <title>Knowledge graph visualization</title>
         <defs>
           <marker
@@ -532,7 +534,7 @@ const KnowledgeGraphPlaygroundPage: React.FC = () => {
             refY="3.5"
             orient="auto"
           >
-            <polygon points="0 0, 10 3.5, 0 7" fill="#888" />
+            <polygon points="0 0, 10 3.5, 0 7" fill="var(--muted-foreground)" />
           </marker>
         </defs>
 
@@ -576,7 +578,7 @@ const KnowledgeGraphPlaygroundPage: React.FC = () => {
                 y1={y1}
                 x2={x2}
                 y2={y2}
-                stroke={isSelected ? "#3b82f6" : "#888"}
+                stroke={isSelected ? "var(--primary)" : "var(--muted-foreground)"}
                 strokeWidth={isSelected ? 2 : 1}
                 markerEnd="url(#arrowhead)"
               />
@@ -888,7 +890,7 @@ const KnowledgeGraphPlaygroundPage: React.FC = () => {
 
       {/* Error Display */}
       {error && (
-        <div className="rounded-lg border border-destructive/30 bg-destructive/10 p-4 text-sm text-destructive">
+        <div className="rounded-none border border-destructive/30 bg-destructive/10 p-4 text-sm text-destructive">
           {error}
         </div>
       )}
@@ -959,7 +961,7 @@ const KnowledgeGraphPlaygroundPage: React.FC = () => {
                 <TabsContent value="visual" className="mt-0">
                   {graphVisualization}
                   {(selectedNode || selectedEdge) && (
-                    <div className="mt-4 p-3 bg-muted/50 rounded-lg border text-sm">
+                    <div className="mt-4 p-3 bg-muted/50 rounded-none border text-sm">
                       {selectedNode && (
                         <div>
                           <div className="font-medium">{selectedNode.canonical_name}</div>
@@ -989,7 +991,7 @@ const KnowledgeGraphPlaygroundPage: React.FC = () => {
                 </TabsContent>
 
                 <TabsContent value="nodes" className="mt-0 h-80 overflow-y-auto">
-                  <div className="rounded-lg border overflow-hidden">
+                  <div className="rounded-none border overflow-hidden">
                     <table className="w-full text-sm">
                       <thead className="bg-muted/50 sticky top-0">
                         <tr>
@@ -1026,7 +1028,7 @@ const KnowledgeGraphPlaygroundPage: React.FC = () => {
                 </TabsContent>
 
                 <TabsContent value="edges" className="mt-0 h-80 overflow-y-auto">
-                  <div className="rounded-lg border overflow-hidden">
+                  <div className="rounded-none border overflow-hidden">
                     <table className="w-full text-sm">
                       <thead className="bg-muted/50 sticky top-0">
                         <tr>

--- a/ts/apps/antfarm/src/pages/ModelsPage.tsx
+++ b/ts/apps/antfarm/src/pages/ModelsPage.tsx
@@ -611,7 +611,10 @@ const ModelDetailSheet: React.FC<{
               <p className="text-xs text-muted-foreground">
                 {model.sourceUrl ? (
                   <>
-                    Use <code className="font-mono bg-muted px-1 py-0.5 rounded-none">termite pull</code>{" "}
+                    Use{" "}
+                    <code className="font-mono bg-muted px-1 py-0.5 rounded-none">
+                      termite pull
+                    </code>{" "}
                     CLI or the Termite operator to manage models in production deployments.
                   </>
                 ) : (

--- a/ts/apps/antfarm/src/pages/ModelsPage.tsx
+++ b/ts/apps/antfarm/src/pages/ModelsPage.tsx
@@ -85,68 +85,15 @@ const MODEL_TYPE_ICONS: Record<ModelType, React.FC<{ className?: string }>> = {
   transcriber: AudioLines,
 };
 
-// Refined color system - bold accent colors with monochrome base
-const MODEL_TYPE_ACCENT: Record<
-  ModelType,
-  { bg: string; text: string; border: string; glow: string }
-> = {
-  embedder: {
-    bg: "bg-blue-500",
-    text: "text-blue-500 dark:text-blue-400",
-    border: "border-blue-500/20 dark:border-blue-400/20",
-    glow: "shadow-blue-500/20",
-  },
-  reranker: {
-    bg: "bg-violet-500",
-    text: "text-violet-500 dark:text-violet-400",
-    border: "border-violet-500/20 dark:border-violet-400/20",
-    glow: "shadow-violet-500/20",
-  },
-  chunker: {
-    bg: "bg-emerald-500",
-    text: "text-emerald-500 dark:text-emerald-400",
-    border: "border-emerald-500/20 dark:border-emerald-400/20",
-    glow: "shadow-emerald-500/20",
-  },
-  recognizer: {
-    bg: "bg-amber-500",
-    text: "text-amber-500 dark:text-amber-400",
-    border: "border-amber-500/20 dark:border-amber-400/20",
-    glow: "shadow-amber-500/20",
-  },
-  rewriter: {
-    bg: "bg-rose-500",
-    text: "text-rose-500 dark:text-rose-400",
-    border: "border-rose-500/20 dark:border-rose-400/20",
-    glow: "shadow-rose-500/20",
-  },
-  generator: {
-    bg: "bg-cyan-500",
-    text: "text-cyan-500 dark:text-cyan-400",
-    border: "border-cyan-500/20 dark:border-cyan-400/20",
-    glow: "shadow-cyan-500/20",
-  },
-  reader: {
-    bg: "bg-orange-500",
-    text: "text-orange-500 dark:text-orange-400",
-    border: "border-orange-500/20 dark:border-orange-400/20",
-    glow: "shadow-orange-500/20",
-  },
-  transcriber: {
-    bg: "bg-teal-500",
-    text: "text-teal-500 dark:text-teal-400",
-    border: "border-teal-500/20 dark:border-teal-400/20",
-    glow: "shadow-teal-500/20",
-  },
-};
+// Model-type chrome is neutral mono — the type is already carried by its
+// icon and name, so it takes no per-type hue (single amber accent language).
+const NEUTRAL_ACCENT = {
+  text: "text-muted-foreground",
+  border: "border-border",
+} as const;
 
-// Capability styling
-const CAPABILITY_STYLES: Record<RecognizerCapability, string> = {
-  labels: "bg-foreground/5 text-foreground/70 border-foreground/10",
-  zeroshot: "bg-amber-500/10 text-amber-600 dark:text-amber-400 border-amber-500/20",
-  relations: "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 border-emerald-500/20",
-  answers: "bg-rose-500/10 text-rose-600 dark:text-rose-400 border-rose-500/20",
-};
+// Capability chips are neutral mono — the capability is carried by its label.
+const CAPABILITY_CHIP = "bg-muted text-muted-foreground border-border";
 
 const CAPABILITY_LABELS: Record<RecognizerCapability, string> = {
   labels: "NER",
@@ -163,13 +110,9 @@ const HARDWARE_ICONS: Record<HardwareCapability, React.FC<{ className?: string }
   cpu: Cpu,
 };
 
-// Hardware badge colors
-const HARDWARE_COLORS: Record<HardwareCapability, string> = {
-  "nvidia-gpu": "bg-green-500/10 text-green-600 dark:text-green-400 border-green-500/20",
-  "apple-silicon": "bg-slate-500/10 text-slate-600 dark:text-slate-400 border-slate-500/20",
-  "google-tpu": "bg-blue-500/10 text-blue-600 dark:text-blue-400 border-blue-500/20",
-  cpu: "bg-foreground/5 text-foreground/70 border-foreground/10",
-};
+// Hardware badges are neutral mono — each kind is differentiated by its icon
+// (single amber accent language; no per-vendor hue).
+const HARDWARE_CHIP = "bg-muted text-muted-foreground border-border";
 
 // Hardware badges component
 const HardwareBadges: React.FC<{
@@ -190,8 +133,8 @@ const HardwareBadges: React.FC<{
               <TooltipTrigger asChild>
                 <span
                   className={cn(
-                    "inline-flex items-center gap-1.5 px-2 py-1 rounded-md text-xs border cursor-help",
-                    HARDWARE_COLORS[cap]
+                    "inline-flex items-center gap-1.5 px-2 py-1 rounded-none text-xs font-mono border cursor-help",
+                    HARDWARE_CHIP
                   )}
                 >
                   <Icon className="w-3 h-3" />
@@ -343,8 +286,8 @@ const ModelStats: React.FC<{ source: string; compact?: boolean }> = ({ source, c
   if (loading) {
     return (
       <div className="flex items-center gap-2 text-xs text-muted-foreground/50">
-        <span className="w-8 h-3 bg-muted animate-pulse rounded" />
-        <span className="w-8 h-3 bg-muted animate-pulse rounded" />
+        <span className="w-8 h-3 bg-muted animate-pulse rounded-none" />
+        <span className="w-8 h-3 bg-muted animate-pulse rounded-none" />
       </div>
     );
   }
@@ -373,7 +316,7 @@ const ModelStats: React.FC<{ source: string; compact?: boolean }> = ({ source, c
   }
 
   return (
-    <div className="flex items-center gap-2 px-3 py-2 rounded-lg bg-muted/50 border border-border/50">
+    <div className="flex items-center gap-2 px-3 py-2 rounded-none bg-muted/50 border border-border/50">
       <HFLogo className="w-4 h-4 text-muted-foreground" />
       <div className="flex items-center gap-3 text-xs">
         <span className="flex items-center gap-1.5 text-muted-foreground">
@@ -438,7 +381,7 @@ const TypePill: React.FC<{
       onClick={onClick}
       aria-pressed={selected}
       className={cn(
-        "px-3 py-1.5 rounded-md text-sm transition-colors",
+        "px-3 py-1.5 rounded-none text-sm transition-colors",
         selected
           ? "bg-foreground text-background"
           : "text-muted-foreground hover:text-foreground hover:bg-muted"
@@ -470,14 +413,14 @@ const ModelCard: React.FC<{
       aria-label={`View details for ${model.name}`}
       className={cn(
         "group text-left w-full",
-        "bg-card border border-border rounded-xl p-5",
+        "bg-card border border-border rounded-none p-5",
         "transition-colors duration-150",
         "hover:bg-accent/50",
         "focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-background"
       )}
     >
       <div className="flex items-start gap-3 mb-3">
-        <div className="flex items-center justify-center w-9 h-9 rounded-lg bg-muted shrink-0">
+        <div className="flex items-center justify-center w-9 h-9 rounded-none bg-muted shrink-0">
           <Icon className="w-4 h-4 text-muted-foreground" />
         </div>
         <div className="min-w-0">
@@ -549,7 +492,7 @@ const ModelDetailSheet: React.FC<{
   if (!model) return null;
 
   const Icon = MODEL_TYPE_ICONS[model.type];
-  const accent = MODEL_TYPE_ACCENT[model.type];
+  const accent = NEUTRAL_ACCENT;
   const typeInfo = types.find((t) => t.type === model.type);
   const command = getDownloadCommand(model, selectedVariant);
 
@@ -572,17 +515,14 @@ const ModelDetailSheet: React.FC<{
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
       <SheetContent className="w-full sm:max-w-md overflow-y-auto p-0">
-        {/* Header with gradient accent */}
+        {/* Header */}
         <div className={cn("relative px-6 pt-6 pb-5", "border-b border-border/50")}>
-          {/* Subtle gradient background */}
-          <div className={cn("absolute inset-0 opacity-[0.03] dark:opacity-[0.06]", accent.bg)} />
-
           <SheetHeader className="relative">
             <div className="flex items-start gap-3.5">
               <div
                 className={cn(
-                  "flex items-center justify-center w-11 h-11 rounded-lg",
-                  "bg-background border shadow-sm",
+                  "flex items-center justify-center w-11 h-11 rounded-none",
+                  "bg-background border",
                   accent.border
                 )}
               >
@@ -602,10 +542,10 @@ const ModelDetailSheet: React.FC<{
             <div className="flex items-center gap-2 mt-4">
               <span
                 className={cn(
-                  "inline-flex items-center gap-1.5 px-2 py-1 rounded-md text-xs font-medium border",
+                  "inline-flex items-center gap-1.5 px-2 py-1 rounded-none text-xs font-mono border",
                   accent.text,
                   accent.border,
-                  "bg-background"
+                  "bg-muted"
                 )}
               >
                 <Icon className="w-3 h-3" />
@@ -613,19 +553,19 @@ const ModelDetailSheet: React.FC<{
               </span>
 
               {model.inRegistry ? (
-                <span className="inline-flex items-center gap-1 px-2 py-1 rounded-md text-xs font-medium bg-success-500/10 text-success-600 dark:text-success-400 border border-success-500/20">
+                <span className="inline-flex items-center gap-1 px-2 py-1 rounded-none text-xs font-medium bg-success-500/10 text-success-600 dark:text-success-400 border border-success-500/20">
                   <Zap className="w-3 h-3" />
                   Ready
                 </span>
               ) : (
-                <span className="inline-flex items-center gap-1 px-2 py-1 rounded-md text-xs bg-muted text-muted-foreground border border-border">
+                <span className="inline-flex items-center gap-1 px-2 py-1 rounded-none text-xs bg-muted text-muted-foreground border border-border">
                   <Package className="w-3 h-3" />
                   Export
                 </span>
               )}
 
               {model.size && (
-                <span className="px-2 py-1 rounded-md text-xs font-mono text-muted-foreground bg-muted/50 border border-border/50">
+                <span className="px-2 py-1 rounded-none text-xs font-mono text-muted-foreground bg-muted/50 border border-border/50">
                   {model.size}
                 </span>
               )}
@@ -653,8 +593,8 @@ const ModelDetailSheet: React.FC<{
                   <span
                     key={cap}
                     className={cn(
-                      "inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs border",
-                      CAPABILITY_STYLES[cap]
+                      "inline-flex items-center gap-1 px-2 py-0.5 rounded-none text-xs font-mono border",
+                      CAPABILITY_CHIP
                     )}
                   >
                     <Check className="w-3 h-3" />
@@ -667,11 +607,11 @@ const ModelDetailSheet: React.FC<{
 
           {/* Download Configuration */}
           {!canShowDownloadCommand ? (
-            <div className="rounded-lg border border-border bg-muted/30 px-4 py-3">
+            <div className="rounded-none border border-border bg-muted/30 px-4 py-3">
               <p className="text-xs text-muted-foreground">
                 {model.sourceUrl ? (
                   <>
-                    Use <code className="font-mono bg-muted px-1 py-0.5 rounded">termite pull</code>{" "}
+                    Use <code className="font-mono bg-muted px-1 py-0.5 rounded-none">termite pull</code>{" "}
                     CLI or the Termite operator to manage models in production deployments.
                   </>
                 ) : (
@@ -680,7 +620,7 @@ const ModelDetailSheet: React.FC<{
               </p>
             </div>
           ) : (
-            <div className="rounded-lg border border-border bg-muted/30 overflow-hidden">
+            <div className="rounded-none border border-border bg-muted/30 overflow-hidden">
               {/* Preset selector */}
               <div className="px-4 py-3 border-b border-border/50">
                 <h4 className="text-xs font-medium text-foreground mb-3">Download variant</h4>
@@ -704,9 +644,9 @@ const ModelDetailSheet: React.FC<{
                           }
                         }}
                         className={cn(
-                          "flex-1 min-w-[100px] px-3 py-2 rounded-lg text-left transition-all",
+                          "flex-1 min-w-[100px] px-3 py-2 rounded-none text-left transition-all",
                           isSelected
-                            ? "bg-foreground text-background shadow-sm"
+                            ? "bg-foreground text-background"
                             : isAvailable
                               ? "bg-background text-foreground border border-border hover:border-foreground/30"
                               : "bg-muted/50 text-muted-foreground/50 border border-border/50 cursor-not-allowed"
@@ -767,7 +707,7 @@ const ModelDetailSheet: React.FC<{
                             setSelectedPreset(null);
                           }}
                           className={cn(
-                            "px-2.5 py-1.5 rounded text-xs text-left transition-all",
+                            "px-2.5 py-1.5 rounded-none text-xs text-left transition-all",
                             selectedVariant === variant.type && selectedPreset === null
                               ? "bg-foreground text-background"
                               : selectedVariant === variant.type
@@ -788,9 +728,9 @@ const ModelDetailSheet: React.FC<{
 
               {/* Command block */}
               <div className="relative">
-                <div className="px-4 py-3 bg-searchaf-11 dark:bg-searchaf-2">
+                <div className="px-4 py-3 bg-muted border border-border">
                   <div className="flex items-start justify-between gap-2">
-                    <code className="text-xs font-mono text-searchaf-1 dark:text-searchaf-11 break-all leading-relaxed">
+                    <code className="text-xs font-mono text-foreground break-all leading-relaxed">
                       {command}
                     </code>
                     <button
@@ -798,9 +738,9 @@ const ModelDetailSheet: React.FC<{
                       onClick={handleCopyCommand}
                       aria-label={copiedCommand ? "Copied!" : "Copy command"}
                       className={cn(
-                        "shrink-0 p-1.5 rounded transition-colors",
-                        "text-searchaf-6 hover:text-searchaf-1 dark:text-searchaf-6 dark:hover:text-searchaf-11",
-                        "hover:bg-searchaf-9/20 dark:hover:bg-searchaf-4/30"
+                        "shrink-0 p-1.5 rounded-none transition-colors",
+                        "text-muted-foreground hover:text-foreground",
+                        "hover:bg-muted"
                       )}
                     >
                       {copiedCommand ? (
@@ -815,7 +755,7 @@ const ModelDetailSheet: React.FC<{
                 {/* Copy feedback toast */}
                 <div
                   className={cn(
-                    "absolute inset-x-4 bottom-full mb-2 py-1.5 px-2 rounded bg-foreground text-background text-xs text-center",
+                    "absolute inset-x-4 bottom-full mb-2 py-1.5 px-2 rounded-none bg-foreground text-background text-xs text-center",
                     "transition-all duration-200",
                     copiedCommand
                       ? "opacity-100 translate-y-0"
@@ -877,7 +817,7 @@ const ModelDetailSheet: React.FC<{
               target="_blank"
               rel="noopener noreferrer"
               className={cn(
-                "flex items-center justify-center gap-2 w-full py-2.5 rounded-lg",
+                "flex items-center justify-center gap-2 w-full py-2.5 rounded-none",
                 "text-sm text-muted-foreground hover:text-foreground",
                 "border border-border hover:border-foreground/20",
                 "transition-colors"
@@ -901,11 +841,11 @@ const TypeContextBanner: React.FC<{
   const Icon = MODEL_TYPE_ICONS[selectedType];
 
   return (
-    <div className="relative isolate mb-8 rounded-xl border border-border overflow-hidden">
+    <div className="relative isolate mb-8 rounded-none border border-border overflow-hidden">
       <GraphPaperBg className="absolute inset-0 -z-10" />
       <div className="p-5">
         <div className="flex items-start gap-4">
-          <div className="flex items-center justify-center w-9 h-9 rounded-lg bg-muted shrink-0">
+          <div className="flex items-center justify-center w-9 h-9 rounded-none bg-muted shrink-0">
             <Icon className="w-4 h-4 text-muted-foreground" />
           </div>
           <div className="flex-1 min-w-0">
@@ -1065,25 +1005,25 @@ const ModelsPage: React.FC = () => {
       <DashboardPage>
         <DashboardPageHeader>
           <div>
-            <div className="mb-3 h-7 w-64 animate-pulse rounded-lg bg-muted" />
-            <div className="h-4 w-full max-w-md animate-pulse rounded-lg bg-muted" />
+            <div className="mb-3 h-7 w-64 animate-pulse rounded-none bg-muted" />
+            <div className="h-4 w-full max-w-md animate-pulse rounded-none bg-muted" />
           </div>
         </DashboardPageHeader>
         <div className="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-4">
           {Array.from({ length: 6 }).map((_, i) => (
             // biome-ignore lint/suspicious/noArrayIndexKey: skeleton placeholders are positional
-            <div key={i} className="bg-card border border-border rounded-xl p-5">
+            <div key={i} className="bg-card border border-border rounded-none p-5">
               <div className="flex items-start gap-3 mb-3">
-                <div className="w-10 h-10 bg-muted animate-pulse rounded-lg" />
+                <div className="w-10 h-10 bg-muted animate-pulse rounded-none" />
                 <div className="flex-1">
-                  <div className="h-5 w-32 bg-muted animate-pulse rounded mb-2" />
-                  <div className="h-3 w-24 bg-muted animate-pulse rounded" />
+                  <div className="h-5 w-32 bg-muted animate-pulse rounded-none mb-2" />
+                  <div className="h-3 w-24 bg-muted animate-pulse rounded-none" />
                 </div>
               </div>
-              <div className="h-10 bg-muted animate-pulse rounded mb-4" />
+              <div className="h-10 bg-muted animate-pulse rounded-none mb-4" />
               <div className="flex gap-2">
-                <div className="h-5 w-16 bg-muted animate-pulse rounded" />
-                <div className="h-5 w-12 bg-muted animate-pulse rounded" />
+                <div className="h-5 w-16 bg-muted animate-pulse rounded-none" />
+                <div className="h-5 w-12 bg-muted animate-pulse rounded-none" />
               </div>
             </div>
           ))}
@@ -1165,7 +1105,7 @@ const ModelsPage: React.FC = () => {
             onClick={() => setSelectedType("all")}
             aria-pressed={selectedType === "all"}
             className={cn(
-              "px-3 py-1.5 rounded-md text-sm transition-colors",
+              "px-3 py-1.5 rounded-none text-sm transition-colors",
               selectedType === "all"
                 ? "bg-foreground text-background"
                 : "text-muted-foreground hover:text-foreground hover:bg-muted"

--- a/ts/apps/antfarm/src/pages/NERPlaygroundPage.tsx
+++ b/ts/apps/antfarm/src/pages/NERPlaygroundPage.tsx
@@ -719,7 +719,7 @@ const RecognizePlaygroundPage: React.FC = () => {
       elements.push(
         <span
           key={`entity-${entity.label}-${entity.start}-${entity.end}`}
-          className={`${colors.bg} ${colors.border} rounded px-1 py-0.5 border cursor-help`}
+          className={`${colors.bg} ${colors.border} rounded-none px-1 py-0.5 border cursor-help`}
           title={`${entity.label}: ${(entity.score * 100).toFixed(1)}% confidence`}
         >
           {entity.text}
@@ -789,7 +789,7 @@ const RecognizePlaygroundPage: React.FC = () => {
                 {(instances as Record<string, unknown>[]).map((instance) => (
                   <div
                     key={`${structName}-${Object.keys(instance).join("-")}`}
-                    className="p-3 bg-muted/50 rounded-lg border text-sm space-y-1"
+                    className="p-3 bg-muted/50 rounded-none border text-sm space-y-1"
                   >
                     {Object.entries(instance).map(([fieldName, fieldValue]) => {
                       // Handle both single ExtractFieldValue and arrays
@@ -1052,7 +1052,7 @@ const RecognizePlaygroundPage: React.FC = () => {
               {schema.map((structure, si) => (
                 <div
                   key={`structure-${structure.name || `unnamed-${structure.fields.length}`}`}
-                  className="p-3 bg-muted/30 rounded-lg border space-y-2"
+                  className="p-3 bg-muted/30 rounded-none border space-y-2"
                 >
                   <div className="flex items-center gap-2">
                     <Input
@@ -1157,7 +1157,7 @@ const RecognizePlaygroundPage: React.FC = () => {
 
       {/* Error Display */}
       {error && (
-        <div className="rounded-lg border border-destructive/30 bg-destructive/10 p-4 text-sm text-destructive">
+        <div className="rounded-none border border-destructive/30 bg-destructive/10 p-4 text-sm text-destructive">
           {error}
         </div>
       )}
@@ -1265,7 +1265,7 @@ const RecognizePlaygroundPage: React.FC = () => {
                   )}
 
                   {/* Highlighted text view */}
-                  <div className="p-3 bg-muted/50 rounded-lg border max-h-37.5 overflow-y-auto">
+                  <div className="p-3 bg-muted/50 rounded-none border max-h-37.5 overflow-y-auto">
                     {renderHighlightedText()}
                   </div>
 
@@ -1274,7 +1274,7 @@ const RecognizePlaygroundPage: React.FC = () => {
                   {/* Entity list */}
                   <div className="space-y-2">
                     {getFilteredEntities().length > 0 ? (
-                      <div className="rounded-lg border overflow-hidden">
+                      <div className="rounded-none border overflow-hidden">
                         <table className="w-full text-sm">
                           <thead className="bg-muted/50">
                             <tr>
@@ -1326,7 +1326,9 @@ const RecognizePlaygroundPage: React.FC = () => {
                     <Tag className="h-12 w-12 mx-auto mb-3 opacity-20" />
                     <p className="mb-3">
                       Enter text and press{" "}
-                      <kbd className="px-1.5 py-0.5 text-xs border rounded bg-muted">Cmd+Enter</kbd>{" "}
+                      <kbd className="px-1.5 py-0.5 text-xs border rounded-none bg-muted">
+                        Cmd+Enter
+                      </kbd>{" "}
                       to extract entities
                     </p>
                     <Button

--- a/ts/apps/antfarm/src/pages/QuestionPlaygroundPage.tsx
+++ b/ts/apps/antfarm/src/pages/QuestionPlaygroundPage.tsx
@@ -334,7 +334,7 @@ const RewritingPlaygroundPage: React.FC = () => {
           return part.toLowerCase() === answer.toLowerCase() ? (
             <span
               key={key}
-              className="bg-yellow-200 dark:bg-yellow-900/50 text-yellow-900 dark:text-yellow-100 px-1 rounded"
+              className="bg-amber-200 dark:bg-amber-900/50 text-amber-900 dark:text-amber-100 px-1 rounded-none"
             >
               {part}
             </span>
@@ -438,7 +438,7 @@ const RewritingPlaygroundPage: React.FC = () => {
 
       {/* Error Display */}
       {error && (
-        <div className="rounded-lg border border-destructive/30 bg-destructive/10 p-4 text-sm text-destructive">
+        <div className="rounded-none border border-destructive/30 bg-destructive/10 p-4 text-sm text-destructive">
           {error}
         </div>
       )}
@@ -516,7 +516,7 @@ const RewritingPlaygroundPage: React.FC = () => {
                     textArray.map((question) => (
                       <div
                         key={`q-${question}`}
-                        className="p-4 bg-primary/5 border border-primary/20 rounded-lg"
+                        className="p-4 bg-primary/5 border border-primary/20 rounded-none"
                       >
                         <div className="flex items-start gap-3">
                           <MessageCircle className="h-5 w-5 text-primary mt-0.5 shrink-0" />
@@ -543,7 +543,7 @@ const RewritingPlaygroundPage: React.FC = () => {
                   <Label className="text-sm text-muted-foreground">
                     Context (answer highlighted)
                   </Label>
-                  <div className="p-3 bg-muted/50 rounded-lg border text-sm leading-relaxed">
+                  <div className="p-3 bg-muted/50 rounded-none border text-sm leading-relaxed">
                     {renderHighlightedContext()}
                   </div>
                 </div>
@@ -551,7 +551,7 @@ const RewritingPlaygroundPage: React.FC = () => {
                 {/* Answer */}
                 <div className="space-y-2">
                   <Label className="text-sm text-muted-foreground">Target Answer</Label>
-                  <div className="p-3 bg-yellow-100 dark:bg-yellow-900/30 rounded-lg border border-yellow-300 dark:border-yellow-700 text-sm font-medium">
+                  <div className="p-3 bg-amber-100 dark:bg-amber-900/30 rounded-none border border-amber-300 dark:border-amber-700 text-sm font-medium">
                     {answer}
                   </div>
                 </div>
@@ -587,7 +587,7 @@ const RewritingPlaygroundPage: React.FC = () => {
           </DialogHeader>
           <div className="space-y-4 py-4">
             {/* Show the Q+A pair */}
-            <div className="space-y-2 p-3 bg-muted/50 rounded-lg text-sm">
+            <div className="space-y-2 p-3 bg-muted/50 rounded-none text-sm">
               <div>
                 <span className="font-medium">Q:</span> {selectedQuestion}
               </div>

--- a/ts/apps/antfarm/src/pages/RagPlaygroundPage.tsx
+++ b/ts/apps/antfarm/src/pages/RagPlaygroundPage.tsx
@@ -101,7 +101,7 @@ function ErrorDisplay({ message }: { message: string }) {
     isLong && !expanded ? `${message.slice(0, ERROR_TRUNCATE_LENGTH)}...` : message;
 
   return (
-    <div className="mb-4 p-4 bg-destructive/10 border border-destructive/30 rounded-lg text-destructive text-sm">
+    <div className="mb-4 p-4 bg-destructive/10 border border-destructive/30 rounded-none text-destructive text-sm">
       {displayText}
       {isLong && (
         <button
@@ -439,7 +439,7 @@ const RagPlaygroundPage: React.FC = () => {
             </div>
           )}
           renderClassification={(data) => (
-            <div className="p-3 rounded-lg bg-muted/50 space-y-2">
+            <div className="p-3 rounded-none bg-muted/50 space-y-2">
               <div className="flex items-center gap-2 text-sm font-medium">
                 <Sparkles className="h-4 w-4" />
                 Classification
@@ -461,7 +461,7 @@ const RagPlaygroundPage: React.FC = () => {
                 </div>
               )}
               {data.reasoning && (
-                <div className="text-xs text-muted-foreground mt-2 p-2 bg-background rounded">
+                <div className="text-xs text-muted-foreground mt-2 p-2 bg-background rounded-none">
                   {data.reasoning}
                 </div>
               )}
@@ -519,7 +519,7 @@ const RagPlaygroundPage: React.FC = () => {
               </CollapsibleTrigger>
               <CollapsibleContent className="space-y-2 mt-2">
                 {hits.map((hit, i) => (
-                  <div key={hit._id || i} className="p-3 rounded-lg border text-xs space-y-1">
+                  <div key={hit._id || i} className="p-3 rounded-none border text-xs space-y-1">
                     <div className="flex items-center justify-between">
                       <span className="font-medium">{hit._id}</span>
                       <Badge variant="secondary" className="text-xs">
@@ -712,7 +712,7 @@ const RagPlaygroundPage: React.FC = () => {
                       <Label className="text-sm font-medium">Pipeline Steps</Label>
 
                       {/* Classification */}
-                      <div className="flex items-center justify-between p-3 rounded-lg border">
+                      <div className="flex items-center justify-between p-3 rounded-none border">
                         <div className="flex items-center gap-3">
                           <Sparkles className="h-4 w-4 text-muted-foreground" />
                           <div>
@@ -751,7 +751,7 @@ const RagPlaygroundPage: React.FC = () => {
                       </div>
 
                       {/* Follow-up */}
-                      <div className="flex items-center justify-between p-3 rounded-lg border">
+                      <div className="flex items-center justify-between p-3 rounded-none border">
                         <div className="flex items-center gap-3">
                           <HelpCircle className="h-4 w-4 text-muted-foreground" />
                           <div>
@@ -796,7 +796,7 @@ const RagPlaygroundPage: React.FC = () => {
                       </div>
 
                       {/* Confidence */}
-                      <div className="flex items-center justify-between p-3 rounded-lg border">
+                      <div className="flex items-center justify-between p-3 rounded-none border">
                         <div className="flex items-center gap-3">
                           <Target className="h-4 w-4 text-muted-foreground" />
                           <div>

--- a/ts/apps/antfarm/src/pages/ReaderPlaygroundPage.tsx
+++ b/ts/apps/antfarm/src/pages/ReaderPlaygroundPage.tsx
@@ -469,7 +469,7 @@ const ReaderPlaygroundPage: React.FC = () => {
 
         {/* Error */}
         {error && (
-          <div className="p-4 bg-destructive/10 border border-destructive/30 rounded-lg text-destructive text-sm">
+          <div className="p-4 bg-destructive/10 border border-destructive/30 rounded-none text-destructive text-sm">
             {error}
           </div>
         )}
@@ -504,7 +504,7 @@ const ReaderPlaygroundPage: React.FC = () => {
             <CardContent className="flex-1 space-y-4">
               {/* Drop zone */}
               <div
-                className={`border-2 border-dashed rounded-lg p-8 text-center cursor-pointer transition-colors ${
+                className={`border-2 border-dashed rounded-none p-8 text-center cursor-pointer transition-colors ${
                   isDraggingImage
                     ? "border-primary bg-primary/5"
                     : "border-muted-foreground/25 hover:border-primary/50"
@@ -546,7 +546,7 @@ const ReaderPlaygroundPage: React.FC = () => {
                   {images.map((img, idx) => (
                     <div
                       key={img.id}
-                      className={`relative group cursor-pointer rounded-md overflow-hidden border-2 transition-all ${
+                      className={`relative group cursor-pointer rounded-none overflow-hidden border-2 transition-all ${
                         selectedImageIndex === idx
                           ? "border-primary ring-2 ring-primary/30"
                           : "border-transparent hover:border-muted-foreground/30"
@@ -579,7 +579,7 @@ const ReaderPlaygroundPage: React.FC = () => {
 
               {/* Selected image preview */}
               {images.length > 0 && images[selectedImageIndex] && (
-                <div className="rounded-lg overflow-hidden border bg-muted/20">
+                <div className="rounded-none overflow-hidden border bg-muted/20">
                   <img
                     src={images[selectedImageIndex].dataUri}
                     alt={images[selectedImageIndex].name}
@@ -634,7 +634,7 @@ const ReaderPlaygroundPage: React.FC = () => {
                           <Copy className="h-3 w-3" />
                           {copiedId === "ocr-text" ? "Copied!" : "Copy"}
                         </Button>
-                        <pre className="p-4 pr-20 bg-muted/30 rounded-lg border text-sm font-mono whitespace-pre-wrap max-h-[500px] overflow-y-auto">
+                        <pre className="p-4 pr-20 bg-muted/30 rounded-none border text-sm font-mono whitespace-pre-wrap max-h-[500px] overflow-y-auto">
                           {currentResult.text || "(no text extracted)"}
                         </pre>
                       </div>
@@ -642,7 +642,7 @@ const ReaderPlaygroundPage: React.FC = () => {
 
                     {hasFields && (
                       <TabsContent value="fields" className="mt-3">
-                        <div className="border rounded-lg overflow-hidden">
+                        <div className="border rounded-none overflow-hidden">
                           <table className="w-full text-sm">
                             <thead>
                               <tr className="border-b bg-muted/30">
@@ -679,7 +679,7 @@ const ReaderPlaygroundPage: React.FC = () => {
                           </Label>
                         </div>
                         {images[selectedImageIndex] && (
-                          <div className="relative rounded-lg overflow-hidden border bg-muted/20 inline-block max-w-full">
+                          <div className="relative rounded-none overflow-hidden border bg-muted/20 inline-block max-w-full">
                             <img
                               src={images[selectedImageIndex].dataUri}
                               alt="regions overlay"
@@ -695,21 +695,16 @@ const ReaderPlaygroundPage: React.FC = () => {
                                 const width = (w / img.width) * 100;
                                 const height = (h / img.height) * 100;
 
-                                const colors = [
-                                  "border-red-500",
-                                  "border-blue-500",
-                                  "border-green-500",
-                                  "border-yellow-500",
-                                  "border-purple-500",
-                                  "border-pink-500",
-                                ];
-                                const color = colors[rIdx % colors.length];
+                                // Cycle the categorical chart palette so each
+                                // region stays distinguishable without raw hues.
+                                const regionColor = `var(--chart-series-${(rIdx % 6) + 1})`;
 
                                 return (
                                   <div
                                     key={`region-${region.bbox.join("-")}-${region.text.slice(0, 20)}`}
-                                    className={`absolute border-2 ${color} pointer-events-none`}
+                                    className="absolute border-2 pointer-events-none"
                                     style={{
+                                      borderColor: regionColor,
                                       left: `${left}%`,
                                       top: `${top}%`,
                                       width: `${width}%`,
@@ -723,7 +718,7 @@ const ReaderPlaygroundPage: React.FC = () => {
                         )}
 
                         {/* Regions table */}
-                        <div className="border rounded-lg overflow-hidden max-h-60 overflow-y-auto">
+                        <div className="border rounded-none overflow-hidden max-h-60 overflow-y-auto">
                           <table className="w-full text-sm">
                             <thead>
                               <tr className="border-b bg-muted/30">
@@ -777,7 +772,7 @@ const ReaderPlaygroundPage: React.FC = () => {
                           <Copy className="h-3 w-3" />
                           {copiedId === "ocr-json" ? "Copied!" : "Copy"}
                         </Button>
-                        <pre className="p-4 pr-20 bg-muted/30 rounded-lg border text-xs font-mono whitespace-pre-wrap max-h-[500px] overflow-y-auto">
+                        <pre className="p-4 pr-20 bg-muted/30 rounded-none border text-xs font-mono whitespace-pre-wrap max-h-[500px] overflow-y-auto">
                           {JSON.stringify(currentResult, null, 2)}
                         </pre>
                       </div>

--- a/ts/apps/antfarm/src/pages/RerankingPlaygroundPage.tsx
+++ b/ts/apps/antfarm/src/pages/RerankingPlaygroundPage.tsx
@@ -438,7 +438,7 @@ const RerankingPlaygroundPage: React.FC = () => {
 
       {/* Error Display */}
       {error && (
-        <div className="rounded-lg border border-destructive/30 bg-destructive/10 p-4 text-sm text-destructive">
+        <div className="rounded-none border border-destructive/30 bg-destructive/10 p-4 text-sm text-destructive">
           {error}
         </div>
       )}
@@ -516,7 +516,7 @@ const RerankingPlaygroundPage: React.FC = () => {
                   const barWidth = maxScore > 0 ? Math.max(2, (doc.score / maxScore) * 100) : 0;
 
                   return (
-                    <div key={doc.index} className="p-3 bg-muted/30 rounded-lg border space-y-2">
+                    <div key={doc.index} className="p-3 bg-muted/30 rounded-none border space-y-2">
                       <div className="flex items-center gap-2">
                         <span className="flex items-center justify-center w-6 h-6 rounded-full bg-primary/10 text-primary text-xs font-bold shrink-0">
                           {doc.rank}

--- a/ts/apps/antfarm/src/pages/TableDetailsPage.tsx
+++ b/ts/apps/antfarm/src/pages/TableDetailsPage.tsx
@@ -696,7 +696,7 @@ const TableDetailsPage: React.FC<TableDetailsPageProps> = ({ currentSection = "i
 
                   <Accordion type="multiple" defaultValue={["semantic"]} className="space-y-2">
                     {/* Field Selection - Collapsible */}
-                    <AccordionItem value="fields" className="border rounded-lg bg-card/50 px-3">
+                    <AccordionItem value="fields" className="border rounded-none bg-card/50 px-3">
                       <AccordionTrigger className="py-2.5 hover:no-underline">
                         <div className="flex items-center gap-2">
                           <span className="font-medium text-sm">Field Selection</span>
@@ -744,7 +744,7 @@ const TableDetailsPage: React.FC<TableDetailsPageProps> = ({ currentSection = "i
                     </AccordionItem>
 
                     {/* Semantic Search */}
-                    <AccordionItem value="semantic" className="border rounded-lg bg-card/50 px-3">
+                    <AccordionItem value="semantic" className="border rounded-none bg-card/50 px-3">
                       <AccordionTrigger className="py-2.5 hover:no-underline">
                         <span className="font-medium text-sm">Semantic Search</span>
                       </AccordionTrigger>
@@ -812,7 +812,7 @@ const TableDetailsPage: React.FC<TableDetailsPageProps> = ({ currentSection = "i
                     </AccordionItem>
 
                     {/* Full-Text Search */}
-                    <AccordionItem value="filter" className="border rounded-lg bg-card/50 px-3">
+                    <AccordionItem value="filter" className="border rounded-none bg-card/50 px-3">
                       <AccordionTrigger className="py-2.5 hover:no-underline">
                         <span className="font-medium text-sm">Full-Text Search</span>
                       </AccordionTrigger>
@@ -898,7 +898,7 @@ const TableDetailsPage: React.FC<TableDetailsPageProps> = ({ currentSection = "i
             )}
 
             {queryResult && (
-              <Card className="shadow-sm">
+              <Card>
                 <CardHeader>
                   <CardTitle>Query Results</CardTitle>
                 </CardHeader>

--- a/ts/apps/antfarm/src/pages/TablesListPage.tsx
+++ b/ts/apps/antfarm/src/pages/TablesListPage.tsx
@@ -181,7 +181,7 @@ const TablesListPage: React.FC = () => {
   return (
     <DashboardPage>
       <div className="relative isolate">
-        <GraphPaperBg className="absolute inset-0 -z-10 rounded-xl" />
+        <GraphPaperBg className="absolute inset-0 -z-10 rounded-none" />
         <DashboardPageHeader>
           <div>
             <DashboardPageTitle className="font-aeonik">Tables</DashboardPageTitle>

--- a/ts/apps/antfarm/src/pages/TranscribePlaygroundPage.tsx
+++ b/ts/apps/antfarm/src/pages/TranscribePlaygroundPage.tsx
@@ -641,7 +641,7 @@ const TranscribePlaygroundPage: React.FC = () => {
 
               <div className="space-y-2">
                 <Label>Input Source</Label>
-                <div className="flex rounded-md border overflow-hidden h-9">
+                <div className="flex rounded-none border overflow-hidden h-9">
                   <button
                     type="button"
                     className={`flex-1 flex items-center justify-center gap-1.5 text-sm transition-colors ${
@@ -873,7 +873,7 @@ const TranscribePlaygroundPage: React.FC = () => {
 
         {/* Error */}
         {error && (
-          <div className="p-4 bg-destructive/10 border border-destructive/30 rounded-lg text-destructive text-sm">
+          <div className="p-4 bg-destructive/10 border border-destructive/30 rounded-none text-destructive text-sm">
             {error}
           </div>
         )}
@@ -918,7 +918,7 @@ const TranscribePlaygroundPage: React.FC = () => {
                 <>
                   {/* Drop zone */}
                   <div
-                    className={`border-2 border-dashed rounded-lg p-8 text-center cursor-pointer transition-colors ${
+                    className={`border-2 border-dashed rounded-none p-8 text-center cursor-pointer transition-colors ${
                       isDraggingAudio
                         ? "border-primary bg-primary/5"
                         : "border-muted-foreground/25 hover:border-primary/50"
@@ -957,15 +957,15 @@ const TranscribePlaygroundPage: React.FC = () => {
                 </>
               ) : (
                 /* Mic recording */
-                <div className="border-2 border-dashed rounded-lg p-8 text-center transition-colors border-muted-foreground/25">
+                <div className="border-2 border-dashed rounded-none p-8 text-center transition-colors border-muted-foreground/25">
                   {isRecording ? (
                     <div className="space-y-4">
                       <div className="flex items-center justify-center gap-2">
                         <span className="relative flex h-3 w-3">
-                          <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-red-400 opacity-75" />
-                          <span className="relative inline-flex rounded-full h-3 w-3 bg-red-500" />
+                          <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-destructive opacity-75" />
+                          <span className="relative inline-flex rounded-full h-3 w-3 bg-destructive" />
                         </span>
-                        <span className="text-sm font-medium text-red-600">Recording</span>
+                        <span className="text-sm font-mono font-medium text-destructive">Recording</span>
                         <span className="text-sm font-mono text-muted-foreground">
                           {formatDuration(recordingDuration)}
                         </span>
@@ -992,7 +992,7 @@ const TranscribePlaygroundPage: React.FC = () => {
 
               {/* Audio file info & player */}
               {audioFile && !isRecording && (
-                <div className="p-4 bg-muted/30 rounded-lg border space-y-3">
+                <div className="p-4 bg-muted/30 rounded-none border space-y-3">
                   <div className="flex items-center justify-between">
                     <div className="flex items-center gap-2 min-w-0">
                       <Mic className="h-4 w-4 shrink-0 text-muted-foreground" />
@@ -1065,7 +1065,7 @@ const TranscribePlaygroundPage: React.FC = () => {
                   {segments.map((seg, i) => (
                     <div
                       key={`seg-${seg.startMs}-${seg.endMs}`}
-                      className="p-3 bg-muted/30 rounded-lg border space-y-2"
+                      className="p-3 bg-muted/30 rounded-none border space-y-2"
                     >
                       {/* Timestamp + copy */}
                       <div className="flex items-center justify-between">

--- a/ts/apps/antfarm/src/pages/TranscribePlaygroundPage.tsx
+++ b/ts/apps/antfarm/src/pages/TranscribePlaygroundPage.tsx
@@ -965,7 +965,9 @@ const TranscribePlaygroundPage: React.FC = () => {
                           <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-destructive opacity-75" />
                           <span className="relative inline-flex rounded-full h-3 w-3 bg-destructive" />
                         </span>
-                        <span className="text-sm font-mono font-medium text-destructive">Recording</span>
+                        <span className="text-sm font-mono font-medium text-destructive">
+                          Recording
+                        </span>
                         <span className="text-sm font-mono text-muted-foreground">
                           {formatDuration(recordingDuration)}
                         </span>

--- a/ts/apps/antfarm/src/pages/UsersPage.tsx
+++ b/ts/apps/antfarm/src/pages/UsersPage.tsx
@@ -535,7 +535,7 @@ export function UsersPage() {
                     {permissions.map((perm) => (
                       <div
                         key={`${perm.type}-${perm.resource_type}-${perm.resource}`}
-                        className="flex items-center justify-between rounded-lg border p-3"
+                        className="flex items-center justify-between rounded-none border p-3"
                       >
                         <div className="space-y-1">
                           <div className="flex items-center gap-2">


### PR DESCRIPTION
Brings the Antfarm dashboard into compliance with `@antfly/design-system@0.1.0`'s rebuilt visual language: square corners, flat (no shadows), 1.5px borders carrying hierarchy, a single amber accent (purple retired), and a mono-forward voice for chrome.

### What changed
- **SDK styles (`global.css`)** — squared and de-shadowed the `.react-af-*` search primitives (autosuggest, querybox, pagination, facets). Kept `bg-primary` (now amber). The 14px `@theme` scale and all `.af-chart-*` / `.af-status-*` utilities are untouched — they were already the target convention.
- **ModelsPage** (epicenter) — retired the multi-hue model-type / capability / hardware color systems for neutral mono chips (the category is already carried by icon + label), dropped the gradient header overlay and `shadow-sm` elevation, and swapped the `searchaf-*` download-command block to semantic muted/foreground tokens.
- **Categorical surfaces** — knowledge-graph node types and Reader region overlays now use the design-system `--chart-series` palette instead of raw hues (retiring the purple node color); graph edge selection uses amber `--primary`. The RAG pipeline edge/node states map to semantic tokens (active = amber, complete = receding muted / success flash, error = destructive). The Transcribe recording indicator is now semantic `destructive`.
- **Query chrome + everything else** — flattened the query-builder cards and table query card; squared every remaining `rounded-*` across all pages, playgrounds, results, schema-builder, rag, and chrome components (avatar / status-dot / ping `rounded-full` kept). Question-playground answer highlights moved from yellow to the amber accent.

### Verification
- `biome check` clean (139 files)
- `tsc --noEmit` clean
- `vite build` succeeds (9112 modules)
- grep gate: zero remaining non-`rounded-full` `rounded-*`, decorative `shadow-*`, `purple`/`violet`, `searchaf-*`, or raw state-color utilities in `ts/apps/antfarm/src` (brand-logo SVGs and grayscale canvas rendering excluded by design)

Storybook stories render the swept components; no story-level debt remained.