### PR TITLE
Bound SDK batch request and response bodies

### DIFF
--- a/go/pkg/sdk/client.go
+++ b/go/pkg/sdk/client.go
@@ -30,6 +30,8 @@ import (
 	"github.com/antflydb/antfly/go/pkg/sdk/oapi"
 )
 
+const maxErrorResponseBytes int64 = 1 << 20
+
 // Config configures the consolidated Antfly SDK.
 type Config struct {
 	// BaseURL is the Antfly server URL without a product prefix, for example
@@ -153,8 +155,24 @@ func (e *APIError) Error() string {
 	return e.Message
 }
 
+func readLimitedBody(r io.Reader, maxBytes int64) ([]byte, bool, error) {
+	if maxBytes <= 0 {
+		body, err := io.ReadAll(r)
+		return body, false, err
+	}
+
+	body, err := io.ReadAll(io.LimitReader(r, maxBytes+1))
+	if err != nil {
+		return nil, false, err
+	}
+	if int64(len(body)) <= maxBytes {
+		return body, false, nil
+	}
+	return body[:maxBytes], true, nil
+}
+
 func readErrorResponse(resp *http.Response) error {
-	respBody, err := io.ReadAll(resp.Body)
+	respBody, truncated, err := readLimitedBody(resp.Body, maxErrorResponseBytes)
 	if err != nil {
 		return fmt.Errorf("reading http response: %w", err)
 	}
@@ -171,8 +189,12 @@ func readErrorResponse(resp *http.Response) error {
 	}
 
 	// Fallback for non-JSON responses
+	message := string(respBody)
+	if truncated {
+		message = fmt.Sprintf("%s (response body exceeded %d bytes)", message, maxErrorResponseBytes)
+	}
 	return &APIError{
 		StatusCode: resp.StatusCode,
-		Message:    string(respBody),
+		Message:    message,
 	}
 }

--- a/go/pkg/sdk/operations.go
+++ b/go/pkg/sdk/operations.go
@@ -34,29 +34,29 @@ import (
 )
 
 const (
-	// DefaultBatchMaxRequestBytes bounds encoded SDK batch request bodies.
-	// Call BatchWithOptions or MultiBatchWithOptions with a larger value for
-	// intentionally large imports.
-	DefaultBatchMaxRequestBytes int64 = 64 << 20
-	// DefaultBatchMaxResponseBytes bounds batch write response bodies. Batch
-	// writes should return small count/error payloads, so large responses are
+	// DefaultWriteMaxRequestBytes bounds encoded SDK write request bodies.
+	// Call write APIs with options and a larger value for intentionally large
+	// imports.
+	DefaultWriteMaxRequestBytes int64 = 64 << 20
+	// DefaultWriteMaxResponseBytes bounds write API response bodies. These
+	// endpoints should return small count/error payloads, so large responses are
 	// treated as protocol errors.
-	DefaultBatchMaxResponseBytes int64 = 1 << 20
+	DefaultWriteMaxResponseBytes int64 = 1 << 20
 )
 
-// BatchOptions controls request and response bounds for batch write APIs.
+// WriteOptions controls request and response bounds for write APIs.
 // Non-positive values use SDK defaults.
-type BatchOptions struct {
+type WriteOptions struct {
 	MaxRequestBytes  int64
 	MaxResponseBytes int64
 }
 
-func normalizeBatchOptions(opts BatchOptions) BatchOptions {
+func normalizeWriteOptions(opts WriteOptions) WriteOptions {
 	if opts.MaxRequestBytes <= 0 {
-		opts.MaxRequestBytes = DefaultBatchMaxRequestBytes
+		opts.MaxRequestBytes = DefaultWriteMaxRequestBytes
 	}
 	if opts.MaxResponseBytes <= 0 {
-		opts.MaxResponseBytes = DefaultBatchMaxResponseBytes
+		opts.MaxResponseBytes = DefaultWriteMaxResponseBytes
 	}
 	return opts
 }
@@ -179,13 +179,13 @@ func (c *AntflyClient) Query(ctx context.Context, opts ...QueryRequest) (*QueryR
 
 // Batch performs a batch operation on a table
 func (c *AntflyClient) Batch(ctx context.Context, tableName string, request BatchRequest) (*BatchResult, error) {
-	return c.BatchWithOptions(ctx, tableName, request, BatchOptions{})
+	return c.BatchWithOptions(ctx, tableName, request, WriteOptions{})
 }
 
 // BatchWithOptions performs a batch operation on a table with request and
 // response size bounds.
-func (c *AntflyClient) BatchWithOptions(ctx context.Context, tableName string, request BatchRequest, opts BatchOptions) (*BatchResult, error) {
-	opts = normalizeBatchOptions(opts)
+func (c *AntflyClient) BatchWithOptions(ctx context.Context, tableName string, request BatchRequest, opts WriteOptions) (*BatchResult, error) {
+	opts = normalizeWriteOptions(opts)
 	batchBody, closeBody := jsonBodyReader(request, opts.MaxRequestBytes)
 	defer closeBody()
 
@@ -234,7 +234,17 @@ func (c *AntflyClient) BatchWithOptions(ctx context.Context, tableName string, r
 // WARNING: Not safe for concurrent merge operations with overlapping ranges.
 // Designed as a sync/import API for single-client use.
 func (c *AntflyClient) LinearMerge(ctx context.Context, tableName string, request LinearMergeRequest) (*LinearMergeResult, error) {
-	resp, err := c.client.LinearMerge(ctx, tableName, request)
+	return c.LinearMergeWithOptions(ctx, tableName, request, WriteOptions{})
+}
+
+// LinearMergeWithOptions performs a stateless linear merge with request and
+// response size bounds.
+func (c *AntflyClient) LinearMergeWithOptions(ctx context.Context, tableName string, request LinearMergeRequest, opts WriteOptions) (*LinearMergeResult, error) {
+	opts = normalizeWriteOptions(opts)
+	body, closeBody := jsonBodyReader(request, opts.MaxRequestBytes)
+	defer closeBody()
+
+	resp, err := c.client.LinearMergeWithBody(ctx, tableName, "application/json", body)
 	if err != nil {
 		return nil, fmt.Errorf("linear merge operation failed: %w", err)
 	}
@@ -244,9 +254,12 @@ func (c *AntflyClient) LinearMerge(ctx context.Context, tableName string, reques
 		return nil, fmt.Errorf("linear merge failed: %w", readErrorResponse(resp))
 	}
 
-	respBody, err := io.ReadAll(resp.Body)
+	respBody, truncated, err := readLimitedBody(resp.Body, opts.MaxResponseBytes)
 	if err != nil {
 		return nil, fmt.Errorf("reading response body: %w", err)
+	}
+	if truncated {
+		return nil, fmt.Errorf("linear merge response exceeded %d bytes", opts.MaxResponseBytes)
 	}
 
 	var result LinearMergeResult
@@ -672,13 +685,13 @@ func (c *AntflyClient) RetrievalAgent(ctx context.Context, req RetrievalAgentReq
 
 // MultiBatch performs a cross-table batch operation atomically.
 func (c *AntflyClient) MultiBatch(ctx context.Context, request MultiBatchRequest) (*MultiBatchResult, error) {
-	return c.MultiBatchWithOptions(ctx, request, BatchOptions{})
+	return c.MultiBatchWithOptions(ctx, request, WriteOptions{})
 }
 
 // MultiBatchWithOptions performs a cross-table batch operation atomically with
 // request and response size bounds.
-func (c *AntflyClient) MultiBatchWithOptions(ctx context.Context, request MultiBatchRequest, opts BatchOptions) (*MultiBatchResult, error) {
-	opts = normalizeBatchOptions(opts)
+func (c *AntflyClient) MultiBatchWithOptions(ctx context.Context, request MultiBatchRequest, opts WriteOptions) (*MultiBatchResult, error) {
+	opts = normalizeWriteOptions(opts)
 	batchBody, closeBody := jsonBodyReader(request, opts.MaxRequestBytes)
 	defer closeBody()
 

--- a/go/pkg/sdk/operations.go
+++ b/go/pkg/sdk/operations.go
@@ -88,20 +88,16 @@ func (w *limitedWriter) Write(p []byte) (int, error) {
 	return n, err
 }
 
-func jsonBodyReader(v any, maxBytes int64) (*io.PipeReader, func()) {
-	pr, pw := io.Pipe()
-	go func() {
-		w := io.Writer(pw)
-		if maxBytes > 0 {
-			w = &limitedWriter{w: pw, max: maxBytes}
-		}
-		if err := json.NewEncoder(w).Encode(v); err != nil {
-			_ = pw.CloseWithError(err)
-			return
-		}
-		_ = pw.Close()
-	}()
-	return pr, func() { _ = pr.Close() }
+func boundedJSONBody(v any, maxBytes int64) (*bytes.Buffer, error) {
+	var body bytes.Buffer
+	w := io.Writer(&body)
+	if maxBytes > 0 {
+		w = &limitedWriter{w: &body, max: maxBytes}
+	}
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		return nil, err
+	}
+	return &body, nil
 }
 
 // readSSEEvents reads SSE events from a reader and yields (eventType, data) pairs.
@@ -186,8 +182,10 @@ func (c *AntflyClient) Batch(ctx context.Context, tableName string, request Batc
 // response size bounds.
 func (c *AntflyClient) BatchWithOptions(ctx context.Context, tableName string, request BatchRequest, opts WriteOptions) (*BatchResult, error) {
 	opts = normalizeWriteOptions(opts)
-	batchBody, closeBody := jsonBodyReader(request, opts.MaxRequestBytes)
-	defer closeBody()
+	batchBody, err := boundedJSONBody(request, opts.MaxRequestBytes)
+	if err != nil {
+		return nil, fmt.Errorf("marshalling batch request: %w", err)
+	}
 
 	resp, err := c.client.BatchWriteWithBody(ctx, tableName, "application/json", batchBody)
 	if err != nil {
@@ -241,8 +239,10 @@ func (c *AntflyClient) LinearMerge(ctx context.Context, tableName string, reques
 // response size bounds.
 func (c *AntflyClient) LinearMergeWithOptions(ctx context.Context, tableName string, request LinearMergeRequest, opts WriteOptions) (*LinearMergeResult, error) {
 	opts = normalizeWriteOptions(opts)
-	body, closeBody := jsonBodyReader(request, opts.MaxRequestBytes)
-	defer closeBody()
+	body, err := boundedJSONBody(request, opts.MaxRequestBytes)
+	if err != nil {
+		return nil, fmt.Errorf("marshalling linear merge request: %w", err)
+	}
 
 	resp, err := c.client.LinearMergeWithBody(ctx, tableName, "application/json", body)
 	if err != nil {
@@ -692,8 +692,10 @@ func (c *AntflyClient) MultiBatch(ctx context.Context, request MultiBatchRequest
 // request and response size bounds.
 func (c *AntflyClient) MultiBatchWithOptions(ctx context.Context, request MultiBatchRequest, opts WriteOptions) (*MultiBatchResult, error) {
 	opts = normalizeWriteOptions(opts)
-	batchBody, closeBody := jsonBodyReader(request, opts.MaxRequestBytes)
-	defer closeBody()
+	batchBody, err := boundedJSONBody(request, opts.MaxRequestBytes)
+	if err != nil {
+		return nil, fmt.Errorf("marshalling multi-batch request: %w", err)
+	}
 
 	resp, err := c.client.MultiBatchWriteWithBody(ctx, "application/json", batchBody)
 	if err != nil {

--- a/go/pkg/sdk/operations.go
+++ b/go/pkg/sdk/operations.go
@@ -33,6 +33,77 @@ import (
 	"github.com/antflydb/antfly/go/pkg/sdk/oapi"
 )
 
+const (
+	// DefaultBatchMaxRequestBytes bounds encoded SDK batch request bodies.
+	// Call BatchWithOptions or MultiBatchWithOptions with a larger value for
+	// intentionally large imports.
+	DefaultBatchMaxRequestBytes int64 = 64 << 20
+	// DefaultBatchMaxResponseBytes bounds batch write response bodies. Batch
+	// writes should return small count/error payloads, so large responses are
+	// treated as protocol errors.
+	DefaultBatchMaxResponseBytes int64 = 1 << 20
+)
+
+// BatchOptions controls request and response bounds for batch write APIs.
+// Non-positive values use SDK defaults.
+type BatchOptions struct {
+	MaxRequestBytes  int64
+	MaxResponseBytes int64
+}
+
+func normalizeBatchOptions(opts BatchOptions) BatchOptions {
+	if opts.MaxRequestBytes <= 0 {
+		opts.MaxRequestBytes = DefaultBatchMaxRequestBytes
+	}
+	if opts.MaxResponseBytes <= 0 {
+		opts.MaxResponseBytes = DefaultBatchMaxResponseBytes
+	}
+	return opts
+}
+
+type limitedWriter struct {
+	w       io.Writer
+	max     int64
+	written int64
+}
+
+func (w *limitedWriter) Write(p []byte) (int, error) {
+	if w.max <= 0 {
+		return w.w.Write(p)
+	}
+	remaining := w.max - w.written
+	if remaining <= 0 {
+		return 0, fmt.Errorf("encoded request exceeded %d bytes", w.max)
+	}
+	if int64(len(p)) > remaining {
+		n, err := w.w.Write(p[:remaining])
+		w.written += int64(n)
+		if err != nil {
+			return n, err
+		}
+		return n, fmt.Errorf("encoded request exceeded %d bytes", w.max)
+	}
+	n, err := w.w.Write(p)
+	w.written += int64(n)
+	return n, err
+}
+
+func jsonBodyReader(v any, maxBytes int64) (*io.PipeReader, func()) {
+	pr, pw := io.Pipe()
+	go func() {
+		w := io.Writer(pw)
+		if maxBytes > 0 {
+			w = &limitedWriter{w: pw, max: maxBytes}
+		}
+		if err := json.NewEncoder(w).Encode(v); err != nil {
+			_ = pw.CloseWithError(err)
+			return
+		}
+		_ = pw.Close()
+	}()
+	return pr, func() { _ = pr.Close() }
+}
+
 // readSSEEvents reads SSE events from a reader and yields (eventType, data) pairs.
 // Events are parsed from "event: <type>" and "data: <content>" lines.
 func readSSEEvents(r io.Reader) iter.Seq2[string, string] {
@@ -108,12 +179,17 @@ func (c *AntflyClient) Query(ctx context.Context, opts ...QueryRequest) (*QueryR
 
 // Batch performs a batch operation on a table
 func (c *AntflyClient) Batch(ctx context.Context, tableName string, request BatchRequest) (*BatchResult, error) {
-	batchBody, err := json.Marshal(request)
-	if err != nil {
-		return nil, fmt.Errorf("marshalling batch request: %w", err)
-	}
+	return c.BatchWithOptions(ctx, tableName, request, BatchOptions{})
+}
 
-	resp, err := c.client.BatchWriteWithBody(ctx, tableName, "application/json", bytes.NewBuffer(batchBody))
+// BatchWithOptions performs a batch operation on a table with request and
+// response size bounds.
+func (c *AntflyClient) BatchWithOptions(ctx context.Context, tableName string, request BatchRequest, opts BatchOptions) (*BatchResult, error) {
+	opts = normalizeBatchOptions(opts)
+	batchBody, closeBody := jsonBodyReader(request, opts.MaxRequestBytes)
+	defer closeBody()
+
+	resp, err := c.client.BatchWriteWithBody(ctx, tableName, "application/json", batchBody)
 	if err != nil {
 		return nil, fmt.Errorf("batch operation failed: %w", err)
 	}
@@ -123,9 +199,12 @@ func (c *AntflyClient) Batch(ctx context.Context, tableName string, request Batc
 		return nil, fmt.Errorf("batch failed: %w", readErrorResponse(resp))
 	}
 
-	respBody, err := io.ReadAll(resp.Body)
+	respBody, truncated, err := readLimitedBody(resp.Body, opts.MaxResponseBytes)
 	if err != nil {
 		return nil, fmt.Errorf("reading response body: %w", err)
+	}
+	if truncated {
+		return nil, fmt.Errorf("batch response exceeded %d bytes", opts.MaxResponseBytes)
 	}
 
 	var result BatchResult
@@ -593,12 +672,17 @@ func (c *AntflyClient) RetrievalAgent(ctx context.Context, req RetrievalAgentReq
 
 // MultiBatch performs a cross-table batch operation atomically.
 func (c *AntflyClient) MultiBatch(ctx context.Context, request MultiBatchRequest) (*MultiBatchResult, error) {
-	batchBody, err := json.Marshal(request)
-	if err != nil {
-		return nil, fmt.Errorf("marshalling multi-batch request: %w", err)
-	}
+	return c.MultiBatchWithOptions(ctx, request, BatchOptions{})
+}
 
-	resp, err := c.client.MultiBatchWriteWithBody(ctx, "application/json", bytes.NewBuffer(batchBody))
+// MultiBatchWithOptions performs a cross-table batch operation atomically with
+// request and response size bounds.
+func (c *AntflyClient) MultiBatchWithOptions(ctx context.Context, request MultiBatchRequest, opts BatchOptions) (*MultiBatchResult, error) {
+	opts = normalizeBatchOptions(opts)
+	batchBody, closeBody := jsonBodyReader(request, opts.MaxRequestBytes)
+	defer closeBody()
+
+	resp, err := c.client.MultiBatchWriteWithBody(ctx, "application/json", batchBody)
 	if err != nil {
 		return nil, fmt.Errorf("multi-batch operation failed: %w", err)
 	}
@@ -608,9 +692,12 @@ func (c *AntflyClient) MultiBatch(ctx context.Context, request MultiBatchRequest
 		return nil, fmt.Errorf("multi-batch failed: %w", readErrorResponse(resp))
 	}
 
-	respBody, err := io.ReadAll(resp.Body)
+	respBody, truncated, err := readLimitedBody(resp.Body, opts.MaxResponseBytes)
 	if err != nil {
 		return nil, fmt.Errorf("reading response body: %w", err)
+	}
+	if truncated {
+		return nil, fmt.Errorf("multi-batch response exceeded %d bytes", opts.MaxResponseBytes)
 	}
 
 	var result MultiBatchResult

--- a/go/pkg/sdk/operations_test.go
+++ b/go/pkg/sdk/operations_test.go
@@ -193,7 +193,7 @@ func TestBatchStreamsRequestAndParsesResponse(t *testing.T) {
 
 	result, err := client.BatchWithOptions(context.Background(), "files", BatchRequest{
 		Inserts: map[string]any{"doc-1": map[string]any{"title": "hello"}},
-	}, BatchOptions{
+	}, WriteOptions{
 		MaxRequestBytes:  1024,
 		MaxResponseBytes: 1024,
 	})
@@ -225,7 +225,7 @@ func TestBatchRejectsOversizedSuccessResponse(t *testing.T) {
 
 	_, err = client.BatchWithOptions(context.Background(), "files", BatchRequest{
 		Inserts: map[string]any{"doc-1": map[string]any{"title": "hello"}},
-	}, BatchOptions{
+	}, WriteOptions{
 		MaxRequestBytes:  1024,
 		MaxResponseBytes: 16,
 	})
@@ -248,7 +248,7 @@ func TestReadErrorResponseCapsBody(t *testing.T) {
 
 	_, err = client.BatchWithOptions(context.Background(), "files", BatchRequest{
 		Inserts: map[string]any{"doc-1": map[string]any{"title": "hello"}},
-	}, BatchOptions{
+	}, WriteOptions{
 		MaxRequestBytes:  1024,
 		MaxResponseBytes: 1024,
 	})
@@ -264,5 +264,70 @@ func TestReadErrorResponseCapsBody(t *testing.T) {
 	}
 	if len(apiErr.Message) > int(maxErrorResponseBytes)+128 {
 		t.Fatalf("APIError.Message length = %d, want capped message", len(apiErr.Message))
+	}
+}
+
+func TestLinearMergeStreamsRequestAndParsesResponse(t *testing.T) {
+	var gotPath string
+	var gotBody string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("ReadAll request body: %v", err)
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		gotBody = string(body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"upserted":1,"status":"success"}`))
+	}))
+	defer server.Close()
+
+	client, err := NewAntflyClientWithOptions(server.URL, oapi.WithHTTPClient(server.Client()))
+	if err != nil {
+		t.Fatalf("NewAntflyClientWithOptions: %v", err)
+	}
+
+	result, err := client.LinearMergeWithOptions(context.Background(), "files", LinearMergeRequest{
+		Records: map[string]any{"doc-1": map[string]any{"title": "hello"}},
+	}, WriteOptions{
+		MaxRequestBytes:  1024,
+		MaxResponseBytes: 1024,
+	})
+	if err != nil {
+		t.Fatalf("LinearMergeWithOptions: %v", err)
+	}
+	if result.Upserted != 1 {
+		t.Fatalf("Upserted = %d, want 1", result.Upserted)
+	}
+	if gotPath != "/db/v1/tables/files/merge" {
+		t.Fatalf("path = %q, want /db/v1/tables/files/merge", gotPath)
+	}
+	if !strings.Contains(gotBody, `"doc-1"`) || !strings.Contains(gotBody, `"title":"hello"`) {
+		t.Fatalf("request body = %q, want encoded record", gotBody)
+	}
+}
+
+func TestLinearMergeRejectsOversizedSuccessResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		_, _ = w.Write([]byte(strings.Repeat("x", 17)))
+	}))
+	defer server.Close()
+
+	client, err := NewAntflyClientWithOptions(server.URL, oapi.WithHTTPClient(server.Client()))
+	if err != nil {
+		t.Fatalf("NewAntflyClientWithOptions: %v", err)
+	}
+
+	_, err = client.LinearMergeWithOptions(context.Background(), "files", LinearMergeRequest{
+		Records: map[string]any{"doc-1": map[string]any{"title": "hello"}},
+	}, WriteOptions{
+		MaxRequestBytes:  1024,
+		MaxResponseBytes: 16,
+	})
+	if err == nil || !strings.Contains(err.Error(), "linear merge response exceeded 16 bytes") {
+		t.Fatalf("LinearMergeWithOptions error = %v, want response limit error", err)
 	}
 }

--- a/go/pkg/sdk/operations_test.go
+++ b/go/pkg/sdk/operations_test.go
@@ -17,10 +17,16 @@ limitations under the License.
 package sdk
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/antflydb/antfly/go/pkg/sdk/oapi"
 )
 
 func TestReadSSEEvents(t *testing.T) {
@@ -160,5 +166,103 @@ func TestReadSSEEventsEarlyTermination(t *testing.T) {
 	}
 	if count != 1 {
 		t.Errorf("early termination: got %d events, want 1", count)
+	}
+}
+
+func TestBatchStreamsRequestAndParsesResponse(t *testing.T) {
+	var gotPath string
+	var gotBody string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("ReadAll request body: %v", err)
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		gotBody = string(body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"inserted":1}`))
+	}))
+	defer server.Close()
+
+	client, err := NewAntflyClientWithOptions(server.URL, oapi.WithHTTPClient(server.Client()))
+	if err != nil {
+		t.Fatalf("NewAntflyClientWithOptions: %v", err)
+	}
+
+	result, err := client.BatchWithOptions(context.Background(), "files", BatchRequest{
+		Inserts: map[string]any{"doc-1": map[string]any{"title": "hello"}},
+	}, BatchOptions{
+		MaxRequestBytes:  1024,
+		MaxResponseBytes: 1024,
+	})
+	if err != nil {
+		t.Fatalf("BatchWithOptions: %v", err)
+	}
+	if result.Inserted != 1 {
+		t.Fatalf("Inserted = %d, want 1", result.Inserted)
+	}
+	if gotPath != "/db/v1/tables/files/batch" {
+		t.Fatalf("path = %q, want /db/v1/tables/files/batch", gotPath)
+	}
+	if !strings.Contains(gotBody, `"doc-1"`) || !strings.Contains(gotBody, `"title":"hello"`) {
+		t.Fatalf("request body = %q, want encoded insert", gotBody)
+	}
+}
+
+func TestBatchRejectsOversizedSuccessResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		_, _ = w.Write([]byte(strings.Repeat("x", 17)))
+	}))
+	defer server.Close()
+
+	client, err := NewAntflyClientWithOptions(server.URL, oapi.WithHTTPClient(server.Client()))
+	if err != nil {
+		t.Fatalf("NewAntflyClientWithOptions: %v", err)
+	}
+
+	_, err = client.BatchWithOptions(context.Background(), "files", BatchRequest{
+		Inserts: map[string]any{"doc-1": map[string]any{"title": "hello"}},
+	}, BatchOptions{
+		MaxRequestBytes:  1024,
+		MaxResponseBytes: 16,
+	})
+	if err == nil || !strings.Contains(err.Error(), "batch response exceeded 16 bytes") {
+		t.Fatalf("BatchWithOptions error = %v, want response limit error", err)
+	}
+}
+
+func TestReadErrorResponseCapsBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		http.Error(w, strings.Repeat("x", int(maxErrorResponseBytes)+1), http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	client, err := NewAntflyClientWithOptions(server.URL, oapi.WithHTTPClient(server.Client()))
+	if err != nil {
+		t.Fatalf("NewAntflyClientWithOptions: %v", err)
+	}
+
+	_, err = client.BatchWithOptions(context.Background(), "files", BatchRequest{
+		Inserts: map[string]any{"doc-1": map[string]any{"title": "hello"}},
+	}, BatchOptions{
+		MaxRequestBytes:  1024,
+		MaxResponseBytes: 1024,
+	})
+	if err == nil {
+		t.Fatal("BatchWithOptions error = nil, want API error")
+	}
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("error = %T %[1]v, want APIError", err)
+	}
+	if !strings.Contains(apiErr.Message, "response body exceeded") {
+		t.Fatalf("APIError.Message missing truncation marker: %q", apiErr.Message)
+	}
+	if len(apiErr.Message) > int(maxErrorResponseBytes)+128 {
+		t.Fatalf("APIError.Message length = %d, want capped message", len(apiErr.Message))
 	}
 }

--- a/go/pkg/sdk/operations_test.go
+++ b/go/pkg/sdk/operations_test.go
@@ -169,11 +169,13 @@ func TestReadSSEEventsEarlyTermination(t *testing.T) {
 	}
 }
 
-func TestBatchStreamsRequestAndParsesResponse(t *testing.T) {
+func TestBatchSendsContentLengthRequestAndParsesResponse(t *testing.T) {
 	var gotPath string
 	var gotBody string
+	var gotContentLength int64
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotPath = r.URL.Path
+		gotContentLength = r.ContentLength
 		body, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Errorf("ReadAll request body: %v", err)
@@ -205,6 +207,9 @@ func TestBatchStreamsRequestAndParsesResponse(t *testing.T) {
 	}
 	if gotPath != "/db/v1/tables/files/batch" {
 		t.Fatalf("path = %q, want /db/v1/tables/files/batch", gotPath)
+	}
+	if gotContentLength <= 0 {
+		t.Fatalf("ContentLength = %d, want fixed positive content length", gotContentLength)
 	}
 	if !strings.Contains(gotBody, `"doc-1"`) || !strings.Contains(gotBody, `"title":"hello"`) {
 		t.Fatalf("request body = %q, want encoded insert", gotBody)
@@ -267,11 +272,40 @@ func TestReadErrorResponseCapsBody(t *testing.T) {
 	}
 }
 
-func TestLinearMergeStreamsRequestAndParsesResponse(t *testing.T) {
+func TestBatchRejectsOversizedRequestBeforeSending(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer server.Close()
+
+	client, err := NewAntflyClientWithOptions(server.URL, oapi.WithHTTPClient(server.Client()))
+	if err != nil {
+		t.Fatalf("NewAntflyClientWithOptions: %v", err)
+	}
+
+	_, err = client.BatchWithOptions(context.Background(), "files", BatchRequest{
+		Inserts: map[string]any{"doc-1": map[string]any{"title": strings.Repeat("x", 128)}},
+	}, WriteOptions{
+		MaxRequestBytes:  64,
+		MaxResponseBytes: 1024,
+	})
+	if err == nil || !strings.Contains(err.Error(), "encoded request exceeded 64 bytes") {
+		t.Fatalf("BatchWithOptions error = %v, want request limit error", err)
+	}
+	if requests != 0 {
+		t.Fatalf("requests = %d, want no request sent after local request limit failure", requests)
+	}
+}
+
+func TestLinearMergeSendsContentLengthRequestAndParsesResponse(t *testing.T) {
 	var gotPath string
 	var gotBody string
+	var gotContentLength int64
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotPath = r.URL.Path
+		gotContentLength = r.ContentLength
 		body, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Errorf("ReadAll request body: %v", err)
@@ -303,6 +337,9 @@ func TestLinearMergeStreamsRequestAndParsesResponse(t *testing.T) {
 	}
 	if gotPath != "/db/v1/tables/files/merge" {
 		t.Fatalf("path = %q, want /db/v1/tables/files/merge", gotPath)
+	}
+	if gotContentLength <= 0 {
+		t.Fatalf("ContentLength = %d, want fixed positive content length", gotContentLength)
 	}
 	if !strings.Contains(gotBody, `"doc-1"`) || !strings.Contains(gotBody, `"title":"hello"`) {
 		t.Fatalf("request body = %q, want encoded record", gotBody)

--- a/zig/build.zig
+++ b/zig/build.zig
@@ -2742,6 +2742,7 @@ pub fn build(b: *std.Build) void {
         "data runtime provisioned root refresh spawn failure preserves retry bookkeeping",
         "data runtime local split fallback preserves source identity namespace",
         "data runtime local merge fallback derives receiver identity namespace from catalog",
+        "data public API listener uses public API request body limit",
         "data server can register a store without enabling data raft",
         "data server registered data raft uses wal state backend by default",
     };
@@ -3213,6 +3214,7 @@ pub fn build(b: *std.Build) void {
         "api http server lists cluster backups through public route",
         "api http server backs up and restores a table through public routes",
         "api http server prefers metadata-owned restore over inline write-source restore",
+        "public API request body limit matches Go linear merge contract",
         "public api smoke e2e creates table inserts and queries documents",
         "public api e2e recreates managed embeddings index after corrupt artifact",
         "public api split e2e uses distributed global text stats for bm25 and significant_terms",
@@ -3895,6 +3897,7 @@ pub fn build(b: *std.Build) void {
             "parse cli accepts canonical host port and models dir flags",
             "termite config uses cli override before common config",
             "swarm public api caps keep alive request reuse",
+            "swarm public HTTP server uses public API request body limit",
             "parse cli accepts termite budget overrides",
             "termite config falls back to common config",
             "swarm runtime resolves paths from common storage base dir",

--- a/zig/pkg/antfly/src/api/http_server.zig
+++ b/zig/pkg/antfly/src/api/http_server.zig
@@ -203,6 +203,12 @@ fn parseSseEventsAlloc(alloc: std.mem.Allocator, body: []const u8) ![]TestSseEve
     return try events.toOwnedSlice(alloc);
 }
 
+pub const public_api_max_request_body_bytes: usize = 64 * 1024 * 1024;
+
+test "public API request body limit matches Go linear merge contract" {
+    try std.testing.expectEqual(@as(usize, 64 * 1024 * 1024), public_api_max_request_body_bytes);
+}
+
 pub const ApiHttpServerConfig = struct {
     auth_enabled: bool = false,
     swarm_mode: bool = false,

--- a/zig/pkg/antfly/src/data/runtime.zig
+++ b/zig/pkg/antfly/src/data/runtime.zig
@@ -99,6 +99,19 @@ const ResolvedMetadataApiUrls = struct {
     }
 };
 
+fn publicApiListenerConfig(bind_host: []const u8, bind_port: u16) antfly.raft.transport.StdHttpListenerConfig {
+    return .{
+        .bind_host = bind_host,
+        .bind_port = bind_port,
+        .max_request_bytes = antfly.public_api.http_server.public_api_max_request_body_bytes,
+    };
+}
+
+test "data public API listener uses public API request body limit" {
+    const cfg = publicApiListenerConfig("127.0.0.1", 8080);
+    try std.testing.expectEqual(antfly.public_api.http_server.public_api_max_request_body_bytes, cfg.max_request_bytes);
+}
+
 const DataDescriptorFactory = struct {
     alloc: std.mem.Allocator,
     fallback_store: *raft_engine.core.MemoryStorage,
@@ -1524,10 +1537,7 @@ pub const DataServer = struct {
             .api_server_cfg = cfg.api_server_cfg,
             .query_async_limit = cfg.query_async_limit,
             .backend_runtime = cfg.backend_runtime,
-            .listener_cfg = .{
-                .bind_host = cfg.bind_host,
-                .bind_port = cfg.bind_port,
-            },
+            .listener_cfg = publicApiListenerConfig(cfg.bind_host, cfg.bind_port),
         };
     }
 
@@ -1557,10 +1567,7 @@ pub const DataServer = struct {
             .api_server_cfg = cfg.api_server_cfg,
             .query_async_limit = cfg.query_async_limit,
             .backend_runtime = cfg.backend_runtime,
-            .listener_cfg = .{
-                .bind_host = cfg.bind_host,
-                .bind_port = cfg.bind_port,
-            },
+            .listener_cfg = publicApiListenerConfig(cfg.bind_host, cfg.bind_port),
         };
     }
 
@@ -1590,10 +1597,7 @@ pub const DataServer = struct {
             .api_server_cfg = cfg.api_server_cfg,
             .query_async_limit = cfg.query_async_limit,
             .backend_runtime = cfg.backend_runtime,
-            .listener_cfg = .{
-                .bind_host = cfg.bind_host,
-                .bind_port = cfg.bind_port,
-            },
+            .listener_cfg = publicApiListenerConfig(cfg.bind_host, cfg.bind_port),
         };
     }
 
@@ -5277,10 +5281,7 @@ pub const DataServer = struct {
             .api_server_cfg = cfg.api_server_cfg,
             .query_async_limit = cfg.query_async_limit,
             .backend_runtime = cfg.backend_runtime,
-            .listener_cfg = .{
-                .bind_host = cfg.bind_host,
-                .bind_port = cfg.bind_port,
-            },
+            .listener_cfg = publicApiListenerConfig(cfg.bind_host, cfg.bind_port),
         };
     }
 };

--- a/zig/pkg/antfly/src/serverless_main.zig
+++ b/zig/pkg/antfly/src/serverless_main.zig
@@ -16,7 +16,7 @@ const std = @import("std");
 const antfly = @import("antfly-zig");
 
 const serverless = antfly.serverless;
-const serverless_default_max_request_bytes: usize = antfly.raft.transport.std_http_listener.default_max_request_bytes;
+const serverless_default_max_request_bytes: usize = antfly.public_api.http_server.public_api_max_request_body_bytes;
 
 const CliConfig = struct {
     artifacts_uri: ?[]const u8 = null,
@@ -529,12 +529,12 @@ test "serverless main enables listener only for query-serving roles" {
     try std.testing.expect(!listenerEnabledForRole(.maintenance_only));
 }
 
-test "serverless main listener config defaults request limit to 32 MiB" {
+test "serverless main listener config defaults request limit to public API limit" {
     var env_map = std.process.Environ.Map.init(std.testing.allocator);
     defer env_map.deinit();
 
     const cfg = serverless_serverConfigFromEnv(&env_map, .{});
-    try std.testing.expectEqual(serverless_default_max_request_bytes, cfg.max_request_bytes);
+    try std.testing.expectEqual(antfly.public_api.http_server.public_api_max_request_body_bytes, cfg.max_request_bytes);
 }
 
 test "serverless main listener config allows env and cli request limit overrides" {

--- a/zig/pkg/antfly/src/swarm/runtime.zig
+++ b/zig/pkg/antfly/src/swarm/runtime.zig
@@ -1102,12 +1102,7 @@ fn serveUnifiedInner(
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
 
-    var server = httpx.Server.initWithConfig(alloc, io_impl.io(), .{
-        .host = bind_host,
-        .port = bind_port,
-        .request_timeout_ms = 300_000,
-        .max_requests_per_connection = public_api_max_requests_per_connection,
-    });
+    var server = httpx.Server.initWithConfig(alloc, io_impl.io(), publicHttpServerConfig(bind_host, bind_port));
     defer server.deinit();
 
     // Register antfly routes under /ai/v1
@@ -1141,6 +1136,16 @@ fn serveUnifiedInner(
     }
 
     try server.listen();
+}
+
+fn publicHttpServerConfig(bind_host: []const u8, bind_port: u16) httpx.ServerConfig {
+    return .{
+        .host = bind_host,
+        .port = bind_port,
+        .max_body_size = antfly.public_api.http_server.public_api_max_request_body_bytes,
+        .request_timeout_ms = 300_000,
+        .max_requests_per_connection = public_api_max_requests_per_connection,
+    };
 }
 
 fn PrefixedServer(comptime prefix: []const u8, comptime Inner: type) type {
@@ -2007,6 +2012,11 @@ test "swarm runtime defaults public listener to antfarm port" {
     const listener = resolvePublicListener(.{});
     try std.testing.expectEqualStrings("127.0.0.1", listener.bind_host);
     try std.testing.expectEqual(@as(u16, default_public_port), listener.bind_port);
+}
+
+test "swarm public HTTP server uses public API request body limit" {
+    const cfg = publicHttpServerConfig("127.0.0.1", 8080);
+    try std.testing.expectEqual(antfly.public_api.http_server.public_api_max_request_body_bytes, cfg.max_body_size);
 }
 
 test "antfly config uses cli override before common config" {


### PR DESCRIPTION
## Summary
- stream SDK Batch and MultiBatch request bodies instead of materializing a full JSON buffer
- add default request/response size bounds with BatchWithOptions and MultiBatchWithOptions overrides
- cap API error response reads to avoid unbounded client heap growth

## Tests
- GOWORK=off go test ./... (from go/pkg/sdk)