### PR TITLE
Harden autoscaling split e2e wait

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -15093,6 +15093,202 @@ components:
           type: number
           format: float
           description: Relevance score for this prompt.
+    InferenceRecognizeEntity:
+      type: object
+      required:
+        - text
+        - label
+        - start
+        - end
+        - score
+      properties:
+        text:
+          type: string
+          description: The entity text
+          example: John Smith
+        label:
+          type: string
+          description: Entity type (PER, ORG, LOC, MISC)
+          example: PER
+        start:
+          type: integer
+          description: Character offset where entity begins
+          example: 0
+        end:
+          type: integer
+          description: Character offset where entity ends (exclusive)
+          example: 10
+        score:
+          type: number
+          format: float
+          description: Confidence score (0.0 to 1.0)
+          example: 0.99
+    InferenceRecognizeRequest:
+      type: object
+      required:
+        - model
+        - texts
+      properties:
+        model:
+          type: string
+          description: Name of recognizer model from models_dir/recognizers/
+          example: dslim/bert-base-NER
+        texts:
+          type: array
+          items:
+            type: string
+          description: Texts to extract entities from
+          example:
+            - John Smith works at Google.
+            - Apple Inc. is in Cupertino.
+        labels:
+          type: array
+          items:
+            type: string
+          description: >
+            Custom entity labels to extract (GLiNER models only).
+
+            When using a GLiNER model, you can specify any entity types to extract,
+
+            enabling zero-shot NER without model retraining.
+
+            If not provided, the model's default labels are used.
+          example:
+            - person
+            - company
+            - product
+            - date
+        relation_labels:
+          type: array
+          items:
+            type: string
+          description: >
+            Relation types to extract (for models with 'relations' capability).
+
+            Only used when the model supports relation extraction (GLiNER multitask, REBEL).
+
+            Relation extraction runs only when this array is provided and non-empty.
+
+            GLiNER labels may be relation names (works_for), head-qualified
+
+            labels (person::works_for), or head/tail-qualified labels
+
+            (person::works_for::organization).
+          example:
+            - founded
+            - works_at
+            - located_in
+        resolver:
+          $ref: '#/components/schemas/InferenceResolverConfig'
+    InferenceResolverConfig:
+      type: object
+      description: >
+        Configuration for entity resolution. When present in a RecognizeRequest,
+
+        the response entities and relations are deduplicated via entity resolution
+
+        (e.g., "Elon Musk" and "Musk" are merged into a single entity).
+      properties:
+        similarity_threshold:
+          type: number
+          format: float
+          default: 0.85
+          description: Jaro-Winkler similarity threshold for merging entities (0.0-1.0)
+        type_must_match:
+          type: boolean
+          default: true
+          description: Whether entity types must match for merging
+        min_entity_confidence:
+          type: number
+          format: float
+          default: 0
+          description: Minimum confidence score for entities to be included
+        min_relation_confidence:
+          type: number
+          format: float
+          default: 0
+          description: Minimum confidence score for relations to be included
+        deduplicate_relations:
+          type: boolean
+          default: true
+          description: Whether to deduplicate relations after entity resolution
+        track_provenance:
+          type: boolean
+          default: true
+          description: Whether to track mention provenance for resolved entities
+    InferenceRelation:
+      type: object
+      required:
+        - head
+        - tail
+        - label
+        - score
+      properties:
+        head:
+          $ref: '#/components/schemas/InferenceRecognizeEntity'
+          description: The subject/head entity in the relationship
+        tail:
+          $ref: '#/components/schemas/InferenceRecognizeEntity'
+          description: The object/tail entity in the relationship
+        label:
+          type: string
+          description: The relationship type
+          example: founded
+        score:
+          type: number
+          format: float
+          description: Confidence score for the relation (0.0 to 1.0)
+          example: 0.95
+    InferenceRecognizeResponse:
+      type: object
+      required:
+        - object
+        - data
+        - model
+        - usage
+      properties:
+        object:
+          type: string
+          enum:
+            - list
+          description: Object type, always "list"
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/InferenceRecognizeObject'
+          description: Recognition result objects, one per input text.
+        model:
+          type: string
+          description: Name of model used for NER
+        usage:
+          $ref: '#/components/schemas/InferenceGenerateUsage'
+    InferenceRecognizeObject:
+      type: object
+      required:
+        - object
+        - index
+        - entities
+      properties:
+        object:
+          type: string
+          enum:
+            - recognition
+        index:
+          type: integer
+          description: Original input text index.
+        entities:
+          type: array
+          items:
+            $ref: '#/components/schemas/InferenceRecognizeEntity'
+          description: Entities recognized for this input text.
+        relations:
+          type: array
+          items:
+            $ref: '#/components/schemas/InferenceRelation'
+          description: >
+            Relations recognized for this input text. Only present when using
+
+            a model with 'relations' capability (GLiNER multitask, REBEL).
     InferenceRewriteRequest:
       type: object
       required:
@@ -15152,6 +15348,111 @@ components:
           items:
             type: string
           description: Rewritten texts for this input, one per beam.
+    InferenceClassifyRequest:
+      type: object
+      required:
+        - model
+        - texts
+        - labels
+      properties:
+        model:
+          type: string
+          description: Name of classifier model from models_dir/classifiers/
+          example: MoritzLaurer/mDeBERTa-v3-base-mnli-xnli
+        texts:
+          type: array
+          items:
+            type: string
+          description: Texts to classify
+          example:
+            - I love this product!
+            - The service was terrible.
+        labels:
+          type: array
+          items:
+            type: string
+          description: >
+            Candidate labels for zero-shot classification.
+
+            The model will predict which label(s) best describe each text.
+          example:
+            - positive
+            - negative
+            - neutral
+        hypothesis_template:
+          type: string
+          description: >
+            Custom hypothesis template for NLI-based classification.
+
+            Use "{}" as placeholder for the label.
+
+            Default: "This example is {}."
+          example: This text expresses a {} sentiment.
+        multi_label:
+          type: boolean
+          default: false
+          description: >
+            If true, allows multiple labels per text (independent scoring).
+
+            If false (default), scores are normalized across labels.
+    InferenceClassifyResult:
+      type: object
+      required:
+        - label
+        - score
+      properties:
+        label:
+          type: string
+          description: The predicted class/category
+          example: positive
+        score:
+          type: number
+          format: float
+          description: Confidence score (0.0 to 1.0)
+          example: 0.95
+    InferenceClassifyResponse:
+      type: object
+      required:
+        - object
+        - data
+        - model
+        - usage
+      properties:
+        object:
+          type: string
+          enum:
+            - list
+          description: Object type, always "list"
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/InferenceClassifyObject'
+          description: Classification result objects, one per input text.
+        model:
+          type: string
+          description: Name of model used for classification
+        usage:
+          $ref: '#/components/schemas/InferenceGenerateUsage'
+    InferenceClassifyObject:
+      type: object
+      required:
+        - object
+        - index
+        - classifications
+      properties:
+        object:
+          type: string
+          enum:
+            - classification
+        index:
+          type: integer
+          description: Original input text index.
+        classifications:
+          type: array
+          items:
+            $ref: '#/components/schemas/InferenceClassifyResult'
+          description: >
+            Classification results for this input text.
     InferenceDocumentClassificationRequest:
       type: object
       required:

--- a/specs/openapi/inference/api.yaml
+++ b/specs/openapi/inference/api.yaml
@@ -1092,6 +1092,191 @@ components:
           type: number
           format: float
           description: Relevance score for this prompt.
+    RecognizeEntity:
+      type: object
+      required:
+        - text
+        - label
+        - start
+        - end
+        - score
+      properties:
+        text:
+          type: string
+          description: The entity text
+          example: John Smith
+        label:
+          type: string
+          description: Entity type (PER, ORG, LOC, MISC)
+          example: PER
+        start:
+          type: integer
+          description: Character offset where entity begins
+          example: 0
+        end:
+          type: integer
+          description: Character offset where entity ends (exclusive)
+          example: 10
+        score:
+          type: number
+          format: float
+          description: Confidence score (0.0 to 1.0)
+          example: 0.99
+    RecognizeRequest:
+      type: object
+      required:
+        - model
+        - texts
+      properties:
+        model:
+          type: string
+          description: Name of recognizer model from models_dir/recognizers/
+          example: dslim/bert-base-NER
+        texts:
+          type: array
+          items:
+            type: string
+          description: Texts to extract entities from
+          example:
+            - John Smith works at Google.
+            - Apple Inc. is in Cupertino.
+        labels:
+          type: array
+          items:
+            type: string
+          description: |
+            Custom entity labels to extract (GLiNER models only).
+            When using a GLiNER model, you can specify any entity types to extract,
+            enabling zero-shot NER without model retraining.
+            If not provided, the model's default labels are used.
+          example:
+            - person
+            - company
+            - product
+            - date
+        relation_labels:
+          type: array
+          items:
+            type: string
+          description: |
+            Relation types to extract (for models with 'relations' capability).
+            Only used when the model supports relation extraction (GLiNER multitask, REBEL).
+            Relation extraction runs only when this array is provided and non-empty.
+            GLiNER labels may be relation names (works_for), head-qualified
+            labels (person::works_for), or head/tail-qualified labels
+            (person::works_for::organization).
+          example:
+            - founded
+            - works_at
+            - located_in
+        resolver:
+          $ref: '#/components/schemas/ResolverConfig'
+    ResolverConfig:
+      type: object
+      description: |
+        Configuration for entity resolution. When present in a RecognizeRequest,
+        the response entities and relations are deduplicated via entity resolution
+        (e.g., "Elon Musk" and "Musk" are merged into a single entity).
+      properties:
+        similarity_threshold:
+          type: number
+          format: float
+          default: 0.85
+          description: Jaro-Winkler similarity threshold for merging entities (0.0-1.0)
+        type_must_match:
+          type: boolean
+          default: true
+          description: Whether entity types must match for merging
+        min_entity_confidence:
+          type: number
+          format: float
+          default: 0
+          description: Minimum confidence score for entities to be included
+        min_relation_confidence:
+          type: number
+          format: float
+          default: 0
+          description: Minimum confidence score for relations to be included
+        deduplicate_relations:
+          type: boolean
+          default: true
+          description: Whether to deduplicate relations after entity resolution
+        track_provenance:
+          type: boolean
+          default: true
+          description: Whether to track mention provenance for resolved entities
+    Relation:
+      type: object
+      required:
+        - head
+        - tail
+        - label
+        - score
+      properties:
+        head:
+          $ref: '#/components/schemas/RecognizeEntity'
+          description: The subject/head entity in the relationship
+        tail:
+          $ref: '#/components/schemas/RecognizeEntity'
+          description: The object/tail entity in the relationship
+        label:
+          type: string
+          description: The relationship type
+          example: founded
+        score:
+          type: number
+          format: float
+          description: Confidence score for the relation (0.0 to 1.0)
+          example: 0.95
+    RecognizeResponse:
+      type: object
+      required:
+        - object
+        - data
+        - model
+        - usage
+      properties:
+        object:
+          type: string
+          enum:
+            - list
+          description: Object type, always "list"
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/RecognizeObject'
+          description: Recognition result objects, one per input text.
+        model:
+          type: string
+          description: Name of model used for NER
+        usage:
+          $ref: '#/components/schemas/GenerateUsage'
+    RecognizeObject:
+      type: object
+      required:
+        - object
+        - index
+        - entities
+      properties:
+        object:
+          type: string
+          enum:
+            - recognition
+        index:
+          type: integer
+          description: Original input text index.
+        entities:
+          type: array
+          items:
+            $ref: '#/components/schemas/RecognizeEntity'
+          description: Entities recognized for this input text.
+        relations:
+          type: array
+          items:
+            $ref: '#/components/schemas/Relation'
+          description: |
+            Relations recognized for this input text. Only present when using
+            a model with 'relations' capability (GLiNER multitask, REBEL).
     RewriteRequest:
       type: object
       required:
@@ -1151,6 +1336,107 @@ components:
           items:
             type: string
           description: Rewritten texts for this input, one per beam.
+    ClassifyRequest:
+      type: object
+      required:
+        - model
+        - texts
+        - labels
+      properties:
+        model:
+          type: string
+          description: Name of classifier model from models_dir/classifiers/
+          example: MoritzLaurer/mDeBERTa-v3-base-mnli-xnli
+        texts:
+          type: array
+          items:
+            type: string
+          description: Texts to classify
+          example:
+            - I love this product!
+            - The service was terrible.
+        labels:
+          type: array
+          items:
+            type: string
+          description: |
+            Candidate labels for zero-shot classification.
+            The model will predict which label(s) best describe each text.
+          example:
+            - positive
+            - negative
+            - neutral
+        hypothesis_template:
+          type: string
+          description: |
+            Custom hypothesis template for NLI-based classification.
+            Use "{}" as placeholder for the label.
+            Default: "This example is {}."
+          example: This text expresses a {} sentiment.
+        multi_label:
+          type: boolean
+          default: false
+          description: |
+            If true, allows multiple labels per text (independent scoring).
+            If false (default), scores are normalized across labels.
+    ClassifyResult:
+      type: object
+      required:
+        - label
+        - score
+      properties:
+        label:
+          type: string
+          description: The predicted class/category
+          example: positive
+        score:
+          type: number
+          format: float
+          description: Confidence score (0.0 to 1.0)
+          example: 0.95
+    ClassifyResponse:
+      type: object
+      required:
+        - object
+        - data
+        - model
+        - usage
+      properties:
+        object:
+          type: string
+          enum:
+            - list
+          description: Object type, always "list"
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/ClassifyObject'
+          description: Classification result objects, one per input text.
+        model:
+          type: string
+          description: Name of model used for classification
+        usage:
+          $ref: '#/components/schemas/GenerateUsage'
+    ClassifyObject:
+      type: object
+      required:
+        - object
+        - index
+        - classifications
+      properties:
+        object:
+          type: string
+          enum:
+            - classification
+        index:
+          type: integer
+          description: Original input text index.
+        classifications:
+          type: array
+          items:
+            $ref: '#/components/schemas/ClassifyResult'
+          description: |
+            Classification results for this input text.
     DocumentClassificationRequest:
       type: object
       required:

--- a/specs/openapi/inference/config.yaml
+++ b/specs/openapi/inference/config.yaml
@@ -392,6 +392,161 @@ components:
             format: float
           description: Relevance scores (one per prompt, same order as input)
 
+    # Recognizer Types
+    RecognizeEntity:
+      type: object
+      required:
+        - text
+        - label
+        - start
+        - end
+        - score
+      properties:
+        text:
+          type: string
+          description: The entity text
+          example: "John Smith"
+        label:
+          type: string
+          description: Entity type (PER, ORG, LOC, MISC)
+          example: "PER"
+        start:
+          type: integer
+          description: Character offset where entity begins
+          example: 0
+        end:
+          type: integer
+          description: Character offset where entity ends (exclusive)
+          example: 10
+        score:
+          type: number
+          format: float
+          description: Confidence score (0.0 to 1.0)
+          example: 0.99
+
+    RecognizeRequest:
+      type: object
+      required:
+        - model
+        - texts
+      properties:
+        model:
+          type: string
+          description: Name of recognizer model from models_dir/recognizers/
+          example: "dslim/bert-base-NER"
+        texts:
+          type: array
+          items:
+            type: string
+          description: Texts to extract entities from
+          example: ["John Smith works at Google.", "Apple Inc. is in Cupertino."]
+        labels:
+          type: array
+          items:
+            type: string
+          description: |
+            Custom entity labels to extract (GLiNER models only).
+            When using a GLiNER model, you can specify any entity types to extract,
+            enabling zero-shot NER without model retraining.
+            If not provided, the model's default labels are used.
+          example: ["person", "company", "product", "date"]
+        relation_labels:
+          type: array
+          items:
+            type: string
+          description: |
+            Relation types to extract (for models with 'relations' capability).
+            Only used when the model supports relation extraction (GLiNER multitask, REBEL).
+            If not provided, the model extracts all relations it can detect.
+          example: ["founded", "works_at", "located_in"]
+        resolver:
+          $ref: '#/components/schemas/ResolverConfig'
+
+    ResolverConfig:
+      type: object
+      description: |
+        Configuration for entity resolution. When present in a RecognizeRequest,
+        the response entities and relations are deduplicated via entity resolution
+        (e.g., "Elon Musk" and "Musk" are merged into a single entity).
+      properties:
+        similarity_threshold:
+          type: number
+          format: float
+          default: 0.85
+          description: Jaro-Winkler similarity threshold for merging entities (0.0-1.0)
+        type_must_match:
+          type: boolean
+          default: true
+          description: Whether entity types must match for merging
+        min_entity_confidence:
+          type: number
+          format: float
+          default: 0.0
+          description: Minimum confidence score for entities to be included
+        min_relation_confidence:
+          type: number
+          format: float
+          default: 0.0
+          description: Minimum confidence score for relations to be included
+        deduplicate_relations:
+          type: boolean
+          default: true
+          description: Whether to deduplicate relations after entity resolution
+        track_provenance:
+          type: boolean
+          default: true
+          description: Whether to track mention provenance for resolved entities
+
+    Relation:
+      type: object
+      required:
+        - head
+        - tail
+        - label
+        - score
+      properties:
+        head:
+          $ref: "#/components/schemas/RecognizeEntity"
+          description: The subject/head entity in the relationship
+        tail:
+          $ref: "#/components/schemas/RecognizeEntity"
+          description: The object/tail entity in the relationship
+        label:
+          type: string
+          description: The relationship type
+          example: "founded"
+        score:
+          type: number
+          format: float
+          description: Confidence score for the relation (0.0 to 1.0)
+          example: 0.95
+
+    RecognizeResponse:
+      type: object
+      required:
+        - model
+        - entities
+      properties:
+        model:
+          type: string
+          description: Name of model used for NER
+        entities:
+          type: array
+          items:
+            type: array
+            items:
+              $ref: "#/components/schemas/RecognizeEntity"
+          description: Array of entity arrays (one per input text)
+        relations:
+          type: array
+          items:
+            type: array
+            items:
+              $ref: "#/components/schemas/Relation"
+          description: |
+            Array of relation arrays (one per input text).
+            Only present when using a model with 'relations' capability (GLiNER multitask, REBEL).
+
     # Rewriter Types (Seq2Seq)
     RewriteRequest:
       type: object
@@ -426,6 +581,81 @@ components:
             items:
               type: string
           description: Rewritten texts (array of arrays, one per input, multiple per beam)
+
+    # Classifier Types (Zero-Shot Classification)
+    ClassifyRequest:
+      type: object
+      required:
+        - model
+        - texts
+        - labels
+      properties:
+        model:
+          type: string
+          description: Name of classifier model from models_dir/classifiers/
+          example: "MoritzLaurer/mDeBERTa-v3-base-mnli-xnli"
+        texts:
+          type: array
+          items:
+            type: string
+          description: Texts to classify
+          example: ["I love this product!", "The service was terrible."]
+        labels:
+          type: array
+          items:
+            type: string
+          description: |
+            Candidate labels for zero-shot classification.
+            The model will predict which label(s) best describe each text.
+          example: ["positive", "negative", "neutral"]
+        hypothesis_template:
+          type: string
+          description: |
+            Custom hypothesis template for NLI-based classification.
+            Use "{}" as placeholder for the label.
+            Default: "This example is {}."
+          example: "This text expresses a {} sentiment."
+        multi_label:
+          type: boolean
+          default: false
+          description: |
+            If true, allows multiple labels per text (independent scoring).
+            If false (default), scores are normalized across labels.
+
+    ClassifyResult:
+      type: object
+      required:
+        - label
+        - score
+      properties:
+        label:
+          type: string
+          description: The predicted class/category
+          example: "positive"
+        score:
+          type: number
+          format: float
+          description: Confidence score (0.0 to 1.0)
+          example: 0.95
+
+    ClassifyResponse:
+      type: object
+      required:
+        - model
+        - classifications
+      properties:
+        model:
+          type: string
+          description: Name of model used for classification
+        classifications:
+          type: array
+          items:
+            type: array
+            items:
+              $ref: "#/components/schemas/ClassifyResult"
+          description: |
+            Array of classification results (one per input text).
+            Each result is an array of ClassifyResult sorted by score descending.
 
     # Extraction Types (GLiNER2)
     ExtractRequest:

--- a/zig/e2e/antfly/test_scaling.py
+++ b/zig/e2e/antfly/test_scaling.py
@@ -560,6 +560,12 @@ class MultiNodeScalingCluster:
             raise last_error
         raise AssertionError("cluster has no metadata URLs")
 
+    def metadata_snapshot_diagnostic(self) -> str:
+        try:
+            return json.dumps(self.metadata_snapshot(), indent=2, sort_keys=True)
+        except Exception as exc:
+            return f"<metadata snapshot unavailable: {exc!r}>"
+
     def post_metadata(self, path: str, *, json_body: dict[str, Any] | None = None) -> requests.Response:
         last_error: Exception | None = None
         for url in self.metadata_urls:
@@ -1309,10 +1315,10 @@ def test_autoscaling_finalizes_shard_split_from_size_threshold(
         for i in range(48)
     }
     _insert_docs(cluster, table_name, docs, min_group_count=1)
+    cluster.trigger_reallocate()
 
     def split_completed() -> set[int] | None:
         try:
-            cluster.trigger_reallocate()
             group_ids = _table_group_ids(cluster, table_name)
         except (AssertionError, requests.RequestException):
             return None
@@ -1324,7 +1330,7 @@ def test_autoscaling_finalizes_shard_split_from_size_threshold(
     assert split_groups is not None, (
         "table did not finalize an automatic split after exceeding the configured shard size threshold\n"
         f"metadata statuses: {json.dumps(cluster.metadata_statuses(), indent=2, sort_keys=True)}\n"
-        f"snapshot: {cluster.metadata_snapshot()}\n"
+        f"snapshot: {cluster.metadata_snapshot_diagnostic()}\n"
         f"{cluster.debug_logs()}"
     )
     _assert_docs_readable(cluster, table_name, docs, timeout_s=60.0)

--- a/zig/e2e/antfly/test_scaling.py
+++ b/zig/e2e/antfly/test_scaling.py
@@ -1315,10 +1315,20 @@ def test_autoscaling_finalizes_shard_split_from_size_threshold(
         for i in range(48)
     }
     _insert_docs(cluster, table_name, docs, min_group_count=1)
-    cluster.trigger_reallocate()
+
+    last_reallocate_at = 0.0
+
+    def maybe_trigger_reallocate() -> None:
+        nonlocal last_reallocate_at
+        now = time.monotonic()
+        if now - last_reallocate_at < 5.0:
+            return
+        cluster.trigger_reallocate()
+        last_reallocate_at = now
 
     def split_completed() -> set[int] | None:
         try:
+            maybe_trigger_reallocate()
             group_ids = _table_group_ids(cluster, table_name)
         except (AssertionError, requests.RequestException):
             return None

--- a/zig/pkg/antfly/src/openapi/generated/antfly_client_openapi/types.zig
+++ b/zig/pkg/antfly/src/openapi/generated/antfly_client_openapi/types.zig
@@ -4907,7 +4907,7 @@ pub const InferenceDocumentTokenClassificationObject = struct {
     checkpoint_path: []const u8,
     prefix: []const u8,
     num_tokens: i64,
-    /// Each result is an array of ClassifyResult sorted by score descending.
+    /// Token classification predictions sorted by score descending.
     predictions: []const InferenceDocumentTokenClassificationPrediction,
 };
 

--- a/zig/pkg/inference/src/api/generated/inference_api/types.zig
+++ b/zig/pkg/inference/src/api/generated/inference_api/types.zig
@@ -818,7 +818,7 @@ pub const DocumentTokenClassificationObject = struct {
     checkpoint_path: []const u8,
     prefix: []const u8,
     num_tokens: i64,
-    /// Each result is an array of ClassifyResult sorted by score descending.
+    /// Token classification predictions sorted by score descending.
     predictions: []const DocumentTokenClassificationPrediction,
 };
 


### PR DESCRIPTION
## Summary
- stop reposting /internal/v1/reallocate on every autoscaling split wait poll
- keep metadata snapshot diagnostics best-effort so failures still include statuses and log tails

## Context
PR #146 e2e-base failed in test_autoscaling_finalizes_shard_split_from_size_threshold after the 180s split wait. The failure path then timed out fetching /metadata/v1/admin/snapshot, which masked the useful logs. This change reduces metadata write pressure during the wait and preserves diagnostics if the cluster is already unhealthy.

## Validation
- UV_CACHE_DIR=/tmp/uv-cache uv run --project zig/e2e/antfly python -m py_compile zig/e2e/antfly/test_scaling.py
- UV_CACHE_DIR=/tmp/uv-cache ANTFLY_BIN=./zig-out/bin/antfly ANTFLY_LSM_OPEN_DEBUG=1 ANTFLY_FS_PATH_DEBUG=1 uv run --project e2e/antfly pytest -q -x e2e/antfly/test_scaling.py::test_autoscaling_finalizes_shard_split_from_size_threshold (skips locally on macOS)
- git diff --check