### PR TITLE
Add trusted-principal MCP auth

### DIFF
--- a/zig/MCP.md
+++ b/zig/MCP.md
@@ -59,6 +59,12 @@ The Go implementation uses mature protocol SDKs:
   - The retrieval agent exposes an event-sink execution path for `classification`, `step_progress`, `hit`,
     `generation`, `followup`, `eval`, and `done` milestones. The A2A retrieval skill uses that path directly so
     retrieval progress is forwarded into the A2A queue as it is produced.
+- Trusted-principal auth
+  - Antfly can accept `X-Antfly-Trusted-Principal: <token>` from a trusted upstream proxy when
+    `ANTFLY_TRUSTED_PRINCIPAL_SECRET` is configured.
+  - `ANTFLY_TRUSTED_PRINCIPAL_ISSUER` optionally constrains the token issuer. Issuer names are provider-owned; Antfly
+    only verifies the configured trust boundary and maps the token's permissions, row filters, and metadata into the
+    normal authenticated identity model.
 - Antfly MCP tools
   - `create_table`
   - `drop_table`
@@ -66,6 +72,7 @@ The Go implementation uses mature protocol SDKs:
   - `create_index`
   - `drop_index`
   - `list_indexes`
+  - `lookup`
   - `query`
   - `backup`
   - `restore`

--- a/zig/pkg/antfly/src/api/http_server.zig
+++ b/zig/pkg/antfly/src/api/http_server.zig
@@ -212,6 +212,8 @@ test "public API request body limit matches Go linear merge contract" {
 
 pub const ApiHttpServerConfig = struct {
     auth_enabled: bool = false,
+    trusted_principal_secret: ?[]const u8 = null,
+    trusted_principal_issuer: ?[]const u8 = null,
     swarm_mode: bool = false,
     backend_runtime: ?*db_mod.background_runtime.BackendRuntime = null,
     foreign_registry: ?*const foreign_mod.Registry = null,
@@ -233,6 +235,13 @@ pub const ApiHttpServerConfig = struct {
     session_owner_lease_ttl_ns: ?u64 = null,
     session_owner_lease_renew_interval_ns: ?u64 = null,
     session_savepoint_limit: ?usize = null,
+};
+
+pub const trusted_principal_header = "X-Antfly-Trusted-Principal";
+
+pub const AuthenticatedRequest = struct {
+    authorization: ?[]const u8 = null,
+    trusted_principal: ?[]const u8 = null,
 };
 
 pub const SemanticStatusResolver = struct {
@@ -1465,14 +1474,21 @@ pub const ApiHttpServer = struct {
     }
 
     fn requiresAuthentication(self: *const ApiHttpServer, path: []const u8) bool {
-        if (!self.cfg.auth_enabled) return false;
-        if (self.cfg.user_manager == null) return false;
+        if (!self.cfg.auth_enabled and self.cfg.trusted_principal_secret == null) return false;
+        if (self.cfg.user_manager == null and self.cfg.trusted_principal_secret == null) return false;
         if (std.mem.eql(u8, path, routes.Routes.agent_card) or std.mem.eql(u8, path, routes.Routes.agent_card_legacy)) return false;
         return !std.mem.startsWith(u8, path, routes.Routes.internal_groups_prefix);
     }
 
-    pub fn authenticateRequest(self: *ApiHttpServer, authorization: ?[]const u8) !AuthenticatedIdentity {
-        const value = authorization orelse return error.Unauthorized;
+    pub fn authenticateRequest(self: *ApiHttpServer, request: AuthenticatedRequest) !AuthenticatedIdentity {
+        if (request.trusted_principal) |trusted_principal| {
+            const token = std.mem.trim(u8, trusted_principal, " \t\r\n");
+            const secret = self.cfg.trusted_principal_secret orelse return error.Unauthorized;
+            if (secret.len == 0) return error.Unauthorized;
+            return try self.authenticateTrustedPrincipal(token, secret);
+        }
+
+        const value = request.authorization orelse return error.Unauthorized;
         const manager = self.cfg.user_manager orelse return error.Unauthorized;
 
         if (std.mem.startsWith(u8, value, "Basic ")) {
@@ -1513,6 +1529,75 @@ pub const ApiHttpServer = struct {
         return error.Unauthorized;
     }
 
+    fn authenticateTrustedPrincipal(self: *ApiHttpServer, token: []const u8, secret: []const u8) !AuthenticatedIdentity {
+        var parts = std.mem.splitScalar(u8, token, '.');
+        const header_b64 = parts.next() orelse return error.Unauthorized;
+        const payload_b64 = parts.next() orelse return error.Unauthorized;
+        const signature_b64 = parts.next() orelse return error.Unauthorized;
+        if (parts.next() != null or header_b64.len == 0 or payload_b64.len == 0 or signature_b64.len == 0) return error.Unauthorized;
+
+        const signing_input = try std.fmt.allocPrint(self.alloc, "{s}.{s}", .{ header_b64, payload_b64 });
+        defer self.alloc.free(signing_input);
+
+        var expected_mac: [std.crypto.auth.hmac.sha2.HmacSha256.mac_length]u8 = undefined;
+        std.crypto.auth.hmac.sha2.HmacSha256.create(expected_mac[0..], signing_input, secret);
+        const signature = try base64UrlDecodeAlloc(self.alloc, signature_b64);
+        defer self.alloc.free(signature);
+        if (!constantTimeEql(signature, expected_mac[0..])) return error.Unauthorized;
+
+        const header_json = try base64UrlDecodeAlloc(self.alloc, header_b64);
+        defer self.alloc.free(header_json);
+        var parsed_header = try std.json.parseFromSlice(std.json.Value, self.alloc, header_json, .{});
+        defer parsed_header.deinit();
+        const header_obj = switch (parsed_header.value) {
+            .object => |object| object,
+            else => return error.Unauthorized,
+        };
+        if (!std.mem.eql(u8, jsonStringField(header_obj.get("alg")) orelse "", "HS256")) return error.Unauthorized;
+
+        const payload_json = try base64UrlDecodeAlloc(self.alloc, payload_b64);
+        defer self.alloc.free(payload_json);
+        var parsed_payload = try std.json.parseFromSlice(std.json.Value, self.alloc, payload_json, .{});
+        defer parsed_payload.deinit();
+        const payload = switch (parsed_payload.value) {
+            .object => |object| object,
+            else => return error.Unauthorized,
+        };
+        if (self.cfg.trusted_principal_issuer) |expected_issuer| {
+            if (!std.mem.eql(u8, jsonStringField(payload.get("iss")) orelse "", expected_issuer)) return error.Unauthorized;
+        }
+        const subject = jsonStringField(payload.get("sub")) orelse return error.Unauthorized;
+        const exp = jsonIntegerField(payload.get("exp")) orelse return error.Unauthorized;
+        const now: i64 = @intCast(@divFloor(nowNs(), std.time.ns_per_s));
+        if (exp < now) return error.Unauthorized;
+        if (jsonIntegerField(payload.get("iat"))) |iat| {
+            if (iat > now + 60) return error.Unauthorized;
+        }
+
+        const permissions = try trustedPrincipalPermissionsFromPayload(self.alloc, payload);
+        errdefer {
+            for (permissions) |*permission| permission.deinit(self.alloc);
+            if (permissions.len > 0) self.alloc.free(permissions);
+        }
+        const row_filters = try trustedPrincipalRowFiltersFromPayload(self.alloc, payload);
+        errdefer {
+            for (row_filters) |*entry| entry.deinit(self.alloc);
+            if (row_filters.len > 0) self.alloc.free(row_filters);
+        }
+        const metadata_json = if (payload.get("metadata")) |metadata|
+            try std.json.Stringify.valueAlloc(self.alloc, metadata, .{})
+        else
+            try self.alloc.dupe(u8, "{}");
+
+        return .{
+            .username = try self.alloc.dupe(u8, subject),
+            .permissions = permissions,
+            .row_filter = row_filters,
+            .metadata_json = metadata_json,
+            .roles = try self.alloc.alloc([]u8, 0),
+        };
+    }
+
     pub fn handleInternalRoute(self: *ApiHttpServer, req: http_common.HttpRequest) !?http_common.HttpResponse {
         const uri_parts = splitTarget(req.uri);
         if (!std.mem.startsWith(u8, uri_parts.path, routes.Routes.internal_groups_prefix) and
@@ -1542,7 +1627,10 @@ pub const ApiHttpServer = struct {
         }
 
         if (self.requiresAuthentication(uri_parts.path)) {
-            authenticated_identity = self.authenticateRequest(req.authorization) catch |err| switch (err) {
+            authenticated_identity = self.authenticateRequest(.{
+                .authorization = req.authorization,
+                .trusted_principal = req.header(trusted_principal_header),
+            }) catch |err| switch (err) {
                 error.Unauthorized, error.InvalidPassword, error.UserNotFound, error.ApiKeyInvalid, error.ApiKeyNotFound, error.ApiKeyExpired => {
                     return try unauthorizedResponse(self.alloc);
                 },
@@ -1611,9 +1699,8 @@ pub const ApiHttpServer = struct {
     }
 
     fn dispatchProtocolRoutes(self: *ApiHttpServer, req: http_common.HttpRequest, uri_parts: UriParts, authenticated_identity: ?AuthenticatedIdentity) !?http_common.HttpResponse {
-        _ = authenticated_identity;
         if ((req.method == .GET or req.method == .POST or req.method == .DELETE) and (std.mem.eql(u8, uri_parts.path, routes.Routes.mcp_v1) or std.mem.startsWith(u8, uri_parts.path, routes.Routes.mcp_v1_prefix))) {
-            return try protocol_adapters.handleMcpRequest(self, req);
+            return try protocol_adapters.handleMcpRequest(self, req, authenticated_identity);
         }
         if (req.method == .POST and std.mem.eql(u8, uri_parts.path, routes.Routes.a2a)) {
             return try protocol_adapters.handleA2aRequest(self, req);
@@ -4341,7 +4428,10 @@ pub const ApiHttpServer = struct {
         var authenticated_identity: ?AuthenticatedIdentity = null;
         defer if (authenticated_identity) |*identity| identity.deinit(self.alloc);
         if (self.requiresAuthentication(uri_parts.path)) {
-            authenticated_identity = self.authenticateRequest(req.authorization) catch return false;
+            authenticated_identity = self.authenticateRequest(.{
+                .authorization = req.authorization,
+                .trusted_principal = req.header(trusted_principal_header),
+            }) catch return false;
             const identity = authenticated_identity.?;
             if (requiresAdminPermission(uri_parts.path) and !permissionsAllow(identity.permissions, .@"*", "*", .admin)) return false;
             if (requiredPermissionForRequest(req.method, uri_parts.path)) |required| {
@@ -5888,6 +5978,126 @@ pub fn permissionsAllow(
     return false;
 }
 
+fn base64UrlDecodeAlloc(alloc: std.mem.Allocator, value: []const u8) ![]u8 {
+    const size = std.base64.url_safe_no_pad.Decoder.calcSizeForSlice(value) catch return error.Unauthorized;
+    const out = try alloc.alloc(u8, size);
+    errdefer alloc.free(out);
+    std.base64.url_safe_no_pad.Decoder.decode(out, value) catch return error.Unauthorized;
+    return out;
+}
+
+fn constantTimeEql(lhs: []const u8, rhs: []const u8) bool {
+    if (lhs.len != rhs.len) return false;
+    var diff: u8 = 0;
+    for (lhs, rhs) |left, right| diff |= left ^ right;
+    return diff == 0;
+}
+
+fn jsonStringField(value: ?std.json.Value) ?[]const u8 {
+    const present = value orelse return null;
+    return jsonStringValue(present);
+}
+
+fn jsonStringValue(value: std.json.Value) ?[]const u8 {
+    return switch (value) {
+        .string => |string| string,
+        else => null,
+    };
+}
+
+fn jsonIntegerField(value: ?std.json.Value) ?i64 {
+    const present = value orelse return null;
+    return jsonIntegerValue(present);
+}
+
+fn jsonIntegerValue(value: std.json.Value) ?i64 {
+    return switch (value) {
+        .integer => |integer| integer,
+        else => null,
+    };
+}
+
+fn jsonBoolField(value: ?std.json.Value) bool {
+    const present = value orelse return false;
+    return jsonBoolValue(present);
+}
+
+fn jsonBoolValue(value: std.json.Value) bool {
+    return switch (value) {
+        .bool => |boolean| boolean,
+        else => false,
+    };
+}
+
+fn trustedPrincipalPermissionsFromPayload(alloc: std.mem.Allocator, payload: std.json.ObjectMap) ![]usermgr.Permission {
+    var out = std.ArrayList(usermgr.Permission).empty;
+    errdefer {
+        for (out.items) |*permission| permission.deinit(alloc);
+        out.deinit(alloc);
+    }
+
+    if (jsonBoolField(payload.get("admin"))) {
+        try out.append(alloc, try usermgr.Permission.initOwned(alloc, .@"*", "*", .admin));
+        return try out.toOwnedSlice(alloc);
+    }
+
+    const tables_value = payload.get("tables");
+    const operations_value = payload.get("operations");
+    if (operations_value == null or operations_value.? != .array or operations_value.?.array.items.len == 0) {
+        return try out.toOwnedSlice(alloc);
+    }
+
+    if (tables_value == null or tables_value.? != .array or tables_value.?.array.items.len == 0) {
+        try appendTrustedPrincipalPermissionsForTable(alloc, &out, "*", operations_value.?.array.items);
+    } else {
+        for (tables_value.?.array.items) |table_value| {
+            const table = jsonStringValue(table_value) orelse continue;
+            if (table.len == 0) continue;
+            try appendTrustedPrincipalPermissionsForTable(alloc, &out, table, operations_value.?.array.items);
+        }
+    }
+    return try out.toOwnedSlice(alloc);
+}
+
+fn appendTrustedPrincipalPermissionsForTable(
+    alloc: std.mem.Allocator,
+    out: *std.ArrayList(usermgr.Permission),
+    table: []const u8,
+    operation_values: []const std.json.Value,
+) !void {
+    for (operation_values) |operation_value| {
+        const operation = jsonStringValue(operation_value) orelse continue;
+        if (std.mem.eql(u8, operation, "read")) {
+            try out.append(alloc, try usermgr.Permission.initOwned(alloc, .table, table, .read));
+        } else if (std.mem.eql(u8, operation, "write")) {
+            try out.append(alloc, try usermgr.Permission.initOwned(alloc, .table, table, .write));
+        } else if (std.mem.eql(u8, operation, "admin")) {
+            try out.append(alloc, try usermgr.Permission.initOwned(alloc, .table, table, .admin));
+        } else if (std.mem.eql(u8, operation, "*")) {
+            try out.append(alloc, try usermgr.Permission.initOwned(alloc, .table, table, .read));
+            try out.append(alloc, try usermgr.Permission.initOwned(alloc, .table, table, .write));
+            try out.append(alloc, try usermgr.Permission.initOwned(alloc, .table, table, .admin));
+        }
+    }
+}
+
+fn trustedPrincipalRowFiltersFromPayload(alloc: std.mem.Allocator, payload: std.json.ObjectMap) ![]usermgr.RowFilterEntry {
+    const row_filter_value = payload.get("row_filter") orelse return try alloc.alloc(usermgr.RowFilterEntry, 0);
+    if (row_filter_value != .object) return error.Unauthorized;
+    var out = std.ArrayList(usermgr.RowFilterEntry).empty;
+    errdefer {
+        for (out.items) |*entry| entry.deinit(alloc);
+        out.deinit(alloc);
+    }
+    var it = row_filter_value.object.iterator();
+    while (it.next()) |entry| {
+        const filter_json = try std.json.Stringify.valueAlloc(alloc, entry.value_ptr.*, .{});
+        defer alloc.free(filter_json);
+        try out.append(alloc, try usermgr.RowFilterEntry.initOwned(alloc, entry.key_ptr.*, filter_json));
+    }
+    return try out.toOwnedSlice(alloc);
+}
+
 fn applyAuthenticatedIdentityToJoinRequest(
     alloc: std.mem.Allocator,
     identity: AuthenticatedIdentity,
@@ -7162,6 +7372,55 @@ test "api http server serves mcp and a2a protocol surfaces" {
     try std.testing.expect(std.mem.indexOf(u8, cancel_resp.body, "\"state\":\"canceled\"") != null);
 }
 
+test "api http server authenticates trusted principal" {
+    const FakeSource = struct {
+        fn iface(_: *@This()) StatusSource {
+            return .{
+                .ptr = undefined,
+                .vtable = &.{ .status = status },
+            };
+        }
+
+        fn status(_: *anyopaque) !metadata_api.MetadataStatus {
+            return .{ .metadata_group_id = 77, .metrics = .{} };
+        }
+    };
+
+    const secret = "trusted-principal-test-secret";
+    const now: i64 = @intCast(@divFloor(nowNs(), std.time.ns_per_s));
+    const payload = try std.fmt.allocPrint(
+        std.testing.allocator,
+        \\{{"iss":"trusted-upstream","sub":"user:alice","tenant":"inst-1","tables":["docs"],"operations":["read"],"row_filter":{{"docs":{{"term":{{"tenant_id":"t1"}}}}}},"iat":{d},"exp":{d}}}
+    ,
+        .{ now, now + 60 },
+    );
+    defer std.testing.allocator.free(payload);
+    const token = try encodeTrustedPrincipalToken(std.testing.allocator, secret, payload);
+    defer std.testing.allocator.free(token);
+
+    var source = FakeSource{};
+    var server = ApiHttpServer.init(
+        std.testing.allocator,
+        .{ .trusted_principal_secret = secret, .trusted_principal_issuer = "trusted-upstream" },
+        source.iface(),
+        null,
+        null,
+    );
+    defer server.deinit();
+    try std.testing.expect(server.requiresAuthentication(routes.Routes.tables));
+
+    var identity = try server.authenticateRequest(.{ .trusted_principal = token });
+    defer identity.deinit(std.testing.allocator);
+    try std.testing.expectEqualStrings("user:alice", identity.username);
+    try std.testing.expectEqual(@as(usize, 1), identity.permissions.len);
+    try std.testing.expectEqual(usermgr.ResourceType.table, identity.permissions[0].resource_type);
+    try std.testing.expectEqualStrings("docs", identity.permissions[0].resource);
+    try std.testing.expectEqual(usermgr.PermissionType.read, identity.permissions[0].type);
+    try std.testing.expectEqual(@as(usize, 1), identity.row_filter.len);
+    try std.testing.expectEqualStrings("docs", identity.row_filter[0].table);
+    try std.testing.expect(std.mem.indexOf(u8, identity.row_filter[0].filter, "\"tenant_id\":\"t1\"") != null);
+}
+
 fn encodeBasicAuthorization(alloc: std.mem.Allocator, username: []const u8, password: []const u8) ![]u8 {
     const raw = try std.fmt.allocPrint(alloc, "{s}:{s}", .{ username, password });
     defer alloc.free(raw);
@@ -7170,6 +7429,27 @@ fn encodeBasicAuthorization(alloc: std.mem.Allocator, username: []const u8, pass
     defer alloc.free(encoded);
     _ = std.base64.standard.Encoder.encode(encoded, raw);
     return try std.fmt.allocPrint(alloc, "Basic {s}", .{encoded});
+}
+
+fn encodeTrustedPrincipalToken(alloc: std.mem.Allocator, secret: []const u8, payload: []const u8) ![]u8 {
+    const header = "{\"alg\":\"HS256\",\"typ\":\"JWT\"}";
+    const header_size = std.base64.url_safe_no_pad.Encoder.calcSize(header.len);
+    const header_encoded = try alloc.alloc(u8, header_size);
+    defer alloc.free(header_encoded);
+    _ = std.base64.url_safe_no_pad.Encoder.encode(header_encoded, header);
+    const payload_size = std.base64.url_safe_no_pad.Encoder.calcSize(payload.len);
+    const payload_encoded = try alloc.alloc(u8, payload_size);
+    defer alloc.free(payload_encoded);
+    _ = std.base64.url_safe_no_pad.Encoder.encode(payload_encoded, payload);
+    const signing_input = try std.fmt.allocPrint(alloc, "{s}.{s}", .{ header_encoded, payload_encoded });
+    defer alloc.free(signing_input);
+    var mac: [std.crypto.auth.hmac.sha2.HmacSha256.mac_length]u8 = undefined;
+    std.crypto.auth.hmac.sha2.HmacSha256.create(mac[0..], signing_input, secret);
+    const signature_size = std.base64.url_safe_no_pad.Encoder.calcSize(mac.len);
+    const signature_encoded = try alloc.alloc(u8, signature_size);
+    defer alloc.free(signature_encoded);
+    _ = std.base64.url_safe_no_pad.Encoder.encode(signature_encoded, mac[0..]);
+    return try std.fmt.allocPrint(alloc, "{s}.{s}", .{ signing_input, signature_encoded });
 }
 
 const TestAuthManager = struct {
@@ -8431,6 +8711,127 @@ test "api http server decodes percent-encoded lookup keys" {
     var parsed = try std.json.parseFromSlice(LookupResponse, std.testing.allocator, resp.body, .{});
     defer parsed.deinit();
     try std.testing.expectEqualStrings("alpha", parsed.value.title);
+}
+
+test "api http server serves lookup through mcp tool" {
+    const alloc = std.testing.allocator;
+    const path = "/tmp/antfly-api-http-mcp-lookup";
+    var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
+    defer io_impl.deinit();
+    std.Io.Dir.cwd().deleteTree(io_impl.io(), path) catch {};
+
+    var db = try db_mod.DB.open(alloc, path, .{});
+    defer {
+        db.close();
+        std.Io.Dir.cwd().deleteTree(io_impl.io(), path) catch {};
+    }
+    try db.batch(.{
+        .writes = &.{
+            .{
+                .key = "docs/getting-started.md",
+                .value = "{\"title\":\"alpha\",\"body\":\"hello\"}",
+            },
+        },
+        .timestamp_ns = 4321,
+    });
+
+    var table_source = table_reads.BoundTableReadSource.init("docs", 77, &db, raft_mod.read_gate.noopReadableLeaseRequester());
+
+    const FakeSource = struct {
+        fn iface(_: *@This()) StatusSource {
+            return .{
+                .ptr = undefined,
+                .vtable = &.{
+                    .status = status,
+                    .admin_snapshot = adminSnapshot,
+                    .free_admin_snapshot = freeAdminSnapshot,
+                },
+            };
+        }
+
+        fn status(_: *anyopaque) !metadata_api.MetadataStatus {
+            return .{ .metadata_group_id = 1, .metrics = .{}, .projected_stores = 1 };
+        }
+
+        fn adminSnapshot(_: *anyopaque) !metadata_api.AdminSnapshot {
+            return .{
+                .status = .{ .metadata_group_id = 1, .metrics = .{} },
+                .tables = @constCast((&[_]metadata_table_manager.TableRecord{.{ .table_id = 1, .name = "docs", .placement_role = "data" }})[0..]),
+                .ranges = @constCast((&[_]metadata_table_manager.RangeRecord{.{ .group_id = 10, .table_id = 1, .start_key = "", .end_key = "" }})[0..]),
+                .stores = @constCast((&[_]metadata_table_manager.StoreRecord{})[0..]),
+                .placement_intents = @constCast((&[_]raft_reconciler.PlacementIntent{})[0..]),
+                .split_transitions = @constCast((&[_]metadata_transition_state.SplitTransitionRecord{})[0..]),
+                .merge_transitions = @constCast((&[_]metadata_transition_state.MergeTransitionRecord{})[0..]),
+            };
+        }
+
+        fn freeAdminSnapshot(_: *anyopaque, _: *metadata_api.AdminSnapshot) void {}
+    };
+
+    var source = FakeSource{};
+    const trusted_principal_secret = "mcp-lookup-trusted-principal-secret";
+    const now: i64 = @intCast(@divFloor(nowNs(), std.time.ns_per_s));
+    const payload = try std.fmt.allocPrint(
+        std.testing.allocator,
+        \\{{"iss":"trusted-upstream","sub":"user:alice","tenant":"inst-1","tables":["docs"],"operations":["read"],"iat":{d},"exp":{d}}}
+    ,
+        .{ now, now + 60 },
+    );
+    defer std.testing.allocator.free(payload);
+    const token = try encodeTrustedPrincipalToken(std.testing.allocator, trusted_principal_secret, payload);
+    defer std.testing.allocator.free(token);
+
+    var server = ApiHttpServer.init(
+        std.testing.allocator,
+        .{
+            .auth_enabled = true,
+            .trusted_principal_secret = trusted_principal_secret,
+            .trusted_principal_issuer = "trusted-upstream",
+        },
+        source.iface(),
+        table_source.source(),
+        null,
+    );
+    defer server.deinit();
+    const trusted_principal_headers = [_]http_common.RequestHeader{
+        .{ .name = trusted_principal_header, .value = token },
+    };
+
+    var init_resp = try server.handle(.{
+        .method = .POST,
+        .uri = routes.Routes.mcp_v1,
+        .headers = &trusted_principal_headers,
+        .content_type = "application/json",
+        .body = "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{}}",
+    });
+    defer init_resp.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(u16, 200), init_resp.status);
+
+    const mcp_session_headers = [_]http_common.RequestHeader{
+        .{ .name = mcp.session_id_header, .value = init_resp.headers[0].value },
+        .{ .name = trusted_principal_header, .value = token },
+    };
+    var tools_resp = try server.handle(.{
+        .method = .POST,
+        .uri = routes.Routes.mcp_v1,
+        .headers = &mcp_session_headers,
+        .content_type = "application/json",
+        .body = "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/list\",\"params\":{}}",
+    });
+    defer tools_resp.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(u16, 200), tools_resp.status);
+    try std.testing.expect(std.mem.indexOf(u8, tools_resp.body, "\"name\":\"lookup\"") != null);
+
+    var call_resp = try server.handle(.{
+        .method = .POST,
+        .uri = routes.Routes.mcp_v1,
+        .headers = &mcp_session_headers,
+        .content_type = "application/json",
+        .body = "{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"tools/call\",\"params\":{\"name\":\"lookup\",\"arguments\":{\"tableName\":\"docs\",\"key\":\"docs/getting-started.md\",\"fields\":[\"title\"]}}}",
+    });
+    defer call_resp.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(u16, 200), call_resp.status);
+    try std.testing.expect(std.mem.indexOf(u8, call_resp.body, "\"structuredContent\":{\"title\":\"alpha\"}") != null);
 }
 
 test "api http server serves table scan as ndjson" {

--- a/zig/pkg/antfly/src/api/httpx_handler.zig
+++ b/zig/pkg/antfly/src/api/httpx_handler.zig
@@ -203,9 +203,15 @@ pub const AntflyApiHandler = struct {
                 return error.UnsupportedMethod;
             },
         };
+        const trusted_principal_headers: []const http_common.RequestHeader = if (ctx.header(http_server_mod.trusted_principal_header)) |trusted_principal| blk: {
+            const headers = try ctx.allocator.alloc(http_common.RequestHeader, 1);
+            headers[0] = .{ .name = http_server_mod.trusted_principal_header, .value = trusted_principal };
+            break :blk headers;
+        } else &.{};
         return .{
             .method = method,
             .uri = ctx.request.uri.raw,
+            .headers = trusted_principal_headers,
             .authorization = ctx.header("authorization"),
             .content_type = ctx.header("content-type"),
             .body = body_data,
@@ -217,9 +223,11 @@ pub const AntflyApiHandler = struct {
     // ---------------------------------------------------------------
 
     fn authenticate(self: *AntflyApiHandler, ctx: *httpx.Context) !?AuthenticatedIdentity {
-        if (!self.api_server.cfg.auth_enabled) return null;
-        const auth_header = ctx.header("authorization");
-        return self.api_server.authenticateRequest(auth_header) catch |err| switch (err) {
+        if (!self.api_server.cfg.auth_enabled and self.api_server.cfg.trusted_principal_secret == null) return null;
+        return self.api_server.authenticateRequest(.{
+            .authorization = ctx.header("authorization"),
+            .trusted_principal = ctx.header(http_server_mod.trusted_principal_header),
+        }) catch |err| switch (err) {
             error.Unauthorized, error.InvalidPassword, error.UserNotFound, error.ApiKeyInvalid, error.ApiKeyNotFound, error.ApiKeyExpired => {
                 return null;
             },
@@ -228,7 +236,7 @@ pub const AntflyApiHandler = struct {
     }
 
     fn requireAuth(self: *AntflyApiHandler, ctx: *httpx.Context) !?AuthenticatedIdentity {
-        if (!self.api_server.cfg.auth_enabled) return null;
+        if (!self.api_server.cfg.auth_enabled and self.api_server.cfg.trusted_principal_secret == null) return null;
         const identity = (try self.authenticate(ctx)) orelse {
             return error.Unauthorized;
         };
@@ -266,11 +274,14 @@ pub const AntflyApiHandler = struct {
 
     fn authorizeRequest(self: *AntflyApiHandler, ctx: *httpx.Context, identity: *?AuthenticatedIdentity) !?httpx.Response {
         identity.* = null;
-        if (!self.api_server.cfg.auth_enabled) return null;
-        if (self.api_server.cfg.user_manager == null) return null;
+        if (!self.api_server.cfg.auth_enabled and self.api_server.cfg.trusted_principal_secret == null) return null;
+        if (self.api_server.cfg.user_manager == null and self.api_server.cfg.trusted_principal_secret == null) return null;
 
         const path = http_server_mod.stripApiPrefix(ctx.request.uri.path);
-        identity.* = self.api_server.authenticateRequest(ctx.header("authorization")) catch |err| switch (err) {
+        identity.* = self.api_server.authenticateRequest(.{
+            .authorization = ctx.header("authorization"),
+            .trusted_principal = ctx.header(http_server_mod.trusted_principal_header),
+        }) catch |err| switch (err) {
             error.Unauthorized, error.InvalidPassword, error.UserNotFound, error.ApiKeyInvalid, error.ApiKeyNotFound, error.ApiKeyExpired => {
                 return try unauthorizedResponse(ctx);
             },

--- a/zig/pkg/antfly/src/api/protocol_adapters.zig
+++ b/zig/pkg/antfly/src/api/protocol_adapters.zig
@@ -15,8 +15,11 @@
 const std = @import("std");
 const routes = @import("http_routes.zig");
 const http_common = @import("../raft/transport/http_common.zig");
+const usermgr = @import("../usermgr/mod.zig");
 const mcp = @import("antfly_mcp");
 const a2a = @import("antfly_a2a");
+
+const trusted_principal_header = "X-Antfly-Trusted-Principal";
 
 const McpToolKind = enum {
     create_table,
@@ -25,6 +28,7 @@ const McpToolKind = enum {
     create_index,
     drop_index,
     list_indexes,
+    lookup,
     query,
     backup,
     restore,
@@ -103,6 +107,16 @@ const mcp_tool_specs = [_]McpToolSpec{
         .fields = &.{.{ .name = "tableName", .schema_type = .string, .required = true }},
     },
     .{
+        .kind = .lookup,
+        .name = "lookup",
+        .description = "Look up an Antfly document by key",
+        .fields = &.{
+            .{ .name = "tableName", .schema_type = .string, .required = true },
+            .{ .name = "key", .schema_type = .string, .required = true },
+            .{ .name = "fields", .schema_type = .array, .items_json = "{\"type\":\"string\"}" },
+        },
+    },
+    .{
         .kind = .query,
         .name = "query",
         .description = "Run an Antfly table query",
@@ -149,11 +163,12 @@ const mcp_tool_specs = [_]McpToolSpec{
     },
 };
 
-pub fn handleMcpRequest(server_ptr: anytype, req: http_common.HttpRequest) !http_common.HttpResponse {
+pub fn handleMcpRequest(server_ptr: anytype, req: http_common.HttpRequest, authenticated_identity: anytype) !http_common.HttpResponse {
     const Server = @TypeOf(server_ptr);
     const ToolContext = struct {
         server: Server,
         authorization: ?[]const u8,
+        trusted_principal: ?[]const u8,
         kind: McpToolKind,
 
         fn handler(ctx: *@This()) mcp.ToolHandler {
@@ -169,6 +184,7 @@ pub fn handleMcpRequest(server_ptr: anytype, req: http_common.HttpRequest) !http
                 .create_index => try ctx.createIndex(alloc, args),
                 .drop_index => try ctx.indexRoute(alloc, args, .DELETE, ""),
                 .list_indexes => try ctx.listIndexes(alloc, args),
+                .lookup => try ctx.lookup(alloc, args),
                 .query => try ctx.query(alloc, args),
                 .backup => try ctx.backupRestore(alloc, args, "backup"),
                 .restore => try ctx.backupRestore(alloc, args, "restore"),
@@ -217,6 +233,33 @@ pub fn handleMcpRequest(server_ptr: anytype, req: http_common.HttpRequest) !http
             const table_name = jsonStringArg(args, "tableName") orelse return mcpError(alloc, "missing tableName");
             const uri = try std.fmt.allocPrint(alloc, "{s}/{s}/indexes", .{ routes.Routes.tables, table_name });
             return try ctx.simpleRoute(alloc, .GET, uri, "");
+        }
+
+        fn lookup(ctx: *@This(), alloc: std.mem.Allocator, args: std.json.Value) !mcp.CallToolResult {
+            const table_name = jsonStringArg(args, "tableName") orelse return mcpError(alloc, "missing tableName");
+            const key = jsonStringArg(args, "key") orelse return mcpError(alloc, "missing key");
+
+            var uri = std.ArrayListUnmanaged(u8).empty;
+            errdefer uri.deinit(alloc);
+            try uri.appendSlice(alloc, routes.Routes.tables);
+            try uri.append(alloc, '/');
+            try uri.appendSlice(alloc, table_name);
+            try uri.appendSlice(alloc, routes.Routes.lookup_marker);
+            try appendUriPathSegment(alloc, &uri, key);
+
+            if (jsonValueArg(args, "fields")) |fields| {
+                if (fields != .array) return mcpError(alloc, "fields must be an array");
+                if (fields.array.items.len > 0) {
+                    try uri.appendSlice(alloc, "?fields=");
+                    for (fields.array.items, 0..) |field, i| {
+                        if (field != .string) return mcpError(alloc, "fields must contain strings");
+                        if (i != 0) try uri.append(alloc, ',');
+                        try uri.appendSlice(alloc, field.string);
+                    }
+                }
+            }
+
+            return try ctx.simpleRoute(alloc, .GET, try uri.toOwnedSlice(alloc), "");
         }
 
         fn indexRoute(ctx: *@This(), alloc: std.mem.Allocator, args: std.json.Value, method: http_common.Method, body: []const u8) !mcp.CallToolResult {
@@ -276,9 +319,14 @@ pub fn handleMcpRequest(server_ptr: anytype, req: http_common.HttpRequest) !http
         }
 
         fn simpleRoute(ctx: *@This(), alloc: std.mem.Allocator, method: http_common.Method, uri: []const u8, body: []const u8) !mcp.CallToolResult {
+            const headers: []const http_common.RequestHeader = if (ctx.trusted_principal) |trusted_principal|
+                &[_]http_common.RequestHeader{.{ .name = trusted_principal_header, .value = trusted_principal }}
+            else
+                &.{};
             var resp = try ctx.server.handle(.{
                 .method = method,
                 .uri = uri,
+                .headers = headers,
                 .authorization = ctx.authorization,
                 .content_type = if (body.len == 0) null else "application/json",
                 .body = body,
@@ -290,7 +338,12 @@ pub fn handleMcpRequest(server_ptr: anytype, req: http_common.HttpRequest) !http
 
     var contexts: [mcp_tool_specs.len]ToolContext = undefined;
     for (&contexts, mcp_tool_specs) |*ctx, spec| {
-        ctx.* = .{ .server = server_ptr, .authorization = req.authorization, .kind = spec.kind };
+        ctx.* = .{
+            .server = server_ptr,
+            .authorization = req.authorization,
+            .trusted_principal = req.header(trusted_principal_header),
+            .kind = spec.kind,
+        };
     }
 
     var input_schemas: [mcp_tool_specs.len][]u8 = undefined;
@@ -309,6 +362,7 @@ pub fn handleMcpRequest(server_ptr: anytype, req: http_common.HttpRequest) !http
     };
     defer protocol_server.deinit(server_ptr.alloc);
     for (&contexts, mcp_tool_specs, 0..) |*ctx, spec, i| {
+        if (!mcpToolVisibleForIdentity(spec.kind, authenticated_identity)) continue;
         try protocol_server.addTool(server_ptr.alloc, .{
             .name = spec.name,
             .description = spec.description,
@@ -335,6 +389,40 @@ pub fn handleMcpRequest(server_ptr: anytype, req: http_common.HttpRequest) !http
     };
     defer transport.deinit(server_ptr.alloc);
     return try mcpBodyResponseWithStatus(server_ptr.alloc, transport);
+}
+
+fn mcpToolVisibleForIdentity(kind: McpToolKind, authenticated_identity: anytype) bool {
+    const identity = authenticated_identity orelse return true;
+    return switch (kind) {
+        .list_tables => identityHasPermission(identity.permissions, .table, "*", .read),
+        .query, .lookup, .list_indexes => identityHasAnyPermission(identity.permissions, .table, .read),
+        .batch => identityHasAnyPermission(identity.permissions, .table, .write),
+        .create_table, .drop_table, .create_index, .drop_index, .backup, .restore => identityHasAnyPermission(identity.permissions, .table, .admin),
+    };
+}
+
+fn identityHasAnyPermission(permissions: []const usermgr.Permission, resource_type: usermgr.ResourceType, permission_type: usermgr.PermissionType) bool {
+    for (permissions) |permission| {
+        const type_match = permission.resource_type == .@"*" or permission.resource_type == resource_type;
+        if (!type_match) continue;
+        if (permission.type == .admin or permission.type == permission_type) return true;
+    }
+    return false;
+}
+
+fn identityHasPermission(
+    permissions: []const usermgr.Permission,
+    resource_type: usermgr.ResourceType,
+    resource: []const u8,
+    permission_type: usermgr.PermissionType,
+) bool {
+    for (permissions) |permission| {
+        const type_match = permission.resource_type == .@"*" or permission.resource_type == resource_type;
+        const resource_match = std.mem.eql(u8, permission.resource, "*") or std.mem.eql(u8, permission.resource, resource);
+        if (!type_match or !resource_match) continue;
+        if (permission.type == .admin or permission.type == permission_type) return true;
+    }
+    return false;
 }
 
 fn validateMcpSession(server_ptr: anytype, req: http_common.HttpRequest) !?http_common.HttpResponse {
@@ -705,6 +793,26 @@ fn appendJsonString(alloc: std.mem.Allocator, out: *std.ArrayListUnmanaged(u8), 
     const encoded = try stringifyJsonValue(alloc, .{ .string = text });
     defer alloc.free(encoded);
     try out.appendSlice(alloc, encoded);
+}
+
+fn appendUriPathSegment(alloc: std.mem.Allocator, out: *std.ArrayListUnmanaged(u8), text: []const u8) !void {
+    const hex = "0123456789ABCDEF";
+    for (text) |ch| {
+        if (isUriUnreserved(ch)) {
+            try out.append(alloc, ch);
+        } else {
+            try out.append(alloc, '%');
+            try out.append(alloc, hex[ch >> 4]);
+            try out.append(alloc, hex[ch & 0x0f]);
+        }
+    }
+}
+
+fn isUriUnreserved(ch: u8) bool {
+    return (ch >= 'A' and ch <= 'Z') or
+        (ch >= 'a' and ch <= 'z') or
+        (ch >= '0' and ch <= '9') or
+        ch == '-' or ch == '.' or ch == '_' or ch == '~';
 }
 
 fn mcpError(alloc: std.mem.Allocator, text: []const u8) !mcp.CallToolResult {

--- a/zig/pkg/antfly/src/data/runtime.zig
+++ b/zig/pkg/antfly/src/data/runtime.zig
@@ -48,6 +48,8 @@ const data_raft_batch_leader_retry_sleep_ns: u64 = 50 * std.time.ns_per_ms;
 const data_raft_metadata_resync_interval_ns: u64 = 500 * std.time.ns_per_ms;
 const data_raft_campaign_retry_interval_ns: u64 = 500 * std.time.ns_per_ms;
 const data_raft_metadata_sync_interval_ms: u64 = 250;
+const trusted_principal_secret_key = "antfly.trusted_principal.secret";
+const trusted_principal_issuer_key = "antfly.trusted_principal.issuer";
 
 const CliConfig = struct {
     config_path: ?[]const u8 = null,
@@ -7211,6 +7213,12 @@ pub fn runFromIterator(
     defer metadata_api_urls.deinit(alloc);
     if ((cli.node_id == null) != (cli.store_id == null)) return error.InvalidArguments;
     const auth_enabled = resolveAuthEnabled(cli, if (loaded_config) |*cfg| cfg else null);
+    const trusted_principal_secret = try resolveTrustedPrincipalSecret(
+        alloc,
+        if (secret_store_initialized) &secret_store else null,
+    );
+    defer if (trusted_principal_secret) |value| alloc.free(value);
+    const effective_auth_enabled = auth_enabled or trusted_principal_secret != null;
 
     var setup_io = std.Io.Threaded.init(alloc, .{ .stack_size = setup_io_thread_stack_size });
     defer setup_io.deinit();
@@ -7252,6 +7260,12 @@ pub fn runFromIterator(
     defer if (auth_runtime) |*runtime| runtime.deinit();
     defer if (auth_backend) |*backend| backend.close();
 
+    const trusted_principal_issuer = try resolveTrustedPrincipalIssuer(
+        alloc,
+        if (secret_store_initialized) &secret_store else null,
+    );
+    defer if (trusted_principal_issuer) |value| alloc.free(value);
+
     var data_server = try DataServer.initFromMetadataApiUrls(alloc, .{
         .bind_host = cli.bind_host orelse "127.0.0.1",
         .bind_port = cli.bind_port orelse 0,
@@ -7267,7 +7281,9 @@ pub fn runFromIterator(
             .failure_domain = cli.failure_domain orelse "",
         } else null,
         .api_server_cfg = .{
-            .auth_enabled = auth_enabled,
+            .auth_enabled = effective_auth_enabled,
+            .trusted_principal_secret = trusted_principal_secret,
+            .trusted_principal_issuer = trusted_principal_issuer,
             .user_manager = if (user_manager) |*manager| manager else null,
             .secret_store = if (secret_store_initialized) &secret_store else null,
         },
@@ -7569,6 +7585,47 @@ fn resolveAuthEnabled(cli: CliConfig, cfg: ?*const antfly.common.config.Config) 
     return false;
 }
 
+fn resolveTrustedPrincipalSecret(
+    alloc: std.mem.Allocator,
+    secret_store: ?*antfly.common.secrets.FileStore,
+) !?[]u8 {
+    return try resolveTrustedPrincipalConfigValue(alloc, secret_store, trusted_principal_secret_key);
+}
+
+fn resolveTrustedPrincipalIssuer(
+    alloc: std.mem.Allocator,
+    secret_store: ?*antfly.common.secrets.FileStore,
+) !?[]u8 {
+    return try resolveTrustedPrincipalConfigValue(alloc, secret_store, trusted_principal_issuer_key);
+}
+
+fn resolveTrustedPrincipalConfigValue(
+    alloc: std.mem.Allocator,
+    secret_store: ?*antfly.common.secrets.FileStore,
+    key: []const u8,
+) !?[]u8 {
+    if (secret_store) |store| {
+        if (try store.getOwned(alloc, key)) |value| {
+            if (std.mem.trim(u8, value, " \t\r\n").len > 0) return value;
+            alloc.free(value);
+            return null;
+        }
+        return null;
+    }
+
+    const env_var = try antfly.common.secrets.envVarForKey(alloc, key);
+    defer alloc.free(env_var);
+    const value = std.process.getEnvVarOwned(alloc, env_var) catch |err| switch (err) {
+        error.EnvironmentVariableNotFound => null,
+        else => return err,
+    };
+    if (value) |raw| {
+        if (std.mem.trim(u8, raw, " \t\r\n").len > 0) return raw;
+        alloc.free(raw);
+    }
+    return null;
+}
+
 fn parseBoolFlag(value: []const u8) ?bool {
     if (std.mem.eql(u8, value, "true")) return true;
     if (std.mem.eql(u8, value, "false")) return false;
@@ -7783,6 +7840,42 @@ test "data runtime leaves auth disabled unless config or cli enables it" {
 
     cli.auth_enabled = false;
     try std.testing.expect(!resolveAuthEnabled(cli, null));
+}
+
+test "data runtime resolves trusted principal secret from secret store" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const store_path = try std.fmt.allocPrint(alloc, ".zig-cache/tmp/{s}/trusted-principal-secrets.json", .{tmp.sub_path});
+    defer alloc.free(store_path);
+
+    var store = try antfly.common.secrets.FileStore.init(alloc, store_path);
+    defer store.deinit();
+    var entry = try store.put(alloc, trusted_principal_secret_key, "cloudaf-shared-secret");
+    defer entry.deinit(alloc);
+
+    const resolved = try resolveTrustedPrincipalSecret(alloc, &store);
+    defer if (resolved) |value| alloc.free(value);
+    try std.testing.expectEqualStrings("cloudaf-shared-secret", resolved.?);
+}
+
+test "data runtime resolves trusted principal issuer from secret store" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const store_path = try std.fmt.allocPrint(alloc, ".zig-cache/tmp/{s}/trusted-principal-issuer.json", .{tmp.sub_path});
+    defer alloc.free(store_path);
+
+    var store = try antfly.common.secrets.FileStore.init(alloc, store_path);
+    defer store.deinit();
+    var entry = try store.put(alloc, trusted_principal_issuer_key, "cloudaf");
+    defer entry.deinit(alloc);
+
+    const resolved = try resolveTrustedPrincipalIssuer(alloc, &store);
+    defer if (resolved) |value| alloc.free(value);
+    try std.testing.expectEqualStrings("cloudaf", resolved.?);
 }
 
 test "data runtime local group status uses injected leadership source" {

--- a/zig/pkg/antfly/src/data/runtime.zig
+++ b/zig/pkg/antfly/src/data/runtime.zig
@@ -27,6 +27,7 @@ const data_raft_batch = @import("raft_batch.zig");
 const platform_clock = @import("../platform/clock.zig");
 const process_memory_mod = @import("../platform/process_memory.zig");
 const platform_time = @import("../platform/time.zig");
+const platform = @import("antfly_platform");
 const raft_engine = @import("raft_engine");
 
 const health_metrics = antfly.common.health_server;
@@ -7615,11 +7616,10 @@ fn resolveTrustedPrincipalConfigValue(
 
     const env_var = try antfly.common.secrets.envVarForKey(alloc, key);
     defer alloc.free(env_var);
-    const value = std.process.getEnvVarOwned(alloc, env_var) catch |err| switch (err) {
-        error.EnvironmentVariableNotFound => null,
-        else => return err,
-    };
-    if (value) |raw| {
+    const env_var_z = try alloc.dupeZ(u8, env_var);
+    defer alloc.free(env_var_z);
+    if (platform.env.getenvSlice(env_var_z)) |value| {
+        const raw = try alloc.dupe(u8, value);
         if (std.mem.trim(u8, raw, " \t\r\n").len > 0) return raw;
         alloc.free(raw);
     }


### PR DESCRIPTION
Summary:
- authenticate generic signed trusted-principal tokens via X-Antfly-Trusted-Principal
- support optional trusted-principal issuer validation via ANTFLY_TRUSTED_PRINCIPAL_ISSUER
- keep Basic/Bearer/API-key auth on Authorization while delegated proxy identity uses the internal header
- filter MCP tools by authenticated permissions
- add native MCP lookup tool backed by the existing table lookup API

Tests:
- zig build lib-api-auth-test -- --test-filter 'api http server authenticates trusted principal' --test-filter 'api http server serves lookup through mcp tool'
- zig build lib-api-auth-test
- zig build lib-mcp-test