### PR TITLE
Fix CLIP image preprocessing contract

### DIFF
--- a/zig/e2e/inference/helpers.py
+++ b/zig/e2e/inference/helpers.py
@@ -446,6 +446,46 @@ def make_solid_png_uri(r: int, g: int, b: int, size: int = 8) -> str:
     return f"data:image/png;base64,{base64.b64encode(png).decode()}"
 
 
+def make_clip_contract_png_uri() -> str:
+    """Generate a non-square CLIP preprocessing contract image as a data URI."""
+    width = 320
+    height = 128
+    canvas = bytearray(width * height * 3)
+
+    for y in range(height):
+        for x in range(width):
+            idx = (y * width + x) * 3
+            if x < 48:
+                canvas[idx:idx + 3] = bytes((240, y, 12))
+            elif x >= 272:
+                canvas[idx:idx + 3] = bytes((20, 240, 255 - y))
+            else:
+                cx = x - 48
+                canvas[idx:idx + 3] = bytes((cx, (y * 2) % 256, 255 - cx))
+
+    def chunk(tag: bytes, data: bytes) -> bytes:
+        return (
+            struct.pack(">I", len(data))
+            + tag
+            + data
+            + struct.pack(">I", zlib.crc32(tag + data) & 0xFFFFFFFF)
+        )
+
+    raw_rows = []
+    stride = width * 3
+    for y in range(height):
+        raw_rows.append(b"\x00" + bytes(canvas[y * stride:(y + 1) * stride]))
+    raw = b"".join(raw_rows)
+    ihdr = struct.pack(">IIBBBBB", width, height, 8, 2, 0, 0, 0)
+    png = b"".join([
+        b"\x89PNG\r\n\x1a\n",
+        chunk(b"IHDR", ihdr),
+        chunk(b"IDAT", zlib.compress(raw)),
+        chunk(b"IEND", b""),
+    ])
+    return f"data:image/png;base64,{base64.b64encode(png).decode()}"
+
+
 def make_text_png_uri(lines: list[str], scale: int = 6, padding: int = 12, line_gap: int = 8) -> str:
     """Generate a simple black-on-white bitmap text PNG as a data URI."""
     rows_per_char = 7

--- a/zig/e2e/inference/test_embed.py
+++ b/zig/e2e/inference/test_embed.py
@@ -17,16 +17,27 @@
 Matches Go antfly's embedders_test.go and clip_test.go patterns.
 """
 
+import base64
+import json
+import subprocess
+
 import pytest
 from .helpers import (
     TINY_PNG_URI,
     can_make_spoken_wav,
     cosine_similarity,
     l2_norm,
+    make_clip_contract_png_uri,
     make_solid_png_uri,
     make_text_png_uri,
     make_spoken_wav_uri,
     make_wav_b64,
+)
+from .models import (
+    ensure_model_by_name,
+    inference_command,
+    inference_download_enabled,
+    local_model_exists,
 )
 
 pytestmark = pytest.mark.model_integration
@@ -153,6 +164,10 @@ def _assert_distinct_rows(*embs):
             assert delta > 1e-5
 
 
+def _weighted_embedding_sum(emb):
+    return sum((i + 1) * value for i, value in enumerate(emb))
+
+
 @pytest.mark.multimodal
 def test_image_embedding(api):
     """Image embedding via image_url content part."""
@@ -161,6 +176,60 @@ def test_image_embedding(api):
     embs = [item["embedding"] for item in resp["data"]]
     assert len(embs) == 1
     assert len(embs[0]) >= 1, "Image embedding should be non-empty"
+
+
+@pytest.mark.multimodal
+@pytest.mark.verification
+def test_clipclap_image_embedding_golden_contract(tmp_path):
+    """ClipClap image embeddings should keep the CLIP preprocessing contract stable."""
+    if not local_model_exists(CLIPCLAP_MODEL, "embedders") and not inference_download_enabled():
+        pytest.skip(f"{CLIPCLAP_MODEL} is not available")
+
+    model_dir = ensure_model_by_name(CLIPCLAP_MODEL, "embedders")
+    if model_dir is None:
+        pytest.skip(f"{CLIPCLAP_MODEL} is not available")
+
+    image_uri = make_clip_contract_png_uri()
+    image_path = tmp_path / "clip-contract.png"
+    image_path.write_bytes(base64.b64decode(image_uri.split(",", 1)[1]))
+
+    result = subprocess.run(
+        [
+            *inference_command(),
+            "embed",
+            str(model_dir),
+            "--backend",
+            "native",
+            "--image",
+            str(image_path),
+        ],
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    combined = [*result.stdout.splitlines(), *result.stderr.splitlines()]
+    response_line = next(line for line in reversed(combined) if line.startswith("{") and "\"embeddings\"" in line)
+    emb = json.loads(response_line)["embeddings"][0]
+
+    assert len(emb) == 512
+    assert abs(l2_norm(emb) - 1.0) < 1e-4
+
+    expected_weighted_sum = -107.44091905420602
+    expected_prefix = [
+        0.041707344,
+        0.03681396,
+        -0.034344856,
+        0.024631007,
+        0.019223439,
+        0.03514648,
+        0.0022730897,
+        0.094304845,
+    ]
+
+    assert abs(_weighted_embedding_sum(emb) - expected_weighted_sum) < 1e-4
+    for i, expected in enumerate(expected_prefix):
+        assert abs(emb[i] - expected) < 1e-4
 
 
 @pytest.mark.multimodal

--- a/zig/pkg/inference/src/models/manifest.zig
+++ b/zig/pkg/inference/src/models/manifest.zig
@@ -1400,6 +1400,7 @@ fn parseInferenceBundleJson(manifest: *ModelManifest, allocator: std.mem.Allocat
             manifest.native_arch_hint = .clip;
             if (manifest.config_model_arch.len > 0) allocator.free(manifest.config_model_arch);
             manifest.config_model_arch = allocator.dupe(u8, "clipclap") catch "";
+            try setManifestInputs(allocator, manifest, &.{ "text", "image", "audio" });
         }
     }
 }
@@ -1478,6 +1479,28 @@ fn parseInferenceVariantsJson(manifest: *ModelManifest, allocator: std.mem.Alloc
     manifest.native_arch_hint = .clip;
     if (manifest.config_model_arch.len > 0) allocator.free(manifest.config_model_arch);
     manifest.config_model_arch = arch;
+    try setManifestInputs(allocator, manifest, &.{ "text", "image", "audio" });
+}
+
+fn setManifestInputs(allocator: std.mem.Allocator, manifest: *ModelManifest, inputs: []const []const u8) !void {
+    if (manifest.inputs.len > 0) {
+        for (manifest.inputs) |input| allocator.free(input);
+        allocator.free(manifest.inputs);
+        manifest.inputs = &.{};
+    }
+
+    const owned = try allocator.alloc([]const u8, inputs.len);
+    errdefer allocator.free(owned);
+    var initialized: usize = 0;
+    errdefer {
+        for (owned[0..initialized]) |input| allocator.free(input);
+    }
+
+    for (inputs, 0..) |input, i| {
+        owned[i] = try allocator.dupe(u8, input);
+        initialized += 1;
+    }
+    manifest.inputs = owned;
 }
 
 const ResolvedClipclapGgufPair = struct {
@@ -1952,6 +1975,9 @@ test "manifest parses clipclap gguf bundle marker" {
     try std.testing.expect(manifest.audio_model_path != null);
     try std.testing.expect(std.mem.endsWith(u8, manifest.gguf_path.?, "/tmp/clipclap-q4_k/clip.gguf"));
     try std.testing.expect(std.mem.endsWith(u8, manifest.audio_model_path.?, "/tmp/clipclap-q4_k/clap.gguf"));
+    try std.testing.expect(manifest.hasInput("text"));
+    try std.testing.expect(manifest.hasInput("image"));
+    try std.testing.expect(manifest.hasInput("audio"));
 }
 
 test "manifest discovers clip onnx variants and prefers f16 over i8" {
@@ -2049,6 +2075,9 @@ test "manifest parses clipclap variants gguf pair" {
     try std.testing.expectEqualStrings("clipclap", manifest.config_model_arch);
     try std.testing.expectEqualStrings(clip_path, manifest.gguf_path.?);
     try std.testing.expectEqualStrings(clap_path, manifest.audio_model_path.?);
+    try std.testing.expect(manifest.hasInput("text"));
+    try std.testing.expect(manifest.hasInput("image"));
+    try std.testing.expect(manifest.hasInput("audio"));
 }
 
 test "manifest ignores stale clipclap variants with missing gguf files" {

--- a/zig/pkg/inference/src/pipelines/embedding.zig
+++ b/zig/pkg/inference/src/pipelines/embedding.zig
@@ -44,6 +44,11 @@ pub const PoolingStrategy = enum {
     last,
 };
 
+pub const ImagePreprocessProfile = enum {
+    default,
+    clip,
+};
+
 pub const EmbeddingConfig = struct {
     normalize: bool = true,
     pooling: PoolingStrategy = .mean,
@@ -64,6 +69,8 @@ pub const EmbeddingConfig = struct {
     resident_qwen3_embedding: bool = false,
     /// For CLIP/SigLIP multimodal models: image size for vision encoder.
     image_size: u32 = 224,
+    /// Model-selected image preprocessing contract.
+    image_preprocess_profile: ImagePreprocessProfile = .default,
     /// For CLAP audio models: mel spectrogram configuration.
     audio_config: audio.AudioConfig = audio.CLAP_CONFIG,
 };
@@ -439,13 +446,22 @@ pub const EmbeddingPipeline = struct {
 
         // Preprocess all images to [batch, 3, H, W]
         const preprocess_start = embedTimingStart(self.print_timing);
-        const pixel_values = try image.preprocessBatch(
-            alloc,
-            images,
-            img_size,
-            image.IMAGENET_MEAN,
-            image.IMAGENET_STD,
-        );
+        const pixel_values = switch (self.config.image_preprocess_profile) {
+            .default => try image.preprocessBatch(
+                alloc,
+                images,
+                img_size,
+                image.IMAGENET_MEAN,
+                image.IMAGENET_STD,
+            ),
+            .clip => try image.preprocessClipBatch(
+                alloc,
+                images,
+                img_size,
+                image.IMAGENET_MEAN,
+                image.IMAGENET_STD,
+            ),
+        };
         defer alloc.free(pixel_values);
         logEmbedTiming("image.preprocess", batch, preprocess_start);
 

--- a/zig/pkg/inference/src/pipelines/image.zig
+++ b/zig/pkg/inference/src/pipelines/image.zig
@@ -185,6 +185,73 @@ test "decode rejects unsupported image format" {
     try std.testing.expectError(error.ImageDecodeFailed, decode(alloc, "not-an-image"));
 }
 
+test "clip preprocessing center crops before resize" {
+    var rgb = [_]u8{
+        10, 0, 0,
+        20, 0, 0,
+        30, 0, 0,
+        40, 0, 0,
+        50, 0, 0,
+        60, 0, 0,
+        70, 0, 0,
+        80, 0, 0,
+    };
+    const img = Image{
+        .data = rgb[0..],
+        .width = 4,
+        .height = 2,
+        .channels = 3,
+    };
+    var out: [12]f32 = undefined;
+
+    preprocessDecodedClip(
+        img,
+        &out,
+        2,
+        .{ 0.0, 0.0, 0.0 },
+        .{ 1.0, 1.0, 1.0 },
+    );
+
+    try std.testing.expectApproxEqAbs(@as(f32, 20.0 / 255.0), out[0], 1e-6);
+    try std.testing.expectApproxEqAbs(@as(f32, 30.0 / 255.0), out[1], 1e-6);
+    try std.testing.expectApproxEqAbs(@as(f32, 60.0 / 255.0), out[2], 1e-6);
+    try std.testing.expectApproxEqAbs(@as(f32, 70.0 / 255.0), out[3], 1e-6);
+}
+
+test "clip preprocessing uses legacy resize source coordinates" {
+    var rgb = [_]u8{
+        0,   0, 0,
+        10,  0, 0,
+        100, 0, 0,
+        110, 0, 0,
+    };
+    const img = Image{
+        .data = rgb[0..],
+        .width = 2,
+        .height = 2,
+        .channels = 3,
+    };
+    var out: [48]f32 = undefined;
+
+    preprocessDecodedClip(
+        img,
+        &out,
+        4,
+        .{ 0.0, 0.0, 0.0 },
+        .{ 1.0, 1.0, 1.0 },
+    );
+
+    const expected_red = [_]f32{
+        0.0,   5.0,   10.0,  10.0,
+        50.0,  55.0,  60.0,  60.0,
+        100.0, 105.0, 110.0, 110.0,
+        100.0, 105.0, 110.0, 110.0,
+    };
+    for (expected_red, 0..) |expected, i| {
+        try std.testing.expectApproxEqAbs(expected / 255.0, out[i], 1e-6);
+    }
+}
+
 test "decode png fixture dimensions are stable" {
     const alloc = std.testing.allocator;
     const img = try decode(alloc, &red_png_2x2);
@@ -611,6 +678,88 @@ pub fn preprocessBatch(
     }
 
     return result;
+}
+
+/// Preprocess CLIP embedding images using Antfly's CLIP runtime contract.
+///
+/// The math intentionally matches the legacy Go termite CLIP path in
+/// go/pkg/termite/lib/pipelines/image.go: crop a centered target_size window
+/// capped by source dimensions, resize that crop to target_size using source
+/// coordinates `dst * src_dim / target_dim`, and normalize to CHW f32.
+///
+/// This is not the generic vision preprocessor. Use it only for CLIP/ClipClap
+/// image embeddings that must stay compatible with vectors produced by the
+/// legacy Go runtime.
+pub fn preprocessClipBatch(
+    allocator: std.mem.Allocator,
+    image_list: []const []const u8,
+    target_size: u32,
+    mean: [3]f32,
+    std_dev: [3]f32,
+) ![]f32 {
+    const ts: usize = target_size;
+    const per_image = 3 * ts * ts;
+    const result = try allocator.alloc(f32, image_list.len * per_image);
+    errdefer allocator.free(result);
+
+    for (image_list, 0..) |image_bytes, i| {
+        const img = try decode(allocator, image_bytes);
+        defer img.deinit(allocator);
+
+        preprocessDecodedClip(
+            img,
+            result[i * per_image ..][0..per_image],
+            target_size,
+            mean,
+            std_dev,
+        );
+    }
+
+    return result;
+}
+
+fn preprocessDecodedClip(
+    img: Image,
+    result: []f32,
+    target_size: u32,
+    mean: [3]f32,
+    std_dev: [3]f32,
+) void {
+    std.debug.assert(target_size > 0);
+    std.debug.assert(img.width > 0 and img.height > 0);
+
+    const ts: usize = target_size;
+    const crop_w: u32 = @min(img.width, target_size);
+    const crop_h: u32 = @min(img.height, target_size);
+    const crop_left: u32 = (img.width - crop_w) / 2;
+    const crop_top: u32 = (img.height - crop_h) / 2;
+    const scale_x = @as(f32, @floatFromInt(crop_w)) / @as(f32, @floatFromInt(target_size));
+    const scale_y = @as(f32, @floatFromInt(crop_h)) / @as(f32, @floatFromInt(target_size));
+
+    for (0..ts) |y| {
+        const src_y = @as(f32, @floatFromInt(y)) * scale_y;
+        const y0: u32 = @intFromFloat(@floor(src_y));
+        const y1: u32 = @min(y0 + 1, crop_h - 1);
+        const fy = src_y - @as(f32, @floatFromInt(y0));
+
+        for (0..ts) |x| {
+            const src_x = @as(f32, @floatFromInt(x)) * scale_x;
+            const x0: u32 = @intFromFloat(@floor(src_x));
+            const x1: u32 = @min(x0 + 1, crop_w - 1);
+            const fx = src_x - @as(f32, @floatFromInt(x0));
+
+            for (0..3) |ch| {
+                const p00 = pixelAt(img, crop_left + x0, crop_top + y0, ch);
+                const p10 = pixelAt(img, crop_left + x1, crop_top + y0, ch);
+                const p01 = pixelAt(img, crop_left + x0, crop_top + y1, ch);
+                const p11 = pixelAt(img, crop_left + x1, crop_top + y1, ch);
+                const top = p00 * (1.0 - fx) + p10 * fx;
+                const bottom = p01 * (1.0 - fx) + p11 * fx;
+                const value = top * (1.0 - fy) + bottom * fy;
+                result[ch * ts * ts + y * ts + x] = (value / 255.0 - mean[ch]) / std_dev[ch];
+            }
+        }
+    }
 }
 
 fn toSharedImage(img: Image) ImageU8 {

--- a/zig/pkg/inference/src/server/model_manager.zig
+++ b/zig/pkg/inference/src/server/model_manager.zig
@@ -733,11 +733,16 @@ pub const LoadedModel = struct {
             .trim_padding_to_batch_max = isJinaStyleEmbeddingManifest(&self.manifest),
             .resident_qwen3_embedding = isJinaStyleEmbeddingManifest(&self.manifest),
         });
+        if (usesClipImagePreprocessProfile(&self.manifest)) {
+            pipeline.config.image_preprocess_profile = .clip;
+        }
         if (session_factory.getClipConfig(self.session)) |cfg| {
             pipeline.config.image_size = cfg.image_size;
+            if (cfg.family == .clip) pipeline.config.image_preprocess_profile = .clip;
         } else if (self.vision_session) |vs| {
             if (session_factory.getClipConfig(vs)) |cfg| {
                 pipeline.config.image_size = cfg.image_size;
+                if (cfg.family == .clip) pipeline.config.image_preprocess_profile = .clip;
             }
         }
         pipeline.vision_session = self.vision_session;
@@ -896,6 +901,12 @@ pub const LoadedModel = struct {
 fn isJinaStyleEmbeddingManifest(manifest: *const manifest_mod.ModelManifest) bool {
     return std.mem.eql(u8, manifest.config_model_arch, "jina_embeddings_v5") or
         (manifest.pooling == .last and std.mem.eql(u8, manifest.embedding_text_prefix, "Document: "));
+}
+
+fn usesClipImagePreprocessProfile(manifest: *const manifest_mod.ModelManifest) bool {
+    return std.mem.eql(u8, manifest.config_model_arch, "clip") or
+        std.mem.eql(u8, manifest.config_model_arch, "clipclap") or
+        manifest.isClipclapGgufBundle();
 }
 
 pub const ModelManager = struct {
@@ -1349,6 +1360,20 @@ test "isManifestPotentiallyLoadableInCurrentBuild hides incomplete colqwen bundl
 
     colqwen.processor_config_path = try allocator.dupe(u8, "processor_config.json");
     try std.testing.expect(isManifestPotentiallyLoadableInCurrentBuild(colqwen));
+}
+
+test "ClipClap manifest selects CLIP image preprocessing profile" {
+    const allocator = std.testing.allocator;
+    var clipclap = manifest_mod.ModelManifest{ .allocator = allocator };
+    defer clipclap.deinit();
+
+    clipclap.config_model_arch = try allocator.dupe(u8, "clipclap");
+    try std.testing.expect(usesClipImagePreprocessProfile(&clipclap));
+
+    var siglip = manifest_mod.ModelManifest{ .allocator = allocator };
+    defer siglip.deinit();
+    siglip.config_model_arch = try allocator.dupe(u8, "siglip");
+    try std.testing.expect(!usesClipImagePreprocessProfile(&siglip));
 }
 
 test "ModelManager loads split gliner bundle and exposes runtime pipeline" {


### PR DESCRIPTION
## Summary
- add a CLIP image preprocessing profile that center-crops before resize and uses the legacy CLIP source-coordinate contract
- select that profile from CLIP/ClipClap model identity, including ONNX/imported sessions where native CLIP config introspection is unavailable
- make ClipClap GGUF bundle/variant manifests expose text, image, and audio inputs automatically
- add a native-backend ClipClap golden embedding e2e contract test under zig/e2e/inference

## Validation
- zig build install -Dedition=inference
- zig build test-bin
- zig build test -Druntime-test-filter=true -- --test-filter "clip preprocessing"
- zig build test -Druntime-test-filter=true -- --test-filter "manifest parses clipclap"
- zig build test -Druntime-test-filter=true -- --test-filter "ClipClap manifest selects"
- UV_CACHE_DIR=/tmp/uv-cache ANTFLY_BIN=/Users/ajroetker/go/src/github.com/antflydb/antfly/zig/zig-out/bin/antfly ANTFLY_INFERENCE_MODELS_DIR=/tmp/antfly-clipclap-e2e-models uv run --project zig/e2e/inference pytest -q -s zig/e2e/inference/test_embed.py -k clipclap_image_embedding_golden_contract

## Related model metadata
Created Hugging Face PR commits for antflydb/clipclap forward metadata:
- antfly_inference_variants.json: https://huggingface.co/antflydb/clipclap/commit/df23c72188155c10f90f50c5465b087ae42f7cc2
- model_manifest.json multimodal inputs: https://huggingface.co/antflydb/clipclap/commit/1a9e7b8e734ac618b6cd7bc0f38464064a0e4c0e