### PR TITLE
Remove default `swarm` CMD from container images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,5 @@ EXPOSE 8080 11433 4200
 
 ENTRYPOINT ["/antfly"]
 
-# Default to single-node swarm mode for easy local usage.
-# Override with a different subcommand (e.g., "metadata", "store", "termite")
-# via Kubernetes Pod args or docker run arguments.
-CMD ["swarm"]
+# Intentionally no default CMD: callers must explicitly choose a role
+# (e.g., "swarm", "metadata", "store", or "termite").

--- a/Dockerfile.omni
+++ b/Dockerfile.omni
@@ -176,7 +176,5 @@ EXPOSE 8080 11433 4200
 
 ENTRYPOINT ["/antfly"]
 
-# Default to single-node swarm mode for easy local usage.
-# Override with a different subcommand (e.g., "metadata", "store", "termite")
-# via Kubernetes Pod args or docker run arguments.
-CMD ["swarm"]
+# Intentionally no default CMD: callers must explicitly choose a role
+# (e.g., "swarm", "metadata", "store", or "termite").


### PR DESCRIPTION
### Motivation
- A recent change set a default `CMD ["swarm"]` in the images causing containers started without args to launch a full unauthenticated single-node swarm bound to `0.0.0.0`, which exposes sensitive metadata/store/raft/internal endpoints; this PR removes that insecure default so callers must explicitly choose the runtime role.

### Description
- Removed the default `CMD ["swarm"]` and added a clarifying comment in both `Dockerfile` and `Dockerfile.omni` so images no longer auto-start the swarm role and deployers must explicitly pass a role (e.g., `swarm`, `metadata`, `store`, or `termite`).

### Testing
- Ran `git diff -- Dockerfile Dockerfile.omni` and `git status --short` to verify the intended changes were applied successfully and created a commit; these checks passed. 
- No runtime or unit tests were executed because this is a Dockerfile-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d1152e6488321b4dae36afd463aff)