### PR TITLE
Add pip and npm CLI packaging

### DIFF
--- a/.github/workflows/antfly-release.yml
+++ b/.github/workflows/antfly-release.yml
@@ -139,9 +139,136 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_ENDPOINT_URL: ${{ secrets.AWS_ENDPOINT_URL }}
 
+  package-cli-artifacts:
+    name: Build CLI package artifacts
+    needs: goreleaser
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Resolve version
+        id: version
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "tag=v${version}" >> "$GITHUB_OUTPUT"
+
+      - name: Download release archives
+        run: |
+          set -euo pipefail
+          version="${{ steps.version.outputs.version }}"
+          tag="${{ steps.version.outputs.tag }}"
+          base="https://releases.antfly.io/antfly/${tag}"
+          mkdir -p dist/release-archives
+          for archive in \
+            "antfly_${version}_Darwin_arm64.tar.gz" \
+            "antfly_${version}_Linux_arm64.tar.gz" \
+            "antfly_${version}_Linux_x86_64.tar.gz"
+          do
+            curl -fsSL "${base}/${archive}" -o "dist/release-archives/${archive}"
+          done
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22.x
+          registry-url: https://registry.npmjs.org/
+
+      - name: Build wheels and populate npm packages
+        run: |
+          python scripts/packaging/package_cli_release.py \
+            --version "${{ steps.version.outputs.version }}" \
+            --archive-dir dist/release-archives \
+            --out-dir dist/cli-packages
+
+      - name: Smoke check package wrappers
+        run: |
+          python -m compileall -q py/packages/cli/src/antfly_cli
+          node --check ts/packages/cli/bin/antfly.js
+
+      - name: Pack npm packages
+        run: |
+          set -euo pipefail
+          mkdir -p dist/cli-packages/npm
+          npm pack --pack-destination dist/cli-packages/npm ./ts/packages/cli-darwin-arm64
+          npm pack --pack-destination dist/cli-packages/npm ./ts/packages/cli-linux-arm64
+          npm pack --pack-destination dist/cli-packages/npm ./ts/packages/cli-linux-x64
+          npm pack --pack-destination dist/cli-packages/npm ./ts/packages/cli
+
+      - name: Upload Python wheels
+        uses: actions/upload-artifact@v6
+        with:
+          name: antfly-cli-wheels
+          path: dist/cli-packages/python/*.whl
+
+      - name: Upload npm tarballs
+        uses: actions/upload-artifact@v6
+        with:
+          name: antfly-cli-npm
+          path: dist/cli-packages/npm/*.tgz
+
+  publish-cli-pypi:
+    name: Publish antfly-cli to PyPI
+    needs: package-cli-artifacts
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/antfly-cli
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v6
+        with:
+          name: antfly-cli-wheels
+          path: dist/
+
+      - name: Publish wheels
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+  publish-cli-npm:
+    name: Publish @antfly/cli to npm
+    needs: package-cli-artifacts
+    runs-on: ubuntu-latest
+    environment: npm
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v6
+        with:
+          name: antfly-cli-npm
+          path: dist/
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22.x
+          registry-url: https://registry.npmjs.org/
+
+      - name: Upgrade npm for OIDC support
+        run: npm install -g npm@latest
+
+      - name: Publish npm packages
+        run: |
+          set -euo pipefail
+          version="${GITHUB_REF_NAME#v}"
+          npm_tag="latest"
+          case "$version" in
+            *-*) npm_tag="next" ;;
+          esac
+          echo "Publishing CLI npm packages with dist-tag: ${npm_tag}"
+          npm publish dist/antfly-cli-darwin-arm64-*.tgz --access public --provenance --tag "$npm_tag"
+          npm publish dist/antfly-cli-linux-arm64-*.tgz --access public --provenance --tag "$npm_tag"
+          npm publish dist/antfly-cli-linux-x64-*.tgz --access public --provenance --tag "$npm_tag"
+          npm publish dist/antfly-cli-[0-9]*.tgz --access public --provenance --tag "$npm_tag"
+
   # Build and publish container images after release
   publish-container:
-    needs: goreleaser
+    needs:
+      - goreleaser
+      - publish-cli-pypi
+      - publish-cli-npm
     uses: ./.github/workflows/antfly-container.yml
     with:
       tag_name: ${{ github.ref_name }}

--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -1,0 +1,152 @@
+name: Publish CLI packages
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: "Antfly version to publish, with or without v prefix"
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Antfly version to publish, with or without v prefix"
+        required: true
+  push:
+    tags:
+      - "cli/v*"
+
+permissions:
+  contents: read
+
+jobs:
+  package:
+    name: Build CLI package artifacts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Resolve version
+        id: version
+        run: |
+          input_version="${{ inputs.version || '' }}"
+          if [ -n "$input_version" ]; then
+            raw="$input_version"
+          else
+            raw="${GITHUB_REF_NAME#cli/}"
+          fi
+          version="${raw#v}"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "tag=v${version}" >> "$GITHUB_OUTPUT"
+
+      - name: Download release archives
+        run: |
+          set -euo pipefail
+          version="${{ steps.version.outputs.version }}"
+          tag="${{ steps.version.outputs.tag }}"
+          base="https://releases.antfly.io/antfly/${tag}"
+          mkdir -p dist/release-archives
+          for archive in \
+            "antfly_${version}_Darwin_arm64.tar.gz" \
+            "antfly_${version}_Linux_arm64.tar.gz" \
+            "antfly_${version}_Linux_x86_64.tar.gz"
+          do
+            curl -fsSL "${base}/${archive}" -o "dist/release-archives/${archive}"
+          done
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22.x
+          registry-url: https://registry.npmjs.org/
+
+      - name: Build wheels and populate npm packages
+        run: |
+          python scripts/packaging/package_cli_release.py \
+            --version "${{ steps.version.outputs.version }}" \
+            --archive-dir dist/release-archives \
+            --out-dir dist/cli-packages
+
+      - name: Smoke check package wrappers
+        run: |
+          python -m compileall -q py/packages/cli/src/antfly_cli
+          node --check ts/packages/cli/bin/antfly.js
+
+      - name: Pack npm packages
+        run: |
+          set -euo pipefail
+          mkdir -p dist/cli-packages/npm
+          npm pack --pack-destination dist/cli-packages/npm ./ts/packages/cli-darwin-arm64
+          npm pack --pack-destination dist/cli-packages/npm ./ts/packages/cli-linux-arm64
+          npm pack --pack-destination dist/cli-packages/npm ./ts/packages/cli-linux-x64
+          npm pack --pack-destination dist/cli-packages/npm ./ts/packages/cli
+
+      - name: Upload Python wheels
+        uses: actions/upload-artifact@v6
+        with:
+          name: antfly-cli-wheels
+          path: dist/cli-packages/python/*.whl
+
+      - name: Upload npm tarballs
+        uses: actions/upload-artifact@v6
+        with:
+          name: antfly-cli-npm
+          path: dist/cli-packages/npm/*.tgz
+
+  publish-pypi:
+    name: Publish antfly-cli to PyPI
+    needs: package
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/antfly-cli
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v6
+        with:
+          name: antfly-cli-wheels
+          path: dist/
+
+      - name: Publish wheels
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+  publish-npm:
+    name: Publish @antfly/cli to npm
+    needs: package
+    runs-on: ubuntu-latest
+    environment: npm
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v6
+        with:
+          name: antfly-cli-npm
+          path: dist/
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22.x
+          registry-url: https://registry.npmjs.org/
+
+      - name: Upgrade npm for OIDC support
+        run: npm install -g npm@latest
+
+      - name: Publish npm packages
+        run: |
+          set -euo pipefail
+          raw="${{ inputs.version || github.ref_name }}"
+          version="${raw#cli/}"
+          version="${version#v}"
+          npm_tag="latest"
+          case "$version" in
+            *-*) npm_tag="next" ;;
+          esac
+          echo "Publishing CLI npm packages with dist-tag: ${npm_tag}"
+          npm publish dist/antfly-cli-darwin-arm64-*.tgz --access public --provenance --tag "$npm_tag"
+          npm publish dist/antfly-cli-linux-arm64-*.tgz --access public --provenance --tag "$npm_tag"
+          npm publish dist/antfly-cli-linux-x64-*.tgz --access public --provenance --tag "$npm_tag"
+          npm publish dist/antfly-cli-[0-9]*.tgz --access public --provenance --tag "$npm_tag"

--- a/docs/cli-packaging.md
+++ b/docs/cli-packaging.md
@@ -1,0 +1,57 @@
+# CLI Packaging
+
+Antfly has separate packages for SDKs and CLI installation:
+
+- Python SDK: `antfly-sdk`
+- TypeScript SDK: `@antfly/sdk`
+- Python CLI installer: `antfly-cli`
+- npm CLI installer: `@antfly/cli`
+
+The CLI packages do not build Antfly from source. They repack the native Zig
+runtime archives produced by the main release workflow.
+
+## Release Flow
+
+1. Publish the normal Antfly release tag, for example `v0.2.0`.
+2. The main release workflow runs GoReleaser and uploads native archives under
+   `https://releases.antfly.io/antfly/v0.2.0/`.
+3. The release workflow downloads those archives, repacks them, and publishes
+   `antfly-cli` and `@antfly/cli`.
+
+The CLI workflow also supports manual runs with a version input and `cli/v*`
+tags for republishing or recovery. Trusted publishing for the normal release
+path should be configured against `.github/workflows/antfly-release.yml`.
+
+The packaging script expects these release archives:
+
+```text
+antfly_0.2.0_Darwin_arm64.tar.gz
+antfly_0.2.0_Linux_arm64.tar.gz
+antfly_0.2.0_Linux_x86_64.tar.gz
+```
+
+For prerelease tags, npm uses the release version directly. Python wheels use
+PEP 440 equivalents, for example `v0.2.0-dev10` becomes `0.2.0.dev10`.
+Stable npm releases publish with the `latest` dist-tag. Prerelease npm versions
+publish with the `next` dist-tag, so `npm install -g @antfly/cli` stays on the
+latest stable release and `npm install -g @antfly/cli@next` can install RC/dev
+builds.
+
+It creates:
+
+```text
+dist/cli-packages/python/antfly_cli-0.2.0-py3-none-macosx_11_0_arm64.whl
+dist/cli-packages/python/antfly_cli-0.2.0-py3-none-manylinux_2_28_aarch64.whl
+dist/cli-packages/python/antfly_cli-0.2.0-py3-none-manylinux_2_28_x86_64.whl
+```
+
+and populates npm platform packages:
+
+```text
+@antfly/cli-darwin-arm64
+@antfly/cli-linux-arm64
+@antfly/cli-linux-x64
+```
+
+The top-level `@antfly/cli` package exposes the `antfly` bin and delegates to
+the right platform package at runtime.

--- a/py/packages/cli/README.md
+++ b/py/packages/cli/README.md
@@ -1,0 +1,12 @@
+# antfly-cli
+
+Python package for installing the native Antfly CLI.
+
+```bash
+pipx install antfly-cli
+antfly --version
+```
+
+This package is separate from `antfly-sdk`, which contains the Python SDK.
+Release wheels include the `antfly` executable and Antfarm dashboard assets for
+the target platform.

--- a/py/packages/cli/pyproject.toml
+++ b/py/packages/cli/pyproject.toml
@@ -1,0 +1,41 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "antfly-cli"
+version = "0.0.0"
+description = "Native Antfly CLI installer package"
+readme = "README.md"
+requires-python = ">=3.9"
+license = {text = "Elastic-2.0"}
+authors = [
+    {name = "Antfly, Inc.", email = "ajroetker@antfly.io"},
+]
+keywords = ["antfly", "cli", "database", "search", "vector"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "License :: Other/Proprietary License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+]
+
+[project.scripts]
+antfly = "antfly_cli:main"
+
+[project.urls]
+Homepage = "https://antfly.io"
+Documentation = "https://docs.antfly.io"
+Repository = "https://github.com/antflydb/antfly"
+Issues = "https://github.com/antflydb/antfly/issues"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/antfly_cli"]
+
+[tool.hatch.build.targets.sdist]
+exclude = [
+    "/src/antfly_cli/bin",
+    "/src/antfly_cli/share",
+]

--- a/py/packages/cli/src/antfly_cli/__init__.py
+++ b/py/packages/cli/src/antfly_cli/__init__.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+__all__ = ["main"]
+
+
+def _binary_path() -> Path:
+    binary_name = "antfly.exe" if os.name == "nt" else "antfly"
+    return Path(__file__).resolve().parent / "bin" / binary_name
+
+
+def main() -> int:
+    binary = _binary_path()
+    if not binary.exists():
+        sys.stderr.write(f"antfly-cli wheel is missing packaged executable: {binary}\n")
+        return 127
+
+    if os.name == "nt":
+        completed = subprocess.run([str(binary), *sys.argv[1:]], check=False)
+        return completed.returncode
+
+    os.execv(str(binary), [str(binary), *sys.argv[1:]])
+    return 127
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/py/packages/cli/src/antfly_cli/__main__.py
+++ b/py/packages/cli/src/antfly_cli/__main__.py
@@ -1,0 +1,3 @@
+from . import main
+
+raise SystemExit(main())

--- a/py/packages/sdk/src/antfly/client_generated/models/__init__.py
+++ b/py/packages/sdk/src/antfly/client_generated/models/__init__.py
@@ -218,6 +218,12 @@ from .inference_chunk_object_object import InferenceChunkObjectObject
 from .inference_chunk_request import InferenceChunkRequest
 from .inference_chunk_response import InferenceChunkResponse
 from .inference_chunk_response_object import InferenceChunkResponseObject
+from .inference_classify_object import InferenceClassifyObject
+from .inference_classify_object_object import InferenceClassifyObjectObject
+from .inference_classify_request import InferenceClassifyRequest
+from .inference_classify_response import InferenceClassifyResponse
+from .inference_classify_response_object import InferenceClassifyResponseObject
+from .inference_classify_result import InferenceClassifyResult
 from .inference_config import InferenceConfig
 from .inference_config_model_strategies import InferenceConfigModelStrategies
 from .inference_config_model_strategies_additional_property import InferenceConfigModelStrategiesAdditionalProperty
@@ -310,6 +316,13 @@ from .inference_read_response import InferenceReadResponse
 from .inference_read_response_object import InferenceReadResponseObject
 from .inference_read_result import InferenceReadResult
 from .inference_read_result_fields import InferenceReadResultFields
+from .inference_recognize_entity import InferenceRecognizeEntity
+from .inference_recognize_object import InferenceRecognizeObject
+from .inference_recognize_object_object import InferenceRecognizeObjectObject
+from .inference_recognize_request import InferenceRecognizeRequest
+from .inference_recognize_response import InferenceRecognizeResponse
+from .inference_recognize_response_object import InferenceRecognizeResponseObject
+from .inference_relation import InferenceRelation
 from .inference_rerank_multimodal_document import InferenceRerankMultimodalDocument
 from .inference_rerank_multimodal_request import InferenceRerankMultimodalRequest
 from .inference_rerank_object import InferenceRerankObject
@@ -317,6 +330,7 @@ from .inference_rerank_object_object import InferenceRerankObjectObject
 from .inference_rerank_request import InferenceRerankRequest
 from .inference_rerank_response import InferenceRerankResponse
 from .inference_rerank_response_object import InferenceRerankResponseObject
+from .inference_resolver_config import InferenceResolverConfig
 from .inference_rewrite_object import InferenceRewriteObject
 from .inference_rewrite_object_object import InferenceRewriteObjectObject
 from .inference_rewrite_request import InferenceRewriteRequest
@@ -358,6 +372,7 @@ from .linear_merge_request_records import LinearMergeRequestRecords
 from .linear_merge_result import LinearMergeResult
 from .list_users_response_200_item import ListUsersResponse200Item
 from .lookup_key_response_200 import LookupKeyResponse200
+from .lsm_storage_status import LsmStorageStatus
 from .match_all_query import MatchAllQuery
 from .match_all_query_match_all import MatchAllQueryMatchAll
 from .match_none_query import MatchNoneQuery
@@ -747,6 +762,12 @@ __all__ = (
     "InferenceChunkRequest",
     "InferenceChunkResponse",
     "InferenceChunkResponseObject",
+    "InferenceClassifyObject",
+    "InferenceClassifyObjectObject",
+    "InferenceClassifyRequest",
+    "InferenceClassifyResponse",
+    "InferenceClassifyResponseObject",
+    "InferenceClassifyResult",
     "InferenceConfig",
     "InferenceConfigModelStrategies",
     "InferenceConfigModelStrategiesAdditionalProperty",
@@ -837,6 +858,13 @@ __all__ = (
     "InferenceReadResponseObject",
     "InferenceReadResult",
     "InferenceReadResultFields",
+    "InferenceRecognizeEntity",
+    "InferenceRecognizeObject",
+    "InferenceRecognizeObjectObject",
+    "InferenceRecognizeRequest",
+    "InferenceRecognizeResponse",
+    "InferenceRecognizeResponseObject",
+    "InferenceRelation",
     "InferenceRerankMultimodalDocument",
     "InferenceRerankMultimodalRequest",
     "InferenceRerankObject",
@@ -844,6 +872,7 @@ __all__ = (
     "InferenceRerankRequest",
     "InferenceRerankResponse",
     "InferenceRerankResponseObject",
+    "InferenceResolverConfig",
     "InferenceRewriteObject",
     "InferenceRewriteObjectObject",
     "InferenceRewriteRequest",
@@ -885,6 +914,7 @@ __all__ = (
     "LinearMergeResult",
     "ListUsersResponse200Item",
     "LookupKeyResponse200",
+    "LsmStorageStatus",
     "MatchAllQuery",
     "MatchAllQueryMatchAll",
     "MatchNoneQuery",

--- a/py/packages/sdk/src/antfly/client_generated/models/inference_classify_object.py
+++ b/py/packages/sdk/src/antfly/client_generated/models/inference_classify_object.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..models.inference_classify_object_object import InferenceClassifyObjectObject
+
+if TYPE_CHECKING:
+    from ..models.inference_classify_result import InferenceClassifyResult
+
+
+T = TypeVar("T", bound="InferenceClassifyObject")
+
+
+@_attrs_define
+class InferenceClassifyObject:
+    """
+    Attributes:
+        object_ (InferenceClassifyObjectObject):
+        index (int): Original input text index.
+        classifications (list[InferenceClassifyResult]): Classification results for this input text.
+    """
+
+    object_: InferenceClassifyObjectObject
+    index: int
+    classifications: list[InferenceClassifyResult]
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        object_ = self.object_.value
+
+        index = self.index
+
+        classifications = []
+        for classifications_item_data in self.classifications:
+            classifications_item = classifications_item_data.to_dict()
+            classifications.append(classifications_item)
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "object": object_,
+                "index": index,
+                "classifications": classifications,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.inference_classify_result import InferenceClassifyResult
+
+        d = dict(src_dict)
+        object_ = InferenceClassifyObjectObject(d.pop("object"))
+
+        index = d.pop("index")
+
+        classifications = []
+        _classifications = d.pop("classifications")
+        for classifications_item_data in _classifications:
+            classifications_item = InferenceClassifyResult.from_dict(classifications_item_data)
+
+            classifications.append(classifications_item)
+
+        inference_classify_object = cls(
+            object_=object_,
+            index=index,
+            classifications=classifications,
+        )
+
+        inference_classify_object.additional_properties = d
+        return inference_classify_object
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/py/packages/sdk/src/antfly/client_generated/models/inference_classify_object_object.py
+++ b/py/packages/sdk/src/antfly/client_generated/models/inference_classify_object_object.py
@@ -1,0 +1,8 @@
+from enum import Enum
+
+
+class InferenceClassifyObjectObject(str, Enum):
+    CLASSIFICATION = "classification"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/py/packages/sdk/src/antfly/client_generated/models/inference_classify_request.py
+++ b/py/packages/sdk/src/antfly/client_generated/models/inference_classify_request.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="InferenceClassifyRequest")
+
+
+@_attrs_define
+class InferenceClassifyRequest:
+    """
+    Attributes:
+        model (str): Name of classifier model from models_dir/classifiers/ Example: MoritzLaurer/mDeBERTa-v3-base-mnli-
+            xnli.
+        texts (list[str]): Texts to classify Example: ['I love this product!', 'The service was terrible.'].
+        labels (list[str]): Candidate labels for zero-shot classification.
+            The model will predict which label(s) best describe each text.
+             Example: ['positive', 'negative', 'neutral'].
+        hypothesis_template (str | Unset): Custom hypothesis template for NLI-based classification.
+            Use "{}" as placeholder for the label.
+            Default: "This example is {}."
+             Example: This text expresses a {} sentiment..
+        multi_label (bool | Unset): If true, allows multiple labels per text (independent scoring).
+            If false (default), scores are normalized across labels.
+             Default: False.
+    """
+
+    model: str
+    texts: list[str]
+    labels: list[str]
+    hypothesis_template: str | Unset = UNSET
+    multi_label: bool | Unset = False
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        model = self.model
+
+        texts = self.texts
+
+        labels = self.labels
+
+        hypothesis_template = self.hypothesis_template
+
+        multi_label = self.multi_label
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "model": model,
+                "texts": texts,
+                "labels": labels,
+            }
+        )
+        if hypothesis_template is not UNSET:
+            field_dict["hypothesis_template"] = hypothesis_template
+        if multi_label is not UNSET:
+            field_dict["multi_label"] = multi_label
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        model = d.pop("model")
+
+        texts = cast(list[str], d.pop("texts"))
+
+        labels = cast(list[str], d.pop("labels"))
+
+        hypothesis_template = d.pop("hypothesis_template", UNSET)
+
+        multi_label = d.pop("multi_label", UNSET)
+
+        inference_classify_request = cls(
+            model=model,
+            texts=texts,
+            labels=labels,
+            hypothesis_template=hypothesis_template,
+            multi_label=multi_label,
+        )
+
+        inference_classify_request.additional_properties = d
+        return inference_classify_request
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/py/packages/sdk/src/antfly/client_generated/models/inference_classify_response.py
+++ b/py/packages/sdk/src/antfly/client_generated/models/inference_classify_response.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..models.inference_classify_response_object import InferenceClassifyResponseObject
+
+if TYPE_CHECKING:
+    from ..models.inference_classify_object import InferenceClassifyObject
+    from ..models.inference_generate_usage import InferenceGenerateUsage
+
+
+T = TypeVar("T", bound="InferenceClassifyResponse")
+
+
+@_attrs_define
+class InferenceClassifyResponse:
+    """
+    Attributes:
+        object_ (InferenceClassifyResponseObject): Object type, always "list"
+        data (list[InferenceClassifyObject]): Classification result objects, one per input text.
+        model (str): Name of model used for classification
+        usage (InferenceGenerateUsage):
+    """
+
+    object_: InferenceClassifyResponseObject
+    data: list[InferenceClassifyObject]
+    model: str
+    usage: InferenceGenerateUsage
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        object_ = self.object_.value
+
+        data = []
+        for data_item_data in self.data:
+            data_item = data_item_data.to_dict()
+            data.append(data_item)
+
+        model = self.model
+
+        usage = self.usage.to_dict()
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "object": object_,
+                "data": data,
+                "model": model,
+                "usage": usage,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.inference_classify_object import InferenceClassifyObject
+        from ..models.inference_generate_usage import InferenceGenerateUsage
+
+        d = dict(src_dict)
+        object_ = InferenceClassifyResponseObject(d.pop("object"))
+
+        data = []
+        _data = d.pop("data")
+        for data_item_data in _data:
+            data_item = InferenceClassifyObject.from_dict(data_item_data)
+
+            data.append(data_item)
+
+        model = d.pop("model")
+
+        usage = InferenceGenerateUsage.from_dict(d.pop("usage"))
+
+        inference_classify_response = cls(
+            object_=object_,
+            data=data,
+            model=model,
+            usage=usage,
+        )
+
+        inference_classify_response.additional_properties = d
+        return inference_classify_response
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/py/packages/sdk/src/antfly/client_generated/models/inference_classify_response_object.py
+++ b/py/packages/sdk/src/antfly/client_generated/models/inference_classify_response_object.py
@@ -1,0 +1,8 @@
+from enum import Enum
+
+
+class InferenceClassifyResponseObject(str, Enum):
+    LIST = "list"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/py/packages/sdk/src/antfly/client_generated/models/inference_classify_result.py
+++ b/py/packages/sdk/src/antfly/client_generated/models/inference_classify_result.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="InferenceClassifyResult")
+
+
+@_attrs_define
+class InferenceClassifyResult:
+    """
+    Attributes:
+        label (str): The predicted class/category Example: positive.
+        score (float): Confidence score (0.0 to 1.0) Example: 0.95.
+    """
+
+    label: str
+    score: float
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        label = self.label
+
+        score = self.score
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "label": label,
+                "score": score,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        label = d.pop("label")
+
+        score = d.pop("score")
+
+        inference_classify_result = cls(
+            label=label,
+            score=score,
+        )
+
+        inference_classify_result.additional_properties = d
+        return inference_classify_result
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/py/packages/sdk/src/antfly/client_generated/models/inference_recognize_entity.py
+++ b/py/packages/sdk/src/antfly/client_generated/models/inference_recognize_entity.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="InferenceRecognizeEntity")
+
+
+@_attrs_define
+class InferenceRecognizeEntity:
+    """
+    Attributes:
+        text (str): The entity text Example: John Smith.
+        label (str): Entity type (PER, ORG, LOC, MISC) Example: PER.
+        start (int): Character offset where entity begins
+        end (int): Character offset where entity ends (exclusive) Example: 10.
+        score (float): Confidence score (0.0 to 1.0) Example: 0.99.
+    """
+
+    text: str
+    label: str
+    start: int
+    end: int
+    score: float
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        text = self.text
+
+        label = self.label
+
+        start = self.start
+
+        end = self.end
+
+        score = self.score
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "text": text,
+                "label": label,
+                "start": start,
+                "end": end,
+                "score": score,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        text = d.pop("text")
+
+        label = d.pop("label")
+
+        start = d.pop("start")
+
+        end = d.pop("end")
+
+        score = d.pop("score")
+
+        inference_recognize_entity = cls(
+            text=text,
+            label=label,
+            start=start,
+            end=end,
+            score=score,
+        )
+
+        inference_recognize_entity.additional_properties = d
+        return inference_recognize_entity
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/py/packages/sdk/src/antfly/client_generated/models/inference_recognize_object.py
+++ b/py/packages/sdk/src/antfly/client_generated/models/inference_recognize_object.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..models.inference_recognize_object_object import InferenceRecognizeObjectObject
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.inference_recognize_entity import InferenceRecognizeEntity
+    from ..models.inference_relation import InferenceRelation
+
+
+T = TypeVar("T", bound="InferenceRecognizeObject")
+
+
+@_attrs_define
+class InferenceRecognizeObject:
+    """
+    Attributes:
+        object_ (InferenceRecognizeObjectObject):
+        index (int): Original input text index.
+        entities (list[InferenceRecognizeEntity]): Entities recognized for this input text.
+        relations (list[InferenceRelation] | Unset): Relations recognized for this input text. Only present when using
+            a model with 'relations' capability (GLiNER multitask, REBEL).
+    """
+
+    object_: InferenceRecognizeObjectObject
+    index: int
+    entities: list[InferenceRecognizeEntity]
+    relations: list[InferenceRelation] | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        object_ = self.object_.value
+
+        index = self.index
+
+        entities = []
+        for entities_item_data in self.entities:
+            entities_item = entities_item_data.to_dict()
+            entities.append(entities_item)
+
+        relations: list[dict[str, Any]] | Unset = UNSET
+        if not isinstance(self.relations, Unset):
+            relations = []
+            for relations_item_data in self.relations:
+                relations_item = relations_item_data.to_dict()
+                relations.append(relations_item)
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "object": object_,
+                "index": index,
+                "entities": entities,
+            }
+        )
+        if relations is not UNSET:
+            field_dict["relations"] = relations
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.inference_recognize_entity import InferenceRecognizeEntity
+        from ..models.inference_relation import InferenceRelation
+
+        d = dict(src_dict)
+        object_ = InferenceRecognizeObjectObject(d.pop("object"))
+
+        index = d.pop("index")
+
+        entities = []
+        _entities = d.pop("entities")
+        for entities_item_data in _entities:
+            entities_item = InferenceRecognizeEntity.from_dict(entities_item_data)
+
+            entities.append(entities_item)
+
+        _relations = d.pop("relations", UNSET)
+        relations: list[InferenceRelation] | Unset = UNSET
+        if _relations is not UNSET:
+            relations = []
+            for relations_item_data in _relations:
+                relations_item = InferenceRelation.from_dict(relations_item_data)
+
+                relations.append(relations_item)
+
+        inference_recognize_object = cls(
+            object_=object_,
+            index=index,
+            entities=entities,
+            relations=relations,
+        )
+
+        inference_recognize_object.additional_properties = d
+        return inference_recognize_object
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/py/packages/sdk/src/antfly/client_generated/models/inference_recognize_object_object.py
+++ b/py/packages/sdk/src/antfly/client_generated/models/inference_recognize_object_object.py
@@ -1,0 +1,8 @@
+from enum import Enum
+
+
+class InferenceRecognizeObjectObject(str, Enum):
+    RECOGNITION = "recognition"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/py/packages/sdk/src/antfly/client_generated/models/inference_recognize_request.py
+++ b/py/packages/sdk/src/antfly/client_generated/models/inference_recognize_request.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.inference_resolver_config import InferenceResolverConfig
+
+
+T = TypeVar("T", bound="InferenceRecognizeRequest")
+
+
+@_attrs_define
+class InferenceRecognizeRequest:
+    """
+    Attributes:
+        model (str): Name of recognizer model from models_dir/recognizers/ Example: dslim/bert-base-NER.
+        texts (list[str]): Texts to extract entities from Example: ['John Smith works at Google.', 'Apple Inc. is in
+            Cupertino.'].
+        labels (list[str] | Unset): Custom entity labels to extract (GLiNER models only).
+            When using a GLiNER model, you can specify any entity types to extract,
+            enabling zero-shot NER without model retraining.
+            If not provided, the model's default labels are used.
+             Example: ['person', 'company', 'product', 'date'].
+        relation_labels (list[str] | Unset): Relation types to extract (for models with 'relations' capability).
+            Only used when the model supports relation extraction (GLiNER multitask, REBEL).
+            Relation extraction runs only when this array is provided and non-empty.
+            GLiNER labels may be relation names (works_for), head-qualified
+            labels (person::works_for), or head/tail-qualified labels
+            (person::works_for::organization).
+             Example: ['founded', 'works_at', 'located_in'].
+        resolver (InferenceResolverConfig | Unset): Configuration for entity resolution. When present in a
+            RecognizeRequest,
+            the response entities and relations are deduplicated via entity resolution
+            (e.g., "Elon Musk" and "Musk" are merged into a single entity).
+    """
+
+    model: str
+    texts: list[str]
+    labels: list[str] | Unset = UNSET
+    relation_labels: list[str] | Unset = UNSET
+    resolver: InferenceResolverConfig | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        model = self.model
+
+        texts = self.texts
+
+        labels: list[str] | Unset = UNSET
+        if not isinstance(self.labels, Unset):
+            labels = self.labels
+
+        relation_labels: list[str] | Unset = UNSET
+        if not isinstance(self.relation_labels, Unset):
+            relation_labels = self.relation_labels
+
+        resolver: dict[str, Any] | Unset = UNSET
+        if not isinstance(self.resolver, Unset):
+            resolver = self.resolver.to_dict()
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "model": model,
+                "texts": texts,
+            }
+        )
+        if labels is not UNSET:
+            field_dict["labels"] = labels
+        if relation_labels is not UNSET:
+            field_dict["relation_labels"] = relation_labels
+        if resolver is not UNSET:
+            field_dict["resolver"] = resolver
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.inference_resolver_config import InferenceResolverConfig
+
+        d = dict(src_dict)
+        model = d.pop("model")
+
+        texts = cast(list[str], d.pop("texts"))
+
+        labels = cast(list[str], d.pop("labels", UNSET))
+
+        relation_labels = cast(list[str], d.pop("relation_labels", UNSET))
+
+        _resolver = d.pop("resolver", UNSET)
+        resolver: InferenceResolverConfig | Unset
+        if isinstance(_resolver, Unset):
+            resolver = UNSET
+        else:
+            resolver = InferenceResolverConfig.from_dict(_resolver)
+
+        inference_recognize_request = cls(
+            model=model,
+            texts=texts,
+            labels=labels,
+            relation_labels=relation_labels,
+            resolver=resolver,
+        )
+
+        inference_recognize_request.additional_properties = d
+        return inference_recognize_request
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/py/packages/sdk/src/antfly/client_generated/models/inference_recognize_response.py
+++ b/py/packages/sdk/src/antfly/client_generated/models/inference_recognize_response.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..models.inference_recognize_response_object import InferenceRecognizeResponseObject
+
+if TYPE_CHECKING:
+    from ..models.inference_generate_usage import InferenceGenerateUsage
+    from ..models.inference_recognize_object import InferenceRecognizeObject
+
+
+T = TypeVar("T", bound="InferenceRecognizeResponse")
+
+
+@_attrs_define
+class InferenceRecognizeResponse:
+    """
+    Attributes:
+        object_ (InferenceRecognizeResponseObject): Object type, always "list"
+        data (list[InferenceRecognizeObject]): Recognition result objects, one per input text.
+        model (str): Name of model used for NER
+        usage (InferenceGenerateUsage):
+    """
+
+    object_: InferenceRecognizeResponseObject
+    data: list[InferenceRecognizeObject]
+    model: str
+    usage: InferenceGenerateUsage
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        object_ = self.object_.value
+
+        data = []
+        for data_item_data in self.data:
+            data_item = data_item_data.to_dict()
+            data.append(data_item)
+
+        model = self.model
+
+        usage = self.usage.to_dict()
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "object": object_,
+                "data": data,
+                "model": model,
+                "usage": usage,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.inference_generate_usage import InferenceGenerateUsage
+        from ..models.inference_recognize_object import InferenceRecognizeObject
+
+        d = dict(src_dict)
+        object_ = InferenceRecognizeResponseObject(d.pop("object"))
+
+        data = []
+        _data = d.pop("data")
+        for data_item_data in _data:
+            data_item = InferenceRecognizeObject.from_dict(data_item_data)
+
+            data.append(data_item)
+
+        model = d.pop("model")
+
+        usage = InferenceGenerateUsage.from_dict(d.pop("usage"))
+
+        inference_recognize_response = cls(
+            object_=object_,
+            data=data,
+            model=model,
+            usage=usage,
+        )
+
+        inference_recognize_response.additional_properties = d
+        return inference_recognize_response
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/py/packages/sdk/src/antfly/client_generated/models/inference_recognize_response_object.py
+++ b/py/packages/sdk/src/antfly/client_generated/models/inference_recognize_response_object.py
@@ -1,0 +1,8 @@
+from enum import Enum
+
+
+class InferenceRecognizeResponseObject(str, Enum):
+    LIST = "list"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/py/packages/sdk/src/antfly/client_generated/models/inference_relation.py
+++ b/py/packages/sdk/src/antfly/client_generated/models/inference_relation.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+if TYPE_CHECKING:
+    from ..models.inference_recognize_entity import InferenceRecognizeEntity
+
+
+T = TypeVar("T", bound="InferenceRelation")
+
+
+@_attrs_define
+class InferenceRelation:
+    """
+    Attributes:
+        head (InferenceRecognizeEntity):
+        tail (InferenceRecognizeEntity):
+        label (str): The relationship type Example: founded.
+        score (float): Confidence score for the relation (0.0 to 1.0) Example: 0.95.
+    """
+
+    head: InferenceRecognizeEntity
+    tail: InferenceRecognizeEntity
+    label: str
+    score: float
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        head = self.head.to_dict()
+
+        tail = self.tail.to_dict()
+
+        label = self.label
+
+        score = self.score
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "head": head,
+                "tail": tail,
+                "label": label,
+                "score": score,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.inference_recognize_entity import InferenceRecognizeEntity
+
+        d = dict(src_dict)
+        head = InferenceRecognizeEntity.from_dict(d.pop("head"))
+
+        tail = InferenceRecognizeEntity.from_dict(d.pop("tail"))
+
+        label = d.pop("label")
+
+        score = d.pop("score")
+
+        inference_relation = cls(
+            head=head,
+            tail=tail,
+            label=label,
+            score=score,
+        )
+
+        inference_relation.additional_properties = d
+        return inference_relation
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/py/packages/sdk/src/antfly/client_generated/models/inference_resolver_config.py
+++ b/py/packages/sdk/src/antfly/client_generated/models/inference_resolver_config.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="InferenceResolverConfig")
+
+
+@_attrs_define
+class InferenceResolverConfig:
+    """Configuration for entity resolution. When present in a RecognizeRequest,
+    the response entities and relations are deduplicated via entity resolution
+    (e.g., "Elon Musk" and "Musk" are merged into a single entity).
+
+        Attributes:
+            similarity_threshold (float | Unset): Jaro-Winkler similarity threshold for merging entities (0.0-1.0) Default:
+                0.85.
+            type_must_match (bool | Unset): Whether entity types must match for merging Default: True.
+            min_entity_confidence (float | Unset): Minimum confidence score for entities to be included Default: 0.0.
+            min_relation_confidence (float | Unset): Minimum confidence score for relations to be included Default: 0.0.
+            deduplicate_relations (bool | Unset): Whether to deduplicate relations after entity resolution Default: True.
+            track_provenance (bool | Unset): Whether to track mention provenance for resolved entities Default: True.
+    """
+
+    similarity_threshold: float | Unset = 0.85
+    type_must_match: bool | Unset = True
+    min_entity_confidence: float | Unset = 0.0
+    min_relation_confidence: float | Unset = 0.0
+    deduplicate_relations: bool | Unset = True
+    track_provenance: bool | Unset = True
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        similarity_threshold = self.similarity_threshold
+
+        type_must_match = self.type_must_match
+
+        min_entity_confidence = self.min_entity_confidence
+
+        min_relation_confidence = self.min_relation_confidence
+
+        deduplicate_relations = self.deduplicate_relations
+
+        track_provenance = self.track_provenance
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if similarity_threshold is not UNSET:
+            field_dict["similarity_threshold"] = similarity_threshold
+        if type_must_match is not UNSET:
+            field_dict["type_must_match"] = type_must_match
+        if min_entity_confidence is not UNSET:
+            field_dict["min_entity_confidence"] = min_entity_confidence
+        if min_relation_confidence is not UNSET:
+            field_dict["min_relation_confidence"] = min_relation_confidence
+        if deduplicate_relations is not UNSET:
+            field_dict["deduplicate_relations"] = deduplicate_relations
+        if track_provenance is not UNSET:
+            field_dict["track_provenance"] = track_provenance
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        similarity_threshold = d.pop("similarity_threshold", UNSET)
+
+        type_must_match = d.pop("type_must_match", UNSET)
+
+        min_entity_confidence = d.pop("min_entity_confidence", UNSET)
+
+        min_relation_confidence = d.pop("min_relation_confidence", UNSET)
+
+        deduplicate_relations = d.pop("deduplicate_relations", UNSET)
+
+        track_provenance = d.pop("track_provenance", UNSET)
+
+        inference_resolver_config = cls(
+            similarity_threshold=similarity_threshold,
+            type_must_match=type_must_match,
+            min_entity_confidence=min_entity_confidence,
+            min_relation_confidence=min_relation_confidence,
+            deduplicate_relations=deduplicate_relations,
+            track_provenance=track_provenance,
+        )
+
+        inference_resolver_config.additional_properties = d
+        return inference_resolver_config
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/py/packages/sdk/src/antfly/client_generated/models/lsm_storage_status.py
+++ b/py/packages/sdk/src/antfly/client_generated/models/lsm_storage_status.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="LsmStorageStatus")
+
+
+@_attrs_define
+class LsmStorageStatus:
+    """Compact LSM backend operational status. Detailed low-level counters are available through metrics.
+
+    Attributes:
+        run_count (int | Unset):
+        run_bytes (int | Unset):
+        l0_run_count (int | Unset):
+        l0_bytes (int | Unset):
+        wal_retained_bytes (int | Unset):
+        compaction_backlog_bytes (int | Unset):
+        active_readers (int | Unset):
+    """
+
+    run_count: int | Unset = UNSET
+    run_bytes: int | Unset = UNSET
+    l0_run_count: int | Unset = UNSET
+    l0_bytes: int | Unset = UNSET
+    wal_retained_bytes: int | Unset = UNSET
+    compaction_backlog_bytes: int | Unset = UNSET
+    active_readers: int | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        run_count = self.run_count
+
+        run_bytes = self.run_bytes
+
+        l0_run_count = self.l0_run_count
+
+        l0_bytes = self.l0_bytes
+
+        wal_retained_bytes = self.wal_retained_bytes
+
+        compaction_backlog_bytes = self.compaction_backlog_bytes
+
+        active_readers = self.active_readers
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if run_count is not UNSET:
+            field_dict["run_count"] = run_count
+        if run_bytes is not UNSET:
+            field_dict["run_bytes"] = run_bytes
+        if l0_run_count is not UNSET:
+            field_dict["l0_run_count"] = l0_run_count
+        if l0_bytes is not UNSET:
+            field_dict["l0_bytes"] = l0_bytes
+        if wal_retained_bytes is not UNSET:
+            field_dict["wal_retained_bytes"] = wal_retained_bytes
+        if compaction_backlog_bytes is not UNSET:
+            field_dict["compaction_backlog_bytes"] = compaction_backlog_bytes
+        if active_readers is not UNSET:
+            field_dict["active_readers"] = active_readers
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        run_count = d.pop("run_count", UNSET)
+
+        run_bytes = d.pop("run_bytes", UNSET)
+
+        l0_run_count = d.pop("l0_run_count", UNSET)
+
+        l0_bytes = d.pop("l0_bytes", UNSET)
+
+        wal_retained_bytes = d.pop("wal_retained_bytes", UNSET)
+
+        compaction_backlog_bytes = d.pop("compaction_backlog_bytes", UNSET)
+
+        active_readers = d.pop("active_readers", UNSET)
+
+        lsm_storage_status = cls(
+            run_count=run_count,
+            run_bytes=run_bytes,
+            l0_run_count=l0_run_count,
+            l0_bytes=l0_bytes,
+            wal_retained_bytes=wal_retained_bytes,
+            compaction_backlog_bytes=compaction_backlog_bytes,
+            active_readers=active_readers,
+        )
+
+        lsm_storage_status.additional_properties = d
+        return lsm_storage_status
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/py/packages/sdk/src/antfly/client_generated/models/storage_status.py
+++ b/py/packages/sdk/src/antfly/client_generated/models/storage_status.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
 from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.lsm_storage_status import LsmStorageStatus
+
 
 T = TypeVar("T", bound="StorageStatus")
 
@@ -17,16 +21,23 @@ class StorageStatus:
     Attributes:
         disk_usage (int | Unset): Disk usage in bytes.
         empty (bool | Unset): Whether the table has received data.
+        lsm (LsmStorageStatus | Unset): Compact LSM backend operational status. Detailed low-level counters are
+            available through metrics.
     """
 
     disk_usage: int | Unset = UNSET
     empty: bool | Unset = UNSET
+    lsm: LsmStorageStatus | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         disk_usage = self.disk_usage
 
         empty = self.empty
+
+        lsm: dict[str, Any] | Unset = UNSET
+        if not isinstance(self.lsm, Unset):
+            lsm = self.lsm.to_dict()
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
@@ -35,19 +46,31 @@ class StorageStatus:
             field_dict["disk_usage"] = disk_usage
         if empty is not UNSET:
             field_dict["empty"] = empty
+        if lsm is not UNSET:
+            field_dict["lsm"] = lsm
 
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.lsm_storage_status import LsmStorageStatus
+
         d = dict(src_dict)
         disk_usage = d.pop("disk_usage", UNSET)
 
         empty = d.pop("empty", UNSET)
 
+        _lsm = d.pop("lsm", UNSET)
+        lsm: LsmStorageStatus | Unset
+        if isinstance(_lsm, Unset):
+            lsm = UNSET
+        else:
+            lsm = LsmStorageStatus.from_dict(_lsm)
+
         storage_status = cls(
             disk_usage=disk_usage,
             empty=empty,
+            lsm=lsm,
         )
 
         storage_status.additional_properties = d

--- a/scripts/packaging/package_cli_release.py
+++ b/scripts/packaging/package_cli_release.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""Repack Antfly release archives as PyPI wheels and npm CLI packages."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import csv
+import hashlib
+import io
+import json
+import re
+import shutil
+import stat
+import tarfile
+import tempfile
+import zipfile
+from dataclasses import dataclass
+from email.message import Message
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class Platform:
+    key: str
+    release_os: str
+    release_arch: str
+    wheel_platform: str
+
+
+PLATFORMS = (
+    Platform("darwin-arm64", "Darwin", "arm64", "macosx_11_0_arm64"),
+    Platform("linux-arm64", "Linux", "arm64", "manylinux_2_28_aarch64"),
+    Platform("linux-x64", "Linux", "x86_64", "manylinux_2_28_x86_64"),
+)
+
+
+def normalize_release_version(raw: str) -> str:
+    version = raw[1:] if raw.startswith("v") else raw
+    if not re.fullmatch(r"[0-9]+(?:\.[0-9]+){1,2}(?:[-+][0-9A-Za-z.-]+)?", version):
+        raise SystemExit(f"invalid version for package metadata: {raw}")
+    return version
+
+
+def python_version_from_release(version: str) -> str:
+    match = re.fullmatch(
+        r"(?P<base>[0-9]+(?:\.[0-9]+){1,2})(?:-(?P<pre>[0-9A-Za-z.]+))?(?:\+(?P<local>[0-9A-Za-z.]+))?",
+        version,
+    )
+    if not match:
+        raise SystemExit(f"invalid release version for Python package metadata: {version}")
+
+    base = match.group("base")
+    pre = match.group("pre")
+    local = match.group("local")
+    py_version = base
+
+    if pre:
+        pre_match = re.fullmatch(r"(dev|alpha|a|beta|b|rc|pre|preview)\.?([0-9]+)", pre.lower())
+        if not pre_match:
+            raise SystemExit(f"unsupported prerelease version for PyPI: {version}")
+        label, number = pre_match.groups()
+        label = {
+            "alpha": "a",
+            "beta": "b",
+            "pre": "rc",
+            "preview": "rc",
+        }.get(label, label)
+        py_version += f".dev{number}" if label == "dev" else f"{label}{number}"
+
+    if local:
+        py_version += f"+{local.lower()}"
+    return py_version
+
+
+def archive_name(version: str, platform: Platform) -> str:
+    return f"antfly_{version}_{platform.release_os}_{platform.release_arch}.tar.gz"
+
+
+def is_packaging_noise(path: Path) -> bool:
+    return any(part == "__MACOSX" or part.startswith("._") for part in path.parts)
+
+
+def ignore_packaging_noise(_dir: str, names: list[str]) -> set[str]:
+    return {name for name in names if name == "__MACOSX" or name.startswith("._")}
+
+
+def safe_extract(tar: tarfile.TarFile, dest: Path) -> None:
+    dest_resolved = dest.resolve()
+    for member in tar.getmembers():
+        member_path = (dest / member.name).resolve()
+        if dest_resolved != member_path and dest_resolved not in member_path.parents:
+            raise SystemExit(f"archive member escapes destination: {member.name}")
+    tar.extractall(dest)
+
+
+def extract_archive(archive_dir: Path, version: str, platform: Platform, dest: Path) -> None:
+    archive = archive_dir / archive_name(version, platform)
+    if not archive.exists():
+        raise SystemExit(f"missing release archive: {archive}")
+    with tarfile.open(archive, "r:gz") as tar:
+        safe_extract(tar, dest)
+    binary = dest / "antfly"
+    if not binary.exists():
+        raise SystemExit(f"release archive does not contain antfly binary: {archive}")
+    binary.chmod(binary.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def copy_antfarm(repo_root: Path, extracted: Path) -> None:
+    dst = extracted / "share" / "antfly" / "antfarm"
+    if dst.exists():
+        return
+    src = repo_root / "go" / "pkg" / "antfly" / "src" / "metadata" / "antfarm"
+    if not src.exists():
+        raise SystemExit(f"missing Antfarm assets: {src}")
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(src, dst, ignore=ignore_packaging_noise)
+
+
+def clean_path(path: Path) -> None:
+    if path.exists():
+        if path.is_dir():
+            shutil.rmtree(path)
+        else:
+            path.unlink()
+
+
+def update_json_version(path: Path, version: str, optional_deps: bool = False) -> None:
+    data = json.loads(path.read_text())
+    data["version"] = version
+    if optional_deps:
+        for package_name in data.get("optionalDependencies", {}):
+            data["optionalDependencies"][package_name] = version
+    path.write_text(json.dumps(data, indent=2) + "\n")
+
+
+def update_pyproject_version(path: Path, version: str) -> None:
+    text = path.read_text()
+    text = re.sub(r'^version = "[^"]+"$', f'version = "{version}"', text, count=1, flags=re.MULTILINE)
+    path.write_text(text)
+
+
+def populate_npm_package(repo_root: Path, platform: Platform, extracted: Path) -> None:
+    package_dir = repo_root / "ts" / "packages" / platform.key.replace("darwin", "cli-darwin").replace("linux", "cli-linux")
+    clean_path(package_dir / "bin")
+    clean_path(package_dir / "share")
+    (package_dir / "bin").mkdir(parents=True)
+    shutil.copy2(extracted / "antfly", package_dir / "bin" / "antfly")
+    shutil.copytree(extracted / "share", package_dir / "share", ignore=ignore_packaging_noise)
+
+
+def package_python_wheel(
+    repo_root: Path,
+    out_dir: Path,
+    python_version: str,
+    platform: Platform,
+    extracted: Path,
+) -> Path:
+    dist_name = "antfly_cli"
+    package_name = "antfly_cli"
+    tag = f"py3-none-{platform.wheel_platform}"
+    wheel_name = f"{dist_name}-{python_version}-{tag}.whl"
+    wheel_path = out_dir / wheel_name
+    source_dir = repo_root / "py" / "packages" / "cli" / "src" / package_name
+    dist_info = f"{dist_name}-{python_version}.dist-info"
+
+    records: list[tuple[str, str, str]] = []
+
+    def write_bytes(zf: zipfile.ZipFile, arcname: str, data: bytes, mode: int | None = None) -> None:
+        info = zipfile.ZipInfo(arcname)
+        info.external_attr = ((mode or 0o644) & 0xFFFF) << 16
+        zf.writestr(info, data)
+        digest = base64.urlsafe_b64encode(hashlib.sha256(data).digest()).rstrip(b"=").decode()
+        records.append((arcname, f"sha256={digest}", str(len(data))))
+
+    def write_file(zf: zipfile.ZipFile, arcname: str, path: Path, mode: int | None = None) -> None:
+        write_bytes(zf, arcname, path.read_bytes(), mode)
+
+    metadata = Message()
+    metadata["Metadata-Version"] = "2.3"
+    metadata["Name"] = "antfly-cli"
+    metadata["Version"] = python_version
+    metadata["Summary"] = "Native Antfly CLI installer package"
+    metadata["Author-email"] = "Antfly, Inc. <ajroetker@antfly.io>"
+    metadata["License"] = "Elastic-2.0"
+    metadata["Requires-Python"] = ">=3.9"
+    metadata["Project-URL"] = "Homepage, https://antfly.io"
+    metadata["Project-URL"] = "Documentation, https://docs.antfly.io"
+    metadata["Project-URL"] = "Repository, https://github.com/antflydb/antfly"
+
+    wheel = (
+        "Wheel-Version: 1.0\n"
+        "Generator: antfly package_cli_release.py\n"
+        "Root-Is-Purelib: false\n"
+        f"Tag: {tag}\n"
+    )
+    entry_points = "[console_scripts]\nantfly = antfly_cli:main\n"
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(wheel_path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        for path in sorted(source_dir.glob("*.py")):
+            write_file(zf, f"{package_name}/{path.name}", path)
+        write_file(zf, f"{package_name}/bin/antfly", extracted / "antfly", 0o755)
+        for path in sorted((extracted / "share").rglob("*")):
+            if path.is_file() and not is_packaging_noise(path.relative_to(extracted)):
+                rel = path.relative_to(extracted)
+                write_file(zf, f"{package_name}/{rel.as_posix()}", path)
+        write_bytes(zf, f"{dist_info}/METADATA", metadata.as_bytes())
+        write_bytes(zf, f"{dist_info}/WHEEL", wheel.encode())
+        write_bytes(zf, f"{dist_info}/entry_points.txt", entry_points.encode())
+
+        record_path = f"{dist_info}/RECORD"
+        record_rows = [*records, (record_path, "", "")]
+        record_buf = []
+        for row in record_rows:
+            record_buf.append(row)
+        csv_io = io.StringIO()
+        writer = csv.writer(csv_io)
+        writer.writerows(record_buf)
+        csv_text = csv_io.getvalue()
+        write_bytes(zf, record_path, csv_text.encode())
+        records.pop()
+    return wheel_path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--version", required=True, help="Antfly version, with or without v prefix")
+    parser.add_argument("--archive-dir", type=Path, default=Path("dist"), help="Directory containing GoReleaser archives")
+    parser.add_argument("--out-dir", type=Path, default=Path("dist/cli-packages"), help="Output directory")
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).resolve().parents[2]
+    version = normalize_release_version(args.version)
+    python_version = python_version_from_release(version)
+    archive_dir = args.archive_dir.resolve()
+    out_dir = args.out_dir.resolve()
+    py_out = out_dir / "python"
+
+    update_pyproject_version(repo_root / "py" / "packages" / "cli" / "pyproject.toml", python_version)
+    update_json_version(repo_root / "ts" / "packages" / "cli" / "package.json", version, optional_deps=True)
+    for platform in PLATFORMS:
+        package_dir_name = platform.key.replace("darwin", "cli-darwin").replace("linux", "cli-linux")
+        update_json_version(repo_root / "ts" / "packages" / package_dir_name / "package.json", version)
+
+    clean_path(py_out)
+    for platform in PLATFORMS:
+        with tempfile.TemporaryDirectory() as tmp_raw:
+            extracted = Path(tmp_raw)
+            extract_archive(archive_dir, version, platform, extracted)
+            copy_antfarm(repo_root, extracted)
+            populate_npm_package(repo_root, platform, extracted)
+            wheel = package_python_wheel(repo_root, py_out, python_version, platform, extracted)
+            print(f"wrote {wheel}")
+
+    print("npm package directories populated under ts/packages/cli-*")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ts/packages/cli-darwin-arm64/README.md
+++ b/ts/packages/cli-darwin-arm64/README.md
@@ -1,0 +1,3 @@
+# @antfly/cli-darwin-arm64
+
+Platform package for `@antfly/cli` on macOS arm64.

--- a/ts/packages/cli-darwin-arm64/package.json
+++ b/ts/packages/cli-darwin-arm64/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@antfly/cli-darwin-arm64",
+  "version": "0.0.0",
+  "description": "Native Antfly CLI binary for macOS arm64",
+  "license": "Elastic-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/antflydb/antfly.git",
+    "directory": "ts/packages/cli-darwin-arm64"
+  },
+  "files": [
+    "bin",
+    "share",
+    "README.md"
+  ],
+  "os": [
+    "darwin"
+  ],
+  "cpu": [
+    "arm64"
+  ]
+}

--- a/ts/packages/cli-linux-arm64/README.md
+++ b/ts/packages/cli-linux-arm64/README.md
@@ -1,0 +1,3 @@
+# @antfly/cli-linux-arm64
+
+Platform package for `@antfly/cli` on Linux arm64.

--- a/ts/packages/cli-linux-arm64/package.json
+++ b/ts/packages/cli-linux-arm64/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@antfly/cli-linux-arm64",
+  "version": "0.0.0",
+  "description": "Native Antfly CLI binary for Linux arm64",
+  "license": "Elastic-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/antflydb/antfly.git",
+    "directory": "ts/packages/cli-linux-arm64"
+  },
+  "files": [
+    "bin",
+    "share",
+    "README.md"
+  ],
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "arm64"
+  ]
+}

--- a/ts/packages/cli-linux-x64/README.md
+++ b/ts/packages/cli-linux-x64/README.md
@@ -1,0 +1,3 @@
+# @antfly/cli-linux-x64
+
+Platform package for `@antfly/cli` on Linux x64.

--- a/ts/packages/cli-linux-x64/package.json
+++ b/ts/packages/cli-linux-x64/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@antfly/cli-linux-x64",
+  "version": "0.0.0",
+  "description": "Native Antfly CLI binary for Linux x64",
+  "license": "Elastic-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/antflydb/antfly.git",
+    "directory": "ts/packages/cli-linux-x64"
+  },
+  "files": [
+    "bin",
+    "share",
+    "README.md"
+  ],
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "x64"
+  ]
+}

--- a/ts/packages/cli/README.md
+++ b/ts/packages/cli/README.md
@@ -1,0 +1,12 @@
+# @antfly/cli
+
+npm package for installing the native Antfly CLI.
+
+```bash
+npm install -g @antfly/cli
+antfly --version
+```
+
+This package is separate from `@antfly/sdk`, which contains the TypeScript SDK.
+The CLI package depends on a platform-specific package that carries the native
+`antfly` executable and Antfarm dashboard assets.

--- a/ts/packages/cli/bin/antfly.js
+++ b/ts/packages/cli/bin/antfly.js
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { createRequire } from "node:module";
+import { join } from "node:path";
+
+const require = createRequire(import.meta.url);
+
+const packageByPlatform = {
+  "darwin-arm64": "@antfly/cli-darwin-arm64",
+  "linux-arm64": "@antfly/cli-linux-arm64",
+  "linux-x64": "@antfly/cli-linux-x64"
+};
+
+const platformKey = `${process.platform}-${process.arch}`;
+const packageName = packageByPlatform[platformKey];
+
+if (!packageName) {
+  console.error(`Unsupported Antfly CLI platform: ${platformKey}`);
+  process.exit(1);
+}
+
+let packageJsonPath;
+try {
+  packageJsonPath = require.resolve(`${packageName}/package.json`);
+} catch {
+  console.error(`Missing Antfly CLI platform package: ${packageName}`);
+  console.error("Reinstall @antfly/cli and verify optional dependencies were not disabled.");
+  process.exit(1);
+}
+
+const executable = join(packageJsonPath, "..", "bin", process.platform === "win32" ? "antfly.exe" : "antfly");
+if (!existsSync(executable)) {
+  console.error(`Antfly CLI executable is missing: ${executable}`);
+  process.exit(1);
+}
+
+const result = spawnSync(executable, process.argv.slice(2), { stdio: "inherit" });
+if (result.error) {
+  console.error(result.error.message);
+  process.exit(1);
+}
+
+process.exit(result.status ?? 1);

--- a/ts/packages/cli/package.json
+++ b/ts/packages/cli/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@antfly/cli",
+  "version": "0.0.0",
+  "description": "Native Antfly CLI installer package",
+  "license": "Elastic-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/antflydb/antfly.git",
+    "directory": "ts/packages/cli"
+  },
+  "bugs": {
+    "url": "https://github.com/antflydb/antfly/issues"
+  },
+  "homepage": "https://antfly.io",
+  "bin": {
+    "antfly": "./bin/antfly.js"
+  },
+  "files": [
+    "bin",
+    "README.md"
+  ],
+  "scripts": {
+    "test": "node --check ./bin/antfly.js"
+  },
+  "optionalDependencies": {
+    "@antfly/cli-darwin-arm64": "0.0.0",
+    "@antfly/cli-linux-arm64": "0.0.0",
+    "@antfly/cli-linux-x64": "0.0.0"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "os": [
+    "darwin",
+    "linux"
+  ],
+  "cpu": [
+    "arm64",
+    "x64"
+  ]
+}

--- a/ts/pnpm-lock.yaml
+++ b/ts/pnpm-lock.yaml
@@ -296,6 +296,14 @@ importers:
         specifier: 5.9.3
         version: 5.9.3
 
+  packages/cli: {}
+
+  packages/cli-darwin-arm64: {}
+
+  packages/cli-linux-arm64: {}
+
+  packages/cli-linux-x64: {}
+
   packages/components:
     dependencies:
       '@babel/runtime':


### PR DESCRIPTION
## Summary
- keep SDK package names as antfly-sdk and @antfly/sdk, and add separate CLI packages antfly-cli and @antfly/cli
- add platform npm packages for darwin-arm64, linux-arm64, and linux-x64 that carry the native antfly binary and Antfarm assets
- add a release repacker plus workflow to publish PyPI wheels and npm tarballs from existing Antfly release archives

## Verification
- env PYTHONPYCACHEPREFIX=/tmp/antfly-cli-pycache python3 -m py_compile scripts/packaging/package_cli_release.py py/packages/cli/src/antfly_cli/__init__.py py/packages/cli/src/antfly_cli/__main__.py
- node --check ts/packages/cli/bin/antfly.js
- env npm_config_cache=/tmp/antfly-npm-cache npm pack --dry-run ./ts/packages/cli
- fake release archive smoke test generated all three antfly-cli wheels and populated npm platform package payloads
- pnpm install --lockfile-only