### PR TITLE
Fix CLI package bin path

### DIFF
--- a/ts/.gitignore
+++ b/ts/.gitignore
@@ -5,6 +5,7 @@ node_modules/
 dist/
 .next/
 tsconfig.tsbuildinfo
+*.tgz
 # Generated declaration files at package root (not src/types/)
 packages/*/types/
 

--- a/ts/packages/cli/package.json
+++ b/ts/packages/cli/package.json
@@ -13,7 +13,7 @@
   },
   "homepage": "https://antfly.io",
   "bin": {
-    "antfly": "./bin/antfly.js"
+    "antfly": "bin/antfly.js"
   },
   "files": [
     "bin",


### PR DESCRIPTION
## Summary
- use npm-normalized bin path for @antfly/cli so publish keeps the antfly command metadata

## Verification
- env npm_config_cache=/tmp/antfly-npm-cache npm pack --dry-run ./ts/packages/cli
- node --check ts/packages/cli/bin/antfly.js