### PR TITLE
Run Python SDK generation check on canonical Python

### DIFF
--- a/.github/workflows/py-ci.yml
+++ b/.github/workflows/py-ci.yml
@@ -35,6 +35,7 @@ jobs:
         run: uv sync
 
       - name: Verify generated client
+        if: matrix.python-version == '3.13'
         working-directory: py/packages/sdk
         run: |
           make generate


### PR DESCRIPTION
## Summary
- run the Python SDK generated-client cleanliness check only on Python 3.13
- keep the 3.9-3.13 matrix for install, lint, type-check, and tests
- avoid non-deterministic openapi-python-client output across Python-specific dependency resolutions

## Verification
- actionlint .github/workflows/py-ci.yml
- make test (py/packages/sdk)
- git diff --check