### PR TITLE
include Antfly Inference unit tests in ci pipeline

### DIFF
--- a/zig/build.zig
+++ b/zig/build.zig
@@ -155,6 +155,7 @@ const DelegatedPackageStep = struct {
 
 const DelegatedInferenceBuildSteps = struct {
     inference_test: *std.Build.Step,
+    inference_finetune_test: *std.Build.Step,
 };
 
 fn dependOnAll(step: *std.Build.Step, dependencies: []const *std.Build.Step) void {
@@ -247,6 +248,7 @@ fn addDelegatedInferenceBuildSteps(
     blas_root: ?[]const u8,
 ) DelegatedInferenceBuildSteps {
     var test_step: ?*std.Build.Step = null;
+    var finetune_test_step: ?*std.Build.Step = null;
     for (inference_delegated_steps) |step_name| {
         const delegated = addDelegatedPackageStep(b, "inference", "pkg/inference", step_name, "pkg/inference");
         const run = delegated.run;
@@ -254,10 +256,13 @@ fn addDelegatedInferenceBuildSteps(
         forwardBuildArgs(b, run);
         if (std.mem.eql(u8, step_name, "test")) {
             test_step = delegated.step;
+        } else if (std.mem.eql(u8, step_name, "test-finetune")) {
+            finetune_test_step = delegated.step;
         }
     }
     return .{
         .inference_test = test_step.?,
+        .inference_finetune_test = finetune_test_step.?,
     };
 }
 
@@ -3998,6 +4003,8 @@ pub fn build(b: *std.Build) void {
     unit_test_step.dependOn(&run_lib_a2a_tests.step);
     unit_test_step.dependOn(&run_lib_image_tests.step);
     unit_test_step.dependOn(&run_lib_audio_tests.step);
+    unit_test_step.dependOn(delegated_inference_steps.inference_test);
+    unit_test_step.dependOn(delegated_inference_steps.inference_finetune_test);
     unit_test_step.dependOn(lib_swarm_runtime_test_step);
     unit_test_step.dependOn(&run_raft_unit_tests.step);
     unit_test_step.dependOn(&run_raft_transport_tests.step);

--- a/zig/pkg/inference/build/finetune/tests.zig
+++ b/zig/pkg/inference/build/finetune/tests.zig
@@ -54,6 +54,7 @@ const tests = [_]common.TestSpec{
         .root_source_file = "src/finetune/test/test_gliner2_run_validation.zig",
         .description = "Run GLiNER2 autodiff training artifact and metrics validation tests",
         .imports = &.{ .build_options, .inference_internal },
+        .native_link = .default,
     },
     .{
         .step_name = "test-entity-cleanup-data",
@@ -65,6 +66,7 @@ const tests = [_]common.TestSpec{
         .root_source_file = "src/test_entity_cleanup_model.zig",
         .description = "Run isolated learned entity cleanup model tests",
         .imports = &.{ .build_options, .inference_hf_tokenizer },
+        .native_link = .default,
     },
     .{
         .step_name = "test-entity-cleanup-gliner-cache",

--- a/zig/pkg/inference/build/finetune/tests.zig
+++ b/zig/pkg/inference/build/finetune/tests.zig
@@ -70,14 +70,14 @@ const tests = [_]common.TestSpec{
         .step_name = "test-entity-cleanup-gliner-cache",
         .root_source_file = "src/test_entity_cleanup_gliner_cache.zig",
         .description = "Run isolated GLiNER2-native entity cleanup cache tests",
-        .imports = &.{ .antfly_platform, .build_options, .inference_hf_tokenizer, .inference_linalg, .ml, .onnx_graph },
+        .imports = &.{ .antfly_platform, .build_options, .inference_hf_tokenizer, .inference_linalg, .ml, .onnx_graph, .inference_internal },
         .native_link = .default,
     },
     .{
         .step_name = "test-gliner2-cleanup-bundle",
         .root_source_file = "src/test_gliner2_cleanup_bundle.zig",
         .description = "Run GLiNER2 cleanup bundle propagation tests",
-        .imports = &.{ .antfly_platform, .build_options, .ml, .pjrt, .inference_linalg, .onnx_graph },
+        .imports = &.{ .antfly_platform, .build_options, .ml, .pjrt, .inference_linalg, .onnx_graph, .inference_internal },
         .native_link = .default,
     },
     .{

--- a/zig/pkg/inference/src/test_entity_cleanup_gliner_cache.zig
+++ b/zig/pkg/inference/src/test_entity_cleanup_gliner_cache.zig
@@ -12,9 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const std = @import("std");
-const entity_cleanup_gliner_cache = @import("finetune/entity_cleanup_gliner_cache.zig");
-
-test {
-    std.testing.refAllDecls(entity_cleanup_gliner_cache);
+test "entity cleanup GLiNER cache declarations compile" {
+    _ = @import("inference_internal").finetune.entity_cleanup_gliner_cache;
 }

--- a/zig/pkg/inference/src/test_gliner2_cleanup_bundle.zig
+++ b/zig/pkg/inference/src/test_gliner2_cleanup_bundle.zig
@@ -12,9 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const std = @import("std");
-const gliner2 = @import("finetune/gliner2.zig");
-
-test {
-    std.testing.refAllDecls(gliner2);
+test "GLiNER2 cleanup bundle declarations compile" {
+    _ = @import("inference_internal").finetune.gliner2;
 }


### PR DESCRIPTION
## Summary
  - Wire Antfly Inference unit coverage into the CI `zig-unit-test` aggregate
  - Include both delegated inference runtime tests and focused finetune tests

  ## Validation
  - `zig fmt zig/build.zig`
  - `zig build -l`
  - `zig build inference-test -Dmetal=false -Donnx=false -Dsystem-blas=false --summary all`