### PR TITLE
Stop building Go fallback artifacts during release

### DIFF
--- a/.github/workflows/antfly-release.yml
+++ b/.github/workflows/antfly-release.yml
@@ -106,35 +106,11 @@ jobs:
   goreleaser:
     needs: build-zig-runtime-archives
     runs-on: arc-antfly-heavy
-    env:
-      GOEXPERIMENT: simd
-      GOCACHE: /mnt/cache/go-build
-      GOMODCACHE: /mnt/cache/go-mod
-      XDG_CACHE_HOME: /mnt/cache/xdg
-      TMPDIR: /mnt/cache/tmp
     steps:
-      - name: Prepare cache directories
-        run: mkdir -p "$GOCACHE" "$GOMODCACHE" "$XDG_CACHE_HOME" "$TMPDIR"
-
       - name: Checkout
         uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Required for GoReleaser changelog generation
-          submodules: true # Your project uses submodules
-
-      - name: Set up Go
-        uses: actions/setup-go@v6
-        with:
-          go-version: "1.26"
-          cache: false
-
-      - name: Verify Go version
-        run: go version
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: lts/*
 
       - name: Download native Zig runtime archives
         uses: actions/download-artifact@v6
@@ -147,91 +123,6 @@ jobs:
         run: |
           cd prebuilt-zig
           shasum -a 256 antfly_*.tar.gz > antfly_zig_checksums.txt
-
-      - name: Install protoc
-        run: |
-          # Install protoc 33.1 (supports Protobuf Editions)
-          # Ubuntu apt has old versions that don't support edition = "2023"
-          PROTOC_VERSION="33.1"
-          curl -fsSLO "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip"
-          sudo unzip -o "protoc-${PROTOC_VERSION}-linux-x86_64.zip" -d /usr/local
-          rm "protoc-${PROTOC_VERSION}-linux-x86_64.zip"
-          protoc --version
-
-      - name: Install protoc-gen-go
-        run: go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.36.10
-
-      - name: Install release dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu xz-utils
-
-      - name: Install Zig
-        uses: mlugg/setup-zig@v2
-        with:
-          version: "0.16.0"
-
-      # Cache ONNX Runtime libraries (versions from scripts/download-onnxruntime.sh)
-      - name: Cache ONNX Runtime libraries
-        id: cache-onnx
-        uses: actions/cache@v5
-        with:
-          path: onnxruntime
-          key: onnxruntime-1.24.3-genai-0.12.1-tokenizers-1.26.0
-
-      - name: Download ONNX Runtime libraries
-        if: steps.cache-onnx.outputs.cache-hit != 'true'
-        run: ./scripts/download-onnxruntime.sh
-
-      # Cache PJRT libraries (versions from scripts/download-pjrt.sh)
-      - name: Cache PJRT libraries
-        id: cache-pjrt
-        uses: actions/cache@v5
-        with:
-          path: pjrt
-          key: pjrt-0.83.4-tokenizers-1.25.0
-
-      - name: Download PJRT libraries
-        if: steps.cache-pjrt.outputs.cache-hit != 'true'
-        run: ./scripts/download-pjrt.sh
-
-      # Cache macOS SDK for cross-compilation
-      - name: Cache macOS SDK
-        id: cache-macos-sdk
-        uses: actions/cache@v5
-        with:
-          path: /tmp/macos-sdk
-          key: macos-sdk-15.5
-
-      - name: Download macOS SDK for cross-compilation
-        if: steps.cache-macos-sdk.outputs.cache-hit != 'true'
-        run: |
-          # Download macOS SDK for cross-compilation
-          # Using the osxcross SDK packages from joseluisq/macosx-sdks
-          mkdir -p /tmp/macos-sdk
-          curl -fsSL https://github.com/joseluisq/macosx-sdks/releases/download/15.5/MacOSX15.5.sdk.tar.xz | tar -xJf - -C /tmp/macos-sdk
-
-      - name: Set macOS SDK path
-        run: |
-          echo "SDK_PATH=/tmp/macos-sdk/MacOSX15.5.sdk" >> "$GITHUB_ENV"
-          # Verify required headers exist (mach headers are in Kernel.framework, not usr/include)
-          echo "Checking for mach headers in Kernel.framework..."
-          mach_headers="/tmp/macos-sdk/MacOSX15.5.sdk/System/Library/Frameworks/Kernel.framework/Versions/A/Headers/mach"
-          if [ -d "$mach_headers" ]; then
-            find "$mach_headers" -maxdepth 1 -mindepth 1 -print | head -20
-          else
-            echo "WARNING: mach headers not found in Kernel.framework"
-          fi
-          test -f "$mach_headers/mach_vm.h" || echo "WARNING: mach_vm.h not found"
-
-      - name: Configure Go for private modules
-        run: |
-          {
-            echo "GONOPROXY=github.com/antflydb/antfly"
-            echo "GOPRIVATE=github.com/antflydb/antfly"
-            echo "ONNXRUNTIME_ROOT=${{ github.workspace }}/onnxruntime"
-            echo "PJRT_ROOT=${{ github.workspace }}/pjrt"
-          } >> "$GITHUB_ENV"
 
       - name: Extract version from tag
         run: |
@@ -246,7 +137,6 @@ jobs:
           args: release --clean --skip=validate
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_ENDPOINT_URL: ${{ secrets.AWS_ENDPOINT_URL }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -8,195 +8,8 @@
 
 version: 2
 
-before:
-  hooks:
-    - ./scripts/completions.sh
-    - sh -c 'cd go/pkg/antfly && go mod tidy'
-    - sh -c 'cd go/pkg/antfly && go generate ./...'
-
-builds:
-  # Go fallback build for platforms without the Zig runtime.
-  - env:
-      - CGO_ENABLED=0
-      - GOEXPERIMENT=simd
-    tags:
-      - afrelease
-    goos:
-      - windows
-    id: "antfly-go-windows"
-    dir: ./go/pkg/antfly
-    main: ./cmd
-    binary: antfly-go
-    ignore:
-      - goarch: "386"
-
-  # ============================================
-  # Go fallback OMNI builds (ONNX + XLA) for old data dirs and rollback.
-  # ============================================
-
-  # Linux AMD64 Go fallback OMNI (ONNX + XLA)
-  - id: "antfly-go-linux-amd64"
-    env:
-      - CGO_ENABLED=1
-      - GOEXPERIMENT=simd
-      - CGO_LDFLAGS=-L{{ .Env.ONNXRUNTIME_ROOT }}/linux-amd64/lib -lonnxruntime -ltokenizers -lstdc++
-      - CGO_CFLAGS=-I{{ .Env.ONNXRUNTIME_ROOT }}/linux-amd64/include
-    flags:
-      - -trimpath
-    ldflags:
-      - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}}
-    tags:
-      - afrelease
-      - onnx
-      - ORT
-      - xla
-      - XLA
-    goos:
-      - linux
-    goarch:
-      - amd64
-    dir: ./go/pkg/antfly
-    main: ./cmd
-    binary: antfly-go
-
-  # Linux ARM64 Go fallback OMNI (ONNX + XLA) (cross-compile)
-  - id: "antfly-go-linux-arm64"
-    env:
-      - CGO_ENABLED=1
-      - GOEXPERIMENT=simd
-      - CC=aarch64-linux-gnu-gcc
-      - CXX=aarch64-linux-gnu-g++
-      - CGO_LDFLAGS=-L{{ .Env.ONNXRUNTIME_ROOT }}/linux-arm64/lib -lonnxruntime -ltokenizers -lstdc++
-      - CGO_CFLAGS=-I{{ .Env.ONNXRUNTIME_ROOT }}/linux-arm64/include
-    flags:
-      - -trimpath
-    ldflags:
-      - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}}
-    tags:
-      - afrelease
-      - onnx
-      - ORT
-      - xla
-      - XLA
-    goos:
-      - linux
-    goarch:
-      - arm64
-    dir: ./go/pkg/antfly
-    main: ./cmd
-    binary: antfly-go
-
-  # macOS ARM64 Go fallback OMNI (ONNX + XLA) (Zig cross-compilation)
-  - id: "antfly-go-darwin-arm64"
-    env:
-      - CGO_ENABLED=1
-      - GOEXPERIMENT=simd
-      - CC=zig c++ -target aarch64-macos -isysroot {{ .Env.SDK_PATH }} -I{{ .Env.SDK_PATH }}/usr/include -I{{ .Env.SDK_PATH }}/System/Library/Frameworks/Kernel.framework/Versions/A/Headers -F{{ .Env.SDK_PATH }}/System/Library/Frameworks -Wno-nullability-completeness
-      - CXX=zig c++ -target aarch64-macos -isysroot {{ .Env.SDK_PATH }} -I{{ .Env.SDK_PATH }}/usr/include -I{{ .Env.SDK_PATH }}/System/Library/Frameworks/Kernel.framework/Versions/A/Headers -F{{ .Env.SDK_PATH }}/System/Library/Frameworks -Wno-nullability-completeness
-      - CGO_LDFLAGS=-L{{ .Env.ONNXRUNTIME_ROOT }}/darwin-arm64/lib -L{{ .Env.SDK_PATH }}/usr/lib -lonnxruntime -ltokenizers -F{{ .Env.SDK_PATH }}/System/Library/Frameworks -framework CoreFoundation -framework Security
-      - CGO_CFLAGS=-I{{ .Env.ONNXRUNTIME_ROOT }}/darwin-arm64/include -isysroot {{ .Env.SDK_PATH }} -I{{ .Env.SDK_PATH }}/usr/include -I{{ .Env.SDK_PATH }}/System/Library/Frameworks/Kernel.framework/Versions/A/Headers -Wno-nullability-completeness
-    flags:
-      - -trimpath
-    ldflags:
-      - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}}
-      - -extldflags "-Wl,-rpath,@executable_path/lib"
-    tags:
-      - afrelease
-      - onnx
-      - ORT
-      - xla
-      - XLA
-    goos:
-      - darwin
-    goarch:
-      - arm64
-    dir: ./go/pkg/antfly
-    main: ./cmd
-    binary: antfly-go
-
-archives:
-  # Go fallback builds. Linux and macOS include bundled ONNX Runtime and PJRT
-  # libraries so existing Go/omni users can keep old data dirs or take a
-  # portable backup before restoring into the Zig runtime.
-  - id: go
-    formats: [tar.gz]
-    name_template: >-
-      {{ .ProjectName }}-go_
-      {{- .Version }}_
-      {{- title .Os }}_
-      {{- if eq .Arch "amd64" }}x86_64
-      {{- else if eq .Arch "386" }}i386
-      {{- else }}{{ .Arch }}{{ end }}
-      {{- if .Arm }}v{{ .Arm }}{{ end }}
-    format_overrides:
-      - goos: windows
-        formats: [zip]
-    ids:
-      - antfly-go-windows
-      - antfly-go-linux-amd64
-      - antfly-go-linux-arm64
-      - antfly-go-darwin-arm64
-    files:
-      - README.md
-      - LICENSE
-      - completions/*
-      # Bundle ONNX Runtime libraries for Linux and macOS fallback builds.
-      - src: "onnxruntime/{{ .Os }}-{{ .Arch }}/lib/libonnxruntime*"
-        dst: lib/
-        strip_parent: true
-        info:
-          mode: 0755
-      # Bundle ONNX Runtime GenAI libraries (for LLM generation)
-      # Note: Not available for linux-arm64 and Windows, glob silently skips if no match
-      - src: "onnxruntime/{{ .Os }}-{{ .Arch }}/lib/libonnxruntime-genai*"
-        dst: lib/
-        strip_parent: true
-        info:
-          mode: 0755
-      # Bundle PJRT CPU plugin for XLA backend
-      - src: "pjrt/{{ .Os }}-{{ .Arch }}/lib/pjrt_c_api_cpu*"
-        dst: lib/
-        strip_parent: true
-        info:
-          mode: 0755
-
-  # Legacy archive id retained for compatibility with old local release commands.
-  # Includes bundled ONNX Runtime and PJRT libraries
-  - id: omni
-    formats: [tar.gz]
-    name_template: >-
-      {{ .ProjectName }}-omni_
-      {{- .Version }}_
-      {{- title .Os }}_
-      {{- if eq .Arch "amd64" }}x86_64
-      {{- else }}{{ .Arch }}{{ end }}
-    ids:
-      - antfly-go-linux-amd64
-      - antfly-go-linux-arm64
-      - antfly-go-darwin-arm64
-    files:
-      - README.md
-      - LICENSE
-      - completions/*
-      # Bundle ONNX Runtime libraries for each platform
-      - src: "onnxruntime/{{ .Os }}-{{ .Arch }}/lib/libonnxruntime*"
-        dst: lib/
-        strip_parent: true
-        info:
-          mode: 0755
-      # Bundle ONNX Runtime GenAI libraries (for LLM generation)
-      # Note: Not available for linux-arm64, glob silently skips if no match
-      - src: "onnxruntime/{{ .Os }}-{{ .Arch }}/lib/libonnxruntime-genai*"
-        dst: lib/
-        strip_parent: true
-        info:
-          mode: 0755
-      # Bundle PJRT CPU plugin for XLA backend
-      - src: "pjrt/{{ .Os }}-{{ .Arch }}/lib/pjrt_c_api_cpu*"
-        dst: lib/
-        strip_parent: true
-        info:
-          mode: 0755
+builds: []
+archives: []
 
 changelog:
   sort: asc
@@ -207,7 +20,6 @@ changelog:
       - "^test:"
       - Merge pull request
       - Merge branch
-      - go mod tidy
 
 release:
   # https://goreleaser.com/customization/release/
@@ -257,41 +69,6 @@ release:
 
   # Upload metadata.json and artifacts.json to the release as well.
   include_meta: true
-brews:
-  - name: antfly-go
-    ids:
-      - go
-    skip_upload: auto
-    directory: Formula
-    repository:
-      owner: antflydb
-      name: homebrew-taps
-      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
-    homepage: "https://docs.antfly.io"
-    description: "Go/omni AntflyDB fallback runtime"
-    license: "Elastic-2.0"
-    url_template: "https://releases.antfly.io/antfly/{{ .Tag }}/{{ .ArtifactName }}"
-    install: |
-      libexec.install "antfly-go"
-      libexec.install "lib" if Dir.exist?("lib")
-      bin.write_exec_script libexec/"antfly-go"
-      bash_completion.install "completions/antfly.bash" => "antfly-go"
-      zsh_completion.install "completions/antfly.zsh" => "_antfly-go"
-      fish_completion.install "completions/antfly.fish" => "antfly-go.fish"
-    service: |
-      run [opt_bin/"antfly-go", "--data-dir", var/"lib/antfly", "swarm"]
-      keep_alive true
-      working_dir var/"lib/antfly"
-      log_path var/"log/antfly-go.log"
-      error_log_path var/"log/antfly-go.err.log"
-    post_install: |
-      (var/"lib/antfly").mkpath
-    test: |
-      system "#{bin}/antfly-go", "--version"
-    caveats: |
-      antfly-go is the previous Go/omni runtime. Use it to keep running an old
-      Go data directory or to create a portable backup before restoring into
-      the default Zig runtime.
 blobs:
   # https://goreleaser.com/customization/blob/
   # You can have multiple blob configs
@@ -299,8 +76,8 @@ blobs:
     endpoint: "{{ .Env.AWS_ENDPOINT_URL }}"
     region: auto  # Required for Cloudflare R2 (doesn't accept AWS region names like us-east-2)
     bucket: antfly-releases
-    # No ids filter: upload every generated Go fallback artifact and the
-    # prebuilt native Zig runtime archives.
+    # No ids filter: upload the prebuilt native Zig runtime archives and
+    # release support files.
     # You can add extra pre-existing files to the bucket.
     #
     # The filename on the release will be the last part of the path (base).
@@ -328,7 +105,7 @@ blobs:
     bucket: antfly-releases
     directory: "antfly/latest"
     disable: "{{ if .Prerelease }}true{{ end }}"
-    # No ids filter: publish all stable-release artifacts to the latest channel.
+    # No ids filter: publish stable-release Zig artifacts to the latest channel.
     extra_files:
       - glob: ./prebuilt-zig/antfly_*.tar.gz
       - glob: ./prebuilt-zig/antfly_zig_checksums.txt


### PR DESCRIPTION
## Summary
- remove Go fallback builds, archives, and antfly-go Homebrew publishing from GoReleaser
- simplify the release GoReleaser job so it only publishes prebuilt Zig archives/support files
- remove release-time Go, protoc, ONNX/PJRT, SDK, and cross-compiler setup

## Validation
- ruby YAML parse for .goreleaser.yaml and antfly-release.yml
- goreleaser check
- git diff --check