### PR TITLE
Set up Go for GoReleaser metadata

### DIFF
--- a/.github/workflows/antfly-release.yml
+++ b/.github/workflows/antfly-release.yml
@@ -129,6 +129,12 @@ jobs:
           echo "GORELEASER_CURRENT_TAG=${GITHUB_REF_NAME}" >> "$GITHUB_ENV"
           echo "Release version: ${GITHUB_REF_NAME}"
 
+      - name: Set up Go for GoReleaser metadata
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.26"
+          cache: false
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
@@ -136,6 +142,7 @@ jobs:
           version: "v2.12.0"
           args: release --clean --skip=validate
         env:
+          GOWORK: off
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -8,7 +8,9 @@
 
 version: 2
 
-builds: []
+builds:
+  - id: antfly-go-disabled
+    skip: true
 archives: []
 
 changelog:


### PR DESCRIPTION
## Summary
- install Go in the release GoReleaser job for GoReleaser's module metadata phase
- keep Go builds disabled with builds: [] and archives: []
- do not restore CGO, ONNX/PJRT, macOS SDK, or Go fallback artifact setup

## Validation
- ruby YAML parse for antfly-release.yml
- goreleaser check
- git diff --check