### PR TITLE
Stabilize scheduled Zig CI followups

### DIFF
--- a/.github/workflows/zig-tests.yml
+++ b/.github/workflows/zig-tests.yml
@@ -294,9 +294,28 @@ jobs:
         working-directory: zig
         run: zig build recall-test
 
-      - name: Run Zig recall harness
+      - name: Run Zig recall harness sweep
         working-directory: zig
-        run: zig build recall-harness -- --dataset-dir testdata/vectorsets
+        run: |
+          set -euo pipefail
+          datasets=(
+            images-512d-10k.gob
+            random-20d-1k.gob
+            fashionminst-784d-1k.gob
+            fashionminst-784d-10k.gob
+            laionclip-768d-1k.gob
+            laiongemini-1408d-1k.gob
+            laiongemini-512d-10k.gob
+            dbpedia-1536d-1k.gob
+            random-2048d-1k.gob
+            random-4096d-1k.gob
+            wikiarticles-768d-10k.gob
+          )
+          for dataset in "${datasets[@]}"; do
+            echo "::group::recall-harness ${dataset}"
+            zig build recall-harness -- --dataset-dir testdata/vectorsets --dataset "${dataset}"
+            echo "::endgroup::"
+          done
 
       - name: Run Zig chaos tests
         working-directory: zig
@@ -394,4 +413,6 @@ jobs:
         working-directory: zig
         env:
           ANTFLY_BIN: ./zig-out/bin/antfly
+          ANTFLY_INFERENCE_DOWNLOAD: "1"
+          ANTFLY_INFERENCE_DEFAULT_GENERATOR_MODEL: openai-community/gpt2
         run: uv run --project e2e/inference pytest -q -x e2e/inference

--- a/zig/e2e/inference/models.py
+++ b/zig/e2e/inference/models.py
@@ -372,7 +372,9 @@ def default_generator_model_name(available_generators: set[str] | None = None) -
     if override:
         return override
 
-    if available_generators:
+    if available_generators is not None:
+        if not available_generators:
+            return None
         for candidate in (DEFAULT_GENERATOR_MODEL, DEFAULT_TOOL_GENERATOR_MODEL):
             if candidate in available_generators:
                 return candidate
@@ -431,9 +433,10 @@ def find_tool_model_name(available_generators: set[str] | None = None) -> str | 
                 if available_generators is None or model_name in available_generators:
                     return model_name
 
-    if available_generators:
+    if available_generators is not None:
         if DEFAULT_TOOL_GENERATOR_MODEL in available_generators:
             return DEFAULT_TOOL_GENERATOR_MODEL
+        return None
 
     return DEFAULT_TOOL_GENERATOR_MODEL
 
@@ -498,9 +501,10 @@ def find_multimodal_generator_model_name(available_generators: set[str] | None =
             if available_generators is None or model_name in available_generators:
                 return model_name
 
-    if available_generators:
+    if available_generators is not None:
         if DEFAULT_MULTIMODAL_GENERATOR_MODEL in available_generators:
             return DEFAULT_MULTIMODAL_GENERATOR_MODEL
+        return None
 
     return DEFAULT_MULTIMODAL_GENERATOR_MODEL
 


### PR DESCRIPTION
## Summary
- keep the full recall harness sweep in full-default, but split it into one invocation per dataset with GitHub log groups so the runner gets clear phase boundaries while preserving coverage
- make scheduled inference full E2E enable lazy model downloads and request the GPT-2 generator used by OpenAI SDK compatibility tests
- make generator helper selection return None for explicitly empty generator listings, so portable no-download runs still skip instead of calling a nonexistent default model

## Failing jobs
- https://github.com/antflydb/antfly/actions/runs/27011919421/job/79717351211
- https://github.com/antflydb/antfly/actions/runs/27011919421/job/79717457239

## Verification
- full recall-harness sweep locally, split by every dataset in recall_cases.zig
- python3 helper check for GPT-2 env bootstrap and empty/non-empty generator selection
- ruby YAML parse check for .github/workflows/zig-tests.yml
- git diff --check