### PR TITLE
Fan out container release publishing

### DIFF
--- a/.github/workflows/antfly-release.yml
+++ b/.github/workflows/antfly-release.yml
@@ -331,8 +331,6 @@ jobs:
     needs:
       - build-zig-runtime-archives
       - publish-release-assets
-      - publish-cli-pypi
-      - publish-cli-npm
     uses: ./.github/workflows/antfly-container.yml
     with:
       tag_name: ${{ github.ref_name }}

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -48,6 +48,10 @@ failed under CI memory pressure, especially Linux arm64 from amd64.
    `artifact_source: github`, so the container image uses the Linux archives
    already built by the release.
 
+After the native archives and release payload are published, package registry
+publishes, Homebrew, and container publishing fan out independently. A PyPI or
+npm publish failure must not block the container image for the same tag.
+
 `.github/workflows/antfly-container.yml` still supports standalone container
 publishes. In standalone mode it builds the Linux archives on native Linux
 runners, uploads them to the container artifact bucket, and packages images from


### PR DESCRIPTION
## Summary
- let container publishing run after release assets instead of waiting on npm/PyPI
- document that package registry, Homebrew, and container publishing fan out independently

## Verification
- actionlint .github/workflows/antfly-release.yml