### PR TITLE
Add Gemma4 12B unified image/audio inference support

### DIFF
--- a/zig/pkg/inference/src/architectures/gemma4_projector.zig
+++ b/zig/pkg/inference/src/architectures/gemma4_projector.zig
@@ -29,6 +29,7 @@ const CT = ops.CT;
 
 const default_spatial_merge_size: usize = 3;
 const default_max_image_tokens: usize = 280;
+const default_max_direct_audio_tokens: usize = 16_384;
 
 pub const ProjectedImages = struct {
     allocator: std.mem.Allocator,
@@ -60,6 +61,7 @@ const Config = struct {
     intermediate_size: usize,
     block_count: usize,
     head_count: usize,
+    direct_unified: bool = false,
     image_size: usize,
     patch_size: usize,
     layer_norm_eps: f32,
@@ -81,6 +83,9 @@ const AudioConfig = struct {
     intermediate_size: usize,
     block_count: usize,
     head_count: usize,
+    direct_unified: bool = false,
+    raw_samples_per_token: usize = 640,
+    max_direct_audio_tokens: usize = default_max_direct_audio_tokens,
     mel_bins: usize,
     layer_norm_eps: f32,
     conv_channels0: usize = 128,
@@ -144,8 +149,8 @@ pub fn isSupportedImageProjectorFile(file: *const gguf_format.File) bool {
 
 /// Run Gemma 4's external GGUF vision projector.
 ///
-/// This supports the `gemma4v` image projector path. Gemma 4 audio projectors use
-/// separate `a.*` tensors and are intentionally not routed through this function.
+/// This supports the `gemma4v` image projector path and the `gemma4uv`
+/// combined image/audio projector metadata used by Gemma 4 12B.
 pub fn encodeProjectedImages(
     cb: *const ComputeBackend,
     allocator: std.mem.Allocator,
@@ -243,6 +248,10 @@ fn encodeSingleAudio(
     cfg: AudioConfig,
     audio_bytes: []const u8,
 ) !EncodedAudio {
+    if (cfg.direct_unified) {
+        return encodeUnifiedDirectAudio(cb, allocator, store, cfg, audio_bytes);
+    }
+
     var features = try prepareGemma4AudioFeatures(allocator, audio_bytes, cfg.mel_bins);
     defer features.deinit();
 
@@ -289,6 +298,67 @@ fn encodeSingleAudio(
         .embeddings = embeddings,
         .tokens = valid_count,
     };
+}
+
+fn encodeUnifiedDirectAudio(
+    cb: *const ComputeBackend,
+    allocator: std.mem.Allocator,
+    store: *tensor_store_mod.GgufStore,
+    cfg: AudioConfig,
+    audio_bytes: []const u8,
+) !EncodedAudio {
+    const frames = try prepareGemma4RawAudioFrames(allocator, audio_bytes, cfg.raw_samples_per_token, cfg.max_direct_audio_tokens);
+    defer allocator.free(frames);
+    const token_count = frames.len / cfg.raw_samples_per_token;
+    if (token_count == 0) {
+        return .{
+            .embeddings = try allocator.alloc(f32, 0),
+            .tokens = 0,
+        };
+    }
+    const frame_shape = [_]i32{ @intCast(token_count), @intCast(cfg.raw_samples_per_token) };
+    const frame_ct = try cb.fromFloat32Shape(frames, &frame_shape);
+    defer cb.free(frame_ct);
+
+    const normed = try rmsNormNoScaleCt(cb, allocator, frame_ct, token_count, cfg.raw_samples_per_token, cfg.layer_norm_eps);
+    defer cb.free(normed);
+    const projection_w = try loadLinearWeightCt(cb, allocator, store, "mm.a.input_projection.weight", cfg.raw_samples_per_token, cfg.text_hidden);
+    defer cb.free(projection_w);
+    const projected = try cb.linearNoBias(normed, projection_w, token_count, cfg.raw_samples_per_token, cfg.text_hidden);
+    defer cb.free(projected);
+
+    return .{
+        .embeddings = try cb.toFloat32(projected, allocator),
+        .tokens = token_count,
+    };
+}
+
+fn prepareGemma4RawAudioFrames(
+    allocator: std.mem.Allocator,
+    audio_bytes: []const u8,
+    samples_per_token: usize,
+    max_tokens: usize,
+) ![]f32 {
+    if (samples_per_token == 0) return error.InvalidTensorShape;
+    const target_rate: u32 = 16_000;
+    const max_samples = std.math.mul(usize, samples_per_token, max_tokens) catch return error.InvalidTensorShape;
+
+    var decoded = try audio.decode(allocator, audio_bytes, .{});
+    defer decoded.deinit();
+    const resampled = try audio.copyOrResample(allocator, decoded.samples, decoded.sample_rate, target_rate);
+    defer allocator.free(resampled);
+
+    if (resampled.len > max_samples) return error.AudioInputTooLong;
+    const real_samples = resampled.len;
+    const frames = if (real_samples == 0)
+        0
+    else
+        (real_samples + samples_per_token - 1) / samples_per_token;
+    const out_len = std.math.mul(usize, frames, samples_per_token) catch return error.InvalidTensorShape;
+    const out = try allocator.alloc(f32, out_len);
+    @memset(out, 0.0);
+    if (real_samples > 0) @memcpy(out[0..real_samples], resampled[0..real_samples]);
+    return out;
 }
 
 const AudioFeatures = struct {
@@ -491,6 +561,10 @@ fn encodeSingleImage(
     cfg: Config,
     image_bytes: []const u8,
 ) !EncodedImage {
+    if (cfg.direct_unified) {
+        return encodeUnifiedDirectImage(cb, allocator, store, cfg, image_bytes);
+    }
+
     const decoded = try image.decode(allocator, image_bytes);
     defer decoded.deinit(allocator);
 
@@ -548,12 +622,171 @@ fn encodeSingleImage(
     };
 }
 
+fn encodeUnifiedDirectImage(
+    cb: *const ComputeBackend,
+    allocator: std.mem.Allocator,
+    store: *tensor_store_mod.GgufStore,
+    cfg: Config,
+    image_bytes: []const u8,
+) !EncodedImage {
+    const decoded = try image.decode(allocator, image_bytes);
+    defer decoded.deinit(allocator);
+
+    const geometry = targetGeometry(cfg, decoded.width, decoded.height);
+    const pixel_values = try image.preprocessDecodedRectScaledWithResample(
+        allocator,
+        decoded,
+        @intCast(geometry.width),
+        @intCast(geometry.height),
+        cfg.image_mean,
+        cfg.image_std,
+        1.0 / 255.0,
+        .bilinear,
+    );
+    defer allocator.free(pixel_values);
+
+    const patches = try extractDirectImagePatches(allocator, pixel_values, cfg, geometry);
+    defer allocator.free(patches);
+    try applyLayerNormFromTensors(allocator, store, patches, geometry.tokenCount(), cfg.patch_size * cfg.patch_size * 3, "v.patch_norm.1", 1e-5);
+
+    const patch_dim = cfg.patch_size * cfg.patch_size * 3;
+    const patch_shape = [_]i32{ @intCast(geometry.tokenCount()), @intCast(patch_dim) };
+    const patch_ct = try cb.fromFloat32Shape(patches, &patch_shape);
+    defer cb.free(patch_ct);
+    const patch_w = try loadLinearWeightCt(cb, allocator, store, "v.patch_embd.weight", patch_dim, cfg.vision_hidden);
+    defer cb.free(patch_w);
+    const patch_projected = try cb.linearNoBias(patch_ct, patch_w, geometry.tokenCount(), patch_dim, cfg.vision_hidden);
+    defer cb.free(patch_projected);
+
+    const hidden = try cb.toFloat32(patch_projected, allocator);
+    defer allocator.free(hidden);
+    try addBiasFromTensor(allocator, store, hidden, geometry.tokenCount(), cfg.vision_hidden, "v.patch_embd.bias");
+    try applyLayerNormFromTensors(allocator, store, hidden, geometry.tokenCount(), cfg.vision_hidden, "v.patch_norm.2", 1e-5);
+    try addPositionEmbeddingsInPlace(allocator, store, cfg, hidden, geometry);
+    try applyLayerNormFromTensors(allocator, store, hidden, geometry.tokenCount(), cfg.vision_hidden, "v.patch_norm.3", 1e-5);
+
+    const hidden_shape = [_]i32{ @intCast(geometry.tokenCount()), @intCast(cfg.vision_hidden) };
+    const hidden_ct = try cb.fromFloat32Shape(hidden, &hidden_shape);
+    defer cb.free(hidden_ct);
+    const normed = try rmsNormNoScaleCt(cb, allocator, hidden_ct, geometry.tokenCount(), cfg.vision_hidden, cfg.layer_norm_eps);
+    defer cb.free(normed);
+    const projection_w = try loadLinearWeightCt(cb, allocator, store, "mm.input_projection.weight", cfg.vision_hidden, cfg.text_hidden);
+    defer cb.free(projection_w);
+    const projected = try cb.linearNoBias(normed, projection_w, geometry.tokenCount(), cfg.vision_hidden, cfg.text_hidden);
+    defer cb.free(projected);
+
+    return .{
+        .embeddings = try cb.toFloat32(projected, allocator),
+        .tokens = geometry.tokenCount(),
+    };
+}
+
+fn extractDirectImagePatches(
+    allocator: std.mem.Allocator,
+    pixel_values: []const f32,
+    cfg: Config,
+    geometry: Geometry,
+) ![]f32 {
+    const patch_dim = cfg.patch_size * cfg.patch_size * 3;
+    const token_count = geometry.tokenCount();
+    if (pixel_values.len != 3 * geometry.height * geometry.width) return error.InvalidPatchEmbeddingShape;
+    if (geometry.grid_x != geometry.pooled_x or geometry.grid_y != geometry.pooled_y) return error.InvalidPatchEmbeddingShape;
+
+    const out = try allocator.alloc(f32, token_count * patch_dim);
+    for (0..geometry.grid_y) |grid_y| {
+        for (0..geometry.grid_x) |grid_x| {
+            const token = grid_y * geometry.grid_x + grid_x;
+            const dst_base = token * patch_dim;
+            var dst: usize = dst_base;
+            for (0..3) |channel| {
+                for (0..cfg.patch_size) |py| {
+                    const src_y = grid_y * cfg.patch_size + py;
+                    const src_row = channel * geometry.height * geometry.width + src_y * geometry.width;
+                    const src_x = grid_x * cfg.patch_size;
+                    @memcpy(out[dst..][0..cfg.patch_size], pixel_values[src_row + src_x ..][0..cfg.patch_size]);
+                    dst += cfg.patch_size;
+                }
+            }
+        }
+    }
+    return out;
+}
+
+fn applyLayerNormFromTensors(
+    allocator: std.mem.Allocator,
+    store: *tensor_store_mod.GgufStore,
+    data: []f32,
+    rows: usize,
+    dim: usize,
+    prefix: []const u8,
+    eps: f32,
+) !void {
+    const weight_name = try std.fmt.allocPrint(allocator, "{s}.weight", .{prefix});
+    defer allocator.free(weight_name);
+    const bias_name = try std.fmt.allocPrint(allocator, "{s}.bias", .{prefix});
+    defer allocator.free(bias_name);
+    var weight = try loadTensorF32(store, weight_name);
+    defer weight.deinit();
+    var bias = try loadTensorF32(store, bias_name);
+    defer bias.deinit();
+    try layerNormRowsInPlace(data, rows, dim, weight.data, bias.data, eps);
+}
+
+fn layerNormRowsInPlace(
+    data: []f32,
+    rows: usize,
+    dim: usize,
+    weight: []const f32,
+    bias: []const f32,
+    eps: f32,
+) !void {
+    if (data.len != rows * dim or weight.len != dim or bias.len != dim) return error.InvalidTensorShape;
+    for (0..rows) |row| {
+        const base = row * dim;
+        var mean: f32 = 0.0;
+        for (0..dim) |i| mean += data[base + i];
+        mean /= @floatFromInt(dim);
+        var variance: f32 = 0.0;
+        for (0..dim) |i| {
+            const delta = data[base + i] - mean;
+            variance += delta * delta;
+        }
+        variance /= @floatFromInt(dim);
+        const inv_std = 1.0 / @sqrt(variance + eps);
+        for (0..dim) |i| {
+            data[base + i] = (data[base + i] - mean) * inv_std * weight[i] + bias[i];
+        }
+    }
+}
+
+fn addBiasFromTensor(
+    allocator: std.mem.Allocator,
+    store: *tensor_store_mod.GgufStore,
+    data: []f32,
+    rows: usize,
+    dim: usize,
+    name: []const u8,
+) !void {
+    _ = allocator;
+    var bias = try loadTensorF32(store, name);
+    defer bias.deinit();
+    if (data.len != rows * dim or bias.data.len != dim) return error.InvalidTensorShape;
+    for (0..rows) |row| {
+        const base = row * dim;
+        for (0..dim) |i| data[base + i] += bias.data[i];
+    }
+}
+
 fn parseConfig(file: *const gguf_format.File) !Config {
     const view = gguf_metadata.View.init(file);
     const arch = view.getString("general.architecture") orelse return error.InvalidGgufProjector;
     if (!std.mem.eql(u8, arch, "clip")) return error.InvalidGgufProjector;
     const projector_type = view.getString("clip.vision.projector_type") orelse return error.InvalidGgufProjector;
-    if (!std.mem.eql(u8, projector_type, "gemma4v")) return error.UnsupportedGgufProjector;
+    if (!projector_format_mod.isGemma4ImageProjectorType(projector_type)) return error.UnsupportedGgufProjector;
+    const block_count: usize = @intCast(view.getU64("clip.vision.block_count") orelse return error.InvalidGgufProjector);
+    const direct_unified = std.mem.eql(u8, projector_type, "gemma4uv") and block_count == 0;
+    const projection_scale_factor: usize = @intCast(view.getU64("clip.vision.projector_scale_factor") orelse default_spatial_merge_size);
+    const metadata_patch_size: usize = @intCast(view.getU64("clip.vision.patch_size") orelse return error.InvalidGgufProjector);
 
     var image_mean = [3]f32{ 0.0, 0.0, 0.0 };
     var image_std = [3]f32{ 1.0, 1.0, 1.0 };
@@ -568,13 +801,15 @@ fn parseConfig(file: *const gguf_format.File) !Config {
         .text_hidden = @intCast(view.getU64("clip.vision.projection_dim") orelse return error.InvalidGgufProjector),
         .vision_hidden = @intCast(view.getU64("clip.vision.embedding_length") orelse return error.InvalidGgufProjector),
         .intermediate_size = @intCast(view.getU64("clip.vision.feed_forward_length") orelse return error.InvalidGgufProjector),
-        .block_count = @intCast(view.getU64("clip.vision.block_count") orelse return error.InvalidGgufProjector),
+        .block_count = block_count,
         .head_count = @intCast(view.getU64("clip.vision.attention.head_count") orelse return error.InvalidGgufProjector),
+        .direct_unified = direct_unified,
         .image_size = @intCast(view.getU64("clip.vision.image_size") orelse return error.InvalidGgufProjector),
-        .patch_size = @intCast(view.getU64("clip.vision.patch_size") orelse return error.InvalidGgufProjector),
+        .patch_size = if (direct_unified) metadata_patch_size * projection_scale_factor else metadata_patch_size,
         .layer_norm_eps = view.getF32("clip.vision.attention.layer_norm_epsilon") orelse 1e-6,
         .image_mean = image_mean,
         .image_std = image_std,
+        .spatial_merge_size = if (direct_unified) 1 else default_spatial_merge_size,
     };
 }
 
@@ -1088,18 +1323,65 @@ fn parseAudioConfig(file: *const gguf_format.File) !AudioConfig {
     const arch = view.getString("general.architecture") orelse return error.InvalidGgufProjector;
     if (!std.mem.eql(u8, arch, "clip")) return error.InvalidGgufProjector;
     const projector_type = view.getString("clip.audio.projector_type") orelse return error.AudioProjectorNotFound;
-    if (!std.mem.eql(u8, projector_type, "gemma4a")) return error.UnsupportedGgufProjector;
+    if (!projector_format_mod.isGemma4AudioProjectorType(projector_type)) return error.UnsupportedGgufProjector;
+    const block_count: usize = @intCast(view.getU64("clip.audio.block_count") orelse return error.InvalidGgufProjector);
+    const direct_unified = std.mem.eql(u8, projector_type, "gemma4ua") or
+        (std.mem.eql(u8, projector_type, "gemma4uv") and block_count == 0);
 
     return .{
         .text_hidden = @intCast(view.getU64("clip.audio.projection_dim") orelse return error.InvalidGgufProjector),
         .audio_hidden = @intCast(view.getU64("clip.audio.embedding_length") orelse return error.InvalidGgufProjector),
         .output_hidden = @intCast(view.getU64("clip.audio.projection_dim") orelse return error.InvalidGgufProjector),
         .intermediate_size = @intCast(view.getU64("clip.audio.feed_forward_length") orelse return error.InvalidGgufProjector),
-        .block_count = @intCast(view.getU64("clip.audio.block_count") orelse return error.InvalidGgufProjector),
+        .block_count = block_count,
         .head_count = @intCast(view.getU64("clip.audio.attention.head_count") orelse return error.InvalidGgufProjector),
+        .direct_unified = direct_unified,
+        .raw_samples_per_token = if (direct_unified) @intCast(view.getU64("clip.audio.samples_per_token") orelse view.getU64("clip.audio.embedding_length") orelse 640) else 640,
+        .max_direct_audio_tokens = @intCast(view.getU64("clip.audio.max_tokens") orelse default_max_direct_audio_tokens),
         .mel_bins = @intCast(view.getU64("clip.audio.num_mel_bins") orelse 128),
         .layer_norm_eps = view.getF32("clip.audio.attention.layer_norm_epsilon") orelse 1e-5,
     };
+}
+
+test "gemma4 unified projector metadata parses image and audio configs" {
+    const allocator = std.testing.allocator;
+    const metadata = [_]gguf_format.MetadataEntry{
+        .{ .key = "general.architecture", .value = .{ .string = "clip" } },
+        .{ .key = "clip.vision.projector_type", .value = .{ .string = "gemma4uv" } },
+        .{ .key = "clip.vision.projection_dim", .value = .{ .u32 = 3840 } },
+        .{ .key = "clip.vision.embedding_length", .value = .{ .u32 = 3840 } },
+        .{ .key = "clip.vision.feed_forward_length", .value = .{ .u32 = 0 } },
+        .{ .key = "clip.vision.block_count", .value = .{ .u32 = 0 } },
+        .{ .key = "clip.vision.attention.head_count", .value = .{ .u32 = 0 } },
+        .{ .key = "clip.vision.image_size", .value = .{ .u32 = 224 } },
+        .{ .key = "clip.vision.patch_size", .value = .{ .u32 = 16 } },
+        .{ .key = "clip.vision.attention.layer_norm_epsilon", .value = .{ .f32 = 0.000001 } },
+        .{ .key = "clip.audio.projector_type", .value = .{ .string = "gemma4ua" } },
+        .{ .key = "clip.audio.projection_dim", .value = .{ .u32 = 3840 } },
+        .{ .key = "clip.audio.embedding_length", .value = .{ .u32 = 640 } },
+        .{ .key = "clip.audio.feed_forward_length", .value = .{ .u32 = 0 } },
+        .{ .key = "clip.audio.block_count", .value = .{ .u32 = 0 } },
+        .{ .key = "clip.audio.attention.head_count", .value = .{ .u32 = 0 } },
+        .{ .key = "clip.audio.num_mel_bins", .value = .{ .u32 = 128 } },
+        .{ .key = "clip.audio.attention.layer_norm_epsilon", .value = .{ .f32 = 0.000001 } },
+    };
+    var layout = try @import("../gguf/writer.zig").buildLayout(allocator, &metadata, &.{});
+    defer layout.deinit(allocator);
+    var parsed = try gguf_format.parse(allocator, layout.header_bytes);
+    defer parsed.deinit(allocator);
+
+    const image_cfg = try parseConfig(&parsed);
+    try std.testing.expectEqual(@as(usize, 3840), image_cfg.text_hidden);
+    try std.testing.expectEqual(@as(usize, 3840), image_cfg.vision_hidden);
+    try std.testing.expectEqual(@as(usize, 224), image_cfg.image_size);
+    try std.testing.expectEqual(@as(usize, 48), image_cfg.patch_size);
+    try std.testing.expect(image_cfg.direct_unified);
+
+    const audio_cfg = try parseAudioConfig(&parsed);
+    try std.testing.expectEqual(@as(usize, 3840), audio_cfg.text_hidden);
+    try std.testing.expectEqual(@as(usize, 640), audio_cfg.audio_hidden);
+    try std.testing.expectEqual(@as(usize, 640), audio_cfg.raw_samples_per_token);
+    try std.testing.expect(audio_cfg.direct_unified);
 }
 
 fn metadataF32Triple(view: gguf_metadata.View, key: []const u8) ?[3]f32 {
@@ -1241,9 +1523,31 @@ fn addPositionEmbeddings(
     patch_embeddings: []const f32,
     geometry: Geometry,
 ) ![]f32 {
+    const patch_count = geometry.grid_x * geometry.grid_y;
+    const out = try allocator.alloc(f32, patch_count * cfg.vision_hidden);
+    @memcpy(out, patch_embeddings);
+    errdefer allocator.free(out);
+    try addPositionEmbeddingsInPlace(allocator, store, cfg, out, geometry);
+    return out;
+}
+
+fn addPositionEmbeddingsInPlace(
+    allocator: std.mem.Allocator,
+    store: *tensor_store_mod.GgufStore,
+    cfg: Config,
+    patch_embeddings: []f32,
+    geometry: Geometry,
+) !void {
+    _ = allocator;
     var pos = try loadTensorF32(store, "v.position_embd.weight");
     defer pos.deinit();
-    if (pos.shape.len != 3 or pos.shape[0] != 2 or pos.shape[2] != @as(i64, @intCast(cfg.vision_hidden))) {
+    const hidden_first = pos.shape.len == 3 and
+        pos.shape[0] == @as(i64, @intCast(cfg.vision_hidden)) and
+        pos.shape[2] == 2;
+    const axis_first = pos.shape.len == 3 and
+        pos.shape[0] == 2 and
+        pos.shape[2] == @as(i64, @intCast(cfg.vision_hidden));
+    if (!hidden_first and !axis_first) {
         return error.InvalidPositionEmbeddingShape;
     }
     const positions_per_axis: usize = @intCast(pos.shape[1]);
@@ -1252,19 +1556,93 @@ fn addPositionEmbeddings(
     }
 
     const patch_count = geometry.grid_x * geometry.grid_y;
-    const out = try allocator.alloc(f32, patch_count * cfg.vision_hidden);
+    if (patch_embeddings.len != patch_count * cfg.vision_hidden) return error.InvalidPositionEmbeddingShape;
     for (0..geometry.grid_y) |y| {
         for (0..geometry.grid_x) |x| {
             const patch_idx = y * geometry.grid_x + x;
             const dst = patch_idx * cfg.vision_hidden;
-            const y_pos = (0 * positions_per_axis + y) * cfg.vision_hidden;
-            const x_pos = (1 * positions_per_axis + x) * cfg.vision_hidden;
             for (0..cfg.vision_hidden) |h| {
-                out[dst + h] = patch_embeddings[dst + h] + pos.data[y_pos + h] + pos.data[x_pos + h];
+                patch_embeddings[dst + h] += positionEmbeddingValue(pos.data, cfg.vision_hidden, positions_per_axis, 0, x, h, hidden_first) +
+                    positionEmbeddingValue(pos.data, cfg.vision_hidden, positions_per_axis, 1, y, h, hidden_first);
             }
         }
     }
-    return out;
+}
+
+fn positionEmbeddingValue(
+    data: []const f32,
+    hidden: usize,
+    positions_per_axis: usize,
+    axis: usize,
+    position: usize,
+    h: usize,
+    hidden_first: bool,
+) f32 {
+    return if (hidden_first)
+        data[(axis * positions_per_axis + position) * hidden + h]
+    else
+        data[(h * positions_per_axis + position) * 2 + axis];
+}
+
+test "gemma4 position embedding indexes hidden-first and axis-first layouts" {
+    const hidden: usize = 3;
+    const positions: usize = 4;
+    const hidden_first = [_]f32{
+        100, 101, 102, 110, 111, 112, 120, 121, 122, 130, 131, 132,
+        200, 201, 202, 210, 211, 212, 220, 221, 222, 230, 231, 232,
+    };
+    try std.testing.expectEqual(@as(f32, 111), positionEmbeddingValue(&hidden_first, hidden, positions, 0, 1, 1, true));
+    try std.testing.expectEqual(@as(f32, 221), positionEmbeddingValue(&hidden_first, hidden, positions, 1, 2, 1, true));
+
+    const axis_first = [_]f32{
+        100, 200, 110, 210, 120, 220, 130, 230,
+        101, 201, 111, 211, 121, 221, 131, 231,
+        102, 202, 112, 212, 122, 222, 132, 232,
+    };
+    try std.testing.expectEqual(@as(f32, 111), positionEmbeddingValue(&axis_first, hidden, positions, 0, 1, 1, false));
+    try std.testing.expectEqual(@as(f32, 221), positionEmbeddingValue(&axis_first, hidden, positions, 1, 2, 1, false));
+}
+
+test "gemma4 12b real mmproj optional projector smoke" {
+    const platform = @import("antfly_platform");
+    const native_compute = @import("../ops/native_compute.zig");
+    const compat = @import("../io/compat.zig");
+
+    const mmproj_path = platform.env.getenvSlice("ANTFLY_GEMMA4_12B_MMPROJ_PATH") orelse return error.SkipZigTest;
+    const image_path = platform.env.getenvSlice("ANTFLY_GEMMA4_12B_IMAGE_PATH");
+    const audio_path = platform.env.getenvSlice("ANTFLY_GEMMA4_12B_AUDIO_PATH");
+    if (image_path == null and audio_path == null) return error.SkipZigTest;
+
+    const allocator = std.testing.allocator;
+    var store = try tensor_store_mod.GgufStore.initAbsolute(allocator, mmproj_path);
+    defer store.tensorStore().deinit();
+
+    var weight_store = native_compute.WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
+    defer native_compute.deinitPrefetchQueue(&weight_store);
+    var compute = native_compute.NativeCompute.init(allocator, &weight_store, null);
+    var cb = compute.computeBackend();
+
+    if (image_path) |path| {
+        const image_bytes = try compat.cwd().readFileAlloc(compat.io(), path, allocator, .limited(64 * 1024 * 1024));
+        defer allocator.free(image_bytes);
+        var projected = try encodeProjectedImagesFromStore(&cb, allocator, store, &.{image_bytes});
+        defer projected.deinit();
+
+        try std.testing.expectEqual(@as(usize, 1), projected.tokens_per_image.len);
+        try std.testing.expect(projected.tokens_per_image[0] > 0);
+        try std.testing.expectEqual(projected.tokens_per_image[0] * projected.hidden_size, projected.embeddings.len);
+    }
+
+    if (audio_path) |path| {
+        const audio_bytes = try compat.cwd().readFileAlloc(compat.io(), path, allocator, .limited(128 * 1024 * 1024));
+        defer allocator.free(audio_bytes);
+        var projected = try encodeProjectedAudioFromStore(&cb, allocator, store, &.{audio_bytes});
+        defer projected.deinit();
+
+        try std.testing.expectEqual(@as(usize, 1), projected.tokens_per_audio.len);
+        try std.testing.expect(projected.tokens_per_audio[0] > 0);
+        try std.testing.expectEqual(projected.tokens_per_audio[0] * projected.hidden_size, projected.embeddings.len);
+    }
 }
 
 fn encoderBlock(

--- a/zig/pkg/inference/src/architectures/projector_format.zig
+++ b/zig/pkg/inference/src/architectures/projector_format.zig
@@ -53,17 +53,28 @@ pub fn detectFile(file: *const gguf_format.File) Kind {
 
     const has_image = blk: {
         const projector_type = view.getString("clip.vision.projector_type") orelse break :blk false;
-        break :blk std.mem.eql(u8, projector_type, "gemma4v");
+        break :blk isGemma4ImageProjectorType(projector_type);
     };
     const has_audio = blk: {
         const projector_type = view.getString("clip.audio.projector_type") orelse break :blk false;
-        break :blk std.mem.eql(u8, projector_type, "gemma4a");
+        break :blk isGemma4AudioProjectorType(projector_type);
     };
 
     if (has_image and has_audio) return .clip_gemma4_image_audio;
     if (has_image) return .clip_gemma4_image;
     if (has_audio) return .clip_gemma4_audio;
     return .unknown;
+}
+
+pub fn isGemma4ImageProjectorType(projector_type: []const u8) bool {
+    return std.mem.eql(u8, projector_type, "gemma4v") or
+        std.mem.eql(u8, projector_type, "gemma4uv");
+}
+
+pub fn isGemma4AudioProjectorType(projector_type: []const u8) bool {
+    return std.mem.eql(u8, projector_type, "gemma4a") or
+        std.mem.eql(u8, projector_type, "gemma4ua") or
+        std.mem.eql(u8, projector_type, "gemma4uv");
 }
 
 pub fn isAntfly(kind: Kind) bool {
@@ -109,6 +120,24 @@ test "detect clip gemma4 image projector" {
     try compat.cwd().writeFile(compat.io(), .{ .sub_path = path, .data = layout.header_bytes });
 
     try std.testing.expectEqual(Kind.clip_gemma4_image, try detectPath(allocator, path));
+}
+
+test "detect clip gemma4 unified image audio projector" {
+    const allocator = std.testing.allocator;
+    const path = try std.fs.path.join(allocator, &.{ "/tmp", "antfly-projector-format-clip-unified.gguf" });
+    defer allocator.free(path);
+    defer compat.cwd().deleteFile(compat.io(), path) catch {};
+
+    const metadata = [_]gguf_mod.format.MetadataEntry{
+        .{ .key = "general.architecture", .value = .{ .string = "clip" } },
+        .{ .key = "clip.vision.projector_type", .value = .{ .string = "gemma4uv" } },
+        .{ .key = "clip.audio.projector_type", .value = .{ .string = "gemma4ua" } },
+    };
+    var layout = try gguf_mod.writer.buildLayout(allocator, &metadata, &.{});
+    defer layout.deinit(allocator);
+    try compat.cwd().writeFile(compat.io(), .{ .sub_path = path, .data = layout.header_bytes });
+
+    try std.testing.expectEqual(Kind.clip_gemma4_image_audio, try detectPath(allocator, path));
 }
 
 test "detect unknown projector metadata" {

--- a/zig/pkg/inference/src/models/gpt.zig
+++ b/zig/pkg/inference/src/models/gpt.zig
@@ -524,7 +524,7 @@ pub fn parseConfig(allocator: std.mem.Allocator, json_bytes: []const u8) !Config
     if (!has_vlm_wrapper) {
         if (obj.get("model_type")) |v| {
             if (v == .string and obj.get("text_config") != null) {
-                if (std.mem.eql(u8, v.string, "gemma4") or std.mem.eql(u8, v.string, "qwen3_5")) {
+                if (isGemma4ModelType(v.string) or std.mem.eql(u8, v.string, "qwen3_5")) {
                     config.weight_prefix = "model.language_model";
                 }
             }
@@ -829,10 +829,16 @@ pub fn parseConfig(allocator: std.mem.Allocator, json_bytes: []const u8) !Config
     if (model_obj.get("boi_token_index")) |v| if (jsonI32(v)) |val| {
         config.boi_token_index = val;
     };
+    if (model_obj.get("boi_token_id")) |v| if (jsonI32(v)) |val| {
+        config.boi_token_index = val;
+    };
     if (model_obj.get("vision_start_token_id")) |v| if (jsonI32(v)) |val| {
         config.boi_token_index = val;
     };
     if (model_obj.get("eoi_token_index")) |v| if (jsonI32(v)) |val| {
+        config.eoi_token_index = val;
+    };
+    if (model_obj.get("eoi_token_id")) |v| if (jsonI32(v)) |val| {
         config.eoi_token_index = val;
     };
     if (model_obj.get("vision_end_token_id")) |v| if (jsonI32(v)) |val| {
@@ -1245,7 +1251,10 @@ fn detectFamily(model_type: []const u8) ModelFamily {
         .{ "gemma3_text", ModelFamily.gemma },
         .{ "gemma4", ModelFamily.gemma },
         .{ "gemma4_text", ModelFamily.gemma },
+        .{ "gemma4_unified", ModelFamily.gemma },
+        .{ "gemma4_unified_text", ModelFamily.gemma },
         .{ "gemma4_assistant", ModelFamily.gemma },
+        .{ "gemma4_unified_assistant", ModelFamily.gemma },
         .{ "bitnet", ModelFamily.bitnet },
         .{ "bitnet-b1.58", ModelFamily.bitnet },
         .{ "falcon", ModelFamily.falcon },
@@ -1261,7 +1270,10 @@ fn detectFamily(model_type: []const u8) ModelFamily {
 fn isGemma4ModelType(model_type: []const u8) bool {
     return std.mem.eql(u8, model_type, "gemma4") or
         std.mem.eql(u8, model_type, "gemma4_text") or
-        std.mem.eql(u8, model_type, "gemma4_assistant");
+        std.mem.eql(u8, model_type, "gemma4_unified") or
+        std.mem.eql(u8, model_type, "gemma4_unified_text") or
+        std.mem.eql(u8, model_type, "gemma4_assistant") or
+        std.mem.eql(u8, model_type, "gemma4_unified_assistant");
 }
 
 fn applyFamilyDefaults(config: *Config) void {
@@ -2151,6 +2163,74 @@ test "parse gemma4 text-only config defaults" {
     try std.testing.expectEqual(@as(u32, 256), config.effectiveHeadDimForLayer(0));
     try std.testing.expectEqual(@as(u32, 8), config.maxKvHeads());
     try std.testing.expectEqual(@as(u32, 256), config.maxHeadDim());
+}
+
+test "parse gemma4 12b unified config aliases" {
+    const allocator = std.testing.allocator;
+    const json =
+        \\{
+        \\  "model_type": "gemma4_unified",
+        \\  "image_token_id": 258880,
+        \\  "boi_token_id": 255999,
+        \\  "eoi_token_id": 258882,
+        \\  "text_config": {
+        \\    "model_type": "gemma4_unified_text",
+        \\    "hidden_size": 3840,
+        \\    "num_hidden_layers": 48,
+        \\    "num_attention_heads": 16,
+        \\    "num_key_value_heads": 8,
+        \\    "num_global_key_value_heads": 1,
+        \\    "head_dim": 256,
+        \\    "global_head_dim": 512,
+        \\    "intermediate_size": 15360,
+        \\    "max_position_embeddings": 262144,
+        \\    "sliding_window": 1024,
+        \\    "tie_word_embeddings": true,
+        \\    "vocab_size": 262144,
+        \\    "hidden_activation": "gelu_pytorch_tanh",
+        \\    "layer_types": [
+        \\      "sliding_attention", "sliding_attention", "sliding_attention",
+        \\      "sliding_attention", "sliding_attention", "full_attention"
+        \\    ],
+        \\    "rope_parameters": {
+        \\      "full_attention": {
+        \\        "partial_rotary_factor": 0.25,
+        \\        "rope_theta": 1000000.0
+        \\      },
+        \\      "sliding_attention": {
+        \\        "rope_theta": 10000.0
+        \\      }
+        \\    }
+        \\  }
+        \\}
+    ;
+    const config = try parseConfig(allocator, json);
+    try std.testing.expectEqual(ModelFamily.gemma, config.family);
+    try std.testing.expectEqualStrings("model.language_model", config.weight_prefix);
+    try std.testing.expectEqual(@as(i32, 258880), config.image_token_index);
+    try std.testing.expectEqual(@as(i32, 255999), config.boi_token_index);
+    try std.testing.expectEqual(@as(i32, 258882), config.eoi_token_index);
+    try std.testing.expectEqual(@as(u32, 3840), config.hidden_size);
+    try std.testing.expectEqual(@as(u32, 48), config.num_hidden_layers);
+    try std.testing.expectEqual(@as(u32, 16), config.num_attention_heads);
+    try std.testing.expectEqual(@as(u32, 8), config.num_key_value_heads);
+    try std.testing.expectEqual(@as(u32, 1), config.num_global_key_value_heads);
+    try std.testing.expectEqual(@as(u32, 256), config.attention_head_dim);
+    try std.testing.expectEqual(@as(u32, 512), config.global_head_dim);
+    try std.testing.expectEqual(@as(u32, 15360), config.intermediate_size);
+    try std.testing.expectEqual(@as(u32, 262144), config.max_position_embeddings);
+    try std.testing.expectEqual(@as(u32, 262144), config.vocab_size);
+    try std.testing.expectEqual(@as(u32, 1024), config.sliding_window);
+    try std.testing.expectEqual(@as(u32, 6), config.sliding_window_pattern);
+    try std.testing.expectEqual(@as(f32, 0.25), config.rope_partial_factor);
+    try std.testing.expectEqual(@as(f32, 1000000.0), config.rope_theta);
+    try std.testing.expectEqual(@as(f32, 10000.0), config.rope_local_theta);
+    try std.testing.expectEqual(@as(u32, 8), config.effectiveKVHeadsForLayer(0));
+    try std.testing.expectEqual(@as(u32, 1), config.effectiveKVHeadsForLayer(5));
+    try std.testing.expectEqual(@as(u32, 256), config.effectiveHeadDimForLayer(0));
+    try std.testing.expectEqual(@as(u32, 512), config.effectiveHeadDimForLayer(5));
+    try std.testing.expectEqual(@as(u32, 512), config.maxHeadDim());
+    try std.testing.expect(config.weight_tying);
 }
 
 test "parse gemma4 moe fields from text_config" {

--- a/zig/pkg/inference/src/models/manifest.zig
+++ b/zig/pkg/inference/src/models/manifest.zig
@@ -2355,6 +2355,34 @@ test "listing manifest detects gguf assets without gguf metadata parse" {
     try std.testing.expect(manifest.gguf_projector_path != null);
 }
 
+test "manifest treats gemma4 unified config as generator" {
+    const allocator = std.testing.allocator;
+    const io = std.testing.io;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.writeFile(io, .{
+        .sub_path = "config.json",
+        .data =
+        \\{"model_type":"gemma4_unified","text_config":{"model_type":"gemma4_unified_text"}}
+        ,
+    });
+    try tmp.dir.writeFile(io, .{ .sub_path = "gemma-4-12B-it-Q4_K_M.gguf", .data = "" });
+    try tmp.dir.writeFile(io, .{ .sub_path = "mmproj-gemma-4-12B-it-bf16.gguf", .data = "" });
+
+    const model_dir = try std.fs.path.join(allocator, &.{ ".zig-cache", "tmp", tmp.sub_path[0..] });
+    defer allocator.free(model_dir);
+
+    var manifest = try loadFromDir(allocator, model_dir);
+    defer manifest.deinit();
+
+    try std.testing.expectEqual(ModelType.generator, manifest.model_type);
+    try std.testing.expectEqualStrings("gemma4_unified", manifest.config_model_arch);
+    try std.testing.expect(manifest.gguf_path != null);
+    try std.testing.expect(manifest.gguf_projector_path != null);
+}
+
 test "manifest infers huggingface tokenizer from gguf gpt2 metadata" {
     const allocator = std.testing.allocator;
 

--- a/zig/pkg/inference/src/native_generate.zig
+++ b/zig/pkg/inference/src/native_generate.zig
@@ -651,6 +651,8 @@ pub fn main(allocator: std.mem.Allocator, io: std.Io, args: []const []const u8) 
     var result = pipeline.generate(&messages, config) catch |err| {
         if (err == error.MemoryBudgetExceeded) {
             printBudgetExceeded(model.session, &run_budget);
+        } else if (err == error.AudioInputTooLong) {
+            print("error: {s}\n", .{generation.userFacingErrorMessage(err)});
         }
         return err;
     };

--- a/zig/pkg/inference/src/pipelines/generation.zig
+++ b/zig/pkg/inference/src/pipelines/generation.zig
@@ -93,6 +93,13 @@ pub fn messagesHaveAudio(messages: []const Message) bool {
     return false;
 }
 
+pub fn userFacingErrorMessage(err: anyerror) []const u8 {
+    return switch (err) {
+        error.AudioInputTooLong => "audio input is too long for the Gemma4 direct audio projector; trim the clip or raise clip.audio.max_tokens in the projector metadata",
+        else => @errorName(err),
+    };
+}
+
 pub const GenerationConfig = struct {
     max_tokens: i32 = 256,
     temperature: f32 = 0,

--- a/zig/pkg/inference/src/server/server.zig
+++ b/zig/pkg/inference/src/server/server.zig
@@ -2206,7 +2206,7 @@ pub const Node = struct {
             }
 
             var result = generateMaybeStopOnTool(&pipeline, messages.items, config, if (tool_parser) |*parser| parser else null) catch |err|
-                return ctx.status(500).json(.{ .@"error" = "GENERATION_FAILED", .message = @errorName(err) });
+                return generationFailureResponse(ctx, err);
             defer result.deinit();
 
             var response_text = result.text;
@@ -2312,7 +2312,7 @@ pub const Node = struct {
                 }
 
                 var result = generateMaybeStopOnTool(&pipeline, messages.items, config, if (tool_parser) |*parser| parser else null) catch |err|
-                    return ctx.status(500).json(.{ .@"error" = "GENERATION_FAILED", .message = @errorName(err) });
+                    return generationFailureResponse(ctx, err);
                 defer result.deinit();
 
                 var response_text = result.text;
@@ -2593,7 +2593,7 @@ pub const Node = struct {
         }
 
         var result = generateMaybeStopOnTool(&pipeline, messages.items, config, if (tool_parser) |*parser| parser else null) catch |err|
-            return ctx.status(500).json(.{ .@"error" = "GENERATION_FAILED", .message = @errorName(err) });
+            return generationFailureResponse(ctx, err);
         defer result.deinit();
 
         var response_text = result.text;
@@ -2673,6 +2673,19 @@ pub const Node = struct {
         }
 
         return result;
+    }
+
+    fn generationFailureResponse(ctx: *httpx.Context, err: anyerror) !httpx.Response {
+        return switch (err) {
+            error.AudioInputTooLong => ctx.status(400).json(.{
+                .@"error" = "INVALID_REQUEST",
+                .message = generation.userFacingErrorMessage(err),
+            }),
+            else => ctx.status(500).json(.{
+                .@"error" = "GENERATION_FAILED",
+                .message = generation.userFacingErrorMessage(err),
+            }),
+        };
     }
 
     /// Send a completed GenerationResult as a single SSE stream.
@@ -3002,7 +3015,7 @@ pub const Node = struct {
             StreamCtx.onToken,
         ) catch |err| {
             // Try to send an error event before closing
-            writer.writeEvent("error", @errorName(err)) catch {};
+            writer.writeEvent("error", generation.userFacingErrorMessage(err)) catch {};
             writer.close() catch {};
             return ctx.response.build();
         };


### PR DESCRIPTION
## Summary

Adds Gemma4 12B GGUF inference support, including the new unified image/audio projector format used by `ggml-org/gemma-4-12B-it-GGUF`.

## What Changed

- Recognize Gemma4 12B unified model config aliases:
  - `gemma4_unified`
  - `gemma4_unified_text`
  - `gemma4_unified_assistant`
- Detect unified Gemma4 projector metadata:
  - `gemma4uv` for image/audio projector bundles
  - `gemma4ua` for direct audio projector metadata
- Add direct Gemma4 12B image projection path:
  - patch extraction
  - patch layer norms
  - position embeddings
  - projection into LLM hidden size
- Add direct Gemma4 12B audio projection path:
  - raw audio decode/resample to 16 kHz
  - samples-per-token framing
  - RMS norm + projection into LLM hidden size
- Harden audio handling:
  - avoid silent truncation
  - return `AudioInputTooLong` when clips exceed configured/direct limits
  - use checked length math for malformed metadata safety
- Improve user-facing errors:
  - CLI prints a clear long-audio error
  - HTTP generation maps long audio to `400 INVALID_REQUEST`
  - streaming generation emits the same clear message
- Add tests for:
  - Gemma4 unified config parsing
  - manifest detection as generator
  - unified projector format detection
  - Gemma4 position embedding layouts
  - optional real-mmproj projector smoke
