### PR TITLE
Tune bulk ingest and inference smoke flows

### DIFF
--- a/examples/epstein/README.md
+++ b/examples/epstein/README.md
@@ -39,9 +39,9 @@ omitted here.
 
 ```bash
 cd zig
-./zig-out/bin/antfly inference pull antflydb/clipclap:gguf:Q4_K --tasks embedders
-./zig-out/bin/antfly inference pull Xenova/trocr-base-printed --tasks readers
-./zig-out/bin/antfly inference pull fastino/gliner2-base-v1:native --tasks recognizers
+./zig-out/bin/antfly inference pull antflydb/clipclap:gguf:Q4_K --tasks embed
+./zig-out/bin/antfly inference pull antflydb/gliner2-base-v1-q4_k --tasks extract --capabilities extraction
+./zig-out/bin/antfly inference pull microsoft/Florence-2-base-ft --tasks read
 ```
 
 ### 3. Build the Tool
@@ -101,6 +101,13 @@ export EPSTEIN_ZIP="/path/to/T9/DataSet_10.zip"
 # Load the small smoke file and enable the Zig artifact-backed relation graph.
 ./epstein load --input epstein-smoke.json --table epstein_smoke --create-table \
   --enable-artifact-graph \
+  --artifact-producer extractor \
+  --artifact-extractor-model antflydb/gliner2-base-v1-q4_k
+
+# Optional: use the slower Gemma tool-call generator path for richer relation extraction.
+./epstein load --input epstein-smoke.json --table epstein_smoke_gemma --create-table \
+  --enable-artifact-graph \
+  --artifact-producer generator \
   --artifact-extractor-model ggml-org/gemma-4-E4B-it-GGUF
 ```
 
@@ -152,7 +159,7 @@ Flags:
               Enable OCR fallback through Antfly inference readers
   --ocr-url   Antfly inference URL (default: ANTFLY_INFERENCE_URL or http://localhost:8080)
   --ocr-models
-              OCR models to try (default: Xenova/trocr-base-printed)
+              OCR models to try (default: microsoft/Florence-2-base-ft)
   --limit-files
               Process at most this many source PDFs (default: all)
   --limit-pages
@@ -184,12 +191,15 @@ Flags:
   --artifact-graph-index
                     Graph index name (default: autograph_relations)
   --artifact-name   Generated asset artifact name (default: relations_v1)
+  --artifact-producer
+                    Artifact producer type: extractor or generator
+                    (default: extractor)
   --artifact-extractor-model
-                    Antfly generator model for tool-call relation extraction
-                    (default: ggml-org/gemma-4-E4B-it-GGUF)
-  --artifact-labels Entity labels for the artifact generator
+                    Antfly model for artifact relation extraction
+                    (default: antflydb/gliner2-base-v1-q4_k)
+  --artifact-labels Entity labels for the artifact extractor
   --artifact-relation-labels
-                    Relation labels for the artifact generator
+                    Relation labels for the artifact extractor
 ```
 
 ### `sync`
@@ -213,7 +223,7 @@ Flags:
   --input       Input JSON file (default: epstein-docs.json)
   --output      Output JSON file (default: {input-base}-enriched.json)
   --inference-url Antfly inference URL (default: ANTFLY_INFERENCE_URL or http://localhost:8080)
-  --model       Reader model (default: Xenova/trocr-base-printed)
+  --model       Reader model (default: microsoft/Florence-2-base-ft)
   --category    ocr, vision, quality, or all (default: ocr)
   --dir         Base directory for resolving split page PDFs
   --zip         Source ZIP archive for page lookup (repeatable)
@@ -230,7 +240,7 @@ Flags:
   --input           Input JSON file (default: epstein-docs.json)
   --output          Output JSON file (default: {input-base}-entities.json)
   --inference-url     Antfly inference URL (default: ANTFLY_INFERENCE_URL or http://localhost:8080)
-  --model           Recognizer model (default: fastino/gliner2-base-v1)
+  --model           Recognizer model (default: antflydb/gliner2-base-v1-q4_k)
   --labels          Entity labels to extract
   --relation-labels Relation labels to extract (default: associated with, communicated with, traveled to, visited, worked for, represented by, mentioned in, located in)
   --batch-size      Text windows per Antfly inference recognize request (default: 16)

--- a/examples/epstein/README.md
+++ b/examples/epstein/README.md
@@ -84,6 +84,11 @@ export EPSTEIN_ZIP="/path/to/T9/DataSet_10.zip"
 # Process PDFs into page records. --split-pages enables direct PDF viewing.
 ./epstein prepare --dir "$EPSTEIN_DOCS_DIR" --split-pages
 
+# Small smoke run from a large local disk: process only the first few PDFs and pages.
+./epstein prepare --dir /Volumes/T9/epstein-files --split-pages \
+  --limit-files 2 --limit-pages 50 \
+  --output epstein-smoke.json
+
 # Optional: OCR low-quality pages through Zig Antfly inference.
 ./epstein enrich --input epstein-docs.json --dir "$EPSTEIN_DOCS_DIR"
 
@@ -92,6 +97,11 @@ export EPSTEIN_ZIP="/path/to/T9/DataSet_10.zip"
 
 # Load into Antfly using ClipClap embeddings.
 ./epstein load --input epstein-docs-enriched-entities.json --create-table
+
+# Load the small smoke file and enable the Zig artifact-backed relation graph.
+./epstein load --input epstein-smoke.json --table epstein_smoke --create-table \
+  --enable-artifact-graph \
+  --artifact-extractor-model ggml-org/gemma-4-E4B-it-GGUF
 ```
 
 For ZIP sources that should not be extracted first:
@@ -143,6 +153,10 @@ Flags:
   --ocr-url   Antfly inference URL (default: ANTFLY_INFERENCE_URL or http://localhost:8080)
   --ocr-models
               OCR models to try (default: Xenova/trocr-base-printed)
+  --limit-files
+              Process at most this many source PDFs (default: all)
+  --limit-pages
+              Keep at most this many parsed pages in output (default: all)
 ```
 
 ### `load`
@@ -165,6 +179,17 @@ Flags:
   --chunker-model   Chunker model (default: fixed-bert-tokenizer)
   --target-tokens   Target tokens per chunk (default: 512)
   --overlap-tokens  Overlap between chunks (default: 50)
+  --enable-artifact-graph
+                    Create an artifact-backed autograph relation graph index
+  --artifact-graph-index
+                    Graph index name (default: autograph_relations)
+  --artifact-name   Generated asset artifact name (default: relations_v1)
+  --artifact-extractor-model
+                    Antfly generator model for tool-call relation extraction
+                    (default: ggml-org/gemma-4-E4B-it-GGUF)
+  --artifact-labels Entity labels for the artifact generator
+  --artifact-relation-labels
+                    Relation labels for the artifact generator
 ```
 
 ### `sync`

--- a/examples/epstein/main.go
+++ b/examples/epstein/main.go
@@ -195,9 +195,13 @@ const (
 	DefaultEmbeddingIndex  = "embeddings"
 	DefaultEmbeddingModel  = "antflydb/clipclap"
 	DefaultEmbeddingPull   = "antflydb/clipclap:gguf:Q4_K"
+	DefaultEmbeddingDims   = 512
 	DefaultChunkerModel    = "fixed-bert-tokenizer"
 	DefaultOCRModel        = "Xenova/trocr-base-printed"
 	DefaultRecognizerModel = "fastino/gliner2-base-v1"
+	DefaultAutographIndex  = "autograph_relations"
+	DefaultAutographAsset  = "relations_v1"
+	DefaultAutographModel  = "ggml-org/gemma-4-E4B-it-GGUF"
 	DefaultEntityLabels    = "person,organization,location,date,case,document,facility,aircraft"
 	DefaultRelationLabels  = "associated with,communicated with,traveled to,visited,worked for,represented by,mentioned in,located in"
 	DefaultEntityMaxChars  = 3000
@@ -289,6 +293,25 @@ func splitCSV(value string) []string {
 		}
 	}
 	return out
+}
+
+func parseSyncLevelFlag(value string) (antfly.SyncLevel, error) {
+	switch normalized := strings.ToLower(strings.TrimSpace(value)); normalized {
+	case "propose":
+		return antfly.SyncLevelPropose, nil
+	case "write":
+		return antfly.SyncLevelWrite, nil
+	case "full_text":
+		return antfly.SyncLevelFullText, nil
+	case "aknn", "embeddings":
+		return antfly.SyncLevelAknn, nil
+	case "full_index":
+		return antfly.SyncLevelFullIndex, nil
+	case "enrichments":
+		return antfly.SyncLevelEnrichments, nil
+	default:
+		return "", fmt.Errorf("invalid --sync-level %q (expected write, full_text, aknn, full_index, enrichments, or propose)", value)
+	}
 }
 
 // downloadCmd downloads Epstein documents from archive.org
@@ -633,6 +656,9 @@ func iterateZipPDFs(zipPath string, fn func(name string, data []byte) error) err
 		}
 
 		if err := fn(filepath.Base(f.Name), data); err != nil {
+			if err == filepath.SkipAll {
+				return nil
+			}
 			return err
 		}
 	}
@@ -918,6 +944,8 @@ func prepareCmd(args []string) error {
 	noHeaderFooter := fs.Bool("no-header-footer-detection", false, "Disable header/footer detection (faster, single pass)")
 	noMirroredRepair := fs.Bool("no-mirrored-text-repair", false, "Disable mirrored text repair (faster)")
 	smartJoin := fs.Bool("smart-join", false, "Enable smart line joining to defragment text layouts")
+	limitFiles := fs.Int("limit-files", 0, "Process at most this many source PDFs (0 = all)")
+	limitPages := fs.Int("limit-pages", 0, "Keep at most this many parsed pages in output (0 = all)")
 	numWorkers := fs.Int("workers", runtime.NumCPU(), "Number of parallel workers for parsing (split-pages mode only)")
 	var zipPaths StringSliceFlag
 	fs.Var(&zipPaths, "zip", "Path to ZIP archive containing PDFs (repeatable, skips extraction)")
@@ -949,6 +977,12 @@ func prepareCmd(args []string) error {
 	fmt.Printf("Header/footer detection: %v\n", !*noHeaderFooter)
 	fmt.Printf("Mirrored text repair: %v\n", !*noMirroredRepair)
 	fmt.Printf("Smart line joining: %v\n", *smartJoin)
+	if *limitFiles > 0 {
+		fmt.Printf("Limit files: %d\n", *limitFiles)
+	}
+	if *limitPages > 0 {
+		fmt.Printf("Limit pages: %d\n", *limitPages)
+	}
 	if *splitPages {
 		fmt.Printf("Workers: %d\n", *numWorkers)
 	}
@@ -1006,6 +1040,7 @@ func prepareCmd(args []string) error {
 
 		// Find and split all PDF files from directory (including subdirectories from extracted ZIPs)
 		if dirExists {
+			sourcePDFsSeen := 0
 			if err := filepath.WalkDir(*dirPath, func(path string, d os.DirEntry, err error) error {
 				if err != nil {
 					return err
@@ -1020,6 +1055,10 @@ func prepareCmd(args []string) error {
 				if !strings.HasSuffix(strings.ToLower(d.Name()), ".pdf") {
 					return nil
 				}
+				if *limitFiles > 0 && sourcePDFsSeen >= *limitFiles {
+					return filepath.SkipAll
+				}
+				sourcePDFsSeen++
 
 				relPath, _ := filepath.Rel(*dirPath, path)
 				fmt.Printf("  Processing %s...\n", relPath)
@@ -1190,6 +1229,9 @@ func prepareCmd(args []string) error {
 				fmt.Printf("    %d PDFs in archive\n", zipPDFCount)
 				zipIdx := 0
 				if err := iterateZipPDFs(zipPath, func(name string, data []byte) error {
+					if *limitFiles > 0 && zipIdx >= *limitFiles {
+						return filepath.SkipAll
+					}
 					zipIdx++
 					pb, meta, err := splitPDFToPagesFromBytes(data, name)
 					if err != nil {
@@ -1309,7 +1351,12 @@ func prepareCmd(args []string) error {
 			}
 			for _, zipPath := range zipPaths {
 				fmt.Printf("Processing ZIP: %s\n", zipPath)
+				zipIdx := 0
 				if err := iterateZipPDFs(zipPath, func(name string, data []byte) error {
+					if *limitFiles > 0 && zipIdx >= *limitFiles {
+						return filepath.SkipAll
+					}
+					zipIdx++
 					zipSections, err := pdfProcessor.Process(name, "", *baseURL, data)
 					if err != nil {
 						fmt.Printf("  Warning: failed to process %s: %v\n", name, err)
@@ -1331,6 +1378,11 @@ func prepareCmd(args []string) error {
 			sections[i].Content = smartJoinLines(sections[i].Content)
 		}
 		fmt.Printf("\n")
+	}
+
+	if *limitPages > 0 && len(sections) > *limitPages {
+		fmt.Printf("Limiting output to first %d pages (from %d parsed pages)\n\n", *limitPages, len(sections))
+		sections = sections[:*limitPages]
 	}
 
 	fmt.Printf("Found %d document sections (pages)\n\n", len(sections))
@@ -1395,13 +1447,25 @@ func loadCmd(args []string) error {
 	createTable := fs.Bool("create-table", false, "Create table if it doesn't exist")
 	numShards := fs.Int("num-shards", 1, "Number of shards for new table")
 	batchSize := fs.Int("batch-size", 25, "Linear merge batch size")
+	limitRecords := fs.Int("limit-records", 0, "Maximum records to load (0 = all)")
+	syncLevelFlag := fs.String("sync-level", "write", "Merge sync level: write, full_text, aknn, full_index, enrichments, or propose")
 	embeddingModel := fs.String("embedding-model", DefaultEmbeddingModel, "Embedding model to use")
 	chunkerModel := fs.String("chunker-model", DefaultChunkerModel, "Chunker model")
 	targetTokens := fs.Int("target-tokens", 512, "Target tokens for chunking")
 	overlapTokens := fs.Int("overlap-tokens", 50, "Overlap tokens for chunking")
+	enableArtifactGraph := fs.Bool("enable-artifact-graph", false, "Create artifact-backed autograph relation graph index")
+	artifactGraphIndex := fs.String("artifact-graph-index", DefaultAutographIndex, "Artifact graph index name")
+	artifactName := fs.String("artifact-name", DefaultAutographAsset, "Generated asset artifact name for relation extraction")
+	artifactExtractorModel := fs.String("artifact-extractor-model", DefaultAutographModel, "Antfly generator model for tool-call artifact relation extraction")
+	artifactLabels := fs.String("artifact-labels", DefaultEntityLabels, "Artifact generator entity labels (comma-separated)")
+	artifactRelationLabels := fs.String("artifact-relation-labels", DefaultRelationLabels, "Artifact generator relation labels (comma-separated)")
 
 	if err := fs.Parse(args); err != nil {
 		return fmt.Errorf("failed to parse flags: %w", err)
+	}
+	syncLevel, err := parseSyncLevelFlag(*syncLevelFlag)
+	if err != nil {
+		return err
 	}
 
 	ctx := context.Background()
@@ -1417,7 +1481,11 @@ func loadCmd(args []string) error {
 	fmt.Printf("Inference URL: %s\n", *inferenceURL)
 	fmt.Printf("Table: %s\n", *tableName)
 	fmt.Printf("Input: %s\n", *inputFile)
+	if *limitRecords > 0 {
+		fmt.Printf("Limit records: %d\n", *limitRecords)
+	}
 	fmt.Printf("Dry run: %v\n\n", *dryRun)
+	fmt.Printf("Sync level: %s\n\n", syncLevel)
 
 	// Create table if requested
 	if *createTable {
@@ -1430,6 +1498,13 @@ func loadCmd(args []string) error {
 		indexes, err := createSearchTableIndexes(*embeddingIndex)
 		if err != nil {
 			return fmt.Errorf("failed to create search index config: %w", err)
+		}
+		if *enableArtifactGraph {
+			graphIndex, err := createArtifactGraphIndex(*artifactGraphIndex, *artifactName, *artifactExtractorModel, *inferenceURL, splitCSV(*artifactLabels), splitCSV(*artifactRelationLabels))
+			if err != nil {
+				return fmt.Errorf("failed to create artifact graph index config: %w", err)
+			}
+			indexes[*artifactGraphIndex] = *graphIndex
 		}
 
 		err = client.CreateTable(ctx, *tableName, antfly.CreateTableRequest{
@@ -1456,11 +1531,11 @@ func loadCmd(args []string) error {
 	}
 	defer f.Close()
 
-	pages := streamJSONPages(f, *batchSize)
+	pages := streamJSONPagesWithLimit(f, *batchSize, *limitRecords)
 
 	mergeResult, err := client.ExecuteLinearMerge(ctx, *tableName, pages, antfly.ExecuteLinearMergeOptions{
 		DryRun:    *dryRun,
-		SyncLevel: antfly.SyncLevelAknn,
+		SyncLevel: syncLevel,
 		OnBatch: func(batch int, result *antfly.LinearMergeResult) {
 			fmt.Printf("[batch %d] upserted: %d, took: %s\n", batch, result.Upserted, result.Took)
 		},
@@ -1486,10 +1561,17 @@ func syncCmd(args []string) error {
 	createTable := fs.Bool("create-table", false, "Create table if needed")
 	numShards := fs.Int("num-shards", 1, "Number of shards")
 	batchSize := fs.Int("batch-size", 25, "Batch size")
+	syncLevelFlag := fs.String("sync-level", "write", "Merge sync level: write, full_text, aknn, full_index, enrichments, or propose")
 	embeddingModel := fs.String("embedding-model", DefaultEmbeddingModel, "Embedding model")
 	chunkerModel := fs.String("chunker-model", DefaultChunkerModel, "Chunker model")
 	targetTokens := fs.Int("target-tokens", 512, "Target tokens")
 	overlapTokens := fs.Int("overlap-tokens", 50, "Overlap tokens")
+	enableArtifactGraph := fs.Bool("enable-artifact-graph", false, "Create artifact-backed autograph relation graph index")
+	artifactGraphIndex := fs.String("artifact-graph-index", DefaultAutographIndex, "Artifact graph index name")
+	artifactName := fs.String("artifact-name", DefaultAutographAsset, "Generated asset artifact name for relation extraction")
+	artifactExtractorModel := fs.String("artifact-extractor-model", DefaultAutographModel, "Antfly generator model for tool-call artifact relation extraction")
+	artifactLabels := fs.String("artifact-labels", DefaultEntityLabels, "Artifact generator entity labels (comma-separated)")
+	artifactRelationLabels := fs.String("artifact-relation-labels", DefaultRelationLabels, "Artifact generator relation labels (comma-separated)")
 	noHeaderFooter := fs.Bool("no-header-footer-detection", false, "Disable header/footer detection (faster)")
 	noMirroredRepair := fs.Bool("no-mirrored-text-repair", false, "Disable mirrored text repair (faster)")
 	var zipPaths StringSliceFlag
@@ -1497,6 +1579,10 @@ func syncCmd(args []string) error {
 
 	if err := fs.Parse(args); err != nil {
 		return fmt.Errorf("failed to parse flags: %w", err)
+	}
+	syncLevel, err := parseSyncLevelFlag(*syncLevelFlag)
+	if err != nil {
+		return err
 	}
 
 	ctx := context.Background()
@@ -1512,6 +1598,7 @@ func syncCmd(args []string) error {
 	fmt.Printf("Inference URL: %s\n", *inferenceURL)
 	fmt.Printf("Directory: %s\n", *dirPath)
 	fmt.Printf("Table: %s\n", *tableName)
+	fmt.Printf("Sync level: %s\n", syncLevel)
 	if len(zipPaths) > 0 {
 		fmt.Printf("ZIP sources: %d\n", len(zipPaths))
 		for _, zp := range zipPaths {
@@ -1531,6 +1618,13 @@ func syncCmd(args []string) error {
 		indexes, err := createSearchTableIndexes(*embeddingIndex)
 		if err != nil {
 			return fmt.Errorf("failed to create search index config: %w", err)
+		}
+		if *enableArtifactGraph {
+			graphIndex, err := createArtifactGraphIndex(*artifactGraphIndex, *artifactName, *artifactExtractorModel, *inferenceURL, splitCSV(*artifactLabels), splitCSV(*artifactRelationLabels))
+			if err != nil {
+				return fmt.Errorf("failed to create artifact graph index config: %w", err)
+			}
+			indexes[*artifactGraphIndex] = *graphIndex
 		}
 
 		err = client.CreateTable(ctx, *tableName, antfly.CreateTableRequest{
@@ -1648,7 +1742,7 @@ func syncCmd(args []string) error {
 
 	mergeResult, err := client.ExecuteLinearMerge(ctx, *tableName, pages, antfly.ExecuteLinearMergeOptions{
 		DryRun:    *dryRun,
-		SyncLevel: antfly.SyncLevelAknn,
+		SyncLevel: syncLevel,
 		OnBatch: func(batch int, result *antfly.LinearMergeResult) {
 			fmt.Printf("[batch %d] upserted: %d, took: %s\n", batch, result.Upserted, result.Took)
 		},
@@ -1910,6 +2004,7 @@ func createEmbeddingIndex(embeddingModel, inferenceURL, chunkerModel string, tar
 	}
 
 	chunker := antfly.ChunkerConfig{}
+	chunker.Provider = antfly.ChunkerProviderAntfly
 	err = chunker.FromAntflyChunkerConfig(antfly.AntflyChunkerConfig{
 		ApiUrl: chunkerURL,
 		Model:  chunkerModel,
@@ -1923,9 +2018,10 @@ func createEmbeddingIndex(embeddingModel, inferenceURL, chunkerModel string, tar
 	}
 
 	err = embeddingIndexConfig.FromEmbeddingsIndexConfig(antfly.EmbeddingsIndexConfig{
-		Field:    "content",
-		Embedder: *embedder,
-		Chunker:  chunker,
+		Field:     "content",
+		Dimension: DefaultEmbeddingDims,
+		Embedder:  *embedder,
+		Chunker:   chunker,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to configure embedding index: %w", err)
@@ -1946,14 +2042,140 @@ func createFullTextIndex() (antfly.IndexConfig, error) {
 }
 
 func createSearchTableIndexes(embeddingIndex antfly.IndexConfig) (map[string]antfly.IndexConfig, error) {
-	fullTextIndex, err := createFullTextIndex()
+	return map[string]antfly.IndexConfig{
+		DefaultEmbeddingIndex: embeddingIndex,
+	}, nil
+}
+
+func createArtifactGraphIndex(indexName, artifactName, model, inferenceURL string, labels, relationLabels []string) (*antfly.IndexConfig, error) {
+	if strings.TrimSpace(indexName) == "" {
+		return nil, fmt.Errorf("artifact graph index name is required")
+	}
+	if strings.TrimSpace(artifactName) == "" {
+		return nil, fmt.Errorf("artifact name is required")
+	}
+	if strings.TrimSpace(model) == "" {
+		return nil, fmt.Errorf("artifact generator model is required")
+	}
+	inferenceAPIURL, err := inferenceMLBaseURL(inferenceURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid artifact inference URL: %w", err)
+	}
+	if len(labels) == 0 {
+		return nil, fmt.Errorf("at least one artifact entity label is required")
+	}
+	if len(relationLabels) == 0 {
+		return nil, fmt.Errorf("at least one artifact relation label is required")
+	}
+
+	relationEnum := append([]string(nil), relationLabels...)
+	labelEnum := append([]string(nil), labels...)
+
+	raw := map[string]any{
+		"name": indexName,
+		"type": antfly.IndexTypeGraph,
+		"source": map[string]any{
+			"kind":     "artifact",
+			"artifact": artifactName,
+			"path":     "$.relations[*]",
+			"format":   "extraction_relation",
+		},
+		"artifact": map[string]any{
+			"name":         artifactName,
+			"kind":         "asset",
+			"field":        "content",
+			"content_type": "application/json",
+			"producer_json": map[string]any{
+				"type": "generator",
+				"config": map[string]any{
+					"provider":    "antfly",
+					"model":       model,
+					"api_url":     inferenceAPIURL,
+					"tool_output": "arguments",
+					"tool_name":   "emit_relations",
+					"tool_choice": map[string]any{
+						"type": "function",
+						"function": map[string]any{
+							"name": "emit_relations",
+						},
+					},
+					"tools": []map[string]any{
+						{
+							"type": "function",
+							"function": map[string]any{
+								"name":        "emit_relations",
+								"description": "Extract autograph, signature, sender, recipient, and related entity relationships from the document text. Return only relations directly supported by the text.",
+								"parameters": map[string]any{
+									"type":                 "object",
+									"additionalProperties": false,
+									"required":             []string{"relations"},
+									"properties": map[string]any{
+										"relations": map[string]any{
+											"type": "array",
+											"items": map[string]any{
+												"type":                 "object",
+												"additionalProperties": false,
+												"required":             []string{"type", "target"},
+												"properties": map[string]any{
+													"type": map[string]any{
+														"type": "string",
+														"enum": relationEnum,
+													},
+													"source": map[string]any{
+														"type":        "object",
+														"description": "Optional source endpoint. Omit this to use the current document as the source.",
+														"properties": map[string]any{
+															"id":    map[string]any{"type": "string"},
+															"label": map[string]any{"type": "string", "enum": labelEnum},
+															"text":  map[string]any{"type": "string"},
+														},
+													},
+													"target": map[string]any{
+														"type":        "object",
+														"description": "Target endpoint for the relation. Use id for the normalized entity name.",
+														"required":    []string{"id"},
+														"properties": map[string]any{
+															"id":    map[string]any{"type": "string"},
+															"label": map[string]any{"type": "string", "enum": labelEnum},
+															"text":  map[string]any{"type": "string"},
+														},
+													},
+													"confidence": map[string]any{
+														"type":    "number",
+														"minimum": 0,
+														"maximum": 1,
+													},
+													"evidence": map[string]any{
+														"type":        "string",
+														"description": "Short text span or explanation supporting the relation.",
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"algebraic_planning": map[string]any{
+			"bounded_traversal": map[string]any{
+				"law": "provenance_semiring",
+			},
+		},
+	}
+
+	encoded, err := json.Marshal(raw)
 	if err != nil {
 		return nil, err
 	}
-	return map[string]antfly.IndexConfig{
-		DefaultFullTextIndex:  fullTextIndex,
-		DefaultEmbeddingIndex: embeddingIndex,
-	}, nil
+	var cfg antfly.IndexConfig
+	if err := json.Unmarshal(encoded, &cfg); err != nil {
+		return nil, err
+	}
+	return &cfg, nil
 }
 
 func searchIndexNames() []string {
@@ -1995,6 +2217,10 @@ func truncateContent(content string, maxLen int) string {
 // (as produced by writeJSONSorted) so that sequential pages form valid
 // non-overlapping ranges for linear merge.
 func streamJSONPages(r io.Reader, batchSize int) iter.Seq[map[string]any] {
+	return streamJSONPagesWithLimit(r, batchSize, 0)
+}
+
+func streamJSONPagesWithLimit(r io.Reader, batchSize int, limit int) iter.Seq[map[string]any] {
 	return func(yield func(map[string]any) bool) {
 		dec := json.NewDecoder(bufio.NewReaderSize(r, 256*1024))
 		dec.UseNumber()
@@ -2006,6 +2232,7 @@ func streamJSONPages(r io.Reader, batchSize int) iter.Seq[map[string]any] {
 		}
 
 		page := make(map[string]any, batchSize)
+		loaded := 0
 		for dec.More() {
 			// Read key
 			tok, err := dec.Token()
@@ -2023,12 +2250,17 @@ func streamJSONPages(r io.Reader, batchSize int) iter.Seq[map[string]any] {
 				return
 			}
 
+			value = normalizePreparedRecordForLoad(value)
 			page[key] = value
+			loaded++
 			if len(page) >= batchSize {
 				if !yield(page) {
 					return
 				}
 				page = make(map[string]any, batchSize)
+			}
+			if limit > 0 && loaded >= limit {
+				break
 			}
 		}
 
@@ -2036,6 +2268,21 @@ func streamJSONPages(r io.Reader, batchSize int) iter.Seq[map[string]any] {
 			yield(page)
 		}
 	}
+}
+
+func normalizePreparedRecordForLoad(value any) any {
+	record, ok := value.(map[string]any)
+	if !ok {
+		return value
+	}
+
+	if docType, ok := record["_type"]; ok {
+		if _, exists := record["document_type"]; !exists {
+			record["document_type"] = docType
+		}
+		delete(record, "_type")
+	}
+	return record
 }
 
 // writeJSONSorted writes a map as a JSON object with keys in sorted order,
@@ -3146,9 +3393,32 @@ type entityWindowSpan struct {
 	End   int `json:"end"`
 }
 
+const recognizedObjectObjectRecognition = "recognition"
+
+type recognizedEntity struct {
+	Text  string  `json:"text"`
+	Label string  `json:"label"`
+	Start int     `json:"start,omitempty"`
+	End   int     `json:"end,omitempty"`
+	Score float32 `json:"score,omitempty"`
+}
+
+type recognizedRelation struct {
+	Head  recognizedEntity `json:"head"`
+	Label string           `json:"label"`
+	Score float32          `json:"score,omitempty"`
+	Tail  recognizedEntity `json:"tail"`
+}
+
+type recognizedObject struct {
+	Entities  []recognizedEntity   `json:"entities,omitempty"`
+	Object    string               `json:"object,omitempty"`
+	Relations []recognizedRelation `json:"relations,omitempty"`
+}
+
 type entityAccum struct {
-	entities         []inferenceoapi.InferenceRecognizeEntity
-	relations        []inferenceoapi.InferenceRelation
+	entities         []recognizedEntity
+	relations        []recognizedRelation
 	failed           []entityWindowSpan
 	windows          int
 	errors           int
@@ -3577,7 +3847,7 @@ func recognizeEntityWindowBatch(
 		usedModel = model
 	}
 
-	resultsByIndex := make(map[int]inferenceoapi.InferenceRecognizeObject, len(resp.Data))
+	resultsByIndex := make(map[int]recognizedObject, len(resp.Data))
 	for resultIdx, result := range resp.Data {
 		idx := resultIdx
 		if idx >= 0 && idx < len(windows) {
@@ -3615,10 +3885,10 @@ func inferenceExtractionInputs(texts []string) ([]inferenceoapi.ExtractionInput,
 	return inputs, nil
 }
 
-func inferenceRecognizeObjectFromExtraction(item inferenceoapi.ExtractionObject) inferenceoapi.InferenceRecognizeObject {
-	entities := make([]inferenceoapi.InferenceRecognizeEntity, len(item.Entities))
+func inferenceRecognizeObjectFromExtraction(item inferenceoapi.ExtractionObject) recognizedObject {
+	entities := make([]recognizedEntity, len(item.Entities))
 	for i, entity := range item.Entities {
-		entities[i] = inferenceoapi.InferenceRecognizeEntity{
+		entities[i] = recognizedEntity{
 			Text:  entity.Text,
 			Label: entity.Label,
 			Score: entity.Score,
@@ -3626,23 +3896,23 @@ func inferenceRecognizeObjectFromExtraction(item inferenceoapi.ExtractionObject)
 			End:   entity.End,
 		}
 	}
-	relations := make([]inferenceoapi.InferenceRelation, 0, len(item.Relations))
+	relations := make([]recognizedRelation, 0, len(item.Relations))
 	for _, relation := range item.Relations {
-		relations = append(relations, inferenceoapi.InferenceRelation{
+		relations = append(relations, recognizedRelation{
 			Head:  inferenceRelationEndpointEntity(relation.Source, entities),
 			Label: relation.Type,
 			Score: relation.Score,
 			Tail:  inferenceRelationEndpointEntity(relation.Target, entities),
 		})
 	}
-	return inferenceoapi.InferenceRecognizeObject{
+	return recognizedObject{
 		Entities:  entities,
-		Object:    inferenceoapi.InferenceRecognizeObjectObjectRecognition,
+		Object:    recognizedObjectObjectRecognition,
 		Relations: relations,
 	}
 }
 
-func inferenceRelationEndpointEntity(endpoint inferenceoapi.ExtractionRelationEndpoint, entities []inferenceoapi.InferenceRecognizeEntity) inferenceoapi.InferenceRecognizeEntity {
+func inferenceRelationEndpointEntity(endpoint inferenceoapi.ExtractionRelationEndpoint, entities []recognizedEntity) recognizedEntity {
 	if endpoint.EntityIndex >= 0 && endpoint.EntityIndex < len(entities) {
 		return entities[endpoint.EntityIndex]
 	}
@@ -3653,25 +3923,25 @@ func inferenceRelationEndpointEntity(endpoint inferenceoapi.ExtractionRelationEn
 			}
 		}
 	}
-	return inferenceoapi.InferenceRecognizeEntity{}
+	return recognizedEntity{}
 }
 
-func offsetEntities(entities []inferenceoapi.InferenceRecognizeEntity, base int) []inferenceoapi.InferenceRecognizeEntity {
-	out := make([]inferenceoapi.InferenceRecognizeEntity, len(entities))
+func offsetEntities(entities []recognizedEntity, base int) []recognizedEntity {
+	out := make([]recognizedEntity, len(entities))
 	for i, entity := range entities {
 		out[i] = offsetEntity(entity, base)
 	}
 	return out
 }
 
-func offsetEntity(entity inferenceoapi.InferenceRecognizeEntity, base int) inferenceoapi.InferenceRecognizeEntity {
+func offsetEntity(entity recognizedEntity, base int) recognizedEntity {
 	entity.Start += base
 	entity.End += base
 	return entity
 }
 
-func offsetRelations(relations []inferenceoapi.InferenceRelation, base int) []inferenceoapi.InferenceRelation {
-	out := make([]inferenceoapi.InferenceRelation, len(relations))
+func offsetRelations(relations []recognizedRelation, base int) []recognizedRelation {
+	out := make([]recognizedRelation, len(relations))
 	for i, relation := range relations {
 		relation.Head = offsetEntity(relation.Head, base)
 		relation.Tail = offsetEntity(relation.Tail, base)
@@ -3680,15 +3950,15 @@ func offsetRelations(relations []inferenceoapi.InferenceRelation, base int) []in
 	return out
 }
 
-func metadataEntities(value any) []inferenceoapi.InferenceRecognizeEntity {
+func metadataEntities(value any) []recognizedEntity {
 	items, ok := value.([]any)
 	if !ok {
-		if entities, ok := value.([]inferenceoapi.InferenceRecognizeEntity); ok {
-			return append([]inferenceoapi.InferenceRecognizeEntity(nil), entities...)
+		if entities, ok := value.([]recognizedEntity); ok {
+			return append([]recognizedEntity(nil), entities...)
 		}
 		return nil
 	}
-	entities := make([]inferenceoapi.InferenceRecognizeEntity, 0, len(items))
+	entities := make([]recognizedEntity, 0, len(items))
 	for _, item := range items {
 		entity, ok := metadataEntity(item)
 		if ok {
@@ -3698,15 +3968,15 @@ func metadataEntities(value any) []inferenceoapi.InferenceRecognizeEntity {
 	return entities
 }
 
-func metadataRelations(value any) []inferenceoapi.InferenceRelation {
+func metadataRelations(value any) []recognizedRelation {
 	items, ok := value.([]any)
 	if !ok {
-		if relations, ok := value.([]inferenceoapi.InferenceRelation); ok {
-			return append([]inferenceoapi.InferenceRelation(nil), relations...)
+		if relations, ok := value.([]recognizedRelation); ok {
+			return append([]recognizedRelation(nil), relations...)
 		}
 		return nil
 	}
-	relations := make([]inferenceoapi.InferenceRelation, 0, len(items))
+	relations := make([]recognizedRelation, 0, len(items))
 	for _, item := range items {
 		relation, ok := metadataRelation(item)
 		if ok {
@@ -3716,15 +3986,15 @@ func metadataRelations(value any) []inferenceoapi.InferenceRelation {
 	return relations
 }
 
-func metadataEntity(value any) (inferenceoapi.InferenceRecognizeEntity, bool) {
-	if entity, ok := value.(inferenceoapi.InferenceRecognizeEntity); ok {
+func metadataEntity(value any) (recognizedEntity, bool) {
+	if entity, ok := value.(recognizedEntity); ok {
 		return entity, true
 	}
 	m, ok := value.(map[string]any)
 	if !ok {
-		return inferenceoapi.InferenceRecognizeEntity{}, false
+		return recognizedEntity{}, false
 	}
-	return inferenceoapi.InferenceRecognizeEntity{
+	return recognizedEntity{
 		Text:  metadataString(m["text"]),
 		Label: metadataString(m["label"]),
 		Start: metadataInt(m["start"]),
@@ -3733,20 +4003,20 @@ func metadataEntity(value any) (inferenceoapi.InferenceRecognizeEntity, bool) {
 	}, true
 }
 
-func metadataRelation(value any) (inferenceoapi.InferenceRelation, bool) {
-	if relation, ok := value.(inferenceoapi.InferenceRelation); ok {
+func metadataRelation(value any) (recognizedRelation, bool) {
+	if relation, ok := value.(recognizedRelation); ok {
 		return relation, true
 	}
 	m, ok := value.(map[string]any)
 	if !ok {
-		return inferenceoapi.InferenceRelation{}, false
+		return recognizedRelation{}, false
 	}
 	head, headOK := metadataEntity(m["head"])
 	tail, tailOK := metadataEntity(m["tail"])
 	if !headOK || !tailOK {
-		return inferenceoapi.InferenceRelation{}, false
+		return recognizedRelation{}, false
 	}
-	return inferenceoapi.InferenceRelation{
+	return recognizedRelation{
 		Head:  head,
 		Label: metadataString(m["label"]),
 		Score: metadataFloat32(m["score"]),
@@ -3818,8 +4088,8 @@ func stringSlicesEqual(a, b []string) bool {
 	return true
 }
 
-func dedupeEntities(entities []inferenceoapi.InferenceRecognizeEntity) []inferenceoapi.InferenceRecognizeEntity {
-	byKey := make(map[string]inferenceoapi.InferenceRecognizeEntity, len(entities))
+func dedupeEntities(entities []recognizedEntity) []recognizedEntity {
+	byKey := make(map[string]recognizedEntity, len(entities))
 	for _, entity := range entities {
 		key := entityKey(entity)
 		if existing, ok := byKey[key]; !ok || entity.Score > existing.Score {
@@ -3827,11 +4097,11 @@ func dedupeEntities(entities []inferenceoapi.InferenceRecognizeEntity) []inferen
 		}
 	}
 
-	out := make([]inferenceoapi.InferenceRecognizeEntity, 0, len(byKey))
+	out := make([]recognizedEntity, 0, len(byKey))
 	for _, entity := range byKey {
 		out = append(out, entity)
 	}
-	slices.SortFunc(out, func(a, b inferenceoapi.InferenceRecognizeEntity) int {
+	slices.SortFunc(out, func(a, b recognizedEntity) int {
 		if a.Start != b.Start {
 			return a.Start - b.Start
 		}
@@ -3846,8 +4116,8 @@ func dedupeEntities(entities []inferenceoapi.InferenceRecognizeEntity) []inferen
 	return out
 }
 
-func dedupeRelations(relations []inferenceoapi.InferenceRelation) []inferenceoapi.InferenceRelation {
-	byKey := make(map[string]inferenceoapi.InferenceRelation, len(relations))
+func dedupeRelations(relations []recognizedRelation) []recognizedRelation {
+	byKey := make(map[string]recognizedRelation, len(relations))
 	for _, relation := range relations {
 		key := relationKey(relation)
 		if existing, ok := byKey[key]; !ok || relation.Score > existing.Score {
@@ -3855,11 +4125,11 @@ func dedupeRelations(relations []inferenceoapi.InferenceRelation) []inferenceoap
 		}
 	}
 
-	out := make([]inferenceoapi.InferenceRelation, 0, len(byKey))
+	out := make([]recognizedRelation, 0, len(byKey))
 	for _, relation := range byKey {
 		out = append(out, relation)
 	}
-	slices.SortFunc(out, func(a, b inferenceoapi.InferenceRelation) int {
+	slices.SortFunc(out, func(a, b recognizedRelation) int {
 		if a.Head.Start != b.Head.Start {
 			return a.Head.Start - b.Head.Start
 		}
@@ -3877,11 +4147,11 @@ func dedupeRelations(relations []inferenceoapi.InferenceRelation) []inferenceoap
 	return out
 }
 
-func entityKey(entity inferenceoapi.InferenceRecognizeEntity) string {
+func entityKey(entity recognizedEntity) string {
 	return fmt.Sprintf("%s\x00%s\x00%d\x00%d", entity.Label, entity.Text, entity.Start, entity.End)
 }
 
-func relationKey(relation inferenceoapi.InferenceRelation) string {
+func relationKey(relation recognizedRelation) string {
 	return fmt.Sprintf("%s\x00%s\x00%s", relation.Label, entityKey(relation.Head), entityKey(relation.Tail))
 }
 

--- a/examples/epstein/main.go
+++ b/examples/epstein/main.go
@@ -189,23 +189,25 @@ var needsOCRFallback = docsaf.NeedsOCRFallback
 var templatesFS embed.FS
 
 const (
-	DefaultAntflyURL       = "http://localhost:8080/db/v1"
-	DefaultInferenceURL    = "http://localhost:8080"
-	DefaultFullTextIndex   = "full_text_index_v0"
-	DefaultEmbeddingIndex  = "embeddings"
-	DefaultEmbeddingModel  = "antflydb/clipclap"
-	DefaultEmbeddingPull   = "antflydb/clipclap:gguf:Q4_K"
-	DefaultEmbeddingDims   = 512
-	DefaultChunkerModel    = "fixed-bert-tokenizer"
-	DefaultOCRModel        = "Xenova/trocr-base-printed"
-	DefaultRecognizerModel = "fastino/gliner2-base-v1"
-	DefaultAutographIndex  = "autograph_relations"
-	DefaultAutographAsset  = "relations_v1"
-	DefaultAutographModel  = "ggml-org/gemma-4-E4B-it-GGUF"
-	DefaultEntityLabels    = "person,organization,location,date,case,document,facility,aircraft"
-	DefaultRelationLabels  = "associated with,communicated with,traveled to,visited,worked for,represented by,mentioned in,located in"
-	DefaultEntityMaxChars  = 3000
-	DefaultEntityOverlap   = 300
+	DefaultAntflyURL        = "http://localhost:8080/db/v1"
+	DefaultInferenceURL     = "http://localhost:8080"
+	DefaultFullTextIndex    = "full_text_index_v0"
+	DefaultEmbeddingIndex   = "embeddings"
+	DefaultEmbeddingModel   = "antflydb/clipclap"
+	DefaultEmbeddingPull    = "antflydb/clipclap:gguf:Q4_K"
+	DefaultEmbeddingDims    = 512
+	DefaultChunkerModel     = "fixed-bert-tokenizer"
+	DefaultOCRModel         = "microsoft/Florence-2-base-ft"
+	DefaultRecognizerModel  = "antflydb/gliner2-base-v1-q4_k"
+	DefaultAutographIndex   = "autograph_relations"
+	DefaultAutographAsset   = "relations_v1"
+	DefaultAutographModel   = DefaultRecognizerModel
+	DefaultGeneratorModel   = "ggml-org/gemma-4-E4B-it-GGUF"
+	DefaultArtifactProducer = "extractor"
+	DefaultEntityLabels     = "person,organization,location,date,case,document,facility,aircraft"
+	DefaultRelationLabels   = "associated with,communicated with,traveled to,visited,worked for,represented by,mentioned in,located in"
+	DefaultEntityMaxChars   = 3000
+	DefaultEntityOverlap    = 300
 )
 
 // Archive.org download URLs for Epstein documents
@@ -1456,9 +1458,10 @@ func loadCmd(args []string) error {
 	enableArtifactGraph := fs.Bool("enable-artifact-graph", false, "Create artifact-backed autograph relation graph index")
 	artifactGraphIndex := fs.String("artifact-graph-index", DefaultAutographIndex, "Artifact graph index name")
 	artifactName := fs.String("artifact-name", DefaultAutographAsset, "Generated asset artifact name for relation extraction")
-	artifactExtractorModel := fs.String("artifact-extractor-model", DefaultAutographModel, "Antfly generator model for tool-call artifact relation extraction")
-	artifactLabels := fs.String("artifact-labels", DefaultEntityLabels, "Artifact generator entity labels (comma-separated)")
-	artifactRelationLabels := fs.String("artifact-relation-labels", DefaultRelationLabels, "Artifact generator relation labels (comma-separated)")
+	artifactProducer := fs.String("artifact-producer", DefaultArtifactProducer, "Artifact producer type: extractor or generator")
+	artifactExtractorModel := fs.String("artifact-extractor-model", DefaultAutographModel, "Antfly model for artifact relation extraction")
+	artifactLabels := fs.String("artifact-labels", DefaultEntityLabels, "Artifact extractor entity labels (comma-separated)")
+	artifactRelationLabels := fs.String("artifact-relation-labels", DefaultRelationLabels, "Artifact extractor relation labels (comma-separated)")
 
 	if err := fs.Parse(args); err != nil {
 		return fmt.Errorf("failed to parse flags: %w", err)
@@ -1500,7 +1503,7 @@ func loadCmd(args []string) error {
 			return fmt.Errorf("failed to create search index config: %w", err)
 		}
 		if *enableArtifactGraph {
-			graphIndex, err := createArtifactGraphIndex(*artifactGraphIndex, *artifactName, *artifactExtractorModel, *inferenceURL, splitCSV(*artifactLabels), splitCSV(*artifactRelationLabels))
+			graphIndex, err := createArtifactGraphIndex(*artifactGraphIndex, *artifactName, *artifactProducer, *artifactExtractorModel, *inferenceURL, splitCSV(*artifactLabels), splitCSV(*artifactRelationLabels))
 			if err != nil {
 				return fmt.Errorf("failed to create artifact graph index config: %w", err)
 			}
@@ -1569,9 +1572,10 @@ func syncCmd(args []string) error {
 	enableArtifactGraph := fs.Bool("enable-artifact-graph", false, "Create artifact-backed autograph relation graph index")
 	artifactGraphIndex := fs.String("artifact-graph-index", DefaultAutographIndex, "Artifact graph index name")
 	artifactName := fs.String("artifact-name", DefaultAutographAsset, "Generated asset artifact name for relation extraction")
-	artifactExtractorModel := fs.String("artifact-extractor-model", DefaultAutographModel, "Antfly generator model for tool-call artifact relation extraction")
-	artifactLabels := fs.String("artifact-labels", DefaultEntityLabels, "Artifact generator entity labels (comma-separated)")
-	artifactRelationLabels := fs.String("artifact-relation-labels", DefaultRelationLabels, "Artifact generator relation labels (comma-separated)")
+	artifactProducer := fs.String("artifact-producer", DefaultArtifactProducer, "Artifact producer type: extractor or generator")
+	artifactExtractorModel := fs.String("artifact-extractor-model", DefaultAutographModel, "Antfly model for artifact relation extraction")
+	artifactLabels := fs.String("artifact-labels", DefaultEntityLabels, "Artifact extractor entity labels (comma-separated)")
+	artifactRelationLabels := fs.String("artifact-relation-labels", DefaultRelationLabels, "Artifact extractor relation labels (comma-separated)")
 	noHeaderFooter := fs.Bool("no-header-footer-detection", false, "Disable header/footer detection (faster)")
 	noMirroredRepair := fs.Bool("no-mirrored-text-repair", false, "Disable mirrored text repair (faster)")
 	var zipPaths StringSliceFlag
@@ -1620,7 +1624,7 @@ func syncCmd(args []string) error {
 			return fmt.Errorf("failed to create search index config: %w", err)
 		}
 		if *enableArtifactGraph {
-			graphIndex, err := createArtifactGraphIndex(*artifactGraphIndex, *artifactName, *artifactExtractorModel, *inferenceURL, splitCSV(*artifactLabels), splitCSV(*artifactRelationLabels))
+			graphIndex, err := createArtifactGraphIndex(*artifactGraphIndex, *artifactName, *artifactProducer, *artifactExtractorModel, *inferenceURL, splitCSV(*artifactLabels), splitCSV(*artifactRelationLabels))
 			if err != nil {
 				return fmt.Errorf("failed to create artifact graph index config: %w", err)
 			}
@@ -2047,15 +2051,22 @@ func createSearchTableIndexes(embeddingIndex antfly.IndexConfig) (map[string]ant
 	}, nil
 }
 
-func createArtifactGraphIndex(indexName, artifactName, model, inferenceURL string, labels, relationLabels []string) (*antfly.IndexConfig, error) {
+func createArtifactGraphIndex(indexName, artifactName, producerType, model, inferenceURL string, labels, relationLabels []string) (*antfly.IndexConfig, error) {
 	if strings.TrimSpace(indexName) == "" {
 		return nil, fmt.Errorf("artifact graph index name is required")
 	}
 	if strings.TrimSpace(artifactName) == "" {
 		return nil, fmt.Errorf("artifact name is required")
 	}
+	producerType = strings.TrimSpace(strings.ToLower(producerType))
+	if producerType == "" {
+		producerType = DefaultArtifactProducer
+	}
+	if producerType != "extractor" && producerType != "generator" {
+		return nil, fmt.Errorf("artifact producer must be extractor or generator")
+	}
 	if strings.TrimSpace(model) == "" {
-		return nil, fmt.Errorf("artifact generator model is required")
+		return nil, fmt.Errorf("artifact extractor model is required")
 	}
 	inferenceAPIURL, err := inferenceMLBaseURL(inferenceURL)
 	if err != nil {
@@ -2070,6 +2081,12 @@ func createArtifactGraphIndex(indexName, artifactName, model, inferenceURL strin
 
 	relationEnum := append([]string(nil), relationLabels...)
 	labelEnum := append([]string(nil), labels...)
+	relationSchemas := make([]map[string]any, 0, len(relationLabels))
+	for _, label := range relationLabels {
+		relationSchemas = append(relationSchemas, map[string]any{"type": label})
+	}
+
+	producerJSON := artifactProducerConfig(producerType, model, inferenceAPIURL, labelEnum, relationEnum, relationSchemas)
 
 	raw := map[string]any{
 		"name": indexName,
@@ -2081,90 +2098,32 @@ func createArtifactGraphIndex(indexName, artifactName, model, inferenceURL strin
 			"format":   "extraction_relation",
 		},
 		"artifact": map[string]any{
-			"name":         artifactName,
-			"kind":         "asset",
-			"field":        "content",
-			"content_type": "application/json",
-			"producer_json": map[string]any{
-				"type": "generator",
-				"config": map[string]any{
-					"provider":    "antfly",
-					"model":       model,
-					"api_url":     inferenceAPIURL,
-					"tool_output": "arguments",
-					"tool_name":   "emit_relations",
-					"tool_choice": map[string]any{
-						"type": "function",
-						"function": map[string]any{
-							"name": "emit_relations",
-						},
-					},
-					"tools": []map[string]any{
-						{
-							"type": "function",
-							"function": map[string]any{
-								"name":        "emit_relations",
-								"description": "Extract autograph, signature, sender, recipient, and related entity relationships from the document text. Return only relations directly supported by the text.",
-								"parameters": map[string]any{
-									"type":                 "object",
-									"additionalProperties": false,
-									"required":             []string{"relations"},
-									"properties": map[string]any{
-										"relations": map[string]any{
-											"type": "array",
-											"items": map[string]any{
-												"type":                 "object",
-												"additionalProperties": false,
-												"required":             []string{"type", "target"},
-												"properties": map[string]any{
-													"type": map[string]any{
-														"type": "string",
-														"enum": relationEnum,
-													},
-													"source": map[string]any{
-														"type":        "object",
-														"description": "Optional source endpoint. Omit this to use the current document as the source.",
-														"properties": map[string]any{
-															"id":    map[string]any{"type": "string"},
-															"label": map[string]any{"type": "string", "enum": labelEnum},
-															"text":  map[string]any{"type": "string"},
-														},
-													},
-													"target": map[string]any{
-														"type":        "object",
-														"description": "Target endpoint for the relation. Use id for the normalized entity name.",
-														"required":    []string{"id"},
-														"properties": map[string]any{
-															"id":    map[string]any{"type": "string"},
-															"label": map[string]any{"type": "string", "enum": labelEnum},
-															"text":  map[string]any{"type": "string"},
-														},
-													},
-													"confidence": map[string]any{
-														"type":    "number",
-														"minimum": 0,
-														"maximum": 1,
-													},
-													"evidence": map[string]any{
-														"type":        "string",
-														"description": "Short text span or explanation supporting the relation.",
-													},
-												},
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
+			"name":          artifactName,
+			"kind":          "asset",
+			"field":         "content",
+			"content_type":  "application/json",
+			"producer_json": producerJSON,
 		},
 		"algebraic_planning": map[string]any{
 			"bounded_traversal": map[string]any{
 				"law": "provenance_semiring",
 			},
 		},
+	}
+	if producerType == "extractor" {
+		raw["nodes"] = map[string]any{
+			"model":  "document",
+			"target": "{{ _item.target.text }}",
+		}
+		raw["edge"] = map[string]any{
+			"weight": "{{ _item.score }}",
+			"metadata": map[string]any{
+				"type":          "{{ _item.type }}",
+				"source_entity": "{{ _item.source.text }}",
+				"target_entity": "{{ _item.target.text }}",
+				"score":         "{{ _item.score }}",
+			},
+		}
 	}
 
 	encoded, err := json.Marshal(raw)
@@ -2176,6 +2135,101 @@ func createArtifactGraphIndex(indexName, artifactName, model, inferenceURL strin
 		return nil, err
 	}
 	return &cfg, nil
+}
+
+func artifactProducerConfig(producerType, model, inferenceAPIURL string, labels, relationLabels []string, relationSchemas []map[string]any) map[string]any {
+	if producerType == "extractor" {
+		return map[string]any{
+			"type": "extractor",
+			"config": map[string]any{
+				"provider": "antfly",
+				"model":    model,
+				"api_url":  inferenceAPIURL,
+				"schema": map[string]any{
+					"entities":  labels,
+					"relations": relationSchemas,
+				},
+				"options": map[string]any{
+					"include_confidence": true,
+					"include_spans":      true,
+				},
+			},
+		}
+	}
+	return map[string]any{
+		"type": "generator",
+		"config": map[string]any{
+			"provider":    "antfly",
+			"model":       model,
+			"api_url":     inferenceAPIURL,
+			"tool_output": "arguments",
+			"tool_name":   "emit_relations",
+			"tool_choice": map[string]any{
+				"type": "function",
+				"function": map[string]any{
+					"name": "emit_relations",
+				},
+			},
+			"tools": []map[string]any{
+				{
+					"type": "function",
+					"function": map[string]any{
+						"name":        "emit_relations",
+						"description": "Extract autograph, signature, sender, recipient, and related entity relationships from the document text. Return only relations directly supported by the text.",
+						"parameters": map[string]any{
+							"type":                 "object",
+							"additionalProperties": false,
+							"required":             []string{"relations"},
+							"properties": map[string]any{
+								"relations": map[string]any{
+									"type": "array",
+									"items": map[string]any{
+										"type":                 "object",
+										"additionalProperties": false,
+										"required":             []string{"type", "target"},
+										"properties": map[string]any{
+											"type": map[string]any{
+												"type": "string",
+												"enum": relationLabels,
+											},
+											"source": map[string]any{
+												"type":        "object",
+												"description": "Optional source endpoint. Omit this to use the current document as the source.",
+												"properties": map[string]any{
+													"id":    map[string]any{"type": "string"},
+													"label": map[string]any{"type": "string", "enum": labels},
+													"text":  map[string]any{"type": "string"},
+												},
+											},
+											"target": map[string]any{
+												"type":        "object",
+												"description": "Target endpoint for the relation. Use id for the normalized entity name.",
+												"required":    []string{"id"},
+												"properties": map[string]any{
+													"id":    map[string]any{"type": "string"},
+													"label": map[string]any{"type": "string", "enum": labels},
+													"text":  map[string]any{"type": "string"},
+												},
+											},
+											"confidence": map[string]any{
+												"type":    "number",
+												"minimum": 0,
+												"maximum": 1,
+											},
+											"evidence": map[string]any{
+												"type":        "string",
+												"description": "Short text span or explanation supporting the relation.",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
 }
 
 func searchIndexNames() []string {

--- a/examples/epstein/main_test.go
+++ b/examples/epstein/main_test.go
@@ -157,6 +157,7 @@ func TestCreateArtifactGraphIndexIncludesProducerConfig(t *testing.T) {
 	idx, err := createArtifactGraphIndex(
 		DefaultAutographIndex,
 		DefaultAutographAsset,
+		"generator",
 		"gemma4-test",
 		DefaultInferenceURL,
 		[]string{"person", "organization"},
@@ -211,6 +212,51 @@ func TestCreateArtifactGraphIndexIncludesProducerConfig(t *testing.T) {
 	tools, ok := cfg["tools"].([]any)
 	if !ok || len(tools) != 1 {
 		t.Fatalf("tools missing from producer config: %#v", cfg)
+	}
+}
+
+func TestCreateArtifactGraphIndexDefaultsToExtractorConfig(t *testing.T) {
+	idx, err := createArtifactGraphIndex(
+		DefaultAutographIndex,
+		DefaultAutographAsset,
+		"",
+		DefaultRecognizerModel,
+		DefaultInferenceURL,
+		[]string{"person", "organization"},
+		[]string{"communicated with"},
+	)
+	if err != nil {
+		t.Fatalf("createArtifactGraphIndex failed: %v", err)
+	}
+
+	encoded, err := json.Marshal(idx)
+	if err != nil {
+		t.Fatalf("marshal graph index: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(encoded, &got); err != nil {
+		t.Fatalf("unmarshal graph index: %v", err)
+	}
+	artifact := got["artifact"].(map[string]any)
+	producer := artifact["producer_json"].(map[string]any)
+	if producer["type"] != "extractor" {
+		t.Fatalf("producer type = %v, want extractor", producer["type"])
+	}
+	cfg := producer["config"].(map[string]any)
+	if cfg["provider"] != "antfly" || cfg["model"] != DefaultRecognizerModel {
+		t.Fatalf("unexpected extractor config: %#v", cfg)
+	}
+	schema := cfg["schema"].(map[string]any)
+	if len(schema["entities"].([]any)) != 2 || len(schema["relations"].([]any)) != 1 {
+		t.Fatalf("unexpected extractor schema: %#v", schema)
+	}
+	nodes := got["nodes"].(map[string]any)
+	if nodes["target"] != "{{ _item.target.text }}" {
+		t.Fatalf("unexpected extractor node mapping: %#v", nodes)
+	}
+	edge := got["edge"].(map[string]any)
+	if edge["weight"] != "{{ _item.score }}" {
+		t.Fatalf("unexpected extractor edge mapping: %#v", edge)
 	}
 }
 

--- a/examples/epstein/main_test.go
+++ b/examples/epstein/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"archive/zip"
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -10,7 +11,6 @@ import (
 	"testing"
 
 	antfly "github.com/antflydb/antfly/go/pkg/sdk"
-	inferenceoapi "github.com/antflydb/antfly/go/pkg/sdk/oapi"
 	"github.com/pdfcpu/pdfcpu/pkg/api"
 	"github.com/pdfcpu/pdfcpu/pkg/pdfcpu/model"
 )
@@ -133,6 +133,9 @@ func TestCreateEmbeddingIndexUsesAntflyClipClap(t *testing.T) {
 	if cfg.Embedder.Provider != antfly.EmbedderProviderAntfly {
 		t.Fatalf("embedder provider = %q, want %q", cfg.Embedder.Provider, antfly.EmbedderProviderAntfly)
 	}
+	if cfg.Dimension != DefaultEmbeddingDims {
+		t.Fatalf("embedding dimension = %d, want %d", cfg.Dimension, DefaultEmbeddingDims)
+	}
 	if embedder.Model != DefaultEmbeddingModel {
 		t.Fatalf("embedder model = %q, want %q", embedder.Model, DefaultEmbeddingModel)
 	}
@@ -141,9 +144,73 @@ func TestCreateEmbeddingIndexUsesAntflyClipClap(t *testing.T) {
 	if err != nil {
 		t.Fatalf("AsAntflyChunkerConfig failed: %v", err)
 	}
+	if cfg.Chunker.Provider != antfly.ChunkerProviderAntfly {
+		t.Fatalf("chunker provider = %q, want %q", cfg.Chunker.Provider, antfly.ChunkerProviderAntfly)
+	}
 	wantChunkerURL := DefaultInferenceURL + "/ai/v1"
 	if chunker.ApiUrl != wantChunkerURL {
 		t.Fatalf("chunker api URL = %q, want %q", chunker.ApiUrl, wantChunkerURL)
+	}
+}
+
+func TestCreateArtifactGraphIndexIncludesProducerConfig(t *testing.T) {
+	idx, err := createArtifactGraphIndex(
+		DefaultAutographIndex,
+		DefaultAutographAsset,
+		"gemma4-test",
+		DefaultInferenceURL,
+		[]string{"person", "organization"},
+		[]string{"communicated with"},
+	)
+	if err != nil {
+		t.Fatalf("createArtifactGraphIndex failed: %v", err)
+	}
+
+	encoded, err := json.Marshal(idx)
+	if err != nil {
+		t.Fatalf("marshal graph index: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(encoded, &got); err != nil {
+		t.Fatalf("unmarshal graph index: %v", err)
+	}
+	if got["name"] != DefaultAutographIndex {
+		t.Fatalf("name = %v, want %s", got["name"], DefaultAutographIndex)
+	}
+	source, ok := got["source"].(map[string]any)
+	if !ok {
+		t.Fatalf("source missing from graph index: %s", encoded)
+	}
+	if source["artifact"] != DefaultAutographAsset || source["path"] != "$.relations[*]" {
+		t.Fatalf("unexpected source config: %#v", source)
+	}
+	artifact, ok := got["artifact"].(map[string]any)
+	if !ok {
+		t.Fatalf("artifact missing from graph index: %s", encoded)
+	}
+	producer, ok := artifact["producer_json"].(map[string]any)
+	if !ok {
+		t.Fatalf("producer_json missing from artifact config: %#v", artifact)
+	}
+	cfg, ok := producer["config"].(map[string]any)
+	if !ok {
+		t.Fatalf("producer config missing: %#v", producer)
+	}
+	if cfg["provider"] != "antfly" || cfg["model"] != "gemma4-test" {
+		t.Fatalf("unexpected producer config: %#v", cfg)
+	}
+	if cfg["api_url"] != DefaultInferenceURL+"/ai/v1" {
+		t.Fatalf("api_url = %v, want %s", cfg["api_url"], DefaultInferenceURL+"/ai/v1")
+	}
+	if producer["type"] != "generator" {
+		t.Fatalf("producer type = %v, want generator", producer["type"])
+	}
+	if cfg["tool_output"] != "arguments" || cfg["tool_name"] != "emit_relations" {
+		t.Fatalf("unexpected tool output config: %#v", cfg)
+	}
+	tools, ok := cfg["tools"].([]any)
+	if !ok || len(tools) != 1 {
+		t.Fatalf("tools missing from producer config: %#v", cfg)
 	}
 }
 
@@ -177,7 +244,36 @@ func TestInferenceMLBaseURLRejectsLegacyAPI(t *testing.T) {
 	}
 }
 
-func TestCreateSearchTableIndexesIncludesQueriedIndexes(t *testing.T) {
+func TestParseSyncLevelFlag(t *testing.T) {
+	tests := []struct {
+		in   string
+		want antfly.SyncLevel
+	}{
+		{in: "write", want: antfly.SyncLevelWrite},
+		{in: " full_text ", want: antfly.SyncLevelFullText},
+		{in: "aknn", want: antfly.SyncLevelAknn},
+		{in: "embeddings", want: antfly.SyncLevelAknn},
+		{in: "full_index", want: antfly.SyncLevelFullIndex},
+		{in: "enrichments", want: antfly.SyncLevelEnrichments},
+		{in: "propose", want: antfly.SyncLevelPropose},
+	}
+
+	for _, tt := range tests {
+		got, err := parseSyncLevelFlag(tt.in)
+		if err != nil {
+			t.Fatalf("parseSyncLevelFlag(%q) failed: %v", tt.in, err)
+		}
+		if got != tt.want {
+			t.Fatalf("parseSyncLevelFlag(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+
+	if _, err := parseSyncLevelFlag("later"); err == nil {
+		t.Fatalf("parseSyncLevelFlag accepted invalid value")
+	}
+}
+
+func TestCreateSearchTableIndexesUsesServerDefaultFullText(t *testing.T) {
 	embeddingIndex, err := createEmbeddingIndex(DefaultEmbeddingModel, DefaultInferenceURL, DefaultChunkerModel, 512, 50)
 	if err != nil {
 		t.Fatalf("createEmbeddingIndex failed: %v", err)
@@ -186,13 +282,81 @@ func TestCreateSearchTableIndexesIncludesQueriedIndexes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("createSearchTableIndexes failed: %v", err)
 	}
-	for _, name := range searchIndexNames() {
-		if _, ok := indexes[name]; !ok {
-			t.Fatalf("search index %q missing from created table indexes: %#v", name, indexes)
-		}
+	if _, ok := indexes[DefaultEmbeddingIndex]; !ok {
+		t.Fatalf("embedding index missing from created table indexes: %#v", indexes)
 	}
-	if indexes[DefaultFullTextIndex].Type != antfly.IndexTypeFullText {
-		t.Fatalf("full-text index type = %q, want %q", indexes[DefaultFullTextIndex].Type, antfly.IndexTypeFullText)
+	if _, ok := indexes[DefaultFullTextIndex]; ok {
+		t.Fatalf("full-text index should be provided by server default, got explicit config: %#v", indexes[DefaultFullTextIndex])
+	}
+}
+
+func TestStreamJSONPagesNormalizesReservedTypeField(t *testing.T) {
+	input := `{
+  "doc_001": {
+    "_type": "pdf_page",
+    "content": "one",
+    "metadata": {"page_number": 1}
+  },
+  "doc_002": {
+    "_type": "pdf_page",
+    "document_type": "custom_page",
+    "content": "two"
+  }
+}`
+
+	var batches []map[string]any
+	for batch := range streamJSONPages(strings.NewReader(input), 1) {
+		batches = append(batches, batch)
+	}
+	if len(batches) != 2 {
+		t.Fatalf("batch count = %d, want 2", len(batches))
+	}
+
+	first, ok := batches[0]["doc_001"].(map[string]any)
+	if !ok {
+		t.Fatalf("doc_001 has type %T, want map[string]any", batches[0]["doc_001"])
+	}
+	if _, ok := first["_type"]; ok {
+		t.Fatalf("doc_001 still has reserved _type field")
+	}
+	if got := first["document_type"]; got != "pdf_page" {
+		t.Fatalf("doc_001 document_type = %v, want pdf_page", got)
+	}
+	if got := first["content"]; got != "one" {
+		t.Fatalf("doc_001 content = %v, want one", got)
+	}
+
+	second, ok := batches[1]["doc_002"].(map[string]any)
+	if !ok {
+		t.Fatalf("doc_002 has type %T, want map[string]any", batches[1]["doc_002"])
+	}
+	if _, ok := second["_type"]; ok {
+		t.Fatalf("doc_002 still has reserved _type field")
+	}
+	if got := second["document_type"]; got != "custom_page" {
+		t.Fatalf("doc_002 document_type = %v, want custom_page", got)
+	}
+}
+
+func TestStreamJSONPagesWithLimit(t *testing.T) {
+	input := `{
+  "doc_001": {"content": "one"},
+  "doc_002": {"content": "two"},
+  "doc_003": {"content": "three"}
+}`
+
+	var batches []map[string]any
+	for batch := range streamJSONPagesWithLimit(strings.NewReader(input), 2, 1) {
+		batches = append(batches, batch)
+	}
+	if len(batches) != 1 {
+		t.Fatalf("batch count = %d, want 1", len(batches))
+	}
+	if len(batches[0]) != 1 {
+		t.Fatalf("record count = %d, want 1", len(batches[0]))
+	}
+	if _, ok := batches[0]["doc_001"]; !ok {
+		t.Fatalf("limited batch missing first record: %#v", batches[0])
 	}
 }
 
@@ -293,7 +457,7 @@ func TestSplitEntityWindowsRebasesAndOverlaps(t *testing.T) {
 }
 
 func TestOffsetAndDedupeEntities(t *testing.T) {
-	entities := []inferenceoapi.InferenceRecognizeEntity{
+	entities := []recognizedEntity{
 		{Text: "Jane", Label: "person", Start: 2, End: 6, Score: 0.2},
 		{Text: "Jane", Label: "person", Start: 2, End: 6, Score: 0.9},
 	}
@@ -312,9 +476,9 @@ func TestOffsetAndDedupeEntities(t *testing.T) {
 }
 
 func TestDedupeRelationsKeepsHighestScore(t *testing.T) {
-	head := inferenceoapi.InferenceRecognizeEntity{Text: "Jane", Label: "person", Start: 12, End: 16}
-	tail := inferenceoapi.InferenceRecognizeEntity{Text: "Acme", Label: "organization", Start: 25, End: 29}
-	relations := dedupeRelations([]inferenceoapi.InferenceRelation{
+	head := recognizedEntity{Text: "Jane", Label: "person", Start: 12, End: 16}
+	tail := recognizedEntity{Text: "Acme", Label: "organization", Start: 25, End: 29}
+	relations := dedupeRelations([]recognizedRelation{
 		{Head: head, Tail: tail, Label: "worked for", Score: 0.4},
 		{Head: head, Tail: tail, Label: "worked for", Score: 0.8},
 	})

--- a/go/pkg/sdk/types.go
+++ b/go/pkg/sdk/types.go
@@ -335,6 +335,7 @@ const (
 	GeneratorProviderMock      = oapi.GeneratorProviderMock
 	RerankerProviderAntfly     = oapi.RerankerProviderAntfly
 	RerankerProviderOllama     = oapi.RerankerProviderOllama
+	ChunkerProviderAntfly      = oapi.ChunkerProviderAntfly
 
 	// MergeStrategy values
 	MergeStrategyRrf      = oapi.MergeStrategyRrf
@@ -347,10 +348,12 @@ const (
 	LinearMergePageStatusError   = oapi.LinearMergePageStatusError
 
 	// SyncLevel values
-	SyncLevelPropose  = oapi.SyncLevelPropose
-	SyncLevelWrite    = oapi.SyncLevelWrite
-	SyncLevelFullText = oapi.SyncLevelFullText
-	SyncLevelAknn     = oapi.SyncLevelAknn
+	SyncLevelPropose     = oapi.SyncLevelPropose
+	SyncLevelWrite       = oapi.SyncLevelWrite
+	SyncLevelFullText    = oapi.SyncLevelFullText
+	SyncLevelAknn        = oapi.SyncLevelAknn
+	SyncLevelFullIndex   = oapi.SyncLevelFullIndex
+	SyncLevelEnrichments = oapi.SyncLevelEnrichments
 
 	// RouteType values
 	RouteTypeQuestion = oapi.RouteTypeQuestion

--- a/zig/lib/generating/src/mod.zig
+++ b/zig/lib/generating/src/mod.zig
@@ -57,6 +57,13 @@ pub const ToolCall = struct {
     id: []const u8,
     name: []const u8,
     arguments: []const u8,
+
+    pub fn deinit(self: *ToolCall, allocator: std.mem.Allocator) void {
+        allocator.free(self.id);
+        allocator.free(self.name);
+        allocator.free(self.arguments);
+        self.* = undefined;
+    }
 };
 
 pub const ChatMessage = struct {
@@ -68,10 +75,13 @@ pub const ChatMessage = struct {
 
 pub const GenerateResult = struct {
     content: []const u8,
+    tool_calls: []ToolCall = &.{},
     allocator: std.mem.Allocator,
 
     pub fn deinit(self: *GenerateResult) void {
         self.allocator.free(self.content);
+        for (self.tool_calls) |*tool_call| tool_call.deinit(self.allocator);
+        if (self.tool_calls.len > 0) self.allocator.free(self.tool_calls);
         self.* = undefined;
     }
 };
@@ -113,6 +123,8 @@ pub const GeneratorConfig = struct {
     project_id: ?[]const u8 = null,
     location: ?[]const u8 = null,
     credentials_path: ?[]const u8 = null,
+    tools_json: ?[]const u8 = null,
+    tool_choice_json: ?[]const u8 = null,
 
     pub fn clone(self: GeneratorConfig, alloc: std.mem.Allocator) !GeneratorConfig {
         return .{
@@ -123,6 +135,8 @@ pub const GeneratorConfig = struct {
             .project_id = if (self.project_id) |value| try alloc.dupe(u8, value) else null,
             .location = if (self.location) |value| try alloc.dupe(u8, value) else null,
             .credentials_path = if (self.credentials_path) |value| try alloc.dupe(u8, value) else null,
+            .tools_json = if (self.tools_json) |value| try alloc.dupe(u8, value) else null,
+            .tool_choice_json = if (self.tool_choice_json) |value| try alloc.dupe(u8, value) else null,
         };
     }
 
@@ -133,6 +147,8 @@ pub const GeneratorConfig = struct {
         if (self.project_id) |value| alloc.free(value);
         if (self.location) |value| alloc.free(value);
         if (self.credentials_path) |value| alloc.free(value);
+        if (self.tools_json) |value| alloc.free(value);
+        if (self.tool_choice_json) |value| alloc.free(value);
         self.* = undefined;
     }
 

--- a/zig/pkg/antfly/src/api/linear_merge.zig
+++ b/zig/pkg/antfly/src/api/linear_merge.zig
@@ -48,7 +48,7 @@ pub fn parseRequest(alloc: std.mem.Allocator, body: []const u8) !OwnedLinearMerg
 
     const root = parsed.value.object;
     const records_value = root.get("records") orelse return error.InvalidLinearMergeRequest;
-    if (records_value != .object or records_value.object.count() == 0) return error.InvalidLinearMergeRequest;
+    if (records_value != .object) return error.InvalidLinearMergeRequest;
 
     const writes = try alloc.alloc(db_mod.types.BatchWrite, records_value.object.count());
     var initialized: usize = 0;
@@ -87,6 +87,8 @@ pub fn parseRequest(alloc: std.mem.Allocator, body: []const u8) !OwnedLinearMerg
         try parseSyncLevel(value)
     else
         db_mod.types.SyncLevel.write;
+
+    if (writes.len == 0 and last_merged_id.len == 0) return error.InvalidLinearMergeRequest;
 
     for (writes) |write| {
         if (last_merged_id.len > 0 and !std.mem.lessThan(u8, last_merged_id, write.key)) {
@@ -135,8 +137,6 @@ pub fn executeResponse(
     table_name: []const u8,
     req: OwnedLinearMergeRequest,
 ) !Response {
-    if (req.writes.len == 0) return error.InvalidLinearMergeRequest;
-
     var request_keys = std.StringHashMapUnmanaged(void){};
     defer request_keys.deinit(alloc);
     for (req.writes) |write| try request_keys.put(alloc, write.key, {});
@@ -159,12 +159,12 @@ pub fn executeResponse(
         }
     }
 
-    const next_cursor = req.writes[req.writes.len - 1].key;
+    const next_cursor = if (req.writes.len > 0) req.writes[req.writes.len - 1].key else req.last_merged_id;
     var scanned = (try reads.scan(
         alloc,
         table_name,
         req.last_merged_id,
-        next_cursor,
+        if (req.writes.len > 0) next_cursor else "",
         .{
             .inclusive_from = false,
             .exclusive_to = false,
@@ -361,6 +361,22 @@ test "linear merge request parser accepts raw payload value under public request
 
     try std.testing.expectEqual(@as(usize, 1), req.writes.len);
     try std.testing.expect(std.mem.indexOf(u8, req.writes[0].value, "\"raw_payload\"") != null);
+}
+
+test "linear merge request parser accepts explicit final cleanup" {
+    var req = try parseRequest(std.testing.allocator,
+        \\{"records":{},"last_merged_id":"doc:z","sync_level":"write"}
+    );
+    defer req.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 0), req.writes.len);
+    try std.testing.expectEqualStrings("doc:z", req.last_merged_id);
+    try std.testing.expectEqual(db_mod.types.SyncLevel.write, req.sync_level);
+}
+
+test "linear merge request parser rejects unbounded empty cleanup" {
+    try std.testing.expectError(error.InvalidLinearMergeRequest, parseRequest(std.testing.allocator,
+        \\{"records":{},"sync_level":"write"}
+    ));
 }
 
 test "linear merge equality ignores system timestamp" {

--- a/zig/pkg/antfly/src/asset_producer_runtime.zig
+++ b/zig/pkg/antfly/src/asset_producer_runtime.zig
@@ -104,8 +104,9 @@ pub const Runtime = struct {
     }
 
     fn generate(self: *Runtime, alloc: Allocator, request: asset_producer.Request) ![]u8 {
-        var cfg = try generating_runtime.parseConfigFromSlice(alloc, request.config_json);
-        defer cfg.deinit(alloc);
+        var parsed_cfg = try parseGeneratorProducerConfig(alloc, request.config_json);
+        defer parsed_cfg.deinit(alloc);
+        const cfg = parsed_cfg.generator;
         var parts: ?[]generating_runtime.ContentPart = null;
         defer if (parts) |items| freeGeneratorContentParts(alloc, items);
         const content: generating_runtime.ChatMessageContent = if (request.source_parts_json) |raw_parts| blk: {
@@ -121,6 +122,9 @@ pub const Runtime = struct {
             .{ .role = .user, .content = content },
         });
         defer result.deinit();
+        if (parsed_cfg.tool_output == .arguments) {
+            return try toolCallArgumentsOutputAlloc(alloc, result.tool_calls, parsed_cfg.tool_name);
+        }
         return try alloc.dupe(u8, result.content);
     }
 
@@ -236,6 +240,118 @@ pub const Runtime = struct {
         return try alloc.dupe(u8, response.json);
     }
 };
+
+const GeneratorToolOutput = enum {
+    arguments,
+    content,
+};
+
+const GeneratorProducerConfig = struct {
+    generator: generating_runtime.GeneratorConfig,
+    parsed: std.json.Parsed(std.json.Value),
+    tool_choice: ?std.json.Value = null,
+    tool_name: ?[]const u8 = null,
+    tool_output: GeneratorToolOutput = .content,
+
+    fn deinit(self: *GeneratorProducerConfig, alloc: Allocator) void {
+        self.generator.deinit(alloc);
+        self.parsed.deinit();
+        self.* = undefined;
+    }
+};
+
+fn parseGeneratorProducerConfig(alloc: Allocator, raw: []const u8) !GeneratorProducerConfig {
+    var parsed = try std.json.parseFromSlice(std.json.Value, alloc, raw, .{});
+    errdefer parsed.deinit();
+    if (parsed.value != .object) return error.InvalidGeneratorConfig;
+
+    var cfg = try generatorConfigFromValue(alloc, parsed.value);
+    errdefer cfg.deinit(alloc);
+
+    const tools = parsed.value.object.get("tools");
+    const tool_choice = parsed.value.object.get("tool_choice");
+    const tool_name = if (parsed.value.object.get("tool_name")) |value|
+        if (value == .string) value.string else null
+    else
+        forcedToolName(tool_choice);
+    const tool_output = if (parsed.value.object.get("tool_output")) |value| blk: {
+        if (value != .string) return error.InvalidGeneratorToolConfig;
+        if (std.mem.eql(u8, value.string, "arguments")) break :blk GeneratorToolOutput.arguments;
+        if (std.mem.eql(u8, value.string, "content")) break :blk GeneratorToolOutput.content;
+        return error.InvalidGeneratorToolConfig;
+    } else if (tools != null) GeneratorToolOutput.arguments else GeneratorToolOutput.content;
+
+    return .{
+        .generator = cfg,
+        .parsed = parsed,
+        .tool_choice = tool_choice,
+        .tool_name = tool_name,
+        .tool_output = tool_output,
+    };
+}
+
+fn generatorConfigFromValue(alloc: Allocator, value: std.json.Value) !generating_runtime.GeneratorConfig {
+    if (value != .object) return error.InvalidGeneratorConfig;
+    const provider_value = value.object.get("provider") orelse return error.InvalidGeneratorConfig;
+    if (provider_value != .string) return error.InvalidGeneratorConfig;
+    const provider = generatorProviderFromString(provider_value.string) orelse return error.UnsupportedGeneratorProvider;
+
+    const model = jsonStringField(value, "model") orelse "";
+    const url = jsonStringField(value, "url") orelse jsonStringField(value, "api_url") orelse "";
+    var cfg = generating_runtime.GeneratorConfig{
+        .provider = provider,
+        .model = if (model.len > 0) try alloc.dupe(u8, model) else "",
+        .url = if (url.len > 0) try alloc.dupe(u8, url) else "",
+        .api_key = if (jsonStringField(value, "api_key")) |text| try alloc.dupe(u8, text) else null,
+        .project_id = if (jsonStringField(value, "project_id")) |text| try alloc.dupe(u8, text) else null,
+        .location = if (jsonStringField(value, "location")) |text| try alloc.dupe(u8, text) else null,
+        .credentials_path = if (jsonStringField(value, "credentials_path")) |text| try alloc.dupe(u8, text) else null,
+        .tools_json = if (value.object.get("tools")) |tools| try std.json.Stringify.valueAlloc(alloc, tools, .{}) else null,
+        .tool_choice_json = if (value.object.get("tool_choice")) |tool_choice| try std.json.Stringify.valueAlloc(alloc, tool_choice, .{}) else null,
+    };
+    errdefer cfg.deinit(alloc);
+    try cfg.validate();
+    return cfg;
+}
+
+fn generatorProviderFromString(value: []const u8) ?generating_runtime.Provider {
+    if (std.mem.eql(u8, value, "gemini")) return .gemini;
+    if (std.mem.eql(u8, value, "vertex")) return .vertex;
+    if (std.mem.eql(u8, value, "openai")) return .openai;
+    if (std.mem.eql(u8, value, "ollama")) return .ollama;
+    if (std.mem.eql(u8, value, "antfly")) return .antfly;
+    if (std.mem.eql(u8, value, "mock")) return .mock;
+    return null;
+}
+
+fn jsonStringField(value: std.json.Value, field: []const u8) ?[]const u8 {
+    if (value != .object) return null;
+    const found = value.object.get(field) orelse return null;
+    return if (found == .string) found.string else null;
+}
+
+fn forcedToolName(tool_choice: ?std.json.Value) ?[]const u8 {
+    const choice = tool_choice orelse return null;
+    switch (choice) {
+        .object => |obj| {
+            const function = obj.get("function") orelse return null;
+            if (function != .object) return null;
+            const name = function.object.get("name") orelse return null;
+            return if (name == .string) name.string else null;
+        },
+        else => return null,
+    }
+}
+
+fn toolCallArgumentsOutputAlloc(alloc: Allocator, calls: []const generating_runtime.ToolCall, expected_name: ?[]const u8) ![]u8 {
+    for (calls) |call| {
+        if (expected_name) |name| {
+            if (!std.mem.eql(u8, call.name, name)) continue;
+        }
+        return try alloc.dupe(u8, call.arguments);
+    }
+    return error.MissingToolCall;
+}
 
 fn isLocalReaderProvider(provider: readers.Provider, url: ?[]const u8) bool {
     return provider == .antfly and url == null;
@@ -527,6 +643,127 @@ test "asset producer runtime passes rendered media parts to generators" {
     if (run_err) |err| return err;
     defer alloc.free(result.?);
     try std.testing.expectEqualStrings("vision result", result.?);
+}
+
+fn expectOpenAiToolGeneratorRequest(req: httpx.testing_mod.RequestInfo) !void {
+    try std.testing.expectEqual(.POST, req.method);
+    try std.testing.expect(std.mem.indexOf(u8, req.body, "\"tools\":[") != null);
+    try std.testing.expect(std.mem.indexOf(u8, req.body, "\"tool_choice\":{\"type\":\"function\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, req.body, "\"name\":\"emit_relations\"") != null);
+}
+
+test "asset producer runtime stores generator tool call arguments" {
+    const alloc = std.testing.allocator;
+    var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
+    defer io_impl.deinit();
+    const io = io_impl.io();
+
+    var server = try httpx.TestServer.start(alloc, io, &.{
+        .{ .method = .POST, .path = "/chat/completions", .assert_request = expectOpenAiToolGeneratorRequest, .respond = .{
+            .body =
+            \\{"choices":[{"message":{"role":"assistant","content":null,"tool_calls":[{"id":"call_1","type":"function","function":{"name":"emit_relations","arguments":"{\"relations\":[{\"type\":\"signed\",\"target\":{\"id\":\"Ada\"}}]}"}}]}}]}
+            ,
+        } },
+    });
+    defer server.deinit();
+
+    var client = httpx.Client.initWithConfig(alloc, io, .{ .keep_alive = false });
+    defer client.deinit();
+    var runtime = Runtime.init(alloc, &client);
+    const producer = runtime.producer();
+
+    const cfg_json = try std.fmt.allocPrint(alloc,
+        \\{{"provider":"openai","model":"gemma4","url":"{s}","tool_output":"arguments","tool_name":"emit_relations","tool_choice":{{"type":"function","function":{{"name":"emit_relations"}}}},"tools":[{{"type":"function","function":{{"name":"emit_relations","parameters":{{"type":"object"}}}}}}]}}
+    , .{server.baseUrl()});
+    defer alloc.free(cfg_json);
+
+    var result: ?[]u8 = null;
+    var run_err: ?anyerror = null;
+    var group = std.Io.Group.init;
+
+    const Fiber = struct {
+        fn run(
+            a: Allocator,
+            p: asset_producer.Producer,
+            cfg: []const u8,
+            out: *?[]u8,
+            err_out: *?anyerror,
+        ) std.Io.Cancelable!void {
+            out.* = p.produce(a, .{
+                .producer_type = .generator,
+                .config_json = cfg,
+                .source_text = "signed by Ada",
+                .content_type = "application/json",
+            }) catch |err| {
+                err_out.* = err;
+                return;
+            };
+        }
+    };
+
+    try group.concurrent(io, Fiber.run, .{ alloc, producer, cfg_json, &result, &run_err });
+    try server.handleOne();
+    try group.await(io);
+    if (run_err) |err| return err;
+    defer alloc.free(result.?);
+    try std.testing.expectEqualStrings("{\"relations\":[{\"type\":\"signed\",\"target\":{\"id\":\"Ada\"}}]}", result.?);
+}
+
+test "asset producer runtime stores forced tool arguments from plain json content" {
+    const alloc = std.testing.allocator;
+    var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
+    defer io_impl.deinit();
+    const io = io_impl.io();
+
+    var server = try httpx.TestServer.start(alloc, io, &.{
+        .{ .method = .POST, .path = "/chat/completions", .assert_request = expectOpenAiToolGeneratorRequest, .respond = .{
+            .body =
+            \\{"choices":[{"message":{"role":"assistant","content":"{\"relations\":[{\"type\":\"mentioned in\",\"target\":{\"id\":\"Ada\"}}]}"}}]}
+            ,
+        } },
+    });
+    defer server.deinit();
+
+    var client = httpx.Client.initWithConfig(alloc, io, .{ .keep_alive = false });
+    defer client.deinit();
+    var runtime = Runtime.init(alloc, &client);
+    const producer = runtime.producer();
+
+    const cfg_json = try std.fmt.allocPrint(alloc,
+        \\{{"provider":"openai","model":"gemma4","url":"{s}","tool_output":"arguments","tool_name":"emit_relations","tool_choice":{{"type":"function","function":{{"name":"emit_relations"}}}},"tools":[{{"type":"function","function":{{"name":"emit_relations","parameters":{{"type":"object"}}}}}}]}}
+    , .{server.baseUrl()});
+    defer alloc.free(cfg_json);
+
+    var result: ?[]u8 = null;
+    var run_err: ?anyerror = null;
+    var group = std.Io.Group.init;
+
+    const Fiber = struct {
+        fn run(
+            a: Allocator,
+            p: asset_producer.Producer,
+            cfg: []const u8,
+            out: *?[]u8,
+            err_out: *?anyerror,
+        ) std.Io.Cancelable!void {
+            out.* = p.produce(a, .{
+                .producer_type = .generator,
+                .config_json = cfg,
+                .source_text = "mentioned Ada",
+                .content_type = "application/json",
+            }) catch |err| {
+                err_out.* = err;
+                return;
+            };
+        }
+    };
+
+    try group.concurrent(io, Fiber.run, .{ alloc, producer, cfg_json, &result, &run_err });
+    try server.handleOne();
+    try group.await(io);
+    if (run_err) |err| return err;
+    defer alloc.free(result.?);
+    try std.testing.expectEqualStrings("{\"relations\":[{\"type\":\"mentioned in\",\"target\":{\"id\":\"Ada\"}}]}", result.?);
 }
 
 test "asset producer runtime routes antfly reader without url to local provider" {

--- a/zig/pkg/antfly/src/data/runtime.zig
+++ b/zig/pkg/antfly/src/data/runtime.zig
@@ -44,6 +44,7 @@ const runtime_status_refresh_max_db_opens_per_run: usize = 16;
 const runtime_status_disk_usage_refresh_interval_ns: u64 = 30 * std.time.ns_per_s;
 const auto_bulk_finish_poll_interval_ms: u64 = 250;
 const provisioned_startup_catch_up_interval_ms: u64 = std.time.ms_per_s;
+const metrics_lsm_maintenance_snapshot_ttl_ns: u64 = 60 * std.time.ns_per_s;
 const data_raft_batch_leader_wait_ns: u64 = 25 * std.time.ns_per_s;
 const data_raft_batch_leader_retry_sleep_ns: u64 = 50 * std.time.ns_per_ms;
 const data_raft_metadata_resync_interval_ns: u64 = 500 * std.time.ns_per_ms;
@@ -322,6 +323,19 @@ const RaftTableApplyStateMachine = struct {
 /// remote metadata API.
 pub const HealthSource = struct {
     data_server: *DataServer,
+    lsm_maintenance_metrics_mutex: std.atomic.Mutex = .unlocked,
+    lsm_maintenance_metrics_stats: lsm_backend_mod.Backend.MaintenanceStats = .{},
+    lsm_maintenance_metrics_built_at_ns: u64 = 0,
+    lsm_maintenance_metrics_last_refresh_duration_ns: u64 = 0,
+    lsm_maintenance_metrics_refreshes: u64 = 0,
+    lsm_maintenance_metrics_refreshing: bool = false,
+
+    const CachedLsmMaintenanceStats = struct {
+        stats: lsm_backend_mod.Backend.MaintenanceStats,
+        age_ns: u64,
+        last_refresh_duration_ns: u64,
+        refreshes: u64,
+    };
 
     pub fn readiness(self: *HealthSource) antfly.common.health_server.ReadinessChecker {
         return .{
@@ -466,13 +480,62 @@ pub const HealthSource = struct {
         try health_metrics.appendPromMetric(writer, "antfly_lsm_maintenance_background_bulk_deferred_total", "counter", "Data server LSM maintenance background wake cycles deferred behind active bulk ingest", self.data_server.lsm_maintenance_bulk_deferred.load(.monotonic));
         try health_metrics.appendPromMetric(writer, "antfly_lsm_maintenance_background_lock_deferred_total", "counter", "Data server LSM maintenance background wake cycles deferred behind foreground locks", self.data_server.lsm_maintenance_lock_deferred.load(.monotonic));
         try health_metrics.appendPromMetric(writer, "antfly_lsm_maintenance_background_next_eligible_ns", "gauge", "Monotonic timestamp when background LSM maintenance can next run", self.data_server.lsm_maintenance_next_eligible_ns.load(.monotonic));
-        try writeLsmMaintenanceMetrics(writer, self.data_server.write_source.lsmMaintenanceStatsBestEffort());
+        const lsm_maintenance_stats = self.cachedLsmMaintenanceStats();
+        try writeLsmMaintenanceSnapshotMetrics(writer, lsm_maintenance_stats);
+        try writeLsmMaintenanceMetrics(writer, lsm_maintenance_stats.stats);
         try writeLsmWriteMetrics(writer, self.data_server.write_source.lsmWriteStatsBestEffort());
         try writeTextMergeMetrics(writer, self.data_server.write_source.textMergeStatsBestEffort());
         try writeAsyncIndexingMetrics(writer, self.data_server.write_source.asyncIndexingStatsBestEffort());
         try antfly.db.query_metrics.writePrometheus(writer);
     }
+
+    fn cachedLsmMaintenanceStats(self: *HealthSource) CachedLsmMaintenanceStats {
+        const now_ns: u64 = @intCast(platform_time.monotonicNs());
+        var should_refresh = false;
+        lockAtomic(&self.lsm_maintenance_metrics_mutex);
+        if ((self.lsm_maintenance_metrics_built_at_ns == 0 or ageSinceNs(now_ns, self.lsm_maintenance_metrics_built_at_ns) >= metrics_lsm_maintenance_snapshot_ttl_ns) and !self.lsm_maintenance_metrics_refreshing) {
+            self.lsm_maintenance_metrics_refreshing = true;
+            should_refresh = true;
+        }
+        const cached = self.lsmMaintenanceStatsSnapshotLocked(now_ns);
+        self.lsm_maintenance_metrics_mutex.unlock();
+        if (!should_refresh) return cached;
+
+        const refresh_started_ns: u64 = @intCast(platform_time.monotonicNs());
+        const refreshed_stats = self.data_server.write_source.lsmMaintenanceStatsBestEffort();
+        const refresh_finished_ns: u64 = @intCast(platform_time.monotonicNs());
+
+        lockAtomic(&self.lsm_maintenance_metrics_mutex);
+        self.lsm_maintenance_metrics_stats = refreshed_stats;
+        self.lsm_maintenance_metrics_built_at_ns = refresh_finished_ns;
+        self.lsm_maintenance_metrics_last_refresh_duration_ns = refresh_finished_ns - refresh_started_ns;
+        self.lsm_maintenance_metrics_refreshes += 1;
+        self.lsm_maintenance_metrics_refreshing = false;
+        const refreshed = self.lsmMaintenanceStatsSnapshotLocked(refresh_finished_ns);
+        self.lsm_maintenance_metrics_mutex.unlock();
+        return refreshed;
+    }
+
+    fn lsmMaintenanceStatsSnapshotLocked(self: *const HealthSource, now_ns: u64) CachedLsmMaintenanceStats {
+        return .{
+            .stats = self.lsm_maintenance_metrics_stats,
+            .age_ns = ageSinceNs(now_ns, self.lsm_maintenance_metrics_built_at_ns),
+            .last_refresh_duration_ns = self.lsm_maintenance_metrics_last_refresh_duration_ns,
+            .refreshes = self.lsm_maintenance_metrics_refreshes,
+        };
+    }
 };
+
+fn ageSinceNs(now_ns: u64, built_at_ns: u64) u64 {
+    if (built_at_ns == 0 or now_ns < built_at_ns) return 0;
+    return now_ns - built_at_ns;
+}
+
+fn writeLsmMaintenanceSnapshotMetrics(writer: *std.Io.Writer, snapshot: HealthSource.CachedLsmMaintenanceStats) !void {
+    try health_metrics.appendPromMetric(writer, "antfly_metrics_lsm_snapshot_age_seconds", "gauge", "Age of the cached LSM maintenance metrics snapshot", snapshot.age_ns / std.time.ns_per_s);
+    try health_metrics.appendPromMetric(writer, "antfly_metrics_lsm_snapshot_refreshes_total", "counter", "Cached LSM maintenance metrics snapshot refreshes completed", snapshot.refreshes);
+    try health_metrics.appendPromMetric(writer, "antfly_metrics_lsm_snapshot_last_refresh_duration_ns", "gauge", "Duration of the most recent LSM maintenance metrics snapshot refresh in monotonic nanoseconds", snapshot.last_refresh_duration_ns);
+}
 
 fn writeLsmMaintenanceMetrics(writer: *std.Io.Writer, stats: lsm_backend_mod.Backend.MaintenanceStats) !void {
     try health_metrics.appendPromMetric(writer, "antfly_lsm_mutable_entries", "gauge", "Cached write LSM active mutable memtable entries", stats.mutable_entries);
@@ -12987,6 +13050,9 @@ test "data runtime health metrics include replay debt and provisioned warmup cou
     try std.testing.expect(std.mem.indexOf(u8, output, "antfly_data_provisioned_read_cache_misses_total") != null);
     try std.testing.expect(std.mem.indexOf(u8, output, "antfly_data_provisioned_write_cache_hits_total") != null);
     try std.testing.expect(std.mem.indexOf(u8, output, "antfly_data_provisioned_write_cache_misses_total") != null);
+    try std.testing.expect(std.mem.indexOf(u8, output, "antfly_metrics_lsm_snapshot_age_seconds") != null);
+    try std.testing.expect(std.mem.indexOf(u8, output, "antfly_metrics_lsm_snapshot_refreshes_total 1") != null);
+    try std.testing.expect(std.mem.indexOf(u8, output, "antfly_metrics_lsm_snapshot_last_refresh_duration_ns") != null);
     try std.testing.expect(std.mem.indexOf(u8, output, "antfly_lsm_mutable_bytes 0") != null);
     try std.testing.expect(std.mem.indexOf(u8, output, "antfly_lsm_immutable_memtables 0") != null);
     try std.testing.expect(std.mem.indexOf(u8, output, "antfly_lsm_immutable_bytes 0") != null);

--- a/zig/pkg/antfly/src/generating/mod.zig
+++ b/zig/pkg/antfly/src/generating/mod.zig
@@ -25,6 +25,7 @@ const common_secrets = @import("../common/secrets.zig");
 pub const Role = lib.Role;
 pub const ContentPart = lib.ContentPart;
 pub const ChatMessageContent = lib.ChatMessageContent;
+pub const ToolCall = lib.ToolCall;
 pub const ChatMessage = lib.ChatMessage;
 pub const GenerateResult = lib.GenerateResult;
 pub const Provider = lib.Provider;
@@ -190,6 +191,7 @@ const BackendState = struct {
                         try provider.setAuthorizationHeader(auth_header);
                     }
                 }
+                provider.setToolOptions(self.cfg.tools_json, self.cfg.tool_choice_json);
                 break :blk try provider.generator().generate(alloc, model, messages);
             },
             .remote_antfly => |*provider| blk: {
@@ -199,6 +201,7 @@ const BackendState = struct {
                         try provider.setAuthorizationHeader(auth_header);
                     }
                 }
+                provider.setToolOptions(self.cfg.tools_json, self.cfg.tool_choice_json);
                 break :blk try provider.generator().generate(alloc, model, messages);
             },
             .vertex => |*provider| try provider.generator().generate(alloc, model, messages),
@@ -231,10 +234,25 @@ const BackendState = struct {
 
         return .{
             .content = try alloc.dupe(u8, result.content),
+            .tool_calls = try cloneToolCalls(alloc, result.tool_calls),
             .allocator = alloc,
         };
     }
 };
+
+fn cloneToolCalls(alloc: std.mem.Allocator, calls: []const inference.types.ToolCall) ![]lib.ToolCall {
+    if (calls.len == 0) return &.{};
+    const out = try alloc.alloc(lib.ToolCall, calls.len);
+    errdefer alloc.free(out);
+    for (calls, 0..) |call, i| {
+        out[i] = .{
+            .id = try alloc.dupe(u8, call.id),
+            .name = try alloc.dupe(u8, call.name),
+            .arguments = try alloc.dupe(u8, call.arguments),
+        };
+    }
+    return out;
+}
 
 fn optionalBearerAuthHeaderOwned(
     state: *BackendState,

--- a/zig/pkg/antfly/src/inference/local.zig
+++ b/zig/pkg/antfly/src/inference/local.zig
@@ -39,6 +39,8 @@ pub const Provider = struct {
     http: *httpx.Client,
     base_url: []const u8,
     auth_header: ?[2][]const u8 = null,
+    tools_json: ?[]const u8 = null,
+    tool_choice_json: ?[]const u8 = null,
 
     pub fn init(allocator: std.mem.Allocator, http: *httpx.Client, base_url: []const u8) Provider {
         return .{
@@ -67,6 +69,11 @@ pub const Provider = struct {
             self.allocator.free(h[1]);
         }
         self.auth_header = .{ "Authorization", try self.allocator.dupe(u8, auth_header) };
+    }
+
+    pub fn setToolOptions(self: *Provider, tools_json: ?[]const u8, tool_choice_json: ?[]const u8) void {
+        self.tools_json = tools_json;
+        self.tool_choice_json = tool_choice_json;
     }
 
     fn authHeaders(self: *const Provider) ?[]const [2][]const u8 {
@@ -278,13 +285,23 @@ pub const Provider = struct {
             choices: []const struct {
                 message: struct {
                     content: ?[]const u8 = null,
+                    tool_calls: ?[]const struct {
+                        id: ?[]const u8 = null,
+                        function: struct {
+                            name: []const u8,
+                            arguments: []const u8,
+                        },
+                    } = null,
                 },
             },
         };
 
         const url = try std.fmt.allocPrint(self.allocator, "{s}/generate", .{self.base_url});
         defer self.allocator.free(url);
-        const json_body = try inference.chatRequestJsonAlloc(self.allocator, model, messages, .termite_native);
+        const json_body = try inference.chatRequestJsonWithOptionsAlloc(self.allocator, model, messages, .termite_native, .{
+            .tools_json = self.tools_json,
+            .tool_choice_json = self.tool_choice_json,
+        });
         defer self.allocator.free(json_body);
         var resp = try self.http.post(url, .{
             .json = json_body,
@@ -298,12 +315,38 @@ pub const Provider = struct {
         defer parsed.deinit();
         const choices = parsed.value.choices;
         if (choices.len == 0) return error.EmptyResponse;
-        const content = choices[0].message.content orelse return error.EmptyResponse;
+        var tool_calls = try cloneOpenAIToolCalls(alloc, choices[0].message.tool_calls);
+        errdefer freeToolCalls(alloc, tool_calls);
+        const content = choices[0].message.content orelse "";
+        if (tool_calls.len == 0 and content.len > 0) {
+            tool_calls = try inference.synthesizeForcedToolCallFromContent(alloc, content, self.tools_json, self.tool_choice_json);
+        }
+        if (content.len == 0 and tool_calls.len == 0) return error.EmptyResponse;
 
         return .{
             .content = try alloc.dupe(u8, content),
+            .tool_calls = tool_calls,
             .allocator = alloc,
         };
+    }
+
+    fn cloneOpenAIToolCalls(alloc: std.mem.Allocator, maybe_calls: anytype) ![]inference.ToolCall {
+        const calls = maybe_calls orelse return &.{};
+        const out = try alloc.alloc(inference.ToolCall, calls.len);
+        errdefer alloc.free(out);
+        for (calls, 0..) |call, i| {
+            out[i] = .{
+                .id = try alloc.dupe(u8, call.id orelse ""),
+                .name = try alloc.dupe(u8, call.function.name),
+                .arguments = try alloc.dupe(u8, call.function.arguments),
+            };
+        }
+        return out;
+    }
+
+    fn freeToolCalls(alloc: std.mem.Allocator, calls: []inference.ToolCall) void {
+        for (calls) |*call| call.deinit(alloc);
+        if (calls.len > 0) alloc.free(calls);
     }
 
     fn rerankImpl(ptr: *anyopaque, alloc: std.mem.Allocator, model: []const u8, query: []const u8, documents: []const []const u8) anyerror!inference.RerankResult {

--- a/zig/pkg/antfly/src/inference/openai.zig
+++ b/zig/pkg/antfly/src/inference/openai.zig
@@ -27,6 +27,8 @@ pub const Provider = struct {
     http: *httpx.Client,
     base_url: []const u8,
     auth_header: ?[2][]const u8 = null,
+    tools_json: ?[]const u8 = null,
+    tool_choice_json: ?[]const u8 = null,
 
     pub fn init(allocator: std.mem.Allocator, http: *httpx.Client, base_url: []const u8) Provider {
         return .{
@@ -56,6 +58,11 @@ pub const Provider = struct {
             self.allocator.free(h[1]);
         }
         self.auth_header = .{ "Authorization", try self.allocator.dupe(u8, auth_header) };
+    }
+
+    pub fn setToolOptions(self: *Provider, tools_json: ?[]const u8, tool_choice_json: ?[]const u8) void {
+        self.tools_json = tools_json;
+        self.tool_choice_json = tool_choice_json;
     }
 
     pub fn embedder(self: *Provider) inference.Embedder {
@@ -126,13 +133,23 @@ pub const Provider = struct {
             choices: []const struct {
                 message: struct {
                     content: ?[]const u8 = null,
+                    tool_calls: ?[]const struct {
+                        id: ?[]const u8 = null,
+                        function: struct {
+                            name: []const u8,
+                            arguments: []const u8,
+                        },
+                    } = null,
                 },
             },
         };
 
         const url = try std.fmt.allocPrint(self.allocator, "{s}/chat/completions", .{self.base_url});
         defer self.allocator.free(url);
-        const json_body = try inference.chatRequestJsonAlloc(self.allocator, model, messages, .openai_compatible);
+        const json_body = try inference.chatRequestJsonWithOptionsAlloc(self.allocator, model, messages, .openai_compatible, .{
+            .tools_json = self.tools_json,
+            .tool_choice_json = self.tool_choice_json,
+        });
         defer self.allocator.free(json_body);
         var resp = try self.http.post(url, .{ .json = json_body, .headers = self.authHeaders() });
         defer resp.deinit();
@@ -143,15 +160,47 @@ pub const Provider = struct {
 
         const choices = parsed.value.choices;
         if (choices.len > 0) {
+            var tool_calls = try cloneOpenAIToolCalls(alloc, choices[0].message.tool_calls);
+            errdefer freeToolCalls(alloc, tool_calls);
             if (choices[0].message.content) |content| {
+                if (tool_calls.len == 0) {
+                    tool_calls = try inference.synthesizeForcedToolCallFromContent(alloc, content, self.tools_json, self.tool_choice_json);
+                }
                 return .{
                     .content = try alloc.dupe(u8, content),
+                    .tool_calls = tool_calls,
+                    .allocator = alloc,
+                };
+            }
+            if (tool_calls.len > 0) {
+                return .{
+                    .content = try alloc.dupe(u8, ""),
+                    .tool_calls = tool_calls,
                     .allocator = alloc,
                 };
             }
         }
 
         return error.GenerateRequestFailed;
+    }
+
+    fn cloneOpenAIToolCalls(alloc: std.mem.Allocator, maybe_calls: anytype) ![]inference.ToolCall {
+        const calls = maybe_calls orelse return &.{};
+        const out = try alloc.alloc(inference.ToolCall, calls.len);
+        errdefer alloc.free(out);
+        for (calls, 0..) |call, i| {
+            out[i] = .{
+                .id = try alloc.dupe(u8, call.id orelse ""),
+                .name = try alloc.dupe(u8, call.function.name),
+                .arguments = try alloc.dupe(u8, call.function.arguments),
+            };
+        }
+        return out;
+    }
+
+    fn freeToolCalls(alloc: std.mem.Allocator, calls: []inference.ToolCall) void {
+        for (calls) |*call| call.deinit(alloc);
+        if (calls.len > 0) alloc.free(calls);
     }
 
     fn authHeaders(self: *const Provider) ?[]const [2][]const u8 {

--- a/zig/pkg/antfly/src/inference/types.zig
+++ b/zig/pkg/antfly/src/inference/types.zig
@@ -30,11 +30,26 @@ pub const ChatWireFlavor = enum {
     termite_native,
 };
 
+pub const ChatRequestOptions = struct {
+    tools_json: ?[]const u8 = null,
+    tool_choice_json: ?[]const u8 = null,
+};
+
 pub fn chatRequestJsonAlloc(
     alloc: std.mem.Allocator,
     model: []const u8,
     messages: []const ChatMessage,
     flavor: ChatWireFlavor,
+) ![]u8 {
+    return try chatRequestJsonWithOptionsAlloc(alloc, model, messages, flavor, .{});
+}
+
+pub fn chatRequestJsonWithOptionsAlloc(
+    alloc: std.mem.Allocator,
+    model: []const u8,
+    messages: []const ChatMessage,
+    flavor: ChatWireFlavor,
+    options: ChatRequestOptions,
 ) ![]u8 {
     var out = std.ArrayListUnmanaged(u8).empty;
     errdefer out.deinit(alloc);
@@ -45,7 +60,16 @@ pub fn chatRequestJsonAlloc(
         if (i > 0) try out.append(alloc, ',');
         try appendChatMessageJson(alloc, &out, message, flavor);
     }
-    try out.appendSlice(alloc, "]}");
+    try out.append(alloc, ']');
+    if (options.tools_json) |tools_json| {
+        try out.appendSlice(alloc, ",\"tools\":");
+        try out.appendSlice(alloc, tools_json);
+    }
+    if (options.tool_choice_json) |tool_choice_json| {
+        try out.appendSlice(alloc, ",\"tool_choice\":");
+        try out.appendSlice(alloc, tool_choice_json);
+    }
+    try out.append(alloc, '}');
     return try out.toOwnedSlice(alloc);
 }
 
@@ -215,13 +239,100 @@ pub const SparseEmbedResult = struct {
 
 pub const GenerateResult = struct {
     content: []const u8,
+    tool_calls: []ToolCall = &.{},
     allocator: std.mem.Allocator,
 
     pub fn deinit(self: *GenerateResult) void {
         self.allocator.free(self.content);
+        for (self.tool_calls) |*tool_call| tool_call.deinit(self.allocator);
+        if (self.tool_calls.len > 0) self.allocator.free(self.tool_calls);
         self.* = undefined;
     }
 };
+
+/// Some OpenAI-compatible providers and native model adapters emit a forced
+/// function call as plain JSON content instead of a `tool_calls` entry. The
+/// provider boundary normalizes that shape into the internal OpenAI-compatible
+/// ToolCall representation. This is intentionally narrow: a single function
+/// must be forced, that function must exist in `tools`, and the content must
+/// parse as JSON.
+pub fn synthesizeForcedToolCallFromContent(
+    alloc: std.mem.Allocator,
+    content_raw: []const u8,
+    tools_json: ?[]const u8,
+    tool_choice_json: ?[]const u8,
+) ![]ToolCall {
+    const content = jsonContentPayload(content_raw);
+    if (content.len == 0) return &.{};
+
+    const forced_name = (try forcedToolNameAlloc(alloc, tool_choice_json)) orelse return &.{};
+    defer alloc.free(forced_name);
+    if (!(try toolsContainFunction(alloc, tools_json, forced_name))) return &.{};
+
+    var parsed = std.json.parseFromSlice(std.json.Value, alloc, content, .{
+        .allocate = .alloc_always,
+    }) catch return &.{};
+    defer parsed.deinit();
+    switch (parsed.value) {
+        .object, .array => {},
+        else => return &.{},
+    }
+
+    const arguments = try std.json.Stringify.valueAlloc(alloc, parsed.value, .{});
+    errdefer alloc.free(arguments);
+    const calls = try alloc.alloc(ToolCall, 1);
+    errdefer alloc.free(calls);
+    calls[0] = .{
+        .id = try alloc.dupe(u8, "call_forced_0"),
+        .name = try alloc.dupe(u8, forced_name),
+        .arguments = arguments,
+    };
+    return calls;
+}
+
+fn forcedToolNameAlloc(alloc: std.mem.Allocator, tool_choice_json: ?[]const u8) !?[]u8 {
+    const raw = tool_choice_json orelse return null;
+    var parsed = std.json.parseFromSlice(std.json.Value, alloc, raw, .{
+        .allocate = .alloc_always,
+    }) catch return null;
+    defer parsed.deinit();
+    if (parsed.value != .object) return null;
+    const function = parsed.value.object.get("function") orelse return null;
+    if (function != .object) return null;
+    const name = function.object.get("name") orelse return null;
+    if (name != .string or name.string.len == 0) return null;
+    return try alloc.dupe(u8, name.string);
+}
+
+fn toolsContainFunction(alloc: std.mem.Allocator, tools_json: ?[]const u8, name: []const u8) !bool {
+    const raw = tools_json orelse return false;
+    var parsed = std.json.parseFromSlice(std.json.Value, alloc, raw, .{
+        .allocate = .alloc_always,
+    }) catch return false;
+    defer parsed.deinit();
+    if (parsed.value != .array) return false;
+    for (parsed.value.array.items) |tool| {
+        if (tool != .object) continue;
+        const tool_type = tool.object.get("type") orelse continue;
+        if (tool_type != .string or !std.mem.eql(u8, tool_type.string, "function")) continue;
+        const function = tool.object.get("function") orelse continue;
+        if (function != .object) continue;
+        const function_name = function.object.get("name") orelse continue;
+        if (function_name == .string and std.mem.eql(u8, function_name.string, name)) return true;
+    }
+    return false;
+}
+
+fn jsonContentPayload(raw: []const u8) []const u8 {
+    var text = std.mem.trim(u8, raw, " \t\r\n");
+    if (!std.mem.startsWith(u8, text, "```")) return text;
+    const first_newline = std.mem.indexOfScalar(u8, text, '\n') orelse return text;
+    text = std.mem.trim(u8, text[first_newline + 1 ..], " \t\r\n");
+    if (std.mem.endsWith(u8, text, "```")) {
+        text = std.mem.trim(u8, text[0 .. text.len - 3], " \t\r\n");
+    }
+    return text;
+}
 
 pub const RerankResult = struct {
     scores: []const f32,
@@ -314,4 +425,52 @@ test "openai compatible chat serialization converts image media urls" {
     try std.testing.expect(std.mem.indexOf(u8, body, "\"type\":\"media\"") == null);
     try std.testing.expect(std.mem.indexOf(u8, body, "\"type\":\"image_url\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, body, "\"url\":\"https://example.test/image.png\"") != null);
+}
+
+test "forced tool call synthesis normalizes plain JSON content" {
+    const alloc = std.testing.allocator;
+    const tools =
+        \\[{"type":"function","function":{"name":"emit_relations","parameters":{"type":"object"}}}]
+    ;
+    const tool_choice =
+        \\{"type":"function","function":{"name":"emit_relations"}}
+    ;
+
+    const calls = try synthesizeForcedToolCallFromContent(alloc,
+        \\{"relations":[{"type":"mentioned in","target":{"id":"Ada"}}]}
+    , tools, tool_choice);
+    defer {
+        for (calls) |*call| call.deinit(alloc);
+        if (calls.len > 0) alloc.free(calls);
+    }
+
+    try std.testing.expectEqual(@as(usize, 1), calls.len);
+    try std.testing.expectEqualStrings("emit_relations", calls[0].name);
+    try std.testing.expect(std.mem.indexOf(u8, calls[0].arguments, "\"relations\"") != null);
+}
+
+test "forced tool call synthesis accepts fenced JSON and rejects non-forced content" {
+    const alloc = std.testing.allocator;
+    const tools =
+        \\[{"type":"function","function":{"name":"emit_relations","parameters":{"type":"object"}}}]
+    ;
+    const tool_choice =
+        \\{"type":"function","function":{"name":"emit_relations"}}
+    ;
+    const fenced =
+        \\```json
+        \\{"relations":[]}
+        \\```
+    ;
+
+    const calls = try synthesizeForcedToolCallFromContent(alloc, fenced, tools, tool_choice);
+    defer {
+        for (calls) |*call| call.deinit(alloc);
+        if (calls.len > 0) alloc.free(calls);
+    }
+    try std.testing.expectEqual(@as(usize, 1), calls.len);
+    try std.testing.expectEqualStrings("{\"relations\":[]}", calls[0].arguments);
+
+    const skipped = try synthesizeForcedToolCallFromContent(alloc, "{\"relations\":[]}", tools, "\"auto\"");
+    try std.testing.expectEqual(@as(usize, 0), skipped.len);
 }

--- a/zig/pkg/antfly/src/inference_runtime/runtime.zig
+++ b/zig/pkg/antfly/src/inference_runtime/runtime.zig
@@ -228,7 +228,7 @@ fn listModels(alloc: std.mem.Allocator, io: std.Io, args: *std.process.Args.Iter
 
 fn pullModel(alloc: std.mem.Allocator, io: std.Io, args: *std.process.Args.Iterator) !void {
     const ref = args.next() orelse {
-        std.debug.print("usage: antfly inference pull <model-ref> [--token <hf-token>] [--models-dir <dir>] [--tasks <csv>] [--capabilities <csv>]\n", .{});
+        std.debug.print("usage: antfly inference pull <model-ref> [--token <hf-token>] [--models-dir <dir>] [--tasks <csv>] [--capabilities <csv>] [--projector <auto|none|Q8_0|filename>]\n", .{});
         return;
     };
 
@@ -236,6 +236,7 @@ fn pullModel(alloc: std.mem.Allocator, io: std.Io, args: *std.process.Args.Itera
     var models_dir: []const u8 = defaultModelsDir(alloc);
     var tasks_csv: ?[]const u8 = null;
     var capabilities_csv: ?[]const u8 = null;
+    var projector_selection: inference.registry.download.ProjectorSelection = .auto;
     while (args.next()) |arg| {
         if (std.mem.eql(u8, arg, "--token")) {
             token = args.next();
@@ -245,6 +246,9 @@ fn pullModel(alloc: std.mem.Allocator, io: std.Io, args: *std.process.Args.Itera
             tasks_csv = args.next();
         } else if (std.mem.eql(u8, arg, "--capabilities")) {
             capabilities_csv = args.next();
+        } else if (std.mem.eql(u8, arg, "--projector")) {
+            const value = args.next() orelse return error.InvalidArguments;
+            projector_selection = inference.registry.download.parseProjectorSelection(value) orelse return error.InvalidArguments;
         }
     }
 
@@ -257,7 +261,7 @@ fn pullModel(alloc: std.mem.Allocator, io: std.Io, args: *std.process.Args.Itera
 
     var reg = inference.registry.ModelRegistry.init(alloc, models_dir);
     defer reg.deinit();
-    try reg.pull(io, ref, token, tasks_csv, capabilities_csv);
+    try reg.pull(io, ref, token, tasks_csv, capabilities_csv, projector_selection);
 
     std.debug.print("done.\n", .{});
 }

--- a/zig/pkg/antfly/src/storage/hbc_adapter.zig
+++ b/zig/pkg/antfly/src/storage/hbc_adapter.zig
@@ -121,6 +121,12 @@ fn defaultRetainedVectorCacheEnabled() bool {
     return true;
 }
 
+fn hbcRuntimeBatchMode(in_bulk_session: bool, lsm_direct_bulk_ingest_enabled: ?bool) vectorindex_store.BatchMode {
+    if (!in_bulk_session) return .default;
+    const direct_bulk_ingest_enabled = lsm_direct_bulk_ingest_enabled orelse return .default;
+    return if (direct_bulk_ingest_enabled) .default else .bulk_ingest;
+}
+
 // ============================================================================
 // Index metadata (serialized to LMDB)
 // ============================================================================
@@ -2696,15 +2702,24 @@ pub const HBCIndex = struct {
             self.apply_workspace_split_bytes = 0;
             self.observeApplyWorkspaceBytes();
         }
+        const in_bulk_session = self.bulk_ingest_session_depth > 0;
         // HBC mutation batches rewrite nodes, ranges, and quantized payloads
-        // heavily. The outer bulk-ingest session still defers manifests and
-        // compaction, but each mutation batch must use normal mutable-state
-        // coalescing instead of direct sorted-run ingestion. Otherwise every
-        // stale internal rewrite becomes durable table bytes during large loads.
+        // heavily. Keep mutable-state coalescing, but preserve bulk transaction
+        // mode when the LSM profile disables direct bulk ingest so LSM defers
+        // batch-exit maintenance until the session boundary. Direct-bulk LSM
+        // profiles and non-LSM backends stay in default mode; otherwise stale
+        // internal rewrites can become durable table bytes during large loads.
         return try self.store.beginBatchWithOptions(.{
-            .mode = .default,
-            .defer_commit_flush = self.bulk_ingest_session_depth > 0,
+            .mode = self.runtimeBatchMode(in_bulk_session),
+            .defer_commit_flush = in_bulk_session,
         });
+    }
+
+    fn runtimeBatchMode(self: *const HBCIndex, in_bulk_session: bool) vectorindex_store.BatchMode {
+        return switch (self.env_owner) {
+            .lsm => |handle| hbcRuntimeBatchMode(in_bulk_session, handle.backend.options.direct_bulk_ingest),
+            .lmdb => hbcRuntimeBatchMode(in_bulk_session, null),
+        };
     }
 
     fn commitTxn(txn: anytype) !void {
@@ -10790,6 +10805,16 @@ test "scoreLeafMembers does not use-after-free when cache evicts during member s
     defer results.deinit();
     try std.testing.expect(ctx.fired);
     try std.testing.expect(results.getHits().len > 0);
+}
+
+test "HBC runtime batch mode preserves bulk only for non-direct LSM bulk sessions" {
+    try std.testing.expectEqual(vectorindex_store.BatchMode.default, hbcRuntimeBatchMode(false, false));
+    try std.testing.expectEqual(vectorindex_store.BatchMode.default, hbcRuntimeBatchMode(false, true));
+    try std.testing.expectEqual(vectorindex_store.BatchMode.default, hbcRuntimeBatchMode(false, null));
+
+    try std.testing.expectEqual(vectorindex_store.BatchMode.bulk_ingest, hbcRuntimeBatchMode(true, false));
+    try std.testing.expectEqual(vectorindex_store.BatchMode.default, hbcRuntimeBatchMode(true, true));
+    try std.testing.expectEqual(vectorindex_store.BatchMode.default, hbcRuntimeBatchMode(true, null));
 }
 
 // ============================================================================

--- a/zig/pkg/inference/TOOL_CALLING.md
+++ b/zig/pkg/inference/TOOL_CALLING.md
@@ -1,0 +1,144 @@
+# Tool Calling Design
+
+Antfly inference exposes and consumes tool calls using the OpenAI-compatible
+Chat Completions shape. Provider and model adapters may have provider-specific
+prompting or parsing internally, but the boundary between inference and
+downstream Antfly runtimes is normalized `tool_calls`.
+
+## Wire Contract
+
+Requests use `tools` and `tool_choice` at the top level:
+
+```json
+{
+  "model": "ggml-org/gemma-4-E4B-it-GGUF",
+  "messages": [
+    { "role": "user", "content": "Extract relations from this text." }
+  ],
+  "tools": [
+    {
+      "type": "function",
+      "function": {
+        "name": "emit_relations",
+        "description": "Extract supported relations from document text.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "relations": { "type": "array" }
+          },
+          "required": ["relations"]
+        }
+      }
+    }
+  ],
+  "tool_choice": {
+    "type": "function",
+    "function": { "name": "emit_relations" }
+  }
+}
+```
+
+Responses are normalized to OpenAI Chat Completions tool calls:
+
+```json
+{
+  "choices": [
+    {
+      "message": {
+        "role": "assistant",
+        "content": null,
+        "tool_calls": [
+          {
+            "id": "call_...",
+            "type": "function",
+            "function": {
+              "name": "emit_relations",
+              "arguments": "{\"relations\":[]}"
+            }
+          }
+        ]
+      },
+      "finish_reason": "tool_calls"
+    }
+  ]
+}
+```
+
+`function.arguments` is a JSON string, not a JSON object. This matches OpenAI
+Chat Completions and keeps Ollama, vLLM, native Gemma, and hosted providers on
+one internal representation.
+
+## Normalization Boundary
+
+Tool-call normalization belongs in inference provider/model adapters:
+
+- OpenAI-compatible providers pass through `message.tool_calls`.
+- Ollama/vLLM-compatible providers are normalized into the same shape before
+  returning `GenerateResult`.
+- Native Gemma/tool-call formats may use model-specific prompting/parsing, but
+  must emit normalized `ToolCall { name, arguments }` values to Antfly.
+
+Downstream consumers, including artifact producers and graph/autograph indexes,
+must not implement provider-specific tool-call parsing. If an asset producer is
+configured with `tool_output: "arguments"`, it requires a normalized tool call
+and should fail when one is absent.
+
+## Forced-Tool JSON Fallback
+
+Some OpenAI-compatible or native model paths produce the forced function
+arguments as plain JSON content instead of a `tool_calls` array. The inference
+adapter may synthesize a normalized tool call only when all of these conditions
+hold:
+
+- `tool_choice` forces exactly one function.
+- The forced function exists in the supplied `tools` array.
+- The model response has no `tool_calls`.
+- The response content parses as JSON. Fenced JSON is accepted only after
+  removing the surrounding code fence.
+
+The synthesized internal result is equivalent to:
+
+```json
+{
+  "tool_calls": [
+    {
+      "id": "call_forced_0",
+      "type": "function",
+      "function": {
+        "name": "emit_relations",
+        "arguments": "{\"relations\":[]}"
+      }
+    }
+  ]
+}
+```
+
+This fallback is intentionally narrow. It is provider/model normalization, not
+asset-producer behavior, and it must not cause arbitrary JSON content to be
+treated as a tool call unless a single function was explicitly forced.
+
+## Artifact Producer Rule
+
+Artifact producers should stay provider-neutral:
+
+```json
+{
+  "type": "generator",
+  "config": {
+    "provider": "antfly",
+    "model": "ggml-org/gemma-4-E4B-it-GGUF",
+    "api_url": "http://127.0.0.1:8080/ai/v1",
+    "tools": [ ... ],
+    "tool_choice": {
+      "type": "function",
+      "function": { "name": "emit_relations" }
+    },
+    "tool_name": "emit_relations",
+    "tool_output": "arguments"
+  }
+}
+```
+
+The producer asks for tool arguments and consumes normalized tool calls. It does
+not know whether the underlying model used OpenAI native tool calls, Ollama,
+vLLM, native Gemma, or a forced-tool JSON fallback.

--- a/zig/pkg/inference/src/main.zig
+++ b/zig/pkg/inference/src/main.zig
@@ -222,7 +222,7 @@ fn listModels(allocator: std.mem.Allocator, io: std.Io, args: []const []const u8
 
 fn pullModel(allocator: std.mem.Allocator, io: std.Io, usage_name: []const u8, args: []const []const u8) !void {
     if (args.len == 0) {
-        print("usage: {s} pull <owner/name|hf:owner/name>[:gguf|:gguf:Q4_K_M|:mmproj] [--token <hf-token>] [--models-dir <dir>] [--tasks <task1,task2>] [--capabilities <cap1,cap2>]\n", .{usage_name});
+        print("usage: {s} pull <owner/name|hf:owner/name>[:gguf|:gguf:Q4_K_M|:mmproj] [--token <hf-token>] [--models-dir <dir>] [--tasks <task1,task2>] [--capabilities <cap1,cap2>] [--projector <auto|none|Q8_0|filename>]\n", .{usage_name});
         return;
     }
     const ref = args[0];
@@ -232,6 +232,7 @@ fn pullModel(allocator: std.mem.Allocator, io: std.Io, usage_name: []const u8, a
     var tasks_csv: ?[]const u8 = null;
     var capabilities_csv: ?[]const u8 = null;
     var models_dir: []const u8 = defaultModelsDir(allocator);
+    var projector_selection: inference.registry.download.ProjectorSelection = .auto;
     var i: usize = 1;
     while (i < args.len) : (i += 1) {
         if (std.mem.eql(u8, args[i], "--token") and i + 1 < args.len) {
@@ -246,6 +247,9 @@ fn pullModel(allocator: std.mem.Allocator, io: std.Io, usage_name: []const u8, a
         } else if (std.mem.eql(u8, args[i], "--capabilities") and i + 1 < args.len) {
             capabilities_csv = args[i + 1];
             i += 1;
+        } else if (std.mem.eql(u8, args[i], "--projector") and i + 1 < args.len) {
+            projector_selection = inference.registry.download.parseProjectorSelection(args[i + 1]) orelse return error.InvalidArguments;
+            i += 1;
         }
     }
 
@@ -258,7 +262,7 @@ fn pullModel(allocator: std.mem.Allocator, io: std.Io, usage_name: []const u8, a
 
     var reg = inference.registry.ModelRegistry.init(allocator, models_dir);
     defer reg.deinit();
-    try reg.pull(io, ref, token, tasks_csv, capabilities_csv);
+    try reg.pull(io, ref, token, tasks_csv, capabilities_csv, projector_selection);
 
     print("done.\n", .{});
 }
@@ -307,6 +311,7 @@ fn printUsage(usage_name: []const u8) void {
         \\  --token <token>   HuggingFace API token (or set HF_TOKEN env var)
         \\  --tasks <list>    Comma-separated task hints for the pulled model
         \\  --capabilities <list> Comma-separated capability hints for the pulled model
+        \\  --projector <value> Projector sidecar selection for GGUF pulls: auto, none, quant suffix, or filename
         \\  --models-dir <dir>    Models directory (default: ~/.antfly/inference/models)
         \\  variants          <model-ref>:gguf, <model-ref>:gguf:Q4_K_M, <model-ref>:mmproj
         \\                    default :gguf now prefers smaller GGUF quants; use :gguf:Q... for larger files

--- a/zig/pkg/inference/src/pipelines/tool_parser.zig
+++ b/zig/pkg/inference/src/pipelines/tool_parser.zig
@@ -744,6 +744,62 @@ pub fn forcedFunctionName(choice: ParsedToolChoice) ?[]const u8 {
     };
 }
 
+pub fn synthesizeForcedFunctionToolCallFromJsonContent(
+    allocator: std.mem.Allocator,
+    content: []const u8,
+    choice: ParsedToolChoice,
+) !?[]ToolCall {
+    const forced_name = forcedFunctionName(choice) orelse return null;
+    const json_content = stripJsonFence(content);
+    if (json_content.len == 0) return null;
+
+    var parsed = std.json.parseFromSlice(std.json.Value, allocator, json_content, .{}) catch return null;
+    defer parsed.deinit();
+    switch (parsed.value) {
+        .object, .array => {},
+        else => return null,
+    }
+
+    const arguments = try std.json.Stringify.valueAlloc(allocator, parsed.value, .{});
+    errdefer allocator.free(arguments);
+    const id = try allocator.dupe(u8, "call_forced_0");
+    errdefer allocator.free(id);
+    const name = try allocator.dupe(u8, forced_name);
+    errdefer allocator.free(name);
+    const calls = try allocator.alloc(ToolCall, 1);
+    calls[0] = .{
+        .id = id,
+        .type = "function",
+        .function = .{
+            .name = name,
+            .arguments = arguments,
+        },
+    };
+    return calls;
+}
+
+pub fn freeToolCalls(allocator: std.mem.Allocator, calls: []ToolCall) void {
+    for (calls) |*call| call.deinit(allocator);
+    allocator.free(calls);
+}
+
+fn stripJsonFence(content: []const u8) []const u8 {
+    var text = std.mem.trim(u8, content, &std.ascii.whitespace);
+    if (!std.mem.startsWith(u8, text, "```")) return text;
+    text = text[3..];
+    if (std.mem.indexOfScalar(u8, text, '\n')) |newline| {
+        const tag = std.mem.trim(u8, text[0..newline], &std.ascii.whitespace);
+        if (tag.len == 0 or std.ascii.eqlIgnoreCase(tag, "json")) {
+            text = text[newline + 1 ..];
+        }
+    }
+    text = std.mem.trim(u8, text, &std.ascii.whitespace);
+    if (std.mem.endsWith(u8, text, "```")) {
+        text = std.mem.trim(u8, text[0 .. text.len - 3], &std.ascii.whitespace);
+    }
+    return text;
+}
+
 pub fn toolCallsEnabled(choice: ParsedToolChoice) bool {
     return switch (choice) {
         .none => false,
@@ -1694,4 +1750,33 @@ test "json parser accepts openai style function wrapper" {
     try std.testing.expectEqualStrings("call_123", calls[0].id);
     try std.testing.expectEqualStrings("lookup", calls[0].function.name);
     try std.testing.expectEqualStrings("{\"id\":42}", calls[0].function.arguments);
+}
+
+test "forced tool call fallback accepts plain and fenced json content" {
+    const allocator = std.testing.allocator;
+    const plain = try synthesizeForcedFunctionToolCallFromJsonContent(
+        allocator,
+        "{\"relations\":[]}",
+        .{ .function = "emit_relations" },
+    ) orelse return error.TestUnexpectedResult;
+    defer freeToolCalls(allocator, plain);
+    try std.testing.expectEqual(@as(usize, 1), plain.len);
+    try std.testing.expectEqualStrings("emit_relations", plain[0].function.name);
+    try std.testing.expectEqualStrings("{\"relations\":[]}", plain[0].function.arguments);
+
+    const fenced = try synthesizeForcedFunctionToolCallFromJsonContent(
+        allocator,
+        "```json\n{\"relations\":[{\"type\":\"mentioned in\"}]}\n```",
+        .{ .function = "emit_relations" },
+    ) orelse return error.TestUnexpectedResult;
+    defer freeToolCalls(allocator, fenced);
+    try std.testing.expectEqual(@as(usize, 1), fenced.len);
+    try std.testing.expectEqualStrings("emit_relations", fenced[0].function.name);
+
+    const skipped = try synthesizeForcedFunctionToolCallFromJsonContent(
+        allocator,
+        "{\"relations\":[]}",
+        .auto,
+    );
+    try std.testing.expectEqual(@as(?[]ToolCall, null), skipped);
 }

--- a/zig/pkg/inference/src/registry/download.zig
+++ b/zig/pkg/inference/src/registry/download.zig
@@ -28,6 +28,24 @@ pub const HubConfig = struct {
     base_url: []const u8 = "https://huggingface.co",
 };
 
+pub const ProjectorSelection = union(enum) {
+    auto,
+    none,
+    match: []const u8,
+};
+
+pub fn parseProjectorSelection(value: []const u8) ?ProjectorSelection {
+    if (std.mem.eql(u8, value, "auto") or std.mem.eql(u8, value, "default")) return .auto;
+    if (std.mem.eql(u8, value, "none") or
+        std.mem.eql(u8, value, "off") or
+        std.mem.eql(u8, value, "false"))
+    {
+        return .none;
+    }
+    if (value.len == 0) return null;
+    return .{ .match = value };
+}
+
 const HubFile = struct {
     name: []const u8,
     size: ?u64 = null,
@@ -330,6 +348,7 @@ fn appendBestRequestedGgufPayload(
     to_download: *std.ArrayListUnmanaged(HubFile),
     files: []const HubFile,
     quant_filter: ?[]const u8,
+    projector_selection: ProjectorSelection,
 ) !bool {
     const has_clipclap_gguf = hasClipclapGgufCandidate(files);
     if (try appendBestClipclapGgufPair(allocator, to_download, files, quant_filter)) {
@@ -337,7 +356,7 @@ fn appendBestRequestedGgufPayload(
     }
     if (has_clipclap_gguf) return false;
     if (try appendBestGgufFile(allocator, to_download, files, quant_filter)) {
-        _ = try appendBestGgufProjectorFile(allocator, to_download, files);
+        _ = try appendSelectedGgufProjectorFile(allocator, to_download, files, projector_selection);
         return true;
     }
     return false;
@@ -408,6 +427,39 @@ fn appendBestGgufProjectorFile(
         }
     }
 
+    return false;
+}
+
+fn appendSelectedGgufProjectorFile(
+    allocator: std.mem.Allocator,
+    to_download: *std.ArrayListUnmanaged(HubFile),
+    files: []const HubFile,
+    selection: ProjectorSelection,
+) !bool {
+    return switch (selection) {
+        .auto => appendBestGgufProjectorFile(allocator, to_download, files),
+        .none => false,
+        .match => |value| appendMatchingGgufProjectorFile(allocator, to_download, files, value),
+    };
+}
+
+fn appendMatchingGgufProjectorFile(
+    allocator: std.mem.Allocator,
+    to_download: *std.ArrayListUnmanaged(HubFile),
+    files: []const HubFile,
+    selector: []const u8,
+) !bool {
+    for (files) |f| {
+        if (!isGgufProjectorFile(f.name)) continue;
+        const base = basename(f.name);
+        if (std.mem.eql(u8, f.name, selector) or
+            std.mem.eql(u8, base, selector) or
+            ggufQuantSuffixMatches(f.name, selector))
+        {
+            try to_download.append(allocator, f);
+            return true;
+        }
+    }
     return false;
 }
 
@@ -805,6 +857,7 @@ pub fn downloadModel(
     variant: []const u8,
     dest_dir: []const u8,
     config: HubConfig,
+    projector_selection: ProjectorSelection,
     progress: ProgressSink,
 ) !void {
     // Create destination directory (pure Zig, cross-platform)
@@ -825,7 +878,10 @@ pub fn downloadModel(
     defer to_download.deinit(allocator);
     var synthetic_metadata: SyntheticMetadataPlan = .none;
 
-    const want_mmproj = std.mem.eql(u8, variant, "mmproj") or std.mem.eql(u8, variant, "projector");
+    const want_mmproj = std.mem.eql(u8, variant, "mmproj") or
+        std.mem.eql(u8, variant, "projector") or
+        std.mem.startsWith(u8, variant, "mmproj:") or
+        std.mem.startsWith(u8, variant, "projector:");
 
     // Always-download files (config, tokenizer, etc.) unless explicitly only
     // fetching the external multimodal projector.
@@ -858,14 +914,20 @@ pub fn downloadModel(
             variant["gguf:".len..]
         else
             null;
-        if (try appendBestRequestedGgufPayload(allocator, &to_download, files, quant_filter)) {
+        if (try appendBestRequestedGgufPayload(allocator, &to_download, files, quant_filter, projector_selection)) {
             found_model_payload = true;
         }
     }
 
     // External multimodal projector only.
     if (want_mmproj) {
-        if (try appendBestGgufProjectorFile(allocator, &to_download, files))
+        const mmproj_selection: ProjectorSelection = if (std.mem.startsWith(u8, variant, "mmproj:"))
+            .{ .match = variant["mmproj:".len..] }
+        else if (std.mem.startsWith(u8, variant, "projector:"))
+            .{ .match = variant["projector:".len..] }
+        else
+            projector_selection;
+        if (try appendSelectedGgufProjectorFile(allocator, &to_download, files, mmproj_selection))
             found_model_payload = true;
     }
 
@@ -1449,7 +1511,7 @@ test "gguf clipclap partial pair does not fall back to generic single file" {
     var to_download = std.ArrayListUnmanaged(HubFile).empty;
     defer to_download.deinit(allocator);
 
-    try std.testing.expect(!try appendBestRequestedGgufPayload(allocator, &to_download, &files, "Q4_K"));
+    try std.testing.expect(!try appendBestRequestedGgufPayload(allocator, &to_download, &files, "Q4_K", .auto));
     try std.testing.expectEqual(@as(usize, 0), to_download.items.len);
 }
 
@@ -1469,6 +1531,42 @@ test "projector-only selection finds mmproj gguf" {
 
     try std.testing.expectEqual(@as(usize, 1), to_download.items.len);
     try std.testing.expectEqualStrings("mmproj-gemma-4-e2b-it-f16.gguf", to_download.items[0].name);
+}
+
+test "gguf selection honors requested projector suffix" {
+    const allocator = std.testing.allocator;
+
+    const files = [_]HubFile{
+        .{ .name = "gemma-4-E4B-it-Q4_K_M.gguf" },
+        .{ .name = "mmproj-gemma-4-E4B-it-bf16.gguf" },
+        .{ .name = "mmproj-gemma-4-E4B-it-Q8_0.gguf" },
+    };
+
+    var to_download = std.ArrayListUnmanaged(HubFile).empty;
+    defer to_download.deinit(allocator);
+
+    try std.testing.expect(try appendBestRequestedGgufPayload(allocator, &to_download, &files, "Q4_K_M", .{ .match = "Q8_0" }));
+
+    try std.testing.expectEqual(@as(usize, 2), to_download.items.len);
+    try std.testing.expectEqualStrings("gemma-4-E4B-it-Q4_K_M.gguf", to_download.items[0].name);
+    try std.testing.expectEqualStrings("mmproj-gemma-4-E4B-it-Q8_0.gguf", to_download.items[1].name);
+}
+
+test "gguf selection can skip projector sidecar" {
+    const allocator = std.testing.allocator;
+
+    const files = [_]HubFile{
+        .{ .name = "gemma-4-E4B-it-Q4_K_M.gguf" },
+        .{ .name = "mmproj-gemma-4-E4B-it-bf16.gguf" },
+    };
+
+    var to_download = std.ArrayListUnmanaged(HubFile).empty;
+    defer to_download.deinit(allocator);
+
+    try std.testing.expect(try appendBestRequestedGgufPayload(allocator, &to_download, &files, "Q4_K_M", .none));
+
+    try std.testing.expectEqual(@as(usize, 1), to_download.items.len);
+    try std.testing.expectEqualStrings("gemma-4-E4B-it-Q4_K_M.gguf", to_download.items[0].name);
 }
 
 test "safetensors selection prefers model index and matching shards" {

--- a/zig/pkg/inference/src/registry/registry.zig
+++ b/zig/pkg/inference/src/registry/registry.zig
@@ -229,6 +229,7 @@ pub const ModelRegistry = struct {
         token: ?[]const u8,
         tasks_csv: ?[]const u8,
         capabilities_csv: ?[]const u8,
+        projector_selection: download.ProjectorSelection,
     ) !void {
         const ref = try ModelRef.parse(ref_str);
         const resolved_models_dir = try resolveModelsDirForWriteAlloc(self.allocator, io, self.models_dir);
@@ -241,7 +242,7 @@ pub const ModelRegistry = struct {
         var progress = ProgressPrinter{};
         try download.downloadModel(self.allocator, io, ref.owner, ref.name, ref.variant, dest, .{
             .token = token,
-        }, .{
+        }, projector_selection, .{
             .callback = ProgressPrinter.onProgress,
             .context = &progress,
         });

--- a/zig/pkg/inference/src/registry/registry.zig
+++ b/zig/pkg/inference/src/registry/registry.zig
@@ -631,8 +631,33 @@ fn appendCsvTasks(
 ) !void {
     var it = std.mem.tokenizeScalar(u8, csv, ',');
     while (it.next()) |raw_task| {
-        try appendUniqueOwnedString(allocator, tasks, raw_task);
+        try appendUniqueOwnedString(allocator, tasks, normalizeTaskHint(raw_task));
     }
+}
+
+fn normalizeTaskHint(raw_task: []const u8) []const u8 {
+    return if (std.mem.eql(u8, raw_task, "embedders"))
+        "embed"
+    else if (std.mem.eql(u8, raw_task, "rerankers"))
+        "rerank"
+    else if (std.mem.eql(u8, raw_task, "chunkers"))
+        "chunk"
+    else if (std.mem.eql(u8, raw_task, "generators"))
+        "generate"
+    else if (std.mem.eql(u8, raw_task, "recognizers"))
+        "recognize"
+    else if (std.mem.eql(u8, raw_task, "classifiers"))
+        "classify"
+    else if (std.mem.eql(u8, raw_task, "rewriters"))
+        "rewrite"
+    else if (std.mem.eql(u8, raw_task, "readers"))
+        "read"
+    else if (std.mem.eql(u8, raw_task, "transcribers"))
+        "transcribe"
+    else if (std.mem.eql(u8, raw_task, "extractors"))
+        "extract"
+    else
+        raw_task;
 }
 
 fn appendCsvCapabilities(
@@ -649,9 +674,10 @@ fn appendCsvCapabilities(
 fn appendInferredInputs(
     allocator: std.mem.Allocator,
     manifest: *const manifest_mod.ModelManifest,
+    effective_type: manifest_mod.ModelType,
     inputs: *std.ArrayListUnmanaged([]const u8),
 ) !void {
-    if (manifest.inputs.len > 0) {
+    if (manifest.inputs.len > 0 and effective_type == manifest.model_type) {
         for (manifest.inputs) |input| try appendUniqueOwnedString(allocator, inputs, input);
         return;
     }
@@ -661,7 +687,7 @@ fn appendInferredInputs(
         manifest.gguf_projector_path != null;
     const has_audio = manifest.audio_model_path != null or manifest.audio_projection_path != null;
 
-    switch (manifest.model_type) {
+    switch (effective_type) {
         .embedder => {
             try appendUniqueOwnedString(allocator, inputs, "text");
             if (has_visual) try appendUniqueOwnedString(allocator, inputs, "image");
@@ -669,10 +695,10 @@ fn appendInferredInputs(
         },
         .chunker, .reranker, .generator, .recognizer, .classifier, .rewriter => {
             try appendUniqueOwnedString(allocator, inputs, "text");
-            if (manifest.model_type == .generator and has_visual) {
+            if (effective_type == .generator and has_visual) {
                 try appendUniqueOwnedString(allocator, inputs, "image");
             }
-            if (manifest.model_type == .generator and has_audio) {
+            if (effective_type == .generator and has_audio) {
                 try appendUniqueOwnedString(allocator, inputs, "audio");
             }
         },
@@ -725,31 +751,32 @@ fn appendJsonStringArray(
 
 fn manifestTypeFromTasks(tasks: []const []const u8, fallback: manifest_mod.ModelType) manifest_mod.ModelType {
     for (tasks) |task| {
-        if (std.mem.eql(u8, task, "recognize") or std.mem.eql(u8, task, "extract")) return .recognizer;
+        if (std.mem.eql(u8, task, "recognize") or std.mem.eql(u8, task, "recognizers") or
+            std.mem.eql(u8, task, "extract") or std.mem.eql(u8, task, "extractors")) return .recognizer;
     }
     for (tasks) |task| {
-        if (std.mem.eql(u8, task, "classify")) return .classifier;
+        if (std.mem.eql(u8, task, "classify") or std.mem.eql(u8, task, "classifiers")) return .classifier;
     }
     for (tasks) |task| {
-        if (std.mem.eql(u8, task, "rerank")) return .reranker;
+        if (std.mem.eql(u8, task, "rerank") or std.mem.eql(u8, task, "rerankers")) return .reranker;
     }
     for (tasks) |task| {
-        if (std.mem.eql(u8, task, "read")) return .reader;
+        if (std.mem.eql(u8, task, "read") or std.mem.eql(u8, task, "readers")) return .reader;
     }
     for (tasks) |task| {
-        if (std.mem.eql(u8, task, "transcribe")) return .transcriber;
+        if (std.mem.eql(u8, task, "transcribe") or std.mem.eql(u8, task, "transcribers")) return .transcriber;
     }
     for (tasks) |task| {
-        if (std.mem.eql(u8, task, "rewrite")) return .rewriter;
+        if (std.mem.eql(u8, task, "rewrite") or std.mem.eql(u8, task, "rewriters")) return .rewriter;
     }
     for (tasks) |task| {
-        if (std.mem.eql(u8, task, "chunk")) return .chunker;
+        if (std.mem.eql(u8, task, "chunk") or std.mem.eql(u8, task, "chunkers")) return .chunker;
     }
     for (tasks) |task| {
-        if (std.mem.eql(u8, task, "generate")) return .generator;
+        if (std.mem.eql(u8, task, "generate") or std.mem.eql(u8, task, "generators")) return .generator;
     }
     for (tasks) |task| {
-        if (std.mem.eql(u8, task, "embed")) return .embedder;
+        if (std.mem.eql(u8, task, "embed") or std.mem.eql(u8, task, "embedders")) return .embedder;
     }
     return fallback;
 }
@@ -776,12 +803,14 @@ fn synthesizePulledModelManifestJson(
         try appendManifestTasks(allocator, &manifest, &tasks);
     }
 
+    const manifest_type = manifestTypeFromTasks(tasks.items, manifest.model_type);
+
     var inputs = std.ArrayListUnmanaged([]const u8).empty;
     defer {
         for (inputs.items) |input| allocator.free(input);
         inputs.deinit(allocator);
     }
-    try appendInferredInputs(allocator, &manifest, &inputs);
+    try appendInferredInputs(allocator, &manifest, manifest_type, &inputs);
 
     var capabilities = std.ArrayListUnmanaged([]const u8).empty;
     defer {
@@ -791,7 +820,6 @@ fn synthesizePulledModelManifestJson(
     try appendInferredCapabilities(allocator, io, &manifest, dest_dir, tasks.items, &capabilities);
     if (capabilities_csv) |csv| try appendCsvCapabilities(allocator, &capabilities, csv);
 
-    const manifest_type = manifestTypeFromTasks(tasks.items, manifest.model_type);
     const sparse_3d_output_layout = inferredSparse3DOutputLayout(allocator, io, &manifest, dest_dir, tasks.items);
 
     var body = std.ArrayListUnmanaged(u8).empty;
@@ -952,6 +980,31 @@ test "synthesized pulled manifest marks splade embedders as sparse" {
     try std.testing.expect(std.mem.indexOf(u8, manifest_json, "\"tasks\":[\"embed\"]") != null);
     try std.testing.expect(std.mem.indexOf(u8, manifest_json, "\"capabilities\":[\"sparse\"]") != null);
     try std.testing.expect(std.mem.indexOf(u8, manifest_json, "\"sparse_3d_output_layout\":\"batch_seq\"") != null);
+}
+
+test "synthesized pulled manifest accepts plural task directory hints" {
+    const allocator = std.testing.allocator;
+    const io = std.testing.io;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.createDirPath(io, "models/florence-reader");
+    try tmp.dir.writeFile(io, .{
+        .sub_path = "models/florence-reader/config.json",
+        .data = "{\"model_type\":\"florence2\"}",
+    });
+
+    const model_dir = try std.fs.path.join(allocator, &.{ ".zig-cache", "tmp", tmp.sub_path[0..], "models/florence-reader" });
+    defer allocator.free(model_dir);
+
+    const manifest_json = try synthesizePulledModelManifestJson(allocator, io, model_dir, "readers", null);
+    defer allocator.free(manifest_json);
+
+    try std.testing.expect(std.mem.indexOf(u8, manifest_json, "\"type\":\"reader\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, manifest_json, "\"tasks\":[\"read\"]") != null);
+    try std.testing.expect(std.mem.indexOf(u8, manifest_json, "\"inputs\":[\"image\"]") != null);
+    try std.testing.expect(std.mem.indexOf(u8, manifest_json, "\"capabilities\"") == null);
 }
 
 test "synthesized pulled manifest preserves explicit sparse capability" {

--- a/zig/pkg/inference/src/server/server.zig
+++ b/zig/pkg/inference/src/server/server.zig
@@ -2212,7 +2212,9 @@ pub const Node = struct {
             var response_text = result.text;
             var tool_response_text: ?[]u8 = null;
             defer if (tool_response_text) |text| ctx.allocator.free(text);
-            const parsed_tool_calls = if (tool_parser) |*parser| blk: {
+            var fallback_tool_calls: ?[]tool_parser_mod.ToolCall = null;
+            defer if (fallback_tool_calls) |calls| tool_parser_mod.freeToolCalls(ctx.allocator, calls);
+            var parsed_tool_calls = if (tool_parser) |*parser| blk: {
                 parser.reset();
                 _ = parser.feed(result.text) catch |err|
                     return ctx.status(500).json(.{ .@"error" = "GENERATION_FAILED", .message = @errorName(err) });
@@ -2223,6 +2225,12 @@ pub const Node = struct {
                 const calls = parser.toolCalls();
                 break :blk if (calls.len > 0) calls else null;
             } else null;
+
+            if (parsed_tool_calls == null and tool_parser != null) {
+                fallback_tool_calls = tool_parser_mod.synthesizeForcedFunctionToolCallFromJsonContent(ctx.allocator, response_text, parsed_tool_choice) catch |err|
+                    return ctx.status(500).json(.{ .@"error" = "GENERATION_FAILED", .message = @errorName(err) });
+                if (fallback_tool_calls) |calls| parsed_tool_calls = calls;
+            }
 
             if (parsed_tool_calls == null and tool_parser != null and response_text.len == 0) {
                 response_text = "No tool call was emitted.";
@@ -2318,7 +2326,9 @@ pub const Node = struct {
                 var response_text = result.text;
                 var tool_response_text: ?[]u8 = null;
                 defer if (tool_response_text) |text| ctx.allocator.free(text);
-                const parsed_tool_calls = if (tool_parser) |*parser| blk: {
+                var fallback_tool_calls: ?[]tool_parser_mod.ToolCall = null;
+                defer if (fallback_tool_calls) |calls| tool_parser_mod.freeToolCalls(ctx.allocator, calls);
+                var parsed_tool_calls = if (tool_parser) |*parser| blk: {
                     parser.reset();
                     _ = parser.feed(result.text) catch |err|
                         return ctx.status(500).json(.{ .@"error" = "GENERATION_FAILED", .message = @errorName(err) });
@@ -2329,6 +2339,12 @@ pub const Node = struct {
                     const calls = parser.toolCalls();
                     break :blk if (calls.len > 0) calls else null;
                 } else null;
+
+                if (parsed_tool_calls == null and tool_parser != null) {
+                    fallback_tool_calls = tool_parser_mod.synthesizeForcedFunctionToolCallFromJsonContent(ctx.allocator, response_text, parsed_tool_choice) catch |err|
+                        return ctx.status(500).json(.{ .@"error" = "GENERATION_FAILED", .message = @errorName(err) });
+                    if (fallback_tool_calls) |calls| parsed_tool_calls = calls;
+                }
 
                 if (parsed_tool_calls == null and tool_parser != null and response_text.len == 0) {
                     response_text = "No tool call was emitted.";
@@ -2599,7 +2615,9 @@ pub const Node = struct {
         var response_text = result.text;
         var tool_response_text: ?[]u8 = null;
         defer if (tool_response_text) |text| ctx.allocator.free(text);
-        const parsed_tool_calls = if (tool_parser) |*parser| blk: {
+        var fallback_tool_calls: ?[]tool_parser_mod.ToolCall = null;
+        defer if (fallback_tool_calls) |calls| tool_parser_mod.freeToolCalls(ctx.allocator, calls);
+        var parsed_tool_calls = if (tool_parser) |*parser| blk: {
             parser.reset();
             _ = parser.feed(result.text) catch |err|
                 return ctx.status(500).json(.{ .@"error" = "GENERATION_FAILED", .message = @errorName(err) });
@@ -2610,6 +2628,12 @@ pub const Node = struct {
             const calls = parser.toolCalls();
             break :blk if (calls.len > 0) calls else null;
         } else null;
+
+        if (parsed_tool_calls == null and tool_parser != null) {
+            fallback_tool_calls = tool_parser_mod.synthesizeForcedFunctionToolCallFromJsonContent(ctx.allocator, response_text, parsed_tool_choice) catch |err|
+                return ctx.status(500).json(.{ .@"error" = "GENERATION_FAILED", .message = @errorName(err) });
+            if (fallback_tool_calls) |calls| parsed_tool_calls = calls;
+        }
 
         if (parsed_tool_calls == null and tool_parser != null and response_text.len == 0) {
             response_text = "No tool call was emitted.";


### PR DESCRIPTION
## Summary
- cache LSM maintenance stats exposed through /metrics so aggressive scraping does not walk maintenance state on every request
- make HBC runtime batch mode explicit: non-direct LSM bulk sessions keep .bulk_ingest, direct-bulk LSM and LMDB stay .default, with a focused regression test
- add inference/tool-calling plumbing and update the Epstein smoke flow without committing generated smoke fixture artifacts

## Testing
- git diff --check
- zig build lib-data-runtime-test --summary failures
- zig build lib-data-storage-test --summary failures
- zig build lib-storage-test --summary failures
- zig build lsm-backend-test --summary failures
- zig build provisioned-query-visibility-test --summary failures
- zig build antfly
- vectordbbench antflyaknn Performance1536D50K on ReleaseFast: load 25.77s, insert 17.39s, optimize 8.39s, QPS 2096.86, recall 0.9866