### PR TITLE
Fix public index and inference pull regressions

### DIFF
--- a/zig/build.zig
+++ b/zig/build.zig
@@ -3503,6 +3503,7 @@ pub fn build(b: *std.Build) void {
             "provisioned table restore rejects mismatched doc identity namespace",
             "provisioned restore repair open rejects stale doc identity namespace",
             "write cache reserves retirement slots when pruning multiple leased generations",
+            "primary lookup adopts seeded write cache across visible generation bump",
             "provisioned table write source coalesces same-group waiters",
             "provisioned table write coalescer isolates failed waiters",
         },

--- a/zig/pkg/antfly/src/api/http_server.zig
+++ b/zig/pkg/antfly/src/api/http_server.zig
@@ -3120,6 +3120,7 @@ pub const ApiHttpServer = struct {
                     },
                 ) catch |err| switch (err) {
                     error.InvalidCreateTableRequest, error.UnsupportedCreateTableRequest => return try textResponse(self.alloc, 400, "unsupported table index configuration"),
+                    error.EmbeddingProbeUnavailable => return try textResponse(self.alloc, 503, "table index validation probe unavailable"),
                     else => return err,
                 };
                 if (create_req.indexes_json) |old_indexes_json| self.alloc.free(old_indexes_json);
@@ -5163,6 +5164,7 @@ pub const ApiHttpServer = struct {
             },
         ) catch |err| switch (err) {
             error.InvalidCreateTableRequest, error.UnsupportedCreateTableRequest => return error.InvalidIndexRequest,
+            error.EmbeddingProbeUnavailable => return error.ProbeUnavailable,
             else => return error.InternalFailure,
         };
         defer alloc.free(normalized_index_json);
@@ -5174,6 +5176,7 @@ pub const ApiHttpServer = struct {
             .inference_api_key = self.cfg.inference_api_key,
         }) catch |err| switch (err) {
             error.InvalidCreateTableRequest, error.UnsupportedCreateTableRequest => return error.InvalidIndexRequest,
+            error.EmbeddingProbeUnavailable => return error.ProbeUnavailable,
             else => return error.InternalFailure,
         };
 
@@ -5198,6 +5201,7 @@ pub const ApiHttpServer = struct {
         if (self.table_writes) |table_writes_source| {
             _ = table_writes_source.createIndex(alloc, table_name, index_name, normalized_index_json) catch |err| switch (err) {
                 error.InvalidCreateTableRequest, error.UnsupportedCreateTableRequest => return error.InvalidIndexRequest,
+                error.EmbeddingProbeUnavailable => return error.ProbeUnavailable,
                 else => {
                     std.log.err("public create index local apply failed table={s} index={s} err={}", .{ table_name, index_name, err });
                 },

--- a/zig/pkg/antfly/src/api/httpx_handler.zig
+++ b/zig/pkg/antfly/src/api/httpx_handler.zig
@@ -34,6 +34,7 @@ const public_table_http = @import("public_table_http.zig");
 const tables_api = @import("tables.zig");
 const table_contract = @import("table_contract.zig");
 const table_reads = @import("table_reads.zig");
+const table_writes = @import("table_writes.zig");
 const linear_merge_api = @import("linear_merge.zig");
 const transactions_api = @import("transactions.zig");
 const distributed_txn = @import("distributed_txn.zig");
@@ -1482,6 +1483,28 @@ pub const AntflyApiHandler = struct {
             return ctx.text("invalid create table request");
         };
         defer create_req.deinit(alloc);
+        const normalized_indexes_json = table_writes.normalizeManagedEmbeddingIndexDimensionsJsonWithOptions(
+            alloc,
+            create_req.indexes_json orelse tables_api.default_indexes_json,
+            .{
+                .antfly_provider = self.api_server.antfly_provider,
+                .secret_store = self.api_server.cfg.secret_store,
+                .remote_content = self.api_server.cfg.remote_content,
+                .inference_api_key = self.api_server.cfg.inference_api_key,
+            },
+        ) catch |err| switch (err) {
+            error.InvalidCreateTableRequest, error.UnsupportedCreateTableRequest => {
+                _ = ctx.status(400);
+                return ctx.text("unsupported table index configuration");
+            },
+            error.EmbeddingProbeUnavailable => {
+                _ = ctx.status(503);
+                return ctx.text("table index validation probe unavailable");
+            },
+            else => return err,
+        };
+        if (create_req.indexes_json) |old_indexes_json| alloc.free(old_indexes_json);
+        create_req.indexes_json = normalized_indexes_json;
         tables_api.validatePublicAlgebraicIndexesJson(alloc, create_req.indexes_json orelse tables_api.default_indexes_json) catch {
             _ = ctx.status(400);
             return ctx.text("unsupported table index configuration");
@@ -1517,6 +1540,10 @@ pub const AntflyApiHandler = struct {
                 error.InvalidCreateTableRequest, error.UnsupportedCreateTableRequest => {
                     _ = ctx.status(400);
                     return ctx.text("unsupported table index configuration");
+                },
+                error.EmbeddingProbeUnavailable => {
+                    _ = ctx.status(503);
+                    return ctx.text("table index validation probe unavailable");
                 },
                 else => {
                     std.log.err("public create table local create failed table={s} err={}", .{ table_name, err });

--- a/zig/pkg/antfly/src/api/public_table_http.zig
+++ b/zig/pkg/antfly/src/api/public_table_http.zig
@@ -79,6 +79,7 @@ pub const TableApi = struct {
         NotFound,
         MethodNotAllowed,
         InvalidIndexRequest,
+        ProbeUnavailable,
         InternalFailure,
     };
 
@@ -474,6 +475,7 @@ pub fn handleTableCreateIndex(
         error.NotFound => return .{ .status = 404, .body = try alloc.dupe(u8, "not found") },
         error.MethodNotAllowed => return .{ .status = 405, .body = try alloc.dupe(u8, "method not allowed") },
         error.InvalidIndexRequest => return .{ .status = 400, .body = try alloc.dupe(u8, "unsupported index configuration") },
+        error.ProbeUnavailable => return .{ .status = 503, .body = try alloc.dupe(u8, "index validation probe unavailable") },
         error.InternalFailure => return .{ .status = 500, .body = try alloc.dupe(u8, "index create failed") },
     };
     return .{ .status = 201, .body = try alloc.dupe(u8, "{}") };

--- a/zig/pkg/antfly/src/api/table_contract.zig
+++ b/zig/pkg/antfly/src/api/table_contract.zig
@@ -58,13 +58,20 @@ pub fn parseCreateTableRequest(alloc: std.mem.Allocator, body: []const u8) !tabl
         req.indexes_json = try alloc.dupe(u8, tables_api.default_indexes_json);
     }
 
-    if (parsed.value.schema) |schema| {
-        const raw_schema = try stringifyJsonAlloc(alloc, schema);
-        defer alloc.free(raw_schema);
-        req.schema_json = tables_api.parseSchemaUpdateRequest(alloc, raw_schema) catch |err| switch (err) {
-            error.InvalidSchemaUpdateRequest => return error.InvalidCreateTableRequest,
-            else => return err,
-        };
+    if (raw_root.get("schema")) |schema_value| {
+        if (schema_value != .null) {
+            const raw_schema = try stringifyJsonAlloc(alloc, schema_value);
+            defer alloc.free(raw_schema);
+            const validated_schema = tables_api.parseSchemaUpdateRequest(alloc, raw_schema) catch |err| switch (err) {
+                error.InvalidSchemaUpdateRequest => return error.InvalidCreateTableRequest,
+                else => return err,
+            };
+            defer alloc.free(validated_schema);
+            req.schema_json = tables_api.normalizeSchemaVersion(alloc, validated_schema, 0) catch |err| switch (err) {
+                error.InvalidSchemaUpdateRequest => return error.InvalidCreateTableRequest,
+                else => return err,
+            };
+        }
     }
     if (parsed.value.replication_sources) |replication_sources| {
         req.replication_sources_json = try stringifyJsonAlloc(alloc, replication_sources);
@@ -402,6 +409,8 @@ test "table contract parses create table via generated openapi type" {
     try std.testing.expectEqualStrings("docs", req.description.?);
     try std.testing.expectEqualStrings(tables_api.default_indexes_json, req.indexes_json.?);
     try std.testing.expect(std.mem.indexOf(u8, req.schema_json.?, "\"default_type\":\"doc\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, req.schema_json.?, "\"version\":0") != null);
+    try std.testing.expect(std.mem.indexOf(u8, req.schema_json.?, "\"version\":null") == null);
 }
 
 test "table contract preserves multi shard create table requests" {

--- a/zig/pkg/antfly/src/api/table_writes.zig
+++ b/zig/pkg/antfly/src/api/table_writes.zig
@@ -884,15 +884,23 @@ pub const ProvisionedTableWriteCache = struct {
             if (entry.group_id != group_id) continue;
             if (entry.lsm_root_generation != lsm_root_generation) continue;
             if (!std.mem.eql(u8, entry.table_name, table_name)) continue;
-            lockAtomic(&self.entry_lifecycle_mutex);
-            defer self.entry_lifecycle_mutex.unlock();
-            entry.active_leases += 1;
-            return .{
-                .cache = self,
-                .entry = entry,
-                .db = &entry.db,
-                .schema_json = entry.schema_json,
-            };
+            return self.leaseEntryLocked(entry);
+        }
+        return null;
+    }
+
+    fn snapshotLeaseOrAdoptSeededLocked(
+        self: *ProvisionedTableWriteCache,
+        group_id: u64,
+        lsm_root_generation: u64,
+        table_name: []const u8,
+    ) ?CachedDb {
+        if (self.snapshotLeaseLocked(group_id, lsm_root_generation, table_name)) |cached| return cached;
+        for (self.entries.items) |entry| {
+            if (entry.group_id != group_id) continue;
+            if (!std.mem.eql(u8, entry.table_name, table_name)) continue;
+            if (!self.adoptSeededEntryGenerationLocked(entry, lsm_root_generation)) continue;
+            return self.leaseEntryLocked(entry);
         }
         return null;
     }
@@ -4648,11 +4656,11 @@ pub const ProvisionedTableWriteSource = struct {
         lockAtomic(&self.local_db_mutex);
         var cached: ?ProvisionedTableWriteCache.CachedDb = null;
         if (self.write_cache) |cache| {
-            cached = cache.snapshotLeaseLocked(group_id, lsm_root_generation, table_name);
+            cached = cache.snapshotLeaseOrAdoptSeededLocked(group_id, lsm_root_generation, table_name);
         }
         if (cached == null) {
             if (self.startup_write_cache) |cache| {
-                cached = cache.snapshotLeaseLocked(group_id, lsm_root_generation, table_name);
+                cached = cache.snapshotLeaseOrAdoptSeededLocked(group_id, lsm_root_generation, table_name);
             }
         }
         self.local_db_mutex.unlock();
@@ -7054,6 +7062,7 @@ fn extractIndexConfigJsonWithOptions(
         if (std.mem.eql(u8, entry.key_ptr.*, "type") or
             std.mem.eql(u8, entry.key_ptr.*, "name") or
             std.mem.eql(u8, entry.key_ptr.*, "description") or
+            std.mem.eql(u8, entry.key_ptr.*, "validation") or
             std.mem.eql(u8, entry.key_ptr.*, "enrichments"))
         {
             continue;
@@ -19474,6 +19483,86 @@ test "write cache adopts just-created db across reconcile generation bump" {
     cached_after_bump.deinit(alloc);
     try std.testing.expectEqual(misses_before, write_cache.miss_count.load(.monotonic));
     try std.testing.expect(write_cache.hit_count.load(.monotonic) > 0);
+}
+
+test "primary lookup adopts seeded write cache across visible generation bump" {
+    const alloc = std.testing.allocator;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const replica_root_dir = try std.fmt.allocPrint(alloc, ".zig-cache/tmp/{s}/primary-lookup-write-cache-generation", .{tmp.sub_path});
+    defer alloc.free(replica_root_dir);
+    const path = try std.fmt.allocPrint(alloc, "{s}/group-7001/table-db", .{replica_root_dir});
+    defer alloc.free(path);
+
+    const Catalog = struct {
+        fn iface() table_catalog.CatalogSource {
+            return .{
+                .ptr = undefined,
+                .vtable = &.{
+                    .admin_snapshot = adminSnapshot,
+                    .free_admin_snapshot = freeAdminSnapshot,
+                },
+            };
+        }
+
+        fn adminSnapshot(_: *anyopaque) !metadata_api.AdminSnapshot {
+            return .{
+                .status = .{ .metadata_group_id = 1, .metrics = .{} },
+                .tables = @constCast((&[_]metadata_table_manager.TableRecord{.{
+                    .table_id = 7,
+                    .name = "docs",
+                    .placement_role = "data",
+                    .indexes_json = "{\"indexes\":[]}",
+                }})[0..]),
+                .ranges = @constCast((&[_]metadata_table_manager.RangeRecord{.{
+                    .group_id = 7001,
+                    .table_id = 7,
+                    .start_key = "",
+                    .end_key = null,
+                }})[0..]),
+                .stores = @constCast((&[_]metadata_table_manager.StoreRecord{})[0..]),
+                .placement_intents = @constCast((&[_]raft_reconciler.PlacementIntent{})[0..]),
+                .split_transitions = @constCast((&[_]metadata_transition_state.SplitTransitionRecord{})[0..]),
+                .merge_transitions = @constCast((&[_]metadata_transition_state.MergeTransitionRecord{})[0..]),
+            };
+        }
+
+        fn freeAdminSnapshot(_: *anyopaque, _: *metadata_api.AdminSnapshot) void {}
+    };
+
+    var generation: u64 = 1;
+    var write_cache = ProvisionedTableWriteCache.init(alloc);
+    defer write_cache.deinit();
+    var source = ProvisionedTableWriteSource.init(replica_root_dir, Catalog.iface());
+    source.write_cache = &write_cache;
+    _ = source.withGroupVisibleRootGeneration(testingVisibleRootGenerationSource(&generation));
+
+    var seeded = try write_cache.getOrOpenLocked(path, Catalog.iface(), 7001, generation, "docs");
+    try seeded.db.batch(.{
+        .writes = &.{.{ .key = "doc:gold", .value = "{\"title\":\"gold doc\"}" }},
+        .sync_level = .write,
+    });
+    seeded.deinit(alloc);
+
+    const primary_lookup = source.primaryLookupDbSource();
+    generation = 2;
+    try std.testing.expect((try primary_lookup.leaseGroup(alloc, "docs", 7001, generation)) == null);
+
+    write_cache.entries.items[0].allow_generation_adoption = true;
+    const misses_before = write_cache.miss_count.load(.monotonic);
+
+    var lease = (try primary_lookup.leaseGroup(alloc, "docs", 7001, generation)).?;
+    defer lease.release(alloc);
+
+    try std.testing.expectEqual(@as(u64, 2), write_cache.entries.items[0].lsm_root_generation);
+    try std.testing.expect(!write_cache.entries.items[0].allow_generation_adoption);
+    try std.testing.expectEqual(misses_before, write_cache.miss_count.load(.monotonic));
+
+    var result = (try lease.db.lookup(alloc, "doc:gold", .{})).?;
+    defer result.deinit(alloc);
+    try std.testing.expect(std.mem.indexOf(u8, result.json, "\"gold doc\"") != null);
 }
 
 test "replica root reconcile seeds write cache across generation bump" {

--- a/zig/pkg/antfly/src/api/tables.zig
+++ b/zig/pkg/antfly/src/api/tables.zig
@@ -1633,7 +1633,7 @@ fn extractCanonicalObjectField(alloc: std.mem.Allocator, schema_json: []const u8
     return try stringifyJsonValue(alloc, value);
 }
 
-fn normalizeSchemaVersion(alloc: std.mem.Allocator, schema_json: []const u8, version: u32) ![]u8 {
+pub fn normalizeSchemaVersion(alloc: std.mem.Allocator, schema_json: []const u8, version: u32) ![]u8 {
     const source = if (schema_json.len > 0) schema_json else "{}";
     var parsed = try std.json.parseFromSlice(std.json.Value, alloc, source, .{});
     defer parsed.deinit();

--- a/zig/pkg/antfly/src/inference/managed_embedder.zig
+++ b/zig/pkg/antfly/src/inference/managed_embedder.zig
@@ -809,7 +809,10 @@ pub fn translateEmbeddingsIndexConfigJsonWithOptions(
     defer if (embedder_json) |raw| alloc.free(raw);
     if (!external and embedder_json == null and chunker_json == null) return error.InvalidCreateTableRequest;
 
-    const dims = try resolveDeclaredEmbeddingDimensionsRequired(cfg);
+    const dims = if (embedder_value) |embedder|
+        try resolveEmbeddingDimensionsForManagedConfig(alloc, index_name, cfg, embedder, options)
+    else
+        try resolveDeclaredEmbeddingDimensionsRequired(cfg);
 
     var out = std.ArrayListUnmanaged(u8).empty;
     defer out.deinit(alloc);
@@ -938,7 +941,8 @@ fn parseManagedEmbeddingEntry(
     const sparse = cfg.sparse orelse false;
 
     const embedder = root.get("embedder") orelse return null;
-    return try buildManagedEmbeddingEntry(alloc, index_name, cfg, embedder, options, if (sparse) 0 else try resolveDeclaredEmbeddingDimensionsRequired(cfg));
+    const dims = if (sparse) 0 else try resolveEmbeddingDimensionsForManagedConfig(alloc, index_name, cfg, embedder, options);
+    return try buildManagedEmbeddingEntry(alloc, index_name, cfg, embedder, options, dims);
 }
 
 fn shouldUseAntflyProvider(embedder: embeddings_types.Config, options: InitOptions) bool {
@@ -2110,6 +2114,20 @@ test "managed embedder translates managed embeddings config into db generator co
     try std.testing.expect(std.mem.indexOf(u8, config_json, "\"dims\":384") != null);
     try std.testing.expect(std.mem.indexOf(u8, config_json, "\"embedding_name\":\"semantic_idx\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, config_json, "\"generator\":{\"kind\":\"dense_embedding\"") != null);
+}
+
+test "managed embedder translates managed embeddings config with probed dimension" {
+    var local = TestLocalDenseProvider{ .dimensions = 3 };
+    var parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator,
+        \\{"type":"embeddings","field":"body","embedder":{"provider":"antfly","model":"antflydb/clipclap"}}
+    , .{});
+    defer parsed.deinit();
+
+    const config_json = try translateEmbeddingsIndexConfigJsonWithOptions(std.testing.allocator, "semantic_idx", parsed.value, .{ .antfly_provider = local.provider() });
+    defer std.testing.allocator.free(config_json);
+
+    try std.testing.expectEqual(@as(usize, 1), local.calls);
+    try std.testing.expect(std.mem.indexOf(u8, config_json, "\"dims\":3") != null);
 }
 
 test "managed embedder normalizes missing dimension from probe result" {

--- a/zig/pkg/antfly/src/inference/managed_embedder.zig
+++ b/zig/pkg/antfly/src/inference/managed_embedder.zig
@@ -123,6 +123,11 @@ pub const InitOptions = struct {
     inference_api_key: ?[]const u8 = null,
 };
 
+const DimensionProbeValidation = enum {
+    strict,
+    defer_probe,
+};
+
 pub const QueryTemplateError = error{
     PermanentPromptFailure,
     TransientPromptFailure,
@@ -876,22 +881,28 @@ pub fn normalizeEmbeddingsIndexDimensionJsonWithOptions(
     defer parsed_cfg.deinit();
     const cfg = parsed_cfg.value;
     const sparse = cfg.sparse orelse false;
+    const validation_value = root.get("validation");
+    const validation = try parseDimensionProbeValidation(root);
 
     const external = cfg.external orelse false;
     const embedder_value = root.get("embedder");
     if (external) {
+        if (validation_value != null) return error.InvalidCreateTableRequest;
         if (!sparse) _ = try resolveDeclaredEmbeddingDimensionsRequired(cfg);
         return null;
     }
     const embedder = embedder_value orelse return error.InvalidCreateTableRequest;
 
     if (sparse) {
+        if (validation_value != null) return error.InvalidCreateTableRequest;
         try validateSparseEmbeddingForManagedConfig(alloc, index_name, cfg, embedder, options);
         return null;
     }
 
-    const dims = try resolveEmbeddingDimensionsForManagedConfig(alloc, index_name, cfg, embedder, options);
-    if (cfg.dimension != null) return null;
+    const declared_dims = try resolveDeclaredEmbeddingDimensions(cfg);
+    if (validation == .defer_probe and declared_dims == null) return error.InvalidCreateTableRequest;
+    const dims = try resolveEmbeddingDimensionsForManagedConfigWithValidation(alloc, index_name, cfg, embedder, options, validation);
+    if (cfg.dimension != null and validation_value == null) return null;
 
     var out = std.ArrayListUnmanaged(u8).empty;
     defer out.deinit(alloc);
@@ -900,6 +911,7 @@ pub fn normalizeEmbeddingsIndexDimensionJsonWithOptions(
     var it = root.iterator();
     while (it.next()) |entry| {
         if (std.mem.eql(u8, entry.key_ptr.*, "dimension")) continue;
+        if (std.mem.eql(u8, entry.key_ptr.*, "validation")) continue;
         if (!first) try out.append(alloc, ',');
         first = false;
         try appendJsonString(alloc, &out, entry.key_ptr.*);
@@ -1052,6 +1064,14 @@ fn resolveDeclaredEmbeddingDimensionsRequired(cfg: indexes_openapi.EmbeddingsInd
     return (try resolveDeclaredEmbeddingDimensions(cfg)) orelse error.InvalidCreateTableRequest;
 }
 
+fn parseDimensionProbeValidation(root: std.json.ObjectMap) !DimensionProbeValidation {
+    const value = root.get("validation") orelse return .strict;
+    if (value != .string) return error.InvalidCreateTableRequest;
+    if (std.mem.eql(u8, value.string, "strict")) return .strict;
+    if (std.mem.eql(u8, value.string, "defer_probe")) return .defer_probe;
+    return error.InvalidCreateTableRequest;
+}
+
 fn resolveEmbeddingDimensionsForManagedConfig(
     alloc: std.mem.Allocator,
     index_name: []const u8,
@@ -1059,13 +1079,32 @@ fn resolveEmbeddingDimensionsForManagedConfig(
     embedder: std.json.Value,
     options: InitOptions,
 ) !u32 {
-    var managed = buildManagedEmbeddingEntry(alloc, index_name, cfg, embedder, options, (try resolveDeclaredEmbeddingDimensions(cfg)) orelse 0) catch |err| switch (err) {
+    if (try resolveDeclaredEmbeddingDimensions(cfg)) |declared| return declared;
+    var managed = buildManagedEmbeddingEntry(alloc, index_name, cfg, embedder, options, 0) catch |err| switch (err) {
         error.InvalidManagedEmbeddingIndex, error.InvalidAntflyInferenceBaseUrl => return error.InvalidCreateTableRequest,
         error.UnsupportedEmbeddingProvider => return error.UnsupportedCreateTableRequest,
         else => return err,
     };
     defer managed.deinit(alloc);
     return try resolveEmbeddingDimensionsForEntry(alloc, cfg, &managed);
+}
+
+fn resolveEmbeddingDimensionsForManagedConfigWithValidation(
+    alloc: std.mem.Allocator,
+    index_name: []const u8,
+    cfg: indexes_openapi.EmbeddingsIndexConfig,
+    embedder: std.json.Value,
+    options: InitOptions,
+    validation: DimensionProbeValidation,
+) !u32 {
+    const declared = try resolveDeclaredEmbeddingDimensions(cfg);
+    var managed = buildManagedEmbeddingEntry(alloc, index_name, cfg, embedder, options, declared orelse 0) catch |err| switch (err) {
+        error.InvalidManagedEmbeddingIndex, error.InvalidAntflyInferenceBaseUrl => return error.InvalidCreateTableRequest,
+        error.UnsupportedEmbeddingProvider => return error.UnsupportedCreateTableRequest,
+        else => return err,
+    };
+    defer managed.deinit(alloc);
+    return try resolveEmbeddingDimensionsForEntryWithValidation(alloc, &managed, declared, validation);
 }
 
 fn validateSparseEmbeddingForManagedConfig(
@@ -1107,16 +1146,36 @@ fn resolveEmbeddingDimensionsForEntry(
     entry: *const ManagedEmbeddingEntry,
 ) !u32 {
     const declared = try resolveDeclaredEmbeddingDimensions(cfg);
+    return try resolveEmbeddingDimensionsForEntryWithValidation(alloc, entry, declared, .strict);
+}
+
+fn resolveEmbeddingDimensionsForEntryWithValidation(
+    alloc: std.mem.Allocator,
+    entry: *const ManagedEmbeddingEntry,
+    declared: ?u32,
+    validation: DimensionProbeValidation,
+) !u32 {
     const probe_dims = inferEmbeddingDimensionsFromEntry(alloc, entry, declared orelse 0) catch |err| switch (err) {
         error.InvalidEmbeddingDimensions,
         error.EmptyEmbeddingResponse,
         error.InvalidEmbeddingResponse,
-        error.EmbedRateLimited,
-        error.EmbedTransientFailure,
         error.EmbedRequestFailed,
         => return error.InvalidCreateTableRequest,
+        error.EmbedRateLimited,
+        error.EmbedTransientFailure,
+        => if (validation == .defer_probe) {
+            return declared orelse error.InvalidCreateTableRequest;
+        } else {
+            return error.EmbeddingProbeUnavailable;
+        },
         error.UnsupportedEmbeddingProvider => return error.UnsupportedCreateTableRequest,
-        else => return err,
+        else => {
+            if (isOperationalEmbeddingProbeError(err)) {
+                if (validation == .defer_probe) return declared orelse error.InvalidCreateTableRequest;
+                return error.EmbeddingProbeUnavailable;
+            }
+            return err;
+        },
     };
     if (probe_dims == 0) return error.InvalidCreateTableRequest;
     if (declared) |declared_dims| {
@@ -1124,6 +1183,24 @@ fn resolveEmbeddingDimensionsForEntry(
         return declared_dims;
     }
     return probe_dims;
+}
+
+fn isOperationalEmbeddingProbeError(err: anyerror) bool {
+    return switch (err) {
+        error.ConnectionRefused,
+        error.ConnectionResetByPeer,
+        error.ConnectionTimedOut,
+        error.Timeout,
+        error.NetworkUnreachable,
+        error.HostLacksNetworkAddresses,
+        error.TemporaryNameServerFailure,
+        error.NameServerFailure,
+        error.UnexpectedReadFailure,
+        error.SendFailed,
+        error.RecvFailed,
+        => true,
+        else => false,
+    };
 }
 
 fn inferEmbeddingDimensionsFromEntry(
@@ -2617,6 +2694,10 @@ test "managed embedder calls ollama compatible embeddings endpoint" {
 }
 
 test "managed embedder rejects embedding dimension mismatch" {
+    try testManagedEmbedderRejectsEmbeddingDimensionMismatch();
+}
+
+fn testManagedEmbedderRejectsEmbeddingDimensionMismatch() !void {
     const FakeApp = struct {
         fn executor() http_common.RequestExecutor {
             return .{
@@ -2658,6 +2739,129 @@ test "managed embedder rejects embedding dimension mismatch" {
     defer parsed.deinit();
 
     try std.testing.expectError(error.InvalidCreateTableRequest, normalizeEmbeddingsIndexDimensionJsonWithOptions(std.testing.allocator, "semantic_idx", parsed.value, .{}));
+}
+
+test "managed embedder defers operational dimension probe failure with explicit dimension" {
+    try testManagedEmbedderDefersOperationalDimensionProbeFailure();
+}
+
+test "managed embedder strict dimension probe failure is retryable" {
+    try testManagedEmbedderStrictDimensionProbeFailureIsRetryable();
+}
+
+pub fn testDimensionProbeValidationModes() !void {
+    try testManagedEmbedderRejectsEmbeddingDimensionMismatch();
+    try testManagedEmbedderDefersOperationalDimensionProbeFailure();
+    try testManagedEmbedderDeferProbeRequiresDeclaredDimension();
+    try testManagedEmbedderStrictDimensionProbeFailureIsRetryable();
+}
+
+fn testManagedEmbedderDefersOperationalDimensionProbeFailure() !void {
+    const FakeApp = struct {
+        fn executor() http_common.RequestExecutor {
+            return .{
+                .ptr = undefined,
+                .vtable = &.{
+                    .execute = execute,
+                },
+            };
+        }
+
+        fn execute(_: *anyopaque, alloc: std.mem.Allocator, _: http_common.HttpRequest) !http_common.HttpResponse {
+            return .{
+                .status = 429,
+                .content_type = try alloc.dupe(u8, "application/json"),
+                .body = try alloc.dupe(u8, "{}"),
+            };
+        }
+    };
+
+    var listener = std_http_listener.StdHttpListener.init(std.testing.allocator, .{}, FakeApp.executor());
+    defer listener.deinit();
+    try listener.start();
+
+    const base_uri = try listener.baseUri(std.testing.allocator);
+    defer std.testing.allocator.free(base_uri);
+
+    const index_json = try std.fmt.allocPrint(std.testing.allocator,
+        \\{{"type":"embeddings","field":"body","dimension":3,"validation":"defer_probe","embedder":{{"provider":"openai","model":"text-embedding-3-small","url":"{s}"}}}}
+    , .{base_uri});
+    defer std.testing.allocator.free(index_json);
+    var parsed = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        index_json,
+        .{},
+    );
+    defer parsed.deinit();
+
+    const normalized = (try normalizeEmbeddingsIndexDimensionJsonWithOptions(std.testing.allocator, "semantic_idx", parsed.value, .{})).?;
+    defer std.testing.allocator.free(normalized);
+    try std.testing.expect(std.mem.indexOf(u8, normalized, "\"dimension\":3") != null);
+    try std.testing.expect(std.mem.indexOf(u8, normalized, "\"validation\"") == null);
+
+    var normalized_parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, normalized, .{});
+    defer normalized_parsed.deinit();
+    const config_json = try translateEmbeddingsIndexConfigJsonWithOptions(std.testing.allocator, "semantic_idx", normalized_parsed.value, .{});
+    defer std.testing.allocator.free(config_json);
+    try std.testing.expect(std.mem.indexOf(u8, config_json, "\"dims\":3") != null);
+}
+
+fn testManagedEmbedderDeferProbeRequiresDeclaredDimension() !void {
+    const index_json =
+        \\{"type":"embeddings","field":"body","validation":"defer_probe","embedder":{"provider":"openai","model":"text-embedding-3-small","url":"http://127.0.0.1:9"}}
+    ;
+    var parsed = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        index_json,
+        .{},
+    );
+    defer parsed.deinit();
+
+    try std.testing.expectError(error.InvalidCreateTableRequest, normalizeEmbeddingsIndexDimensionJsonWithOptions(std.testing.allocator, "semantic_idx", parsed.value, .{}));
+}
+
+fn testManagedEmbedderStrictDimensionProbeFailureIsRetryable() !void {
+    const FakeApp = struct {
+        fn executor() http_common.RequestExecutor {
+            return .{
+                .ptr = undefined,
+                .vtable = &.{
+                    .execute = execute,
+                },
+            };
+        }
+
+        fn execute(_: *anyopaque, alloc: std.mem.Allocator, _: http_common.HttpRequest) !http_common.HttpResponse {
+            return .{
+                .status = 429,
+                .content_type = try alloc.dupe(u8, "application/json"),
+                .body = try alloc.dupe(u8, "{}"),
+            };
+        }
+    };
+
+    var listener = std_http_listener.StdHttpListener.init(std.testing.allocator, .{}, FakeApp.executor());
+    defer listener.deinit();
+    try listener.start();
+
+    const base_uri = try listener.baseUri(std.testing.allocator);
+    defer std.testing.allocator.free(base_uri);
+
+    const index_json = try std.fmt.allocPrint(std.testing.allocator,
+        \\{{"type":"embeddings","field":"body","dimension":3,"embedder":{{"provider":"openai","model":"text-embedding-3-small","url":"{s}"}}}}
+    , .{base_uri});
+    defer std.testing.allocator.free(index_json);
+    var parsed = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        index_json,
+        .{},
+    );
+    defer parsed.deinit();
+
+    try std.testing.expectError(error.EmbeddingProbeUnavailable, normalizeEmbeddingsIndexDimensionJsonWithOptions(std.testing.allocator, "semantic_idx", parsed.value, .{}));
 }
 
 test "managed embedder routes antfly model to local provider" {

--- a/zig/pkg/antfly/src/inference/mod.zig
+++ b/zig/pkg/antfly/src/inference/mod.zig
@@ -64,3 +64,7 @@ test "bedrock provider request helpers" {
 test "managed embedder resolves file-backed api key rotation at request time" {
     try managed_embedder.testFileBackedApiKeyRotation();
 }
+
+test "managed embedder dimension probe validation modes" {
+    try managed_embedder.testDimensionProbeValidationModes();
+}

--- a/zig/pkg/antfly/src/inference_runtime/runtime.zig
+++ b/zig/pkg/antfly/src/inference_runtime/runtime.zig
@@ -229,6 +229,8 @@ fn listModels(alloc: std.mem.Allocator, io: std.Io, args: *std.process.Args.Iter
 fn pullModel(alloc: std.mem.Allocator, io: std.Io, args: *std.process.Args.Iterator) !void {
     const ref = args.next() orelse {
         std.debug.print("usage: antfly inference pull <model-ref> [--token <hf-token>] [--models-dir <dir>] [--tasks <csv>] [--capabilities <csv>] [--projector <auto|none|Q8_0|filename>]\n", .{});
+        std.debug.print("variants: <model-ref>:gguf, <model-ref>:gguf:Q4_K, <model-ref>:onnx, <model-ref>:hybrid, <model-ref>:safetensors\n", .{});
+        std.debug.print("CLIP/CLAP v0.2 example: antfly inference pull antflydb/clipclap:gguf:Q4_K\n", .{});
         return;
     };
 

--- a/zig/pkg/antfly/src/storage/db/db.zig
+++ b/zig/pkg/antfly/src/storage/db/db.zig
@@ -8028,9 +8028,11 @@ pub const DB = struct {
     fn collectLiveIndexStatusSnapshot(index_manager: *index_manager_mod.IndexManager, index_name: []const u8) ?IndexStatusSnapshot {
         if (index_manager.textIndex(index_name)) |entry| {
             const text_snapshot = entry.snapshot();
+            const term_count = textIndexTermCount(entry);
             return .{
                 .kind = .full_text,
                 .doc_count = text_snapshot.global_doc_count,
+                .term_count = term_count,
                 .updated_at_ns = platform_time.monotonicNs(),
             };
         }
@@ -8064,6 +8066,17 @@ pub const DB = struct {
             };
         }
         return null;
+    }
+
+    fn textIndexTermCount(entry: anytype) u64 {
+        const snap = entry.acquireSnapshot();
+        defer snap.release();
+        var terms: u64 = 0;
+        for (snap.segments) |*seg| {
+            const layout = seg.layoutStats(true);
+            terms +|= layout.inverted_one_hit_terms +| layout.inverted_postings_terms;
+        }
+        return terms;
     }
 
     fn saveIndexStatusSnapshots(
@@ -8490,6 +8503,7 @@ pub const DB = struct {
                     if (self.core.textIndex(cfg.name)) |entry| {
                         const text_snapshot = entry.snapshot();
                         item.doc_count = text_snapshot.global_doc_count;
+                        item.term_count = textIndexTermCount(entry);
                         visible_doc_count = @max(visible_doc_count, item.doc_count);
                         term_doc_freq_cache_hits += text_snapshot.term_doc_freq_cache_hits;
                         term_doc_freq_cache_misses += text_snapshot.term_doc_freq_cache_misses;
@@ -32192,6 +32206,7 @@ test "db stats uses full text visible count when available" {
         defer types.freeDBStats(alloc, stats);
         try std.testing.expectEqual(@as(u64, 2), stats.doc_count);
         try std.testing.expectEqual(@as(u64, 2), stats.indexes[0].doc_count);
+        try std.testing.expect(stats.indexes[0].term_count > 0);
     }
 
     try db.batch(.{
@@ -32205,6 +32220,49 @@ test "db stats uses full text visible count when available" {
         try std.testing.expectEqual(@as(u64, 1), stats.doc_count);
         try std.testing.expectEqual(@as(u64, 1), stats.indexes[0].doc_count);
     }
+}
+
+test "db schemaless full text indexes strings into _all for bare text search" {
+    const alloc = std.testing.allocator;
+
+    var path_buf: [256]u8 = undefined;
+    const path = tempPath(&path_buf);
+    defer cleanupTempDir(path);
+
+    var db = try DB.open(alloc, std.mem.span(path), .{});
+    defer db.close();
+
+    try db.addIndex(.{
+        .name = "ft_v0",
+        .kind = .full_text,
+        .config_json = "{}",
+    });
+
+    try db.batch(.{
+        .writes = &.{
+            .{ .key = "doc:a", .value = "{\"title\":\"alpha beta\"}" },
+            .{ .key = "doc:b", .value = "{\"nested\":{\"body\":\"gamma delta\"}}" },
+        },
+        .sync_level = .full_index,
+    });
+
+    var top_level = try db.search(alloc, .{
+        .index_name = "ft_v0",
+        .query = .{ .match = .{ .field = "_all", .text = "alpha" } },
+        .limit = 10,
+    });
+    defer top_level.deinit();
+    try std.testing.expectEqual(@as(u32, 1), top_level.total_hits);
+    try std.testing.expectEqualStrings("doc:a", top_level.hits[0].id);
+
+    var nested = try db.search(alloc, .{
+        .index_name = "ft_v0",
+        .query = .{ .match = .{ .field = "_all", .text = "gamma" } },
+        .limit = 10,
+    });
+    defer nested.deinit();
+    try std.testing.expectEqual(@as(u32, 1), nested.total_hits);
+    try std.testing.expectEqualStrings("doc:b", nested.hits[0].id);
 }
 
 test "db stats does not scan primary docs when full text count is available" {
@@ -35820,6 +35878,7 @@ test "db text compaction preserves ordinal filters across reopen" {
 
 test "db best effort force compact leaves text merge debt under pressure" {
     const alloc = std.testing.allocator;
+    const table_schema_api = @import("../../schema/mod.zig");
 
     var budgets = resource_manager_mod.Options.defaultBudgets();
     budgets[@intFromEnum(resource_manager_mod.Slice.text_merge_buffers)] = .{
@@ -35849,6 +35908,30 @@ test "db best effort force compact leaves text merge debt under pressure" {
         .ttl_cleanup = .{ .enabled = false },
     });
     defer db.close();
+
+    const schema_json =
+        \\{
+        \\  "default_type": "doc",
+        \\  "document_schemas": {
+        \\    "doc": {
+        \\      "schema": {
+        \\        "type": "object",
+        \\        "properties": {
+        \\          "body": {
+        \\            "type": "string",
+        \\            "x-antfly-types": ["text"]
+        \\          }
+        \\        }
+        \\      }
+        \\    }
+        \\  }
+        \\}
+    ;
+    var parsed_schema = try table_schema_api.parseValidatedTableSchema(alloc, schema_json);
+    defer parsed_schema.deinit(alloc);
+    const runtime_schema = try table_schema_api.deriveRuntimeTableSchema(alloc, parsed_schema);
+    defer schema_mod.freeSchema(alloc, runtime_schema);
+    try db.setSchema(runtime_schema);
 
     try db.addIndex(.{
         .name = "ft_v1",

--- a/zig/pkg/antfly/src/storage/db/document_mapper.zig
+++ b/zig/pkg/antfly/src/storage/db/document_mapper.zig
@@ -2088,6 +2088,10 @@ fn appendSchemaLessStringTextFields(
         .field_name = try alloc.dupe(u8, path),
         .text = text,
     });
+    try fields.append(alloc, .{
+        .field_name = "_all",
+        .text = text,
+    });
     if (text.len > schema_less_exact_max_bytes or std.mem.endsWith(u8, path, schema_less_exact_field_suffix)) return;
     const exact_field = try schemaLessExactFieldNameAlloc(alloc, path);
     try fields.append(alloc, .{
@@ -2662,6 +2666,7 @@ test "document mapper builds text segment from top-level string fields" {
     try std.testing.expect((try reader.invertedIndex("title.keyword")) != null);
     try std.testing.expect((try reader.invertedIndex("body")) != null);
     try std.testing.expect((try reader.invertedIndex("body.keyword")) != null);
+    try std.testing.expect((try reader.invertedIndex("_all")) != null);
     try std.testing.expect((try reader.invertedIndex("count")) == null);
 }
 
@@ -2763,6 +2768,7 @@ test "document mapper builds text segment from nested string fields without sche
     try std.testing.expect((try reader.invertedIndex("title")) != null);
     try std.testing.expect((try reader.invertedIndex("meta.summary")) != null);
     try std.testing.expect((try reader.invertedIndex("meta.tags")) != null);
+    try std.testing.expect((try reader.invertedIndex("_all")) != null);
 }
 
 test "document mapper schema-less fast projection indexes nested string fields" {
@@ -2793,6 +2799,7 @@ test "document mapper schema-less fast projection indexes nested string fields" 
     try std.testing.expect((try reader.invertedIndex("meta.summary.keyword")) != null);
     try std.testing.expect((try reader.invertedIndex("meta.tags")) != null);
     try std.testing.expect((try reader.invertedIndex("meta.tags.keyword")) != null);
+    try std.testing.expect((try reader.invertedIndex("_all")) != null);
 }
 
 test "document mapper schema-less projection indexes exact fields with embeddings stripped" {

--- a/zig/pkg/antfly/src/storage/db/enrichment/enrichment_runtime.zig
+++ b/zig/pkg/antfly/src/storage/db/enrichment/enrichment_runtime.zig
@@ -325,6 +325,7 @@ fn isRetryableEnrichmentError(err: anyerror) bool {
     return switch (err) {
         error.EmbedRateLimited,
         error.EmbedTransientFailure,
+        error.ModelNotFound,
         error.ConnectionRefused,
         error.ConnectionResetByPeer,
         error.ConnectionTimedOut,
@@ -339,6 +340,10 @@ fn isRetryableEnrichmentError(err: anyerror) bool {
         => true,
         else => false,
     };
+}
+
+test "enrichment treats missing local model as retryable" {
+    try std.testing.expect(isRetryableEnrichmentError(error.ModelNotFound));
 }
 
 fn noteTransientEmbedRetry(runtime: *EnrichmentRuntime, err: anyerror) void {
@@ -369,6 +374,66 @@ fn runtimeStatusSnapshot(runtime: *EnrichmentRuntime) enrichment_state.RuntimeSt
         .retrying = runtime.retrying,
         .worker_failed = runtime.worker_failed,
     };
+}
+
+fn restorePersistedRuntimeStatus(runtime: anytype, persisted_status: enrichment_state.RuntimeStatus) void {
+    runtime.error_count = persisted_status.error_count;
+    runtime.retryable_error_count = persisted_status.retryable_error_count;
+    runtime.fatal_error_count = persisted_status.fatal_error_count;
+    runtime.retrying = persisted_status.retrying and !persisted_status.worker_failed;
+    runtime.worker_failed = persisted_status.worker_failed;
+    runtime.target_sequence = @max(runtime.applied_sequence, persisted_status.target_sequence);
+}
+
+test "enrichment runtime restore preserves retry target across restart" {
+    var runtime = struct {
+        applied_sequence: u64 = 3,
+        target_sequence: u64 = 0,
+        error_count: u64 = 0,
+        retryable_error_count: u64 = 0,
+        fatal_error_count: u64 = 0,
+        retrying: bool = false,
+        worker_failed: bool = false,
+    }{};
+
+    restorePersistedRuntimeStatus(&runtime, .{
+        .target_sequence = 9,
+        .error_count = 2,
+        .retryable_error_count = 2,
+        .fatal_error_count = 0,
+        .retrying = true,
+        .worker_failed = false,
+    });
+
+    try std.testing.expectEqual(@as(u64, 9), runtime.target_sequence);
+    try std.testing.expectEqual(@as(u64, 2), runtime.error_count);
+    try std.testing.expectEqual(@as(u64, 2), runtime.retryable_error_count);
+    try std.testing.expect(runtime.retrying);
+    try std.testing.expect(!runtime.worker_failed);
+}
+
+test "enrichment runtime restore does not resume persisted fatal failure" {
+    var runtime = struct {
+        applied_sequence: u64 = 7,
+        target_sequence: u64 = 0,
+        error_count: u64 = 0,
+        retryable_error_count: u64 = 0,
+        fatal_error_count: u64 = 0,
+        retrying: bool = false,
+        worker_failed: bool = false,
+    }{};
+
+    restorePersistedRuntimeStatus(&runtime, .{
+        .target_sequence = 4,
+        .error_count = 1,
+        .fatal_error_count = 1,
+        .retrying = true,
+        .worker_failed = true,
+    });
+
+    try std.testing.expectEqual(@as(u64, 7), runtime.target_sequence);
+    try std.testing.expect(!runtime.retrying);
+    try std.testing.expect(runtime.worker_failed);
 }
 
 fn clearPublishedGeneratedArtifacts(runtime: *EnrichmentRuntime) void {
@@ -792,7 +857,8 @@ pub const EnrichmentRuntime = if (builtin.os.tag == .freestanding) struct {
             },
         };
         runtime.applied_sequence = try enrichment_state.loadAppliedSequence(alloc, store, scope_name);
-        runtime.target_sequence = runtime.applied_sequence;
+        const persisted_status = try enrichment_state.loadRuntimeStatus(alloc, store, scope_name);
+        restorePersistedRuntimeStatus(&runtime, persisted_status);
         return runtime;
     }
 
@@ -1013,7 +1079,8 @@ pub const EnrichmentRuntime = if (builtin.os.tag == .freestanding) struct {
             }),
         };
         runtime.applied_sequence = try enrichment_state.loadAppliedSequence(alloc, store, scope_name);
-        runtime.target_sequence = runtime.applied_sequence;
+        const persisted_status = try enrichment_state.loadRuntimeStatus(alloc, store, scope_name);
+        restorePersistedRuntimeStatus(&runtime, persisted_status);
         return runtime;
     }
 

--- a/zig/pkg/inference/src/main.zig
+++ b/zig/pkg/inference/src/main.zig
@@ -223,6 +223,8 @@ fn listModels(allocator: std.mem.Allocator, io: std.Io, args: []const []const u8
 fn pullModel(allocator: std.mem.Allocator, io: std.Io, usage_name: []const u8, args: []const []const u8) !void {
     if (args.len == 0) {
         print("usage: {s} pull <owner/name|hf:owner/name>[:gguf|:gguf:Q4_K_M|:mmproj] [--token <hf-token>] [--models-dir <dir>] [--tasks <task1,task2>] [--capabilities <cap1,cap2>] [--projector <auto|none|Q8_0|filename>]\n", .{usage_name});
+        print("variants: <model-ref>:gguf, <model-ref>:gguf:Q4_K, <model-ref>:onnx, <model-ref>:hybrid, <model-ref>:safetensors\n", .{});
+        print("CLIP/CLAP v0.2 example: {s} pull antflydb/clipclap:gguf:Q4_K\n", .{usage_name});
         return;
     }
     const ref = args[0];
@@ -313,10 +315,11 @@ fn printUsage(usage_name: []const u8) void {
         \\  --capabilities <list> Comma-separated capability hints for the pulled model
         \\  --projector <value> Projector sidecar selection for GGUF pulls: auto, none, quant suffix, or filename
         \\  --models-dir <dir>    Models directory (default: ~/.antfly/inference/models)
-        \\  variants          <model-ref>:gguf, <model-ref>:gguf:Q4_K_M, <model-ref>:mmproj
+        \\  variants          <model-ref>:gguf, <model-ref>:gguf:Q4_K, <model-ref>:onnx, <model-ref>:hybrid, <model-ref>:safetensors
         \\                    default :gguf now prefers smaller GGUF quants; use :gguf:Q... for larger files
+        \\  CLIP/CLAP v0.2    {s} pull antflydb/clipclap:gguf:Q4_K
         \\
-    , .{usage_name});
+    , .{ usage_name, usage_name });
 }
 
 test "run config parses shared scraping fields and ignores api_url" {

--- a/zig/pkg/inference/src/registry/download.zig
+++ b/zig/pkg/inference/src/registry/download.zig
@@ -46,10 +46,21 @@ pub fn parseProjectorSelection(value: []const u8) ?ProjectorSelection {
     return .{ .match = value };
 }
 
-const HubFile = struct {
+pub const HubFile = struct {
     name: []const u8,
     size: ?u64 = null,
     sha256: ?[]const u8 = null,
+};
+
+pub const PayloadSupportSummary = struct {
+    has_gguf: bool = false,
+    has_onnx: bool = false,
+    has_safetensors: bool = false,
+    has_framework_weights: bool = false,
+
+    pub fn hasCompatiblePayload(self: PayloadSupportSummary) bool {
+        return self.has_gguf or self.has_onnx or self.has_safetensors;
+    }
 };
 
 const SyntheticMetadataPlan = union(enum) {
@@ -205,6 +216,86 @@ fn basename(path: []const u8) []const u8 {
 
 fn isGgufFile(path: []const u8) bool {
     return std.mem.endsWith(u8, path, ".gguf");
+}
+
+fn isOnnxFile(path: []const u8) bool {
+    return std.mem.endsWith(u8, path, ".onnx");
+}
+
+fn isSafetensorsFile(path: []const u8) bool {
+    return std.mem.endsWith(u8, path, ".safetensors") or std.mem.endsWith(u8, path, ".safetensors.index.json");
+}
+
+fn isFrameworkWeightFile(path: []const u8) bool {
+    const base = basename(path);
+    return std.mem.eql(u8, base, "pytorch_model.bin") or
+        (std.mem.startsWith(u8, base, "pytorch_model-") and std.mem.endsWith(u8, base, ".bin")) or
+        std.mem.eql(u8, base, "tf_model.h5") or
+        std.mem.eql(u8, base, "flax_model.msgpack") or
+        std.mem.endsWith(u8, base, ".ckpt");
+}
+
+pub fn summarizePayloadSupport(files: []const HubFile) PayloadSupportSummary {
+    var summary: PayloadSupportSummary = .{};
+    for (files) |file| {
+        summary.has_gguf = summary.has_gguf or isGgufFile(file.name);
+        summary.has_onnx = summary.has_onnx or isOnnxFile(file.name);
+        summary.has_safetensors = summary.has_safetensors or isSafetensorsFile(file.name);
+        summary.has_framework_weights = summary.has_framework_weights or isFrameworkWeightFile(file.name);
+    }
+    return summary;
+}
+
+fn appendModelRef(
+    alloc: std.mem.Allocator,
+    out: *std.ArrayListUnmanaged(u8),
+    owner: []const u8,
+    name: []const u8,
+    variant: []const u8,
+) !void {
+    try out.appendSlice(alloc, owner);
+    try out.append(alloc, '/');
+    try out.appendSlice(alloc, name);
+    if (variant.len > 0 and !std.mem.eql(u8, variant, "auto")) {
+        try out.append(alloc, ':');
+        try out.appendSlice(alloc, variant);
+    }
+}
+
+fn isOpenAiClipRef(owner: []const u8, name: []const u8) bool {
+    return std.mem.eql(u8, owner, "openai") and std.mem.startsWith(u8, name, "clip-");
+}
+
+pub fn noModelFilesAdviceAlloc(
+    alloc: std.mem.Allocator,
+    owner: []const u8,
+    name: []const u8,
+    variant: []const u8,
+    files: []const HubFile,
+) ![]u8 {
+    const summary = summarizePayloadSupport(files);
+    var out = std.ArrayListUnmanaged(u8).empty;
+    errdefer out.deinit(alloc);
+
+    try out.appendSlice(alloc, "No compatible model files found for ");
+    try appendModelRef(alloc, &out, owner, name, variant);
+    try out.appendSlice(alloc, ".\n");
+    try out.appendSlice(alloc, "Antfly inference pull expects GGUF, ONNX, or safetensors payloads.");
+    if (summary.has_framework_weights and !summary.hasCompatiblePayload()) {
+        try out.appendSlice(alloc, " This repo appears to publish framework weights only, such as PyTorch, TensorFlow, or Flax files.");
+    }
+    try out.append(alloc, '\n');
+
+    if (isOpenAiClipRef(owner, name)) {
+        try out.appendSlice(alloc, "For v0.2 CLIP/CLAP embeddings, use:\n");
+        try out.appendSlice(alloc, "  antfly inference pull antflydb/clipclap:gguf:Q4_K\n");
+        try out.appendSlice(alloc, "For an ONNX CLIP export, try:\n");
+        try out.appendSlice(alloc, "  antfly inference pull Xenova/clip-vit-base-patch32:hybrid\n");
+    } else {
+        try out.appendSlice(alloc, "Use a repo or variant that includes GGUF, ONNX, or safetensors model files.\n");
+    }
+
+    return try out.toOwnedSlice(alloc);
 }
 
 fn isGgufProjectorFile(path: []const u8) bool {
@@ -963,6 +1054,11 @@ pub fn downloadModel(
     }
 
     if (!found_model_payload) {
+        const advice = noModelFilesAdviceAlloc(allocator, owner, name, variant, files) catch null;
+        if (advice) |message| {
+            defer allocator.free(message);
+            std.debug.print("{s}", .{message});
+        }
         return error.NoModelFilesFound;
     }
 
@@ -1481,6 +1577,43 @@ test "gguf selection keeps clipclap clip and clap pair together" {
     try std.testing.expectEqual(@as(usize, 2), to_download.items.len);
     try std.testing.expectEqualStrings("clipclap-clip.Q4_K.gguf", to_download.items[0].name);
     try std.testing.expectEqualStrings("clipclap-clap.Q4_K.gguf", to_download.items[1].name);
+}
+
+test "payload support summary distinguishes framework-only repos" {
+    const files = [_]HubFile{
+        .{ .name = "config.json" },
+        .{ .name = "pytorch_model.bin" },
+        .{ .name = "tf_model.h5" },
+        .{ .name = "flax_model.msgpack" },
+    };
+
+    const summary = summarizePayloadSupport(&files);
+    try std.testing.expect(!summary.hasCompatiblePayload());
+    try std.testing.expect(summary.has_framework_weights);
+    try std.testing.expect(!summary.has_onnx);
+    try std.testing.expect(!summary.has_safetensors);
+    try std.testing.expect(!summary.has_gguf);
+}
+
+test "no model files advice recommends blessed clipclap ref for openai clip" {
+    const files = [_]HubFile{
+        .{ .name = "config.json" },
+        .{ .name = "pytorch_model.bin" },
+    };
+
+    const advice = try noModelFilesAdviceAlloc(
+        std.testing.allocator,
+        "openai",
+        "clip-vit-base-patch32",
+        "hybrid",
+        &files,
+    );
+    defer std.testing.allocator.free(advice);
+
+    try std.testing.expect(std.mem.indexOf(u8, advice, "openai/clip-vit-base-patch32:hybrid") != null);
+    try std.testing.expect(std.mem.indexOf(u8, advice, "framework weights only") != null);
+    try std.testing.expect(std.mem.indexOf(u8, advice, "antflydb/clipclap:gguf:Q4_K") != null);
+    try std.testing.expect(std.mem.indexOf(u8, advice, "Xenova/clip-vit-base-patch32:hybrid") != null);
 }
 
 test "gguf clipclap selection does not mix quantized pairs" {


### PR DESCRIPTION
## Summary
- preserve table schema versions during create-table contract parsing
- populate schemaless `_all` text fields, verify `_all` search behavior, and report full-text term counts
- probe managed embedding dimensions when omitted and keep missing-model enrichment failures retryable across restart
- improve `antfly inference pull` guidance when a Hub repo only has unsupported framework weights, with CLIP/CLAP v0.2 recommendations

Fixes #179
Fixes #180
Fixes #181
Fixes #182
Fixes #183

## Tests
- `zig build lib-swarm-runtime-test`
- `zig build inference-test`
- `zig build db-test -- --test-filter "db best effort force compact leaves text merge debt under pressure" "db schemaless full text indexes strings into _all for bare text search"`
- `zig build db-test`
- `zig build root-test`
- earlier partial `zig build unit-test` run reached the long metadata simulation suite before interruption; touched test areas had passed