### PR TITLE
Support GLiNER2 split GGUF bundles

### DIFF
--- a/zig/pkg/inference/src/models/manifest.zig
+++ b/zig/pkg/inference/src/models/manifest.zig
@@ -933,7 +933,9 @@ fn isGgufProjectorFileName(name: []const u8) bool {
 }
 
 fn isGlinerHeadGgufFileName(name: []const u8) bool {
-    return std.mem.eql(u8, name, "gliner_head.gguf");
+    return std.mem.eql(u8, name, "gliner_head.gguf") or
+        std.mem.eql(u8, name, "gliner2-head.gguf") or
+        (std.mem.startsWith(u8, name, "gliner2-head.") and std.mem.endsWith(u8, name, ".gguf"));
 }
 
 fn findFirstGgufInDir(allocator: std.mem.Allocator, base_dir: []const u8, want_projector: bool) !?[]const u8 {
@@ -1386,6 +1388,25 @@ fn parseInferenceBundleJson(manifest: *ModelManifest, allocator: std.mem.Allocat
         }
     }
     if (family) |bundle_family| {
+        if (std.mem.eql(u8, bundle_family, "gliner2_split_bundle/v1")) {
+            if (obj.get("encoder")) |encoder| {
+                if (encoder == .string and encoder.string.len > 0) {
+                    setOptionalPath(allocator, &manifest.gguf_path, try resolveBundlePath(allocator, model_dir_path, encoder.string));
+                }
+            }
+            if (obj.get("head")) |head| {
+                if (head == .string and head.string.len > 0) {
+                    const head_path = try resolveBundlePath(allocator, model_dir_path, head.string);
+                    if (std.mem.endsWith(u8, head.string, ".gguf")) {
+                        setOptionalPath(allocator, &manifest.gliner_head_gguf_path, head_path);
+                    } else {
+                        setOptionalPath(allocator, &manifest.gliner_head_safetensors_path, head_path);
+                    }
+                }
+            }
+            manifest.model_type = .recognizer;
+            try setManifestInputs(allocator, manifest, &.{"text"});
+        }
         if (std.mem.eql(u8, bundle_family, "clipclap_gguf_bundle/v1")) {
             if (obj.get("clip")) |clip| {
                 if (clip == .string and clip.string.len > 0) {
@@ -1438,7 +1459,11 @@ fn parseInferenceVariantsJson(manifest: *ModelManifest, allocator: std.mem.Alloc
 
     const obj = parsed.value.object;
     const variants_family = obj.get("family") orelse return;
-    if (variants_family != .string or !std.mem.eql(u8, variants_family.string, "clipclap_variants/v1")) return;
+    if (variants_family != .string) return;
+    if (std.mem.eql(u8, variants_family.string, "gliner2_variants/v1")) {
+        return parseGliner2InferenceVariantsJson(manifest, allocator, model_dir_path, obj);
+    }
+    if (!std.mem.eql(u8, variants_family.string, "clipclap_variants/v1")) return;
     const variants = obj.get("variants") orelse return;
     if (variants != .array) return;
 
@@ -1482,6 +1507,55 @@ fn parseInferenceVariantsJson(manifest: *ModelManifest, allocator: std.mem.Alloc
     try setManifestInputs(allocator, manifest, &.{ "text", "image", "audio" });
 }
 
+fn parseGliner2InferenceVariantsJson(
+    manifest: *ModelManifest,
+    allocator: std.mem.Allocator,
+    model_dir_path: []const u8,
+    obj: std.json.ObjectMap,
+) !void {
+    const variants = obj.get("variants") orelse return;
+    if (variants != .array) return;
+
+    var selected: ?ResolvedGliner2GgufPair = null;
+    errdefer if (selected) |*pair| pair.deinit(allocator);
+    for (variants.array.items) |variant| {
+        if (!isGliner2GgufVariant(variant)) continue;
+        var pair = (try resolveExistingGliner2GgufVariant(allocator, model_dir_path, variant)) orelse continue;
+        if (variant.object.get("format")) |format| {
+            if (format == .string and std.mem.eql(u8, format.string, "Q4_K")) {
+                if (selected) |*old| old.deinit(allocator);
+                selected = pair;
+                break;
+            }
+        }
+        if (selected == null) {
+            selected = pair;
+        } else {
+            pair.deinit(allocator);
+        }
+    }
+
+    var pair = selected orelse return;
+    selected = null;
+    errdefer pair.deinit(allocator);
+
+    const family = try allocator.dupe(u8, "gliner2_split_bundle/v1");
+    errdefer allocator.free(family);
+    const wrapper = try allocator.dupe(u8, "gliner2");
+    errdefer allocator.free(wrapper);
+
+    if (manifest.inference_bundle_family.len > 0) allocator.free(manifest.inference_bundle_family);
+    manifest.inference_bundle_family = family;
+    if (manifest.gliner_model_type.len > 0) allocator.free(manifest.gliner_model_type);
+    manifest.gliner_model_type = wrapper;
+    setOptionalPath(allocator, &manifest.gguf_path, pair.encoder_path);
+    pair.encoder_path = "";
+    setOptionalPath(allocator, &manifest.gliner_head_gguf_path, pair.head_path);
+    pair.head_path = "";
+    manifest.model_type = .recognizer;
+    try setManifestInputs(allocator, manifest, &.{"text"});
+}
+
 fn setManifestInputs(allocator: std.mem.Allocator, manifest: *ModelManifest, inputs: []const []const u8) !void {
     if (manifest.inputs.len > 0) {
         for (manifest.inputs) |input| allocator.free(input);
@@ -1514,6 +1588,17 @@ const ResolvedClipclapGgufPair = struct {
     }
 };
 
+const ResolvedGliner2GgufPair = struct {
+    encoder_path: []const u8,
+    head_path: []const u8,
+
+    fn deinit(self: *ResolvedGliner2GgufPair, allocator: std.mem.Allocator) void {
+        if (self.encoder_path.len > 0) allocator.free(self.encoder_path);
+        if (self.head_path.len > 0) allocator.free(self.head_path);
+        self.* = .{ .encoder_path = "", .head_path = "" };
+    }
+};
+
 fn resolveExistingClipclapGgufVariant(
     allocator: std.mem.Allocator,
     model_dir_path: []const u8,
@@ -1536,6 +1621,28 @@ fn resolveExistingClipclapGgufVariant(
     return .{ .clip_path = clip_path, .clap_path = clap_path };
 }
 
+fn resolveExistingGliner2GgufVariant(
+    allocator: std.mem.Allocator,
+    model_dir_path: []const u8,
+    variant: std.json.Value,
+) !?ResolvedGliner2GgufPair {
+    const encoder = variant.object.get("encoder") orelse return null;
+    const head = variant.object.get("head") orelse return null;
+    if (encoder != .string or encoder.string.len == 0) return null;
+    if (head != .string or head.string.len == 0) return null;
+
+    const encoder_path = try resolveBundlePath(allocator, model_dir_path, encoder.string);
+    errdefer allocator.free(encoder_path);
+    const head_path = try resolveBundlePath(allocator, model_dir_path, head.string);
+    errdefer allocator.free(head_path);
+    if (!c_file.fileExists(allocator, encoder_path) or !c_file.fileExists(allocator, head_path)) {
+        allocator.free(encoder_path);
+        allocator.free(head_path);
+        return null;
+    }
+    return .{ .encoder_path = encoder_path, .head_path = head_path };
+}
+
 fn isClipclapGgufVariant(variant: std.json.Value) bool {
     if (variant != .object) return false;
     const target = variant.object.get("target") orelse return false;
@@ -1543,6 +1650,15 @@ fn isClipclapGgufVariant(variant: std.json.Value) bool {
     const clip = variant.object.get("clip") orelse return false;
     const clap = variant.object.get("clap") orelse return false;
     return clip == .string and clip.string.len > 0 and clap == .string and clap.string.len > 0;
+}
+
+fn isGliner2GgufVariant(variant: std.json.Value) bool {
+    if (variant != .object) return false;
+    const target = variant.object.get("target") orelse return false;
+    if (target != .string or !std.mem.eql(u8, target.string, "gguf")) return false;
+    const encoder = variant.object.get("encoder") orelse return false;
+    const head = variant.object.get("head") orelse return false;
+    return encoder == .string and encoder.string.len > 0 and head == .string and head.string.len > 0;
 }
 
 fn resolveBundlePath(allocator: std.mem.Allocator, model_dir_path: []const u8, path: []const u8) ![]const u8 {
@@ -2153,6 +2269,46 @@ test "manifest falls back to first existing clipclap variant when preferred pair
     try std.testing.expect(manifest.isClipclapGgufBundle());
     try std.testing.expectEqualStrings(clip_path, manifest.gguf_path.?);
     try std.testing.expectEqualStrings(clap_path, manifest.audio_model_path.?);
+}
+
+test "manifest parses gliner2 variants gguf pair" {
+    const allocator = std.testing.allocator;
+    const dir_path = try testScratchDir(allocator, "manifest-gliner2-variants-gguf");
+    defer {
+        compat.cwd().deleteTree(compat.io(), dir_path) catch {};
+        allocator.free(dir_path);
+    }
+    const encoder_path = try std.fs.path.join(allocator, &.{ dir_path, "gliner2-encoder.Q4_K.gguf" });
+    defer allocator.free(encoder_path);
+    const head_path = try std.fs.path.join(allocator, &.{ dir_path, "gliner2-head.Q4_K.gguf" });
+    defer allocator.free(head_path);
+    try compat.cwd().writeFile(compat.io(), .{ .sub_path = encoder_path, .data = "GGUFstub" });
+    try compat.cwd().writeFile(compat.io(), .{ .sub_path = head_path, .data = "GGUFstub" });
+
+    var manifest = ModelManifest{ .allocator = allocator };
+    defer manifest.deinit();
+
+    try parseInferenceVariantsJson(&manifest, allocator, dir_path,
+        \\{
+        \\  "family": "gliner2_variants/v1",
+        \\  "variants": [
+        \\    {
+        \\      "id": "gguf-Q4_K",
+        \\      "target": "gguf",
+        \\      "format": "Q4_K",
+        \\      "encoder": "gliner2-encoder.Q4_K.gguf",
+        \\      "head": "gliner2-head.Q4_K.gguf"
+        \\    }
+        \\  ]
+        \\}
+    );
+
+    try std.testing.expect(manifest.isSplitGlinerBundle());
+    try std.testing.expectEqualStrings("gliner2_split_bundle/v1", manifest.inference_bundle_family);
+    try std.testing.expectEqualStrings("gliner2", manifest.gliner_model_type);
+    try std.testing.expectEqualStrings(encoder_path, manifest.gguf_path.?);
+    try std.testing.expectEqualStrings(head_path, manifest.gliner_head_gguf_path.?);
+    try std.testing.expect(manifest.hasInput("text"));
 }
 
 test "manifest uses clipclap variants when default ONNX bundle is partial" {

--- a/zig/pkg/inference/src/quantize/variants_manifest.zig
+++ b/zig/pkg/inference/src/quantize/variants_manifest.zig
@@ -81,6 +81,18 @@ pub fn clipclapGgufName(
     return std.fmt.allocPrint(allocator, "clipclap-{s}.{s}.gguf", .{ component, suffix });
 }
 
+pub fn gliner2GgufName(
+    allocator: Allocator,
+    component: []const u8,
+    format: []const u8,
+) ![]u8 {
+    const suffix = canonicalFormatSuffix(format);
+    if (suffix.len == 0) {
+        return std.fmt.allocPrint(allocator, "gliner2-{s}.gguf", .{component});
+    }
+    return std.fmt.allocPrint(allocator, "gliner2-{s}.{s}.gguf", .{ component, suffix });
+}
+
 pub fn writeClipclapVariantsManifest(allocator: Allocator, io: std.Io, model_dir: []const u8) !void {
     var names = try listFileNames(allocator, io, model_dir);
     defer {
@@ -209,6 +221,96 @@ pub fn writeClipclapVariantsManifest(allocator: Allocator, io: std.Io, model_dir
     try compat.cwd().writeFile(io, .{ .sub_path = path, .data = text.written() });
 }
 
+pub fn writeGliner2VariantsManifest(allocator: Allocator, io: std.Io, model_dir: []const u8) !void {
+    var names = try listFileNames(allocator, io, model_dir);
+    defer {
+        for (names.items) |name| allocator.free(name);
+        names.deinit(allocator);
+    }
+    if (!looksLikeGliner2Repo(names.items)) return;
+
+    var gguf_suffixes = std.ArrayListUnmanaged([]const u8).empty;
+    defer gguf_suffixes.deinit(allocator);
+    if (hasFile(names.items, "gliner2-encoder.gguf") and hasFile(names.items, "gliner2-head.gguf")) {
+        try gguf_suffixes.append(allocator, "");
+    }
+    for (names.items) |name| {
+        const prefix = "gliner2-encoder.";
+        const ext = ".gguf";
+        if (!std.mem.startsWith(u8, name, prefix) or !std.mem.endsWith(u8, name, ext)) continue;
+        if (name.len <= prefix.len + ext.len) continue;
+        const suffix = name[prefix.len .. name.len - ext.len];
+        if (suffix.len == 0 or containsSuffix(gguf_suffixes.items, suffix)) continue;
+        const head_name = try std.fmt.allocPrint(allocator, "gliner2-head.{s}.gguf", .{suffix});
+        defer allocator.free(head_name);
+        if (hasFile(names.items, head_name)) try gguf_suffixes.append(allocator, suffix);
+    }
+
+    var text: std.Io.Writer.Allocating = .init(allocator);
+    defer text.deinit();
+    const writer = &text.writer;
+    try writer.writeAll(
+        \\{
+        \\  "family": "gliner2_variants/v1",
+        \\  "defaults":
+    );
+    if (hasFile(names.items, "model.onnx")) {
+        try writer.writeAll(
+            \\{
+            \\    "onnx": {
+            \\      "format": "F32",
+            \\      "model": "model.onnx"
+            \\    }
+            \\  }
+        );
+    } else {
+        try writer.writeAll("{}");
+    }
+    try writer.writeAll(
+        \\,
+        \\  "variants": [
+        \\
+    );
+
+    var wrote_any = false;
+    for (gguf_suffixes.items) |suffix| {
+        if (wrote_any) try writer.writeAll(",\n");
+        wrote_any = true;
+        if (suffix.len == 0) {
+            try writer.writeAll(
+                \\    {
+                \\      "id": "gguf-f32",
+                \\      "target": "gguf",
+                \\      "format": "F32",
+                \\      "encoder": "gliner2-encoder.gguf",
+                \\      "head": "gliner2-head.gguf"
+                \\    }
+            );
+        } else {
+            try writer.print(
+                \\    {{
+                \\      "id": "gguf-{s}",
+                \\      "target": "gguf",
+                \\      "format": "{s}",
+                \\      "encoder": "gliner2-encoder.{s}.gguf",
+                \\      "head": "gliner2-head.{s}.gguf"
+                \\    }}
+            , .{ suffix, suffix, suffix, suffix });
+        }
+    }
+
+    try writer.writeAll(
+        \\
+        \\  ]
+        \\}
+        \\
+    );
+
+    const path = try std.fs.path.join(allocator, &.{ model_dir, "antfly_inference_variants.json" });
+    defer allocator.free(path);
+    try compat.cwd().writeFile(io, .{ .sub_path = path, .data = text.written() });
+}
+
 fn listFileNames(allocator: Allocator, io: std.Io, model_dir: []const u8) !std.ArrayListUnmanaged([]u8) {
     var names = std.ArrayListUnmanaged([]u8).empty;
     errdefer {
@@ -270,6 +372,21 @@ fn looksLikeClipclapRepo(names: []const []const u8) bool {
     return false;
 }
 
+fn looksLikeGliner2Repo(names: []const []const u8) bool {
+    if (hasFile(names, "model.onnx") or
+        hasFile(names, "model.safetensors") or
+        hasFile(names, "gliner2-encoder.gguf") or
+        hasFile(names, "gliner2-head.gguf"))
+    {
+        return true;
+    }
+    for (names) |name| {
+        if (std.mem.startsWith(u8, name, "gliner2-encoder.") and std.mem.endsWith(u8, name, ".gguf")) return true;
+        if (std.mem.startsWith(u8, name, "gliner2-head.") and std.mem.endsWith(u8, name, ".gguf")) return true;
+    }
+    return false;
+}
+
 fn hasFile(names: []const []const u8, needle: []const u8) bool {
     for (names) |name| {
         if (std.mem.eql(u8, name, needle)) return true;
@@ -298,6 +415,16 @@ test "ClipClap GGUF names leave F32 unsuffixed" {
     const q4_name = try clipclapGgufName(std.testing.allocator, "clap", "q4_k");
     defer std.testing.allocator.free(q4_name);
     try std.testing.expectEqualStrings("clipclap-clap.Q4_K.gguf", q4_name);
+}
+
+test "GLiNER2 GGUF names leave F32 unsuffixed" {
+    const f32_name = try gliner2GgufName(std.testing.allocator, "encoder", "none");
+    defer std.testing.allocator.free(f32_name);
+    try std.testing.expectEqualStrings("gliner2-encoder.gguf", f32_name);
+
+    const q4_name = try gliner2GgufName(std.testing.allocator, "head", "q4_k");
+    defer std.testing.allocator.free(q4_name);
+    try std.testing.expectEqualStrings("gliner2-head.Q4_K.gguf", q4_name);
 }
 
 test "ClipClap variants manifest indexes complete GGUF and ONNX variants" {
@@ -354,4 +481,37 @@ test "ClipClap variants manifest indexes complete GGUF and ONNX variants" {
     try std.testing.expect(std.mem.indexOf(u8, raw, "\"id\": \"onnx-Q8_0\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, raw, "\"clip\": \"clipclap-clip.Q4_K.gguf\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, raw, "\"text_model\": \"text_model.Q8_0.onnx\"") != null);
+}
+
+test "GLiNER2 variants manifest indexes complete GGUF pairs and ONNX default" {
+    const allocator = std.testing.allocator;
+    const dir_path = try std.fmt.allocPrint(allocator, ".zig-cache/tmp/gliner2-variants-manifest-{d}", .{std.posix.system.getpid()});
+    defer allocator.free(dir_path);
+    defer compat.cwd().deleteTree(compat.io(), dir_path) catch {};
+    try compat.cwd().createDirPath(compat.io(), dir_path);
+
+    const files = [_][]const u8{
+        "model.onnx",
+        "gliner2-encoder.Q4_K.gguf",
+        "gliner2-head.Q4_K.gguf",
+        "gliner2-encoder.Q8_0.gguf",
+    };
+    for (files) |file_name| {
+        const path = try std.fs.path.join(allocator, &.{ dir_path, file_name });
+        defer allocator.free(path);
+        try compat.cwd().writeFile(compat.io(), .{ .sub_path = path, .data = "" });
+    }
+
+    try writeGliner2VariantsManifest(allocator, compat.io(), dir_path);
+
+    const manifest_path = try std.fs.path.join(allocator, &.{ dir_path, "antfly_inference_variants.json" });
+    defer allocator.free(manifest_path);
+    const raw = try compat.cwd().readFileAlloc(compat.io(), manifest_path, allocator, .limited(64 * 1024));
+    defer allocator.free(raw);
+    try std.testing.expect(std.mem.indexOf(u8, raw, "\"family\": \"gliner2_variants/v1\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, raw, "\"id\": \"gguf-Q4_K\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, raw, "\"encoder\": \"gliner2-encoder.Q4_K.gguf\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, raw, "\"head\": \"gliner2-head.Q4_K.gguf\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, raw, "\"gguf-Q8_0\"") == null);
+    try std.testing.expect(std.mem.indexOf(u8, raw, "\"model\": \"model.onnx\"") != null);
 }

--- a/zig/pkg/inference/src/registry/download.zig
+++ b/zig/pkg/inference/src/registry/download.zig
@@ -79,6 +79,10 @@ const always_files = [_][]const u8{
     "modules.json",
     "config_sentence_transformers.json",
     "1_SpladePooling/config.json",
+    "added_tokens.json",
+    "gliner_config.json",
+    "termite_bundle.json",
+    "spm.model",
     "model_manifest.json",
     "antfly_metadata.json",
     "antfly_inference_variants.json",
@@ -336,6 +340,88 @@ fn appendBestClipclapGgufPair(
     return appendFirstCompleteClipclapGgufPair(allocator, to_download, files);
 }
 
+fn isGlinerEncoderGgufFile(path: []const u8) bool {
+    return glinerGgufSuffix(path, "encoder") != null;
+}
+
+fn isGlinerHeadGgufFile(path: []const u8) bool {
+    return glinerGgufSuffix(path, "head") != null;
+}
+
+fn glinerGgufSuffix(path: []const u8, component: []const u8) ?[]const u8 {
+    if (!isGgufFile(path)) return null;
+    const base = basename(path);
+    if (std.mem.eql(u8, component, "encoder") and std.mem.eql(u8, base, "encoder.gguf")) return "";
+    if (std.mem.eql(u8, component, "head") and std.mem.eql(u8, base, "gliner_head.gguf")) return "";
+
+    var prefix_buf: [48]u8 = undefined;
+    const prefix = std.fmt.bufPrint(&prefix_buf, "gliner2-{s}", .{component}) catch return null;
+    if (!std.mem.startsWith(u8, base, prefix)) return null;
+    const ext = ".gguf";
+    const rest = base[prefix.len..];
+    if (std.mem.eql(u8, rest, ext)) return "";
+    if (rest.len <= 1 + ext.len or rest[0] != '.') return null;
+    if (!std.mem.endsWith(u8, rest, ext)) return null;
+    return rest[1 .. rest.len - ext.len];
+}
+
+fn glinerGgufMatchesSuffix(path: []const u8, component: []const u8, suffix: []const u8) bool {
+    const actual = glinerGgufSuffix(path, component) orelse return false;
+    return std.ascii.eqlIgnoreCase(actual, suffix);
+}
+
+fn appendGlinerSplitGgufBundleForQuant(
+    allocator: std.mem.Allocator,
+    to_download: *std.ArrayListUnmanaged(HubFile),
+    files: []const HubFile,
+    quant_suffix: []const u8,
+) !bool {
+    var encoder: ?HubFile = null;
+    var head: ?HubFile = null;
+
+    for (files) |f| {
+        if (encoder == null and glinerGgufMatchesSuffix(f.name, "encoder", quant_suffix)) {
+            encoder = f;
+        } else if (head == null and glinerGgufMatchesSuffix(f.name, "head", quant_suffix)) {
+            head = f;
+        }
+    }
+
+    if (encoder == null or head == null) return false;
+    try to_download.append(allocator, encoder.?);
+    try to_download.append(allocator, head.?);
+    return true;
+}
+
+fn appendGlinerSplitGgufBundle(
+    allocator: std.mem.Allocator,
+    to_download: *std.ArrayListUnmanaged(HubFile),
+    files: []const HubFile,
+    quant_filter: ?[]const u8,
+) !bool {
+    if (quant_filter) |quant| {
+        return appendGlinerSplitGgufBundleForQuant(allocator, to_download, files, quant);
+    }
+
+    for (&gguf_quant_preference) |quant| {
+        if (try appendGlinerSplitGgufBundleForQuant(allocator, to_download, files, quant)) return true;
+    }
+    if (try appendGlinerSplitGgufBundleForQuant(allocator, to_download, files, "")) return true;
+
+    for (files) |f| {
+        const suffix = glinerGgufSuffix(f.name, "encoder") orelse continue;
+        if (try appendGlinerSplitGgufBundleForQuant(allocator, to_download, files, suffix)) return true;
+    }
+    return false;
+}
+
+fn hasGlinerSplitGgufCandidate(files: []const HubFile) bool {
+    for (files) |file| {
+        if (isGlinerEncoderGgufFile(file.name) or isGlinerHeadGgufFile(file.name)) return true;
+    }
+    return false;
+}
+
 fn hasClipclapGgufCandidate(files: []const HubFile) bool {
     for (files) |file| {
         if (isClipclapClipGgufFile(file.name) or isClipclapClapGgufFile(file.name)) return true;
@@ -355,6 +441,11 @@ fn appendBestRequestedGgufPayload(
         return true;
     }
     if (has_clipclap_gguf) return false;
+    const has_gliner_split_gguf = hasGlinerSplitGgufCandidate(files);
+    if (try appendGlinerSplitGgufBundle(allocator, to_download, files, quant_filter)) {
+        return true;
+    }
+    if (has_gliner_split_gguf) return false;
     if (try appendBestGgufFile(allocator, to_download, files, quant_filter)) {
         _ = try appendSelectedGgufProjectorFile(allocator, to_download, files, projector_selection);
         return true;
@@ -1513,6 +1604,60 @@ test "gguf clipclap partial pair does not fall back to generic single file" {
 
     try std.testing.expect(!try appendBestRequestedGgufPayload(allocator, &to_download, &files, "Q4_K", .auto));
     try std.testing.expectEqual(@as(usize, 0), to_download.items.len);
+}
+
+test "gguf selection keeps gliner encoder and head together" {
+    const allocator = std.testing.allocator;
+
+    const files = [_]HubFile{
+        .{ .name = "encoder.gguf" },
+        .{ .name = "gliner_head.gguf" },
+        .{ .name = "unrelated-Q4_K_M.gguf" },
+    };
+
+    var to_download = std.ArrayListUnmanaged(HubFile).empty;
+    defer to_download.deinit(allocator);
+
+    try std.testing.expect(try appendBestRequestedGgufPayload(allocator, &to_download, &files, null, .auto));
+
+    try std.testing.expectEqual(@as(usize, 2), to_download.items.len);
+    try std.testing.expectEqualStrings("encoder.gguf", to_download.items[0].name);
+    try std.testing.expectEqualStrings("gliner_head.gguf", to_download.items[1].name);
+}
+
+test "gguf gliner partial bundle does not fall back to generic single file" {
+    const allocator = std.testing.allocator;
+
+    const files = [_]HubFile{
+        .{ .name = "encoder.gguf" },
+        .{ .name = "unrelated-Q4_K_M.gguf" },
+    };
+
+    var to_download = std.ArrayListUnmanaged(HubFile).empty;
+    defer to_download.deinit(allocator);
+
+    try std.testing.expect(!try appendBestRequestedGgufPayload(allocator, &to_download, &files, null, .auto));
+    try std.testing.expectEqual(@as(usize, 0), to_download.items.len);
+}
+
+test "gguf selection keeps canonical gliner quantized pairs together" {
+    const allocator = std.testing.allocator;
+
+    const files = [_]HubFile{
+        .{ .name = "gliner2-encoder.Q8_0.gguf" },
+        .{ .name = "gliner2-head.Q8_0.gguf" },
+        .{ .name = "gliner2-encoder.Q4_K.gguf" },
+        .{ .name = "gliner2-head.Q4_K.gguf" },
+    };
+
+    var to_download = std.ArrayListUnmanaged(HubFile).empty;
+    defer to_download.deinit(allocator);
+
+    try std.testing.expect(try appendBestRequestedGgufPayload(allocator, &to_download, &files, "Q4_K", .auto));
+
+    try std.testing.expectEqual(@as(usize, 2), to_download.items.len);
+    try std.testing.expectEqualStrings("gliner2-encoder.Q4_K.gguf", to_download.items[0].name);
+    try std.testing.expectEqualStrings("gliner2-head.Q4_K.gguf", to_download.items[1].name);
 }
 
 test "projector-only selection finds mmproj gguf" {


### PR DESCRIPTION
## Summary
- add GLiNER2 split GGUF bundle download selection for canonical encoder/head filenames
- generate `gliner2_variants/v1` manifests with complete encoder/head pairs and ONNX defaults
- parse GLiNER2 variants/bundles into recognizer runtime metadata while avoiding head GGUF misclassification

## Validation
- `zig build inference-test`
- `zig build install`
- `./zig-out/bin/antfly inference list /private/tmp/antfly-gliner2-models` -> `recognizer   antflydb/gliner2-base-v1`
- `git diff --check`