### PR TITLE
Add Epstein graph visualization

### DIFF
--- a/examples/epstein/main.go
+++ b/examples/epstein/main.go
@@ -16,6 +16,7 @@ import (
 	"iter"
 	"log"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -1787,6 +1788,7 @@ func serveCmd(args []string) error {
 	// Create server
 	server := &SearchServer{
 		client:    client,
+		antflyURL: strings.TrimRight(*antflyURL, "/"),
 		tableName: *tableName,
 		tmpl:      tmpl,
 	}
@@ -1798,6 +1800,7 @@ func serveCmd(args []string) error {
 	mux.HandleFunc("/", server.handleIndex)
 	mux.HandleFunc("/search", server.handleSearch)
 	mux.HandleFunc("/api/search", server.handleAPISearch)
+	mux.HandleFunc("/api/graph", server.handleAPIGraph)
 
 	// Serve static PDF files from the pages directory
 	pagesDir := filepath.Join(*pdfDir, "pages")
@@ -1832,6 +1835,7 @@ func serveCmd(args []string) error {
 // SearchServer handles web requests
 type SearchServer struct {
 	client    *antfly.AntflyClient
+	antflyURL string
 	tableName string
 	tmpl      *template.Template
 }
@@ -1860,6 +1864,27 @@ type SearchPageData struct {
 	Error   string
 	Took    string
 	Total   int
+}
+
+type GraphVisualization struct {
+	Query string      `json:"query"`
+	Nodes []GraphNode `json:"nodes"`
+	Edges []GraphEdge `json:"edges"`
+}
+
+type GraphNode struct {
+	ID       string `json:"id"`
+	Label    string `json:"label"`
+	Subtitle string `json:"subtitle,omitempty"`
+	URL      string `json:"url,omitempty"`
+	Depth    int    `json:"depth,omitempty"`
+}
+
+type GraphEdge struct {
+	Source string  `json:"source"`
+	Target string  `json:"target"`
+	Type   string  `json:"type"`
+	Weight float64 `json:"weight,omitempty"`
 }
 
 func (s *SearchServer) handleIndex(w http.ResponseWriter, r *http.Request) {
@@ -1952,6 +1977,234 @@ func (s *SearchServer) handleAPISearch(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(resp)
+}
+
+func (s *SearchServer) handleAPIGraph(w http.ResponseWriter, r *http.Request) {
+	query := strings.TrimSpace(r.URL.Query().Get("q"))
+	if query == "" {
+		http.Error(w, "missing query parameter 'q'", http.StatusBadRequest)
+		return
+	}
+
+	resp, err := s.queryGraphVisualization(r.Context(), graphVisualizationQuery(query))
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	viz := buildGraphVisualization(query, resp)
+	if len(viz.Edges) == 0 {
+		if fallback, err := s.queryGraphVisualization(r.Context(), graphVisualizationSampleQuery()); err == nil {
+			viz = buildGraphVisualization(query, fallback)
+		}
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(viz)
+}
+
+func (s *SearchServer) queryGraphVisualization(ctx context.Context, payload map[string]any) (*antfly.QueryResponses, error) {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("marshal graph query: %w", err)
+	}
+
+	endpoint := fmt.Sprintf("%s/tables/%s/query", s.antflyURL, url.PathEscape(s.tableName))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("create graph query request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("query graph: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		data, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return nil, fmt.Errorf("query graph: %s", strings.TrimSpace(string(data)))
+	}
+
+	var decoded antfly.QueryResponses
+	if err := json.NewDecoder(resp.Body).Decode(&decoded); err != nil {
+		return nil, fmt.Errorf("decode graph query: %w", err)
+	}
+	return &decoded, nil
+}
+
+func graphVisualizationQuery(searchText string) map[string]any {
+	return map[string]any{
+		"full_text_search": map[string]any{
+			"query": searchText,
+		},
+		"limit": 8,
+		"graph_searches": map[string]any{
+			"relations": map[string]any{
+				"type":              "traverse",
+				"index_name":        DefaultAutographIndex,
+				"start_nodes":       map[string]any{"result_ref": "$full_text_results", "limit": 8},
+				"include_documents": true,
+				"fields":            []string{"title", "url", "metadata"},
+				"params": map[string]any{
+					"direction":     "both",
+					"max_depth":     1,
+					"max_results":   80,
+					"include_paths": true,
+				},
+			},
+		},
+	}
+}
+
+func graphVisualizationSampleQuery() map[string]any {
+	return map[string]any{
+		"query": map[string]any{
+			"match_all": map[string]any{},
+		},
+		"limit": 8,
+		"graph_searches": map[string]any{
+			"relations": map[string]any{
+				"type":              "traverse",
+				"index_name":        DefaultAutographIndex,
+				"start_nodes":       map[string]any{"result_ref": "$fused_results", "limit": 8},
+				"include_documents": true,
+				"fields":            []string{"title", "url", "metadata"},
+				"params": map[string]any{
+					"direction":     "both",
+					"max_depth":     1,
+					"max_results":   80,
+					"include_paths": true,
+				},
+			},
+		},
+	}
+}
+
+func buildGraphVisualization(query string, resp *antfly.QueryResponses) GraphVisualization {
+	viz := GraphVisualization{Query: query}
+	if resp == nil || len(resp.Responses) == 0 {
+		return viz
+	}
+	graph, ok := resp.Responses[0].GraphResults["relations"]
+	if !ok {
+		return viz
+	}
+
+	nodeByID := map[string]int{}
+	addNode := func(node GraphNode) {
+		if node.ID == "" {
+			return
+		}
+		if idx, ok := nodeByID[node.ID]; ok {
+			if viz.Nodes[idx].Label == node.ID && node.Label != "" {
+				viz.Nodes[idx].Label = node.Label
+			}
+			if viz.Nodes[idx].Subtitle == "" {
+				viz.Nodes[idx].Subtitle = node.Subtitle
+			}
+			if viz.Nodes[idx].URL == "" {
+				viz.Nodes[idx].URL = node.URL
+			}
+			return
+		}
+		if strings.TrimSpace(node.Label) == "" {
+			node.Label = node.ID
+		}
+		nodeByID[node.ID] = len(viz.Nodes)
+		viz.Nodes = append(viz.Nodes, node)
+	}
+
+	edgeSeen := map[string]struct{}{}
+	addEdge := func(edge GraphEdge) {
+		if edge.Source == "" || edge.Target == "" {
+			return
+		}
+		addNode(GraphNode{ID: edge.Source, Label: edge.Source})
+		addNode(GraphNode{ID: edge.Target, Label: edge.Target})
+		key := edge.Source + "\x00" + edge.Target + "\x00" + edge.Type
+		if _, ok := edgeSeen[key]; ok {
+			return
+		}
+		edgeSeen[key] = struct{}{}
+		viz.Edges = append(viz.Edges, edge)
+	}
+
+	for _, resultNode := range graph.Nodes {
+		addNode(graphNodeFromResult(resultNode))
+		for _, edge := range resultNode.PathEdges {
+			addEdge(GraphEdge{
+				Source: edge.Source,
+				Target: edge.Target,
+				Type:   edge.Type,
+				Weight: edge.Weight,
+			})
+		}
+		for _, edge := range graphEdgesFromPath(resultNode) {
+			addEdge(edge)
+		}
+		for _, edge := range resultNode.Edges {
+			addEdge(GraphEdge{
+				Source: string(edge.Source),
+				Target: string(edge.Target),
+				Type:   edge.Type,
+				Weight: edge.Weight,
+			})
+		}
+	}
+
+	return viz
+}
+
+func graphEdgesFromPath(node antfly.GraphResultNode) []GraphEdge {
+	if len(node.Path) < 2 || len(node.PathEdges) > 0 {
+		return nil
+	}
+	edges := make([]GraphEdge, 0, len(node.Path)-1)
+	for i := 1; i < len(node.Path); i++ {
+		edges = append(edges, GraphEdge{
+			Source: node.Path[i-1],
+			Target: node.Path[i],
+			Type:   "related",
+			Weight: node.Distance,
+		})
+	}
+	return edges
+}
+
+func graphNodeFromResult(node antfly.GraphResultNode) GraphNode {
+	title := node.Key
+	url := ""
+	subtitle := ""
+	if node.Document != nil {
+		if value, ok := node.Document["title"].(string); ok && strings.TrimSpace(value) != "" {
+			title = value
+		}
+		if value, ok := node.Document["url"].(string); ok {
+			url = value
+		}
+		if metadata, ok := node.Document["metadata"].(map[string]any); ok {
+			subtitle = graphNodeSubtitle(metadata)
+		}
+	}
+	return GraphNode{
+		ID:       node.Key,
+		Label:    title,
+		Subtitle: subtitle,
+		URL:      url,
+		Depth:    node.Depth,
+	}
+}
+
+func graphNodeSubtitle(metadata map[string]any) string {
+	parts := make([]string, 0, 2)
+	if source, ok := metadata["source_file"].(string); ok && source != "" {
+		parts = append(parts, filepath.Base(source))
+	}
+	if page, ok := metadata["page_number"].(float64); ok && page > 0 {
+		parts = append(parts, fmt.Sprintf("page %d", int(page)))
+	}
+	return strings.Join(parts, " - ")
 }
 
 func extractEntityChips(value any, limit int) []EntityChip {

--- a/examples/epstein/main_test.go
+++ b/examples/epstein/main_test.go
@@ -260,6 +260,103 @@ func TestCreateArtifactGraphIndexDefaultsToExtractorConfig(t *testing.T) {
 	}
 }
 
+func TestGraphVisualizationQueryUsesAutographIndex(t *testing.T) {
+	req := graphVisualizationQuery("Maxwell")
+	fullText, ok := req["full_text_search"].(map[string]any)
+	if !ok || fullText["query"] != "Maxwell" {
+		t.Fatalf("unexpected full-text search: %#v", req["full_text_search"])
+	}
+	graphSearches, ok := req["graph_searches"].(map[string]any)
+	if !ok {
+		t.Fatalf("graph searches missing: %#v", req)
+	}
+	graph, ok := graphSearches["relations"].(map[string]any)
+	if !ok {
+		t.Fatalf("relations graph search missing: %#v", graphSearches)
+	}
+	if graph["type"] != "traverse" {
+		t.Fatalf("graph type = %q, want traverse", graph["type"])
+	}
+	if graph["index_name"] != DefaultAutographIndex {
+		t.Fatalf("graph index = %q, want %s", graph["index_name"], DefaultAutographIndex)
+	}
+	startNodes, ok := graph["start_nodes"].(map[string]any)
+	if !ok || startNodes["result_ref"] != "$full_text_results" || startNodes["limit"] != 8 {
+		t.Fatalf("unexpected start nodes: %#v", graph["start_nodes"])
+	}
+	if graph["include_documents"] != true {
+		t.Fatalf("graph query should include documents")
+	}
+	params, ok := graph["params"].(map[string]any)
+	if !ok || params["direction"] != "both" || params["max_depth"] != 1 {
+		t.Fatalf("unexpected graph params: %#v", graph["params"])
+	}
+}
+
+func TestBuildGraphVisualizationConvertsGraphResults(t *testing.T) {
+	resp := antfly.QueryResponses{
+		Responses: []antfly.QueryResult{
+			{
+				GraphResults: map[string]antfly.GraphQueryResult{
+					"relations": {
+						Type: antfly.GraphQueryTypeTraverse,
+						Nodes: []antfly.GraphResultNode{
+							{
+								Key:   "doc-a",
+								Depth: 0,
+								Document: map[string]any{
+									"title": "Alpha page",
+									"url":   "http://example.test/a.pdf",
+									"metadata": map[string]any{
+										"source_file": "court/source.pdf",
+										"page_number": float64(12),
+									},
+								},
+							},
+							{
+								Key:   "doc-b",
+								Depth: 1,
+								Document: map[string]any{
+									"title": "Beta page",
+								},
+								PathEdges: []antfly.PathEdge{
+									{Source: "doc-a", Target: "doc-b", Type: "mentioned in", Weight: 0.75},
+								},
+							},
+							{
+								Key:      "Jeffrey Epstein",
+								Depth:    1,
+								Distance: 0.5,
+								Path:     []string{"doc-a", "Jeffrey Epstein"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	viz := buildGraphVisualization("Maxwell", &resp)
+	if viz.Query != "Maxwell" {
+		t.Fatalf("query = %q, want Maxwell", viz.Query)
+	}
+	if len(viz.Nodes) != 3 {
+		t.Fatalf("nodes = %d, want 3: %#v", len(viz.Nodes), viz.Nodes)
+	}
+	if viz.Nodes[0].Label != "Alpha page" || viz.Nodes[0].Subtitle != "source.pdf - page 12" {
+		t.Fatalf("unexpected first node: %#v", viz.Nodes[0])
+	}
+	if len(viz.Edges) != 2 {
+		t.Fatalf("edges = %d, want 2: %#v", len(viz.Edges), viz.Edges)
+	}
+	if viz.Edges[0].Source != "doc-a" || viz.Edges[0].Target != "doc-b" || viz.Edges[0].Type != "mentioned in" {
+		t.Fatalf("unexpected edge: %#v", viz.Edges[0])
+	}
+	if viz.Edges[1].Source != "doc-a" || viz.Edges[1].Target != "Jeffrey Epstein" || viz.Edges[1].Type != "related" {
+		t.Fatalf("unexpected path-derived edge: %#v", viz.Edges[1])
+	}
+}
+
 func TestInferenceMLBaseURLNormalizesRoots(t *testing.T) {
 	tests := []struct {
 		name string

--- a/examples/epstein/templates/index.html
+++ b/examples/epstein/templates/index.html
@@ -237,6 +237,77 @@
             color: #888;
         }
 
+        .graph-panel {
+            background: white;
+            border-radius: 8px;
+            padding: 18px;
+            margin-bottom: 20px;
+            box-shadow: 0 1px 5px rgba(0,0,0,0.08);
+        }
+
+        .graph-header {
+            display: flex;
+            justify-content: space-between;
+            gap: 12px;
+            align-items: baseline;
+            margin-bottom: 12px;
+        }
+
+        .graph-title {
+            font-size: 1rem;
+            font-weight: 600;
+            color: #1a1a2e;
+        }
+
+        .graph-meta {
+            color: #777;
+            font-size: 0.82rem;
+        }
+
+        .graph-canvas {
+            width: 100%;
+            height: 360px;
+            border: 1px solid #e1e5ec;
+            border-radius: 6px;
+            background: #fbfcfe;
+            display: block;
+        }
+
+        .graph-empty {
+            color: #777;
+            font-size: 0.9rem;
+            padding: 24px 0 6px;
+        }
+
+        .graph-node {
+            fill: #ffffff;
+            stroke: #4a90d9;
+            stroke-width: 1.5;
+            cursor: pointer;
+        }
+
+        .graph-node.seed {
+            fill: #e8f4e8;
+            stroke: #2d6a2d;
+        }
+
+        .graph-edge {
+            stroke: #a8b3c2;
+            stroke-width: 1.3;
+        }
+
+        .graph-label {
+            fill: #1a1a2e;
+            font-size: 11px;
+            pointer-events: none;
+        }
+
+        .graph-edge-label {
+            fill: #617089;
+            font-size: 10px;
+            pointer-events: none;
+        }
+
         .examples {
             margin-top: 20px;
             padding: 15px;
@@ -332,6 +403,15 @@
             Found {{.Total}} results for "{{.Query}}" ({{.Took}})
         </div>
 
+        <div class="graph-panel" data-query="{{.Query}}">
+            <div class="graph-header">
+                <div class="graph-title">Relation graph</div>
+                <div class="graph-meta" id="graph-meta">Loading...</div>
+            </div>
+            <svg class="graph-canvas" id="graph-canvas" role="img" aria-label="Relation graph"></svg>
+            <div class="graph-empty" id="graph-empty" hidden>No graph edges found for this search.</div>
+        </div>
+
         {{if .Results}}
             {{range .Results}}
             <div class="result-card">
@@ -374,5 +454,159 @@
             Documents sourced from <a href="https://archive.org/details/combined-all-epstein-files">Internet Archive</a> and <a href="https://www.justice.gov/epstein">DOJ</a>
         </p>
     </footer>
+    <script>
+        (function () {
+            const panel = document.querySelector(".graph-panel[data-query]");
+            if (!panel) return;
+
+            const svg = document.getElementById("graph-canvas");
+            const meta = document.getElementById("graph-meta");
+            const empty = document.getElementById("graph-empty");
+            const query = panel.getAttribute("data-query") || "";
+
+            fetch("/api/graph?q=" + encodeURIComponent(query))
+                .then((resp) => {
+                    if (!resp.ok) throw new Error(resp.statusText || "graph request failed");
+                    return resp.json();
+                })
+                .then((graph) => renderGraph(svg, meta, empty, graph))
+                .catch((err) => {
+                    meta.textContent = "Unavailable";
+                    empty.hidden = false;
+                    empty.textContent = err.message || "Graph data is unavailable.";
+                    svg.setAttribute("hidden", "hidden");
+                });
+
+            function renderGraph(svg, meta, empty, graph) {
+                const nodes = Array.isArray(graph.nodes) ? graph.nodes.slice(0, 40) : [];
+                const nodeIds = new Set(nodes.map((node) => node.id));
+                const edges = (Array.isArray(graph.edges) ? graph.edges : [])
+                    .filter((edge) => nodeIds.has(edge.source) && nodeIds.has(edge.target))
+                    .slice(0, 80);
+
+                meta.textContent = `${nodes.length} nodes, ${edges.length} edges`;
+                if (nodes.length === 0 || edges.length === 0) {
+                    empty.hidden = false;
+                    svg.setAttribute("hidden", "hidden");
+                    return;
+                }
+
+                empty.hidden = true;
+                svg.removeAttribute("hidden");
+                const width = svg.clientWidth || 860;
+                const height = svg.clientHeight || 360;
+                svg.setAttribute("viewBox", `0 0 ${width} ${height}`);
+                svg.textContent = "";
+
+                const state = layout(nodes, edges, width, height);
+                for (const edge of edges) {
+                    const source = state.get(edge.source);
+                    const target = state.get(edge.target);
+                    if (!source || !target) continue;
+                    const line = document.createElementNS("http://www.w3.org/2000/svg", "line");
+                    line.setAttribute("class", "graph-edge");
+                    line.setAttribute("x1", source.x);
+                    line.setAttribute("y1", source.y);
+                    line.setAttribute("x2", target.x);
+                    line.setAttribute("y2", target.y);
+                    svg.appendChild(line);
+
+                    const label = document.createElementNS("http://www.w3.org/2000/svg", "text");
+                    label.setAttribute("class", "graph-edge-label");
+                    label.setAttribute("x", (source.x + target.x) / 2);
+                    label.setAttribute("y", (source.y + target.y) / 2 - 4);
+                    label.setAttribute("text-anchor", "middle");
+                    label.textContent = edge.type || "related";
+                    svg.appendChild(label);
+                }
+
+                for (const node of nodes) {
+                    const point = state.get(node.id);
+                    if (!point) continue;
+                    const group = document.createElementNS("http://www.w3.org/2000/svg", "g");
+                    if (node.url) {
+                        group.addEventListener("click", () => window.open(node.url, "_blank", "noopener"));
+                    }
+                    const circle = document.createElementNS("http://www.w3.org/2000/svg", "circle");
+                    circle.setAttribute("class", "graph-node" + (node.depth === 0 ? " seed" : ""));
+                    circle.setAttribute("cx", point.x);
+                    circle.setAttribute("cy", point.y);
+                    circle.setAttribute("r", node.depth === 0 ? 10 : 8);
+                    group.appendChild(circle);
+
+                    const title = document.createElementNS("http://www.w3.org/2000/svg", "title");
+                    title.textContent = [node.label, node.subtitle].filter(Boolean).join("\n");
+                    group.appendChild(title);
+
+                    const label = document.createElementNS("http://www.w3.org/2000/svg", "text");
+                    label.setAttribute("class", "graph-label");
+                    label.setAttribute("x", point.x + 12);
+                    label.setAttribute("y", point.y + 4);
+                    label.textContent = shortLabel(node.label || node.id);
+                    group.appendChild(label);
+                    svg.appendChild(group);
+                }
+            }
+
+            function layout(nodes, edges, width, height) {
+                const state = new Map();
+                const radius = Math.max(80, Math.min(width, height) * 0.34);
+                nodes.forEach((node, i) => {
+                    const angle = (2 * Math.PI * i) / Math.max(nodes.length, 1);
+                    state.set(node.id, {
+                        x: width / 2 + Math.cos(angle) * radius,
+                        y: height / 2 + Math.sin(angle) * radius,
+                        vx: 0,
+                        vy: 0,
+                    });
+                });
+                for (let step = 0; step < 180; step++) {
+                    for (let i = 0; i < nodes.length; i++) {
+                        const a = state.get(nodes[i].id);
+                        for (let j = i + 1; j < nodes.length; j++) {
+                            const b = state.get(nodes[j].id);
+                            const dx = a.x - b.x || 0.1;
+                            const dy = a.y - b.y || 0.1;
+                            const d2 = dx * dx + dy * dy;
+                            const force = Math.min(1400 / d2, 0.08);
+                            a.vx += dx * force;
+                            a.vy += dy * force;
+                            b.vx -= dx * force;
+                            b.vy -= dy * force;
+                        }
+                    }
+                    for (const edge of edges) {
+                        const a = state.get(edge.source);
+                        const b = state.get(edge.target);
+                        if (!a || !b) continue;
+                        const dx = b.x - a.x;
+                        const dy = b.y - a.y;
+                        const dist = Math.sqrt(dx * dx + dy * dy) || 1;
+                        const force = (dist - 95) * 0.006;
+                        const fx = (dx / dist) * force;
+                        const fy = (dy / dist) * force;
+                        a.vx += fx;
+                        a.vy += fy;
+                        b.vx -= fx;
+                        b.vy -= fy;
+                    }
+                    for (const point of state.values()) {
+                        point.vx += (width / 2 - point.x) * 0.004;
+                        point.vy += (height / 2 - point.y) * 0.004;
+                        point.x = Math.max(20, Math.min(width - 140, point.x + point.vx));
+                        point.y = Math.max(24, Math.min(height - 24, point.y + point.vy));
+                        point.vx *= 0.72;
+                        point.vy *= 0.72;
+                    }
+                }
+                return state;
+            }
+
+            function shortLabel(value) {
+                value = String(value || "").replace(/\s+/g, " ").trim();
+                return value.length > 44 ? value.slice(0, 41) + "..." : value;
+            }
+        })();
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add an Epstein `/api/graph` endpoint backed by the `autograph_relations` graph index
- render a self-contained SVG relation graph panel on search pages
- add focused tests for graph payload construction and result conversion

## Validation
- `go test ./...` from `examples/epstein`
- `go build -o epstein .` from `examples/epstein`
- `git diff --check`
- local smoke: `GET http://127.0.0.1:3010/api/graph?q=Maxwell` returned 4 nodes and 2 edges
- Playwright Chromium smoke confirmed the SVG rendered 4 graph nodes and 2 graph edges