### PR TITLE
Improve recall harness failure diagnostics

### DIFF
--- a/zig/bench/vectors/recall_harness.zig
+++ b/zig/bench/vectors/recall_harness.zig
@@ -168,7 +168,13 @@ fn runSuite(
             "recall_harness_case_start suite={s} dataset={s} randomize={any} count={d} topk={d}\n",
             .{ suite_name, case.dataset, case.randomize, case.count, case.top_k },
         );
-        const actual = try runner(io, alloc, cfg, dataset_path, case);
+        const actual = runner(io, alloc, cfg, dataset_path, case) catch |err| {
+            std.debug.print(
+                "recall_harness_case_error suite={s} dataset={s} path={s} randomize={any} count={d} topk={d} err={s}\n",
+                .{ suite_name, case.dataset, dataset_path, case.randomize, case.count, case.top_k, @errorName(err) },
+            );
+            return err;
+        };
         const case_ok = compareMetrics(case, actual);
         all_ok = all_ok and case_ok;
 
@@ -299,11 +305,23 @@ fn calculateQuantizerRecallMetric(
             );
         }
         const query = queries.atConst(query_idx);
-        try quantizer.estimateDistancesWithScratch(&quantized, query, estimated, error_bounds, &scratch);
+        quantizer.estimateDistancesWithScratch(&quantized, query, estimated, error_bounds, &scratch) catch |err| {
+            std.debug.print(
+                "recall_harness_query_error suite=quantizer dataset={s} metric={s} query={d}/{d} phase=estimate err={s}\n",
+                .{ dataset_label, @tagName(metric), query_number, queries.count, @errorName(err) },
+            );
+            return err;
+        };
         for (prediction, 0..) |*slot, i| slot.* = i;
         std.mem.sort(usize, prediction, commonDistanceCtx(estimated), distanceLessThan);
 
-        const truth = try common.calculateTruth(alloc, top_k, metric, query, data);
+        const truth = common.calculateTruth(alloc, top_k, metric, query, data) catch |err| {
+            std.debug.print(
+                "recall_harness_query_error suite=quantizer dataset={s} metric={s} query={d}/{d} phase=truth err={s}\n",
+                .{ dataset_label, @tagName(metric), query_number, queries.count, @errorName(err) },
+            );
+            return err;
+        };
         defer alloc.free(truth);
         recall_sum += common.calculateRecall(prediction[0..top_k], truth);
     }
@@ -374,7 +392,13 @@ fn calculateHBCRecallMetric(
         "recall_harness_metric_start suite=hbc dataset={s} randomize={any} metric={s} data={d} queries={d}\n",
         .{ dataset_label, randomize, @tagName(metric), split.data.count, split.queries.count },
     );
-    var built = try buildHBCIndex(alloc, split, randomize, metric, bulk_build, centroid_only_routing);
+    var built = buildHBCIndex(alloc, split, randomize, metric, bulk_build, centroid_only_routing) catch |err| {
+        std.debug.print(
+            "recall_harness_build_error suite=hbc dataset={s} randomize={any} metric={s} err={s}\n",
+            .{ dataset_label, randomize, @tagName(metric), @errorName(err) },
+        );
+        return err;
+    };
     defer built.deinit();
     std.debug.print(
         "recall_harness_build_done suite=hbc dataset={s} randomize={any} metric={s}\n",
@@ -393,7 +417,13 @@ fn calculateHBCRecallMetric(
             );
         }
         const query = queries.atConst(query_idx);
-        var results = try built.idx.search(query, top_k);
+        var results = built.idx.search(query, top_k) catch |err| {
+            std.debug.print(
+                "recall_harness_query_error suite=hbc dataset={s} randomize={any} metric={s} query={d}/{d} phase=search err={s}\n",
+                .{ dataset_label, randomize, @tagName(metric), query_number, queries.count, @errorName(err) },
+            );
+            return err;
+        };
         defer results.deinit();
 
         const hits = results.getHits();
@@ -403,7 +433,13 @@ fn calculateHBCRecallMetric(
             slot.* = @intCast(hits[i].vector_id - 1);
         }
 
-        const truth = try common.calculateTruth(alloc, top_k, metric, query, data);
+        const truth = common.calculateTruth(alloc, top_k, metric, query, data) catch |err| {
+            std.debug.print(
+                "recall_harness_query_error suite=hbc dataset={s} randomize={any} metric={s} query={d}/{d} phase=truth err={s}\n",
+                .{ dataset_label, randomize, @tagName(metric), query_number, queries.count, @errorName(err) },
+            );
+            return err;
+        };
         defer alloc.free(truth);
         recall_sum += common.calculateRecall(prediction, truth);
     }

--- a/zig/build.zig
+++ b/zig/build.zig
@@ -6054,6 +6054,7 @@ pub fn build(b: *std.Build) void {
     });
 
     const run_recall_harness = b.addRunArtifact(recall_harness);
+    run_recall_harness.stdio = .inherit;
     if (b.args) |args| {
         run_recall_harness.addArgs(args);
     }
@@ -6130,6 +6131,7 @@ pub fn build(b: *std.Build) void {
     antfly_step.dependOn(&run_antfly.step);
 
     const run_recall_harness_default = b.addRunArtifact(recall_harness);
+    run_recall_harness_default.stdio = .inherit;
     run_recall_harness_default.addArgs(&.{
         "--dataset-dir",
         "testdata/vectorsets",


### PR DESCRIPTION
## Summary
- inherit stdio for recall harness run steps so CI shows harness progress and failure context
- log suite/dataset/path/count/top-k at the case boundary when a runner returns an error
- log HBC build errors and per-query search/truth errors with metric and query number

## Test
- zig build recall-harness -- --dataset-dir testdata/vectorsets --dataset random-20d-1k.gob
- zig build recall-harness -- --dataset-dir testdata/vectorsets --dataset images-512d-10k.gob