### PR TITLE
Make recall harness heartbeat optional

### DIFF
--- a/zig/bench/vectors/recall_harness.zig
+++ b/zig/bench/vectors/recall_harness.zig
@@ -71,11 +71,20 @@ pub fn main(init: std.process.Init) !void {
     const alloc = gpa_state.allocator();
 
     const cfg = try parseArgs(init.minimal.args);
+    std.debug.print("recall_harness_start dataset_dir={s} dataset_filter={s} suite={s}\n", .{
+        cfg.dataset_dir,
+        cfg.dataset_filter orelse "<all>",
+        @tagName(cfg.suite),
+    });
+
     var heartbeat = Heartbeat{};
-    const heartbeat_thread = try std.Thread.spawn(.{ .stack_size = 256 * 1024 }, Heartbeat.run, .{&heartbeat});
+    const heartbeat_thread = std.Thread.spawn(.{ .stack_size = 256 * 1024 }, Heartbeat.run, .{&heartbeat}) catch |err| blk: {
+        std.debug.print("recall_harness_heartbeat_disabled err={s}\n", .{@errorName(err)});
+        break :blk null;
+    };
     defer {
         heartbeat.stop.store(true, .release);
-        heartbeat_thread.join();
+        if (heartbeat_thread) |thread| thread.join();
     }
 
     var ok = true;


### PR DESCRIPTION
## Summary
- log recall harness startup before optional background heartbeat setup
- treat heartbeat thread startup as best-effort so diagnostic heartbeat failures do not fail recall validation
- preserve heartbeat join when the background thread starts successfully

## Context
The main-branch full-default job on 2026-06-06 failed before any recall case diagnostics were emitted, with only error.Unexpected. After #187, the remaining pre-case fallible operation is the diagnostic heartbeat thread spawn; this keeps that diagnostic from failing the harness before recall validation starts.

## Test
- zig build recall-harness -- --dataset-dir testdata/vectorsets --dataset images-512d-10k.gob