### PR TITLE
ci: trigger Colony docs builds

### DIFF
--- a/.github/workflows/trigger-docs-build.yml
+++ b/.github/workflows/trigger-docs-build.yml
@@ -9,6 +9,11 @@ on:
       - 'examples/**'
       - 'docs/**'
       - 'go/pkg/operator/docs/**'
+      - 'go/pkg/termite/registry/index.json'
+      - 'specs/openapi/**'
+  release:
+    types: [published]
+  workflow_dispatch:
 
 jobs:
   trigger:
@@ -20,3 +25,4 @@ jobs:
           token: ${{ secrets.COLONY_DISPATCH_TOKEN }}
           repository: antflydb/colony
           event-type: antfly-docs-updated
+          client-payload: '{"ref":"${{ github.ref_name }}","sha":"${{ github.sha }}","event":"${{ github.event_name }}"}'


### PR DESCRIPTION
## Summary
- trigger Colony docs rebuilds when docs, examples, changelog, operator docs, or OpenAPI specs change
- add release, nightly, and manual triggers for docs publishing
- pass ref, sha, and event metadata in the repository dispatch payload

## Testing
- not run; workflow-only change