### PR TITLE
Fix rc2 query and inference regressions

### DIFF
--- a/zig/e2e/antfly/test_query_string.py
+++ b/zig/e2e/antfly/test_query_string.py
@@ -16,16 +16,19 @@
 
 from __future__ import annotations
 
+import json
 import time
+
+import requests
 
 from helpers import wait_until
 
 
-def _hit_ids(result: dict) -> list[str]:
+def _hit_ids(result: dict, response_index: int = 0) -> list[str]:
     responses = result.get("responses", [])
-    if not responses:
+    if len(responses) <= response_index:
         return []
-    return [hit.get("_id") for hit in responses[0].get("hits", {}).get("hits", [])]
+    return [hit.get("_id") for hit in responses[response_index].get("hits", {}).get("hits", [])]
 
 
 def _query_hit_ids(stateful_api, table_name: str, payload: dict) -> list[str] | None:
@@ -34,6 +37,18 @@ def _query_hit_ids(stateful_api, table_name: str, payload: dict) -> list[str] | 
     except Exception:
         return None
     return _hit_ids(result)
+
+
+def _post_ndjson_multiquery(stateful_api, path: str, payloads: list[dict]) -> dict:
+    body = "\n".join(json.dumps(payload, separators=(",", ":")) for payload in payloads) + "\n"
+    response = requests.post(
+        f"{stateful_api.url}{path}",
+        data=body,
+        headers={"Content-Type": "application/x-ndjson"},
+        timeout=30,
+    )
+    assert response.status_code == 200, response.text
+    return response.json()
 
 
 def test_bleve_query_string_full_text_and_filter(stateful_api):
@@ -112,6 +127,60 @@ def test_bleve_query_string_full_text_and_filter(stateful_api):
     assert filtered_result is not None
     assert filtered_result[:2] == ["doc:a", "doc:b"]
     assert "doc:c" not in filtered_result
+
+    table_multiquery = wait_until(
+        lambda: (
+            result
+            if len((result := _post_ndjson_multiquery(
+                stateful_api,
+                f"/tables/{table_name}/query",
+                [
+                    {
+                        "fields": ["title"],
+                        "limit": 5,
+                    },
+                    {
+                        "fields": ["status"],
+                        "limit": 5,
+                    },
+                ],
+            )).get("responses", [])) == 2
+            and len(result["responses"][0].get("hits", {}).get("hits", [])) > 0
+            and len(result["responses"][1].get("hits", {}).get("hits", [])) > 0
+            else None
+        ),
+        timeout_s=30.0,
+        interval_s=0.5,
+    )
+    assert table_multiquery is not None
+
+    global_multiquery = wait_until(
+        lambda: (
+            result
+            if len((result := _post_ndjson_multiquery(
+                stateful_api,
+                "/query",
+                [
+                    {
+                        "table": table_name,
+                        "fields": ["body"],
+                        "limit": 5,
+                    },
+                    {
+                        "table": table_name,
+                        "fields": ["status"],
+                        "limit": 5,
+                    },
+                ],
+            )).get("responses", [])) == 2
+            and len(result["responses"][0].get("hits", {}).get("hits", [])) > 0
+            and len(result["responses"][1].get("hits", {}).get("hits", [])) > 0
+            else None
+        ),
+        timeout_s=30.0,
+        interval_s=0.5,
+    )
+    assert global_multiquery is not None
 
 
 def test_direct_full_text_match_and_prefix(stateful_api):

--- a/zig/pkg/antfly/src/api/http_server.zig
+++ b/zig/pkg/antfly/src/api/http_server.zig
@@ -82,6 +82,30 @@ const parseJsonValueAlloc = json_helpers.parseJsonValueAlloc;
 const parseOwnedJsonValueAlloc = json_helpers.parseOwnedJsonValueAlloc;
 const parseOwnedJsonObjectMapAlloc = json_helpers.parseOwnedJsonObjectMapAlloc;
 
+const ParsedGlobalQueryTable = struct {
+    parsed: std.json.Parsed(metadata_openapi.QueryRequest),
+    table_name: []const u8,
+
+    fn deinit(self: *@This()) void {
+        self.parsed.deinit();
+    }
+};
+
+fn parseGlobalQueryTable(alloc: std.mem.Allocator, body: []const u8) !ParsedGlobalQueryTable {
+    var parsed = metadata_openapi.server.parseGlobalQueryBody(alloc, body) catch return error.InvalidQueryRequest;
+    errdefer parsed.deinit();
+    return .{
+        .parsed = parsed,
+        .table_name = parsed.value.table orelse "",
+    };
+}
+
+fn isNdjsonContentType(content_type: ?[]const u8) bool {
+    const value = content_type orelse return false;
+    const media_type = std.mem.trim(u8, if (std.mem.indexOfScalar(u8, value, ';')) |idx| value[0..idx] else value, " \t");
+    return std.ascii.eqlIgnoreCase(media_type, "application/x-ndjson");
+}
+
 const TestSseEvent = struct {
     event: []const u8,
     data: []const u8,
@@ -3414,7 +3438,7 @@ pub const ApiHttpServer = struct {
         }
         if (req.method == .POST) {
             if (routes.Routes.matchTableQuery(uri_parts.path)) |query_route| {
-                return try self.handlePublicTableQuery(query_route.table_name, req.body, authenticated_identity);
+                return try self.handlePublicTableQueryWithContentType(query_route.table_name, req.body, req.content_type, authenticated_identity);
             }
         }
         if (req.method == .POST) {
@@ -5464,6 +5488,23 @@ pub const ApiHttpServer = struct {
         };
     }
 
+    pub fn handlePublicTableQueryWithContentType(
+        self: *ApiHttpServer,
+        table_name: []const u8,
+        body: []const u8,
+        content_type: ?[]const u8,
+        authenticated_identity: ?AuthenticatedIdentity,
+    ) !http_common.HttpResponse {
+        if (isNdjsonContentType(content_type)) {
+            return try self.handlePublicTableMultiQuery(table_name, body, authenticated_identity);
+        }
+        return try self.handlePublicTableQuery(table_name, body, authenticated_identity);
+    }
+
+    pub fn handlePublicGlobalMultiQuery(self: *ApiHttpServer, body: []const u8, authenticated_identity: ?AuthenticatedIdentity) !http_common.HttpResponse {
+        return try self.handlePublicTableMultiQuery(null, body, authenticated_identity);
+    }
+
     pub fn handlePublicTableQuery(self: *ApiHttpServer, table_name: []const u8, body: []const u8, authenticated_identity: ?AuthenticatedIdentity) !http_common.HttpResponse {
         const row_filter_json = try resolveEffectiveRowFilterJson(self.alloc, authenticated_identity, table_name);
         defer if (row_filter_json) |value| self.alloc.free(value);
@@ -5491,6 +5532,84 @@ pub const ApiHttpServer = struct {
         defer arena_impl.deinit();
         const parsed = try parseJsonResponseBody(metadata_openapi.QueryResponses, arena_impl.allocator(), response_body);
         return try jsonResponse(self.alloc, parsed);
+    }
+
+    fn handlePublicTableMultiQuery(
+        self: *ApiHttpServer,
+        route_table_name: ?[]const u8,
+        body: []const u8,
+        authenticated_identity: ?AuthenticatedIdentity,
+    ) !http_common.HttpResponse {
+        var arena_impl = std.heap.ArenaAllocator.init(self.alloc);
+        defer arena_impl.deinit();
+        const arena = arena_impl.allocator();
+
+        var out: std.Io.Writer.Allocating = .init(self.alloc);
+        defer out.deinit();
+        try out.writer.writeAll("{\"responses\":[");
+        var emitted: usize = 0;
+
+        var lines = std.mem.splitScalar(u8, body, '\n');
+        while (lines.next()) |raw_line| {
+            const line = std.mem.trim(u8, raw_line, " \t\r");
+            if (line.len == 0) continue;
+
+            const table_name = if (route_table_name) |name| name else blk: {
+                var parsed_table = parseGlobalQueryTable(arena, line) catch {
+                    return try textResponse(self.alloc, 400, "invalid query request");
+                };
+                defer parsed_table.deinit();
+                if (parsed_table.table_name.len == 0) {
+                    return try textResponse(self.alloc, 400, "invalid query request");
+                }
+                break :blk parsed_table.table_name;
+            };
+
+            const row_filter_json = try resolveEffectiveRowFilterJson(self.alloc, authenticated_identity, table_name);
+            defer if (row_filter_json) |value| self.alloc.free(value);
+
+            const source = self.table_reads orelse return try textResponse(self.alloc, 404, "not found");
+            const response_body = self.executePublicTableQueryDispatchWithReadinessRetry(
+                self.alloc,
+                source,
+                table_name,
+                line,
+                row_filter_json,
+                authenticated_identity,
+            ) catch |err| switch (err) {
+                error.InvalidQueryRequest => return try textResponse(self.alloc, 400, "invalid query request"),
+                error.NotFound, error.TableNotFound => return try textResponse(self.alloc, 404, "not found"),
+                error.DocIdentityNamespaceMismatch => return try textResponse(self.alloc, 503, "doc identity unavailable"),
+                else => {
+                    std.log.err("public table multiquery execution failed table={s} err={}", .{ table_name, err });
+                    return try textResponse(self.alloc, 500, "query failed");
+                },
+            };
+            defer self.alloc.free(response_body);
+
+            var parsed = std.json.parseFromSlice(std.json.Value, arena, response_body, .{
+                .allocate = .alloc_always,
+            }) catch return try textResponse(self.alloc, 500, "query failed");
+            defer parsed.deinit();
+            const object = switch (parsed.value) {
+                .object => |object| object,
+                else => return try textResponse(self.alloc, 500, "query failed"),
+            };
+            const responses_value = object.get("responses") orelse return try textResponse(self.alloc, 500, "query failed");
+            const responses = switch (responses_value) {
+                .array => |array| array.items,
+                else => return try textResponse(self.alloc, 500, "query failed"),
+            };
+            for (responses) |response_value| {
+                if (emitted > 0) try out.writer.writeByte(',');
+                try std.json.Stringify.value(response_value, .{}, &out.writer);
+                emitted += 1;
+            }
+        }
+
+        if (emitted == 0) return try textResponse(self.alloc, 400, "invalid query request");
+        try out.writer.writeAll("]}");
+        return try jsonBodyResponseWithStatus(self.alloc, 200, out.written());
     }
 
     pub fn handlePublicTableListIndexes(self: *ApiHttpServer, table_name: []const u8) !http_common.HttpResponse {

--- a/zig/pkg/antfly/src/api/http_server.zig
+++ b/zig/pkg/antfly/src/api/http_server.zig
@@ -5006,10 +5006,34 @@ pub const ApiHttpServer = struct {
         if (row_filter_json) |value| {
             injectRowFilterIntoSearchRequest(alloc, &query_req.req, value) catch return error.InvalidQueryRequest;
         }
-        return (source.query(alloc, table_name, query_req.req, .read_index) catch |err| {
-            std.log.warn("public table query read failed table={s} err={}", .{ table_name, err });
-            return err;
-        }) orelse error.TableNotFound;
+        return (try queryWithTransientReadRetry(alloc, source, table_name, query_req.req, .read_index)) orelse error.TableNotFound;
+    }
+
+    fn queryWithTransientReadRetry(
+        alloc: std.mem.Allocator,
+        source: table_reads.TableReadSource,
+        table_name: []const u8,
+        req: db_mod.types.SearchRequest,
+        consistency: raft_mod.ReadConsistency,
+    ) !?query_api.QueryResponse {
+        const retry_timeout_ns = 5 * std.time.ns_per_s;
+        const retry_poll_ns = 25 * std.time.ns_per_ms;
+        const start_ns = platform_time.monotonicNs();
+        var attempts: u32 = 0;
+        while (true) : (attempts += 1) {
+            return source.query(alloc, table_name, req, consistency) catch |err| switch (err) {
+                error.EndOfStream => {
+                    std.log.warn("public table query read failed table={s} err={} attempt={d}", .{ table_name, err, attempts + 1 });
+                    if (platform_time.monotonicNs() -| start_ns >= retry_timeout_ns) return err;
+                    sleepNs(retry_poll_ns);
+                    continue;
+                },
+                else => {
+                    std.log.warn("public table query read failed table={s} err={}", .{ table_name, err });
+                    return err;
+                },
+            };
+        }
     }
 
     fn stringifyJsonValueAlloc(alloc: std.mem.Allocator, value: std.json.Value) ![]u8 {
@@ -12203,6 +12227,90 @@ test "api http server maps public query doc identity mismatch to unavailable" {
 
     try std.testing.expectEqual(@as(u16, 503), resp.status);
     try std.testing.expectEqualStrings("doc identity unavailable", resp.body);
+}
+
+test "api http server retries transient query EndOfStream before returning 500" {
+    const alloc = std.testing.allocator;
+
+    const FakeSource = struct {
+        fn iface() StatusSource {
+            return .{
+                .ptr = undefined,
+                .vtable = &.{
+                    .status = status,
+                },
+            };
+        }
+
+        fn status(_: *anyopaque) !metadata_api.MetadataStatus {
+            return .{ .metadata_group_id = 1, .metrics = .{}, .projected_stores = 1 };
+        }
+    };
+
+    const FakeReads = struct {
+        attempts: u32 = 0,
+
+        fn source(self: *@This()) table_reads.TableReadSource {
+            return .{
+                .ptr = self,
+                .vtable = &.{
+                    .lookup = lookup,
+                    .scan = scan,
+                    .query = query,
+                },
+            };
+        }
+
+        fn lookup(
+            _: *anyopaque,
+            _: std.mem.Allocator,
+            _: []const u8,
+            _: []const u8,
+            _: db_mod.types.LookupOptions,
+            _: raft_mod.ReadConsistency,
+        ) !?table_reads.LookupResponse {
+            return null;
+        }
+
+        fn scan(
+            _: *anyopaque,
+            _: std.mem.Allocator,
+            _: []const u8,
+            _: []const u8,
+            _: []const u8,
+            _: db_mod.types.ScanOptions,
+            _: raft_mod.ReadConsistency,
+        ) !?table_reads.ScanResponse {
+            return null;
+        }
+
+        fn query(
+            ptr: *anyopaque,
+            inner_alloc: std.mem.Allocator,
+            table_name: []const u8,
+            _: db_mod.types.SearchRequest,
+            _: raft_mod.ReadConsistency,
+        ) !?query_api.QueryResponse {
+            const self: *@This() = @ptrCast(@alignCast(ptr));
+            try std.testing.expectEqualStrings("docs", table_name);
+            self.attempts += 1;
+            if (self.attempts == 1) return error.EndOfStream;
+            return .{ .json = try inner_alloc.dupe(u8, "{\"responses\":[]}") };
+        }
+    };
+
+    var reads = FakeReads{};
+    var server = ApiHttpServer.init(alloc, .{}, FakeSource.iface(), reads.source(), null);
+    defer server.deinit();
+
+    var resp = try server.handlePublicTableQuery("docs",
+        \\{"query":{"match_all":{}}}
+    , null);
+    defer resp.deinit(alloc);
+
+    try std.testing.expectEqual(@as(u16, 200), resp.status);
+    try std.testing.expectEqual(@as(u32, 2), reads.attempts);
+    try std.testing.expect(std.mem.indexOf(u8, resp.body, "\"responses\"") != null);
 }
 
 test "api http server serves internal group transaction routes" {

--- a/zig/pkg/antfly/src/api/httpx_handler.zig
+++ b/zig/pkg/antfly/src/api/httpx_handler.zig
@@ -76,6 +76,12 @@ fn parseGlobalQueryTable(alloc: std.mem.Allocator, body: []const u8) !ParsedGlob
     };
 }
 
+fn isNdjsonContentType(content_type: ?[]const u8) bool {
+    const value = content_type orelse return false;
+    const media_type = std.mem.trim(u8, if (std.mem.indexOfScalar(u8, value, ';')) |idx| value[0..idx] else value, " \t");
+    return std.ascii.eqlIgnoreCase(media_type, "application/x-ndjson");
+}
+
 pub const AntflyApiHandler = struct {
     api_server: *ApiHttpServer,
 
@@ -1145,6 +1151,13 @@ pub const AntflyApiHandler = struct {
             _ = ctx.status(400);
             return ctx.text("missing body");
         };
+        if (isNdjsonContentType(ctx.header("content-type"))) {
+            var resp = try self.api_server.handlePublicGlobalMultiQuery(
+                body_data,
+                authenticated_identity,
+            );
+            return respondWithAllocator(ctx, &resp, self.api_server.alloc);
+        }
         var parsed_table = parseGlobalQueryTable(ctx.allocator, body_data) catch {
             _ = ctx.status(400);
             return ctx.text("invalid query request");
@@ -1659,9 +1672,10 @@ pub const AntflyApiHandler = struct {
             _ = ctx.status(400);
             return ctx.text("missing body");
         };
-        var resp = try self.api_server.handlePublicTableQuery(
+        var resp = try self.api_server.handlePublicTableQueryWithContentType(
             table_name,
             body_data,
+            ctx.header("content-type"),
             authenticated_identity,
         );
         return respondWithAllocator(ctx, &resp, self.api_server.alloc);
@@ -3134,6 +3148,74 @@ test "httpx global query table name comes from request body" {
     defer parsed_table.deinit();
 
     try std.testing.expectEqualStrings("files", parsed_table.table_name);
+}
+
+test "httpx query endpoints accept ndjson multiquery bodies" {
+    const alloc = std.testing.allocator;
+    const db_path = try std.fmt.allocPrint(alloc, "/tmp/antfly-httpx-handler-ndjson-query-{d}", .{platform_time.monotonicNs()});
+    defer alloc.free(db_path);
+
+    var fs_io = std.Io.Threaded.init(std.heap.page_allocator, .{});
+    defer fs_io.deinit();
+    std.Io.Dir.cwd().deleteTree(fs_io.io(), db_path) catch {};
+
+    var db = try db_mod.DB.open(alloc, db_path, .{});
+    defer {
+        db.close();
+        std.Io.Dir.cwd().deleteTree(fs_io.io(), db_path) catch {};
+    }
+    try db.batch(.{
+        .writes = &.{
+            .{
+                .key = "doc:a",
+                .value = "{\"title\":\"alpha\",\"body\":\"hello\"}",
+            },
+        },
+        .timestamp_ns = 4321,
+    });
+
+    var table_source = table_reads.BoundTableReadSource.init("docs", 77, &db, raft_mod.read_gate.noopReadableLeaseRequester());
+    var source = LookupStatusSource{};
+    var api_server = ApiHttpServer.init(alloc, .{}, source.iface(), table_source.source(), null);
+
+    var e2e_server: HttpxE2eServer = undefined;
+    try e2e_server.init(alloc, &api_server);
+    defer e2e_server.deinit();
+
+    var client_io = std.Io.Threaded.init(std.heap.page_allocator, .{});
+    defer client_io.deinit();
+    var client = httpx.Client.initWithConfig(alloc, client_io.io(), .{ .keep_alive = false });
+    defer client.deinit();
+
+    const base_url = try e2e_server.baseUrl(alloc);
+    defer alloc.free(base_url);
+    const table_url = try std.fmt.allocPrint(alloc, "{s}/db/v1/tables/docs/query", .{base_url});
+    defer alloc.free(table_url);
+    const global_url = try std.fmt.allocPrint(alloc, "{s}/db/v1/query", .{base_url});
+    defer alloc.free(global_url);
+    const headers = [_][2][]const u8{.{ "content-type", "application/x-ndjson" }};
+
+    const table_body =
+        \\{"fields":["title"],"limit":1}
+        \\{"fields":["title"],"limit":1}
+    ;
+    var table_resp = try requestWithRetry(&client, client_io.io(), .POST, table_url, table_body, &headers, 20);
+    defer table_resp.deinit();
+    try std.testing.expectEqual(@as(u16, 200), table_resp.status.code);
+    var table_parsed = try std.json.parseFromSlice(std.json.Value, alloc, table_resp.body.?, .{ .ignore_unknown_fields = true });
+    defer table_parsed.deinit();
+    try std.testing.expectEqual(@as(usize, 2), table_parsed.value.object.get("responses").?.array.items.len);
+
+    const global_body =
+        \\{"table":"docs","fields":["title"],"limit":1}
+        \\{"table":"docs","fields":["title"],"limit":1}
+    ;
+    var global_resp = try requestWithRetry(&client, client_io.io(), .POST, global_url, global_body, &headers, 20);
+    defer global_resp.deinit();
+    try std.testing.expectEqual(@as(u16, 200), global_resp.status.code);
+    var global_parsed = try std.json.parseFromSlice(std.json.Value, alloc, global_resp.body.?, .{ .ignore_unknown_fields = true });
+    defer global_parsed.deinit();
+    try std.testing.expectEqual(@as(usize, 2), global_parsed.value.object.get("responses").?.array.items.len);
 }
 
 test "httpx antfly cluster restore preserves backup location validation" {

--- a/zig/pkg/antfly/src/inference/managed_embedder.zig
+++ b/zig/pkg/antfly/src/inference/managed_embedder.zig
@@ -1540,7 +1540,7 @@ fn embedWithEntryParts(
     }
 
     if (isAntflyProvider(entry.provider) and (entry.multimodal or partsContainMedia(parts))) {
-        if (entry.antfly_provider != null) {
+        if (entry.antfly_provider == null) {
             return error.UnsupportedEmbeddingProvider;
         }
         waitForEntryPacer(entry);
@@ -3010,6 +3010,73 @@ test "managed embedder routes antfly with api_url to antfly endpoint" {
     const vector = try managed.embedQuery(std.testing.allocator, "semantic_idx", "alpha concept");
     defer std.testing.allocator.free(vector);
     try std.testing.expectEqualSlices(f32, &.{ 0.125, 0.25, 0.5 }, vector);
+}
+
+test "managed embedder sends antfly media parts when local provider is configured" {
+    const Local = struct {
+        fn dense(_: *anyopaque, _: std.mem.Allocator, _: []const u8, _: []const []const u8) ![][]f32 {
+            return error.TestUnexpectedResult;
+        }
+
+        fn sparse(_: *anyopaque, alloc: std.mem.Allocator, _: []const u8, _: []const []const u8) ![]db_embedder.SparseEmbedding {
+            return try alloc.alloc(db_embedder.SparseEmbedding, 0);
+        }
+    };
+
+    const FakeApp = struct {
+        fn executor() http_common.RequestExecutor {
+            return .{
+                .ptr = undefined,
+                .vtable = &.{
+                    .execute = execute,
+                },
+            };
+        }
+
+        fn execute(_: *anyopaque, alloc: std.mem.Allocator, req: http_common.HttpRequest) !http_common.HttpResponse {
+            try std.testing.expectEqual(http_common.Method.POST, req.method);
+            try std.testing.expect(std.mem.endsWith(u8, req.uri, "/api/embed"));
+            try std.testing.expect(std.mem.indexOf(u8, req.body, "\"type\":\"image_url\"") != null);
+            try std.testing.expect(std.mem.indexOf(u8, req.body, "data:image/png;base64,aaa") != null);
+            return .{
+                .status = 200,
+                .content_type = try alloc.dupe(u8, "application/json"),
+                .body = try alloc.dupe(u8,
+                    \\{"data":[{"embedding":[0.25,0.5,0.75]}]}
+                ),
+            };
+        }
+    };
+
+    var listener = std_http_listener.StdHttpListener.init(std.testing.allocator, .{}, FakeApp.executor());
+    defer listener.deinit();
+    try listener.start();
+
+    const base_uri = try listener.baseUri(std.testing.allocator);
+    defer std.testing.allocator.free(base_uri);
+
+    var local = Local{};
+    const provider = AntflyProvider{
+        .ptr = &local,
+        .embed_dense_texts = Local.dense,
+        .embed_sparse_texts = Local.sparse,
+    };
+
+    const indexes_json = try std.fmt.allocPrint(std.testing.allocator,
+        \\{{"semantic_idx":{{"type":"embeddings","field":"body","dimension":3,"embedder":{{"provider":"antfly","model":"remote-model","api_url":"{s}","multimodal":true}}}}}}
+    , .{base_uri});
+    defer std.testing.allocator.free(indexes_json);
+
+    var managed = try ManagedEmbedder.initFromIndexesJsonWithAntflyProvider(std.testing.allocator, indexes_json, provider);
+    defer managed.deinit();
+
+    const parts = [_]template_mod.ContentPart{
+        .{ .text = "caption" },
+        .{ .media_url = "data:image/png;base64,aaa" },
+    };
+    const vector = try embedWithEntryParts(std.testing.allocator, &managed.entries[0], &parts, 3);
+    defer std.testing.allocator.free(vector);
+    try std.testing.expectEqualSlices(f32, &.{ 0.25, 0.5, 0.75 }, vector);
 }
 
 test "managed embedder preserves antfly api_url path for shared antfly endpoint" {

--- a/zig/pkg/antfly/src/storage/db/apply_rw_lock.zig
+++ b/zig/pkg/antfly/src/storage/db/apply_rw_lock.zig
@@ -34,6 +34,7 @@ pub const ApplyRwLock = struct {
     reader_mutex: std.atomic.Mutex = .unlocked,
     resource_mutex: std.atomic.Mutex = .unlocked,
     reader_count: usize = 0,
+    shared_waiters: AtomicU64 = .init(0),
     shared_lock_calls: AtomicU64 = .init(0),
     shared_contended_calls: AtomicU64 = .init(0),
     shared_wait_ns: AtomicU64 = .init(0),
@@ -46,6 +47,8 @@ pub const ApplyRwLock = struct {
     pub fn lockShared(self: *@This()) void {
         const started_ns = monotonicNs();
         _ = self.shared_lock_calls.fetchAdd(1, .monotonic);
+        _ = self.shared_waiters.fetchAdd(1, .monotonic);
+        defer _ = self.shared_waiters.fetchSub(1, .monotonic);
         if (!lockAtomic(&self.reader_gate)) {
             _ = self.shared_contended_calls.fetchAdd(1, .monotonic);
             noteWait(self, .shared, monotonicNs() -| started_ns);
@@ -96,6 +99,7 @@ pub const ApplyRwLock = struct {
     pub fn lockExclusive(self: *@This()) void {
         const started_ns = monotonicNs();
         _ = self.exclusive_lock_calls.fetchAdd(1, .monotonic);
+        yieldToQueuedReaders(self);
         const gate_idle = lockAtomic(&self.reader_gate);
         errdefer self.reader_gate.unlock();
         const resource_idle = lockAtomic(&self.resource_mutex);
@@ -108,6 +112,9 @@ pub const ApplyRwLock = struct {
     pub fn unlockExclusive(self: *@This()) void {
         self.resource_mutex.unlock();
         self.reader_gate.unlock();
+        if (builtin.os.tag != .freestanding and !builtin.single_threaded) {
+            std.Thread.yield() catch {};
+        }
     }
 
     pub fn snapshot(self: *const @This()) Stats {
@@ -142,6 +149,14 @@ fn lockAtomic(mutex: *std.atomic.Mutex) bool {
         std.Thread.yield() catch {};
     }
     return attempts == 0;
+}
+
+fn yieldToQueuedReaders(lock: *const ApplyRwLock) void {
+    if (builtin.os.tag == .freestanding or builtin.single_threaded) return;
+    var attempts: usize = 0;
+    while (attempts < 64 and lock.shared_waiters.load(.monotonic) > 0) : (attempts += 1) {
+        std.Thread.yield() catch {};
+    }
 }
 
 fn monotonicNs() u64 {
@@ -208,4 +223,46 @@ test "apply rw lock exclusive tryLock succeeds when idle" {
 
     try std.testing.expect(lock.tryLockExclusive());
     lock.unlockExclusive();
+}
+
+test "apply rw lock lets queued readers through sustained exclusive loop" {
+    if (builtin.single_threaded or builtin.os.tag == .freestanding) return error.SkipZigTest;
+
+    const Context = struct {
+        lock: ApplyRwLock = .{},
+        reader_ready: std.atomic.Value(bool) = .init(false),
+        reader_done: std.atomic.Value(bool) = .init(false),
+        writer_done: std.atomic.Value(bool) = .init(false),
+
+        fn writer(ctx: *@This()) void {
+            var i: usize = 0;
+            while (i < 10_000 and !ctx.reader_done.load(.acquire)) : (i += 1) {
+                ctx.lock.lockExclusive();
+                ctx.lock.unlockExclusive();
+            }
+            ctx.writer_done.store(true, .release);
+        }
+
+        fn reader(ctx: *@This()) void {
+            ctx.reader_ready.store(true, .release);
+            ctx.lock.lockShared();
+            ctx.lock.unlockShared();
+            ctx.reader_done.store(true, .release);
+        }
+    };
+
+    var ctx = Context{};
+    const writer_thread = try std.Thread.spawn(.{}, Context.writer, .{&ctx});
+    defer writer_thread.join();
+
+    const reader_thread = try std.Thread.spawn(.{}, Context.reader, .{&ctx});
+    defer reader_thread.join();
+
+    var spins: usize = 0;
+    while (!ctx.reader_done.load(.acquire) and spins < 100_000) : (spins += 1) {
+        std.Thread.yield() catch {};
+    }
+    try std.testing.expect(ctx.reader_ready.load(.acquire));
+    try std.testing.expect(ctx.reader_done.load(.acquire));
+    try std.testing.expect(!ctx.writer_done.load(.acquire) or spins < 100_000);
 }

--- a/zig/pkg/antfly/src/storage/db/db.zig
+++ b/zig/pkg/antfly/src/storage/db/db.zig
@@ -27993,6 +27993,74 @@ test "db runUntilIdle drains enrichment and derived indexing" {
     try std.testing.expectEqualStrings("doc:a", result.hits[0].id);
 }
 
+test "db generated enrichment backfill drains stored docs beyond first replay chunk" {
+    const alloc = std.testing.allocator;
+
+    var path_buf: [256]u8 = undefined;
+    const path = tempPath(&path_buf);
+    defer cleanupTempDir(path);
+
+    var deterministic = embedder_mod.DeterministicDenseEmbedder{};
+    var db = try DB.open(alloc, std.mem.span(path), .{
+        .enrichment = .{
+            .owner_id = "embedded-worker",
+            .dense_embedder = deterministic.interface(),
+        },
+    });
+    defer db.close();
+
+    const total_docs: usize = 129;
+    const writes = try alloc.alloc(types.BatchWrite, total_docs);
+    defer {
+        for (writes) |write| {
+            alloc.free(@constCast(write.key));
+            alloc.free(@constCast(write.value));
+        }
+        alloc.free(writes);
+    }
+    for (writes, 0..) |*write, i| {
+        write.* = .{
+            .key = try std.fmt.allocPrint(alloc, "doc:{d:0>3}", .{i}),
+            .value = try std.fmt.allocPrint(alloc, "{{\"title\":\"doc {d}\",\"body\":\"generated vector text {d}\"}}", .{ i, i }),
+        };
+    }
+    try db.batch(.{
+        .writes = writes,
+        .sync_level = .write,
+    });
+
+    try db.addIndex(.{
+        .name = "dv_v1",
+        .kind = .dense_vector,
+        .config_json = "{\"field\":\"embedding\",\"dims\":3,\"generator\":{\"kind\":\"dense_embedding\",\"source_field\":\"body\",\"embedding_name\":\"body_dense_v1\"}}",
+    });
+    try db.runUntilIdle();
+
+    const pending_after = db.pendingWorkStats();
+    try std.testing.expectEqual(pending_after.enrichment.target_sequence, pending_after.enrichment.applied_sequence);
+
+    const query_vec = try deterministic.interface().embedDense(alloc, "", "generated vector text 128", 3);
+    defer alloc.free(query_vec);
+
+    var result = try waitForSearchResult(alloc, &db, .{
+        .index_name = "dv_v1",
+        .dense = .{
+            .vector = query_vec,
+            .k = 5,
+        },
+    }, 1);
+    defer result.deinit();
+    try std.testing.expect(result.total_hits > 0);
+    var found_last = false;
+    for (result.hits) |hit| {
+        if (std.mem.eql(u8, hit.id, "doc:128")) {
+            found_last = true;
+            break;
+        }
+    }
+    try std.testing.expect(found_last);
+}
+
 test "db runUntilIdle drains lazy dense posting maintenance" {
     const alloc = std.testing.allocator;
 

--- a/zig/pkg/inference/src/models/manifest.zig
+++ b/zig/pkg/inference/src/models/manifest.zig
@@ -332,6 +332,9 @@ pub const ModelManifest = struct {
 
 /// ONNX file candidates in priority order.
 const onnx_candidates = [_][]const u8{
+    "text_model.onnx",
+    "text_model_f16.onnx",
+    "text_model_i8.onnx",
     "model.onnx",
     "model_f16.onnx",
     "model_i8.onnx",
@@ -343,9 +346,6 @@ const onnx_candidates = [_][]const u8{
     "decoder_model_merged_quantized.onnx",
     "decoder_model_merged_q4.onnx",
     "decoder_model_merged_q4f16.onnx",
-    "text_model.onnx",
-    "text_model_f16.onnx",
-    "text_model_i8.onnx",
     "encoder.onnx",
 };
 
@@ -634,6 +634,11 @@ fn applyImplicitModelTypeHints(manifest: *ModelManifest, model_dir_path: []const
         }
     }
 
+    if (hasRerankPathHint(model_dir_path) and (manifest.model_type == .embedder or manifest.model_type == .classifier)) {
+        manifest.model_type = .reranker;
+        return;
+    }
+
     if (inferModelTypeFromTasks(manifest.tasks)) |task_model_type| {
         manifest.model_type = task_model_type;
         return;
@@ -666,10 +671,10 @@ fn inferModelTypeFromTasks(tasks: []const []const u8) ?ModelType {
         if (std.mem.eql(u8, task, "recognize") or std.mem.eql(u8, task, "extract")) return .recognizer;
     }
     for (tasks) |task| {
-        if (std.mem.eql(u8, task, "classify")) return .classifier;
+        if (std.mem.eql(u8, task, "rerank")) return .reranker;
     }
     for (tasks) |task| {
-        if (std.mem.eql(u8, task, "rerank")) return .reranker;
+        if (std.mem.eql(u8, task, "classify")) return .classifier;
     }
     for (tasks) |task| {
         if (std.mem.eql(u8, task, "read")) return .reader;
@@ -714,6 +719,14 @@ fn hasGlinerPathHint(model_dir_path: []const u8) bool {
     var it = std.mem.tokenizeAny(u8, model_dir_path, "/\\");
     while (it.next()) |component| {
         if (containsAsciiIgnoreCase(component, "gliner")) return true;
+    }
+    return false;
+}
+
+fn hasRerankPathHint(model_dir_path: []const u8) bool {
+    var it = std.mem.tokenizeAny(u8, model_dir_path, "/\\");
+    while (it.next()) |component| {
+        if (containsAsciiIgnoreCase(component, "rerank")) return true;
     }
     return false;
 }
@@ -1738,6 +1751,15 @@ test "inferModelTypeFromPath detects classifier directory" {
     try std.testing.expectEqual(@as(?ModelType, .classifier), inferModelTypeFromPath("/tmp/models/classifiers/cross-encoder/nli-distilroberta-base"));
 }
 
+test "rerank model name overrides sequence classifier config" {
+    var manifest = ModelManifest{
+        .allocator = std.testing.allocator,
+        .model_type = .classifier,
+    };
+    applyImplicitModelTypeHints(&manifest, "/tmp/models/mixedbread-ai/mxbai-rerank-base-v1");
+    try std.testing.expectEqual(ModelType.reranker, manifest.model_type);
+}
+
 test "inferModelTypeFromPath detects recognizer directory" {
     try std.testing.expectEqual(@as(?ModelType, .recognizer), inferModelTypeFromPath("C:\\models\\recognizers\\fastino\\gliner2-base-v1"));
 }
@@ -2126,6 +2148,33 @@ test "manifest discovers clip onnx variants and prefers f16 over i8" {
     try std.testing.expect(std.mem.endsWith(u8, manifest.visual_model_path.?, "/visual_model_f16.onnx"));
     try std.testing.expect(std.mem.endsWith(u8, manifest.text_projection_path.?, "/text_projection.onnx"));
     try std.testing.expect(std.mem.endsWith(u8, manifest.visual_projection_path.?, "/visual_projection.onnx"));
+}
+
+test "manifest prefers split clip text model over combined model" {
+    const allocator = std.testing.allocator;
+    const model_dir = try testScratchDir(allocator, "manifest-clip-text-model-before-combined");
+    defer {
+        compat.cwd().deleteTree(compat.io(), model_dir) catch {};
+        allocator.free(model_dir);
+    }
+
+    const files = [_][]const u8{
+        "model.onnx",
+        "text_model.onnx",
+        "vision_model.onnx",
+    };
+    for (files) |file_name| {
+        const path = try std.fs.path.join(allocator, &.{ model_dir, file_name });
+        defer allocator.free(path);
+        try compat.cwd().writeFile(compat.io(), .{ .sub_path = path, .data = "" });
+    }
+
+    var manifest = try loadFromDir(allocator, model_dir);
+    defer manifest.deinit();
+    try std.testing.expect(manifest.onnx_path != null);
+    try std.testing.expect(manifest.visual_model_path != null);
+    try std.testing.expect(std.mem.endsWith(u8, manifest.onnx_path.?, "/text_model.onnx"));
+    try std.testing.expect(std.mem.endsWith(u8, manifest.visual_model_path.?, "/vision_model.onnx"));
 }
 
 test "manifest discovers clip i8 onnx fallback variants" {

--- a/zig/pkg/inference/src/ops/native_compute.zig
+++ b/zig/pkg/inference/src/ops/native_compute.zig
@@ -901,7 +901,17 @@ fn erfApprox(x: f32) f32 {
 fn getData(ct: CT) []f32 {
     const buf = toBuf(ct);
     if (buf.view_strides != null) {
-        materializeViewData(buf) catch |err| std.debug.panic("failed to materialize tensor view: {s}", .{@errorName(err)});
+        materializeViewData(buf) catch |err| {
+            std.log.warn("failed to materialize tensor view: {s}", .{@errorName(err)});
+            releaseOwnedDenseData(buf);
+            if (buf.view_strides) |strides| buf.allocator.free(strides);
+            buf.view_strides = null;
+            buf.view_base_offset = 0;
+            releaseLogicalShape(buf);
+            buf.data = &.{};
+            buf.owned = false;
+            buf.shared_data_refcount = null;
+        };
     }
     return buf.data;
 }
@@ -45666,6 +45676,28 @@ test "sdpaOp preserves 4d logical shape from query input" {
     defer freeTensor(&compute, out_ct);
 
     try std.testing.expectEqualSlices(i64, &.{ 1, 2, 3, 4 }, tensorStoredShape(out_ct).?);
+}
+
+test "invalid lazy view materialization does not panic" {
+    const allocator = std.testing.allocator;
+    var data = [_]f32{ 1.0, 2.0 };
+    var buf = Buf{
+        .data = data[0..],
+        .allocator = allocator,
+        .owned = false,
+    };
+    buf.inline_logical_shape[0] = 2;
+    buf.inline_logical_shape[1] = 2;
+    buf.logical_shape = buf.inline_logical_shape[0..2];
+    buf.logical_shape_inline = true;
+    buf.view_strides = try allocator.dupe(usize, &.{ 3, 3 });
+    buf.view_base_offset = 1;
+
+    const out = getData(@ptrCast(&buf));
+    try std.testing.expectEqual(@as(usize, 0), out.len);
+    try std.testing.expect(buf.view_strides == null);
+    try std.testing.expect(buf.logical_shape == null);
+    try std.testing.expect(!buf.owned);
 }
 
 fn expectApproxEqSlice(expected: []const f32, actual: []const f32, tolerance: f32) !void {

--- a/zig/pkg/inference/src/pipelines/reranking.zig
+++ b/zig/pkg/inference/src/pipelines/reranking.zig
@@ -117,7 +117,7 @@ pub const RerankingPipeline = struct {
         var run = try self.runTextEncoder(all_ids, all_mask, all_type_ids, batch, max_len, true);
         defer run.deinit();
 
-        return try self.extractScores(run.output(), batch);
+        return try self.extractScores(try run.output(), batch);
     }
 
     fn rerankLateInteraction(self: *RerankingPipeline, query: []const u8, documents: []const []const u8) ![]f32 {
@@ -136,7 +136,7 @@ pub const RerankingPipeline = struct {
         var query_run = try self.runTextEncoder(query_encoded.ids, query_encoded.attention_mask, query_type_ids, 1, max_len, false);
         defer query_run.deinit();
 
-        const query_output = query_run.output();
+        const query_output = try query_run.output();
         if (query_output.shape.len != 3) return error.UnexpectedOutputShape;
         const hidden: usize = @intCast(query_output.shape[2]);
 
@@ -162,7 +162,7 @@ pub const RerankingPipeline = struct {
 
             var doc_run = try self.runTextEncoder(doc_ids, doc_mask, doc_type_ids, chunk_len, max_len, false);
             defer doc_run.deinit();
-            const doc_output = doc_run.output();
+            const doc_output = try doc_run.output();
             if (doc_output.shape.len != 3) return error.UnexpectedOutputShape;
 
             const query_hidden = query_output.asFloat32();
@@ -265,8 +265,8 @@ pub const RerankingPipeline = struct {
             self.allocator.free(self.outputs);
         }
 
-        fn output(self: *const TextRun) *const Tensor {
-            if (self.outputs.len == 0) @panic("TextRun.output called without outputs");
+        fn output(self: *const TextRun) !*const Tensor {
+            if (self.outputs.len == 0) return error.MissingModelOutput;
             return &self.outputs[0];
         }
     };
@@ -350,6 +350,15 @@ pub const RerankingPipeline = struct {
         }
     }
 };
+
+test "reranking text run reports missing model output instead of panicking" {
+    const run = RerankingPipeline.TextRun{
+        .allocator = std.testing.allocator,
+        .outputs = &.{},
+    };
+
+    try std.testing.expectError(error.MissingModelOutput, run.output());
+}
 
 pub fn lateInteractionScore(
     query_hidden: []const f32,

--- a/zig/pkg/inference/src/registry/registry.zig
+++ b/zig/pkg/inference/src/registry/registry.zig
@@ -494,6 +494,7 @@ fn modelKindFromManifestType(model_type: manifest_mod.ModelType) ModelKind {
 }
 
 fn inferModelKindFromPath(path: []const u8) ModelKind {
+    var hinted_kind: ?ModelKind = null;
     var it = std.mem.tokenizeAny(u8, path, "/\\");
     while (it.next()) |component| {
         if (std.mem.eql(u8, component, "embedders")) return .embedder;
@@ -506,8 +507,20 @@ fn inferModelKindFromPath(path: []const u8) ModelKind {
         if (std.mem.eql(u8, component, "readers")) return .reader;
         if (std.mem.eql(u8, component, "transcribers")) return .transcriber;
         if (std.mem.eql(u8, component, "extractors")) return .extractor;
+        if (containsAsciiIgnoreCase(component, "rerank")) hinted_kind = .reranker;
     }
-    return .embedder;
+    return hinted_kind orelse .embedder;
+}
+
+fn containsAsciiIgnoreCase(haystack: []const u8, needle: []const u8) bool {
+    if (needle.len == 0) return true;
+    if (haystack.len < needle.len) return false;
+
+    var start: usize = 0;
+    while (start + needle.len <= haystack.len) : (start += 1) {
+        if (std.ascii.eqlIgnoreCase(haystack[start .. start + needle.len], needle)) return true;
+    }
+    return false;
 }
 
 fn modelTypeName(model_type: manifest_mod.ModelType) []const u8 {
@@ -755,10 +768,10 @@ fn manifestTypeFromTasks(tasks: []const []const u8, fallback: manifest_mod.Model
             std.mem.eql(u8, task, "extract") or std.mem.eql(u8, task, "extractors")) return .recognizer;
     }
     for (tasks) |task| {
-        if (std.mem.eql(u8, task, "classify") or std.mem.eql(u8, task, "classifiers")) return .classifier;
+        if (std.mem.eql(u8, task, "rerank") or std.mem.eql(u8, task, "rerankers")) return .reranker;
     }
     for (tasks) |task| {
-        if (std.mem.eql(u8, task, "rerank") or std.mem.eql(u8, task, "rerankers")) return .reranker;
+        if (std.mem.eql(u8, task, "classify") or std.mem.eql(u8, task, "classifiers")) return .classifier;
     }
     for (tasks) |task| {
         if (std.mem.eql(u8, task, "read") or std.mem.eql(u8, task, "readers")) return .reader;
@@ -1005,6 +1018,33 @@ test "synthesized pulled manifest accepts plural task directory hints" {
     try std.testing.expect(std.mem.indexOf(u8, manifest_json, "\"tasks\":[\"read\"]") != null);
     try std.testing.expect(std.mem.indexOf(u8, manifest_json, "\"inputs\":[\"image\"]") != null);
     try std.testing.expect(std.mem.indexOf(u8, manifest_json, "\"capabilities\"") == null);
+}
+
+test "synthesized pulled manifest treats rerank-named sequence classifiers as rerankers" {
+    const allocator = std.testing.allocator;
+    const io = std.testing.io;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.createDirPath(io, "models/mixedbread-ai/mxbai-rerank-base-v1/onnx");
+    try tmp.dir.writeFile(io, .{
+        .sub_path = "models/mixedbread-ai/mxbai-rerank-base-v1/config.json",
+        .data = "{\"architectures\":[\"XLMRobertaForSequenceClassification\"],\"model_type\":\"xlm-roberta\"}",
+    });
+    try tmp.dir.writeFile(io, .{
+        .sub_path = "models/mixedbread-ai/mxbai-rerank-base-v1/onnx/model.onnx",
+        .data = "",
+    });
+
+    const model_dir = try std.fs.path.join(allocator, &.{ ".zig-cache", "tmp", tmp.sub_path[0..], "models/mixedbread-ai/mxbai-rerank-base-v1" });
+    defer allocator.free(model_dir);
+
+    const manifest_json = try synthesizePulledModelManifestJson(allocator, io, model_dir, null, null);
+    defer allocator.free(manifest_json);
+
+    try std.testing.expect(std.mem.indexOf(u8, manifest_json, "\"type\":\"reranker\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, manifest_json, "\"tasks\":[\"rerank\"]") != null);
 }
 
 test "synthesized pulled manifest preserves explicit sparse capability" {

--- a/zig/pkg/inference/src/server/model_manager.zig
+++ b/zig/pkg/inference/src/server/model_manager.zig
@@ -652,6 +652,7 @@ pub const LoadedModel = struct {
     native_generate_coordinator: ?*runtime.scheduler.native_generate.NativeGenerateCoordinator = null,
     // Multimodal sessions (CLIP/CLAP/CLIPCLAP)
     embedding_session_lock: std.atomic.Mutex = .unlocked,
+    reranking_session_lock: std.atomic.Mutex = .unlocked,
     vision_session: ?backends.Session = null,
     audio_session: ?backends.Session = null,
     text_projection: ?backends.Session = null,
@@ -769,6 +770,14 @@ pub const LoadedModel = struct {
             .add_bos_token = self.manifest.add_bos_token,
             .distributed = runtime.distributed.configFromEnv(),
         });
+    }
+
+    pub fn lockRerankingSession(self: *LoadedModel) void {
+        spinLock(&self.reranking_session_lock);
+    }
+
+    pub fn unlockRerankingSession(self: *LoadedModel) void {
+        self.reranking_session_lock.unlock();
     }
 
     pub fn classificationPipeline(self: *LoadedModel, allocator: std.mem.Allocator, config: ClassificationConfig) ClassificationPipeline {

--- a/zig/pkg/inference/src/server/server.zig
+++ b/zig/pkg/inference/src/server/server.zig
@@ -632,6 +632,8 @@ pub const Node = struct {
 
         const model_path = try self.resolveModelPath(io_impl.io(), if (model_name.len > 0) model_name else null, "rerankers");
         const model = try self.model_manager.loadFromDir(model_path);
+        model.lockRerankingSession();
+        defer model.unlockRerankingSession();
         var pipeline = model.rerankingPipeline(allocator);
         return try pipeline.rerank(query, documents);
     }
@@ -1741,6 +1743,8 @@ pub const Node = struct {
         const model = self.model_manager.loadFromDir(model_path) catch |err|
             return ctx.status(500).json(.{ .@"error" = "MODEL_LOAD_FAILED", .message = @errorName(err) });
 
+        model.lockRerankingSession();
+        defer model.unlockRerankingSession();
         var pipeline = model.rerankingPipeline(ctx.allocator);
         const scores = pipeline.rerank(body.query, body.prompts) catch |err|
             return ctx.status(500).json(.{ .@"error" = "INFERENCE_FAILED", .message = @errorName(err) });
@@ -1799,6 +1803,8 @@ pub const Node = struct {
             defer ctx.allocator.free(flat_texts);
             for (parsed_docs.items, 0..) |doc, idx| flat_texts[idx] = doc.text;
 
+            model.lockRerankingSession();
+            defer model.unlockRerankingSession();
             var pipeline = model.rerankingPipeline(ctx.allocator);
             const scores = pipeline.rerank(body.query, flat_texts) catch |err|
                 return ctx.status(500).json(.{ .@"error" = "INFERENCE_FAILED", .message = @errorName(err) });
@@ -1852,9 +1858,13 @@ pub const Node = struct {
 
         for (parsed_docs.items, 0..) |doc, idx| {
             if (doc.images.len == 0) {
-                var text_pipeline = model.rerankingPipeline(ctx.allocator);
-                const text_scores = text_pipeline.rerank(body.query, &.{doc.text}) catch |err|
-                    return ctx.status(500).json(.{ .@"error" = "INFERENCE_FAILED", .message = @errorName(err) });
+                model.lockRerankingSession();
+                const text_scores = blk: {
+                    defer model.unlockRerankingSession();
+                    var text_pipeline = model.rerankingPipeline(ctx.allocator);
+                    break :blk text_pipeline.rerank(body.query, &.{doc.text}) catch |err|
+                        return ctx.status(500).json(.{ .@"error" = "INFERENCE_FAILED", .message = @errorName(err) });
+                };
                 defer ctx.allocator.free(text_scores);
                 scores[idx] = text_scores[0];
                 continue;

--- a/zig/pkg/inference/src/server/server.zig
+++ b/zig/pkg/inference/src/server/server.zig
@@ -385,6 +385,56 @@ fn deinitDiscoveredModelListings(allocator: std.mem.Allocator, listings: []Disco
     allocator.free(listings);
 }
 
+fn appendLoadedAliasModelListings(
+    allocator: std.mem.Allocator,
+    body: *std.ArrayListUnmanaged(u8),
+    openai_data: *std.ArrayListUnmanaged(u8),
+    openai_data_count: *usize,
+    model_count: *usize,
+    task: []const u8,
+    list_created: i64,
+    discovered: []const registry_mod.ModelEntry,
+    model_manager: *model_manager_mod.ModelManager,
+) !void {
+    // Loaded model cache keys include backend variants such as
+    // "<absolute path>\nbackend=onnx"; only public aliases belong in listings.
+    var it = model_manager.loaded_aliases.iterator();
+    while (it.next()) |entry| {
+        const model = entry.value_ptr.*;
+        const model_task = @tagName(model.manifest.model_type);
+        if (!taskMatchesModelListing(task, model_task, model.manifest.gliner_model_type, model.manifest.tasks, model.manifest.capabilities)) continue;
+
+        var already_listed = false;
+        for (discovered) |d| {
+            if (std.mem.eql(u8, d.path, entry.key_ptr.*)) {
+                already_listed = true;
+                break;
+            }
+        }
+        if (already_listed) continue;
+
+        if (model_count.* > 0) try body.append(allocator, ',');
+        try jsonEncodeString(body, allocator, entry.key_ptr.*);
+        try body.append(allocator, ':');
+        try appendModelInfo(
+            body,
+            allocator,
+            model_task,
+            model.manifest.gliner_model_type,
+            model.manifest.capabilities,
+            model.manifest.inputs,
+            model.manifest.visual_model_path != null or model.manifest.visual_projection_path != null,
+            model.manifest.audio_model_path != null or model.manifest.audio_projection_path != null,
+        );
+        if (isOpenAiListTask(task)) {
+            if (openai_data_count.* > 0) try openai_data.append(allocator, ',');
+            try appendOpenAiModelEntry(openai_data, allocator, entry.key_ptr.*, list_created);
+            openai_data_count.* += 1;
+        }
+        model_count.* += 1;
+    }
+}
+
 const ModelCounts = struct {
     embedders: usize = 0,
     rerankers: usize = 0,
@@ -4615,43 +4665,7 @@ pub const Node = struct {
                 model_count += 1;
             }
 
-            // Add loaded models not yet listed (loaded by path, not discovered by name)
-            var it = self.model_manager.loaded.iterator();
-            while (it.next()) |entry| {
-                const model = entry.value_ptr.*;
-                const model_task = @tagName(model.manifest.model_type);
-                if (!taskMatchesModelListing(task, model_task, model.manifest.gliner_model_type, model.manifest.tasks, model.manifest.capabilities)) continue;
-
-                // Skip if already listed from discovery
-                var already_listed = false;
-                for (discovered) |d| {
-                    if (std.mem.eql(u8, d.path, entry.key_ptr.*)) {
-                        already_listed = true;
-                        break;
-                    }
-                }
-                if (!already_listed) {
-                    if (model_count > 0) try body.append(a, ',');
-                    try jsonEncodeString(&body, a, entry.key_ptr.*);
-                    try body.append(a, ':');
-                    try appendModelInfo(
-                        &body,
-                        a,
-                        model_task,
-                        model.manifest.gliner_model_type,
-                        model.manifest.capabilities,
-                        model.manifest.inputs,
-                        model.manifest.visual_model_path != null or model.manifest.visual_projection_path != null,
-                        model.manifest.audio_model_path != null or model.manifest.audio_projection_path != null,
-                    );
-                    if (isOpenAiListTask(task)) {
-                        if (openai_data_count > 0) try openai_data.append(a, ',');
-                        try appendOpenAiModelEntry(&openai_data, a, entry.key_ptr.*, list_created);
-                        openai_data_count += 1;
-                    }
-                    model_count += 1;
-                }
-            }
+            try appendLoadedAliasModelListings(a, &body, &openai_data, &openai_data_count, &model_count, task, list_created, discovered, &self.model_manager);
 
             try body.append(a, '}');
         }
@@ -6220,6 +6234,44 @@ test "download remote content accepts data uri" {
     defer downloaded.deinit(alloc);
     try std.testing.expectEqualStrings("text/plain", downloaded.content_type);
     try std.testing.expectEqualStrings("hello", downloaded.data);
+}
+
+test "model listing emits loaded aliases instead of backend variant cache keys" {
+    var arena_impl = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_impl.deinit();
+    const alloc = arena_impl.allocator();
+
+    var manager = model_manager_mod.ModelManager.init(alloc, backends_mod.SessionManager.init(alloc));
+    const model = try alloc.create(model_manager_mod.LoadedModel);
+    model.* = .{
+        .manifest = .{
+            .allocator = alloc,
+            .model_type = .embedder,
+        },
+        .hf_tok = null,
+        .sp_tok = null,
+        .session = undefined,
+        .session_manager = &manager.session_manager,
+        .model_dir = "/tmp/models/owner/model",
+        .allocator = alloc,
+    };
+
+    try manager.loaded.put(alloc, "/tmp/models/owner/model\nbackend=onnx", model);
+    try manager.loaded_aliases.put(alloc, "owner/model", model);
+
+    var body = std.ArrayListUnmanaged(u8).empty;
+    var openai_data = std.ArrayListUnmanaged(u8).empty;
+    var openai_count: usize = 0;
+    var model_count: usize = 0;
+    try appendLoadedAliasModelListings(alloc, &body, &openai_data, &openai_count, &model_count, "embedders", 123, &.{}, &manager);
+
+    try std.testing.expectEqual(@as(usize, 1), model_count);
+    try std.testing.expectEqual(@as(usize, 1), openai_count);
+    try std.testing.expect(std.mem.indexOf(u8, body.items, "\"owner/model\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, openai_data.items, "\"id\":\"owner/model\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, body.items, "backend=") == null);
+    try std.testing.expect(std.mem.indexOf(u8, openai_data.items, "backend=") == null);
+    try std.testing.expect(std.mem.indexOf(u8, body.items, "/tmp/models/owner/model") == null);
 }
 
 test "download remote content blocks private ip urls when configured" {


### PR DESCRIPTION
Summary
- Fix local antfly media enrichment provider handling that caused media indexes to fail table enrichment
- Restore CLIP text model selection, reranker classification, reranker no-panic paths, and clean /ai/v1/models aliases
- Add NDJSON multiquery handling for table/global query endpoints plus read-starvation, transient EndOfStream, and backfill fixes

Fixes
- Fixes #191
- Fixes #192
- Fixes #193
- Fixes #194
- Fixes #195
- Fixes #196
- Fixes #197

Tests
- zig build root-test -- --test-filter "managed embedder sends antfly media parts"
- zig build root-test -- --test-filter "httpx query endpoints accept ndjson"
- zig build root-test -- --test-filter "apply rw lock lets queued readers"
- zig build root-test -- --test-filter "api http server retries transient query EndOfStream"
- zig build root-test -- --test-filter "generated enrichment backfill drains stored docs beyond first replay chunk"
- zig build inference-test -- --test-filter manifest
- zig build inference-test -- --test-filter registry
- zig build inference-test -- --test-filter reranking
- zig build db-enrichment-test -- --test-filter enrichment
- zig build root-test -- --test-filter "storage.db.apply_rw_lock"
- zig build antfly
- zig build install
- uv run --project zig/e2e/antfly pytest -q -s zig/e2e/antfly/test_query_string.py