### PR TITLE
Fix inference and enrichment issue regressions

### DIFF
--- a/zig/build.zig
+++ b/zig/build.zig
@@ -3314,6 +3314,7 @@ pub fn build(b: *std.Build) void {
             "api table reads reject stale doc identity before multigroup fanout",
             "distributed table reads reject stale doc identity before multigroup fanout",
             "api public table query rejects only top-level internal fields",
+            "single embeddings index encoder scopes isolated enrichment failure to one index",
             "api query contract rejects doc identity control fields when with relaxes schema",
             "api query contract public parser rejects internal shard doc identity controls",
             "api distributed graph hydrate carries identity generation and clears cross-range ordinals",
@@ -3516,6 +3517,7 @@ pub fn build(b: *std.Build) void {
         .root_module = api_table_reads_docid_test_mod,
         .filters = &.{
             "provisioned read cache invalidates repeated ownership moves with pinned leases",
+            "parseRemoteSearchResult preserves fused index scores",
         },
         .test_runner = .{
             .path = b.path("pkg/antfly/src/test_runner.zig"),

--- a/zig/pkg/antfly/src/api/indexes.zig
+++ b/zig/pkg/antfly/src/api/indexes.zig
@@ -611,6 +611,7 @@ const AggregatedIndexStatus = struct {
     kind: ?db_mod.types.IndexKind = null,
     backfill_active: bool = false,
     backfill_progress: f64 = 0.0,
+    enrichment_failed: bool = false,
     table_doc_count: u64 = 0,
     doc_count: u64 = 0,
     term_count: u64 = 0,
@@ -745,6 +746,7 @@ fn aggregateIndexStatus(
         aggregate.replay_applied_sequence += item.replay_applied_sequence;
         aggregate.replay_target_sequence += item.replay_target_sequence;
         if (item.replay_catch_up_required) aggregate.replay_catch_up_required = true;
+        if (item.enrichment_failed) aggregate.enrichment_failed = true;
         aggregate.catch_up_applied_sequence += item.catch_up_applied_sequence;
         aggregate.catch_up_target_sequence += item.catch_up_target_sequence;
         if (item.catch_up_active) aggregate.catch_up_active = true;
@@ -1035,10 +1037,11 @@ fn embeddingsArtifactVisible(item: anytype, sparse: bool) bool {
     return item.doc_count > 0 and (item.node_count > 0 or item.root_node > 0);
 }
 
-fn backfillState(index_type: ApiIndexType, active: bool, replay_applied_sequence: u64, replay_target_sequence: u64, enrichment: ?db_mod.types.EnrichmentStats) []const u8 {
+fn backfillState(index_type: ApiIndexType, active: bool, enrichment_failed: bool, replay_applied_sequence: u64, replay_target_sequence: u64, enrichment: ?db_mod.types.EnrichmentStats) []const u8 {
     if (index_type == .embeddings) {
         _ = replay_applied_sequence;
         _ = replay_target_sequence;
+        if (enrichment_failed) return "failed";
         if (active) {
             if (enrichment) |stats| {
                 if (stats.worker_failed) return "failed";
@@ -1198,7 +1201,7 @@ fn appendSingleIndexRuntimeStatus(
     defer alloc.free(progress);
     try out.appendSlice(alloc, progress);
     try out.appendSlice(alloc, ",\"backfill_state\":");
-    try appendJsonString(alloc, out, backfillState(index_type, backfill_active, replay_applied_sequence, replay_target_sequence, enrichment));
+    try appendJsonString(alloc, out, backfillState(index_type, backfill_active, item.enrichment_failed, replay_applied_sequence, replay_target_sequence, enrichment));
     try out.appendSlice(alloc, ",\"doc_count\":");
     try appendIntValue(alloc, out, item.doc_count);
     try out.appendSlice(alloc, ",\"term_count\":");
@@ -2641,6 +2644,75 @@ test "single embeddings index encoder synthesizes replay state from enrichment r
     try std.testing.expect(std.mem.indexOf(u8, encoded, "\"applied_sequence\":1") != null);
     try std.testing.expect(std.mem.indexOf(u8, encoded, "\"pending_sequence_count\":4") != null);
     try std.testing.expect(std.mem.indexOf(u8, encoded, "\"retryable_error_count\":2") != null);
+}
+
+test "single embeddings index encoder scopes isolated enrichment failure to one index" {
+    const alloc = std.testing.allocator;
+    const indexes = try alloc.alloc(db_mod.types.DBIndexStats, 2);
+    defer alloc.free(indexes);
+    indexes[0] = .{
+        .name = try alloc.dupe(u8, "visual_idx"),
+        .kind = .dense_vector,
+        .doc_count = 0,
+        .node_count = 0,
+        .enrichment_failed = true,
+    };
+    indexes[1] = .{
+        .name = try alloc.dupe(u8, "semantic_idx"),
+        .kind = .dense_vector,
+        .doc_count = 1,
+        .node_count = 1,
+    };
+    defer alloc.free(indexes[0].name);
+    defer alloc.free(indexes[1].name);
+
+    const local_items = try alloc.alloc(runtime_status.LocalTableRuntimeStatus, 1);
+    defer alloc.free(local_items);
+    local_items[0] = .{
+        .group_id = 7,
+        .stats = .{
+            .doc_count = 1,
+            .index_count = 2,
+            .indexes = indexes,
+            .enrichment = .{
+                .enabled = true,
+                .target_sequence = 1,
+                .applied_sequence = 1,
+                .processed_requests = 1,
+                .error_count = 1,
+                .retryable_error_count = 0,
+                .worker_failed = false,
+            },
+        },
+    };
+    var local_status = runtime_status.LocalTableRuntimeStatuses{ .items = local_items };
+
+    const snapshot: metadata_api.AdminSnapshot = .{
+        .status = .{ .metadata_group_id = 1, .metrics = .{} },
+        .tables = @constCast((&[_]metadata_table_manager.TableRecord{.{
+            .table_id = 7,
+            .name = "docs",
+            .indexes_json =
+            \\{"visual_idx":{"type":"embeddings","field":"image","dimension":3},"semantic_idx":{"type":"embeddings","field":"body","dimension":3}}
+            ,
+            .placement_role = "data",
+        }})[0..]),
+        .ranges = @constCast((&[_]metadata_table_manager.RangeRecord{})[0..]),
+        .stores = @constCast((&[_]metadata_table_manager.StoreRecord{})[0..]),
+        .placement_intents = @constCast((&[_]raft_reconciler.PlacementIntent{})[0..]),
+        .split_transitions = @constCast((&[_]metadata_transition_state.SplitTransitionRecord{})[0..]),
+        .merge_transitions = @constCast((&[_]metadata_transition_state.MergeTransitionRecord{})[0..]),
+    };
+
+    const failed_encoded = (try encodeSingleIndex(alloc, &snapshot, "docs", "visual_idx", &local_status)).?;
+    defer alloc.free(failed_encoded);
+    try std.testing.expect(std.mem.indexOf(u8, failed_encoded, "\"backfill_state\":\"failed\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, failed_encoded, "\"worker_failed\":false") != null);
+
+    const healthy_encoded = (try encodeSingleIndex(alloc, &snapshot, "docs", "semantic_idx", &local_status)).?;
+    defer alloc.free(healthy_encoded);
+    try std.testing.expect(std.mem.indexOf(u8, healthy_encoded, "\"backfill_state\":\"ready\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, healthy_encoded, "\"backfill_state\":\"failed\"") == null);
 }
 
 test "single embeddings index encoder keeps published visibility separate from replay debt" {

--- a/zig/pkg/antfly/src/api/query_contract.zig
+++ b/zig/pkg/antfly/src/api/query_contract.zig
@@ -2226,6 +2226,7 @@ fn toOpenApiHit(alloc: std.mem.Allocator, req: db_mod.types.SearchRequest, hit: 
     return .{
         ._id = hit.id,
         ._score = hit.score orelse 0,
+        ._index_scores = try indexScoresJsonValue(alloc, hit.index_scores),
         ._source = if (hit.stored_data) |stored_data|
             if (req.defer_stored_projection)
                 try document_query.projectLookupJsonValue(alloc, stored_data, .{
@@ -2237,6 +2238,35 @@ fn toOpenApiHit(alloc: std.mem.Allocator, req: db_mod.types.SearchRequest, hit: 
         else
             null,
     };
+}
+
+fn indexScoresJsonValue(alloc: std.mem.Allocator, scores: []const fusion_mod.IndexScore) !?std.json.Value {
+    if (scores.len == 0) return null;
+    var obj = std.json.ObjectMap.empty;
+    errdefer obj.deinit(alloc);
+    for (scores) |score| {
+        try obj.put(alloc, score.index_name, .{ .float = score.score });
+    }
+    return .{ .object = obj };
+}
+
+test "api query contract serializes fused index scores" {
+    const alloc = std.testing.allocator;
+    const scores = [_]fusion_mod.IndexScore{
+        .{ .index_name = "text_idx", .score = 0.75 },
+        .{ .index_name = "semantic_idx", .score = 0.25 },
+    };
+
+    var value = (try indexScoresJsonValue(alloc, &scores)).?;
+    defer switch (value) {
+        .object => |*obj| obj.deinit(alloc),
+        else => {},
+    };
+
+    const object = value.object;
+    try std.testing.expectEqual(@as(usize, 2), object.count());
+    try std.testing.expectEqual(@as(f64, 0.75), object.get("text_idx").?.float);
+    try std.testing.expectEqual(@as(f64, 0.25), object.get("semantic_idx").?.float);
 }
 
 fn parseStoredSourceValue(alloc: std.mem.Allocator, stored_data: []const u8) !std.json.Value {

--- a/zig/pkg/antfly/src/api/table_reads.zig
+++ b/zig/pkg/antfly/src/api/table_reads.zig
@@ -52,6 +52,7 @@ const http_client = @import("http_client.zig");
 const http_common = @import("../raft/transport/http_common.zig");
 const platform_time = @import("../platform/time.zig");
 const distributed_stats_mod = @import("../search/distributed_stats.zig");
+const fusion_mod = @import("../search/fusion.zig");
 const regex_mod = @import("../search/regex.zig");
 const httpx = @import("httpx");
 const Io = std.Io;
@@ -12461,6 +12462,7 @@ fn parseRemoteSearchResult(alloc: std.mem.Allocator, body: []const u8) !db_mod.t
         hits[i] = .{
             .id = try alloc.dupe(u8, item._id),
             .score = item._score,
+            .index_scores = try parseRemoteIndexScoresAlloc(alloc, item._index_scores),
             .stored_data = if (item._source) |value| try std.fmt.allocPrint(alloc, "{f}", .{std.json.fmt(value, .{})}) else null,
         };
         initialized += 1;
@@ -12477,6 +12479,62 @@ fn parseRemoteSearchResult(alloc: std.mem.Allocator, body: []const u8) !db_mod.t
         .total_hits = @intCast(hits_obj.total orelse 0),
         .graph_results = graph_results,
     };
+}
+
+fn parseRemoteIndexScoresAlloc(
+    alloc: std.mem.Allocator,
+    maybe_value: ?std.json.Value,
+) ![]fusion_mod.IndexScore {
+    const value = maybe_value orelse return &.{};
+    if (value != .object) return &.{};
+    const object = value.object;
+    if (object.count() == 0) return &.{};
+
+    var scores = try alloc.alloc(fusion_mod.IndexScore, object.count());
+    var initialized: usize = 0;
+    errdefer {
+        for (scores[0..initialized]) |score| alloc.free(score.index_name);
+        alloc.free(scores);
+    }
+
+    var it = object.iterator();
+    while (it.next()) |entry| {
+        const score: f64 = switch (entry.value_ptr.*) {
+            .float => |v| v,
+            .integer => |v| @floatFromInt(v),
+            .number_string => |v| std.fmt.parseFloat(f64, v) catch continue,
+            else => continue,
+        };
+        scores[initialized] = .{
+            .index_name = try alloc.dupe(u8, entry.key_ptr.*),
+            .score = score,
+        };
+        initialized += 1;
+    }
+
+    if (initialized == 0) {
+        alloc.free(scores);
+        return &.{};
+    }
+    if (initialized == scores.len) return scores;
+    const trimmed = try alloc.realloc(scores, initialized);
+    return trimmed;
+}
+
+test "parseRemoteSearchResult preserves fused index scores" {
+    const alloc = std.testing.allocator;
+    var result = try parseRemoteSearchResult(alloc,
+        \\{"responses":[{"hits":{"total":1,"hits":[{"_id":"doc:a","_score":0.9,"_index_scores":{"full_text":0.75,"semantic_idx":0.25},"_source":{"title":"alpha"}}],"max_score":0.9},"took":1,"status":200,"table":"docs"}]}
+    );
+    defer result.deinit();
+
+    try std.testing.expectEqual(@as(usize, 1), result.hits.len);
+    try std.testing.expectEqualStrings("doc:a", result.hits[0].id);
+    try std.testing.expectEqual(@as(usize, 2), result.hits[0].index_scores.len);
+    try std.testing.expectEqualStrings("full_text", result.hits[0].index_scores[0].index_name);
+    try std.testing.expectEqual(@as(f64, 0.75), result.hits[0].index_scores[0].score);
+    try std.testing.expectEqualStrings("semantic_idx", result.hits[0].index_scores[1].index_name);
+    try std.testing.expectEqual(@as(f64, 0.25), result.hits[0].index_scores[1].score);
 }
 
 fn parseRemoteGraphResults(

--- a/zig/pkg/antfly/src/index.zig
+++ b/zig/pkg/antfly/src/index.zig
@@ -783,13 +783,42 @@ pub const IndexWriter = struct {
             if (std.mem.eql(u8, fi.name, segment_mod.doc_ordinals_field)) continue;
             for (fi.sections) |*si| {
                 if (si.section_type != .inverted_text) continue;
-                const sec_data = reader.data[@intCast(si.offset)..][0..@intCast(si.length)];
+                const offset: usize = @intCast(si.offset);
+                if (offset > reader.data.len or si.length > reader.data.len - offset) continue;
+                const sec_data = reader.data[offset..][0..@intCast(si.length)];
                 const inv = inverted.InvertedIndexReader.init(alloc, sec_data) catch continue;
                 const gop = try global_field_lens.getOrPut(alloc, fi.name);
                 if (!gop.found_existing) gop.value_ptr.* = 0;
                 gop.value_ptr.* += inv.total_field_len;
             }
         }
+    }
+
+    test "global field lens ignores invalid inverted section slice" {
+        var sections = [_]segment_mod.SegmentReader.SectionInfo{.{
+            .section_type = .inverted_text,
+            .offset = 60,
+            .length = 8,
+        }};
+        var fields = [_]segment_mod.SegmentReader.FieldInfo{.{
+            .name = "content",
+            .sections = sections[0..],
+        }};
+        const data = [_]u8{0} ** 64;
+        const reader = segment_mod.SegmentReader{
+            .alloc = std.testing.allocator,
+            .data = &data,
+            .stored_offset = data.len - 40,
+            .index_offset = data.len - 40,
+            .doc_count = 0,
+            .num_fields = 1,
+            .fields = fields[0..],
+        };
+        var field_lens = std.StringHashMapUnmanaged(u64).empty;
+        defer field_lens.deinit(std.testing.allocator);
+
+        try IndexWriter.addSegmentFieldLens(std.testing.allocator, &field_lens, &reader);
+        try std.testing.expectEqual(@as(usize, 0), field_lens.count());
     }
 
     /// Like addSegment() but with an explicit segment ID (for recovery).

--- a/zig/pkg/antfly/src/inference/local.zig
+++ b/zig/pkg/antfly/src/inference/local.zig
@@ -177,6 +177,11 @@ pub const Provider = struct {
     pub fn embedParts(self: *Provider, alloc: std.mem.Allocator, model: []const u8, parts: []const template_mod.ContentPart) !inference.EmbedResult {
         var values = std.json.Array.init(alloc);
         defer values.deinit();
+        var encoded_buffers = std.ArrayListUnmanaged([]u8).empty;
+        defer {
+            for (encoded_buffers.items) |buf| alloc.free(buf);
+            encoded_buffers.deinit(alloc);
+        }
 
         for (parts) |part| {
             switch (part) {
@@ -201,11 +206,16 @@ pub const Provider = struct {
                 .binary => |binary_part| {
                     const encoded_len = std.base64.standard.Encoder.calcSize(binary_part.data.len);
                     const encoded = try alloc.alloc(u8, encoded_len);
-                    defer alloc.free(encoded);
+                    errdefer alloc.free(encoded);
                     _ = std.base64.standard.Encoder.encode(encoded, binary_part.data);
+                    try encoded_buffers.append(alloc, encoded);
 
                     var obj = std.json.ObjectMap.empty;
-                    errdefer obj.deinit(alloc);
+                    errdefer {
+                        obj.deinit(alloc);
+                        _ = encoded_buffers.pop();
+                        alloc.free(encoded);
+                    }
                     try obj.put(alloc, "type", .{ .string = "media" });
                     try obj.put(alloc, "data", .{ .string = encoded });
                     try obj.put(alloc, "mime_type", .{ .string = binary_part.mime_type });
@@ -433,6 +443,68 @@ test "antfly embed request omits nullable generated fields" {
     try std.testing.expect(std.mem.indexOf(u8, body, "\"encoding_format\":\"float\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, body, "\"dimensions\"") == null);
     try std.testing.expect(std.mem.indexOf(u8, body, "null") == null);
+}
+
+test "antfly embed parts preserves binary base64 until request serialization" {
+    const alloc = std.testing.allocator;
+    var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
+    defer io_impl.deinit();
+    const io = io_impl.io();
+
+    const Assert = struct {
+        fn request(req: httpx.testing_mod.RequestInfo) !void {
+            try std.testing.expectEqual(httpx.Method.POST, req.method);
+            try std.testing.expectEqualStrings("/embed", req.path);
+            try std.testing.expect(std.mem.indexOf(u8, req.body, "\"type\":\"media\"") != null);
+            try std.testing.expect(std.mem.indexOf(u8, req.body, "\"data\":\"AQID\"") != null);
+            try std.testing.expect(std.mem.indexOf(u8, req.body, "\"mime_type\":\"image/png\"") != null);
+        }
+    };
+
+    var ts = try httpx.TestServer.start(alloc, io, &.{
+        .{ .method = .POST, .path = "/embed", .assert_request = Assert.request, .respond = .{
+            .body = "{\"data\":[{\"embedding\":[0.25,0.5,0.75]}]}",
+            .content_type = "application/json",
+        } },
+    });
+    defer ts.deinit();
+
+    var group = std.Io.Group.init;
+    var result_ok: bool = false;
+    var result_dim: usize = 0;
+    var result_err: anyerror = error.None;
+
+    const Fiber = struct {
+        fn run(a: std.mem.Allocator, test_io: std.Io, base: []const u8, ok_out: *bool, dim_out: *usize, err_out: *anyerror) std.Io.Cancelable!void {
+            var client = httpx.Client.initWithConfig(a, test_io, .{ .keep_alive = false });
+            defer client.deinit();
+
+            var provider = Provider.init(a, &client, base);
+            defer provider.deinit();
+
+            var result = provider.embedParts(a, "clipclap", &.{
+                .{ .binary = .{ .mime_type = "image/png", .data = &[_]u8{ 1, 2, 3 } } },
+            }) catch |e| {
+                err_out.* = e;
+                return;
+            };
+            defer result.deinit();
+
+            ok_out.* = true;
+            dim_out.* = result.dimension;
+        }
+    };
+
+    group.concurrent(io, Fiber.run, .{ alloc, io, ts.baseUrl(), &result_ok, &result_dim, &result_err }) catch return;
+
+    try ts.handleOne();
+    group.await(io) catch {};
+
+    if (!result_ok) {
+        std.debug.print("embed parts fiber error: {}\n", .{result_err});
+        return error.TestUnexpectedResult;
+    }
+    try std.testing.expectEqual(@as(usize, 3), result_dim);
 }
 
 test "antfly generate round trip" {

--- a/zig/pkg/antfly/src/inference/managed_embedder.zig
+++ b/zig/pkg/antfly/src/inference/managed_embedder.zig
@@ -69,6 +69,12 @@ pub const AntflyProvider = struct {
         model: []const u8,
         texts: []const []const u8,
     ) anyerror![]db_embedder.SparseEmbedding,
+    embed_dense_parts: ?*const fn (
+        ptr: *anyopaque,
+        alloc: std.mem.Allocator,
+        model: []const u8,
+        parts: []const template_mod.ContentPart,
+    ) anyerror![][]f32 = null,
     rerank_texts: ?*const fn (
         ptr: *anyopaque,
         alloc: std.mem.Allocator,
@@ -1540,7 +1546,15 @@ fn embedWithEntryParts(
     }
 
     if (isAntflyProvider(entry.provider) and (entry.multimodal or partsContainMedia(parts))) {
-        if (entry.antfly_provider == null) {
+        if (entry.antfly_provider) |local| {
+            if (local.embed_dense_parts) |embed_parts| {
+                waitForEntryPacer(entry);
+                const vectors = try embed_parts(local.ptr, alloc, entry.model, parts);
+                defer db_embedder.freeDenseEmbeddingBatch(alloc, vectors);
+                if (vectors.len == 0) return error.EmptyEmbeddingResponse;
+                if (dims > 0 and vectors[0].len != dims) return error.InvalidEmbeddingDimensions;
+                return try alloc.dupe(f32, vectors[0]);
+            }
             return error.UnsupportedEmbeddingProvider;
         }
         waitForEntryPacer(entry);
@@ -3014,6 +3028,8 @@ test "managed embedder routes antfly with api_url to antfly endpoint" {
 
 test "managed embedder sends antfly media parts when local provider is configured" {
     const Local = struct {
+        saw_parts: bool = false,
+
         fn dense(_: *anyopaque, _: std.mem.Allocator, _: []const u8, _: []const []const u8) ![][]f32 {
             return error.TestUnexpectedResult;
         }
@@ -3021,62 +3037,47 @@ test "managed embedder sends antfly media parts when local provider is configure
         fn sparse(_: *anyopaque, alloc: std.mem.Allocator, _: []const u8, _: []const []const u8) ![]db_embedder.SparseEmbedding {
             return try alloc.alloc(db_embedder.SparseEmbedding, 0);
         }
-    };
 
-    const FakeApp = struct {
-        fn executor() http_common.RequestExecutor {
-            return .{
-                .ptr = undefined,
-                .vtable = &.{
-                    .execute = execute,
-                },
-            };
-        }
+        fn parts(ptr: *anyopaque, alloc: std.mem.Allocator, model: []const u8, parts_slice: []const template_mod.ContentPart) ![][]f32 {
+            const self: *@This() = @ptrCast(@alignCast(ptr));
+            try std.testing.expectEqualStrings("local-model", model);
+            try std.testing.expectEqual(@as(usize, 3), parts_slice.len);
+            try std.testing.expectEqualStrings("caption", parts_slice[0].text);
+            try std.testing.expectEqualStrings("data:image/png;base64,aaa", parts_slice[1].media_url);
+            try std.testing.expectEqualStrings("image/png", parts_slice[2].binary.mime_type);
+            try std.testing.expectEqualStrings(&[_]u8{ 1, 2, 3 }, parts_slice[2].binary.data);
+            self.saw_parts = true;
 
-        fn execute(_: *anyopaque, alloc: std.mem.Allocator, req: http_common.HttpRequest) !http_common.HttpResponse {
-            try std.testing.expectEqual(http_common.Method.POST, req.method);
-            try std.testing.expect(std.mem.endsWith(u8, req.uri, "/api/embed"));
-            try std.testing.expect(std.mem.indexOf(u8, req.body, "\"type\":\"image_url\"") != null);
-            try std.testing.expect(std.mem.indexOf(u8, req.body, "data:image/png;base64,aaa") != null);
-            return .{
-                .status = 200,
-                .content_type = try alloc.dupe(u8, "application/json"),
-                .body = try alloc.dupe(u8,
-                    \\{"data":[{"embedding":[0.25,0.5,0.75]}]}
-                ),
-            };
+            const vectors = try alloc.alloc([]f32, 1);
+            errdefer alloc.free(vectors);
+            vectors[0] = try alloc.dupe(f32, &.{ 0.25, 0.5, 0.75 });
+            return vectors;
         }
     };
-
-    var listener = std_http_listener.StdHttpListener.init(std.testing.allocator, .{}, FakeApp.executor());
-    defer listener.deinit();
-    try listener.start();
-
-    const base_uri = try listener.baseUri(std.testing.allocator);
-    defer std.testing.allocator.free(base_uri);
 
     var local = Local{};
     const provider = AntflyProvider{
         .ptr = &local,
         .embed_dense_texts = Local.dense,
         .embed_sparse_texts = Local.sparse,
+        .embed_dense_parts = Local.parts,
     };
 
-    const indexes_json = try std.fmt.allocPrint(std.testing.allocator,
-        \\{{"semantic_idx":{{"type":"embeddings","field":"body","dimension":3,"embedder":{{"provider":"antfly","model":"remote-model","api_url":"{s}","multimodal":true}}}}}}
-    , .{base_uri});
-    defer std.testing.allocator.free(indexes_json);
-
+    const indexes_json =
+        \\{"semantic_idx":{"type":"embeddings","field":"body","dimension":3,"embedder":{"provider":"antfly","model":"local-model","multimodal":true}}}
+    ;
     var managed = try ManagedEmbedder.initFromIndexesJsonWithAntflyProvider(std.testing.allocator, indexes_json, provider);
     defer managed.deinit();
 
     const parts = [_]template_mod.ContentPart{
         .{ .text = "caption" },
         .{ .media_url = "data:image/png;base64,aaa" },
+        .{ .binary = .{ .mime_type = "image/png", .data = &[_]u8{ 1, 2, 3 } } },
     };
     const vector = try embedWithEntryParts(std.testing.allocator, &managed.entries[0], &parts, 3);
     defer std.testing.allocator.free(vector);
     try std.testing.expectEqualSlices(f32, &.{ 0.25, 0.5, 0.75 }, vector);
+    try std.testing.expect(local.saw_parts);
 }
 
 test "managed embedder preserves antfly api_url path for shared antfly endpoint" {

--- a/zig/pkg/antfly/src/search/search.zig
+++ b/zig/pkg/antfly/src/search/search.zig
@@ -381,6 +381,7 @@ pub const SearchResult = struct {
     pub fn deinit(self: *SearchResult) void {
         for (self.hits) |*hit| {
             if (hit.stored_data) |d| self.alloc.free(d);
+            freeIndexScores(self.alloc, hit.index_scores);
         }
         self.alloc.free(self.hits);
         freeAggResults(self.alloc, self.aggregations);
@@ -391,6 +392,29 @@ pub const SearchResult = struct {
         if (self.graph_results.len > 0) self.alloc.free(self.graph_results);
     }
 };
+
+fn freeIndexScores(alloc: Allocator, scores: []fusion_mod.IndexScore) void {
+    for (scores) |score| alloc.free(score.index_name);
+    if (scores.len > 0) alloc.free(scores);
+}
+
+fn cloneIndexScores(alloc: Allocator, scores: []const fusion_mod.IndexScore) ![]fusion_mod.IndexScore {
+    if (scores.len == 0) return &.{};
+    const cloned = try alloc.alloc(fusion_mod.IndexScore, scores.len);
+    var initialized: usize = 0;
+    errdefer {
+        for (cloned[0..initialized]) |score| alloc.free(score.index_name);
+        alloc.free(cloned);
+    }
+    for (scores, 0..) |score, i| {
+        cloned[i] = .{
+            .index_name = try alloc.dupe(u8, score.index_name),
+            .score = score.score,
+        };
+        initialized += 1;
+    }
+    return cloned;
+}
 
 fn freeAggResults(alloc: Allocator, aggs: []const NamedAggResult) void {
     for (aggs) |agg| {
@@ -424,6 +448,7 @@ pub const ScoredHit = struct {
     score: f32,
     id: ?[]const u8,
     stored_data: ?[]u8,
+    index_scores: []fusion_mod.IndexScore = &.{},
 };
 
 // ============================================================================
@@ -2193,7 +2218,14 @@ fn executeHybrid(
     // Convert fused results back to ScoredHits
     const result_count = @min(fused.len, request.k);
     var hits = try alloc.alloc(ScoredHit, result_count);
-    errdefer alloc.free(hits);
+    var initialized: usize = 0;
+    errdefer {
+        for (hits[0..initialized]) |*hit| {
+            if (hit.stored_data) |data| alloc.free(data);
+            freeIndexScores(alloc, hit.index_scores);
+        }
+        alloc.free(hits);
+    }
 
     for (fused[0..result_count], 0..) |fh, i| {
         const doc_id = std.fmt.parseInt(u32, fh.doc_id, 10) catch 0;
@@ -2202,7 +2234,9 @@ fn executeHybrid(
             .score = @floatCast(fh.score),
             .id = null,
             .stored_data = null,
+            .index_scores = try cloneIndexScores(alloc, fh.index_scores),
         };
+        errdefer freeIndexScores(alloc, hit.index_scores);
         if (request.include_stored) {
             if (try snap.storedDocDecompressed(doc_id)) |stored| {
                 hit.id = stored.id;
@@ -2210,6 +2244,7 @@ fn executeHybrid(
             }
         }
         hits[i] = hit;
+        initialized += 1;
     }
 
     return .{ .alloc = alloc, .hits = hits, .total_hits = @intCast(result_count) };

--- a/zig/pkg/antfly/src/segment.zig
+++ b/zig/pkg/antfly/src/segment.zig
@@ -641,6 +641,7 @@ pub const SegmentReader = struct {
                 switch (section.section_type) {
                     .inverted_text => {
                         stats.inverted_text_bytes +|= length;
+                        if (offset > self.data.len or length > self.data.len - offset) continue;
                         const section_data = self.data[offset..][0..@intCast(length)];
                         if (inverted.InvertedIndexReader.init(self.alloc, section_data)) |reader| {
                             const inverted_layout = if (detailed_inverted)
@@ -1555,6 +1556,32 @@ test "segment roundtrip" {
     const doc1 = (try reader.storedDocDecompressed(1)) orelse return error.TestExpectedEqual;
     defer alloc.free(doc1.data);
     try std.testing.expectEqualStrings("doc-2", doc1.id);
+}
+
+test "segment layout stats ignores invalid inverted section slice" {
+    var sections = [_]SegmentReader.SectionInfo{.{
+        .section_type = .inverted_text,
+        .offset = 60,
+        .length = 8,
+    }};
+    var fields = [_]SegmentReader.FieldInfo{.{
+        .name = "content",
+        .sections = sections[0..],
+    }};
+    const data = [_]u8{0} ** 64;
+    const reader = SegmentReader{
+        .alloc = std.testing.allocator,
+        .data = &data,
+        .stored_offset = data.len - footer_size,
+        .index_offset = data.len - footer_size,
+        .doc_count = 0,
+        .num_fields = 1,
+        .fields = fields[0..],
+    };
+
+    const stats = reader.layoutStatsWithInvertedDetails(true);
+    try std.testing.expectEqual(@as(u64, 8), stats.inverted_text_bytes);
+    try std.testing.expectEqual(@as(u64, 0), stats.inverted_postings_bytes);
 }
 
 test "segment merge" {

--- a/zig/pkg/antfly/src/storage/db/db.zig
+++ b/zig/pkg/antfly/src/storage/db/db.zig
@@ -8166,6 +8166,9 @@ pub const DB = struct {
 
         const target_sequence = self.core.nextDerivedSequence();
         for (runtime_stats.indexes) |*item| {
+            if (self.enrichment_runtime) |runtime| {
+                item.enrichment_failed = runtime.indexHasIsolatedFailure(item.name);
+            }
             const dense_catch_up = item.kind == .dense_vector and runtime_stats.async_indexing.dense_catch_up.active;
             if (!dense_catch_up) if (self.executor.appliedSequence(item.name)) |live_applied| {
                 item.replay_applied_sequence = @max(item.replay_applied_sequence, live_applied);

--- a/zig/pkg/antfly/src/storage/db/enrichment/enrichment_runtime.zig
+++ b/zig/pkg/antfly/src/storage/db/enrichment/enrichment_runtime.zig
@@ -442,6 +442,19 @@ fn clearPublishedGeneratedArtifacts(runtime: *EnrichmentRuntime) void {
     runtime.published_generated_artifacts.clearAndFree(runtime.alloc);
 }
 
+fn clearIsolatedFailedIndexes(runtime: *EnrichmentRuntime) void {
+    var it = runtime.isolated_failed_indexes.iterator();
+    while (it.next()) |entry| runtime.alloc.free(@constCast(entry.key_ptr.*));
+    runtime.isolated_failed_indexes.clearAndFree(runtime.alloc);
+}
+
+fn markIsolatedFailedIndex(runtime: *EnrichmentRuntime, index_name: []const u8) void {
+    if (runtime.isolated_failed_indexes.contains(index_name)) return;
+    const owned_key = runtime.alloc.dupe(u8, index_name) catch return;
+    errdefer runtime.alloc.free(owned_key);
+    runtime.isolated_failed_indexes.put(runtime.alloc, owned_key, {}) catch return;
+}
+
 fn generatedArtifactAlreadyPublished(runtime: *EnrichmentRuntime, artifact_key: []const u8) bool {
     return runtime.published_generated_artifacts.contains(artifact_key);
 }
@@ -819,6 +832,7 @@ pub const EnrichmentRuntime = if (builtin.os.tag == .freestanding) struct {
     sparse_artifact_bytes_written: u64 = 0,
     chunk_artifact_bytes_written: u64 = 0,
     published_generated_artifacts: std.StringHashMapUnmanaged(void) = .empty,
+    isolated_failed_indexes: std.StringHashMapUnmanaged(void) = .empty,
 
     pub fn init(
         alloc: Allocator,
@@ -864,6 +878,7 @@ pub const EnrichmentRuntime = if (builtin.os.tag == .freestanding) struct {
 
     pub fn deinit(self: *@This()) void {
         clearPublishedGeneratedArtifacts(self);
+        clearIsolatedFailedIndexes(self);
         if (self.owns_store) self.store.deinit();
         if (self.config.dense_embedder) |dense_embedder| dense_embedder.deinit(self.alloc);
         if (self.config.sparse_embedder) |sparse_embedder| sparse_embedder.deinit(self.alloc);
@@ -881,6 +896,7 @@ pub const EnrichmentRuntime = if (builtin.os.tag == .freestanding) struct {
     }
 
     pub fn notifySequence(self: *@This(), sequence: u64) void {
+        if (sequence > self.target_sequence) clearIsolatedFailedIndexes(self);
         self.target_sequence = @max(self.target_sequence, sequence);
     }
 
@@ -891,6 +907,7 @@ pub const EnrichmentRuntime = if (builtin.os.tag == .freestanding) struct {
             self.applied_sequence = next_applied;
         }
         clearPublishedGeneratedArtifacts(self);
+        clearIsolatedFailedIndexes(self);
         self.target_sequence = @max(self.target_sequence, @max(target_sequence, next_applied));
     }
 
@@ -933,6 +950,7 @@ pub const EnrichmentRuntime = if (builtin.os.tag == .freestanding) struct {
             self.retrying = false;
             self.worker_failed = false;
             clearPublishedGeneratedArtifacts(self);
+            clearIsolatedFailedIndexes(self);
         }
     }
 
@@ -945,6 +963,7 @@ pub const EnrichmentRuntime = if (builtin.os.tag == .freestanding) struct {
         self.applied_sequence = sequence;
         self.target_sequence = @max(self.target_sequence, sequence);
         clearPublishedGeneratedArtifacts(self);
+        clearIsolatedFailedIndexes(self);
     }
 
     pub fn stats(self: *@This()) types.EnrichmentStats {
@@ -984,6 +1003,10 @@ pub const EnrichmentRuntime = if (builtin.os.tag == .freestanding) struct {
             .chunk_artifact_bytes_written = self.chunk_artifact_bytes_written,
             .artifact_bytes_written = self.dense_artifact_bytes_written + self.sparse_artifact_bytes_written + self.chunk_artifact_bytes_written,
         };
+    }
+
+    pub fn indexHasIsolatedFailure(self: *@This(), index_name: []const u8) bool {
+        return self.isolated_failed_indexes.contains(index_name);
     }
 } else struct {
     alloc: Allocator,
@@ -1030,6 +1053,7 @@ pub const EnrichmentRuntime = if (builtin.os.tag == .freestanding) struct {
     chunk_artifact_bytes_written: u64 = 0,
     last_error_name: ?[]const u8 = null,
     published_generated_artifacts: std.StringHashMapUnmanaged(void) = .empty,
+    isolated_failed_indexes: std.StringHashMapUnmanaged(void) = .empty,
     status_hook: ?StatusHook = null,
     future: ?Io.Future(void) = null,
 
@@ -1096,6 +1120,7 @@ pub const EnrichmentRuntime = if (builtin.os.tag == .freestanding) struct {
         }
         self.future = null;
         clearPublishedGeneratedArtifacts(self);
+        clearIsolatedFailedIndexes(self);
         self.ownership.deinit(self.alloc);
         if (self.owns_store) self.store.deinit();
         if (self.config.dense_embedder) |dense_embedder| dense_embedder.deinit(self.alloc);
@@ -1137,6 +1162,7 @@ pub const EnrichmentRuntime = if (builtin.os.tag == .freestanding) struct {
             if (sequence > self.target_sequence) self.last_error_name = null;
             self.retrying = false;
             self.worker_failed = false;
+            if (sequence > self.target_sequence) clearIsolatedFailedIndexes(self);
             self.target_sequence = @max(self.target_sequence, sequence);
             return;
         };
@@ -1145,6 +1171,7 @@ pub const EnrichmentRuntime = if (builtin.os.tag == .freestanding) struct {
         if (sequence > self.target_sequence) self.last_error_name = null;
         self.retrying = false;
         self.worker_failed = false;
+        if (sequence > self.target_sequence) clearIsolatedFailedIndexes(self);
         self.target_sequence = @max(self.target_sequence, sequence);
         self.cond.broadcast(io);
         self.mutex.unlock(io);
@@ -1162,6 +1189,7 @@ pub const EnrichmentRuntime = if (builtin.os.tag == .freestanding) struct {
         self.retrying = false;
         self.worker_failed = false;
         clearPublishedGeneratedArtifacts(self);
+        clearIsolatedFailedIndexes(self);
         self.cond.broadcast(io);
         self.mutex.unlock(io);
 
@@ -1198,6 +1226,7 @@ pub const EnrichmentRuntime = if (builtin.os.tag == .freestanding) struct {
         self.retrying = false;
         self.worker_failed = false;
         clearPublishedGeneratedArtifacts(self);
+        clearIsolatedFailedIndexes(self);
         status = runtimeStatusSnapshot(self);
         self.cond.broadcast(io);
         self.mutex.unlock(io);
@@ -1253,6 +1282,13 @@ pub const EnrichmentRuntime = if (builtin.os.tag == .freestanding) struct {
         };
     }
 
+    pub fn indexHasIsolatedFailure(self: *EnrichmentRuntime, index_name: []const u8) bool {
+        const maybe_io = if (self.io_impl) |io_impl| io_impl.io() else null;
+        if (maybe_io) |io| self.mutex.lockUncancelable(io);
+        defer if (maybe_io) |io| self.mutex.unlock(io);
+        return self.isolated_failed_indexes.contains(index_name);
+    }
+
     fn recordError(self: *EnrichmentRuntime, io: Io, err: anyerror) void {
         std.log.err("enrichment worker failed: {s}", .{@errorName(err)});
         var status: enrichment_state.RuntimeStatus = .{};
@@ -1296,6 +1332,63 @@ fn handleWorkerLoopError(runtime: *EnrichmentRuntime, io: Io, err: anyerror) voi
         return;
     }
     runtime.recordError(io, err);
+}
+
+fn recordIsolatedRequestError(runtime: *EnrichmentRuntime, request: enrichment_types.GeneratedEnrichmentRequest, err: anyerror) void {
+    std.log.warn("enrichment request failed index={s} artifact={s}: {s}", .{ request.index_name, requestEmbeddingName(request), @errorName(err) });
+    if (runtime.io_impl) |io_impl| {
+        const io = io_impl.io();
+        runtime.mutex.lockUncancelable(io);
+        runtime.error_count += 1;
+        runtime.fatal_error_count += 1;
+        runtime.retrying = false;
+        runtime.worker_failed = false;
+        markIsolatedFailedIndex(runtime, request.index_name);
+        runtime.mutex.unlock(io);
+    } else {
+        runtime.error_count += 1;
+        runtime.fatal_error_count += 1;
+        runtime.retrying = false;
+        runtime.worker_failed = false;
+        markIsolatedFailedIndex(runtime, request.index_name);
+    }
+    runtime.notifyStatusHook();
+}
+
+test "isolated enrichment request error does not mark worker failed" {
+    var runtime = EnrichmentRuntime{
+        .alloc = std.testing.allocator,
+        .io_impl = null,
+        .store = undefined,
+        .owns_store = false,
+        .change_journal = undefined,
+        .replay_source = undefined,
+        .index_manager = undefined,
+        .write_ctx = undefined,
+        .write_fn = undefined,
+        .notify_ctx = undefined,
+        .notify_fn = undefined,
+        .config = .{},
+        .ownership = undefined,
+    };
+    runtime.retrying = true;
+    runtime.worker_failed = true;
+
+    recordIsolatedRequestError(&runtime, .{
+        .kind = .dense_embedding,
+        .index_name = "bad_visual",
+        .embedding_name = "clipclap",
+        .doc_key = "doc:1",
+        .source_field = "image_url",
+    }, error.UnsupportedEmbeddingProvider);
+
+    try std.testing.expectEqual(@as(u64, 1), runtime.error_count);
+    try std.testing.expectEqual(@as(u64, 1), runtime.fatal_error_count);
+    try std.testing.expect(!runtime.retrying);
+    try std.testing.expect(!runtime.worker_failed);
+    try std.testing.expect(runtime.indexHasIsolatedFailure("bad_visual"));
+    try std.testing.expect(!runtime.indexHasIsolatedFailure("healthy_text"));
+    clearIsolatedFailedIndexes(&runtime);
 }
 
 fn workerMain(runtime: *EnrichmentRuntime) void {
@@ -1453,10 +1546,26 @@ fn processPendingDocumentGroup(
             continue;
         }
         switch (request.kind) {
-            .asset => try processAsset(runtime, request, window),
-            .chunk_text => try processChunkText(runtime, request, chunk_cache, window),
-            .dense_embedding => try processDenseEmbedding(runtime, request, chunk_cache, window),
-            .sparse_embedding => try processSparseEmbedding(runtime, request, chunk_cache, window),
+            .asset => processAsset(runtime, request, window) catch |err| {
+                if (isRetryableEnrichmentError(err)) return err;
+                recordIsolatedRequestError(runtime, request, err);
+                continue;
+            },
+            .chunk_text => processChunkText(runtime, request, chunk_cache, window) catch |err| {
+                if (isRetryableEnrichmentError(err)) return err;
+                recordIsolatedRequestError(runtime, request, err);
+                continue;
+            },
+            .dense_embedding => processDenseEmbedding(runtime, request, chunk_cache, window) catch |err| {
+                if (isRetryableEnrichmentError(err)) return err;
+                recordIsolatedRequestError(runtime, request, err);
+                continue;
+            },
+            .sparse_embedding => processSparseEmbedding(runtime, request, chunk_cache, window) catch |err| {
+                if (isRetryableEnrichmentError(err)) return err;
+                recordIsolatedRequestError(runtime, request, err);
+                continue;
+            },
         }
     }
 }
@@ -2288,7 +2397,11 @@ fn processPlainDenseWindow(
             }
         }
 
-        try flushPlainDenseItems(runtime, dense_embedder, embedding_artifact_name, seed.expected_dims, consumer_indexes, items.items, window);
+        flushPlainDenseItems(runtime, dense_embedder, embedding_artifact_name, seed.expected_dims, consumer_indexes, items.items, window) catch |err| {
+            if (isRetryableEnrichmentError(err)) return err;
+            for (items.items) |item| recordIsolatedRequestError(runtime, item.request, err);
+            continue;
+        };
     }
 }
 
@@ -2395,7 +2508,11 @@ fn processChunkedDenseWindow(
         }
         if (chunk_items.items.len == 0) continue;
 
-        const vectors = try embedDenseBatchWithRetry(dense_embedder, runtime, embedding_artifact_name, chunk_texts.items, seed.expected_dims);
+        const vectors = embedDenseBatchWithRetry(dense_embedder, runtime, embedding_artifact_name, chunk_texts.items, seed.expected_dims) catch |err| {
+            if (isRetryableEnrichmentError(err)) return err;
+            for (chunk_items.items) |item| recordIsolatedRequestError(runtime, item.request, err);
+            continue;
+        };
         errdefer embedder_mod.freeDenseEmbeddingBatch(runtime.alloc, vectors);
         if (vectors.len != chunk_items.items.len) return error.InvalidEmbeddingResponse;
 

--- a/zig/pkg/antfly/src/storage/db/query/search_exec.zig
+++ b/zig/pkg/antfly/src/storage/db/query/search_exec.zig
@@ -3585,25 +3585,36 @@ pub fn searchTextQuery(
         const doc_ordinal = try snapshot.docOrdinal(hit.doc_id);
         const id = hit.id orelse {
             const stored = snapshot.storedDoc(hit.doc_id) orelse return error.StoredDocMissing;
-            hits[i] = .{
+            var materialized = types.SearchHit{
                 .id = try alloc.dupe(u8, stored.id),
                 .doc_ordinal = doc_ordinal,
                 .score = hit.score,
                 .stored_data = null,
             };
+            var assigned = false;
+            errdefer if (!assigned) materialized.deinit(alloc);
+            materialized.index_scores = try types.cloneIndexScores(alloc, hit.index_scores);
+            hits[i] = materialized;
+            assigned = true;
             initialized += 1;
             continue;
         };
 
-        hits[i] = .{
+        var materialized = types.SearchHit{
             .id = try alloc.dupe(u8, id),
             .doc_ordinal = doc_ordinal,
             .score = hit.score,
-            .stored_data = if (effective_req.include_stored and hit.stored_data != null)
-                try executor.project_stored_search(executor.ctx, alloc, effective_req, id, hit.stored_data.?)
-            else
-                null,
+            .stored_data = null,
         };
+        var assigned = false;
+        errdefer if (!assigned) materialized.deinit(alloc);
+        materialized.index_scores = try types.cloneIndexScores(alloc, hit.index_scores);
+        materialized.stored_data = if (effective_req.include_stored and hit.stored_data != null)
+            try executor.project_stored_search(executor.ctx, alloc, effective_req, id, hit.stored_data.?)
+        else
+            null;
+        hits[i] = materialized;
+        assigned = true;
         initialized += 1;
     }
     const hits_ns = if (bench_query_profile) platform_time.monotonicNs() - hits_start_ns else 0;

--- a/zig/pkg/antfly/src/storage/db/types.zig
+++ b/zig/pkg/antfly/src/storage/db/types.zig
@@ -1010,6 +1010,7 @@ pub const SearchHit = struct {
     id: []u8,
     doc_ordinal: ?u32 = null,
     score: ?f32 = null,
+    index_scores: []fusion_mod.IndexScore = &.{},
     stored_data: ?[]u8 = null,
     artifact_ref: ?ArtifactRef = null,
     chunk_hits: []ChunkHit = &.{},
@@ -1019,12 +1020,14 @@ pub const SearchHit = struct {
             .id = try alloc.dupe(u8, self.id),
             .doc_ordinal = self.doc_ordinal,
             .score = self.score,
+            .index_scores = try cloneIndexScores(alloc, self.index_scores),
             .stored_data = if (self.stored_data) |data| try alloc.dupe(u8, data) else null,
             .artifact_ref = if (self.artifact_ref) |artifact_ref| try artifact_ref.clone(alloc) else null,
             .chunk_hits = &.{},
         };
         errdefer {
             alloc.free(cloned.id);
+            freeIndexScores(alloc, cloned.index_scores);
             if (cloned.stored_data) |data| alloc.free(data);
             if (cloned.artifact_ref) |*artifact_ref| artifact_ref.deinit(alloc);
         }
@@ -1046,6 +1049,7 @@ pub const SearchHit = struct {
 
     pub fn deinit(self: *SearchHit, alloc: Allocator) void {
         alloc.free(self.id);
+        freeIndexScores(alloc, self.index_scores);
         if (self.stored_data) |data| alloc.free(data);
         if (self.artifact_ref) |*artifact_ref| artifact_ref.deinit(alloc);
         for (self.chunk_hits) |*chunk| chunk.deinit(alloc);
@@ -1053,6 +1057,29 @@ pub const SearchHit = struct {
         self.* = undefined;
     }
 };
+
+pub fn cloneIndexScores(alloc: Allocator, scores: []const fusion_mod.IndexScore) ![]fusion_mod.IndexScore {
+    if (scores.len == 0) return &.{};
+    const cloned = try alloc.alloc(fusion_mod.IndexScore, scores.len);
+    var initialized: usize = 0;
+    errdefer {
+        for (cloned[0..initialized]) |score| alloc.free(score.index_name);
+        alloc.free(cloned);
+    }
+    for (scores, 0..) |score, i| {
+        cloned[i] = .{
+            .index_name = try alloc.dupe(u8, score.index_name),
+            .score = score.score,
+        };
+        initialized += 1;
+    }
+    return cloned;
+}
+
+pub fn freeIndexScores(alloc: Allocator, scores: []fusion_mod.IndexScore) void {
+    for (scores) |score| alloc.free(score.index_name);
+    if (scores.len > 0) alloc.free(scores);
+}
 
 pub const ChunkHit = struct {
     id: []u8,
@@ -1402,6 +1429,7 @@ pub const DBIndexStats = struct {
     root_node: u64 = 0,
     backfill_active: bool = false,
     backfill_progress: f64 = 0.0,
+    enrichment_failed: bool = false,
     replay_applied_sequence: u64 = 0,
     replay_target_sequence: u64 = 0,
     replay_catch_up_required: bool = false,

--- a/zig/pkg/antfly/src/swarm/runtime.zig
+++ b/zig/pkg/antfly/src/swarm/runtime.zig
@@ -796,6 +796,7 @@ fn localAntflyProvider(node: *inference.server.Node) antfly.inference.managed_em
         .ptr = node,
         .embed_dense_texts = localAntflyEmbedDenseTexts,
         .embed_sparse_texts = localAntflyEmbedSparseTexts,
+        .embed_dense_parts = localAntflyEmbedDenseParts,
         .rerank_texts = localAntflyRerankTexts,
         .generate_text = localAntflyGenerateText,
         .generate_messages = localAntflyGenerateMessages,
@@ -813,6 +814,65 @@ fn localAntflyEmbedDenseTexts(
 ) anyerror![][]f32 {
     const node: *inference.server.Node = @ptrCast(@alignCast(ptr));
     return try node.embedDenseTextsDirect(alloc, model, texts);
+}
+
+fn localAntflyEmbedDenseParts(
+    ptr: *anyopaque,
+    alloc: std.mem.Allocator,
+    model: []const u8,
+    parts: []const antfly.template.ContentPart,
+) anyerror![][]f32 {
+    const node: *inference.server.Node = @ptrCast(@alignCast(ptr));
+    var values = std.json.Array.init(alloc);
+    defer values.deinit();
+    var encoded_buffers = std.ArrayListUnmanaged([]u8).empty;
+    defer {
+        for (encoded_buffers.items) |buf| alloc.free(buf);
+        encoded_buffers.deinit(alloc);
+    }
+
+    for (parts) |part| {
+        switch (part) {
+            .text => |text| {
+                var obj = std.json.ObjectMap.empty;
+                errdefer obj.deinit(alloc);
+                try obj.put(alloc, "type", .{ .string = "text" });
+                try obj.put(alloc, "text", .{ .string = text });
+                try values.append(.{ .object = obj });
+            },
+            .media_url => |url| {
+                var image_url = std.json.ObjectMap.empty;
+                errdefer image_url.deinit(alloc);
+                try image_url.put(alloc, "url", .{ .string = url });
+
+                var obj = std.json.ObjectMap.empty;
+                errdefer obj.deinit(alloc);
+                try obj.put(alloc, "type", .{ .string = "image_url" });
+                try obj.put(alloc, "image_url", .{ .object = image_url });
+                try values.append(.{ .object = obj });
+            },
+            .binary => |binary_part| {
+                const encoded_len = std.base64.standard.Encoder.calcSize(binary_part.data.len);
+                const encoded = try alloc.alloc(u8, encoded_len);
+                errdefer alloc.free(encoded);
+                _ = std.base64.standard.Encoder.encode(encoded, binary_part.data);
+                try encoded_buffers.append(alloc, encoded);
+
+                var obj = std.json.ObjectMap.empty;
+                errdefer {
+                    obj.deinit(alloc);
+                    _ = encoded_buffers.pop();
+                    alloc.free(encoded);
+                }
+                try obj.put(alloc, "type", .{ .string = "media" });
+                try obj.put(alloc, "data", .{ .string = encoded });
+                try obj.put(alloc, "mime_type", .{ .string = binary_part.mime_type });
+                try values.append(.{ .object = obj });
+            },
+        }
+    }
+
+    return try node.embedDenseJsonInputDirect(alloc, model, .{ .array = values });
 }
 
 fn localAntflyEmbedSparseTexts(

--- a/zig/pkg/inference/src/architectures/clip.zig
+++ b/zig/pkg/inference/src/architectures/clip.zig
@@ -80,17 +80,14 @@ pub fn textEncoderForward(
         hidden = normed;
     }
 
-    // EOS token pooling: take embedding at last non-padding position per batch
+    // EOS token pooling: CLIP tokenizers use the highest token id as EOT.
     const hidden_data = try cb.toFloat32(hidden, allocator);
     defer allocator.free(hidden_data);
     cb.free(hidden);
 
     const eos_embeddings = try allocator.alloc(f32, batch * H);
     for (0..batch) |b| {
-        var eos_pos: usize = 0;
-        for (0..seq_len) |s| {
-            if (input_ids[b * seq_len + s] != 0) eos_pos = s;
-        }
+        const eos_pos = clipEotPosition(input_ids, b, seq_len);
         @memcpy(eos_embeddings[b * H ..][0..H], hidden_data[(b * seq_len + eos_pos) * H ..][0..H]);
     }
 
@@ -107,6 +104,29 @@ pub fn textEncoderForward(
     const projected = try cb.linearNoBias(eos_ct, proj_w, batch, H, cfg.projection_dim);
     defer cb.free(projected);
     return try cb.toFloat32(projected, allocator);
+}
+
+fn clipEotPosition(input_ids: []const i64, batch_index: usize, seq_len: usize) usize {
+    var eos_pos: usize = 0;
+    var eos_id: i64 = std.math.minInt(i64);
+    for (0..seq_len) |s| {
+        const token_id = input_ids[batch_index * seq_len + s];
+        if (token_id > eos_id) {
+            eos_id = token_id;
+            eos_pos = s;
+        }
+    }
+    return eos_pos;
+}
+
+test "clip text pooling selects first highest token id as eot" {
+    const ids = [_]i64{
+        49406, 111, 49407, 49407, 0,
+        49406, 222, 333,   49407, 0,
+    };
+
+    try std.testing.expectEqual(@as(usize, 2), clipEotPosition(&ids, 0, 5));
+    try std.testing.expectEqual(@as(usize, 3), clipEotPosition(&ids, 1, 5));
 }
 
 // ---- Vision Encoder (ViT) ----
@@ -360,29 +380,148 @@ fn selfAttn(
     defer cb.free(K);
     defer cb.free(V);
 
+    const Q_heads = try packTokenMajorToHeadMajor(cb, allocator, Q, batch, seq_len, num_heads, head_dim);
+    defer cb.free(Q_heads);
+    const K_heads = try packTokenMajorToHeadMajor(cb, allocator, K, batch, seq_len, num_heads, head_dim);
+    defer cb.free(K_heads);
+    const V_heads = try packTokenMajorToHeadMajor(cb, allocator, V, batch, seq_len, num_heads, head_dim);
+    defer cb.free(V_heads);
+
     const attn_out = if (causal)
-        try cb.causalSelfAttention(Q, K, V, null, batch, seq_len, num_heads, head_dim)
+        try cb.causalSelfAttention(Q_heads, K_heads, V_heads, null, batch, seq_len, num_heads, head_dim)
     else blk: {
         const ones = try allocator.alloc(i64, batch * seq_len);
         defer allocator.free(ones);
         @memset(ones, 1);
-        break :blk try cb.scaledDotProductAttention(Q, K, V, ones, null, batch, seq_len, num_heads, head_dim);
+        break :blk try cb.scaledDotProductAttention(Q_heads, K_heads, V_heads, ones, null, batch, seq_len, num_heads, head_dim);
     };
     defer cb.free(attn_out);
+    const attn_token_major = try unpackHeadMajorToTokenMajor(cb, allocator, attn_out, batch, seq_len, num_heads, head_dim);
+    defer cb.free(attn_token_major);
 
     var o_w_buf: [128]u8 = undefined;
     var o_b_buf: [128]u8 = undefined;
     const o_w = try cb.getWeight(try fmt(&o_w_buf, "{s}.{d}.self_attn.out_proj.weight", .{ prefix, layer }));
     const o_b = try cb.getWeight(try fmt(&o_b_buf, "{s}.{d}.self_attn.out_proj.bias", .{ prefix, layer }));
-    return (try cb.linearAdd(attn_out, o_w, o_b, residual, total, hidden, hidden)) orelse blk: {
-        const projected = try cb.linear(attn_out, o_w, o_b, total, hidden, hidden);
+    return (try cb.linearAdd(attn_token_major, o_w, o_b, residual, total, hidden, hidden)) orelse blk: {
+        const projected = try cb.linear(attn_token_major, o_w, o_b, total, hidden, hidden);
         defer cb.free(projected);
         break :blk try cb.add(residual, projected);
     };
 }
 
+fn packTokenMajorToHeadMajor(
+    cb: *const ComputeBackend,
+    allocator: std.mem.Allocator,
+    tensor: CT,
+    batch: usize,
+    seq_len: usize,
+    num_heads: usize,
+    head_dim: usize,
+) !CT {
+    const token_major = try cb.toFloat32(tensor, allocator);
+    defer allocator.free(token_major);
+    const head_major = try packTokenMajorDataToHeadMajor(allocator, token_major, batch, seq_len, num_heads, head_dim);
+    defer allocator.free(head_major);
+    const shape = [_]i32{ @intCast(batch * num_heads), @intCast(seq_len), @intCast(head_dim) };
+    return cb.fromFloat32Shape(head_major, &shape);
+}
+
+fn unpackHeadMajorToTokenMajor(
+    cb: *const ComputeBackend,
+    allocator: std.mem.Allocator,
+    tensor: CT,
+    batch: usize,
+    seq_len: usize,
+    num_heads: usize,
+    head_dim: usize,
+) !CT {
+    const head_major = try cb.toFloat32(tensor, allocator);
+    defer allocator.free(head_major);
+    const token_major = try unpackHeadMajorDataToTokenMajor(allocator, head_major, batch, seq_len, num_heads, head_dim);
+    defer allocator.free(token_major);
+    const shape = [_]i32{ @intCast(batch * seq_len), @intCast(num_heads * head_dim) };
+    return cb.fromFloat32Shape(token_major, &shape);
+}
+
+fn packTokenMajorDataToHeadMajor(
+    allocator: std.mem.Allocator,
+    token_major: []const f32,
+    batch: usize,
+    seq_len: usize,
+    num_heads: usize,
+    head_dim: usize,
+) ![]f32 {
+    const hidden = num_heads * head_dim;
+    const expected = batch * seq_len * hidden;
+    if (token_major.len != expected) return error.InvalidAttentionShape;
+
+    const head_major = try allocator.alloc(f32, expected);
+    for (0..batch) |b| {
+        for (0..seq_len) |s| {
+            for (0..num_heads) |h| {
+                const src = (b * seq_len + s) * hidden + h * head_dim;
+                const dst = (b * num_heads + h) * seq_len * head_dim + s * head_dim;
+                @memcpy(head_major[dst..][0..head_dim], token_major[src..][0..head_dim]);
+            }
+        }
+    }
+    return head_major;
+}
+
+fn unpackHeadMajorDataToTokenMajor(
+    allocator: std.mem.Allocator,
+    head_major: []const f32,
+    batch: usize,
+    seq_len: usize,
+    num_heads: usize,
+    head_dim: usize,
+) ![]f32 {
+    const hidden = num_heads * head_dim;
+    const expected = batch * seq_len * hidden;
+    if (head_major.len != expected) return error.InvalidAttentionShape;
+
+    const token_major = try allocator.alloc(f32, expected);
+    for (0..batch) |b| {
+        for (0..num_heads) |h| {
+            for (0..seq_len) |s| {
+                const src = (b * num_heads + h) * seq_len * head_dim + s * head_dim;
+                const dst = (b * seq_len + s) * hidden + h * head_dim;
+                @memcpy(token_major[dst..][0..head_dim], head_major[src..][0..head_dim]);
+            }
+        }
+    }
+    return token_major;
+}
+
 fn fmt(buf: *[128]u8, comptime format: []const u8, args: anytype) ![]const u8 {
     return std.fmt.bufPrint(buf, format, args) catch return error.WeightNameTooLong;
+}
+
+test "clip attention layout pack round-trips token major hidden rows" {
+    const allocator = std.testing.allocator;
+    const batch = 2;
+    const seq_len = 3;
+    const num_heads = 2;
+    const head_dim = 2;
+    const hidden = num_heads * head_dim;
+
+    var token_major: [batch * seq_len * hidden]f32 = undefined;
+    for (&token_major, 0..) |*value, i| value.* = @floatFromInt(i);
+
+    const head_major = try packTokenMajorDataToHeadMajor(allocator, &token_major, batch, seq_len, num_heads, head_dim);
+    defer allocator.free(head_major);
+
+    try std.testing.expectEqual(@as(f32, 0), head_major[0]);
+    try std.testing.expectEqual(@as(f32, 1), head_major[1]);
+    try std.testing.expectEqual(@as(f32, 4), head_major[2]);
+    try std.testing.expectEqual(@as(f32, 5), head_major[3]);
+    try std.testing.expectEqual(@as(f32, 2), head_major[seq_len * head_dim]);
+    try std.testing.expectEqual(@as(f32, 3), head_major[seq_len * head_dim + 1]);
+
+    const round_trip = try unpackHeadMajorDataToTokenMajor(allocator, head_major, batch, seq_len, num_heads, head_dim);
+    defer allocator.free(round_trip);
+    try std.testing.expectEqualSlices(f32, &token_major, round_trip);
 }
 
 test "native clip vision patch weight direct path matches explicit 2d reshape" {

--- a/zig/pkg/inference/src/backends/backends.zig
+++ b/zig/pkg/inference/src/backends/backends.zig
@@ -85,6 +85,8 @@ pub const BackendType = enum {
     }
 };
 
+const backend_order_capacity = std.meta.fields(BackendType).len;
+
 /// SessionManager selects the best available backend and creates sessions.
 pub const SessionManager = struct {
     allocator: std.mem.Allocator,
@@ -121,7 +123,7 @@ pub const SessionManager = struct {
     ) !Session {
         var manifest = manifest_mod.loadFromDir(self.allocator, model_path) catch null;
         defer if (manifest) |*m| m.deinit();
-        var effective_buf: [4]BackendType = undefined;
+        var effective_buf: [backend_order_capacity]BackendType = undefined;
         const effective_backends = effectiveBackendOrder(self.allocator, &effective_buf, self.preferred_backends, if (manifest) |m| m else null);
 
         for (effective_backends) |backend| {
@@ -262,17 +264,21 @@ pub const SessionManager = struct {
 fn configuredPreferredBackends() []const BackendType {
     if (build_options.enable_wasm) return &.{.wasm};
     if (preferredBackendOverride()) |backend| {
-        return switch (backend) {
-            .onnx => &.{.onnx},
-            .metal => if (build_options.enable_metal) &.{.metal} else &.{.native},
-            .mlx => if (build_options.enable_mlx) &.{.mlx} else &.{.native},
-            .cuda => if (build_options.enable_cuda) &.{.cuda} else &.{.native},
-            .pjrt => if (build_options.enable_pjrt) &.{ .pjrt, .onnx, .metal, .mlx, .native } else &.{ .onnx, .metal, .mlx, .native },
-            .native => &.{.native},
-            .wasm => &.{ .onnx, .metal, .mlx, .native },
-        };
+        return preferredBackendsForOverride(backend);
     }
     return &.{ .onnx, .metal, .mlx, .native };
+}
+
+fn preferredBackendsForOverride(backend: BackendType) []const BackendType {
+    return switch (backend) {
+        .onnx => &.{ .onnx, .metal, .mlx, .native },
+        .metal => if (build_options.enable_metal) &.{ .metal, .onnx, .mlx, .native } else &.{ .native, .onnx, .mlx },
+        .mlx => if (build_options.enable_mlx) &.{ .mlx, .onnx, .metal, .native } else &.{ .native, .onnx, .metal },
+        .cuda => if (build_options.enable_cuda) &.{ .cuda, .onnx, .metal, .mlx, .native } else &.{ .native, .onnx, .metal, .mlx },
+        .pjrt => if (build_options.enable_pjrt) &.{ .pjrt, .onnx, .metal, .mlx, .native } else &.{ .onnx, .metal, .mlx, .native },
+        .native => &.{ .native, .onnx, .metal, .mlx },
+        .wasm => &.{ .onnx, .metal, .mlx, .native },
+    };
 }
 
 fn defaultImportedOnnxBackend() BackendType {
@@ -300,6 +306,11 @@ test "onnx graph import is available without onnx runtime and in wasm" {
     }
 }
 
+test "preferred backend override keeps fallback backends" {
+    try std.testing.expectEqualSlices(BackendType, &.{ .onnx, .metal, .mlx, .native }, preferredBackendsForOverride(.onnx));
+    try std.testing.expectEqualSlices(BackendType, &.{ .native, .onnx, .metal, .mlx }, preferredBackendsForOverride(.native));
+}
+
 test "explicit graph runtime uses imported onnx path before external runtime" {
     var manager = SessionManager.init(std.testing.allocator);
     try std.testing.expect(!manager.shouldUseImportedOnnxGraphRuntime("model.onnx"));
@@ -310,7 +321,9 @@ test "explicit graph runtime uses imported onnx path before external runtime" {
 
 fn preferredBackendOverride() ?BackendType {
     if (build_options.enable_wasm or !build_options.link_libc) return null;
-    const value = std.c.getenv("TERMITE_PREFERRED_BACKEND") orelse return null;
+    const value = std.c.getenv("ANTFLY_INFERENCE_PREFERRED_BACKEND") orelse
+        std.c.getenv("TERMITE_PREFERRED_BACKEND") orelse
+        return null;
     const slice = std.mem.span(value);
     if (std.ascii.eqlIgnoreCase(slice, "auto")) return null;
     if (std.ascii.eqlIgnoreCase(slice, "onnx")) return .onnx;
@@ -355,7 +368,7 @@ fn shouldPreferNativeTextEncoder(man: manifest_mod.ModelManifest) bool {
 
 fn effectiveBackendOrder(
     allocator: std.mem.Allocator,
-    scratch: *[4]BackendType,
+    scratch: *[backend_order_capacity]BackendType,
     preferred: []const BackendType,
     manifest: ?manifest_mod.ModelManifest,
 ) []const BackendType {
@@ -372,7 +385,7 @@ fn effectiveBackendOrder(
 }
 
 fn effectiveBackendOrderForPreference(
-    scratch: *[4]BackendType,
+    scratch: *[backend_order_capacity]BackendType,
     preferred: []const BackendType,
     prefer_blas_before_mlx: bool,
 ) []const BackendType {
@@ -404,7 +417,7 @@ fn effectiveBackendOrderForPreference(
 }
 
 fn reorderNativeAheadOfOnnx(
-    scratch: *[4]BackendType,
+    scratch: *[backend_order_capacity]BackendType,
     preferred: []const BackendType,
     prefer_blas_before_mlx: bool,
 ) []const BackendType {
@@ -457,21 +470,28 @@ test "shouldPreferBlasBeforeMlxForBytes prefers native only above eager dense th
 
 test "effective backend order prefers native before mlx for large gguf generators" {
     const preferred = [_]BackendType{ .onnx, .metal, .mlx, .native };
-    var scratch: [4]BackendType = undefined;
+    var scratch: [backend_order_capacity]BackendType = undefined;
     const effective = effectiveBackendOrderForPreference(&scratch, &preferred, true);
     try std.testing.expectEqualSlices(BackendType, &.{ .onnx, .native, .metal, .mlx }, effective);
 }
 
+test "effective backend order handles five backend preference lists" {
+    const preferred = [_]BackendType{ .cuda, .onnx, .metal, .mlx, .native };
+    var scratch: [backend_order_capacity]BackendType = undefined;
+    const effective = effectiveBackendOrderForPreference(&scratch, &preferred, true);
+    try std.testing.expectEqualSlices(BackendType, &.{ .onnx, .native, .cuda, .metal, .mlx }, effective);
+}
+
 test "effective backend order preserves mlx preference for small gguf generators" {
     const preferred = [_]BackendType{ .onnx, .metal, .mlx, .native };
-    var scratch: [4]BackendType = undefined;
+    var scratch: [backend_order_capacity]BackendType = undefined;
     const effective = effectiveBackendOrderForPreference(&scratch, &preferred, false);
     try std.testing.expectEqualSlices(BackendType, &preferred, effective);
 }
 
 test "effective backend order preserves order for non-gguf models" {
     const preferred = [_]BackendType{ .onnx, .metal, .mlx, .native };
-    var scratch: [4]BackendType = undefined;
+    var scratch: [backend_order_capacity]BackendType = undefined;
     const manifest: manifest_mod.ModelManifest = .{
         .allocator = std.testing.allocator,
         .model_type = .generator,
@@ -483,7 +503,7 @@ test "effective backend order preserves order for non-gguf models" {
 
 test "effective backend order prefers native layoutlmv3 before onnx" {
     const preferred = [_]BackendType{ .onnx, .metal, .mlx, .native };
-    var scratch: [4]BackendType = undefined;
+    var scratch: [backend_order_capacity]BackendType = undefined;
     const manifest: manifest_mod.ModelManifest = .{
         .allocator = std.testing.allocator,
         .native_arch_hint = .layoutlmv3,

--- a/zig/pkg/inference/src/models/manifest.zig
+++ b/zig/pkg/inference/src/models/manifest.zig
@@ -1515,16 +1515,9 @@ fn parseInferenceVariantsJson(manifest: *ModelManifest, allocator: std.mem.Alloc
 }
 
 fn parseInferenceVariantsFile(manifest: *ModelManifest, allocator: std.mem.Allocator, model_dir_path: []const u8) !void {
-    if (c_file.readFileFromDir(allocator, model_dir_path, "antfly_inference_variants.json")) |variants_bytes| {
-        defer allocator.free(variants_bytes);
-        try parseInferenceVariantsJson(manifest, allocator, model_dir_path, variants_bytes);
-        return;
-    } else |_| {}
-
-    if (c_file.readFileFromDir(allocator, model_dir_path, "termite_variants.json")) |variants_bytes| {
-        defer allocator.free(variants_bytes);
-        try parseInferenceVariantsJson(manifest, allocator, model_dir_path, variants_bytes);
-    } else |err| return err;
+    const variants_bytes = try c_file.readFileFromDir(allocator, model_dir_path, "antfly_inference_variants.json");
+    defer allocator.free(variants_bytes);
+    try parseInferenceVariantsJson(manifest, allocator, model_dir_path, variants_bytes);
 }
 
 fn parseGliner2InferenceVariantsJson(
@@ -2252,9 +2245,9 @@ test "manifest parses clipclap variants gguf pair" {
     try std.testing.expect(manifest.hasInput("audio"));
 }
 
-test "manifest loads legacy termite clipclap variants before first gguf fallback" {
+test "manifest loads canonical antfly clipclap variants before first gguf fallback" {
     const allocator = std.testing.allocator;
-    const dir_path = try testScratchDir(allocator, "manifest-clipclap-legacy-variants");
+    const dir_path = try testScratchDir(allocator, "manifest-clipclap-canonical-variants");
     defer {
         compat.cwd().deleteTree(compat.io(), dir_path) catch {};
         allocator.free(dir_path);
@@ -2280,7 +2273,7 @@ test "manifest loads legacy termite clipclap variants before first gguf fallback
         .data = "{\"model_type\":\"clipclap\",\"text_config\":{\"max_position_embeddings\":77}}",
     });
 
-    const variants_path = try std.fs.path.join(allocator, &.{ dir_path, "termite_variants.json" });
+    const variants_path = try std.fs.path.join(allocator, &.{ dir_path, "antfly_inference_variants.json" });
     defer allocator.free(variants_path);
     try compat.cwd().writeFile(compat.io(), .{
         .sub_path = variants_path,

--- a/zig/pkg/inference/src/models/manifest.zig
+++ b/zig/pkg/inference/src/models/manifest.zig
@@ -427,10 +427,7 @@ pub fn loadFromDir(allocator: std.mem.Allocator, model_dir_path: []const u8) !Mo
         parseInferenceBundleJson(&manifest, allocator, model_dir_path, bundle_bytes) catch {};
     } else |_| {}
     if (shouldParseClipclapGgufVariant(allocator, model_dir_path)) {
-        if (c_file.readFileFromDir(allocator, model_dir_path, "antfly_inference_variants.json")) |variants_bytes| {
-            defer allocator.free(variants_bytes);
-            parseInferenceVariantsJson(&manifest, allocator, model_dir_path, variants_bytes) catch {};
-        } else |_| {}
+        parseInferenceVariantsFile(&manifest, allocator, model_dir_path) catch {};
     }
 
     // Try to parse gliner_config.json (for GLiNER NER models)
@@ -551,10 +548,7 @@ pub fn loadListingFromDir(allocator: std.mem.Allocator, model_dir_path: []const 
         defer allocator.free(bundle_bytes);
         parseInferenceBundleJson(&manifest, allocator, model_dir_path, bundle_bytes) catch {};
     } else |_| {}
-    if (c_file.readFileFromDir(allocator, model_dir_path, "antfly_inference_variants.json")) |variants_bytes| {
-        defer allocator.free(variants_bytes);
-        parseInferenceVariantsJson(&manifest, allocator, model_dir_path, variants_bytes) catch {};
-    } else |_| {}
+    parseInferenceVariantsFile(&manifest, allocator, model_dir_path) catch {};
 
     if (c_file.readFileFromDir(allocator, model_dir_path, "gliner_config.json")) |gliner_bytes| {
         defer allocator.free(gliner_bytes);
@@ -1520,6 +1514,19 @@ fn parseInferenceVariantsJson(manifest: *ModelManifest, allocator: std.mem.Alloc
     try setManifestInputs(allocator, manifest, &.{ "text", "image", "audio" });
 }
 
+fn parseInferenceVariantsFile(manifest: *ModelManifest, allocator: std.mem.Allocator, model_dir_path: []const u8) !void {
+    if (c_file.readFileFromDir(allocator, model_dir_path, "antfly_inference_variants.json")) |variants_bytes| {
+        defer allocator.free(variants_bytes);
+        try parseInferenceVariantsJson(manifest, allocator, model_dir_path, variants_bytes);
+        return;
+    } else |_| {}
+
+    if (c_file.readFileFromDir(allocator, model_dir_path, "termite_variants.json")) |variants_bytes| {
+        defer allocator.free(variants_bytes);
+        try parseInferenceVariantsJson(manifest, allocator, model_dir_path, variants_bytes);
+    } else |err| return err;
+}
+
 fn parseGliner2InferenceVariantsJson(
     manifest: *ModelManifest,
     allocator: std.mem.Allocator,
@@ -2243,6 +2250,64 @@ test "manifest parses clipclap variants gguf pair" {
     try std.testing.expect(manifest.hasInput("text"));
     try std.testing.expect(manifest.hasInput("image"));
     try std.testing.expect(manifest.hasInput("audio"));
+}
+
+test "manifest loads legacy termite clipclap variants before first gguf fallback" {
+    const allocator = std.testing.allocator;
+    const dir_path = try testScratchDir(allocator, "manifest-clipclap-legacy-variants");
+    defer {
+        compat.cwd().deleteTree(compat.io(), dir_path) catch {};
+        allocator.free(dir_path);
+    }
+    const clip_path = try std.fs.path.join(allocator, &.{ dir_path, "clipclap-clip.Q4_K.gguf" });
+    defer allocator.free(clip_path);
+    const clap_path = try std.fs.path.join(allocator, &.{ dir_path, "clipclap-clap.Q4_K.gguf" });
+    defer allocator.free(clap_path);
+    try compat.cwd().writeFile(compat.io(), .{ .sub_path = clip_path, .data = "GGUFstub" });
+    try compat.cwd().writeFile(compat.io(), .{ .sub_path = clap_path, .data = "GGUFstub" });
+
+    const model_manifest_path = try std.fs.path.join(allocator, &.{ dir_path, "model_manifest.json" });
+    defer allocator.free(model_manifest_path);
+    try compat.cwd().writeFile(compat.io(), .{
+        .sub_path = model_manifest_path,
+        .data = "{\"type\":\"embedder\",\"tasks\":[\"embed\"],\"inputs\":[\"text\",\"image\",\"audio\"]}",
+    });
+
+    const clip_config_path = try std.fs.path.join(allocator, &.{ dir_path, "clip_config.json" });
+    defer allocator.free(clip_config_path);
+    try compat.cwd().writeFile(compat.io(), .{
+        .sub_path = clip_config_path,
+        .data = "{\"model_type\":\"clipclap\",\"text_config\":{\"max_position_embeddings\":77}}",
+    });
+
+    const variants_path = try std.fs.path.join(allocator, &.{ dir_path, "termite_variants.json" });
+    defer allocator.free(variants_path);
+    try compat.cwd().writeFile(compat.io(), .{
+        .sub_path = variants_path,
+        .data =
+        \\{
+        \\  "family": "clipclap_variants/v1",
+        \\  "variants": [
+        \\    {
+        \\      "id": "gguf-Q4_K",
+        \\      "target": "gguf",
+        \\      "format": "Q4_K",
+        \\      "clip": "clipclap-clip.Q4_K.gguf",
+        \\      "clap": "clipclap-clap.Q4_K.gguf"
+        \\    }
+        \\  ]
+        \\}
+        ,
+    });
+
+    var manifest = try loadFromDir(allocator, dir_path);
+    defer manifest.deinit();
+
+    try std.testing.expect(manifest.isClipclapGgufBundle());
+    try std.testing.expectEqual(NativeArchHint.clip, manifest.native_arch_hint);
+    try std.testing.expectEqualStrings("clipclap", manifest.config_model_arch);
+    try std.testing.expectEqualStrings(clip_path, manifest.gguf_path.?);
+    try std.testing.expectEqualStrings(clap_path, manifest.audio_model_path.?);
 }
 
 test "manifest ignores stale clipclap variants with missing gguf files" {

--- a/zig/pkg/inference/src/ops/native_compute.zig
+++ b/zig/pkg/inference/src/ops/native_compute.zig
@@ -838,21 +838,36 @@ fn materializeViewData(buf: *Buf) !void {
     const view_strides = buf.view_strides orelse return;
     if (logical_shape.len != view_strides.len) return error.InvalidTensorShape;
 
-    const out_len = if (logical_shape.len == 0) @as(usize, 1) else safeShapeNumel(logical_shape) orelse return error.InvalidTensorShape;
-    maybeLogLargeTensor("materialize_view", out_len, logical_shape);
+    var resolved_shape_buf: [8]i64 = undefined;
+    const materialized_shape: []const i64 = blk: {
+        if (logical_shape.len == 0 or safeShapeNumel(logical_shape) != null) break :blk logical_shape;
+        const available = if (buf.view_base_offset <= buf.data.len) buf.data.len - buf.view_base_offset else return error.InvalidTensorShape;
+        const resolved = resolveShapeFromDataLen(logical_shape, available) orelse return error.InvalidTensorShape;
+        for (0..logical_shape.len) |i| resolved_shape_buf[i] = resolved[i];
+        break :blk resolved_shape_buf[0..logical_shape.len];
+    };
+
+    var replacement_shape: ?[]i64 = null;
+    errdefer if (replacement_shape) |shape| buf.allocator.free(shape);
+    if (materialized_shape.ptr != logical_shape.ptr) {
+        replacement_shape = try buf.allocator.dupe(i64, materialized_shape);
+    }
+
+    const out_len = if (materialized_shape.len == 0) @as(usize, 1) else safeShapeNumel(materialized_shape) orelse return error.InvalidTensorShape;
+    maybeLogLargeTensor("materialize_view", out_len, materialized_shape);
     const output = try buf.allocator.alloc(f32, out_len);
     errdefer buf.allocator.free(output);
 
-    if (logical_shape.len == 0) {
+    if (materialized_shape.len == 0) {
         if (buf.view_base_offset >= buf.data.len) return error.InvalidTensorShape;
         output[0] = buf.data[buf.view_base_offset];
     } else {
         var out_strides: [8]usize = undefined;
-        computeStrides(logical_shape, out_strides[0..logical_shape.len]);
+        computeStrides(materialized_shape, out_strides[0..materialized_shape.len]);
         for (0..out_len) |flat_out| {
             var remaining = flat_out;
             var flat_in = buf.view_base_offset;
-            for (0..logical_shape.len) |d| {
+            for (0..materialized_shape.len) |d| {
                 const coord = remaining / out_strides[d];
                 remaining %= out_strides[d];
                 flat_in += coord * view_strides[d];
@@ -873,6 +888,12 @@ fn materializeViewData(buf: *Buf) !void {
     }
 
     releaseOwnedDenseData(buf);
+    if (replacement_shape) |shape| {
+        releaseLogicalShape(buf);
+        buf.logical_shape = shape;
+        buf.logical_shape_inline = false;
+        replacement_shape = null;
+    }
     const refcount = try buf.allocator.create(usize);
     refcount.* = 1;
     buf.data = output;
@@ -2306,6 +2327,7 @@ fn resolveShapeFromTensorMetadata(tensor: CT, shape: []const i64, data_len: usiz
     const buf = toBuf(tensor);
     const view_strides = buf.view_strides orelse return null;
     if (view_strides.len != shape.len) return null;
+    if (resolveShapeFromViewStrides(shape, view_strides, data_len)) |resolved| return resolved;
 
     var resolved: [8]i64 = undefined;
     var infer_index: ?usize = null;
@@ -2332,6 +2354,34 @@ fn resolveShapeFromTensorMetadata(tensor: CT, shape: []const i64, data_len: usiz
         if (known_product == 0 or data_len % known_product != 0) return null;
         resolved[idx] = @intCast(data_len / known_product);
         return resolved;
+    }
+
+    if (known_product != data_len) return null;
+    return resolved;
+}
+
+fn resolveShapeFromViewStrides(shape: []const i64, view_strides: []const usize, data_len: usize) ?[8]i64 {
+    if (shape.len == 0 or shape.len > 8 or view_strides.len != shape.len) return null;
+
+    var resolved: [8]i64 = undefined;
+    var known_product: usize = 1;
+    for (0..shape.len) |i| {
+        if (shape[i] > 0) {
+            resolved[i] = shape[i];
+        } else if (view_strides[i] == 0) {
+            resolved[i] = 1;
+        } else if (i == 0 and data_len % view_strides[i] == 0) {
+            resolved[i] = @intCast(data_len / view_strides[i]);
+        } else if (i > 0 and view_strides[i] > 0 and view_strides[i - 1] % view_strides[i] == 0) {
+            resolved[i] = @intCast(view_strides[i - 1] / view_strides[i]);
+        } else if (i == shape.len - 1 and known_product > 0 and data_len % known_product == 0) {
+            resolved[i] = @intCast(data_len / known_product);
+        } else {
+            return null;
+        }
+
+        if (resolved[i] <= 0) return null;
+        known_product = std.math.mul(usize, known_product, @intCast(resolved[i])) catch return null;
     }
 
     if (known_product != data_len) return null;
@@ -35989,6 +36039,10 @@ fn primTransposeOp(ctx: *anyopaque, input: CT, perm: []const u8, input_shape: []
             for (0..effective_input_shape.len) |i| resolved_shape_buf[i] = resolved[i];
             break :blk .{ resolved_shape_buf[0..effective_input_shape.len], perm, effective_input_shape.len };
         }
+        if (resolveShapeFromTensorMetadata(input, effective_input_shape, input_buf.data.len)) |resolved| {
+            for (0..effective_input_shape.len) |i| resolved_shape_buf[i] = resolved[i];
+            break :blk .{ resolved_shape_buf[0..effective_input_shape.len], perm, effective_input_shape.len };
+        }
         const plan = collapseLeadingDynamicDimsForTranspose(effective_input_shape, perm, input_buf.data.len) orelse {
             std.log.warn("transpose symbolic shape unsupported shape={any} perm={any} len={d}", .{
                 effective_input_shape,
@@ -44736,6 +44790,69 @@ test "transpose resolves clip text attention shape" {
     const input_index = h * 77 * 64 + s * 64 + d;
     const output_index = h * 64 * 77 + d * 77 + s;
     try std.testing.expectEqual(input_data[input_index], out_data[output_index]);
+}
+
+test "transpose resolves zero metadata shape from view strides" {
+    const allocator = std.testing.allocator;
+    var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
+    var compute = NativeCompute.init(allocator, &weight_store, null);
+
+    const batch = 2;
+    const seq = 3;
+    const hidden = 4;
+    const elem_count = batch * seq * hidden;
+    const input_data = try allocator.alloc(f32, elem_count);
+    for (input_data, 0..) |*value, i| value.* = @floatFromInt(i);
+
+    const raw = try compute.makeBuf(input_data, true);
+    defer freeTensor(&compute, raw);
+
+    const view = try makeDenseViewAlias(
+        &compute,
+        raw,
+        &.{ 0, 0, 0 },
+        &.{ seq * hidden, hidden, 1 },
+        0,
+    );
+    defer freeTensor(&compute, view);
+
+    const out = try primTransposeOp(&compute, view, &.{ 0, 2, 1 }, &.{ 0, 0, 0 });
+    defer freeTensor(&compute, out);
+
+    try std.testing.expectEqualSlices(i64, &.{ batch, hidden, seq }, tensorStoredShape(out).?);
+    const out_data = getData(out);
+    try std.testing.expectEqual(@as(usize, elem_count), out_data.len);
+
+    const input_index = 1 * seq * hidden + 2 * hidden + 3;
+    const output_index = 1 * hidden * seq + 3 * seq + 2;
+    try std.testing.expectEqual(input_data[input_index], out_data[output_index]);
+}
+
+test "materialize view resolves symbolic logical shape" {
+    const allocator = std.testing.allocator;
+    var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
+    var compute = NativeCompute.init(allocator, &weight_store, null);
+
+    const elem_count = 8 * 77 * 64;
+    const input_data = try allocator.alloc(f32, elem_count);
+    for (input_data, 0..) |*value, i| value.* = @floatFromInt(i);
+
+    const raw = try compute.makeBuf(input_data, true);
+    defer freeTensor(&compute, raw);
+
+    const view = try makeDenseViewAlias(
+        &compute,
+        raw,
+        &.{ -1, -1, 64 },
+        &.{ 77 * 64, 64, 1 },
+        0,
+    );
+    defer freeTensor(&compute, view);
+
+    const out_data = getData(view);
+    try std.testing.expectEqual(@as(usize, elem_count), out_data.len);
+    try std.testing.expectEqualSlices(i64, &.{ 8, 77, 64 }, tensorStoredShape(view).?);
+    try std.testing.expectEqual(input_data[17], out_data[17]);
 }
 
 test "whereSelect preserves inferred attention cube shape" {

--- a/zig/pkg/inference/src/pipelines/embedding.zig
+++ b/zig/pkg/inference/src/pipelines/embedding.zig
@@ -37,6 +37,21 @@ const resident_ops = @import("../graph/resident_ops.zig");
 
 const qwen3_embedding_resident_override_level = 4;
 
+const TextInputTensorSet = struct {
+    items: [3]Tensor = undefined,
+    len: usize = 0,
+    token_type_tensor: ?Tensor = null,
+
+    fn slice(self: *const TextInputTensorSet) []const Tensor {
+        return self.items[0..self.len];
+    }
+
+    fn deinit(self: *TextInputTensorSet) void {
+        if (self.token_type_tensor) |*tensor| tensor.deinit();
+        self.* = undefined;
+    }
+};
+
 pub const PoolingStrategy = enum {
     mean,
     cls,
@@ -199,12 +214,15 @@ pub const EmbeddingPipeline = struct {
     /// Caller owns the returned slices and must free them with the allocator.
     pub fn embed(self: *EmbeddingPipeline, texts: []const []const u8) ![][]f32 {
         if (texts.len == 0) return try self.allocator.alloc([]f32, 0);
-        if (self.session.backend() == .onnx and texts.len > 1) {
+        const text_session = self.textEncodingSession();
+        if (text_session.backend() == .onnx and texts.len > 1) {
             return try self.embedSerial(texts);
         }
 
         const alloc = self.allocator;
-        const max_len = self.config.max_length;
+        const input_info = text_session.inputInfo();
+        const max_len = textSequenceLengthForInputs(input_info, self.config.max_length);
+        const fixed_len = hasFixedTextSequenceLength(input_info);
         const batch = texts.len;
 
         const encoded = try alloc.alloc(EncodeResult, batch);
@@ -214,7 +232,7 @@ pub const EmbeddingPipeline = struct {
             for (encoded[0..encoded_count]) |*result| result.deinit();
         }
 
-        var effective_len: usize = if (self.config.trim_padding_to_batch_max) 1 else max_len;
+        var effective_len: usize = if (self.config.trim_padding_to_batch_max and !fixed_len) 1 else max_len;
         for (texts, 0..) |text, i| {
             const token_text = if (self.config.text_prefix.len > 0)
                 try std.fmt.allocPrint(alloc, "{s}{s}", .{ self.config.text_prefix, text })
@@ -224,7 +242,7 @@ pub const EmbeddingPipeline = struct {
 
             encoded[i] = try self.tok.encodeForModel(alloc, token_text, max_len);
             encoded_count += 1;
-            if (self.config.trim_padding_to_batch_max) {
+            if (self.config.trim_padding_to_batch_max and !fixed_len) {
                 effective_len = @max(effective_len, activeTokenLength(encoded[i].attention_mask));
             }
         }
@@ -257,27 +275,9 @@ pub const EmbeddingPipeline = struct {
         var attention_mask_tensor = try Tensor.initInt64(alloc, "attention_mask", &shape, mask_i64);
         defer attention_mask_tensor.deinit();
 
-        // Check if model expects token_type_ids
-        var token_type_tensor: ?Tensor = null;
-        defer if (token_type_tensor) |*t| t.deinit();
-
-        const input_info = self.session.inputInfo();
-        var needs_token_type = false;
-        for (input_info) |info| {
-            if (std.mem.eql(u8, info.name, "token_type_ids")) {
-                needs_token_type = true;
-                break;
-            }
-        }
-
-        const inputs = if (needs_token_type) blk: {
-            // Create zeros tensor for token_type_ids
-            const zeros = try alloc.alloc(i64, batch * effective_len);
-            defer alloc.free(zeros);
-            @memset(zeros, 0);
-            token_type_tensor = try Tensor.initInt64(alloc, "token_type_ids", &shape, zeros);
-            break :blk &[_]Tensor{ input_ids_tensor, attention_mask_tensor, token_type_tensor.? };
-        } else &[_]Tensor{ input_ids_tensor, attention_mask_tensor };
+        var input_set = try textInputTensorSet(alloc, input_info, input_ids_tensor, attention_mask_tensor, &shape);
+        defer input_set.deinit();
+        const inputs = input_set.slice();
 
         if (self.text_projection) |proj| {
             if (try self.tryEmbedTextResidentProjection(inputs, all_mask, batch, effective_len, proj)) |resident_embeddings| {
@@ -289,7 +289,7 @@ pub const EmbeddingPipeline = struct {
 
         // Run inference
         const encoder_start = embedTimingStart(self.print_timing);
-        var outputs = try self.session.run(inputs, alloc);
+        var outputs = try text_session.run(inputs, alloc);
         logEmbedTiming("text.encoder", batch, encoder_start);
         defer {
             for (outputs) |*o| o.deinit();
@@ -314,6 +314,18 @@ pub const EmbeddingPipeline = struct {
         }
 
         return embeddings;
+    }
+
+    fn textEncodingSession(self: *const EmbeddingPipeline) backends.Session {
+        if (self.vision_session) |vs| {
+            if (session_factory.getClapConfig(self.session) != null and
+                session_factory.getClipConfig(vs) != null and
+                sessionHasInput(vs, "input_ids"))
+            {
+                return vs;
+            }
+        }
+        return self.session;
     }
 
     fn embedSerial(self: *EmbeddingPipeline, texts: []const []const u8) anyerror![][]f32 {
@@ -1482,6 +1494,112 @@ pub const EmbeddingPipeline = struct {
         return embeddings;
     }
 };
+
+fn textInputTensorSet(
+    alloc: std.mem.Allocator,
+    input_info: []const backends.TensorInfo,
+    input_ids_tensor: Tensor,
+    attention_mask_tensor: Tensor,
+    shape: []const i64,
+) !TextInputTensorSet {
+    var needs_attention_mask = false;
+    var needs_token_type = false;
+    for (input_info) |info| {
+        if (std.mem.eql(u8, info.name, "attention_mask")) needs_attention_mask = true;
+        if (std.mem.eql(u8, info.name, "token_type_ids")) needs_token_type = true;
+    }
+
+    var set = TextInputTensorSet{};
+    set.items[set.len] = input_ids_tensor;
+    set.len += 1;
+
+    if (needs_attention_mask) {
+        set.items[set.len] = attention_mask_tensor;
+        set.len += 1;
+    }
+
+    if (needs_token_type) {
+        const total = try shapeNumelUsize(shape);
+        const zeros = try alloc.alloc(i64, total);
+        defer alloc.free(zeros);
+        @memset(zeros, 0);
+        set.token_type_tensor = try Tensor.initInt64(alloc, "token_type_ids", shape, zeros);
+        set.items[set.len] = set.token_type_tensor.?;
+        set.len += 1;
+    }
+
+    return set;
+}
+
+fn shapeNumelUsize(shape: []const i64) !usize {
+    var total: usize = 1;
+    for (shape) |dim| {
+        if (dim < 0) return error.InvalidInputShape;
+        total = std.math.mul(usize, total, @intCast(dim)) catch return error.InvalidInputShape;
+    }
+    return total;
+}
+
+fn expectTextInputNames(input_info: []const backends.TensorInfo, expected: []const []const u8) !void {
+    const alloc = std.testing.allocator;
+    const shape = [_]i64{ 1, 2 };
+    var input_ids = try Tensor.initInt64(alloc, "input_ids", &shape, &.{ 101, 102 });
+    defer input_ids.deinit();
+    var attention_mask = try Tensor.initInt64(alloc, "attention_mask", &shape, &.{ 1, 1 });
+    defer attention_mask.deinit();
+
+    var set = try textInputTensorSet(alloc, input_info, input_ids, attention_mask, &shape);
+    defer set.deinit();
+
+    const inputs = set.slice();
+    try std.testing.expectEqual(expected.len, inputs.len);
+    for (expected, 0..) |name, i| {
+        try std.testing.expectEqualStrings(name, inputs[i].name);
+    }
+}
+
+fn textSequenceLengthForInputs(input_info: []const backends.TensorInfo, default_len: usize) usize {
+    for (input_info) |info| {
+        if (!std.mem.eql(u8, info.name, "input_ids")) continue;
+        if (info.shape.len < 2 or info.shape[1] <= 0) return default_len;
+        return @intCast(info.shape[1]);
+    }
+    return default_len;
+}
+
+fn hasFixedTextSequenceLength(input_info: []const backends.TensorInfo) bool {
+    for (input_info) |info| {
+        if (!std.mem.eql(u8, info.name, "input_ids")) continue;
+        return info.shape.len >= 2 and info.shape[1] > 0;
+    }
+    return false;
+}
+
+test "embedding text inputs follow declared model arity" {
+    try expectTextInputNames(&.{
+        .{ .name = "input_ids", .dtype = .i64, .shape = &.{ -1, -1 } },
+    }, &.{"input_ids"});
+
+    try expectTextInputNames(&.{
+        .{ .name = "input_ids", .dtype = .i64, .shape = &.{ -1, -1 } },
+        .{ .name = "attention_mask", .dtype = .i64, .shape = &.{ -1, -1 } },
+    }, &.{ "input_ids", "attention_mask" });
+
+    try expectTextInputNames(&.{
+        .{ .name = "input_ids", .dtype = .i64, .shape = &.{ -1, -1 } },
+        .{ .name = "attention_mask", .dtype = .i64, .shape = &.{ -1, -1 } },
+        .{ .name = "token_type_ids", .dtype = .i64, .shape = &.{ -1, -1 } },
+    }, &.{ "input_ids", "attention_mask", "token_type_ids" });
+}
+
+test "embedding text length follows fixed input_ids sequence dimension" {
+    const input_info = [_]backends.TensorInfo{
+        .{ .name = "input_ids", .dtype = .i64, .shape = &.{ -1, 77 } },
+        .{ .name = "attention_mask", .dtype = .i64, .shape = &.{ -1, 77 } },
+    };
+    try std.testing.expect(hasFixedTextSequenceLength(&input_info));
+    try std.testing.expectEqual(@as(usize, 77), textSequenceLengthForInputs(&input_info, 512));
+}
 
 fn sessionHasInput(session: backends.Session, name: []const u8) bool {
     for (session.inputInfo()) |info| {

--- a/zig/pkg/inference/src/server/server.zig
+++ b/zig/pkg/inference/src/server/server.zig
@@ -587,6 +587,38 @@ pub const Node = struct {
         return try pipeline.embed(texts);
     }
 
+    pub fn embedDenseJsonInputDirect(
+        self: *Node,
+        allocator: std.mem.Allocator,
+        model_name: []const u8,
+        input: std.json.Value,
+    ) ![][]f32 {
+        try self.request_queue.acquire();
+        defer self.releaseSlot();
+        self.metrics.incRequest("embed.local");
+        defer self.metrics.decActive();
+
+        var io_impl = std.Io.Threaded.init(allocator, .{});
+        defer io_impl.deinit();
+
+        const model_path = try self.resolveModelPath(io_impl.io(), if (model_name.len > 0) model_name else null, "embedders");
+        const model = try self.model_manager.loadFromDir(model_path);
+        if (model.manifest.hasCapability("sparse")) return error.UnsupportedEmbeddingProvider;
+
+        var inputs = try parseDenseEmbedInputs(self, allocator, &model.manifest, input);
+        defer inputs.deinit(allocator);
+        if (inputs.total_count == 0) return error.EmptyEmbeddingResponse;
+
+        try model.ensureEmbeddingAssets(
+            inputs.texts.items.len > 0,
+            inputs.images.items.len > 0,
+            inputs.audio.items.len > 0,
+        );
+
+        var pipeline = model.embeddingPipeline(allocator);
+        return try embedDenseInputs(allocator, &pipeline, &inputs);
+    }
+
     pub fn embedSparseTextsDirect(
         self: *Node,
         allocator: std.mem.Allocator,


### PR DESCRIPTION
## Summary

Fixes the open issue batch #201 through #208:

- #201: route local Antfly multimodal embedding through an in-process parts vtable and keep binary media base64 buffers alive until request serialization.
- #202: probe declared embedding model inputs before sending `attention_mask` or `token_type_ids`.
- #203: resolve symbolic tensor-view shapes during native materialization so reranker transpose paths do not receive empty tensors.
- #204: guard text segment stats slices against stale/invalid section offsets.
- #205: pool CLIP text embeddings at the EOT token position by highest token id.
- #206: preserve fused hit per-index scores through search, DB result materialization, and query response serialization; clean up partially initialized fused hits on conversion failure.
- #207: isolate non-retryable enrichment request failures so one bad index does not set worker-scoped failure for healthy siblings, while the failing index is still surfaced as failed in index status.
- #208: treat `ANTFLY_INFERENCE_PREFERRED_BACKEND` (and legacy `TERMITE_PREFERRED_BACKEND`) as a preference with fallback backends, including five-backend CUDA preference lists.

## Test Coverage

Added focused regression coverage for:

- local Antfly media parts routing and binary base64 request serialization
- fused `_index_scores` JSON serialization and DB result ownership cleanup on conversion failure paths
- isolated enrichment request errors leaving `worker_failed=false` and marking only the failed index
- index status encoding that reports one failed embeddings index without poisoning a healthy sibling
- preferred backend fallback ordering, including five-backend preference capacity
- declared text embedding input arity for `input_ids`, `attention_mask`, and `token_type_ids`
- CLIP text EOT pooling, including repeated highest-token padding
- invalid inverted section slice guards in segment stats and global field-length aggregation
- symbolic tensor-view materialization for transpose/rerank graph paths

## Verification

- `zig build`
- `zig build inference-test`
- `zig build lib-db-query-test`
- `zig build index-manager-test`
- `zig build inference-test lib-db-query-test lib-db-enrichment-worker-test lib-swarm-runtime-test index-manager-test`
- `zig build unit-test` partially run until the unrelated `data.storage.db_split_handoff.test.db merge coordinator opt-in applies configured receiver identity namespace` failure; the new `api.indexes` status test and enrichment runtime test passed before that failure.
- `git diff --check`

Warnings printed during inference/index-manager tests are from existing diagnostic/negative-path tests; commands exited successfully.