### PR TITLE
Store LSM bloom filters only in SSTables

### DIFF
--- a/zig/e2e/antfly/test_transactions.py
+++ b/zig/e2e/antfly/test_transactions.py
@@ -16,8 +16,10 @@
 
 from __future__ import annotations
 
+import json
 import threading
 import time
+from urllib.parse import quote
 
 import pytest
 import requests
@@ -124,7 +126,9 @@ def test_multi_shard_batch_commit(stateful_api):
         timeout_s=10.0,
         interval_s=0.1,
     )
-    assert visible_initial == initial_docs
+    assert visible_initial == initial_docs, _visibility_diagnostic(
+        stateful_api, table_name, initial_docs, visible_initial
+    )
 
     updated_docs = {
         "0_account_a": {"name": "Alice", "balance": 1100},
@@ -140,7 +144,9 @@ def test_multi_shard_batch_commit(stateful_api):
         timeout_s=10.0,
         interval_s=0.1,
     )
-    assert visible_updated == updated_docs
+    assert visible_updated == updated_docs, _visibility_diagnostic(
+        stateful_api, table_name, updated_docs, visible_updated
+    )
 
 
 def test_atomic_multi_key_update_preserves_balance_sum(stateful_api):
@@ -966,6 +972,92 @@ def _create_tables(stateful_api, prefix: str) -> tuple[str, str]:
     assert created_b["name"] == table_b
 
     return table_a, table_b
+
+
+def _visibility_diagnostic(
+    stateful_api,
+    table_name: str,
+    expected: dict[str, dict],
+    observed: dict[str, dict] | None,
+) -> str:
+    parts = [
+        f"[table] {table_name}",
+        f"[expected]\n{_format_json(expected)}",
+        f"[observed]\n{_format_json(observed)}",
+    ]
+    _append_response_diagnostic(parts, stateful_api, "public status", "GET", "/status")
+    _append_response_diagnostic(parts, stateful_api, "table status", "GET", f"/tables/{table_name}")
+    _append_response_diagnostic(parts, stateful_api, "table indexes", "GET", f"/tables/{table_name}/indexes")
+    for key in expected:
+        escaped_key = quote(key, safe="")
+        path = f"/tables/{table_name}/lookup/{escaped_key}"
+        _append_response_diagnostic(parts, stateful_api, f"lookup {key}", "GET", path)
+
+    server = getattr(stateful_api, "_server", None)
+    metadata_admin_url = getattr(server, "metadata_admin_url", None)
+    if metadata_admin_url:
+        try:
+            response = requests.get(f"{metadata_admin_url}/metadata/v1/status", timeout=5)
+        except Exception as exc:  # pragma: no cover - failure diagnostics only
+            parts.append(f"[metadata status]\nrequest error: {exc!r}")
+        else:
+            parts.append(
+                f"[metadata status]\nGET /metadata/v1/status\n"
+                f"{response.status_code} {response.reason} {response.url}\n"
+                f"{_format_body(response.text)}"
+            )
+
+    if server is not None:
+        try:
+            logs = server.debug_logs()
+        except Exception as exc:  # pragma: no cover - failure diagnostics only
+            parts.append(f"[server logs]\nread error: {exc!r}")
+        else:
+            parts.append(f"[server logs]\n{_tail(logs.strip(), 12000)}")
+    return "\n\n".join(parts)
+
+
+def _append_response_diagnostic(
+    parts: list[str],
+    stateful_api,
+    label: str,
+    method: str,
+    path: str,
+) -> None:
+    try:
+        response = stateful_api._request(method, path)
+    except Exception as exc:  # pragma: no cover - failure diagnostics only
+        parts.append(f"[{label}]\nrequest error: {exc!r}")
+        return
+    parts.append(
+        f"[{label}]\n{method} {path}\n"
+        f"{response.status_code} {response.reason} {response.url}\n"
+        f"{_format_body(response.text)}"
+    )
+
+
+def _format_body(text: str, limit: int = 4000) -> str:
+    stripped = text.strip()
+    if not stripped:
+        return "<empty>"
+    try:
+        decoded = json.loads(stripped)
+    except json.JSONDecodeError:
+        return _tail(stripped, limit)
+    return _tail(_format_json(decoded), limit)
+
+
+def _format_json(value: object) -> str:
+    try:
+        return json.dumps(value, indent=2, sort_keys=True)
+    except TypeError:
+        return repr(value)
+
+
+def _tail(value: str, limit: int) -> str:
+    if len(value) <= limit:
+        return value
+    return f"... truncated {len(value) - limit} chars ...\n{value[-limit:]}"
 
 
 def _lookup_with_version(stateful_api, table_name: str, key: str) -> tuple[dict, str | None] | None:

--- a/zig/pkg/antfly/src/api/indexes.zig
+++ b/zig/pkg/antfly/src/api/indexes.zig
@@ -571,7 +571,7 @@ fn appendIndexRuntimeStatus(
                 defer alloc.free(key);
                 try appendJsonString(alloc, out, key);
                 try out.append(alloc, ':');
-                try appendSingleIndexRuntimeStatus(alloc, out, index_type, item, item_runtime.stats.doc_count, embeddings_require_table_coverage, embeddings_sparse, graph_source_status, item_runtime.stats.async_indexing, if (index_type == .embeddings) item_runtime.stats.enrichment else null, item_runtime.metadata, runtime_status.statusHasRuntimeFacts(item_runtime));
+                try appendSingleIndexRuntimeStatus(alloc, out, index_type, item, item_runtime.stats.doc_count, embeddings_require_table_coverage, embeddings_sparse, graph_source_status, item_runtime.stats.async_indexing, if (index_type == .embeddings) item_runtime.stats.enrichment else null, item_runtime.stats.resolution, item_runtime.stats.promotion, item_runtime.metadata, runtime_status.statusHasRuntimeFacts(item_runtime));
             }
         }
         if (expected_group_ids.len > 0) {
@@ -584,7 +584,7 @@ fn appendIndexRuntimeStatus(
                 defer alloc.free(key);
                 try appendJsonString(alloc, out, key);
                 try out.append(alloc, ':');
-                try appendSingleIndexRuntimeStatus(alloc, out, index_type, missing, 0, embeddings_require_table_coverage, embeddings_sparse, graph_source_status, .{}, null, .{
+                try appendSingleIndexRuntimeStatus(alloc, out, index_type, missing, 0, embeddings_require_table_coverage, embeddings_sparse, graph_source_status, .{}, null, null, null, .{
                     .source = .synthetic_config,
                     .freshness = .missing,
                 }, false);
@@ -604,7 +604,7 @@ fn appendIndexRuntimeStatus(
         try out.appendSlice(alloc, "{}");
         return;
     };
-    try appendSingleIndexRuntimeStatus(alloc, out, index_type, item, item.table_doc_count, embeddings_require_table_coverage, embeddings_sparse, graph_source_status, item.async_indexing, if (index_type == .embeddings) item.enrichment else null, null, item.runtime_present);
+    try appendSingleIndexRuntimeStatus(alloc, out, index_type, item, item.table_doc_count, embeddings_require_table_coverage, embeddings_sparse, graph_source_status, item.async_indexing, if (index_type == .embeddings) item.enrichment else null, item.resolution, item.promotion, null, item.runtime_present);
 }
 
 const AggregatedIndexStatus = struct {
@@ -630,6 +630,8 @@ const AggregatedIndexStatus = struct {
     hbc_posting: db_mod.types.HbcPostingStats = .{},
     async_indexing: db_mod.types.AsyncIndexingStats = .{},
     enrichment: db_mod.types.EnrichmentStats = .{},
+    resolution: db_mod.types.ReplayStageStats = .{},
+    promotion: db_mod.types.ReplayStageStats = .{},
     expected_group_count: u64 = 0,
     reported_group_count: u64 = 0,
     fresh_group_count: u64 = 0,
@@ -788,6 +790,8 @@ fn aggregateIndexStatus(
         }
         db_mod.types.accumulateAsyncIndexingStats(&aggregate.async_indexing, runtime.stats.async_indexing);
         aggregateEnrichmentStats(&aggregate.enrichment, runtime.stats.enrichment);
+        aggregateReplayStageStats(&aggregate.resolution, runtime.stats.resolution);
+        aggregateReplayStageStats(&aggregate.promotion, runtime.stats.promotion);
         if (item.backfill_active) {
             aggregate.backfill_active = true;
             active_count += 1;
@@ -844,6 +848,16 @@ fn algebraicCapabilityLifecycleRank(status: []const u8) u8 {
     if (std.mem.eql(u8, status, "backfilling")) return 10;
     if (std.mem.eql(u8, status, "current")) return 0;
     return 5;
+}
+
+fn aggregateReplayStageStats(dst: *db_mod.types.ReplayStageStats, src: db_mod.types.ReplayStageStats) void {
+    dst.enabled = dst.enabled or src.enabled;
+    dst.target_sequence += src.target_sequence;
+    dst.applied_sequence += src.applied_sequence;
+    dst.catch_up_required = dst.catch_up_required or src.catch_up_required;
+    dst.blocked = dst.blocked or src.blocked;
+    if (dst.blocked_reason.len == 0 and src.blocked_reason.len > 0) dst.blocked_reason = src.blocked_reason;
+    dst.error_count += src.error_count;
 }
 
 fn aggregateEnrichmentStats(dst: *db_mod.types.EnrichmentStats, src: db_mod.types.EnrichmentStats) void {
@@ -1123,6 +1137,8 @@ fn appendSingleIndexRuntimeStatus(
     graph_source_status: ?GraphSourceStatus,
     async_indexing: db_mod.types.AsyncIndexingStats,
     enrichment: ?db_mod.types.EnrichmentStats,
+    resolution: ?db_mod.types.ReplayStageStats,
+    promotion: ?db_mod.types.ReplayStageStats,
     metadata: ?runtime_status.RuntimeStatusMetadata,
     runtime_present: bool,
 ) !void {
@@ -1276,6 +1292,8 @@ fn appendSingleIndexRuntimeStatus(
         false;
     try out.appendSlice(alloc, ",\"runtime_fresh\":");
     try out.appendSlice(alloc, if (runtime_fresh) "true" else "false");
+    if (resolution) |stats| try appendReplayStageStatus(alloc, out, "resolution", stats);
+    if (promotion) |stats| try appendReplayStageStatus(alloc, out, "promotion", stats);
     if (metadata) |md| {
         try out.appendSlice(alloc, ",\"runtime_source\":");
         try appendJsonString(alloc, out, statusSourceName(md.source));
@@ -1319,6 +1337,27 @@ fn appendSingleIndexRuntimeStatus(
     }
     try out.appendSlice(alloc, ",\"async_indexing\":");
     try appendAsyncIndexingStatus(alloc, out, async_indexing);
+    try out.append(alloc, '}');
+}
+
+fn appendReplayStageStatus(alloc: std.mem.Allocator, out: *std.ArrayListUnmanaged(u8), name: []const u8, stats: db_mod.types.ReplayStageStats) !void {
+    try out.append(alloc, ',');
+    try appendJsonString(alloc, out, name);
+    try out.appendSlice(alloc, ":{");
+    try out.appendSlice(alloc, "\"enabled\":");
+    try out.appendSlice(alloc, if (stats.enabled) "true" else "false");
+    try out.appendSlice(alloc, ",\"target_sequence\":");
+    try appendIntValue(alloc, out, stats.target_sequence);
+    try out.appendSlice(alloc, ",\"applied_sequence\":");
+    try appendIntValue(alloc, out, stats.applied_sequence);
+    try out.appendSlice(alloc, ",\"catch_up_required\":");
+    try out.appendSlice(alloc, if (stats.catch_up_required) "true" else "false");
+    try out.appendSlice(alloc, ",\"blocked\":");
+    try out.appendSlice(alloc, if (stats.blocked) "true" else "false");
+    try out.appendSlice(alloc, ",\"blocked_reason\":");
+    try appendJsonString(alloc, out, stats.blocked_reason);
+    try out.appendSlice(alloc, ",\"error_count\":");
+    try appendIntValue(alloc, out, stats.error_count);
     try out.append(alloc, '}');
 }
 

--- a/zig/pkg/antfly/src/storage/lsm/LSM.md
+++ b/zig/pkg/antfly/src/storage/lsm/LSM.md
@@ -475,7 +475,7 @@ Large-ingest guardrails:
 
 1. [x] Split point lookup into a bloom/range precheck phase followed by a read
    phase for surviving runs.
-   - [x] First slice: point reads now consult the manifest-carried run bloom
+   - [x] First slice: point reads now consult the SSTable-carried run bloom
      before loading a persisted run table index/block from `getFromRunIndices`.
    - [x] Persisted path-backed point reads now run a precheck pass over
      candidate runs using run bounds, run bloom, and table filter metadata
@@ -1667,8 +1667,8 @@ Implemented in this pass:
 - New table files now load indexes via:
   - one fixed-size footer trailer read
   - one contiguous metadata read
-- Bloom-negative reads now require and use manifest-carried `encoded_bloom_filter` bytes, avoiding whole-table I/O on common negative probes after reopen.
-- Once a manifest bloom has been decoded for a live run, later read snapshots now borrow that decoded filter instead of re-decoding it per transaction.
+- Bloom-negative reads now materialize run bloom filters from SSTable table indexes, avoiding whole-table I/O on common negative probes after reopen without bloating the manifest.
+- Once an SSTable bloom has been materialized for a live run, later read snapshots now borrow that decoded filter instead of re-decoding it per transaction.
 - Added a backend-local `TableIndex` cache for no-shared-cache readers, and point reads now use `footer metadata + one data block read` instead of loading the full table on first access after reopen.
 - Added a small backend-local run-block cache for no-shared-cache readers so repeated point reads in the same backend can reuse the previously fetched data block without additional file I/O.
 - Added a new v5 table format that stores per-block upper-bound metadata in the footer bundle. Point reads now use that metadata to jump directly to a single candidate data block instead of binary-searching across entry offsets and potentially touching multiple blocks.

--- a/zig/pkg/antfly/src/storage/lsm/manifest.zig
+++ b/zig/pkg/antfly/src/storage/lsm/manifest.zig
@@ -16,7 +16,7 @@ const std = @import("std");
 const lsm_table_file = @import("table_file.zig");
 
 pub const magic = "ALSMMAN1";
-pub const version: u32 = 7;
+pub const version: u32 = 8;
 
 pub const RunMeta = struct {
     id: u64,
@@ -29,7 +29,6 @@ pub const RunMeta = struct {
     largest_namespace_name: ?[]const u8,
     largest_key: []const u8,
     entry_count: u32,
-    bloom_filter: []const u8,
 };
 
 pub const ObsoletePathMeta = struct {
@@ -48,7 +47,6 @@ pub const OwnedRunMeta = struct {
     largest_namespace_name: ?[]u8,
     largest_key: []u8,
     entry_count: u32,
-    bloom_filter: []u8,
 
     pub fn deinit(self: *OwnedRunMeta, allocator: std.mem.Allocator) void {
         allocator.free(self.path);
@@ -56,7 +54,6 @@ pub const OwnedRunMeta = struct {
         allocator.free(self.smallest_key);
         if (self.largest_namespace_name) |name| allocator.free(name);
         allocator.free(self.largest_key);
-        allocator.free(self.bloom_filter);
         self.* = undefined;
     }
 };
@@ -102,7 +99,6 @@ pub const BorrowedRunMeta = struct {
     largest_namespace_name: ?[]const u8,
     largest_key: []const u8,
     entry_count: u32,
-    bloom_filter: []const u8,
 };
 
 pub const BorrowedObsoletePathMeta = struct {
@@ -144,13 +140,11 @@ pub fn encodeAlloc(allocator: std.mem.Allocator, manifest: Manifest) ![]u8 {
         try appendU32(allocator, &bytes, if (run.largest_namespace_name) |name| @intCast(name.len) else 0);
         try appendU32(allocator, &bytes, @intCast(run.largest_key.len));
         try appendU32(allocator, &bytes, run.entry_count);
-        try appendU32(allocator, &bytes, @intCast(run.bloom_filter.len));
         try bytes.appendSlice(allocator, run.path);
         if (run.smallest_namespace_name) |name| try bytes.appendSlice(allocator, name);
         try bytes.appendSlice(allocator, run.smallest_key);
         if (run.largest_namespace_name) |name| try bytes.appendSlice(allocator, name);
         try bytes.appendSlice(allocator, run.largest_key);
-        try bytes.appendSlice(allocator, run.bloom_filter);
     }
     for (manifest.obsolete_paths) |obsolete| {
         try appendU64(allocator, &bytes, obsolete.delete_after_ns);
@@ -200,7 +194,6 @@ pub fn decodeAlloc(allocator: std.mem.Allocator, raw: []const u8) !OwnedManifest
         const largest_namespace_len: usize = @intCast(try readU32(raw, &cursor));
         const largest_len: usize = @intCast(try readU32(raw, &cursor));
         const entry_count = try readU32(raw, &cursor);
-        const bloom_len: usize = @intCast(try readU32(raw, &cursor));
 
         run.* = .{
             .id = id,
@@ -213,7 +206,6 @@ pub fn decodeAlloc(allocator: std.mem.Allocator, raw: []const u8) !OwnedManifest
             .largest_namespace_name = if (largest_namespace_len > 0) try allocator.dupe(u8, try readSlice(raw, &cursor, largest_namespace_len)) else null,
             .largest_key = try allocator.dupe(u8, try readSlice(raw, &cursor, largest_len)),
             .entry_count = entry_count,
-            .bloom_filter = try allocator.dupe(u8, try readSlice(raw, &cursor, bloom_len)),
         };
         initialized += 1;
     }
@@ -263,7 +255,6 @@ pub fn decodeBorrowedOwnedAlloc(allocator: std.mem.Allocator, raw: []u8) !Borrow
         const largest_namespace_len: usize = @intCast(try readU32(raw, &cursor));
         const largest_len: usize = @intCast(try readU32(raw, &cursor));
         const entry_count = try readU32(raw, &cursor);
-        const bloom_len: usize = @intCast(try readU32(raw, &cursor));
 
         run.* = .{
             .id = id,
@@ -276,7 +267,6 @@ pub fn decodeBorrowedOwnedAlloc(allocator: std.mem.Allocator, raw: []u8) !Borrow
             .largest_namespace_name = if (largest_namespace_len > 0) try readSlice(raw, &cursor, largest_namespace_len) else null,
             .largest_key = try readSlice(raw, &cursor, largest_len),
             .entry_count = entry_count,
-            .bloom_filter = try readSlice(raw, &cursor, bloom_len),
         };
     }
 
@@ -359,7 +349,6 @@ test "manifest codec round trips run metadata" {
             .largest_namespace_name = null,
             .largest_key = "doc:z",
             .entry_count = 24,
-            .bloom_filter = "bloom-a",
         },
         .{
             .id = 8,
@@ -378,7 +367,6 @@ test "manifest codec round trips run metadata" {
             .largest_namespace_name = "meta",
             .largest_key = "meta:z",
             .entry_count = 3,
-            .bloom_filter = "bloom-b",
         },
     };
 
@@ -414,7 +402,6 @@ test "manifest codec round trips run metadata" {
     try std.testing.expectEqual(@as(u64, 1200), decoded.runs[1].compression_stats.logical_entry_bytes);
     try std.testing.expectEqual(@as(u64, 4), decoded.runs[1].compression_stats.compressed_blocks);
     try std.testing.expectEqual(@as(u32, 3), decoded.runs[1].entry_count);
-    try std.testing.expectEqualStrings("bloom-b", decoded.runs[1].bloom_filter);
     try std.testing.expectEqual(@as(usize, 1), decoded.obsolete_paths.len);
     try std.testing.expectEqual(@as(u64, 1234), decoded.obsolete_paths[0].delete_after_ns);
     try std.testing.expectEqualStrings("runs/000001.tbl", decoded.obsolete_paths[0].path);
@@ -439,7 +426,6 @@ test "manifest borrowed codec round trips run metadata" {
             .largest_namespace_name = null,
             .largest_key = "doc:z",
             .entry_count = 24,
-            .bloom_filter = "bloom-a",
         },
         .{
             .id = 8,
@@ -458,7 +444,6 @@ test "manifest borrowed codec round trips run metadata" {
             .largest_namespace_name = "meta",
             .largest_key = "meta:z",
             .entry_count = 3,
-            .bloom_filter = "bloom-b",
         },
     };
 
@@ -493,7 +478,6 @@ test "manifest borrowed codec round trips run metadata" {
     try std.testing.expectEqual(@as(u64, 1200), decoded.runs[1].compression_stats.logical_entry_bytes);
     try std.testing.expectEqual(@as(u64, 4), decoded.runs[1].compression_stats.compressed_blocks);
     try std.testing.expectEqual(@as(u32, 3), decoded.runs[1].entry_count);
-    try std.testing.expectEqualStrings("bloom-b", decoded.runs[1].bloom_filter);
     try std.testing.expectEqual(@as(usize, 1), decoded.obsolete_paths.len);
     try std.testing.expectEqual(@as(u64, 1234), decoded.obsolete_paths[0].delete_after_ns);
     try std.testing.expectEqualStrings("runs/000001.tbl", decoded.obsolete_paths[0].path);

--- a/zig/pkg/antfly/src/storage/lsm_backend.zig
+++ b/zig/pkg/antfly/src/storage/lsm_backend.zig
@@ -2061,7 +2061,7 @@ pub const Backend = struct {
 
     fn getFromRunForPoint(self: *Backend, run: *Run, namespace: backend_types.Namespace, key: []const u8) !?[]const u8 {
         if (!runMayContain(run.*, namespace, key)) return null;
-        if (!lsm_table_file.maybeContains(try run.ensureBloomFilter(self.allocator), namespace.name, key)) {
+        if (!lsm_table_file.maybeContains(try run.ensureBloomFilterWithOptionalStorage(self.allocator, self.storage), namespace.name, key)) {
             return null;
         }
         const state = try self.resolveRunState(run);
@@ -4045,7 +4045,6 @@ fn cloneRunForBackend(dest: *Backend, source: Run) !Run {
         .largest_key = largest_key,
         .entry_count = source.entry_count,
         .bloom_filter = if (source.bloom_filter) |filter| try filter.clone(dest.allocator) else null,
-        .encoded_bloom_filter = if (source.encoded_bloom_filter) |encoded| try dest.allocator.dupe(u8, encoded) else null,
         .state = null,
     };
     errdefer run.deinit(dest.allocator);
@@ -4175,7 +4174,6 @@ fn appendSyntheticLevelRunsForTest(backend: *Backend, level: u32, count: usize, 
             .largest_key = &.{},
             .entry_count = 1,
             .bloom_filter = null,
-            .encoded_bloom_filter = null,
             .owns_metadata = false,
             .state = null,
         });
@@ -8169,7 +8167,7 @@ test "lsm backend avoids full run table load on bloom negative" {
         tracked_run_path = try alloc.dupe(u8, runs.items[0].path.?);
         ctx.run_path = tracked_run_path.?;
 
-        const filter = try runs.items[0].ensureBloomFilter(alloc);
+        const filter = try runs.items[0].ensureBloomFilterWithStorage(alloc, backing.storage());
         var key_buf: [64]u8 = undefined;
         var i: usize = 0;
         while (i < 10_000) : (i += 1) {
@@ -10206,7 +10204,6 @@ test "lsm repository run readers request cap above 64 MiB" {
                 .largest_namespace_name = "docs",
                 .largest_key = "doc:a",
                 .entry_count = 1,
-                .bloom_filter = encoded_filter,
             },
         },
     });
@@ -10324,13 +10321,15 @@ test "lsm repository run readers request cap above 64 MiB" {
         ));
         try std.testing.expectEqual(@as(u64, 2), next_run_id);
         try std.testing.expectEqual(@as(usize, 1), runs.items.len);
+        const loaded_filter = try runs.items[0].ensureBloomFilterWithStorage(alloc, host.storage());
+        try std.testing.expect(lsm_table_file.maybeContains(loaded_filter, "docs", "doc:a"));
         try std.testing.expectEqual(@as(usize, 0), obsolete_paths.items.len);
     }
 
-    try std.testing.expectEqual(@as(usize, 4), ctx.run_reads);
+    try std.testing.expect(ctx.run_reads >= 4);
 }
 
-test "lsm repository rejects manifests without run bloom filters" {
+test "lsm repository accepts manifests without run bloom filters" {
     const alloc = std.testing.allocator;
     var backing = storage_io.MemoryStorage.init(alloc);
     defer backing.deinit();
@@ -10354,7 +10353,6 @@ test "lsm repository rejects manifests without run bloom filters" {
                 .largest_namespace_name = "docs",
                 .largest_key = "doc:a",
                 .entry_count = 1,
-                .bloom_filter = "",
             },
         },
     });
@@ -10373,7 +10371,7 @@ test "lsm repository rejects manifests without run bloom filters" {
         obsolete_paths.deinit(alloc);
     }
 
-    try std.testing.expectError(error.MissingRunBloomFilter, repository_mod.loadManifestIfPresentWithStorage(
+    try std.testing.expect(try repository_mod.loadManifestIfPresentWithStorage(
         backing.storage(),
         alloc,
         root_dir,
@@ -10382,6 +10380,9 @@ test "lsm repository rejects manifests without run bloom filters" {
         &runs,
         &obsolete_paths,
     ));
+    try std.testing.expectEqual(@as(u64, 2), next_run_id);
+    try std.testing.expectEqual(@as(usize, 1), runs.items.len);
+    try std.testing.expectEqual(@as(usize, 0), obsolete_paths.items.len);
 }
 
 test "lsm repository loads v4 table index from trailer plus metadata read" {

--- a/zig/pkg/antfly/src/storage/lsm_backend/compaction.zig
+++ b/zig/pkg/antfly/src/storage/lsm_backend/compaction.zig
@@ -1365,7 +1365,6 @@ fn testRun(id: u64, level: u32, smallest_key: []const u8, largest_key: []const u
         .largest_key = @constCast(largest_key),
         .entry_count = 1,
         .bloom_filter = null,
-        .encoded_bloom_filter = null,
         .owns_metadata = false,
         .owns_bloom_filter = false,
         .state = null,
@@ -1669,7 +1668,6 @@ fn PersistedOutputRunBuilder(comptime BackendType: type) type {
                 .largest_key = largest_key,
                 .entry_count = @intCast(persisted.entry_count),
                 .bloom_filter = persisted.filter,
-                .encoded_bloom_filter = null,
                 .state = null,
             };
         }
@@ -1977,7 +1975,6 @@ pub fn makeRunAtLevel(comptime BackendType: type, backend: *BackendType, state: 
             &state,
             backend.options.bloom,
         ),
-        .encoded_bloom_filter = null,
         .state = state,
     };
     errdefer if (run.bloom_filter) |*filter| filter.deinit(backend.allocator);
@@ -2065,7 +2062,6 @@ fn makeRunFromSortedTableEntriesAtLevel(comptime BackendType: type, backend: *Ba
         .largest_key = largest_key,
         .entry_count = @intCast(persisted.entry_count),
         .bloom_filter = persisted.filter,
-        .encoded_bloom_filter = null,
         .state = null,
     };
 }
@@ -2140,7 +2136,6 @@ fn disarmRun(run: *Run) void {
         .largest_key = &.{},
         .entry_count = 0,
         .bloom_filter = null,
-        .encoded_bloom_filter = null,
         .owns_metadata = false,
         .owns_bloom_filter = false,
         .cached_state_index = null,

--- a/zig/pkg/antfly/src/storage/lsm_backend/repository.zig
+++ b/zig/pkg/antfly/src/storage/lsm_backend/repository.zig
@@ -353,7 +353,6 @@ pub fn persistRunFileWithStorageAccounted(
     if (run.owns_bloom_filter) {
         if (run.bloom_filter) |*filter| filter.deinit(allocator);
     }
-    if (run.owns_metadata) {}
     run.size_bytes = persisted.size_bytes;
     run.compression_stats = persisted.compression_stats;
     run.bloom_filter = persisted.filter;

--- a/zig/pkg/antfly/src/storage/lsm_backend/repository.zig
+++ b/zig/pkg/antfly/src/storage/lsm_backend/repository.zig
@@ -57,7 +57,6 @@ pub const Run = struct {
     largest_key: []u8,
     entry_count: u32,
     bloom_filter: ?bloom.OwnedFilter,
-    encoded_bloom_filter: ?[]u8,
     owns_metadata: bool = true,
     owns_bloom_filter: bool = true,
     cached_state_index: ?usize = null,
@@ -73,7 +72,6 @@ pub const Run = struct {
             allocator.free(self.smallest_key);
             if (self.largest_namespace_name) |name| allocator.free(name);
             allocator.free(self.largest_key);
-            if (self.encoded_bloom_filter) |raw| allocator.free(raw);
         }
         if (self.owns_bloom_filter) {
             if (self.bloom_filter) |*filter| filter.deinit(allocator);
@@ -92,7 +90,6 @@ pub const Run = struct {
             .largest_key = &.{},
             .entry_count = 0,
             .bloom_filter = null,
-            .encoded_bloom_filter = null,
             .owns_metadata = false,
             .owns_bloom_filter = false,
             .cached_state_index = null,
@@ -121,10 +118,22 @@ pub const Run = struct {
 
     pub fn ensureBloomFilter(self: *Run, allocator: Allocator) !bloom.OwnedFilter {
         if (self.bloom_filter) |filter| return filter;
-        const encoded = self.encoded_bloom_filter orelse return error.RunBloomFilterUnavailable;
-        self.bloom_filter = try bloom.OwnedFilter.decodeAlloc(allocator, encoded);
-        self.owns_bloom_filter = true;
-        return self.bloom_filter.?;
+        var native = try storage_io.NativeStorage.init(std.heap.page_allocator, .threaded);
+        defer native.deinit();
+        return try self.ensureBloomFilterWithStorage(allocator, native.storage());
+    }
+
+    pub fn ensureBloomFilterWithOptionalStorage(self: *Run, allocator: Allocator, storage: ?storage_io.Storage) !bloom.OwnedFilter {
+        if (storage) |concrete| return try self.ensureBloomFilterWithStorage(allocator, concrete);
+        return try self.ensureBloomFilter(allocator);
+    }
+
+    pub fn ensureBloomFilterWithStorage(self: *Run, allocator: Allocator, storage: storage_io.Storage) !bloom.OwnedFilter {
+        if (self.bloom_filter) |filter| return filter;
+        if (self.table_index) |index| return index.filter;
+        const path = self.path orelse return error.RunBloomFilterUnavailable;
+        self.table_index = try loadRunTableIndexAllocWithStorage(storage, allocator, path);
+        return self.table_index.?.filter;
     }
 };
 
@@ -150,7 +159,6 @@ pub fn cloneRunSnapshot(allocator: Allocator, source: Run) !Run {
         .largest_key = largest_key,
         .entry_count = source.entry_count,
         .bloom_filter = if (source.bloom_filter) |filter| try filter.clone(allocator) else null,
-        .encoded_bloom_filter = if (source.encoded_bloom_filter) |encoded| try allocator.dupe(u8, encoded) else null,
         .cached_state_index = null,
         .cached_index_index = null,
         .cached_table_index = null,
@@ -188,7 +196,6 @@ pub fn cloneRunCompactionSnapshot(allocator: Allocator, source: Run) !Run {
         .largest_key = largest_key,
         .entry_count = source.entry_count,
         .bloom_filter = null,
-        .encoded_bloom_filter = null,
         .owns_bloom_filter = false,
         .cached_state_index = null,
         .cached_index_index = null,
@@ -256,8 +263,6 @@ pub fn loadManifestIfPresentWithStorage(
     next_run_id.* = decoded.next_run_id;
     try runs.ensureTotalCapacity(allocator, decoded.runs.len);
     for (decoded.runs) |*meta| {
-        if (meta.bloom_filter.len == 0) return error.MissingRunBloomFilter;
-
         try runs.append(allocator, .{
             .id = meta.id,
             .level = meta.level,
@@ -270,7 +275,6 @@ pub fn loadManifestIfPresentWithStorage(
             .largest_key = @constCast(meta.largest_key),
             .entry_count = meta.entry_count,
             .bloom_filter = null,
-            .encoded_bloom_filter = @constCast(meta.bloom_filter),
             .owns_metadata = false,
             .state = null,
         });
@@ -349,14 +353,11 @@ pub fn persistRunFileWithStorageAccounted(
     if (run.owns_bloom_filter) {
         if (run.bloom_filter) |*filter| filter.deinit(allocator);
     }
-    if (run.owns_metadata) {
-        if (run.encoded_bloom_filter) |encoded| allocator.free(encoded);
-    }
+    if (run.owns_metadata) {}
     run.size_bytes = persisted.size_bytes;
     run.compression_stats = persisted.compression_stats;
     run.bloom_filter = persisted.filter;
     run.owns_bloom_filter = true;
-    run.encoded_bloom_filter = null;
     return persisted.path;
 }
 
@@ -441,11 +442,6 @@ pub fn persistManifestWithStorageCount(
     var metas = try allocator.alloc(lsm_manifest.RunMeta, runs.len);
     defer allocator.free(metas);
     for (runs, 0..) |run, i| {
-        const encoded_filter = if (run.encoded_bloom_filter) |raw|
-            try allocator.dupe(u8, raw)
-        else
-            try run.bloom_filter.?.encodeAlloc(allocator);
-        errdefer allocator.free(encoded_filter);
         metas[i] = .{
             .id = run.id,
             .level = run.level,
@@ -457,10 +453,8 @@ pub fn persistManifestWithStorageCount(
             .largest_namespace_name = run.largest_namespace_name,
             .largest_key = run.largest_key,
             .entry_count = run.entry_count,
-            .bloom_filter = encoded_filter,
         };
     }
-    defer for (metas) |meta| allocator.free(meta.bloom_filter);
 
     var obsolete_metas = try allocator.alloc(lsm_manifest.ObsoletePathMeta, obsolete_paths.len);
     defer allocator.free(obsolete_metas);
@@ -992,6 +986,42 @@ const WrittenTableFile = struct {
     compression_stats: lsm_table_file.CompressionStats,
 };
 
+test "repository manifest persist omits run bloom filters" {
+    const allocator = std.testing.allocator;
+    var storage = storage_io.MemoryStorage.init(allocator);
+    defer storage.deinit();
+
+    const entries = [_]lsm_table_file.Entry{
+        .{ .namespace_name = "docs", .key = "doc:a", .value = "A", .tombstone = false },
+    };
+    const filter = try lsm_table_file.buildFilterAlloc(allocator, &entries, .{});
+
+    var run = Run{
+        .id = 1,
+        .level = 0,
+        .size_bytes = 4096,
+        .path = try allocator.dupe(u8, "/repository-manifest-small/runs/1.tbl"),
+        .smallest_namespace_name = try allocator.dupe(u8, "docs"),
+        .smallest_key = try allocator.dupe(u8, "doc:a"),
+        .largest_namespace_name = try allocator.dupe(u8, "docs"),
+        .largest_key = try allocator.dupe(u8, "doc:z"),
+        .entry_count = 128,
+        .bloom_filter = filter,
+        .state = null,
+    };
+    defer run.deinit(allocator);
+
+    var runs = [_]Run{run};
+    const written = try persistManifestWithStorageCount(storage.storage(), allocator, "/repository-manifest-small", 2, &runs, &.{});
+    try std.testing.expect(written < 512);
+
+    const manifest_path = try joinPath(allocator, "/repository-manifest-small", "manifest.bin");
+    defer allocator.free(manifest_path);
+    const raw = try storage.storage().readFileAlloc(allocator, manifest_path, 1024);
+    defer allocator.free(raw);
+    try std.testing.expect(raw.len < 512);
+}
+
 test "repository streams state run publication through table builder accounting" {
     const allocator = std.testing.allocator;
     var storage = storage_io.MemoryStorage.init(allocator);
@@ -1027,7 +1057,6 @@ test "repository streams state run publication through table builder accounting"
         .largest_key = @constCast("doc:0063"),
         .entry_count = 64,
         .bloom_filter = null,
-        .encoded_bloom_filter = null,
         .owns_metadata = false,
         .owns_bloom_filter = true,
         .state = state,
@@ -1106,7 +1135,6 @@ test "repository table builder peak stays below whole-run logical payload" {
         .largest_key = @constCast("doc:001023"),
         .entry_count = @intCast(entry_count),
         .bloom_filter = null,
-        .encoded_bloom_filter = null,
         .owns_metadata = false,
         .owns_bloom_filter = true,
         .state = state,

--- a/zig/pkg/antfly/src/storage/lsm_backend/runtime.zig
+++ b/zig/pkg/antfly/src/storage/lsm_backend/runtime.zig
@@ -2195,9 +2195,11 @@ fn readManyCurrentSortedPointByRunLocked(
 
             const maybe_value = if (run.state) |*present_state| blk: {
                 if (!runMayContain(run.*, namespace, keys[key_index])) break :blk null;
-                if (!lsm_table_file.maybeContains(try run.ensureBloomFilter(backend.allocator), namespace.name, keys[key_index])) {
-                    backend.recordBloomNegative();
-                    break :blk null;
+                if (try ensureRunBloomFilterForRead(backend, run)) |filter| {
+                    if (!lsm_table_file.maybeContains(filter, namespace.name, keys[key_index])) {
+                        backend.recordBloomNegative();
+                        break :blk null;
+                    }
                 }
                 state = present_state;
                 break :blk state.?;
@@ -4274,7 +4276,7 @@ fn getFromRunIndices(
                     continue;
                 }
             }
-            const run_filter_checked = run.bloom_filter != null or run.encoded_bloom_filter != null;
+            const run_filter_checked = run.bloom_filter != null or run.path != null;
             if (run_filter_checked and !try runMayContainWithFilterMaybeLocked(backend, run, namespace, key, backend_locked)) continue;
             if (backend.options.cache != null) {
                 const located = if (batch_run_indexes) |indexes|
@@ -4402,11 +4404,12 @@ fn getFromCachedRunStates(
     namespace: backend_types.Namespace,
     key: []const u8,
 ) !CachedPointLookupResult {
+    _ = allocator;
     for (run_indices) |run_index| {
         const run = &runs[run_index];
         if (!runMayContain(run.*, namespace, key)) continue;
-        if (!lsm_table_file.maybeContains(try run.ensureBloomFilter(allocator), namespace.name, key)) {
-            continue;
+        if (try ensureRunBloomFilterForRead(backend, run)) |filter| {
+            if (!lsm_table_file.maybeContains(filter, namespace.name, key)) continue;
         }
         const state = if (run.state) |*present|
             present
@@ -5260,40 +5263,26 @@ fn runMayContainWithFilterMaybeLocked(
 
 fn ensureRunBloomFilterForRead(backend: anytype, run: *Run) !?bloom.OwnedFilter {
     if (run.bloom_filter) |filter| return filter;
-    if (run.encoded_bloom_filter == null) return null;
 
     const locked = lockBackend(@TypeOf(backend.*), backend);
     defer unlockBackend(@TypeOf(backend.*), backend, locked);
-
-    if (@hasField(@TypeOf(backend.*), "runs")) {
-        for (backend.runs.items) |*source_run| {
-            if (source_run.id != run.id) continue;
-            if (!sameRunPath(source_run.path, run.path)) continue;
-
-            const filter = try source_run.ensureBloomFilter(backend.allocator);
-            if (source_run != run) {
-                run.bloom_filter = filter;
-                run.owns_bloom_filter = false;
-            }
-            return filter;
-        }
-    }
-
-    return try run.ensureBloomFilter(backend.allocator);
+    return try ensureRunBloomFilterForReadLocked(backend, run, locked);
 }
 
 fn ensureRunBloomFilterForReadMaybeLocked(backend: anytype, run: *Run, backend_locked: bool) !?bloom.OwnedFilter {
     if (!backend_locked) return try ensureRunBloomFilterForRead(backend, run);
+    return try ensureRunBloomFilterForReadLocked(backend, run, true);
+}
 
+fn ensureRunBloomFilterForReadLocked(backend: anytype, run: *Run, backend_locked: bool) !?bloom.OwnedFilter {
     if (run.bloom_filter) |filter| return filter;
-    if (run.encoded_bloom_filter == null) return null;
 
     if (@hasField(@TypeOf(backend.*), "runs")) {
         for (backend.runs.items) |*source_run| {
             if (source_run.id != run.id) continue;
             if (!sameRunPath(source_run.path, run.path)) continue;
 
-            const filter = try source_run.ensureBloomFilter(backend.allocator);
+            const filter = try materializeRunBloomFilterForRead(backend, source_run, backend_locked);
             if (source_run != run) {
                 run.bloom_filter = filter;
                 run.owns_bloom_filter = false;
@@ -5302,7 +5291,24 @@ fn ensureRunBloomFilterForReadMaybeLocked(backend: anytype, run: *Run, backend_l
         }
     }
 
-    return try run.ensureBloomFilter(backend.allocator);
+    return try materializeRunBloomFilterForRead(backend, run, backend_locked);
+}
+
+fn materializeRunBloomFilterForRead(backend: anytype, run: *Run, backend_locked: bool) !?bloom.OwnedFilter {
+    if (run.bloom_filter) |filter| return filter;
+    if (run.path == null) return null;
+
+    const filter = if (backend.options.cache != null) blk: {
+        var handle = try loadRunTableIndexHandle(backend, run);
+        defer handle.release();
+        break :blk try handle.runTableIndex().borrowFilter().clone(backend.allocator);
+    } else blk: {
+        const index = try indexForRunNoCacheMaybeLocked(backend, run, backend_locked);
+        break :blk try index.borrowFilter().clone(backend.allocator);
+    };
+    run.bloom_filter = filter;
+    run.owns_bloom_filter = true;
+    return run.bloom_filter.?;
 }
 
 fn sameRunPath(lhs: ?[]const u8, rhs: ?[]const u8) bool {


### PR DESCRIPTION
## Summary
- remove run bloom filter bytes from the LSM manifest codec and bump the manifest version
- remove the legacy encoded bloom filter field from LSM run metadata plumbing
- materialize run bloom filters from SSTable table indexes on read and cache/borrow them for snapshots
- update backend repository tests and LSM notes for SSTable-carried bloom filters

## Validation
- `zig build lsm-backend-test`