### PR TITLE
Add resolver replay diagnostics to index status

### DIFF
--- a/zig/pkg/antfly/src/api/indexes.zig
+++ b/zig/pkg/antfly/src/api/indexes.zig
@@ -571,7 +571,7 @@ fn appendIndexRuntimeStatus(
                 defer alloc.free(key);
                 try appendJsonString(alloc, out, key);
                 try out.append(alloc, ':');
-                try appendSingleIndexRuntimeStatus(alloc, out, index_type, item, item_runtime.stats.doc_count, embeddings_require_table_coverage, embeddings_sparse, graph_source_status, item_runtime.stats.async_indexing, if (index_type == .embeddings) item_runtime.stats.enrichment else null, item_runtime.stats.resolution, item_runtime.stats.promotion, item_runtime.metadata, runtime_status.statusHasRuntimeFacts(item_runtime));
+                try appendSingleIndexRuntimeStatus(alloc, out, index_type, item, item_runtime.stats.doc_count, embeddings_require_table_coverage, embeddings_sparse, graph_source_status, item_runtime.stats.async_indexing, if (index_type == .embeddings) item_runtime.stats.enrichment else null, item_runtime.stats.resolution, item_runtime.stats.promotion, item_runtime.stats.resolver_replay, item_runtime.metadata, runtime_status.statusHasRuntimeFacts(item_runtime));
             }
         }
         if (expected_group_ids.len > 0) {
@@ -584,7 +584,7 @@ fn appendIndexRuntimeStatus(
                 defer alloc.free(key);
                 try appendJsonString(alloc, out, key);
                 try out.append(alloc, ':');
-                try appendSingleIndexRuntimeStatus(alloc, out, index_type, missing, 0, embeddings_require_table_coverage, embeddings_sparse, graph_source_status, .{}, null, null, null, .{
+                try appendSingleIndexRuntimeStatus(alloc, out, index_type, missing, 0, embeddings_require_table_coverage, embeddings_sparse, graph_source_status, .{}, null, null, null, .{}, .{
                     .source = .synthetic_config,
                     .freshness = .missing,
                 }, false);
@@ -604,7 +604,7 @@ fn appendIndexRuntimeStatus(
         try out.appendSlice(alloc, "{}");
         return;
     };
-    try appendSingleIndexRuntimeStatus(alloc, out, index_type, item, item.table_doc_count, embeddings_require_table_coverage, embeddings_sparse, graph_source_status, item.async_indexing, if (index_type == .embeddings) item.enrichment else null, item.resolution, item.promotion, null, item.runtime_present);
+    try appendSingleIndexRuntimeStatus(alloc, out, index_type, item, item.table_doc_count, embeddings_require_table_coverage, embeddings_sparse, graph_source_status, item.async_indexing, if (index_type == .embeddings) item.enrichment else null, item.resolution, item.promotion, item.resolver_replay, null, item.runtime_present);
 }
 
 const AggregatedIndexStatus = struct {
@@ -632,6 +632,7 @@ const AggregatedIndexStatus = struct {
     enrichment: db_mod.types.EnrichmentStats = .{},
     resolution: db_mod.types.ReplayStageStats = .{},
     promotion: db_mod.types.ReplayStageStats = .{},
+    resolver_replay: db_mod.types.ResolverReplayDiagnostics = .{},
     expected_group_count: u64 = 0,
     reported_group_count: u64 = 0,
     fresh_group_count: u64 = 0,
@@ -792,6 +793,7 @@ fn aggregateIndexStatus(
         aggregateEnrichmentStats(&aggregate.enrichment, runtime.stats.enrichment);
         aggregateReplayStageStats(&aggregate.resolution, runtime.stats.resolution);
         aggregateReplayStageStats(&aggregate.promotion, runtime.stats.promotion);
+        aggregateResolverReplayDiagnostics(&aggregate.resolver_replay, runtime.stats.resolver_replay);
         if (item.backfill_active) {
             aggregate.backfill_active = true;
             active_count += 1;
@@ -848,6 +850,15 @@ fn algebraicCapabilityLifecycleRank(status: []const u8) u8 {
     if (std.mem.eql(u8, status, "backfilling")) return 10;
     if (std.mem.eql(u8, status, "current")) return 0;
     return 5;
+}
+
+fn aggregateResolverReplayDiagnostics(dst: *db_mod.types.ResolverReplayDiagnostics, src: db_mod.types.ResolverReplayDiagnostics) void {
+    dst.resolver_count += src.resolver_count;
+    dst.resolution_runtime_present = dst.resolution_runtime_present or src.resolution_runtime_present;
+    dst.resolution_worker_started = dst.resolution_worker_started or src.resolution_worker_started;
+    dst.promotion_runtime_present = dst.promotion_runtime_present or src.promotion_runtime_present;
+    dst.promotion_worker_started = dst.promotion_worker_started or src.promotion_worker_started;
+    if (dst.resolvers.len == 0 and src.resolvers.len > 0) dst.resolvers = src.resolvers;
 }
 
 fn aggregateReplayStageStats(dst: *db_mod.types.ReplayStageStats, src: db_mod.types.ReplayStageStats) void {
@@ -1139,6 +1150,7 @@ fn appendSingleIndexRuntimeStatus(
     enrichment: ?db_mod.types.EnrichmentStats,
     resolution: ?db_mod.types.ReplayStageStats,
     promotion: ?db_mod.types.ReplayStageStats,
+    resolver_replay: db_mod.types.ResolverReplayDiagnostics,
     metadata: ?runtime_status.RuntimeStatusMetadata,
     runtime_present: bool,
 ) !void {
@@ -1294,6 +1306,7 @@ fn appendSingleIndexRuntimeStatus(
     try out.appendSlice(alloc, if (runtime_fresh) "true" else "false");
     if (resolution) |stats| try appendReplayStageStatus(alloc, out, "resolution", stats);
     if (promotion) |stats| try appendReplayStageStatus(alloc, out, "promotion", stats);
+    if (index_type == .graph) try appendResolverReplayDiagnosticsStatus(alloc, out, resolver_replay);
     if (metadata) |md| {
         try out.appendSlice(alloc, ",\"runtime_source\":");
         try appendJsonString(alloc, out, statusSourceName(md.source));
@@ -1338,6 +1351,42 @@ fn appendSingleIndexRuntimeStatus(
     try out.appendSlice(alloc, ",\"async_indexing\":");
     try appendAsyncIndexingStatus(alloc, out, async_indexing);
     try out.append(alloc, '}');
+}
+
+fn appendResolverReplayDiagnosticsStatus(alloc: std.mem.Allocator, out: *std.ArrayListUnmanaged(u8), stats: db_mod.types.ResolverReplayDiagnostics) !void {
+    try out.appendSlice(alloc, ",\"resolver_replay\":{");
+    try out.appendSlice(alloc, "\"resolver_count\":");
+    try appendIntValue(alloc, out, stats.resolver_count);
+    try out.appendSlice(alloc, ",\"resolution_runtime_present\":");
+    try out.appendSlice(alloc, if (stats.resolution_runtime_present) "true" else "false");
+    try out.appendSlice(alloc, ",\"resolution_worker_started\":");
+    try out.appendSlice(alloc, if (stats.resolution_worker_started) "true" else "false");
+    try out.appendSlice(alloc, ",\"promotion_runtime_present\":");
+    try out.appendSlice(alloc, if (stats.promotion_runtime_present) "true" else "false");
+    try out.appendSlice(alloc, ",\"promotion_worker_started\":");
+    try out.appendSlice(alloc, if (stats.promotion_worker_started) "true" else "false");
+    try out.appendSlice(alloc, ",\"resolvers\":[");
+    for (stats.resolvers, 0..) |resolver, i| {
+        if (i > 0) try out.appendSlice(alloc, ",");
+        try out.appendSlice(alloc, "{");
+        try appendJsonString(alloc, out, "name");
+        try out.appendSlice(alloc, ":");
+        try appendJsonString(alloc, out, resolver.name);
+        try out.appendSlice(alloc, ",");
+        try appendJsonString(alloc, out, "table");
+        try out.appendSlice(alloc, ":");
+        try appendJsonString(alloc, out, resolver.table);
+        try out.appendSlice(alloc, ",");
+        try appendJsonString(alloc, out, "source_artifact");
+        try out.appendSlice(alloc, ":");
+        try appendJsonString(alloc, out, resolver.source_artifact);
+        try out.appendSlice(alloc, ",");
+        try appendJsonString(alloc, out, "resolution_artifact");
+        try out.appendSlice(alloc, ":");
+        try appendJsonString(alloc, out, resolver.resolution_artifact);
+        try out.appendSlice(alloc, "}");
+    }
+    try out.appendSlice(alloc, "]}");
 }
 
 fn appendReplayStageStatus(alloc: std.mem.Allocator, out: *std.ArrayListUnmanaged(u8), name: []const u8, stats: db_mod.types.ReplayStageStats) !void {

--- a/zig/pkg/antfly/src/api/runtime_status.zig
+++ b/zig/pkg/antfly/src/api/runtime_status.zig
@@ -751,7 +751,50 @@ fn cloneAlgebraicProgressStatuses(
     return out;
 }
 
+fn cloneResolverReplayDiagnostics(alloc: std.mem.Allocator, stats: db_mod.types.ResolverReplayDiagnostics) !db_mod.types.ResolverReplayDiagnostics {
+    var resolvers = try alloc.alloc(db_mod.types.ResolverReplayDiagnostic, stats.resolvers.len);
+    var initialized: usize = 0;
+    errdefer {
+        for (resolvers[0..initialized]) |resolver| {
+            alloc.free(resolver.name);
+            alloc.free(resolver.table);
+            alloc.free(resolver.source_artifact);
+            alloc.free(resolver.resolution_artifact);
+        }
+        if (resolvers.len > 0) alloc.free(resolvers);
+    }
+
+    for (stats.resolvers, 0..) |resolver, i| {
+        const name = try alloc.dupe(u8, resolver.name);
+        errdefer alloc.free(name);
+        const table = try alloc.dupe(u8, resolver.table);
+        errdefer alloc.free(table);
+        const source_artifact = try alloc.dupe(u8, resolver.source_artifact);
+        errdefer alloc.free(source_artifact);
+        const resolution_artifact = try alloc.dupe(u8, resolver.resolution_artifact);
+        errdefer alloc.free(resolution_artifact);
+        resolvers[i] = .{
+            .name = name,
+            .table = table,
+            .source_artifact = source_artifact,
+            .resolution_artifact = resolution_artifact,
+        };
+        initialized += 1;
+    }
+
+    return .{
+        .resolver_count = stats.resolver_count,
+        .resolution_runtime_present = stats.resolution_runtime_present,
+        .resolution_worker_started = stats.resolution_worker_started,
+        .promotion_runtime_present = stats.promotion_runtime_present,
+        .promotion_worker_started = stats.promotion_worker_started,
+        .resolvers = resolvers,
+    };
+}
+
 pub fn cloneDBStats(alloc: std.mem.Allocator, stats: db_mod.types.DBStats) !db_mod.types.DBStats {
+    const resolver_replay = try cloneResolverReplayDiagnostics(alloc, stats.resolver_replay);
+    errdefer db_mod.types.freeResolverReplayDiagnostics(alloc, resolver_replay);
     const indexes = try alloc.alloc(db_mod.types.DBIndexStats, stats.indexes.len);
     var initialized: usize = 0;
     errdefer {
@@ -971,6 +1014,9 @@ pub fn cloneDBStats(alloc: std.mem.Allocator, stats: db_mod.types.DBStats) !db_m
         .doc_identity = stats.doc_identity,
         .doc_set_planning = stats.doc_set_planning,
         .enrichment = stats.enrichment,
+        .resolution = stats.resolution,
+        .promotion = stats.promotion,
+        .resolver_replay = resolver_replay,
         .ttl_cleanup = stats.ttl_cleanup,
         .transaction_recovery = stats.transaction_recovery,
         .text_merge = stats.text_merge,

--- a/zig/pkg/antfly/src/storage/db/db.zig
+++ b/zig/pkg/antfly/src/storage/db/db.zig
@@ -6737,6 +6737,48 @@ pub const DB = struct {
         return self.persistedReplayStageStats(promotion_runtime_mod.scope_name, false) catch .{};
     }
 
+    fn resolverReplayDiagnosticsLocked(self: *DB, alloc: Allocator) !types.ResolverReplayDiagnostics {
+        const catalog = self.core.index_manager.resolvers.items;
+        var resolvers = try alloc.alloc(types.ResolverReplayDiagnostic, catalog.len);
+        var initialized: usize = 0;
+        errdefer {
+            for (resolvers[0..initialized]) |resolver| {
+                alloc.free(resolver.name);
+                alloc.free(resolver.table);
+                alloc.free(resolver.source_artifact);
+                alloc.free(resolver.resolution_artifact);
+            }
+            if (resolvers.len > 0) alloc.free(resolvers);
+        }
+
+        for (catalog) |cfg| {
+            const name = try alloc.dupe(u8, cfg.name);
+            errdefer alloc.free(name);
+            const table = try alloc.dupe(u8, cfg.table);
+            errdefer alloc.free(table);
+            const source_artifact = try alloc.dupe(u8, cfg.source_artifact);
+            errdefer alloc.free(source_artifact);
+            const resolution_artifact = try alloc.dupe(u8, cfg.resolution_artifact);
+            errdefer alloc.free(resolution_artifact);
+            resolvers[initialized] = .{
+                .name = name,
+                .table = table,
+                .source_artifact = source_artifact,
+                .resolution_artifact = resolution_artifact,
+            };
+            initialized += 1;
+        }
+
+        return .{
+            .resolver_count = @intCast(catalog.len),
+            .resolution_runtime_present = self.resolution_runtime != null,
+            .resolution_worker_started = if (self.resolution_runtime) |runtime| runtime.worker_started.load(.acquire) else false,
+            .promotion_runtime_present = self.promotion_runtime != null,
+            .promotion_worker_started = if (self.promotion_runtime) |runtime| runtime.worker_started.load(.acquire) else false,
+            .resolvers = resolvers[0..initialized],
+        };
+    }
+
     fn persistedEnrichmentStats(self: *DB) !types.EnrichmentStats {
         if (!self.core.hasGeneratedEnrichmentTargets()) return .{};
         const resources = self.core.batchExecutionResources();
@@ -8572,6 +8614,7 @@ pub const DB = struct {
             .enrichment = if (self.enrichment_runtime) |runtime| runtime.stats() else .{},
             .resolution = self.resolutionStageStats(),
             .promotion = self.promotionStageStats(),
+            .resolver_replay = try self.resolverReplayDiagnosticsLocked(alloc),
             .ttl_cleanup = if (self.ttl_runtime) |runtime| runtime.stats() else .{},
             .transaction_recovery = if (self.transaction_runtime) |runtime| runtime.stats() else .{},
             .text_merge = if (self.text_merge_runtime) |runtime| runtime.statsAssumeApplyLockHeld() else self.core.index_manager.textMergeStatsSnapshot(),
@@ -8740,6 +8783,7 @@ pub const DB = struct {
             .enrichment = if (self.enrichment_runtime) |runtime| runtime.stats() else try self.persistedEnrichmentStats(),
             .resolution = self.resolutionStageStats(),
             .promotion = self.promotionStageStats(),
+            .resolver_replay = try self.resolverReplayDiagnosticsLocked(alloc),
             .ttl_cleanup = if (self.ttl_runtime) |runtime| runtime.stats() else .{},
             .transaction_recovery = if (self.transaction_runtime) |runtime| runtime.stats() else .{},
             .text_merge = if (self.text_merge_runtime) |runtime| runtime.statsAssumeApplyLockHeld() else self.core.index_manager.textMergeStats(),
@@ -8825,6 +8869,7 @@ pub const DB = struct {
             .doc_set_planning = self.snapshotDocSetPlanningStats(),
             .resolution = self.resolutionStageStats(),
             .promotion = self.promotionStageStats(),
+            .resolver_replay = try self.resolverReplayDiagnosticsLocked(alloc),
             .async_indexing = self.async_context.stats.snapshot(),
         };
     }

--- a/zig/pkg/antfly/src/storage/db/types.zig
+++ b/zig/pkg/antfly/src/storage/db/types.zig
@@ -1238,6 +1238,22 @@ pub const ReplayStageStats = struct {
     error_count: u64 = 0,
 };
 
+pub const ResolverReplayDiagnostic = struct {
+    name: []const u8 = "",
+    table: []const u8 = "",
+    source_artifact: []const u8 = "",
+    resolution_artifact: []const u8 = "",
+};
+
+pub const ResolverReplayDiagnostics = struct {
+    resolver_count: u64 = 0,
+    resolution_runtime_present: bool = false,
+    resolution_worker_started: bool = false,
+    promotion_runtime_present: bool = false,
+    promotion_worker_started: bool = false,
+    resolvers: []const ResolverReplayDiagnostic = &.{},
+};
+
 pub const TransactionRecoveryStats = struct {
     enabled: bool = false,
     lease_owned: bool = false,
@@ -1370,6 +1386,7 @@ pub const DBStats = struct {
     enrichment: EnrichmentStats = .{},
     resolution: ReplayStageStats = .{},
     promotion: ReplayStageStats = .{},
+    resolver_replay: ResolverReplayDiagnostics = .{},
     ttl_cleanup: TTLCleanupStats = .{},
     transaction_recovery: TransactionRecoveryStats = .{},
     text_merge: TextMergeStats = .{},
@@ -1902,7 +1919,18 @@ pub fn accumulateAsyncIndexingStats(dst: *AsyncIndexingStats, src: AsyncIndexing
     dst.bulk_coalescing.flushed_keys += src.bulk_coalescing.flushed_keys;
 }
 
+pub fn freeResolverReplayDiagnostics(alloc: Allocator, stats: ResolverReplayDiagnostics) void {
+    for (stats.resolvers) |resolver| {
+        alloc.free(resolver.name);
+        alloc.free(resolver.table);
+        alloc.free(resolver.source_artifact);
+        alloc.free(resolver.resolution_artifact);
+    }
+    if (stats.resolvers.len > 0) alloc.free(stats.resolvers);
+}
+
 pub fn freeDBStats(alloc: Allocator, stats: DBStats) void {
+    freeResolverReplayDiagnostics(alloc, stats.resolver_replay);
     for (stats.indexes) |item| {
         alloc.free(item.name);
         if (item.algebraic_last_error_doc_key) |value| alloc.free(value);


### PR DESCRIPTION
## Summary
- add resolver replay catalog/runtime diagnostics to DB runtime stats
- surface resolver replay diagnostics in graph index status and shard status
- preserve top-level resolution/promotion and resolver replay stats when cloning runtime status snapshots

## Verification
- zig build lib-resolution-source-test
- zig build root-test