### PR TITLE
Zig query perf: live-doc visibility, search effort policy, stale payload repair

### DIFF
--- a/zig/build.zig
+++ b/zig/build.zig
@@ -2807,6 +2807,7 @@ pub fn build(b: *std.Build) void {
         "data runtime structural changes preserve writer-published runtime status",
         "data runtime startup catch-up prefers cached admin snapshot",
         "data runtime provisioned root refresh spawn failure preserves retry bookkeeping",
+        "data runtime background maintenance is due for dense posting cadence without lsm debt",
         "data runtime local split fallback preserves source identity namespace",
         "data runtime local merge fallback derives receiver identity namespace from catalog",
         "data public API listener uses public API request body limit",

--- a/zig/lib/vectorindex/src/hbc_index.zig
+++ b/zig/lib/vectorindex/src/hbc_index.zig
@@ -2101,6 +2101,14 @@ fn scoreLeafMemberIds(
         }
     }
 
+    if (self.config.use_quantization) {
+        if (!leaf_has_fresh_stored_payload) {
+            profile.leaf_payload_stale += 1;
+        } else {
+            profile.leaf_payload_missing += 1;
+        }
+    }
+
     const fetch_member_ids = scratch.member_ids[0..member_ids.len];
     var fetch_count: usize = 0;
     for (member_ids) |member_id| {

--- a/zig/lib/vectorindex/src/hbc_index.zig
+++ b/zig/lib/vectorindex/src/hbc_index.zig
@@ -1704,7 +1704,7 @@ pub fn searchProfiledRequest(
     };
     const search_width = req.search_width orelse self.config.search_width;
     const epsilon = req.epsilon orelse self.config.epsilon;
-    const rerank_factor: usize = search_mod.rerankFactor(epsilon);
+    const rerank_factor: usize = req.rerank_factor orelse search_mod.rerankFactor(epsilon);
     const should_rerank = self.config.use_quantization and self.config.rerank_policy != .never;
     const candidate_limit: usize = if (should_rerank) req.k * rerank_factor else req.k;
     const candidate_capacity: usize = search_mod.candidateCapacity(search_width, self.metadata.branching_factor);

--- a/zig/lib/vectorindex/src/search_types.zig
+++ b/zig/lib/vectorindex/src/search_types.zig
@@ -75,6 +75,10 @@ pub const SearchProfile = struct {
     approx_leaves_scored: u64 = 0,
     approx_vectors_scored: u64 = 0,
     exact_vectors_scored: u64 = 0,
+    // Leaves that fell back to exact member scoring because their quantized
+    // payload was stale (payload_dirty) or absent from storage.
+    leaf_payload_stale: u64 = 0,
+    leaf_payload_missing: u64 = 0,
     reranked_vectors: u64 = 0,
     approx_candidate_count: u64 = 0,
     rerank_candidate_count: u64 = 0,

--- a/zig/lib/vectorindex/src/search_types.zig
+++ b/zig/lib/vectorindex/src/search_types.zig
@@ -26,6 +26,9 @@ pub const SearchRequest = struct {
     rerank_k: ?usize = null,
     search_width: ?u32 = null,
     epsilon: ?f32 = null,
+    // Multiplier on k for how many approximate candidates are retained for
+    // exact reranking. Defaults to the epsilon-derived legacy factor.
+    rerank_factor: ?usize = null,
     load_metadata: bool = true,
     filter_prefix: []const u8 = "",
     distance_over: ?f32 = null,

--- a/zig/pkg/antfly/src/api/table_writes.zig
+++ b/zig/pkg/antfly/src/api/table_writes.zig
@@ -4084,6 +4084,34 @@ pub const ProvisionedTableWriteSource = struct {
         return progressed;
     }
 
+    pub fn runDensePostingMaintenanceRoundBestEffort(self: *ProvisionedTableWriteSource) !usize {
+        if (!self.local_db_mutex.tryLock()) return 0;
+        var leases = std.ArrayListUnmanaged(ProvisionedTableWriteCache.CachedDb).empty;
+        var lease_alloc: std.mem.Allocator = std.heap.page_allocator;
+        {
+            defer self.local_db_mutex.unlock();
+            const cache = self.write_cache orelse return 0;
+            lease_alloc = cache.alloc;
+            for (cache.entries.items) |entry| {
+                if (entry.bulk_ingest_session_open) continue;
+                if (entry.db.hasActiveDenseBulkWork()) continue;
+                try leases.append(lease_alloc, cache.leaseEntryLocked(entry));
+            }
+        }
+        defer {
+            for (leases.items) |*lease| lease.deinit(lease_alloc);
+            leases.deinit(lease_alloc);
+        }
+        var total_steps: usize = 0;
+        for (leases.items) |lease| {
+            total_steps += lease.db.runDensePostingMaintenanceForIdle() catch |err| blk: {
+                std.log.warn("dense posting maintenance round failed: {}", .{err});
+                break :blk 0;
+            };
+        }
+        return total_steps;
+    }
+
     pub fn finishExpiredAutoBulkIngestBestEffort(self: *ProvisionedTableWriteSource) bool {
         return self.tryFinishExpiredAutoBulkIngest() orelse false;
     }

--- a/zig/pkg/antfly/src/data/runtime.zig
+++ b/zig/pkg/antfly/src/data/runtime.zig
@@ -1743,12 +1743,18 @@ pub const DataServer = struct {
     lsm_maintenance_lock_deferred: std.atomic.Value(u64) = .init(0),
     lsm_maintenance_next_eligible_ns: std.atomic.Value(u64) = .init(0),
     lsm_maintenance_obsolete_reclaim_due_ns: std.atomic.Value(u64) = .init(0),
+    dense_posting_maintenance_next_eligible_ns: std.atomic.Value(u64) = .init(0),
 
     const lsm_maintenance_worker_idle_sleep_ns = 250 * std.time.ns_per_ms;
     const lsm_maintenance_worker_retry_sleep_ns = 100 * std.time.ns_per_ms;
     const lsm_maintenance_worker_bulk_defer_ns = 500 * std.time.ns_per_ms;
     const lsm_maintenance_worker_pressure_defer_ns = 500 * std.time.ns_per_ms;
     const lsm_maintenance_worker_max_steps_per_wake = 8;
+    // Dense posting repair is time-driven rather than score-driven: checking
+    // the backlog requires a posting-state scan, so the worker probes on a
+    // fixed cadence and retries quickly only while repairs are landing.
+    const dense_posting_maintenance_idle_interval_ns = 30 * std.time.ns_per_s;
+    const dense_posting_maintenance_retry_interval_ns = 1 * std.time.ns_per_s;
 
     const ProvisionedWarmupStats = struct {
         warmed_group_count: u64 = 0,
@@ -2235,25 +2241,36 @@ pub const DataServer = struct {
             _ = self.lsm_maintenance_capacity_denied.fetchAdd(1, .monotonic);
             return;
         }
-        if (self.write_source.lsmMaintenanceScoreBestEffort() == 0) {
-            const obsolete_due_ns = self.lsm_maintenance_obsolete_reclaim_due_ns.load(.monotonic);
-            if (obsolete_due_ns != 0 and now_ns < obsolete_due_ns) return;
-            if (self.write_source.nextLsmMaintenanceWakeDelayNsBestEffort()) |delay_ns| {
-                if (delay_ns > 0) {
-                    self.deferLsmObsoleteReclaim(now_ns, delay_ns);
-                    return;
-                }
-            } else {
-                self.lsm_maintenance_obsolete_reclaim_due_ns.store(0, .release);
-                return;
-            }
-        }
-        self.lsm_maintenance_obsolete_reclaim_due_ns.store(0, .release);
+        if (!self.backgroundMaintenanceDue(now_ns)) return;
         self.lsm_maintenance_wake.store(true, .release);
         if (self.lsm_maintenance_thread == null) {
             self.lsm_maintenance_stop.store(false, .release);
             self.lsm_maintenance_thread = try std.Thread.spawn(.{}, lsmMaintenanceWorkerMain, .{self});
         }
+    }
+
+    fn densePostingMaintenanceDue(self: *DataServer, now_ns: u64) bool {
+        return now_ns >= self.dense_posting_maintenance_next_eligible_ns.load(.monotonic);
+    }
+
+    fn backgroundMaintenanceDue(self: *DataServer, now_ns: u64) bool {
+        if (self.write_source.lsmMaintenanceScoreBestEffort() > 0) {
+            self.lsm_maintenance_obsolete_reclaim_due_ns.store(0, .release);
+            return true;
+        }
+        if (self.densePostingMaintenanceDue(now_ns)) return true;
+        const obsolete_due_ns = self.lsm_maintenance_obsolete_reclaim_due_ns.load(.monotonic);
+        if (obsolete_due_ns != 0 and now_ns < obsolete_due_ns) return false;
+        if (self.write_source.nextLsmMaintenanceWakeDelayNsBestEffort()) |delay_ns| {
+            if (delay_ns > 0) {
+                self.deferLsmObsoleteReclaim(now_ns, delay_ns);
+                return false;
+            }
+            self.lsm_maintenance_obsolete_reclaim_due_ns.store(0, .release);
+            return true;
+        }
+        self.lsm_maintenance_obsolete_reclaim_due_ns.store(0, .release);
+        return false;
     }
 
     fn stopLsmMaintenanceBackground(self: *DataServer) void {
@@ -2290,27 +2307,10 @@ pub const DataServer = struct {
                 sleepLsmMaintenanceWorker();
                 continue;
             }
-            if (!woke) {
-                const obsolete_due_ns = self.lsm_maintenance_obsolete_reclaim_due_ns.load(.monotonic);
-                if (obsolete_due_ns != 0 and now_ns < obsolete_due_ns) {
-                    sleepLsmMaintenanceWorker();
-                    continue;
-                }
+            if (!woke and !self.backgroundMaintenanceDue(now_ns)) {
+                sleepLsmMaintenanceWorker();
+                continue;
             }
-            if (!woke and self.write_source.lsmMaintenanceScoreBestEffort() == 0) {
-                if (self.write_source.nextLsmMaintenanceWakeDelayNsBestEffort()) |delay_ns| {
-                    if (delay_ns > 0) {
-                        self.deferLsmObsoleteReclaim(now_ns, delay_ns);
-                        sleepLsmMaintenanceWorker();
-                        continue;
-                    }
-                } else {
-                    self.lsm_maintenance_obsolete_reclaim_due_ns.store(0, .release);
-                    sleepLsmMaintenanceWorker();
-                    continue;
-                }
-            }
-            self.lsm_maintenance_obsolete_reclaim_due_ns.store(0, .release);
             if (self.resourcePressureDefersBackgroundMaintenance()) {
                 self.deferLsmMaintenance(now_ns, lsm_maintenance_worker_pressure_defer_ns);
                 _ = self.lsm_maintenance_capacity_denied.fetchAdd(1, .monotonic);
@@ -2366,9 +2366,17 @@ pub const DataServer = struct {
             // (deferred splits), which forces exact member scoring on every
             // query that visits them. Drain a bounded amount of that repair
             // work alongside the regular LSM maintenance.
-            const posting_steps = self.write_source.runDensePostingMaintenanceRoundBestEffort() catch 0;
-            if (posting_steps > 0) {
-                std.log.info("dense posting maintenance repaired steps={d}", .{posting_steps});
+            const posting_now_ns = platform_time.monotonicNs();
+            if (self.densePostingMaintenanceDue(posting_now_ns)) {
+                const posting_steps = self.write_source.runDensePostingMaintenanceRoundBestEffort() catch 0;
+                const next_delay_ns: u64 = if (posting_steps > 0)
+                    dense_posting_maintenance_retry_interval_ns
+                else
+                    dense_posting_maintenance_idle_interval_ns;
+                self.dense_posting_maintenance_next_eligible_ns.store(posting_now_ns +| next_delay_ns, .release);
+                if (posting_steps > 0) {
+                    std.log.info("dense posting maintenance repaired steps={d}", .{posting_steps});
+                }
             }
             self.lsm_maintenance_active.store(false, .release);
         }
@@ -13237,4 +13245,49 @@ test "data runtime lsm maintenance scheduler defers under resource pressure" {
     var reservation = try server.provisioned_storage.resource_manager.reserve(.lsm_compaction_work, 769 * 1024 * 1024);
     defer reservation.release();
     try std.testing.expect(server.resourcePressureDefersBackgroundMaintenance());
+}
+
+test "data runtime background maintenance is due for dense posting cadence without lsm debt" {
+    const alloc = std.testing.allocator;
+
+    const FakeCatalog = struct {
+        fn iface() antfly.public_api.table_catalog.CatalogSource {
+            return .{
+                .ptr = undefined,
+                .vtable = &.{
+                    .admin_snapshot = adminSnapshot,
+                    .free_admin_snapshot = freeAdminSnapshot,
+                },
+            };
+        }
+
+        fn adminSnapshot(_: *anyopaque) !antfly.metadata_api.AdminSnapshot {
+            return error.UnexpectedCatalogCall;
+        }
+
+        fn freeAdminSnapshot(_: *anyopaque, _: *antfly.metadata_api.AdminSnapshot) void {}
+    };
+
+    var server: DataServer = .{
+        .alloc = alloc,
+        .provisioned_storage = antfly.public_api.ProvisionedGroupStorage.init(alloc),
+        .read_source = antfly.public_api.ProvisionedTableReadSource.init(
+            "/tmp/unused-antfly-data-runtime-dense-posting-maintenance",
+            FakeCatalog.iface(),
+            antfly.raft.read_gate.noopReadableLeaseRequester(),
+        ),
+        .write_source = antfly.public_api.ProvisionedTableWriteSource.init("/tmp/unused-antfly-data-runtime-dense-posting-maintenance", FakeCatalog.iface()),
+        .status_source = undefined,
+        .api_server_cfg = undefined,
+        .query_async_limit = .limited(8),
+        .listener_cfg = undefined,
+    };
+    defer server.deinit();
+
+    try std.testing.expectEqual(@as(u64, 0), server.write_source.lsmMaintenanceScoreBestEffort());
+
+    server.dense_posting_maintenance_next_eligible_ns.store(100, .release);
+    try std.testing.expect(server.backgroundMaintenanceDue(100));
+    try std.testing.expect(server.backgroundMaintenanceDue(101));
+    try std.testing.expect(!server.backgroundMaintenanceDue(99));
 }

--- a/zig/pkg/antfly/src/data/runtime.zig
+++ b/zig/pkg/antfly/src/data/runtime.zig
@@ -2362,6 +2362,14 @@ pub const DataServer = struct {
                 }
             }
             if (completed) _ = self.lsm_maintenance_completed.fetchAdd(1, .monotonic);
+            // Bulk loads can leave leaf postings with stale quantized payloads
+            // (deferred splits), which forces exact member scoring on every
+            // query that visits them. Drain a bounded amount of that repair
+            // work alongside the regular LSM maintenance.
+            const posting_steps = self.write_source.runDensePostingMaintenanceRoundBestEffort() catch 0;
+            if (posting_steps > 0) {
+                std.log.info("dense posting maintenance repaired steps={d}", .{posting_steps});
+            }
             self.lsm_maintenance_active.store(false, .release);
         }
         self.lsm_maintenance_active.store(false, .release);

--- a/zig/pkg/antfly/src/storage/db/db.zig
+++ b/zig/pkg/antfly/src/storage/db/db.zig
@@ -29337,9 +29337,9 @@ test "db preflightSearchRequest validates live lane bindings" {
     try std.testing.expectEqual(@as(u32, 1), dense_summary.shard_count);
     try std.testing.expectEqual(@as(u32, 1), dense_summary.dense_query_count);
     try std.testing.expectEqual(@as(u64, 10), dense_summary.dense_effective_k_total);
-    try std.testing.expect(dense_summary.dense_search_width_total >= dense_summary.dense_effective_k_total);
-    try std.testing.expect(dense_summary.dense_search_width_max >= 64);
-    try std.testing.expect(dense_summary.dense_epsilon_max >= 1.0);
+    try std.testing.expect(dense_summary.dense_search_width_total >= 1);
+    try std.testing.expect(dense_summary.dense_search_width_max >= 1);
+    try std.testing.expect(dense_summary.dense_epsilon_max > 0.0);
     try std.testing.expectEqual(@as(usize, 1), dense_summary.embedding_indexes.len);
     try std.testing.expectEqualStrings("dv_v1", dense_summary.embedding_indexes[0].name);
     try std.testing.expectEqual(@as(u32, 3), dense_summary.embedding_indexes[0].dims);

--- a/zig/pkg/antfly/src/storage/db/db.zig
+++ b/zig/pkg/antfly/src/storage/db/db.zig
@@ -2369,6 +2369,14 @@ pub const DB = struct {
     bulk_ingest_identity_all_new: bool = false,
     bulk_ingest_identity_state: doc_identity.AllNewTrustedState = .{},
     identity_visibility_summary_cache: ?doc_identity.VisibilitySummary = null,
+    // Memoizes the resolved live-doc set for broad (.all) live filtering at a
+    // single identity read generation. Visibility at a fixed generation is
+    // stable, so the entry only turns over when queries arrive at a newer
+    // generation. Guarded by its own mutex because published-path queries do
+    // not hold the apply lock.
+    live_doc_set_cache_mutex: std.atomic.Mutex = .unlocked,
+    live_doc_set_cache_generation: ?u64 = null,
+    live_doc_set_cache_set: ?doc_set.ResolvedDocSet = null,
     bulk_ingest_seen_doc_keys: std.StringHashMapUnmanaged(void) = .{},
     doc_set_planning_stats: DocSetPlanningRuntimeStats = .{},
 
@@ -2998,6 +3006,11 @@ pub const DB = struct {
         // stopping. That must not call back into the write/status cache after
         // optional runtimes or index state have started tearing down.
         self.setQueryVisibilityHook(null);
+        if (self.live_doc_set_cache_set) |*cached| {
+            cached.deinit(self.alloc);
+            self.live_doc_set_cache_set = null;
+            self.live_doc_set_cache_generation = null;
+        }
         self.bulk_ingest_coalescer.deinit(self.alloc);
         self.clearBulkIngestSeenDocKeysLocked();
         self.bulk_ingest_seen_doc_keys.deinit(self.alloc);
@@ -10113,9 +10126,37 @@ pub const DB = struct {
             return try doc_set.cloneAlloc(alloc, set);
         }
         if (set.* == .all) {
-            return try doc_identity.visibleFilteredDocSetFromStoreAlloc(alloc, self.core.store, set, generation);
+            return try self.broadLiveDocSetCachedAlloc(alloc, generation);
         }
         return try doc_identity.visibleFilteredDocSetFromStoreAlloc(alloc, self.core.store, set, generation);
+    }
+
+    fn broadLiveDocSetCachedAlloc(self: *DB, alloc: Allocator, generation: ?u64) !doc_set.ResolvedDocSet {
+        const all_set: doc_set.ResolvedDocSet = .all;
+        const gen = generation orelse {
+            return try doc_identity.visibleFilteredDocSetFromStoreAlloc(alloc, self.core.store, &all_set, generation);
+        };
+        {
+            lockAtomic(&self.live_doc_set_cache_mutex);
+            defer self.live_doc_set_cache_mutex.unlock();
+            if (self.live_doc_set_cache_generation == gen) {
+                if (self.live_doc_set_cache_set) |*cached| {
+                    return try doc_set.cloneAlloc(alloc, cached);
+                }
+            }
+        }
+        var computed = try doc_identity.visibleFilteredDocSetFromStoreAlloc(alloc, self.core.store, &all_set, generation);
+        errdefer computed.deinit(alloc);
+        if (doc_set.cloneAlloc(self.alloc, &computed)) |cloned| {
+            lockAtomic(&self.live_doc_set_cache_mutex);
+            defer self.live_doc_set_cache_mutex.unlock();
+            if (self.live_doc_set_cache_set) |*old| old.deinit(self.alloc);
+            self.live_doc_set_cache_set = cloned;
+            self.live_doc_set_cache_generation = gen;
+        } else |_| {
+            // Caching is best-effort; the computed set is still returned.
+        }
+        return computed;
     }
 
     fn allDocsVisibleCallback(
@@ -10148,7 +10189,10 @@ pub const DB = struct {
                     .{ (platform_time.monotonicNs() - total_start_ns) / 1000, summary_ns / 1000, stats_ns / 1000, all_visible },
                 );
             }
-            if (all_visible) return true;
+            // The summary is definitive in both directions: it tracks tombstone
+            // counts and the max created generation, the same fields the full
+            // identity scan below would recompute.
+            return all_visible;
         }
         if (bench_profile) summary_ns = platform_time.monotonicNs() - summary_start_ns;
         const stats_start_ns = if (bench_profile) platform_time.monotonicNs() else 0;

--- a/zig/pkg/antfly/src/storage/db/doc_identity.zig
+++ b/zig/pkg/antfly/src/storage/db/doc_identity.zig
@@ -645,46 +645,92 @@ pub fn visiblePrimaryDocSetIfCompleteFromStoreAlloc(
     store: *docstore_mod.DocStore,
     generation: ?u64,
 ) !?doc_set.ResolvedDocSet {
-    const State = struct {
-        alloc: Allocator,
-        doc_ids: std.ArrayListUnmanaged([]u8) = .empty,
+    // Three bulk range scans joined through hash maps instead of two LSM point
+    // lookups per document. Intermediate state lives in one arena.
+    var arena_state = std.heap.ArenaAllocator.init(alloc);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
 
-        fn deinit(self: *@This()) void {
-            for (self.doc_ids.items) |doc_id| self.alloc.free(doc_id);
-            self.doc_ids.deinit(self.alloc);
-            self.* = undefined;
+    const StatesScan = struct {
+        arena: Allocator,
+        states: std.AutoHashMapUnmanaged(DocOrdinal, OrdinalState) = .empty,
+
+        fn scanEntry(ctx: ?*anyopaque, key: []const u8, value: []const u8) anyerror!docstore_mod.DocStore.ScanAction {
+            const state: *@This() = @ptrCast(@alignCast(ctx orelse return error.InvalidArgument));
+            const ordinal = internal_keys.parseIdentityOrdinalKey(key, internal_keys.identity_ordinal_state_kind) orelse return .@"continue";
+            const ordinal_state = decodeOrdinalState(value) catch return .@"continue";
+            try state.states.put(state.arena, ordinal, ordinal_state);
+            return .@"continue";
         }
+    };
+    const state_lower = [_]u8{ internal_keys.identity_namespace, internal_keys.identity_ordinal_state_kind };
+    const state_upper = [_]u8{ internal_keys.identity_namespace, internal_keys.identity_ordinal_state_kind + 1 };
+    var states_scan = StatesScan{ .arena = arena };
+    try store.scanWithContext(state_lower[0..], state_upper[0..], .{}, &states_scan, StatesScan.scanEntry);
+
+    const OrdinalsScan = struct {
+        arena: Allocator,
+        ordinals_by_doc: std.StringHashMapUnmanaged(DocOrdinal) = .empty,
+
+        fn scanEntry(ctx: ?*anyopaque, key: []const u8, value: []const u8) anyerror!docstore_mod.DocStore.ScanAction {
+            const state: *@This() = @ptrCast(@alignCast(ctx orelse return error.InvalidArgument));
+            if (value.len != @sizeOf(u32)) return error.InvalidDocIdentity;
+            const ordinal = std.mem.readInt(u32, value[0..4], .big);
+            const doc_id = try parseIdentityDocToOrdinalKeyAlloc(state.arena, key);
+            try state.ordinals_by_doc.put(state.arena, doc_id, ordinal);
+            return .@"continue";
+        }
+    };
+    const doc_lower = [_]u8{ internal_keys.identity_namespace, internal_keys.identity_doc_to_ordinal_kind };
+    const doc_upper = [_]u8{ internal_keys.identity_namespace, internal_keys.identity_doc_to_ordinal_kind + 1 };
+    var ordinals_scan = OrdinalsScan{ .arena = arena };
+    try store.scanWithContext(doc_lower[0..], doc_upper[0..], .{}, &ordinals_scan, OrdinalsScan.scanEntry);
+
+    // Drive off the primary documents so the result keeps the original
+    // contract: only currently stored docs are included, and a stored doc with
+    // missing identity rows or one not visible at the requested generation
+    // makes the whole derivation inconclusive (null).
+    const PrimaryScan = struct {
+        arena: Allocator,
+        ordinals_by_doc: *const std.StringHashMapUnmanaged(DocOrdinal),
+        states: *const std.AutoHashMapUnmanaged(DocOrdinal, OrdinalState),
+        generation: ?u64,
+        ordinals: std.ArrayListUnmanaged(DocOrdinal) = .empty,
+        inconclusive: bool = false,
 
         fn scanEntry(ctx: ?*anyopaque, key: []const u8, value: []const u8) anyerror!docstore_mod.DocStore.ScanAction {
             _ = value;
             const state: *@This() = @ptrCast(@alignCast(ctx orelse return error.InvalidArgument));
-            const doc_id = (try internal_keys.decodePrimaryDocumentKeyAlloc(state.alloc, key)) orelse return .@"continue";
-            errdefer state.alloc.free(doc_id);
-            try state.doc_ids.append(state.alloc, doc_id);
+            const doc_id = (try internal_keys.decodePrimaryDocumentKeyAlloc(state.arena, key)) orelse return .@"continue";
+            const ordinal = state.ordinals_by_doc.get(doc_id) orelse {
+                state.inconclusive = true;
+                return .stop;
+            };
+            const ordinal_state = state.states.get(ordinal) orelse {
+                state.inconclusive = true;
+                return .stop;
+            };
+            const visible = if (state.generation) |at| ordinal_state.isVisibleAt(at) else ordinal_state.isLive();
+            if (!visible) {
+                state.inconclusive = true;
+                return .stop;
+            }
+            try state.ordinals.append(state.arena, ordinal);
             return .@"continue";
         }
     };
-
     const lower = [_]u8{internal_keys.user_namespace};
     const upper = [_]u8{internal_keys.user_namespace + 1};
-    var state = State{ .alloc = alloc };
-    defer state.deinit();
-    try store.scanWithContext(lower[0..], upper[0..], .{}, &state, State.scanEntry);
+    var primary_scan = PrimaryScan{
+        .arena = arena,
+        .ordinals_by_doc = &ordinals_scan.ordinals_by_doc,
+        .states = &states_scan.states,
+        .generation = generation,
+    };
+    try store.scanWithContext(lower[0..], upper[0..], .{}, &primary_scan, PrimaryScan.scanEntry);
+    if (primary_scan.inconclusive) return null;
 
-    var txn = try store.beginProbeTxn();
-    defer txn.abort();
-
-    var ordinals = std.ArrayListUnmanaged(DocOrdinal).empty;
-    defer ordinals.deinit(alloc);
-    for (state.doc_ids.items) |doc_id| {
-        const ordinal = (try lookupOrdinalTxn(alloc, &txn, doc_id)) orelse return null;
-        const ordinal_state = (try lookupStateTxn(&txn, ordinal)) orelse return null;
-        const visible = if (generation) |at| ordinal_state.isVisibleAt(at) else ordinal_state.isLive();
-        if (!visible) return null;
-        try ordinals.append(alloc, ordinal);
-    }
-
-    return try doc_set.fromOrdinalsAlloc(alloc, ordinals.items);
+    return try doc_set.fromOrdinalsAlloc(alloc, primary_scan.ordinals.items);
 }
 
 const DocOrdinalRow = struct {

--- a/zig/pkg/antfly/src/storage/db/query/search_exec.zig
+++ b/zig/pkg/antfly/src/storage/db/query/search_exec.zig
@@ -4456,6 +4456,7 @@ fn searchDenseInternal(
         .rerank_k = if (full_candidate_window) @as(usize, @intCast(@min(paging.offset +| paging.limit, hbc_effective_k))) else null,
         .search_width = resolved_search_width,
         .epsilon = resolved_epsilon,
+        .rerank_factor = resolveRerankFactor(effort),
         .filter_prefix = req.filter_prefix,
         .distance_over = req.distance_over,
         .distance_under = req.distance_under,
@@ -4859,38 +4860,101 @@ fn estimateLeafCount(stats: vectorindex_mod.IndexStats) u32 {
     return @intCast(@min(estimated, @as(u64, std.math.maxInt(u32))));
 }
 
+// Search policy: effort 0..1 maps to a leaf-visit budget (search width), a
+// dynamic-pruning epsilon, and a rerank candidate multiplier. The width floor
+// scales with how many leaves are needed to cover k oversampled results, not
+// with k itself, and the ramp between floor and ceiling is geometric so the
+// knob behaves sensibly across index sizes. Epsilon stays small enough that
+// the SPANN-style "skip leaves whose centroid is (1+eps) x the best" pruning
+// actually fires. The constants can be overridden through environment
+// variables (read once per process) for offline tuning.
+const SearchPolicy = struct {
+    epsilon_base: f32 = 0.90,
+    epsilon_span: f32 = 1.10,
+    width_k_factor: f32 = 4.0,
+    width_min_leaves: u32 = 4,
+    // Fraction of the leaf ceiling visited at balanced (0.5) effort. On the
+    // 50K OpenAI case, recall at the default effort tracks this anchor; the
+    // current HBC tree needs most of its leaves for ~0.98 recall, so the
+    // default anchor sits high and the low-effort range is where the policy
+    // saves work.
+    width_mid_fraction: f32 = 0.70,
+    // Absolute ceiling on the balanced-effort anchor so the default leaf
+    // budget does not grow linearly with corpus size (matches the legacy
+    // behavior at the 1M scale; no effect at 50K-scale trees).
+    width_mid_cap: f32 = 2048.0,
+    rerank_factor_base: f32 = 6.0,
+    rerank_factor_span: f32 = 6.0,
+};
+
+var search_policy: SearchPolicy = .{};
+var search_policy_loaded = std.atomic.Value(bool).init(false);
+
+fn ensureSearchPolicyLoaded() void {
+    if (search_policy_loaded.load(.acquire)) return;
+    // Benign race: concurrent first callers recompute identical values from
+    // the environment before either publishes the flag.
+    loadSearchPolicyEnv();
+    search_policy_loaded.store(true, .release);
+}
+
+fn searchPolicyEnvF32(name: [*:0]const u8, default_value: f32) f32 {
+    const raw = getenv(name) orelse return default_value;
+    return std.fmt.parseFloat(f32, raw) catch default_value;
+}
+
+fn loadSearchPolicyEnv() void {
+    search_policy.epsilon_base = searchPolicyEnvF32("ANTFLY_SEARCH_EPSILON_BASE", search_policy.epsilon_base);
+    search_policy.epsilon_span = searchPolicyEnvF32("ANTFLY_SEARCH_EPSILON_SPAN", search_policy.epsilon_span);
+    search_policy.width_k_factor = searchPolicyEnvF32("ANTFLY_SEARCH_WIDTH_K_FACTOR", search_policy.width_k_factor);
+    search_policy.width_mid_fraction = searchPolicyEnvF32("ANTFLY_SEARCH_WIDTH_MID_FRACTION", search_policy.width_mid_fraction);
+    search_policy.width_mid_cap = searchPolicyEnvF32("ANTFLY_SEARCH_WIDTH_MID_CAP", search_policy.width_mid_cap);
+    search_policy.rerank_factor_base = searchPolicyEnvF32("ANTFLY_SEARCH_RERANK_BASE", search_policy.rerank_factor_base);
+    search_policy.rerank_factor_span = searchPolicyEnvF32("ANTFLY_SEARCH_RERANK_SPAN", search_policy.rerank_factor_span);
+}
+
 pub fn resolveSearchWidth(k: u32, effort: f32, stats: vectorindex_mod.IndexStats) u32 {
-    const min_width = @max(k, @as(u32, 64));
-    const legacy_max_width = @max(min_width * 20, @as(u32, 4096));
-    const legacy_balanced_width = min_width + @as(u32, @intFromFloat(@as(f32, @floatFromInt(legacy_max_width - min_width)) * default_balanced_search_effort));
+    ensureSearchPolicyLoaded();
+    const leaf_size = @max(stats.leaf_size, 1);
     const estimated_leaf_count = estimateLeafCount(stats);
+    const legacy_max_width = @max(@max(k, @as(u32, 64)) * 20, @as(u32, 4096));
     const max_width = if (estimated_leaf_count > 0)
-        @max(min_width, @max(estimated_leaf_count, if (stats.node_count > 0 and stats.node_count <= std.math.maxInt(u32)) @as(u32, @intCast(stats.node_count)) else estimated_leaf_count))
+        estimated_leaf_count
     else if (stats.node_count > legacy_max_width and stats.node_count <= std.math.maxInt(u32))
         @as(u32, @intCast(stats.node_count))
     else
         legacy_max_width;
-    const balanced_cap = if (estimated_leaf_count > 0) @max(min_width, estimated_leaf_count) else max_width;
-    const leaf_balanced_width = min_width + @as(u32, @intFromFloat(@as(f32, @floatFromInt(balanced_cap - min_width)) * default_balanced_search_effort));
-    const balanced_width = @min(legacy_balanced_width, leaf_balanced_width);
 
-    if (effort <= default_balanced_search_effort) {
-        if (balanced_width <= min_width) return min_width;
-        const ratio = effort / default_balanced_search_effort;
-        return min_width + @as(u32, @intFromFloat(@as(f32, @floatFromInt(balanced_width - min_width)) * ratio));
-    }
+    const k_leaves_u64 = std.math.divCeil(u64, @as(u64, @intFromFloat(@max(1.0, @ceil(@as(f32, @floatFromInt(k)) * search_policy.width_k_factor)))), leaf_size) catch 1;
+    const k_leaves: u32 = @intCast(@min(k_leaves_u64, @as(u64, std.math.maxInt(u32))));
+    const min_width = @min(max_width, @max(k_leaves, search_policy.width_min_leaves));
+    if (min_width >= max_width) return max_width;
+    if (effort <= 0) return min_width;
+    if (effort >= 1) return max_width;
 
-    if (max_width <= balanced_width) return max_width;
-    const ratio = (effort - default_balanced_search_effort) / (1 - default_balanced_search_effort);
-    const width = balanced_width + @as(u32, @intFromFloat(@as(f32, @floatFromInt(max_width - balanced_width)) * ratio));
-    return @min(width, max_width);
+    // Two geometric segments anchored at width_mid_fraction x ceiling for the
+    // balanced effort, so the default recall stays calibrated while the floor
+    // and the low-effort range scale with k instead of the corpus.
+    const min_f = @as(f32, @floatFromInt(min_width));
+    const max_f = @as(f32, @floatFromInt(max_width));
+    const mid_f = @min(@min(max_f, search_policy.width_mid_cap), @max(min_f, max_f * search_policy.width_mid_fraction));
+    const width_f = if (effort <= 0.5)
+        min_f * std.math.pow(f32, mid_f / min_f, effort * 2.0)
+    else
+        mid_f * std.math.pow(f32, max_f / mid_f, (effort - 0.5) * 2.0);
+    const width: u32 = @intFromFloat(@min(width_f, max_f));
+    return @max(min_width, @min(width, max_width));
 }
 
 pub fn resolveSearchEpsilon(effort: f32) f32 {
-    if (effort < default_balanced_search_effort) {
-        return 1.0 + (effort * 12.0);
-    }
-    return 7.0 + ((effort - default_balanced_search_effort) * 186.0);
+    ensureSearchPolicyLoaded();
+    return search_policy.epsilon_base + (effort * search_policy.epsilon_span);
+}
+
+pub fn resolveRerankFactor(effort: f32) usize {
+    ensureSearchPolicyLoaded();
+    const factor = search_policy.rerank_factor_base + (effort * search_policy.rerank_factor_span);
+    return @max(1, @as(usize, @intFromFloat(@round(factor))));
 }
 
 fn sparseHitParentOrdinal(
@@ -5874,24 +5938,41 @@ test "resolveSearchEffort maps effort to leaf-aware HBC width" {
     try std.testing.expectApproxEqAbs(@as(f32, default_balanced_search_effort), resolvedSearchEffort(null), 0.0001);
     try std.testing.expectApproxEqAbs(@as(f32, 0.5), resolvedSearchEffort(0.5), 0.0001);
 
-    try std.testing.expectEqual(@as(u32, 2080), resolveSearchWidth(10, default_balanced_search_effort, testIndexStats(0, 0, 128)));
-    try std.testing.expectEqual(@as(u32, 64), resolveSearchWidth(10, 0.0, testIndexStats(0, 0, 128)));
+    // Width floor scales with leaves needed for oversampled k, not with k.
+    try std.testing.expectEqual(@as(u32, 4), resolveSearchWidth(10, 0.0, testIndexStats(0, 0, 128)));
+    try std.testing.expectEqual(@as(u32, 16), resolveSearchWidth(500, 0.0, testIndexStats(0, 0, 128)));
+    // Effort 1.0 reaches the ceiling: all leaves when stats are known,
+    // node count or the legacy cap otherwise.
     try std.testing.expectEqual(@as(u32, 4096), resolveSearchWidth(10, 1.0, testIndexStats(0, 0, 128)));
     try std.testing.expectEqual(@as(u32, 17_591), resolveSearchWidth(10, 1.0, testIndexStats(0, 17_591, 128)));
-    try std.testing.expectEqual(@as(u32, 2080), resolveSearchWidth(10, default_balanced_search_effort, testIndexStats(0, 17_591, 128)));
-    try std.testing.expectEqual(@as(u32, 879), resolveSearchWidth(10, 1.0, testIndexStats(879, 879, 128)));
-    try std.testing.expectEqual(@as(u32, 500), resolveSearchWidth(500, 0.0, testIndexStats(0, 0, 128)));
+    try std.testing.expectEqual(@as(u32, 7), resolveSearchWidth(10, 1.0, testIndexStats(879, 879, 128)));
 
     try std.testing.expectEqual(@as(u32, 391), estimateLeafCount(testIndexStats(50_000, 879, 128)));
-    try std.testing.expectEqual(@as(u32, 161), resolveSearchWidth(10, 0.3, testIndexStats(50_000, 879, 128)));
-    try std.testing.expectEqual(@as(u32, 227), resolveSearchWidth(10, default_balanced_search_effort, testIndexStats(50_000, 879, 128)));
-    try std.testing.expectEqual(@as(u32, 879), resolveSearchWidth(10, 1.0, testIndexStats(50_000, 879, 128)));
-    try std.testing.expectEqual(@as(u32, 2080), resolveSearchWidth(10, default_balanced_search_effort, testIndexStats(1_000_000, 17_591, 128)));
-    try std.testing.expectEqual(@as(u32, 17_591), resolveSearchWidth(10, 1.0, testIndexStats(1_000_000, 17_591, 128)));
+    try std.testing.expectEqual(@as(u32, 391), resolveSearchWidth(10, 1.0, testIndexStats(50_000, 879, 128)));
 
-    try std.testing.expectApproxEqAbs(@as(f32, 1.0), resolveSearchEpsilon(0.0), 0.01);
-    try std.testing.expectApproxEqAbs(@as(f32, 7.0), resolveSearchEpsilon(default_balanced_search_effort), 0.01);
-    try std.testing.expectApproxEqAbs(@as(f32, 100.0), resolveSearchEpsilon(1.0), 0.01);
+    // The ramp is geometric on both sides of the balanced anchor, monotonic,
+    // and the balanced effort lands at the calibrated mid fraction (~50% of
+    // the leaf ceiling).
+    const w03 = resolveSearchWidth(10, 0.3, testIndexStats(50_000, 879, 128));
+    const w05 = resolveSearchWidth(10, default_balanced_search_effort, testIndexStats(50_000, 879, 128));
+    const w07 = resolveSearchWidth(10, 0.7, testIndexStats(50_000, 879, 128));
+    try std.testing.expect(4 < w03 and w03 < w05 and w05 < w07 and w07 < 391);
+    try std.testing.expect(w05 >= 391 * 3 / 5 and w05 <= 391 * 4 / 5);
+
+    // At large corpora the balanced anchor is capped instead of growing
+    // linearly with the leaf count, while effort 1.0 still reaches them all.
+    const w05_1m = resolveSearchWidth(10, default_balanced_search_effort, testIndexStats(1_000_000, 17_591, 128));
+    try std.testing.expect(w05_1m <= 2048);
+    try std.testing.expectEqual(@as(u32, 7813), resolveSearchWidth(10, 1.0, testIndexStats(1_000_000, 17_591, 128)));
+
+    // Epsilon ramps from mild pruning toward effectively unpruned.
+    try std.testing.expectApproxEqAbs(@as(f32, 0.90), resolveSearchEpsilon(0.0), 0.01);
+    try std.testing.expectApproxEqAbs(@as(f32, 1.45), resolveSearchEpsilon(default_balanced_search_effort), 0.01);
+    try std.testing.expectApproxEqAbs(@as(f32, 2.00), resolveSearchEpsilon(1.0), 0.01);
+
+    try std.testing.expectEqual(@as(usize, 6), resolveRerankFactor(0.0));
+    try std.testing.expectEqual(@as(usize, 9), resolveRerankFactor(default_balanced_search_effort));
+    try std.testing.expectEqual(@as(usize, 12), resolveRerankFactor(1.0));
 }
 
 test "multi_match bool_prefix index prefix uses trailing shingle window" {

--- a/zig/pkg/antfly/src/storage/db/query/search_exec.zig
+++ b/zig/pkg/antfly/src/storage/db/query/search_exec.zig
@@ -1955,8 +1955,13 @@ fn applyLiveAllDocFilterToNativeConstraintsAlloc(
     var owned_filter = filter;
     defer owned_filter.deinit(alloc);
 
+    // The include set came from the live filter itself; re-running the live
+    // filter over it would redo one visibility probe per document.
+    var already_filtered_executor = executor;
+    already_filtered_executor.live_filter_doc_set = null;
+
     const resolved_stored_filters_before_live_filter = out.resolved_stored_filters;
-    try applyResolvedDocFilterToNativeConstraintsAlloc(alloc, out, &owned_filter, executor);
+    try applyResolvedDocFilterToNativeConstraintsAlloc(alloc, out, &owned_filter, already_filtered_executor);
     out.resolved_stored_filters = resolved_stored_filters_before_live_filter;
 }
 

--- a/zig/pkg/antfly/src/storage/db/query/search_exec.zig
+++ b/zig/pkg/antfly/src/storage/db/query/search_exec.zig
@@ -367,6 +367,8 @@ pub const DenseSearchProfile = struct {
     hbc_leaves_explored: u64 = 0,
     hbc_approx_vectors_scored: u64 = 0,
     hbc_exact_vectors_scored: u64 = 0,
+    hbc_leaf_payload_stale: u64 = 0,
+    hbc_leaf_payload_missing: u64 = 0,
     hbc_reranked_vectors: u64 = 0,
     hbc_approx_candidate_count: u64 = 0,
     hbc_rerank_candidate_count: u64 = 0,
@@ -4487,6 +4489,8 @@ fn searchDenseInternal(
         profile.hbc_leaves_explored = profiled.profile.leaves_explored;
         profile.hbc_approx_vectors_scored = profiled.profile.approx_vectors_scored;
         profile.hbc_exact_vectors_scored = profiled.profile.exact_vectors_scored;
+        profile.hbc_leaf_payload_stale = profiled.profile.leaf_payload_stale;
+        profile.hbc_leaf_payload_missing = profiled.profile.leaf_payload_missing;
         profile.hbc_reranked_vectors = profiled.profile.reranked_vectors;
         profile.hbc_approx_candidate_count = profiled.profile.approx_candidate_count;
         profile.hbc_rerank_candidate_count = profiled.profile.rerank_candidate_count;
@@ -4787,13 +4791,15 @@ fn logBenchDenseQueryProfile(
         },
     );
     std.log.info(
-        "antfly_bench_dense_query_hbc index={s} nodes_visited={d} leaves={d} approx_vectors={d} exact_vectors={d} reranked={d} approx_candidates={d} rerank_candidates={d} ambiguous_top_k={d} ambiguous_boundary={d} distance_over_hits={d} distance_under_hits={d} full_rerank={any} top_k_count={d} min_distance_gap={d:.6} min_interval_gap={d:.6} rerank_vector_load_us={d} rerank_metadata_us={d} rerank_artifact_key_us={d} rerank_artifact_read_us={d} rerank_artifact_decode_us={d} rerank_artifact_distance_us={d} rerank_lsm_cache_hits={d} rerank_lsm_cache_misses={d} rerank_distance_us={d} inline_meta={d} fetched_meta={d} lookup_doc_key={d}",
+        "antfly_bench_dense_query_hbc index={s} nodes_visited={d} leaves={d} approx_vectors={d} exact_vectors={d} payload_stale={d} payload_missing={d} reranked={d} approx_candidates={d} rerank_candidates={d} ambiguous_top_k={d} ambiguous_boundary={d} distance_over_hits={d} distance_under_hits={d} full_rerank={any} top_k_count={d} min_distance_gap={d:.6} min_interval_gap={d:.6} rerank_vector_load_us={d} rerank_metadata_us={d} rerank_artifact_key_us={d} rerank_artifact_read_us={d} rerank_artifact_decode_us={d} rerank_artifact_distance_us={d} rerank_lsm_cache_hits={d} rerank_lsm_cache_misses={d} rerank_distance_us={d} inline_meta={d} fetched_meta={d} lookup_doc_key={d}",
         .{
             req.index_name orelse "",
             profile.hbc_nodes_visited,
             profile.hbc_leaves_explored,
             profile.hbc_approx_vectors_scored,
             profile.hbc_exact_vectors_scored,
+            profile.hbc_leaf_payload_stale,
+            profile.hbc_leaf_payload_missing,
             profile.hbc_reranked_vectors,
             profile.hbc_approx_candidate_count,
             profile.hbc_rerank_candidate_count,


### PR DESCRIPTION
> Three query-speed fixes for the Zig runtime, found while chasing down the antfly-circus nightly numbers. Each commit is independently revertible and carries its own measurements; everything below is from the 50K OpenAI vdbbench case (k=100, serial HTTP, M4 Max) and big-ann random-xs.
> 
> ## 1. Broad live-doc visibility derivation (`e9316d8`)
> 
> A single tombstone — or any doc created after the read generation — made every dense query materialize the full live-doc set: a primary-namespace scan plus **two LSM point lookups per document**, and then a second per-doc liveness probe when the derived include set was re-filtered through the live filter it had just come from. ~1.8s/query at 50K docs, scaling linearly with table size (the old benchmark client's insert+delete healthcheck probe tripped this on every nightly run).
> 
> - `doc_identity`: three bulk range scans joined through arena hash maps, same contracts (incomplete-identity fallback, per-generation visibility).
> - `db`: memoize the resolved set per identity read generation; trust the visibility summary verdict in both directions.
> - `search_exec`: don't re-apply the live filter to its own output.
> 
> **Tables with 1 or 500 tombstones: ~1.8s → ~5ms per query, recall unchanged (0.983).**
> 
> ## 2. Dense search effort policy (`c2df4ed`)
> 
> - Width floor was `max(k, 64)` *leaves* — a k=100 query scanned ≥100 leaves even at effort 0, and on a ~100-leaf index the effort knob was inert. Now `ceil(4k/leaf_size)`.
> - ε resolved to 7–100, so the `(1+ε)×best` leaf pruning could never fire. Now 0.9–2.0.
> - Rerank retention was `ceil(ε+1)×k` = 8×k at default and **101×k** at effort 1.0; retention saturates ~8×k. Now a decoupled `SearchRequest.rerank_factor` (6–12×k).
> - Width ramps geometrically through a calibrated balanced anchor (70% of the leaf ceiling, absolute cap 2048 leaves so the default budget stops growing linearly with corpus size). Constants are env-overridable (`ANTFLY_SEARCH_*`) for offline tuning.
> 
> **50K defaults: p99 9.1ms → 3.5ms, avg 4.2ms → 3.1ms, recall 0.981 → 0.983. big-ann random-xs: +16% QPS at iso-recall 0.984, +41% at effort 1.0, effort now spans recall 0.87–0.99.**
> 
> ## 3. Stale dense posting payload repair (`c6e83d5`)
> 
> Bulk loads leave ~23% of visited leaf postings with `payload_dirty` set (deferred bulk splits), and nothing in the swarm serving path ever ran posting maintenance — so those leaves fell back to exact member scoring **on every query, forever** (~4.7K raw vector loads + full-precision distances per query at 50K). The background LSM maintenance worker now drains a bounded posting-maintenance round per wake (leases cached DBs, skips active bulk sessions, default 64-postings budget). One tick after a load, queries report zero stale-payload leaves.
> 
> Also adds `leaf_payload_stale`/`leaf_payload_missing` to the search profile and dense bench log line, which is how this was found.
> 
> ## Testing
> 
> - `zig build db-test` (1918 tests), `lib-vectorindex-test`, `provisioned-query-visibility-test` — green on the final state and at each commit boundary's subsystem.
> - Policy unit tests rewritten for the new semantics (floor, geometric ramp + cap, ε range, rerank factors).
> - Bench validation included tombstone-bearing permutations (1 and 500 tombstones) specifically to guard the visibility fast path, plus effort sweeps for the recall/latency frontier.
> 
> Known follow-ups (not in this PR, documented in #devlogs > fable-antfly-yolo): index build quality (identical loads vary ±0.015 full-scan recall; the tree needs ~⅔ of its leaves for 0.98), SIMD for the per-leaf query quantization, per-request serving overhead (the ~2.5K QPS ceiling on tiny datasets).
> 