### PR TITLE
Make Gemma4 Metal tool calling production-ready

### DIFF
--- a/zig/pkg/inference/build.zig
+++ b/zig/pkg/inference/build.zig
@@ -333,6 +333,28 @@ pub fn build(b: *std.Build) void {
     );
     metal_gemma4_prefill_block_parity_test_step.dependOn(&metal_gemma4_prefill_block_parity_test.step);
 
+    const metal_gemma4_tool_calling_test = b.addSystemCommand(&.{
+        "bash",
+        "scripts/test_metal_gemma4_tool_calling.sh",
+    });
+    metal_gemma4_tool_calling_test.step.dependOn(b.getInstallStep());
+    const metal_gemma4_tool_calling_test_step = b.step(
+        "test-metal-gemma4-tool-calling",
+        "Run the local Metal Gemma4 server tool-calling smoke test",
+    );
+    metal_gemma4_tool_calling_test_step.dependOn(&metal_gemma4_tool_calling_test.step);
+
+    const metal_gemma4_cli_tool_calling_test = b.addSystemCommand(&.{
+        "bash",
+        "scripts/test_metal_gemma4_cli_tool_calling.sh",
+    });
+    metal_gemma4_cli_tool_calling_test.step.dependOn(b.getInstallStep());
+    const metal_gemma4_cli_tool_calling_test_step = b.step(
+        "test-metal-gemma4-cli-tool-calling",
+        "Run the local Metal Gemma4 CLI tool-calling smoke test",
+    );
+    metal_gemma4_cli_tool_calling_test_step.dependOn(&metal_gemma4_cli_tool_calling_test.step);
+
     const metal_prefill_bucket_bench_exe = b.addExecutable(.{
         .name = "antfly-inference-metal-prefill-buckets-bench",
         .root_module = b.createModule(.{

--- a/zig/pkg/inference/scripts/test_metal_gemma4_cli_tool_calling.sh
+++ b/zig/pkg/inference/scripts/test_metal_gemma4_cli_tool_calling.sh
@@ -83,10 +83,25 @@ run_antfly() {
 if ! run_antfly generate "$MODEL_DIR" "$PROMPT" \
   --backend metal \
   --max-tokens "$MAX_TOKENS" \
+  --print-timing \
   --tools "$TOOLS_JSON" \
   --tool-choice lookup_order \
   >"$RESPONSE_JSON" 2>"$STDERR_LOG"; then
   echo "CLI generate failed" >&2
+  echo "stderr: $STDERR_LOG" >&2
+  sed -n '1,220p' "$STDERR_LOG" >&2 || true
+  exit 1
+fi
+
+if ! grep -q 'live_whole_model_executor=true' "$STDERR_LOG"; then
+  echo "CLI generate did not report the live whole-model executor fast path" >&2
+  echo "stderr: $STDERR_LOG" >&2
+  sed -n '1,220p' "$STDERR_LOG" >&2 || true
+  exit 1
+fi
+
+if grep -q 'live_whole_model_executor_tool_fallback=true' "$STDERR_LOG"; then
+  echo "CLI generate fell back after the live whole-model executor fast path" >&2
   echo "stderr: $STDERR_LOG" >&2
   sed -n '1,220p' "$STDERR_LOG" >&2 || true
   exit 1

--- a/zig/pkg/inference/scripts/test_metal_gemma4_cli_tool_calling.sh
+++ b/zig/pkg/inference/scripts/test_metal_gemma4_cli_tool_calling.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# Copyright 2026 Antfly, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+PKG_DIR="$ROOT_DIR/pkg/inference"
+
+if [[ -z "${ANTFLY_BIN:-}" ]]; then
+  if [[ -x "$PKG_DIR/zig-out/bin/antfly-inference" ]]; then
+    ANTFLY_BIN="$PKG_DIR/zig-out/bin/antfly-inference"
+  else
+    ANTFLY_BIN="$PKG_DIR/zig-out/bin/antfly"
+  fi
+fi
+
+MODEL_DIR="${ANTFLY_INFERENCE_GEMMA4_MODEL:-$HOME/.antfly/inference/models/ggml-org/gemma-4-e2b-it-gguf}"
+PROMPT="${ANTFLY_INFERENCE_GEMMA4_TOOL_PROMPT:-Use the lookup_order tool for order_id A123. Return only the tool call.}"
+MAX_TOKENS="${ANTFLY_INFERENCE_GEMMA4_TOOL_MAX_TOKENS:-64}"
+OUT_DIR="${OUT_DIR:-/tmp/antfly-inference-metal-gemma4-cli-tool-calling-test}"
+
+if [[ ! -x "$ANTFLY_BIN" ]]; then
+  echo "antfly inference binary not executable: $ANTFLY_BIN" >&2
+  echo "build it first, for example: cd pkg/inference && zig build -Dmetal=true -Dmlx=false -Donnx=false -Dpjrt=false" >&2
+  exit 2
+fi
+
+if [[ ! -d "$MODEL_DIR" ]]; then
+  echo "Gemma4 model directory not found: $MODEL_DIR" >&2
+  echo "set ANTFLY_INFERENCE_GEMMA4_MODEL to the local GGUF model directory" >&2
+  exit 2
+fi
+
+mkdir -p "$OUT_DIR"
+TOOLS_JSON="$OUT_DIR/tools.json"
+RESPONSE_JSON="$OUT_DIR/response.json"
+STDERR_LOG="$OUT_DIR/stderr.log"
+
+cat >"$TOOLS_JSON" <<'JSON'
+[
+  {
+    "type": "function",
+    "function": {
+      "name": "lookup_order",
+      "description": "Look up the status of a customer order.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "order_id": {
+            "type": "string",
+            "description": "The order identifier."
+          }
+        },
+        "required": ["order_id"]
+      }
+    }
+  }
+]
+JSON
+
+run_antfly() {
+  local subcommand="$1"
+  shift
+  if [[ "$(basename "$ANTFLY_BIN")" == "antfly" ]]; then
+    "$ANTFLY_BIN" inference "$subcommand" "$@"
+  else
+    "$ANTFLY_BIN" "$subcommand" "$@"
+  fi
+}
+
+if ! run_antfly generate "$MODEL_DIR" "$PROMPT" \
+  --backend metal \
+  --max-tokens "$MAX_TOKENS" \
+  --tools "$TOOLS_JSON" \
+  --tool-choice lookup_order \
+  >"$RESPONSE_JSON" 2>"$STDERR_LOG"; then
+  echo "CLI generate failed" >&2
+  echo "stderr: $STDERR_LOG" >&2
+  sed -n '1,220p' "$STDERR_LOG" >&2 || true
+  exit 1
+fi
+
+python3 - "$RESPONSE_JSON" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], "r", encoding="utf-8") as f:
+    response = json.load(f)
+if response.get("object") != "chat.completion":
+    raise SystemExit(f"unexpected object: {response.get('object')!r}")
+choice = response["choices"][0]
+if choice.get("finish_reason") != "tool_calls":
+    raise SystemExit(f"expected finish_reason=tool_calls, got {choice.get('finish_reason')!r}")
+calls = choice["message"].get("tool_calls") or []
+if not calls:
+    raise SystemExit("missing normalized tool_calls")
+call = calls[0]
+if call.get("type") != "function":
+    raise SystemExit(f"unexpected call type: {call.get('type')!r}")
+function = call.get("function") or {}
+if function.get("name") != "lookup_order":
+    raise SystemExit(f"unexpected function name: {function.get('name')!r}")
+arguments = function.get("arguments")
+if not isinstance(arguments, str):
+    raise SystemExit("function.arguments must be a JSON string")
+try:
+    json.loads(arguments)
+except json.JSONDecodeError as exc:
+    raise SystemExit(f"function.arguments is not valid JSON: {exc}") from exc
+usage = response.get("usage") or {}
+for key in ("prompt_tokens", "completion_tokens", "total_tokens"):
+    if key not in usage:
+        raise SystemExit(f"missing usage.{key}")
+PY
+
+echo "metal Gemma4 CLI tool-calling smoke passed"
+echo "response: $RESPONSE_JSON"
+echo "stderr: $STDERR_LOG"

--- a/zig/pkg/inference/scripts/test_metal_gemma4_tool_calling.sh
+++ b/zig/pkg/inference/scripts/test_metal_gemma4_tool_calling.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+# Copyright 2026 Antfly, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+PKG_DIR="$ROOT_DIR/pkg/inference"
+
+if [[ -z "${ANTFLY_BIN:-}" ]]; then
+  if [[ -x "$PKG_DIR/zig-out/bin/antfly-inference" ]]; then
+    ANTFLY_BIN="$PKG_DIR/zig-out/bin/antfly-inference"
+  else
+    ANTFLY_BIN="$PKG_DIR/zig-out/bin/antfly"
+  fi
+fi
+
+MODEL_DIR="${ANTFLY_INFERENCE_GEMMA4_MODEL:-$HOME/.antfly/inference/models/ggml-org/gemma-4-e2b-it-gguf}"
+MODEL_NAME="${ANTFLY_INFERENCE_GEMMA4_MODEL_NAME:-ggml-org/gemma-4-e2b-it-gguf}"
+MODELS_DIR="${ANTFLY_INFERENCE_MODELS_DIR:-$(dirname "$(dirname "$MODEL_DIR")")}"
+PORT="${ANTFLY_INFERENCE_GEMMA4_TOOL_PORT:-18091}"
+HOST="${ANTFLY_INFERENCE_GEMMA4_TOOL_HOST:-127.0.0.1}"
+MAX_TOKENS="${ANTFLY_INFERENCE_GEMMA4_TOOL_MAX_TOKENS:-64}"
+OUT_DIR="${OUT_DIR:-/tmp/antfly-inference-metal-gemma4-tool-calling-test}"
+
+if [[ ! -x "$ANTFLY_BIN" ]]; then
+  echo "antfly inference binary not executable: $ANTFLY_BIN" >&2
+  echo "build it first, for example: cd pkg/inference && zig build -Dmetal=true -Dmlx=false -Donnx=false -Dpjrt=false" >&2
+  exit 2
+fi
+
+if [[ ! -d "$MODEL_DIR" ]]; then
+  echo "Gemma4 model directory not found: $MODEL_DIR" >&2
+  echo "set ANTFLY_INFERENCE_GEMMA4_MODEL to the local GGUF model directory" >&2
+  exit 2
+fi
+
+mkdir -p "$OUT_DIR"
+TOOLS_JSON="$OUT_DIR/tools.json"
+REQUEST_JSON="$OUT_DIR/request.json"
+RESPONSE_JSON="$OUT_DIR/response.json"
+SERVER_LOG="$OUT_DIR/server.log"
+
+cat >"$TOOLS_JSON" <<'JSON'
+[
+  {
+    "type": "function",
+    "function": {
+      "name": "lookup_order",
+      "description": "Look up the status of a customer order.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "order_id": {
+            "type": "string",
+            "description": "The order identifier."
+          }
+        },
+        "required": ["order_id"]
+      }
+    }
+  }
+]
+JSON
+
+python3 - "$MODEL_NAME" "$MAX_TOKENS" "$TOOLS_JSON" "$REQUEST_JSON" <<'PY'
+import json
+import sys
+
+model, max_tokens, tools_path, request_path = sys.argv[1:5]
+with open(tools_path, "r", encoding="utf-8") as f:
+    tools = json.load(f)
+body = {
+    "model": model,
+    "backend": "metal",
+    "messages": [
+        {
+            "role": "user",
+            "content": "Use the lookup_order tool for order_id A123. Return only the tool call.",
+        }
+    ],
+    "tools": tools,
+    "tool_choice": {"type": "function", "function": {"name": "lookup_order"}},
+    "max_tokens": int(max_tokens),
+    "temperature": 0,
+}
+with open(request_path, "w", encoding="utf-8") as f:
+    json.dump(body, f)
+PY
+
+run_antfly() {
+  local subcommand="$1"
+  shift
+  if [[ "$(basename "$ANTFLY_BIN")" == "antfly" ]]; then
+    "$ANTFLY_BIN" inference "$subcommand" "$@"
+  else
+    "$ANTFLY_BIN" "$subcommand" "$@"
+  fi
+}
+
+run_antfly run --models-dir "$MODELS_DIR" --host "$HOST" --port "$PORT" >"$SERVER_LOG" 2>&1 &
+SERVER_PID=$!
+cleanup() {
+  kill "$SERVER_PID" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+for _ in {1..120}; do
+  if curl -fsS "http://$HOST:$PORT/ai/v1/models" >/dev/null 2>&1; then
+    break
+  fi
+  if ! kill -0 "$SERVER_PID" >/dev/null 2>&1; then
+    echo "server exited before becoming ready" >&2
+    sed -n '1,220p' "$SERVER_LOG" >&2
+    exit 1
+  fi
+  sleep 0.5
+done
+
+status="$(curl -sS -o "$RESPONSE_JSON" -w "%{http_code}" \
+  -H "content-type: application/json" \
+  -d @"$REQUEST_JSON" \
+  "http://$HOST:$PORT/ai/v1/generate")"
+if [[ "$status" != "200" ]]; then
+  echo "generate request failed with HTTP $status" >&2
+  echo "response: $RESPONSE_JSON" >&2
+  sed -n '1,220p' "$RESPONSE_JSON" >&2 || true
+  echo "server log: $SERVER_LOG" >&2
+  sed -n '1,220p' "$SERVER_LOG" >&2 || true
+  exit 1
+fi
+
+python3 - "$RESPONSE_JSON" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], "r", encoding="utf-8") as f:
+    response = json.load(f)
+choice = response["choices"][0]
+if choice.get("finish_reason") != "tool_calls":
+    raise SystemExit(f"expected finish_reason=tool_calls, got {choice.get('finish_reason')!r}")
+calls = choice["message"].get("tool_calls") or []
+if not calls:
+    raise SystemExit("missing tool_calls")
+call = calls[0]
+if call.get("type") != "function":
+    raise SystemExit(f"unexpected call type: {call.get('type')!r}")
+function = call.get("function") or {}
+if function.get("name") != "lookup_order":
+    raise SystemExit(f"unexpected function name: {function.get('name')!r}")
+try:
+    json.loads(function.get("arguments") or "")
+except json.JSONDecodeError as exc:
+    raise SystemExit(f"function.arguments is not valid JSON: {exc}") from exc
+PY
+
+echo "metal Gemma4 server tool-calling smoke passed"
+echo "response: $RESPONSE_JSON"
+echo "server log: $SERVER_LOG"

--- a/zig/pkg/inference/src/graph/metal_executor.zig
+++ b/zig/pkg/inference/src/graph/metal_executor.zig
@@ -1715,7 +1715,9 @@ fn runtimePrefill(
     const prepare_started_at = monotonicNowNs();
     const decode_context = try runtime_ctx.preparePrefill(request.seq_len, request.query_seq_len, request.attention_mode);
     timing_stats.prefill_prepare_nanos += @intCast(monotonicNowNs() - prepare_started_at);
-    const decoder_runtime_ready = if (decoderRuntimePrefillAfterPrepareRequested())
+    const decoder_runtime_ready = if (request.force_host_logits)
+        false
+    else if (decoderRuntimePrefillAfterPrepareRequested())
         runtime_ctx.decoderRuntimeExecutorEnabled() and (try runtime_ctx.ensureDecoderRuntimePrepared())
     else blk: {
         _ = runtime_ctx.ensureDecoderRuntimePrepared() catch false;

--- a/zig/pkg/inference/src/graph/model_runtime.zig
+++ b/zig/pkg/inference/src/graph/model_runtime.zig
@@ -379,6 +379,7 @@ pub const PrefillRequest = struct {
     seq_len: usize,
     query_seq_len: usize,
     attention_mode: cache_mod.AttentionMode,
+    force_host_logits: bool = false,
 };
 
 pub const DecodeRequest = struct {

--- a/zig/pkg/inference/src/native_generate.zig
+++ b/zig/pkg/inference/src/native_generate.zig
@@ -22,6 +22,7 @@ const ops = @import("ops/ops.zig");
 const gpt_arch = @import("architectures/gpt.zig");
 const session_factory = @import("architectures/session_factory.zig");
 const generation = @import("pipelines/generation.zig");
+const tool_parser_mod = @import("pipelines/tool_parser.zig");
 const graph_mod = @import("graph/root.zig");
 const onnx_decoder_only_vlm = @import("pipelines/onnx_decoder_only_vlm.zig");
 const model_manager_mod = @import("server/model_manager.zig");
@@ -91,12 +92,15 @@ const Options = struct {
     mode: ?ExecutionMode = null,
     compiled_target: ?CompiledTarget = null,
     artifact_dir: ?[]const u8 = null,
+    tools_path: ?[]const u8 = null,
+    tool_choice: ?[]const u8 = null,
 };
 
 pub fn main(allocator: std.mem.Allocator, io: std.Io, args: []const []const u8) !void {
     const opts = try parseArgs(args);
     try native_backend_choice.validate(opts.backend);
     if (opts.draft_model != null and opts.backend == .onnx) return error.SpeculativeDecodingRequiresNativeBackend;
+    if (opts.tools_path == null and opts.tool_choice != null) return error.ToolsRequiredForToolChoice;
     const started_at = std.Io.Timestamp.now(io, .awake);
 
     var preflight_manifest = try manifest_mod.loadFromDir(allocator, opts.model_dir);
@@ -152,15 +156,23 @@ pub fn main(allocator: std.mem.Allocator, io: std.Io, args: []const []const u8) 
         null;
     defer if (content_part_slice) |slice| allocator.free(slice);
 
-    const messages = [_]generation.Message{
-        .{
-            .role = "user",
-            .content = opts.prompt,
-            .image_bytes = message_image_slice,
-            .audio_bytes = message_audio_slice,
-            .content_parts = content_part_slice,
-        },
-    };
+    var messages = std.ArrayListUnmanaged(generation.Message).empty;
+    defer messages.deinit(allocator);
+    var owned_message_contents = std.ArrayListUnmanaged([]u8).empty;
+    defer {
+        for (owned_message_contents.items) |content| allocator.free(content);
+        owned_message_contents.deinit(allocator);
+    }
+    try messages.append(allocator, .{
+        .role = "user",
+        .content = opts.prompt,
+        .image_bytes = message_image_slice,
+        .audio_bytes = message_audio_slice,
+        .content_parts = content_part_slice,
+    });
+
+    var cli_tooling = try prepareCliTooling(allocator, io, opts, &messages, &owned_message_contents);
+    defer cli_tooling.deinit();
 
     var config = generation.GenerationConfig{
         .max_tokens = opts.max_tokens,
@@ -203,9 +215,9 @@ pub fn main(allocator: std.mem.Allocator, io: std.Io, args: []const []const u8) 
         const rendered_prompt = if (opts.raw_prompt)
             try allocator.dupe(u8, opts.prompt)
         else if (apply_chat_template)
-            try pipeline.chat_tmpl.?.apply(allocator, &messages, true)
+            try pipeline.chat_tmpl.?.apply(allocator, messages.items, true)
         else
-            try generation.formatMessages(allocator, &messages);
+            try generation.formatMessages(allocator, messages.items);
         defer allocator.free(rendered_prompt);
         pipeline.prompt_override = rendered_prompt;
 
@@ -234,7 +246,7 @@ pub fn main(allocator: std.mem.Allocator, io: std.Io, args: []const []const u8) 
             print("\n", .{});
         }
 
-        if (artifact_backend != null and opts.draft_model == null and !route_onnx_whole_model_graph and opts.max_tokens == 1 and opts.image_count == 0 and opts.audio_count == 0) {
+        if (artifact_backend != null and !cli_tooling.enabled and opts.draft_model == null and !route_onnx_whole_model_graph and opts.max_tokens == 1 and opts.image_count == 0 and opts.audio_count == 0) {
             if (try tryRunArtifactForPromptShape(
                 allocator,
                 io,
@@ -247,10 +259,14 @@ pub fn main(allocator: std.mem.Allocator, io: std.Io, args: []const []const u8) 
             )) return;
         }
 
-        var result = try pipeline.generate(&messages, config);
+        var result = try generateMaybeStopOnTool(&pipeline, messages.items, config, cli_tooling.parserPtr());
         defer result.deinit();
         const finished_generate_at = std.Io.Timestamp.now(io, .awake);
 
+        if (cli_tooling.enabled) {
+            try emitCliToolAwareJsonResult(allocator, io, opts.model_dir, &result, cli_tooling.parserPtr().?, cli_tooling.parsed_choice);
+            return;
+        }
         print("{s}\n", .{result.text});
         if (opts.print_token_ids) {
             if (result.token_ids) |ids| {
@@ -290,7 +306,7 @@ pub fn main(allocator: std.mem.Allocator, io: std.Io, args: []const []const u8) 
     var model_manager = model_manager_mod.ModelManager.init(allocator, session_manager);
     defer model_manager.deinit();
 
-    if (artifact_backend != null and opts.draft_model == null and !route_onnx_whole_model_graph and opts.max_tokens == 1 and opts.image_count == 0 and opts.audio_count == 0) {
+    if (artifact_backend != null and !cli_tooling.enabled and opts.draft_model == null and !route_onnx_whole_model_graph and opts.max_tokens == 1 and opts.image_count == 0 and opts.audio_count == 0) {
         var artifact_arena = std.heap.ArenaAllocator.init(allocator);
         defer artifact_arena.deinit();
         const artifact_allocator = artifact_arena.allocator();
@@ -316,7 +332,7 @@ pub fn main(allocator: std.mem.Allocator, io: std.Io, args: []const []const u8) 
             allocator,
             io,
             &opts,
-            messages[0..],
+            messages.items,
             config,
             resolved_artifact_dir.?,
             started_at,
@@ -346,9 +362,9 @@ pub fn main(allocator: std.mem.Allocator, io: std.Io, args: []const []const u8) 
     const rendered_prompt = if (opts.raw_prompt)
         try allocator.dupe(u8, opts.prompt)
     else if (apply_chat_template)
-        try model.chat_tmpl.?.apply(allocator, &messages, true)
+        try model.chat_tmpl.?.apply(allocator, messages.items, true)
     else
-        try generation.formatMessages(allocator, &messages);
+        try generation.formatMessages(allocator, messages.items);
     defer allocator.free(rendered_prompt);
     var prompt_encoded = try generation.encodePromptForGeneration(
         tokenizer,
@@ -363,7 +379,7 @@ pub fn main(allocator: std.mem.Allocator, io: std.Io, args: []const []const u8) 
     const prompt_tokens = countPromptTokens(prompt_encoded.attention_mask) +
         opts.image_count * (@as(usize, gpt_config.mm_tokens_per_image) + 1);
 
-    if (artifact_backend != null and opts.draft_model == null and !route_onnx_whole_model_graph and opts.max_tokens == 1 and opts.image_count == 0 and opts.audio_count == 0) {
+    if (artifact_backend != null and !cli_tooling.enabled and opts.draft_model == null and !route_onnx_whole_model_graph and opts.max_tokens == 1 and opts.image_count == 0 and opts.audio_count == 0) {
         if (try tryRunArtifactForPromptShape(
             allocator,
             io,
@@ -429,20 +445,22 @@ pub fn main(allocator: std.mem.Allocator, io: std.Io, args: []const []const u8) 
         };
     }
 
-    if (try tryRunLiveWholeModelExecutorGenerate(
-        allocator,
-        io,
-        &opts,
-        model,
-        gpt_config,
-        tokenizer,
-        config,
-        prompt_encoded.ids[0..countPromptTokens(prompt_encoded.attention_mask)],
-        prompt_tokens,
-        started_at,
-        loaded_model_at,
-        encoded_prompt_at,
-    )) return;
+    if (!cli_tooling.enabled) {
+        if (try tryRunLiveWholeModelExecutorGenerate(
+            allocator,
+            io,
+            &opts,
+            model,
+            gpt_config,
+            tokenizer,
+            config,
+            prompt_encoded.ids[0..countPromptTokens(prompt_encoded.attention_mask)],
+            prompt_tokens,
+            started_at,
+            loaded_model_at,
+            encoded_prompt_at,
+        )) return;
+    }
 
     if (!graph_mode) {
         graph_mod.executor_stats.printBypass("inference.generate", "native_generation_direct_decoder_runtime");
@@ -648,7 +666,7 @@ pub fn main(allocator: std.mem.Allocator, io: std.Io, args: []const []const u8) 
     }
     gpt_arch.resetDebugTimingStats();
 
-    var result = pipeline.generate(&messages, config) catch |err| {
+    var result = generateMaybeStopOnTool(&pipeline, messages.items, config, cli_tooling.parserPtr()) catch |err| {
         if (err == error.MemoryBudgetExceeded) {
             printBudgetExceeded(model.session, &run_budget);
         } else if (err == error.AudioInputTooLong) {
@@ -659,6 +677,10 @@ pub fn main(allocator: std.mem.Allocator, io: std.Io, args: []const []const u8) 
     const finished_generate_at = std.Io.Timestamp.now(io, .awake);
     defer result.deinit();
 
+    if (cli_tooling.enabled) {
+        try emitCliToolAwareJsonResult(allocator, io, opts.model_dir, &result, cli_tooling.parserPtr().?, cli_tooling.parsed_choice);
+        return;
+    }
     print("{s}\n", .{result.text});
     if (opts.print_token_ids) {
         if (result.token_ids) |ids| {
@@ -1849,6 +1871,286 @@ fn validateDraftTokenizerCompatibility(
     }
 }
 
+const CliTooling = struct {
+    parser: ?tool_parser_mod.Parser = null,
+    parsed_choice: tool_parser_mod.ParsedToolChoice = .auto,
+    enabled: bool = false,
+
+    fn parserPtr(self: *CliTooling) ?*tool_parser_mod.Parser {
+        if (self.parser) |*parser| return parser;
+        return null;
+    }
+
+    fn deinit(self: *CliTooling) void {
+        if (self.parser) |*parser| parser.deinit();
+        self.* = undefined;
+    }
+};
+
+fn prepareCliTooling(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    opts: Options,
+    messages: *std.ArrayListUnmanaged(generation.Message),
+    owned_message_contents: *std.ArrayListUnmanaged([]u8),
+) !CliTooling {
+    const tools_path = opts.tools_path orelse return .{};
+    const tools_json = try std.Io.Dir.cwd().readFileAlloc(io, tools_path, allocator, .limited(4 * 1024 * 1024));
+    defer allocator.free(tools_json);
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, tools_json, .{});
+    defer parsed.deinit();
+    if (parsed.value != .array) return error.InvalidToolsFile;
+
+    const parsed_choice = try parseCliToolChoice(opts.tool_choice);
+    if (!tool_parser_mod.toolCallsEnabled(parsed_choice)) {
+        return .{ .parsed_choice = parsed_choice };
+    }
+    if (opts.raw_prompt) return error.RawPromptToolCallingUnsupported;
+
+    var selected_tools = std.ArrayListUnmanaged(tool_parser_mod.ToolDefinition).empty;
+    defer selected_tools.deinit(allocator);
+    const forced_function = tool_parser_mod.forcedFunctionName(parsed_choice);
+    for (parsed.value.array.items) |tool_value| {
+        try appendCliToolDefinition(allocator, tool_value, forced_function, &selected_tools);
+    }
+    if (forced_function != null and selected_tools.items.len == 0) return error.ForcedFunctionNotFound;
+    if (selected_tools.items.len == 0) return error.NoFunctionTools;
+
+    var parser = (try tool_parser_mod.loadParser(allocator, opts.model_dir)) orelse return error.ModelDoesNotSupportToolCalling;
+    errdefer parser.deinit();
+
+    const tools_prompt = try parser.formatToolsPrompt(allocator, selected_tools.items);
+    defer allocator.free(tools_prompt);
+    const prompt = if (forced_function) |forced|
+        try std.fmt.allocPrint(allocator, "{s}\nYou MUST call the {s} function. Do not respond with text, only call the function.\n", .{ tools_prompt, forced })
+    else
+        try allocator.dupe(u8, tools_prompt);
+    defer allocator.free(prompt);
+    try prependCliSystemPrompt(allocator, messages, owned_message_contents, prompt);
+
+    return .{
+        .parser = parser,
+        .parsed_choice = parsed_choice,
+        .enabled = true,
+    };
+}
+
+fn appendCliToolDefinition(
+    allocator: std.mem.Allocator,
+    tool_value: std.json.Value,
+    forced_function: ?[]const u8,
+    selected_tools: *std.ArrayListUnmanaged(tool_parser_mod.ToolDefinition),
+) !void {
+    if (tool_value != .object) return error.InvalidToolsFile;
+    const tool_obj = tool_value.object;
+    const type_val = tool_obj.get("type") orelse return error.InvalidToolsFile;
+    if (type_val != .string or !std.mem.eql(u8, type_val.string, "function")) return error.InvalidToolsFile;
+    const function_val = tool_obj.get("function") orelse return error.InvalidToolsFile;
+    if (function_val != .object) return error.InvalidToolsFile;
+    const function_obj = function_val.object;
+    const name_val = function_obj.get("name") orelse return error.InvalidToolsFile;
+    if (name_val != .string or name_val.string.len == 0) return error.InvalidToolsFile;
+    if (forced_function) |forced| {
+        if (!std.mem.eql(u8, name_val.string, forced)) return;
+    }
+    const description = if (function_obj.get("description")) |desc_val| blk: {
+        if (desc_val != .string) return error.InvalidToolsFile;
+        break :blk desc_val.string;
+    } else "";
+    const strict = if (function_obj.get("strict")) |strict_val| blk: {
+        if (strict_val != .bool) return error.InvalidToolsFile;
+        break :blk strict_val.bool;
+    } else false;
+
+    try selected_tools.append(allocator, .{
+        .type = type_val.string,
+        .function = .{
+            .name = name_val.string,
+            .description = description,
+            .parameters = function_obj.get("parameters"),
+            .strict = strict,
+        },
+    });
+}
+
+fn prependCliSystemPrompt(
+    allocator: std.mem.Allocator,
+    messages: *std.ArrayListUnmanaged(generation.Message),
+    owned_message_contents: *std.ArrayListUnmanaged([]u8),
+    prompt: []const u8,
+) !void {
+    const owned = try allocator.dupe(u8, prompt);
+    errdefer allocator.free(owned);
+    if (messages.items.len > 0 and std.mem.eql(u8, messages.items[0].role, "system")) {
+        const merged = try std.fmt.allocPrint(allocator, "{s}\n\n{s}", .{ prompt, messages.items[0].content });
+        errdefer allocator.free(merged);
+        messages.items[0].content = merged;
+        try owned_message_contents.append(allocator, merged);
+        allocator.free(owned);
+        return;
+    }
+    try messages.insert(allocator, 0, .{
+        .role = "system",
+        .content = owned,
+    });
+    try owned_message_contents.append(allocator, owned);
+}
+
+fn parseCliToolChoice(choice: ?[]const u8) !tool_parser_mod.ParsedToolChoice {
+    const value = choice orelse return .auto;
+    if (std.mem.eql(u8, value, "auto")) return .auto;
+    if (std.mem.eql(u8, value, "none")) return .none;
+    if (std.mem.eql(u8, value, "required")) return .required;
+    if (value.len == 0) return error.InvalidToolChoice;
+    return .{ .function = value };
+}
+
+const ToolStopCtx = struct {
+    parser: *tool_parser_mod.Parser,
+    errored: ?anyerror = null,
+
+    fn onToken(raw_ctx: *anyopaque, token_text: []const u8) bool {
+        const self: *@This() = @ptrCast(@alignCast(raw_ctx));
+        _ = self.parser.feed(token_text) catch |err| {
+            self.errored = err;
+            return false;
+        };
+        return self.parser.toolCalls().len == 0;
+    }
+};
+
+fn generateMaybeStopOnTool(
+    pipeline: anytype,
+    messages: []const generation.Message,
+    config: generation.GenerationConfig,
+    tool_parser: ?*tool_parser_mod.Parser,
+) !generation.GenerationResult {
+    var tool_stop_ctx: ?ToolStopCtx = if (tool_parser) |parser| blk: {
+        parser.reset();
+        break :blk .{ .parser = parser };
+    } else null;
+
+    var result = if (tool_stop_ctx) |*stop_ctx|
+        try pipeline.generateStreaming(messages, config, @ptrCast(stop_ctx), ToolStopCtx.onToken)
+    else
+        try pipeline.generate(messages, config);
+    errdefer result.deinit();
+
+    if (tool_stop_ctx) |stop_ctx| {
+        if (stop_ctx.errored) |err| return err;
+    }
+    return result;
+}
+
+fn emitCliToolAwareJsonResult(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    model_name: []const u8,
+    result: *const generation.GenerationResult,
+    parser: *tool_parser_mod.Parser,
+    parsed_choice: tool_parser_mod.ParsedToolChoice,
+) !void {
+    parser.reset();
+    _ = try parser.feed(result.text);
+    const finished_text = try parser.finishText(allocator);
+    defer allocator.free(finished_text);
+    const response_text = if (finished_text.len > 0) finished_text else result.text;
+
+    var fallback_tool_calls: ?[]tool_parser_mod.ToolCall = null;
+    defer if (fallback_tool_calls) |calls| tool_parser_mod.freeToolCalls(allocator, calls);
+
+    const parsed_tool_calls = if (parser.toolCalls().len > 0)
+        parser.toolCalls()
+    else blk: {
+        fallback_tool_calls = try tool_parser_mod.synthesizeForcedFunctionToolCallFromJsonContent(allocator, response_text, parsed_choice);
+        break :blk if (fallback_tool_calls) |calls| calls else &.{};
+    };
+    const finish_reason = if (parsed_tool_calls.len > 0) "tool_calls" else result.finish_reason;
+    try emitCliGenerateJson(
+        allocator,
+        io,
+        model_name,
+        response_text,
+        finish_reason,
+        result.prompt_tokens,
+        result.tokens_used,
+        if (parsed_tool_calls.len > 0) parsed_tool_calls else null,
+    );
+}
+
+fn emitCliGenerateJson(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    model_name: []const u8,
+    response_text: []const u8,
+    finish_reason: []const u8,
+    prompt_tokens: usize,
+    completion_tokens: usize,
+    tool_calls: ?[]const tool_parser_mod.ToolCall,
+) !void {
+    var out = std.ArrayListUnmanaged(u8).empty;
+    defer out.deinit(allocator);
+
+    try out.appendSlice(allocator, "{\"object\":\"chat.completion\",\"model\":");
+    try appendCliJsonString(&out, allocator, model_name);
+    try out.appendSlice(allocator, ",\"choices\":[{\"index\":0,\"message\":{\"role\":\"assistant\",");
+    if (tool_calls) |calls| {
+        try out.appendSlice(allocator, "\"content\":null,\"tool_calls\":[");
+        for (calls, 0..) |call, idx| {
+            if (idx > 0) try out.append(allocator, ',');
+            try out.appendSlice(allocator, "{\"id\":");
+            try appendCliJsonString(&out, allocator, call.id);
+            try out.appendSlice(allocator, ",\"type\":");
+            try appendCliJsonString(&out, allocator, call.type);
+            try out.appendSlice(allocator, ",\"function\":{\"name\":");
+            try appendCliJsonString(&out, allocator, call.function.name);
+            try out.appendSlice(allocator, ",\"arguments\":");
+            try appendCliJsonString(&out, allocator, call.function.arguments);
+            try out.appendSlice(allocator, "}}");
+        }
+        try out.appendSlice(allocator, "]");
+    } else {
+        try out.appendSlice(allocator, "\"content\":");
+        try appendCliJsonString(&out, allocator, response_text);
+    }
+    try out.appendSlice(allocator, "},\"finish_reason\":");
+    try appendCliJsonString(&out, allocator, finish_reason);
+    try out.appendSlice(allocator, "}],\"usage\":{\"prompt_tokens\":");
+    try appendCliUnsigned(&out, allocator, prompt_tokens);
+    try out.appendSlice(allocator, ",\"completion_tokens\":");
+    try appendCliUnsigned(&out, allocator, completion_tokens);
+    try out.appendSlice(allocator, ",\"total_tokens\":");
+    try appendCliUnsigned(&out, allocator, prompt_tokens + completion_tokens);
+    try out.appendSlice(allocator, "}}\n");
+
+    var stdout_buffer: [4096]u8 = undefined;
+    var stdout_writer = std.Io.File.stdout().writer(io, &stdout_buffer);
+    try stdout_writer.interface.writeAll(out.items);
+    try stdout_writer.interface.flush();
+}
+
+fn appendCliJsonString(buf: *std.ArrayListUnmanaged(u8), allocator: std.mem.Allocator, text: []const u8) !void {
+    try buf.append(allocator, '"');
+    for (text) |ch| {
+        switch (ch) {
+            '\\' => try buf.appendSlice(allocator, "\\\\"),
+            '"' => try buf.appendSlice(allocator, "\\\""),
+            '\n' => try buf.appendSlice(allocator, "\\n"),
+            '\r' => try buf.appendSlice(allocator, "\\r"),
+            '\t' => try buf.appendSlice(allocator, "\\t"),
+            else => try buf.append(allocator, ch),
+        }
+    }
+    try buf.append(allocator, '"');
+}
+
+fn appendCliUnsigned(buf: *std.ArrayListUnmanaged(u8), allocator: std.mem.Allocator, value: usize) !void {
+    var scratch: [32]u8 = undefined;
+    const rendered = try std.fmt.bufPrint(&scratch, "{d}", .{value});
+    try buf.appendSlice(allocator, rendered);
+}
+
 fn parseArgs(args: []const []const u8) !Options {
     if (args.len < 2) {
         printUsage();
@@ -1867,6 +2169,20 @@ fn parseArgs(args: []const []const u8) !Options {
             i += 1;
             if (i >= args.len) return error.MissingBackendValue;
             opts.backend = parseBackendChoice(args[i]) orelse return error.InvalidBackend;
+        } else if (std.mem.eql(u8, arg, "--tools")) {
+            i += 1;
+            if (i >= args.len) return error.MissingToolsPath;
+            opts.tools_path = args[i];
+        } else if (std.mem.startsWith(u8, arg, "--tools=")) {
+            opts.tools_path = arg["--tools=".len..];
+            if (opts.tools_path.?.len == 0) return error.MissingToolsPath;
+        } else if (std.mem.eql(u8, arg, "--tool-choice")) {
+            i += 1;
+            if (i >= args.len) return error.MissingToolChoice;
+            opts.tool_choice = args[i];
+        } else if (std.mem.startsWith(u8, arg, "--tool-choice=")) {
+            opts.tool_choice = arg["--tool-choice=".len..];
+            if (opts.tool_choice.?.len == 0) return error.MissingToolChoice;
         } else if (std.mem.eql(u8, arg, "--artifact-dir")) {
             i += 1;
             if (i >= args.len) return error.MissingArtifactDir;
@@ -2129,8 +2445,10 @@ fn enableMlxRawMetalWholeTokenDebug() bool {
 
 fn printUsage() void {
     print(
-        \\usage: antfly inference generate <model-dir> <prompt> [--image path] [--audio path] [--backend auto|onnx|native|metal|mlx|xla|webgpu] [--mode eager|compiled] [--compiled-target partitioned|whole-model] [--max-tokens N] [--temperature V] [--top-p V] [--top-k N] [--repetition-penalty V] [--prefill-chunk-size N] [--draft-model path] [--speculative-k N] [--cache-dtype f16|f32|int8|fp8|int4|polar4|turbo3] [--host-budget-mb N] [--backend-budget-mb N] [--combined-budget-mb N] [--kv-budget-mb N] [--scratch-budget-mb N] [--artifact-dir <path>] [--no-chat-template] [--raw-prompt] [--no-bos] [--print-finish-reason] [--print-token-count] [--print-token-ids] [--print-prompt-token-ids] [--print-prompt] [--print-chat-template-status] [--print-timing]
+        \\usage: antfly inference generate <model-dir> <prompt> [--image path] [--audio path] [--backend auto|onnx|native|metal|mlx|xla|webgpu] [--tools path.json] [--tool-choice auto|none|required|function_name] [--mode eager|compiled] [--compiled-target partitioned|whole-model] [--max-tokens N] [--temperature V] [--top-p V] [--top-k N] [--repetition-penalty V] [--prefill-chunk-size N] [--draft-model path] [--speculative-k N] [--cache-dtype f16|f32|int8|fp8|int4|polar4|turbo3] [--host-budget-mb N] [--backend-budget-mb N] [--combined-budget-mb N] [--kv-budget-mb N] [--scratch-budget-mb N] [--artifact-dir <path>] [--no-chat-template] [--raw-prompt] [--no-bos] [--print-finish-reason] [--print-token-count] [--print-token-ids] [--print-prompt-token-ids] [--print-prompt] [--print-chat-template-status] [--print-timing]
         \\  Loads a native GGUF/SafeTensors model and prints generated text to stdout.
+        \\  tools enables tool-call prompting and prints an OpenAI chat-completion-style JSON response.
+        \\  tool-choice=none skips tool prompting and preserves plain generation semantics.
         \\  draft-model enables native speculative decoding with a tokenizer-compatible drafter such as a Gemma 4 *-assistant model.
         \\  Explicit compiled backends consult ~/.antfly/inference/artifacts/<owner>/<model>/<backend>/... by default.
         \\  artifact-dir overrides that lookup root.
@@ -2184,6 +2502,58 @@ test "parseArgs accepts artifact dir" {
     try std.testing.expectEqualStrings("/tmp/artifacts", opts.artifact_dir.?);
     try std.testing.expectEqual(@as(i32, 1), opts.max_tokens);
     try std.testing.expect(opts.raw_prompt);
+}
+
+test "parseArgs accepts tool flags" {
+    const opts = try parseArgs(&.{
+        "/tmp/model",
+        "hello",
+        "--backend",
+        "metal",
+        "--tools",
+        "/tmp/tools.json",
+        "--tool-choice",
+        "lookup_order",
+    });
+    try std.testing.expectEqual(BackendChoice.metal, opts.backend);
+    try std.testing.expectEqualStrings("/tmp/tools.json", opts.tools_path.?);
+    try std.testing.expectEqualStrings("lookup_order", opts.tool_choice.?);
+}
+
+test "parseArgs preserves defaults when tools are absent" {
+    const opts = try parseArgs(&.{ "/tmp/model", "hello" });
+    try std.testing.expectEqual(@as(?[]const u8, null), opts.tools_path);
+    try std.testing.expectEqual(@as(?[]const u8, null), opts.tool_choice);
+}
+
+test "parseCliToolChoice variants" {
+    try std.testing.expectEqual(tool_parser_mod.ParsedToolChoice.auto, try parseCliToolChoice(null));
+    try std.testing.expectEqual(tool_parser_mod.ParsedToolChoice.auto, try parseCliToolChoice("auto"));
+    try std.testing.expectEqual(tool_parser_mod.ParsedToolChoice.required, try parseCliToolChoice("required"));
+    try std.testing.expectEqual(tool_parser_mod.ParsedToolChoice.none, try parseCliToolChoice("none"));
+    const forced = try parseCliToolChoice("lookup_order");
+    try std.testing.expectEqualStrings("lookup_order", tool_parser_mod.forcedFunctionName(forced).?);
+}
+
+test "CLI forced tool selection rejects missing function" {
+    const allocator = std.testing.allocator;
+    const parsed = try std.json.parseFromSlice(
+        std.json.Value,
+        allocator,
+        \\[
+        \\  {"type":"function","function":{"name":"get_weather","description":"weather","parameters":{"type":"object","properties":{}}}}
+        \\]
+    ,
+        .{},
+    );
+    defer parsed.deinit();
+
+    var selected_tools = std.ArrayListUnmanaged(tool_parser_mod.ToolDefinition).empty;
+    defer selected_tools.deinit(allocator);
+    for (parsed.value.array.items) |tool_value| {
+        try appendCliToolDefinition(allocator, tool_value, "lookup_order", &selected_tools);
+    }
+    try std.testing.expectEqual(@as(usize, 0), selected_tools.items.len);
 }
 
 test "parseArgs accepts compiled target" {

--- a/zig/pkg/inference/src/native_generate.zig
+++ b/zig/pkg/inference/src/native_generate.zig
@@ -445,21 +445,35 @@ pub fn main(allocator: std.mem.Allocator, io: std.Io, args: []const []const u8) 
         };
     }
 
-    if (!cli_tooling.enabled) {
-        if (try tryRunLiveWholeModelExecutorGenerate(
-            allocator,
-            io,
-            &opts,
-            model,
-            gpt_config,
-            tokenizer,
-            config,
-            prompt_encoded.ids[0..countPromptTokens(prompt_encoded.attention_mask)],
-            prompt_tokens,
-            started_at,
-            loaded_model_at,
-            encoded_prompt_at,
-        )) return;
+    var live_result = try tryRunLiveWholeModelExecutorGenerate(
+        allocator,
+        io,
+        &opts,
+        model,
+        gpt_config,
+        tokenizer,
+        config,
+        prompt_encoded.ids[0..countPromptTokens(prompt_encoded.attention_mask)],
+        prompt_tokens,
+        cli_tooling.parserPtr(),
+        started_at,
+        loaded_model_at,
+        encoded_prompt_at,
+    );
+    if (live_result) |*result| {
+        defer result.deinit();
+        if (cli_tooling.enabled) {
+            if (std.mem.eql(u8, result.finish_reason, "tool_calls")) {
+                try emitCliToolAwareJsonResult(allocator, io, opts.model_dir, result, cli_tooling.parserPtr().?, cli_tooling.parsed_choice);
+                return;
+            }
+            if (opts.print_timing) {
+                print("live_whole_model_executor_tool_fallback=true finish_reason={s} tokens={d}\n", .{ result.finish_reason, result.tokens_used });
+            }
+        } else {
+            emitLiveWholeModelExecutorResult(result, &opts);
+            return;
+        }
     }
 
     if (!graph_mode) {
@@ -1161,14 +1175,15 @@ fn tryRunLiveWholeModelExecutorGenerate(
     config: generation.GenerationConfig,
     prompt_token_ids: []const i32,
     prompt_tokens: usize,
+    tool_parser: ?*tool_parser_mod.Parser,
     started_at: std.Io.Timestamp,
     loaded_model_at: std.Io.Timestamp,
     encoded_prompt_at: std.Io.Timestamp,
-) !bool {
-    if (!liveWholeModelExecutorRequested(opts)) return false;
-    if (generation.NativeDecodeState.requiresDeepSeekV4CompressedCache(gpt_config)) return false;
-    if (opts.draft_model != null) return false;
-    if (opts.image_count > 0 or opts.audio_count > 0) return false;
+) !?generation.GenerationResult {
+    if (!liveWholeModelExecutorRequested(opts)) return null;
+    if (generation.NativeDecodeState.requiresDeepSeekV4CompressedCache(gpt_config)) return null;
+    if (opts.draft_model != null) return null;
+    if (opts.image_count > 0 or opts.audio_count > 0) return null;
 
     gpt_arch.resetDebugTimingStats();
 
@@ -1182,7 +1197,7 @@ fn tryRunLiveWholeModelExecutorGenerate(
         runtime.kv.pool.parseKvDType(name) orelse return error.InvalidCacheDType
     else
         session_factory.recommendedKvDTypeForSession(model.session, kv_backend_kind);
-    var executor = (try model.wholeModelExecutor(allocator, kv_dtype)) orelse return false;
+    var executor = (try model.wholeModelExecutor(allocator, kv_dtype)) orelse return null;
     defer executor.deinit();
 
     var runtime_model = try executor.createRuntime(allocator);
@@ -1205,6 +1220,10 @@ fn tryRunLiveWholeModelExecutorGenerate(
     defer generated_token_ids.deinit(allocator);
 
     var finish_reason: []const u8 = "length";
+    var emitted_text = try allocator.dupe(u8, "");
+    defer allocator.free(emitted_text);
+    if (tool_parser) |parser| parser.reset();
+
     const max_tokens: usize = if (opts.max_tokens > 0) @intCast(opts.max_tokens) else 0;
     const sampling_config: graph_mod.model_runtime.SamplingConfig = .{
         .temperature = config.temperature,
@@ -1234,6 +1253,7 @@ fn tryRunLiveWholeModelExecutorGenerate(
                 .seq_len = chunk_end,
                 .query_seq_len = chunk_end - processed,
                 .attention_mode = .paged_prefill,
+                .force_host_logits = tool_parser != null,
             });
             processed = chunk_end;
         }
@@ -1244,9 +1264,6 @@ fn tryRunLiveWholeModelExecutorGenerate(
     var generated: usize = 0;
     while (generated < max_tokens) {
         const next_token_i32: i32 = if (generated == 0) blk: {
-            if (use_greedy_decode) {
-                break :blk @intCast(try output.greedyToken(allocator, gpt_config.vocab_size));
-            }
             const output_logits = try output.hostLogits(allocator);
             break :blk @intCast(generation.sampleTokenFromLogits(
                 allocator,
@@ -1286,6 +1303,13 @@ fn tryRunLiveWholeModelExecutorGenerate(
         try all_token_ids.append(allocator, next_token_i64);
         generated += 1;
 
+        if (tool_parser) |parser| {
+            const keep_generating = try feedToolParserDeltaForFastPath(allocator, tokenizer, generated_token_ids.items, &emitted_text, parser);
+            if (!keep_generating) {
+                finish_reason = "tool_calls";
+                break;
+            }
+        }
         if (gpt_config.eos_token_id >= 0 and next_token_i32 == gpt_config.eos_token_id) {
             finish_reason = "stop";
             break;
@@ -1303,30 +1327,16 @@ fn tryRunLiveWholeModelExecutorGenerate(
     }
 
     const result_token_ids = try allocator.dupe(i32, generated_token_ids.items);
-    defer allocator.free(result_token_ids);
+    errdefer allocator.free(result_token_ids);
     const result_text = if (result_token_ids.len > 0)
         try tokenizer.decode(allocator, result_token_ids)
     else
         try allocator.dupe(u8, "");
-    defer allocator.free(result_text);
+    errdefer allocator.free(result_text);
 
     const finished_generate_at = std.Io.Timestamp.now(io, .awake);
-    print("{s}\n", .{result_text});
-    if (opts.print_token_ids) {
-        print("token_ids:", .{});
-        for (result_token_ids) |id| print(" {d}", .{id});
-        print("\n", .{});
-    }
-    if (opts.print_finish_reason or opts.print_token_count) {
-        if (opts.print_finish_reason and opts.print_token_count) {
-            print("finish_reason={s} tokens={d}\n", .{ finish_reason, result_token_ids.len });
-        } else if (opts.print_finish_reason) {
-            print("finish_reason={s}\n", .{finish_reason});
-        } else {
-            print("tokens={d}\n", .{result_token_ids.len});
-        }
-    }
     if (opts.print_timing) {
+        print("live_whole_model_executor=true\n", .{});
         print(
             "timing_ms: load_model={d} prompt_prep={d} scheduler=0 backend_setup={d} decode_setup=0 generate={d} total={d}\n",
             .{
@@ -1582,7 +1592,57 @@ fn tryRunLiveWholeModelExecutorGenerate(
             );
         }
     }
-    return true;
+    return .{
+        .text = result_text,
+        .token_ids = result_token_ids,
+        .prompt_tokens = prompt_tokens,
+        .tokens_used = result_token_ids.len,
+        .finish_reason = finish_reason,
+        .allocator = allocator,
+    };
+}
+
+fn emitLiveWholeModelExecutorResult(result: *const generation.GenerationResult, opts: *const Options) void {
+    print("{s}\n", .{result.text});
+    if (opts.print_token_ids) {
+        if (result.token_ids) |ids| {
+            print("token_ids:", .{});
+            for (ids) |id| print(" {d}", .{id});
+            print("\n", .{});
+        } else {
+            print("token_ids=unavailable\n", .{});
+        }
+    }
+    if (opts.print_finish_reason or opts.print_token_count) {
+        if (opts.print_finish_reason and opts.print_token_count) {
+            print("finish_reason={s} tokens={d}\n", .{ result.finish_reason, result.tokens_used });
+        } else if (opts.print_finish_reason) {
+            print("finish_reason={s}\n", .{result.finish_reason});
+        } else {
+            print("tokens={d}\n", .{result.tokens_used});
+        }
+    }
+}
+
+fn feedToolParserDeltaForFastPath(
+    allocator: std.mem.Allocator,
+    tokenizer: tokenizer_mod.Tokenizer,
+    generated_token_ids: []const i32,
+    emitted_text: *[]u8,
+    parser: *tool_parser_mod.Parser,
+) !bool {
+    const decoded_text = try tokenizer.decode(allocator, generated_token_ids);
+    defer allocator.free(decoded_text);
+
+    const prefix_len = std.mem.indexOfDiff(u8, emitted_text.*, decoded_text) orelse @min(emitted_text.*.len, decoded_text.len);
+    const delta = decoded_text[prefix_len..];
+
+    const next_emitted_text = try allocator.dupe(u8, decoded_text);
+    allocator.free(emitted_text.*);
+    emitted_text.* = next_emitted_text;
+    if (delta.len == 0) return true;
+    _ = try parser.feed(delta);
+    return parser.toolCalls().len == 0;
 }
 
 fn runOnnxWholeModelGraphGenerate(
@@ -2533,6 +2593,25 @@ test "parseCliToolChoice variants" {
     try std.testing.expectEqual(tool_parser_mod.ParsedToolChoice.none, try parseCliToolChoice("none"));
     const forced = try parseCliToolChoice("lookup_order");
     try std.testing.expectEqualStrings("lookup_order", tool_parser_mod.forcedFunctionName(forced).?);
+}
+
+test "tool flags keep Metal live whole-model executor eligible" {
+    const opts = try parseArgs(&.{
+        "/tmp/model",
+        "hello",
+        "--backend",
+        "metal",
+        "--tools",
+        "/tmp/tools.json",
+        "--tool-choice",
+        "lookup_order",
+    });
+    try std.testing.expect(liveWholeModelExecutorRequested(&opts));
+}
+
+test "tool-choice none remains disabled for tool prompting" {
+    const parsed = try parseCliToolChoice("none");
+    try std.testing.expect(!tool_parser_mod.toolCallsEnabled(parsed));
 }
 
 test "CLI forced tool selection rejects missing function" {

--- a/zig/pkg/inference/src/registry/download.zig
+++ b/zig/pkg/inference/src/registry/download.zig
@@ -1156,12 +1156,24 @@ pub fn downloadModel(
     // Download each file
     for (to_download.items, 0..) |file_meta, i| {
         const filename = file_meta.name;
-        const total_bytes = file_meta.size orelse (probeDownloadSize(allocator, io, owner, name, filename, config) catch null);
+        const total_bytes = if (file_meta.size) |declared_size| blk: {
+            if (shouldProbeLinkedPayloadSize(filename, declared_size)) {
+                break :blk probeDownloadSize(allocator, io, owner, name, filename, config) catch declared_size;
+            }
+            break :blk declared_size;
+        } else (probeDownloadSize(allocator, io, owner, name, filename, config) catch null);
+        const progress_total_bytes = existingFinalFileProgressSize(
+            allocator,
+            io,
+            dest_dir,
+            filename,
+            total_bytes,
+        ) catch total_bytes;
         if (progress.callback) |cb| {
             cb(.{
                 .file = filename,
                 .bytes_downloaded = 0,
-                .total_bytes = total_bytes,
+                .total_bytes = progress_total_bytes,
                 .files_done = i,
                 .files_total = to_download.items.len,
             }, progress.context);
@@ -1172,8 +1184,8 @@ pub fn downloadModel(
         if (progress.callback) |cb| {
             cb(.{
                 .file = filename,
-                .bytes_downloaded = total_bytes orelse 0,
-                .total_bytes = total_bytes,
+                .bytes_downloaded = progress_total_bytes orelse 0,
+                .total_bytes = progress_total_bytes,
                 .files_done = i + 1,
                 .files_total = to_download.items.len,
             }, progress.context);
@@ -1223,6 +1235,38 @@ fn probeDownloadSize(
         return std.fmt.parseInt(u64, value, 10) catch null;
     }
     return resp.contentLength();
+}
+
+fn shouldProbeLinkedPayloadSize(filename: []const u8, declared_size: u64) bool {
+    if (declared_size > 4096) return false;
+    return isLargeBinaryModelArtifact(filename);
+}
+
+fn isLargeBinaryModelArtifact(filename: []const u8) bool {
+    return std.mem.endsWith(u8, filename, ".gguf") or
+        std.mem.endsWith(u8, filename, ".safetensors") or
+        std.mem.endsWith(u8, filename, ".onnx") or
+        std.mem.endsWith(u8, filename, ".onnx.data") or
+        std.mem.endsWith(u8, filename, ".bin");
+}
+
+fn existingFinalFileProgressSize(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    dest_dir: []const u8,
+    filename: []const u8,
+    total_bytes: ?u64,
+) !?u64 {
+    const total = total_bytes orelse return null;
+    if (!shouldProbeLinkedPayloadSize(filename, total)) return total_bytes;
+    const dest_path = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ dest_dir, filename });
+    defer allocator.free(dest_path);
+    const size = existingFileSize(std.Io.Dir.cwd(), io, dest_path) catch |err| switch (err) {
+        error.FileNotFound => return total_bytes,
+        else => return err,
+    };
+    if (size > total) return size;
+    return total_bytes;
 }
 
 /// List all files in a HuggingFace model repo.
@@ -1388,13 +1432,12 @@ fn downloadFile(
     total_bytes: ?u64,
     expected_sha256: ?[]const u8,
 ) !void {
-    const url = try std.fmt.allocPrint(allocator, "{s}/{s}/{s}/resolve/main/{s}", .{ config.base_url, owner, name, filename });
-    defer allocator.free(url);
-
-    var client = httpx.Client.initWithConfig(allocator, io, .{
-        .keep_alive = false,
-    });
-    defer client.deinit();
+    var dest = std.Io.Dir.cwd();
+    const dest_path = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ dest_dir, filename });
+    defer allocator.free(dest_path);
+    if (try existingFinalFileSatisfies(dest, io, dest_path, filename, total_bytes, expected_sha256)) {
+        return;
+    }
 
     var headers_buf: [4][2][]const u8 = undefined;
     var n_headers: usize = 0;
@@ -1414,6 +1457,14 @@ fn downloadFile(
         n_headers += 1;
     }
 
+    const url = try std.fmt.allocPrint(allocator, "{s}/{s}/{s}/resolve/main/{s}", .{ config.base_url, owner, name, filename });
+    defer allocator.free(url);
+
+    var client = httpx.Client.initWithConfig(allocator, io, .{
+        .keep_alive = false,
+    });
+    defer client.deinit();
+
     const download_url = try resolveDownloadUrl(allocator, &client, url, headers_buf[0..n_headers]);
     defer allocator.free(download_url);
 
@@ -1424,9 +1475,6 @@ fn downloadFile(
         try std.Io.Dir.cwd().createDirPath(io, parent);
     }
 
-    var dest = std.Io.Dir.cwd();
-    const dest_path = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ dest_dir, filename });
-    defer allocator.free(dest_path);
     const temp_path = try std.fmt.allocPrint(allocator, "{s}.part", .{dest_path});
     defer allocator.free(temp_path);
 
@@ -1516,7 +1564,34 @@ fn downloadFile(
         };
     }
 
+    dest.deleteFile(io, dest_path) catch |err| switch (err) {
+        error.FileNotFound => {},
+        else => return err,
+    };
     try std.Io.Dir.rename(dest, temp_path, dest, dest_path, io);
+}
+
+fn existingFinalFileSatisfies(
+    dir: std.Io.Dir,
+    io: std.Io,
+    path: []const u8,
+    filename: []const u8,
+    total_bytes: ?u64,
+    expected_sha256: ?[]const u8,
+) !bool {
+    const size = existingFileSize(dir, io, path) catch |err| switch (err) {
+        error.FileNotFound => return false,
+        else => return err,
+    };
+    if (expected_sha256) |sum| {
+        verifyFileSha256(dir, io, path, sum) catch return false;
+        return true;
+    }
+    if (total_bytes) |total| {
+        if (size == total) return true;
+        if (shouldProbeLinkedPayloadSize(filename, total) and size > total) return true;
+    }
+    return false;
 }
 
 fn existingFileSize(dir: std.Io.Dir, io: std.Io, path: []const u8) !u64 {
@@ -2054,6 +2129,97 @@ test "downloadFile resumes from partial file with 206 response" {
     var log_buf: [128]u8 = undefined;
     const log_n = try log_file.readStreaming(io, &.{log_buf[0..]});
     try std.testing.expect(std.mem.indexOf(u8, log_buf[0..log_n], "bytes=6-") != null);
+}
+
+test "downloadFile skips existing complete destination before network" {
+    const allocator = std.testing.allocator;
+    const io = std.testing.io;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const payload = "already downloaded";
+    const dest_dir = try testTmpPath(allocator, tmp, "downloads");
+    defer allocator.free(dest_dir);
+    try std.Io.Dir.cwd().createDirPath(io, dest_dir);
+    const final_path = try std.fs.path.join(allocator, &.{ dest_dir, "model.gguf" });
+    defer allocator.free(final_path);
+    try std.Io.Dir.cwd().writeFile(io, .{ .sub_path = final_path, .data = payload });
+
+    try downloadFile(allocator, io, "owner", "name", "model.gguf", dest_dir, .{
+        .base_url = "http://127.0.0.1:1",
+    }, .{}, 0, 1, payload.len, null);
+
+    const part_path = try std.fs.path.join(allocator, &.{ dest_dir, "model.gguf.part" });
+    defer allocator.free(part_path);
+    try std.testing.expectError(error.FileNotFound, std.Io.Dir.cwd().openFile(io, part_path, .{}));
+
+    var file = try std.Io.Dir.cwd().openFile(io, final_path, .{});
+    defer file.close(io);
+    var buf: [64]u8 = undefined;
+    const n = try file.readStreaming(io, &.{buf[0..]});
+    try std.testing.expectEqualStrings(payload, buf[0..n]);
+}
+
+test "downloadFile skips existing large artifact with pointer-sized metadata" {
+    const allocator = std.testing.allocator;
+    const io = std.testing.io;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const payload = [_]u8{'G'} ** 8192;
+    const dest_dir = try testTmpPath(allocator, tmp, "downloads");
+    defer allocator.free(dest_dir);
+    try std.Io.Dir.cwd().createDirPath(io, dest_dir);
+    const final_path = try std.fs.path.join(allocator, &.{ dest_dir, "model.gguf" });
+    defer allocator.free(final_path);
+    try std.Io.Dir.cwd().writeFile(io, .{ .sub_path = final_path, .data = &payload });
+
+    try downloadFile(allocator, io, "owner", "name", "model.gguf", dest_dir, .{
+        .base_url = "http://127.0.0.1:1",
+    }, .{}, 0, 1, 102, null);
+
+    const part_path = try std.fs.path.join(allocator, &.{ dest_dir, "model.gguf.part" });
+    defer allocator.free(part_path);
+    try std.testing.expectError(error.FileNotFound, std.Io.Dir.cwd().openFile(io, part_path, .{}));
+
+    var file = try std.Io.Dir.cwd().openFile(io, final_path, .{});
+    defer file.close(io);
+    const stat = try file.stat(io);
+    try std.testing.expectEqual(@as(u64, payload.len), stat.size);
+}
+
+test "tiny declared sizes are reprobed for large binary model artifacts" {
+    try std.testing.expect(shouldProbeLinkedPayloadSize("model.gguf", 102));
+    try std.testing.expect(shouldProbeLinkedPayloadSize("model.safetensors", 102));
+    try std.testing.expect(!shouldProbeLinkedPayloadSize("README.md", 102));
+    try std.testing.expect(!shouldProbeLinkedPayloadSize("model.gguf", 10 * 1024));
+}
+
+test "existing final file progress uses real size for pointer-sized artifacts" {
+    const allocator = std.testing.allocator;
+    const io = std.testing.io;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const payload = [_]u8{'G'} ** 8192;
+    const dest_dir = try testTmpPath(allocator, tmp, "downloads");
+    defer allocator.free(dest_dir);
+    try std.Io.Dir.cwd().createDirPath(io, dest_dir);
+    const final_path = try std.fs.path.join(allocator, &.{ dest_dir, "model.gguf" });
+    defer allocator.free(final_path);
+    try std.Io.Dir.cwd().writeFile(io, .{ .sub_path = final_path, .data = &payload });
+
+    try std.testing.expectEqual(
+        @as(?u64, payload.len),
+        try existingFinalFileProgressSize(allocator, io, dest_dir, "model.gguf", 102),
+    );
+    try std.testing.expectEqual(
+        @as(?u64, 102),
+        try existingFinalFileProgressSize(allocator, io, dest_dir, "README.md", 102),
+    );
 }
 
 test "downloadFile restarts cleanly when range is ignored" {


### PR DESCRIPTION
## Summary

Makes Gemma4 E2B GGUF tool calling production-ready on Metal across the local inference surfaces, with CLI support and real-model readiness gates.

This adds CLI tool-calling support, validates normalized OpenAI-style tool-call output, and makes the Metal live whole-model executor tool-aware so forced Gemma4 tool calls complete on the fast path without falling back.

## Key Changes

- Added `antfly inference generate` tool-calling support:
  - `--tools <path.json>`
  - `--tool-choice auto|none|required|<function-name>`
  - Forced function validation against the supplied tools file
  - Shared `tool_parser.zig` formatting/parsing path with server behavior
  - Normalized chat-completion-style JSON output when tools are enabled

- Made the Gemma4 Metal live whole-model executor tool-aware:
  - Feeds decoded text deltas into the shared tool parser during generation
  - Stops on completed tool calls with `finish_reason="tool_calls"`
  - Preserves plain text behavior when tools are absent
  - Forces host-logits prefill for tool-mode fast path to avoid prepared-tail marker-token loops

- Added/strengthened real-model readiness gates:
  - Server Metal Gemma4 tool-calling smoke
  - CLI Metal Gemma4 tool-calling smoke
  - CLI smoke now asserts the live whole-model executor is used and does not fall back

- Improved GGUF model download behavior:
  - Avoids duplicate temp/download work when final model files already exist
  - Handles large artifact metadata safely
  - Shows accurate existing-file progress/status

## Validation

Passed:

- `zig build test -- --test-filter tool`
- `zig build test -Dmetal=true -- --test-filter tool`
- `zig build test -Dmetal=true -- --test-filter gemma4`
- `zig build -Dmetal=true -Dmlx=false -Donnx=false -Dpjrt=false`
- `zig build test-metal-gemma4-cli-tool-calling -Dmetal=true -Dmlx=false -Donnx=false -Dpjrt=false`

Note: real-model Metal smoke was run outside the Codex sandbox so macOS Metal device access was available.
