### PR TITLE
Align dense stress test with stable vector ids

### DIFF
--- a/zig/pkg/antfly/src/storage/db/db.zig
+++ b/zig/pkg/antfly/src/storage/db/db.zig
@@ -30710,13 +30710,16 @@ test "db io_threaded executor stress applies explicit dense embeddings on lsm ba
     const entry = db.core.index_manager.denseIndex("dv_v1") orelse return error.IndexNotFound;
     try std.testing.expectEqual(@as(u64, @intCast(total_docs)), entry.index.stats().active_count);
 
-    const first_doc = (try db.core.index_manager.lookupDenseDocKey(db.core.store, "dv_v1", 1)) orelse return error.TestUnexpectedResult;
+    const first_vector_id = (try db.core.index_manager.lookupDenseVectorId(db.core.store, "dv_v1", "doc:00000000")) orelse return error.TestUnexpectedResult;
+    try std.testing.expectEqual(denseTestVectorId("doc:00000000"), first_vector_id);
+    const first_doc = (try db.core.index_manager.lookupDenseDocKey(db.core.store, "dv_v1", first_vector_id)) orelse return error.TestUnexpectedResult;
     defer alloc.free(first_doc);
     try std.testing.expectEqualStrings("doc:00000000", first_doc);
 
-    const last_vector_id: u64 = @intCast(total_docs);
     const expected_last_doc = try std.fmt.allocPrint(alloc, "doc:{d:0>8}", .{total_docs - 1});
     defer alloc.free(expected_last_doc);
+    const last_vector_id = (try db.core.index_manager.lookupDenseVectorId(db.core.store, "dv_v1", expected_last_doc)) orelse return error.TestUnexpectedResult;
+    try std.testing.expectEqual(denseTestVectorId(expected_last_doc), last_vector_id);
     const last_doc = (try db.core.index_manager.lookupDenseDocKey(db.core.store, "dv_v1", last_vector_id)) orelse return error.TestUnexpectedResult;
     defer alloc.free(last_doc);
     try std.testing.expectEqualStrings(expected_last_doc, last_doc);


### PR DESCRIPTION
## Summary
- update the gated dense `io_threaded` stress assertion to use stable deterministic vector ids instead of assuming sequential vector ids
- verify doc key -> stable vector id -> reverse doc key mapping for first and last stress docs
- keep the final vector payload assertion keyed by the resolved stable vector id
- audit related core DB dense/provisioned test patterns for the same stale assumption; no additional stale reverse-lookup assertions needed code changes

## Audit notes
- CI compiles this gated stress test through `unit-test`/`lib-db-test`, but the stress body only runs when `ANTFLY_STRESS_DB_DENSE_REPRO=1` is set.
- The stale assumption was test-only: current dense behavior intentionally assigns stable vector ids from document keys rather than sequential `1..N` ids.
- Related stable-vector-id and ordinal-mapping tests already cover current behavior; this PR brings the gated stress assertion back in line with those contracts.

## Verification
```text
cd zig && ANTFLY_STRESS_DB_DENSE_REPRO=1 ANTFLY_STRESS_DENSE_DOCS=128 ANTFLY_STRESS_DENSE_BATCH=32 ANTFLY_STRESS_DENSE_DIMS=32 ANTFLY_STRESS_DENSE_PROGRESS=64 zig build lib-db-test --summary all -- --test-filter "storage.db.db.test.db io_threaded executor stress applies explicit dense embeddings on lsm backend"
# 8/8 passed

cd zig && ANTFLY_STRESS_DB_DENSE_REPRO=1 zig build lib-db-test --summary all -- --test-filter "storage.db.db.test.db io_threaded executor stress applies explicit dense embeddings on lsm backend"
# 8/8 passed

cd zig && zig build lib-db-test --summary all -- --test-filter "storage.db.db.test.dense vector id uses deterministic key hash with legacy mapping fallback" "storage.db.db.test.dense vector id ignores ordinal metadata for a different doc"
# 7/7 passed

cd zig && ANTFLY_STRESS_DENSE_EMBED_REPRO=1 ANTFLY_STRESS_DENSE_DOCS=128 ANTFLY_STRESS_DENSE_BATCH=32 ANTFLY_STRESS_DENSE_DIMS=32 ANTFLY_STRESS_DENSE_PROGRESS=64 zig build lib-db-test --summary all -- --test-filter "storage.db.catalog.index_manager.test.dense index manager stress applies explicit embedding writes on lsm backend"
# 8/8 passed

cd zig && zig build lib-db-test --summary all -- --test-filter "storage.db.db.test.db dense index stores stable vector ids with ordinal filter mappings" "storage.db.db.test.db dense artifact rebuild preserves stable vector ids distinct from ordinals" "storage.db.query.search_exec.test.native dense constraints fail closed without ordinal vector mapping"
# 10/10 passed
```
