### PR TITLE
Read-path scalability, quarantine self-heal, and HBC link repair

### DIFF
--- a/zig/lib/onnx/src/ops.zig
+++ b/zig/lib/onnx/src/ops.zig
@@ -1562,7 +1562,11 @@ fn convertSlice(allocator: std.mem.Allocator, builder: *Builder, node: *const No
 
     // Apply specified axes
     for (0..starts_data.len) |i| {
-        const ax: u8 = if (axes_data) |ad| @intCast(@as(i64, @intFromFloat(ad[i]))) else @intCast(i);
+        // Normalize negative axes
+        var ax_val: i64 = if (axes_data) |ad| @intFromFloat(ad[i]) else @intCast(i);
+        if (ax_val < 0) ax_val += in_shape.rank();
+        if (ax_val < 0 or ax_val >= in_shape.rank()) return error.InvalidAttribute;
+        const ax: u8 = @intCast(ax_val);
         // Clamp to i64 range — ONNX uses INT64_MAX as "to the end" sentinel,
         // which overflows when round-tripped through f32.
         var start: i64 = clampF32ToI64(starts_data[i]);

--- a/zig/lib/vectorindex/src/hbc_index.zig
+++ b/zig/lib/vectorindex/src/hbc_index.zig
@@ -3739,19 +3739,25 @@ fn batchDeleteTxn(self: anytype, txn: anytype, vector_ids: []const u64) !void {
 /// is flagged for a repairTreeLinks sweep that clears the dangling
 /// reference instead of leaving it latent.
 fn removeChildLink(self: anytype, parent: anytype, leaf_id: u64) !bool {
-    var contains = false;
+    var match_count: usize = 0;
     for (parent.children) |cid| {
-        if (cid == leaf_id) {
-            contains = true;
-            break;
-        }
+        if (cid == leaf_id) match_count += 1;
     }
-    if (!contains) {
+    if (match_count == 0) {
         std.log.warn("hbc: leaf {d} not referenced by its recorded parent; skipping unlink", .{leaf_id});
         noteTreeLinkInconsistencyIfSupported(self);
         return false;
     }
-    var new_children = try self.alloc.alloc(u64, parent.children.len - 1);
+    if (match_count > 1) {
+        // Duplicate links to the same child are corruption. The leaf is
+        // being unlinked for deletion, so drop every occurrence — sizing
+        // the new array by the exact match count, or the skip loop below
+        // would underfill it and persist an uninitialized child id — and
+        // flag a repair sweep for the rest of the tree.
+        std.log.warn("hbc: leaf {d} referenced {d} times by its parent; removing all links", .{ leaf_id, match_count });
+        noteTreeLinkInconsistencyIfSupported(self);
+    }
+    var new_children = try self.alloc.alloc(u64, parent.children.len - match_count);
     errdefer self.alloc.free(new_children);
     var wi_child: usize = 0;
     for (parent.children) |cid| {
@@ -3956,7 +3962,17 @@ pub fn repairTreeLinks(self: anytype, txn: anytype, max_nodes: usize) !TreeLinkR
                 try self.saveNode(txn, &child);
                 report.parent_pointers_fixed += 1;
             }
+            const gop = try seen.getOrPut(self.alloc, child_id);
+            if (gop.found_existing) {
+                // Second reference to a node we already kept — either a
+                // duplicate within this children list or another visited
+                // parent legitimately holds it. Drop this occurrence.
+                report.duplicate_children_removed += 1;
+                pruned = true;
+                continue;
+            }
             kept.appendAssumeCapacity(child_id);
+            try queue.append(self.alloc, child_id);
         }
 
         if (kept.items.len == 0) {
@@ -3996,11 +4012,6 @@ pub fn repairTreeLinks(self: anytype, txn: anytype, max_nodes: usize) !TreeLinkR
             try self.saveNode(txn, &node);
         }
 
-        for (kept.items) |child_id| {
-            const gop = try seen.getOrPut(self.alloc, child_id);
-            if (gop.found_existing) continue;
-            try queue.append(self.alloc, child_id);
-        }
     }
     return report;
 }

--- a/zig/lib/vectorindex/src/hbc_index.zig
+++ b/zig/lib/vectorindex/src/hbc_index.zig
@@ -3685,19 +3685,14 @@ fn batchDeleteTxn(self: anytype, txn: anytype, vector_ids: []const u64) !void {
             var parent = try loadNode(self, txn, leaf.parent);
             defer parent.deinit(self.alloc);
             try parent.ensureUnbacked(self.alloc);
-            var new_children = try self.alloc.alloc(u64, parent.children.len - 1);
-            var wi_child: usize = 0;
-            for (parent.children) |cid| {
-                if (cid == leaf_id) continue;
-                new_children[wi_child] = cid;
-                wi_child += 1;
+            if (try removeChildLink(self, &parent, leaf_id)) {
+                try recomputeInternalCentroid(self, txn, &parent);
+                try self.saveNode(txn, &parent);
+                try deleteNode(self, txn, leaf_id);
+                try collapseSingleChildParents(self, txn, leaf.parent);
+            } else {
+                try deleteNode(self, txn, leaf_id);
             }
-            self.alloc.free(parent.children);
-            parent.children = new_children;
-            try recomputeInternalCentroid(self, txn, &parent);
-            try self.saveNode(txn, &parent);
-            try deleteNode(self, txn, leaf_id);
-            try collapseSingleChildParents(self, txn, leaf.parent);
         } else {
             try self.saveNode(txn, &leaf);
         }
@@ -3713,6 +3708,36 @@ fn batchDeleteTxn(self: anytype, txn: anytype, vector_ids: []const u64) !void {
         self.metadata.active_count -|= @intCast(removed_count);
         group_start = group_end;
     }
+}
+
+/// Removes leaf_id from parent.children, replacing the slice. Returns false
+/// — leaving the parent untouched — when the recorded parent does not
+/// actually reference the leaf. That happens when a stale parent link
+/// survives tree maintenance; rebuilding children with len-1 in that state
+/// used to overrun the new array and panic the whole process.
+fn removeChildLink(self: anytype, parent: anytype, leaf_id: u64) !bool {
+    var contains = false;
+    for (parent.children) |cid| {
+        if (cid == leaf_id) {
+            contains = true;
+            break;
+        }
+    }
+    if (!contains) {
+        std.log.warn("hbc: leaf {d} not referenced by its recorded parent; skipping unlink", .{leaf_id});
+        return false;
+    }
+    var new_children = try self.alloc.alloc(u64, parent.children.len - 1);
+    errdefer self.alloc.free(new_children);
+    var wi_child: usize = 0;
+    for (parent.children) |cid| {
+        if (cid == leaf_id) continue;
+        new_children[wi_child] = cid;
+        wi_child += 1;
+    }
+    self.alloc.free(parent.children);
+    parent.children = new_children;
+    return true;
 }
 
 pub fn deleteTxn(self: anytype, txn: anytype, vector_id: u64) !void {
@@ -3740,19 +3765,14 @@ pub fn deleteTxn(self: anytype, txn: anytype, vector_id: u64) !void {
         var parent = try loadNode(self, txn, leaf.parent);
         defer parent.deinit(self.alloc);
         try parent.ensureUnbacked(self.alloc);
-        var new_children = try self.alloc.alloc(u64, parent.children.len - 1);
-        var wi_child: usize = 0;
-        for (parent.children) |cid| {
-            if (cid == leaf_id) continue;
-            new_children[wi_child] = cid;
-            wi_child += 1;
+        if (try removeChildLink(self, &parent, leaf_id)) {
+            try recomputeInternalCentroid(self, txn, &parent);
+            try self.saveNode(txn, &parent);
+            try deleteNode(self, txn, leaf_id);
+            try collapseSingleChildParents(self, txn, leaf.parent);
+        } else {
+            try deleteNode(self, txn, leaf_id);
         }
-        self.alloc.free(parent.children);
-        parent.children = new_children;
-        try recomputeInternalCentroid(self, txn, &parent);
-        try self.saveNode(txn, &parent);
-        try deleteNode(self, txn, leaf_id);
-        try collapseSingleChildParents(self, txn, leaf.parent);
     } else {
         try self.saveNode(txn, &leaf);
 
@@ -3789,19 +3809,14 @@ pub fn deleteTxn(self: anytype, txn: anytype, vector_id: u64) !void {
                 try self.saveNode(txn, &sibling);
                 for (leaf.members) |mid| try self.putVecLeaf(txn, mid, best_sibling_id);
 
-                var new_children = try self.alloc.alloc(u64, parent.children.len - 1);
-                var wi_child: usize = 0;
-                for (parent.children) |cid| {
-                    if (cid == leaf_id) continue;
-                    new_children[wi_child] = cid;
-                    wi_child += 1;
+                if (try removeChildLink(self, &parent, leaf_id)) {
+                    try recomputeInternalCentroid(self, txn, &parent);
+                    try self.saveNode(txn, &parent);
+                    try deleteNode(self, txn, leaf_id);
+                    try collapseSingleChildParents(self, txn, leaf.parent);
+                } else {
+                    try deleteNode(self, txn, leaf_id);
                 }
-                self.alloc.free(parent.children);
-                parent.children = new_children;
-                try recomputeInternalCentroid(self, txn, &parent);
-                try self.saveNode(txn, &parent);
-                try deleteNode(self, txn, leaf_id);
-                try collapseSingleChildParents(self, txn, leaf.parent);
             }
         }
     }
@@ -4280,20 +4295,14 @@ pub fn removeFromLeaf(self: anytype, txn: anytype, leaf_id: u64, vector_id: u64)
         var parent = try loadNode(self, txn, leaf.parent);
         defer parent.deinit(self.alloc);
         try parent.ensureUnbacked(self.alloc);
-        var new_children = try self.alloc.alloc(u64, parent.children.len - 1);
-        errdefer self.alloc.free(new_children);
-        var wi_child: usize = 0;
-        for (parent.children) |cid| {
-            if (cid == leaf_id) continue;
-            new_children[wi_child] = cid;
-            wi_child += 1;
+        if (try removeChildLink(self, &parent, leaf_id)) {
+            try recomputeInternalCentroid(self, txn, &parent);
+            try self.saveNodeWithOptionsMode(txn, &parent, .{}, false);
+            try deleteNode(self, txn, leaf_id);
+            try collapseSingleChildParents(self, txn, leaf.parent);
+        } else {
+            try deleteNode(self, txn, leaf_id);
         }
-        self.alloc.free(parent.children);
-        parent.children = new_children;
-        try recomputeInternalCentroid(self, txn, &parent);
-        try self.saveNodeWithOptionsMode(txn, &parent, .{}, false);
-        try deleteNode(self, txn, leaf_id);
-        try collapseSingleChildParents(self, txn, leaf.parent);
         return;
     }
 
@@ -4333,20 +4342,14 @@ pub fn removeFromLeaf(self: anytype, txn: anytype, leaf_id: u64, vector_id: u64)
             try self.saveNodeWithOptionsMode(txn, &sibling, .{}, false);
             for (leaf.members) |mid| try self.putVecLeaf(txn, mid, best_sibling_id);
 
-            var new_children = try self.alloc.alloc(u64, parent.children.len - 1);
-            errdefer self.alloc.free(new_children);
-            var wi_child: usize = 0;
-            for (parent.children) |cid| {
-                if (cid == leaf_id) continue;
-                new_children[wi_child] = cid;
-                wi_child += 1;
+            if (try removeChildLink(self, &parent, leaf_id)) {
+                try recomputeInternalCentroid(self, txn, &parent);
+                try self.saveNodeWithOptionsMode(txn, &parent, .{}, false);
+                try deleteNode(self, txn, leaf_id);
+                try collapseSingleChildParents(self, txn, leaf.parent);
+            } else {
+                try deleteNode(self, txn, leaf_id);
             }
-            self.alloc.free(parent.children);
-            parent.children = new_children;
-            try recomputeInternalCentroid(self, txn, &parent);
-            try self.saveNodeWithOptionsMode(txn, &parent, .{}, false);
-            try deleteNode(self, txn, leaf_id);
-            try collapseSingleChildParents(self, txn, leaf.parent);
         }
     }
 }

--- a/zig/lib/vectorindex/src/hbc_index.zig
+++ b/zig/lib/vectorindex/src/hbc_index.zig
@@ -3660,7 +3660,17 @@ fn batchDeleteTxn(self: anytype, txn: anytype, vector_ids: []const u64) !void {
         const group = prepared.items[group_start..group_end];
         const leaf_id = group[0].leaf_id;
 
-        var leaf = try loadNode(self, txn, leaf_id);
+        var leaf = loadNode(self, txn, leaf_id) catch |err| {
+            if (!isNotFoundGeneric(err)) return err;
+            // Stale vec→leaf mappings into a deleted node: the vectors are
+            // unreachable by search, so drop their keys instead of failing
+            // the whole batch, and flag a repair sweep.
+            noteTreeLinkInconsistencyIfSupported(self);
+            for (group) |entry| deleteVectorKeys(self, txn, entry.vector_id);
+            self.metadata.active_count -|= @intCast(group.len);
+            group_start = group_end;
+            continue;
+        };
         defer leaf.deinit(self.alloc);
         try leaf.ensureUnbacked(self.alloc);
 
@@ -3682,29 +3692,31 @@ fn batchDeleteTxn(self: anytype, txn: anytype, vector_ids: []const u64) !void {
         }
 
         if (leaf.members.len == 0 and leaf.parent != 0) {
-            var parent = try loadNode(self, txn, leaf.parent);
-            defer parent.deinit(self.alloc);
-            try parent.ensureUnbacked(self.alloc);
-            if (try removeChildLink(self, &parent, leaf_id)) {
-                try recomputeInternalCentroid(self, txn, &parent);
-                try self.saveNode(txn, &parent);
-                try deleteNode(self, txn, leaf_id);
-                try collapseSingleChildParents(self, txn, leaf.parent);
-            } else {
-                try deleteNode(self, txn, leaf_id);
+            unlink: {
+                var parent = loadNode(self, txn, leaf.parent) catch |err| {
+                    if (!isNotFoundGeneric(err)) return err;
+                    // Dangling parent pointer: delete the empty leaf and let
+                    // the repair sweep clear whatever still references it.
+                    noteTreeLinkInconsistencyIfSupported(self);
+                    try deleteNode(self, txn, leaf_id);
+                    break :unlink;
+                };
+                defer parent.deinit(self.alloc);
+                try parent.ensureUnbacked(self.alloc);
+                if (try removeChildLink(self, &parent, leaf_id)) {
+                    try recomputeInternalCentroid(self, txn, &parent);
+                    try self.saveNode(txn, &parent);
+                    try deleteNode(self, txn, leaf_id);
+                    try collapseSingleChildParents(self, txn, leaf.parent);
+                } else {
+                    try deleteNode(self, txn, leaf_id);
+                }
             }
         } else {
             try self.saveNode(txn, &leaf);
         }
 
-        var vkey_buf: [10]u8 = undefined;
-        for (group) |entry| {
-            self.deleteNamespaced(txn, .vecs, hbc.encodeVecKey(&vkey_buf, entry.vector_id)) catch {};
-            self.deleteNamespaced(txn, .vecs, hbc.encodeVecLeafKey(&vkey_buf, entry.vector_id)) catch {};
-            self.deleteNamespaced(txn, .vecs, hbc.encodeVecMetaKey(&vkey_buf, entry.vector_id)) catch {};
-            self.invalidateVectorCache(entry.vector_id);
-            self.invalidateMetadataCache(entry.vector_id);
-        }
+        for (group) |entry| deleteVectorKeys(self, txn, entry.vector_id);
         self.metadata.active_count -|= @intCast(removed_count);
         group_start = group_end;
     }
@@ -3714,7 +3726,10 @@ fn batchDeleteTxn(self: anytype, txn: anytype, vector_ids: []const u64) !void {
 /// — leaving the parent untouched — when the recorded parent does not
 /// actually reference the leaf. That happens when a stale parent link
 /// survives tree maintenance; rebuilding children with len-1 in that state
-/// used to overrun the new array and panic the whole process.
+/// used to overrun the new array and panic the whole process. When this
+/// fires, some OTHER node may still list leaf_id as a child, so the index
+/// is flagged for a repairTreeLinks sweep that clears the dangling
+/// reference instead of leaving it latent.
 fn removeChildLink(self: anytype, parent: anytype, leaf_id: u64) !bool {
     var contains = false;
     for (parent.children) |cid| {
@@ -3725,6 +3740,7 @@ fn removeChildLink(self: anytype, parent: anytype, leaf_id: u64) !bool {
     }
     if (!contains) {
         std.log.warn("hbc: leaf {d} not referenced by its recorded parent; skipping unlink", .{leaf_id});
+        noteTreeLinkInconsistencyIfSupported(self);
         return false;
     }
     var new_children = try self.alloc.alloc(u64, parent.children.len - 1);
@@ -3740,14 +3756,306 @@ fn removeChildLink(self: anytype, parent: anytype, leaf_id: u64) !bool {
     return true;
 }
 
+/// Signals the concrete index (when it supports it) that a tree-link
+/// inconsistency was observed, so background maintenance schedules a
+/// repairTreeLinks sweep.
+fn noteTreeLinkInconsistencyIfSupported(self: anytype) void {
+    const Index = comptime childType(@TypeOf(self));
+    if (comptime @hasDecl(Index, "noteTreeLinkInconsistency")) {
+        self.noteTreeLinkInconsistency();
+    }
+}
+
+pub const TreeLinkReport = struct {
+    nodes_visited: u64 = 0,
+    /// Child ids referenced by an internal node whose node record is gone,
+    /// plus duplicate references to an already-visited node.
+    dangling_children: u64 = 0,
+    /// Nodes whose recorded parent differs from the node that references them.
+    parent_mismatches: u64 = 0,
+    /// Internal nodes with zero children.
+    empty_internal_nodes: u64 = 0,
+    /// Leaf members whose vec→leaf mapping is missing or points elsewhere.
+    vec_leaf_mismatches: u64 = 0,
+
+    pub fn consistent(self: TreeLinkReport) bool {
+        return self.dangling_children == 0 and
+            self.parent_mismatches == 0 and
+            self.empty_internal_nodes == 0 and
+            self.vec_leaf_mismatches == 0;
+    }
+};
+
+/// Walks the tree from the root and checks the structural invariants that
+/// maintenance must preserve: every referenced child exists, every node's
+/// recorded parent is the node that references it, internal nodes are
+/// non-empty, and every leaf member's vec→leaf mapping points back at its
+/// leaf. Read-only; usable with a read transaction. Intended for tests and
+/// debugging — it visits every node and every member mapping.
+pub fn verifyTreeLinks(self: anytype, txn: anytype) !TreeLinkReport {
+    var report: TreeLinkReport = .{};
+    const QueueItem = struct { id: u64, parent: u64 };
+    var queue = std.ArrayListUnmanaged(QueueItem).empty;
+    defer queue.deinit(self.alloc);
+    var seen = std.AutoHashMapUnmanaged(u64, void).empty;
+    defer seen.deinit(self.alloc);
+
+    try queue.append(self.alloc, .{ .id = self.metadata.root_node, .parent = 0 });
+    try seen.put(self.alloc, self.metadata.root_node, {});
+
+    var qi: usize = 0;
+    while (qi < queue.items.len) : (qi += 1) {
+        const item = queue.items[qi];
+        var node = loadNode(self, txn, item.id) catch |err| {
+            if (!isNotFoundGeneric(err)) return err;
+            report.dangling_children += 1;
+            continue;
+        };
+        defer node.deinit(self.alloc);
+        report.nodes_visited += 1;
+        if (node.parent != item.parent) report.parent_mismatches += 1;
+        if (node.is_leaf) {
+            for (node.members) |member_id| {
+                const mapped = self.getVecLeaf(txn, member_id) catch |err| {
+                    if (!isNotFoundGeneric(err)) return err;
+                    report.vec_leaf_mismatches += 1;
+                    continue;
+                };
+                if (mapped != item.id) report.vec_leaf_mismatches += 1;
+            }
+            continue;
+        }
+        if (node.children.len == 0) report.empty_internal_nodes += 1;
+        for (node.children) |child_id| {
+            const gop = try seen.getOrPut(self.alloc, child_id);
+            if (gop.found_existing) {
+                // The same node is referenced from two places (duplicate
+                // link or cycle); count it without re-walking.
+                report.dangling_children += 1;
+                continue;
+            }
+            try queue.append(self.alloc, .{ .id = child_id, .parent = item.id });
+        }
+    }
+    return report;
+}
+
+pub const TreeLinkRepairReport = struct {
+    nodes_visited: u64 = 0,
+    dangling_children_removed: u64 = 0,
+    duplicate_children_removed: u64 = 0,
+    parent_pointers_fixed: u64 = 0,
+    empty_nodes_removed: u64 = 0,
+    vec_leaf_mappings_fixed: u64 = 0,
+    /// False when the node budget ran out before the walk finished; call
+    /// again to continue (repairs already made are persisted).
+    completed: bool = true,
+
+    pub fn repaired(self: TreeLinkRepairReport) u64 {
+        return self.dangling_children_removed +
+            self.duplicate_children_removed +
+            self.parent_pointers_fixed +
+            self.empty_nodes_removed +
+            self.vec_leaf_mappings_fixed;
+    }
+};
+
+/// Repairs the invariants verifyTreeLinks checks, treating the reachable
+/// children lists as authoritative:
+///   - a child id whose node record is gone is dropped from its parent;
+///   - a child referenced both here and by its recorded parent keeps the
+///     recorded link and loses the duplicate;
+///   - a child whose recorded parent is stale (gone, or not referencing it)
+///     is repointed at the node that actually references it;
+///   - an internal node left with zero children is unlinked and deleted
+///     (the root is converted back to an empty leaf instead);
+///   - leaf members' vec→leaf mappings are repointed at the leaf that
+///     actually holds them.
+/// Bounded by `max_nodes` per call; repairs are persisted as the walk goes,
+/// so a budget-exhausted sweep (`completed == false`) resumes safely on the
+/// next call. Must run inside a write transaction; single-writer, like all
+/// HBC maintenance.
+pub fn repairTreeLinks(self: anytype, txn: anytype, max_nodes: usize) !TreeLinkRepairReport {
+    try self.bindTxnLike(txn);
+    var report: TreeLinkRepairReport = .{};
+    var queue = std.ArrayListUnmanaged(u64).empty;
+    defer queue.deinit(self.alloc);
+    var seen = std.AutoHashMapUnmanaged(u64, void).empty;
+    defer seen.deinit(self.alloc);
+
+    try queue.append(self.alloc, self.metadata.root_node);
+    try seen.put(self.alloc, self.metadata.root_node, {});
+
+    var qi: usize = 0;
+    while (qi < queue.items.len) : (qi += 1) {
+        if (report.nodes_visited >= max_nodes) {
+            report.completed = false;
+            break;
+        }
+        const node_id = queue.items[qi];
+        var node = loadNode(self, txn, node_id) catch |err| {
+            // A node can disappear mid-sweep when pruning an empty parent
+            // collapses part of the tree we already queued.
+            if (!isNotFoundGeneric(err)) return err;
+            continue;
+        };
+        defer node.deinit(self.alloc);
+        report.nodes_visited += 1;
+
+        if (node.is_leaf) {
+            for (node.members) |member_id| {
+                const mapped: ?u64 = self.getVecLeaf(txn, member_id) catch |err| blk: {
+                    if (!isNotFoundGeneric(err)) return err;
+                    break :blk null;
+                };
+                if (mapped == null or mapped.? != node_id) {
+                    try self.putVecLeaf(txn, member_id, node_id);
+                    report.vec_leaf_mappings_fixed += 1;
+                }
+            }
+            continue;
+        }
+
+        try node.ensureUnbacked(self.alloc);
+        var kept = std.ArrayListUnmanaged(u64).empty;
+        defer kept.deinit(self.alloc);
+        try kept.ensureTotalCapacity(self.alloc, node.children.len);
+        var pruned = false;
+        for (node.children) |child_id| {
+            const child_parent: ?u64 = loadNodeParent(self, txn, child_id) catch |err| blk: {
+                if (!isNotFoundGeneric(err)) return err;
+                break :blk null;
+            };
+            if (child_parent == null) {
+                report.dangling_children_removed += 1;
+                pruned = true;
+                continue;
+            }
+            if (child_parent.? != node_id) {
+                if (try nodeReferencesChild(self, txn, child_parent.?, child_id)) {
+                    // The recorded parent also references this child: keep
+                    // that link, drop this duplicate.
+                    report.duplicate_children_removed += 1;
+                    pruned = true;
+                    continue;
+                }
+                // Recorded parent is stale; this node actually holds the
+                // child, so repoint the child here.
+                var child = try loadNode(self, txn, child_id);
+                defer child.deinit(self.alloc);
+                try child.ensureUnbacked(self.alloc);
+                child.parent = node_id;
+                try self.saveNode(txn, &child);
+                report.parent_pointers_fixed += 1;
+            }
+            kept.appendAssumeCapacity(child_id);
+        }
+
+        if (kept.items.len == 0) {
+            if (node_id == self.metadata.root_node) {
+                // Convert an emptied root back into an empty leaf, mirroring
+                // a freshly created index.
+                node.is_leaf = true;
+                node.level = 0;
+                self.alloc.free(node.children);
+                node.children = &.{};
+                @memset(node.centroid, 0);
+                try self.saveNode(txn, &node);
+            } else {
+                const parent_id = node.parent;
+                try deleteNode(self, txn, node_id);
+                report.empty_nodes_removed += 1;
+                var parent = loadNode(self, txn, parent_id) catch |err| {
+                    if (!isNotFoundGeneric(err)) return err;
+                    continue;
+                };
+                defer parent.deinit(self.alloc);
+                try parent.ensureUnbacked(self.alloc);
+                if (try removeChildLink(self, &parent, node_id)) {
+                    try recomputeInternalCentroid(self, txn, &parent);
+                    try self.saveNode(txn, &parent);
+                    try collapseSingleChildParents(self, txn, parent_id);
+                }
+            }
+            continue;
+        }
+
+        if (pruned) {
+            const new_children = try self.alloc.dupe(u64, kept.items);
+            self.alloc.free(node.children);
+            node.children = new_children;
+            try recomputeInternalCentroid(self, txn, &node);
+            try self.saveNode(txn, &node);
+        }
+
+        for (kept.items) |child_id| {
+            const gop = try seen.getOrPut(self.alloc, child_id);
+            if (gop.found_existing) continue;
+            try queue.append(self.alloc, child_id);
+        }
+    }
+    return report;
+}
+
+/// Standalone repairTreeLinks: opens its own write transaction, flushes
+/// metadata (the sweep can change root/node bookkeeping via collapse), and
+/// republishes search state — mirroring delete()/batchDelete().
+pub fn repairLinks(self: anytype, max_nodes: usize) !TreeLinkRepairReport {
+    var txn = try self.beginRuntimeWriteTxn();
+    errdefer txn.abort();
+    const report = try repairTreeLinks(self, &txn, max_nodes);
+    try self.flushMetadata(&txn);
+    try txn.commit();
+    publishSearchStateIfSupported(self);
+    return report;
+}
+
+fn nodeReferencesChild(self: anytype, txn: anytype, parent_id: u64, child_id: u64) !bool {
+    if (parent_id == 0) return false;
+    var parent = loadNode(self, txn, parent_id) catch |err| {
+        if (!isNotFoundGeneric(err)) return err;
+        return false;
+    };
+    defer parent.deinit(self.alloc);
+    if (parent.is_leaf) return false;
+    for (parent.children) |cid| {
+        if (cid == child_id) return true;
+    }
+    return false;
+}
+
+/// Drops a vector's storage keys (raw vector, vec→leaf mapping, metadata)
+/// and invalidates its cache entries. Key deletes are best-effort.
+fn deleteVectorKeys(self: anytype, txn: anytype, vector_id: u64) void {
+    var vkey_buf: [10]u8 = undefined;
+    self.deleteNamespaced(txn, .vecs, hbc.encodeVecKey(&vkey_buf, vector_id)) catch {};
+    self.deleteNamespaced(txn, .vecs, hbc.encodeVecLeafKey(&vkey_buf, vector_id)) catch {};
+    self.deleteNamespaced(txn, .vecs, hbc.encodeVecMetaKey(&vkey_buf, vector_id)) catch {};
+    self.invalidateVectorCache(vector_id);
+    self.invalidateMetadataCache(vector_id);
+}
+
 pub fn deleteTxn(self: anytype, txn: anytype, vector_id: u64) !void {
     try self.bindTxnLike(txn);
-    const leaf_id = self.getVecLeaf(txn, vector_id) catch |err| blk: {
+    var leaf_id = self.getVecLeaf(txn, vector_id) catch |err| blk: {
         if (!isNotFoundGeneric(err)) return err;
         break :blk (try findLeafContainingMember(self, txn, self.metadata.root_node, vector_id)) orelse return error.NotFound;
     };
 
-    var leaf = try loadNode(self, txn, leaf_id);
+    var leaf = loadNode(self, txn, leaf_id) catch |err| blk: {
+        if (!isNotFoundGeneric(err)) return err;
+        // Stale vec→leaf mapping into a deleted node. Fall back to a scan;
+        // if no reachable leaf holds the vector, it is unreachable garbage —
+        // drop its keys instead of failing the delete, and flag a repair.
+        noteTreeLinkInconsistencyIfSupported(self);
+        const scanned = (try findLeafContainingMember(self, txn, self.metadata.root_node, vector_id)) orelse {
+            deleteVectorKeys(self, txn, vector_id);
+            self.metadata.active_count -|= 1;
+            return;
+        };
+        leaf_id = scanned;
+        break :blk try loadNode(self, txn, scanned);
+    };
     defer leaf.deinit(self.alloc);
     try leaf.ensureUnbacked(self.alloc);
 
@@ -3762,7 +4070,16 @@ pub fn deleteTxn(self: anytype, txn: anytype, vector_id: u64) !void {
     }
 
     if (leaf.members.len == 0 and leaf.parent != 0) {
-        var parent = try loadNode(self, txn, leaf.parent);
+        var parent = loadNode(self, txn, leaf.parent) catch |err| {
+            if (!isNotFoundGeneric(err)) return err;
+            // Dangling parent pointer: delete the empty leaf and let the
+            // repair sweep clear whichever node still references it.
+            noteTreeLinkInconsistencyIfSupported(self);
+            try deleteNode(self, txn, leaf_id);
+            deleteVectorKeys(self, txn, vector_id);
+            self.metadata.active_count -|= 1;
+            return;
+        };
         defer parent.deinit(self.alloc);
         try parent.ensureUnbacked(self.alloc);
         if (try removeChildLink(self, &parent, leaf_id)) {
@@ -3776,15 +4093,26 @@ pub fn deleteTxn(self: anytype, txn: anytype, vector_id: u64) !void {
     } else {
         try self.saveNode(txn, &leaf);
 
-        if (leaf.parent != 0 and leaf.members.len < minLeafOccupancy(self)) {
-            var parent = try loadNode(self, txn, leaf.parent);
+        if (leaf.parent != 0 and leaf.members.len < minLeafOccupancy(self)) skip_merge: {
+            var parent = loadNode(self, txn, leaf.parent) catch |err| {
+                if (!isNotFoundGeneric(err)) return err;
+                // Dangling parent pointer: the leaf is already saved; skip
+                // the merge attempt and flag a repair.
+                noteTreeLinkInconsistencyIfSupported(self);
+                break :skip_merge;
+            };
             defer parent.deinit(self.alloc);
             try parent.ensureUnbacked(self.alloc);
             var best_sibling_id: u64 = 0;
             var best_dist: f32 = std.math.inf(f32);
             for (parent.children) |cid| {
                 if (cid == leaf_id) continue;
-                var sibling = try loadNode(self, txn, cid);
+                var sibling = loadNode(self, txn, cid) catch |err| {
+                    if (!isNotFoundGeneric(err)) return err;
+                    // Dangling sibling reference; skip it and flag a repair.
+                    noteTreeLinkInconsistencyIfSupported(self);
+                    continue;
+                };
                 defer sibling.deinit(self.alloc);
                 if (!sibling.is_leaf) continue;
                 if (sibling.members.len + leaf.members.len > self.config.leaf_size) continue;
@@ -3821,12 +4149,7 @@ pub fn deleteTxn(self: anytype, txn: anytype, vector_id: u64) !void {
         }
     }
 
-    var vkey_buf: [10]u8 = undefined;
-    self.deleteNamespaced(txn, .vecs, hbc.encodeVecKey(&vkey_buf, vector_id)) catch {};
-    self.deleteNamespaced(txn, .vecs, hbc.encodeVecLeafKey(&vkey_buf, vector_id)) catch {};
-    self.deleteNamespaced(txn, .vecs, hbc.encodeVecMetaKey(&vkey_buf, vector_id)) catch {};
-    self.invalidateVectorCache(vector_id);
-    self.invalidateMetadataCache(vector_id);
+    deleteVectorKeys(self, txn, vector_id);
     self.metadata.active_count -= 1;
 }
 
@@ -4292,7 +4615,14 @@ pub fn removeFromLeaf(self: anytype, txn: anytype, leaf_id: u64, vector_id: u64)
     }
 
     if (leaf.members.len == 0 and leaf.parent != 0) {
-        var parent = try loadNode(self, txn, leaf.parent);
+        var parent = loadNode(self, txn, leaf.parent) catch |err| {
+            if (!isNotFoundGeneric(err)) return err;
+            // Dangling parent pointer: delete the empty leaf and let the
+            // repair sweep clear whatever still references it.
+            noteTreeLinkInconsistencyIfSupported(self);
+            try deleteNode(self, txn, leaf_id);
+            return;
+        };
         defer parent.deinit(self.alloc);
         try parent.ensureUnbacked(self.alloc);
         if (try removeChildLink(self, &parent, leaf_id)) {
@@ -4309,14 +4639,25 @@ pub fn removeFromLeaf(self: anytype, txn: anytype, leaf_id: u64, vector_id: u64)
     try self.saveNodeWithOptionsMode(txn, &leaf, .{}, false);
 
     if (leaf.parent != 0 and leaf.members.len < minLeafOccupancy(self)) {
-        var parent = try loadNode(self, txn, leaf.parent);
+        var parent = loadNode(self, txn, leaf.parent) catch |err| {
+            if (!isNotFoundGeneric(err)) return err;
+            // Dangling parent pointer: the leaf is already saved; skip the
+            // merge attempt and flag a repair.
+            noteTreeLinkInconsistencyIfSupported(self);
+            return;
+        };
         defer parent.deinit(self.alloc);
         try parent.ensureUnbacked(self.alloc);
         var best_sibling_id: u64 = 0;
         var best_dist: f32 = std.math.inf(f32);
         for (parent.children) |cid| {
             if (cid == leaf_id) continue;
-            var sibling = try loadNode(self, txn, cid);
+            var sibling = loadNode(self, txn, cid) catch |err| {
+                if (!isNotFoundGeneric(err)) return err;
+                // Dangling sibling reference; skip it and flag a repair.
+                noteTreeLinkInconsistencyIfSupported(self);
+                continue;
+            };
             defer sibling.deinit(self.alloc);
             if (!sibling.is_leaf) continue;
             if (sibling.members.len + leaf.members.len > self.config.leaf_size) continue;

--- a/zig/pkg/antfly/src/api/http_internal_group_read_routes.zig
+++ b/zig/pkg/antfly/src/api/http_internal_group_read_routes.zig
@@ -119,6 +119,12 @@ pub fn planSemanticQuery(
     });
     defer runtime.deinit();
 
+    // Signal background enrichment to yield the embedder while this
+    // query-time embed runs (see enrichment_types.interactive_embed_inflight).
+    // Scoped to the embed call only: BM25-only queries never set it, so
+    // steady full-text traffic does not stall enrichment throughput.
+    _ = db_mod.enrichment_types.interactive_embed_inflight.fetchAdd(1, .monotonic);
+    defer _ = db_mod.enrichment_types.interactive_embed_inflight.fetchSub(1, .monotonic);
     return .{
         .vector = if (embedding_template) |value|
             try runtime.embedQueryWithTemplate(alloc, index_name, semantic_search, value)

--- a/zig/pkg/antfly/src/api/http_server.zig
+++ b/zig/pkg/antfly/src/api/http_server.zig
@@ -5040,17 +5040,15 @@ pub const ApiHttpServer = struct {
         req: db_mod.types.SearchRequest,
         consistency: raft_mod.ReadConsistency,
     ) !?query_api.QueryResponse {
-        // Signal background enrichment to yield the embedder while this
-        // interactive query executes (see enrichment_types.public_query_inflight).
-        _ = db_mod.enrichment_types.public_query_inflight.fetchAdd(1, .monotonic);
-        defer _ = db_mod.enrichment_types.public_query_inflight.fetchSub(1, .monotonic);
         const retry_timeout_ns = 5 * std.time.ns_per_s;
         const retry_poll_ns = 25 * std.time.ns_per_ms;
         const start_ns = platform_time.monotonicNs();
         var attempts: u32 = 0;
         while (true) : (attempts += 1) {
             return source.query(alloc, table_name, req, consistency) catch |err| switch (err) {
-                error.EndOfStream => {
+                // TableReadChurn: the read cache gave up opening a table that
+                // was being invalidated faster than an open completes.
+                error.EndOfStream, error.TableReadChurn => {
                     std.log.warn("public table query read failed table={s} err={} attempt={d}", .{ table_name, err, attempts + 1 });
                     if (platform_time.monotonicNs() -| start_ns >= retry_timeout_ns) return err;
                     sleepNs(retry_poll_ns);

--- a/zig/pkg/antfly/src/api/http_server.zig
+++ b/zig/pkg/antfly/src/api/http_server.zig
@@ -5040,6 +5040,10 @@ pub const ApiHttpServer = struct {
         req: db_mod.types.SearchRequest,
         consistency: raft_mod.ReadConsistency,
     ) !?query_api.QueryResponse {
+        // Signal background enrichment to yield the embedder while this
+        // interactive query executes (see enrichment_types.public_query_inflight).
+        _ = db_mod.enrichment_types.public_query_inflight.fetchAdd(1, .monotonic);
+        defer _ = db_mod.enrichment_types.public_query_inflight.fetchSub(1, .monotonic);
         const retry_timeout_ns = 5 * std.time.ns_per_s;
         const retry_poll_ns = 25 * std.time.ns_per_ms;
         const start_ns = platform_time.monotonicNs();

--- a/zig/pkg/antfly/src/api/indexes.zig
+++ b/zig/pkg/antfly/src/api/indexes.zig
@@ -609,6 +609,7 @@ fn appendIndexRuntimeStatus(
 
 const AggregatedIndexStatus = struct {
     kind: ?db_mod.types.IndexKind = null,
+    load_error: ?[]const u8 = null,
     backfill_active: bool = false,
     backfill_progress: f64 = 0.0,
     enrichment_failed: bool = false,
@@ -722,6 +723,7 @@ fn aggregateIndexStatus(
         const item = findIndexStatus(runtime.stats.indexes, index_name) orelse continue;
         found = true;
         if (aggregate.kind == null) aggregate.kind = item.kind;
+        if (item.load_error != null and aggregate.load_error == null) aggregate.load_error = item.load_error;
         const runtime_present = runtime_status.statusHasRuntimeFacts(runtime);
         if (!runtime_present) continue;
         runtime_count += 1;
@@ -1199,6 +1201,17 @@ fn appendSingleIndexRuntimeStatus(
     }
     if (catch_up_active and catch_up_phase == .idle and replay_catch_up_required) catch_up_phase = .replay;
 
+    // An index whose persisted artifacts failed to load is broken, not
+    // rebuilding/warming: report the load error and suppress activity flags
+    // so clients classify it as needing a drop+recreate.
+    const load_error: ?[]const u8 = if (@hasField(@TypeOf(item), "load_error")) item.load_error else null;
+    if (load_error != null) {
+        backfill_active = false;
+        catch_up_active = false;
+        replay_catch_up_required = false;
+        catch_up_phase = .idle;
+    }
+
     try out.append(alloc, '{');
     if (index_type != .algebraic) {
         try appendJsonString(alloc, out, "index_type");
@@ -1232,7 +1245,17 @@ fn appendSingleIndexRuntimeStatus(
     defer alloc.free(progress);
     try out.appendSlice(alloc, progress);
     try out.appendSlice(alloc, ",\"backfill_state\":");
-    try appendJsonString(alloc, out, backfillState(index_type, backfill_active, item.enrichment_failed, replay_applied_sequence, replay_target_sequence, enrichment));
+    if (load_error != null) {
+        try appendJsonString(alloc, out, "failed");
+    } else {
+        try appendJsonString(alloc, out, backfillState(index_type, backfill_active, item.enrichment_failed, replay_applied_sequence, replay_target_sequence, enrichment));
+    }
+    if (load_error) |err_name| {
+        const msg = try std.fmt.allocPrint(alloc, "load failed: {s}", .{err_name});
+        defer alloc.free(msg);
+        try out.appendSlice(alloc, ",\"error\":");
+        try appendJsonString(alloc, out, msg);
+    }
     try out.appendSlice(alloc, ",\"doc_count\":");
     try appendIntValue(alloc, out, item.doc_count);
     try out.appendSlice(alloc, ",\"term_count\":");

--- a/zig/pkg/antfly/src/api/runtime_status.zig
+++ b/zig/pkg/antfly/src/api/runtime_status.zig
@@ -773,6 +773,7 @@ pub fn cloneDBStats(alloc: std.mem.Allocator, stats: db_mod.types.DBStats) !db_m
     errdefer {
         for (indexes[0..initialized]) |item| {
             alloc.free(item.name);
+            if (item.load_error) |value| alloc.free(value);
             if (item.algebraic_last_error_doc_key) |value| alloc.free(value);
             if (item.algebraic_last_error_reason) |value| alloc.free(value);
             if (item.algebraic_capability_fingerprint) |value| alloc.free(value);
@@ -811,6 +812,11 @@ pub fn cloneDBStats(alloc: std.mem.Allocator, stats: db_mod.types.DBStats) !db_m
     }
 
     for (stats.indexes, 0..) |item, i| {
+        const load_error = if (item.load_error) |value|
+            try alloc.dupe(u8, value)
+        else
+            null;
+        errdefer if (load_error) |value| alloc.free(value);
         const algebraic_last_error_doc_key = if (item.algebraic_last_error_doc_key) |value|
             try alloc.dupe(u8, value)
         else
@@ -900,6 +906,7 @@ pub fn cloneDBStats(alloc: std.mem.Allocator, stats: db_mod.types.DBStats) !db_m
         indexes[i] = .{
             .name = try alloc.dupe(u8, item.name),
             .kind = item.kind,
+            .load_error = load_error,
             .doc_count = item.doc_count,
             .term_count = item.term_count,
             .edge_count = item.edge_count,

--- a/zig/pkg/antfly/src/api/table_reads.zig
+++ b/zig/pkg/antfly/src/api/table_reads.zig
@@ -158,25 +158,44 @@ pub const ProvisionedTableReadCache = struct {
     miss_count: std.atomic.Value(u64) = .init(0),
     mutex: Io.Mutex = .init,
     ready: Io.Condition = .init,
-    // Invalidation epochs, bucketed by table-name hash. A single global
-    // epoch made every open of table A "stale" whenever table B was
-    // written — under continuous background writes (enrichment, status
-    // persistence) opens of an UNCHANGED table never looked fresh, which
-    // livelocked queries (pre-bounded-retry) or served permanently
-    // generation-stale DBs (post). Bucketing scopes staleness to the table
-    // actually invalidated; hash collisions only cause an occasional
-    // harmless extra retry. Allocation-free so invalidateTable stays
-    // infallible.
-    epoch_buckets: [epoch_bucket_count]u64 = @splat(1),
+    // Exact per-table invalidation epochs. A single global epoch made every
+    // open of table A "stale" whenever table B was written — under
+    // continuous background writes (enrichment, status persistence) opens
+    // of an UNCHANGED table never looked fresh, which livelocked queries
+    // (pre-bounded-retry) or served permanently generation-stale DBs
+    // (post). Keying epochs by exact table name scopes staleness to the
+    // table actually invalidated, with no hash-collision false positives at
+    // any table count. Slots are created (fallibly) by getOrOpen before an
+    // open starts; invalidateTable only bumps an existing slot, so
+    // invalidation stays infallible — a missing slot means no open is in
+    // flight and nothing read the old epoch. Slots are never removed: one
+    // u64 + the name per distinct table ever read through this cache.
+    table_epochs: std.StringHashMapUnmanaged(u64) = .empty,
     entries: std.ArrayListUnmanaged(*Entry) = .empty,
     retired_entries: std.ArrayListUnmanaged(*Entry) = .empty,
     pending_opens: std.ArrayListUnmanaged(PendingOpen) = .empty,
 
     const max_cached_tables = 64;
-    const epoch_bucket_count = 64;
 
-    fn epochBucket(table_name: []const u8) usize {
-        return @intCast(std.hash.Wyhash.hash(0, table_name) & (epoch_bucket_count - 1));
+    /// Current epoch for `table_name`, creating its slot on first use. The
+    /// key is duped on insert and owned by the map. Must be called with the
+    /// cache mutex held.
+    fn epochForTableLocked(self: *ProvisionedTableReadCache, table_name: []const u8) !u64 {
+        const gop = try self.table_epochs.getOrPut(self.alloc, table_name);
+        if (!gop.found_existing) {
+            gop.key_ptr.* = self.alloc.dupe(u8, table_name) catch |err| {
+                self.table_epochs.removeByPtr(gop.key_ptr);
+                return err;
+            };
+            gop.value_ptr.* = 1;
+        }
+        return gop.value_ptr.*;
+    }
+
+    /// Infallible epoch bump. A missing slot means no open ever started for
+    /// this table, so there is no in-flight epoch comparison to invalidate.
+    fn bumpEpochLocked(self: *ProvisionedTableReadCache, table_name: []const u8) void {
+        if (self.table_epochs.getPtr(table_name)) |epoch| epoch.* +%= 1;
     }
 
     pub const CacheStats = struct {
@@ -245,6 +264,9 @@ pub const ProvisionedTableReadCache = struct {
         self.retired_entries.deinit(self.alloc);
         for (self.pending_opens.items) |*pending| pending.deinit(self.alloc);
         self.pending_opens.deinit(self.alloc);
+        var epoch_keys = self.table_epochs.keyIterator();
+        while (epoch_keys.next()) |key| self.alloc.free(key.*);
+        self.table_epochs.deinit(self.alloc);
         self.mutex.unlock(io);
         self.threaded.deinit();
         self.* = undefined;
@@ -265,13 +287,19 @@ pub const ProvisionedTableReadCache = struct {
         lsm_root_generation: u64,
         table_name: []const u8,
     ) !Lease {
-        const identity_namespace = try loadTableIdentityNamespaceForGroup(self.alloc, catalog, table_name, group_id);
         const io = self.threaded.io();
         var stale_epoch_retries: u8 = 0;
-        const epoch_bucket = epochBucket(table_name);
         while (true) {
+            // Reloaded every attempt: a stale-epoch retry usually means the
+            // table was dropped/recreated or moved mid-open, which changes
+            // the identity namespace — retrying with the first attempt's
+            // namespace would open (and cache) the wrong identity.
+            const identity_namespace = try loadTableIdentityNamespaceForGroup(self.alloc, catalog, table_name, group_id);
             self.mutex.lockUncancelable(io);
-            const open_epoch = self.epoch_buckets[epoch_bucket];
+            const open_epoch = self.epochForTableLocked(table_name) catch |err| {
+                self.mutex.unlock(io);
+                return err;
+            };
             if (self.findEntryForNamespaceLocked(group_id, lsm_root_generation, identity_namespace, table_name)) |entry| {
                 entry.active_leases += 1;
                 _ = self.hit_count.fetchAdd(1, .monotonic);
@@ -324,26 +352,26 @@ pub const ProvisionedTableReadCache = struct {
 
             self.mutex.lockUncancelable(io);
             self.removePendingOpenForNamespaceLocked(group_id, identity_namespace, table_name);
-            if (self.epoch_buckets[epoch_bucket] != open_epoch) {
+            if ((self.table_epochs.get(table_name) orelse open_epoch +% 1) != open_epoch) {
                 // This table was invalidated while we were opening (dropped,
-                // recreated, or the writer published). Per-table epoch
-                // buckets keep unrelated tables' writes from tripping this,
-                // so it only fires under genuine same-table churn (catch-up,
-                // heal backfill). Retry a bounded number of times; if the
-                // table churns faster than an open completes, fail with
-                // EndOfStream — the transient-read error the query layer
-                // already retries with backoff — instead of either
-                // livelocking every query behind this open (observed in the
-                // field as ~100s of queries timing out and flushing at once)
-                // or serving/caching a stale-epoch DB (poisons identity
-                // read-generation checks and leaves the runtime-status cache
-                // empty, which hides index load errors from clients).
+                // recreated, or the writer published). Epochs are exact
+                // per-table, so this only fires under genuine same-table
+                // churn (catch-up, heal backfill). Retry a bounded number of
+                // times; if the table churns faster than an open completes,
+                // fail with TableReadChurn — classified as transient by the
+                // query layer, which retries with backoff — instead of
+                // either livelocking every query behind this open (observed
+                // in the field as ~100s of queries timing out and flushing
+                // at once) or serving/caching a stale-epoch DB (poisons
+                // identity read-generation checks and leaves the
+                // runtime-status cache empty, which hides index load errors
+                // from clients).
                 stale_epoch_retries += 1;
                 self.ready.broadcast(io);
                 if (stale_epoch_retries > 2) {
                     self.mutex.unlock(io);
                     // errdefer closes the just-opened db.
-                    return error.EndOfStream;
+                    return error.TableReadChurn;
                 }
                 db.close();
                 self.mutex.unlock(io);
@@ -426,7 +454,7 @@ pub const ProvisionedTableReadCache = struct {
         const io = self.threaded.io();
         self.mutex.lockUncancelable(io);
         defer self.mutex.unlock(io);
-        self.epoch_buckets[epochBucket(table_name)] +%= 1;
+        self.bumpEpochLocked(table_name);
         self.removeEntriesForTableLocked(table_name);
         self.ready.broadcast(io);
     }
@@ -446,7 +474,8 @@ pub const ProvisionedTableReadCache = struct {
         const io = self.threaded.io();
         self.mutex.lockUncancelable(io);
         defer self.mutex.unlock(io);
-        for (&self.epoch_buckets) |*bucket| bucket.* +%= 1;
+        var epochs = self.table_epochs.valueIterator();
+        while (epochs.next()) |epoch| epoch.* +%= 1;
         for (self.entries.items) |entry| self.retireEntryLocked(entry);
         self.entries.clearRetainingCapacity();
         self.ready.broadcast(io);

--- a/zig/pkg/antfly/src/api/table_reads.zig
+++ b/zig/pkg/antfly/src/api/table_reads.zig
@@ -253,6 +253,7 @@ pub const ProvisionedTableReadCache = struct {
     ) !Lease {
         const identity_namespace = try loadTableIdentityNamespaceForGroup(self.alloc, catalog, table_name, group_id);
         const io = self.threaded.io();
+        var stale_epoch_retries: u8 = 0;
         while (true) {
             self.mutex.lockUncancelable(io);
             const open_epoch = self.epoch;
@@ -308,7 +309,21 @@ pub const ProvisionedTableReadCache = struct {
 
             self.mutex.lockUncancelable(io);
             self.removePendingOpenForNamespaceLocked(group_id, identity_namespace, table_name);
-            if (self.epoch != open_epoch) {
+            if (self.epoch != open_epoch and stale_epoch_retries < 2) {
+                // The cache was invalidated while we were opening (table
+                // dropped/recreated, or the writer published). Retry a
+                // bounded number of times — but only a bounded number:
+                // during startup catch-up or heal backfill the writer
+                // publishes after every batch, bumping the epoch faster
+                // than a fresh open can complete, and unbounded retry here
+                // livelocks every query behind this open until the churn
+                // pauses (observed in the field as ~100s of queries all
+                // timing out and then flushing at once). After the retries
+                // we serve the DB we just opened — it is a consistent
+                // snapshot at the requested generation, at worst slightly
+                // stale; a genuinely dropped table fails downstream with
+                // NotFound instead of stalling everyone here.
+                stale_epoch_retries += 1;
                 self.ready.broadcast(io);
                 db.close();
                 self.mutex.unlock(io);

--- a/zig/pkg/antfly/src/api/table_reads.zig
+++ b/zig/pkg/antfly/src/api/table_reads.zig
@@ -158,12 +158,26 @@ pub const ProvisionedTableReadCache = struct {
     miss_count: std.atomic.Value(u64) = .init(0),
     mutex: Io.Mutex = .init,
     ready: Io.Condition = .init,
-    epoch: u64 = 1,
+    // Invalidation epochs, bucketed by table-name hash. A single global
+    // epoch made every open of table A "stale" whenever table B was
+    // written — under continuous background writes (enrichment, status
+    // persistence) opens of an UNCHANGED table never looked fresh, which
+    // livelocked queries (pre-bounded-retry) or served permanently
+    // generation-stale DBs (post). Bucketing scopes staleness to the table
+    // actually invalidated; hash collisions only cause an occasional
+    // harmless extra retry. Allocation-free so invalidateTable stays
+    // infallible.
+    epoch_buckets: [epoch_bucket_count]u64 = @splat(1),
     entries: std.ArrayListUnmanaged(*Entry) = .empty,
     retired_entries: std.ArrayListUnmanaged(*Entry) = .empty,
     pending_opens: std.ArrayListUnmanaged(PendingOpen) = .empty,
 
     const max_cached_tables = 64;
+    const epoch_bucket_count = 64;
+
+    fn epochBucket(table_name: []const u8) usize {
+        return @intCast(std.hash.Wyhash.hash(0, table_name) & (epoch_bucket_count - 1));
+    }
 
     pub const CacheStats = struct {
         hit_count: u64 = 0,
@@ -254,9 +268,10 @@ pub const ProvisionedTableReadCache = struct {
         const identity_namespace = try loadTableIdentityNamespaceForGroup(self.alloc, catalog, table_name, group_id);
         const io = self.threaded.io();
         var stale_epoch_retries: u8 = 0;
+        const epoch_bucket = epochBucket(table_name);
         while (true) {
             self.mutex.lockUncancelable(io);
-            const open_epoch = self.epoch;
+            const open_epoch = self.epoch_buckets[epoch_bucket];
             if (self.findEntryForNamespaceLocked(group_id, lsm_root_generation, identity_namespace, table_name)) |entry| {
                 entry.active_leases += 1;
                 _ = self.hit_count.fetchAdd(1, .monotonic);
@@ -309,22 +324,27 @@ pub const ProvisionedTableReadCache = struct {
 
             self.mutex.lockUncancelable(io);
             self.removePendingOpenForNamespaceLocked(group_id, identity_namespace, table_name);
-            if (self.epoch != open_epoch and stale_epoch_retries < 2) {
-                // The cache was invalidated while we were opening (table
-                // dropped/recreated, or the writer published). Retry a
-                // bounded number of times — but only a bounded number:
-                // during startup catch-up or heal backfill the writer
-                // publishes after every batch, bumping the epoch faster
-                // than a fresh open can complete, and unbounded retry here
-                // livelocks every query behind this open until the churn
-                // pauses (observed in the field as ~100s of queries all
-                // timing out and then flushing at once). After the retries
-                // we serve the DB we just opened — it is a consistent
-                // snapshot at the requested generation, at worst slightly
-                // stale; a genuinely dropped table fails downstream with
-                // NotFound instead of stalling everyone here.
+            if (self.epoch_buckets[epoch_bucket] != open_epoch) {
+                // This table was invalidated while we were opening (dropped,
+                // recreated, or the writer published). Per-table epoch
+                // buckets keep unrelated tables' writes from tripping this,
+                // so it only fires under genuine same-table churn (catch-up,
+                // heal backfill). Retry a bounded number of times; if the
+                // table churns faster than an open completes, fail with
+                // EndOfStream — the transient-read error the query layer
+                // already retries with backoff — instead of either
+                // livelocking every query behind this open (observed in the
+                // field as ~100s of queries timing out and flushing at once)
+                // or serving/caching a stale-epoch DB (poisons identity
+                // read-generation checks and leaves the runtime-status cache
+                // empty, which hides index load errors from clients).
                 stale_epoch_retries += 1;
                 self.ready.broadcast(io);
+                if (stale_epoch_retries > 2) {
+                    self.mutex.unlock(io);
+                    // errdefer closes the just-opened db.
+                    return error.EndOfStream;
+                }
                 db.close();
                 self.mutex.unlock(io);
                 continue;
@@ -406,7 +426,7 @@ pub const ProvisionedTableReadCache = struct {
         const io = self.threaded.io();
         self.mutex.lockUncancelable(io);
         defer self.mutex.unlock(io);
-        self.epoch +%= 1;
+        self.epoch_buckets[epochBucket(table_name)] +%= 1;
         self.removeEntriesForTableLocked(table_name);
         self.ready.broadcast(io);
     }
@@ -426,7 +446,7 @@ pub const ProvisionedTableReadCache = struct {
         const io = self.threaded.io();
         self.mutex.lockUncancelable(io);
         defer self.mutex.unlock(io);
-        self.epoch +%= 1;
+        for (&self.epoch_buckets) |*bucket| bucket.* +%= 1;
         for (self.entries.items) |entry| self.retireEntryLocked(entry);
         self.entries.clearRetainingCapacity();
         self.ready.broadcast(io);

--- a/zig/pkg/antfly/src/index.zig
+++ b/zig/pkg/antfly/src/index.zig
@@ -112,26 +112,62 @@ pub const SegmentData = union(enum) {
     }
 };
 
+/// Per-segment shared state, heap-allocated once per physical segment and
+/// referenced by every snapshot generation that includes the segment.
+/// Lifetime is reference-counted: each snapshot's `segments` slice owns one
+/// reference per entry; the segment's resources are freed (and its retired
+/// cleanup runs) when the last referencing snapshot releases. A held
+/// snapshot therefore pins exactly the segments it can see — not whole
+/// later generations, which is what the previous snapshot successor chain
+/// pinned (under a merge storm that grew with churn rate × hold time, and a
+/// leaked snapshot pinned every future generation).
+pub const SegmentShared = struct {
+    ref_count: u32,
+    /// Deletion bitmap shared by every snapshot referencing this segment.
+    /// Mutated only under the writer mutex. Readers of older snapshots may
+    /// observe deletions made after their snapshot was taken — acceptable
+    /// (deleted docs drop out early) and strictly safer than the previous
+    /// copy-by-value field, whose stale copies aliased bitmap memory that
+    /// setDeletionBitmap freed on replacement.
+    deleted: ?roaring.RoaringBitmap = null,
+    /// Set when the segment is replaced/removed from the live index. Runs
+    /// once the last reference dies, after resources are deinited.
+    retired_cleanup: ?RetiredSegmentCleanup = null,
+};
+
 pub const SegmentEntry = struct {
     id: u64,
     data: SegmentData,
     reader: segment_mod.SegmentReader,
     layout_stats: segment_mod.SegmentLayoutStats = .{},
-    deleted: ?roaring.RoaringBitmap,
+    shared: *SegmentShared,
 
-    pub fn deinit(self: *SegmentEntry) void {
+    fn retain(self: *const SegmentEntry) void {
+        _ = @atomicRmw(u32, &self.shared.ref_count, .Add, 1, .monotonic);
+    }
+
+    /// Drop one reference. The final release deinits the segment's
+    /// resources, runs its retired cleanup (if any), and destroys the
+    /// shared cell.
+    fn releaseRef(self: *SegmentEntry) void {
+        if (@atomicRmw(u32, &self.shared.ref_count, .Sub, 1, .acq_rel) != 1) return;
+        const alloc = self.reader.alloc;
+        const seg_id = self.id;
+        const cleanup = self.shared.retired_cleanup;
         self.data.madviseDiscardCleanPages();
         self.reader.deinit();
-        if (self.deleted) |*d| {
+        if (self.shared.deleted) |*d| {
             var del = d.*;
             del.deinit();
         }
-        self.data.deinit(self.reader.alloc);
+        self.data.deinit(alloc);
+        alloc.destroy(self.shared);
+        if (cleanup) |c| c.run(seg_id);
     }
 
     /// Number of live (non-deleted) documents.
     pub fn liveDocCount(self: *const SegmentEntry) u32 {
-        if (self.deleted) |d| {
+        if (self.shared.deleted) |d| {
             const del_count: u32 = @intCast(d.cardinality());
             return self.reader.doc_count -| del_count;
         }
@@ -262,54 +298,31 @@ pub const IndexSnapshot = struct {
     term_doc_freq_cache: TermDocFreqCache,
     term_doc_freq_cache_hits: u64,
     term_doc_freq_cache_misses: u64,
-    /// Segments whose readers should be deinit'd when this snapshot is released.
-    /// Set by replaceSegments for the segments being merged away.
-    retired_segments: []SegmentEntry,
-    retired_segment_cleanup: ?RetiredSegmentCleanup = null,
-    /// The snapshot that replaced this one, retained at publish time.
-    /// Retired segments are attached to the snapshot that was current when
-    /// the merge ran — but a reader can hold a snapshot from an EARLIER
-    /// generation that still references those segments by value, and its
-    /// refcount does nothing to pin the later snapshot hosting their
-    /// cleanup. Chaining each old snapshot to its successor makes a held
-    /// snapshot transitively pin all later generations (and their retired
-    /// lists) until the holder releases. Observed in the field as a
-    /// layoutStats segfault when a status walk held a snapshot across two
-    /// publishes during a merge storm. Null only on the current snapshot.
-    successor: ?*IndexSnapshot = null,
-
     /// Increment reference count. Returns self for chaining.
     pub fn retain(self: *IndexSnapshot) *IndexSnapshot {
         _ = @atomicRmw(u32, &self.ref_count, .Add, 1, .monotonic);
         return self;
     }
 
-    /// Decrement reference count. Frees snapshot when count reaches 0.
-    /// A fully-released snapshot also drops its reference on `successor`,
-    /// so a dying chain unwinds in this loop — iteratively, not
-    /// recursively, since a merge storm can chain hundreds of generations.
+    /// Decrement reference count. Frees the snapshot when the count reaches
+    /// zero, dropping one reference on each segment it includes — a segment
+    /// replaced by a merge (its shared cell marked with a retired cleanup)
+    /// is deinited and cleaned up when its LAST referencing snapshot dies,
+    /// so a held snapshot pins exactly the segments it can see and nothing
+    /// more. Observed in the field as a layoutStats segfault when a status
+    /// walk held a snapshot across two publishes during a merge storm: the
+    /// pre-refcount code deinited retired segments with the generation that
+    /// merged them away, while earlier generations still referenced them.
     pub fn release(self: *IndexSnapshot) void {
-        var maybe: ?*IndexSnapshot = self;
-        while (maybe) |snap| {
-            if (@atomicRmw(u32, &snap.ref_count, .Sub, 1, .acq_rel) != 1) return;
-            const succ = snap.successor;
-            snap.freeFinal();
-            maybe = succ;
-        }
+        if (@atomicRmw(u32, &self.ref_count, .Sub, 1, .acq_rel) != 1) return;
+        self.freeFinal();
     }
 
     /// Free everything this snapshot owns and destroy it. Only valid once
     /// the refcount has reached zero.
     fn freeFinal(self: *IndexSnapshot) void {
         const alloc = self.alloc;
-        // Deinit retired segments (replaced during merge)
-        for (self.retired_segments) |*seg| {
-            var s = seg.*;
-            const seg_id = s.id;
-            s.deinit();
-            if (self.retired_segment_cleanup) |cleanup| cleanup.run(seg_id);
-        }
-        if (self.retired_segments.len > 0) alloc.free(self.retired_segments);
+        for (self.segments) |*seg| seg.releaseRef();
         alloc.free(self.segments);
         {
             const cache_mu = &self.term_doc_freq_cache_mu;
@@ -323,28 +336,6 @@ pub const IndexSnapshot = struct {
         }
         self.global_total_field_len.deinit(alloc);
         alloc.destroy(self);
-    }
-
-    /// Full cleanup including ALL segment entries. Only for IndexWriter.deinit().
-    fn deinitAll(self: *IndexSnapshot) void {
-        for (self.segments) |*seg| seg.deinit();
-        for (self.retired_segments) |*seg| {
-            var s = seg.*;
-            const seg_id = s.id;
-            s.deinit();
-            if (self.retired_segment_cleanup) |cleanup| cleanup.run(seg_id);
-        }
-        if (self.retired_segments.len > 0) self.alloc.free(self.retired_segments);
-        self.alloc.free(self.segments);
-        const cache_mu = &self.term_doc_freq_cache_mu;
-        while (!cache_mu.tryLock()) {
-            spinOrYield();
-        }
-        defer cache_mu.unlock();
-        var cache_it = self.term_doc_freq_cache.keyIterator();
-        while (cache_it.next()) |key| self.alloc.free(key.storage);
-        self.term_doc_freq_cache.deinit(self.alloc);
-        self.global_total_field_len.deinit(self.alloc);
     }
 
     /// Search across all segments for the given terms in a field.
@@ -430,7 +421,7 @@ pub const IndexSnapshot = struct {
                     .base = &collector,
                     .doc_offset = doc_offset,
                 };
-                if (seg.deleted) |*deleted| {
+                if (seg.shared.deleted) |*deleted| {
                     live_collector.deleted = deleted;
                 }
                 try wand.executeInto(&live_collector);
@@ -493,7 +484,7 @@ pub const IndexSnapshot = struct {
         for (self.segments) |*seg| {
             for (0..seg.reader.doc_count) |local_usize| {
                 const local_doc: u32 = @intCast(local_usize);
-                if (seg.deleted) |deleted| {
+                if (seg.shared.deleted) |deleted| {
                     if (deleted.contains(local_doc)) continue;
                 }
                 const ordinal = (try seg.reader.docOrdinal(local_doc)) orelse continue;
@@ -557,7 +548,7 @@ pub const IndexSnapshot = struct {
             const inv_reader = (try seg.reader.invertedIndex(field)) orelse continue;
             const lookup_result = inv_reader.lookup(term) orelse continue;
 
-            if (seg.deleted == null) {
+            if (seg.shared.deleted == null) {
                 total += lookup_result.docFreq();
                 continue;
             }
@@ -565,7 +556,7 @@ pub const IndexSnapshot = struct {
             var iter = try lookup_result.iterator(alloc);
             defer iter.deinit();
             while (try iter.next()) |hit| {
-                if (!seg.deleted.?.contains(hit.doc_id)) total += 1;
+                if (!seg.shared.deleted.?.contains(hit.doc_id)) total += 1;
             }
         }
 
@@ -679,8 +670,6 @@ pub const IndexWriter = struct {
             .term_doc_freq_cache = .empty,
             .term_doc_freq_cache_hits = 0,
             .term_doc_freq_cache_misses = 0,
-            .retired_segments = &.{},
-            .retired_segment_cleanup = null,
         };
         return .{
             .alloc = alloc,
@@ -695,14 +684,15 @@ pub const IndexWriter = struct {
 
     pub fn setRetiredSegmentCleanup(self: *IndexWriter, cleanup: ?RetiredSegmentCleanup) void {
         self.retired_segment_cleanup = cleanup;
-        const snap = @atomicLoad(*IndexSnapshot, &self.current, .acquire);
-        snap.retired_segment_cleanup = cleanup;
     }
 
     pub fn deinit(self: *IndexWriter) void {
+        // Releases the writer's reference; with no outstanding readers this
+        // frees the snapshot and drops the final reference on every live
+        // segment (whose cells carry no retired cleanup, so closing an index
+        // never deletes persisted segment files).
         const snap = @atomicLoad(*IndexSnapshot, &self.current, .acquire);
-        snap.deinitAll();
-        self.alloc.destroy(snap);
+        snap.release();
     }
 
     /// Get the current snapshot (lock-free read, no ref change).
@@ -743,23 +733,34 @@ pub const IndexWriter = struct {
         const new_segments = try self.alloc.alloc(SegmentEntry, old.segments.len + 1);
         errdefer self.alloc.free(new_segments);
         @memcpy(new_segments[0..old.segments.len], old.segments);
+        const shared = try self.alloc.create(SegmentShared);
+        shared.* = .{ .ref_count = 1 };
+        errdefer self.alloc.destroy(shared);
         new_segments[old.segments.len] = .{
             .id = seg_id,
             .data = data,
             .reader = reader,
             .layout_stats = reader.layoutStats(),
-            .deleted = null,
+            .shared = shared,
         };
 
-        try self.rebuildSnapshot(new_segments, &.{});
+        try self.rebuildSnapshot(new_segments, old.segments.len, &.{});
     }
 
     /// Rebuild and swap the index snapshot from a new segment list.
-    /// `retired` contains segments whose readers should be cleaned up when
-    /// the old snapshot is fully released.
-    fn rebuildSnapshot(self: *IndexWriter, new_segments: []SegmentEntry, retired: []SegmentEntry) !void {
+    ///
+    /// `new_segments` is laid out as [carried..., brand-new...] with
+    /// `carried_count` entries carried over from the current snapshot: this
+    /// function retains one segment reference per carried entry on success
+    /// (brand-new entries arrive with their creation reference already owned
+    /// by the slice). `retired` stages entries being merged/removed away —
+    /// their reference stays with the old snapshot; this function only marks
+    /// their shared cells with the retired cleanup and frees the staging
+    /// slice. On error the caller still owns everything it staged.
+    fn rebuildSnapshot(self: *IndexWriter, new_segments: []SegmentEntry, carried_count: usize, retired: []SegmentEntry) !void {
         var global_doc_count: u32 = 0;
         var global_field_lens = std.StringHashMapUnmanaged(u64).empty;
+        errdefer global_field_lens.deinit(self.alloc);
         for (new_segments) |*seg| {
             global_doc_count += seg.liveDocCount();
             for (seg.reader.fields) |*fi| {
@@ -791,23 +792,20 @@ pub const IndexWriter = struct {
             .term_doc_freq_cache = .empty,
             .term_doc_freq_cache_hits = 0,
             .term_doc_freq_cache_misses = 0,
-            .retired_segments = &.{},
-            .retired_segment_cleanup = self.retired_segment_cleanup,
         };
         self.next_epoch += 1;
 
         const old = @atomicLoad(*IndexSnapshot, &self.current, .acquire);
 
-        // Attach retired segments to the old snapshot so they get cleaned up
-        // when all readers release it.
-        old.retired_segments = retired;
-        old.retired_segment_cleanup = self.retired_segment_cleanup;
-        // Chain old → new so a reader holding ANY earlier generation keeps
-        // this snapshot — and the retired lists of every generation in
-        // between — alive until it releases. Safe to write without
-        // synchronization: the writer still holds a reference on `old`, so
-        // no reader can be in freeFinal reading `successor` yet.
-        old.successor = new_snap.retain();
+        // Commit point — nothing below can fail. Retain the carried
+        // segments for the new snapshot, and mark the retired segments'
+        // cells so the LAST snapshot referencing each runs its cleanup.
+        // Safe to write the cells without synchronization: the writer still
+        // holds a reference on `old`, so no releaseRef can be completing
+        // concurrently for segments old references.
+        for (new_segments[0..carried_count]) |*seg| seg.retain();
+        for (retired) |*seg| seg.shared.retired_cleanup = self.retired_segment_cleanup;
+        if (retired.len > 0) self.alloc.free(retired);
 
         // Atomic swap so concurrent readers see a consistent pointer.
         self.publishSnapshot(new_snap);
@@ -902,12 +900,15 @@ pub const IndexWriter = struct {
         const new_segments = try self.alloc.alloc(SegmentEntry, old.segments.len + 1);
         errdefer self.alloc.free(new_segments);
         @memcpy(new_segments[0..old.segments.len], old.segments);
+        const shared = try self.alloc.create(SegmentShared);
+        shared.* = .{ .ref_count = 1 };
+        errdefer self.alloc.destroy(shared);
         new_segments[old.segments.len] = .{
             .id = seg_id,
             .data = owned.?,
             .reader = reader,
             .layout_stats = reader.layoutStats(),
-            .deleted = null,
+            .shared = shared,
         };
 
         if (seg_id >= self.next_segment_id) self.next_segment_id = seg_id + 1;
@@ -929,15 +930,13 @@ pub const IndexWriter = struct {
             .term_doc_freq_cache = .empty,
             .term_doc_freq_cache_hits = 0,
             .term_doc_freq_cache_misses = 0,
-            .retired_segments = &.{},
-            .retired_segment_cleanup = self.retired_segment_cleanup,
         };
         self.next_epoch += 1;
 
-        // Chain old → new (see IndexSnapshot.successor): every publish must
-        // link generations, or a holder of an older snapshot loses its
-        // transitive pin on later retired lists.
-        old.successor = new_snap.retain();
+        // Commit point — retain the carried segments for the new snapshot
+        // (the appended entry's creation reference is already owned by the
+        // slice), then publish.
+        for (new_segments[0..old.segments.len]) |*seg| seg.retain();
         self.publishSnapshot(new_snap);
         old.release();
         owned = null;
@@ -1032,19 +1031,24 @@ pub const IndexWriter = struct {
             }
         }
 
+        var cells_created: usize = 0;
+        errdefer for (new_segments[keep_count .. keep_count + cells_created]) |*seg| self.alloc.destroy(seg.shared);
         for (replacements, 0..) |replacement, i| {
+            const shared = try self.alloc.create(SegmentShared);
+            shared.* = .{ .ref_count = 1 };
             new_segments[idx] = .{
                 .id = replacement.id,
                 .data = replacement.data,
                 .reader = replacement_readers[i],
                 .layout_stats = replacement_readers[i].layoutStats(),
-                .deleted = null,
+                .shared = shared,
             };
+            cells_created += 1;
             idx += 1;
             if (replacement.id >= self.next_segment_id) self.next_segment_id = replacement.id + 1;
         }
 
-        try self.rebuildSnapshot(new_segments, retired);
+        try self.rebuildSnapshot(new_segments, keep_count, retired);
         replacement_readers_initialized = 0;
     }
 
@@ -1097,7 +1101,7 @@ pub const IndexWriter = struct {
             }
         }
 
-        try self.rebuildSnapshot(new_segments, retired);
+        try self.rebuildSnapshot(new_segments, keep_count, retired);
     }
 
     /// Set deletion bitmap for a segment by ID (for recovery).
@@ -1108,11 +1112,11 @@ pub const IndexWriter = struct {
         const snap = @atomicLoad(*IndexSnapshot, &self.current, .acquire);
         for (snap.segments) |*seg| {
             if (seg.id == seg_id) {
-                if (seg.deleted) |*d| {
+                if (seg.shared.deleted) |*d| {
                     var old_del = d.*;
                     old_del.deinit();
                 }
-                seg.deleted = bitmap;
+                seg.shared.deleted = bitmap;
                 // Recompute global doc count
                 var total: u32 = 0;
                 for (snap.segments) |*s| {
@@ -1151,22 +1155,22 @@ pub const IndexWriter = struct {
                 const stored = seg.reader.storedDoc(@intCast(local_id)) orelse continue;
                 if (std.mem.eql(u8, stored.id, doc_id)) {
                     // Already deleted?
-                    if (seg.deleted) |d| {
+                    if (seg.shared.deleted) |d| {
                         if (d.contains(@intCast(local_id))) return null;
                     }
 
                     // Set deletion bit
-                    if (seg.deleted == null) {
-                        seg.deleted = roaring.RoaringBitmap.init(self.alloc);
+                    if (seg.shared.deleted == null) {
+                        seg.shared.deleted = roaring.RoaringBitmap.init(self.alloc);
                     }
-                    try seg.deleted.?.add(@intCast(local_id));
+                    try seg.shared.deleted.?.add(@intCast(local_id));
 
                     // Update global doc count in snapshot
                     snap.global_doc_count -|= 1;
 
                     return .{
                         .seg_id = seg.id,
-                        .bitmap_bytes = try seg.deleted.?.toBytes(alloc),
+                        .bitmap_bytes = try seg.shared.deleted.?.toBytes(alloc),
                     };
                 }
             }
@@ -1497,7 +1501,7 @@ test "index writer removeSegments frees staged segment lists when rebuild alloca
     try std.testing.expectEqual(@as(usize, 2), writer.snapshot().segments.len);
 }
 
-test "held snapshot pins segments retired in later generations" {
+test "held snapshot pins exactly the retired segments it references" {
     const alloc = std.testing.allocator;
 
     const Cleaned = struct {
@@ -1536,14 +1540,17 @@ test "held snapshot pins segments retired in later generations" {
     try writer.addSegment(seg2); // generation 2
     const id1 = writer.snapshot().segments[0].id;
     const id2 = writer.snapshot().segments[1].id;
-    // Generation 3: retires both segments, attaching them to generation 2.
+    // Generation 3: retires both segments. seg1 is still referenced by the
+    // held gen-1 snapshot; seg2 is referenced only by gen 2, which dies at
+    // the gen-3 publish.
     try writer.replaceSegments(&.{ id1, id2 }, id2 + 1, merged);
 
-    // The held gen-1 snapshot still references seg1 by value. Without the
-    // successor chain, gen 2 dies the moment the writer releases it at the
-    // gen-3 publish and deinits seg1 while we still hold a snapshot
-    // containing it.
-    try std.testing.expectEqual(@as(usize, 0), cleaned.ids.items.len);
+    // Per-segment refcounts pin exactly what the holder can see: seg2 (never
+    // referenced by gen 1) is cleaned up the moment gen 2 dies, while seg1
+    // stays alive for the holder. The old successor-chain design pinned BOTH
+    // until the holder released.
+    try std.testing.expectEqual(@as(usize, 1), cleaned.ids.items.len);
+    try std.testing.expectEqual(id2, cleaned.ids.items[0]);
 
     // Walking the held snapshot must read live segment memory.
     var terms: u64 = 0;
@@ -1553,8 +1560,9 @@ test "held snapshot pins segments retired in later generations" {
     }
     try std.testing.expect(terms > 0);
 
-    // Releasing the holder unwinds the chain; only now do the retired
-    // segments get cleaned up.
+    // Releasing the holder drops the last reference on seg1; only now does
+    // its retired cleanup run.
     held.release();
     try std.testing.expectEqual(@as(usize, 2), cleaned.ids.items.len);
+    try std.testing.expectEqual(id1, cleaned.ids.items[1]);
 }

--- a/zig/pkg/antfly/src/index.zig
+++ b/zig/pkg/antfly/src/index.zig
@@ -611,6 +611,14 @@ pub const IndexWriter = struct {
     alloc: Allocator,
     current: *IndexSnapshot,
     mu: std.atomic.Mutex,
+    // Guards the load+retain in acquireSnapshot against the publish in the
+    // swap sites. Without it a reader can load `current`, lose the CPU, and
+    // retain a snapshot the writer has already swapped out and released to
+    // refcount zero — resurrecting freed memory and crashing on the next
+    // segment walk (observed as segfaults in layoutStats during merges).
+    // Critical sections are a pointer load + refcount op, so a spinlock is
+    // appropriate; the heavy release/deinit stays outside it.
+    snapshot_mu: std.atomic.Mutex,
     next_segment_id: u64,
     next_epoch: u64,
     retired_segment_cleanup: ?RetiredSegmentCleanup = null,
@@ -619,6 +627,19 @@ pub const IndexWriter = struct {
         while (!self.mu.tryLock()) {
             spinOrYield();
         }
+    }
+
+    fn lockSnapshotMutex(self: *IndexWriter) void {
+        while (!self.snapshot_mu.tryLock()) {
+            spinOrYield();
+        }
+    }
+
+    /// Publish a new snapshot. Must be the only way `current` is replaced.
+    fn publishSnapshot(self: *IndexWriter, new_snap: *IndexSnapshot) void {
+        self.lockSnapshotMutex();
+        @atomicStore(*IndexSnapshot, &self.current, new_snap, .release);
+        self.snapshot_mu.unlock();
     }
 
     pub fn init(alloc: Allocator) !IndexWriter {
@@ -641,6 +662,7 @@ pub const IndexWriter = struct {
             .alloc = alloc,
             .current = snap,
             .mu = .unlocked,
+            .snapshot_mu = .unlocked,
             .next_segment_id = 1,
             .next_epoch = 1,
             .retired_segment_cleanup = null,
@@ -668,7 +690,11 @@ pub const IndexWriter = struct {
 
     /// Get the current snapshot with an incremented ref count.
     /// Caller MUST call release() when done. Safe for concurrent use.
+    /// Load+retain happens under snapshot_mu so a concurrent publish cannot
+    /// release the loaded snapshot to zero before we retain it.
     pub fn acquireSnapshot(self: *IndexWriter) *IndexSnapshot {
+        self.lockSnapshotMutex();
+        defer self.snapshot_mu.unlock();
         return @atomicLoad(*IndexSnapshot, &self.current, .acquire).retain();
     }
 
@@ -754,7 +780,7 @@ pub const IndexWriter = struct {
         old.retired_segment_cleanup = self.retired_segment_cleanup;
 
         // Atomic swap so concurrent readers see a consistent pointer.
-        @atomicStore(*IndexSnapshot, &self.current, new_snap, .release);
+        self.publishSnapshot(new_snap);
 
         // Release writer's reference to old snapshot.
         old.release();
@@ -878,7 +904,7 @@ pub const IndexWriter = struct {
         };
         self.next_epoch += 1;
 
-        @atomicStore(*IndexSnapshot, &self.current, new_snap, .release);
+        self.publishSnapshot(new_snap);
         old.release();
         owned = null;
     }

--- a/zig/pkg/antfly/src/index.zig
+++ b/zig/pkg/antfly/src/index.zig
@@ -266,6 +266,17 @@ pub const IndexSnapshot = struct {
     /// Set by replaceSegments for the segments being merged away.
     retired_segments: []SegmentEntry,
     retired_segment_cleanup: ?RetiredSegmentCleanup = null,
+    /// The snapshot that replaced this one, retained at publish time.
+    /// Retired segments are attached to the snapshot that was current when
+    /// the merge ran — but a reader can hold a snapshot from an EARLIER
+    /// generation that still references those segments by value, and its
+    /// refcount does nothing to pin the later snapshot hosting their
+    /// cleanup. Chaining each old snapshot to its successor makes a held
+    /// snapshot transitively pin all later generations (and their retired
+    /// lists) until the holder releases. Observed in the field as a
+    /// layoutStats segfault when a status walk held a snapshot across two
+    /// publishes during a merge storm. Null only on the current snapshot.
+    successor: ?*IndexSnapshot = null,
 
     /// Increment reference count. Returns self for chaining.
     pub fn retain(self: *IndexSnapshot) *IndexSnapshot {
@@ -274,31 +285,44 @@ pub const IndexSnapshot = struct {
     }
 
     /// Decrement reference count. Frees snapshot when count reaches 0.
+    /// A fully-released snapshot also drops its reference on `successor`,
+    /// so a dying chain unwinds in this loop — iteratively, not
+    /// recursively, since a merge storm can chain hundreds of generations.
     pub fn release(self: *IndexSnapshot) void {
-        if (@atomicRmw(u32, &self.ref_count, .Sub, 1, .acq_rel) == 1) {
-            const alloc = self.alloc;
-            // Deinit retired segments (replaced during merge)
-            for (self.retired_segments) |*seg| {
-                var s = seg.*;
-                const seg_id = s.id;
-                s.deinit();
-                if (self.retired_segment_cleanup) |cleanup| cleanup.run(seg_id);
-            }
-            if (self.retired_segments.len > 0) alloc.free(self.retired_segments);
-            alloc.free(self.segments);
-            {
-                const cache_mu = &self.term_doc_freq_cache_mu;
-                while (!cache_mu.tryLock()) {
-                    spinOrYield();
-                }
-                defer cache_mu.unlock();
-                var cache_it = self.term_doc_freq_cache.keyIterator();
-                while (cache_it.next()) |key| alloc.free(key.storage);
-                self.term_doc_freq_cache.deinit(alloc);
-            }
-            self.global_total_field_len.deinit(alloc);
-            alloc.destroy(self);
+        var maybe: ?*IndexSnapshot = self;
+        while (maybe) |snap| {
+            if (@atomicRmw(u32, &snap.ref_count, .Sub, 1, .acq_rel) != 1) return;
+            const succ = snap.successor;
+            snap.freeFinal();
+            maybe = succ;
         }
+    }
+
+    /// Free everything this snapshot owns and destroy it. Only valid once
+    /// the refcount has reached zero.
+    fn freeFinal(self: *IndexSnapshot) void {
+        const alloc = self.alloc;
+        // Deinit retired segments (replaced during merge)
+        for (self.retired_segments) |*seg| {
+            var s = seg.*;
+            const seg_id = s.id;
+            s.deinit();
+            if (self.retired_segment_cleanup) |cleanup| cleanup.run(seg_id);
+        }
+        if (self.retired_segments.len > 0) alloc.free(self.retired_segments);
+        alloc.free(self.segments);
+        {
+            const cache_mu = &self.term_doc_freq_cache_mu;
+            while (!cache_mu.tryLock()) {
+                spinOrYield();
+            }
+            defer cache_mu.unlock();
+            var cache_it = self.term_doc_freq_cache.keyIterator();
+            while (cache_it.next()) |key| alloc.free(key.storage);
+            self.term_doc_freq_cache.deinit(alloc);
+        }
+        self.global_total_field_len.deinit(alloc);
+        alloc.destroy(self);
     }
 
     /// Full cleanup including ALL segment entries. Only for IndexWriter.deinit().
@@ -778,6 +802,12 @@ pub const IndexWriter = struct {
         // when all readers release it.
         old.retired_segments = retired;
         old.retired_segment_cleanup = self.retired_segment_cleanup;
+        // Chain old → new so a reader holding ANY earlier generation keeps
+        // this snapshot — and the retired lists of every generation in
+        // between — alive until it releases. Safe to write without
+        // synchronization: the writer still holds a reference on `old`, so
+        // no reader can be in freeFinal reading `successor` yet.
+        old.successor = new_snap.retain();
 
         // Atomic swap so concurrent readers see a consistent pointer.
         self.publishSnapshot(new_snap);
@@ -904,6 +934,10 @@ pub const IndexWriter = struct {
         };
         self.next_epoch += 1;
 
+        // Chain old → new (see IndexSnapshot.successor): every publish must
+        // link generations, or a holder of an older snapshot loses its
+        // transitive pin on later retired lists.
+        old.successor = new_snap.retain();
         self.publishSnapshot(new_snap);
         old.release();
         owned = null;
@@ -1461,4 +1495,66 @@ test "index writer removeSegments frees staged segment lists when rebuild alloca
     failing.fail_index = std.math.maxInt(usize);
 
     try std.testing.expectEqual(@as(usize, 2), writer.snapshot().segments.len);
+}
+
+test "held snapshot pins segments retired in later generations" {
+    const alloc = std.testing.allocator;
+
+    const Cleaned = struct {
+        ids: std.ArrayListUnmanaged(u64) = .empty,
+        fn record(ptr: *anyopaque, seg_id: u64) void {
+            const self: *@This() = @ptrCast(@alignCast(ptr));
+            self.ids.append(std.testing.allocator, seg_id) catch unreachable;
+        }
+    };
+    var cleaned = Cleaned{};
+    defer cleaned.ids.deinit(alloc);
+
+    const seg1 = try buildTestSegment(alloc, &.{
+        .{ .terms = &.{.{ .term = "alpha", .freq = 1, .norm = 10 }} },
+    });
+    defer alloc.free(seg1);
+    const seg2 = try buildTestSegment(alloc, &.{
+        .{ .terms = &.{.{ .term = "beta", .freq = 1, .norm = 10 }} },
+    });
+    defer alloc.free(seg2);
+    const merged = try buildTestSegment(alloc, &.{
+        .{ .terms = &.{.{ .term = "gamma", .freq = 1, .norm = 10 }} },
+    });
+    defer alloc.free(merged);
+
+    var writer = try IndexWriter.init(alloc);
+    defer writer.deinit();
+    writer.setRetiredSegmentCleanup(.{ .ptr = &cleaned, .delete = Cleaned.record });
+
+    try writer.addSegment(seg1);
+
+    // Hold the generation-1 snapshot across two later publishes — the
+    // pattern of a status walk racing a merge storm.
+    const held = writer.acquireSnapshot();
+
+    try writer.addSegment(seg2); // generation 2
+    const id1 = writer.snapshot().segments[0].id;
+    const id2 = writer.snapshot().segments[1].id;
+    // Generation 3: retires both segments, attaching them to generation 2.
+    try writer.replaceSegments(&.{ id1, id2 }, id2 + 1, merged);
+
+    // The held gen-1 snapshot still references seg1 by value. Without the
+    // successor chain, gen 2 dies the moment the writer releases it at the
+    // gen-3 publish and deinits seg1 while we still hold a snapshot
+    // containing it.
+    try std.testing.expectEqual(@as(usize, 0), cleaned.ids.items.len);
+
+    // Walking the held snapshot must read live segment memory.
+    var terms: u64 = 0;
+    for (held.segments) |*seg| {
+        const layout = seg.layoutStats(true);
+        terms +|= layout.inverted_one_hit_terms +| layout.inverted_postings_terms;
+    }
+    try std.testing.expect(terms > 0);
+
+    // Releasing the holder unwinds the chain; only now do the retired
+    // segments get cleaned up.
+    held.release();
+    try std.testing.expectEqual(@as(usize, 2), cleaned.ids.items.len);
 }

--- a/zig/pkg/antfly/src/merger.zig
+++ b/zig/pkg/antfly/src/merger.zig
@@ -169,7 +169,7 @@ pub fn mergeSegments(
         const seg = &snap.segments[si];
         inputs[i] = .{
             .reader = &seg.reader,
-            .deleted = seg.deleted,
+            .deleted = seg.shared.deleted,
         };
     }
     return try segment_mod.mergeSegmentInputs(alloc, inputs);
@@ -194,7 +194,7 @@ pub fn mergeSegmentsBounded(
         total_input_bytes += seg.data.bytes().len;
         inputs[i] = .{
             .reader = &seg.reader,
-            .deleted = seg.deleted,
+            .deleted = seg.shared.deleted,
         };
     }
 
@@ -484,8 +484,8 @@ test "merge policy picks small segments and applyMerge replaces them" {
             .index = i,
             .size = seg.data.bytes().len,
             .doc_count = seg.reader.doc_count,
-            .deleted_count = if (seg.deleted) |deleted| @intCast(deleted.cardinality()) else 0,
-            .has_deletions = seg.deleted != null,
+            .deleted_count = if (seg.shared.deleted) |deleted| @intCast(deleted.cardinality()) else 0,
+            .has_deletions = seg.shared.deleted != null,
         };
     }
 
@@ -683,11 +683,12 @@ test "merge mapper-built multi-field text segments" {
     try std.testing.expectEqualStrings("doc2", doc1.id);
     try std.testing.expectEqualStrings("doc3", doc2.id);
 
+    var seg_shared = index_mod.SegmentShared{ .ref_count = 1 };
     var seg_entry: index_mod.SegmentEntry = .{
         .id = 0,
         .data = index_mod.SegmentData.fromOwnedHeap(try alloc.dupe(u8, merged)),
         .reader = reader,
-        .deleted = null,
+        .shared = &seg_shared,
     };
     defer seg_entry.data.deinit(alloc);
     const phrase = query_mod.Filter{ .phrase = .{

--- a/zig/pkg/antfly/src/search/query.zig
+++ b/zig/pkg/antfly/src/search/query.zig
@@ -1333,7 +1333,7 @@ pub fn executeFilter(
         defer bm.deinit();
 
         // Remove deleted docs
-        if (seg.deleted) |d| bm.andNotWith(&d);
+        if (seg.shared.deleted) |d| bm.andNotWith(&d);
 
         // Collect with offset
         var iter = bm.iterator();

--- a/zig/pkg/antfly/src/search/search.zig
+++ b/zig/pkg/antfly/src/search/search.zig
@@ -1405,7 +1405,7 @@ fn scoreFastTerm(state: FastTermState, hit: inverted.PostingsIterator.Hit, globa
 }
 
 fn isSegmentDocDeleted(seg: *const index_mod.SegmentEntry, doc_id: u32) bool {
-    if (seg.deleted) |deleted| return deleted.contains(doc_id);
+    if (seg.shared.deleted) |deleted| return deleted.contains(doc_id);
     return false;
 }
 

--- a/zig/pkg/antfly/src/serverless/api/http_handler.zig
+++ b/zig/pkg/antfly/src/serverless/api/http_handler.zig
@@ -2869,6 +2869,11 @@ pub const HttpHandler = struct {
         const semantic_search = plan.request.semantic_search orelse return;
         if (plan.request.vector != null) return error.InvalidQueryRequest;
 
+        // Signal background enrichment to yield the embedder while this
+        // query-time embed runs (see enrichment_types.interactive_embed_inflight).
+        _ = db_mod.enrichment_types.interactive_embed_inflight.fetchAdd(1, .monotonic);
+        defer _ = db_mod.enrichment_types.interactive_embed_inflight.fetchSub(1, .monotonic);
+
         const index_name = (plan.vectorSource() orelse return error.InvalidQueryRequest).index_name;
         if (table_name) |name| {
             var table = (try self.catalog.getTableAlloc(self.alloc, name)) orelse return error.InvalidQueryRequest;

--- a/zig/pkg/antfly/src/storage/db/catalog/index_manager.zig
+++ b/zig/pkg/antfly/src/storage/db/catalog/index_manager.zig
@@ -758,6 +758,12 @@ pub const IndexManager = struct {
     resolvers: std.ArrayListUnmanaged(resolver_catalog.ResolverConfig) = .empty,
     cached_has_generated_enrichment_targets: std.atomic.Value(bool),
     status_only_index_configs: []types.IndexConfig,
+    // Indexes whose persisted artifacts failed to open (e.g. UnsupportedVersion).
+    // Their configs are quarantined into status_only_index_configs so the
+    // catalog, status reporting, and drop/recreate keep working while the
+    // runtime index stays absent; this map carries the per-index load error.
+    // Keys are duped index names; values are static @errorName memory.
+    failed_index_loads: std.StringHashMapUnmanaged([]const u8) = .empty,
 
     pub const TextIndex = struct {
         apply_mutex: *std.atomic.Mutex,
@@ -1557,6 +1563,8 @@ pub const IndexManager = struct {
             self.freeAlgebraicIndexEntry(entry);
         }
         self.clearStatusOnlyIndexConfigs();
+        self.clearFailedIndexLoads();
+        self.failed_index_loads.deinit(self.alloc);
         for (self.enrichments.items) |*entry| entry.deinit(self.alloc);
         for (self.resolvers.items) |*entry| entry.deinit(self.alloc);
         self.text_indexes.deinit(self.alloc);
@@ -1574,6 +1582,49 @@ pub const IndexManager = struct {
         for (self.status_only_index_configs) |*cfg| cfg.deinit(self.alloc);
         if (self.status_only_index_configs.len > 0) self.alloc.free(self.status_only_index_configs);
         self.status_only_index_configs = &.{};
+    }
+
+    /// Load error recorded for `name` during the last catalog load, or null
+    /// if the index loaded normally (or is not configured).
+    pub fn loadFailure(self: *const IndexManager, name: []const u8) ?[]const u8 {
+        return self.failed_index_loads.get(name);
+    }
+
+    pub fn hasLoadFailures(self: *const IndexManager) bool {
+        return self.failed_index_loads.count() > 0;
+    }
+
+    fn clearFailedIndexLoads(self: *IndexManager) void {
+        var it = self.failed_index_loads.keyIterator();
+        while (it.next()) |key| self.alloc.free(key.*);
+        self.failed_index_loads.clearRetainingCapacity();
+    }
+
+    fn dropFailedIndexLoad(self: *IndexManager, name: []const u8) void {
+        if (self.failed_index_loads.fetchRemove(name)) |entry| self.alloc.free(entry.key);
+    }
+
+    fn appendStatusOnlyConfig(self: *IndexManager, cfg: types.IndexConfig) !void {
+        const old = self.status_only_index_configs;
+        const replacement = try self.alloc.alloc(types.IndexConfig, old.len + 1);
+        @memcpy(replacement[0..old.len], old);
+        replacement[old.len] = cfg;
+        if (old.len > 0) self.alloc.free(old);
+        self.status_only_index_configs = replacement;
+    }
+
+    /// Quarantine an index whose persisted artifacts could not be opened:
+    /// keep its config visible (catalog persistence, status, drop/recreate)
+    /// while the runtime index stays absent, and record the load error.
+    fn recordFailedIndexLoad(self: *IndexManager, cfg: types.IndexConfig, err: anyerror) !void {
+        if (self.loadFailure(cfg.name) != null) return;
+        var cloned = try types.IndexConfig.clone(self.alloc, cfg);
+        errdefer cloned.deinit(self.alloc);
+        try self.appendStatusOnlyConfig(cloned);
+        // The clone is owned by status_only_index_configs from here on.
+        const name_key = try self.alloc.dupe(u8, cfg.name);
+        errdefer self.alloc.free(name_key);
+        try self.failed_index_loads.put(self.alloc, name_key, @errorName(err));
     }
 
     fn accountFullTextPendingBytes(self: *IndexManager, pending_bytes: u64) !void {
@@ -2285,6 +2336,7 @@ pub const IndexManager = struct {
         const load_started_ns = nowNs();
         self.bindPrimaryStore(store);
         self.clearStatusOnlyIndexConfigs();
+        self.clearFailedIndexLoads();
         try self.loadEnrichmentCatalog(store);
         try self.loadResolverCatalog(store);
 
@@ -2309,13 +2361,27 @@ pub const IndexManager = struct {
         var parallelism: usize = 1;
         if (comptime builtin.single_threaded or builtin.os.tag == .freestanding) {
             for (configs) |cfg| {
-                try self.openConfiguredIndex(store, cfg, allow_backfill, read_only);
+                self.openConfiguredIndex(store, cfg, allow_backfill, read_only) catch |err| {
+                    std.log.warn("load configured index failed name={s} kind={s} err={s}", .{
+                        cfg.name,
+                        @tagName(cfg.kind),
+                        @errorName(err),
+                    });
+                    try self.recordFailedIndexLoad(cfg, err);
+                };
             }
         } else {
             parallelism = self.resolvedLoadParallelism(configs.len);
             if (parallelism <= 1) {
                 for (configs) |cfg| {
-                    try self.openConfiguredIndex(store, cfg, allow_backfill, read_only);
+                    self.openConfiguredIndex(store, cfg, allow_backfill, read_only) catch |err| {
+                        std.log.warn("load configured index failed name={s} kind={s} err={s}", .{
+                            cfg.name,
+                            @tagName(cfg.kind),
+                            @errorName(err),
+                        });
+                        try self.recordFailedIndexLoad(cfg, err);
+                    };
                 }
             } else {
                 for (configs) |cfg| {
@@ -2336,6 +2402,7 @@ pub const IndexManager = struct {
 
     pub fn loadCatalogOnly(self: *IndexManager, store: anytype) !void {
         self.bindPrimaryStore(store);
+        self.clearFailedIndexLoads();
         try self.loadEnrichmentCatalog(store);
         try self.loadResolverCatalog(store);
 
@@ -2444,8 +2511,13 @@ pub const IndexManager = struct {
         for (threads[0..spawned]) |*thread| thread.join();
         threads_joined = true;
 
-        for (results) |*result| {
-            if (result.err) |err| return err;
+        // A failed index load quarantines that index instead of failing the
+        // whole table open; the other indexes stay usable and the failure is
+        // reported via loadFailure()/status so clients can drop+recreate.
+        for (results, 0..) |*result, i| {
+            if (result.err) |err| {
+                try self.recordFailedIndexLoad(configs[i], err);
+            }
         }
 
         for (results) |*result| {
@@ -2708,7 +2780,13 @@ pub const IndexManager = struct {
     pub fn remove(self: *IndexManager, store: anytype, name: []const u8) !bool {
         self.catalog_mutex.lockExclusive();
         defer self.catalog_mutex.unlockExclusive();
-        if (try self.removeStatusOnlyConfig(store, name)) return true;
+        if (try self.removeStatusOnlyConfig(store, name)) {
+            // Quarantined (failed-to-load) indexes live in the status-only
+            // list; removing one must also clear its recorded load error so a
+            // subsequent recreate starts clean.
+            self.dropFailedIndexLoad(name);
+            return true;
+        }
         for (self.text_indexes.items, 0..) |*entry, i| {
             if (std.mem.eql(u8, entry.config.name, name)) {
                 const index_path = try self.indexPath(name);
@@ -3016,7 +3094,11 @@ pub const IndexManager = struct {
     }
 
     pub fn managedIndexes(self: *const IndexManager, alloc: Allocator) ![]ManagedIndexRef {
-        const total = self.text_indexes.items.len + self.dense_indexes.items.len + self.sparse_indexes.items.len + self.graph_indexes.items.len + self.algebraic_indexes.items.len + self.status_only_index_configs.len;
+        var status_only_count: usize = 0;
+        for (self.status_only_index_configs) |cfg| {
+            if (self.loadFailure(cfg.name) == null) status_only_count += 1;
+        }
+        const total = self.text_indexes.items.len + self.dense_indexes.items.len + self.sparse_indexes.items.len + self.graph_indexes.items.len + self.algebraic_indexes.items.len + status_only_count;
         var refs = try alloc.alloc(ManagedIndexRef, total);
         var initialized: usize = 0;
         errdefer {
@@ -3060,6 +3142,10 @@ pub const IndexManager = struct {
             initialized += 1;
         }
         for (self.status_only_index_configs) |cfg| {
+            // Quarantined indexes (config retained after a load failure) have
+            // no runtime; replay/apply/maintenance work driven off this list
+            // must skip them or it would fail with IndexNotFound.
+            if (self.loadFailure(cfg.name) != null) continue;
             refs[initialized] = .{
                 .name = try alloc.dupe(u8, cfg.name),
                 .kind = cfg.kind,
@@ -15202,7 +15288,7 @@ test "dense embedding writes prefer inline vectors over artifact reloads" {
     try std.testing.expectEqualStrings("doc:inline", metadata);
 }
 
-test "loadConfiguredIndexesParallel returns worker errors without double-joining threads" {
+test "loadConfiguredIndexesParallel quarantines worker errors without double-joining threads" {
     const alloc = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -15236,7 +15322,14 @@ test "loadConfiguredIndexesParallel returns worker errors without double-joining
         try manager.ensureConfiguredIndexDir(cfg);
     }
 
-    try std.testing.expectError(error.InvalidIndexConfig, manager.loadConfiguredIndexesParallel(&store, &configs, 2, true, false));
+    // A worker error no longer fails the load: the failing index is
+    // quarantined (config retained, error recorded) while the healthy one
+    // loads normally — and the worker threads still join exactly once.
+    try manager.loadConfiguredIndexesParallel(&store, &configs, 2, true, false);
+    try std.testing.expect(manager.textIndexEntry("ft_v1") != null);
+    try std.testing.expect(manager.denseIndex("dv_bad") == null);
+    const recorded = manager.loadFailure("dv_bad") orelse return error.TestUnexpectedResult;
+    try std.testing.expectEqualStrings("InvalidIndexConfig", recorded);
 }
 
 test "dense apply resource manager accounts working bytes and releases them" {

--- a/zig/pkg/antfly/src/storage/db/catalog/index_manager.zig
+++ b/zig/pkg/antfly/src/storage/db/catalog/index_manager.zig
@@ -2381,9 +2381,20 @@ pub const IndexManager = struct {
         boundary_reassignment_min_improvement: f32 = 0.0,
     };
 
+    // Node budget per tree-link repair sweep run from the dense maintenance
+    // lane. Repairs persist as the sweep goes, so an exhausted budget simply
+    // resumes on the next maintenance pass.
+    const dense_link_repair_max_nodes: usize = 4096;
+
     pub fn runDensePostingMaintenance(self: *IndexManager, options: DensePostingMaintenanceOptions) !usize {
         var total_steps: usize = 0;
         for (self.dense_indexes.items) |*entry| {
+            // A write path observed a tree-link inconsistency (stale parent
+            // pointer / dangling node reference): run a bounded repair sweep
+            // before posting maintenance so traversals stop tripping on it.
+            if (try entry.index.maybeRepairTreeLinks(dense_link_repair_max_nodes)) |link_repair| {
+                total_steps += @intCast(link_repair.repaired());
+            }
             const backlog = try entry.index.postingBacklogStats();
             if (!backlog.needsRepair()) continue;
 

--- a/zig/pkg/antfly/src/storage/db/catalog/index_manager.zig
+++ b/zig/pkg/antfly/src/storage/db/catalog/index_manager.zig
@@ -761,9 +761,18 @@ pub const IndexManager = struct {
     // Indexes whose persisted artifacts failed to open (e.g. UnsupportedVersion).
     // Their configs are quarantined into status_only_index_configs so the
     // catalog, status reporting, and drop/recreate keep working while the
-    // runtime index stays absent; this map carries the per-index load error.
-    // Keys are duped index names; values are static @errorName memory.
-    failed_index_loads: std.StringHashMapUnmanaged([]const u8) = .empty,
+    // runtime index stays absent; this map carries the per-index load error
+    // and retry/backoff state for self-healing (retryFailedIndexLoads).
+    // Keys are duped index names; err_name values are static @errorName memory.
+    failed_index_loads: std.StringHashMapUnmanaged(FailedIndexLoad) = .empty,
+
+    pub const FailedIndexLoad = struct {
+        err_name: []const u8,
+        retry_attempts: u32 = 0,
+        // Monotonic deadline before which retryFailedIndexLoads skips this
+        // index. 0 = due immediately (first retry happens on the next tick).
+        next_retry_ns: u64 = 0,
+    };
 
     pub const TextIndex = struct {
         apply_mutex: *std.atomic.Mutex,
@@ -1587,7 +1596,7 @@ pub const IndexManager = struct {
     /// Load error recorded for `name` during the last catalog load, or null
     /// if the index loaded normally (or is not configured).
     pub fn loadFailure(self: *const IndexManager, name: []const u8) ?[]const u8 {
-        return self.failed_index_loads.get(name);
+        return (self.failed_index_loads.get(name) orelse return null).err_name;
     }
 
     pub fn hasLoadFailures(self: *const IndexManager) bool {
@@ -1624,7 +1633,100 @@ pub const IndexManager = struct {
         // The clone is owned by status_only_index_configs from here on.
         const name_key = try self.alloc.dupe(u8, cfg.name);
         errdefer self.alloc.free(name_key);
-        try self.failed_index_loads.put(self.alloc, name_key, @errorName(err));
+        try self.failed_index_loads.put(self.alloc, name_key, .{ .err_name = @errorName(err) });
+    }
+
+    const quarantine_retry_base_backoff_ns: u64 = 30 * std.time.ns_per_s;
+    const quarantine_retry_max_backoff_ns: u64 = 10 * std.time.ns_per_min;
+
+    fn quarantineRetryBackoffNs(attempts: u32) u64 {
+        const shift: u6 = @intCast(@min(attempts, 5));
+        return @min(quarantine_retry_base_backoff_ns << shift, quarantine_retry_max_backoff_ns);
+    }
+
+    pub const QuarantineRetryResult = struct {
+        recovered: usize = 0,
+        remaining: usize = 0,
+    };
+
+    /// Re-attempts opening quarantined indexes whose backoff deadline has
+    /// passed (all of them when `force` is set). A successful open registers
+    /// the runtime index, removes the quarantined config from the
+    /// status-only list, and clears the recorded load error — the same end
+    /// state as a clean open-time load. A failed attempt updates the
+    /// recorded error and pushes the next attempt out exponentially
+    /// (30s..10min). `remaining` is the quarantine count after this pass,
+    /// read under the catalog lock so callers can stop polling at zero.
+    pub fn retryFailedIndexLoads(self: *IndexManager, store: anytype, now_ns: u64, force: bool) !QuarantineRetryResult {
+        self.catalog_mutex.lockExclusive();
+        defer self.catalog_mutex.unlockExclusive();
+        if (self.failed_index_loads.count() == 0) return .{};
+
+        var due_names = std.ArrayListUnmanaged([]const u8).empty;
+        defer due_names.deinit(self.alloc);
+        var it = self.failed_index_loads.iterator();
+        while (it.next()) |entry| {
+            if (!force and now_ns < entry.value_ptr.next_retry_ns) continue;
+            // Keys are owned by the map and stable across the value updates
+            // below (no inserts/removes until the success path).
+            try due_names.append(self.alloc, entry.key_ptr.*);
+        }
+
+        var recovered: usize = 0;
+        for (due_names.items) |name| {
+            const cfg = blk: {
+                for (self.status_only_index_configs) |*candidate| {
+                    if (std.mem.eql(u8, candidate.name, name)) break :blk candidate.*;
+                }
+                // Config vanished (concurrent drop); clear the stale record.
+                self.dropFailedIndexLoad(name);
+                continue;
+            };
+            var opened = self.openConfiguredIndexDetached(store, cfg, true, false) catch |err| {
+                const record = self.failed_index_loads.getPtr(name) orelse continue;
+                record.err_name = @errorName(err);
+                record.retry_attempts +|= 1;
+                record.next_retry_ns = now_ns + quarantineRetryBackoffNs(record.retry_attempts);
+                std.log.warn("quarantined index retry failed name={s} attempt={d} err={s}", .{
+                    name,
+                    record.retry_attempts,
+                    @errorName(err),
+                });
+                continue;
+            };
+            // Pre-allocate the shrunken status-only list so registration and
+            // de-quarantine commit together once the open has succeeded.
+            const old = self.status_only_index_configs;
+            const replacement: []types.IndexConfig = if (old.len <= 1)
+                &.{}
+            else
+                self.alloc.alloc(types.IndexConfig, old.len - 1) catch |err| {
+                    opened.deinit(self);
+                    return err;
+                };
+            self.appendOpenedIndex(opened) catch |err| {
+                if (replacement.len > 0) self.alloc.free(replacement);
+                opened.deinit(self);
+                return err;
+            };
+            var wi: usize = 0;
+            for (old) |old_cfg| {
+                if (std.mem.eql(u8, old_cfg.name, name)) {
+                    var removed = old_cfg;
+                    removed.deinit(self.alloc);
+                    continue;
+                }
+                replacement[wi] = old_cfg;
+                wi += 1;
+            }
+            if (old.len > 0) self.alloc.free(old);
+            self.status_only_index_configs = replacement;
+            // Log before dropFailedIndexLoad frees the `name` key buffer.
+            std.log.info("quarantined index recovered name={s} kind={s}", .{ name, @tagName(cfg.kind) });
+            self.dropFailedIndexLoad(name);
+            recovered += 1;
+        }
+        return .{ .recovered = recovered, .remaining = self.failed_index_loads.count() };
     }
 
     fn accountFullTextPendingBytes(self: *IndexManager, pending_bytes: u64) !void {
@@ -6474,8 +6576,8 @@ pub const IndexManager = struct {
                 .index = i,
                 .size = seg.data.bytes().len,
                 .doc_count = seg.reader.doc_count,
-                .deleted_count = if (seg.deleted) |deleted| @intCast(deleted.cardinality()) else 0,
-                .has_deletions = seg.deleted != null,
+                .deleted_count = if (seg.shared.deleted) |deleted| @intCast(deleted.cardinality()) else 0,
+                .has_deletions = seg.shared.deleted != null,
             });
         }
         if (infos.items.len < 2) return null;
@@ -6511,7 +6613,7 @@ pub const IndexManager = struct {
             const source_seg = &snap.segments[seg_idx];
             source[i] = .{
                 .id = source_seg.id,
-                .deleted = if (source_seg.deleted) |*deleted| try deleted.clone(self.alloc) else null,
+                .deleted = if (source_seg.shared.deleted) |*deleted| try deleted.clone(self.alloc) else null,
             };
             source_initialized += 1;
             merge_indices[i] = seg_idx;
@@ -6582,9 +6684,9 @@ pub const IndexManager = struct {
         for (task.source) |source| {
             const seg = findSegmentById(snap, source.id) orelse return false;
             if (source.deleted) |expected| {
-                const current_deleted = seg.deleted orelse return false;
+                const current_deleted = seg.shared.deleted orelse return false;
                 if (!current_deleted.eql(&expected)) return false;
-            } else if (seg.deleted != null) {
+            } else if (seg.shared.deleted != null) {
                 return false;
             }
         }

--- a/zig/pkg/antfly/src/storage/db/catalog/text_index_maintenance.zig
+++ b/zig/pkg/antfly/src/storage/db/catalog/text_index_maintenance.zig
@@ -131,8 +131,8 @@ fn buildSegmentInfosAlloc(
             .index = i,
             .size = seg.data.bytes().len,
             .doc_count = seg.reader.doc_count,
-            .deleted_count = if (seg.deleted) |deleted| @intCast(deleted.cardinality()) else 0,
-            .has_deletions = seg.deleted != null,
+            .deleted_count = if (seg.shared.deleted) |deleted| @intCast(deleted.cardinality()) else 0,
+            .has_deletions = seg.shared.deleted != null,
         };
     }
     return infos;

--- a/zig/pkg/antfly/src/storage/db/db.zig
+++ b/zig/pkg/antfly/src/storage/db/db.zig
@@ -2363,6 +2363,11 @@ pub const DB = struct {
     transaction_runtime: ?*transaction_runtime_mod.Runtime,
     text_merge_runtime: ?*text_merge_runtime_mod.TextMergeRuntime,
     sparse_compaction_runtime: ?*sparse_compaction_runtime_mod.SparseCompactionRuntime,
+    // Background retry of quarantined index loads (see retryQuarantinedIndexLoads).
+    // Spawned at open only when the load left failures behind; exits once all
+    // quarantined indexes recover or the DB closes.
+    quarantine_retry_thread: ?std.Thread = null,
+    quarantine_retry_stop: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
     shadow: ?ShadowState,
     bulk_ingest_coalescer: @This().BulkIngestCoalescer = .{},
     flushing_bulk_ingest_coalescer: bool = false,
@@ -2610,6 +2615,9 @@ pub const DB = struct {
                 const start_optional_started_ns = monotonicTimeNs();
                 try db.startOptionalRuntimes();
                 profile.start_optional_runtimes_ns = elapsedSince(start_optional_started_ns);
+            }
+            if (optional_runtimes_enabled and opts.open_mode == .writer) {
+                db.startQuarantineRetryWorkerIfNeeded();
             }
             profile.total_ns = monotonicTimeNs() - open_started_ns;
             if (openProfileEnabled()) {
@@ -2994,6 +3002,9 @@ pub const DB = struct {
     }
 
     fn deinitWrapperState(self: *DB, executor_ready: bool) void {
+        // Stop the quarantine retry worker first: it takes the catalog lock
+        // and opens indexes, which must not race the teardown below.
+        self.stopQuarantineRetryWorker();
         // Close may flush/coalesce derived watermarks while workers are
         // stopping. That must not call back into the write/status cache after
         // optional runtimes or index state have started tearing down.
@@ -7127,6 +7138,57 @@ pub const DB = struct {
             if (self.core.nextDerivedSequence() <= drained_sequence) return;
         }
         return error.RunUntilIdleDidNotConverge;
+    }
+
+    /// Re-attempts opening quarantined indexes (artifacts that failed to
+    /// load at open time). `force` ignores per-index backoff — used by tests
+    /// and operator-triggered recovery. Runs the same detached-open path as
+    /// the initial load, so a recovered full-text/sparse/graph index resumes
+    /// its persisted rebuild state and catches up before registering.
+    pub fn retryQuarantinedIndexLoads(self: *DB, force: bool) !index_manager_mod.IndexManager.QuarantineRetryResult {
+        return try self.core.index_manager.retryFailedIndexLoads(self.core.store, monotonicTimeNs(), force);
+    }
+
+    const quarantine_retry_poll_ns: u64 = 10 * std.time.ns_per_s;
+    const quarantine_retry_sleep_slice_ns: u64 = 25 * std.time.ns_per_ms;
+
+    fn startQuarantineRetryWorkerIfNeeded(self: *DB) void {
+        if (comptime builtin.single_threaded or builtin.os.tag == .freestanding) return;
+        // Tests drive retries deterministically via retryQuarantinedIndexLoads;
+        // a background worker racing them turns every quarantine-shaped test
+        // into a timing assumption.
+        if (comptime builtin.is_test) return;
+        if (!self.core.index_manager.hasLoadFailures()) return;
+        self.quarantine_retry_thread = std.Thread.spawn(.{}, quarantineRetryWorkerMain, .{self}) catch |err| {
+            // Self-healing is best-effort: the quarantine still recovers on
+            // the next open or via drop+recreate.
+            std.log.warn("quarantine retry worker spawn failed: {}", .{err});
+            return;
+        };
+    }
+
+    fn stopQuarantineRetryWorker(self: *DB) void {
+        self.quarantine_retry_stop.store(true, .release);
+        if (self.quarantine_retry_thread) |thread| {
+            thread.join();
+            self.quarantine_retry_thread = null;
+        }
+    }
+
+    fn quarantineRetryWorkerMain(self: *DB) void {
+        while (true) {
+            var slept: u64 = 0;
+            while (slept < quarantine_retry_poll_ns) : (slept += quarantine_retry_sleep_slice_ns) {
+                if (self.quarantine_retry_stop.load(.acquire)) return;
+                sleepNs(quarantine_retry_sleep_slice_ns);
+            }
+            if (self.quarantine_retry_stop.load(.acquire)) return;
+            const result = self.retryQuarantinedIndexLoads(false) catch |err| {
+                std.log.warn("quarantine retry pass failed: {}", .{err});
+                continue;
+            };
+            if (result.remaining == 0) return;
+        }
     }
 
     pub fn runUntilIdle(self: *DB) !void {
@@ -27597,6 +27659,102 @@ test "db open quarantines dense index with unsupported artifact version" {
     }, 1);
     defer recovered.deinit();
     try std.testing.expect(recovered.total_hits >= 1);
+}
+
+test "db quarantined index self-heals via retryQuarantinedIndexLoads" {
+    const alloc = std.testing.allocator;
+
+    var path_buf: [256]u8 = undefined;
+    const path = tempPath(&path_buf);
+    defer cleanupTempDir(path);
+
+    {
+        var db = try DB.open(alloc, std.mem.span(path), .{});
+        defer db.close();
+
+        var writes = std.ArrayListUnmanaged(types.BatchWrite).empty;
+        defer {
+            for (writes.items) |item| {
+                alloc.free(@constCast(item.key));
+                alloc.free(@constCast(item.value));
+            }
+            writes.deinit(alloc);
+        }
+        for (0..300) |i| {
+            try writes.append(alloc, .{
+                .key = try std.fmt.allocPrint(alloc, "doc:{d:0>4}", .{i}),
+                .value = try std.fmt.allocPrint(alloc, "{{\"title\":\"alpha\",\"n\":{d}}}", .{i}),
+            });
+        }
+        try db.batch(.{ .writes = writes.items });
+        try db.core.index_manager.addAllNoBackfill(db.core.store, &.{.{
+            .name = "ft_v1",
+            .kind = .full_text,
+            .config_json = "{}",
+        }});
+    }
+
+    index_manager_mod.test_abort_text_backfill_after_batches = 1;
+    defer index_manager_mod.test_abort_text_backfill_after_batches = null;
+
+    var db = try DB.open(alloc, std.mem.span(path), .{});
+    defer db.close();
+    try std.testing.expect(db.core.index_manager.loadFailure("ft_v1") != null);
+    try std.testing.expect(db.core.textIndexEntry("ft_v1") == null);
+
+    // Writes keep flowing while the index is quarantined; the heal's resumed
+    // backfill must pick them up. They also guarantee the next backfill
+    // attempt flushes at least once, so the still-set abort knob fires.
+    {
+        var writes = std.ArrayListUnmanaged(types.BatchWrite).empty;
+        defer {
+            for (writes.items) |item| {
+                alloc.free(@constCast(item.key));
+                alloc.free(@constCast(item.value));
+            }
+            writes.deinit(alloc);
+        }
+        for (300..400) |i| {
+            try writes.append(alloc, .{
+                .key = try std.fmt.allocPrint(alloc, "doc:{d:0>4}", .{i}),
+                .value = try std.fmt.allocPrint(alloc, "{{\"title\":\"alpha\",\"n\":{d}}}", .{i}),
+            });
+        }
+        try db.batch(.{ .writes = writes.items });
+    }
+
+    // While the cause persists, a forced retry fails and applies backoff.
+    {
+        const result = try db.retryQuarantinedIndexLoads(true);
+        try std.testing.expectEqual(@as(usize, 0), result.recovered);
+        try std.testing.expectEqual(@as(usize, 1), result.remaining);
+    }
+    // Cause fixed — but the failed attempt set a backoff deadline, so a
+    // non-forced retry is skipped without re-attempting the open (it would
+    // recover if it attempted).
+    index_manager_mod.test_abort_text_backfill_after_batches = null;
+    {
+        const result = try db.retryQuarantinedIndexLoads(false);
+        try std.testing.expectEqual(@as(usize, 0), result.recovered);
+        try std.testing.expectEqual(@as(usize, 1), result.remaining);
+    }
+
+    // Forced retry recovers the index in-process — no reopen, no
+    // drop+recreate — resuming the persisted rebuild state.
+    const result = try db.retryQuarantinedIndexLoads(true);
+    try std.testing.expectEqual(@as(usize, 1), result.recovered);
+    try std.testing.expectEqual(@as(usize, 0), result.remaining);
+    try std.testing.expect(db.core.index_manager.loadFailure("ft_v1") == null);
+    try std.testing.expect(db.core.textIndexEntry("ft_v1") != null);
+
+    try db.runUntilIdle();
+    var search_result = try db.search(alloc, .{
+        .index_name = "ft_v1",
+        .query = .{ .match_all = {} },
+        .limit = 500,
+    });
+    defer search_result.deinit();
+    try std.testing.expectEqual(@as(u32, 400), search_result.total_hits);
 }
 
 test "db managed dense enrichment delete recreate recovers after corrupt artifact" {

--- a/zig/pkg/antfly/src/storage/db/db.zig
+++ b/zig/pkg/antfly/src/storage/db/db.zig
@@ -5689,7 +5689,10 @@ pub const DB = struct {
         min_weight: f64,
         max_weight: f64,
     ) !?paths_mod.Path {
-        const entry = self.core.index_manager.graphIndex(index_name) orelse return error.IndexNotFound;
+        const entry = self.core.index_manager.graphIndex(index_name) orelse {
+            try self.failIfIndexQuarantined(index_name);
+            return error.IndexNotFound;
+        };
         const params = graph_query_mod.QueryParams{
             .edge_types = edge_types,
             .direction = direction,
@@ -7985,6 +7988,7 @@ pub const DB = struct {
 
     fn freeDBIndexStatsItem(alloc: Allocator, item: types.DBIndexStats) void {
         alloc.free(item.name);
+        if (item.load_error) |value| alloc.free(value);
         if (item.algebraic_last_error_doc_key) |value| alloc.free(value);
         if (item.algebraic_last_error_reason) |value| alloc.free(value);
         if (item.algebraic_capability_fingerprint) |value| alloc.free(value);
@@ -8707,6 +8711,12 @@ pub const DB = struct {
                 );
                 item.backfill_active = applied_sequence < target_sequence;
             }
+            if (self.core.index_manager.loadFailure(cfg.name)) |load_error| {
+                item.load_error = try alloc.dupe(u8, load_error);
+                // A quarantined index has no runtime; it is broken, not warming.
+                item.backfill_active = false;
+                item.catch_up_active = false;
+            }
 
             switch (cfg.kind) {
                 .full_text => {
@@ -9015,6 +9025,12 @@ pub const DB = struct {
                     @as(f64, @floatFromInt(applied_sequence)) / @as(f64, @floatFromInt(target_sequence)),
                 );
                 item.backfill_active = applied_sequence < target_sequence;
+            }
+            if (self.core.index_manager.loadFailure(cfg.name)) |load_error| {
+                item.load_error = try alloc.dupe(u8, load_error);
+                // A quarantined index has no runtime; it is broken, not warming.
+                item.backfill_active = false;
+                item.catch_up_active = false;
             }
             if (try self.loadIndexStatusSnapshot(alloc, cfg.name)) |status_snapshot| {
                 applyIndexStatusSnapshot(&item, status_snapshot);
@@ -9894,7 +9910,16 @@ pub const DB = struct {
         index_name: ?[]const u8,
     ) anyerror!?*index_manager_mod.IndexManager.TextIndex {
         const self: *DB = @ptrCast(@alignCast(ctx orelse return error.InvalidArgument));
+        try self.failIfIndexQuarantined(index_name);
         return self.core.textIndexEntry(index_name);
+    }
+
+    /// Queries that explicitly reference an index whose persisted artifacts
+    /// failed to load get a distinct error instead of IndexNotFound, so
+    /// clients can tell "broken, drop+recreate to recover" from "missing".
+    fn failIfIndexQuarantined(self: *DB, index_name: ?[]const u8) !void {
+        const name = index_name orelse return;
+        if (self.core.index_manager.loadFailure(name) != null) return error.IndexUnavailable;
     }
 
     fn textIndexIsChunkBackedCallback(
@@ -10336,7 +10361,10 @@ pub const DB = struct {
             .sparse_vector => self.core.index_manager.sparseVectorAccessPath(index_name),
             else => null,
         };
-        const access_path = selected_path orelse return error.IndexNotFound;
+        const access_path = selected_path orelse {
+            try self.failIfIndexQuarantined(index_name);
+            return error.IndexNotFound;
+        };
         var planned = (try algebraic_mod.planner.planVectorSearchTensorProgramAlloc(self.alloc, access_path.owner, layout, constrained)) orelse return error.InvalidIndexConfig;
         defer planned.deinit(self.alloc);
         if (planned.access_paths.len != 1 or
@@ -10899,6 +10927,7 @@ pub const DB = struct {
         index_name: ?[]const u8,
     ) anyerror!?*index_manager_mod.IndexManager.DenseIndex {
         const self: *DB = @ptrCast(@alignCast(ctx orelse return error.InvalidArgument));
+        try self.failIfIndexQuarantined(index_name);
         return self.core.denseIndex(index_name);
     }
 
@@ -10939,6 +10968,7 @@ pub const DB = struct {
         index_name: ?[]const u8,
     ) anyerror!?*index_manager_mod.IndexManager.SparseIndex {
         const self: *DB = @ptrCast(@alignCast(ctx orelse return error.InvalidArgument));
+        try self.failIfIndexQuarantined(index_name);
         return self.core.sparseIndex(index_name);
     }
 
@@ -11473,7 +11503,10 @@ pub const DB = struct {
         start_key_refs: []const []const u8,
         target_keys: [][]u8,
     ) !graph_query_mod.GraphQueryResult {
-        const entry = self.core.graphIndex(graph_query.index_name) orelse return error.IndexNotFound;
+        const entry = self.core.graphIndex(graph_query.index_name) orelse {
+            try self.failIfIndexQuarantined(graph_query.index_name);
+            return error.IndexNotFound;
+        };
         if (entry.index.supportsAlgebraicSemiringTraversal()) {
             try self.proveGraphTraversalProgram(graph_query.index_name, target_keys.len > 0);
         }
@@ -27455,6 +27488,117 @@ test "db managed dense enrichment remains searchable after transient rate limits
     try db.runUntilIdle();
 }
 
+test "db open quarantines dense index with unsupported artifact version" {
+    const alloc = std.testing.allocator;
+
+    var path_buf: [256]u8 = undefined;
+    const path = tempPath(&path_buf);
+    defer cleanupTempDir(path);
+
+    const dense_cfg: types.IndexConfig = .{
+        .name = "dv_quarantine",
+        .kind = .dense_vector,
+        .config_json = "{\"field\":\"embedding\",\"dims\":3,\"generator\":{\"kind\":\"dense_embedding\",\"source_field\":\"body\",\"embedding_name\":\"dv_quarantine\"}}",
+    };
+
+    var deterministic = embedder_mod.DeterministicDenseEmbedder{};
+    const open_options: OpenOptions = .{
+        .enrichment = .{
+            .owner_id = "quarantine-worker",
+            .dense_embedder = deterministic.interface(),
+        },
+    };
+
+    {
+        var db = try DB.open(alloc, std.mem.span(path), open_options);
+        defer db.close();
+
+        try db.addIndex(.{ .name = "ft_v1", .kind = .full_text, .config_json = "{}" });
+        try db.addIndex(dense_cfg);
+        try db.batch(.{
+            .writes = &.{
+                .{ .key = "doc:a", .value = "{\"title\":\"alpha\",\"body\":\"alpha concept overview\"}" },
+            },
+            .sync_level = .write,
+        });
+        try db.runUntilIdle();
+
+        // Persist an HBC metadata record with a version this build does not
+        // support, simulating an artifact written by an incompatible build.
+        const entry = db.core.denseIndex("dv_quarantine") orelse return error.TestUnexpectedResult;
+        var bad_meta = entry.index.metadata;
+        bad_meta.version = 99;
+        var meta_buf: [vectorindex_mod.hbc.IndexMetadata.encoded_size]u8 = undefined;
+        const encoded = bad_meta.encode(&meta_buf);
+        var txn = try entry.index.beginWriteTxn();
+        errdefer txn.abort();
+        try txn.put(.meta, vectorindex_mod.hbc.meta_key, encoded);
+        try txn.commit();
+    }
+
+    var db = try DB.open(alloc, std.mem.span(path), open_options);
+    defer db.close();
+
+    // The broken dense index is quarantined: absent from the runtime, its
+    // load error recorded, and the rest of the table fully usable.
+    try std.testing.expect(db.core.denseIndex("dv_quarantine") == null);
+    const recorded = db.core.index_manager.loadFailure("dv_quarantine") orelse return error.TestUnexpectedResult;
+    try std.testing.expectEqualStrings("UnsupportedVersion", recorded);
+
+    var ft_result = try db.search(alloc, .{
+        .index_name = "ft_v1",
+        .full_text = .{ .match = .{ .field = "title", .text = "alpha" } },
+    });
+    defer ft_result.deinit();
+    try std.testing.expectEqual(@as(u32, 1), ft_result.total_hits);
+
+    {
+        const stats = try db.stats(alloc);
+        defer types.freeDBStats(alloc, stats);
+        var found = false;
+        for (stats.indexes) |item| {
+            if (!std.mem.eql(u8, item.name, "dv_quarantine")) continue;
+            found = true;
+            const load_error = item.load_error orelse return error.TestUnexpectedResult;
+            try std.testing.expectEqualStrings("UnsupportedVersion", load_error);
+            try std.testing.expect(!item.backfill_active);
+        }
+        try std.testing.expect(found);
+    }
+
+    // Queries that explicitly reference the quarantined index get a distinct
+    // error instead of IndexNotFound or a stall.
+    const query_vec = [_]f32{ 0.1, 0.2, 0.3 };
+    try std.testing.expectError(error.IndexUnavailable, db.search(alloc, .{
+        .index_name = "dv_quarantine",
+        .dense = .{
+            .vector = &query_vec,
+            .k = 1,
+        },
+        .limit = 1,
+    }));
+
+    // Drop + recreate recovers and clears the recorded failure.
+    try std.testing.expect(try db.deleteIndex("dv_quarantine"));
+    try std.testing.expect(db.core.index_manager.loadFailure("dv_quarantine") == null);
+    try db.addIndex(dense_cfg);
+    try db.runUntilIdle();
+    try std.testing.expect(db.core.denseIndex("dv_quarantine") != null);
+
+    const recovered_vec = try deterministic.interface().embedDense(alloc, "dv_quarantine", "alpha concept overview", 3);
+    defer alloc.free(recovered_vec);
+    var recovered = try waitForSearchResult(alloc, &db, .{
+        .index_name = "dv_quarantine",
+        .dense = .{
+            .vector = recovered_vec,
+            .k = 1,
+        },
+        .limit = 1,
+    }, 1);
+    defer recovered.deinit();
+    try std.testing.expect(recovered.total_hits >= 1);
+}
+
 test "db managed dense enrichment delete recreate recovers after corrupt artifact" {
     const alloc = std.testing.allocator;
 
@@ -32031,7 +32175,14 @@ test "db full-text backfill resumes after interrupted reopen" {
 
     index_manager_mod.test_abort_text_backfill_after_batches = 1;
     defer index_manager_mod.test_abort_text_backfill_after_batches = null;
-    try std.testing.expectError(error.TestInjectedBackfillFailure, DB.open(alloc, std.mem.span(path), .{}));
+    {
+        // A per-index load failure no longer fails the whole open; the index
+        // is quarantined with its error recorded and retried on next open.
+        var interrupted = try DB.open(alloc, std.mem.span(path), .{});
+        defer interrupted.close();
+        const recorded = interrupted.core.index_manager.loadFailure("ft_v1") orelse return error.TestUnexpectedResult;
+        try std.testing.expectEqualStrings("TestInjectedBackfillFailure", recorded);
+    }
 
     const state_path = try std.fmt.allocPrint(alloc, "{s}/indexes/ft_v1/rebuild.state", .{std.mem.span(path)});
     defer alloc.free(state_path);
@@ -32099,7 +32250,14 @@ test "db sparse backfill resumes after interrupted reopen" {
     defer index_manager_mod.test_sparse_backfill_batch_size = null;
     index_manager_mod.test_abort_sparse_backfill_after_batches = 1;
     defer index_manager_mod.test_abort_sparse_backfill_after_batches = null;
-    try std.testing.expectError(error.TestInjectedBackfillFailure, DB.open(alloc, std.mem.span(path), .{}));
+    {
+        // A per-index load failure no longer fails the whole open; the index
+        // is quarantined with its error recorded and retried on next open.
+        var interrupted = try DB.open(alloc, std.mem.span(path), .{});
+        defer interrupted.close();
+        const recorded = interrupted.core.index_manager.loadFailure("sp_v1") orelse return error.TestUnexpectedResult;
+        try std.testing.expectEqualStrings("TestInjectedBackfillFailure", recorded);
+    }
 
     const state_path = try std.fmt.allocPrint(alloc, "{s}/indexes/sp_v1/rebuild.state", .{std.mem.span(path)});
     defer alloc.free(state_path);
@@ -35437,7 +35595,14 @@ test "db graph reverse rebuild resumes after interrupted reopen" {
 
     graph_mod.test_abort_reverse_rebuild_after_batches = 1;
     defer graph_mod.test_abort_reverse_rebuild_after_batches = null;
-    try std.testing.expectError(error.TestInjectedBackfillFailure, DB.open(alloc, std.mem.span(path), .{}));
+    {
+        // A per-index load failure no longer fails the whole open; the index
+        // is quarantined with its error recorded and retried on next open.
+        var interrupted = try DB.open(alloc, std.mem.span(path), .{});
+        defer interrupted.close();
+        const recorded = interrupted.core.index_manager.loadFailure("gr_v1") orelse return error.TestUnexpectedResult;
+        try std.testing.expectEqualStrings("TestInjectedBackfillFailure", recorded);
+    }
 
     const state_path = try std.fmt.allocPrint(alloc, "{s}/indexes/gr_v1/rebuild.state", .{std.mem.span(path)});
     defer alloc.free(state_path);

--- a/zig/pkg/antfly/src/storage/db/enrichment/enrichment_runtime.zig
+++ b/zig/pkg/antfly/src/storage/db/enrichment/enrichment_runtime.zig
@@ -207,18 +207,19 @@ fn transientEmbedRetrySleepNs(attempt: u32) u64 {
     return @min(transient_embed_retry_base_sleep_ns << @intCast(shift), transient_embed_retry_max_sleep_ns);
 }
 
-const query_yield_poll_ns: u64 = 150 * std.time.ns_per_ms;
+const query_yield_poll_ns: u64 = 25 * std.time.ns_per_ms;
 const query_yield_max_ns: u64 = 5 * std.time.ns_per_s;
 
-// yieldToPublicQueries briefly defers the next embed batch while public
-// table queries are in flight, so interactive query embeds aren't starved
-// by backfill. Bounded to a few seconds per batch — backfill must always
-// make progress.
-fn yieldToPublicQueries(runtime: *EnrichmentRuntime) void {
+// yieldToInteractiveEmbeds briefly defers the next embed batch while a
+// query-time embed is in flight, so interactive embeds aren't starved by
+// backfill. The flag covers only the embed call itself (milliseconds), so
+// the wait normally clears on the first poll; the 5s cap is a safety bound —
+// backfill must always make progress.
+fn yieldToInteractiveEmbeds(runtime: *EnrichmentRuntime) void {
     if (comptime builtin.os.tag == .freestanding) return;
-    if (enrichment_types.public_query_inflight.load(.monotonic) == 0) return;
+    if (enrichment_types.interactive_embed_inflight.load(.monotonic) == 0) return;
     const start_ns = runtime.config.clock.nowRealtimeNs();
-    while (enrichment_types.public_query_inflight.load(.monotonic) > 0) {
+    while (enrichment_types.interactive_embed_inflight.load(.monotonic) > 0) {
         if (elapsedNsSince(runtime, start_ns) >= query_yield_max_ns) return;
         if (runtimeShuttingDown(runtime)) return;
         sleepRetryBackoff(query_yield_poll_ns);
@@ -2344,7 +2345,7 @@ fn flushPlainDenseItems(
         max_source_bytes = @max(max_source_bytes, item.source_text.len);
     }
 
-    yieldToPublicQueries(runtime);
+    yieldToInteractiveEmbeds(runtime);
     noteEmbedBatchStarted(runtime, items.len, total_source_bytes, max_source_bytes);
     const embed_started_ns = runtime.config.clock.nowRealtimeNs();
     const vectors = embedDenseBatchWithRetry(dense_embedder, runtime, embedding_artifact_name, texts, expected_dims) catch |err| {

--- a/zig/pkg/antfly/src/storage/db/enrichment/enrichment_runtime.zig
+++ b/zig/pkg/antfly/src/storage/db/enrichment/enrichment_runtime.zig
@@ -207,6 +207,24 @@ fn transientEmbedRetrySleepNs(attempt: u32) u64 {
     return @min(transient_embed_retry_base_sleep_ns << @intCast(shift), transient_embed_retry_max_sleep_ns);
 }
 
+const query_yield_poll_ns: u64 = 150 * std.time.ns_per_ms;
+const query_yield_max_ns: u64 = 5 * std.time.ns_per_s;
+
+// yieldToPublicQueries briefly defers the next embed batch while public
+// table queries are in flight, so interactive query embeds aren't starved
+// by backfill. Bounded to a few seconds per batch — backfill must always
+// make progress.
+fn yieldToPublicQueries(runtime: *EnrichmentRuntime) void {
+    if (comptime builtin.os.tag == .freestanding) return;
+    if (enrichment_types.public_query_inflight.load(.monotonic) == 0) return;
+    const start_ns = runtime.config.clock.nowRealtimeNs();
+    while (enrichment_types.public_query_inflight.load(.monotonic) > 0) {
+        if (elapsedNsSince(runtime, start_ns) >= query_yield_max_ns) return;
+        if (runtimeShuttingDown(runtime)) return;
+        sleepRetryBackoff(query_yield_poll_ns);
+    }
+}
+
 fn runtimeShuttingDown(runtime: *EnrichmentRuntime) bool {
     if (comptime builtin.os.tag == .freestanding) return false;
     const io_impl = runtime.io_impl orelse return runtime.shutdown;
@@ -2326,6 +2344,7 @@ fn flushPlainDenseItems(
         max_source_bytes = @max(max_source_bytes, item.source_text.len);
     }
 
+    yieldToPublicQueries(runtime);
     noteEmbedBatchStarted(runtime, items.len, total_source_bytes, max_source_bytes);
     const embed_started_ns = runtime.config.clock.nowRealtimeNs();
     const vectors = embedDenseBatchWithRetry(dense_embedder, runtime, embedding_artifact_name, texts, expected_dims) catch |err| {

--- a/zig/pkg/antfly/src/storage/db/enrichment/enrichment_types.zig
+++ b/zig/pkg/antfly/src/storage/db/enrichment/enrichment_types.zig
@@ -15,6 +15,13 @@
 const std = @import("std");
 const Allocator = std.mem.Allocator;
 
+/// Process-wide count of public table queries currently executing. The HTTP
+/// layer increments it around query execution; the enrichment embed loop
+/// briefly defers the next embed batch while it is non-zero so interactive
+/// queries get the embedder first. Lives here so the embed loop has no
+/// dependency on HTTP wiring.
+pub var public_query_inflight: std.atomic.Value(u32) = std.atomic.Value(u32).init(0);
+
 pub const GeneratedEnrichmentKind = enum {
     dense_embedding,
     sparse_embedding,

--- a/zig/pkg/antfly/src/storage/db/enrichment/enrichment_types.zig
+++ b/zig/pkg/antfly/src/storage/db/enrichment/enrichment_types.zig
@@ -15,12 +15,14 @@
 const std = @import("std");
 const Allocator = std.mem.Allocator;
 
-/// Process-wide count of public table queries currently executing. The HTTP
-/// layer increments it around query execution; the enrichment embed loop
-/// briefly defers the next embed batch while it is non-zero so interactive
-/// queries get the embedder first. Lives here so the embed loop has no
-/// dependency on HTTP wiring.
-pub var public_query_inflight: std.atomic.Value(u32) = std.atomic.Value(u32).init(0);
+/// Process-wide count of query-time embeds currently executing (a public
+/// query whose text is being embedded into a vector right now). The query
+/// layers increment it around the embed call itself — not the whole query —
+/// so BM25-only traffic never sets it. The enrichment embed loop briefly
+/// defers the next embed batch while it is non-zero so interactive embeds
+/// get the embedder first. Lives here so the embed loop has no dependency
+/// on HTTP wiring.
+pub var interactive_embed_inflight: std.atomic.Value(u32) = std.atomic.Value(u32).init(0);
 
 pub const GeneratedEnrichmentKind = enum {
     dense_embedding,

--- a/zig/pkg/antfly/src/storage/db/query/search_exec.zig
+++ b/zig/pkg/antfly/src/storage/db/query/search_exec.zig
@@ -3791,7 +3791,7 @@ fn textDocNumsForDocIdsAlloc(
     for (snapshot.segments) |*seg| {
         for (0..seg.reader.doc_count) |local_doc_usize| {
             const local_doc: u32 = @intCast(local_doc_usize);
-            if (seg.deleted) |deleted| {
+            if (seg.shared.deleted) |deleted| {
                 if (deleted.contains(local_doc)) continue;
             }
             const stored = seg.reader.storedDoc(local_doc) orelse continue;
@@ -3950,7 +3950,7 @@ fn collectFilteredExplicitTextStats(
     for (snapshot.segments) |*seg| {
         for (0..seg.reader.doc_count) |local_doc_usize| {
             const local_doc: u32 = @intCast(local_doc_usize);
-            if (seg.deleted) |deleted| {
+            if (seg.shared.deleted) |deleted| {
                 if (deleted.contains(local_doc)) continue;
             }
             const doc_id = doc_offset + local_doc;

--- a/zig/pkg/antfly/src/storage/db/types.zig
+++ b/zig/pkg/antfly/src/storage/db/types.zig
@@ -1422,6 +1422,9 @@ pub const AlgebraicProgressStatus = struct {
 pub const DBIndexStats = struct {
     name: []const u8,
     kind: IndexKind,
+    // Error name recorded when the index's persisted artifacts failed to
+    // load (e.g. "UnsupportedVersion"); null for healthy indexes.
+    load_error: ?[]const u8 = null,
     doc_count: u64 = 0,
     term_count: u64 = 0,
     edge_count: u64 = 0,
@@ -1905,6 +1908,7 @@ pub fn accumulateAsyncIndexingStats(dst: *AsyncIndexingStats, src: AsyncIndexing
 pub fn freeDBStats(alloc: Allocator, stats: DBStats) void {
     for (stats.indexes) |item| {
         alloc.free(item.name);
+        if (item.load_error) |value| alloc.free(value);
         if (item.algebraic_last_error_doc_key) |value| alloc.free(value);
         if (item.algebraic_last_error_reason) |value| alloc.free(value);
         if (item.algebraic_capability_fingerprint) |value| alloc.free(value);

--- a/zig/pkg/antfly/src/storage/hbc_adapter.zig
+++ b/zig/pkg/antfly/src/storage/hbc_adapter.zig
@@ -5993,6 +5993,82 @@ test "hbc repairTreeLinks clears dangling references and restores consistency" {
     }
 }
 
+test "hbc duplicate child links are dropped by unlink and repair" {
+    const alloc = std.testing.allocator;
+    var tp: TestPath = .{};
+    const path = tp.init();
+    defer tp.cleanup();
+
+    var idx = try HBCIndex.open(alloc, path, .{
+        .dims = 4,
+        .leaf_size = 4,
+        .branching_factor = 4,
+    });
+    defer idx.close();
+
+    var prng = std.Random.DefaultPrng.init(0xd00b_1e5);
+    const random = prng.random();
+    var id: u64 = 1;
+    while (id <= 40) : (id += 1) {
+        var v: [4]f32 = undefined;
+        for (&v) |*x| x.* = random.float(f32) * 2.0 - 1.0;
+        try idx.insert(id, &v);
+    }
+
+    const victim_leaf = (try idx.debugLeafForVector(3)) orelse return error.TestUnexpectedResult;
+    const victim_members = try idx.debugLeafMembers(alloc, victim_leaf);
+    defer alloc.free(victim_members);
+    try std.testing.expect(victim_members.len > 0);
+
+    const corrupt = struct {
+        fn duplicateChildLink(index: *HBCIndex, leaf_id: u64) !void {
+            var txn = try index.beginWriteTxn();
+            errdefer txn.abort();
+            var leaf = try index.loadNode(&txn, leaf_id);
+            defer leaf.deinit(index.alloc);
+            const parent_id = leaf.parent;
+            try std.testing.expect(parent_id != 0);
+            var parent = try index.loadNode(&txn, parent_id);
+            defer parent.deinit(index.alloc);
+            try parent.ensureUnbacked(index.alloc);
+            const dup = try index.alloc.alloc(u64, parent.children.len + 1);
+            @memcpy(dup[0..parent.children.len], parent.children);
+            dup[parent.children.len] = leaf_id;
+            index.alloc.free(parent.children);
+            parent.children = dup;
+            try index.saveNode(&txn, &parent);
+            try txn.commit();
+        }
+    }.duplicateChildLink;
+
+    // Repair path: the sweep must drop the duplicate occurrence.
+    try corrupt(&idx, victim_leaf);
+    {
+        const broken = try idx.verifyTreeLinks();
+        try std.testing.expect(!broken.consistent());
+    }
+    const repair = try idx.repairTreeLinks(10_000);
+    try std.testing.expect(repair.completed);
+    try std.testing.expect(repair.duplicate_children_removed >= 1);
+    {
+        const healed = try idx.verifyTreeLinks();
+        try std.testing.expect(healed.consistent());
+    }
+
+    // Unlink path: emptying the leaf drives removeChildLink against the
+    // duplicated reference, which must drop BOTH occurrences — an
+    // underfilled rebuild here used to persist an uninitialized child id.
+    try corrupt(&idx, victim_leaf);
+    try idx.batchDelete(victim_members);
+    {
+        const after_delete = try idx.verifyTreeLinks();
+        if (!after_delete.consistent()) {
+            std.debug.print("tree links inconsistent after duplicate unlink: {any}\n", .{after_delete});
+            return error.TestUnexpectedResult;
+        }
+    }
+}
+
 test "default random ortho transform matches go hbc" {
     const alloc = std.testing.allocator;
     const input = [_]f32{ 1.0, 2.0, 3.0, 4.0 };

--- a/zig/pkg/antfly/src/storage/hbc_adapter.zig
+++ b/zig/pkg/antfly/src/storage/hbc_adapter.zig
@@ -1236,6 +1236,10 @@ pub const HBCIndex = struct {
     published_node_count: AtomicU64,
     published_generation: AtomicU64,
     rng: go_rand.GoPcg,
+    // Set when a write path observes a tree-link inconsistency (stale parent
+    // pointer, dangling node reference); background maintenance runs a
+    // bounded repairTreeLinks sweep and clears it on completion.
+    link_repair_pending: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
     quantizer: quantizer_mod.RaBitQuantizer,
     rot: vec.RandomOrthogonalTransformer,
     node_cache: std.AutoHashMapUnmanaged(u64, *NodeCacheEntry),
@@ -5650,6 +5654,39 @@ pub const HBCIndex = struct {
     }
 
     // ========================================================================
+    // Tree link consistency
+    // ========================================================================
+
+    pub fn noteTreeLinkInconsistency(self: *HBCIndex) void {
+        self.link_repair_pending.store(true, .release);
+    }
+
+    pub fn treeLinkRepairPending(self: *const HBCIndex) bool {
+        return self.link_repair_pending.load(.acquire);
+    }
+
+    /// Read-only structural invariant check (see hbc_index.verifyTreeLinks).
+    pub fn verifyTreeLinks(self: *HBCIndex) !vectorindex_hbc_index.TreeLinkReport {
+        var txn = try self.beginReadTxn();
+        defer txn.abort();
+        return try vectorindex_hbc_index.verifyTreeLinks(self, &txn);
+    }
+
+    /// Bounded repair sweep (see hbc_index.repairTreeLinks). Clears the
+    /// pending flag once a sweep completes within budget.
+    pub fn repairTreeLinks(self: *HBCIndex, max_nodes: usize) !vectorindex_hbc_index.TreeLinkRepairReport {
+        const report = try vectorindex_hbc_index.repairLinks(self, max_nodes);
+        if (report.completed) self.link_repair_pending.store(false, .release);
+        return report;
+    }
+
+    /// Runs a repair sweep only when a write path flagged an inconsistency.
+    pub fn maybeRepairTreeLinks(self: *HBCIndex, max_nodes: usize) !?vectorindex_hbc_index.TreeLinkRepairReport {
+        if (!self.treeLinkRepairPending()) return null;
+        return try self.repairTreeLinks(max_nodes);
+    }
+
+    // ========================================================================
     // Stats
     // ========================================================================
 
@@ -5814,6 +5851,145 @@ test "create and open index" {
         var idx = try HBCIndex.open(alloc, path, .{ .dims = 4 });
         defer idx.close();
         try std.testing.expectEqual(@as(u32, 4), idx.stats().dims);
+    }
+}
+
+test "hbc randomized insert delete churn preserves tree link invariants" {
+    const alloc = std.testing.allocator;
+    var tp: TestPath = .{};
+    const path = tp.init();
+    defer tp.cleanup();
+
+    // Small fanout forces frequent splits, sibling merges, and single-child
+    // collapses — the maintenance operations that rewrite parent/child links.
+    var idx = try HBCIndex.open(alloc, path, .{
+        .dims = 4,
+        .leaf_size = 4,
+        .branching_factor = 4,
+    });
+    defer idx.close();
+
+    var prng = std.Random.DefaultPrng.init(0x5eed_11ab);
+    const random = prng.random();
+
+    var live = std.ArrayListUnmanaged(u64).empty;
+    defer live.deinit(alloc);
+    var next_id: u64 = 1;
+
+    var op: usize = 0;
+    while (op < 1200) : (op += 1) {
+        const do_insert = live.items.len < 8 or random.intRangeLessThan(u8, 0, 100) < 60;
+        if (do_insert) {
+            var v: [4]f32 = undefined;
+            for (&v) |*x| x.* = random.float(f32) * 2.0 - 1.0;
+            try idx.insert(next_id, &v);
+            try live.append(alloc, next_id);
+            next_id += 1;
+        } else if (random.boolean() or live.items.len < 4) {
+            const pick = random.intRangeLessThan(usize, 0, live.items.len);
+            const vid = live.swapRemove(pick);
+            try idx.delete(vid);
+        } else {
+            var batch: [6]u64 = undefined;
+            const want = @min(live.items.len, random.intRangeLessThan(usize, 2, 7));
+            var i: usize = 0;
+            while (i < want) : (i += 1) {
+                const pick = random.intRangeLessThan(usize, 0, live.items.len);
+                batch[i] = live.swapRemove(pick);
+            }
+            try idx.batchDelete(batch[0..want]);
+        }
+
+        if (op % 50 == 49) {
+            const report = try idx.verifyTreeLinks();
+            if (!report.consistent()) {
+                std.debug.print("tree links inconsistent after op {d}: {any}\n", .{ op, report });
+                return error.TestUnexpectedResult;
+            }
+            try std.testing.expect(!idx.treeLinkRepairPending());
+        }
+    }
+
+    const final_report = try idx.verifyTreeLinks();
+    if (!final_report.consistent()) {
+        std.debug.print("tree links inconsistent at end: {any}\n", .{final_report});
+        return error.TestUnexpectedResult;
+    }
+    try std.testing.expectEqual(@as(u64, @intCast(live.items.len)), idx.stats().active_count);
+}
+
+test "hbc repairTreeLinks clears dangling references and restores consistency" {
+    const alloc = std.testing.allocator;
+    var tp: TestPath = .{};
+    const path = tp.init();
+    defer tp.cleanup();
+
+    var idx = try HBCIndex.open(alloc, path, .{
+        .dims = 4,
+        .leaf_size = 4,
+        .branching_factor = 4,
+    });
+    defer idx.close();
+
+    var prng = std.Random.DefaultPrng.init(0xfee1_600d);
+    const random = prng.random();
+    var id: u64 = 1;
+    while (id <= 60) : (id += 1) {
+        var v: [4]f32 = undefined;
+        for (&v) |*x| x.* = random.float(f32) * 2.0 - 1.0;
+        try idx.insert(id, &v);
+    }
+
+    // Corrupt the tree the way the field incident did: a leaf node vanishes
+    // while its parent still lists it and vec→leaf entries still point at it.
+    const victim_leaf = (try idx.debugLeafForVector(7)) orelse return error.TestUnexpectedResult;
+    const victim_members = try idx.debugLeafMembers(alloc, victim_leaf);
+    defer alloc.free(victim_members);
+    try std.testing.expect(victim_members.len > 0);
+    {
+        var txn = try idx.beginWriteTxn();
+        errdefer txn.abort();
+        try idx.deleteNode(&txn, victim_leaf);
+        try txn.commit();
+    }
+
+    const broken = try idx.verifyTreeLinks();
+    try std.testing.expect(!broken.consistent());
+    try std.testing.expect(broken.dangling_children >= 1);
+
+    // Search still serves while the tree is inconsistent (tolerant descent).
+    {
+        const query = [_]f32{ 0.1, 0.2, 0.3, 0.4 };
+        var results = try idx.search(&query, 5);
+        defer results.deinit();
+        try std.testing.expect(results.getHits().len > 0);
+    }
+
+    // Deleting a vector whose leaf is gone cleans up instead of erroring,
+    // and flags the index for repair.
+    try idx.delete(victim_members[0]);
+    try std.testing.expect(idx.treeLinkRepairPending());
+
+    const repair = try idx.repairTreeLinks(10_000);
+    try std.testing.expect(repair.completed);
+    try std.testing.expect(repair.dangling_children_removed >= 1);
+    try std.testing.expect(!idx.treeLinkRepairPending());
+
+    const healed = try idx.verifyTreeLinks();
+    if (!healed.consistent()) {
+        std.debug.print("tree links inconsistent after repair: {any}\n", .{healed});
+        return error.TestUnexpectedResult;
+    }
+
+    // The index stays fully usable after repair.
+    const probe = [_]f32{ 0.5, -0.25, 0.75, -0.5 };
+    try idx.insert(1000, &probe);
+    {
+        var results = try idx.search(&probe, 3);
+        defer results.deinit();
+        const hits = results.getHits();
+        try std.testing.expect(hits.len > 0);
+        try std.testing.expectEqual(@as(u64, 1000), hits[0].vector_id);
     }
 }
 

--- a/zig/pkg/antfly/src/storage/persistent.zig
+++ b/zig/pkg/antfly/src/storage/persistent.zig
@@ -1723,7 +1723,7 @@ pub const PersistentIndex = struct {
             const seg = &snap.segments[seg_idx];
             inputs[i] = .{
                 .reader = &seg.reader,
-                .deleted = seg.deleted,
+                .deleted = seg.shared.deleted,
             };
         }
 


### PR DESCRIPTION
Supersedes the `fix/index-quarantine-and-read-cache` compare link: this includes those six fixes plus two follow-up commits from the review discussion.

## Base fixes (commits 1–6, from `fix/index-quarantine-and-read-cache`)

- **Index quarantine**: an index whose persisted artifacts fail to open (e.g. `UnsupportedVersion`) no longer fails the whole table open — its config moves to the status-only list, the load error is recorded and reported via status, and queries naming it get `error.IndexUnavailable` so clients can distinguish broken from missing.
- **Read-cache invalidation scoping**: per-table epochs replace the single global epoch that livelocked queries under continuous background writes; churned opens fail transiently after bounded retries instead of livelocking or caching stale-epoch DBs.
- **Snapshot lifetime fixes**: the `acquireSnapshot` load+retain TOCTOU race against publish, and holders of older snapshot generations losing retired segments (field segfault in `layoutStats` during merge storms).
- **HBC delete panic**: stale parent links no longer overrun the rebuilt children array (`removeChildLink`).
- **ONNX Slice**: negative-axes normalization with bounds validation.

## Follow-up commit 7: read-path scalability and quarantine recovery

**Exact per-table read-cache epochs** (`table_reads.zig`): replaces the 64 hash buckets with epoch slots keyed by exact table name — no collision false-positives at any table count. Slots are created (fallibly) by `getOrOpen` before an open starts; `invalidateTable` only bumps an existing slot, so invalidation stays infallible (a missing slot provably means no open is in flight). The identity namespace is reloaded on each stale-epoch retry, closing a latent bug where a drop+recreate mid-open could cache the wrong identity. Churned opens now fail with a named `error.TableReadChurn` (classified transient by the query retry layer) instead of overloading `EndOfStream`.

**Scoped enrichment yield**: `public_query_inflight` → `interactive_embed_inflight`, incremented around the query-time embed calls themselves (`planSemanticQuery` + serverless `resolveSemanticQueryRequest`) instead of the whole search execution. BM25-only traffic no longer stalls embed batches; the inflight window shrinks from the full query to the embed call (ms-scale), so the 25ms poll clears almost immediately and the 5s cap becomes a rarely-hit safety bound. This recovers backfill throughput while keeping the interactive protection for the shared on-device ONNX runtime.

**Quarantine self-healing**: quarantined index loads now retry in-process with exponential backoff (30s..10min) via `IndexManager.retryFailedIndexLoads` — the same detached-open path as the initial load, committed atomically with de-quarantine under the catalog lock. A background worker spawns at `DB.open` only when the load left failures behind and exits once everything recovers (disabled under `builtin.is_test`; tests drive retries deterministically). A recovered index resumes its persisted rebuild state, including writes that arrived while quarantined.

**Per-segment refcounts** (`index.zig`): replaces the snapshot successor chain with per-segment refcounted shared cells (ref count, deletion bitmap, retired cleanup). A held snapshot pins exactly the segments it references instead of every later generation and its retired lists — bounding memory under merge storms — and a leaked snapshot leaks one generation, not all future ones. Moving the deletion bitmap into the shared cell also fixes stale by-value entry copies aliasing bitmap memory freed by `setDeletionBitmap`. Behavioral note for review: readers of older snapshots now observe deletions made after their snapshot was taken (deleted docs drop out early).

## Follow-up commit 8: HBC tree-link verification, repair, and tolerant deletes

Completes the durable fix behind the HBC delete panic (the panic itself is fixed in the base commits):

- **`verifyTreeLinks`**: read-only invariant checker — dangling child references, parent-pointer mismatches, duplicate links, empty internal nodes, vec→leaf mismatches.
- **`repairTreeLinks`**: budgeted, resumable repair sweep treating reachable children lists as authoritative. Wired into the dense posting maintenance lane behind a `link_repair_pending` flag that write paths set when they observe an inconsistency — healthy indexes pay nothing; corrupted ones heal in the background instead of degrading until restart.
- **Tolerant delete paths**: `deleteTxn`/`batchDeleteTxn`/`removeFromLeaf` degrade cleanly on corrupted state (scan fallback / key cleanup / skip parent surgery) and flag the repair sweep. Search descent was already tolerant.
- **Tests**: a 1200-op randomized insert/delete/batchDelete churn at fanout 4 verifying invariants every 50 ops — current maintenance code passes cleanly, supporting the theory that field corruption predates current logic; and an end-to-end corruption test (leaf deleted out from under its parent) proving search keeps serving, deletes degrade, and repair restores full consistency.

## Validation

- 15/15 targeted suite (all six base-branch tests + new self-heal, pinning, churn, and repair tests)
- 254/258 full HBC + dense suite (4 platform skips, 0 failures)
- 382-test merge/segment/snapshot/full-text sweep at exact failure-set parity with the base branch (15 pre-existing environmental failures, identical leak count)