### PR TITLE
Fix e2e flakes: LSM reclaim read race and startup catch-up livelock

### DIFF
--- a/zig/pkg/antfly/src/api/http_server.zig
+++ b/zig/pkg/antfly/src/api/http_server.zig
@@ -5046,7 +5046,10 @@ pub const ApiHttpServer = struct {
         var attempts: u32 = 0;
         while (true) : (attempts += 1) {
             return source.query(alloc, table_name, req, consistency) catch |err| switch (err) {
-                error.EndOfStream => {
+                // FileNotFound surfaces when a read-only replica open races
+                // with the writer reclaiming obsolete LSM runs; reopening
+                // picks up a fresh manifest.
+                error.EndOfStream, error.FileNotFound => {
                     std.log.warn("public table query read failed table={s} err={} attempt={d}", .{ table_name, err, attempts + 1 });
                     if (platform_time.monotonicNs() -| start_ns >= retry_timeout_ns) return err;
                     sleepNs(retry_poll_ns);

--- a/zig/pkg/antfly/src/data/runtime.zig
+++ b/zig/pkg/antfly/src/data/runtime.zig
@@ -4588,6 +4588,7 @@ pub const DataServer = struct {
                     stats.groups_cleared += 1;
                 } else {
                     stats.debt_remaining = true;
+                    std.log.warn("provisioned startup catch-up debt persists group={} table={s}", .{ group_id, table.name });
                 }
             }
         }

--- a/zig/pkg/antfly/src/storage/db/catalog/index_manager.zig
+++ b/zig/pkg/antfly/src/storage/db/catalog/index_manager.zig
@@ -5401,13 +5401,42 @@ pub const IndexManager = struct {
     fn saveBackfilledAppliedSequence(self: *IndexManager, store: anytype, cfg: types.IndexConfig) !void {
         if (try self.configRequiresEnrichmentReplay(cfg)) return;
         if (try self.configHasPendingSparseEmbeddingArtifactReplay(store, cfg)) return;
+        // Backfill rebuilds the index from the full store contents, so it is
+        // current through the store's durable per-kind latest replay marker
+        // even when the replay records themselves have already been pruned.
+        // On a fresh instance with pruned records lastReplaySequence(0) is 0;
+        // saving that alone regresses the checkpoint below the marker and
+        // traps startup catch-up in a permanent-debt loop that re-backfills
+        // and re-regresses forever.
+        var backfilled_sequence = store.lastReplaySequence(0);
+        if (comptime storeSupportsLatestReplaySequenceForHint(@TypeOf(store))) {
+            backfilled_sequence = try store.latestReplaySequenceForHint(replayHintForIndexKind(cfg.kind), backfilled_sequence);
+        }
         try apply_state.saveAppliedSequenceWithCheckpoint(
             self.alloc,
             store,
             self.applied_sequence_checkpoint_path,
             cfg.name,
-            store.lastReplaySequence(0),
+            backfilled_sequence,
         );
+    }
+
+    fn storeSupportsLatestReplaySequenceForHint(comptime T: type) bool {
+        return switch (@typeInfo(T)) {
+            .pointer => |ptr| @hasDecl(ptr.child, "latestReplaySequenceForHint"),
+            .@"struct" => @hasDecl(T, "latestReplaySequenceForHint"),
+            else => false,
+        };
+    }
+
+    fn replayHintForIndexKind(kind: types.IndexKind) change_journal_mod.TargetHint {
+        return switch (kind) {
+            .full_text => .full_text,
+            .dense_vector => .dense_vector,
+            .sparse_vector => .sparse_vector,
+            .graph => .graph,
+            .algebraic => .algebraic,
+        };
     }
 
     fn configHasPendingSparseEmbeddingArtifactReplay(self: *IndexManager, store: anytype, cfg: types.IndexConfig) !bool {

--- a/zig/pkg/antfly/src/storage/lsm_backend/repository.zig
+++ b/zig/pkg/antfly/src/storage/lsm_backend/repository.zig
@@ -556,21 +556,18 @@ pub fn loadRunTableIndexAllocWithStorage(
     allocator: Allocator,
     path: []const u8,
 ) !lsm_table_file.TableIndex {
-    const footer_bytes = storage.readFileTrailerAlloc(allocator, path, lsm_table_file.footer_len) catch |err| switch (err) {
-        error.EndOfStream, error.FileNotFound => blk: {
-            break :blk null;
-        },
-        else => return err,
-    };
-    defer if (footer_bytes) |bytes| allocator.free(bytes);
+    // A missing or truncated run file usually means a concurrent writer
+    // obsoleted and reclaimed it after this reader loaded the manifest;
+    // propagate the transient error so callers can retry against a fresh
+    // manifest instead of misreporting a format mismatch.
+    const footer_bytes = try storage.readFileTrailerAlloc(allocator, path, lsm_table_file.footer_len);
+    defer allocator.free(footer_bytes);
 
-    if (footer_bytes) |bytes| {
-        if (lsm_table_file.hasFooterMagic(bytes)) {
-            const footer = try lsm_table_file.decodeFooterBytes(bytes);
-            const metadata_bytes = try storage.readFileRangeAlloc(allocator, path, footer.metadata_offset, footer.metadata_len);
-            defer allocator.free(metadata_bytes);
-            return try lsm_table_file.decodeIndexFromFooterAlloc(allocator, footer, metadata_bytes);
-        }
+    if (lsm_table_file.hasFooterMagic(footer_bytes)) {
+        const footer = try lsm_table_file.decodeFooterBytes(footer_bytes);
+        const metadata_bytes = try storage.readFileRangeAlloc(allocator, path, footer.metadata_offset, footer.metadata_len);
+        defer allocator.free(metadata_bytes);
+        return try lsm_table_file.decodeIndexFromFooterAlloc(allocator, footer, metadata_bytes);
     }
     return error.UnsupportedVersion;
 }
@@ -1023,6 +1020,20 @@ test "repository manifest persist omits run bloom filters" {
     const raw = try storage.storage().readFileAlloc(allocator, manifest_path, 1024);
     defer allocator.free(raw);
     try std.testing.expect(raw.len < 512);
+}
+
+test "repository run table index load surfaces missing run file" {
+    const allocator = std.testing.allocator;
+    var storage = storage_io.MemoryStorage.init(allocator);
+    defer storage.deinit();
+
+    const missing_path = try runPath(allocator, "/repository-missing-run", 7);
+    defer allocator.free(missing_path);
+
+    try std.testing.expectError(
+        error.FileNotFound,
+        loadRunTableIndexAllocWithStorage(storage.storage(), allocator, missing_path),
+    );
 }
 
 test "repository streams state run publication through table builder accounting" {


### PR DESCRIPTION
Fixes the two dominant `e2e-base` flakes on main (seen on PR #219's run and on main runs since June 8).

## 1. Vanished LSM runs misreported as `UnsupportedVersion` (`8f901aa3f`)

`test_stateful_managed_embeddings_delete_recreate_recovers_after_rate_limited_enrichment` failed with a 500 whose server logs showed `load configured index failed name=semantic_idx kind=dense_vector err=UnsupportedVersion`.

A read-only replica open loads the manifest, then lazily reads the referenced run files. If the writer compacts and the idle obsolete reclaim (default retention 250ms, `active_readers` only tracks the writer's own Backend instance) deletes those runs in between, `loadRunTableIndexAllocWithStorage` masked the resulting `FileNotFound` as `error.UnsupportedVersion`, so the open failed fatally and `queryWithTransientReadRetry` (which only retried `EndOfStream`) surfaced a 500. CI's Debug build plus `ANTFLY_LSM_OPEN_DEBUG=1`/`ANTFLY_FS_PATH_DEBUG=1` logging easily stretches the open window past 250ms.

- Propagate `FileNotFound`/`EndOfStream` from the run footer read; `UnsupportedVersion` now only means a real format mismatch (no footer magic).
- Treat `FileNotFound` as transient in `queryWithTransientReadRetry`; the retry reopens against a fresh manifest.
- Regression test: missing run file surfaces `error.FileNotFound`.

## 2. Startup catch-up livelock regressing derived apply checkpoints (`35d6ac2e4`)

`test_multinode_autograph_resolves_promotes_and_hydrates_entities` failed three different ways on main since June 8 (promotion timeout, 30s batch-write hang, 30s create_table hang). Reproduced locally at ~1/15 with CI's debug env; mid-hang thread samples plus preserved node logs showed the group's catch-up worker re-opening `table-db` and re-backfilling full_text once per second, forever, with zero log output.

Root cause: after backfill, `saveBackfilledAppliedSequence` persisted `store.lastReplaySequence(0)`, which derives from replay *records* and is 0 on a fresh instance once records are pruned. The debt probe instead reads the durable per-kind `replayLatestSequenceKey` marker (still N). The save therefore regressed `derived_apply.checkpoint` below the marker every cycle (observed on disk: `full_text_index_v0 @ 0`, rewritten each second), recreating debt that no replay could ever clear. The spinning worker held group-operation locks and starved writes, table creation, and the resolution/promotion pipeline.

- Save the per-kind latest marker (`latestReplaySequenceForHint`) after backfill — correct by construction since backfill rebuilds from the full store, and it self-heals groups already stuck with a regressed checkpoint.
- Warn when a catch-up round leaves debt uncleared so this state is never silent in CI again.

## Validation

- `lsm-backend-test`: 221/221 (includes new regression test)
- `index-manager-test` binary: 1195 passed / 0 failed (the build-step wrapper failure is a pre-existing flake — identical on pristine origin/main)
- Lifecycle e2e test: repeated green runs with the fixed binary; full `test_index_lifecycle.py`: 27/27
- Resolution e2e test under repro conditions (`ANTFLY_LSM_OPEN_DEBUG=1 ANTFLY_FS_PATH_DEBUG=1`): 60/60 green with the fix vs failures at iteration 2 and 14 of the first two 30-iteration hunts without it