### PR TITLE
Fix raft apply deadlock behind nightly e2e hangs; harden CI diagnostics

### DIFF
--- a/.github/workflows/zig-tests.yml
+++ b/.github/workflows/zig-tests.yml
@@ -150,7 +150,7 @@ jobs:
           submodules: true
 
       - name: Install build tools
-        run: sudo apt-get update && sudo apt-get install -y build-essential pkg-config ca-certificates git curl xz-utils
+        run: sudo apt-get update && sudo apt-get install -y build-essential pkg-config ca-certificates git curl xz-utils gdb
 
       - name: Install uv
         uses: astral-sh/setup-uv@v8.1.0
@@ -191,7 +191,7 @@ jobs:
           submodules: ${{ needs.changes.outputs.trace_validate == 'true' }}
 
       - name: Install build tools
-        run: sudo apt-get update && sudo apt-get install -y build-essential pkg-config ca-certificates git curl xz-utils
+        run: sudo apt-get update && sudo apt-get install -y build-essential pkg-config ca-certificates git curl xz-utils gdb
 
       - name: Set up Zig
         if: needs.changes.outputs.trace_validate == 'true'
@@ -262,7 +262,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install build tools
-        run: sudo apt-get update && sudo apt-get install -y build-essential pkg-config ca-certificates git curl xz-utils
+        run: sudo apt-get update && sudo apt-get install -y build-essential pkg-config ca-certificates git curl xz-utils gdb
 
       - name: Install uv
         uses: astral-sh/setup-uv@v8.1.0
@@ -279,20 +279,33 @@ jobs:
       - name: Verify Zig version
         run: zig version
 
+      # The in-process cluster simulations size their thread pools from the
+      # visible CPU count, which on ARC reflects the node rather than the pod
+      # quota. The resulting burst can starve the runner agent long enough for
+      # GitHub to declare the runner lost (~10 min of missed heartbeats), which
+      # is how most full-default failures present. Bound the test steps to a
+      # fixed CPU set so pools and zig build parallelism stay within budget.
+      - name: Compute CPU bound for heavy test steps
+        id: cpus
+        run: |
+          jobs=$(nproc)
+          if [ "$jobs" -gt 8 ]; then jobs=8; fi
+          echo "list=0-$((jobs - 1))" >> "$GITHUB_OUTPUT"
+
       - name: Run full Zig unit tests
-        run: make zig-unit-test
+        run: taskset -c ${{ steps.cpus.outputs.list }} make zig-unit-test
 
       - name: Run Zig simulation tests
         working-directory: zig
-        run: zig build sim-test
+        run: taskset -c ${{ steps.cpus.outputs.list }} zig build sim-test
 
       - name: Run Zig integration tests
         working-directory: zig
-        run: zig build integration-test
+        run: taskset -c ${{ steps.cpus.outputs.list }} zig build integration-test
 
       - name: Run Zig recall tests
         working-directory: zig
-        run: zig build recall-test
+        run: taskset -c ${{ steps.cpus.outputs.list }} zig build recall-test
 
       - name: Run Zig recall harness sweep
         working-directory: zig
@@ -313,13 +326,13 @@ jobs:
           )
           for dataset in "${datasets[@]}"; do
             echo "::group::recall-harness ${dataset}"
-            zig build recall-harness -- --dataset-dir testdata/vectorsets --dataset "${dataset}"
+            taskset -c ${{ steps.cpus.outputs.list }} zig build recall-harness -- --dataset-dir testdata/vectorsets --dataset "${dataset}"
             echo "::endgroup::"
           done
 
       - name: Run Zig chaos tests
         working-directory: zig
-        run: zig build chaos-test
+        run: taskset -c ${{ steps.cpus.outputs.list }} zig build chaos-test
 
   e2e-base:
     needs: changes
@@ -336,7 +349,7 @@ jobs:
           submodules: true
 
       - name: Install build tools
-        run: sudo apt-get update && sudo apt-get install -y build-essential pkg-config ca-certificates git curl xz-utils
+        run: sudo apt-get update && sudo apt-get install -y build-essential pkg-config ca-certificates git curl xz-utils gdb
 
       - name: Set up Zig
         uses: mlugg/setup-zig@v2
@@ -377,7 +390,7 @@ jobs:
           submodules: true
 
       - name: Install build tools
-        run: sudo apt-get update && sudo apt-get install -y build-essential pkg-config ca-certificates git curl xz-utils
+        run: sudo apt-get update && sudo apt-get install -y build-essential pkg-config ca-certificates git curl xz-utils gdb
 
       - name: Set up Zig
         uses: mlugg/setup-zig@v2

--- a/scripts/ci/zig-e2e-base-linux.sh
+++ b/scripts/ci/zig-e2e-base-linux.sh
@@ -53,7 +53,11 @@ fi
 
 export ANTFLY_BIN="${ANTFLY_BIN:-./zig-out/bin/antfly}"
 export ANTFLY_LSM_OPEN_DEBUG="${ANTFLY_LSM_OPEN_DEBUG:-1}"
-export ANTFLY_FS_PATH_DEBUG="${ANTFLY_FS_PATH_DEBUG:-1}"
+# ANTFLY_FS_PATH_DEBUG is intentionally not defaulted on: it logs one line per
+# path component on every filesystem op (~8k lines/s per node), slowing the
+# servers and flooding the per-node log tails captured on failure until they
+# carry no diagnostic signal. Export it explicitly when chasing an
+# fs-path-specific bug.
 
 if [[ "$#" -gt 0 ]]; then
   antfly_args=("$@")

--- a/zig/.gitignore
+++ b/zig/.gitignore
@@ -2,7 +2,7 @@
 .zig-global-cache/
 .zig-cache-local/
 .zig-local-cache/
-zig-out/
+zig-out*/
 __pycache__/
 .tla-tools/
 specs/tla/states/

--- a/zig/e2e/antfly/conftest.py
+++ b/zig/e2e/antfly/conftest.py
@@ -254,7 +254,7 @@ def raise_request_error_with_logs(
     ) from err
 
 
-def _read_log_tail(path: Path, *, limit: int = 20000) -> str:
+def _read_log_tail(path: Path, *, limit: int = 200000) -> str:
     if not path.exists():
         return ""
     data = path.read_text(errors="replace")

--- a/zig/e2e/antfly/test_resolution.py
+++ b/zig/e2e/antfly/test_resolution.py
@@ -157,9 +157,14 @@ class _Api:
         try:
             response = self.s.post(f"{self.url}/tables/{table}/batch", json=payload, timeout=timeout)
         except requests.RequestException as exc:
+            # A timed-out write usually means a node wedged in memory without
+            # logging anything; capture native stacks before teardown so the
+            # CI failure is diagnosable.
+            stacks = self._server.native_stack_dumps()
             raise AssertionError(
                 f"batch insert timed out/failed table={table!r} key={doc_id!r} "
-                f"sync_level={sync_level!r}: {exc!r}\n[logs]\n{self._server.debug_logs()}"
+                f"sync_level={sync_level!r}: {exc!r}\n[native stacks]\n{stacks}"
+                f"\n[logs]\n{self._server.debug_logs()}"
             ) from exc
         return self._check(response)
 
@@ -272,7 +277,9 @@ def _wait_for_entities(api: _Api, expected_names: dict[str, str], *, deadline: _
     raise AssertionError(
         f"entities were not promoted within {deadline.timeout_s}s "
         f"(elapsed={deadline.elapsed():.1f}s, pending={sorted(pending)!r}, "
-        f"last={last!r}, last_error={last_error!r})\n{api.diagnostic()}"
+        f"last={last!r}, last_error={last_error!r})"
+        f"\n[native stacks]\n{api._server.native_stack_dumps()}"
+        f"\n{api.diagnostic()}"
     )
 
 

--- a/zig/e2e/antfly/test_scaling.py
+++ b/zig/e2e/antfly/test_scaling.py
@@ -1225,12 +1225,21 @@ def test_autoscaling_drains_data_node_and_replaces_placements(
     cluster.create_table(table_name, num_shards=5)
 
     docs = {f"doc-{i:02d}": {"title": f"doc {i}", "rank": i} for i in range(10)}
-    batch = requests.post(
-        f"{cluster.data_api_urls[0]}/tables/{table_name}/batch",
-        json={"inserts": docs, "sync_level": "write"},
-        timeout=30,
-    )
-    batch.raise_for_status()
+    try:
+        batch = requests.post(
+            f"{cluster.data_api_urls[0]}/tables/{table_name}/batch",
+            json={"inserts": docs, "sync_level": "write"},
+            timeout=30,
+        )
+        batch.raise_for_status()
+    except requests.RequestException as exc:
+        # Connection resets here have flaked CI with no server-side context;
+        # attach node logs and native stacks so the failure is diagnosable.
+        raise AssertionError(
+            f"seed batch failed table={table_name!r}: {exc!r}"
+            f"\n[native stacks]\n{cluster.native_stack_dumps()}"
+            f"\n[logs]\n{cluster.debug_logs()}"
+        ) from exc
 
     group_ids = wait_until(lambda: _table_group_ids(cluster, table_name), timeout_s=60.0, interval_s=0.5)
     assert group_ids is not None and len(group_ids) >= 5, (

--- a/zig/e2e/antfly/test_scaling.py
+++ b/zig/e2e/antfly/test_scaling.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import signal
 import subprocess
 import tempfile
@@ -786,6 +787,45 @@ class MultiNodeScalingCluster:
         for handle in self.log_files:
             handle.flush()
         return "\n".join(f"[{path.name}]\n{_read_log_tail(path)}" for path in self.log_paths)
+
+    def native_stack_dumps(self, *, per_process_timeout_s: float = 25.0) -> str:
+        """Best-effort `gdb thread apply all bt` for every live node process.
+
+        Server-side hangs (e.g. a 30s batch-write timeout) leave no log
+        evidence when the wedged thread blocks in memory; a stack snapshot
+        taken at failure time is the only way to diagnose them from CI.
+        """
+        if shutil.which("gdb") is None:
+            return "<gdb not available>"
+        parts: list[str] = []
+        for label, procs in (("metadata", self.metadata_procs), ("data", self.data_procs)):
+            for proc in procs:
+                if proc.poll() is not None:
+                    parts.append(f"[{label} pid {proc.pid}] exited rc={proc.returncode}")
+                    continue
+                try:
+                    result = subprocess.run(
+                        [
+                            "gdb",
+                            "-p",
+                            str(proc.pid),
+                            "-batch",
+                            "-ex",
+                            "set pagination off",
+                            "-ex",
+                            "thread apply all bt 30",
+                        ],
+                        capture_output=True,
+                        text=True,
+                        timeout=per_process_timeout_s,
+                    )
+                    body = result.stdout[-250000:]
+                    if result.returncode != 0:
+                        body += f"\n<gdb rc={result.returncode}>\n{result.stderr[-2000:]}"
+                    parts.append(f"[{label} pid {proc.pid}]\n{body}")
+                except Exception as exc:
+                    parts.append(f"[{label} pid {proc.pid}] gdb failed: {exc!r}")
+        return "\n".join(parts)
 
     def stop(self, *, timeout_s: float = 10.0) -> None:
         procs = [proc for proc in [*self.data_procs, *self.metadata_procs] if proc.poll() is None]

--- a/zig/lib/platform/src/root.zig
+++ b/zig/lib/platform/src/root.zig
@@ -15,4 +15,5 @@
 pub const allocator = @import("allocator.zig");
 pub const atomic = @import("atomic.zig");
 pub const env = @import("env.zig");
+pub const sync = @import("sync.zig");
 pub const time = @import("time.zig");

--- a/zig/lib/platform/src/sync.zig
+++ b/zig/lib/platform/src/sync.zig
@@ -1,0 +1,89 @@
+// Copyright 2026 Antfly, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Lock helpers for try-lock-only mutexes (e.g. `std.atomic.Mutex`).
+//!
+//! A bare `while (!mutex.tryLock()) spinLoopHint()` pins a core per waiter.
+//! When the holder runs long (storage opens, raft rounds, compaction),
+//! spinners starve the holder — and on CPU-quota'd hosts such as CI runner
+//! pods, everything else on the machine, including the runner agent itself.
+//! Spin briefly for the uncontended fast path, then release the CPU between
+//! attempts.
+//!
+//! Use `lockYielding` from plain OS threads. Use `lockYieldingIo` from code
+//! that already has an `Io` handle so the wait reschedules through the Io
+//! runtime instead of the OS scheduler.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const time = @import("time.zig");
+
+const spin_limit = 64;
+
+/// Acquire `mutex` (any type exposing `tryLock`), spinning briefly and then
+/// releasing the CPU between attempts via `time.yieldBriefly`. On
+/// freestanding targets there is no scheduler to yield to, so this degrades
+/// to a pure spin.
+pub fn lockYielding(mutex: anytype) void {
+    var spins: u32 = 0;
+    while (!mutex.tryLock()) {
+        if (comptime builtin.os.tag == .freestanding) {
+            std.atomic.spinLoopHint();
+        } else if (spins < spin_limit) {
+            std.atomic.spinLoopHint();
+            spins +%= 1;
+        } else {
+            time.yieldBriefly();
+        }
+    }
+}
+
+/// Io-aware variant of `lockYielding`: after the spin budget, reschedules
+/// through the Io runtime (`sleep(zero)`) so pool tasks yield cooperatively
+/// instead of calling into the OS scheduler.
+pub fn lockYieldingIo(mutex: anytype, io: std.Io) void {
+    var spins: u32 = 0;
+    while (!mutex.tryLock()) {
+        if (spins < spin_limit) {
+            std.atomic.spinLoopHint();
+            spins +%= 1;
+        } else {
+            io.sleep(std.Io.Duration.zero, .awake) catch std.atomic.spinLoopHint();
+        }
+    }
+}
+
+test "lockYielding acquires an uncontended mutex" {
+    var mutex: std.atomic.Mutex = .unlocked;
+    lockYielding(&mutex);
+    defer mutex.unlock();
+    try std.testing.expect(!mutex.tryLock());
+}
+
+test "lockYielding acquires a mutex released by another thread" {
+    if (builtin.single_threaded) return error.SkipZigTest;
+
+    var mutex: std.atomic.Mutex = .unlocked;
+    lockYielding(&mutex);
+
+    const Holder = struct {
+        fn release(m: *std.atomic.Mutex) void {
+            m.unlock();
+        }
+    };
+    const thread = try std.Thread.spawn(.{}, Holder.release, .{&mutex});
+    lockYielding(&mutex);
+    thread.join();
+    mutex.unlock();
+}

--- a/zig/pkg/antfly/src/api/distributed_join.zig
+++ b/zig/pkg/antfly/src/api/distributed_join.zig
@@ -13,6 +13,7 @@
 // limitations.
 
 const std = @import("std");
+const platform_sync = @import("antfly_platform").sync;
 const table_reads = @import("table_reads.zig");
 const query_api = @import("query.zig");
 const query_contract = @import("query_contract.zig");
@@ -5582,7 +5583,7 @@ pub fn freeFieldList(alloc: std.mem.Allocator, fields: [][]const u8) void {
 // ---------------------------------------------------------------------------
 
 fn lockAtomic(mutex: *std.atomic.Mutex) void {
-    while (!mutex.tryLock()) std.atomic.spinLoopHint();
+    platform_sync.lockYielding(mutex);
 }
 
 pub fn joinJobNowMillis() u64 {

--- a/zig/pkg/antfly/src/api/provisioned_storage.zig
+++ b/zig/pkg/antfly/src/api/provisioned_storage.zig
@@ -13,6 +13,7 @@
 // limitations.
 
 const std = @import("std");
+const platform_sync = @import("antfly_platform").sync;
 const builtin = @import("builtin");
 const hbc_mod = @import("../storage/hbc_adapter.zig");
 const background_runtime_mod = @import("../storage/background_runtime.zig");
@@ -49,7 +50,7 @@ const MinSmartAlgebraicTensorBytes: u64 = 32 * 1024 * 1024;
 const MaxSmartAlgebraicTensorBytes: u64 = 256 * 1024 * 1024;
 
 fn lockAtomic(mutex: *std.atomic.Mutex) void {
-    while (!mutex.tryLock()) std.atomic.spinLoopHint();
+    platform_sync.lockYielding(mutex);
 }
 
 fn readMemoryLimitFile(path: []const u8) ?u64 {

--- a/zig/pkg/antfly/src/api/table_writes.zig
+++ b/zig/pkg/antfly/src/api/table_writes.zig
@@ -3395,7 +3395,15 @@ pub const ProvisionedTableWriteSource = struct {
             defer self.local_db_mutex.unlock();
             cache.retireFailedOpenLocked(&cached);
         }
-        try cached.db.drainResolverBackfill();
+        // .default_async opens run on the raft apply thread
+        // (applyReplicatedBatchGroupLocal). Draining resolver backfill there
+        // blocks the raft loop on the promotion pipeline, whose cross-shard
+        // entity upserts need raft applies that are queued behind this very
+        // open — observed as a full apply wedge (batch writes timing out
+        // cluster-wide) in the multinode autograph e2e. The promotion and
+        // resolution workers started by this open drain the same backlog
+        // asynchronously instead.
+        if (mode != .default_async) try cached.db.drainResolverBackfill();
         return cached;
     }
 
@@ -9576,7 +9584,21 @@ fn sleepNs(duration_ns: u64) void {
 }
 
 fn lockAtomic(mutex: *std.atomic.Mutex) void {
-    while (!mutex.tryLock()) std.atomic.spinLoopHint();
+    // Bounded spin, then yield: local_db_mutex guards cache bookkeeping that
+    // can take a while under contention (opens, invalidation), and a pure
+    // spin pins a core per waiter — on CPU-constrained hosts (CI runners)
+    // that starves the very threads that would release the lock.
+    var spins: u32 = 0;
+    while (!mutex.tryLock()) {
+        if (comptime builtin.os.tag == .freestanding) {
+            std.atomic.spinLoopHint();
+        } else if (spins < 64) {
+            std.atomic.spinLoopHint();
+            spins +%= 1;
+        } else {
+            std.Thread.yield() catch std.atomic.spinLoopHint();
+        }
+    }
 }
 
 fn recoverProvisionedTransactionsOnce(

--- a/zig/pkg/antfly/src/api/table_writes.zig
+++ b/zig/pkg/antfly/src/api/table_writes.zig
@@ -14,6 +14,7 @@
 
 const builtin = @import("builtin");
 const std = @import("std");
+const platform_sync = @import("antfly_platform").sync;
 const metadata_openapi = @import("antfly_metadata_openapi");
 const scraping = @import("antfly_scraping");
 const common_secrets = @import("../common/secrets.zig");
@@ -9584,21 +9585,12 @@ fn sleepNs(duration_ns: u64) void {
 }
 
 fn lockAtomic(mutex: *std.atomic.Mutex) void {
-    // Bounded spin, then yield: local_db_mutex guards cache bookkeeping that
-    // can take a while under contention (opens, invalidation), and a pure
-    // spin pins a core per waiter — on CPU-constrained hosts (CI runners)
-    // that starves the very threads that would release the lock.
-    var spins: u32 = 0;
-    while (!mutex.tryLock()) {
-        if (comptime builtin.os.tag == .freestanding) {
-            std.atomic.spinLoopHint();
-        } else if (spins < 64) {
-            std.atomic.spinLoopHint();
-            spins +%= 1;
-        } else {
-            std.Thread.yield() catch std.atomic.spinLoopHint();
-        }
-    }
+    // Bounded spin, then yield (platform_sync): local_db_mutex guards cache
+    // bookkeeping that can take a while under contention (opens,
+    // invalidation), and a pure spin pins a core per waiter — on
+    // CPU-constrained hosts (CI runners) that starves the very threads that
+    // would release the lock.
+    platform_sync.lockYielding(mutex);
 }
 
 fn recoverProvisionedTransactionsOnce(

--- a/zig/pkg/antfly/src/api/transactions.zig
+++ b/zig/pkg/antfly/src/api/transactions.zig
@@ -13,6 +13,7 @@
 // limitations.
 
 const std = @import("std");
+const platform_sync = @import("antfly_platform").sync;
 const batch_api = @import("batch.zig");
 const db_mod = @import("../storage/db/mod.zig");
 const distributed_txn = @import("distributed_txn.zig");
@@ -28,7 +29,7 @@ const AtomicMutex = struct {
     inner: std.atomic.Mutex = .unlocked,
 
     fn lock(self: *AtomicMutex) void {
-        while (!self.inner.tryLock()) std.atomic.spinLoopHint();
+        platform_sync.lockYielding(&self.inner);
     }
 
     fn unlock(self: *AtomicMutex) void {

--- a/zig/pkg/antfly/src/common/health_server.zig
+++ b/zig/pkg/antfly/src/common/health_server.zig
@@ -25,6 +25,7 @@
 //! server-specific metrics sources (raft metrics, serverless metrics, etc).
 
 const std = @import("std");
+const platform_sync = @import("antfly_platform").sync;
 const Io = std.Io;
 const http_common = @import("http/http_common.zig");
 const std_http_listener = @import("http/std_http_listener.zig");
@@ -407,7 +408,7 @@ fn buildMetricsBody(alloc: std.mem.Allocator, metrics: ?MetricsWriter) ![]u8 {
 }
 
 fn lockAtomic(mutex: *std.atomic.Mutex) void {
-    while (!mutex.tryLock()) std.atomic.spinLoopHint();
+    platform_sync.lockYielding(mutex);
 }
 
 // ---------------------------------------------------------------------------

--- a/zig/pkg/antfly/src/common/http/std_http_listener.zig
+++ b/zig/pkg/antfly/src/common/http/std_http_listener.zig
@@ -211,8 +211,11 @@ pub const StdHttpListener = struct {
             }
             if (self.cfg.serve_in_connection_threads) {
                 if (!self.tryAcquireConnectionThreadSlot()) {
-                    var rejected_stream = stream;
-                    rejected_stream.close(io);
+                    // All connection-thread slots are busy. Serve inline:
+                    // blocking the accept loop is natural backpressure,
+                    // whereas closing an accepted connection sends RST to a
+                    // client that has already written its request.
+                    self.serveStream(stream);
                     continue;
                 }
                 connection_group.concurrent(io, serveStreamFiber, .{ self, stream }) catch |err| {
@@ -255,7 +258,15 @@ pub const StdHttpListener = struct {
         var stream_writer = owned_stream.writer(io, send_buffer);
         var server: std.http.Server = .init(&stream_reader.interface, &stream_writer.interface);
 
-        var request = server.receiveHead() catch return;
+        var request = server.receiveHead() catch |err| {
+            // Closing here with unread request bytes sends RST to a client
+            // that is awaiting a response; keep the common idle-close quiet
+            // but record anything else so resets are diagnosable from logs.
+            if (err != error.HttpConnectionClosing and err != error.EndOfStream) {
+                std.log.warn("http receive head failed err={}", .{err});
+            }
+            return;
+        };
         self.handleRequest(&request) catch |err| {
             std.log.err("http request handler error: {}", .{err});
             _ = request.respond("internal server error", .{
@@ -905,6 +916,127 @@ test "std http listener caps active connection handoff threads" {
     try std.testing.expect(listener.tryAcquireConnectionThreadSlot());
     _ = listener.active_connection_threads.fetchSub(1, .acq_rel);
     try std.testing.expectEqual(@as(u32, 0), listener.active_connection_threads.load(.acquire));
+}
+
+test "std http listener saturated connection slots serve inline instead of resetting" {
+    const std_http_executor = @import("std_http_executor.zig");
+
+    const App = struct {
+        entered_slow: std.atomic.Value(bool) = .init(false),
+        release_slow: std.atomic.Value(bool) = .init(false),
+
+        fn executor(self: *@This()) common.RequestExecutor {
+            return .{
+                .ptr = self,
+                .vtable = &.{
+                    .execute = execute,
+                },
+            };
+        }
+
+        fn execute(ptr: *anyopaque, alloc: std.mem.Allocator, req: common.HttpRequest) !common.HttpResponse {
+            const self: *@This() = @ptrCast(@alignCast(ptr));
+            if (std.mem.eql(u8, req.uri, "/slow")) {
+                self.entered_slow.store(true, .release);
+                while (!self.release_slow.load(.acquire)) sleepMs(1);
+            }
+            return .{
+                .status = 200,
+                .content_type = try alloc.dupe(u8, "text/plain; charset=utf-8"),
+                .body = try alloc.dupe(u8, "ok"),
+            };
+        }
+    };
+
+    const RequestThread = struct {
+        uri: []const u8,
+        executor: common.RequestExecutor,
+        status: std.atomic.Value(u16) = .init(0),
+        failed: std.atomic.Value(bool) = .init(false),
+        done: std.atomic.Value(bool) = .init(false),
+
+        fn run(self: *@This()) void {
+            var response = self.executor.execute(std.heap.page_allocator, .{
+                .method = .GET,
+                .uri = self.uri,
+            }) catch {
+                self.failed.store(true, .release);
+                self.done.store(true, .release);
+                return;
+            };
+            defer response.deinit(std.heap.page_allocator);
+
+            self.status.store(response.status, .release);
+            self.done.store(true, .release);
+        }
+    };
+
+    var app = App{};
+    var executor = std_http_executor.StdHttpExecutor.init(std.heap.page_allocator, .{});
+    defer executor.deinit();
+    const request_executor = executor.executor();
+
+    // One connection-thread slot: the slow request occupies it, so the
+    // second request exercises the saturated path, which must serve inline
+    // rather than close (RST) the accepted connection.
+    var listener = StdHttpListener.init(std.heap.page_allocator, .{
+        .serve_in_connection_threads = true,
+        .max_connection_threads = 1,
+    }, app.executor());
+    defer listener.deinit();
+    try listener.start();
+
+    const base_uri = try listener.baseUri(std.testing.allocator);
+    defer std.testing.allocator.free(base_uri);
+
+    const slow_uri = try std.fmt.allocPrint(std.testing.allocator, "{s}/slow", .{base_uri});
+    defer std.testing.allocator.free(slow_uri);
+    const fast_uri = try std.fmt.allocPrint(std.testing.allocator, "{s}/fast", .{base_uri});
+    defer std.testing.allocator.free(fast_uri);
+
+    var slow_req = RequestThread{ .uri = slow_uri, .executor = request_executor };
+    const slow_thread = try std.Thread.spawn(.{}, RequestThread.run, .{&slow_req});
+    defer slow_thread.join();
+    defer app.release_slow.store(true, .release);
+
+    var saw_slow = false;
+    for (0..1000) |_| {
+        if (app.entered_slow.load(.acquire)) {
+            saw_slow = true;
+            break;
+        }
+        sleepMs(1);
+    }
+    try std.testing.expect(saw_slow);
+
+    var fast_req = RequestThread{ .uri = fast_uri, .executor = request_executor };
+    const fast_thread = try std.Thread.spawn(.{}, RequestThread.run, .{&fast_req});
+    defer fast_thread.join();
+
+    var fast_completed = false;
+    for (0..2000) |_| {
+        if (fast_req.done.load(.acquire)) {
+            fast_completed = true;
+            break;
+        }
+        sleepMs(1);
+    }
+    try std.testing.expect(fast_completed);
+    try std.testing.expect(!fast_req.failed.load(.acquire));
+    try std.testing.expectEqual(@as(u16, 200), fast_req.status.load(.acquire));
+
+    app.release_slow.store(true, .release);
+    var slow_completed = false;
+    for (0..1000) |_| {
+        if (slow_req.done.load(.acquire)) {
+            slow_completed = true;
+            break;
+        }
+        sleepMs(1);
+    }
+    try std.testing.expect(slow_completed);
+    try std.testing.expect(!slow_req.failed.load(.acquire));
+    try std.testing.expectEqual(@as(u16, 200), slow_req.status.load(.acquire));
 }
 
 test "std http listener connection handoff serves fast request while slow request is blocked" {

--- a/zig/pkg/antfly/src/common/http/std_http_listener.zig
+++ b/zig/pkg/antfly/src/common/http/std_http_listener.zig
@@ -189,8 +189,23 @@ pub const StdHttpListener = struct {
         const io = self.io_impl.io();
         var connection_group = std.Io.Group.init;
         defer connection_group.await(io) catch {};
+        var slot_held = false;
+        defer if (slot_held) self.releaseConnectionThreadSlot();
         while (true) {
             if (self.stopping.load(.acquire)) return;
+            if (self.cfg.serve_in_connection_threads and !slot_held) {
+                // Hold a connection-thread slot before accepting so that
+                // saturation backpressures into the kernel backlog. The
+                // alternatives both misbehave: accept-then-close sends RST to
+                // a client that already wrote its request, and serving the
+                // connection inline blocks the accept thread on a client
+                // read, stalling accepts (and stop()) on an idle peer.
+                if (!self.tryAcquireConnectionThreadSlot()) {
+                    sleepMs(1);
+                    continue;
+                }
+                slot_held = true;
+            }
             const stream = if (self.server) |*server|
                 server.accept(io) catch |err| switch (err) {
                     error.SocketNotListening => return,
@@ -210,24 +225,23 @@ pub const StdHttpListener = struct {
                 return;
             }
             if (self.cfg.serve_in_connection_threads) {
-                if (!self.tryAcquireConnectionThreadSlot()) {
-                    // All connection-thread slots are busy. Serve inline:
-                    // blocking the accept loop is natural backpressure,
-                    // whereas closing an accepted connection sends RST to a
-                    // client that has already written its request.
-                    self.serveStream(stream);
-                    continue;
-                }
                 connection_group.concurrent(io, serveStreamFiber, .{ self, stream }) catch |err| {
-                    _ = self.active_connection_threads.fetchSub(1, .acq_rel);
+                    slot_held = false;
+                    self.releaseConnectionThreadSlot();
                     std.log.warn("std http listener connection fiber handoff failed err={}", .{err});
                     self.serveStream(stream);
                     continue;
                 };
+                // The fiber owns the slot now and releases it on completion.
+                slot_held = false;
                 continue;
             }
             self.serveStream(stream);
         }
+    }
+
+    fn releaseConnectionThreadSlot(self: *StdHttpListener) void {
+        _ = self.active_connection_threads.fetchSub(1, .acq_rel);
     }
 
     fn tryAcquireConnectionThreadSlot(self: *StdHttpListener) bool {
@@ -240,7 +254,7 @@ pub const StdHttpListener = struct {
     }
 
     fn serveStreamFiber(self: *StdHttpListener, stream: std.Io.net.Stream) void {
-        defer _ = self.active_connection_threads.fetchSub(1, .acq_rel);
+        defer self.releaseConnectionThreadSlot();
         self.serveStream(stream);
     }
 
@@ -918,7 +932,7 @@ test "std http listener caps active connection handoff threads" {
     try std.testing.expectEqual(@as(u32, 0), listener.active_connection_threads.load(.acquire));
 }
 
-test "std http listener saturated connection slots serve inline instead of resetting" {
+test "std http listener saturated connection slots queue instead of resetting" {
     const std_http_executor = @import("std_http_executor.zig");
 
     const App = struct {
@@ -976,9 +990,10 @@ test "std http listener saturated connection slots serve inline instead of reset
     defer executor.deinit();
     const request_executor = executor.executor();
 
-    // One connection-thread slot: the slow request occupies it, so the
-    // second request exercises the saturated path, which must serve inline
-    // rather than close (RST) the accepted connection.
+    // One connection-thread slot: while the slow request occupies it, a
+    // second connection must queue unaccepted in the kernel backlog (no
+    // accept-then-close RST, no inline serve blocking the accept thread)
+    // and complete once the slot frees.
     var listener = StdHttpListener.init(std.heap.page_allocator, .{
         .serve_in_connection_threads = true,
         .max_connection_threads = 1,
@@ -1013,6 +1028,12 @@ test "std http listener saturated connection slots serve inline instead of reset
     const fast_thread = try std.Thread.spawn(.{}, RequestThread.run, .{&fast_req});
     defer fast_thread.join();
 
+    // While the slot is saturated the second request must not be reset.
+    sleepMs(50);
+    try std.testing.expect(!fast_req.failed.load(.acquire));
+
+    app.release_slow.store(true, .release);
+
     var fast_completed = false;
     for (0..2000) |_| {
         if (fast_req.done.load(.acquire)) {
@@ -1025,7 +1046,6 @@ test "std http listener saturated connection slots serve inline instead of reset
     try std.testing.expect(!fast_req.failed.load(.acquire));
     try std.testing.expectEqual(@as(u16, 200), fast_req.status.load(.acquire));
 
-    app.release_slow.store(true, .release);
     var slow_completed = false;
     for (0..1000) |_| {
         if (slow_req.done.load(.acquire)) {
@@ -1037,6 +1057,124 @@ test "std http listener saturated connection slots serve inline instead of reset
     try std.testing.expect(slow_completed);
     try std.testing.expect(!slow_req.failed.load(.acquire));
     try std.testing.expectEqual(@as(u16, 200), slow_req.status.load(.acquire));
+}
+
+test "std http listener stop returns while saturated with a headerless connection queued" {
+    const std_http_executor = @import("std_http_executor.zig");
+
+    const App = struct {
+        entered_slow: std.atomic.Value(bool) = .init(false),
+        release_slow: std.atomic.Value(bool) = .init(false),
+
+        fn executor(self: *@This()) common.RequestExecutor {
+            return .{
+                .ptr = self,
+                .vtable = &.{
+                    .execute = execute,
+                },
+            };
+        }
+
+        fn execute(ptr: *anyopaque, alloc: std.mem.Allocator, req: common.HttpRequest) !common.HttpResponse {
+            const self: *@This() = @ptrCast(@alignCast(ptr));
+            _ = req;
+            self.entered_slow.store(true, .release);
+            while (!self.release_slow.load(.acquire)) sleepMs(1);
+            return .{
+                .status = 200,
+                .content_type = try alloc.dupe(u8, "text/plain; charset=utf-8"),
+                .body = try alloc.dupe(u8, "ok"),
+            };
+        }
+    };
+
+    const RequestThread = struct {
+        uri: []const u8,
+        executor: common.RequestExecutor,
+        done: std.atomic.Value(bool) = .init(false),
+
+        fn run(self: *@This()) void {
+            var response = self.executor.execute(std.heap.page_allocator, .{
+                .method = .GET,
+                .uri = self.uri,
+            }) catch {
+                self.done.store(true, .release);
+                return;
+            };
+            response.deinit(std.heap.page_allocator);
+            self.done.store(true, .release);
+        }
+    };
+
+    const StopThread = struct {
+        listener: *StdHttpListener,
+        done: std.atomic.Value(bool) = .init(false),
+
+        fn run(self: *@This()) void {
+            self.listener.stop();
+            self.done.store(true, .release);
+        }
+    };
+
+    var app = App{};
+    var executor = std_http_executor.StdHttpExecutor.init(std.heap.page_allocator, .{});
+    defer executor.deinit();
+    const request_executor = executor.executor();
+
+    var listener = StdHttpListener.init(std.heap.page_allocator, .{
+        .serve_in_connection_threads = true,
+        .max_connection_threads = 1,
+    }, app.executor());
+    defer listener.deinit();
+    try listener.start();
+
+    const base_uri = try listener.baseUri(std.testing.allocator);
+    defer std.testing.allocator.free(base_uri);
+    const slow_uri = try std.fmt.allocPrint(std.testing.allocator, "{s}/slow", .{base_uri});
+    defer std.testing.allocator.free(slow_uri);
+
+    var slow_req = RequestThread{ .uri = slow_uri, .executor = request_executor };
+    const slow_thread = try std.Thread.spawn(.{}, RequestThread.run, .{&slow_req});
+    defer slow_thread.join();
+    defer app.release_slow.store(true, .release);
+
+    var saw_slow = false;
+    for (0..1000) |_| {
+        if (app.entered_slow.load(.acquire)) {
+            saw_slow = true;
+            break;
+        }
+        sleepMs(1);
+    }
+    try std.testing.expect(saw_slow);
+
+    // A connection that never sends headers while the listener is
+    // saturated: it must not be accepted (and must not wedge serve/stop).
+    const bound_addr = listener.boundAddress() orelse return error.TestUnexpectedResult;
+    const idle_io = std.Io.Threaded.global_single_threaded.io();
+    var idle_stream = try bound_addr.connect(idle_io, .{ .mode = .stream });
+    defer idle_stream.close(idle_io);
+    sleepMs(20);
+
+    var stop_thread_state = StopThread{ .listener = &listener };
+    const stop_thread = try std.Thread.spawn(.{}, StopThread.run, .{&stop_thread_state});
+    defer stop_thread.join();
+
+    // stop() waits for in-flight requests; release the slow one and the
+    // whole shutdown must then complete promptly even though the headerless
+    // connection is still open.
+    sleepMs(20);
+    app.release_slow.store(true, .release);
+
+    var stopped = false;
+    for (0..5000) |_| {
+        if (stop_thread_state.done.load(.acquire)) {
+            stopped = true;
+            break;
+        }
+        sleepMs(1);
+    }
+    try std.testing.expect(stopped);
 }
 
 test "std http listener connection handoff serves fast request while slow request is blocked" {

--- a/zig/pkg/antfly/src/common/secrets.zig
+++ b/zig/pkg/antfly/src/common/secrets.zig
@@ -13,6 +13,7 @@
 // limitations.
 
 const std = @import("std");
+const platform_sync = @import("antfly_platform").sync;
 const builtin = @import("builtin");
 const fs_paths = @import("fs_paths.zig");
 
@@ -181,7 +182,7 @@ pub const BearerAuthHeaderCache = struct {
         var resolved = try secret.resolveOwnedWithGeneration(out_alloc, secret_store);
         defer resolved.deinit(out_alloc);
 
-        while (!self.mutex.tryLock()) std.atomic.spinLoopHint();
+        platform_sync.lockYielding(&self.mutex);
         defer self.mutex.unlock();
 
         if (self.header == null or self.generation != resolved.cacheGeneration()) {
@@ -534,7 +535,7 @@ pub const FileStore = struct {
     }
 
     fn lock(self: *FileStore) void {
-        while (!self.mutex.tryLock()) std.atomic.spinLoopHint();
+        platform_sync.lockYielding(&self.mutex);
     }
 
     fn unlock(self: *FileStore) void {

--- a/zig/pkg/antfly/src/data/runtime.zig
+++ b/zig/pkg/antfly/src/data/runtime.zig
@@ -13,6 +13,7 @@
 // limitations.
 
 const std = @import("std");
+const platform_sync = @import("antfly_platform").sync;
 const antfly = @import("../root.zig");
 const indexes_api = @import("../api/indexes.zig");
 const json_helpers = @import("../api/json_helpers.zig");
@@ -5751,21 +5752,11 @@ pub const DataServer = struct {
 };
 
 fn lockAtomic(mutex: *std.atomic.Mutex) void {
-    // Bounded spin, then yield: this guards the raft round (which can run for
-    // milliseconds), and a pure spin here pins a core per waiter — on
-    // CPU-constrained hosts (CI runners) that starves the very threads that
-    // would release the lock.
-    var spins: u32 = 0;
-    while (!mutex.tryLock()) {
-        if (comptime @import("builtin").os.tag == .freestanding) {
-            std.atomic.spinLoopHint();
-        } else if (spins < 64) {
-            std.atomic.spinLoopHint();
-            spins +%= 1;
-        } else {
-            std.Thread.yield() catch std.atomic.spinLoopHint();
-        }
-    }
+    // Bounded spin, then yield (platform_sync): this guards the raft round
+    // (which can run for milliseconds), and a pure spin here pins a core per
+    // waiter — on CPU-constrained hosts (CI runners) that starves the very
+    // threads that would release the lock.
+    platform_sync.lockYielding(mutex);
 }
 
 fn appendUniqueNodeId(alloc: std.mem.Allocator, list: *std.ArrayListUnmanaged(u64), node_id: u64) !void {

--- a/zig/pkg/antfly/src/data/runtime.zig
+++ b/zig/pkg/antfly/src/data/runtime.zig
@@ -5751,7 +5751,21 @@ pub const DataServer = struct {
 };
 
 fn lockAtomic(mutex: *std.atomic.Mutex) void {
-    while (!mutex.tryLock()) std.atomic.spinLoopHint();
+    // Bounded spin, then yield: this guards the raft round (which can run for
+    // milliseconds), and a pure spin here pins a core per waiter — on
+    // CPU-constrained hosts (CI runners) that starves the very threads that
+    // would release the lock.
+    var spins: u32 = 0;
+    while (!mutex.tryLock()) {
+        if (comptime @import("builtin").os.tag == .freestanding) {
+            std.atomic.spinLoopHint();
+        } else if (spins < 64) {
+            std.atomic.spinLoopHint();
+            spins +%= 1;
+        } else {
+            std.Thread.yield() catch std.atomic.spinLoopHint();
+        }
+    }
 }
 
 fn appendUniqueNodeId(alloc: std.mem.Allocator, list: *std.ArrayListUnmanaged(u64), node_id: u64) !void {

--- a/zig/pkg/antfly/src/foreign/postgres_libpq.zig
+++ b/zig/pkg/antfly/src/foreign/postgres_libpq.zig
@@ -13,6 +13,7 @@
 // limitations.
 
 const std = @import("std");
+const platform_sync = @import("antfly_platform").sync;
 const builtin = @import("builtin");
 const filter = @import("filter.zig");
 const foreign_source = @import("source.zig");
@@ -1515,7 +1516,7 @@ fn freeColumns(alloc: Allocator, columns: []foreign_source.Column) void {
 }
 
 fn lock(mutex: *Mutex) void {
-    while (!mutex.tryLock()) std.atomic.spinLoopHint();
+    platform_sync.lockYielding(mutex);
 }
 
 pub fn registerDefaultExecutor(alloc: Allocator, registry: *foreign_source.Registry) !void {

--- a/zig/pkg/antfly/src/inference/managed_embedder.zig
+++ b/zig/pkg/antfly/src/inference/managed_embedder.zig
@@ -13,6 +13,7 @@
 // limitations.
 
 const std = @import("std");
+const platform_sync = @import("antfly_platform").sync;
 const builtin = @import("builtin");
 const httpx = @import("httpx");
 const hbs = @import("handlebars");
@@ -170,7 +171,7 @@ fn sleepNs(duration_ns: u64) void {
 }
 
 fn lockAtomic(mutex: *std.atomic.Mutex) void {
-    while (!mutex.tryLock()) std.atomic.spinLoopHint();
+    platform_sync.lockYielding(mutex);
 }
 
 const RequestPacer = struct {
@@ -2402,7 +2403,7 @@ pub fn testFileBackedApiKeyRotation() !void {
         fn execute(ptr: *anyopaque, response_alloc: std.mem.Allocator, req: http_common.HttpRequest) !http_common.HttpResponse {
             const self: *@This() = @ptrCast(@alignCast(ptr));
             const auth = req.authorization orelse req.header("authorization") orelse "";
-            while (!self.mutex.tryLock()) std.atomic.spinLoopHint();
+            platform_sync.lockYielding(&self.mutex);
             defer self.mutex.unlock();
             const index = self.count;
             if (index < self.headers.len) {
@@ -2421,7 +2422,7 @@ pub fn testFileBackedApiKeyRotation() !void {
         }
 
         fn expectHeader(self: *@This(), index: usize, expected: []const u8) !void {
-            while (!self.mutex.tryLock()) std.atomic.spinLoopHint();
+            platform_sync.lockYielding(&self.mutex);
             defer self.mutex.unlock();
             try std.testing.expect(index < self.count);
             try std.testing.expectEqualStrings(expected, self.headers[index] orelse return error.TestUnexpectedResult);

--- a/zig/pkg/antfly/src/serverless/catalog/fs_progress_store.zig
+++ b/zig/pkg/antfly/src/serverless/catalog/fs_progress_store.zig
@@ -13,6 +13,7 @@
 // limitations.
 
 const std = @import("std");
+const platform_sync = @import("antfly_platform").sync;
 const Allocator = std.mem.Allocator;
 const fs_paths = @import("../../common/fs_paths.zig");
 const catalog_types = @import("types.zig");
@@ -367,7 +368,7 @@ fn threadedIo() std.Io.Threaded {
 }
 
 fn lockAtomic(mutex: *std.atomic.Mutex) void {
-    while (!mutex.tryLock()) std.atomic.spinLoopHint();
+    platform_sync.lockYielding(mutex);
 }
 
 fn readFileAlloc(alloc: Allocator, path: []const u8) ![]u8 {

--- a/zig/pkg/antfly/src/serverless/catalog/fs_store.zig
+++ b/zig/pkg/antfly/src/serverless/catalog/fs_store.zig
@@ -13,6 +13,7 @@
 // limitations.
 
 const std = @import("std");
+const platform_sync = @import("antfly_platform").sync;
 const Allocator = std.mem.Allocator;
 const fs_paths = @import("../../common/fs_paths.zig");
 const catalog_types = @import("types.zig");
@@ -537,7 +538,7 @@ fn threadedIo() std.Io.Threaded {
 }
 
 fn lockAtomic(mutex: *std.atomic.Mutex) void {
-    while (!mutex.tryLock()) std.atomic.spinLoopHint();
+    platform_sync.lockYielding(mutex);
 }
 
 fn fileExists(path: []const u8) bool {

--- a/zig/pkg/antfly/src/serverless/catalog/object_progress_store.zig
+++ b/zig/pkg/antfly/src/serverless/catalog/object_progress_store.zig
@@ -13,6 +13,7 @@
 // limitations.
 
 const std = @import("std");
+const platform_sync = @import("antfly_platform").sync;
 const objectstore = @import("objectstore");
 const catalog_types = @import("types.zig");
 const progress_store = @import("progress_store.zig");
@@ -412,7 +413,7 @@ fn enrichmentStageKeyAlloc(
 }
 
 fn lockAtomic(mutex: *std.atomic.Mutex) void {
-    while (!mutex.tryLock()) std.atomic.spinLoopHint();
+    platform_sync.lockYielding(mutex);
 }
 
 test "objectstore-backed progress store supports cas over file uri" {

--- a/zig/pkg/antfly/src/serverless/catalog/object_store.zig
+++ b/zig/pkg/antfly/src/serverless/catalog/object_store.zig
@@ -13,6 +13,7 @@
 // limitations.
 
 const std = @import("std");
+const platform_sync = @import("antfly_platform").sync;
 const object_storage = @import("../../storage/object_storage.zig");
 const catalog_types = @import("types.zig");
 const catalog_store = @import("store.zig");
@@ -704,7 +705,7 @@ fn findNamespaceRecord(records: []const catalog_types.NamespaceRecord, namespace
 }
 
 fn lockAtomic(mutex: *std.atomic.Mutex) void {
-    while (!mutex.tryLock()) std.atomic.spinLoopHint();
+    platform_sync.lockYielding(mutex);
 }
 
 test "objectstore-backed catalog store persists namespace records over file uri" {

--- a/zig/pkg/antfly/src/serverless/manifest/fs_store.zig
+++ b/zig/pkg/antfly/src/serverless/manifest/fs_store.zig
@@ -13,6 +13,7 @@
 // limitations.
 
 const std = @import("std");
+const platform_sync = @import("antfly_platform").sync;
 const Allocator = std.mem.Allocator;
 const fs_paths = @import("../../common/fs_paths.zig");
 const manifest_types = @import("types.zig");
@@ -213,7 +214,7 @@ fn fileExists(path: []const u8) bool {
 }
 
 fn lockAtomic(mutex: *std.atomic.Mutex) void {
-    while (!mutex.tryLock()) std.atomic.spinLoopHint();
+    platform_sync.lockYielding(mutex);
 }
 
 fn readFileAlloc(alloc: Allocator, path: []const u8) ![]u8 {

--- a/zig/pkg/antfly/src/serverless/query/cache.zig
+++ b/zig/pkg/antfly/src/serverless/query/cache.zig
@@ -13,6 +13,7 @@
 // limitations.
 
 const std = @import("std");
+const platform_sync = @import("antfly_platform").sync;
 const Allocator = std.mem.Allocator;
 const fs_paths = @import("../../common/fs_paths.zig");
 const artifacts_mod = @import("../artifacts/mod.zig");
@@ -497,7 +498,7 @@ fn cacheUsageNoLock(alloc: Allocator, root_dir: []const u8) !CacheUsage {
 }
 
 fn lockAtomic(mutex: *std.atomic.Mutex) void {
-    while (!mutex.tryLock()) std.atomic.spinLoopHint();
+    platform_sync.lockYielding(mutex);
 }
 
 fn incrementBlockClassHit(stats: *QueryCacheStats, block_class: BlockClass) void {

--- a/zig/pkg/antfly/src/serverless/query/runtime.zig
+++ b/zig/pkg/antfly/src/serverless/query/runtime.zig
@@ -13,6 +13,7 @@
 // limitations.
 
 const std = @import("std");
+const platform_sync = @import("antfly_platform").sync;
 const Allocator = std.mem.Allocator;
 const artifacts_mod = @import("../artifacts/mod.zig");
 const catalog_mod = @import("../catalog/mod.zig");
@@ -517,7 +518,7 @@ test "query runtime warming keeps artifact available through cache" {
 }
 
 fn lockAtomic(mutex: *std.atomic.Mutex) void {
-    while (!mutex.tryLock()) std.atomic.spinLoopHint();
+    platform_sync.lockYielding(mutex);
 }
 
 fn applyModeCount(metrics: *QueryExecutionMetrics, mode: request_mod.QueryMode) void {

--- a/zig/pkg/antfly/src/serverless/runtime/manager.zig
+++ b/zig/pkg/antfly/src/serverless/runtime/manager.zig
@@ -13,6 +13,7 @@
 // limitations.
 
 const std = @import("std");
+const platform_sync = @import("antfly_platform").sync;
 const Allocator = std.mem.Allocator;
 const api_mod = @import("../api/mod.zig");
 const build_mod = @import("../build/mod.zig");
@@ -767,5 +768,5 @@ fn sleepMs(ms: u64) void {
 }
 
 fn lockAtomic(mutex: *std.atomic.Mutex) void {
-    while (!mutex.tryLock()) std.atomic.spinLoopHint();
+    platform_sync.lockYielding(mutex);
 }

--- a/zig/pkg/antfly/src/serverless/wal/fs_store.zig
+++ b/zig/pkg/antfly/src/serverless/wal/fs_store.zig
@@ -13,6 +13,7 @@
 // limitations.
 
 const std = @import("std");
+const platform_sync = @import("antfly_platform").sync;
 const Allocator = std.mem.Allocator;
 const fs_paths = @import("../../common/fs_paths.zig");
 const wal_types = @import("types.zig");
@@ -225,7 +226,7 @@ fn fileExists(path: []const u8) bool {
 }
 
 fn lockAtomic(mutex: *std.atomic.Mutex) void {
-    while (!mutex.tryLock()) std.atomic.spinLoopHint();
+    platform_sync.lockYielding(mutex);
 }
 
 fn readFileAlloc(alloc: Allocator, path: []const u8) ![]u8 {

--- a/zig/pkg/antfly/src/serverless/wal/object_store.zig
+++ b/zig/pkg/antfly/src/serverless/wal/object_store.zig
@@ -13,6 +13,7 @@
 // limitations.
 
 const std = @import("std");
+const platform_sync = @import("antfly_platform").sync;
 const objectstore = @import("objectstore");
 const wal_types = @import("types.zig");
 const wal_store = @import("store.zig");
@@ -361,7 +362,7 @@ fn logKeyAlloc(alloc: std.mem.Allocator, prefix: []const u8, namespace: []const 
 }
 
 fn lockAtomic(mutex: *std.atomic.Mutex) void {
-    while (!mutex.tryLock()) std.atomic.spinLoopHint();
+    platform_sync.lockYielding(mutex);
 }
 
 test "objectstore-backed wal store appends and truncates over file uri" {

--- a/zig/pkg/antfly/src/storage/db/db.zig
+++ b/zig/pkg/antfly/src/storage/db/db.zig
@@ -13,6 +13,7 @@
 // limitations.
 
 const std = @import("std");
+const platform_sync = @import("antfly_platform").sync;
 const builtin = @import("builtin");
 const build_options = @import("build_options");
 const platform = @import("antfly_platform");
@@ -25383,7 +25384,7 @@ const FakePromotionSink = struct {
     fn upsertFn(ptr: *anyopaque, allocator: std.mem.Allocator, table: []const u8, key: []const u8, doc_json: []const u8) anyerror!void {
         _ = allocator;
         const self: *FakePromotionSink = @ptrCast(@alignCast(ptr));
-        while (!self.mutex.tryLock()) std.Thread.yield() catch {};
+        platform_sync.lockYielding(&self.mutex);
         defer self.mutex.unlock();
         const t = try self.alloc.dupe(u8, table);
         errdefer self.alloc.free(t);
@@ -25395,7 +25396,7 @@ const FakePromotionSink = struct {
     }
 
     fn findKey(self: *FakePromotionSink, key: []const u8) ?[]const u8 {
-        while (!self.mutex.tryLock()) std.Thread.yield() catch {};
+        platform_sync.lockYielding(&self.mutex);
         defer self.mutex.unlock();
         for (self.upserts.items) |u| {
             if (std.mem.eql(u8, u.key, key)) return u.doc;

--- a/zig/pkg/antfly/src/storage/db/db.zig
+++ b/zig/pkg/antfly/src/storage/db/db.zig
@@ -3605,10 +3605,24 @@ pub const DB = struct {
             dense_backend.manifest_dirty = false;
         }
 
-        try std.testing.expectEqual(@as(u64, 1), dense_backend.snapshotMaintenanceStats().obsolete_paths_reclaimable);
+        try expectObsoletePathsReclaimable(dense_backend, 1);
         try std.testing.expect(try db.runLsmMaintenanceStepBestEffort());
         try std.testing.expectEqual(@as(u64, 0), dense_backend.snapshotMaintenanceStats().obsolete_paths);
         try std.testing.expectError(error.FileNotFound, dense_backend.storage.?.readFileAlloc(alloc, obsolete_path, 1024));
+    }
+
+    /// A queued obsolete path only counts as reclaimable once no reader pins
+    /// the backend; transient background readers (index loads, status probes)
+    /// mask it as pinned_by_readers for a moment. Poll instead of asserting a
+    /// single snapshot so loaded CI machines don't flake.
+    fn expectObsoletePathsReclaimable(backend: *lsm_backend_mod.Backend, expected: u64) !void {
+        var attempts: usize = 0;
+        while (backend.snapshotMaintenanceStats().obsolete_paths_reclaimable != expected) : (attempts += 1) {
+            if (attempts >= 2000) {
+                return std.testing.expectEqual(expected, backend.snapshotMaintenanceStats().obsolete_paths_reclaimable);
+            }
+            std.Thread.yield() catch {};
+        }
     }
 
     test "db primary lsm maintenance step does not reclaim index obsolete paths" {
@@ -3675,8 +3689,8 @@ pub const DB = struct {
             dense_backend.manifest_dirty = false;
         }
 
-        try std.testing.expectEqual(@as(u64, 1), primary_backend.snapshotMaintenanceStats().obsolete_paths_reclaimable);
-        try std.testing.expectEqual(@as(u64, 1), dense_backend.snapshotMaintenanceStats().obsolete_paths_reclaimable);
+        try expectObsoletePathsReclaimable(primary_backend, 1);
+        try expectObsoletePathsReclaimable(dense_backend, 1);
 
         _ = try db.runPrimaryLsmMaintenanceStep();
 

--- a/zig/pkg/antfly/src/storage/db/derived/apply_state.zig
+++ b/zig/pkg/antfly/src/storage/db/derived/apply_state.zig
@@ -13,6 +13,7 @@
 // limitations.
 
 const std = @import("std");
+const platform_sync = @import("antfly_platform").sync;
 const builtin = @import("builtin");
 const Allocator = std.mem.Allocator;
 const backend_erased = @import("../../backend_erased.zig");
@@ -32,7 +33,7 @@ var checkpoint_lock_registry_mutex: std.atomic.Mutex = .unlocked;
 var checkpoint_locks: std.StringHashMapUnmanaged(*CheckpointFileLock) = .empty;
 
 fn lockAtomicMutex(mutex: *std.atomic.Mutex) void {
-    while (!mutex.tryLock()) std.Thread.yield() catch {};
+    platform_sync.lockYielding(mutex);
 }
 
 const CheckpointFileLock = struct {

--- a/zig/pkg/antfly/src/storage/db/derived/derived_log.zig
+++ b/zig/pkg/antfly/src/storage/db/derived/derived_log.zig
@@ -13,6 +13,7 @@
 // limitations.
 
 const std = @import("std");
+const platform_sync = @import("antfly_platform").sync;
 const builtin = @import("builtin");
 const Allocator = std.mem.Allocator;
 const lsm_backend = @import("../../lsm_backend/mod.zig");
@@ -303,7 +304,7 @@ test "derived log propagates wal group commit settings" {
         fn wait(self: *@This(), total: usize) void {
             var registered = false;
             while (true) {
-                while (!self.mutex.tryLock()) std.Thread.yield() catch {};
+                platform_sync.lockYielding(&self.mutex);
                 if (!registered) {
                     self.waiting += 1;
                     registered = true;

--- a/zig/pkg/antfly/src/storage/db/promotion_runtime.zig
+++ b/zig/pkg/antfly/src/storage/db/promotion_runtime.zig
@@ -30,7 +30,7 @@
 //! no-op. The stage advances `applied_sequence` only after the upserts return.
 
 const std = @import("std");
-const builtin = @import("builtin");
+const platform_sync = @import("antfly_platform").sync;
 const resolver_lib = @import("antfly_resolver");
 const internal_keys = @import("../internal_keys.zig");
 const change_journal_mod = @import("derived/change_journal.zig");
@@ -539,13 +539,7 @@ pub const PromotionRuntime = struct {
 };
 
 fn lockMutex(mutex: *std.atomic.Mutex) void {
-    while (!mutex.tryLock()) {
-        if (builtin.single_threaded) {
-            std.atomic.spinLoopHint();
-            continue;
-        }
-        std.Thread.yield() catch {};
-    }
+    platform_sync.lockYielding(mutex);
 }
 
 const testing = std.testing;

--- a/zig/pkg/antfly/src/storage/db/query_metrics.zig
+++ b/zig/pkg/antfly/src/storage/db/query_metrics.zig
@@ -13,6 +13,7 @@
 // limitations.
 
 const std = @import("std");
+const platform_sync = @import("antfly_platform").sync;
 
 const metric_name = "antfly_indexes_query_duration_seconds";
 const metric_help = "Index query latency in seconds.";
@@ -96,7 +97,7 @@ const MetricsMutex = struct {
     state: std.atomic.Mutex = .unlocked,
 
     fn lock(self: *@This()) void {
-        while (!self.state.tryLock()) std.atomic.spinLoopHint();
+        platform_sync.lockYielding(&self.state);
     }
 
     fn unlock(self: *@This()) void {

--- a/zig/pkg/antfly/src/storage/lmdb.zig
+++ b/zig/pkg/antfly/src/storage/lmdb.zig
@@ -34,6 +34,7 @@
 
 const builtin = @import("builtin");
 const std = @import("std");
+const platform_sync = @import("antfly_platform").sync;
 const platform = @import("antfly_platform");
 const zig_lmdb = @import("lmdb_engine");
 const lmdb_sim_test = @import("lmdb_sim_test.zig");
@@ -56,7 +57,7 @@ fn heapAllocator() std.mem.Allocator {
 }
 
 fn lockAtomic(mutex: *std.atomic.Mutex) void {
-    while (!mutex.tryLock()) std.Thread.yield() catch {};
+    platform_sync.lockYielding(mutex);
 }
 
 fn backoffWriterLockRetry() void {

--- a/zig/pkg/antfly/src/storage/lsm_backend/cache.zig
+++ b/zig/pkg/antfly/src/storage/lsm_backend/cache.zig
@@ -13,6 +13,7 @@
 // limitations.
 
 const std = @import("std");
+const platform_sync = @import("antfly_platform").sync;
 const builtin = @import("builtin");
 const platform = @import("antfly_platform");
 
@@ -919,7 +920,7 @@ fn copyKey(allocator: Allocator, key: Cache.Key) !Cache.Key {
 
 fn lockAtomic(mutex: *std.atomic.Mutex) bool {
     if (builtin.os.tag == .freestanding) return false;
-    while (!mutex.tryLock()) std.atomic.spinLoopHint();
+    platform_sync.lockYielding(mutex);
     return true;
 }
 

--- a/zig/pkg/antfly/src/storage/lsm_backend/runtime.zig
+++ b/zig/pkg/antfly/src/storage/lsm_backend/runtime.zig
@@ -13,6 +13,7 @@
 // limitations.
 
 const std = @import("std");
+const platform_sync = @import("antfly_platform").sync;
 const builtin = @import("builtin");
 const bloom = @import("bloom");
 const Allocator = std.mem.Allocator;
@@ -234,7 +235,7 @@ pub fn lockBackend(comptime BackendType: type, backend: *BackendType) bool {
             platform_time.monotonicNs()
         else
             0;
-        while (!backend.mu.tryLock()) std.atomic.spinLoopHint();
+        platform_sync.lockYielding(&backend.mu);
         if (@hasDecl(BackendType, "recordBackendLockWait")) {
             backend.recordBackendLockWait(platform_time.monotonicNs() -| started_ns);
         }

--- a/zig/pkg/antfly/src/storage/lsm_backend/storage_io.zig
+++ b/zig/pkg/antfly/src/storage/lsm_backend/storage_io.zig
@@ -13,6 +13,7 @@
 // limitations.
 
 const std = @import("std");
+const platform_sync = @import("antfly_platform").sync;
 const builtin = @import("builtin");
 const platform = @import("antfly_platform");
 const fs_paths = @import("../../common/fs_paths.zig");
@@ -2017,7 +2018,7 @@ pub const MemoryStorage = struct {
 
 fn lockAtomic(mutex: *std.atomic.Mutex) bool {
     if (builtin.os.tag == .freestanding) return false;
-    while (!mutex.tryLock()) std.atomic.spinLoopHint();
+    platform_sync.lockYielding(mutex);
     return true;
 }
 

--- a/zig/pkg/antfly/src/storage/mem_backend.zig
+++ b/zig/pkg/antfly/src/storage/mem_backend.zig
@@ -13,6 +13,7 @@
 // limitations.
 
 const std = @import("std");
+const platform_sync = @import("antfly_platform").sync;
 const Allocator = std.mem.Allocator;
 const backend_adapter = @import("backend_adapter.zig");
 const backend_erased = @import("backend_erased.zig");
@@ -489,7 +490,7 @@ pub const Backend = struct {
 };
 
 fn lockBackend(backend: *Backend) void {
-    while (!backend.mutex.tryLock()) std.Thread.yield() catch {};
+    platform_sync.lockYielding(&backend.mutex);
 }
 
 fn identityNamespace(namespace: backend_types.Namespace) !backend_types.Namespace {

--- a/zig/pkg/antfly/src/storage/persistent.zig
+++ b/zig/pkg/antfly/src/storage/persistent.zig
@@ -36,6 +36,7 @@
 //!   4. WAL.truncate(LSN)
 
 const std = @import("std");
+const platform_sync = @import("antfly_platform").sync;
 const builtin = @import("builtin");
 const Allocator = std.mem.Allocator;
 const backend_adapter = @import("backend_adapter.zig");
@@ -512,7 +513,7 @@ const deletions_db_name = "deletions";
 var global_storage_mu: std.atomic.Mutex = .unlocked;
 
 fn lockPersistentStorage() void {
-    while (!global_storage_mu.tryLock()) std.atomic.spinLoopHint();
+    platform_sync.lockYielding(&global_storage_mu);
 }
 
 fn unlockPersistentStorage() void {

--- a/zig/pkg/antfly/src/storage/portable_wal.zig
+++ b/zig/pkg/antfly/src/storage/portable_wal.zig
@@ -13,6 +13,7 @@
 // limitations.
 
 const std = @import("std");
+const platform_sync = @import("antfly_platform").sync;
 const Allocator = std.mem.Allocator;
 const lsm_backend = @import("lsm_backend/mod.zig");
 const storage_io = @import("lsm_backend/storage_io.zig");
@@ -354,5 +355,5 @@ fn computeNextLsn(bytes: []const u8) u64 {
 }
 
 fn lockAtomic(mutex: *std.atomic.Mutex) void {
-    while (!mutex.tryLock()) std.atomic.spinLoopHint();
+    platform_sync.lockYielding(mutex);
 }

--- a/zig/pkg/antfly/src/swarm/runtime.zig
+++ b/zig/pkg/antfly/src/swarm/runtime.zig
@@ -13,6 +13,7 @@
 // limitations.
 
 const std = @import("std");
+const platform_sync = @import("antfly_platform").sync;
 const httpx = @import("httpx");
 const antfly = @import("../root.zig");
 const group_ids = @import("../common/group_ids.zig");
@@ -1478,7 +1479,7 @@ fn runLocalReplicaRootReconcilePermitHook(ptr: *anyopaque) bool {
 }
 
 fn lockAtomic(mutex: *std.atomic.Mutex) void {
-    while (!mutex.tryLock()) std.atomic.spinLoopHint();
+    platform_sync.lockYielding(mutex);
 }
 
 fn readFileAlloc(alloc: std.mem.Allocator, path: []const u8, max_bytes: usize) ![]u8 {

--- a/zig/pkg/antfly/src/tracing/antfly_trace_writer.zig
+++ b/zig/pkg/antfly/src/tracing/antfly_trace_writer.zig
@@ -13,6 +13,7 @@
 // limitations.
 
 const std = @import("std");
+const platform_sync = @import("antfly_platform").sync;
 
 /// Event emitted by instrumented Antfly transaction code for TLA+ trace validation.
 pub const AntflyTracingEvent = struct {
@@ -58,7 +59,7 @@ pub const AntflyNdjsonTraceWriter = struct {
 
     fn traceEvent(ptr: *anyopaque, event: *const AntflyTracingEvent) void {
         const self: *AntflyNdjsonTraceWriter = @ptrCast(@alignCast(ptr));
-        while (!self.mutex.tryLock()) std.atomic.spinLoopHint();
+        platform_sync.lockYielding(&self.mutex);
         defer self.mutex.unlock();
         self.writeEvent(event) catch {};
         self.writer.flush() catch {};

--- a/zig/pkg/antfly/src/tracing/raft_trace_logger.zig
+++ b/zig/pkg/antfly/src/tracing/raft_trace_logger.zig
@@ -13,6 +13,7 @@
 // limitations.
 
 const std = @import("std");
+const platform_sync = @import("antfly_platform").sync;
 const raft_engine = @import("raft_engine");
 const core = raft_engine.core;
 
@@ -59,7 +60,7 @@ pub const RaftNdjsonTraceLogger = struct {
         if (event.event_type == .become_pre_candidate) return;
 
         const self: *RaftNdjsonTraceLogger = @ptrCast(@alignCast(ptr));
-        while (!self.mutex.tryLock()) std.atomic.spinLoopHint();
+        platform_sync.lockYielding(&self.mutex);
         defer self.mutex.unlock();
 
         // Pre-event synthesis: events that must appear BEFORE the main event.


### PR DESCRIPTION
Fixes the two failing nightly jobs from run 27327168835 (`e2e-base`, `full-default`), which turn out to share a root cause. Diagnosed by reproducing the hang in a Linux container and taking gdb thread dumps mid-wedge.

## The deadlock (e2e-base: `test_multinode_autograph_resolves_promotes_and_hydrates_entities`)

Mid-hang stacks show the **raft apply thread** wedged:

```
MultiRaft.runRound → flushPendingApply → applyReady
  → applyReplicatedBatchGroupLocal → getOrOpenCachedDbMode
  → drainResolverBackfill → runUntilIdle → PromotionRuntime.catchUp → lockMutex   (blocked ≥30s)
```

`getOrOpenCachedDbModeAtGeneration` unconditionally ran `db.drainResolverBackfill()` after every cache-layer open — including `.default_async` opens on the raft apply thread (the inner `DB.open` even passes `drain_resolver_backfill = false`, but the cache layer drained anyway). The drain runs promotion catch-up, whose cross-shard entity upserts need raft applies that are queued behind this very open. Result: the raft loop blocks, every group's applies stall, batch writes time out cluster-wide, and nothing is logged (pure in-memory waits). This matches all three observed e2e failure modes (doc:b insert timeout, create_table timeout, "entities were not promoted").

**Fix:** skip the synchronous drain for `.default_async` opens. The promotion/resolution workers started by the open drain the same backlog asynchronously.

## Spin-lock starvation (full-default: "runner lost communication")

Two helpers spin with no yield (`while (!tryLock()) spinLoopHint()`): `data.runtime.lockAtomic` and `api.table_writes.lockAtomic`. The dumps show waiters (e.g. `waitForLocalRaftBatchApply` behind the wedged raft loop) pinning a core each. On CPU-quota'd ARC pods this starves the lock holder — and the runner agent, which stops heartbeating; GitHub declares the runner lost after ~10 min, which is how most `full-default` failures present (death consistently ~1s into an in-process cluster sim test, runner silent exactly 10 minutes before the job dies). Both now bounded-spin then `Thread.yield()`, with the freestanding comptime guard used elsewhere (`clock.zig`). ~28 more pure-spin sites exist across the tree — worth a shared helper as follow-up.

Additional `full-default` hardening: heavy zig steps run under `taskset -c 0-7`, bounding both `zig build` parallelism and `getCpuCount()`-derived thread pools inside the cluster sims (sized from node-visible cores, not pod quota).

## CI diagnosability (how this stays fixed)

- `MultiNodeScalingCluster.native_stack_dumps()` — gdb `thread apply all bt` for every node process, attached to batch-insert and promotion-timeout failures in `test_resolution` (gdb added to workflow deps). The next silent wedge arrives with stacks in the CI failure output; this is how this PR's deadlock was found.
- `ANTFLY_FS_PATH_DEBUG` no longer defaults on in the e2e script: ~8k lines/s/node of path-component logging slowed servers and made the captured failure tails pure noise (every prior CI dump of this hang was undiagnosable because of it). Failure log tails raised 20KB → 200KB.

## Validation

- Container repro (4 CPUs, Linux, Debug, CI-like env): failed within 2 iterations before the fix, both failure modes; **19/20 after** even with fs-path logging still enabled, and the remaining failure's stack dumps show no lock wedge (pure resource saturation at 4 CPUs: all nodes mid-compaction/encoding). One residual finding for follow-up: `status_only` opens hold `local_db_mutex` across a full DB open, queueing lookups behind status refresh on slow machines.
- Native: `zig build integration-test` 55/55; lifecycle + resolution e2e green.
- The wasm target fails to build on main for pre-existing reasons (`mem_backend.zig` `Thread.yield`, 64-bit atomics in `promotion_runtime.zig`) — untouched by this PR.