### PR TITLE
Clean up Antfarm connections rendering

### DIFF
--- a/ts/apps/antfarm/src/components/ConnectedProvidersSummary.tsx
+++ b/ts/apps/antfarm/src/components/ConnectedProvidersSummary.tsx
@@ -44,7 +44,7 @@ export function ConnectedProvidersSummary() {
         const count = modelCount(connection);
         return (
           <button
-            key={connection.name}
+            key={connection.id}
             type="button"
             onClick={() => navigate("/connections")}
             title={`${providerTypeLabel(connection.inference?.provider ?? "")}${

--- a/ts/apps/antfarm/src/components/playground/GeneratorSelector.tsx
+++ b/ts/apps/antfarm/src/components/playground/GeneratorSelector.tsx
@@ -155,10 +155,11 @@ export function GeneratorSelector({
       return;
     }
     const nextProvider = provider as GeneratorProvider;
+    const liveDefault = liveGenerators[nextProvider]?.[0];
     onChange({
       ...value,
       provider: nextProvider,
-      model: GENERATOR_PROVIDER_DEFAULTS[nextProvider] || value.model,
+      model: liveDefault || GENERATOR_PROVIDER_DEFAULTS[nextProvider] || value.model,
     });
   };
 

--- a/ts/apps/antfarm/src/hooks/use-connections.ts
+++ b/ts/apps/antfarm/src/hooks/use-connections.ts
@@ -91,6 +91,7 @@ function useConnectionsInternal(includeModels: boolean): ConnectionsState {
       setConnections(fromCache.connections);
       setSupported(fromCache.supported);
       setLoading(false);
+      setError(null);
       return () => {
         isMountedRef.current = false;
       };

--- a/ts/apps/antfarm/src/pages/ConnectionsPage.tsx
+++ b/ts/apps/antfarm/src/pages/ConnectionsPage.tsx
@@ -20,6 +20,7 @@ import {
   HardDrive,
   RefreshCw,
 } from "lucide-react";
+import type { ComponentType } from "react";
 import { useState } from "react";
 import { AntyEmptyState, ErrorState } from "@/components/branded-empty-state";
 import {
@@ -68,7 +69,7 @@ function ModelGroup({
   models,
 }: {
   label: string;
-  icon: React.ComponentType<{ className?: string }>;
+  icon: ComponentType<{ className?: string }>;
   models: ConnectedModel[];
 }) {
   const [open, setOpen] = useState(false);
@@ -520,7 +521,7 @@ export default function ConnectionsPage() {
               <MonoLabel className="mb-3 block">Inference providers</MonoLabel>
               <div className="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-4">
                 {providers.map((connection) => (
-                  <ProviderCard key={connection.name} connection={connection} />
+                  <ProviderCard key={connection.id} connection={connection} />
                 ))}
               </div>
             </section>
@@ -531,7 +532,7 @@ export default function ConnectionsPage() {
               <MonoLabel className="mb-3 block">Web search</MonoLabel>
               <div className="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-4">
                 {webSearchConnections.map((connection) => (
-                  <WebSearchCard key={connection.name} connection={connection} />
+                  <WebSearchCard key={connection.id} connection={connection} />
                 ))}
               </div>
             </section>
@@ -542,7 +543,7 @@ export default function ConnectionsPage() {
               <MonoLabel className="mb-3 block">External IO</MonoLabel>
               <div className="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-4">
                 {infrastructure.map((connection) => (
-                  <InfrastructureCard key={connection.name} connection={connection} />
+                  <InfrastructureCard key={connection.id} connection={connection} />
                 ))}
               </div>
             </section>
@@ -553,7 +554,7 @@ export default function ConnectionsPage() {
               <MonoLabel className="mb-3 block">CDC sources</MonoLabel>
               <div className="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-4">
                 {cdcConnections.map((connection) => (
-                  <CdcCard key={connection.name} connection={connection} />
+                  <CdcCard key={connection.id} connection={connection} />
                 ))}
               </div>
             </section>


### PR DESCRIPTION
## Summary

- Use stable `connection.id` keys for Antfarm connection lists and provider summaries.
- Import `ComponentType` explicitly on the Connections page instead of relying on the `React` namespace.
- Prefer the live model-list default when switching generator providers after `/connections?include=models` suggestions have loaded.
- Clear stale hook errors when `useConnectionsInternal` restores a cached result for a changed endpoint/expansion key.

## Why

This is a small cleanup on top of the connections UI work from antflydb/antfly#228. The API exposes `id` as the stable resource identifier, so React list keys should use that field rather than the human-readable `name`. The generator selector should also use the live model inventory it already fetched instead of falling back to static defaults when changing providers. The hook cache path should restore the full successful state, including clearing any previous fetch error.

## Validation

- `node_modules/.bin/biome check apps/antfarm/src/pages/ConnectionsPage.tsx apps/antfarm/src/components/ConnectedProvidersSummary.tsx apps/antfarm/src/components/playground/GeneratorSelector.tsx apps/antfarm/src/hooks/use-connections.ts apps/antfarm/src/hooks/use-connections.test.ts`

Note: the local Vitest binary is not present in this checkout, and a direct raw `tsc -b apps/antfarm/tsconfig.json` invocation is noisy because workspace package links/types are not resolved in this local install.