### PR TITLE
Recover malformed PDF content parsing

### DIFF
--- a/zig/lib/pdf/src/reader.zig
+++ b/zig/lib/pdf/src/reader.zig
@@ -787,7 +787,10 @@ fn extractTextRunsFromContentAppendWithState(
     var current_clip_fill_rule: FillRule = initial_clip_fill_rule;
     try current_clip_points.appendSlice(alloc, initial_clip_points);
     while (true) {
-        var lex = try scanner.readLexeme();
+        var lex = (try readContentLexeme(&scanner)) orelse {
+            clearContentOperands(alloc, &operands);
+            continue;
+        };
         defer syntax.Scanner.freeLexeme(alloc, &lex);
 
         if (lex == .eof) break;
@@ -799,7 +802,12 @@ fn extractTextRunsFromContentAppendWithState(
         }
 
         try scanner.unreadLexeme(try cloneLexemeForContent(alloc, lex));
-        try operands.append(alloc, try scanner.readObject());
+        const maybe_obj = try readContentObject(&scanner);
+        if (maybe_obj) |obj| {
+            try operands.append(alloc, obj);
+        } else {
+            clearContentOperands(alloc, &operands);
+        }
     }
 }
 
@@ -853,7 +861,10 @@ fn extractImageRunsFromContentAppendWithState(
     try current_clip_points.appendSlice(alloc, initial_clip_points);
 
     while (true) {
-        var lex = try scanner.readLexeme();
+        var lex = (try readContentLexeme(&scanner)) orelse {
+            clearContentOperands(alloc, &operands);
+            continue;
+        };
         defer syntax.Scanner.freeLexeme(alloc, &lex);
 
         if (lex == .eof) break;
@@ -865,7 +876,12 @@ fn extractImageRunsFromContentAppendWithState(
         }
 
         try scanner.unreadLexeme(try cloneLexemeForContent(alloc, lex));
-        try operands.append(alloc, try scanner.readObject());
+        const maybe_obj = try readContentObject(&scanner);
+        if (maybe_obj) |obj| {
+            try operands.append(alloc, obj);
+        } else {
+            clearContentOperands(alloc, &operands);
+        }
     }
 }
 
@@ -944,7 +960,10 @@ fn extractShadingRunsFromContentAppendWithState(
     try current_clip_points.appendSlice(alloc, initial_clip_points);
 
     while (true) {
-        var lex = try scanner.readLexeme();
+        var lex = (try readContentLexeme(&scanner)) orelse {
+            clearContentOperands(alloc, &operands);
+            continue;
+        };
         defer syntax.Scanner.freeLexeme(alloc, &lex);
 
         if (lex == .eof) break;
@@ -956,7 +975,12 @@ fn extractShadingRunsFromContentAppendWithState(
         }
 
         try scanner.unreadLexeme(try cloneLexemeForContent(alloc, lex));
-        try operands.append(alloc, try scanner.readObject());
+        const maybe_obj = try readContentObject(&scanner);
+        if (maybe_obj) |obj| {
+            try operands.append(alloc, obj);
+        } else {
+            clearContentOperands(alloc, &operands);
+        }
     }
 }
 
@@ -1003,7 +1027,10 @@ fn extractPatternRunsFromContentAppendWithState(
     try current_clip_points.appendSlice(alloc, initial_clip_points);
 
     while (true) {
-        var lex = try scanner.readLexeme();
+        var lex = (try readContentLexeme(&scanner)) orelse {
+            clearContentOperands(alloc, &operands);
+            continue;
+        };
         defer syntax.Scanner.freeLexeme(alloc, &lex);
 
         if (lex == .eof) break;
@@ -1015,7 +1042,12 @@ fn extractPatternRunsFromContentAppendWithState(
         }
 
         try scanner.unreadLexeme(try cloneLexemeForContent(alloc, lex));
-        try operands.append(alloc, try scanner.readObject());
+        const maybe_obj = try readContentObject(&scanner);
+        if (maybe_obj) |obj| {
+            try operands.append(alloc, obj);
+        } else {
+            clearContentOperands(alloc, &operands);
+        }
     }
 }
 
@@ -1061,7 +1093,10 @@ fn extractShapeRunsFromContentAppendWithState(
     try current_clip_points.appendSlice(alloc, initial_clip_points);
 
     while (true) {
-        var lex = try scanner.readLexeme();
+        var lex = (try readContentLexeme(&scanner)) orelse {
+            clearContentOperands(alloc, &operands);
+            continue;
+        };
         defer syntax.Scanner.freeLexeme(alloc, &lex);
 
         if (lex == .eof) break;
@@ -1073,7 +1108,12 @@ fn extractShapeRunsFromContentAppendWithState(
         }
 
         try scanner.unreadLexeme(try cloneLexemeForContent(alloc, lex));
-        try operands.append(alloc, try scanner.readObject());
+        const maybe_obj = try readContentObject(&scanner);
+        if (maybe_obj) |obj| {
+            try operands.append(alloc, obj);
+        } else {
+            clearContentOperands(alloc, &operands);
+        }
     }
 }
 
@@ -5186,7 +5226,10 @@ fn extractTextFromContentAlloc(alloc: Allocator, bytes: []const u8, fonts: []con
     var state = TextExtractionState{};
 
     while (true) {
-        var lex = try scanner.readLexeme();
+        var lex = (try readContentLexeme(&scanner)) orelse {
+            clearContentOperands(alloc, &operands);
+            continue;
+        };
         defer syntax.Scanner.freeLexeme(alloc, &lex);
 
         if (lex == .eof) break;
@@ -5198,10 +5241,49 @@ fn extractTextFromContentAlloc(alloc: Allocator, bytes: []const u8, fonts: []con
         }
 
         try scanner.unreadLexeme(try cloneLexemeForContent(alloc, lex));
-        try operands.append(alloc, try scanner.readObject());
+        const maybe_obj = try readContentObject(&scanner);
+        if (maybe_obj) |obj| {
+            try operands.append(alloc, obj);
+        } else {
+            clearContentOperands(alloc, &operands);
+        }
     }
 
     return try out.toOwnedSlice(alloc);
+}
+
+fn readContentLexeme(scanner: *syntax.Scanner) anyerror!?syntax.Lexeme {
+    return scanner.readLexeme() catch |err| {
+        if (isRecoverableContentSyntaxError(err)) return null;
+        return err;
+    };
+}
+
+fn readContentObject(scanner: *syntax.Scanner) anyerror!?syntax.Object {
+    return scanner.readObject() catch |err| {
+        if (isRecoverableContentSyntaxError(err)) return null;
+        return err;
+    };
+}
+
+fn clearContentOperands(alloc: Allocator, operands: *std.ArrayList(syntax.Object)) void {
+    for (operands.items) |*obj| obj.deinit(alloc);
+    operands.clearRetainingCapacity();
+}
+
+fn isRecoverableContentSyntaxError(err: anyerror) bool {
+    return switch (err) {
+        error.UnexpectedDelimiter,
+        error.MalformedHexString,
+        error.MalformedName,
+        error.InvalidEscapeSequence,
+        error.InvalidOctalEscape,
+        error.UnexpectedKeyword,
+        error.UnexpectedDictKey,
+        error.UnexpectedEof,
+        => true,
+        else => false,
+    };
 }
 
 fn cloneLexemeForContent(alloc: Allocator, lex: syntax.Lexeme) !syntax.Lexeme {

--- a/zig/lib/pdf/src/syntax.zig
+++ b/zig/lib/pdf/src/syntax.zig
@@ -284,6 +284,9 @@ pub const Scanner = struct {
     fn readArray(self: *Scanner) anyerror!Object {
         var items = std.ArrayList(Object).empty;
         defer items.deinit(self.alloc);
+        errdefer {
+            for (items.items) |*item| item.deinit(self.alloc);
+        }
 
         while (true) {
             var tok = try self.readToken();
@@ -291,10 +294,15 @@ pub const Scanner = struct {
             if (tok == .eof) return error.UnexpectedEof;
             if (tok == .keyword and std.mem.eql(u8, tok.keyword, "]")) break;
             try self.unreadToken(try cloneToken(self.alloc, tok));
-            try items.append(self.alloc, try self.readObject());
+            var item = try self.readObject();
+            errdefer item.deinit(self.alloc);
+            try items.append(self.alloc, item);
+            item = .null;
         }
 
-        return .{ .array = try items.toOwnedSlice(self.alloc) };
+        const owned = try items.toOwnedSlice(self.alloc);
+        items = .empty;
+        return .{ .array = owned };
     }
 
     fn readDictOrStream(self: *Scanner) anyerror!Object {
@@ -788,7 +796,7 @@ test "scanner returns unterminated hex string prefix" {
     var tok = try scanner.readLexeme();
     defer tok.deinit(alloc);
     try std.testing.expect(tok == .string);
-    try std.testing.expectEqualSlices(u8, &.{ 0xAB }, tok.string);
+    try std.testing.expectEqualSlices(u8, &.{0xAB}, tok.string);
 }
 
 test "scanner terminates malformed hex strings with decoded prefix" {
@@ -799,7 +807,7 @@ test "scanner terminates malformed hex strings with decoded prefix" {
     var tok = try scanner.readLexeme();
     defer tok.deinit(alloc);
     try std.testing.expect(tok == .string);
-    try std.testing.expectEqualSlices(u8, &.{ 0xAB }, tok.string);
+    try std.testing.expectEqualSlices(u8, &.{0xAB}, tok.string);
 }
 
 test "scanner accepts odd-length hex strings" {
@@ -838,6 +846,14 @@ test "scanner tokenizes standalone closing delimiters" {
         try std.testing.expect(tok == .keyword);
         try std.testing.expectEqualStrings(">>", tok.keyword);
     }
+}
+
+test "scanner cleans partial array objects on parse error" {
+    const alloc = std.testing.allocator;
+    var scanner = Scanner.init(alloc, "[(abc");
+    defer scanner.deinit();
+
+    try std.testing.expectError(error.UnexpectedEof, scanner.readObject());
 }
 
 test "scanner tokenizes strings names and numbers" {

--- a/zig/lib/pdf/src/syntax.zig
+++ b/zig/lib/pdf/src/syntax.zig
@@ -395,10 +395,11 @@ pub const Scanner = struct {
                         return .{ .keyword = try self.alloc.dupe(u8, "<<") };
                     }
                 }
+                if (!self.nextStartsHexString()) return .{ .keyword = try self.alloc.dupe(u8, "<") };
                 return .{ .string = try self.readHexString() };
             },
             '(' => return .{ .string = try self.readLiteralString() },
-            '[', ']', '{', '}' => {
+            '[', ']', '{', '}', ')' => {
                 var buf: [1]u8 = .{c};
                 return .{ .keyword = try self.alloc.dupe(u8, &buf) };
             },
@@ -410,7 +411,7 @@ pub const Scanner = struct {
                         return .{ .keyword = try self.alloc.dupe(u8, ">>") };
                     }
                 }
-                return error.UnexpectedDelimiter;
+                return .{ .keyword = try self.alloc.dupe(u8, ">") };
             },
             else => {
                 if (isDelim(c)) return error.UnexpectedDelimiter;
@@ -439,17 +440,33 @@ pub const Scanner = struct {
         }
     }
 
+    fn nextStartsHexString(self: *const Scanner) bool {
+        var i = self.pos;
+        while (i < self.bytes.len and isSpace(self.bytes[i])) : (i += 1) {}
+        if (i >= self.bytes.len) return false;
+        return self.bytes[i] == '>' or unhex(self.bytes[i]) != null;
+    }
+
     fn readHexString(self: *Scanner) anyerror![]u8 {
         var out = std.ArrayList(u8).empty;
         defer out.deinit(self.alloc);
 
         while (true) {
-            const c = self.readSkippingSpace() orelse return error.UnexpectedEof;
+            const c = self.readSkippingSpace() orelse break;
             if (c == '>') break;
-            const c2 = self.readSkippingSpace() orelse return error.UnexpectedEof;
-            if (c2 == '>') return error.MalformedHexString;
-            const hi = unhex(c) orelse return error.MalformedHexString;
-            const lo = unhex(c2) orelse return error.MalformedHexString;
+            const hi = unhex(c) orelse break;
+            const c2 = self.readSkippingSpace() orelse {
+                try out.append(self.alloc, hi << 4);
+                break;
+            };
+            if (c2 == '>') {
+                try out.append(self.alloc, hi << 4);
+                break;
+            }
+            const lo = unhex(c2) orelse {
+                try out.append(self.alloc, hi << 4);
+                break;
+            };
             try out.append(self.alloc, (hi << 4) | lo);
         }
         return try out.toOwnedSlice(self.alloc);
@@ -499,14 +516,13 @@ pub const Scanner = struct {
                             if (x > 255) return error.InvalidOctalEscape;
                             try out.append(self.alloc, @intCast(x));
                         },
-                        else => return error.InvalidEscapeSequence,
+                        else => try out.append(self.alloc, escaped),
                     }
                 },
                 else => try out.append(self.alloc, c),
             }
         }
 
-        if (depth != 0) return error.UnexpectedEof;
         return try out.toOwnedSlice(self.alloc);
     }
 
@@ -521,10 +537,27 @@ pub const Scanner = struct {
                 break;
             }
             if (c == '#') {
-                const hi_c = self.readByte() orelse return error.MalformedName;
-                const lo_c = self.readByte() orelse return error.MalformedName;
-                const hi = unhex(hi_c) orelse return error.MalformedName;
-                const lo = unhex(lo_c) orelse return error.MalformedName;
+                const hi_c = self.readByte() orelse {
+                    try out.append(self.alloc, '#');
+                    break;
+                };
+                const lo_c = self.readByte() orelse {
+                    try out.append(self.alloc, '#');
+                    try out.append(self.alloc, hi_c);
+                    break;
+                };
+                const hi = unhex(hi_c) orelse {
+                    try out.append(self.alloc, '#');
+                    try out.append(self.alloc, hi_c);
+                    try out.append(self.alloc, lo_c);
+                    continue;
+                };
+                const lo = unhex(lo_c) orelse {
+                    try out.append(self.alloc, '#');
+                    try out.append(self.alloc, hi_c);
+                    try out.append(self.alloc, lo_c);
+                    continue;
+                };
                 try out.append(self.alloc, (hi << 4) | lo);
                 continue;
             }
@@ -692,6 +725,119 @@ fn isReal(s: []const u8) bool {
         if (!std.ascii.isDigit(c)) return false;
     }
     return dots == 1;
+}
+
+test "scanner returns unterminated literal string prefix" {
+    const alloc = std.testing.allocator;
+    var scanner = Scanner.init(alloc, "(abc");
+    defer scanner.deinit();
+
+    var tok = try scanner.readLexeme();
+    defer tok.deinit(alloc);
+    try std.testing.expect(tok == .string);
+    try std.testing.expectEqualStrings("abc", tok.string);
+}
+
+test "scanner preserves unknown literal string escapes" {
+    const alloc = std.testing.allocator;
+    var scanner = Scanner.init(alloc, "(a\\qb)");
+    defer scanner.deinit();
+
+    var tok = try scanner.readLexeme();
+    defer tok.deinit(alloc);
+    try std.testing.expect(tok == .string);
+    try std.testing.expectEqualStrings("aqb", tok.string);
+}
+
+test "scanner keeps malformed name escapes literal" {
+    const alloc = std.testing.allocator;
+    var scanner = Scanner.init(alloc, "/A#6$B /C#");
+    defer scanner.deinit();
+
+    {
+        var tok = try scanner.readLexeme();
+        defer tok.deinit(alloc);
+        try std.testing.expect(tok == .name);
+        try std.testing.expectEqualStrings("A#6$B", tok.name);
+    }
+
+    {
+        var tok = try scanner.readLexeme();
+        defer tok.deinit(alloc);
+        try std.testing.expect(tok == .name);
+        try std.testing.expectEqualStrings("C#", tok.name);
+    }
+}
+
+test "scanner treats non-hex less-than as keyword" {
+    const alloc = std.testing.allocator;
+    var scanner = Scanner.init(alloc, "<K");
+    defer scanner.deinit();
+
+    var tok = try scanner.readLexeme();
+    defer tok.deinit(alloc);
+    try std.testing.expect(tok == .keyword);
+    try std.testing.expectEqualStrings("<", tok.keyword);
+}
+
+test "scanner returns unterminated hex string prefix" {
+    const alloc = std.testing.allocator;
+    var scanner = Scanner.init(alloc, "<AB");
+    defer scanner.deinit();
+
+    var tok = try scanner.readLexeme();
+    defer tok.deinit(alloc);
+    try std.testing.expect(tok == .string);
+    try std.testing.expectEqualSlices(u8, &.{ 0xAB }, tok.string);
+}
+
+test "scanner terminates malformed hex strings with decoded prefix" {
+    const alloc = std.testing.allocator;
+    var scanner = Scanner.init(alloc, "<ABZ>");
+    defer scanner.deinit();
+
+    var tok = try scanner.readLexeme();
+    defer tok.deinit(alloc);
+    try std.testing.expect(tok == .string);
+    try std.testing.expectEqualSlices(u8, &.{ 0xAB }, tok.string);
+}
+
+test "scanner accepts odd-length hex strings" {
+    const alloc = std.testing.allocator;
+    var scanner = Scanner.init(alloc, "<ABC>");
+    defer scanner.deinit();
+
+    var tok = try scanner.readLexeme();
+    defer tok.deinit(alloc);
+    try std.testing.expect(tok == .string);
+    try std.testing.expectEqualSlices(u8, &.{ 0xAB, 0xC0 }, tok.string);
+}
+
+test "scanner tokenizes standalone closing delimiters" {
+    const alloc = std.testing.allocator;
+    var scanner = Scanner.init(alloc, ") > >>");
+    defer scanner.deinit();
+
+    {
+        var tok = try scanner.readLexeme();
+        defer tok.deinit(alloc);
+        try std.testing.expect(tok == .keyword);
+        try std.testing.expectEqualStrings(")", tok.keyword);
+    }
+
+    {
+        var tok = try scanner.readLexeme();
+        defer tok.deinit(alloc);
+        try std.testing.expect(tok == .keyword);
+        try std.testing.expectEqualStrings(">", tok.keyword);
+    }
+
+    {
+        var tok = try scanner.readLexeme();
+        defer tok.deinit(alloc);
+        try std.testing.expect(tok == .keyword);
+        try std.testing.expectEqualStrings(">>", tok.keyword);
+    }
 }
 
 test "scanner tokenizes strings names and numbers" {


### PR DESCRIPTION
## Summary

- Tolerate malformed PDF content streams during native PDF extraction/render parsing.
- Keep malformed scanner tokens recoverable without aborting content stream extraction.
- Fix partial array cleanup on parse errors so recovered malformed arrays do not leak owned objects.

## Validation

- `zig test zig/lib/pdf/src/syntax.zig`
- `zig build root-test`

## Notes

The branch is based on an older merge base and may need a rebase before merge.