### PR TITLE
Fix document extraction failure recovery

### DIFF
--- a/zig/build.zig
+++ b/zig/build.zig
@@ -4378,6 +4378,7 @@ pub fn build(b: *std.Build) void {
     db_test_mod.addImport("antfly_pdf", pdf_mod);
     db_test_mod.addImport("antfly_image", image_mod);
     db_test_mod.addImport("antfly_font", font_mod);
+    db_test_mod.addImport("structlog", structlog_mod);
 
     const db_split_sim_default_filters = [_][]const u8{
         "db split sim default workload stays green",
@@ -4471,6 +4472,10 @@ pub fn build(b: *std.Build) void {
             "dirty runtime status refresh finishes expired auto bulk before collecting leases",
             "managed startup catch-up ignores stale dirty bit after writer cache entry is gone",
             "provisioned table write source deinit drains restore repair jobs",
+        },
+        .test_runner = .{
+            .path = b.path("pkg/antfly/src/test_runner.zig"),
+            .mode = .simple,
         },
     });
     const run_provisioned_query_visibility_tests = b.addRunArtifact(provisioned_query_visibility_tests);

--- a/zig/build.zig
+++ b/zig/build.zig
@@ -4419,6 +4419,10 @@ pub fn build(b: *std.Build) void {
 
     const db_unit_tests = b.addTest(.{
         .root_module = db_test_mod,
+        .test_runner = .{
+            .path = b.path("pkg/antfly/src/test_runner.zig"),
+            .mode = .simple,
+        },
     });
     const run_db_unit_tests = b.addRunArtifact(db_unit_tests);
     const db_test_step = b.step("db-test", "Run storage/db unit tests");

--- a/zig/build.zig
+++ b/zig/build.zig
@@ -2265,6 +2265,10 @@ pub fn build(b: *std.Build) void {
             "artifact reprocess job store recovers durable jobs and reseeds ids",
             "artifact reprocess job cleanup removes recovered durable expired jobs",
         },
+        .test_runner = .{
+            .path = b.path("pkg/antfly/src/test_runner.zig"),
+            .mode = .simple,
+        },
     });
     const run_api_artifact_reprocess_jobs_tests = b.addRunArtifact(api_artifact_reprocess_jobs_tests);
     const lib_api_artifact_reprocess_jobs_test_step = b.step("lib-api-artifact-reprocess-jobs-test", "Run artifact reprocess job store tests");
@@ -4036,6 +4040,10 @@ pub fn build(b: *std.Build) void {
             "parse cli accepts inference budget overrides",
             "inference config falls back to common config",
             "swarm runtime resolves paths from common storage base dir",
+        },
+        .test_runner = .{
+            .path = b.path("pkg/antfly/src/test_runner.zig"),
+            .mode = .simple,
         },
     });
     const lib_swarm_runtime_test_step = b.step("lib-swarm-runtime-test", "Run focused swarm runtime tests");
@@ -6183,6 +6191,10 @@ pub fn build(b: *std.Build) void {
     });
     const antfly_main_tests = b.addTest(.{
         .root_module = antfly_main_mod,
+        .test_runner = .{
+            .path = b.path("pkg/antfly/src/test_runner.zig"),
+            .mode = .simple,
+        },
     });
     const run_antfly_main_tests = b.addRunArtifact(antfly_main_tests);
     const antfly_main_test_step = b.step("antfly-main-test", "Run top-level Antfly CLI tests");

--- a/zig/build.zig
+++ b/zig/build.zig
@@ -2604,6 +2604,10 @@ pub fn build(b: *std.Build) void {
     const lib_common_config_tests = b.addTest(.{
         .root_module = lib_test_mod,
         .filters = &.{"common config"},
+        .test_runner = .{
+            .path = b.path("pkg/antfly/src/test_runner.zig"),
+            .mode = .simple,
+        },
     });
     const run_lib_common_config_tests = b.addRunArtifact(lib_common_config_tests);
     const lib_common_config_test_step = b.step("lib-common-config-test", "Run common/config tests");
@@ -3850,6 +3854,10 @@ pub fn build(b: *std.Build) void {
             "hbc cache shrinks to resource budget under pressure",
             "provisioned group storage derives all resource budgets",
         },
+        .test_runner = .{
+            .path = b.path("pkg/antfly/src/test_runner.zig"),
+            .mode = .simple,
+        },
     });
     const run_resource_budget_tests = b.addRunArtifact(resource_budget_tests);
     const resource_budget_test_step = b.step("resource-budget-test", "Run storage resource-manager accounting tests");
@@ -4175,8 +4183,13 @@ pub fn build(b: *std.Build) void {
 
     const wal_test_mod = makeLmdbModule(b, "pkg/antfly/src/wal_test_root.zig", target, optimize, build_options, lmdb_engine_mod, platform_mod);
     wal_test_mod.addImport("bloom", bloom_mod);
+    wal_test_mod.addImport("structlog", structlog_mod);
     const wal_unit_tests = b.addTest(.{
         .root_module = wal_test_mod,
+        .test_runner = .{
+            .path = b.path("pkg/antfly/src/test_runner.zig"),
+            .mode = .simple,
+        },
     });
     const run_wal_unit_tests = b.addRunArtifact(wal_unit_tests);
 
@@ -4242,8 +4255,13 @@ pub fn build(b: *std.Build) void {
     persistent_test_mod.addImport("antfly_vector", vector_mod);
     persistent_test_mod.addImport("antfly_vectorindex", vectorindex_mod);
     persistent_test_mod.addImport("antfly_reranking", reranking_mod);
+    persistent_test_mod.addImport("structlog", structlog_mod);
     const persistent_unit_tests = b.addTest(.{
         .root_module = persistent_test_mod,
+        .test_runner = .{
+            .path = b.path("pkg/antfly/src/test_runner.zig"),
+            .mode = .simple,
+        },
     });
     const run_persistent_unit_tests = b.addRunArtifact(persistent_unit_tests);
 
@@ -4307,9 +4325,14 @@ pub fn build(b: *std.Build) void {
     index_manager_test_mod.addImport("antfly_resolver", resolver_mod);
     index_manager_test_mod.addImport("antfly_chunking", chunking_mod);
     index_manager_test_mod.addImport("antfly_regex", regex_mod);
+    index_manager_test_mod.addImport("structlog", structlog_mod);
     const index_manager_unit_tests = b.addTest(.{
         .root_module = index_manager_test_mod,
         .filters = selectTestFilters(b, &.{}),
+        .test_runner = .{
+            .path = b.path("pkg/antfly/src/test_runner.zig"),
+            .mode = .simple,
+        },
     });
     const run_index_manager_unit_tests = b.addRunArtifact(index_manager_unit_tests);
 

--- a/zig/build.zig
+++ b/zig/build.zig
@@ -2809,6 +2809,10 @@ pub fn build(b: *std.Build) void {
     const lib_db_tests = b.addTest(.{
         .root_module = lib_test_mod,
         .filters = selectTestFilters(b, &.{"storage.db.db.test."}),
+        .test_runner = .{
+            .path = b.path("pkg/antfly/src/test_runner.zig"),
+            .mode = .simple,
+        },
     });
     const run_lib_db_tests = b.addRunArtifact(lib_db_tests);
     const lib_db_test_step = b.step("lib-db-test", "Run root-module DB tests only");
@@ -3320,6 +3324,10 @@ pub fn build(b: *std.Build) void {
     const public_api_parity_tests = b.addTest(.{
         .root_module = lib_test_mod,
         .filters = selectTestFilters(b, &public_api_parity_default_filters),
+        .test_runner = .{
+            .path = b.path("pkg/antfly/src/test_runner.zig"),
+            .mode = .simple,
+        },
     });
     const run_public_api_parity_tests = b.addRunArtifact(public_api_parity_tests);
     run_public_api_parity_tests.step.dependOn(&openapi_root_check.step);
@@ -3356,6 +3364,10 @@ pub fn build(b: *std.Build) void {
             "auth row filter validator rejects malformed auth node",
             "effective resolved row filter prefers table filter before wildcard",
             "artifact operations apply source document row filter visibility",
+        },
+        .test_runner = .{
+            .path = b.path("pkg/antfly/src/test_runner.zig"),
+            .mode = .simple,
         },
     });
     const run_lib_api_auth_tests = b.addRunArtifact(lib_api_auth_tests);

--- a/zig/pkg/antfly/src/api/indexes.zig
+++ b/zig/pkg/antfly/src/api/indexes.zig
@@ -410,11 +410,42 @@ fn appendIndexConfig(
         try out.append(alloc, ',');
         try appendJsonString(alloc, out, entry.key_ptr.*);
         try out.append(alloc, ':');
-        const encoded = try std.fmt.allocPrint(alloc, "{f}", .{std.json.fmt(entry.value_ptr.*, .{})});
-        defer alloc.free(encoded);
-        try out.appendSlice(alloc, encoded);
+        if (std.mem.eql(u8, entry.key_ptr.*, "enrichments")) {
+            try appendCanonicalIndexEnrichments(alloc, out, entry.value_ptr.*);
+        } else {
+            const encoded = try std.fmt.allocPrint(alloc, "{f}", .{std.json.fmt(entry.value_ptr.*, .{})});
+            defer alloc.free(encoded);
+            try out.appendSlice(alloc, encoded);
+        }
     }
     try out.append(alloc, '}');
+}
+
+fn appendCanonicalIndexEnrichments(
+    alloc: std.mem.Allocator,
+    out: *std.ArrayListUnmanaged(u8),
+    value: std.json.Value,
+) !void {
+    if (value != .array) {
+        const encoded = try std.fmt.allocPrint(alloc, "{f}", .{std.json.fmt(value, .{})});
+        defer alloc.free(encoded);
+        try out.appendSlice(alloc, encoded);
+        return;
+    }
+    try out.append(alloc, '[');
+    for (value.array.items, 0..) |item, i| {
+        if (i > 0) try out.append(alloc, ',');
+        switch (item) {
+            .string => |name| try appendJsonString(alloc, out, name),
+            .object => |object| {
+                const name = object.get("name") orelse return error.InvalidTableIndexMetadata;
+                if (name != .string) return error.InvalidTableIndexMetadata;
+                try appendJsonString(alloc, out, name.string);
+            },
+            else => return error.InvalidTableIndexMetadata,
+        }
+    }
+    try out.append(alloc, ']');
 }
 
 fn canonicalIndexConfigJson(
@@ -1866,6 +1897,30 @@ test "index config map encoder injects canonical name and type" {
     defer std.testing.allocator.free(encoded);
     try std.testing.expect(std.mem.indexOf(u8, encoded, "\"full_text_index_v0\":{\"name\":\"full_text_index_v0\",\"type\":\"full_text\"}") != null);
     try std.testing.expect(std.mem.indexOf(u8, encoded, "\"embed_idx\":{\"name\":\"embed_idx\",\"type\":\"embeddings\",\"dimension\":384}") != null);
+}
+
+test "index status encoder projects inline enrichment configs as names" {
+    const snapshot: metadata_api.AdminSnapshot = .{
+        .status = .{ .metadata_group_id = 1, .metrics = .{} },
+        .tables = @constCast((&[_]metadata_table_manager.TableRecord{.{
+            .table_id = 7,
+            .name = "docs",
+            .indexes_json =
+            \\{"document_text":{"type":"full_text","enrichments":[{"name":"document_units_v1","kind":"asset"},{"name":"document_chunks_v1","kind":"chunk"}]},"document_vectors":{"type":"embeddings","enrichments":[{"name":"document_chunk_dense_v1","kind":"embedding"}]}}
+            ,
+            .placement_role = "data",
+        }})[0..]),
+        .ranges = @constCast((&[_]metadata_table_manager.RangeRecord{})[0..]),
+        .stores = @constCast((&[_]metadata_table_manager.StoreRecord{})[0..]),
+        .placement_intents = @constCast((&[_]raft_reconciler.PlacementIntent{})[0..]),
+        .split_transitions = @constCast((&[_]metadata_transition_state.SplitTransitionRecord{})[0..]),
+        .merge_transitions = @constCast((&[_]metadata_transition_state.MergeTransitionRecord{})[0..]),
+    };
+
+    const encoded_list = (try encodeIndexList(std.testing.allocator, &snapshot, "docs", null)).?;
+    defer std.testing.allocator.free(encoded_list);
+    try std.testing.expect(std.mem.indexOf(u8, encoded_list, "\"enrichments\":[\"document_units_v1\",\"document_chunks_v1\"]") != null);
+    try std.testing.expect(std.mem.indexOf(u8, encoded_list, "\"enrichments\":[\"document_chunk_dense_v1\"]") != null);
 }
 
 test "single index config encoder isolates requested index" {

--- a/zig/pkg/antfly/src/api/tables.zig
+++ b/zig/pkg/antfly/src/api/tables.zig
@@ -412,7 +412,9 @@ pub fn encodeTableListWithStorageStatuses(
     var arena_impl = std.heap.ArenaAllocator.init(alloc);
     defer arena_impl.deinit();
     const listed = try buildTableListWithStorageStatuses(arena_impl.allocator(), snapshot, prefix, storage_statuses);
-    return try std.json.Stringify.valueAlloc(alloc, listed, .{ .emit_null_optional_fields = false });
+    const encoded = try std.json.Stringify.valueAlloc(alloc, listed, .{ .emit_null_optional_fields = false });
+    defer alloc.free(encoded);
+    return try projectInlineEnrichmentConfigsInTableStatusJson(alloc, encoded);
 }
 
 pub fn encodeSingleTableStatus(
@@ -432,7 +434,9 @@ pub fn encodeSingleTableStatusWithStorageStatuses(
     var arena_impl = std.heap.ArenaAllocator.init(alloc);
     defer arena_impl.deinit();
     const status = (try buildSingleTableStatusWithStorageStatuses(arena_impl.allocator(), snapshot, table_name, storage_statuses)) orelse return null;
-    return try std.json.Stringify.valueAlloc(alloc, status, .{ .emit_null_optional_fields = false });
+    const encoded = try std.json.Stringify.valueAlloc(alloc, status, .{ .emit_null_optional_fields = false });
+    defer alloc.free(encoded);
+    return try projectInlineEnrichmentConfigsInTableStatusJson(alloc, encoded);
 }
 
 pub fn buildTableListWithStorageStatuses(
@@ -1215,13 +1219,7 @@ fn appendCanonicalIndexConfig(
         try out.append(alloc, ',');
         try appendJsonString(alloc, out, entry.key_ptr.*);
         try out.append(alloc, ':');
-        const value = if (std.mem.eql(u8, entry.key_ptr.*, "enrichments"))
-            try canonicalIndexEnrichmentsValue(alloc, entry.value_ptr.*)
-        else
-            try cloneJsonValueAlloc(alloc, entry.value_ptr.*);
-        var owned_value = value;
-        defer deinitJsonValue(alloc, &owned_value);
-        const encoded = try stringifyJsonValue(alloc, owned_value);
+        const encoded = try stringifyJsonValue(alloc, entry.value_ptr.*);
         defer alloc.free(encoded);
         try out.appendSlice(alloc, encoded);
     }
@@ -1255,11 +1253,7 @@ fn buildCanonicalIndexConfigValue(
     var it = config.object.iterator();
     while (it.next()) |entry| {
         if (std.mem.eql(u8, entry.key_ptr.*, "name")) continue;
-        const value = if (std.mem.eql(u8, entry.key_ptr.*, "enrichments"))
-            try canonicalIndexEnrichmentsValue(alloc, entry.value_ptr.*)
-        else
-            try cloneJsonValueAlloc(alloc, entry.value_ptr.*);
-        try object.put(alloc, try alloc.dupe(u8, entry.key_ptr.*), value);
+        try object.put(alloc, try alloc.dupe(u8, entry.key_ptr.*), try cloneJsonValueAlloc(alloc, entry.value_ptr.*));
     }
     return .{ .object = object };
 }
@@ -1283,6 +1277,34 @@ fn canonicalIndexEnrichmentsValue(alloc: std.mem.Allocator, value: std.json.Valu
         }
     }
     return .{ .array = array };
+}
+
+fn projectInlineEnrichmentConfigsInTableStatusJson(alloc: std.mem.Allocator, encoded: []const u8) ![]u8 {
+    var parsed = try std.json.parseFromSlice(std.json.Value, alloc, encoded, .{});
+    defer parsed.deinit();
+    try projectInlineEnrichmentConfigsInTableStatusValue(alloc, &parsed.value);
+    return try std.json.Stringify.valueAlloc(alloc, parsed.value, .{ .emit_null_optional_fields = false });
+}
+
+fn projectInlineEnrichmentConfigsInTableStatusValue(alloc: std.mem.Allocator, value: *std.json.Value) !void {
+    switch (value.*) {
+        .array => |*array| {
+            for (array.items) |*item| try projectInlineEnrichmentConfigsInTableStatusValue(alloc, item);
+        },
+        .object => |*object| {
+            const indexes_value = object.getPtr("indexes") orelse return;
+            if (indexes_value.* != .object) return;
+            var index_it = indexes_value.object.iterator();
+            while (index_it.next()) |index_entry| {
+                if (index_entry.value_ptr.* != .object) continue;
+                const enrichments_value = index_entry.value_ptr.object.getPtr("enrichments") orelse continue;
+                const projected = try canonicalIndexEnrichmentsValue(alloc, enrichments_value.*);
+                deinitJsonValue(alloc, enrichments_value);
+                enrichments_value.* = projected;
+            }
+        },
+        else => {},
+    }
 }
 
 fn inferIndexType(index_name: []const u8, config: std.json.Value) ?ApiIndexType {

--- a/zig/pkg/antfly/src/api/tables.zig
+++ b/zig/pkg/antfly/src/api/tables.zig
@@ -1215,7 +1215,13 @@ fn appendCanonicalIndexConfig(
         try out.append(alloc, ',');
         try appendJsonString(alloc, out, entry.key_ptr.*);
         try out.append(alloc, ':');
-        const encoded = try stringifyJsonValue(alloc, entry.value_ptr.*);
+        const value = if (std.mem.eql(u8, entry.key_ptr.*, "enrichments"))
+            try canonicalIndexEnrichmentsValue(alloc, entry.value_ptr.*)
+        else
+            try cloneJsonValueAlloc(alloc, entry.value_ptr.*);
+        var owned_value = value;
+        defer deinitJsonValue(alloc, &owned_value);
+        const encoded = try stringifyJsonValue(alloc, owned_value);
         defer alloc.free(encoded);
         try out.appendSlice(alloc, encoded);
     }
@@ -1249,9 +1255,34 @@ fn buildCanonicalIndexConfigValue(
     var it = config.object.iterator();
     while (it.next()) |entry| {
         if (std.mem.eql(u8, entry.key_ptr.*, "name")) continue;
-        try object.put(alloc, try alloc.dupe(u8, entry.key_ptr.*), try cloneJsonValueAlloc(alloc, entry.value_ptr.*));
+        const value = if (std.mem.eql(u8, entry.key_ptr.*, "enrichments"))
+            try canonicalIndexEnrichmentsValue(alloc, entry.value_ptr.*)
+        else
+            try cloneJsonValueAlloc(alloc, entry.value_ptr.*);
+        try object.put(alloc, try alloc.dupe(u8, entry.key_ptr.*), value);
     }
     return .{ .object = object };
+}
+
+fn canonicalIndexEnrichmentsValue(alloc: std.mem.Allocator, value: std.json.Value) !std.json.Value {
+    if (value != .array) return try cloneJsonValueAlloc(alloc, value);
+    var array = std.json.Array.init(alloc);
+    errdefer {
+        var owned: std.json.Value = .{ .array = array };
+        deinitJsonValue(alloc, &owned);
+    }
+    for (value.array.items) |item| {
+        switch (item) {
+            .string => |name| try array.append(.{ .string = try alloc.dupe(u8, name) }),
+            .object => |object| {
+                const name = object.get("name") orelse return error.InvalidTableIndexMetadata;
+                if (name != .string) return error.InvalidTableIndexMetadata;
+                try array.append(.{ .string = try alloc.dupe(u8, name.string) });
+            },
+            else => return error.InvalidTableIndexMetadata,
+        }
+    }
+    return .{ .array = array };
 }
 
 fn inferIndexType(index_name: []const u8, config: std.json.Value) ?ApiIndexType {
@@ -2302,6 +2333,44 @@ test "metadata.table status encoder canonicalizes embeddings indexes without inl
     const encoded = (try encodeSingleTableStatus(std.testing.allocator, &snapshot, "docs")).?;
     defer std.testing.allocator.free(encoded);
     try std.testing.expect(std.mem.indexOf(u8, encoded, "\"semantic_kg\":{\"name\":\"semantic_kg\",\"type\":\"embeddings\"") != null);
+}
+
+test "metadata.table status encoder projects inline enrichment configs as names" {
+    const indexes_json =
+        \\{
+        \\  "document_text":{
+        \\    "type":"full_text",
+        \\    "artifact_name":"document_chunks_v1",
+        \\    "enrichments":[
+        \\      {"name":"document_units_v1","kind":"asset","field":"url","producer_json":"{\"type\":\"document_extraction\"}"},
+        \\      {"name":"document_chunks_v1","kind":"chunk","source_artifact_name":"document_units_v1","field":"text"}
+        \\    ]
+        \\  },
+        \\  "document_vectors":{
+        \\    "type":"embeddings",
+        \\    "field":"embedding",
+        \\    "dims":768,
+        \\    "metric":"cosine",
+        \\    "enrichments":[
+        \\      {"name":"document_chunk_dense_v1","kind":"embedding","source_artifact_name":"document_chunks_v1","field":"text"}
+        \\    ]
+        \\  }
+        \\}
+    ;
+    const snapshot: metadata_api.AdminSnapshot = .{
+        .status = .{ .metadata_group_id = 1, .metrics = .{} },
+        .tables = @constCast((&[_]metadata_table_manager.TableRecord{.{ .table_id = 7, .name = "docs", .indexes_json = indexes_json, .replication_sources_json = "[]", .placement_role = "data" }})[0..]),
+        .ranges = @constCast((&[_]metadata_table_manager.RangeRecord{.{ .group_id = 7001, .table_id = 7, .start_key = "", .end_key = null }})[0..]),
+        .stores = @constCast((&[_]metadata_table_manager.StoreRecord{})[0..]),
+        .placement_intents = @constCast((&[_]raft_reconciler.PlacementIntent{})[0..]),
+        .split_transitions = @constCast((&[_]metadata_transition_state.SplitTransitionRecord{})[0..]),
+        .merge_transitions = @constCast((&[_]metadata_transition_state.MergeTransitionRecord{})[0..]),
+    };
+
+    const encoded = (try encodeSingleTableStatus(std.testing.allocator, &snapshot, "docs")).?;
+    defer std.testing.allocator.free(encoded);
+    try std.testing.expect(std.mem.indexOf(u8, encoded, "\"enrichments\":[\"document_units_v1\",\"document_chunks_v1\"]") != null);
+    try std.testing.expect(std.mem.indexOf(u8, encoded, "\"enrichments\":[\"document_chunk_dense_v1\"]") != null);
 }
 
 test "metadata.table debug encoder emits runtime schemas and index bindings" {

--- a/zig/pkg/antfly/src/api/tables.zig
+++ b/zig/pkg/antfly/src/api/tables.zig
@@ -1282,8 +1282,10 @@ fn canonicalIndexEnrichmentsValue(alloc: std.mem.Allocator, value: std.json.Valu
 fn projectInlineEnrichmentConfigsInTableStatusJson(alloc: std.mem.Allocator, encoded: []const u8) ![]u8 {
     var parsed = try std.json.parseFromSlice(std.json.Value, alloc, encoded, .{});
     defer parsed.deinit();
-    try projectInlineEnrichmentConfigsInTableStatusValue(alloc, &parsed.value);
-    return try std.json.Stringify.valueAlloc(alloc, parsed.value, .{ .emit_null_optional_fields = false });
+    var owned = try cloneJsonValueAlloc(alloc, parsed.value);
+    defer deinitJsonValue(alloc, &owned);
+    try projectInlineEnrichmentConfigsInTableStatusValue(alloc, &owned);
+    return try std.json.Stringify.valueAlloc(alloc, owned, .{ .emit_null_optional_fields = false });
 }
 
 fn projectInlineEnrichmentConfigsInTableStatusValue(alloc: std.mem.Allocator, value: *std.json.Value) !void {

--- a/zig/pkg/antfly/src/metadata/table_provisioner.zig
+++ b/zig/pkg/antfly/src/metadata/table_provisioner.zig
@@ -549,8 +549,8 @@ fn collectDesiredEnrichments(
                             .allocate = .alloc_always,
                             .ignore_unknown_fields = true,
                         });
-                        errdefer parsed.deinit();
-                        try out.append(alloc, parsed.value);
+                        defer parsed.deinit();
+                        try out.append(alloc, try db_mod.types.EnrichmentConfig.clone(alloc, parsed.value));
                     }
                 }
             }
@@ -1114,6 +1114,57 @@ test "table provisioner registers a resolver declared in the table index config"
         std.testing.allocator.free(removed_resolvers);
     }
     try std.testing.expectEqual(@as(usize, 0), removed_resolvers.len);
+}
+
+test "table provisioner registers explicit document enrichments from index config" {
+    const alloc = std.heap.c_allocator;
+    const path = "/tmp/antfly-metadata-table-provisioner-enrichments";
+    var io_impl = std.Io.Threaded.init(alloc, .{});
+    defer io_impl.deinit();
+    std.Io.Dir.cwd().deleteTree(io_impl.io(), path) catch {};
+    defer std.Io.Dir.cwd().deleteTree(io_impl.io(), path) catch {};
+
+    const indexes_json =
+        \\{
+        \\  "document_text":{"type":"full_text","artifact_name":"document_chunks_v1","enrichments":[
+        \\    {"name":"document_units_v1","kind":"asset","field":"url","content_type":"application/json","producer_json":"{\"type\":\"document_extraction\",\"config\":{}}"},
+        \\    {"name":"document_chunks_v1","kind":"chunk","source_artifact_name":"document_units_v1","field":"text","chunk_size":512,"chunk_overlap":50}
+        \\  ]}
+        \\}
+    ;
+
+    const summary = try reconcileReplicaRoot(
+        alloc,
+        path,
+        100,
+        &.{ 100, 2001 },
+        &.{.{
+            .table_id = 11,
+            .name = "docs",
+            .indexes_json = indexes_json,
+        }},
+        &.{.{
+            .group_id = 2001,
+            .table_id = 11,
+            .start_key = "doc:a",
+            .end_key = "doc:z",
+        }},
+    );
+    try std.testing.expectEqual(@as(usize, 1), summary.dbs_opened);
+    try std.testing.expectEqual(@as(usize, 1), summary.indexes_added);
+    try std.testing.expectEqual(@as(usize, 2), summary.enrichments_added);
+
+    const db_path = try groupDbPathFromReplicaRoot(alloc, path, 2001);
+    defer alloc.free(db_path);
+    var db = try db_mod.DB.open(alloc, db_path, .{});
+    defer db.close();
+    const enrichments = try db.listEnrichments(alloc);
+    defer db_mod.types.freeEnrichmentConfigs(alloc, enrichments);
+    try std.testing.expectEqual(@as(usize, 2), enrichments.len);
+    try std.testing.expectEqualStrings("document_units_v1", enrichments[0].name);
+    try std.testing.expectEqual(.asset, enrichments[0].kind);
+    try std.testing.expectEqualStrings("document_chunks_v1", enrichments[1].name);
+    try std.testing.expectEqual(.chunk, enrichments[1].kind);
 }
 
 test "table provisioner restores local shard data from metadata restore intent" {

--- a/zig/pkg/antfly/src/storage/db/db.zig
+++ b/zig/pkg/antfly/src/storage/db/db.zig
@@ -19155,13 +19155,8 @@ fn applyDerivedBatchToIndexContextProfiled(ctx: *const AsyncContext, batch: deri
                 .compact_text_segment_threshold = null,
                 .defer_text_compaction = true,
             };
-            const delete_keys = if (batch.deleted_keys.len == 0)
-                batch.overwritten_doc_keys
-            else if (batch.overwritten_doc_keys.len == 0)
-                batch.deleted_keys
-            else
-                try collectCombinedDeleteKeys(ctx.alloc, batch.deleted_keys, batch.overwritten_doc_keys);
-            defer if (batch.deleted_keys.len > 0 and batch.overwritten_doc_keys.len > 0) ctx.alloc.free(delete_keys);
+            const delete_keys = try collectTextReplayDeleteKeys(ctx.alloc, batch);
+            defer if (delete_keys.len > 0) ctx.alloc.free(delete_keys);
 
             const missing_required = try applyTextDocumentsForIndex(
                 ctx.alloc,
@@ -19927,11 +19922,30 @@ fn collectDocumentWritesProfiled(
     };
 }
 
-fn collectCombinedDeleteKeys(alloc: Allocator, deleted_keys: []const []const u8, overwritten_doc_keys: []const []const u8) ![]const []const u8 {
-    const combined = try alloc.alloc([]const u8, deleted_keys.len + overwritten_doc_keys.len);
-    @memcpy(combined[0..deleted_keys.len], deleted_keys);
-    @memcpy(combined[deleted_keys.len..], overwritten_doc_keys);
-    return combined;
+fn appendUniqueBorrowedKey(
+    alloc: Allocator,
+    out: *std.ArrayListUnmanaged([]const u8),
+    key: []const u8,
+) !void {
+    if (key.len == 0) return;
+    for (out.items) |existing| {
+        if (std.mem.eql(u8, existing, key)) return;
+    }
+    try out.append(alloc, key);
+}
+
+fn collectTextReplayDeleteKeys(alloc: Allocator, batch: derived_types.DerivedBatch) ![]const []const u8 {
+    var keys = std.ArrayListUnmanaged([]const u8).empty;
+    errdefer keys.deinit(alloc);
+
+    for (batch.deleted_keys) |key| try appendUniqueBorrowedKey(alloc, &keys, key);
+    for (batch.overwritten_doc_keys) |key| try appendUniqueBorrowedKey(alloc, &keys, key);
+    for (batch.documents) |doc| {
+        if (doc.action != .upsert) continue;
+        try appendUniqueBorrowedKey(alloc, &keys, doc.key);
+    }
+
+    return try keys.toOwnedSlice(alloc);
 }
 
 fn denseEmbeddingDocKeySet(
@@ -37165,6 +37179,31 @@ test "collectDocumentWrites skips missing out-of-range replay docs" {
     try std.testing.expectEqual(@as(usize, 0), writes.missing_required);
     try std.testing.expectEqualStrings("doc:z", writes.items[0].key);
     try std.testing.expectEqualStrings("{\"title\":\"zeta\"}", writes.items[0].value);
+}
+
+test "text replay delete keys include upserted derived document keys" {
+    const alloc = std.testing.allocator;
+
+    const docs = [_]derived_types.DerivedDocument{
+        .{ .key = "chunk:1", .action = .upsert, .cleaned_value = "{\"text\":\"new\"}" },
+        .{ .key = "ignored", .action = .delete },
+        .{ .key = "chunk:1", .action = .upsert, .cleaned_value = "{\"text\":\"newer\"}" },
+    };
+    const deleted = [_][]const u8{"deleted:1"};
+    const overwritten = [_][]const u8{ "chunk:1", "overwritten:1" };
+    const batch = derived_types.DerivedBatch{
+        .documents = &docs,
+        .deleted_keys = &deleted,
+        .overwritten_doc_keys = &overwritten,
+    };
+
+    const keys = try collectTextReplayDeleteKeys(alloc, batch);
+    defer alloc.free(keys);
+
+    try std.testing.expectEqual(@as(usize, 3), keys.len);
+    try std.testing.expectEqualStrings("deleted:1", keys[0]);
+    try std.testing.expectEqualStrings("chunk:1", keys[1]);
+    try std.testing.expectEqualStrings("overwritten:1", keys[2]);
 }
 
 test "db replay respects per-index applied watermarks" {

--- a/zig/pkg/antfly/src/storage/db/enrichment/enrichment_runtime.zig
+++ b/zig/pkg/antfly/src/storage/db/enrichment/enrichment_runtime.zig
@@ -1785,16 +1785,33 @@ fn processDocumentExtractionAsset(
     var downloaded_mut = downloaded;
     defer downloaded_mut.deinit(runtime.alloc);
 
-    var extraction = try document_extraction_mod.extractDownloadedAlloc(runtime.alloc, downloaded_mut, source_url, config);
-    defer extraction.deinit(runtime.alloc);
-    try completeRuntimeDocumentExtractionGeneratedText(runtime, config, source_url, extraction.content_type, &extraction);
-
     const byte_source_fingerprint = if (metadata_fingerprint == null)
         try documentExtractionFingerprintAlloc(runtime.alloc, source_url, config_json, config.content_type, config.filename, downloaded_mut.content_type, downloaded_mut.data)
     else
         null;
     defer if (byte_source_fingerprint) |fingerprint| runtime.alloc.free(fingerprint);
     const source_fingerprint = metadata_fingerprint orelse byte_source_fingerprint.?;
+
+    var extraction = document_extraction_mod.extractDownloadedAlloc(runtime.alloc, downloaded_mut, source_url, config) catch |err| {
+        try writeDocumentExtractionFailureManifest(
+            runtime,
+            request.doc_key,
+            artifact_name,
+            source_url,
+            source_fingerprint,
+            if (config.content_type.len > 0) config.content_type else downloaded_mut.content_type,
+            @errorName(err),
+            manifest_key,
+            state_key,
+            previous_child_ranges,
+            existing_state,
+            from_generation,
+            window,
+        );
+        return;
+    };
+    defer extraction.deinit(runtime.alloc);
+    try completeRuntimeDocumentExtractionGeneratedText(runtime, config, source_url, extraction.content_type, &extraction);
 
     var desired_unit_keys = std.ArrayListUnmanaged([]const u8).empty;
     defer {
@@ -1888,6 +1905,7 @@ fn processDocumentExtractionAsset(
         from_generation,
         to_generation,
         "in_progress",
+        null,
     );
     defer runtime.alloc.free(in_progress_manifest);
     const in_progress_key = try runtime.alloc.dupe(u8, manifest_key);
@@ -1957,6 +1975,7 @@ fn processDocumentExtractionAsset(
         from_generation,
         to_generation,
         "converged",
+        null,
     );
     errdefer runtime.alloc.free(manifest);
     try writes.append(runtime.alloc, .{
@@ -1969,6 +1988,96 @@ fn processDocumentExtractionAsset(
         .key = try runtime.alloc.dupe(u8, state_key),
         .value = try runtime.alloc.dupe(u8, new_state),
     });
+
+    try storePutBatchWithRetry(runtime, writes.items, deletes.items);
+    recordArtifactBytes(runtime, .asset, manifest.len);
+}
+
+fn writeDocumentExtractionFailureManifest(
+    runtime: *EnrichmentRuntime,
+    doc_key: []const u8,
+    artifact_name: []const u8,
+    source_url: []const u8,
+    source_fingerprint: []const u8,
+    content_type: []const u8,
+    last_error: []const u8,
+    manifest_key: []const u8,
+    state_key: []const u8,
+    previous_child_ranges: []const types.DocumentArtifactChildRange,
+    existing_state: ?[]const u8,
+    from_generation: u64,
+    window: *GeneratedReplayWindow,
+) !void {
+    var previous_unit_keys: []const []const u8 = &.{};
+    defer freeOwnedConstKeySlice(runtime.alloc, previous_unit_keys);
+    var previous_unit_descriptors: []DocumentExtractionUnitDescriptor = &.{};
+    defer freeDocumentExtractionUnitDescriptors(runtime.alloc, previous_unit_descriptors);
+    var previous_chunk_keys: []const []const u8 = &.{};
+    defer freeOwnedConstKeySlice(runtime.alloc, previous_chunk_keys);
+    if (existing_state) |state| {
+        previous_unit_keys = try documentExtractionStateUnitKeysAlloc(runtime.alloc, state);
+        previous_unit_descriptors = try documentExtractionStateUnitDescriptorsAlloc(runtime.alloc, state);
+        previous_chunk_keys = try documentExtractionStateChunkKeysAlloc(runtime.alloc, state);
+    }
+
+    const empty_units: [0]document_extraction_mod.Unit = .{};
+    const failed_extraction = document_extraction_mod.Result{
+        .content_type = @constCast(content_type),
+        .route_type = @constCast("error"),
+        .units = @constCast(empty_units[0..]),
+    };
+    const to_generation = from_generation + 1;
+    const manifest = try documentExtractionManifestPayloadAlloc(
+        runtime.alloc,
+        doc_key,
+        artifact_name,
+        source_url,
+        source_fingerprint,
+        failed_extraction,
+        &.{},
+        &.{},
+        &.{},
+        previous_child_ranges,
+        previous_unit_keys,
+        previous_unit_descriptors,
+        previous_chunk_keys,
+        to_generation,
+        from_generation,
+        to_generation,
+        "failed",
+        last_error,
+    );
+    defer runtime.alloc.free(manifest);
+
+    var writes = std.ArrayListUnmanaged(KVPair).empty;
+    defer {
+        for (writes.items) |write| {
+            runtime.alloc.free(@constCast(write.key));
+            runtime.alloc.free(@constCast(write.value));
+        }
+        writes.deinit(runtime.alloc);
+    }
+    var deletes = std.ArrayListUnmanaged([]const u8).empty;
+    defer {
+        for (deletes.items) |key| runtime.alloc.free(@constCast(key));
+        deletes.deinit(runtime.alloc);
+    }
+
+    try writes.append(runtime.alloc, .{
+        .key = try runtime.alloc.dupe(u8, manifest_key),
+        .value = try runtime.alloc.dupe(u8, manifest),
+    });
+    try appendUniqueDupeKey(runtime.alloc, &window.changed_artifact_keys, manifest_key);
+
+    try deletes.append(runtime.alloc, try runtime.alloc.dupe(u8, state_key));
+    for (previous_unit_keys) |previous_key| {
+        try deletes.append(runtime.alloc, try runtime.alloc.dupe(u8, previous_key));
+        try appendUniqueDupeKey(runtime.alloc, &window.changed_artifact_keys, previous_key);
+    }
+    for (previous_chunk_keys) |previous_key| {
+        try deletes.append(runtime.alloc, try runtime.alloc.dupe(u8, previous_key));
+        try appendUniqueDupeKey(runtime.alloc, &window.changed_artifact_keys, previous_key);
+    }
 
     try storePutBatchWithRetry(runtime, writes.items, deletes.items);
     recordArtifactBytes(runtime, .asset, manifest.len);
@@ -4897,6 +5006,7 @@ fn documentExtractionManifestPayloadAlloc(
     from_generation: u64,
     to_generation: u64,
     merge_status: []const u8,
+    last_error: ?[]const u8,
 ) ![]u8 {
     var out = std.ArrayListUnmanaged(u8).empty;
     errdefer out.deinit(alloc);
@@ -4913,6 +5023,9 @@ fn documentExtractionManifestPayloadAlloc(
     try appendJsonFieldString(alloc, &out, &first, "route_type", extraction.route_type);
     if (extraction.unsupported_reason.len > 0) {
         try appendJsonFieldString(alloc, &out, &first, "unsupported_reason", extraction.unsupported_reason);
+    }
+    if (last_error) |value| {
+        try appendJsonFieldString(alloc, &out, &first, "last_error", value);
     }
     try appendJsonFieldUsize(alloc, &out, &first, "unit_count", extraction.units.len);
     try appendJsonFieldUsize(alloc, &out, &first, "chunk_count", chunk_keys.len);
@@ -5738,6 +5851,7 @@ test "enrichment runtime document extraction manifest uses v2 range and merge sh
         4,
         5,
         "converged",
+        null,
     );
     defer alloc.free(manifest);
 
@@ -5788,12 +5902,45 @@ test "enrichment runtime document extraction manifest uses v2 range and merge sh
         4,
         5,
         "in_progress",
+        null,
     );
     defer alloc.free(in_progress);
     try std.testing.expect(std.mem.indexOf(u8, in_progress, "\"generation\":4") != null);
     try std.testing.expect(std.mem.indexOf(u8, in_progress, "\"from_generation\":4") != null);
     try std.testing.expect(std.mem.indexOf(u8, in_progress, "\"to_generation\":5") != null);
     try std.testing.expect(std.mem.indexOf(u8, in_progress, "\"status\":\"in_progress\"") != null);
+
+    const failed_extraction = document_extraction_mod.Result{
+        .content_type = @constCast("application/pdf"),
+        .route_type = @constCast("error"),
+        .units = @constCast(&.{}),
+    };
+    const failed = try documentExtractionManifestPayloadAlloc(
+        alloc,
+        "doc:a",
+        "document_units_v1",
+        "data:application/pdf;base64,bad",
+        "source-fingerprint",
+        failed_extraction,
+        &.{},
+        &.{},
+        &.{},
+        &.{},
+        &previous_unit_keys,
+        &previous_descriptors,
+        &previous_chunk_keys,
+        6,
+        5,
+        6,
+        "failed",
+        "InvalidPdf",
+    );
+    defer alloc.free(failed);
+    try std.testing.expect(std.mem.indexOf(u8, failed, "\"generation\":6") != null);
+    try std.testing.expect(std.mem.indexOf(u8, failed, "\"last_error\":\"InvalidPdf\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, failed, "\"unit_count\":0") != null);
+    try std.testing.expect(std.mem.indexOf(u8, failed, "\"chunk_count\":0") != null);
+    try std.testing.expect(std.mem.indexOf(u8, failed, "\"status\":\"failed\"") != null);
 }
 
 test "extractSourceText with template renders all document fields" {

--- a/zig/pkg/antfly/src/storage/db/enrichment/enrichment_runtime.zig
+++ b/zig/pkg/antfly/src/storage/db/enrichment/enrichment_runtime.zig
@@ -1771,16 +1771,57 @@ fn processDocumentExtractionAsset(
         }
     }
 
-    const fetched = try template_remote.downloadRemoteContentOutcomeAllocWithConfig(
+    const fetched = template_remote.downloadRemoteContentOutcomeAllocWithConfig(
         runtime.alloc,
         runtime.config.remote_content,
         runtime.config.secret_store,
         source_url,
         if (config.credentials.len > 0) config.credentials else null,
-    );
+    ) catch |err| switch (err) {
+        std.mem.Allocator.Error.OutOfMemory => return err,
+        else => {
+            try writeDocumentExtractionFailureManifest(
+                runtime,
+                request.doc_key,
+                artifact_name,
+                source_url,
+                metadata_fingerprint orelse "",
+                config.content_type,
+                @errorName(err),
+                "remote content download failed",
+                manifest_key,
+                state_key,
+                previous_child_ranges,
+                existing_state,
+                from_generation,
+                window,
+            );
+            return;
+        },
+    };
     const downloaded = switch (fetched) {
         .ok => |content| content,
-        .http_error => return error.RemoteDocumentFetchFailed,
+        .http_error => |http_error| {
+            const message = try std.fmt.allocPrint(runtime.alloc, "{s}: HTTP {d}", .{ http_error.message, http_error.status });
+            defer runtime.alloc.free(message);
+            try writeDocumentExtractionFailureManifest(
+                runtime,
+                request.doc_key,
+                artifact_name,
+                source_url,
+                metadata_fingerprint orelse "",
+                config.content_type,
+                "RemoteDocumentFetchFailed",
+                message,
+                manifest_key,
+                state_key,
+                previous_child_ranges,
+                existing_state,
+                from_generation,
+                window,
+            );
+            return;
+        },
     };
     var downloaded_mut = downloaded;
     defer downloaded_mut.deinit(runtime.alloc);
@@ -1801,6 +1842,7 @@ fn processDocumentExtractionAsset(
             source_fingerprint,
             if (config.content_type.len > 0) config.content_type else downloaded_mut.content_type,
             @errorName(err),
+            "document extraction failed",
             manifest_key,
             state_key,
             previous_child_ranges,
@@ -1879,11 +1921,13 @@ fn processDocumentExtractionAsset(
             if (runtimeContainsConstKey(desired_unit_keys.items, previous_key)) continue;
             try deletes.append(runtime.alloc, try runtime.alloc.dupe(u8, previous_key));
             try appendUniqueDupeKey(runtime.alloc, &window.changed_artifact_keys, previous_key);
+            try appendUniqueDupeKey(runtime.alloc, &window.deleted_keys, previous_key);
         }
         for (previous_chunk_keys) |previous_key| {
             if (runtimeContainsConstKey(desired_chunk_keys.items, previous_key)) continue;
             try deletes.append(runtime.alloc, try runtime.alloc.dupe(u8, previous_key));
             try appendUniqueDupeKey(runtime.alloc, &window.changed_artifact_keys, previous_key);
+            try appendUniqueDupeKey(runtime.alloc, &window.deleted_keys, previous_key);
         }
     }
 
@@ -1901,6 +1945,7 @@ fn processDocumentExtractionAsset(
         previous_unit_keys,
         previous_unit_descriptors,
         previous_chunk_keys,
+        &.{},
         from_generation,
         from_generation,
         to_generation,
@@ -1971,6 +2016,7 @@ fn processDocumentExtractionAsset(
         previous_unit_keys,
         previous_unit_descriptors,
         previous_chunk_keys,
+        &.{},
         to_generation,
         from_generation,
         to_generation,
@@ -2000,7 +2046,8 @@ fn writeDocumentExtractionFailureManifest(
     source_url: []const u8,
     source_fingerprint: []const u8,
     content_type: []const u8,
-    last_error: []const u8,
+    error_code: []const u8,
+    error_message: []const u8,
     manifest_key: []const u8,
     state_key: []const u8,
     previous_child_ranges: []const types.DocumentArtifactChildRange,
@@ -2041,11 +2088,12 @@ fn writeDocumentExtractionFailureManifest(
         previous_unit_keys,
         previous_unit_descriptors,
         previous_chunk_keys,
+        previous_child_ranges,
         to_generation,
         from_generation,
         to_generation,
         "failed",
-        last_error,
+        .{ .code = error_code, .message = error_message },
     );
     defer runtime.alloc.free(manifest);
 
@@ -2073,10 +2121,12 @@ fn writeDocumentExtractionFailureManifest(
     for (previous_unit_keys) |previous_key| {
         try deletes.append(runtime.alloc, try runtime.alloc.dupe(u8, previous_key));
         try appendUniqueDupeKey(runtime.alloc, &window.changed_artifact_keys, previous_key);
+        try appendUniqueDupeKey(runtime.alloc, &window.deleted_keys, previous_key);
     }
     for (previous_chunk_keys) |previous_key| {
         try deletes.append(runtime.alloc, try runtime.alloc.dupe(u8, previous_key));
         try appendUniqueDupeKey(runtime.alloc, &window.changed_artifact_keys, previous_key);
+        try appendUniqueDupeKey(runtime.alloc, &window.deleted_keys, previous_key);
     }
 
     try storePutBatchWithRetry(runtime, writes.items, deletes.items);
@@ -4778,6 +4828,33 @@ fn appendDocumentExtractionRangePolicy(alloc: Allocator, out: *std.ArrayListUnma
     try out.append(alloc, '}');
 }
 
+fn appendDocumentExtractionExistingRanges(
+    alloc: Allocator,
+    out: *std.ArrayListUnmanaged(u8),
+    ranges: []const types.DocumentArtifactChildRange,
+) !void {
+    for (ranges, 0..) |range, i| {
+        if (i > 0) try out.append(alloc, ',');
+        var first = true;
+        try out.append(alloc, '{');
+        try appendJsonFieldString(alloc, out, &first, "range_id", range.range_id);
+        try appendJsonFieldString(alloc, out, &first, "range_kind", range.range_kind);
+        try appendJsonFieldString(alloc, out, &first, "artifact_name", range.artifact_name);
+        try appendJsonFieldString(alloc, out, &first, "split_boundary", range.split_boundary);
+        try appendJsonFieldString(alloc, out, &first, "placement", range.placement);
+        if (range.owner_group_id) |value| try appendJsonFieldU64(alloc, out, &first, "owner_group_id", value);
+        if (range.placement_generation) |value| try appendJsonFieldU64(alloc, out, &first, "placement_generation", value);
+        if (range.route_status) |value| try appendJsonFieldString(alloc, out, &first, "route_status", value);
+        if (range.split_eligible) |value| try appendJsonFieldBool(alloc, out, &first, "split_eligible", value);
+        try appendJsonFieldString(alloc, out, &first, "start_key", range.start_key);
+        try appendJsonFieldString(alloc, out, &first, "end_key_exclusive", range.end_key_exclusive);
+        try appendJsonFieldString(alloc, out, &first, "last_key", range.last_key);
+        try appendJsonFieldUsize(alloc, out, &first, "child_count", range.child_count);
+        if (range.text_bytes) |value| try appendJsonFieldUsize(alloc, out, &first, "text_bytes", value);
+        try out.append(alloc, '}');
+    }
+}
+
 fn appendDocumentExtractionKeyRanges(
     alloc: Allocator,
     out: *std.ArrayListUnmanaged(u8),
@@ -4988,6 +5065,11 @@ fn appendDocumentExtractionMergeOperation(
     try out.append(alloc, '}');
 }
 
+const DocumentExtractionLastError = struct {
+    code: []const u8,
+    message: []const u8,
+};
+
 fn documentExtractionManifestPayloadAlloc(
     alloc: Allocator,
     doc_key: []const u8,
@@ -5002,11 +5084,12 @@ fn documentExtractionManifestPayloadAlloc(
     previous_unit_keys: []const []const u8,
     previous_unit_descriptors: []const DocumentExtractionUnitDescriptor,
     previous_chunk_keys: []const []const u8,
+    child_ranges_override: []const types.DocumentArtifactChildRange,
     manifest_generation: u64,
     from_generation: u64,
     to_generation: u64,
     merge_status: []const u8,
-    last_error: ?[]const u8,
+    last_error: ?DocumentExtractionLastError,
 ) ![]u8 {
     var out = std.ArrayListUnmanaged(u8).empty;
     errdefer out.deinit(alloc);
@@ -5025,13 +5108,22 @@ fn documentExtractionManifestPayloadAlloc(
         try appendJsonFieldString(alloc, &out, &first, "unsupported_reason", extraction.unsupported_reason);
     }
     if (last_error) |value| {
-        try appendJsonFieldString(alloc, &out, &first, "last_error", value);
+        try appendJsonFieldName(alloc, &out, &first, "last_error");
+        try out.append(alloc, '{');
+        var error_first = true;
+        try appendJsonFieldString(alloc, &out, &error_first, "code", value.code);
+        try appendJsonFieldString(alloc, &out, &error_first, "message", value.message);
+        try out.append(alloc, '}');
     }
     try appendJsonFieldUsize(alloc, &out, &first, "unit_count", extraction.units.len);
     try appendJsonFieldUsize(alloc, &out, &first, "chunk_count", chunk_keys.len);
     try appendJsonFieldName(alloc, &out, &first, "child_ranges");
     try out.append(alloc, '[');
-    try appendDocumentExtractionRangeDescriptors(alloc, &out, artifact_name, unit_keys, chunk_keys, extraction.units, previous_child_ranges);
+    if (child_ranges_override.len > 0) {
+        try appendDocumentExtractionExistingRanges(alloc, &out, child_ranges_override);
+    } else {
+        try appendDocumentExtractionRangeDescriptors(alloc, &out, artifact_name, unit_keys, chunk_keys, extraction.units, previous_child_ranges);
+    }
     try out.append(alloc, ']');
     try appendJsonFieldName(alloc, &out, &first, "range_policy");
     try appendDocumentExtractionRangePolicy(alloc, &out);
@@ -5828,6 +5920,22 @@ test "enrichment runtime document extraction manifest uses v2 range and merge sh
         .{ .key = previous_unit_keys[0], .fingerprint = "same-fingerprint" },
         .{ .key = previous_unit_keys[1], .fingerprint = "old-fingerprint" },
     };
+    const previous_ranges = [_]types.DocumentArtifactChildRange{.{
+        .range_id = @constCast("range:000000"),
+        .range_kind = @constCast("unit"),
+        .artifact_name = @constCast("document_units_v1"),
+        .split_boundary = @constCast("unit"),
+        .placement = @constCast("child"),
+        .owner_group_id = 2001,
+        .placement_generation = 17,
+        .route_status = @constCast("remote_committed"),
+        .split_eligible = true,
+        .start_key = @constCast(previous_unit_keys[0]),
+        .end_key_exclusive = @constCast(""),
+        .last_key = @constCast(previous_unit_keys[1]),
+        .child_count = previous_unit_keys.len,
+        .text_bytes = 123,
+    }};
 
     const state = try documentExtractionStateValueAlloc(alloc, "source-fingerprint", &unit_keys, &desired_descriptors, &chunk_keys);
     defer alloc.free(state);
@@ -5847,6 +5955,7 @@ test "enrichment runtime document extraction manifest uses v2 range and merge sh
         &previous_unit_keys,
         &previous_descriptors,
         &previous_chunk_keys,
+        &.{},
         5,
         4,
         5,
@@ -5898,6 +6007,7 @@ test "enrichment runtime document extraction manifest uses v2 range and merge sh
         &previous_unit_keys,
         &previous_descriptors,
         &previous_chunk_keys,
+        &.{},
         4,
         4,
         5,
@@ -5929,17 +6039,20 @@ test "enrichment runtime document extraction manifest uses v2 range and merge sh
         &previous_unit_keys,
         &previous_descriptors,
         &previous_chunk_keys,
+        &previous_ranges,
         6,
         5,
         6,
         "failed",
-        "InvalidPdf",
+        .{ .code = "InvalidPdf", .message = "document extraction failed" },
     );
     defer alloc.free(failed);
     try std.testing.expect(std.mem.indexOf(u8, failed, "\"generation\":6") != null);
-    try std.testing.expect(std.mem.indexOf(u8, failed, "\"last_error\":\"InvalidPdf\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, failed, "\"last_error\":{\"code\":\"InvalidPdf\",\"message\":\"document extraction failed\"}") != null);
     try std.testing.expect(std.mem.indexOf(u8, failed, "\"unit_count\":0") != null);
     try std.testing.expect(std.mem.indexOf(u8, failed, "\"chunk_count\":0") != null);
+    try std.testing.expect(std.mem.indexOf(u8, failed, "\"child_count\":2") != null);
+    try std.testing.expect(std.mem.indexOf(u8, failed, "\"route_status\":\"remote_committed\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, failed, "\"status\":\"failed\"") != null);
 }
 


### PR DESCRIPTION
## Summary

Fixes document extraction recovery behavior for background enrichment failures.

- Records failed manifests for runtime remote download exceptions and HTTP fetch failures instead of surfacing worker errors without recovery state.
- Writes `last_error` in the existing structured `{code, message}` manifest shape so artifact APIs can expose failure details.
- Preserves prior child range descriptors in failed manifests so later retries keep placement/routing recovery context.
- Publishes stale unit/chunk artifact removals as replay deletes so full-text indexes clear old derived text entries.
- Runs warning/skip-heavy unit buckets through the repository test runner so expected warning logs do not fail Zig 0.16 unit CI.
- Keeps table status OpenAPI parsing on structured inline enrichment configs while projecting status JSON enrichments to name arrays at the API boundary.

## Root Cause

The runtime recovery path diverged from the synchronous DB-side document extraction path: failures were only partially captured, used a different `last_error` schema, and deleted prior artifact records without publishing replay-visible deletes for text indexes.

The unit CI failure was a runner mismatch: several existing unit buckets emitted expected warnings or skips under the default Zig test runner, which exits nonzero for that output shape in CI. Nearby buckets already use `pkg/antfly/src/test_runner.zig` for this behavior, so the noisy buckets now do the same.

Table status also needed to preserve generated OpenAPI `IndexConfig` parsing internally; inline enrichment config objects are now converted to enrichment names only when encoding the public JSON response.

## Validation

- `zig fmt zig/pkg/antfly/src/storage/db/enrichment/enrichment_runtime.zig`
- `zig fmt build.zig pkg/antfly/src/api/tables.zig`
- `git diff --check`
- `zig build db-enrichment-test`
- `zig build --seed 0xb99b6566 lib-db-test public-api-parity-test lib-api-auth-test`
- `zig build --seed 0x114aec87 lib-metadata-logic-test`
- `zig build --seed 0x114aec87 lib-api-docid-test lib-api-artifact-reprocess-jobs-test lib-swarm-runtime-test antfly-main-test`
- `zig build --seed 0x9aa9ccfc provisioned-query-visibility-test`
- `zig build --seed 0x66159c7f db-test`
- `zig build --seed 0x8217e3c2 lib-common-config-test wal-test persistent-test index-manager-test resource-budget-test`
- `zig build --seed 0x6a61b9c0 lib-metadata-test`

Note: local `gh auth status` reports an invalid CLI token, so this PR was created through the GitHub app connector.