### PR TITLE
Fix ONNX symbolic projection embeddings

### DIFF
--- a/zig/pkg/inference/src/graph/interpreter.zig
+++ b/zig/pkg/inference/src/graph/interpreter.zig
@@ -1397,9 +1397,55 @@ fn resolveRuntimeSplitLastDim(actual: []const i64, target: Shape, input_numel: u
     return null;
 }
 
+fn resolveFlattenedProjectionSuffixDims(src_actual: []const i64, target: Shape, input_numel: usize, out: *[8]i64) ?[]const i64 {
+    const rank = target.rank();
+    if (src_actual.len < 2 or rank <= src_actual.len - 1 or rank > out.len) return null;
+
+    const prefix_rank = src_actual.len - 1;
+    var prefix_numel: usize = 1;
+    for (0..prefix_rank) |i| {
+        const src_dim = src_actual[i];
+        if (src_dim <= 0) return null;
+        const target_dim = target.dim(@intCast(i));
+        if (target_dim > 0 and target_dim != src_dim) return null;
+        out[i] = src_dim;
+        prefix_numel = std.math.mul(usize, prefix_numel, @intCast(src_dim)) catch return null;
+    }
+    if (prefix_numel == 0 or input_numel % prefix_numel != 0) return null;
+    const projected_width = input_numel / prefix_numel;
+    if (projected_width == 0) return null;
+
+    var suffix_product: usize = 1;
+    var unknown_suffix: ?usize = null;
+    for (prefix_rank..rank) |i| {
+        const dim = target.dim(@intCast(i));
+        if (dim > 0) {
+            out[i] = dim;
+            suffix_product = std.math.mul(usize, suffix_product, @intCast(dim)) catch return null;
+        } else if (dim < 0) {
+            if (unknown_suffix != null) return null;
+            unknown_suffix = i;
+            out[i] = dim;
+        } else {
+            return null;
+        }
+    }
+
+    if (unknown_suffix) |idx| {
+        if (suffix_product == 0 or projected_width % suffix_product != 0) return null;
+        out[idx] = @intCast(projected_width / suffix_product);
+    } else if (suffix_product != projected_width) {
+        return null;
+    }
+
+    if (safeElementCountFromDims(out[0..rank]) == input_numel) return out[0..rank];
+    return null;
+}
+
 fn resolveProjectionRestoreFromSourceActual(src_actual: []const i64, target: Shape, input_numel: usize, out: *[8]i64) ?[]const i64 {
     if (resolveRuntimeAlignedDynamicDims(src_actual, target, input_numel, out)) |resolved| return resolved;
     if (resolveRuntimeSplitLastDim(src_actual, target, input_numel, out)) |resolved| return resolved;
+    if (resolveFlattenedProjectionSuffixDims(src_actual, target, input_numel, out)) |resolved| return resolved;
 
     const rank = target.rank();
     if (src_actual.len == rank + 1 and rank >= 2 and rank <= out.len) {
@@ -2480,7 +2526,7 @@ pub fn executeNode(
                 attrs.lhs_batch[0..attrs.num_batch],
                 attrs.rhs_batch[0..attrs.num_batch],
             ) catch |err| {
-                if (err == error.UnsupportedShape) {
+                if (err == error.UnsupportedShape or err == error.UnsupportedPrimitiveOp) {
                     const lhs_actual = cb.tensorShape(lhs.value, std.heap.page_allocator) catch null;
                     defer if (lhs_actual) |shape| std.heap.page_allocator.free(shape);
                     const rhs_actual = cb.tensorShape(rhs.value, std.heap.page_allocator) catch null;
@@ -3764,6 +3810,18 @@ test "resolveProjectionRestoreFromSourceActual restores packed attention output 
     ) orelse return error.TestUnexpectedResult;
 
     try std.testing.expectEqualSlices(i64, &.{ 3, 512, 128 }, resolved);
+}
+
+test "resolveProjectionRestoreFromSourceActual restores nomic qkv projection suffix" {
+    var out: [8]i64 = undefined;
+    const resolved = resolveProjectionRestoreFromSourceActual(
+        &.{ 1, 512, 768 },
+        Shape.init(.f32, &.{ -1, -1, 3, 12, 64 }),
+        1 * 512 * 3 * 12 * 64,
+        &out,
+    ) orelse return error.TestUnexpectedResult;
+
+    try std.testing.expectEqualSlices(i64, &.{ 1, 512, 3, 12, 64 }, resolved);
 }
 
 test "isLeadingAxisFlatten validates only true leading-axis flatten" {

--- a/zig/pkg/inference/src/ops/native_compute.zig
+++ b/zig/pkg/inference/src/ops/native_compute.zig
@@ -36313,6 +36313,34 @@ fn primDotGeneralOp(ctx: *anyopaque, lhs: CT, rhs: CT, lhs_shape: []const i64, r
         }
     }
 
+    if (lhs_batch.len == 0 and rhs_batch.len == 0 and lhs_contracting.len == 0 and rhs_contracting.len == 0) {
+        if (lhs_effective_shape.len == 1 and rhs_effective_shape.len == 1) {
+            const lhs_view = try denseWeightView(self, lhs);
+            defer if (lhs_view.owned) |owned| self.allocator.free(owned);
+            const rhs_view = try denseWeightView(self, rhs);
+            defer if (rhs_view.owned) |owned| self.allocator.free(owned);
+
+            const m = positiveShapeDim(lhs_effective_shape, 0) catch lhs_view.data.len;
+            const n = positiveShapeDim(rhs_effective_shape, 0) catch rhs_view.data.len;
+            if (m != lhs_view.data.len or n != rhs_view.data.len) return error.ShapeMismatch;
+
+            const output = try self.allocator.alloc(f32, m * n);
+            var raw_output: ?[]f32 = output;
+            errdefer if (raw_output) |raw| self.allocator.free(raw);
+            for (0..m) |i| {
+                for (0..n) |j| {
+                    output[i * n + j] = lhs_view.data[i] * rhs_view.data[j];
+                }
+            }
+
+            const result = try self.makeBuf(output, true);
+            raw_output = null;
+            errdefer freeTensor(self, result);
+            const out_shape = [_]i64{ @intCast(m), @intCast(n) };
+            return self.withLogicalShape(result, &out_shape);
+        }
+    }
+
     // Handle common case: 2D matmul (no batch dims, one contracting dim each).
     if (lhs_batch.len == 0 and lhs_contracting.len == 1 and rhs_contracting.len == 1) {
         const lhs_rank = lhs_effective_shape.len;
@@ -46276,6 +46304,33 @@ test "dot_general flattens lhs suffix for shared rhs source tensor" {
     for (out, expected) |actual, want| {
         try std.testing.expectApproxEqAbs(want, actual, 1e-4);
     }
+}
+
+test "dot_general handles rank1 outer product without contracting axes" {
+    const allocator = std.testing.allocator;
+    var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
+    var compute = NativeCompute.init(allocator, &weight_store, null);
+
+    var lhs_data = [_]f32{ 1, 2, 3 };
+    var rhs_data = [_]f32{ 10, 20, 30, 40 };
+
+    const lhs_ct = try compute.makeBuf(lhs_data[0..], false);
+    defer freeTensor(&compute, lhs_ct);
+    const lhs_shaped = try compute.withLogicalShape(lhs_ct, &.{3});
+
+    const rhs_ct = try compute.makeBuf(rhs_data[0..], false);
+    defer freeTensor(&compute, rhs_ct);
+    const rhs_shaped = try compute.withLogicalShape(rhs_ct, &.{4});
+
+    const out_ct = try primDotGeneralOp(&compute, lhs_shaped, rhs_shaped, &.{3}, &.{4}, &.{}, &.{}, &.{}, &.{});
+    defer freeTensor(&compute, out_ct);
+
+    try std.testing.expectEqualSlices(i64, &.{ 3, 4 }, tensorStoredShape(out_ct).?);
+    try std.testing.expectEqualSlices(f32, &.{
+        10, 20, 30, 40,
+        20, 40, 60, 80,
+        30, 60, 90, 120,
+    }, getData(out_ct));
 }
 
 test "dot_general handles rank2 lhs transpose view without materializing input first" {


### PR DESCRIPTION
## Summary

Follow-up to PR #236 for the remaining SearchAF ONNX embedding failures in `nomic-ai/nomic-embed-text-v1.5`.

After the graph-wide runtime shape fix, the model still needed two narrower native execution cases:

- restoring the original runtime prefix for flattened projection reshapes like `[1, 512, 768] -> [512, 2304] -> [-1, -1, 3, 12, 64]`
- executing ONNX-lowered rank-1 outer products represented as `dot_general` with no contracting axes, e.g. `[512] x [32] -> [512, 32]`

## Changes

- Extend projection reshape restoration to preserve the source runtime prefix and expand the projected hidden axis across multiple concrete target suffix dimensions.
- Add a `nomic`-style projection shape regression for `[1, 512, 768] -> [1, 512, 3, 12, 64]`.
- Log `dot_general` operand context for `UnsupportedPrimitiveOp` as well as `UnsupportedShape`.
- Add native `dot_general` support for rank-1 outer products with no contracting axes.
- Add a native outer-product regression.

## Validation

From `zig/pkg/inference`:

- `zig build test -- --test-filter "resolveProjectionRestoreFromSourceActual restores nomic qkv projection suffix"`
- `zig build test -- --test-filter "dot_general handles rank1 outer product without contracting axes"`
- `zig build test -- --test-filter "resolveProjectionRestoreFromSourceActual"`
- `zig build test -- --test-filter dot_general`
- `zig build test-bin`