### PR TITLE
Add Google Drive auth to docsaf CLI

### DIFF
--- a/examples/docsaf/README.md
+++ b/examples/docsaf/README.md
@@ -134,7 +134,7 @@ Source flags:
 - `--inline-content`: encode source bytes into `data:` URLs for local smoke
   tests and private sources.
 - `--max-inline-bytes`: maximum bytes per source row when using
-  `--inline-content`. Defaults to 3 MiB for filesystem sources and 128 MiB for
+  `--inline-content`. Defaults to 3 MiB for filesystem sources and 100 MiB for
   Google Drive sources.
 - `--id-prefix`: optional stable prefix for source document IDs.
 - `--include`: include pattern; repeatable and supports `**`.
@@ -187,8 +187,10 @@ Inline content is useful for small local tests only.
 For private Google Drive folders, use `--inline-content` unless Antfly can fetch
 the emitted Drive links directly. The CLI authenticates locally to traverse and
 download Drive files; the derived document extraction worker later reads the
-source row URL from Antfly. Drive sync raises the default inline limit to 128
-MiB; use `--max-inline-bytes` for larger files.
+source row URL from Antfly. Drive sync raises the default inline limit to 100
+MiB to match the Drive download cap. For larger files, stage the content behind
+Antfly-readable URLs and sync it with a source that does not require Drive
+downloads.
 
 The source-row design is documented in
 [`go/pkg/docsaf/DOCSAF.md`](../../go/pkg/docsaf/DOCSAF.md).

--- a/examples/docsaf/README.md
+++ b/examples/docsaf/README.md
@@ -80,17 +80,66 @@ For local smoke tests, inline file bytes as `data:` URLs:
   --create-table
 ```
 
+Authorize Google Drive access for a personal Drive account:
+
+```bash
+./docsaf auth google-drive \
+  --client-secret ./client_secret.json
+```
+
+Then sync a Drive folder:
+
+```bash
+./docsaf sync \
+  --source google-drive \
+  --drive-folder "https://drive.google.com/drive/folders/..." \
+  --inline-content \
+  --table docs \
+  --create-table
+```
+
+Service accounts are also supported for shared folders:
+
+```bash
+./docsaf sync \
+  --source google-drive \
+  --drive-folder "https://drive.google.com/drive/folders/..." \
+  --drive-credentials ./service-account.json \
+  --inline-content \
+  --table docs \
+  --create-table
+```
+
 ## Flags
 
 Source flags:
 
+- `--source`: source type, `filesystem` (default) or `google-drive`.
 - `--dir`: directory containing source documents.
 - `--base-url`: fetchable URL prefix for source documents.
 - `--inline-content`: encode source bytes into `data:` URLs for local smoke
-  tests.
+  tests and private sources.
 - `--id-prefix`: optional stable prefix for source document IDs.
 - `--include`: include pattern; repeatable and supports `**`.
 - `--exclude`: exclude pattern; repeatable and supports `**`.
+
+Google Drive source flags:
+
+- `--drive-folder`: Google Drive folder ID or folder URL.
+- `--drive-token-file`: token cache created by `docsaf auth google-drive`.
+- `--drive-credentials`: Google service account JSON or path.
+- `--drive-access-token`: pre-obtained OAuth access token; also reads
+  `GOOGLE_DRIVE_ACCESS_TOKEN`.
+- `--drive-concurrency`: parallel Drive downloads.
+- `--drive-include-shared-drives`: include shared/team drives.
+
+Auth flags:
+
+- `docsaf auth google-drive --client-secret`: OAuth client secret JSON for a
+  Google installed/desktop app.
+- `docsaf auth google-drive --token-file`: where to write the token cache.
+- `docsaf auth google-drive --port`: local OAuth callback port; `0` chooses a
+  free port.
 
 Load/sync flags:
 
@@ -112,6 +161,11 @@ Load/sync flags:
 
 Production sync should use URLs Antfly can fetch directly, such as S3 or HTTPS.
 Inline content is useful for small local tests only.
+
+For private Google Drive folders, use `--inline-content` unless Antfly can fetch
+the emitted Drive links directly. The CLI authenticates locally to traverse and
+download Drive files; the derived document extraction worker later reads the
+source row URL from Antfly.
 
 The source-row design is documented in
 [`go/pkg/docsaf/DOCSAF.md`](../../go/pkg/docsaf/DOCSAF.md).

--- a/examples/docsaf/README.md
+++ b/examples/docsaf/README.md
@@ -133,6 +133,9 @@ Source flags:
 - `--base-url`: fetchable URL prefix for source documents.
 - `--inline-content`: encode source bytes into `data:` URLs for local smoke
   tests and private sources.
+- `--max-inline-bytes`: maximum bytes per source row when using
+  `--inline-content`. Defaults to 3 MiB for filesystem sources and 128 MiB for
+  Google Drive sources.
 - `--id-prefix`: optional stable prefix for source document IDs.
 - `--include`: include pattern; repeatable and supports `**`.
 - `--exclude`: exclude pattern; repeatable and supports `**`.
@@ -148,7 +151,9 @@ Google Drive source flags:
 - `--drive-include-shared-drives`: include shared/team drives.
 
 If no explicit Drive credentials or docsaf token cache are configured, docsaf
-falls back to Google Application Default Credentials.
+falls back to Google Application Default Credentials. If the docsaf token cache
+exists but is corrupt, docsaf warns and still tries Application Default
+Credentials.
 
 Auth flags:
 
@@ -182,7 +187,8 @@ Inline content is useful for small local tests only.
 For private Google Drive folders, use `--inline-content` unless Antfly can fetch
 the emitted Drive links directly. The CLI authenticates locally to traverse and
 download Drive files; the derived document extraction worker later reads the
-source row URL from Antfly.
+source row URL from Antfly. Drive sync raises the default inline limit to 128
+MiB; use `--max-inline-bytes` for larger files.
 
 The source-row design is documented in
 [`go/pkg/docsaf/DOCSAF.md`](../../go/pkg/docsaf/DOCSAF.md).

--- a/examples/docsaf/README.md
+++ b/examples/docsaf/README.md
@@ -98,6 +98,20 @@ Then sync a Drive folder:
   --create-table
 ```
 
+Developers with the Google Cloud CLI can also use Application Default
+Credentials:
+
+```bash
+gcloud auth application-default login \
+  --scopes=https://www.googleapis.com/auth/drive.readonly
+
+./docsaf sync \
+  --source google-drive \
+  --drive-folder "https://drive.google.com/drive/folders/..." \
+  --inline-content \
+  --table docs
+```
+
 Service accounts are also supported for shared folders:
 
 ```bash
@@ -132,6 +146,9 @@ Google Drive source flags:
   `GOOGLE_DRIVE_ACCESS_TOKEN`.
 - `--drive-concurrency`: parallel Drive downloads.
 - `--drive-include-shared-drives`: include shared/team drives.
+
+If no explicit Drive credentials or docsaf token cache are configured, docsaf
+falls back to Google Application Default Credentials.
 
 Auth flags:
 

--- a/go/pkg/docsaf/README.md
+++ b/go/pkg/docsaf/README.md
@@ -361,8 +361,9 @@ docsaf sync --source google-drive --drive-folder <folder-url> --inline-content -
 
 For private Drive folders, `--inline-content` is usually required unless Antfly
 can fetch the emitted Drive links directly. The CLI raises the default inline
-limit to 128 MiB for Google Drive sources; use `--max-inline-bytes` for larger
-files.
+limit to 100 MiB for Google Drive sources to match the Drive download cap. For
+larger files, stage the content behind Antfly-readable URLs and sync it with a
+source that does not require Drive downloads.
 
 #### Using with MinIO
 

--- a/go/pkg/docsaf/README.md
+++ b/go/pkg/docsaf/README.md
@@ -360,7 +360,9 @@ docsaf sync --source google-drive --drive-folder <folder-url> --inline-content -
 ```
 
 For private Drive folders, `--inline-content` is usually required unless Antfly
-can fetch the emitted Drive links directly.
+can fetch the emitted Drive links directly. The CLI raises the default inline
+limit to 128 MiB for Google Drive sources; use `--max-inline-bytes` for larger
+files.
 
 #### Using with MinIO
 

--- a/go/pkg/docsaf/README.md
+++ b/go/pkg/docsaf/README.md
@@ -351,6 +351,14 @@ docsaf auth google-drive --client-secret ./client_secret.json
 docsaf sync --source google-drive --drive-folder <folder-url> --inline-content --table docs
 ```
 
+It also supports Google Application Default Credentials for users who already
+have the Google Cloud CLI:
+
+```bash
+gcloud auth application-default login --scopes=https://www.googleapis.com/auth/drive.readonly
+docsaf sync --source google-drive --drive-folder <folder-url> --inline-content --table docs
+```
+
 For private Drive folders, `--inline-content` is usually required unless Antfly
 can fetch the emitted Drive links directly.
 

--- a/go/pkg/docsaf/README.md
+++ b/go/pkg/docsaf/README.md
@@ -4,7 +4,7 @@ A generic content traversal and processing library for building documentation fr
 
 ## Features
 
-- **Multiple Content Sources**: Traverse local directories, crawl websites, clone Git repositories, or fetch from S3-compatible storage
+- **Multiple Content Sources**: Traverse local directories, crawl websites, clone Git repositories, fetch from S3-compatible storage, or sync Google Drive folders
 - **Pluggable Processors**: Markdown, HTML, PDF, OpenAPI, and custom processors
 - **Web Crawling**: Full-featured web crawler with sitemap support via go-colly
 - **Git Integration**: Clone and traverse Git repositories with branch/tag support
@@ -315,6 +315,44 @@ source, err := docsaf.NewS3Source(docsaf.S3SourceConfig{
     Concurrency: 10,
 })
 ```
+
+### GoogleDriveSource
+
+Traverses a Google Drive folder recursively, downloads regular files, and
+exports supported Google Workspace documents before yielding content items.
+Google Docs are exported as HTML and Google Slides are exported as PDF.
+
+```go
+includeSharedDrives := true
+source, err := docsaf.NewGoogleDriveSource(ctx, docsaf.GoogleDriveSourceConfig{
+    // Required: folder ID or folder URL
+    FolderID: "https://drive.google.com/drive/folders/...",
+
+    // Auth option 1: service account JSON or path
+    CredentialsJSON: "./service-account.json",
+
+    // Auth option 2: pre-obtained OAuth access token
+    // AccessToken: os.Getenv("GOOGLE_DRIVE_ACCESS_TOKEN"),
+
+    // Optional: include shared/team drives, defaults to true
+    IncludeSharedDrives: &includeSharedDrives,
+
+    // Optional: glob filters
+    IncludePatterns: []string{"**/*.pdf", "**/*.docx"},
+    ExcludePatterns: []string{"**/drafts/**"},
+})
+```
+
+The `docsaf` command line tool can create a refresh-token cache for personal
+Drive accounts:
+
+```bash
+docsaf auth google-drive --client-secret ./client_secret.json
+docsaf sync --source google-drive --drive-folder <folder-url> --inline-content --table docs
+```
+
+For private Drive folders, `--inline-content` is usually required unless Antfly
+can fetch the emitted Drive links directly.
 
 #### Using with MinIO
 

--- a/go/pkg/docsaf/cmd/docsaf/auth_google_drive.go
+++ b/go/pkg/docsaf/cmd/docsaf/auth_google_drive.go
@@ -1,0 +1,233 @@
+package main
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+	"google.golang.org/api/drive/v3"
+)
+
+const googleDriveAuthTimeout = 5 * time.Minute
+
+type googleDriveTokenCache struct {
+	ClientID     string          `json:"client_id"`
+	ClientSecret string          `json:"client_secret"`
+	Endpoint     oauth2.Endpoint `json:"endpoint"`
+	Scopes       []string        `json:"scopes"`
+	Token        *oauth2.Token   `json:"token"`
+}
+
+func defaultGoogleDriveTokenFile() string {
+	if dir, err := os.UserConfigDir(); err == nil && dir != "" {
+		return filepath.Join(dir, "antfly", "docsaf", "google-drive-token.json")
+	}
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		return filepath.Join(home, ".config", "antfly", "docsaf", "google-drive-token.json")
+	}
+	return "google-drive-token.json"
+}
+
+func authCmd(args []string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("usage: docsaf auth google-drive [flags]")
+	}
+	switch args[0] {
+	case "google-drive":
+		return authGoogleDriveCmd(args[1:])
+	default:
+		return fmt.Errorf("unknown auth provider %q; expected google-drive", args[0])
+	}
+}
+
+func authGoogleDriveCmd(args []string) error {
+	fs := flag.NewFlagSet("auth google-drive", flag.ExitOnError)
+	clientSecretPath := fs.String("client-secret", "", "Google OAuth client secret JSON file for an installed/desktop app")
+	tokenFile := fs.String("token-file", defaultGoogleDriveTokenFile(), "Path to write the Google Drive OAuth token cache")
+	port := fs.Int("port", 0, "Local callback port; 0 chooses a free port")
+	timeout := fs.Duration("timeout", googleDriveAuthTimeout, "Time to wait for browser authorization")
+	if err := fs.Parse(args); err != nil {
+		return fmt.Errorf("failed to parse flags: %w", err)
+	}
+	if strings.TrimSpace(*clientSecretPath) == "" {
+		return fmt.Errorf("--client-secret is required")
+	}
+
+	clientSecretJSON, err := os.ReadFile(*clientSecretPath)
+	if err != nil {
+		return fmt.Errorf("read client secret: %w", err)
+	}
+
+	listener, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", *port))
+	if err != nil {
+		return fmt.Errorf("listen for OAuth callback: %w", err)
+	}
+	defer listener.Close() //nolint:errcheck // best-effort close during command cleanup
+
+	redirectURL := "http://" + listener.Addr().String() + "/callback"
+	config, err := google.ConfigFromJSON(clientSecretJSON, drive.DriveReadonlyScope)
+	if err != nil {
+		return fmt.Errorf("parse OAuth client secret: %w", err)
+	}
+	config.RedirectURL = redirectURL
+
+	state, err := randomState()
+	if err != nil {
+		return err
+	}
+
+	codeCh := make(chan string, 1)
+	errCh := make(chan error, 1)
+	server := &http.Server{
+		Handler: googleDriveCallbackHandler(state, codeCh, errCh),
+	}
+	defer server.Shutdown(context.Background()) //nolint:errcheck // command is exiting
+	go func() {
+		if err := server.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			errCh <- err
+		}
+	}()
+
+	authURL := config.AuthCodeURL(state, oauth2.AccessTypeOffline, oauth2.ApprovalForce)
+	fmt.Printf("Open this URL in your browser to authorize docsaf Google Drive access:\n\n%s\n\n", authURL)
+	fmt.Printf("Waiting for Google OAuth callback on %s...\n", redirectURL)
+
+	ctx, cancel := context.WithTimeout(context.Background(), *timeout)
+	defer cancel()
+
+	var code string
+	select {
+	case code = <-codeCh:
+	case err := <-errCh:
+		return err
+	case <-ctx.Done():
+		return fmt.Errorf("timed out waiting for Google OAuth callback after %s", timeout.String())
+	}
+
+	token, err := config.Exchange(ctx, code)
+	if err != nil {
+		return fmt.Errorf("exchange OAuth code: %w", err)
+	}
+	if token.RefreshToken == "" {
+		fmt.Printf("Warning: Google did not return a refresh token. Revoke the app grant or use a new client if future syncs fail after the access token expires.\n")
+	}
+
+	cache := googleDriveTokenCache{
+		ClientID:     config.ClientID,
+		ClientSecret: config.ClientSecret,
+		Endpoint:     config.Endpoint,
+		Scopes:       config.Scopes,
+		Token:        token,
+	}
+	if err := writeGoogleDriveTokenCache(*tokenFile, cache); err != nil {
+		return err
+	}
+
+	fmt.Printf("Google Drive authorization saved to %s\n", *tokenFile)
+	return nil
+}
+
+func googleDriveCallbackHandler(expectedState string, codeCh chan<- string, errCh chan<- error) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/callback" {
+			http.NotFound(w, r)
+			return
+		}
+		if got := r.URL.Query().Get("state"); got != expectedState {
+			http.Error(w, "invalid OAuth state", http.StatusBadRequest)
+			select {
+			case errCh <- fmt.Errorf("invalid OAuth state"):
+			default:
+			}
+			return
+		}
+		if errText := r.URL.Query().Get("error"); errText != "" {
+			http.Error(w, "authorization failed", http.StatusBadRequest)
+			select {
+			case errCh <- fmt.Errorf("Google authorization failed: %s", errText):
+			default:
+			}
+			return
+		}
+		code := r.URL.Query().Get("code")
+		if code == "" {
+			http.Error(w, "missing OAuth code", http.StatusBadRequest)
+			select {
+			case errCh <- fmt.Errorf("missing OAuth code"):
+			default:
+			}
+			return
+		}
+		fmt.Fprintln(w, "docsaf Google Drive authorization complete. You can close this window.")
+		select {
+		case codeCh <- code:
+		default:
+		}
+	})
+}
+
+func randomState() (string, error) {
+	var raw [32]byte
+	if _, err := rand.Read(raw[:]); err != nil {
+		return "", fmt.Errorf("generate OAuth state: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(raw[:]), nil
+}
+
+func writeGoogleDriveTokenCache(path string, cache googleDriveTokenCache) error {
+	data, err := json.MarshalIndent(cache, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal token cache: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return fmt.Errorf("create token cache directory: %w", err)
+	}
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		return fmt.Errorf("write token cache: %w", err)
+	}
+	return nil
+}
+
+func loadGoogleDriveTokenSource(ctx context.Context, path string) (oauth2.TokenSource, error) {
+	if strings.TrimSpace(path) == "" {
+		return nil, fmt.Errorf("Google Drive token file path is empty")
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read Google Drive token file %q: %w", path, err)
+	}
+	var cache googleDriveTokenCache
+	if err := json.Unmarshal(data, &cache); err != nil {
+		return nil, fmt.Errorf("parse Google Drive token file %q: %w", path, err)
+	}
+	if cache.ClientID == "" || cache.ClientSecret == "" || cache.Token == nil {
+		return nil, fmt.Errorf("Google Drive token file %q is missing OAuth client or token data", path)
+	}
+	endpoint := cache.Endpoint
+	if endpoint.AuthURL == "" || endpoint.TokenURL == "" {
+		endpoint = google.Endpoint
+	}
+	scopes := cache.Scopes
+	if len(scopes) == 0 {
+		scopes = []string{drive.DriveReadonlyScope}
+	}
+	config := &oauth2.Config{
+		ClientID:     cache.ClientID,
+		ClientSecret: cache.ClientSecret,
+		Endpoint:     endpoint,
+		Scopes:       scopes,
+	}
+	return config.TokenSource(ctx, cache.Token), nil
+}

--- a/go/pkg/docsaf/cmd/docsaf/auth_google_drive.go
+++ b/go/pkg/docsaf/cmd/docsaf/auth_google_drive.go
@@ -22,6 +22,8 @@ import (
 
 const googleDriveAuthTimeout = 5 * time.Minute
 
+var googleDriveADCTokenSource = loadGoogleDriveADCTokenSource
+
 type googleDriveTokenCache struct {
 	ClientID     string          `json:"client_id"`
 	ClientSecret string          `json:"client_secret"`
@@ -230,4 +232,33 @@ func loadGoogleDriveTokenSource(ctx context.Context, path string) (oauth2.TokenS
 		Scopes:       scopes,
 	}
 	return config.TokenSource(ctx, cache.Token), nil
+}
+
+func resolveGoogleDriveTokenSource(ctx context.Context, tokenFile string) (oauth2.TokenSource, error) {
+	if strings.TrimSpace(tokenFile) != "" {
+		if tokenSource, err := loadGoogleDriveTokenSource(ctx, tokenFile); err == nil {
+			return tokenSource, nil
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return nil, err
+		}
+	}
+	if tokenSource, err := googleDriveADCTokenSource(ctx); err == nil {
+		return tokenSource, nil
+	}
+	return nil, missingGoogleDriveAuthError()
+}
+
+func loadGoogleDriveADCTokenSource(ctx context.Context) (oauth2.TokenSource, error) {
+	credentials, err := google.FindDefaultCredentials(ctx, drive.DriveReadonlyScope)
+	if err != nil {
+		return nil, err
+	}
+	if credentials.TokenSource == nil {
+		return nil, fmt.Errorf("application default credentials did not include a token source")
+	}
+	return credentials.TokenSource, nil
+}
+
+func missingGoogleDriveAuthError() error {
+	return fmt.Errorf("no Google Drive auth found\n\nRun one of:\n  docsaf auth google-drive --client-secret ./client_secret.json\n  gcloud auth application-default login --scopes=%s\n\nThen retry with:\n  docsaf sync --source google-drive --drive-folder <folder-url>", drive.DriveReadonlyScope)
 }

--- a/go/pkg/docsaf/cmd/docsaf/auth_google_drive.go
+++ b/go/pkg/docsaf/cmd/docsaf/auth_google_drive.go
@@ -239,7 +239,7 @@ func resolveGoogleDriveTokenSource(ctx context.Context, tokenFile string) (oauth
 		if tokenSource, err := loadGoogleDriveTokenSource(ctx, tokenFile); err == nil {
 			return tokenSource, nil
 		} else if !errors.Is(err, os.ErrNotExist) {
-			return nil, err
+			fmt.Fprintf(os.Stderr, "Warning: ignoring unusable Google Drive token file %q: %v\n", tokenFile, err)
 		}
 	}
 	if tokenSource, err := googleDriveADCTokenSource(ctx); err == nil {

--- a/go/pkg/docsaf/cmd/docsaf/main.go
+++ b/go/pkg/docsaf/cmd/docsaf/main.go
@@ -82,7 +82,7 @@ func (f sourceFlags) validate(ctx context.Context) error {
 		if f.googleDriveAuthConfigured(ctx) {
 			return nil
 		}
-		return fmt.Errorf("google-drive source requires --drive-credentials, --drive-access-token, GOOGLE_DRIVE_ACCESS_TOKEN, or a token file from `docsaf auth google-drive`")
+		return missingGoogleDriveAuthError()
 	default:
 		return fmt.Errorf("unknown --source %q; expected filesystem or google-drive", *f.sourceType)
 	}
@@ -117,10 +117,7 @@ func (f sourceFlags) googleDriveAuthConfigured(ctx context.Context) bool {
 	if strings.TrimSpace(*f.driveCredentials) != "" || strings.TrimSpace(*f.driveAccessToken) != "" || strings.TrimSpace(os.Getenv("GOOGLE_DRIVE_ACCESS_TOKEN")) != "" {
 		return true
 	}
-	if strings.TrimSpace(*f.driveTokenFile) == "" {
-		return false
-	}
-	_, err := loadGoogleDriveTokenSource(ctx, *f.driveTokenFile)
+	_, err := resolveGoogleDriveTokenSource(ctx, *f.driveTokenFile)
 	return err == nil
 }
 
@@ -149,7 +146,7 @@ func (f sourceFlags) source(ctx context.Context) (docsaf.ContentSource, error) {
 		} else if token := strings.TrimSpace(os.Getenv("GOOGLE_DRIVE_ACCESS_TOKEN")); token != "" {
 			config.AccessToken = token
 		} else {
-			tokenSource, err := loadGoogleDriveTokenSource(ctx, *f.driveTokenFile)
+			tokenSource, err := resolveGoogleDriveTokenSource(ctx, *f.driveTokenFile)
 			if err != nil {
 				return nil, err
 			}

--- a/go/pkg/docsaf/cmd/docsaf/main.go
+++ b/go/pkg/docsaf/cmd/docsaf/main.go
@@ -35,31 +35,62 @@ func (s *StringSliceFlag) Set(value string) error {
 }
 
 type sourceFlags struct {
-	dirPath         *string
-	baseURL         *string
-	inlineContent   *bool
-	maxInlineBytes  *int64
-	idPrefix        *string
-	includePatterns StringSliceFlag
-	excludePatterns StringSliceFlag
+	sourceType        *string
+	dirPath           *string
+	baseURL           *string
+	inlineContent     *bool
+	maxInlineBytes    *int64
+	idPrefix          *string
+	driveFolder       *string
+	driveCredentials  *string
+	driveAccessToken  *string
+	driveTokenFile    *string
+	driveConcurrency  *int
+	driveSharedDrives *bool
+	includePatterns   StringSliceFlag
+	excludePatterns   StringSliceFlag
 }
 
 func registerSourceFlags(fs *flag.FlagSet) sourceFlags {
 	flags := sourceFlags{
-		dirPath:        fs.String("dir", "", "Path to directory containing source documents (required)"),
-		baseURL:        fs.String("base-url", "", "Fetchable URL prefix for source documents"),
-		inlineContent:  fs.Bool("inline-content", false, "Encode source bytes as data: URLs for local smoke tests"),
-		maxInlineBytes: fs.Int64("max-inline-bytes", defaultDocsafMaxInlineContentBytes, "Maximum source bytes allowed with --inline-content"),
-		idPrefix:       fs.String("id-prefix", "", "Optional prefix for source document IDs"),
+		sourceType:        fs.String("source", "filesystem", "Source type: filesystem or google-drive"),
+		dirPath:           fs.String("dir", "", "Path to directory containing source documents (required for filesystem source)"),
+		baseURL:           fs.String("base-url", "", "Fetchable URL prefix for source documents"),
+		inlineContent:     fs.Bool("inline-content", false, "Encode source bytes as data: URLs for local smoke tests and private sources"),
+		maxInlineBytes:    fs.Int64("max-inline-bytes", defaultDocsafMaxInlineContentBytes, "Maximum source bytes allowed with --inline-content"),
+		idPrefix:          fs.String("id-prefix", "", "Optional prefix for source document IDs"),
+		driveFolder:       fs.String("drive-folder", "", "Google Drive folder ID or folder URL (required for google-drive source)"),
+		driveCredentials:  fs.String("drive-credentials", "", "Google service account JSON or path for Drive readonly access"),
+		driveAccessToken:  fs.String("drive-access-token", "", "Google Drive OAuth access token; falls back to GOOGLE_DRIVE_ACCESS_TOKEN"),
+		driveTokenFile:    fs.String("drive-token-file", defaultGoogleDriveTokenFile(), "OAuth token cache from `docsaf auth google-drive`"),
+		driveConcurrency:  fs.Int("drive-concurrency", 5, "Parallel Google Drive downloads"),
+		driveSharedDrives: fs.Bool("drive-include-shared-drives", true, "Include files from Google shared drives"),
 	}
 	fs.Var(&flags.includePatterns, "include", "Include pattern (can be repeated, supports ** wildcards)")
 	fs.Var(&flags.excludePatterns, "exclude", "Exclude pattern (can be repeated, supports ** wildcards)")
 	return flags
 }
 
-func (f sourceFlags) validate() error {
+func (f sourceFlags) validate(ctx context.Context) error {
+	switch f.normalizedSourceType() {
+	case "filesystem":
+		return f.validateFilesystem()
+	case "google-drive":
+		if strings.TrimSpace(*f.driveFolder) == "" {
+			return fmt.Errorf("--drive-folder is required for --source google-drive")
+		}
+		if f.googleDriveAuthConfigured(ctx) {
+			return nil
+		}
+		return fmt.Errorf("google-drive source requires --drive-credentials, --drive-access-token, GOOGLE_DRIVE_ACCESS_TOKEN, or a token file from `docsaf auth google-drive`")
+	default:
+		return fmt.Errorf("unknown --source %q; expected filesystem or google-drive", *f.sourceType)
+	}
+}
+
+func (f sourceFlags) validateFilesystem() error {
 	if *f.dirPath == "" {
-		return fmt.Errorf("--dir flag is required")
+		return fmt.Errorf("--dir flag is required for --source filesystem")
 	}
 	if *f.baseURL == "" && !*f.inlineContent {
 		return fmt.Errorf("set --base-url for fetchable source URLs or --inline-content for local smoke tests")
@@ -74,13 +105,60 @@ func (f sourceFlags) validate() error {
 	return nil
 }
 
-func (f sourceFlags) source() *docsaf.FilesystemSource {
-	return docsaf.NewFilesystemSource(docsaf.FilesystemSourceConfig{
-		BaseDir:         *f.dirPath,
-		BaseURL:         *f.baseURL,
-		IncludePatterns: f.includePatterns,
-		ExcludePatterns: f.excludePatterns,
-	})
+func (f sourceFlags) normalizedSourceType() string {
+	sourceType := strings.TrimSpace(*f.sourceType)
+	if sourceType == "" {
+		return "filesystem"
+	}
+	return sourceType
+}
+
+func (f sourceFlags) googleDriveAuthConfigured(ctx context.Context) bool {
+	if strings.TrimSpace(*f.driveCredentials) != "" || strings.TrimSpace(*f.driveAccessToken) != "" || strings.TrimSpace(os.Getenv("GOOGLE_DRIVE_ACCESS_TOKEN")) != "" {
+		return true
+	}
+	if strings.TrimSpace(*f.driveTokenFile) == "" {
+		return false
+	}
+	_, err := loadGoogleDriveTokenSource(ctx, *f.driveTokenFile)
+	return err == nil
+}
+
+func (f sourceFlags) source(ctx context.Context) (docsaf.ContentSource, error) {
+	switch f.normalizedSourceType() {
+	case "filesystem":
+		return docsaf.NewFilesystemSource(docsaf.FilesystemSourceConfig{
+			BaseDir:         *f.dirPath,
+			BaseURL:         *f.baseURL,
+			IncludePatterns: f.includePatterns,
+			ExcludePatterns: f.excludePatterns,
+		}), nil
+	case "google-drive":
+		config := docsaf.GoogleDriveSourceConfig{
+			FolderID:            *f.driveFolder,
+			BaseURL:             *f.baseURL,
+			IncludePatterns:     f.includePatterns,
+			ExcludePatterns:     f.excludePatterns,
+			Concurrency:         *f.driveConcurrency,
+			IncludeSharedDrives: f.driveSharedDrives,
+		}
+		if token := strings.TrimSpace(*f.driveAccessToken); token != "" {
+			config.AccessToken = token
+		} else if credentials := strings.TrimSpace(*f.driveCredentials); credentials != "" {
+			config.CredentialsJSON = credentials
+		} else if token := strings.TrimSpace(os.Getenv("GOOGLE_DRIVE_ACCESS_TOKEN")); token != "" {
+			config.AccessToken = token
+		} else {
+			tokenSource, err := loadGoogleDriveTokenSource(ctx, *f.driveTokenFile)
+			if err != nil {
+				return nil, err
+			}
+			config.TokenSource = tokenSource
+		}
+		return docsaf.NewGoogleDriveSource(ctx, config)
+	default:
+		return nil, fmt.Errorf("unknown --source %q; expected filesystem or google-drive", *f.sourceType)
+	}
 }
 
 func (f sourceFlags) options() docsaf.SourceDocumentOptions {
@@ -93,7 +171,22 @@ func (f sourceFlags) options() docsaf.SourceDocumentOptions {
 }
 
 func (f sourceFlags) print() {
-	fmt.Printf("Directory: %s\n", *f.dirPath)
+	sourceType := f.normalizedSourceType()
+	fmt.Printf("Source: %s\n", sourceType)
+	switch sourceType {
+	case "filesystem":
+		fmt.Printf("Directory: %s\n", *f.dirPath)
+	case "google-drive":
+		fmt.Printf("Drive folder: %s\n", *f.driveFolder)
+		fmt.Printf("Drive token file: %s\n", *f.driveTokenFile)
+		fmt.Printf("Drive service account configured: %v\n", strings.TrimSpace(*f.driveCredentials) != "")
+		fmt.Printf("Drive access token configured: %v\n", strings.TrimSpace(*f.driveAccessToken) != "" || strings.TrimSpace(os.Getenv("GOOGLE_DRIVE_ACCESS_TOKEN")) != "")
+		fmt.Printf("Drive include shared drives: %v\n", *f.driveSharedDrives)
+		fmt.Printf("Drive concurrency: %d\n", *f.driveConcurrency)
+		if !*f.inlineContent && *f.baseURL == "" {
+			fmt.Printf("Drive URL mode: using Drive web links; private files usually require --inline-content or Antfly-readable URLs\n")
+		}
+	}
 	if *f.baseURL != "" {
 		fmt.Printf("Base URL: %s\n", *f.baseURL)
 	}
@@ -121,7 +214,8 @@ func prepareCmd(args []string) error {
 	if err := fs.Parse(args); err != nil {
 		return fmt.Errorf("failed to parse flags: %w", err)
 	}
-	if err := sourceFlags.validate(); err != nil {
+	ctx := context.Background()
+	if err := sourceFlags.validate(ctx); err != nil {
 		return err
 	}
 
@@ -129,7 +223,11 @@ func prepareCmd(args []string) error {
 	sourceFlags.print()
 	fmt.Printf("Output: %s\n\n", *outputFile)
 
-	docs, err := docsaf.BuildSourceDocuments(context.Background(), sourceFlags.source(), sourceFlags.options())
+	source, err := sourceFlags.source(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to create source: %w", err)
+	}
+	docs, err := docsaf.BuildSourceDocuments(ctx, source, sourceFlags.options())
 	if err != nil {
 		return fmt.Errorf("failed to build source documents: %w", err)
 	}
@@ -248,12 +346,12 @@ func syncCmd(args []string) error {
 	if err := fs.Parse(args); err != nil {
 		return fmt.Errorf("failed to parse flags: %w", err)
 	}
-	if err := sourceFlags.validate(); err != nil {
+	ctx := context.Background()
+	if err := sourceFlags.validate(ctx); err != nil {
 		return err
 	}
 	token := resolveAuthToken(*authToken)
 
-	ctx := context.Background()
 	client, err := newDocsafClient(*antflyURL, token)
 	if err != nil {
 		return fmt.Errorf("failed to create Antfly client: %w", err)
@@ -278,7 +376,11 @@ func syncCmd(args []string) error {
 		}
 	}
 
-	docs, err := docsaf.BuildSourceDocuments(ctx, sourceFlags.source(), sourceFlags.options())
+	source, err := sourceFlags.source(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to create source: %w", err)
+	}
+	docs, err := docsaf.BuildSourceDocuments(ctx, source, sourceFlags.options())
 	if err != nil {
 		return fmt.Errorf("failed to build source documents: %w", err)
 	}
@@ -540,11 +642,14 @@ func main() {
 		fmt.Fprintf(os.Stderr, "  docsaf prepare [flags]  - Traverse files and create source-row JSON\n")
 		fmt.Fprintf(os.Stderr, "  docsaf load [flags]     - Load source-row JSON into Antfly\n")
 		fmt.Fprintf(os.Stderr, "  docsaf sync [flags]     - Traverse files and load source rows directly\n")
+		fmt.Fprintf(os.Stderr, "  docsaf auth google-drive [flags] - Authorize Drive access for prepare/sync\n")
 		fmt.Fprintf(os.Stderr, "\nExamples:\n")
 		fmt.Fprintf(os.Stderr, "  docsaf prepare --dir ./docs --base-url s3://docs-bucket --output docs.json\n")
 		fmt.Fprintf(os.Stderr, "  docsaf load --input docs.json --table docs --create-table\n")
 		fmt.Fprintf(os.Stderr, "  docsaf sync --dir ./docs --base-url s3://docs-bucket --table docs --create-table\n")
 		fmt.Fprintf(os.Stderr, "  docsaf sync --dir ./docs --inline-content --table docs --create-table\n")
+		fmt.Fprintf(os.Stderr, "  docsaf auth google-drive --client-secret ./client_secret.json\n")
+		fmt.Fprintf(os.Stderr, "  docsaf sync --source google-drive --drive-folder <folder-url> --inline-content --table docs\n")
 		os.Exit(1)
 	}
 
@@ -556,9 +661,11 @@ func main() {
 		err = loadCmd(os.Args[2:])
 	case "sync":
 		err = syncCmd(os.Args[2:])
+	case "auth":
+		err = authCmd(os.Args[2:])
 	default:
 		fmt.Fprintf(os.Stderr, "Unknown command: %s\n", os.Args[1])
-		fmt.Fprintf(os.Stderr, "Valid commands: prepare, load, sync\n")
+		fmt.Fprintf(os.Stderr, "Valid commands: prepare, load, sync, auth\n")
 		os.Exit(1)
 	}
 

--- a/go/pkg/docsaf/cmd/docsaf/main.go
+++ b/go/pkg/docsaf/cmd/docsaf/main.go
@@ -36,6 +36,7 @@ func (s *StringSliceFlag) Set(value string) error {
 }
 
 type sourceFlags struct {
+	fs                *flag.FlagSet
 	sourceType        *string
 	dirPath           *string
 	baseURL           *string
@@ -54,6 +55,7 @@ type sourceFlags struct {
 
 func registerSourceFlags(fs *flag.FlagSet) sourceFlags {
 	flags := sourceFlags{
+		fs:                fs,
 		sourceType:        fs.String("source", "filesystem", "Source type: filesystem or google-drive"),
 		dirPath:           fs.String("dir", "", "Path to directory containing source documents (required for filesystem source)"),
 		baseURL:           fs.String("base-url", "", "Fetchable URL prefix for source documents"),
@@ -73,9 +75,6 @@ func registerSourceFlags(fs *flag.FlagSet) sourceFlags {
 }
 
 func (f sourceFlags) validate(ctx context.Context) error {
-	if err := f.validateInlineOptions(); err != nil {
-		return err
-	}
 	switch f.normalizedSourceType() {
 	case "filesystem":
 		return f.validateFilesystem()
@@ -92,17 +91,23 @@ func (f sourceFlags) validate(ctx context.Context) error {
 	}
 }
 
-func (f sourceFlags) validateInlineOptions() error {
-	if *f.inlineContent && *f.maxInlineBytes <= 0 {
-		return fmt.Errorf("--max-inline-bytes must be positive when --inline-content is set")
-	}
-	return nil
-}
-
 func (f sourceFlags) normalizeForSource() {
-	if f.normalizedSourceType() == "google-drive" && *f.inlineContent && *f.maxInlineBytes == defaultDocsafMaxInlineContentBytes {
+	if f.normalizedSourceType() == "google-drive" && *f.inlineContent && !f.flagSet("max-inline-bytes") {
 		*f.maxInlineBytes = defaultDriveMaxInlineContentBytes
 	}
+}
+
+func (f sourceFlags) flagSet(name string) bool {
+	if f.fs == nil {
+		return false
+	}
+	set := false
+	f.fs.Visit(func(flag *flag.Flag) {
+		if flag.Name == name {
+			set = true
+		}
+	})
+	return set
 }
 
 func (f sourceFlags) validateFilesystem() error {

--- a/go/pkg/docsaf/cmd/docsaf/main.go
+++ b/go/pkg/docsaf/cmd/docsaf/main.go
@@ -20,7 +20,7 @@ import (
 const (
 	defaultDocsafMaxMergeRequestBytes  int64 = 48 << 20
 	defaultDocsafMaxInlineContentBytes int64 = 3 << 20
-	defaultDriveMaxInlineContentBytes  int64 = 128 << 20
+	defaultDriveMaxInlineContentBytes  int64 = 100 << 20
 )
 
 // StringSliceFlag allows repeated flags to build a slice.

--- a/go/pkg/docsaf/cmd/docsaf/main.go
+++ b/go/pkg/docsaf/cmd/docsaf/main.go
@@ -20,6 +20,7 @@ import (
 const (
 	defaultDocsafMaxMergeRequestBytes  int64 = 48 << 20
 	defaultDocsafMaxInlineContentBytes int64 = 3 << 20
+	defaultDriveMaxInlineContentBytes  int64 = 128 << 20
 )
 
 // StringSliceFlag allows repeated flags to build a slice.
@@ -72,6 +73,9 @@ func registerSourceFlags(fs *flag.FlagSet) sourceFlags {
 }
 
 func (f sourceFlags) validate(ctx context.Context) error {
+	if err := f.validateInlineOptions(); err != nil {
+		return err
+	}
 	switch f.normalizedSourceType() {
 	case "filesystem":
 		return f.validateFilesystem()
@@ -85,6 +89,19 @@ func (f sourceFlags) validate(ctx context.Context) error {
 		return missingGoogleDriveAuthError()
 	default:
 		return fmt.Errorf("unknown --source %q; expected filesystem or google-drive", *f.sourceType)
+	}
+}
+
+func (f sourceFlags) validateInlineOptions() error {
+	if *f.inlineContent && *f.maxInlineBytes <= 0 {
+		return fmt.Errorf("--max-inline-bytes must be positive when --inline-content is set")
+	}
+	return nil
+}
+
+func (f sourceFlags) normalizeForSource() {
+	if f.normalizedSourceType() == "google-drive" && *f.inlineContent && *f.maxInlineBytes == defaultDocsafMaxInlineContentBytes {
+		*f.maxInlineBytes = defaultDriveMaxInlineContentBytes
 	}
 }
 
@@ -211,6 +228,7 @@ func prepareCmd(args []string) error {
 	if err := fs.Parse(args); err != nil {
 		return fmt.Errorf("failed to parse flags: %w", err)
 	}
+	sourceFlags.normalizeForSource()
 	ctx := context.Background()
 	if err := sourceFlags.validate(ctx); err != nil {
 		return err
@@ -343,6 +361,7 @@ func syncCmd(args []string) error {
 	if err := fs.Parse(args); err != nil {
 		return fmt.Errorf("failed to parse flags: %w", err)
 	}
+	sourceFlags.normalizeForSource()
 	ctx := context.Background()
 	if err := sourceFlags.validate(ctx); err != nil {
 		return err

--- a/go/pkg/docsaf/cmd/docsaf/main_test.go
+++ b/go/pkg/docsaf/cmd/docsaf/main_test.go
@@ -18,11 +18,122 @@ package main
 
 import (
 	"context"
+	"flag"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/antflydb/antfly/go/pkg/docsaf"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+	"google.golang.org/api/drive/v3"
 )
+
+func parseSourceFlagsForTest(t *testing.T, args ...string) sourceFlags {
+	t.Helper()
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	flags := registerSourceFlags(fs)
+	if err := fs.Parse(args); err != nil {
+		t.Fatalf("parse source flags: %v", err)
+	}
+	return flags
+}
+
+func TestSourceFlagsFilesystemDefaultRequiresDir(t *testing.T) {
+	flags := parseSourceFlagsForTest(t, "--base-url", "s3://docs")
+	err := flags.validate(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "--dir flag is required") {
+		t.Fatalf("validate error = %v, want missing dir", err)
+	}
+}
+
+func TestSourceFlagsGoogleDriveRequiresFolder(t *testing.T) {
+	flags := parseSourceFlagsForTest(t, "--source", "google-drive", "--drive-access-token", "token")
+	err := flags.validate(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "--drive-folder is required") {
+		t.Fatalf("validate error = %v, want missing drive folder", err)
+	}
+}
+
+func TestSourceFlagsGoogleDriveRequiresAuth(t *testing.T) {
+	t.Setenv("GOOGLE_DRIVE_ACCESS_TOKEN", "")
+	flags := parseSourceFlagsForTest(t,
+		"--source", "google-drive",
+		"--drive-folder", "folder-id",
+		"--drive-token-file", filepath.Join(t.TempDir(), "missing-token.json"),
+	)
+	err := flags.validate(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "google-drive source requires") {
+		t.Fatalf("validate error = %v, want missing auth", err)
+	}
+}
+
+func TestSourceFlagsGoogleDriveAccessTokenBuildsSource(t *testing.T) {
+	flags := parseSourceFlagsForTest(t,
+		"--source", "google-drive",
+		"--drive-folder", "folder-id",
+		"--drive-access-token", "token",
+		"--include", "**/*.md",
+		"--exclude", "**/drafts/**",
+	)
+	if err := flags.validate(context.Background()); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	source, err := flags.source(context.Background())
+	if err != nil {
+		t.Fatalf("source: %v", err)
+	}
+	if source.Type() != "google_drive" {
+		t.Fatalf("source.Type() = %q, want google_drive", source.Type())
+	}
+	if _, ok := source.(*docsaf.GoogleDriveSource); !ok {
+		t.Fatalf("source type = %T, want *docsaf.GoogleDriveSource", source)
+	}
+}
+
+func TestGoogleDriveTokenCacheLoadTokenSource(t *testing.T) {
+	tokenFile := filepath.Join(t.TempDir(), "google-drive-token.json")
+	cache := googleDriveTokenCache{
+		ClientID:     "client-id",
+		ClientSecret: "client-secret",
+		Endpoint:     google.Endpoint,
+		Scopes:       []string{drive.DriveReadonlyScope},
+		Token: &oauth2.Token{
+			AccessToken:  "access-token",
+			RefreshToken: "refresh-token",
+			TokenType:    "Bearer",
+			Expiry:       time.Now().Add(time.Hour),
+		},
+	}
+	if err := writeGoogleDriveTokenCache(tokenFile, cache); err != nil {
+		t.Fatalf("write token cache: %v", err)
+	}
+	info, err := os.Stat(tokenFile)
+	if err != nil {
+		t.Fatalf("stat token cache: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0600 {
+		t.Fatalf("token cache mode = %v, want 0600", got)
+	}
+
+	source, err := loadGoogleDriveTokenSource(context.Background(), tokenFile)
+	if err != nil {
+		t.Fatalf("load token source: %v", err)
+	}
+	token, err := source.Token()
+	if err != nil {
+		t.Fatalf("token: %v", err)
+	}
+	if token.AccessToken != "access-token" {
+		t.Fatalf("AccessToken = %q, want access-token", token.AccessToken)
+	}
+}
 
 func TestCreateTableWithIndexesReturnsNonConflictError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/go/pkg/docsaf/cmd/docsaf/main_test.go
+++ b/go/pkg/docsaf/cmd/docsaf/main_test.go
@@ -109,6 +109,19 @@ func TestSourceFlagsGoogleDriveAccessTokenBuildsSource(t *testing.T) {
 	}
 }
 
+func TestSourceFlagsGoogleDriveInlineDefaultIsLargeEnoughForDocuments(t *testing.T) {
+	flags := parseSourceFlagsForTest(t,
+		"--source", "google-drive",
+		"--drive-folder", "folder-id",
+		"--drive-access-token", "token",
+		"--inline-content",
+	)
+	flags.normalizeForSource()
+	if got := *flags.maxInlineBytes; got != defaultDriveMaxInlineContentBytes {
+		t.Fatalf("maxInlineBytes = %d, want %d", got, defaultDriveMaxInlineContentBytes)
+	}
+}
+
 func TestGoogleDriveTokenCacheLoadTokenSource(t *testing.T) {
 	tokenFile := filepath.Join(t.TempDir(), "google-drive-token.json")
 	cache := googleDriveTokenCache{
@@ -144,6 +157,31 @@ func TestGoogleDriveTokenCacheLoadTokenSource(t *testing.T) {
 	}
 	if token.AccessToken != "access-token" {
 		t.Fatalf("AccessToken = %q, want access-token", token.AccessToken)
+	}
+}
+
+func TestResolveGoogleDriveTokenSourceFallsBackToADCWhenCacheInvalid(t *testing.T) {
+	tokenFile := filepath.Join(t.TempDir(), "google-drive-token.json")
+	if err := os.WriteFile(tokenFile, []byte("{"), 0600); err != nil {
+		t.Fatalf("write invalid token cache: %v", err)
+	}
+
+	originalADC := googleDriveADCTokenSource
+	googleDriveADCTokenSource = func(context.Context) (oauth2.TokenSource, error) {
+		return oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "adc-token"}), nil
+	}
+	t.Cleanup(func() { googleDriveADCTokenSource = originalADC })
+
+	source, err := resolveGoogleDriveTokenSource(context.Background(), tokenFile)
+	if err != nil {
+		t.Fatalf("resolve token source: %v", err)
+	}
+	token, err := source.Token()
+	if err != nil {
+		t.Fatalf("token: %v", err)
+	}
+	if token.AccessToken != "adc-token" {
+		t.Fatalf("AccessToken = %q, want adc-token", token.AccessToken)
 	}
 }
 

--- a/go/pkg/docsaf/cmd/docsaf/main_test.go
+++ b/go/pkg/docsaf/cmd/docsaf/main_test.go
@@ -19,6 +19,7 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -63,14 +64,25 @@ func TestSourceFlagsGoogleDriveRequiresFolder(t *testing.T) {
 
 func TestSourceFlagsGoogleDriveRequiresAuth(t *testing.T) {
 	t.Setenv("GOOGLE_DRIVE_ACCESS_TOKEN", "")
+	originalADC := googleDriveADCTokenSource
+	googleDriveADCTokenSource = func(context.Context) (oauth2.TokenSource, error) {
+		return nil, fmt.Errorf("adc unavailable")
+	}
+	t.Cleanup(func() { googleDriveADCTokenSource = originalADC })
+
 	flags := parseSourceFlagsForTest(t,
 		"--source", "google-drive",
 		"--drive-folder", "folder-id",
 		"--drive-token-file", filepath.Join(t.TempDir(), "missing-token.json"),
 	)
 	err := flags.validate(context.Background())
-	if err == nil || !strings.Contains(err.Error(), "google-drive source requires") {
-		t.Fatalf("validate error = %v, want missing auth", err)
+	if err == nil {
+		t.Fatalf("validate error = nil, want missing auth")
+	}
+	for _, want := range []string{"no Google Drive auth found", "docsaf auth google-drive", "gcloud auth application-default login"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("validate error = %v, want %q", err, want)
+		}
 	}
 }
 

--- a/go/pkg/docsaf/cmd/docsaf/main_test.go
+++ b/go/pkg/docsaf/cmd/docsaf/main_test.go
@@ -122,6 +122,40 @@ func TestSourceFlagsGoogleDriveInlineDefaultIsLargeEnoughForDocuments(t *testing
 	}
 }
 
+func TestSourceFlagsGoogleDriveInlineMaxInlineBytesCanBeExplicitlySmall(t *testing.T) {
+	flags := parseSourceFlagsForTest(t,
+		"--source", "google-drive",
+		"--drive-folder", "folder-id",
+		"--drive-access-token", "token",
+		"--inline-content",
+		"--max-inline-bytes", fmt.Sprint(defaultDocsafMaxInlineContentBytes),
+	)
+	flags.normalizeForSource()
+	if got := *flags.maxInlineBytes; got != defaultDocsafMaxInlineContentBytes {
+		t.Fatalf("maxInlineBytes = %d, want explicit %d", got, defaultDocsafMaxInlineContentBytes)
+	}
+}
+
+func TestSourceFlagsInlineMaxInlineBytesCanDisableGuard(t *testing.T) {
+	flags := parseSourceFlagsForTest(t,
+		"--source", "google-drive",
+		"--drive-folder", "folder-id",
+		"--drive-access-token", "token",
+		"--inline-content",
+		"--max-inline-bytes", "0",
+	)
+	flags.normalizeForSource()
+	if err := flags.validate(context.Background()); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	if got := *flags.maxInlineBytes; got != 0 {
+		t.Fatalf("maxInlineBytes = %d, want disabled guard", got)
+	}
+	if got := flags.options().MaxInlineBytes; got != 0 {
+		t.Fatalf("options().MaxInlineBytes = %d, want disabled guard", got)
+	}
+}
+
 func TestGoogleDriveTokenCacheLoadTokenSource(t *testing.T) {
 	tokenFile := filepath.Join(t.TempDir(), "google-drive-token.json")
 	cache := googleDriveTokenCache{

--- a/go/pkg/docsaf/source_documents_test.go
+++ b/go/pkg/docsaf/source_documents_test.go
@@ -55,6 +55,40 @@ func TestSourceDocumentFromContentItemInline(t *testing.T) {
 	}
 }
 
+func TestSourceDocumentFromContentItemCanonicalMetadata(t *testing.T) {
+	modTime := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	item := ContentItem{
+		Path:        "drive/report.pdf",
+		SourceURL:   "https://drive.google.com/file/d/file-id/view",
+		Content:     []byte("%PDF"),
+		ContentType: "application/pdf",
+		Metadata: map[string]any{
+			"source_type": "google_drive",
+			"file_size":   int64(42),
+			"mod_time":    modTime,
+			"etag":        "checksum",
+			"version":     "revision",
+		},
+	}
+
+	doc, err := SourceDocumentFromContentItem(item, SourceDocumentOptions{})
+	if err != nil {
+		t.Fatalf("SourceDocumentFromContentItem: %v", err)
+	}
+	if doc.SizeBytes != 42 {
+		t.Fatalf("SizeBytes = %d, want 42", doc.SizeBytes)
+	}
+	if !doc.ModifiedAt.Equal(modTime) {
+		t.Fatalf("ModifiedAt = %v, want %v", doc.ModifiedAt, modTime)
+	}
+	if doc.ETag != "checksum" {
+		t.Fatalf("ETag = %q, want checksum", doc.ETag)
+	}
+	if doc.Version != "revision" {
+		t.Fatalf("Version = %q, want revision", doc.Version)
+	}
+}
+
 func TestBuildSourceDocumentsRequiresURL(t *testing.T) {
 	source := singleItemSource{item: ContentItem{
 		Path:    "a.txt",

--- a/go/pkg/docsaf/source_googledrive.go
+++ b/go/pkg/docsaf/source_googledrive.go
@@ -322,7 +322,10 @@ func (s *GoogleDriveSource) traverseFolder(ctx context.Context, folderID, pathPr
 					Metadata: map[string]any{
 						"source_type":   "google_drive",
 						"drive_file_id": f.Id,
+						"etag":          f.Md5Checksum,
+						"file_size":     f.Size,
 						"mime_type":     f.MimeType,
+						"mod_time":      f.ModifiedTime,
 						"modified_time": f.ModifiedTime,
 						"md5_checksum":  f.Md5Checksum,
 						"size":          f.Size,

--- a/go/pkg/docsaf/source_googledrive.go
+++ b/go/pkg/docsaf/source_googledrive.go
@@ -189,7 +189,12 @@ func (s *GoogleDriveSource) Traverse(ctx context.Context) (<-chan ContentItem, <
 // downloadSlot holds the result channel for a single concurrent download,
 // allowing ordered emission after concurrent downloads complete.
 type downloadSlot struct {
-	ch chan ContentItem
+	ch chan downloadResult
+}
+
+type downloadResult struct {
+	item ContentItem
+	err  error
 }
 
 // traverseFolder recursively lists files in a folder and sends them to the items channel.
@@ -293,19 +298,19 @@ func (s *GoogleDriveSource) traverseFolder(ctx context.Context, folderID, pathPr
 		slots := make([]downloadSlot, len(files))
 		var wg sync.WaitGroup
 		for i, fe := range files {
-			slots[i] = downloadSlot{ch: make(chan ContentItem, 1)}
+			slots[i] = downloadSlot{ch: make(chan downloadResult, 1)}
 
 			wg.Add(1)
 			s.semaphore <- struct{}{}
-			go func(f *drive.File, relPath string, slot chan<- ContentItem) {
+			go func(f *drive.File, relPath string, slot chan<- downloadResult) {
 				defer wg.Done()
 				defer func() { <-s.semaphore }()
 				defer close(slot)
 
 				content, contentType, err := s.downloadFile(ctx, f)
 				if err != nil {
-					log.Printf("Warning: Failed to download %s: %v", relPath, err)
-					return // slot closed empty — skipped in emission
+					slot <- downloadResult{err: fmt.Errorf("failed to download %s: %w", relPath, err)}
+					return
 				}
 
 				driveURL := f.WebViewLink
@@ -314,21 +319,23 @@ func (s *GoogleDriveSource) traverseFolder(ctx context.Context, folderID, pathPr
 				}
 
 				select {
-				case slot <- ContentItem{
-					Path:        relPath,
-					SourceURL:   driveURL,
-					Content:     content,
-					ContentType: contentType,
-					Metadata: map[string]any{
-						"source_type":   "google_drive",
-						"drive_file_id": f.Id,
-						"etag":          f.Md5Checksum,
-						"file_size":     f.Size,
-						"mime_type":     f.MimeType,
-						"mod_time":      f.ModifiedTime,
-						"modified_time": f.ModifiedTime,
-						"md5_checksum":  f.Md5Checksum,
-						"size":          f.Size,
+				case slot <- downloadResult{
+					item: ContentItem{
+						Path:        relPath,
+						SourceURL:   driveURL,
+						Content:     content,
+						ContentType: contentType,
+						Metadata: map[string]any{
+							"source_type":   "google_drive",
+							"drive_file_id": f.Id,
+							"etag":          f.Md5Checksum,
+							"file_size":     f.Size,
+							"mime_type":     f.MimeType,
+							"mod_time":      f.ModifiedTime,
+							"modified_time": f.ModifiedTime,
+							"md5_checksum":  f.Md5Checksum,
+							"size":          f.Size,
+						},
 					},
 				}:
 				case <-ctx.Done():
@@ -339,9 +346,13 @@ func (s *GoogleDriveSource) traverseFolder(ctx context.Context, folderID, pathPr
 		// Emit items in name-sorted order by reading slots sequentially.
 		// Each slot blocks until that file's download completes.
 		for _, slot := range slots {
-			if item, ok := <-slot.ch; ok {
+			if result, ok := <-slot.ch; ok {
+				if result.err != nil {
+					wg.Wait()
+					return result.err
+				}
 				select {
-				case items <- item:
+				case items <- result.item:
 				case <-ctx.Done():
 					wg.Wait()
 					return ctx.Err()
@@ -349,8 +360,7 @@ func (s *GoogleDriveSource) traverseFolder(ctx context.Context, folderID, pathPr
 			}
 		}
 
-		// Wait for any remaining goroutines (e.g., failed downloads
-		// whose slots were already closed empty).
+		// Wait for any remaining goroutines.
 		wg.Wait()
 
 		pageToken = fileList.NextPageToken

--- a/go/pkg/docsaf/source_googledrive.go
+++ b/go/pkg/docsaf/source_googledrive.go
@@ -19,7 +19,7 @@ import (
 	"google.golang.org/api/option"
 )
 
-// maxFileDownloadSize is the maximum size for a single file download (100MB).
+// maxFileDownloadSize is the maximum size for a single file download (100 MiB).
 const maxFileDownloadSize = 100 * 1024 * 1024
 
 // Workspace MIME types and the format to export them as.
@@ -377,7 +377,7 @@ func (s *GoogleDriveSource) downloadFile(ctx context.Context, file *drive.File) 
 		}
 		defer resp.Body.Close() //nolint:errcheck // best-effort close in deferred cleanup
 
-		data, err := io.ReadAll(io.LimitReader(resp.Body, maxFileDownloadSize))
+		data, err := readLimitedDriveContent(resp.Body, maxFileDownloadSize)
 		if err != nil {
 			return nil, "", fmt.Errorf("reading exported file %s: %w", file.Name, err)
 		}
@@ -391,13 +391,24 @@ func (s *GoogleDriveSource) downloadFile(ctx context.Context, file *drive.File) 
 	}
 	defer resp.Body.Close() //nolint:errcheck // best-effort close in deferred cleanup
 
-	data, err := io.ReadAll(io.LimitReader(resp.Body, maxFileDownloadSize))
+	data, err := readLimitedDriveContent(resp.Body, maxFileDownloadSize)
 	if err != nil {
 		return nil, "", fmt.Errorf("reading file %s: %w", file.Name, err)
 	}
 
 	contentType := DetectContentType(file.Name, data)
 	return data, contentType, nil
+}
+
+func readLimitedDriveContent(r io.Reader, maxBytes int64) ([]byte, error) {
+	data, err := io.ReadAll(io.LimitReader(r, maxBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(data)) > maxBytes {
+		return nil, fmt.Errorf("Google Drive file exceeds download limit of %d bytes", maxBytes)
+	}
+	return data, nil
 }
 
 // parseFolderID extracts a folder ID from a Google Drive URL or returns the input as-is.

--- a/go/pkg/docsaf/source_googledrive.go
+++ b/go/pkg/docsaf/source_googledrive.go
@@ -46,12 +46,16 @@ var folderIDRegexp = regexp.MustCompile(`/folders/([a-zA-Z0-9_-]+)`)
 
 // GoogleDriveSourceConfig holds configuration for a GoogleDriveSource.
 type GoogleDriveSourceConfig struct {
+	// TokenSource is an OAuth2 token source, usually backed by a refresh token.
+	// If set, it takes precedence over AccessToken and CredentialsJSON.
+	TokenSource oauth2.TokenSource
+
 	// CredentialsJSON is a service account key JSON string or file path.
-	// Either CredentialsJSON or AccessToken must be provided.
+	// TokenSource, CredentialsJSON, or AccessToken must be provided.
 	CredentialsJSON string
 
 	// AccessToken is a pre-obtained OAuth2 access token.
-	// Either CredentialsJSON or AccessToken must be provided.
+	// TokenSource, CredentialsJSON, or AccessToken must be provided.
 	AccessToken string
 
 	// FolderID is the Google Drive folder ID or full folder URL (required).
@@ -91,8 +95,8 @@ type GoogleDriveSource struct {
 
 // NewGoogleDriveSource creates a new Google Drive content source.
 func NewGoogleDriveSource(ctx context.Context, config GoogleDriveSourceConfig) (*GoogleDriveSource, error) {
-	if config.CredentialsJSON == "" && config.AccessToken == "" {
-		return nil, fmt.Errorf("either CredentialsJSON or AccessToken is required")
+	if config.TokenSource == nil && config.CredentialsJSON == "" && config.AccessToken == "" {
+		return nil, fmt.Errorf("TokenSource, CredentialsJSON, or AccessToken is required")
 	}
 	if config.FolderID == "" {
 		return nil, fmt.Errorf("FolderID is required")
@@ -108,7 +112,9 @@ func NewGoogleDriveSource(ctx context.Context, config GoogleDriveSourceConfig) (
 
 	// Build Drive service
 	var opts []option.ClientOption
-	if config.AccessToken != "" {
+	if config.TokenSource != nil {
+		opts = append(opts, option.WithTokenSource(config.TokenSource))
+	} else if config.AccessToken != "" {
 		ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: config.AccessToken})
 		opts = append(opts, option.WithTokenSource(ts))
 	} else {

--- a/go/pkg/docsaf/source_googledrive_test.go
+++ b/go/pkg/docsaf/source_googledrive_test.go
@@ -1,6 +1,7 @@
 package docsaf
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -298,6 +299,21 @@ func TestGoogleDriveSource_WorkspaceExportFormats(t *testing.T) {
 		if !workspaceSkipTypes[mimeType] {
 			t.Errorf("Expected %s to be in workspaceSkipTypes", mimeType)
 		}
+	}
+}
+
+func TestReadLimitedDriveContentRejectsOversize(t *testing.T) {
+	data, err := readLimitedDriveContent(strings.NewReader("12345"), 5)
+	if err != nil {
+		t.Fatalf("readLimitedDriveContent exact limit: %v", err)
+	}
+	if string(data) != "12345" {
+		t.Fatalf("data = %q, want 12345", data)
+	}
+
+	_, err = readLimitedDriveContent(strings.NewReader("123456"), 5)
+	if err == nil || !strings.Contains(err.Error(), "exceeds download limit of 5 bytes") {
+		t.Fatalf("readLimitedDriveContent oversize error = %v, want limit error", err)
 	}
 }
 

--- a/go/pkg/docsaf/source_googledrive_test.go
+++ b/go/pkg/docsaf/source_googledrive_test.go
@@ -1,8 +1,16 @@
 package docsaf
 
 import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"golang.org/x/time/rate"
+	"google.golang.org/api/drive/v3"
+	"google.golang.org/api/option"
 )
 
 func TestGoogleDriveSource_Type(t *testing.T) {
@@ -314,6 +322,59 @@ func TestReadLimitedDriveContentRejectsOversize(t *testing.T) {
 	_, err = readLimitedDriveContent(strings.NewReader("123456"), 5)
 	if err == nil || !strings.Contains(err.Error(), "exceeds download limit of 5 bytes") {
 		t.Fatalf("readLimitedDriveContent oversize error = %v, want limit error", err)
+	}
+}
+
+func TestGoogleDriveSourceTraversePropagatesDownloadErrors(t *testing.T) {
+	ctx := context.Background()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/files" && r.URL.Query().Get("alt") != "media":
+			w.Header().Set("Content-Type", "application/json")
+			if err := json.NewEncoder(w).Encode(map[string]any{
+				"files": []map[string]any{
+					{
+						"id":           "file-id",
+						"name":         "huge.txt",
+						"mimeType":     "text/plain",
+						"size":         "12",
+						"modifiedTime": "2026-01-02T03:04:05.000Z",
+						"md5Checksum":  "checksum",
+						"webViewLink":  "https://drive.google.com/file/d/file-id/view",
+					},
+				},
+			}); err != nil {
+				t.Fatalf("encode list response: %v", err)
+			}
+		case r.Method == http.MethodGet && r.URL.Path == "/files/file-id" && r.URL.Query().Get("alt") == "media":
+			http.Error(w, "download failed", http.StatusInternalServerError)
+		default:
+			t.Fatalf("unexpected Drive API request: %s %s?%s", r.Method, r.URL.Path, r.URL.RawQuery)
+		}
+	}))
+	defer server.Close()
+
+	service, err := drive.NewService(ctx, option.WithEndpoint(server.URL+"/"), option.WithoutAuthentication())
+	if err != nil {
+		t.Fatalf("new Drive service: %v", err)
+	}
+	source := &GoogleDriveSource{
+		config:    GoogleDriveSourceConfig{FolderID: "folder-id"},
+		service:   service,
+		semaphore: make(chan struct{}, 1),
+		limiter:   rate.NewLimiter(rate.Inf, 1),
+	}
+
+	items, errs := source.Traverse(ctx)
+	for item := range items {
+		t.Fatalf("unexpected item emitted after failed download: %#v", item)
+	}
+	var gotErr error
+	for err := range errs {
+		gotErr = err
+	}
+	if gotErr == nil || !strings.Contains(gotErr.Error(), "failed to download huge.txt") {
+		t.Fatalf("Traverse error = %v, want download failure", gotErr)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add google-drive as a docsaf prepare/sync source with Drive folder, credential, access-token, token-file, concurrency, and shared-drive flags
- add docsaf auth google-drive using a local OAuth callback and refresh-token cache
- fall back to Google Application Default Credentials from gcloud auth application-default login when no docsaf token cache or explicit Drive auth is configured
- document Google Drive sync paths and add focused CLI/source tests

## Tests
- env GOWORK=off GOEXPERIMENT=simd GOCACHE=/tmp/antfly-go-build-cache go test ./...