### PR TITLE
Fix SDK npm publish tag trigger

### DIFF
--- a/.github/workflows/ts-npm-publish.yml
+++ b/.github/workflows/ts-npm-publish.yml
@@ -1,5 +1,5 @@
 # Publish packages to npm when tagged
-# - ts/antfly/sdk/v* tags publish @antfly/sdk
+# - ts/packages/sdk/v* tags publish @antfly/sdk
 # - ts/antfly/components/v* tags publish @antfly/components
 # - ts/antfly/design-system/v* tags publish @antfly/design-system
 #
@@ -13,7 +13,7 @@ name: Publish to npm
 on:
   push:
     tags:
-      - 'ts/antfly/sdk/v*'
+      - 'ts/packages/sdk/v*'
       - 'ts/antfly/components/v*'
       - 'ts/antfly/design-system/v*'
 
@@ -55,7 +55,7 @@ jobs:
         run: npm install -g npm@latest
 
       - name: Publish SDK
-        if: startsWith(github.ref, 'refs/tags/ts/antfly/sdk/v')
+        if: startsWith(github.ref, 'refs/tags/ts/packages/sdk/v')
         working-directory: ts
         run: pnpm --filter @antfly/sdk publish --access public --no-git-checks --provenance
 


### PR DESCRIPTION
## Summary
- change the @antfly/sdk npm publish trigger from ts/antfly/sdk/v* to ts/packages/sdk/v*
- update the matching publish step condition and workflow comment

## Test
- actionlint antfly/.github/workflows/ts-npm-publish.yml