### PR TITLE
Fix Antfarm table detail crash on sparse schemas

### DIFF
--- a/ts/apps/antfarm/src/components/CreateIndexDialog.test.tsx
+++ b/ts/apps/antfarm/src/components/CreateIndexDialog.test.tsx
@@ -1,0 +1,63 @@
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { TableSchema } from "../api";
+import CreateIndexDialog, { getSchemaFieldNames } from "./CreateIndexDialog";
+
+vi.mock("./IndexForm", () => ({
+  default: ({ schemaFields }: { schemaFields: string[] }) => (
+    <div data-testid="index-form">{schemaFields.join(",")}</div>
+  ),
+}));
+
+describe("CreateIndexDialog", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("derives schema fields from valid document schema properties", () => {
+    const schema = {
+      document_schemas: {
+        dynamic: {
+          schema: {
+            type: "object",
+          },
+        },
+        article: {
+          schema: {
+            type: "object",
+            properties: {
+              title: { type: "string" },
+              body: { type: "string" },
+            },
+          },
+        },
+      },
+    } as unknown as TableSchema;
+
+    expect(getSchemaFieldNames(schema)).toEqual(["body", "title"]);
+  });
+
+  it("does not crash while closed when schema properties are absent", () => {
+    const schema = {
+      document_schemas: {
+        dynamic: {
+          schema: {
+            type: "object",
+          },
+        },
+      },
+    } as unknown as TableSchema;
+
+    expect(() =>
+      render(
+        <CreateIndexDialog
+          open={false}
+          onClose={() => undefined}
+          tableName="montessori_copilot_ft"
+          onIndexCreated={() => undefined}
+          schema={schema}
+        />
+      )
+    ).not.toThrow();
+  });
+});

--- a/ts/apps/antfarm/src/components/CreateIndexDialog.tsx
+++ b/ts/apps/antfarm/src/components/CreateIndexDialog.tsx
@@ -29,6 +29,22 @@ interface CreateIndexDialogProps {
   schema: TableSchema | null;
 }
 
+export function getSchemaFieldNames(schema: TableSchema | null): string[] {
+  if (!schema?.document_schemas || typeof schema.document_schemas !== "object") {
+    return [];
+  }
+
+  const fields = Object.values(schema.document_schemas).flatMap((documentSchema) => {
+    const properties = documentSchema?.schema?.properties;
+    if (!properties || typeof properties !== "object") {
+      return [];
+    }
+    return Object.keys(properties);
+  });
+
+  return [...new Set(fields)].sort((a, b) => a.localeCompare(b));
+}
+
 const indexFormSchema = z.object({
   name: z.string().min(1, "Index name is required."),
   dimension: z.number().optional(),
@@ -206,10 +222,7 @@ const CreateIndexDialog: React.FC<CreateIndexDialogProps> = ({
     setViewMode(newMode);
   };
 
-  const schemaFields =
-    schema?.document_schemas && Object.values(schema.document_schemas)[0]
-      ? Object.keys(Object.values(schema.document_schemas)[0].schema.properties)
-      : [];
+  const schemaFields = getSchemaFieldNames(schema);
 
   return (
     <Dialog open={open} onOpenChange={onClose}>


### PR DESCRIPTION
## Summary

Fixes a table-detail crash in Antfarm when a table schema contains a document schema entry without `schema.properties`.

The table details page mounts `CreateIndexDialog` even when the dialog is closed. That dialog derived field options with `Object.keys(...schema.properties)`, which throws when the API returns sparse/dynamic schema metadata.

## Changes

- Add a null-safe `getSchemaFieldNames` helper for deriving index field options.
- Collect fields across all document schemas instead of only the first one.
- Add regression coverage for property-less document schemas and the closed-dialog render path.

## Validation

- `pnpm --filter antfarm exec vitest --project unit src/components/CreateIndexDialog.test.tsx`

## Notes

- No embedded Antfarm bundle changes are included in this PR to keep the diff source-only.