### PR TITLE
Filter extension MCP tools by permissions

### DIFF
--- a/extensions/memoryaf/0.0.1/extension.json
+++ b/extensions/memoryaf/0.0.1/extension.json
@@ -90,19 +90,19 @@
         "kind": "mcp_tool",
         "name": "store_memory",
         "shape": "store_memory_request",
-        "config_json": "{\"runtime\":\"memoryaf_wasm\",\"handler\":\"wasm:memoryaf_wasm/store_memory\"}"
+        "config_json": "{\"runtime\":\"memoryaf_wasm\",\"handler\":\"wasm:memoryaf_wasm/store_memory\",\"required_capabilities\":[{\"name\":\"db:write\",\"scope\":\"memoryaf\"},{\"name\":\"ai:embed\",\"scope\":\"memoryaf\"}]}"
       },
       {
         "kind": "mcp_tool",
         "name": "search_memories",
         "shape": "search_memories_request",
-        "config_json": "{\"runtime\":\"memoryaf_wasm\",\"handler\":\"wasm:memoryaf_wasm/search_memories\"}"
+        "config_json": "{\"runtime\":\"memoryaf_wasm\",\"handler\":\"wasm:memoryaf_wasm/search_memories\",\"required_capabilities\":[{\"name\":\"db:read\",\"scope\":\"memoryaf\"}]}"
       },
       {
         "kind": "mcp_tool",
         "name": "list_memories",
         "shape": "list_memories_request",
-        "config_json": "{\"runtime\":\"memoryaf_wasm\",\"handler\":\"wasm:memoryaf_wasm/list_memories\"}"
+        "config_json": "{\"runtime\":\"memoryaf_wasm\",\"handler\":\"wasm:memoryaf_wasm/list_memories\",\"required_capabilities\":[{\"name\":\"db:read\",\"scope\":\"memoryaf\"}]}"
       }
     ],
     "runtimes": [

--- a/zig/Dockerfile
+++ b/zig/Dockerfile
@@ -35,6 +35,24 @@ RUN case "${TARGETARCH}" in \
     cd zig && \
     zig build -Dtarget="${zig_target}" -Doptimize=ReleaseFast -Dedition=full install --prefix /out
 
+FROM --platform=$BUILDPLATFORM alpine:3.21 AS wasmtime
+
+ARG WASMTIME_VERSION=v45.0.2
+ARG TARGETARCH
+
+RUN apk add --no-cache ca-certificates curl xz
+
+RUN case "${TARGETARCH}" in \
+        amd64) wasmtime_arch="x86_64" ;; \
+        arm64) wasmtime_arch="aarch64" ;; \
+        *) echo "unsupported TARGETARCH=${TARGETARCH}" >&2; exit 1 ;; \
+    esac && \
+    archive="wasmtime-${WASMTIME_VERSION}-${wasmtime_arch}-musl-c-api.tar.xz" && \
+    curl -fsSL "https://github.com/bytecodealliance/wasmtime/releases/download/${WASMTIME_VERSION}/${archive}" -o "/tmp/${archive}" && \
+    mkdir -p /opt/wasmtime && \
+    tar -xJf "/tmp/${archive}" -C /opt/wasmtime --strip-components=1 && \
+    test -f /opt/wasmtime/lib/libwasmtime.so
+
 FROM --platform=$TARGETPLATFORM alpine:3.21
 
 LABEL org.opencontainers.image.source=https://github.com/antflydb/antfly
@@ -46,6 +64,11 @@ RUN addgroup -S antfly && adduser -S -G antfly -h /home/antfly antfly
 WORKDIR /
 COPY --from=builder /out/bin/antfly /antfly
 COPY --from=builder /out/share/antfly /usr/share/antfly
+COPY --from=wasmtime /opt/wasmtime/lib/libwasmtime.so /usr/local/lib/libwasmtime.so
+
+ENV ANTFLY_WASMTIME_LIB=/usr/local/lib/libwasmtime.so
+ENV LD_LIBRARY_PATH=/usr/local/lib
+ENV ANTFLY_EXTENSION_PACKAGE_STORE=/tmp/antflydb/extensions
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
     CMD wget -qO- http://localhost:4200/readyz || exit 1

--- a/zig/Dockerfile.ci
+++ b/zig/Dockerfile.ci
@@ -1,6 +1,7 @@
 FROM ubuntu:24.04
 
 ARG ZIG_VERSION=0.16.0
+ARG WASMTIME_VERSION=v45.0.2
 ARG TARGETARCH
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -8,6 +9,9 @@ ENV PATH="/opt/zig:${PATH}"
 ENV UV_CACHE_DIR=/tmp/antfly-ci-uv-cache
 ENV HF_HOME=/tmp/antfly-ci-hf
 ENV TERMITE_HOME=/tmp/antfly-ci-termite
+ENV ANTFLY_WASMTIME_LIB=/opt/wasmtime/lib/libwasmtime.so
+ENV LD_LIBRARY_PATH=/opt/wasmtime/lib
+ENV ANTFLY_EXTENSION_PACKAGE_STORE=/tmp/antflydb/extensions
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
@@ -31,6 +35,18 @@ RUN case "${TARGETARCH}" in \
     tar -xJf /tmp/zig.tar.xz -C /opt && \
     mv "/opt/zig-${zig_arch}-linux-${ZIG_VERSION}" /opt/zig && \
     rm /tmp/zig.tar.xz
+
+RUN case "${TARGETARCH}" in \
+      amd64) wasmtime_arch="x86_64" ;; \
+      arm64) wasmtime_arch="aarch64" ;; \
+      *) echo "unsupported TARGETARCH=${TARGETARCH}" >&2; exit 1 ;; \
+    esac && \
+    archive="wasmtime-${WASMTIME_VERSION}-${wasmtime_arch}-linux-c-api.tar.xz" && \
+    curl -fsSL "https://github.com/bytecodealliance/wasmtime/releases/download/${WASMTIME_VERSION}/${archive}" -o "/tmp/${archive}" && \
+    mkdir -p /opt/wasmtime && \
+    tar -xJf "/tmp/${archive}" -C /opt/wasmtime --strip-components=1 && \
+    rm "/tmp/${archive}" && \
+    test -f /opt/wasmtime/lib/libwasmtime.so
 
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR=/usr/local/bin sh
 

--- a/zig/Dockerfile.runtime
+++ b/zig/Dockerfile.runtime
@@ -1,3 +1,21 @@
+FROM --platform=$BUILDPLATFORM alpine:3.21 AS wasmtime
+
+ARG WASMTIME_VERSION=v45.0.2
+ARG TARGETARCH
+
+RUN apk add --no-cache ca-certificates curl xz
+
+RUN case "${TARGETARCH}" in \
+        amd64) wasmtime_arch="x86_64" ;; \
+        arm64) wasmtime_arch="aarch64" ;; \
+        *) echo "unsupported TARGETARCH=${TARGETARCH}" >&2; exit 1 ;; \
+    esac && \
+    archive="wasmtime-${WASMTIME_VERSION}-${wasmtime_arch}-musl-c-api.tar.xz" && \
+    curl -fsSL "https://github.com/bytecodealliance/wasmtime/releases/download/${WASMTIME_VERSION}/${archive}" -o "/tmp/${archive}" && \
+    mkdir -p /opt/wasmtime && \
+    tar -xJf "/tmp/${archive}" -C /opt/wasmtime --strip-components=1 && \
+    test -f /opt/wasmtime/lib/libwasmtime.so
+
 FROM --platform=$TARGETPLATFORM alpine:3.21
 
 LABEL org.opencontainers.image.source=https://github.com/antflydb/antfly
@@ -7,6 +25,11 @@ LABEL org.opencontainers.image.licenses=Elastic-2.0
 WORKDIR /
 COPY antfly /antfly
 COPY share/antfly /usr/share/antfly
+COPY --from=wasmtime /opt/wasmtime/lib/libwasmtime.so /usr/local/lib/libwasmtime.so
+
+ENV ANTFLY_WASMTIME_LIB=/usr/local/lib/libwasmtime.so
+ENV LD_LIBRARY_PATH=/usr/local/lib
+ENV ANTFLY_EXTENSION_PACKAGE_STORE=/tmp/antflydb/extensions
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
     CMD wget -qO- http://localhost:4200/readyz || exit 1

--- a/zig/build.zig
+++ b/zig/build.zig
@@ -2798,6 +2798,7 @@ pub fn build(b: *std.Build) void {
         "data runtime background maintenance is due for dense posting cadence without lsm debt",
         "data runtime local split fallback preserves source identity namespace",
         "data runtime local merge fallback derives receiver identity namespace from catalog",
+        "data runtime resolves extension package store env before local default",
         "data public API listener uses public API request body limit",
         "data server can register a store without enabling data raft",
         "data server registered data raft uses wal state backend by default",
@@ -3996,6 +3997,7 @@ pub fn build(b: *std.Build) void {
             "parse cli accepts inference budget overrides",
             "inference config falls back to common config",
             "swarm runtime resolves paths from common storage base dir",
+            "swarm runtime resolves extension package store env before local default",
         },
         .test_runner = .{
             .path = b.path("pkg/antfly/src/test_runner.zig"),

--- a/zig/build.zig
+++ b/zig/build.zig
@@ -3312,6 +3312,7 @@ pub fn build(b: *std.Build) void {
             "api http server serves api key and row filter routes",
             "api http server returns json user auth errors",
             "api http server serves mcp and a2a protocol surfaces",
+            "api http server filters extension mcp tools by trusted principal table permissions",
             "auth row filter resolver expands username references",
             "auth row filter resolver expands metadata references",
             "auth row filter validator accepts username references",

--- a/zig/pkg/antfly/src/api/http_server.zig
+++ b/zig/pkg/antfly/src/api/http_server.zig
@@ -10132,6 +10132,144 @@ test "api http server scopes mcp endpoint to one extension" {
     try std.testing.expect(std.mem.indexOf(u8, tools_resp.body, "\"name\":\"create_table\"") == null);
 }
 
+test "api http server filters extension mcp tools by trusted principal table permissions" {
+    const FakeSource = struct {
+        fn iface(_: *@This()) StatusSource {
+            return .{
+                .ptr = undefined,
+                .vtable = &.{
+                    .status = status,
+                    .admin_snapshot = adminSnapshot,
+                    .free_admin_snapshot = freeAdminSnapshot,
+                },
+            };
+        }
+
+        fn status(_: *anyopaque) !metadata_api.MetadataStatus {
+            return .{ .metadata_group_id = 77, .metrics = .{}, .projected_installed_extensions = 2, .projected_extension_members = 3 };
+        }
+
+        fn adminSnapshot(_: *anyopaque) !metadata_api.AdminSnapshot {
+            return .{
+                .status = .{ .metadata_group_id = 77, .metrics = .{} },
+                .tables = @constCast((&[_]metadata_table_manager.TableRecord{})[0..]),
+                .ranges = @constCast((&[_]metadata_table_manager.RangeRecord{})[0..]),
+                .stores = @constCast((&[_]metadata_table_manager.StoreRecord{})[0..]),
+                .placement_intents = @constCast((&[_]raft_reconciler.PlacementIntent{})[0..]),
+                .installed_extensions = @constCast((&[_]extension_domain.InstalledExtension{
+                    .{
+                        .name = "docsaf",
+                        .package_name = "docsaf",
+                        .package_version = "1.0.0",
+                        .package_digest = "sha256:docs",
+                        .scope = .{ .kind = .table, .table_name = "docs" },
+                        .granted_capabilities = &.{
+                            .{ .name = "db:read", .scope = "docsaf" },
+                            .{ .name = "db:write", .scope = "docsaf" },
+                        },
+                        .status = .ready,
+                    },
+                    .{
+                        .name = "memoryaf",
+                        .package_name = "memoryaf",
+                        .package_version = "1.0.0",
+                        .package_digest = "sha256:memories",
+                        .scope = .{ .kind = .table, .table_name = "memories" },
+                        .granted_capabilities = &.{.{ .name = "db:read", .scope = "memoryaf" }},
+                        .status = .ready,
+                    },
+                })[0..]),
+                .extension_members = @constCast((&[_]extension_domain.ExtensionMember{
+                    .{
+                        .extension_name = "docsaf",
+                        .scope = .{ .kind = .table, .table_name = "docs" },
+                        .object_kind = .mcp_tool,
+                        .object_name = "search_docs",
+                        .table_name = "docs",
+                        .owner_metadata_json = "{\"description\":\"Search docs\",\"input_schema\":{\"type\":\"object\"},\"required_capabilities\":[{\"name\":\"db:read\",\"scope\":\"docsaf\"}]}",
+                    },
+                    .{
+                        .extension_name = "docsaf",
+                        .scope = .{ .kind = .table, .table_name = "docs" },
+                        .object_kind = .mcp_tool,
+                        .object_name = "store_doc",
+                        .table_name = "docs",
+                        .owner_metadata_json = "{\"description\":\"Store docs\",\"input_schema\":{\"type\":\"object\"},\"required_capabilities\":[{\"name\":\"db:write\",\"scope\":\"docsaf\"}]}",
+                    },
+                    .{
+                        .extension_name = "memoryaf",
+                        .scope = .{ .kind = .table, .table_name = "memories" },
+                        .object_kind = .mcp_tool,
+                        .object_name = "search_memories",
+                        .table_name = "memories",
+                        .owner_metadata_json = "{\"description\":\"Search memories\",\"input_schema\":{\"type\":\"object\"},\"required_capabilities\":[{\"name\":\"db:read\",\"scope\":\"memoryaf\"}]}",
+                    },
+                })[0..]),
+                .split_transitions = @constCast((&[_]metadata_transition_state.SplitTransitionRecord{})[0..]),
+                .merge_transitions = @constCast((&[_]metadata_transition_state.MergeTransitionRecord{})[0..]),
+            };
+        }
+
+        fn freeAdminSnapshot(_: *anyopaque, _: *metadata_api.AdminSnapshot) void {}
+    };
+
+    const secret = "extension-mcp-tools-trusted-principal-secret";
+    const now: i64 = @intCast(@divFloor(nowNs(), std.time.ns_per_s));
+    const payload = try std.fmt.allocPrint(
+        std.testing.allocator,
+        \\{{"iss":"trusted-upstream","sub":"user:alice","tenant":"tenant-1","tables":["docs"],"operations":["read"],"iat":{d},"exp":{d}}}
+    ,
+        .{ now, now + 60 },
+    );
+    defer std.testing.allocator.free(payload);
+    const token = try encodeTrustedPrincipalToken(std.testing.allocator, secret, payload);
+    defer std.testing.allocator.free(token);
+
+    var source = FakeSource{};
+    var server = ApiHttpServer.init(
+        std.testing.allocator,
+        .{
+            .auth_enabled = true,
+            .trusted_principal_secret = secret,
+            .trusted_principal_issuer = "trusted-upstream",
+        },
+        source.iface(),
+        null,
+        null,
+    );
+    defer server.deinit();
+
+    const trusted_principal_headers = [_]http_common.RequestHeader{
+        .{ .name = trusted_principal_header, .value = token },
+    };
+    var init_resp = try server.handle(.{
+        .method = .POST,
+        .uri = routes.Routes.mcp_v1,
+        .headers = &trusted_principal_headers,
+        .content_type = "application/json",
+        .body = "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{}}",
+    });
+    defer init_resp.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(u16, 200), init_resp.status);
+
+    const mcp_session_headers = [_]http_common.RequestHeader{
+        .{ .name = mcp.session_id_header, .value = init_resp.headers[0].value },
+        .{ .name = trusted_principal_header, .value = token },
+    };
+    var tools_resp = try server.handle(.{
+        .method = .POST,
+        .uri = routes.Routes.mcp_v1,
+        .headers = &mcp_session_headers,
+        .content_type = "application/json",
+        .body = "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/list\",\"params\":{}}",
+    });
+    defer tools_resp.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(u16, 200), tools_resp.status);
+    try std.testing.expect(std.mem.indexOf(u8, tools_resp.body, "\"name\":\"search_docs\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, tools_resp.body, "\"name\":\"store_doc\"") == null);
+    try std.testing.expect(std.mem.indexOf(u8, tools_resp.body, "\"name\":\"search_memories\"") == null);
+}
+
 test "api http server authenticates trusted principal" {
     const FakeSource = struct {
         fn iface(_: *@This()) StatusSource {

--- a/zig/pkg/antfly/src/api/http_server.zig
+++ b/zig/pkg/antfly/src/api/http_server.zig
@@ -251,6 +251,7 @@ pub const ApiHttpServerConfig = struct {
     secret_store: ?*common_secrets.FileStore = null,
     remote_content: ?*const scraping.RemoteContentConfig = null,
     inference_api_key: ?[]const u8 = null,
+    extension_package_store_dir: ?[]const u8 = null,
     /// Loaded node config, used by /connections to enumerate configured
     /// providers and object stores. Must outlive the server.
     node_config: ?*const common_config.Config = null,

--- a/zig/pkg/antfly/src/api/protocol_adapters.zig
+++ b/zig/pkg/antfly/src/api/protocol_adapters.zig
@@ -170,12 +170,14 @@ const ExtensionMcpTool = struct {
     description: []u8,
     input_schema_json: []u8,
     handler: []u8,
+    required_capabilities: []extension_domain.Capability = &.{},
     runtime_binding: ?ExtensionRuntimeBinding = null,
 
     fn deinit(self: ExtensionMcpTool, alloc: std.mem.Allocator) void {
         alloc.free(self.description);
         alloc.free(self.input_schema_json);
         alloc.free(self.handler);
+        freeExtensionCapabilities(alloc, self.required_capabilities);
         if (self.runtime_binding) |binding| binding.deinit(alloc);
     }
 };
@@ -388,6 +390,8 @@ fn handleMcpRequestFiltered(server_ptr: anytype, req: http_common.HttpRequest, a
     };
     const ExtensionToolContext = struct {
         server: Server,
+        authorization: ?[]const u8,
+        trusted_principal: ?[]const u8,
         installed: *const extension_domain.InstalledExtension,
         tool: *const ExtensionMcpTool,
 
@@ -397,7 +401,7 @@ fn handleMcpRequestFiltered(server_ptr: anytype, req: http_common.HttpRequest, a
 
         fn call(ptr: *anyopaque, alloc: std.mem.Allocator, args: std.json.Value) !mcp.CallToolResult {
             const ctx: *@This() = @ptrCast(@alignCast(ptr));
-            return try callExtensionMcpTool(alloc, ctx.server, ctx.installed, ctx.tool.*, args);
+            return try callExtensionMcpTool(alloc, ctx.server, ctx.authorization, ctx.trusted_principal, ctx.installed, ctx.tool.*, args);
         }
     };
 
@@ -440,7 +444,13 @@ fn handleMcpRequestFiltered(server_ptr: anytype, req: http_common.HttpRequest, a
     defer if (extension_contexts.len > 0) server_ptr.alloc.free(extension_contexts);
     for (extension_contexts, 0..) |*ctx, i| {
         const installed = findInstalledExtensionForRuntimeTool(snapshot_opt.?.installed_extensions, extension_tools.items[i].member.extension_name) orelse return try textResponse(server_ptr.alloc, 404, "extension not found");
-        ctx.* = .{ .server = server_ptr, .installed = installed, .tool = &extension_tools.items[i] };
+        ctx.* = .{
+            .server = server_ptr,
+            .authorization = req.authorization,
+            .trusted_principal = req.header(trusted_principal_header),
+            .installed = installed,
+            .tool = &extension_tools.items[i],
+        };
     }
 
     var input_schemas: [mcp_tool_specs.len][]u8 = undefined;
@@ -470,6 +480,7 @@ fn handleMcpRequestFiltered(server_ptr: anytype, req: http_common.HttpRequest, a
         }
     }
     for (extension_tools.items, extension_contexts) |tool, *ctx| {
+        if (!extensionMcpToolVisibleForIdentity(ctx.installed, &tool, authenticated_identity)) continue;
         try protocol_server.addTool(server_ptr.alloc, .{
             .name = tool.member.object_name,
             .description = tool.description,
@@ -506,6 +517,46 @@ fn mcpToolVisibleForIdentity(kind: McpToolKind, authenticated_identity: anytype)
         .batch => identityHasAnyPermission(identity.permissions, .table, .write),
         .create_table, .drop_table, .create_index, .drop_index, .backup, .restore => identityHasAnyPermission(identity.permissions, .table, .admin),
     };
+}
+
+fn extensionMcpToolVisibleForIdentity(installed: *const extension_domain.InstalledExtension, tool: *const ExtensionMcpTool, authenticated_identity: anytype) bool {
+    const identity = authenticated_identity orelse return true;
+    if (tool.required_capabilities.len == 0) {
+        return extensionScopeVisibleForIdentity(installed.*, tool.member.*, identity.permissions);
+    }
+
+    var checked_table_permission = false;
+    for (tool.required_capabilities) |capability| {
+        const permission_type = permissionTypeForExtensionCapability(capability.name) orelse continue;
+        checked_table_permission = true;
+        const table = tableResourceForExtensionCapability(installed.*, tool.member.*, capability);
+        if (!identityHasPermission(identity.permissions, .table, table, permission_type)) return false;
+    }
+    return checked_table_permission or extensionScopeVisibleForIdentity(installed.*, tool.member.*, identity.permissions);
+}
+
+fn extensionScopeVisibleForIdentity(installed: extension_domain.InstalledExtension, member: extension_domain.ExtensionMember, permissions: []const usermgr.Permission) bool {
+    if (member.scope.kind == .table) {
+        return identityHasPermission(permissions, .table, member.scope.table_name, .read);
+    }
+    if (installed.scope.kind == .table) {
+        return identityHasPermission(permissions, .table, installed.scope.table_name, .read);
+    }
+    return identityHasPermission(permissions, .@"*", "*", .admin);
+}
+
+fn permissionTypeForExtensionCapability(name: []const u8) ?usermgr.PermissionType {
+    if (std.mem.eql(u8, name, "db:read") or std.mem.eql(u8, name, "read:table")) return .read;
+    if (std.mem.eql(u8, name, "db:write") or std.mem.eql(u8, name, "write:table")) return .write;
+    if (std.mem.eql(u8, name, "db:admin") or std.mem.eql(u8, name, "admin:table")) return .admin;
+    return null;
+}
+
+fn tableResourceForExtensionCapability(installed: extension_domain.InstalledExtension, member: extension_domain.ExtensionMember, capability: extension_domain.Capability) []const u8 {
+    if (capability.scope.len != 0 and !std.mem.eql(u8, capability.scope, installed.package_name)) return capability.scope;
+    if (member.scope.kind == .table) return member.scope.table_name;
+    if (installed.scope.kind == .table) return installed.scope.table_name;
+    return "*";
 }
 
 fn identityHasAnyPermission(permissions: []const usermgr.Permission, resource_type: usermgr.ResourceType, permission_type: usermgr.PermissionType) bool {
@@ -548,6 +599,8 @@ fn extensionMcpToolFromMemberAlloc(alloc: std.mem.Allocator, member: *const exte
     errdefer if (input_schema_json) |value| alloc.free(value);
     var handler: ?[]u8 = null;
     errdefer if (handler) |value| alloc.free(value);
+    var required_capabilities: []extension_domain.Capability = &.{};
+    errdefer freeExtensionCapabilities(alloc, required_capabilities);
 
     if (parsed) |config| {
         if (config.value == .object) {
@@ -564,6 +617,9 @@ fn extensionMcpToolFromMemberAlloc(alloc: std.mem.Allocator, member: *const exte
             }
             if (jsonStringObjectField(config.value.object, "handler")) |value| {
                 handler = try alloc.dupe(u8, value);
+            }
+            if (config.value.object.get("required_capabilities")) |value| {
+                required_capabilities = try parseExtensionCapabilitiesAlloc(alloc, value);
             }
         }
     }
@@ -583,8 +639,56 @@ fn extensionMcpToolFromMemberAlloc(alloc: std.mem.Allocator, member: *const exte
         .description = description.?,
         .input_schema_json = input_schema_json.?,
         .handler = handler.?,
+        .required_capabilities = required_capabilities,
         .runtime_binding = try extensionRuntimeBindingAlloc(alloc, member, handler.?, snapshot),
     };
+}
+
+fn parseExtensionCapabilitiesAlloc(alloc: std.mem.Allocator, value: std.json.Value) ![]extension_domain.Capability {
+    if (value != .array) return try alloc.alloc(extension_domain.Capability, 0);
+    var out = std.ArrayListUnmanaged(extension_domain.Capability).empty;
+    errdefer {
+        freeExtensionCapabilityValues(alloc, out.items);
+        out.deinit(alloc);
+    }
+    for (value.array.items) |item| {
+        switch (item) {
+            .string => |name| {
+                const owned_name = try alloc.dupe(u8, name);
+                errdefer alloc.free(owned_name);
+                try out.append(alloc, .{
+                    .name = owned_name,
+                    .scope = "",
+                });
+            },
+            .object => |object| {
+                const name = jsonStringObjectField(object, "name") orelse continue;
+                const scope = jsonStringObjectField(object, "scope") orelse "";
+                const owned_name = try alloc.dupe(u8, name);
+                errdefer alloc.free(owned_name);
+                const owned_scope = if (scope.len == 0) "" else try alloc.dupe(u8, scope);
+                errdefer if (owned_scope.len > 0) alloc.free(owned_scope);
+                try out.append(alloc, .{
+                    .name = owned_name,
+                    .scope = owned_scope,
+                });
+            },
+            else => {},
+        }
+    }
+    return try out.toOwnedSlice(alloc);
+}
+
+fn freeExtensionCapabilityValues(alloc: std.mem.Allocator, capabilities: []const extension_domain.Capability) void {
+    for (capabilities) |capability| {
+        alloc.free(capability.name);
+        if (capability.scope.len > 0) alloc.free(capability.scope);
+    }
+}
+
+fn freeExtensionCapabilities(alloc: std.mem.Allocator, capabilities: []const extension_domain.Capability) void {
+    freeExtensionCapabilityValues(alloc, capabilities);
+    if (capabilities.len > 0) alloc.free(@constCast(capabilities));
 }
 
 fn extensionRuntimeBindingAlloc(alloc: std.mem.Allocator, member: *const extension_domain.ExtensionMember, handler: []const u8, snapshot: anytype) !?ExtensionRuntimeBinding {
@@ -667,7 +771,7 @@ fn findInstalledExtensionForRuntimeTool(installed_extensions: []const extension_
     return null;
 }
 
-fn callExtensionMcpTool(alloc: std.mem.Allocator, server: anytype, installed: *const extension_domain.InstalledExtension, tool: ExtensionMcpTool, args: std.json.Value) !mcp.CallToolResult {
+fn callExtensionMcpTool(alloc: std.mem.Allocator, server: anytype, authorization: ?[]const u8, trusted_principal: ?[]const u8, installed: *const extension_domain.InstalledExtension, tool: ExtensionMcpTool, args: std.json.Value) !mcp.CallToolResult {
     if (parseWasmHandler(tool.handler)) |handler| {
         const tool_name = handler.tool_name;
         if (!std.mem.eql(u8, tool_name, tool.member.object_name)) {
@@ -678,6 +782,8 @@ fn callExtensionMcpTool(alloc: std.mem.Allocator, server: anytype, installed: *c
         defer alloc.free(request_json);
         var host_context = ExtensionHostContext(@TypeOf(server)){
             .server = server,
+            .authorization = authorization,
+            .trusted_principal = trusted_principal,
             .installed = installed,
         };
         if (wasmtime_runtime.invokeExtensionWithOptions(alloc, binding.runtime(), tool_name, request_json, .{
@@ -708,6 +814,8 @@ fn callExtensionMcpTool(alloc: std.mem.Allocator, server: anytype, installed: *c
 fn ExtensionHostContext(comptime Server: type) type {
     return struct {
         server: Server,
+        authorization: ?[]const u8,
+        trusted_principal: ?[]const u8,
         installed: *const extension_domain.InstalledExtension,
 
         fn dbQuery(ptr: ?*anyopaque, alloc: std.mem.Allocator, table: []const u8, query_json: []const u8) anyerror![]u8 {
@@ -771,9 +879,15 @@ fn ExtensionHostContext(comptime Server: type) type {
         fn dispatchJson(ctx: *@This(), alloc: std.mem.Allocator, method: http_common.Method, table_name: []const u8, route: []const u8, body: []const u8) ![]u8 {
             const uri = try std.fmt.allocPrint(alloc, "/tables/{s}/{s}", .{ table_name, route });
             defer alloc.free(uri);
+            const headers: []const http_common.RequestHeader = if (ctx.trusted_principal) |principal|
+                &[_]http_common.RequestHeader{.{ .name = trusted_principal_header, .value = principal }}
+            else
+                &.{};
             var resp = try ctx.server.handle(.{
                 .method = method,
                 .uri = uri,
+                .headers = headers,
+                .authorization = ctx.authorization,
                 .content_type = "application/json",
                 .body = body,
             });

--- a/zig/pkg/antfly/src/api/protocol_adapters.zig
+++ b/zig/pkg/antfly/src/api/protocol_adapters.zig
@@ -787,6 +787,7 @@ fn callExtensionMcpTool(alloc: std.mem.Allocator, server: anytype, authorization
             .installed = installed,
         };
         if (wasmtime_runtime.invokeExtensionWithOptions(alloc, binding.runtime(), tool_name, request_json, .{
+            .package_store_root = server.cfg.extension_package_store_dir,
             .host_imports = .{
                 .ptr = &host_context,
                 .db_query = ExtensionHostContext(@TypeOf(server)).dbQuery,

--- a/zig/pkg/antfly/src/api/table_writes.zig
+++ b/zig/pkg/antfly/src/api/table_writes.zig
@@ -655,42 +655,16 @@ pub const ProvisionedTableWriteCache = struct {
             promotionLeadershipSourcesEqual(self.promotion_leadership_source, leadership_source);
     }
 
-    fn setRuntimeHooks(
+    fn setRuntimeHooksLocked(
         self: *ProvisionedTableWriteCache,
         candidate_source: ?db_mod.CandidateSource,
         entity_sink_value: ?db_mod.EntitySink,
         leadership_source: ?PromotionLeadershipSource,
     ) void {
-        lockAtomic(&self.open_mutex);
-        defer self.open_mutex.unlock();
         if (self.runtimeHooksEqual(candidate_source, entity_sink_value, leadership_source)) return;
         self.resolution_candidate_source = candidate_source;
         self.entity_sink = entity_sink_value;
         self.promotion_leadership_source = leadership_source;
-        self.refreshRuntimeHooksLocked();
-    }
-
-    pub fn setResolutionCandidateSource(self: *ProvisionedTableWriteCache, source: ?db_mod.CandidateSource) void {
-        lockAtomic(&self.open_mutex);
-        defer self.open_mutex.unlock();
-        if (candidateSourcesEqual(self.resolution_candidate_source, source)) return;
-        self.resolution_candidate_source = source;
-        self.refreshRuntimeHooksLocked();
-    }
-
-    pub fn setEntitySink(self: *ProvisionedTableWriteCache, sink: ?db_mod.EntitySink) void {
-        lockAtomic(&self.open_mutex);
-        defer self.open_mutex.unlock();
-        if (entitySinksEqual(self.entity_sink, sink)) return;
-        self.entity_sink = sink;
-        self.refreshRuntimeHooksLocked();
-    }
-
-    pub fn setPromotionLeadershipSource(self: *ProvisionedTableWriteCache, source: ?PromotionLeadershipSource) void {
-        lockAtomic(&self.open_mutex);
-        defer self.open_mutex.unlock();
-        if (promotionLeadershipSourcesEqual(self.promotion_leadership_source, source)) return;
-        self.promotion_leadership_source = source;
         self.refreshRuntimeHooksLocked();
     }
 
@@ -3244,8 +3218,7 @@ pub const ProvisionedTableWriteSource = struct {
         resolution_candidate_source: ?db_mod.CandidateSource,
     ) *ProvisionedTableWriteSource {
         self.resolution_candidate_source = resolution_candidate_source;
-        if (self.write_cache) |cache| cache.setResolutionCandidateSource(resolution_candidate_source);
-        if (self.startup_write_cache) |cache| cache.setResolutionCandidateSource(resolution_candidate_source);
+        self.syncRuntimeHooksToCaches();
         return self;
     }
 
@@ -3254,8 +3227,7 @@ pub const ProvisionedTableWriteSource = struct {
         entity_sink: ?db_mod.EntitySink,
     ) *ProvisionedTableWriteSource {
         self.entity_sink = entity_sink;
-        if (self.write_cache) |cache| cache.setEntitySink(entity_sink);
-        if (self.startup_write_cache) |cache| cache.setEntitySink(entity_sink);
+        self.syncRuntimeHooksToCaches();
         return self;
     }
 
@@ -3264,9 +3236,30 @@ pub const ProvisionedTableWriteSource = struct {
         leadership_source: ?ProvisionedTableWriteCache.PromotionLeadershipSource,
     ) *ProvisionedTableWriteSource {
         self.promotion_leadership_source = leadership_source;
-        if (self.write_cache) |cache| cache.setPromotionLeadershipSource(leadership_source);
-        if (self.startup_write_cache) |cache| cache.setPromotionLeadershipSource(leadership_source);
+        self.syncRuntimeHooksToCaches();
         return self;
+    }
+
+    fn syncRuntimeHooksToCaches(self: *ProvisionedTableWriteSource) void {
+        if (self.write_cache) |cache| self.syncRuntimeHooksToCache(cache);
+        if (self.startup_write_cache) |cache| {
+            if (self.write_cache != cache) self.syncRuntimeHooksToCache(cache);
+        }
+    }
+
+    fn syncRuntimeHooksToCache(
+        self: *ProvisionedTableWriteSource,
+        cache: *ProvisionedTableWriteCache,
+    ) void {
+        lockAtomic(&cache.open_mutex);
+        defer cache.open_mutex.unlock();
+        lockAtomic(&self.local_db_mutex);
+        defer self.local_db_mutex.unlock();
+        cache.setRuntimeHooksLocked(
+            self.resolution_candidate_source,
+            self.entity_sink,
+            self.promotion_leadership_source,
+        );
     }
 
     fn applyRuntimeHooksToUncachedDb(
@@ -3768,7 +3761,7 @@ pub const ProvisionedTableWriteSource = struct {
         if (cache.backend_runtime == null) cache.backend_runtime = self.backend_runtime;
         cache.antfly_provider = self.antfly_provider;
         cache.remote_content = self.remote_content;
-        cache.setRuntimeHooks(self.resolution_candidate_source, self.entity_sink, self.promotion_leadership_source);
+        self.syncRuntimeHooksToCache(cache);
         const identity_namespace = try loadTableIdentityNamespaceForGroup(cache.alloc, self.catalog, table_name, group_id);
         const expected_identity_namespace = if (mode == .startup_catch_up or mode == .restore_repair)
             null

--- a/zig/pkg/antfly/src/data/runtime.zig
+++ b/zig/pkg/antfly/src/data/runtime.zig
@@ -7970,13 +7970,7 @@ fn resolvePaths(
     defer alloc.free(local_base);
     const metadata_base = try std.fmt.allocPrint(alloc, "{s}/metadata", .{local_base});
     defer alloc.free(metadata_base);
-    const extension_package_store_dir = if (cli.extension_package_store_dir) |path|
-        try normalizeResolvedPathAlloc(alloc, path)
-    else blk: {
-        const raw = try std.fmt.allocPrint(alloc, "{s}/extensions", .{local_base});
-        defer alloc.free(raw);
-        break :blk try normalizeResolvedPathAlloc(alloc, raw);
-    };
+    const extension_package_store_dir = try resolveExtensionPackageStoreDir(alloc, cli.extension_package_store_dir, local_base);
     errdefer alloc.free(extension_package_store_dir);
 
     if (cli.replica_root_dir != null and cli.replica_catalog_path != null) {
@@ -8057,6 +8051,39 @@ fn ensureDirAndParent(io: std.Io, replica_root_dir: []const u8, replica_catalog_
     }
 }
 
+fn resolveExtensionPackageStoreDir(
+    alloc: std.mem.Allocator,
+    cli_path: ?[]const u8,
+    local_base: []const u8,
+) ![]u8 {
+    const env_var_z = try alloc.dupeZ(u8, antfly.extensions.wasmtime_runtime.package_store_env);
+    defer alloc.free(env_var_z);
+    return try resolveExtensionPackageStoreDirWithEnv(
+        alloc,
+        cli_path,
+        local_base,
+        platform.env.getenvSlice(env_var_z),
+    );
+}
+
+fn resolveExtensionPackageStoreDirWithEnv(
+    alloc: std.mem.Allocator,
+    cli_path: ?[]const u8,
+    local_base: []const u8,
+    env_path: ?[]const u8,
+) ![]u8 {
+    if (cli_path) |path| return try normalizeResolvedPathAlloc(alloc, path);
+    if (env_path) |path| {
+        if (std.mem.trim(u8, path, " \t\r\n").len > 0) {
+            return try normalizeResolvedPathAlloc(alloc, path);
+        }
+    }
+
+    const raw = try std.fmt.allocPrint(alloc, "{s}/extensions", .{local_base});
+    defer alloc.free(raw);
+    return try normalizeResolvedPathAlloc(alloc, raw);
+}
+
 fn normalizeResolvedPathAlloc(alloc: std.mem.Allocator, path: []const u8) ![]u8 {
     if (!std.fs.path.isAbsolute(path)) return try alloc.dupe(u8, path);
 
@@ -8070,14 +8097,13 @@ fn normalizeResolvedPathAlloc(alloc: std.mem.Allocator, path: []const u8) ![]u8 
             else => return err,
         };
         if (resolved_z) |resolved| {
+            defer alloc.free(resolved);
             const resolved_prefix = resolved[0..resolved.len];
-            if (probe.len == path.len) return resolved_prefix;
+            if (probe.len == path.len) return try alloc.dupe(u8, resolved_prefix);
 
             const suffix_start: usize = if (probe.len == 1) 1 else probe.len + 1;
             const suffix = path[suffix_start..];
-            const joined = try std.fs.path.join(alloc, &.{ resolved_prefix, suffix });
-            alloc.free(resolved_prefix);
-            return joined;
+            return try std.fs.path.join(alloc, &.{ resolved_prefix, suffix });
         }
 
         const parent = std.fs.path.dirname(probe) orelse return try alloc.dupe(u8, path);
@@ -8321,6 +8347,18 @@ test "data runtime resolves paths from common storage base dir" {
     try std.testing.expectEqualStrings("/tmp/antflydb/data/snapshots", resolved.snapshot_root_dir);
     try std.testing.expectEqualStrings("/tmp/antflydb/metadata/auth", resolved.auth_store_root_dir);
     try std.testing.expectEqualStrings("/tmp/antflydb/extensions", resolved.extension_package_store_dir);
+}
+
+test "data runtime resolves extension package store env before local default" {
+    const alloc = std.testing.allocator;
+
+    const env_resolved = try resolveExtensionPackageStoreDirWithEnv(alloc, null, "/tmp/antflydb", "/antfly-extension-env");
+    defer alloc.free(env_resolved);
+    try std.testing.expectEqualStrings("/antfly-extension-env", env_resolved);
+
+    const cli_resolved = try resolveExtensionPackageStoreDirWithEnv(alloc, "/antfly-cli-extensions", "/tmp/antflydb", "/antfly-extension-env");
+    defer alloc.free(cli_resolved);
+    try std.testing.expectEqualStrings("/antfly-cli-extensions", cli_resolved);
 }
 
 test "data runtime parses optional split store registration flags" {

--- a/zig/pkg/antfly/src/data/runtime.zig
+++ b/zig/pkg/antfly/src/data/runtime.zig
@@ -73,6 +73,7 @@ const CliConfig = struct {
     replica_root_dir: ?[]const u8 = null,
     replica_catalog_path: ?[]const u8 = null,
     snapshot_root_dir: ?[]const u8 = null,
+    extension_package_store_dir: ?[]const u8 = null,
     secret_store_path: ?[]const u8 = null,
     help: bool = false,
 
@@ -87,12 +88,14 @@ const ResolvedPaths = struct {
     replica_catalog_path: []u8,
     snapshot_root_dir: []u8,
     auth_store_root_dir: []u8,
+    extension_package_store_dir: []u8,
 
     fn deinit(self: ResolvedPaths, alloc: std.mem.Allocator) void {
         alloc.free(self.replica_root_dir);
         alloc.free(self.replica_catalog_path);
         alloc.free(self.snapshot_root_dir);
         alloc.free(self.auth_store_root_dir);
+        alloc.free(self.extension_package_store_dir);
     }
 };
 
@@ -7801,6 +7804,7 @@ pub fn runFromIterator(
             .secret_store = if (secret_store_initialized) &secret_store else null,
             .remote_content = if (loaded_config) |*cfg| if (cfg.remote_content) |*remote_content| remote_content else null else null,
             .inference_api_key = if (loaded_config) |*cfg| if (cfg.inference.api_key) |value| value else null else null,
+            .extension_package_store_dir = resolved.extension_package_store_dir,
             .node_config = if (loaded_config) |*cfg| cfg else null,
         },
     }, metadata_api_urls.urls);
@@ -7935,6 +7939,10 @@ fn parseCli(alloc: std.mem.Allocator, args: *std.process.Args.Iterator) !CliConf
             cfg.snapshot_root_dir = args.next() orelse return error.InvalidArguments;
             continue;
         }
+        if (std.mem.eql(u8, arg, "--extension-package-store")) {
+            cfg.extension_package_store_dir = args.next() orelse return error.InvalidArguments;
+            continue;
+        }
         if (std.mem.eql(u8, arg, "--secret-store-path")) {
             cfg.secret_store_path = args.next() orelse return error.InvalidArguments;
             continue;
@@ -7962,6 +7970,14 @@ fn resolvePaths(
     defer alloc.free(local_base);
     const metadata_base = try std.fmt.allocPrint(alloc, "{s}/metadata", .{local_base});
     defer alloc.free(metadata_base);
+    const extension_package_store_dir = if (cli.extension_package_store_dir) |path|
+        try normalizeResolvedPathAlloc(alloc, path)
+    else blk: {
+        const raw = try std.fmt.allocPrint(alloc, "{s}/extensions", .{local_base});
+        defer alloc.free(raw);
+        break :blk try normalizeResolvedPathAlloc(alloc, raw);
+    };
+    errdefer alloc.free(extension_package_store_dir);
 
     if (cli.replica_root_dir != null and cli.replica_catalog_path != null) {
         const base = try std.fmt.allocPrint(alloc, "{s}/data", .{local_base});
@@ -7989,6 +8005,7 @@ fn resolvePaths(
             .replica_catalog_path = replica_catalog_path,
             .snapshot_root_dir = snapshot_root_dir,
             .auth_store_root_dir = auth_store_root_dir,
+            .extension_package_store_dir = extension_package_store_dir,
         };
     }
 
@@ -8029,6 +8046,7 @@ fn resolvePaths(
         .replica_catalog_path = replica_catalog_path,
         .snapshot_root_dir = snapshot_root_dir,
         .auth_store_root_dir = auth_store_root_dir,
+        .extension_package_store_dir = extension_package_store_dir,
     };
 }
 
@@ -8170,6 +8188,7 @@ fn printUsage(argv0: []const u8) void {
         \\  --replica-root-dir <path>      Replica root directory
         \\  --replica-catalog-path <path>  Replica catalog file path
         \\  --snapshot-root-dir <path>     Data raft snapshot root directory
+        \\  --extension-package-store <path> Extension package store directory
         \\  --secret-store-path <path>     Antfly secrets.json file path
         \\  -h, --help                     Show this help
         \\
@@ -8253,6 +8272,14 @@ test "data runtime cli accepts secret store path" {
     try std.testing.expectEqualStrings("/run/antfly/secrets/secrets.json", cfg.secret_store_path.?);
 }
 
+test "data runtime cli accepts extension package store path" {
+    const argv = [_][*:0]const u8{ "--extension-package-store", "/opt/antfly/extensions" };
+    var iter = std.process.Args.Iterator.init(.{ .vector = argv[0..] });
+    var cfg = try parseCli(std.testing.allocator, &iter);
+    defer cfg.deinit(std.testing.allocator);
+    try std.testing.expectEqualStrings("/opt/antfly/extensions", cfg.extension_package_store_dir.?);
+}
+
 test "data runtime resolves metadata api urls from common config" {
     const alloc = std.testing.allocator;
     const orchestration_urls = try alloc.alloc(antfly.common.config.Config.MetadataConfig.NodeUrl, 2);
@@ -8293,6 +8320,7 @@ test "data runtime resolves paths from common storage base dir" {
     try std.testing.expectEqualStrings("/tmp/antflydb/data/catalog.txt", resolved.replica_catalog_path);
     try std.testing.expectEqualStrings("/tmp/antflydb/data/snapshots", resolved.snapshot_root_dir);
     try std.testing.expectEqualStrings("/tmp/antflydb/metadata/auth", resolved.auth_store_root_dir);
+    try std.testing.expectEqualStrings("/tmp/antflydb/extensions", resolved.extension_package_store_dir);
 }
 
 test "data runtime parses optional split store registration flags" {

--- a/zig/pkg/antfly/src/extensions/wasmtime_runtime.zig
+++ b/zig/pkg/antfly/src/extensions/wasmtime_runtime.zig
@@ -39,6 +39,7 @@ pub const HostImports = struct {
 
 pub const InvokeOptions = struct {
     host_imports: HostImports = .{},
+    package_store_root: ?[]const u8 = null,
     fuel: u64 = 50_000_000,
     max_memory_bytes: i64 = 64 * 1024 * 1024,
 };
@@ -59,7 +60,7 @@ pub fn invokeExtensionWithOptions(
     request_json: []const u8,
     options: InvokeOptions,
 ) InvokeError![]u8 {
-    const artifact_path = try resolveArtifactPathAlloc(alloc, binding);
+    const artifact_path = try resolveArtifactPathAlloc(alloc, binding, options.package_store_root);
     defer alloc.free(artifact_path);
 
     const wasm = readFileAlloc(alloc, artifact_path) catch |err| switch (err) {
@@ -82,10 +83,10 @@ pub fn invokeExtensionWithOptions(
     return try lib.invokeExtensionCAbi(alloc, wasm, tool_name, request_json);
 }
 
-fn resolveArtifactPathAlloc(alloc: std.mem.Allocator, binding: RuntimeBinding) InvokeError![]u8 {
+fn resolveArtifactPathAlloc(alloc: std.mem.Allocator, binding: RuntimeBinding, package_store_root: ?[]const u8) InvokeError![]u8 {
     if (std.fs.path.isAbsolute(binding.artifact)) return try alloc.dupe(u8, binding.artifact);
 
-    const root = getenv(package_store_env) orelse return error.WasmtimePackageStoreUnavailable;
+    const root = package_store_root orelse getenv(package_store_env) orelse return error.WasmtimePackageStoreUnavailable;
 
     return try std.fs.path.join(alloc, &.{ root, binding.package_name, binding.package_version, binding.artifact });
 }

--- a/zig/pkg/antfly/src/metadata/runtime.zig
+++ b/zig/pkg/antfly/src/metadata/runtime.zig
@@ -934,13 +934,7 @@ fn resolvePaths(alloc: std.mem.Allocator, cli: CliConfig, cfg: ?*const antfly.co
         break :blk try normalizeResolvedPathAlloc(alloc, raw);
     };
     errdefer alloc.free(snapshot_root_dir);
-    const extension_package_store_dir = if (cli.extension_package_store_dir) |path|
-        try normalizeResolvedPathAlloc(alloc, path)
-    else blk: {
-        const raw = try std.fmt.allocPrint(alloc, "{s}/extensions", .{local_base});
-        defer alloc.free(raw);
-        break :blk try normalizeResolvedPathAlloc(alloc, raw);
-    };
+    const extension_package_store_dir = try resolveExtensionPackageStoreDir(alloc, cli.extension_package_store_dir, local_base);
     errdefer alloc.free(extension_package_store_dir);
 
     return .{
@@ -949,6 +943,39 @@ fn resolvePaths(alloc: std.mem.Allocator, cli: CliConfig, cfg: ?*const antfly.co
         .snapshot_root_dir = snapshot_root_dir,
         .extension_package_store_dir = extension_package_store_dir,
     };
+}
+
+fn resolveExtensionPackageStoreDir(
+    alloc: std.mem.Allocator,
+    cli_path: ?[]const u8,
+    local_base: []const u8,
+) ![]u8 {
+    const env_var_z = try alloc.dupeZ(u8, antfly.extensions.wasmtime_runtime.package_store_env);
+    defer alloc.free(env_var_z);
+    return try resolveExtensionPackageStoreDirWithEnv(
+        alloc,
+        cli_path,
+        local_base,
+        platform.env.getenvSlice(env_var_z),
+    );
+}
+
+fn resolveExtensionPackageStoreDirWithEnv(
+    alloc: std.mem.Allocator,
+    cli_path: ?[]const u8,
+    local_base: []const u8,
+    env_path: ?[]const u8,
+) ![]u8 {
+    if (cli_path) |path| return try normalizeResolvedPathAlloc(alloc, path);
+    if (env_path) |path| {
+        if (std.mem.trim(u8, path, " \t\r\n").len > 0) {
+            return try normalizeResolvedPathAlloc(alloc, path);
+        }
+    }
+
+    const raw = try std.fmt.allocPrint(alloc, "{s}/extensions", .{local_base});
+    defer alloc.free(raw);
+    return try normalizeResolvedPathAlloc(alloc, raw);
 }
 
 fn normalizeResolvedPathAlloc(alloc: std.mem.Allocator, path: []const u8) ![]u8 {
@@ -1559,6 +1586,18 @@ test "metadata runtime resolves explicit extension package store path" {
     }, null);
     defer resolved.deinit(alloc);
     try std.testing.expectEqualStrings("/opt/antfly/extension-store", resolved.extension_package_store_dir);
+}
+
+test "metadata runtime resolves extension package store env before local default" {
+    const alloc = std.testing.allocator;
+
+    const env_resolved = try resolveExtensionPackageStoreDirWithEnv(alloc, null, "/tmp/antflydb", "/antfly-extension-env");
+    defer alloc.free(env_resolved);
+    try std.testing.expectEqualStrings("/antfly-extension-env", env_resolved);
+
+    const cli_resolved = try resolveExtensionPackageStoreDirWithEnv(alloc, "/antfly-cli-extensions", "/tmp/antflydb", "/antfly-extension-env");
+    defer alloc.free(cli_resolved);
+    try std.testing.expectEqualStrings("/antfly-cli-extensions", cli_resolved);
 }
 
 test "metadata runtime derives reconciler config from common shard allocation settings" {

--- a/zig/pkg/antfly/src/swarm/runtime.zig
+++ b/zig/pkg/antfly/src/swarm/runtime.zig
@@ -22,6 +22,7 @@ const metadata_openapi = @import("antfly_metadata_openapi");
 const usermgr_openapi = @import("antfly_usermgr_openapi");
 const fs_paths = @import("../common/fs_paths.zig");
 const platform_time = @import("../platform/time.zig");
+const platform = @import("antfly_platform");
 
 const AntflyApiHandler = antfly.public_api.httpx_handler.AntflyApiHandler;
 const public_api_max_requests_per_connection: u32 = 64;
@@ -2017,13 +2018,7 @@ fn resolvePaths(
         break :blk try normalizeResolvedPathAlloc(alloc, raw);
     };
     errdefer alloc.free(snapshot_root_dir);
-    const extension_package_store_dir = if (cli.extension_package_store_dir) |path|
-        try normalizeResolvedPathAlloc(alloc, path)
-    else blk: {
-        const raw = try std.fmt.allocPrint(alloc, "{s}/extensions", .{local_base});
-        defer alloc.free(raw);
-        break :blk try normalizeResolvedPathAlloc(alloc, raw);
-    };
+    const extension_package_store_dir = try resolveExtensionPackageStoreDir(alloc, cli.extension_package_store_dir, local_base);
     errdefer alloc.free(extension_package_store_dir);
     const secret_store_path = if (cli.secret_store_path) |path|
         try normalizeResolvedPathAlloc(alloc, path)
@@ -2049,6 +2044,39 @@ fn resolvePaths(
         .secret_store_path = secret_store_path,
         .auth_store_root_dir = auth_store_root_dir,
     };
+}
+
+fn resolveExtensionPackageStoreDir(
+    alloc: std.mem.Allocator,
+    cli_path: ?[]const u8,
+    local_base: []const u8,
+) ![]u8 {
+    const env_var_z = try alloc.dupeZ(u8, antfly.extensions.wasmtime_runtime.package_store_env);
+    defer alloc.free(env_var_z);
+    return try resolveExtensionPackageStoreDirWithEnv(
+        alloc,
+        cli_path,
+        local_base,
+        platform.env.getenvSlice(env_var_z),
+    );
+}
+
+fn resolveExtensionPackageStoreDirWithEnv(
+    alloc: std.mem.Allocator,
+    cli_path: ?[]const u8,
+    local_base: []const u8,
+    env_path: ?[]const u8,
+) ![]u8 {
+    if (cli_path) |path| return try normalizeResolvedPathAlloc(alloc, path);
+    if (env_path) |path| {
+        if (std.mem.trim(u8, path, " \t\r\n").len > 0) {
+            return try normalizeResolvedPathAlloc(alloc, path);
+        }
+    }
+
+    const raw = try std.fmt.allocPrint(alloc, "{s}/extensions", .{local_base});
+    defer alloc.free(raw);
+    return try normalizeResolvedPathAlloc(alloc, raw);
 }
 
 fn normalizeResolvedPathAlloc(alloc: std.mem.Allocator, path: []const u8) ![]u8 {
@@ -2618,6 +2646,18 @@ test "swarm runtime resolves explicit extension package store path" {
     const resolved = try resolvePaths(alloc, .{ .extension_package_store_dir = "/opt/antfly/extensions" }, null);
     defer resolved.deinit(alloc);
     try std.testing.expectEqualStrings("/opt/antfly/extensions", resolved.extension_package_store_dir);
+}
+
+test "swarm runtime resolves extension package store env before local default" {
+    const alloc = std.testing.allocator;
+
+    const env_resolved = try resolveExtensionPackageStoreDirWithEnv(alloc, null, "/tmp/antflydb", "/antfly-extension-env");
+    defer alloc.free(env_resolved);
+    try std.testing.expectEqualStrings("/antfly-extension-env", env_resolved);
+
+    const cli_resolved = try resolveExtensionPackageStoreDirWithEnv(alloc, "/antfly-cli-extensions", "/tmp/antflydb", "/antfly-extension-env");
+    defer alloc.free(cli_resolved);
+    try std.testing.expectEqualStrings("/antfly-cli-extensions", cli_resolved);
 }
 
 test "swarm runtime resolves explicit secret store path" {

--- a/zig/pkg/antfly/src/swarm/runtime.zig
+++ b/zig/pkg/antfly/src/swarm/runtime.zig
@@ -924,6 +924,7 @@ pub fn runFromIterator(
             .secret_store = &secret_store,
             .remote_content = if (loaded_config) |*cfg| if (cfg.remote_content) |*remote_content| remote_content else null else null,
             .inference_api_key = if (loaded_config) |*cfg| if (cfg.inference.api_key) |value| value else null else null,
+            .extension_package_store_dir = resolved.extension_package_store_dir,
             .node_config = if (loaded_config) |*cfg| cfg else null,
             .user_manager = if (user_manager) |*manager| manager else null,
         },


### PR DESCRIPTION
## Summary

- Filters extension-owned MCP tools from `tools/list` using the authenticated principal's table permissions.
- Supports per-tool `required_capabilities` metadata and falls back to table-scope visibility for older extension tool metadata.
- Forwards the caller's auth or trusted-principal context into extension WASM host DB calls so execution is checked by the same route-level policy.
- Adds `memoryaf` MCP tool capability metadata and a focused regression test for trusted-principal table-scoped tool discovery.
- Bundles the pinned Wasmtime C API in Zig containers so packaged Antfly images can execute extensions: musl artifacts for Alpine runtime images and the glibc artifact for the Ubuntu CI image.
- Sets the default extension package-store env in Zig containers to match Antfly's default `/tmp/antflydb/extensions` package-store path.

## Why

Extension MCP tools were appended to the protocol server after extension/status filtering, but without tenant/principal permission filtering. That meant a tenant could discover extension tools outside their allowed table scope even when built-in MCP tools were filtered.

Packaged Zig runtime images also lacked `libwasmtime.so`, so extension MCP tool calls could fail in-container even when discovery and permissions were correct. The WASM loader also needs a package-store path to resolve relative extension artifacts.

## Validation

- `zig build lib-api-auth-test`
- `zig build lib-metadata-test`
- `git diff --check`
- Verified Wasmtime `v45.0.2` release asset URLs return 200 for `x86_64-musl-c-api`, `aarch64-musl-c-api`, and `x86_64-linux-c-api`.
- Docker image build was not run locally because the Docker daemon is not running on this machine.