### PR TITLE
Fix backup job URL configuration

### DIFF
--- a/go/pkg/antfly/cmd/cmd/cli/config_test.go
+++ b/go/pkg/antfly/cmd/cmd/cli/config_test.go
@@ -121,3 +121,17 @@ func TestBackupListJSONWritesStdout(t *testing.T) {
 		t.Fatalf("stdout did not contain backup JSON: %s", out.String())
 	}
 }
+
+func TestBackupListRejectsJSONL(t *testing.T) {
+	cmd := newBackupCmd()
+	cmd.PreRunE = nil
+	cmd.SetArgs([]string{"--list", "--location", "s3://bucket/backups", "-o", "jsonl"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("backup --list -o jsonl succeeded, want error")
+	}
+	if !strings.Contains(err.Error(), "supports output formats table and json") {
+		t.Fatalf("backup --list -o jsonl error = %q", err)
+	}
+}

--- a/go/pkg/antfly/cmd/cmd/cli/config_test.go
+++ b/go/pkg/antfly/cmd/cmd/cli/config_test.go
@@ -17,6 +17,11 @@ limitations under the License.
 package cli
 
 import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -65,5 +70,54 @@ func TestResolveTokenPrefersFlag(t *testing.T) {
 
 	if got := resolveToken(cmd); got != "flag-token" {
 		t.Fatalf("resolveToken = %q", got)
+	}
+}
+
+func TestBackupListJSONWritesStdout(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/db/v1/backups" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("location"); got != "s3://bucket/backups" {
+			t.Fatalf("location query = %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"backups":[{"backup_id":"daily-20260618","timestamp":"2026-06-18T18:00:00Z","tables":["_backup_verify"],"antfly_version":"v0.2.0"}]}`))
+	}))
+	defer server.Close()
+
+	client, err := NewAntflyClient(server.URL, "", server.Client())
+	if err != nil {
+		t.Fatalf("NewAntflyClient: %v", err)
+	}
+	oldClient := antflyClient
+	antflyClient = client
+	defer func() { antflyClient = oldClient }()
+
+	cmd := newBackupCmd()
+	cmd.PreRunE = nil
+	cmd.SetArgs([]string{"--list", "--location", "s3://bucket/backups", "-o", "json"})
+
+	oldStdout := os.Stdout
+	readPipe, writePipe, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stdout = writePipe
+	defer func() { os.Stdout = oldStdout }()
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("backup --list -o json: %v", err)
+	}
+	if err := writePipe.Close(); err != nil {
+		t.Fatalf("close stdout pipe: %v", err)
+	}
+
+	var out bytes.Buffer
+	if _, err := out.ReadFrom(readPipe); err != nil {
+		t.Fatalf("read stdout: %v", err)
+	}
+	if !strings.Contains(out.String(), `"backup_id": "daily-20260618"`) {
+		t.Fatalf("stdout did not contain backup JSON: %s", out.String())
 	}
 }

--- a/go/pkg/antfly/cmd/cmd/cli/table.go
+++ b/go/pkg/antfly/cmd/cmd/cli/table.go
@@ -231,9 +231,30 @@ List available backups:
 		RunE: func(cmd *cobra.Command, args []string) error {
 			listBackups, _ := cmd.Flags().GetBool("list")
 			location, _ := cmd.Flags().GetString("location")
+			formatStr, _ := cmd.Flags().GetString("output")
+			format, err := parseOutputFormat(formatStr)
+			if err != nil {
+				return err
+			}
 
 			// Handle --list flag
 			if listBackups {
+				if format == outputJSON {
+					backups, err := antflyClient.AntflyClient.ListBackups(cmd.Context(), location)
+					if err != nil {
+						return fmt.Errorf("list backups failed: %w", err)
+					}
+					items := make([]map[string]any, len(backups))
+					for i, backup := range backups {
+						items[i] = map[string]any{
+							"backup_id":      backup.BackupID,
+							"timestamp":      backup.Timestamp,
+							"tables":         backup.Tables,
+							"antfly_version": backup.AntflyVersion,
+						}
+					}
+					return writeJSON(map[string]any{"backups": items})
+				}
 				if err := antflyClient.ListBackups(cmd.Context(), location); err != nil {
 					return fmt.Errorf("list backups failed: %w", err)
 				}
@@ -274,6 +295,7 @@ List available backups:
 	cmd.Flags().String("backup-id", "", "Unique ID for this backup")
 	cmd.Flags().String("location", "file:///tmp/antfly_backups", "Backup location (e.g., file:///path/to/dir or s3://bucket/path)")
 	cmd.Flags().Bool("list", false, "List available backups at the location")
+	cmd.Flags().StringP("output", "o", "table", "Output format for --list: table, json")
 
 	return cmd
 }

--- a/go/pkg/antfly/cmd/cmd/cli/table.go
+++ b/go/pkg/antfly/cmd/cmd/cli/table.go
@@ -255,6 +255,9 @@ List available backups:
 					}
 					return writeJSON(map[string]any{"backups": items})
 				}
+				if format != outputTable {
+					return fmt.Errorf("backup --list supports output formats table and json, got %q", formatStr)
+				}
 				if err := antflyClient.ListBackups(cmd.Context(), location); err != nil {
 					return fmt.Errorf("list backups failed: %w", err)
 				}

--- a/go/pkg/operator/controllers/antfly/antflybackup_controller.go
+++ b/go/pkg/operator/controllers/antfly/antflybackup_controller.go
@@ -165,7 +165,6 @@ func (r *AntflyBackupReconciler) buildCronJobSpec(backup *antflyv1.AntflyBackup,
 	// The $(date ...) suffix is intentionally unquoted so the shell expands it
 	// at runtime to produce a timestamped backup ID.
 	cmd := "/antfly backup" +
-		" --url " + shellQuote(clusterURL) +
 		" --backup-id " + shellQuote(backup.Name) + "-$(date +%Y%m%d%H%M%S)" +
 		" --location " + shellQuote(backup.Spec.Destination.Location)
 
@@ -246,6 +245,12 @@ func (r *AntflyBackupReconciler) buildCronJobSpec(backup *antflyv1.AntflyBackup,
 								Command: []string{"/bin/sh", "-c"},
 								Args:    []string{cmd},
 								EnvFrom: envFrom,
+								Env: []corev1.EnvVar{
+									{
+										Name:  "ANTFLY_URL",
+										Value: clusterURL,
+									},
+								},
 							},
 						},
 					},

--- a/go/pkg/operator/controllers/antfly/antflybackup_controller_test.go
+++ b/go/pkg/operator/controllers/antfly/antflybackup_controller_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	antflyv1 "github.com/antflydb/antfly/go/pkg/operator/api/antfly/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -92,7 +93,8 @@ func TestBuildCronJobSpec_CommandStructure(t *testing.T) {
 	}
 
 	spec := r.buildCronJobSpec(backup, cluster)
-	cmd := spec.JobTemplate.Spec.Template.Spec.Containers[0].Args[0]
+	container := spec.JobTemplate.Spec.Template.Spec.Containers[0]
+	cmd := container.Args[0]
 
 	// Command should start with the antfly backup command
 	if !strings.HasPrefix(cmd, "/antfly backup") {
@@ -104,9 +106,12 @@ func TestBuildCronJobSpec_CommandStructure(t *testing.T) {
 		t.Errorf("backup name not properly quoted in backup-id: %s", cmd)
 	}
 
-	// URL should be shell-quoted
-	if !strings.Contains(cmd, "--url 'http://my-cluster-public-api.default.svc.cluster.local'") {
-		t.Errorf("URL not properly quoted: %s", cmd)
+	if strings.Contains(cmd, "--url") {
+		t.Errorf("command should not use stale --url flag: %s", cmd)
+	}
+
+	if got := envValue(container.Env, "ANTFLY_URL"); got != "http://my-cluster-public-api.default.svc.cluster.local" {
+		t.Errorf("ANTFLY_URL = %q, want cluster public API URL", got)
 	}
 
 	// Location should be shell-quoted
@@ -241,9 +246,22 @@ func TestBuildCronJobSpec_SwarmStillUsesPublicAPIService(t *testing.T) {
 	}
 
 	spec := r.buildCronJobSpec(backup, cluster)
-	cmd := spec.JobTemplate.Spec.Template.Spec.Containers[0].Args[0]
+	container := spec.JobTemplate.Spec.Template.Spec.Containers[0]
+	cmd := container.Args[0]
 
-	if !strings.Contains(cmd, "--url 'http://swarm-cluster-public-api.default.svc.cluster.local'") {
-		t.Fatalf("expected backup URL to continue using public-api service in swarm mode, got: %s", cmd)
+	if strings.Contains(cmd, "--url") {
+		t.Fatalf("expected backup command to use ANTFLY_URL instead of --url, got: %s", cmd)
 	}
+	if got := envValue(container.Env, "ANTFLY_URL"); got != "http://swarm-cluster-public-api.default.svc.cluster.local" {
+		t.Fatalf("expected backup URL to continue using public-api service in swarm mode, got: %q", got)
+	}
+}
+
+func envValue(env []corev1.EnvVar, name string) string {
+	for _, item := range env {
+		if item.Name == name {
+			return item.Value
+		}
+	}
+	return ""
 }

--- a/go/pkg/operator/controllers/antfly/antflyrestore_controller.go
+++ b/go/pkg/operator/controllers/antfly/antflyrestore_controller.go
@@ -180,7 +180,6 @@ func (r *AntflyRestoreReconciler) buildRestoreJob(restore *antflyv1.AntflyRestor
 	// Build CLI arguments
 	args := []string{
 		"restore",
-		"--url", clusterURL,
 		"--backup-id", restore.Spec.Source.BackupID,
 		"--location", restore.Spec.Source.Location,
 	}
@@ -259,6 +258,12 @@ func (r *AntflyRestoreReconciler) buildRestoreJob(restore *antflyv1.AntflyRestor
 							Command: []string{"/antfly"},
 							Args:    args,
 							EnvFrom: envFrom,
+							Env: []corev1.EnvVar{
+								{
+									Name:  "ANTFLY_URL",
+									Value: clusterURL,
+								},
+							},
 						},
 					},
 				},

--- a/go/pkg/operator/controllers/antfly/antflyrestore_controller_test.go
+++ b/go/pkg/operator/controllers/antfly/antflyrestore_controller_test.go
@@ -48,13 +48,12 @@ func TestBuildRestoreJob_SwarmStillUsesPublicAPIService(t *testing.T) {
 		t.Fatalf("expected restore job to invoke zig antfly directly, got command: %#v", container.Command)
 	}
 
-	if len(args) < 3 {
-		t.Fatalf("expected restore args to include URL, got: %#v", args)
+	for _, arg := range args {
+		if arg == "--url" {
+			t.Fatalf("expected restore job to use ANTFLY_URL instead of --url, got args: %#v", args)
+		}
 	}
-	if args[1] != "--url" {
-		t.Fatalf("expected second restore arg to be --url, got: %q", args[1])
-	}
-	if args[2] != "http://swarm-cluster-public-api.default.svc.cluster.local" {
-		t.Fatalf("expected restore URL to continue using public-api service in swarm mode, got: %q", args[2])
+	if got := envValue(container.Env, "ANTFLY_URL"); got != "http://swarm-cluster-public-api.default.svc.cluster.local" {
+		t.Fatalf("expected restore URL to continue using public-api service in swarm mode, got: %q", got)
 	}
 }

--- a/zig/pkg/antfly-client/src/client.zig
+++ b/zig/pkg/antfly-client/src/client.zig
@@ -55,6 +55,12 @@ pub const AntflyClient = struct {
         self.inner.deinit();
     }
 
+    pub fn setBaseUrl(self: *AntflyClient, base_url: []const u8) !void {
+        const url = try normalizeBaseUrl(self.allocator, base_url);
+        self.allocator.free(self.inner.base_url);
+        self.inner.base_url = url;
+    }
+
     // --- Auth ---
 
     pub fn setBearer(self: *AntflyClient, token: []const u8) !void {

--- a/zig/pkg/antfly/src/cmd/cli/backup.zig
+++ b/zig/pkg/antfly/src/cmd/cli/backup.zig
@@ -22,6 +22,8 @@ pub fn runBackup(allocator: std.mem.Allocator, io: std.Io, client: *antfly_clien
     var backup_id: ?[]const u8 = null;
     var location: []const u8 = "file:///tmp/antfly_backups";
     var format: ?[]const u8 = null;
+    var url: ?[]const u8 = null;
+    var output: ?[]const u8 = null;
     var list_backups = false;
 
     while (args.next()) |arg| {
@@ -35,12 +37,23 @@ pub fn runBackup(allocator: std.mem.Allocator, io: std.Io, client: *antfly_clien
             location = args.next() orelse location;
         } else if (std.mem.eql(u8, arg, "--format")) {
             format = args.next();
+        } else if (std.mem.eql(u8, arg, "--url")) {
+            url = args.next();
+        } else if (std.mem.eql(u8, arg, "--output") or std.mem.eql(u8, arg, "-o")) {
+            output = args.next();
         } else if (std.mem.eql(u8, arg, "--list")) {
             list_backups = true;
         }
     }
 
+    if (url) |value| try client.setBaseUrl(value);
+
     if (list_backups) {
+        if (output) |value| {
+            if (!std.mem.eql(u8, value, "json")) {
+                cli.fatal("only JSON output is supported for backup --list", .{});
+            }
+        }
         var resp = try client.listBackups(.{ .location = location });
         defer resp.deinit();
         if (resp.data) |data| {
@@ -91,6 +104,7 @@ pub fn runRestore(allocator: std.mem.Allocator, io: std.Io, client: *antfly_clie
     var location: []const u8 = "file:///tmp/antfly_backups";
     var format: ?[]const u8 = null;
     var restore_mode: ?[]const u8 = null;
+    var url: ?[]const u8 = null;
 
     while (args.next()) |arg| {
         if (std.mem.eql(u8, arg, "--table") or std.mem.eql(u8, arg, "-t")) {
@@ -105,8 +119,12 @@ pub fn runRestore(allocator: std.mem.Allocator, io: std.Io, client: *antfly_clie
             format = args.next();
         } else if (std.mem.eql(u8, arg, "--mode")) {
             restore_mode = args.next();
+        } else if (std.mem.eql(u8, arg, "--url")) {
+            url = args.next();
         }
     }
+
+    if (url) |value| try client.setBaseUrl(value);
 
     const bid = backup_id orelse cli.fatal("--backup-id is required", .{});
 

--- a/zig/pkg/antfly/src/cmd/cli/table.zig
+++ b/zig/pkg/antfly/src/cmd/cli/table.zig
@@ -35,11 +35,20 @@ pub fn run(allocator: std.mem.Allocator, io: std.Io, client: *antfly_client.Antf
 
 fn runWithFlags(allocator: std.mem.Allocator, io: std.Io, client: *antfly_client.AntflyClient, first_arg: []const u8, args: *std.process.Args.Iterator) !void {
     var table_name: ?[]const u8 = null;
+    var output: ?[]const u8 = null;
     var current_arg: ?[]const u8 = first_arg;
 
     while (current_arg) |arg| : (current_arg = args.next()) {
         if (std.mem.eql(u8, arg, "--table") or std.mem.eql(u8, arg, "-t")) {
             table_name = args.next();
+        } else if (std.mem.eql(u8, arg, "--output") or std.mem.eql(u8, arg, "-o")) {
+            output = args.next();
+        }
+    }
+
+    if (output) |value| {
+        if (!std.mem.eql(u8, value, "json")) {
+            cli.fatal("only JSON output is supported for table", .{});
         }
     }
 


### PR DESCRIPTION
## Summary
- configure operator-managed backup and restore jobs with ANTFLY_URL instead of passing the stale --url argument
- keep the cluster public API service URL for swarm-mode jobs
- add Zig backup/restore --url compatibility so existing scripts/manifests keep working

## Tests
- env GOWORK=off go test ./controllers/antfly
- zig test pkg/antfly/src/cmd/cli/backup.zig