### PR TITLE
Stabilize scaling drain e2e seed writes

### DIFF
--- a/zig/e2e/antfly/test_scaling.py
+++ b/zig/e2e/antfly/test_scaling.py
@@ -1225,21 +1225,7 @@ def test_autoscaling_drains_data_node_and_replaces_placements(
     cluster.create_table(table_name, num_shards=5)
 
     docs = {f"doc-{i:02d}": {"title": f"doc {i}", "rank": i} for i in range(10)}
-    try:
-        batch = requests.post(
-            f"{cluster.data_api_urls[0]}/tables/{table_name}/batch",
-            json={"inserts": docs, "sync_level": "write"},
-            timeout=30,
-        )
-        batch.raise_for_status()
-    except requests.RequestException as exc:
-        # Connection resets here have flaked CI with no server-side context;
-        # attach node logs and native stacks so the failure is diagnosable.
-        raise AssertionError(
-            f"seed batch failed table={table_name!r}: {exc!r}"
-            f"\n[native stacks]\n{cluster.native_stack_dumps()}"
-            f"\n[logs]\n{cluster.debug_logs()}"
-        ) from exc
+    _insert_docs(cluster, table_name, docs, min_group_count=5)
 
     group_ids = wait_until(lambda: _table_group_ids(cluster, table_name), timeout_s=60.0, interval_s=0.5)
     assert group_ids is not None and len(group_ids) >= 5, (


### PR DESCRIPTION
## Summary
- Use the existing retrying _insert_docs helper in the scaling drain test
- Wait for all five table groups to become write-routable before seeding docs
- Avoid a single direct POST to the first data API during placement convergence

## Test
- zig build install
- env ANTFLY_E2E_PRESERVE_ROOT=1 uv run --project zig/e2e/antfly pytest -q -x -s zig/e2e/antfly/test_scaling.py::test_autoscaling_drains_data_node_and_replaces_placements (passed twice)