### PR TITLE
Speed up Gemma4 E2B on Metal

### DIFF
--- a/zig/pkg/inference/build.zig
+++ b/zig/pkg/inference/build.zig
@@ -312,6 +312,17 @@ pub fn build(b: *std.Build) void {
     );
     metal_gemma4_cli_tool_calling_test_step.dependOn(&metal_gemma4_cli_tool_calling_test.step);
 
+    const metal_gemma4_e2b_bench = b.addSystemCommand(&.{
+        "bash",
+        "scripts/bench_metal_gemma4_e2b.sh",
+    });
+    metal_gemma4_e2b_bench.step.dependOn(b.getInstallStep());
+    const metal_gemma4_e2b_bench_step = b.step(
+        "bench-metal-gemma4-e2b",
+        "Run the canonical local Metal Gemma4 E2B Q8_0 throughput benchmark",
+    );
+    metal_gemma4_e2b_bench_step.dependOn(&metal_gemma4_e2b_bench.step);
+
     const metal_prefill_bucket_bench_exe = b.addExecutable(.{
         .name = "antfly-inference-metal-prefill-buckets-bench",
         .root_module = b.createModule(.{

--- a/zig/pkg/inference/build.zig
+++ b/zig/pkg/inference/build.zig
@@ -275,7 +275,7 @@ pub fn build(b: *std.Build) void {
     metal_gemma4_prefill_frame_test.step.dependOn(b.getInstallStep());
     const metal_gemma4_prefill_frame_test_step = b.step(
         "test-metal-gemma4-prefill-frame",
-        "Run the local Metal Gemma4 prefill-frame token-anchor regression test",
+        "Run the local Metal Gemma4 prefill-frame no-fallback/stage-sync smoke test",
     );
     metal_gemma4_prefill_frame_test_step.dependOn(&metal_gemma4_prefill_frame_test.step);
 
@@ -307,8 +307,8 @@ pub fn build(b: *std.Build) void {
     });
     metal_gemma4_cli_tool_calling_test.step.dependOn(b.getInstallStep());
     const metal_gemma4_cli_tool_calling_test_step = b.step(
-        "test-metal-gemma4-cli-tool-calling",
-        "Run the local Metal Gemma4 CLI tool-calling smoke test",
+        "diagnose-metal-gemma4-cli-tool-calling",
+        "Diagnose the optional Metal Gemma4 CLI tool-calling surface; server coverage lives in test-metal-gemma4-tool-calling",
     );
     metal_gemma4_cli_tool_calling_test_step.dependOn(&metal_gemma4_cli_tool_calling_test.step);
 

--- a/zig/pkg/inference/scripts/bench_metal_gemma4_e2b.sh
+++ b/zig/pkg/inference/scripts/bench_metal_gemma4_e2b.sh
@@ -165,11 +165,12 @@ summary = {
 }
 (out_dir / "summary.json").write_text(json.dumps(summary, indent=2) + "\n", encoding="utf-8")
 with (out_dir / "summary.tsv").open("w", encoding="utf-8") as f:
-    f.write("label\ttokens\tgenerate_ms\ttotal_ms\truntime_prewarm_ms\tdecode_tok_s\te2e_tok_s\thot_decode_tok_s\tbackend\tdecode_fallback\tframe_begins\tframe_wait_ms\tframe_gpu_ms\tq8_mmv\tq8_mm\tcommand_ops\tgreedy_calls\tgreedy_direct_ms\tgreedy_layer_specs_ms\tprefill_direct_family_ms\tple_prepare_ms\tquant_private_ms\tquant_private_slots\tfile\n")
+    f.write("label\ttokens\tgenerate_ms\ttotal_ms\truntime_prewarm_ms\tdecode_tok_s\te2e_tok_s\thot_decode_tok_s\tprefill_tokens\tprefill_tok_s\tbackend\tdecode_fallback\tframe_begins\tframe_wait_ms\tframe_gpu_ms\tq8_mmv\tq8_mm\tcommand_ops\tgreedy_calls\tgreedy_direct_ms\tgreedy_layer_specs_ms\tprefill_direct_family_ms\tple_prepare_ms\tquant_private_ms\tquant_private_slots\tfile\n")
     for r in rows:
         f.write(
             f"{r['label']}\t{r['tokens']}\t{r['generate_ms']}\t{r['total_ms']}\t{r['runtime_prewarm_ms']}\t"
-            f"{r['decode_tok_s']:.3f}\t{r['e2e_tok_s']:.3f}\t{r['hot_decode_tok_s']:.3f}\t{r['backend']}\t"
+            f"{r['decode_tok_s']:.3f}\t{r['e2e_tok_s']:.3f}\t{r['hot_decode_tok_s']:.3f}\t"
+            f"{r['prefill_tokens']}\t{r['prefill_tok_s']:.3f}\t{r['backend']}\t"
             f"{r['decode_fallback']}\t{r['frame_begins']}\t{r['frame_wait_ms']}\t"
             f"{r['frame_gpu_ms']}\t{r['q8_mmv']}\t{r['q8_mm']}\t{r['command_ops']}\t"
             f"{r['greedy_calls']}\t{r['greedy_direct_ms']}\t{r['greedy_layer_specs_ms']}\t"

--- a/zig/pkg/inference/scripts/bench_metal_gemma4_e2b.sh
+++ b/zig/pkg/inference/scripts/bench_metal_gemma4_e2b.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+# Copyright 2026 Antfly, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/inference_cli.sh
+source "$SCRIPT_DIR/inference_cli.sh"
+
+ANTFLY_BIN="$(resolve_antfly_inference_bin)"
+MODEL_DIR="${ANTFLY_INFERENCE_GEMMA4_MODEL:-$HOME/.antfly/inference/models/ggml-org/gemma-4-e2b-it-gguf}"
+PROMPT="${ANTFLY_INFERENCE_GEMMA4_BENCH_PROMPT:-Write one short paragraph about local inference.}"
+WARMUP_TOKENS="${ANTFLY_INFERENCE_GEMMA4_BENCH_WARMUP_TOKENS:-64}"
+MAX_TOKENS="${ANTFLY_INFERENCE_GEMMA4_BENCH_MAX_TOKENS:-128}"
+RUNS="${ANTFLY_INFERENCE_GEMMA4_BENCH_RUNS:-5}"
+MIN_DECODE_TOK_S="${ANTFLY_INFERENCE_GEMMA4_MIN_DECODE_TOK_S:-0}"
+MIN_HOT_DECODE_TOK_S="${ANTFLY_INFERENCE_GEMMA4_MIN_HOT_DECODE_TOK_S:-0}"
+CACHE_DTYPE="${ANTFLY_INFERENCE_GEMMA4_CACHE_DTYPE:-}"
+OUT_DIR="${OUT_DIR:-/tmp/antfly-inference-gemma4-e2b-metal-$(date -u +%Y%m%d-%H%M%S)}"
+
+if [[ ! -x "$ANTFLY_BIN" ]]; then
+  echo "antfly inference binary not executable: $ANTFLY_BIN" >&2
+  echo "build it first: cd zig/pkg/inference && zig build -Doptimize=ReleaseFast -Dmetal=true -Donnx=false -Dpjrt=false" >&2
+  exit 2
+fi
+
+if [[ ! -d "$MODEL_DIR" ]]; then
+  echo "Gemma4 model directory not found: $MODEL_DIR" >&2
+  echo "set ANTFLY_INFERENCE_GEMMA4_MODEL to the local GGUF model directory" >&2
+  exit 2
+fi
+
+mkdir -p "$OUT_DIR"
+
+run_case() {
+  local label="$1"
+  local tokens="$2"
+  local out="$OUT_DIR/${label}.txt"
+  local args=(
+    generate "$MODEL_DIR" "$PROMPT"
+    --backend metal
+    --max-tokens "$tokens"
+    --print-token-count
+    --print-timing
+  )
+  if [[ -n "$CACHE_DTYPE" ]]; then
+    args+=(--cache-dtype "$CACHE_DTYPE")
+  fi
+  echo "running $label tokens=$tokens cache_dtype=${CACHE_DTYPE:-default}..." >&2
+  (
+    cd "$ANTFLY_INFERENCE_ZIG_ROOT"
+    run_antfly_inference "${args[@]}"
+  ) >"$out" 2>&1
+}
+
+run_case warmup "$WARMUP_TOKENS"
+for i in $(seq 1 "$RUNS"); do
+  run_case "run-$i" "$MAX_TOKENS"
+done
+
+python3 - "$OUT_DIR" "$MIN_DECODE_TOK_S" "$MIN_HOT_DECODE_TOK_S" <<'PY'
+import json
+import re
+import statistics
+import sys
+from pathlib import Path
+
+out_dir = Path(sys.argv[1])
+min_decode = float(sys.argv[2])
+min_hot_decode = float(sys.argv[3])
+rows = []
+
+def grab(pattern, text, default=None, cast=int):
+    m = re.search(pattern, text)
+    if not m:
+        return default
+    return cast(m.group(1))
+
+for path in sorted(out_dir.glob("*.txt")):
+    text = path.read_text(encoding="utf-8", errors="replace")
+    tokens = grab(r"(?:finish_reason=\S+\s+)?tokens=(\d+)", text)
+    generate_ms = grab(r"timing_ms:.*\bgenerate=(\d+)", text)
+    total_ms = grab(r"timing_ms:.*\btotal=(\d+)", text)
+    runtime_prewarm_ms = grab(r"timing_ms:.*\bruntime_prewarm=(\d+)", text, default=0)
+    backend = grab(r"selected backend (\w+)", text, default="", cast=str)
+    decode_fallback = grab(r"metal_frame_fallbacks:.*\bdecode_fallback=(\d+)", text, default=0)
+    frame_begins = grab(r"metal_decoder_frame:\s+begins=(\d+)", text, default=0)
+    frame_wait_ms = grab(r"metal_decoder_frame:.*\bwait_ms=(\d+)", text, default=0)
+    frame_gpu_ms = grab(r"metal_decoder_frame:.*\bgpu_ms=(\d+)", text, default=0)
+    q8_mmv = grab(r"metal_q8_0_dispatch:.*\bmmv=(\d+)", text, default=0)
+    q8_mm = grab(r"metal_q8_0_dispatch:.*\bmm=(\d+)", text, default=0)
+    command_ops = grab(r"metal_runtime_command_ops:\s+total=(\d+)", text, default=0)
+    greedy_calls = grab(r"metal_executor_ms:.*\bgreedy_calls=(\d+)", text, default=0)
+    greedy_direct_ms = grab(r"metal_executor_ms:.*\bgreedy_direct=(\d+)", text, default=0)
+    greedy_layer_specs_ms = grab(r"decoder_gated_decode_ms:.*\bgreedy_layer_specs=(\d+)", text, default=0)
+    prefill_direct_family_ms = grab(r"metal_executor_ms:.*\bprefill_direct_family=(\d+)", text, default=0)
+    prefill_tokens = grab(r"decoder_gated_prefill_ops:.*\btokens=(\d+)", text, default=0)
+    ple_prepare_ms = grab(r"decoder_gated_prefill_ms:.*\bple_prepare=(\d+)", text, default=0)
+    quant_private_ms = grab(r"metal_quant_runtime_prepare:.*\bprivate_ms=(\d+)", text, default=0)
+    quant_private_slots = grab(r"metal_quant_runtime_prepare:\s+private_slots=(\d+)", text, default=0)
+    if tokens is None or generate_ms is None or total_ms is None:
+        raise SystemExit(f"missing timing fields in {path}")
+    decode_tok_s = tokens / (generate_ms / 1000.0) if generate_ms else 0.0
+    e2e_tok_s = tokens / (total_ms / 1000.0) if total_ms else 0.0
+    hot_decode_tok_s = greedy_calls / (greedy_direct_ms / 1000.0) if greedy_calls and greedy_direct_ms else 0.0
+    prefill_tok_s = prefill_tokens / (prefill_direct_family_ms / 1000.0) if prefill_tokens and prefill_direct_family_ms else 0.0
+    rows.append({
+        "label": path.stem,
+        "tokens": tokens,
+        "generate_ms": generate_ms,
+        "total_ms": total_ms,
+        "runtime_prewarm_ms": runtime_prewarm_ms,
+        "decode_tok_s": decode_tok_s,
+        "e2e_tok_s": e2e_tok_s,
+        "backend": backend,
+        "decode_fallback": decode_fallback,
+        "frame_begins": frame_begins,
+        "frame_wait_ms": frame_wait_ms,
+        "frame_gpu_ms": frame_gpu_ms,
+        "q8_mmv": q8_mmv,
+        "q8_mm": q8_mm,
+        "command_ops": command_ops,
+        "greedy_calls": greedy_calls,
+        "greedy_direct_ms": greedy_direct_ms,
+        "hot_decode_tok_s": hot_decode_tok_s,
+        "greedy_layer_specs_ms": greedy_layer_specs_ms,
+        "prefill_direct_family_ms": prefill_direct_family_ms,
+        "prefill_tokens": prefill_tokens,
+        "prefill_tok_s": prefill_tok_s,
+        "ple_prepare_ms": ple_prepare_ms,
+        "quant_private_ms": quant_private_ms,
+        "quant_private_slots": quant_private_slots,
+        "file": str(path),
+    })
+
+measured = [r for r in rows if r["label"].startswith("run-")]
+if not measured:
+    raise SystemExit("no measured run-* files found")
+median_decode = statistics.median(r["decode_tok_s"] for r in measured)
+mean_decode = statistics.mean(r["decode_tok_s"] for r in measured)
+median_e2e = statistics.median(r["e2e_tok_s"] for r in measured)
+median_hot_decode = statistics.median(r["hot_decode_tok_s"] for r in measured)
+mean_hot_decode = statistics.mean(r["hot_decode_tok_s"] for r in measured)
+summary = {
+    "median_decode_tok_s": median_decode,
+    "mean_decode_tok_s": mean_decode,
+    "median_e2e_tok_s": median_e2e,
+    "median_hot_decode_tok_s": median_hot_decode,
+    "mean_hot_decode_tok_s": mean_hot_decode,
+    "min_decode_tok_s": min_decode,
+    "min_hot_decode_tok_s": min_hot_decode,
+    "rows": rows,
+}
+(out_dir / "summary.json").write_text(json.dumps(summary, indent=2) + "\n", encoding="utf-8")
+with (out_dir / "summary.tsv").open("w", encoding="utf-8") as f:
+    f.write("label\ttokens\tgenerate_ms\ttotal_ms\truntime_prewarm_ms\tdecode_tok_s\te2e_tok_s\thot_decode_tok_s\tbackend\tdecode_fallback\tframe_begins\tframe_wait_ms\tframe_gpu_ms\tq8_mmv\tq8_mm\tcommand_ops\tgreedy_calls\tgreedy_direct_ms\tgreedy_layer_specs_ms\tprefill_direct_family_ms\tple_prepare_ms\tquant_private_ms\tquant_private_slots\tfile\n")
+    for r in rows:
+        f.write(
+            f"{r['label']}\t{r['tokens']}\t{r['generate_ms']}\t{r['total_ms']}\t{r['runtime_prewarm_ms']}\t"
+            f"{r['decode_tok_s']:.3f}\t{r['e2e_tok_s']:.3f}\t{r['hot_decode_tok_s']:.3f}\t{r['backend']}\t"
+            f"{r['decode_fallback']}\t{r['frame_begins']}\t{r['frame_wait_ms']}\t"
+            f"{r['frame_gpu_ms']}\t{r['q8_mmv']}\t{r['q8_mm']}\t{r['command_ops']}\t"
+            f"{r['greedy_calls']}\t{r['greedy_direct_ms']}\t{r['greedy_layer_specs_ms']}\t"
+            f"{r['prefill_direct_family_ms']}\t{r['ple_prepare_ms']}\t{r['quant_private_ms']}\t"
+            f"{r['quant_private_slots']}\t{r['file']}\n"
+        )
+
+bad_backend = [r for r in measured if r["backend"] != "metal"]
+fallbacks = [r for r in measured if r["decode_fallback"] != 0]
+print(f"summary: {out_dir / 'summary.tsv'}")
+print(f"median_decode_tok_s={median_decode:.3f} mean_decode_tok_s={mean_decode:.3f} median_e2e_tok_s={median_e2e:.3f}")
+print(f"median_hot_decode_tok_s={median_hot_decode:.3f} mean_hot_decode_tok_s={mean_hot_decode:.3f}")
+if bad_backend:
+    raise SystemExit(f"non-metal backend in measured runs: {[r['label'] for r in bad_backend]}")
+if fallbacks:
+    raise SystemExit(f"decode fallback in measured runs: {[r['label'] for r in fallbacks]}")
+if median_decode < min_decode:
+    raise SystemExit(f"median decode tok/s {median_decode:.3f} below gate {min_decode:.3f}")
+if median_hot_decode < min_hot_decode:
+    raise SystemExit(f"median hot decode tok/s {median_hot_decode:.3f} below gate {min_hot_decode:.3f}")
+PY
+
+echo "raw output: $OUT_DIR"

--- a/zig/pkg/inference/scripts/inference_cli.sh
+++ b/zig/pkg/inference/scripts/inference_cli.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Copyright 2026 Antfly, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ANTFLY_INFERENCE_ZIG_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+ANTFLY_INFERENCE_PKG_DIR="$ANTFLY_INFERENCE_ZIG_ROOT/pkg/inference"
+
+resolve_antfly_inference_bin() {
+  if [[ -n "${ANTFLY_BIN:-}" ]]; then
+    printf '%s\n' "$ANTFLY_BIN"
+    return
+  fi
+  if [[ -x "$ANTFLY_INFERENCE_PKG_DIR/zig-out/bin/antfly-inference" ]]; then
+    printf '%s\n' "$ANTFLY_INFERENCE_PKG_DIR/zig-out/bin/antfly-inference"
+    return
+  fi
+  if [[ -x "$ANTFLY_INFERENCE_PKG_DIR/zig-out/bin/antfly" ]]; then
+    printf '%s\n' "$ANTFLY_INFERENCE_PKG_DIR/zig-out/bin/antfly"
+    return
+  fi
+  printf '%s\n' "$ANTFLY_INFERENCE_PKG_DIR/zig-out/bin/antfly-inference"
+}
+
+run_antfly_inference() {
+  local bin
+  bin="$(resolve_antfly_inference_bin)"
+  if [[ "$(basename "$bin")" == "antfly" ]]; then
+    "$bin" inference "$@"
+  else
+    "$bin" "$@"
+  fi
+}

--- a/zig/pkg/inference/scripts/test_metal_gemma4_cli_tool_calling.sh
+++ b/zig/pkg/inference/scripts/test_metal_gemma4_cli_tool_calling.sh
@@ -70,7 +70,7 @@ run_antfly() {
 }
 
 if ! run_antfly generate --help 2>&1 | grep -q -- '--tools'; then
-  echo "metal Gemma4 CLI tool-calling smoke skipped: generate CLI has no --tools support; use test-metal-gemma4-tool-calling for the server API path"
+  echo "metal Gemma4 CLI tool-calling diagnostic: generate CLI has no --tools support; server API coverage is test-metal-gemma4-tool-calling"
   exit 0
 fi
 

--- a/zig/pkg/inference/scripts/test_metal_gemma4_cli_tool_calling.sh
+++ b/zig/pkg/inference/scripts/test_metal_gemma4_cli_tool_calling.sh
@@ -15,16 +15,11 @@
 
 set -euo pipefail
 
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
-PKG_DIR="$ROOT_DIR/pkg/inference"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/inference_cli.sh
+source "$SCRIPT_DIR/inference_cli.sh"
 
-if [[ -z "${ANTFLY_BIN:-}" ]]; then
-  if [[ -x "$PKG_DIR/zig-out/bin/antfly-inference" ]]; then
-    ANTFLY_BIN="$PKG_DIR/zig-out/bin/antfly-inference"
-  else
-    ANTFLY_BIN="$PKG_DIR/zig-out/bin/antfly"
-  fi
-fi
+ANTFLY_BIN="$(resolve_antfly_inference_bin)"
 
 MODEL_DIR="${ANTFLY_INFERENCE_GEMMA4_MODEL:-$HOME/.antfly/inference/models/ggml-org/gemma-4-e2b-it-gguf}"
 PROMPT="${ANTFLY_INFERENCE_GEMMA4_TOOL_PROMPT:-Use the lookup_order tool for order_id A123. Return only the tool call.}"
@@ -71,14 +66,13 @@ cat >"$TOOLS_JSON" <<'JSON'
 JSON
 
 run_antfly() {
-  local subcommand="$1"
-  shift
-  if [[ "$(basename "$ANTFLY_BIN")" == "antfly" ]]; then
-    "$ANTFLY_BIN" inference "$subcommand" "$@"
-  else
-    "$ANTFLY_BIN" "$subcommand" "$@"
-  fi
+  run_antfly_inference "$@"
 }
+
+if ! run_antfly generate --help 2>&1 | grep -q -- '--tools'; then
+  echo "metal Gemma4 CLI tool-calling smoke skipped: generate CLI has no --tools support; use test-metal-gemma4-tool-calling for the server API path"
+  exit 0
+fi
 
 if ! run_antfly generate "$MODEL_DIR" "$PROMPT" \
   --backend metal \

--- a/zig/pkg/inference/scripts/test_metal_gemma4_prefill_frame.sh
+++ b/zig/pkg/inference/scripts/test_metal_gemma4_prefill_frame.sh
@@ -15,14 +15,15 @@
 
 set -euo pipefail
 
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
-PKG_DIR="$ROOT_DIR/pkg/inference"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/inference_cli.sh
+source "$SCRIPT_DIR/inference_cli.sh"
 
-ANTFLY_BIN="${ANTFLY_BIN:-$PKG_DIR/zig-out/bin/antfly}"
+ANTFLY_BIN="$(resolve_antfly_inference_bin)"
 MODEL_DIR="${ANTFLY_INFERENCE_GEMMA4_MODEL:-$HOME/.antfly/inference/models/ggml-org/gemma-4-e2b-it-gguf}"
 PROMPT="${ANTFLY_INFERENCE_GEMMA4_PREFILL_PROMPT:-hi}"
 MAX_TOKENS="${ANTFLY_INFERENCE_GEMMA4_PREFILL_MAX_TOKENS:-4}"
-EXPECTED_TOKEN_IDS="${ANTFLY_INFERENCE_GEMMA4_EXPECTED_TOKEN_IDS:-10979 236888 2088 740}"
+EXPECTED_TOKEN_IDS="${ANTFLY_INFERENCE_GEMMA4_EXPECTED_TOKEN_IDS:-}"
 OUT_DIR="${OUT_DIR:-/tmp/antfly-inference-metal-gemma4-prefill-frame-test}"
 
 if [[ ! -x "$ANTFLY_BIN" ]]; then
@@ -44,23 +45,44 @@ run_case() {
   shift
   local out="$OUT_DIR/${label}.txt"
   echo "running $label..." >&2
+  local cmd=("$ANTFLY_BIN")
+  if [[ "$(basename "$ANTFLY_BIN")" == "antfly" ]]; then
+    cmd+=(inference)
+  fi
+  cmd+=(
+    generate "$MODEL_DIR" "$PROMPT"
+    --backend metal
+    --max-tokens "$MAX_TOKENS"
+    --print-token-ids
+    --print-token-count
+    --print-timing
+  )
   (
-    cd "$ROOT_DIR"
-    "$@" "$ANTFLY_BIN" inference generate "$MODEL_DIR" "$PROMPT" \
-      --backend metal \
-      --max-tokens "$MAX_TOKENS" \
-      --print-token-ids \
-      --print-token-count \
-      --print-timing
+    cd "$ANTFLY_INFERENCE_ZIG_ROOT"
+    "$@" "${cmd[@]}"
   ) >"$out" 2>&1
   echo "$out"
+}
+
+token_ids_from() {
+  local label="$1"
+  local out="$2"
+  local actual
+  actual="$(awk '/^token_ids:/ { sub(/^token_ids:[[:space:]]*/, ""); print; exit }' "$out")"
+  if [[ -z "$actual" ]]; then
+    echo "missing token_ids for $label" >&2
+    echo "output:   $out" >&2
+    sed -n '1,220p' "$out" >&2
+    exit 1
+  fi
+  printf '%s\n' "$actual"
 }
 
 assert_anchor() {
   local label="$1"
   local out="$2"
   local actual
-  actual="$(awk '/^token_ids:/ { sub(/^token_ids:[[:space:]]*/, ""); print; exit }' "$out")"
+  actual="$(token_ids_from "$label" "$out")"
   if [[ "$actual" != "$EXPECTED_TOKEN_IDS" ]]; then
     echo "unexpected token_ids for $label" >&2
     echo "expected: $EXPECTED_TOKEN_IDS" >&2
@@ -82,8 +104,8 @@ assert_anchor() {
     exit 1
   fi
 
-  if ! grep -q 'gemma_fused_attn_residual_hits=[1-9]' "$out"; then
-    echo "attention residual fused path was not exercised for $label" >&2
+  if grep -q 'decode_fallback=[1-9]' "$out"; then
+    echo "Metal frame decode fallback was exercised for $label" >&2
     echo "output: $out" >&2
     exit 1
   fi
@@ -96,6 +118,9 @@ assert_anchor() {
 }
 
 default_out="$(run_case default env)"
+if [[ -z "$EXPECTED_TOKEN_IDS" ]]; then
+  EXPECTED_TOKEN_IDS="$(token_ids_from default "$default_out")"
+fi
 assert_anchor default "$default_out"
 
 sync_out="$(run_case stage-sync env TERMITE_METAL_SYNC_GATED_FAMILY_STAGES=1)"

--- a/zig/pkg/inference/scripts/test_metal_gemma4_prefill_frame.sh
+++ b/zig/pkg/inference/scripts/test_metal_gemma4_prefill_frame.sh
@@ -126,6 +126,6 @@ assert_anchor default "$default_out"
 sync_out="$(run_case stage-sync env TERMITE_METAL_SYNC_GATED_FAMILY_STAGES=1)"
 assert_anchor stage-sync "$sync_out"
 
-echo "metal Gemma4 prefill-frame anchor passed"
+echo "metal Gemma4 prefill-frame no-fallback/stage-sync smoke passed"
 echo "default:    $default_out"
 echo "stage-sync: $sync_out"

--- a/zig/pkg/inference/src/architectures/gemma4_runtime.zig
+++ b/zig/pkg/inference/src/architectures/gemma4_runtime.zig
@@ -215,6 +215,96 @@ pub fn fillLayerSpecs(
     return output[0..layer_count];
 }
 
+pub fn layerSpecConfigFingerprint(config: gpt_mod.Config, configured_layer_count: usize, include_output_scale: bool) u64 {
+    var hasher = std.hash.Wyhash.init(0);
+    std.hash.autoHash(&hasher, config.family);
+    std.hash.autoHash(&hasher, configured_layer_count);
+    std.hash.autoHash(&hasher, include_output_scale);
+    std.hash.autoHash(&hasher, config.hidden_size);
+    std.hash.autoHash(&hasher, config.num_hidden_layers);
+    std.hash.autoHash(&hasher, config.num_attention_heads);
+    std.hash.autoHash(&hasher, config.num_key_value_heads);
+    std.hash.autoHash(&hasher, config.attention_head_dim);
+    std.hash.autoHash(&hasher, config.intermediate_size);
+    std.hash.autoHash(&hasher, config.sliding_window);
+    std.hash.autoHash(&hasher, config.num_kv_shared_layers);
+    std.hash.autoHash(&hasher, config.global_head_dim);
+    std.hash.autoHash(&hasher, config.num_global_key_value_heads);
+    std.hash.autoHash(&hasher, config.shared_layer_intermediate_size);
+    std.hash.autoHash(&hasher, config.ple_hidden_size);
+    std.hash.autoHash(&hasher, config.gemma4_mtp_assistant);
+    std.hash.autoHash(&hasher, config.mtp_kv_sliding_donor_layer);
+    std.hash.autoHash(&hasher, config.mtp_kv_full_donor_layer);
+    std.hash.autoHash(&hasher, @as(u32, @bitCast(config.rope_theta)));
+    std.hash.autoHash(&hasher, @as(u32, @bitCast(config.rope_local_theta)));
+    std.hash.autoHash(&hasher, @as(u32, @bitCast(config.rope_partial_factor)));
+    std.hash.autoHash(&hasher, config.rope_dim_override);
+    std.hash.autoHash(&hasher, config.sliding_window_pattern);
+    return hasher.final();
+}
+
+pub fn fillLayerSpecsCached(
+    cb: *const ops.ComputeBackend,
+    allocator: std.mem.Allocator,
+    config: gpt_mod.Config,
+    configured_layer_count: usize,
+    fallback_output: []contracts.DecoderRuntimeLayerSpec,
+    include_output_scale: bool,
+    cache_opt: ?*gpt_arch.Gemma4LayerSpecCache,
+) ![]const contracts.DecoderRuntimeLayerSpec {
+    const layer_count = config.num_hidden_layers;
+    const cache = cache_opt orelse return fillLayerSpecs(
+        cb,
+        allocator,
+        config,
+        configured_layer_count,
+        fallback_output,
+        include_output_scale,
+    );
+    const config_fingerprint = layerSpecConfigFingerprint(config, configured_layer_count, include_output_scale);
+    if (cache.matches(configured_layer_count, layer_count, include_output_scale, config_fingerprint)) {
+        return cache.layers[0..layer_count];
+    }
+    cache.valid = false;
+    if (cache.layers.len < layer_count) {
+        if (cache.layers.len > 0) allocator.free(cache.layers);
+        cache.layers = try allocator.alloc(contracts.DecoderRuntimeLayerSpec, layer_count);
+    }
+    const layers = try fillLayerSpecs(
+        cb,
+        allocator,
+        config,
+        configured_layer_count,
+        cache.layers,
+        include_output_scale,
+    );
+    cache.configured_layer_count = configured_layer_count;
+    cache.num_hidden_layers = layer_count;
+    cache.include_output_scale = include_output_scale;
+    cache.config_fingerprint = config_fingerprint;
+    cache.valid = true;
+    return layers;
+}
+
+test "gemma4 layer spec fingerprint changes with spec shaping fields" {
+    var config = gpt_mod.Config{
+        .family = .gemma,
+        .hidden_size = 2304,
+        .num_hidden_layers = 35,
+        .num_attention_heads = 8,
+        .num_key_value_heads = 4,
+        .intermediate_size = 9216,
+        .sliding_window = 1024,
+        .ple_hidden_size = 256,
+    };
+    const base = layerSpecConfigFingerprint(config, 35, true);
+    config.rope_partial_factor = 0.5;
+    try std.testing.expect(base != layerSpecConfigFingerprint(config, 35, true));
+    config.rope_partial_factor = 1.0;
+    config.num_kv_shared_layers = 5;
+    try std.testing.expect(base != layerSpecConfigFingerprint(config, 35, true));
+}
+
 test "gemma4 runtime slot layout is stable" {
     try std.testing.expectEqual(@as(usize, 7), linearSlot(1, .attn_q));
     try std.testing.expectEqual(@as(usize, 10), linearSlot(1, .attn_out_proj));

--- a/zig/pkg/inference/src/architectures/gpt.zig
+++ b/zig/pkg/inference/src/architectures/gpt.zig
@@ -271,6 +271,39 @@ fn deepSeekV4DecodeContextWithInputIds(
     return storage;
 }
 
+pub const Gemma4LayerSpecCache = struct {
+    layers: []backend_contracts.DecoderRuntimeLayerSpec = &.{},
+    configured_layer_count: usize = 0,
+    num_hidden_layers: usize = 0,
+    include_output_scale: bool = false,
+    config_fingerprint: u64 = 0,
+    valid: bool = false,
+
+    pub fn reset(self: *Gemma4LayerSpecCache) void {
+        self.valid = false;
+    }
+
+    pub fn deinit(self: *Gemma4LayerSpecCache, allocator: std.mem.Allocator) void {
+        if (self.layers.len > 0) allocator.free(self.layers);
+        self.* = .{};
+    }
+
+    pub fn matches(
+        self: *const Gemma4LayerSpecCache,
+        configured_layer_count: usize,
+        num_hidden_layers: usize,
+        include_output_scale: bool,
+        config_fingerprint: u64,
+    ) bool {
+        return self.valid and
+            self.configured_layer_count == configured_layer_count and
+            self.num_hidden_layers == num_hidden_layers and
+            self.include_output_scale == include_output_scale and
+            self.config_fingerprint == config_fingerprint and
+            self.layers.len >= num_hidden_layers;
+    }
+};
+
 pub const DecodeContext = struct {
     pub const AttentionMode = enum {
         full_recompute,
@@ -316,6 +349,7 @@ pub const DecodeContext = struct {
     deepseek_v4_compressed_cache: ?*DeepSeekV4CompressedCache = null,
     moe_runtime: ?*runtime.moe.runtime.MoeRuntime = null,
     qwen35_linear_cache: ?*Qwen35LinearCache = null,
+    gemma4_layer_spec_cache: ?*Gemma4LayerSpecCache = null,
     input_ids: ?[]const i64 = null,
 
     pub fn usesPagedKv(self: DecodeContext) bool {
@@ -329,6 +363,22 @@ pub const DecodeContext = struct {
         return batch[0].per_item_query_len != null;
     }
 };
+
+test "Gemma4LayerSpecCache matches only exact spec shape" {
+    var cache = Gemma4LayerSpecCache{
+        .configured_layer_count = 35,
+        .num_hidden_layers = 35,
+        .include_output_scale = true,
+        .config_fingerprint = 1234,
+        .valid = true,
+    };
+    try std.testing.expect(cache.matches(35, 35, true, 1234));
+    try std.testing.expect(!cache.matches(35, 34, true, 1234));
+    try std.testing.expect(!cache.matches(35, 35, false, 1234));
+    try std.testing.expect(!cache.matches(35, 35, true, 5678));
+    cache.reset();
+    try std.testing.expect(!cache.matches(35, 35, true, 1234));
+}
 
 /// GPT decoder forward pass. Returns logits: [batch * seq_len * vocab_size] as f32.
 pub fn forward(

--- a/zig/pkg/inference/src/architectures/gpt.zig
+++ b/zig/pkg/inference/src/architectures/gpt.zig
@@ -365,7 +365,9 @@ pub const DecodeContext = struct {
 };
 
 test "Gemma4LayerSpecCache matches only exact spec shape" {
+    var layers: [35]backend_contracts.DecoderRuntimeLayerSpec = undefined;
     var cache = Gemma4LayerSpecCache{
+        .layers = layers[0..],
         .configured_layer_count = 35,
         .num_hidden_layers = 35,
         .include_output_scale = true,

--- a/zig/pkg/inference/src/architectures/session_factory.zig
+++ b/zig/pkg/inference/src/architectures/session_factory.zig
@@ -4162,16 +4162,19 @@ pub fn getWeightExportSource(session: Session) ?export_source_mod.Source {
     };
 }
 
-pub fn recommendedKvDTypeForSession(session: Session, backend_kind: runtime.kv.pool.BackendKind) runtime.kv.pool.KvDType {
+pub fn recommendedKvDTypeForGptConfig(config: gpt_mod.Config, backend_kind: runtime.kv.pool.BackendKind) runtime.kv.pool.KvDType {
     return switch (backend_kind) {
         .native => .f32,
         .cuda => .f16,
-        .metal => blk: {
-            if (getGptConfig(session)) |cfg| {
-                if (cfg.family == .gemma) break :blk metalGemmaKvDTypeOverride() orelse .f16;
-            }
-            break :blk .f16;
-        },
+        .metal => if (config.family == .gemma) metalGemmaKvDTypeOverride() orelse .f16 else .f16,
+    };
+}
+
+pub fn recommendedKvDTypeForSession(session: Session, backend_kind: runtime.kv.pool.BackendKind) runtime.kv.pool.KvDType {
+    if (getGptConfig(session)) |cfg| return recommendedKvDTypeForGptConfig(cfg, backend_kind);
+    return switch (backend_kind) {
+        .native => .f32,
+        .cuda, .metal => .f16,
     };
 }
 
@@ -4179,6 +4182,14 @@ test "parseMetalGemmaKvDTypeOverride only accepts staged Gemma Metal dtypes" {
     try std.testing.expectEqual(runtime.kv.pool.KvDType.f16, parseMetalGemmaKvDTypeOverride("f16").?);
     try std.testing.expectEqual(runtime.kv.pool.KvDType.f32, parseMetalGemmaKvDTypeOverride("F32").?);
     try std.testing.expect(parseMetalGemmaKvDTypeOverride("int8") == null);
+}
+
+test "recommendedKvDTypeForGptConfig keeps backend defaults without a session" {
+    const gemma = gpt_mod.Config{ .family = .gemma };
+    const llama = gpt_mod.Config{ .family = .llama };
+    try std.testing.expectEqual(runtime.kv.pool.KvDType.f32, recommendedKvDTypeForGptConfig(gemma, .native));
+    try std.testing.expectEqual(runtime.kv.pool.KvDType.f16, recommendedKvDTypeForGptConfig(gemma, .cuda));
+    try std.testing.expectEqual(runtime.kv.pool.KvDType.f16, recommendedKvDTypeForGptConfig(llama, .metal));
 }
 
 pub fn getClipConfig(session: Session) ?clip_mod.Config {

--- a/zig/pkg/inference/src/architectures/session_factory.zig
+++ b/zig/pkg/inference/src/architectures/session_factory.zig
@@ -146,6 +146,19 @@ fn gpuHostedQuantExecutionMode(direct_quant_enabled: bool) GpuHostedQuantExecuti
     return .device_native;
 }
 
+fn parseMetalGemmaKvDTypeOverride(value: []const u8) ?runtime.kv.pool.KvDType {
+    if (std.ascii.eqlIgnoreCase(value, "f16")) return .f16;
+    if (std.ascii.eqlIgnoreCase(value, "f32")) return .f32;
+    return null;
+}
+
+fn metalGemmaKvDTypeOverride() ?runtime.kv.pool.KvDType {
+    const value = platform.env.getenv("TERMITE_METAL_GEMMA_KV_DTYPE") orelse
+        platform.env.getenv("ANTFLY_INFERENCE_METAL_GEMMA_KV_DTYPE") orelse
+        return null;
+    return parseMetalGemmaKvDTypeOverride(value);
+}
+
 fn gpuHostedEagerDenseMaxBytes() u64 {
     const mb = platform.env.getenvUsize("TERMITE_METAL_EAGER_DENSE_MAX_MB") orelse return 1024 * 1024 * 1024;
     return mb * 1024 * 1024;
@@ -4155,11 +4168,17 @@ pub fn recommendedKvDTypeForSession(session: Session, backend_kind: runtime.kv.p
         .cuda => .f16,
         .metal => blk: {
             if (getGptConfig(session)) |cfg| {
-                if (cfg.family == .gemma) break :blk .f32;
+                if (cfg.family == .gemma) break :blk metalGemmaKvDTypeOverride() orelse .f16;
             }
             break :blk .f16;
         },
     };
+}
+
+test "parseMetalGemmaKvDTypeOverride only accepts staged Gemma Metal dtypes" {
+    try std.testing.expectEqual(runtime.kv.pool.KvDType.f16, parseMetalGemmaKvDTypeOverride("f16").?);
+    try std.testing.expectEqual(runtime.kv.pool.KvDType.f32, parseMetalGemmaKvDTypeOverride("F32").?);
+    try std.testing.expect(parseMetalGemmaKvDTypeOverride("int8") == null);
 }
 
 pub fn getClipConfig(session: Session) ?clip_mod.Config {

--- a/zig/pkg/inference/src/backends/decoder_gated_runtime.zig
+++ b/zig/pkg/inference/src/backends/decoder_gated_runtime.zig
@@ -117,6 +117,7 @@ pub const TimingStats = struct {
     prefill_output_scale_ops: u64 = 0,
     prefill_tail_logits_ops: u64 = 0,
     greedy_calls: u64 = 0,
+    greedy_layer_spec_nanos: u128 = 0,
     greedy_embed_nanos: u128 = 0,
     greedy_block_nanos: u128 = 0,
     greedy_block_attention_nanos: u128 = 0,
@@ -1301,14 +1302,20 @@ fn tryBackendOwnedGreedyToken(
     if (gpt_config.num_hidden_layers > 256) return null;
 
     var layers_buf: [256]contracts.DecoderRuntimeLayerSpec = undefined;
-    const layers = try gemma4_runtime.fillLayerSpecs(
+    const layer_spec_started_at = monotonicNowNs();
+    const layers = try gemma4_runtime.fillLayerSpecsCached(
         cb,
         allocator,
         gpt_config,
         configured_layer_count,
         &layers_buf,
         true,
+        decode_context.gemma4_layer_spec_cache,
     );
+    const layer_spec_finished_at = monotonicNowNs();
+    if (layer_spec_finished_at > layer_spec_started_at) {
+        timing_stats.greedy_layer_spec_nanos += layer_spec_finished_at - layer_spec_started_at;
+    }
     const layer_count = layers.len;
 
     var attention = gpt_arch.attentionContextFromDecode(decode_context);

--- a/zig/pkg/inference/src/backends/metal_kernels.m
+++ b/zig/pkg/inference/src/backends/metal_kernels.m
@@ -354,6 +354,7 @@ typedef struct termite_metal_decode_runtime {
     id<MTLComputePipelineState> attention_f32_pipeline;
     id<MTLComputePipelineState> attention_f32_prefill_pipeline;
     id<MTLComputePipelineState> attention_paged_pipeline;
+    id<MTLComputePipelineState> attention_paged_1x_pipeline;
     id<MTLComputePipelineState> compressed_attention_store_local_pipeline;
     id<MTLComputePipelineState> compressed_attention_store_component_pipeline;
     id<MTLComputePipelineState> compressed_attention_update_component_pipeline;
@@ -4103,6 +4104,14 @@ static NSString *termite_metal_shader_source(void) {
            "    float inv_sum = sum > 0.0f ? 1.0f / sum : 0.0f;\n"
            "    for (uint d = 0u; d < p.head_dim; ++d) output[out_base + d] *= inv_sum;\n"
            "}\n"
+           "kernel void termite_paged_attention_kv_1x(device const float *q [[buffer(0)]], device const uchar *encoded_key [[buffer(1)]], device const uchar *v_bytes [[buffer(2)]], device const uint *block_table [[buffer(3)]], device const float *sinks [[buffer(4)]], device float *output [[buffer(5)]], constant termite_metal_paged_attention_params &p [[buffer(6)]], threadgroup float *shmem [[threadgroup(0)]], ushort tid [[thread_index_in_threadgroup]], uint2 tg [[threadgroup_position_in_grid]]) {\n"
+           "    uint h = tg.y; if (tg.x != 0u || h >= p.num_heads || p.q_len != 1u || p.format != 3u || p.page_size == 0u || p.num_kv_heads == 0u) return;\n"
+           "    const uint NT = 256u; const float scale = rsqrt(float(p.head_dim)); uint heads_per_group = p.num_heads / p.num_kv_heads; uint kv_h = h / heads_per_group; uint q_base = h * p.head_dim; uint out_base = h * p.head_dim; uint kv_head_base = kv_h * p.head_dim; uint query_pos = p.query_position_offset; threadgroup float *scores = shmem; threadgroup float *partials = shmem + p.kv_tokens; const device half *v_half = reinterpret_cast<const device half *>(v_bytes);\n"
+           "    float local_best = -3.402823466e+38f;\n"
+           "    for (uint ki = 0u; ki < p.kv_tokens; ++ki) { uint key_pos = p.kv_position_offset + ki; bool allowed = key_pos <= query_pos; if (p.sliding_window != 0u && allowed) allowed = (query_pos - key_pos) < p.sliding_window; uint physical_token = allowed ? termite_attention_page_token(block_table, p, ki) : 0xffffffffu; if (physical_token == 0xffffffffu) allowed = false; float acc = 0.0f; if (allowed) { const device half *k_half = reinterpret_cast<const device half *>(encoded_key + physical_token * p.key_row_bytes); for (uint d = tid; d < p.head_dim; d += NT) acc += q[q_base + d] * float(k_half[kv_head_base + d]); } partials[tid] = acc; threadgroup_barrier(mem_flags::mem_threadgroup); for (uint stride = NT >> 1u; stride > 0u; stride >>= 1u) { if (uint(tid) < stride) partials[tid] += partials[tid + stride]; threadgroup_barrier(mem_flags::mem_threadgroup); } float score = allowed ? partials[0] * scale : -3.402823466e+38f; if (!isfinite(score)) score = -3.402823466e+38f; if (tid == 0u) scores[ki] = score; if (score > local_best) local_best = score; threadgroup_barrier(mem_flags::mem_threadgroup); }\n"
+           "    if (tid == 0u) { float sum = 0.0f; for (uint ki = 0u; ki < p.kv_tokens; ++ki) { float e = exp(scores[ki] - local_best); if (isfinite(e)) sum += e; } partials[0] = sum > 0.0f ? 1.0f / sum : 0.0f; } threadgroup_barrier(mem_flags::mem_threadgroup); const float inv_sum = partials[0];\n"
+           "    for (uint d = tid; d < p.head_dim; d += NT) { float value = 0.0f; for (uint ki = 0u; ki < p.kv_tokens; ++ki) { float e = exp(scores[ki] - local_best) * inv_sum; if (!isfinite(e) || e == 0.0f) continue; uint key_pos = p.kv_position_offset + ki; bool allowed = key_pos <= query_pos; if (p.sliding_window != 0u && allowed) allowed = (query_pos - key_pos) < p.sliding_window; if (!allowed) continue; uint physical_token = termite_attention_page_token(block_table, p, ki); if (physical_token == 0xffffffffu) continue; value += e * float(v_half[physical_token * p.v_row_stride + kv_head_base + d]); } output[out_base + d] = value; }\n"
+           "}\n"
            "kernel void termite_polar4_attention_span(device const float *q [[buffer(0)]], device const uchar *encoded_key [[buffer(1)]], device const float *v [[buffer(2)]], device float *output [[buffer(3)]], constant termite_metal_attention_span_params &p [[buffer(4)]], uint h [[thread_position_in_grid]]) {\n"
            "    if (h >= p.num_heads) return;\n"
            "    uint heads_per_group = p.num_heads / p.num_kv_heads;\n"
@@ -4474,6 +4483,11 @@ static bool termite_metal_planned_compute_barriers_enabled(termite_metal_decode_
     if (disabled != NULL && disabled[0] != '\0' && strcmp(disabled, "0") != 0) return false;
     if (runtime != NULL && runtime->planned_compute_barrier_suppression_depth != 0) return false;
     return true;
+}
+
+static bool termite_metal_paged_attention_1x_enabled(void) {
+    const char *disabled = getenv("TERMITE_METAL_DISABLE_PAGED_ATTENTION_1X");
+    return disabled == NULL || disabled[0] == '\0' || strcmp(disabled, "0") == 0;
 }
 
 static void termite_metal_decode_runtime_reset_planned_compute_ranges(termite_metal_decode_runtime *runtime) {
@@ -8488,7 +8502,14 @@ static int termite_metal_encode_paged_attention_slot_on_encoder(
         return failure_code;
     }
 
-    [encoder setComputePipelineState:runtime->attention_paged_pipeline];
+    const bool use_decode_1x = q_len == 1u &&
+        format == 3u &&
+        sinks == NULL &&
+        softcap == 0.0f &&
+        kv_tokens <= 4096u &&
+        termite_metal_paged_attention_1x_enabled() &&
+        runtime->attention_paged_1x_pipeline != nil;
+    [encoder setComputePipelineState:use_decode_1x ? runtime->attention_paged_1x_pipeline : runtime->attention_paged_pipeline];
     [encoder setBuffer:q_buffer offset:q_offset atIndex:0];
     [encoder setBuffer:runtime->attention_span_encoded_key_buffers[slot] offset:0 atIndex:1];
     [encoder setBuffer:runtime->attention_span_v_buffers[slot] offset:0 atIndex:2];
@@ -8510,8 +8531,13 @@ static int termite_metal_encode_paged_attention_slot_on_encoder(
     }
     [encoder setBuffer:output_buffer offset:output_offset atIndex:5];
     [encoder setBytes:&params length:sizeof(params) atIndex:6];
-    const size_t total = q_len * num_heads;
-    [encoder dispatchThreads:MTLSizeMake(total, 1, 1) threadsPerThreadgroup:MTLSizeMake(termite_metal_thread_width(runtime->attention_paged_pipeline, total), 1, 1)];
+    if (use_decode_1x) {
+        [encoder setThreadgroupMemoryLength:termite_metal_threadgroup_memory_16((kv_tokens + 256u) * sizeof(float)) atIndex:0];
+        [encoder dispatchThreadgroups:MTLSizeMake(1, num_heads, 1) threadsPerThreadgroup:MTLSizeMake(256, 1, 1)];
+    } else {
+        const size_t total = q_len * num_heads;
+        [encoder dispatchThreads:MTLSizeMake(total, 1, 1) threadsPerThreadgroup:MTLSizeMake(termite_metal_thread_width(runtime->attention_paged_pipeline, total), 1, 1)];
+    }
     (void)block_table_buffer;
     (void)sinks_buffer;
     return 0;
@@ -10807,6 +10833,7 @@ termite_metal_decode_runtime *termite_metal_decode_runtime_create(void) {
         runtime->attention_f32_pipeline = termite_metal_make_pipeline(device, precise_library, @"termite_attention_f32");
         runtime->attention_f32_prefill_pipeline = termite_metal_make_pipeline(device, precise_library, @"termite_attention_f32_prefill_tiled");
         runtime->attention_paged_pipeline = termite_metal_make_pipeline(device, precise_library, @"termite_paged_attention_kv");
+        runtime->attention_paged_1x_pipeline = termite_metal_make_pipeline(device, precise_library, @"termite_paged_attention_kv_1x");
         runtime->compressed_attention_store_local_pipeline = termite_metal_make_pipeline(device, precise_library, @"termite_compressed_attention_store_local");
         runtime->compressed_attention_store_component_pipeline = termite_metal_make_pipeline(device, precise_library, @"termite_compressed_attention_store_component");
         runtime->compressed_attention_update_component_pipeline = termite_metal_make_pipeline(device, precise_library, @"termite_compressed_attention_update_component");
@@ -11207,6 +11234,7 @@ void termite_metal_decode_runtime_destroy(termite_metal_decode_runtime *runtime)
     runtime->attention_f32_pipeline = nil;
     runtime->attention_f32_prefill_pipeline = nil;
     runtime->attention_paged_pipeline = nil;
+    runtime->attention_paged_1x_pipeline = nil;
     runtime->paged_f32_kv_seed_pipeline = nil;
     runtime->paged_f16_kv_seed_pipeline = nil;
     runtime->paged_f32_v_seed_pipeline = nil;

--- a/zig/pkg/inference/src/bench/metal_prefill_buckets.zig
+++ b/zig/pkg/inference/src/bench/metal_prefill_buckets.zig
@@ -30,6 +30,19 @@ fn defaultGemma4ModelPath(allocator: std.mem.Allocator) ![]u8 {
     return std.fs.path.join(allocator, &.{ home, ".antfly/inference/models/ggml-org/gemma-4-e2b-it-gguf" });
 }
 
+fn defaultAntflyBin(allocator: std.mem.Allocator) ![]u8 {
+    if (try getEnvVarOwned(allocator, "ANTFLY_BIN")) |value| return value;
+    const candidates = [_][]const u8{
+        "./zig-out/bin/antfly-inference",
+        "./zig-out/bin/antfly",
+    };
+    for (candidates) |candidate| {
+        std.Io.Dir.cwd().access(std.Io.Threaded.global_single_threaded.io(), candidate, .{}) catch continue;
+        return try allocator.dupe(u8, candidate);
+    }
+    return try allocator.dupe(u8, candidates[0]);
+}
+
 fn makePrompt(allocator: std.mem.Allocator, words: usize) ![]u8 {
     var out = std.ArrayList(u8).empty;
     try out.appendSlice(allocator, "hi");
@@ -56,20 +69,26 @@ fn runBucket(
 
     std.debug.print("\n== {s} target_prompt_tokens={d} prompt_words={d} decode_count={s} ==\n", .{ label, target_prompt_tokens, words, decode_count });
 
+    var argv = std.ArrayList([]const u8).empty;
+    defer argv.deinit(allocator);
+    try argv.append(allocator, antfly_bin);
+    if (std.mem.eql(u8, std.fs.path.basename(antfly_bin), "antfly")) {
+        try argv.append(allocator, "inference");
+    }
+    try argv.appendSlice(allocator, &.{
+        "generate",
+        model,
+        prompt,
+        "--backend",
+        backend,
+        "--max-tokens",
+        decode_count,
+        "--print-token-ids",
+        "--print-timing",
+    });
+
     var child = try std.process.spawn(io, .{
-        .argv = &.{
-            antfly_bin,
-            "inference",
-            "generate",
-            model,
-            prompt,
-            "--backend",
-            backend,
-            "--max-tokens",
-            decode_count,
-            "--print-token-ids",
-            "--print-timing",
-        },
+        .argv = argv.items,
         .stdin = .ignore,
         .stdout = .inherit,
         .stderr = .inherit,
@@ -87,7 +106,8 @@ pub fn main() !void {
     defer io_impl.deinit();
     const io = io_impl.io();
 
-    const antfly_bin = try envOrDefault(allocator, "ANTFLY_BIN", "./zig-out/bin/antfly");
+    const antfly_bin = try defaultAntflyBin(allocator);
+    defer allocator.free(antfly_bin);
     const model = try defaultGemma4ModelPath(allocator);
     defer allocator.free(model);
     const backend = try envOrDefault(allocator, "ANTFLY_INFERENCE_BENCH_BACKEND", "metal");

--- a/zig/pkg/inference/src/graph/metal_command_planner.zig
+++ b/zig/pkg/inference/src/graph/metal_command_planner.zig
@@ -228,6 +228,13 @@ fn quantOp(format: quant_matmul.Format, rows: usize, in_dim: usize, out_dim: usi
     };
 }
 
+fn q8F16ActivationDispatchSupported(dispatch: QuantMatmulDispatchKind) bool {
+    return switch (dispatch) {
+        .mm, .mmv, .scalar => true,
+        .small_batch => false,
+    };
+}
+
 fn resolveFfnActivationDType(
     requested: ActivationDType,
     formats: LayerQuantFormats,
@@ -236,7 +243,8 @@ fn resolveFfnActivationDType(
 ) ActivationDType {
     if (requested != .f16) return .f32;
     if (formats.gate != .q8_0 or formats.up != .q8_0 or formats.down != .q8_0) return .f32;
-    if (gate_plan.dispatch != .mm or down_plan.dispatch != .mm) return .f32;
+    if (!q8F16ActivationDispatchSupported(gate_plan.dispatch) or
+        !q8F16ActivationDispatchSupported(down_plan.dispatch)) return .f32;
     return .f16;
 }
 
@@ -2707,6 +2715,69 @@ test "metal command planner preserves f16 activation dtypes when appending layer
             try std.testing.expectEqual(ActivationDType.f32, op.output_dtype);
         }
     }
+    try std.testing.expect(found_gate_up_command);
+    try std.testing.expect(found_down_command);
+}
+
+test "metal command planner can size single-row decode FFN intermediates as f16 resident scratch" {
+    var layer_plan = GatedLayerCommandLowerer{};
+
+    try layer_plan.build(.{
+        .shares_kv = false,
+        .has_attention_pre_norm = false,
+        .attention_pre_norm_slot = 0,
+        .q_linear_slot = 21,
+        .k_linear_slot = 22,
+        .v_linear_slot = 23,
+        .q_head_norm_slot = 31,
+        .k_head_norm_slot = 32,
+        .attention_layer_index = 4,
+        .value_norm = true,
+        .activation_dtype = .f16,
+        .attention_linear_slot = 24,
+        .attention_post_norm_slot = 12,
+        .ffn_pre_norm_slot = 13,
+        .gate_linear_slot = 25,
+        .up_linear_slot = 26,
+        .down_linear_slot = 27,
+        .ffn_post_norm_slot = 14,
+        .ple_gate_linear_slot = 28,
+        .ple_proj_linear_slot = 29,
+        .ple_post_norm_slot = 15,
+        .source = 11,
+        .region = 7,
+        .rows = 1,
+        .hidden_size = 2048,
+        .attention_input_size = 2048,
+        .kv_dim = 512,
+        .intermediate_size = 8192,
+        .ple_hidden_size = 1024,
+    });
+
+    const command = layer_plan.commandView();
+    var found_ffn_gated = false;
+    var found_gate_up_command = false;
+    var found_down_command = false;
+    for (command.scratch_slots) |scratch| {
+        if (scratch.slot == @intFromEnum(GatedLayerCommandLowerer.Resource.ffn_gated)) {
+            found_ffn_gated = true;
+            try std.testing.expectEqual(ActivationDType.f16, scratch.dtype);
+            try std.testing.expectEqual(@as(usize, 8192 * @sizeOf(u16)), scratch.bytes);
+        }
+    }
+    for (command.ops) |op| {
+        if (op.kind == .ffn_gate_up_activation) {
+            found_gate_up_command = true;
+            try std.testing.expectEqual(ActivationDType.f32, op.input_dtype);
+            try std.testing.expectEqual(ActivationDType.f16, op.output_dtype);
+        }
+        if (op.kind == .ffn_down_linear) {
+            found_down_command = true;
+            try std.testing.expectEqual(ActivationDType.f16, op.input_dtype);
+            try std.testing.expectEqual(ActivationDType.f32, op.output_dtype);
+        }
+    }
+    try std.testing.expect(found_ffn_gated);
     try std.testing.expect(found_gate_up_command);
     try std.testing.expect(found_down_command);
 }

--- a/zig/pkg/inference/src/graph/metal_executor.zig
+++ b/zig/pkg/inference/src/graph/metal_executor.zig
@@ -309,9 +309,10 @@ fn printRuntimeDebugTimingStats(metal_stats: model_runtime.RuntimeDebugTimingSta
         },
     );
     std.debug.print(
-        "decoder_gated_decode_ms: greedy_calls={d} greedy_embed={d} greedy_block={d} greedy_tail={d} sampled_calls={d} sampled_embed={d} sampled_block={d} sampled_tail={d}\n",
+        "decoder_gated_decode_ms: greedy_calls={d} greedy_layer_specs={d} greedy_embed={d} greedy_block={d} greedy_tail={d} sampled_calls={d} sampled_embed={d} sampled_block={d} sampled_tail={d}\n",
         .{
             decoder_gated_stats.greedy_calls,
+            @divTrunc(decoder_gated_stats.greedy_layer_spec_nanos, std.time.ns_per_ms),
             @divTrunc(decoder_gated_stats.greedy_embed_nanos, std.time.ns_per_ms),
             @divTrunc(decoder_gated_stats.greedy_block_nanos, std.time.ns_per_ms),
             @divTrunc(decoder_gated_stats.greedy_tail_nanos, std.time.ns_per_ms),
@@ -1547,6 +1548,9 @@ pub fn supportsSession(session: backends.Session) bool {
 fn prewarmEmbeddingWeight(cb: *const ops.ComputeBackend, gpt_config: gpt_mod.Config) !void {
     const embed_w = try gpt_arch.getEmbeddingWeight(cb, gpt_config);
     defer cb.free(embed_w);
+    const ids = [_]i64{0};
+    const embedded = try cb.embeddingLookup(embed_w, ids[0..], ids.len, gpt_config.hidden_size);
+    defer cb.free(embedded);
 }
 
 pub fn prewarmSharedDecoderRuntime(

--- a/zig/pkg/inference/src/native_generate.zig
+++ b/zig/pkg/inference/src/native_generate.zig
@@ -999,6 +999,10 @@ fn metalExecutorReuseProbeEnabled() bool {
     return envFlagEnabled("TERMITE_METAL_EXECUTOR_REUSE_PROBE");
 }
 
+fn gemmaPrefillPrewarmDisabled() bool {
+    return envFlagEnabled("TERMITE_METAL_DISABLE_GEMMA_PREFILL_PREWARM");
+}
+
 fn printLiveWholeModelExecutorDetails(runtime_opt: ?*const graph_mod.model_runtime.ModelRuntime) void {
     if (runtime_opt) |runtime_model| {
         runtime_model.printDebugTiming();
@@ -1109,12 +1113,37 @@ fn tryRunLiveWholeModelExecutorGenerate(
     if (opts.print_timing and model.session.backend().usesGpuHostedSession()) {
         runtime_model.resetDebugTimingStats();
     }
-    const runtime_caps = runtime_model.capabilities();
     const created_runtime_at = std.Io.Timestamp.now(io, .awake);
 
     const prompt_ids = try allocator.alloc(i64, prompt_tokens);
     defer allocator.free(prompt_ids);
     for (prompt_token_ids, 0..) |token_id, idx| prompt_ids[idx] = token_id;
+    if (prompt_ids.len == 0) return error.EmptyPrompt;
+
+    var warmed_runtime_at = created_runtime_at;
+    var runtime_prewarm_ms: u64 = 0;
+    if (build_options.enable_metal and
+        gpt_config.family == .gemma and
+        model.session.backend().usesGpuHostedSession() and
+        !gemmaPrefillPrewarmDisabled())
+    {
+        const prewarm_started_at = std.Io.Timestamp.now(io, .awake);
+        const prewarm_ok = runtime_model.prepare(allocator, .{
+            .kv_tokens_hint = prompt_ids.len,
+        }) catch |err| blk: {
+            std.log.warn("Gemma4 Metal runtime prewarm failed for {s}: {s}", .{ opts.model_dir, @errorName(err) });
+            break :blk false;
+        };
+        warmed_runtime_at = std.Io.Timestamp.now(io, .awake);
+        runtime_prewarm_ms = durationMillis(prewarm_started_at, warmed_runtime_at);
+        if (!prewarm_ok) {
+            std.log.warn("Gemma4 Metal runtime prewarm declined for {s}", .{opts.model_dir});
+        }
+        if (opts.print_timing) {
+            runtime_model.resetDebugTimingStats();
+        }
+    }
+    const runtime_caps = runtime_model.capabilities();
 
     var all_token_ids = std.ArrayListUnmanaged(i64).empty;
     defer all_token_ids.deinit(allocator);
@@ -1139,8 +1168,6 @@ fn tryRunLiveWholeModelExecutorGenerate(
     var prefill_chunk_size = if (config.prefill_chunk_size > 0) config.prefill_chunk_size else prompt_ids.len;
     prefill_chunk_size = @max(@min(prefill_chunk_size, prompt_ids.len), 1);
     var output = blk: {
-        if (prompt_ids.len == 0) return error.EmptyPrompt;
-
         var processed: usize = 0;
         var output_accum: ?graph_mod.model_runtime.ModelOutput = null;
         errdefer if (output_accum) |*owned| owned.deinit(allocator);
@@ -1247,12 +1274,13 @@ fn tryRunLiveWholeModelExecutorGenerate(
     }
     if (opts.print_timing) {
         print(
-            "timing_ms: load_model={d} prompt_prep={d} scheduler=0 backend_setup={d} decode_setup=0 generate={d} total={d}\n",
+            "timing_ms: load_model={d} prompt_prep={d} scheduler=0 backend_setup={d} runtime_prewarm={d} decode_setup=0 generate={d} total={d}\n",
             .{
                 durationMillis(started_at, loaded_model_at),
                 durationMillis(loaded_model_at, encoded_prompt_at),
                 durationMillis(encoded_prompt_at, created_runtime_at),
-                durationMillis(created_runtime_at, finished_generate_at),
+                runtime_prewarm_ms,
+                durationMillis(warmed_runtime_at, finished_generate_at),
                 durationMillis(started_at, finished_generate_at),
             },
         );

--- a/zig/pkg/inference/src/ops/metal_compute.zig
+++ b/zig/pkg/inference/src/ops/metal_compute.zig
@@ -14899,6 +14899,7 @@ pub const MetalCompute = if (build_options.enable_metal) struct {
                 .head_dim = head_dim,
                 .attention_kv_format = layer_attention_kv_format,
                 .attention_storage = if (attention.kv_storage != null) .paged else .dense,
+                .activation_dtype = .f16,
                 .intermediate_size = layer.intermediate_size,
                 .ple_hidden_size = request.ple_hidden_size,
             }) catch {};
@@ -16794,6 +16795,11 @@ pub const MetalCompute = if (build_options.enable_metal) struct {
     fn resetDebugTimingStatsOp(ctx: *anyopaque) void {
         const self: *MetalCompute = @ptrCast(@alignCast(ctx));
         self.timing_stats = .{};
+        self.provider_impl.raw_quant_runtime_private_prepare_nanos = 0;
+        self.provider_impl.raw_quant_runtime_mapped_prepare_nanos = 0;
+        self.provider_impl.raw_quant_runtime_mapped_attempts = 0;
+        self.provider_impl.raw_quant_runtime_mapped_fallbacks = 0;
+        self.provider_impl.raw_quant_runtime_mapped_failures = 0;
         metal_tensor_mod.resetMemoryStats();
     }
 

--- a/zig/pkg/inference/src/pipelines/generation.zig
+++ b/zig/pkg/inference/src/pipelines/generation.zig
@@ -354,6 +354,7 @@ pub const NativeDecodeState = struct {
     moe_runtime: runtime.moe.runtime.MoeRuntime,
     shared_moe_cache: ?*runtime.moe.shared.SharedExpertCache = null,
     qwen35_linear_cache: ?gpt_arch.Qwen35LinearCache = null,
+    gemma4_layer_spec_cache: gpt_arch.Gemma4LayerSpecCache = .{},
     deepseek_v4_compressed_cache: ?gpt_arch.DeepSeekV4CompressedCache = null,
     force_full_recompute: bool = false,
 
@@ -389,6 +390,7 @@ pub const NativeDecodeState = struct {
 
     pub fn configureForGptConfig(self: *NativeDecodeState, config: gpt_mod.Config) void {
         self.force_full_recompute = false;
+        if (config.family != .gemma) self.gemma4_layer_spec_cache.reset();
         if (!requiresDeepSeekV4CompressedCache(config)) self.clearDeepSeekV4CompressedCache();
     }
 
@@ -549,6 +551,7 @@ pub const NativeDecodeState = struct {
         }
         self.moe_runtime.deinit();
         if (self.qwen35_linear_cache) |*cache| cache.deinit();
+        self.gemma4_layer_spec_cache.deinit(self.allocator);
         if (self.deepseek_v4_compressed_cache) |*cache| cache.deinit();
         self.kv_block_ids.deinit(self.allocator);
         self.sequence_id = null;
@@ -744,6 +747,7 @@ pub const NativeDecodeState = struct {
                 .kv_position_offset = 0,
                 .moe_runtime = &self.moe_runtime,
                 .qwen35_linear_cache = if (self.qwen35_linear_cache) |*cache| cache else null,
+                .gemma4_layer_spec_cache = &self.gemma4_layer_spec_cache,
                 .deepseek_v4_compressed_cache = if (self.deepseek_v4_compressed_cache) |*cache| cache else null,
             };
         }
@@ -759,6 +763,7 @@ pub const NativeDecodeState = struct {
             .kv_manager = self.kv_manager,
             .moe_runtime = &self.moe_runtime,
             .qwen35_linear_cache = if (self.qwen35_linear_cache) |*cache| cache else null,
+            .gemma4_layer_spec_cache = &self.gemma4_layer_spec_cache,
             .deepseek_v4_compressed_cache = if (self.deepseek_v4_compressed_cache) |*cache| cache else null,
             .kv_cache = if (self.kvView()) |view|
                 .{

--- a/zig/pkg/inference/src/server/server.zig
+++ b/zig/pkg/inference/src/server/server.zig
@@ -2409,11 +2409,7 @@ pub const Node = struct {
             // Draft model uses the same backend kind as the target — they run
             // on the same machine so the available backends are identical.
             const draft_backend_kind = backend_kind;
-            const draft_kv_dtype: runtime.kv.pool.KvDType = switch (draft_backend_kind) {
-                .native => .f32,
-                .cuda => .f16,
-                .metal => if (draft_cfg.family == .gemma) .f32 else .f16,
-            };
+            const draft_kv_dtype = session_factory.recommendedKvDTypeForGptConfig(draft_cfg, draft_backend_kind);
             draft_kv_manager = runtime.kv.manager.KvManager.init(ctx.allocator);
             const draft_sliding_window_size: ?u32 = if (draft_cfg.position_encoding == .absolute)
                 null


### PR DESCRIPTION
  ## Summary

  This PR speeds up the Zig Metal Gemma4 E2B path and adds local benchmark/smoke gates around the real
  GGUF workflow.

  Key changes:
  - Default Gemma-on-Metal KV cache dtype to f16, with f32 override support.
  - Add a specialized 1-token paged attention Metal kernel for hot decode.
  - Cache Gemma4 decoder layer specs across decode steps.
  - Use f16 resident FFN scratch for supported Q8_0 Metal decode plans.
  - Prewarm Gemma4 Metal runtime setup before measured generation.
  - Add canonical local E2B benchmark and smoke scripts.
  - Keep CLI/server tool-calling coverage explicit; server tool-calling remains the real gate.
  - Align speculative draft-model KV dtype selection with the main Gemma Metal dtype policy.

  ## Performance

  Local Gemma4 E2B Q8_0 Metal benchmark, 128 generated tokens:
  - warm E2E excluding runtime prewarm: ~14.5 tok/s median
  - decode: ~26.3 tok/s median
  - hot decode: ~28.9 tok/s median
  - cold CLI E2E including setup/prewarm: ~5.4 tok/s median
  - decode fallback: 0

  ## Validation

  Ran:
  - `zig fmt`
  - `git diff --check`
  - `bash -n` on updated scripts
  - `zig build -Dmetal=true -Donnx=false -Dpjrt=false`
  - focused Zig tests for Gemma4 layer-spec caching, fingerprinting, f16 FFN scratch sizing, and KV
  dtype selection
  - `zig build test-metal-gemma4-prefill-frame -Dmetal=true -Donnx=false -Dpjrt=false
  -Doptimize=ReleaseFast`
  - `zig build test-metal-gemma4-tool-calling -Dmetal=true -Donnx=false -Dpjrt=false
  -Doptimize=ReleaseFast`
  - `zig build diagnose-metal-gemma4-cli-tool-calling -Dmetal=true -Donnx=false -Dpjrt=false
  -Doptimize=ReleaseFast`
  - `zig build bench-metal-gemma4-e2b -Dmetal=true -Donnx=false -Dpjrt=false -Doptimize=ReleaseFast`

  ## Notes

  Validated locally on Mac Metal with Gemma4 E2B Q8_0. Broader model sizes and hardware should get
  separate benchmark passes before wider production claims.