### PR TITLE
support fielded MCP full text search

### DIFF
--- a/go/pkg/antfly/src/mcp/mcp.go
+++ b/go/pkg/antfly/src/mcp/mcp.go
@@ -54,14 +54,15 @@ type IndexInfo struct {
 
 // QueryRequest holds query parameters passed from MCP tools.
 type QueryRequest struct {
-	TableName      string
-	FullTextSearch string
-	SemanticSearch string
-	Fields         []string
-	Limit          int
-	OrderBy        []indexes.SortField
-	Indexes        []string
-	FilterPrefix   string
+	TableName           string
+	FullTextSearch      any
+	FullTextSearchField string
+	SemanticSearch      string
+	Fields              []string
+	Limit               int
+	OrderBy             []indexes.SortField
+	Indexes             []string
+	FilterPrefix        string
 }
 
 // QueryResult holds query results returned to MCP tools.
@@ -109,14 +110,16 @@ type DropIndexArgs struct {
 
 // QueryArgs defines the query tool parameters.
 type QueryArgs struct {
-	TableName      string              `json:"tableName"                mcp:"name of the table to query"`
-	FullTextSearch string              `json:"fullTextSearch,omitempty" mcp:"full text search query using bleve query string syntax"`
-	Fields         []string            `json:"fields,omitempty"         mcp:"fields to return"`
-	Limit          int                 `json:"limit,omitempty"          mcp:"maximum number of results (default: 10)"`
-	OrderBy        []indexes.SortField `json:"orderBy,omitempty"        mcp:"sort fields with direction (desc: true for descending)"`
-	SemanticSearch string              `json:"semanticSearch,omitempty" mcp:"semantic search query"`
-	Indexes        []string            `json:"indexes,omitempty"        mcp:"index names to use for semantic search"`
-	FilterPrefix   string              `json:"filterPrefix,omitempty"   mcp:"filter results by document id/key prefix"`
+	TableName           string              `json:"tableName"                     mcp:"name of the table to query"`
+	FullTextSearch      any                 `json:"fullTextSearch,omitempty"      mcp:"full text search query string shorthand, or the generic full_text_search query object accepted by the REST API"`
+	FullTextSearchRaw   map[string]any      `json:"full_text_search,omitempty"    mcp:"generic REST-shaped full_text_search query object"`
+	FullTextSearchField string              `json:"fullTextSearchField,omitempty" mcp:"field to search when fullTextSearch is a string shorthand, for example content"`
+	Fields              []string            `json:"fields,omitempty"              mcp:"fields to return"`
+	Limit               int                 `json:"limit,omitempty"               mcp:"maximum number of results (default: 10)"`
+	OrderBy             []indexes.SortField `json:"orderBy,omitempty"             mcp:"sort fields with direction (desc: true for descending)"`
+	SemanticSearch      string              `json:"semanticSearch,omitempty"      mcp:"semantic search query"`
+	Indexes             []string            `json:"indexes,omitempty"             mcp:"index names to use for semantic search"`
+	FilterPrefix        string              `json:"filterPrefix,omitempty"        mcp:"filter results by document id/key prefix"`
 }
 
 // BackupArgs defines the backup tool parameters.
@@ -360,14 +363,18 @@ func (s *AntflyMCPServer) Query(
 	}
 
 	qr := QueryRequest{
-		TableName:      args.TableName,
-		FullTextSearch: args.FullTextSearch,
-		SemanticSearch: args.SemanticSearch,
-		Fields:         args.Fields,
-		Limit:          limit,
-		OrderBy:        args.OrderBy,
-		Indexes:        args.Indexes,
-		FilterPrefix:   args.FilterPrefix,
+		TableName:           args.TableName,
+		FullTextSearch:      args.FullTextSearch,
+		FullTextSearchField: args.FullTextSearchField,
+		SemanticSearch:      args.SemanticSearch,
+		Fields:              args.Fields,
+		Limit:               limit,
+		OrderBy:             args.OrderBy,
+		Indexes:             args.Indexes,
+		FilterPrefix:        args.FilterPrefix,
+	}
+	if args.FullTextSearchRaw != nil {
+		qr.FullTextSearch = args.FullTextSearchRaw
 	}
 
 	result, err := s.handler.Query(ctx, qr)

--- a/go/pkg/antfly/src/mcp/mcp_test.go
+++ b/go/pkg/antfly/src/mcp/mcp_test.go
@@ -256,8 +256,10 @@ func TestDropTable(t *testing.T) {
 }
 
 func TestQuery(t *testing.T) {
+	var gotReq QueryRequest
 	handler := &mockHandler{
 		queryFn: func(ctx context.Context, req QueryRequest) (*QueryResult, error) {
+			gotReq = req
 			return &QueryResult{
 				HitCount: 2,
 				Structured: map[string]any{
@@ -277,9 +279,10 @@ func TestQuery(t *testing.T) {
 	result, err := session.CallTool(context.Background(), &mcp.CallToolParams{
 		Name: "query",
 		Arguments: map[string]any{
-			"tableName":      "docs",
-			"fullTextSearch": "test",
-			"limit":          10,
+			"tableName":           "docs",
+			"fullTextSearch":      "test",
+			"fullTextSearchField": "content",
+			"limit":               10,
 		},
 	})
 	require.NoError(t, err)
@@ -288,6 +291,9 @@ func TestQuery(t *testing.T) {
 	tc, ok := result.Content[0].(*mcp.TextContent)
 	require.True(t, ok)
 	assert.Contains(t, tc.Text, "2 results")
+	assert.Equal(t, "docs", gotReq.TableName)
+	assert.Equal(t, "test", gotReq.FullTextSearch)
+	assert.Equal(t, "content", gotReq.FullTextSearchField)
 
 	// Verify structured content is a map (round-tripped query result)
 	if result.StructuredContent != nil {

--- a/go/pkg/antfly/src/metadata/mcp_adapter.go
+++ b/go/pkg/antfly/src/metadata/mcp_adapter.go
@@ -221,10 +221,10 @@ func (a *mcpAdapter) Query(ctx context.Context, req antflymcp.QueryRequest) (*an
 		internalReq.FilterPrefix = []byte(req.FilterPrefix)
 	}
 
-	// Convert bleve query string syntax to json.RawMessage
-	if req.FullTextSearch != "" {
-		q := query.NewQueryStringQuery(req.FullTextSearch)
-		ftsJSON, err := json.Marshal(q)
+	// Convert MCP full-text args to the same structured query JSON accepted by
+	// the REST query API.
+	if req.FullTextSearch != nil {
+		ftsJSON, err := mcpFullTextSearchJSON(req.FullTextSearch, req.FullTextSearchField)
 		if err != nil {
 			return nil, fmt.Errorf("invalid full text search query: %w", err)
 		}
@@ -255,6 +255,38 @@ func (a *mcpAdapter) Query(ctx context.Context, req antflymcp.QueryRequest) (*an
 		HitCount:   hitCount,
 		Structured: structured,
 	}, nil
+}
+
+func mcpFullTextSearchJSON(fullTextSearch any, field string) (json.RawMessage, error) {
+	switch value := fullTextSearch.(type) {
+	case string:
+		if value == "" {
+			return nil, nil
+		}
+		if field != "" {
+			ftsJSON, err := json.Marshal(map[string]any{
+				"match": value,
+				"field": field,
+			})
+			if err != nil {
+				return nil, err
+			}
+			return ftsJSON, nil
+		}
+
+		q := query.NewQueryStringQuery(value)
+		ftsJSON, err := json.Marshal(q)
+		if err != nil {
+			return nil, err
+		}
+		return ftsJSON, nil
+	case map[string]any:
+		return json.Marshal(value)
+	case json.RawMessage:
+		return value, nil
+	default:
+		return nil, fmt.Errorf("expected string or object")
+	}
 }
 
 // Batch implements antflymcp.AntflyHandler.

--- a/go/pkg/antfly/src/metadata/mcp_adapter_test.go
+++ b/go/pkg/antfly/src/metadata/mcp_adapter_test.go
@@ -1,0 +1,59 @@
+// Copyright 2026 Antfly, Inc.
+//
+// Licensed under the Elastic License 2.0 (ELv2); you may not use this file
+// except in compliance with the Elastic License 2.0. You may obtain a copy of
+// the Elastic License 2.0 at
+//
+//     https://www.antfly.io/licensing/ELv2-license
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Elastic License 2.0 is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+// the Elastic License 2.0 for the specific language governing permissions and
+// limitations.
+
+package metadata
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMCPFullTextSearchJSONWithField(t *testing.T) {
+	raw, err := mcpFullTextSearchJSON("individual freedom personality development", "content")
+	require.NoError(t, err)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(raw, &got))
+	assert.Equal(t, map[string]any{
+		"match": "individual freedom personality development",
+		"field": "content",
+	}, got)
+}
+
+func TestMCPFullTextSearchJSONWithoutFieldUsesQueryString(t *testing.T) {
+	raw, err := mcpFullTextSearchJSON("content:montessori", "")
+	require.NoError(t, err)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(raw, &got))
+	assert.Equal(t, "content:montessori", got["query"])
+}
+
+func TestMCPFullTextSearchJSONPassesThroughObject(t *testing.T) {
+	raw, err := mcpFullTextSearchJSON(map[string]any{
+		"match": "individual freedom personality development",
+		"field": "content",
+	}, "")
+	require.NoError(t, err)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(raw, &got))
+	assert.Equal(t, map[string]any{
+		"match": "individual freedom personality development",
+		"field": "content",
+	}, got)
+}

--- a/zig/pkg/antfly/src/api/http_server.zig
+++ b/zig/pkg/antfly/src/api/http_server.zig
@@ -11744,6 +11744,115 @@ test "api http server serves document lookup through mcp tool" {
     try std.testing.expect(std.mem.indexOf(u8, call_resp.body, "\"structuredContent\":{\"title\":\"alpha\"}") != null);
 }
 
+test "api http server serves fielded full-text search through mcp tools" {
+    const alloc = std.testing.allocator;
+    const path = "/tmp/antfly-api-http-mcp-fielded-search";
+    var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
+    defer io_impl.deinit();
+    std.Io.Dir.cwd().deleteTree(io_impl.io(), path) catch {};
+
+    var db = try db_mod.DB.open(alloc, path, .{});
+    defer {
+        db.close();
+        std.Io.Dir.cwd().deleteTree(io_impl.io(), path) catch {};
+    }
+    try db.addIndex(.{ .name = "full_text_index_v0", .kind = .full_text, .config_json = "{}" });
+    try db.batch(.{
+        .writes = &.{.{ .key = "doc:a", .value = "{\"title\":\"alpha\",\"body\":\"hello\"}" }},
+        .sync_level = .full_index,
+    });
+
+    var table_source = table_reads.BoundTableReadSource.init("docs", 77, &db, raft_mod.read_gate.noopReadableLeaseRequester());
+
+    const FakeSource = struct {
+        fn iface(_: *@This()) StatusSource {
+            return .{
+                .ptr = undefined,
+                .vtable = &.{
+                    .status = status,
+                },
+            };
+        }
+
+        fn status(_: *anyopaque) !metadata_api.MetadataStatus {
+            return .{ .metadata_group_id = 1, .metrics = .{}, .projected_stores = 1 };
+        }
+    };
+
+    var source = FakeSource{};
+    var server = ApiHttpServer.init(std.testing.allocator, .{}, source.iface(), table_source.source(), null);
+    defer server.deinit();
+
+    var init_resp = try server.handle(.{
+        .method = .POST,
+        .uri = routes.Routes.mcp_v1,
+        .content_type = "application/json",
+        .body = "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{}}",
+    });
+    defer init_resp.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(u16, 200), init_resp.status);
+
+    const mcp_session_headers = [_]http_common.RequestHeader{
+        .{ .name = mcp.session_id_header, .value = init_resp.headers[0].value },
+    };
+    var tools_resp = try server.handle(.{
+        .method = .POST,
+        .uri = routes.Routes.mcp_v1,
+        .headers = &mcp_session_headers,
+        .content_type = "application/json",
+        .body = "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/list\",\"params\":{}}",
+    });
+    defer tools_resp.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(u16, 200), tools_resp.status);
+    try std.testing.expect(std.mem.indexOf(u8, tools_resp.body, "\"fullTextSearchField\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, tools_resp.body, "\"full_text_search\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, tools_resp.body, "\"oneOf\"") != null);
+
+    var wrong_field_resp = try server.handle(.{
+        .method = .POST,
+        .uri = routes.Routes.mcp_v1,
+        .headers = &mcp_session_headers,
+        .content_type = "application/json",
+        .body = "{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"tools/call\",\"params\":{\"name\":\"query\",\"arguments\":{\"tableName\":\"docs\",\"full_text_search\":{\"match\":\"hello\",\"field\":\"title\"},\"fields\":[\"title\",\"body\"],\"limit\":5}}}",
+    });
+    defer wrong_field_resp.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(u16, 200), wrong_field_resp.status);
+    try std.testing.expect(std.mem.indexOf(u8, wrong_field_resp.body, "\"doc:a\"") == null);
+
+    var query_resp = try server.handle(.{
+        .method = .POST,
+        .uri = routes.Routes.mcp_v1,
+        .headers = &mcp_session_headers,
+        .content_type = "application/json",
+        .body = "{\"jsonrpc\":\"2.0\",\"id\":5,\"method\":\"tools/call\",\"params\":{\"name\":\"query\",\"arguments\":{\"tableName\":\"docs\",\"fullTextSearch\":\"hello\",\"fullTextSearchField\":\"body\",\"fields\":[\"title\",\"body\"],\"limit\":5}}}",
+    });
+    defer query_resp.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(u16, 200), query_resp.status);
+    try std.testing.expect(std.mem.indexOf(u8, query_resp.body, "\"doc:a\"") != null);
+
+    var query_object_resp = try server.handle(.{
+        .method = .POST,
+        .uri = routes.Routes.mcp_v1,
+        .headers = &mcp_session_headers,
+        .content_type = "application/json",
+        .body = "{\"jsonrpc\":\"2.0\",\"id\":6,\"method\":\"tools/call\",\"params\":{\"name\":\"query\",\"arguments\":{\"tableName\":\"docs\",\"fullTextSearch\":{\"match\":\"hello\",\"field\":\"body\"},\"fields\":[\"title\",\"body\"],\"limit\":5}}}",
+    });
+    defer query_object_resp.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(u16, 200), query_object_resp.status);
+    try std.testing.expect(std.mem.indexOf(u8, query_object_resp.body, "\"doc:a\"") != null);
+
+    var query_rest_alias_resp = try server.handle(.{
+        .method = .POST,
+        .uri = routes.Routes.mcp_v1,
+        .headers = &mcp_session_headers,
+        .content_type = "application/json",
+        .body = "{\"jsonrpc\":\"2.0\",\"id\":7,\"method\":\"tools/call\",\"params\":{\"name\":\"query\",\"arguments\":{\"tableName\":\"docs\",\"full_text_search\":{\"match\":\"hello\",\"field\":\"body\"},\"fields\":[\"title\",\"body\"],\"limit\":5}}}",
+    });
+    defer query_rest_alias_resp.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(u16, 200), query_rest_alias_resp.status);
+    try std.testing.expect(std.mem.indexOf(u8, query_rest_alias_resp.body, "\"doc:a\"") != null);
+}
+
 test "api http server serves table scan as ndjson" {
     const ScanRow = struct {
         key: []const u8,

--- a/zig/pkg/antfly/src/api/protocol_adapters.zig
+++ b/zig/pkg/antfly/src/api/protocol_adapters.zig
@@ -58,7 +58,12 @@ const McpToolFieldSpec = struct {
     description: ?[]const u8 = null,
     default_json: ?[]const u8 = null,
     items_json: ?[]const u8 = null,
+    schema_json: ?[]const u8 = null,
 };
+
+const full_text_search_schema_json =
+    \\{"oneOf":[{"type":"string"},{"type":"object","additionalProperties":true}],"description":"Full-text query string shorthand, or the generic full_text_search query object accepted by the REST API"}
+;
 
 const mcp_tool_specs = [_]McpToolSpec{
     .{
@@ -124,7 +129,9 @@ const mcp_tool_specs = [_]McpToolSpec{
         .description = "Run an Antfly table query",
         .fields = &.{
             .{ .name = "tableName", .schema_type = .string, .required = true },
-            .{ .name = "fullTextSearch", .schema_type = .string },
+            .{ .name = "fullTextSearch", .schema_type = .object, .schema_json = full_text_search_schema_json },
+            .{ .name = "full_text_search", .schema_type = .object, .description = "Generic REST-shaped full_text_search query object" },
+            .{ .name = "fullTextSearchField", .schema_type = .string, .description = "Field to search when fullTextSearch is a string shorthand, for example content" },
             .{ .name = "semanticSearch", .schema_type = .string },
             .{ .name = "fields", .schema_type = .array, .items_json = "{\"type\":\"string\"}" },
             .{ .name = "limit", .schema_type = .integer, .default_json = "10" },
@@ -325,13 +332,7 @@ fn handleMcpRequestFiltered(server_ptr: anytype, req: http_common.HttpRequest, a
         fn query(ctx: *@This(), alloc: std.mem.Allocator, args: std.json.Value) !mcp.CallToolResult {
             const table_name = jsonStringArg(args, "tableName") orelse return mcpError(alloc, "missing tableName");
             var body = std.json.ObjectMap.empty;
-            if (jsonStringArg(args, "fullTextSearch")) |full_text| {
-                if (full_text.len != 0) {
-                    var full_text_obj = std.json.ObjectMap.empty;
-                    try full_text_obj.put(alloc, "query", .{ .string = full_text });
-                    try body.put(alloc, "full_text_search", .{ .object = full_text_obj });
-                }
-            }
+            putFullTextSearchArg(alloc, &body, args) catch return mcpError(alloc, "invalid fullTextSearch");
             if (jsonStringArg(args, "semanticSearch")) |semantic| if (semantic.len != 0) try body.put(alloc, "semantic_search", .{ .string = semantic });
             if (jsonValueArg(args, "fields")) |fields| try body.put(alloc, "fields", fields);
             if (jsonValueArg(args, "orderBy")) |order_by| try body.put(alloc, "order_by", order_by);
@@ -996,7 +997,12 @@ fn buildMcpInputSchema(alloc: std.mem.Allocator, spec: McpToolSpec) ![]u8 {
     for (spec.fields, 0..) |field, i| {
         if (i != 0) try out.append(alloc, ',');
         try appendJsonString(alloc, &out, field.name);
-        try out.appendSlice(alloc, ":{\"type\":");
+        try out.append(alloc, ':');
+        if (field.schema_json) |schema_json| {
+            try out.appendSlice(alloc, schema_json);
+            continue;
+        }
+        try out.appendSlice(alloc, "{\"type\":");
         try appendJsonString(alloc, &out, @tagName(field.schema_type));
         if (field.items_json) |items_json| {
             try out.appendSlice(alloc, ",\"items\":");
@@ -1322,6 +1328,44 @@ fn jsonIntObjectField(object: anytype, key: []const u8) ?i64 {
 fn jsonValueArg(value: std.json.Value, key: []const u8) ?std.json.Value {
     if (value != .object) return null;
     return value.object.get(key);
+}
+
+fn putFullTextSearch(
+    alloc: std.mem.Allocator,
+    body: *std.json.ObjectMap,
+    match: []const u8,
+    field: ?[]const u8,
+) !void {
+    var full_text_obj = std.json.ObjectMap.empty;
+    if (field) |field_name| {
+        if (field_name.len != 0) {
+            try full_text_obj.put(alloc, "match", .{ .string = match });
+            try full_text_obj.put(alloc, "field", .{ .string = field_name });
+            try body.put(alloc, "full_text_search", .{ .object = full_text_obj });
+            return;
+        }
+    }
+    try full_text_obj.put(alloc, "query", .{ .string = match });
+    try body.put(alloc, "full_text_search", .{ .object = full_text_obj });
+}
+
+fn putFullTextSearchArg(
+    alloc: std.mem.Allocator,
+    body: *std.json.ObjectMap,
+    args: std.json.Value,
+) !void {
+    if (jsonValueArg(args, "full_text_search")) |full_text| {
+        if (full_text != .null) try body.put(alloc, "full_text_search", full_text);
+        return;
+    }
+    if (jsonValueArg(args, "fullTextSearch")) |full_text| {
+        switch (full_text) {
+            .string => |text| if (text.len != 0) try putFullTextSearch(alloc, body, text, jsonStringArg(args, "fullTextSearchField")),
+            .object => try body.put(alloc, "full_text_search", full_text),
+            .null => {},
+            else => return error.InvalidParams,
+        }
+    }
 }
 
 fn stringifyJsonValue(alloc: std.mem.Allocator, value: std.json.Value) ![]u8 {


### PR DESCRIPTION
## Summary

Updates the MCP `query` tool so full-text search can use the same generic `full_text_search` shape accepted by the REST query API. This lets callers target a specific field with `{ "match": "...", "field": "content" }` instead of relying on the default full-text parser/field.

## Details

- Zig MCP `query` now accepts:
  - `full_text_search` as a REST-shaped object
  - object-form `fullTextSearch`
  - string-form `fullTextSearch` with optional `fullTextSearchField`
- Go MCP parity now forwards the same fielded full-text shape through the metadata adapter.
- Adds focused Zig integration coverage and Go unit coverage for fielded search JSON construction.

## Validation

- `zig build root-test -- --test-filter "api http server serves fielded full-text search through mcp tools"`
- `env GOWORK=off GOCACHE=/tmp/antfly-go-build-cache go test ./src/mcp ./src/metadata -run 'Test(ListTools|Query|MCPFullTextSearchJSON)'`

Note: the Go test run emitted existing local linker warnings about a missing onnxruntime search path, but the packages passed.