### PR TITLE
support raw MCP query requests

### DIFF
--- a/go/pkg/antfly/src/mcp/mcp.go
+++ b/go/pkg/antfly/src/mcp/mcp.go
@@ -55,6 +55,7 @@ type IndexInfo struct {
 // QueryRequest holds query parameters passed from MCP tools.
 type QueryRequest struct {
 	TableName           string
+	RawQueryRequest     map[string]any
 	FullTextSearch      any
 	FullTextSearchField string
 	SemanticSearch      string
@@ -111,6 +112,7 @@ type DropIndexArgs struct {
 // QueryArgs defines the query tool parameters.
 type QueryArgs struct {
 	TableName           string              `json:"tableName"                     mcp:"name of the table to query"`
+	QueryRequest        map[string]any      `json:"queryRequest,omitempty"        mcp:"raw Antfly QueryRequest body for POST /tables/{tableName}/query; mutually exclusive with query shorthand arguments"`
 	FullTextSearch      any                 `json:"fullTextSearch,omitempty"      mcp:"full text search query string shorthand, or the generic full_text_search query object accepted by the REST API"`
 	FullTextSearchRaw   map[string]any      `json:"full_text_search,omitempty"    mcp:"generic REST-shaped full_text_search query object"`
 	FullTextSearchField string              `json:"fullTextSearchField,omitempty" mcp:"field to search when fullTextSearch is a string shorthand, for example content"`
@@ -156,6 +158,75 @@ type ListTablesResult struct {
 // ListIndexesResult wraps the list of indexes in a struct for MCP output schema compatibility.
 type ListIndexesResult struct {
 	Indexes []IndexInfo `json:"indexes"`
+}
+
+// QueryRequestDescription returns compact schema guidance for the raw queryRequest argument.
+func QueryRequestDescription() map[string]any {
+	return map[string]any{
+		"openapi_schema":   "specs/openapi/antfly/metadata.yaml#/components/schemas/QueryRequest",
+		"query_ast_schema": "specs/openapi/antfly/query.yaml#/components/schemas/Query",
+		"mcp_usage": map[string]any{
+			"tool":                   "query",
+			"path_table_argument":    "tableName",
+			"raw_body_argument":      "queryRequest",
+			"raw_mode_exclusive":     true,
+			"rejects_query_table":    true,
+			"shorthand_arguments":    []string{"fullTextSearch", "fullTextSearchField", "semanticSearch", "fields", "limit", "orderBy", "indexes", "filterPrefix"},
+			"forwarded_request_path": "POST /tables/{tableName}/query",
+		},
+		"top_level_fields": []string{
+			"query", "full_text_search", "semantic_search", "embedding_template", "indexes",
+			"filter_prefix", "filter_query", "exclusion_query", "aggregations", "embeddings",
+			"search_effort", "fields", "limit", "offset", "order_by", "search_after",
+			"search_before", "distance_under", "distance_over", "merge_config", "count",
+			"profile", "reranker", "analyses", "graph_searches", "expand_strategy",
+			"document_renderer", "pruner", "join", "foreign_sources",
+		},
+		"examples": map[string]any{
+			"fielded_full_text": map[string]any{
+				"full_text_search": map[string]any{"match": "hello", "field": "body"},
+				"fields":           []string{"title", "body"},
+				"limit":            5,
+			},
+			"hybrid": map[string]any{
+				"full_text_search": map[string]any{"match": "raft", "field": "body"},
+				"semantic_search":  "raft snapshot architecture",
+				"indexes":          []string{"body_embedding"},
+				"merge_config":     map[string]any{"strategy": "rrf"},
+				"fields":           []string{"title", "body"},
+				"limit":            20,
+				"profile":          true,
+			},
+		},
+	}
+}
+
+// MCPCapabilitiesDescription returns compact capability discovery metadata.
+func MCPCapabilitiesDescription() map[string]any {
+	return map[string]any{
+		"protocol":         "mcp",
+		"protocol_version": "2025-06-18",
+		"transport":        "streamable_http",
+		"sessions": map[string]any{
+			"initialize_returns_session_id":  true,
+			"delete_closes_session":          true,
+			"last_event_id_cursor_supported": true,
+			"historical_replay":              false,
+		},
+		"query_builder": "Use the A2A query-builder skill for agentic natural-language query planning. MCP stays focused on deterministic database tools and raw QueryRequest execution.",
+		"tools": map[string]any{
+			"deterministic":   []string{"list_tables", "list_indexes", "query", "describe_query_request"},
+			"write":           []string{"create_table", "drop_table", "create_index", "drop_index", "batch", "backup", "restore"},
+			"schema_helpers":  []string{"describe_query_request", "describe_mcp_capabilities"},
+			"zig_extra_tools": []string{"describe_table", "describe_indexes", "get_document", "sample_documents"},
+		},
+		"query": map[string]any{
+			"raw_query_request":          true,
+			"raw_query_request_argument": "queryRequest",
+			"shorthand_arguments":        []string{"fullTextSearch", "fullTextSearchField", "semanticSearch", "fields", "limit", "orderBy", "indexes", "filterPrefix"},
+			"raw_mode_exclusive":         true,
+		},
+	}
 }
 
 // AntflyMCPServer wraps an AntflyHandler for MCP operations.
@@ -357,9 +428,24 @@ func (s *AntflyMCPServer) Query(
 ) (*mcp.CallToolResult, map[string]any, error) {
 	var res mcp.CallToolResult
 
-	limit := args.Limit
-	if limit == 0 {
-		limit = 10 // default
+	if args.QueryRequest != nil {
+		if _, ok := args.QueryRequest["table"]; ok {
+			res.Content = []mcp.Content{
+				&mcp.TextContent{Text: "queryRequest.table is not allowed; pass the table as tableName"},
+			}
+			return &res, nil, nil
+		}
+		if queryRequestHasShorthandArgs(args) {
+			res.Content = []mcp.Content{
+				&mcp.TextContent{Text: "queryRequest cannot be combined with query shorthand arguments"},
+			}
+			return &res, nil, nil
+		}
+		qr := QueryRequest{
+			TableName:       args.TableName,
+			RawQueryRequest: args.QueryRequest,
+		}
+		return s.runQuery(ctx, qr)
 	}
 
 	qr := QueryRequest{
@@ -368,15 +454,35 @@ func (s *AntflyMCPServer) Query(
 		FullTextSearchField: args.FullTextSearchField,
 		SemanticSearch:      args.SemanticSearch,
 		Fields:              args.Fields,
-		Limit:               limit,
+		Limit:               args.Limit,
 		OrderBy:             args.OrderBy,
 		Indexes:             args.Indexes,
 		FilterPrefix:        args.FilterPrefix,
+	}
+	if qr.Limit == 0 {
+		qr.Limit = 10 // default
 	}
 	if args.FullTextSearchRaw != nil {
 		qr.FullTextSearch = args.FullTextSearchRaw
 	}
 
+	return s.runQuery(ctx, qr)
+}
+
+func queryRequestHasShorthandArgs(args QueryArgs) bool {
+	return args.FullTextSearch != nil ||
+		args.FullTextSearchRaw != nil ||
+		args.FullTextSearchField != "" ||
+		args.SemanticSearch != "" ||
+		len(args.Fields) != 0 ||
+		args.Limit != 0 ||
+		len(args.OrderBy) != 0 ||
+		len(args.Indexes) != 0 ||
+		args.FilterPrefix != ""
+}
+
+func (s *AntflyMCPServer) runQuery(ctx context.Context, qr QueryRequest) (*mcp.CallToolResult, map[string]any, error) {
+	var res mcp.CallToolResult
 	result, err := s.handler.Query(ctx, qr)
 	if err != nil {
 		res.Content = []mcp.Content{
@@ -391,6 +497,32 @@ func (s *AntflyMCPServer) Query(
 		},
 	}
 	return &res, result.Structured, nil
+}
+
+// DescribeQueryRequest returns compact guidance for query.queryRequest.
+func (s *AntflyMCPServer) DescribeQueryRequest(
+	ctx context.Context,
+	req *mcp.CallToolRequest,
+	args struct{},
+) (*mcp.CallToolResult, map[string]any, error) {
+	var res mcp.CallToolResult
+	res.Content = []mcp.Content{
+		&mcp.TextContent{Text: "Antfly QueryRequest schema summary for query.queryRequest"},
+	}
+	return &res, QueryRequestDescription(), nil
+}
+
+// DescribeMCPCapabilities returns compact capability discovery metadata.
+func (s *AntflyMCPServer) DescribeMCPCapabilities(
+	ctx context.Context,
+	req *mcp.CallToolRequest,
+	args struct{},
+) (*mcp.CallToolResult, map[string]any, error) {
+	var res mcp.CallToolResult
+	res.Content = []mcp.Content{
+		&mcp.TextContent{Text: "Antfly MCP capabilities"},
+	}
+	return &res, MCPCapabilitiesDescription(), nil
 }
 
 // Backup creates a backup of a table
@@ -539,6 +671,14 @@ func NewMCPServer(handler AntflyHandler) *mcp.Server {
 		Name:        "query",
 		Description: "Query data from a table with full-text and semantic search",
 	}, s.Query)
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "describe_query_request",
+		Description: "Return compact guidance for the raw Antfly QueryRequest accepted by query.queryRequest",
+	}, s.DescribeQueryRequest)
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "describe_mcp_capabilities",
+		Description: "Describe Antfly MCP capabilities, deterministic tools, and A2A query-builder handoff guidance",
+	}, s.DescribeMCPCapabilities)
 
 	// Backup and restore
 	mcp.AddTool(server, &mcp.Tool{

--- a/go/pkg/antfly/src/mcp/mcp_test.go
+++ b/go/pkg/antfly/src/mcp/mcp_test.go
@@ -136,6 +136,8 @@ func TestListTools(t *testing.T) {
 		"batch",
 		"create_index",
 		"create_table",
+		"describe_mcp_capabilities",
+		"describe_query_request",
 		"drop_index",
 		"drop_table",
 		"list_indexes",
@@ -144,6 +146,51 @@ func TestListTools(t *testing.T) {
 		"restore",
 	}
 	assert.Equal(t, want, got)
+}
+
+func TestDescribeMCPCapabilities(t *testing.T) {
+	session := setupMCPTest(t, &mockHandler{})
+
+	result, err := session.CallTool(context.Background(), &mcp.CallToolParams{
+		Name: "describe_mcp_capabilities",
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, result.Content)
+
+	tc, ok := result.Content[0].(*mcp.TextContent)
+	require.True(t, ok)
+	assert.Contains(t, tc.Text, "MCP capabilities")
+
+	sc, ok := result.StructuredContent.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "mcp", sc["protocol"])
+	queryBuilder, ok := sc["query_builder"].(string)
+	require.True(t, ok)
+	assert.Contains(t, queryBuilder, "query-builder")
+	query, ok := sc["query"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, true, query["raw_query_request"])
+}
+
+func TestDescribeQueryRequest(t *testing.T) {
+	session := setupMCPTest(t, &mockHandler{})
+
+	result, err := session.CallTool(context.Background(), &mcp.CallToolParams{
+		Name: "describe_query_request",
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, result.Content)
+
+	tc, ok := result.Content[0].(*mcp.TextContent)
+	require.True(t, ok)
+	assert.Contains(t, tc.Text, "QueryRequest")
+
+	sc, ok := result.StructuredContent.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "specs/openapi/antfly/metadata.yaml#/components/schemas/QueryRequest", sc["openapi_schema"])
+	examples, ok := sc["examples"].(map[string]any)
+	require.True(t, ok)
+	assert.Contains(t, examples, "fielded_full_text")
 }
 
 func TestListTables(t *testing.T) {
@@ -305,6 +352,96 @@ func TestQuery(t *testing.T) {
 		require.True(t, ok)
 		assert.Len(t, hitList, 2)
 	}
+}
+
+func TestQueryRawRequest(t *testing.T) {
+	var gotReq QueryRequest
+	handler := &mockHandler{
+		queryFn: func(ctx context.Context, req QueryRequest) (*QueryResult, error) {
+			gotReq = req
+			return &QueryResult{
+				HitCount:   1,
+				Structured: map[string]any{"hits": map[string]any{"total": 1}},
+			}, nil
+		},
+	}
+	session := setupMCPTest(t, handler)
+
+	result, err := session.CallTool(context.Background(), &mcp.CallToolParams{
+		Name: "query",
+		Arguments: map[string]any{
+			"tableName": "docs",
+			"queryRequest": map[string]any{
+				"full_text_search": map[string]any{"match": "hello", "field": "body"},
+				"fields":           []string{"title", "body"},
+				"limit":            5,
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, result.Content)
+
+	tc, ok := result.Content[0].(*mcp.TextContent)
+	require.True(t, ok)
+	assert.Contains(t, tc.Text, "1 results")
+	assert.Equal(t, "docs", gotReq.TableName)
+	require.NotNil(t, gotReq.RawQueryRequest)
+	assert.Equal(t, []any{"title", "body"}, gotReq.RawQueryRequest["fields"])
+	assert.Equal(t, float64(5), gotReq.RawQueryRequest["limit"])
+	fts, ok := gotReq.RawQueryRequest["full_text_search"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "hello", fts["match"])
+	assert.Equal(t, "body", fts["field"])
+}
+
+func TestQueryRawRequestRejectsShorthandMix(t *testing.T) {
+	session := setupMCPTest(t, &mockHandler{
+		queryFn: func(ctx context.Context, req QueryRequest) (*QueryResult, error) {
+			t.Fatal("query handler should not be called")
+			return nil, nil
+		},
+	})
+
+	result, err := session.CallTool(context.Background(), &mcp.CallToolParams{
+		Name: "query",
+		Arguments: map[string]any{
+			"tableName": "docs",
+			"queryRequest": map[string]any{
+				"full_text_search": map[string]any{"match": "hello", "field": "body"},
+			},
+			"limit": 5,
+		},
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, result.Content)
+	tc, ok := result.Content[0].(*mcp.TextContent)
+	require.True(t, ok)
+	assert.Contains(t, tc.Text, "queryRequest cannot be combined")
+}
+
+func TestQueryRawRequestRejectsTableField(t *testing.T) {
+	session := setupMCPTest(t, &mockHandler{
+		queryFn: func(ctx context.Context, req QueryRequest) (*QueryResult, error) {
+			t.Fatal("query handler should not be called")
+			return nil, nil
+		},
+	})
+
+	result, err := session.CallTool(context.Background(), &mcp.CallToolParams{
+		Name: "query",
+		Arguments: map[string]any{
+			"tableName": "docs",
+			"queryRequest": map[string]any{
+				"table":            "docs",
+				"full_text_search": map[string]any{"match": "hello", "field": "body"},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, result.Content)
+	tc, ok := result.Content[0].(*mcp.TextContent)
+	require.True(t, ok)
+	assert.Contains(t, tc.Text, "queryRequest.table is not allowed")
 }
 
 func TestBatch(t *testing.T) {

--- a/go/pkg/antfly/src/metadata/mcp_adapter.go
+++ b/go/pkg/antfly/src/metadata/mcp_adapter.go
@@ -208,6 +208,22 @@ func (a *mcpAdapter) ListIndexes(ctx context.Context, tableName string) ([]antfl
 
 // Query implements antflymcp.AntflyHandler.
 func (a *mcpAdapter) Query(ctx context.Context, req antflymcp.QueryRequest) (*antflymcp.QueryResult, error) {
+	if req.RawQueryRequest != nil {
+		if _, ok := req.RawQueryRequest["table"]; ok {
+			return nil, fmt.Errorf("queryRequest.table is not allowed; pass the table through tableName")
+		}
+		raw, err := json.Marshal(req.RawQueryRequest)
+		if err != nil {
+			return nil, fmt.Errorf("marshaling queryRequest: %w", err)
+		}
+		var internalReq QueryRequest
+		if err := json.Unmarshal(raw, &internalReq); err != nil {
+			return nil, fmt.Errorf("unmarshaling queryRequest: %w", err)
+		}
+		internalReq.Table = req.TableName
+		return a.runMCPQuery(ctx, &internalReq)
+	}
+
 	internalReq := QueryRequest{
 		Table:          req.TableName,
 		SemanticSearch: req.SemanticSearch,
@@ -231,7 +247,11 @@ func (a *mcpAdapter) Query(ctx context.Context, req antflymcp.QueryRequest) (*an
 		internalReq.FullTextSearch = ftsJSON
 	}
 
-	qr := a.t.runQuery(ctx, &internalReq)
+	return a.runMCPQuery(ctx, &internalReq)
+}
+
+func (a *mcpAdapter) runMCPQuery(ctx context.Context, req *QueryRequest) (*antflymcp.QueryResult, error) {
+	qr := a.t.runQuery(ctx, req)
 	if qr.Error != "" {
 		return nil, fmt.Errorf("query error: %s", qr.Error)
 	}

--- a/zig/MCP.md
+++ b/zig/MCP.md
@@ -69,12 +69,16 @@ The Go implementation uses mature protocol SDKs:
   - `create_table`
   - `drop_table`
   - `list_tables`
+  - `describe_table`
   - `create_index`
   - `drop_index`
   - `list_indexes`
+  - `describe_indexes`
   - `get_document`
+  - `sample_documents`
   - `query`
   - `describe_query_request`
+  - `describe_mcp_capabilities`
   - `backup`
   - `restore`
   - `batch`
@@ -83,6 +87,11 @@ The Go implementation uses mature protocol SDKs:
   - `retrieval`
 
 ## MCP Query Request Design
+
+MCP is the deterministic database control and retrieval surface. It should expose exact table/index/document/query
+operations, schema/capability discovery, and raw request pass-through. It should not duplicate the agentic query
+planner. Natural-language query planning belongs in the A2A `query-builder` skill, which can inspect context, propose a
+query plan, and then call MCP `query` with either shorthand args or a raw `queryRequest`.
 
 The MCP `query` tool has two modes:
 
@@ -130,6 +139,23 @@ structured summary with examples and pointers to:
 - `specs/openapi/antfly/metadata.yaml#/components/schemas/QueryRequest`
 - `specs/openapi/antfly/query.yaml#/components/schemas/Query`
 
+## MCP Introspection Tools
+
+The MCP tool surface includes deterministic helpers so clients can discover table shape and build precise requests
+without needing to scrape broad list responses:
+
+- `describe_table` calls the existing table status route for one table, including schema, indexes, ranges, and storage
+  status when available.
+- `describe_indexes` calls the existing table index listing route for one table. It is intentionally an alias-shaped
+  companion to `list_indexes` for clients that distinguish list and describe workflows.
+- `sample_documents` calls the existing lookup/scan route with bounded `limit` and optional `from`, `to`,
+  `inclusiveFrom`, and `fields` arguments. It is for schema/content inspection, not agentic retrieval planning.
+- `describe_mcp_capabilities` returns MCP transport/session capabilities, deterministic tool categories, raw
+  `queryRequest` support, shorthand query args, and the A2A `query-builder` handoff guidance.
+
+These tools route through the same HTTP handlers as REST calls where possible. That keeps auth, permission checks,
+validation, and error behavior aligned with the product API.
+
 ## Verification
 
 - `zig build lib-mcp-test`
@@ -137,6 +163,8 @@ structured summary with examples and pointers to:
 - `zig build raft-transport-test`
 - `zig build lib-api-auth-test`
 - `zig build public-api-parity-test -- --test-filter "retrieval agent event sink receives live milestones" "api http server serves retrieval agent event stream"`
+- `zig build root-test -- --test-filter "api http server serves fielded full-text search through mcp tools"`
+- `go test ./src/mcp ./src/metadata`
 
 The API auth test bucket includes an HTTP-level coverage test for MCP initialize, the A2A well-known agent card, and
 the A2A card JSON-RPC method. It also covers MCP session response headers, MCP GET event-stream endpoint framing, A2A
@@ -175,7 +203,7 @@ The next durability improvements should be:
 1. Add MCP historical event replay if clients need more than cursor-aware stream continuation.
 2. Expose the `go/pkg/antfly/lib/mcp` stdio dispatcher through a product CLI/server mode if local agent hosts need it.
 3. Add durable task store plumbing if A2A task state needs to survive process restart.
-4. Broaden adapter failure mapping and tool schema stability tests.
+4. Broaden adapter failure mapping, tool schema stability tests, and cross-language MCP parity tests.
 5. Consider deriving MCP tool schemas from generated OpenAPI or Zig request structs if the tool surface continues to
    expand.
 

--- a/zig/MCP.md
+++ b/zig/MCP.md
@@ -72,14 +72,63 @@ The Go implementation uses mature protocol SDKs:
   - `create_index`
   - `drop_index`
   - `list_indexes`
-  - `lookup`
+  - `get_document`
   - `query`
+  - `describe_query_request`
   - `backup`
   - `restore`
   - `batch`
 - Antfly A2A skills
   - `query-builder`
   - `retrieval`
+
+## MCP Query Request Design
+
+The MCP `query` tool has two modes:
+
+1. Shorthand mode, for common agent calls. This keeps the existing MCP-friendly arguments such as `fullTextSearch`,
+   `fullTextSearchField`, `semanticSearch`, `fields`, `limit`, `orderBy`, `indexes`, and `filterPrefix`.
+2. Raw QueryRequest mode, for the full Antfly query contract. Callers pass `queryRequest`, which is forwarded as the
+   JSON body for `POST /tables/{tableName}/query`.
+
+Example raw QueryRequest call:
+
+```json
+{
+  "tableName": "montessori_copilot_ft",
+  "queryRequest": {
+    "full_text_search": {
+      "match": "individual freedom personality development",
+      "field": "content"
+    },
+    "fields": ["document_title", "page", "content"],
+    "limit": 5
+  }
+}
+```
+
+The raw `queryRequest` path is intentionally generic. It can carry the OpenAPI `QueryRequest` fields such as `query`,
+`full_text_search`, `filter_query`, `exclusion_query`, `semantic_search`, `embedding_template`, `indexes`,
+`embeddings`, `fields`, `limit`, `offset`, `order_by`, `search_after`, `search_before`, `distance_under`,
+`distance_over`, `search_effort`, `merge_config`, `count`, `profile`, `reranker`, `aggregations`, `graph_searches`,
+`expand_strategy`, `document_renderer`, `pruner`, `join`, and `foreign_sources`.
+
+Raw mode rules:
+
+- `tableName` remains the MCP path/table selector.
+- `queryRequest` must be a JSON object.
+- `queryRequest` is mutually exclusive with shorthand query arguments. The adapter does not merge the two modes because
+  precedence rules would otherwise drift from the REST/OpenAPI contract.
+- `queryRequest.table` is rejected on table-scoped MCP calls. Use `tableName` instead.
+- The raw object is validated by the same `/tables/{tableName}/query` path as direct REST calls.
+
+The full OpenAPI schema is not inlined into every `tools/list` response because the schema is large and references
+recursive query/reranker/graph/join definitions. The `query.queryRequest` input schema stays permissive with compact
+top-level field guidance. Clients that need schema help can call `describe_query_request`, which returns a compact,
+structured summary with examples and pointers to:
+
+- `specs/openapi/antfly/metadata.yaml#/components/schemas/QueryRequest`
+- `specs/openapi/antfly/query.yaml#/components/schemas/Query`
 
 ## Verification
 
@@ -112,7 +161,9 @@ missing A2A tasks.
 - Protocol structs are intentionally minimal. Dynamic `std.json.Value` remains the extension path for evolving MCP/A2A
   fields and tool payloads.
 - MCP schemas are generated from Antfly MCP tool descriptors and cover the current Go-parity tool arguments. They are
-  not yet derived from generated OpenAPI or Zig request structs.
+  not yet derived from generated OpenAPI or Zig request structs. The raw `queryRequest` field deliberately uses a
+  permissive schema plus the `describe_query_request` helper to avoid inlining the full recursive OpenAPI query schema
+  into every MCP `tools/list` response.
 
 ## Long-Term Direction
 

--- a/zig/pkg/antfly/src/api/http_server.zig
+++ b/zig/pkg/antfly/src/api/http_server.zig
@@ -11804,6 +11804,9 @@ test "api http server serves fielded full-text search through mcp tools" {
     });
     defer tools_resp.deinit(std.testing.allocator);
     try std.testing.expectEqual(@as(u16, 200), tools_resp.status);
+    try std.testing.expect(std.mem.indexOf(u8, tools_resp.body, "\"name\":\"describe_query_request\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, tools_resp.body, "\"queryRequest\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, tools_resp.body, "Raw Antfly QueryRequest body") != null);
     try std.testing.expect(std.mem.indexOf(u8, tools_resp.body, "\"fullTextSearchField\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, tools_resp.body, "\"full_text_search\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, tools_resp.body, "\"oneOf\"") != null);
@@ -11851,6 +11854,56 @@ test "api http server serves fielded full-text search through mcp tools" {
     defer query_rest_alias_resp.deinit(std.testing.allocator);
     try std.testing.expectEqual(@as(u16, 200), query_rest_alias_resp.status);
     try std.testing.expect(std.mem.indexOf(u8, query_rest_alias_resp.body, "\"doc:a\"") != null);
+
+    var raw_query_request_resp = try server.handle(.{
+        .method = .POST,
+        .uri = routes.Routes.mcp_v1,
+        .headers = &mcp_session_headers,
+        .content_type = "application/json",
+        .body = "{\"jsonrpc\":\"2.0\",\"id\":8,\"method\":\"tools/call\",\"params\":{\"name\":\"query\",\"arguments\":{\"tableName\":\"docs\",\"queryRequest\":{\"full_text_search\":{\"match\":\"hello\",\"field\":\"body\"},\"fields\":[\"title\",\"body\"],\"limit\":5}}}}",
+    });
+    defer raw_query_request_resp.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(u16, 200), raw_query_request_resp.status);
+    try std.testing.expect(std.mem.indexOf(u8, raw_query_request_resp.body, "\"doc:a\"") != null);
+
+    var mixed_query_request_resp = try server.handle(.{
+        .method = .POST,
+        .uri = routes.Routes.mcp_v1,
+        .headers = &mcp_session_headers,
+        .content_type = "application/json",
+        .body = "{\"jsonrpc\":\"2.0\",\"id\":9,\"method\":\"tools/call\",\"params\":{\"name\":\"query\",\"arguments\":{\"tableName\":\"docs\",\"queryRequest\":{\"full_text_search\":{\"match\":\"hello\",\"field\":\"body\"}},\"limit\":5}}}",
+    });
+    defer mixed_query_request_resp.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(u16, 200), mixed_query_request_resp.status);
+    try std.testing.expect(std.mem.indexOf(u8, mixed_query_request_resp.body, "\"isError\":true") != null);
+    try std.testing.expect(std.mem.indexOf(u8, mixed_query_request_resp.body, "queryRequest cannot be combined") != null);
+
+    var raw_query_request_table_resp = try server.handle(.{
+        .method = .POST,
+        .uri = routes.Routes.mcp_v1,
+        .headers = &mcp_session_headers,
+        .content_type = "application/json",
+        .body = "{\"jsonrpc\":\"2.0\",\"id\":10,\"method\":\"tools/call\",\"params\":{\"name\":\"query\",\"arguments\":{\"tableName\":\"docs\",\"queryRequest\":{\"table\":\"docs\",\"full_text_search\":{\"match\":\"hello\",\"field\":\"body\"}}}}}",
+    });
+    defer raw_query_request_table_resp.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(u16, 200), raw_query_request_table_resp.status);
+    try std.testing.expect(std.mem.indexOf(u8, raw_query_request_table_resp.body, "\"isError\":true") != null);
+    try std.testing.expect(std.mem.indexOf(u8, raw_query_request_table_resp.body, "queryRequest.table is not allowed") != null);
+
+    var describe_query_request_resp = try server.handle(.{
+        .method = .POST,
+        .uri = routes.Routes.mcp_v1,
+        .headers = &mcp_session_headers,
+        .content_type = "application/json",
+        .body = "{\"jsonrpc\":\"2.0\",\"id\":11,\"method\":\"tools/call\",\"params\":{\"name\":\"describe_query_request\",\"arguments\":{}}}",
+    });
+    defer describe_query_request_resp.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(u16, 200), describe_query_request_resp.status);
+    try std.testing.expect(std.mem.indexOf(u8, describe_query_request_resp.body, "\"structuredContent\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, describe_query_request_resp.body, "metadata.yaml#/components/schemas/QueryRequest") != null);
+    try std.testing.expect(std.mem.indexOf(u8, describe_query_request_resp.body, "\"queryRequest\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, describe_query_request_resp.body, "\"fielded_full_text\":{\"full_text_search\":{\"match\":\"hello\",\"field\":\"body\"}") != null);
+    try std.testing.expect(std.mem.indexOf(u8, describe_query_request_resp.body, "\"fields\":[\"title\",\"body\"],\"limit\":5") != null);
 }
 
 test "api http server serves table scan as ndjson" {

--- a/zig/pkg/antfly/src/api/http_server.zig
+++ b/zig/pkg/antfly/src/api/http_server.zig
@@ -11879,6 +11879,30 @@ test "api http server serves fielded full-text search through mcp tools" {
     try std.testing.expect(std.mem.indexOf(u8, sample_documents_resp.body, "\"doc:a\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, sample_documents_resp.body, "\"hello\"") != null);
 
+    var sample_documents_zero_limit_resp = try server.handle(.{
+        .method = .POST,
+        .uri = routes.Routes.mcp_v1,
+        .headers = &mcp_session_headers,
+        .content_type = "application/json",
+        .body = "{\"jsonrpc\":\"2.0\",\"id\":16,\"method\":\"tools/call\",\"params\":{\"name\":\"sample_documents\",\"arguments\":{\"tableName\":\"docs\",\"limit\":0}}}",
+    });
+    defer sample_documents_zero_limit_resp.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(u16, 200), sample_documents_zero_limit_resp.status);
+    try std.testing.expect(std.mem.indexOf(u8, sample_documents_zero_limit_resp.body, "\"isError\":true") != null);
+    try std.testing.expect(std.mem.indexOf(u8, sample_documents_zero_limit_resp.body, "limit must be greater than 0") != null);
+
+    var sample_documents_large_limit_resp = try server.handle(.{
+        .method = .POST,
+        .uri = routes.Routes.mcp_v1,
+        .headers = &mcp_session_headers,
+        .content_type = "application/json",
+        .body = "{\"jsonrpc\":\"2.0\",\"id\":17,\"method\":\"tools/call\",\"params\":{\"name\":\"sample_documents\",\"arguments\":{\"tableName\":\"docs\",\"limit\":101}}}",
+    });
+    defer sample_documents_large_limit_resp.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(u16, 200), sample_documents_large_limit_resp.status);
+    try std.testing.expect(std.mem.indexOf(u8, sample_documents_large_limit_resp.body, "\"isError\":true") != null);
+    try std.testing.expect(std.mem.indexOf(u8, sample_documents_large_limit_resp.body, "limit exceeds maximum sample size") != null);
+
     var describe_capabilities_resp = try server.handle(.{
         .method = .POST,
         .uri = routes.Routes.mcp_v1,

--- a/zig/pkg/antfly/src/api/http_server.zig
+++ b/zig/pkg/antfly/src/api/http_server.zig
@@ -11765,11 +11765,13 @@ test "api http server serves fielded full-text search through mcp tools" {
     var table_source = table_reads.BoundTableReadSource.init("docs", 77, &db, raft_mod.read_gate.noopReadableLeaseRequester());
 
     const FakeSource = struct {
-        fn iface(_: *@This()) StatusSource {
+        fn iface(self: *@This()) StatusSource {
             return .{
-                .ptr = undefined,
+                .ptr = self,
                 .vtable = &.{
                     .status = status,
+                    .admin_snapshot = adminSnapshot,
+                    .free_admin_snapshot = freeAdminSnapshot,
                 },
             };
         }
@@ -11777,6 +11779,31 @@ test "api http server serves fielded full-text search through mcp tools" {
         fn status(_: *anyopaque) !metadata_api.MetadataStatus {
             return .{ .metadata_group_id = 1, .metrics = .{}, .projected_stores = 1 };
         }
+
+        fn adminSnapshot(_: *anyopaque) !metadata_api.AdminSnapshot {
+            return .{
+                .status = .{ .metadata_group_id = 1, .metrics = .{}, .projected_stores = 1 },
+                .tables = @constCast((&[_]metadata_table_manager.TableRecord{.{
+                    .table_id = 77,
+                    .name = "docs",
+                    .schema_json = "{\"document_schemas\":{\"doc\":{\"schema\":{\"type\":\"object\",\"properties\":{\"title\":{\"type\":\"text\"},\"body\":{\"type\":\"text\"}}}}}}",
+                    .indexes_json = "{\"full_text_index_v0\":{\"type\":\"full_text\",\"field\":\"body\"}}",
+                    .placement_role = "data",
+                }})[0..]),
+                .ranges = @constCast((&[_]metadata_table_manager.RangeRecord{.{
+                    .group_id = 77,
+                    .table_id = 77,
+                    .start_key = "",
+                    .end_key = null,
+                }})[0..]),
+                .stores = @constCast((&[_]metadata_table_manager.StoreRecord{})[0..]),
+                .placement_intents = @constCast((&[_]raft_reconciler.PlacementIntent{})[0..]),
+                .split_transitions = @constCast((&[_]metadata_transition_state.SplitTransitionRecord{})[0..]),
+                .merge_transitions = @constCast((&[_]metadata_transition_state.MergeTransitionRecord{})[0..]),
+            };
+        }
+
+        fn freeAdminSnapshot(_: *anyopaque, _: *metadata_api.AdminSnapshot) void {}
     };
 
     var source = FakeSource{};
@@ -11805,11 +11832,65 @@ test "api http server serves fielded full-text search through mcp tools" {
     defer tools_resp.deinit(std.testing.allocator);
     try std.testing.expectEqual(@as(u16, 200), tools_resp.status);
     try std.testing.expect(std.mem.indexOf(u8, tools_resp.body, "\"name\":\"describe_query_request\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, tools_resp.body, "\"name\":\"describe_table\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, tools_resp.body, "\"name\":\"describe_indexes\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, tools_resp.body, "\"name\":\"sample_documents\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, tools_resp.body, "\"name\":\"describe_mcp_capabilities\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, tools_resp.body, "\"queryRequest\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, tools_resp.body, "Raw Antfly QueryRequest body") != null);
     try std.testing.expect(std.mem.indexOf(u8, tools_resp.body, "\"fullTextSearchField\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, tools_resp.body, "\"full_text_search\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, tools_resp.body, "\"oneOf\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, tools_resp.body, "\"inclusiveFrom\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, tools_resp.body, "\"boolean\"") != null);
+
+    var describe_table_resp = try server.handle(.{
+        .method = .POST,
+        .uri = routes.Routes.mcp_v1,
+        .headers = &mcp_session_headers,
+        .content_type = "application/json",
+        .body = "{\"jsonrpc\":\"2.0\",\"id\":12,\"method\":\"tools/call\",\"params\":{\"name\":\"describe_table\",\"arguments\":{\"tableName\":\"docs\"}}}",
+    });
+    defer describe_table_resp.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(u16, 200), describe_table_resp.status);
+    try std.testing.expect(std.mem.indexOf(u8, describe_table_resp.body, "\"name\":\"docs\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, describe_table_resp.body, "\"full_text_index_v0\"") != null);
+
+    var describe_indexes_resp = try server.handle(.{
+        .method = .POST,
+        .uri = routes.Routes.mcp_v1,
+        .headers = &mcp_session_headers,
+        .content_type = "application/json",
+        .body = "{\"jsonrpc\":\"2.0\",\"id\":13,\"method\":\"tools/call\",\"params\":{\"name\":\"describe_indexes\",\"arguments\":{\"tableName\":\"docs\"}}}",
+    });
+    defer describe_indexes_resp.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(u16, 200), describe_indexes_resp.status);
+    try std.testing.expect(std.mem.indexOf(u8, describe_indexes_resp.body, "\"full_text_index_v0\"") != null);
+
+    var sample_documents_resp = try server.handle(.{
+        .method = .POST,
+        .uri = routes.Routes.mcp_v1,
+        .headers = &mcp_session_headers,
+        .content_type = "application/json",
+        .body = "{\"jsonrpc\":\"2.0\",\"id\":14,\"method\":\"tools/call\",\"params\":{\"name\":\"sample_documents\",\"arguments\":{\"tableName\":\"docs\",\"fields\":[\"title\",\"body\"],\"limit\":1,\"inclusiveFrom\":true}}}",
+    });
+    defer sample_documents_resp.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(u16, 200), sample_documents_resp.status);
+    try std.testing.expect(std.mem.indexOf(u8, sample_documents_resp.body, "\"doc:a\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, sample_documents_resp.body, "\"hello\"") != null);
+
+    var describe_capabilities_resp = try server.handle(.{
+        .method = .POST,
+        .uri = routes.Routes.mcp_v1,
+        .headers = &mcp_session_headers,
+        .content_type = "application/json",
+        .body = "{\"jsonrpc\":\"2.0\",\"id\":15,\"method\":\"tools/call\",\"params\":{\"name\":\"describe_mcp_capabilities\",\"arguments\":{}}}",
+    });
+    defer describe_capabilities_resp.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(u16, 200), describe_capabilities_resp.status);
+    try std.testing.expect(std.mem.indexOf(u8, describe_capabilities_resp.body, "\"structuredContent\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, describe_capabilities_resp.body, "query-builder") != null);
+    try std.testing.expect(std.mem.indexOf(u8, describe_capabilities_resp.body, "\"raw_query_request\":true") != null);
 
     var wrong_field_resp = try server.handle(.{
         .method = .POST,

--- a/zig/pkg/antfly/src/api/protocol_adapters.zig
+++ b/zig/pkg/antfly/src/api/protocol_adapters.zig
@@ -22,6 +22,7 @@ const mcp = @import("antfly_mcp");
 const a2a = @import("antfly_a2a");
 
 const trusted_principal_header = "X-Antfly-Trusted-Principal";
+const max_mcp_sample_documents_limit: i64 = 100;
 
 const McpToolKind = enum {
     create_table,
@@ -383,8 +384,11 @@ fn handleMcpRequestFiltered(server_ptr: anytype, req: http_common.HttpRequest, a
 
         fn sampleDocuments(ctx: *@This(), alloc: std.mem.Allocator, args: std.json.Value) !mcp.CallToolResult {
             const table_name = jsonStringArg(args, "tableName") orelse return mcpError(alloc, "missing tableName");
+            const limit = jsonIntArg(args, "limit") orelse 5;
+            if (limit <= 0) return mcpError(alloc, "limit must be greater than 0");
+            if (limit > max_mcp_sample_documents_limit) return mcpError(alloc, "limit exceeds maximum sample size");
             var body = std.json.ObjectMap.empty;
-            try body.put(alloc, "limit", .{ .integer = jsonIntArg(args, "limit") orelse 5 });
+            try body.put(alloc, "limit", .{ .integer = limit });
             if (jsonStringArg(args, "from")) |from| if (from.len != 0) try body.put(alloc, "from", .{ .string = from });
             if (jsonStringArg(args, "to")) |to| if (to.len != 0) try body.put(alloc, "to", .{ .string = to });
             if (jsonBoolArg(args, "inclusiveFrom")) |inclusive| try body.put(alloc, "inclusive_from", .{ .bool = inclusive });

--- a/zig/pkg/antfly/src/api/protocol_adapters.zig
+++ b/zig/pkg/antfly/src/api/protocol_adapters.zig
@@ -27,12 +27,16 @@ const McpToolKind = enum {
     create_table,
     drop_table,
     list_tables,
+    describe_table,
     create_index,
     drop_index,
     list_indexes,
+    describe_indexes,
     get_document,
+    sample_documents,
     query,
     describe_query_request,
+    describe_mcp_capabilities,
     backup,
     restore,
     batch,
@@ -48,6 +52,7 @@ const McpToolSpec = struct {
 const McpToolFieldType = enum {
     string,
     integer,
+    boolean,
     array,
     object,
 };
@@ -74,6 +79,10 @@ const query_request_description_json =
     \\{"openapi_schema":"specs/openapi/antfly/metadata.yaml#/components/schemas/QueryRequest","query_ast_schema":"specs/openapi/antfly/query.yaml#/components/schemas/Query","mcp_usage":{"tool":"query","path_table_argument":"tableName","raw_body_argument":"queryRequest","rules":["queryRequest is forwarded unchanged as the POST /tables/{tableName}/query body.","queryRequest is mutually exclusive with shorthand query arguments such as fullTextSearch, semanticSearch, fields, limit, orderBy, indexes, and filterPrefix.","queryRequest.table is rejected because tableName selects the table-scoped route.","Use describe_query_request for this compact schema instead of relying on tools/list to inline the full recursive OpenAPI schema."]},"top_level_fields":["query","full_text_search","semantic_search","embedding_template","indexes","filter_prefix","filter_query","exclusion_query","aggregations","embeddings","search_effort","fields","limit","offset","order_by","search_after","search_before","distance_under","distance_over","merge_config","count","profile","reranker","analyses","graph_searches","expand_strategy","document_renderer","pruner","join","foreign_sources"],"examples":{"fielded_full_text":{"full_text_search":{"match":"hello","field":"body"},"fields":["title","body"],"limit":5},"hybrid":{"full_text_search":{"match":"raft","field":"body"},"semantic_search":"raft snapshot architecture","indexes":["body_embedding"],"merge_config":{"strategy":"rrf"},"fields":["title","body"],"limit":20,"profile":true},"filtered":{"query":{"bool":{"must":[{"match":{"field":"body","text":"computer"}}],"filter":[{"term":{"path":"/tenant","value":"acme"}}]}},"fields":["title","url"],"limit":10}}}
 ;
 
+const mcp_capabilities_description_json =
+    \\{"protocol":"mcp","protocol_version":"2025-06-18","transport":"streamable_http","endpoint":"/mcp/v1","sessions":{"initialize_returns_session_id":true,"delete_closes_session":true,"last_event_id_cursor_supported":true,"historical_replay":false},"query_builder":"Use the A2A query-builder skill for agentic natural-language query planning. MCP stays focused on deterministic database tools and raw QueryRequest execution.","tools":{"deterministic":["list_tables","describe_table","list_indexes","describe_indexes","get_document","sample_documents","query","describe_query_request"],"write":["create_table","drop_table","create_index","drop_index","batch","backup","restore"],"schema_helpers":["describe_query_request","describe_mcp_capabilities"]},"query":{"raw_query_request":true,"raw_query_request_argument":"queryRequest","shorthand_arguments":["fullTextSearch","fullTextSearchField","semanticSearch","fields","limit","orderBy","indexes","filterPrefix"],"raw_mode_exclusive":true}}
+;
+
 const mcp_tool_specs = [_]McpToolSpec{
     .{
         .kind = .create_table,
@@ -93,6 +102,12 @@ const mcp_tool_specs = [_]McpToolSpec{
         .fields = &.{.{ .name = "tableName", .schema_type = .string, .required = true }},
     },
     .{ .kind = .list_tables, .name = "list_tables", .description = "List Antfly tables" },
+    .{
+        .kind = .describe_table,
+        .name = "describe_table",
+        .description = "Describe an Antfly table, including schema, indexes, ranges, and storage status when available",
+        .fields = &.{.{ .name = "tableName", .schema_type = .string, .required = true }},
+    },
     .{
         .kind = .create_index,
         .name = "create_index",
@@ -123,12 +138,31 @@ const mcp_tool_specs = [_]McpToolSpec{
         .fields = &.{.{ .name = "tableName", .schema_type = .string, .required = true }},
     },
     .{
+        .kind = .describe_indexes,
+        .name = "describe_indexes",
+        .description = "Describe indexes for an Antfly table",
+        .fields = &.{.{ .name = "tableName", .schema_type = .string, .required = true }},
+    },
+    .{
         .kind = .get_document,
         .name = "get_document",
         .description = "Get an Antfly document by key",
         .fields = &.{
             .{ .name = "tableName", .schema_type = .string, .required = true },
             .{ .name = "key", .schema_type = .string, .required = true },
+            .{ .name = "fields", .schema_type = .array, .items_json = "{\"type\":\"string\"}" },
+        },
+    },
+    .{
+        .kind = .sample_documents,
+        .name = "sample_documents",
+        .description = "Return a bounded NDJSON sample from a table using the table lookup/scan route",
+        .fields = &.{
+            .{ .name = "tableName", .schema_type = .string, .required = true },
+            .{ .name = "limit", .schema_type = .integer, .default_json = "5" },
+            .{ .name = "from", .schema_type = .string },
+            .{ .name = "to", .schema_type = .string },
+            .{ .name = "inclusiveFrom", .schema_type = .boolean, .description = "Set to true to include the from key." },
             .{ .name = "fields", .schema_type = .array, .items_json = "{\"type\":\"string\"}" },
         },
     },
@@ -154,6 +188,11 @@ const mcp_tool_specs = [_]McpToolSpec{
         .kind = .describe_query_request,
         .name = "describe_query_request",
         .description = "Return compact guidance for the raw Antfly QueryRequest accepted by query.queryRequest",
+    },
+    .{
+        .kind = .describe_mcp_capabilities,
+        .name = "describe_mcp_capabilities",
+        .description = "Describe Antfly MCP capabilities, deterministic tools, and A2A query-builder handoff guidance",
     },
     .{
         .kind = .backup,
@@ -256,12 +295,16 @@ fn handleMcpRequestFiltered(server_ptr: anytype, req: http_common.HttpRequest, a
                 .create_table => try ctx.createTable(alloc, args),
                 .drop_table => try ctx.tableRoute(alloc, args, .DELETE, "tableName", null, ""),
                 .list_tables => try ctx.simpleRoute(alloc, .GET, routes.Routes.tables, ""),
+                .describe_table => try ctx.tableRoute(alloc, args, .GET, "tableName", null, ""),
                 .create_index => try ctx.createIndex(alloc, args),
                 .drop_index => try ctx.indexRoute(alloc, args, .DELETE, ""),
                 .list_indexes => try ctx.listIndexes(alloc, args),
+                .describe_indexes => try ctx.listIndexes(alloc, args),
                 .get_document => try ctx.getDocument(alloc, args),
+                .sample_documents => try ctx.sampleDocuments(alloc, args),
                 .query => try ctx.query(alloc, args),
                 .describe_query_request => try ctx.describeQueryRequest(alloc),
+                .describe_mcp_capabilities => try ctx.describeMcpCapabilities(alloc),
                 .backup => try ctx.backupRestore(alloc, args, "backup"),
                 .restore => try ctx.backupRestore(alloc, args, "restore"),
                 .batch => try ctx.batch(alloc, args),
@@ -338,6 +381,18 @@ fn handleMcpRequestFiltered(server_ptr: anytype, req: http_common.HttpRequest, a
             return try ctx.simpleRoute(alloc, .GET, try uri.toOwnedSlice(alloc), "");
         }
 
+        fn sampleDocuments(ctx: *@This(), alloc: std.mem.Allocator, args: std.json.Value) !mcp.CallToolResult {
+            const table_name = jsonStringArg(args, "tableName") orelse return mcpError(alloc, "missing tableName");
+            var body = std.json.ObjectMap.empty;
+            try body.put(alloc, "limit", .{ .integer = jsonIntArg(args, "limit") orelse 5 });
+            if (jsonStringArg(args, "from")) |from| if (from.len != 0) try body.put(alloc, "from", .{ .string = from });
+            if (jsonStringArg(args, "to")) |to| if (to.len != 0) try body.put(alloc, "to", .{ .string = to });
+            if (jsonBoolArg(args, "inclusiveFrom")) |inclusive| try body.put(alloc, "inclusive_from", .{ .bool = inclusive });
+            if (jsonValueArg(args, "fields")) |fields| try body.put(alloc, "fields", fields);
+            const uri = try std.fmt.allocPrint(alloc, "{s}/{s}/lookup", .{ routes.Routes.tables, table_name });
+            return try ctx.simpleRoute(alloc, .POST, uri, try stringifyJsonValue(alloc, .{ .object = body }));
+        }
+
         fn indexRoute(ctx: *@This(), alloc: std.mem.Allocator, args: std.json.Value, method: http_common.Method, body: []const u8) !mcp.CallToolResult {
             const table_name = jsonStringArg(args, "tableName") orelse return mcpError(alloc, "missing tableName");
             const index_name = jsonStringArg(args, "indexName") orelse return mcpError(alloc, "missing indexName");
@@ -372,6 +427,14 @@ fn handleMcpRequestFiltered(server_ptr: anytype, req: http_common.HttpRequest, a
             const structured = try std.json.parseFromSliceLeaky(std.json.Value, alloc, query_request_description_json, .{});
             return .{
                 .text = try alloc.dupe(u8, "Antfly QueryRequest schema summary for query.queryRequest"),
+                .structured = structured,
+            };
+        }
+
+        fn describeMcpCapabilities(_: *@This(), alloc: std.mem.Allocator) !mcp.CallToolResult {
+            const structured = try std.json.parseFromSliceLeaky(std.json.Value, alloc, mcp_capabilities_description_json, .{});
+            return .{
+                .text = try alloc.dupe(u8, "Antfly MCP capabilities"),
                 .structured = structured,
             };
         }
@@ -546,9 +609,9 @@ fn handleMcpRequestFiltered(server_ptr: anytype, req: http_common.HttpRequest, a
 fn mcpToolVisibleForIdentity(kind: McpToolKind, authenticated_identity: anytype) bool {
     const identity = authenticated_identity orelse return true;
     return switch (kind) {
-        .describe_query_request => true,
+        .describe_query_request, .describe_mcp_capabilities => true,
         .list_tables => identityHasPermission(identity.permissions, .table, "*", .read),
-        .query, .get_document, .list_indexes => identityHasAnyPermission(identity.permissions, .table, .read),
+        .query, .describe_table, .describe_indexes, .get_document, .sample_documents, .list_indexes => identityHasAnyPermission(identity.permissions, .table, .read),
         .batch => identityHasAnyPermission(identity.permissions, .table, .write),
         .create_table, .drop_table, .create_index, .drop_index, .backup, .restore => identityHasAnyPermission(identity.permissions, .table, .admin),
     };
@@ -1355,6 +1418,15 @@ fn jsonIntObjectField(object: anytype, key: []const u8) ?i64 {
     return switch (value) {
         .integer => |n| n,
         .float => |n| @intFromFloat(n),
+        else => null,
+    };
+}
+
+fn jsonBoolArg(value: std.json.Value, key: []const u8) ?bool {
+    if (value != .object) return null;
+    const raw = value.object.get(key) orelse return null;
+    return switch (raw) {
+        .bool => |flag| flag,
         else => null,
     };
 }

--- a/zig/pkg/antfly/src/api/protocol_adapters.zig
+++ b/zig/pkg/antfly/src/api/protocol_adapters.zig
@@ -32,6 +32,7 @@ const McpToolKind = enum {
     list_indexes,
     get_document,
     query,
+    describe_query_request,
     backup,
     restore,
     batch,
@@ -63,6 +64,14 @@ const McpToolFieldSpec = struct {
 
 const full_text_search_schema_json =
     \\{"oneOf":[{"type":"string"},{"type":"object","additionalProperties":true}],"description":"Full-text query string shorthand, or the generic full_text_search query object accepted by the REST API"}
+;
+
+const query_request_schema_json =
+    \\{"type":"object","additionalProperties":true,"description":"Raw Antfly QueryRequest body for POST /tables/{tableName}/query. Use this to access the full OpenAPI query contract. Mutually exclusive with query shorthand arguments.","properties":{"query":{"type":"object","additionalProperties":true},"full_text_search":{"type":"object","additionalProperties":true},"filter_query":{"type":"object","additionalProperties":true},"exclusion_query":{"type":"object","additionalProperties":true},"semantic_search":{"type":"string"},"embedding_template":{"type":"string"},"indexes":{"type":"array","items":{"type":"string"}},"embeddings":{"type":"object","additionalProperties":true},"fields":{"type":"array","items":{"type":"string"}},"limit":{"type":"integer"},"offset":{"type":"integer"},"order_by":{"type":"array"},"search_after":{"type":"array","items":{"type":"string"}},"search_before":{"type":"array","items":{"type":"string"}},"filter_prefix":{"type":"string"},"distance_under":{"type":"number"},"distance_over":{"type":"number"},"search_effort":{"type":"number"},"merge_config":{"type":"object","additionalProperties":true},"count":{"type":"boolean"},"profile":{"type":"boolean"},"reranker":{"type":"object","additionalProperties":true},"aggregations":{"type":"object","additionalProperties":true},"graph_searches":{"type":"object","additionalProperties":true},"expand_strategy":{"type":"string"},"document_renderer":{"type":"string"},"pruner":{"type":"object","additionalProperties":true},"join":{"type":"object","additionalProperties":true},"foreign_sources":{"type":"object","additionalProperties":true}}}
+;
+
+const query_request_description_json =
+    \\{"openapi_schema":"specs/openapi/antfly/metadata.yaml#/components/schemas/QueryRequest","query_ast_schema":"specs/openapi/antfly/query.yaml#/components/schemas/Query","mcp_usage":{"tool":"query","path_table_argument":"tableName","raw_body_argument":"queryRequest","rules":["queryRequest is forwarded unchanged as the POST /tables/{tableName}/query body.","queryRequest is mutually exclusive with shorthand query arguments such as fullTextSearch, semanticSearch, fields, limit, orderBy, indexes, and filterPrefix.","queryRequest.table is rejected because tableName selects the table-scoped route.","Use describe_query_request for this compact schema instead of relying on tools/list to inline the full recursive OpenAPI schema."]},"top_level_fields":["query","full_text_search","semantic_search","embedding_template","indexes","filter_prefix","filter_query","exclusion_query","aggregations","embeddings","search_effort","fields","limit","offset","order_by","search_after","search_before","distance_under","distance_over","merge_config","count","profile","reranker","analyses","graph_searches","expand_strategy","document_renderer","pruner","join","foreign_sources"],"examples":{"fielded_full_text":{"full_text_search":{"match":"hello","field":"body"},"fields":["title","body"],"limit":5},"hybrid":{"full_text_search":{"match":"raft","field":"body"},"semantic_search":"raft snapshot architecture","indexes":["body_embedding"],"merge_config":{"strategy":"rrf"},"fields":["title","body"],"limit":20,"profile":true},"filtered":{"query":{"bool":{"must":[{"match":{"field":"body","text":"computer"}}],"filter":[{"term":{"path":"/tenant","value":"acme"}}]}},"fields":["title","url"],"limit":10}}}
 ;
 
 const mcp_tool_specs = [_]McpToolSpec{
@@ -129,6 +138,7 @@ const mcp_tool_specs = [_]McpToolSpec{
         .description = "Run an Antfly table query",
         .fields = &.{
             .{ .name = "tableName", .schema_type = .string, .required = true },
+            .{ .name = "queryRequest", .schema_type = .object, .schema_json = query_request_schema_json },
             .{ .name = "fullTextSearch", .schema_type = .object, .schema_json = full_text_search_schema_json },
             .{ .name = "full_text_search", .schema_type = .object, .description = "Generic REST-shaped full_text_search query object" },
             .{ .name = "fullTextSearchField", .schema_type = .string, .description = "Field to search when fullTextSearch is a string shorthand, for example content" },
@@ -139,6 +149,11 @@ const mcp_tool_specs = [_]McpToolSpec{
             .{ .name = "indexes", .schema_type = .array, .items_json = "{\"type\":\"string\"}" },
             .{ .name = "filterPrefix", .schema_type = .string },
         },
+    },
+    .{
+        .kind = .describe_query_request,
+        .name = "describe_query_request",
+        .description = "Return compact guidance for the raw Antfly QueryRequest accepted by query.queryRequest",
     },
     .{
         .kind = .backup,
@@ -246,6 +261,7 @@ fn handleMcpRequestFiltered(server_ptr: anytype, req: http_common.HttpRequest, a
                 .list_indexes => try ctx.listIndexes(alloc, args),
                 .get_document => try ctx.getDocument(alloc, args),
                 .query => try ctx.query(alloc, args),
+                .describe_query_request => try ctx.describeQueryRequest(alloc),
                 .backup => try ctx.backupRestore(alloc, args, "backup"),
                 .restore => try ctx.backupRestore(alloc, args, "restore"),
                 .batch => try ctx.batch(alloc, args),
@@ -331,6 +347,15 @@ fn handleMcpRequestFiltered(server_ptr: anytype, req: http_common.HttpRequest, a
 
         fn query(ctx: *@This(), alloc: std.mem.Allocator, args: std.json.Value) !mcp.CallToolResult {
             const table_name = jsonStringArg(args, "tableName") orelse return mcpError(alloc, "missing tableName");
+            if (jsonValueArg(args, "queryRequest")) |query_request| {
+                if (query_request != .object) return mcpError(alloc, "queryRequest must be an object");
+                if (hasNonRawQueryArg(args)) return mcpError(alloc, "queryRequest cannot be combined with shorthand query arguments");
+                if (query_request.object.get("table") != null) return mcpError(alloc, "queryRequest.table is not allowed; use tableName");
+
+                const uri = try std.fmt.allocPrint(alloc, "{s}/{s}/query", .{ routes.Routes.tables, table_name });
+                return try ctx.simpleRoute(alloc, .POST, uri, try stringifyJsonValue(alloc, query_request));
+            }
+
             var body = std.json.ObjectMap.empty;
             putFullTextSearchArg(alloc, &body, args) catch return mcpError(alloc, "invalid fullTextSearch");
             if (jsonStringArg(args, "semanticSearch")) |semantic| if (semantic.len != 0) try body.put(alloc, "semantic_search", .{ .string = semantic });
@@ -341,6 +366,14 @@ fn handleMcpRequestFiltered(server_ptr: anytype, req: http_common.HttpRequest, a
             try body.put(alloc, "limit", .{ .integer = jsonIntArg(args, "limit") orelse 10 });
             const uri = try std.fmt.allocPrint(alloc, "{s}/{s}/query", .{ routes.Routes.tables, table_name });
             return try ctx.simpleRoute(alloc, .POST, uri, try stringifyJsonValue(alloc, .{ .object = body }));
+        }
+
+        fn describeQueryRequest(_: *@This(), alloc: std.mem.Allocator) !mcp.CallToolResult {
+            const structured = try std.json.parseFromSliceLeaky(std.json.Value, alloc, query_request_description_json, .{});
+            return .{
+                .text = try alloc.dupe(u8, "Antfly QueryRequest schema summary for query.queryRequest"),
+                .structured = structured,
+            };
         }
 
         fn backupRestore(ctx: *@This(), alloc: std.mem.Allocator, args: std.json.Value, operation: []const u8) !mcp.CallToolResult {
@@ -513,6 +546,7 @@ fn handleMcpRequestFiltered(server_ptr: anytype, req: http_common.HttpRequest, a
 fn mcpToolVisibleForIdentity(kind: McpToolKind, authenticated_identity: anytype) bool {
     const identity = authenticated_identity orelse return true;
     return switch (kind) {
+        .describe_query_request => true,
         .list_tables => identityHasPermission(identity.permissions, .table, "*", .read),
         .query, .get_document, .list_indexes => identityHasAnyPermission(identity.permissions, .table, .read),
         .batch => identityHasAnyPermission(identity.permissions, .table, .write),
@@ -1328,6 +1362,17 @@ fn jsonIntObjectField(object: anytype, key: []const u8) ?i64 {
 fn jsonValueArg(value: std.json.Value, key: []const u8) ?std.json.Value {
     if (value != .object) return null;
     return value.object.get(key);
+}
+
+fn hasNonRawQueryArg(args: std.json.Value) bool {
+    if (args != .object) return false;
+    var it = args.object.iterator();
+    while (it.next()) |entry| {
+        const key = entry.key_ptr.*;
+        if (std.mem.eql(u8, key, "tableName") or std.mem.eql(u8, key, "queryRequest")) continue;
+        return true;
+    }
+    return false;
 }
 
 fn putFullTextSearch(


### PR DESCRIPTION
## Summary

Adds raw Antfly QueryRequest support to the Zig MCP query tool via a new queryRequest argument. The raw object is forwarded unchanged to POST /tables/{tableName}/query, while existing shorthand query arguments remain available for common calls.

## Details

- Adds query.queryRequest with compact schema guidance for full QueryRequest fields.
- Enforces raw mode rules: queryRequest must be an object, cannot be mixed with shorthand args, and cannot include queryRequest.table.
- Adds describe_query_request to return compact structured schema guidance and OpenAPI pointers without inlining the full recursive schema into tools/list.
- Documents the design in zig/MCP.md.
- Extends the Zig MCP HTTP integration test to validate the advertised fielded_full_text example through the real table query path.

## Validation

- Focused Zig MCP HTTP test passed.