### PR TITLE
Florence2 and the Machine: Metal Version

### DIFF
--- a/zig/pkg/inference/src/architectures/florence.zig
+++ b/zig/pkg/inference/src/architectures/florence.zig
@@ -285,11 +285,23 @@ fn logitsBiasSlice(
         element_count *= @intCast(dim);
     }
     if (element_count < vocab_size) return error.InvalidTensorShape;
-    if (element_count == vocab_size) return .{ .tensor = logits_bias, .owned = false };
+    if (element_count == vocab_size) {
+        if (shape.len == 1 and @as(usize, @intCast(shape[0])) == vocab_size) {
+            return .{ .tensor = logits_bias, .owned = false };
+        }
+        if (shape.len == 2 and shape[0] == 1 and @as(usize, @intCast(shape[1])) == vocab_size) {
+            return .{ .tensor = logits_bias, .owned = false };
+        }
+        const row_shape = [_]i64{@intCast(vocab_size)};
+        return .{ .tensor = try cb.primReshape(logits_bias, &row_shape), .owned = true };
+    }
 
     const start: usize = if (element_count == vocab_size + 1) 1 else 0;
+    const flat_shape = [_]i64{ 1, @intCast(element_count) };
+    const flat_bias = try cb.primReshape(logits_bias, &flat_shape);
+    defer cb.free(flat_bias);
     return .{
-        .tensor = try cb.sliceLastDim(logits_bias, start, start + vocab_size),
+        .tensor = try cb.sliceLastDim(flat_bias, start, start + vocab_size),
         .owned = true,
     };
 }

--- a/zig/pkg/inference/src/architectures/florence.zig
+++ b/zig/pkg/inference/src/architectures/florence.zig
@@ -40,6 +40,11 @@ pub const EncoderForwardResult = struct {
     seq_len: usize,
 };
 
+pub const EncoderForwardTensorResult = struct {
+    hidden: CT,
+    seq_len: usize,
+};
+
 const VisionForwardResult = struct {
     features: []f32,
     seq_len: usize,
@@ -54,6 +59,22 @@ pub fn encoderForward(
     prompt_input_ids: []const i64,
     prompt_seq_len: usize,
 ) !EncoderForwardResult {
+    const encoder = try encoderForwardTensor(cb, allocator, config, pixel_values, batch, prompt_input_ids, prompt_seq_len);
+    defer cb.free(encoder.hidden);
+
+    const result = try cb.toFloat32(encoder.hidden, allocator);
+    return .{ .hidden = result, .seq_len = encoder.seq_len };
+}
+
+pub fn encoderForwardTensor(
+    cb: *const ComputeBackend,
+    allocator: std.mem.Allocator,
+    config: Config,
+    pixel_values: []const f32,
+    batch: usize,
+    prompt_input_ids: []const i64,
+    prompt_seq_len: usize,
+) !EncoderForwardTensorResult {
     const image = try visionEncoderForward(cb, allocator, config, pixel_values, batch);
     defer allocator.free(image.features);
 
@@ -97,9 +118,7 @@ pub fn encoderForward(
         hidden = next;
     }
 
-    const result = try cb.toFloat32(hidden, allocator);
-    cb.free(hidden);
-    return .{ .hidden = result, .seq_len = total_seq };
+    return .{ .hidden = hidden, .seq_len = total_seq };
 }
 
 /// Run the Florence/BART text encoder without any vision inputs.
@@ -181,6 +200,33 @@ pub fn decoderForward(
     dec_seq: usize,
     enc_seq: usize,
 ) ![]f32 {
+    const logits = try decoderForwardTensor(
+        cb,
+        allocator,
+        config,
+        decoder_input_ids,
+        encoder_hidden,
+        encoder_mask,
+        batch,
+        dec_seq,
+        enc_seq,
+    );
+    defer cb.free(logits);
+
+    return try cb.toFloat32(logits, allocator);
+}
+
+pub fn decoderForwardTensor(
+    cb: *const ComputeBackend,
+    allocator: std.mem.Allocator,
+    config: Config,
+    decoder_input_ids: []const i64,
+    encoder_hidden: CT,
+    encoder_mask: []const i64,
+    batch: usize,
+    dec_seq: usize,
+    enc_seq: usize,
+) !CT {
     const dec_total = batch * dec_seq;
     var hidden = try applyDecoderEmbeddings(cb, allocator, config, decoder_input_ids, batch, dec_seq);
 
@@ -204,22 +250,48 @@ pub fn decoderForward(
     }
 
     const lm_w = try lmHeadWeight(cb);
-    const logits = try cb.linearNoBias(hidden, lm_w, dec_total, config.d_model, config.vocab_size);
+    var logits = try cb.linearNoBias(hidden, lm_w, dec_total, config.d_model, config.vocab_size);
     cb.free(hidden);
+    errdefer cb.free(logits);
 
-    const result = try cb.toFloat32(logits, allocator);
-    cb.free(logits);
     if (try tryOptionalWeight(cb, "language_model.final_logits_bias")) |logits_bias| {
-        const bias = try cb.toFloat32(logits_bias, allocator);
-        defer allocator.free(bias);
-        const bias_offset: usize = if (bias.len == config.vocab_size) 0 else if (bias.len == config.vocab_size + 1) 1 else 0;
-        const bias_slice = bias[bias_offset..][0..config.vocab_size];
-        for (0..dec_total) |row| {
-            const row_slice = result[row * config.vocab_size ..][0..config.vocab_size];
-            for (row_slice, bias_slice) |*value, bias_value| value.* += bias_value;
-        }
+        const bias = try logitsBiasSlice(cb, allocator, logits_bias, config.vocab_size);
+        defer if (bias.owned) cb.free(bias.tensor);
+
+        const biased = try cb.add(logits, bias.tensor);
+        cb.free(logits);
+        logits = biased;
     }
-    return result;
+    return logits;
+}
+
+const LogitsBiasSlice = struct {
+    tensor: CT,
+    owned: bool,
+};
+
+fn logitsBiasSlice(
+    cb: *const ComputeBackend,
+    allocator: std.mem.Allocator,
+    logits_bias: CT,
+    vocab_size: usize,
+) !LogitsBiasSlice {
+    const shape = try cb.tensorShape(logits_bias, allocator);
+    defer allocator.free(shape);
+
+    var element_count: usize = 1;
+    for (shape) |dim| {
+        if (dim <= 0) return error.InvalidTensorShape;
+        element_count *= @intCast(dim);
+    }
+    if (element_count < vocab_size) return error.InvalidTensorShape;
+    if (element_count == vocab_size) return .{ .tensor = logits_bias, .owned = false };
+
+    const start: usize = if (element_count == vocab_size + 1) 1 else 0;
+    return .{
+        .tensor = try cb.sliceLastDim(logits_bias, start, start + vocab_size),
+        .owned = true,
+    };
 }
 
 fn visionEncoderForward(
@@ -244,18 +316,21 @@ fn visionEncoderForward(
         const depth: usize = config.depths[stage];
         if (useTensorNativeVision(cb)) {
             const stage_shape = [_]i32{ @intCast(batch * stage_h * stage_w), @intCast(config.dim_embed[stage]) };
-            var hidden = try cb.fromFloat32Shape(stage_tokens.?, &stage_shape);
+            var hidden: ?CT = try cb.fromFloat32Shape(stage_tokens.?, &stage_shape);
             allocator.free(stage_tokens.?);
             stage_tokens = null;
-            errdefer cb.free(hidden);
+            errdefer if (hidden) |h| cb.free(h);
 
             for (0..depth) |layer| {
-                const next = try daViTBlock(cb, allocator, config, hidden, batch, stage_h, stage_w, stage, layer);
+                const current = hidden.?;
+                hidden = null;
+                const next = try daViTBlock(cb, allocator, config, current, batch, stage_h, stage_w, stage, layer);
                 hidden = next;
             }
 
-            stage_tokens = try cb.toFloat32(hidden, allocator);
-            cb.free(hidden);
+            stage_tokens = try cb.toFloat32(hidden.?, allocator);
+            cb.free(hidden.?);
+            hidden = null;
         } else {
             for (0..depth) |layer| {
                 stage_tokens = try daViTBlockData(cb, allocator, config, stage_tokens.?, batch, stage_h, stage_w, stage, layer);

--- a/zig/pkg/inference/src/architectures/session_factory.zig
+++ b/zig/pkg/inference/src/architectures/session_factory.zig
@@ -4298,6 +4298,60 @@ pub fn getFlorenceConfig(session: Session) ?florence_mod.Config {
     };
 }
 
+pub fn runFlorenceEncoderResident(
+    session: Session,
+    cb: *const ops.ComputeBackend,
+    allocator: std.mem.Allocator,
+    pixel_values: []const f32,
+    batch: usize,
+    prompt_input_ids: []const i64,
+    prompt_seq_len: usize,
+) !?florence_arch.EncoderForwardTensorResult {
+    if (session.vtable != &arch_vtable) return null;
+    const self: *ArchSession = @ptrCast(@alignCast(session.ptr));
+    return switch (self.arch_config) {
+        .florence => |cfg| try florence_arch.encoderForwardTensor(
+            cb,
+            allocator,
+            cfg,
+            pixel_values,
+            batch,
+            prompt_input_ids,
+            prompt_seq_len,
+        ),
+        else => null,
+    };
+}
+
+pub fn runFlorenceDecoderResident(
+    session: Session,
+    cb: *const ops.ComputeBackend,
+    allocator: std.mem.Allocator,
+    decoder_input_ids: []const i64,
+    encoder_hidden: ops.CT,
+    encoder_mask: []const i64,
+    batch: usize,
+    dec_seq: usize,
+    enc_seq: usize,
+) !?ops.CT {
+    if (session.vtable != &arch_vtable) return null;
+    const self: *ArchSession = @ptrCast(@alignCast(session.ptr));
+    return switch (self.arch_config) {
+        .florence => |cfg| try florence_arch.decoderForwardTensor(
+            cb,
+            allocator,
+            cfg,
+            decoder_input_ids,
+            encoder_hidden,
+            encoder_mask,
+            batch,
+            dec_seq,
+            enc_seq,
+        ),
+        else => null,
+    };
+}
+
 /// Get a ComputeBackend from an architecture session.
 pub fn getComputeBackend(session: Session, allocator: std.mem.Allocator) !ops.ComputeBackend {
     if (session.vtable != &arch_vtable) return error.NotArchSession;

--- a/zig/pkg/inference/src/backends/metal_kernels.m
+++ b/zig/pkg/inference/src/backends/metal_kernels.m
@@ -372,6 +372,10 @@ typedef struct termite_metal_decode_runtime {
     id<MTLComputePipelineState> argmax_axis_f32_pipeline;
     id<MTLComputePipelineState> convert_dtype_f32_pipeline;
     id<MTLComputePipelineState> sdpa_f32_pipeline;
+    id<MTLComputePipelineState> florence_window_pack_f32_pipeline;
+    id<MTLComputePipelineState> florence_window_unpack_f32_pipeline;
+    id<MTLComputePipelineState> florence_channel_scores_f32_pipeline;
+    id<MTLComputePipelineState> florence_channel_apply_f32_pipeline;
     id<MTLComputePipelineState> disentangled_relative_attention_f32_pipeline;
     id<MTLComputePipelineState> disentangled_relative_attention_f32_tg_pipeline;
     id<MTLComputePipelineState> disentangled_relative_attention_f32_flash4_pipeline;
@@ -421,6 +425,7 @@ typedef struct termite_metal_decode_runtime {
     id<MTLComputePipelineState> linear_bias_pipeline;
     id<MTLComputePipelineState> argmax_logits_pipeline;
     id<MTLComputePipelineState> argmax_logits_partials_pipeline;
+    id<MTLComputePipelineState> argmax_logits_suppress_partials_pipeline;
     id<MTLComputePipelineState> argmax_logits_reduce_pipeline;
     id<MTLComputePipelineState> sample_logits_pipeline;
     id<MTLComputePipelineState> sample_topk_partials_pipeline;
@@ -1155,6 +1160,7 @@ static int termite_metal_decode_runtime_encode_sample_from_logits_buffer(
     uint32_t seed
 );
 int termite_metal_decode_runtime_reserve(termite_metal_decode_runtime *runtime, size_t scratch_bytes, size_t token_bytes);
+int termite_metal_decode_runtime_begin_frame(termite_metal_decode_runtime *runtime);
 int termite_metal_decode_runtime_flush_active_frame(termite_metal_decode_runtime *runtime);
 int termite_metal_decode_runtime_active_frame_has_work(termite_metal_decode_runtime *runtime);
 int termite_metal_decode_runtime_submit_frame(termite_metal_decode_runtime *runtime);
@@ -1476,6 +1482,32 @@ typedef struct termite_metal_attention_f32_params {
     uint32_t has_bias;
     uint32_t has_mask;
 } termite_metal_attention_f32_params;
+
+typedef struct termite_metal_florence_window_params {
+    uint32_t batch;
+    uint32_t height;
+    uint32_t width;
+    uint32_t dim;
+    uint32_t window_size;
+    uint32_t padded_h;
+    uint32_t padded_w;
+    uint32_t window_area;
+    uint32_t window_count;
+    uint32_t reserved0;
+    uint32_t reserved1;
+    uint32_t reserved2;
+} termite_metal_florence_window_params;
+
+typedef struct termite_metal_florence_channel_params {
+    uint32_t batch;
+    uint32_t seq_len;
+    uint32_t dim;
+    uint32_t groups;
+    uint32_t channels_per_group;
+    uint32_t reserved0;
+    uint32_t reserved1;
+    uint32_t reserved2;
+} termite_metal_florence_channel_params;
 
 typedef struct termite_metal_compressed_attention_store_local_params {
     uint32_t query_rows;
@@ -1932,6 +1964,9 @@ static NSString *termite_metal_shader_source(void) {
            "struct termite_metal_broadcast_last_dim_params { uint rows; uint in_dim; uint out_dim; uint reserved; };\n"
            "struct termite_metal_quantize_rows_params { uint rows; uint dim; };\n"
            "struct termite_metal_attention_f32_params { uint q_len; uint kv_len; uint num_heads; uint num_kv_heads; uint head_dim; uint query_position_offset; uint kv_position_offset; uint sliding_window; uint total_sequence_len; uint has_bias; uint has_mask; };\n"
+           "struct termite_metal_florence_window_params { uint batch; uint height; uint width; uint dim; uint window_size; uint padded_h; uint padded_w; uint window_area; uint window_count; uint reserved0; uint reserved1; uint reserved2; };\n"
+           "struct termite_metal_florence_channel_params { uint batch; uint seq_len; uint dim; uint groups; uint channels_per_group; uint reserved0; uint reserved1; uint reserved2; };\n"
+           "struct termite_metal_argmax_suppress_params { uint out_dim; uint suppress_count; uint reserved0; uint reserved1; };\n"
            "struct termite_metal_compressed_attention_store_local_params { uint query_rows; uint query_abs_start; uint head_dim; uint reserved; };\n"
            "struct termite_metal_compressed_attention_component_params { uint query_rows; uint query_abs_start; uint total_tokens; uint compress_rate; uint row_dim; uint gate_width; uint row_count; uint rope_dim; float theta; float freq_scale; float eps; uint consecutive_pairs; uint bias_rows; uint reserved0; uint reserved1; uint reserved2; };\n"
            "struct termite_metal_compressed_attention_params { uint query_abs_start; uint query_rows; uint token_count; uint compressed_rows; uint num_heads; uint head_dim; uint sliding_window; uint top_k; uint has_indexer; uint index_rows; uint index_heads; uint index_head_dim; uint has_sinks; uint reserved0; float scale; float reserved1; };\n"
@@ -3016,6 +3051,38 @@ static NSString *termite_metal_shader_source(void) {
            "    }\n"
            "    if (tid == 0u) { partial_values[block] = sh_vals[0]; partial_ids[block] = sh_ids[0]; }\n"
            "}\n"
+           "inline bool termite_argmax_suppressed_token(uint token_id, device const int *suppress_ids, uint suppress_count) {\n"
+           "    for (uint i = 0u; i < suppress_count; ++i) {\n"
+           "        int raw = suppress_ids[i];\n"
+           "        if (raw >= 0 && uint(raw) == token_id) return true;\n"
+           "    }\n"
+           "    return false;\n"
+           "}\n"
+           "kernel void termite_argmax_logits_suppress_partials(device const float *logits [[buffer(0)]], device const int *suppress_ids [[buffer(1)]], device float *partial_values [[buffer(2)]], device uint *partial_ids [[buffer(3)]], constant termite_metal_argmax_suppress_params &p [[buffer(4)]], threadgroup float *sh_vals [[threadgroup(0)]], threadgroup uint *sh_ids [[threadgroup(1)]], ushort tid [[thread_index_in_threadgroup]], ushort tg_size [[threads_per_threadgroup]], uint block [[threadgroup_position_in_grid]]) {\n"
+           "    const uint block_size = 1024u;\n"
+           "    uint start = block * block_size;\n"
+           "    uint end = min(start + block_size, p.out_dim);\n"
+           "    float best = -INFINITY;\n"
+           "    uint best_idx = 0xffffffffu;\n"
+           "    for (uint i = start + uint(tid); i < end; i += uint(tg_size)) {\n"
+           "        if (termite_argmax_suppressed_token(i, suppress_ids, p.suppress_count)) continue;\n"
+           "        float value = logits[i];\n"
+           "        if (value > best || (value == best && i < best_idx)) { best = value; best_idx = i; }\n"
+           "    }\n"
+           "    if (best_idx == 0xffffffffu) best_idx = 0u;\n"
+           "    sh_vals[tid] = best;\n"
+           "    sh_ids[tid] = best_idx;\n"
+           "    threadgroup_barrier(mem_flags::mem_threadgroup);\n"
+           "    for (uint stride = uint(tg_size) >> 1u; stride > 0u; stride >>= 1u) {\n"
+           "        if (uint(tid) < stride) {\n"
+           "            float other = sh_vals[uint(tid) + stride];\n"
+           "            uint other_idx = sh_ids[uint(tid) + stride];\n"
+           "            if (other > sh_vals[tid] || (other == sh_vals[tid] && other_idx < sh_ids[tid])) { sh_vals[tid] = other; sh_ids[tid] = other_idx; }\n"
+           "        }\n"
+           "        threadgroup_barrier(mem_flags::mem_threadgroup);\n"
+           "    }\n"
+           "    if (tid == 0u) { partial_values[block] = sh_vals[0]; partial_ids[block] = sh_ids[0]; }\n"
+           "}\n"
            "kernel void termite_argmax_logits_reduce(device const float *partial_values [[buffer(0)]], device const uint *partial_ids [[buffer(1)]], device uint *output [[buffer(2)]], constant uint &partial_count [[buffer(3)]], uint gid [[thread_position_in_grid]]) {\n"
            "    if (gid != 0u) return;\n"
            "    if (partial_count == 0u) { output[0] = 0u; return; }\n"
@@ -3702,6 +3769,35 @@ static NSString *termite_metal_shader_source(void) {
            "        float w = exp(score - best); sum += w; accum += w * v[(bh * p.seq_len + ki) * p.head_dim + d];\n"
            "    }\n"
            "    output[gid] = sum > 0.0f ? accum / sum : 0.0f;\n"
+           "}\n"
+           "kernel void termite_florence_window_pack_f32(device const float *input [[buffer(0)]], device float *output [[buffer(1)]], constant termite_metal_florence_window_params &p [[buffer(2)]], uint gid [[thread_position_in_grid]]) {\n"
+           "    uint total = p.window_count * p.window_area * p.dim; if (gid >= total || p.dim == 0u || p.window_size == 0u) return;\n"
+           "    uint c = gid % p.dim; uint token = gid / p.dim; uint pos = token % p.window_area; uint win = token / p.window_area;\n"
+           "    uint windows_w = p.padded_w / p.window_size; uint windows_h = p.padded_h / p.window_size; uint windows_per_batch = windows_h * windows_w;\n"
+           "    uint b = win / windows_per_batch; uint rem = win - b * windows_per_batch; uint wh = rem / windows_w; uint ww = rem - wh * windows_w;\n"
+           "    uint dy = pos / p.window_size; uint dx = pos - dy * p.window_size; uint y = wh * p.window_size + dy; uint x = ww * p.window_size + dx;\n"
+           "    output[gid] = (b < p.batch && y < p.height && x < p.width) ? input[((b * p.height + y) * p.width + x) * p.dim + c] : 0.0f;\n"
+           "}\n"
+           "kernel void termite_florence_window_unpack_f32(device const float *input [[buffer(0)]], device float *output [[buffer(1)]], constant termite_metal_florence_window_params &p [[buffer(2)]], uint gid [[thread_position_in_grid]]) {\n"
+           "    uint total = p.batch * p.height * p.width * p.dim; if (gid >= total || p.dim == 0u || p.window_size == 0u) return;\n"
+           "    uint c = gid % p.dim; uint token = gid / p.dim; uint x = token % p.width; uint tmp = token / p.width; uint y = tmp % p.height; uint b = tmp / p.height;\n"
+           "    uint windows_w = p.padded_w / p.window_size; uint windows_h = p.padded_h / p.window_size; uint wh = y / p.window_size; uint ww = x / p.window_size;\n"
+           "    uint dy = y - wh * p.window_size; uint dx = x - ww * p.window_size; uint win = (b * windows_h + wh) * windows_w + ww; uint src_token = win * p.window_area + dy * p.window_size + dx;\n"
+           "    output[gid] = input[src_token * p.dim + c];\n"
+           "}\n"
+           "kernel void termite_florence_channel_scores_f32(device const float *qkv [[buffer(0)]], device float *scores [[buffer(1)]], constant termite_metal_florence_channel_params &p [[buffer(2)]], uint gid [[thread_position_in_grid]]) {\n"
+           "    uint cpg = p.channels_per_group; uint total = p.batch * p.groups * cpg * cpg; if (gid >= total || cpg == 0u || p.seq_len == 0u) return;\n"
+           "    uint kc = gid % cpg; uint tmp = gid / cpg; uint qc = tmp % cpg; tmp /= cpg; uint g = tmp % p.groups; uint b = tmp / p.groups; uint group_off = g * cpg;\n"
+           "    float acc = 0.0f; for (uint n = 0u; n < p.seq_len; ++n) { uint base = ((b * p.seq_len + n) * p.dim * 3u) + group_off; acc += qkv[base + qc] * qkv[base + p.dim + kc]; }\n"
+           "    scores[gid] = acc * rsqrt(float(p.seq_len));\n"
+           "}\n"
+           "kernel void termite_florence_channel_apply_f32(device const float *qkv [[buffer(0)]], device const float *scores [[buffer(1)]], device float *output [[buffer(2)]], constant termite_metal_florence_channel_params &p [[buffer(3)]], uint gid [[thread_position_in_grid]]) {\n"
+           "    uint total = p.batch * p.seq_len * p.dim; uint cpg = p.channels_per_group; if (gid >= total || cpg == 0u) return;\n"
+           "    uint c = gid % p.dim; uint token = gid / p.dim; uint n = token % p.seq_len; uint b = token / p.seq_len; uint g = c / cpg; uint qc = c - g * cpg; uint score_base = ((b * p.groups + g) * cpg + qc) * cpg;\n"
+           "    float best = -3.402823466e+38f; for (uint vc = 0u; vc < cpg; ++vc) best = max(best, scores[score_base + vc]);\n"
+           "    float sum = 0.0f; float acc = 0.0f; uint v_base = ((b * p.seq_len + n) * p.dim * 3u) + 2u * p.dim + g * cpg;\n"
+           "    for (uint vc = 0u; vc < cpg; ++vc) { float w = exp(scores[score_base + vc] - best); sum += w; acc += w * qkv[v_base + vc]; }\n"
+           "    output[gid] = sum > 0.0f ? acc / sum : 0.0f;\n"
            "}\n"
            "kernel void termite_disentangled_relative_attention_f32(device const float *q [[buffer(0)]], device const float *k [[buffer(1)]], device const float *v [[buffer(2)]], device const float *q_r [[buffer(3)]], device const float *k_r [[buffer(4)]], device const float *mask [[buffer(5)]], device float *output [[buffer(6)]], constant termite_metal_disentangled_relative_attention_f32_params &p [[buffer(7)]], uint gid [[thread_position_in_grid]]) {\n"
            "    uint hidden = p.num_heads * p.head_dim; uint total = p.batch * p.seq_len * hidden; if (gid >= total || p.seq_len == 0u || p.head_dim == 0u || hidden == 0u) return;\n"
@@ -10851,6 +10947,10 @@ termite_metal_decode_runtime *termite_metal_decode_runtime_create(void) {
         runtime->argmax_axis_f32_pipeline = termite_metal_make_pipeline(device, precise_library, @"termite_argmax_axis_f32");
         runtime->convert_dtype_f32_pipeline = termite_metal_make_pipeline(device, precise_library, @"termite_convert_dtype_f32");
         runtime->sdpa_f32_pipeline = termite_metal_make_pipeline(device, precise_library, @"termite_sdpa_f32");
+        runtime->florence_window_pack_f32_pipeline = termite_metal_make_pipeline(device, precise_library, @"termite_florence_window_pack_f32");
+        runtime->florence_window_unpack_f32_pipeline = termite_metal_make_pipeline(device, precise_library, @"termite_florence_window_unpack_f32");
+        runtime->florence_channel_scores_f32_pipeline = termite_metal_make_pipeline(device, precise_library, @"termite_florence_channel_scores_f32");
+        runtime->florence_channel_apply_f32_pipeline = termite_metal_make_pipeline(device, precise_library, @"termite_florence_channel_apply_f32");
         runtime->disentangled_relative_attention_f32_pipeline = termite_metal_make_pipeline(device, precise_library, @"termite_disentangled_relative_attention_f32");
         runtime->disentangled_relative_attention_f32_tg_pipeline = termite_metal_make_pipeline(device, precise_library, @"termite_disentangled_relative_attention_f32_tg");
         runtime->disentangled_relative_attention_f32_flash4_pipeline = termite_metal_make_pipeline(device, precise_library, @"termite_disentangled_relative_attention_f32_flash4");
@@ -10900,6 +11000,7 @@ termite_metal_decode_runtime *termite_metal_decode_runtime_create(void) {
         runtime->linear_bias_pipeline = termite_metal_make_pipeline(device, library, @"termite_apply_linear_bias_2d");
         runtime->argmax_logits_pipeline = termite_metal_make_pipeline(device, library, @"termite_argmax_logits_1x");
         runtime->argmax_logits_partials_pipeline = termite_metal_make_pipeline(device, library, @"termite_argmax_logits_partials");
+        runtime->argmax_logits_suppress_partials_pipeline = termite_metal_make_pipeline(device, library, @"termite_argmax_logits_suppress_partials");
         runtime->argmax_logits_reduce_pipeline = termite_metal_make_pipeline(device, library, @"termite_argmax_logits_reduce");
         runtime->sample_logits_pipeline = termite_metal_make_pipeline(device, library, @"termite_sample_logits_1x");
         runtime->sample_topk_partials_pipeline = termite_metal_make_pipeline(device, library, @"termite_sample_topk_partials");
@@ -11005,7 +11106,7 @@ termite_metal_decode_runtime *termite_metal_decode_runtime_create(void) {
         runtime->turbo3_attention_span_pipeline = termite_metal_make_pipeline(device, library, @"termite_turbo3_attention_span");
         BOOL missing_quant_reduce_pipeline = runtime->q4_1_reduce_pipeline == nil || runtime->q5_1_reduce_pipeline == nil || runtime->q8_1_reduce_pipeline == nil || runtime->q8_k_reduce_pipeline == nil || runtime->iq4_nl_reduce_pipeline == nil || runtime->iq4_xs_reduce_pipeline == nil || runtime->mxfp4_reduce_pipeline == nil;
         BOOL missing_dense_multi_row_reduce_pipeline = runtime->linear_bf16_multi_row_reduce_pipeline == nil || runtime->linear_multi_row_reduce_pipeline == nil;
-        if (missing_quant_reduce_pipeline || missing_dense_multi_row_reduce_pipeline || runtime->embed_absolute_position_pipeline == nil || runtime->embedding_lookup_pipeline == nil || runtime->q4_0_get_rows_pipeline == nil || runtime->q4_0_set_rows_pipeline == nil || runtime->q4_0_cpy_q_to_f32_pipeline == nil || runtime->q4_0_cpy_f32_to_q_pipeline == nil || runtime->q4_1_get_rows_pipeline == nil || runtime->q4_1_set_rows_pipeline == nil || runtime->q4_1_cpy_q_to_f32_pipeline == nil || runtime->q4_1_cpy_f32_to_q_pipeline == nil || runtime->q5_0_get_rows_pipeline == nil || runtime->q5_0_set_rows_pipeline == nil || runtime->q5_0_cpy_q_to_f32_pipeline == nil || runtime->q5_0_cpy_f32_to_q_pipeline == nil || runtime->q5_1_get_rows_pipeline == nil || runtime->q5_1_set_rows_pipeline == nil || runtime->q5_1_cpy_q_to_f32_pipeline == nil || runtime->q5_1_cpy_f32_to_q_pipeline == nil || runtime->q4_k_get_rows_pipeline == nil || runtime->q4_k_set_rows_pipeline == nil || runtime->q4_k_cpy_q_to_f32_pipeline == nil || runtime->q4_k_cpy_f32_to_q_pipeline == nil || runtime->q5_k_get_rows_pipeline == nil || runtime->q5_k_set_rows_pipeline == nil || runtime->q5_k_cpy_q_to_f32_pipeline == nil || runtime->q5_k_cpy_f32_to_q_pipeline == nil || runtime->q6_k_get_rows_pipeline == nil || runtime->q6_k_set_rows_pipeline == nil || runtime->q6_k_cpy_q_to_f32_pipeline == nil || runtime->q6_k_cpy_f32_to_q_pipeline == nil || runtime->q8_0_get_rows_pipeline == nil || runtime->q8_0_set_rows_pipeline == nil || runtime->q8_0_cpy_q_to_f32_pipeline == nil || runtime->q8_0_cpy_f32_to_q_pipeline == nil || runtime->q8_1_get_rows_pipeline == nil || runtime->q8_1_set_rows_pipeline == nil || runtime->q8_1_cpy_q_to_f32_pipeline == nil || runtime->q8_1_cpy_f32_to_q_pipeline == nil || runtime->rope_pipeline == nil || runtime->head_rms_rope_pipeline == nil || runtime->attention_f32_pipeline == nil || runtime->attention_f32_prefill_pipeline == nil || runtime->attention_paged_pipeline == nil || runtime->paged_f32_kv_seed_pipeline == nil || runtime->paged_f16_kv_seed_pipeline == nil || runtime->paged_f32_v_seed_pipeline == nil || runtime->slice_last_dim_f32_2d_pipeline == nil || runtime->transpose_f32_pipeline == nil || runtime->dot_general_2d_f32_pipeline == nil || runtime->dot_general_batched_f32_pipeline == nil || runtime->conv1d_f32_pipeline == nil || runtime->conv2d_f32_pipeline == nil || runtime->layer_norm_pipeline == nil || runtime->rms_norm_pipeline == nil || runtime->rms_norm_reduce_pipeline == nil || runtime->rms_norm_rows_pipeline == nil || runtime->rms_norm_add_pipeline == nil || runtime->rms_norm_add_scale_pipeline == nil || runtime->rms_norm_add_scale_rows_pipeline == nil || runtime->linear_pipeline == nil || runtime->linear_reduce_pipeline == nil || runtime->linear_bf16_pipeline == nil || runtime->linear_bf16_reduce_pipeline == nil || runtime->linear_bf16_multi_row_pipeline == nil || runtime->linear_pair_reduce_pipeline == nil || runtime->linear_multi_row_pipeline == nil || runtime->linear_bias_pipeline == nil || runtime->argmax_logits_pipeline == nil || runtime->argmax_logits_partials_pipeline == nil || runtime->argmax_logits_reduce_pipeline == nil || runtime->sample_logits_pipeline == nil || runtime->sample_topk_partials_pipeline == nil || runtime->sample_topk_reduce_pipeline == nil || runtime->activation_pipeline == nil || runtime->activation_multiply_pipeline == nil || runtime->softmax_pipeline == nil || runtime->reduce_last_dim_pipeline == nil || runtime->reduce_axis_f32_pipeline == nil || runtime->multiply_reduce_last_dim_pipeline == nil || runtime->broadcast_last_dim_pipeline == nil || runtime->broadcast_f32_pipeline == nil || runtime->multiply_pipeline == nil || runtime->scale_pipeline == nil || runtime->add_pipeline == nil || runtime->add_scale_pipeline == nil || runtime->subtract_pipeline == nil || runtime->divide_pipeline == nil || runtime->less_than_pipeline == nil || runtime->where_select_pipeline == nil || runtime->i2_s_quantize_pipeline == nil || runtime->q1_0_pipeline == nil || runtime->i8_s_pipeline == nil || runtime->q2_k_pipeline == nil || runtime->q3_k_pipeline == nil || runtime->q4_k_pipeline == nil || runtime->q4_k_reduce_pipeline == nil || runtime->q4_k_pair_pipeline == nil || runtime->q4_0_pipeline == nil || runtime->q4_0_pair_pipeline == nil || runtime->q4_0_reduce_pipeline == nil || runtime->q4_1_pipeline == nil || runtime->q5_0_pipeline == nil || runtime->q5_0_reduce_pipeline == nil || runtime->q5_1_pipeline == nil || runtime->q8_0_pipeline == nil || runtime->q8_0_pair_pipeline == nil || runtime->q8_0_mmv_pipeline == nil || runtime->q8_0_rms_scale_mmv_pipeline == nil || runtime->q8_0_small_batch_pipeline == nil || (runtime->q8_0_mm_pipeline == nil && runtime->q8_0_mm_sg_pipeline == nil) || runtime->q8_0_pair_mmv_pipeline == nil || runtime->q8_0_pair_small_batch_pipeline == nil || runtime->q8_0_qkv_mmv_pipeline == nil || runtime->q8_0_pair_activation_reduce_pipeline == nil || runtime->q8_0_pair_activation_mmv_pipeline == nil || runtime->q8_0_pair_activation_small_batch_pipeline == nil || runtime->q8_0_activation_multiply_reduce_pipeline == nil || runtime->q8_0_activation_multiply_mmv_pipeline == nil || runtime->q8_1_pipeline == nil || runtime->q5_k_pipeline == nil || runtime->q5_k_reduce_pipeline == nil || runtime->q6_k_pipeline == nil || runtime->q6_k_reduce_pipeline == nil || runtime->q6_k_pair_pipeline == nil || runtime->q8_k_pipeline == nil || runtime->iq4_nl_pipeline == nil || runtime->iq4_xs_pipeline == nil || runtime->mxfp4_pipeline == nil || runtime->nvfp4_pipeline == nil || runtime->iq2_xs_pipeline == nil || runtime->i2_s_pipeline == nil || runtime->i2_s_pair_pipeline == nil || runtime->i2_s_linear_i8_pipeline == nil || runtime->i2_s_pair_i8_pipeline == nil || runtime->tl1_pipeline == nil || runtime->tl2_pipeline == nil || runtime->encode_polar4_key_pipeline == nil || runtime->encode_turbo3_key_pipeline == nil || runtime->polar4_attention_span_pipeline == nil || runtime->turbo3_attention_span_pipeline == nil) {
+        if (missing_quant_reduce_pipeline || missing_dense_multi_row_reduce_pipeline || runtime->embed_absolute_position_pipeline == nil || runtime->embedding_lookup_pipeline == nil || runtime->q4_0_get_rows_pipeline == nil || runtime->q4_0_set_rows_pipeline == nil || runtime->q4_0_cpy_q_to_f32_pipeline == nil || runtime->q4_0_cpy_f32_to_q_pipeline == nil || runtime->q4_1_get_rows_pipeline == nil || runtime->q4_1_set_rows_pipeline == nil || runtime->q4_1_cpy_q_to_f32_pipeline == nil || runtime->q4_1_cpy_f32_to_q_pipeline == nil || runtime->q5_0_get_rows_pipeline == nil || runtime->q5_0_set_rows_pipeline == nil || runtime->q5_0_cpy_q_to_f32_pipeline == nil || runtime->q5_0_cpy_f32_to_q_pipeline == nil || runtime->q5_1_get_rows_pipeline == nil || runtime->q5_1_set_rows_pipeline == nil || runtime->q5_1_cpy_q_to_f32_pipeline == nil || runtime->q5_1_cpy_f32_to_q_pipeline == nil || runtime->q4_k_get_rows_pipeline == nil || runtime->q4_k_set_rows_pipeline == nil || runtime->q4_k_cpy_q_to_f32_pipeline == nil || runtime->q4_k_cpy_f32_to_q_pipeline == nil || runtime->q5_k_get_rows_pipeline == nil || runtime->q5_k_set_rows_pipeline == nil || runtime->q5_k_cpy_q_to_f32_pipeline == nil || runtime->q5_k_cpy_f32_to_q_pipeline == nil || runtime->q6_k_get_rows_pipeline == nil || runtime->q6_k_set_rows_pipeline == nil || runtime->q6_k_cpy_q_to_f32_pipeline == nil || runtime->q6_k_cpy_f32_to_q_pipeline == nil || runtime->q8_0_get_rows_pipeline == nil || runtime->q8_0_set_rows_pipeline == nil || runtime->q8_0_cpy_q_to_f32_pipeline == nil || runtime->q8_0_cpy_f32_to_q_pipeline == nil || runtime->q8_1_get_rows_pipeline == nil || runtime->q8_1_set_rows_pipeline == nil || runtime->q8_1_cpy_q_to_f32_pipeline == nil || runtime->q8_1_cpy_f32_to_q_pipeline == nil || runtime->rope_pipeline == nil || runtime->head_rms_rope_pipeline == nil || runtime->attention_f32_pipeline == nil || runtime->attention_f32_prefill_pipeline == nil || runtime->attention_paged_pipeline == nil || runtime->paged_f32_kv_seed_pipeline == nil || runtime->paged_f16_kv_seed_pipeline == nil || runtime->paged_f32_v_seed_pipeline == nil || runtime->slice_last_dim_f32_2d_pipeline == nil || runtime->transpose_f32_pipeline == nil || runtime->dot_general_2d_f32_pipeline == nil || runtime->dot_general_batched_f32_pipeline == nil || runtime->conv1d_f32_pipeline == nil || runtime->conv2d_f32_pipeline == nil || runtime->layer_norm_pipeline == nil || runtime->rms_norm_pipeline == nil || runtime->rms_norm_reduce_pipeline == nil || runtime->rms_norm_rows_pipeline == nil || runtime->rms_norm_add_pipeline == nil || runtime->rms_norm_add_scale_pipeline == nil || runtime->rms_norm_add_scale_rows_pipeline == nil || runtime->linear_pipeline == nil || runtime->linear_reduce_pipeline == nil || runtime->linear_bf16_pipeline == nil || runtime->linear_bf16_reduce_pipeline == nil || runtime->linear_bf16_multi_row_pipeline == nil || runtime->linear_pair_reduce_pipeline == nil || runtime->linear_multi_row_pipeline == nil || runtime->linear_bias_pipeline == nil || runtime->argmax_logits_pipeline == nil || runtime->argmax_logits_partials_pipeline == nil || runtime->argmax_logits_suppress_partials_pipeline == nil || runtime->argmax_logits_reduce_pipeline == nil || runtime->sample_logits_pipeline == nil || runtime->sample_topk_partials_pipeline == nil || runtime->sample_topk_reduce_pipeline == nil || runtime->activation_pipeline == nil || runtime->activation_multiply_pipeline == nil || runtime->softmax_pipeline == nil || runtime->reduce_last_dim_pipeline == nil || runtime->reduce_axis_f32_pipeline == nil || runtime->multiply_reduce_last_dim_pipeline == nil || runtime->broadcast_last_dim_pipeline == nil || runtime->broadcast_f32_pipeline == nil || runtime->multiply_pipeline == nil || runtime->scale_pipeline == nil || runtime->add_pipeline == nil || runtime->add_scale_pipeline == nil || runtime->subtract_pipeline == nil || runtime->divide_pipeline == nil || runtime->less_than_pipeline == nil || runtime->where_select_pipeline == nil || runtime->i2_s_quantize_pipeline == nil || runtime->q1_0_pipeline == nil || runtime->i8_s_pipeline == nil || runtime->q2_k_pipeline == nil || runtime->q3_k_pipeline == nil || runtime->q4_k_pipeline == nil || runtime->q4_k_reduce_pipeline == nil || runtime->q4_k_pair_pipeline == nil || runtime->q4_0_pipeline == nil || runtime->q4_0_pair_pipeline == nil || runtime->q4_0_reduce_pipeline == nil || runtime->q4_1_pipeline == nil || runtime->q5_0_pipeline == nil || runtime->q5_0_reduce_pipeline == nil || runtime->q5_1_pipeline == nil || runtime->q8_0_pipeline == nil || runtime->q8_0_pair_pipeline == nil || runtime->q8_0_mmv_pipeline == nil || runtime->q8_0_rms_scale_mmv_pipeline == nil || runtime->q8_0_small_batch_pipeline == nil || (runtime->q8_0_mm_pipeline == nil && runtime->q8_0_mm_sg_pipeline == nil) || runtime->q8_0_pair_mmv_pipeline == nil || runtime->q8_0_pair_small_batch_pipeline == nil || runtime->q8_0_qkv_mmv_pipeline == nil || runtime->q8_0_pair_activation_reduce_pipeline == nil || runtime->q8_0_pair_activation_mmv_pipeline == nil || runtime->q8_0_pair_activation_small_batch_pipeline == nil || runtime->q8_0_activation_multiply_reduce_pipeline == nil || runtime->q8_0_activation_multiply_mmv_pipeline == nil || runtime->q8_1_pipeline == nil || runtime->q5_k_pipeline == nil || runtime->q5_k_reduce_pipeline == nil || runtime->q6_k_pipeline == nil || runtime->q6_k_reduce_pipeline == nil || runtime->q6_k_pair_pipeline == nil || runtime->q8_k_pipeline == nil || runtime->iq4_nl_pipeline == nil || runtime->iq4_xs_pipeline == nil || runtime->mxfp4_pipeline == nil || runtime->nvfp4_pipeline == nil || runtime->iq2_xs_pipeline == nil || runtime->i2_s_pipeline == nil || runtime->i2_s_pair_pipeline == nil || runtime->i2_s_linear_i8_pipeline == nil || runtime->i2_s_pair_i8_pipeline == nil || runtime->tl1_pipeline == nil || runtime->tl2_pipeline == nil || runtime->encode_polar4_key_pipeline == nil || runtime->encode_turbo3_key_pipeline == nil || runtime->polar4_attention_span_pipeline == nil || runtime->turbo3_attention_span_pipeline == nil) {
             fprintf(stderr, "metal-runtime-create: pipeline=nil");
             if (runtime->embed_absolute_position_pipeline == nil) fprintf(stderr, " embed_absolute_position");
             if (runtime->embedding_lookup_pipeline == nil) fprintf(stderr, " embedding_lookup");
@@ -11077,6 +11178,7 @@ termite_metal_decode_runtime *termite_metal_decode_runtime_create(void) {
             if (runtime->linear_multi_row_reduce_pipeline == nil) fprintf(stderr, " linear_multi_row_reduce");
             if (runtime->argmax_logits_pipeline == nil) fprintf(stderr, " argmax_logits");
             if (runtime->argmax_logits_partials_pipeline == nil) fprintf(stderr, " argmax_logits_partials");
+            if (runtime->argmax_logits_suppress_partials_pipeline == nil) fprintf(stderr, " argmax_logits_suppress_partials");
             if (runtime->argmax_logits_reduce_pipeline == nil) fprintf(stderr, " argmax_logits_reduce");
             if (runtime->sample_logits_pipeline == nil) fprintf(stderr, " sample_logits");
             if (runtime->sample_topk_partials_pipeline == nil) fprintf(stderr, " sample_topk_partials");
@@ -11247,6 +11349,10 @@ void termite_metal_decode_runtime_destroy(termite_metal_decode_runtime *runtime)
     runtime->argmax_axis_f32_pipeline = nil;
     runtime->convert_dtype_f32_pipeline = nil;
     runtime->sdpa_f32_pipeline = nil;
+    runtime->florence_window_pack_f32_pipeline = nil;
+    runtime->florence_window_unpack_f32_pipeline = nil;
+    runtime->florence_channel_scores_f32_pipeline = nil;
+    runtime->florence_channel_apply_f32_pipeline = nil;
     runtime->disentangled_relative_attention_f32_pipeline = nil;
     runtime->disentangled_relative_attention_f32_tg_pipeline = nil;
     runtime->disentangled_relative_attention_f32_flash4_pipeline = nil;
@@ -11295,6 +11401,7 @@ void termite_metal_decode_runtime_destroy(termite_metal_decode_runtime *runtime)
     runtime->linear_multi_row_tiled32_m16_activation_f32_pipeline = nil;
     runtime->argmax_logits_pipeline = nil;
     runtime->argmax_logits_partials_pipeline = nil;
+    runtime->argmax_logits_suppress_partials_pipeline = nil;
     runtime->argmax_logits_reduce_pipeline = nil;
     runtime->sample_logits_pipeline = nil;
     runtime->sample_topk_partials_pipeline = nil;
@@ -13567,6 +13674,215 @@ int termite_metal_decode_runtime_apply_attention_f32_device(
     }
 }
 
+int termite_metal_decode_runtime_florence_window_pack_f32_device(
+    termite_metal_decode_runtime *runtime,
+    void *input_handle,
+    size_t input_offset,
+    void *output_handle,
+    size_t output_offset,
+    size_t batch,
+    size_t height,
+    size_t width,
+    size_t dim,
+    size_t window_size
+) {
+    if (runtime == NULL || input_handle == NULL || output_handle == NULL) return -1;
+    if (runtime->florence_window_pack_f32_pipeline == nil) return -2;
+    if (batch == 0 || height == 0 || width == 0 || dim == 0 || window_size == 0) return -3;
+    if (batch > UINT32_MAX || height > UINT32_MAX || width > UINT32_MAX || dim > UINT32_MAX || window_size > UINT32_MAX) return -4;
+    const size_t pad_h = (window_size - (height % window_size)) % window_size;
+    const size_t pad_w = (window_size - (width % window_size)) % window_size;
+    const size_t padded_h = height + pad_h;
+    const size_t padded_w = width + pad_w;
+    if (padded_h > UINT32_MAX || padded_w > UINT32_MAX) return -5;
+    const size_t windows_h = padded_h / window_size;
+    const size_t windows_w = padded_w / window_size;
+    const size_t window_area = window_size * window_size;
+    if (window_area > UINT32_MAX) return -6;
+    if (batch > SIZE_MAX / windows_h || batch * windows_h > SIZE_MAX / windows_w) return -7;
+    const size_t window_count = batch * windows_h * windows_w;
+    if (window_count > UINT32_MAX) return -8;
+    if (batch > SIZE_MAX / height || batch * height > SIZE_MAX / width || batch * height * width > SIZE_MAX / dim) return -9;
+    const size_t input_elems = batch * height * width * dim;
+    if (window_count > SIZE_MAX / window_area || window_count * window_area > SIZE_MAX / dim) return -10;
+    const size_t output_elems = window_count * window_area * dim;
+    if (output_elems > UINT32_MAX) return -11;
+    @autoreleasepool {
+        id<MTLBuffer> input_buffer = (__bridge id<MTLBuffer>)input_handle;
+        id<MTLBuffer> output_buffer = (__bridge id<MTLBuffer>)output_handle;
+        const size_t input_bytes = input_elems * sizeof(float);
+        const size_t output_bytes = output_elems * sizeof(float);
+        if (input_offset + input_bytes > input_buffer.length || output_offset + output_bytes > output_buffer.length) return -12;
+        termite_metal_florence_window_params params = {
+            .batch = (uint32_t)batch,
+            .height = (uint32_t)height,
+            .width = (uint32_t)width,
+            .dim = (uint32_t)dim,
+            .window_size = (uint32_t)window_size,
+            .padded_h = (uint32_t)padded_h,
+            .padded_w = (uint32_t)padded_w,
+            .window_area = (uint32_t)window_area,
+            .window_count = (uint32_t)window_count,
+            .reserved0 = 0,
+            .reserved1 = 0,
+            .reserved2 = 0,
+        };
+        bool frame_owned = true;
+        id<MTLCommandBuffer> command_buffer = termite_metal_decode_runtime_command_buffer(runtime, __func__, &frame_owned);
+        if (command_buffer == nil) return -13;
+        id<MTLComputeCommandEncoder> encoder = termite_metal_tracked_compute_command_encoder_for(command_buffer, TERMITE_METAL_COMPUTE_SOURCE_OTHER);
+        if (encoder == nil) return -14;
+        [encoder setComputePipelineState:runtime->florence_window_pack_f32_pipeline];
+        [encoder setBuffer:input_buffer offset:input_offset atIndex:0];
+        [encoder setBuffer:output_buffer offset:output_offset atIndex:1];
+        [encoder setBytes:&params length:sizeof(params) atIndex:2];
+        [encoder dispatchThreads:MTLSizeMake(output_elems, 1, 1)
+           threadsPerThreadgroup:MTLSizeMake(termite_metal_thread_width(runtime->florence_window_pack_f32_pipeline, output_elems), 1, 1)];
+        [encoder endEncoding];
+        return termite_metal_decode_runtime_finish_command_buffer(command_buffer, frame_owned, -15);
+    }
+}
+
+int termite_metal_decode_runtime_florence_window_unpack_f32_device(
+    termite_metal_decode_runtime *runtime,
+    void *input_handle,
+    size_t input_offset,
+    void *output_handle,
+    size_t output_offset,
+    size_t batch,
+    size_t height,
+    size_t width,
+    size_t dim,
+    size_t window_size
+) {
+    if (runtime == NULL || input_handle == NULL || output_handle == NULL) return -1;
+    if (runtime->florence_window_unpack_f32_pipeline == nil) return -2;
+    if (batch == 0 || height == 0 || width == 0 || dim == 0 || window_size == 0) return -3;
+    if (batch > UINT32_MAX || height > UINT32_MAX || width > UINT32_MAX || dim > UINT32_MAX || window_size > UINT32_MAX) return -4;
+    const size_t pad_h = (window_size - (height % window_size)) % window_size;
+    const size_t pad_w = (window_size - (width % window_size)) % window_size;
+    const size_t padded_h = height + pad_h;
+    const size_t padded_w = width + pad_w;
+    if (padded_h > UINT32_MAX || padded_w > UINT32_MAX) return -5;
+    const size_t windows_h = padded_h / window_size;
+    const size_t windows_w = padded_w / window_size;
+    const size_t window_area = window_size * window_size;
+    if (window_area > UINT32_MAX) return -6;
+    if (batch > SIZE_MAX / windows_h || batch * windows_h > SIZE_MAX / windows_w) return -7;
+    const size_t window_count = batch * windows_h * windows_w;
+    if (window_count > UINT32_MAX) return -8;
+    if (window_count > SIZE_MAX / window_area || window_count * window_area > SIZE_MAX / dim) return -9;
+    const size_t input_elems = window_count * window_area * dim;
+    if (batch > SIZE_MAX / height || batch * height > SIZE_MAX / width || batch * height * width > SIZE_MAX / dim) return -10;
+    const size_t output_elems = batch * height * width * dim;
+    if (output_elems > UINT32_MAX) return -11;
+    @autoreleasepool {
+        id<MTLBuffer> input_buffer = (__bridge id<MTLBuffer>)input_handle;
+        id<MTLBuffer> output_buffer = (__bridge id<MTLBuffer>)output_handle;
+        const size_t input_bytes = input_elems * sizeof(float);
+        const size_t output_bytes = output_elems * sizeof(float);
+        if (input_offset + input_bytes > input_buffer.length || output_offset + output_bytes > output_buffer.length) return -12;
+        termite_metal_florence_window_params params = {
+            .batch = (uint32_t)batch,
+            .height = (uint32_t)height,
+            .width = (uint32_t)width,
+            .dim = (uint32_t)dim,
+            .window_size = (uint32_t)window_size,
+            .padded_h = (uint32_t)padded_h,
+            .padded_w = (uint32_t)padded_w,
+            .window_area = (uint32_t)window_area,
+            .window_count = (uint32_t)window_count,
+            .reserved0 = 0,
+            .reserved1 = 0,
+            .reserved2 = 0,
+        };
+        bool frame_owned = true;
+        id<MTLCommandBuffer> command_buffer = termite_metal_decode_runtime_command_buffer(runtime, __func__, &frame_owned);
+        if (command_buffer == nil) return -13;
+        id<MTLComputeCommandEncoder> encoder = termite_metal_tracked_compute_command_encoder_for(command_buffer, TERMITE_METAL_COMPUTE_SOURCE_OTHER);
+        if (encoder == nil) return -14;
+        [encoder setComputePipelineState:runtime->florence_window_unpack_f32_pipeline];
+        [encoder setBuffer:input_buffer offset:input_offset atIndex:0];
+        [encoder setBuffer:output_buffer offset:output_offset atIndex:1];
+        [encoder setBytes:&params length:sizeof(params) atIndex:2];
+        [encoder dispatchThreads:MTLSizeMake(output_elems, 1, 1)
+           threadsPerThreadgroup:MTLSizeMake(termite_metal_thread_width(runtime->florence_window_unpack_f32_pipeline, output_elems), 1, 1)];
+        [encoder endEncoding];
+        return termite_metal_decode_runtime_finish_command_buffer(command_buffer, frame_owned, -15);
+    }
+}
+
+int termite_metal_decode_runtime_florence_channel_attention_f32_device(
+    termite_metal_decode_runtime *runtime,
+    void *qkv_handle,
+    size_t qkv_offset,
+    void *output_handle,
+    size_t output_offset,
+    size_t batch,
+    size_t seq_len,
+    size_t dim,
+    size_t groups
+) {
+    if (runtime == NULL || qkv_handle == NULL || output_handle == NULL) return -1;
+    if (runtime->florence_channel_scores_f32_pipeline == nil || runtime->florence_channel_apply_f32_pipeline == nil) return -2;
+    if (batch == 0 || seq_len == 0 || dim == 0 || groups == 0 || dim % groups != 0) return -3;
+    const size_t channels_per_group = dim / groups;
+    if (batch > UINT32_MAX || seq_len > UINT32_MAX || dim > UINT32_MAX || groups > UINT32_MAX || channels_per_group > UINT32_MAX) return -4;
+    if (batch > SIZE_MAX / seq_len || batch * seq_len > SIZE_MAX / dim) return -5;
+    const size_t output_elems = batch * seq_len * dim;
+    if (output_elems > UINT32_MAX) return -6;
+    if (output_elems > SIZE_MAX / 3u) return -7;
+    const size_t qkv_elems = output_elems * 3u;
+    if (batch > SIZE_MAX / groups || batch * groups > SIZE_MAX / channels_per_group || batch * groups * channels_per_group > SIZE_MAX / channels_per_group) return -8;
+    const size_t score_elems = batch * groups * channels_per_group * channels_per_group;
+    if (score_elems > UINT32_MAX) return -9;
+    @autoreleasepool {
+        id<MTLBuffer> qkv_buffer = (__bridge id<MTLBuffer>)qkv_handle;
+        id<MTLBuffer> output_buffer = (__bridge id<MTLBuffer>)output_handle;
+        const size_t qkv_bytes = qkv_elems * sizeof(float);
+        const size_t output_bytes = output_elems * sizeof(float);
+        const size_t score_bytes = score_elems * sizeof(float);
+        if (qkv_offset + qkv_bytes > qkv_buffer.length || output_offset + output_bytes > output_buffer.length) return -10;
+        id<MTLBuffer> scores_buffer = [runtime->device newBufferWithLength:score_bytes options:MTLResourceStorageModePrivate];
+        if (scores_buffer == nil) return -11;
+        termite_metal_florence_channel_params params = {
+            .batch = (uint32_t)batch,
+            .seq_len = (uint32_t)seq_len,
+            .dim = (uint32_t)dim,
+            .groups = (uint32_t)groups,
+            .channels_per_group = (uint32_t)channels_per_group,
+            .reserved0 = 0,
+            .reserved1 = 0,
+            .reserved2 = 0,
+        };
+        bool frame_owned = true;
+        id<MTLCommandBuffer> command_buffer = termite_metal_decode_runtime_command_buffer(runtime, __func__, &frame_owned);
+        if (command_buffer == nil) return -12;
+        if (!frame_owned && termite_metal_decode_runtime_retain_frame_resource(runtime, scores_buffer) != 0) return -13;
+        id<MTLComputeCommandEncoder> scores_encoder = termite_metal_tracked_compute_command_encoder_for(command_buffer, TERMITE_METAL_COMPUTE_SOURCE_ATTENTION);
+        if (scores_encoder == nil) return -14;
+        [scores_encoder setComputePipelineState:runtime->florence_channel_scores_f32_pipeline];
+        [scores_encoder setBuffer:qkv_buffer offset:qkv_offset atIndex:0];
+        [scores_encoder setBuffer:scores_buffer offset:0 atIndex:1];
+        [scores_encoder setBytes:&params length:sizeof(params) atIndex:2];
+        [scores_encoder dispatchThreads:MTLSizeMake(score_elems, 1, 1)
+           threadsPerThreadgroup:MTLSizeMake(termite_metal_thread_width(runtime->florence_channel_scores_f32_pipeline, score_elems), 1, 1)];
+        [scores_encoder endEncoding];
+
+        id<MTLComputeCommandEncoder> apply_encoder = termite_metal_tracked_compute_command_encoder_for(command_buffer, TERMITE_METAL_COMPUTE_SOURCE_ATTENTION);
+        if (apply_encoder == nil) return -15;
+        [apply_encoder setComputePipelineState:runtime->florence_channel_apply_f32_pipeline];
+        [apply_encoder setBuffer:qkv_buffer offset:qkv_offset atIndex:0];
+        [apply_encoder setBuffer:scores_buffer offset:0 atIndex:1];
+        [apply_encoder setBuffer:output_buffer offset:output_offset atIndex:2];
+        [apply_encoder setBytes:&params length:sizeof(params) atIndex:3];
+        [apply_encoder dispatchThreads:MTLSizeMake(output_elems, 1, 1)
+           threadsPerThreadgroup:MTLSizeMake(termite_metal_thread_width(runtime->florence_channel_apply_f32_pipeline, output_elems), 1, 1)];
+        [apply_encoder endEncoding];
+        return termite_metal_decode_runtime_finish_command_buffer(command_buffer, frame_owned, -16);
+    }
+}
+
 int termite_metal_decode_runtime_compressed_attention_store_local_device(
     termite_metal_decode_runtime *runtime,
     void *input_handle,
@@ -14490,6 +14806,94 @@ static int termite_metal_encode_argmax_logits_on_encoder(
     [encoder setBuffer:runtime->sample_topk_values_buffer offset:0 atIndex:1];
     [encoder setBuffer:runtime->sample_topk_ids_buffer offset:0 atIndex:2];
     [encoder setBytes:&out_dim_u32 length:sizeof(out_dim_u32) atIndex:3];
+    [encoder setThreadgroupMemoryLength:256u * sizeof(float) atIndex:0];
+    [encoder setThreadgroupMemoryLength:256u * sizeof(uint32_t) atIndex:1];
+    [encoder dispatchThreadgroups:MTLSizeMake(block_count, 1, 1) threadsPerThreadgroup:MTLSizeMake(256, 1, 1)];
+
+    if (runtime->active_planned_compute_encoder == encoder) {
+        termite_metal_planned_encoder_range reduce_accesses[3];
+        if (termite_metal_planned_range_make(runtime->sample_topk_values_buffer, 0, partial_bytes, TERMITE_METAL_PLANNED_RANGE_READ, &reduce_accesses[0], failure_code) != 0 ||
+            termite_metal_planned_range_make(runtime->sample_topk_ids_buffer, 0, partial_bytes, TERMITE_METAL_PLANNED_RANGE_READ, &reduce_accesses[1], failure_code) != 0 ||
+            termite_metal_planned_range_make(runtime->token_buffer, 0, sizeof(uint32_t), TERMITE_METAL_PLANNED_RANGE_WRITE, &reduce_accesses[2], failure_code) != 0 ||
+            termite_metal_decode_runtime_prepare_planned_compute_accesses(runtime, reduce_accesses, 3, failure_code) != 0)
+        {
+            return failure_code;
+        }
+    } else {
+        [encoder memoryBarrierWithScope:MTLBarrierScopeBuffers];
+    }
+
+    const uint32_t block_count_u32 = (uint32_t)block_count;
+    [encoder setComputePipelineState:runtime->argmax_logits_reduce_pipeline];
+    [encoder setBuffer:runtime->sample_topk_values_buffer offset:0 atIndex:0];
+    [encoder setBuffer:runtime->sample_topk_ids_buffer offset:0 atIndex:1];
+    [encoder setBuffer:runtime->token_buffer offset:0 atIndex:2];
+    [encoder setBytes:&block_count_u32 length:sizeof(block_count_u32) atIndex:3];
+    [encoder dispatchThreads:MTLSizeMake(1, 1, 1) threadsPerThreadgroup:MTLSizeMake(1, 1, 1)];
+    return 0;
+}
+
+static int termite_metal_encode_argmax_logits_suppress_on_encoder(
+    termite_metal_decode_runtime *runtime,
+    id<MTLComputeCommandEncoder> encoder,
+    id<MTLBuffer> logits_buffer,
+    size_t logits_offset,
+    size_t out_dim,
+    id<MTLBuffer> suppress_buffer,
+    size_t suppress_count,
+    int failure_code
+) {
+    if (runtime == NULL || encoder == nil || logits_buffer == nil) return failure_code;
+    if (suppress_count == 0) return termite_metal_encode_argmax_logits_on_encoder(runtime, encoder, logits_buffer, logits_offset, out_dim, failure_code);
+    if (runtime->argmax_logits_suppress_partials_pipeline == nil || runtime->argmax_logits_reduce_pipeline == nil) return failure_code;
+    if (suppress_buffer == nil || out_dim == 0 || out_dim > UINT32_MAX || suppress_count > UINT32_MAX) return failure_code;
+    size_t logits_bytes = 0;
+    if (!termite_metal_size_mul(out_dim, sizeof(float), &logits_bytes)) return failure_code;
+    size_t suppress_bytes = 0;
+    if (!termite_metal_size_mul(suppress_count, sizeof(int32_t), &suppress_bytes)) return failure_code;
+    if (runtime->token_capacity < sizeof(uint32_t) || runtime->token_buffer == nil || runtime->token_buffer.storageMode != MTLStorageModeShared) {
+        id<MTLBuffer> token = [runtime->device newBufferWithLength:sizeof(uint32_t) options:MTLResourceStorageModeShared];
+        if (token == nil) return failure_code;
+        runtime->token_buffer = token;
+        runtime->token_capacity = sizeof(uint32_t);
+    }
+
+    const size_t block_size = 1024u;
+    const size_t block_count = (out_dim + block_size - 1u) / block_size;
+    if (block_count == 0 || block_count > UINT32_MAX) return failure_code;
+    const size_t partial_bytes = block_count * sizeof(float);
+    if (termite_metal_decode_runtime_ensure_sample_topk_buffers(runtime, partial_bytes) != 0) return failure_code;
+    if (runtime->sample_topk_values_buffer == nil || runtime->sample_topk_ids_buffer == nil) return failure_code;
+
+    termite_metal_planned_encoder_range partial_accesses[4];
+    if (termite_metal_planned_range_make(logits_buffer, logits_offset, logits_bytes, TERMITE_METAL_PLANNED_RANGE_READ, &partial_accesses[0], failure_code) != 0 ||
+        termite_metal_planned_range_make(suppress_buffer, 0, suppress_bytes, TERMITE_METAL_PLANNED_RANGE_READ, &partial_accesses[1], failure_code) != 0 ||
+        termite_metal_planned_range_make(runtime->sample_topk_values_buffer, 0, partial_bytes, TERMITE_METAL_PLANNED_RANGE_WRITE, &partial_accesses[2], failure_code) != 0 ||
+        termite_metal_planned_range_make(runtime->sample_topk_ids_buffer, 0, partial_bytes, TERMITE_METAL_PLANNED_RANGE_WRITE, &partial_accesses[3], failure_code) != 0 ||
+        termite_metal_decode_runtime_prepare_planned_compute_accesses(runtime, partial_accesses, 4, failure_code) != 0)
+    {
+        return failure_code;
+    }
+
+    typedef struct {
+        uint32_t out_dim;
+        uint32_t suppress_count;
+        uint32_t reserved0;
+        uint32_t reserved1;
+    } termite_metal_argmax_suppress_params_host;
+    const termite_metal_argmax_suppress_params_host params = {
+        .out_dim = (uint32_t)out_dim,
+        .suppress_count = (uint32_t)suppress_count,
+        .reserved0 = 0,
+        .reserved1 = 0,
+    };
+
+    [encoder setComputePipelineState:runtime->argmax_logits_suppress_partials_pipeline];
+    [encoder setBuffer:logits_buffer offset:logits_offset atIndex:0];
+    [encoder setBuffer:suppress_buffer offset:0 atIndex:1];
+    [encoder setBuffer:runtime->sample_topk_values_buffer offset:0 atIndex:2];
+    [encoder setBuffer:runtime->sample_topk_ids_buffer offset:0 atIndex:3];
+    [encoder setBytes:&params length:sizeof(params) atIndex:4];
     [encoder setThreadgroupMemoryLength:256u * sizeof(float) atIndex:0];
     [encoder setThreadgroupMemoryLength:256u * sizeof(uint32_t) atIndex:1];
     [encoder dispatchThreadgroups:MTLSizeMake(block_count, 1, 1) threadsPerThreadgroup:MTLSizeMake(256, 1, 1)];
@@ -19414,6 +19818,18 @@ int termite_metal_decode_runtime_argmax_from_logits_device(
             runtime->token_buffer = token;
             runtime->token_capacity = sizeof(uint32_t);
         }
+        const bool restore_active_frame = (runtime->active_frame_cb != nil);
+        if (restore_active_frame) {
+            if (!termite_metal_decode_runtime_active_frame_empty(runtime)) {
+                int flush_rc = termite_metal_decode_runtime_flush_active_frame(runtime);
+                if (flush_rc != 0) return -10;
+            }
+            if (runtime->active_frame_cb != nil) {
+                if (!termite_metal_decode_runtime_active_frame_empty(runtime)) return -10;
+                int cancel_rc = termite_metal_decode_runtime_cancel_frame(runtime);
+                if (cancel_rc != 0) return -10;
+            }
+        }
         bool frame_owned = true;
         id<MTLCommandBuffer> command_buffer = termite_metal_decode_runtime_command_buffer(runtime, __func__, &frame_owned);
         if (command_buffer == nil) return -6;
@@ -19422,13 +19838,99 @@ int termite_metal_decode_runtime_argmax_from_logits_device(
         const int encode_rc = termite_metal_encode_argmax_logits_on_encoder(runtime, encoder, logits_buffer, logits_offset, out_dim, -7);
         [encoder endEncoding];
         if (encode_rc != 0) return encode_rc;
-        if (!frame_owned) return -10;
-        [command_buffer commit];
-        [command_buffer waitUntilCompleted];
-        if (command_buffer.status != MTLCommandBufferStatusCompleted) return -8;
+        if (!frame_owned) {
+            int flush_rc = termite_metal_decode_runtime_flush_active_frame(runtime);
+            if (flush_rc != 0) return -10;
+        } else {
+            [command_buffer commit];
+            [command_buffer waitUntilCompleted];
+            if (command_buffer.status != MTLCommandBufferStatusCompleted) return -8;
+        }
         uint32_t *result = (uint32_t *)runtime->token_buffer.contents;
         if (result == NULL) return -9;
         output_token_id[0] = result[0];
+        if (restore_active_frame) {
+            int begin_rc = termite_metal_decode_runtime_begin_frame(runtime);
+            if (begin_rc != 0) return -11;
+        }
+        return 0;
+    }
+}
+
+int termite_metal_decode_runtime_argmax_from_logits_suppress_device(
+    termite_metal_decode_runtime *runtime,
+    void *logits_handle,
+    size_t logits_offset,
+    size_t out_dim,
+    const int32_t *suppress_token_ids,
+    size_t suppress_count,
+    uint32_t *output_token_id
+) {
+    if (runtime == NULL || logits_handle == NULL || output_token_id == NULL) return -1;
+    if (suppress_count == 0) {
+        return termite_metal_decode_runtime_argmax_from_logits_device(
+            runtime,
+            logits_handle,
+            logits_offset,
+            out_dim,
+            output_token_id);
+    }
+    if (suppress_token_ids == NULL) return -2;
+    if (runtime->argmax_logits_suppress_partials_pipeline == nil || runtime->argmax_logits_reduce_pipeline == nil) return -3;
+    if (out_dim == 0 || out_dim > UINT32_MAX || suppress_count > UINT32_MAX) return -4;
+    @autoreleasepool {
+        id<MTLBuffer> logits_buffer = (__bridge id<MTLBuffer>)logits_handle;
+        const size_t logits_bytes = out_dim * sizeof(float);
+        if (logits_offset + logits_bytes > logits_buffer.length) return -5;
+        size_t suppress_bytes = 0;
+        if (!termite_metal_size_mul(suppress_count, sizeof(int32_t), &suppress_bytes)) return -6;
+        id<MTLBuffer> suppress_buffer = [runtime->device newBufferWithBytes:suppress_token_ids length:suppress_bytes options:MTLResourceStorageModeShared];
+        if (suppress_buffer == nil) return -7;
+
+        const bool restore_active_frame = (runtime->active_frame_cb != nil);
+        if (restore_active_frame) {
+            if (!termite_metal_decode_runtime_active_frame_empty(runtime)) {
+                int flush_rc = termite_metal_decode_runtime_flush_active_frame(runtime);
+                if (flush_rc != 0) return -10;
+            }
+            if (runtime->active_frame_cb != nil) {
+                if (!termite_metal_decode_runtime_active_frame_empty(runtime)) return -10;
+                int cancel_rc = termite_metal_decode_runtime_cancel_frame(runtime);
+                if (cancel_rc != 0) return -10;
+            }
+        }
+
+        bool frame_owned = true;
+        id<MTLCommandBuffer> command_buffer = termite_metal_decode_runtime_command_buffer(runtime, __func__, &frame_owned);
+        if (command_buffer == nil) return -8;
+        id<MTLComputeCommandEncoder> encoder = termite_metal_tracked_compute_command_encoder(command_buffer);
+        if (encoder == nil) return -9;
+        const int encode_rc = termite_metal_encode_argmax_logits_suppress_on_encoder(
+            runtime,
+            encoder,
+            logits_buffer,
+            logits_offset,
+            out_dim,
+            suppress_buffer,
+            suppress_count,
+            -9);
+        [encoder endEncoding];
+        if (encode_rc != 0) return encode_rc;
+        if (!frame_owned) {
+            int flush_rc = termite_metal_decode_runtime_flush_active_frame(runtime);
+            if (flush_rc != 0) return -10;
+        } else {
+            [command_buffer commit];
+            [command_buffer waitUntilCompleted];
+            if (command_buffer.status != MTLCommandBufferStatusCompleted) return -11;
+        }
+        uint32_t *result = (uint32_t *)runtime->token_buffer.contents;
+        if (result == NULL) return -12;
+        output_token_id[0] = result[0];
+        if (restore_active_frame) {
+            int begin_rc = termite_metal_decode_runtime_begin_frame(runtime);
+            if (begin_rc != 0) return -13;
+        }
         return 0;
     }
 }

--- a/zig/pkg/inference/src/backends/metal_runtime.zig
+++ b/zig/pkg/inference/src/backends/metal_runtime.zig
@@ -21260,6 +21260,134 @@ test "metal native decoder runtime attention device bias mask matches host" {
     }
 }
 
+test "metal native decoder runtime florence window pack unpack matches host" {
+    if (!build_options.enable_metal) return error.SkipZigTest;
+    if (!metalDeviceAvailable()) return error.SkipZigTest;
+
+    const metal_native_provider = @import("metal_native_provider.zig");
+    var provider = try metal_native_provider.MetalNativeProvider.create();
+    defer provider.deinitOwned();
+    if (!provider.hasDecoderRuntime()) return error.SkipZigTest;
+
+    const runtime = provider.raw_decode_runtime orelse return error.SkipZigTest;
+    const input_data = [_]f32{
+        1.0,  2.0,
+        3.0,  4.0,
+        5.0,  6.0,
+        7.0,  8.0,
+        9.0,  10.0,
+        11.0, 12.0,
+    };
+    var input = try testDeviceTensorFromSlice(runtime, &input_data, &[_]i32{ 6, 2 });
+    defer input.deinit();
+
+    var packed_windows = (try decoderRuntimeFlorenceWindowPackF32Device(&provider, input, 1, 2, 3, 2, 2)) orelse return error.UnexpectedNull;
+    defer packed_windows.deinit();
+    try std.testing.expect(packed_windows.isDevice());
+
+    const packed_values = try packed_windows.toHostSlice();
+    try std.testing.expectEqualSlices(f32, &.{
+        1.0,  2.0,  3.0, 4.0,
+        7.0,  8.0,  9.0, 10.0,
+        5.0,  6.0,  0.0, 0.0,
+        11.0, 12.0, 0.0, 0.0,
+    }, packed_values);
+
+    var unpacked = (try decoderRuntimeFlorenceWindowUnpackF32Device(&provider, packed_windows, 1, 2, 3, 2, 2)) orelse return error.UnexpectedNull;
+    defer unpacked.deinit();
+    try std.testing.expect(unpacked.isDevice());
+
+    const unpacked_values = try unpacked.toHostSlice();
+    try std.testing.expectEqualSlices(f32, &input_data, unpacked_values);
+}
+
+fn testFlorenceChannelAttentionHost(
+    output: []f32,
+    qkv: []const f32,
+    batch: usize,
+    seq_len: usize,
+    dim: usize,
+    groups: usize,
+) void {
+    const channels_per_group = dim / groups;
+    const scale = 1.0 / @sqrt(@as(f32, @floatFromInt(seq_len)));
+    var scores_buf: [64 * 64]f32 = undefined;
+
+    for (0..batch) |b| {
+        for (0..groups) |g| {
+            const group_offset = g * channels_per_group;
+            const scores = scores_buf[0 .. channels_per_group * channels_per_group];
+            @memset(scores, 0.0);
+
+            for (0..channels_per_group) |qc| {
+                const row = scores[qc * channels_per_group ..][0..channels_per_group];
+                for (0..channels_per_group) |kc| {
+                    var acc: f32 = 0.0;
+                    for (0..seq_len) |n| {
+                        const base = ((b * seq_len + n) * dim * 3) + group_offset;
+                        acc += qkv[base + qc] * qkv[base + dim + kc];
+                    }
+                    row[kc] = acc * scale;
+                }
+
+                var best = row[0];
+                for (row[1..]) |value| best = @max(best, value);
+                var sum: f32 = 0.0;
+                for (row) |*value| {
+                    value.* = @exp(value.* - best);
+                    sum += value.*;
+                }
+                const inv_sum = if (sum > 0.0) 1.0 / sum else 0.0;
+                for (row) |*value| value.* *= inv_sum;
+            }
+
+            for (0..seq_len) |n| {
+                const dst = (b * seq_len + n) * dim + group_offset;
+                const value_base = ((b * seq_len + n) * dim * 3) + 2 * dim + group_offset;
+                for (0..channels_per_group) |qc| {
+                    var acc: f32 = 0.0;
+                    for (0..channels_per_group) |vc| {
+                        acc += scores[qc * channels_per_group + vc] * qkv[value_base + vc];
+                    }
+                    output[dst + qc] = acc;
+                }
+            }
+        }
+    }
+}
+
+test "metal native decoder runtime florence channel attention matches host" {
+    if (!build_options.enable_metal) return error.SkipZigTest;
+    if (!metalDeviceAvailable()) return error.SkipZigTest;
+
+    const metal_native_provider = @import("metal_native_provider.zig");
+    var provider = try metal_native_provider.MetalNativeProvider.create();
+    defer provider.deinitOwned();
+    if (!provider.hasDecoderRuntime()) return error.SkipZigTest;
+
+    const runtime = provider.raw_decode_runtime orelse return error.SkipZigTest;
+    var qkv_data: [1 * 3 * 4 * 3]f32 = undefined;
+    for (&qkv_data, 0..) |*value, i| {
+        const centered: i32 = @intCast((i * 7) % 17);
+        value.* = @as(f32, @floatFromInt(centered - 8)) * 0.125;
+    }
+
+    var expected: [1 * 3 * 4]f32 = undefined;
+    testFlorenceChannelAttentionHost(&expected, &qkv_data, 1, 3, 4, 2);
+
+    var qkv = try testDeviceTensorFromSlice(runtime, &qkv_data, &[_]i32{ 3, 12 });
+    defer qkv.deinit();
+    var output = (try decoderRuntimeFlorenceChannelAttentionF32Device(&provider, qkv, 1, 3, 4, 2)) orelse return error.UnexpectedNull;
+    defer output.deinit();
+    try std.testing.expect(output.isDevice());
+
+    const actual = try output.toHostSlice();
+    try std.testing.expectEqual(expected.len, actual.len);
+    for (expected, actual) |want, got| {
+        try std.testing.expectApproxEqAbs(want, got, 1e-5);
+    }
+}
+
 test "metal native decoder runtime dense linear and rms-linear preserve device tensors" {
     if (!build_options.enable_metal) return error.SkipZigTest;
     if (!metalDeviceAvailable()) return error.SkipZigTest;

--- a/zig/pkg/inference/src/backends/metal_runtime.zig
+++ b/zig/pkg/inference/src/backends/metal_runtime.zig
@@ -2072,6 +2072,30 @@ pub fn argmaxLogitsDevice(self: anytype, input: MetalTensor, out_dim: usize) !?u
     return token_id;
 }
 
+pub fn argmaxLogitsSuppressDevice(self: anytype, input: MetalTensor, out_dim: usize, suppress_token_ids: []const i32) !?usize {
+    if (suppress_token_ids.len == 0) return argmaxLogitsDevice(self, input, out_dim);
+    const runtime = self.raw_decode_runtime orelse return null;
+    if (termite_metal_decode_runtime_ready(runtime) == 0) return null;
+    if (!input.isDevice()) return null;
+    if (out_dim == 0) return null;
+    if (input.ndim() != 2) return null;
+    if (@as(usize, @intCast(input.dim(0))) != 1) return null;
+    if (@as(usize, @intCast(input.dim(1))) != out_dim) return null;
+
+    var token_id: u32 = 0;
+    const rc = termite_metal_decode_runtime_argmax_from_logits_suppress_device(
+        runtime,
+        input.deviceHandle(),
+        input.deviceByteOffset(),
+        out_dim,
+        suppress_token_ids.ptr,
+        suppress_token_ids.len,
+        &token_id,
+    );
+    if (rc != 0) return null;
+    return token_id;
+}
+
 pub fn encodeArgmaxLogitsDevice(self: anytype, input: MetalTensor, out_dim: usize) !bool {
     const runtime = self.raw_decode_runtime orelse return false;
     if (termite_metal_decode_runtime_ready(runtime) == 0) return false;
@@ -3692,6 +3716,122 @@ pub fn decoderRuntimeSdpaF32Device(self: anytype, request: anytype) !?MetalTenso
         if (mask_tensor != null) 1 else 0,
         output_device.deviceHandle(),
         output_device.deviceByteOffset(),
+    );
+    if (rc != 0) return null;
+    return output_device;
+}
+
+pub fn decoderRuntimeFlorenceWindowPackF32Device(
+    self: anytype,
+    input: MetalTensor,
+    batch: usize,
+    height: usize,
+    width: usize,
+    dim: usize,
+    window_size: usize,
+) !?MetalTensor {
+    const runtime = self.raw_decode_runtime orelse return null;
+    if (termite_metal_decode_runtime_ready(runtime) == 0) return null;
+    if (!input.isDevice()) return null;
+    if (batch == 0 or height == 0 or width == 0 or dim == 0 or window_size == 0) return null;
+    if (input.elemCount() != batch * height * width * dim) return null;
+    const pad_h = (window_size - (height % window_size)) % window_size;
+    const pad_w = (window_size - (width % window_size)) % window_size;
+    const padded_h = height + pad_h;
+    const padded_w = width + pad_w;
+    const windows_h = padded_h / window_size;
+    const windows_w = padded_w / window_size;
+    const window_area = window_size * window_size;
+    const window_count = batch * windows_h * windows_w;
+    const out_rows = window_count * window_area;
+    const output_shape = [_]i32{ @intCast(out_rows), @intCast(dim) };
+    var output_device = try MetalTensor.deviceAllocate(runtime, out_rows * dim * @sizeOf(f32), .private, &output_shape);
+    errdefer output_device.deinit();
+    const rc = termite_metal_decode_runtime_florence_window_pack_f32_device(
+        runtime,
+        input.deviceHandle(),
+        input.deviceByteOffset(),
+        output_device.deviceHandle(),
+        output_device.deviceByteOffset(),
+        batch,
+        height,
+        width,
+        dim,
+        window_size,
+    );
+    if (rc != 0) return null;
+    return output_device;
+}
+
+pub fn decoderRuntimeFlorenceWindowUnpackF32Device(
+    self: anytype,
+    input: MetalTensor,
+    batch: usize,
+    height: usize,
+    width: usize,
+    dim: usize,
+    window_size: usize,
+) !?MetalTensor {
+    const runtime = self.raw_decode_runtime orelse return null;
+    if (termite_metal_decode_runtime_ready(runtime) == 0) return null;
+    if (!input.isDevice()) return null;
+    if (batch == 0 or height == 0 or width == 0 or dim == 0 or window_size == 0) return null;
+    const pad_h = (window_size - (height % window_size)) % window_size;
+    const pad_w = (window_size - (width % window_size)) % window_size;
+    const padded_h = height + pad_h;
+    const padded_w = width + pad_w;
+    const windows_h = padded_h / window_size;
+    const windows_w = padded_w / window_size;
+    const window_area = window_size * window_size;
+    const window_count = batch * windows_h * windows_w;
+    if (input.elemCount() != window_count * window_area * dim) return null;
+    const out_rows = batch * height * width;
+    const output_shape = [_]i32{ @intCast(out_rows), @intCast(dim) };
+    var output_device = try MetalTensor.deviceAllocate(runtime, out_rows * dim * @sizeOf(f32), .private, &output_shape);
+    errdefer output_device.deinit();
+    const rc = termite_metal_decode_runtime_florence_window_unpack_f32_device(
+        runtime,
+        input.deviceHandle(),
+        input.deviceByteOffset(),
+        output_device.deviceHandle(),
+        output_device.deviceByteOffset(),
+        batch,
+        height,
+        width,
+        dim,
+        window_size,
+    );
+    if (rc != 0) return null;
+    return output_device;
+}
+
+pub fn decoderRuntimeFlorenceChannelAttentionF32Device(
+    self: anytype,
+    qkv: MetalTensor,
+    batch: usize,
+    seq_len: usize,
+    dim: usize,
+    groups: usize,
+) !?MetalTensor {
+    const runtime = self.raw_decode_runtime orelse return null;
+    if (termite_metal_decode_runtime_ready(runtime) == 0) return null;
+    if (!qkv.isDevice()) return null;
+    if (batch == 0 or seq_len == 0 or dim == 0 or groups == 0 or dim % groups != 0) return null;
+    if (qkv.elemCount() != batch * seq_len * dim * 3) return null;
+    const out_rows = batch * seq_len;
+    const output_shape = [_]i32{ @intCast(out_rows), @intCast(dim) };
+    var output_device = try MetalTensor.deviceAllocate(runtime, out_rows * dim * @sizeOf(f32), .private, &output_shape);
+    errdefer output_device.deinit();
+    const rc = termite_metal_decode_runtime_florence_channel_attention_f32_device(
+        runtime,
+        qkv.deviceHandle(),
+        qkv.deviceByteOffset(),
+        output_device.deviceHandle(),
+        output_device.deviceByteOffset(),
+        batch,
+        seq_len,
+        dim,
+        groups,
     );
     if (rc != 0) return null;
     return output_device;
@@ -7347,6 +7487,15 @@ pub extern fn termite_metal_decode_runtime_argmax_from_logits_device(
     out_dim: usize,
     output_token_id: [*c]u32,
 ) c_int;
+pub extern fn termite_metal_decode_runtime_argmax_from_logits_suppress_device(
+    runtime: ?*RawMetalDecodeRuntime,
+    logits_handle: ?*anyopaque,
+    logits_offset: usize,
+    out_dim: usize,
+    suppress_token_ids: [*c]const i32,
+    suppress_count: usize,
+    output_token_id: [*c]u32,
+) c_int;
 pub extern fn termite_metal_decode_runtime_encode_argmax_from_logits_device(
     runtime: ?*RawMetalDecodeRuntime,
     logits_handle: ?*anyopaque,
@@ -7721,6 +7870,41 @@ pub extern fn termite_metal_decode_runtime_sdpa_f32_device(
     has_mask: u32,
     output_handle: ?*anyopaque,
     output_offset: usize,
+) c_int;
+pub extern fn termite_metal_decode_runtime_florence_window_pack_f32_device(
+    runtime: ?*RawMetalDecodeRuntime,
+    input_handle: ?*anyopaque,
+    input_offset: usize,
+    output_handle: ?*anyopaque,
+    output_offset: usize,
+    batch: usize,
+    height: usize,
+    width: usize,
+    dim: usize,
+    window_size: usize,
+) c_int;
+pub extern fn termite_metal_decode_runtime_florence_window_unpack_f32_device(
+    runtime: ?*RawMetalDecodeRuntime,
+    input_handle: ?*anyopaque,
+    input_offset: usize,
+    output_handle: ?*anyopaque,
+    output_offset: usize,
+    batch: usize,
+    height: usize,
+    width: usize,
+    dim: usize,
+    window_size: usize,
+) c_int;
+pub extern fn termite_metal_decode_runtime_florence_channel_attention_f32_device(
+    runtime: ?*RawMetalDecodeRuntime,
+    qkv_handle: ?*anyopaque,
+    qkv_offset: usize,
+    output_handle: ?*anyopaque,
+    output_offset: usize,
+    batch: usize,
+    seq_len: usize,
+    dim: usize,
+    groups: usize,
 ) c_int;
 pub extern fn termite_metal_decode_runtime_disentangled_relative_attention_f32_device(
     runtime: ?*RawMetalDecodeRuntime,
@@ -21391,6 +21575,36 @@ test "metal native decoder runtime dense linear and rms-linear preserve device t
         .out_dim = out_dim,
     })) orelse return error.UnexpectedNull;
     try std.testing.expect(token_id < out_dim);
+}
+
+test "metal native decoder runtime argmax suppress stays device resident" {
+    if (!build_options.enable_metal) return error.SkipZigTest;
+    if (!metalDeviceAvailable()) return error.SkipZigTest;
+
+    const metal_native_provider = @import("metal_native_provider.zig");
+    var provider = try metal_native_provider.MetalNativeProvider.create();
+    defer provider.deinitOwned();
+    if (!provider.hasDecoderRuntime()) return error.SkipZigTest;
+
+    const runtime = provider.raw_decode_runtime orelse return error.SkipZigTest;
+    const out_dim: usize = 4096;
+    const logits = try std.testing.allocator.alloc(f32, out_dim);
+    defer std.testing.allocator.free(logits);
+    @memset(logits, -100.0);
+    logits[17] = 11.0;
+    logits[1025] = 10.0;
+    logits[3001] = 12.0;
+
+    var logits_tensor = try testDeviceTensorFromSlice(runtime, logits, &[_]i32{ 1, @intCast(out_dim) });
+    defer logits_tensor.deinit();
+
+    try std.testing.expectEqual(@as(usize, 3001), (try argmaxLogitsDevice(&provider, logits_tensor, out_dim)) orelse return error.UnexpectedNull);
+
+    const suppress_best = [_]i32{3001};
+    try std.testing.expectEqual(@as(usize, 17), (try argmaxLogitsSuppressDevice(&provider, logits_tensor, out_dim, &suppress_best)) orelse return error.UnexpectedNull);
+
+    const suppress_two = [_]i32{ 3001, 17 };
+    try std.testing.expectEqual(@as(usize, 1025), (try argmaxLogitsSuppressDevice(&provider, logits_tensor, out_dim, &suppress_two)) orelse return error.UnexpectedNull);
 }
 
 test "metal native decoder runtime can prepare bf16 linear without copying model-owned bytes" {

--- a/zig/pkg/inference/src/models/manifest.zig
+++ b/zig/pkg/inference/src/models/manifest.zig
@@ -322,6 +322,20 @@ pub const ModelManifest = struct {
             self.processor_config_path == null;
     }
 
+    pub fn isFlorence2GgufBundle(self: *const ModelManifest) bool {
+        return std.mem.eql(u8, self.inference_bundle_family, "florence2_gguf_bundle/v1");
+    }
+
+    pub fn hasIncompleteFlorence2GgufBundle(self: *const ModelManifest) bool {
+        if (!self.isFlorence2GgufBundle()) return false;
+        return self.gguf_path == null or
+            self.config_path == null or
+            self.model_manifest_path == null or
+            self.tokenizer_json_path == null or
+            self.tokenizer_config_path == null or
+            self.preprocessor_config_path == null;
+    }
+
     pub fn hasInput(self: *const ModelManifest, input: []const u8) bool {
         for (self.inputs) |candidate| {
             if (std.mem.eql(u8, candidate, input)) return true;
@@ -1432,6 +1446,16 @@ fn parseInferenceBundleJson(manifest: *ModelManifest, allocator: std.mem.Allocat
             manifest.config_model_arch = allocator.dupe(u8, "clipclap") catch "";
             try setManifestInputs(allocator, manifest, &.{ "text", "image", "audio" });
         }
+        if (std.mem.eql(u8, bundle_family, "florence2_gguf_bundle/v1")) {
+            const model = obj.get("model") orelse obj.get("gguf") orelse return;
+            if (model == .string and model.string.len > 0) {
+                try applyFlorence2GgufBundle(
+                    manifest,
+                    allocator,
+                    try resolveBundlePath(allocator, model_dir_path, model.string),
+                );
+            }
+        }
     }
 }
 
@@ -1469,6 +1493,9 @@ fn parseInferenceVariantsJson(manifest: *ModelManifest, allocator: std.mem.Alloc
     const obj = parsed.value.object;
     const variants_family = obj.get("family") orelse return;
     if (variants_family != .string) return;
+    if (std.mem.eql(u8, variants_family.string, "florence2_variants/v1")) {
+        return parseFlorence2InferenceVariantsJson(manifest, allocator, model_dir_path, obj);
+    }
     if (std.mem.eql(u8, variants_family.string, "gliner2_variants/v1")) {
         return parseGliner2InferenceVariantsJson(manifest, allocator, model_dir_path, obj);
     }
@@ -1571,6 +1598,68 @@ fn parseGliner2InferenceVariantsJson(
     try setManifestInputs(allocator, manifest, &.{"text"});
 }
 
+fn parseFlorence2InferenceVariantsJson(
+    manifest: *ModelManifest,
+    allocator: std.mem.Allocator,
+    model_dir_path: []const u8,
+    obj: std.json.ObjectMap,
+) !void {
+    const variants = obj.get("variants") orelse return;
+    if (variants != .array) return;
+
+    var selected: ?ResolvedFlorence2Gguf = null;
+    errdefer if (selected) |*model| model.deinit(allocator);
+    for (variants.array.items) |variant| {
+        if (!isFlorence2GgufVariant(variant)) continue;
+        var model = (try resolveExistingFlorence2GgufVariant(allocator, model_dir_path, variant)) orelse continue;
+        if (variant.object.get("format")) |format| {
+            if (format == .string and std.mem.eql(u8, format.string, "Q4_K")) {
+                if (selected) |*old| old.deinit(allocator);
+                selected = model;
+                break;
+            }
+        }
+        if (selected == null) {
+            selected = model;
+        } else {
+            model.deinit(allocator);
+        }
+    }
+
+    var model = selected orelse return;
+    selected = null;
+    errdefer model.deinit(allocator);
+
+    try applyFlorence2GgufBundle(manifest, allocator, model.model_path);
+    model.model_path = "";
+}
+
+fn applyFlorence2GgufBundle(
+    manifest: *ModelManifest,
+    allocator: std.mem.Allocator,
+    gguf_path: []const u8,
+) !void {
+    var path = gguf_path;
+    errdefer if (path.len > 0) allocator.free(path);
+
+    var family = try allocator.dupe(u8, "florence2_gguf_bundle/v1");
+    errdefer if (family.len > 0) allocator.free(family);
+    var arch = try allocator.dupe(u8, "florence2");
+    errdefer if (arch.len > 0) allocator.free(arch);
+
+    if (manifest.inference_bundle_family.len > 0) allocator.free(manifest.inference_bundle_family);
+    manifest.inference_bundle_family = family;
+    family = "";
+    setOptionalPath(allocator, &manifest.gguf_path, path);
+    path = "";
+    manifest.native_arch_hint = .florence;
+    manifest.model_type = .reader;
+    if (manifest.config_model_arch.len > 0) allocator.free(manifest.config_model_arch);
+    manifest.config_model_arch = arch;
+    arch = "";
+    try setManifestInputs(allocator, manifest, &.{ "text", "image" });
+}
+
 fn setManifestInputs(allocator: std.mem.Allocator, manifest: *ModelManifest, inputs: []const []const u8) !void {
     if (manifest.inputs.len > 0) {
         for (manifest.inputs) |input| allocator.free(input);
@@ -1611,6 +1700,15 @@ const ResolvedGliner2GgufPair = struct {
         if (self.encoder_path.len > 0) allocator.free(self.encoder_path);
         if (self.head_path.len > 0) allocator.free(self.head_path);
         self.* = .{ .encoder_path = "", .head_path = "" };
+    }
+};
+
+const ResolvedFlorence2Gguf = struct {
+    model_path: []const u8,
+
+    fn deinit(self: *ResolvedFlorence2Gguf, allocator: std.mem.Allocator) void {
+        if (self.model_path.len > 0) allocator.free(self.model_path);
+        self.* = .{ .model_path = "" };
     }
 };
 
@@ -1658,6 +1756,23 @@ fn resolveExistingGliner2GgufVariant(
     return .{ .encoder_path = encoder_path, .head_path = head_path };
 }
 
+fn resolveExistingFlorence2GgufVariant(
+    allocator: std.mem.Allocator,
+    model_dir_path: []const u8,
+    variant: std.json.Value,
+) !?ResolvedFlorence2Gguf {
+    const model = variant.object.get("model") orelse variant.object.get("gguf") orelse return null;
+    if (model != .string or model.string.len == 0) return null;
+
+    const model_path = try resolveBundlePath(allocator, model_dir_path, model.string);
+    errdefer allocator.free(model_path);
+    if (!c_file.fileExists(allocator, model_path)) {
+        allocator.free(model_path);
+        return null;
+    }
+    return .{ .model_path = model_path };
+}
+
 fn isClipclapGgufVariant(variant: std.json.Value) bool {
     if (variant != .object) return false;
     const target = variant.object.get("target") orelse return false;
@@ -1674,6 +1789,14 @@ fn isGliner2GgufVariant(variant: std.json.Value) bool {
     const encoder = variant.object.get("encoder") orelse return false;
     const head = variant.object.get("head") orelse return false;
     return encoder == .string and encoder.string.len > 0 and head == .string and head.string.len > 0;
+}
+
+fn isFlorence2GgufVariant(variant: std.json.Value) bool {
+    if (variant != .object) return false;
+    const target = variant.object.get("target") orelse return false;
+    if (target != .string or !std.mem.eql(u8, target.string, "gguf")) return false;
+    const model = variant.object.get("model") orelse variant.object.get("gguf") orelse return false;
+    return model == .string and model.string.len > 0;
 }
 
 fn resolveBundlePath(allocator: std.mem.Allocator, model_dir_path: []const u8, path: []const u8) ![]const u8 {
@@ -2126,6 +2249,26 @@ test "manifest parses clipclap gguf bundle marker" {
     try std.testing.expect(manifest.hasInput("audio"));
 }
 
+test "manifest parses florence2 gguf bundle marker" {
+    const allocator = std.testing.allocator;
+    var manifest = ModelManifest{ .allocator = allocator };
+    defer manifest.deinit();
+
+    try parseInferenceBundleJson(&manifest, allocator, "/tmp/florence2-q4_k",
+        \\{"family":"florence2_gguf_bundle/v1","model":"florence-2-base.Q4_K.gguf","inputs":["text","image"]}
+    );
+
+    try std.testing.expect(manifest.isFlorence2GgufBundle());
+    try std.testing.expect(manifest.hasIncompleteFlorence2GgufBundle());
+    try std.testing.expectEqual(ModelType.reader, manifest.model_type);
+    try std.testing.expectEqual(NativeArchHint.florence, manifest.native_arch_hint);
+    try std.testing.expectEqualStrings("florence2", manifest.config_model_arch);
+    try std.testing.expect(manifest.gguf_path != null);
+    try std.testing.expect(std.mem.endsWith(u8, manifest.gguf_path.?, "/tmp/florence2-q4_k/florence-2-base.Q4_K.gguf"));
+    try std.testing.expect(manifest.hasInput("text"));
+    try std.testing.expect(manifest.hasInput("image"));
+}
+
 test "manifest discovers clip onnx variants and prefers f16 over i8" {
     const allocator = std.testing.allocator;
     const model_dir = try testScratchDir(allocator, "manifest-clip-onnx-f16-preferred");
@@ -2424,6 +2567,146 @@ test "manifest parses gliner2 variants gguf pair" {
     try std.testing.expectEqualStrings(encoder_path, manifest.gguf_path.?);
     try std.testing.expectEqualStrings(head_path, manifest.gliner_head_gguf_path.?);
     try std.testing.expect(manifest.hasInput("text"));
+}
+
+test "manifest parses florence2 variants gguf model" {
+    const allocator = std.testing.allocator;
+    const dir_path = try testScratchDir(allocator, "manifest-florence2-variants-gguf");
+    defer {
+        compat.cwd().deleteTree(compat.io(), dir_path) catch {};
+        allocator.free(dir_path);
+    }
+    const q4_path = try std.fs.path.join(allocator, &.{ dir_path, "florence-2-base.Q4_K.gguf" });
+    defer allocator.free(q4_path);
+    try compat.cwd().writeFile(compat.io(), .{ .sub_path = q4_path, .data = "GGUFstub" });
+
+    var manifest = ModelManifest{ .allocator = allocator };
+    defer manifest.deinit();
+
+    try parseInferenceVariantsJson(&manifest, allocator, dir_path,
+        \\{
+        \\  "family": "florence2_variants/v1",
+        \\  "variants": [
+        \\    {
+        \\      "id": "gguf-Q4_K",
+        \\      "target": "gguf",
+        \\      "format": "Q4_K",
+        \\      "model": "florence-2-base.Q4_K.gguf"
+        \\    }
+        \\  ]
+        \\}
+    );
+
+    try std.testing.expect(manifest.isFlorence2GgufBundle());
+    try std.testing.expectEqual(ModelType.reader, manifest.model_type);
+    try std.testing.expectEqual(NativeArchHint.florence, manifest.native_arch_hint);
+    try std.testing.expectEqualStrings("florence2", manifest.config_model_arch);
+    try std.testing.expectEqualStrings(q4_path, manifest.gguf_path.?);
+    try std.testing.expect(manifest.hasInput("text"));
+    try std.testing.expect(manifest.hasInput("image"));
+}
+
+test "manifest loads canonical antfly florence2 variants before first gguf fallback" {
+    const allocator = std.testing.allocator;
+    const dir_path = try testScratchDir(allocator, "manifest-florence2-canonical-variants");
+    defer {
+        compat.cwd().deleteTree(compat.io(), dir_path) catch {};
+        allocator.free(dir_path);
+    }
+    const q8_path = try std.fs.path.join(allocator, &.{ dir_path, "florence-2-base.Q8_0.gguf" });
+    defer allocator.free(q8_path);
+    const q4_path = try std.fs.path.join(allocator, &.{ dir_path, "florence-2-base.Q4_K.gguf" });
+    defer allocator.free(q4_path);
+    try compat.cwd().writeFile(compat.io(), .{ .sub_path = q8_path, .data = "GGUFstub" });
+    try compat.cwd().writeFile(compat.io(), .{ .sub_path = q4_path, .data = "GGUFstub" });
+
+    const config_path = try std.fs.path.join(allocator, &.{ dir_path, "config.json" });
+    defer allocator.free(config_path);
+    try compat.cwd().writeFile(compat.io(), .{
+        .sub_path = config_path,
+        .data = "{\"model_type\":\"florence2\",\"text_config\":{\"d_model\":768},\"vision_config\":{\"image_size\":768}}",
+    });
+    const model_manifest_path = try std.fs.path.join(allocator, &.{ dir_path, "model_manifest.json" });
+    defer allocator.free(model_manifest_path);
+    try compat.cwd().writeFile(compat.io(), .{
+        .sub_path = model_manifest_path,
+        .data = "{\"type\":\"reader\",\"tasks\":[\"read\"],\"inputs\":[\"text\",\"image\"]}",
+    });
+    const tokenizer_path = try std.fs.path.join(allocator, &.{ dir_path, "tokenizer.json" });
+    defer allocator.free(tokenizer_path);
+    try compat.cwd().writeFile(compat.io(), .{ .sub_path = tokenizer_path, .data = "{}" });
+    const tokenizer_config_path = try std.fs.path.join(allocator, &.{ dir_path, "tokenizer_config.json" });
+    defer allocator.free(tokenizer_config_path);
+    try compat.cwd().writeFile(compat.io(), .{ .sub_path = tokenizer_config_path, .data = "{}" });
+    const preprocessor_path = try std.fs.path.join(allocator, &.{ dir_path, "preprocessor_config.json" });
+    defer allocator.free(preprocessor_path);
+    try compat.cwd().writeFile(compat.io(), .{ .sub_path = preprocessor_path, .data = "{\"size\":{\"height\":768,\"width\":768}}" });
+
+    const variants_path = try std.fs.path.join(allocator, &.{ dir_path, "antfly_inference_variants.json" });
+    defer allocator.free(variants_path);
+    try compat.cwd().writeFile(compat.io(), .{
+        .sub_path = variants_path,
+        .data =
+        \\{
+        \\  "family": "florence2_variants/v1",
+        \\  "variants": [
+        \\    {
+        \\      "id": "gguf-Q8_0",
+        \\      "target": "gguf",
+        \\      "format": "Q8_0",
+        \\      "model": "florence-2-base.Q8_0.gguf"
+        \\    },
+        \\    {
+        \\      "id": "gguf-Q4_K",
+        \\      "target": "gguf",
+        \\      "format": "Q4_K",
+        \\      "model": "florence-2-base.Q4_K.gguf"
+        \\    }
+        \\  ]
+        \\}
+        ,
+    });
+
+    var manifest = try loadFromDir(allocator, dir_path);
+    defer manifest.deinit();
+
+    try std.testing.expect(manifest.isFlorence2GgufBundle());
+    try std.testing.expect(!manifest.hasIncompleteFlorence2GgufBundle());
+    try std.testing.expectEqual(ModelType.reader, manifest.model_type);
+    try std.testing.expectEqual(NativeArchHint.florence, manifest.native_arch_hint);
+    try std.testing.expectEqualStrings("florence2", manifest.config_model_arch);
+    try std.testing.expectEqualStrings(q4_path, manifest.gguf_path.?);
+    try std.testing.expect(manifest.hasInput("text"));
+    try std.testing.expect(manifest.hasInput("image"));
+}
+
+test "manifest ignores stale florence2 variants with missing gguf files" {
+    const allocator = std.testing.allocator;
+    const dir_path = try testScratchDir(allocator, "manifest-florence2-stale-variants");
+    defer {
+        compat.cwd().deleteTree(compat.io(), dir_path) catch {};
+        allocator.free(dir_path);
+    }
+
+    var manifest = ModelManifest{ .allocator = allocator };
+    defer manifest.deinit();
+
+    try parseInferenceVariantsJson(&manifest, allocator, dir_path,
+        \\{
+        \\  "family": "florence2_variants/v1",
+        \\  "variants": [
+        \\    {
+        \\      "id": "gguf-Q4_K",
+        \\      "target": "gguf",
+        \\      "format": "Q4_K",
+        \\      "model": "florence-2-base.Q4_K.gguf"
+        \\    }
+        \\  ]
+        \\}
+    );
+
+    try std.testing.expect(!manifest.isFlorence2GgufBundle());
+    try std.testing.expectEqual(@as(?[]const u8, null), manifest.gguf_path);
 }
 
 test "manifest uses clipclap variants when default ONNX bundle is partial" {

--- a/zig/pkg/inference/src/models/tensor_store.zig
+++ b/zig/pkg/inference/src/models/tensor_store.zig
@@ -1077,6 +1077,7 @@ pub const CompositeGlinerStore = struct {
 
 pub fn openFromManifest(allocator: std.mem.Allocator, manifest: manifest_mod.ModelManifest) !TensorStore {
     if (manifest.hasIncompleteGlinerBundle()) return error.IncompleteGlinerBundle;
+    if (manifest.hasIncompleteFlorence2GgufBundle()) return error.IncompleteFlorence2Bundle;
     if (manifest.gliner_model_type.len > 0 and manifest.gguf_path != null and (manifest.gliner_head_gguf_path != null or manifest.gliner_head_safetensors_path != null)) {
         const head_path = manifest.gliner_head_gguf_path orelse manifest.gliner_head_safetensors_path.?;
         const store = try CompositeGlinerStore.initAbsolute(allocator, manifest.gguf_path.?, head_path, manifest.gliner_head_gguf_path != null);

--- a/zig/pkg/inference/src/native_export_gguf.zig
+++ b/zig/pkg/inference/src/native_export_gguf.zig
@@ -358,6 +358,9 @@ fn writePlannedExport(
     if (isColqwenBundleExportManifest(manifest)) {
         try exportColqwenBundleSidecars(allocator, model_dir, output_path, manifest);
     }
+    if (isFlorence2ExportManifest(manifest)) {
+        try exportFlorence2BundleSidecars(allocator, model_dir, output_path);
+    }
 }
 
 fn writeSinglePlanExport(
@@ -393,6 +396,11 @@ fn isColqwenBundleExportManifest(manifest: manifest_mod.ModelManifest) bool {
 fn isClipclapExportManifest(manifest: manifest_mod.ModelManifest) bool {
     return std.mem.eql(u8, manifest.config_model_arch, "clipclap") or
         std.mem.eql(u8, manifest.inference_bundle_family, "clipclap_gguf_bundle/v1");
+}
+
+fn isFlorence2ExportManifest(manifest: manifest_mod.ModelManifest) bool {
+    return florence_mod.isFlorenceModel(manifest.config_model_arch) or
+        std.mem.eql(u8, manifest.inference_bundle_family, "florence2_gguf_bundle/v1");
 }
 
 const colqwen_required_sidecars = [_][]const u8{
@@ -561,6 +569,91 @@ fn synthesizeColqwenModelManifestJson(
         .capabilities = caps.items,
         .inputs = &[_][]const u8{ "text", "image" },
     }, .{});
+}
+
+const florence2_required_sidecars = [_][]const u8{
+    "config.json",
+    "tokenizer.json",
+    "tokenizer_config.json",
+    "preprocessor_config.json",
+};
+
+const florence2_optional_sidecars = [_][]const u8{
+    "processor_config.json",
+    "special_tokens_map.json",
+    "added_tokens.json",
+    "vocab.json",
+    "merges.txt",
+    "generation_config.json",
+    "chat_template.jinja",
+};
+
+fn exportFlorence2BundleSidecars(
+    allocator: std.mem.Allocator,
+    model_dir: []const u8,
+    output_path: []const u8,
+) !void {
+    const io = io_compat();
+    const out_dir = std.fs.path.dirname(output_path) orelse ".";
+    if (out_dir.len > 0) try compat.cwd().createDirPath(io, out_dir);
+
+    for (florence2_required_sidecars) |file_name| {
+        try copyRequiredFlorence2Sidecar(allocator, model_dir, out_dir, file_name);
+    }
+    for (florence2_optional_sidecars) |file_name| {
+        try copySidecarIfExists(allocator, model_dir, out_dir, file_name);
+    }
+
+    const model_manifest_out = try std.fs.path.join(allocator, &.{ out_dir, "model_manifest.json" });
+    defer allocator.free(model_manifest_out);
+    const manifest_json = try synthesizeFlorence2ModelManifestJson(allocator);
+    defer allocator.free(manifest_json);
+    try compat.cwd().writeFile(io, .{ .sub_path = model_manifest_out, .data = manifest_json });
+
+    try writeFlorence2BundleMarker(allocator, out_dir, output_path);
+    try variants_manifest.writeFlorence2VariantsManifest(allocator, io, out_dir);
+}
+
+fn copyRequiredFlorence2Sidecar(
+    allocator: std.mem.Allocator,
+    source_dir: []const u8,
+    out_dir: []const u8,
+    file_name: []const u8,
+) !void {
+    if (!c_file.fileExistsInDir(allocator, source_dir, file_name)) return error.MissingRequiredFlorence2Sidecar;
+    try copySidecarIfExists(allocator, source_dir, out_dir, file_name);
+}
+
+fn synthesizeFlorence2ModelManifestJson(allocator: std.mem.Allocator) ![]u8 {
+    return std.json.Stringify.valueAlloc(allocator, .{
+        .type = "reader",
+        .tasks = &[_][]const u8{"read"},
+        .capabilities = &[_][]const u8{ "extraction", "ocr", "captioning" },
+        .inputs = &[_][]const u8{ "text", "image" },
+    }, .{});
+}
+
+fn writeFlorence2BundleMarker(
+    allocator: std.mem.Allocator,
+    out_dir: []const u8,
+    output_path: []const u8,
+) !void {
+    const marker_path = try std.fs.path.join(allocator, &.{ out_dir, "antfly_inference_bundle.json" });
+    defer allocator.free(marker_path);
+    const marker_bytes = try std.json.Stringify.valueAlloc(allocator, .{
+        .family = "florence2_gguf_bundle/v1",
+        .model = std.fs.path.basename(output_path),
+        .required_sidecars = &florence2_required_sidecars,
+        .optional_sidecars = &florence2_optional_sidecars,
+        .tasks = &[_][]const u8{"read"},
+        .capabilities = &[_][]const u8{ "extraction", "ocr", "captioning" },
+        .inputs = &[_][]const u8{ "text", "image" },
+    }, .{});
+    defer allocator.free(marker_bytes);
+    try compat.cwd().writeFile(io_compat(), .{
+        .sub_path = marker_path,
+        .data = marker_bytes,
+    });
 }
 
 const clipclap_required_sidecars = [_][]const u8{
@@ -6407,6 +6500,15 @@ test "dense florence export writes florence metadata and tensors" {
         \\{"model_type":"florence2","text_config":{"d_model":8,"encoder_layers":1,"decoder_layers":1,"encoder_attention_heads":2,"decoder_attention_heads":2,"encoder_ffn_dim":16,"decoder_ffn_dim":16,"vocab_size":32,"max_position_embeddings":16},"vision_config":{"image_size":32,"hidden_size":8,"patch_size":[7,3,3,3],"patch_stride":[4,2,2,2],"patch_padding":[3,1,1,1],"patch_prenorm":[false,true,true,true],"dim_embed":[8,16,24,32],"num_heads":[1,2,3,4],"num_groups":[1,2,3,4],"depths":[1,1,2,1],"window_size":12,"image_pos_embed":{"max_pos_embeddings":50},"visual_temporal_embedding":{"max_temporal_embeddings":100},"image_feature_source":["spatial_avg_pool","last_frame"]},"projection_dim":8,"image_token_id":31,"bos_token_id":2,"eos_token_id":3,"pad_token_id":1,"decoder_start_token_id":2}
         ,
     });
+    try writeTestFileInDir(allocator, dir_path, "tokenizer.json",
+        \\{"version":"1.0","model":{"type":"BPE","vocab":{"<s>":2,"</s>":3,"<OCR>":4},"merges":[]}}
+    );
+    try writeTestFileInDir(allocator, dir_path, "tokenizer_config.json", "{}");
+    try writeTestFileInDir(allocator, dir_path, "preprocessor_config.json",
+        \\{"size":{"height":32,"width":32},"image_mean":[0.5,0.5,0.5],"image_std":[0.5,0.5,0.5]}
+    );
+    try writeTestFileInDir(allocator, dir_path, "vocab.json", "{}");
+    try writeTestFileInDir(allocator, dir_path, "merges.txt", "");
 
     const st_path = try std.fs.path.join(allocator, &.{ dir_path, "model.safetensors" });
     defer allocator.free(st_path);
@@ -6424,7 +6526,7 @@ test "dense florence export writes florence metadata and tensors" {
         .{ .name = "lm_head.weight", .shape = &.{ 32, 8 }, .data = &([_]f32{0.0} ** 256) },
     });
 
-    const out_path = try std.fs.path.join(allocator, &.{ dir_path, "florence.gguf" });
+    const out_path = try std.fs.path.join(allocator, &.{ dir_path, "florence-2-base.gguf" });
     defer allocator.free(out_path);
     try exportModelDirToGguf(allocator, dir_path, out_path, .none);
 
@@ -6449,6 +6551,30 @@ test "dense florence export writes florence metadata and tensors" {
     try std.testing.expect(catalog.find("language_model.model.decoder.layers.0.self_attn.k_proj.weight") != null);
     try std.testing.expect(catalog.find("language_model.final_logits_bias") != null);
     try std.testing.expect(catalog.find("lm_head.weight") != null);
+
+    const bundle_marker_path = try std.fs.path.join(allocator, &.{ dir_path, "antfly_inference_bundle.json" });
+    defer allocator.free(bundle_marker_path);
+    const bundle_marker = try c_file.readFile(allocator, bundle_marker_path);
+    defer allocator.free(bundle_marker);
+    try std.testing.expect(std.mem.indexOf(u8, bundle_marker, "\"family\":\"florence2_gguf_bundle/v1\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, bundle_marker, "\"model\":\"florence-2-base.gguf\"") != null);
+
+    const variants_path = try std.fs.path.join(allocator, &.{ dir_path, "antfly_inference_variants.json" });
+    defer allocator.free(variants_path);
+    const variants = try c_file.readFile(allocator, variants_path);
+    defer allocator.free(variants);
+    try std.testing.expect(std.mem.indexOf(u8, variants, "\"family\": \"florence2_variants/v1\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, variants, "\"model\": \"florence-2-base.gguf\"") != null);
+
+    var exported_manifest = try manifest_mod.loadFromDir(allocator, dir_path);
+    defer exported_manifest.deinit();
+    try std.testing.expect(exported_manifest.isFlorence2GgufBundle());
+    try std.testing.expect(!exported_manifest.hasIncompleteFlorence2GgufBundle());
+    try std.testing.expectEqual(manifest_mod.ModelType.reader, exported_manifest.model_type);
+    try std.testing.expect(exported_manifest.hasTask("read"));
+    try std.testing.expect(exported_manifest.hasCapability("extraction"));
+    try std.testing.expect(exported_manifest.hasInput("text"));
+    try std.testing.expect(exported_manifest.hasInput("image"));
 }
 
 test "gliner2 export writes split encoder gguf bundle" {
@@ -8012,6 +8138,12 @@ fn writeWideQuantFixture(allocator: std.mem.Allocator, dir_path: []const u8) !vo
         .{ .name = "model.layers.0.mlp.up_proj.weight", .shape = &.{ 256, 256 }, .data = wide },
         .{ .name = "model.layers.0.mlp.down_proj.weight", .shape = &.{ 256, 256 }, .data = wide },
     });
+}
+
+fn writeTestFileInDir(allocator: std.mem.Allocator, dir_path: []const u8, name: []const u8, data: []const u8) !void {
+    const path = try std.fs.path.join(allocator, &.{ dir_path, name });
+    defer allocator.free(path);
+    try compat.cwd().writeFile(compat.io(), .{ .sub_path = path, .data = data });
 }
 
 fn writeMinimalQuantizedGgufFixture(allocator: std.mem.Allocator, path: []const u8) !void {

--- a/zig/pkg/inference/src/native_export_gguf.zig
+++ b/zig/pkg/inference/src/native_export_gguf.zig
@@ -611,7 +611,7 @@ fn exportFlorence2BundleSidecars(
     try compat.cwd().writeFile(io, .{ .sub_path = model_manifest_out, .data = manifest_json });
 
     try writeFlorence2BundleMarker(allocator, out_dir, output_path);
-    try variants_manifest.writeFlorence2VariantsManifest(allocator, io, out_dir);
+    try variants_manifest.writeFlorence2VariantsManifestForModel(allocator, io, out_dir, std.fs.path.basename(output_path));
 }
 
 fn copyRequiredFlorence2Sidecar(

--- a/zig/pkg/inference/src/ops/metal_compute.zig
+++ b/zig/pkg/inference/src/ops/metal_compute.zig
@@ -215,6 +215,14 @@ fn traceAttentionResidualNullLayerTarget() ?usize {
     return getenvUsize("TERMITE_METAL_TRACE_ATTN_RESIDUAL_NULL_LAYER");
 }
 
+fn strictFlorence2ResidentMetal() bool {
+    return getenvBool("TERMITE_FLORENCE2_METAL_STRICT_RESIDENT");
+}
+
+fn traceFlorence2ResidentMetal() bool {
+    return getenvBool("TERMITE_FLORENCE2_METAL_TRACE_RESIDENT");
+}
+
 fn enableContiguousSliceDeviceView() bool {
     return getenvBool("TERMITE_METAL_ENABLE_CONTIGUOUS_SLICE_DEVICE_VIEW");
 }
@@ -3842,6 +3850,21 @@ pub const MetalCompute = if (build_options.enable_metal) struct {
         const shape_i64 = shape_override orelse buf.logical_shape orelse &[_]i64{@intCast(bufElemCount(buf))};
         const shape_i32 = try self.i32ShapeFromI64(shape_i64);
         defer self.allocator.free(shape_i32);
+        if (buf.quantized_storage) |storage| {
+            const host = try self.dequantizeStorageToFloat32(ct, storage, self.allocator);
+            defer self.allocator.free(host);
+            return native_ctx.cb.fromFloat32Shape(host, shape_i32);
+        }
+        if (buf.runtime_quantized_storage) |storage| {
+            const host = try self.dequantizeStorageToFloat32(ct, storage, self.allocator);
+            defer self.allocator.free(host);
+            return native_ctx.cb.fromFloat32Shape(host, shape_i32);
+        }
+        if (buf.owned_quantized_storage) |storage| {
+            const host = try self.dequantizeStorageToFloat32(ct, storage, self.allocator);
+            defer self.allocator.free(host);
+            return native_ctx.cb.fromFloat32Shape(host, shape_i32);
+        }
         if (buf.native_dense_bytes != null and buf.native_dense_dtype != null and buf.data.len == 0) {
             const expected_count = try shapeNumel(shape_i64);
             const host = try convertNativeDenseBytesToOwnedF32(
@@ -4149,6 +4172,69 @@ pub const MetalCompute = if (build_options.enable_metal) struct {
             else => null,
         };
         if (maybe_tensor) |tensor| return self.ctFromOwnedMetalTensor(tensor);
+        return null;
+    }
+
+    const Matrix2DShape = struct {
+        rows: usize,
+        cols: usize,
+    };
+
+    fn concreteMatrix2DShape(buf: *const Buf) ?Matrix2DShape {
+        if (buf.logical_shape) |shape| {
+            if (shape.len == 2 and shape[0] > 0 and shape[1] > 0) {
+                return .{ .rows = @intCast(shape[0]), .cols = @intCast(shape[1]) };
+            }
+        }
+        if (buf.metal_tensor) |*metal_tensor| {
+            if (metal_tensor.ndim() == 2 and metal_tensor.dim(0) > 0 and metal_tensor.dim(1) > 0) {
+                return .{ .rows = @intCast(metal_tensor.dim(0)), .cols = @intCast(metal_tensor.dim(1)) };
+            }
+        }
+        return null;
+    }
+
+    fn tryDeviceRowBroadcastAdd(
+        self: *MetalCompute,
+        row_ct: CT,
+        matrix_buf: *const Buf,
+        row_buf: *const Buf,
+    ) !?CT {
+        const matrix_shape = concreteMatrix2DShape(matrix_buf) orelse return null;
+        const row_len = bufElemCount(row_buf);
+        if (matrix_shape.rows == 0 or matrix_shape.cols == 0 or row_len != matrix_shape.cols) return null;
+        const matrix_metal = matrix_buf.metal_tensor orelse return null;
+        if (!matrix_metal.isDevice()) return null;
+
+        var lhs = try matrix_metal.retainedCopy();
+        defer lhs.deinit();
+        var row = try self.ownedDeviceMetalTensorFromCt(row_ct);
+        defer row.deinit();
+        if (!row.isDevice()) return null;
+
+        const output_elems = std.math.mul(usize, matrix_shape.rows, matrix_shape.cols) catch return error.InvalidTensorShape;
+        const output_shape = [_]i32{ @intCast(matrix_shape.rows), @intCast(matrix_shape.cols) };
+        const out_strides = [_]u32{ @intCast(matrix_shape.cols), 1 };
+        const input_strides = [_]u32{ 0, 1 };
+        var broadcasted = (try metal_runtime.decoderRuntimeBroadcastF32Device(
+            self.provider_impl,
+            row,
+            &out_strides,
+            &input_strides,
+            2,
+            matrix_shape.cols,
+            output_elems,
+            &output_shape,
+        )) orelse return null;
+        defer broadcasted.deinit();
+
+        if (try metal_runtime.decoderRuntimeApplyAdd(self.provider_impl, .{
+            .lhs = lhs,
+            .rhs = broadcasted,
+            .dim = output_elems,
+        }, &self.timing_stats)) |tensor| {
+            return self.ctFromOwnedMetalTensor(tensor);
+        }
         return null;
     }
 
@@ -4960,6 +5046,566 @@ pub const MetalCompute = if (build_options.enable_metal) struct {
             padding_w,
             groups,
         );
+    }
+
+    fn tokenGridConv2dOp(
+        ctx: *anyopaque,
+        input: CT,
+        weight: CT,
+        bias: CT,
+        batch: usize,
+        in_channels: usize,
+        out_channels: usize,
+        height: usize,
+        width: usize,
+        kernel_h: usize,
+        kernel_w: usize,
+        stride_h: usize,
+        stride_w: usize,
+        padding_h: usize,
+        padding_w: usize,
+        groups: usize,
+    ) anyerror!CT {
+        const out_h = (height + 2 * padding_h - kernel_h) / stride_h + 1;
+        const out_w = (width + 2 * padding_w - kernel_w) / stride_w + 1;
+
+        const token_4d_shape = [_]i64{
+            @intCast(batch),
+            @intCast(height),
+            @intCast(width),
+            @intCast(in_channels),
+        };
+        const token_4d = try primReshapeOp(ctx, input, &token_4d_shape);
+        defer freeOp(ctx, token_4d);
+
+        const to_nchw = [_]u8{ 0, 3, 1, 2 };
+        const image_nchw = try primTransposeOp(ctx, token_4d, &to_nchw, &token_4d_shape);
+        defer freeOp(ctx, image_nchw);
+
+        const conv_nchw = try conv2dOp(
+            ctx,
+            image_nchw,
+            weight,
+            bias,
+            batch,
+            in_channels,
+            out_channels,
+            height,
+            width,
+            kernel_h,
+            kernel_w,
+            stride_h,
+            stride_w,
+            padding_h,
+            padding_w,
+            groups,
+        );
+        defer freeOp(ctx, conv_nchw);
+
+        const conv_shape = [_]i64{
+            @intCast(batch),
+            @intCast(out_channels),
+            @intCast(out_h),
+            @intCast(out_w),
+        };
+        const to_nhwc = [_]u8{ 0, 2, 3, 1 };
+        const tokens_4d = try primTransposeOp(ctx, conv_nchw, &to_nhwc, &conv_shape);
+        defer freeOp(ctx, tokens_4d);
+
+        const out_token_shape = [_]i64{
+            @intCast(batch * out_h * out_w),
+            @intCast(out_channels),
+        };
+        return primReshapeOp(ctx, tokens_4d, &out_token_shape);
+    }
+
+    fn isDeviceResidentCt(tensor: CT) bool {
+        const buf = toBuf(tensor);
+        if (buf.metal_tensor) |*metal_tensor| return metal_tensor.isDevice();
+        return false;
+    }
+
+    fn requireFlorence2DeviceResident(tensor: CT) !void {
+        if (strictFlorence2ResidentMetal() and !isDeviceResidentCt(tensor)) return error.UnsupportedFlorence2ResidentMetal;
+    }
+
+    fn florenceWindowPackDevice(
+        self: *MetalCompute,
+        input: CT,
+        batch: usize,
+        height: usize,
+        width: usize,
+        dim: usize,
+        window_size: usize,
+    ) !?CT {
+        const input_buf = toBuf(input);
+        if (input_buf.quantized_storage != null or
+            input_buf.runtime_quantized_storage != null or
+            input_buf.owned_quantized_storage != null)
+        {
+            return null;
+        }
+        if (strictFlorence2ResidentMetal() and !isDeviceResidentCt(input)) return error.UnsupportedFlorence2ResidentMetal;
+        var input_mt = try self.ownedDeviceMetalTensorFromCt(input);
+        defer input_mt.deinit();
+        if (!input_mt.isDevice()) return null;
+        if (try metal_runtime.decoderRuntimeFlorenceWindowPackF32Device(
+            self.provider_impl,
+            input_mt,
+            batch,
+            height,
+            width,
+            dim,
+            window_size,
+        )) |tensor| {
+            return self.ctFromOwnedMetalTensor(tensor);
+        }
+        return null;
+    }
+
+    fn florenceWindowUnpackDevice(
+        self: *MetalCompute,
+        input: CT,
+        batch: usize,
+        height: usize,
+        width: usize,
+        dim: usize,
+        window_size: usize,
+    ) !?CT {
+        const input_buf = toBuf(input);
+        if (input_buf.quantized_storage != null or
+            input_buf.runtime_quantized_storage != null or
+            input_buf.owned_quantized_storage != null)
+        {
+            return null;
+        }
+        if (strictFlorence2ResidentMetal() and !isDeviceResidentCt(input)) return error.UnsupportedFlorence2ResidentMetal;
+        var input_mt = try self.ownedDeviceMetalTensorFromCt(input);
+        defer input_mt.deinit();
+        if (!input_mt.isDevice()) return null;
+        if (try metal_runtime.decoderRuntimeFlorenceWindowUnpackF32Device(
+            self.provider_impl,
+            input_mt,
+            batch,
+            height,
+            width,
+            dim,
+            window_size,
+        )) |tensor| {
+            return self.ctFromOwnedMetalTensor(tensor);
+        }
+        return null;
+    }
+
+    fn tryWindowedSelfAttentionResident(
+        self: *MetalCompute,
+        ctx: *anyopaque,
+        input: CT,
+        norm_weight: CT,
+        norm_bias: CT,
+        qkv_weight: CT,
+        qkv_bias: CT,
+        proj_weight: CT,
+        proj_bias: CT,
+        batch: usize,
+        height: usize,
+        width: usize,
+        dim: usize,
+        num_heads: usize,
+        window_size: usize,
+    ) !?CT {
+        if (batch == 0 or height == 0 or width == 0 or dim == 0 or num_heads == 0 or window_size == 0) return null;
+        if (dim % num_heads != 0) return null;
+        const pad_h = (window_size - (height % window_size)) % window_size;
+        const pad_w = (window_size - (width % window_size)) % window_size;
+        const padded_h = height + pad_h;
+        const padded_w = width + pad_w;
+        const windows_h = padded_h / window_size;
+        const windows_w = padded_w / window_size;
+        const window_count = batch * windows_h * windows_w;
+        const window_area = window_size * window_size;
+        const rows = window_count * window_area;
+        const head_dim = dim / num_heads;
+
+        try requireFlorence2DeviceResident(input);
+        const normed = try layerNormOp(ctx, input, norm_weight, norm_bias, dim, 1e-5);
+        defer freeOp(ctx, normed);
+        try requireFlorence2DeviceResident(normed);
+
+        const packed_windows = (try self.florenceWindowPackDevice(normed, batch, height, width, dim, window_size)) orelse return null;
+        defer freeOp(ctx, packed_windows);
+        try requireFlorence2DeviceResident(packed_windows);
+
+        const qkv = try linearOp(ctx, packed_windows, qkv_weight, qkv_bias, rows, dim, dim * 3);
+        defer freeOp(ctx, qkv);
+        try requireFlorence2DeviceResident(qkv);
+
+        const q = try sliceLastDimOp(ctx, qkv, 0, dim);
+        defer freeOp(ctx, q);
+        try requireFlorence2DeviceResident(q);
+        const k = try sliceLastDimOp(ctx, qkv, dim, dim * 2);
+        defer freeOp(ctx, k);
+        try requireFlorence2DeviceResident(k);
+        const v = try sliceLastDimOp(ctx, qkv, dim * 2, dim * 3);
+        defer freeOp(ctx, v);
+        try requireFlorence2DeviceResident(v);
+
+        const empty_mask = [_]i64{};
+        const attended = try scaledDotProductAttentionOp(ctx, q, k, v, &empty_mask, null, window_count, window_area, num_heads, head_dim);
+        defer freeOp(ctx, attended);
+        try requireFlorence2DeviceResident(attended);
+
+        const projected = try linearOp(ctx, attended, proj_weight, proj_bias, rows, dim, dim);
+        defer freeOp(ctx, projected);
+        try requireFlorence2DeviceResident(projected);
+
+        const output = (try self.florenceWindowUnpackDevice(projected, batch, height, width, dim, window_size)) orelse return null;
+        try requireFlorence2DeviceResident(output);
+        return output;
+    }
+
+    fn florenceChannelAttentionDevice(
+        self: *MetalCompute,
+        qkv: CT,
+        batch: usize,
+        seq_len: usize,
+        dim: usize,
+        groups: usize,
+    ) !?CT {
+        const qkv_buf = toBuf(qkv);
+        if (qkv_buf.quantized_storage != null or
+            qkv_buf.runtime_quantized_storage != null or
+            qkv_buf.owned_quantized_storage != null)
+        {
+            return null;
+        }
+        if (strictFlorence2ResidentMetal() and !isDeviceResidentCt(qkv)) return error.UnsupportedFlorence2ResidentMetal;
+        var qkv_mt = try self.ownedDeviceMetalTensorFromCt(qkv);
+        defer qkv_mt.deinit();
+        if (!qkv_mt.isDevice()) return null;
+        if (try metal_runtime.decoderRuntimeFlorenceChannelAttentionF32Device(
+            self.provider_impl,
+            qkv_mt,
+            batch,
+            seq_len,
+            dim,
+            groups,
+        )) |tensor| {
+            return self.ctFromOwnedMetalTensor(tensor);
+        }
+        return null;
+    }
+
+    fn tryChannelSelfAttentionResident(
+        self: *MetalCompute,
+        ctx: *anyopaque,
+        input: CT,
+        norm_weight: CT,
+        norm_bias: CT,
+        qkv_weight: CT,
+        qkv_bias: CT,
+        proj_weight: CT,
+        proj_bias: CT,
+        batch: usize,
+        seq_len: usize,
+        dim: usize,
+        groups: usize,
+    ) !?CT {
+        if (batch == 0 or seq_len == 0 or dim == 0 or groups == 0 or dim % groups != 0) return null;
+        const rows = batch * seq_len;
+
+        try requireFlorence2DeviceResident(input);
+        const normed = try layerNormOp(ctx, input, norm_weight, norm_bias, dim, 1e-5);
+        defer freeOp(ctx, normed);
+        try requireFlorence2DeviceResident(normed);
+
+        const qkv = try linearOp(ctx, normed, qkv_weight, qkv_bias, rows, dim, dim * 3);
+        defer freeOp(ctx, qkv);
+        try requireFlorence2DeviceResident(qkv);
+
+        const attended = (try self.florenceChannelAttentionDevice(qkv, batch, seq_len, dim, groups)) orelse return null;
+        defer freeOp(ctx, attended);
+        try requireFlorence2DeviceResident(attended);
+
+        const projected = try linearOp(ctx, attended, proj_weight, proj_bias, rows, dim, dim);
+        errdefer freeOp(ctx, projected);
+        try requireFlorence2DeviceResident(projected);
+        return projected;
+    }
+
+    fn windowedSelfAttentionOp(
+        ctx: *anyopaque,
+        input: CT,
+        norm_weight: CT,
+        norm_bias: CT,
+        qkv_weight: CT,
+        qkv_bias: CT,
+        proj_weight: CT,
+        proj_bias: CT,
+        batch: usize,
+        height: usize,
+        width: usize,
+        dim: usize,
+        num_heads: usize,
+        window_size: usize,
+    ) anyerror!CT {
+        const self: *MetalCompute = @ptrCast(@alignCast(ctx));
+        if (try self.tryWindowedSelfAttentionResident(
+            ctx,
+            input,
+            norm_weight,
+            norm_bias,
+            qkv_weight,
+            qkv_bias,
+            proj_weight,
+            proj_bias,
+            batch,
+            height,
+            width,
+            dim,
+            num_heads,
+            window_size,
+        )) |resident| {
+            if (traceFlorence2ResidentMetal()) {
+                std.debug.print(
+                    "florence2-metal: resident op=windowed_self_attention batch={d} height={d} width={d} dim={d} heads={d} window={d}\n",
+                    .{ batch, height, width, dim, num_heads, window_size },
+                );
+            }
+            return resident;
+        }
+        if (strictFlorence2ResidentMetal()) return error.UnsupportedFlorence2ResidentMetal;
+        if (traceFlorence2ResidentMetal()) {
+            std.debug.print("florence2-metal: host-fallback op=windowed_self_attention\n", .{});
+        }
+        var native_ctx = try HostFallbackNative.init(self.allocator);
+        defer native_ctx.deinit();
+
+        const input_shape = [_]i64{ @intCast(batch * height * width), @intCast(dim) };
+        const norm_shape = [_]i64{@intCast(dim)};
+        const qkv_weight_shape = [_]i64{ @intCast(dim * 3), @intCast(dim) };
+        const qkv_bias_shape = [_]i64{@intCast(dim * 3)};
+        const proj_weight_shape = [_]i64{ @intCast(dim), @intCast(dim) };
+        const proj_bias_shape = [_]i64{@intCast(dim)};
+
+        const n_input = try self.importCtToHostNative(&native_ctx, input, &input_shape);
+        defer native_ctx.cb.free(n_input);
+        const n_norm_weight = try self.importCtToHostNative(&native_ctx, norm_weight, &norm_shape);
+        defer native_ctx.cb.free(n_norm_weight);
+        const n_norm_bias = try self.importCtToHostNative(&native_ctx, norm_bias, &norm_shape);
+        defer native_ctx.cb.free(n_norm_bias);
+        const n_qkv_weight = try self.importCtToHostNative(&native_ctx, qkv_weight, &qkv_weight_shape);
+        defer native_ctx.cb.free(n_qkv_weight);
+        const n_qkv_bias = try self.importCtToHostNative(&native_ctx, qkv_bias, &qkv_bias_shape);
+        defer native_ctx.cb.free(n_qkv_bias);
+        const n_proj_weight = try self.importCtToHostNative(&native_ctx, proj_weight, &proj_weight_shape);
+        defer native_ctx.cb.free(n_proj_weight);
+        const n_proj_bias = try self.importCtToHostNative(&native_ctx, proj_bias, &proj_bias_shape);
+        defer native_ctx.cb.free(n_proj_bias);
+
+        const n_output = try native_ctx.cb.windowedSelfAttention(
+            n_input,
+            n_norm_weight,
+            n_norm_bias,
+            n_qkv_weight,
+            n_qkv_bias,
+            n_proj_weight,
+            n_proj_bias,
+            batch,
+            height,
+            width,
+            dim,
+            num_heads,
+            window_size,
+        );
+        defer native_ctx.cb.free(n_output);
+        return self.exportCtFromHostNative(&native_ctx, n_output, &input_shape);
+    }
+
+    fn channelSelfAttentionOp(
+        ctx: *anyopaque,
+        input: CT,
+        norm_weight: CT,
+        norm_bias: CT,
+        qkv_weight: CT,
+        qkv_bias: CT,
+        proj_weight: CT,
+        proj_bias: CT,
+        batch: usize,
+        seq_len: usize,
+        dim: usize,
+        groups: usize,
+    ) anyerror!CT {
+        const self: *MetalCompute = @ptrCast(@alignCast(ctx));
+        if (try self.tryChannelSelfAttentionResident(
+            ctx,
+            input,
+            norm_weight,
+            norm_bias,
+            qkv_weight,
+            qkv_bias,
+            proj_weight,
+            proj_bias,
+            batch,
+            seq_len,
+            dim,
+            groups,
+        )) |resident| {
+            if (traceFlorence2ResidentMetal()) {
+                std.debug.print(
+                    "florence2-metal: resident op=channel_self_attention batch={d} seq_len={d} dim={d} groups={d}\n",
+                    .{ batch, seq_len, dim, groups },
+                );
+            }
+            return resident;
+        }
+        if (strictFlorence2ResidentMetal()) return error.UnsupportedFlorence2ResidentMetal;
+        if (traceFlorence2ResidentMetal()) {
+            std.debug.print("florence2-metal: host-fallback op=channel_self_attention\n", .{});
+        }
+        var native_ctx = try HostFallbackNative.init(self.allocator);
+        defer native_ctx.deinit();
+
+        const input_shape = [_]i64{ @intCast(batch * seq_len), @intCast(dim) };
+        const norm_shape = [_]i64{@intCast(dim)};
+        const qkv_weight_shape = [_]i64{ @intCast(dim * 3), @intCast(dim) };
+        const qkv_bias_shape = [_]i64{@intCast(dim * 3)};
+        const proj_weight_shape = [_]i64{ @intCast(dim), @intCast(dim) };
+        const proj_bias_shape = [_]i64{@intCast(dim)};
+
+        const n_input = try self.importCtToHostNative(&native_ctx, input, &input_shape);
+        defer native_ctx.cb.free(n_input);
+        const n_norm_weight = try self.importCtToHostNative(&native_ctx, norm_weight, &norm_shape);
+        defer native_ctx.cb.free(n_norm_weight);
+        const n_norm_bias = try self.importCtToHostNative(&native_ctx, norm_bias, &norm_shape);
+        defer native_ctx.cb.free(n_norm_bias);
+        const n_qkv_weight = try self.importCtToHostNative(&native_ctx, qkv_weight, &qkv_weight_shape);
+        defer native_ctx.cb.free(n_qkv_weight);
+        const n_qkv_bias = try self.importCtToHostNative(&native_ctx, qkv_bias, &qkv_bias_shape);
+        defer native_ctx.cb.free(n_qkv_bias);
+        const n_proj_weight = try self.importCtToHostNative(&native_ctx, proj_weight, &proj_weight_shape);
+        defer native_ctx.cb.free(n_proj_weight);
+        const n_proj_bias = try self.importCtToHostNative(&native_ctx, proj_bias, &proj_bias_shape);
+        defer native_ctx.cb.free(n_proj_bias);
+
+        const n_output = try native_ctx.cb.channelSelfAttention(
+            n_input,
+            n_norm_weight,
+            n_norm_bias,
+            n_qkv_weight,
+            n_qkv_bias,
+            n_proj_weight,
+            n_proj_bias,
+            batch,
+            seq_len,
+            dim,
+            groups,
+        );
+        defer native_ctx.cb.free(n_output);
+        return self.exportCtFromHostNative(&native_ctx, n_output, &input_shape);
+    }
+
+    fn crossAttentionOp(
+        ctx: *anyopaque,
+        q_ct: CT,
+        k_ct: CT,
+        v_ct: CT,
+        enc_mask: []const i64,
+        batch: usize,
+        dec_seq: usize,
+        enc_seq: usize,
+        num_heads: usize,
+        head_dim: usize,
+    ) anyerror!CT {
+        const self: *MetalCompute = @ptrCast(@alignCast(ctx));
+        const hidden_dim = num_heads * head_dim;
+        if (batch == 1 and dec_seq != 0 and enc_seq != 0 and num_heads != 0 and head_dim != 0) resident_path: {
+            for (enc_mask) |value| {
+                if (value == 0) break :resident_path;
+            }
+            const q_buf = toBuf(q_ct);
+            const k_buf = toBuf(k_ct);
+            const v_buf = toBuf(v_ct);
+            if (q_buf.quantized_storage != null or k_buf.quantized_storage != null or v_buf.quantized_storage != null) break :resident_path;
+            if (q_buf.runtime_quantized_storage != null or k_buf.runtime_quantized_storage != null or v_buf.runtime_quantized_storage != null) break :resident_path;
+            if (q_buf.owned_quantized_storage != null or k_buf.owned_quantized_storage != null or v_buf.owned_quantized_storage != null) break :resident_path;
+
+            const q_existing = q_buf.metal_tensor;
+            const k_existing = k_buf.metal_tensor;
+            const v_existing = v_buf.metal_tensor;
+            if (strictFlorence2ResidentMetal()) {
+                if (q_existing == null or k_existing == null or v_existing == null) return error.UnsupportedFlorence2ResidentMetal;
+                if (!q_existing.?.isDevice() or !k_existing.?.isDevice() or !v_existing.?.isDevice()) return error.UnsupportedFlorence2ResidentMetal;
+            }
+
+            var q_mt = try self.ownedDeviceMetalTensorFromCt(q_ct);
+            defer q_mt.deinit();
+            var k_mt = try self.ownedDeviceMetalTensorFromCt(k_ct);
+            defer k_mt.deinit();
+            var v_mt = try self.ownedDeviceMetalTensorFromCt(v_ct);
+            defer v_mt.deinit();
+            if (!q_mt.isDevice() or !k_mt.isDevice() or !v_mt.isDevice()) break :resident_path;
+            if (q_mt.elemCount() != dec_seq * hidden_dim or
+                k_mt.elemCount() != enc_seq * hidden_dim or
+                v_mt.elemCount() != enc_seq * hidden_dim)
+            {
+                break :resident_path;
+            }
+
+            if (try metal_runtime.decoderRuntimeApplyAttentionF32(self.provider_impl, .{
+                .q = q_mt,
+                .k = k_mt,
+                .v = v_mt,
+                .q_len = dec_seq,
+                .kv_len = enc_seq,
+                .num_heads = num_heads,
+                .num_kv_heads = num_heads,
+                .head_dim = head_dim,
+                .query_position_offset = enc_seq,
+                .kv_position_offset = 0,
+                .sliding_window = 0,
+                .total_sequence_len = enc_seq + dec_seq,
+            })) |tensor| {
+                if (traceFlorence2ResidentMetal()) {
+                    std.debug.print(
+                        "florence2-metal: resident op=cross_attention dec_seq={d} enc_seq={d} heads={d} head_dim={d}\n",
+                        .{ dec_seq, enc_seq, num_heads, head_dim },
+                    );
+                }
+                return self.ctFromOwnedMetalTensor(tensor);
+            }
+        }
+
+        if (strictFlorence2ResidentMetal()) return error.UnsupportedFlorence2ResidentMetal;
+        if (traceFlorence2ResidentMetal()) {
+            std.debug.print("florence2-metal: host-fallback op=cross_attention\n", .{});
+        }
+        var native_ctx = try HostFallbackNative.init(self.allocator);
+        defer native_ctx.deinit();
+
+        const q_shape = [_]i64{ @intCast(batch * dec_seq), @intCast(hidden_dim) };
+        const kv_shape = [_]i64{ @intCast(batch * enc_seq), @intCast(hidden_dim) };
+
+        const n_q = try self.importCtToHostNative(&native_ctx, q_ct, &q_shape);
+        defer native_ctx.cb.free(n_q);
+        const n_k = try self.importCtToHostNative(&native_ctx, k_ct, &kv_shape);
+        defer native_ctx.cb.free(n_k);
+        const n_v = try self.importCtToHostNative(&native_ctx, v_ct, &kv_shape);
+        defer native_ctx.cb.free(n_v);
+
+        const n_output = try native_ctx.cb.crossAttention(
+            n_q,
+            n_k,
+            n_v,
+            enc_mask,
+            batch,
+            dec_seq,
+            enc_seq,
+            num_heads,
+            head_dim,
+        );
+        defer native_ctx.cb.free(n_output);
+        return self.exportCtFromHostNative(&native_ctx, n_output, &q_shape);
     }
 
     fn tryDeviceConv1d(
@@ -13281,6 +13927,8 @@ pub const MetalCompute = if (build_options.enable_metal) struct {
             const a_len = bufElemCount(a_buf);
             const b_len = bufElemCount(b_buf);
             if (try self.tryAnyDeviceEqualSizeBinaryRuntimeOp(a, b, a_len, b_len, .add)) |device_result| return device_result;
+            if (try self.tryDeviceRowBroadcastAdd(b, a_buf, b_buf)) |device_result| return device_result;
+            if (try self.tryDeviceRowBroadcastAdd(a, b_buf, a_buf)) |device_result| return device_result;
             if (a_buf.metal_tensor) |*a_metal| {
                 if (b_buf.metal_tensor) |*b_metal| {
                     if (a_metal.isDevice() and b_metal.isDevice() and a_metal.elemCount() == b_metal.elemCount()) {
@@ -17373,6 +18021,98 @@ pub const MetalCompute = if (build_options.enable_metal) struct {
         return best_idx;
     }
 
+    fn tokenSuppressed(token_id: usize, suppress_token_ids: []const i32) bool {
+        for (suppress_token_ids) |raw| {
+            if (raw >= 0 and @as(usize, @intCast(raw)) == token_id) return true;
+        }
+        return false;
+    }
+
+    fn argmaxDenseRowSuppress(row: []const f32, suppress_token_ids: []const i32) u32 {
+        var best_idx: u32 = 0;
+        var best_val: f32 = -std.math.inf(f32);
+        var found = false;
+        for (row, 0..) |value, idx| {
+            if (tokenSuppressed(idx, suppress_token_ids)) continue;
+            if (!found or value > best_val) {
+                found = true;
+                best_val = value;
+                best_idx = @intCast(idx);
+            }
+        }
+        return best_idx;
+    }
+
+    fn argmaxRowsSuppressOp(
+        ctx: *anyopaque,
+        tensor: CT,
+        row_start: usize,
+        row_count: usize,
+        dim: usize,
+        suppress_token_ids: []const i32,
+        allocator: std.mem.Allocator,
+    ) anyerror!?[]u32 {
+        if (row_count == 0 or dim == 0) return error.InvalidTensorShape;
+        const row_end = std.math.add(usize, row_start, row_count) catch return error.InvalidTensorShape;
+        const elem_count = std.math.mul(usize, row_end, dim) catch return error.InvalidTensorShape;
+        const self: *MetalCompute = @ptrCast(@alignCast(ctx));
+        const buf = toBuf(tensor);
+        if (buf.quantized_storage != null) return error.UnsupportedTensorType;
+
+        const tokens = try allocator.alloc(u32, row_count);
+        errdefer allocator.free(tokens);
+
+        if (buf.metal_tensor) |*metal_tensor| {
+            if (metal_tensor.isDevice()) {
+                for (tokens, 0..) |*token, row_idx| {
+                    const row = row_start + row_idx;
+                    const elem_offset = std.math.mul(usize, row, dim) catch return error.InvalidTensorShape;
+                    const byte_offset = std.math.mul(usize, elem_offset, @sizeOf(f32)) catch return error.InvalidTensorShape;
+                    const byte_len = std.math.mul(usize, dim, @sizeOf(f32)) catch return error.InvalidTensorShape;
+                    const shape = [_]i32{ 1, @intCast(dim) };
+                    var row_view = try metal_tensor.retainedView(byte_offset, byte_len, &shape);
+                    defer row_view.deinit();
+                    const selected = if (suppress_token_ids.len == 0)
+                        try metal_runtime.argmaxLogitsDevice(self.provider_impl, row_view, dim)
+                    else
+                        try metal_runtime.argmaxLogitsSuppressDevice(self.provider_impl, row_view, dim, suppress_token_ids);
+                    if (selected) |token_id| {
+                        token.* = @intCast(token_id);
+                    } else {
+                        if (strictFlorence2ResidentMetal()) return error.UnsupportedFlorence2ResidentMetal;
+                        break;
+                    }
+                } else {
+                    return tokens;
+                }
+            }
+        }
+
+        if (strictFlorence2ResidentMetal() and isDeviceResidentCt(tensor)) return error.UnsupportedFlorence2ResidentMetal;
+        const data = if (buf.metal_tensor) |*metal_tensor|
+            try metal_tensor.toHostSlice()
+        else
+            buf.data;
+        if (data.len < elem_count) return error.InvalidTensorShape;
+        for (tokens, 0..) |*token, row_idx| {
+            const row = row_start + row_idx;
+            const row_data = data[row * dim ..][0..dim];
+            token.* = argmaxDenseRowSuppress(row_data, suppress_token_ids);
+        }
+        return tokens;
+    }
+
+    fn argmaxLastRowSuppressTensorOp(ctx: *anyopaque, tensor: CT, rows: usize, dim: usize, suppress_token_ids: []const i32) anyerror!?CT {
+        if (rows == 0 or dim == 0) return null;
+        const self: *MetalCompute = @ptrCast(@alignCast(ctx));
+        const tokens = (try argmaxRowsSuppressOp(ctx, tensor, rows - 1, 1, dim, suppress_token_ids, self.allocator)) orelse return null;
+        defer self.allocator.free(tokens);
+        if (tokens.len != 1) return error.InvalidTensorShape;
+        const token_f32 = [_]f32{@floatFromInt(tokens[0])};
+        const shape = [_]i32{1};
+        return try fromFloat32ShapeOp(ctx, &token_f32, &shape);
+    }
+
     fn sampleLastRowOp(ctx: *anyopaque, request: *const ops.SampleLastRowRequest) anyerror!?u32 {
         const self: *MetalCompute = @ptrCast(@alignCast(ctx));
         if (request.rows == 0 or request.dim == 0) return null;
@@ -17811,6 +18551,8 @@ pub const MetalCompute = if (build_options.enable_metal) struct {
         vt.sliceLastDim = sliceLastDimOp;
         vt.evalTensor = evalTensorOp;
         vt.argmaxLastRow = argmaxLastRowOp;
+        vt.argmaxRowsSuppress = argmaxRowsSuppressOp;
+        vt.argmaxLastRowSuppressTensor = argmaxLastRowSuppressTensorOp;
         vt.sampleLastRow = sampleLastRowOp;
         vt.zeroTensor = zeroTensorOp;
         vt.subtract = subtractOp;
@@ -17842,9 +18584,13 @@ pub const MetalCompute = if (build_options.enable_metal) struct {
         vt.scaledDotProductAttention = scaledDotProductAttentionOp;
         vt.disentangledRelativeAttention = disentangledRelativeAttentionOp;
         vt.causalSelfAttention = causalSelfAttentionOp;
+        vt.crossAttention = crossAttentionOp;
         vt.logSoftmaxOp = logSoftmaxOp;
         vt.conv1d = conv1dOp;
         vt.conv2d = conv2dOp;
+        vt.tokenGridConv2d = tokenGridConv2dOp;
+        vt.windowedSelfAttention = windowedSelfAttentionOp;
+        vt.channelSelfAttention = channelSelfAttentionOp;
         vt.unaryConsume = unsupportedUnaryConsumeOp;
         vt.addConsumeLeft = addConsumeLeftOp;
         vt.addConsumeRight = addConsumeRightOp;
@@ -20440,6 +21186,38 @@ test "metal_compute: add uploads equal-size host peer instead of downloading dev
     const out_data = try metal_cb.toFloat32(out, allocator);
     defer allocator.free(out_data);
     try std.testing.expectEqualSlices(f32, &.{ 11, 22, 33, 44, 55, 66 }, out_data);
+}
+
+test "metal_compute: add keeps row-wise rhs broadcast resident" {
+    if (!build_options.enable_metal) return error.SkipZigTest;
+    if (!@import("../backends/metal_runtime.zig").metalDeviceAvailable()) return error.SkipZigTest;
+
+    const allocator = std.testing.allocator;
+
+    var metal_ws = testMetalWeightStoreInit(allocator);
+    defer metal_ws.lazy_weights.deinit(allocator);
+    var metal_compute = try MetalCompute.init(allocator, &metal_ws, null);
+    defer metal_compute.deinit();
+    var metal_cb = metal_compute.computeBackend();
+
+    const lhs_host = try metal_cb.fromFloat32Shape(&.{ 1, 2, 3, 4, 5, 6 }, &.{ 2, 3 });
+    defer metal_cb.free(lhs_host);
+    const rhs = try metal_cb.fromFloat32Shape(&.{ 10, 20, 30 }, &.{3});
+    defer metal_cb.free(rhs);
+    const lhs_mt = try metal_compute.ownedDeviceMetalTensorFromCt(lhs_host);
+    const lhs = try metal_compute.ctFromOwnedMetalTensor(lhs_mt);
+    defer metal_cb.free(lhs);
+
+    const out = try metal_cb.add(lhs, rhs);
+    defer metal_cb.free(out);
+    try std.testing.expect(MetalCompute.debugHasDeviceTensor(&metal_cb, out));
+
+    const out_shape = try metal_cb.tensorShape(out, allocator);
+    defer allocator.free(out_shape);
+    try std.testing.expectEqualSlices(i64, &.{ 2, 3 }, out_shape);
+    const out_data = try metal_cb.toFloat32(out, allocator);
+    defer allocator.free(out_data);
+    try std.testing.expectEqualSlices(f32, &.{ 11, 22, 33, 14, 25, 36 }, out_data);
 }
 
 test "metal_compute: multiply uploads equal-size host peer instead of downloading device operand" {

--- a/zig/pkg/inference/src/ops/metal_compute.zig
+++ b/zig/pkg/inference/src/ops/metal_compute.zig
@@ -4194,6 +4194,23 @@ pub const MetalCompute = if (build_options.enable_metal) struct {
         return null;
     }
 
+    fn isRowVectorForColumns(buf: *const Buf, cols: usize) bool {
+        if (buf.logical_shape) |shape| {
+            if (shape.len == 1) return shape[0] > 0 and @as(usize, @intCast(shape[0])) == cols;
+            if (shape.len == 2) {
+                return shape[0] == 1 and shape[1] > 0 and @as(usize, @intCast(shape[1])) == cols;
+            }
+            return false;
+        }
+        if (buf.metal_tensor) |*metal_tensor| {
+            if (metal_tensor.ndim() == 1) return metal_tensor.dim(0) > 0 and @as(usize, @intCast(metal_tensor.dim(0))) == cols;
+            if (metal_tensor.ndim() == 2) {
+                return metal_tensor.dim(0) == 1 and metal_tensor.dim(1) > 0 and @as(usize, @intCast(metal_tensor.dim(1))) == cols;
+            }
+        }
+        return false;
+    }
+
     fn tryDeviceRowBroadcastAdd(
         self: *MetalCompute,
         row_ct: CT,
@@ -4203,6 +4220,7 @@ pub const MetalCompute = if (build_options.enable_metal) struct {
         const matrix_shape = concreteMatrix2DShape(matrix_buf) orelse return null;
         const row_len = bufElemCount(row_buf);
         if (matrix_shape.rows == 0 or matrix_shape.cols == 0 or row_len != matrix_shape.cols) return null;
+        if (!isRowVectorForColumns(row_buf, matrix_shape.cols)) return null;
         const matrix_metal = matrix_buf.metal_tensor orelse return null;
         if (!matrix_metal.isDevice()) return null;
 
@@ -21218,6 +21236,29 @@ test "metal_compute: add keeps row-wise rhs broadcast resident" {
     const out_data = try metal_cb.toFloat32(out, allocator);
     defer allocator.free(out_data);
     try std.testing.expectEqualSlices(f32, &.{ 11, 22, 33, 14, 25, 36 }, out_data);
+}
+
+test "metal_compute: add rejects column-shaped rhs with row-sized flat length" {
+    if (!build_options.enable_metal) return error.SkipZigTest;
+    if (!@import("../backends/metal_runtime.zig").metalDeviceAvailable()) return error.SkipZigTest;
+
+    const allocator = std.testing.allocator;
+
+    var metal_ws = testMetalWeightStoreInit(allocator);
+    defer metal_ws.lazy_weights.deinit(allocator);
+    var metal_compute = try MetalCompute.init(allocator, &metal_ws, null);
+    defer metal_compute.deinit();
+    var metal_cb = metal_compute.computeBackend();
+
+    const lhs_host = try metal_cb.fromFloat32Shape(&.{ 1, 2, 3, 4, 5, 6 }, &.{ 2, 3 });
+    defer metal_cb.free(lhs_host);
+    const rhs = try metal_cb.fromFloat32Shape(&.{ 10, 20, 30 }, &.{ 3, 1 });
+    defer metal_cb.free(rhs);
+    const lhs_mt = try metal_compute.ownedDeviceMetalTensorFromCt(lhs_host);
+    const lhs = try metal_compute.ctFromOwnedMetalTensor(lhs_mt);
+    defer metal_cb.free(lhs);
+
+    try std.testing.expectError(error.UnsupportedShape, metal_cb.add(lhs, rhs));
 }
 
 test "metal_compute: multiply uploads equal-size host peer instead of downloading device operand" {

--- a/zig/pkg/inference/src/pipelines/reading.zig
+++ b/zig/pkg/inference/src/pipelines/reading.zig
@@ -20,7 +20,7 @@
 // Supported model layouts:
 //   - vision_encoder.onnx (or encoder_model.onnx)
 //   - decoder_model.onnx
-//   - or a native Florence safetensors directory
+//   - or a native Florence safetensors/GGUF directory
 //   - preprocessor_config.json (image size, normalization)
 //   - tokenizer.json
 //   - config.json (model_type: florence2, etc.)
@@ -134,6 +134,8 @@ pub const ReadingPipeline = struct {
         // 1. Preprocess image: decode/resize/normalize → [1, 3, H, W] f32
         // 2. Run vision encoder
         const img_sz: i64 = @intCast(img_size);
+        if (try self.readPixelValuesFlorenceResident(pixel_values)) |result| return result;
+
         const pv_shape = [_]i64{ 1, 3, img_sz, img_sz };
         var pv_tensor = try backends.Tensor.initFloat32(allocator, "pixel_values", &pv_shape, pixel_values);
         defer pv_tensor.deinit();
@@ -143,6 +145,10 @@ pub const ReadingPipeline = struct {
         defer if (prompt_ids_i64) |ids| allocator.free(ids);
         var prompt_tensor: ?backends.Tensor = null;
         defer if (prompt_tensor) |*t| t.deinit();
+
+        if (is_native_florence and self.vision_encoder.backend() == .metal) {
+            return error.UnsupportedFlorence2ResidentMetal;
+        }
 
         const encoder_outputs = if (is_native_florence) blk: {
             const florence_cfg = session_factory.getFlorenceConfig(self.vision_encoder).?;
@@ -178,6 +184,104 @@ pub const ReadingPipeline = struct {
 
         if (encoder_outputs.len == 0) return error.NoEncoderOutput;
         return self.decodeFromEncoderOutputs(encoder_outputs, null);
+    }
+
+    fn readPixelValuesFlorenceResident(self: *ReadingPipeline, pixel_values: []const f32) !?ReadResult {
+        if (self.vision_encoder.backend() != .metal) return null;
+        if (self.vision_encoder.vtable != self.decoder.vtable or self.vision_encoder.ptr != self.decoder.ptr) return null;
+
+        const florence_cfg = session_factory.getFlorenceConfig(self.vision_encoder) orelse return null;
+        const allocator = self.allocator;
+        var cb = try session_factory.getComputeBackend(self.vision_encoder, allocator);
+        defer cb.deinit();
+
+        const prompt_text = self.config.prompt orelse "<OCR>";
+        const prompt_i32 = try buildFlorencePromptIds(
+            allocator,
+            self.tokenizer,
+            florence_cfg,
+            prompt_text,
+        );
+        defer allocator.free(prompt_i32);
+
+        const prompt_i64 = try allocator.alloc(i64, prompt_i32.len);
+        defer allocator.free(prompt_i64);
+        for (prompt_i32, 0..) |id, i| prompt_i64[i] = id;
+
+        const encoder = (try session_factory.runFlorenceEncoderResident(
+            self.vision_encoder,
+            &cb,
+            allocator,
+            pixel_values,
+            1,
+            prompt_i64,
+            prompt_i64.len,
+        )) orelse return null;
+        defer cb.free(encoder.hidden);
+
+        const encoder_attention_mask = try allocator.alloc(i64, encoder.seq_len);
+        defer allocator.free(encoder_attention_mask);
+        @memset(encoder_attention_mask, 1);
+
+        const max_len = self.config.max_length;
+        var dec_ids = try allocator.alloc(i64, max_len);
+        defer allocator.free(dec_ids);
+        dec_ids[0] = self.config.decoder_start_token_id;
+        var dec_len: usize = 1;
+        if (self.config.forced_bos_token_id) |forced_bos| {
+            if (max_len > 1) {
+                dec_ids[1] = forced_bos;
+                dec_len = 2;
+            }
+        }
+
+        while (dec_len < max_len) {
+            const logits = (try session_factory.runFlorenceDecoderResident(
+                self.decoder,
+                &cb,
+                allocator,
+                dec_ids[0..dec_len],
+                encoder.hidden,
+                encoder_attention_mask,
+                1,
+                dec_len,
+                encoder.seq_len,
+            )) orelse return null;
+            defer cb.free(logits);
+
+            const suppress_tokens = try buildNoRepeatSuppressTokens(
+                allocator,
+                dec_ids[0..dec_len],
+                self.config.no_repeat_ngram_size,
+            );
+            defer allocator.free(suppress_tokens);
+
+            const best_id = if (suppress_tokens.len == 0) blk: {
+                break :blk (try cb.argmaxLastRow(logits, dec_len, florence_cfg.vocab_size)) orelse return error.UnsupportedOperation;
+            } else blk: {
+                if (try cb.argmaxRowsSuppress(logits, dec_len - 1, 1, florence_cfg.vocab_size, suppress_tokens, allocator)) |tokens| {
+                    defer allocator.free(tokens);
+                    if (tokens.len != 1) return error.InvalidTensorShape;
+                    break :blk tokens[0];
+                }
+
+                if (try cb.argmaxLastRowSuppressTensor(logits, dec_len, florence_cfg.vocab_size, suppress_tokens)) |token_tensor| {
+                    defer cb.free(token_tensor);
+                    const token_ids = try cb.toFloat32(token_tensor, allocator);
+                    defer allocator.free(token_ids);
+                    if (token_ids.len != 1 or token_ids[0] < 0) return error.InvalidTensorShape;
+                    break :blk @as(u32, @intFromFloat(token_ids[0]));
+                }
+
+                return error.UnsupportedFlorence2NoRepeatMetal;
+            };
+            if (@as(i32, @intCast(best_id)) == self.config.eos_token_id) break;
+
+            dec_ids[dec_len] = @intCast(best_id);
+            dec_len += 1;
+        }
+
+        return try self.decodeGeneratedIds(dec_ids[0..dec_len], dec_len);
     }
 
     fn readPix2StructDecoded(self: *ReadingPipeline, img: image.Image) !ReadResult {
@@ -325,8 +429,11 @@ pub const ReadingPipeline = struct {
             dec_len += 1;
         }
 
-        // 4. Decode token IDs to text
-        // Convert i64 to i32 for tokenizer
+        return try self.decodeGeneratedIds(dec_ids[0..dec_len], dec_len);
+    }
+
+    fn decodeGeneratedIds(self: *ReadingPipeline, dec_ids: []const i64, dec_len: usize) !ReadResult {
+        const allocator = self.allocator;
         const prefix_len: usize = if (self.config.forced_bos_token_id != null and dec_len > 1) 2 else 1;
         const text_len = if (dec_len > prefix_len) dec_len - prefix_len else 0;
         const token_ids = try allocator.alloc(i32, text_len);
@@ -431,6 +538,44 @@ fn selectGreedyToken(logits: []const f32, prefix: []const i64, no_repeat_ngram_s
     return best_id;
 }
 
+fn buildNoRepeatSuppressTokens(
+    allocator: std.mem.Allocator,
+    prefix: []const i64,
+    no_repeat_ngram_size: usize,
+) ![]i32 {
+    if (no_repeat_ngram_size <= 1 or prefix.len < no_repeat_ngram_size) {
+        return allocator.alloc(i32, 0);
+    }
+
+    const context_len = no_repeat_ngram_size - 1;
+    const context_start = prefix.len - context_len;
+    const context = prefix[context_start..];
+    const search_end = prefix.len - no_repeat_ngram_size + 1;
+
+    var suppress_tokens = std.ArrayListUnmanaged(i32).empty;
+    errdefer suppress_tokens.deinit(allocator);
+
+    for (0..search_end) |start| {
+        if (!std.mem.eql(i64, prefix[start .. start + context_len], context)) continue;
+        const candidate = prefix[start + context_len];
+        if (candidate < 0 or candidate > std.math.maxInt(i32)) continue;
+        try appendUniqueSuppressToken(allocator, &suppress_tokens, @intCast(candidate));
+    }
+
+    return suppress_tokens.toOwnedSlice(allocator);
+}
+
+fn appendUniqueSuppressToken(
+    allocator: std.mem.Allocator,
+    suppress_tokens: *std.ArrayListUnmanaged(i32),
+    token_id: i32,
+) !void {
+    for (suppress_tokens.items) |existing| {
+        if (existing == token_id) return;
+    }
+    try suppress_tokens.append(allocator, token_id);
+}
+
 fn wouldRepeatNgram(prefix: []const i64, candidate: i64, no_repeat_ngram_size: usize) bool {
     if (no_repeat_ngram_size <= 1) return false;
     if (prefix.len < no_repeat_ngram_size) return false;
@@ -458,4 +603,20 @@ test "selectGreedyToken skips repeated ngrams when configured" {
     const prefix = [_]i64{ 2, 0, 1, 3, 4, 1, 3 };
     try std.testing.expectEqual(@as(usize, 3), selectGreedyToken(&logits, &prefix, 3));
     try std.testing.expectEqual(@as(usize, 4), selectGreedyToken(&logits, &prefix, 0));
+}
+
+test "buildNoRepeatSuppressTokens returns repeated continuations" {
+    const allocator = std.testing.allocator;
+    const prefix = [_]i64{ 2, 0, 42, 77, 9, 42, 77 };
+    const suppress_tokens = try buildNoRepeatSuppressTokens(allocator, &prefix, 3);
+    defer allocator.free(suppress_tokens);
+    try std.testing.expectEqualSlices(i32, &.{9}, suppress_tokens);
+}
+
+test "buildNoRepeatSuppressTokens deduplicates continuations" {
+    const allocator = std.testing.allocator;
+    const prefix = [_]i64{ 2, 4, 5, 9, 4, 5, 9, 4, 5 };
+    const suppress_tokens = try buildNoRepeatSuppressTokens(allocator, &prefix, 3);
+    defer allocator.free(suppress_tokens);
+    try std.testing.expectEqualSlices(i32, &.{9}, suppress_tokens);
 }

--- a/zig/pkg/inference/src/pipelines/reading.zig
+++ b/zig/pkg/inference/src/pipelines/reading.zig
@@ -224,6 +224,7 @@ pub const ReadingPipeline = struct {
         @memset(encoder_attention_mask, 1);
 
         const max_len = self.config.max_length;
+        if (max_len == 0) return .{ .text = try allocator.dupe(u8, ""), .allocator = allocator };
         var dec_ids = try allocator.alloc(i64, max_len);
         defer allocator.free(dec_ids);
         dec_ids[0] = self.config.decoder_start_token_id;
@@ -348,6 +349,7 @@ pub const ReadingPipeline = struct {
 
         // 3. Autoregressive decode
         const max_len = self.config.max_length;
+        if (max_len == 0) return .{ .text = try allocator.dupe(u8, ""), .allocator = allocator };
         var dec_ids = try allocator.alloc(i64, max_len);
         defer allocator.free(dec_ids);
         dec_ids[0] = self.config.decoder_start_token_id;

--- a/zig/pkg/inference/src/quantize/variants_manifest.zig
+++ b/zig/pkg/inference/src/quantize/variants_manifest.zig
@@ -323,28 +323,40 @@ pub fn writeGliner2VariantsManifest(allocator: Allocator, io: std.Io, model_dir:
 }
 
 pub fn writeFlorence2VariantsManifest(allocator: Allocator, io: std.Io, model_dir: []const u8) !void {
+    return writeFlorence2VariantsManifestForModel(allocator, io, model_dir, null);
+}
+
+pub fn writeFlorence2VariantsManifestForModel(
+    allocator: Allocator,
+    io: std.Io,
+    model_dir: []const u8,
+    preferred_model_name: ?[]const u8,
+) !void {
     var names = try listFileNames(allocator, io, model_dir);
     defer {
         for (names.items) |name| allocator.free(name);
         names.deinit(allocator);
     }
-    if (!looksLikeFlorence2Repo(names.items)) return;
+    if (preferred_model_name == null and !looksLikeFlorence2Repo(names.items)) return;
 
-    var gguf_suffixes = std.ArrayListUnmanaged([]const u8).empty;
-    defer gguf_suffixes.deinit(allocator);
+    var gguf_names = std.ArrayListUnmanaged([]const u8).empty;
+    defer gguf_names.deinit(allocator);
+    if (preferred_model_name) |name| {
+        if (hasFile(names.items, name) and std.mem.endsWith(u8, name, ".gguf")) {
+            try appendUniqueName(allocator, &gguf_names, name);
+        }
+    }
     if (hasFile(names.items, "florence-2-base.gguf")) {
-        try gguf_suffixes.append(allocator, "");
+        try appendUniqueName(allocator, &gguf_names, "florence-2-base.gguf");
     }
     for (names.items) |name| {
         const prefix = "florence-2-base.";
         const ext = ".gguf";
         if (!std.mem.startsWith(u8, name, prefix) or !std.mem.endsWith(u8, name, ext)) continue;
         if (name.len <= prefix.len + ext.len) continue;
-        const suffix = name[prefix.len .. name.len - ext.len];
-        if (suffix.len == 0 or containsSuffix(gguf_suffixes.items, suffix)) continue;
-        try gguf_suffixes.append(allocator, suffix);
+        try appendUniqueName(allocator, &gguf_names, name);
     }
-    if (gguf_suffixes.items.len == 0) return;
+    if (gguf_names.items.len == 0) return;
 
     var text: std.Io.Writer.Allocating = .init(allocator);
     defer text.deinit();
@@ -358,27 +370,28 @@ pub fn writeFlorence2VariantsManifest(allocator: Allocator, io: std.Io, model_di
     );
 
     var wrote_any = false;
-    for (gguf_suffixes.items) |suffix| {
+    for (gguf_names.items) |name| {
         if (wrote_any) try writer.writeAll(",\n");
         wrote_any = true;
+        const suffix = florence2FormatSuffixFromGgufName(name);
         if (suffix.len == 0) {
-            try writer.writeAll(
-                \\    {
+            try writer.print(
+                \\    {{
                 \\      "id": "gguf-f32",
                 \\      "target": "gguf",
                 \\      "format": "F32",
-                \\      "model": "florence-2-base.gguf"
-                \\    }
-            );
+                \\      "model": "{s}"
+                \\    }}
+            , .{name});
         } else {
             try writer.print(
                 \\    {{
                 \\      "id": "gguf-{s}",
                 \\      "target": "gguf",
                 \\      "format": "{s}",
-                \\      "model": "florence-2-base.{s}.gguf"
+                \\      "model": "{s}"
                 \\    }}
-            , .{ suffix, suffix, suffix });
+            , .{ suffix, suffix, name });
         }
     }
 
@@ -392,6 +405,27 @@ pub fn writeFlorence2VariantsManifest(allocator: Allocator, io: std.Io, model_di
     const path = try std.fs.path.join(allocator, &.{ model_dir, "antfly_inference_variants.json" });
     defer allocator.free(path);
     try compat.cwd().writeFile(io, .{ .sub_path = path, .data = text.written() });
+}
+
+fn appendUniqueName(allocator: Allocator, names: *std.ArrayListUnmanaged([]const u8), name: []const u8) !void {
+    for (names.items) |existing| {
+        if (std.mem.eql(u8, existing, name)) return;
+    }
+    try names.append(allocator, name);
+}
+
+fn florence2FormatSuffixFromGgufName(name: []const u8) []const u8 {
+    const ext = ".gguf";
+    if (!std.mem.endsWith(u8, name, ext)) return "";
+    const stem = name[0 .. name.len - ext.len];
+    const dot = std.mem.lastIndexOfScalar(u8, stem, '.') orelse return "";
+    const suffix = stem[dot + 1 ..];
+    const canonical = canonicalFormatSuffix(suffix);
+    if (canonical.len == 0) return "";
+    inline for (.{ "Q1_0", "Q2_K", "Q3_K", "Q4_0", "Q4_1", "Q4_K", "Q5_0", "Q5_1", "Q5_K", "Q6_K", "Q8_0", "Q8_1", "Q8_K" }) |known| {
+        if (std.mem.eql(u8, canonical, known)) return known;
+    }
+    return "";
 }
 
 fn listFileNames(allocator: Allocator, io: std.Io, model_dir: []const u8) !std.ArrayListUnmanaged([]u8) {
@@ -645,4 +679,28 @@ test "Florence2 variants manifest indexes available GGUF models" {
     try std.testing.expect(std.mem.indexOf(u8, raw, "\"id\": \"gguf-f32\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, raw, "\"id\": \"gguf-Q4_K\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, raw, "\"model\": \"florence-2-base.Q4_K.gguf\"") != null);
+}
+
+test "Florence2 variants manifest indexes explicit custom GGUF model" {
+    const allocator = std.testing.allocator;
+    const dir_path = try std.fmt.allocPrint(allocator, ".zig-cache/tmp/florence2-custom-variants-manifest-{d}", .{std.posix.system.getpid()});
+    defer allocator.free(dir_path);
+    defer compat.cwd().deleteTree(compat.io(), dir_path) catch {};
+    try compat.cwd().createDirPath(compat.io(), dir_path);
+
+    const custom_name = "model.Q4_K.gguf";
+    const custom_path = try std.fs.path.join(allocator, &.{ dir_path, custom_name });
+    defer allocator.free(custom_path);
+    try compat.cwd().writeFile(compat.io(), .{ .sub_path = custom_path, .data = "" });
+
+    try writeFlorence2VariantsManifestForModel(allocator, compat.io(), dir_path, custom_name);
+
+    const manifest_path = try std.fs.path.join(allocator, &.{ dir_path, "antfly_inference_variants.json" });
+    defer allocator.free(manifest_path);
+    const raw = try compat.cwd().readFileAlloc(compat.io(), manifest_path, allocator, .limited(64 * 1024));
+    defer allocator.free(raw);
+    try std.testing.expect(std.mem.indexOf(u8, raw, "\"family\": \"florence2_variants/v1\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, raw, "\"id\": \"gguf-Q4_K\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, raw, "\"format\": \"Q4_K\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, raw, "\"model\": \"model.Q4_K.gguf\"") != null);
 }

--- a/zig/pkg/inference/src/quantize/variants_manifest.zig
+++ b/zig/pkg/inference/src/quantize/variants_manifest.zig
@@ -93,6 +93,17 @@ pub fn gliner2GgufName(
     return std.fmt.allocPrint(allocator, "gliner2-{s}.{s}.gguf", .{ component, suffix });
 }
 
+pub fn florence2GgufName(
+    allocator: Allocator,
+    format: []const u8,
+) ![]u8 {
+    const suffix = canonicalFormatSuffix(format);
+    if (suffix.len == 0) {
+        return allocator.dupe(u8, "florence-2-base.gguf");
+    }
+    return std.fmt.allocPrint(allocator, "florence-2-base.{s}.gguf", .{suffix});
+}
+
 pub fn writeClipclapVariantsManifest(allocator: Allocator, io: std.Io, model_dir: []const u8) !void {
     var names = try listFileNames(allocator, io, model_dir);
     defer {
@@ -311,6 +322,78 @@ pub fn writeGliner2VariantsManifest(allocator: Allocator, io: std.Io, model_dir:
     try compat.cwd().writeFile(io, .{ .sub_path = path, .data = text.written() });
 }
 
+pub fn writeFlorence2VariantsManifest(allocator: Allocator, io: std.Io, model_dir: []const u8) !void {
+    var names = try listFileNames(allocator, io, model_dir);
+    defer {
+        for (names.items) |name| allocator.free(name);
+        names.deinit(allocator);
+    }
+    if (!looksLikeFlorence2Repo(names.items)) return;
+
+    var gguf_suffixes = std.ArrayListUnmanaged([]const u8).empty;
+    defer gguf_suffixes.deinit(allocator);
+    if (hasFile(names.items, "florence-2-base.gguf")) {
+        try gguf_suffixes.append(allocator, "");
+    }
+    for (names.items) |name| {
+        const prefix = "florence-2-base.";
+        const ext = ".gguf";
+        if (!std.mem.startsWith(u8, name, prefix) or !std.mem.endsWith(u8, name, ext)) continue;
+        if (name.len <= prefix.len + ext.len) continue;
+        const suffix = name[prefix.len .. name.len - ext.len];
+        if (suffix.len == 0 or containsSuffix(gguf_suffixes.items, suffix)) continue;
+        try gguf_suffixes.append(allocator, suffix);
+    }
+    if (gguf_suffixes.items.len == 0) return;
+
+    var text: std.Io.Writer.Allocating = .init(allocator);
+    defer text.deinit();
+    const writer = &text.writer;
+    try writer.writeAll(
+        \\{
+        \\  "family": "florence2_variants/v1",
+        \\  "defaults": {},
+        \\  "variants": [
+        \\
+    );
+
+    var wrote_any = false;
+    for (gguf_suffixes.items) |suffix| {
+        if (wrote_any) try writer.writeAll(",\n");
+        wrote_any = true;
+        if (suffix.len == 0) {
+            try writer.writeAll(
+                \\    {
+                \\      "id": "gguf-f32",
+                \\      "target": "gguf",
+                \\      "format": "F32",
+                \\      "model": "florence-2-base.gguf"
+                \\    }
+            );
+        } else {
+            try writer.print(
+                \\    {{
+                \\      "id": "gguf-{s}",
+                \\      "target": "gguf",
+                \\      "format": "{s}",
+                \\      "model": "florence-2-base.{s}.gguf"
+                \\    }}
+            , .{ suffix, suffix, suffix });
+        }
+    }
+
+    try writer.writeAll(
+        \\
+        \\  ]
+        \\}
+        \\
+    );
+
+    const path = try std.fs.path.join(allocator, &.{ model_dir, "antfly_inference_variants.json" });
+    defer allocator.free(path);
+    try compat.cwd().writeFile(io, .{ .sub_path = path, .data = text.written() });
+}
+
 fn listFileNames(allocator: Allocator, io: std.Io, model_dir: []const u8) !std.ArrayListUnmanaged([]u8) {
     var names = std.ArrayListUnmanaged([]u8).empty;
     errdefer {
@@ -387,6 +470,14 @@ fn looksLikeGliner2Repo(names: []const []const u8) bool {
     return false;
 }
 
+fn looksLikeFlorence2Repo(names: []const []const u8) bool {
+    if (hasFile(names, "florence-2-base.gguf")) return true;
+    for (names) |name| {
+        if (std.mem.startsWith(u8, name, "florence-2-base.") and std.mem.endsWith(u8, name, ".gguf")) return true;
+    }
+    return false;
+}
+
 fn hasFile(names: []const []const u8, needle: []const u8) bool {
     for (names) |name| {
         if (std.mem.eql(u8, name, needle)) return true;
@@ -425,6 +516,16 @@ test "GLiNER2 GGUF names leave F32 unsuffixed" {
     const q4_name = try gliner2GgufName(std.testing.allocator, "head", "q4_k");
     defer std.testing.allocator.free(q4_name);
     try std.testing.expectEqualStrings("gliner2-head.Q4_K.gguf", q4_name);
+}
+
+test "Florence2 GGUF names leave F32 unsuffixed" {
+    const f32_name = try florence2GgufName(std.testing.allocator, "none");
+    defer std.testing.allocator.free(f32_name);
+    try std.testing.expectEqualStrings("florence-2-base.gguf", f32_name);
+
+    const q4_name = try florence2GgufName(std.testing.allocator, "q4_k");
+    defer std.testing.allocator.free(q4_name);
+    try std.testing.expectEqualStrings("florence-2-base.Q4_K.gguf", q4_name);
 }
 
 test "ClipClap variants manifest indexes complete GGUF and ONNX variants" {
@@ -514,4 +615,34 @@ test "GLiNER2 variants manifest indexes complete GGUF pairs and ONNX default" {
     try std.testing.expect(std.mem.indexOf(u8, raw, "\"head\": \"gliner2-head.Q4_K.gguf\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, raw, "\"gguf-Q8_0\"") == null);
     try std.testing.expect(std.mem.indexOf(u8, raw, "\"model\": \"model.onnx\"") != null);
+}
+
+test "Florence2 variants manifest indexes available GGUF models" {
+    const allocator = std.testing.allocator;
+    const dir_path = try std.fmt.allocPrint(allocator, ".zig-cache/tmp/florence2-variants-manifest-{d}", .{std.posix.system.getpid()});
+    defer allocator.free(dir_path);
+    defer compat.cwd().deleteTree(compat.io(), dir_path) catch {};
+    try compat.cwd().createDirPath(compat.io(), dir_path);
+
+    const files = [_][]const u8{
+        "florence-2-base.gguf",
+        "florence-2-base.Q4_K.gguf",
+        "florence-2-base.Q8_0.gguf",
+    };
+    for (files) |file_name| {
+        const path = try std.fs.path.join(allocator, &.{ dir_path, file_name });
+        defer allocator.free(path);
+        try compat.cwd().writeFile(compat.io(), .{ .sub_path = path, .data = "" });
+    }
+
+    try writeFlorence2VariantsManifest(allocator, compat.io(), dir_path);
+
+    const manifest_path = try std.fs.path.join(allocator, &.{ dir_path, "antfly_inference_variants.json" });
+    defer allocator.free(manifest_path);
+    const raw = try compat.cwd().readFileAlloc(compat.io(), manifest_path, allocator, .limited(64 * 1024));
+    defer allocator.free(raw);
+    try std.testing.expect(std.mem.indexOf(u8, raw, "\"family\": \"florence2_variants/v1\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, raw, "\"id\": \"gguf-f32\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, raw, "\"id\": \"gguf-Q4_K\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, raw, "\"model\": \"florence-2-base.Q4_K.gguf\"") != null);
 }

--- a/zig/pkg/inference/src/readers/vision_reader.zig
+++ b/zig/pkg/inference/src/readers/vision_reader.zig
@@ -192,7 +192,7 @@ pub fn isSupportedModelDir(allocator: std.mem.Allocator, model_path: []const u8)
     defer man.deinit();
 
     return man.native_arch_hint == .florence and
-        (man.safetensors_path != null or man.safetensors_index_path != null);
+        (man.gguf_path != null or man.safetensors_path != null or man.safetensors_index_path != null);
 }
 
 pub fn loadPreprocessorConfig(allocator: std.mem.Allocator, model_dir: []const u8) PreprocessorConfig {
@@ -289,4 +289,22 @@ fn jsonValueGetFloatArray3(val: std.json.Value) ?[3]f32 {
         };
     }
     return result;
+}
+
+test "vision reader supports gguf-backed native Florence directories" {
+    const allocator = std.testing.allocator;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.writeFile(std.testing.io, .{
+        .sub_path = "config.json",
+        .data = "{\"model_type\":\"florence2\",\"text_config\":{\"d_model\":768},\"vision_config\":{\"image_size\":768}}",
+    });
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "florence-2-base.Q4_K.gguf", .data = "GGUFstub" });
+
+    const model_dir = try std.fs.path.join(allocator, &.{ ".zig-cache", "tmp", tmp.sub_path[0..] });
+    defer allocator.free(model_dir);
+
+    try std.testing.expect(isSupportedModelDir(allocator, model_dir));
 }

--- a/zig/pkg/inference/src/server/model_manager.zig
+++ b/zig/pkg/inference/src/server/model_manager.zig
@@ -697,6 +697,7 @@ pub fn isManifestPotentiallyLoadableInCurrentBuild(man: manifest_mod.ModelManife
     if (man.hasIncompleteGlinerBundle()) return false;
     if (man.hasIncompleteColqwenBundle()) return false;
     if (man.hasIncompleteClipclapGgufBundle()) return false;
+    if (man.hasIncompleteFlorence2GgufBundle()) return false;
     if (man.onnx_path != null or
         man.visual_model_path != null or
         man.audio_model_path != null or
@@ -1060,6 +1061,7 @@ pub const ModelManager = struct {
         if (man.hasIncompleteGlinerBundle()) return error.IncompleteGlinerBundle;
         if (man.hasIncompleteColqwenBundle()) return error.IncompleteColqwenBundle;
         if (man.hasIncompleteClipclapGgufBundle()) return error.IncompleteClipclapGgufBundle;
+        if (man.hasIncompleteFlorence2GgufBundle()) return error.IncompleteFlorence2Bundle;
 
         // Load tokenizer
         var hf_tok: ?*hf_tokenizer.HfTokenizer = null;


### PR DESCRIPTION
## Summary

Adds production-ready Florence-2 GGUF support for Antfly Inference, including bundle export, manifest discovery, and resident Metal reading for OCR/caption-style tasks.

## What Changed

- Added Florence-2 GGUF bundle packaging:
  - copies required tokenizer/preprocessor sidecars
  - writes `model_manifest.json`
  - writes `antfly_inference_bundle.json`
  - writes `antfly_inference_variants.json`
  - supports custom GGUF output basenames

- Enabled Florence-2 GGUF loading through the reader stack:
  - manifest detects Florence-2 GGUF bundles
  - vision reader accepts GGUF-backed native Florence dirs
  - model manager rejects incomplete Florence bundles cleanly

- Added resident Metal Florence-2 decode path:
  - keeps encoder hidden state and decoder logits on device
  - adds device argmax with no-repeat suppression
  - adds Florence-specific Metal kernels for window packing/unpacking and channel attention
  - avoids host materialization in strict resident mode

- Hardened review findings:
  - constrained generic Metal row-broadcast add to true row vectors only
  - normalized Florence `final_logits_bias` locally instead of relying on generic add behavior
  - guarded zero-token decode requests
  - added regression coverage for malformed broadcast shapes and custom variant names

## Validation

- `zig build inference-test`
- `git diff --check`
- Earlier branch validation included:
  - `zig build antfly`
  - Florence-2 Q4_K export dry run
  - real OCR/caption/detailed-caption smoke reads on the generated GGUF bundle
  - strict resident Metal run with no host materialization trace