### PR TITLE
Stabilize TTL full-text search test

### DIFF
--- a/zig/pkg/antfly/src/storage/db/db.zig
+++ b/zig/pkg/antfly/src/storage/db/db.zig
@@ -46624,6 +46624,7 @@ test "db writes and reads timestamp metadata" {
 
 test "db lookup hides expired documents when ttl schema is configured" {
     const alloc = std.testing.allocator;
+    const ttl_duration_ns: u64 = 60 * std.time.ns_per_s;
 
     var path_buf: [256]u8 = undefined;
     const path = tempPath(&path_buf);
@@ -46635,13 +46636,13 @@ test "db lookup hides expired documents when ttl schema is configured" {
     try db.setSchema(.{
         .version = 1,
         .default_type = "_default",
-        .ttl_duration_ns = 1_000_000_000,
+        .ttl_duration_ns = ttl_duration_ns,
     });
 
     const now_ns = currentTimeNs();
     try db.batch(.{
         .writes = &.{.{ .key = "doc:old", .value = "{\"title\":\"old\"}" }},
-        .timestamp_ns = now_ns - 2_000_000_000,
+        .timestamp_ns = now_ns - 2 * ttl_duration_ns,
     });
     try db.batch(.{
         .writes = &.{.{ .key = "doc:new", .value = "{\"title\":\"new\"}" }},
@@ -46656,6 +46657,7 @@ test "db lookup hides expired documents when ttl schema is configured" {
 
 test "db search filters expired documents when ttl schema is configured" {
     const alloc = std.testing.allocator;
+    const ttl_duration_ns: u64 = 60 * std.time.ns_per_s;
 
     var path_buf: [256]u8 = undefined;
     const path = tempPath(&path_buf);
@@ -46667,7 +46669,7 @@ test "db search filters expired documents when ttl schema is configured" {
     try db.setSchema(.{
         .version = 1,
         .default_type = "_default",
-        .ttl_duration_ns = 1_000_000_000,
+        .ttl_duration_ns = ttl_duration_ns,
     });
 
     const now_ns = currentTimeNs();
@@ -46676,7 +46678,7 @@ test "db search filters expired documents when ttl schema is configured" {
             .{ .key = "doc:old", .value = "{\"title\":\"alpha\",\"body\":\"common token\"}" },
             .{ .key = "doc:new", .value = "{\"title\":\"beta\",\"body\":\"common token\"}" },
         },
-        .timestamp_ns = now_ns - 2_000_000_000,
+        .timestamp_ns = now_ns - 2 * ttl_duration_ns,
     });
     try db.batch(.{
         .writes = &.{.{ .key = "doc:fresh", .value = "{\"title\":\"fresh\",\"body\":\"common token\"}" }},
@@ -46710,6 +46712,7 @@ test "db search filters expired documents when ttl schema is configured" {
 
 test "db ttl falls back to write timestamp when ttl field is missing" {
     const alloc = std.testing.allocator;
+    const ttl_duration_ns: u64 = 60 * std.time.ns_per_s;
 
     var path_buf: [256]u8 = undefined;
     const path = tempPath(&path_buf);
@@ -46721,7 +46724,7 @@ test "db ttl falls back to write timestamp when ttl field is missing" {
     try db.setSchema(.{
         .version = 1,
         .default_type = "_default",
-        .ttl_duration_ns = 1_000_000_000,
+        .ttl_duration_ns = ttl_duration_ns,
         .ttl_field = "expires_at",
     });
 
@@ -46730,7 +46733,7 @@ test "db ttl falls back to write timestamp when ttl field is missing" {
         .writes = &.{
             .{ .key = "doc:old", .value = "{\"title\":\"alpha\",\"body\":\"common token\"}" },
         },
-        .timestamp_ns = now_ns - 2_000_000_000,
+        .timestamp_ns = now_ns - 2 * ttl_duration_ns,
     });
     try db.batch(.{
         .writes = &.{


### PR DESCRIPTION
## Summary
- widen the TTL window in query-time TTL tests so fresh docs cannot expire during full-text index backfill on slower CI runners
- keep expired fixtures two TTL windows old so the tests still validate expired-document filtering

## Verification
- zig fmt zig/pkg/antfly/src/storage/db/db.zig
- env ZIG_GLOBAL_CACHE_DIR=/tmp/antfly-zig-global-fix-ttl zig build lib-db-txn-test
- started env ZIG_GLOBAL_CACHE_DIR=/tmp/antfly-zig-global-fix-ttl zig build unit-test; the DB shard passed, including the previously failing TTL full-text search test, but the aggregate run was stopped after unrelated local listener bind failures under the sandbox