### PR TITLE
Fix startup catch-up busy retry loop

### DIFF
--- a/zig/build.zig
+++ b/zig/build.zig
@@ -3026,6 +3026,7 @@ pub fn build(b: *std.Build) void {
         "data runtime data changes mark provisioned startup catch-up dirty",
         "data runtime structural changes preserve writer-published runtime status",
         "data runtime startup catch-up prefers cached admin snapshot",
+        "data runtime startup catch-up clears no-debt busy writer groups",
         "data runtime provisioned root refresh spawn failure preserves retry bookkeeping",
         "data runtime background maintenance is due for dense posting cadence without lsm debt",
         "data runtime local split fallback preserves source identity namespace",

--- a/zig/pkg/antfly/src/data/runtime.zig
+++ b/zig/pkg/antfly/src/data/runtime.zig
@@ -5150,7 +5150,14 @@ pub const DataServer = struct {
                 stats.group_count += 1;
                 if (result.busy) {
                     stats.busy_groups += 1;
-                    stats.debt_remaining = true;
+                    if (self.runtime_status_dirty.load(.acquire) or self.runtime_status_refresh_active.load(.acquire)) {
+                        stats.debt_remaining = true;
+                        continue;
+                    }
+                    const cached_debt: ?bool = self.cachedRuntimeStatusHasStartupCatchUpDebt(table.name, group_id) catch true;
+                    if (cached_debt orelse true) {
+                        stats.debt_remaining = true;
+                    }
                     continue;
                 }
                 if (!result.had_debt) continue;
@@ -5541,6 +5548,13 @@ pub const DataServer = struct {
             }
         }
         return false;
+    }
+
+    fn cachedRuntimeStatusHasStartupCatchUpDebt(self: *DataServer, table_name: []const u8, group_id: u64) !?bool {
+        const status = try self.provisioned_storage.runtime_status_cache.snapshotGroupStatus(self.alloc, table_name, group_id);
+        var owned = status orelse return null;
+        defer owned.deinit(self.alloc);
+        return runtimeStatusStartupCatchUpDebtPresent((&[_]runtime_status.LocalTableRuntimeStatus{owned})[0..]);
     }
 
     fn setProvisionedStartupCatchUpTarget(self: *DataServer, group_id: u64, table_name: []const u8) !void {
@@ -12260,6 +12274,157 @@ test "data runtime provisioned startup catch-up clears replay debt for local gro
         try std.testing.expectEqual(appended_sequence, stats.indexes[0].replay_applied_sequence);
         try std.testing.expectEqual(appended_sequence, stats.indexes[0].replay_target_sequence);
         try std.testing.expect(!stats.indexes[0].replay_catch_up_required);
+    }
+}
+
+test "data runtime startup catch-up clears no-debt busy writer groups" {
+    const alloc = std.testing.allocator;
+
+    const cases = [_]struct {
+        suffix: []const u8,
+        runtime_status_dirty: bool = false,
+        runtime_status_refresh_active: bool = false,
+        expect_dirty: bool,
+    }{
+        .{ .suffix = "quiescent", .expect_dirty = false },
+        .{ .suffix = "runtime-dirty", .runtime_status_dirty = true, .expect_dirty = true },
+        .{ .suffix = "refresh-active", .runtime_status_refresh_active = true, .expect_dirty = true },
+    };
+
+    for (cases) |tc| {
+        var tmp = std.testing.tmpDir(.{});
+        defer tmp.cleanup();
+
+        const replica_root_dir = try std.fmt.allocPrint(alloc, ".zig-cache/tmp/{s}/data-runtime-startup-catch-up-busy-no-debt-{s}", .{ tmp.sub_path, tc.suffix });
+        defer alloc.free(replica_root_dir);
+        const db_path = try std.fmt.allocPrint(alloc, "{s}/group-77/table-db", .{replica_root_dir});
+        defer alloc.free(db_path);
+
+        const FakeStatus = struct {
+            fn iface() antfly.public_api.http_server.StatusSource {
+                return .{
+                    .ptr = undefined,
+                    .vtable = &.{
+                        .status = status,
+                        .admin_snapshot = adminSnapshot,
+                        .free_admin_snapshot = freeAdminSnapshot,
+                    },
+                };
+            }
+
+            fn status(_: *anyopaque) !antfly.metadata_api.MetadataStatus {
+                return .{ .metadata_group_id = 1, .metrics = .{} };
+            }
+
+            fn adminSnapshot(_: *anyopaque) !antfly.metadata_api.AdminSnapshot {
+                return .{
+                    .status = .{ .metadata_group_id = 1, .metrics = .{} },
+                    .tables = @constCast((&[_]antfly.metadata.table_manager.TableRecord{.{
+                        .table_id = 7,
+                        .name = "docs",
+                        .placement_role = "data",
+                        .indexes_json = "{\"indexes\":[]}",
+                    }})[0..]),
+                    .ranges = @constCast((&[_]antfly.metadata.table_manager.RangeRecord{.{
+                        .group_id = 77,
+                        .table_id = 7,
+                        .start_key = "",
+                        .end_key = null,
+                    }})[0..]),
+                    .stores = @constCast((&[_]antfly.metadata.table_manager.StoreRecord{.{
+                        .store_id = 19,
+                        .node_id = 9,
+                        .role = "data",
+                        .live = true,
+                        .health_class = "healthy",
+                    }})[0..]),
+                    .placement_intents = @constCast((&[_]antfly.raft.reconciler.PlacementIntent{.{
+                        .record = .{ .group_id = 77, .replica_id = 1, .local_node_id = 9 },
+                        .store_id = 19,
+                        .peer_node_ids = &.{9},
+                    }})[0..]),
+                    .split_transitions = @constCast((&[_]antfly.metadata.SplitTransitionRecord{})[0..]),
+                    .merge_transitions = @constCast((&[_]antfly.metadata.MergeTransitionRecord{})[0..]),
+                };
+            }
+
+            fn freeAdminSnapshot(_: *anyopaque, _: *antfly.metadata_api.AdminSnapshot) void {}
+        };
+
+        const FakeCatalog = struct {
+            fn iface() antfly.public_api.table_catalog.CatalogSource {
+                return .{
+                    .ptr = undefined,
+                    .vtable = &.{
+                        .admin_snapshot = adminSnapshot,
+                        .free_admin_snapshot = freeAdminSnapshot,
+                    },
+                };
+            }
+
+            fn adminSnapshot(_: *anyopaque) !antfly.metadata_api.AdminSnapshot {
+                return try FakeStatus.adminSnapshot(undefined);
+            }
+
+            fn freeAdminSnapshot(_: *anyopaque, _: *antfly.metadata_api.AdminSnapshot) void {}
+        };
+
+        var write_cache = antfly.public_api.ProvisionedTableWriteCache.init(alloc);
+        defer write_cache.deinit();
+
+        var server: DataServer = .{
+            .alloc = alloc,
+            .store_registration = .{
+                .node_id = 9,
+                .store_id = 19,
+                .role = "data",
+                .failure_domain = "test",
+            },
+            .provisioned_storage = antfly.public_api.ProvisionedGroupStorage.init(alloc),
+            .read_source = antfly.public_api.ProvisionedTableReadSource.init(
+                replica_root_dir,
+                FakeCatalog.iface(),
+                antfly.raft.read_gate.noopReadableLeaseRequester(),
+            ),
+            .write_source = antfly.public_api.ProvisionedTableWriteSource.init(
+                replica_root_dir,
+                FakeCatalog.iface(),
+            ),
+            .status_source = FakeStatus.iface(),
+            .api_server_cfg = undefined,
+            .query_async_limit = .limited(8),
+            .listener_cfg = undefined,
+        };
+        defer server.deinit();
+        server.provisioned_storage.attachSources(&server.read_source, &server.write_source);
+        server.write_source.write_cache = &write_cache;
+
+        try write_cache.beginBulkIngestLocked("docs");
+        {
+            lockAtomic(server.write_source.localDbMutex());
+            defer server.write_source.localDbMutex().unlock();
+
+            var cached = try write_cache.getOrOpenLocked(db_path, FakeCatalog.iface(), 77, 0, "docs");
+            defer cached.deinit(alloc);
+            const stats = try cached.db.stats(alloc);
+            defer antfly.db.types.freeDBStats(alloc, stats);
+            try server.provisioned_storage.runtime_status_cache.upsertGroupStatus("docs", .{
+                .group_id = 77,
+                .stats = stats,
+            });
+        }
+
+        server.runtime_status_dirty.store(tc.runtime_status_dirty, .release);
+        server.runtime_status_refresh_active.store(tc.runtime_status_refresh_active, .release);
+        server.provisioned_startup_catch_up_dirty.store(true, .monotonic);
+        _ = server.runProvisionedStartupCatchUp();
+
+        try std.testing.expectEqual(@as(u64, 1), server.provisioned_startup_catch_up_started.load(.monotonic));
+        try std.testing.expectEqual(@as(u64, 1), server.provisioned_startup_catch_up_completed.load(.monotonic));
+        try std.testing.expectEqual(@as(u64, 1), server.provisioned_startup_catch_up_last_group_count.load(.monotonic));
+        try std.testing.expectEqual(@as(u64, 0), server.provisioned_startup_catch_up_last_groups_with_debt.load(.monotonic));
+        try std.testing.expectEqual(@as(u64, 1), server.provisioned_startup_catch_up_last_busy_groups.load(.monotonic));
+        try std.testing.expectEqual(tc.expect_dirty, server.provisioned_startup_catch_up_dirty.load(.monotonic));
     }
 }
 

--- a/zig/pkg/antfly/src/storage/db/catalog/index_manager.zig
+++ b/zig/pkg/antfly/src/storage/db/catalog/index_manager.zig
@@ -5414,6 +5414,12 @@ pub const IndexManager = struct {
         vector_id: u64,
     };
 
+    const PendingDenseVectorDelete = struct {
+        doc_key: []const u8,
+        vector_id: u64,
+        ordinal: ?doc_identity.DocOrdinal = null,
+    };
+
     const DenseOrdinalVectorCacheUpdate = struct {
         ordinal: doc_identity.DocOrdinal,
         vector_id: u64,
@@ -8419,26 +8425,36 @@ pub const IndexManager = struct {
         keys: []const []const u8,
         batch_options: StoreBatchOptions,
     ) !void {
+        var pending_deletes = std.ArrayListUnmanaged(PendingDenseVectorDelete).empty;
+        defer pending_deletes.deinit(self.alloc);
+        {
+            var read_txn = try store.beginReadTxn();
+            defer read_txn.abort();
+            for (keys) |key| {
+                const vector_id = (try self.resolveDenseVectorIdForDeleteTxn(&read_txn, entry.config.name, key)) orelse continue;
+                const ordinal = if (entry.chunk_name == null)
+                    (try doc_identity.lookupOrdinalTxn(self.alloc, &read_txn, key)) orelse
+                        try self.lookupDenseVectorOrdinalTxn(&read_txn, entry.config.name, vector_id)
+                else
+                    null;
+                try pending_deletes.append(self.alloc, .{
+                    .doc_key = key,
+                    .vector_id = vector_id,
+                    .ordinal = ordinal,
+                });
+            }
+        }
+        if (pending_deletes.items.len == 0) return;
+
         var store_batch = try store.beginWriteBatchWithOptions(batch_options);
         errdefer store_batch.abort();
         const store_txn = store_batch.asTxn();
         var vector_ids = std.ArrayListUnmanaged(u64).empty;
         defer vector_ids.deinit(self.alloc);
-        var removed_ordinal_vectors = std.ArrayListUnmanaged(DenseOrdinalVectorCacheUpdate).empty;
-        defer removed_ordinal_vectors.deinit(self.alloc);
 
-        for (keys) |key| {
-            const vector_id = (try self.resolveDenseVectorIdForDeleteTxn(store_txn, entry.config.name, key)) orelse continue;
-            try vector_ids.append(self.alloc, vector_id);
-            if (entry.chunk_name == null) {
-                if (try doc_identity.lookupOrdinalTxn(self.alloc, store_txn, key)) |ordinal| {
-                    try removed_ordinal_vectors.append(self.alloc, .{
-                        .ordinal = ordinal,
-                        .vector_id = vector_id,
-                    });
-                }
-            }
-            try self.clearDenseVectorMappingTxn(store_txn, entry.config.name, key, vector_id);
+        for (pending_deletes.items) |pending| {
+            try vector_ids.append(self.alloc, pending.vector_id);
+            try self.clearDenseVectorMappingTxnWithOrdinal(store_txn, entry.config.name, pending.doc_key, pending.vector_id, pending.ordinal);
         }
 
         entry.index.batchApply(&.{}, vector_ids.items) catch |err| switch (err) {
@@ -8446,9 +8462,11 @@ pub const IndexManager = struct {
             else => return err,
         };
         try store_batch.commit();
-        for (removed_ordinal_vectors.items) |removed| {
-            _ = entry.ordinal_vector_ids.remove(removed.ordinal);
-            _ = entry.vector_ordinals.remove(removed.vector_id);
+        for (pending_deletes.items) |pending| {
+            if (pending.ordinal) |ordinal| {
+                _ = entry.ordinal_vector_ids.remove(ordinal);
+                _ = entry.vector_ordinals.remove(pending.vector_id);
+            }
         }
     }
 
@@ -11043,7 +11061,7 @@ pub const IndexManager = struct {
         parent_doc_key: ?[]const u8,
         vector_id: u64,
     ) !void {
-        var mutable_txn = txn;
+        const mutable_txn = txn;
         const doc_map_key = try denseDocMappingKey(self.alloc, index_name, doc_key);
         defer self.alloc.free(doc_map_key);
         const vector_map_key = try denseVectorIdMappingKey(self.alloc, index_name, vector_id);
@@ -11090,6 +11108,20 @@ pub const IndexManager = struct {
     }
 
     fn clearDenseVectorMappingTxn(self: *IndexManager, txn: anytype, index_name: []const u8, doc_key: []const u8, vector_id: u64) !void {
+        const mutable_txn = txn;
+        const ordinal = (try doc_identity.lookupOrdinalTxn(self.alloc, mutable_txn, doc_key)) orelse
+            try self.lookupDenseVectorOrdinalTxn(mutable_txn, index_name, vector_id);
+        try self.clearDenseVectorMappingTxnWithOrdinal(mutable_txn, index_name, doc_key, vector_id, ordinal);
+    }
+
+    fn clearDenseVectorMappingTxnWithOrdinal(
+        self: *IndexManager,
+        txn: anytype,
+        index_name: []const u8,
+        doc_key: []const u8,
+        vector_id: u64,
+        ordinal: ?doc_identity.DocOrdinal,
+    ) !void {
         var mutable_txn = txn;
         const doc_map_key = try denseDocMappingKey(self.alloc, index_name, doc_key);
         defer self.alloc.free(doc_map_key);
@@ -11099,8 +11131,6 @@ pub const IndexManager = struct {
         defer self.alloc.free(legacy_doc_map_key);
         const legacy_vector_map_key = try legacyDenseVectorIdMappingKey(self.alloc, index_name, vector_id);
         defer self.alloc.free(legacy_vector_map_key);
-        const ordinal = (try doc_identity.lookupOrdinalTxn(self.alloc, mutable_txn, doc_key)) orelse
-            try self.lookupDenseVectorOrdinalTxn(mutable_txn, index_name, vector_id);
 
         mutable_txn.delete(doc_map_key) catch |err| switch (err) {
             error.NotFound => {},

--- a/zig/pkg/antfly/src/storage/lsm_backend.zig
+++ b/zig/pkg/antfly/src/storage/lsm_backend.zig
@@ -1593,7 +1593,7 @@ pub const Backend = struct {
     }
 
     fn cloneMutableStateWithReason(self: *Backend, reason: MutableSnapshotReason) !State {
-        var snapshot = try self.mutable.clone(self.allocator);
+        var snapshot = try self.mutable.cloneArena(self.allocator);
         errdefer snapshot.deinit(self.allocator);
         const snapshot_bytes = estimateStateBytes(&snapshot);
         self.mutable_snapshot_clone_calls +|= 1;

--- a/zig/pkg/antfly/src/storage/lsm_backend.zig
+++ b/zig/pkg/antfly/src/storage/lsm_backend.zig
@@ -1389,7 +1389,10 @@ pub const Backend = struct {
         manager.observeUsage(
             .lsm_in_memory_state,
             &self.tracked_in_memory_state_bytes,
-            stats.mutable_bytes +| stats.immutable_bytes +| stats.bulk_ingest_current_scan_clone_active_bytes,
+            stats.mutable_bytes +|
+                stats.immutable_bytes +|
+                stats.bulk_ingest_current_scan_clone_active_bytes +|
+                self.mutableReadSnapshotBytesLocked(),
         );
     }
 
@@ -1420,6 +1423,18 @@ pub const Backend = struct {
             bytes +|= estimateStateBytes(state);
         }
         bytes +|= self.bulk_ingest_current_scan_clone_active_bytes;
+        bytes +|= self.mutableReadSnapshotBytesLocked();
+        return bytes;
+    }
+
+    fn mutableReadSnapshotBytesLocked(self: *const Backend) u64 {
+        var bytes: u64 = 0;
+        if (self.mutable_read_snapshot) |snapshot| {
+            bytes +|= estimateStateBytes(snapshot);
+        }
+        for (self.retired_mutable_snapshots.items) |snapshot| {
+            bytes +|= estimateStateBytes(snapshot);
+        }
         return bytes;
     }
 
@@ -1615,6 +1630,7 @@ pub const Backend = struct {
         errdefer snapshot.deinit(self.allocator);
         try self.retired_mutable_snapshots.ensureUnusedCapacity(self.allocator, 1);
         self.mutable_read_snapshot = snapshot;
+        self.syncTrackedInMemoryStateUsageCurrentLocked();
         return snapshot;
     }
 
@@ -1670,6 +1686,7 @@ pub const Backend = struct {
         const snapshot = self.mutable_read_snapshot orelse return;
         self.mutable_read_snapshot = null;
         self.retireMutableSnapshot(snapshot);
+        self.syncTrackedInMemoryStateUsageCurrentLocked();
     }
 
     fn destroyImmutableMemtable(self: *Backend, state: *State) void {
@@ -1713,6 +1730,7 @@ pub const Backend = struct {
             self.destroyMutableSnapshot(state);
         }
         self.retired_mutable_snapshots.clearRetainingCapacity();
+        self.syncTrackedInMemoryStateUsageCurrentLocked();
     }
 
     fn compactImmutableMemtableQueue(self: *Backend) void {
@@ -10996,6 +11014,49 @@ test "lsm backend reuses mutable read snapshot until writes invalidate it" {
     try std.testing.expectEqualStrings("B", try read_c.get(.{ .name = "docs" }, "doc:b"));
     try std.testing.expect(backend.mutable_read_snapshot != null);
     try std.testing.expect(first_snapshot != backend.mutable_read_snapshot.?);
+}
+
+test "lsm backend resource manager accounts pinned mutable read snapshots" {
+    var manager = resource_manager_mod.ResourceManager.init(.{});
+    var backend = Backend.init(std.testing.allocator, .{ .resource_manager = &manager });
+    defer backend.close();
+
+    {
+        var txn = try backend.beginWrite();
+        try txn.put(.{ .name = "docs" }, "doc:a", "A");
+        try txn.commit();
+    }
+
+    const base_bytes = manager.sliceStats(.lsm_in_memory_state).used_bytes;
+    try std.testing.expect(base_bytes > 0);
+
+    var read_a = try backend.beginRead();
+    var read_a_open = true;
+    defer if (read_a_open) read_a.abort();
+    try std.testing.expectEqualStrings("A", try read_a.get(.{ .name = "docs" }, "doc:a"));
+
+    const with_snapshot = manager.sliceStats(.lsm_in_memory_state).used_bytes;
+    try std.testing.expect(with_snapshot > base_bytes);
+
+    {
+        var txn = try backend.beginWrite();
+        try txn.put(.{ .name = "docs" }, "doc:b", "B");
+        try txn.commit();
+    }
+
+    const with_retired = manager.sliceStats(.lsm_in_memory_state).used_bytes;
+    try std.testing.expect(with_retired >= with_snapshot);
+    try std.testing.expectEqual(@as(?*State, null), backend.mutable_read_snapshot);
+    try std.testing.expectEqual(@as(usize, 1), backend.retired_mutable_snapshots.items.len);
+
+    read_a.abort();
+    read_a_open = false;
+
+    const after_release = manager.sliceStats(.lsm_in_memory_state).used_bytes;
+    const maintenance = backend.snapshotMaintenanceStats();
+    try std.testing.expect(after_release < with_retired);
+    try std.testing.expectEqual(@as(usize, 0), backend.retired_mutable_snapshots.items.len);
+    try std.testing.expectEqual(maintenance.mutable_bytes +| maintenance.immutable_bytes, after_release);
 }
 
 test "lsm backend rotates large mutable state for read snapshots instead of cloning" {

--- a/zig/pkg/antfly/src/storage/lsm_backend/state.zig
+++ b/zig/pkg/antfly/src/storage/lsm_backend/state.zig
@@ -71,6 +71,17 @@ pub const State = struct {
         return out;
     }
 
+    pub fn cloneArena(self: *const State, allocator: Allocator) !State {
+        var out: State = .{};
+        errdefer out.deinit(allocator);
+        try out.entries.ensureTotalCapacity(allocator, self.entries.items.len);
+        const arena_allocator = try out.ensureArenaAllocator(allocator);
+        for (self.entries.items) |entry| {
+            out.entries.appendAssumeCapacity(try initArenaEntry(arena_allocator, namespaceOf(entry), entry.key, entry.value, entry.tombstone));
+        }
+        return out;
+    }
+
     pub fn ensureArenaAllocator(self: *State, allocator: Allocator) !Allocator {
         if (self.arena_owner == null) {
             const arena = try allocator.create(std.heap.ArenaAllocator);
@@ -209,6 +220,18 @@ pub const ActiveMemTable = struct {
         try out.entries.ensureTotalCapacity(allocator, self.entries.items.len);
         for (self.entries.items) |entry| {
             out.entries.appendAssumeCapacity(try cloneEntry(allocator, entry));
+        }
+        sortStateEntries(&out);
+        return out;
+    }
+
+    pub fn cloneArena(self: *const ActiveMemTable, allocator: Allocator) !State {
+        var out: State = .{};
+        errdefer out.deinit(allocator);
+        try out.entries.ensureTotalCapacity(allocator, self.entries.items.len);
+        const arena_allocator = try out.ensureArenaAllocator(allocator);
+        for (self.entries.items) |entry| {
+            out.entries.appendAssumeCapacity(try initArenaEntry(arena_allocator, namespaceOf(entry), entry.key, entry.value, entry.tombstone));
         }
         sortStateEntries(&out);
         return out;


### PR DESCRIPTION
## Summary
- stop treating busy startup catch-up groups as dirty when cached runtime status shows no replay/backfill debt
- keep retry behavior when cached status is unavailable or still reports startup catch-up debt
- add a regression test for the no-debt busy writer case and include it in lib-data-runtime-test

## Production context
The prod CPU alert was traced to ns-cloud-antfly-inc-rowan-rowanlab/antflydb-swarm-0. Metrics showed provisioned startup catch-up looping with last_groups_with_debt=0 and last_busy_groups=3, pinning the pod near its 1 CPU limit.

## Test
- zig build lib-data-runtime-test
