### PR TITLE
Fix operator container build with local module replaces

### DIFF
--- a/go/pkg/operator/Dockerfile
+++ b/go/pkg/operator/Dockerfile
@@ -2,15 +2,22 @@
 FROM --platform=$BUILDPLATFORM golang:1.26-alpine AS builder
 
 WORKDIR /workspace/go/pkg/operator
-# Copy the Go Modules manifests
+# Copy the Go module manifests, including local modules referenced by replace
+# directives in go/pkg/operator/go.mod.
 COPY go/pkg/operator/go.mod go.mod
 COPY go/pkg/operator/go.sum go.sum
+COPY go/pkg/libaf/go.mod ../libaf/go.mod
+COPY go/pkg/libaf/go.sum ../libaf/go.sum
+COPY go/pkg/sdk/go.mod ../sdk/go.mod
+COPY go/pkg/sdk/go.sum ../sdk/go.sum
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
 RUN go mod download
 
 # Copy only source needed for `go build` so docs/examples/work-log changes do
 # not invalidate the build layer.
+COPY go/pkg/libaf ../libaf
+COPY go/pkg/sdk ../sdk
 COPY go/pkg/operator/api ./api
 COPY go/pkg/operator/bootstrap ./bootstrap
 COPY go/pkg/operator/cmd ./cmd


### PR DESCRIPTION
## Summary
- copy local libaf and sdk module manifests before operator Dockerfile runs `go mod download`
- copy libaf and sdk source into the builder before `go build`
- fixes the Cloud Build failure from https://github.com/antflydb/antfly/actions/runs/28110289607 where `../libaf/go.mod` was missing under the operator module replace path

## Verification
- `env GOWORK=off go test ./...` from `go/pkg/operator`
- simulated the Dockerfile dependency layer by copying operator/libaf/sdk go.mod/go.sum files into a temp `/tmp/.../go/pkg/operator` layout and running `env GOWORK=off go mod download`

Note: Docker daemon was not available locally, so I could not run a full local image build.