### PR TITLE
Shrink generated operator CRDs

### DIFF
--- a/go/pkg/operator/api/antfly/v1/groupversion_info.go
+++ b/go/pkg/operator/api/antfly/v1/groupversion_info.go
@@ -4,7 +4,7 @@
 package v1
 
 //go:generate go tool controller-gen object:headerFile="../../../hack/boilerplate.go.txt" paths="."
-//go:generate go tool controller-gen crd paths="." output:crd:artifacts:config=../../../manifests/crd
+//go:generate go tool controller-gen crd:maxDescLen=0 paths="." output:crd:artifacts:config=../../../manifests/crd
 
 import (
 	"k8s.io/apimachinery/pkg/runtime/schema"

--- a/go/pkg/operator/api/inference/v1alpha1/groupversion_info.go
+++ b/go/pkg/operator/api/inference/v1alpha1/groupversion_info.go
@@ -18,7 +18,7 @@
 package v1alpha1
 
 //go:generate go tool controller-gen object paths="."
-//go:generate go tool controller-gen crd paths="." output:crd:artifacts:config=../../../manifests/crd
+//go:generate go tool controller-gen crd:maxDescLen=0 paths="." output:crd:artifacts:config=../../../manifests/crd
 
 import (
 	"k8s.io/apimachinery/pkg/runtime/schema"

--- a/go/pkg/operator/manifests/crd/antfly.io_antflybackups.yaml
+++ b/go/pkg/operator/manifests/crd/antfly.io_antflybackups.yaml
@@ -33,63 +33,36 @@ spec:
     name: v1
     schema:
       openAPIV3Schema:
-        description: AntflyBackup is the Schema for scheduled Antfly backups
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
-            description: AntflyBackupSpec defines the desired state of AntflyBackup
             properties:
               backupTimeout:
-                description: 'BackupTimeout is max duration for a backup operation
-                  (default: 1h)'
                 type: string
               clusterRef:
-                description: ClusterRef references the AntflyCluster to back up
                 properties:
                   name:
-                    description: Name of the AntflyCluster
                     type: string
                   namespace:
-                    description: Namespace of the AntflyCluster (defaults to same
-                      namespace as this resource)
                     type: string
                 required:
                 - name
                 type: object
               destination:
-                description: Destination defines where backups are stored
                 properties:
                   credentialsSecret:
-                    description: |-
-                      CredentialsSecret references a Secret containing storage credentials
-                      For S3: expects keys AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, and optionally AWS_REGION
                     properties:
                       name:
-                        description: Name of the Secret
                         type: string
                     required:
                     - name
                     type: object
                   location:
-                    description: |-
-                      Location is the backup destination URL
-                      Supports: s3://bucket/path or file:///path
                     pattern: ^(s3://|file://).+
                     type: string
                 required:
@@ -97,28 +70,20 @@ spec:
                 type: object
               failedJobsHistoryLimit:
                 default: 1
-                description: 'FailedJobsHistoryLimit is the number of failed finished
-                  jobs to retain (default: 1)'
                 format: int32
                 minimum: 0
                 type: integer
               schedule:
-                description: Schedule in Cron format (e.g., "0 2 * * *" for daily
-                  at 2am)
                 type: string
               successfulJobsHistoryLimit:
                 default: 3
-                description: 'SuccessfulJobsHistoryLimit is the number of successful
-                  finished jobs to retain (default: 3)'
                 format: int32
                 minimum: 0
                 type: integer
               suspend:
                 default: false
-                description: Suspend stops scheduled backups when true
                 type: boolean
               tables:
-                description: Tables to back up (nil = all tables)
                 items:
                   type: string
                 type: array
@@ -128,54 +93,32 @@ spec:
             - schedule
             type: object
           status:
-            description: AntflyBackupStatus defines the observed state of AntflyBackup
             properties:
               conditions:
-                description: Conditions represent the current state
                 items:
-                  description: Condition contains details for one aspect of the current
-                    state of this API Resource.
                   properties:
                     lastTransitionTime:
-                      description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: |-
-                        message is a human readable message indicating details about the transition.
-                        This may be an empty string.
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: |-
-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                        with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
-                      description: |-
-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                        Producers of specific condition types may define expected values and meanings for this field,
-                        and whether the values are considered a guaranteed API.
-                        The value should be a CamelCase string.
-                        This field may not be empty.
                       maxLength: 1024
                       minLength: 1
                       pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
                       type: string
                     status:
-                      description: status of the condition, one of True, False, Unknown.
                       enum:
                       - "True"
                       - "False"
                       - Unknown
                       type: string
                     type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -188,37 +131,25 @@ spec:
                   type: object
                 type: array
               cronJobName:
-                description: CronJobName is the name of the CronJob managing this
-                  backup
                 type: string
               lastScheduledTime:
-                description: LastScheduledTime is when the last backup was scheduled
                 format: date-time
                 type: string
               lastSuccessfulBackup:
-                description: LastSuccessfulBackup records the most recent successful
-                  backup
                 properties:
                   backupId:
-                    description: BackupID is the unique identifier for this backup
                     type: string
                   completionTime:
-                    description: CompletionTime when backup completed (nil if still
-                      running)
                     format: date-time
                     type: string
                   error:
-                    description: Error message if failed
                     type: string
                   startTime:
-                    description: StartTime when backup started
                     format: date-time
                     type: string
                   status:
-                    description: 'Status of this backup: Running, Completed, Failed'
                     type: string
                   tables:
-                    description: Tables that were backed up
                     items:
                       type: string
                     type: array
@@ -228,45 +159,29 @@ spec:
                 - status
                 type: object
               nextScheduledBackup:
-                description: NextScheduledBackup is the next planned backup time
                 format: date-time
                 type: string
               observedGeneration:
-                description: |-
-                  ObservedGeneration is the most recent generation observed by the controller.
-                  Used to detect spec changes when the backup is in a Failed state,
-                  allowing the controller to re-validate after user corrections.
                 format: int64
                 type: integer
               phase:
-                description: Phase of the backup schedule
                 type: string
               recentBackups:
-                description: RecentBackups stores recent backup records
                 items:
-                  description: BackupRecord stores information about a single backup
-                    execution
                   properties:
                     backupId:
-                      description: BackupID is the unique identifier for this backup
                       type: string
                     completionTime:
-                      description: CompletionTime when backup completed (nil if still
-                        running)
                       format: date-time
                       type: string
                     error:
-                      description: Error message if failed
                       type: string
                     startTime:
-                      description: StartTime when backup started
                       format: date-time
                       type: string
                     status:
-                      description: 'Status of this backup: Running, Completed, Failed'
                       type: string
                     tables:
-                      description: Tables that were backed up
                       items:
                         type: string
                       type: array

--- a/go/pkg/operator/manifests/crd/antfly.io_antflyclusters.yaml
+++ b/go/pkg/operator/manifests/crd/antfly.io_antflyclusters.yaml
@@ -30,90 +30,36 @@ spec:
     name: v1
     schema:
       openAPIV3Schema:
-        description: AntflyCluster is the Schema for the antflyclusters API
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
-            description: AntflyClusterSpec defines the desired state of AntflyCluster
             properties:
               config:
-                description: Config is the configuration file content for Antfly
                 type: string
               dataNodes:
-                description: |-
-                  DataNodes defines the configuration for data nodes (StatefulSet).
-                  Required for Clustered mode and must be omitted in Swarm mode.
                 properties:
                   affinity:
-                    description: |-
-                      Affinity defines affinity rules for pod scheduling.
-                      Cloud-provider-specific affinity rules (e.g., EKS instance type preference)
-                      are appended to any user-specified node affinity preferred terms.
                     properties:
                       nodeAffinity:
-                        description: Describes node affinity scheduling rules for
-                          the pod.
                         properties:
                           preferredDuringSchedulingIgnoredDuringExecution:
-                            description: |-
-                              The scheduler will prefer to schedule pods to nodes that satisfy
-                              the affinity expressions specified by this field, but it may choose
-                              a node that violates one or more of the expressions. The node that is
-                              most preferred is the one with the greatest sum of weights, i.e.
-                              for each node that meets all of the scheduling requirements (resource
-                              request, requiredDuringScheduling affinity expressions, etc.),
-                              compute a sum by iterating through the elements of this field and adding
-                              "weight" to the sum if the node matches the corresponding matchExpressions; the
-                              node(s) with the highest sum are the most preferred.
                             items:
-                              description: |-
-                                An empty preferred scheduling term matches all objects with implicit weight 0
-                                (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
                               properties:
                                 preference:
-                                  description: A node selector term, associated with
-                                    the corresponding weight.
                                   properties:
                                     matchExpressions:
-                                      description: A list of node selector requirements
-                                        by node's labels.
                                       items:
-                                        description: |-
-                                          A node selector requirement is a selector that contains values, a key, and an operator
-                                          that relates the key and values.
                                         properties:
                                           key:
-                                            description: The label key that the selector
-                                              applies to.
                                             type: string
                                           operator:
-                                            description: |-
-                                              Represents a key's relationship to a set of values.
-                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                             type: string
                                           values:
-                                            description: |-
-                                              An array of string values. If the operator is In or NotIn,
-                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. If the operator is Gt or Lt, the values
-                                              array must have a single element, which will be interpreted as an integer.
-                                              This array is replaced during a strategic merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -125,29 +71,13 @@ spec:
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     matchFields:
-                                      description: A list of node selector requirements
-                                        by node's fields.
                                       items:
-                                        description: |-
-                                          A node selector requirement is a selector that contains values, a key, and an operator
-                                          that relates the key and values.
                                         properties:
                                           key:
-                                            description: The label key that the selector
-                                              applies to.
                                             type: string
                                           operator:
-                                            description: |-
-                                              Represents a key's relationship to a set of values.
-                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                             type: string
                                           values:
-                                            description: |-
-                                              An array of string values. If the operator is In or NotIn,
-                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. If the operator is Gt or Lt, the values
-                                              array must have a single element, which will be interpreted as an integer.
-                                              This array is replaced during a strategic merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -161,8 +91,6 @@ spec:
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 weight:
-                                  description: Weight associated with matching the
-                                    corresponding nodeSelectorTerm, in the range 1-100.
                                   format: int32
                                   type: integer
                               required:
@@ -172,46 +100,18 @@ spec:
                             type: array
                             x-kubernetes-list-type: atomic
                           requiredDuringSchedulingIgnoredDuringExecution:
-                            description: |-
-                              If the affinity requirements specified by this field are not met at
-                              scheduling time, the pod will not be scheduled onto the node.
-                              If the affinity requirements specified by this field cease to be met
-                              at some point during pod execution (e.g. due to an update), the system
-                              may or may not try to eventually evict the pod from its node.
                             properties:
                               nodeSelectorTerms:
-                                description: Required. A list of node selector terms.
-                                  The terms are ORed.
                                 items:
-                                  description: |-
-                                    A null or empty node selector term matches no objects. The requirements of
-                                    them are ANDed.
-                                    The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
                                   properties:
                                     matchExpressions:
-                                      description: A list of node selector requirements
-                                        by node's labels.
                                       items:
-                                        description: |-
-                                          A node selector requirement is a selector that contains values, a key, and an operator
-                                          that relates the key and values.
                                         properties:
                                           key:
-                                            description: The label key that the selector
-                                              applies to.
                                             type: string
                                           operator:
-                                            description: |-
-                                              Represents a key's relationship to a set of values.
-                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                             type: string
                                           values:
-                                            description: |-
-                                              An array of string values. If the operator is In or NotIn,
-                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. If the operator is Gt or Lt, the values
-                                              array must have a single element, which will be interpreted as an integer.
-                                              This array is replaced during a strategic merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -223,29 +123,13 @@ spec:
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     matchFields:
-                                      description: A list of node selector requirements
-                                        by node's fields.
                                       items:
-                                        description: |-
-                                          A node selector requirement is a selector that contains values, a key, and an operator
-                                          that relates the key and values.
                                         properties:
                                           key:
-                                            description: The label key that the selector
-                                              applies to.
                                             type: string
                                           operator:
-                                            description: |-
-                                              Represents a key's relationship to a set of values.
-                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                             type: string
                                           values:
-                                            description: |-
-                                              An array of string values. If the operator is In or NotIn,
-                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. If the operator is Gt or Lt, the values
-                                              array must have a single element, which will be interpreted as an integer.
-                                              This array is replaced during a strategic merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -266,59 +150,22 @@ spec:
                             x-kubernetes-map-type: atomic
                         type: object
                       podAffinity:
-                        description: Describes pod affinity scheduling rules (e.g.
-                          co-locate this pod in the same node, zone, etc. as some
-                          other pod(s)).
                         properties:
                           preferredDuringSchedulingIgnoredDuringExecution:
-                            description: |-
-                              The scheduler will prefer to schedule pods to nodes that satisfy
-                              the affinity expressions specified by this field, but it may choose
-                              a node that violates one or more of the expressions. The node that is
-                              most preferred is the one with the greatest sum of weights, i.e.
-                              for each node that meets all of the scheduling requirements (resource
-                              request, requiredDuringScheduling affinity expressions, etc.),
-                              compute a sum by iterating through the elements of this field and adding
-                              "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
-                              node(s) with the highest sum are the most preferred.
                             items:
-                              description: The weights of all of the matched WeightedPodAffinityTerm
-                                fields are added per-node to find the most preferred
-                                node(s)
                               properties:
                                 podAffinityTerm:
-                                  description: Required. A pod affinity term, associated
-                                    with the corresponding weight.
                                   properties:
                                     labelSelector:
-                                      description: |-
-                                        A label query over a set of resources, in this case pods.
-                                        If it's null, this PodAffinityTerm matches with no Pods.
                                       properties:
                                         matchExpressions:
-                                          description: matchExpressions is a list
-                                            of label selector requirements. The requirements
-                                            are ANDed.
                                           items:
-                                            description: |-
-                                              A label selector requirement is a selector that contains values, a key, and an operator that
-                                              relates the key and values.
                                             properties:
                                               key:
-                                                description: key is the label key
-                                                  that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: |-
-                                                  operator represents a key's relationship to a set of values.
-                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                                 type: string
                                               values:
-                                                description: |-
-                                                  values is an array of string values. If the operator is In or NotIn,
-                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. This array is replaced during a strategic
-                                                  merge patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -332,73 +179,29 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: |-
-                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     matchLabelKeys:
-                                      description: |-
-                                        MatchLabelKeys is a set of pod label keys to select which pods will
-                                        be taken into consideration. The keys are used to lookup values from the
-                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                        to select the group of existing pods which pods will be taken into consideration
-                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                        pod labels will be ignored. The default value is empty.
-                                        The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                        Also, matchLabelKeys cannot be set when labelSelector isn't set.
                                       items:
                                         type: string
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     mismatchLabelKeys:
-                                      description: |-
-                                        MismatchLabelKeys is a set of pod label keys to select which pods will
-                                        be taken into consideration. The keys are used to lookup values from the
-                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                        to select the group of existing pods which pods will be taken into consideration
-                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                        pod labels will be ignored. The default value is empty.
-                                        The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                        Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
                                       items:
                                         type: string
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     namespaceSelector:
-                                      description: |-
-                                        A label query over the set of namespaces that the term applies to.
-                                        The term is applied to the union of the namespaces selected by this field
-                                        and the ones listed in the namespaces field.
-                                        null selector and null or empty namespaces list means "this pod's namespace".
-                                        An empty selector ({}) matches all namespaces.
                                       properties:
                                         matchExpressions:
-                                          description: matchExpressions is a list
-                                            of label selector requirements. The requirements
-                                            are ANDed.
                                           items:
-                                            description: |-
-                                              A label selector requirement is a selector that contains values, a key, and an operator that
-                                              relates the key and values.
                                             properties:
                                               key:
-                                                description: key is the label key
-                                                  that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: |-
-                                                  operator represents a key's relationship to a set of values.
-                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                                 type: string
                                               values:
-                                                description: |-
-                                                  values is an array of string values. If the operator is In or NotIn,
-                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. This array is replaced during a strategic
-                                                  merge patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -412,38 +215,20 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: |-
-                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     namespaces:
-                                      description: |-
-                                        namespaces specifies a static list of namespace names that the term applies to.
-                                        The term is applied to the union of the namespaces listed in this field
-                                        and the ones selected by namespaceSelector.
-                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                       items:
                                         type: string
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     topologyKey:
-                                      description: |-
-                                        This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
-                                        the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                        whose value of the label with key topologyKey matches that of any node on which any of the
-                                        selected pods is running.
-                                        Empty topologyKey is not allowed.
                                       type: string
                                   required:
                                   - topologyKey
                                   type: object
                                 weight:
-                                  description: |-
-                                    weight associated with matching the corresponding podAffinityTerm,
-                                    in the range 1-100.
                                   format: int32
                                   type: integer
                               required:
@@ -453,52 +238,18 @@ spec:
                             type: array
                             x-kubernetes-list-type: atomic
                           requiredDuringSchedulingIgnoredDuringExecution:
-                            description: |-
-                              If the affinity requirements specified by this field are not met at
-                              scheduling time, the pod will not be scheduled onto the node.
-                              If the affinity requirements specified by this field cease to be met
-                              at some point during pod execution (e.g. due to a pod label update), the
-                              system may or may not try to eventually evict the pod from its node.
-                              When there are multiple elements, the lists of nodes corresponding to each
-                              podAffinityTerm are intersected, i.e. all terms must be satisfied.
                             items:
-                              description: |-
-                                Defines a set of pods (namely those matching the labelSelector
-                                relative to the given namespace(s)) that this pod should be
-                                co-located (affinity) or not co-located (anti-affinity) with,
-                                where co-located is defined as running on a node whose value of
-                                the label with key <topologyKey> matches that of any node on which
-                                a pod of the set of pods is running
                               properties:
                                 labelSelector:
-                                  description: |-
-                                    A label query over a set of resources, in this case pods.
-                                    If it's null, this PodAffinityTerm matches with no Pods.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
                                       items:
-                                        description: |-
-                                          A label selector requirement is a selector that contains values, a key, and an operator that
-                                          relates the key and values.
                                         properties:
                                           key:
-                                            description: key is the label key that
-                                              the selector applies to.
                                             type: string
                                           operator:
-                                            description: |-
-                                              operator represents a key's relationship to a set of values.
-                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
-                                            description: |-
-                                              values is an array of string values. If the operator is In or NotIn,
-                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This array is replaced during a strategic
-                                              merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -512,73 +263,29 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: |-
-                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 matchLabelKeys:
-                                  description: |-
-                                    MatchLabelKeys is a set of pod label keys to select which pods will
-                                    be taken into consideration. The keys are used to lookup values from the
-                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                    to select the group of existing pods which pods will be taken into consideration
-                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                    pod labels will be ignored. The default value is empty.
-                                    The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                    Also, matchLabelKeys cannot be set when labelSelector isn't set.
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 mismatchLabelKeys:
-                                  description: |-
-                                    MismatchLabelKeys is a set of pod label keys to select which pods will
-                                    be taken into consideration. The keys are used to lookup values from the
-                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                    to select the group of existing pods which pods will be taken into consideration
-                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                    pod labels will be ignored. The default value is empty.
-                                    The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                    Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 namespaceSelector:
-                                  description: |-
-                                    A label query over the set of namespaces that the term applies to.
-                                    The term is applied to the union of the namespaces selected by this field
-                                    and the ones listed in the namespaces field.
-                                    null selector and null or empty namespaces list means "this pod's namespace".
-                                    An empty selector ({}) matches all namespaces.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
                                       items:
-                                        description: |-
-                                          A label selector requirement is a selector that contains values, a key, and an operator that
-                                          relates the key and values.
                                         properties:
                                           key:
-                                            description: key is the label key that
-                                              the selector applies to.
                                             type: string
                                           operator:
-                                            description: |-
-                                              operator represents a key's relationship to a set of values.
-                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
-                                            description: |-
-                                              values is an array of string values. If the operator is In or NotIn,
-                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This array is replaced during a strategic
-                                              merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -592,30 +299,15 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: |-
-                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 namespaces:
-                                  description: |-
-                                    namespaces specifies a static list of namespace names that the term applies to.
-                                    The term is applied to the union of the namespaces listed in this field
-                                    and the ones selected by namespaceSelector.
-                                    null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 topologyKey:
-                                  description: |-
-                                    This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
-                                    the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                    whose value of the label with key topologyKey matches that of any node on which any of the
-                                    selected pods is running.
-                                    Empty topologyKey is not allowed.
                                   type: string
                               required:
                               - topologyKey
@@ -624,59 +316,22 @@ spec:
                             x-kubernetes-list-type: atomic
                         type: object
                       podAntiAffinity:
-                        description: Describes pod anti-affinity scheduling rules
-                          (e.g. avoid putting this pod in the same node, zone, etc.
-                          as some other pod(s)).
                         properties:
                           preferredDuringSchedulingIgnoredDuringExecution:
-                            description: |-
-                              The scheduler will prefer to schedule pods to nodes that satisfy
-                              the anti-affinity expressions specified by this field, but it may choose
-                              a node that violates one or more of the expressions. The node that is
-                              most preferred is the one with the greatest sum of weights, i.e.
-                              for each node that meets all of the scheduling requirements (resource
-                              request, requiredDuringScheduling anti-affinity expressions, etc.),
-                              compute a sum by iterating through the elements of this field and subtracting
-                              "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
-                              node(s) with the highest sum are the most preferred.
                             items:
-                              description: The weights of all of the matched WeightedPodAffinityTerm
-                                fields are added per-node to find the most preferred
-                                node(s)
                               properties:
                                 podAffinityTerm:
-                                  description: Required. A pod affinity term, associated
-                                    with the corresponding weight.
                                   properties:
                                     labelSelector:
-                                      description: |-
-                                        A label query over a set of resources, in this case pods.
-                                        If it's null, this PodAffinityTerm matches with no Pods.
                                       properties:
                                         matchExpressions:
-                                          description: matchExpressions is a list
-                                            of label selector requirements. The requirements
-                                            are ANDed.
                                           items:
-                                            description: |-
-                                              A label selector requirement is a selector that contains values, a key, and an operator that
-                                              relates the key and values.
                                             properties:
                                               key:
-                                                description: key is the label key
-                                                  that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: |-
-                                                  operator represents a key's relationship to a set of values.
-                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                                 type: string
                                               values:
-                                                description: |-
-                                                  values is an array of string values. If the operator is In or NotIn,
-                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. This array is replaced during a strategic
-                                                  merge patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -690,73 +345,29 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: |-
-                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     matchLabelKeys:
-                                      description: |-
-                                        MatchLabelKeys is a set of pod label keys to select which pods will
-                                        be taken into consideration. The keys are used to lookup values from the
-                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                        to select the group of existing pods which pods will be taken into consideration
-                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                        pod labels will be ignored. The default value is empty.
-                                        The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                        Also, matchLabelKeys cannot be set when labelSelector isn't set.
                                       items:
                                         type: string
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     mismatchLabelKeys:
-                                      description: |-
-                                        MismatchLabelKeys is a set of pod label keys to select which pods will
-                                        be taken into consideration. The keys are used to lookup values from the
-                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                        to select the group of existing pods which pods will be taken into consideration
-                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                        pod labels will be ignored. The default value is empty.
-                                        The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                        Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
                                       items:
                                         type: string
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     namespaceSelector:
-                                      description: |-
-                                        A label query over the set of namespaces that the term applies to.
-                                        The term is applied to the union of the namespaces selected by this field
-                                        and the ones listed in the namespaces field.
-                                        null selector and null or empty namespaces list means "this pod's namespace".
-                                        An empty selector ({}) matches all namespaces.
                                       properties:
                                         matchExpressions:
-                                          description: matchExpressions is a list
-                                            of label selector requirements. The requirements
-                                            are ANDed.
                                           items:
-                                            description: |-
-                                              A label selector requirement is a selector that contains values, a key, and an operator that
-                                              relates the key and values.
                                             properties:
                                               key:
-                                                description: key is the label key
-                                                  that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: |-
-                                                  operator represents a key's relationship to a set of values.
-                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                                 type: string
                                               values:
-                                                description: |-
-                                                  values is an array of string values. If the operator is In or NotIn,
-                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. This array is replaced during a strategic
-                                                  merge patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -770,38 +381,20 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: |-
-                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     namespaces:
-                                      description: |-
-                                        namespaces specifies a static list of namespace names that the term applies to.
-                                        The term is applied to the union of the namespaces listed in this field
-                                        and the ones selected by namespaceSelector.
-                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                       items:
                                         type: string
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     topologyKey:
-                                      description: |-
-                                        This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
-                                        the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                        whose value of the label with key topologyKey matches that of any node on which any of the
-                                        selected pods is running.
-                                        Empty topologyKey is not allowed.
                                       type: string
                                   required:
                                   - topologyKey
                                   type: object
                                 weight:
-                                  description: |-
-                                    weight associated with matching the corresponding podAffinityTerm,
-                                    in the range 1-100.
                                   format: int32
                                   type: integer
                               required:
@@ -811,52 +404,18 @@ spec:
                             type: array
                             x-kubernetes-list-type: atomic
                           requiredDuringSchedulingIgnoredDuringExecution:
-                            description: |-
-                              If the anti-affinity requirements specified by this field are not met at
-                              scheduling time, the pod will not be scheduled onto the node.
-                              If the anti-affinity requirements specified by this field cease to be met
-                              at some point during pod execution (e.g. due to a pod label update), the
-                              system may or may not try to eventually evict the pod from its node.
-                              When there are multiple elements, the lists of nodes corresponding to each
-                              podAffinityTerm are intersected, i.e. all terms must be satisfied.
                             items:
-                              description: |-
-                                Defines a set of pods (namely those matching the labelSelector
-                                relative to the given namespace(s)) that this pod should be
-                                co-located (affinity) or not co-located (anti-affinity) with,
-                                where co-located is defined as running on a node whose value of
-                                the label with key <topologyKey> matches that of any node on which
-                                a pod of the set of pods is running
                               properties:
                                 labelSelector:
-                                  description: |-
-                                    A label query over a set of resources, in this case pods.
-                                    If it's null, this PodAffinityTerm matches with no Pods.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
                                       items:
-                                        description: |-
-                                          A label selector requirement is a selector that contains values, a key, and an operator that
-                                          relates the key and values.
                                         properties:
                                           key:
-                                            description: key is the label key that
-                                              the selector applies to.
                                             type: string
                                           operator:
-                                            description: |-
-                                              operator represents a key's relationship to a set of values.
-                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
-                                            description: |-
-                                              values is an array of string values. If the operator is In or NotIn,
-                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This array is replaced during a strategic
-                                              merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -870,73 +429,29 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: |-
-                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 matchLabelKeys:
-                                  description: |-
-                                    MatchLabelKeys is a set of pod label keys to select which pods will
-                                    be taken into consideration. The keys are used to lookup values from the
-                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                    to select the group of existing pods which pods will be taken into consideration
-                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                    pod labels will be ignored. The default value is empty.
-                                    The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                    Also, matchLabelKeys cannot be set when labelSelector isn't set.
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 mismatchLabelKeys:
-                                  description: |-
-                                    MismatchLabelKeys is a set of pod label keys to select which pods will
-                                    be taken into consideration. The keys are used to lookup values from the
-                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                    to select the group of existing pods which pods will be taken into consideration
-                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                    pod labels will be ignored. The default value is empty.
-                                    The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                    Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 namespaceSelector:
-                                  description: |-
-                                    A label query over the set of namespaces that the term applies to.
-                                    The term is applied to the union of the namespaces selected by this field
-                                    and the ones listed in the namespaces field.
-                                    null selector and null or empty namespaces list means "this pod's namespace".
-                                    An empty selector ({}) matches all namespaces.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
                                       items:
-                                        description: |-
-                                          A label selector requirement is a selector that contains values, a key, and an operator that
-                                          relates the key and values.
                                         properties:
                                           key:
-                                            description: key is the label key that
-                                              the selector applies to.
                                             type: string
                                           operator:
-                                            description: |-
-                                              operator represents a key's relationship to a set of values.
-                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
-                                            description: |-
-                                              values is an array of string values. If the operator is In or NotIn,
-                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This array is replaced during a strategic
-                                              merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -950,30 +465,15 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: |-
-                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 namespaces:
-                                  description: |-
-                                    namespaces specifies a static list of namespace names that the term applies to.
-                                    The term is applied to the union of the namespaces listed in this field
-                                    and the ones selected by namespaceSelector.
-                                    null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 topologyKey:
-                                  description: |-
-                                    This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
-                                    the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                    whose value of the label with key topologyKey matches that of any node on which any of the
-                                    selected pods is running.
-                                    Empty topologyKey is not allowed.
                                   type: string
                               required:
                               - topologyKey
@@ -983,47 +483,31 @@ spec:
                         type: object
                     type: object
                   api:
-                    description: API defines the API configuration
                     properties:
                       host:
-                        description: 'Host is the host to bind to (default: 0.0.0.0)'
                         type: string
                       port:
-                        description: Port is the port number (optional, operator sets
-                          defaults)
                         format: int32
                         type: integer
                     type: object
                   autoScaling:
-                    description: AutoScaling defines autoscaling configuration
                     properties:
                       enabled:
-                        description: Enabled indicates if autoscaling is enabled
                         type: boolean
                       maxReplicas:
-                        description: MaxReplicas is the maximum number of replicas
                         format: int32
                         type: integer
                       minReplicas:
-                        description: MinReplicas is the minimum number of replicas
                         format: int32
                         type: integer
                       scaleDownCooldown:
-                        description: 'ScaleDownCooldown is the cooldown period before
-                          another scale down (default: 300s)'
                         type: string
                       scaleUpCooldown:
-                        description: 'ScaleUpCooldown is the cooldown period before
-                          another scale up (default: 60s)'
                         type: string
                       targetCPUUtilizationPercentage:
-                        description: TargetCPUUtilizationPercentage is the target
-                          CPU utilization percentage
                         format: int32
                         type: integer
                       targetMemoryUtilizationPercentage:
-                        description: TargetMemoryUtilizationPercentage is the target
-                          memory utilization percentage
                         format: int32
                         type: integer
                     required:
@@ -1032,208 +516,102 @@ spec:
                     - minReplicas
                     type: object
                   envFrom:
-                    description: |-
-                      EnvFrom is a list of sources to populate environment variables in the container.
-                      This is commonly used to inject backup credentials from Secrets or ConfigMaps.
-                      The keys within a source must be a C_IDENTIFIER. All invalid keys will be
-                      reported as an event when the container is starting.
-                      Example usage for S3/GCS backup credentials:
-                        envFrom:
-                          - secretRef:
-                              name: backup-credentials
-                      The secret should contain AWS SDK compatible keys:
-                        AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_ENDPOINT_URL (optional), AWS_REGION (optional)
                     items:
-                      description: EnvFromSource represents the source of a set of
-                        ConfigMaps or Secrets
                       properties:
                         configMapRef:
-                          description: The ConfigMap to select from
                           properties:
                             name:
                               default: ""
-                              description: |-
-                                Name of the referent.
-                                This field is effectively required, but due to backwards compatibility is
-                                allowed to be empty. Instances of this type with an empty value here are
-                                almost certainly wrong.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                               type: string
                             optional:
-                              description: Specify whether the ConfigMap must be defined
                               type: boolean
                           type: object
                           x-kubernetes-map-type: atomic
                         prefix:
-                          description: |-
-                            Optional text to prepend to the name of each environment variable.
-                            May consist of any printable ASCII characters except '='.
                           type: string
                         secretRef:
-                          description: The Secret to select from
                           properties:
                             name:
                               default: ""
-                              description: |-
-                                Name of the referent.
-                                This field is effectively required, but due to backwards compatibility is
-                                allowed to be empty. Instances of this type with an empty value here are
-                                almost certainly wrong.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                               type: string
                             optional:
-                              description: Specify whether the Secret must be defined
                               type: boolean
                           type: object
                           x-kubernetes-map-type: atomic
                       type: object
                     type: array
                   health:
-                    description: Health defines the health check endpoint configuration
                     properties:
                       host:
-                        description: 'Host is the host to bind to (default: 0.0.0.0)'
                         type: string
                       port:
-                        description: Port is the port number (optional, operator sets
-                          defaults)
                         format: int32
                         type: integer
                     type: object
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: |-
-                      NodeSelector defines node selector labels for pod scheduling.
-                      Merged with any cloud-provider-specific node selectors.
-                      Note: GKE Autopilot mode overrides node selectors with compute class annotations.
                     type: object
                   raft:
-                    description: Raft defines the Raft configuration
                     properties:
                       host:
-                        description: 'Host is the host to bind to (default: 0.0.0.0)'
                         type: string
                       port:
-                        description: Port is the port number (optional, operator sets
-                          defaults)
                         format: int32
                         type: integer
                     type: object
                   replicas:
-                    description: |-
-                      Replicas is the number of data nodes. Zero or omitted uses the controller
-                      default of 3; use suspend for intentional scale-to-zero.
                     format: int32
                     type: integer
                   resources:
-                    description: Resources defines the resource requirements
                     properties:
                       cpu:
-                        description: CPU resource requirements
                         type: string
                       limits:
-                        description: Limits defines the resource limits
                         properties:
                           cpu:
-                            description: CPU limit
                             type: string
                           gpu:
-                            description: GPU limit (maps to nvidia.com/gpu resource)
                             type: string
                           memory:
-                            description: Memory limit
                             type: string
                         type: object
                       memory:
-                        description: Memory resource requirements
                         type: string
                     required:
                     - limits
                     type: object
                   suspend:
-                    description: |-
-                      Suspend scales data nodes to zero while retaining PVCs. This is a
-                      pause/resume operation, not permanent node removal.
                     type: boolean
                   tolerations:
-                    description: |-
-                      Tolerations defines tolerations for pod scheduling.
-                      Merged with any cloud-provider-specific tolerations (e.g., EKS Spot).
                     items:
-                      description: |-
-                        The pod this Toleration is attached to tolerates any taint that matches
-                        the triple <key,value,effect> using the matching operator <operator>.
                       properties:
                         effect:
-                          description: |-
-                            Effect indicates the taint effect to match. Empty means match all taint effects.
-                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                           type: string
                         key:
-                          description: |-
-                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                           type: string
                         operator:
-                          description: |-
-                            Operator represents a key's relationship to the value.
-                            Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
-                            Exists is equivalent to wildcard for value, so that a pod can
-                            tolerate all taints of a particular category.
-                            Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                           type: string
                         tolerationSeconds:
-                          description: |-
-                            TolerationSeconds represents the period of time the toleration (which must be
-                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                            it is not set, which means tolerate the taint forever (do not evict). Zero and
-                            negative values will be treated as 0 (evict immediately) by the system.
                           format: int64
                           type: integer
                         value:
-                          description: |-
-                            Value is the taint value the toleration matches to.
-                            If the operator is Exists, the value should be empty, otherwise just a regular string.
                           type: string
                       type: object
                     type: array
                   topologySpreadConstraints:
-                    description: TopologySpreadConstraints describes how pods should
-                      spread across topology domains.
                     items:
-                      description: TopologySpreadConstraint specifies how to spread
-                        matching pods among the given topology.
                       properties:
                         labelSelector:
-                          description: |-
-                            LabelSelector is used to find matching pods.
-                            Pods that match this label selector are counted to determine the number of pods
-                            in their corresponding topology domain.
                           properties:
                             matchExpressions:
-                              description: matchExpressions is a list of label selector
-                                requirements. The requirements are ANDed.
                               items:
-                                description: |-
-                                  A label selector requirement is a selector that contains values, a key, and an operator that
-                                  relates the key and values.
                                 properties:
                                   key:
-                                    description: key is the label key that the selector
-                                      applies to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      operator represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                     type: string
                                   values:
-                                    description: |-
-                                      values is an array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. This array is replaced during a strategic
-                                      merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -1247,125 +625,27 @@ spec:
                             matchLabels:
                               additionalProperties:
                                 type: string
-                              description: |-
-                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                               type: object
                           type: object
                           x-kubernetes-map-type: atomic
                         matchLabelKeys:
-                          description: |-
-                            MatchLabelKeys is a set of pod label keys to select the pods over which
-                            spreading will be calculated. The keys are used to lookup values from the
-                            incoming pod labels, those key-value labels are ANDed with labelSelector
-                            to select the group of existing pods over which spreading will be calculated
-                            for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
-                            MatchLabelKeys cannot be set when LabelSelector isn't set.
-                            Keys that don't exist in the incoming pod labels will
-                            be ignored. A null or empty list means only match against labelSelector.
-
-                            This is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).
                           items:
                             type: string
                           type: array
                           x-kubernetes-list-type: atomic
                         maxSkew:
-                          description: |-
-                            MaxSkew describes the degree to which pods may be unevenly distributed.
-                            When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
-                            between the number of matching pods in the target topology and the global minimum.
-                            The global minimum is the minimum number of matching pods in an eligible domain
-                            or zero if the number of eligible domains is less than MinDomains.
-                            For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
-                            labelSelector spread as 2/2/1:
-                            In this case, the global minimum is 1.
-                            | zone1 | zone2 | zone3 |
-                            |  P P  |  P P  |   P   |
-                            - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2;
-                            scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2)
-                            violate MaxSkew(1).
-                            - if MaxSkew is 2, incoming pod can be scheduled onto any zone.
-                            When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence
-                            to topologies that satisfy it.
-                            It's a required field. Default value is 1 and 0 is not allowed.
                           format: int32
                           type: integer
                         minDomains:
-                          description: |-
-                            MinDomains indicates a minimum number of eligible domains.
-                            When the number of eligible domains with matching topology keys is less than minDomains,
-                            Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed.
-                            And when the number of eligible domains with matching topology keys equals or greater than minDomains,
-                            this value has no effect on scheduling.
-                            As a result, when the number of eligible domains is less than minDomains,
-                            scheduler won't schedule more than maxSkew Pods to those domains.
-                            If value is nil, the constraint behaves as if MinDomains is equal to 1.
-                            Valid values are integers greater than 0.
-                            When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
-
-                            For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same
-                            labelSelector spread as 2/2/2:
-                            | zone1 | zone2 | zone3 |
-                            |  P P  |  P P  |  P P  |
-                            The number of domains is less than 5(MinDomains), so "global minimum" is treated as 0.
-                            In this situation, new pod with the same labelSelector cannot be scheduled,
-                            because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones,
-                            it will violate MaxSkew.
                           format: int32
                           type: integer
                         nodeAffinityPolicy:
-                          description: |-
-                            NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
-                            when calculating pod topology spread skew. Options are:
-                            - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
-                            - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
-
-                            If this value is nil, the behavior is equivalent to the Honor policy.
                           type: string
                         nodeTaintsPolicy:
-                          description: |-
-                            NodeTaintsPolicy indicates how we will treat node taints when calculating
-                            pod topology spread skew. Options are:
-                            - Honor: nodes without taints, along with tainted nodes for which the incoming pod
-                            has a toleration, are included.
-                            - Ignore: node taints are ignored. All nodes are included.
-
-                            If this value is nil, the behavior is equivalent to the Ignore policy.
                           type: string
                         topologyKey:
-                          description: |-
-                            TopologyKey is the key of node labels. Nodes that have a label with this key
-                            and identical values are considered to be in the same topology.
-                            We consider each <key, value> as a "bucket", and try to put balanced number
-                            of pods into each bucket.
-                            We define a domain as a particular instance of a topology.
-                            Also, we define an eligible domain as a domain whose nodes meet the requirements of
-                            nodeAffinityPolicy and nodeTaintsPolicy.
-                            e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology.
-                            And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology.
-                            It's a required field.
                           type: string
                         whenUnsatisfiable:
-                          description: |-
-                            WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
-                            the spread constraint.
-                            - DoNotSchedule (default) tells the scheduler not to schedule it.
-                            - ScheduleAnyway tells the scheduler to schedule the pod in any location,
-                              but giving higher precedence to topologies that would help reduce the
-                              skew.
-                            A constraint is considered "Unsatisfiable" for an incoming pod
-                            if and only if every possible node assignment for that pod would violate
-                            "MaxSkew" on some topology.
-                            For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
-                            labelSelector spread as 3/1/1:
-                            | zone1 | zone2 | zone3 |
-                            | P P P |   P   |   P   |
-                            If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled
-                            to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies
-                            MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler
-                            won't make it *more* imbalanced.
-                            It's a required field.
                           type: string
                       required:
                       - maxSkew
@@ -1374,10 +654,6 @@ spec:
                       type: object
                     type: array
                   useSpotPods:
-                    description: |-
-                      UseSpotPods enables GKE Spot Pods for data nodes (standard GKE only)
-                      MUST be false when spec.gke.autopilot=true (use spec.gke.autopilotComputeClass instead)
-                      Safe for data nodes with 3+ replicas
                     type: boolean
                 required:
                 - api
@@ -1385,38 +661,18 @@ spec:
                 - resources
                 type: object
               eks:
-                description: EKS defines AWS EKS-specific configuration (optional)
                 properties:
                   ebsEncrypted:
-                    description: |-
-                      EBSEncrypted enables encryption for EBS volumes
-                      When true, volumes will be encrypted using the specified KMS key or the default EBS encryption key
                     type: boolean
                   ebsIOPs:
-                    description: |-
-                      EBSIOPs specifies the provisioned IOPS for io1/io2 volumes
-                      Only applicable when EBSVolumeType is io1 or io2
                     format: int32
                     type: integer
                   ebsKmsKeyId:
-                    description: |-
-                      EBSKmsKeyId is the KMS key ID or ARN for EBS volume encryption
-                      Only used when EBSEncrypted is true
-                      If not specified, the default EBS encryption key for the account is used
                     type: string
                   ebsThroughput:
-                    description: |-
-                      EBSThroughput specifies the throughput in MiB/s for gp3 volumes
-                      Only applicable when EBSVolumeType is gp3
-                      Default is 125 MiB/s, maximum is 1000 MiB/s
                     format: int32
                     type: integer
                   ebsVolumeType:
-                    description: |-
-                      EBSVolumeType specifies the EBS volume type for persistent storage
-                      Valid values: gp3 (default), gp2, io1, io2, st1, sc1
-                      gp3 is recommended for most workloads (better price/performance)
-                      io1/io2 for high-performance requirements
                     enum:
                     - gp3
                     - gp2
@@ -1427,63 +683,34 @@ spec:
                     - ""
                     type: string
                   enabled:
-                    description: Enabled enables EKS-specific optimizations and configurations
                     type: boolean
                   instanceTypes:
-                    description: |-
-                      InstanceTypes specifies preferred EC2 instance types for node scheduling
-                      Examples: ["m5.large", "m5.xlarge", "m6i.large"]
-                      Used with node affinity to target specific instance types
                     items:
                       type: string
                     type: array
                   irsaRoleARN:
-                    description: |-
-                      IRSARoleARN is the ARN of the IAM role for IRSA (IAM Roles for Service Accounts)
-                      Format: arn:aws:iam::<account-id>:role/<role-name>
-                      When specified, the operator will annotate the ServiceAccount with this role
-                      This enables pods to assume IAM roles for AWS API access (e.g., S3 backups)
                     type: string
                   podDisruptionBudget:
-                    description: |-
-                      PodDisruptionBudget enables automatic PodDisruptionBudget creation for StatefulSets
-                      Recommended for production deployments to prevent excessive disruption
                     properties:
                       enabled:
-                        description: Enabled indicates if PodDisruptionBudget should
-                          be created
                         type: boolean
                       maxUnavailable:
-                        description: 'MaxUnavailable is the maximum number of pods
-                          that can be unavailable (default: 1)'
                         format: int32
                         type: integer
                       minAvailable:
-                        description: MinAvailable is the minimum number of pods that
-                          must be available
                         format: int32
                         type: integer
                     required:
                     - enabled
                     type: object
                   useSpotInstances:
-                    description: |-
-                      UseSpotInstances enables EC2 Spot Instances for cost savings (up to 90%)
-                      When enabled, pods will be scheduled on Spot Instance nodes
-                      Recommended for data nodes with 3+ replicas; not recommended for metadata nodes
                     type: boolean
                 type: object
               gke:
-                description: GKE defines GKE-specific configuration (optional)
                 properties:
                   autopilot:
-                    description: Autopilot enables GKE Autopilot-specific optimizations
                     type: boolean
                   autopilotComputeClass:
-                    description: |-
-                      AutopilotComputeClass specifies the GKE Autopilot compute class
-                      Valid values: "Accelerator", "Balanced", "Performance", "Scale-Out", "autopilot", "autopilot-spot"
-                      Defaults to "Balanced" when Autopilot=true and this field is empty
                     enum:
                     - Accelerator
                     - Balanced
@@ -1494,21 +721,13 @@ spec:
                     - ""
                     type: string
                   podDisruptionBudget:
-                    description: PodDisruptionBudget enables automatic PodDisruptionBudget
-                      creation for StatefulSets
                     properties:
                       enabled:
-                        description: Enabled indicates if PodDisruptionBudget should
-                          be created
                         type: boolean
                       maxUnavailable:
-                        description: 'MaxUnavailable is the maximum number of pods
-                          that can be unavailable (default: 1)'
                         format: int32
                         type: integer
                       minAvailable:
-                        description: MinAvailable is the minimum number of pods that
-                          must be available
                         format: int32
                         type: integer
                     required:
@@ -1516,155 +735,66 @@ spec:
                     type: object
                 type: object
               highAvailability:
-                description: |-
-                  HighAvailability configures Postgres-style hot-standby HA for the Zig runtime.
-                  This mode is separate from Raft-backed distributed write ownership.
                 properties:
                   admin:
-                    description: Admin configures HA admin endpoints and optional
-                      operator execution.
                     properties:
                       envFrom:
-                        description: EnvFrom is applied to CLI-backed HA admin Job
-                          containers, commonly for backup object-store credentials.
                         items:
-                          description: EnvFromSource represents the source of a set
-                            of ConfigMaps or Secrets
                           properties:
                             configMapRef:
-                              description: The ConfigMap to select from
                               properties:
                                 name:
                                   default: ""
-                                  description: |-
-                                    Name of the referent.
-                                    This field is effectively required, but due to backwards compatibility is
-                                    allowed to be empty. Instances of this type with an empty value here are
-                                    almost certainly wrong.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap must
-                                    be defined
                                   type: boolean
                               type: object
                               x-kubernetes-map-type: atomic
                             prefix:
-                              description: |-
-                                Optional text to prepend to the name of each environment variable.
-                                May consist of any printable ASCII characters except '='.
                               type: string
                             secretRef:
-                              description: The Secret to select from
                               properties:
                                 name:
                                   default: ""
-                                  description: |-
-                                    Name of the referent.
-                                    This field is effectively required, but due to backwards compatibility is
-                                    allowed to be empty. Instances of this type with an empty value here are
-                                    almost certainly wrong.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret must be
-                                    defined
                                   type: boolean
                               type: object
                               x-kubernetes-map-type: atomic
                           type: object
                         type: array
                       executePlannedActions:
-                        description: |-
-                          ExecutePlannedActions lets the operator execute planned HA actions.
-                          The operator prefers typed /admin/v1/ha calls and uses CLI-backed Kubernetes Jobs for pod-local files, shared backup volumes, or break-glass workflows.
                         type: boolean
                       jobBackoffLimit:
-                        description: JobBackoffLimit is the CLI-backed HA admin Job
-                          retry count before Kubernetes marks it failed.
                         format: int32
                         type: integer
                       jobTTLSecondsAfterFinished:
-                        description: JobTTLSecondsAfterFinished controls how long
-                          completed CLI-backed HA admin Jobs are retained.
                         format: int32
                         type: integer
                       jobTimeoutSeconds:
-                        description: JobTimeoutSeconds is the CLI-backed HA admin
-                          Job active deadline.
                         format: int64
                         type: integer
                       primaryURL:
-                        description: PrimaryURL is the primary HA admin endpoint used
-                          for typed status, slot, seed, and fence actions.
                         type: string
                       tokenEnvVar:
-                        description: |-
-                          TokenEnvVar is the operator process environment variable containing the bearer token for typed /admin/v1/ha calls.
-                          This lets Kubernetes inject the token from a Secret into the operator pod without granting the operator Secret read permissions.
-                          Defaults to ANTFLY_HA_ADMIN_TOKEN when omitted and that environment variable is set.
-                          CLI-backed HA admin Jobs pass --ha-token-env only when this field is explicitly set; inject the same variable into those Jobs with envFrom when authenticated CLI fallback is needed.
                         pattern: ^$|^[A-Za-z_][A-Za-z0-9_]*$
                         type: string
                       volumeMounts:
-                        description: VolumeMounts are added to the CLI-backed HA admin
-                          Job container.
                         items:
-                          description: VolumeMount describes a mounting of a Volume
-                            within a container.
                           properties:
                             mountPath:
-                              description: |-
-                                Path within the container at which the volume should be mounted.  Must
-                                not contain ':'.
                               type: string
                             mountPropagation:
-                              description: |-
-                                mountPropagation determines how mounts are propagated from the host
-                                to container and the other way around.
-                                When not set, MountPropagationNone is used.
-                                This field is beta in 1.10.
-                                When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified
-                                (which defaults to None).
                               type: string
                             name:
-                              description: This must match the Name of a Volume.
                               type: string
                             readOnly:
-                              description: |-
-                                Mounted read-only if true, read-write otherwise (false or unspecified).
-                                Defaults to false.
                               type: boolean
                             recursiveReadOnly:
-                              description: |-
-                                RecursiveReadOnly specifies whether read-only mounts should be handled
-                                recursively.
-
-                                If ReadOnly is false, this field has no meaning and must be unspecified.
-
-                                If ReadOnly is true, and this field is set to Disabled, the mount is not made
-                                recursively read-only.  If this field is set to IfPossible, the mount is made
-                                recursively read-only, if it is supported by the container runtime.  If this
-                                field is set to Enabled, the mount is made recursively read-only if it is
-                                supported by the container runtime, otherwise the pod will not be started and
-                                an error will be generated to indicate the reason.
-
-                                If this field is set to IfPossible or Enabled, MountPropagation must be set to
-                                None (or be unspecified, which defaults to None).
-
-                                If this field is not specified, it is treated as an equivalent of Disabled.
                               type: string
                             subPath:
-                              description: |-
-                                Path within the volume from which the container's volume should be mounted.
-                                Defaults to "" (volume's root).
                               type: string
                             subPathExpr:
-                              description: |-
-                                Expanded path within the volume from which the container's volume should be mounted.
-                                Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
-                                Defaults to "" (volume's root).
-                                SubPathExpr and SubPath are mutually exclusive.
                               type: string
                           required:
                           - mountPath
@@ -1672,256 +802,111 @@ spec:
                           type: object
                         type: array
                       volumes:
-                        description: Volumes are added to CLI-backed HA admin Job
-                          pods, commonly for shared base-backup manifests and contents.
                         items:
-                          description: Volume represents a named volume in a pod that
-                            may be accessed by any container in the pod.
                           properties:
                             awsElasticBlockStore:
-                              description: |-
-                                awsElasticBlockStore represents an AWS Disk resource that is attached to a
-                                kubelet's host machine and then exposed to the pod.
-                                Deprecated: AWSElasticBlockStore is deprecated. All operations for the in-tree
-                                awsElasticBlockStore type are redirected to the ebs.csi.aws.com CSI driver.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type of the volume that you want to mount.
-                                    Tip: Ensure that the filesystem type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                   type: string
                                 partition:
-                                  description: |-
-                                    partition is the partition in the volume that you want to mount.
-                                    If omitted, the default is to mount by volume name.
-                                    Examples: For volume /dev/sda1, you specify the partition as "1".
-                                    Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
                                   format: int32
                                   type: integer
                                 readOnly:
-                                  description: |-
-                                    readOnly value true will force the readOnly setting in VolumeMounts.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                   type: boolean
                                 volumeID:
-                                  description: |-
-                                    volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                   type: string
                               required:
                               - volumeID
                               type: object
                             azureDisk:
-                              description: |-
-                                azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
-                                Deprecated: AzureDisk is deprecated. All operations for the in-tree azureDisk type
-                                are redirected to the disk.csi.azure.com CSI driver.
                               properties:
                                 cachingMode:
-                                  description: 'cachingMode is the Host Caching mode:
-                                    None, Read Only, Read Write.'
                                   type: string
                                 diskName:
-                                  description: diskName is the Name of the data disk
-                                    in the blob storage
                                   type: string
                                 diskURI:
-                                  description: diskURI is the URI of data disk in
-                                    the blob storage
                                   type: string
                                 fsType:
                                   default: ext4
-                                  description: |-
-                                    fsType is Filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 kind:
-                                  description: 'kind expected values are Shared: multiple
-                                    blob disks per storage account  Dedicated: single
-                                    blob disk per storage account  Managed: azure
-                                    managed data disk (only in managed availability
-                                    set). defaults to shared'
                                   type: string
                                 readOnly:
                                   default: false
-                                  description: |-
-                                    readOnly Defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                               required:
                               - diskName
                               - diskURI
                               type: object
                             azureFile:
-                              description: |-
-                                azureFile represents an Azure File Service mount on the host and bind mount to the pod.
-                                Deprecated: AzureFile is deprecated. All operations for the in-tree azureFile type
-                                are redirected to the file.csi.azure.com CSI driver.
                               properties:
                                 readOnly:
-                                  description: |-
-                                    readOnly defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretName:
-                                  description: secretName is the  name of secret that
-                                    contains Azure Storage Account Name and Key
                                   type: string
                                 shareName:
-                                  description: shareName is the azure share Name
                                   type: string
                               required:
                               - secretName
                               - shareName
                               type: object
                             cephfs:
-                              description: |-
-                                cephFS represents a Ceph FS mount on the host that shares a pod's lifetime.
-                                Deprecated: CephFS is deprecated and the in-tree cephfs type is no longer supported.
                               properties:
                                 monitors:
-                                  description: |-
-                                    monitors is Required: Monitors is a collection of Ceph monitors
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 path:
-                                  description: 'path is Optional: Used as the mounted
-                                    root, rather than the full Ceph tree, default
-                                    is /'
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   type: boolean
                                 secretFile:
-                                  description: |-
-                                    secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   type: string
                                 secretRef:
-                                  description: |-
-                                    secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   properties:
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 user:
-                                  description: |-
-                                    user is optional: User is the rados user name, default is admin
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   type: string
                               required:
                               - monitors
                               type: object
                             cinder:
-                              description: |-
-                                cinder represents a cinder volume attached and mounted on kubelets host machine.
-                                Deprecated: Cinder is deprecated. All operations for the in-tree cinder type
-                                are redirected to the cinder.csi.openstack.org CSI driver.
-                                More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
-                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                   type: boolean
                                 secretRef:
-                                  description: |-
-                                    secretRef is optional: points to a secret object containing parameters used to connect
-                                    to OpenStack.
                                   properties:
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 volumeID:
-                                  description: |-
-                                    volumeID used to identify the volume in cinder.
-                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                   type: string
                               required:
                               - volumeID
                               type: object
                             configMap:
-                              description: configMap represents a configMap that should
-                                populate this volume
                               properties:
                                 defaultMode:
-                                  description: |-
-                                    defaultMode is optional: mode bits used to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                    Defaults to 0644.
-                                    Directories within the path are not affected by this setting.
-                                    This might be in conflict with other options that affect the file
-                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 items:
-                                  description: |-
-                                    items if unspecified, each key-value pair in the Data field of the referenced
-                                    ConfigMap will be projected into the volume as a file whose name is the
-                                    key and content is the value. If specified, the listed keys will be
-                                    projected into the specified paths, and unlisted keys will not be
-                                    present. If a key is specified which is not present in the ConfigMap,
-                                    the volume setup will error unless it is marked optional. Paths must be
-                                    relative and may not contain the '..' path or start with '..'.
                                   items:
-                                    description: Maps a string key to a path within
-                                      a volume.
                                     properties:
                                       key:
-                                        description: key is the key to project.
                                         type: string
                                       mode:
-                                        description: |-
-                                          mode is Optional: mode bits used to set permissions on this file.
-                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                          If not specified, the volume defaultMode will be used.
-                                          This might be in conflict with other options that affect the file
-                                          mode, like fsGroup, and the result can be other mode bits set.
                                         format: int32
                                         type: integer
                                       path:
-                                        description: |-
-                                          path is the relative path of the file to map the key to.
-                                          May not be an absolute path.
-                                          May not contain the path element '..'.
-                                          May not start with the string '..'.
                                         type: string
                                     required:
                                     - key
@@ -1931,148 +916,67 @@ spec:
                                   x-kubernetes-list-type: atomic
                                 name:
                                   default: ""
-                                  description: |-
-                                    Name of the referent.
-                                    This field is effectively required, but due to backwards compatibility is
-                                    allowed to be empty. Instances of this type with an empty value here are
-                                    almost certainly wrong.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                   type: string
                                 optional:
-                                  description: optional specify whether the ConfigMap
-                                    or its keys must be defined
                                   type: boolean
                               type: object
                               x-kubernetes-map-type: atomic
                             csi:
-                              description: csi (Container Storage Interface) represents
-                                ephemeral storage that is handled by certain external
-                                CSI drivers.
                               properties:
                                 driver:
-                                  description: |-
-                                    driver is the name of the CSI driver that handles this volume.
-                                    Consult with your admin for the correct name as registered in the cluster.
                                   type: string
                                 fsType:
-                                  description: |-
-                                    fsType to mount. Ex. "ext4", "xfs", "ntfs".
-                                    If not provided, the empty value is passed to the associated CSI driver
-                                    which will determine the default filesystem to apply.
                                   type: string
                                 nodePublishSecretRef:
-                                  description: |-
-                                    nodePublishSecretRef is a reference to the secret object containing
-                                    sensitive information to pass to the CSI driver to complete the CSI
-                                    NodePublishVolume and NodeUnpublishVolume calls.
-                                    This field is optional, and  may be empty if no secret is required. If the
-                                    secret object contains more than one secret, all secret references are passed.
                                   properties:
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 readOnly:
-                                  description: |-
-                                    readOnly specifies a read-only configuration for the volume.
-                                    Defaults to false (read/write).
                                   type: boolean
                                 volumeAttributes:
                                   additionalProperties:
                                     type: string
-                                  description: |-
-                                    volumeAttributes stores driver-specific properties that are passed to the CSI
-                                    driver. Consult your driver's documentation for supported values.
                                   type: object
                               required:
                               - driver
                               type: object
                             downwardAPI:
-                              description: downwardAPI represents downward API about
-                                the pod that should populate this volume
                               properties:
                                 defaultMode:
-                                  description: |-
-                                    Optional: mode bits to use on created files by default. Must be a
-                                    Optional: mode bits used to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                    Defaults to 0644.
-                                    Directories within the path are not affected by this setting.
-                                    This might be in conflict with other options that affect the file
-                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 items:
-                                  description: Items is a list of downward API volume
-                                    file
                                   items:
-                                    description: DownwardAPIVolumeFile represents
-                                      information to create the file containing the
-                                      pod field
                                     properties:
                                       fieldRef:
-                                        description: 'Required: Selects a field of
-                                          the pod: only annotations, labels, name,
-                                          namespace and uid are supported.'
                                         properties:
                                           apiVersion:
-                                            description: Version of the schema the
-                                              FieldPath is written in terms of, defaults
-                                              to "v1".
                                             type: string
                                           fieldPath:
-                                            description: Path of the field to select
-                                              in the specified API version.
                                             type: string
                                         required:
                                         - fieldPath
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       mode:
-                                        description: |-
-                                          Optional: mode bits used to set permissions on this file, must be an octal value
-                                          between 0000 and 0777 or a decimal value between 0 and 511.
-                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                          If not specified, the volume defaultMode will be used.
-                                          This might be in conflict with other options that affect the file
-                                          mode, like fsGroup, and the result can be other mode bits set.
                                         format: int32
                                         type: integer
                                       path:
-                                        description: 'Required: Path is  the relative
-                                          path name of the file to be created. Must
-                                          not be absolute or contain the ''..'' path.
-                                          Must be utf-8 encoded. The first item of
-                                          the relative path must not start with ''..'''
                                         type: string
                                       resourceFieldRef:
-                                        description: |-
-                                          Selects a resource of the container: only resources limits and requests
-                                          (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                         properties:
                                           containerName:
-                                            description: 'Container name: required
-                                              for volumes, optional for env vars'
                                             type: string
                                           divisor:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Specifies the output format
-                                              of the exposed resources, defaults to
-                                              "1"
                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
                                           resource:
-                                            description: 'Required: resource to select'
                                             type: string
                                         required:
                                         - resource
@@ -2085,127 +989,36 @@ spec:
                                   x-kubernetes-list-type: atomic
                               type: object
                             emptyDir:
-                              description: |-
-                                emptyDir represents a temporary directory that shares a pod's lifetime.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                               properties:
                                 medium:
-                                  description: |-
-                                    medium represents what type of storage medium should back this directory.
-                                    The default is "" which means to use the node's default medium.
-                                    Must be an empty string (default) or Memory.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                   type: string
                                 sizeLimit:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: |-
-                                    sizeLimit is the total amount of local storage required for this EmptyDir volume.
-                                    The size limit is also applicable for memory medium.
-                                    The maximum usage on memory medium EmptyDir would be the minimum value between
-                                    the SizeLimit specified here and the sum of memory limits of all containers in a pod.
-                                    The default is nil which means that the limit is undefined.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                               type: object
                             ephemeral:
-                              description: |-
-                                ephemeral represents a volume that is handled by a cluster storage driver.
-                                The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
-                                and deleted when the pod is removed.
-
-                                Use this if:
-                                a) the volume is only needed while the pod runs,
-                                b) features of normal volumes like restoring from snapshot or capacity
-                                   tracking are needed,
-                                c) the storage driver is specified through a storage class, and
-                                d) the storage driver supports dynamic volume provisioning through
-                                   a PersistentVolumeClaim (see EphemeralVolumeSource for more
-                                   information on the connection between this volume type
-                                   and PersistentVolumeClaim).
-
-                                Use PersistentVolumeClaim or one of the vendor-specific
-                                APIs for volumes that persist for longer than the lifecycle
-                                of an individual pod.
-
-                                Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
-                                be used that way - see the documentation of the driver for
-                                more information.
-
-                                A pod can use both types of ephemeral volumes and
-                                persistent volumes at the same time.
                               properties:
                                 volumeClaimTemplate:
-                                  description: |-
-                                    Will be used to create a stand-alone PVC to provision the volume.
-                                    The pod in which this EphemeralVolumeSource is embedded will be the
-                                    owner of the PVC, i.e. the PVC will be deleted together with the
-                                    pod.  The name of the PVC will be `<pod name>-<volume name>` where
-                                    `<volume name>` is the name from the `PodSpec.Volumes` array
-                                    entry. Pod validation will reject the pod if the concatenated name
-                                    is not valid for a PVC (for example, too long).
-
-                                    An existing PVC with that name that is not owned by the pod
-                                    will *not* be used for the pod to avoid using an unrelated
-                                    volume by mistake. Starting the pod is then blocked until
-                                    the unrelated PVC is removed. If such a pre-created PVC is
-                                    meant to be used by the pod, the PVC has to updated with an
-                                    owner reference to the pod once the pod exists. Normally
-                                    this should not be necessary, but it may be useful when
-                                    manually reconstructing a broken cluster.
-
-                                    This field is read-only and no changes will be made by Kubernetes
-                                    to the PVC after it has been created.
-
-                                    Required, must not be nil.
                                   properties:
                                     metadata:
-                                      description: |-
-                                        May contain labels and annotations that will be copied into the PVC
-                                        when creating it. No other fields are allowed and will be rejected during
-                                        validation.
                                       type: object
                                     spec:
-                                      description: |-
-                                        The specification for the PersistentVolumeClaim. The entire content is
-                                        copied unchanged into the PVC that gets created from this
-                                        template. The same fields as in a PersistentVolumeClaim
-                                        are also valid here.
                                       properties:
                                         accessModes:
-                                          description: |-
-                                            accessModes contains the desired access modes the volume should have.
-                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
                                           items:
                                             type: string
                                           type: array
                                           x-kubernetes-list-type: atomic
                                         dataSource:
-                                          description: |-
-                                            dataSource field can be used to specify either:
-                                            * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-                                            * An existing PVC (PersistentVolumeClaim)
-                                            If the provisioner or an external controller can support the specified data source,
-                                            it will create a new volume based on the contents of the specified data source.
-                                            When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
-                                            and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
-                                            If the namespace is specified, then dataSourceRef will not be copied to dataSource.
                                           properties:
                                             apiGroup:
-                                              description: |-
-                                                APIGroup is the group for the resource being referenced.
-                                                If APIGroup is not specified, the specified Kind must be in the core API group.
-                                                For any other third-party types, APIGroup is required.
                                               type: string
                                             kind:
-                                              description: Kind is the type of resource
-                                                being referenced
                                               type: string
                                             name:
-                                              description: Name is the name of resource
-                                                being referenced
                                               type: string
                                           required:
                                           - kind
@@ -2213,62 +1026,20 @@ spec:
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         dataSourceRef:
-                                          description: |-
-                                            dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
-                                            volume is desired. This may be any object from a non-empty API group (non
-                                            core object) or a PersistentVolumeClaim object.
-                                            When this field is specified, volume binding will only succeed if the type of
-                                            the specified object matches some installed volume populator or dynamic
-                                            provisioner.
-                                            This field will replace the functionality of the dataSource field and as such
-                                            if both fields are non-empty, they must have the same value. For backwards
-                                            compatibility, when namespace isn't specified in dataSourceRef,
-                                            both fields (dataSource and dataSourceRef) will be set to the same
-                                            value automatically if one of them is empty and the other is non-empty.
-                                            When namespace is specified in dataSourceRef,
-                                            dataSource isn't set to the same value and must be empty.
-                                            There are three important differences between dataSource and dataSourceRef:
-                                            * While dataSource only allows two specific types of objects, dataSourceRef
-                                              allows any non-core object, as well as PersistentVolumeClaim objects.
-                                            * While dataSource ignores disallowed values (dropping them), dataSourceRef
-                                              preserves all values, and generates an error if a disallowed value is
-                                              specified.
-                                            * While dataSource only allows local objects, dataSourceRef allows objects
-                                              in any namespaces.
-                                            (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
-                                            (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                           properties:
                                             apiGroup:
-                                              description: |-
-                                                APIGroup is the group for the resource being referenced.
-                                                If APIGroup is not specified, the specified Kind must be in the core API group.
-                                                For any other third-party types, APIGroup is required.
                                               type: string
                                             kind:
-                                              description: Kind is the type of resource
-                                                being referenced
                                               type: string
                                             name:
-                                              description: Name is the name of resource
-                                                being referenced
                                               type: string
                                             namespace:
-                                              description: |-
-                                                Namespace is the namespace of resource being referenced
-                                                Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
-                                                (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                               type: string
                                           required:
                                           - kind
                                           - name
                                           type: object
                                         resources:
-                                          description: |-
-                                            resources represents the minimum resources the volume should have.
-                                            Users are allowed to specify resource requirements
-                                            that are lower than previous value but must still be higher than capacity recorded in the
-                                            status field of the claim.
-                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
                                           properties:
                                             limits:
                                               additionalProperties:
@@ -2277,9 +1048,6 @@ spec:
                                                 - type: string
                                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                 x-kubernetes-int-or-string: true
-                                              description: |-
-                                                Limits describes the maximum amount of compute resources allowed.
-                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                               type: object
                                             requests:
                                               additionalProperties:
@@ -2288,42 +1056,18 @@ spec:
                                                 - type: string
                                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                 x-kubernetes-int-or-string: true
-                                              description: |-
-                                                Requests describes the minimum amount of compute resources required.
-                                                If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                                otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                               type: object
                                           type: object
                                         selector:
-                                          description: selector is a label query over
-                                            volumes to consider for binding.
                                           properties:
                                             matchExpressions:
-                                              description: matchExpressions is a list
-                                                of label selector requirements. The
-                                                requirements are ANDed.
                                               items:
-                                                description: |-
-                                                  A label selector requirement is a selector that contains values, a key, and an operator that
-                                                  relates the key and values.
                                                 properties:
                                                   key:
-                                                    description: key is the label
-                                                      key that the selector applies
-                                                      to.
                                                     type: string
                                                   operator:
-                                                    description: |-
-                                                      operator represents a key's relationship to a set of values.
-                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                                     type: string
                                                   values:
-                                                    description: |-
-                                                      values is an array of string values. If the operator is In or NotIn,
-                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                      the values array must be empty. This array is replaced during a strategic
-                                                      merge patch.
                                                     items:
                                                       type: string
                                                     type: array
@@ -2337,39 +1081,16 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: |-
-                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         storageClassName:
-                                          description: |-
-                                            storageClassName is the name of the StorageClass required by the claim.
-                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
                                           type: string
                                         volumeAttributesClassName:
-                                          description: |-
-                                            volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
-                                            If specified, the CSI driver will create or update the volume with the attributes defined
-                                            in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                                            it can be changed after the claim is created. An empty string or nil value indicates that no
-                                            VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
-                                            this field can be reset to its previous value (including nil) to cancel the modification.
-                                            If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
-                                            set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
-                                            exists.
-                                            More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
                                           type: string
                                         volumeMode:
-                                          description: |-
-                                            volumeMode defines what type of volume is required by the claim.
-                                            Value of Filesystem is implied when not included in claim spec.
                                           type: string
                                         volumeName:
-                                          description: volumeName is the binding reference
-                                            to the PersistentVolume backing this claim.
                                           type: string
                                       type: object
                                   required:
@@ -2377,84 +1098,41 @@ spec:
                                   type: object
                               type: object
                             fc:
-                              description: fc represents a Fibre Channel resource
-                                that is attached to a kubelet's host machine and then
-                                exposed to the pod.
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 lun:
-                                  description: 'lun is Optional: FC target lun number'
                                   format: int32
                                   type: integer
                                 readOnly:
-                                  description: |-
-                                    readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 targetWWNs:
-                                  description: 'targetWWNs is Optional: FC target
-                                    worldwide names (WWNs)'
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 wwids:
-                                  description: |-
-                                    wwids Optional: FC volume world wide identifiers (wwids)
-                                    Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                               type: object
                             flexVolume:
-                              description: |-
-                                flexVolume represents a generic volume resource that is
-                                provisioned/attached using an exec based plugin.
-                                Deprecated: FlexVolume is deprecated. Consider using a CSIDriver instead.
                               properties:
                                 driver:
-                                  description: driver is the name of the driver to
-                                    use for this volume.
                                   type: string
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
                                   type: string
                                 options:
                                   additionalProperties:
                                     type: string
-                                  description: 'options is Optional: this field holds
-                                    extra command options if any.'
                                   type: object
                                 readOnly:
-                                  description: |-
-                                    readOnly is Optional: defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: |-
-                                    secretRef is Optional: secretRef is reference to the secret object containing
-                                    sensitive information to pass to the plugin scripts. This may be
-                                    empty if no secret object is specified. If the secret object
-                                    contains more than one secret, all secrets are passed to the plugin
-                                    scripts.
                                   properties:
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -2462,236 +1140,98 @@ spec:
                               - driver
                               type: object
                             flocker:
-                              description: |-
-                                flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running.
-                                Deprecated: Flocker is deprecated and the in-tree flocker type is no longer supported.
                               properties:
                                 datasetName:
-                                  description: |-
-                                    datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
-                                    should be considered as deprecated
                                   type: string
                                 datasetUUID:
-                                  description: datasetUUID is the UUID of the dataset.
-                                    This is unique identifier of a Flocker dataset
                                   type: string
                               type: object
                             gcePersistentDisk:
-                              description: |-
-                                gcePersistentDisk represents a GCE Disk resource that is attached to a
-                                kubelet's host machine and then exposed to the pod.
-                                Deprecated: GCEPersistentDisk is deprecated. All operations for the in-tree
-                                gcePersistentDisk type are redirected to the pd.csi.storage.gke.io CSI driver.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is filesystem type of the volume that you want to mount.
-                                    Tip: Ensure that the filesystem type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                   type: string
                                 partition:
-                                  description: |-
-                                    partition is the partition in the volume that you want to mount.
-                                    If omitted, the default is to mount by volume name.
-                                    Examples: For volume /dev/sda1, you specify the partition as "1".
-                                    Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                   format: int32
                                   type: integer
                                 pdName:
-                                  description: |-
-                                    pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the ReadOnly setting in VolumeMounts.
-                                    Defaults to false.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                   type: boolean
                               required:
                               - pdName
                               type: object
                             gitRepo:
-                              description: |-
-                                gitRepo represents a git repository at a particular revision.
-                                Deprecated: GitRepo is deprecated. To provision a container with a git repo, mount an
-                                EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
-                                into the Pod's container.
                               properties:
                                 directory:
-                                  description: |-
-                                    directory is the target directory name.
-                                    Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the
-                                    git repository.  Otherwise, if specified, the volume will contain the git repository in
-                                    the subdirectory with the given name.
                                   type: string
                                 repository:
-                                  description: repository is the URL
                                   type: string
                                 revision:
-                                  description: revision is the commit hash for the
-                                    specified revision.
                                   type: string
                               required:
                               - repository
                               type: object
                             glusterfs:
-                              description: |-
-                                glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
-                                Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.
                               properties:
                                 endpoints:
-                                  description: endpoints is the endpoint name that
-                                    details Glusterfs topology.
                                   type: string
                                 path:
-                                  description: |-
-                                    path is the Glusterfs volume path.
-                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
-                                    Defaults to false.
-                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                   type: boolean
                               required:
                               - endpoints
                               - path
                               type: object
                             hostPath:
-                              description: |-
-                                hostPath represents a pre-existing file or directory on the host
-                                machine that is directly exposed to the container. This is generally
-                                used for system agents or other privileged things that are allowed
-                                to see the host machine. Most containers will NOT need this.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                               properties:
                                 path:
-                                  description: |-
-                                    path of the directory on the host.
-                                    If the path is a symlink, it will follow the link to the real path.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                                   type: string
                                 type:
-                                  description: |-
-                                    type for HostPath Volume
-                                    Defaults to ""
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                                   type: string
                               required:
                               - path
                               type: object
                             image:
-                              description: |-
-                                image represents an OCI object (a container image or artifact) pulled and mounted on the kubelet's host machine.
-                                The volume is resolved at pod startup depending on which PullPolicy value is provided:
-
-                                - Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
-                                - Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
-                                - IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
-
-                                The volume gets re-resolved if the pod gets deleted and recreated, which means that new remote content will become available on pod recreation.
-                                A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
-                                The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
-                                The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                                The volume will be mounted read-only (ro) and non-executable files (noexec).
-                                Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
-                                The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                               properties:
                                 pullPolicy:
-                                  description: |-
-                                    Policy for pulling OCI objects. Possible values are:
-                                    Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
-                                    Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
-                                    IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
-                                    Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
                                   type: string
                                 reference:
-                                  description: |-
-                                    Required: Image or artifact reference to be used.
-                                    Behaves in the same way as pod.spec.containers[*].image.
-                                    Pull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.
-                                    More info: https://kubernetes.io/docs/concepts/containers/images
-                                    This field is optional to allow higher level config management to default or override
-                                    container images in workload controllers like Deployments and StatefulSets.
                                   type: string
                               type: object
                             iscsi:
-                              description: |-
-                                iscsi represents an ISCSI Disk resource that is attached to a
-                                kubelet's host machine and then exposed to the pod.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes/#iscsi
                               properties:
                                 chapAuthDiscovery:
-                                  description: chapAuthDiscovery defines whether support
-                                    iSCSI Discovery CHAP authentication
                                   type: boolean
                                 chapAuthSession:
-                                  description: chapAuthSession defines whether support
-                                    iSCSI Session CHAP authentication
                                   type: boolean
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type of the volume that you want to mount.
-                                    Tip: Ensure that the filesystem type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
                                   type: string
                                 initiatorName:
-                                  description: |-
-                                    initiatorName is the custom iSCSI Initiator Name.
-                                    If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface
-                                    <target portal>:<volume name> will be created for the connection.
                                   type: string
                                 iqn:
-                                  description: iqn is the target iSCSI Qualified Name.
                                   type: string
                                 iscsiInterface:
                                   default: default
-                                  description: |-
-                                    iscsiInterface is the interface Name that uses an iSCSI transport.
-                                    Defaults to 'default' (tcp).
                                   type: string
                                 lun:
-                                  description: lun represents iSCSI Target Lun number.
                                   format: int32
                                   type: integer
                                 portals:
-                                  description: |-
-                                    portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port
-                                    is other than default (typically TCP ports 860 and 3260).
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the ReadOnly setting in VolumeMounts.
-                                    Defaults to false.
                                   type: boolean
                                 secretRef:
-                                  description: secretRef is the CHAP Secret for iSCSI
-                                    target and initiator authentication
                                   properties:
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 targetPortal:
-                                  description: |-
-                                    targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
-                                    is other than default (typically TCP ports 860 and 3260).
                                   type: string
                               required:
                               - iqn
@@ -2699,169 +1239,68 @@ spec:
                               - targetPortal
                               type: object
                             name:
-                              description: |-
-                                name of the volume.
-                                Must be a DNS_LABEL and unique within the pod.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                               type: string
                             nfs:
-                              description: |-
-                                nfs represents an NFS mount on the host that shares a pod's lifetime
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                               properties:
                                 path:
-                                  description: |-
-                                    path that is exported by the NFS server.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the NFS export to be mounted with read-only permissions.
-                                    Defaults to false.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                   type: boolean
                                 server:
-                                  description: |-
-                                    server is the hostname or IP address of the NFS server.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                   type: string
                               required:
                               - path
                               - server
                               type: object
                             persistentVolumeClaim:
-                              description: |-
-                                persistentVolumeClaimVolumeSource represents a reference to a
-                                PersistentVolumeClaim in the same namespace.
-                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                               properties:
                                 claimName:
-                                  description: |-
-                                    claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
-                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly Will force the ReadOnly setting in VolumeMounts.
-                                    Default false.
                                   type: boolean
                               required:
                               - claimName
                               type: object
                             photonPersistentDisk:
-                              description: |-
-                                photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine.
-                                Deprecated: PhotonPersistentDisk is deprecated and the in-tree photonPersistentDisk type is no longer supported.
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 pdID:
-                                  description: pdID is the ID that identifies Photon
-                                    Controller persistent disk
                                   type: string
                               required:
                               - pdID
                               type: object
                             portworxVolume:
-                              description: |-
-                                portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
-                                Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                                are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                                is on.
                               properties:
                                 fsType:
-                                  description: |-
-                                    fSType represents the filesystem type to mount
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 volumeID:
-                                  description: volumeID uniquely identifies a Portworx
-                                    volume
                                   type: string
                               required:
                               - volumeID
                               type: object
                             projected:
-                              description: projected items for all in one resources
-                                secrets, configmaps, and downward API
                               properties:
                                 defaultMode:
-                                  description: |-
-                                    defaultMode are the mode bits used to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                    Directories within the path are not affected by this setting.
-                                    This might be in conflict with other options that affect the file
-                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 sources:
-                                  description: |-
-                                    sources is the list of volume projections. Each entry in this list
-                                    handles one source.
                                   items:
-                                    description: |-
-                                      Projection that may be projected along with other supported volume types.
-                                      Exactly one of these fields must be set.
                                     properties:
                                       clusterTrustBundle:
-                                        description: |-
-                                          ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
-                                          of ClusterTrustBundle objects in an auto-updating file.
-
-                                          Alpha, gated by the ClusterTrustBundleProjection feature gate.
-
-                                          ClusterTrustBundle objects can either be selected by name, or by the
-                                          combination of signer name and a label selector.
-
-                                          Kubelet performs aggressive normalization of the PEM contents written
-                                          into the pod filesystem.  Esoteric PEM features such as inter-block
-                                          comments and block headers are stripped.  Certificates are deduplicated.
-                                          The ordering of certificates within the file is arbitrary, and Kubelet
-                                          may change the order over time.
                                         properties:
                                           labelSelector:
-                                            description: |-
-                                              Select all ClusterTrustBundles that match this label selector.  Only has
-                                              effect if signerName is set.  Mutually-exclusive with name.  If unset,
-                                              interpreted as "match nothing".  If set but empty, interpreted as "match
-                                              everything".
                                             properties:
                                               matchExpressions:
-                                                description: matchExpressions is a
-                                                  list of label selector requirements.
-                                                  The requirements are ANDed.
                                                 items:
-                                                  description: |-
-                                                    A label selector requirement is a selector that contains values, a key, and an operator that
-                                                    relates the key and values.
                                                   properties:
                                                     key:
-                                                      description: key is the label
-                                                        key that the selector applies
-                                                        to.
                                                       type: string
                                                     operator:
-                                                      description: |-
-                                                        operator represents a key's relationship to a set of values.
-                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
                                                       type: string
                                                     values:
-                                                      description: |-
-                                                        values is an array of string values. If the operator is In or NotIn,
-                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                        the values array must be empty. This array is replaced during a strategic
-                                                        merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -2875,75 +1314,31 @@ spec:
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
-                                                description: |-
-                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                 type: object
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           name:
-                                            description: |-
-                                              Select a single ClusterTrustBundle by object name.  Mutually-exclusive
-                                              with signerName and labelSelector.
                                             type: string
                                           optional:
-                                            description: |-
-                                              If true, don't block pod startup if the referenced ClusterTrustBundle(s)
-                                              aren't available.  If using name, then the named ClusterTrustBundle is
-                                              allowed not to exist.  If using signerName, then the combination of
-                                              signerName and labelSelector is allowed to match zero
-                                              ClusterTrustBundles.
                                             type: boolean
                                           path:
-                                            description: Relative path from the volume
-                                              root to write the bundle.
                                             type: string
                                           signerName:
-                                            description: |-
-                                              Select all ClusterTrustBundles that match this signer name.
-                                              Mutually-exclusive with name.  The contents of all selected
-                                              ClusterTrustBundles will be unified and deduplicated.
                                             type: string
                                         required:
                                         - path
                                         type: object
                                       configMap:
-                                        description: configMap information about the
-                                          configMap data to project
                                         properties:
                                           items:
-                                            description: |-
-                                              items if unspecified, each key-value pair in the Data field of the referenced
-                                              ConfigMap will be projected into the volume as a file whose name is the
-                                              key and content is the value. If specified, the listed keys will be
-                                              projected into the specified paths, and unlisted keys will not be
-                                              present. If a key is specified which is not present in the ConfigMap,
-                                              the volume setup will error unless it is marked optional. Paths must be
-                                              relative and may not contain the '..' path or start with '..'.
                                             items:
-                                              description: Maps a string key to a
-                                                path within a volume.
                                               properties:
                                                 key:
-                                                  description: key is the key to project.
                                                   type: string
                                                 mode:
-                                                  description: |-
-                                                    mode is Optional: mode bits used to set permissions on this file.
-                                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                                    If not specified, the volume defaultMode will be used.
-                                                    This might be in conflict with other options that affect the file
-                                                    mode, like fsGroup, and the result can be other mode bits set.
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: |-
-                                                    path is the relative path of the file to map the key to.
-                                                    May not be an absolute path.
-                                                    May not contain the path element '..'.
-                                                    May not start with the string '..'.
                                                   type: string
                                               required:
                                               - key
@@ -2953,92 +1348,42 @@ spec:
                                             x-kubernetes-list-type: atomic
                                           name:
                                             default: ""
-                                            description: |-
-                                              Name of the referent.
-                                              This field is effectively required, but due to backwards compatibility is
-                                              allowed to be empty. Instances of this type with an empty value here are
-                                              almost certainly wrong.
-                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                             type: string
                                           optional:
-                                            description: optional specify whether
-                                              the ConfigMap or its keys must be defined
                                             type: boolean
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       downwardAPI:
-                                        description: downwardAPI information about
-                                          the downwardAPI data to project
                                         properties:
                                           items:
-                                            description: Items is a list of DownwardAPIVolume
-                                              file
                                             items:
-                                              description: DownwardAPIVolumeFile represents
-                                                information to create the file containing
-                                                the pod field
                                               properties:
                                                 fieldRef:
-                                                  description: 'Required: Selects
-                                                    a field of the pod: only annotations,
-                                                    labels, name, namespace and uid
-                                                    are supported.'
                                                   properties:
                                                     apiVersion:
-                                                      description: Version of the
-                                                        schema the FieldPath is written
-                                                        in terms of, defaults to "v1".
                                                       type: string
                                                     fieldPath:
-                                                      description: Path of the field
-                                                        to select in the specified
-                                                        API version.
                                                       type: string
                                                   required:
                                                   - fieldPath
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 mode:
-                                                  description: |-
-                                                    Optional: mode bits used to set permissions on this file, must be an octal value
-                                                    between 0000 and 0777 or a decimal value between 0 and 511.
-                                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                                    If not specified, the volume defaultMode will be used.
-                                                    This might be in conflict with other options that affect the file
-                                                    mode, like fsGroup, and the result can be other mode bits set.
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: 'Required: Path is  the
-                                                    relative path name of the file
-                                                    to be created. Must not be absolute
-                                                    or contain the ''..'' path. Must
-                                                    be utf-8 encoded. The first item
-                                                    of the relative path must not
-                                                    start with ''..'''
                                                   type: string
                                                 resourceFieldRef:
-                                                  description: |-
-                                                    Selects a resource of the container: only resources limits and requests
-                                                    (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                                   properties:
                                                     containerName:
-                                                      description: 'Container name:
-                                                        required for volumes, optional
-                                                        for env vars'
                                                       type: string
                                                     divisor:
                                                       anyOf:
                                                       - type: integer
                                                       - type: string
-                                                      description: Specifies the output
-                                                        format of the exposed resources,
-                                                        defaults to "1"
                                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                       x-kubernetes-int-or-string: true
                                                     resource:
-                                                      description: 'Required: resource
-                                                        to select'
                                                       type: string
                                                   required:
                                                   - resource
@@ -3051,164 +1396,39 @@ spec:
                                             x-kubernetes-list-type: atomic
                                         type: object
                                       podCertificate:
-                                        description: |-
-                                          Projects an auto-rotating credential bundle (private key and certificate
-                                          chain) that the pod can use either as a TLS client or server.
-
-                                          Kubelet generates a private key and uses it to send a
-                                          PodCertificateRequest to the named signer.  Once the signer approves the
-                                          request and issues a certificate chain, Kubelet writes the key and
-                                          certificate chain to the pod filesystem.  The pod does not start until
-                                          certificates have been issued for each podCertificate projected volume
-                                          source in its spec.
-
-                                          Kubelet will begin trying to rotate the certificate at the time indicated
-                                          by the signer using the PodCertificateRequest.Status.BeginRefreshAt
-                                          timestamp.
-
-                                          Kubelet can write a single file, indicated by the credentialBundlePath
-                                          field, or separate files, indicated by the keyPath and
-                                          certificateChainPath fields.
-
-                                          The credential bundle is a single file in PEM format.  The first PEM
-                                          entry is the private key (in PKCS#8 format), and the remaining PEM
-                                          entries are the certificate chain issued by the signer (typically,
-                                          signers will return their certificate chain in leaf-to-root order).
-
-                                          Prefer using the credential bundle format, since your application code
-                                          can read it atomically.  If you use keyPath and certificateChainPath,
-                                          your application must make two separate file reads. If these coincide
-                                          with a certificate rotation, it is possible that the private key and leaf
-                                          certificate you read may not correspond to each other.  Your application
-                                          will need to check for this condition, and re-read until they are
-                                          consistent.
-
-                                          The named signer controls chooses the format of the certificate it
-                                          issues; consult the signer implementation's documentation to learn how to
-                                          use the certificates it issues.
                                         properties:
                                           certificateChainPath:
-                                            description: |-
-                                              Write the certificate chain at this path in the projected volume.
-
-                                              Most applications should use credentialBundlePath.  When using keyPath
-                                              and certificateChainPath, your application needs to check that the key
-                                              and leaf certificate are consistent, because it is possible to read the
-                                              files mid-rotation.
                                             type: string
                                           credentialBundlePath:
-                                            description: |-
-                                              Write the credential bundle at this path in the projected volume.
-
-                                              The credential bundle is a single file that contains multiple PEM blocks.
-                                              The first PEM block is a PRIVATE KEY block, containing a PKCS#8 private
-                                              key.
-
-                                              The remaining blocks are CERTIFICATE blocks, containing the issued
-                                              certificate chain from the signer (leaf and any intermediates).
-
-                                              Using credentialBundlePath lets your Pod's application code make a single
-                                              atomic read that retrieves a consistent key and certificate chain.  If you
-                                              project them to separate files, your application code will need to
-                                              additionally check that the leaf certificate was issued to the key.
                                             type: string
                                           keyPath:
-                                            description: |-
-                                              Write the key at this path in the projected volume.
-
-                                              Most applications should use credentialBundlePath.  When using keyPath
-                                              and certificateChainPath, your application needs to check that the key
-                                              and leaf certificate are consistent, because it is possible to read the
-                                              files mid-rotation.
                                             type: string
                                           keyType:
-                                            description: |-
-                                              The type of keypair Kubelet will generate for the pod.
-
-                                              Valid values are "RSA3072", "RSA4096", "ECDSAP256", "ECDSAP384",
-                                              "ECDSAP521", and "ED25519".
                                             type: string
                                           maxExpirationSeconds:
-                                            description: |-
-                                              maxExpirationSeconds is the maximum lifetime permitted for the
-                                              certificate.
-
-                                              Kubelet copies this value verbatim into the PodCertificateRequests it
-                                              generates for this projection.
-
-                                              If omitted, kube-apiserver will set it to 86400(24 hours). kube-apiserver
-                                              will reject values shorter than 3600 (1 hour).  The maximum allowable
-                                              value is 7862400 (91 days).
-
-                                              The signer implementation is then free to issue a certificate with any
-                                              lifetime *shorter* than MaxExpirationSeconds, but no shorter than 3600
-                                              seconds (1 hour).  This constraint is enforced by kube-apiserver.
-                                              `kubernetes.io` signers will never issue certificates with a lifetime
-                                              longer than 24 hours.
                                             format: int32
                                             type: integer
                                           signerName:
-                                            description: Kubelet's generated CSRs
-                                              will be addressed to this signer.
                                             type: string
                                           userAnnotations:
                                             additionalProperties:
                                               type: string
-                                            description: |-
-                                              userAnnotations allow pod authors to pass additional information to
-                                              the signer implementation.  Kubernetes does not restrict or validate this
-                                              metadata in any way.
-
-                                              These values are copied verbatim into the `spec.unverifiedUserAnnotations` field of
-                                              the PodCertificateRequest objects that Kubelet creates.
-
-                                              Entries are subject to the same validation as object metadata annotations,
-                                              with the addition that all keys must be domain-prefixed. No restrictions
-                                              are placed on values, except an overall size limitation on the entire field.
-
-                                              Signers should document the keys and values they support. Signers should
-                                              deny requests that contain keys they do not recognize.
                                             type: object
                                         required:
                                         - keyType
                                         - signerName
                                         type: object
                                       secret:
-                                        description: secret information about the
-                                          secret data to project
                                         properties:
                                           items:
-                                            description: |-
-                                              items if unspecified, each key-value pair in the Data field of the referenced
-                                              Secret will be projected into the volume as a file whose name is the
-                                              key and content is the value. If specified, the listed keys will be
-                                              projected into the specified paths, and unlisted keys will not be
-                                              present. If a key is specified which is not present in the Secret,
-                                              the volume setup will error unless it is marked optional. Paths must be
-                                              relative and may not contain the '..' path or start with '..'.
                                             items:
-                                              description: Maps a string key to a
-                                                path within a volume.
                                               properties:
                                                 key:
-                                                  description: key is the key to project.
                                                   type: string
                                                 mode:
-                                                  description: |-
-                                                    mode is Optional: mode bits used to set permissions on this file.
-                                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                                    If not specified, the volume defaultMode will be used.
-                                                    This might be in conflict with other options that affect the file
-                                                    mode, like fsGroup, and the result can be other mode bits set.
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: |-
-                                                    path is the relative path of the file to map the key to.
-                                                    May not be an absolute path.
-                                                    May not contain the path element '..'.
-                                                    May not start with the string '..'.
                                                   type: string
                                               required:
                                               - key
@@ -3218,44 +1438,19 @@ spec:
                                             x-kubernetes-list-type: atomic
                                           name:
                                             default: ""
-                                            description: |-
-                                              Name of the referent.
-                                              This field is effectively required, but due to backwards compatibility is
-                                              allowed to be empty. Instances of this type with an empty value here are
-                                              almost certainly wrong.
-                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                             type: string
                                           optional:
-                                            description: optional field specify whether
-                                              the Secret or its key must be defined
                                             type: boolean
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       serviceAccountToken:
-                                        description: serviceAccountToken is information
-                                          about the serviceAccountToken data to project
                                         properties:
                                           audience:
-                                            description: |-
-                                              audience is the intended audience of the token. A recipient of a token
-                                              must identify itself with an identifier specified in the audience of the
-                                              token, and otherwise should reject the token. The audience defaults to the
-                                              identifier of the apiserver.
                                             type: string
                                           expirationSeconds:
-                                            description: |-
-                                              expirationSeconds is the requested duration of validity of the service
-                                              account token. As the token approaches expiration, the kubelet volume
-                                              plugin will proactively rotate the service account token. The kubelet will
-                                              start trying to rotate the token if the token is older than 80 percent of
-                                              its time to live or if the token is older than 24 hours.Defaults to 1 hour
-                                              and must be at least 10 minutes.
                                             format: int64
                                             type: integer
                                           path:
-                                            description: |-
-                                              path is the path relative to the mount point of the file to project the
-                                              token into.
                                             type: string
                                         required:
                                         - path
@@ -3265,182 +1460,84 @@ spec:
                                   x-kubernetes-list-type: atomic
                               type: object
                             quobyte:
-                              description: |-
-                                quobyte represents a Quobyte mount on the host that shares a pod's lifetime.
-                                Deprecated: Quobyte is deprecated and the in-tree quobyte type is no longer supported.
                               properties:
                                 group:
-                                  description: |-
-                                    group to map volume access to
-                                    Default is no group
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the Quobyte volume to be mounted with read-only permissions.
-                                    Defaults to false.
                                   type: boolean
                                 registry:
-                                  description: |-
-                                    registry represents a single or multiple Quobyte Registry services
-                                    specified as a string as host:port pair (multiple entries are separated with commas)
-                                    which acts as the central registry for volumes
                                   type: string
                                 tenant:
-                                  description: |-
-                                    tenant owning the given Quobyte volume in the Backend
-                                    Used with dynamically provisioned Quobyte volumes, value is set by the plugin
                                   type: string
                                 user:
-                                  description: |-
-                                    user to map volume access to
-                                    Defaults to serivceaccount user
                                   type: string
                                 volume:
-                                  description: volume is a string that references
-                                    an already created Quobyte volume by name.
                                   type: string
                               required:
                               - registry
                               - volume
                               type: object
                             rbd:
-                              description: |-
-                                rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
-                                Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type of the volume that you want to mount.
-                                    Tip: Ensure that the filesystem type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
                                   type: string
                                 image:
-                                  description: |-
-                                    image is the rados image name.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                                 keyring:
                                   default: /etc/ceph/keyring
-                                  description: |-
-                                    keyring is the path to key ring for RBDUser.
-                                    Default is /etc/ceph/keyring.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                                 monitors:
-                                  description: |-
-                                    monitors is a collection of Ceph monitors.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 pool:
                                   default: rbd
-                                  description: |-
-                                    pool is the rados pool name.
-                                    Default is rbd.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the ReadOnly setting in VolumeMounts.
-                                    Defaults to false.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: boolean
                                 secretRef:
-                                  description: |-
-                                    secretRef is name of the authentication secret for RBDUser. If provided
-                                    overrides keyring.
-                                    Default is nil.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   properties:
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 user:
                                   default: admin
-                                  description: |-
-                                    user is the rados user name.
-                                    Default is admin.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                               required:
                               - image
                               - monitors
                               type: object
                             scaleIO:
-                              description: |-
-                                scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
-                                Deprecated: ScaleIO is deprecated and the in-tree scaleIO type is no longer supported.
                               properties:
                                 fsType:
                                   default: xfs
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs".
-                                    Default is "xfs".
                                   type: string
                                 gateway:
-                                  description: gateway is the host address of the
-                                    ScaleIO API Gateway.
                                   type: string
                                 protectionDomain:
-                                  description: protectionDomain is the name of the
-                                    ScaleIO Protection Domain for the configured storage.
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly Defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: |-
-                                    secretRef references to the secret for ScaleIO user and other
-                                    sensitive information. If this is not provided, Login operation will fail.
                                   properties:
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 sslEnabled:
-                                  description: sslEnabled Flag enable/disable SSL
-                                    communication with Gateway, default false
                                   type: boolean
                                 storageMode:
                                   default: ThinProvisioned
-                                  description: |-
-                                    storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
-                                    Default is ThinProvisioned.
                                   type: string
                                 storagePool:
-                                  description: storagePool is the ScaleIO Storage
-                                    Pool associated with the protection domain.
                                   type: string
                                 system:
-                                  description: system is the name of the storage system
-                                    as configured in ScaleIO.
                                   type: string
                                 volumeName:
-                                  description: |-
-                                    volumeName is the name of a volume already created in the ScaleIO system
-                                    that is associated with this volume source.
                                   type: string
                               required:
                               - gateway
@@ -3448,53 +1545,19 @@ spec:
                               - system
                               type: object
                             secret:
-                              description: |-
-                                secret represents a secret that should populate this volume.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                               properties:
                                 defaultMode:
-                                  description: |-
-                                    defaultMode is Optional: mode bits used to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                    YAML accepts both octal and decimal values, JSON requires decimal values
-                                    for mode bits. Defaults to 0644.
-                                    Directories within the path are not affected by this setting.
-                                    This might be in conflict with other options that affect the file
-                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 items:
-                                  description: |-
-                                    items If unspecified, each key-value pair in the Data field of the referenced
-                                    Secret will be projected into the volume as a file whose name is the
-                                    key and content is the value. If specified, the listed keys will be
-                                    projected into the specified paths, and unlisted keys will not be
-                                    present. If a key is specified which is not present in the Secret,
-                                    the volume setup will error unless it is marked optional. Paths must be
-                                    relative and may not contain the '..' path or start with '..'.
                                   items:
-                                    description: Maps a string key to a path within
-                                      a volume.
                                     properties:
                                       key:
-                                        description: key is the key to project.
                                         type: string
                                       mode:
-                                        description: |-
-                                          mode is Optional: mode bits used to set permissions on this file.
-                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                          If not specified, the volume defaultMode will be used.
-                                          This might be in conflict with other options that affect the file
-                                          mode, like fsGroup, and the result can be other mode bits set.
                                         format: int32
                                         type: integer
                                       path:
-                                        description: |-
-                                          path is the relative path of the file to map the key to.
-                                          May not be an absolute path.
-                                          May not contain the path element '..'.
-                                          May not start with the string '..'.
                                         type: string
                                     required:
                                     - key
@@ -3503,86 +1566,37 @@ spec:
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 optional:
-                                  description: optional field specify whether the
-                                    Secret or its keys must be defined
                                   type: boolean
                                 secretName:
-                                  description: |-
-                                    secretName is the name of the secret in the pod's namespace to use.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                                   type: string
                               type: object
                             storageos:
-                              description: |-
-                                storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
-                                Deprecated: StorageOS is deprecated and the in-tree storageos type is no longer supported.
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: |-
-                                    secretRef specifies the secret to use for obtaining the StorageOS API
-                                    credentials.  If not specified, default values will be attempted.
                                   properties:
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 volumeName:
-                                  description: |-
-                                    volumeName is the human-readable name of the StorageOS volume.  Volume
-                                    names are only unique within a namespace.
                                   type: string
                                 volumeNamespace:
-                                  description: |-
-                                    volumeNamespace specifies the scope of the volume within StorageOS.  If no
-                                    namespace is specified then the Pod's namespace will be used.  This allows the
-                                    Kubernetes name scoping to be mirrored within StorageOS for tighter integration.
-                                    Set VolumeName to any name to override the default behaviour.
-                                    Set to "default" if you are not using namespaces within StorageOS.
-                                    Namespaces that do not pre-exist within StorageOS will be created.
                                   type: string
                               type: object
                             vsphereVolume:
-                              description: |-
-                                vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine.
-                                Deprecated: VsphereVolume is deprecated. All operations for the in-tree vsphereVolume type
-                                are redirected to the csi.vsphere.vmware.com CSI driver.
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 storagePolicyID:
-                                  description: storagePolicyID is the storage Policy
-                                    Based Management (SPBM) profile ID associated
-                                    with the StoragePolicyName.
                                   type: string
                                 storagePolicyName:
-                                  description: storagePolicyName is the storage Policy
-                                    Based Management (SPBM) profile name.
                                   type: string
                                 volumePath:
-                                  description: volumePath is the path that identifies
-                                    vSphere volume vmdk
                                   type: string
                               required:
                               - volumePath
@@ -3593,16 +1607,11 @@ spec:
                         type: array
                     type: object
                   automaticFailover:
-                    description: AutomaticFailover configures fenced automatic promotion.
                     properties:
                       enabled:
-                        description: Enabled allows the operator to promote a standby
-                          automatically.
                         type: boolean
                       fencingAuthority:
                         default: None
-                        description: FencingAuthority must be set to a concrete authority
-                          before automatic promotion.
                         enum:
                         - None
                         - KubernetesLease
@@ -3611,174 +1620,96 @@ spec:
                         - External
                         type: string
                       maximumLagLSN:
-                        description: MaximumLagLSN is the tolerated standby lag for
-                          automatic promotion.
                         format: int64
                         type: integer
                       requireRemoteApply:
                         default: true
-                        description: RequireRemoteApply requires an applied standby
-                          before automatic promotion.
                         type: boolean
                     type: object
                   identity:
-                    description: Identity identifies the replicated HA unit for admin/fencing
-                      commands.
                     properties:
                       clusterID:
-                        description: ClusterID is the stable replicated cluster identifier.
                         format: int64
                         type: integer
                       currentPrimaryID:
-                        description: CurrentPrimaryID is the logical id of the current
-                          primary.
                         type: string
                       epoch:
-                        description: Epoch is the current primary epoch.
                         format: int64
                         type: integer
                       shardID:
-                        description: ShardID is the replicated shard identifier. Zero
-                          means whole-instance or default shard scope.
                         format: int64
                         type: integer
                       tableID:
-                        description: TableID is the replicated table identifier. Zero
-                          means whole-instance or default table scope.
                         format: int64
                         type: integer
                       timelineID:
-                        description: TimelineID is the current primary timeline.
                         format: int64
                         type: integer
                     type: object
                   mode:
                     default: Disabled
-                    description: Mode selects whether hot standby is managed.
                     enum:
                     - Disabled
                     - HotStandby
                     type: string
                   retention:
-                    description: Retention caps WAL retention pressure from replication
-                      slots.
                     properties:
                       maxLagLSN:
-                        description: |-
-                          MaxLagLSN marks standbys for reseed after this many retained LSNs.
-                          Zero disables the cap.
                         format: int64
                         type: integer
                       maxRetainedAgeNS:
-                        description: |-
-                          MaxRetainedAgeNS marks oldest standbys for reseed when retained WAL timestamp span exceeds this cap.
-                          Zero disables the cap.
                         format: int64
                         type: integer
                       maxRetainedBytes:
-                        description: |-
-                          MaxRetainedBytes marks oldest standbys for reseed when retained WAL bytes exceed this cap.
-                          Zero disables the cap.
                         format: int64
                         type: integer
                     type: object
                   runtime:
-                    description: |-
-                      Runtime configures the local Zig antfly swarm HA runtime role and durable WAL paths.
-                      Supported only when spec.mode=Swarm; split metadata/data topology HA process wiring is not yet modeled here.
                     properties:
                       adminTokenEnvVar:
-                        description: |-
-                          AdminTokenEnvVar is the Antfly process environment variable containing the bearer token required by /admin/v1/ha.
-                          When set, the operator passes --ha-admin-token-env and the runtime rejects typed HA admin requests without a matching Authorization header.
-                          Populate it with adminTokenSecretRef or spec.swarm.envFrom.
                         pattern: ^$|^[A-Za-z_][A-Za-z0-9_]*$
                         type: string
                       adminTokenSecretRef:
-                        description: |-
-                          AdminTokenSecretRef injects AdminTokenEnvVar from a required Secret key into the Antfly runtime container.
-                          Use this when the token is not already provided by spec.swarm.envFrom. optional must not be true.
                         properties:
                           key:
-                            description: The key of the secret to select from.  Must
-                              be a valid secret key.
                             type: string
                           name:
                             default: ""
-                            description: |-
-                              Name of the referent.
-                              This field is effectively required, but due to backwards compatibility is
-                              allowed to be empty. Instances of this type with an empty value here are
-                              almost certainly wrong.
-                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                             type: string
                           optional:
-                            description: Specify whether the Secret or its key must
-                              be defined
                             type: boolean
                         required:
                         - key
                         type: object
                         x-kubernetes-map-type: atomic
                       fencePath:
-                        description: |-
-                          FencePath is the durable promotion fence WAL path shared by HA admin fence and promotion operations.
-                          Defaults to /antflydb/ha/fence.wal.
                         type: string
                       formerPrimaryLogPath:
-                        description: |-
-                          FormerPrimaryLogPath is the durable HA replication log used by former-primary rewind admin workflows.
-                          Set this on nodes that may need to rejoin after failover; for a primary this is usually the same path
-                          as primary.logPath, and the Swarm runtime wiring defaults it to primary.logPath when omitted.
                         type: string
                       nodeID:
-                        description: NodeID is the logical HA node id used in typed
-                          admin receipts and fencing.
                         minLength: 1
                         type: string
                       primary:
-                        description: Primary configures primary-side durable HA state.
-                          Defaults are under /antflydb/ha.
                         properties:
                           logPath:
-                            description: |-
-                              LogPath is the durable HA primary replication log path.
-                              Defaults to /antflydb/ha/primary.wal.
                             type: string
                           slotsPath:
-                            description: |-
-                              SlotsPath is the durable HA replication slot store path.
-                              Defaults to /antflydb/ha/slots.
                             type: string
                         type: object
                       role:
-                        description: Role selects whether this process opens primary
-                          or standby HA runtime state.
                         enum:
                         - Primary
                         - Standby
                         type: string
                       standby:
-                        description: Standby configures standby-side durable HA state
-                          and optional continuous pull source.
                         properties:
                           logPath:
-                            description: |-
-                              LogPath is the durable received-WAL log path.
-                              Defaults to /antflydb/ha/standby.wal.
                             type: string
                           progressPath:
-                            description: |-
-                              ProgressPath is the durable standby apply progress WAL path.
-                              Defaults to /antflydb/ha/standby-progress.wal.
                             type: string
                           slotName:
-                            description: SlotName is the upstream replication slot
-                              used by this standby.
                             type: string
                           upstreamURL:
-                            description: UpstreamURL is the primary internal replication
-                              base URL for continuous pull/apply.
                             type: string
                         type: object
                     required:
@@ -3786,67 +1717,39 @@ spec:
                     - role
                     type: object
                   standbys:
-                    description: Standbys declares desired standby replicas and replication
-                      slots.
                     items:
-                      description: HAStandbySpec declares one desired hot standby.
                       properties:
                         adminURL:
-                          description: AdminURL is the standby HA admin endpoint used
-                            for typed status and promotion actions.
                           type: string
                         desired:
                           default: true
-                          description: Desired controls whether the operator should
-                            keep this standby attached.
                           type: boolean
                         dropSlotOnRemoval:
-                          description: |-
-                            DropSlotOnRemoval lets the operator drop this standby's replication slot after desired is set false.
-                            This releases WAL retention and is destructive for the standby; keep false to pause the slot instead.
                           type: boolean
                         initialLSN:
-                          description: InitialLSN optionally pins slot creation to
-                            an existing primary LSN.
                           format: int64
                           type: integer
                         name:
-                          description: Name is the logical standby and default replication
-                            slot name.
                           minLength: 1
                           type: string
                         routeSelector:
                           additionalProperties:
                             type: string
-                          description: RouteSelector is the public-api Service selector
-                            to use when this standby is promoted.
                           type: object
                         seedContentRoot:
-                          description: |-
-                            SeedContentRoot is the copied base-backup content root visible to the standby CLI-backed HA admin Job.
-                            Defaults to the manifest parent directory when omitted.
                           type: string
                         seedManifestPath:
-                          description: |-
-                            SeedManifestPath is the base-backup manifest path visible to CLI-backed HA admin Jobs.
-                            When set, the operator can run seed finish on the primary and seed bootstrap on this standby.
                           type: string
                         slotName:
-                          description: SlotName overrides the replication slot name.
-                            Defaults to name.
                           type: string
                       required:
                       - name
                       type: object
                     type: array
                   syncPolicy:
-                    description: SyncPolicy configures async, remote-write, or remote-apply
-                      durability.
                     properties:
                       failurePolicy:
                         default: Block
-                        description: FailurePolicy controls writes when synchronous
-                          durability is unavailable.
                         enum:
                         - Block
                         - FailClosed
@@ -3854,119 +1757,58 @@ spec:
                         type: string
                       mode:
                         default: Async
-                        description: Mode selects async, remote-write, or remote-apply
-                          acknowledgement.
                         enum:
                         - Async
                         - RemoteWrite
                         - RemoteApply
                         type: string
                       required:
-                        description: Required is the number of standbys needed for
-                          Any/First policies.
                         format: int32
                         minimum: 1
                         type: integer
                       selection:
                         default: Any
-                        description: Selection chooses how named standbys satisfy
-                          the policy.
                         enum:
                         - Any
                         - First
                         - All
                         type: string
                       standbyNames:
-                        description: StandbyNames are the synchronous standby names
-                          in priority order.
                         items:
                           type: string
                         type: array
                     type: object
                 type: object
               image:
-                description: Image is the container image to use for Antfly
                 type: string
               imagePullPolicy:
-                description: ImagePullPolicy defines the image pull policy
                 type: string
               inference:
-                description: |-
-                  Inference configures inference pools used by this cluster.
-                  Pools may be owned by this cluster, referenced as customer-managed shared
-                  pools, or referenced as platform-managed shared pools.
                 properties:
                   managedPools:
-                    description: |-
-                      ManagedPools are InferencePools created and owned by this AntflyCluster.
-                      Valid when mode is Managed.
                     items:
-                      description: ManagedInferencePoolSpec describes one InferencePool
-                        owned by an AntflyCluster.
                       properties:
                         name:
-                          description: |-
-                            Name is the child InferencePool name. If omitted for a single managed pool,
-                            the operator uses "<antflycluster-name>-inference".
                           type: string
                         spec:
-                          description: Spec is the InferencePool spec to apply to
-                            the child pool.
                           properties:
                             affinity:
-                              description: |-
-                                Affinity defines affinity rules for pod scheduling.
-                                Cloud-provider-specific affinity rules (e.g., EKS instance type preference)
-                                are appended to any user-specified node affinity preferred terms.
                               properties:
                                 nodeAffinity:
-                                  description: Describes node affinity scheduling
-                                    rules for the pod.
                                   properties:
                                     preferredDuringSchedulingIgnoredDuringExecution:
-                                      description: |-
-                                        The scheduler will prefer to schedule pods to nodes that satisfy
-                                        the affinity expressions specified by this field, but it may choose
-                                        a node that violates one or more of the expressions. The node that is
-                                        most preferred is the one with the greatest sum of weights, i.e.
-                                        for each node that meets all of the scheduling requirements (resource
-                                        request, requiredDuringScheduling affinity expressions, etc.),
-                                        compute a sum by iterating through the elements of this field and adding
-                                        "weight" to the sum if the node matches the corresponding matchExpressions; the
-                                        node(s) with the highest sum are the most preferred.
                                       items:
-                                        description: |-
-                                          An empty preferred scheduling term matches all objects with implicit weight 0
-                                          (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
                                         properties:
                                           preference:
-                                            description: A node selector term, associated
-                                              with the corresponding weight.
                                             properties:
                                               matchExpressions:
-                                                description: A list of node selector
-                                                  requirements by node's labels.
                                                 items:
-                                                  description: |-
-                                                    A node selector requirement is a selector that contains values, a key, and an operator
-                                                    that relates the key and values.
                                                   properties:
                                                     key:
-                                                      description: The label key that
-                                                        the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: |-
-                                                        Represents a key's relationship to a set of values.
-                                                        Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                       type: string
                                                     values:
-                                                      description: |-
-                                                        An array of string values. If the operator is In or NotIn,
-                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                        the values array must be empty. If the operator is Gt or Lt, the values
-                                                        array must have a single element, which will be interpreted as an integer.
-                                                        This array is replaced during a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -3978,29 +1820,13 @@ spec:
                                                 type: array
                                                 x-kubernetes-list-type: atomic
                                               matchFields:
-                                                description: A list of node selector
-                                                  requirements by node's fields.
                                                 items:
-                                                  description: |-
-                                                    A node selector requirement is a selector that contains values, a key, and an operator
-                                                    that relates the key and values.
                                                   properties:
                                                     key:
-                                                      description: The label key that
-                                                        the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: |-
-                                                        Represents a key's relationship to a set of values.
-                                                        Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                       type: string
                                                     values:
-                                                      description: |-
-                                                        An array of string values. If the operator is In or NotIn,
-                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                        the values array must be empty. If the operator is Gt or Lt, the values
-                                                        array must have a single element, which will be interpreted as an integer.
-                                                        This array is replaced during a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -4014,9 +1840,6 @@ spec:
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           weight:
-                                            description: Weight associated with matching
-                                              the corresponding nodeSelectorTerm,
-                                              in the range 1-100.
                                             format: int32
                                             type: integer
                                         required:
@@ -4026,46 +1849,18 @@ spec:
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     requiredDuringSchedulingIgnoredDuringExecution:
-                                      description: |-
-                                        If the affinity requirements specified by this field are not met at
-                                        scheduling time, the pod will not be scheduled onto the node.
-                                        If the affinity requirements specified by this field cease to be met
-                                        at some point during pod execution (e.g. due to an update), the system
-                                        may or may not try to eventually evict the pod from its node.
                                       properties:
                                         nodeSelectorTerms:
-                                          description: Required. A list of node selector
-                                            terms. The terms are ORed.
                                           items:
-                                            description: |-
-                                              A null or empty node selector term matches no objects. The requirements of
-                                              them are ANDed.
-                                              The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
                                             properties:
                                               matchExpressions:
-                                                description: A list of node selector
-                                                  requirements by node's labels.
                                                 items:
-                                                  description: |-
-                                                    A node selector requirement is a selector that contains values, a key, and an operator
-                                                    that relates the key and values.
                                                   properties:
                                                     key:
-                                                      description: The label key that
-                                                        the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: |-
-                                                        Represents a key's relationship to a set of values.
-                                                        Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                       type: string
                                                     values:
-                                                      description: |-
-                                                        An array of string values. If the operator is In or NotIn,
-                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                        the values array must be empty. If the operator is Gt or Lt, the values
-                                                        array must have a single element, which will be interpreted as an integer.
-                                                        This array is replaced during a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -4077,29 +1872,13 @@ spec:
                                                 type: array
                                                 x-kubernetes-list-type: atomic
                                               matchFields:
-                                                description: A list of node selector
-                                                  requirements by node's fields.
                                                 items:
-                                                  description: |-
-                                                    A node selector requirement is a selector that contains values, a key, and an operator
-                                                    that relates the key and values.
                                                   properties:
                                                     key:
-                                                      description: The label key that
-                                                        the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: |-
-                                                        Represents a key's relationship to a set of values.
-                                                        Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                       type: string
                                                     values:
-                                                      description: |-
-                                                        An array of string values. If the operator is In or NotIn,
-                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                        the values array must be empty. If the operator is Gt or Lt, the values
-                                                        array must have a single element, which will be interpreted as an integer.
-                                                        This array is replaced during a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -4120,62 +1899,22 @@ spec:
                                       x-kubernetes-map-type: atomic
                                   type: object
                                 podAffinity:
-                                  description: Describes pod affinity scheduling rules
-                                    (e.g. co-locate this pod in the same node, zone,
-                                    etc. as some other pod(s)).
                                   properties:
                                     preferredDuringSchedulingIgnoredDuringExecution:
-                                      description: |-
-                                        The scheduler will prefer to schedule pods to nodes that satisfy
-                                        the affinity expressions specified by this field, but it may choose
-                                        a node that violates one or more of the expressions. The node that is
-                                        most preferred is the one with the greatest sum of weights, i.e.
-                                        for each node that meets all of the scheduling requirements (resource
-                                        request, requiredDuringScheduling affinity expressions, etc.),
-                                        compute a sum by iterating through the elements of this field and adding
-                                        "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
-                                        node(s) with the highest sum are the most preferred.
                                       items:
-                                        description: The weights of all of the matched
-                                          WeightedPodAffinityTerm fields are added
-                                          per-node to find the most preferred node(s)
                                         properties:
                                           podAffinityTerm:
-                                            description: Required. A pod affinity
-                                              term, associated with the corresponding
-                                              weight.
                                             properties:
                                               labelSelector:
-                                                description: |-
-                                                  A label query over a set of resources, in this case pods.
-                                                  If it's null, this PodAffinityTerm matches with no Pods.
                                                 properties:
                                                   matchExpressions:
-                                                    description: matchExpressions
-                                                      is a list of label selector
-                                                      requirements. The requirements
-                                                      are ANDed.
                                                     items:
-                                                      description: |-
-                                                        A label selector requirement is a selector that contains values, a key, and an operator that
-                                                        relates the key and values.
                                                       properties:
                                                         key:
-                                                          description: key is the
-                                                            label key that the selector
-                                                            applies to.
                                                           type: string
                                                         operator:
-                                                          description: |-
-                                                            operator represents a key's relationship to a set of values.
-                                                            Valid operators are In, NotIn, Exists and DoesNotExist.
                                                           type: string
                                                         values:
-                                                          description: |-
-                                                            values is an array of string values. If the operator is In or NotIn,
-                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                            the values array must be empty. This array is replaced during a strategic
-                                                            merge patch.
                                                           items:
                                                             type: string
                                                           type: array
@@ -4189,75 +1928,29 @@ spec:
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
-                                                    description: |-
-                                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                     type: object
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               matchLabelKeys:
-                                                description: |-
-                                                  MatchLabelKeys is a set of pod label keys to select which pods will
-                                                  be taken into consideration. The keys are used to lookup values from the
-                                                  incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                                  to select the group of existing pods which pods will be taken into consideration
-                                                  for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                                  pod labels will be ignored. The default value is empty.
-                                                  The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                                  Also, matchLabelKeys cannot be set when labelSelector isn't set.
                                                 items:
                                                   type: string
                                                 type: array
                                                 x-kubernetes-list-type: atomic
                                               mismatchLabelKeys:
-                                                description: |-
-                                                  MismatchLabelKeys is a set of pod label keys to select which pods will
-                                                  be taken into consideration. The keys are used to lookup values from the
-                                                  incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                                  to select the group of existing pods which pods will be taken into consideration
-                                                  for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                                  pod labels will be ignored. The default value is empty.
-                                                  The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                                  Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
                                                 items:
                                                   type: string
                                                 type: array
                                                 x-kubernetes-list-type: atomic
                                               namespaceSelector:
-                                                description: |-
-                                                  A label query over the set of namespaces that the term applies to.
-                                                  The term is applied to the union of the namespaces selected by this field
-                                                  and the ones listed in the namespaces field.
-                                                  null selector and null or empty namespaces list means "this pod's namespace".
-                                                  An empty selector ({}) matches all namespaces.
                                                 properties:
                                                   matchExpressions:
-                                                    description: matchExpressions
-                                                      is a list of label selector
-                                                      requirements. The requirements
-                                                      are ANDed.
                                                     items:
-                                                      description: |-
-                                                        A label selector requirement is a selector that contains values, a key, and an operator that
-                                                        relates the key and values.
                                                       properties:
                                                         key:
-                                                          description: key is the
-                                                            label key that the selector
-                                                            applies to.
                                                           type: string
                                                         operator:
-                                                          description: |-
-                                                            operator represents a key's relationship to a set of values.
-                                                            Valid operators are In, NotIn, Exists and DoesNotExist.
                                                           type: string
                                                         values:
-                                                          description: |-
-                                                            values is an array of string values. If the operator is In or NotIn,
-                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                            the values array must be empty. This array is replaced during a strategic
-                                                            merge patch.
                                                           items:
                                                             type: string
                                                           type: array
@@ -4271,38 +1964,20 @@ spec:
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
-                                                    description: |-
-                                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                     type: object
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               namespaces:
-                                                description: |-
-                                                  namespaces specifies a static list of namespace names that the term applies to.
-                                                  The term is applied to the union of the namespaces listed in this field
-                                                  and the ones selected by namespaceSelector.
-                                                  null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                                 items:
                                                   type: string
                                                 type: array
                                                 x-kubernetes-list-type: atomic
                                               topologyKey:
-                                                description: |-
-                                                  This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
-                                                  the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                                  whose value of the label with key topologyKey matches that of any node on which any of the
-                                                  selected pods is running.
-                                                  Empty topologyKey is not allowed.
                                                 type: string
                                             required:
                                             - topologyKey
                                             type: object
                                           weight:
-                                            description: |-
-                                              weight associated with matching the corresponding podAffinityTerm,
-                                              in the range 1-100.
                                             format: int32
                                             type: integer
                                         required:
@@ -4312,53 +1987,18 @@ spec:
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     requiredDuringSchedulingIgnoredDuringExecution:
-                                      description: |-
-                                        If the affinity requirements specified by this field are not met at
-                                        scheduling time, the pod will not be scheduled onto the node.
-                                        If the affinity requirements specified by this field cease to be met
-                                        at some point during pod execution (e.g. due to a pod label update), the
-                                        system may or may not try to eventually evict the pod from its node.
-                                        When there are multiple elements, the lists of nodes corresponding to each
-                                        podAffinityTerm are intersected, i.e. all terms must be satisfied.
                                       items:
-                                        description: |-
-                                          Defines a set of pods (namely those matching the labelSelector
-                                          relative to the given namespace(s)) that this pod should be
-                                          co-located (affinity) or not co-located (anti-affinity) with,
-                                          where co-located is defined as running on a node whose value of
-                                          the label with key <topologyKey> matches that of any node on which
-                                          a pod of the set of pods is running
                                         properties:
                                           labelSelector:
-                                            description: |-
-                                              A label query over a set of resources, in this case pods.
-                                              If it's null, this PodAffinityTerm matches with no Pods.
                                             properties:
                                               matchExpressions:
-                                                description: matchExpressions is a
-                                                  list of label selector requirements.
-                                                  The requirements are ANDed.
                                                 items:
-                                                  description: |-
-                                                    A label selector requirement is a selector that contains values, a key, and an operator that
-                                                    relates the key and values.
                                                   properties:
                                                     key:
-                                                      description: key is the label
-                                                        key that the selector applies
-                                                        to.
                                                       type: string
                                                     operator:
-                                                      description: |-
-                                                        operator represents a key's relationship to a set of values.
-                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
                                                       type: string
                                                     values:
-                                                      description: |-
-                                                        values is an array of string values. If the operator is In or NotIn,
-                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                        the values array must be empty. This array is replaced during a strategic
-                                                        merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -4372,74 +2012,29 @@ spec:
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
-                                                description: |-
-                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                 type: object
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           matchLabelKeys:
-                                            description: |-
-                                              MatchLabelKeys is a set of pod label keys to select which pods will
-                                              be taken into consideration. The keys are used to lookup values from the
-                                              incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                              to select the group of existing pods which pods will be taken into consideration
-                                              for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                              pod labels will be ignored. The default value is empty.
-                                              The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                              Also, matchLabelKeys cannot be set when labelSelector isn't set.
                                             items:
                                               type: string
                                             type: array
                                             x-kubernetes-list-type: atomic
                                           mismatchLabelKeys:
-                                            description: |-
-                                              MismatchLabelKeys is a set of pod label keys to select which pods will
-                                              be taken into consideration. The keys are used to lookup values from the
-                                              incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                              to select the group of existing pods which pods will be taken into consideration
-                                              for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                              pod labels will be ignored. The default value is empty.
-                                              The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                              Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
                                             items:
                                               type: string
                                             type: array
                                             x-kubernetes-list-type: atomic
                                           namespaceSelector:
-                                            description: |-
-                                              A label query over the set of namespaces that the term applies to.
-                                              The term is applied to the union of the namespaces selected by this field
-                                              and the ones listed in the namespaces field.
-                                              null selector and null or empty namespaces list means "this pod's namespace".
-                                              An empty selector ({}) matches all namespaces.
                                             properties:
                                               matchExpressions:
-                                                description: matchExpressions is a
-                                                  list of label selector requirements.
-                                                  The requirements are ANDed.
                                                 items:
-                                                  description: |-
-                                                    A label selector requirement is a selector that contains values, a key, and an operator that
-                                                    relates the key and values.
                                                   properties:
                                                     key:
-                                                      description: key is the label
-                                                        key that the selector applies
-                                                        to.
                                                       type: string
                                                     operator:
-                                                      description: |-
-                                                        operator represents a key's relationship to a set of values.
-                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
                                                       type: string
                                                     values:
-                                                      description: |-
-                                                        values is an array of string values. If the operator is In or NotIn,
-                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                        the values array must be empty. This array is replaced during a strategic
-                                                        merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -4453,30 +2048,15 @@ spec:
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
-                                                description: |-
-                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                 type: object
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           namespaces:
-                                            description: |-
-                                              namespaces specifies a static list of namespace names that the term applies to.
-                                              The term is applied to the union of the namespaces listed in this field
-                                              and the ones selected by namespaceSelector.
-                                              null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                             items:
                                               type: string
                                             type: array
                                             x-kubernetes-list-type: atomic
                                           topologyKey:
-                                            description: |-
-                                              This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
-                                              the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                              whose value of the label with key topologyKey matches that of any node on which any of the
-                                              selected pods is running.
-                                              Empty topologyKey is not allowed.
                                             type: string
                                         required:
                                         - topologyKey
@@ -4485,62 +2065,22 @@ spec:
                                       x-kubernetes-list-type: atomic
                                   type: object
                                 podAntiAffinity:
-                                  description: Describes pod anti-affinity scheduling
-                                    rules (e.g. avoid putting this pod in the same
-                                    node, zone, etc. as some other pod(s)).
                                   properties:
                                     preferredDuringSchedulingIgnoredDuringExecution:
-                                      description: |-
-                                        The scheduler will prefer to schedule pods to nodes that satisfy
-                                        the anti-affinity expressions specified by this field, but it may choose
-                                        a node that violates one or more of the expressions. The node that is
-                                        most preferred is the one with the greatest sum of weights, i.e.
-                                        for each node that meets all of the scheduling requirements (resource
-                                        request, requiredDuringScheduling anti-affinity expressions, etc.),
-                                        compute a sum by iterating through the elements of this field and subtracting
-                                        "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
-                                        node(s) with the highest sum are the most preferred.
                                       items:
-                                        description: The weights of all of the matched
-                                          WeightedPodAffinityTerm fields are added
-                                          per-node to find the most preferred node(s)
                                         properties:
                                           podAffinityTerm:
-                                            description: Required. A pod affinity
-                                              term, associated with the corresponding
-                                              weight.
                                             properties:
                                               labelSelector:
-                                                description: |-
-                                                  A label query over a set of resources, in this case pods.
-                                                  If it's null, this PodAffinityTerm matches with no Pods.
                                                 properties:
                                                   matchExpressions:
-                                                    description: matchExpressions
-                                                      is a list of label selector
-                                                      requirements. The requirements
-                                                      are ANDed.
                                                     items:
-                                                      description: |-
-                                                        A label selector requirement is a selector that contains values, a key, and an operator that
-                                                        relates the key and values.
                                                       properties:
                                                         key:
-                                                          description: key is the
-                                                            label key that the selector
-                                                            applies to.
                                                           type: string
                                                         operator:
-                                                          description: |-
-                                                            operator represents a key's relationship to a set of values.
-                                                            Valid operators are In, NotIn, Exists and DoesNotExist.
                                                           type: string
                                                         values:
-                                                          description: |-
-                                                            values is an array of string values. If the operator is In or NotIn,
-                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                            the values array must be empty. This array is replaced during a strategic
-                                                            merge patch.
                                                           items:
                                                             type: string
                                                           type: array
@@ -4554,75 +2094,29 @@ spec:
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
-                                                    description: |-
-                                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                     type: object
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               matchLabelKeys:
-                                                description: |-
-                                                  MatchLabelKeys is a set of pod label keys to select which pods will
-                                                  be taken into consideration. The keys are used to lookup values from the
-                                                  incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                                  to select the group of existing pods which pods will be taken into consideration
-                                                  for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                                  pod labels will be ignored. The default value is empty.
-                                                  The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                                  Also, matchLabelKeys cannot be set when labelSelector isn't set.
                                                 items:
                                                   type: string
                                                 type: array
                                                 x-kubernetes-list-type: atomic
                                               mismatchLabelKeys:
-                                                description: |-
-                                                  MismatchLabelKeys is a set of pod label keys to select which pods will
-                                                  be taken into consideration. The keys are used to lookup values from the
-                                                  incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                                  to select the group of existing pods which pods will be taken into consideration
-                                                  for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                                  pod labels will be ignored. The default value is empty.
-                                                  The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                                  Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
                                                 items:
                                                   type: string
                                                 type: array
                                                 x-kubernetes-list-type: atomic
                                               namespaceSelector:
-                                                description: |-
-                                                  A label query over the set of namespaces that the term applies to.
-                                                  The term is applied to the union of the namespaces selected by this field
-                                                  and the ones listed in the namespaces field.
-                                                  null selector and null or empty namespaces list means "this pod's namespace".
-                                                  An empty selector ({}) matches all namespaces.
                                                 properties:
                                                   matchExpressions:
-                                                    description: matchExpressions
-                                                      is a list of label selector
-                                                      requirements. The requirements
-                                                      are ANDed.
                                                     items:
-                                                      description: |-
-                                                        A label selector requirement is a selector that contains values, a key, and an operator that
-                                                        relates the key and values.
                                                       properties:
                                                         key:
-                                                          description: key is the
-                                                            label key that the selector
-                                                            applies to.
                                                           type: string
                                                         operator:
-                                                          description: |-
-                                                            operator represents a key's relationship to a set of values.
-                                                            Valid operators are In, NotIn, Exists and DoesNotExist.
                                                           type: string
                                                         values:
-                                                          description: |-
-                                                            values is an array of string values. If the operator is In or NotIn,
-                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                            the values array must be empty. This array is replaced during a strategic
-                                                            merge patch.
                                                           items:
                                                             type: string
                                                           type: array
@@ -4636,38 +2130,20 @@ spec:
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
-                                                    description: |-
-                                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                     type: object
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               namespaces:
-                                                description: |-
-                                                  namespaces specifies a static list of namespace names that the term applies to.
-                                                  The term is applied to the union of the namespaces listed in this field
-                                                  and the ones selected by namespaceSelector.
-                                                  null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                                 items:
                                                   type: string
                                                 type: array
                                                 x-kubernetes-list-type: atomic
                                               topologyKey:
-                                                description: |-
-                                                  This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
-                                                  the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                                  whose value of the label with key topologyKey matches that of any node on which any of the
-                                                  selected pods is running.
-                                                  Empty topologyKey is not allowed.
                                                 type: string
                                             required:
                                             - topologyKey
                                             type: object
                                           weight:
-                                            description: |-
-                                              weight associated with matching the corresponding podAffinityTerm,
-                                              in the range 1-100.
                                             format: int32
                                             type: integer
                                         required:
@@ -4677,53 +2153,18 @@ spec:
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     requiredDuringSchedulingIgnoredDuringExecution:
-                                      description: |-
-                                        If the anti-affinity requirements specified by this field are not met at
-                                        scheduling time, the pod will not be scheduled onto the node.
-                                        If the anti-affinity requirements specified by this field cease to be met
-                                        at some point during pod execution (e.g. due to a pod label update), the
-                                        system may or may not try to eventually evict the pod from its node.
-                                        When there are multiple elements, the lists of nodes corresponding to each
-                                        podAffinityTerm are intersected, i.e. all terms must be satisfied.
                                       items:
-                                        description: |-
-                                          Defines a set of pods (namely those matching the labelSelector
-                                          relative to the given namespace(s)) that this pod should be
-                                          co-located (affinity) or not co-located (anti-affinity) with,
-                                          where co-located is defined as running on a node whose value of
-                                          the label with key <topologyKey> matches that of any node on which
-                                          a pod of the set of pods is running
                                         properties:
                                           labelSelector:
-                                            description: |-
-                                              A label query over a set of resources, in this case pods.
-                                              If it's null, this PodAffinityTerm matches with no Pods.
                                             properties:
                                               matchExpressions:
-                                                description: matchExpressions is a
-                                                  list of label selector requirements.
-                                                  The requirements are ANDed.
                                                 items:
-                                                  description: |-
-                                                    A label selector requirement is a selector that contains values, a key, and an operator that
-                                                    relates the key and values.
                                                   properties:
                                                     key:
-                                                      description: key is the label
-                                                        key that the selector applies
-                                                        to.
                                                       type: string
                                                     operator:
-                                                      description: |-
-                                                        operator represents a key's relationship to a set of values.
-                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
                                                       type: string
                                                     values:
-                                                      description: |-
-                                                        values is an array of string values. If the operator is In or NotIn,
-                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                        the values array must be empty. This array is replaced during a strategic
-                                                        merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -4737,74 +2178,29 @@ spec:
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
-                                                description: |-
-                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                 type: object
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           matchLabelKeys:
-                                            description: |-
-                                              MatchLabelKeys is a set of pod label keys to select which pods will
-                                              be taken into consideration. The keys are used to lookup values from the
-                                              incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                              to select the group of existing pods which pods will be taken into consideration
-                                              for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                              pod labels will be ignored. The default value is empty.
-                                              The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                              Also, matchLabelKeys cannot be set when labelSelector isn't set.
                                             items:
                                               type: string
                                             type: array
                                             x-kubernetes-list-type: atomic
                                           mismatchLabelKeys:
-                                            description: |-
-                                              MismatchLabelKeys is a set of pod label keys to select which pods will
-                                              be taken into consideration. The keys are used to lookup values from the
-                                              incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                              to select the group of existing pods which pods will be taken into consideration
-                                              for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                              pod labels will be ignored. The default value is empty.
-                                              The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                              Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
                                             items:
                                               type: string
                                             type: array
                                             x-kubernetes-list-type: atomic
                                           namespaceSelector:
-                                            description: |-
-                                              A label query over the set of namespaces that the term applies to.
-                                              The term is applied to the union of the namespaces selected by this field
-                                              and the ones listed in the namespaces field.
-                                              null selector and null or empty namespaces list means "this pod's namespace".
-                                              An empty selector ({}) matches all namespaces.
                                             properties:
                                               matchExpressions:
-                                                description: matchExpressions is a
-                                                  list of label selector requirements.
-                                                  The requirements are ANDed.
                                                 items:
-                                                  description: |-
-                                                    A label selector requirement is a selector that contains values, a key, and an operator that
-                                                    relates the key and values.
                                                   properties:
                                                     key:
-                                                      description: key is the label
-                                                        key that the selector applies
-                                                        to.
                                                       type: string
                                                     operator:
-                                                      description: |-
-                                                        operator represents a key's relationship to a set of values.
-                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
                                                       type: string
                                                     values:
-                                                      description: |-
-                                                        values is an array of string values. If the operator is In or NotIn,
-                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                        the values array must be empty. This array is replaced during a strategic
-                                                        merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -4818,30 +2214,15 @@ spec:
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
-                                                description: |-
-                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                 type: object
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           namespaces:
-                                            description: |-
-                                              namespaces specifies a static list of namespace names that the term applies to.
-                                              The term is applied to the union of the namespaces listed in this field
-                                              and the ones selected by namespaceSelector.
-                                              null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                             items:
                                               type: string
                                             type: array
                                             x-kubernetes-list-type: atomic
                                           topologyKey:
-                                            description: |-
-                                              This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
-                                              the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                              whose value of the label with key topologyKey matches that of any node on which any of the
-                                              selected pods is running.
-                                              Empty topologyKey is not allowed.
                                             type: string
                                         required:
                                         - topologyKey
@@ -4851,45 +2232,26 @@ spec:
                                   type: object
                               type: object
                             autoscaling:
-                              description: Autoscaling defines autoscaling behavior
                               properties:
                                 enabled:
                                   default: true
-                                  description: Enabled toggles autoscaling
                                   type: boolean
                                 metrics:
-                                  description: Metrics defines scaling triggers
                                   items:
-                                    description: ScalingMetric defines a single scaling
-                                      trigger
                                     properties:
                                       endpoint:
-                                        description: Endpoint is the API endpoint
-                                          to measure (for latency metrics)
                                         type: string
                                       scaleDown:
-                                        description: ScaleDown defines scale-down
-                                          behavior
                                         properties:
                                           policies:
-                                            description: Policies defines scaling
-                                              policies
                                             items:
-                                              description: ScalingPolicy defines a
-                                                single scaling policy
                                               properties:
                                                 periodSeconds:
-                                                  description: PeriodSeconds is the
-                                                    time window for this policy
                                                   format: int32
                                                   type: integer
                                                 type:
-                                                  description: Type is the policy
-                                                    type (Pods or Percent)
                                                   type: string
                                                 value:
-                                                  description: Value is the scaling
-                                                    amount
                                                   format: int32
                                                   type: integer
                                               required:
@@ -4899,32 +2261,19 @@ spec:
                                               type: object
                                             type: array
                                           stabilizationWindow:
-                                            description: StabilizationWindow is the
-                                              time to wait before scaling
                                             type: string
                                         type: object
                                       scaleUp:
-                                        description: ScaleUp defines scale-up behavior
                                         properties:
                                           policies:
-                                            description: Policies defines scaling
-                                              policies
                                             items:
-                                              description: ScalingPolicy defines a
-                                                single scaling policy
                                               properties:
                                                 periodSeconds:
-                                                  description: PeriodSeconds is the
-                                                    time window for this policy
                                                   format: int32
                                                   type: integer
                                                 type:
-                                                  description: Type is the policy
-                                                    type (Pods or Percent)
                                                   type: string
                                                 value:
-                                                  description: Value is the scaling
-                                                    amount
                                                   format: int32
                                                   type: integer
                                               required:
@@ -4934,16 +2283,11 @@ spec:
                                               type: object
                                             type: array
                                           stabilizationWindow:
-                                            description: StabilizationWindow is the
-                                              time to wait before scaling
                                             type: string
                                         type: object
                                       target:
-                                        description: Target is the target value (interpretation
-                                          depends on type)
                                         type: string
                                       type:
-                                        description: Type is the metric type
                                         enum:
                                         - queue-depth
                                         - latency-p99
@@ -4959,190 +2303,113 @@ spec:
                                     type: object
                                   type: array
                                 modelLoadingGracePeriod:
-                                  description: ModelLoadingGracePeriod prevents scale-down
-                                    during model loading
                                   type: string
                                 scaleDownStabilization:
-                                  description: ScaleDownStabilization is the stabilization
-                                    window for scale-down
                                   type: string
                                 warmupReplicas:
-                                  description: WarmupReplicas is the number of replicas
-                                    to pre-warm before traffic
                                   format: int32
                                   type: integer
                               type: object
                             availability:
-                              description: Availability defines availability configuration
                               properties:
                                 livenessProbe:
-                                  description: LivenessProbe configuration
                                   properties:
                                     failureThreshold:
-                                      description: FailureThreshold is the number
-                                        of failures before marking unhealthy
                                       format: int32
                                       type: integer
                                     periodSeconds:
-                                      description: PeriodSeconds is the probe interval
                                       format: int32
                                       type: integer
                                     timeoutSeconds:
-                                      description: TimeoutSeconds is the probe timeout
                                       format: int32
                                       type: integer
                                   type: object
                                 podDisruptionBudget:
-                                  description: PodDisruptionBudget configuration
                                   properties:
                                     enabled:
                                       default: false
-                                      description: Enabled indicates if PodDisruptionBudget
-                                        should be created
                                       type: boolean
                                     maxUnavailable:
-                                      description: MaxUnavailable is the maximum unavailable
-                                        pods
                                       format: int32
                                       type: integer
                                     minAvailable:
-                                      description: MinAvailable is the minimum available
-                                        pods
                                       format: int32
                                       type: integer
                                   type: object
                                 readinessProbe:
-                                  description: ReadinessProbe configuration
                                   properties:
                                     failureThreshold:
-                                      description: FailureThreshold is the number
-                                        of failures before marking unhealthy
                                       format: int32
                                       type: integer
                                     periodSeconds:
-                                      description: PeriodSeconds is the probe interval
                                       format: int32
                                       type: integer
                                     timeoutSeconds:
-                                      description: TimeoutSeconds is the probe timeout
                                       format: int32
                                       type: integer
                                   type: object
                                 startupProbe:
-                                  description: StartupProbe configuration
                                   properties:
                                     failureThreshold:
-                                      description: FailureThreshold is the number
-                                        of failures before marking unhealthy
                                       format: int32
                                       type: integer
                                     periodSeconds:
-                                      description: PeriodSeconds is the probe interval
                                       format: int32
                                       type: integer
                                     timeoutSeconds:
-                                      description: TimeoutSeconds is the probe timeout
                                       format: int32
                                       type: integer
                                   type: object
                               type: object
                             burst:
-                              description: Burst defines burst handling configuration
                               properties:
                                 burstThreshold:
                                   default: 100
-                                  description: BurstThreshold is the queue depth that
-                                    triggers burst mode
                                   format: int32
                                   type: integer
                                 cooldownPeriod:
-                                  description: CooldownPeriod is the time before scaling
-                                    down burst replicas
                                   type: string
                                 enabled:
-                                  description: Enabled toggles burst handling
                                   type: boolean
                                 maxSurge:
                                   default: 5
-                                  description: MaxSurge is the maximum extra replicas
-                                    during burst
                                   format: int32
                                   type: integer
                               required:
                               - enabled
                               type: object
                             config:
-                              description: |-
-                                Config is the Inference configuration as a JSON string.
-                                This is merged with auto-generated configuration and passed to inference via --config.
-                                Supports all inference config options including logging, GPU settings, keep_alive, etc.
-                                Example: {"log": {"level": "debug", "style": "json"}, "gpu": "auto"}
                               type: string
                             eks:
-                              description: EKS defines AWS EKS-specific configuration
-                                (optional)
                               properties:
                                 enabled:
-                                  description: Enabled enables EKS-specific optimizations
-                                    and configurations
                                   type: boolean
                                 instanceTypes:
-                                  description: |-
-                                    InstanceTypes specifies preferred EC2 instance types for node scheduling
-                                    Examples: ["m5.large", "m5.xlarge", "m6i.large"]
-                                    Used with node affinity to target specific instance types
                                   items:
                                     type: string
                                   type: array
                                 irsaRoleARN:
-                                  description: |-
-                                    IRSARoleARN is the ARN of the IAM role for IRSA (IAM Roles for Service Accounts)
-                                    Format: arn:aws:iam::<account-id>:role/<role-name>
-                                    When specified, the operator will annotate the ServiceAccount with this role
-                                    This enables pods to assume IAM roles for AWS API access (e.g., S3 model registry)
                                   type: string
                                 podDisruptionBudget:
-                                  description: |-
-                                    PodDisruptionBudget enables automatic PodDisruptionBudget creation
-                                    Recommended for production deployments to prevent excessive disruption
                                   properties:
                                     enabled:
                                       default: false
-                                      description: Enabled indicates if PodDisruptionBudget
-                                        should be created
                                       type: boolean
                                     maxUnavailable:
-                                      description: MaxUnavailable is the maximum unavailable
-                                        pods
                                       format: int32
                                       type: integer
                                     minAvailable:
-                                      description: MinAvailable is the minimum available
-                                        pods
                                       format: int32
                                       type: integer
                                   type: object
                                 useSpotInstances:
-                                  description: |-
-                                    UseSpotInstances enables EC2 Spot Instances for cost savings (up to 90%)
-                                    When enabled, pods will be scheduled on Spot Instance nodes
                                   type: boolean
                               type: object
                             gke:
-                              description: GKE defines GKE-specific configuration
-                                for Autopilot and Standard clusters
                               properties:
                                 autopilot:
-                                  description: |-
-                                    Autopilot enables GKE Autopilot-specific optimizations.
-                                    When true, uses compute class annotations instead of node selectors.
                                   type: boolean
                                 autopilotComputeClass:
-                                  description: |-
-                                    AutopilotComputeClass specifies the GKE Autopilot compute class.
-                                    Valid values: "Accelerator", "Balanced", "Performance", "Scale-Out", "autopilot", "autopilot-spot"
-                                    Defaults to "Balanced" when Autopilot=true and this field is empty.
-                                    Note: "Accelerator" is for GPU workloads only, NOT TPUs.
                                   enum:
                                   - Accelerator
                                   - Balanced
@@ -5153,133 +2420,78 @@ spec:
                                   - ""
                                   type: string
                                 podDisruptionBudget:
-                                  description: PodDisruptionBudget enables automatic
-                                    PodDisruptionBudget creation
                                   properties:
                                     enabled:
                                       default: false
-                                      description: Enabled indicates if PodDisruptionBudget
-                                        should be created
                                       type: boolean
                                     maxUnavailable:
-                                      description: MaxUnavailable is the maximum unavailable
-                                        pods
                                       format: int32
                                       type: integer
                                     minAvailable:
-                                      description: MinAvailable is the minimum available
-                                        pods
                                       format: int32
                                       type: integer
                                   type: object
                               type: object
                             hardware:
-                              description: Hardware defines TPU/accelerator configuration
                               properties:
                                 accelerator:
-                                  description: Accelerator is the accelerator type
-                                    label (empty = no accelerator/CPU only)
                                   type: string
                                 machineType:
-                                  description: MachineType is the GKE machine type
                                   type: string
                                 spot:
                                   default: false
-                                  description: Spot enables spot/preemptible instances
                                   type: boolean
                                 topology:
-                                  description: Topology is the TPU topology (e.g.,
-                                    "2x2", "2x4"). Only required when accelerator
-                                    is set.
                                   type: string
                               type: object
                             image:
-                              description: |-
-                                Image is the Antfly container image used for this InferencePool.
-                                The image must provide the `/antfly inference ...` runtime contract.
                               type: string
                             imagePullSecrets:
-                              description: ImagePullSecrets for private registries
                               items:
-                                description: |-
-                                  LocalObjectReference contains enough information to let you locate the
-                                  referenced object inside the same namespace.
                                 properties:
                                   name:
                                     default: ""
-                                    description: |-
-                                      Name of the referent.
-                                      This field is effectively required, but due to backwards compatibility is
-                                      allowed to be empty. Instances of this type with an empty value here are
-                                      almost certainly wrong.
-                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                     type: string
                                 type: object
                                 x-kubernetes-map-type: atomic
                               type: array
                             models:
-                              description: Models defines which models to load and
-                                how
                               properties:
                                 keepAlive:
-                                  description: KeepAlive duration before unloading
-                                    idle models (for lazy strategy)
                                   type: string
                                 loadingStrategy:
                                   default: eager
-                                  description: LoadingStrategy defines how models
-                                    are loaded
                                   enum:
                                   - eager
                                   - lazy
                                   - bounded
                                   type: string
                                 maxLoadedModels:
-                                  description: MaxLoadedModels limits concurrent loaded
-                                    models (for bounded strategy)
                                   type: integer
                                 preload:
-                                  description: Preload lists models to preload on
-                                    this pool
                                   items:
-                                    description: ModelSpec defines a single model
-                                      to load
                                     properties:
                                       capabilities:
-                                        description: |-
-                                          Capabilities declares modality/runtime capabilities to write into the
-                                          pulled model manifest. For example: ["text", "image", "audio"].
                                         items:
                                           type: string
                                         type: array
                                       name:
-                                        description: |-
-                                          Name is the model reference, including an optional tag/variant suffix
-                                          (e.g., "BAAI/bge-small-en-v1.5:i8" or "hf:antflydb/clipclap:gguf:Q4_K").
                                         minLength: 1
                                         type: string
                                       priority:
                                         default: medium
-                                        description: Priority determines loading order
-                                          and eviction priority
                                         enum:
                                         - high
                                         - medium
                                         - low
                                         type: string
                                       strategy:
-                                        description: |-
-                                          Strategy overrides the pool-level loading strategy for this model.
-                                          If not specified, uses the pool's loadingStrategy.
                                         enum:
                                         - eager
                                         - lazy
                                         - bounded
                                         type: string
                                       tasks:
-                                        description: |-
-                                          Tasks declares the model tasks to write into the pulled model manifest.
-                                          For example: ["embed"].
                                         items:
                                           type: string
                                         type: array
@@ -5288,7 +2500,6 @@ spec:
                                     type: object
                                   type: array
                                 registryURL:
-                                  description: RegistryURL is the model registry URL
                                   type: string
                               required:
                               - preload
@@ -5296,70 +2507,39 @@ spec:
                             nodeSelector:
                               additionalProperties:
                                 type: string
-                              description: |-
-                                NodeSelector defines node selector labels for pod scheduling.
-                                Merged with any cloud-provider-specific node selectors.
-                                Note: GKE Autopilot mode overrides node selectors with compute class annotations.
                               type: object
                             replicas:
-                              description: Replicas defines scaling bounds
                               properties:
                                 max:
-                                  description: Max is the maximum number of replicas
                                   format: int32
                                   minimum: 1
                                   type: integer
                                 min:
-                                  description: Min is the minimum number of replicas
                                   format: int32
                                   minimum: 0
                                   type: integer
                                 perModel:
                                   additionalProperties:
-                                    description: PerModelReplica defines per-model
-                                      replica requirements
                                     properties:
                                       min:
-                                        description: Min replicas that must have this
-                                          model loaded
                                         format: int32
                                         type: integer
                                     required:
                                     - min
                                     type: object
-                                  description: PerModel allows per-model minimum replicas
                                   type: object
                               required:
                               - max
                               - min
                               type: object
                             resources:
-                              description: Resources defines compute resource requirements
                               properties:
                                 claims:
-                                  description: |-
-                                    Claims lists the names of resources, defined in spec.resourceClaims,
-                                    that are used by this container.
-
-                                    This field depends on the
-                                    DynamicResourceAllocation feature gate.
-
-                                    This field is immutable. It can only be set for containers.
                                   items:
-                                    description: ResourceClaim references one entry
-                                      in PodSpec.ResourceClaims.
                                     properties:
                                       name:
-                                        description: |-
-                                          Name must match the name of one entry in pod.spec.resourceClaims of
-                                          the Pod where this field is used. It makes that resource available
-                                          inside a container.
                                         type: string
                                       request:
-                                        description: |-
-                                          Request is the name chosen for a request in the referenced claim.
-                                          If empty, everything from the claim is made available, otherwise
-                                          only the result of this request.
                                         type: string
                                     required:
                                     - name
@@ -5375,9 +2555,6 @@ spec:
                                     - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
-                                  description: |-
-                                    Limits describes the maximum amount of compute resources allowed.
-                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                   type: object
                                 requests:
                                   additionalProperties:
@@ -5386,127 +2563,61 @@ spec:
                                     - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
-                                  description: |-
-                                    Requests describes the minimum amount of compute resources required.
-                                    If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                    otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                   type: object
                               type: object
                             routing:
-                              description: Routing defines routing hints for the proxy
                               properties:
                                 circuitBreaker:
-                                  description: CircuitBreaker configuration
                                   properties:
                                     enabled:
-                                      description: Enabled toggles circuit breaker
                                       type: boolean
                                     errorThreshold:
                                       default: 5
-                                      description: ErrorThreshold is the error count
-                                        to open circuit
                                       format: int32
                                       type: integer
                                     timeout:
-                                      description: Timeout is the circuit breaker
-                                        timeout
                                       type: string
                                   required:
                                   - enabled
                                   type: object
                                 drainTimeout:
-                                  description: DrainTimeout is the time to drain before
-                                    termination
                                   type: string
                                 weight:
                                   default: 100
-                                  description: Weight is the relative routing weight
-                                    (0-100)
                                   format: int32
                                   maximum: 100
                                   minimum: 0
                                   type: integer
                               type: object
                             tolerations:
-                              description: |-
-                                Tolerations defines tolerations for pod scheduling.
-                                Merged with any cloud-provider-specific tolerations (e.g., EKS Spot).
                               items:
-                                description: |-
-                                  The pod this Toleration is attached to tolerates any taint that matches
-                                  the triple <key,value,effect> using the matching operator <operator>.
                                 properties:
                                   effect:
-                                    description: |-
-                                      Effect indicates the taint effect to match. Empty means match all taint effects.
-                                      When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                                     type: string
                                   key:
-                                    description: |-
-                                      Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                                      If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Operator represents a key's relationship to the value.
-                                      Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
-                                      Exists is equivalent to wildcard for value, so that a pod can
-                                      tolerate all taints of a particular category.
-                                      Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                                     type: string
                                   tolerationSeconds:
-                                    description: |-
-                                      TolerationSeconds represents the period of time the toleration (which must be
-                                      of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                                      it is not set, which means tolerate the taint forever (do not evict). Zero and
-                                      negative values will be treated as 0 (evict immediately) by the system.
                                     format: int64
                                     type: integer
                                   value:
-                                    description: |-
-                                      Value is the taint value the toleration matches to.
-                                      If the operator is Exists, the value should be empty, otherwise just a regular string.
                                     type: string
                                 type: object
                               type: array
                             topologySpreadConstraints:
-                              description: TopologySpreadConstraints describes how
-                                pods should spread across topology domains.
                               items:
-                                description: TopologySpreadConstraint specifies how
-                                  to spread matching pods among the given topology.
                                 properties:
                                   labelSelector:
-                                    description: |-
-                                      LabelSelector is used to find matching pods.
-                                      Pods that match this label selector are counted to determine the number of pods
-                                      in their corresponding topology domain.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of
-                                          label selector requirements. The requirements
-                                          are ANDed.
                                         items:
-                                          description: |-
-                                            A label selector requirement is a selector that contains values, a key, and an operator that
-                                            relates the key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that
-                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: |-
-                                                operator represents a key's relationship to a set of values.
-                                                Valid operators are In, NotIn, Exists and DoesNotExist.
                                               type: string
                                             values:
-                                              description: |-
-                                                values is an array of string values. If the operator is In or NotIn,
-                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This array is replaced during a strategic
-                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -5520,125 +2631,27 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: |-
-                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   matchLabelKeys:
-                                    description: |-
-                                      MatchLabelKeys is a set of pod label keys to select the pods over which
-                                      spreading will be calculated. The keys are used to lookup values from the
-                                      incoming pod labels, those key-value labels are ANDed with labelSelector
-                                      to select the group of existing pods over which spreading will be calculated
-                                      for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
-                                      MatchLabelKeys cannot be set when LabelSelector isn't set.
-                                      Keys that don't exist in the incoming pod labels will
-                                      be ignored. A null or empty list means only match against labelSelector.
-
-                                      This is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).
                                     items:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   maxSkew:
-                                    description: |-
-                                      MaxSkew describes the degree to which pods may be unevenly distributed.
-                                      When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
-                                      between the number of matching pods in the target topology and the global minimum.
-                                      The global minimum is the minimum number of matching pods in an eligible domain
-                                      or zero if the number of eligible domains is less than MinDomains.
-                                      For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
-                                      labelSelector spread as 2/2/1:
-                                      In this case, the global minimum is 1.
-                                      | zone1 | zone2 | zone3 |
-                                      |  P P  |  P P  |   P   |
-                                      - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2;
-                                      scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2)
-                                      violate MaxSkew(1).
-                                      - if MaxSkew is 2, incoming pod can be scheduled onto any zone.
-                                      When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence
-                                      to topologies that satisfy it.
-                                      It's a required field. Default value is 1 and 0 is not allowed.
                                     format: int32
                                     type: integer
                                   minDomains:
-                                    description: |-
-                                      MinDomains indicates a minimum number of eligible domains.
-                                      When the number of eligible domains with matching topology keys is less than minDomains,
-                                      Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed.
-                                      And when the number of eligible domains with matching topology keys equals or greater than minDomains,
-                                      this value has no effect on scheduling.
-                                      As a result, when the number of eligible domains is less than minDomains,
-                                      scheduler won't schedule more than maxSkew Pods to those domains.
-                                      If value is nil, the constraint behaves as if MinDomains is equal to 1.
-                                      Valid values are integers greater than 0.
-                                      When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
-
-                                      For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same
-                                      labelSelector spread as 2/2/2:
-                                      | zone1 | zone2 | zone3 |
-                                      |  P P  |  P P  |  P P  |
-                                      The number of domains is less than 5(MinDomains), so "global minimum" is treated as 0.
-                                      In this situation, new pod with the same labelSelector cannot be scheduled,
-                                      because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones,
-                                      it will violate MaxSkew.
                                     format: int32
                                     type: integer
                                   nodeAffinityPolicy:
-                                    description: |-
-                                      NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
-                                      when calculating pod topology spread skew. Options are:
-                                      - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
-                                      - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
-
-                                      If this value is nil, the behavior is equivalent to the Honor policy.
                                     type: string
                                   nodeTaintsPolicy:
-                                    description: |-
-                                      NodeTaintsPolicy indicates how we will treat node taints when calculating
-                                      pod topology spread skew. Options are:
-                                      - Honor: nodes without taints, along with tainted nodes for which the incoming pod
-                                      has a toleration, are included.
-                                      - Ignore: node taints are ignored. All nodes are included.
-
-                                      If this value is nil, the behavior is equivalent to the Ignore policy.
                                     type: string
                                   topologyKey:
-                                    description: |-
-                                      TopologyKey is the key of node labels. Nodes that have a label with this key
-                                      and identical values are considered to be in the same topology.
-                                      We consider each <key, value> as a "bucket", and try to put balanced number
-                                      of pods into each bucket.
-                                      We define a domain as a particular instance of a topology.
-                                      Also, we define an eligible domain as a domain whose nodes meet the requirements of
-                                      nodeAffinityPolicy and nodeTaintsPolicy.
-                                      e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology.
-                                      And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology.
-                                      It's a required field.
                                     type: string
                                   whenUnsatisfiable:
-                                    description: |-
-                                      WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
-                                      the spread constraint.
-                                      - DoNotSchedule (default) tells the scheduler not to schedule it.
-                                      - ScheduleAnyway tells the scheduler to schedule the pod in any location,
-                                        but giving higher precedence to topologies that would help reduce the
-                                        skew.
-                                      A constraint is considered "Unsatisfiable" for an incoming pod
-                                      if and only if every possible node assignment for that pod would violate
-                                      "MaxSkew" on some topology.
-                                      For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
-                                      labelSelector spread as 3/1/1:
-                                      | zone1 | zone2 | zone3 |
-                                      | P P P |   P   |   P   |
-                                      If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled
-                                      to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies
-                                      MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler
-                                      won't make it *more* imbalanced.
-                                      It's a required field.
                                     type: string
                                 required:
                                 - maxSkew
@@ -5648,8 +2661,6 @@ spec:
                               type: array
                             workloadType:
                               default: general
-                              description: WorkloadType classifies this pool for routing
-                                decisions
                               enum:
                               - read-heavy
                               - write-heavy
@@ -5667,7 +2678,6 @@ spec:
                     type: array
                   mode:
                     default: Managed
-                    description: Mode selects how Inference pools are provided.
                     enum:
                     - Disabled
                     - PlatformShared
@@ -5675,54 +2685,28 @@ spec:
                     - SharedRef
                     type: string
                   platformPools:
-                    description: |-
-                      PlatformPools references platform-operated shared InferencePools.
-                      Valid when mode is PlatformShared.
                     items:
-                      description: InferencePoolReference points at an existing shared
-                        InferencePool or service.
                       properties:
                         apiURL:
-                          description: |-
-                            APIURL optionally pins the Inference API URL for this reference. When omitted,
-                            higher-level platform wiring may resolve the URL from the referenced pool.
                           type: string
                         name:
-                          description: Name is the referenced InferencePool or logical
-                            platform pool name.
                           minLength: 1
                           type: string
                         namespace:
-                          description: |-
-                            Namespace is the referenced pool namespace. If omitted, the cluster
-                            namespace is used.
                           type: string
                       required:
                       - name
                       type: object
                     type: array
                   sharedPools:
-                    description: |-
-                      SharedPools references existing customer-managed InferencePools.
-                      Valid when mode is SharedRef.
                     items:
-                      description: InferencePoolReference points at an existing shared
-                        InferencePool or service.
                       properties:
                         apiURL:
-                          description: |-
-                            APIURL optionally pins the Inference API URL for this reference. When omitted,
-                            higher-level platform wiring may resolve the URL from the referenced pool.
                           type: string
                         name:
-                          description: Name is the referenced InferencePool or logical
-                            platform pool name.
                           minLength: 1
                           type: string
                         namespace:
-                          description: |-
-                            Namespace is the referenced pool namespace. If omitted, the cluster
-                            namespace is used.
                           type: string
                       required:
                       - name
@@ -5730,64 +2714,24 @@ spec:
                     type: array
                 type: object
               metadataNodes:
-                description: |-
-                  MetadataNodes defines the configuration for metadata nodes (StatefulSet).
-                  Required for Clustered mode and must be omitted in Swarm mode.
                 properties:
                   affinity:
-                    description: |-
-                      Affinity defines affinity rules for pod scheduling.
-                      Cloud-provider-specific affinity rules (e.g., EKS instance type preference)
-                      are appended to any user-specified node affinity preferred terms.
                     properties:
                       nodeAffinity:
-                        description: Describes node affinity scheduling rules for
-                          the pod.
                         properties:
                           preferredDuringSchedulingIgnoredDuringExecution:
-                            description: |-
-                              The scheduler will prefer to schedule pods to nodes that satisfy
-                              the affinity expressions specified by this field, but it may choose
-                              a node that violates one or more of the expressions. The node that is
-                              most preferred is the one with the greatest sum of weights, i.e.
-                              for each node that meets all of the scheduling requirements (resource
-                              request, requiredDuringScheduling affinity expressions, etc.),
-                              compute a sum by iterating through the elements of this field and adding
-                              "weight" to the sum if the node matches the corresponding matchExpressions; the
-                              node(s) with the highest sum are the most preferred.
                             items:
-                              description: |-
-                                An empty preferred scheduling term matches all objects with implicit weight 0
-                                (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
                               properties:
                                 preference:
-                                  description: A node selector term, associated with
-                                    the corresponding weight.
                                   properties:
                                     matchExpressions:
-                                      description: A list of node selector requirements
-                                        by node's labels.
                                       items:
-                                        description: |-
-                                          A node selector requirement is a selector that contains values, a key, and an operator
-                                          that relates the key and values.
                                         properties:
                                           key:
-                                            description: The label key that the selector
-                                              applies to.
                                             type: string
                                           operator:
-                                            description: |-
-                                              Represents a key's relationship to a set of values.
-                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                             type: string
                                           values:
-                                            description: |-
-                                              An array of string values. If the operator is In or NotIn,
-                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. If the operator is Gt or Lt, the values
-                                              array must have a single element, which will be interpreted as an integer.
-                                              This array is replaced during a strategic merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -5799,29 +2743,13 @@ spec:
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     matchFields:
-                                      description: A list of node selector requirements
-                                        by node's fields.
                                       items:
-                                        description: |-
-                                          A node selector requirement is a selector that contains values, a key, and an operator
-                                          that relates the key and values.
                                         properties:
                                           key:
-                                            description: The label key that the selector
-                                              applies to.
                                             type: string
                                           operator:
-                                            description: |-
-                                              Represents a key's relationship to a set of values.
-                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                             type: string
                                           values:
-                                            description: |-
-                                              An array of string values. If the operator is In or NotIn,
-                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. If the operator is Gt or Lt, the values
-                                              array must have a single element, which will be interpreted as an integer.
-                                              This array is replaced during a strategic merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -5835,8 +2763,6 @@ spec:
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 weight:
-                                  description: Weight associated with matching the
-                                    corresponding nodeSelectorTerm, in the range 1-100.
                                   format: int32
                                   type: integer
                               required:
@@ -5846,46 +2772,18 @@ spec:
                             type: array
                             x-kubernetes-list-type: atomic
                           requiredDuringSchedulingIgnoredDuringExecution:
-                            description: |-
-                              If the affinity requirements specified by this field are not met at
-                              scheduling time, the pod will not be scheduled onto the node.
-                              If the affinity requirements specified by this field cease to be met
-                              at some point during pod execution (e.g. due to an update), the system
-                              may or may not try to eventually evict the pod from its node.
                             properties:
                               nodeSelectorTerms:
-                                description: Required. A list of node selector terms.
-                                  The terms are ORed.
                                 items:
-                                  description: |-
-                                    A null or empty node selector term matches no objects. The requirements of
-                                    them are ANDed.
-                                    The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
                                   properties:
                                     matchExpressions:
-                                      description: A list of node selector requirements
-                                        by node's labels.
                                       items:
-                                        description: |-
-                                          A node selector requirement is a selector that contains values, a key, and an operator
-                                          that relates the key and values.
                                         properties:
                                           key:
-                                            description: The label key that the selector
-                                              applies to.
                                             type: string
                                           operator:
-                                            description: |-
-                                              Represents a key's relationship to a set of values.
-                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                             type: string
                                           values:
-                                            description: |-
-                                              An array of string values. If the operator is In or NotIn,
-                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. If the operator is Gt or Lt, the values
-                                              array must have a single element, which will be interpreted as an integer.
-                                              This array is replaced during a strategic merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -5897,29 +2795,13 @@ spec:
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     matchFields:
-                                      description: A list of node selector requirements
-                                        by node's fields.
                                       items:
-                                        description: |-
-                                          A node selector requirement is a selector that contains values, a key, and an operator
-                                          that relates the key and values.
                                         properties:
                                           key:
-                                            description: The label key that the selector
-                                              applies to.
                                             type: string
                                           operator:
-                                            description: |-
-                                              Represents a key's relationship to a set of values.
-                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                             type: string
                                           values:
-                                            description: |-
-                                              An array of string values. If the operator is In or NotIn,
-                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. If the operator is Gt or Lt, the values
-                                              array must have a single element, which will be interpreted as an integer.
-                                              This array is replaced during a strategic merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -5940,59 +2822,22 @@ spec:
                             x-kubernetes-map-type: atomic
                         type: object
                       podAffinity:
-                        description: Describes pod affinity scheduling rules (e.g.
-                          co-locate this pod in the same node, zone, etc. as some
-                          other pod(s)).
                         properties:
                           preferredDuringSchedulingIgnoredDuringExecution:
-                            description: |-
-                              The scheduler will prefer to schedule pods to nodes that satisfy
-                              the affinity expressions specified by this field, but it may choose
-                              a node that violates one or more of the expressions. The node that is
-                              most preferred is the one with the greatest sum of weights, i.e.
-                              for each node that meets all of the scheduling requirements (resource
-                              request, requiredDuringScheduling affinity expressions, etc.),
-                              compute a sum by iterating through the elements of this field and adding
-                              "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
-                              node(s) with the highest sum are the most preferred.
                             items:
-                              description: The weights of all of the matched WeightedPodAffinityTerm
-                                fields are added per-node to find the most preferred
-                                node(s)
                               properties:
                                 podAffinityTerm:
-                                  description: Required. A pod affinity term, associated
-                                    with the corresponding weight.
                                   properties:
                                     labelSelector:
-                                      description: |-
-                                        A label query over a set of resources, in this case pods.
-                                        If it's null, this PodAffinityTerm matches with no Pods.
                                       properties:
                                         matchExpressions:
-                                          description: matchExpressions is a list
-                                            of label selector requirements. The requirements
-                                            are ANDed.
                                           items:
-                                            description: |-
-                                              A label selector requirement is a selector that contains values, a key, and an operator that
-                                              relates the key and values.
                                             properties:
                                               key:
-                                                description: key is the label key
-                                                  that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: |-
-                                                  operator represents a key's relationship to a set of values.
-                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                                 type: string
                                               values:
-                                                description: |-
-                                                  values is an array of string values. If the operator is In or NotIn,
-                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. This array is replaced during a strategic
-                                                  merge patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -6006,73 +2851,29 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: |-
-                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     matchLabelKeys:
-                                      description: |-
-                                        MatchLabelKeys is a set of pod label keys to select which pods will
-                                        be taken into consideration. The keys are used to lookup values from the
-                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                        to select the group of existing pods which pods will be taken into consideration
-                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                        pod labels will be ignored. The default value is empty.
-                                        The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                        Also, matchLabelKeys cannot be set when labelSelector isn't set.
                                       items:
                                         type: string
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     mismatchLabelKeys:
-                                      description: |-
-                                        MismatchLabelKeys is a set of pod label keys to select which pods will
-                                        be taken into consideration. The keys are used to lookup values from the
-                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                        to select the group of existing pods which pods will be taken into consideration
-                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                        pod labels will be ignored. The default value is empty.
-                                        The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                        Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
                                       items:
                                         type: string
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     namespaceSelector:
-                                      description: |-
-                                        A label query over the set of namespaces that the term applies to.
-                                        The term is applied to the union of the namespaces selected by this field
-                                        and the ones listed in the namespaces field.
-                                        null selector and null or empty namespaces list means "this pod's namespace".
-                                        An empty selector ({}) matches all namespaces.
                                       properties:
                                         matchExpressions:
-                                          description: matchExpressions is a list
-                                            of label selector requirements. The requirements
-                                            are ANDed.
                                           items:
-                                            description: |-
-                                              A label selector requirement is a selector that contains values, a key, and an operator that
-                                              relates the key and values.
                                             properties:
                                               key:
-                                                description: key is the label key
-                                                  that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: |-
-                                                  operator represents a key's relationship to a set of values.
-                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                                 type: string
                                               values:
-                                                description: |-
-                                                  values is an array of string values. If the operator is In or NotIn,
-                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. This array is replaced during a strategic
-                                                  merge patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -6086,38 +2887,20 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: |-
-                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     namespaces:
-                                      description: |-
-                                        namespaces specifies a static list of namespace names that the term applies to.
-                                        The term is applied to the union of the namespaces listed in this field
-                                        and the ones selected by namespaceSelector.
-                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                       items:
                                         type: string
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     topologyKey:
-                                      description: |-
-                                        This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
-                                        the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                        whose value of the label with key topologyKey matches that of any node on which any of the
-                                        selected pods is running.
-                                        Empty topologyKey is not allowed.
                                       type: string
                                   required:
                                   - topologyKey
                                   type: object
                                 weight:
-                                  description: |-
-                                    weight associated with matching the corresponding podAffinityTerm,
-                                    in the range 1-100.
                                   format: int32
                                   type: integer
                               required:
@@ -6127,52 +2910,18 @@ spec:
                             type: array
                             x-kubernetes-list-type: atomic
                           requiredDuringSchedulingIgnoredDuringExecution:
-                            description: |-
-                              If the affinity requirements specified by this field are not met at
-                              scheduling time, the pod will not be scheduled onto the node.
-                              If the affinity requirements specified by this field cease to be met
-                              at some point during pod execution (e.g. due to a pod label update), the
-                              system may or may not try to eventually evict the pod from its node.
-                              When there are multiple elements, the lists of nodes corresponding to each
-                              podAffinityTerm are intersected, i.e. all terms must be satisfied.
                             items:
-                              description: |-
-                                Defines a set of pods (namely those matching the labelSelector
-                                relative to the given namespace(s)) that this pod should be
-                                co-located (affinity) or not co-located (anti-affinity) with,
-                                where co-located is defined as running on a node whose value of
-                                the label with key <topologyKey> matches that of any node on which
-                                a pod of the set of pods is running
                               properties:
                                 labelSelector:
-                                  description: |-
-                                    A label query over a set of resources, in this case pods.
-                                    If it's null, this PodAffinityTerm matches with no Pods.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
                                       items:
-                                        description: |-
-                                          A label selector requirement is a selector that contains values, a key, and an operator that
-                                          relates the key and values.
                                         properties:
                                           key:
-                                            description: key is the label key that
-                                              the selector applies to.
                                             type: string
                                           operator:
-                                            description: |-
-                                              operator represents a key's relationship to a set of values.
-                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
-                                            description: |-
-                                              values is an array of string values. If the operator is In or NotIn,
-                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This array is replaced during a strategic
-                                              merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -6186,73 +2935,29 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: |-
-                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 matchLabelKeys:
-                                  description: |-
-                                    MatchLabelKeys is a set of pod label keys to select which pods will
-                                    be taken into consideration. The keys are used to lookup values from the
-                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                    to select the group of existing pods which pods will be taken into consideration
-                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                    pod labels will be ignored. The default value is empty.
-                                    The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                    Also, matchLabelKeys cannot be set when labelSelector isn't set.
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 mismatchLabelKeys:
-                                  description: |-
-                                    MismatchLabelKeys is a set of pod label keys to select which pods will
-                                    be taken into consideration. The keys are used to lookup values from the
-                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                    to select the group of existing pods which pods will be taken into consideration
-                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                    pod labels will be ignored. The default value is empty.
-                                    The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                    Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 namespaceSelector:
-                                  description: |-
-                                    A label query over the set of namespaces that the term applies to.
-                                    The term is applied to the union of the namespaces selected by this field
-                                    and the ones listed in the namespaces field.
-                                    null selector and null or empty namespaces list means "this pod's namespace".
-                                    An empty selector ({}) matches all namespaces.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
                                       items:
-                                        description: |-
-                                          A label selector requirement is a selector that contains values, a key, and an operator that
-                                          relates the key and values.
                                         properties:
                                           key:
-                                            description: key is the label key that
-                                              the selector applies to.
                                             type: string
                                           operator:
-                                            description: |-
-                                              operator represents a key's relationship to a set of values.
-                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
-                                            description: |-
-                                              values is an array of string values. If the operator is In or NotIn,
-                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This array is replaced during a strategic
-                                              merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -6266,30 +2971,15 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: |-
-                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 namespaces:
-                                  description: |-
-                                    namespaces specifies a static list of namespace names that the term applies to.
-                                    The term is applied to the union of the namespaces listed in this field
-                                    and the ones selected by namespaceSelector.
-                                    null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 topologyKey:
-                                  description: |-
-                                    This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
-                                    the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                    whose value of the label with key topologyKey matches that of any node on which any of the
-                                    selected pods is running.
-                                    Empty topologyKey is not allowed.
                                   type: string
                               required:
                               - topologyKey
@@ -6298,59 +2988,22 @@ spec:
                             x-kubernetes-list-type: atomic
                         type: object
                       podAntiAffinity:
-                        description: Describes pod anti-affinity scheduling rules
-                          (e.g. avoid putting this pod in the same node, zone, etc.
-                          as some other pod(s)).
                         properties:
                           preferredDuringSchedulingIgnoredDuringExecution:
-                            description: |-
-                              The scheduler will prefer to schedule pods to nodes that satisfy
-                              the anti-affinity expressions specified by this field, but it may choose
-                              a node that violates one or more of the expressions. The node that is
-                              most preferred is the one with the greatest sum of weights, i.e.
-                              for each node that meets all of the scheduling requirements (resource
-                              request, requiredDuringScheduling anti-affinity expressions, etc.),
-                              compute a sum by iterating through the elements of this field and subtracting
-                              "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
-                              node(s) with the highest sum are the most preferred.
                             items:
-                              description: The weights of all of the matched WeightedPodAffinityTerm
-                                fields are added per-node to find the most preferred
-                                node(s)
                               properties:
                                 podAffinityTerm:
-                                  description: Required. A pod affinity term, associated
-                                    with the corresponding weight.
                                   properties:
                                     labelSelector:
-                                      description: |-
-                                        A label query over a set of resources, in this case pods.
-                                        If it's null, this PodAffinityTerm matches with no Pods.
                                       properties:
                                         matchExpressions:
-                                          description: matchExpressions is a list
-                                            of label selector requirements. The requirements
-                                            are ANDed.
                                           items:
-                                            description: |-
-                                              A label selector requirement is a selector that contains values, a key, and an operator that
-                                              relates the key and values.
                                             properties:
                                               key:
-                                                description: key is the label key
-                                                  that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: |-
-                                                  operator represents a key's relationship to a set of values.
-                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                                 type: string
                                               values:
-                                                description: |-
-                                                  values is an array of string values. If the operator is In or NotIn,
-                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. This array is replaced during a strategic
-                                                  merge patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -6364,73 +3017,29 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: |-
-                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     matchLabelKeys:
-                                      description: |-
-                                        MatchLabelKeys is a set of pod label keys to select which pods will
-                                        be taken into consideration. The keys are used to lookup values from the
-                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                        to select the group of existing pods which pods will be taken into consideration
-                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                        pod labels will be ignored. The default value is empty.
-                                        The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                        Also, matchLabelKeys cannot be set when labelSelector isn't set.
                                       items:
                                         type: string
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     mismatchLabelKeys:
-                                      description: |-
-                                        MismatchLabelKeys is a set of pod label keys to select which pods will
-                                        be taken into consideration. The keys are used to lookup values from the
-                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                        to select the group of existing pods which pods will be taken into consideration
-                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                        pod labels will be ignored. The default value is empty.
-                                        The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                        Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
                                       items:
                                         type: string
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     namespaceSelector:
-                                      description: |-
-                                        A label query over the set of namespaces that the term applies to.
-                                        The term is applied to the union of the namespaces selected by this field
-                                        and the ones listed in the namespaces field.
-                                        null selector and null or empty namespaces list means "this pod's namespace".
-                                        An empty selector ({}) matches all namespaces.
                                       properties:
                                         matchExpressions:
-                                          description: matchExpressions is a list
-                                            of label selector requirements. The requirements
-                                            are ANDed.
                                           items:
-                                            description: |-
-                                              A label selector requirement is a selector that contains values, a key, and an operator that
-                                              relates the key and values.
                                             properties:
                                               key:
-                                                description: key is the label key
-                                                  that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: |-
-                                                  operator represents a key's relationship to a set of values.
-                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                                 type: string
                                               values:
-                                                description: |-
-                                                  values is an array of string values. If the operator is In or NotIn,
-                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. This array is replaced during a strategic
-                                                  merge patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -6444,38 +3053,20 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: |-
-                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     namespaces:
-                                      description: |-
-                                        namespaces specifies a static list of namespace names that the term applies to.
-                                        The term is applied to the union of the namespaces listed in this field
-                                        and the ones selected by namespaceSelector.
-                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                       items:
                                         type: string
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     topologyKey:
-                                      description: |-
-                                        This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
-                                        the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                        whose value of the label with key topologyKey matches that of any node on which any of the
-                                        selected pods is running.
-                                        Empty topologyKey is not allowed.
                                       type: string
                                   required:
                                   - topologyKey
                                   type: object
                                 weight:
-                                  description: |-
-                                    weight associated with matching the corresponding podAffinityTerm,
-                                    in the range 1-100.
                                   format: int32
                                   type: integer
                               required:
@@ -6485,52 +3076,18 @@ spec:
                             type: array
                             x-kubernetes-list-type: atomic
                           requiredDuringSchedulingIgnoredDuringExecution:
-                            description: |-
-                              If the anti-affinity requirements specified by this field are not met at
-                              scheduling time, the pod will not be scheduled onto the node.
-                              If the anti-affinity requirements specified by this field cease to be met
-                              at some point during pod execution (e.g. due to a pod label update), the
-                              system may or may not try to eventually evict the pod from its node.
-                              When there are multiple elements, the lists of nodes corresponding to each
-                              podAffinityTerm are intersected, i.e. all terms must be satisfied.
                             items:
-                              description: |-
-                                Defines a set of pods (namely those matching the labelSelector
-                                relative to the given namespace(s)) that this pod should be
-                                co-located (affinity) or not co-located (anti-affinity) with,
-                                where co-located is defined as running on a node whose value of
-                                the label with key <topologyKey> matches that of any node on which
-                                a pod of the set of pods is running
                               properties:
                                 labelSelector:
-                                  description: |-
-                                    A label query over a set of resources, in this case pods.
-                                    If it's null, this PodAffinityTerm matches with no Pods.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
                                       items:
-                                        description: |-
-                                          A label selector requirement is a selector that contains values, a key, and an operator that
-                                          relates the key and values.
                                         properties:
                                           key:
-                                            description: key is the label key that
-                                              the selector applies to.
                                             type: string
                                           operator:
-                                            description: |-
-                                              operator represents a key's relationship to a set of values.
-                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
-                                            description: |-
-                                              values is an array of string values. If the operator is In or NotIn,
-                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This array is replaced during a strategic
-                                              merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -6544,73 +3101,29 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: |-
-                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 matchLabelKeys:
-                                  description: |-
-                                    MatchLabelKeys is a set of pod label keys to select which pods will
-                                    be taken into consideration. The keys are used to lookup values from the
-                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                    to select the group of existing pods which pods will be taken into consideration
-                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                    pod labels will be ignored. The default value is empty.
-                                    The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                    Also, matchLabelKeys cannot be set when labelSelector isn't set.
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 mismatchLabelKeys:
-                                  description: |-
-                                    MismatchLabelKeys is a set of pod label keys to select which pods will
-                                    be taken into consideration. The keys are used to lookup values from the
-                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                    to select the group of existing pods which pods will be taken into consideration
-                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                    pod labels will be ignored. The default value is empty.
-                                    The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                    Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 namespaceSelector:
-                                  description: |-
-                                    A label query over the set of namespaces that the term applies to.
-                                    The term is applied to the union of the namespaces selected by this field
-                                    and the ones listed in the namespaces field.
-                                    null selector and null or empty namespaces list means "this pod's namespace".
-                                    An empty selector ({}) matches all namespaces.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
                                       items:
-                                        description: |-
-                                          A label selector requirement is a selector that contains values, a key, and an operator that
-                                          relates the key and values.
                                         properties:
                                           key:
-                                            description: key is the label key that
-                                              the selector applies to.
                                             type: string
                                           operator:
-                                            description: |-
-                                              operator represents a key's relationship to a set of values.
-                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
-                                            description: |-
-                                              values is an array of string values. If the operator is In or NotIn,
-                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This array is replaced during a strategic
-                                              merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -6624,30 +3137,15 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: |-
-                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 namespaces:
-                                  description: |-
-                                    namespaces specifies a static list of namespace names that the term applies to.
-                                    The term is applied to the union of the namespaces listed in this field
-                                    and the ones selected by namespaceSelector.
-                                    null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 topologyKey:
-                                  description: |-
-                                    This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
-                                    the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                    whose value of the label with key topologyKey matches that of any node on which any of the
-                                    selected pods is running.
-                                    Empty topologyKey is not allowed.
                                   type: string
                               required:
                               - topologyKey
@@ -6657,214 +3155,108 @@ spec:
                         type: object
                     type: object
                   envFrom:
-                    description: |-
-                      EnvFrom is a list of sources to populate environment variables in the container.
-                      This is commonly used to inject backup credentials from Secrets or ConfigMaps.
-                      The keys within a source must be a C_IDENTIFIER. All invalid keys will be
-                      reported as an event when the container is starting.
-                      Example usage for S3/GCS backup credentials:
-                        envFrom:
-                          - secretRef:
-                              name: backup-credentials
-                      The secret should contain AWS SDK compatible keys:
-                        AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_ENDPOINT_URL (optional), AWS_REGION (optional)
                     items:
-                      description: EnvFromSource represents the source of a set of
-                        ConfigMaps or Secrets
                       properties:
                         configMapRef:
-                          description: The ConfigMap to select from
                           properties:
                             name:
                               default: ""
-                              description: |-
-                                Name of the referent.
-                                This field is effectively required, but due to backwards compatibility is
-                                allowed to be empty. Instances of this type with an empty value here are
-                                almost certainly wrong.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                               type: string
                             optional:
-                              description: Specify whether the ConfigMap must be defined
                               type: boolean
                           type: object
                           x-kubernetes-map-type: atomic
                         prefix:
-                          description: |-
-                            Optional text to prepend to the name of each environment variable.
-                            May consist of any printable ASCII characters except '='.
                           type: string
                         secretRef:
-                          description: The Secret to select from
                           properties:
                             name:
                               default: ""
-                              description: |-
-                                Name of the referent.
-                                This field is effectively required, but due to backwards compatibility is
-                                allowed to be empty. Instances of this type with an empty value here are
-                                almost certainly wrong.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                               type: string
                             optional:
-                              description: Specify whether the Secret must be defined
                               type: boolean
                           type: object
                           x-kubernetes-map-type: atomic
                       type: object
                     type: array
                   health:
-                    description: Health defines the health check endpoint configuration
                     properties:
                       host:
-                        description: 'Host is the host to bind to (default: 0.0.0.0)'
                         type: string
                       port:
-                        description: Port is the port number (optional, operator sets
-                          defaults)
                         format: int32
                         type: integer
                     type: object
                   metadataAPI:
-                    description: MetadataAPI defines the metadata API configuration
                     properties:
                       host:
-                        description: 'Host is the host to bind to (default: 0.0.0.0)'
                         type: string
                       port:
-                        description: Port is the port number (optional, operator sets
-                          defaults)
                         format: int32
                         type: integer
                     type: object
                   metadataRaft:
-                    description: MetadataRaft defines the metadata Raft configuration
                     properties:
                       host:
-                        description: 'Host is the host to bind to (default: 0.0.0.0)'
                         type: string
                       port:
-                        description: Port is the port number (optional, operator sets
-                          defaults)
                         format: int32
                         type: integer
                     type: object
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: |-
-                      NodeSelector defines node selector labels for pod scheduling.
-                      Merged with any cloud-provider-specific node selectors.
-                      Note: GKE Autopilot mode overrides node selectors with compute class annotations.
                     type: object
                   replicas:
-                    description: 'Replicas is the number of metadata nodes (default:
-                      3)'
                     format: int32
                     type: integer
                   resources:
-                    description: Resources defines the resource requirements
                     properties:
                       cpu:
-                        description: CPU resource requirements
                         type: string
                       limits:
-                        description: Limits defines the resource limits
                         properties:
                           cpu:
-                            description: CPU limit
                             type: string
                           gpu:
-                            description: GPU limit (maps to nvidia.com/gpu resource)
                             type: string
                           memory:
-                            description: Memory limit
                             type: string
                         type: object
                       memory:
-                        description: Memory resource requirements
                         type: string
                     required:
                     - limits
                     type: object
                   tolerations:
-                    description: |-
-                      Tolerations defines tolerations for pod scheduling.
-                      Merged with any cloud-provider-specific tolerations (e.g., EKS Spot).
                     items:
-                      description: |-
-                        The pod this Toleration is attached to tolerates any taint that matches
-                        the triple <key,value,effect> using the matching operator <operator>.
                       properties:
                         effect:
-                          description: |-
-                            Effect indicates the taint effect to match. Empty means match all taint effects.
-                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                           type: string
                         key:
-                          description: |-
-                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                           type: string
                         operator:
-                          description: |-
-                            Operator represents a key's relationship to the value.
-                            Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
-                            Exists is equivalent to wildcard for value, so that a pod can
-                            tolerate all taints of a particular category.
-                            Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                           type: string
                         tolerationSeconds:
-                          description: |-
-                            TolerationSeconds represents the period of time the toleration (which must be
-                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                            it is not set, which means tolerate the taint forever (do not evict). Zero and
-                            negative values will be treated as 0 (evict immediately) by the system.
                           format: int64
                           type: integer
                         value:
-                          description: |-
-                            Value is the taint value the toleration matches to.
-                            If the operator is Exists, the value should be empty, otherwise just a regular string.
                           type: string
                       type: object
                     type: array
                   topologySpreadConstraints:
-                    description: TopologySpreadConstraints describes how pods should
-                      spread across topology domains.
                     items:
-                      description: TopologySpreadConstraint specifies how to spread
-                        matching pods among the given topology.
                       properties:
                         labelSelector:
-                          description: |-
-                            LabelSelector is used to find matching pods.
-                            Pods that match this label selector are counted to determine the number of pods
-                            in their corresponding topology domain.
                           properties:
                             matchExpressions:
-                              description: matchExpressions is a list of label selector
-                                requirements. The requirements are ANDed.
                               items:
-                                description: |-
-                                  A label selector requirement is a selector that contains values, a key, and an operator that
-                                  relates the key and values.
                                 properties:
                                   key:
-                                    description: key is the label key that the selector
-                                      applies to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      operator represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                     type: string
                                   values:
-                                    description: |-
-                                      values is an array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. This array is replaced during a strategic
-                                      merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -6878,125 +3270,27 @@ spec:
                             matchLabels:
                               additionalProperties:
                                 type: string
-                              description: |-
-                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                               type: object
                           type: object
                           x-kubernetes-map-type: atomic
                         matchLabelKeys:
-                          description: |-
-                            MatchLabelKeys is a set of pod label keys to select the pods over which
-                            spreading will be calculated. The keys are used to lookup values from the
-                            incoming pod labels, those key-value labels are ANDed with labelSelector
-                            to select the group of existing pods over which spreading will be calculated
-                            for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
-                            MatchLabelKeys cannot be set when LabelSelector isn't set.
-                            Keys that don't exist in the incoming pod labels will
-                            be ignored. A null or empty list means only match against labelSelector.
-
-                            This is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).
                           items:
                             type: string
                           type: array
                           x-kubernetes-list-type: atomic
                         maxSkew:
-                          description: |-
-                            MaxSkew describes the degree to which pods may be unevenly distributed.
-                            When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
-                            between the number of matching pods in the target topology and the global minimum.
-                            The global minimum is the minimum number of matching pods in an eligible domain
-                            or zero if the number of eligible domains is less than MinDomains.
-                            For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
-                            labelSelector spread as 2/2/1:
-                            In this case, the global minimum is 1.
-                            | zone1 | zone2 | zone3 |
-                            |  P P  |  P P  |   P   |
-                            - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2;
-                            scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2)
-                            violate MaxSkew(1).
-                            - if MaxSkew is 2, incoming pod can be scheduled onto any zone.
-                            When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence
-                            to topologies that satisfy it.
-                            It's a required field. Default value is 1 and 0 is not allowed.
                           format: int32
                           type: integer
                         minDomains:
-                          description: |-
-                            MinDomains indicates a minimum number of eligible domains.
-                            When the number of eligible domains with matching topology keys is less than minDomains,
-                            Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed.
-                            And when the number of eligible domains with matching topology keys equals or greater than minDomains,
-                            this value has no effect on scheduling.
-                            As a result, when the number of eligible domains is less than minDomains,
-                            scheduler won't schedule more than maxSkew Pods to those domains.
-                            If value is nil, the constraint behaves as if MinDomains is equal to 1.
-                            Valid values are integers greater than 0.
-                            When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
-
-                            For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same
-                            labelSelector spread as 2/2/2:
-                            | zone1 | zone2 | zone3 |
-                            |  P P  |  P P  |  P P  |
-                            The number of domains is less than 5(MinDomains), so "global minimum" is treated as 0.
-                            In this situation, new pod with the same labelSelector cannot be scheduled,
-                            because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones,
-                            it will violate MaxSkew.
                           format: int32
                           type: integer
                         nodeAffinityPolicy:
-                          description: |-
-                            NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
-                            when calculating pod topology spread skew. Options are:
-                            - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
-                            - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
-
-                            If this value is nil, the behavior is equivalent to the Honor policy.
                           type: string
                         nodeTaintsPolicy:
-                          description: |-
-                            NodeTaintsPolicy indicates how we will treat node taints when calculating
-                            pod topology spread skew. Options are:
-                            - Honor: nodes without taints, along with tainted nodes for which the incoming pod
-                            has a toleration, are included.
-                            - Ignore: node taints are ignored. All nodes are included.
-
-                            If this value is nil, the behavior is equivalent to the Ignore policy.
                           type: string
                         topologyKey:
-                          description: |-
-                            TopologyKey is the key of node labels. Nodes that have a label with this key
-                            and identical values are considered to be in the same topology.
-                            We consider each <key, value> as a "bucket", and try to put balanced number
-                            of pods into each bucket.
-                            We define a domain as a particular instance of a topology.
-                            Also, we define an eligible domain as a domain whose nodes meet the requirements of
-                            nodeAffinityPolicy and nodeTaintsPolicy.
-                            e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology.
-                            And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology.
-                            It's a required field.
                           type: string
                         whenUnsatisfiable:
-                          description: |-
-                            WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
-                            the spread constraint.
-                            - DoNotSchedule (default) tells the scheduler not to schedule it.
-                            - ScheduleAnyway tells the scheduler to schedule the pod in any location,
-                              but giving higher precedence to topologies that would help reduce the
-                              skew.
-                            A constraint is considered "Unsatisfiable" for an incoming pod
-                            if and only if every possible node assignment for that pod would violate
-                            "MaxSkew" on some topology.
-                            For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
-                            labelSelector spread as 3/1/1:
-                            | zone1 | zone2 | zone3 |
-                            | P P P |   P   |   P   |
-                            If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled
-                            to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies
-                            MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler
-                            won't make it *more* imbalanced.
-                            It's a required field.
                           type: string
                       required:
                       - maxSkew
@@ -7005,10 +3299,6 @@ spec:
                       type: object
                     type: array
                   useSpotPods:
-                    description: |-
-                      UseSpotPods enables GKE Spot Pods for metadata nodes (standard GKE only)
-                      MUST be false when spec.gke.autopilot=true (use spec.gke.autopilotComputeClass instead)
-                      Not recommended for production metadata nodes as they maintain Raft consensus
                     type: boolean
                 required:
                 - metadataAPI
@@ -7017,84 +3307,45 @@ spec:
                 type: object
               mode:
                 default: Clustered
-                description: Mode selects the runtime topology managed by the operator.
                 enum:
                 - Clustered
                 - Swarm
                 type: string
               productTier:
-                description: |-
-                  ProductTier records the CloudAF/product tier intent that was expanded
-                  into the explicit operator fields below. The operator does not resolve
-                  prices or tier catalogs; it validates that a stamped tier has concrete
-                  resources, storage, and autoscaling intent in the normal fields.
                 properties:
                   dataTier:
-                    description: |-
-                      DataTier optionally records the data-node sub-tier name when
-                      Mode=Clustered.
                     type: string
                   inferenceTier:
-                    description: |-
-                      InferenceTier optionally records the InferencePool sub-tier name when
-                      spec.inference is set.
                     type: string
                   managedBy:
-                    description: |-
-                      ManagedBy identifies the system that expanded the tier, for example
-                      "cloudaf".
                     type: string
                   metadataTier:
-                    description: |-
-                      MetadataTier optionally records the metadata-node sub-tier name when
-                      Mode=Clustered.
                     type: string
                   name:
-                    description: Name is the external product tier name, such as "starter"
-                      or "pro".
                     type: string
                   revision:
-                    description: Revision identifies the tier catalog revision used
-                      to expand this CR.
                     type: string
                   swarmTier:
-                    description: SwarmTier optionally records the swarm sub-tier name
-                      when Mode=Swarm.
                     type: string
                 type: object
               publicAPI:
-                description: |-
-                  PublicAPI defines the public API service configuration (optional)
-                  Controls the external-facing service that exposes the cluster API
                 properties:
                   enabled:
                     default: false
-                    description: |-
-                      Enabled controls whether the public API service is created
-                      When false, no external service is created (users manage their own Ingress)
                     type: boolean
                   nodePort:
-                    description: |-
-                      NodePort specifies the node port when ServiceType is NodePort
-                      Only valid when ServiceType=NodePort
-                      If not specified, Kubernetes will auto-assign a port in the range 30000-32767
                     format: int32
                     maximum: 32767
                     minimum: 30000
                     type: integer
                   port:
                     default: 80
-                    description: 'Port is the service port to expose (default: 80)'
                     format: int32
                     maximum: 65535
                     minimum: 1
                     type: integer
                   serviceType:
                     default: LoadBalancer
-                    description: |-
-                      ServiceType specifies the Kubernetes service type
-                      Valid values: ClusterIP, NodePort, LoadBalancer
-                      Default: LoadBalancer
                     enum:
                     - ClusterIP
                     - NodePort
@@ -7102,183 +3353,87 @@ spec:
                     type: string
                 type: object
               secretStore:
-                description: |-
-                  SecretStore mounts a Kubernetes Secret containing an Antfly secrets.json
-                  file for runtime secret resolution.
                 properties:
                   key:
-                    description: |-
-                      Key is the Secret data key containing the Antfly secrets file.
-                      Defaults to secrets.json.
                     type: string
                   path:
-                    description: |-
-                      Path is the absolute file path where the secret file should be mounted.
-                      Defaults to /run/antfly/secrets/secrets.json.
                     type: string
                   secretName:
-                    description: SecretName is the Kubernetes Secret name in the AntflyCluster
-                      namespace.
                     type: string
                 required:
                 - secretName
                 type: object
               serviceAccountName:
-                description: |-
-                  ServiceAccountName is the name of the Kubernetes ServiceAccount to use for pods
-                  This allows pods to authenticate with cloud providers (GCP, AWS) for Workload Identity
-                  If not specified, the default ServiceAccount for the namespace is used
                 type: string
               serviceMesh:
-                description: ServiceMesh configures optional service mesh integration
                 properties:
                   annotations:
                     additionalProperties:
                       type: string
-                    description: |-
-                      Annotations contains mesh-specific annotations to apply to pod templates
-                      Common examples:
-                        Istio: {"sidecar.istio.io/inject": "true"}
-                        Linkerd: {"linkerd.io/inject": "enabled"}
-                        Consul: {"consul.hashicorp.com/connect-inject": "true"}
                     type: object
                   enabled:
                     default: false
-                    description: Enabled controls whether service mesh sidecar injection
-                      is enabled
                     type: boolean
                 type: object
               storage:
-                description: Storage defines the storage configuration
                 properties:
                   dataStorage:
-                    description: DataStorage defines storage for data nodes
                     type: string
                   metadataStorage:
-                    description: MetadataStorage defines storage for metadata nodes
                     type: string
                   pvcRetentionPolicy:
-                    description: |-
-                      PVCRetentionPolicy controls what happens to PVCs when the cluster is deleted or scaled down.
-                      Maps to StatefulSet's persistentVolumeClaimRetentionPolicy (beta in K8s 1.27, GA in 1.32).
-                      On clusters < 1.27, this field is silently ignored by the StatefulSet controller;
-                      the finalizer provides a fallback for WhenDeleted=Delete.
                     properties:
                       whenDeleted:
                         default: Retain
-                        description: |-
-                          WhenDeleted controls PVC retention when the AntflyCluster is deleted.
-                          Valid values: Retain (default), Delete.
                         enum:
                         - Retain
                         - Delete
                         type: string
                       whenScaled:
                         default: Retain
-                        description: |-
-                          WhenScaled controls PVC retention when the StatefulSet is scaled down.
-                          Valid values: Retain (default), Delete.
-                          WARNING: Delete causes a full Raft snapshot resync per shard when nodes rejoin after scale-up.
-                          Cannot be set to Delete when dataNodes.autoScaling.enabled is true (webhook-enforced).
                         enum:
                         - Retain
                         - Delete
                         type: string
                     type: object
                   storageAutoGrow:
-                    description: |-
-                      StorageAutoGrow configures operator-owned grow-only disk autoscaling.
-                      Clustered mode currently applies this policy only to data PVCs. Swarm
-                      mode applies it to the swarm PVC.
                     properties:
                       enabled:
-                        description: Enabled controls whether the operator automatically
-                          grows storage.
                         type: boolean
                       growIncrement:
-                        description: |-
-                          GrowIncrement is the amount added per grow step. Defaults to 10Gi when
-                          omitted.
                         type: string
                       growThresholdPercent:
-                        description: |-
-                          GrowThresholdPercent is the percent-used threshold that triggers growth.
-                          Defaults to 85 when omitted.
                         format: int32
                         type: integer
                       maxDataStorage:
-                        description: MaxDataStorage is the maximum size for clustered
-                          data PVC auto-grow.
                         type: string
                       maxSwarmStorage:
-                        description: |-
-                          MaxSwarmStorage is the maximum size for swarm PVC auto-grow. If omitted
-                          in swarm mode, MaxDataStorage is used as the limit.
                         type: string
                     type: object
                   storageClass:
-                    description: StorageClass is the storage class to use
                     type: string
                   swarmStorage:
-                    description: |-
-                      SwarmStorage defines storage for the swarm topology.
-                      Used when spec.mode=Swarm.
                     type: string
                 type: object
               swarm:
-                description: Swarm defines the single-node swarm topology when Mode=Swarm.
                 properties:
                   affinity:
-                    description: Affinity defines affinity rules for pod scheduling.
                     properties:
                       nodeAffinity:
-                        description: Describes node affinity scheduling rules for
-                          the pod.
                         properties:
                           preferredDuringSchedulingIgnoredDuringExecution:
-                            description: |-
-                              The scheduler will prefer to schedule pods to nodes that satisfy
-                              the affinity expressions specified by this field, but it may choose
-                              a node that violates one or more of the expressions. The node that is
-                              most preferred is the one with the greatest sum of weights, i.e.
-                              for each node that meets all of the scheduling requirements (resource
-                              request, requiredDuringScheduling affinity expressions, etc.),
-                              compute a sum by iterating through the elements of this field and adding
-                              "weight" to the sum if the node matches the corresponding matchExpressions; the
-                              node(s) with the highest sum are the most preferred.
                             items:
-                              description: |-
-                                An empty preferred scheduling term matches all objects with implicit weight 0
-                                (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
                               properties:
                                 preference:
-                                  description: A node selector term, associated with
-                                    the corresponding weight.
                                   properties:
                                     matchExpressions:
-                                      description: A list of node selector requirements
-                                        by node's labels.
                                       items:
-                                        description: |-
-                                          A node selector requirement is a selector that contains values, a key, and an operator
-                                          that relates the key and values.
                                         properties:
                                           key:
-                                            description: The label key that the selector
-                                              applies to.
                                             type: string
                                           operator:
-                                            description: |-
-                                              Represents a key's relationship to a set of values.
-                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                             type: string
                                           values:
-                                            description: |-
-                                              An array of string values. If the operator is In or NotIn,
-                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. If the operator is Gt or Lt, the values
-                                              array must have a single element, which will be interpreted as an integer.
-                                              This array is replaced during a strategic merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -7290,29 +3445,13 @@ spec:
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     matchFields:
-                                      description: A list of node selector requirements
-                                        by node's fields.
                                       items:
-                                        description: |-
-                                          A node selector requirement is a selector that contains values, a key, and an operator
-                                          that relates the key and values.
                                         properties:
                                           key:
-                                            description: The label key that the selector
-                                              applies to.
                                             type: string
                                           operator:
-                                            description: |-
-                                              Represents a key's relationship to a set of values.
-                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                             type: string
                                           values:
-                                            description: |-
-                                              An array of string values. If the operator is In or NotIn,
-                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. If the operator is Gt or Lt, the values
-                                              array must have a single element, which will be interpreted as an integer.
-                                              This array is replaced during a strategic merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -7326,8 +3465,6 @@ spec:
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 weight:
-                                  description: Weight associated with matching the
-                                    corresponding nodeSelectorTerm, in the range 1-100.
                                   format: int32
                                   type: integer
                               required:
@@ -7337,46 +3474,18 @@ spec:
                             type: array
                             x-kubernetes-list-type: atomic
                           requiredDuringSchedulingIgnoredDuringExecution:
-                            description: |-
-                              If the affinity requirements specified by this field are not met at
-                              scheduling time, the pod will not be scheduled onto the node.
-                              If the affinity requirements specified by this field cease to be met
-                              at some point during pod execution (e.g. due to an update), the system
-                              may or may not try to eventually evict the pod from its node.
                             properties:
                               nodeSelectorTerms:
-                                description: Required. A list of node selector terms.
-                                  The terms are ORed.
                                 items:
-                                  description: |-
-                                    A null or empty node selector term matches no objects. The requirements of
-                                    them are ANDed.
-                                    The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
                                   properties:
                                     matchExpressions:
-                                      description: A list of node selector requirements
-                                        by node's labels.
                                       items:
-                                        description: |-
-                                          A node selector requirement is a selector that contains values, a key, and an operator
-                                          that relates the key and values.
                                         properties:
                                           key:
-                                            description: The label key that the selector
-                                              applies to.
                                             type: string
                                           operator:
-                                            description: |-
-                                              Represents a key's relationship to a set of values.
-                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                             type: string
                                           values:
-                                            description: |-
-                                              An array of string values. If the operator is In or NotIn,
-                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. If the operator is Gt or Lt, the values
-                                              array must have a single element, which will be interpreted as an integer.
-                                              This array is replaced during a strategic merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -7388,29 +3497,13 @@ spec:
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     matchFields:
-                                      description: A list of node selector requirements
-                                        by node's fields.
                                       items:
-                                        description: |-
-                                          A node selector requirement is a selector that contains values, a key, and an operator
-                                          that relates the key and values.
                                         properties:
                                           key:
-                                            description: The label key that the selector
-                                              applies to.
                                             type: string
                                           operator:
-                                            description: |-
-                                              Represents a key's relationship to a set of values.
-                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                             type: string
                                           values:
-                                            description: |-
-                                              An array of string values. If the operator is In or NotIn,
-                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. If the operator is Gt or Lt, the values
-                                              array must have a single element, which will be interpreted as an integer.
-                                              This array is replaced during a strategic merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -7431,59 +3524,22 @@ spec:
                             x-kubernetes-map-type: atomic
                         type: object
                       podAffinity:
-                        description: Describes pod affinity scheduling rules (e.g.
-                          co-locate this pod in the same node, zone, etc. as some
-                          other pod(s)).
                         properties:
                           preferredDuringSchedulingIgnoredDuringExecution:
-                            description: |-
-                              The scheduler will prefer to schedule pods to nodes that satisfy
-                              the affinity expressions specified by this field, but it may choose
-                              a node that violates one or more of the expressions. The node that is
-                              most preferred is the one with the greatest sum of weights, i.e.
-                              for each node that meets all of the scheduling requirements (resource
-                              request, requiredDuringScheduling affinity expressions, etc.),
-                              compute a sum by iterating through the elements of this field and adding
-                              "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
-                              node(s) with the highest sum are the most preferred.
                             items:
-                              description: The weights of all of the matched WeightedPodAffinityTerm
-                                fields are added per-node to find the most preferred
-                                node(s)
                               properties:
                                 podAffinityTerm:
-                                  description: Required. A pod affinity term, associated
-                                    with the corresponding weight.
                                   properties:
                                     labelSelector:
-                                      description: |-
-                                        A label query over a set of resources, in this case pods.
-                                        If it's null, this PodAffinityTerm matches with no Pods.
                                       properties:
                                         matchExpressions:
-                                          description: matchExpressions is a list
-                                            of label selector requirements. The requirements
-                                            are ANDed.
                                           items:
-                                            description: |-
-                                              A label selector requirement is a selector that contains values, a key, and an operator that
-                                              relates the key and values.
                                             properties:
                                               key:
-                                                description: key is the label key
-                                                  that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: |-
-                                                  operator represents a key's relationship to a set of values.
-                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                                 type: string
                                               values:
-                                                description: |-
-                                                  values is an array of string values. If the operator is In or NotIn,
-                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. This array is replaced during a strategic
-                                                  merge patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -7497,73 +3553,29 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: |-
-                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     matchLabelKeys:
-                                      description: |-
-                                        MatchLabelKeys is a set of pod label keys to select which pods will
-                                        be taken into consideration. The keys are used to lookup values from the
-                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                        to select the group of existing pods which pods will be taken into consideration
-                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                        pod labels will be ignored. The default value is empty.
-                                        The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                        Also, matchLabelKeys cannot be set when labelSelector isn't set.
                                       items:
                                         type: string
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     mismatchLabelKeys:
-                                      description: |-
-                                        MismatchLabelKeys is a set of pod label keys to select which pods will
-                                        be taken into consideration. The keys are used to lookup values from the
-                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                        to select the group of existing pods which pods will be taken into consideration
-                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                        pod labels will be ignored. The default value is empty.
-                                        The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                        Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
                                       items:
                                         type: string
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     namespaceSelector:
-                                      description: |-
-                                        A label query over the set of namespaces that the term applies to.
-                                        The term is applied to the union of the namespaces selected by this field
-                                        and the ones listed in the namespaces field.
-                                        null selector and null or empty namespaces list means "this pod's namespace".
-                                        An empty selector ({}) matches all namespaces.
                                       properties:
                                         matchExpressions:
-                                          description: matchExpressions is a list
-                                            of label selector requirements. The requirements
-                                            are ANDed.
                                           items:
-                                            description: |-
-                                              A label selector requirement is a selector that contains values, a key, and an operator that
-                                              relates the key and values.
                                             properties:
                                               key:
-                                                description: key is the label key
-                                                  that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: |-
-                                                  operator represents a key's relationship to a set of values.
-                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                                 type: string
                                               values:
-                                                description: |-
-                                                  values is an array of string values. If the operator is In or NotIn,
-                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. This array is replaced during a strategic
-                                                  merge patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -7577,38 +3589,20 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: |-
-                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     namespaces:
-                                      description: |-
-                                        namespaces specifies a static list of namespace names that the term applies to.
-                                        The term is applied to the union of the namespaces listed in this field
-                                        and the ones selected by namespaceSelector.
-                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                       items:
                                         type: string
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     topologyKey:
-                                      description: |-
-                                        This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
-                                        the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                        whose value of the label with key topologyKey matches that of any node on which any of the
-                                        selected pods is running.
-                                        Empty topologyKey is not allowed.
                                       type: string
                                   required:
                                   - topologyKey
                                   type: object
                                 weight:
-                                  description: |-
-                                    weight associated with matching the corresponding podAffinityTerm,
-                                    in the range 1-100.
                                   format: int32
                                   type: integer
                               required:
@@ -7618,52 +3612,18 @@ spec:
                             type: array
                             x-kubernetes-list-type: atomic
                           requiredDuringSchedulingIgnoredDuringExecution:
-                            description: |-
-                              If the affinity requirements specified by this field are not met at
-                              scheduling time, the pod will not be scheduled onto the node.
-                              If the affinity requirements specified by this field cease to be met
-                              at some point during pod execution (e.g. due to a pod label update), the
-                              system may or may not try to eventually evict the pod from its node.
-                              When there are multiple elements, the lists of nodes corresponding to each
-                              podAffinityTerm are intersected, i.e. all terms must be satisfied.
                             items:
-                              description: |-
-                                Defines a set of pods (namely those matching the labelSelector
-                                relative to the given namespace(s)) that this pod should be
-                                co-located (affinity) or not co-located (anti-affinity) with,
-                                where co-located is defined as running on a node whose value of
-                                the label with key <topologyKey> matches that of any node on which
-                                a pod of the set of pods is running
                               properties:
                                 labelSelector:
-                                  description: |-
-                                    A label query over a set of resources, in this case pods.
-                                    If it's null, this PodAffinityTerm matches with no Pods.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
                                       items:
-                                        description: |-
-                                          A label selector requirement is a selector that contains values, a key, and an operator that
-                                          relates the key and values.
                                         properties:
                                           key:
-                                            description: key is the label key that
-                                              the selector applies to.
                                             type: string
                                           operator:
-                                            description: |-
-                                              operator represents a key's relationship to a set of values.
-                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
-                                            description: |-
-                                              values is an array of string values. If the operator is In or NotIn,
-                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This array is replaced during a strategic
-                                              merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -7677,73 +3637,29 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: |-
-                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 matchLabelKeys:
-                                  description: |-
-                                    MatchLabelKeys is a set of pod label keys to select which pods will
-                                    be taken into consideration. The keys are used to lookup values from the
-                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                    to select the group of existing pods which pods will be taken into consideration
-                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                    pod labels will be ignored. The default value is empty.
-                                    The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                    Also, matchLabelKeys cannot be set when labelSelector isn't set.
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 mismatchLabelKeys:
-                                  description: |-
-                                    MismatchLabelKeys is a set of pod label keys to select which pods will
-                                    be taken into consideration. The keys are used to lookup values from the
-                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                    to select the group of existing pods which pods will be taken into consideration
-                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                    pod labels will be ignored. The default value is empty.
-                                    The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                    Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 namespaceSelector:
-                                  description: |-
-                                    A label query over the set of namespaces that the term applies to.
-                                    The term is applied to the union of the namespaces selected by this field
-                                    and the ones listed in the namespaces field.
-                                    null selector and null or empty namespaces list means "this pod's namespace".
-                                    An empty selector ({}) matches all namespaces.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
                                       items:
-                                        description: |-
-                                          A label selector requirement is a selector that contains values, a key, and an operator that
-                                          relates the key and values.
                                         properties:
                                           key:
-                                            description: key is the label key that
-                                              the selector applies to.
                                             type: string
                                           operator:
-                                            description: |-
-                                              operator represents a key's relationship to a set of values.
-                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
-                                            description: |-
-                                              values is an array of string values. If the operator is In or NotIn,
-                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This array is replaced during a strategic
-                                              merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -7757,30 +3673,15 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: |-
-                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 namespaces:
-                                  description: |-
-                                    namespaces specifies a static list of namespace names that the term applies to.
-                                    The term is applied to the union of the namespaces listed in this field
-                                    and the ones selected by namespaceSelector.
-                                    null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 topologyKey:
-                                  description: |-
-                                    This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
-                                    the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                    whose value of the label with key topologyKey matches that of any node on which any of the
-                                    selected pods is running.
-                                    Empty topologyKey is not allowed.
                                   type: string
                               required:
                               - topologyKey
@@ -7789,59 +3690,22 @@ spec:
                             x-kubernetes-list-type: atomic
                         type: object
                       podAntiAffinity:
-                        description: Describes pod anti-affinity scheduling rules
-                          (e.g. avoid putting this pod in the same node, zone, etc.
-                          as some other pod(s)).
                         properties:
                           preferredDuringSchedulingIgnoredDuringExecution:
-                            description: |-
-                              The scheduler will prefer to schedule pods to nodes that satisfy
-                              the anti-affinity expressions specified by this field, but it may choose
-                              a node that violates one or more of the expressions. The node that is
-                              most preferred is the one with the greatest sum of weights, i.e.
-                              for each node that meets all of the scheduling requirements (resource
-                              request, requiredDuringScheduling anti-affinity expressions, etc.),
-                              compute a sum by iterating through the elements of this field and subtracting
-                              "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
-                              node(s) with the highest sum are the most preferred.
                             items:
-                              description: The weights of all of the matched WeightedPodAffinityTerm
-                                fields are added per-node to find the most preferred
-                                node(s)
                               properties:
                                 podAffinityTerm:
-                                  description: Required. A pod affinity term, associated
-                                    with the corresponding weight.
                                   properties:
                                     labelSelector:
-                                      description: |-
-                                        A label query over a set of resources, in this case pods.
-                                        If it's null, this PodAffinityTerm matches with no Pods.
                                       properties:
                                         matchExpressions:
-                                          description: matchExpressions is a list
-                                            of label selector requirements. The requirements
-                                            are ANDed.
                                           items:
-                                            description: |-
-                                              A label selector requirement is a selector that contains values, a key, and an operator that
-                                              relates the key and values.
                                             properties:
                                               key:
-                                                description: key is the label key
-                                                  that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: |-
-                                                  operator represents a key's relationship to a set of values.
-                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                                 type: string
                                               values:
-                                                description: |-
-                                                  values is an array of string values. If the operator is In or NotIn,
-                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. This array is replaced during a strategic
-                                                  merge patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -7855,73 +3719,29 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: |-
-                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     matchLabelKeys:
-                                      description: |-
-                                        MatchLabelKeys is a set of pod label keys to select which pods will
-                                        be taken into consideration. The keys are used to lookup values from the
-                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                        to select the group of existing pods which pods will be taken into consideration
-                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                        pod labels will be ignored. The default value is empty.
-                                        The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                        Also, matchLabelKeys cannot be set when labelSelector isn't set.
                                       items:
                                         type: string
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     mismatchLabelKeys:
-                                      description: |-
-                                        MismatchLabelKeys is a set of pod label keys to select which pods will
-                                        be taken into consideration. The keys are used to lookup values from the
-                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                        to select the group of existing pods which pods will be taken into consideration
-                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                        pod labels will be ignored. The default value is empty.
-                                        The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                        Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
                                       items:
                                         type: string
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     namespaceSelector:
-                                      description: |-
-                                        A label query over the set of namespaces that the term applies to.
-                                        The term is applied to the union of the namespaces selected by this field
-                                        and the ones listed in the namespaces field.
-                                        null selector and null or empty namespaces list means "this pod's namespace".
-                                        An empty selector ({}) matches all namespaces.
                                       properties:
                                         matchExpressions:
-                                          description: matchExpressions is a list
-                                            of label selector requirements. The requirements
-                                            are ANDed.
                                           items:
-                                            description: |-
-                                              A label selector requirement is a selector that contains values, a key, and an operator that
-                                              relates the key and values.
                                             properties:
                                               key:
-                                                description: key is the label key
-                                                  that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: |-
-                                                  operator represents a key's relationship to a set of values.
-                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                                 type: string
                                               values:
-                                                description: |-
-                                                  values is an array of string values. If the operator is In or NotIn,
-                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. This array is replaced during a strategic
-                                                  merge patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -7935,38 +3755,20 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: |-
-                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     namespaces:
-                                      description: |-
-                                        namespaces specifies a static list of namespace names that the term applies to.
-                                        The term is applied to the union of the namespaces listed in this field
-                                        and the ones selected by namespaceSelector.
-                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                       items:
                                         type: string
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     topologyKey:
-                                      description: |-
-                                        This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
-                                        the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                        whose value of the label with key topologyKey matches that of any node on which any of the
-                                        selected pods is running.
-                                        Empty topologyKey is not allowed.
                                       type: string
                                   required:
                                   - topologyKey
                                   type: object
                                 weight:
-                                  description: |-
-                                    weight associated with matching the corresponding podAffinityTerm,
-                                    in the range 1-100.
                                   format: int32
                                   type: integer
                               required:
@@ -7976,52 +3778,18 @@ spec:
                             type: array
                             x-kubernetes-list-type: atomic
                           requiredDuringSchedulingIgnoredDuringExecution:
-                            description: |-
-                              If the anti-affinity requirements specified by this field are not met at
-                              scheduling time, the pod will not be scheduled onto the node.
-                              If the anti-affinity requirements specified by this field cease to be met
-                              at some point during pod execution (e.g. due to a pod label update), the
-                              system may or may not try to eventually evict the pod from its node.
-                              When there are multiple elements, the lists of nodes corresponding to each
-                              podAffinityTerm are intersected, i.e. all terms must be satisfied.
                             items:
-                              description: |-
-                                Defines a set of pods (namely those matching the labelSelector
-                                relative to the given namespace(s)) that this pod should be
-                                co-located (affinity) or not co-located (anti-affinity) with,
-                                where co-located is defined as running on a node whose value of
-                                the label with key <topologyKey> matches that of any node on which
-                                a pod of the set of pods is running
                               properties:
                                 labelSelector:
-                                  description: |-
-                                    A label query over a set of resources, in this case pods.
-                                    If it's null, this PodAffinityTerm matches with no Pods.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
                                       items:
-                                        description: |-
-                                          A label selector requirement is a selector that contains values, a key, and an operator that
-                                          relates the key and values.
                                         properties:
                                           key:
-                                            description: key is the label key that
-                                              the selector applies to.
                                             type: string
                                           operator:
-                                            description: |-
-                                              operator represents a key's relationship to a set of values.
-                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
-                                            description: |-
-                                              values is an array of string values. If the operator is In or NotIn,
-                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This array is replaced during a strategic
-                                              merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -8035,73 +3803,29 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: |-
-                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 matchLabelKeys:
-                                  description: |-
-                                    MatchLabelKeys is a set of pod label keys to select which pods will
-                                    be taken into consideration. The keys are used to lookup values from the
-                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                    to select the group of existing pods which pods will be taken into consideration
-                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                    pod labels will be ignored. The default value is empty.
-                                    The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                    Also, matchLabelKeys cannot be set when labelSelector isn't set.
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 mismatchLabelKeys:
-                                  description: |-
-                                    MismatchLabelKeys is a set of pod label keys to select which pods will
-                                    be taken into consideration. The keys are used to lookup values from the
-                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                    to select the group of existing pods which pods will be taken into consideration
-                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                    pod labels will be ignored. The default value is empty.
-                                    The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                    Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 namespaceSelector:
-                                  description: |-
-                                    A label query over the set of namespaces that the term applies to.
-                                    The term is applied to the union of the namespaces selected by this field
-                                    and the ones listed in the namespaces field.
-                                    null selector and null or empty namespaces list means "this pod's namespace".
-                                    An empty selector ({}) matches all namespaces.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
                                       items:
-                                        description: |-
-                                          A label selector requirement is a selector that contains values, a key, and an operator that
-                                          relates the key and values.
                                         properties:
                                           key:
-                                            description: key is the label key that
-                                              the selector applies to.
                                             type: string
                                           operator:
-                                            description: |-
-                                              operator represents a key's relationship to a set of values.
-                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
-                                            description: |-
-                                              values is an array of string values. If the operator is In or NotIn,
-                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This array is replaced during a strategic
-                                              merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -8115,30 +3839,15 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: |-
-                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 namespaces:
-                                  description: |-
-                                    namespaces specifies a static list of namespace names that the term applies to.
-                                    The term is applied to the union of the namespaces listed in this field
-                                    and the ones selected by namespaceSelector.
-                                    null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 topologyKey:
-                                  description: |-
-                                    This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
-                                    the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                    whose value of the label with key topologyKey matches that of any node on which any of the
-                                    selected pods is running.
-                                    Empty topologyKey is not allowed.
                                   type: string
                               required:
                               - topologyKey
@@ -8148,242 +3857,134 @@ spec:
                         type: object
                     type: object
                   envFrom:
-                    description: EnvFrom is a list of sources to populate environment
-                      variables in the container.
                     items:
-                      description: EnvFromSource represents the source of a set of
-                        ConfigMaps or Secrets
                       properties:
                         configMapRef:
-                          description: The ConfigMap to select from
                           properties:
                             name:
                               default: ""
-                              description: |-
-                                Name of the referent.
-                                This field is effectively required, but due to backwards compatibility is
-                                allowed to be empty. Instances of this type with an empty value here are
-                                almost certainly wrong.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                               type: string
                             optional:
-                              description: Specify whether the ConfigMap must be defined
                               type: boolean
                           type: object
                           x-kubernetes-map-type: atomic
                         prefix:
-                          description: |-
-                            Optional text to prepend to the name of each environment variable.
-                            May consist of any printable ASCII characters except '='.
                           type: string
                         secretRef:
-                          description: The Secret to select from
                           properties:
                             name:
                               default: ""
-                              description: |-
-                                Name of the referent.
-                                This field is effectively required, but due to backwards compatibility is
-                                allowed to be empty. Instances of this type with an empty value here are
-                                almost certainly wrong.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                               type: string
                             optional:
-                              description: Specify whether the Secret must be defined
                               type: boolean
                           type: object
                           x-kubernetes-map-type: atomic
                       type: object
                     type: array
                   health:
-                    description: Health defines the health endpoint configuration.
                     properties:
                       host:
-                        description: 'Host is the host to bind to (default: 0.0.0.0)'
                         type: string
                       port:
-                        description: Port is the port number (optional, operator sets
-                          defaults)
                         format: int32
                         type: integer
                     type: object
                   inference:
-                    description: Inference controls the optional inference sidecar
-                      runtime integrated into swarm mode.
                     properties:
                       apiURL:
-                        description: APIURL is the inference API URL.
                         type: string
                       enabled:
-                        description: Enabled controls whether inference runs alongside
-                          the swarm node.
                         type: boolean
                     type: object
                   metadataAPI:
-                    description: MetadataAPI defines the metadata API configuration.
                     properties:
                       host:
-                        description: 'Host is the host to bind to (default: 0.0.0.0)'
                         type: string
                       port:
-                        description: Port is the port number (optional, operator sets
-                          defaults)
                         format: int32
                         type: integer
                     type: object
                   metadataRaft:
-                    description: MetadataRaft defines the metadata raft configuration.
                     properties:
                       host:
-                        description: 'Host is the host to bind to (default: 0.0.0.0)'
                         type: string
                       port:
-                        description: Port is the port number (optional, operator sets
-                          defaults)
                         format: int32
                         type: integer
                     type: object
                   nodeID:
-                    description: NodeID is the swarm node ID used for local orchestration
-                      URLs.
                     format: int32
                     type: integer
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: NodeSelector defines node selector labels for pod
-                      scheduling.
                     type: object
                   replicas:
-                    description: Replicas is the number of swarm replicas. MVP only
-                      supports 1.
                     format: int32
                     type: integer
                   resources:
-                    description: Resources defines the resource requirements.
                     properties:
                       cpu:
-                        description: CPU resource requirements
                         type: string
                       limits:
-                        description: Limits defines the resource limits
                         properties:
                           cpu:
-                            description: CPU limit
                             type: string
                           gpu:
-                            description: GPU limit (maps to nvidia.com/gpu resource)
                             type: string
                           memory:
-                            description: Memory limit
                             type: string
                         type: object
                       memory:
-                        description: Memory resource requirements
                         type: string
                     required:
                     - limits
                     type: object
                   storeAPI:
-                    description: StoreAPI defines the store API configuration.
                     properties:
                       host:
-                        description: 'Host is the host to bind to (default: 0.0.0.0)'
                         type: string
                       port:
-                        description: Port is the port number (optional, operator sets
-                          defaults)
                         format: int32
                         type: integer
                     type: object
                   storeRaft:
-                    description: StoreRaft defines the store raft configuration.
                     properties:
                       host:
-                        description: 'Host is the host to bind to (default: 0.0.0.0)'
                         type: string
                       port:
-                        description: Port is the port number (optional, operator sets
-                          defaults)
                         format: int32
                         type: integer
                     type: object
                   tolerations:
-                    description: Tolerations defines tolerations for pod scheduling.
                     items:
-                      description: |-
-                        The pod this Toleration is attached to tolerates any taint that matches
-                        the triple <key,value,effect> using the matching operator <operator>.
                       properties:
                         effect:
-                          description: |-
-                            Effect indicates the taint effect to match. Empty means match all taint effects.
-                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                           type: string
                         key:
-                          description: |-
-                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                           type: string
                         operator:
-                          description: |-
-                            Operator represents a key's relationship to the value.
-                            Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
-                            Exists is equivalent to wildcard for value, so that a pod can
-                            tolerate all taints of a particular category.
-                            Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                           type: string
                         tolerationSeconds:
-                          description: |-
-                            TolerationSeconds represents the period of time the toleration (which must be
-                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                            it is not set, which means tolerate the taint forever (do not evict). Zero and
-                            negative values will be treated as 0 (evict immediately) by the system.
                           format: int64
                           type: integer
                         value:
-                          description: |-
-                            Value is the taint value the toleration matches to.
-                            If the operator is Exists, the value should be empty, otherwise just a regular string.
                           type: string
                       type: object
                     type: array
                   topologySpreadConstraints:
-                    description: TopologySpreadConstraints describes how pods should
-                      spread across topology domains.
                     items:
-                      description: TopologySpreadConstraint specifies how to spread
-                        matching pods among the given topology.
                       properties:
                         labelSelector:
-                          description: |-
-                            LabelSelector is used to find matching pods.
-                            Pods that match this label selector are counted to determine the number of pods
-                            in their corresponding topology domain.
                           properties:
                             matchExpressions:
-                              description: matchExpressions is a list of label selector
-                                requirements. The requirements are ANDed.
                               items:
-                                description: |-
-                                  A label selector requirement is a selector that contains values, a key, and an operator that
-                                  relates the key and values.
                                 properties:
                                   key:
-                                    description: key is the label key that the selector
-                                      applies to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      operator represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                     type: string
                                   values:
-                                    description: |-
-                                      values is an array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. This array is replaced during a strategic
-                                      merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -8397,125 +3998,27 @@ spec:
                             matchLabels:
                               additionalProperties:
                                 type: string
-                              description: |-
-                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                               type: object
                           type: object
                           x-kubernetes-map-type: atomic
                         matchLabelKeys:
-                          description: |-
-                            MatchLabelKeys is a set of pod label keys to select the pods over which
-                            spreading will be calculated. The keys are used to lookup values from the
-                            incoming pod labels, those key-value labels are ANDed with labelSelector
-                            to select the group of existing pods over which spreading will be calculated
-                            for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
-                            MatchLabelKeys cannot be set when LabelSelector isn't set.
-                            Keys that don't exist in the incoming pod labels will
-                            be ignored. A null or empty list means only match against labelSelector.
-
-                            This is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).
                           items:
                             type: string
                           type: array
                           x-kubernetes-list-type: atomic
                         maxSkew:
-                          description: |-
-                            MaxSkew describes the degree to which pods may be unevenly distributed.
-                            When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
-                            between the number of matching pods in the target topology and the global minimum.
-                            The global minimum is the minimum number of matching pods in an eligible domain
-                            or zero if the number of eligible domains is less than MinDomains.
-                            For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
-                            labelSelector spread as 2/2/1:
-                            In this case, the global minimum is 1.
-                            | zone1 | zone2 | zone3 |
-                            |  P P  |  P P  |   P   |
-                            - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2;
-                            scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2)
-                            violate MaxSkew(1).
-                            - if MaxSkew is 2, incoming pod can be scheduled onto any zone.
-                            When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence
-                            to topologies that satisfy it.
-                            It's a required field. Default value is 1 and 0 is not allowed.
                           format: int32
                           type: integer
                         minDomains:
-                          description: |-
-                            MinDomains indicates a minimum number of eligible domains.
-                            When the number of eligible domains with matching topology keys is less than minDomains,
-                            Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed.
-                            And when the number of eligible domains with matching topology keys equals or greater than minDomains,
-                            this value has no effect on scheduling.
-                            As a result, when the number of eligible domains is less than minDomains,
-                            scheduler won't schedule more than maxSkew Pods to those domains.
-                            If value is nil, the constraint behaves as if MinDomains is equal to 1.
-                            Valid values are integers greater than 0.
-                            When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
-
-                            For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same
-                            labelSelector spread as 2/2/2:
-                            | zone1 | zone2 | zone3 |
-                            |  P P  |  P P  |  P P  |
-                            The number of domains is less than 5(MinDomains), so "global minimum" is treated as 0.
-                            In this situation, new pod with the same labelSelector cannot be scheduled,
-                            because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones,
-                            it will violate MaxSkew.
                           format: int32
                           type: integer
                         nodeAffinityPolicy:
-                          description: |-
-                            NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
-                            when calculating pod topology spread skew. Options are:
-                            - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
-                            - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
-
-                            If this value is nil, the behavior is equivalent to the Honor policy.
                           type: string
                         nodeTaintsPolicy:
-                          description: |-
-                            NodeTaintsPolicy indicates how we will treat node taints when calculating
-                            pod topology spread skew. Options are:
-                            - Honor: nodes without taints, along with tainted nodes for which the incoming pod
-                            has a toleration, are included.
-                            - Ignore: node taints are ignored. All nodes are included.
-
-                            If this value is nil, the behavior is equivalent to the Ignore policy.
                           type: string
                         topologyKey:
-                          description: |-
-                            TopologyKey is the key of node labels. Nodes that have a label with this key
-                            and identical values are considered to be in the same topology.
-                            We consider each <key, value> as a "bucket", and try to put balanced number
-                            of pods into each bucket.
-                            We define a domain as a particular instance of a topology.
-                            Also, we define an eligible domain as a domain whose nodes meet the requirements of
-                            nodeAffinityPolicy and nodeTaintsPolicy.
-                            e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology.
-                            And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology.
-                            It's a required field.
                           type: string
                         whenUnsatisfiable:
-                          description: |-
-                            WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
-                            the spread constraint.
-                            - DoNotSchedule (default) tells the scheduler not to schedule it.
-                            - ScheduleAnyway tells the scheduler to schedule the pod in any location,
-                              but giving higher precedence to topologies that would help reduce the
-                              skew.
-                            A constraint is considered "Unsatisfiable" for an incoming pod
-                            if and only if every possible node assignment for that pod would violate
-                            "MaxSkew" on some topology.
-                            For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
-                            labelSelector spread as 3/1/1:
-                            | zone1 | zone2 | zone3 |
-                            | P P P |   P   |   P   |
-                            If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled
-                            to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies
-                            MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler
-                            won't make it *more* imbalanced.
-                            It's a required field.
                           type: string
                       required:
                       - maxSkew
@@ -8532,53 +4035,31 @@ spec:
             - storage
             type: object
           status:
-            description: AntflyClusterStatus defines the observed state of AntflyCluster
             properties:
               autoScalingStatus:
-                description: AutoScalingStatus tracks autoscaling state
                 properties:
                   blockedMessage:
-                    description: BlockedMessage provides human-readable detail for
-                      BlockedReason.
                     type: string
                   blockedReason:
-                    description: BlockedReason explains why the autoscaler recommendation
-                      was not applied.
                     type: string
                   currentCPUUtilizationPercentage:
-                    description: CurrentCPUUtilizationPercentage is the current CPU
-                      utilization
                     format: int32
                     type: integer
                   currentMemoryUtilizationPercentage:
-                    description: CurrentMemoryUtilizationPercentage is the current
-                      memory utilization
                     format: int32
                     type: integer
                   currentReplicas:
-                    description: CurrentReplicas is the current number of replicas
                     format: int32
                     type: integer
                   desiredReplicas:
-                    description: |-
-                      DesiredReplicas is the replica count the operator is currently applying.
-                      When scale-down is blocked, this remains at CurrentReplicas even if
-                      RecommendationReplicas is lower.
                     format: int32
                     type: integer
                   lastScaleDirection:
-                    description: |-
-                      LastScaleDirection indicates the direction of the last scaling operation
-                      Values: "up", "down", or empty string if no scaling has occurred
                     type: string
                   lastScaleTime:
-                    description: LastScaleTime is the last time scaling occurred
                     format: date-time
                     type: string
                   recommendationReplicas:
-                    description: |-
-                      RecommendationReplicas is the latest replica recommendation from the
-                      operator autoscaler before safety gates are applied.
                     format: int32
                     type: integer
                 required:
@@ -8586,51 +4067,30 @@ spec:
                 - desiredReplicas
                 type: object
               conditions:
-                description: Conditions represent the current conditions of the cluster
                 items:
-                  description: Condition contains details for one aspect of the current
-                    state of this API Resource.
                   properties:
                     lastTransitionTime:
-                      description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: |-
-                        message is a human readable message indicating details about the transition.
-                        This may be an empty string.
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: |-
-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                        with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
-                      description: |-
-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                        Producers of specific condition types may define expected values and meanings for this field,
-                        and whether the values are considered a guaranteed API.
-                        The value should be a CamelCase string.
-                        This field may not be empty.
                       maxLength: 1024
                       minLength: 1
                       pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
                       type: string
                     status:
-                      description: status of the condition, one of True, False, Unknown.
                       enum:
                       - "True"
                       - "False"
                       - Unknown
                       type: string
                     type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -8643,72 +4103,44 @@ spec:
                   type: object
                 type: array
               dataNodesReady:
-                description: DataNodesReady represents the number of ready data nodes
                 format: int32
                 type: integer
               dataScaleDownStatus:
-                description: DataScaleDownStatus tracks the operator-owned data-node
-                  scale-down workflow.
                 properties:
                   appliedReplicas:
-                    description: AppliedReplicas is the replica count applied to the
-                      StatefulSet for this step.
                     format: int32
                     type: integer
                   drainingNodeID:
-                    description: DrainingNodeID is the Antfly node ID selected for
-                      this step.
                     type: string
                   drainingOrdinal:
-                    description: DrainingOrdinal is the StatefulSet ordinal selected
-                      for this step.
                     format: int32
                     type: integer
                   fromReplicas:
-                    description: FromReplicas is the observed/applied replica count
-                      before this scale-down step.
                     format: int32
                     type: integer
                   lastTransitionTime:
-                    description: LastTransitionTime records the last phase transition.
                     format: date-time
                     type: string
                   message:
-                    description: Message describes the current scale-down workflow
-                      state.
                     type: string
                   phase:
-                    description: Phase is the current scale-down workflow phase.
                     type: string
                   source:
-                    description: |-
-                      Source reports whether the current scale-down step was requested by the
-                      manual replica field or by the operator autoscaler.
                     type: string
                   targetReplicas:
-                    description: TargetReplicas is the user or autoscaler requested
-                      final replica count.
                     format: int32
                     type: integer
                 type: object
               haStatus:
-                description: HAStatus reports hot-standby replication and failover
-                  state.
                 properties:
                   automaticPromotionAllowed:
-                    description: AutomaticPromotionAllowed reports whether the operator
-                      planner allows promotion.
                     type: boolean
                   desiredStandbyCount:
-                    description: DesiredStandbyCount is the count requested by spec.highAvailability.
                     format: int32
                     type: integer
                   fencing:
-                    description: Fencing reports the observed fencing authority state
-                      used for automatic promotion.
                     properties:
                       authority:
-                        description: Authority is the observed fencing authority.
                         enum:
                         - None
                         - KubernetesLease
@@ -8717,26 +4149,16 @@ spec:
                         - External
                         type: string
                       generation:
-                        description: Generation is the observed fencing epoch used
-                          to order promotions.
                         format: int64
                         type: integer
                       holder:
-                        description: Holder identifies the actor that currently holds
-                          or can acquire the fence.
                         type: string
                       ready:
-                        description: Ready reports whether the fencing authority has
-                          been observed and can fence a primary.
                         type: boolean
                       reason:
-                        description: Reason describes the latest fencing readiness
-                          decision.
                         type: string
                     type: object
                   formerPrimary:
-                    description: FormerPrimary reports the old primary's rejoin disposition
-                      after promotion.
                     properties:
                       action:
                         type: string
@@ -8749,8 +4171,6 @@ spec:
                       diverged:
                         type: boolean
                       fenceAuthority:
-                        description: HAFencingAuthority selects the authority used
-                          before automatic promotion.
                         type: string
                       fenceGeneration:
                         format: int64
@@ -8801,21 +4221,14 @@ spec:
                         type: integer
                     type: object
                   healthyStandbyCount:
-                    description: HealthyStandbyCount is the count of desired standbys
-                      caught up to apply.
                     format: int32
                     type: integer
                   laggingStandbyCount:
-                    description: LaggingStandbyCount is the count of desired standbys
-                      with non-zero replication lag.
                     format: int32
                     type: integer
                   lastPromotion:
-                    description: LastPromotion records the last completed promotion.
                     properties:
                       clusterID:
-                        description: ClusterID is the replicated cluster identity
-                          of the promotion scope.
                         format: int64
                         type: integer
                       completionTime:
@@ -8824,8 +4237,6 @@ spec:
                       dataLossPossible:
                         type: boolean
                       fenceAuthority:
-                        description: HAFencingAuthority selects the authority used
-                          before automatic promotion.
                         type: string
                       fenceGeneration:
                         format: int64
@@ -8859,344 +4270,189 @@ spec:
                         format: int64
                         type: integer
                       shardID:
-                        description: ShardID is the replicated shard identity of the
-                          promotion scope. Zero means whole-instance or default shard
-                          scope.
                         format: int64
                         type: integer
                       switchLSN:
                         format: int64
                         type: integer
                       tableID:
-                        description: TableID is the replicated table identity of the
-                          promotion scope. Zero means whole-instance or default table
-                          scope.
                         format: int64
                         type: integer
                     type: object
                   mode:
-                    description: Mode is the observed HA mode.
                     type: string
                   plannedActions:
-                    description: PlannedActions reports HA reconciliation actions
-                      the operator plans to take.
                     items:
-                      description: HAPlannedActionStatus reports one planned HA operator
-                        action.
                       properties:
                         adminCommand:
-                          description: AdminCommand is a compatibility CLI argv hint
-                            for HA actions that need a Kubernetes Job or break-glass
-                            execution.
                           items:
                             type: string
                           type: array
                         adminError:
-                          description: AdminError records the latest direct /admin/v1
-                            HA execution or result-validation error for this action.
                           type: string
                         adminJobName:
-                          description: AdminJobName records direct-admin-api for typed
-                            execution or the Kubernetes Job created for CLI-backed
-                            execution.
                           type: string
                         adminJobPhase:
-                          description: AdminJobPhase summarizes dependency wait state,
-                            direct admin API execution, or CLI-backed Kubernetes Job
-                            state.
                           type: string
                         adminMethod:
-                          description: AdminMethod is the HTTP method for the typed
-                            /admin/v1 operation that executes this action.
                           type: string
                         adminNodeID:
-                          description: AdminNodeID is the node id expected in the
-                            typed HA admin action receipt from AdminURL.
                           type: string
                         adminPath:
-                          description: AdminPath is the typed /admin/v1 operation
-                            path that executes this action.
                           type: string
                         adminResult:
-                          description: AdminResult records stable identifiers returned
-                            by a successful typed /admin/v1 HA operation.
                           properties:
                             actionID:
-                              description: ActionID is the stable typed HA admin action
-                                correlation id.
                               type: string
                             actionKind:
-                              description: ActionKind is the typed HA admin action
-                                kind that produced this result.
                               type: string
                             actionNodeID:
-                              description: ActionNodeID is the node id of the node-local
-                                HA admin endpoint that produced this result.
                               type: string
                             actionState:
-                              description: ActionState is the idempotency state returned
-                                by the HA admin action.
                               type: string
                             actionTarget:
-                              description: ActionTarget is the node id, slot name,
-                                manifest id, or promotion boundary acted on.
                               type: string
                             backupLSN:
-                              description: BackupLSN is the base-backup stream boundary
-                                returned by seed operations.
                               format: int64
                               type: integer
                             checkpointLSN:
-                              description: CheckpointLSN is the standby checkpoint
-                                LSN returned by seed bootstrap.
                               format: int64
                               type: integer
                             dataLossDiscarded:
-                              description: DataLossDiscarded reports whether rewind
-                                would discard former-primary data.
                               type: boolean
                             endRecordLSN:
-                              description: EndRecordLSN is the durable backup_end
-                                record LSN returned by seed finish.
                               format: int64
                               type: integer
                             fenceClusterID:
-                              description: FenceClusterID is the cluster identity
-                                carried by a promotion fence receipt.
                               format: int64
                               type: integer
                             fenceForced:
-                              description: FenceForced reports whether the promotion
-                                fence was acquired with force.
                               type: boolean
                             fenceGeneration:
-                              description: FenceGeneration is the promotion fence
-                                generation returned by fence operations.
                               format: int64
                               type: integer
                             fenceNewEpoch:
-                              description: FenceNewEpoch is the promoted epoch carried
-                                by a promotion fence receipt.
                               format: int64
                               type: integer
                             fenceNewTimelineID:
-                              description: FenceNewTimelineID is the promoted timeline
-                                carried by a promotion fence receipt.
                               format: int64
                               type: integer
                             fenceObservedLSN:
-                              description: FenceObservedLSN is the observed standby
-                                LSN carried by a promotion fence receipt.
                               format: int64
                               type: integer
                             fenceOldPrimaryID:
-                              description: FenceOldPrimaryID is the fenced primary
-                                node id carried by a promotion fence receipt.
                               type: string
                             fenceParentEpoch:
-                              description: FenceParentEpoch is the parent epoch carried
-                                by a promotion fence receipt.
                               format: int64
                               type: integer
                             fenceParentTimelineID:
-                              description: FenceParentTimelineID is the parent timeline
-                                carried by a promotion fence receipt.
                               format: int64
                               type: integer
                             fencePromotedNodeID:
-                              description: FencePromotedNodeID is the promoted standby
-                                node id carried by a promotion fence receipt.
                               type: string
                             fenceReason:
-                              description: FenceReason is the reason carried by a
-                                promotion fence receipt.
                               type: string
                             fenceRequiredLSN:
-                              description: FenceRequiredLSN is the minimum promotion
-                                LSN carried by a promotion fence receipt.
                               format: int64
                               type: integer
                             fenceShardID:
-                              description: FenceShardID is the shard identity carried
-                                by a promotion fence receipt.
                               format: int64
                               type: integer
                             fenceTableID:
-                              description: FenceTableID is the table identity carried
-                                by a promotion fence receipt.
                               format: int64
                               type: integer
                             fenceToken:
-                              description: FenceToken is the opaque promotion fence
-                                receipt token returned by fence operations.
                               type: string
                             forkLSN:
-                              description: ForkLSN is the timeline fork LSN returned
-                                by a rejoin assessment.
                               format: int64
                               type: integer
                             formerLastLSN:
-                              description: FormerLastLSN is the former primary's last
-                                observed LSN returned by a rejoin assessment.
                               format: int64
                               type: integer
                             formerNodeID:
-                              description: FormerNodeID is the former-primary node
-                                id returned by a rejoin assessment.
                               type: string
                             manifestID:
-                              description: ManifestID is the base-backup manifest/action
-                                id returned by seed operations.
                               type: string
                             promotionAppliedLSN:
-                              description: PromotionAppliedLSN is the standby applied
-                                LSN observed by a promotion assessment.
                               format: int64
                               type: integer
                             promotionCanPromote:
-                              description: PromotionCanPromote reports whether a promotion
-                                assessment permits promotion.
                               type: boolean
                             promotionDataLossPossible:
-                              description: PromotionDataLossPossible reports whether
-                                a promotion assessment found possible data loss.
                               type: boolean
                             promotionFenced:
-                              description: PromotionFenced reports whether promotion
-                                assessment observed a fence.
                               type: boolean
                             promotionForce:
-                              description: PromotionForce reports whether a promotion
-                                assessment used force.
                               type: boolean
                             promotionMode:
-                              description: PromotionMode is the explicit promotion
-                                assessment mode reported by the admin API.
                               type: string
                             promotionReceivedLSN:
-                              description: PromotionReceivedLSN is the standby received
-                                LSN observed by a promotion assessment.
                               format: int64
                               type: integer
                             promotionRequiredLSN:
-                              description: PromotionRequiredLSN is the minimum LSN
-                                checked by a promotion assessment.
                               format: int64
                               type: integer
                             promotionRequiresFencing:
-                              description: PromotionRequiresFencing reports whether
-                                a promotion assessment still needs fencing.
                               type: boolean
                             promotionRequiresForce:
-                              description: PromotionRequiresForce reports whether
-                                a promotion assessment needs force to proceed.
                               type: boolean
                             promotionSafe:
-                              description: PromotionSafe reports whether a promotion
-                                assessment found no safety violation.
                               type: boolean
                             rejoinAction:
-                              description: RejoinAction is the former-primary rejoin
-                                action returned by a rejoin assessment.
                               type: string
                             rejoinReason:
-                              description: RejoinReason is the former-primary rejoin
-                                reason returned by a rejoin assessment.
                               type: string
                             reseedBaseBackupRequired:
-                              description: ReseedBaseBackupRequired reports that a
-                                new base backup must be taken before bootstrap.
                               type: boolean
                             reseedExecuted:
-                              description: ReseedExecuted reports that `/admin/v1/ha/rejoin/reseed`
-                                marked the former-primary slot for reseed.
                               type: boolean
                             reseedRequired:
-                              description: ReseedRequired reports that the former-primary
-                                slot is now reseed-required.
                               type: boolean
                             reseedSlotName:
-                              description: ReseedSlotName is the replication slot
-                                marked for former-primary reseed.
                               type: string
                             retainedFromLSN:
-                              description: RetainedFromLSN is the earliest retained
-                                WAL LSN used by a rejoin assessment.
                               format: int64
                               type: integer
                             rewindCurrentLastLSN:
-                              description: RewindCurrentLastLSN is the former-primary
-                                log tail after rewind execution.
                               format: int64
                               type: integer
                             rewindDiscardedLSNCount:
-                              description: RewindDiscardedLSNCount is the count of
-                                divergent former-primary LSNs discarded by rewind.
                               format: int64
                               type: integer
                             rewindExecuted:
-                              description: RewindExecuted reports that `/admin/v1/ha/rejoin/rewind`
-                                returned a concrete rewind result.
                               type: boolean
                             rewindNextLSN:
-                              description: RewindNextLSN is the next append LSN after
-                                rewind execution.
                               format: int64
                               type: integer
                             rewindPreviousLastLSN:
-                              description: RewindPreviousLastLSN is the former-primary
-                                log tail before rewind execution.
                               format: int64
                               type: integer
                             schemaVersion:
-                              description: SchemaVersion is the response schema version
-                                returned by the HA admin API.
                               format: int32
                               type: integer
                             slotAction:
-                              description: SlotAction is the executed replication
-                                slot action.
                               type: string
                             slotName:
-                              description: SlotName is the affected replication slot
-                                or base-backup standby slot.
                               type: string
                             startRecordLSN:
-                              description: StartRecordLSN is the durable backup_start
-                                record LSN returned by seed begin.
                               format: int64
                               type: integer
                             targetEpoch:
-                              description: TargetEpoch is the promoted epoch returned
-                                by a rejoin assessment.
                               format: int64
                               type: integer
                             targetTimelineID:
-                              description: TargetTimelineID is the promoted timeline
-                                returned by a rejoin assessment.
                               format: int64
                               type: integer
                           type: object
                         adminStatusCode:
-                          description: AdminStatusCode records the latest typed /admin/v1
-                            HA HTTP status code for this action.
                           type: integer
                         adminURL:
-                          description: AdminURL is the HA admin endpoint for typed
-                            /admin/v1/ha execution or CLI-backed job targeting.
                           type: string
                         dependsOn:
-                          description: DependsOn names the action kind that must complete
-                            before this action runs.
                           type: string
                         executor:
-                          description: Executor identifies whether typed /admin/v1,
-                            a CLI-backed Job, or the Kubernetes controller executes
-                            this action.
                           type: string
                         fenceAuthority:
-                          description: HAFencingAuthority selects the authority used
-                            before automatic promotion.
                           type: string
                         fenceGeneration:
                           format: int64
@@ -9211,8 +4467,6 @@ spec:
                           format: int64
                           type: integer
                         phase:
-                          description: Phase groups the action into the HA workflow
-                            stage.
                           type: string
                         reason:
                           type: string
@@ -9224,12 +4478,8 @@ spec:
                         routeTo:
                           type: string
                         seedContentRoot:
-                          description: SeedContentRoot is the copied base-backup content
-                            root used by seed bootstrap actions.
                           type: string
                         seedManifestPath:
-                          description: SeedManifestPath is the base-backup manifest
-                            path used by seed finish/bootstrap actions.
                           type: string
                         slotName:
                           type: string
@@ -9241,25 +4491,15 @@ spec:
                       type: object
                     type: array
                   primaryAdminLastError:
-                    description: PrimaryAdminLastError reports the latest primary
-                      HA admin observation error.
                     type: string
                   primaryAdminReachable:
-                    description: |-
-                      PrimaryAdminReachable reports whether the operator most recently reached the primary HA admin endpoint.
-                      Automatic promotion requires this to be false with PrimaryAdminLastError set.
                     type: boolean
                   primaryAdminStatusCode:
-                    description: PrimaryAdminStatusCode records the latest typed /admin/v1
-                      HA status-observation HTTP status code.
                     type: integer
                   primaryLSN:
-                    description: PrimaryLSN is the current primary replication LSN.
                     format: int64
                     type: integer
                   primaryRoute:
-                    description: PrimaryRoute reports the operator-facing primary
-                      endpoint target.
                     properties:
                       action:
                         type: string
@@ -9268,8 +4508,6 @@ spec:
                       desiredTarget:
                         type: string
                       fenceAuthority:
-                        description: HAFencingAuthority selects the authority used
-                          before automatic promotion.
                         type: string
                       fenceGeneration:
                         format: int64
@@ -9282,17 +4520,12 @@ spec:
                         type: boolean
                     type: object
                   readSafeStandbyCount:
-                    description: ReadSafeStandbyCount is the count of desired standbys
-                      safe for reads.
                     format: int32
                     type: integer
                   reseedRequiredCount:
-                    description: ReseedRequiredCount is the count of desired standbys
-                      requiring reseed.
                     format: int32
                     type: integer
                   retention:
-                    description: Retention summarizes primary WAL retention pressure.
                     properties:
                       activeSlots:
                         format: int32
@@ -9304,13 +4537,9 @@ spec:
                         format: int32
                         type: integer
                       retainedAgeNS:
-                        description: RetainedAgeNS is the HA WAL timestamp span retained
-                          for active slots.
                         format: int64
                         type: integer
                       retainedByteCount:
-                        description: RetainedByteCount is the encoded HA WAL bytes
-                          retained for active slots.
                         format: int64
                         type: integer
                       retainedLSNCount:
@@ -9318,15 +4547,11 @@ spec:
                         type: integer
                     type: object
                   standbys:
-                    description: Standbys contains per-standby slot state.
                     items:
-                      description: HAStandbyStatus reports one hot standby slot.
                       properties:
                         active:
                           type: boolean
                         adminStatusCode:
-                          description: AdminStatusCode records the latest typed /admin/v1
-                            HA standby status-observation HTTP status code.
                           type: integer
                         appliedLSN:
                           format: int64
@@ -9387,8 +4612,6 @@ spec:
                       type: object
                     type: array
                   sync:
-                    description: Sync reports the observed synchronous durability
-                      policy state.
                     properties:
                       action:
                         type: string
@@ -9398,12 +4621,8 @@ spec:
                       degraded:
                         type: boolean
                       failurePolicy:
-                        description: HAFailurePolicy selects what happens when synchronous
-                          durability cannot be met.
                         type: string
                       mode:
-                        description: HADurabilityMode selects when a primary write
-                          may be acknowledged.
                         type: string
                       required:
                         format: int32
@@ -9412,230 +4631,138 @@ spec:
                         format: int32
                         type: integer
                       selection:
-                        description: HAStandbySelection selects which named standbys
-                          satisfy synchronous commit.
                         type: string
                     type: object
                   unhealthyStandbyCount:
-                    description: UnhealthyStandbyCount is the count of desired standbys
-                      missing, inactive, or reporting replication errors.
                     format: int32
                     type: integer
                 type: object
               metadataNodesReady:
-                description: MetadataNodesReady represents the number of ready metadata
-                  nodes
                 format: int32
                 type: integer
               mode:
-                description: Mode reports the observed topology mode.
                 type: string
               observedGeneration:
-                description: |-
-                  ObservedGeneration is the most recent generation observed by the controller.
-                  Used to skip expensive validation when the spec has not changed since
-                  the last successful reconciliation.
                 format: int64
                 type: integer
               phase:
-                description: Phase represents the current phase of the cluster
                 type: string
               productTierStatus:
-                description: ProductTierStatus reports the concrete shape observed
-                  for spec.productTier.
                 properties:
                   dataAutoscaling:
-                    description: DataAutoscaling reports the observed data autoscaling
-                      bounds.
                     type: string
                   dataReplicas:
-                    description: DataReplicas is the observed data replica count.
                     format: int32
                     type: integer
                   dataResources:
-                    description: DataResources summarizes data CPU/memory requests
-                      and limits.
                     type: string
                   dataStorage:
-                    description: DataStorage is the observed data storage size.
                     type: string
                   dataTier:
-                    description: DataTier records the observed data sub-tier name.
                     type: string
                   inferenceEnabled:
-                    description: InferenceEnabled reports whether this tier has an
-                      operator-managed InferencePool.
                     type: boolean
                   inferenceReplicas:
-                    description: InferenceReplicas reports the observed InferencePool
-                      replica bounds.
                     type: string
                   inferenceTier:
-                    description: InferenceTier records the observed inference sub-tier
-                      name.
                     type: string
                   managedBy:
-                    description: ManagedBy is the observed tier owner.
                     type: string
                   metadataReplicas:
-                    description: MetadataReplicas is the observed metadata replica
-                      count.
                     format: int32
                     type: integer
                   metadataResources:
-                    description: MetadataResources summarizes metadata CPU/memory
-                      requests and limits.
                     type: string
                   metadataStorage:
-                    description: MetadataStorage is the observed metadata storage
-                      size.
                     type: string
                   metadataTier:
-                    description: MetadataTier records the observed metadata sub-tier
-                      name.
                     type: string
                   mode:
-                    description: Mode is the topology mode for this tier shape.
                     type: string
                   name:
-                    description: Name is the observed tier name.
                     type: string
                   observedGeneration:
-                    description: ObservedGeneration is the AntflyCluster generation
-                      used for this status.
                     format: int64
                     type: integer
                   revision:
-                    description: Revision is the observed tier catalog revision.
                     type: string
                   swarmResources:
-                    description: SwarmResources summarizes swarm CPU/memory requests
-                      and limits.
                     type: string
                   swarmStorage:
-                    description: SwarmStorage is the observed swarm storage size.
                     type: string
                   swarmTier:
-                    description: SwarmTier records the observed swarm sub-tier name.
                     type: string
                 type: object
               readyReplicas:
-                description: ReadyReplicas is the total number of ready replicas across
-                  the active topology.
                 format: int32
                 type: integer
               serviceMeshStatus:
-                description: ServiceMeshStatus reports service mesh operational state
                 properties:
                   enabled:
-                    description: Enabled reflects whether service mesh is currently
-                      enabled (mirrors spec)
                     type: boolean
                   lastTransitionTime:
-                    description: LastTransitionTime when status last changed
                     format: date-time
                     type: string
                   podsWithSidecars:
-                    description: PodsWithSidecars count of pods with sidecars injected
                     format: int32
                     type: integer
                   sidecarInjectionStatus:
-                    description: |-
-                      SidecarInjectionStatus indicates sidecar injection state
-                      Values: "Complete", "Partial", "None", "Unknown"
                     type: string
                   totalPods:
-                    description: TotalPods total expected pods (metadata + data replicas)
                     format: int32
                     type: integer
                 type: object
               storageAutoGrowStatus:
-                description: StorageAutoGrowStatus tracks the latest operator-owned
-                  storage auto-grow evaluation.
                 properties:
                   capacityBytes:
-                    description: CapacityBytes is the observed capacity bytes across
-                      matching PVC volumes.
                     format: int64
                     type: integer
                   component:
-                    description: Component is the component evaluated by the latest
-                      auto-grow pass.
                     type: string
                   currentSize:
-                    description: CurrentSize is the current effective requested PVC
-                      size.
                     type: string
                   lastEvaluationTime:
-                    description: LastEvaluationTime records when auto-grow was last
-                      evaluated.
                     format: date-time
                     type: string
                   maxSize:
-                    description: MaxSize is the configured maximum size for the evaluated
-                      component.
                     type: string
                   message:
-                    description: Message describes the latest auto-grow decision.
                     type: string
                   reason:
-                    description: Reason is the reason for the latest auto-grow decision.
                     type: string
                   recommendedSize:
-                    description: RecommendedSize is the size the operator selected
-                      when growth is needed.
                     type: string
                   usagePercent:
-                    description: UsagePercent is the observed storage usage percentage.
                     format: int32
                     type: integer
                   usedBytes:
-                    description: UsedBytes is the observed used bytes across matching
-                      PVC volumes.
                     format: int64
                     type: integer
                 type: object
               swarmNodesReady:
-                description: SwarmNodesReady represents the number of ready swarm
-                  nodes.
                 format: int32
                 type: integer
               swarmStatus:
-                description: SwarmStatus reports swarm-specific operational state.
                 properties:
                   inferenceReady:
-                    description: InferenceReady indicates that inference is ready
-                      when enabled.
                     type: boolean
                   lastTransitionTime:
-                    description: LastTransitionTime records the last swarm status
-                      transition.
                     format: date-time
                     type: string
                   metadataReady:
-                    description: MetadataReady indicates that the metadata API is
-                      ready.
                     type: boolean
                   nodeID:
-                    description: NodeID is the configured swarm node ID.
                     format: int32
                     type: integer
                   observedConfigHash:
-                    description: ObservedConfigHash records the config hash seen by
-                      the controller.
                     type: string
                   podIP:
-                    description: PodIP is the IP of the backing swarm pod.
                     type: string
                   podName:
-                    description: PodName is the name of the backing swarm pod.
                     type: string
                   ready:
-                    description: Ready indicates that the combined swarm workload
-                      is ready.
                     type: boolean
                   storeReady:
-                    description: StoreReady indicates that the store API is ready.
                     type: boolean
                 type: object
             type: object

--- a/go/pkg/operator/manifests/crd/antfly.io_antflyrestores.yaml
+++ b/go/pkg/operator/manifests/crd/antfly.io_antflyrestores.yaml
@@ -30,82 +30,50 @@ spec:
     name: v1
     schema:
       openAPIV3Schema:
-        description: AntflyRestore is the Schema for on-demand Antfly restores
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
-            description: AntflyRestoreSpec defines the desired state of AntflyRestore
             properties:
               backoffLimit:
                 default: 3
-                description: 'BackoffLimit specifies the number of retries before
-                  marking restore as failed (default: 3)'
                 format: int32
                 minimum: 0
                 type: integer
               clusterRef:
-                description: ClusterRef references the target AntflyCluster to restore
-                  to
                 properties:
                   name:
-                    description: Name of the AntflyCluster
                     type: string
                   namespace:
-                    description: Namespace of the AntflyCluster (defaults to same
-                      namespace as this resource)
                     type: string
                 required:
                 - name
                 type: object
               restoreMode:
                 default: fail_if_exists
-                description: RestoreMode defines behavior when tables exist
                 enum:
                 - fail_if_exists
                 - skip_if_exists
                 - overwrite
                 type: string
               restoreTimeout:
-                description: 'RestoreTimeout is max duration for the restore operation
-                  (default: 2h)'
                 type: string
               source:
-                description: Source defines where to restore from
                 properties:
                   backupId:
-                    description: BackupID identifies which backup to restore
                     type: string
                   credentialsSecret:
-                    description: |-
-                      CredentialsSecret references a Secret containing storage credentials
-                      For S3: expects keys AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, and optionally AWS_REGION
                     properties:
                       name:
-                        description: Name of the Secret
                         type: string
                     required:
                     - name
                     type: object
                   location:
-                    description: |-
-                      Location is the backup source URL
-                      Supports: s3://bucket/path or file:///path
                     pattern: ^(s3://|file://).+
                     type: string
                 required:
@@ -113,7 +81,6 @@ spec:
                 - location
                 type: object
               tables:
-                description: Tables to restore (nil = all tables from backup)
                 items:
                   type: string
                 type: array
@@ -122,58 +89,35 @@ spec:
             - source
             type: object
           status:
-            description: AntflyRestoreStatus defines the observed state of AntflyRestore
             properties:
               completionTime:
-                description: CompletionTime when restore finished
                 format: date-time
                 type: string
               conditions:
-                description: Conditions represent the current state
                 items:
-                  description: Condition contains details for one aspect of the current
-                    state of this API Resource.
                   properties:
                     lastTransitionTime:
-                      description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: |-
-                        message is a human readable message indicating details about the transition.
-                        This may be an empty string.
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: |-
-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                        with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
-                      description: |-
-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                        Producers of specific condition types may define expected values and meanings for this field,
-                        and whether the values are considered a guaranteed API.
-                        The value should be a CamelCase string.
-                        This field may not be empty.
                       maxLength: 1024
                       minLength: 1
                       pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
                       type: string
                     status:
-                      description: status of the condition, one of True, False, Unknown.
                       enum:
                       - "True"
                       - "False"
                       - Unknown
                       type: string
                     type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -186,32 +130,22 @@ spec:
                   type: object
                 type: array
               jobName:
-                description: JobName is the name of the Job executing this restore
                 type: string
               message:
-                description: Message provides details about current state
                 type: string
               phase:
-                description: Phase of the restore operation
                 type: string
               startTime:
-                description: StartTime when restore began
                 format: date-time
                 type: string
               tables:
-                description: Tables tracks per-table restore status
                 items:
-                  description: TableRestoreStatus tracks restore status per table
                   properties:
                     error:
-                      description: Error message if failed
                       type: string
                     name:
-                      description: Name of the table
                       type: string
                     status:
-                      description: 'Status: Pending, Restoring, Completed, Failed,
-                        Skipped'
                       type: string
                   required:
                   - name

--- a/go/pkg/operator/manifests/crd/antfly.io_externalinferencepools.yaml
+++ b/go/pkg/operator/manifests/crd/antfly.io_externalinferencepools.yaml
@@ -30,66 +30,36 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: ExternalInferencePool is the Schema for externally managed Inference
-          pools.
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
-            description: ExternalInferencePoolSpec defines externally managed Inference-compatible
-              endpoints.
             properties:
               endpoints:
-                description: |-
-                  Endpoints are Kubernetes Service-backed Inference API endpoints.
-                  The proxy resolves these service names inside the cluster.
                 items:
-                  description: ExternalInferenceEndpoint defines one externally managed
-                    Inference service endpoint.
                   properties:
                     apiPort:
                       default: 11433
-                      description: APIPort is the Inference ML API port.
                       format: int32
                       maximum: 65535
                       minimum: 1
                       type: integer
                     apiServiceRef:
-                      description: APIServiceRef is the Kubernetes Service name for
-                        the Inference ML API.
                       minLength: 1
                       type: string
                     healthPort:
                       default: 4200
-                      description: HealthPort is the operational health server port.
-                        Health is checked at /readyz.
                       format: int32
                       maximum: 65535
                       minimum: 1
                       type: integer
                     healthServiceRef:
-                      description: |-
-                        HealthServiceRef is the Kubernetes Service name for the operational health server.
-                        Defaults to APIServiceRef when omitted.
                       type: string
                     name:
-                      description: Name is a stable identifier for this endpoint within
-                        the pool.
                       minLength: 1
                       type: string
                   required:
@@ -99,47 +69,29 @@ spec:
                 minItems: 1
                 type: array
               models:
-                description: |-
-                  Models optionally declares expected models before runtime discovery completes.
-                  Runtime /ml/v1/models discovery remains authoritative.
                 items:
-                  description: ModelSpec defines a single model to load
                   properties:
                     capabilities:
-                      description: |-
-                        Capabilities declares modality/runtime capabilities to write into the
-                        pulled model manifest. For example: ["text", "image", "audio"].
                       items:
                         type: string
                       type: array
                     name:
-                      description: |-
-                        Name is the model reference, including an optional tag/variant suffix
-                        (e.g., "BAAI/bge-small-en-v1.5:i8" or "hf:antflydb/clipclap:gguf:Q4_K").
                       minLength: 1
                       type: string
                     priority:
                       default: medium
-                      description: Priority determines loading order and eviction
-                        priority
                       enum:
                       - high
                       - medium
                       - low
                       type: string
                     strategy:
-                      description: |-
-                        Strategy overrides the pool-level loading strategy for this model.
-                        If not specified, uses the pool's loadingStrategy.
                       enum:
                       - eager
                       - lazy
                       - bounded
                       type: string
                     tasks:
-                      description: |-
-                        Tasks declares the model tasks to write into the pulled model manifest.
-                        For example: ["embed"].
                       items:
                         type: string
                       type: array
@@ -149,7 +101,6 @@ spec:
                 type: array
               workloadType:
                 default: general
-                description: WorkloadType classifies this pool for routing decisions.
                 enum:
                 - read-heavy
                 - write-heavy
@@ -160,56 +111,32 @@ spec:
             - endpoints
             type: object
           status:
-            description: |-
-              ExternalInferencePoolStatus defines the observed state of ExternalInferencePool.
-              Reserved for a future controller; the embedded CloudAF proxy reads spec directly.
             properties:
               conditions:
-                description: Conditions represent the latest available observations.
                 items:
-                  description: Condition contains details for one aspect of the current
-                    state of this API Resource.
                   properties:
                     lastTransitionTime:
-                      description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: |-
-                        message is a human readable message indicating details about the transition.
-                        This may be an empty string.
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: |-
-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                        with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
-                      description: |-
-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                        Producers of specific condition types may define expected values and meanings for this field,
-                        and whether the values are considered a guaranteed API.
-                        The value should be a CamelCase string.
-                        This field may not be empty.
                       maxLength: 1024
                       minLength: 1
                       pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
                       type: string
                     status:
-                      description: status of the condition, one of True, False, Unknown.
                       enum:
                       - "True"
                       - "False"
                       - Unknown
                       type: string
                     type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -222,11 +149,7 @@ spec:
                   type: object
                 type: array
               endpoints:
-                description: Endpoints mirrors the resolved endpoint URLs observed
-                  by the proxy/operator.
                 items:
-                  description: ExternalInferenceEndpointStatus reports one resolved
-                    external endpoint.
                   properties:
                     apiURL:
                       type: string
@@ -244,12 +167,9 @@ spec:
                   type: object
                 type: array
               observedGeneration:
-                description: ObservedGeneration is the most recent generation observed
-                  by a controller.
                 format: int64
                 type: integer
               phase:
-                description: Phase is a coarse summary of pool availability.
                 type: string
             type: object
         type: object

--- a/go/pkg/operator/manifests/crd/antfly.io_inferencepools.yaml
+++ b/go/pkg/operator/manifests/crd/antfly.io_inferencepools.yaml
@@ -33,82 +33,32 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: InferencePool is the Schema for the inferencepools API
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
-            description: InferencePoolSpec defines the desired state of InferencePool
             properties:
               affinity:
-                description: |-
-                  Affinity defines affinity rules for pod scheduling.
-                  Cloud-provider-specific affinity rules (e.g., EKS instance type preference)
-                  are appended to any user-specified node affinity preferred terms.
                 properties:
                   nodeAffinity:
-                    description: Describes node affinity scheduling rules for the
-                      pod.
                     properties:
                       preferredDuringSchedulingIgnoredDuringExecution:
-                        description: |-
-                          The scheduler will prefer to schedule pods to nodes that satisfy
-                          the affinity expressions specified by this field, but it may choose
-                          a node that violates one or more of the expressions. The node that is
-                          most preferred is the one with the greatest sum of weights, i.e.
-                          for each node that meets all of the scheduling requirements (resource
-                          request, requiredDuringScheduling affinity expressions, etc.),
-                          compute a sum by iterating through the elements of this field and adding
-                          "weight" to the sum if the node matches the corresponding matchExpressions; the
-                          node(s) with the highest sum are the most preferred.
                         items:
-                          description: |-
-                            An empty preferred scheduling term matches all objects with implicit weight 0
-                            (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
                           properties:
                             preference:
-                              description: A node selector term, associated with the
-                                corresponding weight.
                               properties:
                                 matchExpressions:
-                                  description: A list of node selector requirements
-                                    by node's labels.
                                   items:
-                                    description: |-
-                                      A node selector requirement is a selector that contains values, a key, and an operator
-                                      that relates the key and values.
                                     properties:
                                       key:
-                                        description: The label key that the selector
-                                          applies to.
                                         type: string
                                       operator:
-                                        description: |-
-                                          Represents a key's relationship to a set of values.
-                                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                         type: string
                                       values:
-                                        description: |-
-                                          An array of string values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                          the values array must be empty. If the operator is Gt or Lt, the values
-                                          array must have a single element, which will be interpreted as an integer.
-                                          This array is replaced during a strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -120,29 +70,13 @@ spec:
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 matchFields:
-                                  description: A list of node selector requirements
-                                    by node's fields.
                                   items:
-                                    description: |-
-                                      A node selector requirement is a selector that contains values, a key, and an operator
-                                      that relates the key and values.
                                     properties:
                                       key:
-                                        description: The label key that the selector
-                                          applies to.
                                         type: string
                                       operator:
-                                        description: |-
-                                          Represents a key's relationship to a set of values.
-                                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                         type: string
                                       values:
-                                        description: |-
-                                          An array of string values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                          the values array must be empty. If the operator is Gt or Lt, the values
-                                          array must have a single element, which will be interpreted as an integer.
-                                          This array is replaced during a strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -156,8 +90,6 @@ spec:
                               type: object
                               x-kubernetes-map-type: atomic
                             weight:
-                              description: Weight associated with matching the corresponding
-                                nodeSelectorTerm, in the range 1-100.
                               format: int32
                               type: integer
                           required:
@@ -167,46 +99,18 @@ spec:
                         type: array
                         x-kubernetes-list-type: atomic
                       requiredDuringSchedulingIgnoredDuringExecution:
-                        description: |-
-                          If the affinity requirements specified by this field are not met at
-                          scheduling time, the pod will not be scheduled onto the node.
-                          If the affinity requirements specified by this field cease to be met
-                          at some point during pod execution (e.g. due to an update), the system
-                          may or may not try to eventually evict the pod from its node.
                         properties:
                           nodeSelectorTerms:
-                            description: Required. A list of node selector terms.
-                              The terms are ORed.
                             items:
-                              description: |-
-                                A null or empty node selector term matches no objects. The requirements of
-                                them are ANDed.
-                                The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
                               properties:
                                 matchExpressions:
-                                  description: A list of node selector requirements
-                                    by node's labels.
                                   items:
-                                    description: |-
-                                      A node selector requirement is a selector that contains values, a key, and an operator
-                                      that relates the key and values.
                                     properties:
                                       key:
-                                        description: The label key that the selector
-                                          applies to.
                                         type: string
                                       operator:
-                                        description: |-
-                                          Represents a key's relationship to a set of values.
-                                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                         type: string
                                       values:
-                                        description: |-
-                                          An array of string values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                          the values array must be empty. If the operator is Gt or Lt, the values
-                                          array must have a single element, which will be interpreted as an integer.
-                                          This array is replaced during a strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -218,29 +122,13 @@ spec:
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 matchFields:
-                                  description: A list of node selector requirements
-                                    by node's fields.
                                   items:
-                                    description: |-
-                                      A node selector requirement is a selector that contains values, a key, and an operator
-                                      that relates the key and values.
                                     properties:
                                       key:
-                                        description: The label key that the selector
-                                          applies to.
                                         type: string
                                       operator:
-                                        description: |-
-                                          Represents a key's relationship to a set of values.
-                                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                         type: string
                                       values:
-                                        description: |-
-                                          An array of string values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                          the values array must be empty. If the operator is Gt or Lt, the values
-                                          array must have a single element, which will be interpreted as an integer.
-                                          This array is replaced during a strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -261,57 +149,22 @@ spec:
                         x-kubernetes-map-type: atomic
                     type: object
                   podAffinity:
-                    description: Describes pod affinity scheduling rules (e.g. co-locate
-                      this pod in the same node, zone, etc. as some other pod(s)).
                     properties:
                       preferredDuringSchedulingIgnoredDuringExecution:
-                        description: |-
-                          The scheduler will prefer to schedule pods to nodes that satisfy
-                          the affinity expressions specified by this field, but it may choose
-                          a node that violates one or more of the expressions. The node that is
-                          most preferred is the one with the greatest sum of weights, i.e.
-                          for each node that meets all of the scheduling requirements (resource
-                          request, requiredDuringScheduling affinity expressions, etc.),
-                          compute a sum by iterating through the elements of this field and adding
-                          "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
-                          node(s) with the highest sum are the most preferred.
                         items:
-                          description: The weights of all of the matched WeightedPodAffinityTerm
-                            fields are added per-node to find the most preferred node(s)
                           properties:
                             podAffinityTerm:
-                              description: Required. A pod affinity term, associated
-                                with the corresponding weight.
                               properties:
                                 labelSelector:
-                                  description: |-
-                                    A label query over a set of resources, in this case pods.
-                                    If it's null, this PodAffinityTerm matches with no Pods.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
                                       items:
-                                        description: |-
-                                          A label selector requirement is a selector that contains values, a key, and an operator that
-                                          relates the key and values.
                                         properties:
                                           key:
-                                            description: key is the label key that
-                                              the selector applies to.
                                             type: string
                                           operator:
-                                            description: |-
-                                              operator represents a key's relationship to a set of values.
-                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
-                                            description: |-
-                                              values is an array of string values. If the operator is In or NotIn,
-                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This array is replaced during a strategic
-                                              merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -325,73 +178,29 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: |-
-                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 matchLabelKeys:
-                                  description: |-
-                                    MatchLabelKeys is a set of pod label keys to select which pods will
-                                    be taken into consideration. The keys are used to lookup values from the
-                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                    to select the group of existing pods which pods will be taken into consideration
-                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                    pod labels will be ignored. The default value is empty.
-                                    The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                    Also, matchLabelKeys cannot be set when labelSelector isn't set.
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 mismatchLabelKeys:
-                                  description: |-
-                                    MismatchLabelKeys is a set of pod label keys to select which pods will
-                                    be taken into consideration. The keys are used to lookup values from the
-                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                    to select the group of existing pods which pods will be taken into consideration
-                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                    pod labels will be ignored. The default value is empty.
-                                    The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                    Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 namespaceSelector:
-                                  description: |-
-                                    A label query over the set of namespaces that the term applies to.
-                                    The term is applied to the union of the namespaces selected by this field
-                                    and the ones listed in the namespaces field.
-                                    null selector and null or empty namespaces list means "this pod's namespace".
-                                    An empty selector ({}) matches all namespaces.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
                                       items:
-                                        description: |-
-                                          A label selector requirement is a selector that contains values, a key, and an operator that
-                                          relates the key and values.
                                         properties:
                                           key:
-                                            description: key is the label key that
-                                              the selector applies to.
                                             type: string
                                           operator:
-                                            description: |-
-                                              operator represents a key's relationship to a set of values.
-                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
-                                            description: |-
-                                              values is an array of string values. If the operator is In or NotIn,
-                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This array is replaced during a strategic
-                                              merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -405,38 +214,20 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: |-
-                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 namespaces:
-                                  description: |-
-                                    namespaces specifies a static list of namespace names that the term applies to.
-                                    The term is applied to the union of the namespaces listed in this field
-                                    and the ones selected by namespaceSelector.
-                                    null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 topologyKey:
-                                  description: |-
-                                    This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
-                                    the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                    whose value of the label with key topologyKey matches that of any node on which any of the
-                                    selected pods is running.
-                                    Empty topologyKey is not allowed.
                                   type: string
                               required:
                               - topologyKey
                               type: object
                             weight:
-                              description: |-
-                                weight associated with matching the corresponding podAffinityTerm,
-                                in the range 1-100.
                               format: int32
                               type: integer
                           required:
@@ -446,51 +237,18 @@ spec:
                         type: array
                         x-kubernetes-list-type: atomic
                       requiredDuringSchedulingIgnoredDuringExecution:
-                        description: |-
-                          If the affinity requirements specified by this field are not met at
-                          scheduling time, the pod will not be scheduled onto the node.
-                          If the affinity requirements specified by this field cease to be met
-                          at some point during pod execution (e.g. due to a pod label update), the
-                          system may or may not try to eventually evict the pod from its node.
-                          When there are multiple elements, the lists of nodes corresponding to each
-                          podAffinityTerm are intersected, i.e. all terms must be satisfied.
                         items:
-                          description: |-
-                            Defines a set of pods (namely those matching the labelSelector
-                            relative to the given namespace(s)) that this pod should be
-                            co-located (affinity) or not co-located (anti-affinity) with,
-                            where co-located is defined as running on a node whose value of
-                            the label with key <topologyKey> matches that of any node on which
-                            a pod of the set of pods is running
                           properties:
                             labelSelector:
-                              description: |-
-                                A label query over a set of resources, in this case pods.
-                                If it's null, this PodAffinityTerm matches with no Pods.
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label
-                                    selector requirements. The requirements are ANDed.
                                   items:
-                                    description: |-
-                                      A label selector requirement is a selector that contains values, a key, and an operator that
-                                      relates the key and values.
                                     properties:
                                       key:
-                                        description: key is the label key that the
-                                          selector applies to.
                                         type: string
                                       operator:
-                                        description: |-
-                                          operator represents a key's relationship to a set of values.
-                                          Valid operators are In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
-                                        description: |-
-                                          values is an array of string values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                          the values array must be empty. This array is replaced during a strategic
-                                          merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -504,72 +262,29 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: |-
-                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
                                   type: object
                               type: object
                               x-kubernetes-map-type: atomic
                             matchLabelKeys:
-                              description: |-
-                                MatchLabelKeys is a set of pod label keys to select which pods will
-                                be taken into consideration. The keys are used to lookup values from the
-                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                to select the group of existing pods which pods will be taken into consideration
-                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                pod labels will be ignored. The default value is empty.
-                                The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                Also, matchLabelKeys cannot be set when labelSelector isn't set.
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             mismatchLabelKeys:
-                              description: |-
-                                MismatchLabelKeys is a set of pod label keys to select which pods will
-                                be taken into consideration. The keys are used to lookup values from the
-                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                to select the group of existing pods which pods will be taken into consideration
-                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                pod labels will be ignored. The default value is empty.
-                                The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             namespaceSelector:
-                              description: |-
-                                A label query over the set of namespaces that the term applies to.
-                                The term is applied to the union of the namespaces selected by this field
-                                and the ones listed in the namespaces field.
-                                null selector and null or empty namespaces list means "this pod's namespace".
-                                An empty selector ({}) matches all namespaces.
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label
-                                    selector requirements. The requirements are ANDed.
                                   items:
-                                    description: |-
-                                      A label selector requirement is a selector that contains values, a key, and an operator that
-                                      relates the key and values.
                                     properties:
                                       key:
-                                        description: key is the label key that the
-                                          selector applies to.
                                         type: string
                                       operator:
-                                        description: |-
-                                          operator represents a key's relationship to a set of values.
-                                          Valid operators are In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
-                                        description: |-
-                                          values is an array of string values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                          the values array must be empty. This array is replaced during a strategic
-                                          merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -583,30 +298,15 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: |-
-                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
                                   type: object
                               type: object
                               x-kubernetes-map-type: atomic
                             namespaces:
-                              description: |-
-                                namespaces specifies a static list of namespace names that the term applies to.
-                                The term is applied to the union of the namespaces listed in this field
-                                and the ones selected by namespaceSelector.
-                                null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             topologyKey:
-                              description: |-
-                                This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
-                                the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                whose value of the label with key topologyKey matches that of any node on which any of the
-                                selected pods is running.
-                                Empty topologyKey is not allowed.
                               type: string
                           required:
                           - topologyKey
@@ -615,58 +315,22 @@ spec:
                         x-kubernetes-list-type: atomic
                     type: object
                   podAntiAffinity:
-                    description: Describes pod anti-affinity scheduling rules (e.g.
-                      avoid putting this pod in the same node, zone, etc. as some
-                      other pod(s)).
                     properties:
                       preferredDuringSchedulingIgnoredDuringExecution:
-                        description: |-
-                          The scheduler will prefer to schedule pods to nodes that satisfy
-                          the anti-affinity expressions specified by this field, but it may choose
-                          a node that violates one or more of the expressions. The node that is
-                          most preferred is the one with the greatest sum of weights, i.e.
-                          for each node that meets all of the scheduling requirements (resource
-                          request, requiredDuringScheduling anti-affinity expressions, etc.),
-                          compute a sum by iterating through the elements of this field and subtracting
-                          "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
-                          node(s) with the highest sum are the most preferred.
                         items:
-                          description: The weights of all of the matched WeightedPodAffinityTerm
-                            fields are added per-node to find the most preferred node(s)
                           properties:
                             podAffinityTerm:
-                              description: Required. A pod affinity term, associated
-                                with the corresponding weight.
                               properties:
                                 labelSelector:
-                                  description: |-
-                                    A label query over a set of resources, in this case pods.
-                                    If it's null, this PodAffinityTerm matches with no Pods.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
                                       items:
-                                        description: |-
-                                          A label selector requirement is a selector that contains values, a key, and an operator that
-                                          relates the key and values.
                                         properties:
                                           key:
-                                            description: key is the label key that
-                                              the selector applies to.
                                             type: string
                                           operator:
-                                            description: |-
-                                              operator represents a key's relationship to a set of values.
-                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
-                                            description: |-
-                                              values is an array of string values. If the operator is In or NotIn,
-                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This array is replaced during a strategic
-                                              merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -680,73 +344,29 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: |-
-                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 matchLabelKeys:
-                                  description: |-
-                                    MatchLabelKeys is a set of pod label keys to select which pods will
-                                    be taken into consideration. The keys are used to lookup values from the
-                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                    to select the group of existing pods which pods will be taken into consideration
-                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                    pod labels will be ignored. The default value is empty.
-                                    The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                    Also, matchLabelKeys cannot be set when labelSelector isn't set.
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 mismatchLabelKeys:
-                                  description: |-
-                                    MismatchLabelKeys is a set of pod label keys to select which pods will
-                                    be taken into consideration. The keys are used to lookup values from the
-                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                    to select the group of existing pods which pods will be taken into consideration
-                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                    pod labels will be ignored. The default value is empty.
-                                    The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                    Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 namespaceSelector:
-                                  description: |-
-                                    A label query over the set of namespaces that the term applies to.
-                                    The term is applied to the union of the namespaces selected by this field
-                                    and the ones listed in the namespaces field.
-                                    null selector and null or empty namespaces list means "this pod's namespace".
-                                    An empty selector ({}) matches all namespaces.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
                                       items:
-                                        description: |-
-                                          A label selector requirement is a selector that contains values, a key, and an operator that
-                                          relates the key and values.
                                         properties:
                                           key:
-                                            description: key is the label key that
-                                              the selector applies to.
                                             type: string
                                           operator:
-                                            description: |-
-                                              operator represents a key's relationship to a set of values.
-                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
-                                            description: |-
-                                              values is an array of string values. If the operator is In or NotIn,
-                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This array is replaced during a strategic
-                                              merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -760,38 +380,20 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: |-
-                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 namespaces:
-                                  description: |-
-                                    namespaces specifies a static list of namespace names that the term applies to.
-                                    The term is applied to the union of the namespaces listed in this field
-                                    and the ones selected by namespaceSelector.
-                                    null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 topologyKey:
-                                  description: |-
-                                    This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
-                                    the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                    whose value of the label with key topologyKey matches that of any node on which any of the
-                                    selected pods is running.
-                                    Empty topologyKey is not allowed.
                                   type: string
                               required:
                               - topologyKey
                               type: object
                             weight:
-                              description: |-
-                                weight associated with matching the corresponding podAffinityTerm,
-                                in the range 1-100.
                               format: int32
                               type: integer
                           required:
@@ -801,51 +403,18 @@ spec:
                         type: array
                         x-kubernetes-list-type: atomic
                       requiredDuringSchedulingIgnoredDuringExecution:
-                        description: |-
-                          If the anti-affinity requirements specified by this field are not met at
-                          scheduling time, the pod will not be scheduled onto the node.
-                          If the anti-affinity requirements specified by this field cease to be met
-                          at some point during pod execution (e.g. due to a pod label update), the
-                          system may or may not try to eventually evict the pod from its node.
-                          When there are multiple elements, the lists of nodes corresponding to each
-                          podAffinityTerm are intersected, i.e. all terms must be satisfied.
                         items:
-                          description: |-
-                            Defines a set of pods (namely those matching the labelSelector
-                            relative to the given namespace(s)) that this pod should be
-                            co-located (affinity) or not co-located (anti-affinity) with,
-                            where co-located is defined as running on a node whose value of
-                            the label with key <topologyKey> matches that of any node on which
-                            a pod of the set of pods is running
                           properties:
                             labelSelector:
-                              description: |-
-                                A label query over a set of resources, in this case pods.
-                                If it's null, this PodAffinityTerm matches with no Pods.
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label
-                                    selector requirements. The requirements are ANDed.
                                   items:
-                                    description: |-
-                                      A label selector requirement is a selector that contains values, a key, and an operator that
-                                      relates the key and values.
                                     properties:
                                       key:
-                                        description: key is the label key that the
-                                          selector applies to.
                                         type: string
                                       operator:
-                                        description: |-
-                                          operator represents a key's relationship to a set of values.
-                                          Valid operators are In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
-                                        description: |-
-                                          values is an array of string values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                          the values array must be empty. This array is replaced during a strategic
-                                          merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -859,72 +428,29 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: |-
-                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
                                   type: object
                               type: object
                               x-kubernetes-map-type: atomic
                             matchLabelKeys:
-                              description: |-
-                                MatchLabelKeys is a set of pod label keys to select which pods will
-                                be taken into consideration. The keys are used to lookup values from the
-                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                to select the group of existing pods which pods will be taken into consideration
-                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                pod labels will be ignored. The default value is empty.
-                                The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                Also, matchLabelKeys cannot be set when labelSelector isn't set.
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             mismatchLabelKeys:
-                              description: |-
-                                MismatchLabelKeys is a set of pod label keys to select which pods will
-                                be taken into consideration. The keys are used to lookup values from the
-                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                to select the group of existing pods which pods will be taken into consideration
-                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                pod labels will be ignored. The default value is empty.
-                                The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             namespaceSelector:
-                              description: |-
-                                A label query over the set of namespaces that the term applies to.
-                                The term is applied to the union of the namespaces selected by this field
-                                and the ones listed in the namespaces field.
-                                null selector and null or empty namespaces list means "this pod's namespace".
-                                An empty selector ({}) matches all namespaces.
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label
-                                    selector requirements. The requirements are ANDed.
                                   items:
-                                    description: |-
-                                      A label selector requirement is a selector that contains values, a key, and an operator that
-                                      relates the key and values.
                                     properties:
                                       key:
-                                        description: key is the label key that the
-                                          selector applies to.
                                         type: string
                                       operator:
-                                        description: |-
-                                          operator represents a key's relationship to a set of values.
-                                          Valid operators are In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
-                                        description: |-
-                                          values is an array of string values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                          the values array must be empty. This array is replaced during a strategic
-                                          merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -938,30 +464,15 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: |-
-                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
                                   type: object
                               type: object
                               x-kubernetes-map-type: atomic
                             namespaces:
-                              description: |-
-                                namespaces specifies a static list of namespace names that the term applies to.
-                                The term is applied to the union of the namespaces listed in this field
-                                and the ones selected by namespaceSelector.
-                                null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             topologyKey:
-                              description: |-
-                                This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
-                                the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                whose value of the label with key topologyKey matches that of any node on which any of the
-                                selected pods is running.
-                                Empty topologyKey is not allowed.
                               type: string
                           required:
                           - topologyKey
@@ -971,41 +482,26 @@ spec:
                     type: object
                 type: object
               autoscaling:
-                description: Autoscaling defines autoscaling behavior
                 properties:
                   enabled:
                     default: true
-                    description: Enabled toggles autoscaling
                     type: boolean
                   metrics:
-                    description: Metrics defines scaling triggers
                     items:
-                      description: ScalingMetric defines a single scaling trigger
                       properties:
                         endpoint:
-                          description: Endpoint is the API endpoint to measure (for
-                            latency metrics)
                           type: string
                         scaleDown:
-                          description: ScaleDown defines scale-down behavior
                           properties:
                             policies:
-                              description: Policies defines scaling policies
                               items:
-                                description: ScalingPolicy defines a single scaling
-                                  policy
                                 properties:
                                   periodSeconds:
-                                    description: PeriodSeconds is the time window
-                                      for this policy
                                     format: int32
                                     type: integer
                                   type:
-                                    description: Type is the policy type (Pods or
-                                      Percent)
                                     type: string
                                   value:
-                                    description: Value is the scaling amount
                                     format: int32
                                     type: integer
                                 required:
@@ -1015,30 +511,19 @@ spec:
                                 type: object
                               type: array
                             stabilizationWindow:
-                              description: StabilizationWindow is the time to wait
-                                before scaling
                               type: string
                           type: object
                         scaleUp:
-                          description: ScaleUp defines scale-up behavior
                           properties:
                             policies:
-                              description: Policies defines scaling policies
                               items:
-                                description: ScalingPolicy defines a single scaling
-                                  policy
                                 properties:
                                   periodSeconds:
-                                    description: PeriodSeconds is the time window
-                                      for this policy
                                     format: int32
                                     type: integer
                                   type:
-                                    description: Type is the policy type (Pods or
-                                      Percent)
                                     type: string
                                   value:
-                                    description: Value is the scaling amount
                                     format: int32
                                     type: integer
                                 required:
@@ -1048,16 +533,11 @@ spec:
                                 type: object
                               type: array
                             stabilizationWindow:
-                              description: StabilizationWindow is the time to wait
-                                before scaling
                               type: string
                           type: object
                         target:
-                          description: Target is the target value (interpretation
-                            depends on type)
                           type: string
                         type:
-                          description: Type is the metric type
                           enum:
                           - queue-depth
                           - latency-p99
@@ -1073,183 +553,113 @@ spec:
                       type: object
                     type: array
                   modelLoadingGracePeriod:
-                    description: ModelLoadingGracePeriod prevents scale-down during
-                      model loading
                     type: string
                   scaleDownStabilization:
-                    description: ScaleDownStabilization is the stabilization window
-                      for scale-down
                     type: string
                   warmupReplicas:
-                    description: WarmupReplicas is the number of replicas to pre-warm
-                      before traffic
                     format: int32
                     type: integer
                 type: object
               availability:
-                description: Availability defines availability configuration
                 properties:
                   livenessProbe:
-                    description: LivenessProbe configuration
                     properties:
                       failureThreshold:
-                        description: FailureThreshold is the number of failures before
-                          marking unhealthy
                         format: int32
                         type: integer
                       periodSeconds:
-                        description: PeriodSeconds is the probe interval
                         format: int32
                         type: integer
                       timeoutSeconds:
-                        description: TimeoutSeconds is the probe timeout
                         format: int32
                         type: integer
                     type: object
                   podDisruptionBudget:
-                    description: PodDisruptionBudget configuration
                     properties:
                       enabled:
                         default: false
-                        description: Enabled indicates if PodDisruptionBudget should
-                          be created
                         type: boolean
                       maxUnavailable:
-                        description: MaxUnavailable is the maximum unavailable pods
                         format: int32
                         type: integer
                       minAvailable:
-                        description: MinAvailable is the minimum available pods
                         format: int32
                         type: integer
                     type: object
                   readinessProbe:
-                    description: ReadinessProbe configuration
                     properties:
                       failureThreshold:
-                        description: FailureThreshold is the number of failures before
-                          marking unhealthy
                         format: int32
                         type: integer
                       periodSeconds:
-                        description: PeriodSeconds is the probe interval
                         format: int32
                         type: integer
                       timeoutSeconds:
-                        description: TimeoutSeconds is the probe timeout
                         format: int32
                         type: integer
                     type: object
                   startupProbe:
-                    description: StartupProbe configuration
                     properties:
                       failureThreshold:
-                        description: FailureThreshold is the number of failures before
-                          marking unhealthy
                         format: int32
                         type: integer
                       periodSeconds:
-                        description: PeriodSeconds is the probe interval
                         format: int32
                         type: integer
                       timeoutSeconds:
-                        description: TimeoutSeconds is the probe timeout
                         format: int32
                         type: integer
                     type: object
                 type: object
               burst:
-                description: Burst defines burst handling configuration
                 properties:
                   burstThreshold:
                     default: 100
-                    description: BurstThreshold is the queue depth that triggers burst
-                      mode
                     format: int32
                     type: integer
                   cooldownPeriod:
-                    description: CooldownPeriod is the time before scaling down burst
-                      replicas
                     type: string
                   enabled:
-                    description: Enabled toggles burst handling
                     type: boolean
                   maxSurge:
                     default: 5
-                    description: MaxSurge is the maximum extra replicas during burst
                     format: int32
                     type: integer
                 required:
                 - enabled
                 type: object
               config:
-                description: |-
-                  Config is the Inference configuration as a JSON string.
-                  This is merged with auto-generated configuration and passed to inference via --config.
-                  Supports all inference config options including logging, GPU settings, keep_alive, etc.
-                  Example: {"log": {"level": "debug", "style": "json"}, "gpu": "auto"}
                 type: string
               eks:
-                description: EKS defines AWS EKS-specific configuration (optional)
                 properties:
                   enabled:
-                    description: Enabled enables EKS-specific optimizations and configurations
                     type: boolean
                   instanceTypes:
-                    description: |-
-                      InstanceTypes specifies preferred EC2 instance types for node scheduling
-                      Examples: ["m5.large", "m5.xlarge", "m6i.large"]
-                      Used with node affinity to target specific instance types
                     items:
                       type: string
                     type: array
                   irsaRoleARN:
-                    description: |-
-                      IRSARoleARN is the ARN of the IAM role for IRSA (IAM Roles for Service Accounts)
-                      Format: arn:aws:iam::<account-id>:role/<role-name>
-                      When specified, the operator will annotate the ServiceAccount with this role
-                      This enables pods to assume IAM roles for AWS API access (e.g., S3 model registry)
                     type: string
                   podDisruptionBudget:
-                    description: |-
-                      PodDisruptionBudget enables automatic PodDisruptionBudget creation
-                      Recommended for production deployments to prevent excessive disruption
                     properties:
                       enabled:
                         default: false
-                        description: Enabled indicates if PodDisruptionBudget should
-                          be created
                         type: boolean
                       maxUnavailable:
-                        description: MaxUnavailable is the maximum unavailable pods
                         format: int32
                         type: integer
                       minAvailable:
-                        description: MinAvailable is the minimum available pods
                         format: int32
                         type: integer
                     type: object
                   useSpotInstances:
-                    description: |-
-                      UseSpotInstances enables EC2 Spot Instances for cost savings (up to 90%)
-                      When enabled, pods will be scheduled on Spot Instance nodes
                     type: boolean
                 type: object
               gke:
-                description: GKE defines GKE-specific configuration for Autopilot
-                  and Standard clusters
                 properties:
                   autopilot:
-                    description: |-
-                      Autopilot enables GKE Autopilot-specific optimizations.
-                      When true, uses compute class annotations instead of node selectors.
                     type: boolean
                   autopilotComputeClass:
-                    description: |-
-                      AutopilotComputeClass specifies the GKE Autopilot compute class.
-                      Valid values: "Accelerator", "Balanced", "Performance", "Scale-Out", "autopilot", "autopilot-spot"
-                      Defaults to "Balanced" when Autopilot=true and this field is empty.
-                      Note: "Accelerator" is for GPU workloads only, NOT TPUs.
                     enum:
                     - Accelerator
                     - Balanced
@@ -1260,126 +670,78 @@ spec:
                     - ""
                     type: string
                   podDisruptionBudget:
-                    description: PodDisruptionBudget enables automatic PodDisruptionBudget
-                      creation
                     properties:
                       enabled:
                         default: false
-                        description: Enabled indicates if PodDisruptionBudget should
-                          be created
                         type: boolean
                       maxUnavailable:
-                        description: MaxUnavailable is the maximum unavailable pods
                         format: int32
                         type: integer
                       minAvailable:
-                        description: MinAvailable is the minimum available pods
                         format: int32
                         type: integer
                     type: object
                 type: object
               hardware:
-                description: Hardware defines TPU/accelerator configuration
                 properties:
                   accelerator:
-                    description: Accelerator is the accelerator type label (empty
-                      = no accelerator/CPU only)
                     type: string
                   machineType:
-                    description: MachineType is the GKE machine type
                     type: string
                   spot:
                     default: false
-                    description: Spot enables spot/preemptible instances
                     type: boolean
                   topology:
-                    description: Topology is the TPU topology (e.g., "2x2", "2x4").
-                      Only required when accelerator is set.
                     type: string
                 type: object
               image:
-                description: |-
-                  Image is the Antfly container image used for this InferencePool.
-                  The image must provide the `/antfly inference ...` runtime contract.
                 type: string
               imagePullSecrets:
-                description: ImagePullSecrets for private registries
                 items:
-                  description: |-
-                    LocalObjectReference contains enough information to let you locate the
-                    referenced object inside the same namespace.
                   properties:
                     name:
                       default: ""
-                      description: |-
-                        Name of the referent.
-                        This field is effectively required, but due to backwards compatibility is
-                        allowed to be empty. Instances of this type with an empty value here are
-                        almost certainly wrong.
-                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                       type: string
                   type: object
                   x-kubernetes-map-type: atomic
                 type: array
               models:
-                description: Models defines which models to load and how
                 properties:
                   keepAlive:
-                    description: KeepAlive duration before unloading idle models (for
-                      lazy strategy)
                     type: string
                   loadingStrategy:
                     default: eager
-                    description: LoadingStrategy defines how models are loaded
                     enum:
                     - eager
                     - lazy
                     - bounded
                     type: string
                   maxLoadedModels:
-                    description: MaxLoadedModels limits concurrent loaded models (for
-                      bounded strategy)
                     type: integer
                   preload:
-                    description: Preload lists models to preload on this pool
                     items:
-                      description: ModelSpec defines a single model to load
                       properties:
                         capabilities:
-                          description: |-
-                            Capabilities declares modality/runtime capabilities to write into the
-                            pulled model manifest. For example: ["text", "image", "audio"].
                           items:
                             type: string
                           type: array
                         name:
-                          description: |-
-                            Name is the model reference, including an optional tag/variant suffix
-                            (e.g., "BAAI/bge-small-en-v1.5:i8" or "hf:antflydb/clipclap:gguf:Q4_K").
                           minLength: 1
                           type: string
                         priority:
                           default: medium
-                          description: Priority determines loading order and eviction
-                            priority
                           enum:
                           - high
                           - medium
                           - low
                           type: string
                         strategy:
-                          description: |-
-                            Strategy overrides the pool-level loading strategy for this model.
-                            If not specified, uses the pool's loadingStrategy.
                           enum:
                           - eager
                           - lazy
                           - bounded
                           type: string
                         tasks:
-                          description: |-
-                            Tasks declares the model tasks to write into the pulled model manifest.
-                            For example: ["embed"].
                           items:
                             type: string
                           type: array
@@ -1388,7 +750,6 @@ spec:
                       type: object
                     type: array
                   registryURL:
-                    description: RegistryURL is the model registry URL
                     type: string
                 required:
                 - preload
@@ -1396,67 +757,39 @@ spec:
               nodeSelector:
                 additionalProperties:
                   type: string
-                description: |-
-                  NodeSelector defines node selector labels for pod scheduling.
-                  Merged with any cloud-provider-specific node selectors.
-                  Note: GKE Autopilot mode overrides node selectors with compute class annotations.
                 type: object
               replicas:
-                description: Replicas defines scaling bounds
                 properties:
                   max:
-                    description: Max is the maximum number of replicas
                     format: int32
                     minimum: 1
                     type: integer
                   min:
-                    description: Min is the minimum number of replicas
                     format: int32
                     minimum: 0
                     type: integer
                   perModel:
                     additionalProperties:
-                      description: PerModelReplica defines per-model replica requirements
                       properties:
                         min:
-                          description: Min replicas that must have this model loaded
                           format: int32
                           type: integer
                       required:
                       - min
                       type: object
-                    description: PerModel allows per-model minimum replicas
                     type: object
                 required:
                 - max
                 - min
                 type: object
               resources:
-                description: Resources defines compute resource requirements
                 properties:
                   claims:
-                    description: |-
-                      Claims lists the names of resources, defined in spec.resourceClaims,
-                      that are used by this container.
-
-                      This field depends on the
-                      DynamicResourceAllocation feature gate.
-
-                      This field is immutable. It can only be set for containers.
                     items:
-                      description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                       properties:
                         name:
-                          description: |-
-                            Name must match the name of one entry in pod.spec.resourceClaims of
-                            the Pod where this field is used. It makes that resource available
-                            inside a container.
                           type: string
                         request:
-                          description: |-
-                            Request is the name chosen for a request in the referenced claim.
-                            If empty, everything from the claim is made available, otherwise
-                            only the result of this request.
                           type: string
                       required:
                       - name
@@ -1472,9 +805,6 @@ spec:
                       - type: string
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
-                    description: |-
-                      Limits describes the maximum amount of compute resources allowed.
-                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                     type: object
                   requests:
                     additionalProperties:
@@ -1483,122 +813,61 @@ spec:
                       - type: string
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
-                    description: |-
-                      Requests describes the minimum amount of compute resources required.
-                      If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                      otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                     type: object
                 type: object
               routing:
-                description: Routing defines routing hints for the proxy
                 properties:
                   circuitBreaker:
-                    description: CircuitBreaker configuration
                     properties:
                       enabled:
-                        description: Enabled toggles circuit breaker
                         type: boolean
                       errorThreshold:
                         default: 5
-                        description: ErrorThreshold is the error count to open circuit
                         format: int32
                         type: integer
                       timeout:
-                        description: Timeout is the circuit breaker timeout
                         type: string
                     required:
                     - enabled
                     type: object
                   drainTimeout:
-                    description: DrainTimeout is the time to drain before termination
                     type: string
                   weight:
                     default: 100
-                    description: Weight is the relative routing weight (0-100)
                     format: int32
                     maximum: 100
                     minimum: 0
                     type: integer
                 type: object
               tolerations:
-                description: |-
-                  Tolerations defines tolerations for pod scheduling.
-                  Merged with any cloud-provider-specific tolerations (e.g., EKS Spot).
                 items:
-                  description: |-
-                    The pod this Toleration is attached to tolerates any taint that matches
-                    the triple <key,value,effect> using the matching operator <operator>.
                   properties:
                     effect:
-                      description: |-
-                        Effect indicates the taint effect to match. Empty means match all taint effects.
-                        When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                       type: string
                     key:
-                      description: |-
-                        Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                        If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                       type: string
                     operator:
-                      description: |-
-                        Operator represents a key's relationship to the value.
-                        Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
-                        Exists is equivalent to wildcard for value, so that a pod can
-                        tolerate all taints of a particular category.
-                        Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                       type: string
                     tolerationSeconds:
-                      description: |-
-                        TolerationSeconds represents the period of time the toleration (which must be
-                        of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                        it is not set, which means tolerate the taint forever (do not evict). Zero and
-                        negative values will be treated as 0 (evict immediately) by the system.
                       format: int64
                       type: integer
                     value:
-                      description: |-
-                        Value is the taint value the toleration matches to.
-                        If the operator is Exists, the value should be empty, otherwise just a regular string.
                       type: string
                   type: object
                 type: array
               topologySpreadConstraints:
-                description: TopologySpreadConstraints describes how pods should spread
-                  across topology domains.
                 items:
-                  description: TopologySpreadConstraint specifies how to spread matching
-                    pods among the given topology.
                   properties:
                     labelSelector:
-                      description: |-
-                        LabelSelector is used to find matching pods.
-                        Pods that match this label selector are counted to determine the number of pods
-                        in their corresponding topology domain.
                       properties:
                         matchExpressions:
-                          description: matchExpressions is a list of label selector
-                            requirements. The requirements are ANDed.
                           items:
-                            description: |-
-                              A label selector requirement is a selector that contains values, a key, and an operator that
-                              relates the key and values.
                             properties:
                               key:
-                                description: key is the label key that the selector
-                                  applies to.
                                 type: string
                               operator:
-                                description: |-
-                                  operator represents a key's relationship to a set of values.
-                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                 type: string
                               values:
-                                description: |-
-                                  values is an array of string values. If the operator is In or NotIn,
-                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                  the values array must be empty. This array is replaced during a strategic
-                                  merge patch.
                                 items:
                                   type: string
                                 type: array
@@ -1612,125 +881,27 @@ spec:
                         matchLabels:
                           additionalProperties:
                             type: string
-                          description: |-
-                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                            map is equivalent to an element of matchExpressions, whose key field is "key", the
-                            operator is "In", and the values array contains only "value". The requirements are ANDed.
                           type: object
                       type: object
                       x-kubernetes-map-type: atomic
                     matchLabelKeys:
-                      description: |-
-                        MatchLabelKeys is a set of pod label keys to select the pods over which
-                        spreading will be calculated. The keys are used to lookup values from the
-                        incoming pod labels, those key-value labels are ANDed with labelSelector
-                        to select the group of existing pods over which spreading will be calculated
-                        for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
-                        MatchLabelKeys cannot be set when LabelSelector isn't set.
-                        Keys that don't exist in the incoming pod labels will
-                        be ignored. A null or empty list means only match against labelSelector.
-
-                        This is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).
                       items:
                         type: string
                       type: array
                       x-kubernetes-list-type: atomic
                     maxSkew:
-                      description: |-
-                        MaxSkew describes the degree to which pods may be unevenly distributed.
-                        When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
-                        between the number of matching pods in the target topology and the global minimum.
-                        The global minimum is the minimum number of matching pods in an eligible domain
-                        or zero if the number of eligible domains is less than MinDomains.
-                        For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
-                        labelSelector spread as 2/2/1:
-                        In this case, the global minimum is 1.
-                        | zone1 | zone2 | zone3 |
-                        |  P P  |  P P  |   P   |
-                        - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2;
-                        scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2)
-                        violate MaxSkew(1).
-                        - if MaxSkew is 2, incoming pod can be scheduled onto any zone.
-                        When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence
-                        to topologies that satisfy it.
-                        It's a required field. Default value is 1 and 0 is not allowed.
                       format: int32
                       type: integer
                     minDomains:
-                      description: |-
-                        MinDomains indicates a minimum number of eligible domains.
-                        When the number of eligible domains with matching topology keys is less than minDomains,
-                        Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed.
-                        And when the number of eligible domains with matching topology keys equals or greater than minDomains,
-                        this value has no effect on scheduling.
-                        As a result, when the number of eligible domains is less than minDomains,
-                        scheduler won't schedule more than maxSkew Pods to those domains.
-                        If value is nil, the constraint behaves as if MinDomains is equal to 1.
-                        Valid values are integers greater than 0.
-                        When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
-
-                        For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same
-                        labelSelector spread as 2/2/2:
-                        | zone1 | zone2 | zone3 |
-                        |  P P  |  P P  |  P P  |
-                        The number of domains is less than 5(MinDomains), so "global minimum" is treated as 0.
-                        In this situation, new pod with the same labelSelector cannot be scheduled,
-                        because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones,
-                        it will violate MaxSkew.
                       format: int32
                       type: integer
                     nodeAffinityPolicy:
-                      description: |-
-                        NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
-                        when calculating pod topology spread skew. Options are:
-                        - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
-                        - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
-
-                        If this value is nil, the behavior is equivalent to the Honor policy.
                       type: string
                     nodeTaintsPolicy:
-                      description: |-
-                        NodeTaintsPolicy indicates how we will treat node taints when calculating
-                        pod topology spread skew. Options are:
-                        - Honor: nodes without taints, along with tainted nodes for which the incoming pod
-                        has a toleration, are included.
-                        - Ignore: node taints are ignored. All nodes are included.
-
-                        If this value is nil, the behavior is equivalent to the Ignore policy.
                       type: string
                     topologyKey:
-                      description: |-
-                        TopologyKey is the key of node labels. Nodes that have a label with this key
-                        and identical values are considered to be in the same topology.
-                        We consider each <key, value> as a "bucket", and try to put balanced number
-                        of pods into each bucket.
-                        We define a domain as a particular instance of a topology.
-                        Also, we define an eligible domain as a domain whose nodes meet the requirements of
-                        nodeAffinityPolicy and nodeTaintsPolicy.
-                        e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology.
-                        And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology.
-                        It's a required field.
                       type: string
                     whenUnsatisfiable:
-                      description: |-
-                        WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
-                        the spread constraint.
-                        - DoNotSchedule (default) tells the scheduler not to schedule it.
-                        - ScheduleAnyway tells the scheduler to schedule the pod in any location,
-                          but giving higher precedence to topologies that would help reduce the
-                          skew.
-                        A constraint is considered "Unsatisfiable" for an incoming pod
-                        if and only if every possible node assignment for that pod would violate
-                        "MaxSkew" on some topology.
-                        For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
-                        labelSelector spread as 3/1/1:
-                        | zone1 | zone2 | zone3 |
-                        | P P P |   P   |   P   |
-                        If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled
-                        to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies
-                        MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler
-                        won't make it *more* imbalanced.
-                        It's a required field.
                       type: string
                   required:
                   - maxSkew
@@ -1740,7 +911,6 @@ spec:
                 type: array
               workloadType:
                 default: general
-                description: WorkloadType classifies this pool for routing decisions
                 enum:
                 - read-heavy
                 - write-heavy
@@ -1753,54 +923,32 @@ spec:
             - replicas
             type: object
           status:
-            description: InferencePoolStatus defines the observed state of InferencePool
             properties:
               conditions:
-                description: Conditions represent the latest available observations
                 items:
-                  description: Condition contains details for one aspect of the current
-                    state of this API Resource.
                   properties:
                     lastTransitionTime:
-                      description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: |-
-                        message is a human readable message indicating details about the transition.
-                        This may be an empty string.
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: |-
-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                        with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
-                      description: |-
-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                        Producers of specific condition types may define expected values and meanings for this field,
-                        and whether the values are considered a guaranteed API.
-                        The value should be a CamelCase string.
-                        This field may not be empty.
                       maxLength: 1024
                       minLength: 1
                       pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
                       type: string
                     status:
-                      description: status of the condition, one of True, False, Unknown.
                       enum:
                       - "True"
                       - "False"
                       - Unknown
                       type: string
                     type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -1813,32 +961,24 @@ spec:
                   type: object
                 type: array
               endpoints:
-                description: Endpoints lists the current Inference endpoints
                 items:
                   type: string
                 type: array
               lastScaleTime:
-                description: LastScaleTime is the last time the pool scaled
                 format: date-time
                 type: string
               loadedModels:
-                description: LoadedModels shows which models are loaded and where
                 items:
-                  description: LoadedModelStatus shows model loading status
                   properties:
                     avgLoadTimeMs:
-                      description: AvgLoadTimeMs is the average model load time
                       format: int64
                       type: integer
                     name:
-                      description: Name is the model name
                       type: string
                     replicas:
-                      description: Replicas is the number of replicas with this model
                       format: int32
                       type: integer
                     status:
-                      description: Status is the model status (loaded, loading, error)
                       type: string
                   required:
                   - name
@@ -1846,28 +986,19 @@ spec:
                   type: object
                 type: array
               observedGeneration:
-                description: |-
-                  ObservedGeneration is the most recent generation observed by the controller.
-                  Used to skip expensive validation when the spec has not changed since
-                  the last successful reconciliation.
                 format: int64
                 type: integer
               phase:
-                description: Phase is the current phase of the pool
                 type: string
               replicas:
-                description: Replicas shows replica counts
                 properties:
                   desired:
-                    description: Desired is the desired number of replicas
                     format: int32
                     type: integer
                   ready:
-                    description: Ready is the number of ready replicas
                     format: int32
                     type: integer
                   total:
-                    description: Total is the total number of replicas
                     format: int32
                     type: integer
                 required:

--- a/go/pkg/operator/manifests/crd/antfly.io_inferenceproxies.yaml
+++ b/go/pkg/operator/manifests/crd/antfly.io_inferenceproxies.yaml
@@ -27,152 +27,99 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: InferenceProxy is the Schema for the inferenceproxies API
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
-            description: InferenceProxySpec defines the desired state of InferenceProxy
             properties:
               fallback:
-                description: Fallback defines behavior when all destinations are unavailable
                 properties:
                   action:
-                    description: Action is what to do when all destinations fail
                     enum:
                     - queue
                     - reject
                     - redirect
                     type: string
                   errorResponse:
-                    description: ErrorResponse customizes the error response (for
-                      action=reject)
                     properties:
                       message:
-                        description: Message is the error message
                         type: string
                       retryAfter:
-                        description: RetryAfter suggests when to retry (seconds)
                         format: int32
                         type: integer
                       statusCode:
                         default: 503
-                        description: StatusCode is the HTTP status code
                         format: int32
                         type: integer
                     type: object
                   maxQueueTime:
-                    description: MaxQueueTime is max time to queue before rejecting
-                      (for action=queue)
                     type: string
                   redirectPool:
-                    description: RedirectPool is the pool to redirect to (for action=redirect)
                     type: string
                 required:
                 - action
                 type: object
               match:
-                description: Match defines when this route applies
                 properties:
                   headers:
                     additionalProperties:
-                      description: StringMatch defines how to match a string value
                       properties:
                         exact:
-                          description: Exact matches the exact value
                           type: string
                         prefix:
-                          description: Prefix matches a prefix
                           type: string
                         regex:
-                          description: Regex matches a regular expression
                           type: string
                       type: object
-                    description: Headers matches request headers
                     type: object
                   models:
-                    description: 'Models matches model names (supports wildcards:
-                      "bge-*", "*-rerank-*")'
                     items:
                       type: string
                     type: array
                   operations:
-                    description: Operations matches specific API operations
                     items:
-                      description: OperationType represents a Inference API operation
                       type: string
                     type: array
                   source:
-                    description: Source matches the source of the request (e.g., specific
-                      Antfly tables)
                     properties:
                       apiKeyPrefixes:
-                        description: APIKeyPrefixes matches requests authenticated
-                          with specific hosted API key prefixes.
                         items:
                           type: string
                         type: array
                       namespaces:
-                        description: |-
-                          Namespaces is reserved for future authenticated source identity support.
-                          Requests that set this field are currently rejected.
                         items:
                           type: string
                         type: array
                       organizations:
-                        description: Organizations matches requests authenticated
-                          for specific hosted organizations.
                         items:
                           type: string
                         type: array
                       projects:
-                        description: Projects matches requests authenticated for specific
-                          hosted projects.
                         items:
                           type: string
                         type: array
                       serviceAccounts:
-                        description: |-
-                          ServiceAccounts is reserved for future authenticated source identity support.
-                          Requests that set this field are currently rejected.
                         items:
                           type: string
                         type: array
                       tables:
-                        description: Tables matches requests from specific Antfly
-                          tables
                         items:
                           type: string
                         type: array
                     type: object
                   timeWindow:
-                    description: TimeWindow restricts when this route is active
                     properties:
                       days:
-                        description: Days restricts to specific days (0=Sunday, 6=Saturday)
                         items:
                           type: integer
                         type: array
                       end:
-                        description: End is the end time in HH:MM format (UTC)
                         type: string
                       start:
-                        description: Start is the start time in HH:MM format (UTC)
                         type: string
                     required:
                     - end
@@ -181,87 +128,56 @@ spec:
                 type: object
               priority:
                 default: 100
-                description: |-
-                  Priority determines the order routes are evaluated (higher = first)
-                  Routes with the same priority are evaluated in alphabetical order
                 format: int32
                 type: integer
               rateLimiting:
-                description: RateLimiting applies rate limits to this route
                 properties:
                   burstSize:
-                    description: BurstSize allows temporary bursts
                     format: int32
                     type: integer
                   perModel:
-                    description: PerModel applies limits per model (vs global)
                     type: boolean
                   requestsPerSecond:
-                    description: RequestsPerSecond limits requests per second
                     format: int32
                     type: integer
                 required:
                 - requestsPerSecond
                 type: object
               retry:
-                description: Retry configures retry behavior for this route
                 properties:
                   attempts:
                     default: 3
-                    description: Attempts is the max retry attempts
                     format: int32
                     type: integer
                   perTryTimeout:
-                    description: PerTryTimeout is the timeout per attempt
                     type: string
                   retryOn:
-                    description: RetryOn specifies which errors trigger retries
                     items:
-                      description: RetryCondition defines a condition that triggers
-                        a retry
                       type: string
                     type: array
                 type: object
               route:
-                description: Route defines where to send matching requests
                 items:
-                  description: RouteDestination defines a destination for requests
                   properties:
                     condition:
-                      description: Condition makes this destination conditional
                       properties:
                         availableReplicas:
-                          description: AvailableReplicas activates when replica count
-                            matches
                           type: string
                         latency:
-                          description: Latency activates when the rolling P99 latency
-                            matches (e.g., ">100ms")
                           type: string
                         modelLoaded:
-                          description: ModelLoaded activates only if the model is
-                            loaded on this pool
                           type: boolean
                         queueDepth:
-                          description: |-
-                            QueueDepth activates when queue depth matches
-                            Supports operators: ">50", "<10", ">=100"
                           type: string
                         timeOfDay:
-                          description: TimeOfDay activates during specific hours
                           properties:
                             days:
-                              description: Days restricts to specific days (0=Sunday,
-                                6=Saturday)
                               items:
                                 type: integer
                               type: array
                             end:
-                              description: End is the end time in HH:MM format (UTC)
                               type: string
                             start:
-                              description: Start is the start time in HH:MM format
-                                (UTC)
                               type: string
                           required:
                           - end
@@ -269,13 +185,9 @@ spec:
                           type: object
                       type: object
                     pool:
-                      description: Pool is the InferencePool to route to
                       type: string
                     weight:
                       default: 100
-                      description: |-
-                        Weight is the relative weight for this destination (0-100)
-                        Used for traffic splitting between multiple destinations
                       format: int32
                       maximum: 100
                       minimum: 0
@@ -289,57 +201,34 @@ spec:
             - route
             type: object
           status:
-            description: InferenceProxyStatus defines the observed state of InferenceProxy
             properties:
               active:
-                description: Active indicates if the route is currently active
                 type: boolean
               conditions:
-                description: Conditions represent the latest available observations
                 items:
-                  description: Condition contains details for one aspect of the current
-                    state of this API Resource.
                   properties:
                     lastTransitionTime:
-                      description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: |-
-                        message is a human readable message indicating details about the transition.
-                        This may be an empty string.
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: |-
-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                        with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
-                      description: |-
-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                        Producers of specific condition types may define expected values and meanings for this field,
-                        and whether the values are considered a guaranteed API.
-                        The value should be a CamelCase string.
-                        This field may not be empty.
                       maxLength: 1024
                       minLength: 1
                       pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
                       type: string
                     status:
-                      description: status of the condition, one of True, False, Unknown.
                       enum:
                       - "True"
                       - "False"
                       - Unknown
                       type: string
                     type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -352,9 +241,6 @@ spec:
                   type: object
                 type: array
               observedGeneration:
-                description: |-
-                  ObservedGeneration is the most recent generation observed by the controller.
-                  Used to skip validation when the spec has not changed.
                 format: int64
                 type: integer
             type: object


### PR DESCRIPTION
## Summary
- generate operator CRDs with controller-gen crd:maxDescLen=0
- regenerate Antfly and inference CRDs without schema descriptions
- reduce CRD payload size while preserving validation fields

## Size impact
- total generated CRD YAML: 808,939 -> 286,877 bytes
- AntflyCluster YAML: 647,423 -> 222,472 bytes
- AntflyCluster compact JSON payload: 333,787 -> 78,720 bytes

This keeps the AntflyCluster CRD comfortably below the Kubernetes annotation limit if a client-side apply path is used.

## Validation
- GOWORK=off go generate ./api/antfly/v1 ./api/inference/v1alpha1
- GOWORK=off go test ./api/antfly/v1 ./api/inference/v1alpha1
- git diff --check
- inspected generated CRD diff for validation field changes; only descriptions were removed