### PR TITLE
Use read-index barrier for metadata backups

### DIFF
--- a/.github/workflows/zig-tests.yml
+++ b/.github/workflows/zig-tests.yml
@@ -141,7 +141,7 @@ jobs:
     runs-on: arc-antfly-heavy
     timeout-minutes: 45
     env:
-      ZIG_LOCAL_CACHE_DIR: /mnt/cache/antfly/zig/${{ github.job }}/zig-local
+      ZIG_LOCAL_CACHE_DIR: /mnt/cache/antfly/zig/${{ github.job }}/${{ github.run_id }}-${{ github.run_attempt }}/zig-local
       ZIG_GLOBAL_CACHE_DIR: /mnt/cache/antfly/zig/zig-global
     steps:
       - uses: actions/checkout@v6
@@ -163,7 +163,7 @@ jobs:
 
       - name: Restore ARC Zig cache dirs
         run: |
-          local_cache="/mnt/cache/antfly/zig/${{ github.job }}/zig-local"
+          local_cache="/mnt/cache/antfly/zig/${{ github.job }}/${{ github.run_id }}-${{ github.run_attempt }}/zig-local"
           global_cache="/mnt/cache/antfly/zig/zig-global"
           echo "ZIG_LOCAL_CACHE_DIR=$local_cache" >> "$GITHUB_ENV"
           echo "ZIG_GLOBAL_CACHE_DIR=$global_cache" >> "$GITHUB_ENV"
@@ -185,7 +185,7 @@ jobs:
     runs-on: ${{ needs.changes.outputs.trace_validate == 'true' && 'arc-antfly-heavy' || 'arc-antfly-standard' }}
     timeout-minutes: 30
     env:
-      ZIG_LOCAL_CACHE_DIR: /mnt/cache/antfly/zig/${{ github.job }}/zig-local
+      ZIG_LOCAL_CACHE_DIR: /mnt/cache/antfly/zig/${{ github.job }}/${{ github.run_id }}-${{ github.run_attempt }}/zig-local
       ZIG_GLOBAL_CACHE_DIR: /mnt/cache/antfly/zig/zig-global
     steps:
       - uses: actions/checkout@v6
@@ -205,7 +205,7 @@ jobs:
       - name: Restore ARC Zig cache dirs
         if: needs.changes.outputs.trace_validate == 'true'
         run: |
-          local_cache="/mnt/cache/antfly/zig/${{ github.job }}/zig-local"
+          local_cache="/mnt/cache/antfly/zig/${{ github.job }}/${{ github.run_id }}-${{ github.run_attempt }}/zig-local"
           global_cache="/mnt/cache/antfly/zig/zig-global"
           echo "ZIG_LOCAL_CACHE_DIR=$local_cache" >> "$GITHUB_ENV"
           echo "ZIG_GLOBAL_CACHE_DIR=$global_cache" >> "$GITHUB_ENV"
@@ -263,7 +263,7 @@ jobs:
     runs-on: arc-antfly-heavy
     timeout-minutes: 60
     env:
-      ZIG_LOCAL_CACHE_DIR: /mnt/cache/antfly/zig/${{ github.job }}/zig-local
+      ZIG_LOCAL_CACHE_DIR: /mnt/cache/antfly/zig/${{ github.job }}/${{ github.run_id }}-${{ github.run_attempt }}/zig-local
       ZIG_GLOBAL_CACHE_DIR: /mnt/cache/antfly/zig/zig-global
     steps:
       - uses: actions/checkout@v6
@@ -282,7 +282,7 @@ jobs:
 
       - name: Restore ARC Zig cache dirs
         run: |
-          local_cache="/mnt/cache/antfly/zig/${{ github.job }}/zig-local"
+          local_cache="/mnt/cache/antfly/zig/${{ github.job }}/${{ github.run_id }}-${{ github.run_attempt }}/zig-local"
           global_cache="/mnt/cache/antfly/zig/zig-global"
           echo "ZIG_LOCAL_CACHE_DIR=$local_cache" >> "$GITHUB_ENV"
           echo "ZIG_GLOBAL_CACHE_DIR=$global_cache" >> "$GITHUB_ENV"
@@ -352,7 +352,7 @@ jobs:
     runs-on: arc-antfly-heavy
     timeout-minutes: 45
     env:
-      ZIG_LOCAL_CACHE_DIR: /mnt/cache/antfly/zig/${{ github.job }}/zig-local
+      ZIG_LOCAL_CACHE_DIR: /mnt/cache/antfly/zig/${{ github.job }}/${{ github.run_id }}-${{ github.run_attempt }}/zig-local
       ZIG_GLOBAL_CACHE_DIR: /mnt/cache/antfly/zig/zig-global
       UV_CACHE_DIR: /mnt/cache/antfly/zig/uv
       HF_HOME: /mnt/cache/antfly/zig/hf
@@ -373,7 +373,7 @@ jobs:
 
       - name: Restore ARC cache dirs
         run: |
-          local_cache="/mnt/cache/antfly/zig/${{ github.job }}/zig-local"
+          local_cache="/mnt/cache/antfly/zig/${{ github.job }}/${{ github.run_id }}-${{ github.run_attempt }}/zig-local"
           global_cache="/mnt/cache/antfly/zig/zig-global"
           echo "ZIG_LOCAL_CACHE_DIR=$local_cache" >> "$GITHUB_ENV"
           echo "ZIG_GLOBAL_CACHE_DIR=$global_cache" >> "$GITHUB_ENV"
@@ -400,7 +400,7 @@ jobs:
     runs-on: arc-antfly-heavy
     timeout-minutes: 90
     env:
-      ZIG_LOCAL_CACHE_DIR: /mnt/cache/antfly/zig/${{ github.job }}/zig-local
+      ZIG_LOCAL_CACHE_DIR: /mnt/cache/antfly/zig/${{ github.job }}/${{ github.run_id }}-${{ github.run_attempt }}/zig-local
       ZIG_GLOBAL_CACHE_DIR: /mnt/cache/antfly/zig/zig-global
       UV_CACHE_DIR: /mnt/cache/antfly/zig/uv
       HF_HOME: /mnt/cache/antfly/zig/hf
@@ -420,7 +420,7 @@ jobs:
 
       - name: Restore ARC cache dirs
         run: |
-          local_cache="/mnt/cache/antfly/zig/${{ github.job }}/zig-local"
+          local_cache="/mnt/cache/antfly/zig/${{ github.job }}/${{ github.run_id }}-${{ github.run_attempt }}/zig-local"
           global_cache="/mnt/cache/antfly/zig/zig-global"
           echo "ZIG_LOCAL_CACHE_DIR=$local_cache" >> "$GITHUB_ENV"
           echo "ZIG_GLOBAL_CACHE_DIR=$global_cache" >> "$GITHUB_ENV"

--- a/zig/e2e/antfly/test_backup_restore.py
+++ b/zig/e2e/antfly/test_backup_restore.py
@@ -16,13 +16,28 @@
 
 from __future__ import annotations
 
+import json
 import os
+import signal
+import subprocess
 import tempfile
 import time
+from pathlib import Path
 
 import pytest
 import requests
 
+from conftest import (
+    ANTFLY_PUBLIC_API_ROOT,
+    DEFAULT_ANTFLY_BIN,
+    REPO_ROOT,
+    _read_log_tail,
+    antfly_public_api_url,
+    find_free_port,
+    maybe_preserve_tempdir,
+    resolve_binary_path,
+    wait_for_server,
+)
 from helpers import wait_until
 
 
@@ -30,6 +45,17 @@ def _lookup_doc(stateful_api, table_name: str, key: str) -> dict | None:
     try:
         return stateful_api.lookup_key(table_name, key)
     except requests.HTTPError:
+        return None
+
+
+def _lookup_doc_from_url(session: requests.Session, api_url: str, table_name: str, key: str) -> dict | None:
+    try:
+        response = session.get(f"{api_url}/tables/{table_name}/documents/{key}", timeout=10)
+        if response.status_code >= 400:
+            return None
+        payload = response.json()
+        return payload if isinstance(payload, dict) else None
+    except (requests.RequestException, ValueError):
         return None
 
 
@@ -178,6 +204,256 @@ def _remote_backup_location(backend: str) -> str:
 
     prefix = f"antfly-backup-e2e/{scheme}/{time.time_ns()}"
     return f"{scheme}://{bucket}/{prefix}"
+
+
+def _check_response(response: requests.Response) -> dict:
+    try:
+        response.raise_for_status()
+    except requests.HTTPError as exc:
+        raise AssertionError(f"{response.request.method} {response.url} failed: {response.text}") from exc
+    payload = response.json()
+    assert isinstance(payload, dict)
+    return payload
+
+
+class MultiMetadataBackupCluster:
+    def __init__(self, binary: str):
+        self.binary = binary
+        self.host = "127.0.0.1"
+        self.tempdir = tempfile.TemporaryDirectory(prefix="antfly-zig-metadata-backup-e2e-")
+        self.root = Path(self.tempdir.name)
+
+        self.metadata_raft_ports = [find_free_port() for _ in range(3)]
+        self.metadata_admin_ports = [find_free_port() for _ in range(3)]
+        self.metadata_admin_urls = [f"http://{self.host}:{port}" for port in self.metadata_admin_ports]
+        self.metadata_public_urls = [
+            antfly_public_api_url(url, root=ANTFLY_PUBLIC_API_ROOT) for url in self.metadata_admin_urls
+        ]
+        self.data_port = find_free_port()
+        self.data_raft_port = find_free_port()
+        self.data_url = f"http://{self.host}:{self.data_port}"
+        self.data_api_url = antfly_public_api_url(self.data_url, binary=binary)
+
+        self.config_path = self.root / "antfly-metadata-cluster.json"
+        self._write_config()
+
+        self.metadata_log_paths = [self.root / f"metadata-{node_id}.log" for node_id in range(1, 4)]
+        self.metadata_log_files = [path.open("w") for path in self.metadata_log_paths]
+        self.data_log_path = self.root / "data.log"
+        self.data_log_file = self.data_log_path.open("w")
+
+        self.metadata_procs: list[subprocess.Popen[str]] = []
+        self.data_proc: subprocess.Popen[str] | None = None
+
+        try:
+            self._start()
+        except BaseException:
+            self.stop()
+            raise
+
+    def _write_config(self) -> None:
+        metadata = {
+            "orchestration_urls": {
+                str(node_id): self.metadata_admin_urls[node_id - 1] for node_id in range(1, 4)
+            },
+            "raft_urls": {
+                str(node_id): f"http://{self.host}:{self.metadata_raft_ports[node_id - 1]}"
+                for node_id in range(1, 4)
+            },
+        }
+        self.config_path.write_text(
+            json.dumps(
+                {
+                    "metadata": metadata,
+                    "remote_content": {"security": {"block_private_ips": False}},
+                    "replication_factor": 1,
+                    "default_shards_per_table": 1,
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    def _metadata_command(self, node_id: int) -> list[str]:
+        return [
+            self.binary,
+            "metadata",
+            "--config",
+            str(self.config_path),
+            "--id",
+            str(node_id),
+            "--raft-host",
+            self.host,
+            "--raft-port",
+            str(self.metadata_raft_ports[node_id - 1]),
+            "--api-host",
+            self.host,
+            "--api-port",
+            str(self.metadata_admin_ports[node_id - 1]),
+            "--health",
+            "false",
+            "--tick-ms",
+            "5",
+            "--data-dir",
+            str(self.root / f"metadata-{node_id}"),
+            "--replica-root-dir",
+            str(self.root / f"metadata-{node_id}-replicas"),
+            "--replica-catalog-path",
+            str(self.root / f"metadata-{node_id}-catalog.txt"),
+            "--snapshot-root-dir",
+            str(self.root / f"metadata-{node_id}-snapshots"),
+        ]
+
+    def _data_command(self) -> list[str]:
+        command = [
+            self.binary,
+            "data",
+            "--config",
+            str(self.config_path),
+            "--api-host",
+            self.host,
+            "--api-port",
+            str(self.data_port),
+            "--raft-host",
+            self.host,
+            "--raft-port",
+            str(self.data_raft_port),
+            "--node-id",
+            "4",
+            "--store-id",
+            "4",
+            "--store-role",
+            "data",
+            "--health",
+            "false",
+            "--tick-ms",
+            "5",
+            "--data-dir",
+            str(self.root / "data"),
+            "--replica-root-dir",
+            str(self.root / "data-replicas"),
+            "--replica-catalog-path",
+            str(self.root / "data-catalog.txt"),
+            "--snapshot-root-dir",
+            str(self.root / "data-snapshots"),
+        ]
+        for url in self.metadata_admin_urls:
+            command.extend(["--metadata-api", url])
+        return command
+
+    def _start(self) -> None:
+        for i in range(3):
+            proc = subprocess.Popen(
+                self._metadata_command(i + 1),
+                stdout=self.metadata_log_files[i],
+                stderr=subprocess.STDOUT,
+                cwd=REPO_ROOT,
+            )
+            self.metadata_procs.append(proc)
+
+        for url in self.metadata_admin_urls:
+            if not wait_for_server(url, path="/metadata/v1/status", timeout=30.0):
+                raise RuntimeError(f"metadata server failed to start at {url}\n{self.debug_logs()}")
+
+        if self.metadata_leader_index(timeout_s=30.0) is None:
+            raise RuntimeError(f"metadata cluster did not elect a leader\n{self.debug_logs()}")
+
+        self.data_proc = subprocess.Popen(
+            self._data_command(),
+            stdout=self.data_log_file,
+            stderr=subprocess.STDOUT,
+            cwd=REPO_ROOT,
+        )
+        if not wait_for_server(self.data_api_url, timeout=30.0):
+            raise RuntimeError(f"data server failed to start at {self.data_api_url}\n{self.debug_logs()}")
+
+    def debug_logs(self) -> str:
+        for handle in self.metadata_log_files:
+            handle.flush()
+        self.data_log_file.flush()
+        parts = [
+            f"[metadata-{i + 1}]\n{_read_log_tail(path)}"
+            for i, path in enumerate(self.metadata_log_paths)
+        ]
+        parts.append(f"[data]\n{_read_log_tail(self.data_log_path)}")
+        return "\n".join(parts)
+
+    def metadata_statuses(self) -> list[dict | None]:
+        statuses: list[dict | None] = []
+        for url in self.metadata_admin_urls:
+            try:
+                response = requests.get(f"{url}/metadata/v1/status", timeout=5)
+                statuses.append(_check_response(response))
+            except (AssertionError, requests.RequestException, ValueError):
+                statuses.append(None)
+        return statuses
+
+    def metadata_leader_index(self, *, timeout_s: float) -> int | None:
+        def current_leader() -> int | None:
+            statuses = self.metadata_statuses()
+            leader_ids = {
+                int(status["metadata_raft_leader_id"])
+                for status in statuses
+                if status and status.get("metadata_raft_leader_id") is not None
+            }
+            if len(leader_ids) != 1:
+                return None
+            leader_id = leader_ids.pop()
+            if leader_id < 1 or leader_id > len(self.metadata_admin_urls):
+                return None
+            return leader_id - 1
+
+        return wait_until(current_leader, timeout_s=timeout_s, interval_s=0.25)
+
+    def metadata_follower_public_url(self) -> str:
+        leader_index = self.metadata_leader_index(timeout_s=10.0)
+        if leader_index is None:
+            raise AssertionError(f"metadata leader unavailable\n{self.debug_logs()}")
+        for index, url in enumerate(self.metadata_public_urls):
+            if index != leader_index:
+                return url
+        raise AssertionError("metadata cluster has no follower")
+
+    def stop(self) -> None:
+        if self.data_proc is not None and self.data_proc.poll() is None:
+            self.data_proc.send_signal(signal.SIGTERM)
+            try:
+                self.data_proc.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                self.data_proc.kill()
+                self.data_proc.wait()
+        self.data_proc = None
+
+        for proc in reversed(self.metadata_procs):
+            if proc.poll() is None:
+                proc.send_signal(signal.SIGTERM)
+                try:
+                    proc.wait(timeout=10)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+                    proc.wait()
+        self.metadata_procs = []
+
+        for handle in [self.data_log_file, *self.metadata_log_files]:
+            if not handle.closed:
+                handle.close()
+        if not maybe_preserve_tempdir(self.tempdir):
+            self.tempdir.cleanup()
+
+
+@pytest.fixture
+def multi_metadata_backup_cluster() -> MultiMetadataBackupCluster:
+    binary = resolve_binary_path(os.environ.get("ANTFLY_BIN", str(DEFAULT_ANTFLY_BIN)))
+    resolved = Path(binary)
+    if resolved.name != "antfly":
+        pytest.skip("multi-metadata backup e2e requires the antfly binary")
+    if not resolved.exists():
+        pytest.skip(f"antfly binary not built: {resolved}")
+
+    cluster = MultiMetadataBackupCluster(str(resolved))
+    try:
+        yield cluster
+    finally:
+        cluster.stop()
 
 
 def test_table_backup_restore_round_trip(backup_api):
@@ -449,6 +725,65 @@ def test_cluster_backup_restore_round_trip(backup_api):
             )
             assert restored_doc is not None
             assert restored_doc["title"] == expected_title
+
+
+def test_cluster_backup_through_metadata_follower_public_api(
+    multi_metadata_backup_cluster: MultiMetadataBackupCluster,
+) -> None:
+    cluster = multi_metadata_backup_cluster
+    table_name = f"metadata_follower_backup_{time.time_ns()}"
+    backup_id = f"metadata-follower-backup-{time.time_ns()}"
+    session = requests.Session()
+    session.headers["Content-Type"] = "application/json"
+    session.headers["Connection"] = "close"
+
+    created = _check_response(
+        session.post(
+            f"{cluster.data_api_url}/tables/{table_name}",
+            json={"num_shards": 1, "description": "metadata follower backup docs"},
+            timeout=30,
+        )
+    )
+    assert created["name"] == table_name
+
+    batch = _check_response(
+        session.post(
+            f"{cluster.data_api_url}/tables/{table_name}/batch",
+            json={
+                "inserts": {
+                    "doc:1": {
+                        "title": "Follower Backup",
+                        "content": "cluster backup requests can arrive at metadata followers",
+                    }
+                }
+            },
+            timeout=30,
+        )
+    )
+    assert batch["inserted"] == 1
+    assert wait_until(
+        lambda: _lookup_doc_from_url(session, cluster.data_api_url, table_name, "doc:1"),
+        timeout_s=30.0,
+        interval_s=0.5,
+    ), cluster.debug_logs()
+
+    follower_public_url = cluster.metadata_follower_public_url()
+    with tempfile.TemporaryDirectory(prefix="antfly-metadata-follower-cluster-backup-") as backup_dir:
+        backup = _check_response(
+            session.post(
+                f"{follower_public_url}/backup",
+                json={
+                    "backup_id": backup_id,
+                    "location": f"file://{backup_dir}",
+                    "table_names": [table_name],
+                },
+                timeout=120,
+            )
+        )
+
+        assert backup["backup_id"] == backup_id
+        assert backup["status"] == "completed", f"backup={backup}\n{cluster.debug_logs()}"
+        assert [table["name"] for table in backup["tables"]] == [table_name]
 
 
 @pytest.mark.objectstore_integration

--- a/zig/pkg/antfly/src/api/http_server.zig
+++ b/zig/pkg/antfly/src/api/http_server.zig
@@ -5072,7 +5072,7 @@ pub const ApiHttpServer = struct {
         if (table.read_schema_json.len > 0) return error.UnsupportedBackupMigrationState;
 
         const table_writes_source = self.table_writes orelse return error.UnsupportedOperation;
-        if (try table_writes_source.backupTableToLocation(self.alloc, table_name, backup_id, format, location_uri)) |shards| {
+        if (try table_writes_source.backupTableToLocation(self.alloc, table_name, backup_id, format, location_uri, backup_location)) |shards| {
             defer freeBackupShards(self.alloc, shards);
             var manifest = try backups_api.createManifest(self.alloc, backup_id, &table, shards);
             defer manifest.deinit(self.alloc);

--- a/zig/pkg/antfly/src/api/http_server.zig
+++ b/zig/pkg/antfly/src/api/http_server.zig
@@ -376,6 +376,7 @@ pub const StatusSource = struct {
         status: *const fn (ptr: *anyopaque) anyerror!metadata_api.MetadataStatus,
         admin_snapshot: ?*const fn (ptr: *anyopaque) anyerror!metadata_api.AdminSnapshot = null,
         cached_admin_snapshot: ?*const fn (ptr: *anyopaque) anyerror!?metadata_api.AdminSnapshot = null,
+        ensure_linearizable_read: ?*const fn (ptr: *anyopaque) anyerror!void = null,
         free_admin_snapshot: ?*const fn (ptr: *anyopaque, snapshot: *metadata_api.AdminSnapshot) void = null,
         create_table: ?*const fn (ptr: *anyopaque, alloc: std.mem.Allocator, table_name: []const u8, req: tables_api.CreateTableRequest) anyerror!void = null,
         restore_table: ?*const fn (ptr: *anyopaque, alloc: std.mem.Allocator, table_name: []const u8, location_uri: []const u8, backup_id: []const u8) anyerror!void = null,
@@ -411,6 +412,11 @@ pub const StatusSource = struct {
 
     pub fn cachedAdminSnapshot(self: StatusSource) !?metadata_api.AdminSnapshot {
         const fn_ptr = self.vtable.cached_admin_snapshot orelse return null;
+        return try fn_ptr(self.ptr);
+    }
+
+    pub fn ensureLinearizableRead(self: StatusSource) !void {
+        const fn_ptr = self.vtable.ensure_linearizable_read orelse return;
         return try fn_ptr(self.ptr);
     }
 
@@ -554,6 +560,10 @@ pub const StatusSource = struct {
                 return try cast(ptr).adminSnapshot();
             }
 
+            fn ensureLinearizableRead(ptr: *anyopaque) anyerror!void {
+                return try cast(ptr).ensureLinearizableRead();
+            }
+
             fn freeAdminSnapshot(ptr: *anyopaque, snapshot: *metadata_api.AdminSnapshot) void {
                 cast(ptr).freeAdminSnapshot(snapshot);
             }
@@ -659,6 +669,7 @@ pub const StatusSource = struct {
             .status = Gen.status,
             .admin_snapshot = Gen.adminSnapshot,
             .cached_admin_snapshot = Gen.cachedAdminSnapshot,
+            .ensure_linearizable_read = Gen.ensureLinearizableRead,
             .free_admin_snapshot = Gen.freeAdminSnapshot,
             .create_table = Gen.createTable,
             .restore_table = Gen.restoreTable,
@@ -3873,7 +3884,6 @@ pub const ApiHttpServer = struct {
             }
         }
         if (req.method == .POST and std.mem.eql(u8, uri_parts.path, routes.Routes.backup)) {
-            if (try self.forwardMetadataMutationToLeader(req)) |resp| return resp;
             return try self.handlePublicClusterBackup(req.body);
         }
         if (req.method == .POST) {
@@ -6124,6 +6134,10 @@ pub const ApiHttpServer = struct {
         location: *backups_api.BackupLocation,
     ) public_table_http.TableApi.ExecuteBackupError!void {
         const self: *ApiHttpServer = @ptrCast(@alignCast(ptr));
+        self.source.ensureLinearizableRead() catch |err| {
+            std.log.warn("table backup metadata read barrier failed table={s} err={s}", .{ table_name, @errorName(err) });
+            return error.InternalFailure;
+        };
         self.backupOwnedTable(table_name, location, location_uri, backup_id, format) catch |err| switch (err) {
             error.TableNotFound => return error.NotFound,
             error.UnsupportedOperation => return error.MethodNotAllowed,
@@ -6505,6 +6519,11 @@ pub const ApiHttpServer = struct {
         location: *backups_api.BackupLocation,
     ) cluster_api_http.ClusterApi.ExecuteBackupError![]u8 {
         const self: *ApiHttpServer = @ptrCast(@alignCast(ptr));
+
+        self.source.ensureLinearizableRead() catch |err| {
+            std.log.warn("cluster backup metadata read barrier failed err={s}", .{@errorName(err)});
+            return error.InternalFailure;
+        };
 
         const owns_table_names = req.table_names == null;
         const table_names = if (req.table_names) |values|

--- a/zig/pkg/antfly/src/api/http_server.zig
+++ b/zig/pkg/antfly/src/api/http_server.zig
@@ -270,6 +270,7 @@ pub const ApiHttpServerConfig = struct {
     user_manager: ?*usermgr.UserManager = null,
     session_router: ?table_router.HostedGroupRouter = null,
     session_executor: ?http_common.RequestExecutor = null,
+    metadata_mutation_forwarder: ?RequestForwarder = null,
     session_store: ?*transactions_api.DurableSessionStore = null,
     session_store_path: ?[]const u8 = null,
     ha_admin_executor: ?http_common.RequestExecutor = null,
@@ -284,6 +285,19 @@ pub const ApiHttpServerConfig = struct {
     session_owner_lease_ttl_ns: ?u64 = null,
     session_owner_lease_renew_interval_ns: ?u64 = null,
     session_savepoint_limit: ?usize = null,
+};
+
+pub const RequestForwarder = struct {
+    ptr: *anyopaque,
+    vtable: *const VTable,
+
+    pub const VTable = struct {
+        forward: *const fn (ptr: *anyopaque, alloc: std.mem.Allocator, req: http_common.HttpRequest) anyerror!?http_common.HttpResponse,
+    };
+
+    pub fn forward(self: RequestForwarder, alloc: std.mem.Allocator, req: http_common.HttpRequest) !?http_common.HttpResponse {
+        return try self.vtable.forward(self.ptr, alloc, req);
+    }
 };
 
 pub const trusted_principal_header = "X-Antfly-Trusted-Principal";
@@ -3859,10 +3873,12 @@ pub const ApiHttpServer = struct {
             }
         }
         if (req.method == .POST and std.mem.eql(u8, uri_parts.path, routes.Routes.backup)) {
+            if (try self.forwardMetadataMutationToLeader(req)) |resp| return resp;
             return try self.handlePublicClusterBackup(req.body);
         }
         if (req.method == .POST) {
             if (std.mem.eql(u8, uri_parts.path, routes.Routes.restore)) {
+                if (try self.forwardMetadataMutationToLeader(req)) |resp| return resp;
                 return try self.handlePublicClusterRestore(req.body);
             }
         }
@@ -5335,6 +5351,12 @@ pub const ApiHttpServer = struct {
             if (try self.tryAdoptSession(txn_id)) return null;
             return err;
         };
+    }
+
+    fn forwardMetadataMutationToLeader(self: *ApiHttpServer, req: http_common.HttpRequest) !?http_common.HttpResponse {
+        if (req.source_node_id != null) return null;
+        const forwarder = self.cfg.metadata_mutation_forwarder orelse return null;
+        return try forwarder.forward(self.alloc, req);
     }
 
     fn tryAdoptSession(self: *ApiHttpServer, txn_id: db_mod.types.TxnId) !bool {

--- a/zig/pkg/antfly/src/api/http_server.zig
+++ b/zig/pkg/antfly/src/api/http_server.zig
@@ -6158,21 +6158,17 @@ pub const ApiHttpServer = struct {
         const self: *ApiHttpServer = @ptrCast(@alignCast(ptr));
         if (self.tableExists(table_name) catch return error.InternalFailure) return error.TableAlreadyExists;
 
-        if (self.source.restoreTable(self.alloc, table_name, location_uri, backup_id) catch |err| switch (err) {
-            error.UnsupportedOperation => false,
-            error.InvalidBackupRequest => {
-                if (self.tableExists(table_name) catch return error.InternalFailure) return error.TableAlreadyExists;
-                return error.InvalidBackupRequest;
-            },
-            else => return mapExecuteRestoreError(err),
-        }) {
-            if (self.cfg.swarm_mode) {
-                self.restoreLocalTableDataFromManifest(table_name, location, backup_id) catch |err| {
-                    std.log.err("swarm local restore data apply failed table={s} backup_id={s} err={}", .{ table_name, backup_id, err });
-                    return mapExecuteRestoreError(err);
-                };
+        if (!self.cfg.swarm_mode) {
+            if (self.source.restoreTable(self.alloc, table_name, location_uri, backup_id) catch |err| switch (err) {
+                error.UnsupportedOperation => false,
+                error.InvalidBackupRequest => {
+                    if (self.tableExists(table_name) catch return error.InternalFailure) return error.TableAlreadyExists;
+                    return error.InvalidBackupRequest;
+                },
+                else => return mapExecuteRestoreError(err),
+            }) {
+                return;
             }
-            return;
         }
 
         self.restoreOwnedTableWithRetry(table_name, location, backup_id) catch |err| switch (err) {
@@ -6672,7 +6668,7 @@ pub const ApiHttpServer = struct {
 
             // For overwrite, skip the metadata restore path and use the owned-table
             // restore which creates the table and copies data synchronously.
-            if (!is_overwrite) {
+            if (!is_overwrite and !self.cfg.swarm_mode) {
                 const restored_via_metadata = self.source.restoreTable(alloc, table_name, req.location, table_backup_id) catch |err| switch (err) {
                     error.UnsupportedOperation => false,
                     else => {
@@ -6693,25 +6689,6 @@ pub const ApiHttpServer = struct {
                     },
                 };
                 if (restored_via_metadata) {
-                    if (self.cfg.swarm_mode) {
-                        self.restoreLocalTableDataFromManifest(table_name, location, table_backup_id) catch |err| {
-                            std.log.err("cluster restore local data apply failed table={s} backup_id={s} err={}", .{
-                                table_name,
-                                table_backup_id,
-                                err,
-                            });
-                            statuses[i].@"error" = switch (err) {
-                                error.UnsupportedOperation => "method not allowed",
-                                error.UnsupportedBackupFormat => "restore does not support this backup layout",
-                                error.UnsupportedBackupMigrationState => "restore does not support active schema migration",
-                                error.TableAlreadyExists => "table already exists",
-                                error.TableNotFound => "not found",
-                                error.InvalidBackupRequest => "invalid restore request",
-                                else => "restore failed",
-                            };
-                            continue;
-                        };
-                    }
                     statuses[i].status = "triggered";
                     continue;
                 }

--- a/zig/pkg/antfly/src/api/http_server.zig
+++ b/zig/pkg/antfly/src/api/http_server.zig
@@ -5063,6 +5063,7 @@ pub const ApiHttpServer = struct {
         self: *ApiHttpServer,
         table_name: []const u8,
         backup_location: *backups_api.BackupLocation,
+        location_uri: []const u8,
         backup_id: []const u8,
         format: backups_api.BackupFormat,
     ) !void {
@@ -5071,6 +5072,14 @@ pub const ApiHttpServer = struct {
         if (table.read_schema_json.len > 0) return error.UnsupportedBackupMigrationState;
 
         const table_writes_source = self.table_writes orelse return error.UnsupportedOperation;
+        if (try table_writes_source.backupTableToLocation(self.alloc, table_name, backup_id, format, location_uri)) |shards| {
+            defer freeBackupShards(self.alloc, shards);
+            var manifest = try backups_api.createManifest(self.alloc, backup_id, &table, shards);
+            defer manifest.deinit(self.alloc);
+            try backups_api.writeManifestToLocation(self.alloc, backup_location, &manifest);
+            return;
+        }
+
         const local_backup_root = switch (backup_location.*) {
             .file => |value| value,
             .remote => try createBackupStagingRoot(self.alloc, backup_id),
@@ -6111,10 +6120,11 @@ pub const ApiHttpServer = struct {
         table_name: []const u8,
         backup_id: []const u8,
         format: backups_api.BackupFormat,
+        location_uri: []const u8,
         location: *backups_api.BackupLocation,
     ) public_table_http.TableApi.ExecuteBackupError!void {
         const self: *ApiHttpServer = @ptrCast(@alignCast(ptr));
-        self.backupOwnedTable(table_name, location, backup_id, format) catch |err| switch (err) {
+        self.backupOwnedTable(table_name, location, location_uri, backup_id, format) catch |err| switch (err) {
             error.TableNotFound => return error.NotFound,
             error.UnsupportedOperation => return error.MethodNotAllowed,
             error.UnsupportedBackupMigrationState => return error.UnsupportedBackupMigrationState,
@@ -6516,7 +6526,7 @@ pub const ApiHttpServer = struct {
         for (table_names, 0..) |table_name, i| {
             statuses[i] = .{ .name = table_name, .status = "failed", .@"error" = null };
             const table_backup_id = backups_api.clusterTableBackupId(alloc, req.backup_id, table_name) catch return error.InternalFailure;
-            self.backupOwnedTable(table_name, location, table_backup_id, .native) catch |err| {
+            self.backupOwnedTable(table_name, location, req.location, table_backup_id, .native) catch |err| {
                 statuses[i].@"error" = switch (err) {
                     error.TableNotFound => "not found",
                     error.UnsupportedOperation => "method not allowed",

--- a/zig/pkg/antfly/src/api/public_table_http.zig
+++ b/zig/pkg/antfly/src/api/public_table_http.zig
@@ -204,6 +204,7 @@ pub const TableApi = struct {
             table_name: []const u8,
             backup_id: []const u8,
             format: backups_api.BackupFormat,
+            location_uri: []const u8,
             location: *backups_api.BackupLocation,
         ) ExecuteBackupError!void,
         execute_table_restore: *const fn (
@@ -314,9 +315,10 @@ pub const TableApi = struct {
         table_name: []const u8,
         backup_id: []const u8,
         format: backups_api.BackupFormat,
+        location_uri: []const u8,
         location: *backups_api.BackupLocation,
     ) ExecuteBackupError!void {
-        return try self.vtable.execute_table_backup(self.ptr, alloc, table_name, backup_id, format, location);
+        return try self.vtable.execute_table_backup(self.ptr, alloc, table_name, backup_id, format, location_uri, location);
     }
 
     pub fn executeTableRestore(
@@ -601,7 +603,7 @@ pub fn handleTableBackup(
     };
     defer location.deinit(alloc);
 
-    api.executeTableBackup(alloc, table_name, parsed_req.value.backup_id, backup_format, &location) catch |err| switch (err) {
+    api.executeTableBackup(alloc, table_name, parsed_req.value.backup_id, backup_format, parsed_req.value.location, &location) catch |err| switch (err) {
         error.NotFound => return .{ .status = 404, .body = try alloc.dupe(u8, "not found") },
         error.MethodNotAllowed => return .{ .status = 405, .body = try alloc.dupe(u8, "method not allowed") },
         error.UnsupportedBackupMigrationState => return .{ .status = 400, .body = try alloc.dupe(u8, "backup does not support active schema migration") },
@@ -1141,6 +1143,7 @@ fn unsupportedBackup(
     _: []const u8,
     _: []const u8,
     _: backups_api.BackupFormat,
+    _: []const u8,
     _: *backups_api.BackupLocation,
 ) TableApi.ExecuteBackupError!void {
     return error.InternalFailure;
@@ -1791,6 +1794,7 @@ test "public table backup handler maps unsupported multi-range error" {
             _: []const u8,
             _: []const u8,
             _: backups_api.BackupFormat,
+            _: []const u8,
             _: *backups_api.BackupLocation,
         ) TableApi.ExecuteBackupError!void {
             return error.UnsupportedMultiRangeTable;
@@ -1837,6 +1841,7 @@ test "public table backup handler accepts portable format" {
             _: []const u8,
             _: []const u8,
             format: backups_api.BackupFormat,
+            _: []const u8,
             _: *backups_api.BackupLocation,
         ) TableApi.ExecuteBackupError!void {
             const self: *@This() = @ptrCast(@alignCast(ptr));

--- a/zig/pkg/antfly/src/api/table_writes.zig
+++ b/zig/pkg/antfly/src/api/table_writes.zig
@@ -2252,6 +2252,7 @@ pub const TableWriteSource = struct {
             backup_id: []const u8,
             format: backups_api.BackupFormat,
             location_uri: []const u8,
+            location: *backups_api.BackupLocation,
         ) anyerror!?[]backups_api.ShardSnapshot = null,
         restore_table: ?*const fn (
             ptr: *anyopaque,
@@ -2512,9 +2513,10 @@ pub const TableWriteSource = struct {
         backup_id: []const u8,
         format: backups_api.BackupFormat,
         location_uri: []const u8,
+        location: *backups_api.BackupLocation,
     ) !?[]backups_api.ShardSnapshot {
         const fn_ptr = self.vtable.backup_table_to_location orelse return null;
-        return try fn_ptr(self.ptr, alloc, table_name, backup_id, format, location_uri);
+        return try fn_ptr(self.ptr, alloc, table_name, backup_id, format, location_uri, location);
     }
 
     pub fn restoreTable(
@@ -8178,6 +8180,7 @@ pub const HostedProvisionedTableWriteSource = struct {
         backup_id: []const u8,
         format: backups_api.BackupFormat,
         location_uri: []const u8,
+        location: *backups_api.BackupLocation,
     ) !?[]backups_api.ShardSnapshot {
         const self: *HostedProvisionedTableWriteSource = @ptrCast(@alignCast(ptr));
         const group_id = (try table_catalog.resolveSingleRangeGroup(alloc, self.catalog, table_name)) orelse return null;
@@ -8202,9 +8205,7 @@ pub const HostedProvisionedTableWriteSource = struct {
                 var response = try client.fetchBackupTable(remote.base_uri, table_name, body);
                 response.deinit(alloc);
 
-                var location = try backups_api.openBackupLocation(alloc, location_uri);
-                defer location.deinit(alloc);
-                var manifest = try backups_api.readManifestFromLocation(alloc, &location, backup_id);
+                var manifest = try backups_api.readManifestFromLocation(alloc, location, backup_id);
                 defer manifest.deinit(alloc);
                 return try cloneShardSnapshots(alloc, manifest.shards);
             },

--- a/zig/pkg/antfly/src/api/table_writes.zig
+++ b/zig/pkg/antfly/src/api/table_writes.zig
@@ -2245,6 +2245,14 @@ pub const TableWriteSource = struct {
             table_name: []const u8,
             plan: backups_api.TableBackupPlan,
         ) anyerror!?[]backups_api.ShardSnapshot = null,
+        backup_table_to_location: ?*const fn (
+            ptr: *anyopaque,
+            alloc: std.mem.Allocator,
+            table_name: []const u8,
+            backup_id: []const u8,
+            format: backups_api.BackupFormat,
+            location_uri: []const u8,
+        ) anyerror!?[]backups_api.ShardSnapshot = null,
         restore_table: ?*const fn (
             ptr: *anyopaque,
             alloc: std.mem.Allocator,
@@ -2495,6 +2503,18 @@ pub const TableWriteSource = struct {
     ) !?[]backups_api.ShardSnapshot {
         const fn_ptr = self.vtable.backup_table orelse return null;
         return try fn_ptr(self.ptr, alloc, table_name, plan);
+    }
+
+    pub fn backupTableToLocation(
+        self: TableWriteSource,
+        alloc: std.mem.Allocator,
+        table_name: []const u8,
+        backup_id: []const u8,
+        format: backups_api.BackupFormat,
+        location_uri: []const u8,
+    ) !?[]backups_api.ShardSnapshot {
+        const fn_ptr = self.vtable.backup_table_to_location orelse return null;
+        return try fn_ptr(self.ptr, alloc, table_name, backup_id, format, location_uri);
     }
 
     pub fn restoreTable(
@@ -7949,6 +7969,7 @@ pub const HostedProvisionedTableWriteSource = struct {
                 .commit_transaction = commitTransaction,
                 .commit_transaction_with_id = commitTransactionWithId,
                 .backup_table = backupTable,
+                .backup_table_to_location = backupTableToLocation,
                 .restore_table = restoreTable,
                 .batch = batch,
                 .batch_group_local = batchGroupLocal,
@@ -8148,6 +8169,46 @@ pub const HostedProvisionedTableWriteSource = struct {
         _: backups_api.TableBackupPlan,
     ) !?[]backups_api.ShardSnapshot {
         return error.UnsupportedOperation;
+    }
+
+    fn backupTableToLocation(
+        ptr: *anyopaque,
+        alloc: std.mem.Allocator,
+        table_name: []const u8,
+        backup_id: []const u8,
+        format: backups_api.BackupFormat,
+        location_uri: []const u8,
+    ) !?[]backups_api.ShardSnapshot {
+        const self: *HostedProvisionedTableWriteSource = @ptrCast(@alignCast(ptr));
+        const group_id = (try table_catalog.resolveSingleRangeGroup(alloc, self.catalog, table_name)) orelse return null;
+        const resolved_route = try table_router.resolveGroupRoute(alloc, self.catalog, self.router, group_id, .prefer_leader);
+        var route = resolved_route orelse return null;
+        defer route.deinit(alloc);
+        switch (route) {
+            .local => return error.UnsupportedOperation,
+            .remote => |remote| {
+                const format_name = switch (format) {
+                    .native => "native",
+                    .portable => "portable",
+                };
+                const body = try std.fmt.allocPrint(alloc, "{f}", .{std.json.fmt(.{
+                    .backup_id = backup_id,
+                    .location = location_uri,
+                    .format = format_name,
+                }, .{})});
+                defer alloc.free(body);
+
+                var client = http_client.ApiHttpClient.init(alloc, self.executor);
+                var response = try client.fetchBackupTable(remote.base_uri, table_name, body);
+                response.deinit(alloc);
+
+                var location = try backups_api.openBackupLocation(alloc, location_uri);
+                defer location.deinit(alloc);
+                var manifest = try backups_api.readManifestFromLocation(alloc, &location, backup_id);
+                defer manifest.deinit(alloc);
+                return try cloneShardSnapshots(alloc, manifest.shards);
+            },
+        }
     }
 
     fn restoreTable(
@@ -11363,6 +11424,28 @@ fn readBackupFileAlloc(alloc: std.mem.Allocator, path: []const u8) ![]u8 {
 fn freeBackupShards(alloc: std.mem.Allocator, shards: []const backups_api.ShardSnapshot) void {
     for (shards) |shard| shard.deinit(alloc);
     alloc.free(@constCast(shards));
+}
+
+fn cloneShardSnapshots(
+    alloc: std.mem.Allocator,
+    shards: []const backups_api.ShardSnapshot,
+) ![]backups_api.ShardSnapshot {
+    const out = try alloc.alloc(backups_api.ShardSnapshot, shards.len);
+    var initialized: usize = 0;
+    errdefer {
+        for (out[0..initialized]) |shard| shard.deinit(alloc);
+        alloc.free(out);
+    }
+    for (shards, 0..) |shard, i| {
+        out[i] = .{
+            .group_id = shard.group_id,
+            .start_key = try alloc.dupe(u8, shard.start_key),
+            .end_key = if (shard.end_key) |value| try alloc.dupe(u8, value) else null,
+            .snapshot_path = try alloc.dupe(u8, shard.snapshot_path),
+        };
+        initialized += 1;
+    }
+    return out;
 }
 
 fn resolveWritesForSchemaValidation(

--- a/zig/pkg/antfly/src/metadata/server.zig
+++ b/zig/pkg/antfly/src/metadata/server.zig
@@ -53,6 +53,7 @@ pub const MetadataServer = struct {
     owned_admin_http_server: ?*metadata_http_server.MetadataHttpServer = null,
     owned_public_read_source: ?*api_table_reads.HostedProvisionedTableReadSource = null,
     owned_public_write_source: ?*api_table_writes.HostedProvisionedTableWriteSource = null,
+    owned_public_forwarder: ?*MetadataPublicApiForwarder = null,
     owned_public_http_server: ?*public_api_http_server.ApiHttpServer = null,
     owned_admin_mux: ?*MetadataAdminMux = null,
     owned_admin_listener: ?*raft_transport.StdHttpListener = null,
@@ -106,6 +107,8 @@ pub const MetadataServer = struct {
         errdefer if (owned_public_read_source) |read_source| alloc.destroy(read_source);
         var owned_public_write_source: ?*api_table_writes.HostedProvisionedTableWriteSource = null;
         errdefer if (owned_public_write_source) |write_source| alloc.destroy(write_source);
+        var owned_public_forwarder: ?*MetadataPublicApiForwarder = null;
+        errdefer if (owned_public_forwarder) |forwarder| alloc.destroy(forwarder);
         var owned_public_http_server: ?*public_api_http_server.ApiHttpServer = null;
         errdefer if (owned_public_http_server) |public_http_server| {
             public_http_server.deinit();
@@ -153,9 +156,14 @@ pub const MetadataServer = struct {
             _ = public_write_source.withRemoteContent(cfg.api_server_cfg.remote_content);
             owned_public_write_source = public_write_source;
 
+            const public_forwarder = try alloc.create(MetadataPublicApiForwarder);
+            public_forwarder.* = .{ .svc = svc };
+            owned_public_forwarder = public_forwarder;
+
             var api_server_cfg = cfg.api_server_cfg;
             api_server_cfg.shard_ops = if (owned_hosted_shard_ops) |ops| ops.adapter() else null;
             api_server_cfg.shard_db_adapter = owned_hosted_shard_db.?.adapter();
+            api_server_cfg.metadata_mutation_forwarder = public_forwarder.forwarder();
 
             const public_http_server = try alloc.create(public_api_http_server.ApiHttpServer);
             public_http_server.* = public_api_http_server.ApiHttpServer.init(
@@ -191,6 +199,7 @@ pub const MetadataServer = struct {
             .owned_admin_http_server = owned_admin_http_server,
             .owned_public_read_source = owned_public_read_source,
             .owned_public_write_source = owned_public_write_source,
+            .owned_public_forwarder = owned_public_forwarder,
             .owned_public_http_server = owned_public_http_server,
             .owned_admin_mux = owned_admin_mux,
             .owned_admin_listener = owned_admin_listener,
@@ -211,6 +220,9 @@ pub const MetadataServer = struct {
         }
         if (self.owned_public_write_source) |write_source| {
             self.alloc.destroy(write_source);
+        }
+        if (self.owned_public_forwarder) |forwarder| {
+            self.alloc.destroy(forwarder);
         }
         if (self.owned_public_read_source) |read_source| {
             self.alloc.destroy(read_source);
@@ -317,6 +329,22 @@ pub const MetadataServer = struct {
         try self.control_loop.stateRef().syncProjected(self.svc);
         try self.control_loop.stateRef().seedDesiredFromProjected();
         _ = try self.svc.reconcilePreparedIfLeaseHeld(&self.control_loop);
+    }
+};
+
+const MetadataPublicApiForwarder = struct {
+    svc: *service.MetadataHttpService,
+
+    fn forwarder(self: *@This()) public_api_http_server.RequestForwarder {
+        return .{
+            .ptr = self,
+            .vtable = &.{ .forward = forward },
+        };
+    }
+
+    fn forward(ptr: *anyopaque, alloc: std.mem.Allocator, req: http_common.HttpRequest) !?http_common.HttpResponse {
+        const self: *@This() = @ptrCast(@alignCast(ptr));
+        return try self.svc.forwardMetadataLeaderRequest(alloc, req);
     }
 };
 

--- a/zig/pkg/antfly/src/metadata/service.zig
+++ b/zig/pkg/antfly/src/metadata/service.zig
@@ -2325,15 +2325,31 @@ pub const MetadataHttpService = struct {
         const base_uri = self.metadataOrchestrationUrlForNode(target_node_id) orelse return null;
         const uri = try std.fmt.allocPrint(alloc, "{s}{s}", .{ base_uri, req.uri });
         defer alloc.free(uri);
+        const headers = try filteredForwardHeaders(alloc, req.headers);
+        defer if (headers.len > 0) alloc.free(headers);
         return try self.raft.host.http_host.request_executor.execute(alloc, .{
             .method = req.method,
             .uri = uri,
-            .headers = req.headers,
+            .headers = headers,
             .source_node_id = local_node_id,
             .authorization = req.authorization,
             .content_type = req.content_type,
             .body = req.body,
         });
+    }
+
+    fn filteredForwardHeaders(alloc: std.mem.Allocator, headers: []const http_common.RequestHeader) ![]http_common.RequestHeader {
+        if (headers.len == 0) return &.{};
+        var out = std.ArrayListUnmanaged(http_common.RequestHeader).empty;
+        errdefer out.deinit(alloc);
+        for (headers) |header| {
+            if (std.ascii.eqlIgnoreCase(header.name, "host")) continue;
+            if (std.ascii.eqlIgnoreCase(header.name, "connection")) continue;
+            if (std.ascii.eqlIgnoreCase(header.name, "content-length")) continue;
+            if (std.ascii.eqlIgnoreCase(header.name, "content-type")) continue;
+            try out.append(alloc, header);
+        }
+        return try out.toOwnedSlice(alloc);
     }
 
     fn metadataOrchestrationUrlForNode(self: *const MetadataHttpService, node_id: u64) ?[]const u8 {

--- a/zig/pkg/antfly/src/metadata/service.zig
+++ b/zig/pkg/antfly/src/metadata/service.zig
@@ -282,6 +282,7 @@ pub const MetadataStatus = metadata_api.MetadataStatus;
 
 const LinearizableMetadataReadTracker = struct {
     alloc: std.mem.Allocator,
+    metadata_group_id: raft_engine.core.types.GroupId,
     mutex: std.Io.Mutex = .init,
     next_request_id: std.atomic.Value(u64) = .init(1),
     requests: std.AutoHashMapUnmanaged(u64, bool) = .empty,
@@ -333,11 +334,13 @@ const LinearizableMetadataReadTracker = struct {
         read_states: []const raft_engine.core.ReadState,
     ) !void {
         const self: *@This() = @ptrCast(@alignCast(ptr));
-        for (read_states) |read_state| {
-            if (!std.mem.startsWith(u8, read_state.request_ctx, linearizable_metadata_read_prefix)) continue;
-            const suffix = read_state.request_ctx[linearizable_metadata_read_prefix.len..];
-            const request_id = std.fmt.parseUnsigned(u64, suffix, 10) catch continue;
-            self.markComplete(request_id);
+        if (group_id == self.metadata_group_id) {
+            for (read_states) |read_state| {
+                if (!std.mem.startsWith(u8, read_state.request_ctx, linearizable_metadata_read_prefix)) continue;
+                const suffix = read_state.request_ctx[linearizable_metadata_read_prefix.len..];
+                const request_id = std.fmt.parseUnsigned(u64, suffix, 10) catch continue;
+                self.markComplete(request_id);
+            }
         }
         if (self.downstream) |downstream| try downstream.onReadStates(group_id, read_states);
     }
@@ -2194,6 +2197,7 @@ pub const MetadataHttpService = struct {
         errdefer if (read_tracker_owned) alloc.destroy(read_tracker);
         read_tracker.* = .{
             .alloc = alloc,
+            .metadata_group_id = metadata_group_id,
             .downstream = http_deps.read_state_observer,
         };
         http_deps.read_state_observer = read_tracker.observer();
@@ -8946,13 +8950,29 @@ test "metadata service committed metadata changes request lifecycle reconcile ho
 }
 
 test "linearizable metadata read tracker completes only matching request" {
-    var tracker = LinearizableMetadataReadTracker{ .alloc = std.testing.allocator };
+    var tracker = LinearizableMetadataReadTracker{
+        .alloc = std.testing.allocator,
+        .metadata_group_id = 42,
+    };
     defer tracker.deinit();
 
     const first_id = try tracker.registerRequest();
     const second_id = try tracker.registerRequest();
 
-    tracker.markComplete(second_id);
+    const second_ctx = try std.fmt.allocPrint(std.testing.allocator, "{s}{d}", .{ linearizable_metadata_read_prefix, second_id });
+    defer std.testing.allocator.free(second_ctx);
+
+    try tracker.observer().onReadStates(43, &.{.{
+        .index = 1,
+        .request_ctx = second_ctx,
+    }});
+    try std.testing.expect(!tracker.isComplete(first_id));
+    try std.testing.expect(!tracker.isComplete(second_id));
+
+    try tracker.observer().onReadStates(42, &.{.{
+        .index = 1,
+        .request_ctx = second_ctx,
+    }});
 
     try std.testing.expect(!tracker.isComplete(first_id));
     try std.testing.expect(tracker.isComplete(second_id));

--- a/zig/pkg/antfly/src/metadata/service.zig
+++ b/zig/pkg/antfly/src/metadata/service.zig
@@ -39,6 +39,7 @@ const raft_catalog = @import("../raft/catalog.zig");
 const raft_host = @import("../raft/host.zig");
 const raft_managed_host = @import("../raft/managed_host.zig");
 const raft_service = @import("../raft/service.zig");
+const raft_state_machine = @import("../raft/state_machine/mod.zig");
 const http_common = @import("../raft/transport/http_common.zig");
 const api_table_catalog = @import("../api/table_catalog.zig");
 const api_table_router = @import("../api/table_router.zig");
@@ -51,6 +52,8 @@ const foreign_mod = @import("../foreign/mod.zig");
 
 const cdc_replication_round_interval_ms: u64 = 1_000;
 const metadata_run_round_slow_phase_threshold_ns: u64 = 500 * std.time.ns_per_ms;
+const linearizable_metadata_read_prefix = "metadata:linearizable-read:";
+const linearizable_metadata_read_timeout_ns: u64 = 5 * std.time.ns_per_s;
 
 fn logMetadataRunRoundPhase(name: []const u8, start_ns: u64) void {
     const elapsed_ns = platform_time.monotonicNs() -| start_ns;
@@ -276,6 +279,70 @@ pub const MetadataHttpServiceDeps = struct {
 };
 
 pub const MetadataStatus = metadata_api.MetadataStatus;
+
+const LinearizableMetadataReadTracker = struct {
+    alloc: std.mem.Allocator,
+    mutex: std.Io.Mutex = .init,
+    next_request_id: std.atomic.Value(u64) = .init(1),
+    requests: std.AutoHashMapUnmanaged(u64, bool) = .empty,
+    downstream: ?raft_state_machine.ReadStateObserver = null,
+
+    fn deinit(self: *@This()) void {
+        self.requests.deinit(self.alloc);
+        self.* = undefined;
+    }
+
+    fn observer(self: *@This()) raft_state_machine.ReadStateObserver {
+        return .{
+            .ptr = self,
+            .vtable = &.{
+                .on_read_states = onReadStates,
+            },
+        };
+    }
+
+    fn registerRequest(self: *@This()) !u64 {
+        const request_id = self.next_request_id.fetchAdd(1, .monotonic);
+        self.mutex.lockUncancelable(std.Options.debug_io);
+        defer self.mutex.unlock(std.Options.debug_io);
+        try self.requests.put(self.alloc, request_id, false);
+        return request_id;
+    }
+
+    fn isComplete(self: *@This(), request_id: u64) bool {
+        self.mutex.lockUncancelable(std.Options.debug_io);
+        defer self.mutex.unlock(std.Options.debug_io);
+        return if (self.requests.get(request_id)) |complete| complete else false;
+    }
+
+    fn markComplete(self: *@This(), request_id: u64) void {
+        self.mutex.lockUncancelable(std.Options.debug_io);
+        defer self.mutex.unlock(std.Options.debug_io);
+        if (self.requests.getPtr(request_id)) |complete| complete.* = true;
+    }
+
+    fn finishRequest(self: *@This(), request_id: u64) void {
+        self.mutex.lockUncancelable(std.Options.debug_io);
+        defer self.mutex.unlock(std.Options.debug_io);
+        _ = self.requests.remove(request_id);
+    }
+
+    fn onReadStates(
+        ptr: *anyopaque,
+        group_id: raft_engine.core.types.GroupId,
+        read_states: []const raft_engine.core.ReadState,
+    ) !void {
+        const self: *@This() = @ptrCast(@alignCast(ptr));
+        for (read_states) |read_state| {
+            if (!std.mem.startsWith(u8, read_state.request_ctx, linearizable_metadata_read_prefix)) continue;
+            const suffix = read_state.request_ctx[linearizable_metadata_read_prefix.len..];
+            const request_id = std.fmt.parseUnsigned(u64, suffix, 10) catch continue;
+            self.markComplete(request_id);
+        }
+        if (self.downstream) |downstream| try downstream.onReadStates(group_id, read_states);
+    }
+};
+
 // Backfill marker discovery does not need sub-second polling when the system is
 // otherwise idle. Keep active-marker refreshes fast, but back off empty-root
 // probes so they do not add filesystem churn on the read hot path.
@@ -958,6 +1025,10 @@ pub const MetadataService = struct {
         }
         if (self.backend_runtime) |runtime| return runtime;
         unreachable;
+    }
+
+    pub fn ensureLinearizableRead(self: *MetadataService) !void {
+        _ = self;
     }
 
     pub fn lifecycleSignalCurrent(self: *const MetadataService) u32 {
@@ -2097,6 +2168,7 @@ pub const MetadataHttpService = struct {
     backend_runtime: ?*backend_runtime_mod.BackendRuntime = null,
     owned_backend_runtime: ?backend_runtime_mod.BackendRuntimeHandle = null,
     metadata_orchestration_urls: []MetadataOrchestrationUrl = &.{},
+    linearizable_read_tracker: *LinearizableMetadataReadTracker,
     json_response_calls: std.atomic.Value(u64) = .init(0),
     json_response_bytes_total: std.atomic.Value(u64) = .init(0),
     json_response_peak_bytes: std.atomic.Value(u64) = .init(0),
@@ -2117,6 +2189,14 @@ pub const MetadataHttpService = struct {
         };
         var http_deps = deps.http;
         http_deps.http.backend_runtime = backend_runtime;
+        const read_tracker = try alloc.create(LinearizableMetadataReadTracker);
+        var read_tracker_owned = true;
+        errdefer if (read_tracker_owned) alloc.destroy(read_tracker);
+        read_tracker.* = .{
+            .alloc = alloc,
+            .downstream = http_deps.read_state_observer,
+        };
+        http_deps.read_state_observer = read_tracker.observer();
         var service = MetadataHttpService{
             .alloc = alloc,
             .metadata_group_id = metadata_group_id,
@@ -2140,8 +2220,10 @@ pub const MetadataHttpService = struct {
             .owned_backend_runtime = owned_backend_runtime,
             .secret_store = cfg.secret_store,
             .metadata_orchestration_urls = try cloneMetadataOrchestrationUrls(alloc, cfg.metadata_orchestration_urls),
+            .linearizable_read_tracker = read_tracker,
             .raft = try raft_service.ManagedHttpHostService.init(alloc, host_cfg, http_deps, cfg.raft, deps.raft),
         };
+        read_tracker_owned = false;
         owned_backend_runtime = null;
         errdefer service.deinit();
         try foreign_mod.registerDefaultPostgresExecutor(alloc, &service.cdc_backfill_registry);
@@ -2155,6 +2237,8 @@ pub const MetadataHttpService = struct {
         self.lifecycle_signal.deinit();
         freeMetadataOrchestrationUrls(self.alloc, self.metadata_orchestration_urls);
         self.raft.deinit();
+        self.linearizable_read_tracker.deinit();
+        self.alloc.destroy(self.linearizable_read_tracker);
         if (self.replica_root_dir) |replica_root_dir| {
             api_table_writes.closeHostedManagedDbCacheForRoot(replica_root_dir);
         }
@@ -2843,6 +2927,41 @@ pub const MetadataHttpService = struct {
         current_status.metadata_epoch = self.lifecycle_signal.currentEpoch();
         current_status.metrics = self.metrics();
         return current_status;
+    }
+
+    pub fn ensureLinearizableRead(self: *MetadataHttpService) !void {
+        const request_id = try self.linearizable_read_tracker.registerRequest();
+        defer self.linearizable_read_tracker.finishRequest(request_id);
+        var request_ctx_buf: [64]u8 = undefined;
+        const request_ctx = try std.fmt.bufPrint(
+            &request_ctx_buf,
+            "{s}{d}",
+            .{ linearizable_metadata_read_prefix, request_id },
+        );
+
+        self.lockRuntime();
+        {
+            defer self.unlockRuntime();
+            try self.raft.requestReadableLease(self.metadata_group_id, request_ctx);
+        }
+
+        const deadline_ns = platform_time.monotonicNs() + linearizable_metadata_read_timeout_ns;
+        while (platform_time.monotonicNs() < deadline_ns) {
+            if (self.linearizable_read_tracker.isComplete(request_id)) return;
+            self.lockRuntime();
+            {
+                defer self.unlockRuntime();
+                if (self.raft.pending_updates.items.len > 0) {
+                    _ = try self.raft.syncPendingRaftOnly();
+                } else {
+                    try self.raft.runRaftRoundOnly();
+                }
+            }
+            if (self.linearizable_read_tracker.isComplete(request_id)) return;
+            platform_clock.Clock.real().sleepMs(1);
+        }
+        if (self.linearizable_read_tracker.isComplete(request_id)) return;
+        return error.MetadataLinearizableReadTimeout;
     }
 
     pub fn adminSnapshot(self: *MetadataHttpService) !metadata_api.AdminSnapshot {
@@ -8824,6 +8943,22 @@ test "metadata service committed metadata changes request lifecycle reconcile ho
     try svc.requestReallocation(1);
     try runServiceRounds(&svc, 8);
     try std.testing.expect(capture.calls >= 1);
+}
+
+test "linearizable metadata read tracker completes only matching request" {
+    var tracker = LinearizableMetadataReadTracker{ .alloc = std.testing.allocator };
+    defer tracker.deinit();
+
+    const first_id = try tracker.registerRequest();
+    const second_id = try tracker.registerRequest();
+
+    tracker.markComplete(second_id);
+
+    try std.testing.expect(!tracker.isComplete(first_id));
+    try std.testing.expect(tracker.isComplete(second_id));
+
+    tracker.finishRequest(first_id);
+    tracker.finishRequest(second_id);
 }
 
 test "metadata service clears restore intent once all placement replicas report restore progress" {

--- a/zig/pkg/antfly/src/metadata/sim_harness.zig
+++ b/zig/pkg/antfly/src/metadata/sim_harness.zig
@@ -5687,6 +5687,7 @@ test "metadata http cluster simulation forwards public split flow from a non-hos
     var status_sources: [4]PublicApiStatusSource = undefined;
     var catalog_sources: [4]PublicApiCatalogSource = undefined;
     var routers: [4]PublicApiRouter(4) = undefined;
+    var forwarders: [4]PublicApiMetadataForwarder(4) = undefined;
     var read_sources: [4]api_table_reads.HostedProvisionedTableReadSource = undefined;
     var write_sources: [4]api_table_writes.HostedProvisionedTableWriteSource = undefined;
     var api_base_uris: [4][]const u8 = undefined;
@@ -5708,6 +5709,7 @@ test "metadata http cluster simulation forwards public split flow from a non-hos
         &status_sources,
         &catalog_sources,
         &routers,
+        &forwarders,
         &read_sources,
         &write_sources,
         .{},
@@ -5888,6 +5890,7 @@ test "metadata http cluster simulation forwards public merge flow from a non-hos
     var status_sources: [4]PublicApiStatusSource = undefined;
     var catalog_sources: [4]PublicApiCatalogSource = undefined;
     var routers: [4]PublicApiRouter(4) = undefined;
+    var forwarders: [4]PublicApiMetadataForwarder(4) = undefined;
     var read_sources: [4]api_table_reads.HostedProvisionedTableReadSource = undefined;
     var write_sources: [4]api_table_writes.HostedProvisionedTableWriteSource = undefined;
     var api_base_uris: [4][]const u8 = undefined;
@@ -5909,6 +5912,7 @@ test "metadata http cluster simulation forwards public merge flow from a non-hos
         &status_sources,
         &catalog_sources,
         &routers,
+        &forwarders,
         &read_sources,
         &write_sources,
         .{},

--- a/zig/pkg/antfly/src/metadata/sim_harness.zig
+++ b/zig/pkg/antfly/src/metadata/sim_harness.zig
@@ -25,7 +25,6 @@ const metadata_store_observer = @import("store_observer.zig");
 const metadata_storage = @import("storage/mod.zig");
 const metadata_table_manager = @import("table_manager.zig");
 const metadata_table_workflow = @import("table_workflow.zig");
-const backups_api = @import("../api/backups.zig");
 const api_http_client = @import("../api/http_client.zig");
 const api_http_routes = @import("../api/http_routes.zig");
 const api_http_server = @import("../api/http_server.zig");
@@ -5511,122 +5510,6 @@ test "metadata http cluster simulation serves public lifecycle from a non-host n
     var parsed_tables_after_drop = try std.json.parseFromSlice([]TableListEntry, std.heap.page_allocator, listed_tables_after_drop.body, .{ .ignore_unknown_fields = true });
     defer parsed_tables_after_drop.deinit();
     try std.testing.expectEqual(@as(usize, 0), parsed_tables_after_drop.value.len);
-}
-
-test "metadata follower public cluster backup forwards to metadata leader" {
-    var sim_alloc_state: LeanSimAllocator = .init;
-    defer _ = sim_alloc_state.deinit();
-    const sim_alloc = sim_alloc_state.allocator();
-
-    var tmp = std.testing.tmpDir(.{});
-    defer tmp.cleanup();
-
-    var store_a = raft_engine.core.MemoryStorage.init(sim_alloc);
-    defer store_a.deinit();
-    var store_b = raft_engine.core.MemoryStorage.init(sim_alloc);
-    defer store_b.deinit();
-    var store_c = raft_engine.core.MemoryStorage.init(sim_alloc);
-    defer store_c.deinit();
-
-    var factory_a = TestDescriptorFactory{ .alloc = sim_alloc, .store = &store_a, .peers = &.{ 1, 2, 3 } };
-    var factory_b = TestDescriptorFactory{ .alloc = sim_alloc, .store = &store_b, .peers = &.{ 1, 2, 3 } };
-    var factory_c = TestDescriptorFactory{ .alloc = sim_alloc, .store = &store_c, .peers = &.{ 1, 2, 3 } };
-
-    const root_a = try std.fmt.allocPrint(sim_alloc, ".zig-cache/tmp/{s}/meta-sim-backup-forward-a", .{tmp.sub_path});
-    defer sim_alloc.free(root_a);
-    const root_b = try std.fmt.allocPrint(sim_alloc, ".zig-cache/tmp/{s}/meta-sim-backup-forward-b", .{tmp.sub_path});
-    defer sim_alloc.free(root_b);
-    const root_c = try std.fmt.allocPrint(sim_alloc, ".zig-cache/tmp/{s}/meta-sim-backup-forward-c", .{tmp.sub_path});
-    defer sim_alloc.free(root_c);
-    const cat_a = try std.fmt.allocPrint(sim_alloc, ".zig-cache/tmp/{s}/meta-sim-backup-forward-a.txt", .{tmp.sub_path});
-    defer sim_alloc.free(cat_a);
-    const cat_b = try std.fmt.allocPrint(sim_alloc, ".zig-cache/tmp/{s}/meta-sim-backup-forward-b.txt", .{tmp.sub_path});
-    defer sim_alloc.free(cat_b);
-    const cat_c = try std.fmt.allocPrint(sim_alloc, ".zig-cache/tmp/{s}/meta-sim-backup-forward-c.txt", .{tmp.sub_path});
-    defer sim_alloc.free(cat_c);
-
-    const configs = [_]raft_sim.ManagedHttpHostSimulationConfig{
-        makeHostSimConfig(1, 4870, root_a, cat_a),
-        makeHostSimConfig(2, 4870, root_b, cat_b),
-        makeHostSimConfig(3, 4870, root_c, cat_c),
-    };
-    const deps = [_]raft_sim.ManagedHttpHostSimulationDeps{
-        makeHostSimDeps(&factory_a),
-        makeHostSimDeps(&factory_b),
-        makeHostSimDeps(&factory_c),
-    };
-
-    var cluster = try MetadataHttpClusterSimulation.init(sim_alloc, 4870, configs[0..], deps[0..]);
-    defer cluster.deinit();
-    try cluster.startAll();
-    defer cluster.stopAll();
-    try cluster.bootstrapMetadataReplicas();
-    const metadata_leader_index = (try cluster.waitForMetadataLeader(24)) orelse return error.TestExpectedEqual;
-    try cluster.node(metadata_leader_index).campaignMetadataGroup();
-    try cluster.stepAll();
-    try cluster.publishClusterNodes(metadata_leader_index);
-    try cluster.publishClusterStores(metadata_leader_index);
-
-    const roots = [_][]const u8{ root_a, root_b, root_c };
-    var public_api: PublicApiTestRig(3) = undefined;
-    try public_api.initLeaderBackedInPlace(sim_alloc, &cluster, roots);
-    defer public_api.deinit();
-
-    var client = public_api.client;
-    const create_body = try test_contract_helpers.encodeCreateTableRequest(std.heap.page_allocator, "backup forwarding docs");
-    defer std.heap.page_allocator.free(create_body);
-    var created = try client.createTable(public_api.api_base_uris[metadata_leader_index], "docs", create_body);
-    defer created.deinit(std.heap.page_allocator);
-
-    const created_range = try waitForFirstProjectedRange(&cluster, metadata_leader_index, null, null, false, 48);
-    try std.testing.expect(created_range.active_count >= 1);
-    const group_leader_index = (try waitForGroupLeaderIndex(&cluster, created_range.group_id, 96)) orelse return error.TestExpectedEqual;
-
-    const batch_body = try test_contract_helpers.normalizeBatchRequest(std.heap.page_allocator,
-        \\{"inserts":{"doc:a":{"title":"alpha","body":"backup follower forwarding"}}}
-    );
-    defer std.heap.page_allocator.free(batch_body);
-    var batch = try client.fetchBatch(public_api.api_base_uris[group_leader_index], "docs", batch_body);
-    defer batch.deinit(std.heap.page_allocator);
-    try std.testing.expect(std.mem.indexOf(u8, batch.body, "\"inserted\":1") != null);
-
-    const current_leader_index = currentMetadataLeaderIndex(&cluster) orelse metadata_leader_index;
-    const follower_index: usize = if (current_leader_index == 0) 1 else 0;
-    const backup_id = "follower-public-cluster-backup";
-    var backup_io = std.Io.Threaded.init(sim_alloc, .{});
-    defer backup_io.deinit();
-    const cwd_tmp = try std.Io.Dir.cwd().realPathFileAlloc(backup_io.io(), ".zig-cache/tmp", sim_alloc);
-    defer sim_alloc.free(cwd_tmp);
-    const backup_root = try std.fs.path.join(sim_alloc, &.{ cwd_tmp, tmp.sub_path[0..], "backup-forward" });
-    defer sim_alloc.free(backup_root);
-    try std.Io.Dir.cwd().createDirPath(backup_io.io(), backup_root);
-    const backup_location = try std.fmt.allocPrint(sim_alloc, "file://{s}", .{backup_root});
-    defer sim_alloc.free(backup_location);
-    const backup_body = try std.fmt.allocPrint(sim_alloc, "{{\"backup_id\":\"{s}\",\"location\":\"{s}\"}}", .{ backup_id, backup_location });
-    defer sim_alloc.free(backup_body);
-
-    const backup_uri = try std.fmt.allocPrint(sim_alloc, "{s}{s}", .{ public_api.api_base_uris[follower_index], api_http_routes.Routes.backup });
-    defer sim_alloc.free(backup_uri);
-    var backup = try public_api.client_executor.executor().execute(std.heap.page_allocator, .{
-        .method = .POST,
-        .uri = backup_uri,
-        .content_type = "application/json",
-        .body = backup_body,
-    });
-    defer backup.deinit(std.heap.page_allocator);
-    if (backup.status != 200) {
-        std.debug.print("backup through follower failed status={d} body={s}\n", .{ backup.status, backup.body });
-    }
-    try std.testing.expectEqual(@as(u16, 200), backup.status);
-    try std.testing.expect(std.mem.indexOf(u8, backup.body, "\"backup_id\":\"follower-public-cluster-backup\"") != null);
-    try std.testing.expect(std.mem.indexOf(u8, backup.body, "\"name\":\"docs\"") != null);
-    try std.testing.expect(public_api.forwarders[follower_index].forward_count.load(.monotonic) > 0);
-
-    var location = try backups_api.openBackupLocation(sim_alloc, backup_location);
-    defer location.deinit(sim_alloc);
-    var manifest = try backups_api.readClusterManifestFromLocation(sim_alloc, &location, backup_id);
-    defer manifest.deinit(sim_alloc);
-    try std.testing.expectEqualStrings(backup_id, manifest.backup_id);
 }
 
 test "metadata http cluster simulation seeds default admin for auth-enabled public api" {

--- a/zig/pkg/antfly/src/metadata/sim_harness.zig
+++ b/zig/pkg/antfly/src/metadata/sim_harness.zig
@@ -25,6 +25,7 @@ const metadata_store_observer = @import("store_observer.zig");
 const metadata_storage = @import("storage/mod.zig");
 const metadata_table_manager = @import("table_manager.zig");
 const metadata_table_workflow = @import("table_workflow.zig");
+const backups_api = @import("../api/backups.zig");
 const api_http_client = @import("../api/http_client.zig");
 const api_http_routes = @import("../api/http_routes.zig");
 const api_http_server = @import("../api/http_server.zig");
@@ -48,6 +49,7 @@ const transition_runtime = @import("../raft/transition_runtime.zig");
 const transition_state = @import("transition_state.zig");
 const raft_engine = @import("raft_engine");
 const data_mod = @import("../data/mod.zig");
+const http_common = @import("../raft/transport/http_common.zig");
 const std_http_executor = @import("../raft/transport/std_http_executor.zig");
 const std_http_listener = @import("../raft/transport/std_http_listener.zig");
 const docstore_mod = @import("../storage/docstore.zig");
@@ -4305,6 +4307,42 @@ fn PublicApiRouter(comptime N: usize) type {
     };
 }
 
+fn PublicApiMetadataForwarder(comptime N: usize) type {
+    return struct {
+        node: MetadataHttpNodeSimulation,
+        cluster: *MetadataHttpClusterSimulation,
+        api_base_uris: *const [N][]const u8,
+        executor: http_common.RequestExecutor,
+        forward_count: std.atomic.Value(u64) = .init(0),
+
+        fn iface(self: *@This()) api_http_server.RequestForwarder {
+            return .{
+                .ptr = self,
+                .vtable = &.{ .forward = forward },
+            };
+        }
+
+        fn forward(ptr: *anyopaque, alloc: std.mem.Allocator, req: http_common.HttpRequest) !?http_common.HttpResponse {
+            const self: *@This() = @ptrCast(@alignCast(ptr));
+            const leader_index = currentMetadataLeaderIndex(self.cluster) orelse return null;
+            const leader_node_id = @as(u64, @intCast(leader_index + 1));
+            const local_node_id = @as(u64, @intCast(self.node.index + 1));
+            if (leader_node_id == local_node_id) return null;
+            const uri = try std.fmt.allocPrint(alloc, "{s}{s}", .{ self.api_base_uris[leader_index], req.uri });
+            defer alloc.free(uri);
+            _ = self.forward_count.fetchAdd(1, .monotonic);
+            return try self.executor.execute(alloc, .{
+                .method = req.method,
+                .uri = uri,
+                .source_node_id = local_node_id,
+                .authorization = req.authorization,
+                .content_type = req.content_type,
+                .body = req.body,
+            });
+        }
+    };
+}
+
 const SimAuthManager = struct {
     store: usermgr.MemoryStore,
     policy_store: casbin.MemoryAdapter,
@@ -4367,6 +4405,7 @@ fn startPublicApiServers(
     status_sources: *[N]PublicApiStatusSource,
     catalog_sources: *[N]PublicApiCatalogSource,
     routers: *[N]PublicApiRouter(N),
+    forwarders: *[N]PublicApiMetadataForwarder(N),
     read_sources: *[N]api_table_reads.HostedProvisionedTableReadSource,
     write_sources: *[N]api_table_writes.HostedProvisionedTableWriteSource,
     options: PublicApiServerOptions(N),
@@ -4382,6 +4421,7 @@ fn startPublicApiServers(
         status_sources[i] = .{ .node = cluster.node(i), .metadata_snapshot_mode = metadata_snapshot_mode };
         catalog_sources[i] = .{ .node = cluster.node(i), .metadata_snapshot_mode = metadata_snapshot_mode };
         routers[i] = .{ .node = cluster.node(i), .cluster = cluster, .api_base_uris = api_base_uris };
+        forwarders[i] = .{ .node = cluster.node(i), .cluster = cluster, .api_base_uris = api_base_uris, .executor = forward_executor.executor() };
         read_sources[i] = api_table_reads.HostedProvisionedTableReadSource.init(
             roots[i],
             catalog_sources[i].iface(),
@@ -4397,10 +4437,11 @@ fn startPublicApiServers(
             forward_executor.executor(),
         );
         attachHostedSourcesBackendRuntimeForSimulation(&read_sources[i], &write_sources[i], cluster.backendRuntime(i));
-        const server_config: api_http_server.ApiHttpServerConfig = if (options.auth_managers) |auth_managers| .{
+        var server_config: api_http_server.ApiHttpServerConfig = if (options.auth_managers) |auth_managers| .{
             .auth_enabled = true,
             .user_manager = &auth_managers[i].manager,
         } else .{};
+        server_config.metadata_mutation_forwarder = forwarders[i].iface();
         servers[i] = api_http_server.ApiHttpServer.init(
             alloc,
             server_config,
@@ -4461,6 +4502,7 @@ fn PublicApiTestRig(comptime N: usize) type {
         status_sources: [N]PublicApiStatusSource = undefined,
         catalog_sources: [N]PublicApiCatalogSource = undefined,
         routers: [N]PublicApiRouter(N) = undefined,
+        forwarders: [N]PublicApiMetadataForwarder(N) = undefined,
         read_sources: [N]api_table_reads.HostedProvisionedTableReadSource = undefined,
         write_sources: [N]api_table_writes.HostedProvisionedTableWriteSource = undefined,
         api_base_uris: [N][]const u8 = undefined,
@@ -4535,6 +4577,7 @@ fn PublicApiTestRig(comptime N: usize) type {
                 &self.status_sources,
                 &self.catalog_sources,
                 &self.routers,
+                &self.forwarders,
                 &self.read_sources,
                 &self.write_sources,
                 options,
@@ -5468,6 +5511,122 @@ test "metadata http cluster simulation serves public lifecycle from a non-host n
     var parsed_tables_after_drop = try std.json.parseFromSlice([]TableListEntry, std.heap.page_allocator, listed_tables_after_drop.body, .{ .ignore_unknown_fields = true });
     defer parsed_tables_after_drop.deinit();
     try std.testing.expectEqual(@as(usize, 0), parsed_tables_after_drop.value.len);
+}
+
+test "metadata follower public cluster backup forwards to metadata leader" {
+    var sim_alloc_state: LeanSimAllocator = .init;
+    defer _ = sim_alloc_state.deinit();
+    const sim_alloc = sim_alloc_state.allocator();
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    var store_a = raft_engine.core.MemoryStorage.init(sim_alloc);
+    defer store_a.deinit();
+    var store_b = raft_engine.core.MemoryStorage.init(sim_alloc);
+    defer store_b.deinit();
+    var store_c = raft_engine.core.MemoryStorage.init(sim_alloc);
+    defer store_c.deinit();
+
+    var factory_a = TestDescriptorFactory{ .alloc = sim_alloc, .store = &store_a, .peers = &.{ 1, 2, 3 } };
+    var factory_b = TestDescriptorFactory{ .alloc = sim_alloc, .store = &store_b, .peers = &.{ 1, 2, 3 } };
+    var factory_c = TestDescriptorFactory{ .alloc = sim_alloc, .store = &store_c, .peers = &.{ 1, 2, 3 } };
+
+    const root_a = try std.fmt.allocPrint(sim_alloc, ".zig-cache/tmp/{s}/meta-sim-backup-forward-a", .{tmp.sub_path});
+    defer sim_alloc.free(root_a);
+    const root_b = try std.fmt.allocPrint(sim_alloc, ".zig-cache/tmp/{s}/meta-sim-backup-forward-b", .{tmp.sub_path});
+    defer sim_alloc.free(root_b);
+    const root_c = try std.fmt.allocPrint(sim_alloc, ".zig-cache/tmp/{s}/meta-sim-backup-forward-c", .{tmp.sub_path});
+    defer sim_alloc.free(root_c);
+    const cat_a = try std.fmt.allocPrint(sim_alloc, ".zig-cache/tmp/{s}/meta-sim-backup-forward-a.txt", .{tmp.sub_path});
+    defer sim_alloc.free(cat_a);
+    const cat_b = try std.fmt.allocPrint(sim_alloc, ".zig-cache/tmp/{s}/meta-sim-backup-forward-b.txt", .{tmp.sub_path});
+    defer sim_alloc.free(cat_b);
+    const cat_c = try std.fmt.allocPrint(sim_alloc, ".zig-cache/tmp/{s}/meta-sim-backup-forward-c.txt", .{tmp.sub_path});
+    defer sim_alloc.free(cat_c);
+
+    const configs = [_]raft_sim.ManagedHttpHostSimulationConfig{
+        makeHostSimConfig(1, 4870, root_a, cat_a),
+        makeHostSimConfig(2, 4870, root_b, cat_b),
+        makeHostSimConfig(3, 4870, root_c, cat_c),
+    };
+    const deps = [_]raft_sim.ManagedHttpHostSimulationDeps{
+        makeHostSimDeps(&factory_a),
+        makeHostSimDeps(&factory_b),
+        makeHostSimDeps(&factory_c),
+    };
+
+    var cluster = try MetadataHttpClusterSimulation.init(sim_alloc, 4870, configs[0..], deps[0..]);
+    defer cluster.deinit();
+    try cluster.startAll();
+    defer cluster.stopAll();
+    try cluster.bootstrapMetadataReplicas();
+    const metadata_leader_index = (try cluster.waitForMetadataLeader(24)) orelse return error.TestExpectedEqual;
+    try cluster.node(metadata_leader_index).campaignMetadataGroup();
+    try cluster.stepAll();
+    try cluster.publishClusterNodes(metadata_leader_index);
+    try cluster.publishClusterStores(metadata_leader_index);
+
+    const roots = [_][]const u8{ root_a, root_b, root_c };
+    var public_api: PublicApiTestRig(3) = undefined;
+    try public_api.initLeaderBackedInPlace(sim_alloc, &cluster, roots);
+    defer public_api.deinit();
+
+    var client = public_api.client;
+    const create_body = try test_contract_helpers.encodeCreateTableRequest(std.heap.page_allocator, "backup forwarding docs");
+    defer std.heap.page_allocator.free(create_body);
+    var created = try client.createTable(public_api.api_base_uris[metadata_leader_index], "docs", create_body);
+    defer created.deinit(std.heap.page_allocator);
+
+    const created_range = try waitForFirstProjectedRange(&cluster, metadata_leader_index, null, null, false, 48);
+    try std.testing.expect(created_range.active_count >= 1);
+    const group_leader_index = (try waitForGroupLeaderIndex(&cluster, created_range.group_id, 96)) orelse return error.TestExpectedEqual;
+
+    const batch_body = try test_contract_helpers.normalizeBatchRequest(std.heap.page_allocator,
+        \\{"inserts":{"doc:a":{"title":"alpha","body":"backup follower forwarding"}}}
+    );
+    defer std.heap.page_allocator.free(batch_body);
+    var batch = try client.fetchBatch(public_api.api_base_uris[group_leader_index], "docs", batch_body);
+    defer batch.deinit(std.heap.page_allocator);
+    try std.testing.expect(std.mem.indexOf(u8, batch.body, "\"inserted\":1") != null);
+
+    const current_leader_index = currentMetadataLeaderIndex(&cluster) orelse metadata_leader_index;
+    const follower_index: usize = if (current_leader_index == 0) 1 else 0;
+    const backup_id = "follower-public-cluster-backup";
+    var backup_io = std.Io.Threaded.init(sim_alloc, .{});
+    defer backup_io.deinit();
+    const cwd_tmp = try std.Io.Dir.cwd().realPathFileAlloc(backup_io.io(), ".zig-cache/tmp", sim_alloc);
+    defer sim_alloc.free(cwd_tmp);
+    const backup_root = try std.fs.path.join(sim_alloc, &.{ cwd_tmp, tmp.sub_path[0..], "backup-forward" });
+    defer sim_alloc.free(backup_root);
+    try std.Io.Dir.cwd().createDirPath(backup_io.io(), backup_root);
+    const backup_location = try std.fmt.allocPrint(sim_alloc, "file://{s}", .{backup_root});
+    defer sim_alloc.free(backup_location);
+    const backup_body = try std.fmt.allocPrint(sim_alloc, "{{\"backup_id\":\"{s}\",\"location\":\"{s}\"}}", .{ backup_id, backup_location });
+    defer sim_alloc.free(backup_body);
+
+    const backup_uri = try std.fmt.allocPrint(sim_alloc, "{s}{s}", .{ public_api.api_base_uris[follower_index], api_http_routes.Routes.backup });
+    defer sim_alloc.free(backup_uri);
+    var backup = try public_api.client_executor.executor().execute(std.heap.page_allocator, .{
+        .method = .POST,
+        .uri = backup_uri,
+        .content_type = "application/json",
+        .body = backup_body,
+    });
+    defer backup.deinit(std.heap.page_allocator);
+    if (backup.status != 200) {
+        std.debug.print("backup through follower failed status={d} body={s}\n", .{ backup.status, backup.body });
+    }
+    try std.testing.expectEqual(@as(u16, 200), backup.status);
+    try std.testing.expect(std.mem.indexOf(u8, backup.body, "\"backup_id\":\"follower-public-cluster-backup\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, backup.body, "\"name\":\"docs\"") != null);
+    try std.testing.expect(public_api.forwarders[follower_index].forward_count.load(.monotonic) > 0);
+
+    var location = try backups_api.openBackupLocation(sim_alloc, backup_location);
+    defer location.deinit(sim_alloc);
+    var manifest = try backups_api.readClusterManifestFromLocation(sim_alloc, &location, backup_id);
+    defer manifest.deinit(sim_alloc);
+    try std.testing.expectEqualStrings(backup_id, manifest.backup_id);
 }
 
 test "metadata http cluster simulation seeds default admin for auth-enabled public api" {

--- a/zig/pkg/antfly/src/serverless/api/http_handler.zig
+++ b/zig/pkg/antfly/src/serverless/api/http_handler.zig
@@ -4353,6 +4353,7 @@ pub const HttpHandler = struct {
         _: []const u8,
         _: []const u8,
         _: backups_api.BackupFormat,
+        _: []const u8,
         _: *backups_api.BackupLocation,
     ) public_table_http.TableApi.ExecuteBackupError!void {
         return error.MethodNotAllowed;

--- a/zig/pkg/antfly/src/storage/db/db.zig
+++ b/zig/pkg/antfly/src/storage/db/db.zig
@@ -30215,7 +30215,11 @@ test "db resolver removal retires resolution artifacts and mention graph state" 
     var sink = FakePromotionSink{ .alloc = alloc };
     defer sink.deinit();
 
-    var db = try DB.open(alloc, std.mem.span(path), .{ .entity_sink = sink.sink() });
+    var db = try DB.open(alloc, std.mem.span(path), .{
+        .executor = .{ .backend = .manual },
+        .start_index_workers = false,
+        .entity_sink = sink.sink(),
+    });
     defer db.close();
 
     try db.addIndex(.{


### PR DESCRIPTION
## Summary
- add a linearizable metadata read barrier backed by raft read-index for public backup paths
- remove backup-specific metadata leader forwarding while leaving restore forwarding in place for metadata intent writes
- preserve delegated backup support for data-owner backups and add a multi-metadata follower backup e2e
- track read-index completions per request so concurrent backup requests cannot satisfy each other's barrier

## Tests
- zig build lib-metadata-test -- --test-filter "linearizable metadata read tracker completes only matching request"
- zig build root-test -- --test-filter "api http server backs up and restores a table through public routes"
- zig build lib-metadata-test -- --test-filter "metadata admin mux routes public db v1 requests through public api server"
- zig build
- ANTFLY_BIN=./zig-out/bin/antfly uv run --project e2e/antfly pytest -q -s e2e/antfly/test_backup_restore.py -k metadata_follower
- git diff --check