### PR TITLE
Fix HTTP raft snapshot catch-up

### DIFF
--- a/zig/lib/raft/src/runtime/multi_raft.zig
+++ b/zig/lib/raft/src/runtime/multi_raft.zig
@@ -876,6 +876,7 @@ const TransportOutbox = struct {
                 const snapshot = item.message.snapshot orelse return error.MissingSnapshot;
                 try snapshot_transport.sendSnapshot(.{
                     .group_id = item.group_id,
+                    .from = item.message.from,
                     .to = item.message.to,
                     .term = item.message.term,
                     .snapshot = snapshot,

--- a/zig/lib/raft/src/runtime/snapshot_transport_iface.zig
+++ b/zig/lib/raft/src/runtime/snapshot_transport_iface.zig
@@ -22,6 +22,7 @@ pub const SnapshotLocator = struct {
 
 pub const SnapshotSendRequest = struct {
     group_id: core.types.GroupId,
+    from: core.types.NodeId = 0,
     to: core.types.NodeId,
     term: core.types.Term = 0,
     snapshot: core.types.Snapshot,

--- a/zig/pkg/antfly/src/common/http/std_http_listener.zig
+++ b/zig/pkg/antfly/src/common/http/std_http_listener.zig
@@ -557,6 +557,7 @@ test "std http listener and executor round-trip raft batch route" {
         raft_engine.runtime.BinaryCodec.codec(),
         handler.iface(),
         null,
+        null,
     );
     var listener = StdHttpListener.init(std.testing.allocator, .{}, app.executor());
     defer listener.deinit();
@@ -727,6 +728,7 @@ test "std http listener and executor round-trip snapshot routes" {
         raft_engine.runtime.BinaryCodec.codec(),
         noop.iface(),
         store.iface(),
+        null,
     );
     var listener = StdHttpListener.init(std.testing.allocator, .{}, app.executor());
     defer listener.deinit();

--- a/zig/pkg/antfly/src/metadata/service.zig
+++ b/zig/pkg/antfly/src/metadata/service.zig
@@ -54,6 +54,7 @@ const cdc_replication_round_interval_ms: u64 = 1_000;
 const metadata_run_round_slow_phase_threshold_ns: u64 = 500 * std.time.ns_per_ms;
 const linearizable_metadata_read_prefix = "metadata:linearizable-read:";
 const linearizable_metadata_read_timeout_ns: u64 = 5 * std.time.ns_per_s;
+const linearizable_metadata_read_retry_ns: u64 = 50 * std.time.ns_per_ms;
 
 fn logMetadataRunRoundPhase(name: []const u8, start_ns: u64) void {
     const elapsed_ns = platform_time.monotonicNs() -| start_ns;
@@ -2943,15 +2944,26 @@ pub const MetadataHttpService = struct {
             .{ linearizable_metadata_read_prefix, request_id },
         );
 
-        self.lockRuntime();
-        {
-            defer self.unlockRuntime();
-            try self.raft.requestReadableLease(self.metadata_group_id, request_ctx);
-        }
-
         const deadline_ns = platform_time.monotonicNs() + linearizable_metadata_read_timeout_ns;
+        var next_request_ns: u64 = 0;
         while (platform_time.monotonicNs() < deadline_ns) {
             if (self.linearizable_read_tracker.isComplete(request_id)) return;
+            const now_ns = platform_time.monotonicNs();
+            if (now_ns >= next_request_ns) {
+                self.lockRuntime();
+                {
+                    defer self.unlockRuntime();
+                    self.raft.requestReadableLease(self.metadata_group_id, request_ctx) catch |err| switch (err) {
+                        // A follower may not know the leader yet during elections,
+                        // restarts, or after endpoint-level load balancing. Keep
+                        // driving raft below and retry the same read context until
+                        // the barrier completes or the caller's timeout expires.
+                        error.NotLeader => {},
+                        else => return err,
+                    };
+                }
+                next_request_ns = now_ns + linearizable_metadata_read_retry_ns;
+            }
             self.lockRuntime();
             {
                 defer self.unlockRuntime();
@@ -9221,6 +9233,99 @@ test "metadata http service projected tables cache invalidates without prior run
     defer svc.freeProjectedTables(std.testing.allocator, after);
     try std.testing.expectEqual(@as(usize, 0), after.len);
     try std.testing.expectEqual(epoch_after_signal, svc.projected_core_snapshot_cache.projection_epoch);
+}
+
+test "metadata http service linearizable read waits for leader discovery" {
+    const Factory = struct {
+        alloc: std.mem.Allocator,
+        store: *raft_engine.core.MemoryStorage,
+
+        fn iface(self: *@This()) raft_host.ReplicaDescriptorFactory {
+            return .{ .ptr = self, .vtable = &.{ .build_descriptor = buildDescriptor, .free_descriptor = freeDescriptor } };
+        }
+
+        fn buildDescriptor(ptr: *anyopaque, record: raft_host.catalog.ReplicaRecord) !raft_engine.runtime.ReplicaDescriptor {
+            const self: *@This() = @ptrCast(@alignCast(ptr));
+            const peers = try self.alloc.dupe(raft_engine.core.types.NodeId, &[_]raft_engine.core.types.NodeId{record.local_node_id});
+            return .{
+                .group = .{
+                    .group_id = record.group_id,
+                    .local_node_id = record.local_node_id,
+                    .raft_config = .{
+                        .id = record.local_node_id,
+                        .group_id = record.group_id,
+                        .peers = peers,
+                        .election_tick = 5,
+                        .heartbeat_tick = 1,
+                        .pre_vote = false,
+                        .check_quorum = true,
+                    },
+                    .storage = self.store.storage(),
+                },
+                .bootstrap = switch (record.bootstrap_mode) {
+                    .empty => .empty,
+                    .persisted => .persisted,
+                    .fetch_snapshot => .persisted,
+                },
+            };
+        }
+
+        fn freeDescriptor(ptr: *anyopaque, alloc: std.mem.Allocator, desc: *raft_engine.runtime.ReplicaDescriptor) void {
+            const self: *@This() = @ptrCast(@alignCast(ptr));
+            _ = alloc;
+            self.alloc.free(desc.group.raft_config.peers);
+        }
+    };
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const replica_root = try std.fmt.allocPrint(std.testing.allocator, ".zig-cache/tmp/{s}/metadata-http-service-read-barrier-root", .{tmp.sub_path});
+    defer std.testing.allocator.free(replica_root);
+    const replica_catalog_path = try std.fmt.allocPrint(std.testing.allocator, ".zig-cache/tmp/{s}/metadata-http-service-read-barrier-catalog.txt", .{tmp.sub_path});
+    defer std.testing.allocator.free(replica_catalog_path);
+    const snapshot_root = try std.fmt.allocPrint(std.testing.allocator, ".zig-cache/tmp/{s}/metadata-http-service-read-barrier-snapshots", .{tmp.sub_path});
+    defer std.testing.allocator.free(snapshot_root);
+
+    var store = raft_engine.core.MemoryStorage.init(std.testing.allocator);
+    defer store.deinit();
+    var factory = Factory{ .alloc = std.testing.allocator, .store = &store };
+
+    var svc = try MetadataHttpService.init(std.testing.allocator, .{
+        .http = .{
+            .host = .{
+                .local_node_id = 1,
+                .metadata_group_id = 2910,
+                .replica_root_dir = replica_root,
+                .replica_catalog_path = replica_catalog_path,
+            },
+            .transport = .{
+                .snapshot = .{ .root_dir = snapshot_root },
+            },
+        },
+    }, .{
+        .http = .{
+            .http = .{
+                .host = .{
+                    .descriptor_factory = factory.iface(),
+                },
+            },
+        },
+    }, .{
+        .observe_local_replica_root = false,
+    });
+    defer svc.deinit();
+
+    _ = try svc.ensureMetadataReplica(.{
+        .group_id = 2910,
+        .replica_id = 1,
+        .local_node_id = 1,
+        .bootstrap_mode = .empty,
+    });
+
+    try std.testing.expect(!svc.raft.host.http_host.host.isLocalLeader(2910));
+    try svc.ensureLinearizableRead();
+    try std.testing.expect(svc.raft.host.http_host.host.isLocalLeader(2910));
+    try std.testing.expect(svc.metrics().read_lease_requests > 0);
 }
 
 test "metadata http projected clone helpers clean up on allocation failure" {

--- a/zig/pkg/antfly/src/raft/host.zig
+++ b/zig/pkg/antfly/src/raft/host.zig
@@ -173,6 +173,48 @@ pub const HttpHostDeps = struct {
     backend_runtime: ?*backend_runtime_mod.BackendRuntime = null,
 };
 
+const PeerSnapshotTargetResolver = struct {
+    peer_resolver: peer_resolver.PeerResolver,
+
+    fn resolver(self: *PeerSnapshotTargetResolver) transport.http_snapshot.SnapshotTargetResolver {
+        return .{
+            .ptr = self,
+            .vtable = &.{
+                .resolve_upload_uri = resolveUploadUri,
+            },
+        };
+    }
+
+    fn resolveUploadUri(
+        ptr: *anyopaque,
+        alloc: std.mem.Allocator,
+        group_id: u64,
+        node_id: u64,
+        snapshot_id: []const u8,
+    ) ![]u8 {
+        const self: *PeerSnapshotTargetResolver = @ptrCast(@alignCast(ptr));
+        const endpoints = try self.peer_resolver.resolveGroupPeer(alloc, group_id, node_id);
+        defer {
+            for (endpoints) |endpoint| {
+                alloc.free(endpoint.address);
+                alloc.free(endpoint.metadata);
+            }
+            alloc.free(endpoints);
+        }
+        for (endpoints) |endpoint| {
+            switch (endpoint.protocol) {
+                .http, .https, .http2, .http3 => {
+                    const upload_path = try transport.Routes.snapshotUploadPath(alloc, snapshot_id);
+                    defer alloc.free(upload_path);
+                    return try transport.Routes.join(alloc, endpoint.address, upload_path);
+                },
+                .quic => {},
+            }
+        }
+        return error.NoHttpSnapshotEndpoint;
+    }
+};
+
 pub const Host = struct {
     const PendingInboundMessage = struct {
         group_id: u64,
@@ -558,6 +600,31 @@ pub const Host = struct {
         try self.runtime_host.transferLeader(group_id, transferee);
     }
 
+    pub fn handleSnapshotUpload(self: *Host, upload: transport.http_server.SnapshotUpload) !void {
+        var owned = upload;
+        errdefer owned.snapshot.deinit(self.alloc);
+        const grp = self.runtime_host.group(upload.group_id) orelse return error.UnknownGroup;
+        if (upload.to != grp.localNodeId()) return error.SnapshotUploadTargetMismatch;
+        var msg: raft_engine.core.Message = .{
+            .msg_type = .snapshot,
+            .from = upload.from,
+            .to = upload.to,
+            .term = upload.term,
+            .snapshot = owned.snapshot,
+        };
+        owned.snapshot = .{};
+        errdefer msg.deinit(self.alloc);
+
+        self.lockInbound();
+        defer self.inbound_mutex.unlock();
+        try self.pending_inbound.append(self.alloc, .{
+            .group_id = upload.group_id,
+            .message = msg,
+        });
+        self.metrics.inbound_message_enqueues += 1;
+        self.metrics.pending_inbound_messages = self.pending_inbound.items.len;
+    }
+
     pub fn forgetLeader(self: *Host, group_id: u64) !void {
         try self.runtime_host.forgetLeader(group_id);
     }
@@ -687,6 +754,7 @@ pub const HttpHost = struct {
     executor: ?*transport.StdHttpExecutor,
     request_executor: transport.RequestExecutor,
     transport_stack: *transport.HttpTransportStack,
+    owned_snapshot_resolver: ?*PeerSnapshotTargetResolver,
     owned_snapshot_store: ?*transport.FileSnapshotStore,
     host: *Host,
     batch_handler: *transport.HostBatchHandler,
@@ -714,13 +782,26 @@ pub const HttpHost = struct {
 
         const transport_stack = try alloc.create(transport.HttpTransportStack);
         errdefer alloc.destroy(transport_stack);
+        const owned_snapshot_resolver = if (deps.snapshot_resolver == null) blk: {
+            const peer = deps.host.peer_resolver orelse break :blk null;
+            const resolver = try alloc.create(PeerSnapshotTargetResolver);
+            resolver.* = .{ .peer_resolver = peer };
+            break :blk resolver;
+        } else null;
+        errdefer if (owned_snapshot_resolver) |resolver| alloc.destroy(resolver);
+        const snapshot_resolver = if (deps.snapshot_resolver) |resolver|
+            resolver
+        else if (owned_snapshot_resolver) |resolver|
+            resolver.resolver()
+        else
+            null;
         const transport_io = if (deps.backend_runtime) |runtime| runtime.raftOutboundIo() else null;
         transport_stack.* = try transport.HttpTransportStack.init(
             alloc,
             cfg.transport,
             request_executor,
             transport_io,
-            deps.snapshot_resolver,
+            snapshot_resolver,
         );
         errdefer transport_stack.deinit();
 
@@ -753,6 +834,7 @@ pub const HttpHost = struct {
         server.* = transport_stack.makeServer(
             batch_handler.handler(),
             if (deps.snapshot_store) |snapshot_store| snapshot_store else if (owned_snapshot_store) |snapshot_store| snapshot_store.store() else null,
+            batch_handler.snapshotHandler(),
         );
 
         const listener = try alloc.create(transport.StdHttpListener);
@@ -772,6 +854,7 @@ pub const HttpHost = struct {
             .executor = executor,
             .request_executor = request_executor,
             .transport_stack = transport_stack,
+            .owned_snapshot_resolver = owned_snapshot_resolver,
             .owned_snapshot_store = owned_snapshot_store,
             .host = host,
             .batch_handler = batch_handler,
@@ -789,6 +872,7 @@ pub const HttpHost = struct {
         self.alloc.destroy(self.host);
         self.transport_stack.deinit();
         self.alloc.destroy(self.transport_stack);
+        if (self.owned_snapshot_resolver) |resolver| self.alloc.destroy(resolver);
         if (self.owned_snapshot_store) |snapshot_store| {
             snapshot_store.deinit();
             self.alloc.destroy(snapshot_store);
@@ -991,6 +1075,164 @@ test "host can ensure and remove a replica" {
 
     try host.removeReplica(41);
     try std.testing.expectEqual(.absent, host.status(41));
+}
+
+test "host rejects live snapshot uploads addressed to another node" {
+    const Factory = struct {
+        alloc: std.mem.Allocator,
+        store: *raft_engine.core.MemoryStorage,
+
+        fn iface(self: *@This()) ReplicaDescriptorFactory {
+            return .{
+                .ptr = self,
+                .vtable = &.{
+                    .build_descriptor = buildDescriptor,
+                    .free_descriptor = freeDescriptor,
+                },
+            };
+        }
+
+        fn buildDescriptor(ptr: *anyopaque, record: catalog.ReplicaRecord) !raft_engine.runtime.ReplicaDescriptor {
+            const self: *@This() = @ptrCast(@alignCast(ptr));
+            const peers = try self.alloc.dupe(raft_engine.core.types.NodeId, &[_]raft_engine.core.types.NodeId{record.local_node_id});
+            return .{
+                .group = .{
+                    .group_id = record.group_id,
+                    .local_node_id = record.local_node_id,
+                    .raft_config = .{
+                        .id = record.local_node_id,
+                        .group_id = record.group_id,
+                        .peers = peers[0..],
+                        .election_tick = 5,
+                        .heartbeat_tick = 1,
+                        .pre_vote = false,
+                    },
+                    .storage = self.store.storage(),
+                },
+                .bootstrap = .empty,
+            };
+        }
+
+        fn freeDescriptor(ptr: *anyopaque, alloc: std.mem.Allocator, desc: *raft_engine.runtime.ReplicaDescriptor) void {
+            const self: *@This() = @ptrCast(@alignCast(ptr));
+            _ = alloc;
+            self.alloc.free(desc.group.raft_config.peers);
+        }
+    };
+
+    var store = raft_engine.core.MemoryStorage.init(std.testing.allocator);
+    defer store.deinit();
+    var factory = Factory{ .alloc = std.testing.allocator, .store = &store };
+    var host = Host.init(std.testing.allocator, .{ .local_node_id = 1 }, .{
+        .descriptor_factory = factory.iface(),
+    });
+    defer host.deinit();
+
+    _ = try host.ensureReplica(.{
+        .group_id = 41,
+        .replica_id = 1,
+        .local_node_id = 1,
+    });
+
+    const voters = try std.testing.allocator.dupe(u64, &[_]u64{1});
+    const data = try std.testing.allocator.dupe(u8, "wrong-target");
+    try std.testing.expectError(error.SnapshotUploadTargetMismatch, host.handleSnapshotUpload(.{
+        .group_id = 41,
+        .from = 2,
+        .to = 3,
+        .term = 7,
+        .snapshot = .{
+            .metadata = .{
+                .index = 1,
+                .term = 1,
+                .conf_state = .{ .voters = voters },
+            },
+            .data = data,
+        },
+    }));
+}
+
+test "host queues live snapshot uploads for runtime round" {
+    const Factory = struct {
+        alloc: std.mem.Allocator,
+        store: *raft_engine.core.MemoryStorage,
+
+        fn iface(self: *@This()) ReplicaDescriptorFactory {
+            return .{
+                .ptr = self,
+                .vtable = &.{
+                    .build_descriptor = buildDescriptor,
+                    .free_descriptor = freeDescriptor,
+                },
+            };
+        }
+
+        fn buildDescriptor(ptr: *anyopaque, record: catalog.ReplicaRecord) !raft_engine.runtime.ReplicaDescriptor {
+            const self: *@This() = @ptrCast(@alignCast(ptr));
+            const peers = try self.alloc.dupe(raft_engine.core.types.NodeId, &[_]raft_engine.core.types.NodeId{record.local_node_id});
+            return .{
+                .group = .{
+                    .group_id = record.group_id,
+                    .local_node_id = record.local_node_id,
+                    .raft_config = .{
+                        .id = record.local_node_id,
+                        .group_id = record.group_id,
+                        .peers = peers[0..],
+                        .election_tick = 5,
+                        .heartbeat_tick = 1,
+                        .pre_vote = false,
+                    },
+                    .storage = self.store.storage(),
+                },
+                .bootstrap = .empty,
+            };
+        }
+
+        fn freeDescriptor(ptr: *anyopaque, alloc: std.mem.Allocator, desc: *raft_engine.runtime.ReplicaDescriptor) void {
+            const self: *@This() = @ptrCast(@alignCast(ptr));
+            _ = alloc;
+            self.alloc.free(desc.group.raft_config.peers);
+        }
+    };
+
+    var store = raft_engine.core.MemoryStorage.init(std.testing.allocator);
+    defer store.deinit();
+    var factory = Factory{ .alloc = std.testing.allocator, .store = &store };
+    var host = Host.init(std.testing.allocator, .{ .local_node_id = 1 }, .{
+        .descriptor_factory = factory.iface(),
+    });
+    defer host.deinit();
+
+    _ = try host.ensureReplica(.{
+        .group_id = 41,
+        .replica_id = 1,
+        .local_node_id = 1,
+    });
+
+    const voters = try std.testing.allocator.dupe(u64, &[_]u64{1});
+    const data = try std.testing.allocator.dupe(u8, "queued-snapshot");
+    try host.handleSnapshotUpload(.{
+        .group_id = 41,
+        .from = 2,
+        .to = 1,
+        .term = 7,
+        .snapshot = .{
+            .metadata = .{
+                .index = 1,
+                .term = 1,
+                .conf_state = .{ .voters = voters },
+            },
+            .data = data,
+        },
+    });
+
+    try std.testing.expectEqual(@as(usize, 1), host.metrics.inbound_message_enqueues);
+    try std.testing.expectEqual(@as(usize, 1), host.metrics.pending_inbound_messages);
+    try std.testing.expectEqual(@as(usize, 0), host.metrics.inbound_message_drains);
+
+    _ = try host.runRoundBounded(1, 1, 1);
+    try std.testing.expectEqual(@as(usize, 1), host.metrics.inbound_message_drains);
+    try std.testing.expectEqual(@as(usize, 0), host.metrics.pending_inbound_messages);
 }
 
 test "host drops stale inbound peer batch groups without leaking pending storage" {

--- a/zig/pkg/antfly/src/raft/sim_harness.zig
+++ b/zig/pkg/antfly/src/raft/sim_harness.zig
@@ -1623,6 +1623,25 @@ fn waitForLastIndexInCluster(
     return (try store.storage().lastIndex()) >= target_index;
 }
 
+fn waitForSnapshotIndexInCluster(
+    cluster: *ManagedHttpClusterSimulation,
+    store: *raft_engine.core.MemoryStorage,
+    target_index: u64,
+    max_rounds: usize,
+) !bool {
+    var i: usize = 0;
+    while (i < max_rounds) : (i += 1) {
+        var snapshot = try store.storage().snapshot(std.testing.allocator);
+        const reached = snapshot.metadata.index >= target_index;
+        snapshot.deinit(std.testing.allocator);
+        if (reached) return true;
+        try cluster.stepAll();
+    }
+    var snapshot = try store.storage().snapshot(std.testing.allocator);
+    defer snapshot.deinit(std.testing.allocator);
+    return snapshot.metadata.index >= target_index;
+}
+
 fn waitForCommitIndex(
     sim: *ManagedHostSimulation,
     group_id: u64,
@@ -1655,6 +1674,24 @@ fn waitForCommitIndexInCluster(
         try cluster.stepAll();
     }
     if (cluster.node(node_index).raftStatus(group_id)) |status| return status.hard.commit_index >= target_index;
+    return false;
+}
+
+fn waitForAppliedIndexInCluster(
+    cluster: *ManagedHttpClusterSimulation,
+    node_index: usize,
+    group_id: u64,
+    target_index: u64,
+    max_rounds: usize,
+) !bool {
+    var i: usize = 0;
+    while (i < max_rounds) : (i += 1) {
+        if (cluster.node(node_index).raftStatus(group_id)) |status| {
+            if (status.applied_index >= target_index) return true;
+        }
+        try cluster.stepAll();
+    }
+    if (cluster.node(node_index).raftStatus(group_id)) |status| return status.applied_index >= target_index;
     return false;
 }
 
@@ -3427,6 +3464,129 @@ test "managed http cluster simulation restarts a node with WAL-backed raft state
     try std.testing.expectEqual(@as(?u64, 1), try cluster.waitForLeader(3004, 64));
     try cluster.node(0).propose(3004, "after-restart");
     try std.testing.expect(try waitForCommitIndexInCluster(&cluster, 0, 3004, leader_baseline_commit + 1, 128));
+}
+
+test "managed http cluster simulation catches up lagging follower from live HTTP snapshot" {
+    var tmp_a = std.testing.tmpDir(.{});
+    defer tmp_a.cleanup();
+    var tmp_b = std.testing.tmpDir(.{});
+    defer tmp_b.cleanup();
+    var tmp_c = std.testing.tmpDir(.{});
+    defer tmp_c.cleanup();
+
+    const root_a = try std.fmt.allocPrint(std.testing.allocator, ".zig-cache/tmp/{s}/raft-http-live-snap-a", .{tmp_a.sub_path});
+    defer std.testing.allocator.free(root_a);
+    const root_b = try std.fmt.allocPrint(std.testing.allocator, ".zig-cache/tmp/{s}/raft-http-live-snap-b", .{tmp_b.sub_path});
+    defer std.testing.allocator.free(root_b);
+    const root_c = try std.fmt.allocPrint(std.testing.allocator, ".zig-cache/tmp/{s}/raft-http-live-snap-c", .{tmp_c.sub_path});
+    defer std.testing.allocator.free(root_c);
+
+    var store_a = raft_engine.core.MemoryStorage.init(std.testing.allocator);
+    defer store_a.deinit();
+    var store_b = raft_engine.core.MemoryStorage.init(std.testing.allocator);
+    defer store_b.deinit();
+    var store_c = raft_engine.core.MemoryStorage.init(std.testing.allocator);
+    defer store_c.deinit();
+
+    var persist_a = StorageRecorder{ .alloc = std.testing.allocator };
+    defer persist_a.deinit();
+    var persist_b = StorageRecorder{ .alloc = std.testing.allocator };
+    defer persist_b.deinit();
+    var persist_c = StorageRecorder{ .alloc = std.testing.allocator };
+    defer persist_c.deinit();
+    try persist_a.registerStore(3006, &store_a);
+    try persist_b.registerStore(3006, &store_b);
+    try persist_c.registerStore(3006, &store_c);
+
+    var factory_a = SimulationDescriptorFactory{ .alloc = std.testing.allocator, .store = &store_a, .peers = &.{ 1, 2, 3 } };
+    var factory_b = SimulationDescriptorFactory{ .alloc = std.testing.allocator, .store = &store_b, .peers = &.{ 1, 2, 3 } };
+    var factory_c = SimulationDescriptorFactory{ .alloc = std.testing.allocator, .store = &store_c, .peers = &.{ 1, 2, 3 } };
+
+    const compacting_runtime: raft_engine.runtime.RuntimeConfig = .{
+        .applied_log_retained_entries = 1,
+        .applied_log_compaction_min_interval_entries = 1,
+        .applied_log_compaction_single_node_only = false,
+    };
+    const configs = [_]ManagedHttpHostSimulationConfig{
+        .{ .host = .{ .http = .{ .host = .{ .local_node_id = 1, .runtime = compacting_runtime }, .transport = .{ .snapshot = .{ .root_dir = root_a } } } } },
+        .{ .host = .{ .http = .{ .host = .{ .local_node_id = 2, .runtime = compacting_runtime }, .transport = .{ .snapshot = .{ .root_dir = root_b } } } } },
+        .{ .host = .{ .http = .{ .host = .{ .local_node_id = 3, .runtime = compacting_runtime }, .transport = .{ .snapshot = .{ .root_dir = root_c } } } } },
+    };
+    const deps = [_]ManagedHttpHostSimulationDeps{
+        .{ .host = .{ .http = .{ .host = .{ .descriptor_factory = factory_a.iface(), .runtime_hooks = .{ .group_storage = persist_a.iface() } } } } },
+        .{ .host = .{ .http = .{ .host = .{ .descriptor_factory = factory_b.iface(), .runtime_hooks = .{ .group_storage = persist_b.iface() } } } } },
+        .{ .host = .{ .http = .{ .host = .{ .descriptor_factory = factory_c.iface(), .runtime_hooks = .{ .group_storage = persist_c.iface() } } } } },
+    };
+
+    var cluster = try ManagedHttpClusterSimulation.init(std.testing.allocator, configs[0..], deps[0..]);
+    defer cluster.deinit();
+    try cluster.startAll();
+    defer cluster.stopAll();
+
+    const base_a = try cluster.node(0).baseUri(std.testing.allocator);
+    defer std.testing.allocator.free(base_a);
+    const base_b = try cluster.node(1).baseUri(std.testing.allocator);
+    defer std.testing.allocator.free(base_b);
+    const base_c = try cluster.node(2).baseUri(std.testing.allocator);
+    defer std.testing.allocator.free(base_c);
+
+    try cluster.node(0).applyBatch(&.{
+        .{ .upsert_replica_intent = .{ .record = .{ .group_id = 3006, .replica_id = 1, .local_node_id = 1 }, .peer_node_ids = &.{ 2, 3 } } },
+        .{ .upsert_peer_route = .{ .group_id = 3006, .node_id = 2, .endpoints = &.{.{ .protocol = .http, .address = base_b, .metadata = "" }} } },
+        .{ .upsert_peer_route = .{ .group_id = 3006, .node_id = 3, .endpoints = &.{.{ .protocol = .http, .address = base_c, .metadata = "" }} } },
+    });
+    try cluster.node(1).applyBatch(&.{
+        .{ .upsert_replica_intent = .{ .record = .{ .group_id = 3006, .replica_id = 2, .local_node_id = 2 }, .peer_node_ids = &.{ 1, 3 } } },
+        .{ .upsert_peer_route = .{ .group_id = 3006, .node_id = 1, .endpoints = &.{.{ .protocol = .http, .address = base_a, .metadata = "" }} } },
+        .{ .upsert_peer_route = .{ .group_id = 3006, .node_id = 3, .endpoints = &.{.{ .protocol = .http, .address = base_c, .metadata = "" }} } },
+    });
+    try cluster.node(2).applyBatch(&.{
+        .{ .upsert_replica_intent = .{ .record = .{ .group_id = 3006, .replica_id = 3, .local_node_id = 3 }, .peer_node_ids = &.{ 1, 2 } } },
+        .{ .upsert_peer_route = .{ .group_id = 3006, .node_id = 1, .endpoints = &.{.{ .protocol = .http, .address = base_a, .metadata = "" }} } },
+        .{ .upsert_peer_route = .{ .group_id = 3006, .node_id = 2, .endpoints = &.{.{ .protocol = .http, .address = base_b, .metadata = "" }} } },
+    });
+    try cluster.stepAll();
+    try cluster.node(0).campaignGroup(3006);
+    try std.testing.expectEqual(@as(?u64, 1), try cluster.waitForLeader(3006, 64));
+
+    try cluster.node(0).propose(3006, "live-snapshot-warmup");
+    try std.testing.expect(try waitForLastIndexInCluster(&cluster, &store_b, 2, 64));
+    try std.testing.expect(try waitForLastIndexInCluster(&cluster, &store_c, 2, 64));
+
+    try cluster.inject(.{ .partition_node = 2 });
+    try cluster.node(0).propose(3006, "live-snapshot-1");
+    try cluster.node(0).propose(3006, "live-snapshot-2");
+    try cluster.node(0).propose(3006, "live-snapshot-3");
+    try cluster.node(0).propose(3006, "live-snapshot-4");
+    try std.testing.expect(try waitForLastIndexInCluster(&cluster, &store_c, 6, 128));
+    try std.testing.expect(try waitForCommitIndexInCluster(&cluster, 0, 3006, 6, 128));
+    try std.testing.expect(try waitForAppliedIndexInCluster(&cluster, 0, 3006, 6, 128));
+    try std.testing.expect((try store_b.storage().lastIndex()) < 6);
+
+    const leader_status = cluster.node(0).raftStatus(3006) orelse return error.MissingRaftStatus;
+    const compact_index = leader_status.hard.commit_index;
+    try std.testing.expect(compact_index > try store_b.storage().lastIndex());
+    try store_a.compactTo(compact_index, leader_status.conf_state);
+    const leader_group = cluster.node(0).runtime.svc.host.http_host.host.runtime_host.group(3006) orelse return error.MissingRaftStatus;
+    try leader_group.compactAppliedLogTo(compact_index);
+
+    try cluster.restartNode(1);
+    try cluster.node(1).applyBatch(&.{
+        .{ .upsert_replica_intent = .{ .record = .{ .group_id = 3006, .replica_id = 2, .local_node_id = 2, .bootstrap_mode = .persisted }, .peer_node_ids = &.{ 1, 3 } } },
+        .{ .upsert_peer_route = .{ .group_id = 3006, .node_id = 1, .endpoints = &.{.{ .protocol = .http, .address = base_a, .metadata = "" }} } },
+        .{ .upsert_peer_route = .{ .group_id = 3006, .node_id = 3, .endpoints = &.{.{ .protocol = .http, .address = base_c, .metadata = "" }} } },
+    });
+    try cluster.stepAll();
+    try std.testing.expect((try store_b.storage().lastIndex()) < compact_index);
+
+    cluster.heal(.{ .partition_node = 2 });
+    try std.testing.expect(try waitForSnapshotIndexInCluster(&cluster, &store_b, compact_index, 256));
+    try std.testing.expect(try waitForLastIndexInCluster(&cluster, &store_b, compact_index, 128));
+
+    var follower_snapshot = try store_b.storage().snapshot(std.testing.allocator);
+    defer follower_snapshot.deinit(std.testing.allocator);
+    try std.testing.expectEqual(compact_index, follower_snapshot.metadata.index);
+    try std.testing.expect(std.mem.indexOfScalar(u64, follower_snapshot.metadata.conf_state.voters, 2) != null);
 }
 
 test "managed http cluster simulation can remove and rejoin a node from HTTP snapshot fetch" {

--- a/zig/pkg/antfly/src/raft/transport/host_batch_handler.zig
+++ b/zig/pkg/antfly/src/raft/transport/host_batch_handler.zig
@@ -28,9 +28,23 @@ pub const HostBatchHandler = struct {
         };
     }
 
+    pub fn snapshotHandler(self: *HostBatchHandler) http_server.SnapshotUploadHandler {
+        return .{
+            .ptr = self,
+            .vtable = &.{
+                .handle_snapshot_upload = handleSnapshotUpload,
+            },
+        };
+    }
+
     fn handlePeerBatch(ptr: *anyopaque, batch: raft_engine.runtime.transport_iface.PeerBatch) !void {
         const self: *HostBatchHandler = @ptrCast(@alignCast(ptr));
         try self.host.enqueueInboundBatch(batch);
+    }
+
+    fn handleSnapshotUpload(ptr: *anyopaque, upload: http_server.SnapshotUpload) !void {
+        const self: *HostBatchHandler = @ptrCast(@alignCast(ptr));
+        try self.host.handleSnapshotUpload(upload);
     }
 };
 

--- a/zig/pkg/antfly/src/raft/transport/http_server.zig
+++ b/zig/pkg/antfly/src/raft/transport/http_server.zig
@@ -149,22 +149,20 @@ pub const HttpServer = struct {
                     return error.InvalidSnapshotUploadHeaders;
                 }
 
-                var live_upload: ?SnapshotUpload = null;
-                errdefer if (live_upload) |*upload| upload.snapshot.deinit(self.alloc);
-                if (self.snapshot_upload_handler != null and header_state == .complete) {
-                    live_upload = (try parseSnapshotUpload(self.alloc, req)) orelse unreachable;
-                }
-
-                if (self.snapshot_store) |store| {
-                    try store.putSnapshot(self.alloc, snapshot_id, req.body);
-                } else if (self.snapshot_upload_handler == null) {
-                    return error.MissingSnapshotStore;
-                }
                 if (self.snapshot_upload_handler) |handler| {
-                    if (live_upload) |upload| {
-                        live_upload = null;
+                    if (header_state == .complete) {
+                        var live_upload = (try parseSnapshotUpload(self.alloc, req)) orelse unreachable;
+                        errdefer live_upload.snapshot.deinit(self.alloc);
+                        const upload = live_upload;
+                        live_upload.snapshot = .{};
                         try handler.handleSnapshotUpload(upload);
+                    } else if (self.snapshot_store) |store| {
+                        try store.putSnapshot(self.alloc, snapshot_id, req.body);
                     }
+                } else if (self.snapshot_store) |store| {
+                    try store.putSnapshot(self.alloc, snapshot_id, req.body);
+                } else {
+                    return error.MissingSnapshotStore;
                 }
                 return .{
                     .status = 201,
@@ -440,10 +438,34 @@ test "http server dispatches live snapshot uploads to handler" {
         }
     };
 
+    const Store = struct {
+        put_calls: usize = 0,
+
+        fn iface(self: *@This()) SnapshotStore {
+            return .{
+                .ptr = self,
+                .vtable = &.{
+                    .put_snapshot = putSnapshot,
+                    .get_snapshot = getSnapshot,
+                },
+            };
+        }
+
+        fn putSnapshot(ptr: *anyopaque, _: std.mem.Allocator, _: []const u8, _: []const u8) !void {
+            const self: *@This() = @ptrCast(@alignCast(ptr));
+            self.put_calls += 1;
+        }
+
+        fn getSnapshot(_: *anyopaque, _: std.mem.Allocator, _: []const u8) ![]u8 {
+            return error.UnexpectedFetch;
+        }
+    };
+
     var noop = Noop{};
+    var store = Store{};
     var handler = Handler{};
     defer handler.deinit();
-    var server = HttpServer.init(std.testing.allocator, .{}, raft_engine.runtime.BinaryCodec.codec(), noop.iface(), null, handler.iface());
+    var server = HttpServer.init(std.testing.allocator, .{}, raft_engine.runtime.BinaryCodec.codec(), noop.iface(), store.iface(), handler.iface());
 
     var voters = [_]u64{ 1, 2, 3 };
     const snapshot_body = try http_snapshot.HttpSnapshotTransport.encodeSnapshotEnvelope(std.testing.allocator, .{
@@ -480,6 +502,7 @@ test "http server dispatches live snapshot uploads to handler" {
     try std.testing.expectEqual(@as(u64, 8), handler.term);
     try std.testing.expectEqual(@as(u64, 42), handler.index);
     try std.testing.expectEqualStrings("live-snapshot", handler.data.?);
+    try std.testing.expectEqual(@as(usize, 0), store.put_calls);
 }
 
 test "http server rejects malformed live snapshot upload metadata" {

--- a/zig/pkg/antfly/src/raft/transport/http_server.zig
+++ b/zig/pkg/antfly/src/raft/transport/http_server.zig
@@ -16,6 +16,7 @@ const std = @import("std");
 const raft_engine = @import("raft_engine");
 const common_http = @import("../../common/http/mod.zig");
 const common = @import("http_common.zig");
+const http_snapshot = @import("http_snapshot.zig");
 const routes = @import("routes.zig");
 
 pub const HttpServerConfig = struct {
@@ -53,12 +54,35 @@ pub const SnapshotStore = struct {
     }
 };
 
+pub const SnapshotUpload = struct {
+    group_id: u64,
+    from: u64,
+    to: u64,
+    term: u64,
+    snapshot: raft_engine.core.types.Snapshot,
+};
+
+pub const SnapshotUploadHandler = struct {
+    ptr: *anyopaque,
+    vtable: *const VTable,
+
+    pub const VTable = struct {
+        /// Takes ownership of `upload.snapshot` whether it succeeds or fails.
+        handle_snapshot_upload: *const fn (ptr: *anyopaque, upload: SnapshotUpload) anyerror!void,
+    };
+
+    pub fn handleSnapshotUpload(self: SnapshotUploadHandler, upload: SnapshotUpload) !void {
+        return try self.vtable.handle_snapshot_upload(self.ptr, upload);
+    }
+};
+
 pub const HttpServer = struct {
     alloc: std.mem.Allocator,
     cfg: HttpServerConfig,
     codec: raft_engine.runtime.MessageCodec,
     batch_handler: BatchHandler,
     snapshot_store: ?SnapshotStore = null,
+    snapshot_upload_handler: ?SnapshotUploadHandler = null,
 
     pub fn init(
         alloc: std.mem.Allocator,
@@ -66,6 +90,7 @@ pub const HttpServer = struct {
         codec: raft_engine.runtime.MessageCodec,
         batch_handler: BatchHandler,
         snapshot_store: ?SnapshotStore,
+        snapshot_upload_handler: ?SnapshotUploadHandler,
     ) HttpServer {
         return .{
             .alloc = alloc,
@@ -73,6 +98,7 @@ pub const HttpServer = struct {
             .codec = codec,
             .batch_handler = batch_handler,
             .snapshot_store = snapshot_store,
+            .snapshot_upload_handler = snapshot_upload_handler,
         };
     }
 
@@ -116,8 +142,30 @@ pub const HttpServer = struct {
         }
         if (req.method == .POST) {
             if (routes.Routes.matchSnapshotUpload(req.uri)) |snapshot_id| {
-                const store = self.snapshot_store orelse return error.MissingSnapshotStore;
-                try store.putSnapshot(self.alloc, snapshot_id, req.body);
+                const header_state = snapshotUploadHeaderState(req);
+                if (self.snapshot_upload_handler != null and
+                    (header_state == .partial or (header_state == .absent and self.snapshot_store == null)))
+                {
+                    return error.InvalidSnapshotUploadHeaders;
+                }
+
+                var live_upload: ?SnapshotUpload = null;
+                errdefer if (live_upload) |*upload| upload.snapshot.deinit(self.alloc);
+                if (self.snapshot_upload_handler != null and header_state == .complete) {
+                    live_upload = (try parseSnapshotUpload(self.alloc, req)) orelse unreachable;
+                }
+
+                if (self.snapshot_store) |store| {
+                    try store.putSnapshot(self.alloc, snapshot_id, req.body);
+                } else if (self.snapshot_upload_handler == null) {
+                    return error.MissingSnapshotStore;
+                }
+                if (self.snapshot_upload_handler) |handler| {
+                    if (live_upload) |upload| {
+                        live_upload = null;
+                        try handler.handleSnapshotUpload(upload);
+                    }
+                }
                 return .{
                     .status = 201,
                     .content_type = try self.alloc.dupe(u8, "text/plain"),
@@ -149,6 +197,41 @@ pub const HttpServer = struct {
     }
 };
 
+const SnapshotUploadHeaderState = enum {
+    absent,
+    partial,
+    complete,
+};
+
+fn snapshotUploadHeaderState(req: common.HttpRequest) SnapshotUploadHeaderState {
+    const group_present = req.header("x-antfly-raft-group-id") != null;
+    const from_present = req.header("x-antfly-raft-from-node-id") != null;
+    const to_present = req.header("x-antfly-raft-to-node-id") != null;
+    const term_present = req.header("x-antfly-raft-term") != null;
+    var present_count: usize = 0;
+    if (group_present) present_count += 1;
+    if (from_present) present_count += 1;
+    if (to_present) present_count += 1;
+    if (term_present) present_count += 1;
+    if (present_count == 0) return .absent;
+    if (present_count == 4) return .complete;
+    return .partial;
+}
+
+fn parseSnapshotUpload(alloc: std.mem.Allocator, req: common.HttpRequest) !?SnapshotUpload {
+    const group_header = req.header("x-antfly-raft-group-id") orelse return null;
+    const from_header = req.header("x-antfly-raft-from-node-id") orelse return null;
+    const to_header = req.header("x-antfly-raft-to-node-id") orelse return null;
+    const term_header = req.header("x-antfly-raft-term") orelse return null;
+    return .{
+        .group_id = try std.fmt.parseInt(u64, group_header, 10),
+        .from = try std.fmt.parseInt(u64, from_header, 10),
+        .to = try std.fmt.parseInt(u64, to_header, 10),
+        .term = try std.fmt.parseInt(u64, term_header, 10),
+        .snapshot = try http_snapshot.HttpSnapshotTransport.decodeSnapshotEnvelope(alloc, req.body),
+    };
+}
+
 test "http server module compiles" {
     _ = HttpServerConfig;
     _ = BatchHandler;
@@ -173,7 +256,7 @@ test "http server exposes request executor" {
     };
 
     var handler = Handler{};
-    var server = HttpServer.init(std.testing.allocator, .{}, raft_engine.runtime.BinaryCodec.codec(), handler.iface(), null);
+    var server = HttpServer.init(std.testing.allocator, .{}, raft_engine.runtime.BinaryCodec.codec(), handler.iface(), null, null);
     const executor = server.executor();
     var resp = try executor.execute(std.testing.allocator, .{
         .method = .GET,
@@ -203,7 +286,7 @@ test "http server decodes raft batch requests and dispatches them" {
     };
 
     var handler = Handler{};
-    var server = HttpServer.init(std.testing.allocator, .{}, raft_engine.runtime.BinaryCodec.codec(), handler.iface(), null);
+    var server = HttpServer.init(std.testing.allocator, .{}, raft_engine.runtime.BinaryCodec.codec(), handler.iface(), null, null);
 
     const msg = raft_engine.core.Message{
         .msg_type = .heartbeat,
@@ -280,7 +363,7 @@ test "http server stores and fetches snapshot bodies by route" {
     var store = Store{};
     defer if (store.body) |body| std.testing.allocator.free(body);
     var noop = Noop{};
-    var server = HttpServer.init(std.testing.allocator, .{}, raft_engine.runtime.BinaryCodec.codec(), noop.iface(), store.iface());
+    var server = HttpServer.init(std.testing.allocator, .{}, raft_engine.runtime.BinaryCodec.codec(), noop.iface(), store.iface(), null);
 
     const upload_path = try routes.Routes.snapshotUploadPath(std.testing.allocator, "snap-7");
     defer std.testing.allocator.free(upload_path);
@@ -301,4 +384,187 @@ test "http server stores and fetches snapshot bodies by route" {
     defer fetch.deinit(std.testing.allocator);
     try std.testing.expectEqual(@as(u16, 200), fetch.status);
     try std.testing.expectEqualStrings("snapshot-body", fetch.body);
+}
+
+test "http server dispatches live snapshot uploads to handler" {
+    const Noop = struct {
+        fn iface(_: *@This()) BatchHandler {
+            return .{
+                .ptr = undefined,
+                .vtable = &.{
+                    .handle_peer_batch = handlePeerBatch,
+                },
+            };
+        }
+
+        fn handlePeerBatch(_: *anyopaque, batch: raft_engine.runtime.transport_iface.PeerBatch) !void {
+            _ = batch;
+        }
+    };
+
+    const Handler = struct {
+        seen: usize = 0,
+        group_id: u64 = 0,
+        from: u64 = 0,
+        to: u64 = 0,
+        term: u64 = 0,
+        index: u64 = 0,
+        data: ?[]u8 = null,
+
+        fn iface(self: *@This()) SnapshotUploadHandler {
+            return .{
+                .ptr = self,
+                .vtable = &.{
+                    .handle_snapshot_upload = handleSnapshotUpload,
+                },
+            };
+        }
+
+        fn deinit(self: *@This()) void {
+            if (self.data) |data| std.testing.allocator.free(data);
+            self.* = undefined;
+        }
+
+        fn handleSnapshotUpload(ptr: *anyopaque, upload: SnapshotUpload) !void {
+            const self: *@This() = @ptrCast(@alignCast(ptr));
+            var owned = upload;
+            defer owned.snapshot.deinit(std.testing.allocator);
+            self.seen += 1;
+            self.group_id = upload.group_id;
+            self.from = upload.from;
+            self.to = upload.to;
+            self.term = upload.term;
+            self.index = upload.snapshot.metadata.index;
+            if (self.data) |data| std.testing.allocator.free(data);
+            self.data = try std.testing.allocator.dupe(u8, upload.snapshot.data);
+        }
+    };
+
+    var noop = Noop{};
+    var handler = Handler{};
+    defer handler.deinit();
+    var server = HttpServer.init(std.testing.allocator, .{}, raft_engine.runtime.BinaryCodec.codec(), noop.iface(), null, handler.iface());
+
+    var voters = [_]u64{ 1, 2, 3 };
+    const snapshot_body = try http_snapshot.HttpSnapshotTransport.encodeSnapshotEnvelope(std.testing.allocator, .{
+        .metadata = .{
+            .index = 42,
+            .term = 7,
+            .conf_state = .{ .voters = voters[0..] },
+        },
+        .data = @constCast("live-snapshot"),
+    });
+    defer std.testing.allocator.free(snapshot_body);
+
+    const upload_path = try routes.Routes.snapshotUploadPath(std.testing.allocator, "snap-live");
+    defer std.testing.allocator.free(upload_path);
+    const headers = [_]common.RequestHeader{
+        .{ .name = "x-antfly-raft-group-id", .value = "91" },
+        .{ .name = "x-antfly-raft-from-node-id", .value = "1" },
+        .{ .name = "x-antfly-raft-to-node-id", .value = "2" },
+        .{ .name = "x-antfly-raft-term", .value = "8" },
+    };
+    var resp = try server.handle(.{
+        .method = .POST,
+        .uri = upload_path,
+        .headers = &headers,
+        .body = snapshot_body,
+    });
+    defer resp.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(u16, 201), resp.status);
+    try std.testing.expectEqual(@as(usize, 1), handler.seen);
+    try std.testing.expectEqual(@as(u64, 91), handler.group_id);
+    try std.testing.expectEqual(@as(u64, 1), handler.from);
+    try std.testing.expectEqual(@as(u64, 2), handler.to);
+    try std.testing.expectEqual(@as(u64, 8), handler.term);
+    try std.testing.expectEqual(@as(u64, 42), handler.index);
+    try std.testing.expectEqualStrings("live-snapshot", handler.data.?);
+}
+
+test "http server rejects malformed live snapshot upload metadata" {
+    const Noop = struct {
+        fn iface(_: *@This()) BatchHandler {
+            return .{
+                .ptr = undefined,
+                .vtable = &.{
+                    .handle_peer_batch = handlePeerBatch,
+                },
+            };
+        }
+
+        fn handlePeerBatch(_: *anyopaque, batch: raft_engine.runtime.transport_iface.PeerBatch) !void {
+            _ = batch;
+        }
+    };
+
+    const Handler = struct {
+        seen: usize = 0,
+
+        fn iface(self: *@This()) SnapshotUploadHandler {
+            return .{
+                .ptr = self,
+                .vtable = &.{
+                    .handle_snapshot_upload = handleSnapshotUpload,
+                },
+            };
+        }
+
+        fn handleSnapshotUpload(ptr: *anyopaque, upload: SnapshotUpload) !void {
+            const self: *@This() = @ptrCast(@alignCast(ptr));
+            var owned = upload;
+            defer owned.snapshot.deinit(std.testing.allocator);
+            self.seen += 1;
+        }
+    };
+
+    const Store = struct {
+        put_calls: usize = 0,
+
+        fn iface(self: *@This()) SnapshotStore {
+            return .{
+                .ptr = self,
+                .vtable = &.{
+                    .put_snapshot = putSnapshot,
+                    .get_snapshot = getSnapshot,
+                },
+            };
+        }
+
+        fn putSnapshot(ptr: *anyopaque, _: std.mem.Allocator, _: []const u8, _: []const u8) !void {
+            const self: *@This() = @ptrCast(@alignCast(ptr));
+            self.put_calls += 1;
+        }
+
+        fn getSnapshot(_: *anyopaque, _: std.mem.Allocator, _: []const u8) ![]u8 {
+            return error.UnexpectedFetch;
+        }
+    };
+
+    var noop = Noop{};
+    var handler = Handler{};
+    const upload_path = try routes.Routes.snapshotUploadPath(std.testing.allocator, "snap-live");
+    defer std.testing.allocator.free(upload_path);
+
+    var handler_only_server = HttpServer.init(std.testing.allocator, .{}, raft_engine.runtime.BinaryCodec.codec(), noop.iface(), null, handler.iface());
+    try std.testing.expectError(error.InvalidSnapshotUploadHeaders, handler_only_server.handle(.{
+        .method = .POST,
+        .uri = upload_path,
+        .body = "snapshot-body",
+    }));
+    try std.testing.expectEqual(@as(usize, 0), handler.seen);
+
+    var store = Store{};
+    var store_and_handler_server = HttpServer.init(std.testing.allocator, .{}, raft_engine.runtime.BinaryCodec.codec(), noop.iface(), store.iface(), handler.iface());
+    const partial_headers = [_]common.RequestHeader{
+        .{ .name = "x-antfly-raft-group-id", .value = "91" },
+    };
+    try std.testing.expectError(error.InvalidSnapshotUploadHeaders, store_and_handler_server.handle(.{
+        .method = .POST,
+        .uri = upload_path,
+        .headers = &partial_headers,
+        .body = "snapshot-body",
+    }));
+    try std.testing.expectEqual(@as(usize, 0), store.put_calls);
+    try std.testing.expectEqual(@as(usize, 0), handler.seen);
 }

--- a/zig/pkg/antfly/src/raft/transport/http_snapshot.zig
+++ b/zig/pkg/antfly/src/raft/transport/http_snapshot.zig
@@ -99,15 +99,45 @@ pub const HttpSnapshotTransport = struct {
 
     fn sendSnapshot(ptr: *anyopaque, req: raft_engine.runtime.snapshot_transport_iface.SnapshotSendRequest) !void {
         const self: *HttpSnapshotTransport = @ptrCast(@alignCast(ptr));
-        const uri = try self.resolveUploadUri(req);
+        const snapshot_id = if (req.locator) |locator|
+            try self.alloc.dupe(u8, locator.snapshot_id)
+        else
+            try std.fmt.allocPrint(self.alloc, "{d}-{d}-{d}-{d}-{d}", .{
+                req.group_id,
+                req.from,
+                req.to,
+                req.snapshot.metadata.index,
+                req.snapshot.metadata.term,
+            });
+        defer self.alloc.free(snapshot_id);
+
+        const uri = try self.resolveUploadUri(req, snapshot_id);
         defer self.alloc.free(uri);
 
         const body = try encodeSnapshotEnvelope(self.alloc, req.snapshot);
         defer self.alloc.free(body);
 
+        var group_id_buf: [32]u8 = undefined;
+        var from_buf: [32]u8 = undefined;
+        var to_buf: [32]u8 = undefined;
+        var term_buf: [32]u8 = undefined;
+        const group_id = try std.fmt.bufPrint(&group_id_buf, "{d}", .{req.group_id});
+        const from = try std.fmt.bufPrint(&from_buf, "{d}", .{req.from});
+        const to = try std.fmt.bufPrint(&to_buf, "{d}", .{req.to});
+        const term = try std.fmt.bufPrint(&term_buf, "{d}", .{req.term});
+        const live_headers = [_]common.RequestHeader{
+            .{ .name = "x-antfly-raft-group-id", .value = group_id },
+            .{ .name = "x-antfly-raft-from-node-id", .value = from },
+            .{ .name = "x-antfly-raft-to-node-id", .value = to },
+            .{ .name = "x-antfly-raft-term", .value = term },
+        };
+        const headers: []const common.RequestHeader = if (req.from == 0) &.{} else live_headers[0..];
+
         var resp = try self.executor.execute(self.alloc, .{
             .method = .POST,
             .uri = uri,
+            .headers = headers,
+            .source_node_id = if (req.from == 0) null else req.from,
             .content_type = "application/x-antflydb-raft-snapshot",
             .body = body,
         });
@@ -134,17 +164,18 @@ pub const HttpSnapshotTransport = struct {
     fn resolveUploadUri(
         self: *HttpSnapshotTransport,
         req: raft_engine.runtime.snapshot_transport_iface.SnapshotSendRequest,
+        snapshot_id: []const u8,
     ) ![]u8 {
         if (req.locator) |locator| {
             if (locator.uri.len > 0) return try self.alloc.dupe(u8, locator.uri);
-            if (self.resolver) |resolver| {
-                return try resolver.resolveUploadUri(self.alloc, req.group_id, req.to, locator.snapshot_id);
-            }
+        }
+        if (self.resolver) |resolver| {
+            return try resolver.resolveUploadUri(self.alloc, req.group_id, req.to, snapshot_id);
         }
         return error.MissingSnapshotUploadUri;
     }
 
-    fn encodeSnapshotEnvelope(alloc: std.mem.Allocator, snapshot: raft_engine.core.types.Snapshot) ![]u8 {
+    pub fn encodeSnapshotEnvelope(alloc: std.mem.Allocator, snapshot: raft_engine.core.types.Snapshot) ![]u8 {
         var out = std.ArrayListUnmanaged(u8).empty;
         defer out.deinit(alloc);
 
@@ -159,7 +190,7 @@ pub const HttpSnapshotTransport = struct {
         return try out.toOwnedSlice(alloc);
     }
 
-    fn decodeSnapshotEnvelope(alloc: std.mem.Allocator, bytes: []const u8) !raft_engine.core.types.Snapshot {
+    pub fn decodeSnapshotEnvelope(alloc: std.mem.Allocator, bytes: []const u8) !raft_engine.core.types.Snapshot {
         var cursor: usize = 0;
         const index = try readInt(u64, bytes, &cursor);
         const term = try readInt(u64, bytes, &cursor);
@@ -334,6 +365,7 @@ test "http snapshot transport posts and fetches serialized snapshots" {
         raft_engine.runtime.BinaryCodec.codec(),
         noop.iface(),
         store_impl.iface(),
+        null,
     );
     var executor = RecordingExecutor{ .server = &server };
     var transport = HttpSnapshotTransport.init(std.testing.allocator, .{
@@ -368,4 +400,172 @@ test "http snapshot transport posts and fetches serialized snapshots" {
     }, receiver.iface());
     try std.testing.expectEqual(@as(usize, 1), receiver.seen);
     try std.testing.expectEqual(@as(u64, 12), receiver.index);
+}
+
+test "http snapshot transport resolves upload uri when locator is absent" {
+    const Resolver = struct {
+        seen: usize = 0,
+        group_id: u64 = 0,
+        node_id: u64 = 0,
+        snapshot_id: ?[]u8 = null,
+
+        fn iface(self: *@This()) SnapshotTargetResolver {
+            return .{
+                .ptr = self,
+                .vtable = &.{
+                    .resolve_upload_uri = resolveUploadUri,
+                },
+            };
+        }
+
+        fn deinit(self: *@This()) void {
+            if (self.snapshot_id) |snapshot_id| std.testing.allocator.free(snapshot_id);
+            self.* = undefined;
+        }
+
+        fn resolveUploadUri(ptr: *anyopaque, alloc: std.mem.Allocator, group_id: u64, node_id: u64, snapshot_id: []const u8) ![]u8 {
+            const self: *@This() = @ptrCast(@alignCast(ptr));
+            self.seen += 1;
+            self.group_id = group_id;
+            self.node_id = node_id;
+            if (self.snapshot_id) |existing| std.testing.allocator.free(existing);
+            self.snapshot_id = try std.testing.allocator.dupe(u8, snapshot_id);
+            return try alloc.dupe(u8, "/raft/v1/snapshot/upload/resolved");
+        }
+    };
+
+    const Executor = struct {
+        seen: usize = 0,
+        uri: ?[]u8 = null,
+        group_id: ?[]u8 = null,
+        from: ?[]u8 = null,
+        to: ?[]u8 = null,
+        term: ?[]u8 = null,
+        source_node_id: ?u64 = null,
+        body_len: usize = 0,
+
+        fn iface(self: *@This()) common.RequestExecutor {
+            return .{
+                .ptr = self,
+                .vtable = &.{
+                    .execute = execute,
+                },
+            };
+        }
+
+        fn deinit(self: *@This()) void {
+            if (self.uri) |value| std.testing.allocator.free(value);
+            if (self.group_id) |value| std.testing.allocator.free(value);
+            if (self.from) |value| std.testing.allocator.free(value);
+            if (self.to) |value| std.testing.allocator.free(value);
+            if (self.term) |value| std.testing.allocator.free(value);
+            self.* = undefined;
+        }
+
+        fn capture(dst: *?[]u8, value: ?[]const u8) !void {
+            if (dst.*) |existing| std.testing.allocator.free(existing);
+            dst.* = if (value) |present| try std.testing.allocator.dupe(u8, present) else null;
+        }
+
+        fn execute(ptr: *anyopaque, _: std.mem.Allocator, req: common.HttpRequest) !common.HttpResponse {
+            const self: *@This() = @ptrCast(@alignCast(ptr));
+            self.seen += 1;
+            try capture(&self.uri, req.uri);
+            try capture(&self.group_id, req.header("x-antfly-raft-group-id"));
+            try capture(&self.from, req.header("x-antfly-raft-from-node-id"));
+            try capture(&self.to, req.header("x-antfly-raft-to-node-id"));
+            try capture(&self.term, req.header("x-antfly-raft-term"));
+            self.source_node_id = req.source_node_id;
+            self.body_len = req.body.len;
+            return .{ .status = 201 };
+        }
+    };
+
+    var resolver = Resolver{};
+    defer resolver.deinit();
+    var executor = Executor{};
+    defer executor.deinit();
+    var transport = HttpSnapshotTransport.init(std.testing.allocator, .{
+        .root_dir = "/tmp",
+    }, executor.iface(), resolver.iface());
+
+    var voters = [_]u64{ 1, 2, 3 };
+    try transport.transport().sendSnapshot(.{
+        .group_id = 91,
+        .from = 1,
+        .to = 2,
+        .term = 8,
+        .snapshot = .{
+            .metadata = .{
+                .index = 42,
+                .term = 7,
+                .conf_state = .{ .voters = voters[0..] },
+            },
+            .data = @constCast("live-snapshot"),
+        },
+    });
+
+    try std.testing.expectEqual(@as(usize, 1), resolver.seen);
+    try std.testing.expectEqual(@as(u64, 91), resolver.group_id);
+    try std.testing.expectEqual(@as(u64, 2), resolver.node_id);
+    try std.testing.expectEqualStrings("91-1-2-42-7", resolver.snapshot_id.?);
+    try std.testing.expectEqual(@as(usize, 1), executor.seen);
+    try std.testing.expectEqualStrings("/raft/v1/snapshot/upload/resolved", executor.uri.?);
+    try std.testing.expectEqualStrings("91", executor.group_id.?);
+    try std.testing.expectEqualStrings("1", executor.from.?);
+    try std.testing.expectEqualStrings("2", executor.to.?);
+    try std.testing.expectEqualStrings("8", executor.term.?);
+    try std.testing.expectEqual(@as(?u64, 1), executor.source_node_id);
+    try std.testing.expect(executor.body_len > 0);
+}
+
+test "http snapshot transport omits live upload headers for store-only locator uploads" {
+    const Executor = struct {
+        seen: usize = 0,
+        headers_len: usize = 0,
+        source_node_id: ?u64 = 99,
+
+        fn iface(self: *@This()) common.RequestExecutor {
+            return .{
+                .ptr = self,
+                .vtable = &.{
+                    .execute = execute,
+                },
+            };
+        }
+
+        fn execute(ptr: *anyopaque, _: std.mem.Allocator, req: common.HttpRequest) !common.HttpResponse {
+            const self: *@This() = @ptrCast(@alignCast(ptr));
+            self.seen += 1;
+            self.headers_len = req.headers.len;
+            self.source_node_id = req.source_node_id;
+            try std.testing.expect(req.header("x-antfly-raft-group-id") == null);
+            try std.testing.expect(req.body.len > 0);
+            return .{ .status = 201 };
+        }
+    };
+
+    var executor = Executor{};
+    var transport = HttpSnapshotTransport.init(std.testing.allocator, .{
+        .root_dir = "/tmp",
+    }, executor.iface(), null);
+
+    var voters = [_]u64{ 1, 2 };
+    try transport.transport().sendSnapshot(.{
+        .group_id = 91,
+        .to = 2,
+        .snapshot = .{
+            .metadata = .{
+                .index = 12,
+                .term = 4,
+                .conf_state = .{ .voters = voters[0..] },
+            },
+            .data = @constCast("store-only-snapshot"),
+        },
+        .locator = .{ .snapshot_id = "snap-1", .uri = "/raft/v1/snapshot/upload/snap-1" },
+    });
+
+    try std.testing.expectEqual(@as(usize, 1), executor.seen);
+    try std.testing.expectEqual(@as(usize, 0), executor.headers_len);
+    try std.testing.expectEqual(@as(?u64, null), executor.source_node_id);
 }

--- a/zig/pkg/antfly/src/raft/transport/stack.zig
+++ b/zig/pkg/antfly/src/raft/transport/stack.zig
@@ -104,6 +104,7 @@ pub const HttpTransportStack = struct {
         self: *HttpTransportStack,
         batch_handler: http_server.BatchHandler,
         snapshot_store: ?http_server.SnapshotStore,
+        snapshot_upload_handler: ?http_server.SnapshotUploadHandler,
     ) http_server.HttpServer {
         return http_server.HttpServer.init(
             self.alloc,
@@ -111,6 +112,7 @@ pub const HttpTransportStack = struct {
             raft_engine.runtime.BinaryCodec.codec(),
             batch_handler,
             snapshot_store,
+            snapshot_upload_handler,
         );
     }
 };


### PR DESCRIPTION
## Summary

Fixes live HTTP raft snapshot catch-up so leaders can send snapshots to lagging peers without crashing on missing upload URI.

The rc10 rollout exposed this when a dev metadata node needed a raft snapshot and the HTTP snapshot transport returned `MissingSnapshotUploadUri`.

## Root Cause

`MultiRaft` sends catch-up snapshots through `snapshot_transport`, but the live send request did not include enough delivery information for the HTTP implementation. The HTTP snapshot transport required either a locator URI or an explicit resolver, and the normal HTTP host wiring did not install a resolver from the existing peer resolver. Uploaded snapshots were also only handled as stored snapshot bodies, not stepped into the destination raft group for live catch-up.

## Changes

- Add source node metadata to `SnapshotSendRequest` and pass it from `MultiRaft`.
- Install an HTTP snapshot target resolver from the host peer resolver when no resolver override is provided.
- Generate deterministic snapshot IDs for live catch-up sends and derive upload URIs from peer routes.
- Send group/from/to/term metadata with snapshot upload requests.
- Decode live snapshot uploads on the HTTP raft server and step them into the local raft group.
- Preserve existing explicit snapshot upload/fetch behavior for bootstrap paths.

## Validation

- `zig build raft-transport-test --summary failures`
- `zig build raft-test --summary failures`

Note: `raft-test` prints loopback bind stack traces in this sandbox from tests that skip when local bind is unavailable, but the command exits successfully.