### PR TITLE
Fix clipclap ONNX embedding correctness

### DIFF
--- a/zig/lib/linalg/src/attention.zig
+++ b/zig/lib/linalg/src/attention.zig
@@ -428,6 +428,8 @@ pub fn flashAttentionHost(
                     bh_idx * seq_sq
                 else if (bdata.len == bias_shared_len)
                     h * seq_sq
+                else if (bdata.len == seq_sq)
+                    0
                 else
                     null
             else

--- a/zig/lib/ml/src/graph/passes/fuse.zig
+++ b/zig/lib/ml/src/graph/passes/fuse.zig
@@ -2787,7 +2787,7 @@ fn buildTypedScalar(work: *Graph, dtype: shape_mod.DType, value: f64) !?NodeId {
 //
 // Detects the decomposed attention pattern:
 //   dot_general(softmax(mul(dot_general(Q, transpose(K)), scale)), V)
-// and replaces it with fused_sdpa(Q, K, V).
+// and replaces it with fused_sdpa(Q, K, V, optional_additive_bias).
 //
 // The pattern matching walks backwards from each batched dot_general
 // node and checks the chain: probs @ V where probs = softmax(scale * (Q @ K^T)).
@@ -2796,6 +2796,10 @@ fn fuseSDPA(allocator: std.mem.Allocator, work: *Graph) !PairFusionResult {
     var redirects = std.ArrayListUnmanaged(Redirect).empty;
     errdefer redirects.deinit(allocator);
     var num_rewrites: u32 = 0;
+
+    if (std.c.getenv("ANTFLY_DISABLE_SDPA_FUSION") != null) {
+        return .{ .redirects = redirects, .num_rewrites = num_rewrites };
+    }
 
     const count = work.nodeCount();
 
@@ -2833,6 +2837,7 @@ fn fuseSDPA(allocator: std.mem.Allocator, work: *Graph) !PairFusionResult {
         const softmax_input = softmax_node.inputs[0];
         if (softmax_input == null_node) continue;
         const scale_result = findScaleOp(work, softmax_input) orelse continue;
+        if (scale_result.masked) continue;
 
         // Scores must be dot_general(Q, K^T)
         const scores_id = scale_result.scores_id;
@@ -2906,6 +2911,7 @@ fn fuseSDPA(allocator: std.mem.Allocator, work: *Graph) !PairFusionResult {
         if (!approxEqScale(effective_scale, expected_scale)) continue;
 
         const out_shape = n.output_shape;
+        const fused_num_inputs: u8 = if (scale_result.attn_bias_id != null_node) 4 else 3;
         const fused_id = try work.addNode(.{
             .op = .{ .fused_sdpa = .{
                 .batch = batch,
@@ -2914,8 +2920,8 @@ fn fuseSDPA(allocator: std.mem.Allocator, work: *Graph) !PairFusionResult {
                 .head_dim = head_dim,
             } },
             .output_shape = out_shape,
-            .inputs = .{ q_id, k_id, v_id, null_node },
-            .num_inputs = 3,
+            .inputs = .{ q_id, k_id, v_id, scale_result.attn_bias_id },
+            .num_inputs = fused_num_inputs,
             .vjp_alternate = @intCast(i),
         });
 
@@ -2929,11 +2935,43 @@ fn fuseSDPA(allocator: std.mem.Allocator, work: *Graph) !PairFusionResult {
 const ScaleResult = struct {
     scores_id: NodeId,
     scale: f32,
+    attn_bias_id: NodeId = null_node,
+    // Boolean where-style masks are not representable by the current fused
+    // graph op unless they have already been lowered to additive bias.
+    masked: bool = false,
 };
 
-/// Walk backward from a node through masking ops (where_select, add,
-/// convert_dtype) to find a mul or div by a scalar constant. Returns the
-/// scores input to the scale op if found.
+fn scaleResultWithBias(result: ScaleResult, bias_id: NodeId) ScaleResult {
+    if (bias_id == null_node) return result;
+    if (result.attn_bias_id != null_node) {
+        return .{
+            .scores_id = result.scores_id,
+            .scale = result.scale,
+            .attn_bias_id = result.attn_bias_id,
+            .masked = true,
+        };
+    }
+    return .{
+        .scores_id = result.scores_id,
+        .scale = result.scale,
+        .attn_bias_id = bias_id,
+        .masked = result.masked,
+    };
+}
+
+fn scaleResultMarkMasked(result: ScaleResult) ScaleResult {
+    return .{
+        .scores_id = result.scores_id,
+        .scale = result.scale,
+        .attn_bias_id = result.attn_bias_id,
+        .masked = true,
+    };
+}
+
+/// Walk backward from a node through additive masking/casting/shape-only ops
+/// to find a mul or div by a scalar constant. Returns the scores input to the
+/// scale op and, when present, the additive attention bias that should become
+/// fused_sdpa input 3.
 fn findScaleOp(graph: *const Graph, start_id: NodeId) ?ScaleResult {
     var cur = start_id;
     var depth: u32 = 0;
@@ -2971,40 +3009,37 @@ fn findScaleOp(graph: *const Graph, start_id: NodeId) ?ScaleResult {
         // Skip through masking/casting/shape-only ops
         if (tag == .where_select or tag == .add or tag == .convert_dtype or tag == .reshape or tag == .broadcast_in_dim) {
             // For where_select: input 0 is condition, inputs 1/2 are values.
-            // The scores flow through input 1 (true_value) or input 2.
-            // For add: one operand is the mask, other is scores — follow
-            // the non-constant operand.
+            // The scores may flow through input 1 (true_value) or input 2.
+            // Keep the pattern decomposed because a boolean condition plus
+            // selected score tensor is not the same thing as additive bias.
+            // For add: one operand is additive bias, other is scores.
             // For convert_dtype/reshape/broadcast_in_dim: pass through input 0.
             if (tag == .convert_dtype or tag == .reshape or tag == .broadcast_in_dim) {
                 cur = node.inputs[0];
                 continue;
             }
             if (tag == .where_select) {
-                // where(cond, false_val, true_val) — scores are in true_val (input 2)
-                // or false_val (input 1). Try input 2 first (ONNX Where convention
-                // after conversion: inputs = [cond, false, true]).
-                cur = node.inputs[2];
-                if (cur == null_node) cur = node.inputs[1];
-                continue;
+                if (findScaleOp(graph, node.inputs[1])) |result| {
+                    return scaleResultMarkMasked(result);
+                }
+                if (findScaleOp(graph, node.inputs[2])) |result| {
+                    return scaleResultMarkMasked(result);
+                }
+                return null;
             }
             if (tag == .add) {
                 const a0 = node.inputs[0];
                 const a1 = node.inputs[1];
-                // Follow the non-broadcast/non-constant operand
+                if (a0 == null_node or a1 == null_node) return null;
                 if (a1 != null_node and isSmallOrBroadcast(graph, a1)) {
-                    if (findScaleOp(graph, a0)) |result| return result;
-                    cur = a0;
-                } else if (a0 != null_node and isSmallOrBroadcast(graph, a0)) {
-                    if (findScaleOp(graph, a1)) |result| return result;
-                    cur = a1;
-                } else {
-                    // Can't determine which is the mask. Prefer the branch
-                    // that actually resolves to a score chain.
-                    if (findScaleOp(graph, a0)) |result| return result;
-                    if (findScaleOp(graph, a1)) |result| return result;
-                    cur = a0;
+                    if (findScaleOp(graph, a0)) |result| return scaleResultWithBias(result, a1);
                 }
-                continue;
+                if (a0 != null_node and isSmallOrBroadcast(graph, a0)) {
+                    if (findScaleOp(graph, a1)) |result| return scaleResultWithBias(result, a0);
+                }
+                if (findScaleOp(graph, a0)) |result| return scaleResultWithBias(result, a1);
+                if (findScaleOp(graph, a1)) |result| return scaleResultWithBias(result, a0);
+                return null;
             }
         }
 
@@ -3961,7 +3996,7 @@ test "fuse detects SDPA pattern: matmul-scale-softmax-matmul" {
     try std.testing.expect(found_sdpa);
 }
 
-test "fuse detects SDPA pattern: GPT-2 style (4D, dynamic, div-where-add-cast)" {
+test "fuse detects SDPA pattern: 4D dynamic additive bias is preserved" {
     const allocator = std.testing.allocator;
     var g = Graph.init(allocator);
     defer g.deinit();
@@ -4008,22 +4043,6 @@ test "fuse detects SDPA pattern: GPT-2 style (4D, dynamic, div-where-add-cast)" 
     });
     const scaled = try b.div(scores, scale_bcast);
 
-    // Causal mask via where(cond, neg_inf, scaled)
-    const cond = try b.parameter("mask_cond", Shape.init(.bool_, &.{ 1, 1, S, S }));
-    const neg_inf = try b.scalarConst(.f32, -std.math.inf(f32));
-    const neg_inf_bcast = try g.addNode(.{
-        .op = .{ .broadcast_in_dim = .{ .target_shape = target_shape } },
-        .output_shape = target_shape,
-        .inputs = .{ neg_inf, null_node, null_node, null_node },
-        .num_inputs = 1,
-    });
-    const masked = try g.addNode(.{
-        .op = .{ .where_select = {} },
-        .output_shape = target_shape,
-        .inputs = .{ cond, neg_inf_bcast, scaled, null_node },
-        .num_inputs = 3,
-    });
-
     // Additive bias (broadcast parameter acting like an attention mask)
     const bias = try b.parameter("mask_bias", Shape.init(.f32, &.{ 1, 1, S, S }));
     const bias_bcast = try g.addNode(.{
@@ -4036,7 +4055,7 @@ test "fuse detects SDPA pattern: GPT-2 style (4D, dynamic, div-where-add-cast)" 
         .inputs = .{ bias, null_node, null_node, null_node },
         .num_inputs = 1,
     });
-    const biased = try b.add(masked, bias_bcast);
+    const biased = try b.add(scaled, bias_bcast);
 
     // Softmax (along last axis — dynamic, uses 0 sentinel).
     const probs_f32 = try g.addNode(.{
@@ -4082,11 +4101,88 @@ test "fuse detects SDPA pattern: GPT-2 style (4D, dynamic, div-where-add-cast)" 
             try std.testing.expectEqual(@as(u32, 12), attrs.num_heads);
             try std.testing.expectEqual(@as(u32, 0), attrs.seq_len); // dynamic
             try std.testing.expectEqual(@as(u32, 64), attrs.head_dim);
+            const node = result.graph.node(@intCast(idx));
+            try std.testing.expectEqual(@as(u8, 4), node.num_inputs);
+            try std.testing.expectEqual(bias_bcast, node.inputs[3]);
             found_sdpa = true;
             break;
         }
     }
     try std.testing.expect(found_sdpa);
+}
+
+test "fuse skips SDPA pattern with where_select mask" {
+    const allocator = std.testing.allocator;
+    var g = Graph.init(allocator);
+    defer g.deinit();
+    var b = Builder.init(&g);
+
+    const B: i64 = 1;
+    const H: i64 = 2;
+    const S: i64 = 4;
+    const D: i64 = 8;
+
+    const q = try b.parameter("Q", Shape.init(.f32, &.{ B, H, S, D }));
+    const k = try b.parameter("K", Shape.init(.f32, &.{ B, H, S, D }));
+    const v = try b.parameter("V", Shape.init(.f32, &.{ B, H, S, D }));
+    const k_t = try b.transpose(k, &.{ 0, 1, 3, 2 });
+
+    const scores = try g.addNode(.{
+        .op = .{ .dot_general = .{
+            .lhs_contracting = .{ 3, 0, 0, 0, 0, 0, 0, 0 },
+            .rhs_contracting = .{ 2, 0, 0, 0, 0, 0, 0, 0 },
+            .lhs_batch = .{ 0, 1, 0, 0, 0, 0, 0, 0 },
+            .rhs_batch = .{ 0, 1, 0, 0, 0, 0, 0, 0 },
+            .num_contracting = 1,
+            .num_batch = 2,
+        } },
+        .output_shape = Shape.init(.f32, &.{ B, H, S, S }),
+        .inputs = .{ q, k_t, null_node, null_node },
+        .num_inputs = 2,
+    });
+    const scale = try b.scalarConst(.f32, 1.0 / @sqrt(@as(f32, @floatFromInt(D))));
+    const scaled = try b.mul(scores, scale);
+    const cond = try b.parameter("mask_cond", Shape.init(.bool_, &.{ B, 1, S, S }));
+    const neg_inf = try b.scalarConst(.f32, -std.math.inf(f32));
+    const neg_inf_bcast = try g.addNode(.{
+        .op = .{ .broadcast_in_dim = .{ .target_shape = Shape.init(.f32, &.{ B, H, S, S }) } },
+        .output_shape = Shape.init(.f32, &.{ B, H, S, S }),
+        .inputs = .{ neg_inf, null_node, null_node, null_node },
+        .num_inputs = 1,
+    });
+    const masked = try g.addNode(.{
+        .op = .{ .where_select = {} },
+        .output_shape = Shape.init(.f32, &.{ B, H, S, S }),
+        .inputs = .{ cond, neg_inf_bcast, scaled, null_node },
+        .num_inputs = 3,
+    });
+    const probs = try g.addNode(.{
+        .op = .{ .fused_softmax = .{ .dim = 3 } },
+        .output_shape = Shape.init(.f32, &.{ B, H, S, S }),
+        .inputs = .{ masked, null_node, null_node, null_node },
+        .num_inputs = 1,
+    });
+    const output = try g.addNode(.{
+        .op = .{ .dot_general = .{
+            .lhs_contracting = .{ 3, 0, 0, 0, 0, 0, 0, 0 },
+            .rhs_contracting = .{ 2, 0, 0, 0, 0, 0, 0, 0 },
+            .lhs_batch = .{ 0, 1, 0, 0, 0, 0, 0, 0 },
+            .rhs_batch = .{ 0, 1, 0, 0, 0, 0, 0, 0 },
+            .num_contracting = 1,
+            .num_batch = 2,
+        } },
+        .output_shape = Shape.init(.f32, &.{ B, H, S, D }),
+        .inputs = .{ probs, v, null_node, null_node },
+        .num_inputs = 2,
+    });
+    try g.markOutput(output);
+
+    var result = try fuse(allocator, &g);
+    defer result.deinit();
+
+    for (0..result.graph.nodeCount()) |idx| {
+        try std.testing.expect(std.meta.activeTag(result.graph.node(@intCast(idx)).op) != .fused_sdpa);
+    }
 }
 
 test "fuse detects SDPA pattern: CLIP-style prescaled query" {

--- a/zig/lib/onnx/src/ops.zig
+++ b/zig/lib/onnx/src/ops.zig
@@ -859,21 +859,21 @@ fn materializeConstantValues(builder: *Builder, node_id: NodeId, buf: []f32) ?[]
             const where_inputs = n.getInputs();
             if (where_inputs.len < 3) return null;
             var cond_buf: [8]f32 = undefined;
-            var false_buf: [8]f32 = undefined;
             var true_buf: [8]f32 = undefined;
+            var false_buf: [8]f32 = undefined;
             const cond = materializeConstantValues(builder, where_inputs[0], &cond_buf) orelse return null;
-            const on_false = materializeConstantValues(builder, where_inputs[1], &false_buf) orelse return null;
-            const on_true = materializeConstantValues(builder, where_inputs[2], &true_buf) orelse return null;
+            const on_true = materializeConstantValues(builder, where_inputs[1], &true_buf) orelse return null;
+            const on_false = materializeConstantValues(builder, where_inputs[2], &false_buf) orelse return null;
             const out_shape = n.output_shape;
             const total = shapeElementCount(out_shape) orelse return null;
             if (total > buf.len) return null;
             const cond_shape = builder.graph.node(where_inputs[0]).output_shape;
-            const false_shape = builder.graph.node(where_inputs[1]).output_shape;
-            const true_shape = builder.graph.node(where_inputs[2]).output_shape;
+            const true_shape = builder.graph.node(where_inputs[1]).output_shape;
+            const false_shape = builder.graph.node(where_inputs[2]).output_shape;
             for (0..total) |i| {
                 const cond_idx = if (cond.len == 1 and total > 1) 0 else broadcastLinearIndex(cond_shape, out_shape, i) orelse return null;
-                const false_idx = if (on_false.len == 1 and total > 1) 0 else broadcastLinearIndex(false_shape, out_shape, i) orelse return null;
                 const true_idx = if (on_true.len == 1 and total > 1) 0 else broadcastLinearIndex(true_shape, out_shape, i) orelse return null;
+                const false_idx = if (on_false.len == 1 and total > 1) 0 else broadcastLinearIndex(false_shape, out_shape, i) orelse return null;
                 if (cond_idx >= cond.len or false_idx >= on_false.len or true_idx >= on_true.len) return null;
                 buf[i] = if (cond[cond_idx] != 0.0) on_true[true_idx] else on_false[false_idx];
             }
@@ -1800,13 +1800,13 @@ fn convertGreater(builder: *Builder, a: NodeId, b: NodeId) ConvertError!NodeId {
 
 fn convertLessOrEqual(builder: *Builder, a: NodeId, b: NodeId) ConvertError!NodeId {
     // a <= b  ⟺  ¬(b < a)
-    const gt = try cmpLessThan(builder, b, a);
+    const gt = try broadcastBinaryOp(builder, .less_than, b, a);
     return convertNot(builder, gt);
 }
 
 fn convertGreaterOrEqual(builder: *Builder, a: NodeId, b: NodeId) ConvertError!NodeId {
     // a >= b  ⟺  ¬(a < b)
-    const lt = try cmpLessThan(builder, a, b);
+    const lt = try broadcastBinaryOp(builder, .less_than, a, b);
     return convertNot(builder, lt);
 }
 
@@ -1817,8 +1817,8 @@ fn convertEqual(builder: *Builder, a: NodeId, b: NodeId) ConvertError!NodeId {
     const dtype = out_shape.dtype;
     const zero = try builder.scalarConst(dtype, 0.0);
     const one = try builder.scalarConst(dtype, 1.0);
-    const lt = try cmpLessThan(builder, a, b);
-    const gt = try cmpLessThan(builder, b, a);
+    const lt = try broadcastBinaryOp(builder, .less_than, a, b);
+    const gt = try broadcastBinaryOp(builder, .less_than, b, a);
     const not_gt = try selectOp(builder, gt, zero, one);
     return selectOp(builder, lt, zero, not_gt);
 }
@@ -4907,7 +4907,7 @@ fn selectOp(builder: *Builder, cond: NodeId, on_true: NodeId, on_false: NodeId) 
     return builder.graph.addNode(.{
         .op = .{ .where_select = {} },
         .output_shape = out_shape,
-        .inputs = .{ cond_node, false_node, true_node, null_node },
+        .inputs = .{ cond_node, true_node, false_node, null_node },
         .num_inputs = 3,
     });
 }
@@ -6525,6 +6525,45 @@ test "convertNode Where broadcasts scalar branch" {
     try std.testing.expectEqual(@as(i64, 4), out_shape.dim(2));
 }
 
+test "convertNode Where preserves ONNX true false branch order" {
+    const allocator = std.testing.allocator;
+    var g = Graph.init(allocator);
+    defer g.deinit();
+    var b = Builder.init(&g);
+
+    const cond = try b.parameter("cond", Shape.init(.bool_, &.{2}));
+    const x = try b.parameter("x", Shape.init(.f32, &.{2}));
+    const y = try b.parameter("y", Shape.init(.f32, &.{2}));
+    const node = NodeProto{ .op_type = "Where" };
+    const result = try convertNode(allocator, &b, &node, &.{ cond, x, y }, null);
+
+    const inputs = g.node(result).getInputs();
+    try std.testing.expectEqual(cond, inputs[0]);
+    try std.testing.expectEqual(x, inputs[1]);
+    try std.testing.expectEqual(y, inputs[2]);
+}
+
+test "materializeConstantValues folds where_select using internal true false order" {
+    const allocator = std.testing.allocator;
+    var g = Graph.init(allocator);
+    defer g.deinit();
+    var b = Builder.init(&g);
+
+    const cond = try b.tensorConst(&.{ 1.0, 0.0, 1.0 }, Shape.init(.bool_, &.{3}));
+    const on_true = try b.tensorConst(&.{ 10.0, 20.0, 30.0 }, Shape.init(.f32, &.{3}));
+    const on_false = try b.tensorConst(&.{ 40.0, 50.0, 60.0 }, Shape.init(.f32, &.{3}));
+    const selected = try g.addNode(.{
+        .op = .{ .where_select = {} },
+        .output_shape = Shape.init(.f32, &.{3}),
+        .inputs = .{ cond, on_true, on_false, null_node },
+        .num_inputs = 3,
+    });
+
+    var buf: [8]f32 = undefined;
+    const values = materializeConstantValues(&b, selected, &buf) orelse return error.TestUnexpectedResult;
+    try std.testing.expectEqualSlices(f32, &.{ 10.0, 50.0, 30.0 }, values);
+}
+
 test "materializeConstantValues folds broadcasted equal/where shape masks" {
     const allocator = std.testing.allocator;
     var g = Graph.init(allocator);
@@ -6557,6 +6596,25 @@ test "convertNode Equal" {
     const result = try convertNode(allocator, &b, &node, &.{ x, y }, null);
     // Equal → ends with where_select
     try std.testing.expect(std.meta.activeTag(g.node(result).op) == .where_select);
+}
+
+test "convertNode LessOrEqual broadcasts operands before comparison" {
+    const allocator = std.testing.allocator;
+    var g = Graph.init(allocator);
+    defer g.deinit();
+    var b = Builder.init(&g);
+
+    const row = try b.parameter("row", Shape.init(.i64, &.{ 1, 1, 77, 1 }));
+    const col = try b.parameter("col", Shape.init(.i64, &.{ 1, 1, 1, 77 }));
+    const node = NodeProto{ .op_type = "LessOrEqual" };
+    const result = try convertNode(allocator, &b, &node, &.{ row, col }, null);
+    const out_shape = g.node(result).output_shape;
+
+    try std.testing.expectEqual(@as(u8, 4), out_shape.rank());
+    try std.testing.expectEqual(@as(i64, 1), out_shape.dim(0));
+    try std.testing.expectEqual(@as(i64, 1), out_shape.dim(1));
+    try std.testing.expectEqual(@as(i64, 77), out_shape.dim(2));
+    try std.testing.expectEqual(@as(i64, 77), out_shape.dim(3));
 }
 
 test "convertNode Not" {

--- a/zig/lib/tokenizer/src/hf_tokenizer.zig
+++ b/zig/lib/tokenizer/src/hf_tokenizer.zig
@@ -29,6 +29,7 @@ const ModelType = enum { word_piece, bpe, unigram };
 const PreTokenizerType = enum {
     bert, // BertPreTokenizer: split on whitespace + punctuation
     byte_level, // ByteLevel: byte-to-unicode mapping
+    byte_level_split, // Split(regex) followed by ByteLevel, used by CLIP tokenizers
     metaspace, // Metaspace: replace spaces with ▁
     none, // No pre-tokenization
 };
@@ -49,6 +50,7 @@ pub const HfTokenizer = struct {
     /// next-occurrence lookups. Built lazily after `parseAddedTokens`.
     added_trie: AddedTokenTrie,
     special: SpecialTokens,
+    pad_token_seen: bool,
     do_lowercase: bool,
     replace_space_with: ?[]const u8,
     pre_tokenizer_type: PreTokenizerType,
@@ -237,7 +239,10 @@ pub const HfTokenizer = struct {
     ) void {
         if (bos_id) |id| self.special.cls_id = id;
         if (eos_id) |id| self.special.sep_id = id;
-        if (pad_id) |id| self.special.pad_id = id;
+        if (pad_id) |id| {
+            self.special.pad_id = id;
+            self.pad_token_seen = true;
+        }
         if (unk_id) |id| self.special.unk_id = id;
     }
 
@@ -272,6 +277,7 @@ pub const HfTokenizer = struct {
             .added_tokens = .{},
             .added_trie = try AddedTokenTrie.init(allocator),
             .special = .{},
+            .pad_token_seen = false,
             .do_lowercase = false,
             .replace_space_with = null,
             .pre_tokenizer_type = .bert,
@@ -376,15 +382,20 @@ pub const HfTokenizer = struct {
                         self.pre_tokenizer_type = .none;
                     }
                 } else if (std.mem.eql(u8, t.string, "Sequence")) {
-                    // For Sequence pre-tokenizers, use the first meaningful type
+                    var saw_split = false;
+                    // For Sequence pre-tokenizers, use the first meaningful type.
+                    // CLIP commonly uses Split(regex) followed by ByteLevel; the
+                    // split removes whitespace before byte-level BPE runs.
                     if (obj.get("pretokenizers")) |pts| {
                         if (pts == .array) {
                             for (pts.array.items) |item| {
                                 if (item == .object) {
                                     if (item.object.get("type")) |pt| {
                                         if (pt == .string) {
-                                            if (std.mem.eql(u8, pt.string, "ByteLevel")) {
-                                                self.pre_tokenizer_type = .byte_level;
+                                            if (std.mem.eql(u8, pt.string, "Split")) {
+                                                saw_split = true;
+                                            } else if (std.mem.eql(u8, pt.string, "ByteLevel")) {
+                                                self.pre_tokenizer_type = if (saw_split) .byte_level_split else .byte_level;
                                                 return;
                                             } else if (std.mem.eql(u8, pt.string, "Metaspace")) {
                                                 self.pre_tokenizer_type = .metaspace;
@@ -493,9 +504,14 @@ pub const HfTokenizer = struct {
             if (merges_val == .array) {
                 var rank: u32 = 0;
                 for (merges_val.array.items) |item| {
-                    if (item != .string) continue;
-                    if (std.mem.indexOfScalar(u8, item.string, ' ') == null) continue;
-                    const key = try self.allocator.dupe(u8, item.string);
+                    const raw_key = if (item == .string) blk: {
+                        if (std.mem.indexOfScalar(u8, item.string, ' ') == null) continue;
+                        break :blk item.string;
+                    } else if (item == .array and item.array.items.len >= 2 and item.array.items[0] == .string and item.array.items[1] == .string) blk: {
+                        break :blk try std.fmt.allocPrint(self.allocator, "{s} {s}", .{ item.array.items[0].string, item.array.items[1].string });
+                    } else continue;
+                    defer if (item == .array) self.allocator.free(raw_key);
+                    const key = try self.allocator.dupe(u8, raw_key);
                     try self.arena_strings.append(self.allocator, key);
                     // Earlier merges win ties because getOrPut is no-op on existing.
                     const gop = try self.merge_ranks.getOrPut(self.allocator, key);
@@ -666,7 +682,10 @@ pub const HfTokenizer = struct {
             // Detect common special tokens by content
             if (std.mem.eql(u8, content.string, "[CLS]")) self.special.cls_id = id;
             if (std.mem.eql(u8, content.string, "[SEP]")) self.special.sep_id = id;
-            if (std.mem.eql(u8, content.string, "[PAD]")) self.special.pad_id = id;
+            if (std.mem.eql(u8, content.string, "[PAD]")) {
+                self.special.pad_id = id;
+                self.pad_token_seen = true;
+            }
             if (std.mem.eql(u8, content.string, "[UNK]")) self.special.unk_id = id;
             if (std.mem.eql(u8, content.string, "[MASK]")) self.special.mask_id = id;
             // RoBERTa/GPT-style special tokens
@@ -674,13 +693,21 @@ pub const HfTokenizer = struct {
             if (std.mem.eql(u8, content.string, "<bos>")) self.special.cls_id = id;
             if (std.mem.eql(u8, content.string, "</s>")) self.special.sep_id = id;
             if (std.mem.eql(u8, content.string, "<eos>")) self.special.sep_id = id;
-            if (std.mem.eql(u8, content.string, "<pad>")) self.special.pad_id = id;
+            if (std.mem.eql(u8, content.string, "<pad>")) {
+                self.special.pad_id = id;
+                self.pad_token_seen = true;
+            }
             if (std.mem.eql(u8, content.string, "<unk>")) self.special.unk_id = id;
             if (std.mem.eql(u8, content.string, "<mask>")) self.special.mask_id = id;
         }
     }
 
     fn parsePostProcessor(self: *HfTokenizer, obj: std.json.ObjectMap) void {
+        const processor_type = if (obj.get("type")) |t|
+            if (t == .string) t.string else ""
+        else
+            "";
+
         if (obj.get("cls")) |cls| {
             if (cls == .array and cls.array.items.len >= 2) {
                 if (cls.array.items[1] == .integer) {
@@ -699,11 +726,26 @@ pub const HfTokenizer = struct {
             if (st == .object) {
                 if (st.object.get("[CLS]")) |cls| self.resolveSpecialToken(cls, &self.special.cls_id);
                 if (st.object.get("[SEP]")) |sep| self.resolveSpecialToken(sep, &self.special.sep_id);
-                if (st.object.get("[PAD]")) |pad| self.resolveSpecialToken(pad, &self.special.pad_id);
+                if (st.object.get("[PAD]")) |pad| {
+                    self.resolveSpecialToken(pad, &self.special.pad_id);
+                    self.pad_token_seen = true;
+                }
                 if (st.object.get("<bos>")) |bos| self.resolveSpecialToken(bos, &self.special.cls_id);
                 if (st.object.get("<eos>")) |eos| self.resolveSpecialToken(eos, &self.special.sep_id);
-                if (st.object.get("<pad>")) |pad| self.resolveSpecialToken(pad, &self.special.pad_id);
+                if (st.object.get("<pad>")) |pad| {
+                    self.resolveSpecialToken(pad, &self.special.pad_id);
+                    self.pad_token_seen = true;
+                }
             }
+        }
+
+        if (!self.pad_token_seen and
+            std.mem.eql(u8, processor_type, "RobertaProcessing") and
+            self.special.sep_id >= 0)
+        {
+            // CLIP tokenizers use RobertaProcessing with BOS/EOS specials but
+            // no distinct pad token. HuggingFace pads these models with EOS.
+            self.special.pad_id = self.special.sep_id;
         }
     }
 
@@ -1086,6 +1128,16 @@ pub const HfTokenizer = struct {
                     try self.bpeEncodeWord(allocator, word, ids);
                 }
             },
+            .byte_level_split => {
+                const words = try byteLevelSplitPreTokenize(allocator, text);
+                defer {
+                    for (words) |w| allocator.free(w);
+                    allocator.free(words);
+                }
+                for (words) |word| {
+                    try self.bpeEncodeWord(allocator, word, ids);
+                }
+            },
             .metaspace => {
                 // Metaspace: prepend ▁, split on spaces
                 const prepend_scheme = metaspace_scheme_override orelse self.metaspace_prepend_scheme;
@@ -1180,8 +1232,12 @@ pub const HfTokenizer = struct {
 
         // Some HF BPE tokenizers, including Gemma 3, contain whole-word entries
         // that are not reconstructible from the merge table alone. Prefer an
-        // exact vocab hit before falling back to character-split merges.
-        if (self.vocab.get(word)) |id| {
+        // exact vocab hit before falling back to character-split merges, but
+        // only for models without an end-of-word suffix. CLIP-style BPE has
+        // both raw byte/character entries ("a") and word-final entries
+        // ("a</w>"); taking the raw hit here bypasses suffix-aware merges.
+        if (self.end_of_word_suffix.len == 0 and self.vocab.get(word) != null) {
+            const id = self.vocab.get(word).?;
             try ids.append(allocator, id);
             return;
         }
@@ -2223,6 +2279,60 @@ fn byteLevelPreTokenize(allocator: std.mem.Allocator, text: []const u8) ![][]con
     return try words.toOwnedSlice(allocator);
 }
 
+fn byteLevelSplitPreTokenize(allocator: std.mem.Allocator, text: []const u8) ![][]const u8 {
+    var words = std.ArrayListUnmanaged([]const u8).empty;
+    var i: usize = 0;
+    while (i < text.len) {
+        const c = text[i];
+        if (std.ascii.isWhitespace(c)) {
+            i += 1;
+            continue;
+        }
+
+        const start = i;
+        if (c == '\'') {
+            const contraction_len = clipContractionLen(text[i..]);
+            if (contraction_len > 0) {
+                const encoded = try byteLevelEncode(allocator, text[i .. i + contraction_len]);
+                try words.append(allocator, encoded);
+                i += contraction_len;
+                continue;
+            }
+        }
+
+        if (std.ascii.isAlphabetic(c) or c >= 0x80) {
+            i += utf8CodepointLen(c);
+            while (i < text.len) {
+                const next = text[i];
+                if (!(std.ascii.isAlphabetic(next) or next >= 0x80)) break;
+                i += utf8CodepointLen(next);
+            }
+        } else if (std.ascii.isDigit(c)) {
+            i += 1;
+        } else {
+            i += 1;
+            while (i < text.len) {
+                const next = text[i];
+                if (std.ascii.isWhitespace(next) or std.ascii.isAlphabetic(next) or std.ascii.isDigit(next) or next >= 0x80) break;
+                if (next == '\'' and clipContractionLen(text[i..]) > 0) break;
+                i += 1;
+            }
+        }
+
+        const encoded = try byteLevelEncode(allocator, text[start..i]);
+        try words.append(allocator, encoded);
+    }
+    return try words.toOwnedSlice(allocator);
+}
+
+fn clipContractionLen(text: []const u8) usize {
+    const contractions = [_][]const u8{ "'s", "'t", "'re", "'ve", "'m", "'ll", "'d" };
+    for (contractions) |suffix| {
+        if (text.len >= suffix.len and std.ascii.eqlIgnoreCase(text[0..suffix.len], suffix)) return suffix.len;
+    }
+    return 0;
+}
+
 fn byteLevelEncode(allocator: std.mem.Allocator, text: []const u8) ![]u8 {
     var buf = std.ArrayListUnmanaged(u8).empty;
     for (text) |byte| {
@@ -2654,6 +2764,72 @@ test "infer byte-level bpe when model type is omitted" {
     try std.testing.expectEqualSlices(i32, &.{ 1, 2 }, ids);
 }
 
+test "clip byte-level bpe honors split pretokenizer array merges and end suffix" {
+    const allocator = std.testing.allocator;
+
+    const json_str =
+        \\{
+        \\  "model": {
+        \\    "type": "BPE",
+        \\    "end_of_word_suffix": "</w>",
+        \\    "vocab": {
+        \\      "<|startoftext|>": 49406,
+        \\      "<|endoftext|>": 49407,
+        \\      "a": 64,
+        \\      "a</w>": 320,
+        \\      "c": 66,
+        \\      "u": 84,
+        \\      "p": 79,
+        \\      "k": 74,
+        \\      "e": 68,
+        \\      "cu": 1000,
+        \\      "cup": 1001,
+        \\      "cupc": 1002,
+        \\      "cupca": 1003,
+        \\      "cupcak": 1004,
+        \\      "e</w>": 1005,
+        \\      "cupcake</w>": 17025
+        \\    },
+        \\    "merges": [
+        \\      ["a", "</w>"],
+        \\      ["c", "u"],
+        \\      ["cu", "p"],
+        \\      ["cup", "c"],
+        \\      ["cupc", "a"],
+        \\      ["cupca", "k"],
+        \\      ["e", "</w>"],
+        \\      ["cupcak", "e</w>"]
+        \\    ]
+        \\  },
+        \\  "pre_tokenizer": {
+        \\    "type": "Sequence",
+        \\    "pretokenizers": [
+        \\      {"type": "Split", "pattern": {"Regex": "[\\p{L}]+"}, "behavior": "Removed", "invert": true},
+        \\      {"type": "ByteLevel", "add_prefix_space": false, "trim_offsets": true}
+        \\    ]
+        \\  },
+        \\  "added_tokens": [
+        \\    {"id": 49406, "content": "<|startoftext|>", "special": true},
+        \\    {"id": 49407, "content": "<|endoftext|>", "special": true}
+        \\  ],
+        \\  "post_processor": {
+        \\    "type": "RobertaProcessing",
+        \\    "sep": ["<|endoftext|>", 49407],
+        \\    "cls": ["<|startoftext|>", 49406]
+        \\  }
+        \\}
+    ;
+
+    var hf = try HfTokenizer.loadFromBytes(allocator, json_str);
+    defer hf.deinitSelf();
+
+    var encoded = try hf.tokenizer().encodeForModel(allocator, "a cupcake", 6);
+    defer encoded.deinit();
+
+    try std.testing.expectEqualSlices(i32, &.{ 49406, 320, 17025, 49407, 49407, 49407 }, encoded.ids);
+    try std.testing.expectEqualSlices(i32, &.{ 1, 1, 1, 1, 0, 0 }, encoded.attention_mask);
+}
+
 test "sequence normalizer applies lowercase before byte-level bpe" {
     const allocator = std.testing.allocator;
 
@@ -2709,7 +2885,49 @@ test "sequence normalizer applies lowercase before byte-level bpe" {
     const tok = hf.tokenizer();
     var encoded = try tok.encodeForModel(allocator, "WHITE", 4);
     defer encoded.deinit();
-    try std.testing.expectEqualSlices(i32, &.{ 10, 1, 11, 0 }, encoded.ids);
+    try std.testing.expectEqualSlices(i32, &.{ 10, 1, 11, 11 }, encoded.ids);
+}
+
+test "clip roberta processing pads with eos when no pad token is declared" {
+    const allocator = std.testing.allocator;
+
+    const json_str =
+        \\{
+        \\  "model": {
+        \\    "type": "BPE",
+        \\    "vocab": {
+        \\      "<|startoftext|>": 49406,
+        \\      "<|endoftext|>": 49407,
+        \\      "cup": 1
+        \\    },
+        \\    "merges": []
+        \\  },
+        \\  "pre_tokenizer": {"type": "ByteLevel"},
+        \\  "added_tokens": [
+        \\    {"id": 49406, "content": "<|startoftext|>", "special": true},
+        \\    {"id": 49407, "content": "<|endoftext|>", "special": true}
+        \\  ],
+        \\  "post_processor": {
+        \\    "type": "RobertaProcessing",
+        \\    "sep": ["<|endoftext|>", 49407],
+        \\    "cls": ["<|startoftext|>", 49406]
+        \\  }
+        \\}
+    ;
+
+    var hf = try HfTokenizer.loadFromBytes(allocator, json_str);
+    defer hf.deinitSelf();
+
+    const special = hf.getSpecialTokens();
+    try std.testing.expectEqual(@as(i32, 49407), special.pad_id);
+
+    const tok = hf.tokenizer();
+    var encoded = try tok.encodeForModel(allocator, "cup", 6);
+    defer encoded.deinit();
+    try std.testing.expectEqual(@as(i32, 49406), encoded.ids[0]);
+    try std.testing.expectEqual(@as(i32, 49407), encoded.ids[2]);
+    try std.testing.expectEqual(@as(i32, 49407), encoded.ids[3]);
+    try std.testing.expectEqual(@as(i32, 0), encoded.attention_mask[3]);
 }
 
 test "bpe encode basic" {

--- a/zig/lib/vectorindex/src/search_runtime.zig
+++ b/zig/lib/vectorindex/src/search_runtime.zig
@@ -203,13 +203,7 @@ pub fn exactDistanceToStoredVector(
     query_measure: f32,
     candidate: []const f32,
 ) f32 {
-    return switch (metric.metric) {
-        .cosine => blk: {
-            if (query_measure == 0) break :blk 1.0;
-            break :blk 1.0 - (vec.dot(query, candidate) / query_measure);
-        },
-        else => vec.distanceToQuery(query, query_measure, candidate, metric.metric),
-    };
+    return vec.distanceToQuery(query, query_measure, candidate, metric.metric);
 }
 
 pub fn exactDistancesToStoredVectors(
@@ -232,9 +226,34 @@ pub fn exactDistancesToStoredVectors(
                 return;
             }
             vec.batchDot(query, candidates, distances);
-            for (distances[0..candidates.len]) |*distance| {
-                distance.* = 1.0 - (distance.* / query_measure);
+            for (distances[0..candidates.len], candidates[0..candidates.len]) |*distance, candidate| {
+                const candidate_norm = vec.norm(candidate);
+                distance.* = if (candidate_norm == 0.0) 1.0 else 1.0 - (distance.* / (query_measure * candidate_norm));
             }
         },
     }
+}
+
+test "exact cosine distance includes candidate norm" {
+    const metric = types.HBCConfig{ .dims = 2, .metric = .cosine };
+    const query = [_]f32{ 1.0, 0.0 };
+    const same_direction_large = [_]f32{ 10.0, 0.0 };
+    const orthogonal = [_]f32{ 0.0, 2.0 };
+    const query_measure = vec.norm(&query);
+
+    try std.testing.expectApproxEqAbs(
+        @as(f32, 0.0),
+        exactDistanceToStoredVector(metric, &query, query_measure, &same_direction_large),
+        1e-6,
+    );
+    try std.testing.expectApproxEqAbs(
+        @as(f32, 1.0),
+        exactDistanceToStoredVector(metric, &query, query_measure, &orthogonal),
+        1e-6,
+    );
+
+    var distances: [2]f32 = undefined;
+    exactDistancesToStoredVectors(metric, &query, query_measure, &.{ &same_direction_large, &orthogonal }, &distances);
+    try std.testing.expectApproxEqAbs(@as(f32, 0.0), distances[0], 1e-6);
+    try std.testing.expectApproxEqAbs(@as(f32, 1.0), distances[1], 1e-6);
 }

--- a/zig/pkg/antfly/src/storage/db/catalog/index_manager.zig
+++ b/zig/pkg/antfly/src/storage/db/catalog/index_manager.zig
@@ -6792,6 +6792,7 @@ pub const IndexManager = struct {
             };
         } else |err| switch (err) {
             error.Unsupported => {},
+            error.EmptySegment => return .{ .segments = &.{} },
             else => {
                 if (builtin.os.tag != .freestanding) {
                     std.log.err("scheduled text merge file-backed build failed index={s}: {s}", .{ task.index_name, @errorName(err) });
@@ -10753,10 +10754,7 @@ pub const IndexManager = struct {
         candidate: []const f32,
         metric: vector_mod.DistanceMetric,
     ) f32 {
-        return switch (metric) {
-            .cosine => if (query_measure == 0) 1.0 else 1.0 - (vector_mod.dot(query, candidate) / query_measure),
-            else => vector_mod.distanceToQuery(query, query_measure, candidate, metric),
-        };
+        return vector_mod.distanceToQuery(query, query_measure, candidate, metric);
     }
 
     fn loadDenseVectorArtifactForHbc(
@@ -17402,6 +17400,86 @@ test "text merge task skips stale source after concurrent delete" {
     const entry = manager.textIndexEntry("ft_v1") orelse return error.IndexNotFound;
     try std.testing.expect(entry.compaction_pending);
     try std.testing.expect(entry.persistent.snapshot().segments.len >= 12);
+}
+
+test "text merge task retires all-deleted file-backed inputs" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const path = try std.fmt.bufPrint(&path_buf, ".zig-cache/tmp/{s}", .{tmp.sub_path});
+    const path_z = try alloc.dupeZ(u8, path);
+    defer alloc.free(path_z);
+
+    var store = try docstore_mod.DocStore.open(alloc, path_z, .{});
+    defer store.close();
+
+    var manager = try IndexManager.init(alloc, path);
+    defer manager.deinit();
+    manager.updateRange(.{ .start = "", .end = "" });
+
+    try manager.addAllNoBackfill(&store, &.{
+        .{
+            .name = "ft_v1",
+            .kind = .full_text,
+            .config_json = "{\"field\":\"title\"}",
+        },
+    });
+
+    const opts: IndexBatchOptions = .{
+        .compact_text = false,
+        .compact_text_segment_threshold = 2,
+        .defer_text_compaction = true,
+    };
+    var inserted_keys: std.ArrayListUnmanaged([]u8) = .empty;
+    defer {
+        for (inserted_keys.items) |key| alloc.free(key);
+        inserted_keys.deinit(alloc);
+    }
+    for (0..12) |i| {
+        var key_buf: [64]u8 = undefined;
+        const key = try alloc.dupe(u8, std.fmt.bufPrint(&key_buf, "doc:{d:0>8}", .{i}) catch unreachable);
+        errdefer alloc.free(key);
+        const value = try std.fmt.allocPrint(alloc, "{{\"title\":\"merge deleted {d}\"}}", .{i});
+        defer alloc.free(value);
+
+        try store.putBatch(&.{.{ .key = key, .value = value }}, &.{});
+        try manager.indexTextBatchByNameWithOptions(&store, "ft_v1", &.{.{ .key = key, .value = value }}, opts);
+        try inserted_keys.append(alloc, key);
+    }
+    try manager.deleteTextBatchByNameWithOptions("ft_v1", inserted_keys.items, opts);
+
+    var task = (try manager.beginTextMergeTask()) orelse return error.TestUnexpectedResult;
+    defer task.deinit(alloc);
+
+    var result = try IndexManager.executeTextMergeTask(alloc, &task);
+    defer result.deinit(alloc);
+    try std.testing.expectEqual(@as(usize, 0), result.segments.len);
+    try std.testing.expectEqual(@as(usize, 0), result.prepared_segments.len);
+    try std.testing.expect(try manager.finishTextMergeTask(&task, &result));
+
+    const stats = manager.textMergeStats();
+    try std.testing.expectEqual(@as(u64, 0), stats.failed_merges);
+    try std.testing.expectEqual(@as(u64, 0), stats.in_flight_merges);
+}
+
+test "dense artifact rerank cosine distance includes candidate norm" {
+    const query = [_]f32{ 1.0, 0.0 };
+    const same_direction_large = [_]f32{ 10.0, 0.0 };
+    const orthogonal = [_]f32{ 0.0, 2.0 };
+    const query_measure = vector_mod.norm(&query);
+
+    try std.testing.expectApproxEqAbs(
+        @as(f32, 0.0),
+        IndexManager.exactStoredVectorDistance(&query, query_measure, &same_direction_large, .cosine),
+        1e-6,
+    );
+    try std.testing.expectApproxEqAbs(
+        @as(f32, 1.0),
+        IndexManager.exactStoredVectorDistance(&query, query_measure, &orthogonal, .cosine),
+        1e-6,
+    );
 }
 
 test "force text compaction supersedes in-flight scheduled merge" {

--- a/zig/pkg/antfly/src/storage/db/catalog/text_index_maintenance.zig
+++ b/zig/pkg/antfly/src/storage/db/catalog/text_index_maintenance.zig
@@ -95,6 +95,7 @@ pub fn applyPlannedMerge(
         };
     } else |err| switch (err) {
         error.Unsupported => {},
+        error.EmptySegment => return try index.removeSegmentsIfActive(old_ids),
         else => {
             logErr(merge_error_prefix, err);
             return err;

--- a/zig/pkg/inference/src/architectures/clip.zig
+++ b/zig/pkg/inference/src/architectures/clip.zig
@@ -380,31 +380,22 @@ fn selfAttn(
     defer cb.free(K);
     defer cb.free(V);
 
-    const Q_heads = try packTokenMajorToHeadMajor(cb, allocator, Q, batch, seq_len, num_heads, head_dim);
-    defer cb.free(Q_heads);
-    const K_heads = try packTokenMajorToHeadMajor(cb, allocator, K, batch, seq_len, num_heads, head_dim);
-    defer cb.free(K_heads);
-    const V_heads = try packTokenMajorToHeadMajor(cb, allocator, V, batch, seq_len, num_heads, head_dim);
-    defer cb.free(V_heads);
-
     const attn_out = if (causal)
-        try cb.causalSelfAttention(Q_heads, K_heads, V_heads, null, batch, seq_len, num_heads, head_dim)
+        try cb.causalSelfAttention(Q, K, V, null, batch, seq_len, num_heads, head_dim)
     else blk: {
         const ones = try allocator.alloc(i64, batch * seq_len);
         defer allocator.free(ones);
         @memset(ones, 1);
-        break :blk try cb.scaledDotProductAttention(Q_heads, K_heads, V_heads, ones, null, batch, seq_len, num_heads, head_dim);
+        break :blk try cb.scaledDotProductAttention(Q, K, V, ones, null, batch, seq_len, num_heads, head_dim);
     };
     defer cb.free(attn_out);
-    const attn_token_major = try unpackHeadMajorToTokenMajor(cb, allocator, attn_out, batch, seq_len, num_heads, head_dim);
-    defer cb.free(attn_token_major);
 
     var o_w_buf: [128]u8 = undefined;
     var o_b_buf: [128]u8 = undefined;
     const o_w = try cb.getWeight(try fmt(&o_w_buf, "{s}.{d}.self_attn.out_proj.weight", .{ prefix, layer }));
     const o_b = try cb.getWeight(try fmt(&o_b_buf, "{s}.{d}.self_attn.out_proj.bias", .{ prefix, layer }));
-    return (try cb.linearAdd(attn_token_major, o_w, o_b, residual, total, hidden, hidden)) orelse blk: {
-        const projected = try cb.linear(attn_token_major, o_w, o_b, total, hidden, hidden);
+    return (try cb.linearAdd(attn_out, o_w, o_b, residual, total, hidden, hidden)) orelse blk: {
+        const projected = try cb.linear(attn_out, o_w, o_b, total, hidden, hidden);
         defer cb.free(projected);
         break :blk try cb.add(residual, projected);
     };

--- a/zig/pkg/inference/src/architectures/clip_graph.zig
+++ b/zig/pkg/inference/src/architectures/clip_graph.zig
@@ -429,12 +429,29 @@ fn buildEosIndices(allocator: std.mem.Allocator, input_ids: []const i64, batch: 
     const indices = try allocator.alloc(i64, batch);
     for (0..batch) |b| {
         var eos_pos: usize = 0;
+        var eos_id: i64 = std.math.minInt(i64);
         for (0..seq_len) |s| {
-            if (input_ids[b * seq_len + s] != 0) eos_pos = s;
+            const token_id = input_ids[b * seq_len + s];
+            if (token_id > eos_id) {
+                eos_id = token_id;
+                eos_pos = s;
+            }
         }
         indices[b] = @intCast(b * seq_len + eos_pos);
     }
     return indices;
+}
+
+test "clip graph eos indices use first highest token id" {
+    const allocator = std.testing.allocator;
+    const ids = [_]i64{
+        49406, 111, 49407, 49407, 0,
+        49406, 222, 333,   49407, 49407,
+    };
+    const indices = try buildEosIndices(allocator, &ids, 2, 5);
+    defer allocator.free(indices);
+
+    try std.testing.expectEqualSlices(i64, &.{ 2, 8 }, indices);
 }
 
 fn extractPatches(

--- a/zig/pkg/inference/src/backends/backends.zig
+++ b/zig/pkg/inference/src/backends/backends.zig
@@ -138,18 +138,33 @@ pub const SessionManager = struct {
             };
 
             const session = switch (backend) {
-                .onnx => if ((shared_backend_ctx != null and isOnnxFilePath(effective_model_path)) or self.shouldUseImportedOnnxGraphRuntime(effective_model_path))
+                .onnx => if (comptime build_options.enable_onnx) blk: {
+                    if (self.shouldUseExternalOnnxRuntime(effective_model_path)) {
+                        break :blk onnx.createSession(self.allocator, effective_model_path) catch |err| {
+                            std.log.err("onnx runtime session create failed for {s}: {s}", .{ effective_model_path, @errorName(err) });
+                            return self.createImportedOnnxSession(effective_model_path, defaultImportedOnnxBackend(), shared_backend_ctx) catch |graph_err| {
+                                std.log.err("imported onnx session create failed for {s}: {s}", .{ effective_model_path, @errorName(graph_err) });
+                                return graph_err;
+                            };
+                        };
+                    }
+                    if (self.shouldUseImportedOnnxGraphRuntime(effective_model_path)) {
+                        break :blk self.createImportedOnnxSession(effective_model_path, defaultImportedOnnxBackend(), shared_backend_ctx) catch |err| {
+                            std.log.err("imported onnx graph-runtime session create failed for {s}: {s}", .{ effective_model_path, @errorName(err) });
+                            continue;
+                        };
+                    }
+                    if (isOnnxFilePath(effective_model_path)) {
+                        break :blk self.createImportedOnnxSession(effective_model_path, defaultImportedOnnxBackend(), shared_backend_ctx) catch |err| {
+                            std.log.err("imported onnx session create failed for {s}: {s}", .{ effective_model_path, @errorName(err) });
+                            continue;
+                        };
+                    }
+                    continue;
+                } else if (self.shouldUseImportedOnnxGraphRuntime(effective_model_path))
                     self.createImportedOnnxSession(effective_model_path, defaultImportedOnnxBackend(), shared_backend_ctx) catch |err| {
                         std.log.err("imported onnx graph-runtime session create failed for {s}: {s}", .{ effective_model_path, @errorName(err) });
                         continue;
-                    }
-                else if (build_options.enable_onnx and isOnnxFilePath(effective_model_path))
-                    onnx.createSession(self.allocator, effective_model_path) catch |err| {
-                        std.log.err("onnx runtime session create failed for {s}: {s}", .{ effective_model_path, @errorName(err) });
-                        return self.createImportedOnnxSession(effective_model_path, defaultImportedOnnxBackend(), shared_backend_ctx) catch |graph_err| {
-                            std.log.err("imported onnx session create failed for {s}: {s}", .{ effective_model_path, @errorName(graph_err) });
-                            return graph_err;
-                        };
                     }
                 else if (isOnnxFilePath(effective_model_path))
                     self.createImportedOnnxSession(effective_model_path, defaultImportedOnnxBackend(), shared_backend_ctx) catch |err| {
@@ -226,6 +241,13 @@ pub const SessionManager = struct {
         backend: BackendType,
         shared_backend_ctx: ?*imported_onnx_session.SharedBackendContext,
     ) !Session {
+        if (shouldFailClosedImportedClipclapOnnx(model_path)) {
+            std.log.err(
+                "imported clipclap ONNX graph runtime is disabled for {s}; build with -Donnx=true to use ONNX Runtime or set ANTFLY_UNSAFE_IMPORTED_CLIPCLAP_ONNX=1 for diagnostics",
+                .{model_path},
+            );
+            return error.UnsupportedImportedClipclapOnnxRuntime;
+        }
         return imported_onnx_session.createSessionWithOptions(self.allocator, model_path, backend, .{
             .graph_runtime_strategy = self.graph_runtime_strategy,
             .shared_backend_ctx = shared_backend_ctx,
@@ -235,6 +257,10 @@ pub const SessionManager = struct {
 
     fn shouldUseImportedOnnxGraphRuntime(self: *const SessionManager, model_path: []const u8) bool {
         return self.graph_runtime_strategy != null and isOnnxFilePath(model_path);
+    }
+
+    fn shouldUseExternalOnnxRuntime(self: *const SessionManager, model_path: []const u8) bool {
+        return build_options.enable_onnx and isOnnxFilePath(model_path) and !self.shouldUseImportedOnnxGraphRuntime(model_path);
     }
 
     pub fn bestAvailable(self: *const SessionManager) ?BackendType {
@@ -297,9 +323,23 @@ test "preferred backend override keeps fallback backends" {
 test "explicit graph runtime uses imported onnx path before external runtime" {
     var manager = SessionManager.init(std.testing.allocator);
     try std.testing.expect(!manager.shouldUseImportedOnnxGraphRuntime("model.onnx"));
+    try std.testing.expectEqual(build_options.enable_onnx, manager.shouldUseExternalOnnxRuntime("model.onnx"));
     manager.graph_runtime_strategy = .partitioned;
     try std.testing.expect(manager.shouldUseImportedOnnxGraphRuntime("model.onnx"));
+    try std.testing.expect(!manager.shouldUseExternalOnnxRuntime("model.onnx"));
     try std.testing.expect(!manager.shouldUseImportedOnnxGraphRuntime("model.gguf"));
+    try std.testing.expect(!manager.shouldUseExternalOnnxRuntime("model.gguf"));
+}
+
+test "clipclap imported onnx paths fail closed by default" {
+    try std.testing.expect(isClipclapOnnxPath("/tmp/clipclap/text_model.onnx"));
+    try std.testing.expect(isClipclapOnnxPath("/tmp/antflydb/clipclap/text_projection.onnx"));
+    try std.testing.expect(isClipclapOnnxPath("/tmp/clip-clap/visual_model.onnx"));
+    try std.testing.expect(!isClipclapOnnxPath("/tmp/other/text_model.onnx"));
+    try std.testing.expect(!isClipclapOnnxPath("/tmp/clipclap/model.gguf"));
+    if (build_options.enable_wasm or !build_options.link_libc) {
+        try std.testing.expect(shouldFailClosedImportedClipclapOnnx("/tmp/clipclap/text_model.onnx"));
+    }
 }
 
 fn preferredBackendOverride() ?BackendType {
@@ -346,6 +386,34 @@ fn shouldPreferNativeTextEncoder(man: manifest_mod.ModelManifest) bool {
         man.text_projection_path == null and
         man.visual_projection_path == null and
         man.audio_projection_path == null;
+}
+
+fn shouldFailClosedImportedClipclapOnnx(model_path: []const u8) bool {
+    if (!isClipclapOnnxPath(model_path)) return false;
+    return !unsafeImportedClipclapOnnxEnabled();
+}
+
+fn unsafeImportedClipclapOnnxEnabled() bool {
+    if (build_options.enable_wasm or !build_options.link_libc) return false;
+    const value = std.c.getenv("ANTFLY_UNSAFE_IMPORTED_CLIPCLAP_ONNX") orelse return false;
+    const slice = std.mem.span(value);
+    return std.mem.eql(u8, slice, "1") or std.ascii.eqlIgnoreCase(slice, "true");
+}
+
+fn isClipclapOnnxPath(model_path: []const u8) bool {
+    if (!isOnnxFilePath(model_path)) return false;
+    if (std.mem.indexOf(u8, model_path, "clipclap") == null and
+        std.mem.indexOf(u8, model_path, "clip-clap") == null)
+    {
+        return false;
+    }
+    const base = std.fs.path.basename(model_path);
+    return std.mem.eql(u8, base, "text_model.onnx") or
+        std.mem.eql(u8, base, "text_projection.onnx") or
+        std.mem.eql(u8, base, "visual_model.onnx") or
+        std.mem.eql(u8, base, "visual_projection.onnx") or
+        std.mem.eql(u8, base, "audio_model.onnx") or
+        std.mem.eql(u8, base, "audio_projection.onnx");
 }
 
 fn effectiveBackendOrder(

--- a/zig/pkg/inference/src/backends/backends.zig
+++ b/zig/pkg/inference/src/backends/backends.zig
@@ -46,7 +46,7 @@ pub const BackendType = enum {
     pub fn available(self: BackendType) bool {
         return switch (self) {
             .native => build_options.enable_native,
-            .onnx => true,
+            .onnx => build_options.enable_onnx,
             .metal => build_options.enable_metal,
             .cuda => build_options.enable_cuda,
             .pjrt => build_options.enable_pjrt,
@@ -139,41 +139,13 @@ pub const SessionManager = struct {
 
             const session = switch (backend) {
                 .onnx => if (comptime build_options.enable_onnx) blk: {
-                    if (self.shouldUseExternalOnnxRuntime(effective_model_path)) {
-                        break :blk onnx.createSession(self.allocator, effective_model_path) catch |err| {
-                            std.log.err("onnx runtime session create failed for {s}: {s}", .{ effective_model_path, @errorName(err) });
-                            return self.createImportedOnnxSession(effective_model_path, defaultImportedOnnxBackend(), shared_backend_ctx) catch |graph_err| {
-                                std.log.err("imported onnx session create failed for {s}: {s}", .{ effective_model_path, @errorName(graph_err) });
-                                return graph_err;
-                            };
-                        };
-                    }
-                    if (self.shouldUseImportedOnnxGraphRuntime(effective_model_path)) {
-                        break :blk self.createImportedOnnxSession(effective_model_path, defaultImportedOnnxBackend(), shared_backend_ctx) catch |err| {
-                            std.log.err("imported onnx graph-runtime session create failed for {s}: {s}", .{ effective_model_path, @errorName(err) });
-                            continue;
-                        };
-                    }
-                    if (isOnnxFilePath(effective_model_path)) {
-                        break :blk self.createImportedOnnxSession(effective_model_path, defaultImportedOnnxBackend(), shared_backend_ctx) catch |err| {
-                            std.log.err("imported onnx session create failed for {s}: {s}", .{ effective_model_path, @errorName(err) });
-                            continue;
-                        };
-                    }
-                    continue;
-                } else if (self.shouldUseImportedOnnxGraphRuntime(effective_model_path))
-                    self.createImportedOnnxSession(effective_model_path, defaultImportedOnnxBackend(), shared_backend_ctx) catch |err| {
-                        std.log.err("imported onnx graph-runtime session create failed for {s}: {s}", .{ effective_model_path, @errorName(err) });
+                    if (!isOnnxFilePath(effective_model_path)) continue;
+                    break :blk onnx.createSession(self.allocator, effective_model_path) catch |err| {
+                        std.log.err("onnx runtime session create failed for {s}: {s}", .{ effective_model_path, @errorName(err) });
                         continue;
-                    }
-                else if (isOnnxFilePath(effective_model_path))
-                    self.createImportedOnnxSession(effective_model_path, defaultImportedOnnxBackend(), shared_backend_ctx) catch |err| {
-                        std.log.err("imported onnx session create failed for {s}: {s}", .{ effective_model_path, @errorName(err) });
-                        continue;
-                    }
-                else
-                    continue,
-                .metal => if (isOnnxFilePath(effective_model_path))
+                    };
+                } else continue,
+                .metal => if (self.shouldUseImportedOnnxGraphRuntime(effective_model_path))
                     self.createImportedOnnxSession(effective_model_path, .metal, shared_backend_ctx) catch |err| {
                         std.log.err("imported onnx metal session create failed for {s}: {s}", .{ effective_model_path, @errorName(err) });
                         continue;
@@ -185,7 +157,7 @@ pub const SessionManager = struct {
                     }
                 else
                     continue,
-                .cuda => if (isOnnxFilePath(effective_model_path))
+                .cuda => if (self.shouldUseImportedOnnxGraphRuntime(effective_model_path))
                     self.createImportedOnnxSession(effective_model_path, .cuda, shared_backend_ctx) catch |err| {
                         std.log.err("imported onnx CUDA session create failed for {s}: {s}", .{ effective_model_path, @errorName(err) });
                         continue;
@@ -197,7 +169,7 @@ pub const SessionManager = struct {
                     }
                 else
                     continue,
-                .native => if (isOnnxFilePath(effective_model_path))
+                .native => if (self.shouldUseImportedOnnxGraphRuntime(effective_model_path))
                     self.createImportedOnnxSession(effective_model_path, .native, shared_backend_ctx) catch |err| {
                         std.log.err("imported onnx native session create failed for {s}: {s}", .{ effective_model_path, @errorName(err) });
                         continue;
@@ -207,7 +179,7 @@ pub const SessionManager = struct {
                         std.log.err("native session create failed for {s}: {s}", .{ model_path, @errorName(err) });
                         continue;
                     },
-                .wasm => if (isOnnxFilePath(effective_model_path))
+                .wasm => if (self.shouldUseImportedOnnxGraphRuntime(effective_model_path))
                     self.createImportedOnnxSession(effective_model_path, .wasm, shared_backend_ctx) catch |err| {
                         std.log.err("imported onnx wasm session create failed for {s}: {s}", .{ effective_model_path, @errorName(err) });
                         continue;
@@ -241,13 +213,6 @@ pub const SessionManager = struct {
         backend: BackendType,
         shared_backend_ctx: ?*imported_onnx_session.SharedBackendContext,
     ) !Session {
-        if (shouldFailClosedImportedClipclapOnnx(model_path)) {
-            std.log.err(
-                "imported clipclap ONNX graph runtime is disabled for {s}; build with -Donnx=true to use ONNX Runtime or set ANTFLY_UNSAFE_IMPORTED_CLIPCLAP_ONNX=1 for diagnostics",
-                .{model_path},
-            );
-            return error.UnsupportedImportedClipclapOnnxRuntime;
-        }
         return imported_onnx_session.createSessionWithOptions(self.allocator, model_path, backend, .{
             .graph_runtime_strategy = self.graph_runtime_strategy,
             .shared_backend_ctx = shared_backend_ctx,
@@ -260,7 +225,8 @@ pub const SessionManager = struct {
     }
 
     fn shouldUseExternalOnnxRuntime(self: *const SessionManager, model_path: []const u8) bool {
-        return build_options.enable_onnx and isOnnxFilePath(model_path) and !self.shouldUseImportedOnnxGraphRuntime(model_path);
+        _ = self;
+        return build_options.enable_onnx and isOnnxFilePath(model_path);
     }
 
     pub fn bestAvailable(self: *const SessionManager) ?BackendType {
@@ -303,8 +269,8 @@ test "onnx artifact routes graph execution for direct compute backends" {
     try std.testing.expect(!isOnnxFilePath("model.gguf"));
 }
 
-test "onnx graph import is available without onnx runtime and in wasm" {
-    try std.testing.expect(BackendType.onnx.available());
+test "onnx backend availability follows linked onnx runtime" {
+    try std.testing.expectEqual(build_options.enable_onnx, BackendType.onnx.available());
     try std.testing.expect(BackendType.onnx.supportsDirectSessionLoad());
     if (build_options.enable_wasm) {
         try std.testing.expectEqual(BackendType.wasm, configuredPreferredBackends()[0]);
@@ -320,26 +286,15 @@ test "preferred backend override keeps fallback backends" {
     try std.testing.expectEqualSlices(BackendType, &.{ .native, .onnx, .metal }, preferredBackendsForOverride(.native));
 }
 
-test "explicit graph runtime uses imported onnx path before external runtime" {
+test "explicit graph runtime is independent from onnx runtime backend availability" {
     var manager = SessionManager.init(std.testing.allocator);
     try std.testing.expect(!manager.shouldUseImportedOnnxGraphRuntime("model.onnx"));
     try std.testing.expectEqual(build_options.enable_onnx, manager.shouldUseExternalOnnxRuntime("model.onnx"));
     manager.graph_runtime_strategy = .partitioned;
     try std.testing.expect(manager.shouldUseImportedOnnxGraphRuntime("model.onnx"));
-    try std.testing.expect(!manager.shouldUseExternalOnnxRuntime("model.onnx"));
+    try std.testing.expectEqual(build_options.enable_onnx, manager.shouldUseExternalOnnxRuntime("model.onnx"));
     try std.testing.expect(!manager.shouldUseImportedOnnxGraphRuntime("model.gguf"));
     try std.testing.expect(!manager.shouldUseExternalOnnxRuntime("model.gguf"));
-}
-
-test "clipclap imported onnx paths fail closed by default" {
-    try std.testing.expect(isClipclapOnnxPath("/tmp/clipclap/text_model.onnx"));
-    try std.testing.expect(isClipclapOnnxPath("/tmp/antflydb/clipclap/text_projection.onnx"));
-    try std.testing.expect(isClipclapOnnxPath("/tmp/clip-clap/visual_model.onnx"));
-    try std.testing.expect(!isClipclapOnnxPath("/tmp/other/text_model.onnx"));
-    try std.testing.expect(!isClipclapOnnxPath("/tmp/clipclap/model.gguf"));
-    if (build_options.enable_wasm or !build_options.link_libc) {
-        try std.testing.expect(shouldFailClosedImportedClipclapOnnx("/tmp/clipclap/text_model.onnx"));
-    }
 }
 
 fn preferredBackendOverride() ?BackendType {
@@ -386,34 +341,6 @@ fn shouldPreferNativeTextEncoder(man: manifest_mod.ModelManifest) bool {
         man.text_projection_path == null and
         man.visual_projection_path == null and
         man.audio_projection_path == null;
-}
-
-fn shouldFailClosedImportedClipclapOnnx(model_path: []const u8) bool {
-    if (!isClipclapOnnxPath(model_path)) return false;
-    return !unsafeImportedClipclapOnnxEnabled();
-}
-
-fn unsafeImportedClipclapOnnxEnabled() bool {
-    if (build_options.enable_wasm or !build_options.link_libc) return false;
-    const value = std.c.getenv("ANTFLY_UNSAFE_IMPORTED_CLIPCLAP_ONNX") orelse return false;
-    const slice = std.mem.span(value);
-    return std.mem.eql(u8, slice, "1") or std.ascii.eqlIgnoreCase(slice, "true");
-}
-
-fn isClipclapOnnxPath(model_path: []const u8) bool {
-    if (!isOnnxFilePath(model_path)) return false;
-    if (std.mem.indexOf(u8, model_path, "clipclap") == null and
-        std.mem.indexOf(u8, model_path, "clip-clap") == null)
-    {
-        return false;
-    }
-    const base = std.fs.path.basename(model_path);
-    return std.mem.eql(u8, base, "text_model.onnx") or
-        std.mem.eql(u8, base, "text_projection.onnx") or
-        std.mem.eql(u8, base, "visual_model.onnx") or
-        std.mem.eql(u8, base, "visual_projection.onnx") or
-        std.mem.eql(u8, base, "audio_model.onnx") or
-        std.mem.eql(u8, base, "audio_projection.onnx");
 }
 
 fn effectiveBackendOrder(

--- a/zig/pkg/inference/src/backends/imported_onnx_session.zig
+++ b/zig/pkg/inference/src/backends/imported_onnx_session.zig
@@ -52,6 +52,8 @@ const GpuWeightStore = if (build_options.enable_metal) gpu_store_mod.WeightStore
 const MetalCompute = if (build_options.enable_metal) metal_compute_mod.MetalCompute else opaque {};
 const WasmCompute = if (build_options.enable_wasm) wasm_compute_mod.WasmCompute else opaque {};
 const clipclap_audio_input_frames: i64 = 1001;
+const clipclap_text_batch: i64 = 1;
+const clipclap_text_sequence_length: i64 = 77;
 
 const WasmGraphRuntime = struct {
     pub const Strategy = enum {
@@ -122,6 +124,11 @@ const WasmGraphRuntime = struct {
 fn shouldSpecializeClipclapAudioInputTime(path: []const u8) bool {
     const base = std.fs.path.basename(path);
     return std.mem.eql(u8, base, "audio_model.onnx");
+}
+
+fn shouldSpecializeClipclapTextInputShape(path: []const u8) bool {
+    const base = std.fs.path.basename(path);
+    return std.mem.eql(u8, base, "text_model.onnx");
 }
 
 const BackendContext = union(enum) {
@@ -730,14 +737,19 @@ pub fn createSessionWithOptions(
     var model = try onnx_graph.parseLazyAsModelWithBaseDir(allocator, model_bytes, model_dir);
     defer model.deinit();
 
-    var clipclap_audio_dim_overrides: onnx_graph.DimOverrides = .empty;
-    defer clipclap_audio_dim_overrides.deinit(allocator);
-    var use_clipclap_audio_dim_overrides = false;
+    var clipclap_dim_overrides: onnx_graph.DimOverrides = .empty;
+    defer clipclap_dim_overrides.deinit(allocator);
+    var use_clipclap_dim_overrides = false;
     if (options.dim_overrides == null and shouldSpecializeClipclapAudioInputTime(onnx_path)) {
-        try clipclap_audio_dim_overrides.put(allocator, "time", clipclap_audio_input_frames);
-        use_clipclap_audio_dim_overrides = true;
+        try clipclap_dim_overrides.put(allocator, "time", clipclap_audio_input_frames);
+        use_clipclap_dim_overrides = true;
     }
-    const dim_overrides = options.dim_overrides orelse if (use_clipclap_audio_dim_overrides) &clipclap_audio_dim_overrides else null;
+    if (options.dim_overrides == null and shouldSpecializeClipclapTextInputShape(onnx_path)) {
+        try clipclap_dim_overrides.put(allocator, "batch_size", clipclap_text_batch);
+        try clipclap_dim_overrides.put(allocator, "sequence_length", clipclap_text_sequence_length);
+        use_clipclap_dim_overrides = true;
+    }
+    const dim_overrides = options.dim_overrides orelse if (use_clipclap_dim_overrides) &clipclap_dim_overrides else null;
 
     var converted = try model.convertToGraphWithDims(allocator, dim_overrides);
     errdefer converted.deinit(allocator);
@@ -1814,8 +1826,14 @@ fn defaultClipclapTextModelPath(allocator: std.mem.Allocator) ![]u8 {
 }
 
 fn defaultClipclapModelPath(allocator: std.mem.Allocator, file_name: []const u8) ![]u8 {
+    if (std.c.getenv("ANTFLY_TEST_CLIPCLAP_ONNX_DIR")) |dir| {
+        return std.fs.path.join(allocator, &.{ std.mem.span(dir), file_name });
+    }
     const home = std.c.getenv("HOME") orelse return error.SkipZigTest;
-    return std.fs.path.join(allocator, &.{ std.mem.span(home), ".antfly", "models", "antflydb", "clipclap", file_name });
+    const preferred = try std.fs.path.join(allocator, &.{ std.mem.span(home), ".antfly", "models", "antflydb", "clipclap", file_name });
+    if (c_file.fileExists(allocator, preferred)) return preferred;
+    allocator.free(preferred);
+    return std.fs.path.join(allocator, &.{ std.mem.span(home), ".antfly", "inference", "models", "antflydb", "clipclap", file_name });
 }
 
 test "imported onnx session executes clipclap text model natively with padded mask" {
@@ -1848,6 +1866,17 @@ test "imported onnx session executes clipclap text model natively with padded ma
     }
 
     try std.testing.expect(outputs.len > 0);
+    if (std.c.getenv("ANTFLY_TEST_DUMP_CLIPCLAP_OUTPUTS") != null) {
+        std.debug.print("clipclap outputs={d}\n", .{outputs.len});
+        for (outputs, 0..) |*output, idx| {
+            const values = output.asFloat32();
+            std.debug.print("  output[{d}] name={s} shape={any} first=", .{ idx, output.name, output.shape });
+            for (values[0..@min(values.len, 8)]) |value| {
+                std.debug.print("{d:.6} ", .{value});
+            }
+            std.debug.print("\n", .{});
+        }
+    }
     try std.testing.expectEqual(DType.f32, outputs[0].dtype);
     try std.testing.expect(outputs[0].elementCount() > 0);
     for (outputs[0].asFloat32()) |value| {
@@ -2003,14 +2032,19 @@ fn expectClipclapOnnxPlansForMetal(file_name: []const u8, expectations: Clipclap
     var model = try onnx_graph.parseLazyAsModelWithBaseDir(allocator, model_bytes, model_dir);
     defer model.deinit();
 
-    var clipclap_audio_dim_overrides: onnx_graph.DimOverrides = .empty;
-    defer clipclap_audio_dim_overrides.deinit(allocator);
-    var use_clipclap_audio_dim_overrides = false;
+    var clipclap_dim_overrides: onnx_graph.DimOverrides = .empty;
+    defer clipclap_dim_overrides.deinit(allocator);
+    var use_clipclap_dim_overrides = false;
     if (shouldSpecializeClipclapAudioInputTime(path)) {
-        try clipclap_audio_dim_overrides.put(allocator, "time", clipclap_audio_input_frames);
-        use_clipclap_audio_dim_overrides = true;
+        try clipclap_dim_overrides.put(allocator, "time", clipclap_audio_input_frames);
+        use_clipclap_dim_overrides = true;
     }
-    const dim_overrides: ?*const onnx_graph.DimOverrides = if (use_clipclap_audio_dim_overrides) &clipclap_audio_dim_overrides else null;
+    if (shouldSpecializeClipclapTextInputShape(path)) {
+        try clipclap_dim_overrides.put(allocator, "batch_size", clipclap_text_batch);
+        try clipclap_dim_overrides.put(allocator, "sequence_length", clipclap_text_sequence_length);
+        use_clipclap_dim_overrides = true;
+    }
+    const dim_overrides: ?*const onnx_graph.DimOverrides = if (use_clipclap_dim_overrides) &clipclap_dim_overrides else null;
 
     var converted = try model.convertToGraphWithDims(allocator, dim_overrides);
     defer converted.deinit(allocator);

--- a/zig/pkg/inference/src/backends/session.zig
+++ b/zig/pkg/inference/src/backends/session.zig
@@ -29,7 +29,16 @@ pub const ResidentOutputs = struct {
     allocator: std.mem.Allocator,
 
     pub fn deinit(self: *ResidentOutputs) void {
-        for (self.outputs) |output| self.backend.free(output);
+        for (self.outputs, 0..) |output, idx| {
+            var seen = false;
+            for (self.outputs[0..idx]) |prev| {
+                if (prev == output) {
+                    seen = true;
+                    break;
+                }
+            }
+            if (!seen) self.backend.free(output);
+        }
         self.allocator.free(self.outputs);
         self.outputs = &.{};
     }

--- a/zig/pkg/inference/src/native_export_gguf.zig
+++ b/zig/pkg/inference/src/native_export_gguf.zig
@@ -2384,6 +2384,7 @@ fn buildClipPlannedExportFiltered(
     name_filter: TensorNameFilter,
 ) !PlannedExport {
     const source_is_gguf = source_kind == .gguf;
+    const source_is_onnx = tensor_access_mod.isOnnxInitializerAccess(access);
     const names = try access.listNames(allocator);
     defer allocator.free(names);
     std.mem.sort([]const u8, names, {}, struct {
@@ -2410,10 +2411,10 @@ fn buildClipPlannedExportFiltered(
             try mapDenseTensorNameToClipGguf(allocator, record.descriptor.name);
         defer if (output_name_result.owned) allocator.free(output_name_result.name);
 
-        const transform = if (source_is_gguf)
+        const transform = if (source_is_gguf or !source_is_onnx)
             TensorTransform.none
         else
-            clipClapDenseExportTransformForTensor(name_filter, record.descriptor.name, record.descriptor.shape);
+            clipClapOnnxDenseExportTransformForTensor(record.descriptor.name, record.descriptor.shape);
         const dimensions = switch (transform) {
             .none => try reversedDimsFromShape(allocator, record.descriptor.shape),
             .transpose_2d_dense => try dimsFromShape(allocator, record.descriptor.shape),
@@ -2505,6 +2506,7 @@ fn buildClapPlannedExportFiltered(
     name_filter: TensorNameFilter,
 ) !PlannedExport {
     const source_is_gguf = source_kind == .gguf;
+    const source_is_onnx = tensor_access_mod.isOnnxInitializerAccess(access);
     const names = try access.listNames(allocator);
     defer allocator.free(names);
     std.mem.sort([]const u8, names, {}, struct {
@@ -2531,10 +2533,10 @@ fn buildClapPlannedExportFiltered(
             try mapDenseTensorNameToClapGguf(allocator, record.descriptor.name);
         defer if (output_name_result.owned) allocator.free(output_name_result.name);
 
-        const transform = if (source_is_gguf)
+        const transform = if (source_is_gguf or !source_is_onnx)
             TensorTransform.none
         else
-            clipClapDenseExportTransformForTensor(name_filter, record.descriptor.name, record.descriptor.shape);
+            clipClapOnnxDenseExportTransformForTensor(record.descriptor.name, record.descriptor.shape);
         const dimensions = switch (transform) {
             .none => try reversedDimsFromShape(allocator, record.descriptor.shape),
             .transpose_2d_dense => try dimsFromShape(allocator, record.descriptor.shape),
@@ -2628,12 +2630,10 @@ fn isExportableDenseRecord(record: tensor_access_mod.Record) bool {
     };
 }
 
-fn clipClapDenseExportTransformForTensor(
-    name_filter: TensorNameFilter,
+fn clipClapOnnxDenseExportTransformForTensor(
     source_name: []const u8,
     shape: []const i64,
 ) TensorTransform {
-    if (name_filter == .all) return .none;
     if (shape.len != 2) return .none;
     if (!std.mem.endsWith(u8, source_name, ".weight")) return .none;
     if (isClipOnnxMatMulWeight(source_name) or isClapOnnxMatMulWeight(source_name)) return .transpose_2d_dense;
@@ -2657,6 +2657,34 @@ fn isClapOnnxMatMulWeight(source_name: []const u8) bool {
         std.mem.indexOf(u8, source_name, ".downsample.reduction.") != null or
         std.mem.indexOf(u8, source_name, ".intermediate.dense.") != null or
         std.mem.indexOf(u8, source_name, ".output.dense.") != null;
+}
+
+test "clipclap ONNX export transforms MatMul weights independent of bundle filter" {
+    try std.testing.expectEqual(
+        TensorTransform.transpose_2d_dense,
+        clipClapOnnxDenseExportTransformForTensor(
+            "text_model.encoder.layers.0.self_attn.q_proj.weight",
+            &.{ 512, 512 },
+        ),
+    );
+    try std.testing.expectEqual(
+        TensorTransform.transpose_2d_dense,
+        clipClapOnnxDenseExportTransformForTensor(
+            "audio_model.audio_encoder.layers.0.intermediate.dense.weight",
+            &.{ 2048, 1024 },
+        ),
+    );
+    try std.testing.expectEqual(
+        TensorTransform.none,
+        clipClapOnnxDenseExportTransformForTensor("text_projection.weight", &.{ 512, 512 }),
+    );
+    try std.testing.expectEqual(
+        TensorTransform.none,
+        clipClapOnnxDenseExportTransformForTensor(
+            "text_model.encoder.layers.0.self_attn.q_proj.bias",
+            &.{512},
+        ),
+    );
 }
 
 fn appendGptNeoxSplitTensorPlans(

--- a/zig/pkg/inference/src/ops/native_compute.zig
+++ b/zig/pkg/inference/src/ops/native_compute.zig
@@ -46567,6 +46567,51 @@ test "dot_general handles batched rhs free-before-contract layout" {
     }
 }
 
+test "dot_general handles clip vision attention score shape" {
+    const allocator = std.testing.allocator;
+    var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
+    var compute = NativeCompute.init(allocator, &weight_store, null);
+
+    const batch = 1;
+    const heads = 12;
+    const seq = 50;
+    const dim = 64;
+
+    const lhs_data = try allocator.alloc(f32, batch * heads * seq * dim);
+    defer allocator.free(lhs_data);
+    @memset(lhs_data, 1.0);
+    const rhs_data = try allocator.alloc(f32, batch * heads * dim * seq);
+    defer allocator.free(rhs_data);
+    @memset(rhs_data, 1.0);
+
+    const lhs_ct = try compute.makeBuf(lhs_data, false);
+    defer freeTensor(&compute, lhs_ct);
+    const lhs_shaped = try compute.withLogicalShape(lhs_ct, &.{ batch, heads, seq, dim });
+
+    const rhs_ct = try compute.makeBuf(rhs_data, false);
+    defer freeTensor(&compute, rhs_ct);
+    const rhs_shaped = try compute.withLogicalShape(rhs_ct, &.{ batch, heads, dim, seq });
+
+    const out_ct = try primDotGeneralOp(
+        &compute,
+        lhs_shaped,
+        rhs_shaped,
+        &.{ -1, heads, seq, dim },
+        &.{ -1, heads, dim, seq },
+        &.{3},
+        &.{2},
+        &.{ 0, 1 },
+        &.{ 0, 1 },
+    );
+    defer freeTensor(&compute, out_ct);
+
+    try std.testing.expectEqualSlices(i64, &.{ batch, heads, seq, seq }, tensorStoredShape(out_ct).?);
+    try std.testing.expectEqual(@as(usize, batch * heads * seq * seq), getData(out_ct).len);
+    for (getData(out_ct)) |value| {
+        try std.testing.expectApproxEqAbs(@as(f32, dim), value, 1e-5);
+    }
+}
+
 test "dot_general preserves declared symbolic batch factorization" {
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };

--- a/zig/pkg/inference/src/ops/native_compute.zig
+++ b/zig/pkg/inference/src/ops/native_compute.zig
@@ -6100,7 +6100,8 @@ fn sdpaOp(ctx: *anyopaque, q_ct: CT, k_ct: CT, v_ct: CT, mask: []const i64, attn
             seq_len,
         });
     }
-    const bias_shared_len = num_heads * effective_seq_len * effective_seq_len;
+    const bias_seq_len = effective_seq_len * effective_seq_len;
+    const bias_shared_len = num_heads * bias_seq_len;
     const bias_batched_len = effective_batch * bias_shared_len;
     const bh = effective_batch * num_heads;
     const scale: f32 = 1.0 / @sqrt(@as(f32, @floatFromInt(head_dim)));
@@ -6116,7 +6117,7 @@ fn sdpaOp(ctx: *anyopaque, q_ct: CT, k_ct: CT, v_ct: CT, mask: []const i64, attn
     // broadcasts; safer to keep that case on the legacy path.
     const flash_eligible = effective_seq_len >= 32 and
         mask.len >= effective_batch * effective_seq_len and
-        (bias == null or bias.?.len == bias_shared_len or bias.?.len == bias_batched_len);
+        (bias == null or bias.?.len == bias_seq_len or bias.?.len == bias_shared_len or bias.?.len == bias_batched_len);
     if (flash_eligible) {
         const flash_output = try linalg.flashAttentionHost(
             self.allocator,
@@ -6174,13 +6175,19 @@ fn sdpaOp(ctx: *anyopaque, q_ct: CT, k_ct: CT, v_ct: CT, mask: []const i64, attn
 
         // Add position bias if provided: bias[h, qi, ki]
         if (bias) |b_data| {
-            const head_offset = if (b_data.len == bias_batched_len)
+            const head_offset: ?usize = if (b_data.len == bias_batched_len)
                 bh_idx * effective_seq_len * effective_seq_len
+            else if (b_data.len == bias_shared_len)
+                h * effective_seq_len * effective_seq_len
+            else if (b_data.len == bias_seq_len)
+                0
             else
-                h * effective_seq_len * effective_seq_len;
-            for (0..effective_seq_len) |qi| {
-                for (0..effective_seq_len) |ki| {
-                    scores[qi * effective_seq_len + ki] += b_data[head_offset + qi * effective_seq_len + ki];
+                null;
+            if (head_offset) |off| {
+                for (0..effective_seq_len) |qi| {
+                    for (0..effective_seq_len) |ki| {
+                        scores[qi * effective_seq_len + ki] += b_data[off + qi * effective_seq_len + ki];
+                    }
                 }
             }
         }

--- a/zig/pkg/inference/src/pipelines/embedding.zig
+++ b/zig/pkg/inference/src/pipelines/embedding.zig
@@ -298,6 +298,21 @@ pub const EmbeddingPipeline = struct {
 
         if (outputs.len == 0) return error.NoOutputTensors;
 
+        if (self.text_projection) |proj| {
+            if (projectionInputDim(proj)) |expected_dim| {
+                if (selectProjectedOutput(outputs, expected_dim, batch)) |selection| {
+                    logEmbedSelectedTensor(self.print_timing, "text.project_input", selection.tensor);
+                    const projected_embeddings = if (selection.use_cls_pool)
+                        try self.pool3D(selection.tensor, all_mask, batch, effective_len, false)
+                    else
+                        try self.extract2D(selection.tensor, batch, false);
+                    errdefer freeEmbeddingSlices(alloc, projected_embeddings);
+                    try self.projectEmbeddings(projected_embeddings, proj);
+                    return projected_embeddings;
+                }
+            }
+        }
+
         // Get the first output tensor (last_hidden_state for encoder models)
         const output = &outputs[0];
         const output_shape = output.shape;
@@ -2135,6 +2150,23 @@ test "resident 2d embedding extraction normalizes before host readback" {
     try std.testing.expectApproxEqAbs(@as(f32, 0.6), embeddings[0][0], 1e-6);
     try std.testing.expectApproxEqAbs(@as(f32, 0.8), embeddings[0][1], 1e-6);
     try std.testing.expectEqualSlices(f32, &.{ 0.0, 0.0 }, embeddings[1]);
+}
+
+test "projected output selection prefers pooled 2D encoder output" {
+    const allocator = std.testing.allocator;
+
+    const hidden_data = [_]f32{ 1.0, 2.0, 3.0, 4.0 };
+    var hidden = try Tensor.initFloat32(allocator, "last_hidden_state", &.{ 1, 2, 2 }, &hidden_data);
+    defer hidden.deinit();
+    const pooled_data = [_]f32{ 5.0, 6.0 };
+    var pooled = try Tensor.initFloat32(allocator, "pooler_output", &.{ 1, 2 }, &pooled_data);
+    defer pooled.deinit();
+
+    var outputs = [_]Tensor{ hidden, pooled };
+    const selection = selectProjectedOutput(outputs[0..], 2, 1) orelse return error.TestExpectedEqual;
+
+    try std.testing.expect(!selection.use_cls_pool);
+    try std.testing.expectEqualStrings("pooler_output", selection.tensor.name);
 }
 
 test "embedImages uses one vision session run for an image batch" {

--- a/zig/pkg/inference/src/pipelines/embedding.zig
+++ b/zig/pkg/inference/src/pipelines/embedding.zig
@@ -215,7 +215,7 @@ pub const EmbeddingPipeline = struct {
     pub fn embed(self: *EmbeddingPipeline, texts: []const []const u8) ![][]f32 {
         if (texts.len == 0) return try self.allocator.alloc([]f32, 0);
         const text_session = self.textEncodingSession();
-        if (text_session.backend() == .onnx and texts.len > 1) {
+        if (textSessionRequiresSerialBatch(text_session, texts.len)) {
             return try self.embedSerial(texts);
         }
 
@@ -1616,9 +1616,34 @@ test "embedding text length follows fixed input_ids sequence dimension" {
     try std.testing.expectEqual(@as(usize, 77), textSequenceLengthForInputs(&input_info, 512));
 }
 
+test "embedding text serializes batches that exceed declared input_ids batch" {
+    const dynamic = fakeTextSession(.native, &.{ -1, 77 });
+    try std.testing.expect(!textSessionRequiresSerialBatch(dynamic, 2));
+
+    const fixed_one = fakeTextSession(.native, &.{ 1, 77 });
+    try std.testing.expect(!textSessionRequiresSerialBatch(fixed_one, 1));
+    try std.testing.expect(textSessionRequiresSerialBatch(fixed_one, 2));
+
+    const external_onnx = fakeTextSession(.onnx, &.{ -1, 77 });
+    try std.testing.expect(textSessionRequiresSerialBatch(external_onnx, 2));
+}
+
 fn sessionHasInput(session: backends.Session, name: []const u8) bool {
     for (session.inputInfo()) |info| {
         if (std.mem.eql(u8, info.name, name)) return true;
+    }
+    return false;
+}
+
+fn textSessionRequiresSerialBatch(session: backends.Session, requested_batch: usize) bool {
+    if (requested_batch <= 1) return false;
+    if (session.backend() == .onnx) return true;
+    if (backends.imported_onnx_session.sharedBackendContext(session) != null) return true;
+    for (session.inputInfo()) |info| {
+        if (!std.mem.eql(u8, info.name, "input_ids")) continue;
+        if (info.shape.len == 0) return false;
+        const declared_batch = info.shape[0];
+        return declared_batch > 0 and @as(usize, @intCast(declared_batch)) < requested_batch;
     }
     return false;
 }
@@ -1645,6 +1670,41 @@ fn outputsContainBatchRows(outputs: []const Tensor, expected_batch: usize) bool 
         if (output.shape.len >= 2 and tensorHasBatchRows(output, expected_batch)) return true;
     }
     return false;
+}
+
+fn fakeTextSession(comptime backend_type: backends.BackendType, comptime input_shape: []const i64) backends.Session {
+    const VTable = struct {
+        fn run(_: *anyopaque, _: []const Tensor, _: std.mem.Allocator) anyerror![]Tensor {
+            return error.TestUnexpectedResult;
+        }
+
+        fn inputInfo(_: *anyopaque) []const backends.TensorInfo {
+            return &.{.{ .name = "input_ids", .dtype = .i64, .shape = input_shape }};
+        }
+
+        fn outputInfo(_: *anyopaque) []const backends.TensorInfo {
+            return &.{};
+        }
+
+        fn backend(_: *anyopaque) backends.BackendType {
+            return backend_type;
+        }
+
+        fn close(_: *anyopaque) void {}
+    };
+    const state = struct {
+        var value: u8 = 0;
+    };
+    return .{
+        .ptr = @ptrCast(&state.value),
+        .vtable = &.{
+            .run = VTable.run,
+            .inputInfo = VTable.inputInfo,
+            .outputInfo = VTable.outputInfo,
+            .backend = VTable.backend,
+            .close = VTable.close,
+        },
+    };
 }
 
 fn embedTimingEnabled(explicit: bool) bool {


### PR DESCRIPTION
## Summary
- fix CLIP/clipclap HuggingFace tokenizer parity for Split+ByteLevel tokenizers, array-form BPE merges, </w> suffix merges, and EOS padding
- prefer external ONNX Runtime for .onnx sessions when built with -Donnx=true instead of routing through the imported graph context
- fail closed for known-bad imported clipclap ONNX graph-runtime paths unless ANTFLY_UNSAFE_IMPORTED_CLIPCLAP_ONNX=1 is set
- fix exact cosine rerank normalization and all-deleted text segment merge handling
- add focused regressions for tokenizer, CLIP pooling/projection selection, CLIP attention dot_general shape, cosine distance, and empty text merges

## Validation
- zig build
- zig build -Donnx=true
- zig build test-tokenizer
- zig build test -Druntime-test-filter=true -- --test-filter "clipclap imported onnx paths fail closed by default"
- zig build test -Druntime-test-filter=true -- --test-filter "explicit graph runtime uses imported onnx path before external runtime"
- zig build test -Druntime-test-filter=true -- --test-filter "projected output selection prefers pooled 2D encoder output"
- zig build lib-storage-test -- --test-filter "text merge task retires all-deleted file-backed inputs"
- zig build lib-storage-test -- --test-filter "dense artifact rerank cosine distance includes candidate norm"
- zig build lib-vectorindex-test
- local stock ONNX Runtime vs Antfly ONNX clipclap text probe: same-text cosine min/mean/max = 1.000000/1.000000/1.000000
- forced imported graph runtime now exits non-zero instead of returning bad clipclap vectors

## Notes
Native GGUF clipclap text embeddings still do not match the ONNX reference closely enough to call correct. This PR prevents silent bad imported ONNX graph results and fixes the validated external ORT path; native GGUF parity should be handled with a dedicated native CLIP parity harness.