### PR TITLE
Fix backup forwarding and runRound phase logs

### DIFF
--- a/zig/build.zig
+++ b/zig/build.zig
@@ -3516,6 +3516,7 @@ pub fn build(b: *std.Build) void {
         "api http server serves table metadata routes against real metadata service",
         "api http server create table with replication sources returns encoded table detail",
         "api http server lists cluster backups through public route",
+        "api http server forwards cluster backup mutations to metadata leader",
         "api http server backs up and restores a table through public routes",
         "api http server prefers metadata-owned restore over inline write-source restore",
         "public API request body limit matches Go linear merge contract",

--- a/zig/pkg/antfly/src/api/http_server.zig
+++ b/zig/pkg/antfly/src/api/http_server.zig
@@ -3899,6 +3899,7 @@ pub const ApiHttpServer = struct {
             }
         }
         if (req.method == .POST and std.mem.eql(u8, uri_parts.path, routes.Routes.backup)) {
+            if (try self.forwardMetadataMutationToLeader(req)) |resp| return resp;
             return try self.handlePublicClusterBackup(req.body);
         }
         if (req.method == .POST) {
@@ -12219,9 +12220,9 @@ test "api http server requires auth on public routes when enabled" {
 test "api http server dispatches HA admin and internal executors" {
     const alloc = std.testing.allocator;
     const FakeSource = struct {
-        fn iface(_: *@This()) StatusSource {
+        fn iface(self: *@This()) StatusSource {
             return .{
-                .ptr = undefined,
+                .ptr = self,
                 .vtable = &.{ .status = status },
             };
         }
@@ -12304,9 +12305,9 @@ test "api http server dispatches HA admin and internal executors" {
 test "api http server protects HA admin routes while exempting HA internal routes" {
     const alloc = std.testing.allocator;
     const FakeSource = struct {
-        fn iface(_: *@This()) StatusSource {
+        fn iface(self: *@This()) StatusSource {
             return .{
-                .ptr = undefined,
+                .ptr = self,
                 .vtable = &.{ .status = status },
             };
         }
@@ -20752,6 +20753,75 @@ test "api http server lists cluster backups through public route" {
     try std.testing.expectEqualStrings("docs", parsed.value.backups[0].tables[0]);
     try std.testing.expectEqualStrings(location_uri, parsed.value.backups[0].location);
     try std.testing.expect(parsed.value.backups[0].timestamp.len > 0);
+}
+
+test "api http server forwards cluster backup mutations to metadata leader" {
+    const alloc = std.testing.allocator;
+    const FakeSource = struct {
+        fn iface(self: *@This()) StatusSource {
+            return .{
+                .ptr = self,
+                .vtable = &.{ .status = status },
+            };
+        }
+
+        fn status(_: *anyopaque) !metadata_api.MetadataStatus {
+            return .{ .metadata_group_id = 1, .metrics = .{}, .projected_stores = 1 };
+        }
+    };
+    const CaptureForwarder = struct {
+        calls: usize = 0,
+        uri: []u8 = &.{},
+        body: []u8 = &.{},
+
+        fn iface(self: *@This()) RequestForwarder {
+            return .{
+                .ptr = self,
+                .vtable = &.{ .forward = forward },
+            };
+        }
+
+        fn deinit(self: *@This(), allocator: std.mem.Allocator) void {
+            if (self.uri.len > 0) allocator.free(self.uri);
+            if (self.body.len > 0) allocator.free(self.body);
+            self.* = .{};
+        }
+
+        fn forward(ptr: *anyopaque, allocator: std.mem.Allocator, req: http_common.HttpRequest) !?http_common.HttpResponse {
+            const self: *@This() = @ptrCast(@alignCast(ptr));
+            self.calls += 1;
+            if (self.uri.len > 0) allocator.free(self.uri);
+            if (self.body.len > 0) allocator.free(self.body);
+            self.uri = try allocator.dupe(u8, req.uri);
+            self.body = try allocator.dupe(u8, req.body);
+            return .{
+                .status = 202,
+                .content_type = try allocator.dupe(u8, "text/plain"),
+                .body = try allocator.dupe(u8, "forwarded"),
+            };
+        }
+    };
+
+    var source = FakeSource{};
+    var forwarder = CaptureForwarder{};
+    defer forwarder.deinit(alloc);
+    var server = ApiHttpServer.init(alloc, .{
+        .metadata_mutation_forwarder = forwarder.iface(),
+    }, source.iface(), null, null);
+
+    var resp = try server.handle(.{
+        .method = .POST,
+        .uri = "/backup",
+        .content_type = "application/json",
+        .body = "{\"backup_id\":\"snap1\",\"location\":\"file:///tmp/backups\"}",
+    });
+    defer resp.deinit(alloc);
+
+    try std.testing.expectEqual(@as(usize, 1), forwarder.calls);
+    try std.testing.expectEqual(@as(u16, 202), resp.status);
+    try std.testing.expectEqualStrings("forwarded", resp.body);
+    try std.testing.expectEqualStrings("/backup", forwarder.uri);
+    try std.testing.expectEqualStrings("{\"backup_id\":\"snap1\",\"location\":\"file:///tmp/backups\"}", forwarder.body);
 }
 
 test "api http server backs up and restores a table through public routes" {

--- a/zig/pkg/antfly/src/metadata/runtime.zig
+++ b/zig/pkg/antfly/src/metadata/runtime.zig
@@ -848,7 +848,7 @@ pub fn runFromIterator(
         const run_round_start_ns = platform_time.monotonicNs();
         try server.runRound();
         const run_round_elapsed_ns = platform_time.monotonicNs() -| run_round_start_ns;
-        if (run_round_elapsed_ns > std.time.ns_per_s) {
+        if (run_round_elapsed_ns > antfly.metadata_service.metadata_run_round_slow_threshold_ns) {
             std.log.warn("metadata runRound slow elapsed_ms={d}", .{@divTrunc(run_round_elapsed_ns, std.time.ns_per_ms)});
         }
         const cdc_round_start_ns = platform_time.monotonicNs();

--- a/zig/pkg/antfly/src/metadata/service.zig
+++ b/zig/pkg/antfly/src/metadata/service.zig
@@ -51,20 +51,97 @@ const internal_keys = @import("../storage/internal_keys.zig");
 const foreign_mod = @import("../foreign/mod.zig");
 
 const cdc_replication_round_interval_ms: u64 = 1_000;
+pub const metadata_run_round_slow_threshold_ns: u64 = std.time.ns_per_s;
 const metadata_run_round_slow_phase_threshold_ns: u64 = 500 * std.time.ns_per_ms;
+const metadata_run_round_trace_max_phases: usize = 32;
 const linearizable_metadata_read_prefix = "metadata:linearizable-read:";
 const linearizable_metadata_read_timeout_ns: u64 = 5 * std.time.ns_per_s;
 const linearizable_metadata_read_retry_ns: u64 = 50 * std.time.ns_per_ms;
 
-fn logMetadataRunRoundPhase(name: []const u8, start_ns: u64) void {
-    const elapsed_ns = platform_time.monotonicNs() -| start_ns;
+fn logMetadataRunRoundPhase(name: []const u8, elapsed_ns: u64) void {
     if (elapsed_ns > metadata_run_round_slow_phase_threshold_ns) {
-        std.log.debug("metadata runRound phase slow phase={s} elapsed_ms={d}", .{
+        std.log.warn("metadata runRound phase slow phase={s} elapsed_ms={d}", .{
             name,
             @divTrunc(elapsed_ns, std.time.ns_per_ms),
         });
     }
 }
+
+const MetadataRunRoundTrace = struct {
+    const Phase = struct {
+        name: []const u8,
+        elapsed_ns: u64,
+    };
+
+    start_ns: u64,
+    phases: [metadata_run_round_trace_max_phases]Phase = undefined,
+    phase_count: usize = 0,
+    dropped_phases: usize = 0,
+
+    fn init() MetadataRunRoundTrace {
+        return .{ .start_ns = platform_time.monotonicNs() };
+    }
+
+    fn recordSince(self: *MetadataRunRoundTrace, name: []const u8, start_ns: u64) void {
+        const elapsed_ns = platform_time.monotonicNs() -| start_ns;
+        if (self.phase_count < self.phases.len) {
+            self.phases[self.phase_count] = .{ .name = name, .elapsed_ns = elapsed_ns };
+            self.phase_count += 1;
+        } else {
+            self.dropped_phases += 1;
+        }
+        logMetadataRunRoundPhase(name, elapsed_ns);
+    }
+
+    fn logIfSlow(self: *const MetadataRunRoundTrace) void {
+        const total_elapsed_ns = platform_time.monotonicNs() -| self.start_ns;
+        if (total_elapsed_ns <= metadata_run_round_slow_threshold_ns) return;
+
+        const top = self.topPhaseIndexes();
+        const top0 = phaseOrEmpty(self, top[0]);
+        const top1 = phaseOrEmpty(self, top[1]);
+        const top2 = phaseOrEmpty(self, top[2]);
+        std.log.warn(
+            "metadata runRound phase summary slow elapsed_ms={d} phases={d} dropped_phases={d} top1_phase={s} top1_ms={d} top2_phase={s} top2_ms={d} top3_phase={s} top3_ms={d}",
+            .{
+                @divTrunc(total_elapsed_ns, std.time.ns_per_ms),
+                self.phase_count,
+                self.dropped_phases,
+                top0.name,
+                @divTrunc(top0.elapsed_ns, std.time.ns_per_ms),
+                top1.name,
+                @divTrunc(top1.elapsed_ns, std.time.ns_per_ms),
+                top2.name,
+                @divTrunc(top2.elapsed_ns, std.time.ns_per_ms),
+            },
+        );
+    }
+
+    fn topPhaseIndexes(self: *const MetadataRunRoundTrace) [3]?usize {
+        var top: [3]?usize = .{ null, null, null };
+        for (self.phases[0..self.phase_count], 0..) |phase, idx| {
+            var insert_at: ?usize = null;
+            for (top, 0..) |existing, top_idx| {
+                if (existing == null or phase.elapsed_ns > self.phases[existing.?].elapsed_ns) {
+                    insert_at = top_idx;
+                    break;
+                }
+            }
+            if (insert_at) |slot| {
+                var move_idx: usize = top.len - 1;
+                while (move_idx > slot) : (move_idx -= 1) {
+                    top[move_idx] = top[move_idx - 1];
+                }
+                top[slot] = idx;
+            }
+        }
+        return top;
+    }
+
+    fn phaseOrEmpty(self: *const MetadataRunRoundTrace, idx: ?usize) Phase {
+        return if (idx) |value| self.phases[value] else .{ .name = "-", .elapsed_ns = 0 };
+    }
+};
 
 const LifecycleSignal = struct {
     alloc: std.mem.Allocator,
@@ -2626,11 +2703,21 @@ pub const MetadataHttpService = struct {
     }
 
     pub fn runRound(self: *MetadataHttpService) !void {
+        var run_round_trace = MetadataRunRoundTrace.init();
+        defer run_round_trace.logIfSlow();
         var phase_start_ns = platform_time.monotonicNs();
         try self.ensureLifecycleListenerRegistered();
-        logMetadataRunRoundPhase("ensure_lifecycle_listener", phase_start_ns);
-        defer self.refreshMetadataStatusCacheIfDue();
-        defer self.lifecycle_signal.notify(null);
+        run_round_trace.recordSince("ensure_lifecycle_listener", phase_start_ns);
+        defer {
+            const status_cache_phase_start_ns = platform_time.monotonicNs();
+            self.refreshMetadataStatusCacheIfDue();
+            run_round_trace.recordSince("refresh_metadata_status_cache", status_cache_phase_start_ns);
+        }
+        defer {
+            const lifecycle_signal_phase_start_ns = platform_time.monotonicNs();
+            self.lifecycle_signal.notify(null);
+            run_round_trace.recordSince("lifecycle_signal_notify", lifecycle_signal_phase_start_ns);
+        }
         phase_start_ns = platform_time.monotonicNs();
         self.lockRuntime();
         {
@@ -2642,22 +2729,26 @@ pub const MetadataHttpService = struct {
             }
         }
         self.refreshProbeReady();
-        logMetadataRunRoundPhase("raft_round", phase_start_ns);
+        run_round_trace.recordSince("raft_round", phase_start_ns);
         if (!self.observe_local_replica_root) return;
 
         phase_start_ns = platform_time.monotonicNs();
         const has_reconcile_lease = try self.ensureReconcileLease();
-        logMetadataRunRoundPhase("ensure_reconcile_lease", phase_start_ns);
+        run_round_trace.recordSince("ensure_reconcile_lease", phase_start_ns);
         if (!has_reconcile_lease) return;
 
         phase_start_ns = platform_time.monotonicNs();
         var local_projection_inputs = try captureLocalProjectionInputs(self);
-        defer freeLocalProjectionInputs(self, &local_projection_inputs);
-        logMetadataRunRoundPhase("capture_projection_inputs", phase_start_ns);
+        defer {
+            const cleanup_phase_start_ns = platform_time.monotonicNs();
+            freeLocalProjectionInputs(self, &local_projection_inputs);
+            run_round_trace.recordSince("free_projection_inputs", cleanup_phase_start_ns);
+        }
+        run_round_trace.recordSince("capture_projection_inputs", phase_start_ns);
 
         phase_start_ns = platform_time.monotonicNs();
         const backfill_markers = try self.refreshStoreStatusBackfillMarkersForRound();
-        logMetadataRunRoundPhase("refresh_store_status_backfill_markers", phase_start_ns);
+        run_round_trace.recordSince("refresh_store_status_backfill_markers", phase_start_ns);
         if ((self.store_status_ticks >= 40 or backfill_markers.len > 0) and shouldRefreshLocalStoreStatus(self, backfill_markers)) {
             self.store_status_ticks = 0;
             phase_start_ns = platform_time.monotonicNs();
@@ -2665,46 +2756,54 @@ pub const MetadataHttpService = struct {
                 error.UnknownGroup, error.FileNotFound, error.WriterLocked, error.LmdbUnexpected, error.Corrupted => {},
                 else => return err,
             };
-            logMetadataRunRoundPhase("refresh_local_store_status", phase_start_ns);
+            run_round_trace.recordSince("refresh_local_store_status", phase_start_ns);
         }
         phase_start_ns = platform_time.monotonicNs();
         self.refreshLocalSchemaProgress(&local_projection_inputs) catch |err| switch (err) {
             error.FileNotFound, error.WriterLocked, error.LmdbUnexpected, error.Corrupted => {},
             else => return err,
         };
-        logMetadataRunRoundPhase("refresh_local_schema_progress", phase_start_ns);
+        run_round_trace.recordSince("refresh_local_schema_progress", phase_start_ns);
         phase_start_ns = platform_time.monotonicNs();
         var local_placement_inputs = try captureLocalPlacementInputs(self);
-        defer freeLocalPlacementInputs(self, &local_placement_inputs);
-        logMetadataRunRoundPhase("capture_placement_inputs", phase_start_ns);
+        defer {
+            const cleanup_phase_start_ns = platform_time.monotonicNs();
+            freeLocalPlacementInputs(self, &local_placement_inputs);
+            run_round_trace.recordSince("free_placement_inputs", cleanup_phase_start_ns);
+        }
+        run_round_trace.recordSince("capture_placement_inputs", phase_start_ns);
         phase_start_ns = platform_time.monotonicNs();
         var local_transition_inputs = try captureLocalTransitionInputs(self);
-        defer freeLocalTransitionInputs(self, &local_transition_inputs);
-        logMetadataRunRoundPhase("capture_transition_inputs", phase_start_ns);
+        defer {
+            const cleanup_phase_start_ns = platform_time.monotonicNs();
+            freeLocalTransitionInputs(self, &local_transition_inputs);
+            run_round_trace.recordSince("free_transition_inputs", cleanup_phase_start_ns);
+        }
+        run_round_trace.recordSince("capture_transition_inputs", phase_start_ns);
         phase_start_ns = platform_time.monotonicNs();
         try self.refreshLocalPlacementIntents(&local_placement_inputs);
-        logMetadataRunRoundPhase("refresh_local_placement_intents", phase_start_ns);
+        run_round_trace.recordSince("refresh_local_placement_intents", phase_start_ns);
         phase_start_ns = platform_time.monotonicNs();
         try self.refreshLocalTransitions(&local_transition_inputs);
-        logMetadataRunRoundPhase("refresh_local_transitions", phase_start_ns);
+        run_round_trace.recordSince("refresh_local_transitions", phase_start_ns);
         phase_start_ns = platform_time.monotonicNs();
         _ = self.refreshLocalTableProvisioning(&local_projection_inputs) catch |err| switch (err) {
             error.FileNotFound, error.WriterLocked, error.LmdbUnexpected, error.Corrupted => .{},
             else => return err,
         };
-        logMetadataRunRoundPhase("refresh_local_table_provisioning", phase_start_ns);
+        run_round_trace.recordSince("refresh_local_table_provisioning", phase_start_ns);
         phase_start_ns = platform_time.monotonicNs();
         try self.completeRestoreIntentsIfReady(&local_projection_inputs, &local_placement_inputs);
-        logMetadataRunRoundPhase("complete_restore_intents", phase_start_ns);
+        run_round_trace.recordSince("complete_restore_intents", phase_start_ns);
         phase_start_ns = platform_time.monotonicNs();
         try self.runReplicationBackfillRound();
-        logMetadataRunRoundPhase("run_replication_backfill", phase_start_ns);
+        run_round_trace.recordSince("run_replication_backfill", phase_start_ns);
         phase_start_ns = platform_time.monotonicNs();
         try self.runLifecycleReconcileHookIfRequested();
-        logMetadataRunRoundPhase("run_lifecycle_reconcile_hook", phase_start_ns);
+        run_round_trace.recordSince("run_lifecycle_reconcile_hook", phase_start_ns);
         phase_start_ns = platform_time.monotonicNs();
         _ = try self.raft.stepTransitions();
-        logMetadataRunRoundPhase("step_transitions", phase_start_ns);
+        run_round_trace.recordSince("step_transitions", phase_start_ns);
     }
 
     pub fn probeReady(self: *const MetadataHttpService) bool {


### PR DESCRIPTION
## Summary
- forward public cluster backup mutations to the metadata leader before local handling
- add regression coverage and include it in the public API parity defaults
- add aggregate-aware metadata runRound phase summaries, including deferred cleanup/status-cache phases, so slow total rounds report top phase durations even when no individual phase crosses the per-phase threshold
- share the slow-round threshold between the runtime aggregate warning and service phase summary

## Tests
- zig build public-api-parity-test -- --test-filter "api http server forwards cluster backup mutations to metadata leader"
- zig build lib-metadata-test