### PR TITLE
Fail loud on remote media render failures

### DIFF
--- a/zig/pkg/antfly/src/storage/db/catalog/index_manager.zig
+++ b/zig/pkg/antfly/src/storage/db/catalog/index_manager.zig
@@ -6791,8 +6791,8 @@ pub const IndexManager = struct {
                 .prepared_owner = task.persistent,
             };
         } else |err| switch (err) {
-            error.Unsupported => {},
             error.EmptySegment => return .{ .segments = &.{} },
+            error.Unsupported => {},
             else => {
                 if (builtin.os.tag != .freestanding) {
                     std.log.err("scheduled text merge file-backed build failed index={s}: {s}", .{ task.index_name, @errorName(err) });
@@ -6804,6 +6804,7 @@ pub const IndexManager = struct {
         const merged = merger_mod.mergeSegmentsBounded(alloc, task.snapshot, task.merge_indices, .{
             .target_segment_bytes = @intCast(default_merge_policy.max_segment_size),
         }) catch |err| {
+            if (err == error.EmptySegment) return .{};
             if (builtin.os.tag != .freestanding) {
                 std.log.err("scheduled text merge failed index={s}: {s}", .{ task.index_name, @errorName(err) });
             }
@@ -6835,7 +6836,9 @@ pub const IndexManager = struct {
         defer self.alloc.free(old_ids);
         const input_bytes = textMergeTaskInputBytes(task);
         const output_stats = textMergeResultOutputStats(result);
-        const applied = if (result.prepared_segments.len > 0) blk: {
+        const applied = if (result.prepared_segments.len == 0 and result.segments.len == 0) blk: {
+            break :blk try entry.persistent.removeSegmentsIfActive(old_ids);
+        } else if (result.prepared_segments.len > 0) blk: {
             const prepared_segments = result.prepared_segments;
             result.prepared_segments = &.{};
             result.prepared_owner = null;

--- a/zig/pkg/antfly/src/storage/db/db.zig
+++ b/zig/pkg/antfly/src/storage/db/db.zig
@@ -13881,6 +13881,14 @@ fn renderSourceTemplateText(
     template_source: []const u8,
     doc_value: []const u8,
 ) ![]const u8 {
+    if (comptime @hasDecl(template_remote, "renderJsonToValidatedTextWithConfig")) {
+        return try template_remote.renderJsonToValidatedTextWithConfig(
+            alloc,
+            template_source,
+            doc_value,
+            remoteRenderConfig(secret_store, remote_content),
+        );
+    }
     return try template_remote.renderJsonToTextWithConfig(
         alloc,
         template_source,
@@ -13985,7 +13993,10 @@ fn getOrCreateChunks(
     }
 
     const source_text = if (request.source_template.len > 0)
-        renderSourceTemplateText(alloc, db.secret_store, db.remote_content, request.source_template, doc_value) catch null
+        renderSourceTemplateText(alloc, db.secret_store, db.remote_content, request.source_template, doc_value) catch |err| switch (err) {
+            error.PermanentPromptFailure, error.TransientPromptFailure => return err,
+            else => null,
+        }
     else
         try extractStringField(alloc, doc_value, request.source_field);
     if (source_text == null or source_text.?.len == 0) {
@@ -16174,7 +16185,10 @@ fn extractAssetSourceValue(
     request: enrichment_types.GeneratedEnrichmentRequest,
 ) !?[]u8 {
     if (request.source_template.len > 0) {
-        const rendered = renderSourceTemplateText(alloc, db.secret_store, db.remote_content, request.source_template, doc_value) catch return null;
+        const rendered = renderSourceTemplateText(alloc, db.secret_store, db.remote_content, request.source_template, doc_value) catch |err| switch (err) {
+            error.PermanentPromptFailure, error.TransientPromptFailure => return err,
+            else => return null,
+        };
         errdefer alloc.free(rendered);
         try document_extraction_mod.validateInlineSourceSize(db.remote_content, rendered);
         return @constCast(rendered);
@@ -16787,7 +16801,7 @@ fn computeDenseRequestImpl(
     }
 
     if (request.source_template.len > 0 and dense_embedder.supportsParts()) {
-        const source_parts = renderSourceParts(alloc, db, doc_value, request) catch null;
+        const source_parts = try renderSourceParts(alloc, db, doc_value, request);
         if (source_parts) |parts| {
             defer template_mod.freeContentParts(alloc, parts);
 
@@ -16811,7 +16825,10 @@ fn computeDenseRequestImpl(
     }
 
     const source_text = if (request.source_template.len > 0)
-        renderSourceTemplateText(alloc, db.secret_store, db.remote_content, request.source_template, doc_value) catch null
+        renderSourceTemplateText(alloc, db.secret_store, db.remote_content, request.source_template, doc_value) catch |err| switch (err) {
+            error.PermanentPromptFailure, error.TransientPromptFailure => return err,
+            else => null,
+        }
     else
         try extractStringField(alloc, doc_value, request.source_field);
     if (source_text == null or source_text.?.len == 0) {
@@ -16889,7 +16906,10 @@ fn computeSparseRequestDerived(
     }
 
     const source_text = if (request.source_template.len > 0)
-        renderSourceTemplateText(alloc, db.secret_store, db.remote_content, request.source_template, doc_value) catch null
+        renderSourceTemplateText(alloc, db.secret_store, db.remote_content, request.source_template, doc_value) catch |err| switch (err) {
+            error.PermanentPromptFailure, error.TransientPromptFailure => return err,
+            else => null,
+        }
     else
         try extractStringField(alloc, doc_value, request.source_field);
     if (source_text == null or source_text.?.len == 0) {
@@ -17073,7 +17093,10 @@ fn renderSourceParts(
     request: enrichment_types.GeneratedEnrichmentRequest,
 ) !?[]template_mod.ContentPart {
     if (request.source_template.len == 0) return null;
-    const parts = renderSourceTemplateParts(alloc, db.secret_store, db.remote_content, request.source_template, doc_value) catch return null;
+    const parts = renderSourceTemplateParts(alloc, db.secret_store, db.remote_content, request.source_template, doc_value) catch |err| switch (err) {
+        error.PermanentPromptFailure, error.TransientPromptFailure => return err,
+        else => return null,
+    };
     if (parts.len == 0) {
         template_mod.freeContentParts(alloc, parts);
         return null;

--- a/zig/pkg/antfly/src/storage/db/db.zig
+++ b/zig/pkg/antfly/src/storage/db/db.zig
@@ -160,7 +160,10 @@ fn validateDocumentExtractionInlineSources(db: *DB, doc_value: []const u8) !void
         if (producer_cfg.type != .document_extraction) continue;
 
         if (entry.source_template.len > 0) {
-            const rendered = renderSourceTemplateText(db.alloc, db.secret_store, db.remote_content, entry.source_template, doc_value) catch continue;
+            const rendered = renderSourceTemplateText(db.alloc, db.secret_store, db.remote_content, entry.source_template, doc_value) catch |err| switch (err) {
+                error.PermanentPromptFailure, error.TransientPromptFailure => return err,
+                else => continue,
+            };
             defer db.alloc.free(rendered);
             try document_extraction_mod.validateInlineSourceSize(db.remote_content, rendered);
             continue;
@@ -26697,6 +26700,68 @@ test "db allocates final document ordinal then rejects new documents" {
         .writes = &.{.{ .key = "doc:overflow", .value = "{\"name\":\"overflow\"}" }},
         .sync_level = .write,
     }));
+}
+
+test "document extraction template prompt failure is rejected before persistence" {
+    const alloc = std.testing.allocator;
+
+    var path_buf: [256]u8 = undefined;
+    const path = tempPath(&path_buf);
+    defer cleanupTempDir(path);
+
+    var db = try DB.open(alloc, std.mem.span(path), .{
+        .start_index_workers = false,
+        .ttl_cleanup = .{ .enabled = false },
+    });
+    defer db.close();
+
+    try db.addEnrichment(.{
+        .name = "document_units_v1",
+        .kind = .asset,
+        .template = "<<<error:status=413 message=StreamTooLong>>> fallback text",
+        .content_type = "application/json",
+        .producer_json = "{\"type\":\"document_extraction\",\"config\":{}}",
+    });
+
+    try std.testing.expectError(error.PermanentPromptFailure, db.batch(.{
+        .writes = &.{.{
+            .key = "doc:templated-prompt-failure",
+            .value = "{\"url\":\"data:text/plain;base64,Zm9v\"}",
+        }},
+        .sync_level = .write,
+    }));
+}
+
+fn testRemoteTemplateHostRenderJsonToPartsErrorDirective(
+    _: ?*anyopaque,
+    alloc: Allocator,
+    _: []const u8,
+    _: []const u8,
+    _: template_remote.RenderConfig,
+) ![]template_mod.ContentPart {
+    const parts = try alloc.alloc(template_mod.ContentPart, 1);
+    errdefer alloc.free(parts);
+    parts[0] = .{ .text = try alloc.dupe(u8, "<<<error:status=413 message=StreamTooLong>>> fallback text") };
+    return parts;
+}
+
+test "remote template host-rendered parts preserve prompt failures" {
+    const alloc = std.testing.allocator;
+    template_remote.setHostRenderer(.{
+        .render_json_to_parts = testRemoteTemplateHostRenderJsonToPartsErrorDirective,
+    });
+    defer template_remote.setHostRenderer(null);
+
+    try std.testing.expectError(
+        error.PermanentPromptFailure,
+        renderSourceTemplateParts(
+            alloc,
+            null,
+            null,
+            "{{remoteMedia url=this}}",
+            "\"https://example.com/photo.png\"",
+        ),
+    );
 }
 
 test "db allocates final document ordinal with all index families present" {

--- a/zig/pkg/antfly/src/storage/db/enrichment/enrichment_runtime.zig
+++ b/zig/pkg/antfly/src/storage/db/enrichment/enrichment_runtime.zig
@@ -4286,7 +4286,7 @@ fn processDenseEmbedding(
     defer runtime.alloc.free(raw);
 
     if (request.source_template.len > 0 and dense_embedder.supportsParts()) {
-        const source_parts = renderSourceParts(runtime.alloc, runtime.config, raw, request) catch null;
+        const source_parts = try renderSourceParts(runtime.alloc, runtime.config, raw, request);
         if (source_parts) |parts| {
             defer template.freeContentParts(runtime.alloc, parts);
 
@@ -6359,12 +6359,10 @@ fn extractSourceText(
 ) !?[]const u8 {
     if (request.source_template.len > 0) {
         // Render via Handlebars template
-        const rendered = template_remote.renderJsonToTextWithConfig(
-            alloc,
-            request.source_template,
-            raw_doc,
-            remoteRenderConfig(config.secret_store, config.remote_content),
-        ) catch return null;
+        const rendered = renderSourceTemplateText(alloc, config, raw_doc, request.source_template) catch |err| switch (err) {
+            error.PermanentPromptFailure, error.TransientPromptFailure => return err,
+            else => return null,
+        };
         if (rendered.len == 0) {
             alloc.free(rendered);
             return null;
@@ -6381,6 +6379,28 @@ fn extractSourceText(
     return try alloc.dupe(u8, source.string);
 }
 
+fn renderSourceTemplateText(
+    alloc: Allocator,
+    config: Config,
+    raw_doc: []const u8,
+    source_template: []const u8,
+) ![]const u8 {
+    if (comptime @hasDecl(template_remote, "renderJsonToValidatedTextWithConfig")) {
+        return try template_remote.renderJsonToValidatedTextWithConfig(
+            alloc,
+            source_template,
+            raw_doc,
+            remoteRenderConfig(config.secret_store, config.remote_content),
+        );
+    }
+    return try template_remote.renderJsonToTextWithConfig(
+        alloc,
+        source_template,
+        raw_doc,
+        remoteRenderConfig(config.secret_store, config.remote_content),
+    );
+}
+
 fn extractAssetSourceValue(
     alloc: Allocator,
     config: Config,
@@ -6388,12 +6408,10 @@ fn extractAssetSourceValue(
     request: enrichment_types.GeneratedEnrichmentRequest,
 ) !?[]const u8 {
     if (request.source_template.len > 0) {
-        const rendered = template_remote.renderJsonToTextWithConfig(
-            alloc,
-            request.source_template,
-            raw_doc,
-            remoteRenderConfig(config.secret_store, config.remote_content),
-        ) catch return null;
+        const rendered = renderSourceTemplateText(alloc, config, raw_doc, request.source_template) catch |err| switch (err) {
+            error.PermanentPromptFailure, error.TransientPromptFailure => return err,
+            else => return null,
+        };
         if (rendered.len == 0) {
             alloc.free(rendered);
             return null;
@@ -6429,9 +6447,15 @@ fn renderSourceParts(
 ) !?[]template.ContentPart {
     if (request.source_template.len == 0) return null;
     const parts = if (comptime @hasDecl(template_remote, "renderJsonToPartsWithConfig"))
-        template_remote.renderJsonToPartsWithConfig(alloc, request.source_template, raw_doc, remoteRenderConfig(config.secret_store, config.remote_content)) catch return null
+        template_remote.renderJsonToPartsWithConfig(alloc, request.source_template, raw_doc, remoteRenderConfig(config.secret_store, config.remote_content)) catch |err| switch (err) {
+            error.PermanentPromptFailure, error.TransientPromptFailure => return err,
+            else => return null,
+        }
     else
-        template_remote.renderJsonToParts(alloc, request.source_template, raw_doc) catch return null;
+        template_remote.renderJsonToParts(alloc, request.source_template, raw_doc) catch |err| switch (err) {
+            error.PermanentPromptFailure, error.TransientPromptFailure => return err,
+            else => return null,
+        };
     if (parts.len == 0) {
         template.freeContentParts(alloc, parts);
         return null;
@@ -6764,6 +6788,19 @@ test "extractSourceText with template and invalid JSON returns null" {
     };
     const result = try extractSourceText(alloc, .{}, "not json", request);
     try std.testing.expect(result == null);
+}
+
+test "enrichment extractSourceText with template error directive fails instead of returning text" {
+    const alloc = std.testing.allocator;
+    const doc = "{\"body\":\"large image description\"}";
+    const request = enrichment_types.GeneratedEnrichmentRequest{
+        .kind = .dense_embedding,
+        .index_name = "idx",
+        .doc_key = "doc:1",
+        .source_field = "body",
+        .source_template = "<<<error:status=413 message=StreamTooLong>>> fallback text",
+    };
+    try std.testing.expectError(error.PermanentPromptFailure, extractSourceText(alloc, .{}, doc, request));
 }
 
 test "extractSourceText with template and scrubHtml helper" {

--- a/zig/pkg/antfly/src/storage/db/template_remote_stub.zig
+++ b/zig/pkg/antfly/src/storage/db/template_remote_stub.zig
@@ -267,33 +267,3 @@ test "template remote stub can use host text renderer for remote helpers" {
 
     try std.testing.expectEqualStrings("remote text", rendered);
 }
-
-fn testHostRenderJsonToPartsErrorDirective(
-    _: ?*anyopaque,
-    alloc: Allocator,
-    _: []const u8,
-    _: []const u8,
-    _: RenderConfig,
-) ![]template_mod.ContentPart {
-    const parts = try alloc.alloc(template_mod.ContentPart, 1);
-    errdefer alloc.free(parts);
-    parts[0] = .{ .text = try alloc.dupe(u8, "<<<error:status=413 message=StreamTooLong>>> fallback text") };
-    return parts;
-}
-
-test "template remote stub validates host-rendered parts for error directives" {
-    const alloc = std.testing.allocator;
-    setHostRenderer(.{
-        .render_json_to_parts = testHostRenderJsonToPartsErrorDirective,
-    });
-    defer setHostRenderer(null);
-
-    try std.testing.expectError(
-        RenderError.PermanentPromptFailure,
-        renderJsonToParts(
-            alloc,
-            "{{remoteMedia url=this}}",
-            "\"https://example.com/photo.png\"",
-        ),
-    );
-}

--- a/zig/pkg/antfly/src/storage/db/template_remote_stub.zig
+++ b/zig/pkg/antfly/src/storage/db/template_remote_stub.zig
@@ -31,7 +31,7 @@ pub const RenderError = error{
 
 pub const RenderConfig = struct {};
 
-pub const default_remote_fetch_max_download_size_bytes: u64 = 4 << 20;
+pub const default_remote_fetch_max_download_size_bytes: u64 = 100 * 1024 * 1024;
 
 const remote_fetch_security = scraping.ContentSecurityConfig{
     .block_private_ips = true,
@@ -113,6 +113,18 @@ pub fn renderJsonToTextWithConfig(
     return try template_mod.renderDocument(alloc, template_source, json_doc);
 }
 
+pub fn renderJsonToValidatedTextWithConfig(
+    alloc: Allocator,
+    template_source: []const u8,
+    json_doc: []const u8,
+    config: RenderConfig,
+) ![]const u8 {
+    const rendered = try renderJsonToTextWithConfig(alloc, template_source, json_doc, config);
+    errdefer alloc.free(@constCast(rendered));
+    try validateRenderedTemplate(alloc, rendered);
+    return rendered;
+}
+
 pub fn renderJsonToParts(
     alloc: Allocator,
     template_source: []const u8,
@@ -134,12 +146,22 @@ pub fn renderJsonToPartsWithConfig(
         }
         const rendered = try callHostRenderJsonToText(alloc, template_source, json_doc, config);
         defer alloc.free(@constCast(rendered));
+        try validateRenderedTemplate(alloc, rendered);
         return try template_mod.textToParts(alloc, rendered);
     }
 
     const rendered = try template_mod.renderDocument(alloc, template_source, json_doc);
     defer alloc.free(@constCast(rendered));
+    try validateRenderedTemplate(alloc, rendered);
     return try template_mod.textToParts(alloc, rendered);
+}
+
+fn validateRenderedTemplate(alloc: Allocator, rendered: []const u8) !void {
+    const directives = try template_mod.parseErrorDirectives(alloc, rendered);
+    defer template_mod.freeErrorDirectives(alloc, directives);
+    if (directives.len == 0) return;
+    if (directives[0].isPermanent()) return RenderError.PermanentPromptFailure;
+    return RenderError.TransientPromptFailure;
 }
 
 pub fn downloadRemoteContentOutcomeAllocWithConfig(

--- a/zig/pkg/antfly/src/storage/db/template_remote_stub.zig
+++ b/zig/pkg/antfly/src/storage/db/template_remote_stub.zig
@@ -142,7 +142,10 @@ pub fn renderJsonToPartsWithConfig(
     if (requiresRemoteHelpers(template_source)) {
         const renderer = host_renderer orelse return error.UnsupportedPlatform;
         if (renderer.render_json_to_parts) |render_fn| {
-            return try render_fn(renderer.ctx, alloc, template_source, json_doc, config);
+            const parts = try render_fn(renderer.ctx, alloc, template_source, json_doc, config);
+            errdefer template_mod.freeContentParts(alloc, parts);
+            try validateRenderedParts(alloc, parts);
+            return parts;
         }
         const rendered = try callHostRenderJsonToText(alloc, template_source, json_doc, config);
         defer alloc.free(@constCast(rendered));
@@ -162,6 +165,15 @@ fn validateRenderedTemplate(alloc: Allocator, rendered: []const u8) !void {
     if (directives.len == 0) return;
     if (directives[0].isPermanent()) return RenderError.PermanentPromptFailure;
     return RenderError.TransientPromptFailure;
+}
+
+fn validateRenderedParts(alloc: Allocator, parts: []const template_mod.ContentPart) !void {
+    for (parts) |part| {
+        switch (part) {
+            .text => |text| try validateRenderedTemplate(alloc, text),
+            else => {},
+        }
+    }
 }
 
 pub fn downloadRemoteContentOutcomeAllocWithConfig(
@@ -254,4 +266,34 @@ test "template remote stub can use host text renderer for remote helpers" {
     defer alloc.free(@constCast(rendered));
 
     try std.testing.expectEqualStrings("remote text", rendered);
+}
+
+fn testHostRenderJsonToPartsErrorDirective(
+    _: ?*anyopaque,
+    alloc: Allocator,
+    _: []const u8,
+    _: []const u8,
+    _: RenderConfig,
+) ![]template_mod.ContentPart {
+    const parts = try alloc.alloc(template_mod.ContentPart, 1);
+    errdefer alloc.free(parts);
+    parts[0] = .{ .text = try alloc.dupe(u8, "<<<error:status=413 message=StreamTooLong>>> fallback text") };
+    return parts;
+}
+
+test "template remote stub validates host-rendered parts for error directives" {
+    const alloc = std.testing.allocator;
+    setHostRenderer(.{
+        .render_json_to_parts = testHostRenderJsonToPartsErrorDirective,
+    });
+    defer setHostRenderer(null);
+
+    try std.testing.expectError(
+        RenderError.PermanentPromptFailure,
+        renderJsonToParts(
+            alloc,
+            "{{remoteMedia url=this}}",
+            "\"https://example.com/photo.png\"",
+        ),
+    );
 }

--- a/zig/pkg/antfly/src/storage/db/template_stub.zig
+++ b/zig/pkg/antfly/src/storage/db/template_stub.zig
@@ -280,7 +280,7 @@ pub const ErrorDirective = struct {
 
     pub fn isPermanent(self: ErrorDirective) bool {
         return self.status == 401 or self.status == 403 or
-            self.status == 404 or self.status == 410;
+            self.status == 404 or self.status == 410 or self.status == 413;
     }
 };
 

--- a/zig/pkg/antfly/src/template.zig
+++ b/zig/pkg/antfly/src/template.zig
@@ -295,7 +295,7 @@ pub const ErrorDirective = struct {
     /// unavailable and should not be retried.
     pub fn isPermanent(self: ErrorDirective) bool {
         return self.status == 401 or self.status == 403 or
-            self.status == 404 or self.status == 410;
+            self.status == 404 or self.status == 410 or self.status == 413;
     }
 };
 

--- a/zig/pkg/antfly/src/template_remote.zig
+++ b/zig/pkg/antfly/src/template_remote.zig
@@ -40,7 +40,7 @@ pub const RenderConfig = struct {
     secret_store: ?*common_secrets.FileStore = null,
 };
 
-pub const default_remote_fetch_max_download_size_bytes: u64 = 4 << 20;
+pub const default_remote_fetch_max_download_size_bytes: u64 = 100 * 1024 * 1024;
 
 const remote_fetch_security = scraping.ContentSecurityConfig{
     .block_private_ips = true,
@@ -83,6 +83,18 @@ pub fn renderJsonToTextWithConfig(
     defer active_render_context = prev_ctx;
 
     return try template_mod.renderDocumentWithHelpers(alloc, template_source, json_doc, &extra_helpers);
+}
+
+pub fn renderJsonToValidatedTextWithConfig(
+    alloc: Allocator,
+    template_source: []const u8,
+    json_doc: []const u8,
+    config: RenderConfig,
+) ![]const u8 {
+    const rendered = try renderJsonToTextWithConfig(alloc, template_source, json_doc, config);
+    errdefer alloc.free(rendered);
+    try validateRenderedTemplate(alloc, rendered);
+    return rendered;
 }
 
 pub fn renderJsonToParts(
@@ -136,7 +148,7 @@ fn remoteMediaHelper(ctx: hbs.HelperContext) anyerror!hbs.Value {
     };
 
     const fetched = downloadRemoteContentOutcomeAlloc(render_ctx, url_str, credentialName(ctx)) catch |err| {
-        const result = try template_mod.formatErrorDirective(ctx.arena, 0, @errorName(err));
+        const result = try formatRemoteFetchErrorDirective(ctx.arena, err);
         return .{ .safe_string = result };
     };
     if (fetched == .http_error) {
@@ -197,7 +209,7 @@ fn remoteTextHelper(ctx: hbs.HelperContext) anyerror!hbs.Value {
     };
 
     const fetched = downloadRemoteContentOutcomeAlloc(render_ctx, url_str, credentialName(ctx)) catch |err| {
-        const result = try template_mod.formatErrorDirective(ctx.arena, 0, @errorName(err));
+        const result = try formatRemoteFetchErrorDirective(ctx.arena, err);
         return .{ .safe_string = result };
     };
     if (fetched == .http_error) {
@@ -233,7 +245,7 @@ fn remotePdfHelper(ctx: hbs.HelperContext) anyerror!hbs.Value {
     };
 
     const fetched = downloadRemoteContentOutcomeAlloc(render_ctx, url_str, credentialName(ctx)) catch |err| {
-        const result = try template_mod.formatErrorDirective(ctx.arena, 0, @errorName(err));
+        const result = try formatRemoteFetchErrorDirective(ctx.arena, err);
         return .{ .safe_string = result };
     };
     if (fetched == .http_error) {
@@ -269,6 +281,13 @@ fn credentialName(ctx: hbs.HelperContext) ?[]const u8 {
     return switch (value) {
         .string => |text| if (text.len > 0) text else null,
         else => null,
+    };
+}
+
+fn formatRemoteFetchErrorDirective(alloc: Allocator, err: anyerror) ![]const u8 {
+    return switch (err) {
+        error.StreamTooLong => try template_mod.formatErrorDirective(alloc, 413, @errorName(err)),
+        else => try template_mod.formatErrorDirective(alloc, 0, @errorName(err)),
     };
 }
 
@@ -517,7 +536,7 @@ test "template remote applies remote content security to http urls" {
     defer resolved.deinit(alloc);
 
     try std.testing.expectEqual(@as(?bool, false), resolved.security.block_private_ips);
-    try std.testing.expectEqual(@as(?u64, 4 << 20), resolved.security.max_download_size_bytes);
+    try std.testing.expectEqual(@as(?u64, default_remote_fetch_max_download_size_bytes), resolved.security.max_download_size_bytes);
 }
 
 test "template remote renders remotePDF extract with injected pdf backend" {
@@ -718,4 +737,23 @@ test "template remote preserves http status from shared scraping fetches" {
     try std.testing.expectEqual(@as(usize, 1), directives.len);
     try std.testing.expectEqual(@as(u16, 404), directives[0].status);
     try std.testing.expectEqualStrings("remote fetch failed", directives[0].message);
+}
+
+test "template remote validated text rejects oversized remote media directive" {
+    const alloc = std.testing.allocator;
+
+    const json_doc =
+        \\{"photo":"data:image/png;base64,aGVsbG8="}
+    ;
+    var remote_content = scraping.RemoteContentConfig{
+        .security = .{ .max_download_size_bytes = 4 },
+    };
+    defer remote_content.deinit(alloc);
+
+    try std.testing.expectError(
+        RenderError.PermanentPromptFailure,
+        renderJsonToValidatedTextWithConfig(alloc, "{{remoteMedia url=photo}} fallback text", json_doc, .{
+            .remote_content = &remote_content,
+        }),
+    );
 }

--- a/zig/pkg/antfly/src/template_remote.zig
+++ b/zig/pkg/antfly/src/template_remote.zig
@@ -742,11 +742,39 @@ test "template remote preserves http status from shared scraping fetches" {
 test "template remote validated text rejects oversized remote media directive" {
     const alloc = std.testing.allocator;
 
-    const json_doc =
-        \\{"photo":"data:image/png;base64,aGVsbG8="}
-    ;
+    const ListenerApp = struct {
+        fn executor() @import("raft/transport/http_common.zig").RequestExecutor {
+            return .{
+                .ptr = undefined,
+                .vtable = &.{
+                    .execute = execute,
+                },
+            };
+        }
+
+        fn execute(_: *anyopaque, req_alloc: Allocator, req: @import("raft/transport/http_common.zig").HttpRequest) !@import("raft/transport/http_common.zig").HttpResponse {
+            try std.testing.expectEqual(@import("raft/transport/http_common.zig").Method.GET, req.method);
+            return .{
+                .status = 200,
+                .content_type = try req_alloc.dupe(u8, "image/png"),
+                .body = try req_alloc.dupe(u8, "0123456789abcdef"),
+            };
+        }
+    };
+
+    var listener = @import("raft/transport/std_http_listener.zig").StdHttpListener.init(alloc, .{}, ListenerApp.executor());
+    defer listener.deinit();
+    try listener.start();
+
+    const base_uri = try listener.baseUri(alloc);
+    defer alloc.free(base_uri);
+    const photo_url = try std.fmt.allocPrint(alloc, "{s}/photo.png", .{base_uri});
+    defer alloc.free(photo_url);
+
+    const json_doc = try std.fmt.allocPrint(alloc, "{{\"photo\":{f}}}", .{std.json.fmt(photo_url, .{})});
+    defer alloc.free(json_doc);
     var remote_content = scraping.RemoteContentConfig{
-        .security = .{ .max_download_size_bytes = 4 },
+        .security = .{ .block_private_ips = false, .max_download_size_bytes = 4 },
     };
     defer remote_content.deinit(alloc);
 


### PR DESCRIPTION
## Summary
- include the prior empty scheduled text merge fix
- raise the default template remote fetch cap to 100MB to match embed API behavior
- validate rendered remote template output so error directives fail loudly instead of falling back to text-only embedding
- preserve oversized remote fetches as permanent 413 prompt failures across production and DB test/stub paths
- keep host-rendered remote template parts parity covered through DB tests

Fixes #281

## Tests
- zig test pkg/antfly/src/template.zig --test-filter ErrorDirective
- env ZIG_GLOBAL_CACHE_DIR=/tmp/antfly-zig-global zig build
- env ZIG_GLOBAL_CACHE_DIR=/tmp/antfly-zig-global zig build lib-template-test -- --test-filter "oversized remote media"
- env ZIG_GLOBAL_CACHE_DIR=/tmp/antfly-zig-global zig build lib-db-test -- --test-filter "document extraction template prompt failure"
- env ZIG_GLOBAL_CACHE_DIR=/tmp/antfly-zig-global zig build lib-db-test -- --test-filter "remote template host-rendered parts"
- env ANTFLY_BIN=./zig-out/bin/antfly ANTFLY_LSM_OPEN_DEBUG=1 UV_PROJECT_ENVIRONMENT=/tmp/antfly-ci-venv/antfly uv run --project e2e/antfly pytest -q -s -x e2e/antfly/test_resolution.py::test_multinode_autograph_resolves_promotes_and_hydrates_entities
- git diff --check