### PR TITLE
Fix dense replay progress and alias-safe startup drains

### DIFF
--- a/zig/pkg/antfly/src/common/byte_copy.zig
+++ b/zig/pkg/antfly/src/common/byte_copy.zig
@@ -1,0 +1,74 @@
+// Copyright 2026 Antfly, Inc.
+//
+// Licensed under the Elastic License 2.0 (ELv2); you may not use this file
+// except in compliance with the Elastic License 2.0. You may obtain a copy of
+// the Elastic License 2.0 at
+//
+//     https://www.antfly.io/licensing/ELv2-license
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the Elastic License 2.0 is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// Elastic License 2.0 for the specific language governing permissions and
+// limitations.
+
+const std = @import("std");
+
+pub fn copyPossiblyAliased(dest: []u8, src: []const u8) void {
+    std.debug.assert(dest.len == src.len);
+    if (dest.len == 0 or dest.ptr == src.ptr) return;
+    const dest_start = @intFromPtr(dest.ptr);
+    const dest_end = dest_start + dest.len;
+    const src_start = @intFromPtr(src.ptr);
+    const src_end = src_start + src.len;
+    if (dest_end <= src_start or src_end <= dest_start) {
+        @memcpy(dest, src);
+    } else if (dest_start < src_start) {
+        std.mem.copyForwards(u8, dest, src);
+    } else {
+        std.mem.copyBackwards(u8, dest, src);
+    }
+}
+
+pub fn appendSlicePossiblyAliased(list: *std.ArrayListUnmanaged(u8), allocator: std.mem.Allocator, bytes: []const u8) !void {
+    if (sliceOffsetInBuffer(list.items, bytes)) |source_offset| {
+        const source_len = bytes.len;
+        const old_len = list.items.len;
+        try list.ensureUnusedCapacity(allocator, source_len);
+        list.items.len = old_len + source_len;
+        copyPossiblyAliased(list.items[old_len..][0..source_len], list.items[source_offset..][0..source_len]);
+        return;
+    }
+    try list.appendSlice(allocator, bytes);
+}
+
+fn sliceOffsetInBuffer(buffer: []const u8, slice: []const u8) ?usize {
+    if (slice.len == 0) return buffer.len;
+    if (buffer.len == 0) return null;
+    const buffer_start = @intFromPtr(buffer.ptr);
+    const buffer_end = buffer_start + buffer.len;
+    const slice_start = @intFromPtr(slice.ptr);
+    const slice_end = slice_start + slice.len;
+    if (slice_start < buffer_start or slice_end > buffer_end) return null;
+    return slice_start - buffer_start;
+}
+
+test "copyPossiblyAliased supports overlapping ranges" {
+    var bytes = [_]u8{ 'a', 'b', 'c', 'd', 'e', 'f' };
+
+    copyPossiblyAliased(bytes[2..6], bytes[0..4]);
+    try std.testing.expectEqualStrings("ababcd", &bytes);
+
+    copyPossiblyAliased(bytes[0..4], bytes[2..6]);
+    try std.testing.expectEqualStrings("abcdcd", &bytes);
+}
+
+test "appendSlicePossiblyAliased preserves self-referential sources across growth" {
+    var list: std.ArrayListUnmanaged(u8) = .empty;
+    defer list.deinit(std.testing.allocator);
+
+    try list.appendSlice(std.testing.allocator, "abcdef");
+    try appendSlicePossiblyAliased(&list, std.testing.allocator, list.items[1..5]);
+
+    try std.testing.expectEqualStrings("abcdefbcde", list.items);
+}

--- a/zig/pkg/antfly/src/common/mod.zig
+++ b/zig/pkg/antfly/src/common/mod.zig
@@ -21,6 +21,7 @@ pub const health_server = @import("health_server.zig");
 pub const group_ids = @import("group_ids.zig");
 pub const data_format = @import("data_format.zig");
 pub const fs_paths = @import("fs_paths.zig");
+pub const byte_copy = @import("byte_copy.zig");
 
 test {
     _ = provider_registry;
@@ -32,4 +33,5 @@ test {
     _ = group_ids;
     _ = data_format;
     _ = fs_paths;
+    _ = byte_copy;
 }

--- a/zig/pkg/antfly/src/data/runtime.zig
+++ b/zig/pkg/antfly/src/data/runtime.zig
@@ -3342,7 +3342,7 @@ pub const DataServer = struct {
     fn localRaftStatusShouldBootstrapCampaign(status: ?raft_engine.core.Status, local_node_id: u64) bool {
         const raft_status = status orelse return false;
         if (raft_status.soft.leader_id != null) return false;
-        if (raft_status.soft.role != .follower) return false;
+        if (raft_status.soft.role == .leader) return false;
         return localRaftStatusIsVoter(raft_status, local_node_id);
     }
 
@@ -8962,6 +8962,36 @@ test "data runtime module compiles" {
     _ = DataServerConfig;
     _ = DataServer;
     _ = GroupLeadershipSource;
+}
+
+test "data raft bootstrap campaign retries leaderless voter elections" {
+    var voters = [_]u64{ 1, 2, 3 };
+    var status = raft_engine.core.Status{
+        .id = 1,
+        .group_id = 7001,
+        .soft = .{ .leader_id = null, .role = .follower },
+        .hard = .{},
+        .conf_state = .{ .voters = voters[0..] },
+    };
+
+    try std.testing.expect(DataServer.localRaftStatusShouldBootstrapCampaign(status, 1));
+
+    status.soft.role = .pre_candidate;
+    try std.testing.expect(DataServer.localRaftStatusShouldBootstrapCampaign(status, 1));
+
+    status.soft.role = .candidate;
+    try std.testing.expect(DataServer.localRaftStatusShouldBootstrapCampaign(status, 1));
+
+    status.soft.role = .leader;
+    status.soft.leader_id = 1;
+    try std.testing.expect(!DataServer.localRaftStatusShouldBootstrapCampaign(status, 1));
+
+    status.soft.role = .follower;
+    status.soft.leader_id = 2;
+    try std.testing.expect(!DataServer.localRaftStatusShouldBootstrapCampaign(status, 1));
+
+    status.soft.leader_id = null;
+    try std.testing.expect(!DataServer.localRaftStatusShouldBootstrapCampaign(status, 4));
 }
 
 test "data runtime live writer source follows raft apply ownership" {

--- a/zig/pkg/antfly/src/data/runtime.zig
+++ b/zig/pkg/antfly/src/data/runtime.zig
@@ -3342,7 +3342,10 @@ pub const DataServer = struct {
     fn localRaftStatusShouldBootstrapCampaign(status: ?raft_engine.core.Status, local_node_id: u64) bool {
         const raft_status = status orelse return false;
         if (raft_status.soft.leader_id != null) return false;
-        if (raft_status.soft.role == .leader) return false;
+        switch (raft_status.soft.role) {
+            .follower, .pre_candidate => {},
+            .candidate, .leader => return false,
+        }
         return localRaftStatusIsVoter(raft_status, local_node_id);
     }
 
@@ -8980,7 +8983,7 @@ test "data raft bootstrap campaign retries leaderless voter elections" {
     try std.testing.expect(DataServer.localRaftStatusShouldBootstrapCampaign(status, 1));
 
     status.soft.role = .candidate;
-    try std.testing.expect(DataServer.localRaftStatusShouldBootstrapCampaign(status, 1));
+    try std.testing.expect(!DataServer.localRaftStatusShouldBootstrapCampaign(status, 1));
 
     status.soft.role = .leader;
     status.soft.leader_id = 1;

--- a/zig/pkg/antfly/src/metadata/runtime.zig
+++ b/zig/pkg/antfly/src/metadata/runtime.zig
@@ -549,6 +549,10 @@ pub const Server = struct {
 
         try self.server.svc.raft.submitBatch(updates.items);
         _ = try self.server.svc.syncPending();
+        if (metadataClusterPreferredCampaigner(cluster_peers, local_node_id)) {
+            try self.server.campaignMetadataGroup();
+            try self.server.runRound();
+        }
     }
 
     pub fn bootstrapLocal(self: *Server, metadata_group_id: u64, local_node_id: u64) !void {
@@ -655,6 +659,15 @@ fn indexOfClusterPeer(cluster_peers: []const MetadataClusterPeer, node_id: u64) 
         if (peer.node_id == node_id) return index;
     }
     return null;
+}
+
+fn metadataClusterPreferredCampaigner(cluster_peers: []const MetadataClusterPeer, local_node_id: u64) bool {
+    if (cluster_peers.len == 0) return true;
+    var min_node_id = cluster_peers[0].node_id;
+    for (cluster_peers[1..]) |peer| {
+        if (peer.node_id < min_node_id) min_node_id = peer.node_id;
+    }
+    return local_node_id == min_node_id;
 }
 
 fn allocMetadataPeerNodeIds(
@@ -1486,6 +1499,19 @@ test "metadata runtime enables bounded raft storage compaction for multi-node gr
     try std.testing.expectEqual(@as(u64, metadata_raft_retained_entries), wal_cfg.compaction_retained_entries);
     try std.testing.expectEqual(@as(u64, metadata_raft_compaction_min_interval_entries), wal_cfg.compaction_min_interval_entries);
     try std.testing.expect(!wal_cfg.compaction_single_node_only);
+}
+
+test "metadata runtime chooses one preferred bootstrap campaigner" {
+    const peers = [_]MetadataClusterPeer{
+        .{ .node_id = 3, .raft_url = "http://127.0.0.1:3003" },
+        .{ .node_id = 1, .raft_url = "http://127.0.0.1:3001" },
+        .{ .node_id = 2, .raft_url = "http://127.0.0.1:3002" },
+    };
+
+    try std.testing.expect(metadataClusterPreferredCampaigner(&.{}, 7));
+    try std.testing.expect(metadataClusterPreferredCampaigner(&peers, 1));
+    try std.testing.expect(!metadataClusterPreferredCampaigner(&peers, 2));
+    try std.testing.expect(!metadataClusterPreferredCampaigner(&peers, 3));
 }
 
 test "metadata runtime metrics expose memory ownership buckets" {

--- a/zig/pkg/antfly/src/metadata/runtime.zig
+++ b/zig/pkg/antfly/src/metadata/runtime.zig
@@ -26,6 +26,8 @@ const platform_time = @import("../platform/time.zig");
 const setup_io_thread_stack_size = 1 * 1024 * 1024;
 const metadata_raft_retained_entries = 1024;
 const metadata_raft_compaction_min_interval_entries = 512;
+const metadata_raft_election_max_ticks = 60;
+const metadata_bootstrap_campaign_retry_min_interval_ns: u64 = 500 * std.time.ns_per_ms;
 const trusted_principal_secret_key = "antfly.trusted_principal.secret";
 const trusted_principal_issuer_key = "antfly.trusted_principal.issuer";
 
@@ -549,10 +551,6 @@ pub const Server = struct {
 
         try self.server.svc.raft.submitBatch(updates.items);
         _ = try self.server.svc.syncPending();
-        if (metadataClusterPreferredCampaigner(cluster_peers, local_node_id)) {
-            try self.server.campaignMetadataGroup();
-            try self.server.runRound();
-        }
     }
 
     pub fn bootstrapLocal(self: *Server, metadata_group_id: u64, local_node_id: u64) !void {
@@ -585,6 +583,13 @@ pub const Server = struct {
 
     pub fn runCdcRound(self: *Server) !void {
         try self.server.runCdcRound();
+    }
+
+    pub fn campaignMetadataGroupIfBootstrapLeaderless(self: *Server, metadata_group_id: u64, local_node_id: u64) !bool {
+        const raft_status = self.server.svc.raft.host.http_host.host.raftStatus(metadata_group_id);
+        if (!metadataRaftStatusShouldBootstrapCampaign(raft_status, local_node_id)) return false;
+        try self.server.campaignMetadataGroup();
+        return true;
     }
 
     pub fn status(self: *Server) !antfly.metadata_api.MetadataStatus {
@@ -668,6 +673,30 @@ fn metadataClusterPreferredCampaigner(cluster_peers: []const MetadataClusterPeer
         if (peer.node_id < min_node_id) min_node_id = peer.node_id;
     }
     return local_node_id == min_node_id;
+}
+
+fn metadataRaftStatusIsVoter(status: raft_engine.core.Status, local_node_id: u64) bool {
+    for (status.conf_state.voters) |node_id| {
+        if (node_id == local_node_id) return true;
+    }
+    return false;
+}
+
+fn metadataRaftStatusShouldBootstrapCampaign(status: ?raft_engine.core.Status, local_node_id: u64) bool {
+    const raft_status = status orelse return false;
+    if (raft_status.soft.leader_id != null) return false;
+    switch (raft_status.soft.role) {
+        .follower, .pre_candidate, .candidate => {},
+        .leader => return false,
+    }
+    return metadataRaftStatusIsVoter(raft_status, local_node_id);
+}
+
+fn metadataBootstrapCampaignRetryIntervalNs(tick_ms: u64) u64 {
+    return @max(
+        metadata_bootstrap_campaign_retry_min_interval_ns,
+        tick_ms * std.time.ns_per_ms * metadata_raft_election_max_ticks * 2,
+    );
 }
 
 fn allocMetadataPeerNodeIds(
@@ -857,7 +886,21 @@ pub fn runFromIterator(
         .sec = @intCast(tick_ms / std.time.ms_per_s),
         .nsec = @intCast((tick_ms % std.time.ms_per_s) * std.time.ns_per_ms),
     };
+    const preferred_bootstrap_campaigner = metadataClusterPreferredCampaigner(cluster_peers, local_node_id);
+    const bootstrap_campaign_retry_interval_ns = metadataBootstrapCampaignRetryIntervalNs(tick_ms);
+    var last_bootstrap_campaign_retry_ns = platform_time.monotonicNs();
     while (true) {
+        if (preferred_bootstrap_campaigner) {
+            const now_ns = platform_time.monotonicNs();
+            if (last_bootstrap_campaign_retry_ns == 0 or
+                now_ns -| last_bootstrap_campaign_retry_ns >= bootstrap_campaign_retry_interval_ns)
+            {
+                if (try server.campaignMetadataGroupIfBootstrapLeaderless(metadata_group_id, local_node_id)) {
+                    std.log.warn("metadata bootstrap campaign retry node_id={}", .{local_node_id});
+                    last_bootstrap_campaign_retry_ns = now_ns;
+                }
+            }
+        }
         const run_round_start_ns = platform_time.monotonicNs();
         try server.runRound();
         const run_round_elapsed_ns = platform_time.monotonicNs() -| run_round_start_ns;
@@ -1512,6 +1555,47 @@ test "metadata runtime chooses one preferred bootstrap campaigner" {
     try std.testing.expect(metadataClusterPreferredCampaigner(&peers, 1));
     try std.testing.expect(!metadataClusterPreferredCampaigner(&peers, 2));
     try std.testing.expect(!metadataClusterPreferredCampaigner(&peers, 3));
+}
+
+test "metadata runtime retries bootstrap campaign only for leaderless voters" {
+    var voters = [_]u64{ 1, 2, 3 };
+    var status = raft_engine.core.Status{
+        .id = 1,
+        .group_id = group_ids.main_metadata_group_id,
+        .soft = .{ .leader_id = null, .role = .follower },
+        .hard = .{},
+        .conf_state = .{ .voters = voters[0..] },
+    };
+
+    try std.testing.expect(metadataRaftStatusShouldBootstrapCampaign(status, 1));
+
+    status.soft.role = .pre_candidate;
+    try std.testing.expect(metadataRaftStatusShouldBootstrapCampaign(status, 1));
+
+    status.soft.role = .candidate;
+    try std.testing.expect(metadataRaftStatusShouldBootstrapCampaign(status, 1));
+
+    status.soft.role = .leader;
+    status.soft.leader_id = 1;
+    try std.testing.expect(!metadataRaftStatusShouldBootstrapCampaign(status, 1));
+
+    status.soft.role = .follower;
+    status.soft.leader_id = 2;
+    try std.testing.expect(!metadataRaftStatusShouldBootstrapCampaign(status, 1));
+
+    status.soft.leader_id = null;
+    try std.testing.expect(!metadataRaftStatusShouldBootstrapCampaign(status, 4));
+}
+
+test "metadata runtime scales bootstrap campaign retry interval with tick" {
+    try std.testing.expectEqual(
+        @as(u64, 600 * std.time.ns_per_ms),
+        metadataBootstrapCampaignRetryIntervalNs(5),
+    );
+    try std.testing.expectEqual(
+        @as(u64, 12 * std.time.ns_per_s),
+        metadataBootstrapCampaignRetryIntervalNs(100),
+    );
 }
 
 test "metadata runtime metrics expose memory ownership buckets" {

--- a/zig/pkg/antfly/src/segment.zig
+++ b/zig/pkg/antfly/src/segment.zig
@@ -32,6 +32,7 @@
 
 const std = @import("std");
 const Allocator = std.mem.Allocator;
+const byte_copy = @import("common/byte_copy.zig");
 const platform_time = @import("platform/time.zig");
 const inverted = @import("section/inverted.zig");
 const typed_dv = @import("section/typed_doc_values.zig");
@@ -906,7 +907,7 @@ pub const MemorySegmentSink = struct {
 
     fn appendSlice(ptr: *anyopaque, bytes: []const u8) !void {
         const self: *MemorySegmentSink = @ptrCast(@alignCast(ptr));
-        try self.out.appendSlice(self.alloc, bytes);
+        try byte_copy.appendSlicePossiblyAliased(&self.out, self.alloc, bytes);
     }
 
     fn appendByte(ptr: *anyopaque, byte: u8) !void {
@@ -922,7 +923,7 @@ pub const MemorySegmentSink = struct {
     fn writeAt(ptr: *anyopaque, offset: usize, bytes: []const u8) !void {
         const self: *MemorySegmentSink = @ptrCast(@alignCast(ptr));
         if (offset > self.out.items.len or bytes.len > self.out.items.len - offset) return error.InvalidSegment;
-        @memcpy(self.out.items[offset..][0..bytes.len], bytes);
+        byte_copy.copyPossiblyAliased(self.out.items[offset..][0..bytes.len], bytes);
     }
 
     fn crc32Prefix(ptr: *anyopaque, len_prefix: usize) !u32 {

--- a/zig/pkg/antfly/src/storage/db/db.zig
+++ b/zig/pkg/antfly/src/storage/db/db.zig
@@ -19864,13 +19864,13 @@ fn replayPendingDerivedBatchesContext(ctx: *const BatchExecutionContext) !void {
             _ = try ctx.index_manager.runDenseLsmMaintenanceByName(index_ref.name, denseCatchUpMaintenanceSteps());
         }
         saw_entries = saw_entries or stats.scanned_entries > 0;
-        if (stats.last_sequence > applied) {
+        if (stats.appliedSequenceAdvance(applied)) |sequence| {
             try ctx.index_manager.checkpointLsmWalForManagedIndex(index_ref);
             try updates.append(ctx.alloc, .{
                 .index_name = index_ref.name,
-                .sequence = stats.last_sequence,
+                .sequence = sequence,
             });
-        } else if (stats.scanned_entries == 0 and target_sequence > applied and
+        } else if (stats.shouldTryTargetAdvance(applied, target_sequence) and
             try canAdvanceDerivedReplayTargetContext(ctx, index_ref, applied, target_sequence))
         {
             try ctx.index_manager.checkpointLsmWalForManagedIndex(index_ref);
@@ -20286,10 +20286,10 @@ fn replayPendingDerivedBatches(self: *DB, progress_ctx: ?*anyopaque, progress_ho
             }
         }
         saw_entries = saw_entries or stats.scanned_entries > 0;
-        if (stats.last_sequence > applied) {
-            try self.core.saveAppliedSequence(index_ref.name, stats.last_sequence);
+        if (stats.appliedSequenceAdvance(applied)) |sequence| {
+            try self.core.saveAppliedSequence(index_ref.name, sequence);
             try resources.index_manager.checkpointLsmWalForManagedIndex(index_ref);
-        } else if (stats.scanned_entries == 0 and target_sequence > applied and
+        } else if (stats.shouldTryTargetAdvance(applied, target_sequence) and
             try canAdvanceDerivedToTargetAsync(self.async_context, index_ref, applied, target_sequence))
         {
             try self.core.saveAppliedSequence(index_ref.name, target_sequence);

--- a/zig/pkg/antfly/src/storage/db/derived/async_runtime.zig
+++ b/zig/pkg/antfly/src/storage/db/derived/async_runtime.zig
@@ -509,7 +509,7 @@ fn workerMain(worker: *Worker) void {
             closeWorkerReplayCursor(runtime, worker);
         }
 
-        const target_advance_allowed = if (stats.last_sequence == 0 and target_sequence > from_sequence)
+        const target_advance_allowed = if (stats.shouldTryTargetAdvance(from_sequence, target_sequence))
             canAdvanceToTarget(runtime, worker, from_sequence, target_sequence) catch |err| {
                 close_success = false;
                 runtime.recordError(err);
@@ -517,13 +517,13 @@ fn workerMain(worker: *Worker) void {
             }
         else
             false;
-        const caught_up_sequence = if (stats.last_sequence > from_sequence)
-            stats.last_sequence
+        const caught_up_sequence = if (stats.appliedSequenceAdvance(from_sequence)) |sequence|
+            sequence
         else if (target_advance_allowed)
             target_sequence
         else
             from_sequence;
-        if (caught_up_sequence == from_sequence and stats.last_sequence == 0 and target_sequence > from_sequence) {
+        if (caught_up_sequence == from_sequence and stats.shouldTryTargetAdvance(from_sequence, target_sequence)) {
             closeWorkerCatchUpState(runtime, worker, false) catch |err| {
                 close_success = false;
                 runtime.recordError(err);
@@ -777,10 +777,12 @@ const TestRuntimeCapture = struct {
     finish_calls: std.atomic.Value(u64) = .init(0),
     publish_failures: std.atomic.Value(u64) = .init(0),
     apply_not_found_failures: std.atomic.Value(u64) = .init(0),
+    target_advance_calls: std.atomic.Value(u64) = .init(0),
     persist_calls: std.atomic.Value(u64) = .init(0),
     persisted_sequence: std.atomic.Value(u64) = .init(0),
     last_applied_batch_sequence: std.atomic.Value(u64) = .init(0),
     defer_next_persist: std.atomic.Value(bool) = .init(false),
+    skip_next_apply: std.atomic.Value(bool) = .init(false),
     fail_next_dense_apply_not_found: std.atomic.Value(bool) = .init(false),
     fail_next_publish: std.atomic.Value(bool) = .init(false),
 };
@@ -793,6 +795,7 @@ fn testRuntimeApply(ctx: *anyopaque, batch: derived_types.DerivedBatch, index_re
         _ = capture.apply_not_found_failures.fetchAdd(1, .monotonic);
         return error.NotFound;
     }
+    if (capture.skip_next_apply.swap(false, .monotonic)) return false;
     return true;
 }
 
@@ -825,6 +828,14 @@ fn testRuntimeFinishCatchUp(ctx: *anyopaque, index_ref: index_manager_mod.Manage
         _ = capture.publish_failures.fetchAdd(1, .monotonic);
         return error.NotFound;
     }
+}
+
+fn testRuntimeCanAdvanceToTarget(ctx: *anyopaque, index_ref: index_manager_mod.ManagedIndexRef, from_sequence: u64, target_sequence: u64) !bool {
+    _ = index_ref;
+    try std.testing.expect(target_sequence > from_sequence);
+    const capture: *TestRuntimeCapture = @ptrCast(@alignCast(ctx));
+    _ = capture.target_advance_calls.fetchAdd(1, .monotonic);
+    return true;
 }
 
 fn appendTestChangeJournalRecord(log: *change_journal_mod.Journal, alloc: Allocator, record: change_journal_mod.Record) !void {
@@ -952,6 +963,52 @@ test "async non-tail replay cursor refreshes before watermark advance" {
     try std.testing.expectEqual(@as(u64, 1), capture.apply_calls.load(.monotonic));
     try std.testing.expectEqual(@as(u64, 1), capture.last_applied_batch_sequence.load(.monotonic));
     try std.testing.expectEqual(@as(u64, 2), runtime.appliedSequence("dense_idx").?);
+}
+
+test "async dense zero-applied replay window advances only through target coverage guard" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const journal_path = try std.fmt.allocPrint(alloc, ".zig-cache/tmp/{s}/async-dense-zero-applied-target-advance-journal", .{tmp.sub_path});
+    defer alloc.free(journal_path);
+    const journal_path_z = try alloc.dupeZ(u8, journal_path);
+    defer alloc.free(journal_path_z);
+
+    var journal = try change_journal_mod.Journal.open(journal_path_z, testInMemoryJournalOpenOptions());
+    defer journal.close();
+
+    try appendTestChangeJournalRecord(&journal, alloc, .{
+        .sequence = 1,
+        .changed_doc_keys = &.{"doc:text-only"},
+        .target_hints = &.{.dense_vector},
+    });
+
+    var capture = TestRuntimeCapture{ .alloc = alloc };
+    capture.skip_next_apply.store(true, .monotonic);
+    var runtime = DerivedRuntime.init(
+        alloc,
+        replay_source_mod.Source.fromJournal(&journal),
+        &capture,
+        testRuntimeApply,
+        testRuntimePersist,
+        testRuntimeTruncate,
+        testRuntimeBeginCatchUp,
+        testRuntimeFinishCatchUp,
+        testRuntimeCanAdvanceToTarget,
+        null,
+    );
+    defer runtime.deinit();
+
+    try runtime.addWorker("dense_idx", .{ .name = "dense_idx", .kind = .dense_vector }, 0);
+    runtime.notifySequence(1);
+    try runtime.waitForAll(1);
+    try runtime.failIfUnhealthy();
+
+    try std.testing.expectEqual(@as(u64, 1), capture.apply_calls.load(.monotonic));
+    try std.testing.expectEqual(@as(u64, 1), capture.target_advance_calls.load(.monotonic));
+    try std.testing.expectEqual(@as(u64, 1), capture.persisted_sequence.load(.monotonic));
+    try std.testing.expectEqual(@as(u64, 1), runtime.appliedSequence("dense_idx").?);
 }
 
 test "async dense publish NotFound retries without failing runtime" {

--- a/zig/pkg/antfly/src/storage/db/derived/derived_executor.zig
+++ b/zig/pkg/antfly/src/storage/db/derived/derived_executor.zig
@@ -398,9 +398,9 @@ const ManualRuntime = struct {
             if (worker.target_sequence <= worker.applied_sequence) continue;
 
             const stats = try self.catchUpWorker(worker);
-            const caught_up_sequence = if (stats.last_sequence > worker.applied_sequence)
-                stats.last_sequence
-            else if (stats.last_sequence == 0 and worker.target_sequence > worker.applied_sequence and
+            const caught_up_sequence = if (stats.appliedSequenceAdvance(worker.applied_sequence)) |applied_sequence|
+                applied_sequence
+            else if (stats.shouldTryTargetAdvance(worker.applied_sequence, worker.target_sequence) and
                 try self.canAdvanceToTarget(worker, worker.applied_sequence, worker.target_sequence))
                 worker.target_sequence
             else
@@ -428,9 +428,9 @@ const ManualRuntime = struct {
             if (worker.target_sequence <= worker.applied_sequence) continue;
 
             const stats = try self.catchUpWorker(worker);
-            const caught_up_sequence = if (stats.last_sequence > worker.applied_sequence)
-                stats.last_sequence
-            else if (stats.last_sequence == 0 and worker.target_sequence > worker.applied_sequence and
+            const caught_up_sequence = if (stats.appliedSequenceAdvance(worker.applied_sequence)) |applied_sequence|
+                applied_sequence
+            else if (stats.shouldTryTargetAdvance(worker.applied_sequence, worker.target_sequence) and
                 try self.canAdvanceToTarget(worker, worker.applied_sequence, worker.target_sequence))
                 worker.target_sequence
             else

--- a/zig/pkg/antfly/src/storage/db/derived/derived_worker.zig
+++ b/zig/pkg/antfly/src/storage/db/derived/derived_worker.zig
@@ -42,7 +42,53 @@ pub const CatchUpStats = struct {
     last_sequence: u64 = 0,
     window_collect_ns: u64 = 0,
     apply_ns: u64 = 0,
+
+    pub fn appliedSequenceAdvance(self: @This(), from_sequence: u64) ?u64 {
+        if (self.applied_entries == 0) return null;
+        if (self.last_sequence <= from_sequence) return null;
+        return self.last_sequence;
+    }
+
+    pub fn shouldTryTargetAdvance(self: @This(), from_sequence: u64, target_sequence: u64) bool {
+        return self.applied_entries == 0 and target_sequence > from_sequence;
+    }
 };
+
+test "CatchUpStats target advance covers scanned zero-applied tail" {
+    const applied: u64 = 260;
+    const target_sequence: u64 = 273;
+
+    try std.testing.expect((CatchUpStats{
+        .scanned_entries = 13,
+        .applied_entries = 0,
+        .last_sequence = applied,
+    }).shouldTryTargetAdvance(applied, target_sequence));
+    try std.testing.expect((CatchUpStats{
+        .scanned_entries = 0,
+        .applied_entries = 0,
+        .last_sequence = applied,
+    }).shouldTryTargetAdvance(applied, target_sequence));
+    try std.testing.expect(!(CatchUpStats{
+        .scanned_entries = 13,
+        .applied_entries = 1,
+        .last_sequence = target_sequence,
+    }).shouldTryTargetAdvance(applied, target_sequence));
+    try std.testing.expect(!(CatchUpStats{
+        .scanned_entries = 13,
+        .applied_entries = 0,
+        .last_sequence = applied,
+    }).shouldTryTargetAdvance(target_sequence, target_sequence));
+    try std.testing.expectEqual(@as(?u64, null), (CatchUpStats{
+        .scanned_entries = 13,
+        .applied_entries = 0,
+        .last_sequence = target_sequence,
+    }).appliedSequenceAdvance(applied));
+    try std.testing.expectEqual(target_sequence, (CatchUpStats{
+        .scanned_entries = 13,
+        .applied_entries = 1,
+        .last_sequence = target_sequence,
+    }).appliedSequenceAdvance(applied).?);
+}
 
 pub const CatchUpProgress = struct {
     sequence: u64 = 0,

--- a/zig/pkg/antfly/src/storage/db/derived/io_threaded_runtime.zig
+++ b/zig/pkg/antfly/src/storage/db/derived/io_threaded_runtime.zig
@@ -837,7 +837,7 @@ fn workerMain(worker: *Worker) void {
             closeWorkerReplayCursor(runtime, worker);
         }
 
-        const target_advance_allowed = if (stats.last_sequence == 0 and target_sequence > from_sequence)
+        const target_advance_allowed = if (stats.shouldTryTargetAdvance(from_sequence, target_sequence))
             canAdvanceToTarget(runtime, worker, from_sequence, target_sequence) catch |err| {
                 close_success = false;
                 runtime.recordError(io, worker.name, "target_advance", err);
@@ -845,13 +845,13 @@ fn workerMain(worker: *Worker) void {
             }
         else
             false;
-        const caught_up_sequence = if (stats.last_sequence > from_sequence)
-            stats.last_sequence
+        const caught_up_sequence = if (stats.appliedSequenceAdvance(from_sequence)) |sequence|
+            sequence
         else if (target_advance_allowed)
             target_sequence
         else
             from_sequence;
-        if (caught_up_sequence == from_sequence and stats.last_sequence == 0 and target_sequence > from_sequence) {
+        if (caught_up_sequence == from_sequence and stats.shouldTryTargetAdvance(from_sequence, target_sequence)) {
             closeWorkerCatchUpState(runtime, worker, false) catch |err| {
                 close_success = false;
                 runtime.recordError(io, worker.name, "coverage_gap_close", err);

--- a/zig/pkg/antfly/src/storage/lite/bridge.zig
+++ b/zig/pkg/antfly/src/storage/lite/bridge.zig
@@ -21,6 +21,7 @@
 
 const std = @import("std");
 const builtin = @import("builtin");
+const byte_copy = @import("../../common/byte_copy.zig");
 const fs_paths = @import("../../common/fs_paths.zig");
 const platform_sync = @import("antfly_platform").sync;
 const storage_io = @import("../lsm_backend/storage_io.zig");
@@ -747,13 +748,13 @@ const ContainerAtomicWriteSink = struct {
 
     fn appendSlice(ptr: *anyopaque, bytes: []const u8) !void {
         const self: *ContainerAtomicWriteSink = @ptrCast(@alignCast(ptr));
-        try self.out.appendSlice(self.allocator, bytes);
+        try byte_copy.appendSlicePossiblyAliased(&self.out, self.allocator, bytes);
     }
 
     fn writeAt(ptr: *anyopaque, offset: usize, bytes: []const u8) !void {
         const self: *ContainerAtomicWriteSink = @ptrCast(@alignCast(ptr));
         if (offset > self.out.items.len or bytes.len > self.out.items.len - offset) return error.InvalidAtomicWriteOffset;
-        @memcpy(self.out.items[offset..][0..bytes.len], bytes);
+        byte_copy.copyPossiblyAliased(self.out.items[offset..][0..bytes.len], bytes);
     }
 
     fn crc32Prefix(ptr: *anyopaque, len_prefix: usize) !u32 {

--- a/zig/pkg/antfly/src/storage/lite/index_storage.zig
+++ b/zig/pkg/antfly/src/storage/lite/index_storage.zig
@@ -22,6 +22,7 @@
 
 const std = @import("std");
 const platform_sync = @import("antfly_platform").sync;
+const byte_copy = @import("../../common/byte_copy.zig");
 const docstore = @import("docstore.zig");
 const native = @import("native.zig");
 const storage_io = @import("../lsm_backend/storage_io.zig");
@@ -263,13 +264,13 @@ const NativeAtomicWriteSink = struct {
 
     fn appendSlice(ptr: *anyopaque, bytes: []const u8) !void {
         const self: *NativeAtomicWriteSink = @ptrCast(@alignCast(ptr));
-        try self.out.appendSlice(self.allocator, bytes);
+        try byte_copy.appendSlicePossiblyAliased(&self.out, self.allocator, bytes);
     }
 
     fn writeAt(ptr: *anyopaque, offset: usize, bytes: []const u8) !void {
         const self: *NativeAtomicWriteSink = @ptrCast(@alignCast(ptr));
         if (offset > self.out.items.len or bytes.len > self.out.items.len - offset) return error.InvalidAtomicWriteOffset;
-        @memcpy(self.out.items[offset..][0..bytes.len], bytes);
+        byte_copy.copyPossiblyAliased(self.out.items[offset..][0..bytes.len], bytes);
     }
 
     fn crc32Prefix(ptr: *anyopaque, len_prefix: usize) !u32 {

--- a/zig/pkg/antfly/src/storage/lsm/table_file.zig
+++ b/zig/pkg/antfly/src/storage/lsm/table_file.zig
@@ -14,6 +14,7 @@
 
 const std = @import("std");
 const bloom = @import("bloom");
+const byte_copy = @import("../../common/byte_copy.zig");
 const snappy = @import("../../encoding/snappy.zig");
 
 pub const magic = "ALSMTBL2";
@@ -697,7 +698,7 @@ pub const MemoryTableSink = struct {
 
     fn appendSlice(ptr: *anyopaque, bytes: []const u8) !void {
         const self: *MemoryTableSink = @ptrCast(@alignCast(ptr));
-        try self.out.appendSlice(self.allocator, bytes);
+        try byte_copy.appendSlicePossiblyAliased(&self.out, self.allocator, bytes);
     }
 
     fn appendByte(ptr: *anyopaque, byte: u8) !void {
@@ -708,7 +709,7 @@ pub const MemoryTableSink = struct {
     fn writeAt(ptr: *anyopaque, offset: usize, bytes: []const u8) !void {
         const self: *MemoryTableSink = @ptrCast(@alignCast(ptr));
         if (offset > self.out.items.len or bytes.len > self.out.items.len - offset) return error.InvalidTableFile;
-        @memcpy(self.out.items[offset..][0..bytes.len], bytes);
+        byte_copy.copyPossiblyAliased(self.out.items[offset..][0..bytes.len], bytes);
     }
 };
 
@@ -718,6 +719,19 @@ const memory_table_sink_vtable = TableSink.VTable{
     .append_byte = MemoryTableSink.appendByte,
     .write_at = MemoryTableSink.writeAt,
 };
+
+test "memory table sink supports overlapping writes and appends" {
+    var sink_impl = MemoryTableSink.init(std.testing.allocator);
+    defer sink_impl.deinit();
+    var sink = sink_impl.sink();
+
+    try sink.appendSlice("abcdef");
+    try sink.writeAt(2, sink_impl.out.items[0..4]);
+    try std.testing.expectEqualStrings("ababcd", sink_impl.out.items);
+
+    try sink.appendSlice(sink_impl.out.items[1..5]);
+    try std.testing.expectEqualStrings("ababcdbabc", sink_impl.out.items);
+}
 
 pub fn encodeAlloc(allocator: std.mem.Allocator, entries: []const Entry) ![]u8 {
     var filter = try buildFilterAlloc(allocator, entries, default_filter_config);

--- a/zig/pkg/antfly/src/storage/lsm_backend/repository.zig
+++ b/zig/pkg/antfly/src/storage/lsm_backend/repository.zig
@@ -15,6 +15,7 @@
 const std = @import("std");
 const Allocator = std.mem.Allocator;
 const bloom = @import("bloom");
+const byte_copy = @import("../../common/byte_copy.zig");
 const lsm_manifest = @import("../lsm/manifest.zig");
 const lsm_table_file = @import("../lsm/table_file.zig");
 const resource_manager_mod = @import("../resource_manager.zig");
@@ -739,7 +740,7 @@ const BufferedAtomicTableSink = struct {
                 continue;
             }
             const n = @min(self.buffer.len - self.len_buffered, remaining.len);
-            @memcpy(self.buffer[self.len_buffered..][0..n], remaining[0..n]);
+            byte_copy.copyPossiblyAliased(self.buffer[self.len_buffered..][0..n], remaining[0..n]);
             self.len_buffered += n;
             remaining = remaining[n..];
         }
@@ -766,7 +767,7 @@ const BufferedAtomicTableSink = struct {
 
         if (src_offset < bytes.len) {
             const buffer_offset = offset + src_offset - self.len_flushed;
-            @memcpy(self.buffer[buffer_offset..][0 .. bytes.len - src_offset], bytes[src_offset..]);
+            byte_copy.copyPossiblyAliased(self.buffer[buffer_offset..][0 .. bytes.len - src_offset], bytes[src_offset..]);
         }
     }
 };

--- a/zig/pkg/antfly/src/storage/lsm_backend/storage_io.zig
+++ b/zig/pkg/antfly/src/storage/lsm_backend/storage_io.zig
@@ -16,6 +16,7 @@ const std = @import("std");
 const platform_sync = @import("antfly_platform").sync;
 const builtin = @import("builtin");
 const platform = @import("antfly_platform");
+const byte_copy = @import("../../common/byte_copy.zig");
 const fs_paths = @import("../../common/fs_paths.zig");
 
 const Allocator = std.mem.Allocator;
@@ -535,13 +536,13 @@ const BufferedAtomicWriteSink = struct {
 
     fn appendSlice(ptr: *anyopaque, bytes: []const u8) !void {
         const self: *BufferedAtomicWriteSink = @ptrCast(@alignCast(ptr));
-        try self.out.appendSlice(self.allocator, bytes);
+        try byte_copy.appendSlicePossiblyAliased(&self.out, self.allocator, bytes);
     }
 
     fn writeAt(ptr: *anyopaque, offset: usize, bytes: []const u8) !void {
         const self: *BufferedAtomicWriteSink = @ptrCast(@alignCast(ptr));
         if (offset > self.out.items.len or bytes.len > self.out.items.len - offset) return error.InvalidAtomicWriteOffset;
-        @memcpy(self.out.items[offset..][0..bytes.len], bytes);
+        byte_copy.copyPossiblyAliased(self.out.items[offset..][0..bytes.len], bytes);
     }
 
     fn crc32Prefix(ptr: *anyopaque, len_prefix: usize) !u32 {
@@ -1980,13 +1981,13 @@ const NativeBufferedAtomicWriteSink = struct {
 
     fn appendSlice(ptr: *anyopaque, bytes: []const u8) !void {
         const self: *NativeBufferedAtomicWriteSink = @ptrCast(@alignCast(ptr));
-        try self.out.appendSlice(self.allocator, bytes);
+        try byte_copy.appendSlicePossiblyAliased(&self.out, self.allocator, bytes);
     }
 
     fn writeAt(ptr: *anyopaque, offset: usize, bytes: []const u8) !void {
         const self: *NativeBufferedAtomicWriteSink = @ptrCast(@alignCast(ptr));
         if (offset > self.out.items.len or bytes.len > self.out.items.len - offset) return error.InvalidAtomicWriteOffset;
-        @memcpy(self.out.items[offset..][0..bytes.len], bytes);
+        byte_copy.copyPossiblyAliased(self.out.items[offset..][0..bytes.len], bytes);
     }
 
     fn crc32Prefix(ptr: *anyopaque, len_prefix: usize) !u32 {
@@ -2507,6 +2508,30 @@ test "native atomic write sink supports patching and crc before finish" {
     const written = try native.storage().readFileAlloc(std.testing.allocator, path, 64);
     defer std.testing.allocator.free(written);
     try std.testing.expectEqualStrings("hello world", written);
+}
+
+test "buffered atomic write sink supports overlapping writes and appends" {
+    var backing = MemoryStorage.init(std.testing.allocator);
+    defer backing.deinit();
+
+    var writer = try backing.storage().beginAtomicWrite(std.testing.allocator, "/alias-safe.bin");
+    var active = true;
+    defer if (active) writer.abort();
+
+    try writer.appendSlice("abcdef");
+    const impl: *BufferedAtomicWriteSink = @ptrCast(@alignCast(writer.ptr));
+    try writer.writeAt(2, impl.out.items[0..4]);
+    try std.testing.expectEqualStrings("ababcd", impl.out.items);
+
+    try writer.appendSlice(impl.out.items[1..5]);
+    try std.testing.expectEqualStrings("ababcdbabc", impl.out.items);
+
+    active = false;
+    try writer.finish();
+
+    const written = try backing.storage().readFileAlloc(std.testing.allocator, "/alias-safe.bin", 64);
+    defer std.testing.allocator.free(written);
+    try std.testing.expectEqualStrings("ababcdbabc", written);
 }
 
 test "native fd cache evicts to per-store budget" {


### PR DESCRIPTION
Fixes #291.
Fixes #293.

## Summary
- centralize derived replay progress decisions on `CatchUpStats`: applied-work sequence advance vs guarded zero-applied target advance
- route DB startup replay, manual executor replay, async runtime replay, and IO-threaded runtime replay through the same accounting
- require the dense coverage guard before advancing any zero-applied replay window to target, including scanned-but-zero-applied windows
- add alias-safe byte copy/append helpers for storage sink implementations that can patch or append from overlapping buffers
- harden LSM table/atomic sinks, repository table staging, Lite atomic sinks, and segment sinks against `@memcpy arguments alias` panics during rebuild and drain paths

## Verification
- `git diff --check`
- `zig build root-test -- "CatchUpStats target advance covers scanned zero-applied tail"`
- `zig build root-test -- "async dense zero-applied replay window advances only through target coverage guard"`
- `zig build root-test -- "async dense catch-up NotFound retries without failing runtime"`
- `zig build root-test -- "copyPossiblyAliased supports overlapping ranges"`
- `zig build root-test -- "memory table sink supports overlapping writes and appends"`
- `zig build lsm-backend-test -- "buffered atomic write sink supports overlapping writes and appends"`
- `zig build -Doptimize=ReleaseSafe lsm-backend-test -- "buffered atomic write sink supports overlapping writes and appends"`
- `zig build lsm-backend-test`
- `zig build root-test`
- `zig build lite-native-test`