### PR TITLE
Diagnose backup raft stalls and reconcile backup jobs

### DIFF
--- a/go/pkg/operator/controllers/antfly/antflybackup_controller.go
+++ b/go/pkg/operator/controllers/antfly/antflybackup_controller.go
@@ -14,10 +14,13 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	antflyv1 "github.com/antflydb/antfly/go/pkg/operator/api/antfly/v1"
@@ -389,8 +392,38 @@ func (r *AntflyBackupReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&antflyv1.AntflyBackup{}).
 		Owns(&batchv1.CronJob{}).
-		Watches(&antflyv1.AntflyCluster{}, handler.EnqueueRequestsFromMapFunc(r.requestsForCluster)).
+		Watches(
+			&antflyv1.AntflyCluster{},
+			handler.EnqueueRequestsFromMapFunc(r.requestsForCluster),
+			builder.WithPredicates(backupClusterDependencyChangedPredicate()),
+		).
 		Complete(r)
+}
+
+func backupClusterDependencyChangedPredicate() predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(event.CreateEvent) bool {
+			return true
+		},
+		DeleteFunc: func(event.DeleteEvent) bool {
+			return true
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldCluster, oldOK := e.ObjectOld.(*antflyv1.AntflyCluster)
+			newCluster, newOK := e.ObjectNew.(*antflyv1.AntflyCluster)
+			if !oldOK || !newOK {
+				return false
+			}
+			return backupClusterDependencyKey(oldCluster) != backupClusterDependencyKey(newCluster)
+		},
+		GenericFunc: func(event.GenericEvent) bool {
+			return true
+		},
+	}
+}
+
+func backupClusterDependencyKey(cluster *antflyv1.AntflyCluster) string {
+	return cluster.Spec.Image
 }
 
 func (r *AntflyBackupReconciler) requestsForCluster(ctx context.Context, obj client.Object) []reconcile.Request {

--- a/go/pkg/operator/controllers/antfly/antflybackup_controller.go
+++ b/go/pkg/operator/controllers/antfly/antflybackup_controller.go
@@ -16,7 +16,9 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	antflyv1 "github.com/antflydb/antfly/go/pkg/operator/api/antfly/v1"
 )
@@ -387,5 +389,41 @@ func (r *AntflyBackupReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&antflyv1.AntflyBackup{}).
 		Owns(&batchv1.CronJob{}).
+		Watches(&antflyv1.AntflyCluster{}, handler.EnqueueRequestsFromMapFunc(r.requestsForCluster)).
 		Complete(r)
+}
+
+func (r *AntflyBackupReconciler) requestsForCluster(ctx context.Context, obj client.Object) []reconcile.Request {
+	cluster, ok := obj.(*antflyv1.AntflyCluster)
+	if !ok {
+		return nil
+	}
+
+	backupList := &antflyv1.AntflyBackupList{}
+	if err := r.List(ctx, backupList); err != nil {
+		log.FromContext(ctx).Error(err, "Failed to list AntflyBackups for AntflyCluster watch",
+			"cluster", cluster.Name,
+			"namespace", cluster.Namespace,
+		)
+		return nil
+	}
+
+	requests := make([]reconcile.Request, 0, len(backupList.Items))
+	for i := range backupList.Items {
+		backup := &backupList.Items[i]
+		clusterNamespace := backup.Spec.ClusterRef.Namespace
+		if clusterNamespace == "" {
+			clusterNamespace = backup.Namespace
+		}
+		if backup.Spec.ClusterRef.Name != cluster.Name || clusterNamespace != cluster.Namespace {
+			continue
+		}
+		requests = append(requests, reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      backup.Name,
+				Namespace: backup.Namespace,
+			},
+		})
+	}
+	return requests
 }

--- a/go/pkg/operator/controllers/antfly/antflybackup_controller_test.go
+++ b/go/pkg/operator/controllers/antfly/antflybackup_controller_test.go
@@ -10,6 +10,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 )
 
 func TestShellQuote(t *testing.T) {
@@ -312,6 +313,53 @@ func TestRequestsForClusterEnqueuesReferencingBackups(t *testing.T) {
 	}
 	if got["cluster-ns/other"] {
 		t.Fatalf("did not expect unrelated backup request, got %#v", got)
+	}
+}
+
+func TestBackupClusterDependencyChangedPredicate(t *testing.T) {
+	pred := backupClusterDependencyChangedPredicate()
+
+	base := &antflyv1.AntflyCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "cluster",
+			Namespace:  "default",
+			Generation: 10,
+		},
+		Spec: antflyv1.AntflyClusterSpec{
+			Image: "antfly:v1",
+			Mode:  antflyv1.ClusterModeClustered,
+		},
+	}
+
+	if !pred.Create(event.CreateEvent{Object: base}) {
+		t.Fatalf("expected create event to enqueue backups")
+	}
+	if !pred.Delete(event.DeleteEvent{Object: base}) {
+		t.Fatalf("expected delete event to enqueue backups")
+	}
+	if !pred.Generic(event.GenericEvent{Object: base}) {
+		t.Fatalf("expected generic event to enqueue backups")
+	}
+
+	statusOnly := base.DeepCopy()
+	statusOnly.Status.Phase = "Running"
+	statusOnly.Generation = base.Generation
+	if pred.Update(event.UpdateEvent{ObjectOld: base, ObjectNew: statusOnly}) {
+		t.Fatalf("expected status-only cluster update to be filtered")
+	}
+
+	unrelatedSpec := base.DeepCopy()
+	unrelatedSpec.Generation = base.Generation + 1
+	unrelatedSpec.Spec.Mode = antflyv1.ClusterModeSwarm
+	if pred.Update(event.UpdateEvent{ObjectOld: base, ObjectNew: unrelatedSpec}) {
+		t.Fatalf("expected non-image spec update to be filtered")
+	}
+
+	imageChanged := base.DeepCopy()
+	imageChanged.Generation = base.Generation + 1
+	imageChanged.Spec.Image = "antfly:v2"
+	if !pred.Update(event.UpdateEvent{ObjectOld: base, ObjectNew: imageChanged}) {
+		t.Fatalf("expected image update to enqueue backups")
 	}
 }
 

--- a/go/pkg/operator/controllers/antfly/antflybackup_controller_test.go
+++ b/go/pkg/operator/controllers/antfly/antflybackup_controller_test.go
@@ -1,12 +1,15 @@
 package controllers
 
 import (
+	"context"
 	"strings"
 	"testing"
 
 	antflyv1 "github.com/antflydb/antfly/go/pkg/operator/api/antfly/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestShellQuote(t *testing.T) {
@@ -254,6 +257,61 @@ func TestBuildCronJobSpec_SwarmStillUsesPublicAPIService(t *testing.T) {
 	}
 	if got := envValue(container.Env, "ANTFLY_URL"); got != "http://swarm-cluster-public-api.default.svc.cluster.local" {
 		t.Fatalf("expected backup URL to continue using public-api service in swarm mode, got: %q", got)
+	}
+}
+
+func TestRequestsForClusterEnqueuesReferencingBackups(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := antflyv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme failed: %v", err)
+	}
+
+	cluster := &antflyv1.AntflyCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster", Namespace: "cluster-ns"},
+	}
+	sameNamespaceBackup := &antflyv1.AntflyBackup{
+		ObjectMeta: metav1.ObjectMeta{Name: "same-ns", Namespace: "cluster-ns"},
+		Spec: antflyv1.AntflyBackupSpec{
+			ClusterRef: antflyv1.ClusterReference{Name: "cluster"},
+		},
+	}
+	crossNamespaceBackup := &antflyv1.AntflyBackup{
+		ObjectMeta: metav1.ObjectMeta{Name: "cross-ns", Namespace: "backup-ns"},
+		Spec: antflyv1.AntflyBackupSpec{
+			ClusterRef: antflyv1.ClusterReference{Name: "cluster", Namespace: "cluster-ns"},
+		},
+	}
+	otherBackup := &antflyv1.AntflyBackup{
+		ObjectMeta: metav1.ObjectMeta{Name: "other", Namespace: "cluster-ns"},
+		Spec: antflyv1.AntflyBackupSpec{
+			ClusterRef: antflyv1.ClusterReference{Name: "other-cluster"},
+		},
+	}
+
+	r := &AntflyBackupReconciler{
+		Client: fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(sameNamespaceBackup, crossNamespaceBackup, otherBackup).
+			Build(),
+	}
+
+	requests := r.requestsForCluster(context.Background(), cluster)
+	got := make(map[string]bool, len(requests))
+	for _, req := range requests {
+		got[req.NamespacedName.String()] = true
+	}
+
+	if len(got) != 2 {
+		t.Fatalf("expected 2 requests, got %d: %#v", len(got), got)
+	}
+	if !got["cluster-ns/same-ns"] {
+		t.Fatalf("expected same-namespace backup request, got %#v", got)
+	}
+	if !got["backup-ns/cross-ns"] {
+		t.Fatalf("expected cross-namespace backup request, got %#v", got)
+	}
+	if got["cluster-ns/other"] {
+		t.Fatalf("did not expect unrelated backup request, got %#v", got)
 	}
 }
 

--- a/zig/lib/raft/src/runtime/clock.zig
+++ b/zig/lib/raft/src/runtime/clock.zig
@@ -1,0 +1,30 @@
+// Copyright 2026 Antfly, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const builtin = @import("builtin");
+const std = @import("std");
+
+pub fn monotonicNs() u64 {
+    if (comptime builtin.os.tag == .freestanding and (builtin.cpu.arch == .wasm32 or builtin.cpu.arch == .wasm64)) return 0;
+
+    var ts: std.posix.timespec = undefined;
+    switch (std.posix.errno(std.posix.system.clock_gettime(.MONOTONIC, &ts))) {
+        .SUCCESS => return @intCast(@as(i128, ts.sec) * std.time.ns_per_s + ts.nsec),
+        else => return 0,
+    }
+}
+
+pub fn elapsedSinceNs(start_ns: u64) u64 {
+    return monotonicNs() -| start_ns;
+}

--- a/zig/lib/raft/src/runtime/multi_raft.zig
+++ b/zig/lib/raft/src/runtime/multi_raft.zig
@@ -505,7 +505,10 @@ pub const MultiRaft = struct {
         const batch = if (self.hooks.disk_batcher) |disk_batcher| try disk_batcher.beginBatch() else null;
         if (diagnostics) |diag| diag.persist_batch_begin_elapsed_ns = clock.elapsedSinceNs(persist_batch_begin_start_ns);
         if (batch != null) self.metrics.persist_batches += 1;
-        errdefer if (batch) |persist_batch| persist_batch.finish() catch unreachable;
+        var batch_finish_attempted = false;
+        errdefer if (!batch_finish_attempted) {
+            if (batch) |persist_batch| persist_batch.finish() catch unreachable;
+        };
 
         var scanned: usize = 0;
         const scan_limit = self.groups.count();
@@ -536,7 +539,11 @@ pub const MultiRaft = struct {
         if (diagnostics) |diag| diag.transport_flush_elapsed_ns = clock.elapsedSinceNs(transport_flush_start_ns);
         if (batch) |persist_batch| {
             const persist_batch_finish_start_ns = clock.monotonicNs();
-            try persist_batch.finish();
+            batch_finish_attempted = true;
+            persist_batch.finish() catch |err| {
+                if (diagnostics) |diag| diag.persist_batch_finish_elapsed_ns = clock.elapsedSinceNs(persist_batch_finish_start_ns);
+                return err;
+            };
             if (diagnostics) |diag| diag.persist_batch_finish_elapsed_ns = clock.elapsedSinceNs(persist_batch_finish_start_ns);
         }
         self.refreshQueueMetrics();

--- a/zig/lib/raft/src/runtime/multi_raft.zig
+++ b/zig/lib/raft/src/runtime/multi_raft.zig
@@ -14,6 +14,7 @@
 
 const std = @import("std");
 const core = @import("../core/mod.zig");
+const clock = @import("clock.zig");
 const group_mod = @import("group.zig");
 const scheduler_mod = @import("scheduler.zig");
 const transport_iface = @import("transport_iface.zig");
@@ -53,11 +54,68 @@ pub const RuntimeHooks = struct {
     replica_factory: ?replica_catalog_iface.ReplicaFactory = null,
 };
 
+pub const ReadyGroupDiagnostics = struct {
+    group_id: core.types.GroupId = 0,
+    elapsed_ns: u64 = 0,
+    ready_build_elapsed_ns: u64 = 0,
+    backpressure_elapsed_ns: u64 = 0,
+    capacity_check_elapsed_ns: u64 = 0,
+    snapshot_throttle_elapsed_ns: u64 = 0,
+    persist_ready_elapsed_ns: u64 = 0,
+    async_ready_elapsed_ns: u64 = 0,
+    clone_messages_elapsed_ns: u64 = 0,
+    enqueue_apply_elapsed_ns: u64 = 0,
+    async_message_loop_elapsed_ns: u64 = 0,
+    outbox_append_elapsed_ns: u64 = 0,
+    raft_advance_elapsed_ns: u64 = 0,
+    inline_apply_flush_elapsed_ns: u64 = 0,
+    inline_outbox_drain_elapsed_ns: u64 = 0,
+    inline_transport_flush_elapsed_ns: u64 = 0,
+    message_count: usize = 0,
+    message_bytes: usize = 0,
+    committed_entries: usize = 0,
+    committed_entry_bytes: usize = 0,
+    unstable_entries: usize = 0,
+    unstable_entry_bytes: usize = 0,
+    read_states: usize = 0,
+    has_snapshot: bool = false,
+    snapshot_bytes: usize = 0,
+    async_storage_writes: bool = false,
+    processed: bool = false,
+    denied_by_backpressure: bool = false,
+    denied_by_transport_capacity: bool = false,
+    denied_by_apply_capacity: bool = false,
+    denied_by_snapshot_throttle: bool = false,
+    has_more_ready: bool = false,
+};
+
 pub const HostRound = struct {
     ticked_groups: usize = 0,
     processed_groups: usize = 0,
     virtual_round: u64 = 0,
     virtual_time_ms: u64 = 0,
+    elapsed_ns: u64 = 0,
+    inbound_drain_elapsed_ns: u64 = 0,
+    tick_elapsed_ns: u64 = 0,
+    drain_ready_elapsed_ns: u64 = 0,
+    drain_ready_scan_elapsed_ns: u64 = 0,
+    persist_batch_begin_elapsed_ns: u64 = 0,
+    persist_batch_finish_elapsed_ns: u64 = 0,
+    outbox_drain_elapsed_ns: u64 = 0,
+    apply_flush_elapsed_ns: u64 = 0,
+    transport_flush_elapsed_ns: u64 = 0,
+    transport_advance_elapsed_ns: u64 = 0,
+    slowest_ready_group: ReadyGroupDiagnostics = .{},
+};
+
+pub const DrainReadyDiagnostics = struct {
+    scan_elapsed_ns: u64 = 0,
+    persist_batch_begin_elapsed_ns: u64 = 0,
+    persist_batch_finish_elapsed_ns: u64 = 0,
+    outbox_drain_elapsed_ns: u64 = 0,
+    apply_flush_elapsed_ns: u64 = 0,
+    transport_flush_elapsed_ns: u64 = 0,
+    slowest_ready_group: ReadyGroupDiagnostics = .{},
 };
 
 pub const HostMetrics = struct {
@@ -304,27 +362,47 @@ pub const MultiRaft = struct {
     }
 
     pub fn runRound(self: *MultiRaft, max_tick_groups: usize, max_ready_groups: usize) !HostRound {
+        const round_start_ns = clock.monotonicNs();
         const virtual_time = self.scheduler.advanceVirtualTime();
         var ticked_groups: usize = 0;
         const tick_limit = @min(max_tick_groups, self.scheduler.activeGroupCount());
 
+        const tick_start_ns = clock.monotonicNs();
         while (ticked_groups < tick_limit) : (ticked_groups += 1) {
             const group_id = self.scheduler.nextTickGroup() orelse break;
             try self.tickGroup(group_id);
         }
+        const tick_elapsed_ns = clock.elapsedSinceNs(tick_start_ns);
 
-        const round: HostRound = .{
+        var drain_diag = DrainReadyDiagnostics{};
+        const drain_ready_start_ns = clock.monotonicNs();
+        const processed_groups = try self.drainReadyWithDiagnostics(max_ready_groups, &drain_diag);
+        const drain_ready_elapsed_ns = clock.elapsedSinceNs(drain_ready_start_ns);
+
+        var round: HostRound = .{
             .ticked_groups = ticked_groups,
-            .processed_groups = try self.drainReady(max_ready_groups),
+            .processed_groups = processed_groups,
             .virtual_round = virtual_time.round,
             .virtual_time_ms = virtual_time.now_ms,
+            .tick_elapsed_ns = tick_elapsed_ns,
+            .drain_ready_elapsed_ns = drain_ready_elapsed_ns,
+            .drain_ready_scan_elapsed_ns = drain_diag.scan_elapsed_ns,
+            .persist_batch_begin_elapsed_ns = drain_diag.persist_batch_begin_elapsed_ns,
+            .persist_batch_finish_elapsed_ns = drain_diag.persist_batch_finish_elapsed_ns,
+            .outbox_drain_elapsed_ns = drain_diag.outbox_drain_elapsed_ns,
+            .apply_flush_elapsed_ns = drain_diag.apply_flush_elapsed_ns,
+            .transport_flush_elapsed_ns = drain_diag.transport_flush_elapsed_ns,
+            .slowest_ready_group = drain_diag.slowest_ready_group,
         };
         self.metrics.rounds += 1;
         self.metrics.virtual_round = virtual_time.round;
         self.metrics.virtual_time_ms = virtual_time.now_ms;
         self.metrics.ticked_groups += round.ticked_groups;
         self.metrics.processed_groups += round.processed_groups;
+        const transport_advance_start_ns = clock.monotonicNs();
         if (self.hooks.transport) |transport| try transport.advanceTimeMs(virtual_time.now_ms);
+        round.transport_advance_elapsed_ns = clock.elapsedSinceNs(transport_advance_start_ns);
+        round.elapsed_ns = clock.elapsedSinceNs(round_start_ns);
         return round;
     }
 
@@ -407,7 +485,7 @@ pub const MultiRaft = struct {
         const batch = if (self.hooks.disk_batcher) |disk_batcher| try disk_batcher.beginBatch() else null;
         if (batch != null) self.metrics.persist_batches += 1;
         defer if (batch) |persist_batch| persist_batch.finish() catch unreachable;
-        const processed = try self.processReadyIntoOutbox(group_id, &outbox, batch, false, false);
+        const processed = try self.processReadyIntoOutbox(group_id, &outbox, batch, false, false, null);
         try outbox.drainInto(self.alloc, &self.pending_outbox);
         try self.flushPendingApply();
         try self.flushPendingTransport();
@@ -416,24 +494,51 @@ pub const MultiRaft = struct {
     }
 
     pub fn drainReady(self: *MultiRaft, max_groups: usize) !usize {
+        return try self.drainReadyWithDiagnostics(max_groups, null);
+    }
+
+    fn drainReadyWithDiagnostics(self: *MultiRaft, max_groups: usize, diagnostics: ?*DrainReadyDiagnostics) !usize {
         var processed: usize = 0;
         var outbox = TransportOutbox{};
         defer outbox.deinit(self.alloc);
+        const persist_batch_begin_start_ns = clock.monotonicNs();
         const batch = if (self.hooks.disk_batcher) |disk_batcher| try disk_batcher.beginBatch() else null;
+        if (diagnostics) |diag| diag.persist_batch_begin_elapsed_ns = clock.elapsedSinceNs(persist_batch_begin_start_ns);
         if (batch != null) self.metrics.persist_batches += 1;
-        defer if (batch) |persist_batch| persist_batch.finish() catch unreachable;
+        errdefer if (batch) |persist_batch| persist_batch.finish() catch unreachable;
 
         var scanned: usize = 0;
         const scan_limit = self.groups.count();
+        const scan_start_ns = clock.monotonicNs();
         while (scanned < scan_limit) : (scanned += 1) {
             if (processed >= max_groups) break;
             const group_id = self.scheduler.nextReadyGroup() orelse break;
-            if (try self.processReadyIntoOutbox(group_id, &outbox, batch, false, false)) processed += 1;
+            var ready_diag = ReadyGroupDiagnostics{ .group_id = group_id };
+            const ready_start_ns = clock.monotonicNs();
+            const ready_processed = try self.processReadyIntoOutbox(group_id, &outbox, batch, false, false, &ready_diag);
+            ready_diag.elapsed_ns = clock.elapsedSinceNs(ready_start_ns);
+            ready_diag.processed = ready_processed;
+            if (diagnostics) |diag| {
+                if (ready_diag.elapsed_ns > diag.slowest_ready_group.elapsed_ns) diag.slowest_ready_group = ready_diag;
+            }
+            if (ready_processed) processed += 1;
         }
+        if (diagnostics) |diag| diag.scan_elapsed_ns = clock.elapsedSinceNs(scan_start_ns);
 
+        const outbox_drain_start_ns = clock.monotonicNs();
         try outbox.drainInto(self.alloc, &self.pending_outbox);
+        if (diagnostics) |diag| diag.outbox_drain_elapsed_ns = clock.elapsedSinceNs(outbox_drain_start_ns);
+        const apply_flush_start_ns = clock.monotonicNs();
         try self.flushPendingApply();
+        if (diagnostics) |diag| diag.apply_flush_elapsed_ns = clock.elapsedSinceNs(apply_flush_start_ns);
+        const transport_flush_start_ns = clock.monotonicNs();
         try self.flushPendingTransport();
+        if (diagnostics) |diag| diag.transport_flush_elapsed_ns = clock.elapsedSinceNs(transport_flush_start_ns);
+        if (batch) |persist_batch| {
+            const persist_batch_finish_start_ns = clock.monotonicNs();
+            try persist_batch.finish();
+            if (diagnostics) |diag| diag.persist_batch_finish_elapsed_ns = clock.elapsedSinceNs(persist_batch_finish_start_ns);
+        }
         self.refreshQueueMetrics();
         return processed;
     }
@@ -445,27 +550,52 @@ pub const MultiRaft = struct {
         persist_batch: ?storage_iface.PersistBatch,
         flush_transport: bool,
         flush_apply_queue: bool,
+        diagnostics: ?*ReadyGroupDiagnostics,
     ) !bool {
         const grp = self.group(group_id) orelse return error.UnknownGroup;
         if (!grp.hasReady()) return false;
 
+        const ready_build_start_ns = clock.monotonicNs();
         const ready = grp.ready();
+        if (diagnostics) |diag| diag.ready_build_elapsed_ns = clock.elapsedSinceNs(ready_build_start_ns);
         if (ready.isEmpty()) return false;
 
+        const ready_pressure = summarizeReady(group_id, ready);
+        const async_storage_writes = grp.asyncStorageWrites();
+        if (diagnostics) |diag| {
+            diag.message_count = ready_pressure.message_count;
+            diag.message_bytes = ready_pressure.message_bytes;
+            diag.committed_entries = ready_pressure.committed_entries;
+            diag.committed_entry_bytes = ready_pressure.committed_entry_bytes;
+            diag.unstable_entries = ready_pressure.unstable_entries;
+            diag.unstable_entry_bytes = ready_pressure.unstable_entry_bytes;
+            diag.read_states = ready.read_states.len;
+            diag.has_snapshot = ready_pressure.has_snapshot;
+            diag.snapshot_bytes = ready_pressure.snapshot_bytes;
+            diag.async_storage_writes = async_storage_writes;
+        }
+
         if (self.hooks.backpressure) |backpressure| {
-            const pressure = summarizeReady(group_id, ready);
-            if (!backpressure.allowReady(pressure)) {
+            const backpressure_start_ns = clock.monotonicNs();
+            const allowed = backpressure.allowReady(ready_pressure);
+            if (diagnostics) |diag| diag.backpressure_elapsed_ns = clock.elapsedSinceNs(backpressure_start_ns);
+            if (!allowed) {
+                if (diagnostics) |diag| diag.denied_by_backpressure = true;
                 self.metrics.backpressure_denials += 1;
                 self.scheduler.noteReady(group_id);
                 return false;
             }
         }
 
-        const ready_pressure = summarizeReady(group_id, ready);
+        const capacity_check_start_ns = clock.monotonicNs();
         if (!self.hasOutboundCapacity(
             outbox.items.items.len + ready_pressure.message_count,
             outbox.approxBytes() + ready_pressure.message_bytes,
         )) {
+            if (diagnostics) |diag| {
+                diag.capacity_check_elapsed_ns = clock.elapsedSinceNs(capacity_check_start_ns);
+                diag.denied_by_transport_capacity = true;
+            }
             self.metrics.transport_queue_denials += 1;
             self.scheduler.noteReady(group_id);
             return false;
@@ -474,15 +604,25 @@ pub const MultiRaft = struct {
             if (ready.committed_entries.len > 0 or ready.read_states.len > 0) 1 else 0,
             ready_pressure.committed_entry_bytes + approxReadStatesSize(ready.read_states),
         )) {
+            if (diagnostics) |diag| {
+                diag.capacity_check_elapsed_ns = clock.elapsedSinceNs(capacity_check_start_ns);
+                diag.denied_by_apply_capacity = true;
+            }
             self.metrics.apply_queue_denials += 1;
             self.scheduler.noteReady(group_id);
             return false;
         }
+        if (diagnostics) |diag| diag.capacity_check_elapsed_ns = clock.elapsedSinceNs(capacity_check_start_ns);
 
+        const snapshot_throttle_start_ns = clock.monotonicNs();
         const snapshot_started = blk: {
             if (ready.snapshot == null) break :blk false;
             if (self.hooks.snapshot_throttle) |throttle| {
                 if (!throttle.beginSnapshot(group_id)) {
+                    if (diagnostics) |diag| {
+                        diag.snapshot_throttle_elapsed_ns = clock.elapsedSinceNs(snapshot_throttle_start_ns);
+                        diag.denied_by_snapshot_throttle = true;
+                    }
                     self.metrics.snapshot_throttle_denials += 1;
                     self.scheduler.noteReady(group_id);
                     return false;
@@ -491,30 +631,51 @@ pub const MultiRaft = struct {
             }
             break :blk false;
         };
+        if (diagnostics) |diag| diag.snapshot_throttle_elapsed_ns = clock.elapsedSinceNs(snapshot_throttle_start_ns);
         defer if (snapshot_started) {
             self.hooks.snapshot_throttle.?.endSnapshot(group_id);
         };
 
+        const persist_ready_start_ns = clock.monotonicNs();
         if (persist_batch) |batch| {
             try batch.persistReady(group_id, ready);
         } else if (self.hooks.group_storage) |storage| {
             try storage.persistReady(group_id, ready);
         }
+        if (diagnostics) |diag| diag.persist_ready_elapsed_ns = clock.elapsedSinceNs(persist_ready_start_ns);
 
-        if (grp.asyncStorageWrites()) {
-            try self.handleAsyncReady(group_id, grp, ready, outbox, flush_apply_queue);
+        if (async_storage_writes) {
+            const async_ready_start_ns = clock.monotonicNs();
+            try self.handleAsyncReady(group_id, grp, ready, outbox, flush_apply_queue, diagnostics);
+            if (diagnostics) |diag| diag.async_ready_elapsed_ns = clock.elapsedSinceNs(async_ready_start_ns);
         } else {
+            const enqueue_apply_start_ns = clock.monotonicNs();
             try self.enqueueApply(group_id, ready.committed_entries, ready.read_states);
+            if (diagnostics) |diag| diag.enqueue_apply_elapsed_ns = clock.elapsedSinceNs(enqueue_apply_start_ns);
+            const outbox_append_start_ns = clock.monotonicNs();
             try outbox.appendMessages(self.alloc, group_id, ready.messages);
+            if (diagnostics) |diag| diag.outbox_append_elapsed_ns = clock.elapsedSinceNs(outbox_append_start_ns);
+            const advance_start_ns = clock.monotonicNs();
             grp.advance(ready);
+            if (diagnostics) |diag| diag.raft_advance_elapsed_ns = clock.elapsedSinceNs(advance_start_ns);
         }
 
-        if (flush_apply_queue) try self.flushPendingApply();
-        if (flush_transport) {
-            try outbox.drainInto(self.alloc, &self.pending_outbox);
-            try self.flushPendingTransport();
+        if (flush_apply_queue) {
+            const inline_apply_flush_start_ns = clock.monotonicNs();
+            try self.flushPendingApply();
+            if (diagnostics) |diag| diag.inline_apply_flush_elapsed_ns = clock.elapsedSinceNs(inline_apply_flush_start_ns);
         }
-        if (grp.hasReady()) self.scheduler.noteReady(group_id);
+        if (flush_transport) {
+            const inline_outbox_drain_start_ns = clock.monotonicNs();
+            try outbox.drainInto(self.alloc, &self.pending_outbox);
+            if (diagnostics) |diag| diag.inline_outbox_drain_elapsed_ns = clock.elapsedSinceNs(inline_outbox_drain_start_ns);
+            const inline_transport_flush_start_ns = clock.monotonicNs();
+            try self.flushPendingTransport();
+            if (diagnostics) |diag| diag.inline_transport_flush_elapsed_ns = clock.elapsedSinceNs(inline_transport_flush_start_ns);
+        }
+        const has_more_ready = grp.hasReady();
+        if (diagnostics) |diag| diag.has_more_ready = has_more_ready;
+        if (has_more_ready) self.scheduler.noteReady(group_id);
         return true;
     }
 
@@ -525,13 +686,23 @@ pub const MultiRaft = struct {
         ready: core.Ready,
         outbox: *TransportOutbox,
         flush_apply_queue: bool,
+        diagnostics: ?*ReadyGroupDiagnostics,
     ) !void {
+        const clone_messages_start_ns = clock.monotonicNs();
         const messages = try core.message.cloneMessages(self.alloc, ready.messages);
         defer core.message.freeMessages(self.alloc, messages);
+        if (diagnostics) |diag| diag.clone_messages_elapsed_ns = clock.elapsedSinceNs(clone_messages_start_ns);
 
+        const enqueue_apply_start_ns = clock.monotonicNs();
         try self.enqueueApply(group_id, ready.committed_entries, ready.read_states);
-        if (flush_apply_queue) try self.flushPendingApply();
+        if (diagnostics) |diag| diag.enqueue_apply_elapsed_ns = clock.elapsedSinceNs(enqueue_apply_start_ns);
+        if (flush_apply_queue) {
+            const inline_apply_flush_start_ns = clock.monotonicNs();
+            try self.flushPendingApply();
+            if (diagnostics) |diag| diag.inline_apply_flush_elapsed_ns = clock.elapsedSinceNs(inline_apply_flush_start_ns);
+        }
 
+        const async_message_loop_start_ns = clock.monotonicNs();
         for (messages) |msg| {
             switch (msg.msg_type) {
                 .storage_append => try self.handleLocalStorageAppend(group_id, grp, msg, outbox),
@@ -539,6 +710,7 @@ pub const MultiRaft = struct {
                 else => try outbox.appendMessage(self.alloc, group_id, msg),
             }
         }
+        if (diagnostics) |diag| diag.async_message_loop_elapsed_ns = clock.elapsedSinceNs(async_message_loop_start_ns);
     }
 
     fn enqueueApply(

--- a/zig/lib/raft/src/runtime/multi_raft.zig
+++ b/zig/lib/raft/src/runtime/multi_raft.zig
@@ -501,7 +501,7 @@ pub const MultiRaft = struct {
         var processed: usize = 0;
         var outbox = TransportOutbox{};
         defer outbox.deinit(self.alloc);
-        const persist_batch_begin_start_ns = clock.monotonicNs();
+        const persist_batch_begin_start_ns = if (diagnostics != null) clock.monotonicNs() else 0;
         const batch = if (self.hooks.disk_batcher) |disk_batcher| try disk_batcher.beginBatch() else null;
         if (diagnostics) |diag| diag.persist_batch_begin_elapsed_ns = clock.elapsedSinceNs(persist_batch_begin_start_ns);
         if (batch != null) self.metrics.persist_batches += 1;
@@ -512,33 +512,34 @@ pub const MultiRaft = struct {
 
         var scanned: usize = 0;
         const scan_limit = self.groups.count();
-        const scan_start_ns = clock.monotonicNs();
+        const scan_start_ns = if (diagnostics != null) clock.monotonicNs() else 0;
         while (scanned < scan_limit) : (scanned += 1) {
             if (processed >= max_groups) break;
             const group_id = self.scheduler.nextReadyGroup() orelse break;
-            var ready_diag = ReadyGroupDiagnostics{ .group_id = group_id };
-            const ready_start_ns = clock.monotonicNs();
-            const ready_processed = try self.processReadyIntoOutbox(group_id, &outbox, batch, false, false, &ready_diag);
-            ready_diag.elapsed_ns = clock.elapsedSinceNs(ready_start_ns);
-            ready_diag.processed = ready_processed;
-            if (diagnostics) |diag| {
+            const ready_processed = if (diagnostics) |diag| blk: {
+                var ready_diag = ReadyGroupDiagnostics{ .group_id = group_id };
+                const ready_start_ns = clock.monotonicNs();
+                const processed_ready = try self.processReadyIntoOutbox(group_id, &outbox, batch, false, false, &ready_diag);
+                ready_diag.elapsed_ns = clock.elapsedSinceNs(ready_start_ns);
+                ready_diag.processed = processed_ready;
                 if (ready_diag.elapsed_ns > diag.slowest_ready_group.elapsed_ns) diag.slowest_ready_group = ready_diag;
-            }
+                break :blk processed_ready;
+            } else try self.processReadyIntoOutbox(group_id, &outbox, batch, false, false, null);
             if (ready_processed) processed += 1;
         }
         if (diagnostics) |diag| diag.scan_elapsed_ns = clock.elapsedSinceNs(scan_start_ns);
 
-        const outbox_drain_start_ns = clock.monotonicNs();
+        const outbox_drain_start_ns = if (diagnostics != null) clock.monotonicNs() else 0;
         try outbox.drainInto(self.alloc, &self.pending_outbox);
         if (diagnostics) |diag| diag.outbox_drain_elapsed_ns = clock.elapsedSinceNs(outbox_drain_start_ns);
-        const apply_flush_start_ns = clock.monotonicNs();
+        const apply_flush_start_ns = if (diagnostics != null) clock.monotonicNs() else 0;
         try self.flushPendingApply();
         if (diagnostics) |diag| diag.apply_flush_elapsed_ns = clock.elapsedSinceNs(apply_flush_start_ns);
-        const transport_flush_start_ns = clock.monotonicNs();
+        const transport_flush_start_ns = if (diagnostics != null) clock.monotonicNs() else 0;
         try self.flushPendingTransport();
         if (diagnostics) |diag| diag.transport_flush_elapsed_ns = clock.elapsedSinceNs(transport_flush_start_ns);
         if (batch) |persist_batch| {
-            const persist_batch_finish_start_ns = clock.monotonicNs();
+            const persist_batch_finish_start_ns = if (diagnostics != null) clock.monotonicNs() else 0;
             batch_finish_attempted = true;
             persist_batch.finish() catch |err| {
                 if (diagnostics) |diag| diag.persist_batch_finish_elapsed_ns = clock.elapsedSinceNs(persist_batch_finish_start_ns);
@@ -562,7 +563,7 @@ pub const MultiRaft = struct {
         const grp = self.group(group_id) orelse return error.UnknownGroup;
         if (!grp.hasReady()) return false;
 
-        const ready_build_start_ns = clock.monotonicNs();
+        const ready_build_start_ns = if (diagnostics != null) clock.monotonicNs() else 0;
         const ready = grp.ready();
         if (diagnostics) |diag| diag.ready_build_elapsed_ns = clock.elapsedSinceNs(ready_build_start_ns);
         if (ready.isEmpty()) return false;
@@ -583,7 +584,7 @@ pub const MultiRaft = struct {
         }
 
         if (self.hooks.backpressure) |backpressure| {
-            const backpressure_start_ns = clock.monotonicNs();
+            const backpressure_start_ns = if (diagnostics != null) clock.monotonicNs() else 0;
             const allowed = backpressure.allowReady(ready_pressure);
             if (diagnostics) |diag| diag.backpressure_elapsed_ns = clock.elapsedSinceNs(backpressure_start_ns);
             if (!allowed) {
@@ -594,7 +595,7 @@ pub const MultiRaft = struct {
             }
         }
 
-        const capacity_check_start_ns = clock.monotonicNs();
+        const capacity_check_start_ns = if (diagnostics != null) clock.monotonicNs() else 0;
         if (!self.hasOutboundCapacity(
             outbox.items.items.len + ready_pressure.message_count,
             outbox.approxBytes() + ready_pressure.message_bytes,
@@ -621,7 +622,7 @@ pub const MultiRaft = struct {
         }
         if (diagnostics) |diag| diag.capacity_check_elapsed_ns = clock.elapsedSinceNs(capacity_check_start_ns);
 
-        const snapshot_throttle_start_ns = clock.monotonicNs();
+        const snapshot_throttle_start_ns = if (diagnostics != null) clock.monotonicNs() else 0;
         const snapshot_started = blk: {
             if (ready.snapshot == null) break :blk false;
             if (self.hooks.snapshot_throttle) |throttle| {
@@ -643,7 +644,7 @@ pub const MultiRaft = struct {
             self.hooks.snapshot_throttle.?.endSnapshot(group_id);
         };
 
-        const persist_ready_start_ns = clock.monotonicNs();
+        const persist_ready_start_ns = if (diagnostics != null) clock.monotonicNs() else 0;
         if (persist_batch) |batch| {
             try batch.persistReady(group_id, ready);
         } else if (self.hooks.group_storage) |storage| {
@@ -652,31 +653,31 @@ pub const MultiRaft = struct {
         if (diagnostics) |diag| diag.persist_ready_elapsed_ns = clock.elapsedSinceNs(persist_ready_start_ns);
 
         if (async_storage_writes) {
-            const async_ready_start_ns = clock.monotonicNs();
+            const async_ready_start_ns = if (diagnostics != null) clock.monotonicNs() else 0;
             try self.handleAsyncReady(group_id, grp, ready, outbox, flush_apply_queue, diagnostics);
             if (diagnostics) |diag| diag.async_ready_elapsed_ns = clock.elapsedSinceNs(async_ready_start_ns);
         } else {
-            const enqueue_apply_start_ns = clock.monotonicNs();
+            const enqueue_apply_start_ns = if (diagnostics != null) clock.monotonicNs() else 0;
             try self.enqueueApply(group_id, ready.committed_entries, ready.read_states);
             if (diagnostics) |diag| diag.enqueue_apply_elapsed_ns = clock.elapsedSinceNs(enqueue_apply_start_ns);
-            const outbox_append_start_ns = clock.monotonicNs();
+            const outbox_append_start_ns = if (diagnostics != null) clock.monotonicNs() else 0;
             try outbox.appendMessages(self.alloc, group_id, ready.messages);
             if (diagnostics) |diag| diag.outbox_append_elapsed_ns = clock.elapsedSinceNs(outbox_append_start_ns);
-            const advance_start_ns = clock.monotonicNs();
+            const advance_start_ns = if (diagnostics != null) clock.monotonicNs() else 0;
             grp.advance(ready);
             if (diagnostics) |diag| diag.raft_advance_elapsed_ns = clock.elapsedSinceNs(advance_start_ns);
         }
 
         if (flush_apply_queue) {
-            const inline_apply_flush_start_ns = clock.monotonicNs();
+            const inline_apply_flush_start_ns = if (diagnostics != null) clock.monotonicNs() else 0;
             try self.flushPendingApply();
             if (diagnostics) |diag| diag.inline_apply_flush_elapsed_ns = clock.elapsedSinceNs(inline_apply_flush_start_ns);
         }
         if (flush_transport) {
-            const inline_outbox_drain_start_ns = clock.monotonicNs();
+            const inline_outbox_drain_start_ns = if (diagnostics != null) clock.monotonicNs() else 0;
             try outbox.drainInto(self.alloc, &self.pending_outbox);
             if (diagnostics) |diag| diag.inline_outbox_drain_elapsed_ns = clock.elapsedSinceNs(inline_outbox_drain_start_ns);
-            const inline_transport_flush_start_ns = clock.monotonicNs();
+            const inline_transport_flush_start_ns = if (diagnostics != null) clock.monotonicNs() else 0;
             try self.flushPendingTransport();
             if (diagnostics) |diag| diag.inline_transport_flush_elapsed_ns = clock.elapsedSinceNs(inline_transport_flush_start_ns);
         }
@@ -695,21 +696,21 @@ pub const MultiRaft = struct {
         flush_apply_queue: bool,
         diagnostics: ?*ReadyGroupDiagnostics,
     ) !void {
-        const clone_messages_start_ns = clock.monotonicNs();
+        const clone_messages_start_ns = if (diagnostics != null) clock.monotonicNs() else 0;
         const messages = try core.message.cloneMessages(self.alloc, ready.messages);
         defer core.message.freeMessages(self.alloc, messages);
         if (diagnostics) |diag| diag.clone_messages_elapsed_ns = clock.elapsedSinceNs(clone_messages_start_ns);
 
-        const enqueue_apply_start_ns = clock.monotonicNs();
+        const enqueue_apply_start_ns = if (diagnostics != null) clock.monotonicNs() else 0;
         try self.enqueueApply(group_id, ready.committed_entries, ready.read_states);
         if (diagnostics) |diag| diag.enqueue_apply_elapsed_ns = clock.elapsedSinceNs(enqueue_apply_start_ns);
         if (flush_apply_queue) {
-            const inline_apply_flush_start_ns = clock.monotonicNs();
+            const inline_apply_flush_start_ns = if (diagnostics != null) clock.monotonicNs() else 0;
             try self.flushPendingApply();
             if (diagnostics) |diag| diag.inline_apply_flush_elapsed_ns = clock.elapsedSinceNs(inline_apply_flush_start_ns);
         }
 
-        const async_message_loop_start_ns = clock.monotonicNs();
+        const async_message_loop_start_ns = if (diagnostics != null) clock.monotonicNs() else 0;
         for (messages) |msg| {
             switch (msg.msg_type) {
                 .storage_append => try self.handleLocalStorageAppend(group_id, grp, msg, outbox),

--- a/zig/pkg/antfly/src/metadata/service.zig
+++ b/zig/pkg/antfly/src/metadata/service.zig
@@ -71,7 +71,7 @@ fn logMetadataRaftRoundDiagnostics(round: raft_engine.runtime.multi_raft.HostRou
     if (round.elapsed_ns <= metadata_run_round_slow_phase_threshold_ns) return;
     const ready = round.slowest_ready_group;
     std.log.warn(
-        "metadata raft round slow elapsed_ms={d} inbound_ms={d} tick_ms={d} drain_ready_ms={d} drain_scan_ms={d} persist_begin_ms={d} persist_finish_ms={d} outbox_drain_ms={d} apply_flush_ms={d} transport_flush_ms={d} transport_advance_ms={d} ticked_groups={d} processed_groups={d} virtual_round={d} virtual_time_ms={d} ready_group_id={d} ready_group_ms={d} ready_build_ms={d} ready_backpressure_ms={d} ready_capacity_ms={d} ready_snapshot_throttle_ms={d} ready_persist_ms={d} ready_async_ms={d} ready_clone_messages_ms={d} ready_enqueue_apply_ms={d} ready_async_loop_ms={d} ready_outbox_append_ms={d} ready_advance_ms={d} ready_inline_apply_flush_ms={d} ready_inline_outbox_drain_ms={d} ready_inline_transport_flush_ms={d} ready_messages={d} ready_message_bytes={d} ready_committed_entries={d} ready_committed_bytes={d} ready_unstable_entries={d} ready_unstable_bytes={d} ready_read_states={d} ready_has_snapshot={} ready_snapshot_bytes={d} ready_async_storage={} ready_processed={} ready_denied_backpressure={} ready_denied_transport_capacity={} ready_denied_apply_capacity={} ready_denied_snapshot_throttle={} ready_has_more={}",
+        "metadata raft round slow elapsed_ms={d} inbound_ms={d} tick_ms={d} drain_ready_ms={d} drain_scan_ms={d} persist_begin_ms={d} persist_finish_ms={d} outbox_drain_ms={d} apply_flush_ms={d} transport_flush_ms={d} transport_advance_ms={d} ticked_groups={d} processed_groups={d} virtual_round={d} virtual_time_ms={d} ready_group_id={d} ready_group_ms={d}",
         .{
             @divTrunc(round.elapsed_ns, std.time.ns_per_ms),
             @divTrunc(round.inbound_drain_elapsed_ns, std.time.ns_per_ms),
@@ -90,6 +90,12 @@ fn logMetadataRaftRoundDiagnostics(round: raft_engine.runtime.multi_raft.HostRou
             round.virtual_time_ms,
             ready.group_id,
             @divTrunc(ready.elapsed_ns, std.time.ns_per_ms),
+        },
+    );
+    std.log.warn(
+        "metadata raft ready slow group_id={d} ready_build_ms={d} ready_backpressure_ms={d} ready_capacity_ms={d} ready_snapshot_throttle_ms={d} ready_persist_ms={d} ready_async_ms={d} ready_clone_messages_ms={d} ready_enqueue_apply_ms={d} ready_async_loop_ms={d} ready_outbox_append_ms={d} ready_advance_ms={d} ready_inline_apply_flush_ms={d} ready_inline_outbox_drain_ms={d} ready_inline_transport_flush_ms={d}",
+        .{
+            ready.group_id,
             @divTrunc(ready.ready_build_elapsed_ns, std.time.ns_per_ms),
             @divTrunc(ready.backpressure_elapsed_ns, std.time.ns_per_ms),
             @divTrunc(ready.capacity_check_elapsed_ns, std.time.ns_per_ms),
@@ -104,6 +110,12 @@ fn logMetadataRaftRoundDiagnostics(round: raft_engine.runtime.multi_raft.HostRou
             @divTrunc(ready.inline_apply_flush_elapsed_ns, std.time.ns_per_ms),
             @divTrunc(ready.inline_outbox_drain_elapsed_ns, std.time.ns_per_ms),
             @divTrunc(ready.inline_transport_flush_elapsed_ns, std.time.ns_per_ms),
+        },
+    );
+    std.log.warn(
+        "metadata raft ready pressure group_id={d} ready_messages={d} ready_message_bytes={d} ready_committed_entries={d} ready_committed_bytes={d} ready_unstable_entries={d} ready_unstable_bytes={d} ready_read_states={d} ready_has_snapshot={} ready_snapshot_bytes={d} ready_async_storage={} ready_processed={} ready_denied_backpressure={} ready_denied_transport_capacity={} ready_denied_apply_capacity={} ready_denied_snapshot_throttle={} ready_has_more={}",
+        .{
+            ready.group_id,
             ready.message_count,
             ready.message_bytes,
             ready.committed_entries,
@@ -3123,6 +3135,7 @@ pub const MetadataHttpService = struct {
         var not_leader_count: usize = 0;
         var raft_rounds: usize = 0;
         var slowest_round: raft_engine.runtime.multi_raft.HostRound = .{};
+        var latest_raft_diagnostics_snapshot: MetadataRaftDiagnosticsSnapshot = .{};
         while (platform_time.monotonicNs() < deadline_ns) {
             if (self.linearizable_read_tracker.isComplete(request_id)) return;
             const now_ns = platform_time.monotonicNs();
@@ -3154,6 +3167,7 @@ pub const MetadataHttpService = struct {
                     try self.raft.runRaftRoundOnly();
                 }
                 raft_diagnostics_snapshot = self.raftDiagnosticsSnapshotLocked();
+                latest_raft_diagnostics_snapshot = raft_diagnostics_snapshot;
             }
             raft_rounds += 1;
             if (raft_diagnostics_snapshot.last_runtime_round) |round| {
@@ -3164,12 +3178,7 @@ pub const MetadataHttpService = struct {
             platform_clock.Clock.real().sleepMs(1);
         }
         if (self.linearizable_read_tracker.isComplete(request_id)) return;
-        const timeout_snapshot = blk: {
-            self.lockRuntime();
-            defer self.unlockRuntime();
-            break :blk self.raftDiagnosticsSnapshotLocked();
-        };
-        self.logLinearizableReadTimeout(request_id, request_attempts, not_leader_count, raft_rounds, slowest_round, timeout_snapshot);
+        self.logLinearizableReadTimeout(request_id, request_attempts, not_leader_count, raft_rounds, slowest_round, latest_raft_diagnostics_snapshot);
         return error.MetadataLinearizableReadTimeout;
     }
 
@@ -3184,7 +3193,7 @@ pub const MetadataHttpService = struct {
     ) void {
         const ready = slowest_round.slowest_ready_group;
         std.log.warn(
-            "metadata linearizable read timeout request_id={d} group_id={d} attempts={d} not_leader={d} raft_rounds={d} pending_updates={d} node_id={d} role={s} has_leader={} leader_id={d} term={d} commit_index={d} applied_index={d} last_index={d} election_elapsed={d} slowest_round_ms={d} slowest_inbound_ms={d} slowest_tick_ms={d} slowest_drain_ready_ms={d} slowest_drain_scan_ms={d} slowest_apply_flush_ms={d} slowest_transport_flush_ms={d} slowest_transport_advance_ms={d} slowest_ticked_groups={d} slowest_processed_groups={d} slowest_ready_group_id={d} slowest_ready_group_ms={d} slowest_ready_build_ms={d} slowest_ready_backpressure_ms={d} slowest_ready_capacity_ms={d} slowest_ready_snapshot_throttle_ms={d} slowest_ready_persist_ms={d} slowest_ready_async_ms={d} slowest_ready_clone_messages_ms={d} slowest_ready_enqueue_apply_ms={d} slowest_ready_async_loop_ms={d} slowest_ready_outbox_append_ms={d} slowest_ready_advance_ms={d} slowest_ready_inline_apply_flush_ms={d} slowest_ready_inline_outbox_drain_ms={d} slowest_ready_inline_transport_flush_ms={d} slowest_ready_messages={d} slowest_ready_committed_entries={d} slowest_ready_unstable_entries={d} slowest_ready_read_states={d} slowest_ready_has_snapshot={} slowest_ready_async_storage={} slowest_ready_processed={} slowest_ready_denied_backpressure={} slowest_ready_denied_transport_capacity={} slowest_ready_denied_apply_capacity={} slowest_ready_denied_snapshot_throttle={} slowest_ready_has_more={}",
+            "metadata linearizable read timeout request_id={d} group_id={d} attempts={d} not_leader={d} raft_rounds={d} pending_updates={d} node_id={d} role={s} has_leader={} leader_id={d} term={d} commit_index={d} applied_index={d} last_index={d} election_elapsed={d} slowest_round_ms={d} slowest_inbound_ms={d} slowest_tick_ms={d} slowest_drain_ready_ms={d} slowest_drain_scan_ms={d} slowest_apply_flush_ms={d} slowest_transport_flush_ms={d} slowest_transport_advance_ms={d} slowest_ticked_groups={d} slowest_processed_groups={d} slowest_ready_group_id={d} slowest_ready_group_ms={d}",
             .{
                 request_id,
                 self.metadata_group_id,
@@ -3213,6 +3222,13 @@ pub const MetadataHttpService = struct {
                 slowest_round.processed_groups,
                 ready.group_id,
                 @divTrunc(ready.elapsed_ns, std.time.ns_per_ms),
+            },
+        );
+        std.log.warn(
+            "metadata linearizable read timeout ready timings request_id={d} group_id={d} ready_build_ms={d} ready_backpressure_ms={d} ready_capacity_ms={d} ready_snapshot_throttle_ms={d} ready_persist_ms={d} ready_async_ms={d} ready_clone_messages_ms={d} ready_enqueue_apply_ms={d} ready_async_loop_ms={d} ready_outbox_append_ms={d} ready_advance_ms={d} ready_inline_apply_flush_ms={d} ready_inline_outbox_drain_ms={d} ready_inline_transport_flush_ms={d}",
+            .{
+                request_id,
+                ready.group_id,
                 @divTrunc(ready.ready_build_elapsed_ns, std.time.ns_per_ms),
                 @divTrunc(ready.backpressure_elapsed_ns, std.time.ns_per_ms),
                 @divTrunc(ready.capacity_check_elapsed_ns, std.time.ns_per_ms),
@@ -3227,6 +3243,13 @@ pub const MetadataHttpService = struct {
                 @divTrunc(ready.inline_apply_flush_elapsed_ns, std.time.ns_per_ms),
                 @divTrunc(ready.inline_outbox_drain_elapsed_ns, std.time.ns_per_ms),
                 @divTrunc(ready.inline_transport_flush_elapsed_ns, std.time.ns_per_ms),
+            },
+        );
+        std.log.warn(
+            "metadata linearizable read timeout ready pressure request_id={d} group_id={d} slowest_ready_messages={d} slowest_ready_committed_entries={d} slowest_ready_unstable_entries={d} slowest_ready_read_states={d} slowest_ready_has_snapshot={} slowest_ready_async_storage={} slowest_ready_processed={} slowest_ready_denied_backpressure={} slowest_ready_denied_transport_capacity={} slowest_ready_denied_apply_capacity={} slowest_ready_denied_snapshot_throttle={} slowest_ready_has_more={}",
+            .{
+                request_id,
+                ready.group_id,
                 ready.message_count,
                 ready.committed_entries,
                 ready.unstable_entries,

--- a/zig/pkg/antfly/src/metadata/service.zig
+++ b/zig/pkg/antfly/src/metadata/service.zig
@@ -124,6 +124,20 @@ fn logMetadataRaftRoundDiagnostics(round: raft_engine.runtime.multi_raft.HostRou
     );
 }
 
+const MetadataRaftDiagnosticsSnapshot = struct {
+    pending_updates: usize = 0,
+    node_id: u64 = 0,
+    role: []const u8 = "unknown",
+    has_leader: bool = false,
+    leader_id: u64 = 0,
+    term: u64 = 0,
+    commit_index: u64 = 0,
+    applied_index: u64 = 0,
+    last_index: u64 = 0,
+    election_elapsed: u64 = 0,
+    last_runtime_round: ?raft_engine.runtime.multi_raft.HostRound = null,
+};
+
 const MetadataRunRoundTrace = struct {
     const Phase = struct {
         name: []const u8,
@@ -2776,6 +2790,7 @@ pub const MetadataHttpService = struct {
             run_round_trace.recordSince("lifecycle_signal_notify", lifecycle_signal_phase_start_ns);
         }
         phase_start_ns = platform_time.monotonicNs();
+        var raft_diagnostics_snapshot: MetadataRaftDiagnosticsSnapshot = .{};
         self.lockRuntime();
         {
             defer self.unlockRuntime();
@@ -2784,10 +2799,11 @@ pub const MetadataHttpService = struct {
             } else {
                 try self.raft.runRaftRoundOnly();
             }
+            raft_diagnostics_snapshot = self.raftDiagnosticsSnapshotLocked();
         }
         self.refreshProbeReady();
         run_round_trace.recordSince("raft_round", phase_start_ns);
-        if (self.raft.lastRuntimeRound()) |round| logMetadataRaftRoundDiagnostics(round);
+        if (raft_diagnostics_snapshot.last_runtime_round) |round| logMetadataRaftRoundDiagnostics(round);
         if (!self.observe_local_replica_root) return;
 
         phase_start_ns = platform_time.monotonicNs();
@@ -3128,6 +3144,7 @@ pub const MetadataHttpService = struct {
                 }
                 next_request_ns = now_ns + linearizable_metadata_read_retry_ns;
             }
+            var raft_diagnostics_snapshot: MetadataRaftDiagnosticsSnapshot = .{};
             self.lockRuntime();
             {
                 defer self.unlockRuntime();
@@ -3136,9 +3153,10 @@ pub const MetadataHttpService = struct {
                 } else {
                     try self.raft.runRaftRoundOnly();
                 }
+                raft_diagnostics_snapshot = self.raftDiagnosticsSnapshotLocked();
             }
             raft_rounds += 1;
-            if (self.raft.lastRuntimeRound()) |round| {
+            if (raft_diagnostics_snapshot.last_runtime_round) |round| {
                 if (round.elapsed_ns > slowest_round.elapsed_ns) slowest_round = round;
                 logMetadataRaftRoundDiagnostics(round);
             }
@@ -3146,7 +3164,12 @@ pub const MetadataHttpService = struct {
             platform_clock.Clock.real().sleepMs(1);
         }
         if (self.linearizable_read_tracker.isComplete(request_id)) return;
-        self.logLinearizableReadTimeout(request_id, request_attempts, not_leader_count, raft_rounds, slowest_round);
+        const timeout_snapshot = blk: {
+            self.lockRuntime();
+            defer self.unlockRuntime();
+            break :blk self.raftDiagnosticsSnapshotLocked();
+        };
+        self.logLinearizableReadTimeout(request_id, request_attempts, not_leader_count, raft_rounds, slowest_round, timeout_snapshot);
         return error.MetadataLinearizableReadTimeout;
     }
 
@@ -3157,17 +3180,8 @@ pub const MetadataHttpService = struct {
         not_leader_count: usize,
         raft_rounds: usize,
         slowest_round: raft_engine.runtime.multi_raft.HostRound,
+        snapshot: MetadataRaftDiagnosticsSnapshot,
     ) void {
-        const raft_status = self.raft.raftStatus(self.metadata_group_id);
-        const node_id = if (raft_status) |s| s.id else 0;
-        const role = if (raft_status) |s| @tagName(s.soft.role) else "unknown";
-        const leader_id = if (raft_status) |s| if (s.soft.leader_id) |leader| leader else 0 else 0;
-        const has_leader = if (raft_status) |s| s.soft.leader_id != null else false;
-        const term = if (raft_status) |s| s.hard.current_term else 0;
-        const commit_index = if (raft_status) |s| s.hard.commit_index else 0;
-        const applied_index = if (raft_status) |s| s.applied_index else 0;
-        const last_index = if (raft_status) |s| s.last_index else 0;
-        const election_elapsed = if (raft_status) |s| s.election_elapsed else 0;
         const ready = slowest_round.slowest_ready_group;
         std.log.warn(
             "metadata linearizable read timeout request_id={d} group_id={d} attempts={d} not_leader={d} raft_rounds={d} pending_updates={d} node_id={d} role={s} has_leader={} leader_id={d} term={d} commit_index={d} applied_index={d} last_index={d} election_elapsed={d} slowest_round_ms={d} slowest_inbound_ms={d} slowest_tick_ms={d} slowest_drain_ready_ms={d} slowest_drain_scan_ms={d} slowest_apply_flush_ms={d} slowest_transport_flush_ms={d} slowest_transport_advance_ms={d} slowest_ticked_groups={d} slowest_processed_groups={d} slowest_ready_group_id={d} slowest_ready_group_ms={d} slowest_ready_build_ms={d} slowest_ready_backpressure_ms={d} slowest_ready_capacity_ms={d} slowest_ready_snapshot_throttle_ms={d} slowest_ready_persist_ms={d} slowest_ready_async_ms={d} slowest_ready_clone_messages_ms={d} slowest_ready_enqueue_apply_ms={d} slowest_ready_async_loop_ms={d} slowest_ready_outbox_append_ms={d} slowest_ready_advance_ms={d} slowest_ready_inline_apply_flush_ms={d} slowest_ready_inline_outbox_drain_ms={d} slowest_ready_inline_transport_flush_ms={d} slowest_ready_messages={d} slowest_ready_committed_entries={d} slowest_ready_unstable_entries={d} slowest_ready_read_states={d} slowest_ready_has_snapshot={} slowest_ready_async_storage={} slowest_ready_processed={} slowest_ready_denied_backpressure={} slowest_ready_denied_transport_capacity={} slowest_ready_denied_apply_capacity={} slowest_ready_denied_snapshot_throttle={} slowest_ready_has_more={}",
@@ -3177,16 +3191,16 @@ pub const MetadataHttpService = struct {
                 request_attempts,
                 not_leader_count,
                 raft_rounds,
-                self.raft.pending_updates.items.len,
-                node_id,
-                role,
-                has_leader,
-                leader_id,
-                term,
-                commit_index,
-                applied_index,
-                last_index,
-                election_elapsed,
+                snapshot.pending_updates,
+                snapshot.node_id,
+                snapshot.role,
+                snapshot.has_leader,
+                snapshot.leader_id,
+                snapshot.term,
+                snapshot.commit_index,
+                snapshot.applied_index,
+                snapshot.last_index,
+                snapshot.election_elapsed,
                 @divTrunc(slowest_round.elapsed_ns, std.time.ns_per_ms),
                 @divTrunc(slowest_round.inbound_drain_elapsed_ns, std.time.ns_per_ms),
                 @divTrunc(slowest_round.tick_elapsed_ns, std.time.ns_per_ms),
@@ -3583,6 +3597,25 @@ pub const MetadataHttpService = struct {
 
     fn unlockRuntime(self: *MetadataHttpService) void {
         self.runtime_mutex.unlock(std.Options.debug_io);
+    }
+
+    fn raftDiagnosticsSnapshotLocked(self: *MetadataHttpService) MetadataRaftDiagnosticsSnapshot {
+        var snapshot = MetadataRaftDiagnosticsSnapshot{
+            .pending_updates = self.raft.pending_updates.items.len,
+            .last_runtime_round = self.raft.lastRuntimeRound(),
+        };
+        if (self.raft.raftStatus(self.metadata_group_id)) |raft_status| {
+            snapshot.node_id = raft_status.id;
+            snapshot.role = @tagName(raft_status.soft.role);
+            snapshot.has_leader = raft_status.soft.leader_id != null;
+            snapshot.leader_id = if (raft_status.soft.leader_id) |leader| leader else 0;
+            snapshot.term = raft_status.hard.current_term;
+            snapshot.commit_index = raft_status.hard.commit_index;
+            snapshot.applied_index = raft_status.applied_index;
+            snapshot.last_index = raft_status.last_index;
+            snapshot.election_elapsed = raft_status.election_elapsed;
+        }
+        return snapshot;
     }
 
     fn refreshLocalPlacementIntents(self: *MetadataHttpService, round_inputs: ?*const LocalPlacementInputs) !void {

--- a/zig/pkg/antfly/src/metadata/service.zig
+++ b/zig/pkg/antfly/src/metadata/service.zig
@@ -67,6 +67,63 @@ fn logMetadataRunRoundPhase(name: []const u8, elapsed_ns: u64) void {
     }
 }
 
+fn logMetadataRaftRoundDiagnostics(round: raft_engine.runtime.multi_raft.HostRound) void {
+    if (round.elapsed_ns <= metadata_run_round_slow_phase_threshold_ns) return;
+    const ready = round.slowest_ready_group;
+    std.log.warn(
+        "metadata raft round slow elapsed_ms={d} inbound_ms={d} tick_ms={d} drain_ready_ms={d} drain_scan_ms={d} persist_begin_ms={d} persist_finish_ms={d} outbox_drain_ms={d} apply_flush_ms={d} transport_flush_ms={d} transport_advance_ms={d} ticked_groups={d} processed_groups={d} virtual_round={d} virtual_time_ms={d} ready_group_id={d} ready_group_ms={d} ready_build_ms={d} ready_backpressure_ms={d} ready_capacity_ms={d} ready_snapshot_throttle_ms={d} ready_persist_ms={d} ready_async_ms={d} ready_clone_messages_ms={d} ready_enqueue_apply_ms={d} ready_async_loop_ms={d} ready_outbox_append_ms={d} ready_advance_ms={d} ready_inline_apply_flush_ms={d} ready_inline_outbox_drain_ms={d} ready_inline_transport_flush_ms={d} ready_messages={d} ready_message_bytes={d} ready_committed_entries={d} ready_committed_bytes={d} ready_unstable_entries={d} ready_unstable_bytes={d} ready_read_states={d} ready_has_snapshot={} ready_snapshot_bytes={d} ready_async_storage={} ready_processed={} ready_denied_backpressure={} ready_denied_transport_capacity={} ready_denied_apply_capacity={} ready_denied_snapshot_throttle={} ready_has_more={}",
+        .{
+            @divTrunc(round.elapsed_ns, std.time.ns_per_ms),
+            @divTrunc(round.inbound_drain_elapsed_ns, std.time.ns_per_ms),
+            @divTrunc(round.tick_elapsed_ns, std.time.ns_per_ms),
+            @divTrunc(round.drain_ready_elapsed_ns, std.time.ns_per_ms),
+            @divTrunc(round.drain_ready_scan_elapsed_ns, std.time.ns_per_ms),
+            @divTrunc(round.persist_batch_begin_elapsed_ns, std.time.ns_per_ms),
+            @divTrunc(round.persist_batch_finish_elapsed_ns, std.time.ns_per_ms),
+            @divTrunc(round.outbox_drain_elapsed_ns, std.time.ns_per_ms),
+            @divTrunc(round.apply_flush_elapsed_ns, std.time.ns_per_ms),
+            @divTrunc(round.transport_flush_elapsed_ns, std.time.ns_per_ms),
+            @divTrunc(round.transport_advance_elapsed_ns, std.time.ns_per_ms),
+            round.ticked_groups,
+            round.processed_groups,
+            round.virtual_round,
+            round.virtual_time_ms,
+            ready.group_id,
+            @divTrunc(ready.elapsed_ns, std.time.ns_per_ms),
+            @divTrunc(ready.ready_build_elapsed_ns, std.time.ns_per_ms),
+            @divTrunc(ready.backpressure_elapsed_ns, std.time.ns_per_ms),
+            @divTrunc(ready.capacity_check_elapsed_ns, std.time.ns_per_ms),
+            @divTrunc(ready.snapshot_throttle_elapsed_ns, std.time.ns_per_ms),
+            @divTrunc(ready.persist_ready_elapsed_ns, std.time.ns_per_ms),
+            @divTrunc(ready.async_ready_elapsed_ns, std.time.ns_per_ms),
+            @divTrunc(ready.clone_messages_elapsed_ns, std.time.ns_per_ms),
+            @divTrunc(ready.enqueue_apply_elapsed_ns, std.time.ns_per_ms),
+            @divTrunc(ready.async_message_loop_elapsed_ns, std.time.ns_per_ms),
+            @divTrunc(ready.outbox_append_elapsed_ns, std.time.ns_per_ms),
+            @divTrunc(ready.raft_advance_elapsed_ns, std.time.ns_per_ms),
+            @divTrunc(ready.inline_apply_flush_elapsed_ns, std.time.ns_per_ms),
+            @divTrunc(ready.inline_outbox_drain_elapsed_ns, std.time.ns_per_ms),
+            @divTrunc(ready.inline_transport_flush_elapsed_ns, std.time.ns_per_ms),
+            ready.message_count,
+            ready.message_bytes,
+            ready.committed_entries,
+            ready.committed_entry_bytes,
+            ready.unstable_entries,
+            ready.unstable_entry_bytes,
+            ready.read_states,
+            ready.has_snapshot,
+            ready.snapshot_bytes,
+            ready.async_storage_writes,
+            ready.processed,
+            ready.denied_by_backpressure,
+            ready.denied_by_transport_capacity,
+            ready.denied_by_apply_capacity,
+            ready.denied_by_snapshot_throttle,
+            ready.has_more_ready,
+        },
+    );
+}
+
 const MetadataRunRoundTrace = struct {
     const Phase = struct {
         name: []const u8,
@@ -2730,6 +2787,7 @@ pub const MetadataHttpService = struct {
         }
         self.refreshProbeReady();
         run_round_trace.recordSince("raft_round", phase_start_ns);
+        if (self.raft.lastRuntimeRound()) |round| logMetadataRaftRoundDiagnostics(round);
         if (!self.observe_local_replica_root) return;
 
         phase_start_ns = platform_time.monotonicNs();
@@ -3045,6 +3103,10 @@ pub const MetadataHttpService = struct {
 
         const deadline_ns = platform_time.monotonicNs() + linearizable_metadata_read_timeout_ns;
         var next_request_ns: u64 = 0;
+        var request_attempts: usize = 0;
+        var not_leader_count: usize = 0;
+        var raft_rounds: usize = 0;
+        var slowest_round: raft_engine.runtime.multi_raft.HostRound = .{};
         while (platform_time.monotonicNs() < deadline_ns) {
             if (self.linearizable_read_tracker.isComplete(request_id)) return;
             const now_ns = platform_time.monotonicNs();
@@ -3052,12 +3114,15 @@ pub const MetadataHttpService = struct {
                 self.lockRuntime();
                 {
                     defer self.unlockRuntime();
+                    request_attempts += 1;
                     self.raft.requestReadableLease(self.metadata_group_id, request_ctx) catch |err| switch (err) {
                         // A follower may not know the leader yet during elections,
                         // restarts, or after endpoint-level load balancing. Keep
                         // driving raft below and retry the same read context until
                         // the barrier completes or the caller's timeout expires.
-                        error.NotLeader => {},
+                        error.NotLeader => {
+                            not_leader_count += 1;
+                        },
                         else => return err,
                     };
                 }
@@ -3072,11 +3137,96 @@ pub const MetadataHttpService = struct {
                     try self.raft.runRaftRoundOnly();
                 }
             }
+            raft_rounds += 1;
+            if (self.raft.lastRuntimeRound()) |round| {
+                if (round.elapsed_ns > slowest_round.elapsed_ns) slowest_round = round;
+                logMetadataRaftRoundDiagnostics(round);
+            }
             if (self.linearizable_read_tracker.isComplete(request_id)) return;
             platform_clock.Clock.real().sleepMs(1);
         }
         if (self.linearizable_read_tracker.isComplete(request_id)) return;
+        self.logLinearizableReadTimeout(request_id, request_attempts, not_leader_count, raft_rounds, slowest_round);
         return error.MetadataLinearizableReadTimeout;
+    }
+
+    fn logLinearizableReadTimeout(
+        self: *MetadataHttpService,
+        request_id: u64,
+        request_attempts: usize,
+        not_leader_count: usize,
+        raft_rounds: usize,
+        slowest_round: raft_engine.runtime.multi_raft.HostRound,
+    ) void {
+        const raft_status = self.raft.raftStatus(self.metadata_group_id);
+        const node_id = if (raft_status) |s| s.id else 0;
+        const role = if (raft_status) |s| @tagName(s.soft.role) else "unknown";
+        const leader_id = if (raft_status) |s| if (s.soft.leader_id) |leader| leader else 0 else 0;
+        const has_leader = if (raft_status) |s| s.soft.leader_id != null else false;
+        const term = if (raft_status) |s| s.hard.current_term else 0;
+        const commit_index = if (raft_status) |s| s.hard.commit_index else 0;
+        const applied_index = if (raft_status) |s| s.applied_index else 0;
+        const last_index = if (raft_status) |s| s.last_index else 0;
+        const election_elapsed = if (raft_status) |s| s.election_elapsed else 0;
+        const ready = slowest_round.slowest_ready_group;
+        std.log.warn(
+            "metadata linearizable read timeout request_id={d} group_id={d} attempts={d} not_leader={d} raft_rounds={d} pending_updates={d} node_id={d} role={s} has_leader={} leader_id={d} term={d} commit_index={d} applied_index={d} last_index={d} election_elapsed={d} slowest_round_ms={d} slowest_inbound_ms={d} slowest_tick_ms={d} slowest_drain_ready_ms={d} slowest_drain_scan_ms={d} slowest_apply_flush_ms={d} slowest_transport_flush_ms={d} slowest_transport_advance_ms={d} slowest_ticked_groups={d} slowest_processed_groups={d} slowest_ready_group_id={d} slowest_ready_group_ms={d} slowest_ready_build_ms={d} slowest_ready_backpressure_ms={d} slowest_ready_capacity_ms={d} slowest_ready_snapshot_throttle_ms={d} slowest_ready_persist_ms={d} slowest_ready_async_ms={d} slowest_ready_clone_messages_ms={d} slowest_ready_enqueue_apply_ms={d} slowest_ready_async_loop_ms={d} slowest_ready_outbox_append_ms={d} slowest_ready_advance_ms={d} slowest_ready_inline_apply_flush_ms={d} slowest_ready_inline_outbox_drain_ms={d} slowest_ready_inline_transport_flush_ms={d} slowest_ready_messages={d} slowest_ready_committed_entries={d} slowest_ready_unstable_entries={d} slowest_ready_read_states={d} slowest_ready_has_snapshot={} slowest_ready_async_storage={} slowest_ready_processed={} slowest_ready_denied_backpressure={} slowest_ready_denied_transport_capacity={} slowest_ready_denied_apply_capacity={} slowest_ready_denied_snapshot_throttle={} slowest_ready_has_more={}",
+            .{
+                request_id,
+                self.metadata_group_id,
+                request_attempts,
+                not_leader_count,
+                raft_rounds,
+                self.raft.pending_updates.items.len,
+                node_id,
+                role,
+                has_leader,
+                leader_id,
+                term,
+                commit_index,
+                applied_index,
+                last_index,
+                election_elapsed,
+                @divTrunc(slowest_round.elapsed_ns, std.time.ns_per_ms),
+                @divTrunc(slowest_round.inbound_drain_elapsed_ns, std.time.ns_per_ms),
+                @divTrunc(slowest_round.tick_elapsed_ns, std.time.ns_per_ms),
+                @divTrunc(slowest_round.drain_ready_elapsed_ns, std.time.ns_per_ms),
+                @divTrunc(slowest_round.drain_ready_scan_elapsed_ns, std.time.ns_per_ms),
+                @divTrunc(slowest_round.apply_flush_elapsed_ns, std.time.ns_per_ms),
+                @divTrunc(slowest_round.transport_flush_elapsed_ns, std.time.ns_per_ms),
+                @divTrunc(slowest_round.transport_advance_elapsed_ns, std.time.ns_per_ms),
+                slowest_round.ticked_groups,
+                slowest_round.processed_groups,
+                ready.group_id,
+                @divTrunc(ready.elapsed_ns, std.time.ns_per_ms),
+                @divTrunc(ready.ready_build_elapsed_ns, std.time.ns_per_ms),
+                @divTrunc(ready.backpressure_elapsed_ns, std.time.ns_per_ms),
+                @divTrunc(ready.capacity_check_elapsed_ns, std.time.ns_per_ms),
+                @divTrunc(ready.snapshot_throttle_elapsed_ns, std.time.ns_per_ms),
+                @divTrunc(ready.persist_ready_elapsed_ns, std.time.ns_per_ms),
+                @divTrunc(ready.async_ready_elapsed_ns, std.time.ns_per_ms),
+                @divTrunc(ready.clone_messages_elapsed_ns, std.time.ns_per_ms),
+                @divTrunc(ready.enqueue_apply_elapsed_ns, std.time.ns_per_ms),
+                @divTrunc(ready.async_message_loop_elapsed_ns, std.time.ns_per_ms),
+                @divTrunc(ready.outbox_append_elapsed_ns, std.time.ns_per_ms),
+                @divTrunc(ready.raft_advance_elapsed_ns, std.time.ns_per_ms),
+                @divTrunc(ready.inline_apply_flush_elapsed_ns, std.time.ns_per_ms),
+                @divTrunc(ready.inline_outbox_drain_elapsed_ns, std.time.ns_per_ms),
+                @divTrunc(ready.inline_transport_flush_elapsed_ns, std.time.ns_per_ms),
+                ready.message_count,
+                ready.committed_entries,
+                ready.unstable_entries,
+                ready.read_states,
+                ready.has_snapshot,
+                ready.async_storage_writes,
+                ready.processed,
+                ready.denied_by_backpressure,
+                ready.denied_by_transport_capacity,
+                ready.denied_by_apply_capacity,
+                ready.denied_by_snapshot_throttle,
+                ready.has_more_ready,
+            },
+        );
     }
 
     pub fn adminSnapshot(self: *MetadataHttpService) !metadata_api.AdminSnapshot {

--- a/zig/pkg/antfly/src/raft/host.zig
+++ b/zig/pkg/antfly/src/raft/host.zig
@@ -496,8 +496,13 @@ pub const Host = struct {
         max_tick_groups: usize,
         max_ready_groups: usize,
     ) !raft_engine.runtime.multi_raft.HostRound {
+        const inbound_start_ns = platform_time.monotonicNs();
         _ = try self.drainInboundMessages(max_inbound_messages);
-        return try self.runtime_host.runRound(max_tick_groups, max_ready_groups);
+        const inbound_elapsed_ns = platform_time.monotonicNs() -| inbound_start_ns;
+        var round = try self.runtime_host.runRound(max_tick_groups, max_ready_groups);
+        round.inbound_drain_elapsed_ns = inbound_elapsed_ns;
+        round.elapsed_ns += round.inbound_drain_elapsed_ns;
+        return round;
     }
 
     pub fn step(self: *Host, group_id: u64, msg: raft_engine.core.Message) !void {

--- a/zig/pkg/antfly/src/raft/service.zig
+++ b/zig/pkg/antfly/src/raft/service.zig
@@ -411,6 +411,7 @@ pub const ManagedHttpHostService = struct {
     pending_updates: std.ArrayListUnmanaged(metadata_view.MetadataUpdate) = .empty,
     transition_svc: ?transition_service.TransitionService = null,
     metrics: ManagedServiceMetrics = .{},
+    last_runtime_round: ?raft_engine.runtime.multi_raft.HostRound = null,
 
     pub fn init(
         alloc: std.mem.Allocator,
@@ -592,6 +593,7 @@ pub const ManagedHttpHostService = struct {
             self.cfg.max_tick_groups,
             self.cfg.max_ready_groups,
         );
+        self.last_runtime_round = result.runtime;
         try self.enqueueTransitionUpdates(self.pending_updates.items);
         self.metrics.applied_updates += self.pending_updates.items.len;
         self.metrics.sync_rounds += 1;
@@ -608,6 +610,7 @@ pub const ManagedHttpHostService = struct {
             self.cfg.max_tick_groups,
             self.cfg.max_ready_groups,
         );
+        self.last_runtime_round = result.runtime;
         try self.enqueueTransitionUpdates(self.pending_updates.items);
         self.metrics.applied_updates += self.pending_updates.items.len;
         self.metrics.sync_rounds += 1;
@@ -617,7 +620,7 @@ pub const ManagedHttpHostService = struct {
     }
 
     pub fn runRound(self: *ManagedHttpHostService) !void {
-        _ = try self.host.runRoundBounded(
+        self.last_runtime_round = try self.host.runRoundBounded(
             self.cfg.max_inbound_messages,
             self.cfg.max_tick_groups,
             self.cfg.max_ready_groups,
@@ -627,12 +630,20 @@ pub const ManagedHttpHostService = struct {
     }
 
     pub fn runRaftRoundOnly(self: *ManagedHttpHostService) !void {
-        _ = try self.host.runRoundBounded(
+        self.last_runtime_round = try self.host.runRoundBounded(
             self.cfg.max_inbound_messages,
             self.cfg.max_tick_groups,
             self.cfg.max_ready_groups,
         );
         self.metrics.sync_rounds += 1;
+    }
+
+    pub fn lastRuntimeRound(self: *const ManagedHttpHostService) ?raft_engine.runtime.multi_raft.HostRound {
+        return self.last_runtime_round;
+    }
+
+    pub fn raftStatus(self: *ManagedHttpHostService, group_id: u64) ?raft_engine.core.Status {
+        return self.host.http_host.raftStatus(group_id);
     }
 
     pub fn stepTransitions(self: *ManagedHttpHostService) !transition_service.TransitionStepResult {


### PR DESCRIPTION
## Summary
- Reconcile AntflyBackup CronJobs when referenced AntflyCluster resources change so backup job image templates track cluster image updates.
- Add raft runtime slow-round diagnostics that break down tick, drain-ready, apply, transport, and slowest ready-group substeps.
- Log richer metadata linearizable-read timeout context including raft status, retry counts, and slowest round/ready-group details.

## Tests
- env ZIG_GLOBAL_CACHE_DIR=/tmp/antfly-zig-global zig build raft-test
- env ZIG_GLOBAL_CACHE_DIR=/tmp/antfly-zig-global zig build lib-metadata-service-test
- env GOWORK=off GOCACHE=/tmp/antfly-go-build-cache go test ./controllers/antfly -run 'Test(RequestsForClusterEnqueuesReferencingBackups|BuildCronJobSpec|ShellQuote)'
- git -C antfly diff --check