### PR TITLE
Fix data raft leader readiness publication

### DIFF
--- a/zig/build.zig
+++ b/zig/build.zig
@@ -3027,6 +3027,7 @@ pub fn build(b: *std.Build) void {
         "data runtime keeps status refresh dirty for non-startup async index work",
         "data runtime runRound does not refresh provisioned replica root inline while worker is active",
         "data runtime data changes mark provisioned startup catch-up dirty",
+        "data runtime raft status changes force immediate store status publication",
         "data runtime structural changes preserve writer-published runtime status",
         "data runtime startup catch-up prefers cached admin snapshot",
         "data runtime startup catch-up clears no-debt busy writer groups",

--- a/zig/e2e/antfly/test_scaling.py
+++ b/zig/e2e/antfly/test_scaling.py
@@ -42,6 +42,9 @@ from conftest import (
 from helpers import wait_until
 
 
+MULTI_SHARD_WRITE_ROUTE_TIMEOUT_S = 120.0
+
+
 class _ClusterStartupDeadline:
     def __init__(self, expires_at: float):
         self.expires_at = expires_at
@@ -925,6 +928,77 @@ def _all_metadata_snapshots(cluster: MultiNodeScalingCluster) -> list[dict[str, 
         return None
 
 
+def _table_write_route_diagnostic(
+    cluster: MultiNodeScalingCluster,
+    table_name: str,
+    *,
+    min_group_count: int,
+) -> dict[str, Any]:
+    snapshot = cluster.metadata_snapshot()
+    table_id: int | None = None
+    for table in snapshot.get("tables", []):
+        if isinstance(table, dict) and table.get("name") == table_name:
+            table_id = int(table.get("table_id", 0))
+            break
+    if table_id is None:
+        return {
+            "table_name": table_name,
+            "table_found": False,
+            "min_group_count": min_group_count,
+            "projected_tables": [table.get("name") for table in snapshot.get("tables", []) if isinstance(table, dict)],
+        }
+
+    group_ids = sorted(
+        int(record.get("group_id", 0))
+        for record in snapshot.get("ranges", [])
+        if isinstance(record, dict) and int(record.get("table_id", 0)) == table_id
+    )
+    leader_store_by_group: dict[int, int] = {}
+    group_statuses: dict[int, dict[str, Any]] = {}
+    for status in snapshot.get("merged_group_statuses", []):
+        if not isinstance(status, dict):
+            continue
+        group_id = int(status.get("group_id", 0))
+        if group_id not in group_ids:
+            continue
+        group_statuses[group_id] = {
+            "leader_known": bool(status.get("leader_known", False)),
+            "leader_store_id": int(status.get("leader_store_id", 0)),
+            "voter_count_known": bool(status.get("voter_count_known", False)),
+            "voter_count": int(status.get("voter_count", 0)),
+            "healthy_voter_reports": int(status.get("healthy_voter_reports", 0)),
+            "updated_at_millis": int(status.get("updated_at_millis", 0)),
+        }
+        leader_store_id = int(status.get("leader_store_id", 0))
+        if leader_store_id != 0:
+            leader_store_by_group[group_id] = leader_store_id
+
+    placed_nodes_by_group: dict[int, list[int]] = {group_id: [] for group_id in group_ids}
+    for intent in snapshot.get("placement_intents", []):
+        if not isinstance(intent, dict) or not isinstance(intent.get("record"), dict):
+            continue
+        group_id = int(intent["record"].get("group_id", 0))
+        if group_id not in placed_nodes_by_group:
+            continue
+        placed_nodes_by_group[group_id].append(int(intent["record"].get("local_node_id", 0)))
+    for nodes in placed_nodes_by_group.values():
+        nodes.sort()
+
+    return {
+        "table_name": table_name,
+        "table_found": True,
+        "table_id": table_id,
+        "min_group_count": min_group_count,
+        "group_count": len(group_ids),
+        "group_ids": group_ids,
+        "missing_group_count": max(0, min_group_count - len(group_ids)),
+        "missing_leader_group_ids": [group_id for group_id in group_ids if group_id not in leader_store_by_group],
+        "leader_store_by_group": leader_store_by_group,
+        "group_statuses": group_statuses,
+        "placed_nodes_by_group": placed_nodes_by_group,
+    }
+
+
 def _lookup_from_any_data_node(
     cluster: MultiNodeScalingCluster,
     table_name: str,
@@ -971,11 +1045,12 @@ def _insert_docs(
                 return api_url
         return None
 
-    api_url = wait_until(route_ready, timeout_s=60.0, interval_s=0.5)
+    api_url = wait_until(route_ready, timeout_s=MULTI_SHARD_WRITE_ROUTE_TIMEOUT_S, interval_s=0.5)
     assert api_url is not None, (
         f"table {table_name} never became write-routable before seed batch\n"
+        f"route readiness: {json.dumps(_table_write_route_diagnostic(cluster, table_name, min_group_count=min_group_count), indent=2, sort_keys=True)}\n"
         f"metadata statuses: {json.dumps(cluster.metadata_statuses(), indent=2, sort_keys=True)}\n"
-        f"snapshot: {cluster.metadata_snapshot()}\n"
+        f"snapshot: {cluster.metadata_snapshot_diagnostic()}\n"
         f"{cluster.debug_logs()}"
     )
 

--- a/zig/pkg/antfly/src/data/runtime.zig
+++ b/zig/pkg/antfly/src/data/runtime.zig
@@ -1899,6 +1899,7 @@ pub const DataServer = struct {
     last_store_status_report_at_ms: u64 = 0,
     last_data_raft_metadata_sync_at_ms: u64 = 0,
     last_data_raft_placement_fingerprint: ?u64 = null,
+    last_data_raft_status_fingerprint: ?u64 = null,
     provision_ticks: usize = 0,
     last_provision_fingerprint: ?u64 = null,
     last_provision_metadata_epoch: ?u64 = null,
@@ -3458,8 +3459,22 @@ pub const DataServer = struct {
         // forcing a local group-status refresh. The next runtime round should
         // publish promptly; otherwise slow debug builds can sit behind the
         // periodic tick gate even though fresh writer status is available.
+        self.markStoreStatusDirtyImmediate();
+    }
+
+    fn markStoreStatusDirtyImmediate(self: *DataServer) void {
         self.store_status_dirty = true;
         self.store_status_ticks = store_status_report_interval_ticks;
+    }
+
+    fn observeDataRaftStatusFingerprint(self: *DataServer, fingerprint: u64) void {
+        if (self.last_data_raft_status_fingerprint != null and
+            self.last_data_raft_status_fingerprint.? == fingerprint)
+        {
+            return;
+        }
+        self.last_data_raft_status_fingerprint = fingerprint;
+        self.markStoreStatusDirtyImmediate();
     }
 
     fn markRuntimeStatusDirty(
@@ -4584,7 +4599,7 @@ pub const DataServer = struct {
         if (placement_changed) {
             self.last_data_raft_placement_fingerprint = placement_fingerprint;
             self.invalidateLocalGroupStatusCache();
-            self.store_status_dirty = true;
+            self.markStoreStatusDirtyImmediate();
         }
 
         var updates = std.ArrayListUnmanaged(antfly.raft.MetadataUpdate).empty;
@@ -4643,6 +4658,8 @@ pub const DataServer = struct {
                 std.log.warn("data raft bootstrap campaign drive failed node_id={} err={}", .{ registration.node_id, err });
             };
         }
+
+        self.observeDataRaftStatusFingerprint(dataRaftLocalStatusFingerprint(raft, local_intents.items));
     }
 
     fn reportStoreStatusHeartbeat(self: *DataServer) !void {
@@ -8021,6 +8038,35 @@ fn dataRaftPlacementIntentsFingerprint(intents: []const antfly.raft.PlacementInt
     return hasher.final();
 }
 
+fn dataRaftLocalStatusFingerprint(
+    raft: *antfly.raft.ManagedHttpHostService,
+    intents: []const antfly.raft.PlacementIntent,
+) u64 {
+    var hasher = std.hash.Wyhash.init(0x4d2c_e31a_7f8b_2026);
+    hashU64(&hasher, intents.len);
+    for (intents) |intent| {
+        hashU64(&hasher, intent.record.group_id);
+        const status = raft.host.http_host.host.raftStatus(intent.record.group_id) orelse {
+            hashU64(&hasher, 0);
+            continue;
+        };
+        hashU64(&hasher, 1);
+        hashU64(&hasher, status.id);
+        hashU64(&hasher, @intFromEnum(status.soft.role));
+        if (status.soft.leader_id) |leader_id| {
+            hashU64(&hasher, 1);
+            hashU64(&hasher, leader_id);
+        } else {
+            hashU64(&hasher, 0);
+        }
+        hashU64(&hasher, status.conf_state.voters.len);
+        for (status.conf_state.voters) |node_id| hashU64(&hasher, node_id);
+        hashU64(&hasher, status.conf_state.voters_outgoing.len);
+        for (status.conf_state.voters_outgoing) |node_id| hashU64(&hasher, node_id);
+    }
+    return hasher.final();
+}
+
 fn hashU64(hasher: *std.hash.Wyhash, value: u64) void {
     hasher.update(std.mem.asBytes(&value));
 }
@@ -9715,6 +9761,49 @@ test "data runtime local group status provider collects and caches group statuse
     const empty_cached = (try server.cloneCachedLocalGroupStatuses(alloc, 3, 99)) orelse return error.TestUnexpectedResult;
     defer antfly.metadata.table_manager.freeGroupStatuses(alloc, empty_cached);
     try std.testing.expectEqual(@as(usize, 0), empty_cached.len);
+}
+
+test "data runtime raft status changes force immediate store status publication" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const replica_root_dir = try std.fmt.allocPrint(std.testing.allocator, ".zig-cache/tmp/{s}/data-runtime-raft-status-publication", .{tmp.sub_path});
+    defer std.testing.allocator.free(replica_root_dir);
+
+    var server: DataServer = .{
+        .alloc = std.testing.allocator,
+        .provisioned_storage = antfly.public_api.ProvisionedGroupStorage.init(std.testing.allocator),
+        .read_source = antfly.public_api.ProvisionedTableReadSource.init(
+            replica_root_dir,
+            antfly.public_api.table_catalog.emptyCatalogSource(),
+            antfly.raft.read_gate.noopReadableLeaseRequester(),
+        ),
+        .write_source = antfly.public_api.ProvisionedTableWriteSource.init(
+            replica_root_dir,
+            antfly.public_api.table_catalog.emptyCatalogSource(),
+        ),
+        .status_source = undefined,
+        .api_server_cfg = undefined,
+        .query_async_limit = .limited(8),
+        .listener_cfg = undefined,
+    };
+    defer server.deinit();
+
+    server.store_status_dirty = false;
+    server.store_status_ticks = 0;
+    server.observeDataRaftStatusFingerprint(11);
+    try std.testing.expect(server.store_status_dirty);
+    try std.testing.expectEqual(store_status_report_interval_ticks, server.store_status_ticks);
+
+    server.store_status_dirty = false;
+    server.store_status_ticks = 0;
+    server.observeDataRaftStatusFingerprint(11);
+    try std.testing.expect(!server.store_status_dirty);
+    try std.testing.expectEqual(@as(usize, 0), server.store_status_ticks);
+
+    server.observeDataRaftStatusFingerprint(12);
+    try std.testing.expect(server.store_status_dirty);
+    try std.testing.expectEqual(store_status_report_interval_ticks, server.store_status_ticks);
 }
 
 test "data runtime local split fallback preserves source identity namespace" {


### PR DESCRIPTION
## Summary
- publish a full store status immediately when local data-raft placement or leader/membership status changes
- fingerprint local raft status so leader visibility is not stuck behind the periodic store-status tick gate
- add targeted scaling e2e route-readiness diagnostics and a longer multi-shard bootstrap route timeout

## Verification
- zig build lib-data-runtime-test
- zig build lib-data-runtime-test -- --test-filter "data runtime raft status changes force immediate store status publication"
- zig build -Dedition=full install
- env PYTHONPYCACHEPREFIX=/tmp/antfly-pycache ANTFLY_BIN=./zig-out/bin/antfly uv run --project e2e/antfly pytest -q e2e/antfly/test_scaling.py::test_autoscaling_node_churn_keeps_reads_available
- env PYTHONPYCACHEPREFIX=/tmp/antfly-pycache ANTFLY_BIN=./zig-out/bin/antfly uv run --project e2e/antfly pytest -q e2e/antfly/test_scaling.py
- git diff --check