### PR TITLE
Clean recovered LSM table temps and detail raft persist latency

### DIFF
--- a/zig/lib/raft/src/runtime/multi_raft.zig
+++ b/zig/lib/raft/src/runtime/multi_raft.zig
@@ -62,6 +62,7 @@ pub const ReadyGroupDiagnostics = struct {
     capacity_check_elapsed_ns: u64 = 0,
     snapshot_throttle_elapsed_ns: u64 = 0,
     persist_ready_elapsed_ns: u64 = 0,
+    persist_ready_detail: storage_iface.ReadyPersistenceDiagnostics = .{},
     async_ready_elapsed_ns: u64 = 0,
     clone_messages_elapsed_ns: u64 = 0,
     enqueue_apply_elapsed_ns: u64 = 0,
@@ -646,9 +647,17 @@ pub const MultiRaft = struct {
 
         const persist_ready_start_ns = if (diagnostics != null) clock.monotonicNs() else 0;
         if (persist_batch) |batch| {
-            try batch.persistReady(group_id, ready);
+            try batch.persistReadyWithDiagnostics(
+                group_id,
+                ready,
+                if (diagnostics) |diag| &diag.persist_ready_detail else null,
+            );
         } else if (self.hooks.group_storage) |storage| {
-            try storage.persistReady(group_id, ready);
+            try storage.persistReadyWithDiagnostics(
+                group_id,
+                ready,
+                if (diagnostics) |diag| &diag.persist_ready_detail else null,
+            );
         }
         if (diagnostics) |diag| diag.persist_ready_elapsed_ns = clock.elapsedSinceNs(persist_ready_start_ns);
 

--- a/zig/lib/raft/src/runtime/storage_iface.zig
+++ b/zig/lib/raft/src/runtime/storage_iface.zig
@@ -14,6 +14,21 @@
 
 const core = @import("../core/mod.zig");
 
+pub const ReadyPersistenceDiagnostics = struct {
+    storage_apply_elapsed_ns: u64 = 0,
+    encode_elapsed_ns: u64 = 0,
+    wal_append_elapsed_ns: u64 = 0,
+    wal_wait_elapsed_ns: u64 = 0,
+    wal_coalesce_elapsed_ns: u64 = 0,
+    wal_txn_open_elapsed_ns: u64 = 0,
+    wal_put_elapsed_ns: u64 = 0,
+    wal_commit_elapsed_ns: u64 = 0,
+    wal_physical_commits: u64 = 0,
+    encoded_bytes: u64 = 0,
+    delta_records_since_checkpoint: u64 = 0,
+    delta_bytes_since_checkpoint: u64 = 0,
+};
+
 // GroupStorage owns raft-log durability for one hosted group.
 // Implementations must consume the passed slices synchronously and must not retain them.
 pub const GroupStorage = struct {
@@ -22,10 +37,30 @@ pub const GroupStorage = struct {
 
     pub const VTable = struct {
         persist_ready: *const fn (ptr: *anyopaque, group_id: core.types.GroupId, ready: core.Ready) anyerror!void,
+        persist_ready_diagnostics: ?*const fn (
+            ptr: *anyopaque,
+            group_id: core.types.GroupId,
+            ready: core.Ready,
+            diagnostics: *ReadyPersistenceDiagnostics,
+        ) anyerror!void = null,
     };
 
     pub fn persistReady(self: GroupStorage, group_id: core.types.GroupId, ready: core.Ready) !void {
         return try self.vtable.persist_ready(self.ptr, group_id, ready);
+    }
+
+    pub fn persistReadyWithDiagnostics(
+        self: GroupStorage,
+        group_id: core.types.GroupId,
+        ready: core.Ready,
+        diagnostics: ?*ReadyPersistenceDiagnostics,
+    ) !void {
+        if (diagnostics) |diag| {
+            if (self.vtable.persist_ready_diagnostics) |persist_ready_diagnostics| {
+                return try persist_ready_diagnostics(self.ptr, group_id, ready, diag);
+            }
+        }
+        return try self.persistReady(group_id, ready);
     }
 };
 
@@ -37,11 +72,31 @@ pub const PersistBatch = struct {
 
     pub const VTable = struct {
         persist_ready: *const fn (ptr: *anyopaque, group_id: core.types.GroupId, ready: core.Ready) anyerror!void,
+        persist_ready_diagnostics: ?*const fn (
+            ptr: *anyopaque,
+            group_id: core.types.GroupId,
+            ready: core.Ready,
+            diagnostics: *ReadyPersistenceDiagnostics,
+        ) anyerror!void = null,
         finish: *const fn (ptr: *anyopaque) anyerror!void,
     };
 
     pub fn persistReady(self: PersistBatch, group_id: core.types.GroupId, ready: core.Ready) !void {
         return try self.vtable.persist_ready(self.ptr, group_id, ready);
+    }
+
+    pub fn persistReadyWithDiagnostics(
+        self: PersistBatch,
+        group_id: core.types.GroupId,
+        ready: core.Ready,
+        diagnostics: ?*ReadyPersistenceDiagnostics,
+    ) !void {
+        if (diagnostics) |diag| {
+            if (self.vtable.persist_ready_diagnostics) |persist_ready_diagnostics| {
+                return try persist_ready_diagnostics(self.ptr, group_id, ready, diag);
+            }
+        }
+        return try self.persistReady(group_id, ready);
     }
 
     pub fn finish(self: PersistBatch) !void {

--- a/zig/pkg/antfly/src/metadata/service.zig
+++ b/zig/pkg/antfly/src/metadata/service.zig
@@ -112,6 +112,25 @@ fn logMetadataRaftRoundDiagnostics(round: raft_engine.runtime.multi_raft.HostRou
             @divTrunc(ready.inline_transport_flush_elapsed_ns, std.time.ns_per_ms),
         },
     );
+    const persist = ready.persist_ready_detail;
+    std.log.warn(
+        "metadata raft ready persist detail group_id={d} storage_apply_ms={d} encode_ms={d} wal_append_ms={d} wal_wait_ms={d} wal_coalesce_ms={d} wal_txn_open_ms={d} wal_put_ms={d} wal_commit_ms={d} wal_physical_commits={d} encoded_bytes={d} replay_debt_records={d} replay_debt_bytes={d}",
+        .{
+            ready.group_id,
+            @divTrunc(persist.storage_apply_elapsed_ns, std.time.ns_per_ms),
+            @divTrunc(persist.encode_elapsed_ns, std.time.ns_per_ms),
+            @divTrunc(persist.wal_append_elapsed_ns, std.time.ns_per_ms),
+            @divTrunc(persist.wal_wait_elapsed_ns, std.time.ns_per_ms),
+            @divTrunc(persist.wal_coalesce_elapsed_ns, std.time.ns_per_ms),
+            @divTrunc(persist.wal_txn_open_elapsed_ns, std.time.ns_per_ms),
+            @divTrunc(persist.wal_put_elapsed_ns, std.time.ns_per_ms),
+            @divTrunc(persist.wal_commit_elapsed_ns, std.time.ns_per_ms),
+            persist.wal_physical_commits,
+            persist.encoded_bytes,
+            persist.delta_records_since_checkpoint,
+            persist.delta_bytes_since_checkpoint,
+        },
+    );
     std.log.warn(
         "metadata raft ready pressure group_id={d} ready_messages={d} ready_message_bytes={d} ready_committed_entries={d} ready_committed_bytes={d} ready_unstable_entries={d} ready_unstable_bytes={d} ready_read_states={d} ready_has_snapshot={} ready_snapshot_bytes={d} ready_async_storage={} ready_processed={} ready_denied_backpressure={} ready_denied_transport_capacity={} ready_denied_apply_capacity={} ready_denied_snapshot_throttle={} ready_has_more={}",
         .{
@@ -3243,6 +3262,26 @@ pub const MetadataHttpService = struct {
                 @divTrunc(ready.inline_apply_flush_elapsed_ns, std.time.ns_per_ms),
                 @divTrunc(ready.inline_outbox_drain_elapsed_ns, std.time.ns_per_ms),
                 @divTrunc(ready.inline_transport_flush_elapsed_ns, std.time.ns_per_ms),
+            },
+        );
+        const persist = ready.persist_ready_detail;
+        std.log.warn(
+            "metadata linearizable read timeout persist detail request_id={d} group_id={d} storage_apply_ms={d} encode_ms={d} wal_append_ms={d} wal_wait_ms={d} wal_coalesce_ms={d} wal_txn_open_ms={d} wal_put_ms={d} wal_commit_ms={d} wal_physical_commits={d} encoded_bytes={d} replay_debt_records={d} replay_debt_bytes={d}",
+            .{
+                request_id,
+                ready.group_id,
+                @divTrunc(persist.storage_apply_elapsed_ns, std.time.ns_per_ms),
+                @divTrunc(persist.encode_elapsed_ns, std.time.ns_per_ms),
+                @divTrunc(persist.wal_append_elapsed_ns, std.time.ns_per_ms),
+                @divTrunc(persist.wal_wait_elapsed_ns, std.time.ns_per_ms),
+                @divTrunc(persist.wal_coalesce_elapsed_ns, std.time.ns_per_ms),
+                @divTrunc(persist.wal_txn_open_elapsed_ns, std.time.ns_per_ms),
+                @divTrunc(persist.wal_put_elapsed_ns, std.time.ns_per_ms),
+                @divTrunc(persist.wal_commit_elapsed_ns, std.time.ns_per_ms),
+                persist.wal_physical_commits,
+                persist.encoded_bytes,
+                persist.delta_records_since_checkpoint,
+                persist.delta_bytes_since_checkpoint,
             },
         );
         std.log.warn(

--- a/zig/pkg/antfly/src/raft/storage/wal_replica_state.zig
+++ b/zig/pkg/antfly/src/raft/storage/wal_replica_state.zig
@@ -18,6 +18,7 @@ const raft_engine = @import("raft_engine");
 const platform_time = @import("../../platform/time.zig");
 const wal_mod = @import("../../storage/wal.zig");
 const storage_mod = @import("mod.zig");
+const storage_iface = raft_engine.runtime.storage_iface;
 
 const magic: u32 = 0x41524654; // ARFT
 const version: u32 = 2;
@@ -149,6 +150,7 @@ pub const WalReplicaState = struct {
             .ptr = self,
             .vtable = &.{
                 .persist_ready = persistReady,
+                .persist_ready_diagnostics = persistReadyWithDiagnostics,
             },
         };
     }
@@ -209,16 +211,39 @@ pub const WalReplicaState = struct {
     }
 
     fn persistReady(ptr: *anyopaque, group_id: u64, ready: raft_engine.core.Ready) !void {
-        _ = group_id;
         const self: *WalReplicaState = @ptrCast(@alignCast(ptr));
+        try self.persistReadyInternal(group_id, ready, null);
+    }
+
+    fn persistReadyWithDiagnostics(
+        ptr: *anyopaque,
+        group_id: u64,
+        ready: raft_engine.core.Ready,
+        diagnostics: *storage_iface.ReadyPersistenceDiagnostics,
+    ) !void {
+        const self: *WalReplicaState = @ptrCast(@alignCast(ptr));
+        try self.persistReadyInternal(group_id, ready, diagnostics);
+    }
+
+    fn persistReadyInternal(
+        self: *WalReplicaState,
+        group_id: u64,
+        ready: raft_engine.core.Ready,
+        diagnostics: ?*storage_iface.ReadyPersistenceDiagnostics,
+    ) !void {
+        _ = group_id;
         self.stats.persist_ready_calls += 1;
+
+        const storage_apply_started_ns = if (diagnostics != null) nowNs() else 0;
         if (ready.snapshot) |snapshot| {
             try self.store.applySnapshot(snapshot);
             if (snapshot.metadata.index > self.applied_index) self.applied_index = snapshot.metadata.index;
         }
         if (ready.hard_state) |hard_state| self.store.setHardState(hard_state);
         if (ready.entries.len > 0) try self.store.append(ready.entries);
-        try self.persistReadyDelta(ready);
+        if (diagnostics) |diag| diag.storage_apply_elapsed_ns += elapsedSince(storage_apply_started_ns);
+
+        try self.persistReadyDelta(ready, diagnostics);
     }
 
     fn load(self: *WalReplicaState) !void {
@@ -308,21 +333,41 @@ pub const WalReplicaState = struct {
         return try buffer.toOwnedSlice(self.alloc);
     }
 
-    fn persistReadyDelta(self: *WalReplicaState, ready: raft_engine.core.Ready) !void {
+    fn persistReadyDelta(
+        self: *WalReplicaState,
+        ready: raft_engine.core.Ready,
+        diagnostics: ?*storage_iface.ReadyPersistenceDiagnostics,
+    ) !void {
         const started_ns = nowNs();
         self.stats.ready_persist_calls += 1;
 
         const encode_started_ns = nowNs();
         const encoded = try self.encodeReadyDelta(ready);
-        self.stats.encode_ns += elapsedSince(encode_started_ns);
+        const encode_elapsed_ns = elapsedSince(encode_started_ns);
+        self.stats.encode_ns += encode_elapsed_ns;
+        if (diagnostics) |diag| diag.encode_elapsed_ns += encode_elapsed_ns;
         defer self.alloc.free(encoded);
         self.stats.encoded_bytes += encoded.len;
+        if (diagnostics) |diag| diag.encoded_bytes += encoded.len;
 
+        const wal_stats_before = if (diagnostics != null) self.wal.statsSnapshot() else null;
         const append_started_ns = nowNs();
         _ = try self.wal.append(encoded);
-        self.stats.wal_append_ns += elapsedSince(append_started_ns);
+        const wal_append_elapsed_ns = elapsedSince(append_started_ns);
+        self.stats.wal_append_ns += wal_append_elapsed_ns;
+        if (diagnostics) |diag| {
+            diag.wal_append_elapsed_ns += wal_append_elapsed_ns;
+            if (wal_stats_before) |before| {
+                const after = self.wal.statsSnapshot();
+                addWalStatsDelta(diag, before, after);
+            }
+        }
         self.stats.persist_ns += elapsedSince(started_ns);
         self.deltaRecordsPersisted(encoded.len);
+        if (diagnostics) |diag| {
+            diag.delta_records_since_checkpoint = self.delta_records_since_checkpoint;
+            diag.delta_bytes_since_checkpoint = self.delta_bytes_since_checkpoint;
+        }
     }
 
     fn persistConfStateDelta(self: *WalReplicaState) !void {
@@ -664,6 +709,24 @@ pub const WalReplicaState = struct {
         try encodeNodeList(alloc, out, conf_state.learners);
         try encodeNodeList(alloc, out, conf_state.learners_next);
         try appendBool(alloc, out, conf_state.auto_leave);
+    }
+
+    fn addWalStatsDelta(
+        diagnostics: *storage_iface.ReadyPersistenceDiagnostics,
+        before: wal_mod.WalStats,
+        after: wal_mod.WalStats,
+    ) void {
+        diagnostics.wal_wait_elapsed_ns += counterDelta(before.total_wait_ns, after.total_wait_ns);
+        diagnostics.wal_coalesce_elapsed_ns += counterDelta(before.total_coalesce_ns, after.total_coalesce_ns);
+        diagnostics.wal_txn_open_elapsed_ns += counterDelta(before.total_txn_open_ns, after.total_txn_open_ns);
+        diagnostics.wal_put_elapsed_ns += counterDelta(before.total_put_ns, after.total_put_ns);
+        diagnostics.wal_commit_elapsed_ns += counterDelta(before.total_commit_ns, after.total_commit_ns);
+        diagnostics.wal_physical_commits += counterDelta(before.physical_commits, after.physical_commits);
+    }
+
+    fn counterDelta(before: u64, after: u64) u64 {
+        if (after < before) return 0;
+        return after - before;
     }
 
     fn nowNs() u64 {

--- a/zig/pkg/antfly/src/storage/lsm_backend.zig
+++ b/zig/pkg/antfly/src/storage/lsm_backend.zig
@@ -4210,6 +4210,16 @@ pub const Backend = struct {
         return std.fmt.parseUnsigned(u64, stem, 10) catch null;
     }
 
+    fn parseRunIdFromRecoveredTableTempFileName(name: []const u8) ?u64 {
+        const marker = ".tbl.tmp-";
+        const marker_index = std.mem.indexOf(u8, name, marker) orelse return null;
+        if (marker_index == 0) return null;
+        const nonce = name[marker_index + marker.len ..];
+        if (nonce.len == 0) return null;
+        _ = std.fmt.parseUnsigned(u64, nonce, 10) catch return null;
+        return std.fmt.parseUnsigned(u64, name[0..marker_index], 10) catch null;
+    }
+
     fn runIdTrackedByManifestLocked(self: *Backend, run_id: u64) bool {
         for (self.runs.items) |run| {
             if (run.id == run_id) return true;
@@ -4235,7 +4245,46 @@ pub const Backend = struct {
     }
 
     pub fn cleanupRecoveredRunFilesForManifest(self: *Backend) !bool {
-        _ = self;
+        const root_dir = self.root_dir orelse return false;
+        if (self.storage == null or self.options.backend.read_only) return false;
+        if (!std.fs.path.isAbsolute(root_dir)) return false;
+
+        const runs_dir = try std.fs.path.join(self.allocator, &.{ root_dir, "runs" });
+        defer self.allocator.free(runs_dir);
+
+        var io_impl = std.Io.Threaded.init(self.allocator, .{});
+        defer io_impl.deinit();
+
+        var dir = std.Io.Dir.cwd().openDir(io_impl.io(), runs_dir, .{ .iterate = true }) catch |err| switch (err) {
+            error.FileNotFound => return false,
+            else => return err,
+        };
+        defer dir.close(io_impl.io());
+
+        var deleted_count: u64 = 0;
+        var deleted_bytes: u64 = 0;
+        var it = dir.iterate();
+        while (try it.next(io_impl.io())) |entry| {
+            if (entry.kind != .file) continue;
+            _ = parseRunIdFromRecoveredTableTempFileName(entry.name) orelse continue;
+
+            const path = try std.fs.path.join(self.allocator, &.{ runs_dir, entry.name });
+            defer self.allocator.free(path);
+            const size = self.storage.?.fileSize(path) catch 0;
+            repository_mod.deleteFileAbsoluteWithStorage(self.storage.?, path) catch |err| switch (err) {
+                error.FileNotFound => {},
+                else => return err,
+            };
+            deleted_count += 1;
+            deleted_bytes += size;
+        }
+        if (deleted_count > 0) {
+            std.log.warn(
+                "lsm backend open cleaned recovered table temp files root={s} count={d} bytes={d}",
+                .{ root_dir, deleted_count, deleted_bytes },
+            );
+            return true;
+        }
         return false;
     }
 
@@ -11563,6 +11612,42 @@ test "lsm backend close reclaims eligible queued obsolete files" {
     var native = try storage_io.NativeStorage.init(std.heap.page_allocator, .threaded);
     defer native.deinit();
     try std.testing.expectError(error.FileNotFound, native.storage().readFileAlloc(std.testing.allocator, obsolete_path, 1024));
+}
+
+test "lsm backend open removes recovered atomic table temp files" {
+    var path_buf: [256]u8 = undefined;
+    const path = repository_mod.tmpPath(&path_buf, "recovered-table-temp");
+    defer repository_mod.cleanupTmp(path);
+
+    var native = try storage_io.NativeStorage.init(std.heap.page_allocator, .threaded);
+    defer native.deinit();
+
+    const root_dir = std.mem.span(path);
+    const runs_dir = try std.fs.path.join(std.testing.allocator, &.{ root_dir, "runs" });
+    defer std.testing.allocator.free(runs_dir);
+    try native.storage().createDirPath(runs_dir);
+
+    const live_run_path = try std.fs.path.join(std.testing.allocator, &.{ runs_dir, "1.tbl" });
+    defer std.testing.allocator.free(live_run_path);
+    const stale_tmp_path = try std.fs.path.join(std.testing.allocator, &.{ runs_dir, "1.tbl.tmp-42" });
+    defer std.testing.allocator.free(stale_tmp_path);
+    const malformed_tmp_path = try std.fs.path.join(std.testing.allocator, &.{ runs_dir, "not-a-run.tbl.tmp-42" });
+    defer std.testing.allocator.free(malformed_tmp_path);
+
+    try repository_mod.writeFileAbsoluteWithStorage(native.storage(), live_run_path, "live");
+    try repository_mod.writeFileAbsoluteWithStorage(native.storage(), stale_tmp_path, "stale");
+    try repository_mod.writeFileAbsoluteWithStorage(native.storage(), malformed_tmp_path, "malformed");
+
+    var backend = try Backend.open(std.testing.allocator, root_dir, .{});
+    backend.close();
+
+    try std.testing.expectError(error.FileNotFound, native.storage().readFileAlloc(std.testing.allocator, stale_tmp_path, 1024));
+    const live = try native.storage().readFileAlloc(std.testing.allocator, live_run_path, 1024);
+    defer std.testing.allocator.free(live);
+    try std.testing.expectEqualStrings("live", live);
+    const malformed = try native.storage().readFileAlloc(std.testing.allocator, malformed_tmp_path, 1024);
+    defer std.testing.allocator.free(malformed);
+    try std.testing.expectEqualStrings("malformed", malformed);
 }
 
 test "lsm repository run readers request cap above 64 MiB" {


### PR DESCRIPTION
## Summary
- clean recovered atomic table temp files (for example `runs/123.tbl.tmp-*`) during LSM backend open after the writer lock is held
- add raft ready persistence sub-timing diagnostics through the raft storage interface and metadata slow-round/timeout logs
- report storage apply, encode, WAL append/wait/coalesce/txn-open/put/commit, physical commits, encoded bytes, and replay debt for slow metadata ready persistence

## Why
- dev metadata rollout was blocked by a state-wal runs directory with many stale atomic table temp files; open now repairs that state safely instead of leaving it to accumulate
- prod slow `metadata runRound` diagnostics currently stop at `ready_persist_ms`; the new detail line tells us whether the time is memory-store apply, encoding, WAL append, or commit/sync

## Tests
- `zig build lsm-backend-test`
- `zig build raft-test`
- `zig build antfly`