### PR TITLE
Fix Metal SDPA seq-major layout

### DIFF
--- a/zig/pkg/inference/src/backends/metal_kernels.m
+++ b/zig/pkg/inference/src/backends/metal_kernels.m
@@ -1878,7 +1878,7 @@ typedef struct termite_metal_sdpa_f32_params {
     uint32_t head_dim;
     uint32_t bias_mode;
     uint32_t has_mask;
-    uint32_t reserved0;
+    uint32_t layout;
     uint32_t reserved1;
 } termite_metal_sdpa_f32_params;
 
@@ -2022,7 +2022,7 @@ static NSString *termite_metal_shader_source(void) {
            "struct termite_metal_gliner_gru_combine_f32_params { uint rows; uint dim; uint reserved0; uint reserved1; };\n"
            "struct termite_metal_argmax_axis_f32_params { uint outer; uint axis_dim; uint inner; uint reserved; };\n"
            "struct termite_metal_convert_dtype_f32_params { uint elem_count; uint kind; uint reserved0; uint reserved1; };\n"
-           "struct termite_metal_sdpa_f32_params { uint batch; uint seq_len; uint num_heads; uint head_dim; uint bias_mode; uint has_mask; uint reserved0; uint reserved1; };\n"
+           "struct termite_metal_sdpa_f32_params { uint batch; uint seq_len; uint num_heads; uint head_dim; uint bias_mode; uint has_mask; uint layout; uint reserved1; };\n"
            "struct termite_metal_disentangled_relative_attention_f32_params { uint batch; uint seq_len; uint num_heads; uint head_dim; uint has_mask; uint reserved0; uint reserved1; uint reserved2; };\n"
            "struct termite_metal_deberta_relative_score_gemm_f32_params { uint batch; uint seq_len; uint rel_len; uint num_heads; uint head_dim; uint mode; uint reserved0; uint reserved1; };\n"
            "struct termite_metal_transpose_f32_params { uint rank; uint total; uint reserved0; uint reserved1; uint dims[8]; uint in_strides[8]; uint out_strides[8]; uint perm[8]; };\n"
@@ -3848,12 +3848,15 @@ static NSString *termite_metal_shader_source(void) {
            "}\n"
            "kernel void termite_sdpa_f32(device const float *q [[buffer(0)]], device const float *k [[buffer(1)]], device const float *v [[buffer(2)]], device const float *bias [[buffer(3)]], device const float *mask [[buffer(4)]], device float *output [[buffer(5)]], constant termite_metal_sdpa_f32_params &p [[buffer(6)]], uint gid [[thread_position_in_grid]]) {\n"
            "    uint total = p.batch * p.num_heads * p.seq_len * p.head_dim; if (gid >= total || p.seq_len == 0u || p.head_dim == 0u) return;\n"
-           "    uint d = gid % p.head_dim; uint tmp = gid / p.head_dim; uint qi = tmp % p.seq_len; uint bh = tmp / p.seq_len; uint b = bh / p.num_heads; uint h = bh - b * p.num_heads;\n"
-           "    uint q_base = (bh * p.seq_len + qi) * p.head_dim;\n"
+           "    uint d = gid % p.head_dim; uint tmp = gid / p.head_dim; uint h; uint qi; uint b;\n"
+           "    if (p.layout == 1u) { h = tmp % p.num_heads; tmp /= p.num_heads; qi = tmp % p.seq_len; b = tmp / p.seq_len; }\n"
+           "    else { qi = tmp % p.seq_len; uint bh0 = tmp / p.seq_len; b = bh0 / p.num_heads; h = bh0 - b * p.num_heads; }\n"
+           "    uint hidden = p.num_heads * p.head_dim; uint bh = b * p.num_heads + h;\n"
+           "    uint q_base = p.layout == 1u ? (b * p.seq_len + qi) * hidden + h * p.head_dim : (bh * p.seq_len + qi) * p.head_dim;\n"
            "    float scale = rsqrt(float(p.head_dim)); float best = -3.402823466e+38f;\n"
            "    for (uint ki = 0u; ki < p.seq_len; ++ki) {\n"
            "        bool allowed = p.has_mask == 0u || mask[b * p.seq_len + ki] != 0.0f; if (!allowed) continue;\n"
-           "        uint k_base = (bh * p.seq_len + ki) * p.head_dim; float score = 0.0f;\n"
+           "        uint k_base = p.layout == 1u ? (b * p.seq_len + ki) * hidden + h * p.head_dim : (bh * p.seq_len + ki) * p.head_dim; float score = 0.0f;\n"
            "        for (uint x = 0u; x < p.head_dim; ++x) score += q[q_base + x] * k[k_base + x];\n"
            "        score *= scale;\n"
            "        if (p.bias_mode == 1u) score += bias[(h * p.seq_len + qi) * p.seq_len + ki];\n"
@@ -3864,13 +3867,14 @@ static NSString *termite_metal_shader_source(void) {
            "    float sum = 0.0f; float accum = 0.0f;\n"
            "    for (uint ki = 0u; ki < p.seq_len; ++ki) {\n"
            "        bool allowed = p.has_mask == 0u || mask[b * p.seq_len + ki] != 0.0f; if (!allowed) continue;\n"
-           "        uint k_base = (bh * p.seq_len + ki) * p.head_dim; float score = 0.0f;\n"
+           "        uint k_base = p.layout == 1u ? (b * p.seq_len + ki) * hidden + h * p.head_dim : (bh * p.seq_len + ki) * p.head_dim; float score = 0.0f;\n"
            "        for (uint x = 0u; x < p.head_dim; ++x) score += q[q_base + x] * k[k_base + x];\n"
            "        score *= scale;\n"
            "        if (p.bias_mode == 1u) score += bias[(h * p.seq_len + qi) * p.seq_len + ki];\n"
            "        else if (p.bias_mode == 2u) score += bias[(bh * p.seq_len + qi) * p.seq_len + ki];\n"
            "        else if (p.bias_mode == 3u) score += bias[(b * p.seq_len + qi) * p.seq_len + ki];\n"
-           "        float w = exp(score - best); sum += w; accum += w * v[(bh * p.seq_len + ki) * p.head_dim + d];\n"
+           "        uint v_base = p.layout == 1u ? (b * p.seq_len + ki) * hidden + h * p.head_dim : (bh * p.seq_len + ki) * p.head_dim;\n"
+           "        float w = exp(score - best); sum += w; accum += w * v[v_base + d];\n"
            "    }\n"
            "    output[gid] = sum > 0.0f ? accum / sum : 0.0f;\n"
            "}\n"
@@ -23787,12 +23791,13 @@ int termite_metal_decode_runtime_sdpa_f32_device(
     size_t head_dim,
     uint32_t bias_mode,
     uint32_t has_mask,
+    uint32_t layout,
     void *output_handle,
     size_t output_offset
 ) {
     if (runtime == NULL || q_handle == NULL || k_handle == NULL || v_handle == NULL || output_handle == NULL) return -1;
     if (runtime->sdpa_f32_pipeline == nil) return -2;
-    if (batch == 0 || seq_len == 0 || num_heads == 0 || head_dim == 0 || bias_mode > 3u || has_mask > 1u) return -3;
+    if (batch == 0 || seq_len == 0 || num_heads == 0 || head_dim == 0 || bias_mode > 3u || has_mask > 1u || layout > 1u) return -3;
     if (bias_mode != 0u && bias_handle == NULL) return -4;
     if (has_mask != 0u && mask_handle == NULL) return -5;
     if (batch > UINT32_MAX || seq_len > UINT32_MAX || num_heads > UINT32_MAX || head_dim > UINT32_MAX) return -6;
@@ -23829,7 +23834,7 @@ int termite_metal_decode_runtime_sdpa_f32_device(
             .head_dim = (uint32_t)head_dim,
             .bias_mode = bias_mode,
             .has_mask = has_mask,
-            .reserved0 = 0,
+            .layout = layout,
             .reserved1 = 0,
         };
         bool frame_owned = true;

--- a/zig/pkg/inference/src/backends/metal_runtime.zig
+++ b/zig/pkg/inference/src/backends/metal_runtime.zig
@@ -3829,8 +3829,30 @@ pub fn decoderRuntimeSdpaF32Device(self: anytype, request: anytype) !?MetalTenso
     if (termite_metal_decode_runtime_ready(runtime) == 0) return null;
     if (!request.q.isDevice() or !request.k.isDevice() or !request.v.isDevice()) return null;
     if (request.batch == 0 or request.seq_len == 0 or request.num_heads == 0 or request.head_dim == 0) return null;
-    const total = request.batch * request.num_heads * request.seq_len * request.head_dim;
+    const hidden = std.math.mul(usize, request.num_heads, request.head_dim) catch return null;
+    const token_count = std.math.mul(usize, request.batch, request.seq_len) catch return null;
+    const total = std.math.mul(usize, token_count, hidden) catch return null;
     if (request.q.elemCount() != total or request.k.elemCount() != total or request.v.elemCount() != total) return null;
+    if (token_count > std.math.maxInt(i32) or hidden > std.math.maxInt(i32)) return null;
+    const batch_heads = std.math.mul(usize, request.batch, request.num_heads) catch return null;
+    if (batch_heads > std.math.maxInt(i32) or request.seq_len > std.math.maxInt(i32) or request.head_dim > std.math.maxInt(i32)) return null;
+    const seq_major_shape = [_]i32{ @intCast(token_count), @intCast(hidden) };
+    const head_major_3d_shape = [_]i32{ @intCast(batch_heads), @intCast(request.seq_len), @intCast(request.head_dim) };
+    const head_major_4d_shape = [_]i32{ @intCast(request.batch), @intCast(request.num_heads), @intCast(request.seq_len), @intCast(request.head_dim) };
+    const layout: u32 = if (std.mem.eql(i32, request.q.shape(), &seq_major_shape) and
+        std.mem.eql(i32, request.k.shape(), &seq_major_shape) and
+        std.mem.eql(i32, request.v.shape(), &seq_major_shape))
+        1
+    else if (std.mem.eql(i32, request.q.shape(), &head_major_3d_shape) and
+        std.mem.eql(i32, request.k.shape(), &head_major_3d_shape) and
+        std.mem.eql(i32, request.v.shape(), &head_major_3d_shape))
+        0
+    else if (std.mem.eql(i32, request.q.shape(), &head_major_4d_shape) and
+        std.mem.eql(i32, request.k.shape(), &head_major_4d_shape) and
+        std.mem.eql(i32, request.v.shape(), &head_major_4d_shape))
+        0
+    else
+        return null;
     const bias_tensor: ?MetalTensor = if (@hasField(@TypeOf(request), "bias")) request.bias else null;
     const mask_tensor: ?MetalTensor = if (@hasField(@TypeOf(request), "mask")) request.mask else null;
     const bias_mode: u32 = if (@hasField(@TypeOf(request), "bias_mode")) request.bias_mode else 0;
@@ -3862,6 +3884,7 @@ pub fn decoderRuntimeSdpaF32Device(self: anytype, request: anytype) !?MetalTenso
         request.head_dim,
         bias_mode,
         if (mask_tensor != null) 1 else 0,
+        layout,
         output_device.deviceHandle(),
         output_device.deviceByteOffset(),
     );
@@ -8175,6 +8198,7 @@ pub extern fn termite_metal_decode_runtime_sdpa_f32_device(
     head_dim: usize,
     bias_mode: u32,
     has_mask: u32,
+    layout: u32,
     output_handle: ?*anyopaque,
     output_offset: usize,
 ) c_int;

--- a/zig/pkg/inference/src/ops/metal_compute.zig
+++ b/zig/pkg/inference/src/ops/metal_compute.zig
@@ -21604,6 +21604,126 @@ test "metal_compute: scaled dot product attention fallback preserves shape and v
     }
 }
 
+test "metal_compute: scaled dot product attention supports seq-major interleaved heads" {
+    if (!build_options.enable_metal) return error.SkipZigTest;
+    if (!@import("../backends/metal_runtime.zig").metalDeviceAvailable()) return error.SkipZigTest;
+
+    const allocator = std.testing.allocator;
+
+    var metal_ws = testMetalWeightStoreInit(allocator);
+    defer metal_ws.lazy_weights.deinit(allocator);
+    var metal_compute = try MetalCompute.init(allocator, &metal_ws, null);
+    defer metal_compute.deinit();
+    var metal_cb = metal_compute.computeBackend();
+
+    const batch: usize = 2;
+    const seq_len: usize = 3;
+    const num_heads: usize = 2;
+    const head_dim: usize = 2;
+    const hidden = num_heads * head_dim;
+    const total = batch * seq_len * hidden;
+    const qkv_shape = [_]i32{ @intCast(batch * seq_len), @intCast(hidden) };
+    const bias_shape = [_]i32{ @intCast(num_heads), @intCast(seq_len), @intCast(seq_len) };
+
+    var q_data: [total]f32 = undefined;
+    var k_data: [total]f32 = undefined;
+    var v_data: [total]f32 = undefined;
+    var bias_data: [num_heads * seq_len * seq_len]f32 = undefined;
+    const mask = [_]i64{
+        1, 1, 0,
+        1, 0, 1,
+    };
+
+    for (0..total) |i| {
+        q_data[i] = @as(f32, @floatFromInt(@as(i32, @intCast((i * 7) % 19)) - 9)) * 0.06;
+        k_data[i] = @as(f32, @floatFromInt(@as(i32, @intCast((i * 5) % 17)) - 8)) * 0.07;
+        v_data[i] = @as(f32, @floatFromInt(@as(i32, @intCast((i * 3) % 13)) - 6)) * 0.11;
+    }
+    for (0..bias_data.len) |i| {
+        bias_data[i] = @as(f32, @floatFromInt(@as(i32, @intCast(i % 7)) - 3)) * 0.015;
+    }
+
+    const q_host = try metal_cb.fromFloat32Shape(&q_data, &qkv_shape);
+    defer metal_cb.free(q_host);
+    const k_host = try metal_cb.fromFloat32Shape(&k_data, &qkv_shape);
+    defer metal_cb.free(k_host);
+    const v_host = try metal_cb.fromFloat32Shape(&v_data, &qkv_shape);
+    defer metal_cb.free(v_host);
+    const bias = try metal_cb.fromFloat32Shape(&bias_data, &bias_shape);
+    defer metal_cb.free(bias);
+
+    const q_mt = try metal_compute.ownedDeviceMetalTensorFromCt(q_host);
+    const q = try metal_compute.ctFromOwnedMetalTensor(q_mt);
+    defer metal_cb.free(q);
+    const k_mt = try metal_compute.ownedDeviceMetalTensorFromCt(k_host);
+    const k = try metal_compute.ctFromOwnedMetalTensor(k_mt);
+    defer metal_cb.free(k);
+    const v_mt = try metal_compute.ownedDeviceMetalTensorFromCt(v_host);
+    const v = try metal_compute.ctFromOwnedMetalTensor(v_mt);
+    defer metal_cb.free(v);
+
+    const out = try metal_cb.scaledDotProductAttention(q, k, v, &mask, bias, batch, seq_len, num_heads, head_dim);
+    defer metal_cb.free(out);
+    try std.testing.expect(MetalCompute.debugHasDeviceTensor(&metal_cb, out));
+
+    const out_shape = try metal_cb.tensorShape(out, allocator);
+    defer allocator.free(out_shape);
+    try std.testing.expectEqualSlices(i64, &.{ @intCast(batch * seq_len), @intCast(hidden) }, out_shape);
+
+    var expected: [total]f32 = undefined;
+    @memset(&expected, 0.0);
+    var scores: [seq_len]f32 = undefined;
+    const scale: f32 = 1.0 / @sqrt(@as(f32, @floatFromInt(head_dim)));
+
+    for (0..batch) |b| {
+        for (0..num_heads) |h| {
+            for (0..seq_len) |qi| {
+                var row_max: f32 = -std.math.inf(f32);
+                for (0..seq_len) |ki| {
+                    if (mask[b * seq_len + ki] == 0) {
+                        scores[ki] = -std.math.inf(f32);
+                        continue;
+                    }
+                    const q_base = (b * seq_len + qi) * hidden + h * head_dim;
+                    const k_base = (b * seq_len + ki) * hidden + h * head_dim;
+                    var dot: f32 = 0.0;
+                    for (0..head_dim) |d| dot += q_data[q_base + d] * k_data[k_base + d];
+                    const bias_idx = (h * seq_len + qi) * seq_len + ki;
+                    scores[ki] = dot * scale + bias_data[bias_idx];
+                    row_max = @max(row_max, scores[ki]);
+                }
+
+                var sum: f32 = 0.0;
+                for (0..seq_len) |ki| {
+                    if (scores[ki] == -std.math.inf(f32)) {
+                        scores[ki] = 0.0;
+                    } else {
+                        scores[ki] = @exp(scores[ki] - row_max);
+                        sum += scores[ki];
+                    }
+                }
+                if (sum > 0.0) {
+                    for (0..seq_len) |ki| scores[ki] /= sum;
+                }
+
+                const out_base = (b * seq_len + qi) * hidden + h * head_dim;
+                for (0..seq_len) |ki| {
+                    const weight = scores[ki];
+                    if (weight == 0.0) continue;
+                    const v_base = (b * seq_len + ki) * hidden + h * head_dim;
+                    for (0..head_dim) |d| expected[out_base + d] += weight * v_data[v_base + d];
+                }
+            }
+        }
+    }
+
+    const out_data = try metal_cb.toFloat32(out, allocator);
+    defer allocator.free(out_data);
+    for (expected, out_data) |expected_value, actual_value| {
+        try std.testing.expectApproxEqAbs(expected_value, actual_value, 1e-4);
+    }
+}
+
 test "metal_compute: linearTriple is owned by metal backend" {
     if (!build_options.enable_metal) return error.SkipZigTest;
     if (!@import("../backends/metal_runtime.zig").metalDeviceAvailable()) return error.SkipZigTest;


### PR DESCRIPTION
## Summary
- make the Metal SDPA runtime infer seq-major vs head-major layout from Q/K/V tensor shapes
- update the Metal SDPA kernel to index 2D seq-major/interleaved-head tensors correctly while preserving 3D/4D head-major behavior
- add a Metal regression test for seq-major interleaved heads with mask and bias coverage

## Verification
- `zig build test -Dmetal=true -Druntime-test-filter=true -- --test-filter "scaled dot product attention"`
- `zig build test -Dmetal=true -Druntime-test-filter=true -- --test-filter "florence"`
- `zig build install -Dmetal=true`
- GGUF Florence-2 Metal OCR on the project-creation screenshot now reads the dialog text instead of `Cerciad`
- safetensors Florence-2 Metal `<MORE_DETAILED_CAPTION>` now describes the project-creation UI instead of hallucinating video-game content