### PR TITLE
Fix backup restore writer conflict

### DIFF
--- a/zig/pkg/antfly/src/raft/storage/backup_restore.zig
+++ b/zig/pkg/antfly/src/raft/storage/backup_restore.zig
@@ -79,6 +79,9 @@ pub fn restoreSnapshotMatchesPath(
 
     var db = db_mod.DB.open(alloc, path, .{
         .identity_namespace = options.expected_identity_namespace,
+        .open_mode = .query_readonly,
+        .start_index_workers = false,
+        .start_optional_runtimes = false,
     }) catch |err| switch (err) {
         error.FileNotFound, error.IdentityNamespaceMismatch => return false,
         else => return err,
@@ -193,10 +196,6 @@ fn applyRestoreSnapshot(
         .snapshot_path = snapshot_path,
         .group_id = group_id,
     });
-
-    var restored_db = try db_mod.DB.open(alloc, path, .{});
-    defer restored_db.close();
-    if (manifest.indexes_json.len > 0) _ = try reconcileDbIndexes(alloc, &restored_db, manifest.indexes_json);
 }
 
 fn restoreSnapshotDocCount(alloc: std.mem.Allocator, restore: RestoreSource) !u64 {


### PR DESCRIPTION
## Summary
- Open restore idempotence checks in query-readonly mode so they do not contend with live/deferred restore writers
- Keep deferred restore import from immediately reopening the restored root as a normal writer; managed restore repair owns that follow-up work

## Verification
- zig build lib-api-swarm-backup-restore-test
- zig build api-table-writes-docid-test -- --test-filter restore
- ANTFLY_BIN=./zig-out/bin/antfly uv run --project e2e/antfly pytest -q -x e2e/antfly/test_backup_restore.py::test_table_backup_restore_round_trip_managed_chunked_semantic