### PR TITLE
Fix metadata bootstrap churn and raft no-op persistence

### DIFF
--- a/zig/build.zig
+++ b/zig/build.zig
@@ -3046,6 +3046,8 @@ pub fn build(b: *std.Build) void {
         "data runtime startup catch-up clears no-debt busy writer groups",
         "data runtime provisioned root refresh spawn failure preserves retry bookkeeping",
         "data runtime background maintenance is due for dense posting cadence without lsm debt",
+        "data runtime treats metadata leadership churn as retryable bootstrap failure",
+        "data runtime metadata bootstrap retry delay is bounded and jittered",
         "data runtime live writer source follows raft apply ownership",
         "data runtime local split fallback preserves source identity namespace",
         "data runtime split apply store seeding reuses cached source writer",

--- a/zig/build.zig
+++ b/zig/build.zig
@@ -3039,6 +3039,8 @@ pub fn build(b: *std.Build) void {
         "data runtime status refresh reuses managed writer snapshot instead of reopening table db",
         "data runtime keeps status refresh dirty for non-startup async index work",
         "data runtime runRound does not refresh provisioned replica root inline while worker is active",
+        "data runtime runRound backs off retryable provision metadata failures",
+        "data runtime provisioned root refresh worker backs off retryable metadata failures",
         "data runtime data changes mark provisioned startup catch-up dirty",
         "data runtime raft status changes force immediate store status publication",
         "data runtime structural changes preserve writer-published runtime status",

--- a/zig/lib/raft/src/core/ready.zig
+++ b/zig/lib/raft/src/core/ready.zig
@@ -14,6 +14,7 @@
 
 const types = @import("types.zig");
 const message = @import("message.zig");
+const std = @import("std");
 
 pub const Ready = struct {
     soft_state: ?types.SoftState = null,
@@ -33,4 +34,24 @@ pub const Ready = struct {
             self.read_states.len == 0 and
             self.messages.len == 0;
     }
+
+    pub fn requiresPersistence(self: Ready) bool {
+        return self.hard_state != null or
+            self.snapshot != null or
+            self.entries.len > 0;
+    }
 };
+
+test "ready persistence predicate only includes durable raft state" {
+    var request_ctx = [_]u8{ 'c', 't', 'x' };
+    try std.testing.expect(!(Ready{ .messages = &.{.{
+        .msg_type = .heartbeat,
+        .from = 1,
+        .to = 2,
+    }} }).requiresPersistence());
+    try std.testing.expect(!(Ready{ .committed_entries = &.{.{ .term = 1, .index = 1 }} }).requiresPersistence());
+    try std.testing.expect(!(Ready{ .read_states = &.{.{ .index = 1, .request_ctx = &request_ctx }} }).requiresPersistence());
+    try std.testing.expect((Ready{ .hard_state = .{ .current_term = 2 } }).requiresPersistence());
+    try std.testing.expect((Ready{ .entries = &.{.{ .term = 2, .index = 3 }} }).requiresPersistence());
+    try std.testing.expect((Ready{ .snapshot = .{} }).requiresPersistence());
+}

--- a/zig/lib/raft/src/runtime/multi_raft.zig
+++ b/zig/lib/raft/src/runtime/multi_raft.zig
@@ -646,18 +646,24 @@ pub const MultiRaft = struct {
         };
 
         const persist_ready_start_ns = if (diagnostics != null) clock.monotonicNs() else 0;
-        if (persist_batch) |batch| {
-            try batch.persistReadyWithDiagnostics(
-                group_id,
-                ready,
-                if (diagnostics) |diag| &diag.persist_ready_detail else null,
-            );
-        } else if (self.hooks.group_storage) |storage| {
-            try storage.persistReadyWithDiagnostics(
-                group_id,
-                ready,
-                if (diagnostics) |diag| &diag.persist_ready_detail else null,
-            );
+        if (ready.requiresPersistence()) {
+            if (persist_batch) |batch| {
+                if (diagnostics) |diag| diag.persist_ready_detail.used_batch = true;
+                try batch.persistReadyWithDiagnostics(
+                    group_id,
+                    ready,
+                    if (diagnostics) |diag| &diag.persist_ready_detail else null,
+                );
+            } else if (self.hooks.group_storage) |storage| {
+                if (diagnostics) |diag| diag.persist_ready_detail.used_group_storage = true;
+                try storage.persistReadyWithDiagnostics(
+                    group_id,
+                    ready,
+                    if (diagnostics) |diag| &diag.persist_ready_detail else null,
+                );
+            }
+        } else {
+            if (diagnostics) |diag| diag.persist_ready_detail.skipped_no_durable_state = true;
         }
         if (diagnostics) |diag| diag.persist_ready_elapsed_ns = clock.elapsedSinceNs(persist_ready_start_ns);
 

--- a/zig/lib/raft/src/runtime/runtime_test.zig
+++ b/zig/lib/raft/src/runtime/runtime_test.zig
@@ -787,6 +787,63 @@ test "multi raft uses disk batcher and apply queue across a host round" {
     try std.testing.expectEqual(@as(usize, 1), metrics.apply_queue_drains);
 }
 
+test "multi raft skips persistence for message-only ready" {
+    var store = core.MemoryStorage.init(std.testing.allocator);
+    defer store.deinit();
+
+    var storage_recorder = StorageRecorder{ .alloc = std.testing.allocator };
+    defer storage_recorder.deinit();
+    try storage_recorder.registerStore(155, &store);
+
+    var transport_recorder = TransportRecorder{ .alloc = std.testing.allocator };
+    var host = runtime.MultiRaft.init(std.testing.allocator, .{}, .{
+        .group_storage = storage_recorder.iface(),
+        .transport = transport_recorder.iface(),
+    });
+    defer host.deinit();
+
+    var peers = [_]core.types.NodeId{ 1, 2 };
+    try host.addGroup(.{
+        .group_id = 155,
+        .local_node_id = 1,
+        .raft_config = .{
+            .id = 1,
+            .group_id = 155,
+            .peers = peers[0..],
+            .election_tick = 5,
+            .heartbeat_tick = 1,
+            .pre_vote = false,
+        },
+        .storage = store.storage(),
+    });
+
+    try host.group(155).?.campaign();
+    _ = try drainGroup(&host, 155);
+    try host.step(155, .{
+        .msg_type = .request_vote_response,
+        .from = 2,
+        .to = 1,
+        .term = 1,
+    });
+    _ = try drainGroup(&host, 155);
+    try std.testing.expectEqual(core.types.StateRole.leader, host.group(155).?.status().soft.role);
+
+    const persisted_before_heartbeat = storage_recorder.persist_calls;
+    transport_recorder.send_calls = 0;
+    transport_recorder.peer_batch_calls = 0;
+    transport_recorder.sent_messages = 0;
+    transport_recorder.batched_peer_count = 0;
+    transport_recorder.batched_group_count = 0;
+
+    const round = try host.runRound(1, 1);
+    try std.testing.expectEqual(@as(usize, 1), round.processed_groups);
+    try std.testing.expect(transport_recorder.sent_messages > 0);
+    try std.testing.expectEqual(persisted_before_heartbeat, storage_recorder.persist_calls);
+    try std.testing.expect(round.slowest_ready_group.persist_ready_detail.skipped_no_durable_state);
+    try std.testing.expect(!round.slowest_ready_group.persist_ready_detail.used_group_storage);
+    try std.testing.expect(!round.slowest_ready_group.persist_ready_detail.used_batch);
+}
+
 test "multi raft metrics track quiesced groups and throttle denials" {
     var store = core.MemoryStorage.init(std.testing.allocator);
     defer store.deinit();

--- a/zig/lib/raft/src/runtime/storage_iface.zig
+++ b/zig/lib/raft/src/runtime/storage_iface.zig
@@ -15,6 +15,9 @@
 const core = @import("../core/mod.zig");
 
 pub const ReadyPersistenceDiagnostics = struct {
+    skipped_no_durable_state: bool = false,
+    used_batch: bool = false,
+    used_group_storage: bool = false,
     storage_apply_elapsed_ns: u64 = 0,
     encode_elapsed_ns: u64 = 0,
     wal_append_elapsed_ns: u64 = 0,

--- a/zig/pkg/antfly/src/api/mod.zig
+++ b/zig/pkg/antfly/src/api/mod.zig
@@ -54,6 +54,7 @@ pub const http_server = @import("http_server.zig");
 pub const http_client = @import("http_client.zig");
 pub const httpx_handler = @import("httpx_handler.zig");
 pub const connections = @import("connections.zig");
+const protocol_adapters = @import("protocol_adapters.zig");
 
 pub const ClusterHealth = cluster.ClusterHealth;
 pub const ClusterStatus = cluster.ClusterStatus;
@@ -99,6 +100,14 @@ test "linear merge request parser accepts raw payload value under public request
 
     try std.testing.expectEqual(@as(usize, 1), req.writes.len);
     try std.testing.expect(std.mem.indexOf(u8, req.writes[0].value, "\"raw_payload\"") != null);
+}
+
+test "protocol adapters require extension runtime package digest identity" {
+    try protocol_adapters.testExtensionRuntimeBindingRequiresInstalledPackageDigestMatch();
+}
+
+test "protocol adapters carry matched extension runtime package digest" {
+    try protocol_adapters.testExtensionRuntimeBindingCarriesMatchedInstalledPackageDigest();
 }
 
 test "public batch default schema accepts docsaf doc_type row and rejects reserved _type" {

--- a/zig/pkg/antfly/src/api/protocol_adapters.zig
+++ b/zig/pkg/antfly/src/api/protocol_adapters.zig
@@ -799,7 +799,7 @@ fn freeExtensionCapabilities(alloc: std.mem.Allocator, capabilities: []const ext
 fn extensionRuntimeBindingAlloc(alloc: std.mem.Allocator, member: *const extension_domain.ExtensionMember, handler: []const u8, snapshot: anytype) !?ExtensionRuntimeBinding {
     const parsed = parseWasmHandler(handler) orelse return null;
     const installed = findInstalledExtension(snapshot.installed_extensions, member.extension_name) orelse return null;
-    const package = findExtensionPackage(snapshot.extension_packages, installed.package_name, installed.package_version) orelse return null;
+    const package = findExtensionPackage(snapshot.extension_packages, installed.package_name, installed.package_version, installed.package_digest) orelse return null;
     const runtime = findWasmRuntime(package.install.runtimes, parsed.runtime_name) orelse return null;
 
     var package_name: ?[]u8 = null;
@@ -859,11 +859,111 @@ fn findInstalledExtension(installed_extensions: []const extension_domain.Install
     return null;
 }
 
-fn findExtensionPackage(packages: []const extension_domain.PackageManifest, name: []const u8, version: []const u8) ?extension_domain.PackageManifest {
+fn findExtensionPackage(packages: []const extension_domain.PackageManifest, name: []const u8, version: []const u8, digest: []const u8) ?extension_domain.PackageManifest {
     for (packages) |package| {
-        if (std.mem.eql(u8, package.name, name) and std.mem.eql(u8, package.version, version)) return package;
+        if (std.mem.eql(u8, package.name, name) and
+            std.mem.eql(u8, package.version, version) and
+            std.mem.eql(u8, package.digest, digest))
+        {
+            return package;
+        }
     }
     return null;
+}
+
+pub fn testExtensionRuntimeBindingRequiresInstalledPackageDigestMatch() !void {
+    if (!@import("builtin").is_test) @compileError("test-only helper");
+    const alloc = std.testing.allocator;
+    const runtimes = [_]extension_domain.RuntimeDecl{.{
+        .name = "memoryaf_wasm",
+        .mode = .wasm,
+        .artifact = "target/wasm32-wasip2/release/memoryaf_extension.wasm",
+    }};
+    const packages = [_]extension_domain.PackageManifest{.{
+        .name = "memoryaf",
+        .version = "0.0.1",
+        .digest = "sha256:projected",
+        .install = .{
+            .scopes_supported = &.{.cluster},
+            .runtimes = &runtimes,
+        },
+    }};
+    const installed = [_]extension_domain.InstalledExtension{.{
+        .name = "memories",
+        .package_name = "memoryaf",
+        .package_version = "0.0.1",
+        .package_digest = "sha256:installed",
+        .scope = .{ .kind = .cluster },
+        .status = .ready,
+    }};
+    const snapshot = .{
+        .extension_packages = packages[0..],
+        .installed_extensions = installed[0..],
+    };
+    const member = extension_domain.ExtensionMember{
+        .extension_name = "memories",
+        .scope = .{ .kind = .cluster },
+        .object_kind = .mcp_tool,
+        .object_name = "store_memory",
+    };
+
+    try std.testing.expectEqual(@as(?ExtensionRuntimeBinding, null), try extensionRuntimeBindingAlloc(alloc, &member, "wasm:memoryaf_wasm/store_memory", snapshot));
+}
+
+test "extension runtime binding requires installed package digest to match projected package" {
+    try testExtensionRuntimeBindingRequiresInstalledPackageDigestMatch();
+}
+
+pub fn testExtensionRuntimeBindingCarriesMatchedInstalledPackageDigest() !void {
+    if (!@import("builtin").is_test) @compileError("test-only helper");
+    const alloc = std.testing.allocator;
+    const runtimes = [_]extension_domain.RuntimeDecl{.{
+        .name = "memoryaf_wasm",
+        .mode = .wasm,
+        .artifact = "target/wasm32-wasip2/release/memoryaf_extension.wasm",
+        .config_json = "{\"entrypoint\":\"run-tool\"}",
+    }};
+    const packages = [_]extension_domain.PackageManifest{.{
+        .name = "memoryaf",
+        .version = "0.0.1",
+        .digest = "sha256:projected",
+        .install = .{
+            .scopes_supported = &.{.cluster},
+            .runtimes = &runtimes,
+        },
+    }};
+    const installed = [_]extension_domain.InstalledExtension{.{
+        .name = "memories",
+        .package_name = "memoryaf",
+        .package_version = "0.0.1",
+        .package_digest = "sha256:projected",
+        .scope = .{ .kind = .cluster },
+        .status = .ready,
+    }};
+    const snapshot = .{
+        .extension_packages = packages[0..],
+        .installed_extensions = installed[0..],
+    };
+    const member = extension_domain.ExtensionMember{
+        .extension_name = "memories",
+        .scope = .{ .kind = .cluster },
+        .object_kind = .mcp_tool,
+        .object_name = "store_memory",
+    };
+
+    const binding = (try extensionRuntimeBindingAlloc(alloc, &member, "wasm:memoryaf_wasm/store_memory", snapshot)).?;
+    defer binding.deinit(alloc);
+
+    try std.testing.expectEqualStrings("memoryaf", binding.package_name);
+    try std.testing.expectEqualStrings("0.0.1", binding.package_version);
+    try std.testing.expectEqualStrings("sha256:projected", binding.package_digest);
+    try std.testing.expectEqualStrings("memoryaf_wasm", binding.runtime_name);
+    try std.testing.expectEqualStrings("target/wasm32-wasip2/release/memoryaf_extension.wasm", binding.artifact);
+    try std.testing.expectEqualStrings("run-tool", binding.entrypoint);
+}
+
+test "extension runtime binding carries matched installed package digest" {
+    try testExtensionRuntimeBindingCarriesMatchedInstalledPackageDigest();
 }
 
 fn findWasmRuntime(runtimes: []const extension_domain.RuntimeDecl, name: []const u8) ?extension_domain.RuntimeDecl {

--- a/zig/pkg/antfly/src/api/protocol_adapters.zig
+++ b/zig/pkg/antfly/src/api/protocol_adapters.zig
@@ -247,6 +247,7 @@ const ExtensionMcpTool = struct {
 const ExtensionRuntimeBinding = struct {
     package_name: []u8,
     package_version: []u8,
+    package_digest: []u8,
     runtime_name: []u8,
     artifact: []u8,
     entrypoint: []u8,
@@ -254,6 +255,7 @@ const ExtensionRuntimeBinding = struct {
     fn deinit(self: ExtensionRuntimeBinding, alloc: std.mem.Allocator) void {
         alloc.free(self.package_name);
         alloc.free(self.package_version);
+        alloc.free(self.package_digest);
         alloc.free(self.runtime_name);
         alloc.free(self.artifact);
         alloc.free(self.entrypoint);
@@ -263,6 +265,7 @@ const ExtensionRuntimeBinding = struct {
         return .{
             .package_name = self.package_name,
             .package_version = self.package_version,
+            .package_digest = self.package_digest,
             .runtime_name = self.runtime_name,
             .artifact = self.artifact,
             .entrypoint = self.entrypoint,
@@ -803,6 +806,8 @@ fn extensionRuntimeBindingAlloc(alloc: std.mem.Allocator, member: *const extensi
     errdefer if (package_name) |value| alloc.free(value);
     var package_version: ?[]u8 = null;
     errdefer if (package_version) |value| alloc.free(value);
+    var package_digest: ?[]u8 = null;
+    errdefer if (package_digest) |value| alloc.free(value);
     var runtime_name: ?[]u8 = null;
     errdefer if (runtime_name) |value| alloc.free(value);
     var artifact: ?[]u8 = null;
@@ -812,6 +817,7 @@ fn extensionRuntimeBindingAlloc(alloc: std.mem.Allocator, member: *const extensi
 
     package_name = try alloc.dupe(u8, installed.package_name);
     package_version = try alloc.dupe(u8, installed.package_version);
+    package_digest = try alloc.dupe(u8, installed.package_digest);
     runtime_name = try alloc.dupe(u8, parsed.runtime_name);
     artifact = try alloc.dupe(u8, runtime.artifact);
     entrypoint = try runtimeEntrypointAlloc(alloc, runtime.config_json);
@@ -819,6 +825,7 @@ fn extensionRuntimeBindingAlloc(alloc: std.mem.Allocator, member: *const extensi
     return .{
         .package_name = package_name.?,
         .package_version = package_version.?,
+        .package_digest = package_digest.?,
         .runtime_name = runtime_name.?,
         .artifact = artifact.?,
         .entrypoint = entrypoint.?,
@@ -904,8 +911,14 @@ fn callExtensionMcpTool(alloc: std.mem.Allocator, server: anytype, authorization
             error.WasmtimePackageStoreUnavailable,
             error.WasmtimeArtifactNotFound,
             error.WasmtimeSymbolMissing,
-            => return try mcpError(alloc, "extension wasm runtime is unavailable"),
-            else => return try mcpError(alloc, "extension wasm runtime invocation failed"),
+            => {
+                std.log.warn("extension wasm runtime unavailable package={s} version={s} runtime={s} artifact={s} err={}", .{ binding.package_name, binding.package_version, binding.runtime_name, binding.artifact, err });
+                return try mcpError(alloc, "extension wasm runtime is unavailable");
+            },
+            else => {
+                std.log.warn("extension wasm runtime invocation failed package={s} version={s} runtime={s} artifact={s} err={}", .{ binding.package_name, binding.package_version, binding.runtime_name, binding.artifact, err });
+                return try mcpError(alloc, "extension wasm runtime invocation failed");
+            },
         }
     }
 

--- a/zig/pkg/antfly/src/data/runtime.zig
+++ b/zig/pkg/antfly/src/data/runtime.zig
@@ -1953,6 +1953,7 @@ pub const DataServer = struct {
     metadata_local_providers_registered: bool = false,
     store_registration: ?StoreRegistrationConfig = null,
     store_registration_confirmed: bool = false,
+    metadata_bootstrap_retry_mutex: std.atomic.Mutex = .unlocked,
     metadata_bootstrap_retry_attempts: u32 = 0,
     next_metadata_bootstrap_retry_at_ms: u64 = 0,
     group_leadership_source: ?GroupLeadershipSource = null,
@@ -2616,17 +2617,23 @@ pub const DataServer = struct {
         };
     }
 
-    fn metadataBootstrapRetryDue(self: *const DataServer, now_ms: u64) bool {
+    fn metadataBootstrapRetryDue(self: *DataServer, now_ms: u64) bool {
+        lockAtomic(&self.metadata_bootstrap_retry_mutex);
+        defer self.metadata_bootstrap_retry_mutex.unlock();
         return self.next_metadata_bootstrap_retry_at_ms == 0 or
             now_ms >= self.next_metadata_bootstrap_retry_at_ms;
     }
 
     fn clearMetadataBootstrapRetry(self: *DataServer) void {
+        lockAtomic(&self.metadata_bootstrap_retry_mutex);
+        defer self.metadata_bootstrap_retry_mutex.unlock();
         self.metadata_bootstrap_retry_attempts = 0;
         self.next_metadata_bootstrap_retry_at_ms = 0;
     }
 
     fn deferMetadataBootstrapRetry(self: *DataServer, now_ms: u64) void {
+        lockAtomic(&self.metadata_bootstrap_retry_mutex);
+        defer self.metadata_bootstrap_retry_mutex.unlock();
         self.metadata_bootstrap_retry_attempts = self.metadata_bootstrap_retry_attempts +| 1;
         const delay_ms = metadataBootstrapRetryDelayMs(
             self.store_registration,
@@ -2639,6 +2646,24 @@ pub const DataServer = struct {
     fn recordMetadataBootstrapError(self: *DataServer, err: anyerror, now_ms: u64) !void {
         if (!isRetryableMetadataBootstrapError(err)) return err;
         self.deferMetadataBootstrapRetry(now_ms);
+    }
+
+    fn recordProvisionedRootRefreshMetadataError(self: *DataServer, err: anyerror, now_ms: u64) !void {
+        if (!isRetryableMetadataBootstrapError(err)) return err;
+        self.provisioned_root_refresh_dirty.store(true, .release);
+        self.deferMetadataBootstrapRetry(now_ms);
+    }
+
+    fn metadataBootstrapRetryAttemptsForTest(self: *DataServer) u32 {
+        lockAtomic(&self.metadata_bootstrap_retry_mutex);
+        defer self.metadata_bootstrap_retry_mutex.unlock();
+        return self.metadata_bootstrap_retry_attempts;
+    }
+
+    fn nextMetadataBootstrapRetryAtMsForTest(self: *DataServer) u64 {
+        lockAtomic(&self.metadata_bootstrap_retry_mutex);
+        defer self.metadata_bootstrap_retry_mutex.unlock();
+        return self.next_metadata_bootstrap_retry_at_ms;
     }
 
     pub fn runRound(self: *DataServer) !void {
@@ -2715,27 +2740,24 @@ pub const DataServer = struct {
                         };
                     }
                 }
-            }
 
-            self.provision_ticks += 1;
-            if (self.provision_ticks >= 4) {
-                self.provision_ticks = 0;
-                self.maybeRequestProvisionedRootRefresh() catch |err| switch (err) {
-                    // Local split-runtime provisioning can race with active writes.
-                    // Treat those as transient and retry on the next provision tick.
-                    error.WriterLocked,
-                    error.FileNotFound,
-                    error.UnknownGroup,
-                    error.LmdbUnexpected,
-                    error.Corrupted,
-                    error.HttpConnectionClosing,
-                    error.ConnectionResetByPeer,
-                    error.ConnectionRefused,
-                    error.BrokenPipe,
-                    error.EndOfStream,
-                    => {},
-                    else => return err,
-                };
+                if (self.metadataBootstrapRetryDue(now_ms)) {
+                    self.provision_ticks += 1;
+                    if (self.provision_ticks >= 4) {
+                        self.provision_ticks = 0;
+                        self.maybeRequestProvisionedRootRefresh() catch |err| switch (err) {
+                            // Local split-runtime provisioning can race with active writes.
+                            // Treat those as transient and retry on the next provision tick.
+                            error.WriterLocked,
+                            error.FileNotFound,
+                            error.UnknownGroup,
+                            error.LmdbUnexpected,
+                            error.Corrupted,
+                            => {},
+                            else => |retry_err| try self.recordProvisionedRootRefreshMetadataError(retry_err, now_ms),
+                        };
+                    }
+                }
             }
         }
         try self.maybeRequestRuntimeStatusRefresh();
@@ -6215,11 +6237,15 @@ pub const DataServer = struct {
         defer self.provisioned_root_refresh_last_duration_ns.store(platform_time.monotonicNs() - started_ns, .monotonic);
 
         self.refreshProvisionedReplicaRoot() catch |err| {
-            self.provisioned_root_refresh_dirty.store(true, .release);
+            const now_ms: u64 = @intCast(@divTrunc(platform_time.monotonicNs(), std.time.ns_per_ms));
+            self.recordProvisionedRootRefreshMetadataError(err, now_ms) catch {
+                self.provisioned_root_refresh_dirty.store(true, .release);
+            };
             _ = self.provisioned_root_refresh_failed.fetchAdd(1, .monotonic);
             std.log.warn("provisioned replica-root refresh failed err={}", .{err});
             return;
         };
+        self.clearMetadataBootstrapRetry();
         _ = self.provisioned_root_refresh_completed.fetchAdd(1, .monotonic);
     }
 
@@ -6593,6 +6619,10 @@ fn appendOwnedPeerRouteUpsert(
 }
 
 const RemoteMetadataSource = struct {
+    const TestFaults = if (@import("builtin").is_test) struct {
+        fetch_head_error: ?anyerror = null,
+    } else struct {};
+
     alloc: std.mem.Allocator,
     base_uris: [][]u8,
     preferred_base_uri_index: usize = 0,
@@ -6601,6 +6631,7 @@ const RemoteMetadataSource = struct {
     cached_head_at_ms: u64 = 0,
     cached_snapshot: ?antfly.metadata_api.AdminSnapshot = null,
     cached_snapshot_at_ms: u64 = 0,
+    test_faults: TestFaults = .{},
 
     fn init(alloc: std.mem.Allocator, base_uris: []const []const u8) !RemoteMetadataSource {
         if (base_uris.len == 0) return error.MissingMetadataApi;
@@ -6643,6 +6674,9 @@ const RemoteMetadataSource = struct {
     }
 
     fn fetchHead(self: *RemoteMetadataSource) !antfly.metadata_api.MetadataHead {
+        if (@import("builtin").is_test) {
+            if (self.test_faults.fetch_head_error) |err| return err;
+        }
         const now_ms: u64 = @intCast(@divTrunc(platform_time.monotonicNs(), std.time.ns_per_ms));
         lockAtomic(&self.cache_mutex);
         if (self.cached_head) |head| {
@@ -13444,7 +13478,7 @@ test "data runtime runRound does not refresh provisioned replica root inline whi
     defer alloc.free(replica_root_dir);
 
     const remote_metadata = try alloc.create(RemoteMetadataSource);
-    const metadata_api_urls = [_][]const u8{"http://127.0.0.1:1"};
+    const metadata_api_urls = [_][]const u8{"http://metadata.test"};
     remote_metadata.* = try RemoteMetadataSource.init(alloc, &metadata_api_urls);
 
     var server: DataServer = .{
@@ -13473,6 +13507,7 @@ test "data runtime runRound does not refresh provisioned replica root inline whi
     };
     defer server.deinit();
 
+    server.store_registration_confirmed = true;
     server.store_status_dirty = false;
     server.runtime_status_dirty.store(false, .release);
     server.provisioned_startup_catch_up_dirty.store(false, .release);
@@ -13486,6 +13521,136 @@ test "data runtime runRound does not refresh provisioned replica root inline whi
     try std.testing.expect(server.provisioned_root_refresh_dirty.load(.acquire));
     try std.testing.expectEqual(@as(u64, 0), server.provisioned_root_refresh_started.load(.monotonic));
     try std.testing.expectEqual(@as(u64, 0), server.last_provision_head_check_at_ms);
+}
+
+test "data runtime runRound backs off retryable provision metadata failures" {
+    const alloc = std.testing.allocator;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const replica_root_dir = try std.fmt.allocPrint(alloc, ".zig-cache/tmp/{s}/data-runtime-provision-metadata-backoff", .{tmp.sub_path});
+    defer alloc.free(replica_root_dir);
+
+    const remote_metadata = try alloc.create(RemoteMetadataSource);
+    const metadata_api_urls = [_][]const u8{"http://metadata.test"};
+    remote_metadata.* = try RemoteMetadataSource.init(alloc, &metadata_api_urls);
+    remote_metadata.test_faults.fetch_head_error = error.NotLeader;
+
+    var server: DataServer = .{
+        .alloc = alloc,
+        .remote_metadata = remote_metadata,
+        .store_registration = .{
+            .node_id = 9,
+            .store_id = 19,
+            .role = "data",
+            .failure_domain = "test",
+        },
+        .provisioned_storage = antfly.public_api.ProvisionedGroupStorage.init(alloc),
+        .read_source = antfly.public_api.ProvisionedTableReadSource.init(
+            replica_root_dir,
+            antfly.public_api.table_catalog.emptyCatalogSource(),
+            antfly.raft.read_gate.noopReadableLeaseRequester(),
+        ),
+        .write_source = antfly.public_api.ProvisionedTableWriteSource.init(
+            replica_root_dir,
+            antfly.public_api.table_catalog.emptyCatalogSource(),
+        ),
+        .status_source = undefined,
+        .api_server_cfg = undefined,
+        .query_async_limit = .limited(8),
+        .listener_cfg = undefined,
+    };
+    defer server.deinit();
+
+    server.store_registration_confirmed = true;
+    server.store_status_dirty = false;
+    server.runtime_status_dirty.store(false, .release);
+    server.provisioned_startup_catch_up_dirty.store(false, .release);
+    server.provisioned_root_refresh_dirty.store(false, .release);
+    server.provision_ticks = 3;
+
+    try server.runRound();
+
+    try std.testing.expectEqual(@as(u32, 1), server.metadataBootstrapRetryAttemptsForTest());
+    try std.testing.expect(server.nextMetadataBootstrapRetryAtMsForTest() != 0);
+    try std.testing.expect(server.provisioned_root_refresh_dirty.load(.acquire));
+    try std.testing.expectEqual(@as(usize, 0), server.provision_ticks);
+    try std.testing.expect(server.last_provision_head_check_at_ms != 0);
+
+    const next_retry_at_ms = server.nextMetadataBootstrapRetryAtMsForTest();
+    const last_head_check_at_ms = server.last_provision_head_check_at_ms;
+    server.provision_ticks = 3;
+
+    try server.runRound();
+
+    try std.testing.expectEqual(@as(u32, 1), server.metadataBootstrapRetryAttemptsForTest());
+    try std.testing.expectEqual(next_retry_at_ms, server.nextMetadataBootstrapRetryAtMsForTest());
+    try std.testing.expectEqual(last_head_check_at_ms, server.last_provision_head_check_at_ms);
+    try std.testing.expectEqual(@as(usize, 3), server.provision_ticks);
+}
+
+test "data runtime provisioned root refresh worker backs off retryable metadata failures" {
+    const alloc = std.testing.allocator;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const replica_root_dir = try std.fmt.allocPrint(alloc, ".zig-cache/tmp/{s}/data-runtime-provision-worker-backoff", .{tmp.sub_path});
+    defer alloc.free(replica_root_dir);
+
+    const remote_metadata = try alloc.create(RemoteMetadataSource);
+    const metadata_api_urls = [_][]const u8{"http://metadata.test"};
+    remote_metadata.* = try RemoteMetadataSource.init(alloc, &metadata_api_urls);
+    remote_metadata.test_faults.fetch_head_error = error.NotLeader;
+
+    var server: DataServer = .{
+        .alloc = alloc,
+        .remote_metadata = remote_metadata,
+        .store_registration = .{
+            .node_id = 9,
+            .store_id = 19,
+            .role = "data",
+            .failure_domain = "test",
+        },
+        .provisioned_storage = antfly.public_api.ProvisionedGroupStorage.init(alloc),
+        .read_source = antfly.public_api.ProvisionedTableReadSource.init(
+            replica_root_dir,
+            antfly.public_api.table_catalog.emptyCatalogSource(),
+            antfly.raft.read_gate.noopReadableLeaseRequester(),
+        ),
+        .write_source = antfly.public_api.ProvisionedTableWriteSource.init(
+            replica_root_dir,
+            antfly.public_api.table_catalog.emptyCatalogSource(),
+        ),
+        .status_source = undefined,
+        .api_server_cfg = undefined,
+        .query_async_limit = .limited(8),
+        .listener_cfg = undefined,
+    };
+    defer server.deinit();
+
+    server.provisioned_root_refresh_dirty.store(true, .release);
+
+    server.runProvisionedRootRefresh();
+
+    try std.testing.expectEqual(@as(u64, 1), server.provisioned_root_refresh_failed.load(.monotonic));
+    try std.testing.expectEqual(@as(u32, 1), server.metadataBootstrapRetryAttemptsForTest());
+    try std.testing.expect(server.nextMetadataBootstrapRetryAtMsForTest() != 0);
+    try std.testing.expect(server.provisioned_root_refresh_dirty.load(.acquire));
+
+    const next_retry_at_ms = server.nextMetadataBootstrapRetryAtMsForTest();
+    server.store_registration_confirmed = true;
+    server.store_status_dirty = false;
+    server.runtime_status_dirty.store(false, .release);
+    server.provisioned_startup_catch_up_dirty.store(false, .release);
+    server.provision_ticks = 3;
+
+    try server.runRound();
+
+    try std.testing.expectEqual(@as(u32, 1), server.metadataBootstrapRetryAttemptsForTest());
+    try std.testing.expectEqual(next_retry_at_ms, server.nextMetadataBootstrapRetryAtMsForTest());
+    try std.testing.expectEqual(@as(usize, 3), server.provision_ticks);
 }
 
 test "data runtime provisioned root refresh spawn failure preserves retry bookkeeping" {

--- a/zig/pkg/antfly/src/data/runtime.zig
+++ b/zig/pkg/antfly/src/data/runtime.zig
@@ -51,6 +51,9 @@ const data_raft_batch_leader_retry_sleep_ns: u64 = 50 * std.time.ns_per_ms;
 const data_raft_metadata_resync_interval_ns: u64 = 500 * std.time.ns_per_ms;
 const data_raft_campaign_retry_interval_ns: u64 = 500 * std.time.ns_per_ms;
 const data_raft_metadata_sync_interval_ms: u64 = 250;
+const metadata_bootstrap_retry_base_ms: u64 = 250;
+const metadata_bootstrap_retry_max_ms: u64 = 5 * std.time.ms_per_s;
+const metadata_bootstrap_retry_jitter_ms: u64 = 250;
 const trusted_principal_secret_key = "antfly.trusted_principal.secret";
 const trusted_principal_issuer_key = "antfly.trusted_principal.issuer";
 
@@ -1686,6 +1689,61 @@ fn isNonFatalHAStandbyReplicationError(err: anyerror) bool {
     };
 }
 
+fn isRetryableMetadataBootstrapError(err: anyerror) bool {
+    return switch (err) {
+        error.HttpConnectionClosing,
+        error.ConnectionResetByPeer,
+        error.ConnectionRefused,
+        error.BrokenPipe,
+        error.EndOfStream,
+        error.UnexpectedHttpStatus,
+        error.NotListening,
+        error.NotLeader,
+        error.ProposalDropped,
+        error.LeaderTransferInProgress,
+        => true,
+        else => false,
+    };
+}
+
+fn metadataBootstrapRetryDelayMs(registration: ?StoreRegistrationConfig, attempts: u32, now_ms: u64) u64 {
+    const capped_attempts = @min(attempts, 5);
+    const exponential = metadata_bootstrap_retry_base_ms << @intCast(capped_attempts -| 1);
+    const bounded = @min(exponential, metadata_bootstrap_retry_max_ms);
+    var hasher = std.hash.Wyhash.init(0x8d6a_2026_4c1f_b007);
+    hashU64(&hasher, now_ms);
+    hashU64(&hasher, attempts);
+    if (registration) |record| {
+        hashU64(&hasher, record.node_id);
+        hashU64(&hasher, record.store_id);
+    }
+    const jitter = hasher.final() % (metadata_bootstrap_retry_jitter_ms + 1);
+    return @min(bounded +| jitter, metadata_bootstrap_retry_max_ms + metadata_bootstrap_retry_jitter_ms);
+}
+
+test "data runtime treats metadata leadership churn as retryable bootstrap failure" {
+    try std.testing.expect(isRetryableMetadataBootstrapError(error.NotLeader));
+    try std.testing.expect(isRetryableMetadataBootstrapError(error.ProposalDropped));
+    try std.testing.expect(isRetryableMetadataBootstrapError(error.LeaderTransferInProgress));
+    try std.testing.expect(isRetryableMetadataBootstrapError(error.ConnectionRefused));
+    try std.testing.expect(!isRetryableMetadataBootstrapError(error.InvalidArguments));
+}
+
+test "data runtime metadata bootstrap retry delay is bounded and jittered" {
+    const registration = StoreRegistrationConfig{
+        .node_id = 7,
+        .store_id = 11,
+        .role = "data",
+    };
+    const first = metadataBootstrapRetryDelayMs(registration, 1, 1000);
+    const later = metadataBootstrapRetryDelayMs(registration, 4, 1000);
+    const capped = metadataBootstrapRetryDelayMs(registration, 16, 1000);
+    try std.testing.expect(first >= metadata_bootstrap_retry_base_ms);
+    try std.testing.expect(first <= metadata_bootstrap_retry_base_ms + metadata_bootstrap_retry_jitter_ms);
+    try std.testing.expect(later >= first);
+    try std.testing.expect(capped <= metadata_bootstrap_retry_max_ms + metadata_bootstrap_retry_jitter_ms);
+}
+
 pub const StoreRegistrationConfig = struct {
     node_id: u64,
     store_id: u64,
@@ -1895,6 +1953,8 @@ pub const DataServer = struct {
     metadata_local_providers_registered: bool = false,
     store_registration: ?StoreRegistrationConfig = null,
     store_registration_confirmed: bool = false,
+    metadata_bootstrap_retry_attempts: u32 = 0,
+    next_metadata_bootstrap_retry_at_ms: u64 = 0,
     group_leadership_source: ?GroupLeadershipSource = null,
     group_membership_source: ?GroupMembershipSource = null,
     local_transition_runtime: ?antfly.raft.TransitionRuntime = null,
@@ -2556,6 +2616,31 @@ pub const DataServer = struct {
         };
     }
 
+    fn metadataBootstrapRetryDue(self: *const DataServer, now_ms: u64) bool {
+        return self.next_metadata_bootstrap_retry_at_ms == 0 or
+            now_ms >= self.next_metadata_bootstrap_retry_at_ms;
+    }
+
+    fn clearMetadataBootstrapRetry(self: *DataServer) void {
+        self.metadata_bootstrap_retry_attempts = 0;
+        self.next_metadata_bootstrap_retry_at_ms = 0;
+    }
+
+    fn deferMetadataBootstrapRetry(self: *DataServer, now_ms: u64) void {
+        self.metadata_bootstrap_retry_attempts = self.metadata_bootstrap_retry_attempts +| 1;
+        const delay_ms = metadataBootstrapRetryDelayMs(
+            self.store_registration,
+            self.metadata_bootstrap_retry_attempts,
+            now_ms,
+        );
+        self.next_metadata_bootstrap_retry_at_ms = now_ms +| delay_ms;
+    }
+
+    fn recordMetadataBootstrapError(self: *DataServer, err: anyerror, now_ms: u64) !void {
+        if (!isRetryableMetadataBootstrapError(err)) return err;
+        self.deferMetadataBootstrapRetry(now_ms);
+    }
+
     pub fn runRound(self: *DataServer) !void {
         const ha_standby_replication_ok = blk: {
             self.runHAStandbyReplicationRound() catch |err| {
@@ -2589,62 +2674,47 @@ pub const DataServer = struct {
             }
         }
         if (self.remote_metadata != null and self.store_registration != null) {
-            if (!self.store_registration_confirmed) {
-                self.registerNodeIfConfigured() catch |register_err| switch (register_err) {
-                    error.HttpConnectionClosing,
-                    error.ConnectionResetByPeer,
-                    error.ConnectionRefused,
-                    error.BrokenPipe,
-                    error.EndOfStream,
-                    error.UnexpectedHttpStatus,
-                    error.NotListening,
-                    => {},
-                    else => return register_err,
-                };
-            }
-            self.store_status_ticks += 1;
             const now_ms: u64 = @intCast(@divTrunc(platform_time.monotonicNs(), std.time.ns_per_ms));
-            const due_store_status_heartbeat = self.last_store_status_report_at_ms == 0 or
-                now_ms -| self.last_store_status_report_at_ms >= store_status_heartbeat_interval_ms;
-            const due_full_store_status = self.localGroupStatusCacheStale(now_ms);
-            const due_data_raft_status_refresh = self.data_raft != null;
-            if (self.store_status_ticks >= store_status_report_interval_ticks and
-                (self.store_status_dirty or due_store_status_heartbeat or due_full_store_status or due_data_raft_status_refresh))
-            {
-                self.store_status_ticks = 0;
-                const result = if (self.store_status_dirty or due_full_store_status or due_data_raft_status_refresh)
-                    self.reportStoreStatus()
-                else
-                    self.reportStoreStatusHeartbeat();
-                result catch |err| switch (err) {
-                    // Split runtime can briefly observe placement before the
-                    // local replica root is fully provisioned on disk.
-                    error.FileNotFound,
-                    error.UnknownGroup,
-                    error.LmdbUnexpected,
-                    error.Corrupted,
-                    error.HttpConnectionClosing,
-                    error.ConnectionResetByPeer,
-                    error.ConnectionRefused,
-                    error.BrokenPipe,
-                    error.EndOfStream,
-                    error.UnexpectedHttpStatus,
-                    => {},
-                    error.UnknownStore => {
-                        self.store_registration_confirmed = false;
-                        self.registerNodeIfConfigured() catch |register_err| switch (register_err) {
-                            error.HttpConnectionClosing,
-                            error.ConnectionResetByPeer,
-                            error.ConnectionRefused,
-                            error.BrokenPipe,
-                            error.EndOfStream,
-                            error.UnexpectedHttpStatus,
-                            => {},
-                            else => return register_err,
+            if (self.metadataBootstrapRetryDue(now_ms)) {
+                const registration_ready = blk: {
+                    if (!self.store_registration_confirmed) {
+                        self.registerNodeIfConfigured() catch |err| {
+                            try self.recordMetadataBootstrapError(err, now_ms);
+                            break :blk false;
                         };
-                    },
-                    else => return err,
+                    }
+                    break :blk true;
                 };
+                if (registration_ready) {
+                    self.store_status_ticks += 1;
+                    const due_store_status_heartbeat = self.last_store_status_report_at_ms == 0 or
+                        now_ms -| self.last_store_status_report_at_ms >= store_status_heartbeat_interval_ms;
+                    const due_full_store_status = self.localGroupStatusCacheStale(now_ms);
+                    const due_data_raft_status_refresh = self.data_raft != null;
+                    if (self.store_status_ticks >= store_status_report_interval_ticks and
+                        (self.store_status_dirty or due_store_status_heartbeat or due_full_store_status or due_data_raft_status_refresh))
+                    {
+                        self.store_status_ticks = 0;
+                        const result = if (self.store_status_dirty or due_full_store_status or due_data_raft_status_refresh)
+                            self.reportStoreStatus()
+                        else
+                            self.reportStoreStatusHeartbeat();
+                        result catch |err| switch (err) {
+                            // Split runtime can briefly observe placement before the
+                            // local replica root is fully provisioned on disk.
+                            error.FileNotFound,
+                            error.UnknownGroup,
+                            error.LmdbUnexpected,
+                            error.Corrupted,
+                            => {},
+                            error.UnknownStore => {
+                                self.store_registration_confirmed = false;
+                                self.registerNodeIfConfigured() catch |register_err| try self.recordMetadataBootstrapError(register_err, now_ms);
+                            },
+                            else => |retry_err| try self.recordMetadataBootstrapError(retry_err, now_ms),
+                        };
+                    }
+                }
             }
 
             self.provision_ticks += 1;
@@ -4049,6 +4119,7 @@ pub const DataServer = struct {
             .live = true,
         });
         self.store_registration_confirmed = true;
+        self.clearMetadataBootstrapRetry();
         // Startup should not block on reopening every local group DB just to
         // compute an initial best-effort status report. Mark the store dirty
         // and let the main run loop publish status once listeners are up.
@@ -4582,6 +4653,7 @@ pub const DataServer = struct {
         try self.storeStatusHeartbeatCacheReplace(report);
         self.store_status_dirty = false;
         self.last_store_status_report_at_ms = @intCast(@divTrunc(platform_time.monotonicNs(), std.time.ns_per_ms));
+        self.clearMetadataBootstrapRetry();
     }
 
     fn syncDataRaftFromRemoteMetadata(self: *DataServer) !void {
@@ -4690,6 +4762,7 @@ pub const DataServer = struct {
         defer freeStoreStatusReportOwned(self.alloc, &report);
         try remote_metadata.reportNodeStatus(report);
         self.last_store_status_report_at_ms = @intCast(@divTrunc(platform_time.monotonicNs(), std.time.ns_per_ms));
+        self.clearMetadataBootstrapRetry();
     }
 
     fn cloneHeartbeatStoreStatusReport(

--- a/zig/pkg/antfly/src/extensions/wasmtime_runtime.zig
+++ b/zig/pkg/antfly/src/extensions/wasmtime_runtime.zig
@@ -23,6 +23,7 @@ const core_magic = [_]u8{ 0x00, 'a', 's', 'm', 0x01, 0x00, 0x00, 0x00 };
 pub const RuntimeBinding = struct {
     package_name: []const u8,
     package_version: []const u8,
+    package_digest: []const u8 = "",
     runtime_name: []const u8,
     artifact: []const u8,
     entrypoint: []const u8 = "call-tool",
@@ -88,7 +89,115 @@ fn resolveArtifactPathAlloc(alloc: std.mem.Allocator, binding: RuntimeBinding, p
 
     const root = package_store_root orelse getenv(package_store_env) orelse return error.WasmtimePackageStoreUnavailable;
 
-    return try std.fs.path.join(alloc, &.{ root, binding.package_name, binding.package_version, binding.artifact });
+    var candidates = std.ArrayListUnmanaged([]u8).empty;
+    defer {
+        for (candidates.items) |candidate| alloc.free(candidate);
+        candidates.deinit(alloc);
+    }
+
+    if (contentAddressedDigest(binding.package_digest)) |digest| {
+        try candidates.append(alloc, try std.fs.path.join(alloc, &.{ root, "sha256", digest, binding.artifact }));
+    }
+    try candidates.append(alloc, try std.fs.path.join(alloc, &.{ root, binding.package_name, binding.artifact }));
+    try candidates.append(alloc, try std.fs.path.join(alloc, &.{ root, binding.package_name, binding.package_version, binding.artifact }));
+
+    for (candidates.items) |candidate| {
+        artifactPathExists(candidate) catch |err| switch (err) {
+            error.FileNotFound => continue,
+            else => return err,
+        };
+        const out = try alloc.dupe(u8, candidate);
+        return out;
+    }
+
+    return try alloc.dupe(u8, candidates.items[candidates.items.len - 1]);
+}
+
+fn contentAddressedDigest(digest: []const u8) ?[]const u8 {
+    if (!std.mem.startsWith(u8, digest, "sha256:")) return null;
+    const value = digest["sha256:".len..];
+    return if (value.len == 0) null else value;
+}
+
+fn artifactPathExists(path: []const u8) !void {
+    const fd = try std.posix.openat(std.posix.AT.FDCWD, path, .{
+        .ACCMODE = .RDONLY,
+        .CLOEXEC = true,
+    }, 0);
+    _ = std.posix.system.close(fd);
+}
+
+test "wasmtime runtime resolves canonical package store artifacts" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDirPath(std.testing.io, "extensions/memoryaf/target/wasm32-wasip2/release");
+    try tmp.dir.writeFile(std.testing.io, .{
+        .sub_path = "extensions/memoryaf/target/wasm32-wasip2/release/memoryaf_extension.wasm",
+        .data = &component_magic,
+    });
+    const root_path = try std.fmt.allocPrint(std.testing.allocator, ".zig-cache/tmp/{s}/extensions", .{tmp.sub_path});
+    defer std.testing.allocator.free(root_path);
+
+    const path = try resolveArtifactPathAlloc(std.testing.allocator, .{
+        .package_name = "memoryaf",
+        .package_version = "0.0.1",
+        .package_digest = "sha256:memoryaf-0.0.1-reference",
+        .runtime_name = "memoryaf_wasm",
+        .artifact = "target/wasm32-wasip2/release/memoryaf_extension.wasm",
+    }, root_path);
+    defer std.testing.allocator.free(path);
+
+    try std.testing.expect(std.mem.endsWith(u8, path, "extensions/memoryaf/target/wasm32-wasip2/release/memoryaf_extension.wasm"));
+}
+
+test "wasmtime runtime resolves content-addressed package store artifacts first" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDirPath(std.testing.io, "extensions/sha256/abc123/target/wasm32-wasip2/release");
+    try tmp.dir.writeFile(std.testing.io, .{
+        .sub_path = "extensions/sha256/abc123/target/wasm32-wasip2/release/memoryaf_extension.wasm",
+        .data = &component_magic,
+    });
+    try tmp.dir.createDirPath(std.testing.io, "extensions/memoryaf/target/wasm32-wasip2/release");
+    try tmp.dir.writeFile(std.testing.io, .{
+        .sub_path = "extensions/memoryaf/target/wasm32-wasip2/release/memoryaf_extension.wasm",
+        .data = &component_magic,
+    });
+    const root_path = try std.fmt.allocPrint(std.testing.allocator, ".zig-cache/tmp/{s}/extensions", .{tmp.sub_path});
+    defer std.testing.allocator.free(root_path);
+
+    const path = try resolveArtifactPathAlloc(std.testing.allocator, .{
+        .package_name = "memoryaf",
+        .package_version = "0.0.1",
+        .package_digest = "sha256:abc123",
+        .runtime_name = "memoryaf_wasm",
+        .artifact = "target/wasm32-wasip2/release/memoryaf_extension.wasm",
+    }, root_path);
+    defer std.testing.allocator.free(path);
+
+    try std.testing.expect(std.mem.indexOf(u8, path, "extensions/sha256/abc123/") != null);
+}
+
+test "wasmtime runtime preserves legacy versioned artifact layout" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDirPath(std.testing.io, "extensions/memoryaf/0.0.1/target/wasm32-wasip2/release");
+    try tmp.dir.writeFile(std.testing.io, .{
+        .sub_path = "extensions/memoryaf/0.0.1/target/wasm32-wasip2/release/memoryaf_extension.wasm",
+        .data = &component_magic,
+    });
+    const root_path = try std.fmt.allocPrint(std.testing.allocator, ".zig-cache/tmp/{s}/extensions", .{tmp.sub_path});
+    defer std.testing.allocator.free(root_path);
+
+    const path = try resolveArtifactPathAlloc(std.testing.allocator, .{
+        .package_name = "memoryaf",
+        .package_version = "0.0.1",
+        .runtime_name = "memoryaf_wasm",
+        .artifact = "target/wasm32-wasip2/release/memoryaf_extension.wasm",
+    }, root_path);
+    defer std.testing.allocator.free(path);
+
+    try std.testing.expect(std.mem.endsWith(u8, path, "extensions/memoryaf/0.0.1/target/wasm32-wasip2/release/memoryaf_extension.wasm"));
 }
 
 fn readFileAlloc(alloc: std.mem.Allocator, path: []const u8) ![]u8 {

--- a/zig/pkg/antfly/src/extensions/wasmtime_runtime.zig
+++ b/zig/pkg/antfly/src/extensions/wasmtime_runtime.zig
@@ -85,7 +85,7 @@ pub fn invokeExtensionWithOptions(
 }
 
 fn resolveArtifactPathAlloc(alloc: std.mem.Allocator, binding: RuntimeBinding, package_store_root: ?[]const u8) InvokeError![]u8 {
-    if (std.fs.path.isAbsolute(binding.artifact)) return try alloc.dupe(u8, binding.artifact);
+    if (!safeRelativeArtifactPath(binding.artifact)) return error.InvalidArtifactPath;
 
     const root = package_store_root orelse getenv(package_store_env) orelse return error.WasmtimePackageStoreUnavailable;
 
@@ -95,7 +95,7 @@ fn resolveArtifactPathAlloc(alloc: std.mem.Allocator, binding: RuntimeBinding, p
         candidates.deinit(alloc);
     }
 
-    if (contentAddressedDigest(binding.package_digest)) |digest| {
+    if (try contentAddressedDigest(binding.package_digest)) |digest| {
         try candidates.append(alloc, try std.fs.path.join(alloc, &.{ root, "sha256", digest, binding.artifact }));
     }
     try candidates.append(alloc, try std.fs.path.join(alloc, &.{ root, binding.package_name, binding.artifact }));
@@ -113,10 +113,36 @@ fn resolveArtifactPathAlloc(alloc: std.mem.Allocator, binding: RuntimeBinding, p
     return try alloc.dupe(u8, candidates.items[candidates.items.len - 1]);
 }
 
-fn contentAddressedDigest(digest: []const u8) ?[]const u8 {
+fn contentAddressedDigest(digest: []const u8) !?[]const u8 {
     if (!std.mem.startsWith(u8, digest, "sha256:")) return null;
     const value = digest["sha256:".len..];
-    return if (value.len == 0) null else value;
+    if (!safePathSegment(value)) return error.InvalidPackageDigest;
+    return value;
+}
+
+fn safePathSegment(value: []const u8) bool {
+    if (value.len == 0) return false;
+    if (std.mem.eql(u8, value, ".") or std.mem.eql(u8, value, "..")) return false;
+    for (value) |c| {
+        const valid =
+            (c >= 'a' and c <= 'z') or
+            (c >= 'A' and c <= 'Z') or
+            (c >= '0' and c <= '9') or
+            c == '_' or
+            c == '-' or
+            c == '.';
+        if (!valid) return false;
+    }
+    return true;
+}
+
+fn safeRelativeArtifactPath(path: []const u8) bool {
+    if (path.len == 0 or std.fs.path.isAbsolute(path)) return false;
+    var parts = std.mem.splitScalar(u8, path, '/');
+    while (parts.next()) |part| {
+        if (!safePathSegment(part)) return false;
+    }
+    return true;
 }
 
 fn artifactPathExists(path: []const u8) !void {
@@ -176,6 +202,39 @@ test "wasmtime runtime resolves content-addressed package store artifacts first"
     defer std.testing.allocator.free(path);
 
     try std.testing.expect(std.mem.indexOf(u8, path, "extensions/sha256/abc123/") != null);
+}
+
+test "wasmtime runtime rejects unsafe content-addressed package digests" {
+    try std.testing.expectError(error.InvalidPackageDigest, contentAddressedDigest("sha256:../escape"));
+    try std.testing.expectError(error.InvalidPackageDigest, contentAddressedDigest("sha256:nested/path"));
+    try std.testing.expectError(error.InvalidPackageDigest, contentAddressedDigest("sha256:"));
+    try std.testing.expectEqualStrings("memoryaf-0.0.1-reference", (try contentAddressedDigest("sha256:memoryaf-0.0.1-reference")).?);
+}
+
+test "wasmtime runtime rejects unsafe relative artifact paths" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const root_path = try std.fmt.allocPrint(std.testing.allocator, ".zig-cache/tmp/{s}/extensions", .{tmp.sub_path});
+    defer std.testing.allocator.free(root_path);
+
+    try std.testing.expectError(error.InvalidArtifactPath, resolveArtifactPathAlloc(std.testing.allocator, .{
+        .package_name = "memoryaf",
+        .package_version = "0.0.1",
+        .runtime_name = "memoryaf_wasm",
+        .artifact = "../escape.wasm",
+    }, root_path));
+    try std.testing.expectError(error.InvalidArtifactPath, resolveArtifactPathAlloc(std.testing.allocator, .{
+        .package_name = "memoryaf",
+        .package_version = "0.0.1",
+        .runtime_name = "memoryaf_wasm",
+        .artifact = "target//memoryaf_extension.wasm",
+    }, root_path));
+    try std.testing.expectError(error.InvalidArtifactPath, resolveArtifactPathAlloc(std.testing.allocator, .{
+        .package_name = "memoryaf",
+        .package_version = "0.0.1",
+        .runtime_name = "memoryaf_wasm",
+        .artifact = "/tmp/memoryaf_extension.wasm",
+    }, root_path));
 }
 
 test "wasmtime runtime preserves legacy versioned artifact layout" {

--- a/zig/pkg/antfly/src/metadata/runtime.zig
+++ b/zig/pkg/antfly/src/metadata/runtime.zig
@@ -452,6 +452,8 @@ pub const Server = struct {
             .admin_listener = .{
                 .bind_host = result.admin_bind_host,
                 .bind_port = cfg.admin_bind_port,
+                .serve_in_connection_threads = true,
+                .max_connection_threads = 32,
             },
             .service = service_cfg,
             .api_server_cfg = cfg.api_server_cfg,
@@ -1638,6 +1640,30 @@ test "metadata runtime scales bootstrap campaign retry interval with tick" {
         @as(u64, 12 * std.time.ns_per_s),
         metadataBootstrapCampaignRetryIntervalNs(100),
     );
+}
+
+test "metadata runtime serves admin listener requests on threaded io connections" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const replica_root = try std.fmt.allocPrint(std.testing.allocator, ".zig-cache/tmp/{s}/metadata-admin-threaded-listener/replicas", .{tmp.sub_path});
+    defer std.testing.allocator.free(replica_root);
+    const replica_catalog_path = try std.fmt.allocPrint(std.testing.allocator, ".zig-cache/tmp/{s}/metadata-admin-threaded-listener/catalog.txt", .{tmp.sub_path});
+    defer std.testing.allocator.free(replica_catalog_path);
+    const snapshot_root = try std.fmt.allocPrint(std.testing.allocator, ".zig-cache/tmp/{s}/metadata-admin-threaded-listener/snapshots", .{tmp.sub_path});
+    defer std.testing.allocator.free(snapshot_root);
+
+    var server = try Server.init(std.testing.allocator, .{
+        .replica_root_dir = replica_root,
+        .replica_catalog_path = replica_catalog_path,
+        .snapshot_root_dir = snapshot_root,
+    });
+    defer server.deinit();
+
+    const admin_listener = server.server.owned_admin_listener orelse return error.MissingMetadataAdminListener;
+    try std.testing.expect(admin_listener.cfg.serve_in_connection_threads);
+    try std.testing.expectEqual(@as(u32, 32), admin_listener.cfg.max_connection_threads);
+    try std.testing.expect(server.metadataHttpService().apiIoImpl() != null);
 }
 
 test "metadata runtime metrics expose memory ownership buckets" {

--- a/zig/pkg/antfly/src/metadata/service.zig
+++ b/zig/pkg/antfly/src/metadata/service.zig
@@ -114,9 +114,12 @@ fn logMetadataRaftRoundDiagnostics(round: raft_engine.runtime.multi_raft.HostRou
     );
     const persist = ready.persist_ready_detail;
     std.log.warn(
-        "metadata raft ready persist detail group_id={d} storage_apply_ms={d} encode_ms={d} wal_append_ms={d} wal_wait_ms={d} wal_coalesce_ms={d} wal_txn_open_ms={d} wal_put_ms={d} wal_commit_ms={d} wal_physical_commits={d} encoded_bytes={d} replay_debt_records={d} replay_debt_bytes={d}",
+        "metadata raft ready persist detail group_id={d} skipped_no_durable_state={} used_batch={} used_group_storage={} storage_apply_ms={d} encode_ms={d} wal_append_ms={d} wal_wait_ms={d} wal_coalesce_ms={d} wal_txn_open_ms={d} wal_put_ms={d} wal_commit_ms={d} wal_physical_commits={d} encoded_bytes={d} replay_debt_records={d} replay_debt_bytes={d}",
         .{
             ready.group_id,
+            persist.skipped_no_durable_state,
+            persist.used_batch,
+            persist.used_group_storage,
             @divTrunc(persist.storage_apply_elapsed_ns, std.time.ns_per_ms),
             @divTrunc(persist.encode_elapsed_ns, std.time.ns_per_ms),
             @divTrunc(persist.wal_append_elapsed_ns, std.time.ns_per_ms),
@@ -3183,10 +3186,13 @@ pub const MetadataHttpService = struct {
         );
         const persist = ready.persist_ready_detail;
         std.log.warn(
-            "metadata linearizable read timeout persist detail request_id={d} group_id={d} storage_apply_ms={d} encode_ms={d} wal_append_ms={d} wal_wait_ms={d} wal_coalesce_ms={d} wal_txn_open_ms={d} wal_put_ms={d} wal_commit_ms={d} wal_physical_commits={d} encoded_bytes={d} replay_debt_records={d} replay_debt_bytes={d}",
+            "metadata linearizable read timeout persist detail request_id={d} group_id={d} skipped_no_durable_state={} used_batch={} used_group_storage={} storage_apply_ms={d} encode_ms={d} wal_append_ms={d} wal_wait_ms={d} wal_coalesce_ms={d} wal_txn_open_ms={d} wal_put_ms={d} wal_commit_ms={d} wal_physical_commits={d} encoded_bytes={d} replay_debt_records={d} replay_debt_bytes={d}",
             .{
                 request_id,
                 ready.group_id,
+                persist.skipped_no_durable_state,
+                persist.used_batch,
+                persist.used_group_storage,
                 @divTrunc(persist.storage_apply_elapsed_ns, std.time.ns_per_ms),
                 @divTrunc(persist.encode_elapsed_ns, std.time.ns_per_ms),
                 @divTrunc(persist.wal_append_elapsed_ns, std.time.ns_per_ms),


### PR DESCRIPTION
## Summary
- treat metadata leadership churn as retryable during data-node registration/status bootstrap instead of process-fatal
- skip raft persistence hooks for Ready values with no durable state, while still applying/sending message-only Ready output
- add persist diagnostics flags so slow logs show skipped no-op persistence vs batch/group-storage execution

## Tests
- zig build raft-test
- zig build lib-data-runtime-test
- zig build lib-metadata-test