### PR TITLE
Default imported ONNX graphs without enabling ORT by default

### DIFF
--- a/zig/pkg/inference/src/backends/backends.zig
+++ b/zig/pkg/inference/src/backends/backends.zig
@@ -221,7 +221,8 @@ pub const SessionManager = struct {
     }
 
     fn shouldUseImportedOnnxGraphRuntime(self: *const SessionManager, model_path: []const u8) bool {
-        return self.graph_runtime_strategy != null and isOnnxFilePath(model_path);
+        _ = self;
+        return isOnnxFilePath(model_path);
     }
 
     fn shouldUseExternalOnnxRuntime(self: *const SessionManager, model_path: []const u8) bool {
@@ -242,7 +243,7 @@ fn configuredPreferredBackends() []const BackendType {
     if (preferredBackendOverride()) |backend| {
         return preferredBackendsForOverride(backend);
     }
-    return &.{ .onnx, .metal, .native };
+    return &.{ .metal, .native };
 }
 
 fn preferredBackendsForOverride(backend: BackendType) []const BackendType {
@@ -288,13 +289,20 @@ test "preferred backend override keeps fallback backends" {
 
 test "explicit graph runtime is independent from onnx runtime backend availability" {
     var manager = SessionManager.init(std.testing.allocator);
-    try std.testing.expect(!manager.shouldUseImportedOnnxGraphRuntime("model.onnx"));
+    try std.testing.expect(manager.shouldUseImportedOnnxGraphRuntime("model.onnx"));
     try std.testing.expectEqual(build_options.enable_onnx, manager.shouldUseExternalOnnxRuntime("model.onnx"));
     manager.graph_runtime_strategy = .partitioned;
     try std.testing.expect(manager.shouldUseImportedOnnxGraphRuntime("model.onnx"));
     try std.testing.expectEqual(build_options.enable_onnx, manager.shouldUseExternalOnnxRuntime("model.onnx"));
     try std.testing.expect(!manager.shouldUseImportedOnnxGraphRuntime("model.gguf"));
     try std.testing.expect(!manager.shouldUseExternalOnnxRuntime("model.gguf"));
+}
+
+test "auto backend order keeps external onnx runtime opt-in" {
+    if (!build_options.enable_wasm) {
+        try std.testing.expectEqualSlices(BackendType, &.{ .metal, .native }, configuredPreferredBackends());
+    }
+    try std.testing.expectEqualSlices(BackendType, &.{ .onnx, .metal, .native }, preferredBackendsForOverride(.onnx));
 }
 
 fn preferredBackendOverride() ?BackendType {

--- a/zig/pkg/inference/src/bench/clipclap_e2e.zig
+++ b/zig/pkg/inference/src/bench/clipclap_e2e.zig
@@ -761,9 +761,9 @@ fn parseOutputFormat(value: []const u8) ?OutputFormat {
 fn configureBackendPreference(session_manager: *backends.SessionManager, choice: BackendChoice) void {
     session_manager.preferred_backends = switch (choice) {
         .auto => if (build_options.enable_metal)
-            &.{ backends.BackendType.onnx, backends.BackendType.metal, backends.BackendType.native }
+            &.{ backends.BackendType.metal, backends.BackendType.native }
         else
-            &.{ backends.BackendType.onnx, backends.BackendType.native },
+            &.{backends.BackendType.native},
         .onnx => &.{backends.BackendType.onnx},
         .native => &.{backends.BackendType.native},
         .metal => if (build_options.enable_metal) &.{backends.BackendType.metal} else &.{backends.BackendType.native},

--- a/zig/pkg/inference/src/native_embed.zig
+++ b/zig/pkg/inference/src/native_embed.zig
@@ -427,9 +427,9 @@ fn parseBackendChoice(value: []const u8) ?BackendChoice {
 fn configureBackendPreference(session_manager: *backends.SessionManager, choice: BackendChoice) void {
     session_manager.preferred_backends = switch (choice) {
         .auto => if (build_options.enable_metal)
-            &.{ backends.BackendType.onnx, backends.BackendType.metal, backends.BackendType.native }
+            &.{ backends.BackendType.metal, backends.BackendType.native }
         else
-            &.{ backends.BackendType.onnx, backends.BackendType.native },
+            &.{backends.BackendType.native},
         .onnx => &.{backends.BackendType.onnx},
         .native => &.{backends.BackendType.native},
         .metal => if (build_options.enable_metal) &.{backends.BackendType.metal} else &.{backends.BackendType.native},
@@ -496,6 +496,18 @@ test "parseArgs preserves multimodal input order" {
     try std.testing.expectEqual(Modality.audio, opts.order.items[2].modality);
     try std.testing.expectEqual(Modality.text, opts.order.items[3].modality);
     try std.testing.expectEqual(@as(usize, 1), opts.order.items[3].index);
+}
+
+test "embed auto backend keeps external onnx runtime opt-in" {
+    var session_manager = backends.SessionManager.init(std.testing.allocator);
+    configureBackendPreference(&session_manager, .auto);
+    if (build_options.enable_metal) {
+        try std.testing.expectEqualSlices(backends.BackendType, &.{ .metal, .native }, session_manager.preferred_backends);
+    } else {
+        try std.testing.expectEqualSlices(backends.BackendType, &.{.native}, session_manager.preferred_backends);
+    }
+    configureBackendPreference(&session_manager, .onnx);
+    try std.testing.expectEqualSlices(backends.BackendType, &.{.onnx}, session_manager.preferred_backends);
 }
 
 test "appendSparseEmbeddingJson writes cli sparse embedding shape" {

--- a/zig/pkg/inference/src/native_read.zig
+++ b/zig/pkg/inference/src/native_read.zig
@@ -483,11 +483,11 @@ fn parseBackendChoice(value: []const u8) ?BackendChoice {
 fn configureBackendPreference(session_manager: *backends.SessionManager, choice: BackendChoice) void {
     session_manager.preferred_backends = switch (choice) {
         .auto => if (build_options.enable_cuda)
-            &.{ backends.BackendType.onnx, backends.BackendType.cuda, backends.BackendType.native }
+            &.{ backends.BackendType.cuda, backends.BackendType.native }
         else if (build_options.enable_metal)
-            &.{ backends.BackendType.onnx, backends.BackendType.metal, backends.BackendType.native }
+            &.{ backends.BackendType.metal, backends.BackendType.native }
         else
-            &.{ backends.BackendType.onnx, backends.BackendType.native },
+            &.{backends.BackendType.native},
         .onnx => &.{backends.BackendType.onnx},
         .native => &.{backends.BackendType.native},
         .metal => if (build_options.enable_metal) &.{backends.BackendType.metal} else &.{backends.BackendType.native},


### PR DESCRIPTION
## Summary

Fixes the default runtime behavior for imported ONNX graph artifacts while keeping external ONNX Runtime opt-in.

## What Changed

- Removed external ONNX Runtime from `auto` backend ordering for `embed`, `read`, and the ClipClap e2e bench.
- Default `auto` now prefers native hosted execution paths:
  - Metal then native when Metal is built.
  - Native otherwise.
- Imported `.onnx` graph artifacts now activate Antfly’s graph runtime by default, falling back to the interpreter when no explicit `--graph-runtime` is provided.
- Added focused tests to lock in:
  - Imported ONNX graph runtime activation for `.onnx` files.
  - External ONNX Runtime remaining opt-in.
  - `embed --backend auto` not selecting ORT by default.

## Why

The CLI help said graph runtime defaults to environment fallback, then interpreter, but imported ONNX graph sessions were only used when `--graph-runtime` was explicitly set. That made `antfly inference embed antflydb/clipclap --text hi` fall through to direct native/Metal loading and fail on ONNX projection sidecars.

## Validation

- `git diff --check`
- Focused Zig tests for backend ordering and imported graph runtime routing
- Live HF `antflydb/clipclap` GGUF text embedding: passed
- Live HF `antflydb/clipclap` GGUF audio embedding: passed
- Live HF ONNX text embedding with `--backend onnx`: passed

## Notes

External ONNX Runtime still works when explicitly requested with `--backend onnx`; it is just no longer the default.