### PR TITLE
Fix CLIP image preprocessing and Metal parity

### DIFF
--- a/zig/lib/image/src/jpeg.zig
+++ b/zig/lib/image/src/jpeg.zig
@@ -1238,6 +1238,44 @@ pub fn decodeRgba(alloc: Allocator, jpeg_bytes: []const u8) !DecodedImage {
     return error.JpegDecodeFailed;
 }
 
+pub fn preprocessClipChw(
+    alloc: Allocator,
+    jpeg_bytes: []const u8,
+    target_size: u32,
+    mean: [3]f32,
+    std_dev: [3]f32,
+) ![]f32 {
+    return preprocessClipChwWithOptions(alloc, jpeg_bytes, target_size, mean, std_dev, false);
+}
+
+/// CLIP JPEG preprocessing using JPEG DCT scaling. This is a speed/quality
+/// tradeoff and is not bit-identical to full decode plus resize.
+pub fn preprocessClipChwDctScaled(
+    alloc: Allocator,
+    jpeg_bytes: []const u8,
+    target_size: u32,
+    mean: [3]f32,
+    std_dev: [3]f32,
+) ![]f32 {
+    return preprocessClipChwWithOptions(alloc, jpeg_bytes, target_size, mean, std_dev, true);
+}
+
+fn preprocessClipChwWithOptions(
+    alloc: Allocator,
+    jpeg_bytes: []const u8,
+    target_size: u32,
+    mean: [3]f32,
+    std_dev: [3]f32,
+    allow_dct_scale: bool,
+) ![]f32 {
+    const structure = try parseStructure(jpeg_bytes);
+    if (target_size == 0) return error.JpegDecodeFailed;
+    if (canPureZigDecodeColorBaseline(structure)) {
+        return preprocessClipChwPureZigColorBaseline(alloc, jpeg_bytes, structure, target_size, mean, std_dev, allow_dct_scale);
+    }
+    return error.UnsupportedJpegFormat;
+}
+
 pub fn supportsPlannedLosslessDecode(structure: Structure) bool {
     if (structure.info.frame_kind != .lossless) return false;
     if (structure.info.bits_per_sample == 0 or structure.info.bits_per_sample > 16) return false;
@@ -2602,6 +2640,157 @@ fn decodeRgbaPureZigColorBaseline(
     };
 }
 
+fn preprocessClipChwPureZigColorBaseline(
+    alloc: Allocator,
+    jpeg_bytes: []const u8,
+    structure: Structure,
+    target_size: u32,
+    mean: [3]f32,
+    std_dev: [3]f32,
+    allow_dct_scale: bool,
+) ![]f32 {
+    const width = structure.info.width;
+    const height = structure.info.height;
+    const color_encoding = colorEncodingForStructure(structure) orelse return error.JpegDecodeFailed;
+    const dct_scale = if (allow_dct_scale) clipDctScale(width, height, target_size) else 1;
+
+    const scan = structure.scans[0];
+    const entropy_bytes = try scanEntropyBytes(structure, jpeg_bytes, 0);
+    var reader = EntropyBitReader.init(entropy_bytes);
+    var dc_predictors = [_]i64{0} ** max_components;
+    const restart_interval = structure.restart_interval orelse 0;
+    var restart_index: u8 = 0;
+
+    var component_dc_tables: [max_components]CanonicalHuffmanTable = undefined;
+    var component_ac_tables: [max_components]CanonicalHuffmanTable = undefined;
+    var component_quant_tables: [max_components][64]u16 = undefined;
+    var max_h: u8 = 1;
+    var max_v: u8 = 1;
+
+    for (0..structure.info.component_count) |frame_index| {
+        const component = structure.info.components[frame_index];
+        const scan_component = scan.components[frame_index];
+        component_dc_tables[frame_index] = try buildCanonicalHuffmanTable(scan.dc_tables[scan_component.dc_table_id]);
+        component_ac_tables[frame_index] = try buildCanonicalHuffmanTable(scan.ac_tables[scan_component.ac_table_id]);
+        component_quant_tables[frame_index] = quantTableNaturalOrder(structure.quant_tables[component.quant_table_id]);
+        if (component.horizontal_sampling > max_h) max_h = component.horizontal_sampling;
+        if (component.vertical_sampling > max_v) max_v = component.vertical_sampling;
+    }
+
+    const mcu_width = @as(usize, max_h) * 8;
+    const mcu_height = @as(usize, max_v) * 8;
+    const blocks_x = @divFloor(@as(usize, width) + (mcu_width - 1), mcu_width);
+    const blocks_y = @divFloor(@as(usize, height) + (mcu_height - 1), mcu_height);
+    const total_mcus = blocks_x * blocks_y;
+    var mcus_decoded: usize = 0;
+
+    var component_planes = try initComponentSamplePlanes(
+        alloc,
+        scaledDimension(width, dct_scale),
+        scaledDimension(height, dct_scale),
+        structure.info.components,
+        structure.info.component_count,
+        max_h,
+        max_v,
+    );
+    defer freeComponentSamplePlanes(alloc, &component_planes);
+
+    for (0..blocks_y) |mcu_y| {
+        for (0..blocks_x) |mcu_x| {
+            for (0..structure.info.component_count) |frame_index| {
+                const component = structure.info.components[frame_index];
+                const block_count = @as(usize, component.horizontal_sampling) * @as(usize, component.vertical_sampling);
+                for (0..block_count) |block_index| {
+                    const block = decodeBaselineBlock(
+                        &reader,
+                        component_dc_tables[frame_index],
+                        component_ac_tables[frame_index],
+                        dc_predictors[frame_index],
+                    ) catch |err| return err;
+                    dc_predictors[frame_index] = block.dc_predictor;
+
+                    const block_col = block_index % @as(usize, component.horizontal_sampling);
+                    const block_row = block_index / @as(usize, component.horizontal_sampling);
+                    const plane_block_x = mcu_x * @as(usize, component.horizontal_sampling) + block_col;
+                    const plane_block_y = mcu_y * @as(usize, component.vertical_sampling) + block_row;
+                    switch (dct_scale) {
+                        8 => writeScaledDctBlockToPlane(
+                            component_planes[frame_index],
+                            plane_block_x,
+                            plane_block_y,
+                            8,
+                            dequantizeAndInverseDctScaledNative(
+                                block.coefficients,
+                                component_quant_tables[frame_index],
+                                structure.info.bits_per_sample,
+                                8,
+                            ),
+                        ),
+                        4 => writeScaledDctBlockToPlane(
+                            component_planes[frame_index],
+                            plane_block_x,
+                            plane_block_y,
+                            4,
+                            dequantizeAndInverseDctScaledNative(
+                                block.coefficients,
+                                component_quant_tables[frame_index],
+                                structure.info.bits_per_sample,
+                                4,
+                            ),
+                        ),
+                        2 => writeScaledDctBlockToPlane(
+                            component_planes[frame_index],
+                            plane_block_x,
+                            plane_block_y,
+                            2,
+                            dequantizeAndInverseDctScaledNative(
+                                block.coefficients,
+                                component_quant_tables[frame_index],
+                                structure.info.bits_per_sample,
+                                2,
+                            ),
+                        ),
+                        else => {
+                            const spatial = dequantizeAndInverseDctNativeWithSamplePrecision(
+                                block.coefficients,
+                                component_quant_tables[frame_index],
+                                structure.info.bits_per_sample,
+                            );
+                            writeSpatialBlockToPlane(component_planes[frame_index], plane_block_x, plane_block_y, spatial);
+                        },
+                    }
+                }
+            }
+
+            mcus_decoded += 1;
+            if (restart_interval != 0 and mcus_decoded < total_mcus and mcus_decoded % restart_interval == 0) {
+                try reader.consumeExpectedRestartMarker(0xd0 + restart_index);
+                restart_index = (restart_index + 1) & 0x7;
+                dc_predictors = [_]i64{0} ** max_components;
+            }
+        }
+    }
+
+    const ts: usize = @intCast(target_size);
+    const result = try alloc.alloc(f32, 3 * ts * ts);
+    errdefer alloc.free(result);
+    writeClipColorPlanesToChw(
+        result,
+        scaledDimension(width, dct_scale),
+        scaledDimension(height, dct_scale),
+        target_size,
+        mean,
+        std_dev,
+        structure.info.bits_per_sample,
+        color_encoding,
+        structure.info.components,
+        max_h,
+        max_v,
+        component_planes,
+    );
+    return result;
+}
+
 fn decodeRgbaPureZigLossless(
     alloc: Allocator,
     jpeg_bytes: []const u8,
@@ -2807,6 +2996,29 @@ fn dequantizeAndInverseDct(coefficients: anytype, quant_table: [64]u16) [64]u8 {
     return dequantizeAndInverseDctWithSamplePrecision(coefficients, quant_table, 8);
 }
 
+fn dequantizeAndInverseDctScaledNative(
+    coefficients: anytype,
+    quant_table: [64]u16,
+    bits_per_sample: u8,
+    comptime dct_scale: u8,
+) [scaledBlockSampleCount(dct_scale)]u16 {
+    var out = std.mem.zeroes([scaledBlockSampleCount(dct_scale)]u16);
+    const sample_center: i64 = @as(i64, 1) << @as(u6, @intCast(bits_per_sample - 1));
+    const sample_max: f64 = @floatFromInt((@as(u64, 1) << @as(u6, @intCast(bits_per_sample))) - 1);
+    const dequantized = dequantizeCoefficientsSimd(coefficients, quant_table);
+    const kernel = comptime scaledDctKernel(dct_scale);
+
+    for (0..scaledBlockSampleCount(dct_scale)) |sample_index| {
+        var sum: f64 = 0.0;
+        for (0..64) |i| {
+            sum += @as(f64, @floatFromInt(dequantized[i])) * kernel[sample_index][i];
+        }
+        const sample = std.math.clamp(@round(sum + @as(f64, @floatFromInt(sample_center))), 0.0, sample_max);
+        out[sample_index] = @intFromFloat(sample);
+    }
+    return out;
+}
+
 fn dequantizeAndInverseDctNativeWithSamplePrecision(
     coefficients: anytype,
     quant_table: [64]u16,
@@ -2979,6 +3191,41 @@ fn dequantizeAndInverseDctWithSamplePrecision(
     return out;
 }
 
+fn scaledBlockSide(comptime dct_scale: u8) usize {
+    return 8 / dct_scale;
+}
+
+fn scaledBlockSampleCount(comptime dct_scale: u8) usize {
+    const side = scaledBlockSide(dct_scale);
+    return side * side;
+}
+
+fn scaledDctKernel(comptime dct_scale: u8) [scaledBlockSampleCount(dct_scale)][64]f64 {
+    @setEvalBranchQuota(10000);
+    const out_side = scaledBlockSide(dct_scale);
+    var kernel: [scaledBlockSampleCount(dct_scale)][64]f64 = undefined;
+    inline for (0..out_side) |y| {
+        inline for (0..out_side) |x| {
+            const sample_index = y * out_side + x;
+            inline for (0..8) |v| {
+                const cv: f64 = if (v == 0) 0.7071067811865476 else 1.0;
+                const cy = scaledDctCos(dct_scale, y, v);
+                inline for (0..8) |u| {
+                    const cu: f64 = if (u == 0) 0.7071067811865476 else 1.0;
+                    const cx = scaledDctCos(dct_scale, x, u);
+                    kernel[sample_index][v * 8 + u] = 0.25 * cu * cv * cx * cy;
+                }
+            }
+        }
+    }
+    return kernel;
+}
+
+fn scaledDctCos(comptime dct_scale: u8, comptime output_index: usize, comptime frequency: usize) f64 {
+    const position = (@as(f64, @floatFromInt(output_index)) + 0.5) * @as(f64, @floatFromInt(dct_scale));
+    return std.math.cos(position * @as(f64, @floatFromInt(frequency)) * std.math.pi / 8.0);
+}
+
 fn rangeLimitSampleIjpeg(value: i64, bits_per_sample: u8) i64 {
     const sample_count: i64 = @as(i64, 1) << @as(u6, @intCast(bits_per_sample));
     const center: i64 = sample_count >> 1;
@@ -3101,6 +3348,31 @@ fn writeSpatialBlockToPlane(
     }
 }
 
+fn writeScaledDctBlockToPlane(
+    plane: SamplePlane,
+    block_x: usize,
+    block_y: usize,
+    comptime dct_scale: u8,
+    block: [scaledBlockSampleCount(dct_scale)]u16,
+) void {
+    const out_side: comptime_int = 8 / dct_scale;
+    const start_x = block_x * out_side;
+    const start_y = block_y * out_side;
+    if (start_x >= plane.width or start_y >= plane.height) return;
+
+    for (0..out_side) |local_y| {
+        const sample_y = start_y + local_y;
+        if (sample_y >= plane.height) break;
+
+        const src_off = local_y * out_side;
+        const dst_off = sample_y * plane.width + start_x;
+        const copy_len = @min(out_side, plane.width - start_x);
+        for (0..copy_len) |i| {
+            plane.samples[dst_off + i] = block[src_off + i];
+        }
+    }
+}
+
 fn renderColorPlanesToRgba(
     rgba: []u8,
     width: u32,
@@ -3181,6 +3453,146 @@ fn renderColorPlanesToRgba(
             rgba[pixel_index + 3] = 0xff;
         }
     }
+}
+
+fn writeClipColorPlanesToChw(
+    result: []f32,
+    width: u32,
+    height: u32,
+    target_size: u32,
+    mean: [3]f32,
+    std_dev: [3]f32,
+    bits_per_sample: u8,
+    color_encoding: ColorEncoding,
+    components: [max_components]ComponentInfo,
+    max_h: u8,
+    max_v: u8,
+    planes: [max_components]SamplePlane,
+) void {
+    const ts: usize = @intCast(target_size);
+    const resized = clipResizeDimsForTarget(width, height, target_size);
+    const crop_left = (resized.width - target_size) / 2;
+    const crop_top = (resized.height - target_size) / 2;
+    const scale_x = @as(f32, @floatFromInt(width)) / @as(f32, @floatFromInt(resized.width));
+    const scale_y = @as(f32, @floatFromInt(height)) / @as(f32, @floatFromInt(resized.height));
+    const plane_stride = ts * ts;
+
+    for (0..ts) |y| {
+        const src_y = @as(f32, @floatFromInt(crop_top + @as(u32, @intCast(y)))) * scale_y;
+        const y0: usize = @intFromFloat(@floor(src_y));
+        const y1 = @min(y0 + 1, @as(usize, height) - 1);
+        const fy = src_y - @as(f32, @floatFromInt(y0));
+
+        for (0..ts) |x| {
+            const src_x = @as(f32, @floatFromInt(crop_left + @as(u32, @intCast(x)))) * scale_x;
+            const x0: usize = @intFromFloat(@floor(src_x));
+            const x1 = @min(x0 + 1, @as(usize, width) - 1);
+            const fx = src_x - @as(f32, @floatFromInt(x0));
+
+            const p00 = rgbAtColorPlanes(bits_per_sample, color_encoding, components, max_h, max_v, planes, x0, y0);
+            const p10 = rgbAtColorPlanes(bits_per_sample, color_encoding, components, max_h, max_v, planes, x1, y0);
+            const p01 = rgbAtColorPlanes(bits_per_sample, color_encoding, components, max_h, max_v, planes, x0, y1);
+            const p11 = rgbAtColorPlanes(bits_per_sample, color_encoding, components, max_h, max_v, planes, x1, y1);
+            const dst = y * ts + x;
+
+            inline for (0..3) |ch| {
+                const top = @as(f32, @floatFromInt(p00[ch])) * (1.0 - fx) + @as(f32, @floatFromInt(p10[ch])) * fx;
+                const bottom = @as(f32, @floatFromInt(p01[ch])) * (1.0 - fx) + @as(f32, @floatFromInt(p11[ch])) * fx;
+                const value = (top * (1.0 - fy) + bottom * fy) / 255.0;
+                result[ch * plane_stride + dst] = (value - mean[ch]) / std_dev[ch];
+            }
+        }
+    }
+}
+
+fn rgbAtColorPlanes(
+    bits_per_sample: u8,
+    color_encoding: ColorEncoding,
+    components: [max_components]ComponentInfo,
+    max_h: u8,
+    max_v: u8,
+    planes: [max_components]SamplePlane,
+    x: usize,
+    y: usize,
+) [3]u8 {
+    return switch (color_encoding) {
+        .rgb => blk: {
+            const r = samplePlaneValue(planes[0], components[0], max_h, max_v, bits_per_sample, x, y);
+            const g = samplePlaneValue(planes[1], components[1], max_h, max_v, bits_per_sample, x, y);
+            const b = samplePlaneValue(planes[2], components[2], max_h, max_v, bits_per_sample, x, y);
+            break :blk if (bits_per_sample == 8)
+                [3]u8{ @intCast(r), @intCast(g), @intCast(b) }
+            else
+                [3]u8{
+                    scaleSampleToByteWide(r, bits_per_sample),
+                    scaleSampleToByteWide(g, bits_per_sample),
+                    scaleSampleToByteWide(b, bits_per_sample),
+                };
+        },
+        .ycbcr => blk: {
+            const yy = samplePlaneValue(planes[0], components[0], max_h, max_v, bits_per_sample, x, y);
+            const cb = samplePlaneValue(planes[1], components[1], max_h, max_v, bits_per_sample, x, y);
+            const cr = samplePlaneValue(planes[2], components[2], max_h, max_v, bits_per_sample, x, y);
+            break :blk if (bits_per_sample == 8)
+                ycbcrToRgb(@intCast(yy), @intCast(cb), @intCast(cr))
+            else
+                ycbcrToRgbWide(yy, cb, cr, bits_per_sample);
+        },
+        .cmyk => blk: {
+            const c = samplePlaneValue(planes[0], components[0], max_h, max_v, bits_per_sample, x, y);
+            const m = samplePlaneValue(planes[1], components[1], max_h, max_v, bits_per_sample, x, y);
+            const yy = samplePlaneValue(planes[2], components[2], max_h, max_v, bits_per_sample, x, y);
+            const k = samplePlaneValue(planes[3], components[3], max_h, max_v, bits_per_sample, x, y);
+            break :blk if (bits_per_sample == 8)
+                invertedCmykToRgb(@intCast(c), @intCast(m), @intCast(yy), @intCast(k))
+            else
+                invertedCmykToRgbWide(c, m, yy, k, bits_per_sample);
+        },
+        .ycck => blk: {
+            const yy = samplePlaneValue(planes[0], components[0], max_h, max_v, bits_per_sample, x, y);
+            const cb = samplePlaneValue(planes[1], components[1], max_h, max_v, bits_per_sample, x, y);
+            const cr = samplePlaneValue(planes[2], components[2], max_h, max_v, bits_per_sample, x, y);
+            const k = samplePlaneValue(planes[3], components[3], max_h, max_v, bits_per_sample, x, y);
+            break :blk if (bits_per_sample == 8)
+                ycckToRgb(@intCast(yy), @intCast(cb), @intCast(cr), @intCast(k))
+            else
+                ycckToRgbWide(yy, cb, cr, k, bits_per_sample);
+        },
+    };
+}
+
+const ClipResizeDims = struct {
+    width: u32,
+    height: u32,
+};
+
+fn clipResizeDimsForTarget(width: u32, height: u32, target_size: u32) ClipResizeDims {
+    if (width <= height) {
+        return .{ .width = target_size, .height = scaledLongEdgeForTarget(height, width, target_size) };
+    }
+    return .{ .width = scaledLongEdgeForTarget(width, height, target_size), .height = target_size };
+}
+
+fn scaledLongEdgeForTarget(long_edge: u32, short_edge: u32, target_size: u32) u32 {
+    const scaled = @divFloor(@as(u64, long_edge) * @as(u64, target_size), @as(u64, short_edge));
+    return @max(target_size, @as(u32, @intCast(scaled)));
+}
+
+fn clipDctScale(width: u32, height: u32, target_size: u32) u8 {
+    const short_edge = @min(width, height);
+    if (edgeAtLeastScaledTarget(short_edge, target_size, 32)) return 8;
+    if (edgeAtLeastScaledTarget(short_edge, target_size, 8)) return 4;
+    if (edgeAtLeastScaledTarget(short_edge, target_size, 4)) return 2;
+    return 1;
+}
+
+fn edgeAtLeastScaledTarget(edge: u32, target_size: u32, scale: u32) bool {
+    return @as(u64, edge) >= @as(u64, target_size) * @as(u64, scale);
+}
+
+fn scaledDimension(value: u32, dct_scale: u8) u32 {
+    if (dct_scale == 1) return value;
+    return @intCast(@divFloor(@as(usize, value) + @as(usize, dct_scale) - 1, @as(usize, dct_scale)));
 }
 
 fn canRenderDirectRgb8(
@@ -4219,6 +4631,69 @@ test "decode rgba matches manifest-backed white fixture" {
     const actual_hex = try test_support.sha256HexAlloc(alloc, decoded.rgba);
     defer alloc.free(actual_hex);
     try std.testing.expectEqualStrings(fixture.pixel_hashes[0], actual_hex);
+}
+
+test "preprocess clip chw matches full decode resize crop on 420 fixture" {
+    const alloc = std.testing.allocator;
+    const fixture_bytes = try test_support.readFixtureAlloc(alloc, std.testing.io, "jpeg/upstream/libjpeg_turbo_seed_corpora/8x8_420.jpg");
+    defer alloc.free(fixture_bytes);
+
+    const full = try decodeRgba(alloc, fixture_bytes);
+    defer alloc.free(full.rgba);
+    const target_size: u32 = 4;
+    const fast = try preprocessClipChw(alloc, fixture_bytes, target_size, .{ 0.0, 0.0, 0.0 }, .{ 1.0, 1.0, 1.0 });
+    defer alloc.free(fast);
+
+    try std.testing.expectEqual(@as(u32, 8), full.width);
+    try std.testing.expectEqual(@as(u32, 8), full.height);
+    try std.testing.expectEqual(@as(usize, 3 * 4 * 4), fast.len);
+
+    const ts: usize = @intCast(target_size);
+    const resized = clipResizeDimsForTarget(full.width, full.height, target_size);
+    const crop_left = (resized.width - target_size) / 2;
+    const crop_top = (resized.height - target_size) / 2;
+    const scale_x = @as(f32, @floatFromInt(full.width)) / @as(f32, @floatFromInt(resized.width));
+    const scale_y = @as(f32, @floatFromInt(full.height)) / @as(f32, @floatFromInt(resized.height));
+
+    for (0..ts) |y| {
+        const src_y = @as(f32, @floatFromInt(crop_top + @as(u32, @intCast(y)))) * scale_y;
+        const y0: usize = @intFromFloat(@floor(src_y));
+        const y1 = @min(y0 + 1, @as(usize, full.height) - 1);
+        const fy = src_y - @as(f32, @floatFromInt(y0));
+        for (0..ts) |x| {
+            const src_x = @as(f32, @floatFromInt(crop_left + @as(u32, @intCast(x)))) * scale_x;
+            const x0: usize = @intFromFloat(@floor(src_x));
+            const x1 = @min(x0 + 1, @as(usize, full.width) - 1);
+            const fx = src_x - @as(f32, @floatFromInt(x0));
+            inline for (0..3) |ch| {
+                const p00 = @as(f32, @floatFromInt(full.rgba[(y0 * @as(usize, full.width) + x0) * 4 + ch]));
+                const p10 = @as(f32, @floatFromInt(full.rgba[(y0 * @as(usize, full.width) + x1) * 4 + ch]));
+                const p01 = @as(f32, @floatFromInt(full.rgba[(y1 * @as(usize, full.width) + x0) * 4 + ch]));
+                const p11 = @as(f32, @floatFromInt(full.rgba[(y1 * @as(usize, full.width) + x1) * 4 + ch]));
+                const top = p00 * (1.0 - fx) + p10 * fx;
+                const bottom = p01 * (1.0 - fx) + p11 * fx;
+                const expected = (top * (1.0 - fy) + bottom * fy) / 255.0;
+                try std.testing.expectApproxEqAbs(expected, fast[ch * ts * ts + y * ts + x], 1e-6);
+            }
+        }
+    }
+}
+
+test "preprocess clip chw uses scaled dct path when source is large enough" {
+    const alloc = std.testing.allocator;
+    const fixture_bytes = try test_support.readFixtureAlloc(alloc, std.testing.io, "jpeg/upstream/libjpeg_turbo_seed_corpora/8x8_420.jpg");
+    defer alloc.free(fixture_bytes);
+
+    try std.testing.expectEqual(@as(u8, 4), clipDctScale(8, 8, 1));
+    try std.testing.expectEqual(@as(u8, 8), clipDctScale(32, 32, 1));
+    const fast = try preprocessClipChwDctScaled(alloc, fixture_bytes, 1, .{ 0.0, 0.0, 0.0 }, .{ 1.0, 1.0, 1.0 });
+    defer alloc.free(fast);
+
+    try std.testing.expectEqual(@as(usize, 3), fast.len);
+    for (fast) |value| {
+        try std.testing.expect(std.math.isFinite(value));
+        try std.testing.expect(value >= 0.0 and value <= 1.0);
+    }
 }
 
 test "probe matches manifest-backed baseline jpeg metadata" {

--- a/zig/pkg/inference/src/architectures/clip.zig
+++ b/zig/pkg/inference/src/architectures/clip.zig
@@ -373,12 +373,18 @@ fn selfAttn(
     const v_b = try cb.getWeight(try fmt(&v_b_buf, "{s}.{d}.self_attn.v_proj.bias", .{ prefix, layer }));
 
     const qkv = try cb.linearTriple(input, q_w, q_b, k_w, k_b, v_w, v_b, total, hidden, hidden);
-    const Q = qkv.first;
-    const K = qkv.second;
-    const V = qkv.third;
-    defer cb.free(Q);
-    defer cb.free(K);
-    defer cb.free(V);
+    const Q_token = qkv.first;
+    const K_token = qkv.second;
+    const V_token = qkv.third;
+    defer cb.free(Q_token);
+    defer cb.free(K_token);
+    defer cb.free(V_token);
+    const Q = if (causal) Q_token else try packTokenMajorToHeadMajor(cb, allocator, Q_token, batch, seq_len, num_heads, head_dim);
+    defer if (!causal) cb.free(Q);
+    const K = if (causal) K_token else try packTokenMajorToHeadMajor(cb, allocator, K_token, batch, seq_len, num_heads, head_dim);
+    defer if (!causal) cb.free(K);
+    const V = if (causal) V_token else try packTokenMajorToHeadMajor(cb, allocator, V_token, batch, seq_len, num_heads, head_dim);
+    defer if (!causal) cb.free(V);
 
     const attn_out = if (causal)
         try cb.causalSelfAttention(Q, K, V, null, batch, seq_len, num_heads, head_dim)
@@ -389,16 +395,19 @@ fn selfAttn(
         break :blk try cb.scaledDotProductAttention(Q, K, V, ones, null, batch, seq_len, num_heads, head_dim);
     };
     defer cb.free(attn_out);
+    const projected_input = if (causal) attn_out else try unpackHeadMajorToTokenMajor(cb, allocator, attn_out, batch, seq_len, num_heads, head_dim);
+    defer if (!causal) cb.free(projected_input);
 
     var o_w_buf: [128]u8 = undefined;
     var o_b_buf: [128]u8 = undefined;
     const o_w = try cb.getWeight(try fmt(&o_w_buf, "{s}.{d}.self_attn.out_proj.weight", .{ prefix, layer }));
     const o_b = try cb.getWeight(try fmt(&o_b_buf, "{s}.{d}.self_attn.out_proj.bias", .{ prefix, layer }));
-    return (try cb.linearAdd(attn_out, o_w, o_b, residual, total, hidden, hidden)) orelse blk: {
-        const projected = try cb.linear(attn_out, o_w, o_b, total, hidden, hidden);
+    const projected = (try cb.linearAdd(projected_input, o_w, o_b, residual, total, hidden, hidden)) orelse blk: {
+        const projected = try cb.linear(projected_input, o_w, o_b, total, hidden, hidden);
         defer cb.free(projected);
         break :blk try cb.add(residual, projected);
     };
+    return projected;
 }
 
 fn packTokenMajorToHeadMajor(

--- a/zig/pkg/inference/src/pipelines/image.zig
+++ b/zig/pkg/inference/src/pipelines/image.zig
@@ -110,6 +110,57 @@ pub fn decode(allocator: std.mem.Allocator, image_bytes: []const u8) !Image {
     return error.ImageDecodeFailed;
 }
 
+fn decodeRgba(allocator: std.mem.Allocator, image_bytes: []const u8) !Image {
+    if (isPng(image_bytes)) {
+        const decoded = antfly_image.png.decodeRgba(allocator, image_bytes) catch |err| switch (err) {
+            error.PngDecodeFailed, error.UnsupportedPngFormat => return error.ImageDecodeFailed,
+            else => return err,
+        };
+        return .{
+            .data = decoded.rgba,
+            .width = decoded.width,
+            .height = decoded.height,
+            .channels = 4,
+        };
+    }
+
+    if (isJpeg(image_bytes)) {
+        const decoded = antfly_image.jpeg.decodeRgba(allocator, image_bytes) catch |err| switch (err) {
+            error.JpegDecodeFailed => return error.ImageDecodeFailed,
+            else => return err,
+        };
+        return .{
+            .data = decoded.rgba,
+            .width = decoded.width,
+            .height = decoded.height,
+            .channels = 4,
+        };
+    }
+
+    if (isGif(image_bytes)) {
+        const frames = antfly_image.gif.decodeFramesAlloc(allocator, image_bytes) catch |err| switch (err) {
+            error.GifDecodeFailed, error.UnsupportedGifFormat => return error.ImageDecodeFailed,
+            else => return err,
+        };
+        errdefer {
+            for (frames) |frame| allocator.free(frame.rgba);
+            allocator.free(frames);
+        }
+        if (frames.len == 0) return error.ImageDecodeFailed;
+        const first = frames[0];
+        for (frames[1..]) |frame| allocator.free(frame.rgba);
+        allocator.free(frames);
+        return .{
+            .data = first.rgba,
+            .width = first.width,
+            .height = first.height,
+            .channels = 4,
+        };
+    }
+
+    return error.ImageDecodeFailed;
+}
+
 fn rgbaToRgbAlloc(allocator: std.mem.Allocator, rgba: []const u8) ![]u8 {
     if (rgba.len % 4 != 0) return error.ImageDecodeFailed;
     const pixel_count = rgba.len / 4;
@@ -185,21 +236,17 @@ test "decode rejects unsupported image format" {
     try std.testing.expectError(error.ImageDecodeFailed, decode(alloc, "not-an-image"));
 }
 
-test "clip preprocessing center crops before resize" {
+test "clip preprocessing resizes short edge before center crop" {
     var rgb = [_]u8{
-        10, 0, 0,
-        20, 0, 0,
-        30, 0, 0,
-        40, 0, 0,
-        50, 0, 0,
-        60, 0, 0,
-        70, 0, 0,
-        80, 0, 0,
+        0, 0, 0, 10, 0, 0, 20, 0, 0, 30, 0, 0, 40, 0, 0, 50, 0, 0, 60, 0, 0, 70, 0, 0,
+        0, 0, 0, 10, 0, 0, 20, 0, 0, 30, 0, 0, 40, 0, 0, 50, 0, 0, 60, 0, 0, 70, 0, 0,
+        0, 0, 0, 10, 0, 0, 20, 0, 0, 30, 0, 0, 40, 0, 0, 50, 0, 0, 60, 0, 0, 70, 0, 0,
+        0, 0, 0, 10, 0, 0, 20, 0, 0, 30, 0, 0, 40, 0, 0, 50, 0, 0, 60, 0, 0, 70, 0, 0,
     };
     const img = Image{
         .data = rgb[0..],
-        .width = 4,
-        .height = 2,
+        .width = 8,
+        .height = 4,
         .channels = 3,
     };
     var out: [12]f32 = undefined;
@@ -213,12 +260,12 @@ test "clip preprocessing center crops before resize" {
     );
 
     try std.testing.expectApproxEqAbs(@as(f32, 20.0 / 255.0), out[0], 1e-6);
-    try std.testing.expectApproxEqAbs(@as(f32, 30.0 / 255.0), out[1], 1e-6);
-    try std.testing.expectApproxEqAbs(@as(f32, 60.0 / 255.0), out[2], 1e-6);
-    try std.testing.expectApproxEqAbs(@as(f32, 70.0 / 255.0), out[3], 1e-6);
+    try std.testing.expectApproxEqAbs(@as(f32, 40.0 / 255.0), out[1], 1e-6);
+    try std.testing.expectApproxEqAbs(@as(f32, 20.0 / 255.0), out[2], 1e-6);
+    try std.testing.expectApproxEqAbs(@as(f32, 40.0 / 255.0), out[3], 1e-6);
 }
 
-test "clip preprocessing uses legacy resize source coordinates" {
+test "clip preprocessing uses resize source coordinates" {
     var rgb = [_]u8{
         0,   0, 0,
         10,  0, 0,
@@ -250,6 +297,77 @@ test "clip preprocessing uses legacy resize source coordinates" {
     for (expected_red, 0..) |expected, i| {
         try std.testing.expectApproxEqAbs(expected / 255.0, out[i], 1e-6);
     }
+}
+
+test "clip preprocessing accepts decoded rgba without changing rgb result" {
+    var rgb = [_]u8{
+        10,  20,  30,
+        40,  50,  60,
+        70,  80,  90,
+        100, 110, 120,
+    };
+    var rgba = [_]u8{
+        10,  20,  30,  255,
+        40,  50,  60,  128,
+        70,  80,  90,  64,
+        100, 110, 120, 0,
+    };
+    const rgb_img = Image{
+        .data = rgb[0..],
+        .width = 2,
+        .height = 2,
+        .channels = 3,
+    };
+    const rgba_img = Image{
+        .data = rgba[0..],
+        .width = 2,
+        .height = 2,
+        .channels = 4,
+    };
+    var rgb_out: [12]f32 = undefined;
+    var rgba_out: [12]f32 = undefined;
+
+    preprocessDecodedClip(
+        rgb_img,
+        &rgb_out,
+        2,
+        .{ 0.0, 0.0, 0.0 },
+        .{ 1.0, 1.0, 1.0 },
+    );
+    preprocessDecodedClip(
+        rgba_img,
+        &rgba_out,
+        2,
+        .{ 0.0, 0.0, 0.0 },
+        .{ 1.0, 1.0, 1.0 },
+    );
+
+    try std.testing.expectEqualSlices(f32, &rgb_out, &rgba_out);
+}
+
+test "clip batch preprocessing matches single image preprocessing" {
+    const alloc = std.testing.allocator;
+    const images = [_][]const u8{ red_png_2x2[0..], red_png_2x2[0..] };
+
+    const batch = try preprocessClipBatch(
+        alloc,
+        &images,
+        2,
+        .{ 0.0, 0.0, 0.0 },
+        .{ 1.0, 1.0, 1.0 },
+    );
+    defer alloc.free(batch);
+    const single = try preprocessClipBatch(
+        alloc,
+        images[0..1],
+        2,
+        .{ 0.0, 0.0, 0.0 },
+        .{ 1.0, 1.0, 1.0 },
+    );
+    defer alloc.free(single);
+
+    try std.testing.expectEqualSlices(f32, single, batch[0..single.len]);
+    try std.testing.expectEqualSlices(f32, single, batch[single.len .. single.len * 2]);
 }
 
 test "decode png fixture dimensions are stable" {
@@ -680,16 +798,8 @@ pub fn preprocessBatch(
     return result;
 }
 
-/// Preprocess CLIP embedding images using Antfly's CLIP runtime contract.
-///
-/// The math intentionally matches the legacy Go termite CLIP path in
-/// go/pkg/termite/lib/pipelines/image.go: crop a centered target_size window
-/// capped by source dimensions, resize that crop to target_size using source
-/// coordinates `dst * src_dim / target_dim`, and normalize to CHW f32.
-///
-/// This is not the generic vision preprocessor. Use it only for CLIP/ClipClap
-/// image embeddings that must stay compatible with vectors produced by the
-/// legacy Go runtime.
+/// Preprocess CLIP embedding images: resize the shortest edge to target_size,
+/// center crop target_size x target_size, and normalize to CHW f32.
 pub fn preprocessClipBatch(
     allocator: std.mem.Allocator,
     image_list: []const []const u8,
@@ -702,12 +812,15 @@ pub fn preprocessClipBatch(
     const result = try allocator.alloc(f32, image_list.len * per_image);
     errdefer allocator.free(result);
 
-    for (image_list, 0..) |image_bytes, i| {
-        const img = try decode(allocator, image_bytes);
-        defer img.deinit(allocator);
+    if (image_list.len > 1) {
+        try preprocessClipBatchParallel(image_list, result, per_image, target_size, mean, std_dev);
+        return result;
+    }
 
-        preprocessDecodedClip(
-            img,
+    for (image_list, 0..) |image_bytes, i| {
+        try preprocessClipImage(
+            allocator,
+            image_bytes,
             result[i * per_image ..][0..per_image],
             target_size,
             mean,
@@ -716,6 +829,140 @@ pub fn preprocessClipBatch(
     }
 
     return result;
+}
+
+const max_clip_preprocess_threads: usize = 8;
+
+const ClipPreprocessBatch = struct {
+    image_list: []const []const u8,
+    result: []f32,
+    per_image: usize,
+    target_size: u32,
+    mean: [3]f32,
+    std_dev: [3]f32,
+    next: std.atomic.Value(usize) = .{ .raw = 0 },
+};
+
+const ClipPreprocessWorker = struct {
+    batch: *ClipPreprocessBatch,
+    err: ?anyerror = null,
+
+    fn run(self: *ClipPreprocessWorker) void {
+        const allocator = std.heap.page_allocator;
+
+        while (true) {
+            const i = self.batch.next.fetchAdd(1, .monotonic);
+            if (i >= self.batch.image_list.len) return;
+
+            preprocessClipImage(
+                allocator,
+                self.batch.image_list[i],
+                self.batch.result[i * self.batch.per_image ..][0..self.batch.per_image],
+                self.batch.target_size,
+                self.batch.mean,
+                self.batch.std_dev,
+            ) catch |err| {
+                self.err = err;
+                return;
+            };
+        }
+    }
+};
+
+fn preprocessClipBatchParallel(
+    image_list: []const []const u8,
+    result: []f32,
+    per_image: usize,
+    target_size: u32,
+    mean: [3]f32,
+    std_dev: [3]f32,
+) !void {
+    const cpu_count = std.Thread.getCpuCount() catch 1;
+    const thread_count = @min(image_list.len, @min(cpu_count, max_clip_preprocess_threads));
+    if (thread_count <= 1) {
+        const allocator = std.heap.page_allocator;
+        for (image_list, 0..) |image_bytes, i| {
+            try preprocessClipImage(
+                allocator,
+                image_bytes,
+                result[i * per_image ..][0..per_image],
+                target_size,
+                mean,
+                std_dev,
+            );
+        }
+        return;
+    }
+
+    var batch = ClipPreprocessBatch{
+        .image_list = image_list,
+        .result = result,
+        .per_image = per_image,
+        .target_size = target_size,
+        .mean = mean,
+        .std_dev = std_dev,
+    };
+    var workers: [max_clip_preprocess_threads]ClipPreprocessWorker = undefined;
+    var threads: [max_clip_preprocess_threads]std.Thread = undefined;
+    var spawned: usize = 0;
+
+    while (spawned < thread_count) : (spawned += 1) {
+        workers[spawned] = .{ .batch = &batch };
+        threads[spawned] = std.Thread.spawn(.{}, ClipPreprocessWorker.run, .{&workers[spawned]}) catch |err| {
+            for (threads[0..spawned]) |thread| thread.join();
+            return err;
+        };
+    }
+    for (threads[0..spawned]) |thread| thread.join();
+    for (workers[0..spawned]) |worker| {
+        if (worker.err) |err| return err;
+    }
+}
+
+fn preprocessClipImage(
+    allocator: std.mem.Allocator,
+    image_bytes: []const u8,
+    result: []f32,
+    target_size: u32,
+    mean: [3]f32,
+    std_dev: [3]f32,
+) !void {
+    if (isJpeg(image_bytes)) {
+        const fast = preprocessClipJpegChw(allocator, image_bytes, target_size, mean, std_dev) catch |err| switch (err) {
+            error.UnsupportedJpegFormat => null,
+            error.JpegDecodeFailed => return error.ImageDecodeFailed,
+            else => return err,
+        };
+        if (fast) |chw| {
+            defer allocator.free(chw);
+            @memcpy(result, chw);
+            return;
+        }
+    }
+
+    const img = try decodeRgba(allocator, image_bytes);
+    defer img.deinit(allocator);
+    preprocessDecodedClip(img, result, target_size, mean, std_dev);
+}
+
+fn preprocessClipJpegChw(
+    allocator: std.mem.Allocator,
+    image_bytes: []const u8,
+    target_size: u32,
+    mean: [3]f32,
+    std_dev: [3]f32,
+) ![]f32 {
+    if (clipJpegDctScaleEnabled()) {
+        // Opt-in only: DCT scaling is faster but changes the resulting CLIP tensor.
+        return antfly_image.jpeg.preprocessClipChwDctScaled(allocator, image_bytes, target_size, mean, std_dev);
+    }
+    return antfly_image.jpeg.preprocessClipChw(allocator, image_bytes, target_size, mean, std_dev);
+}
+
+fn clipJpegDctScaleEnabled() bool {
+    const raw = std.c.getenv("TERMITE_CLIP_JPEG_DCT_SCALE") orelse return false;
+    const value = std.mem.span(raw);
+    return std.mem.eql(u8, value, "1") or std.mem.eql(u8, value, "true") or std.mem.eql(u8, value, "TRUE");
 }
 
 fn preprocessDecodedClip(
@@ -729,34 +976,93 @@ fn preprocessDecodedClip(
     std.debug.assert(img.width > 0 and img.height > 0);
 
     const ts: usize = target_size;
-    const crop_w: u32 = @min(img.width, target_size);
-    const crop_h: u32 = @min(img.height, target_size);
-    const crop_left: u32 = (img.width - crop_w) / 2;
-    const crop_top: u32 = (img.height - crop_h) / 2;
-    const scale_x = @as(f32, @floatFromInt(crop_w)) / @as(f32, @floatFromInt(target_size));
-    const scale_y = @as(f32, @floatFromInt(crop_h)) / @as(f32, @floatFromInt(target_size));
+    const resized = clipResizeDims(img.width, img.height, target_size);
+    const resized_w = resized.width;
+    const resized_h = resized.height;
+    const crop_left = (resized_w - target_size) / 2;
+    const crop_top = (resized_h - target_size) / 2;
+    const scale_x = @as(f32, @floatFromInt(img.width)) / @as(f32, @floatFromInt(resized_w));
+    const scale_y = @as(f32, @floatFromInt(img.height)) / @as(f32, @floatFromInt(resized_h));
+
+    if (img.width == target_size and img.height == target_size) {
+        preprocessClipCenterCropNoResize(img, result, ts, 0, 0, mean, std_dev);
+        return;
+    }
 
     for (0..ts) |y| {
-        const src_y = @as(f32, @floatFromInt(y)) * scale_y;
+        const src_y = @as(f32, @floatFromInt(crop_top + @as(u32, @intCast(y)))) * scale_y;
         const y0: u32 = @intFromFloat(@floor(src_y));
-        const y1: u32 = @min(y0 + 1, crop_h - 1);
+        const y1: u32 = @min(y0 + 1, img.height - 1);
         const fy = src_y - @as(f32, @floatFromInt(y0));
 
         for (0..ts) |x| {
-            const src_x = @as(f32, @floatFromInt(x)) * scale_x;
+            const src_x = @as(f32, @floatFromInt(crop_left + @as(u32, @intCast(x)))) * scale_x;
             const x0: u32 = @intFromFloat(@floor(src_x));
-            const x1: u32 = @min(x0 + 1, crop_w - 1);
+            const x1: u32 = @min(x0 + 1, img.width - 1);
             const fx = src_x - @as(f32, @floatFromInt(x0));
 
             for (0..3) |ch| {
-                const p00 = pixelAt(img, crop_left + x0, crop_top + y0, ch);
-                const p10 = pixelAt(img, crop_left + x1, crop_top + y0, ch);
-                const p01 = pixelAt(img, crop_left + x0, crop_top + y1, ch);
-                const p11 = pixelAt(img, crop_left + x1, crop_top + y1, ch);
+                const p00 = pixelAt(img, x0, y0, ch);
+                const p10 = pixelAt(img, x1, y0, ch);
+                const p01 = pixelAt(img, x0, y1, ch);
+                const p11 = pixelAt(img, x1, y1, ch);
                 const top = p00 * (1.0 - fx) + p10 * fx;
                 const bottom = p01 * (1.0 - fx) + p11 * fx;
                 const value = top * (1.0 - fy) + bottom * fy;
                 result[ch * ts * ts + y * ts + x] = (value / 255.0 - mean[ch]) / std_dev[ch];
+            }
+        }
+    }
+}
+
+const ClipResizeDims = struct {
+    width: u32,
+    height: u32,
+};
+
+fn clipResizeDims(width: u32, height: u32, target_size: u32) ClipResizeDims {
+    if (width <= height) {
+        return .{ .width = target_size, .height = scaledLongEdge(height, width, target_size) };
+    }
+    return .{ .width = scaledLongEdge(width, height, target_size), .height = target_size };
+}
+
+fn scaledLongEdge(long_edge: u32, short_edge: u32, target_size: u32) u32 {
+    const scaled = @divFloor(@as(u64, long_edge) * @as(u64, target_size), @as(u64, short_edge));
+    return @max(target_size, @as(u32, @intCast(scaled)));
+}
+
+fn preprocessClipCenterCropNoResize(
+    img: Image,
+    result: []f32,
+    target_size: usize,
+    crop_left: u32,
+    crop_top: u32,
+    mean: [3]f32,
+    std_dev: [3]f32,
+) void {
+    const width: usize = @intCast(img.width);
+    const channels: usize = @intCast(img.channels);
+    const left: usize = @intCast(crop_left);
+    const top: usize = @intCast(crop_top);
+    const plane_stride = target_size * target_size;
+
+    const inv_std = [3]f32{
+        1.0 / std_dev[0],
+        1.0 / std_dev[1],
+        1.0 / std_dev[2],
+    };
+    const inv_255 = 1.0 / 255.0;
+
+    for (0..target_size) |y| {
+        const row_base = ((top + y) * width + left) * channels;
+        const dst_row = y * target_size;
+        for (0..target_size) |x| {
+            const src = row_base + x * channels;
+            const dst = dst_row + x;
+            inline for (0..3) |ch| {
+                const value = @as(f32, @floatFromInt(img.data[src + ch])) * inv_255;
+                result[ch * plane_stride + dst] = (value - mean[ch]) * inv_std[ch];
             }
         }
     }


### PR DESCRIPTION
## Summary

- Optimize Zig JPEG/CLIP image preprocessing for faster image loads.
- Use standard CLIP preprocessing before center crop.
- Fix CLIP vision attention layout by packing token-major Q/K/V into head-major for non-causal ViT attention, then unpacking before projection.
- Restore native/Metal image embedding parity.

## Performance

Image batch 8, 2048px JPEG inputs:

| Backend | Preprocess | Encoder | Image phase | Total | Throughput |
| --- | ---: | ---: | ---: | ---: | ---: |
| Native | `35.9ms` | `2036.8ms` | `2073ms` | `2165ms` | `3.9 img/s` |
| Metal | `25.7ms` | `706.1ms` | `732ms` | `836ms` | `10.9 img/s` |

Metal is about `2.9x` faster on encoder time and `2.6x` faster end-to-end for the image batch.

Batching on Metal:
- Before/after fix single-image encoder: ~`166-170ms/img`
- Batch 8 encoder: ~`88-90ms/img`
- About `1.9x` better per-image encoder latency from batching

## Validation

- `zig build install ... -Dmetal=true -Donnx=true`
- `zig build inference-test ... -- --test-filter "clip attention layout"`
- Full ClipClap native vs Metal smoke:
  - text cosine: `0.999746644`
  - image cosine: `0.998054091`
  - audio cosine: `0.999972751`
- Batch 8 image parity:
  - cosine min/max: `1.000000000`
  - max abs diff: `0.000000473`