### PR TITLE
Handle unsupported OCR backend paths

### DIFF
--- a/zig/build.zig
+++ b/zig/build.zig
@@ -1913,6 +1913,7 @@ pub fn build(b: *std.Build) void {
         .optimize = .ReleaseSafe,
         .single_threaded = true,
     });
+    wasm_inference_ml_mod.addImport("antfly_platform", wasm_platform_mod);
     const wasm_inference_onnx_graph_mod = b.createModule(.{
         .root_source_file = b.path("lib/onnx/src/root.zig"),
         .target = wasm_target,

--- a/zig/build.zig
+++ b/zig/build.zig
@@ -2214,6 +2214,13 @@ pub fn build(b: *std.Build) void {
     const lib_ml_tabular_test_step = b.step("lib-ml-tabular-test", "Run standalone lib/ml/tabular tests");
     lib_ml_tabular_test_step.dependOn(&run_lib_ml_tabular_tests.step);
 
+    const lib_onnx_tests = b.addTest(.{
+        .root_module = termite_onnx_graph_mod,
+    });
+    const run_lib_onnx_tests = b.addRunArtifact(lib_onnx_tests);
+    const lib_onnx_test_step = b.step("lib-onnx-test", "Run standalone lib/onnx tests");
+    lib_onnx_test_step.dependOn(&run_lib_onnx_tests.step);
+
     const fuzz_tabular_loader = b.addTest(.{
         .root_module = b.createModule(.{
             .root_source_file = b.path("lib/ml/tabular/src/fuzz_loader.zig"),
@@ -4877,6 +4884,7 @@ pub fn build(b: *std.Build) void {
     // are wired here once.
     dependOnAll(unit_test_step, &.{
         &run_lib_json_tests.step,
+        &run_lib_onnx_tests.step,
         &run_httpx_json_tests.step,
         &run_httpx_tests.step,
         &run_api_json_helpers_tests.step,

--- a/zig/build.zig
+++ b/zig/build.zig
@@ -1478,6 +1478,7 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
     });
+    termite_ml_mod.addImport("antfly_platform", platform_mod);
     const ml_tabular_mod = b.addModule("ml_tabular", .{
         .root_source_file = b.path("lib/ml/tabular/src/root.zig"),
         .target = target,

--- a/zig/e2e/inference/conftest.py
+++ b/zig/e2e/inference/conftest.py
@@ -356,7 +356,7 @@ def api(base_url):
             return payload
 
         def readyz(self):
-            r = requests.get(f"{self.base_url}/readyz", timeout=10)
+            r = requests.get(f"{self.url}/readyz", timeout=10)
             _check(r)
             return r.json()
 

--- a/zig/e2e/inference/test_read.py
+++ b/zig/e2e/inference/test_read.py
@@ -33,13 +33,13 @@ def _assert_read_result_shape(result: dict):
     assert "text" in result
     assert isinstance(result["text"], str)
 
-    if "fields" in result:
+    if result.get("fields") is not None:
         assert isinstance(result["fields"], dict)
         for key, value in result["fields"].items():
             assert isinstance(key, str)
             assert isinstance(value, str)
 
-    if "regions" in result:
+    if result.get("regions") is not None:
         assert isinstance(result["regions"], list)
         for region in result["regions"]:
             assert isinstance(region, dict)
@@ -52,7 +52,7 @@ def _assert_read_result_shape(result: dict):
                 assert isinstance(coord, (int, float))
             if "confidence" in region:
                 assert isinstance(region["confidence"], (int, float))
-            if "label" in region:
+            if region.get("label") is not None:
                 assert isinstance(region["label"], str)
 
 
@@ -285,7 +285,7 @@ def test_read_multistage_model_round_trips_richer_shape(api):
     assert len(results) == 1
     _assert_read_result_shape(results[0])
 
-    regions = results[0].get("regions", [])
+    regions = results[0].get("regions") or []
     assert len(regions) >= 1
     assert any(region["text"].strip() for region in regions)
 

--- a/zig/lib/ml/src/graph/passes/fuse.zig
+++ b/zig/lib/ml/src/graph/passes/fuse.zig
@@ -35,6 +35,7 @@
 // redirects. Unreachable nodes are dropped (implicit DCE).
 
 const std = @import("std");
+const platform = @import("antfly_platform");
 const graph_mod = @import("../graph.zig");
 const node_mod = @import("../node.zig");
 const shape_mod = @import("../shape.zig");
@@ -2797,7 +2798,7 @@ fn fuseSDPA(allocator: std.mem.Allocator, work: *Graph) !PairFusionResult {
     errdefer redirects.deinit(allocator);
     var num_rewrites: u32 = 0;
 
-    if (std.c.getenv("ANTFLY_DISABLE_SDPA_FUSION") != null) {
+    if (platform.env.getenvBool("ANTFLY_DISABLE_SDPA_FUSION")) {
         return .{ .redirects = redirects, .num_rewrites = num_rewrites };
     }
 

--- a/zig/lib/onnx/src/ops.zig
+++ b/zig/lib/onnx/src/ops.zig
@@ -607,8 +607,8 @@ fn convertSigmoid(builder: *Builder, input: NodeId) ConvertError!NodeId {
     const one = try builder.scalarConst(dtype, 1.0);
     const neg_x = try builder.neg(input);
     const exp_neg = try builder.expOp(neg_x);
-    const denom = try builder.add(one, exp_neg);
-    return builder.div(one, denom);
+    const denom = try broadcastBinaryOp(builder, .add, one, exp_neg);
+    return broadcastBinaryOp(builder, .div, one, denom);
 }
 
 fn convertSoftmax(builder: *Builder, _: *const NodeProto, input: NodeId, comptime is_log: bool) ConvertError!NodeId {
@@ -2805,8 +2805,12 @@ fn convertConv(builder: *Builder, node: *const NodeProto, inputs: []const NodeId
         const pad_begin: i64 = conv_attrs.padding[i][0];
         const pad_end: i64 = conv_attrs.padding[i][1];
         const dilation: i64 = if (i < dilations_attr.len) dilations_attr[i] else 1;
-        const effective_k = dilation * (k_d - 1) + 1;
-        out_dims[i + 2] = @divTrunc(in_d + pad_begin + pad_end - effective_k, stride) + 1;
+        if (in_d <= 0 or k_d <= 0 or stride <= 0 or dilation <= 0) {
+            out_dims[i + 2] = -1;
+        } else {
+            const effective_k = dilation * (k_d - 1) + 1;
+            out_dims[i + 2] = @divTrunc(in_d + pad_begin + pad_end - effective_k, stride) + 1;
+        }
     }
     const out_shape = Shape{ .dtype = x_shape.dtype, .dims = out_dims, .rank_ = x_shape.rank_ };
 
@@ -3907,6 +3911,11 @@ fn convertConvTranspose(builder: *Builder, node: *const NodeProto, inputs: []con
     const output_padding_attr = getInts(node.attributes, "output_padding");
     const group: u32 = @intCast(getInt(node.attributes, "group", 1));
 
+    for (0..num_spatial) |i| {
+        const stride: i64 = if (i < strides_attr.len) strides_attr[i] else 1;
+        if (stride != 1) return error.UnsupportedOp;
+    }
+
     // ConvTranspose: decompose as conv_general with adjusted padding.
     // For stride=1, ConvTranspose is conv with kernel spatially flipped and
     // padding = kernel_size - 1 - original_padding (full convolution).
@@ -3940,7 +3949,10 @@ fn convertConvTranspose(builder: *Builder, node: *const NodeProto, inputs: []con
         const out_pad: i64 = if (i < output_padding_attr.len) output_padding_attr[i] else 0;
         const effective_k = dilation * (k_d - 1) + 1;
 
-        out_dims[i + 2] = (in_d - 1) * stride - pad_begin - pad_end + effective_k + out_pad;
+        out_dims[i + 2] = if (in_d <= 0 or k_d <= 0)
+            -1
+        else
+            (in_d - 1) * stride - pad_begin - pad_end + effective_k + out_pad;
 
         // Effective padding for the transpose conv (full convolution padding)
         conv_attrs.padding[i][0] = @intCast(effective_k - 1 - pad_begin);
@@ -4011,8 +4023,12 @@ fn convertResize(builder: *Builder, node: *const NodeProto, inputs: []const Node
                 for (0..rank) |i| {
                     const s = scales_data[i];
                     const in_d = in_shape.dim(@intCast(i));
-                    out_dims[i] = @intFromFloat(@as(f32, @floatFromInt(in_d)) * s);
-                    if (out_dims[i] < 1) out_dims[i] = 1;
+                    if (in_d <= 0) {
+                        out_dims[i] = -1;
+                    } else {
+                        out_dims[i] = @intFromFloat(@as(f32, @floatFromInt(in_d)) * s);
+                        if (out_dims[i] < 1) out_dims[i] = 1;
+                    }
                     // Check if integer
                     const si: i64 = @intFromFloat(s);
                     if (s != @as(f32, @floatFromInt(si)) or si < 1) {
@@ -4051,7 +4067,7 @@ fn convertResize(builder: *Builder, node: *const NodeProto, inputs: []const Node
     // Check if all dims unchanged (no-op)
     var all_same = true;
     for (0..rank) |i| {
-        if (out_dims[i] != in_shape.dim(@intCast(i))) {
+        if (out_dims[i] != in_shape.dim(@intCast(i)) or scale_factors[i] != 1) {
             all_same = false;
             break;
         }
@@ -4142,7 +4158,8 @@ fn resizeIntegerBroadcast(builder: *Builder, input: NodeId, in_shape: Shape, ran
 
     var out_dims: [8]i64 = .{0} ** 8;
     for (0..rank) |i| {
-        out_dims[i] = in_shape.dim(@intCast(i)) * scale_factors[i];
+        const in_d = in_shape.dim(@intCast(i));
+        out_dims[i] = if (in_d <= 0) -1 else in_d * scale_factors[i];
     }
     const out_shape = Shape{
         .dtype = in_shape.dtype,
@@ -5130,6 +5147,35 @@ test "convertNode Add" {
     try std.testing.expect(std.meta.activeTag(g.node(result).op) == .add);
 }
 
+test "convertNode Add preserves dynamic non-singleton broadcast dimensions" {
+    const allocator = std.testing.allocator;
+    var g = Graph.init(allocator);
+    defer g.deinit();
+    var b = Builder.init(&g);
+
+    const x = try b.parameter("x", Shape.init(.f32, &.{ -1, 96, -1, -1 }));
+    const y = try b.parameter("y", Shape.init(.f32, &.{ 1, 96, 8, 8 }));
+    const node = NodeProto{ .op_type = "Add" };
+    const result = try convertNode(allocator, &b, &node, &.{ x, y }, null);
+    const out = g.node(result).output_shape;
+
+    try std.testing.expectEqualSlices(i64, &.{ -1, 96, -1, -1 }, out.dims[0..out.rank()]);
+}
+
+test "convertNode Sigmoid preserves dynamic input shape" {
+    const allocator = std.testing.allocator;
+    var g = Graph.init(allocator);
+    defer g.deinit();
+    var b = Builder.init(&g);
+
+    const x = try b.parameter("x", Shape.init(.f32, &.{ -1, 1, -1, -1 }));
+    const node = NodeProto{ .op_type = "Sigmoid" };
+    const result = try convertNode(allocator, &b, &node, &.{x}, null);
+    const out = g.node(result).output_shape;
+
+    try std.testing.expectEqualSlices(i64, &.{ -1, 1, -1, -1 }, out.dims[0..out.rank()]);
+}
+
 test "convertNode Relu emits fused" {
     const allocator = std.testing.allocator;
     var g = Graph.init(allocator);
@@ -5470,6 +5516,29 @@ test "convertNode Conv 2D with stride/pad/groups emits fused_conv2d" {
     try std.testing.expectEqual(@as(i64, 8), out_shape.dim(2));
     try std.testing.expectEqual(@as(i64, 8), out_shape.dim(3));
     try std.testing.expect(std.meta.activeTag(g.node(result).op) == .fused_conv2d);
+}
+
+test "convertNode Conv preserves dynamic spatial dimensions" {
+    const allocator = std.testing.allocator;
+    var g = Graph.init(allocator);
+    defer g.deinit();
+    var b = Builder.init(&g);
+
+    const x = try b.parameter("x", Shape.init(.f32, &.{ -1, 32, -1, -1 }));
+    const w = try b.parameter("w", Shape.init(.f32, &.{ 32, 32, 3, 3 }));
+    var attrs = [_]AttributeProto{
+        .{ .name = "kernel_shape", .ints = @constCast(&[_]i64{ 3, 3 }) },
+        .{ .name = "strides", .ints = @constCast(&[_]i64{ 2, 2 }) },
+        .{ .name = "pads", .ints = @constCast(&[_]i64{ 1, 1, 1, 1 }) },
+    };
+    const node = NodeProto{ .op_type = "Conv", .attributes = &attrs };
+    const result = try convertNode(allocator, &b, &node, &.{ x, w }, null);
+    const out_shape = g.node(result).output_shape;
+
+    try std.testing.expectEqual(@as(i64, -1), out_shape.dim(0));
+    try std.testing.expectEqual(@as(i64, 32), out_shape.dim(1));
+    try std.testing.expectEqual(@as(i64, -1), out_shape.dim(2));
+    try std.testing.expectEqual(@as(i64, -1), out_shape.dim(3));
 }
 
 test "convertNode Conv falls back to conv_general on dilation" {
@@ -5986,6 +6055,25 @@ test "convertNode Resize nearest 2x with scales" {
     try std.testing.expectEqual(@as(i64, 1), out.dim(1));
     try std.testing.expectEqual(@as(i64, 4), out.dim(2));
     try std.testing.expectEqual(@as(i64, 6), out.dim(3));
+}
+
+test "convertNode Resize integer scale preserves dynamic spatial dimensions" {
+    const allocator = std.testing.allocator;
+    var g = Graph.init(allocator);
+    defer g.deinit();
+    var b = Builder.init(&g);
+
+    const x = try b.parameter("x", Shape.init(.f32, &.{ -1, 96, -1, -1 }));
+    const roi = try b.tensorConst(&.{}, Shape.init(.f32, &.{0}));
+    const scales = try b.tensorConst(&.{ 1.0, 1.0, 8.0, 8.0 }, Shape.init(.f32, &.{4}));
+    const node = NodeProto{ .op_type = "Resize" };
+    const result = try convertNode(allocator, &b, &node, &.{ x, roi, scales }, null);
+    const out = g.node(result).output_shape;
+
+    try std.testing.expectEqual(@as(i64, -1), out.dim(0));
+    try std.testing.expectEqual(@as(i64, 96), out.dim(1));
+    try std.testing.expectEqual(@as(i64, -1), out.dim(2));
+    try std.testing.expectEqual(@as(i64, -1), out.dim(3));
 }
 
 test "convertNode Resize nearest with output sizes" {
@@ -6958,7 +7046,7 @@ test "convertNode ConvTranspose 1D" {
     try std.testing.expectEqual(@as(i64, 10), out_shape.dim(2));
 }
 
-test "convertNode ConvTranspose 2D with stride" {
+test "convertNode ConvTranspose 2D with stride is unsupported until native upsampling is exact" {
     const allocator = std.testing.allocator;
     var g = Graph.init(allocator);
     defer g.deinit();
@@ -6972,13 +7060,7 @@ test "convertNode ConvTranspose 2D with stride" {
         .{ .name = "strides", .ints = &strides },
     };
     const node = NodeProto{ .op_type = "ConvTranspose", .attributes = &attrs };
-    const result = try convertNode(allocator, &b, &node, &.{ x, w }, null);
-    const out_shape = g.node(result).output_shape;
-    // out = (4-1)*2 + 3 = 9
-    try std.testing.expectEqual(@as(i64, 1), out_shape.dim(0));
-    try std.testing.expectEqual(@as(i64, 2), out_shape.dim(1));
-    try std.testing.expectEqual(@as(i64, 9), out_shape.dim(2));
-    try std.testing.expectEqual(@as(i64, 9), out_shape.dim(3));
+    try std.testing.expectError(error.UnsupportedOp, convertNode(allocator, &b, &node, &.{ x, w }, null));
 }
 
 test "convertNode ConvTranspose with bias" {

--- a/zig/pkg/inference/build.zig
+++ b/zig/pkg/inference/build.zig
@@ -1304,6 +1304,7 @@ pub fn build(b: *std.Build) void {
             .optimize = .ReleaseSafe,
             .single_threaded = true,
         });
+        wasm_ml_mod.addImport("antfly_platform", wasm_platform_mod);
         const wasm_onnx_graph_mod = b.createModule(.{
             .root_source_file = b.path(b.fmt("{s}/lib/onnx/src/root.zig", .{shared_lib_root})),
             .target = wasm_target,

--- a/zig/pkg/inference/build/runtime.zig
+++ b/zig/pkg/inference/build/runtime.zig
@@ -181,7 +181,11 @@ pub fn create(config: Config) Graph {
     });
     const protobuf_mod = shared.protobuf orelse protobuf_dep.module("protobuf");
     const sentencepiece_proto_mod = shared.sentencepiece_proto orelse addSentencePieceProtoModule(b, protobuf_dep, paths, config.register_public_modules);
-    const ml_mod = shared.ml orelse createSharedModuleNamed(config, "ml", "lib/ml/src/root.zig");
+    const ml_mod = shared.ml orelse blk: {
+        const mod = createSharedModuleNamed(config, "ml", "lib/ml/src/root.zig");
+        mod.addImport("antfly_platform", platform_mod);
+        break :blk mod;
+    };
     const ml_tabular_mod = shared.ml_tabular orelse createSharedModuleNamed(config, "ml_tabular", "lib/ml/tabular/src/root.zig");
     const onnx_graph_mod = shared.onnx_graph orelse blk: {
         const mod = b.dependency("onnx_graph", .{

--- a/zig/pkg/inference/src/graph/interpreter.zig
+++ b/zig/pkg/inference/src/graph/interpreter.zig
@@ -1332,6 +1332,8 @@ fn resolveRuntimeReshapeDims(actual: []const i64, declared: Shape, target: Shape
     }
 
     if (countNegativeDims(out[0..rank]) > 1) {
+        if (resolveRuntimeCollapsedResizeDims(actual, target, input_numel, out)) |resolved| return resolved;
+        if (resolveRuntimeInterleavedResizeDims(actual, target, input_numel, out)) |resolved| return resolved;
         if (resolveRuntimeSplitLastDim(actual, target, input_numel, out)) |resolved| return resolved;
         if (resolveRuntimeAlignedDynamicDims(actual, target, input_numel, out)) |resolved| return resolved;
     }
@@ -1339,6 +1341,51 @@ fn resolveRuntimeReshapeDims(actual: []const i64, declared: Shape, target: Shape
     if (countNegativeDims(out[0..rank]) <= 1 and resolveSingleInferredDim(out[0..rank], input_numel)) {
         return out[0..rank];
     }
+    return null;
+}
+
+fn resolveRuntimeCollapsedResizeDims(actual: []const i64, target: Shape, input_numel: usize, out: *[8]i64) ?[]const i64 {
+    const rank = target.rank();
+    if (actual.len != rank * 2 or rank == 0 or rank > out.len) return null;
+
+    for (0..rank) |i| {
+        const copied_axis = i * 2;
+        const scale_axis = copied_axis + 1;
+        const copied_dim = actual[copied_axis];
+        const scale_dim = actual[scale_axis];
+        if (copied_dim <= 0 or scale_dim <= 0) return null;
+
+        const target_dim = target.dim(@intCast(i));
+        const resolved_dim = std.math.mul(i64, copied_dim, scale_dim) catch return null;
+        if (target_dim > 0 and target_dim != resolved_dim) return null;
+        out[i] = resolved_dim;
+    }
+
+    if (safeElementCountFromDims(out[0..rank]) == input_numel) return out[0..rank];
+    return null;
+}
+
+fn resolveRuntimeInterleavedResizeDims(actual: []const i64, target: Shape, input_numel: usize, out: *[8]i64) ?[]const i64 {
+    const rank = target.rank();
+    if (rank != actual.len * 2 or rank > out.len or actual.len == 0) return null;
+
+    for (0..actual.len) |i| {
+        const source_dim = actual[i];
+        if (source_dim <= 0) return null;
+
+        const copied_axis = i * 2;
+        const inserted_axis = copied_axis + 1;
+        const copied_dim = target.dim(@intCast(copied_axis));
+        const inserted_dim = target.dim(@intCast(inserted_axis));
+
+        if (copied_dim > 0 and copied_dim != source_dim) return null;
+        if (inserted_dim != 1) return null;
+
+        out[copied_axis] = source_dim;
+        out[inserted_axis] = 1;
+    }
+
+    if (safeElementCountFromDims(out[0..rank]) == input_numel) return out[0..rank];
     return null;
 }
 
@@ -3798,6 +3845,30 @@ test "resolveRuntimeReshapeDims preserves dynamic leading axes when splitting hi
     try std.testing.expectEqualSlices(i64, &.{ 3, 512, 2, 64 }, resolved);
 }
 
+test "resolveRuntimeReshapeDims preserves dynamic resize interleaved axes" {
+    var out: [8]i64 = undefined;
+    const resolved = resolveRuntimeReshapeDims(
+        &.{ 1, 24, 120, 120 },
+        Shape.init(.f32, &.{ -1, 24, -1, -1 }),
+        Shape.init(.f32, &.{ -1, 1, 24, 1, -1, 1, -1, 1 }),
+        &out,
+    ) orelse return error.TestUnexpectedResult;
+
+    try std.testing.expectEqualSlices(i64, &.{ 1, 1, 24, 1, 120, 1, 120, 1 }, resolved);
+}
+
+test "resolveRuntimeReshapeDims collapses dynamic resize interleaved axes" {
+    var out: [8]i64 = undefined;
+    const resolved = resolveRuntimeReshapeDims(
+        &.{ 1, 1, 24, 1, 120, 8, 120, 8 },
+        Shape.init(.f32, &.{ -1, 1, 24, 1, -1, 8, -1, 8 }),
+        Shape.init(.f32, &.{ -1, 24, -1, -1 }),
+        &out,
+    ) orelse return error.TestUnexpectedResult;
+
+    try std.testing.expectEqualSlices(i64, &.{ 1, 24, 960, 960 }, resolved);
+}
+
 test "resolveProjectionRestoreFromSourceActual restores batch sequence after flattened matmul" {
     var out: [8]i64 = undefined;
     const resolved = resolveProjectionRestoreFromSourceActual(
@@ -4909,6 +4980,62 @@ test "runtime shape drives symbolic broadcast_in_dim" {
         4, 5, 6,
         4, 5, 6,
         4, 5, 6,
+    }, actual);
+}
+
+test "runtime shape drives dynamic integer resize broadcast values" {
+    const allocator = std.testing.allocator;
+
+    var g = Graph.init(allocator);
+    defer g.deinit();
+    var builder = ml.graph.Builder.init(&g);
+
+    const x = try builder.parameter("x", Shape.init(.f32, &.{ -1, 1, -1, -1 }));
+    const reshaped = try builder.reshape(x, Shape.init(.f32, &.{ -1, 1, 1, 1, -1, 1, -1, 1 }));
+
+    var attrs = ml.graph.node.BroadcastAttrs{ .target_shape = Shape.init(.f32, &.{ -1, 1, 1, 1, -1, 2, -1, 2 }) };
+    attrs.broadcast_axes = .{ 0, 1, 2, 3, 4, 5, 6, 7 };
+    attrs.num_axes = 8;
+    const broadcasted = try g.addNode(.{
+        .op = .{ .broadcast_in_dim = attrs },
+        .output_shape = attrs.target_shape,
+        .inputs = .{ reshaped, null_node, null_node, null_node },
+        .num_inputs = 1,
+    });
+    const out = try builder.reshape(broadcasted, Shape.init(.f32, &.{ -1, 1, -1, -1 }));
+    try g.markOutput(out);
+
+    var ws = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
+    var compute = NativeCompute.init(allocator, &ws, null);
+    var cb_val = compute.computeBackend();
+
+    const input = [_]f32{
+        1, 2,
+        3, 4,
+    };
+    const x_ct = try cb_val.fromFloat32Shape(&input, &.{ 1, 1, 2, 2 });
+    defer cb_val.free(x_ct);
+
+    const rt_inputs = [_]RuntimeInput{
+        .{ .node_id = x, .value = x_ct },
+    };
+
+    var result = try execute(allocator, &g, &cb_val, .{
+        .runtime_inputs = &rt_inputs,
+    });
+    defer result.deinit(&cb_val);
+
+    const actual_shape = try cb_val.tensorShape(result.outputs[0], allocator);
+    defer allocator.free(actual_shape);
+    try std.testing.expectEqualSlices(i64, &.{ 1, 1, 4, 4 }, actual_shape);
+
+    const actual = try cb_val.toFloat32(result.outputs[0], allocator);
+    defer allocator.free(actual);
+    try std.testing.expectEqualSlices(f32, &.{
+        1, 1, 2, 2,
+        1, 1, 2, 2,
+        3, 3, 4, 4,
+        3, 3, 4, 4,
     }, actual);
 }
 

--- a/zig/pkg/inference/src/pipelines/multistage_ocr.zig
+++ b/zig/pkg/inference/src/pipelines/multistage_ocr.zig
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 const std = @import("std");
+const platform = @import("antfly_platform");
 const backends = @import("../backends/backends.zig");
 const image = @import("image.zig");
 const crop = @import("crop.zig");
@@ -460,6 +461,7 @@ pub const MultiStageOCRPipeline = struct {
 
         const heatmap = try extractDetectionHeatmap(self.allocator, &outputs[0], self.detection_preprocess.width, self.detection_preprocess.height);
         defer self.allocator.free(heatmap.values);
+        traceDetectionHeatmap(&outputs[0], heatmap.values, heatmap.width, heatmap.height, self.post_processor);
         return self.post_processor.process(self.allocator, heatmap.values, heatmap.width, heatmap.height, img.width, img.height);
     }
 
@@ -765,6 +767,31 @@ fn extractDetectionHeatmap(
             .height = fallback_height,
         },
     }
+}
+
+fn traceDetectionHeatmap(output: *const backends.Tensor, values: []const f32, width: usize, height: usize, processor: DetectionPostProcessor) void {
+    if (!platform.env.getenvBoolDefault("ANTFLY_INFERENCE_TRACE_OCR_DETECTION", false)) return;
+
+    var min_value: f32 = std.math.inf(f32);
+    var max_value: f32 = -std.math.inf(f32);
+    var sum: f64 = 0;
+    var above_threshold: usize = 0;
+    const threshold = switch (processor) {
+        .db => |db| db.threshold,
+        .heatmap => |heatmap| heatmap.threshold,
+    };
+
+    for (values) |value| {
+        min_value = @min(min_value, value);
+        max_value = @max(max_value, value);
+        sum += value;
+        if (value > threshold) above_threshold += 1;
+    }
+    const mean = if (values.len > 0) sum / @as(f64, @floatFromInt(values.len)) else 0;
+    std.log.info(
+        "ocr detection output shape={any} heatmap={}x{} values={} min={d:.6} max={d:.6} mean={d:.6} above_threshold={} threshold={d:.6}",
+        .{ output.shape, width, height, values.len, min_value, max_value, mean, above_threshold, threshold },
+    );
 }
 
 fn computeBoxScore(prob_map: []const f32, comp: connected_components.ComponentRect, width: usize) f64 {

--- a/zig/pkg/inference/src/readers/multistage_reader.zig
+++ b/zig/pkg/inference/src/readers/multistage_reader.zig
@@ -34,6 +34,32 @@ pub const LoadedMultiStageReader = struct {
         defer metadata.deinit();
         if (!metadata_mod.isMultiStage(&metadata)) return error.InvalidMetadata;
 
+        for (session_manager.preferred_backends) |backend| {
+            if (!backend.supportsDirectSessionLoad()) continue;
+            var single_backend = [_]backends.BackendType{backend};
+            var stage_session_manager = session_manager.*;
+            stage_session_manager.preferred_backends = single_backend[0..];
+            return loadFromDirWithSessionManager(
+                allocator,
+                model_path,
+                &metadata,
+                &stage_session_manager,
+            ) catch |err| {
+                if (err == error.MultiStageReaderNotYetSupported) return err;
+                std.log.err("multistage reader backend {s} failed for {s}: {s}", .{ @tagName(backend), model_path, @errorName(err) });
+                continue;
+            };
+        }
+
+        return error.NoBackendAvailable;
+    }
+
+    fn loadFromDirWithSessionManager(
+        allocator: std.mem.Allocator,
+        model_path: []const u8,
+        metadata: *const metadata_mod.MultiStageMetadata,
+        session_manager: *backends.SessionManager,
+    ) !LoadedMultiStageReader {
         const detection_stage = metadata.stages.get("detection") orelse return error.InvalidMetadata;
         const detection_file = detection_stage.model_file orelse return error.InvalidMetadata;
         const detection_path = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ model_path, detection_file });
@@ -45,7 +71,7 @@ pub const LoadedMultiStageReader = struct {
         const detection_preprocess = try loadStagePreprocessConfig(
             allocator,
             model_path,
-            &metadata,
+            metadata,
             &detection_stage,
             detector,
             .detection,
@@ -80,7 +106,7 @@ pub const LoadedMultiStageReader = struct {
                 const recognition_preprocess = try loadStagePreprocessConfig(
                     allocator,
                     model_path,
-                    &metadata,
+                    metadata,
                     &recognition_stage,
                     rec_session,
                     .recognition,


### PR DESCRIPTION
## Summary
- reject unsupported strided ConvTranspose imports in native ONNX so incompatible OCR detector graphs fall through instead of producing invalid output
- retry multi-stage OCR reader loading per backend candidate so the whole pipeline lands on a compatible backend
- tighten dynamic shape handling for ONNX Sigmoid, Conv, Resize, and runtime reshape paths, with focused regression coverage
- add generic detector-output tracing behind ANTFLY_INFERENCE_TRACE_OCR_DETECTION for future OCR diagnostics

## Why
Some OCR reader models can be partially accepted by the native backend even when required graph semantics are not implemented exactly. That can produce malformed detector outputs and empty OCR results. This change makes unsupported native paths explicit and lets backend selection recover model-agnostically.

## Verification
- zig build install -Dedition=inference -Dmetal=false -Donnx=true
- native-preferred multi-stage OCR e2e passes by falling back to a compatible backend
- focused ONNX/import/runtime regression tests pass
- git diff --check