### PR TITLE
Fix document extraction state recovery

### DIFF
--- a/zig/pkg/antfly/src/storage/db/db.zig
+++ b/zig/pkg/antfly/src/storage/db/db.zig
@@ -17745,9 +17745,13 @@ fn documentExtractionStateUnitDescriptorsAlloc(alloc: Allocator, state: []const 
         const key_value = item.object.get("key") orelse return error.InvalidDocumentExtractionState;
         const fingerprint_value = item.object.get("fingerprint") orelse return error.InvalidDocumentExtractionState;
         if (fingerprint_value != .string) return error.InvalidDocumentExtractionState;
+        const key = try documentExtractionStateByteSliceAlloc(alloc, key_value);
+        errdefer alloc.free(@constCast(key));
+        const fingerprint = try alloc.dupe(u8, fingerprint_value.string);
+        errdefer alloc.free(fingerprint);
         out[i] = .{
-            .key = try documentExtractionStateByteSliceAlloc(alloc, key_value),
-            .fingerprint = try alloc.dupe(u8, fingerprint_value.string),
+            .key = key,
+            .fingerprint = fingerprint,
         };
         initialized += 1;
     }
@@ -36287,6 +36291,20 @@ test "db async document extraction deletes artifacts with corrupt previous extra
         .content_type = "application/json",
         .producer_json = "{\"type\":\"document_extraction\",\"config\":{}}",
     });
+    try db.addEnrichment(.{
+        .name = "document_chunks_v1",
+        .kind = .chunk,
+        .field = "text",
+        .source_artifact_name = "document_units_v1",
+        .chunk_size = 16,
+        .chunk_overlap = 0,
+        .full_text_index = true,
+    });
+    try db.addIndex(.{
+        .name = "ft_document_chunks",
+        .kind = .full_text,
+        .config_json = "{\"chunk_name\":\"document_chunks_v1\"}",
+    });
 
     try db.batch(.{
         .writes = &.{.{
@@ -36301,11 +36319,22 @@ test "db async document extraction deletes artifacts with corrupt previous extra
     defer alloc.free(manifest_key);
     const unit_key = try internal_keys.documentUnitArtifactKeyAlloc(alloc, "doc:async-delete", "document_units_v1", "document:000001");
     defer alloc.free(unit_key);
+    const chunk_key = try internal_keys.documentUnitChunkArtifactKeyAlloc(alloc, "doc:async-delete", "document_chunks_v1", "document:000001", 0);
+    defer alloc.free(chunk_key);
     const state_key = try assetStateKeyAlloc(alloc, "doc:async-delete", "document_units_v1");
     defer alloc.free(state_key);
 
     const initial_unit_payload = try db.core.store.get(alloc, unit_key);
     alloc.free(initial_unit_payload);
+    const initial_chunk_payload = try db.core.store.get(alloc, chunk_key);
+    alloc.free(initial_chunk_payload);
+    var before_delete = try db.search(alloc, .{
+        .index_name = "ft_document_chunks",
+        .full_text = .{ .match = .{ .field = "text", .text = "alpha" } },
+        .return_mode = .chunk,
+    });
+    defer before_delete.deinit();
+    try std.testing.expect(before_delete.total_hits > 0);
     try db.core.store.put(state_key, "{");
 
     try db.batch(.{
@@ -36319,7 +36348,15 @@ test "db async document extraction deletes artifacts with corrupt previous extra
 
     try std.testing.expectError(error.NotFound, db.core.store.get(alloc, manifest_key));
     try std.testing.expectError(error.NotFound, db.core.store.get(alloc, unit_key));
+    try std.testing.expectError(error.NotFound, db.core.store.get(alloc, chunk_key));
     try std.testing.expectError(error.NotFound, db.core.store.get(alloc, state_key));
+    var after_delete = try db.search(alloc, .{
+        .index_name = "ft_document_chunks",
+        .full_text = .{ .match = .{ .field = "text", .text = "alpha" } },
+        .return_mode = .chunk,
+    });
+    defer after_delete.deinit();
+    try std.testing.expectEqual(@as(u32, 0), after_delete.total_hits);
 }
 
 test "db document extraction routes mixed files using source metadata fields" {

--- a/zig/pkg/antfly/src/storage/db/db.zig
+++ b/zig/pkg/antfly/src/storage/db/db.zig
@@ -17069,8 +17069,7 @@ fn loadDocumentExtractionPreviousState(
             return parsed;
         } else |err| switch (err) {
             error.OutOfMemory => return err,
-            error.InvalidDocumentExtractionState, error.SyntaxError => {},
-            else => return err,
+            else => {},
         }
     }
     var recovered = try scanDocumentExtractionPreviousStateFromStore(alloc, db, doc_key, artifact_name);
@@ -36258,6 +36257,63 @@ test "db async document extraction accounts resource manager working set" {
     try std.testing.expectEqual(@as(u64, 0), stats.used_bytes);
 }
 
+test "db async document extraction deletes artifacts with corrupt previous extraction state" {
+    const alloc = std.testing.allocator;
+
+    var path_buf: [256]u8 = undefined;
+    const path = tempPath(&path_buf);
+    defer cleanupTempDir(path);
+
+    var db = try DB.open(alloc, std.mem.span(path), .{
+        .enrichment = .{
+            .owner_id = "worker-a",
+            .enable_without_producers = true,
+        },
+    });
+    defer db.close();
+
+    try db.addEnrichment(.{
+        .name = "document_units_v1",
+        .kind = .asset,
+        .field = "url",
+        .content_type = "application/json",
+        .producer_json = "{\"type\":\"document_extraction\",\"config\":{}}",
+    });
+
+    try db.batch(.{
+        .writes = &.{.{
+            .key = "doc:async-delete",
+            .value = "{\"url\":\"data:text/plain;base64,YWxwaGEgYmV0YQ==\"}",
+        }},
+        .sync_level = .write,
+    });
+    try db.runUntilIdle();
+
+    const manifest_key = try internal_keys.artifactNamedPrefixAlloc(alloc, "doc:async-delete", "asset", "document_units_v1");
+    defer alloc.free(manifest_key);
+    const unit_key = try internal_keys.documentUnitArtifactKeyAlloc(alloc, "doc:async-delete", "document_units_v1", "document:000001");
+    defer alloc.free(unit_key);
+    const state_key = try assetStateKeyAlloc(alloc, "doc:async-delete", "document_units_v1");
+    defer alloc.free(state_key);
+
+    const initial_unit_payload = try db.core.store.get(alloc, unit_key);
+    alloc.free(initial_unit_payload);
+    try db.core.store.put(state_key, "{");
+
+    try db.batch(.{
+        .writes = &.{.{
+            .key = "doc:async-delete",
+            .value = "{\"url\":\"\"}",
+        }},
+        .sync_level = .write,
+    });
+    try db.runUntilIdle();
+
+    try std.testing.expectError(error.NotFound, db.core.store.get(alloc, manifest_key));
+    try std.testing.expectError(error.NotFound, db.core.store.get(alloc, unit_key));
+    try std.testing.expectError(error.NotFound, db.core.store.get(alloc, state_key));
+}
+
 test "db document extraction routes mixed files using source metadata fields" {
     const alloc = std.testing.allocator;
 
@@ -39488,6 +39544,23 @@ test "db document extraction update recovers corrupt previous extraction state" 
     const recovered_chunk_keys = try documentExtractionStateChunkKeysAlloc(alloc, recovered_state);
     defer freeOwnedConstKeySlice(alloc, recovered_chunk_keys);
     try std.testing.expect(recovered_chunk_keys.len > 0);
+
+    try db.core.store.put(state_key, "{");
+
+    const url_v3 = try testLargeHtmlDataUrlAlloc(alloc, "v3", "corruptthirdtoken", 80);
+    defer alloc.free(url_v3);
+    const doc_v3 = try testSourceDocumentJsonAlloc(alloc, url_v3, "sha-v3");
+    defer alloc.free(doc_v3);
+    try db.batch(.{
+        .writes = &.{.{ .key = "doc:corrupt", .value = doc_v3 }},
+        .sync_level = .full_index,
+    });
+
+    const recovered_truncated_state = try db.core.store.get(alloc, state_key);
+    defer alloc.free(recovered_truncated_state);
+    const recovered_truncated_chunk_keys = try documentExtractionStateChunkKeysAlloc(alloc, recovered_truncated_state);
+    defer freeOwnedConstKeySlice(alloc, recovered_truncated_chunk_keys);
+    try std.testing.expect(recovered_truncated_chunk_keys.len > 0);
 }
 
 test "db extractEnrichments exposes cleaned writes and special fields" {

--- a/zig/pkg/antfly/src/storage/db/db.zig
+++ b/zig/pkg/antfly/src/storage/db/db.zig
@@ -16601,7 +16601,7 @@ fn computeDocumentExtractionAssetRequestDerived(
     ) catch |err| switch (err) {
         error.OutOfMemory => return err,
         else => {
-            try appendDocumentExtractionFailureManifest(alloc, request.doc_key, artifact_name, source_url, manifest_key, state_key, existing_state, from_generation, to_generation, @errorName(err), "remote content download failed", artifact_writes, artifact_delete_keys);
+            try appendDocumentExtractionFailureManifest(alloc, db, request.doc_key, artifact_name, source_url, manifest_key, state_key, existing_state, from_generation, to_generation, @errorName(err), "remote content download failed", artifact_writes, artifact_delete_keys);
             return;
         },
     };
@@ -16610,7 +16610,7 @@ fn computeDocumentExtractionAssetRequestDerived(
         .http_error => |http_error| {
             const message = try std.fmt.allocPrint(alloc, "{s}: HTTP {d}", .{ http_error.message, http_error.status });
             defer alloc.free(message);
-            try appendDocumentExtractionFailureManifest(alloc, request.doc_key, artifact_name, source_url, manifest_key, state_key, existing_state, from_generation, to_generation, "RemoteDocumentFetchFailed", message, artifact_writes, artifact_delete_keys);
+            try appendDocumentExtractionFailureManifest(alloc, db, request.doc_key, artifact_name, source_url, manifest_key, state_key, existing_state, from_generation, to_generation, "RemoteDocumentFetchFailed", message, artifact_writes, artifact_delete_keys);
             return;
         },
     };
@@ -16620,7 +16620,7 @@ fn computeDocumentExtractionAssetRequestDerived(
     var extraction = document_extraction_mod.extractDownloadedAlloc(alloc, downloaded_mut, source_url, config) catch |err| switch (err) {
         error.OutOfMemory => return err,
         else => {
-            try appendDocumentExtractionFailureManifest(alloc, request.doc_key, artifact_name, source_url, manifest_key, state_key, existing_state, from_generation, to_generation, @errorName(err), "document extraction failed", artifact_writes, artifact_delete_keys);
+            try appendDocumentExtractionFailureManifest(alloc, db, request.doc_key, artifact_name, source_url, manifest_key, state_key, existing_state, from_generation, to_generation, @errorName(err), "document extraction failed", artifact_writes, artifact_delete_keys);
             return;
         },
     };
@@ -16658,12 +16658,8 @@ fn computeDocumentExtractionAssetRequestDerived(
     const new_state = try documentExtractionStateValueAlloc(alloc, source_fingerprint, desired_unit_keys.items, desired_unit_descriptors, desired_chunk_keys.items);
     defer alloc.free(new_state);
 
-    var previous_unit_keys: []const []const u8 = &.{};
-    defer freeOwnedConstKeySlice(alloc, previous_unit_keys);
-    var previous_unit_descriptors: []DocumentExtractionUnitDescriptor = &.{};
-    defer freeDocumentExtractionUnitDescriptors(alloc, previous_unit_descriptors);
-    var previous_chunk_keys: []const []const u8 = &.{};
-    defer freeOwnedConstKeySlice(alloc, previous_chunk_keys);
+    var previous_state = DocumentExtractionPreviousState{};
+    defer previous_state.deinit(alloc);
 
     if (existing_state) |state| {
         if (!force_reprocess and std.mem.eql(u8, state, new_state)) {
@@ -16678,16 +16674,17 @@ fn computeDocumentExtractionAssetRequestDerived(
             }
         }
 
-        previous_unit_keys = try documentExtractionStateUnitKeysAlloc(alloc, state);
-        previous_unit_descriptors = try documentExtractionStateUnitDescriptorsAlloc(alloc, state);
-        for (previous_unit_keys) |previous_key| {
+        previous_state = try loadDocumentExtractionPreviousState(alloc, db, request.doc_key, artifact_name, state);
+        for (previous_state.unit_keys) |previous_key| {
             if (containsDeleteKey(desired_unit_keys.items, previous_key)) continue;
             try artifact_delete_keys.append(alloc, try alloc.dupe(u8, previous_key));
         }
-        previous_chunk_keys = try documentExtractionStateChunkKeysAlloc(alloc, state);
-        for (previous_chunk_keys) |previous_key| {
+        for (previous_state.chunk_keys) |previous_key| {
             if (containsDeleteKey(desired_chunk_keys.items, previous_key)) continue;
             try artifact_delete_keys.append(alloc, try alloc.dupe(u8, previous_key));
+        }
+        if (previous_state.recovered_from_store_scan) {
+            try artifact_delete_keys.append(alloc, try alloc.dupe(u8, state_key));
         }
     }
 
@@ -16705,7 +16702,7 @@ fn computeDocumentExtractionAssetRequestDerived(
         defer alloc.free(unit_range_id);
         const unit_route = documentExtractionRangeRoute(previous_child_ranges, unit_range_id, "unit", artifact_name);
         const unit_unchanged = std.mem.eql(u8, unit_descriptor.key, unit_key) and
-            unitDescriptorFingerprintMatches(previous_unit_descriptors, unit_key, unit_descriptor.fingerprint);
+            unitDescriptorFingerprintMatches(previous_state.unit_descriptors, unit_key, unit_descriptor.fingerprint);
         if (unit_unchanged and
             try documentUnitCanSkipLocalWrites(alloc, db, request.doc_key, artifact_name, unit_key, unit, text_indexes))
         {
@@ -16781,9 +16778,9 @@ fn computeDocumentExtractionAssetRequestDerived(
         desired_unit_descriptors,
         desired_chunk_keys.items,
         previous_child_ranges,
-        previous_unit_keys,
-        previous_unit_descriptors,
-        previous_chunk_keys,
+        previous_state.unit_keys,
+        previous_state.unit_descriptors,
+        previous_state.chunk_keys,
         to_generation,
         from_generation,
         to_generation,
@@ -16994,15 +16991,13 @@ fn appendDocumentExtractionDeleteKeys(
         else => return err,
     };
     defer if (existing_state) |value| alloc.free(value);
-    if (existing_state) |state| {
-        const previous_keys = try documentExtractionStateUnitKeysAlloc(alloc, state);
-        defer freeOwnedConstKeySlice(alloc, previous_keys);
-        for (previous_keys) |previous_key| {
+    if (existing_state != null) {
+        var previous_state = try loadDocumentExtractionPreviousState(alloc, db, doc_key, artifact_name, existing_state);
+        defer previous_state.deinit(alloc);
+        for (previous_state.unit_keys) |previous_key| {
             try artifact_delete_keys.append(alloc, try alloc.dupe(u8, previous_key));
         }
-        const previous_chunk_keys = try documentExtractionStateChunkKeysAlloc(alloc, state);
-        defer freeOwnedConstKeySlice(alloc, previous_chunk_keys);
-        for (previous_chunk_keys) |previous_key| {
+        for (previous_state.chunk_keys) |previous_key| {
             try artifact_delete_keys.append(alloc, try alloc.dupe(u8, previous_key));
         }
     }
@@ -17042,11 +17037,109 @@ const DocumentExtractionUnitDescriptor = struct {
     fingerprint: []const u8,
 };
 
+const DocumentExtractionPreviousState = struct {
+    unit_keys: []const []const u8 = &.{},
+    unit_descriptors: []DocumentExtractionUnitDescriptor = &.{},
+    chunk_keys: []const []const u8 = &.{},
+    recovered_from_store_scan: bool = false,
+
+    fn deinit(self: *@This(), alloc: Allocator) void {
+        freeOwnedConstKeySlice(alloc, self.unit_keys);
+        freeDocumentExtractionUnitDescriptors(alloc, self.unit_descriptors);
+        freeOwnedConstKeySlice(alloc, self.chunk_keys);
+        self.* = undefined;
+    }
+};
+
 const DocumentExtractionRangeRoute = struct {
     range_id: []const u8,
     route_status: []const u8 = "local_committed",
     owner_group_id: u64 = 0,
 };
+
+fn loadDocumentExtractionPreviousState(
+    alloc: Allocator,
+    db: *DB,
+    doc_key: []const u8,
+    artifact_name: []const u8,
+    existing_state: ?[]const u8,
+) !DocumentExtractionPreviousState {
+    if (existing_state) |state| {
+        if (loadDocumentExtractionPreviousStateFromJson(alloc, state)) |parsed| {
+            return parsed;
+        } else |err| switch (err) {
+            error.OutOfMemory => return err,
+            error.InvalidDocumentExtractionState, error.SyntaxError => {},
+            else => return err,
+        }
+    }
+    var recovered = try scanDocumentExtractionPreviousStateFromStore(alloc, db, doc_key, artifact_name);
+    recovered.recovered_from_store_scan = existing_state != null;
+    return recovered;
+}
+
+fn loadDocumentExtractionPreviousStateFromJson(alloc: Allocator, state: []const u8) !DocumentExtractionPreviousState {
+    var out = DocumentExtractionPreviousState{};
+    errdefer out.deinit(alloc);
+    out.unit_keys = try documentExtractionStateUnitKeysAlloc(alloc, state);
+    out.unit_descriptors = try documentExtractionStateUnitDescriptorsAlloc(alloc, state);
+    out.chunk_keys = try documentExtractionStateChunkKeysAlloc(alloc, state);
+    return out;
+}
+
+fn scanDocumentExtractionPreviousStateFromStore(
+    alloc: Allocator,
+    db: *DB,
+    doc_key: []const u8,
+    artifact_name: []const u8,
+) !DocumentExtractionPreviousState {
+    var out = DocumentExtractionPreviousState{};
+    errdefer out.deinit(alloc);
+
+    var unit_keys = std.ArrayListUnmanaged([]const u8).empty;
+    errdefer {
+        for (unit_keys.items) |key| alloc.free(@constCast(key));
+        unit_keys.deinit(alloc);
+    }
+    const unit_prefix = try internal_keys.artifactNamedPrefixAlloc(alloc, doc_key, "asset", artifact_name);
+    defer alloc.free(unit_prefix);
+    const unit_rows = try db.core.store.scanPrefix(alloc, unit_prefix);
+    defer docstore_mod.DocStore.freeResults(alloc, unit_rows);
+    for (unit_rows) |entry| {
+        if (std.mem.eql(u8, entry.key, unit_prefix)) continue;
+        if (internal_keys.isDerivedEmbeddingArtifactKey(entry.key)) continue;
+        try unit_keys.append(alloc, try alloc.dupe(u8, entry.key));
+    }
+
+    var chunk_keys = std.ArrayListUnmanaged([]const u8).empty;
+    errdefer {
+        for (chunk_keys.items) |key| alloc.free(@constCast(key));
+        chunk_keys.deinit(alloc);
+    }
+    for (db.core.index_manager.enrichments.items) |entry| {
+        if (entry.kind != .chunk) continue;
+        if (!std.mem.eql(u8, entry.source_artifact_name, artifact_name)) continue;
+        const chunk_prefix = try internal_keys.artifactNamedPrefixAlloc(alloc, doc_key, "chunk", entry.name);
+        defer alloc.free(chunk_prefix);
+        const chunk_rows = try db.core.store.scanPrefix(alloc, chunk_prefix);
+        defer docstore_mod.DocStore.freeResults(alloc, chunk_rows);
+        for (chunk_rows) |row| {
+            if (!internal_keys.isChunkArtifactRecordKey(row.key)) continue;
+            try chunk_keys.append(alloc, try alloc.dupe(u8, row.key));
+        }
+    }
+
+    out.unit_keys = try unit_keys.toOwnedSlice(alloc);
+    out.chunk_keys = try chunk_keys.toOwnedSlice(alloc);
+    out.unit_descriptors = try alloc.alloc(DocumentExtractionUnitDescriptor, out.unit_keys.len);
+    for (out.unit_descriptors, out.unit_keys) |*descriptor, key| {
+        descriptor.* = .{
+            .key = try alloc.dupe(u8, key),
+            .fingerprint = "",
+        };
+    }
+    return out;
+}
 
 fn documentExtractionUnitDescriptorsFromKeysAlloc(
     alloc: Allocator,
@@ -17644,9 +17737,9 @@ fn documentExtractionStateUnitDescriptorsAlloc(alloc: Allocator, state: []const 
         if (item != .object) return error.InvalidDocumentExtractionState;
         const key_value = item.object.get("key") orelse return error.InvalidDocumentExtractionState;
         const fingerprint_value = item.object.get("fingerprint") orelse return error.InvalidDocumentExtractionState;
-        if (key_value != .string or fingerprint_value != .string) return error.InvalidDocumentExtractionState;
+        if (fingerprint_value != .string) return error.InvalidDocumentExtractionState;
         out[i] = .{
-            .key = try alloc.dupe(u8, key_value.string),
+            .key = try documentExtractionStateByteSliceAlloc(alloc, key_value),
             .fingerprint = try alloc.dupe(u8, fingerprint_value.string),
         };
         initialized += 1;
@@ -17667,9 +17760,8 @@ fn documentExtractionStateUnitDescriptorFallbackAlloc(alloc: Allocator, object: 
         alloc.free(out);
     }
     for (keys_value.array.items, 0..) |item, i| {
-        if (item != .string) return error.InvalidDocumentExtractionState;
         out[i] = .{
-            .key = try alloc.dupe(u8, item.string),
+            .key = try documentExtractionStateByteSliceAlloc(alloc, item),
             .fingerprint = "",
         };
         initialized += 1;
@@ -17690,11 +17782,26 @@ fn documentExtractionStateKeysAlloc(alloc: Allocator, state: []const u8, field_n
         alloc.free(out);
     }
     for (keys_value.array.items, 0..) |item, i| {
-        if (item != .string) return error.InvalidDocumentExtractionState;
-        out[i] = try alloc.dupe(u8, item.string);
+        out[i] = try documentExtractionStateByteSliceAlloc(alloc, item);
         initialized += 1;
     }
     return out;
+}
+
+fn documentExtractionStateByteSliceAlloc(alloc: Allocator, value: std.json.Value) ![]const u8 {
+    switch (value) {
+        .string => |string| return try alloc.dupe(u8, string),
+        .array => |array| {
+            const out = try alloc.alloc(u8, array.items.len);
+            errdefer alloc.free(out);
+            for (array.items, 0..) |item, i| {
+                if (item != .integer) return error.InvalidDocumentExtractionState;
+                out[i] = std.math.cast(u8, item.integer) orelse return error.InvalidDocumentExtractionState;
+            }
+            return out;
+        },
+        else => return error.InvalidDocumentExtractionState,
+    }
 }
 
 fn documentExtractionUnitKeyStillPresent(
@@ -18431,6 +18538,7 @@ fn documentExtractionFailureManifestPayloadAlloc(
 
 fn appendDocumentExtractionFailureManifest(
     alloc: Allocator,
+    db: *DB,
     doc_key: []const u8,
     artifact_name: []const u8,
     source_url: []const u8,
@@ -18444,15 +18552,13 @@ fn appendDocumentExtractionFailureManifest(
     artifact_writes: *std.ArrayListUnmanaged(types.BatchWrite),
     artifact_delete_keys: *std.ArrayListUnmanaged([]const u8),
 ) !void {
-    if (existing_state) |state| {
-        const previous_unit_keys = try documentExtractionStateUnitKeysAlloc(alloc, state);
-        defer freeOwnedConstKeySlice(alloc, previous_unit_keys);
-        for (previous_unit_keys) |previous_key| {
+    if (existing_state != null) {
+        var previous_state = try loadDocumentExtractionPreviousState(alloc, db, doc_key, artifact_name, existing_state);
+        defer previous_state.deinit(alloc);
+        for (previous_state.unit_keys) |previous_key| {
             try artifact_delete_keys.append(alloc, try alloc.dupe(u8, previous_key));
         }
-        const previous_chunk_keys = try documentExtractionStateChunkKeysAlloc(alloc, state);
-        defer freeOwnedConstKeySlice(alloc, previous_chunk_keys);
-        for (previous_chunk_keys) |previous_key| {
+        for (previous_state.chunk_keys) |previous_key| {
             try artifact_delete_keys.append(alloc, try alloc.dupe(u8, previous_key));
         }
         try artifact_delete_keys.append(alloc, try alloc.dupe(u8, state_key));
@@ -39169,6 +39275,219 @@ test "db document extraction chunks units through source artifact enrichment" {
     });
     try std.testing.expectError(error.NotFound, db.core.store.get(alloc, unit_key));
     try std.testing.expectError(error.NotFound, db.core.store.get(alloc, chunk_key));
+}
+
+fn testLargeHtmlDataUrlAlloc(alloc: Allocator, version: []const u8, unique_token: []const u8, paragraph_count: usize) ![]u8 {
+    var html = std.ArrayListUnmanaged(u8).empty;
+    defer html.deinit(alloc);
+    try html.appendSlice(alloc, "<html><body><h1>Synthetic Report ");
+    try html.appendSlice(alloc, version);
+    try html.appendSlice(alloc, "</h1>");
+    for (0..paragraph_count) |i| {
+        const paragraph = try std.fmt.allocPrint(
+            alloc,
+            "<p>{s} harbor terminal cargo fiscal quarterly report section {d} renewal authority volume meridian refrigerated shipping expansion contract.</p>\n",
+            .{ unique_token, i },
+        );
+        defer alloc.free(paragraph);
+        try html.appendSlice(alloc, paragraph);
+    }
+    try html.appendSlice(alloc, "</body></html>");
+
+    const encoded_len = std.base64.standard.Encoder.calcSize(html.items.len);
+    const encoded = try alloc.alloc(u8, encoded_len);
+    defer alloc.free(encoded);
+    _ = std.base64.standard.Encoder.encode(encoded, html.items);
+    return try std.fmt.allocPrint(alloc, "data:text/html;base64,{s}", .{encoded});
+}
+
+fn testSourceDocumentJsonAlloc(alloc: Allocator, url: []const u8, sha256: []const u8) ![]u8 {
+    return try std.fmt.allocPrint(
+        alloc,
+        "{{\"_type\":\"source_document\",\"url\":\"{s}\",\"filename\":\"doc.html\",\"mime_type\":\"text/html\",\"sha256\":\"{s}\",\"file_type\":\"document\"}}",
+        .{ url, sha256 },
+    );
+}
+
+test "db document extraction state round-trips binary chunk keys beyond one byte ids" {
+    const alloc = std.testing.allocator;
+
+    var unit_keys = std.ArrayListUnmanaged([]const u8).empty;
+    defer {
+        for (unit_keys.items) |key| alloc.free(@constCast(key));
+        unit_keys.deinit(alloc);
+    }
+    var unit_fingerprints = std.ArrayListUnmanaged([]const u8).empty;
+    defer {
+        for (unit_fingerprints.items) |fingerprint| alloc.free(@constCast(fingerprint));
+        unit_fingerprints.deinit(alloc);
+    }
+    var chunk_keys = std.ArrayListUnmanaged([]const u8).empty;
+    defer {
+        for (chunk_keys.items) |key| alloc.free(@constCast(key));
+        chunk_keys.deinit(alloc);
+    }
+
+    try unit_keys.append(alloc, try internal_keys.documentUnitArtifactKeyAlloc(alloc, "doc:large", "document_units_v1", "document:000001"));
+    try unit_fingerprints.append(alloc, try alloc.dupe(u8, "unit-fingerprint"));
+    for (0..320) |i| {
+        try chunk_keys.append(alloc, try internal_keys.documentUnitChunkArtifactKeyAlloc(alloc, "doc:large", "document_chunks_v1", "document:000001", @intCast(i)));
+    }
+
+    const descriptors = try documentExtractionUnitDescriptorsFromKeysAlloc(alloc, unit_keys.items, unit_fingerprints.items);
+    defer alloc.free(descriptors);
+    const state = try documentExtractionStateValueAlloc(alloc, "source-fingerprint", unit_keys.items, descriptors, chunk_keys.items);
+    defer alloc.free(state);
+
+    const parsed_chunk_keys = try documentExtractionStateChunkKeysAlloc(alloc, state);
+    defer freeOwnedConstKeySlice(alloc, parsed_chunk_keys);
+    try std.testing.expectEqual(chunk_keys.items.len, parsed_chunk_keys.len);
+    for (chunk_keys.items, parsed_chunk_keys) |expected, actual| {
+        try std.testing.expectEqualSlices(u8, expected, actual);
+    }
+}
+
+test "db document extraction changed version updates large chunked source document" {
+    const alloc = std.testing.allocator;
+
+    var path_buf: [256]u8 = undefined;
+    const path = tempPath(&path_buf);
+    defer cleanupTempDir(path);
+
+    var db = try DB.open(alloc, std.mem.span(path), .{});
+    defer db.close();
+
+    try db.addEnrichment(.{
+        .name = "document_units_v1",
+        .kind = .asset,
+        .field = "url",
+        .content_type = "application/json",
+        .producer_json = "{\"type\":\"document_extraction\",\"config\":{\"source\":{\"etag_field\":\"sha256\",\"version_field\":\"sha256\",\"content_type_field\":\"mime_type\",\"filename_field\":\"filename\"}}}",
+    });
+    try db.addEnrichment(.{
+        .name = "document_chunks_v1",
+        .kind = .chunk,
+        .field = "text",
+        .source_artifact_name = "document_units_v1",
+        .chunk_size = 96,
+        .chunk_overlap = 0,
+        .full_text_index = true,
+    });
+    try db.addIndex(.{
+        .name = "ft_document_chunks",
+        .kind = .full_text,
+        .config_json = "{\"chunk_name\":\"document_chunks_v1\"}",
+    });
+
+    const url_v1 = try testLargeHtmlDataUrlAlloc(alloc, "v1", "firstversiontoken", 360);
+    defer alloc.free(url_v1);
+    const doc_v1 = try testSourceDocumentJsonAlloc(alloc, url_v1, "sha-v1");
+    defer alloc.free(doc_v1);
+    try db.batch(.{
+        .writes = &.{.{ .key = "doc:large", .value = doc_v1 }},
+        .sync_level = .full_index,
+    });
+
+    const state_key = try assetStateKeyAlloc(alloc, "doc:large", "document_units_v1");
+    defer alloc.free(state_key);
+    const first_state = try db.core.store.get(alloc, state_key);
+    defer alloc.free(first_state);
+    const first_chunk_keys = try documentExtractionStateChunkKeysAlloc(alloc, first_state);
+    defer freeOwnedConstKeySlice(alloc, first_chunk_keys);
+    try std.testing.expect(first_chunk_keys.len > 300);
+
+    const url_v2 = try testLargeHtmlDataUrlAlloc(alloc, "v2", "secondversiontoken", 360);
+    defer alloc.free(url_v2);
+    const doc_v2 = try testSourceDocumentJsonAlloc(alloc, url_v2, "sha-v2");
+    defer alloc.free(doc_v2);
+    try db.batch(.{
+        .writes = &.{.{ .key = "doc:large", .value = doc_v2 }},
+        .sync_level = .full_index,
+    });
+
+    const manifest_key = try internal_keys.artifactNamedPrefixAlloc(alloc, "doc:large", "asset", "document_units_v1");
+    defer alloc.free(manifest_key);
+    const manifest = try db.core.store.get(alloc, manifest_key);
+    defer alloc.free(manifest);
+    try std.testing.expect(std.mem.indexOf(u8, manifest, "\"generation\":2") != null);
+
+    const second_state = try db.core.store.get(alloc, state_key);
+    defer alloc.free(second_state);
+    const second_chunk_keys = try documentExtractionStateChunkKeysAlloc(alloc, second_state);
+    defer freeOwnedConstKeySlice(alloc, second_chunk_keys);
+    try std.testing.expect(second_chunk_keys.len > 300);
+
+    var second_result = try db.search(alloc, .{
+        .index_name = "ft_document_chunks",
+        .full_text = .{ .match = .{ .field = "text", .text = "secondversiontoken" } },
+        .return_mode = .chunk,
+    });
+    defer second_result.deinit();
+    try std.testing.expect(second_result.total_hits > 0);
+
+    var first_result = try db.search(alloc, .{
+        .index_name = "ft_document_chunks",
+        .full_text = .{ .match = .{ .field = "text", .text = "firstversiontoken" } },
+        .return_mode = .chunk,
+    });
+    defer first_result.deinit();
+    try std.testing.expectEqual(@as(u32, 0), first_result.total_hits);
+}
+
+test "db document extraction update recovers corrupt previous extraction state" {
+    const alloc = std.testing.allocator;
+
+    var path_buf: [256]u8 = undefined;
+    const path = tempPath(&path_buf);
+    defer cleanupTempDir(path);
+
+    var db = try DB.open(alloc, std.mem.span(path), .{});
+    defer db.close();
+
+    try db.addEnrichment(.{
+        .name = "document_units_v1",
+        .kind = .asset,
+        .field = "url",
+        .content_type = "application/json",
+        .producer_json = "{\"type\":\"document_extraction\",\"config\":{\"source\":{\"etag_field\":\"sha256\",\"version_field\":\"sha256\",\"content_type_field\":\"mime_type\",\"filename_field\":\"filename\"}}}",
+    });
+    try db.addEnrichment(.{
+        .name = "document_chunks_v1",
+        .kind = .chunk,
+        .field = "text",
+        .source_artifact_name = "document_units_v1",
+        .chunk_size = 96,
+        .chunk_overlap = 0,
+        .full_text_index = true,
+    });
+
+    const url_v1 = try testLargeHtmlDataUrlAlloc(alloc, "v1", "corruptoldtoken", 80);
+    defer alloc.free(url_v1);
+    const doc_v1 = try testSourceDocumentJsonAlloc(alloc, url_v1, "sha-v1");
+    defer alloc.free(doc_v1);
+    try db.batch(.{
+        .writes = &.{.{ .key = "doc:corrupt", .value = doc_v1 }},
+        .sync_level = .full_index,
+    });
+
+    const state_key = try assetStateKeyAlloc(alloc, "doc:corrupt", "document_units_v1");
+    defer alloc.free(state_key);
+    try db.core.store.put(state_key, "{\"kind\":\"document_extraction_state_v1\",\"unit_keys\":[7],\"unit_descriptors\":{},\"chunk_keys\":[false]}");
+
+    const url_v2 = try testLargeHtmlDataUrlAlloc(alloc, "v2", "corruptnewtoken", 80);
+    defer alloc.free(url_v2);
+    const doc_v2 = try testSourceDocumentJsonAlloc(alloc, url_v2, "sha-v2");
+    defer alloc.free(doc_v2);
+    try db.batch(.{
+        .writes = &.{.{ .key = "doc:corrupt", .value = doc_v2 }},
+        .sync_level = .full_index,
+    });
+
+    const recovered_state = try db.core.store.get(alloc, state_key);
+    defer alloc.free(recovered_state);
+    const recovered_chunk_keys = try documentExtractionStateChunkKeysAlloc(alloc, recovered_state);
+    defer freeOwnedConstKeySlice(alloc, recovered_chunk_keys);
+    try std.testing.expect(recovered_chunk_keys.len > 0);
 }
 
 test "db extractEnrichments exposes cleaned writes and special fields" {

--- a/zig/pkg/antfly/src/storage/db/db.zig
+++ b/zig/pkg/antfly/src/storage/db/db.zig
@@ -10538,7 +10538,10 @@ pub const DB = struct {
         };
 
         var targets = std.ArrayListUnmanaged(DenseArtifactRebuildTarget).empty;
-        errdefer targets.deinit(alloc);
+        errdefer {
+            for (targets.items) |*target| target.deinit(alloc);
+            targets.deinit(alloc);
+        }
 
         var candidates = std.ArrayListUnmanaged(Candidate).empty;
         defer {
@@ -11041,6 +11044,7 @@ pub const DB = struct {
         try self.prepareDenseArtifactRebuildPlan(plan);
         const ResumePersistCtx = struct {
             db: *DB,
+            alloc: Allocator,
             targets: []DenseArtifactRebuildTarget,
 
             fn run(ctx: *anyopaque, last_key: []const u8) !void {
@@ -11050,19 +11054,20 @@ pub const DB = struct {
                         if (std.mem.order(u8, last_key, resume_from) != .gt) continue;
                     }
                     const entry = &persist.db.core.index_manager.dense_indexes.items[target.dense_index_idx];
-                    const rebuild_root_path = try persist.db.denseIndexRebuildStatePathAlloc(persist.db.alloc, entry.config.name);
-                    defer persist.db.alloc.free(rebuild_root_path);
+                    const rebuild_root_path = try persist.db.denseIndexRebuildStatePathAlloc(persist.alloc, entry.config.name);
+                    defer persist.alloc.free(rebuild_root_path);
                     const rebuild_state = backfill_state_mod.RebuildState.init(rebuild_root_path);
                     try rebuild_state.update(last_key);
-                    const owned_key = try persist.db.alloc.dupe(u8, last_key);
-                    errdefer persist.db.alloc.free(owned_key);
-                    if (target.resume_from) |resume_from| persist.db.alloc.free(resume_from);
+                    const owned_key = try persist.alloc.dupe(u8, last_key);
+                    errdefer persist.alloc.free(owned_key);
+                    if (target.resume_from) |resume_from| persist.alloc.free(resume_from);
                     target.resume_from = owned_key;
                 }
             }
         };
         var persist_ctx = ResumePersistCtx{
             .db = self,
+            .alloc = alloc,
             .targets = plan.targets,
         };
         const rebuilt = try self.rebuildDenseIndexesFromStoredEmbeddingArtifactsResumeWithProgress(
@@ -49618,6 +49623,67 @@ test "db dense artifact rebuild resumes from persisted state" {
         }
         try std.testing.expectEqual(@as(?u64, doc_count), dense_doc_count);
     }
+}
+
+test "db dense artifact rebuild resume keys are owned by plan allocator" {
+    const alloc = std.testing.allocator;
+    const db_alloc = std.heap.page_allocator;
+    const doc_count: usize = 3;
+
+    var path_buf: [256]u8 = undefined;
+    const path = tempPath(&path_buf);
+    defer cleanupTempDir(path);
+
+    {
+        var db = try DB.open(db_alloc, std.mem.span(path), .{
+            .start_index_workers = false,
+            .ttl_cleanup = .{ .enabled = false },
+        });
+        defer db.close();
+
+        try db.addIndex(.{
+            .name = "dense_idx",
+            .kind = .dense_vector,
+            .config_json = "{\"field\":\"embedding\",\"dims\":3,\"metric\":\"l2_squared\",\"external\":true}",
+        });
+
+        for (0..doc_count) |i| {
+            const doc_id = try std.fmt.allocPrint(alloc, "doc:{d:0>5}", .{i});
+            defer alloc.free(doc_id);
+            const stored_key = try internal_keys.documentKeyAlloc(alloc, doc_id);
+            defer alloc.free(stored_key);
+            const stored_value = try std.fmt.allocPrint(alloc, "{{\"title\":\"doc-{d}\"}}", .{i});
+            defer alloc.free(stored_value);
+            try db.core.store.putBatch(&.{
+                .{ .key = stored_key, .value = stored_value },
+            }, &.{});
+
+            const artifact_key = try expectedDocumentEmbeddingArtifactKeyAlloc(alloc, doc_id, "dense_idx");
+            defer alloc.free(artifact_key);
+            try putDenseEmbeddingArtifactWithCounterForTest(&db, alloc, artifact_key, null, &[_]f32{
+                @floatFromInt(i + 1),
+                0,
+                0,
+            });
+        }
+    }
+
+    var io_impl = threadedIo();
+    defer io_impl.deinit();
+    const dense_index_path = try std.fmt.allocPrint(alloc, "{s}/indexes/dense_idx", .{std.mem.span(path)});
+    defer alloc.free(dense_index_path);
+    try std.Io.Dir.cwd().deleteTree(io_impl.io(), dense_index_path);
+
+    var reopened = try DB.open(db_alloc, std.mem.span(path), .{
+        .open_mode = .writer_no_replay,
+        .start_index_workers = false,
+        .ttl_cleanup = .{ .enabled = false },
+    });
+    defer reopened.close();
+
+    const rebuilt = try reopened.rebuildDenseIndexesFromStoredEmbeddingArtifactsIfNeeded(alloc);
+    try std.testing.expectEqual(doc_count, rebuilt);
+    try std.testing.expectEqual(@as(u64, doc_count), reopened.core.index_manager.denseIndex("dense_idx").?.index.metadata.active_count);
 }
 
 test "db dense artifact rebuild progress counts source artifacts across multiple consumer indexes" {

--- a/zig/pkg/antfly/src/storage/db/db.zig
+++ b/zig/pkg/antfly/src/storage/db/db.zig
@@ -41071,7 +41071,10 @@ test "db write sync trailing dense no-op batches drain stale delete replay at id
     while (attempts < slow_test_wait_attempts) : (attempts += 1) {
         const stats = try db.stats(alloc);
         defer types.freeDBStats(alloc, stats);
-        try std.testing.expectEqual(@as(usize, 1), stats.indexes.len);
+        if (stats.indexes.len != 1) {
+            sleepPollInterval();
+            continue;
+        }
         const index = stats.indexes[0];
         if (index.doc_count == 3 and
             index.replay_applied_sequence >= index.replay_target_sequence and
@@ -41107,7 +41110,10 @@ test "db write sync trailing dense no-op batches drain stale delete replay at id
     while (attempts < slow_test_wait_attempts) : (attempts += 1) {
         const stats = try db.stats(alloc);
         defer types.freeDBStats(alloc, stats);
-        try std.testing.expectEqual(@as(usize, 1), stats.indexes.len);
+        if (stats.indexes.len != 1) {
+            sleepPollInterval();
+            continue;
+        }
         const index = stats.indexes[0];
         if (index.doc_count == 2 and
             index.replay_applied_sequence >= index.replay_target_sequence and

--- a/zig/pkg/antfly/src/storage/db/db.zig
+++ b/zig/pkg/antfly/src/storage/db/db.zig
@@ -17131,6 +17131,9 @@ fn scanDocumentExtractionPreviousStateFromStore(
     out.unit_keys = try unit_keys.toOwnedSlice(alloc);
     out.chunk_keys = try chunk_keys.toOwnedSlice(alloc);
     out.unit_descriptors = try alloc.alloc(DocumentExtractionUnitDescriptor, out.unit_keys.len);
+    for (out.unit_descriptors) |*descriptor| {
+        descriptor.* = .{ .key = "", .fingerprint = "" };
+    }
     for (out.unit_descriptors, out.unit_keys) |*descriptor, key| {
         descriptor.* = .{
             .key = try alloc.dupe(u8, key),

--- a/zig/pkg/antfly/src/storage/db/enrichment/enrichment_runtime.zig
+++ b/zig/pkg/antfly/src/storage/db/enrichment/enrichment_runtime.zig
@@ -2052,9 +2052,6 @@ fn processDocumentExtractionAsset(
             try appendUniqueDupeKey(runtime.alloc, &window.changed_artifact_keys, previous_key);
             try appendUniqueDupeKey(runtime.alloc, &window.deleted_keys, previous_key);
         }
-        if (previous_state.recovered_from_store_scan) {
-            try deletes.append(runtime.alloc, try runtime.alloc.dupe(u8, state_key));
-        }
     }
 
     const empty_units: [0]document_extraction_mod.Unit = .{};
@@ -5687,6 +5684,9 @@ fn scanRuntimeDocumentExtractionPreviousStateFromStore(
     out.unit_keys = try unit_keys.toOwnedSlice(runtime.alloc);
     out.chunk_keys = try chunk_keys.toOwnedSlice(runtime.alloc);
     out.unit_descriptors = try runtime.alloc.alloc(DocumentExtractionUnitDescriptor, out.unit_keys.len);
+    for (out.unit_descriptors) |*descriptor| {
+        descriptor.* = .{ .key = "", .fingerprint = "" };
+    }
     for (out.unit_descriptors, out.unit_keys) |*descriptor, key| {
         descriptor.* = .{
             .key = try runtime.alloc.dupe(u8, key),

--- a/zig/pkg/antfly/src/storage/db/enrichment/enrichment_runtime.zig
+++ b/zig/pkg/antfly/src/storage/db/enrichment/enrichment_runtime.zig
@@ -2311,6 +2311,7 @@ fn deleteDocumentExtractionForRuntime(
     try deletes.append(runtime.alloc, try runtime.alloc.dupe(u8, manifest_key));
     try deletes.append(runtime.alloc, try runtime.alloc.dupe(u8, state_key));
     try appendUniqueDupeKey(runtime.alloc, &window.changed_artifact_keys, manifest_key);
+    try appendUniqueDupeKey(runtime.alloc, &window.artifact_delete_keys, manifest_key);
 
     const existing_state = storeGetAlloc(runtime, state_key) catch |err| switch (err) {
         std.mem.Allocator.Error.OutOfMemory => return err,
@@ -2323,10 +2324,12 @@ fn deleteDocumentExtractionForRuntime(
         for (previous_state.unit_keys) |previous_key| {
             try deletes.append(runtime.alloc, try runtime.alloc.dupe(u8, previous_key));
             try appendUniqueDupeKey(runtime.alloc, &window.changed_artifact_keys, previous_key);
+            try appendUniqueDupeKey(runtime.alloc, &window.artifact_delete_keys, previous_key);
         }
         for (previous_state.chunk_keys) |previous_key| {
             try deletes.append(runtime.alloc, try runtime.alloc.dupe(u8, previous_key));
             try appendUniqueDupeKey(runtime.alloc, &window.changed_artifact_keys, previous_key);
+            try appendUniqueDupeKey(runtime.alloc, &window.artifact_delete_keys, previous_key);
         }
     }
 
@@ -5846,9 +5849,13 @@ fn documentExtractionStateUnitDescriptorsAlloc(alloc: Allocator, state: []const 
         const key_value = item.object.get("key") orelse return error.InvalidDocumentExtractionState;
         const fingerprint_value = item.object.get("fingerprint") orelse return error.InvalidDocumentExtractionState;
         if (fingerprint_value != .string) return error.InvalidDocumentExtractionState;
+        const key = try documentExtractionStateByteSliceAlloc(alloc, key_value);
+        errdefer alloc.free(@constCast(key));
+        const fingerprint = try alloc.dupe(u8, fingerprint_value.string);
+        errdefer alloc.free(fingerprint);
         out[i] = .{
-            .key = try documentExtractionStateByteSliceAlloc(alloc, key_value),
-            .fingerprint = try alloc.dupe(u8, fingerprint_value.string),
+            .key = key,
+            .fingerprint = fingerprint,
         };
         initialized += 1;
     }

--- a/zig/pkg/antfly/src/storage/db/enrichment/enrichment_runtime.zig
+++ b/zig/pkg/antfly/src/storage/db/enrichment/enrichment_runtime.zig
@@ -2033,30 +2033,27 @@ fn processDocumentExtractionAsset(
         deletes.deinit(runtime.alloc);
     }
 
-    var previous_unit_keys: []const []const u8 = &.{};
-    defer freeOwnedConstKeySlice(runtime.alloc, previous_unit_keys);
-    var previous_unit_descriptors: []DocumentExtractionUnitDescriptor = &.{};
-    defer freeDocumentExtractionUnitDescriptors(runtime.alloc, previous_unit_descriptors);
-    var previous_chunk_keys: []const []const u8 = &.{};
-    defer freeOwnedConstKeySlice(runtime.alloc, previous_chunk_keys);
+    var previous_state = RuntimeDocumentExtractionPreviousState{};
+    defer previous_state.deinit(runtime.alloc);
     if (existing_state) |state| {
-        previous_unit_keys = try documentExtractionStateUnitKeysAlloc(runtime.alloc, state);
-        previous_unit_descriptors = try documentExtractionStateUnitDescriptorsAlloc(runtime.alloc, state);
-        previous_chunk_keys = try documentExtractionStateChunkKeysAlloc(runtime.alloc, state);
+        previous_state = try loadRuntimeDocumentExtractionPreviousState(runtime, request.doc_key, artifact_name, state);
     }
 
     if (existing_state != null) {
-        for (previous_unit_keys) |previous_key| {
+        for (previous_state.unit_keys) |previous_key| {
             if (runtimeContainsConstKey(desired_unit_keys.items, previous_key)) continue;
             try deletes.append(runtime.alloc, try runtime.alloc.dupe(u8, previous_key));
             try appendUniqueDupeKey(runtime.alloc, &window.changed_artifact_keys, previous_key);
             try appendUniqueDupeKey(runtime.alloc, &window.deleted_keys, previous_key);
         }
-        for (previous_chunk_keys) |previous_key| {
+        for (previous_state.chunk_keys) |previous_key| {
             if (runtimeContainsConstKey(desired_chunk_keys.items, previous_key)) continue;
             try deletes.append(runtime.alloc, try runtime.alloc.dupe(u8, previous_key));
             try appendUniqueDupeKey(runtime.alloc, &window.changed_artifact_keys, previous_key);
             try appendUniqueDupeKey(runtime.alloc, &window.deleted_keys, previous_key);
+        }
+        if (previous_state.recovered_from_store_scan) {
+            try deletes.append(runtime.alloc, try runtime.alloc.dupe(u8, state_key));
         }
     }
 
@@ -2080,9 +2077,9 @@ fn processDocumentExtractionAsset(
         desired_unit_descriptors,
         desired_chunk_keys.items,
         previous_child_ranges,
-        previous_unit_keys,
-        previous_unit_descriptors,
-        previous_chunk_keys,
+        previous_state.unit_keys,
+        previous_state.unit_descriptors,
+        previous_state.chunk_keys,
         &.{},
         from_generation,
         from_generation,
@@ -2158,9 +2155,9 @@ fn processDocumentExtractionAsset(
         desired_unit_descriptors,
         desired_chunk_keys.items,
         previous_child_ranges,
-        previous_unit_keys,
-        previous_unit_descriptors,
-        previous_chunk_keys,
+        previous_state.unit_keys,
+        previous_state.unit_descriptors,
+        previous_state.chunk_keys,
         &.{},
         to_generation,
         from_generation,
@@ -2227,16 +2224,10 @@ fn writeDocumentExtractionFailureManifest(
     from_generation: u64,
     window: *GeneratedReplayWindow,
 ) !void {
-    var previous_unit_keys: []const []const u8 = &.{};
-    defer freeOwnedConstKeySlice(runtime.alloc, previous_unit_keys);
-    var previous_unit_descriptors: []DocumentExtractionUnitDescriptor = &.{};
-    defer freeDocumentExtractionUnitDescriptors(runtime.alloc, previous_unit_descriptors);
-    var previous_chunk_keys: []const []const u8 = &.{};
-    defer freeOwnedConstKeySlice(runtime.alloc, previous_chunk_keys);
+    var previous_state = RuntimeDocumentExtractionPreviousState{};
+    defer previous_state.deinit(runtime.alloc);
     if (existing_state) |state| {
-        previous_unit_keys = try documentExtractionStateUnitKeysAlloc(runtime.alloc, state);
-        previous_unit_descriptors = try documentExtractionStateUnitDescriptorsAlloc(runtime.alloc, state);
-        previous_chunk_keys = try documentExtractionStateChunkKeysAlloc(runtime.alloc, state);
+        previous_state = try loadRuntimeDocumentExtractionPreviousState(runtime, doc_key, artifact_name, state);
     }
 
     const empty_units: [0]document_extraction_mod.Unit = .{};
@@ -2258,9 +2249,9 @@ fn writeDocumentExtractionFailureManifest(
         &.{},
         &.{},
         previous_child_ranges,
-        previous_unit_keys,
-        previous_unit_descriptors,
-        previous_chunk_keys,
+        previous_state.unit_keys,
+        previous_state.unit_descriptors,
+        previous_state.chunk_keys,
         previous_child_ranges,
         to_generation,
         from_generation,
@@ -2291,12 +2282,12 @@ fn writeDocumentExtractionFailureManifest(
     try appendUniqueDupeKey(runtime.alloc, &window.changed_artifact_keys, manifest_key);
 
     try deletes.append(runtime.alloc, try runtime.alloc.dupe(u8, state_key));
-    for (previous_unit_keys) |previous_key| {
+    for (previous_state.unit_keys) |previous_key| {
         try deletes.append(runtime.alloc, try runtime.alloc.dupe(u8, previous_key));
         try appendUniqueDupeKey(runtime.alloc, &window.changed_artifact_keys, previous_key);
         try appendUniqueDupeKey(runtime.alloc, &window.deleted_keys, previous_key);
     }
-    for (previous_chunk_keys) |previous_key| {
+    for (previous_state.chunk_keys) |previous_key| {
         try deletes.append(runtime.alloc, try runtime.alloc.dupe(u8, previous_key));
         try appendUniqueDupeKey(runtime.alloc, &window.changed_artifact_keys, previous_key);
         try appendUniqueDupeKey(runtime.alloc, &window.deleted_keys, previous_key);
@@ -5611,6 +5602,100 @@ const DocumentExtractionRangeRoute = struct {
     route_status: []const u8 = "local_committed",
     owner_group_id: u64 = 0,
 };
+
+const RuntimeDocumentExtractionPreviousState = struct {
+    unit_keys: []const []const u8 = &.{},
+    unit_descriptors: []DocumentExtractionUnitDescriptor = &.{},
+    chunk_keys: []const []const u8 = &.{},
+    recovered_from_store_scan: bool = false,
+
+    fn deinit(self: *@This(), alloc: Allocator) void {
+        freeOwnedConstKeySlice(alloc, self.unit_keys);
+        freeDocumentExtractionUnitDescriptors(alloc, self.unit_descriptors);
+        freeOwnedConstKeySlice(alloc, self.chunk_keys);
+        self.* = undefined;
+    }
+};
+
+fn loadRuntimeDocumentExtractionPreviousState(
+    runtime: *EnrichmentRuntime,
+    doc_key: []const u8,
+    artifact_name: []const u8,
+    state: []const u8,
+) !RuntimeDocumentExtractionPreviousState {
+    if (loadRuntimeDocumentExtractionPreviousStateFromJson(runtime.alloc, state)) |parsed| {
+        return parsed;
+    } else |err| switch (err) {
+        error.OutOfMemory => return err,
+        error.InvalidDocumentExtractionState, error.SyntaxError => {},
+        else => return err,
+    }
+    var recovered = try scanRuntimeDocumentExtractionPreviousStateFromStore(runtime, doc_key, artifact_name);
+    recovered.recovered_from_store_scan = true;
+    return recovered;
+}
+
+fn loadRuntimeDocumentExtractionPreviousStateFromJson(alloc: Allocator, state: []const u8) !RuntimeDocumentExtractionPreviousState {
+    var out = RuntimeDocumentExtractionPreviousState{};
+    errdefer out.deinit(alloc);
+    out.unit_keys = try documentExtractionStateUnitKeysAlloc(alloc, state);
+    out.unit_descriptors = try documentExtractionStateUnitDescriptorsAlloc(alloc, state);
+    out.chunk_keys = try documentExtractionStateChunkKeysAlloc(alloc, state);
+    return out;
+}
+
+fn scanRuntimeDocumentExtractionPreviousStateFromStore(
+    runtime: *EnrichmentRuntime,
+    doc_key: []const u8,
+    artifact_name: []const u8,
+) !RuntimeDocumentExtractionPreviousState {
+    var out = RuntimeDocumentExtractionPreviousState{};
+    errdefer out.deinit(runtime.alloc);
+
+    var unit_keys = std.ArrayListUnmanaged([]const u8).empty;
+    errdefer {
+        for (unit_keys.items) |key| runtime.alloc.free(@constCast(key));
+        unit_keys.deinit(runtime.alloc);
+    }
+    const unit_prefix = try internal_keys.artifactNamedPrefixAlloc(runtime.alloc, doc_key, "asset", artifact_name);
+    defer runtime.alloc.free(unit_prefix);
+    const unit_rows = try backend_scan.scanPrefix(runtime.alloc, &runtime.store, unit_prefix);
+    defer backend_scan.freeResults(runtime.alloc, unit_rows);
+    for (unit_rows) |entry| {
+        if (std.mem.eql(u8, entry.key, unit_prefix)) continue;
+        if (internal_keys.isDerivedEmbeddingArtifactKey(entry.key)) continue;
+        try unit_keys.append(runtime.alloc, try runtime.alloc.dupe(u8, entry.key));
+    }
+
+    var chunk_keys = std.ArrayListUnmanaged([]const u8).empty;
+    errdefer {
+        for (chunk_keys.items) |key| runtime.alloc.free(@constCast(key));
+        chunk_keys.deinit(runtime.alloc);
+    }
+    for (runtime.index_manager.enrichments.items) |entry| {
+        if (entry.kind != .chunk) continue;
+        if (!std.mem.eql(u8, entry.source_artifact_name, artifact_name)) continue;
+        const chunk_prefix = try internal_keys.artifactNamedPrefixAlloc(runtime.alloc, doc_key, "chunk", entry.name);
+        defer runtime.alloc.free(chunk_prefix);
+        const chunk_rows = try backend_scan.scanPrefix(runtime.alloc, &runtime.store, chunk_prefix);
+        defer backend_scan.freeResults(runtime.alloc, chunk_rows);
+        for (chunk_rows) |row| {
+            if (!internal_keys.isChunkArtifactRecordKey(row.key)) continue;
+            try chunk_keys.append(runtime.alloc, try runtime.alloc.dupe(u8, row.key));
+        }
+    }
+
+    out.unit_keys = try unit_keys.toOwnedSlice(runtime.alloc);
+    out.chunk_keys = try chunk_keys.toOwnedSlice(runtime.alloc);
+    out.unit_descriptors = try runtime.alloc.alloc(DocumentExtractionUnitDescriptor, out.unit_keys.len);
+    for (out.unit_descriptors, out.unit_keys) |*descriptor, key| {
+        descriptor.* = .{
+            .key = try runtime.alloc.dupe(u8, key),
+            .fingerprint = "",
+        };
+    }
+    return out;
+}
 
 fn documentExtractionUnitFingerprintAlloc(alloc: Allocator, unit: document_extraction_mod.Unit) ![]u8 {
     var hasher = std.crypto.hash.sha2.Sha256.init(.{});

--- a/zig/pkg/antfly/src/storage/db/enrichment/enrichment_runtime.zig
+++ b/zig/pkg/antfly/src/storage/db/enrichment/enrichment_runtime.zig
@@ -1745,7 +1745,7 @@ fn processAsset(
         const state_key = try assetStateKeyAlloc(runtime.alloc, request.doc_key, artifact_name);
         defer runtime.alloc.free(state_key);
         if (producer_cfg.type == .document_extraction) {
-            try deleteDocumentExtractionForRuntime(runtime, key, state_key, window);
+            try deleteDocumentExtractionForRuntime(runtime, request.doc_key, artifact_name, key, state_key, window);
         } else {
             try storePutBatchWithRetry(runtime, &.{}, &.{ key, state_key });
             try appendUniqueDupeKey(runtime.alloc, &window.changed_artifact_keys, key);
@@ -1759,7 +1759,7 @@ fn processAsset(
         const state_key = try assetStateKeyAlloc(runtime.alloc, request.doc_key, artifact_name);
         defer runtime.alloc.free(state_key);
         if (producer_cfg.type == .document_extraction) {
-            try deleteDocumentExtractionForRuntime(runtime, key, state_key, window);
+            try deleteDocumentExtractionForRuntime(runtime, request.doc_key, artifact_name, key, state_key, window);
         } else {
             try storePutBatchWithRetry(runtime, &.{}, &.{ key, state_key });
             try appendUniqueDupeKey(runtime.alloc, &window.changed_artifact_keys, key);
@@ -2299,6 +2299,8 @@ fn writeDocumentExtractionFailureManifest(
 
 fn deleteDocumentExtractionForRuntime(
     runtime: *EnrichmentRuntime,
+    doc_key: []const u8,
+    artifact_name: []const u8,
     manifest_key: []const u8,
     state_key: []const u8,
     window: *GeneratedReplayWindow,
@@ -2319,15 +2321,13 @@ fn deleteDocumentExtractionForRuntime(
     };
     defer if (existing_state) |value| runtime.alloc.free(value);
     if (existing_state) |state| {
-        const previous_keys = try documentExtractionStateUnitKeysAlloc(runtime.alloc, state);
-        defer freeOwnedConstKeySlice(runtime.alloc, previous_keys);
-        for (previous_keys) |previous_key| {
+        var previous_state = try loadRuntimeDocumentExtractionPreviousState(runtime, doc_key, artifact_name, state);
+        defer previous_state.deinit(runtime.alloc);
+        for (previous_state.unit_keys) |previous_key| {
             try deletes.append(runtime.alloc, try runtime.alloc.dupe(u8, previous_key));
             try appendUniqueDupeKey(runtime.alloc, &window.changed_artifact_keys, previous_key);
         }
-        const previous_chunk_keys = try documentExtractionStateChunkKeysAlloc(runtime.alloc, state);
-        defer freeOwnedConstKeySlice(runtime.alloc, previous_chunk_keys);
-        for (previous_chunk_keys) |previous_key| {
+        for (previous_state.chunk_keys) |previous_key| {
             try deletes.append(runtime.alloc, try runtime.alloc.dupe(u8, previous_key));
             try appendUniqueDupeKey(runtime.alloc, &window.changed_artifact_keys, previous_key);
         }
@@ -5627,8 +5627,7 @@ fn loadRuntimeDocumentExtractionPreviousState(
         return parsed;
     } else |err| switch (err) {
         error.OutOfMemory => return err,
-        error.InvalidDocumentExtractionState, error.SyntaxError => {},
-        else => return err,
+        else => {},
     }
     var recovered = try scanRuntimeDocumentExtractionPreviousStateFromStore(runtime, doc_key, artifact_name);
     recovered.recovered_from_store_scan = true;
@@ -5846,9 +5845,9 @@ fn documentExtractionStateUnitDescriptorsAlloc(alloc: Allocator, state: []const 
         if (item != .object) return error.InvalidDocumentExtractionState;
         const key_value = item.object.get("key") orelse return error.InvalidDocumentExtractionState;
         const fingerprint_value = item.object.get("fingerprint") orelse return error.InvalidDocumentExtractionState;
-        if (key_value != .string or fingerprint_value != .string) return error.InvalidDocumentExtractionState;
+        if (fingerprint_value != .string) return error.InvalidDocumentExtractionState;
         out[i] = .{
-            .key = try alloc.dupe(u8, key_value.string),
+            .key = try documentExtractionStateByteSliceAlloc(alloc, key_value),
             .fingerprint = try alloc.dupe(u8, fingerprint_value.string),
         };
         initialized += 1;
@@ -5869,9 +5868,8 @@ fn documentExtractionStateUnitDescriptorFallbackAlloc(alloc: Allocator, object: 
         alloc.free(out);
     }
     for (keys_value.array.items, 0..) |item, i| {
-        if (item != .string) return error.InvalidDocumentExtractionState;
         out[i] = .{
-            .key = try alloc.dupe(u8, item.string),
+            .key = try documentExtractionStateByteSliceAlloc(alloc, item),
             .fingerprint = "",
         };
         initialized += 1;
@@ -5892,11 +5890,26 @@ fn documentExtractionStateKeysAlloc(alloc: Allocator, state: []const u8, field_n
         alloc.free(out);
     }
     for (keys_value.array.items, 0..) |item, i| {
-        if (item != .string) return error.InvalidDocumentExtractionState;
-        out[i] = try alloc.dupe(u8, item.string);
+        out[i] = try documentExtractionStateByteSliceAlloc(alloc, item);
         initialized += 1;
     }
     return out;
+}
+
+fn documentExtractionStateByteSliceAlloc(alloc: Allocator, value: std.json.Value) ![]const u8 {
+    switch (value) {
+        .string => |string| return try alloc.dupe(u8, string),
+        .array => |array| {
+            const out = try alloc.alloc(u8, array.items.len);
+            errdefer alloc.free(out);
+            for (array.items, 0..) |item, i| {
+                if (item != .integer) return error.InvalidDocumentExtractionState;
+                out[i] = std.math.cast(u8, item.integer) orelse return error.InvalidDocumentExtractionState;
+            }
+            return out;
+        },
+        else => return error.InvalidDocumentExtractionState,
+    }
 }
 
 fn documentExtractionUnitKeyStillPresent(
@@ -7624,6 +7637,24 @@ fn freeJsonValue(alloc: Allocator, value: *std.json.Value) void {
 // ============================================================================
 // Tests
 // ============================================================================
+
+test "enrichment runtime document extraction state parses byte-array keys" {
+    const alloc = std.testing.allocator;
+    const state = "{\"kind\":\"document_extraction_state_v1\",\"fingerprint\":\"source\",\"unit_keys\":[[65,0,255]],\"unit_descriptors\":[{\"key\":[65,0,255],\"fingerprint\":\"fp\"}],\"chunk_keys\":[[66,1,254]]}";
+
+    var parsed = try loadRuntimeDocumentExtractionPreviousStateFromJson(alloc, state);
+    defer parsed.deinit(alloc);
+
+    const expected_unit_key = [_]u8{ 65, 0, 255 };
+    const expected_chunk_key = [_]u8{ 66, 1, 254 };
+    try std.testing.expectEqual(@as(usize, 1), parsed.unit_keys.len);
+    try std.testing.expectEqualSlices(u8, &expected_unit_key, parsed.unit_keys[0]);
+    try std.testing.expectEqual(@as(usize, 1), parsed.unit_descriptors.len);
+    try std.testing.expectEqualSlices(u8, &expected_unit_key, parsed.unit_descriptors[0].key);
+    try std.testing.expectEqualStrings("fp", parsed.unit_descriptors[0].fingerprint);
+    try std.testing.expectEqual(@as(usize, 1), parsed.chunk_keys.len);
+    try std.testing.expectEqualSlices(u8, &expected_chunk_key, parsed.chunk_keys[0]);
+}
 
 test "enrichment runtime document extraction manifest uses v2 range and merge shape" {
     const alloc = std.testing.allocator;


### PR DESCRIPTION
## Summary
- Decode document extraction state keys from both JSON strings and Zig byte-array JSON values.
- Recover from corrupt or incompatible previous extraction state by scanning stored document unit and chunk artifacts.
- Mirror the recovery behavior in the async enrichment runtime.

Fixes #328.

## Validation
- PR #326 does not cover this foreground document extraction state parsing/recovery path.
- zig build lib-db-test --summary failures -- --test-filter "document extraction"
- zig build lib-db-test --summary failures