### PR TITLE
Skip latest aliases for v0.1 releases

### DIFF
--- a/.github/workflows/antfly-container.yml
+++ b/.github/workflows/antfly-container.yml
@@ -219,7 +219,7 @@ jobs:
           }
           VERSION="${{ steps.version.outputs.version }}"
           ALIAS_TAG=latest
-          if [[ "$VERSION" == *-* ]]; then
+          if [[ "$VERSION" == *-* || "$VERSION" == v0.1.* ]]; then
             ALIAS_TAG=__skip_alias__
           fi
           submit_cloud_build . \
@@ -238,7 +238,7 @@ jobs:
           echo "${{ steps.auth.outputs.access_token }}" | crane auth login "$GAR_REGISTRY" -u oauth2accesstoken --password-stdin
           echo "${{ secrets.GITHUB_TOKEN }}" | crane auth login ghcr.io -u "${{ github.actor }}" --password-stdin
           TAGS=("${VERSION}")
-          if [[ "$VERSION" != *-* ]]; then
+          if [[ "$VERSION" != *-* && "$VERSION" != v0.1.* ]]; then
             TAGS=(latest "${TAGS[@]}")
           fi
           for tag in "${TAGS[@]}"; do
@@ -253,7 +253,7 @@ jobs:
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           TAGS=("${VERSION}")
-          if [[ "$VERSION" != *-* ]]; then
+          if [[ "$VERSION" != *-* && "$VERSION" != v0.1.* ]]; then
             TAGS=(latest "${TAGS[@]}")
           fi
           for tag in "${TAGS[@]}"; do
@@ -268,7 +268,7 @@ jobs:
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           TAGS=("${VERSION}")
-          if [[ "$VERSION" != *-* ]]; then
+          if [[ "$VERSION" != *-* && "$VERSION" != v0.1.* ]]; then
             TAGS=(latest "${TAGS[@]}")
           fi
           for tag in "${TAGS[@]}"; do


### PR DESCRIPTION
## Summary
- Prevent v0.1.x release-published container workflows from moving latest aliases
- Keep normal latest alias behavior for non-prerelease tags outside v0.1.x

## Why
The v0.1.2 tag is cut from v0.1.x, but publishing the GitHub release can trigger the default-branch container workflow via release: published. This keeps ghcr/GAR latest pointed at the intended current release while still allowing versioned v0.1.2 images.