### PR TITLE
Include OpenAPI specs in Docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -55,6 +55,8 @@ work-log/
 
 # Specs, datasets, and build cache
 specs/
+!specs/openapi/
+!specs/openapi/**
 datasets/
 .turbo/
 


### PR DESCRIPTION
## Summary

- re-include `specs/openapi/**` in the Docker build context
- keep the broader `specs/` exclusion in place for non-build spec content

## Why

The Antfly Zig build reads OpenAPI specs under `specs/openapi`, including `specs/openapi/ard/api.yaml`, but `.dockerignore` excluded the entire `specs/` tree. That made the Docker build context incomplete for builds that compile the Zig runtime from a Docker context.

## Verification

- `git diff --check`
- `docker build -f /private/tmp/antfly-openapi-context-smoke.Dockerfile -t antfly-openapi-context-smoke:local .`

The smoke Dockerfile uses `FROM scratch` and only copies `specs/openapi/ard/api.yaml`, confirming the required OpenAPI spec is now present in the Docker context without running the long Zig compile.
