### PR TITLE
De-flake scaling drain/shutdown e2e waits by nudging reallocation

### DIFF
--- a/zig/e2e/antfly/test_scaling.py
+++ b/zig/e2e/antfly/test_scaling.py
@@ -1290,6 +1290,14 @@ def _wait_node_shutdown_phase(
     timeout_s: float = 60.0,
 ) -> dict[str, Any] | None:
     def status_matches() -> dict[str, Any] | None:
+        # Shutdown convergence (drain debt clearing, then post-finalize cleanup to
+        # "not_found") is driven by the metadata reconcile loop. A reallocation
+        # request is a reconcile wake signal, so nudge it each poll to keep the loop
+        # advancing under load instead of waiting on the next unforced periodic pass.
+        try:
+            cluster.trigger_reallocate()
+        except (AssertionError, requests.RequestException):
+            pass
         try:
             response = requests.get(f"{cluster.metadata_urls[0]}/internal/v1/nodes/{node_id}/shutdown", timeout=10)
             response.raise_for_status()
@@ -1370,6 +1378,15 @@ def test_autoscaling_drains_data_node_and_replaces_placements(
     cluster.request_node_shutdown(node_to_drain)
 
     def drained_and_replaced() -> dict[str, Any] | None:
+        # Reallocation off a draining node is request-driven (a ReallocationRequest
+        # record consumed by the metadata control loop). Nudge it on every poll like
+        # the other placement-progress helpers do, so the drain makes deterministic
+        # progress instead of relying on an unforced background pass that can lag past
+        # the timeout on a loaded runner.
+        try:
+            cluster.trigger_reallocate()
+        except (AssertionError, requests.RequestException):
+            return None
         snapshots = _all_metadata_snapshots(cluster)
         if snapshots is None:
             return None


### PR DESCRIPTION
> ## Problem
> 
> `test_autoscaling_*` in `zig/e2e/antfly/test_scaling.py` intermittently time out. In CI this surfaced as:
> 
> ```
> AssertionError: drained node still owned table placements before stop
> ```
> 
> and reproduced locally as the later `finalize -> not_found` wait timing out. Both are the same root cause.
> 
> ## Root cause
> 
> These waits depend on the metadata **reconcile control loop** advancing, but do not poke it. Reallocation off a draining node and post-shutdown cleanup are driven by that loop, which is signal-woken — and a `ReallocationRequest` is one of the wake signals (`metadata/service.zig` reconcile signal check). The robust placement-progress helpers already call `trigger_reallocate()` on every poll; `_wait_node_drained_for_groups` was fixed this way already, but two sites still relied on an unforced periodic pass that lags past the timeout on a loaded runner:
> 
> - the inline drain wait in `test_autoscaling_drains_data_node_and_replaces_placements`
> - `_wait_node_shutdown_phase` (used for both the `complete` and post-finalize `not_found` waits)
> 
> ## Fix
> 
> Nudge `trigger_reallocate()` on each poll in the two remaining sites, guarded exactly like the existing helpers. No assertion is weakened — the tests still require intents to actually move off the node and the shutdown phase to actually converge; they just stop depending on background-loop timing.
> 
> ## Validation
> 
> Built the `antfly` binary (zig 0.16.0) and ran the drain/churn scaling tests locally:
> 
> - Before: the loaded drain+churn scenario intermittently failed (~98s to timeout).
> - After: **three consecutive green runs** of the three drain/churn tests, ~27-29s each (also ~3x faster, since convergence is now driven deterministically instead of waiting on periodic passes).