### PR TITLE
Fix HA failover recovery from live Kind validation

### DIFF
--- a/go/pkg/operator/controllers/antfly/antflycluster_controller.go
+++ b/go/pkg/operator/controllers/antfly/antflycluster_controller.go
@@ -3444,6 +3444,7 @@ func (r *AntflyClusterReconciler) updateStatus(ctx context.Context, cluster *ant
 		if err := r.observeHAFencingStatus(ctx, cluster); err != nil {
 			return err
 		}
+		r.observeHAFormerPrimaryFenceStatus(ctx, cluster)
 		r.updateHAStatusAndConditions(cluster)
 		if haAdminStatusErr != nil {
 			setHACondition(
@@ -3539,6 +3540,7 @@ func (r *AntflyClusterReconciler) updateStatus(ctx context.Context, cluster *ant
 	if err := r.observeHAFencingStatus(ctx, cluster); err != nil {
 		return err
 	}
+	r.observeHAFormerPrimaryFenceStatus(ctx, cluster)
 	r.updateHAStatusAndConditions(cluster)
 	if haAdminStatusErr != nil {
 		setHACondition(
@@ -5147,8 +5149,15 @@ func (r *AntflyClusterReconciler) applyHADirectRejoinJobResult(cluster *antflyv1
 	}
 	action.AdminResult = haRejoinAdminActionResult(result)
 	if !haActionHasRequiredAdminResult(*action) {
-		action.AdminResult = nil
-		return false
+		if haActionKind(action.Kind) == haActionDemoteFormerPrimary &&
+			strings.TrimSpace(action.AdminResult.RejoinAction) != "" &&
+			strings.TrimSpace(action.AdminResult.FormerNodeID) != "" {
+			// DemoteFormerPrimary records the assessment step. A valid assessment
+			// may reject rejoin before any rewind/reseed execution result exists.
+		} else {
+			action.AdminResult = nil
+			return false
+		}
 	}
 	if cluster.Status.HAStatus.FormerPrimary == nil {
 		cluster.Status.HAStatus.FormerPrimary = &antflyv1.HAFormerPrimaryStatus{NodeID: action.StandbyName}
@@ -5239,14 +5248,16 @@ func haDirectRejoinResultMatchesAction(result haRejoinJobResult, status *antflyv
 	if action.StandbyName != "" && result.FormerNodeID != action.StandbyName {
 		return false
 	}
-	if action.TargetLSN > 0 && result.ForkLSN != action.TargetLSN {
-		return false
-	}
-	if action.ObservedLSN > 0 && result.FormerLastLSN != action.ObservedLSN {
-		return false
+	if haActionKind(action.Kind) == haActionDemoteFormerPrimary {
+		if action.ObservedLSN > 0 && result.FormerLastLSN != action.ObservedLSN {
+			return false
+		}
 	}
 	if action.RetainedFromLSN > 0 && result.RetainedFromLSN != action.RetainedFromLSN {
 		return false
+	}
+	if haActionKind(action.Kind) == haActionDemoteFormerPrimary {
+		return true
 	}
 	if status != nil && status.LastPromotion != nil {
 		promotion := status.LastPromotion
@@ -7371,11 +7382,10 @@ func haRejoinResultMatchesRequiredAdminResult(action antflyv1.HAPlannedActionSta
 	if action.StandbyName != "" && result.FormerNodeID != action.StandbyName {
 		return false
 	}
-	if action.TargetLSN > 0 && result.ForkLSN != action.TargetLSN {
-		return false
-	}
-	if action.ObservedLSN > 0 && result.FormerLastLSN != action.ObservedLSN {
-		return false
+	if haActionKind(action.Kind) == haActionDemoteFormerPrimary {
+		if action.ObservedLSN > 0 && result.FormerLastLSN != action.ObservedLSN {
+			return false
+		}
 	}
 	if action.RetainedFromLSN > 0 && result.RetainedFromLSN != action.RetainedFromLSN {
 		return false
@@ -7384,6 +7394,9 @@ func haRejoinResultMatchesRequiredAdminResult(action antflyv1.HAPlannedActionSta
 }
 
 func haFormerPrimaryActionSucceededWithPromotionEvidence(status *antflyv1.HAStatus, action antflyv1.HAPlannedActionStatus) bool {
+	if haActionKind(action.Kind) == haActionDemoteFormerPrimary {
+		return haAdminActionSucceededWithEvidence(action)
+	}
 	return haAdminActionSucceededWithEvidence(action) &&
 		haRejoinResultMatchesPromotion(status, action, action.AdminResult)
 }
@@ -7402,10 +7415,7 @@ func haRejoinResultMatchesPromotion(status *antflyv1.HAStatus, action antflyv1.H
 	if result.TargetTimelineID != promotion.NewTimelineID || result.TargetEpoch != promotion.NewEpoch {
 		return false
 	}
-	if promotion.SwitchLSN != 0 && result.ForkLSN != promotion.SwitchLSN {
-		return false
-	}
-	if promotion.RequiredLSN != 0 && result.ForkLSN != promotion.RequiredLSN {
+	if expectedForkLSN := haPromotionObservedLSN(promotion); expectedForkLSN != 0 && result.ForkLSN != expectedForkLSN {
 		return false
 	}
 	if haActionKind(action.Kind) == haActionRewindFormerPrimary &&

--- a/go/pkg/operator/controllers/antfly/antflycluster_controller.go
+++ b/go/pkg/operator/controllers/antfly/antflycluster_controller.go
@@ -5144,7 +5144,11 @@ func (r *AntflyClusterReconciler) applyHADirectRejoinJobResult(cluster *antflyv1
 	if cluster == nil || cluster.Status.HAStatus == nil || action == nil {
 		return false
 	}
-	if !haDirectRejoinResultMatchesAction(result, cluster.Status.HAStatus, *action) {
+	matchAction := *action
+	if haActionKind(matchAction.Kind) != haActionDemoteFormerPrimary && result.FormerLastLSN > 0 {
+		matchAction.ObservedLSN = result.FormerLastLSN
+	}
+	if !haDirectRejoinResultMatchesAction(result, cluster.Status.HAStatus, matchAction) {
 		return false
 	}
 	action.AdminResult = haRejoinAdminActionResult(result)
@@ -5249,6 +5253,13 @@ func haDirectRejoinResultMatchesAction(result haRejoinJobResult, status *antflyv
 		return false
 	}
 	if haActionKind(action.Kind) == haActionDemoteFormerPrimary {
+		if action.ObservedLSN > 0 && result.FormerLastLSN != action.ObservedLSN {
+			return false
+		}
+	} else {
+		if action.TargetLSN > 0 && result.ForkLSN != action.TargetLSN {
+			return false
+		}
 		if action.ObservedLSN > 0 && result.FormerLastLSN != action.ObservedLSN {
 			return false
 		}
@@ -7415,7 +7426,10 @@ func haRejoinResultMatchesPromotion(status *antflyv1.HAStatus, action antflyv1.H
 	if result.TargetTimelineID != promotion.NewTimelineID || result.TargetEpoch != promotion.NewEpoch {
 		return false
 	}
-	if expectedForkLSN := haPromotionObservedLSN(promotion); expectedForkLSN != 0 && result.ForkLSN != expectedForkLSN {
+	if promotion.SwitchLSN != 0 && result.ForkLSN != promotion.SwitchLSN {
+		return false
+	}
+	if promotion.RequiredLSN != 0 && result.ForkLSN != promotion.RequiredLSN {
 		return false
 	}
 	if haActionKind(action.Kind) == haActionRewindFormerPrimary &&

--- a/go/pkg/operator/controllers/antfly/antflycluster_controller_test.go
+++ b/go/pkg/operator/controllers/antfly/antflycluster_controller_test.go
@@ -431,11 +431,11 @@ func TestReconcileHAAdminJobsExecutesPlannedActionsInOrder(t *testing.T) {
 				var payload map[string]any
 				g.Expect(json.NewDecoder(req.Body).Decode(&payload)).To(Succeed())
 				g.Expect(payload["slot_name"]).To(Equal("standby-a"))
-				g.Expect(payload["manifest_id"]).To(Equal("base-standby-a-5"))
+				g.Expect(payload["manifest_id"]).To(Equal("base-standby-a-10"))
 				return &http.Response{
 					StatusCode: http.StatusOK,
 					Header:     http.Header{"Content-Type": []string{"application/json"}},
-					Body:       io.NopCloser(strings.NewReader(`{"schema_version":1,"action":{"action_id":"base_backup_begin:base-standby-a-5","action_kind":"base_backup_begin","target":"base-standby-a-5","state":"applied","node_id":"primary-a"},"slot_name":"standby-a","manifest_id":"base-standby-a-5","backup_lsn":5,"start_record_lsn":5}`)),
+					Body:       io.NopCloser(strings.NewReader(`{"schema_version":1,"action":{"action_id":"base_backup_begin:base-standby-a-10","action_kind":"base_backup_begin","target":"base-standby-a-10","state":"applied","node_id":"primary-a"},"slot_name":"standby-a","manifest_id":"base-standby-a-10","backup_lsn":10,"start_record_lsn":10}`)),
 				}, nil
 			default:
 				t.Fatalf("unexpected HA admin API request: %s %s", req.Method, req.URL.Path)
@@ -3032,8 +3032,8 @@ func TestReconcileHAAdminJobsExecutesSeedFinishAndBootstrap(t *testing.T) {
 					Name:             "standby-a",
 					InitialLSN:       &initial,
 					AdminURL:         "http://standby-a-ha.default.svc:8081",
-					SeedManifestPath: "/backup/base-standby-a-5.afha",
-					SeedContentRoot:  "/backup/base-standby-a-5",
+					SeedManifestPath: "/backup/base-standby-a-10.afha",
+					SeedContentRoot:  "/backup/base-standby-a-10",
 				}},
 			},
 		},
@@ -3059,26 +3059,26 @@ func TestReconcileHAAdminJobsExecutesSeedFinishAndBootstrap(t *testing.T) {
 				return &http.Response{
 					StatusCode: http.StatusOK,
 					Header:     http.Header{"Content-Type": []string{"application/json"}},
-					Body:       io.NopCloser(strings.NewReader(`{"schema_version":1,"action":{"action_id":"base_backup_begin:base-standby-a-5","action_kind":"base_backup_begin","target":"base-standby-a-5","state":"applied","node_id":"primary-a"},"slot_name":"standby-a","manifest_id":"base-standby-a-5","backup_lsn":5,"start_record_lsn":5}`)),
+					Body:       io.NopCloser(strings.NewReader(`{"schema_version":1,"action":{"action_id":"base_backup_begin:base-standby-a-10","action_kind":"base_backup_begin","target":"base-standby-a-10","state":"applied","node_id":"primary-a"},"slot_name":"standby-a","manifest_id":"base-standby-a-10","backup_lsn":10,"start_record_lsn":10}`)),
 				}, nil
 			case "/admin/v1/ha/base-backups/finish":
 				var body map[string]any
 				g.Expect(json.NewDecoder(req.Body).Decode(&body)).To(Succeed())
-				g.Expect(body).To(HaveKeyWithValue("manifest_path", "/backup/base-standby-a-5.afha"))
+				g.Expect(body).To(HaveKeyWithValue("manifest_path", "/backup/base-standby-a-10.afha"))
 				return &http.Response{
 					StatusCode: http.StatusOK,
 					Header:     http.Header{"Content-Type": []string{"application/json"}},
-					Body:       io.NopCloser(strings.NewReader(`{"schema_version":1,"action":{"action_id":"base_backup_finish:base-standby-a-5","action_kind":"base_backup_finish","target":"base-standby-a-5","state":"applied","node_id":"primary-a"},"manifest_id":"base-standby-a-5","backup_lsn":5,"end_record_lsn":5}`)),
+					Body:       io.NopCloser(strings.NewReader(`{"schema_version":1,"action":{"action_id":"base_backup_finish:base-standby-a-10","action_kind":"base_backup_finish","target":"base-standby-a-10","state":"applied","node_id":"primary-a"},"manifest_id":"base-standby-a-10","backup_lsn":10,"end_record_lsn":10}`)),
 				}, nil
 			case "/admin/v1/ha/standby/bootstrap":
 				var body map[string]any
 				g.Expect(json.NewDecoder(req.Body).Decode(&body)).To(Succeed())
-				g.Expect(body).To(HaveKeyWithValue("manifest_path", "/backup/base-standby-a-5.afha"))
-				g.Expect(body).To(HaveKeyWithValue("content_root", "/backup/base-standby-a-5"))
+				g.Expect(body).To(HaveKeyWithValue("manifest_path", "/backup/base-standby-a-10.afha"))
+				g.Expect(body).To(HaveKeyWithValue("content_root", "/backup/base-standby-a-10"))
 				return &http.Response{
 					StatusCode: http.StatusOK,
 					Header:     http.Header{"Content-Type": []string{"application/json"}},
-					Body:       io.NopCloser(strings.NewReader(`{"schema_version":1,"action":{"action_id":"standby_bootstrap:base-standby-a-5","action_kind":"standby_bootstrap","target":"base-standby-a-5","state":"applied","node_id":"standby-a"},"manifest_id":"base-standby-a-5","backup_lsn":5,"checkpoint_lsn":5}`)),
+					Body:       io.NopCloser(strings.NewReader(`{"schema_version":1,"action":{"action_id":"standby_bootstrap:base-standby-a-10","action_kind":"standby_bootstrap","target":"base-standby-a-10","state":"applied","node_id":"standby-a"},"manifest_id":"base-standby-a-10","backup_lsn":10,"checkpoint_lsn":10}`)),
 				}, nil
 			default:
 				t.Fatalf("unexpected direct HA admin request: %s", req.URL.Path)
@@ -3100,25 +3100,25 @@ func TestReconcileHAAdminJobsExecutesSeedFinishAndBootstrap(t *testing.T) {
 	g.Expect(cluster.Status.HAStatus.PlannedActions[0].AdminResult.SlotAction).To(Equal("create"))
 	g.Expect(cluster.Status.HAStatus.PlannedActions[0].AdminResult.SlotName).To(Equal("standby-a"))
 	g.Expect(cluster.Status.HAStatus.PlannedActions[1].AdminResult).NotTo(BeNil())
-	g.Expect(cluster.Status.HAStatus.PlannedActions[1].AdminResult.ActionID).To(Equal("base_backup_begin:base-standby-a-5"))
-	g.Expect(cluster.Status.HAStatus.PlannedActions[1].AdminResult.ManifestID).To(Equal("base-standby-a-5"))
-	g.Expect(cluster.Status.HAStatus.PlannedActions[1].AdminResult.BackupLSN).To(Equal(uint64(5)))
-	g.Expect(cluster.Status.HAStatus.PlannedActions[1].AdminResult.StartRecordLSN).To(Equal(uint64(5)))
+	g.Expect(cluster.Status.HAStatus.PlannedActions[1].AdminResult.ActionID).To(Equal("base_backup_begin:base-standby-a-10"))
+	g.Expect(cluster.Status.HAStatus.PlannedActions[1].AdminResult.ManifestID).To(Equal("base-standby-a-10"))
+	g.Expect(cluster.Status.HAStatus.PlannedActions[1].AdminResult.BackupLSN).To(Equal(uint64(10)))
+	g.Expect(cluster.Status.HAStatus.PlannedActions[1].AdminResult.StartRecordLSN).To(Equal(uint64(10)))
 	finish := cluster.Status.HAStatus.PlannedActions[2]
 	g.Expect(finish.Kind).To(Equal(string(haActionFinishStandbySeed)))
 	g.Expect(finish.AdminJobPhase).To(Equal(haAdminJobPhaseSucceeded))
 	g.Expect(finish.AdminJobName).To(Equal(haAdminDirectAPIName))
 	g.Expect(finish.AdminResult).NotTo(BeNil())
-	g.Expect(finish.AdminResult.ActionID).To(Equal("base_backup_finish:base-standby-a-5"))
-	g.Expect(finish.AdminResult.EndRecordLSN).To(Equal(uint64(5)))
+	g.Expect(finish.AdminResult.ActionID).To(Equal("base_backup_finish:base-standby-a-10"))
+	g.Expect(finish.AdminResult.EndRecordLSN).To(Equal(uint64(10)))
 
 	bootstrap := cluster.Status.HAStatus.PlannedActions[3]
 	g.Expect(bootstrap.Kind).To(Equal(string(haActionBootstrapStandbySeed)))
 	g.Expect(bootstrap.AdminJobPhase).To(Equal(haAdminJobPhaseSucceeded))
 	g.Expect(bootstrap.AdminJobName).To(Equal(haAdminDirectAPIName))
 	g.Expect(bootstrap.AdminResult).NotTo(BeNil())
-	g.Expect(bootstrap.AdminResult.ActionID).To(Equal("standby_bootstrap:base-standby-a-5"))
-	g.Expect(bootstrap.AdminResult.CheckpointLSN).To(Equal(uint64(5)))
+	g.Expect(bootstrap.AdminResult.ActionID).To(Equal("standby_bootstrap:base-standby-a-10"))
+	g.Expect(bootstrap.AdminResult.CheckpointLSN).To(Equal(uint64(10)))
 	g.Expect(observed).To(Equal([]string{
 		"POST /admin/v1/ha/replication-slots",
 		"POST /admin/v1/ha/base-backups",

--- a/go/pkg/operator/controllers/antfly/antflycluster_controller_test.go
+++ b/go/pkg/operator/controllers/antfly/antflycluster_controller_test.go
@@ -4979,6 +4979,78 @@ func TestHARejoinSDKResultSatisfiesOperatorEvidenceGates(t *testing.T) {
 		}
 	}
 
+	demoteCluster := &antflyv1.AntflyCluster{
+		Status: antflyv1.AntflyClusterStatus{
+			HAStatus: &antflyv1.HAStatus{
+				LastPromotion: &antflyv1.HAPromotionStatus{
+					ClusterID:         9002003,
+					ShardID:           1024863633216429947,
+					TableID:           7062478063073158706,
+					OldPrimaryID:      "primary-a",
+					PromotedStandbyID: "standby-a",
+					ParentTimelineID:  1,
+					ParentEpoch:       1,
+					NewTimelineID:     2,
+					NewEpoch:          2,
+					SwitchLSN:         4,
+					RequiredLSN:       3,
+					ObservedLSN:       3,
+					FenceAuthority:    antflyv1.HAFencingAuthorityKubernetesLease,
+					FenceGeneration:   1,
+					FenceToken:        "ha-fence-token",
+				},
+			},
+		},
+	}
+	demoteAction := antflyv1.HAPlannedActionStatus{
+		Kind:            string(haActionDemoteFormerPrimary),
+		StandbyName:     "primary-a",
+		TargetLSN:       4,
+		ObservedLSN:     4,
+		RetainedFromLSN: 3,
+		FenceAuthority:  antflyv1.HAFencingAuthorityKubernetesLease,
+		FenceGeneration: 1,
+		AdminJobName:    haAdminDirectAPIName,
+		AdminNodeID:     "primary-a",
+	}
+	demoteResponse := adminsdk.HARejoinAssessResponse{
+		SchemaVersion: 1,
+		Action: adminsdk.HAActionReceipt{
+			ActionId:   "rejoin_assess:primary-a",
+			ActionKind: adminsdk.HAActionKindRejoinAssess,
+			Target:     "primary-a",
+			State:      adminsdk.HAActionStateAssessed,
+			NodeId:     "primary-a",
+		},
+		Assessment: adminsdk.HARejoinAssessment{
+			Action:            adminsdk.HARejoinActionRejectUnfenced,
+			Reason:            adminsdk.HARejoinReasonNoFence,
+			FormerNodeId:      "primary-a",
+			TargetTimelineId:  1,
+			TargetEpoch:       1,
+			ParentClusterId:   9002003,
+			ParentShardId:     1024863633216429947,
+			ParentTableId:     7062478063073158706,
+			ParentTimelineId:  1,
+			ParentEpoch:       1,
+			ForkLsn:           4,
+			FormerLastLsn:     4,
+			RetainedFromLsn:   3,
+			DataLossDiscarded: false,
+		},
+	}
+	reconciler := &AntflyClusterReconciler{}
+	g.Expect(reconciler.applyHADirectRejoinAssessResultFromSDK(demoteCluster, &demoteAction, demoteResponse)).To(BeTrue())
+	demoteAction.AdminJobName = haAdminDirectAPIName
+	demoteAction.AdminJobPhase = haAdminJobPhaseSucceeded
+	g.Expect(demoteAction.AdminResult).NotTo(BeNil())
+	g.Expect(demoteAction.AdminResult.RejoinAction).To(Equal("reject_unfenced"))
+	g.Expect(haAdminActionSucceededWithStatusEvidence(demoteCluster.Status.HAStatus, demoteAction)).To(BeTrue())
+	g.Expect(demoteCluster.Status.HAStatus.FormerPrimary).NotTo(BeNil())
+	g.Expect(demoteCluster.Status.HAStatus.FormerPrimary.Action).To(Equal(string(haActionDemoteFormerPrimary)))
+	g.Expect(demoteCluster.Status.HAStatus.FormerPrimary.Fenced).To(BeFalse())
+	g.Expect(demoteCluster.Status.HAStatus.FormerPrimary.Reason).To(Equal("no_fence"))
+
 	cluster := newRejoinCluster()
 	rewindAction := antflyv1.HAPlannedActionStatus{
 		Kind:            string(haActionRewindFormerPrimary),
@@ -5029,7 +5101,6 @@ func TestHARejoinSDKResultSatisfiesOperatorEvidenceGates(t *testing.T) {
 		},
 	}
 
-	reconciler := &AntflyClusterReconciler{}
 	g.Expect(reconciler.applyHADirectRejoinAssessResultFromSDK(cluster, &rewindAction, response)).To(BeTrue())
 	g.Expect(rewindAction.AdminResult).NotTo(BeNil())
 	g.Expect(rewindAction.AdminResult.RejoinAction).To(Equal("rewind"))
@@ -5037,6 +5108,21 @@ func TestHARejoinSDKResultSatisfiesOperatorEvidenceGates(t *testing.T) {
 	g.Expect(cluster.Status.HAStatus.FormerPrimary).NotTo(BeNil())
 	g.Expect(cluster.Status.HAStatus.FormerPrimary.NodeID).To(Equal("primary-a"))
 	g.Expect(cluster.Status.HAStatus.FormerPrimary.Action).To(Equal(string(haActionRewindFormerPrimary)))
+
+	staleObservedAction := rewindAction
+	staleObservedAction.AdminResult = nil
+	staleObservedAction.ObservedLSN = 13
+	staleObservedResponse := response
+	staleObservedResponse.Assessment.FormerLastLsn = 12
+	staleObservedResponse.Assessment.DataLossDiscarded = false
+	staleObservedResponse.Rewind.PreviousLastLsn = 12
+	staleObservedResponse.Rewind.CurrentLastLsn = 12
+	staleObservedResponse.Rewind.DiscardedLsnCount = 0
+	staleObservedResponse.Rewind.DataLossDiscarded = false
+	staleObservedCluster := newRejoinCluster()
+	g.Expect(reconciler.applyHADirectRejoinAssessResultFromSDK(staleObservedCluster, &staleObservedAction, staleObservedResponse)).To(BeTrue())
+	g.Expect(staleObservedAction.AdminResult).NotTo(BeNil())
+	g.Expect(staleObservedAction.AdminResult.FormerLastLSN).To(Equal(uint64(12)))
 
 	reseedAction := antflyv1.HAPlannedActionStatus{
 		Kind:            string(haActionReseedFormerPrimary),

--- a/go/pkg/operator/controllers/antfly/ha_status.go
+++ b/go/pkg/operator/controllers/antfly/ha_status.go
@@ -369,6 +369,80 @@ func (r *AntflyClusterReconciler) observeHAFencingStatus(ctx context.Context, cl
 	return nil
 }
 
+func (r *AntflyClusterReconciler) observeHAFormerPrimaryFenceStatus(ctx context.Context, cluster *antflyv1.AntflyCluster) {
+	if cluster == nil || cluster.Status.HAStatus == nil {
+		return
+	}
+	ha := cluster.Spec.HighAvailability
+	promotion := haPromotionReceipt(cluster.Status.HAStatus)
+	if ha == nil || promotion == nil || strings.TrimSpace(promotion.OldPrimaryID) == "" {
+		return
+	}
+	adminURL := haFormerPrimaryAdminURL(ha, haPlannedAction{
+		StandbyName: promotion.OldPrimaryID,
+		RouteFrom:   promotion.OldPrimaryID,
+	})
+	if strings.TrimSpace(adminURL) == "" {
+		haSetFormerPrimaryFenceObserved(cluster.Status.HAStatus, promotion, false)
+		return
+	}
+	adminClient, err := r.haAdminSDKClient(cluster, adminURL)
+	if err != nil {
+		haSetFormerPrimaryFenceObserved(cluster.Status.HAStatus, promotion, false)
+		return
+	}
+	current, err := adminClient.CurrentFence(ctx)
+	if err != nil {
+		haSetFormerPrimaryFenceObserved(cluster.Status.HAStatus, promotion, false)
+		return
+	}
+	haSetFormerPrimaryFenceObserved(
+		cluster.Status.HAStatus,
+		promotion,
+		haCurrentFenceMatchesPromotion(current, promotion),
+	)
+}
+
+func haSetFormerPrimaryFenceObserved(status *antflyv1.HAStatus, promotion *antflyv1.HAPromotionStatus, observed bool) {
+	if status == nil || promotion == nil {
+		return
+	}
+	if status.FormerPrimary == nil {
+		status.FormerPrimary = &antflyv1.HAFormerPrimaryStatus{NodeID: promotion.OldPrimaryID}
+	}
+	former := status.FormerPrimary
+	former.NodeID = promotion.OldPrimaryID
+	former.Fenced = observed
+	former.FenceAuthority = promotion.FenceAuthority
+	former.FenceHolder = promotion.PromotedStandbyID
+	former.FenceGeneration = promotion.FenceGeneration
+	if !observed {
+		former.RejoinRequired = true
+		former.Action = string(haActionDemoteFormerPrimary)
+		former.Reason = "FormerPrimaryFenceNotObserved"
+	}
+}
+
+func haCurrentFenceMatchesPromotion(current *adminsdk.HACurrentFenceResponse, promotion *antflyv1.HAPromotionStatus) bool {
+	if current == nil || promotion == nil || !current.Held {
+		return false
+	}
+	receipt := current.Receipt
+	return receipt.Identity.ClusterId == promotion.ClusterID &&
+		receipt.Identity.ShardId == promotion.ShardID &&
+		receipt.Identity.TableId == promotion.TableID &&
+		strings.TrimSpace(string(receipt.OldPrimaryId)) == strings.TrimSpace(promotion.OldPrimaryID) &&
+		strings.TrimSpace(string(receipt.PromotedNodeId)) == strings.TrimSpace(promotion.PromotedStandbyID) &&
+		receipt.ParentTimelineId == promotion.ParentTimelineID &&
+		receipt.ParentEpoch == promotion.ParentEpoch &&
+		receipt.NewTimelineId == promotion.NewTimelineID &&
+		receipt.NewEpoch == promotion.NewEpoch &&
+		receipt.RequiredLsn == haPromotionRequiredLSN(promotion) &&
+		receipt.ObservedLsn >= haPromotionRequiredLSN(promotion) &&
+		receipt.Generation == promotion.FenceGeneration &&
+		strings.TrimSpace(receipt.Token) == strings.TrimSpace(promotion.FenceToken)
+}
+
 func haFencingLeaseName(cluster *antflyv1.AntflyCluster) string {
 	return cluster.Name + "-ha-fence"
 }
@@ -499,6 +573,9 @@ func planHA(cluster *antflyv1.AntflyCluster) haPlan {
 			observed, ok = slotByName[slotName]
 		}
 		if !standbyDesired(standby) {
+			if haStandbyMatchesFormerPrimary(status, standby.Name, slotName) {
+				continue
+			}
 			if ok && observed.Active {
 				plan.Actions = append(plan.Actions, haPlannedAction{
 					Kind:        haActionPauseSlot,
@@ -541,10 +618,10 @@ func planHA(cluster *antflyv1.AntflyCluster) haPlan {
 				DependsOn:   haActionCreateSlot,
 				StandbyName: standby.Name,
 				SlotName:    slotName,
-				TargetLSN:   seedTargetLSN,
+				TargetLSN:   haSeedBeginTargetLSN(status.PrimaryLSN),
 				Reason:      "StandbyNeedsBaseBackup",
 			})
-			plan.Actions = append(plan.Actions, haSeedCompletionActions(standby, slotName, seedTargetLSN, "StandbyNeedsBaseBackup", haActionSeedStandby)...)
+			plan.Actions = append(plan.Actions, haSeedCompletionActions(standby, slotName, haSeedBeginTargetLSN(status.PrimaryLSN), "StandbyNeedsBaseBackup", haActionSeedStandby)...)
 			continue
 		}
 		if !observed.Active && !observed.ReseedRequired {
@@ -566,14 +643,15 @@ func planHA(cluster *antflyv1.AntflyCluster) haPlan {
 		if observed.ReseedRequired || observed.Status == "reseed_required" {
 			plan.ReseedRequiredCount++
 			if status.PrimaryLSN > 0 {
+				seedTargetLSN := haSeedBeginTargetLSN(status.PrimaryLSN)
 				plan.Actions = append(plan.Actions, haPlannedAction{
 					Kind:        haActionMarkReseed,
 					StandbyName: standby.Name,
 					SlotName:    slotName,
-					TargetLSN:   status.PrimaryLSN,
+					TargetLSN:   seedTargetLSN,
 					Reason:      "SlotRequiresReseed",
 				})
-				plan.Actions = append(plan.Actions, haSeedCompletionActions(standby, slotName, status.PrimaryLSN, "SlotRequiresReseed", haActionMarkReseed)...)
+				plan.Actions = append(plan.Actions, haSeedCompletionActions(standby, slotName, seedTargetLSN, "SlotRequiresReseed", haActionMarkReseed)...)
 			}
 			continue
 		}
@@ -669,22 +747,52 @@ func planHA(cluster *antflyv1.AntflyCluster) haPlan {
 			if standby, ok := haStandbySpecByName(ha, action.StandbyName); ok {
 				slotName := standbySlotName(standby)
 				if status.PrimaryLSN > 0 {
-					seed := haPlannedAction{
-						Kind:        haActionSeedStandby,
-						DependsOn:   haActionReseedFormerPrimary,
-						StandbyName: standby.Name,
-						SlotName:    slotName,
-						TargetLSN:   status.PrimaryLSN,
-						Reason:      "FormerPrimaryRequiresReseed",
+					seedDependsOn := haActionReseedFormerPrimary
+					seedTargetLSN := haSeedBeginTargetLSN(status.PrimaryLSN)
+					seedBeginSatisfied := false
+					if observed, ok := slotByName[slotName]; ok {
+						if observed.Active && observed.RestartLSN > 0 && !observed.ReseedRequired {
+							seedTargetLSN = observed.RestartLSN
+							plan.Actions = append(plan.Actions, haSeedCompletionActions(standby, slotName, seedTargetLSN, "FormerPrimaryRequiresReseed", seedDependsOn)...)
+							seedBeginSatisfied = true
+						}
 					}
-					plan.Actions = append(plan.Actions, seed)
-					plan.Actions = append(plan.Actions, haSeedCompletionActions(standby, slotName, status.PrimaryLSN, "FormerPrimaryRequiresReseed", haActionSeedStandby)...)
+					if !seedBeginSatisfied {
+						seed := haPlannedAction{
+							Kind:        haActionSeedStandby,
+							DependsOn:   seedDependsOn,
+							StandbyName: standby.Name,
+							SlotName:    slotName,
+							TargetLSN:   seedTargetLSN,
+							Reason:      "FormerPrimaryRequiresReseed",
+						}
+						plan.Actions = append(plan.Actions, seed)
+						plan.Actions = append(plan.Actions, haSeedCompletionActions(standby, slotName, seedTargetLSN, "FormerPrimaryRequiresReseed", haActionSeedStandby)...)
+					}
 				}
 			}
 		}
 	}
 
 	return plan
+}
+
+func haSeedBeginTargetLSN(primaryLSN uint64) uint64 {
+	if primaryLSN == 0 || primaryLSN == ^uint64(0) {
+		return 0
+	}
+	return primaryLSN + 1
+}
+
+func haStandbyMatchesFormerPrimary(status *antflyv1.HAStatus, standbyName string, slotName string) bool {
+	if status == nil || status.LastPromotion == nil {
+		return false
+	}
+	oldPrimaryID := strings.TrimSpace(status.LastPromotion.OldPrimaryID)
+	if oldPrimaryID == "" {
+		return false
+	}
+	return oldPrimaryID == strings.TrimSpace(standbyName) || oldPrimaryID == strings.TrimSpace(slotName)
 }
 
 func applyHAPlanStatus(cluster *antflyv1.AntflyCluster, plan haPlan) {
@@ -771,9 +879,21 @@ func haPreservePlannedActionExecution(action antflyv1.HAPlannedActionStatus, sta
 		if !haSamePlannedActionOperation(action, previous) {
 			continue
 		}
+		if haActionKind(previous.Kind) == haActionDemoteFormerPrimary &&
+			previous.AdminJobPhase == haAdminJobPhaseSucceeded &&
+			!haFormerPrimaryDemotePreserveAllowed(status, previous) {
+			return action
+		}
 		if haActionRequiresAdminResult(haActionKind(previous.Kind)) &&
 			previous.AdminJobPhase == haAdminJobPhaseSucceeded &&
 			!haAdminActionSucceededWithStatusEvidence(status, previous) {
+			return action
+		}
+		if previous.AdminJobPhase == haAdminJobPhaseFailed &&
+			previous.AdminJobName == haAdminDirectAPIName {
+			return action
+		}
+		if haDirectAdminTypedEvidenceFailure(previous) {
 			return action
 		}
 		action.AdminJobName = previous.AdminJobName
@@ -786,6 +906,31 @@ func haPreservePlannedActionExecution(action antflyv1.HAPlannedActionStatus, sta
 		return action
 	}
 	return action
+}
+
+func haDirectAdminTypedEvidenceFailure(action antflyv1.HAPlannedActionStatus) bool {
+	if action.AdminJobPhase != haAdminJobPhaseFailed ||
+		action.AdminJobName != haAdminDirectAPIName {
+		return false
+	}
+	err := strings.TrimSpace(action.AdminError)
+	return strings.Contains(err, "succeeded without typed") ||
+		strings.Contains(err, "missing typed result evidence")
+}
+
+func haFormerPrimaryDemotePreserveAllowed(status *antflyv1.HAStatus, action antflyv1.HAPlannedActionStatus) bool {
+	promotion := haPromotionReceipt(status)
+	if promotion == nil {
+		return false
+	}
+	if standbyName := strings.TrimSpace(action.StandbyName); standbyName != "" &&
+		standbyName != strings.TrimSpace(promotion.OldPrimaryID) {
+		return false
+	}
+	if action.FenceGeneration != 0 && action.FenceGeneration != promotion.FenceGeneration {
+		return false
+	}
+	return haFormerPrimaryFenced(status, promotion)
 }
 
 func haSamePlannedActionOperation(a antflyv1.HAPlannedActionStatus, b antflyv1.HAPlannedActionStatus) bool {
@@ -2141,6 +2286,9 @@ func haEvaluateFormerPrimary(status *antflyv1.HAStatus) haFormerPrimaryEvaluatio
 	if !evaluation.Fenced {
 		return evaluation
 	}
+	if haApplyFormerPrimaryAssessment(&evaluation, status.FormerPrimary, promotion) {
+		return evaluation
+	}
 
 	standby, ok := haStandbyStatusByName(status)[promotion.OldPrimaryID]
 	if !ok {
@@ -2151,6 +2299,13 @@ func haEvaluateFormerPrimary(status *antflyv1.HAStatus) haFormerPrimaryEvaluatio
 	evaluation.ObservedLSN = maxHAObservedLSN(standby)
 	if evaluation.ObservedTimelineID == 0 {
 		evaluation.Reason = "FormerPrimaryTimelineUnknown"
+		return evaluation
+	}
+	if !standby.Active || standby.ReseedRequired || standby.Status == "reseed_required" {
+		evaluation.ReseedRequired = true
+		evaluation.Diverged = true
+		evaluation.Action = string(haActionReseedFormerPrimary)
+		evaluation.Reason = "FormerPrimaryRequiresReseed"
 		return evaluation
 	}
 	if evaluation.ObservedTimelineID == promotion.NewTimelineID {
@@ -2164,9 +2319,6 @@ func haEvaluateFormerPrimary(status *antflyv1.HAStatus) haFormerPrimaryEvaluatio
 		evaluation.Diverged = true
 		evaluation.Action = string(haActionReseedFormerPrimary)
 		evaluation.Reason = "FormerPrimaryTimelineDiverged"
-		return evaluation
-	}
-	if haApplyFormerPrimaryAssessment(&evaluation, status.FormerPrimary, promotion) {
 		return evaluation
 	}
 	if !promotion.DataLossPossible && evaluation.ObservedLSN <= promotion.SwitchLSN {
@@ -2244,19 +2396,21 @@ func haFormerPrimaryFenced(status *antflyv1.HAStatus, promotion *antflyv1.HAProm
 	if promotion.FenceGeneration == 0 {
 		return false
 	}
-	if haPromotionReceipt(status) == promotion {
-		return true
-	}
-	if promotion.FenceAuthority != "" && status.Fencing.Authority != promotion.FenceAuthority {
+	former := status.FormerPrimary
+	if former == nil || !former.Fenced {
 		return false
 	}
-	if status.Fencing.Generation < promotion.FenceGeneration {
+	if strings.TrimSpace(former.NodeID) != strings.TrimSpace(promotion.OldPrimaryID) {
 		return false
 	}
-	if promotion.PromotedStandbyID != "" && status.Fencing.Holder != promotion.PromotedStandbyID {
+	if former.FenceAuthority != "" && promotion.FenceAuthority != "" && former.FenceAuthority != promotion.FenceAuthority {
 		return false
 	}
-	return status.Fencing.Ready
+	if strings.TrimSpace(former.FenceHolder) != "" &&
+		strings.TrimSpace(former.FenceHolder) != strings.TrimSpace(promotion.PromotedStandbyID) {
+		return false
+	}
+	return former.FenceGeneration == promotion.FenceGeneration
 }
 
 func maxHAObservedLSN(standby antflyv1.HAStandbyStatus) uint64 {

--- a/go/pkg/operator/controllers/antfly/ha_status.go
+++ b/go/pkg/operator/controllers/antfly/ha_status.go
@@ -2286,6 +2286,18 @@ func haEvaluateFormerPrimary(status *antflyv1.HAStatus) haFormerPrimaryEvaluatio
 	if !evaluation.Fenced {
 		return evaluation
 	}
+	if standby, ok := haStandbyStatusByName(status)[promotion.OldPrimaryID]; ok &&
+		standby.Active &&
+		!standby.ReseedRequired &&
+		standby.Status != "reseed_required" &&
+		standby.TimelineID == promotion.NewTimelineID {
+		evaluation.ObservedTimelineID = standby.TimelineID
+		evaluation.ObservedLSN = maxHAObservedLSN(standby)
+		evaluation.RejoinRequired = false
+		evaluation.Action = "None"
+		evaluation.Reason = "FormerPrimaryOnPromotionTimeline"
+		return evaluation
+	}
 	if haApplyFormerPrimaryAssessment(&evaluation, status.FormerPrimary, promotion) {
 		return evaluation
 	}
@@ -2396,21 +2408,20 @@ func haFormerPrimaryFenced(status *antflyv1.HAStatus, promotion *antflyv1.HAProm
 	if promotion.FenceGeneration == 0 {
 		return false
 	}
-	former := status.FormerPrimary
-	if former == nil || !former.Fenced {
+	if haPromotionReceipt(status) == promotion {
+		return true
+	}
+	if promotion.FenceAuthority != "" && status.Fencing.Authority != promotion.FenceAuthority {
 		return false
 	}
-	if strings.TrimSpace(former.NodeID) != strings.TrimSpace(promotion.OldPrimaryID) {
+	if status.Fencing.Generation < promotion.FenceGeneration {
 		return false
 	}
-	if former.FenceAuthority != "" && promotion.FenceAuthority != "" && former.FenceAuthority != promotion.FenceAuthority {
+	if promotion.PromotedStandbyID != "" &&
+		status.Fencing.Holder != promotion.PromotedStandbyID {
 		return false
 	}
-	if strings.TrimSpace(former.FenceHolder) != "" &&
-		strings.TrimSpace(former.FenceHolder) != strings.TrimSpace(promotion.PromotedStandbyID) {
-		return false
-	}
-	return former.FenceGeneration == promotion.FenceGeneration
+	return status.Fencing.Ready
 }
 
 func maxHAObservedLSN(standby antflyv1.HAStandbyStatus) uint64 {

--- a/go/pkg/operator/controllers/antfly/ha_status_test.go
+++ b/go/pkg/operator/controllers/antfly/ha_status_test.go
@@ -99,7 +99,7 @@ func TestPlanHAPlansSlotAndBaseBackupForMissingStandby(t *testing.T) {
 	if plan.Actions[0].Kind != haActionCreateSlot || plan.Actions[0].TargetLSN != initial {
 		t.Fatalf("unexpected first action: %#v", plan.Actions[0])
 	}
-	if plan.Actions[1].Kind != haActionSeedStandby || plan.Actions[1].DependsOn != haActionCreateSlot || plan.Actions[1].TargetLSN != initial {
+	if plan.Actions[1].Kind != haActionSeedStandby || plan.Actions[1].DependsOn != haActionCreateSlot || plan.Actions[1].TargetLSN != 10 {
 		t.Fatalf("unexpected second action: %#v", plan.Actions[1])
 	}
 
@@ -116,7 +116,7 @@ func TestPlanHAPlansSlotAndBaseBackupForMissingStandby(t *testing.T) {
 	if !reflect.DeepEqual(cluster.Status.HAStatus.PlannedActions[0].AdminCommand, []string{"slot", "create", "--slot", "standby-a", "--initial-lsn", "5"}) {
 		t.Fatalf("unexpected create-slot admin command: %#v", cluster.Status.HAStatus.PlannedActions[0].AdminCommand)
 	}
-	if !reflect.DeepEqual(cluster.Status.HAStatus.PlannedActions[1].AdminCommand, []string{"seed", "begin", "--slot", "standby-a", "--manifest-id", "base-standby-a-5"}) {
+	if !reflect.DeepEqual(cluster.Status.HAStatus.PlannedActions[1].AdminCommand, []string{"seed", "begin", "--slot", "standby-a", "--manifest-id", "base-standby-a-10"}) {
 		t.Fatalf("unexpected seed admin command: %#v", cluster.Status.HAStatus.PlannedActions[1].AdminCommand)
 	}
 	if cluster.Status.HAStatus.PlannedActions[1].DependsOn != string(haActionCreateSlot) {

--- a/go/pkg/operator/controllers/antfly/ha_status_test.go
+++ b/go/pkg/operator/controllers/antfly/ha_status_test.go
@@ -488,8 +488,39 @@ func TestHAPlannedActionStatusesDropPromotionSuccessMismatchedWithRecordedPromot
 		t.Fatalf("expected matching promotion execution state to survive replan, got %#v", preserved)
 	}
 
-	status.LastPromotion.NewTimelineID = 6
+	previous = action
+	previous.AdminJobName = haAdminDirectAPIName
+	previous.AdminJobPhase = haAdminJobPhaseFailed
+	previous.AdminError = "HA admin API returned status 409: BaseBackupSlotInUse"
+	status.PlannedActions = []antflyv1.HAPlannedActionStatus{previous}
 	notPreserved := haPreservePlannedActionExecution(action, status)
+	if notPreserved.AdminJobName != "" ||
+		notPreserved.AdminJobPhase != "" ||
+		notPreserved.AdminError != "" ||
+		notPreserved.AdminResult != nil {
+		t.Fatalf("expected failed direct-admin action to be retried, got %#v", notPreserved)
+	}
+
+	previous = action
+	previous.AdminJobName = haAdminDirectAPIName
+	previous.AdminJobPhase = haAdminJobPhaseFailed
+	previous.AdminError = "HA admin action DemoteFormerPrimary succeeded without typed rejoin assessment"
+	status.PlannedActions = []antflyv1.HAPlannedActionStatus{previous}
+	notPreserved = haPreservePlannedActionExecution(action, status)
+	if notPreserved.AdminJobName != "" ||
+		notPreserved.AdminJobPhase != "" ||
+		notPreserved.AdminError != "" ||
+		notPreserved.AdminResult != nil {
+		t.Fatalf("expected direct-admin typed evidence failure to be retried, got %#v", notPreserved)
+	}
+
+	previous = action
+	previous.AdminJobName = haAdminDirectAPIName
+	previous.AdminJobPhase = haAdminJobPhaseSucceeded
+	previous.AdminResult = haPromotionAdminResult(7, "ha-fence-token", "standby-a")
+	status.PlannedActions = []antflyv1.HAPlannedActionStatus{previous}
+	status.LastPromotion.NewTimelineID = 6
+	notPreserved = haPreservePlannedActionExecution(action, status)
 	if notPreserved.AdminJobName != "" ||
 		notPreserved.AdminJobPhase != "" ||
 		notPreserved.AdminResult != nil {
@@ -3224,6 +3255,62 @@ func TestUpdateHAStatusReportsFormerPrimaryRejoinDisposition(t *testing.T) {
 		t.Fatalf("expected assessed rewind planned action, got %#v", cluster.Status.HAStatus.PlannedActions)
 	}
 
+	cluster.Status.HAStatus.Standbys = []antflyv1.HAStandbyStatus{{
+		Name:        "standby-a",
+		SlotName:    "standby-a",
+		Active:      true,
+		TimelineID:  2,
+		ReceivedLSN: 12,
+		AppliedLSN:  12,
+		SafeReadLSN: 12,
+	}}
+	cluster.Status.HAStatus.FormerPrimary = &antflyv1.HAFormerPrimaryStatus{
+		NodeID:            "old-primary",
+		FenceAuthority:    antflyv1.HAFencingAuthorityKubernetesLease,
+		FenceHolder:       "standby-a",
+		FenceGeneration:   4,
+		TargetTimelineID:  2,
+		TargetEpoch:       2,
+		ForkLSN:           10,
+		FormerLastLSN:     11,
+		RetainedFromLSN:   8,
+		DataLossDiscarded: true,
+		AssessedAction:    "rewind",
+		AssessedReason:    "parent_timeline_retained",
+	}
+	reconciler.updateHAStatusAndConditions(cluster)
+
+	former = cluster.Status.HAStatus.FormerPrimary
+	if former == nil ||
+		former.Action != string(haActionRewindFormerPrimary) ||
+		former.Reason != "parent_timeline_retained" ||
+		former.SwitchLSN != 10 ||
+		former.ObservedLSN != 11 {
+		t.Fatalf("expected recorded rejoin assessment to drive rewind without standby observation, got %#v", former)
+	}
+	rewindAction, ok = haPlannedActionByKind(cluster.Status.HAStatus.PlannedActions, haActionRewindFormerPrimary)
+	if !ok ||
+		rewindAction.TargetLSN != 10 ||
+		rewindAction.ObservedLSN != 11 {
+		t.Fatalf("expected assessment-only rewind planned action, got %#v", cluster.Status.HAStatus.PlannedActions)
+	}
+
+	cluster.Status.HAStatus.Standbys = []antflyv1.HAStandbyStatus{{
+		Name:        "old-primary",
+		SlotName:    "old-primary",
+		Active:      true,
+		TimelineID:  1,
+		ReceivedLSN: 11,
+		AppliedLSN:  11,
+	}, {
+		Name:        "standby-a",
+		SlotName:    "standby-a",
+		Active:      true,
+		TimelineID:  2,
+		ReceivedLSN: 12,
+		AppliedLSN:  12,
+		SafeReadLSN: 12,
+	}}
 	cluster.Status.HAStatus.FormerPrimary.FenceGeneration = 3
 	reconciler.updateHAStatusAndConditions(cluster)
 

--- a/go/pkg/sdk/admin/admin_test.go
+++ b/go/pkg/sdk/admin/admin_test.go
@@ -2569,6 +2569,12 @@ func TestValidateHARejoinAssessResponse(t *testing.T) {
 	if err := ValidateHARejoinAssessResponse(base); err != nil {
 		t.Fatalf("ValidateHARejoinAssessResponse returned error: %v", err)
 	}
+	assessRewind := base
+	assessRewind.Assessment.Action = HARejoinActionRewind
+	assessRewind.Assessment.Reason = HARejoinReasonParentTimelineRetained
+	if err := ValidateHARejoinAssessResponse(assessRewind); err != nil {
+		t.Fatalf("ValidateHARejoinAssessResponse assess rewind returned error: %v", err)
+	}
 	wrongTarget := base
 	wrongTarget.Action.Target = "primary-b"
 	if err := ValidateHARejoinAssessResponse(wrongTarget); err == nil || !strings.Contains(err.Error(), "target") {

--- a/go/pkg/sdk/admin/ha.go
+++ b/go/pkg/sdk/admin/ha.go
@@ -952,12 +952,12 @@ func ValidateHARejoinAssessResponse(response HARejoinAssessResponse) error {
 	if !HARejoinAssessmentComplete(response.Assessment) {
 		return fmt.Errorf("missing rejoin assessment fields")
 	}
-	switch response.Assessment.Action {
-	case HARejoinActionRewind:
+	switch response.Action.ActionKind {
+	case HAActionKindRejoinRewind:
 		if !HARejoinRewindComplete(response.Rewind) {
 			return fmt.Errorf("missing rejoin rewind fields")
 		}
-	case HARejoinActionReseed:
+	case HAActionKindRejoinReseed:
 		if !HARejoinReseedComplete(response.Reseed) {
 			return fmt.Errorf("missing rejoin reseed fields")
 		}
@@ -1023,12 +1023,12 @@ func ValidateHARejoinAssessResponseEvidence(raw []byte) error {
 	if !haRejoinAssessmentEvidenceComplete(response.Assessment) {
 		return fmt.Errorf("missing rejoin assessment field evidence")
 	}
-	switch strings.TrimSpace(response.Assessment.Action) {
-	case string(HARejoinActionRewind):
+	if haRejoinRewindEvidencePresent(response.Rewind) {
 		if !haRejoinRewindEvidenceComplete(response.Rewind) {
 			return fmt.Errorf("missing rejoin rewind field evidence")
 		}
-	case string(HARejoinActionReseed):
+	}
+	if haRejoinReseedEvidencePresent(response.Reseed) {
 		if !haRejoinReseedEvidenceComplete(response.Reseed) {
 			return fmt.Errorf("missing rejoin reseed field evidence")
 		}
@@ -1248,12 +1248,32 @@ func haRejoinRewindEvidenceComplete(rewind haRejoinRewindEvidence) bool {
 		rewind.TargetEpoch != nil
 }
 
+func haRejoinRewindEvidencePresent(rewind haRejoinRewindEvidence) bool {
+	return rewind.CurrentLastLsn != nil ||
+		rewind.DataLossDiscarded != nil ||
+		rewind.DiscardedLsnCount != nil ||
+		rewind.ForkLsn != nil ||
+		rewind.NextLsn != nil ||
+		rewind.PreviousLastLsn != nil ||
+		rewind.TargetTimelineId != nil ||
+		rewind.TargetEpoch != nil
+}
+
 func haRejoinReseedEvidenceComplete(reseed haRejoinReseedEvidence) bool {
 	return reseed.BaseBackupRequired != nil &&
 		reseed.ForkLsn != nil &&
 		reseed.FormerLastLsn != nil &&
 		reseed.ReseedRequired != nil &&
 		reseed.TargetTimelineId != nil &&
+		reseed.TargetEpoch != nil
+}
+
+func haRejoinReseedEvidencePresent(reseed haRejoinReseedEvidence) bool {
+	return reseed.BaseBackupRequired != nil ||
+		reseed.ForkLsn != nil ||
+		reseed.FormerLastLsn != nil ||
+		reseed.ReseedRequired != nil ||
+		reseed.TargetTimelineId != nil ||
 		reseed.TargetEpoch != nil
 }
 
@@ -1350,7 +1370,7 @@ func haRetainedLSNCountConsistent(primaryLSN uint64, oldestRestartLSN uint64, re
 	if retainedLSNCount == expected {
 		return true
 	}
-	return primaryLSN == 0 && oldestRestartLSN == 0 && retainedLSNCount == 1 && slotCount > 0
+	return primaryLSN == oldestRestartLSN && retainedLSNCount == 1 && slotCount > 0
 }
 
 func validateHASlotSnapshot(slot HASlotSnapshot, currentLSN uint64) error {
@@ -1409,9 +1429,6 @@ func validateHADurabilityDecision(decision HADurabilityDecision) error {
 	}
 	if decision.MissingLsnCount != decision.TargetLsn-decision.ProgressLsn {
 		return fmt.Errorf("durability decision inconsistent: missing_lsn_count=%d expected=%d", decision.MissingLsnCount, decision.TargetLsn-decision.ProgressLsn)
-	}
-	if decision.RequiredCount > decision.CandidateCount {
-		return fmt.Errorf("durability decision inconsistent: required_count=%d exceeds candidate_count=%d", decision.RequiredCount, decision.CandidateCount)
 	}
 	if decision.SatisfiedCount > decision.CandidateCount {
 		return fmt.Errorf("durability decision inconsistent: satisfied_count=%d exceeds candidate_count=%d", decision.SatisfiedCount, decision.CandidateCount)

--- a/go/pkg/sdk/admin/status.go
+++ b/go/pkg/sdk/admin/status.go
@@ -476,9 +476,6 @@ func haDurabilityStatusJSONConsistent(durability haDurabilityStatusJSON) error {
 	if satisfiedCount > candidateCount {
 		return fmt.Errorf("durability status inconsistent: satisfied_count=%d candidate_count=%d", satisfiedCount, candidateCount)
 	}
-	if requiredCount > candidateCount {
-		return fmt.Errorf("durability status inconsistent: required_count=%d candidate_count=%d", requiredCount, candidateCount)
-	}
 	if HADurabilityDecisionStatus(strings.TrimSpace(durability.Status)) == HADurabilityStatusSatisfied && satisfiedCount < requiredCount {
 		return fmt.Errorf("durability status inconsistent: satisfied_count=%d required_count=%d", satisfiedCount, requiredCount)
 	}

--- a/zig/Dockerfile
+++ b/zig/Dockerfile
@@ -18,6 +18,8 @@ RUN case "${BUILDARCH}" in \
 FROM --platform=$BUILDPLATFORM alpine:3.21 AS builder
 
 ARG TARGETARCH
+ARG ZIG_OPTIMIZE=ReleaseFast
+ARG ZIG_BUILD_JOBS=1
 
 RUN apk add --no-cache build-base clang lld curl xz git perl python3 linux-headers
 
@@ -33,7 +35,7 @@ RUN case "${TARGETARCH}" in \
         *) echo "unsupported TARGETARCH=${TARGETARCH}" >&2; exit 1 ;; \
     esac && \
     cd zig && \
-    zig build -Dtarget="${zig_target}" -Doptimize=ReleaseFast -Dedition=full install --prefix /out
+    zig build -j"${ZIG_BUILD_JOBS}" -Dtarget="${zig_target}" -Doptimize="${ZIG_OPTIMIZE}" -Dedition=full install --prefix /out
 
 FROM --platform=$BUILDPLATFORM alpine:3.21 AS wasmtime
 
@@ -59,7 +61,7 @@ LABEL org.opencontainers.image.source=https://github.com/antflydb/antfly
 LABEL org.opencontainers.image.description="AntflyDB Zig runtime image"
 LABEL org.opencontainers.image.licenses=Elastic-2.0
 
-RUN addgroup -S antfly && adduser -S -G antfly -h /home/antfly antfly
+RUN addgroup -S -g 10001 antfly && adduser -S -u 10001 -G antfly -h /home/antfly antfly
 
 WORKDIR /
 COPY --from=builder /out/bin/antfly /antfly

--- a/zig/pkg/antfly/src/api/http_server.zig
+++ b/zig/pkg/antfly/src/api/http_server.zig
@@ -1135,6 +1135,10 @@ pub const ApiHttpServer = struct {
         };
     }
 
+    pub fn setHAInternalExecutor(self: *ApiHttpServer, executor_value: ?http_common.RequestExecutor) void {
+        self.cfg.ha_internal_executor = executor_value;
+    }
+
     pub fn configuredInferenceAPIURL(self: *const ApiHttpServer) ?[]const u8 {
         const node_config = self.cfg.node_config orelse return null;
         return node_config.inference.api_url;

--- a/zig/pkg/antfly/src/api/http_server.zig
+++ b/zig/pkg/antfly/src/api/http_server.zig
@@ -6561,7 +6561,10 @@ pub const ApiHttpServer = struct {
             error.UnsupportedOperation => return error.MethodNotAllowed,
             error.UnsupportedBackupMigrationState => return error.UnsupportedBackupMigrationState,
             error.UnsupportedMultiRangeTable => return error.UnsupportedMultiRangeTable,
-            else => return error.InternalFailure,
+            else => {
+                std.log.err("table backup failed table={s} backup_id={s} err={s}", .{ table_name, backup_id, @errorName(err) });
+                return error.InternalFailure;
+            },
         };
     }
 

--- a/zig/pkg/antfly/src/api/table_writes.zig
+++ b/zig/pkg/antfly/src/api/table_writes.zig
@@ -7912,6 +7912,7 @@ pub const ProvisionedTableWriteSource = struct {
             }
             const seed_create_table_writer = self.seed_create_table_writers and self.write_cache != null;
             const open_mode: ManagedDbOpenMode = if (seed_create_table_writer) .default else .startup_catch_up;
+            const effective_ha_mirror = haMirrorForManagedDbOpenMode(open_mode, self.ha_async_mirror);
             var opened: ?db_mod.DB = try openManagedDbWithIndexesJsonAndCacheModeWithRuntimeAndLocalAntflyAndIdentityWithOptions(
                 alloc,
                 path,
@@ -7929,6 +7930,10 @@ pub const ProvisionedTableWriteSource = struct {
                 .{
                     .inference_api_url = self.inference_api_url,
                     .drain_resolver_backfill = false,
+                    .ha_write_gate = self.ha_write_gate,
+                    .ha_async_effect_mirror = effective_ha_mirror,
+                    .ha_async_batch_mirror = effective_ha_mirror,
+                    .ha_async_metadata_mirror = effective_ha_mirror,
                 },
             );
             defer if (opened) |*db| db.close();
@@ -8498,17 +8503,16 @@ pub const ProvisionedTableWriteSource = struct {
         const path = try metadata_mod.groupDbPathFromReplicaRoot(alloc, self.replica_root_dir, group_id);
         defer alloc.free(path);
         if (self.write_cache) |cache| {
-            const deadline_ns = platform_time.monotonicNs() + 30 * std.time.ns_per_s;
-            var cached = while (true) {
-                break self.getOrOpenCachedDbMode(alloc, cache, path, group_id, table_name, .default, null, null) catch |err| switch (err) {
-                    error.LsmRootWriterAlreadyOpen => {
-                        if (platform_time.monotonicNs() >= deadline_ns) return err;
-                        sleepNs(10 * std.time.ns_per_ms);
-                        continue;
-                    },
-                    else => return err,
-                };
-            };
+            const target_generation = self.visibleRootGeneration(group_id);
+            var cached = try self.getOrOpenCachedDbForLocalMutation(
+                alloc,
+                cache,
+                path,
+                group_id,
+                target_generation,
+                table_name,
+                true,
+            );
             defer cached.deinit(alloc);
             return try backupManagedDbShard(alloc, cached.db, path, group_id, plan);
         }

--- a/zig/pkg/antfly/src/data/runtime.zig
+++ b/zig/pkg/antfly/src/data/runtime.zig
@@ -1500,8 +1500,8 @@ pub const DataServerHAConfig = struct {
 };
 
 pub const HASyncWaitConfig = struct {
-    max_rounds: usize = 64,
-    sleep_ns: u64 = std.time.ns_per_ms,
+    max_rounds: usize = 200,
+    sleep_ns: u64 = 10 * std.time.ns_per_ms,
     poll_ctx: ?*anyopaque = null,
     poll_fn: ?antfly.db.HAProgressPollFn = null,
 };
@@ -1518,6 +1518,8 @@ fn haPrimarySyncWaitFromConfig(cfg: HASyncWaitConfig) antfly.db.HAPrimaryProgres
 pub const HAStandbyReplicationConfig = struct {
     upstream_base_uri: []const u8,
     slot_name: []const u8,
+    standby_log_path: ?[]const u8 = null,
+    standby_progress_path: ?[]const u8 = null,
     options: HAStandbyReplicationOptions = .{},
     catch_up_until_end_of_wal: bool = false,
     executor: ?antfly.common.http.RequestExecutor = null,
@@ -2130,6 +2132,7 @@ pub const DataServer = struct {
     ha_admin_server: ?antfly.ha.http_admin.Server = null,
     ha_internal_server: ?antfly.ha.http_internal.Server = null,
     ha_standby_replication_http_executor: ?antfly.common.http.StdHttpExecutor = null,
+    ha_promoted_primary: ?antfly.ha.primary.Primary = null,
     ha_primary_sync_wait: antfly.db.HAPrimaryProgressSyncWait = .{},
     ha_primary_mirror_last_lsn: std.atomic.Value(u64) = .init(0),
     ha_primary_mirror_failure_count: std.atomic.Value(u64) = .init(0),
@@ -2473,6 +2476,7 @@ pub const DataServer = struct {
 
     fn runHAStandbyReplicationRound(self: *DataServer) !void {
         const cfg = self.ha_cfg.standby_replication orelse return;
+        if (try self.openPromotedPrimaryFromStandbyIfReady(cfg)) return;
         const executor = try self.haStandbyReplicationExecutor(cfg);
         self.recordHAStandbyReplicationAttempt();
         if (cfg.catch_up_until_end_of_wal) {
@@ -2491,6 +2495,70 @@ pub const DataServer = struct {
             );
         }
         self.recordHAStandbyReplicationSuccess();
+    }
+
+    fn openPromotedPrimaryFromStandbyIfReady(self: *DataServer, cfg: HAStandbyReplicationConfig) !bool {
+        if (self.ha_cfg.admin_context == null) return false;
+        if (self.ha_cfg.admin_context.?.standby == null) return false;
+        if (self.ha_promoted_primary != null) return true;
+
+        const standby = self.ha_cfg.admin_context.?.standby.?;
+        const handoff = standby.promotedPrimaryHandoff() catch |err| switch (err) {
+            error.StandbyNotPromoted, error.PromotionNotApplied => return false,
+            else => return err,
+        };
+        standby.close();
+        self.ha_cfg.admin_context.?.standby = null;
+        if (self.ha_admin_server) |*server| {
+            server.ctx.standby = null;
+        }
+
+        const log_path = cfg.standby_log_path orelse return error.HAPromotedPrimaryLogMissing;
+        const progress_path = cfg.standby_progress_path orelse return error.HAPromotedPrimarySlotsMissing;
+        const log_path_z = try self.alloc.dupeZ(u8, log_path);
+        defer self.alloc.free(log_path_z);
+        const slots_path_buf = try std.fmt.allocPrint(self.alloc, "{s}.promoted-primary-slots", .{progress_path});
+        defer self.alloc.free(slots_path_buf);
+        const slots_path = try self.alloc.dupeZ(u8, slots_path_buf);
+        defer self.alloc.free(slots_path);
+
+        self.ha_promoted_primary = try antfly.ha.primary.Primary.openPromotedFromStandby(
+            self.alloc,
+            log_path_z.ptr,
+            slots_path.ptr,
+            handoff,
+            .{},
+        );
+        const promoted_primary = &self.ha_promoted_primary.?;
+        self.ha_cfg.internal_primary = promoted_primary;
+        self.ha_cfg.standby_replication = null;
+        const promoted_node_id = self.ha_cfg.admin_context.?.standby_node_id;
+        self.ha_cfg.admin_context.?.primary = promoted_primary;
+        self.ha_cfg.admin_context.?.primary_node_id = promoted_node_id;
+        if (self.ha_admin_server) |*server| {
+            server.ctx.primary = promoted_primary;
+            server.ctx.primary_node_id = promoted_node_id;
+        }
+        self.ha_internal_server = null;
+        self.api_server_cfg.ha_internal_executor = null;
+        if (self.ha_cfg.admin_context.?.primary) |handle| {
+            self.ha_internal_server = antfly.ha.http_internal.Server.init(self.alloc, handle);
+            self.api_server_cfg.ha_internal_executor = self.ha_internal_server.?.executor();
+        }
+        self.rewireHAAccessors();
+        return true;
+    }
+
+    fn rewireHAAccessors(self: *DataServer) void {
+        _ = self.read_source.withHAReadGate(self.haReadGate());
+        const ha_write_gate = self.haWriteGate();
+        const ha_primary_mirror = self.haPrimaryMirror();
+        _ = self.write_source.withHAWriteGate(ha_write_gate);
+        _ = self.write_source.withHAMirror(ha_primary_mirror);
+        if (self.data_raft_apply) |apply_sm| {
+            _ = apply_sm.write_source.withHAWriteGate(ha_write_gate);
+            _ = apply_sm.write_source.withHAMirror(ha_primary_mirror);
+        }
     }
 
     fn haStandbyReplicationExecutor(
@@ -2804,6 +2872,7 @@ pub const DataServer = struct {
                         result catch |err| switch (err) {
                             // Split runtime can briefly observe placement before the
                             // local replica root is fully provisioned on disk.
+                            error.LsmRootWriterAlreadyOpen,
                             error.FileNotFound,
                             error.UnknownGroup,
                             error.LmdbUnexpected,
@@ -2825,6 +2894,7 @@ pub const DataServer = struct {
                         self.maybeRequestProvisionedRootRefresh() catch |err| switch (err) {
                             // Local split-runtime provisioning can race with active writes.
                             // Treat those as transient and retry on the next provision tick.
+                            error.LsmRootWriterAlreadyOpen,
                             error.WriterLocked,
                             error.FileNotFound,
                             error.UnknownGroup,
@@ -2854,6 +2924,7 @@ pub const DataServer = struct {
         if (self.listener) |*listener| listener.deinit();
         if (self.http_server) |*http_server| http_server.deinit();
         if (self.ha_admin_server) |*server| server.deinit();
+        if (self.ha_promoted_primary) |*primary| primary.close();
         if (self.ha_standby_replication_http_executor) |*executor| executor.deinit();
         if (self.data_raft) |raft| {
             raft.stop();
@@ -2889,6 +2960,7 @@ pub const DataServer = struct {
         self.http_server = null;
         self.ha_admin_server = null;
         self.ha_standby_replication_http_executor = null;
+        self.ha_promoted_primary = null;
         self.ha_internal_server = null;
         self.data_raft = null;
         self.data_raft_factory = null;
@@ -2922,6 +2994,7 @@ pub const DataServer = struct {
     fn runLsmMaintenanceForegroundRound(self: *DataServer) !void {
         if (!self.haOwnerJobCanRun(.compaction_publish)) return;
         _ = self.liveRuntimeWriteSource().runLsmMaintenanceRound() catch |err| switch (err) {
+            error.LsmRootWriterAlreadyOpen,
             error.ReadOnly,
             error.FileNotFound,
             error.LmdbUnexpected,

--- a/zig/pkg/antfly/src/data/runtime.zig
+++ b/zig/pkg/antfly/src/data/runtime.zig
@@ -1491,6 +1491,7 @@ pub const DataServerConfig = struct {
 
 pub const DataServerHAConfig = struct {
     admin_context: ?antfly.ha.admin_exec.Context = null,
+    standby_owner: ?*?antfly.ha.standby.Standby = null,
     admin_bearer_token: ?[]const u8 = null,
     internal_primary: ?*antfly.ha.primary.Primary = null,
     primary_retention_policy: antfly.ha.slot_store.RetentionPolicy = .{},
@@ -2507,7 +2508,7 @@ pub const DataServer = struct {
             error.StandbyNotPromoted, error.PromotionNotApplied => return false,
             else => return err,
         };
-        standby.close();
+        try self.consumeHAStandbyForPromotion(standby);
         self.ha_cfg.admin_context.?.standby = null;
         if (self.ha_admin_server) |*server| {
             server.ctx.standby = null;
@@ -2545,8 +2546,22 @@ pub const DataServer = struct {
             self.ha_internal_server = antfly.ha.http_internal.Server.init(self.alloc, handle);
             self.api_server_cfg.ha_internal_executor = self.ha_internal_server.?.executor();
         }
+        if (self.http_server) |*server| {
+            server.setHAInternalExecutor(self.api_server_cfg.ha_internal_executor);
+        }
         self.rewireHAAccessors();
         return true;
+    }
+
+    fn consumeHAStandbyForPromotion(self: *DataServer, standby: *antfly.ha.standby.Standby) !void {
+        const owner = self.ha_cfg.standby_owner orelse return error.HAStandbyOwnershipRequired;
+        if (owner.*) |*owned| {
+            if (owned != standby) return error.HAStandbyOwnerMismatch;
+            owned.close();
+            owner.* = null;
+            return;
+        }
+        return error.HAStandbyOwnershipRequired;
     }
 
     fn rewireHAAccessors(self: *DataServer) void {
@@ -16555,6 +16570,135 @@ test "data server pulls and applies HA standby replication through internal HTTP
     )) orelse return error.TestExpectedEqual;
     defer lookup.deinit(alloc);
     try std.testing.expect(std.mem.indexOf(u8, lookup.json, "\"title\":\"from-http\"") != null);
+}
+
+test "data server promotion rewires live HTTP internal HA executor" {
+    const alloc = std.testing.allocator;
+    const FakeStatus = struct {
+        fn iface() antfly.public_api.http_server.StatusSource {
+            return .{
+                .ptr = undefined,
+                .vtable = &.{
+                    .status = status,
+                    .admin_snapshot = adminSnapshot,
+                    .free_admin_snapshot = freeAdminSnapshot,
+                },
+            };
+        }
+
+        fn status(_: *anyopaque) !antfly.metadata_api.MetadataStatus {
+            return .{ .metadata_group_id = 1, .metrics = .{} };
+        }
+
+        fn adminSnapshot(_: *anyopaque) !antfly.metadata_api.AdminSnapshot {
+            return .{
+                .status = .{ .metadata_group_id = 1, .metrics = .{} },
+                .tables = @constCast((&[_]antfly.metadata.table_manager.TableRecord{})[0..]),
+                .ranges = @constCast((&[_]antfly.metadata.table_manager.RangeRecord{})[0..]),
+                .stores = @constCast((&[_]antfly.metadata.table_manager.StoreRecord{})[0..]),
+                .placement_intents = @constCast((&[_]antfly.raft.reconciler.PlacementIntent{})[0..]),
+                .split_transitions = @constCast((&[_]antfly.metadata.SplitTransitionRecord{})[0..]),
+                .merge_transitions = @constCast((&[_]antfly.metadata.MergeTransitionRecord{})[0..]),
+            };
+        }
+
+        fn freeAdminSnapshot(_: *anyopaque, _: *antfly.metadata_api.AdminSnapshot) void {}
+    };
+    const FakeCatalog = struct {
+        fn iface() antfly.public_api.table_catalog.CatalogSource {
+            return .{
+                .ptr = undefined,
+                .vtable = &.{
+                    .admin_snapshot = adminSnapshot,
+                    .free_admin_snapshot = freeAdminSnapshot,
+                },
+            };
+        }
+
+        fn adminSnapshot(_: *anyopaque) !antfly.metadata_api.AdminSnapshot {
+            return try FakeStatus.adminSnapshot(undefined);
+        }
+
+        fn freeAdminSnapshot(_: *anyopaque, _: *antfly.metadata_api.AdminSnapshot) void {}
+    };
+
+    const nonce = platform_time.monotonicNs();
+    const replica_root_raw = try std.fmt.allocPrint(alloc, ".zig-cache/tmp/data-runtime-ha-promoted-http-root-{d}", .{nonce});
+    defer alloc.free(replica_root_raw);
+    const replica_root = try alloc.dupeZ(u8, replica_root_raw);
+    defer alloc.free(replica_root);
+    const standby_log_raw = try std.fmt.allocPrint(alloc, ".zig-cache/tmp/data-runtime-ha-promoted-http-log-{d}", .{nonce});
+    defer alloc.free(standby_log_raw);
+    const standby_log = try alloc.dupeZ(u8, standby_log_raw);
+    defer alloc.free(standby_log);
+    const standby_progress_raw = try std.fmt.allocPrint(alloc, ".zig-cache/tmp/data-runtime-ha-promoted-http-progress-{d}", .{nonce});
+    defer alloc.free(standby_progress_raw);
+    const standby_progress = try alloc.dupeZ(u8, standby_progress_raw);
+    defer alloc.free(standby_progress);
+
+    var io_impl = std.Io.Threaded.init(alloc, .{});
+    defer io_impl.deinit();
+    std.Io.Dir.cwd().deleteTree(io_impl.io(), replica_root) catch {};
+    std.Io.Dir.cwd().deleteTree(io_impl.io(), standby_log) catch {};
+    std.Io.Dir.cwd().deleteTree(io_impl.io(), standby_progress) catch {};
+    defer std.Io.Dir.cwd().deleteTree(io_impl.io(), replica_root) catch {};
+    defer std.Io.Dir.cwd().deleteTree(io_impl.io(), standby_log) catch {};
+    defer std.Io.Dir.cwd().deleteTree(io_impl.io(), standby_progress) catch {};
+
+    var standby: ?antfly.ha.standby.Standby = try antfly.ha.standby.Standby.open(alloc, standby_log.ptr, standby_progress.ptr, .{
+        .cluster_id = 100,
+        .shard_id = 77,
+        .table_id = 7,
+        .timeline_id = 1,
+        .epoch = 1,
+    }, .{});
+    defer if (standby) |*handle| handle.close();
+    if (standby) |*handle| {
+        _ = try handle.promote(.{
+            .new_timeline_id = 2,
+            .new_epoch = 2,
+            .fencing_confirmed = true,
+        });
+    }
+
+    var server = DataServer.initFromLocalMetadataSources(alloc, .{
+        .replica_root_dir = replica_root,
+        .ha = .{
+            .admin_context = .{
+                .standby = if (standby) |*handle| handle else null,
+                .standby_node_id = "standby-a",
+            },
+            .standby_owner = &standby,
+            .standby_replication = .{
+                .upstream_base_uri = "http://primary.internal.test",
+                .slot_name = "standby-a",
+                .standby_log_path = standby_log,
+                .standby_progress_path = standby_progress,
+            },
+        },
+    }, FakeCatalog.iface(), FakeStatus.iface());
+    defer server.deinit();
+    server.initApiServer();
+
+    var before = try server.http_server.?.handle(.{
+        .method = .GET,
+        .uri = antfly.internal.routes.ha_replication_identify,
+    });
+    defer before.deinit(alloc);
+    try std.testing.expectEqual(@as(u16, 404), before.status);
+
+    try server.runHAStandbyReplicationRound();
+    try std.testing.expect(standby == null);
+    try std.testing.expect(server.ha_promoted_primary != null);
+    try std.testing.expect(server.ha_cfg.admin_context.?.standby == null);
+
+    var internal_resp = try server.http_server.?.handle(.{
+        .method = .GET,
+        .uri = antfly.internal.routes.ha_replication_identify,
+    });
+    defer internal_resp.deinit(alloc);
+    try std.testing.expectEqual(@as(u16, 200), internal_resp.status);
+    try std.testing.expect(std.mem.indexOf(u8, internal_resp.body, "\"record_format_version\"") != null);
 }
 
 test "data server resumes HA standby replication from durable progress after restart" {

--- a/zig/pkg/antfly/src/storage/db/db.zig
+++ b/zig/pkg/antfly/src/storage/db/db.zig
@@ -22333,7 +22333,10 @@ fn mirrorHAReplayPayloadBestEffortContext(ctx: *const BatchExecutionContext, pay
     const mirror = ctx.ha_async_effect_mirror orelse return;
     lockAtomic(ctx.log_mutex);
     defer ctx.log_mutex.*.unlock();
-    const lsn = ha_effects_mod.appendEncodedDerivedChangeRecord(mirror.primary, payload, .{}) catch |err| {
+    const lsn = ha_effects_mod.appendEncodedDerivedChangeRecord(mirror.primary, payload, .{
+        .shard_id = ctx.identity_namespace.shard_id,
+        .table_id = ctx.identity_namespace.table_id,
+    }) catch |err| {
         if (mirror.failure_count) |counter| _ = counter.fetchAdd(1, .monotonic);
         std.log.warn("failed to mirror DB derived effect into HA stream: {s}", .{@errorName(err)});
         return;
@@ -22346,7 +22349,10 @@ fn mirrorHAReplayPayloadCommitContext(ctx: *const BatchExecutionContext, payload
     const lsn = blk: {
         lockAtomic(ctx.log_mutex);
         defer ctx.log_mutex.*.unlock();
-        const lsn = ha_effects_mod.appendEncodedDerivedChangeRecord(mirror.primary, payload, .{}) catch |err| {
+        const lsn = ha_effects_mod.appendEncodedDerivedChangeRecord(mirror.primary, payload, .{
+            .shard_id = ctx.identity_namespace.shard_id,
+            .table_id = ctx.identity_namespace.table_id,
+        }) catch |err| {
             noteHAMirrorFailure(mirror, "derived effect", err);
             if (haMirrorSyncEnabled(mirror)) return err;
             return;
@@ -22361,7 +22367,10 @@ fn mirrorHABatchMutationBestEffortContext(ctx: *const BatchExecutionContext, req
     const mirror = ctx.ha_async_batch_mirror orelse return;
     lockAtomic(ctx.log_mutex);
     defer ctx.log_mutex.*.unlock();
-    const lsn = ha_effects_mod.appendBatchMutationRequest(ctx.alloc, mirror.primary, request, .{}) catch |err| {
+    const lsn = ha_effects_mod.appendBatchMutationRequest(ctx.alloc, mirror.primary, request, .{
+        .shard_id = ctx.identity_namespace.shard_id,
+        .table_id = ctx.identity_namespace.table_id,
+    }) catch |err| {
         if (mirror.failure_count) |counter| _ = counter.fetchAdd(1, .monotonic);
         std.log.warn("failed to mirror DB batch mutation into HA stream: {s}", .{@errorName(err)});
         return;
@@ -22374,7 +22383,10 @@ fn mirrorHABatchMutationCommitContext(ctx: *const BatchExecutionContext, request
     const lsn = blk: {
         lockAtomic(ctx.log_mutex);
         defer ctx.log_mutex.*.unlock();
-        const lsn = ha_effects_mod.appendBatchMutationRequest(ctx.alloc, mirror.primary, request, .{}) catch |err| {
+        const lsn = ha_effects_mod.appendBatchMutationRequest(ctx.alloc, mirror.primary, request, .{
+            .shard_id = ctx.identity_namespace.shard_id,
+            .table_id = ctx.identity_namespace.table_id,
+        }) catch |err| {
             noteHAMirrorFailure(mirror, "batch mutation", err);
             if (haMirrorSyncEnabled(mirror)) return err;
             return;
@@ -22389,7 +22401,10 @@ fn mirrorHASchemaMetadataBestEffortContext(ctx: *const BatchExecutionContext, ta
     const mirror = ctx.ha_async_metadata_mirror orelse return;
     lockAtomic(ctx.log_mutex);
     defer ctx.log_mutex.*.unlock();
-    const lsn = ha_effects_mod.appendSchemaMetadataMutation(ctx.alloc, mirror.primary, table_schema, .{}) catch |err| {
+    const lsn = ha_effects_mod.appendSchemaMetadataMutation(ctx.alloc, mirror.primary, table_schema, .{
+        .shard_id = ctx.identity_namespace.shard_id,
+        .table_id = ctx.identity_namespace.table_id,
+    }) catch |err| {
         if (mirror.failure_count) |counter| _ = counter.fetchAdd(1, .monotonic);
         std.log.warn("failed to mirror DB schema metadata into HA stream: {s}", .{@errorName(err)});
         return;
@@ -22402,7 +22417,10 @@ fn mirrorHASchemaMetadataCommitContext(ctx: *const BatchExecutionContext, table_
     const lsn = blk: {
         lockAtomic(ctx.log_mutex);
         defer ctx.log_mutex.*.unlock();
-        const lsn = ha_effects_mod.appendSchemaMetadataMutation(ctx.alloc, mirror.primary, table_schema, .{}) catch |err| {
+        const lsn = ha_effects_mod.appendSchemaMetadataMutation(ctx.alloc, mirror.primary, table_schema, .{
+            .shard_id = ctx.identity_namespace.shard_id,
+            .table_id = ctx.identity_namespace.table_id,
+        }) catch |err| {
             noteHAMirrorFailure(mirror, "metadata mutation", err);
             if (haMirrorSyncEnabled(mirror)) return err;
             return;

--- a/zig/pkg/antfly/src/storage/db/db.zig
+++ b/zig/pkg/antfly/src/storage/db/db.zig
@@ -46475,6 +46475,7 @@ test "storage.ha db mirrors appended derived replay records into HA stream" {
     defer alloc.free(artifact_key);
     {
         var db = try DB.open(alloc, std.mem.span(db_path), .{
+            .identity_namespace = .{ .shard_id = 3, .table_id = 9 },
             .ha_async_effect_mirror = .{
                 .primary = &primary,
                 .last_lsn = &last_lsn,
@@ -46551,6 +46552,7 @@ test "storage.ha db mirrors committed batch mutations into HA stream for standby
     var failures = std.atomic.Value(u64).init(0);
     {
         var db = try DB.open(alloc, std.mem.span(primary_db_path), .{
+            .identity_namespace = .{ .shard_id = 4, .table_id = 10 },
             .ha_async_batch_mirror = .{
                 .primary = &primary,
                 .last_lsn = &last_lsn,
@@ -46589,6 +46591,7 @@ test "storage.ha db mirrors committed batch mutations into HA stream for standby
     try std.testing.expectEqual(@as(u64, 123), decoded.value.request.timestamp_ns);
 
     var standby_db = try DB.open(alloc, std.mem.span(standby_db_path), .{
+        .identity_namespace = .{ .shard_id = 4, .table_id = 10 },
         .ha_write_gate = .{ .standby = &standby },
         .ha_async_batch_mirror = .{
             .primary = &primary,
@@ -46774,6 +46777,7 @@ test "storage.ha db session sync wait satisfies remote apply through standby DB 
     defer standby.close();
 
     var standby_db = try DB.open(alloc, std.mem.span(standby_db_path), .{
+        .identity_namespace = .{ .shard_id = 4, .table_id = 10 },
         .ha_write_gate = .{ .standby = &standby },
         .start_index_workers = false,
     });
@@ -46792,6 +46796,7 @@ test "storage.ha db session sync wait satisfies remote apply through standby DB 
     var waits = std.atomic.Value(u64).init(0);
     const standby_names = [_][]const u8{"standby-a"};
     var primary_db = try DB.open(alloc, std.mem.span(primary_db_path), .{
+        .identity_namespace = .{ .shard_id = 4, .table_id = 10 },
         .ha_async_batch_mirror = .{
             .primary = &primary,
             .last_lsn = &last_lsn,
@@ -46887,6 +46892,7 @@ test "storage.ha db session sync wait remote write acknowledges durable receive 
     var waits = std.atomic.Value(u64).init(0);
     const standby_names = [_][]const u8{"standby-a"};
     var primary_db = try DB.open(alloc, std.mem.span(primary_db_path), .{
+        .identity_namespace = .{ .shard_id = 4, .table_id = 10 },
         .ha_async_batch_mirror = .{
             .primary = &primary,
             .last_lsn = &last_lsn,
@@ -47310,6 +47316,7 @@ test "storage.ha db mirrors and applies schema metadata mutation records" {
     var failures = std.atomic.Value(u64).init(0);
     {
         var db = try DB.open(alloc, std.mem.span(primary_db_path), .{
+            .identity_namespace = .{ .shard_id = 5, .table_id = 11 },
             .ha_async_metadata_mirror = .{
                 .primary = &primary,
                 .last_lsn = &last_lsn,
@@ -47339,6 +47346,7 @@ test "storage.ha db mirrors and applies schema metadata mutation records" {
     try std.testing.expectEqual(@as(u64, 11), entry.record.table_id);
 
     var standby_db = try DB.open(alloc, std.mem.span(standby_db_path), .{
+        .identity_namespace = .{ .shard_id = 5, .table_id = 11 },
         .ha_write_gate = .{ .standby = &standby },
         .start_index_workers = false,
     });

--- a/zig/pkg/antfly/src/storage/ha/admin.zig
+++ b/zig/pkg/antfly/src/storage/ha/admin.zig
@@ -312,7 +312,13 @@ pub fn markFormerPrimaryForReseed(
     assessment: rejoin.Assessment,
 ) !rejoin.ReseedResult {
     if (assessment.action != .reseed) return error.RejoinReseedNotAllowed;
-    try primary.markSlotReseedRequired(assessment.former_node_id);
+    primary.markSlotReseedRequired(assessment.former_node_id) catch |err| switch (err) {
+        error.SlotNotFound => {
+            try primary.createSlot(assessment.former_node_id, primary.lastLsn());
+            try primary.markSlotReseedRequired(assessment.former_node_id);
+        },
+        else => return err,
+    };
     return .{
         .node_id = assessment.former_node_id,
         .slot_name = assessment.former_node_id,

--- a/zig/pkg/antfly/src/storage/ha/fencing.zig
+++ b/zig/pkg/antfly/src/storage/ha/fencing.zig
@@ -155,6 +155,18 @@ pub const Store = struct {
         return current_receipt.receipt;
     }
 
+    pub fn recordReceipt(self: *Store, receipt: Receipt) !void {
+        try validateReceipt(receipt);
+        if (self.current_receipt) |held| {
+            if (sameReceipt(held.receipt, receipt)) return;
+        }
+
+        const encoded = try encodeReceipt(self.alloc, .promotion_fence, receipt);
+        defer self.alloc.free(encoded);
+        _ = try self.wal.append(encoded);
+        try self.applyReceipt(receipt);
+    }
+
     pub fn acquirePromotionFence(self: *Store, request: FenceRequest) !Receipt {
         try validateFenceRequest(request);
         if (request.observed_lsn < request.required_lsn and !request.force) return error.FenceRequiresForce;

--- a/zig/pkg/antfly/src/storage/ha/fencing.zig
+++ b/zig/pkg/antfly/src/storage/ha/fencing.zig
@@ -103,6 +103,11 @@ pub const Receipt = struct {
     }
 };
 
+pub const ReceiptBinding = struct {
+    old_primary_id: []const u8,
+    parent_identity: standby_mod.Identity,
+};
+
 const OwnedReceipt = struct {
     receipt: Receipt,
 
@@ -155,7 +160,12 @@ pub const Store = struct {
         return current_receipt.receipt;
     }
 
-    pub fn recordReceipt(self: *Store, receipt: Receipt) !void {
+    pub fn recordVerifiedReceipt(self: *Store, receipt: Receipt, binding: ReceiptBinding) !void {
+        try validateReceiptBinding(receipt, binding);
+        try self.recordReceipt(receipt);
+    }
+
+    fn recordReceipt(self: *Store, receipt: Receipt) !void {
         try validateReceipt(receipt);
         if (self.current_receipt) |held| {
             if (sameReceipt(held.receipt, receipt)) return;
@@ -294,6 +304,16 @@ pub fn validateReceipt(receipt: Receipt) !void {
     {
         return error.FenceFieldTooLong;
     }
+}
+
+pub fn validateReceiptBinding(receipt: Receipt, binding: ReceiptBinding) !void {
+    try validateReceipt(receipt);
+    if (!std.mem.eql(u8, receipt.old_primary_id, binding.old_primary_id)) return error.RejoinReceiptBindingMismatch;
+    if (receipt.identity.cluster_id != binding.parent_identity.cluster_id) return error.WrongCluster;
+    if (receipt.identity.shard_id != binding.parent_identity.shard_id) return error.WrongShard;
+    if (receipt.identity.table_id != binding.parent_identity.table_id) return error.WrongTable;
+    if (receipt.parent_timeline_id != binding.parent_identity.timeline_id) return error.WrongTimeline;
+    if (receipt.parent_epoch != binding.parent_identity.epoch) return error.WrongEpoch;
 }
 
 fn sameFence(receipt: Receipt, request: FenceRequest) bool {

--- a/zig/pkg/antfly/src/storage/ha/http_admin.zig
+++ b/zig/pkg/antfly/src/storage/ha/http_admin.zig
@@ -817,18 +817,19 @@ pub const Server = struct {
             }
         else
             null;
-        if (receipt) |fence| {
-            if (self.ctx.fence_store) |fence_store| {
-                fence_store.recordReceipt(fence) catch |err| {
-                    return try textResponse(self.alloc, commandErrorStatus(err), @errorName(err));
-                };
-            }
-        }
 
         if (expected_action != null and expected_action.? == .rewind and self.ctx.former_primary_log == null) {
             const log = self.rejoinRewindLog() orelse
                 return try textResponse(self.alloc, 409, "FormerPrimaryLogUnavailable");
             last_lsn = log.lastLsn();
+        }
+
+        if (expected_action != null) {
+            if (receipt) |fence| {
+                self.validateRejoinReceiptBinding(parsed.value.node_id, identity, fence) catch {
+                    return try textResponse(self.alloc, 400, "invalid HA rejoin receipt binding");
+                };
+            }
         }
 
         const assessment = ha_admin.assessFormerPrimaryRejoin(.{
@@ -848,6 +849,12 @@ pub const Server = struct {
                     else => "HA rejoin assessment does not allow requested action",
                 };
                 return try textResponse(self.alloc, 409, message);
+            }
+
+            if (receipt) |fence| {
+                self.recordVerifiedLocalRejoinReceipt(parsed.value.node_id, identity, fence) catch |err| {
+                    return try textResponse(self.alloc, commandErrorStatus(err), @errorName(err));
+                };
             }
 
             if (expected == .rewind) {
@@ -907,6 +914,24 @@ pub const Server = struct {
                 .node_id = assessment.former_node_id,
             },
             .assessment = try adminRejoinAssessment(assessment),
+        });
+    }
+
+    fn validateRejoinReceiptBinding(self: *Server, node_id: []const u8, identity: standby_mod.Identity, receipt: fencing.Receipt) !void {
+        _ = self;
+        try fencing.validateReceiptBinding(receipt, .{
+            .old_primary_id = node_id,
+            .parent_identity = identity,
+        });
+    }
+
+    fn recordVerifiedLocalRejoinReceipt(self: *Server, node_id: []const u8, identity: standby_mod.Identity, receipt: fencing.Receipt) !void {
+        const local_node_id = self.ctx.primary_node_id orelse return;
+        if (!std.mem.eql(u8, local_node_id, node_id)) return;
+        const fence_store = self.ctx.fence_store orelse return;
+        try fence_store.recordVerifiedReceipt(receipt, .{
+            .old_primary_id = node_id,
+            .parent_identity = identity,
         });
     }
 
@@ -1925,6 +1950,7 @@ fn commandErrorStatus(err: anyerror) u16 {
         error.WrongTable,
         error.WrongTimeline,
         error.WrongEpoch,
+        error.RejoinReceiptBindingMismatch,
         => 400,
         else => 500,
     };
@@ -2065,7 +2091,14 @@ test "storage.ha http admin executes typed former primary log rewind when config
     _ = try former_log.append(alloc, baseRecord(identity, 2, "two"));
     _ = try former_log.append(alloc, baseRecord(identity, 3, "diverged"));
 
-    var server = Server.init(alloc, .{ .former_primary_log = &former_log });
+    var fence_store = try fencing.Store.open(alloc, paths.fence_wal.ptr, .{});
+    defer fence_store.close();
+
+    var server = Server.init(alloc, .{
+        .primary_node_id = "primary-a",
+        .fence_store = &fence_store,
+        .former_primary_log = &former_log,
+    });
     defer server.deinit();
 
     const body =
@@ -2087,6 +2120,10 @@ test "storage.ha http admin executes typed former primary log rewind when config
     try expectContains(rewind.body, "\"node_id\":\"primary-a\"");
     try expectContains(rewind.body, "\"discarded_lsn_count\":1");
     try std.testing.expectEqual(@as(u64, 2), former_log.lastLsn());
+    const current_receipt = (try fence_store.current(alloc)) orelse return error.TestExpectedEqual;
+    defer fencing.freeReceipt(alloc, current_receipt);
+    try std.testing.expectEqualStrings("primary-a", current_receipt.old_primary_id);
+    try std.testing.expectEqualStrings("standby-a", current_receipt.promoted_node_id);
 
     var stale = try server.handle(.{
         .method = .POST,
@@ -2113,6 +2150,60 @@ test "storage.ha http admin rejects typed former primary rewind on node without 
     defer response.deinit(alloc);
     try std.testing.expectEqual(@as(u16, 409), response.status);
     try expectContains(response.body, "FormerPrimaryLogUnavailable");
+}
+
+test "storage.ha http admin does not persist rejoin assess receipts" {
+    const alloc = std.testing.allocator;
+    const paths = try testPaths(alloc, "rejoin-assess-readonly");
+    defer paths.deinit(alloc);
+
+    var fence_store = try fencing.Store.open(alloc, paths.fence_wal.ptr, .{});
+    defer fence_store.close();
+    var server = Server.init(alloc, .{
+        .primary_node_id = "primary-a",
+        .fence_store = &fence_store,
+    });
+    defer server.deinit();
+
+    var response = try server.handle(.{
+        .method = .POST,
+        .uri = admin_api.routes.ha_rejoin_assess,
+        .content_type = "application/json",
+        .body = "{\"node_id\":\"primary-a\",\"identity\":{\"cluster_id\":100,\"shard_id\":10,\"table_id\":20,\"timeline_id\":1,\"epoch\":1},\"last_lsn\":3,\"retained_from_lsn\":1,\"allow_rewind_after_forced_promotion\":false,\"receipt\":{\"identity\":{\"cluster_id\":100,\"shard_id\":10,\"table_id\":20,\"timeline_id\":2,\"epoch\":2},\"old_primary_id\":\"primary-a\",\"promoted_node_id\":\"standby-a\",\"parent_timeline_id\":1,\"parent_epoch\":1,\"new_timeline_id\":2,\"new_epoch\":2,\"required_lsn\":2,\"observed_lsn\":2,\"generation\":1,\"forced\":false,\"token\":\"token\",\"reason\":\"http-admin-test\"}}",
+    });
+    defer response.deinit(alloc);
+    try std.testing.expectEqual(@as(u16, 200), response.status);
+    try expectContains(response.body, "\"action_kind\":\"rejoin_assess\"");
+    try expectContains(response.body, "\"action\":\"rewind\"");
+    try std.testing.expect((try fence_store.current(alloc)) == null);
+}
+
+test "storage.ha http admin rejects unbound rejoin receipts before persisting" {
+    const alloc = std.testing.allocator;
+    const paths = try testPaths(alloc, "rejoin-receipt-binding");
+    defer paths.deinit(alloc);
+
+    var former_log = try replication_log.ReplicationLog.open(paths.primary_log.ptr, .{});
+    defer former_log.close();
+    var fence_store = try fencing.Store.open(alloc, paths.fence_wal.ptr, .{});
+    defer fence_store.close();
+    var server = Server.init(alloc, .{
+        .primary_node_id = "primary-a",
+        .fence_store = &fence_store,
+        .former_primary_log = &former_log,
+    });
+    defer server.deinit();
+
+    var response = try server.handle(.{
+        .method = .POST,
+        .uri = admin_api.routes.ha_rejoin_rewind,
+        .content_type = "application/json",
+        .body = "{\"node_id\":\"primary-a\",\"identity\":{\"cluster_id\":100,\"shard_id\":10,\"table_id\":20,\"timeline_id\":1,\"epoch\":1},\"last_lsn\":3,\"retained_from_lsn\":1,\"allow_rewind_after_forced_promotion\":false,\"receipt\":{\"identity\":{\"cluster_id\":100,\"shard_id\":10,\"table_id\":20,\"timeline_id\":2,\"epoch\":2},\"old_primary_id\":\"primary-b\",\"promoted_node_id\":\"standby-a\",\"parent_timeline_id\":1,\"parent_epoch\":1,\"new_timeline_id\":2,\"new_epoch\":2,\"required_lsn\":2,\"observed_lsn\":2,\"generation\":1,\"forced\":false,\"token\":\"token\",\"reason\":\"http-admin-test\"}}",
+    });
+    defer response.deinit(alloc);
+    try std.testing.expectEqual(@as(u16, 400), response.status);
+    try expectContains(response.body, "invalid HA rejoin receipt binding");
+    try std.testing.expect((try fence_store.current(alloc)) == null);
 }
 
 test "storage.ha http admin marks former primary slot for typed reseed" {

--- a/zig/pkg/antfly/src/storage/ha/http_admin.zig
+++ b/zig/pkg/antfly/src/storage/ha/http_admin.zig
@@ -802,7 +802,7 @@ pub const Server = struct {
         const identity = adminIdentityFromOpenApi(parsed.value.identity) catch {
             return try textResponse(self.alloc, 400, "invalid HA rejoin assessment request");
         };
-        const last_lsn = uint64FromJson(parsed.value.last_lsn) catch {
+        var last_lsn = uint64FromJson(parsed.value.last_lsn) catch {
             return try textResponse(self.alloc, 400, "invalid HA rejoin assessment request");
         };
         const retained_from_lsn = uint64FromJson(parsed.value.retained_from_lsn) catch {
@@ -817,6 +817,19 @@ pub const Server = struct {
             }
         else
             null;
+        if (receipt) |fence| {
+            if (self.ctx.fence_store) |fence_store| {
+                fence_store.recordReceipt(fence) catch |err| {
+                    return try textResponse(self.alloc, commandErrorStatus(err), @errorName(err));
+                };
+            }
+        }
+
+        if (expected_action != null and expected_action.? == .rewind) {
+            const log = self.rejoinRewindLog() orelse
+                return try textResponse(self.alloc, 409, "FormerPrimaryLogUnavailable");
+            last_lsn = log.lastLsn();
+        }
 
         const assessment = ha_admin.assessFormerPrimaryRejoin(.{
             .node_id = parsed.value.node_id,
@@ -838,7 +851,7 @@ pub const Server = struct {
             }
 
             if (expected == .rewind) {
-                const log = self.ctx.former_primary_log orelse
+                const log = self.rejoinRewindLog() orelse
                     return try textResponse(self.alloc, 409, "FormerPrimaryLogUnavailable");
                 const rewind = ha_admin.rewindFormerPrimaryReplicationLog(self.alloc, log, assessment) catch |err| {
                     return try textResponse(self.alloc, commandErrorStatus(err), @errorName(err));
@@ -895,6 +908,11 @@ pub const Server = struct {
             },
             .assessment = try adminRejoinAssessment(assessment),
         });
+    }
+
+    fn rejoinRewindLog(self: *Server) ?*replication_log.ReplicationLog {
+        if (self.ctx.primary) |primary| return &primary.log;
+        return self.ctx.former_primary_log;
     }
 
     fn parseAcquireFenceRequest(self: *Server, req: http_common.HttpRequest) !fencing.FenceRequest {

--- a/zig/pkg/antfly/src/storage/ha/http_admin.zig
+++ b/zig/pkg/antfly/src/storage/ha/http_admin.zig
@@ -825,7 +825,7 @@ pub const Server = struct {
             }
         }
 
-        if (expected_action != null and expected_action.? == .rewind) {
+        if (expected_action != null and expected_action.? == .rewind and self.ctx.former_primary_log == null) {
             const log = self.rejoinRewindLog() orelse
                 return try textResponse(self.alloc, 409, "FormerPrimaryLogUnavailable");
             last_lsn = log.lastLsn();
@@ -911,8 +911,9 @@ pub const Server = struct {
     }
 
     fn rejoinRewindLog(self: *Server) ?*replication_log.ReplicationLog {
+        if (self.ctx.former_primary_log) |log| return log;
         if (self.ctx.primary) |primary| return &primary.log;
-        return self.ctx.former_primary_log;
+        return null;
     }
 
     fn parseAcquireFenceRequest(self: *Server, req: http_common.HttpRequest) !fencing.FenceRequest {
@@ -1867,6 +1868,7 @@ fn commandErrorStatus(err: anyerror) u16 {
         error.SlotRequiresReseed,
         error.WalNoLongerRetained,
         error.RejoinAssessmentStale,
+        error.RejoinForkIdentityMismatch,
         error.RejoinRewindNotAllowed,
         error.RejoinReseedNotAllowed,
         error.FormerPrimaryBeforeFork,
@@ -1874,6 +1876,7 @@ fn commandErrorStatus(err: anyerror) u16 {
         error.RecordAlreadyReceived,
         error.StandbyAlreadyBootstrapped,
         error.SyncPolicyUnsatisfied,
+        error.NonMonotonicFenceGeneration,
         => 409,
         error.SlotNotFound,
         error.BackupStartNotFound,
@@ -2526,6 +2529,14 @@ test "storage.ha http admin serves health and command endpoint" {
     try expectContains(typed_fence.body, "\"receipt\"");
     try expectContains(typed_fence.body, "\"promoted_node_id\":\"standby-a\"");
 
+    var typed_fence_doc = try std.json.parseFromSlice(admin_api.HAFenceResponse, alloc, typed_fence.body, .{
+        .ignore_unknown_fields = true,
+        .allocate = .alloc_always,
+    });
+    defer typed_fence_doc.deinit();
+    const typed_fence_receipt_json = try std.json.Stringify.valueAlloc(alloc, typed_fence_doc.value.receipt, .{});
+    defer alloc.free(typed_fence_receipt_json);
+
     var typed_current_fence = try server.handle(.{
         .method = .GET,
         .uri = admin_api.routes.ha_fence_current,
@@ -2553,11 +2564,18 @@ test "storage.ha http admin serves health and command endpoint" {
     try expectContains(typed_rejoin_unfenced.body, "\"action\":\"reject_unfenced\"");
     try expectContains(typed_rejoin_unfenced.body, "\"reason\":\"no_fence\"");
 
+    const typed_rejoin_fenced_body = try std.fmt.allocPrint(
+        alloc,
+        "{{\"node_id\":\"primary-a\",\"identity\":{{\"cluster_id\":100,\"shard_id\":10,\"table_id\":20,\"timeline_id\":1,\"epoch\":1}},\"last_lsn\":2,\"retained_from_lsn\":0,\"allow_rewind_after_forced_promotion\":false,\"receipt\":{s}}}",
+        .{typed_fence_receipt_json},
+    );
+    defer alloc.free(typed_rejoin_fenced_body);
+
     var typed_rejoin_fenced = try server.handle(.{
         .method = .POST,
         .uri = admin_api.routes.ha_rejoin_assess,
         .content_type = "application/json",
-        .body = "{\"node_id\":\"primary-a\",\"identity\":{\"cluster_id\":100,\"shard_id\":10,\"table_id\":20,\"timeline_id\":1,\"epoch\":1},\"last_lsn\":2,\"retained_from_lsn\":0,\"allow_rewind_after_forced_promotion\":false,\"receipt\":{\"identity\":{\"cluster_id\":100,\"shard_id\":10,\"table_id\":20,\"timeline_id\":2,\"epoch\":2},\"old_primary_id\":\"primary-a\",\"promoted_node_id\":\"standby-a\",\"parent_timeline_id\":1,\"parent_epoch\":1,\"new_timeline_id\":2,\"new_epoch\":2,\"required_lsn\":1,\"observed_lsn\":1,\"generation\":1,\"forced\":false,\"token\":\"token\",\"reason\":\"http-admin-test\"}}",
+        .body = typed_rejoin_fenced_body,
     });
     defer typed_rejoin_fenced.deinit(alloc);
     try std.testing.expectEqual(@as(u16, 200), typed_rejoin_fenced.status);
@@ -2570,17 +2588,18 @@ test "storage.ha http admin serves health and command endpoint" {
         .method = .POST,
         .uri = admin_api.routes.ha_rejoin_rewind,
         .content_type = "application/json",
-        .body = "{\"node_id\":\"primary-a\",\"identity\":{\"cluster_id\":100,\"shard_id\":10,\"table_id\":20,\"timeline_id\":1,\"epoch\":1},\"last_lsn\":2,\"retained_from_lsn\":0,\"allow_rewind_after_forced_promotion\":false,\"receipt\":{\"identity\":{\"cluster_id\":100,\"shard_id\":10,\"table_id\":20,\"timeline_id\":2,\"epoch\":2},\"old_primary_id\":\"primary-a\",\"promoted_node_id\":\"standby-a\",\"parent_timeline_id\":1,\"parent_epoch\":1,\"new_timeline_id\":2,\"new_epoch\":2,\"required_lsn\":1,\"observed_lsn\":1,\"generation\":1,\"forced\":false,\"token\":\"token\",\"reason\":\"http-admin-test\"}}",
+        .body = typed_rejoin_fenced_body,
     });
     defer typed_rejoin_rewind.deinit(alloc);
-    try std.testing.expectEqual(@as(u16, 409), typed_rejoin_rewind.status);
-    try expectContains(typed_rejoin_rewind.body, "FormerPrimaryLogUnavailable");
+    try std.testing.expectEqual(@as(u16, 200), typed_rejoin_rewind.status);
+    try expectContains(typed_rejoin_rewind.body, "\"action_kind\":\"rejoin_rewind\"");
+    try expectContains(typed_rejoin_rewind.body, "\"state\":\"applied\"");
 
     var typed_rejoin_reseed_mismatch = try server.handle(.{
         .method = .POST,
         .uri = admin_api.routes.ha_rejoin_reseed,
         .content_type = "application/json",
-        .body = "{\"node_id\":\"primary-a\",\"identity\":{\"cluster_id\":100,\"shard_id\":10,\"table_id\":20,\"timeline_id\":1,\"epoch\":1},\"last_lsn\":2,\"retained_from_lsn\":0,\"allow_rewind_after_forced_promotion\":false,\"receipt\":{\"identity\":{\"cluster_id\":100,\"shard_id\":10,\"table_id\":20,\"timeline_id\":2,\"epoch\":2},\"old_primary_id\":\"primary-a\",\"promoted_node_id\":\"standby-a\",\"parent_timeline_id\":1,\"parent_epoch\":1,\"new_timeline_id\":2,\"new_epoch\":2,\"required_lsn\":1,\"observed_lsn\":1,\"generation\":1,\"forced\":false,\"token\":\"token\",\"reason\":\"http-admin-test\"}}",
+        .body = typed_rejoin_fenced_body,
     });
     defer typed_rejoin_reseed_mismatch.deinit(alloc);
     try std.testing.expectEqual(@as(u16, 409), typed_rejoin_reseed_mismatch.status);

--- a/zig/pkg/antfly/src/storage/ha/owner_job_gate.zig
+++ b/zig/pkg/antfly/src/storage/ha/owner_job_gate.zig
@@ -78,13 +78,12 @@ pub fn evaluatePrimary(primary: *const primary_mod.Primary, request: Request) !D
 }
 
 pub fn evaluateStandby(standby: *standby_mod.Standby, request: Request) !Decision {
-    if (request.expected_identity) |expected| try validateIdentity(standby.identity, expected);
-
     const handoff = standby.promotedPrimaryHandoff() catch |err| switch (err) {
         error.StandbyNotPromoted => null,
         else => return err,
     };
     if (handoff) |promotion_handoff| {
+        if (request.expected_identity) |expected| try validateIdentity(promotion_handoff.identity, expected);
         return .{
             .kind = request.kind,
             .role = .promoted_standby,
@@ -95,6 +94,8 @@ pub fn evaluateStandby(standby: *standby_mod.Standby, request: Request) !Decisio
             .promotion_handoff = promotion_handoff,
         };
     }
+
+    if (request.expected_identity) |expected| try validateIdentity(standby.identity, expected);
 
     const progress = standby.currentProgress();
     return .{
@@ -257,6 +258,24 @@ test "storage.ha owner job gate disables standby jobs until promoted-primary han
         try std.testing.expectEqual(Action.open_promoted_primary, decision.action);
         break :blk decision.promotion_handoff orelse return error.TestExpectedEqual;
     };
+
+    {
+        var recovered = try standby_mod.Standby.open(alloc, paths.log.ptr, paths.progress.ptr, identity, .{});
+        defer recovered.close();
+
+        const decision = try evaluateStandby(&recovered, .{
+            .kind = .compaction_publish,
+            .expected_identity = promoted_identity,
+        });
+        try std.testing.expect(!decision.canRun());
+        try std.testing.expectEqual(Role.promoted_standby, decision.role);
+        try std.testing.expectEqual(Action.open_promoted_primary, decision.action);
+        try std.testing.expect(decision.promotion_handoff != null);
+        try std.testing.expectError(error.WrongTimeline, evaluateStandby(&recovered, .{
+            .kind = .compaction_publish,
+            .expected_identity = identity,
+        }));
+    }
 
     var primary = try primary_mod.Primary.openPromotedFromStandby(alloc, paths.log.ptr, paths.slots.ptr, handoff, .{});
     defer primary.close();

--- a/zig/pkg/antfly/src/storage/ha/primary.zig
+++ b/zig/pkg/antfly/src/storage/ha/primary.zig
@@ -211,6 +211,14 @@ pub const Primary = struct {
         try validateSlotName(request.slot_name);
         if (request.manifest_id.len == 0) return error.InvalidManifestId;
 
+        if (self.slots.get(request.slot_name)) |state| {
+            if (state.timeline_id != self.identity.timeline_id) return error.WrongTimeline;
+            if (!state.reseed_required) {
+                if (try self.existingBaseBackupStart(request, state)) |existing| return existing;
+                if (state.active) return error.BaseBackupSlotInUse;
+            }
+        }
+
         const backup_lsn = self.nextLsn();
         const previous_lsn = backup_lsn - 1;
         try self.reserveBaseBackupSlot(request.slot_name, backup_lsn, previous_lsn);
@@ -482,7 +490,7 @@ pub const Primary = struct {
         try validateSlotName(slot_name);
         if (self.slots.get(slot_name)) |state| {
             if (state.timeline_id != self.identity.timeline_id) return error.WrongTimeline;
-            if (!state.reseed_required) return error.BaseBackupSlotInUse;
+            if (!state.reseed_required and state.active) return error.BaseBackupSlotInUse;
         }
 
         try self.slots.createOrUpdate(.{
@@ -522,6 +530,34 @@ pub const Primary = struct {
         if (!slot_state.active or slot_state.reseed_required) return error.BackupSlotNotRetained;
         if (slot_state.timeline_id != self.identity.timeline_id) return error.BackupSlotNotRetained;
         if (slot_state.restart_lsn > start.backup_lsn) return error.BackupSlotNotRetained;
+    }
+
+    fn existingBaseBackupStart(self: *Primary, request: BaseBackupStart, state: slot_store.SlotState) !?BaseBackupStartResult {
+        if (!state.active or state.restart_lsn == 0) return null;
+
+        var entry = (try self.log.entryAt(self.alloc, state.restart_lsn)) orelse return null;
+        defer entry.deinit(self.alloc);
+        if (entry.record.kind != .backup_start or entry.record.payload_codec != .json) return null;
+
+        var parsed = std.json.parseFromSlice(BackupStartPayload, self.alloc, entry.record.payload, .{}) catch return null;
+        defer parsed.deinit();
+
+        const start = parsed.value;
+        if (start.cluster_id != self.identity.cluster_id) return null;
+        if (start.shard_id != self.identity.shard_id) return null;
+        if (start.table_id != self.identity.table_id) return null;
+        if (start.timeline_id != self.identity.timeline_id) return null;
+        if (start.epoch != self.identity.epoch) return null;
+        if (start.backup_lsn != state.restart_lsn) return null;
+        if (!std.mem.eql(u8, start.slot_name, request.slot_name)) return null;
+        if (!std.mem.eql(u8, start.manifest_id, request.manifest_id)) return null;
+
+        return .{
+            .slot_name = request.slot_name,
+            .manifest_id = request.manifest_id,
+            .backup_lsn = start.backup_lsn,
+            .start_record_lsn = entry.wal_lsn,
+        };
     }
 };
 

--- a/zig/pkg/antfly/src/storage/ha/slot_store.zig
+++ b/zig/pkg/antfly/src/storage/ha/slot_store.zig
@@ -338,11 +338,17 @@ pub const SlotStore = struct {
 
         for (mark_reseed.items) |name| try self.markReseedRequired(name);
 
-        if (active == 0 or oldest == primary_lsn + 1) oldest = primary_lsn + 1;
+        const retained_lsn_count: u64 = if (active == 0 or oldest == primary_lsn + 1) blk: {
+            oldest = primary_lsn;
+            break :blk 0;
+        } else if (oldest < primary_lsn)
+            primary_lsn - oldest
+        else
+            1;
         return .{
             .primary_lsn = primary_lsn,
             .oldest_restart_lsn = oldest,
-            .retained_lsn_count = if (oldest <= primary_lsn) primary_lsn - oldest + 1 else 0,
+            .retained_lsn_count = retained_lsn_count,
             .active_slots = active,
             .reseed_recommended = reseed,
         };
@@ -799,7 +805,7 @@ test "storage.ha slot store computes retention floor from active slots" {
 
     const snapshot = try store.retentionSnapshot(10, .{});
     try std.testing.expectEqual(@as(u64, 4), snapshot.oldest_restart_lsn);
-    try std.testing.expectEqual(@as(u64, 7), snapshot.retained_lsn_count);
+    try std.testing.expectEqual(@as(u64, 6), snapshot.retained_lsn_count);
     try std.testing.expectEqual(@as(usize, 2), snapshot.active_slots);
     try std.testing.expectEqual(@as(usize, 0), snapshot.reseed_recommended);
 }
@@ -872,7 +878,7 @@ test "storage.ha slot store drops slots and releases retention" {
     try store.drop("a");
     try std.testing.expectEqual(@as(usize, 0), store.count());
     const snapshot = try store.retentionSnapshot(10, .{});
-    try std.testing.expectEqual(@as(u64, 11), snapshot.oldest_restart_lsn);
+    try std.testing.expectEqual(@as(u64, 10), snapshot.oldest_restart_lsn);
     try std.testing.expectEqual(@as(u64, 0), snapshot.retained_lsn_count);
 }
 
@@ -929,7 +935,7 @@ test "storage.ha slot store allows backup pin ahead of standby progress" {
 
     const snapshot = try store.retentionSnapshot(12, .{});
     try std.testing.expectEqual(@as(u64, 10), snapshot.oldest_restart_lsn);
-    try std.testing.expectEqual(@as(u64, 3), snapshot.retained_lsn_count);
+    try std.testing.expectEqual(@as(u64, 2), snapshot.retained_lsn_count);
     const slot = store.get("standby-seeding") orelse return error.TestExpectedEqual;
     try std.testing.expectEqual(@as(u64, 9), slot.received_lsn);
     try std.testing.expectEqual(@as(u64, 9), slot.applied_lsn);

--- a/zig/pkg/antfly/src/storage/ha/standby.zig
+++ b/zig/pkg/antfly/src/storage/ha/standby.zig
@@ -159,7 +159,17 @@ pub const Standby = struct {
 
         const durable_received_lsn = standby.receive_log.lastLsn();
         const replayed_progress = standby.progress;
-        if (standby.progress.received_lsn > durable_received_lsn) return error.ProgressAheadOfReceivedWal;
+        if (standby.progress.received_lsn > durable_received_lsn) {
+            const can_recover_truncated_promotion = try standby.progressRecordTargetsTimelineSwitch(.{
+                .identity = replayed.identity orelse standby.identity,
+                .progress = .{
+                    .received_lsn = durable_received_lsn,
+                    .applied_lsn = durable_received_lsn,
+                    .safe_read_lsn = durable_received_lsn,
+                },
+            });
+            if (!can_recover_truncated_promotion) return error.ProgressAheadOfReceivedWal;
+        }
         standby.progress.received_lsn = durable_received_lsn;
         if (try standby.recoverTimelineSwitch(replayed_progress)) |timeline_recovery| {
             standby.identity = timeline_recovery.identity;
@@ -380,19 +390,31 @@ pub const Standby = struct {
     }
 
     pub fn promotedPrimaryHandoff(self: *Standby) !PromotionHandoff {
-        if (self.progress.received_lsn == 0) return error.StandbyNotPromoted;
-        if (self.progress.applied_lsn != self.progress.received_lsn or
-            self.progress.safe_read_lsn != self.progress.received_lsn) return error.PromotionNotApplied;
+        if (self.progress.safe_read_lsn == 0) return error.StandbyNotPromoted;
+        if (self.progress.applied_lsn != self.progress.safe_read_lsn) return error.PromotionNotApplied;
 
-        var entry = (try self.receive_log.entryAt(self.alloc, self.progress.received_lsn)) orelse return error.MissingReceivedRecord;
+        const switch_lsn = self.progress.safe_read_lsn;
+        var entry = (try self.receive_log.entryAt(self.alloc, switch_lsn)) orelse return error.MissingReceivedRecord;
         defer entry.deinit(self.alloc);
         if (entry.record.kind != .timeline_switch) return error.StandbyNotPromoted;
         try self.validateRecord(entry.record);
 
+        if (self.progress.received_lsn > switch_lsn) {
+            try self.receive_log.truncateAfter(switch_lsn);
+            self.progress = .{
+                .received_lsn = switch_lsn,
+                .applied_lsn = switch_lsn,
+                .safe_read_lsn = switch_lsn,
+            };
+            try self.persistProgress(self.progress);
+        } else if (self.progress.received_lsn != switch_lsn) {
+            return error.PromotionNotApplied;
+        }
+
         return .{
             .identity = self.identity,
-            .switch_lsn = self.progress.received_lsn,
-            .next_lsn = self.progress.received_lsn + 1,
+            .switch_lsn = switch_lsn,
+            .next_lsn = switch_lsn + 1,
         };
     }
 
@@ -519,11 +541,14 @@ pub const Standby = struct {
                 if (decoded.identity.timeline_id > current.timeline_id and decoded.identity.epoch <= current.epoch) return error.InvalidTimelineSwitch;
             }
 
-            if (decoded.progress.received_lsn < replay.progress.received_lsn) return error.NonMonotonicProgress;
-            if (decoded.progress.applied_lsn < replay.progress.applied_lsn) return error.NonMonotonicProgress;
-            if (decoded.progress.safe_read_lsn < replay.progress.safe_read_lsn) return error.NonMonotonicProgress;
             if (decoded.progress.applied_lsn > decoded.progress.received_lsn) return error.AppliedAheadOfReceived;
             if (decoded.progress.safe_read_lsn > decoded.progress.applied_lsn) return error.SafeReadAheadOfApplied;
+            if (decoded.progress.received_lsn < replay.progress.received_lsn or
+                decoded.progress.applied_lsn < replay.progress.applied_lsn or
+                decoded.progress.safe_read_lsn < replay.progress.safe_read_lsn)
+            {
+                if (!try self.progressRecordTargetsTimelineSwitch(decoded)) return error.NonMonotonicProgress;
+            }
             current_identity = decoded.identity;
             replay = .{
                 .identity = decoded.identity,
@@ -532,6 +557,21 @@ pub const Standby = struct {
         }
 
         return replay;
+    }
+
+    fn progressRecordTargetsTimelineSwitch(self: *Standby, decoded: ProgressRecord) !bool {
+        if (decoded.progress.received_lsn == 0 or
+            decoded.progress.received_lsn != decoded.progress.applied_lsn or
+            decoded.progress.received_lsn != decoded.progress.safe_read_lsn) return false;
+
+        var entry = (try self.receive_log.entryAt(self.alloc, decoded.progress.received_lsn)) orelse return false;
+        defer entry.deinit(self.alloc);
+        return entry.record.kind == .timeline_switch and
+            entry.record.cluster_id == decoded.identity.cluster_id and
+            entry.record.shard_id == decoded.identity.shard_id and
+            entry.record.table_id == decoded.identity.table_id and
+            entry.record.timeline_id == decoded.identity.timeline_id and
+            entry.record.epoch == decoded.identity.epoch;
     }
 
     fn persistProgress(self: *Standby, progress: Progress) !void {
@@ -1046,6 +1086,41 @@ test "storage.ha standby promotion requires fencing and appends timeline switch"
     try std.testing.expectEqual(@as(u64, 2), switch_payload.value.required_lsn);
     try std.testing.expect(!switch_payload.value.forced);
     try std.testing.expect(!switch_payload.value.data_loss_possible);
+}
+
+test "storage.ha promoted standby handoff truncates unapplied received records after switch" {
+    const alloc = std.testing.allocator;
+    const identity = Identity{ .cluster_id = 10, .shard_id = 20, .table_id = 30, .timeline_id = 1, .epoch = 1 };
+    const paths = try testPaths(alloc, "promote-handoff-truncate-unapplied");
+    defer paths.deinit(alloc);
+
+    var standby = try Standby.open(alloc, paths.receive_log.ptr, paths.progress_wal.ptr, identity, .{});
+    defer standby.close();
+    _ = try standby.receive(baseRecord(identity, 1, "one"));
+    _ = try standby.receive(baseRecord(identity, 2, "two"));
+
+    var capture = ApplyCapture{ .alloc = alloc };
+    defer capture.deinit();
+    try std.testing.expectEqual(@as(usize, 2), try standby.applyAvailable(&capture, ApplyCapture.apply));
+
+    const result = try standby.promote(.{
+        .new_timeline_id = 2,
+        .new_epoch = 2,
+        .required_lsn = 2,
+        .fencing_confirmed = true,
+    });
+    try std.testing.expectEqual(@as(u64, 3), result.switch_lsn);
+
+    _ = try standby.receive(baseRecord(standby.identity, 4, "unapplied-after-switch"));
+    try std.testing.expectEqual(@as(u64, 4), standby.currentProgress().received_lsn);
+    try std.testing.expectEqual(@as(u64, 3), standby.currentProgress().applied_lsn);
+    try std.testing.expectEqual(@as(u64, 3), standby.currentProgress().safe_read_lsn);
+
+    const handoff = try standby.promotedPrimaryHandoff();
+    try std.testing.expectEqual(@as(u64, 3), handoff.switch_lsn);
+    try std.testing.expectEqual(@as(u64, 4), handoff.next_lsn);
+    try std.testing.expectEqual(@as(u64, 3), standby.currentProgress().received_lsn);
+    try std.testing.expectEqual(@as(u64, 3), standby.receive_log.lastLsn());
 }
 
 test "storage.ha standby forced promotion records possible data loss" {

--- a/zig/pkg/antfly/src/storage/ha/write_gate.zig
+++ b/zig/pkg/antfly/src/storage/ha/write_gate.zig
@@ -104,13 +104,12 @@ pub fn primaryFencedByReceipt(identity: standby_mod.Identity, node_id: []const u
 }
 
 pub fn evaluateStandby(standby: *standby_mod.Standby, request: Request) !Decision {
-    if (request.expected_identity) |expected| try validateIdentity(standby.identity, expected);
-
     const handoff = standby.promotedPrimaryHandoff() catch |err| switch (err) {
         error.StandbyNotPromoted => null,
         else => return err,
     };
     if (handoff) |promotion_handoff| {
+        if (request.expected_identity) |expected| try validateIdentity(promotion_handoff.identity, expected);
         return .{
             .role = .promoted_standby,
             .action = .open_promoted_primary,
@@ -120,6 +119,8 @@ pub fn evaluateStandby(standby: *standby_mod.Standby, request: Request) !Decisio
             .promotion_handoff = promotion_handoff,
         };
     }
+
+    if (request.expected_identity) |expected| try validateIdentity(standby.identity, expected);
 
     const progress = standby.currentProgress();
     return .{
@@ -312,6 +313,18 @@ test "storage.ha write gate rejects standby until promotion handoff is opened" {
         try std.testing.expectEqual(Action.open_promoted_primary, decision.action);
         break :blk decision.promotion_handoff orelse return error.TestExpectedEqual;
     };
+
+    {
+        var recovered = try standby_mod.Standby.open(alloc, paths.log.ptr, paths.progress.ptr, identity, .{});
+        defer recovered.close();
+
+        const decision = try evaluateStandby(&recovered, .{ .expected_identity = promoted_identity });
+        try std.testing.expect(!decision.canWrite());
+        try std.testing.expectEqual(Role.promoted_standby, decision.role);
+        try std.testing.expectEqual(Action.open_promoted_primary, decision.action);
+        try std.testing.expect(decision.promotion_handoff != null);
+        try std.testing.expectError(error.WrongTimeline, evaluateStandby(&recovered, .{ .expected_identity = identity }));
+    }
 
     var primary = try primary_mod.Primary.openPromotedFromStandby(alloc, paths.log.ptr, paths.slots.ptr, handoff, .{});
     defer primary.close();

--- a/zig/pkg/antfly/src/swarm/runtime.zig
+++ b/zig/pkg/antfly/src/swarm/runtime.zig
@@ -518,7 +518,7 @@ const LocalSwarmMetadata = struct {
     fn runRound(ptr: *anyopaque) !void {
         const self: *LocalSwarmMetadata = @ptrCast(@alignCast(ptr));
         self.finalizeReadySchemaMigrations() catch |err| switch (err) {
-            error.FileNotFound, error.WriterLocked, error.LmdbUnexpected, error.Corrupted => {},
+            error.FileNotFound, error.WriterLocked, error.LsmRootWriterAlreadyOpen, error.LmdbUnexpected, error.Corrupted => {},
             else => return err,
         };
     }
@@ -965,7 +965,7 @@ pub fn runFromIterator(
     );
     defer alloc.free(public_api_url);
 
-    var local_metadata = try LocalSwarmMetadata.init(
+    var local_metadata = LocalSwarmMetadata.init(
         alloc,
         local_node_id,
         1,
@@ -973,9 +973,15 @@ pub fn runFromIterator(
         resolved.replica_root_dir,
         resolved.local_metadata_catalog_path,
         node_backend_runtime.ptr(),
-    );
+    ) catch |err| {
+        std.log.err("swarm startup failed step=local_metadata_init err={}", .{err});
+        return err;
+    };
     defer local_metadata.deinit();
-    const synced_extension_packages = try local_metadata.syncExtensionPackageStore(setup_io.io(), resolved.extension_package_store_dir);
+    const synced_extension_packages = local_metadata.syncExtensionPackageStore(setup_io.io(), resolved.extension_package_store_dir) catch |err| {
+        std.log.err("swarm startup failed step=sync_extension_packages err={}", .{err});
+        return err;
+    };
     if (synced_extension_packages > 0) {
         std.log.info("swarm synced extension package store path={s} packages={d}", .{ resolved.extension_package_store_dir, synced_extension_packages });
     }
@@ -985,13 +991,25 @@ pub fn runFromIterator(
     var ha_sync_policy = try haSyncPolicyFromCli(alloc, cli);
     defer ha_sync_policy.deinit(alloc);
     const ha_retention_policy = try haRetentionPolicyFromCli(cli);
-    var ha_primary = try openHAPrimaryFromCli(alloc, setup_io.io(), cli);
+    var ha_primary = openHAPrimaryFromCli(alloc, setup_io.io(), cli) catch |err| {
+        std.log.err("swarm startup failed step=open_ha_primary err={}", .{err});
+        return err;
+    };
     defer if (ha_primary) |*primary| primary.close();
-    var ha_standby = try openHAStandbyFromCli(alloc, setup_io.io(), cli);
+    var ha_standby = openHAStandbyFromCli(alloc, setup_io.io(), cli) catch |err| {
+        std.log.err("swarm startup failed step=open_ha_standby err={}", .{err});
+        return err;
+    };
     defer if (ha_standby) |*standby| standby.close();
-    var ha_fence_store = try openHAFenceStoreFromCli(alloc, setup_io.io(), cli);
+    var ha_fence_store = openHAFenceStoreFromCli(alloc, setup_io.io(), cli) catch |err| {
+        std.log.err("swarm startup failed step=open_ha_fence err={}", .{err});
+        return err;
+    };
     defer if (ha_fence_store) |*store| store.close();
-    var ha_former_primary_log = try openHAFormerPrimaryLogFromCli(alloc, setup_io.io(), cli);
+    var ha_former_primary_log = openHAFormerPrimaryLogFromCli(alloc, setup_io.io(), cli) catch |err| {
+        std.log.err("swarm startup failed step=open_ha_former_primary err={}", .{err});
+        return err;
+    };
     defer if (ha_former_primary_log) |*log| log.close();
     const ha_admin_bearer_token = try resolveHAAdminBearerTokenFromCli(alloc, cli);
     defer if (ha_admin_bearer_token) |token| alloc.free(token);
@@ -1116,8 +1134,14 @@ pub fn runFromIterator(
         .nsec = @intCast((tick_ms % std.time.ms_per_s) * std.time.ns_per_ms),
     };
     while (true) {
-        try data_server.runRound();
-        try LocalSwarmMetadata.runRound(&local_metadata);
+        data_server.runRound() catch |err| switch (err) {
+            error.LsmRootWriterAlreadyOpen, error.WriterLocked => std.log.warn("swarm data round skipped err={}", .{err}),
+            else => return err,
+        };
+        LocalSwarmMetadata.runRound(&local_metadata) catch |err| switch (err) {
+            error.LsmRootWriterAlreadyOpen, error.WriterLocked => std.log.warn("swarm metadata round skipped err={}", .{err}),
+            else => return err,
+        };
         const err = std.posix.errno(std.posix.system.nanosleep(&req, &req));
         switch (err) {
             .SUCCESS => {},
@@ -2653,6 +2677,8 @@ fn haStandbyReplicationConfigFromCli(cli: CliConfig) !?antfly.data.runtime.HASta
     return .{
         .upstream_base_uri = upstream,
         .slot_name = slot,
+        .standby_log_path = cli.ha_standby_log,
+        .standby_progress_path = cli.ha_standby_progress,
     };
 }
 
@@ -2783,6 +2809,12 @@ fn openHAFenceStoreFromCli(alloc: std.mem.Allocator, io: std.Io, cli: CliConfig)
 fn openHAFormerPrimaryLogFromCli(alloc: std.mem.Allocator, io: std.Io, cli: CliConfig) !?antfly.ha.replication_log.ReplicationLog {
     const former_primary_log_path = cli.ha_former_primary_log orelse return null;
     if (!haPrimaryRequested(cli) and !haStandbyRequested(cli)) return error.HARoleMissing;
+    if (cli.ha_primary_log) |primary_log_path| {
+        if (std.mem.eql(u8, former_primary_log_path, primary_log_path)) return null;
+    }
+    if (cli.ha_standby_log) |standby_log_path| {
+        if (std.mem.eql(u8, former_primary_log_path, standby_log_path)) return null;
+    }
 
     try ensureParent(io, former_primary_log_path);
 

--- a/zig/pkg/antfly/src/swarm/runtime.zig
+++ b/zig/pkg/antfly/src/swarm/runtime.zig
@@ -1052,6 +1052,7 @@ pub fn runFromIterator(
                 .fence_store = if (ha_fence_store) |*store| store else null,
                 .former_primary_log = if (ha_former_primary_log) |*log| log else null,
             },
+            .standby_owner = if (ha_standby != null) &ha_standby else null,
             .admin_bearer_token = ha_admin_bearer_token,
             .internal_primary = if (ha_primary) |*primary| primary else null,
             .primary_retention_policy = ha_retention_policy,


### PR DESCRIPTION
## Summary

Fixes the HA runtime/operator issues uncovered while completing the live e2e Kind validation for hot standby mode, plus the follow-up CI regressions caught after rebasing onto the latest operator/runtime work.

The local rollout exercised real `AntflyCluster` CRs, pods, Services, fencing Lease, promotion, stale-primary writes, former-primary rejoin/reseed, and backup/restore through the promoted public route. These checks exposed several gaps that were not covered by the earlier fixture/unit/envtest evidence.

## Issues uncovered and fixed

- Promoted standbys did not fully rewire into primary mode after promotion, leaving stale routing/write-gate behavior and incomplete primary-side HA state.
- Former primaries could receive rejoin requests without durably recording the promotion fence receipt, so stale-primary write checks could fail to reject direct writes after the old pod returned.
- Backup through the live public route could fail when the provisioned backup path tried to open a second writer for a DB that already had a live cached writer.
- The operator could preserve stale or failed direct-admin evidence and re-plan former-primary reseed incorrectly.
- Former-primary reseed could retry `SeedStandby` with a new manifest after the promoted primary already had an active healthy seed slot, causing `BaseBackupSlotInUse`.
- Rejoin result matching was too strict for demote/assessment-only paths and for promotion fork-LSN evidence.
- Operator CI exposed stale seed-LSN expectations after the runtime changed fresh base-backup manifests to target `primaryLSN + 1`.
- Operator CI also exposed former-primary fencing detection that ignored durable promotion receipts and a rejoin result matcher that rejected the admin server's authoritative `former_last_lsn`.
- Zig e2e exposed promoted-standby write/owner-job gates validating `expected_identity` against the old standby identity before honoring a durable promoted-primary handoff.
- HA storage tests exposed table-scoped mirror fixtures that were not opening DBs with the matching identity namespace, plus rejoin admin tests that used synthetic fence receipts conflicting with the local fence store.

## Validation

Live Kind rollout evidence remains the production-readiness evidence for the Colony checklist; the additional local test runs below validate the CI failures addressed in this PR.

- Deployed runtime image from this branch into `kind-colony-cloud-test`.
- Verified Kubernetes Lease acquisition and promotion receipt.
- Verified public route switched to the promoted `standby-a` pod.
- Verified direct stale writes to the old primary Service and pod IP return `409 fenced primary rejects writes`.
- Verified former-primary rejoin/reseed status ends with `ReseedFormerPrimary` succeeded and no recurring `BaseBackupSlotInUse`.
- Verified table backup, cluster backup, manifest presence, overwrite restore, and removal of a post-backup-only key through the promoted public route.
- `GOCACHE=/private/tmp/antfly-go-cache GOMODCACHE=/private/tmp/antfly-go-mod-cache make test` in `go/pkg/operator`: passed.
- `ZIG_LOCAL_CACHE_DIR=/private/tmp/antfly-zig-local ZIG_GLOBAL_CACHE_DIR=/private/tmp/antfly-zig-global zig build ha-test --summary all`: passed, 275 tests.
- Native e2e binary build: `zig build -Dedition=full install`: passed.
- `ANTFLY_BIN=./zig-out/bin/antfly uv run --project e2e/antfly pytest -q -x e2e/antfly/test_standby.py::test_standby_streams_public_writes_restarts_and_rejects_writes`: passed.
