### PR TITLE
Pin release publishing to npm 11

### DIFF
--- a/.github/workflows/antfly-release.yml
+++ b/.github/workflows/antfly-release.yml
@@ -271,7 +271,8 @@ jobs:
           registry-url: https://registry.npmjs.org/
 
       - name: Upgrade npm for OIDC support
-        run: npm install -g npm@latest
+        # npm 12.0.0 omitted sigstore from its published bundle: npm/cli#9722.
+        run: npm install -g npm@11
 
       - name: Publish npm packages
         run: |


### PR DESCRIPTION
## Summary

- pin the release workflow npm upgrade to the supported 11.x line
- avoid npm 12.0.0, whose published bundle omits the `sigstore` module required by provenance publishing

## Context

The RC 18 npm publish job failed before publishing its first package with `MODULE_NOT_FOUND: sigstore`: https://github.com/antflydb/antfly/actions/runs/29053946377/job/86252181298

This is tracked upstream as https://github.com/npm/cli/issues/9722. Rerunning the tagged workflow while `npm@latest` resolves to 12.0.0 will reproduce the failure.

## Validation

- `actionlint .github/workflows/antfly-release.yml`
- `git diff --check`