### PR TITLE
Fix HA promotion and replication state races

### DIFF
--- a/zig/build.zig
+++ b/zig/build.zig
@@ -4221,6 +4221,7 @@ pub fn build(b: *std.Build) void {
             "managed source status-only open drains stale pending close before retry",
             "hosted status-only open drains stale pending close before retry",
             "write cache HA gate clear drains inactive pending closes before returning",
+            "write cache retires shared HA generation stale entries before reuse",
         },
         .test_runner = .{
             .path = b.path("pkg/antfly/src/test_runner.zig"),

--- a/zig/pkg/antfly/src/api/table_reads.zig
+++ b/zig/pkg/antfly/src/api/table_reads.zig
@@ -33,6 +33,7 @@ const db_mod = @import("../storage/db/mod.zig");
 const doc_set = @import("../storage/db/doc_set.zig");
 const db_embedder = @import("../storage/db/enrichment/embedder.zig");
 const asset_producer_mod = @import("../storage/db/enrichment/asset_producer.zig");
+const ha_public_gate_state = @import("../storage/ha/public_gate_state.zig");
 const ha_read_gate_mod = @import("../storage/ha/read_gate.zig");
 const ha_standby_mod = @import("../storage/ha/standby.zig");
 const storage_schema = @import("../storage/schema.zig");
@@ -764,21 +765,28 @@ pub const GroupVisibleRootGenerationSource = struct {
     }
 };
 
-pub const HAReadGate = struct {
+pub const HAReadGate = union(enum) {
     standby: *const ha_standby_mod.Standby,
+    shared: *const ha_public_gate_state.State,
 
     pub fn check(self: HAReadGate, consistency: raft_mod.ReadConsistency) !void {
-        const decision = try ha_read_gate_mod.evaluateStandby(self.standby, .{
+        const request = ha_read_gate_mod.Request{
             .consistency = switch (consistency) {
                 .stale => .stale_ok,
                 .leader_lease, .read_index => .primary,
             },
-        });
-        switch (decision.action) {
-            .serve_standby => {},
-            .wait_for_apply => return error.HAReadWaitForApply,
-            .wait_for_metadata => return error.HAReadWaitForMetadata,
-            .route_to_primary => return error.HAReadRequiresPrimary,
+        };
+        switch (self) {
+            .shared => |state| try state.checkRead(request),
+            .standby => |standby| {
+                const decision = try ha_read_gate_mod.evaluateStandby(standby, request);
+                switch (decision.action) {
+                    .serve_standby => {},
+                    .wait_for_apply => return error.HAReadWaitForApply,
+                    .wait_for_metadata => return error.HAReadWaitForMetadata,
+                    .route_to_primary => return error.HAReadRequiresPrimary,
+                }
+            },
         }
     }
 };

--- a/zig/pkg/antfly/src/api/table_writes.zig
+++ b/zig/pkg/antfly/src/api/table_writes.zig
@@ -39,6 +39,7 @@ const lsm_backend = @import("../storage/lsm_backend/mod.zig");
 const portable_backup = @import("../storage/portable_backup.zig");
 const resource_manager_mod = @import("../storage/resource_manager.zig");
 const ha_primary_mod = @import("../storage/ha/primary.zig");
+const ha_public_gate_state_mod = @import("../storage/ha/public_gate_state.zig");
 const storage_schema = @import("../storage/schema.zig");
 const lmdb = @import("../storage/lmdb.zig");
 const table_catalog = @import("table_catalog.zig");
@@ -729,6 +730,7 @@ pub const ProvisionedTableWriteCache = struct {
     const Entry = struct {
         group_id: u64,
         lsm_root_generation: u64,
+        ha_write_gate_generation: ?u64 = null,
         table_name: []u8,
         promotion_owner_state: PromotionOwnerState = .{},
         db: db_mod.DB,
@@ -836,6 +838,10 @@ pub const ProvisionedTableWriteCache = struct {
         }
     }
 
+    fn entryHAWriteGateCurrent(self: *const ProvisionedTableWriteCache, entry: *const Entry) bool {
+        return entry.ha_write_gate_generation == haWriteGateCurrentGeneration(self.ha_write_gate);
+    }
+
     fn retireFailedOpenLocked(self: *ProvisionedTableWriteCache, cached: *CachedDb) void {
         const entry = cached.entry orelse {
             cached.deinit(self.alloc);
@@ -930,6 +936,14 @@ pub const ProvisionedTableWriteCache = struct {
                 .primary, .fenced_primary, .standby => false,
                 .shared => |right| left.state == right.state and left.generation == right.generation,
             },
+        };
+    }
+
+    fn haWriteGateCurrentGeneration(gate: ?db_mod.HAWriteGate) ?u64 {
+        const configured = gate orelse return null;
+        return switch (configured) {
+            .shared => |shared| shared.state.currentGeneration(),
+            .primary, .fenced_primary, .standby => null,
         };
     }
 
@@ -1331,6 +1345,7 @@ pub const ProvisionedTableWriteCache = struct {
         }
         for (self.entries.items) |entry| {
             if (entry.group_id == group_id and entry.lsm_root_generation == lsm_root_generation and std.mem.eql(u8, entry.table_name, table_name)) {
+                if (!self.entryHAWriteGateCurrent(entry)) continue;
                 _ = self.hit_count.fetchAdd(1, .monotonic);
                 lockAtomic(&self.entry_lifecycle_mutex);
                 defer self.entry_lifecycle_mutex.unlock();
@@ -1383,6 +1398,7 @@ pub const ProvisionedTableWriteCache = struct {
         owned_entry.* = .{
             .group_id = group_id,
             .lsm_root_generation = lsm_root_generation,
+            .ha_write_gate_generation = haWriteGateCurrentGeneration(self.ha_write_gate),
             .table_name = owned_table_name,
             .db = opened.db,
             .schema_json = if (metadata.schema_json) |value| try self.alloc.dupe(u8, value) else null,
@@ -1428,6 +1444,7 @@ pub const ProvisionedTableWriteCache = struct {
         }
         for (self.entries.items) |entry| {
             if (entry.group_id == group_id and entry.lsm_root_generation == lsm_root_generation and std.mem.eql(u8, entry.table_name, table_name)) {
+                if (!self.entryHAWriteGateCurrent(entry)) continue;
                 _ = self.hit_count.fetchAdd(1, .monotonic);
                 lockAtomic(&self.entry_lifecycle_mutex);
                 defer self.entry_lifecycle_mutex.unlock();
@@ -1445,6 +1462,7 @@ pub const ProvisionedTableWriteCache = struct {
         for (self.entries.items) |entry| {
             if (entry.group_id != group_id) continue;
             if (!std.mem.eql(u8, entry.table_name, table_name)) continue;
+            if (!self.entryHAWriteGateCurrent(entry)) continue;
             if (!self.adoptSeededEntryGenerationLocked(entry, lsm_root_generation)) continue;
             _ = self.hit_count.fetchAdd(1, .monotonic);
             lockAtomic(&self.entry_lifecycle_mutex);
@@ -1479,6 +1497,7 @@ pub const ProvisionedTableWriteCache = struct {
             if (entry.group_id != group_id) continue;
             if (entry.lsm_root_generation != lsm_root_generation) continue;
             if (!std.mem.eql(u8, entry.table_name, table_name)) continue;
+            if (!self.entryHAWriteGateCurrent(entry)) continue;
             return self.leaseEntryLocked(entry);
         }
         return null;
@@ -1494,6 +1513,7 @@ pub const ProvisionedTableWriteCache = struct {
         for (self.entries.items) |entry| {
             if (entry.group_id != group_id) continue;
             if (!std.mem.eql(u8, entry.table_name, table_name)) continue;
+            if (!self.entryHAWriteGateCurrent(entry)) continue;
             if (!self.adoptSeededEntryGenerationLocked(entry, lsm_root_generation)) continue;
             return self.leaseEntryLocked(entry);
         }
@@ -1522,6 +1542,7 @@ pub const ProvisionedTableWriteCache = struct {
             if (entry.group_id != group_id) continue;
             if (!std.mem.eql(u8, entry.table_name, table_name)) continue;
             if (!allow_bulk_session and (entry.bulk_ingest_session_open or entry.auto_bulk_ingest_session_open)) return null;
+            if (!self.entryHAWriteGateCurrent(entry)) continue;
             return self.leaseEntryLocked(entry);
         }
         return null;
@@ -1554,6 +1575,7 @@ pub const ProvisionedTableWriteCache = struct {
         }
         for (self.entries.items) |entry| {
             if (entry.group_id == group_id and entry.lsm_root_generation == lsm_root_generation and std.mem.eql(u8, entry.table_name, table_name)) {
+                if (!self.entryHAWriteGateCurrent(entry)) continue;
                 if (opened.*) |*db| db.close();
                 opened.* = null;
                 _ = self.hit_count.fetchAdd(1, .monotonic);
@@ -1590,6 +1612,7 @@ pub const ProvisionedTableWriteCache = struct {
         owned_entry.* = .{
             .group_id = group_id,
             .lsm_root_generation = lsm_root_generation,
+            .ha_write_gate_generation = haWriteGateCurrentGeneration(self.ha_write_gate),
             .table_name = owned_table_name,
             .db = db,
             .schema_json = prepared.schema_json,
@@ -1623,6 +1646,7 @@ pub const ProvisionedTableWriteCache = struct {
             if (entry.group_id != group_id) continue;
             if (entry.lsm_root_generation != lsm_root_generation) continue;
             if (!std.mem.eql(u8, entry.table_name, table_name)) continue;
+            if (!self.entryHAWriteGateCurrent(entry)) continue;
             if (opened.*) |*db| db.close();
             opened.* = null;
             try self.replaceTableMetadataLocked(table_name, indexes_json, schema_json);
@@ -1643,6 +1667,7 @@ pub const ProvisionedTableWriteCache = struct {
         owned_entry.* = .{
             .group_id = group_id,
             .lsm_root_generation = lsm_root_generation,
+            .ha_write_gate_generation = haWriteGateCurrentGeneration(self.ha_write_gate),
             .table_name = owned_table_name,
             .db = db,
             .schema_json = owned_schema_json,
@@ -1712,11 +1737,12 @@ pub const ProvisionedTableWriteCache = struct {
                 i += 1;
                 continue;
             }
-            if (entry.lsm_root_generation == lsm_root_generation) {
+            const stale_ha_write_gate = !self.entryHAWriteGateCurrent(entry);
+            if (entry.lsm_root_generation == lsm_root_generation and !stale_ha_write_gate) {
                 i += 1;
                 continue;
             }
-            if (self.adoptSeededEntryGenerationLocked(entry, lsm_root_generation)) {
+            if (!stale_ha_write_gate and self.adoptSeededEntryGenerationLocked(entry, lsm_root_generation)) {
                 i += 1;
                 continue;
             }
@@ -4910,6 +4936,7 @@ pub const ProvisionedTableWriteSource = struct {
         for (cache.entries.items) |entry| {
             if (entry.group_id != group_id) continue;
             if (!std.mem.eql(u8, entry.table_name, table_name)) continue;
+            if (!cache.entryHAWriteGateCurrent(entry)) continue;
             if (entry.auto_bulk_ingest_session_open) {
                 try self.finishEntryAutoBulkIngestForForegroundVisibility(cache, entry);
                 return cache.leaseEntryLocked(entry);
@@ -27099,6 +27126,102 @@ test "write cache HA gate clear drains inactive pending closes before returning"
     write_cache.setHAWriteGate(.{ .primary = &primary });
     try std.testing.expectEqual(@as(usize, 0), write_cache.entries.items.len);
     try std.testing.expectEqual(@as(usize, 0), write_cache.closing_entries.items.len);
+}
+
+test "write cache retires shared HA generation stale entries before reuse" {
+    const alloc = std.testing.allocator;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const replica_root_dir = try std.fmt.allocPrint(alloc, ".zig-cache/tmp/{s}/write-cache-ha-generation-stale", .{tmp.sub_path});
+    defer alloc.free(replica_root_dir);
+    defer closeHostedManagedDbCacheForRoot(replica_root_dir);
+    const path = try metadata_mod.groupDbPathFromReplicaRoot(alloc, replica_root_dir, 7001);
+    defer alloc.free(path);
+
+    const Catalog = struct {
+        fn iface() table_catalog.CatalogSource {
+            return .{
+                .ptr = undefined,
+                .vtable = &.{
+                    .admin_snapshot = adminSnapshot,
+                    .free_admin_snapshot = freeAdminSnapshot,
+                },
+            };
+        }
+
+        fn adminSnapshot(_: *anyopaque) !metadata_api.AdminSnapshot {
+            return .{
+                .status = .{ .metadata_group_id = 1, .metrics = .{} },
+                .tables = @constCast((&[_]metadata_table_manager.TableRecord{.{
+                    .table_id = 7,
+                    .name = "docs",
+                    .placement_role = "data",
+                    .indexes_json = "{\"indexes\":[]}",
+                }})[0..]),
+                .ranges = @constCast((&[_]metadata_table_manager.RangeRecord{.{
+                    .group_id = 7001,
+                    .table_id = 7,
+                    .start_key = "",
+                    .end_key = null,
+                }})[0..]),
+                .stores = @constCast((&[_]metadata_table_manager.StoreRecord{})[0..]),
+                .placement_intents = @constCast((&[_]raft_reconciler.PlacementIntent{})[0..]),
+                .split_transitions = @constCast((&[_]metadata_transition_state.SplitTransitionRecord{})[0..]),
+                .merge_transitions = @constCast((&[_]metadata_transition_state.MergeTransitionRecord{})[0..]),
+            };
+        }
+
+        fn freeAdminSnapshot(_: *anyopaque, _: *metadata_api.AdminSnapshot) void {}
+    };
+
+    var state = ha_public_gate_state_mod.State{};
+    state.configureStandby(.{
+        .received_lsn = 1,
+        .applied_lsn = 1,
+        .safe_read_lsn = 1,
+    });
+    const primary_log_path_raw = try std.fmt.allocPrint(alloc, ".zig-cache/tmp/{s}/write-cache-ha-generation-primary-log", .{tmp.sub_path});
+    defer alloc.free(primary_log_path_raw);
+    const primary_log_path = try alloc.dupeZ(u8, primary_log_path_raw);
+    defer alloc.free(primary_log_path);
+    const primary_slots_path_raw = try std.fmt.allocPrint(alloc, ".zig-cache/tmp/{s}/write-cache-ha-generation-primary-slots", .{tmp.sub_path});
+    defer alloc.free(primary_slots_path_raw);
+    const primary_slots_path = try alloc.dupeZ(u8, primary_slots_path_raw);
+    defer alloc.free(primary_slots_path);
+    var promoted_primary = try ha_primary_mod.Primary.open(alloc, primary_log_path.ptr, primary_slots_path.ptr, .{
+        .cluster_id = 700,
+        .shard_id = 1,
+        .table_id = 7,
+        .timeline_id = 2,
+        .epoch = 2,
+    }, .{});
+    defer promoted_primary.close();
+
+    var write_cache = ProvisionedTableWriteCache.init(alloc);
+    defer write_cache.deinit();
+    write_cache.setHAWriteGate(.{ .shared = .{ .state = &state } });
+
+    var standby_cached = try write_cache.getOrOpenLocked(path, Catalog.iface(), 7001, 0, "docs");
+    standby_cached.deinit(alloc);
+    try std.testing.expectEqual(@as(usize, 1), write_cache.entries.items.len);
+    try std.testing.expectEqual(@as(?u64, 1), write_cache.entries.items[0].ha_write_gate_generation);
+
+    state.publishPrimary(&promoted_primary, false);
+
+    try std.testing.expectError(
+        error.LsmRootWriterAlreadyOpen,
+        write_cache.getOrOpenLocked(path, Catalog.iface(), 7001, 0, "docs"),
+    );
+    try std.testing.expectEqual(@as(usize, 0), write_cache.entries.items.len);
+    try std.testing.expectEqual(@as(usize, 1), write_cache.closing_entries.items.len);
+
+    write_cache.drainPendingClosesForGroupTable(7001, "docs");
+    var primary_cached = try write_cache.getOrOpenLocked(path, Catalog.iface(), 7001, 0, "docs");
+    primary_cached.deinit(alloc);
+    try std.testing.expectEqual(@as(usize, 1), write_cache.entries.items.len);
+    try std.testing.expectEqual(@as(?u64, 2), write_cache.entries.items[0].ha_write_gate_generation);
 }
 
 test "hosted status-only open drains stale pending close before retry" {

--- a/zig/pkg/antfly/src/api/table_writes.zig
+++ b/zig/pkg/antfly/src/api/table_writes.zig
@@ -39,7 +39,6 @@ const lsm_backend = @import("../storage/lsm_backend/mod.zig");
 const portable_backup = @import("../storage/portable_backup.zig");
 const resource_manager_mod = @import("../storage/resource_manager.zig");
 const ha_primary_mod = @import("../storage/ha/primary.zig");
-const ha_write_gate_mod = @import("../storage/ha/write_gate.zig");
 const storage_schema = @import("../storage/schema.zig");
 const lmdb = @import("../storage/lmdb.zig");
 const table_catalog = @import("table_catalog.zig");
@@ -911,6 +910,7 @@ pub const ProvisionedTableWriteCache = struct {
                 .primary => |right| left == right,
                 .fenced_primary => false,
                 .standby => false,
+                .shared => false,
             },
             .fenced_primary => |left| switch (b.?) {
                 .primary => false,
@@ -918,11 +918,17 @@ pub const ProvisionedTableWriteCache = struct {
                     left.fence_store == right.fence_store and
                     std.mem.eql(u8, left.node_id, right.node_id),
                 .standby => false,
+                .shared => false,
             },
             .standby => |left| switch (b.?) {
                 .primary => false,
                 .fenced_primary => false,
                 .standby => |right| left == right,
+                .shared => false,
+            },
+            .shared => |left| switch (b.?) {
+                .primary, .fenced_primary, .standby => false,
+                .shared => |right| left.state == right.state and left.generation == right.generation,
             },
         };
     }
@@ -10003,17 +10009,7 @@ pub const ProvisionedTableWriteSource = struct {
 
 fn enforceHAWriteGateOptional(gate: ?db_mod.HAWriteGate) !void {
     const configured = gate orelse return;
-    const decision = switch (configured) {
-        .primary => |primary| try ha_write_gate_mod.evaluatePrimary(primary, .{}),
-        .fenced_primary => |gate_value| try ha_write_gate_mod.evaluateFencedPrimary(gate_value, .{}),
-        .standby => |standby| try ha_write_gate_mod.evaluateStandby(standby, .{}),
-    };
-    switch (decision.action) {
-        .allow_write => return,
-        .reject_read_only_standby => return error.HAReadOnlyStandby,
-        .open_promoted_primary => return error.HAPromotedStandbyRequiresPrimaryOpen,
-        .reject_fenced_primary => return error.HAFencedPrimary,
-    }
+    try configured.check();
 }
 
 pub const HostedProvisionedTableWriteSource = struct {

--- a/zig/pkg/antfly/src/data/runtime.zig
+++ b/zig/pkg/antfly/src/data/runtime.zig
@@ -2131,6 +2131,7 @@ pub const DataServer = struct {
     api_server_cfg: antfly.public_api.http_server.ApiHttpServerConfig,
     ha_cfg: DataServerHAConfig = .{},
     ha_state_mutex: std.atomic.Mutex = .unlocked,
+    ha_public_gate_state: antfly.ha.public_gate_state.State = .{},
     ha_admin_server: ?antfly.ha.http_admin.Server = null,
     ha_internal_server: ?antfly.ha.http_internal.Server = null,
     ha_standby_replication_http_executor: ?antfly.common.http.StdHttpExecutor = null,
@@ -2178,6 +2179,8 @@ pub const DataServer = struct {
     // fixed cadence and retries quickly only while repairs are landing.
     const dense_posting_maintenance_idle_interval_ns = 30 * std.time.ns_per_s;
     const dense_posting_maintenance_retry_interval_ns = 1 * std.time.ns_per_s;
+    const ha_replication_default_max_records_per_apply = 256;
+    const ha_replication_default_max_encoded_bytes_per_apply = 4 * 1024 * 1024;
 
     const ProvisionedWarmupStats = struct {
         warmed_group_count: u64 = 0,
@@ -2346,6 +2349,7 @@ pub const DataServer = struct {
         api_server_cfg.shard_ops = self.localShardOperationAdapter();
         api_server_cfg.shard_db_adapter = self.localShardDbAdapter();
         api_server_cfg.backend_runtime = self.backend_runtime;
+        self.configureHAPublicGateState();
         self.attachHaExecutors(&api_server_cfg);
         if (self.query_io_impl == null) {
             self.query_io_impl = std.Io.Threaded.init(self.alloc, .{
@@ -2438,6 +2442,11 @@ pub const DataServer = struct {
         try self.applyHAReplicationRecord(record);
     }
 
+    const HAStandbyFetchSnapshot = struct {
+        identity: antfly.ha.standby.Identity,
+        requested_lsn: u64,
+    };
+
     pub fn replicateHAStandbyAvailable(
         self: *DataServer,
         executor: antfly.common.http.RequestExecutor,
@@ -2447,14 +2456,7 @@ pub const DataServer = struct {
     ) !HAStandbyReplicationResult {
         if (self.http_server == null) self.initApiServer();
         var client = antfly.ha.http_replication_client.Client.init(self.alloc, executor);
-        return try client.replicateAvailable(
-            upstream_base_uri,
-            slot_name,
-            try self.haStandbyHandle(),
-            self,
-            DataServer.applyHAReplicationRecordCallback,
-            options,
-        );
+        return try self.replicateHAStandbyAvailableWithClient(&client, upstream_base_uri, slot_name, options);
     }
 
     pub fn replicateHAStandbyUntilCaughtUp(
@@ -2466,21 +2468,139 @@ pub const DataServer = struct {
     ) !HAStandbyReplicationLoopResult {
         if (self.http_server == null) self.initApiServer();
         var client = antfly.ha.http_replication_client.Client.init(self.alloc, executor);
-        return try client.replicateUntilCaughtUp(
+        var iterations: usize = 0;
+        var received_count: usize = 0;
+        var applied_count: usize = 0;
+        var batch_options = options;
+
+        while (true) {
+            const result = try self.replicateHAStandbyAvailableWithClient(
+                &client,
+                upstream_base_uri,
+                slot_name,
+                batch_options,
+            );
+            batch_options.verify_upstream = false;
+            iterations += 1;
+            received_count += result.received_count;
+            applied_count += result.applied_count;
+
+            if (result.end_of_wal) {
+                return .{
+                    .iterations = iterations,
+                    .received_count = received_count,
+                    .applied_count = applied_count,
+                    .progress = result.progress,
+                    .current_lsn = result.current_lsn,
+                    .last_sent_lsn = result.last_sent_lsn,
+                    .next_lsn = result.next_lsn,
+                };
+            }
+            if (result.received_count == 0 and result.applied_count == 0) {
+                return error.InternalReplicationDidNotAdvance;
+            }
+        }
+    }
+
+    fn replicateHAStandbyAvailableWithClient(
+        self: *DataServer,
+        client: *antfly.ha.http_replication_client.Client,
+        upstream_base_uri: []const u8,
+        slot_name: []const u8,
+        options: HAStandbyReplicationOptions,
+    ) !HAStandbyReplicationResult {
+        const snapshot = try self.snapshotHAStandbyForFetch();
+        var batch_options = options;
+        if (batch_options.max_records == 0) {
+            batch_options.max_records = ha_replication_default_max_records_per_apply;
+        }
+        if (batch_options.max_encoded_bytes == 0) {
+            batch_options.max_encoded_bytes = ha_replication_default_max_encoded_bytes_per_apply;
+        }
+        var batch = try client.fetchAvailable(
             upstream_base_uri,
             slot_name,
-            try self.haStandbyHandle(),
+            snapshot.identity,
+            snapshot.requested_lsn,
+            batch_options,
+        );
+        defer batch.deinit();
+
+        lockAtomic(&self.ha_state_mutex);
+        const ctx = self.ha_cfg.admin_context orelse {
+            self.ha_state_mutex.unlock();
+            return error.HAStandbyStateChanged;
+        };
+        const standby = ctx.standby orelse {
+            self.ha_state_mutex.unlock();
+            return error.HAStandbyStateChanged;
+        };
+        if (!std.meta.eql(standby.identity, snapshot.identity) or
+            standby.nextReceiveLsn() != snapshot.requested_lsn)
+        {
+            self.ha_state_mutex.unlock();
+            return error.HAStandbyStateChanged;
+        }
+
+        const applied = client.applyFetched(
+            &batch,
+            standby,
             self,
             DataServer.applyHAReplicationRecordCallback,
-            options,
+        ) catch |err| {
+            const status_identity = standby.identity;
+            const status_progress = standby.currentProgress();
+            self.ha_public_gate_state.publishStandbyProgress(status_progress);
+            self.ha_state_mutex.unlock();
+            _ = client.updateStandbyStatusSnapshot(
+                upstream_base_uri,
+                slot_name,
+                status_identity,
+                status_progress,
+            ) catch {};
+            return err;
+        };
+        const status_identity = standby.identity;
+        self.ha_public_gate_state.publishStandbyProgress(applied.progress);
+        self.ha_state_mutex.unlock();
+
+        try client.updateStandbyStatusSnapshot(
+            upstream_base_uri,
+            slot_name,
+            status_identity,
+            applied.progress,
         );
+        return .{
+            .received_count = applied.received_count,
+            .applied_count = applied.applied_count,
+            .progress = applied.progress,
+            .current_lsn = batch.current_lsn,
+            .last_sent_lsn = batch.last_sent_lsn,
+            .next_lsn = batch.next_lsn,
+            .end_of_wal = batch.end_of_wal,
+        };
+    }
+
+    fn snapshotHAStandbyForFetch(self: *DataServer) !HAStandbyFetchSnapshot {
+        lockAtomic(&self.ha_state_mutex);
+        defer self.ha_state_mutex.unlock();
+        const ctx = self.ha_cfg.admin_context orelse return error.HAStandbyNotConfigured;
+        const standby = ctx.standby orelse return error.HAStandbyNotConfigured;
+        return .{
+            .identity = standby.identity,
+            .requested_lsn = standby.nextReceiveLsn(),
+        };
     }
 
     fn runHAStandbyReplicationRound(self: *DataServer) !void {
         const cfg = self.ha_cfg.standby_replication orelse return;
         lockAtomic(&self.ha_state_mutex);
-        defer self.ha_state_mutex.unlock();
-        if (try self.openPromotedPrimaryFromStandbyIfReady(cfg)) return;
+        const promoted = self.openPromotedPrimaryFromStandbyIfReady(cfg) catch |err| {
+            self.ha_state_mutex.unlock();
+            return err;
+        };
+        self.ha_state_mutex.unlock();
+        if (promoted) return;
         const executor = try self.haStandbyReplicationExecutor(cfg);
         self.recordHAStandbyReplicationAttempt();
         if (cfg.catch_up_until_end_of_wal) {
@@ -2511,6 +2631,7 @@ pub const DataServer = struct {
             error.StandbyNotPromoted, error.PromotionNotApplied => return false,
             else => return err,
         };
+        self.ha_public_gate_state.beginPromotion();
         try self.consumeHAStandbyForPromotion(standby);
         self.ha_cfg.admin_context.?.standby = null;
         if (self.ha_admin_server) |*server| {
@@ -2556,7 +2677,11 @@ pub const DataServer = struct {
         if (self.http_server) |*server| {
             server.setHAInternalExecutor(self.api_server_cfg.ha_internal_executor);
         }
-        self.rewireHAAccessors();
+        self.rewireHAPromotionMirrors();
+        self.ha_public_gate_state.publishPrimary(
+            promoted_primary,
+            haContextPrimaryIsFenced(self.ha_cfg.admin_context.?),
+        );
         return true;
     }
 
@@ -2571,14 +2696,10 @@ pub const DataServer = struct {
         return error.HAStandbyOwnershipRequired;
     }
 
-    fn rewireHAAccessors(self: *DataServer) void {
-        _ = self.read_source.withHAReadGate(self.haReadGate());
-        const ha_write_gate = self.haWriteGate();
+    fn rewireHAPromotionMirrors(self: *DataServer) void {
         const ha_primary_mirror = self.haPrimaryMirror();
-        _ = self.write_source.withHAWriteGate(ha_write_gate);
         _ = self.write_source.withHAMirror(ha_primary_mirror);
         if (self.data_raft_apply) |apply_sm| {
-            _ = apply_sm.write_source.withHAWriteGate(ha_write_gate);
             _ = apply_sm.write_source.withHAMirror(ha_primary_mirror);
         }
     }
@@ -2594,26 +2715,45 @@ pub const DataServer = struct {
         return self.ha_standby_replication_http_executor.?.executor();
     }
 
-    fn haStandbyHandle(self: *DataServer) !*antfly.ha.standby.Standby {
-        const ctx = self.ha_cfg.admin_context orelse return error.HAStandbyNotConfigured;
-        return ctx.standby orelse error.HAStandbyNotConfigured;
+    fn configureHAPublicGateState(self: *DataServer) void {
+        const ctx = self.ha_cfg.admin_context orelse return;
+        if (ctx.standby) |standby| {
+            self.ha_public_gate_state.configureStandby(standby.currentProgress());
+            return;
+        }
+        if (ctx.primary) |primary| {
+            self.ha_public_gate_state.configurePrimary(primary, haContextPrimaryIsFenced(ctx));
+        }
+    }
+
+    fn refreshHAPublicGateState(self: *DataServer) void {
+        const ctx = self.ha_cfg.admin_context orelse return;
+        if (ctx.standby) |standby| {
+            _ = standby.promotedPrimaryHandoff() catch |err| switch (err) {
+                error.StandbyNotPromoted, error.PromotionNotApplied => {
+                    self.ha_public_gate_state.publishStandbyProgress(standby.currentProgress());
+                    return;
+                },
+                else => return,
+            };
+            self.ha_public_gate_state.beginPromotion();
+            return;
+        }
+        if (ctx.primary != null) {
+            self.ha_public_gate_state.publishPrimaryFence(haContextPrimaryIsFenced(ctx));
+        }
+    }
+
+    fn haPublicGateStateChangedCallback(ptr: *anyopaque) void {
+        const self: *DataServer = @ptrCast(@alignCast(ptr));
+        self.refreshHAPublicGateState();
     }
 
     fn haWriteGate(self: *DataServer) ?antfly.db.HAWriteGate {
         const ctx = self.ha_cfg.admin_context orelse return null;
-        if (ctx.standby) |standby| return .{ .standby = standby };
-        if (ctx.primary) |primary| {
-            if (ctx.fence_store) |fence_store| {
-                if (ctx.primary_node_id) |node_id| {
-                    return .{ .fenced_primary = .{
-                        .primary = primary,
-                        .fence_store = fence_store,
-                        .node_id = node_id,
-                    } };
-                }
-            }
-            return .{ .primary = primary };
-        }
+        if (ctx.standby != null or ctx.primary != null) return .{ .shared = .{
+            .state = &self.ha_public_gate_state,
+        } };
         return null;
     }
 
@@ -2647,7 +2787,7 @@ pub const DataServer = struct {
 
     fn haReadGate(self: *DataServer) ?antfly.public_api.HAReadGate {
         const ctx = self.ha_cfg.admin_context orelse return null;
-        if (ctx.standby) |standby| return .{ .standby = standby };
+        if (ctx.standby != null) return .{ .shared = &self.ha_public_gate_state };
         return null;
     }
 
@@ -2655,23 +2795,8 @@ pub const DataServer = struct {
         self: *DataServer,
         kind: antfly.ha.owner_job_gate.JobKind,
     ) bool {
-        const ctx = self.ha_cfg.admin_context orelse return true;
-        if (ctx.primary) |primary| {
-            if (ctx.fence_store) |fence_store| {
-                if (ctx.primary_node_id) |node_id| {
-                    if (fence_store.currentBorrowed()) |receipt| {
-                        if (antfly.ha.write_gate.primaryFencedByReceipt(primary.identity, node_id, receipt)) return false;
-                    }
-                }
-            }
-            const decision = antfly.ha.owner_job_gate.evaluatePrimary(primary, .{ .kind = kind }) catch return false;
-            return decision.canRun();
-        }
-        if (ctx.standby) |standby| {
-            const decision = antfly.ha.owner_job_gate.evaluateStandby(standby, .{ .kind = kind }) catch return false;
-            return decision.canRun();
-        }
-        return true;
+        _ = kind;
+        return self.ha_public_gate_state.ownerJobsCanRun();
     }
 
     fn attachHaExecutors(self: *DataServer, api_server_cfg: *antfly.public_api.http_server.ApiHttpServerConfig) void {
@@ -2679,7 +2804,11 @@ pub const DataServer = struct {
             if (self.ha_cfg.admin_context) |ctx| {
                 self.ha_admin_server = antfly.ha.http_admin.Server.initWithOptions(self.alloc, ctx, .{
                     .bearer_token = self.ha_cfg.admin_bearer_token,
-                    .state_mutex = if (ctx.primary != null or self.ha_cfg.standby_replication != null) &self.ha_state_mutex else null,
+                    .state_mutex = if (ctx.primary != null or ctx.standby != null) &self.ha_state_mutex else null,
+                    .state_changed = .{
+                        .ptr = self,
+                        .run_fn = DataServer.haPublicGateStateChangedCallback,
+                    },
                     .standby_status_extras = .{
                         .ptr = self,
                         .last_error = haStandbyReplicationLastErrorCallback,
@@ -6777,6 +6906,14 @@ fn lockAtomic(mutex: *std.atomic.Mutex) void {
     // waiter — on CPU-constrained hosts (CI runners) that starves the very
     // threads that would release the lock.
     platform_sync.lockYielding(mutex);
+}
+
+fn haContextPrimaryIsFenced(ctx: antfly.ha.admin_exec.Context) bool {
+    const primary = ctx.primary orelse return false;
+    const fence_store = ctx.fence_store orelse return false;
+    const node_id = ctx.primary_node_id orelse return false;
+    const receipt = fence_store.currentBorrowed() orelse return false;
+    return antfly.ha.write_gate.primaryFencedByReceipt(primary.identity, node_id, receipt);
 }
 
 fn appendUniqueNodeId(alloc: std.mem.Allocator, list: *std.ArrayListUnmanaged(u64), node_id: u64) !void {
@@ -16096,18 +16233,27 @@ test "data server propagates standby HA write gate into provisioned write source
 
     const source_gate = server.write_source.ha_write_gate orelse return error.TestExpectedEqual;
     switch (source_gate) {
-        .standby => |handle| try std.testing.expect(handle == &standby),
-        .fenced_primary, .primary => return error.TestExpectedEqual,
+        .shared => |gate| {
+            try std.testing.expect(gate.state == &server.ha_public_gate_state);
+            try std.testing.expect(gate.generation == null);
+        },
+        .standby, .fenced_primary, .primary => return error.TestExpectedEqual,
     }
 
     const cache_gate = server.provisioned_storage.write_cache.ha_write_gate orelse return error.TestExpectedEqual;
     switch (cache_gate) {
-        .standby => |handle| try std.testing.expect(handle == &standby),
-        .fenced_primary, .primary => return error.TestExpectedEqual,
+        .shared => |gate| {
+            try std.testing.expect(gate.state == &server.ha_public_gate_state);
+            try std.testing.expect(gate.generation == null);
+        },
+        .standby, .fenced_primary, .primary => return error.TestExpectedEqual,
     }
 
     const read_gate = server.read_source.ha_read_gate orelse return error.TestExpectedEqual;
-    try std.testing.expect(read_gate.standby == &standby);
+    switch (read_gate) {
+        .shared => |state| try std.testing.expect(state == &server.ha_public_gate_state),
+        .standby => return error.TestExpectedEqual,
+    }
     try std.testing.expectError(
         error.HAReadRequiresPrimary,
         server.read_source.source().lookup(alloc, "docs", "doc:a", .{}, .read_index),
@@ -16225,17 +16371,6 @@ test "storage.ha data server rejects writes and owner jobs after primary promoti
 
     var fence_store = try antfly.ha.fencing.Store.open(alloc, fence_path.ptr, .{});
     defer fence_store.close();
-    const receipt = try fence_store.acquirePromotionFence(.{
-        .identity = identity,
-        .old_primary_id = "primary-a",
-        .promoted_node_id = "standby-a",
-        .new_timeline_id = 2,
-        .new_epoch = 2,
-        .required_lsn = 1,
-        .observed_lsn = 1,
-        .reason = "data-server-test",
-    });
-    defer antfly.ha.fencing.freeReceipt(alloc, receipt);
 
     var server = DataServer.initFromLocalMetadataSources(alloc, .{
         .replica_root_dir = ".",
@@ -16252,13 +16387,23 @@ test "storage.ha data server rejects writes and owner jobs after primary promoti
 
     const source_gate = server.write_source.ha_write_gate orelse return error.TestExpectedEqual;
     switch (source_gate) {
-        .fenced_primary => |gate| {
-            try std.testing.expect(gate.primary == &primary);
-            try std.testing.expect(gate.fence_store == &fence_store);
-            try std.testing.expectEqualStrings("primary-a", gate.node_id);
+        .shared => |gate| {
+            try std.testing.expect(gate.state == &server.ha_public_gate_state);
+            try std.testing.expect(gate.generation == null);
         },
-        .primary, .standby => return error.TestExpectedEqual,
+        .primary, .fenced_primary, .standby => return error.TestExpectedEqual,
     }
+    try source_gate.check();
+
+    var fence_response = try server.http_server.?.handle(.{
+        .method = .POST,
+        .uri = antfly.admin.routes.ha_fence,
+        .content_type = "application/json",
+        .body = "{\"identity\":{\"cluster_id\":100,\"shard_id\":10,\"table_id\":20,\"timeline_id\":1,\"epoch\":1},\"old_primary_id\":\"primary-a\",\"promoted_node_id\":\"standby-a\",\"new_timeline_id\":2,\"new_epoch\":2,\"required_lsn\":1,\"observed_lsn\":1,\"force\":false,\"reason\":\"data-server-test\"}",
+    });
+    defer fence_response.deinit(alloc);
+    try std.testing.expectEqual(@as(u16, 200), fence_response.status);
+    try std.testing.expectError(error.HAFencedPrimary, source_gate.check());
 
     try std.testing.expectError(error.HAFencedPrimary, server.write_source.source().batchGroupLocal(alloc, 10, "docs", .{
         .writes = &.{.{ .key = "doc:local", .value = "{\"title\":\"local-write\"}" }},
@@ -16582,6 +16727,194 @@ test "data server pulls and applies HA standby replication through internal HTTP
     try std.testing.expect(std.mem.indexOf(u8, lookup.json, "\"title\":\"from-http\"") != null);
 }
 
+test "data server HA replication network wait leaves state mutex available" {
+    const alloc = std.testing.allocator;
+    const FakeStatus = struct {
+        fn iface() antfly.public_api.http_server.StatusSource {
+            return .{
+                .ptr = undefined,
+                .vtable = &.{
+                    .status = status,
+                    .admin_snapshot = adminSnapshot,
+                    .free_admin_snapshot = freeAdminSnapshot,
+                },
+            };
+        }
+
+        fn status(_: *anyopaque) !antfly.metadata_api.MetadataStatus {
+            return .{ .metadata_group_id = 1, .metrics = .{} };
+        }
+
+        fn adminSnapshot(_: *anyopaque) !antfly.metadata_api.AdminSnapshot {
+            return .{
+                .status = .{ .metadata_group_id = 1, .metrics = .{} },
+                .tables = @constCast((&[_]antfly.metadata.table_manager.TableRecord{})[0..]),
+                .ranges = @constCast((&[_]antfly.metadata.table_manager.RangeRecord{})[0..]),
+                .stores = @constCast((&[_]antfly.metadata.table_manager.StoreRecord{})[0..]),
+                .placement_intents = @constCast((&[_]antfly.raft.reconciler.PlacementIntent{})[0..]),
+                .split_transitions = @constCast((&[_]antfly.metadata.SplitTransitionRecord{})[0..]),
+                .merge_transitions = @constCast((&[_]antfly.metadata.MergeTransitionRecord{})[0..]),
+            };
+        }
+
+        fn freeAdminSnapshot(_: *anyopaque, _: *antfly.metadata_api.AdminSnapshot) void {}
+    };
+    const FakeCatalog = struct {
+        fn iface() antfly.public_api.table_catalog.CatalogSource {
+            return .{
+                .ptr = undefined,
+                .vtable = &.{
+                    .admin_snapshot = adminSnapshot,
+                    .free_admin_snapshot = freeAdminSnapshot,
+                },
+            };
+        }
+
+        fn adminSnapshot(_: *anyopaque) !antfly.metadata_api.AdminSnapshot {
+            return try FakeStatus.adminSnapshot(undefined);
+        }
+
+        fn freeAdminSnapshot(_: *anyopaque, _: *antfly.metadata_api.AdminSnapshot) void {}
+    };
+    const BlockingExecutor = struct {
+        upstream: antfly.common.http.RequestExecutor,
+        entered: std.atomic.Value(bool) = .init(false),
+        release: std.atomic.Value(bool) = .init(false),
+
+        fn executor(self: *@This()) antfly.common.http.RequestExecutor {
+            return .{
+                .ptr = self,
+                .vtable = &.{ .execute = execute },
+            };
+        }
+
+        fn execute(
+            ptr: *anyopaque,
+            alloc_arg: std.mem.Allocator,
+            req: antfly.common.http.HttpRequest,
+        ) anyerror!antfly.common.http.HttpResponse {
+            const self: *@This() = @ptrCast(@alignCast(ptr));
+            if (std.mem.endsWith(u8, req.uri, antfly.internal.routes.ha_replication_start)) {
+                self.entered.store(true, .release);
+                while (!self.release.load(.acquire)) std.Thread.yield() catch {};
+            }
+            return try self.upstream.execute(alloc_arg, req);
+        }
+    };
+    const ReplicationThread = struct {
+        server: *DataServer,
+        err: ?anyerror = null,
+
+        fn run(self: *@This()) void {
+            self.server.runHAStandbyReplicationRound() catch |err| {
+                self.err = err;
+            };
+        }
+    };
+
+    const nonce = platform_time.monotonicNs();
+    const replica_root_raw = try std.fmt.allocPrint(alloc, ".zig-cache/tmp/data-runtime-ha-unlocked-network-root-{d}", .{nonce});
+    defer alloc.free(replica_root_raw);
+    const replica_root = try alloc.dupeZ(u8, replica_root_raw);
+    defer alloc.free(replica_root);
+    const primary_log_raw = try std.fmt.allocPrint(alloc, ".zig-cache/tmp/data-runtime-ha-unlocked-network-primary-log-{d}", .{nonce});
+    defer alloc.free(primary_log_raw);
+    const primary_log = try alloc.dupeZ(u8, primary_log_raw);
+    defer alloc.free(primary_log);
+    const primary_slots_raw = try std.fmt.allocPrint(alloc, ".zig-cache/tmp/data-runtime-ha-unlocked-network-primary-slots-{d}", .{nonce});
+    defer alloc.free(primary_slots_raw);
+    const primary_slots = try alloc.dupeZ(u8, primary_slots_raw);
+    defer alloc.free(primary_slots);
+    const standby_log_raw = try std.fmt.allocPrint(alloc, ".zig-cache/tmp/data-runtime-ha-unlocked-network-log-{d}", .{nonce});
+    defer alloc.free(standby_log_raw);
+    const standby_log = try alloc.dupeZ(u8, standby_log_raw);
+    defer alloc.free(standby_log);
+    const standby_progress_raw = try std.fmt.allocPrint(alloc, ".zig-cache/tmp/data-runtime-ha-unlocked-network-progress-{d}", .{nonce});
+    defer alloc.free(standby_progress_raw);
+    const standby_progress = try alloc.dupeZ(u8, standby_progress_raw);
+    defer alloc.free(standby_progress);
+
+    var io_impl = std.Io.Threaded.init(alloc, .{});
+    defer io_impl.deinit();
+    std.Io.Dir.cwd().deleteTree(io_impl.io(), replica_root) catch {};
+    std.Io.Dir.cwd().deleteTree(io_impl.io(), primary_log) catch {};
+    std.Io.Dir.cwd().deleteTree(io_impl.io(), primary_slots) catch {};
+    std.Io.Dir.cwd().deleteTree(io_impl.io(), standby_log) catch {};
+    std.Io.Dir.cwd().deleteTree(io_impl.io(), standby_progress) catch {};
+    defer std.Io.Dir.cwd().deleteTree(io_impl.io(), replica_root) catch {};
+    defer std.Io.Dir.cwd().deleteTree(io_impl.io(), primary_log) catch {};
+    defer std.Io.Dir.cwd().deleteTree(io_impl.io(), primary_slots) catch {};
+    defer std.Io.Dir.cwd().deleteTree(io_impl.io(), standby_log) catch {};
+    defer std.Io.Dir.cwd().deleteTree(io_impl.io(), standby_progress) catch {};
+
+    const identity: antfly.ha.standby.Identity = .{
+        .cluster_id = 100,
+        .shard_id = 77,
+        .table_id = 7,
+        .timeline_id = 1,
+        .epoch = 1,
+    };
+    var primary = try antfly.ha.primary.Primary.open(alloc, primary_log.ptr, primary_slots.ptr, identity, .{});
+    defer primary.close();
+    try primary.createSlot("standby-a", 0);
+    var primary_internal = antfly.ha.http_internal.Server.init(alloc, &primary);
+    var standby = try antfly.ha.standby.Standby.open(alloc, standby_log.ptr, standby_progress.ptr, identity, .{});
+    defer standby.close();
+    var blocking_executor = BlockingExecutor{ .upstream = primary_internal.executor() };
+    var server = DataServer.initFromLocalMetadataSources(alloc, .{
+        .replica_root_dir = replica_root,
+        .ha = .{
+            .admin_context = .{
+                .standby = &standby,
+                .standby_node_id = "standby-a",
+            },
+            .standby_replication = .{
+                .upstream_base_uri = "http://primary.internal.test",
+                .slot_name = "standby-a",
+                .options = .{ .verify_upstream = false },
+                .executor = blocking_executor.executor(),
+            },
+        },
+    }, FakeCatalog.iface(), FakeStatus.iface());
+    defer server.deinit();
+    server.initApiServer();
+
+    var replication_thread = ReplicationThread{ .server = &server };
+    const thread = try std.Thread.spawn(.{}, ReplicationThread.run, .{&replication_thread});
+    var joined = false;
+    defer if (!joined) {
+        blocking_executor.release.store(true, .release);
+        thread.join();
+    };
+
+    var spins: usize = 0;
+    while (!blocking_executor.entered.load(.acquire) and spins < 1_000_000) : (spins += 1) {
+        std.Thread.yield() catch {};
+    }
+    try std.testing.expect(blocking_executor.entered.load(.acquire));
+
+    const mutex_available = server.ha_state_mutex.tryLock();
+    var promotion_err: ?anyerror = null;
+    if (mutex_available) {
+        _ = standby.promote(.{
+            .new_timeline_id = 2,
+            .new_epoch = 2,
+            .fencing_confirmed = true,
+        }) catch |err| {
+            promotion_err = err;
+        };
+        server.ha_state_mutex.unlock();
+    }
+    blocking_executor.release.store(true, .release);
+    thread.join();
+    joined = true;
+
+    try std.testing.expect(mutex_available);
+    try std.testing.expect(promotion_err == null);
+    const replication_err = replication_thread.err orelse return error.TestExpectedEqual;
+    try std.testing.expectEqual(error.HAStandbyStateChanged, replication_err);
+}
+
 test "data server promotion rewires live HTTP internal HA executor" {
     const alloc = std.testing.allocator;
     const FakeStatus = struct {
@@ -16690,6 +17023,9 @@ test "data server promotion rewires live HTTP internal HA executor" {
     defer server.deinit();
     server.initApiServer();
 
+    const public_read_gate_before = server.read_source.ha_read_gate orelse return error.TestExpectedEqual;
+    const public_write_gate_before = server.write_source.ha_write_gate orelse return error.TestExpectedEqual;
+
     var before = try server.http_server.?.handle(.{
         .method = .GET,
         .uri = antfly.internal.routes.ha_replication_identify,
@@ -16704,6 +17040,12 @@ test "data server promotion rewires live HTTP internal HA executor" {
     try std.testing.expect(server.ha_cfg.admin_context.?.promoted_standby_handoff != null);
     try std.testing.expect(server.ha_admin_server.?.auth.state_mutex == &server.ha_state_mutex);
     try std.testing.expect(server.ha_internal_server.?.state_mutex == &server.ha_state_mutex);
+    const public_read_gate_after = server.read_source.ha_read_gate orelse return error.TestExpectedEqual;
+    const public_write_gate_after = server.write_source.ha_write_gate orelse return error.TestExpectedEqual;
+    try std.testing.expect(std.meta.eql(public_read_gate_before, public_read_gate_after));
+    try std.testing.expect(std.meta.eql(public_write_gate_before, public_write_gate_after));
+    try public_read_gate_before.check(.stale);
+    try public_write_gate_before.check();
 
     var write_check = try server.http_server.?.handle(.{
         .method = .POST,

--- a/zig/pkg/antfly/src/data/runtime.zig
+++ b/zig/pkg/antfly/src/data/runtime.zig
@@ -2130,6 +2130,7 @@ pub const DataServer = struct {
     http_server: ?antfly.public_api.ApiHttpServer = null,
     api_server_cfg: antfly.public_api.http_server.ApiHttpServerConfig,
     ha_cfg: DataServerHAConfig = .{},
+    ha_state_mutex: std.atomic.Mutex = .unlocked,
     ha_admin_server: ?antfly.ha.http_admin.Server = null,
     ha_internal_server: ?antfly.ha.http_internal.Server = null,
     ha_standby_replication_http_executor: ?antfly.common.http.StdHttpExecutor = null,
@@ -2477,6 +2478,8 @@ pub const DataServer = struct {
 
     fn runHAStandbyReplicationRound(self: *DataServer) !void {
         const cfg = self.ha_cfg.standby_replication orelse return;
+        lockAtomic(&self.ha_state_mutex);
+        defer self.ha_state_mutex.unlock();
         if (try self.openPromotedPrimaryFromStandbyIfReady(cfg)) return;
         const executor = try self.haStandbyReplicationExecutor(cfg);
         self.recordHAStandbyReplicationAttempt();
@@ -2536,14 +2539,18 @@ pub const DataServer = struct {
         const promoted_node_id = self.ha_cfg.admin_context.?.standby_node_id;
         self.ha_cfg.admin_context.?.primary = promoted_primary;
         self.ha_cfg.admin_context.?.primary_node_id = promoted_node_id;
+        self.ha_cfg.admin_context.?.promoted_standby_handoff = handoff;
         if (self.ha_admin_server) |*server| {
             server.ctx.primary = promoted_primary;
             server.ctx.primary_node_id = promoted_node_id;
+            server.ctx.promoted_standby_handoff = handoff;
         }
         self.ha_internal_server = null;
         self.api_server_cfg.ha_internal_executor = null;
         if (self.ha_cfg.admin_context.?.primary) |handle| {
-            self.ha_internal_server = antfly.ha.http_internal.Server.init(self.alloc, handle);
+            self.ha_internal_server = antfly.ha.http_internal.Server.initWithOptions(self.alloc, handle, .{
+                .state_mutex = &self.ha_state_mutex,
+            });
             self.api_server_cfg.ha_internal_executor = self.ha_internal_server.?.executor();
         }
         if (self.http_server) |*server| {
@@ -2672,6 +2679,7 @@ pub const DataServer = struct {
             if (self.ha_cfg.admin_context) |ctx| {
                 self.ha_admin_server = antfly.ha.http_admin.Server.initWithOptions(self.alloc, ctx, .{
                     .bearer_token = self.ha_cfg.admin_bearer_token,
+                    .state_mutex = if (ctx.primary != null or self.ha_cfg.standby_replication != null) &self.ha_state_mutex else null,
                     .standby_status_extras = .{
                         .ptr = self,
                         .last_error = haStandbyReplicationLastErrorCallback,
@@ -2686,7 +2694,9 @@ pub const DataServer = struct {
         if (api_server_cfg.ha_internal_executor == null) {
             const primary = self.ha_cfg.internal_primary orelse if (self.ha_cfg.admin_context) |ctx| ctx.primary else null;
             if (primary) |handle| {
-                self.ha_internal_server = antfly.ha.http_internal.Server.init(self.alloc, handle);
+                self.ha_internal_server = antfly.ha.http_internal.Server.initWithOptions(self.alloc, handle, .{
+                    .state_mutex = &self.ha_state_mutex,
+                });
                 api_server_cfg.ha_internal_executor = self.ha_internal_server.?.executor();
             }
         }
@@ -16691,6 +16701,32 @@ test "data server promotion rewires live HTTP internal HA executor" {
     try std.testing.expect(standby == null);
     try std.testing.expect(server.ha_promoted_primary != null);
     try std.testing.expect(server.ha_cfg.admin_context.?.standby == null);
+    try std.testing.expect(server.ha_cfg.admin_context.?.promoted_standby_handoff != null);
+    try std.testing.expect(server.ha_admin_server.?.auth.state_mutex == &server.ha_state_mutex);
+    try std.testing.expect(server.ha_internal_server.?.state_mutex == &server.ha_state_mutex);
+
+    var write_check = try server.http_server.?.handle(.{
+        .method = .POST,
+        .uri = antfly.admin.routes.ha_write_check,
+        .content_type = "application/json",
+        .body = "{\"role\":\"standby\",\"expected_identity\":{\"cluster_id\":100,\"shard_id\":77,\"table_id\":7,\"timeline_id\":2,\"epoch\":2}}",
+    });
+    defer write_check.deinit(alloc);
+    try std.testing.expectEqual(@as(u16, 200), write_check.status);
+    try std.testing.expect(std.mem.indexOf(u8, write_check.body, "\"role\":\"promoted_standby\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, write_check.body, "\"action\":\"open_promoted_primary\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, write_check.body, "\"promotion_handoff\"") != null);
+
+    var owner_job_check = try server.http_server.?.handle(.{
+        .method = .POST,
+        .uri = antfly.admin.routes.ha_owner_job_check,
+        .content_type = "application/json",
+        .body = "{\"role\":\"standby\",\"kind\":\"retention_advance\",\"expected_identity\":{\"cluster_id\":100,\"shard_id\":77,\"table_id\":7,\"timeline_id\":2,\"epoch\":2}}",
+    });
+    defer owner_job_check.deinit(alloc);
+    try std.testing.expectEqual(@as(u16, 200), owner_job_check.status);
+    try std.testing.expect(std.mem.indexOf(u8, owner_job_check.body, "\"role\":\"promoted_standby\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, owner_job_check.body, "\"action\":\"open_promoted_primary\"") != null);
 
     var internal_resp = try server.http_server.?.handle(.{
         .method = .GET,

--- a/zig/pkg/antfly/src/data/runtime.zig
+++ b/zig/pkg/antfly/src/data/runtime.zig
@@ -2631,15 +2631,10 @@ pub const DataServer = struct {
             error.StandbyNotPromoted, error.PromotionNotApplied => return false,
             else => return err,
         };
-        self.ha_public_gate_state.beginPromotion();
-        try self.consumeHAStandbyForPromotion(standby);
-        self.ha_cfg.admin_context.?.standby = null;
-        if (self.ha_admin_server) |*server| {
-            server.ctx.standby = null;
-        }
-
         const log_path = cfg.standby_log_path orelse return error.HAPromotedPrimaryLogMissing;
         const progress_path = cfg.standby_progress_path orelse return error.HAPromotedPrimarySlotsMissing;
+        try self.validateHAStandbyPromotionOwner(standby);
+
         const log_path_z = try self.alloc.dupeZ(u8, log_path);
         defer self.alloc.free(log_path_z);
         const slots_path_buf = try std.fmt.allocPrint(self.alloc, "{s}.promoted-primary-slots", .{progress_path});
@@ -2647,22 +2642,32 @@ pub const DataServer = struct {
         const slots_path = try self.alloc.dupeZ(u8, slots_path_buf);
         defer self.alloc.free(slots_path);
 
-        self.ha_promoted_primary = try antfly.ha.primary.Primary.openPromotedFromStandby(
+        var promoted_primary = try antfly.ha.primary.Primary.openPromotedFromStandby(
             self.alloc,
             log_path_z.ptr,
             slots_path.ptr,
             handoff,
             .{},
         );
-        const promoted_primary = &self.ha_promoted_primary.?;
-        self.ha_cfg.internal_primary = promoted_primary;
+        errdefer promoted_primary.close();
+
+        self.ha_public_gate_state.beginPromotion();
+        try self.consumeHAStandbyForPromotion(standby);
+        self.ha_cfg.admin_context.?.standby = null;
+        if (self.ha_admin_server) |*server| {
+            server.ctx.standby = null;
+        }
+
+        self.ha_promoted_primary = promoted_primary;
+        const promoted_primary_handle = &self.ha_promoted_primary.?;
+        self.ha_cfg.internal_primary = promoted_primary_handle;
         self.ha_cfg.standby_replication = null;
         const promoted_node_id = self.ha_cfg.admin_context.?.standby_node_id;
-        self.ha_cfg.admin_context.?.primary = promoted_primary;
+        self.ha_cfg.admin_context.?.primary = promoted_primary_handle;
         self.ha_cfg.admin_context.?.primary_node_id = promoted_node_id;
         self.ha_cfg.admin_context.?.promoted_standby_handoff = handoff;
         if (self.ha_admin_server) |*server| {
-            server.ctx.primary = promoted_primary;
+            server.ctx.primary = promoted_primary_handle;
             server.ctx.primary_node_id = promoted_node_id;
             server.ctx.promoted_standby_handoff = handoff;
         }
@@ -2679,10 +2684,19 @@ pub const DataServer = struct {
         }
         self.rewireHAPromotionMirrors();
         self.ha_public_gate_state.publishPrimary(
-            promoted_primary,
+            promoted_primary_handle,
             haContextPrimaryIsFenced(self.ha_cfg.admin_context.?),
         );
         return true;
+    }
+
+    fn validateHAStandbyPromotionOwner(self: *DataServer, standby: *antfly.ha.standby.Standby) !void {
+        const owner = self.ha_cfg.standby_owner orelse return error.HAStandbyOwnershipRequired;
+        if (owner.*) |*owned| {
+            if (owned != standby) return error.HAStandbyOwnerMismatch;
+            return;
+        }
+        return error.HAStandbyOwnershipRequired;
     }
 
     fn consumeHAStandbyForPromotion(self: *DataServer, standby: *antfly.ha.standby.Standby) !void {
@@ -17085,6 +17099,140 @@ test "data server promotion rewires live HTTP internal HA executor" {
     defer internal_resp.deinit(alloc);
     try std.testing.expectEqual(@as(u16, 200), internal_resp.status);
     try std.testing.expect(std.mem.indexOf(u8, internal_resp.body, "\"record_format_version\"") != null);
+}
+
+test "data server promotion open failure preserves retryable standby" {
+    const alloc = std.testing.allocator;
+    const FakeStatus = struct {
+        fn iface() antfly.public_api.http_server.StatusSource {
+            return .{
+                .ptr = undefined,
+                .vtable = &.{
+                    .status = status,
+                    .admin_snapshot = adminSnapshot,
+                    .free_admin_snapshot = freeAdminSnapshot,
+                },
+            };
+        }
+
+        fn status(_: *anyopaque) !antfly.metadata_api.MetadataStatus {
+            return .{ .metadata_group_id = 1, .metrics = .{} };
+        }
+
+        fn adminSnapshot(_: *anyopaque) !antfly.metadata_api.AdminSnapshot {
+            return .{
+                .status = .{ .metadata_group_id = 1, .metrics = .{} },
+                .tables = @constCast((&[_]antfly.metadata.table_manager.TableRecord{})[0..]),
+                .ranges = @constCast((&[_]antfly.metadata.table_manager.RangeRecord{})[0..]),
+                .stores = @constCast((&[_]antfly.metadata.table_manager.StoreRecord{})[0..]),
+                .placement_intents = @constCast((&[_]antfly.raft.reconciler.PlacementIntent{})[0..]),
+                .split_transitions = @constCast((&[_]antfly.metadata.SplitTransitionRecord{})[0..]),
+                .merge_transitions = @constCast((&[_]antfly.metadata.MergeTransitionRecord{})[0..]),
+            };
+        }
+
+        fn freeAdminSnapshot(_: *anyopaque, _: *antfly.metadata_api.AdminSnapshot) void {}
+    };
+    const FakeCatalog = struct {
+        fn iface() antfly.public_api.table_catalog.CatalogSource {
+            return .{
+                .ptr = undefined,
+                .vtable = &.{
+                    .admin_snapshot = adminSnapshot,
+                    .free_admin_snapshot = freeAdminSnapshot,
+                },
+            };
+        }
+
+        fn adminSnapshot(_: *anyopaque) !antfly.metadata_api.AdminSnapshot {
+            return try FakeStatus.adminSnapshot(undefined);
+        }
+
+        fn freeAdminSnapshot(_: *anyopaque, _: *antfly.metadata_api.AdminSnapshot) void {}
+    };
+
+    const nonce = platform_time.monotonicNs();
+    const replica_root_raw = try std.fmt.allocPrint(alloc, ".zig-cache/tmp/data-runtime-ha-promote-retry-root-{d}", .{nonce});
+    defer alloc.free(replica_root_raw);
+    const replica_root = try alloc.dupeZ(u8, replica_root_raw);
+    defer alloc.free(replica_root);
+    const standby_log_raw = try std.fmt.allocPrint(alloc, ".zig-cache/tmp/data-runtime-ha-promote-retry-log-{d}", .{nonce});
+    defer alloc.free(standby_log_raw);
+    const standby_log = try alloc.dupeZ(u8, standby_log_raw);
+    defer alloc.free(standby_log);
+    const standby_progress_raw = try std.fmt.allocPrint(alloc, ".zig-cache/tmp/data-runtime-ha-promote-retry-progress-{d}", .{nonce});
+    defer alloc.free(standby_progress_raw);
+    const standby_progress = try alloc.dupeZ(u8, standby_progress_raw);
+    defer alloc.free(standby_progress);
+    const wrong_log_raw = try std.fmt.allocPrint(alloc, ".zig-cache/tmp/data-runtime-ha-promote-retry-wrong-log-{d}", .{nonce});
+    defer alloc.free(wrong_log_raw);
+    const wrong_log = try alloc.dupeZ(u8, wrong_log_raw);
+    defer alloc.free(wrong_log);
+
+    var io_impl = std.Io.Threaded.init(alloc, .{});
+    defer io_impl.deinit();
+    std.Io.Dir.cwd().deleteTree(io_impl.io(), replica_root) catch {};
+    std.Io.Dir.cwd().deleteTree(io_impl.io(), standby_log) catch {};
+    std.Io.Dir.cwd().deleteTree(io_impl.io(), standby_progress) catch {};
+    std.Io.Dir.cwd().deleteTree(io_impl.io(), wrong_log) catch {};
+    defer std.Io.Dir.cwd().deleteTree(io_impl.io(), replica_root) catch {};
+    defer std.Io.Dir.cwd().deleteTree(io_impl.io(), standby_log) catch {};
+    defer std.Io.Dir.cwd().deleteTree(io_impl.io(), standby_progress) catch {};
+    defer std.Io.Dir.cwd().deleteTree(io_impl.io(), wrong_log) catch {};
+    defer {
+        const promoted_slots = std.fmt.allocPrint(alloc, "{s}.promoted-primary-slots", .{standby_progress}) catch null;
+        if (promoted_slots) |path| {
+            std.Io.Dir.cwd().deleteTree(io_impl.io(), path) catch {};
+            alloc.free(path);
+        }
+    }
+
+    var standby: ?antfly.ha.standby.Standby = try antfly.ha.standby.Standby.open(alloc, standby_log.ptr, standby_progress.ptr, .{
+        .cluster_id = 100,
+        .shard_id = 77,
+        .table_id = 7,
+        .timeline_id = 1,
+        .epoch = 1,
+    }, .{});
+    defer if (standby) |*handle| handle.close();
+    if (standby) |*handle| {
+        _ = try handle.promote(.{
+            .new_timeline_id = 2,
+            .new_epoch = 2,
+            .fencing_confirmed = true,
+        });
+    }
+
+    var server = DataServer.initFromLocalMetadataSources(alloc, .{
+        .replica_root_dir = replica_root,
+        .ha = .{
+            .admin_context = .{
+                .standby = if (standby) |*handle| handle else null,
+                .standby_node_id = "standby-a",
+            },
+            .standby_owner = &standby,
+            .standby_replication = .{
+                .upstream_base_uri = "http://primary.internal.test",
+                .slot_name = "standby-a",
+                .standby_log_path = wrong_log,
+                .standby_progress_path = standby_progress,
+            },
+        },
+    }, FakeCatalog.iface(), FakeStatus.iface());
+    defer server.deinit();
+
+    try std.testing.expectError(error.PromotedLogMismatch, server.runHAStandbyReplicationRound());
+    try std.testing.expect(standby != null);
+    try std.testing.expect(server.ha_promoted_primary == null);
+    try std.testing.expect(server.ha_cfg.admin_context.?.standby != null);
+    try std.testing.expect(server.ha_cfg.admin_context.?.primary == null);
+
+    server.ha_cfg.standby_replication.?.standby_log_path = standby_log;
+    try server.runHAStandbyReplicationRound();
+    try std.testing.expect(standby == null);
+    try std.testing.expect(server.ha_promoted_primary != null);
+    try std.testing.expect(server.ha_cfg.admin_context.?.standby == null);
+    try std.testing.expect(server.ha_cfg.admin_context.?.primary != null);
 }
 
 test "data server resumes HA standby replication from durable progress after restart" {

--- a/zig/pkg/antfly/src/data/runtime.zig
+++ b/zig/pkg/antfly/src/data/runtime.zig
@@ -2787,7 +2787,7 @@ pub const DataServer = struct {
 
     fn haReadGate(self: *DataServer) ?antfly.public_api.HAReadGate {
         const ctx = self.ha_cfg.admin_context orelse return null;
-        if (ctx.standby != null) return .{ .shared = &self.ha_public_gate_state };
+        if (ctx.standby != null or ctx.primary != null) return .{ .shared = &self.ha_public_gate_state };
         return null;
     }
 
@@ -16404,6 +16404,14 @@ test "storage.ha data server rejects writes and owner jobs after primary promoti
     defer fence_response.deinit(alloc);
     try std.testing.expectEqual(@as(u16, 200), fence_response.status);
     try std.testing.expectError(error.HAFencedPrimary, source_gate.check());
+    try std.testing.expectError(
+        error.HAReadRequiresPrimary,
+        server.read_source.source().lookup(alloc, "docs", "doc:local", .{}, .stale),
+    );
+    try std.testing.expectError(
+        error.HAReadRequiresPrimary,
+        server.read_source.source().lookup(alloc, "docs", "doc:local", .{}, .read_index),
+    );
 
     try std.testing.expectError(error.HAFencedPrimary, server.write_source.source().batchGroupLocal(alloc, 10, "docs", .{
         .writes = &.{.{ .key = "doc:local", .value = "{\"title\":\"local-write\"}" }},

--- a/zig/pkg/antfly/src/data/runtime.zig
+++ b/zig/pkg/antfly/src/data/runtime.zig
@@ -2732,7 +2732,7 @@ pub const DataServer = struct {
     fn configureHAPublicGateState(self: *DataServer) void {
         const ctx = self.ha_cfg.admin_context orelse return;
         if (ctx.standby) |standby| {
-            self.ha_public_gate_state.configureStandby(standby.currentProgress());
+            self.publishHAStandbyPublicGateState(standby, true);
             return;
         }
         if (ctx.primary) |primary| {
@@ -2743,19 +2743,34 @@ pub const DataServer = struct {
     fn refreshHAPublicGateState(self: *DataServer) void {
         const ctx = self.ha_cfg.admin_context orelse return;
         if (ctx.standby) |standby| {
-            _ = standby.promotedPrimaryHandoff() catch |err| switch (err) {
-                error.StandbyNotPromoted, error.PromotionNotApplied => {
-                    self.ha_public_gate_state.publishStandbyProgress(standby.currentProgress());
-                    return;
-                },
-                else => return,
-            };
-            self.ha_public_gate_state.beginPromotion();
+            self.publishHAStandbyPublicGateState(standby, false);
             return;
         }
         if (ctx.primary != null) {
             self.ha_public_gate_state.publishPrimaryFence(haContextPrimaryIsFenced(ctx));
         }
+    }
+
+    fn publishHAStandbyPublicGateState(
+        self: *DataServer,
+        standby: *antfly.ha.standby.Standby,
+        configure_role: bool,
+    ) void {
+        _ = standby.promotedPrimaryHandoff() catch |err| switch (err) {
+            error.StandbyNotPromoted, error.PromotionNotApplied => {
+                if (configure_role) {
+                    self.ha_public_gate_state.configureStandby(standby.currentProgress());
+                } else {
+                    self.ha_public_gate_state.publishStandbyProgress(standby.currentProgress());
+                }
+                return;
+            },
+            else => {
+                self.ha_public_gate_state.beginPromotion();
+                return;
+            },
+        };
+        self.ha_public_gate_state.beginPromotion();
     }
 
     fn haPublicGateStateChangedCallback(ptr: *anyopaque) void {
@@ -17047,6 +17062,8 @@ test "data server promotion rewires live HTTP internal HA executor" {
 
     const public_read_gate_before = server.read_source.ha_read_gate orelse return error.TestExpectedEqual;
     const public_write_gate_before = server.write_source.ha_write_gate orelse return error.TestExpectedEqual;
+    try std.testing.expectError(error.HAReadRequiresPrimary, public_read_gate_before.check(.stale));
+    try std.testing.expectError(error.HAPromotedStandbyRequiresPrimaryOpen, public_write_gate_before.check());
 
     var before = try server.http_server.?.handle(.{
         .method = .GET,
@@ -17220,6 +17237,12 @@ test "data server promotion open failure preserves retryable standby" {
         },
     }, FakeCatalog.iface(), FakeStatus.iface());
     defer server.deinit();
+    server.initApiServer();
+
+    const public_read_gate = server.read_source.ha_read_gate orelse return error.TestExpectedEqual;
+    const public_write_gate = server.write_source.ha_write_gate orelse return error.TestExpectedEqual;
+    try std.testing.expectError(error.HAReadRequiresPrimary, public_read_gate.check(.stale));
+    try std.testing.expectError(error.HAPromotedStandbyRequiresPrimaryOpen, public_write_gate.check());
 
     try std.testing.expectError(error.PromotedLogMismatch, server.runHAStandbyReplicationRound());
     try std.testing.expect(standby != null);

--- a/zig/pkg/antfly/src/storage/db/db.zig
+++ b/zig/pkg/antfly/src/storage/db/db.zig
@@ -51,6 +51,7 @@ const ha_effects_mod = @import("../ha/effects.zig");
 const ha_commit_gate_mod = @import("../ha/commit_gate.zig");
 const ha_fencing_mod = @import("../ha/fencing.zig");
 const ha_primary_mod = @import("../ha/primary.zig");
+const ha_public_gate_state_mod = @import("../ha/public_gate_state.zig");
 const ha_replication_record_mod = @import("../ha/replication_record.zig");
 const ha_session_mod = @import("../ha/session.zig");
 const ha_standby_mod = @import("../ha/standby.zig");
@@ -444,10 +445,48 @@ fn haSyncPolicyIncludesStandby(policy: ha_primary_mod.SyncPolicy, slot_name: []c
 pub const HAAsyncBatchMirror = HAAsyncEffectMirror;
 pub const HAAsyncMetadataMirror = HAAsyncEffectMirror;
 
+pub const SharedHAWriteGate = struct {
+    state: *const ha_public_gate_state_mod.State,
+    /// Sources track the live role. DB instances pin the generation they opened
+    /// with so a promotion cannot pair old runtime hooks with the new primary.
+    generation: ?u64 = null,
+};
+
 pub const HAWriteGate = union(enum) {
     primary: *ha_primary_mod.Primary,
     fenced_primary: ha_write_gate_mod.FencedPrimary,
     standby: *ha_standby_mod.Standby,
+    shared: SharedHAWriteGate,
+
+    pub fn check(self: HAWriteGate) !void {
+        switch (self) {
+            .shared => |shared| return try shared.state.checkWrite(shared.generation),
+            else => {},
+        }
+
+        const decision = switch (self) {
+            .primary => |primary| try ha_write_gate_mod.evaluatePrimary(primary, .{}),
+            .fenced_primary => |fenced| try ha_write_gate_mod.evaluateFencedPrimary(fenced, .{}),
+            .standby => |standby| try ha_write_gate_mod.evaluateStandby(standby, .{}),
+            .shared => unreachable,
+        };
+        switch (decision.action) {
+            .allow_write => {},
+            .reject_read_only_standby => return error.HAReadOnlyStandby,
+            .open_promoted_primary => return error.HAPromotedStandbyRequiresPrimaryOpen,
+            .reject_fenced_primary => return error.HAFencedPrimary,
+        }
+    }
+
+    pub fn pinned(self: HAWriteGate) HAWriteGate {
+        return switch (self) {
+            .shared => |shared| .{ .shared = .{
+                .state = shared.state,
+                .generation = shared.generation orelse shared.state.currentGeneration(),
+            } },
+            else => self,
+        };
+    }
 };
 
 fn haWriteGateIsStandby(gate: ?HAWriteGate) bool {
@@ -456,6 +495,7 @@ fn haWriteGateIsStandby(gate: ?HAWriteGate) bool {
         .primary => false,
         .fenced_primary => false,
         .standby => true,
+        .shared => |shared| shared.state.isStandbyRole(),
     };
 }
 
@@ -2929,6 +2969,7 @@ pub const DB = struct {
     pub fn open(alloc: Allocator, path: []const u8, opts: OpenOptions) !DB {
         return blk: {
             const open_started_ns = monotonicTimeNs();
+            const ha_write_gate = if (opts.ha_write_gate) |gate| gate.pinned() else null;
             var profile = OpenProfile{};
             const runtime_alloc = backgroundRuntimeAllocator(alloc);
             var owned_async_context: ?*AsyncContext = null;
@@ -3030,7 +3071,7 @@ pub const DB = struct {
                 .lsm_memory => |*lsm_opts| lsm_opts.background_executor = null,
                 .lmdb, .mem => {},
             }
-            const ha_standby_role = haWriteGateIsStandby(opts.ha_write_gate);
+            const ha_standby_role = haWriteGateIsStandby(ha_write_gate);
             const start_index_workers = opts.open_mode.allowsIndexWorkers() and opts.start_index_workers and !ha_standby_role;
 
             var db = DB{
@@ -3059,7 +3100,7 @@ pub const DB = struct {
                 .ha_async_effect_mirror = opts.ha_async_effect_mirror,
                 .ha_async_batch_mirror = opts.ha_async_batch_mirror,
                 .ha_async_metadata_mirror = opts.ha_async_metadata_mirror,
-                .ha_write_gate = opts.ha_write_gate,
+                .ha_write_gate = ha_write_gate,
                 .ttl_cleanup_context = null,
                 .ttl_runtime = null,
                 .transaction_recovery_identity_context = null,
@@ -22745,17 +22786,7 @@ fn encodeChangeRecordPayload(ctx: *const BatchExecutionContext, batch: derived_t
 
 fn enforceHAWriteGateOptional(gate: ?HAWriteGate) !void {
     const configured = gate orelse return;
-    const decision = switch (configured) {
-        .primary => |primary| try ha_write_gate_mod.evaluatePrimary(primary, .{}),
-        .fenced_primary => |fenced| try ha_write_gate_mod.evaluateFencedPrimary(fenced, .{}),
-        .standby => |standby| try ha_write_gate_mod.evaluateStandby(standby, .{}),
-    };
-    switch (decision.action) {
-        .allow_write => return,
-        .reject_read_only_standby => return error.HAReadOnlyStandby,
-        .open_promoted_primary => return error.HAPromotedStandbyRequiresPrimaryOpen,
-        .reject_fenced_primary => return error.HAFencedPrimary,
-    }
+    try configured.check();
 }
 
 fn mirrorHAReplayPayloadBestEffortContext(ctx: *const BatchExecutionContext, payload: []const u8) void {

--- a/zig/pkg/antfly/src/storage/ha/admin.zig
+++ b/zig/pkg/antfly/src/storage/ha/admin.zig
@@ -174,6 +174,14 @@ pub fn evaluateStandbyWrite(
     return try write_gate.evaluateStandby(standby, request);
 }
 
+pub fn evaluatePromotedPrimaryWrite(
+    primary: *const primary_mod.Primary,
+    handoff: standby_mod.PromotionHandoff,
+    request: write_gate.Request,
+) !write_gate.Decision {
+    return try write_gate.evaluatePromotedPrimary(primary, handoff, request);
+}
+
 pub fn evaluatePrimaryOwnerJob(
     primary: *const primary_mod.Primary,
     request: owner_job_gate.Request,
@@ -186,6 +194,14 @@ pub fn evaluateStandbyOwnerJob(
     request: owner_job_gate.Request,
 ) !owner_job_gate.Decision {
     return try owner_job_gate.evaluateStandby(standby, request);
+}
+
+pub fn evaluatePromotedPrimaryOwnerJob(
+    primary: *const primary_mod.Primary,
+    handoff: standby_mod.PromotionHandoff,
+    request: owner_job_gate.Request,
+) !owner_job_gate.Decision {
+    return try owner_job_gate.evaluatePromotedPrimary(primary, handoff, request);
 }
 
 pub fn assessPromotion(

--- a/zig/pkg/antfly/src/storage/ha/admin_exec.zig
+++ b/zig/pkg/antfly/src/storage/ha/admin_exec.zig
@@ -56,6 +56,7 @@ pub const Context = struct {
     primary_node_id: ?[]const u8 = null,
     standby: ?*standby_mod.Standby = null,
     standby_node_id: ?[]const u8 = null,
+    promoted_standby_handoff: ?standby_mod.PromotionHandoff = null,
     fence_store: ?*fencing.Store = null,
     former_primary_log: ?*replication_log.ReplicationLog = null,
     metadata_applied_lsn_ctx: ?*anyopaque = null,
@@ -1089,7 +1090,14 @@ fn executeOperatorPlan(
 fn executeWriteCheck(ctx: Context, command: admin_cli.WriteCheckCommand) !write_gate.Decision {
     return switch (command.role) {
         .primary => try evaluatePrimaryWriteWithContext(ctx, command.request),
-        .standby => try admin.evaluateStandbyWrite(try requireStandby(ctx), command.request),
+        .standby => if (ctx.standby) |standby|
+            try admin.evaluateStandbyWrite(standby, command.request)
+        else
+            try admin.evaluatePromotedPrimaryWrite(
+                try requirePrimary(ctx),
+                ctx.promoted_standby_handoff orelse return error.StandbyUnavailable,
+                command.request,
+            ),
     };
 }
 
@@ -1111,7 +1119,14 @@ fn evaluatePrimaryWriteWithContext(ctx: Context, request: write_gate.Request) !w
 fn executeOwnerJobCheck(ctx: Context, command: admin_cli.OwnerJobCheckCommand) !owner_job_gate.Decision {
     return switch (command.role) {
         .primary => try admin.evaluatePrimaryOwnerJob(try requirePrimary(ctx), command.request),
-        .standby => try admin.evaluateStandbyOwnerJob(try requireStandby(ctx), command.request),
+        .standby => if (ctx.standby) |standby|
+            try admin.evaluateStandbyOwnerJob(standby, command.request)
+        else
+            try admin.evaluatePromotedPrimaryOwnerJob(
+                try requirePrimary(ctx),
+                ctx.promoted_standby_handoff orelse return error.StandbyUnavailable,
+                command.request,
+            ),
     };
 }
 

--- a/zig/pkg/antfly/src/storage/ha/http_admin.zig
+++ b/zig/pkg/antfly/src/storage/ha/http_admin.zig
@@ -20,6 +20,7 @@
 
 const std = @import("std");
 const Allocator = std.mem.Allocator;
+const platform_sync = @import("antfly_platform").sync;
 const admin_api = @import("../../admin/mod.zig");
 const http_common = @import("../../common/http/http_common.zig");
 const ha_admin = @import("admin.zig");
@@ -84,6 +85,7 @@ pub const Server = struct {
     pub const AuthOptions = struct {
         bearer_token: ?[]const u8 = null,
         standby_status_extras: ?StandbyStatusExtras = null,
+        state_mutex: ?*std.atomic.Mutex = null,
     };
 
     pub fn init(alloc: Allocator, ctx: admin_exec.Context) Server {
@@ -116,11 +118,15 @@ pub const Server = struct {
         if (isAdminAuthRequired(path) and !self.authorized(req)) {
             return try textResponse(self.alloc, 401, "unauthorized");
         }
+        if (req.method == .GET and std.mem.eql(u8, path, Routes.health)) {
+            return try textResponse(self.alloc, 200, "ok");
+        }
+        if (self.auth.state_mutex) |mutex| {
+            platform_sync.lockYielding(mutex);
+            defer mutex.unlock();
+        }
         switch (req.method) {
             .GET => {
-                if (std.mem.eql(u8, path, Routes.health)) {
-                    return try textResponse(self.alloc, 200, "ok");
-                }
                 if (std.mem.eql(u8, path, Routes.ready)) {
                     if (self.ready()) return try textResponse(self.alloc, 200, "ready");
                     return try textResponse(self.alloc, 503, "not ready");
@@ -485,8 +491,16 @@ pub const Server = struct {
                 };
             },
             .standby => blk: {
-                const standby = self.ctx.standby orelse return try textResponse(self.alloc, 409, "StandbyUnavailable");
-                break :blk ha_admin.evaluateStandbyWrite(standby, request.request) catch |err| {
+                const evaluated = if (self.ctx.standby) |standby|
+                    ha_admin.evaluateStandbyWrite(standby, request.request)
+                else if (self.ctx.primary) |primary|
+                    if (self.ctx.promoted_standby_handoff) |handoff|
+                        ha_admin.evaluatePromotedPrimaryWrite(primary, handoff, request.request)
+                    else
+                        return try textResponse(self.alloc, 409, "StandbyUnavailable")
+                else
+                    return try textResponse(self.alloc, 409, "StandbyUnavailable");
+                break :blk evaluated catch |err| {
                     return try textResponse(self.alloc, commandErrorStatus(err), @errorName(err));
                 };
             },
@@ -515,8 +529,16 @@ pub const Server = struct {
                 };
             },
             .standby => blk: {
-                const standby = self.ctx.standby orelse return try textResponse(self.alloc, 409, "StandbyUnavailable");
-                break :blk ha_admin.evaluateStandbyOwnerJob(standby, request.request) catch |err| {
+                const evaluated = if (self.ctx.standby) |standby|
+                    ha_admin.evaluateStandbyOwnerJob(standby, request.request)
+                else if (self.ctx.primary) |primary|
+                    if (self.ctx.promoted_standby_handoff) |handoff|
+                        ha_admin.evaluatePromotedPrimaryOwnerJob(primary, handoff, request.request)
+                    else
+                        return try textResponse(self.alloc, 409, "StandbyUnavailable")
+                else
+                    return try textResponse(self.alloc, 409, "StandbyUnavailable");
+                break :blk evaluated catch |err| {
                     return try textResponse(self.alloc, commandErrorStatus(err), @errorName(err));
                 };
             },

--- a/zig/pkg/antfly/src/storage/ha/http_admin.zig
+++ b/zig/pkg/antfly/src/storage/ha/http_admin.zig
@@ -82,10 +82,20 @@ pub const Server = struct {
         }
     };
 
+    pub const StateChangedHook = struct {
+        ptr: *anyopaque,
+        run_fn: *const fn (ptr: *anyopaque) void,
+
+        pub fn run(self: StateChangedHook) void {
+            self.run_fn(self.ptr);
+        }
+    };
+
     pub const AuthOptions = struct {
         bearer_token: ?[]const u8 = null,
         standby_status_extras: ?StandbyStatusExtras = null,
         state_mutex: ?*std.atomic.Mutex = null,
+        state_changed: ?StateChangedHook = null,
     };
 
     pub fn init(alloc: Allocator, ctx: admin_exec.Context) Server {
@@ -125,6 +135,7 @@ pub const Server = struct {
             platform_sync.lockYielding(mutex);
             defer mutex.unlock();
         }
+        defer if (self.auth.state_changed) |hook| hook.run();
         switch (req.method) {
             .GET => {
                 if (std.mem.eql(u8, path, Routes.ready)) {

--- a/zig/pkg/antfly/src/storage/ha/http_internal.zig
+++ b/zig/pkg/antfly/src/storage/ha/http_internal.zig
@@ -20,6 +20,7 @@
 
 const std = @import("std");
 const Allocator = std.mem.Allocator;
+const platform_sync = @import("antfly_platform").sync;
 const http_common = @import("../../common/http/http_common.zig");
 const internal_api = @import("../../internal/mod.zig");
 const primary_mod = @import("primary.zig");
@@ -32,11 +33,21 @@ var test_path_counter: u64 = 0;
 pub const Server = struct {
     alloc: Allocator,
     primary: ?*primary_mod.Primary = null,
+    state_mutex: ?*std.atomic.Mutex = null,
+
+    pub const Options = struct {
+        state_mutex: ?*std.atomic.Mutex = null,
+    };
 
     pub fn init(alloc: Allocator, primary: ?*primary_mod.Primary) Server {
+        return initWithOptions(alloc, primary, .{});
+    }
+
+    pub fn initWithOptions(alloc: Allocator, primary: ?*primary_mod.Primary, options: Options) Server {
         return .{
             .alloc = alloc,
             .primary = primary,
+            .state_mutex = options.state_mutex,
         };
     }
 
@@ -50,6 +61,10 @@ pub const Server = struct {
     }
 
     pub fn handle(self: *Server, req: http_common.HttpRequest) !http_common.HttpResponse {
+        if (self.state_mutex) |mutex| {
+            platform_sync.lockYielding(mutex);
+            defer mutex.unlock();
+        }
         const path = requestPath(req.uri);
         switch (req.method) {
             .GET => {

--- a/zig/pkg/antfly/src/storage/ha/http_replication_client.zig
+++ b/zig/pkg/antfly/src/storage/ha/http_replication_client.zig
@@ -57,6 +57,28 @@ pub const LoopResult = struct {
     next_lsn: u64,
 };
 
+pub const FetchedBatch = struct {
+    alloc: Allocator,
+    identity: standby_mod.Identity,
+    requested_lsn: u64,
+    frames: []VerifiedFrame,
+    current_lsn: u64,
+    last_sent_lsn: u64,
+    next_lsn: u64,
+    end_of_wal: bool,
+
+    pub fn deinit(self: *FetchedBatch) void {
+        freeVerifiedFrames(self.alloc, self.frames);
+        self.* = undefined;
+    }
+};
+
+pub const AppliedBatch = struct {
+    received_count: usize,
+    applied_count: usize,
+    progress: standby_mod.Progress,
+};
+
 pub const Client = struct {
     alloc: Allocator,
     executor: http_common.RequestExecutor,
@@ -139,10 +161,82 @@ pub const Client = struct {
         base_uri: []const u8,
         standby: *const standby_mod.Standby,
     ) !void {
+        return try self.verifyCompatibleUpstreamIdentity(base_uri, standby.identity);
+    }
+
+    pub fn verifyCompatibleUpstreamIdentity(
+        self: *Client,
+        base_uri: []const u8,
+        identity: standby_mod.Identity,
+    ) !void {
         const identified = try self.identifySystem(base_uri);
-        try verifyIdentity(identified.identity, standby.identity);
+        try verifyIdentity(identified.identity, identity);
         const format_version = try positiveUint64FromJson(identified.record_format_version);
         if (format_version != replication_record.format_version) return error.UnsupportedReplicationFormat;
+    }
+
+    pub fn fetchAvailable(
+        self: *Client,
+        base_uri: []const u8,
+        slot_name: []const u8,
+        identity: standby_mod.Identity,
+        requested_lsn: u64,
+        options: ReplicateOptions,
+    ) !FetchedBatch {
+        try validateSlotName(slot_name);
+        if (options.verify_upstream) {
+            try self.verifyCompatibleUpstreamIdentity(base_uri, identity);
+        }
+        var response = try self.startReplication(base_uri, slot_name, requested_lsn, options);
+        defer response.deinit();
+        try verifyStartReplicationResponse(response.parsed.value, slot_name, identity);
+
+        const current_lsn = try uint64FromJson(response.parsed.value.current_lsn);
+        const last_sent_lsn = try uint64FromJson(response.parsed.value.last_sent_lsn);
+        const next_lsn = try positiveUint64FromJson(response.parsed.value.next_lsn);
+        const frames = try decodeAndValidateFrames(
+            self.alloc,
+            response.parsed.value,
+            identity,
+            requested_lsn,
+            current_lsn,
+            last_sent_lsn,
+            next_lsn,
+            response.parsed.value.end_of_wal,
+        );
+
+        return .{
+            .alloc = self.alloc,
+            .identity = identity,
+            .requested_lsn = requested_lsn,
+            .frames = frames,
+            .current_lsn = current_lsn,
+            .last_sent_lsn = last_sent_lsn,
+            .next_lsn = next_lsn,
+            .end_of_wal = response.parsed.value.end_of_wal,
+        };
+    }
+
+    pub fn applyFetched(
+        self: *Client,
+        batch: *const FetchedBatch,
+        standby: *standby_mod.Standby,
+        apply_ctx: *anyopaque,
+        apply_fn: standby_mod.ApplyFn,
+    ) !AppliedBatch {
+        _ = self;
+        if (!std.meta.eql(standby.identity, batch.identity)) return error.HAStandbyStateChanged;
+        if (standby.nextReceiveLsn() != batch.requested_lsn) return error.HAStandbyStateChanged;
+
+        for (batch.frames) |frame| {
+            _ = try standby.receive(frame.record);
+        }
+        const applied_count = try standby.applyAvailable(apply_ctx, apply_fn);
+        return .{
+            .received_count = batch.frames.len,
+            .applied_count = applied_count,
+            .progress = standby.currentProgress(),
+        };
     }
 
     pub fn replicateAvailable(
@@ -154,51 +248,23 @@ pub const Client = struct {
         apply_fn: standby_mod.ApplyFn,
         options: ReplicateOptions,
     ) !Result {
-        try validateSlotName(slot_name);
-        if (options.verify_upstream) {
-            try self.verifyCompatibleUpstream(base_uri, standby);
-        }
         const requested_lsn = standby.nextReceiveLsn();
-        var response = try self.startReplication(base_uri, slot_name, requested_lsn, options);
-        defer response.deinit();
-        try verifyStartReplicationResponse(response.parsed.value, slot_name, standby.identity);
-
-        const current_lsn = try uint64FromJson(response.parsed.value.current_lsn);
-        const last_sent_lsn = try uint64FromJson(response.parsed.value.last_sent_lsn);
-        const next_lsn = try positiveUint64FromJson(response.parsed.value.next_lsn);
-
-        const frames = try decodeAndValidateFrames(
-            self.alloc,
-            response.parsed.value,
-            standby.identity,
-            requested_lsn,
-            current_lsn,
-            last_sent_lsn,
-            next_lsn,
-            response.parsed.value.end_of_wal,
-        );
-        defer freeVerifiedFrames(self.alloc, frames);
-
-        for (frames) |frame| {
-            _ = standby.receive(frame.record) catch |err| {
-                _ = self.updateStandbyStatus(base_uri, slot_name, standby) catch {};
-                return err;
-            };
-        }
-
-        const applied_count = standby.applyAvailable(apply_ctx, apply_fn) catch |err| {
-            try self.updateStandbyStatus(base_uri, slot_name, standby);
+        const identity = standby.identity;
+        var batch = try self.fetchAvailable(base_uri, slot_name, identity, requested_lsn, options);
+        defer batch.deinit();
+        const applied = self.applyFetched(&batch, standby, apply_ctx, apply_fn) catch |err| {
+            _ = self.updateStandbyStatusSnapshot(base_uri, slot_name, standby.identity, standby.currentProgress()) catch {};
             return err;
         };
-        try self.updateStandbyStatus(base_uri, slot_name, standby);
+        try self.updateStandbyStatusSnapshot(base_uri, slot_name, standby.identity, applied.progress);
         return .{
-            .received_count = frames.len,
-            .applied_count = applied_count,
-            .progress = standby.currentProgress(),
-            .current_lsn = current_lsn,
-            .last_sent_lsn = last_sent_lsn,
-            .next_lsn = next_lsn,
-            .end_of_wal = response.parsed.value.end_of_wal,
+            .received_count = applied.received_count,
+            .applied_count = applied.applied_count,
+            .progress = applied.progress,
+            .current_lsn = batch.current_lsn,
+            .last_sent_lsn = batch.last_sent_lsn,
+            .next_lsn = batch.next_lsn,
+            .end_of_wal = batch.end_of_wal,
         };
     }
 
@@ -313,14 +379,14 @@ pub const Client = struct {
         };
     }
 
-    fn updateStandbyStatus(
+    pub fn updateStandbyStatusSnapshot(
         self: *Client,
         base_uri: []const u8,
         slot_name: []const u8,
-        standby: *const standby_mod.Standby,
+        identity: standby_mod.Identity,
+        progress: standby_mod.Progress,
     ) !void {
         try validateSlotName(slot_name);
-        const progress = standby.currentProgress();
         const body = try std.json.Stringify.valueAlloc(
             self.alloc,
             struct {
@@ -331,7 +397,7 @@ pub const Client = struct {
                 safe_read_lsn: u64,
             }{
                 .slot_name = slot_name,
-                .timeline_id = standby.identity.timeline_id,
+                .timeline_id = identity.timeline_id,
                 .received_lsn = progress.received_lsn,
                 .applied_lsn = progress.applied_lsn,
                 .safe_read_lsn = progress.safe_read_lsn,
@@ -361,7 +427,7 @@ pub const Client = struct {
             .{ .ignore_unknown_fields = true },
         );
         defer parsed.deinit();
-        try verifyStandbyStatusUpdateResponse(parsed.value, slot_name, standby.identity, progress);
+        try verifyStandbyStatusUpdateResponse(parsed.value, slot_name, identity, progress);
     }
 
     fn execute(self: *Client, req: http_common.HttpRequest) !OwnedResponse {

--- a/zig/pkg/antfly/src/storage/ha/mod.zig
+++ b/zig/pkg/antfly/src/storage/ha/mod.zig
@@ -27,6 +27,7 @@ pub const rejoin = @import("rejoin.zig");
 pub const commit_gate = @import("commit_gate.zig");
 pub const read_gate = @import("read_gate.zig");
 pub const write_gate = @import("write_gate.zig");
+pub const public_gate_state = @import("public_gate_state.zig");
 pub const owner_job_gate = @import("owner_job_gate.zig");
 pub const admin = @import("admin.zig");
 pub const admin_exec = @import("admin_exec.zig");
@@ -58,6 +59,7 @@ test {
     _ = commit_gate;
     _ = read_gate;
     _ = write_gate;
+    _ = public_gate_state;
     _ = owner_job_gate;
     _ = admin;
     _ = admin_exec;

--- a/zig/pkg/antfly/src/storage/ha/owner_job_gate.zig
+++ b/zig/pkg/antfly/src/storage/ha/owner_job_gate.zig
@@ -108,6 +108,31 @@ pub fn evaluateStandby(standby: *standby_mod.Standby, request: Request) !Decisio
     };
 }
 
+pub fn evaluatePromotedPrimary(
+    primary: *const primary_mod.Primary,
+    handoff: standby_mod.PromotionHandoff,
+    request: Request,
+) !Decision {
+    try validateIdentity(primary.identity, handoff.identity);
+    if (handoff.switch_lsn == 0 or
+        handoff.switch_lsn == std.math.maxInt(u64) or
+        handoff.next_lsn != handoff.switch_lsn + 1)
+    {
+        return error.InvalidPromotionHandoff;
+    }
+    if (primary.lastLsn() < handoff.switch_lsn) return error.PromotedLogMismatch;
+    if (request.expected_identity) |expected| try validateIdentity(handoff.identity, expected);
+    return .{
+        .kind = request.kind,
+        .role = .promoted_standby,
+        .action = .open_promoted_primary,
+        .identity = handoff.identity,
+        .durable_lsn = handoff.switch_lsn,
+        .next_lsn = handoff.next_lsn,
+        .promotion_handoff = handoff,
+    };
+}
+
 fn validateIdentity(actual: standby_mod.Identity, expected: standby_mod.Identity) !void {
     if (actual.cluster_id != expected.cluster_id) return error.WrongCluster;
     if (actual.shard_id != expected.shard_id) return error.WrongShard;
@@ -285,4 +310,14 @@ test "storage.ha owner job gate disables standby jobs until promoted-primary han
     });
     try std.testing.expect(primary_decision.canRun());
     try std.testing.expectEqual(@as(u64, 3), primary_decision.next_lsn);
+
+    const completed_handoff = try evaluatePromotedPrimary(&primary, handoff, .{
+        .kind = .compaction_publish,
+        .expected_identity = promoted_identity,
+    });
+    try std.testing.expect(!completed_handoff.canRun());
+    try std.testing.expectEqual(Role.promoted_standby, completed_handoff.role);
+    try std.testing.expectEqual(Action.open_promoted_primary, completed_handoff.action);
+    try std.testing.expectEqual(handoff.switch_lsn, completed_handoff.durable_lsn);
+    try std.testing.expect(completed_handoff.promotion_handoff != null);
 }

--- a/zig/pkg/antfly/src/storage/ha/public_gate_state.zig
+++ b/zig/pkg/antfly/src/storage/ha/public_gate_state.zig
@@ -1,0 +1,227 @@
+// Copyright 2026 Antfly, Inc.
+//
+// Licensed under the Elastic License 2.0 (ELv2); you may not use this file
+// except in compliance with the Elastic License 2.0. You may obtain a copy of
+// the Elastic License 2.0 at
+//
+//     https://www.antfly.io/licensing/ELv2-license
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Elastic License 2.0 is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+// the Elastic License 2.0 for the specific language governing permissions and
+// limitations.
+
+//! Lock-free public read/write role gates for a live HA data server.
+//!
+//! The mutable standby object remains behind the runtime HA mutex. Public
+//! requests consume only atomically published role/progress state, so promotion
+//! can close the standby without leaving request paths with borrowed pointers.
+
+const std = @import("std");
+const primary_mod = @import("primary.zig");
+const read_gate = @import("read_gate.zig");
+const standby_mod = @import("standby.zig");
+const write_gate = @import("write_gate.zig");
+
+pub const Role = enum(u8) {
+    disabled,
+    standby,
+    transitioning,
+    primary,
+    fenced_primary,
+};
+
+pub const State = struct {
+    role: std.atomic.Value(u8) = .init(@intFromEnum(Role.disabled)),
+    generation: std.atomic.Value(u64) = .init(1),
+    progress_sequence: std.atomic.Value(u64) = .init(0),
+    received_lsn: std.atomic.Value(u64) = .init(0),
+    applied_lsn: std.atomic.Value(u64) = .init(0),
+    safe_read_lsn: std.atomic.Value(u64) = .init(0),
+    primary: ?*const primary_mod.Primary = null,
+
+    pub fn configureStandby(self: *State, progress: standby_mod.Progress) void {
+        self.publishStandbyProgress(progress);
+        self.role.store(@intFromEnum(Role.standby), .release);
+    }
+
+    pub fn configurePrimary(
+        self: *State,
+        primary: *const primary_mod.Primary,
+        fenced: bool,
+    ) void {
+        self.primary = primary;
+        self.publishPrimaryFence(fenced);
+    }
+
+    pub fn publishStandbyProgress(self: *State, progress: standby_mod.Progress) void {
+        _ = self.progress_sequence.fetchAdd(1, .acq_rel);
+        self.received_lsn.store(progress.received_lsn, .monotonic);
+        self.applied_lsn.store(progress.applied_lsn, .monotonic);
+        self.safe_read_lsn.store(progress.safe_read_lsn, .monotonic);
+        _ = self.progress_sequence.fetchAdd(1, .release);
+    }
+
+    pub fn beginPromotion(self: *State) void {
+        self.role.store(@intFromEnum(Role.transitioning), .release);
+    }
+
+    pub fn publishPrimary(
+        self: *State,
+        primary: *const primary_mod.Primary,
+        fenced: bool,
+    ) void {
+        _ = self.generation.fetchAdd(1, .acq_rel);
+        self.configurePrimary(primary, fenced);
+    }
+
+    pub fn publishPrimaryFence(self: *State, fenced: bool) void {
+        if (fenced) {
+            self.role.store(@intFromEnum(Role.fenced_primary), .release);
+            return;
+        }
+
+        var current = self.role.load(.acquire);
+        while (current != @intFromEnum(Role.fenced_primary)) {
+            current = self.role.cmpxchgWeak(
+                current,
+                @intFromEnum(Role.primary),
+                .release,
+                .acquire,
+            ) orelse return;
+        }
+    }
+
+    pub fn currentGeneration(self: *const State) u64 {
+        return self.generation.load(.acquire);
+    }
+
+    pub fn isStandbyRole(self: *const State) bool {
+        return switch (self.currentRole()) {
+            .standby, .transitioning => true,
+            .disabled, .primary, .fenced_primary => false,
+        };
+    }
+
+    pub fn ownerJobsCanRun(self: *const State) bool {
+        return switch (self.currentRole()) {
+            .disabled, .primary => true,
+            .standby, .transitioning, .fenced_primary => false,
+        };
+    }
+
+    pub fn checkRead(self: *const State, request: read_gate.Request) !void {
+        switch (self.currentRole()) {
+            .disabled, .primary, .fenced_primary => return,
+            .transitioning => return error.HAReadRequiresPrimary,
+            .standby => {},
+        }
+
+        const decision = try read_gate.evaluateProgress(self.standbyProgress(), request);
+        switch (decision.action) {
+            .serve_standby => {},
+            .wait_for_apply => return error.HAReadWaitForApply,
+            .wait_for_metadata => return error.HAReadWaitForMetadata,
+            .route_to_primary => return error.HAReadRequiresPrimary,
+        }
+    }
+
+    pub fn checkWrite(self: *const State, expected_generation: ?u64) !void {
+        if (expected_generation) |expected| {
+            if (expected != self.currentGeneration()) {
+                return error.HAPromotedStandbyRequiresPrimaryOpen;
+            }
+        }
+
+        const decision = switch (self.currentRole()) {
+            .disabled => return,
+            .standby => return error.HAReadOnlyStandby,
+            .transitioning => return error.HAPromotedStandbyRequiresPrimaryOpen,
+            .primary => try write_gate.evaluatePrimary(self.primary orelse return error.HAPrimaryNotConfigured, .{}),
+            .fenced_primary => return error.HAFencedPrimary,
+        };
+        switch (decision.action) {
+            .allow_write => {},
+            .reject_read_only_standby => return error.HAReadOnlyStandby,
+            .open_promoted_primary => return error.HAPromotedStandbyRequiresPrimaryOpen,
+            .reject_fenced_primary => return error.HAFencedPrimary,
+        }
+    }
+
+    fn currentRole(self: *const State) Role {
+        return @enumFromInt(self.role.load(.acquire));
+    }
+
+    fn standbyProgress(self: *const State) standby_mod.Progress {
+        while (true) {
+            const before = self.progress_sequence.load(.acquire);
+            if (before & 1 != 0) continue;
+            const progress = standby_mod.Progress{
+                .received_lsn = self.received_lsn.load(.monotonic),
+                .applied_lsn = self.applied_lsn.load(.monotonic),
+                .safe_read_lsn = self.safe_read_lsn.load(.monotonic),
+            };
+            const after = self.progress_sequence.load(.acquire);
+            if (before == after) return progress;
+        }
+    }
+};
+
+test "storage.ha public gate state invalidates pinned standby writes during promotion" {
+    var state = State{};
+    state.configureStandby(.{
+        .received_lsn = 7,
+        .applied_lsn = 6,
+        .safe_read_lsn = 5,
+    });
+
+    const standby_generation = state.currentGeneration();
+    try state.checkRead(.{ .consistency = .stale_ok });
+    try std.testing.expectError(
+        error.HAReadRequiresPrimary,
+        state.checkRead(.{ .consistency = .primary }),
+    );
+    try std.testing.expectError(
+        error.HAReadOnlyStandby,
+        state.checkWrite(standby_generation),
+    );
+
+    state.beginPromotion();
+
+    try std.testing.expectEqual(standby_generation, state.currentGeneration());
+    try std.testing.expectError(
+        error.HAPromotedStandbyRequiresPrimaryOpen,
+        state.checkWrite(standby_generation),
+    );
+    try std.testing.expectError(
+        error.HAReadRequiresPrimary,
+        state.checkRead(.{ .consistency = .stale_ok }),
+    );
+
+    var primary: primary_mod.Primary = undefined;
+    state.publishPrimary(&primary, false);
+
+    try std.testing.expectEqual(standby_generation + 1, state.currentGeneration());
+    try std.testing.expectError(
+        error.HAPromotedStandbyRequiresPrimaryOpen,
+        state.checkWrite(standby_generation),
+    );
+    try state.checkRead(.{ .consistency = .stale_ok });
+
+    state.publishPrimaryFence(true);
+    try std.testing.expectError(error.HAFencedPrimary, state.checkWrite(null));
+    try std.testing.expect(!state.ownerJobsCanRun());
+}
+
+test "storage.ha public gate state never clears an observed primary fence" {
+    var state = State{};
+    var primary: primary_mod.Primary = undefined;
+    state.configurePrimary(&primary, false);
+
+    state.publishPrimaryFence(true);
+    state.publishPrimaryFence(false);
+
+    try std.testing.expectError(error.HAFencedPrimary, state.checkWrite(null));
+    try std.testing.expect(!state.ownerJobsCanRun());
+}

--- a/zig/pkg/antfly/src/storage/ha/public_gate_state.zig
+++ b/zig/pkg/antfly/src/storage/ha/public_gate_state.zig
@@ -113,7 +113,8 @@ pub const State = struct {
 
     pub fn checkRead(self: *const State, request: read_gate.Request) !void {
         switch (self.currentRole()) {
-            .disabled, .primary, .fenced_primary => return,
+            .disabled, .primary => return,
+            .fenced_primary => return error.HAReadRequiresPrimary,
             .transitioning => return error.HAReadRequiresPrimary,
             .standby => {},
         }
@@ -211,6 +212,10 @@ test "storage.ha public gate state invalidates pinned standby writes during prom
 
     state.publishPrimaryFence(true);
     try std.testing.expectError(error.HAFencedPrimary, state.checkWrite(null));
+    try std.testing.expectError(
+        error.HAReadRequiresPrimary,
+        state.checkRead(.{ .consistency = .stale_ok }),
+    );
     try std.testing.expect(!state.ownerJobsCanRun());
 }
 

--- a/zig/pkg/antfly/src/storage/ha/write_gate.zig
+++ b/zig/pkg/antfly/src/storage/ha/write_gate.zig
@@ -132,6 +132,30 @@ pub fn evaluateStandby(standby: *standby_mod.Standby, request: Request) !Decisio
     };
 }
 
+pub fn evaluatePromotedPrimary(
+    primary: *const primary_mod.Primary,
+    handoff: standby_mod.PromotionHandoff,
+    request: Request,
+) !Decision {
+    try validateIdentity(primary.identity, handoff.identity);
+    if (handoff.switch_lsn == 0 or
+        handoff.switch_lsn == std.math.maxInt(u64) or
+        handoff.next_lsn != handoff.switch_lsn + 1)
+    {
+        return error.InvalidPromotionHandoff;
+    }
+    if (primary.lastLsn() < handoff.switch_lsn) return error.PromotedLogMismatch;
+    if (request.expected_identity) |expected| try validateIdentity(handoff.identity, expected);
+    return .{
+        .role = .promoted_standby,
+        .action = .open_promoted_primary,
+        .identity = handoff.identity,
+        .durable_lsn = handoff.switch_lsn,
+        .next_lsn = handoff.next_lsn,
+        .promotion_handoff = handoff,
+    };
+}
+
 fn validateIdentity(actual: standby_mod.Identity, expected: standby_mod.Identity) !void {
     if (actual.cluster_id != expected.cluster_id) return error.WrongCluster;
     if (actual.shard_id != expected.shard_id) return error.WrongShard;
@@ -331,4 +355,11 @@ test "storage.ha write gate rejects standby until promotion handoff is opened" {
     const primary_decision = try evaluatePrimary(&primary, .{ .expected_identity = promoted_identity });
     try std.testing.expect(primary_decision.canWrite());
     try std.testing.expectEqual(@as(u64, 3), primary_decision.next_lsn);
+
+    const completed_handoff = try evaluatePromotedPrimary(&primary, handoff, .{ .expected_identity = promoted_identity });
+    try std.testing.expect(!completed_handoff.canWrite());
+    try std.testing.expectEqual(Role.promoted_standby, completed_handoff.role);
+    try std.testing.expectEqual(Action.open_promoted_primary, completed_handoff.action);
+    try std.testing.expectEqual(handoff.switch_lsn, completed_handoff.durable_lsn);
+    try std.testing.expect(completed_handoff.promotion_handoff != null);
 }

--- a/zig/pkg/antfly/src/storage/wal.zig
+++ b/zig/pkg/antfly/src/storage/wal.zig
@@ -193,6 +193,16 @@ const StoreOwner = union(enum) {
         }
     }
 
+    fn syncCommitDurability(self: *StoreOwner) !void {
+        switch (self.*) {
+            .lmdb => |backend| try backend.sync(true),
+            // The LSM transaction has already appended and fsynced its replay
+            // WAL. Sync that durable boundary without forcing an unrelated
+            // memtable flush and compaction build on every outer WAL append.
+            .lsm => |*handle| try handle.backend.syncReplayState(),
+        }
+    }
+
     fn commitStatsSnapshot(self: *StoreOwner) ?lmdb.CommitStats {
         return switch (self.*) {
             .lmdb => |backend| backend.commitStatsSnapshot(),
@@ -876,7 +886,7 @@ pub const WAL = struct {
         };
         self.next_lsn = lsn;
         if (self.sync_after_commit) {
-            self.store_owner.sync(true) catch |err| {
+            self.store_owner.syncCommitDurability() catch |err| {
                 stats.commit_ns = self.elapsedSince(commit_started);
                 return .{
                     .result = .{ .failure = err },


### PR DESCRIPTION
## Summary

- make HA promotion handoff safe for concurrent public reads and writes without adding a mutex to the public request path
- keep HA admin/internal mutation serialized while moving upstream fetch, decode, acknowledgement, and catch-up loops outside the HA state mutex
- retain the LSM replay-WAL durability fix from the original investigation

## Root cause

The flaky `test_standby_streams_public_writes_restarts_and_rejects_writes` failure was a real set of HA ownership races exposed by timing, rather than a behavior introduced by [PR #342](https://github.com/antflydb/antfly/pull/342).

The unified HTTP server runs HA handlers on worker threads while `DataServer.runRound()` performs standby replication and promotion handoff on the main swarm thread. The original fix serialized those paths, which addressed the observed use-after-close in `Standby.persistProgress()` and the matching primary slot-store race.

Review then identified two remaining problems:

1. Public read/write gates still held raw standby pointers. A request or cached DB could retain the old gate while promotion closed the standby.
2. The HA mutex covered the entire replication round, including upstream network I/O and unbounded catch-up loops, delaying admin and internal HA requests.

Stress testing the follow-up also exposed a fail-open publication edge: a later HA control-plane refresh could overwrite an already observed `fenced_primary` role with `primary`.

## Fix

- add a stable, shared public HA gate state with atomically published role, generation, and standby progress
- keep public write checks lock-free: they perform atomic role/generation reads and the existing primary check, with no `ha_state_mutex` acquisition
- pin each opened DB to the HA generation it opened under, so pre-promotion DBs fail closed and reopen with the promoted-primary mirror
- publish `transitioning` before consuming/closing the standby, then publish the new primary generation only after mirrors are rewired
- make observed primary fencing monotonic for the process so later control-plane refreshes cannot re-enable a fenced former primary
- split replication into fetch/decode, bounded local apply, and status acknowledgement phases
- perform upstream network I/O and catch-up iteration outside the mutex; retain the mutex only for short state snapshots, promotion, and bounded local apply batches
- cap a default apply batch at 256 records or 4 MiB when callers request an unbounded round
- discard an old-timeline fetch with `HAStandbyStateChanged` if promotion or progress changes while network I/O is in flight
- keep `/ha/v1/health` outside the state lock
- keep the outer-WAL LSM replay durability sync, without forcing an unrelated memtable flush/compaction on every append

## TDD regressions

- a promotion test captures public gates before handoff and invokes those same gates after the standby is closed
- a blocking replication executor proves the HA mutex remains available during upstream I/O, promotes while the response is in flight, and verifies the stale response is rejected
- a public gate test proves an observed primary fence cannot be cleared by a later stale refresh
- a runtime test acquires a real fence through the live admin route and verifies the existing public write gate and owner jobs fail closed

## Validation

- `zig build -fincremental lib-data-runtime-test --summary all` (49 passed)
- `zig build -fincremental ha-test --summary all` (279 passed)
- `zig build -fincremental wal-test --summary all` (465 passed, 1 skipped)
- `zig build -fincremental -Dedition=full install --summary all` (12/12 steps)
- formerly flaky standby E2E passed 20 consecutive full process-level runs

Original failing job: https://github.com/antflydb/antfly/actions/runs/29124763525/job/86467969106?pr=342
