### PR TITLE
Fix heap corruption and deterministic CI failures behind the full e2e gate

### DIFF
--- a/zig/e2e/antfly/conftest.py
+++ b/zig/e2e/antfly/conftest.py
@@ -128,7 +128,7 @@ def find_free_port() -> int:
 
 def wait_for_server(
     url: str,
-    timeout: float = 30.0,
+    timeout: float = float(os.environ.get("ANTFLY_E2E_SERVER_START_TIMEOUT_S", "30.0")),
     path: str = "/status",
     *,
     allow_unauthorized: bool = False,

--- a/zig/e2e/antfly/test_stress_corruption.py
+++ b/zig/e2e/antfly/test_stress_corruption.py
@@ -1,0 +1,111 @@
+# Copyright 2026 Antfly, Inc.
+#
+# Licensed under the Elastic License 2.0 (ELv2); you may not use this file
+# except in compliance with the Elastic License 2.0. You may obtain a copy of
+# the Elastic License 2.0 at
+#
+#     https://www.antfly.io/licensing/ELv2-license
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the Elastic License 2.0 is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# Elastic License 2.0 for the specific language governing permissions and
+# limitations.
+
+"""Heap-corruption regression stress for the managed chunked-semantic flow.
+
+Repeats the create/index/write/scan/search/backup/delete cycle against a
+single swarm server. This loop reproduced the request-allocator identity
+corruption (search hits adopting index-owned metadata buffers freed through
+a different allocator) within one to three iterations; a crashed server
+surfaces as a connection error on the next request.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import time
+
+import pytest
+
+from helpers import wait_until
+from test_backup_restore import _chunked_doc, _semantic_top_hit
+
+pytestmark = pytest.mark.slow
+
+
+def test_stress_chunked_semantic_corruption(backup_api, openai_embedder):
+    for i in range(30):
+        table_name = f"stress_chunked_{i}_{time.time_ns()}"
+        backup_id = f"stress-backup-{i}-{time.time_ns()}"
+
+        created = backup_api.create_table(table_name, num_shards=1, description="stress")
+        assert created["name"] == table_name
+
+        assert (
+            backup_api.create_index(
+                table_name,
+                "semantic_chunked_idx",
+                {
+                    "name": "semantic_chunked_idx",
+                    "type": "embeddings",
+                    "field": "content",
+                    "dimension": 3,
+                    "embedder": {
+                        "provider": "openai",
+                        "model": "text-embedding-3-small",
+                        "url": openai_embedder,
+                    },
+                    "chunker": {
+                        "provider": "antfly",
+                        "model": "fixed-bert-tokenizer",
+                        "store_chunks": True,
+                        "text": {
+                            "target_tokens": 4,
+                            "overlap_tokens": 1,
+                            "separator": " ",
+                        },
+                    },
+                },
+            )
+            == {}
+        )
+
+        backup_api.wait_index_ready(table_name, "semantic_chunked_idx", timeout_s=30.0, interval_s=0.5)
+
+        batch = backup_api.batch_write(
+            table_name,
+            inserts={
+                "doc:a": {
+                    "title": "Alpha backup",
+                    "content": "alpha body alpha body alpha body alpha body alpha tail",
+                },
+                "doc:b": {
+                    "title": "Beta backup",
+                    "content": "beta body beta body beta body beta tail",
+                },
+            },
+            sync_level="full_index",
+        )
+        assert batch["inserted"] == 2, f"iteration {i}"
+
+        before_scan = wait_until(
+            lambda: _chunked_doc(backup_api, table_name, "doc:a", "semantic_chunked_idx_chunks"),
+            timeout_s=60.0,
+            interval_s=0.5,
+        )
+        assert before_scan is not None, f"iteration {i}"
+
+        assert wait_until(
+            lambda: _semantic_top_hit(backup_api, table_name, "alpha concept", "semantic_chunked_idx", "doc:a"),
+            timeout_s=60.0,
+            interval_s=0.5,
+        ), f"iteration {i}"
+
+        with tempfile.TemporaryDirectory(prefix="antfly-stress-backup-") as backup_dir:
+            location = f"file://{backup_dir}"
+            backup = backup_api.backup_table(table_name, backup_id=backup_id, location=location)
+            assert backup["backup"] == "successful", f"iteration {i}"
+
+            deleted = backup_api.delete_table(table_name)
+            assert deleted == {}, f"iteration {i}"

--- a/zig/pkg/antfly/src/api/http_server.zig
+++ b/zig/pkg/antfly/src/api/http_server.zig
@@ -1430,7 +1430,13 @@ pub const ApiHttpServer = struct {
         else
             items.items.len == 0 or !read_statuses_present or read_needs_refresh;
         if (should_query_writes and self.table_writes != null) {
-            if (try self.table_writes.?.localRuntimeStatuses(self.alloc, table_name)) |statuses| {
+            // Local write-source statuses are a best-effort refresh: a shard
+            // that is not hosted locally must not fail the status request.
+            const write_statuses = self.table_writes.?.localRuntimeStatuses(self.alloc, table_name) catch |err| blk: {
+                std.log.warn("index status local write-source runtime statuses unavailable table={s} err={s}", .{ table_name, @errorName(err) });
+                break :blk null;
+            };
+            if (write_statuses) |statuses| {
                 var owned = statuses;
                 errdefer owned.deinit(self.alloc);
                 try self.appendLocalRuntimeStatuses(table_name, snapshot, &items, &owned, if (read_needs_refresh) .replace_existing else .append);
@@ -22240,7 +22246,7 @@ test "api index status uses propagated remote store runtime status" {
     defer resp.deinit(alloc);
     try std.testing.expectEqual(@as(u16, 200), resp.status);
     try std.testing.expectEqual(@as(u32, 1), reads.status_calls.load(.monotonic));
-    try std.testing.expectEqual(@as(u32, 0), writes.status_calls.load(.monotonic));
+    try std.testing.expectEqual(@as(u32, 1), writes.status_calls.load(.monotonic));
     var parsed = try std.json.parseFromSlice(Response, alloc, resp.body, .{ .ignore_unknown_fields = true });
     defer parsed.deinit();
     try std.testing.expectEqual(@as(?u64, 12), parsed.value.status.doc_count);
@@ -22470,7 +22476,7 @@ test "api index status ignores propagated runtime status from removed owner" {
     });
     defer resp.deinit(alloc);
     try std.testing.expectEqual(@as(u16, 200), resp.status);
-    try std.testing.expectEqual(@as(u32, 0), writes.status_calls.load(.monotonic));
+    try std.testing.expectEqual(@as(u32, 1), writes.status_calls.load(.monotonic));
     var parsed = try std.json.parseFromSlice(Response, alloc, resp.body, .{ .ignore_unknown_fields = true });
     defer parsed.deinit();
     try std.testing.expectEqual(@as(?u64, null), parsed.value.status.doc_count);
@@ -22610,7 +22616,7 @@ test "api index status reports missing remote shard as not ready" {
     });
     defer resp.deinit(alloc);
     try std.testing.expectEqual(@as(u16, 200), resp.status);
-    try std.testing.expectEqual(@as(u32, 0), writes.status_calls.load(.monotonic));
+    try std.testing.expectEqual(@as(u32, 1), writes.status_calls.load(.monotonic));
     var parsed = try std.json.parseFromSlice(Response, alloc, resp.body, .{ .ignore_unknown_fields = true });
     defer parsed.deinit();
     if (parsed.value.status.rebuilding) |rebuilding| try std.testing.expect(rebuilding);

--- a/zig/pkg/antfly/src/data/runtime.zig
+++ b/zig/pkg/antfly/src/data/runtime.zig
@@ -2423,9 +2423,13 @@ pub const DataServer = struct {
             _ = apply_sm.write_source.withEntitySink(entity_sink);
         }
         self.syncInferenceRuntimeConfig();
+        // Request allocations must share identity with the process allocator
+        // used by DB internals (c_allocator when libc is linked): search hits
+        // adopt index-owned metadata buffers, so a distinct request allocator
+        // identity turns those adoptions into cross-allocator frees.
         self.http_server = antfly.public_api.ApiHttpServer.initWithRequestAllocator(
             self.alloc,
-            std.heap.smp_allocator,
+            platform.allocator.processAllocator(std.heap.smp_allocator),
             api_server_cfg,
             self.status_source,
             self.read_source.source(),

--- a/zig/pkg/antfly/src/graph/graph.zig
+++ b/zig/pkg/antfly/src/graph/graph.zig
@@ -1772,9 +1772,13 @@ test "graph reverse backend adapters expose txn cursor and batch operations" {
         var txn = try graph.beginWriteReverseTxn();
         errdefer txn.abort();
         try txn.put("k1", "v1");
-        var cur = try txn.openCursor();
-        defer cur.close();
-        try std.testing.expectEqualStrings("k1", (try cur.start(.{})).?.key);
+        {
+            // Cursors must close before commit: committing with an open
+            // cursor fails closed with error.TransactionCursorActive.
+            var cur = try txn.openCursor();
+            defer cur.close();
+            try std.testing.expectEqualStrings("k1", (try cur.start(.{})).?.key);
+        }
         try txn.commit();
     }
 

--- a/zig/pkg/antfly/src/metadata/server.zig
+++ b/zig/pkg/antfly/src/metadata/server.zig
@@ -13,6 +13,7 @@
 // limitations.
 
 const std = @import("std");
+const platform = @import("antfly_platform");
 const metadata_mod = @import("mod.zig");
 const service = @import("service.zig");
 const transition_state = @import("transition_state.zig");
@@ -120,7 +121,13 @@ pub const MetadataServer = struct {
         };
 
         if (cfg.admin_listener) |listener_cfg| {
-            const request_alloc = std.heap.smp_allocator;
+            // The request allocator must share identity with the process
+            // allocator used by DB internals (c_allocator when libc is
+            // linked): request-scoped results adopt buffers allocated by
+            // DB-owned components (index metadata, table record clones), so a
+            // distinct allocator identity here turns those adoptions into
+            // cross-allocator frees that corrupt the heap.
+            const request_alloc = platform.allocator.processAllocator(std.heap.smp_allocator);
             const admin_http_server = try alloc.create(metadata_http_server.MetadataHttpServer);
             admin_http_server.* = metadata_http_server.MetadataHttpServer.init(
                 alloc,

--- a/zig/pkg/antfly/src/sparse/sparse.zig
+++ b/zig/pkg/antfly/src/sparse/sparse.zig
@@ -4913,9 +4913,13 @@ test "sparse backend adapters expose txn cursor operations" {
         errdefer txn.abort();
         const encoded = std.mem.toBytes(@as(u64, 7));
         try txn.put("meta:next_doc_num", &encoded);
-        var cur = try txn.openCursor();
-        defer cur.close();
-        try std.testing.expectEqualStrings("meta:next_doc_num", (try cur.first()).?.key);
+        {
+            // Cursors must close before commit: committing with an open
+            // cursor fails closed with error.TransactionCursorActive.
+            var cur = try txn.openCursor();
+            defer cur.close();
+            try std.testing.expectEqualStrings("meta:next_doc_num", (try cur.first()).?.key);
+        }
         try txn.commit();
     }
 

--- a/zig/pkg/antfly/src/storage/db/db.zig
+++ b/zig/pkg/antfly/src/storage/db/db.zig
@@ -62648,6 +62648,11 @@ test "db restore snapshot repeatedly validates run-backed doc identity metadata"
             },
         );
         _ = try staged_generation.publish();
+        // Release the staged generation and the exclusive transition before
+        // reopening the live path: published-generation reads fail closed with
+        // GenerationTransitionActive while an exclusive transition is active.
+        staged_generation.deinit();
+        transition.deinit();
 
         var restored = try DB.open(alloc, std.mem.span(restore_path), .{
             .primary_backend = primary_backend,

--- a/zig/pkg/antfly/src/storage/db/generation_lifecycle.zig
+++ b/zig/pkg/antfly/src/storage/db/generation_lifecycle.zig
@@ -569,7 +569,9 @@ fn hasPublicationMarker(alloc: Allocator, io: std.Io, root: []const u8) !bool {
     const marker_path = try publicationMarkerPathAlloc(alloc, root);
     defer alloc.free(marker_path);
     const marker = std.Io.Dir.cwd().readFileAlloc(io, marker_path, alloc, .limited(publication_marker_data.len + 1)) catch |err| switch (err) {
-        error.FileNotFound => return false,
+        // NotDir: the live root is a file (e.g. an Antfly Lite *.aflite
+        // database), so a marker can never exist beneath it.
+        error.FileNotFound, error.NotDir => return false,
         else => return err,
     };
     defer alloc.free(marker);
@@ -581,7 +583,7 @@ fn clearPublicationMarker(alloc: Allocator, io: std.Io, root: []const u8) bool {
     const marker_path = publicationMarkerPathAlloc(alloc, root) catch return false;
     defer alloc.free(marker_path);
     std.Io.Dir.cwd().deleteFile(io, marker_path) catch |err| switch (err) {
-        error.FileNotFound => return true,
+        error.FileNotFound, error.NotDir => return true,
         else => {
             std.log.warn("generation publication marker cleanup deferred path={s} err={s}", .{ marker_path, @errorName(err) });
             return false;

--- a/zig/pkg/antfly/src/storage/wal.zig
+++ b/zig/pkg/antfly/src/storage/wal.zig
@@ -3828,9 +3828,13 @@ test "wal backend adapters expose txn cursor operations" {
         errdefer txn.abort();
         var write = txn.writeAdapter();
         try write.put(&key, "value");
-        var cur = try write.openCursor();
-        defer cur.close();
-        try std.testing.expectEqualStrings(&key, (try cur.start(.{})).?.key);
+        {
+            // Cursors must close before commit: committing with an open
+            // cursor fails closed with error.TransactionCursorActive.
+            var cur = try write.openCursor();
+            defer cur.close();
+            try std.testing.expectEqualStrings(&key, (try cur.start(.{})).?.key);
+        }
         try write.commit();
     }
 


### PR DESCRIPTION
## Summary

Fixes the flaky e2e crashes and the deterministic zig-base failures keeping #335 red. `origin/main` is already fully merged (the branch tip merge is up to date with `main`).

### Heap corruption (the flaky e2e crashes)

The `e2e-base` failures (`Remote end closed connection without response`, server SIGABRT with `munmap_chunk(): invalid pointer` / `corrupted size vs. prev_size`) were heap corruption from a request-allocator identity split: the threaded HTTP request-allocator hardening pointed the swarm/metadata public API servers at `std.heap.smp_allocator`, while DB internals allocate through `platform.allocator.processAllocator` (c_allocator on libc). Request-scoped results adopt DB-owned buffers — dense search hits take index metadata as `hit.id` (`hbc getMetadata` / `SearchResults.takeMetadata` / `lookup_doc_key`), handlers clone table records — so the distinct identity turned those adoptions into cross-allocator frees: smp's size-class freelist got threaded through glibc heap chunks and every recycle sprayed `0xAA` over live chunk headers.

Fix: wrap both request allocators in `platform.allocator.processAllocator(std.heap.smp_allocator)`, matching the existing `runtimeAllocator` pattern in `main.zig` — thread-safe in all build modes, one allocator identity per process on libc builds.

Verification: a 30-iteration create/index/write/scan/search/backup/delete stress loop reproduced the crash within 1–3 iterations before the change (while `origin/main` ran clean); after it, 150/150 stress iterations and 3/3 runs of `test_table_backup_restore_round_trip_managed_chunked_semantic` pass. The stress loop is committed as a slow-marked regression test (runs with the full gate, deselected from `e2e-base`).

### Deterministic zig-base fixes

- `db restore snapshot repeatedly validates run-backed doc identity metadata` held its exclusive generation transition (and staged generation) across `DB.open` of the published live path, which the hardened lifecycle correctly rejects with `GenerationTransitionActive`; the test now releases both after publish, matching the production restore sequence.
- Lite `NotDir` failures (storage.lite, cmd.lite, cmd.cli.backup): `hasPublicationMarker`/`clearPublicationMarker` now treat `error.NotDir` like `FileNotFound` so `DB.open` works for file-backed roots (*.aflite).
- sparse/graph/wal adapter tests committed with an open cursor, which the new fail-closed ParentBox transaction contract rejects with `TransactionCursorActive`; the tests close cursors before commit.
- Index-status GETs 500'd when the widened write-source fallback hit a shard that is not hosted locally; local write-source runtime status errors are now best-effort (log and continue), and the three index-status tests expect the widened fallback.
- e2e conftest: server readiness timeout overridable via `ANTFLY_E2E_SERVER_START_TIMEOUT_S` (default unchanged) for running the suite under heavy instrumentation.

## Validation

- Stress regression 5×30 iterations + original failing e2e test 3× — all pass (pre-fix: crash every run)
- `zig build lib-db-test` (doc-identity restore test), `sparse-test` 411 pass/1 skip, `wal-test` 469 pass/1 skip, graph adapter test via `root-test` filter, `lite-native-test` 110/110, `lite-cli-test` 49/49, `public-api-parity-test` 63/63
- `pytest --collect-only -m "not … and not slow"` confirms the new stress test is deselected from `e2e-base`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GinKmScCQwfcvXTUvQDa4k

---
_Generated by [Claude Code](https://claude.ai/code/session_01GinKmScCQwfcvXTUvQDa4k)_