### PR TITLE
ci: publish documentation to Cloudflare R2

### DIFF
--- a/.github/workflows/publish-docs-r2.yml
+++ b/.github/workflows/publish-docs-r2.yml
@@ -1,0 +1,111 @@
+name: Publish Docs to Cloudflare R2
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - 'scripts/docs/build-r2-manifest.mjs'
+      - '.github/workflows/publish-docs-r2.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+# Serialize publications so --delete and the current pointer cannot race.
+concurrency:
+  group: antfly-docs-r2-production
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: docs-r2
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Validate R2 configuration
+        env:
+          R2_BUCKET_NAME: ${{ vars.R2_BUCKET_NAME }}
+          R2_ENDPOINT: ${{ vars.R2_ENDPOINT }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -n "$R2_BUCKET_NAME"
+          test -n "$R2_ACCESS_KEY_ID"
+          test -n "$R2_SECRET_ACCESS_KEY"
+          [[ "$R2_BUCKET_NAME" =~ ^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$ ]]
+          [[ "$R2_ENDPOINT" =~ ^https://[a-zA-Z0-9.-]+\.r2\.cloudflarestorage\.com/?$ ]]
+
+      - name: Build publication manifests
+        run: |
+          node scripts/docs/build-r2-manifest.mjs \
+            --source docs \
+            --output "$RUNNER_TEMP/r2-publication" \
+            --repository "$GITHUB_REPOSITORY" \
+            --commit "$GITHUB_SHA"
+
+      - name: Publish documentation
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          AWS_REGION: auto
+          AWS_DEFAULT_REGION: auto
+          R2_BUCKET_NAME: ${{ vars.R2_BUCKET_NAME }}
+          R2_ENDPOINT: ${{ vars.R2_ENDPOINT }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          endpoint="${R2_ENDPOINT%/}"
+          release_prefix="docs/releases/$GITHUB_SHA"
+
+          aws s3 sync docs "s3://$R2_BUCKET_NAME/$release_prefix/" \
+            --endpoint-url "$endpoint" \
+            --no-progress \
+            --only-show-errors
+
+          aws s3 cp "$RUNNER_TEMP/r2-publication/manifest.json" \
+            "s3://$R2_BUCKET_NAME/docs/manifests/$GITHUB_SHA.json" \
+            --endpoint-url "$endpoint" \
+            --content-type application/json \
+            --no-progress \
+            --only-show-errors
+
+          aws s3 sync docs "s3://$R2_BUCKET_NAME/docs/current/" \
+            --endpoint-url "$endpoint" \
+            --delete \
+            --no-progress \
+            --only-show-errors
+
+          aws s3 cp "$RUNNER_TEMP/r2-publication/current.json" \
+            "s3://$R2_BUCKET_NAME/docs/current.json" \
+            --endpoint-url "$endpoint" \
+            --content-type application/json \
+            --cache-control no-cache \
+            --no-progress \
+            --only-show-errors
+
+      - name: Verify publication pointer
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          AWS_REGION: auto
+          AWS_DEFAULT_REGION: auto
+          R2_BUCKET_NAME: ${{ vars.R2_BUCKET_NAME }}
+          R2_ENDPOINT: ${{ vars.R2_ENDPOINT }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          aws s3 cp "s3://$R2_BUCKET_NAME/docs/current.json" \
+            "$RUNNER_TEMP/current.remote.json" \
+            --endpoint-url "${R2_ENDPOINT%/}" \
+            --no-progress \
+            --only-show-errors
+          cmp "$RUNNER_TEMP/r2-publication/current.json" "$RUNNER_TEMP/current.remote.json"

--- a/scripts/docs/build-r2-manifest.mjs
+++ b/scripts/docs/build-r2-manifest.mjs
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+
+import { createHash } from 'node:crypto';
+import { mkdir, readFile, readdir, stat, writeFile } from 'node:fs/promises';
+import { extname, join, relative, resolve, sep } from 'node:path';
+
+const MIME_TYPES = new Map([
+  ['.css', 'text/css'],
+  ['.gif', 'image/gif'],
+  ['.html', 'text/html'],
+  ['.jpeg', 'image/jpeg'],
+  ['.jpg', 'image/jpeg'],
+  ['.js', 'text/javascript'],
+  ['.json', 'application/json'],
+  ['.md', 'text/markdown'],
+  ['.mdx', 'text/markdown'],
+  ['.pdf', 'application/pdf'],
+  ['.png', 'image/png'],
+  ['.svg', 'image/svg+xml'],
+  ['.webp', 'image/webp'],
+  ['.yaml', 'application/yaml'],
+  ['.yml', 'application/yaml'],
+]);
+
+function usage() {
+  return 'usage: build-r2-manifest.mjs --source DIR --output DIR --repository OWNER/REPO --commit SHA';
+}
+
+function parseArgs(argv) {
+  const values = new Map();
+  for (let index = 0; index < argv.length; index += 2) {
+    const name = argv[index];
+    const value = argv[index + 1];
+    if (!name?.startsWith('--') || !value) throw new Error(usage());
+    values.set(name.slice(2), value);
+  }
+
+  for (const required of ['source', 'output', 'repository', 'commit']) {
+    if (!values.get(required)) throw new Error(`missing --${required}\n${usage()}`);
+  }
+  if (!/^[0-9a-f]{40}$/i.test(values.get('commit'))) {
+    throw new Error('--commit must be a 40-character Git commit SHA');
+  }
+  return values;
+}
+
+async function walk(root, directory = root) {
+  const entries = await readdir(directory, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) files.push(...(await walk(root, path)));
+    else if (entry.isFile()) files.push(path);
+  }
+  return files;
+}
+
+function portablePath(root, path) {
+  return relative(root, path).split(sep).join('/');
+}
+
+const args = parseArgs(process.argv.slice(2));
+const source = resolve(args.get('source'));
+const output = resolve(args.get('output'));
+const repository = args.get('repository');
+const commit = args.get('commit').toLowerCase();
+const sourceInfo = await stat(source);
+if (!sourceInfo.isDirectory()) throw new Error(`source is not a directory: ${source}`);
+
+const paths = (await walk(source)).sort((left, right) =>
+  portablePath(source, left).localeCompare(portablePath(source, right), 'en')
+);
+const files = [];
+for (const path of paths) {
+  const content = await readFile(path);
+  const relativePath = portablePath(source, path);
+  files.push({
+    path: relativePath,
+    key: `docs/releases/${commit}/${relativePath}`,
+    content_type: MIME_TYPES.get(extname(relativePath).toLowerCase()) ?? 'application/octet-stream',
+    size: content.byteLength,
+    sha256: createHash('sha256').update(content).digest('hex'),
+  });
+}
+
+const manifestKey = `docs/manifests/${commit}.json`;
+const manifest = {
+  schema_version: 1,
+  source_repository: repository,
+  source_commit: commit,
+  source_url: `https://github.com/${repository}/tree/${commit}/docs`,
+  object_prefix: `docs/releases/${commit}/`,
+  file_count: files.length,
+  files,
+};
+const current = {
+  schema_version: 1,
+  source_repository: repository,
+  source_commit: commit,
+  manifest_key: manifestKey,
+  object_prefix: manifest.object_prefix,
+};
+
+await mkdir(output, { recursive: true });
+await writeFile(join(output, 'manifest.json'), `${JSON.stringify(manifest, null, 2)}\n`);
+await writeFile(join(output, 'current.json'), `${JSON.stringify(current, null, 2)}\n`);


### PR DESCRIPTION
## Summary
- publish docs to immutable commit-addressed R2 release prefixes
- maintain a synchronized `docs/current/` prefix and `docs/current.json` pointer
- generate SHA-256 publication manifests and verify the uploaded pointer
- use the protected `docs-r2` GitHub environment for R2 configuration

## Required environment configuration

Variables:
- `R2_BUCKET_NAME`
- `R2_ENDPOINT`

Secrets:
- `R2_ACCESS_KEY_ID`
- `R2_SECRET_ACCESS_KEY`

## Validation
- generated and cross-checked a manifest for all 25 files in `docs/`
- `git diff --check`

Merging this PR triggers the initial upload because the workflow watches changes to its own file.