### PR TITLE
[pdfs] Preserve remote PDF MIME across large downloads

### DIFF
--- a/zig/lib/scraping/src/mod.zig
+++ b/zig/lib/scraping/src/mod.zig
@@ -357,6 +357,8 @@ fn downloadHttpOutcomeAlloc(
         trimMimeParameters(value)
     else
         "application/octet-stream";
+    const owned_mime = try alloc.dupe(u8, mime);
+    errdefer alloc.free(owned_mime);
 
     const max_size: usize = if (security) |cfg|
         @intCast(cfg.max_download_size_bytes orelse (100 * 1024 * 1024))
@@ -368,7 +370,7 @@ fn downloadHttpOutcomeAlloc(
     errdefer alloc.free(body);
 
     return .{ .ok = .{
-        .content_type = try alloc.dupe(u8, mime),
+        .content_type = owned_mime,
         .data = body,
     } };
 }

--- a/zig/pkg/antfly/src/template_remote.zig
+++ b/zig/pkg/antfly/src/template_remote.zig
@@ -539,7 +539,7 @@ test "template remote applies remote content security to http urls" {
     try std.testing.expectEqual(@as(?u64, default_remote_fetch_max_download_size_bytes), resolved.security.max_download_size_bytes);
 }
 
-test "template remote renders remotePDF extract with injected pdf backend" {
+test "template remote preserves PDF content type across a multi-megabyte download" {
     const alloc = std.testing.allocator;
 
     const FakePdfBackend = struct {
@@ -572,10 +572,12 @@ test "template remote renders remotePDF extract with injected pdf backend" {
         fn execute(_: *anyopaque, req_alloc: Allocator, req: @import("raft/transport/http_common.zig").HttpRequest) !@import("raft/transport/http_common.zig").HttpResponse {
             try std.testing.expectEqual(@import("raft/transport/http_common.zig").Method.GET, req.method);
             if (std.mem.endsWith(u8, req.uri, "/doc.pdf")) {
+                const body = try req_alloc.alloc(u8, 3_062_180);
+                @memset(body, 'x');
                 return .{
                     .status = 200,
                     .content_type = try req_alloc.dupe(u8, "application/pdf"),
-                    .body = try req_alloc.dupe(u8, "%PDF-fake"),
+                    .body = body,
                 };
             }
             return .{


### PR DESCRIPTION
Codex (GPT-5):

## Summary

- Preserve the response MIME value before initializing the HTTP body reader.
- Exercise `remotePDF` with the issue's exact 3,062,180-byte response size.
- Allow valid multi-megabyte PDF responses to reach the configured PDF extractor.

Fixes #353

## Root cause

`std.http.Response.reader()` invalidates strings borrowed from the response head. `downloadHttpOutcomeAlloc` retained the borrowed `Content-Type`, read the multi-megabyte body, and copied the MIME value only afterward. The invalidated value no longer matched `application/pdf`, so `remotePDF` rejected the valid response before invoking the PDF extractor.

## Proof of mitigation

TDD red/green on current `origin/main`:

- **Red, regression only:** `zig build lib-template-test` reported 96/97 passing; the new exact-size test failed with `remotePDF requires an application/pdf response` before the PDF backend was called.
- **Green, ownership fix applied:** the identical `zig build lib-template-test` command passed.

Additional validation:

- `make zig-unit-test`
- `zig fmt --check lib/scraping/src/mod.zig pkg/antfly/src/template_remote.zig`
- `git diff --check`