### PR TITLE
[bug] Fix HTTP listener timeout starvation

### DIFF
--- a/zig/pkg/antfly/src/common/http/std_http_listener.zig
+++ b/zig/pkg/antfly/src/common/http/std_http_listener.zig
@@ -359,7 +359,8 @@ pub const StdHttpListener = struct {
         var select_buffer: [2]SelectResult = undefined;
         var select = std.Io.Select(SelectResult).init(io, &select_buffer);
         try select.concurrent(.receive, Task.receiveTask, .{server});
-        select.async(.timeout, Task.timeoutTask, .{
+        defer select.cancelDiscard();
+        try select.concurrent(.timeout, Task.timeoutTask, .{
             io,
             std.Io.Timeout{ .duration = .{
                 .raw = std.Io.Duration.fromMilliseconds(@intCast(timeout_ms)),
@@ -370,13 +371,11 @@ pub const StdHttpListener = struct {
         const first = try select.await();
         switch (first) {
             .receive => |receive_result| {
-                select.cancelDiscard();
                 return try receive_result;
             },
             .timeout => |timeout_result| {
                 try timeout_result;
                 stream.shutdown(io, .both) catch {};
-                while (select.cancel()) |_| {}
                 return error.Timeout;
             },
         }
@@ -671,13 +670,23 @@ pub const StdHttpListener = struct {
             fn timeoutTask(task_io: std.Io, timeout: std.Io.Timeout) TimeoutResult {
                 return timeout.sleep(task_io);
             }
+
+            fn drainResult(listener: *StdHttpListener, result: SelectResult) void {
+                switch (result) {
+                    .read => |read_result| {
+                        if (read_result) |body| listener.alloc.free(body) else |_| {}
+                    },
+                    .timeout => |timeout_result| timeout_result catch {},
+                }
+            }
         };
 
         const io = self.io_impl.io();
         var select_buffer: [2]SelectResult = undefined;
         var select = std.Io.Select(SelectResult).init(io, &select_buffer);
         try select.concurrent(.read, Task.readTask, .{ self, body_reader });
-        select.async(.timeout, Task.timeoutTask, .{
+        defer while (select.cancel()) |result| Task.drainResult(self, result);
+        try select.concurrent(.timeout, Task.timeoutTask, .{
             io,
             std.Io.Timeout{ .duration = .{
                 .raw = std.Io.Duration.fromMilliseconds(@intCast(timeout_ms)),
@@ -688,20 +697,11 @@ pub const StdHttpListener = struct {
         const first = try select.await();
         switch (first) {
             .read => |read_result| {
-                select.cancelDiscard();
                 return try read_result;
             },
             .timeout => |timeout_result| {
                 try timeout_result;
                 if (stream) |active_stream| active_stream.shutdown(io, .both) catch {};
-                while (select.cancel()) |result| switch (result) {
-                    .read => |read_result| {
-                        if (read_result) |body| {
-                            self.alloc.free(body);
-                        } else |_| {}
-                    },
-                    .timeout => |cancel_timeout| cancel_timeout catch {},
-                };
                 return error.Timeout;
             },
         }
@@ -1251,6 +1251,61 @@ test "std http listener saturated connection slots queue instead of resetting" {
     try std.testing.expect(slow_completed);
     try std.testing.expect(!slow_req.failed.load(.acquire));
     try std.testing.expectEqual(@as(u16, 200), slow_req.status.load(.acquire));
+}
+
+test "std http listener responds before header timeout without async capacity" {
+    const std_http_executor = @import("std_http_executor.zig");
+
+    const App = struct {
+        fn executor(self: *@This()) common.RequestExecutor {
+            return .{
+                .ptr = self,
+                .vtable = &.{ .execute = execute },
+            };
+        }
+
+        fn execute(_: *anyopaque, alloc: std.mem.Allocator, _: common.HttpRequest) !common.HttpResponse {
+            return .{
+                .status = 200,
+                .content_type = try alloc.dupe(u8, "text/plain; charset=utf-8"),
+                .body = try alloc.dupe(u8, "ok"),
+            };
+        }
+    };
+
+    var app = App{};
+    var executor = std_http_executor.StdHttpExecutor.init(std.heap.page_allocator, .{});
+    defer executor.deinit();
+    const request_executor = executor.executor();
+
+    var listener = StdHttpListener.init(std.heap.page_allocator, .{
+        .serve_in_connection_threads = true,
+        .header_read_timeout_ms = 1_000,
+        .body_read_timeout_ms = 1_000,
+    }, app.executor());
+    defer listener.deinit();
+    listener.io_impl.setAsyncLimit(.nothing);
+    try listener.start();
+
+    const base_uri = try listener.baseUri(std.testing.allocator);
+    defer std.testing.allocator.free(base_uri);
+
+    var response = try request_executor.execute(std.testing.allocator, .{
+        .method = .GET,
+        .uri = base_uri,
+        .timeout_ms = 250,
+    });
+    defer response.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(u16, 200), response.status);
+
+    var body_response = try request_executor.execute(std.testing.allocator, .{
+        .method = .POST,
+        .uri = base_uri,
+        .body = "ping",
+        .timeout_ms = 250,
+    });
+    defer body_response.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(u16, 200), body_response.status);
 }
 
 test "std http listener header timeout releases accepted idle connection slot" {

--- a/zig/pkg/antfly/src/common/http/std_http_listener.zig
+++ b/zig/pkg/antfly/src/common/http/std_http_listener.zig
@@ -339,46 +339,45 @@ pub const StdHttpListener = struct {
         const timeout_ms = self.cfg.header_read_timeout_ms;
         if (timeout_ms == 0) return try server.receiveHead();
 
-        const ReceiveResult = anyerror!std.http.Server.Request;
-        const TimeoutResult = anyerror!void;
-        const SelectResult = union(enum) {
-            receive: ReceiveResult,
-            timeout: TimeoutResult,
+        const RaceState = enum(u8) {
+            pending,
+            receive_complete,
+            timed_out,
         };
 
         const Task = struct {
-            fn receiveTask(srv: *std.http.Server) ReceiveResult {
-                return srv.receiveHead();
-            }
-
-            fn timeoutTask(task_io: std.Io, timeout: std.Io.Timeout) TimeoutResult {
-                return timeout.sleep(task_io);
+            fn timeoutTask(
+                task_io: std.Io,
+                timeout: std.Io.Timeout,
+                state: *std.atomic.Value(RaceState),
+                active_stream: *const std.Io.net.Stream,
+            ) std.Io.Cancelable!void {
+                try timeout.sleep(task_io);
+                if (state.cmpxchgStrong(.pending, .timed_out, .acq_rel, .acquire) == null) {
+                    active_stream.shutdown(task_io, .both) catch {};
+                }
             }
         };
 
-        var select_buffer: [2]SelectResult = undefined;
-        var select = std.Io.Select(SelectResult).init(io, &select_buffer);
-        try select.concurrent(.receive, Task.receiveTask, .{server});
-        defer select.cancelDiscard();
-        try select.concurrent(.timeout, Task.timeoutTask, .{
+        var state = std.atomic.Value(RaceState).init(.pending);
+        var timeout_group: std.Io.Group = .init;
+        try timeout_group.concurrent(io, Task.timeoutTask, .{
             io,
             std.Io.Timeout{ .duration = .{
                 .raw = std.Io.Duration.fromMilliseconds(@intCast(timeout_ms)),
                 .clock = .awake,
             } },
+            &state,
+            stream,
         });
+        defer timeout_group.cancel(io);
 
-        const first = try select.await();
-        switch (first) {
-            .receive => |receive_result| {
-                return try receive_result;
-            },
-            .timeout => |timeout_result| {
-                try timeout_result;
-                stream.shutdown(io, .both) catch {};
-                return error.Timeout;
-            },
+        const receive_result = server.receiveHead();
+        if (state.cmpxchgStrong(.pending, .receive_complete, .acq_rel, .acquire) != null) {
+            _ = receive_result catch {};
+            return error.Timeout;
         }
+        return try receive_result;
     }
 
     fn registerActiveStream(self: *StdHttpListener, stream: *const std.Io.net.Stream) !void {
@@ -655,56 +654,46 @@ pub const StdHttpListener = struct {
         const timeout_ms = self.cfg.body_read_timeout_ms;
         if (timeout_ms == 0 or stream == null) return try body_reader.allocRemaining(self.alloc, .limited(self.cfg.max_request_bytes));
 
-        const ReadResult = anyerror![]u8;
-        const TimeoutResult = anyerror!void;
-        const SelectResult = union(enum) {
-            read: ReadResult,
-            timeout: TimeoutResult,
+        const RaceState = enum(u8) {
+            pending,
+            read_complete,
+            timed_out,
         };
 
         const Task = struct {
-            fn readTask(listener: *StdHttpListener, reader: *std.Io.Reader) ReadResult {
-                return reader.allocRemaining(listener.alloc, .limited(listener.cfg.max_request_bytes));
-            }
-
-            fn timeoutTask(task_io: std.Io, timeout: std.Io.Timeout) TimeoutResult {
-                return timeout.sleep(task_io);
-            }
-
-            fn drainResult(listener: *StdHttpListener, result: SelectResult) void {
-                switch (result) {
-                    .read => |read_result| {
-                        if (read_result) |body| listener.alloc.free(body) else |_| {}
-                    },
-                    .timeout => |timeout_result| timeout_result catch {},
+            fn timeoutTask(
+                task_io: std.Io,
+                timeout: std.Io.Timeout,
+                state: *std.atomic.Value(RaceState),
+                active_stream: *const std.Io.net.Stream,
+            ) std.Io.Cancelable!void {
+                try timeout.sleep(task_io);
+                if (state.cmpxchgStrong(.pending, .timed_out, .acq_rel, .acquire) == null) {
+                    active_stream.shutdown(task_io, .both) catch {};
                 }
             }
         };
 
         const io = self.io_impl.io();
-        var select_buffer: [2]SelectResult = undefined;
-        var select = std.Io.Select(SelectResult).init(io, &select_buffer);
-        try select.concurrent(.read, Task.readTask, .{ self, body_reader });
-        defer while (select.cancel()) |result| Task.drainResult(self, result);
-        try select.concurrent(.timeout, Task.timeoutTask, .{
+        var state = std.atomic.Value(RaceState).init(.pending);
+        var timeout_group: std.Io.Group = .init;
+        try timeout_group.concurrent(io, Task.timeoutTask, .{
             io,
             std.Io.Timeout{ .duration = .{
                 .raw = std.Io.Duration.fromMilliseconds(@intCast(timeout_ms)),
                 .clock = .awake,
             } },
+            &state,
+            stream.?,
         });
+        defer timeout_group.cancel(io);
 
-        const first = try select.await();
-        switch (first) {
-            .read => |read_result| {
-                return try read_result;
-            },
-            .timeout => |timeout_result| {
-                try timeout_result;
-                if (stream) |active_stream| active_stream.shutdown(io, .both) catch {};
-                return error.Timeout;
-            },
+        const read_result = body_reader.allocRemaining(self.alloc, .limited(self.cfg.max_request_bytes));
+        if (state.cmpxchgStrong(.pending, .read_complete, .acq_rel, .acquire) != null) {
+            if (read_result) |body| self.alloc.free(body) else |_| {}
+            return error.Timeout;
         }
+        return try read_result;
     }
 
     fn mapMethod(method: std.http.Method) ?common.Method {
@@ -1290,22 +1279,24 @@ test "std http listener responds before header timeout without async capacity" {
     const base_uri = try listener.baseUri(std.testing.allocator);
     defer std.testing.allocator.free(base_uri);
 
-    var response = try request_executor.execute(std.testing.allocator, .{
-        .method = .GET,
-        .uri = base_uri,
-        .timeout_ms = 250,
-    });
-    defer response.deinit(std.testing.allocator);
-    try std.testing.expectEqual(@as(u16, 200), response.status);
+    for (0..32) |_| {
+        var response = try request_executor.execute(std.testing.allocator, .{
+            .method = .GET,
+            .uri = base_uri,
+            .timeout_ms = 250,
+        });
+        defer response.deinit(std.testing.allocator);
+        try std.testing.expectEqual(@as(u16, 200), response.status);
 
-    var body_response = try request_executor.execute(std.testing.allocator, .{
-        .method = .POST,
-        .uri = base_uri,
-        .body = "ping",
-        .timeout_ms = 250,
-    });
-    defer body_response.deinit(std.testing.allocator);
-    try std.testing.expectEqual(@as(u16, 200), body_response.status);
+        var body_response = try request_executor.execute(std.testing.allocator, .{
+            .method = .POST,
+            .uri = base_uri,
+            .body = "ping",
+            .timeout_ms = 250,
+        });
+        defer body_response.deinit(std.testing.allocator);
+        try std.testing.expectEqual(@as(u16, 200), body_response.status);
+    }
 }
 
 test "std http listener header timeout releases accepted idle connection slot" {


### PR DESCRIPTION
Codex (GPT-5):

## Summary

- prevent HTTP listener timeout work from executing inline when async capacity is exhausted
- race each synchronous header/body read against exactly one concurrent timer with an atomic winner
- make shutdown/cancellation wait for the timer task so teardown cannot retain stack or connection references
- add a deterministic, repeated zero-async-capacity regression covering both GET and body-bearing POST requests

## Root cause

`StdHttpListener` previously scheduled a read and its timeout using different executor classes. Zig permits `async` work to execute immediately when the executor has no async capacity. Because the default async capacity is `visible_cpu_count - 1`, a one-CPU process has zero capacity and the connection worker could run the timeout sleep inline before observing an already-completed read. In rc18 this delayed `GET /healthz` by the full 30-second header timeout while the unrelated public API remained responsive.

The first attempted mitigation made both racers concurrent. That removed starvation, but Linux CI exposed a cleanup race: cancellation during listener shutdown could leave two scheduled tasks competing over connection and stack-owned state, and the common test process aborted.

The final implementation keeps the socket read on the connection worker and launches only the timer concurrently. An atomic state records whether the read or timer won. The timer shuts down the stream only when it wins; the connection worker frees a late body allocation if timeout won; and `Io.Group.cancel` joins timer cleanup on every exit. This removes both inline timeout starvation and the two-task teardown race.

## Red/green TDD evidence

### Red: production regression

With `listener.io_impl.setAsyncLimit(.nothing)`, the original implementation failed the new regression deterministically:

```text
$ zig build lib-common-test
30/31 tests passed
common.http.std_http_listener.test.std http listener responds before header timeout without async capacity
error.Timeout at std_http_executor.zig:187
```

The test is independent of host CPU count. It configures 1,000 ms server read timeouts and requires GET and body-bearing POST responses within a 250 ms client timeout.

### Red: initial mitigation cleanup race

GitHub Actions run `29288626616` showed that using two concurrent select tasks was not sufficient: `zig-base` aborted in the common listener test process during Linux teardown. That failure drove the one-timer design now in this PR.

### Green: final mitigation

macOS arm64:

```text
$ zig build --summary all lib-common-test
Build Summary: 11/11 steps succeeded; 31/31 tests passed

$ zig build root-test -- --test-filter 'std http listener'
17 passed; 0 skipped; 0 failed; 0 leaked.
```

Ubuntu 24.04 arm64, using the repository CI image:

```text
$ zig build --summary all lib-common-test
Build Summary: 11/11 steps succeeded; 31/31 tests passed

20 randomized full common-suite repetitions
20 passed; 0 failed
```

The zero-capacity regression now runs 32 GET/POST pairs (64 requests) to exercise timer cancellation and body ownership repeatedly.

## Before / after

| Scenario | Before | After |
|---|---|---|
| One visible CPU, `GET :4200/healthz` | Probe waited for the 30-second header timeout | Zero-capacity regression responds inside 250 ms |
| Async capacity exhausted | Timeout could sleep inline on the connection worker | Read remains synchronous; one timer is guaranteed concurrent or launch fails closed |
| Listener shutdown | Initial two-task mitigation could abort during cleanup | Timer cancellation is joined before connection/stack state is released |
| Genuinely idle/slow clients | Existing timeout behavior | Preserved by the common listener suite |

## CI provenance

The `e2e-base` failure in the first run is unrelated to this one-file listener change: the HA test expected `404` from a fenced former primary, while the runtime correctly failed closed with `503`. That stale HA assertion is being corrected and certified on the HA hardening branch rather than folded into this listener PR.

Fixes #355
