### PR TITLE
Fix MCP index list structured content

### DIFF
--- a/zig/pkg/antfly/src/api/http_server.zig
+++ b/zig/pkg/antfly/src/api/http_server.zig
@@ -16462,6 +16462,19 @@ test "api http server serves fielded full-text search through mcp tools" {
     defer describe_indexes_resp.deinit(std.testing.allocator);
     try std.testing.expectEqual(@as(u16, 200), describe_indexes_resp.status);
     try std.testing.expect(std.mem.indexOf(u8, describe_indexes_resp.body, "\"full_text_index_v0\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, describe_indexes_resp.body, "\"structuredContent\":{\"indexes\":[") != null);
+
+    var list_indexes_resp = try server.handle(.{
+        .method = .POST,
+        .uri = routes.Routes.mcp_v1,
+        .headers = &mcp_session_headers,
+        .content_type = "application/json",
+        .body = "{\"jsonrpc\":\"2.0\",\"id\":15,\"method\":\"tools/call\",\"params\":{\"name\":\"list_indexes\",\"arguments\":{\"tableName\":\"docs\"}}}",
+    });
+    defer list_indexes_resp.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(u16, 200), list_indexes_resp.status);
+    try std.testing.expect(std.mem.indexOf(u8, list_indexes_resp.body, "\"full_text_index_v0\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, list_indexes_resp.body, "\"structuredContent\":{\"indexes\":[") != null);
 
     var sample_documents_resp = try server.handle(.{
         .method = .POST,

--- a/zig/pkg/antfly/src/api/protocol_adapters.zig
+++ b/zig/pkg/antfly/src/api/protocol_adapters.zig
@@ -355,7 +355,15 @@ fn handleMcpRequestFiltered(server_ptr: anytype, req: http_common.HttpRequest, a
         fn listIndexes(ctx: *@This(), alloc: std.mem.Allocator, args: std.json.Value) !mcp.CallToolResult {
             const table_name = jsonStringArg(args, "tableName") orelse return mcpError(alloc, "missing tableName");
             const uri = try std.fmt.allocPrint(alloc, "{s}/{s}/indexes", .{ routes.Routes.tables, table_name });
-            return try ctx.simpleRoute(alloc, .GET, uri, "");
+            var result = try ctx.simpleRoute(alloc, .GET, uri, "");
+            if (result.structured) |structured| {
+                if (structured == .array) {
+                    var wrapped = std.json.ObjectMap.empty;
+                    try wrapped.put(alloc, "indexes", structured);
+                    result.structured = .{ .object = wrapped };
+                }
+            }
+            return result;
         }
 
         fn getDocument(ctx: *@This(), alloc: std.mem.Allocator, args: std.json.Value) !mcp.CallToolResult {


### PR DESCRIPTION
## Summary
- wrap index-list arrays in an MCP-compliant `structuredContent.indexes` object
- cover both `list_indexes` and `describe_indexes` in the MCP HTTP integration test
- preserve the existing raw JSON text response

## Test
- `zig fmt --check pkg/antfly/src/api/protocol_adapters.zig pkg/antfly/src/api/http_server.zig`
- `zig build root-test -- --test-filter "api http server serves fielded full-text search through mcp tools"`