### PR TITLE
Bound zig-base unit test concurrency

### DIFF
--- a/.github/workflows/zig-tests.yml
+++ b/.github/workflows/zig-tests.yml
@@ -178,6 +178,17 @@ jobs:
       - name: Check generated sources
         run: make zig-generated-check
 
+      # ARC exposes the node CPU count instead of the pod quota. Bound both
+      # zig build's process fan-out and std.Io.Threaded pool sizing to the same
+      # budget used by zig-full so teardown remains reliable under contention.
+      - name: Compute CPU bound for unit tests
+        if: needs.changes.outputs.zig_tests == 'true'
+        id: cpus
+        run: |
+          jobs=$(nproc)
+          if [ "$jobs" -gt 8 ]; then jobs=8; fi
+          echo "list=0-$((jobs - 1))" >> "$GITHUB_OUTPUT"
+
       - name: Run hermetic Antfly unit tests
         if: needs.changes.outputs.zig_tests == 'true'
         env:
@@ -283,7 +294,7 @@ jobs:
 
           (
             set +e
-            make zig-unit-test 2>&1 | tee -a "$unit_log"
+            taskset -c "${{ steps.cpus.outputs.list }}" make zig-unit-test 2>&1 | tee -a "$unit_log"
             exit "${PIPESTATUS[0]}"
           ) &
           unit_pid="$!"

--- a/scripts/tla-segment-raft-trace.py
+++ b/scripts/tla-segment-raft-trace.py
@@ -65,11 +65,13 @@ def segment_trace(lines):
     current = []
     init_nodes = set()  # nodes with InitState in current segment
 
-    for line in lines:
+    for line_number, line in enumerate(lines, 1):
         try:
             obj = json.loads(line)
-        except json.JSONDecodeError:
-            continue
+        except json.JSONDecodeError as exc:
+            raise ValueError(
+                f"{line_number}: invalid JSON trace event: {exc.msg}"
+            ) from exc
         if obj.get("tag") != "trace":
             continue
 
@@ -136,7 +138,11 @@ def main():
     with open(trace_file) as f:
         lines = [l.strip() for l in f if l.strip()]
 
-    segments = segment_trace(lines)
+    try:
+        segments = segment_trace(lines)
+    except ValueError as exc:
+        print(f"{trace_file}:{exc}", file=sys.stderr)
+        sys.exit(1)
     for i, seg in enumerate(segments):
         # Skip segments with no non-bootstrap events (empty runs)
         has_activity = any(

--- a/zig/pkg/antfly/src/tracing/raft_trace_logger.zig
+++ b/zig/pkg/antfly/src/tracing/raft_trace_logger.zig
@@ -203,7 +203,7 @@ pub const RaftNdjsonTraceLogger = struct {
             }
             try w.writeAll("],\"transition\":\"");
             try w.writeAll(@tagName(event.conf_transition));
-            try w.writeAll("\"}}}");
+            try w.writeAll("\"}}");
         }
 
         try w.writeAll("}}\n");
@@ -572,4 +572,11 @@ test "raft trace logger emits valid ndjson" {
     try std.testing.expect(std.mem.indexOf(u8, change_output, "\"name\":\"ChangeConf\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, change_output, "\"action\":\"RemoveServer\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, change_output, "\"nid\":\"3\"") != null);
+
+    var lines = std.mem.splitScalar(u8, change_output, '\n');
+    while (lines.next()) |line| {
+        if (line.len == 0) continue;
+        var parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, line, .{});
+        parsed.deinit();
+    }
 }


### PR DESCRIPTION
## Summary
- apply the existing zig-full CPU affinity limit to zig-base unit tests
- constrain both Zig build fan-out and inherited std.Io.Threaded pool sizing on ARC runners
- emit valid NDJSON for Raft configuration-change trace events
- fail trace segmentation immediately on malformed JSON instead of silently dropping events

## Root causes
The original CLI binaries completed all assertions, cleanup, and leak checks before aborting under the uncapped zig-base runner. ARC exposes node CPU count rather than pod quota, multiplying both Zig test process fan-out and per-process I/O pools; the same aggregate passes under zig-full's existing eight-CPU affinity cap.

The follow-up validation passed the unit step and exposed an independent deterministic TLA trace defect. ChangeConf events had one extra closing brace, so the segmenter discarded them and TLC later saw a self-ack without its configuration proposal.

## Validation
- actionlint -ignore SC2009 .github/workflows/zig-tests.yml
- root test binary containing cmd.lite repeated 20 times
- zig build lite-cli-test -fincremental
- focused Raft trace logger NDJSON test
- malformed trace rejected with exact file and line
- regenerated Raft trace corpus: 34 of 34 segments passed TLC