### PR TITLE
fix(operator): wait for PVC expansion before auto-grow

### DIFF
--- a/go/pkg/operator/controllers/antfly/antflycluster_controller.go
+++ b/go/pkg/operator/controllers/antfly/antflycluster_controller.go
@@ -8650,10 +8650,12 @@ func (r *AntflyClusterReconciler) reconcilePodDisruptionBudget(ctx context.Conte
 }
 
 type pvcUsageObservation struct {
-	matched       int
-	usedBytes     int64
-	capacityBytes int64
-	maxRequest    resource.Quantity
+	matched             int
+	expanding           int
+	usedBytes           int64
+	capacityBytes       int64
+	maxRequest          resource.Quantity
+	maxReportedCapacity resource.Quantity
 }
 
 type kubeletStatsSummary struct {
@@ -8722,6 +8724,25 @@ func (r *AntflyClusterReconciler) reconcileStorageAutoGrow(ctx context.Context, 
 		currentSize = observation.maxRequest
 		currentSizeStr = currentSize.String()
 	}
+	usagePercent := int32(0)
+	if observation.capacityBytes > 0 {
+		usagePercentValue := (observation.usedBytes/observation.capacityBytes)*100 + ((observation.usedBytes%observation.capacityBytes)*100)/observation.capacityBytes
+		const maxInt32 = int64(1<<31 - 1)
+		if usagePercentValue > maxInt32 {
+			usagePercentValue = maxInt32
+		}
+		usagePercent = int32(usagePercentValue)
+	}
+	if observation.expanding > 0 {
+		reportedCapacity := observation.maxReportedCapacity.String()
+		if observation.maxReportedCapacity.IsZero() {
+			reportedCapacity = "not yet reported"
+		}
+		message := fmt.Sprintf("Waiting for %d %s PVC(s) to finish expansion from reported capacity %s to requested size %s", observation.expanding, component, reportedCapacity, currentSize.String())
+		r.setStorageAutoGrowStatus(cluster, component, currentSize.String(), currentSize.String(), maxSize.String(), observation.usedBytes, observation.capacityBytes, usagePercent, antflyv1.ReasonStorageAutoGrowInProgress, message)
+		r.setStorageAutoGrowCondition(cluster, metav1.ConditionUnknown, antflyv1.ReasonStorageAutoGrowInProgress, message)
+		return currentSizeStr
+	}
 	if err != nil {
 		message := fmt.Sprintf("%s storage usage is unavailable: %v", component, err)
 		r.setStorageAutoGrowStatus(cluster, component, currentSize.String(), "", maxSize.String(), 0, 0, 0, antflyv1.ReasonStorageAutoGrowUsageUnavailable, message)
@@ -8735,12 +8756,6 @@ func (r *AntflyClusterReconciler) reconcileStorageAutoGrow(ctx context.Context, 
 		return currentSizeStr
 	}
 
-	usagePercentValue := (observation.usedBytes/observation.capacityBytes)*100 + ((observation.usedBytes%observation.capacityBytes)*100)/observation.capacityBytes
-	const maxInt32 = int64(1<<31 - 1)
-	if usagePercentValue > maxInt32 {
-		usagePercentValue = maxInt32
-	}
-	usagePercent := int32(usagePercentValue)
 	threshold := policy.GrowThresholdPercent
 	if threshold == 0 {
 		threshold = 85
@@ -8788,6 +8803,14 @@ func (r *AntflyClusterReconciler) observePVCUsage(ctx context.Context, cluster *
 		pvcNames[pvc.Name] = struct{}{}
 		if request := pvc.Spec.Resources.Requests[corev1.ResourceStorage]; request.Cmp(observation.maxRequest) > 0 {
 			observation.maxRequest = request
+		}
+		request := pvc.Spec.Resources.Requests[corev1.ResourceStorage]
+		capacity := pvc.Status.Capacity[corev1.ResourceStorage]
+		if capacity.Cmp(observation.maxReportedCapacity) > 0 {
+			observation.maxReportedCapacity = capacity
+		}
+		if capacity.IsZero() || request.Cmp(capacity) > 0 || pvcHasFileSystemResizePending(pvc) {
+			observation.expanding++
 		}
 	}
 	if len(pvcNames) == 0 {

--- a/go/pkg/operator/controllers/antfly/antflycluster_controller_test.go
+++ b/go/pkg/operator/controllers/antfly/antflycluster_controller_test.go
@@ -7974,6 +7974,11 @@ func TestReconcileStorageAutoGrowRecommendsGrowth(t *testing.T) {
 				},
 			},
 		},
+		Status: corev1.PersistentVolumeClaimStatus{
+			Capacity: corev1.ResourceList{
+				corev1.ResourceStorage: resource.MustParse("10Gi"),
+			},
+		},
 	}
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -8016,6 +8021,119 @@ func TestReconcileStorageAutoGrowRecommendsGrowth(t *testing.T) {
 	g.Expect(cond).NotTo(BeNil())
 	g.Expect(cond.Status).To(Equal(metav1.ConditionUnknown))
 	g.Expect(cond.Reason).To(Equal(antflyv1.ReasonStorageAutoGrowInProgress))
+}
+
+func TestReconcileStorageAutoGrowWaitsForInFlightPVCExpansion(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	s := runtime.NewScheme()
+	g.Expect(antflyv1.AddToScheme(s)).To(Succeed())
+	g.Expect(corev1.AddToScheme(s)).To(Succeed())
+
+	cluster := &antflyv1.AntflyCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-cluster", Namespace: "default", Generation: 8},
+		Spec: antflyv1.AntflyClusterSpec{
+			Storage: antflyv1.StorageSpec{
+				DataStorage: "10Gi",
+				StorageAutoGrow: &antflyv1.StorageAutoGrowSpec{
+					Enabled:              true,
+					MaxDataStorage:       "20Gi",
+					GrowThresholdPercent: 80,
+					GrowIncrement:        "5Gi",
+				},
+			},
+		},
+	}
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "data-storage-test-cluster-data-0",
+			Namespace: "default",
+			Labels: map[string]string{
+				"app.kubernetes.io/instance": "test-cluster",
+			},
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: resource.MustParse("10Gi"),
+				},
+			},
+		},
+		Status: corev1.PersistentVolumeClaimStatus{
+			Capacity: corev1.ResourceList{
+				corev1.ResourceStorage: resource.MustParse("10Gi"),
+			},
+		},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster-data-0",
+			Namespace: "default",
+			Labels:    serviceSelectorLabels("test-cluster", "data"),
+		},
+		Spec: corev1.PodSpec{NodeName: "node-1"},
+	}
+	usedBytes := uint64(9 * 1024 * 1024 * 1024)
+	capacityBytes := uint64(10 * 1024 * 1024 * 1024)
+	reconciler := &AntflyClusterReconciler{
+		Client: fake.NewClientBuilder().WithScheme(s).WithObjects(pvc, pod).Build(),
+		Scheme: s,
+		NodeStatsFetcher: func(context.Context, string) (*kubeletStatsSummary, error) {
+			return &kubeletStatsSummary{
+				Pods: []kubeletPodStats{
+					{
+						PodRef: kubeletPodReference{Name: pod.Name, Namespace: pod.Namespace},
+						Volume: []kubeletVolumeStats{
+							{
+								PVCRef:        &kubeletPVCReference{Name: pvc.Name, Namespace: pvc.Namespace},
+								UsedBytes:     &usedBytes,
+								CapacityBytes: &capacityBytes,
+							},
+						},
+					},
+				},
+			}, nil
+		},
+	}
+
+	firstRecommendation := reconciler.reconcileStorageAutoGrow(ctx, cluster, "data", "data-storage", "test-cluster-data", "10Gi", "20Gi")
+	g.Expect(firstRecommendation).To(Equal("15Gi"))
+
+	currentPVC := &corev1.PersistentVolumeClaim{}
+	g.Expect(reconciler.Get(ctx, types.NamespacedName{Name: pvc.Name, Namespace: pvc.Namespace}, currentPVC)).To(Succeed())
+	currentPVC.Spec.Resources.Requests[corev1.ResourceStorage] = resource.MustParse(firstRecommendation)
+	g.Expect(reconciler.Update(ctx, currentPVC)).To(Succeed())
+
+	secondRecommendation := reconciler.reconcileStorageAutoGrow(ctx, cluster, "data", "data-storage", "test-cluster-data", firstRecommendation, "20Gi")
+
+	g.Expect(secondRecommendation).To(Equal("15Gi"))
+	g.Expect(cluster.Status.StorageAutoGrowStatus).NotTo(BeNil())
+	g.Expect(cluster.Status.StorageAutoGrowStatus.CurrentSize).To(Equal("15Gi"))
+	g.Expect(cluster.Status.StorageAutoGrowStatus.RecommendedSize).To(Equal("15Gi"))
+	g.Expect(cluster.Status.StorageAutoGrowStatus.UsagePercent).To(Equal(int32(90)))
+	g.Expect(cluster.Status.StorageAutoGrowStatus.Reason).To(Equal(antflyv1.ReasonStorageAutoGrowInProgress))
+	g.Expect(cluster.Status.StorageAutoGrowStatus.Message).To(ContainSubstring("reported capacity 10Gi to requested size 15Gi"))
+	cond := meta.FindStatusCondition(cluster.Status.Conditions, antflyv1.TypeStorageAutoGrow)
+	g.Expect(cond).NotTo(BeNil())
+	g.Expect(cond.Status).To(Equal(metav1.ConditionUnknown))
+	g.Expect(cond.Reason).To(Equal(antflyv1.ReasonStorageAutoGrowInProgress))
+
+	g.Expect(reconciler.Get(ctx, types.NamespacedName{Name: pvc.Name, Namespace: pvc.Namespace}, currentPVC)).To(Succeed())
+	currentPVC.Status.Capacity[corev1.ResourceStorage] = resource.MustParse("15Gi")
+	currentPVC.Status.Conditions = []corev1.PersistentVolumeClaimCondition{
+		{
+			Type:   corev1.PersistentVolumeClaimFileSystemResizePending,
+			Status: corev1.ConditionTrue,
+		},
+	}
+	g.Expect(reconciler.Status().Update(ctx, currentPVC)).To(Succeed())
+
+	fileSystemResizePendingRecommendation := reconciler.reconcileStorageAutoGrow(ctx, cluster, "data", "data-storage", "test-cluster-data", firstRecommendation, "20Gi")
+
+	g.Expect(fileSystemResizePendingRecommendation).To(Equal("15Gi"))
+	g.Expect(cluster.Status.StorageAutoGrowStatus.CurrentSize).To(Equal("15Gi"))
+	g.Expect(cluster.Status.StorageAutoGrowStatus.RecommendedSize).To(Equal("15Gi"))
+	g.Expect(cluster.Status.StorageAutoGrowStatus.Message).To(ContainSubstring("reported capacity 15Gi to requested size 15Gi"))
 }
 
 func TestSetPVCExpansionConditionReportsComplete(t *testing.T) {


### PR DESCRIPTION
Codex (GPT-5):

## What

Add an in-flight guard to operator-owned PVC auto-growth.

The operator now waits when any matching PVC:

- requests more storage than `status.capacity` reports,
- has no reported capacity yet, or
- reports `FileSystemResizePending=True`.

While waiting, it retains the current requested size and reports `StorageAutoGrowInProgress` with requested/reported sizes and observed usage.

## Why

Without this guard, a PVC request could advance from one increment to the next on successive reconciles before the CSI/filesystem expansion completed. A 20 GiB Starter disk under pressure could therefore leap through 30 GiB and 40 GiB toward its cap instead of applying one bounded step at a time.

This is the operator dependency for https://github.com/antflydb/colony/issues/365.

## Impact

- Prevents overlapping auto-grow decisions.
- Does not shrink storage.
- Does not alter clusters with auto-grow disabled.
- Keeps expansion state visible through existing typed status and conditions.

## Checks

- `go test ./controllers/antfly -run 'TestReconcile(StorageAutoGrow|PVCExpansion)' -count=1`
- `go test ./controllers/antfly -count=1`
- `git diff --check`
