### PR TITLE
gate hot-standby HA pending paired release

### DIFF
--- a/.github/workflows/zig-tests.yml
+++ b/.github/workflows/zig-tests.yml
@@ -16,6 +16,9 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   ZIG_LOCAL_CACHE_DIR: ${{ github.workspace }}/zig/.zig-cache
   ZIG_GLOBAL_CACHE_DIR: ${{ github.workspace }}/zig/.zig-global-cache
+  # Required PR/push/scheduled aggregates skip the gated HA suites. Manual
+  # dispatch retains the full HA test surface until PRs #346/#347 land.
+  ZIG_BUILD_FLAGS: ${{ github.event_name == 'workflow_dispatch' && '-Dha-tests=true' || '-Dha-tests=false' }}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
@@ -460,7 +463,7 @@ jobs:
 
       - name: Run Zig chaos tests
         working-directory: zig
-        run: taskset -c ${{ steps.cpus.outputs.list }} zig build chaos-test
+        run: taskset -c ${{ steps.cpus.outputs.list }} zig build chaos-test ${ZIG_BUILD_FLAGS}
 
   e2e-base:
     name: e2e-base

--- a/.github/workflows/zig-tests.yml
+++ b/.github/workflows/zig-tests.yml
@@ -17,7 +17,8 @@ env:
   ZIG_LOCAL_CACHE_DIR: ${{ github.workspace }}/zig/.zig-cache
   ZIG_GLOBAL_CACHE_DIR: ${{ github.workspace }}/zig/.zig-global-cache
   # Required PR/push/scheduled aggregates skip the gated HA suites. Manual
-  # dispatch retains the full HA test surface until PRs #346/#347 land.
+  # dispatch retains the full HA test surface until the paired Colony and
+  # Antfly HA changes land.
   ZIG_BUILD_FLAGS: ${{ github.event_name == 'workflow_dispatch' && '-Dha-tests=true' || '-Dha-tests=false' }}
 
 concurrency:

--- a/Makefile
+++ b/Makefile
@@ -132,7 +132,7 @@ zig-test:
 	$(ZIG_MAKE) test
 
 zig-unit-test:
-	$(ZIG_MAKE) unit-test
+	$(ZIG_MAKE) unit-test ZIG_BUILD_FLAGS="$(ZIG_BUILD_FLAGS)"
 
 zig-generate:
 	$(ZIG_MAKE) generate

--- a/go/pkg/operator/cmd/antfly-operator/main.go
+++ b/go/pkg/operator/cmd/antfly-operator/main.go
@@ -54,6 +54,7 @@ func main() {
 	var probeAddr string
 	var skipCRDInstall bool
 	var enableInferenceControllers bool
+	var enableHotStandbyHA bool
 	var inferenceAntflyImage string
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
@@ -64,6 +65,8 @@ func main() {
 		"Skip automatic CRD installation (use if CRDs managed externally)")
 	flag.BoolVar(&enableInferenceControllers, "enable-inference-controllers", true,
 		"Enable InferencePool and InferenceProxy controllers and AntflyCluster.spec.inference management. CRD installation remains unconditional unless --skip-crd-install is set.")
+	flag.BoolVar(&enableHotStandbyHA, "enable-hot-standby-ha", false,
+		"Enable admission and reconciliation of AntflyCluster.spec.highAvailability.mode=HotStandby.")
 	flag.StringVar(&inferenceAntflyImage, "inference-antfly-image", defaultInferenceOmniImage,
 		"Default omni Antfly image for InferencePool pods. The image must provide the /antfly inference runtime contract.")
 	opts := zap.Options{
@@ -105,6 +108,7 @@ func main() {
 
 	setupLog.Info("operator configuration",
 		"enableInferenceControllers", enableInferenceControllers,
+		"enableHotStandbyHA", enableHotStandbyHA,
 		"inferenceAntflyImage", inferenceAntflyImage,
 		"skipCRDInstall", skipCRDInstall,
 		"webhooksEnabled", webhooksEnabled(),
@@ -120,6 +124,7 @@ func main() {
 		KubeClient:            k8sClient,
 		Recorder:              mgr.GetEventRecorder("antfly-operator"),
 		ManageInferencePools:  enableInferenceControllers,
+		EnableHotStandbyHA:    &enableHotStandbyHA,
 		DefaultInferenceImage: inferenceAntflyImage,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "AntflyCluster")
@@ -167,7 +172,7 @@ func main() {
 
 	// Setup webhooks
 	if webhooksEnabled() {
-		if err := webhookv1.SetupWithManager(mgr); err != nil {
+		if err := webhookv1.SetupWithManager(mgr, enableHotStandbyHA); err != nil {
 			setupLog.Error(err, "unable to create webhooks")
 			os.Exit(1)
 		}

--- a/go/pkg/operator/config/manager/deployment.yaml
+++ b/go/pkg/operator/config/manager/deployment.yaml
@@ -38,6 +38,7 @@ spec:
         args:
         - --leader-elect
         - --enable-inference-controllers=true
+        - --enable-hot-standby-ha=false
         env:
         - name: ANTFLY_HA_ADMIN_TOKEN
           valueFrom:

--- a/go/pkg/operator/controllers/antfly/antflycluster_controller.go
+++ b/go/pkg/operator/controllers/antfly/antflycluster_controller.go
@@ -49,13 +49,16 @@ import (
 // AntflyClusterReconciler reconciles an AntflyCluster object
 type AntflyClusterReconciler struct {
 	client.Client
-	Scheme                *runtime.Scheme
-	AutoScaler            *AutoScaler
-	KubeClient            kubernetes.Interface
-	NodeStatsFetcher      func(context.Context, string) (*kubeletStatsSummary, error)
-	HTTPClient            *http.Client
-	Recorder              events.EventRecorder
-	ManageInferencePools  bool
+	Scheme               *runtime.Scheme
+	AutoScaler           *AutoScaler
+	KubeClient           kubernetes.Interface
+	NodeStatsFetcher     func(context.Context, string) (*kubeletStatsSummary, error)
+	HTTPClient           *http.Client
+	Recorder             events.EventRecorder
+	ManageInferencePools bool
+	// EnableHotStandbyHA is always set by the operator binary. A nil value keeps
+	// existing embedded controller and unit-test constructors backward compatible.
+	EnableHotStandbyHA    *bool
 	DefaultInferenceImage string
 
 	// validationAttempts tracks consecutive validation failure counts per cluster
@@ -1125,8 +1128,24 @@ func (r *AntflyClusterReconciler) applyDefaults(cluster *antflyv1.AntflyCluster)
 // validateClusterConfiguration validates the cluster configuration (T025)
 // This is a fallback validation for cases where webhook validation is disabled
 func (r *AntflyClusterReconciler) validateClusterConfiguration(cluster *antflyv1.AntflyCluster) error {
+	if !r.hotStandbyHAEnabled() && hotStandbyHARequested(cluster) {
+		return hotStandbyHAFeatureGateError()
+	}
 	// Call the webhook validation methods as fallback
 	return cluster.ValidateCreate()
+}
+
+func (r *AntflyClusterReconciler) hotStandbyHAEnabled() bool {
+	return r.EnableHotStandbyHA == nil || *r.EnableHotStandbyHA
+}
+
+func hotStandbyHARequested(cluster *antflyv1.AntflyCluster) bool {
+	return cluster != nil && cluster.Spec.HighAvailability != nil &&
+		cluster.Spec.HighAvailability.Mode == antflyv1.HAModeHotStandby
+}
+
+func hotStandbyHAFeatureGateError() error {
+	return fmt.Errorf("hot-standby HA is disabled by the operator feature gate; restart the operator with --enable-hot-standby-ha=true to reconcile spec.highAvailability.mode=HotStandby")
 }
 
 // calculateBackoff calculates exponential backoff duration for validation failures (T027)
@@ -1445,6 +1464,16 @@ func (r *AntflyClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			}
 		}
 		return ctrl.Result{}, nil
+	}
+
+	if !r.hotStandbyHAEnabled() && hotStandbyHARequested(&antflyCluster) {
+		validationErr := hotStandbyHAFeatureGateError()
+		log.Error(validationErr, "Cluster configuration validation failed")
+		if statusErr := r.updateStatusWithValidationError(ctx, &antflyCluster, validationErr); statusErr != nil {
+			log.Error(statusErr, "Failed to update status with validation error")
+		}
+		attempt := r.incrementValidationAttempts(req.String())
+		return ctrl.Result{RequeueAfter: calculateBackoff(attempt - 1)}, nil
 	}
 
 	// Ensure finalizer is present when WhenDeleted=Delete.

--- a/go/pkg/operator/controllers/antfly/feature_gate_test.go
+++ b/go/pkg/operator/controllers/antfly/feature_gate_test.go
@@ -1,0 +1,79 @@
+package controllers
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	antflyv1 "github.com/antflydb/antfly/go/pkg/operator/api/antfly/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/events"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestValidateClusterConfigurationRejectsHotStandbyWhenFeatureGateDisabled(t *testing.T) {
+	enabled := false
+	reconciler := &AntflyClusterReconciler{EnableHotStandbyHA: &enabled}
+	cluster := &antflyv1.AntflyCluster{
+		Spec: antflyv1.AntflyClusterSpec{
+			HighAvailability: &antflyv1.HighAvailabilitySpec{Mode: antflyv1.HAModeHotStandby},
+		},
+	}
+
+	err := reconciler.validateClusterConfiguration(cluster)
+	if err == nil || !strings.Contains(err.Error(), "--enable-hot-standby-ha=true") {
+		t.Fatalf("expected disabled hot-standby feature-gate error, got %v", err)
+	}
+}
+
+func TestHotStandbyFeatureGateKeepsEmbeddedConstructorsBackwardCompatible(t *testing.T) {
+	if !(&AntflyClusterReconciler{}).hotStandbyHAEnabled() {
+		t.Fatal("nil feature gate should preserve existing embedded controller behavior")
+	}
+	enabled := true
+	if !(&AntflyClusterReconciler{EnableHotStandbyHA: &enabled}).hotStandbyHAEnabled() {
+		t.Fatal("explicitly enabled feature gate should allow hot-standby HA")
+	}
+}
+
+func TestReconcileStopsBeforeTopologyMutationWhenHotStandbyFeatureGateDisabled(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := antflyv1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	cluster := &antflyv1.AntflyCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "gated-ha", Namespace: "default"},
+		Spec: antflyv1.AntflyClusterSpec{
+			Mode:             antflyv1.ClusterModeStandalone,
+			HighAvailability: &antflyv1.HighAvailabilitySpec{Mode: antflyv1.HAModeHotStandby},
+		},
+	}
+	client := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(cluster).WithObjects(cluster).Build()
+	enabled := false
+	reconciler := &AntflyClusterReconciler{
+		Client: client, Scheme: scheme, Recorder: events.NewFakeRecorder(1), EnableHotStandbyHA: &enabled,
+	}
+
+	result, err := reconciler.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{
+		Name: cluster.Name, Namespace: cluster.Namespace,
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.RequeueAfter <= 0 {
+		t.Fatalf("expected gated HA reconciliation to back off, got %+v", result)
+	}
+
+	updated := &antflyv1.AntflyCluster{}
+	if err := client.Get(context.Background(), types.NamespacedName{Name: cluster.Name, Namespace: cluster.Namespace}, updated); err != nil {
+		t.Fatal(err)
+	}
+	condition := meta.FindStatusCondition(updated.Status.Conditions, antflyv1.TypeConfigurationValid)
+	if condition == nil || condition.Status != metav1.ConditionFalse || !strings.Contains(condition.Message, "--enable-hot-standby-ha=true") {
+		t.Fatalf("expected feature-gate validation condition, got %+v", condition)
+	}
+}

--- a/go/pkg/operator/docs/operations/hot-standby-ha.md
+++ b/go/pkg/operator/docs/operations/hot-standby-ha.md
@@ -5,6 +5,11 @@ clusters running in Standalone mode. It is separate from the Raft metadata HA pa
 hot standby is a single-primary data-plane strategy with one or more standby
 processes receiving and applying HA WAL records.
 
+> [!IMPORTANT]
+> Hot-standby HA is release-gated off by default. The operator must be started
+> with `--enable-hot-standby-ha=true` before it will admit or reconcile an
+> `AntflyCluster` with `spec.highAvailability.mode: HotStandby`.
+
 ## Control Surfaces
 
 Use the typed admin API for normal automation:

--- a/go/pkg/operator/internal/webhook/antfly/v1/antflycluster_validator.go
+++ b/go/pkg/operator/internal/webhook/antfly/v1/antflycluster_validator.go
@@ -2,17 +2,23 @@ package v1
 
 import (
 	"context"
+	"fmt"
 
 	antflyv1 "github.com/antflydb/antfly/go/pkg/operator/api/antfly/v1"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
 // AntflyClusterValidator implements admission.Validator for AntflyCluster.
-type AntflyClusterValidator struct{}
+type AntflyClusterValidator struct {
+	EnableHotStandbyHA bool
+}
 
 var _ admission.Validator[*antflyv1.AntflyCluster] = &AntflyClusterValidator{}
 
 func (v *AntflyClusterValidator) ValidateCreate(ctx context.Context, obj *antflyv1.AntflyCluster) (admission.Warnings, error) {
+	if err := v.validateHotStandbyFeatureGate(obj); err != nil {
+		return nil, err
+	}
 	return nil, obj.ValidateAntflyCluster()
 }
 
@@ -20,9 +26,24 @@ func (v *AntflyClusterValidator) ValidateUpdate(ctx context.Context, oldObj, new
 	if err := newObj.ValidateImmutability(oldObj); err != nil {
 		return nil, err
 	}
+	if err := v.validateHotStandbyFeatureGate(newObj); err != nil {
+		return nil, err
+	}
 	return nil, newObj.ValidateAntflyCluster()
 }
 
 func (v *AntflyClusterValidator) ValidateDelete(ctx context.Context, obj *antflyv1.AntflyCluster) (admission.Warnings, error) {
 	return nil, nil
+}
+
+func (v *AntflyClusterValidator) validateHotStandbyFeatureGate(obj *antflyv1.AntflyCluster) error {
+	if v.EnableHotStandbyHA || !hotStandbyHARequested(obj) {
+		return nil
+	}
+	return fmt.Errorf("hot-standby HA is disabled by the operator feature gate; restart the operator with --enable-hot-standby-ha=true to admit spec.highAvailability.mode=HotStandby")
+}
+
+func hotStandbyHARequested(obj *antflyv1.AntflyCluster) bool {
+	return obj != nil && obj.Spec.HighAvailability != nil &&
+		obj.Spec.HighAvailability.Mode == antflyv1.HAModeHotStandby
 }

--- a/go/pkg/operator/internal/webhook/antfly/v1/setup.go
+++ b/go/pkg/operator/internal/webhook/antfly/v1/setup.go
@@ -7,9 +7,9 @@ import (
 )
 
 // SetupWithManager registers all admission webhooks with the manager.
-func SetupWithManager(mgr ctrl.Manager) error {
+func SetupWithManager(mgr ctrl.Manager, enableHotStandbyHA bool) error {
 	if err := builder.WebhookManagedBy(mgr, &antflyv1.AntflyCluster{}).
-		WithValidator(&AntflyClusterValidator{}).
+		WithValidator(&AntflyClusterValidator{EnableHotStandbyHA: enableHotStandbyHA}).
 		Complete(); err != nil {
 		return err
 	}

--- a/go/pkg/operator/internal/webhook/antfly/v1/validators_test.go
+++ b/go/pkg/operator/internal/webhook/antfly/v1/validators_test.go
@@ -349,3 +349,35 @@ func TestAntflyClusterValidator_ValidateDelete(t *testing.T) {
 		t.Errorf("expected no warnings on delete, got: %v", warnings)
 	}
 }
+
+func TestAntflyClusterValidator_RejectsHotStandbyWhenFeatureGateDisabled(t *testing.T) {
+	v := &AntflyClusterValidator{}
+	cluster := &antflyv1.AntflyCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-cluster", Namespace: "default"},
+		Spec: antflyv1.AntflyClusterSpec{
+			HighAvailability: &antflyv1.HighAvailabilitySpec{Mode: antflyv1.HAModeHotStandby},
+		},
+	}
+
+	_, err := v.ValidateCreate(context.Background(), cluster)
+	if err == nil || !strings.Contains(err.Error(), "--enable-hot-standby-ha=true") {
+		t.Fatalf("expected disabled hot-standby feature-gate error, got %v", err)
+	}
+}
+
+func TestAntflyClusterValidator_AllowsDisablingHotStandbyWhenFeatureGateDisabled(t *testing.T) {
+	v := &AntflyClusterValidator{}
+	oldCluster := &antflyv1.AntflyCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-cluster", Namespace: "default"},
+		Spec: antflyv1.AntflyClusterSpec{
+			MetadataNodes:    antflyv1.MetadataNodesSpec{Replicas: 3},
+			HighAvailability: &antflyv1.HighAvailabilitySpec{Mode: antflyv1.HAModeHotStandby},
+		},
+	}
+	newCluster := oldCluster.DeepCopy()
+	newCluster.Spec.HighAvailability = nil
+
+	if _, err := v.ValidateUpdate(context.Background(), oldCluster, newCluster); err != nil {
+		t.Fatalf("expected disabling hot-standby HA to remain available, got %v", err)
+	}
+}

--- a/go/pkg/operator/manifests/rbac_test.go
+++ b/go/pkg/operator/manifests/rbac_test.go
@@ -67,6 +67,9 @@ func TestHAAdminTokenSecretInjectionManifestsAreAligned(t *testing.T) {
 	if deployment.Namespace != OperatorNamespace {
 		t.Fatalf("deployment namespace = %q, want %q", deployment.Namespace, OperatorNamespace)
 	}
+	if !containerHasArg(deployment.Spec.Template.Spec.Containers, "antfly-operator-manager", "--enable-hot-standby-ha=false") {
+		t.Fatal("deployment must keep hot-standby HA release-gated off by default")
+	}
 
 	tokenEnv, ok := findContainerEnv(deployment.Spec.Template.Spec.Containers, "antfly-operator-manager", "ANTFLY_HA_ADMIN_TOKEN")
 	if !ok {
@@ -137,6 +140,15 @@ func TestStorageAutoGrowRBACGrantsNodeProxyOnly(t *testing.T) {
 	if subject.Kind != "ServiceAccount" || subject.Name != ServiceAccountName || subject.Namespace != OperatorNamespace {
 		t.Fatalf("StorageAutoGrowClusterRoleBinding subject = %#v", subject)
 	}
+}
+
+func containerHasArg(containers []corev1.Container, containerName, arg string) bool {
+	for _, container := range containers {
+		if container.Name == containerName && containsString(container.Args, arg) {
+			return true
+		}
+	}
+	return false
 }
 
 func findContainerEnv(containers []corev1.Container, containerName string, envName string) (corev1.EnvVar, bool) {

--- a/zig/Makefile
+++ b/zig/Makefile
@@ -42,7 +42,7 @@ test: ## Run the default Zig test aggregate.
 	$(ZIG) build test
 
 unit-test: ## Run hermetic Antfly unit tests.
-	$(ZIG) build unit-test
+	$(ZIG) build unit-test $(ZIG_BUILD_FLAGS)
 
 clean-onnx: ## Remove downloaded ONNX Runtime files.
 	rm -rf $(ONNXRUNTIME_ROOT)

--- a/zig/build.zig
+++ b/zig/build.zig
@@ -1091,6 +1091,7 @@ pub fn build(b: *std.Build) void {
     const with_tla = b.option(bool, "with_tla", "Enable TLA+ trace instrumentation (ndjson event logging)") orelse false;
     const link_libc = b.option(bool, "link-libc", "Link Antfly runtime modules against libc") orelse true;
     const sanitize_thread = b.option(bool, "sanitize-thread", "Enable ThreadSanitizer for the Antfly runtime") orelse false;
+    const include_ha_tests_in_aggregates = b.option(bool, "ha-tests", "Include hot-standby HA suites in aggregate test steps") orelse true;
     const edition = b.option(BuildEdition, "edition", "Build edition: full or inference") orelse .full;
     const antfly_bin_name = b.option([]const u8, "antfly-bin-name", "Installed filename for the top-level Antfly CLI") orelse "antfly";
     if (antfly_bin_name.len == 0 or std.mem.indexOfAny(u8, antfly_bin_name, "/\\") != null) {
@@ -5035,7 +5036,9 @@ pub fn build(b: *std.Build) void {
     var chaos_progress_tail: ?*std.Build.Step = null;
     chaos_progress_tail = chainLabeledRun(b, lib_metadata_vopr_chaos_tests, "lib-metadata-vopr-chaos-test", chaos_progress_tail);
     chaos_progress_tail = chainLabeledRun(b, lib_lsm_backend_chaos_tests, "lib-lsm-backend-chaos-test", chaos_progress_tail);
-    chaos_progress_tail = chainLabeledRun(b, lib_ha_chaos_tests, "ha-chaos-test", chaos_progress_tail);
+    if (include_ha_tests_in_aggregates) {
+        chaos_progress_tail = chainLabeledRun(b, lib_ha_chaos_tests, "ha-chaos-test", chaos_progress_tail);
+    }
     chaos_test_step.dependOn(chaos_progress_tail.?);
 
     const chaos_soak_test_step = b.step("chaos-soak-test", "Run broad legacy metadata and raft chaos simulation soaks");
@@ -5286,7 +5289,9 @@ pub fn build(b: *std.Build) void {
     unit_test_step.dependOn(delegated_inference_steps.inference_test);
     unit_test_step.dependOn(delegated_inference_steps.inference_finetune_test);
     unit_test_step.dependOn(lib_standalone_runtime_test_step);
-    unit_test_step.dependOn(ha_test_step);
+    if (include_ha_tests_in_aggregates) {
+        unit_test_step.dependOn(ha_test_step);
+    }
     unit_test_step.dependOn(&run_raft_unit_tests.step);
     unit_test_step.dependOn(&run_raft_transport_tests.step);
 
@@ -6466,7 +6471,9 @@ pub fn build(b: *std.Build) void {
     run_compat.addArg("compat/cases");
     const compat_step = b.step("compat", "Run the shared compatibility corpus");
     compat_step.dependOn(&run_compat.step);
-    compat_step.dependOn(&run_lib_ha_compat_tests.step);
+    if (include_ha_tests_in_aggregates) {
+        compat_step.dependOn(&run_lib_ha_compat_tests.step);
+    }
 
     const search_benchmark_index_mod = b.createModule(.{
         .root_source_file = b.path("bench/full_text/search_benchmark_index.zig"),


### PR DESCRIPTION
Codex (GPT-5): Temporarily gates hot-standby HA off for the current Antfly release while preserving an explicit opt-in and manual verification path pending the paired Antfly and Colony changes.

## Why

Hot-standby HA is present on current Antfly `main`, but it is not release-ready until [antflydb/antfly#347](https://github.com/antflydb/antfly/pull/347) and [antflydb/colony#346](https://github.com/antflydb/colony/pull/346) land together. Required Zig aggregates also include the HA suites today, so HA-specific flakes can block an otherwise unrelated release build.

## What changed

- Add `--enable-hot-standby-ha`, defaulting to `false`, and pin the shipped operator Deployment manifest to `false`.
- Reject new or updated `spec.highAvailability.mode: HotStandby` resources at admission while disabled.
- Enforce the same boundary in the reconciler before finalizers, topology normalization, or workload mutation when webhooks are unavailable.
- Keep deletion and updates that disable HA available. Existing HA workloads are left untouched while the controller reports a `ConfigurationValid=False` status and backs off.
- Add `-Dha-tests` to Zig aggregate test selection. Required PR, push, merge-queue, and scheduled workflow runs pass `-Dha-tests=false`; manual workflow dispatch passes `-Dha-tests=true`.
- Keep standalone `ha-test`, `ha-chaos-test`, and HA compatibility targets available for explicit verification.

## Cloud boundary

Current Colony `main` does not yet expose the HA admission/configuration surface, so it remains effectively off without adding an unused environment variable in this release. Colony PR #346 owns the Cloud-side default-off `COLONY_CLOUD_HA_ADMISSION_ENABLED` boundary. The intended rollout is to merge the paired Colony #346 and Antfly #347 changes, verify that exact pair, then explicitly enable both gates.

## Impact

Non-HA clusters are unchanged. Hot-standby HA requests fail closed with an actionable message until the operator is restarted with `--enable-hot-standby-ha=true`. Required CI stops depending on the gated HA suites; manual and standalone HA validation remains available.

## Validation

- `GOCACHE=/private/tmp/antfly-ha-release-gate-full-gocache make test` from `go/pkg/operator` — passed, including generate, fmt, vet, and all Go tests.
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/zig-tests.yml` — passed.
- `zig build -Dha-tests=false --help` with isolated caches — passed; aggregate option and standalone HA targets are registered.
- `make -n zig-unit-test ZIG_BUILD_FLAGS=-Dha-tests=false` — confirmed the root Makefile forwards the gate into the Zig build.
- `git diff --check` — passed.

This intentionally does not address unrelated failures already present on `main`.
