### PR TITLE
Accept v1 Raft delta records

### DIFF
--- a/zig/build.zig
+++ b/zig/build.zig
@@ -1752,6 +1752,13 @@ pub fn build(b: *std.Build) void {
     });
     antfly_imports.configure(b, data_storage_test_mod, true, true);
 
+    const wal_replica_state_test_mod = b.createModule(.{
+        .root_source_file = b.path("pkg/antfly/src/wal_replica_state_test_root.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    antfly_imports.configure(b, wal_replica_state_test_mod, true, true);
+
     const usermgr_storage_lib_mod = b.createModule(.{
         .root_source_file = b.path("pkg/antfly/src/usermgr/storage_imports.zig"),
         .target = target,
@@ -3208,6 +3215,12 @@ pub fn build(b: *std.Build) void {
         .filters = selectTestFilters(b, &.{"raft."}),
     });
     const run_raft_unit_tests = b.addRunArtifact(raft_unit_tests);
+
+    const wal_v1_compat_tests = b.addTest(.{
+        .root_module = wal_replica_state_test_mod,
+        .filters = &.{"wal replica state replays version 1 ready deltas"},
+    });
+    const run_wal_v1_compat_tests = b.addRunArtifact(wal_v1_compat_tests);
 
     const raft_transport_tests = b.addTest(.{
         .root_module = lib_test_mod,
@@ -5275,11 +5288,13 @@ pub fn build(b: *std.Build) void {
 
     const raft_test_step = b.step("raft-test", "Run raft integration unit tests");
     raft_test_step.dependOn(&run_raft_unit_tests.step);
+    raft_test_step.dependOn(&run_wal_v1_compat_tests.step);
 
     const raft_transport_test_step = b.step("raft-transport-test", "Run raft transport unit tests");
     raft_transport_test_step.dependOn(&run_raft_transport_tests.step);
 
     unit_test_step.dependOn(&run_lib_regex_tests.step);
+    unit_test_step.dependOn(&run_wal_v1_compat_tests.step);
     unit_test_step.dependOn(&run_lib_jsonschema_tests.step);
     unit_test_step.dependOn(&run_lib_generating_tests.step);
     unit_test_step.dependOn(&run_lib_embeddings_tests.step);

--- a/zig/pkg/antfly/src/raft/storage/wal_replica_state.zig
+++ b/zig/pkg/antfly/src/raft/storage/wal_replica_state.zig
@@ -23,6 +23,7 @@ const storage_iface = raft_engine.runtime.storage_iface;
 const magic: u32 = 0x41524654; // ARFT
 const version: u32 = 2;
 const delta_magic: u32 = 0x4152444c; // ARDL
+const legacy_delta_version: u32 = 1;
 const delta_version: u32 = 2;
 const applied_watermark_magic: u32 = 0x4152574d; // ARWM
 const applied_watermark_version: u32 = 1;
@@ -614,7 +615,7 @@ pub const WalReplicaState = struct {
         var cursor: usize = 0;
         if (try readInt(u32, bytes, &cursor) != delta_magic) return error.InvalidReplicaState;
         const file_version = try readInt(u32, bytes, &cursor);
-        if (file_version != delta_version) return error.UnsupportedReplicaStateVersion;
+        if (file_version != legacy_delta_version and file_version != delta_version) return error.UnsupportedReplicaStateVersion;
 
         const kind_tag = if (cursor < bytes.len) bytes[cursor] else return error.InvalidReplicaState;
         cursor += 1;
@@ -652,7 +653,7 @@ pub const WalReplicaState = struct {
                     for (entries) |*entry| entry.* = try decodeEntry(self.alloc, bytes, &cursor);
                     try self.store.append(entries);
                 }
-                if (try readBool(bytes, &cursor)) {
+                if (file_version >= 2 and try readBool(bytes, &cursor)) {
                     var conf_state = try decodeConfState(self.alloc, bytes, &cursor);
                     defer conf_state.deinit(self.alloc);
                     try self.store.setConfState(conf_state);
@@ -826,6 +827,41 @@ pub const WalReplicaState = struct {
 
 test "wal replica state defaults to lsm backend" {
     try std.testing.expectEqual(wal_mod.StorageBackend.lsm, ((WalReplicaStateConfig{}).wal).resolvedBackend());
+}
+
+test "wal replica state replays version 1 ready deltas" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const root = try std.fmt.allocPrint(std.testing.allocator, ".zig-cache/tmp/{s}/wal-v1-delta", .{tmp.sub_path});
+    defer std.testing.allocator.free(root);
+
+    var layout = try storage_mod.ReplicaPathLayout.initForReplica(std.testing.allocator, root, 176, 3);
+    defer layout.deinit(std.testing.allocator);
+
+    var state = try WalReplicaState.init(std.testing.allocator, layout, .{});
+    defer state.deinit();
+
+    var delta = std.ArrayListUnmanaged(u8).empty;
+    defer delta.deinit(std.testing.allocator);
+    try WalReplicaState.appendInt(u32, std.testing.allocator, &delta, delta_magic);
+    try WalReplicaState.appendInt(u32, std.testing.allocator, &delta, legacy_delta_version);
+    try delta.append(std.testing.allocator, @intFromEnum(DeltaRecordKind.ready));
+    try WalReplicaState.appendBool(std.testing.allocator, &delta, true);
+    try WalReplicaState.appendInt(u64, std.testing.allocator, &delta, 2);
+    try WalReplicaState.appendBool(std.testing.allocator, &delta, true);
+    try WalReplicaState.appendInt(u64, std.testing.allocator, &delta, 3);
+    try WalReplicaState.appendInt(u64, std.testing.allocator, &delta, 1);
+    try WalReplicaState.appendBool(std.testing.allocator, &delta, false);
+    try WalReplicaState.appendInt(u32, std.testing.allocator, &delta, 0);
+
+    try state.decodeDeltaIntoStore(delta.items);
+
+    var initial = try state.storage().initialState(std.testing.allocator);
+    defer initial.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(u64, 2), initial.hard_state.current_term);
+    try std.testing.expectEqual(@as(?u64, 3), initial.hard_state.voted_for);
+    try std.testing.expectEqual(@as(u64, 1), initial.hard_state.commit_index);
 }
 
 test "wal replica state persists ready updates across reopen" {

--- a/zig/pkg/antfly/src/wal_replica_state_test_root.zig
+++ b/zig/pkg/antfly/src/wal_replica_state_test_root.zig
@@ -1,0 +1,17 @@
+// Copyright 2026 Antfly, Inc.
+//
+// Licensed under the Elastic License 2.0 (ELv2); you may not use this file
+// except in compliance with the Elastic License 2.0. You may obtain a copy of
+// the Elastic License 2.0 at
+//
+//     https://www.antfly.io/licensing/ELv2-license
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the Elastic License 2.0 is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// Elastic License 2.0 for the specific language governing permissions and
+// limitations.
+
+test {
+    _ = @import("raft/storage/wal_replica_state.zig");
+}


### PR DESCRIPTION
Codex (GPT-5):

## What changed

- accept both v1 and v2 Raft ready-delta records during WAL replay
- decode the optional persisted `conf_state` suffix only for v2 records
- add a dedicated compatibility test root so the regression is exercised by `raft-test` and the default unit aggregate

## Why

The v2 delta format added a `conf_state` suffix, but the decoder stopped accepting v1 records. During the dev rollout from `v0.2.0-rc.17` to `v0.2.0-rc.20`, a metadata replica with an rc.17 WAL failed at startup with `UnsupportedReplicaStateVersion`.

This preserves the existing v2 write format while restoring forward-read compatibility for WAL records written by rc.17.

## Validation

- `zig build root-test` — 222 passed
- `zig build raft-test` — passed
- negative control: reverting the decoder acceptance caused the dedicated test to fail with `UnsupportedReplicaStateVersion`

The live dev rollout remains paused safely with two healthy old metadata replicas while this fix builds.
