### PR TITLE
Fix S3 document fetch hangs

### DIFF
--- a/zig/lib/httpx/src/client/client.zig
+++ b/zig/lib/httpx/src/client/client.zig
@@ -2834,6 +2834,39 @@ const python_tls_fixed_keepalive_server_script =
     "            continue\n" ++
     "listener.close()\n";
 
+const python_tls_head_keepalive_server_script =
+    "import socket\n" ++
+    "import ssl\n" ++
+    "import sys\n" ++
+    "import time\n" ++
+    "\n" ++
+    "port = int(sys.argv[1])\n" ++
+    "cert = sys.argv[2]\n" ++
+    "key = sys.argv[3]\n" ++
+    "listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)\n" ++
+    "listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)\n" ++
+    "listener.bind(('127.0.0.1', port))\n" ++
+    "listener.listen(1)\n" ++
+    "ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)\n" ++
+    "ctx.load_cert_chain(certfile=cert, keyfile=key)\n" ++
+    "conn, _ = listener.accept()\n" ++
+    "with conn:\n" ++
+    "    with ctx.wrap_socket(conn, server_side=True) as tls_conn:\n" ++
+    "        data = b''\n" ++
+    "        while b'\\r\\n\\r\\n' not in data:\n" ++
+    "            chunk = tls_conn.recv(4096)\n" ++
+    "            if not chunk:\n" ++
+    "                break\n" ++
+    "            data += chunk\n" ++
+    "        tls_conn.sendall(\n" ++
+    "            b'HTTP/1.1 403 Forbidden\\r\\n'\n" ++
+    "            b'Content-Length: 243\\r\\n'\n" ++
+    "            b'Content-Type: application/xml\\r\\n'\n" ++
+    "            b'Connection: keep-alive\\r\\n\\r\\n'\n" ++
+    "        )\n" ++
+    "        time.sleep(2.0)\n" ++
+    "listener.close()\n";
+
 const python_slow_drip_server_script =
     "import socket\n" ++
     "import sys\n" ++
@@ -3233,6 +3266,59 @@ test "HTTPS client streams fixed content-length body with keep-alive to writer" 
     try std.testing.expectEqual(@as(u16, 200), resp.status.code);
     try std.testing.expectEqual(@as(usize, 16 * 16384), out.items.len);
     try std.testing.expect(resp.body == null);
+}
+
+test "HTTPS HEAD returns after headers on a keep-alive connection" {
+    const allocator = std.testing.allocator;
+    const io = std.testing.io;
+
+    const port = try reserveEphemeralPort(io);
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.writeFile(io, .{ .sub_path = "cert.pem", .data = test_tls_cert_pem });
+    try tmp.dir.writeFile(io, .{ .sub_path = "key.pem", .data = test_tls_key_pem });
+    try tmp.dir.writeFile(io, .{ .sub_path = "server.py", .data = python_tls_head_keepalive_server_script });
+
+    var port_buf: [16]u8 = undefined;
+    const port_arg = try std.fmt.bufPrint(&port_buf, "{d}", .{port});
+
+    var child = std.process.spawn(io, .{
+        .argv = &.{
+            "python3",
+            "server.py",
+            port_arg,
+            "cert.pem",
+            "key.pem",
+        },
+        .cwd = .{ .dir = tmp.dir },
+        .stdin = .ignore,
+        .stdout = .inherit,
+        .stderr = .inherit,
+    }) catch |err| switch (err) {
+        error.FileNotFound => return,
+        else => return err,
+    };
+    defer child.kill(io);
+
+    io.sleep(Io.Duration.fromMilliseconds(500), .awake) catch {};
+
+    const url = try std.fmt.allocPrint(allocator, "https://127.0.0.1:{d}/object", .{port});
+    defer allocator.free(url);
+
+    var client = Client.initWithConfig(allocator, io, .{
+        .verify_ssl = false,
+        .retry_policy = .{ .max_retries = 0 },
+        .timeouts = .{ .request_ms = 500, .read_ms = 500, .write_ms = 500 },
+    });
+    defer client.deinit();
+
+    var resp = try client.head(url, .{});
+    defer resp.deinit();
+
+    try std.testing.expectEqual(@as(u16, 403), resp.status.code);
+    try std.testing.expect(resp.body == null);
+    try std.testing.expectEqualStrings("243", resp.headers.get(HeaderName.CONTENT_LENGTH).?);
 }
 
 // Tests for decompressBody and responseFromParser were removed — these methods

--- a/zig/lib/httpx/src/tls/tls.zig
+++ b/zig/lib/httpx/src/tls/tls.zig
@@ -300,12 +300,16 @@ pub const TlsSession = struct {
 
     /// Reads decrypted data from the session.
     pub fn read(self: *Self, buffer: []u8) !usize {
+        if (buffer.len == 0) return 0;
         const c = if (self.client) |*c| c else return error.NotConnected;
-        var iov = [_][]u8{buffer};
-        return c.reader.readVec(&iov) catch |err| switch (err) {
-            error.EndOfStream => 0,
-            else => error.ReadFailed,
+        const available = c.reader.peekGreedy(1) catch |err| switch (err) {
+            error.EndOfStream => return 0,
+            else => return error.ReadFailed,
         };
+        const len = @min(buffer.len, available.len);
+        @memcpy(buffer[0..len], available[0..len]);
+        c.reader.toss(len);
+        return len;
     }
 
     /// Writes data to be encrypted and sent.

--- a/zig/lib/objectstore/src/s3.zig
+++ b/zig/lib/objectstore/src/s3.zig
@@ -1241,7 +1241,7 @@ fn byteRangeHeaderAlloc(alloc: Allocator, range: types.ByteRange) ![]u8 {
 fn currentUnixSeconds() u64 {
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
-    const now = std.Io.Timestamp.now(io_impl.io(), .awake);
+    const now = std.Io.Timestamp.now(io_impl.io(), .real);
     const ns: u64 = @intCast(now.toNanoseconds());
     return ns / std.time.ns_per_s;
 }
@@ -1256,7 +1256,7 @@ fn formatAmzDateAlloc(alloc: Allocator, unix_seconds: u64) ![]u8 {
         "{d:0>4}{d:0>2}{d:0>2}T{d:0>2}{d:0>2}{d:0>2}Z",
         .{
             year_day.year,
-            @intFromEnum(month_day.month) + 1,
+            @intFromEnum(month_day.month),
             month_day.day_index + 1,
             day_seconds.getHoursIntoDay(),
             day_seconds.getMinutesIntoHour(),
@@ -1274,7 +1274,7 @@ fn formatScopeDateAlloc(alloc: Allocator, unix_seconds: u64) ![]u8 {
         "{d:0>4}{d:0>2}{d:0>2}",
         .{
             year_day.year,
-            @intFromEnum(month_day.month) + 1,
+            @intFromEnum(month_day.month),
             month_day.day_index + 1,
         },
     );
@@ -1284,6 +1284,29 @@ fn asciiLowerAlloc(alloc: Allocator, input: []const u8) ![]u8 {
     const out = try alloc.dupe(u8, input);
     _ = std.ascii.lowerString(out, out);
     return out;
+}
+
+test "s3 signing timestamp uses Unix wall clock" {
+    var io_impl = std.Io.Threaded.init(std.testing.allocator, .{});
+    defer io_impl.deinit();
+
+    const before: u64 = @intCast(std.Io.Timestamp.now(io_impl.io(), .real).toSeconds());
+    const actual = currentUnixSeconds();
+    const after: u64 = @intCast(std.Io.Timestamp.now(io_impl.io(), .real).toSeconds());
+
+    try std.testing.expect(actual >= before);
+    try std.testing.expect(actual <= after);
+}
+
+test "s3 signing dates use calendar month numbers" {
+    const alloc = std.testing.allocator;
+    const amz_date = try formatAmzDateAlloc(alloc, 0);
+    defer alloc.free(amz_date);
+    const scope_date = try formatScopeDateAlloc(alloc, 0);
+    defer alloc.free(scope_date);
+
+    try std.testing.expectEqualStrings("19700101T000000Z", amz_date);
+    try std.testing.expectEqualStrings("19700101", scope_date);
 }
 
 fn encodeUriComponentAlloc(alloc: Allocator, input: []const u8, encode_slash: bool) ![]u8 {


### PR DESCRIPTION
> ## Summary
> 
> - return already-decrypted TLS bytes instead of blocking while trying to fill the caller's buffer
> - add a TLS HEAD/keep-alive regression test
> - use the wall clock and correct calendar month numbering for S3 SigV4 timestamps
> - add regression coverage for S3 signing time and date formatting
> 
> ## Root cause
> 
> Credentialed S3 document extraction issued a signed HEAD request. The small TLS response was buffered, but the TLS reader waited for additional bytes even though a keep-alive HEAD response has no body. This wedged the enrichment worker.
> 
> After fixing the read, DigitalOcean Spaces exposed two SigV4 timestamp regressions: signing used the monotonic clock rather than Unix wall time, and the formatter added one to Zig's already one-based month enum.
> 
> ## Impact
> 
> S3 backfill document extraction now completes without wedging the worker. Invalid credentials produce a failure manifest, and valid DigitalOcean Spaces documents are downloaded and extracted normally.
> 
> ## Validation
> 
> - exact reported fake-credential repro produces a failure manifest and the following HTTPS document completes
> - real DigitalOcean Spaces Markdown converges with 1 unit / 3 chunks
> - real DigitalOcean Spaces DOCX converges with 3 units / 110 chunks
> - `zig build lib-httpx-test`
> - standalone objectstore tests
> - `make build`
> - `git diff --check`
> 