### PR TITLE
Optimize Metal SDPA with bounded-barrier dispatch

### DIFF
--- a/zig/pkg/inference/src/backends/metal_kernels.m
+++ b/zig/pkg/inference/src/backends/metal_kernels.m
@@ -375,6 +375,7 @@ typedef struct termite_metal_decode_runtime {
     id<MTLComputePipelineState> argmax_axis_f32_pipeline;
     id<MTLComputePipelineState> convert_dtype_f32_pipeline;
     id<MTLComputePipelineState> sdpa_f32_pipeline;
+    id<MTLComputePipelineState> sdpa_f32_tg_pipeline;
     id<MTLComputePipelineState> florence_window_pack_f32_pipeline;
     id<MTLComputePipelineState> florence_window_unpack_f32_pipeline;
     id<MTLComputePipelineState> florence_channel_scores_f32_pipeline;
@@ -1062,6 +1063,7 @@ typedef struct termite_metal_decode_runtime_memory_stats {
 } termite_metal_decode_runtime_memory_stats;
 
 static NSUInteger termite_metal_thread_width(id<MTLComputePipelineState> pipeline, size_t dim);
+static NSUInteger termite_metal_sdpa_thread_width(id<MTLComputePipelineState> pipeline, size_t seq_len, size_t head_dim);
 static NSUInteger termite_metal_threadgroup_memory_16(NSUInteger bytes);
 static uint64_t termite_metal_clock_monotonic_nanos(void);
 static id<MTLDevice> termite_metal_shared_device(void);
@@ -4184,6 +4186,33 @@ static NSString *termite_metal_shader_source(void) {
            "        float w = exp(score - best); sum += w; accum += w * v[v_base + d];\n"
            "    }\n"
            "    output[gid] = sum > 0.0f ? accum / sum : 0.0f;\n"
+           "}\n"
+           "kernel void termite_sdpa_f32_tg(device const float *q [[buffer(0)]], device const float *k [[buffer(1)]], device const float *v [[buffer(2)]], device const float *bias [[buffer(3)]], device const float *mask [[buffer(4)]], device float *output [[buffer(5)]], constant termite_metal_sdpa_f32_params &p [[buffer(6)]], threadgroup float *scratch [[threadgroup(0)]], ushort tid [[thread_index_in_threadgroup]], uint3 tpg [[threads_per_threadgroup]], uint3 tg [[threadgroup_position_in_grid]]) {\n"
+           "    if (p.seq_len == 0u || p.num_heads == 0u || p.head_dim == 0u) return;\n"
+           "    uint row = tg.x; uint qi = row % p.seq_len; uint tmp = row / p.seq_len; uint h = tmp % p.num_heads; uint b = tmp / p.num_heads; if (b >= p.batch) return;\n"
+           "    uint lid = uint(tid); uint width = uint(tpg.x); uint hidden = p.num_heads * p.head_dim; uint bh = b * p.num_heads + h;\n"
+           "    uint q_base = p.layout == 1u ? (b * p.seq_len + qi) * hidden + h * p.head_dim : (bh * p.seq_len + qi) * p.head_dim;\n"
+           "    threadgroup float *scores = scratch; threadgroup float *partials = scratch + p.seq_len; const float neg_inf = -3.402823466e+38f; float scale = rsqrt(float(p.head_dim)); float local_best = neg_inf;\n"
+           "    for (uint ki = lid; ki < p.seq_len; ki += width) {\n"
+           "        bool allowed = p.has_mask == 0u || mask[b * p.seq_len + ki] != 0.0f; float score = neg_inf;\n"
+           "        if (allowed) {\n"
+           "            uint k_base = p.layout == 1u ? (b * p.seq_len + ki) * hidden + h * p.head_dim : (bh * p.seq_len + ki) * p.head_dim; float dot = 0.0f;\n"
+           "            for (uint d = 0u; d < p.head_dim; ++d) dot += q[q_base + d] * k[k_base + d];\n"
+           "            score = dot * scale;\n"
+           "            if (p.bias_mode == 1u) score += bias[(h * p.seq_len + qi) * p.seq_len + ki];\n"
+           "            else if (p.bias_mode == 2u) score += bias[(bh * p.seq_len + qi) * p.seq_len + ki];\n"
+           "            else if (p.bias_mode == 3u) score += bias[(b * p.seq_len + qi) * p.seq_len + ki];\n"
+           "            local_best = max(local_best, score);\n"
+           "        }\n"
+           "        scores[ki] = score;\n"
+           "    }\n"
+           "    partials[lid] = local_best; threadgroup_barrier(mem_flags::mem_threadgroup);\n"
+           "    for (uint stride = width >> 1u; stride > 0u; stride >>= 1u) { if (lid < stride) partials[lid] = max(partials[lid], partials[lid + stride]); threadgroup_barrier(mem_flags::mem_threadgroup); }\n"
+           "    float best = partials[0];\n"
+           "    // Preserve scalar weight-sum and final-division order so Florence cached/full greedy decode remains token-identical.\n"
+           "    if (lid == 0u) { float denom = 0.0f; for (uint ki = 0u; ki < p.seq_len; ++ki) { float score = scores[ki]; float weight = score > neg_inf ? exp(score - best) : 0.0f; scores[ki] = weight; denom += weight; } partials[0] = denom; } threadgroup_barrier(mem_flags::mem_threadgroup);\n"
+           "    float denom = partials[0];\n"
+           "    for (uint d = lid; d < p.head_dim; d += width) { float accum = 0.0f; for (uint ki = 0u; ki < p.seq_len; ++ki) { uint v_base = p.layout == 1u ? (b * p.seq_len + ki) * hidden + h * p.head_dim : (bh * p.seq_len + ki) * p.head_dim; accum += scores[ki] * v[v_base + d]; } output[q_base + d] = denom > 0.0f ? accum / denom : 0.0f; }\n"
            "}\n"
            "kernel void termite_florence_window_pack_f32(device const float *input [[buffer(0)]], device float *output [[buffer(1)]], constant termite_metal_florence_window_params &p [[buffer(2)]], uint gid [[thread_position_in_grid]]) {\n"
            "    uint total = p.window_count * p.window_area * p.dim; if (gid >= total || p.dim == 0u || p.window_size == 0u) return;\n"
@@ -13086,6 +13115,7 @@ termite_metal_decode_runtime *termite_metal_decode_runtime_create(void) {
         runtime->argmax_axis_f32_pipeline = termite_metal_make_pipeline(device, precise_library, @"termite_argmax_axis_f32");
         runtime->convert_dtype_f32_pipeline = termite_metal_make_pipeline(device, precise_library, @"termite_convert_dtype_f32");
         runtime->sdpa_f32_pipeline = termite_metal_make_pipeline(device, precise_library, @"termite_sdpa_f32");
+        runtime->sdpa_f32_tg_pipeline = termite_metal_make_pipeline(device, precise_library, @"termite_sdpa_f32_tg");
         runtime->florence_window_pack_f32_pipeline = termite_metal_make_pipeline(device, precise_library, @"termite_florence_window_pack_f32");
         runtime->florence_window_unpack_f32_pipeline = termite_metal_make_pipeline(device, precise_library, @"termite_florence_window_unpack_f32");
         runtime->florence_channel_scores_f32_pipeline = termite_metal_make_pipeline(device, precise_library, @"termite_florence_channel_scores_f32");
@@ -13550,6 +13580,7 @@ void termite_metal_decode_runtime_destroy(termite_metal_decode_runtime *runtime)
     runtime->argmax_axis_f32_pipeline = nil;
     runtime->convert_dtype_f32_pipeline = nil;
     runtime->sdpa_f32_pipeline = nil;
+    runtime->sdpa_f32_tg_pipeline = nil;
     runtime->florence_window_pack_f32_pipeline = nil;
     runtime->florence_window_unpack_f32_pipeline = nil;
     runtime->florence_channel_scores_f32_pipeline = nil;
@@ -25461,6 +25492,16 @@ int termite_metal_decode_runtime_sdpa_f32_device(
             .layout = layout,
             .reserved1 = 0,
         };
+        const NSUInteger tg_width = termite_metal_sdpa_thread_width(runtime->sdpa_f32_tg_pipeline, seq_len, head_dim);
+        const NSUInteger tg_scratch_bytes = tg_width > 0u
+            ? termite_metal_threadgroup_memory_16((seq_len + tg_width) * sizeof(float))
+            : 0u;
+        const BOOL use_tg = getenv("TERMITE_METAL_DISABLE_SDPA_TG") == NULL &&
+            runtime->sdpa_f32_tg_pipeline != nil &&
+            tg_width > 0u &&
+            tg_scratch_bytes <= runtime->device.maxThreadgroupMemoryLength;
+        if (!use_tg && getenv("TERMITE_METAL_REQUIRE_SDPA_TG") != NULL) return -18;
+        id<MTLComputePipelineState> pipeline = use_tg ? runtime->sdpa_f32_tg_pipeline : runtime->sdpa_f32_pipeline;
         bool frame_owned = true;
         id<MTLCommandBuffer> command_buffer = termite_metal_decode_runtime_command_buffer(runtime, __func__, &frame_owned);
         if (command_buffer == nil) return -14;
@@ -25482,7 +25523,7 @@ int termite_metal_decode_runtime_sdpa_f32_device(
         BOOL encoder_owned = YES;
         id<MTLComputeCommandEncoder> encoder = termite_metal_scoped_compute_encoder_for(runtime, command_buffer, TERMITE_METAL_COMPUTE_SOURCE_ATTENTION, &encoder_owned);
         if (encoder == nil) return -15;
-        [encoder setComputePipelineState:runtime->sdpa_f32_pipeline];
+        [encoder setComputePipelineState:pipeline];
         [encoder setBuffer:q_buffer offset:q_offset atIndex:0];
         [encoder setBuffer:k_buffer offset:k_offset atIndex:1];
         [encoder setBuffer:v_buffer offset:v_offset atIndex:2];
@@ -25490,8 +25531,14 @@ int termite_metal_decode_runtime_sdpa_f32_device(
         [encoder setBuffer:mask_buffer offset:mask_offset atIndex:4];
         [encoder setBuffer:output_buffer offset:output_offset atIndex:5];
         [encoder setBytes:&params length:sizeof(params) atIndex:6];
-        [encoder dispatchThreads:MTLSizeMake(total, 1, 1)
-           threadsPerThreadgroup:MTLSizeMake(termite_metal_thread_width(runtime->sdpa_f32_pipeline, total), 1, 1)];
+        if (use_tg) {
+            [encoder setThreadgroupMemoryLength:tg_scratch_bytes atIndex:0];
+            [encoder dispatchThreadgroups:MTLSizeMake(batch * num_heads * seq_len, 1, 1)
+                       threadsPerThreadgroup:MTLSizeMake(tg_width, 1, 1)];
+        } else {
+            [encoder dispatchThreads:MTLSizeMake(total, 1, 1)
+               threadsPerThreadgroup:MTLSizeMake(termite_metal_thread_width(runtime->sdpa_f32_pipeline, total), 1, 1)];
+        }
         termite_metal_end_scoped_compute_encoder(encoder, encoder_owned);
         return termite_metal_decode_runtime_finish_command_buffer(command_buffer, frame_owned, -16);
     }
@@ -33925,6 +33972,21 @@ static NSUInteger termite_metal_thread_width(id<MTLComputePipelineState> pipelin
     if (thread_width == 0) thread_width = 64;
     if (dim > 0 && thread_width > dim) thread_width = dim;
     return thread_width;
+}
+
+static NSUInteger termite_metal_sdpa_thread_width(id<MTLComputePipelineState> pipeline, size_t seq_len, size_t head_dim) {
+    if (pipeline == nil) return 0;
+    NSUInteger max_width = pipeline.maxTotalThreadsPerThreadgroup;
+    if (max_width == 0u) return 0;
+    NSUInteger width = pipeline.threadExecutionWidth;
+    if (width == 0u) width = 32u;
+    const size_t work = seq_len > head_dim ? seq_len : head_dim;
+    while (width < 256u && width < max_width && width < work) {
+        const NSUInteger next = width << 1u;
+        if (next > max_width) break;
+        width = next;
+    }
+    return width;
 }
 
 static NSUInteger termite_metal_threadgroup_memory_16(NSUInteger bytes) {

--- a/zig/pkg/inference/src/backends/metal_runtime.zig
+++ b/zig/pkg/inference/src/backends/metal_runtime.zig
@@ -4215,6 +4215,17 @@ pub fn decoderRuntimeConvertDTypeF32Device(self: anytype, input: MetalTensor, ki
     return output_device;
 }
 
+fn metalSdpaRuntimeSucceeded(rc: c_int) !bool {
+    if (rc == -18) return error.MetalSdpaThreadgroupRequired;
+    return rc == 0;
+}
+
+test "metal runtime SDPA required threadgroup failure does not fall back" {
+    try std.testing.expect(try metalSdpaRuntimeSucceeded(0));
+    try std.testing.expect(!(try metalSdpaRuntimeSucceeded(-1)));
+    try std.testing.expectError(error.MetalSdpaThreadgroupRequired, metalSdpaRuntimeSucceeded(-18));
+}
+
 pub fn decoderRuntimeSdpaF32Device(self: anytype, request: anytype) !?MetalTensor {
     const runtime = self.raw_decode_runtime orelse return null;
     if (termite_metal_decode_runtime_ready(runtime) == 0) return null;
@@ -4279,7 +4290,7 @@ pub fn decoderRuntimeSdpaF32Device(self: anytype, request: anytype) !?MetalTenso
         output_device.deviceHandle(),
         output_device.deviceByteOffset(),
     );
-    if (rc != 0) return null;
+    if (!try metalSdpaRuntimeSucceeded(rc)) return null;
     return output_device;
 }
 

--- a/zig/pkg/inference/src/ops/metal_compute.zig
+++ b/zig/pkg/inference/src/ops/metal_compute.zig
@@ -22902,6 +22902,14 @@ test "metal_compute: scaled dot product attention handles Florence window layout
     try expectUniformMetalSdpa(std.testing.allocator, 6, 49, 8, 32, false);
 }
 
+test "metal_compute: scaled dot product attention strides keys and output dimensions" {
+    if (!build_options.enable_metal) return error.SkipZigTest;
+    if (!@import("../backends/metal_runtime.zig").metalDeviceAvailable()) return error.SkipZigTest;
+
+    try expectUniformMetalSdpa(std.testing.allocator, 1, 257, 1, 1, false);
+    try expectUniformMetalSdpa(std.testing.allocator, 1, 1, 1, 257, false);
+}
+
 test "metal_compute: linearTriple is owned by metal backend" {
     if (!build_options.enable_metal) return error.SkipZigTest;
     if (!@import("../backends/metal_runtime.zig").metalDeviceAvailable()) return error.SkipZigTest;

--- a/zig/pkg/inference/src/ops/metal_compute.zig
+++ b/zig/pkg/inference/src/ops/metal_compute.zig
@@ -22653,6 +22653,7 @@ fn expectUniformMetalSdpa(
     head_dim: usize,
     masked: bool,
 ) !void {
+    const key_step: f32 = 0.01;
     const hidden = num_heads * head_dim;
     const total = batch * seq_len * hidden;
     const qkv_shape = [_]i32{ @intCast(batch * seq_len), @intCast(hidden) };
@@ -22680,7 +22681,7 @@ fn expectUniformMetalSdpa(
                     v_data[idx] =
                         @as(f32, @floatFromInt(b)) * 0.1 +
                         @as(f32, @floatFromInt(h)) * 0.01 +
-                        @as(f32, @floatFromInt(ki)) * 0.001 +
+                        @as(f32, @floatFromInt(ki)) * key_step +
                         @as(f32, @floatFromInt(d)) * 0.0001;
                 }
             }
@@ -22716,7 +22717,7 @@ fn expectUniformMetalSdpa(
                     const expected =
                         @as(f32, @floatFromInt(b)) * 0.1 +
                         @as(f32, @floatFromInt(h)) * 0.01 +
-                        mean_ki * 0.001 +
+                        mean_ki * key_step +
                         @as(f32, @floatFromInt(d)) * 0.0001;
                     try std.testing.expectApproxEqAbs(expected, out_data[idx], 5e-4);
                 }

--- a/zig/pkg/inference/src/ops/metal_compute.zig
+++ b/zig/pkg/inference/src/ops/metal_compute.zig
@@ -22645,6 +22645,86 @@ test "metal_compute: divideConsumeLeft uploads equal-size host rhs instead of do
     try std.testing.expectEqualSlices(f32, &.{ 1, 2, 3, 2, 2, 8 }, out_data);
 }
 
+fn expectUniformMetalSdpa(
+    allocator: std.mem.Allocator,
+    batch: usize,
+    seq_len: usize,
+    num_heads: usize,
+    head_dim: usize,
+    masked: bool,
+) !void {
+    const hidden = num_heads * head_dim;
+    const total = batch * seq_len * hidden;
+    const qkv_shape = [_]i32{ @intCast(batch * seq_len), @intCast(hidden) };
+
+    const q_data = try allocator.alloc(f32, total);
+    defer allocator.free(q_data);
+    @memset(q_data, 0.0);
+    const k_data = try allocator.alloc(f32, total);
+    defer allocator.free(k_data);
+    @memset(k_data, 0.0);
+    const v_data = try allocator.alloc(f32, total);
+    defer allocator.free(v_data);
+    const mask = try allocator.alloc(i64, if (masked) batch * seq_len else 0);
+    defer allocator.free(mask);
+
+    for (0..batch) |b| {
+        const allowed = if (masked) 1 + (b % @min(seq_len, 17)) else seq_len;
+        if (masked) {
+            for (0..seq_len) |ki| mask[b * seq_len + ki] = if (ki < allowed) 1 else 0;
+        }
+        for (0..seq_len) |ki| {
+            for (0..num_heads) |h| {
+                for (0..head_dim) |d| {
+                    const idx = (b * seq_len + ki) * hidden + h * head_dim + d;
+                    v_data[idx] =
+                        @as(f32, @floatFromInt(b)) * 0.1 +
+                        @as(f32, @floatFromInt(h)) * 0.01 +
+                        @as(f32, @floatFromInt(ki)) * 0.001 +
+                        @as(f32, @floatFromInt(d)) * 0.0001;
+                }
+            }
+        }
+    }
+
+    var metal_ws = testMetalWeightStoreInit(allocator);
+    defer metal_ws.lazy_weights.deinit(allocator);
+    var metal_compute = try MetalCompute.init(allocator, &metal_ws, null);
+    defer metal_compute.deinit();
+    var metal_cb = metal_compute.computeBackend();
+
+    const q = try metal_cb.fromFloat32Shape(q_data, &qkv_shape);
+    defer metal_cb.free(q);
+    const k = try metal_cb.fromFloat32Shape(k_data, &qkv_shape);
+    defer metal_cb.free(k);
+    const v = try metal_cb.fromFloat32Shape(v_data, &qkv_shape);
+    defer metal_cb.free(v);
+
+    const out = try metal_cb.scaledDotProductAttention(q, k, v, mask, null, batch, seq_len, num_heads, head_dim);
+    defer metal_cb.free(out);
+    try std.testing.expect(MetalCompute.debugHasDeviceTensor(&metal_cb, out));
+
+    const out_data = try metal_cb.toFloat32(out, allocator);
+    defer allocator.free(out_data);
+    for ([_]usize{ 0, batch / 2, batch - 1 }) |b| {
+        const allowed = if (masked) 1 + (b % @min(seq_len, 17)) else seq_len;
+        const mean_ki = @as(f32, @floatFromInt(allowed - 1)) * 0.5;
+        for ([_]usize{ 0, num_heads - 1 }) |h| {
+            for ([_]usize{ 0, seq_len / 2, seq_len - 1 }) |qi| {
+                for ([_]usize{ 0, head_dim - 1 }) |d| {
+                    const idx = (b * seq_len + qi) * hidden + h * head_dim + d;
+                    const expected =
+                        @as(f32, @floatFromInt(b)) * 0.1 +
+                        @as(f32, @floatFromInt(h)) * 0.01 +
+                        mean_ki * 0.001 +
+                        @as(f32, @floatFromInt(d)) * 0.0001;
+                    try std.testing.expectApproxEqAbs(expected, out_data[idx], 5e-4);
+                }
+            }
+        }
+    }
+}
+
 test "metal_compute: scaled dot product attention fallback preserves shape and values" {
     if (!build_options.enable_metal) return error.SkipZigTest;
     if (!@import("../backends/metal_runtime.zig").metalDeviceAvailable()) return error.SkipZigTest;
@@ -22806,6 +22886,20 @@ test "metal_compute: scaled dot product attention supports seq-major interleaved
     for (expected, out_data) |expected_value, actual_value| {
         try std.testing.expectApproxEqAbs(expected_value, actual_value, 1e-4);
     }
+}
+
+test "metal_compute: scaled dot product attention handles BGE-scale masked batches" {
+    if (!build_options.enable_metal) return error.SkipZigTest;
+    if (!@import("../backends/metal_runtime.zig").metalDeviceAvailable()) return error.SkipZigTest;
+
+    try expectUniformMetalSdpa(std.testing.allocator, 50, 128, 12, 64, true);
+}
+
+test "metal_compute: scaled dot product attention handles Florence window layout" {
+    if (!build_options.enable_metal) return error.SkipZigTest;
+    if (!@import("../backends/metal_runtime.zig").metalDeviceAvailable()) return error.SkipZigTest;
+
+    try expectUniformMetalSdpa(std.testing.allocator, 6, 49, 8, 32, false);
 }
 
 test "metal_compute: linearTriple is owned by metal backend" {


### PR DESCRIPTION
## Summary

Stacked on #388.

- keeps the known-good per-output SDPA kernel as a runtime fallback
- adds a cooperative Metal SDPA kernel that partitions keys across lanes and reduces the row max once, avoiding #349 per-key 256-lane reductions and barriers
- chooses a power-of-two threadgroup width from the pipeline execution width, capped at 256
- preserves scalar softmax accumulation and final division order so Florence cached/full greedy decoding remains token-identical
- adds BGE-scale masked-batch and Florence window-shape Metal tests

`TERMITE_METAL_DISABLE_SDPA_TG=1` forces the #388 fallback. `TERMITE_METAL_REQUIRE_SDPA_TG=1` is available for validation so tests cannot silently fall back.

## Validation

- `TERMITE_METAL_REQUIRE_SDPA_TG=1 zig build test -Doptimize=ReleaseSafe -- --test-filter "scaled dot product attention"`: 30/30 passed
- `TERMITE_METAL_DISABLE_SDPA_TG=1 zig build test -Doptimize=ReleaseSafe -- --test-filter "scaled dot product attention"`: 30/30 passed
- `zig build install -Dedition=full -Doptimize=ReleaseSafe --summary all`: 12/12 steps succeeded
- Florence-2 Q4_K canonical 32-token Metal gate, warmup 1 / measure 3: exact cached/full output parity; cached p50 3.582s, full p50 4.900s, 1.368x speedup
- synthetic BGE shape: batch 50, seq 128, 12 heads, head dim 64, heavily masked

## Follow-up validation

The private seven-table issue #386 harness and BGE model used for #388 50/50 run were not available in this checkout. Please rerun that exact harness against this stacked branch before merging it into #388.