### PR TITLE
Fix PDF OCR review blockers

### DIFF
--- a/zig/lib/pdf/src/reader.zig
+++ b/zig/lib/pdf/src/reader.zig
@@ -4868,7 +4868,7 @@ fn applyStreamFilterAlloc(
         }
         const inflated = try inflated_list.toOwnedSlice(alloc);
         defer alloc.free(inflated);
-        const decoded = try applyPredictorAlloc(alloc, inflated, param);
+        const decoded = try applyPredictorAlloc(alloc, inflated, param, max_decoded_stream_bytes);
         return try enforceDecodedStreamLimit(alloc, decoded, max_decoded_stream_bytes);
     }
     if (std.mem.eql(u8, name, "ASCIIHexDecode")) {
@@ -4876,8 +4876,7 @@ fn applyStreamFilterAlloc(
         return try enforceDecodedStreamLimit(alloc, decoded, max_decoded_stream_bytes);
     }
     if (std.mem.eql(u8, name, "ASCII85Decode")) {
-        const decoded = try ascii85DecodeAlloc(alloc, input);
-        return try enforceDecodedStreamLimit(alloc, decoded, max_decoded_stream_bytes);
+        return try ascii85DecodeAlloc(alloc, input, max_decoded_stream_bytes);
     }
     if (std.mem.eql(u8, name, "LZWDecode")) {
         return try lzwDecodeAlloc(alloc, input, param, max_decoded_stream_bytes);
@@ -4922,7 +4921,7 @@ fn asciiHexDecodeAlloc(alloc: Allocator, input: []const u8) ![]u8 {
     return try out.toOwnedSlice(alloc);
 }
 
-fn ascii85DecodeAlloc(alloc: Allocator, input: []const u8) ![]u8 {
+fn ascii85DecodeAlloc(alloc: Allocator, input: []const u8, max_bytes: usize) ![]u8 {
     var digits = std.ArrayList(u8).empty;
     defer digits.deinit(alloc);
     var out = std.ArrayList(u8).empty;
@@ -4935,13 +4934,14 @@ fn ascii85DecodeAlloc(alloc: Allocator, input: []const u8) ![]u8 {
         if (ch == '~') break;
         if (ch == 'z') {
             if (digits.items.len != 0) return error.MalformedAscii85;
+            if (out.items.len > max_bytes or 4 > max_bytes - out.items.len) return error.DecodedStreamTooLarge;
             try out.appendSlice(alloc, &.{ 0, 0, 0, 0 });
             continue;
         }
         if (ch < '!' or ch > 'u') return error.MalformedAscii85;
         try digits.append(alloc, ch - '!');
         if (digits.items.len == 5) {
-            try appendAscii85Group(alloc, &out, digits.items, 4);
+            try appendAscii85Group(alloc, &out, digits.items, 4, max_bytes);
             digits.clearRetainingCapacity();
         }
     }
@@ -4949,7 +4949,7 @@ fn ascii85DecodeAlloc(alloc: Allocator, input: []const u8) ![]u8 {
     if (digits.items.len > 0) {
         const original_len = digits.items.len;
         while (digits.items.len < 5) try digits.append(alloc, 'u' - '!');
-        try appendAscii85Group(alloc, &out, digits.items, original_len - 1);
+        try appendAscii85Group(alloc, &out, digits.items, original_len - 1, max_bytes);
     }
 
     return try out.toOwnedSlice(alloc);
@@ -5032,7 +5032,7 @@ fn lzwDecodeAlloc(alloc: Allocator, input: []const u8, param: ?*const syntax.Obj
 
     const decoded = try out.toOwnedSlice(alloc);
     defer alloc.free(decoded);
-    const predicted = try applyPredictorAlloc(alloc, decoded, param);
+    const predicted = try applyPredictorAlloc(alloc, decoded, param, max_bytes);
     return try enforceDecodedStreamLimit(alloc, predicted, max_bytes);
 }
 
@@ -5093,7 +5093,13 @@ fn parseRawCode(raw: []const u8) u32 {
     return code;
 }
 
-fn appendAscii85Group(alloc: Allocator, out: *std.ArrayList(u8), digits: []const u8, keep_bytes: usize) !void {
+fn appendAscii85Group(
+    alloc: Allocator,
+    out: *std.ArrayList(u8),
+    digits: []const u8,
+    keep_bytes: usize,
+    max_bytes: usize,
+) !void {
     var value: u64 = 0;
     for (digits) |digit| value = value * 85 + digit;
     var buf: [4]u8 = .{
@@ -5102,10 +5108,16 @@ fn appendAscii85Group(alloc: Allocator, out: *std.ArrayList(u8), digits: []const
         @intCast((value >> 8) & 0xff),
         @intCast(value & 0xff),
     };
+    if (out.items.len > max_bytes or keep_bytes > max_bytes - out.items.len) return error.DecodedStreamTooLarge;
     try out.appendSlice(alloc, buf[0..keep_bytes]);
 }
 
-fn applyPredictorAlloc(alloc: Allocator, decoded: []const u8, param: ?*const syntax.Object) ![]u8 {
+fn applyPredictorAlloc(
+    alloc: Allocator,
+    decoded: []const u8,
+    param: ?*const syntax.Object,
+    max_bytes: usize,
+) ![]u8 {
     if (param == null or param.?.* != .dict) return try alloc.dupe(u8, decoded);
     const predictor_obj = param.?.get("Predictor") orelse return try alloc.dupe(u8, decoded);
     const predictor = predictor_obj.asInteger() orelse return try alloc.dupe(u8, decoded);
@@ -5116,14 +5128,27 @@ fn applyPredictorAlloc(alloc: Allocator, decoded: []const u8, param: ?*const syn
     const bits_i = if (param.?.get("BitsPerComponent")) |obj| obj.asInteger() orelse 8 else 8;
     if (columns_i <= 0 or colors_i <= 0 or bits_i <= 0) return error.UnsupportedPredictor;
 
-    const bytes_per_pixel: usize = @intCast(@divTrunc(colors_i * bits_i + 7, 8));
-    const row_len: usize = @intCast(@divTrunc(columns_i * colors_i * bits_i + 7, 8));
+    const columns = std.math.cast(usize, columns_i) orelse return error.UnsupportedPredictor;
+    const colors = std.math.cast(usize, colors_i) orelse return error.UnsupportedPredictor;
+    const bits = std.math.cast(usize, bits_i) orelse return error.UnsupportedPredictor;
+    if (colors > 32) return error.UnsupportedPredictor;
+    switch (bits) {
+        1, 2, 4, 8, 16 => {},
+        else => return error.UnsupportedPredictor,
+    }
+    const bits_per_pixel = std.math.mul(usize, colors, bits) catch return error.UnsupportedPredictor;
+    const bytes_per_pixel = (std.math.add(usize, bits_per_pixel, 7) catch return error.UnsupportedPredictor) / 8;
+    const row_bits = std.math.mul(usize, columns, bits_per_pixel) catch return error.UnsupportedPredictor;
+    const row_len = (std.math.add(usize, row_bits, 7) catch return error.UnsupportedPredictor) / 8;
+    if (row_len == 0) return error.UnsupportedPredictor;
+    if (row_len > max_bytes) return error.DecodedStreamTooLarge;
+    if (row_len > decoded.len) return error.MalformedPredictorData;
 
     if (predictor == 2) {
         // TIFF Predictor 2 stores each sample as its difference from the
         // corresponding sample in the preceding pixel. PDF image streams in
         // the wild commonly use this with 8-bit RGB and grayscale data.
-        if (bits_i != 8 or row_len == 0 or decoded.len % row_len != 0) return error.UnsupportedPredictor;
+        if (bits != 8 or decoded.len % row_len != 0) return error.UnsupportedPredictor;
         const out = try alloc.dupe(u8, decoded);
         var row_start: usize = 0;
         while (row_start < out.len) : (row_start += row_len) {
@@ -5135,7 +5160,8 @@ fn applyPredictorAlloc(alloc: Allocator, decoded: []const u8, param: ?*const syn
         return out;
     }
     if (predictor < 10 or predictor > 15) return error.UnsupportedPredictor;
-    if ((row_len + 1) == 0 or decoded.len % (row_len + 1) != 0) return error.MalformedPredictorData;
+    const encoded_row_len = std.math.add(usize, row_len, 1) catch return error.UnsupportedPredictor;
+    if (decoded.len % encoded_row_len != 0) return error.MalformedPredictorData;
 
     var out = std.ArrayList(u8).empty;
     defer out.deinit(alloc);
@@ -9445,11 +9471,37 @@ test "reader can decode run length stream object" {
 
 test "stream decoders enforce the decoded byte budget before growth" {
     const alloc = std.testing.allocator;
+    try std.testing.expectError(error.DecodedStreamTooLarge, ascii85DecodeAlloc(alloc, "zz~>", 7));
+
     const lzw = &.{ 0x80, 0x0b, 0x60, 0x50, 0x22, 0x0c, 0x0c, 0x85, 0x01 };
     try std.testing.expectError(error.DecodedStreamTooLarge, lzwDecodeAlloc(alloc, lzw, null, 5));
 
     const run_length = &.{ 2, 'A', 'B', 'C', 254, 'Z', 128 };
     try std.testing.expectError(error.DecodedStreamTooLarge, runLengthDecodeAlloc(alloc, run_length, 5));
+}
+
+test "predictor dimensions reject overflow and oversized rows before allocation" {
+    var overflow_entries = [_]syntax.DictEntry{
+        .{ .key = @constCast("Predictor"), .value = .{ .integer = 12 } },
+        .{ .key = @constCast("Columns"), .value = .{ .integer = std.math.maxInt(i64) } },
+        .{ .key = @constCast("Colors"), .value = .{ .integer = 32 } },
+        .{ .key = @constCast("BitsPerComponent"), .value = .{ .integer = 16 } },
+    };
+    var overflow_param: syntax.Object = .{ .dict = &overflow_entries };
+    try std.testing.expectError(
+        error.UnsupportedPredictor,
+        applyPredictorAlloc(std.testing.allocator, &.{0}, &overflow_param, 256),
+    );
+
+    var oversized_entries = [_]syntax.DictEntry{
+        .{ .key = @constCast("Predictor"), .value = .{ .integer = 12 } },
+        .{ .key = @constCast("Columns"), .value = .{ .integer = 1024 } },
+    };
+    var oversized_param: syntax.Object = .{ .dict = &oversized_entries };
+    try std.testing.expectError(
+        error.DecodedStreamTooLarge,
+        applyPredictorAlloc(std.testing.allocator, &.{0}, &oversized_param, 128),
+    );
 }
 
 test "reader can extract plain text from simple page content" {

--- a/zig/lib/platform/src/process.zig
+++ b/zig/lib/platform/src/process.zig
@@ -37,3 +37,41 @@ pub fn alive(pid: u32) bool {
         else => return true,
     }
 }
+
+pub const FileDescriptorLimit = struct {
+    initial_soft: u64,
+    soft: u64,
+    hard: u64,
+};
+
+/// Raises the process file-descriptor soft limit toward `target`, without
+/// exceeding the hard limit. The caller owns the policy and any logging.
+pub fn ensureFileDescriptorSoftLimitAtLeast(target: u64) !FileDescriptorLimit {
+    if (comptime std.posix.rlimit_resource == void) return error.UnsupportedPlatform;
+
+    const initial = try std.posix.getrlimit(.NOFILE);
+    const initial_soft: u64 = @intCast(initial.cur);
+    const hard: u64 = @intCast(initial.max);
+    const desired = desiredFileDescriptorSoftLimit(initial_soft, hard, target);
+    if (desired > initial_soft) {
+        var raised = initial;
+        raised.cur = @intCast(desired);
+        try std.posix.setrlimit(.NOFILE, raised);
+    }
+    const final = try std.posix.getrlimit(.NOFILE);
+    return .{
+        .initial_soft = initial_soft,
+        .soft = @intCast(final.cur),
+        .hard = @intCast(final.max),
+    };
+}
+
+fn desiredFileDescriptorSoftLimit(current: u64, hard: u64, target: u64) u64 {
+    return @max(current, @min(hard, target));
+}
+
+test "file descriptor target is bounded by hard limit" {
+    try std.testing.expectEqual(@as(u64, 4096), desiredFileDescriptorSoftLimit(256, 8192, 4096));
+    try std.testing.expectEqual(@as(u64, 1024), desiredFileDescriptorSoftLimit(256, 1024, 4096));
+    try std.testing.expectEqual(@as(u64, 8192), desiredFileDescriptorSoftLimit(8192, 8192, 4096));
+}

--- a/zig/lib/readers/src/mod.zig
+++ b/zig/lib/readers/src/mod.zig
@@ -81,9 +81,9 @@ pub const Request = struct {
     images: []const []const u8,
     prompt: ?[]const u8 = null,
     max_tokens: ?i64 = null,
-    /// Internal-only correlation for opt-in inference profiling. Remote
-    /// reader providers deliberately do not serialize this value.
-    correlation_id: ?[]const u8 = null,
+    /// Stable source fingerprint for opt-in inference profiling. Remote reader
+    /// providers deliberately do not serialize this internal-only value.
+    source_fingerprint: ?[]const u8 = null,
 };
 
 pub const Result = struct {

--- a/zig/pkg/antfly/src/api/tables.zig
+++ b/zig/pkg/antfly/src/api/tables.zig
@@ -1842,7 +1842,7 @@ fn projectInlineEnrichmentConfigsInTableStatusJson(alloc: std.mem.Allocator, enc
     defer arena_impl.deinit();
     const arena = arena_impl.allocator();
     var parsed = try std.json.parseFromSlice(std.json.Value, arena, encoded, .{});
-    redactInlineEnrichmentProducerConfigs(&parsed.value);
+    redactInlineEnrichmentProducerConfigsFromTableStatuses(&parsed.value);
     return try std.json.Stringify.valueAlloc(alloc, parsed.value, .{ .emit_null_optional_fields = false });
 }
 
@@ -1852,24 +1852,40 @@ fn projectSingleTableStatusJson(alloc: std.mem.Allocator, encoded: []const u8, i
     const arena = arena_impl.allocator();
     var parsed = try std.json.parseFromSlice(std.json.Value, arena, encoded, .{});
     try attachArtifactEnrichmentsToTableStatus(arena, &parsed.value, indexes_json);
-    redactInlineEnrichmentProducerConfigs(&parsed.value);
+    redactInlineEnrichmentProducerConfigsFromTableStatuses(&parsed.value);
     return try std.json.Stringify.valueAlloc(alloc, parsed.value, .{ .emit_null_optional_fields = false });
 }
 
 /// Producer configuration is accepted on writes but is deliberately omitted
 /// from table-status responses. Besides provider credentials, producer_json
 /// can contain arbitrary nested reader configuration supplied by a client.
-fn redactInlineEnrichmentProducerConfigs(value: *std.json.Value) void {
+fn redactInlineEnrichmentProducerConfigsFromTableStatuses(value: *std.json.Value) void {
     switch (value.*) {
         .array => |*array| {
-            for (array.items) |*item| redactInlineEnrichmentProducerConfigs(item);
+            for (array.items) |*item| redactInlineEnrichmentProducerConfigsFromTableStatus(item);
         },
-        .object => |*object| {
-            _ = object.swapRemove("producer_json");
-            var it = object.iterator();
-            while (it.next()) |entry| redactInlineEnrichmentProducerConfigs(entry.value_ptr);
-        },
+        .object => redactInlineEnrichmentProducerConfigsFromTableStatus(value),
         else => {},
+    }
+}
+
+fn redactInlineEnrichmentProducerConfigsFromTableStatus(value: *std.json.Value) void {
+    if (value.* != .object) return;
+    if (value.object.getPtr("indexes")) |indexes| {
+        if (indexes.* == .object) {
+            var it = indexes.object.iterator();
+            while (it.next()) |entry| redactProducerConfigsFromEnrichmentArray(entry.value_ptr, "enrichments");
+        }
+    }
+    redactProducerConfigsFromEnrichmentArray(value, "artifact_enrichments");
+}
+
+fn redactProducerConfigsFromEnrichmentArray(container: *std.json.Value, key: []const u8) void {
+    if (container.* != .object) return;
+    const enrichments = container.object.getPtr(key) orelse return;
+    if (enrichments.* != .array) return;
+    for (enrichments.array.items) |*enrichment| {
+        if (enrichment.* == .object) _ = enrichment.object.swapRemove("producer_json");
     }
 }
 
@@ -3525,6 +3541,9 @@ test "metadata.table status merges observed capabilities conservatively" {
 }
 
 test "metadata.table status encoder preserves enrichment summaries without producer configuration" {
+    const schema_json =
+        \\{"version":1,"default_type":"doc","document_schemas":{"doc":{"schema":{"type":"object","properties":{"producer_json":{"type":"string"}}}}}}
+    ;
     const indexes_json =
         \\{
         \\  "document_text":{
@@ -3548,7 +3567,14 @@ test "metadata.table status encoder preserves enrichment summaries without produ
     ;
     const snapshot: metadata_api.AdminSnapshot = .{
         .status = .{ .metadata_group_id = 1, .metrics = .{} },
-        .tables = @constCast((&[_]metadata_table_manager.TableRecord{.{ .table_id = 7, .name = "docs", .indexes_json = indexes_json, .replication_sources_json = "[]", .placement_role = "data" }})[0..]),
+        .tables = @constCast((&[_]metadata_table_manager.TableRecord{.{
+            .table_id = 7,
+            .name = "docs",
+            .schema_json = schema_json,
+            .indexes_json = indexes_json,
+            .replication_sources_json = "[]",
+            .placement_role = "data",
+        }})[0..]),
         .ranges = @constCast((&[_]metadata_table_manager.RangeRecord{.{ .group_id = 7001, .table_id = 7, .start_key = "", .end_key = null }})[0..]),
         .stores = @constCast((&[_]metadata_table_manager.StoreRecord{})[0..]),
         .placement_intents = @constCast((&[_]raft_reconciler.PlacementIntent{})[0..]),
@@ -3558,11 +3584,36 @@ test "metadata.table status encoder preserves enrichment summaries without produ
 
     const encoded = (try encodeSingleTableStatus(std.testing.allocator, &snapshot, "docs")).?;
     defer std.testing.allocator.free(encoded);
+    var parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, encoded, .{});
+    defer parsed.deinit();
+    const indexes = parsed.value.object.get("indexes").?;
+    const document_text = indexes.object.get("document_text").?;
+    const document_enrichments = document_text.object.get("enrichments").?;
+    try std.testing.expect(document_enrichments.array.items[0].object.get("producer_json") == null);
+    const artifact_enrichments = parsed.value.object.get("artifact_enrichments").?;
+    try std.testing.expect(artifact_enrichments.array.items[0].object.get("producer_json") == null);
+
     try std.testing.expect(std.mem.indexOf(u8, encoded, "\"enrichments\":[{\"name\":\"document_units_v1\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, encoded, "{\"name\":\"document_chunks_v1\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, encoded, "\"enrichments\":[{\"name\":\"document_chunk_dense_v1\"") != null);
-    try std.testing.expect(std.mem.indexOf(u8, encoded, "producer_json") == null);
+    try std.testing.expect(std.mem.indexOf(u8, encoded, "\"producer_json\":{\"type\":\"string\"}") != null);
     try std.testing.expect(std.mem.indexOf(u8, encoded, "do-not-return") == null);
+}
+
+test "metadata.table list projection redacts only enrichment producer configuration" {
+    const encoded =
+        \\[{"schema":{"properties":{"producer_json":{"type":"string"}}},"indexes":{"document_text":{"enrichments":[{"name":"units","producer_json":"secret"}]}}}]
+    ;
+    const projected = try projectInlineEnrichmentConfigsInTableStatusJson(std.testing.allocator, encoded);
+    defer std.testing.allocator.free(projected);
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, projected, .{});
+    defer parsed.deinit();
+    const status = parsed.value.array.items[0];
+    try std.testing.expect(status.object.get("schema").?.object.get("properties").?.object.get("producer_json") != null);
+    const enrichment = status.object.get("indexes").?.object.get("document_text").?.object.get("enrichments").?.array.items[0];
+    try std.testing.expect(enrichment.object.get("producer_json") == null);
+    try std.testing.expect(std.mem.indexOf(u8, projected, "secret") == null);
 }
 
 test "metadata.table debug encoder emits runtime schemas and index bindings" {

--- a/zig/pkg/antfly/src/asset_producer_runtime.zig
+++ b/zig/pkg/antfly/src/asset_producer_runtime.zig
@@ -341,7 +341,7 @@ pub const Runtime = struct {
                 .images = chunk_images,
                 .prompt = shared_prompt,
                 .max_tokens = cfg_parsed.value.max_tokens,
-                .correlation_id = requests[0].correlation_id,
+                .source_fingerprint = requests[0].source_fingerprint,
             });
             if (chunk_results.len != chunk_images.len) {
                 for (chunk_results) |*result| readers.deinitResult(alloc, result);
@@ -416,7 +416,7 @@ pub const Runtime = struct {
             .images = source.images,
             .prompt = source.prompt orelse cfg_parsed.value.prompt,
             .max_tokens = cfg_parsed.value.max_tokens,
-            .correlation_id = request.correlation_id,
+            .source_fingerprint = request.source_fingerprint,
         });
         defer {
             for (results) |*result| readers.deinitResult(alloc, result);

--- a/zig/pkg/antfly/src/main.zig
+++ b/zig/pkg/antfly/src/main.zig
@@ -22,7 +22,17 @@ const antfly_client = @import("antfly-client");
 const platform = @import("antfly_platform");
 
 const antfly_cloud_binary = "antfly-cloud";
-const recommended_server_fd_limit: std.posix.rlim_t = 4096;
+const recommended_server_fd_limit: u64 = 4096;
+
+const ServerSubcommand = enum {
+    data,
+    metadata,
+    standalone,
+    inference,
+    serverless,
+    lite,
+    ha,
+};
 
 pub const std_options: std.Options = .{
     .logFn = structlog.logFn,
@@ -49,16 +59,18 @@ pub fn main(init: std.process.Init) !void {
         return;
     }
 
-    if (isServerSubcommand(subcommand)) ensureServerFileDescriptorLimit();
-
-    // Server-side subcommands
-    if (std.mem.eql(u8, subcommand, "data")) return try cmd.data.runFromIterator(runtimeInit(init), argv0, &args);
-    if (std.mem.eql(u8, subcommand, "metadata")) return try cmd.metadata.runFromIterator(runtimeInit(init), argv0, &args);
-    if (std.mem.eql(u8, subcommand, "standalone")) return try cmd.standalone.runFromIterator(runtimeInit(init), argv0, &args);
-    if (std.mem.eql(u8, subcommand, "inference")) return try cmd.inference.runFromIterator(runtimeInit(init), argv0, &args);
-    if (std.mem.eql(u8, subcommand, "serverless")) return try cmd.serverless.runFromIterator(runtimeInit(init), argv0, &args);
-    if (std.mem.eql(u8, subcommand, "lite")) return try cmd.lite.runFromIterator(runtimeInit(init), argv0, &args);
-    if (std.mem.eql(u8, subcommand, "ha")) return try cmd.ha.runFromIterator(runtimeInit(init), argv0, &args);
+    if (serverSubcommand(subcommand)) |server_command| {
+        ensureServerFileDescriptorLimit();
+        return switch (server_command) {
+            .data => try cmd.data.runFromIterator(runtimeInit(init), argv0, &args),
+            .metadata => try cmd.metadata.runFromIterator(runtimeInit(init), argv0, &args),
+            .standalone => try cmd.standalone.runFromIterator(runtimeInit(init), argv0, &args),
+            .inference => try cmd.inference.runFromIterator(runtimeInit(init), argv0, &args),
+            .serverless => try cmd.serverless.runFromIterator(runtimeInit(init), argv0, &args),
+            .lite => try cmd.lite.runFromIterator(runtimeInit(init), argv0, &args),
+            .ha => try cmd.ha.runFromIterator(runtimeInit(init), argv0, &args),
+        };
+    }
 
     if (std.mem.eql(u8, subcommand, "cloud")) {
         const code = try runAntflyCloud(init.gpa, init.io, &args);
@@ -90,49 +102,29 @@ pub fn main(init: std.process.Init) !void {
     return error.InvalidArguments;
 }
 
-fn isServerSubcommand(subcommand: []const u8) bool {
-    return std.mem.eql(u8, subcommand, "data") or
-        std.mem.eql(u8, subcommand, "metadata") or
-        std.mem.eql(u8, subcommand, "standalone") or
-        std.mem.eql(u8, subcommand, "inference") or
-        std.mem.eql(u8, subcommand, "serverless");
-}
-
-fn desiredServerFileDescriptorLimit(current: std.posix.rlim_t, hard: std.posix.rlim_t) std.posix.rlim_t {
-    return @max(current, @min(hard, recommended_server_fd_limit));
+fn serverSubcommand(subcommand: []const u8) ?ServerSubcommand {
+    return std.meta.stringToEnum(ServerSubcommand, subcommand);
 }
 
 fn ensureServerFileDescriptorLimit() void {
-    if (comptime std.posix.rlimit_resource == void) {
-        std.log.warn("server file-descriptor limit unavailable platform={s} recommended={d}", .{ @tagName(builtin.os.tag), recommended_server_fd_limit });
-        return;
-    }
-    const initial = std.posix.getrlimit(.NOFILE) catch |err| {
-        std.log.warn("server file-descriptor limit query failed error={s} recommended={d}", .{ @errorName(err), recommended_server_fd_limit });
+    const limit = platform.process.ensureFileDescriptorSoftLimitAtLeast(recommended_server_fd_limit) catch |err| {
+        std.log.warn("server file-descriptor limit unavailable platform={s} recommended={d} error={s}", .{ @tagName(builtin.os.tag), recommended_server_fd_limit, @errorName(err) });
         return;
     };
-    const desired = desiredServerFileDescriptorLimit(initial.cur, initial.max);
-    if (desired > initial.cur) {
-        var raised = initial;
-        raised.cur = desired;
-        std.posix.setrlimit(.NOFILE, raised) catch |err| {
-            std.log.warn("server file-descriptor limit raise failed soft={d} hard={d} requested={d} error={s}", .{ initial.cur, initial.max, desired, @errorName(err) });
-        };
-    }
-    const final = std.posix.getrlimit(.NOFILE) catch initial;
-    if (final.cur < recommended_server_fd_limit) {
-        std.log.warn("LOW SERVER FILE-DESCRIPTOR LIMIT soft={d} hard={d} recommended={d} index creation may fail with ProcessFdQuotaExceeded", .{ final.cur, final.max, recommended_server_fd_limit });
-    } else if (final.cur != initial.cur) {
-        std.log.info("raised server file-descriptor limit initial_soft={d} soft={d} hard={d} recommended={d}", .{ initial.cur, final.cur, final.max, recommended_server_fd_limit });
+    if (limit.soft < recommended_server_fd_limit) {
+        std.log.warn("LOW SERVER FILE-DESCRIPTOR LIMIT soft={d} hard={d} recommended={d} index creation may fail with ProcessFdQuotaExceeded", .{ limit.soft, limit.hard, recommended_server_fd_limit });
+    } else if (limit.soft != limit.initial_soft) {
+        std.log.info("raised server file-descriptor limit initial_soft={d} soft={d} hard={d} recommended={d}", .{ limit.initial_soft, limit.soft, limit.hard, recommended_server_fd_limit });
     } else {
-        std.log.info("server file-descriptor limit soft={d} hard={d} recommended={d}", .{ final.cur, final.max, recommended_server_fd_limit });
+        std.log.info("server file-descriptor limit soft={d} hard={d} recommended={d}", .{ limit.soft, limit.hard, recommended_server_fd_limit });
     }
 }
 
-test "server file descriptor target is bounded by hard limit" {
-    try std.testing.expectEqual(@as(std.posix.rlim_t, 4096), desiredServerFileDescriptorLimit(256, 8192));
-    try std.testing.expectEqual(@as(std.posix.rlim_t, 1024), desiredServerFileDescriptorLimit(256, 1024));
-    try std.testing.expectEqual(@as(std.posix.rlim_t, 8192), desiredServerFileDescriptorLimit(8192, 8192));
+test "server subcommand classification includes every server dispatch" {
+    inline for (std.meta.tags(ServerSubcommand)) |server_command| {
+        try std.testing.expectEqual(server_command, serverSubcommand(@tagName(server_command)).?);
+    }
+    try std.testing.expect(serverSubcommand("table") == null);
 }
 
 fn cliHelpRequested(args: *std.process.Args.Iterator) bool {

--- a/zig/pkg/antfly/src/storage/db/enrichment/asset_producer.zig
+++ b/zig/pkg/antfly/src/storage/db/enrichment/asset_producer.zig
@@ -74,8 +74,8 @@ pub const Request = struct {
     source_text: []const u8,
     source_parts_json: ?[]const u8 = null,
     content_type: []const u8 = "",
-    /// Internal-only correlation for opt-in producer/inference profiling.
-    correlation_id: ?[]const u8 = null,
+    /// Stable source fingerprint for opt-in producer/inference profiling.
+    source_fingerprint: ?[]const u8 = null,
 };
 
 pub const Producer = struct {

--- a/zig/pkg/antfly/src/storage/db/enrichment/enrichment_runtime.zig
+++ b/zig/pkg/antfly/src/storage/db/enrichment/enrichment_runtime.zig
@@ -2924,7 +2924,7 @@ fn completeRuntimeDocumentExtractionGeneratedTextBatch(
     var source_digest: [32]u8 = undefined;
     std.crypto.hash.sha2.Sha256.hash(source_bytes, &source_digest, .{});
     const source_hex = std.fmt.bytesToHex(source_digest, .lower);
-    const profile_source_id = source_hex[0..16];
+    const source_fingerprint = source_hex[0..16];
 
     const pending_status = switch (kind) {
         .ocr => "pending_ocr",
@@ -2972,7 +2972,7 @@ fn completeRuntimeDocumentExtractionGeneratedTextBatch(
                 units[idx].ocr_render_dpi = config.ocr_render_dpi;
                 const render_started_ns = runtime.config.clock.nowRealtimeNs();
                 const rendered_page = pdf_session.?.renderPagePngAdaptiveAlloc(alloc, unit.page_number orelse 1, config.ocr_render_dpi, config.ocr_max_rendered_pixels, config.ocr_max_rendered_dimension) catch |err| {
-                    logRuntimeOcrRenderProfile(runtime, profile_source_id, unit.page_number, config.ocr_render_dpi, null, null, null, null, render_started_ns, @errorName(err));
+                    logRuntimeOcrRenderProfile(runtime, source_fingerprint, unit.page_number, config.ocr_render_dpi, null, null, null, null, render_started_ns, @errorName(err));
                     if (isEnrichmentControlError(err) or isRetryableEnrichmentError(err)) return err;
                     try setRuntimeGeneratedUnitFailureStage(alloc, &units[idx], kind, "render");
                     try markRuntimeGeneratedUnitTextFailure(alloc, &units[idx], method, kind, err);
@@ -2983,7 +2983,7 @@ fn completeRuntimeDocumentExtractionGeneratedTextBatch(
                 units[idx].ocr_rendered_height = rendered_page.height;
                 units[idx].ocr_rendered_bytes = rendered_page.png.len;
                 rendered = rendered_page.png;
-                logRuntimeOcrRenderProfile(runtime, profile_source_id, unit.page_number, config.ocr_render_dpi, rendered_page.effective_dpi, rendered_page.width, rendered_page.height, rendered_page.png.len, render_started_ns, null);
+                logRuntimeOcrRenderProfile(runtime, source_fingerprint, unit.page_number, config.ocr_render_dpi, rendered_page.effective_dpi, rendered_page.width, rendered_page.height, rendered_page.png.len, render_started_ns, null);
             }
         }
         // Avoid allocating the base64 and JSON copies when the encoded PNG
@@ -3009,7 +3009,7 @@ fn completeRuntimeDocumentExtractionGeneratedTextBatch(
             .source_text = if (rendered != null) "" else source_url,
             .source_parts_json = parts_json,
             .content_type = "text/plain",
-            .correlation_id = profile_source_id,
+            .source_fingerprint = source_fingerprint,
         };
         const request_bytes = runtimeGeneratedTextRequestBytes(request);
         if (request_bytes > batch_policy.max_bytes) {
@@ -3020,7 +3020,7 @@ fn completeRuntimeDocumentExtractionGeneratedTextBatch(
             continue;
         }
         if (requests.items.len > 0 and (requests.items.len >= batch_policy.max_items or batch_bytes + request_bytes > batch_policy.max_bytes)) {
-            try flushRuntimeGeneratedTextBatch(runtime, alloc, producer, requests.items, unit_indices.items, &parts_values, units, method, kind, config.ocr_quality, ocr_prompt, profile_source_id);
+            try flushRuntimeGeneratedTextBatch(runtime, alloc, producer, requests.items, unit_indices.items, &parts_values, units, method, kind, config.ocr_quality, ocr_prompt, source_fingerprint);
             requests.clearRetainingCapacity();
             unit_indices.clearRetainingCapacity();
             batch_bytes = 0;
@@ -3032,7 +3032,7 @@ fn completeRuntimeDocumentExtractionGeneratedTextBatch(
         batch_bytes = addUsizeSaturating(batch_bytes, request_bytes);
     }
     if (requests.items.len > 0) {
-        try flushRuntimeGeneratedTextBatch(runtime, alloc, producer, requests.items, unit_indices.items, &parts_values, units, method, kind, config.ocr_quality, ocr_prompt, profile_source_id);
+        try flushRuntimeGeneratedTextBatch(runtime, alloc, producer, requests.items, unit_indices.items, &parts_values, units, method, kind, config.ocr_quality, ocr_prompt, source_fingerprint);
     }
 }
 
@@ -3063,7 +3063,7 @@ fn flushRuntimeGeneratedTextBatch(
     kind: RuntimeGeneratedUnitTextKind,
     quality_config: document_extraction_mod.OcrQualityConfig,
     ocr_prompt: []const u8,
-    profile_source_id: []const u8,
+    source_fingerprint: []const u8,
 ) !void {
     if (requests.len == 0) return;
     if (requests.len != unit_indices.len) return error.InvalidAssetProducerResponse;
@@ -3071,20 +3071,20 @@ fn flushRuntimeGeneratedTextBatch(
     const started_ns = runtime.config.clock.nowRealtimeNs();
     const request_bytes = runtimeGeneratedTextBatchBytes(requests);
     var produced = producer.produceBatch(alloc, requests) catch |err| {
-        logRuntimeOcrBatchProfile(runtime, profile_source_id, units, unit_indices, requests.len, request_bytes, "serial_fallback", @errorName(err), started_ns);
+        logRuntimeOcrBatchProfile(runtime, source_fingerprint, units, unit_indices, requests.len, request_bytes, "serial_fallback", @errorName(err), started_ns);
         if (isEnrichmentControlError(err) or isRetryableEnrichmentError(err)) return err;
         for (unit_indices) |unit_idx| try setRuntimeGeneratedUnitFailureStage(alloc, &units[unit_idx], kind, "inference");
-        return try flushRuntimeGeneratedTextBatchSequential(runtime, alloc, producer, requests, unit_indices, parts_values, units, method, kind, quality_config, ocr_prompt, profile_source_id, @errorName(err));
+        return try flushRuntimeGeneratedTextBatchSequential(runtime, alloc, producer, requests, unit_indices, parts_values, units, method, kind, quality_config, ocr_prompt, source_fingerprint, @errorName(err));
     };
     if (produced.len != requests.len) {
         for (produced) |item| {
             if (item.len > 0) alloc.free(item);
         }
         alloc.free(produced);
-        logRuntimeOcrBatchProfile(runtime, profile_source_id, units, unit_indices, requests.len, request_bytes, "serial_fallback", "response_count_mismatch", started_ns);
-        return try flushRuntimeGeneratedTextBatchSequential(runtime, alloc, producer, requests, unit_indices, parts_values, units, method, kind, quality_config, ocr_prompt, profile_source_id, "response_count_mismatch");
+        logRuntimeOcrBatchProfile(runtime, source_fingerprint, units, unit_indices, requests.len, request_bytes, "serial_fallback", "response_count_mismatch", started_ns);
+        return try flushRuntimeGeneratedTextBatchSequential(runtime, alloc, producer, requests, unit_indices, parts_values, units, method, kind, quality_config, ocr_prompt, source_fingerprint, "response_count_mismatch");
     }
-    logRuntimeOcrBatchProfile(runtime, profile_source_id, units, unit_indices, requests.len, request_bytes, "batch", null, started_ns);
+    logRuntimeOcrBatchProfile(runtime, source_fingerprint, units, unit_indices, requests.len, request_bytes, "batch", null, started_ns);
 
     defer alloc.free(produced);
     errdefer {
@@ -3115,20 +3115,20 @@ fn flushRuntimeGeneratedTextBatchSequential(
     kind: RuntimeGeneratedUnitTextKind,
     quality_config: document_extraction_mod.OcrQualityConfig,
     ocr_prompt: []const u8,
-    profile_source_id: []const u8,
+    source_fingerprint: []const u8,
     fallback_reason: []const u8,
 ) !void {
     if (requests.len != unit_indices.len) return error.InvalidAssetProducerResponse;
     for (requests, unit_indices) |request, unit_idx| {
         const started_ns = runtime.config.clock.nowRealtimeNs();
         const produced = producer.produce(alloc, request) catch |err| {
-            logRuntimeOcrBatchProfile(runtime, profile_source_id, units, &.{unit_idx}, 1, runtimeGeneratedTextRequestBytes(request), "serial", @errorName(err), started_ns);
+            logRuntimeOcrBatchProfile(runtime, source_fingerprint, units, &.{unit_idx}, 1, runtimeGeneratedTextRequestBytes(request), "serial", @errorName(err), started_ns);
             if (isEnrichmentControlError(err) or isRetryableEnrichmentError(err)) return err;
             try setRuntimeGeneratedUnitFailureStage(alloc, &units[unit_idx], kind, runtimeGeneratedTextFailureStage(err));
             try markRuntimeGeneratedUnitTextFailure(alloc, &units[unit_idx], method, kind, err);
             continue;
         };
-        logRuntimeOcrBatchProfile(runtime, profile_source_id, units, &.{unit_idx}, 1, runtimeGeneratedTextRequestBytes(request), "serial", fallback_reason, started_ns);
+        logRuntimeOcrBatchProfile(runtime, source_fingerprint, units, &.{unit_idx}, 1, runtimeGeneratedTextRequestBytes(request), "serial", fallback_reason, started_ns);
         applyRuntimeGeneratedUnitText(alloc, &units[unit_idx], produced, method, "completed", kind, quality_config, ocr_prompt) catch |err| {
             if (isEnrichmentControlError(err) or isRetryableEnrichmentError(err)) return err;
             try setRuntimeGeneratedUnitFailureStage(alloc, &units[unit_idx], kind, runtimeGeneratedTextFailureStage(err));
@@ -3156,7 +3156,7 @@ fn profileElapsedMs(runtime: *EnrichmentRuntime, started_ns: u64) f64 {
 
 fn logRuntimeOcrRenderProfile(
     runtime: *EnrichmentRuntime,
-    source_id: []const u8,
+    source_fingerprint: []const u8,
     page_number: ?u32,
     requested_dpi: u16,
     effective_dpi: ?u16,
@@ -3167,14 +3167,14 @@ fn logRuntimeOcrRenderProfile(
     failure: ?[]const u8,
 ) void {
     if (!runtimeReadProfileEnabled()) return;
-    std.log.info("read-profile phase=pdf_render source_sha256={s} page={?d} requested_dpi={d} effective_dpi={?d} width={?d} height={?d} encoded_bytes={?d} failure={?s} elapsed_ms={d:.3}", .{
-        source_id, page_number, requested_dpi, effective_dpi, width, height, encoded_bytes, failure, profileElapsedMs(runtime, started_ns),
+    std.log.info("read-profile phase=pdf_render source_fingerprint={s} page={?d} requested_dpi={d} effective_dpi={?d} width={?d} height={?d} encoded_bytes={?d} failure={?s} elapsed_ms={d:.3}", .{
+        source_fingerprint, page_number, requested_dpi, effective_dpi, width, height, encoded_bytes, failure, profileElapsedMs(runtime, started_ns),
     });
 }
 
 fn logRuntimeOcrBatchProfile(
     runtime: *EnrichmentRuntime,
-    source_id: []const u8,
+    source_fingerprint: []const u8,
     units: []const document_extraction_mod.Unit,
     unit_indices: []const usize,
     batch_size: usize,
@@ -3186,8 +3186,8 @@ fn logRuntimeOcrBatchProfile(
     if (!runtimeReadProfileEnabled()) return;
     const first_page = if (unit_indices.len > 0) units[unit_indices[0]].page_number else null;
     const last_page = if (unit_indices.len > 0) units[unit_indices[unit_indices.len - 1]].page_number else null;
-    std.log.info("read-profile phase=ocr_batch source_sha256={s} first_page={?d} last_page={?d} batch_size={d} request_bytes={d} mode={s} serial_fallback_reason={?s} elapsed_ms={d:.3}", .{
-        source_id, first_page, last_page, batch_size, request_bytes, mode, fallback_reason, profileElapsedMs(runtime, started_ns),
+    std.log.info("read-profile phase=ocr_batch source_fingerprint={s} first_page={?d} last_page={?d} batch_size={d} request_bytes={d} mode={s} serial_fallback_reason={?s} elapsed_ms={d:.3}", .{
+        source_fingerprint, first_page, last_page, batch_size, request_bytes, mode, fallback_reason, profileElapsedMs(runtime, started_ns),
     });
 }
 

--- a/zig/pkg/inference/src/pipelines/reading.zig
+++ b/zig/pkg/inference/src/pipelines/reading.zig
@@ -51,7 +51,7 @@ pub const ReadTelemetry = struct {
 };
 
 var last_read_telemetry: ReadTelemetry = .{};
-threadlocal var active_read_profile_correlation_id: ?[]const u8 = null;
+threadlocal var active_read_profile_source_fingerprint: ?[]const u8 = null;
 
 pub fn resetLastReadTelemetry() void {
     last_read_telemetry = .{};
@@ -78,7 +78,7 @@ pub const ReadConfig = struct {
     pix2struct_patch_width: usize = 0,
     pix2struct_do_normalize: bool = false,
     prompt: ?[]const u8 = null,
-    correlation_id: ?[]const u8 = null,
+    source_fingerprint: ?[]const u8 = null,
 };
 
 pub const ReadResult = struct {
@@ -118,9 +118,9 @@ pub const ReadingPipeline = struct {
 
     /// Read text from an image. image_data is raw JPEG/PNG bytes.
     pub fn read(self: *ReadingPipeline, image_data: []const u8) !ReadResult {
-        const previous_correlation_id = active_read_profile_correlation_id;
-        active_read_profile_correlation_id = self.config.correlation_id;
-        defer active_read_profile_correlation_id = previous_correlation_id;
+        const previous_source_fingerprint = active_read_profile_source_fingerprint;
+        active_read_profile_source_fingerprint = self.config.source_fingerprint;
+        defer active_read_profile_source_fingerprint = previous_source_fingerprint;
         resetLastReadTelemetry();
         const allocator = self.allocator;
         const debug_cuda_session = platform.env.getenvBool("ANTFLY_INFERENCE_DEBUG_CUDA_SESSION");
@@ -157,9 +157,9 @@ pub const ReadingPipeline = struct {
     /// back to the existing serial path; native Florence uses a batched encoder
     /// and KV-decoder path where the selected backend supports it.
     pub fn readBatch(self: *ReadingPipeline, image_datas: []const []const u8) ![]ReadResult {
-        const previous_correlation_id = active_read_profile_correlation_id;
-        active_read_profile_correlation_id = self.config.correlation_id;
-        defer active_read_profile_correlation_id = previous_correlation_id;
+        const previous_source_fingerprint = active_read_profile_source_fingerprint;
+        active_read_profile_source_fingerprint = self.config.source_fingerprint;
+        defer active_read_profile_source_fingerprint = previous_source_fingerprint;
         const allocator = self.allocator;
         if (image_datas.len == 0) return try allocator.alloc(ReadResult, 0);
         if (image_datas.len == 1) {
@@ -1333,8 +1333,8 @@ pub const ReadingPipeline = struct {
         const text_len = if (dec_len > prefix_len) dec_len - prefix_len else 0;
         last_read_telemetry.generated_tokens = text_len;
         if (readProfileEnabled()) {
-            if (active_read_profile_correlation_id) |correlation_id| {
-                std.log.info("read-profile correlation_id={s} phase=output output_tokens={d} model_max_tokens={d}", .{ correlation_id, text_len, self.config.max_length });
+            if (active_read_profile_source_fingerprint) |source_fingerprint| {
+                std.log.info("read-profile source_fingerprint={s} phase=output output_tokens={d} model_max_tokens={d}", .{ source_fingerprint, text_len, self.config.max_length });
             } else {
                 std.log.info("read-profile phase=output output_tokens={d} model_max_tokens={d}", .{ text_len, self.config.max_length });
             }
@@ -1469,8 +1469,8 @@ fn tokenTensorToU32(cb: *const ComputeBackend, allocator: std.mem.Allocator, tok
 
 fn logReadProfile(phase: []const u8, start_ns: u64) void {
     if (!readProfileEnabled()) return;
-    if (active_read_profile_correlation_id) |correlation_id| {
-        std.log.info("read-profile correlation_id={s} phase={s} elapsed_ms={d:.3}", .{ correlation_id, phase, nsToMs(nowNs() - start_ns) });
+    if (active_read_profile_source_fingerprint) |source_fingerprint| {
+        std.log.info("read-profile source_fingerprint={s} phase={s} elapsed_ms={d:.3}", .{ source_fingerprint, phase, nsToMs(nowNs() - start_ns) });
     } else {
         std.log.info("read-profile phase={s} elapsed_ms={d:.3}", .{ phase, nsToMs(nowNs() - start_ns) });
     }
@@ -1478,8 +1478,8 @@ fn logReadProfile(phase: []const u8, start_ns: u64) void {
 
 fn logReadProfileStep(phase: []const u8, step: usize, seq_len: usize, elapsed_ns: u64) void {
     if (!readProfileEnabled()) return;
-    if (active_read_profile_correlation_id) |correlation_id| {
-        std.log.info("read-profile correlation_id={s} phase={s} step={d} seq_len={d} elapsed_ms={d:.3}", .{ correlation_id, phase, step, seq_len, nsToMs(elapsed_ns) });
+    if (active_read_profile_source_fingerprint) |source_fingerprint| {
+        std.log.info("read-profile source_fingerprint={s} phase={s} step={d} seq_len={d} elapsed_ms={d:.3}", .{ source_fingerprint, phase, step, seq_len, nsToMs(elapsed_ns) });
     } else {
         std.log.info("read-profile phase={s} step={d} seq_len={d} elapsed_ms={d:.3}", .{ phase, step, seq_len, nsToMs(elapsed_ns) });
     }
@@ -1489,11 +1489,11 @@ fn logReadBatchMode(mode: []const u8, image_datas: []const []const u8, fallback_
     if (!readProfileEnabled()) return;
     var encoded_bytes: usize = 0;
     for (image_datas) |data| encoded_bytes +|= data.len;
-    if (active_read_profile_correlation_id) |correlation_id| {
+    if (active_read_profile_source_fingerprint) |source_fingerprint| {
         if (fallback_reason) |reason| {
-            std.log.info("read-profile correlation_id={s} phase=batch mode={s} count={d} encoded_bytes={d} serial_fallback_reason={s}", .{ correlation_id, mode, image_datas.len, encoded_bytes, reason });
+            std.log.info("read-profile source_fingerprint={s} phase=batch mode={s} count={d} encoded_bytes={d} serial_fallback_reason={s}", .{ source_fingerprint, mode, image_datas.len, encoded_bytes, reason });
         } else {
-            std.log.info("read-profile correlation_id={s} phase=batch mode={s} count={d} encoded_bytes={d}", .{ correlation_id, mode, image_datas.len, encoded_bytes });
+            std.log.info("read-profile source_fingerprint={s} phase=batch mode={s} count={d} encoded_bytes={d}", .{ source_fingerprint, mode, image_datas.len, encoded_bytes });
         }
     } else if (fallback_reason) |reason| {
         std.log.info("read-profile phase=batch mode={s} count={d} encoded_bytes={d} serial_fallback_reason={s}", .{ mode, image_datas.len, encoded_bytes, reason });

--- a/zig/pkg/inference/src/readers/reader.zig
+++ b/zig/pkg/inference/src/readers/reader.zig
@@ -69,7 +69,7 @@ const VisionLoadedReader = struct {
         var raw = try self.core.readRaw(image_data, .{
             .prompt = normalized_prompt,
             .max_tokens = options.max_tokens,
-            .correlation_id = options.correlation_id,
+            .source_fingerprint = options.source_fingerprint,
         });
         defer raw.deinit();
 
@@ -82,7 +82,7 @@ const VisionLoadedReader = struct {
         const raw_results = try self.core.readRawBatch(image_datas, .{
             .prompt = normalized_prompt,
             .max_tokens = options.max_tokens,
-            .correlation_id = options.correlation_id,
+            .source_fingerprint = options.source_fingerprint,
         });
         defer {
             for (raw_results) |raw| {

--- a/zig/pkg/inference/src/readers/types.zig
+++ b/zig/pkg/inference/src/readers/types.zig
@@ -61,7 +61,7 @@ pub const ReadOptions = struct {
     prompt: ?[]const u8 = null,
     max_tokens: ?usize = null,
     cache_dtype: ?[]const u8 = null,
-    correlation_id: ?[]const u8 = null,
+    source_fingerprint: ?[]const u8 = null,
 };
 
 pub fn flattenStructuredToFields(allocator: std.mem.Allocator, value: *const StructuredValue) ![]Field {

--- a/zig/pkg/inference/src/readers/vision_reader.zig
+++ b/zig/pkg/inference/src/readers/vision_reader.zig
@@ -183,7 +183,7 @@ pub const LoadedVisionReader = struct {
                 .pix2struct_patch_width = self.preproc.pix2struct_patch_width,
                 .pix2struct_do_normalize = self.preproc.pix2struct_do_normalize,
                 .prompt = options.prompt,
-                .correlation_id = options.correlation_id,
+                .source_fingerprint = options.source_fingerprint,
             },
             &self.florence_final_logits_bias_zero,
         );

--- a/zig/pkg/inference/src/server/server.zig
+++ b/zig/pkg/inference/src/server/server.zig
@@ -1213,7 +1213,7 @@ pub const Node = struct {
         const results = try reader.readBatch(image_datas, .{
             .prompt = request.prompt,
             .max_tokens = max_tokens,
-            .correlation_id = request.correlation_id,
+            .source_fingerprint = request.source_fingerprint,
         });
         defer {
             for (results) |result| {


### PR DESCRIPTION
Stacked on the exact current head reported by #366 (01c28ba). The author fork branch was force-reset to a partial, diverged history, so aj/pr366-review-base preserves that reviewed head as the comparison base.

Fixes the concrete review blockers identified on #366:

- Enforce the ASCII85 decoded-byte budget before each output growth.
- Validate predictor parameters with checked arithmetic and bound rows before allocation.
- Scope producer_json redaction to enrichment configurations while preserving legitimate document schema properties.
- Move file-descriptor limit mechanics into antfly_platform and classify every server command from one enum, including lite and ha.
- Name the stable source hash prefix source_fingerprint throughout profiling rather than correlation_id/source_sha256.

Validation:
- zig build lib-pdf-test
- zig build lib-readers-test
- targeted metadata, asset runtime, enrichment runtime, inference, and antfly-main tests
- native and Windows compile checks for the platform process abstraction

The larger generic processing-stage and derivation-provenance API redesign is intentionally left for a separate coordinated schema migration; this follow-up stays backward-compatible and focused on the correctness, security, and bounded design fixes.