### PR TITLE
Restore Go CI for v0.1.x

### DIFF
--- a/.github/workflows/antfly-go.yml
+++ b/.github/workflows/antfly-go.yml
@@ -5,7 +5,7 @@ name: Go
 
 on:
   push:
-    branches: ["main"]
+    branches: ["v0.1.x"]
     paths-ignore:
       - "*.md"
       - "docs/**"
@@ -19,7 +19,7 @@ on:
       - ".github/workflows/antfly-container.yml"
       - ".github/workflows/trigger-docs-build.yml"
   pull_request:
-    branches: ["main"]
+    branches: ["v0.1.x"]
     paths-ignore:
       - "*.md"
       - "docs/**"
@@ -32,6 +32,7 @@ on:
       - ".github/workflows/antfly-operator-*.yml"
       - ".github/workflows/antfly-container.yml"
       - ".github/workflows/trigger-docs-build.yml"
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}

--- a/e2e/go.sum
+++ b/e2e/go.sum
@@ -178,8 +178,6 @@ github.com/blevesearch/zapx/v15 v15.4.3 h1:iJiMJOHrz216jyO6lS0m9RTCEkprUnzvqAI2l
 github.com/blevesearch/zapx/v15 v15.4.3/go.mod h1:1pssev/59FsuWcgSnTa0OeEpOzmhtmr/0/11H0Z8+Nw=
 github.com/blevesearch/zapx/v16 v16.3.1 h1:ERxZUSC9UcuKggCQ6b3y4sTkyL4WnGOWuopzglR874g=
 github.com/blevesearch/zapx/v16 v16.3.1/go.mod h1:zCFjv7McXWm1C8rROL+3mUoD5WYe2RKsZP3ufqcYpLY=
-github.com/blevesearch/zapx/v17 v17.0.4 h1:TGfCW5s1nDgIefTyqEpdJFf01lgPFLR5pHRwlHQBZjs=
-github.com/blevesearch/zapx/v17 v17.0.4/go.mod h1:7v2Fb6FOUBqB19jWnSkDc9vKLD+tPWBceVF17Vje2uQ=
 github.com/bmatcuk/doublestar v1.1.1/go.mod h1:UD6OnuiIn0yFxxA2le/rnRU1G4RaI4UvFv1sNto9p6w=
 github.com/bmatcuk/doublestar/v4 v4.6.1/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/bmatcuk/doublestar/v4 v4.10.0 h1:zU9WiOla1YA122oLM6i4EXvGW62DvKZVxIe6TYWexEs=


### PR DESCRIPTION
> ## Summary
> 
> - run the legacy Go workflow for pushes and pull requests targeting `v0.1.x`
> - add a manual `workflow_dispatch` trigger
> - remove two stale `e2e/go.sum` entries that otherwise fail `make tidy-check`
> 
> ## Why
> 
> The Go workflow remained on the maintenance branch after Go CI was removed from `main`, but its branch filters still targeted `main`. As a result, changes such as #381 receive no legacy Go test coverage.
> 
> This is CI-maintenance work for the supported v0.1.x line; it does not alter #381's implementation.
> 
> ## Validation
> 
> - `make tidy-check`
> - `git diff --check`
> - `actionlint .github/workflows/antfly-go.yml` parses the workflow and reports only pre-existing shell-quoting warnings in unchanged steps
> 
> After this merges, #381 must receive a new `pull_request` event (for example, close/reopen or synchronize) because Actions does not retroactively run workflows for existing PR events.
> 