### PR TITLE
Fix ARM64 vector distance SIMD dispatch

### DIFF
--- a/e2e/go.mod
+++ b/e2e/go.mod
@@ -65,7 +65,7 @@ require (
 	github.com/RaduBerinde/btreemap v0.0.0-20260105202824-d3184786f603 // indirect
 	github.com/RoaringBitmap/roaring/v2 v2.16.0 // indirect
 	github.com/a2aproject/a2a-go v0.3.12 // indirect
-	github.com/ajroetker/go-highway v0.0.13-0.20260309234436-8d249c4caa48 // indirect
+	github.com/ajroetker/go-highway v0.0.13-0.20260528204430-c3b5b59834b1 // indirect
 	github.com/ajroetker/go-jpeg2000 v0.0.2 // indirect
 	github.com/ajroetker/pdf v0.0.1-antfly001 // indirect
 	github.com/ajroetker/pdf/render v0.0.1-antfly003 // indirect

--- a/e2e/go.sum
+++ b/e2e/go.sum
@@ -50,8 +50,8 @@ github.com/a2aproject/a2a-go v0.3.12 h1:l5Yd0UgZrZyEuiMRlj3ybiqxmqXvVhJ8bTyWB7Zl
 github.com/a2aproject/a2a-go v0.3.12/go.mod h1:I7Cm+a1oL+UT6zMoP+roaRE5vdfUa1iQGVN8aSOuZ0I=
 github.com/aclements/go-perfevent v0.0.0-20240301234650-f7843625020f h1:JjxwchlOepwsUWcQwD2mLUAGE9aCp0/ehy6yCHFBOvo=
 github.com/aclements/go-perfevent v0.0.0-20240301234650-f7843625020f/go.mod h1:tMDTce/yLLN/SK8gMOxQfnyeMeCg8KGzp0D1cbECEeo=
-github.com/ajroetker/go-highway v0.0.13-0.20260309234436-8d249c4caa48 h1:Q7rlCp02ZQ6YQ6cYx4X8cI6l1LRtIEmRRYB389X8msM=
-github.com/ajroetker/go-highway v0.0.13-0.20260309234436-8d249c4caa48/go.mod h1:un7fcrwix7UOHJrr18Lgh5eeF+1yaZiGWdTw3FbfDv4=
+github.com/ajroetker/go-highway v0.0.13-0.20260528204430-c3b5b59834b1 h1:PAEA9KYpE58upyfgLfokJa8Gt8sph52bytdCqomEHV4=
+github.com/ajroetker/go-highway v0.0.13-0.20260528204430-c3b5b59834b1/go.mod h1:un7fcrwix7UOHJrr18Lgh5eeF+1yaZiGWdTw3FbfDv4=
 github.com/ajroetker/go-jpeg2000 v0.0.2 h1:ni8brffZrci4Kacx3nM5d92ipmTDfak84KgHYi6IxFw=
 github.com/ajroetker/go-jpeg2000 v0.0.2/go.mod h1:7ld88W47lZy0x8gRQesRGAonDPOpr6ev8rckjCAfbzE=
 github.com/ajroetker/gomlx v0.0.0-antfly011 h1:t0BZSBrYuJIwTiZplB9vxsVQy6OaP8+pMjCHaWUI3iY=

--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,7 @@ require (
 	cloud.google.com/go/speech v1.30.0
 	codeberg.org/readeck/go-readability/v2 v2.1.1
 	github.com/a2aproject/a2a-go v0.3.12
-	github.com/ajroetker/go-highway v0.0.13-0.20260309234436-8d249c4caa48
+	github.com/ajroetker/go-highway v0.0.13-0.20260528204430-c3b5b59834b1
 	github.com/ajroetker/pdf v0.0.1-antfly001
 	github.com/ajroetker/pdf/render v0.0.1-antfly003
 	github.com/alpkeskin/gotoon v0.1.1

--- a/go.sum
+++ b/go.sum
@@ -165,8 +165,8 @@ github.com/aclements/go-perfevent v0.0.0-20240301234650-f7843625020f h1:JjxwchlO
 github.com/aclements/go-perfevent v0.0.0-20240301234650-f7843625020f/go.mod h1:tMDTce/yLLN/SK8gMOxQfnyeMeCg8KGzp0D1cbECEeo=
 github.com/agnivade/levenshtein v1.2.1 h1:EHBY3UOn1gwdy/VbFwgo4cxecRznFk7fKWN1KOX7eoM=
 github.com/agnivade/levenshtein v1.2.1/go.mod h1:QVVI16kDrtSuwcpd0p1+xMC6Z/VfhtCyDIjcwga4/DU=
-github.com/ajroetker/go-highway v0.0.13-0.20260309234436-8d249c4caa48 h1:Q7rlCp02ZQ6YQ6cYx4X8cI6l1LRtIEmRRYB389X8msM=
-github.com/ajroetker/go-highway v0.0.13-0.20260309234436-8d249c4caa48/go.mod h1:un7fcrwix7UOHJrr18Lgh5eeF+1yaZiGWdTw3FbfDv4=
+github.com/ajroetker/go-highway v0.0.13-0.20260528204430-c3b5b59834b1 h1:PAEA9KYpE58upyfgLfokJa8Gt8sph52bytdCqomEHV4=
+github.com/ajroetker/go-highway v0.0.13-0.20260528204430-c3b5b59834b1/go.mod h1:un7fcrwix7UOHJrr18Lgh5eeF+1yaZiGWdTw3FbfDv4=
 github.com/ajroetker/go-jpeg2000 v0.0.2 h1:ni8brffZrci4Kacx3nM5d92ipmTDfak84KgHYi6IxFw=
 github.com/ajroetker/go-jpeg2000 v0.0.2/go.mod h1:7ld88W47lZy0x8gRQesRGAonDPOpr6ev8rckjCAfbzE=
 github.com/ajroetker/gomlx v0.0.0-antfly011 h1:t0BZSBrYuJIwTiZplB9vxsVQy6OaP8+pMjCHaWUI3iY=


### PR DESCRIPTION
## Summary
- bump go-highway to the current Go 1.26-compatible main revision
- pick up the ARM64 dispatcher fix that installs the NEON distance kernels instead of the scalar fallback
- align the root and e2e module graphs and checksums

## Context
The previous go-highway snapshot generated ARM64 distance dispatchers that always selected the scalar fallback, even though NEON assembly implementations were present. This becomes especially expensive during WAL catch-up, where vector distance calculations are performed at high volume.

The new revision routes initDistanceAll through initDistanceNEONAsm on ARM64 and installs the float32/float64 NEON assembly wrappers. No tagged go-highway release currently contains this fix, so this PR pins the upstream main commit c3b5b59834b1.

## Validation
- env GOWORK=off GOEXPERIMENT=simd go test ./lib/vector/... ./lib/vectorindex/... ./lib/sparseindex/... github.com/ajroetker/go-highway/hwy/contrib/vec
- root and e2e go mod tidy -diff
- git diff --check

Validation was run natively on ARM64.