### PR TITLE
Back off recoverable derived-index retries

### DIFF
--- a/zig/build.zig
+++ b/zig/build.zig
@@ -4776,6 +4776,7 @@ pub fn build(b: *std.Build) void {
             "provisioned table write source consistent visibility refreshes stale dense status",
             "provisioned table write source visibility hook defers status sampling to runtime owner",
             "provisioned table write source status visibility does not invalidate read cache",
+            "provisioned table write source metrics serve cached snapshot while write cache lock is busy",
             "provisioned table restore lifecycle reserves forwarded owner and caller sources",
             "provisioned startup catch-up enters through forwarded write owner",
             "provisioned runtime status inspection remains available during structural transition",

--- a/zig/lib/platform/src/process_memory.zig
+++ b/zig/lib/platform/src/process_memory.zig
@@ -16,6 +16,9 @@ const std = @import("std");
 const builtin = @import("builtin");
 
 pub const Stats = struct {
+    cpu_available: bool = false,
+    user_cpu_ns: u64 = 0,
+    system_cpu_ns: u64 = 0,
     available: bool = false,
     resident_bytes: u64 = 0,
     peak_resident_bytes: u64 = 0,
@@ -45,6 +48,10 @@ pub fn pressureWorkingSetBytes(stats: Stats) u64 {
 
 pub fn snapshot() Stats {
     var stats = pressureSnapshot();
+    const cpu = processCpuSnapshot();
+    stats.cpu_available = cpu.available;
+    stats.user_cpu_ns = cpu.user_ns;
+    stats.system_cpu_ns = cpu.system_ns;
     if (!stats.available or builtin.os.tag != .macos) return stats;
 
     const malloc_stats = darwin.mallocStats();
@@ -52,6 +59,31 @@ pub fn snapshot() Stats {
     stats.malloc_allocated_bytes = malloc_stats.allocated_bytes;
     stats.malloc_zone_bytes = malloc_stats.zone_bytes;
     return stats;
+}
+
+const CpuStats = struct {
+    available: bool = false,
+    user_ns: u64 = 0,
+    system_ns: u64 = 0,
+};
+
+fn processCpuSnapshot() CpuStats {
+    if (builtin.os.tag == .freestanding or builtin.os.tag == .windows or builtin.os.tag == .wasi) return .{};
+    const usage = std.posix.getrusage(std.posix.rusage.SELF);
+    return .{
+        .available = true,
+        .user_ns = timevalNs(usage.utime),
+        .system_ns = timevalNs(usage.stime),
+    };
+}
+
+fn timevalNs(value: anytype) u64 {
+    if (value.sec < 0 or value.usec < 0) return 0;
+    const seconds: u64 = @intCast(value.sec);
+    const microseconds: u64 = @intCast(value.usec);
+    const seconds_ns = std.math.mul(u64, seconds, std.time.ns_per_s) catch std.math.maxInt(u64);
+    const microseconds_ns = std.math.mul(u64, microseconds, std.time.ns_per_us) catch std.math.maxInt(u64);
+    return seconds_ns +| microseconds_ns;
 }
 
 /// Low-overhead OS memory-pressure sample for hot qualification loops. This

--- a/zig/pkg/antfly/src/api/runtime_status.zig
+++ b/zig/pkg/antfly/src/api/runtime_status.zig
@@ -156,6 +156,7 @@ pub const TableRuntimeSummary = struct {
     indexes_with_replay_debt: usize = 0,
     outstanding_replay_sequences: u64 = 0,
     max_index_replay_backlog: u64 = 0,
+    text_merge: db_mod.types.TextMergeStats = .{},
     async_indexing: db_mod.types.AsyncIndexingStats = .{},
 };
 
@@ -626,6 +627,7 @@ pub const TableRuntimeSnapshotCache = struct {
             var group_it = entry.groups.valueIterator();
             while (group_it.next()) |status| {
                 result.group_count += 1;
+                db_mod.types.accumulateTextMergeStats(&result.text_merge, status.stats.text_merge);
                 db_mod.types.accumulateAsyncIndexingStats(&result.async_indexing, status.stats.async_indexing);
                 var group_has_replay_debt = false;
                 result.index_count += status.stats.indexes.len;

--- a/zig/pkg/antfly/src/api/table_writes.zig
+++ b/zig/pkg/antfly/src/api/table_writes.zig
@@ -8953,9 +8953,7 @@ pub const ProvisionedTableWriteSource = struct {
     pub fn asyncIndexingStatsBestEffort(self: *ProvisionedTableWriteSource) db_mod.types.AsyncIndexingStats {
         const startup_active = self.startup_catch_up_active.load(.monotonic);
         if (!self.local_db_mutex.tryLock()) {
-            if (startup_active) {
-                if (self.runtime_status_cache) |snapshot_cache| return snapshot_cache.summary().async_indexing;
-            }
+            if (self.runtime_status_cache) |snapshot_cache| return snapshot_cache.summary().async_indexing;
             return .{};
         }
         defer self.local_db_mutex.unlock();
@@ -9001,13 +8999,24 @@ pub const ProvisionedTableWriteSource = struct {
     }
 
     pub fn textMergeStatsBestEffort(self: *ProvisionedTableWriteSource) db_mod.types.TextMergeStats {
-        if (!self.local_db_mutex.tryLock()) return .{};
+        if (!self.local_db_mutex.tryLock()) {
+            if (self.runtime_status_cache) |snapshot_cache| return snapshot_cache.summary().text_merge;
+            return .{};
+        }
         defer self.local_db_mutex.unlock();
-        const cache = self.write_cache orelse return .{};
+        const cache = self.write_cache orelse {
+            if (self.runtime_status_cache) |snapshot_cache| return snapshot_cache.summary().text_merge;
+            return .{};
+        };
         var stats = db_mod.types.TextMergeStats{};
+        var observed = false;
         for (cache.entries.items) |entry| {
             const entry_stats = entry.db.trySnapshotTextMergeStats() orelse continue;
+            observed = true;
             db_mod.types.accumulateTextMergeStats(&stats, entry_stats);
+        }
+        if (!observed) {
+            if (self.runtime_status_cache) |snapshot_cache| return snapshot_cache.summary().text_merge;
         }
         return stats;
     }
@@ -28475,7 +28484,7 @@ test "provisioned table write source managed writer probe is unknown while sourc
     try std.testing.expectEqual(@as(ProvisionedTableWriteSource.ManagedWriterGroupProbe, .unknown), source.probeManagedWriterGroupBestEffort("docs", 7001));
 }
 
-test "provisioned table write source runtime status stays null while dirty and busy during startup catch-up" {
+test "provisioned table write source metrics serve cached snapshot while write cache lock is busy" {
     const alloc = std.testing.allocator;
 
     const NoCatalog = struct {
@@ -28506,7 +28515,17 @@ test "provisioned table write source runtime status stays null while dirty and b
             .doc_count = 9,
             .index_count = 1,
             .indexes = try alloc.alloc(db_mod.types.DBIndexStats, 1),
+            .text_merge = .{
+                .completed_merges = 42,
+            },
             .async_indexing = .{
+                .derived_workers = .{
+                    .workers = 1,
+                    .workers_with_replay_debt = 1,
+                    .max_replay_lag_sequences = 5,
+                    .recoverable_retries = 7,
+                    .writer_locked_retries = 7,
+                },
                 .startup = .{
                     .active = true,
                     .phase = .artifact_rebuild,
@@ -28558,6 +28577,13 @@ test "provisioned table write source runtime status stays null while dirty and b
     try std.testing.expectEqual(@as(u64, 99), async_stats.startup.wal_retained_bytes);
     try std.testing.expect(async_stats.dense_catch_up.active);
     try std.testing.expectEqual(@as(u64, 9), async_stats.dense_catch_up.current_target_sequence);
+
+    source.startup_catch_up_active.store(false, .monotonic);
+    const steady_state_async_stats = source.asyncIndexingStatsBestEffort();
+    try std.testing.expectEqual(@as(u64, 1), steady_state_async_stats.derived_workers.workers_with_replay_debt);
+    try std.testing.expectEqual(@as(u64, 7), steady_state_async_stats.derived_workers.writer_locked_retries);
+    const text_merge_stats = source.textMergeStatsBestEffort();
+    try std.testing.expectEqual(@as(u64, 42), text_merge_stats.completed_merges);
 }
 
 test "provisioned table write source runtime status serves cached snapshot when request is idle" {

--- a/zig/pkg/antfly/src/data/runtime.zig
+++ b/zig/pkg/antfly/src/data/runtime.zig
@@ -1543,6 +1543,16 @@ const AsyncMutexMetricField = enum {
 };
 
 fn writeAsyncIndexingMetrics(writer: *std.Io.Writer, stats: antfly.db.types.AsyncIndexingStats) !void {
+    try health_metrics.appendPromMetric(writer, "antfly_async_index_workers", "gauge", "Derived-index workers running across cached writable tables", stats.derived_workers.workers);
+    try health_metrics.appendPromMetric(writer, "antfly_async_index_workers_with_replay_debt", "gauge", "Derived-index workers whose target sequence is ahead of their applied sequence", stats.derived_workers.workers_with_replay_debt);
+    try health_metrics.appendPromMetric(writer, "antfly_async_index_max_replay_lag_sequences", "gauge", "Largest target-minus-applied sequence lag across derived-index workers", stats.derived_workers.max_replay_lag_sequences);
+    try health_metrics.appendPromMetricHeader(writer, "antfly_async_index_recoverable_retries_total", "counter", "Derived-index worker retries after recoverable failures, labeled by reason");
+    try appendDerivedRetrySample(writer, "writer_locked", stats.derived_workers.writer_locked_retries);
+    try appendDerivedRetrySample(writer, "resource_budget_exceeded", stats.derived_workers.resource_budget_retries);
+    try appendDerivedRetrySample(writer, "replay_document_not_visible", stats.derived_workers.replay_document_not_visible_retries);
+    try appendDerivedRetrySample(writer, "artifact_repair_required", stats.derived_workers.artifact_repair_required_retries);
+    try appendDerivedRetrySample(writer, "not_found", stats.derived_workers.not_found_retries);
+
     try writeAsyncMutexMetricFamily(writer, stats, .lock_calls, "antfly_async_index_mutex_lock_calls_total", "counter", "Async indexing mutex lock attempts");
     try writeAsyncMutexMetricFamily(writer, stats, .contended_calls, "antfly_async_index_mutex_contended_calls_total", "counter", "Async indexing mutex lock attempts that encountered contention");
     try writeAsyncMutexMetricFamily(writer, stats, .max_waiters, "antfly_async_index_mutex_max_waiters", "gauge", "Maximum concurrent waiters observed for each async indexing mutex");
@@ -1653,6 +1663,12 @@ fn writeAsyncIndexingMetrics(writer: *std.Io.Writer, stats: antfly.db.types.Asyn
     try health_metrics.appendPromMetric(writer, "antfly_async_index_dense_catch_up_manifest_ns_total", "counter", "Manifest write nanoseconds observed during dense catch-up finish", stats.dense_catch_up.manifest_ns);
     try health_metrics.appendPromMetric(writer, "antfly_async_index_dense_catch_up_write_pressure_compactions_total", "counter", "Write-pressure compactions observed during dense catch-up finish", stats.dense_catch_up.write_pressure_compactions);
     try health_metrics.appendPromMetric(writer, "antfly_async_index_dense_catch_up_write_pressure_ns_total", "counter", "Write-pressure compaction nanoseconds observed during dense catch-up finish", stats.dense_catch_up.write_pressure_ns);
+}
+
+fn appendDerivedRetrySample(writer: *std.Io.Writer, reason: []const u8, count: u64) !void {
+    try health_metrics.appendPromSampleLabeled(writer, "antfly_async_index_recoverable_retries_total", &.{
+        .{ .name = "reason", .value = reason },
+    }, count);
 }
 
 fn writeAsyncMutexMetricFamily(
@@ -1812,6 +1828,16 @@ fn writeLsmNativeStorageMetrics(writer: *std.Io.Writer, stats: ?lsm_backend_mod.
 }
 
 fn writeProcessMemoryMetrics(writer: *std.Io.Writer, stats: process_memory_mod.Stats) !void {
+    try health_metrics.appendPromMetric(writer, "antfly_process_cpu_available", "gauge", "Whether process CPU metrics are available on this platform", if (stats.cpu_available) 1 else 0);
+    if (stats.cpu_available) {
+        try health_metrics.appendPromMetricHeader(writer, "antfly_process_cpu_ns_total", "counter", "Process CPU time in nanoseconds, labeled by mode");
+        try health_metrics.appendPromSampleLabeled(writer, "antfly_process_cpu_ns_total", &.{
+            .{ .name = "mode", .value = "user" },
+        }, stats.user_cpu_ns);
+        try health_metrics.appendPromSampleLabeled(writer, "antfly_process_cpu_ns_total", &.{
+            .{ .name = "mode", .value = "system" },
+        }, stats.system_cpu_ns);
+    }
     try health_metrics.appendPromMetric(writer, "antfly_process_memory_available", "gauge", "Whether process memory metrics are available on this platform", if (stats.available) 1 else 0);
     if (!stats.available) return;
     try health_metrics.appendPromMetric(writer, "antfly_process_resident_bytes", "gauge", "Process resident bytes reported by the operating system", stats.resident_bytes);
@@ -20313,6 +20339,9 @@ test "data runtime metrics use prometheus labels for resource and cache dimensio
 
     writer = .fixed(&writer_buf);
     try writeProcessMemoryMetrics(&writer, .{
+        .cpu_available = true,
+        .user_cpu_ns = 1_500_000_000,
+        .system_cpu_ns = 250_000_000,
         .available = true,
         .resident_bytes = 11,
         .anonymous_bytes = 12,
@@ -20325,6 +20354,9 @@ test "data runtime metrics use prometheus labels for resource and cache dimensio
         .malloc_zone_bytes = 31,
     });
     const process_memory_output = writer.buffered();
+    try std.testing.expect(std.mem.indexOf(u8, process_memory_output, "antfly_process_cpu_available 1") != null);
+    try std.testing.expect(std.mem.indexOf(u8, process_memory_output, "antfly_process_cpu_ns_total{mode=\"user\"} 1500000000") != null);
+    try std.testing.expect(std.mem.indexOf(u8, process_memory_output, "antfly_process_cpu_ns_total{mode=\"system\"} 250000000") != null);
     try std.testing.expect(std.mem.indexOf(u8, process_memory_output, "antfly_process_memory_available 1") != null);
     try std.testing.expect(std.mem.indexOf(u8, process_memory_output, "antfly_process_anonymous_bytes 12") != null);
     try std.testing.expect(std.mem.indexOf(u8, process_memory_output, "antfly_process_private_dirty_bytes 17") != null);
@@ -20622,6 +20654,17 @@ test "data runtime health metrics include replay debt and provisioned warmup cou
             .index_count = 2,
             .indexes = try std.testing.allocator.alloc(antfly.db.types.DBIndexStats, 2),
             .async_indexing = .{
+                .derived_workers = .{
+                    .workers = 2,
+                    .workers_with_replay_debt = 1,
+                    .max_replay_lag_sequences = 3,
+                    .recoverable_retries = 11,
+                    .writer_locked_retries = 7,
+                    .resource_budget_retries = 1,
+                    .replay_document_not_visible_retries = 1,
+                    .artifact_repair_required_retries = 1,
+                    .not_found_retries = 1,
+                },
                 .startup = .{
                     .active = true,
                     .phase = .opening_db,
@@ -20820,6 +20863,11 @@ test "data runtime health metrics include replay debt and provisioned warmup cou
     try std.testing.expect(std.mem.indexOf(u8, output, "antfly_lsm_wal_append_records_total 0") != null);
     try std.testing.expect(std.mem.indexOf(u8, output, "antfly_lsm_wal_sync_ns_total 0") != null);
     try std.testing.expect(std.mem.indexOf(u8, output, "antfly_lsm_wal_resets_total 0") != null);
+    try std.testing.expect(std.mem.indexOf(u8, output, "antfly_async_index_workers 2") != null);
+    try std.testing.expect(std.mem.indexOf(u8, output, "antfly_async_index_workers_with_replay_debt 1") != null);
+    try std.testing.expect(std.mem.indexOf(u8, output, "antfly_async_index_max_replay_lag_sequences 3") != null);
+    try std.testing.expect(std.mem.indexOf(u8, output, "antfly_async_index_recoverable_retries_total{reason=\"writer_locked\"} 7") != null);
+    try std.testing.expect(std.mem.indexOf(u8, output, "antfly_async_index_recoverable_retries_total{reason=\"resource_budget_exceeded\"} 1") != null);
     try std.testing.expect(std.mem.indexOf(u8, output, "antfly_async_index_startup_active 1") != null);
     try std.testing.expect(std.mem.indexOf(u8, output, "antfly_async_index_startup_wal_retained_segments 4") != null);
     try std.testing.expect(std.mem.indexOf(u8, output, "antfly_async_index_startup_wal_retained_bytes 99") != null);

--- a/zig/pkg/antfly/src/data/runtime.zig
+++ b/zig/pkg/antfly/src/data/runtime.zig
@@ -1198,7 +1198,12 @@ pub const HealthSource = struct {
         try writeLsmMaintenanceMetrics(writer, lsm_maintenance_stats.stats);
         try writeLsmWriteMetrics(writer, live_write_source.lsmWriteStatsBestEffort());
         try writeTextMergeMetrics(writer, live_write_source.textMergeStatsBestEffort());
-        try writeAsyncIndexingMetrics(writer, live_write_source.asyncIndexingStatsBestEffort());
+        var async_indexing_stats = live_write_source.asyncIndexingStatsBestEffort();
+        applyProcessDerivedRetryStats(
+            &async_indexing_stats,
+            self.data_server.provisioned_storage.resource_manager.derivedRecoverableRetryStats(),
+        );
+        try writeAsyncIndexingMetrics(writer, async_indexing_stats);
         try antfly.db.query_metrics.writePrometheus(writer);
         try antfly.db.enrichment_utf8_text.writePrometheus(writer);
     }
@@ -1663,6 +1668,18 @@ fn writeAsyncIndexingMetrics(writer: *std.Io.Writer, stats: antfly.db.types.Asyn
     try health_metrics.appendPromMetric(writer, "antfly_async_index_dense_catch_up_manifest_ns_total", "counter", "Manifest write nanoseconds observed during dense catch-up finish", stats.dense_catch_up.manifest_ns);
     try health_metrics.appendPromMetric(writer, "antfly_async_index_dense_catch_up_write_pressure_compactions_total", "counter", "Write-pressure compactions observed during dense catch-up finish", stats.dense_catch_up.write_pressure_compactions);
     try health_metrics.appendPromMetric(writer, "antfly_async_index_dense_catch_up_write_pressure_ns_total", "counter", "Write-pressure compaction nanoseconds observed during dense catch-up finish", stats.dense_catch_up.write_pressure_ns);
+}
+
+fn applyProcessDerivedRetryStats(
+    stats: *antfly.db.types.AsyncIndexingStats,
+    retries: resource_manager_mod.DerivedRecoverableRetryStats,
+) void {
+    stats.derived_workers.recoverable_retries = retries.total;
+    stats.derived_workers.writer_locked_retries = retries.writer_locked;
+    stats.derived_workers.resource_budget_retries = retries.resource_budget;
+    stats.derived_workers.replay_document_not_visible_retries = retries.replay_document_not_visible;
+    stats.derived_workers.artifact_repair_required_retries = retries.artifact_repair_required;
+    stats.derived_workers.not_found_retries = retries.not_found;
 }
 
 fn appendDerivedRetrySample(writer: *std.Io.Writer, reason: []const u8, count: u64) !void {
@@ -20658,12 +20675,15 @@ test "data runtime health metrics include replay debt and provisioned warmup cou
                     .workers = 2,
                     .workers_with_replay_debt = 1,
                     .max_replay_lag_sequences = 3,
-                    .recoverable_retries = 11,
-                    .writer_locked_retries = 7,
-                    .resource_budget_retries = 1,
-                    .replay_document_not_visible_retries = 1,
-                    .artifact_repair_required_retries = 1,
-                    .not_found_retries = 1,
+                    // Deliberately stale relative to the process-owned
+                    // counters populated below. Counter export must not fall
+                    // back to this evictable runtime snapshot.
+                    .recoverable_retries = 110,
+                    .writer_locked_retries = 70,
+                    .resource_budget_retries = 10,
+                    .replay_document_not_visible_retries = 10,
+                    .artifact_repair_required_retries = 10,
+                    .not_found_retries = 10,
                 },
                 .startup = .{
                     .active = true,
@@ -20748,6 +20768,11 @@ test "data runtime health metrics include replay debt and provisioned warmup cou
     server.provisioned_root_refresh_completed.store(7, .monotonic);
     server.provisioned_root_refresh_failed.store(1, .monotonic);
     server.provisioned_root_refresh_last_duration_ns.store(66, .monotonic);
+    for (0..7) |_| server.provisioned_storage.resource_manager.recordDerivedRecoverableRetry(error.WriterLocked);
+    server.provisioned_storage.resource_manager.recordDerivedRecoverableRetry(error.ResourceBudgetExceeded);
+    server.provisioned_storage.resource_manager.recordDerivedRecoverableRetry(error.ReplayDocumentNotVisible);
+    server.provisioned_storage.resource_manager.recordDerivedRecoverableRetry(error.ArtifactRepairRequired);
+    server.provisioned_storage.resource_manager.recordDerivedRecoverableRetry(error.NotFound);
 
     var health = HealthSource{ .data_server = &server };
     var writer: std.Io.Writer.Allocating = .init(std.testing.allocator);

--- a/zig/pkg/antfly/src/storage/db/db.zig
+++ b/zig/pkg/antfly/src/storage/db/db.zig
@@ -4378,6 +4378,7 @@ pub const DB = struct {
     pub fn snapshotAsyncIndexingStats(self: *DB) types.AsyncIndexingStats {
         var async_stats = self.async_context.stats.snapshot();
         async_stats.bulk_coalescing = self.bulk_ingest_coalescer.stats.snapshot();
+        async_stats.derived_workers = self.executor.snapshotStats();
         return async_stats;
     }
 

--- a/zig/pkg/antfly/src/storage/db/derived/async_runtime.zig
+++ b/zig/pkg/antfly/src/storage/db/derived/async_runtime.zig
@@ -1141,6 +1141,8 @@ const DenseTargetAdvanceSessionCapture = struct {
     target_advance_calls: std.atomic.Value(u64) = .init(0),
     persist_calls: std.atomic.Value(u64) = .init(0),
     persisted_sequence: std.atomic.Value(u64) = .init(0),
+    truncate_calls: std.atomic.Value(u64) = .init(0),
+    truncated_sequence: std.atomic.Value(u64) = .init(0),
 };
 
 fn testDenseTargetAdvanceSessionApply(ctx: *anyopaque, batch: derived_types.DerivedBatch, index_ref: index_manager_mod.ManagedIndexRef) !bool {
@@ -1158,6 +1160,12 @@ fn testDenseTargetAdvanceSessionPersist(ctx: *anyopaque, index_name: []const u8,
     _ = capture.persist_calls.fetchAdd(1, .monotonic);
     capture.persisted_sequence.store(sequence, .monotonic);
     return true;
+}
+
+fn testDenseTargetAdvanceSessionTruncate(ctx: *anyopaque, sequence: u64) !void {
+    const capture: *DenseTargetAdvanceSessionCapture = @ptrCast(@alignCast(ctx));
+    _ = capture.truncate_calls.fetchAdd(1, .monotonic);
+    capture.truncated_sequence.store(sequence, .monotonic);
 }
 
 fn testDenseTargetAdvanceSessionBegin(ctx: *anyopaque, index_ref: index_manager_mod.ManagedIndexRef) !void {
@@ -1211,7 +1219,7 @@ test "async dense workers advance zero-applied target while catch-up sessions ar
         &capture,
         testDenseTargetAdvanceSessionApply,
         testDenseTargetAdvanceSessionPersist,
-        testRuntimeTruncate,
+        testDenseTargetAdvanceSessionTruncate,
         testDenseTargetAdvanceSessionBegin,
         testDenseTargetAdvanceSessionFinish,
         testDenseTargetAdvanceWhileSessionOpen,
@@ -1234,6 +1242,8 @@ test "async dense workers advance zero-applied target while catch-up sessions ar
     try std.testing.expectEqual(@as(u64, 2), capture.finish_calls.load(.monotonic));
     try std.testing.expectEqual(@as(u64, 0), capture.active_sessions.load(.monotonic));
     try std.testing.expectEqual(@as(u64, 1), capture.persisted_sequence.load(.monotonic));
+    try std.testing.expect(capture.truncate_calls.load(.monotonic) >= 1);
+    try std.testing.expectEqual(@as(u64, 1), capture.truncated_sequence.load(.monotonic));
 }
 
 test "async dense publish NotFound retries without failing runtime" {

--- a/zig/pkg/antfly/src/storage/db/derived/async_runtime.zig
+++ b/zig/pkg/antfly/src/storage/db/derived/async_runtime.zig
@@ -461,6 +461,7 @@ fn workerMain(worker: *Worker) void {
         if (target_sequence <= from_sequence) {
             if (from_sequence > persisted_sequence) {
                 const persisted = persistIdleAppliedSequence(runtime, worker, from_sequence) catch |err| {
+                    if (err == error.WorkerStopping) return;
                     if (err == error.WriterLocked or err == error.ResourceBudgetExceeded) {
                         sleepAfterRecoverableCatchUpError(worker, err);
                         continue;
@@ -629,24 +630,17 @@ fn workerMain(worker: *Worker) void {
         if (applied_sequence_advanced) if (runtime.applied_sequence_advanced_fn) |callback| {
             callback(runtime.ctx, worker.name, caught_up_sequence);
         };
-        worker.recoverable_retry_backoff.reset();
 
         if (shouldRefreshReplayCursor(worker, caught_up_sequence)) {
             closeWorkerReplayCursor(runtime, worker);
         }
 
         if (truncate_sequence > 0) {
-            runtime.truncate_fn(runtime.ctx, truncate_sequence) catch |err| {
-                if (err == error.WriterLocked) {
-                    lock(runtime);
-                    runtime.truncates_in_flight -= 1;
-                    runtime.mutex.unlock();
-                    std.Thread.yield() catch {};
-                    continue;
-                }
+            truncateWithRecoverableRetry(runtime, worker, truncate_sequence) catch |err| {
                 lock(runtime);
                 runtime.truncates_in_flight -= 1;
                 runtime.mutex.unlock();
+                if (err == error.WorkerStopping) return;
                 runtime.recordError(err);
                 return;
             };
@@ -655,6 +649,7 @@ fn workerMain(worker: *Worker) void {
             runtime.truncates_in_flight -= 1;
             runtime.mutex.unlock();
         }
+        worker.recoverable_retry_backoff.reset();
     }
 }
 
@@ -678,7 +673,7 @@ fn persistIdleAppliedSequence(runtime: *DerivedRuntime, worker: *Worker, sequenc
     runtime.mutex.unlock();
 
     if (truncate_sequence > 0) {
-        runtime.truncate_fn(runtime.ctx, truncate_sequence) catch |err| {
+        truncateWithRecoverableRetry(runtime, worker, truncate_sequence) catch |err| {
             lock(runtime);
             runtime.truncates_in_flight -= 1;
             runtime.mutex.unlock();
@@ -690,6 +685,23 @@ fn persistIdleAppliedSequence(runtime: *DerivedRuntime, worker: *Worker, sequenc
         runtime.mutex.unlock();
     }
     return persisted;
+}
+
+fn truncateWithRecoverableRetry(runtime: *DerivedRuntime, worker: *Worker, sequence: u64) !void {
+    while (true) {
+        lock(runtime);
+        const stopping = runtime.shutdown or worker.stop or runtime.last_error_name != null;
+        runtime.mutex.unlock();
+        if (stopping) return error.WorkerStopping;
+        runtime.truncate_fn(runtime.ctx, sequence) catch |err| {
+            if (err == error.WriterLocked) {
+                sleepAfterRecoverableCatchUpError(worker, err);
+                continue;
+            }
+            return err;
+        };
+        return;
+    }
 }
 
 fn ensureWorkerCatchUpState(runtime: *DerivedRuntime, worker: *Worker, from_sequence: u64) !void {
@@ -746,6 +758,7 @@ fn isRecoverableCatchUpError(worker: *const Worker, err: anyerror) bool {
 fn sleepAfterRecoverableCatchUpError(worker: *Worker, err: anyerror) void {
     const delay_ns = catch_up_policy.recordRecoverableRetry(
         &worker.runtime.recoverable_retry_counters,
+        worker.runtime.backlog.resource_manager,
         &worker.recoverable_retry_backoff,
         err,
     );
@@ -855,11 +868,14 @@ const TestRuntimeCapture = struct {
     target_advance_calls: std.atomic.Value(u64) = .init(0),
     persist_calls: std.atomic.Value(u64) = .init(0),
     persisted_sequence: std.atomic.Value(u64) = .init(0),
+    truncate_calls: std.atomic.Value(u64) = .init(0),
+    truncated_sequence: std.atomic.Value(u64) = .init(0),
     last_applied_batch_sequence: std.atomic.Value(u64) = .init(0),
     defer_next_persist: std.atomic.Value(bool) = .init(false),
     skip_next_apply: std.atomic.Value(bool) = .init(false),
     fail_next_dense_apply_not_found: std.atomic.Value(bool) = .init(false),
     fail_next_publish: std.atomic.Value(bool) = .init(false),
+    fail_next_truncate_writer_locked: std.atomic.Value(bool) = .init(false),
 };
 
 fn testRuntimeApply(ctx: *anyopaque, batch: derived_types.DerivedBatch, index_ref: index_manager_mod.ManagedIndexRef) !bool {
@@ -885,8 +901,10 @@ fn testRuntimePersist(ctx: *anyopaque, index_name: []const u8, sequence: u64, fo
 }
 
 fn testRuntimeTruncate(ctx: *anyopaque, sequence: u64) !void {
-    _ = ctx;
-    _ = sequence;
+    const capture: *TestRuntimeCapture = @ptrCast(@alignCast(ctx));
+    _ = capture.truncate_calls.fetchAdd(1, .monotonic);
+    if (capture.fail_next_truncate_writer_locked.swap(false, .monotonic)) return error.WriterLocked;
+    capture.truncated_sequence.store(sequence, .monotonic);
 }
 
 fn testRuntimeBeginCatchUp(ctx: *anyopaque, index_ref: index_manager_mod.ManagedIndexRef) !void {
@@ -1426,6 +1444,57 @@ test "async worker retries idle applied sequence persist and releases backlog" {
     try std.testing.expectEqual(@as(u64, 0), stats.slices[@intFromEnum(resource_manager_mod.Slice.derived_backlog)].used_bytes);
     try std.testing.expect(capture.persist_calls.load(.monotonic) >= 2);
     try std.testing.expectEqual(@as(u64, 1), capture.persisted_sequence.load(.monotonic));
+}
+
+test "async worker backoffs and retries replay truncation writer lock" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const journal_path = try std.fmt.allocPrint(alloc, ".zig-cache/tmp/{s}/async-truncate-writer-lock-retry-journal", .{tmp.sub_path});
+    defer alloc.free(journal_path);
+    const journal_path_z = try alloc.dupeZ(u8, journal_path);
+    defer alloc.free(journal_path_z);
+
+    var journal = try change_journal_mod.Journal.open(journal_path_z, testInMemoryJournalOpenOptions());
+    defer journal.close();
+    try appendTestChangeJournalRecord(&journal, alloc, .{
+        .sequence = 1,
+        .changed_doc_keys = &.{"doc:a"},
+        .target_hints = &.{.full_text},
+    });
+
+    var manager = resource_manager_mod.ResourceManager.init(.{});
+    defer manager.deinit(alloc);
+    var capture = TestRuntimeCapture{ .alloc = alloc };
+    capture.fail_next_truncate_writer_locked.store(true, .monotonic);
+    var runtime = DerivedRuntime.init(
+        alloc,
+        replay_source_mod.Source.fromJournal(&journal),
+        &capture,
+        testRuntimeApply,
+        testRuntimePersist,
+        testRuntimeTruncate,
+        testRuntimeBeginCatchUp,
+        testRuntimeFinishCatchUp,
+        null,
+        null,
+        &manager,
+    );
+    defer runtime.deinit();
+
+    try runtime.addWorker("text_idx", .{ .name = "text_idx", .kind = .full_text }, 0);
+    runtime.notifySequence(1);
+    try runtime.waitForAll(1);
+    try runtime.failIfUnhealthy();
+
+    try std.testing.expectEqual(@as(u64, 2), capture.truncate_calls.load(.monotonic));
+    try std.testing.expectEqual(@as(u64, 1), capture.truncated_sequence.load(.monotonic));
+    try std.testing.expectEqual(@as(u64, 1), runtime.snapshotStats().writer_locked_retries);
+    try std.testing.expectEqual(@as(u64, 1), manager.derivedRecoverableRetryStats().writer_locked);
+    lock(&runtime);
+    defer runtime.mutex.unlock();
+    try std.testing.expectEqual(@as(u8, 0), runtime.workers.items[0].recoverable_retry_backoff.failures);
 }
 
 test "async dense publishes applied window before target tail is visible" {

--- a/zig/pkg/antfly/src/storage/db/derived/async_runtime.zig
+++ b/zig/pkg/antfly/src/storage/db/derived/async_runtime.zig
@@ -49,7 +49,7 @@ const Worker = struct {
     replay_cursor: ?replay_source_mod.MatchingCursor = null,
     replay_cursor_open_sequence: u64 = 0,
     last_replay_tail_records: u64 = 0,
-    pressure_retry_backoff: catch_up_policy.PressureRetryBackoff = .{},
+    recoverable_retry_backoff: catch_up_policy.RecoverableRetryBackoff = .{},
 };
 
 fn forcePersistAppliedSequence(worker: *const Worker) bool {
@@ -90,6 +90,7 @@ pub const DerivedRuntime = struct {
     last_notified_sequence: u64 = 0,
     truncates_in_flight: usize = 0,
     backlog: backlog_tracker_mod.Tracker,
+    recoverable_retry_counters: catch_up_policy.RecoverableRetryCounters = .{},
 
     pub fn init(
         alloc: Allocator,
@@ -217,6 +218,27 @@ pub const DerivedRuntime = struct {
             if (std.mem.eql(u8, worker.name, name)) return worker.applied_sequence;
         }
         return null;
+    }
+
+    pub fn snapshotStats(self: *DerivedRuntime) types.DerivedWorkerStats {
+        lock(self);
+        defer self.mutex.unlock();
+        var stats = types.DerivedWorkerStats{
+            .workers = @intCast(self.workers.items.len),
+        };
+        for (self.workers.items) |worker| {
+            const lag = worker.target_sequence -| worker.applied_sequence;
+            if (lag > 0) stats.workers_with_replay_debt += 1;
+            stats.max_replay_lag_sequences = @max(stats.max_replay_lag_sequences, lag);
+        }
+        const retries = self.recoverable_retry_counters.snapshot();
+        stats.recoverable_retries = retries.total;
+        stats.writer_locked_retries = retries.writer_locked;
+        stats.resource_budget_retries = retries.resource_budget;
+        stats.replay_document_not_visible_retries = retries.replay_document_not_visible;
+        stats.artifact_repair_required_retries = retries.artifact_repair_required;
+        stats.not_found_retries = retries.not_found;
+        return stats;
     }
 
     pub fn notifySequence(self: *DerivedRuntime, sequence: u64) void {
@@ -446,7 +468,7 @@ fn workerMain(worker: *Worker) void {
                     runtime.recordError(err);
                     return;
                 };
-                worker.pressure_retry_backoff.reset();
+                worker.recoverable_retry_backoff.reset();
                 if (!persisted) sleepNs(50 * std.time.ns_per_ms);
                 continue;
             }
@@ -607,7 +629,7 @@ fn workerMain(worker: *Worker) void {
         if (applied_sequence_advanced) if (runtime.applied_sequence_advanced_fn) |callback| {
             callback(runtime.ctx, worker.name, caught_up_sequence);
         };
-        worker.pressure_retry_backoff.reset();
+        worker.recoverable_retry_backoff.reset();
 
         if (shouldRefreshReplayCursor(worker, caught_up_sequence)) {
             closeWorkerReplayCursor(runtime, worker);
@@ -722,16 +744,15 @@ fn isRecoverableCatchUpError(worker: *const Worker, err: anyerror) bool {
 }
 
 fn sleepAfterRecoverableCatchUpError(worker: *Worker, err: anyerror) void {
-    if (err != error.ResourceBudgetExceeded) {
-        worker.pressure_retry_backoff.reset();
-        std.Thread.yield() catch {};
-        return;
-    }
-    const delay_ns = worker.pressure_retry_backoff.nextDelayNs();
-    if (worker.pressure_retry_backoff.shouldLog()) {
+    const delay_ns = catch_up_policy.recordRecoverableRetry(
+        &worker.runtime.recoverable_retry_counters,
+        &worker.recoverable_retry_backoff,
+        err,
+    );
+    if (worker.recoverable_retry_backoff.shouldLog()) {
         std.log.warn(
-            "derived worker resource admission deferred worker={s} failures={} retry_ms={}",
-            .{ worker.name, worker.pressure_retry_backoff.failures, delay_ns / std.time.ns_per_ms },
+            "derived worker retrying recoverable failure worker={s} error={s} failures={} retry_ms={}",
+            .{ worker.name, @errorName(err), worker.recoverable_retry_backoff.failures, delay_ns / std.time.ns_per_ms },
         );
     }
     sleepNs(delay_ns);

--- a/zig/pkg/antfly/src/storage/db/derived/catch_up_policy.zig
+++ b/zig/pkg/antfly/src/storage/db/derived/catch_up_policy.zig
@@ -29,13 +29,13 @@ const replay_default_max_items_per_window: usize = 8 * 1024;
 const replay_default_window_bytes: u64 = 16 * 1024 * 1024;
 const dense_replay_default_window_bytes: u64 = 64 * 1024 * 1024;
 const dense_replay_max_window_bytes: u64 = 256 * 1024 * 1024;
-const pressure_retry_min_delay_ns: u64 = 10 * std.time.ns_per_ms;
-const pressure_retry_max_delay_ns: u64 = 250 * std.time.ns_per_ms;
+const recoverable_retry_min_delay_ns: u64 = 10 * std.time.ns_per_ms;
+const recoverable_retry_max_delay_ns: u64 = 250 * std.time.ns_per_ms;
 
-/// Bounded backoff for transient resource-admission failures. The derived
-/// worker owns this state, so a pressured index yields without poisoning the
-/// whole runtime or spinning while compaction releases memory.
-pub const PressureRetryBackoff = struct {
+/// Bounded backoff for transient derived-worker failures. The worker owns this
+/// state so a persistently unavailable dependency yields without poisoning the
+/// whole runtime or spinning until the dependency becomes available.
+pub const RecoverableRetryBackoff = struct {
     failures: u8 = 0,
 
     pub fn reset(self: *@This()) void {
@@ -45,13 +45,63 @@ pub const PressureRetryBackoff = struct {
     pub fn nextDelayNs(self: *@This()) u64 {
         const shift: u6 = @intCast(@min(self.failures, 5));
         self.failures +|= 1;
-        return @min(pressure_retry_min_delay_ns << shift, pressure_retry_max_delay_ns);
+        return @min(recoverable_retry_min_delay_ns << shift, recoverable_retry_max_delay_ns);
     }
 
     pub fn shouldLog(self: @This()) bool {
         return self.failures == 1 or std.math.isPowerOfTwo(self.failures);
     }
 };
+
+pub const RecoverableRetryStats = struct {
+    total: u64 = 0,
+    writer_locked: u64 = 0,
+    resource_budget: u64 = 0,
+    replay_document_not_visible: u64 = 0,
+    artifact_repair_required: u64 = 0,
+    not_found: u64 = 0,
+};
+
+pub const RecoverableRetryCounters = struct {
+    total: std.atomic.Value(u64) = .init(0),
+    writer_locked: std.atomic.Value(u64) = .init(0),
+    resource_budget: std.atomic.Value(u64) = .init(0),
+    replay_document_not_visible: std.atomic.Value(u64) = .init(0),
+    artifact_repair_required: std.atomic.Value(u64) = .init(0),
+    not_found: std.atomic.Value(u64) = .init(0),
+
+    pub fn record(self: *@This(), err: anyerror) void {
+        _ = self.total.fetchAdd(1, .monotonic);
+        switch (err) {
+            error.WriterLocked => _ = self.writer_locked.fetchAdd(1, .monotonic),
+            error.ResourceBudgetExceeded => _ = self.resource_budget.fetchAdd(1, .monotonic),
+            error.ReplayDocumentNotVisible => _ = self.replay_document_not_visible.fetchAdd(1, .monotonic),
+            error.ArtifactRepairRequired => _ = self.artifact_repair_required.fetchAdd(1, .monotonic),
+            error.NotFound => _ = self.not_found.fetchAdd(1, .monotonic),
+            else => {},
+        }
+    }
+
+    pub fn snapshot(self: *const @This()) RecoverableRetryStats {
+        return .{
+            .total = self.total.load(.monotonic),
+            .writer_locked = self.writer_locked.load(.monotonic),
+            .resource_budget = self.resource_budget.load(.monotonic),
+            .replay_document_not_visible = self.replay_document_not_visible.load(.monotonic),
+            .artifact_repair_required = self.artifact_repair_required.load(.monotonic),
+            .not_found = self.not_found.load(.monotonic),
+        };
+    }
+};
+
+pub fn recordRecoverableRetry(
+    counters: *RecoverableRetryCounters,
+    backoff: *RecoverableRetryBackoff,
+    err: anyerror,
+) u64 {
+    counters.record(err);
+    return backoff.nextDelayNs();
+}
 
 fn getenv(name: [*:0]const u8) ?[*:0]u8 {
     if (!builtin.link_libc) return null;
@@ -195,8 +245,8 @@ fn denseReplayMaxWindowBytes(resource_manager: ?*resource_manager_mod.ResourceMa
     });
 }
 
-test "pressure retry backoff is bounded and resets" {
-    var backoff = PressureRetryBackoff{};
+test "recoverable retry backoff is bounded and resets" {
+    var backoff = RecoverableRetryBackoff{};
     try std.testing.expectEqual(@as(u64, 10 * std.time.ns_per_ms), backoff.nextDelayNs());
     try std.testing.expectEqual(@as(u64, 20 * std.time.ns_per_ms), backoff.nextDelayNs());
     try std.testing.expectEqual(@as(u64, 40 * std.time.ns_per_ms), backoff.nextDelayNs());
@@ -206,6 +256,35 @@ test "pressure retry backoff is bounded and resets" {
     try std.testing.expectEqual(@as(u64, 250 * std.time.ns_per_ms), backoff.nextDelayNs());
     backoff.reset();
     try std.testing.expectEqual(@as(u64, 10 * std.time.ns_per_ms), backoff.nextDelayNs());
+}
+
+test "writer-locked derived-worker retries are counted and backoffed" {
+    var counters = RecoverableRetryCounters{};
+    var backoff = RecoverableRetryBackoff{};
+    try std.testing.expectEqual(
+        @as(u64, 10 * std.time.ns_per_ms),
+        recordRecoverableRetry(&counters, &backoff, error.WriterLocked),
+    );
+    const stats = counters.snapshot();
+    try std.testing.expectEqual(@as(u64, 1), stats.total);
+    try std.testing.expectEqual(@as(u64, 1), stats.writer_locked);
+}
+
+test "recoverable retry counters preserve failure reasons" {
+    var counters = RecoverableRetryCounters{};
+    counters.record(error.WriterLocked);
+    counters.record(error.ResourceBudgetExceeded);
+    counters.record(error.ReplayDocumentNotVisible);
+    counters.record(error.ArtifactRepairRequired);
+    counters.record(error.NotFound);
+
+    const stats = counters.snapshot();
+    try std.testing.expectEqual(@as(u64, 5), stats.total);
+    try std.testing.expectEqual(@as(u64, 1), stats.writer_locked);
+    try std.testing.expectEqual(@as(u64, 1), stats.resource_budget);
+    try std.testing.expectEqual(@as(u64, 1), stats.replay_document_not_visible);
+    try std.testing.expectEqual(@as(u64, 1), stats.artifact_repair_required);
+    try std.testing.expectEqual(@as(u64, 1), stats.not_found);
 }
 
 test "full text replay policy bounds work by item count as well as bytes" {

--- a/zig/pkg/antfly/src/storage/db/derived/catch_up_policy.zig
+++ b/zig/pkg/antfly/src/storage/db/derived/catch_up_policy.zig
@@ -96,10 +96,12 @@ pub const RecoverableRetryCounters = struct {
 
 pub fn recordRecoverableRetry(
     counters: *RecoverableRetryCounters,
+    resource_manager: ?*resource_manager_mod.ResourceManager,
     backoff: *RecoverableRetryBackoff,
     err: anyerror,
 ) u64 {
     counters.record(err);
+    if (resource_manager) |manager| manager.recordDerivedRecoverableRetry(err);
     return backoff.nextDelayNs();
 }
 
@@ -260,14 +262,17 @@ test "recoverable retry backoff is bounded and resets" {
 
 test "writer-locked derived-worker retries are counted and backoffed" {
     var counters = RecoverableRetryCounters{};
+    var manager = resource_manager_mod.ResourceManager.init(.{});
+    defer manager.deinit(std.testing.allocator);
     var backoff = RecoverableRetryBackoff{};
     try std.testing.expectEqual(
         @as(u64, 10 * std.time.ns_per_ms),
-        recordRecoverableRetry(&counters, &backoff, error.WriterLocked),
+        recordRecoverableRetry(&counters, &manager, &backoff, error.WriterLocked),
     );
     const stats = counters.snapshot();
     try std.testing.expectEqual(@as(u64, 1), stats.total);
     try std.testing.expectEqual(@as(u64, 1), stats.writer_locked);
+    try std.testing.expectEqual(@as(u64, 1), manager.derivedRecoverableRetryStats().writer_locked);
 }
 
 test "recoverable retry counters preserve failure reasons" {

--- a/zig/pkg/antfly/src/storage/db/derived/derived_executor.zig
+++ b/zig/pkg/antfly/src/storage/db/derived/derived_executor.zig
@@ -99,6 +99,10 @@ const async_runtime_mod = if (builtin.os.tag == .freestanding) struct {
             return null;
         }
 
+        pub fn snapshotStats(_: *@This()) types.DerivedWorkerStats {
+            return .{};
+        }
+
         pub fn notifySequence(self: *@This(), sequence: u64) void {
             _ = self;
             _ = sequence;
@@ -179,6 +183,7 @@ pub const Executor = struct {
         add_worker: *const fn (ptr: *anyopaque, name: []const u8, kind: index_manager_mod.ManagedIndexRef, applied_sequence: u64) anyerror!void,
         remove_worker: *const fn (ptr: *anyopaque, name: []const u8) void,
         applied_sequence: *const fn (ptr: *anyopaque, name: []const u8) ?u64,
+        snapshot_stats: *const fn (ptr: *anyopaque) types.DerivedWorkerStats,
         notify_sequence: *const fn (ptr: *anyopaque, sequence: u64) void,
         notify_indexes: *const fn (ptr: *anyopaque, sequence: u64, index_names: []const []const u8) void,
         notify_except_kind: *const fn (ptr: *anyopaque, sequence: u64, excluded_kind: types.IndexKind) void,
@@ -213,6 +218,10 @@ pub const Executor = struct {
 
     pub fn appliedSequence(self: *Executor, name: []const u8) ?u64 {
         return self.vtable.applied_sequence(self.ptr, name);
+    }
+
+    pub fn snapshotStats(self: *Executor) types.DerivedWorkerStats {
+        return self.vtable.snapshot_stats(self.ptr);
     }
 
     pub fn notifySequence(self: *Executor, sequence: u64) void {
@@ -337,6 +346,18 @@ const ManualRuntime = struct {
             if (std.mem.eql(u8, worker.name, name)) return worker.applied_sequence;
         }
         return null;
+    }
+
+    fn snapshotStats(self: *ManualRuntime) types.DerivedWorkerStats {
+        var stats = types.DerivedWorkerStats{
+            .workers = @intCast(self.workers.items.len),
+        };
+        for (self.workers.items) |worker| {
+            const lag = worker.target_sequence -| worker.applied_sequence;
+            if (lag > 0) stats.workers_with_replay_debt += 1;
+            stats.max_replay_lag_sequences = @max(stats.max_replay_lag_sequences, lag);
+        }
+        return stats;
     }
 
     fn notifySequence(self: *ManualRuntime, sequence: u64) void {
@@ -517,6 +538,7 @@ const manual_vtable = Executor.VTable{
     .add_worker = manualAddWorker,
     .remove_worker = manualRemoveWorker,
     .applied_sequence = manualAppliedSequence,
+    .snapshot_stats = manualSnapshotStats,
     .notify_sequence = manualNotifySequence,
     .notify_indexes = manualNotifyIndexes,
     .notify_except_kind = manualNotifyExceptKind,
@@ -557,6 +579,11 @@ fn manualRemoveWorker(ptr: *anyopaque, name: []const u8) void {
 fn manualAppliedSequence(ptr: *anyopaque, name: []const u8) ?u64 {
     const runtime: *ManualRuntime = @ptrCast(@alignCast(ptr));
     return runtime.appliedSequence(name);
+}
+
+fn manualSnapshotStats(ptr: *anyopaque) types.DerivedWorkerStats {
+    const runtime: *ManualRuntime = @ptrCast(@alignCast(ptr));
+    return runtime.snapshotStats();
 }
 
 fn manualNotifySequence(ptr: *anyopaque, sequence: u64) void {
@@ -641,6 +668,7 @@ const io_threaded_vtable = Executor.VTable{
     .add_worker = ioThreadedAddWorker,
     .remove_worker = ioThreadedRemoveWorker,
     .applied_sequence = ioThreadedAppliedSequence,
+    .snapshot_stats = ioThreadedSnapshotStats,
     .notify_sequence = ioThreadedNotifySequence,
     .notify_indexes = ioThreadedNotifyIndexes,
     .notify_except_kind = ioThreadedNotifyExceptKind,
@@ -681,6 +709,11 @@ fn ioThreadedRemoveWorker(ptr: *anyopaque, name: []const u8) void {
 fn ioThreadedAppliedSequence(ptr: *anyopaque, name: []const u8) ?u64 {
     const runtime: *io_threaded_runtime_mod.DerivedRuntime = @ptrCast(@alignCast(ptr));
     return runtime.appliedSequence(name);
+}
+
+fn ioThreadedSnapshotStats(ptr: *anyopaque) types.DerivedWorkerStats {
+    const runtime: *io_threaded_runtime_mod.DerivedRuntime = @ptrCast(@alignCast(ptr));
+    return runtime.snapshotStats();
 }
 
 fn ioThreadedNotifySequence(ptr: *anyopaque, sequence: u64) void {

--- a/zig/pkg/antfly/src/storage/db/derived/io_threaded_runtime.zig
+++ b/zig/pkg/antfly/src/storage/db/derived/io_threaded_runtime.zig
@@ -50,7 +50,7 @@ const Worker = struct {
     replay_cursor_open_sequence: u64 = 0,
     catch_up_active: bool = false,
     last_replay_tail_records: u64 = 0,
-    pressure_retry_backoff: catch_up_policy.PressureRetryBackoff = .{},
+    recoverable_retry_backoff: catch_up_policy.RecoverableRetryBackoff = .{},
 };
 
 const PersistSnapshot = struct {
@@ -147,6 +147,10 @@ pub const DerivedRuntime = if (builtin.os.tag == .freestanding) struct {
         return null;
     }
 
+    pub fn snapshotStats(_: *@This()) types.DerivedWorkerStats {
+        return .{};
+    }
+
     pub fn notifySequence(self: *@This(), sequence: u64) void {
         _ = self;
         _ = sequence;
@@ -218,6 +222,7 @@ pub const DerivedRuntime = if (builtin.os.tag == .freestanding) struct {
     last_notified_sequence: u64 = 0,
     truncates_in_flight: usize = 0,
     backlog: backlog_tracker_mod.Tracker,
+    recoverable_retry_counters: catch_up_policy.RecoverableRetryCounters = .{},
 
     pub fn init(
         alloc: Allocator,
@@ -432,6 +437,28 @@ pub const DerivedRuntime = if (builtin.os.tag == .freestanding) struct {
             if (std.mem.eql(u8, worker.name, name)) return worker.applied_sequence;
         }
         return null;
+    }
+
+    pub fn snapshotStats(self: *DerivedRuntime) types.DerivedWorkerStats {
+        const io = self.ioContext();
+        self.mutex.lockUncancelable(io);
+        defer self.mutex.unlock(io);
+        var stats = types.DerivedWorkerStats{
+            .workers = @intCast(self.workers.items.len),
+        };
+        for (self.workers.items) |worker| {
+            const lag = worker.target_sequence -| worker.applied_sequence;
+            if (lag > 0) stats.workers_with_replay_debt += 1;
+            stats.max_replay_lag_sequences = @max(stats.max_replay_lag_sequences, lag);
+        }
+        const retries = self.recoverable_retry_counters.snapshot();
+        stats.recoverable_retries = retries.total;
+        stats.writer_locked_retries = retries.writer_locked;
+        stats.resource_budget_retries = retries.resource_budget;
+        stats.replay_document_not_visible_retries = retries.replay_document_not_visible;
+        stats.artifact_repair_required_retries = retries.artifact_repair_required;
+        stats.not_found_retries = retries.not_found;
+        return stats;
     }
 
     pub fn notifySequence(self: *DerivedRuntime, sequence: u64) void {
@@ -744,7 +771,7 @@ fn workerMain(worker: *Worker) void {
                     runtime.recordError(io, worker.name, "idle_persist", err);
                     return;
                 };
-                worker.pressure_retry_backoff.reset();
+                worker.recoverable_retry_backoff.reset();
                 if (!persisted) io.sleep(Io.Duration.fromNanoseconds(50 * std.time.ns_per_ms), .awake) catch {};
                 runtime.mutex.lockUncancelable(io);
                 continue;
@@ -955,7 +982,7 @@ fn workerMain(worker: *Worker) void {
         if (applied_sequence_advanced) if (runtime.applied_sequence_advanced_fn) |callback| {
             callback(runtime.ctx, worker.name, caught_up_sequence);
         };
-        worker.pressure_retry_backoff.reset();
+        worker.recoverable_retry_backoff.reset();
 
         if (shouldRefreshReplayCursor(worker, caught_up_sequence)) {
             closeWorkerReplayCursor(runtime, worker);
@@ -1088,16 +1115,15 @@ fn isRecoverableCatchUpError(worker: *const Worker, err: anyerror) bool {
 }
 
 fn sleepAfterRecoverableCatchUpError(worker: *Worker, err: anyerror, io: Io) void {
-    if (err != error.ResourceBudgetExceeded) {
-        worker.pressure_retry_backoff.reset();
-        io.sleep(Io.Duration.zero, .awake) catch {};
-        return;
-    }
-    const delay_ns = worker.pressure_retry_backoff.nextDelayNs();
-    if (worker.pressure_retry_backoff.shouldLog()) {
+    const delay_ns = catch_up_policy.recordRecoverableRetry(
+        &worker.runtime.recoverable_retry_counters,
+        &worker.recoverable_retry_backoff,
+        err,
+    );
+    if (worker.recoverable_retry_backoff.shouldLog()) {
         std.log.warn(
-            "derived worker resource admission deferred worker={s} failures={} retry_ms={}",
-            .{ worker.name, worker.pressure_retry_backoff.failures, delay_ns / std.time.ns_per_ms },
+            "derived worker retrying recoverable failure worker={s} error={s} failures={} retry_ms={}",
+            .{ worker.name, @errorName(err), worker.recoverable_retry_backoff.failures, delay_ns / std.time.ns_per_ms },
         );
     }
     io.sleep(Io.Duration.fromNanoseconds(@intCast(delay_ns)), .awake) catch {};

--- a/zig/pkg/antfly/src/storage/db/derived/io_threaded_runtime.zig
+++ b/zig/pkg/antfly/src/storage/db/derived/io_threaded_runtime.zig
@@ -763,6 +763,7 @@ fn workerMain(worker: *Worker) void {
                 const sequence = worker.applied_sequence;
                 runtime.mutex.unlock(io);
                 const persisted = persistIdleAppliedSequence(runtime, worker, sequence, io) catch |err| {
+                    if (err == error.WorkerStopping) return;
                     if (err == error.WriterLocked or err == error.ResourceBudgetExceeded) {
                         sleepAfterRecoverableCatchUpError(worker, err, io);
                         runtime.mutex.lockUncancelable(io);
@@ -982,26 +983,18 @@ fn workerMain(worker: *Worker) void {
         if (applied_sequence_advanced) if (runtime.applied_sequence_advanced_fn) |callback| {
             callback(runtime.ctx, worker.name, caught_up_sequence);
         };
-        worker.recoverable_retry_backoff.reset();
 
         if (shouldRefreshReplayCursor(worker, caught_up_sequence)) {
             closeWorkerReplayCursor(runtime, worker);
         }
 
         if (truncate_sequence > 0) {
-            runtime.truncate_fn(runtime.ctx, truncate_sequence) catch |err| {
-                if (err == error.WriterLocked) {
-                    runtime.mutex.lockUncancelable(io);
-                    runtime.truncates_in_flight -= 1;
-                    runtime.cond.broadcast(io);
-                    runtime.mutex.unlock(io);
-                    io.sleep(Io.Duration.zero, .awake) catch {};
-                    continue;
-                }
+            truncateWithRecoverableRetry(runtime, worker, truncate_sequence, io) catch |err| {
                 runtime.mutex.lockUncancelable(io);
                 runtime.truncates_in_flight -= 1;
                 runtime.cond.broadcast(io);
                 runtime.mutex.unlock(io);
+                if (err == error.WorkerStopping) return;
                 runtime.recordError(io, worker.name, "truncate", err);
                 return;
             };
@@ -1011,6 +1004,7 @@ fn workerMain(worker: *Worker) void {
             runtime.cond.broadcast(io);
             runtime.mutex.unlock(io);
         }
+        worker.recoverable_retry_backoff.reset();
     }
 }
 
@@ -1036,7 +1030,7 @@ fn persistIdleAppliedSequence(runtime: *DerivedRuntime, worker: *Worker, sequenc
     runtime.mutex.unlock(io);
 
     if (truncate_sequence > 0) {
-        runtime.truncate_fn(runtime.ctx, truncate_sequence) catch |err| {
+        truncateWithRecoverableRetry(runtime, worker, truncate_sequence, io) catch |err| {
             runtime.mutex.lockUncancelable(io);
             runtime.truncates_in_flight -= 1;
             runtime.cond.broadcast(io);
@@ -1050,6 +1044,23 @@ fn persistIdleAppliedSequence(runtime: *DerivedRuntime, worker: *Worker, sequenc
         runtime.mutex.unlock(io);
     }
     return persisted;
+}
+
+fn truncateWithRecoverableRetry(runtime: *DerivedRuntime, worker: *Worker, sequence: u64, io: Io) !void {
+    while (true) {
+        runtime.mutex.lockUncancelable(io);
+        const stopping = runtime.shutdown or worker.stop or runtime.last_error_name != null;
+        runtime.mutex.unlock(io);
+        if (stopping) return error.WorkerStopping;
+        runtime.truncate_fn(runtime.ctx, sequence) catch |err| {
+            if (err == error.WriterLocked) {
+                sleepAfterRecoverableCatchUpError(worker, err, io);
+                continue;
+            }
+            return err;
+        };
+        return;
+    }
 }
 
 fn ensureWorkerCatchUpState(runtime: *DerivedRuntime, worker: *Worker, from_sequence: u64) !void {
@@ -1117,6 +1128,7 @@ fn isRecoverableCatchUpError(worker: *const Worker, err: anyerror) bool {
 fn sleepAfterRecoverableCatchUpError(worker: *Worker, err: anyerror, io: Io) void {
     const delay_ns = catch_up_policy.recordRecoverableRetry(
         &worker.runtime.recoverable_retry_counters,
+        worker.runtime.backlog.resource_manager,
         &worker.recoverable_retry_backoff,
         err,
     );
@@ -1230,11 +1242,14 @@ const TestThreadedRuntimeCapture = struct {
     apply_not_found_failures: std.atomic.Value(u64) = .init(0),
     resource_budget_failures: std.atomic.Value(u64) = .init(0),
     persisted_sequence: std.atomic.Value(u64) = .init(0),
+    truncate_calls: std.atomic.Value(u64) = .init(0),
+    truncated_sequence: std.atomic.Value(u64) = .init(0),
     advanced_sequence: std.atomic.Value(u64) = .init(0),
     callback_observed_applied_sequence: std.atomic.Value(u64) = .init(0),
     fail_next_dense_apply_not_found: std.atomic.Value(bool) = .init(false),
     fail_next_apply_resource_budget: std.atomic.Value(bool) = .init(false),
     fail_next_publish: std.atomic.Value(bool) = .init(false),
+    fail_next_truncate_writer_locked: std.atomic.Value(bool) = .init(false),
 };
 
 fn testThreadedRuntimeAppliedSequenceAdvanced(ctx: *anyopaque, index_name: []const u8, sequence: u64) void {
@@ -1268,8 +1283,10 @@ fn testThreadedRuntimePersist(ctx: *anyopaque, index_name: []const u8, sequence:
 }
 
 fn testThreadedRuntimeTruncate(ctx: *anyopaque, sequence: u64) !void {
-    _ = ctx;
-    _ = sequence;
+    const capture: *TestThreadedRuntimeCapture = @ptrCast(@alignCast(ctx));
+    _ = capture.truncate_calls.fetchAdd(1, .monotonic);
+    if (capture.fail_next_truncate_writer_locked.swap(false, .monotonic)) return error.WriterLocked;
+    capture.truncated_sequence.store(sequence, .monotonic);
 }
 
 fn testThreadedRuntimeBeginCatchUp(ctx: *anyopaque, index_ref: index_manager_mod.ManagedIndexRef) !void {
@@ -1348,6 +1365,58 @@ test "io threaded applied callback observes published watermark outside runtime 
 
     try std.testing.expectEqual(@as(u64, 1), capture.advanced_sequence.load(.acquire));
     try std.testing.expectEqual(@as(u64, 1), capture.callback_observed_applied_sequence.load(.acquire));
+}
+
+test "io threaded worker backoffs and retries replay truncation writer lock" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const journal_path = try std.fmt.allocPrint(alloc, ".zig-cache/tmp/{s}/io-threaded-truncate-writer-lock-retry-journal", .{tmp.sub_path});
+    defer alloc.free(journal_path);
+    const journal_path_z = try alloc.dupeZ(u8, journal_path);
+    defer alloc.free(journal_path_z);
+
+    var journal = try change_journal_mod.Journal.open(journal_path_z, testThreadedRuntimeJournalOpenOptions());
+    defer journal.close();
+    try appendTestThreadedRuntimeRecord(&journal, alloc, .{
+        .sequence = 1,
+        .changed_doc_keys = &.{"doc:a"},
+        .target_hints = &.{.full_text},
+    });
+
+    var manager = resource_manager_mod.ResourceManager.init(.{});
+    defer manager.deinit(alloc);
+    var capture = TestThreadedRuntimeCapture{};
+    capture.fail_next_truncate_writer_locked.store(true, .monotonic);
+    var runtime = try DerivedRuntime.init(
+        alloc,
+        replay_source_mod.Source.fromJournal(&journal),
+        &capture,
+        testThreadedRuntimeApply,
+        testThreadedRuntimePersist,
+        testThreadedRuntimeTruncate,
+        testThreadedRuntimeBeginCatchUp,
+        testThreadedRuntimeFinishCatchUp,
+        null,
+        null,
+        &manager,
+    );
+    defer runtime.deinit();
+
+    try runtime.addWorker("text_idx", .{ .name = "text_idx", .kind = .full_text }, 0);
+    runtime.notifySequence(1);
+    try runtime.waitForAll(1);
+    try runtime.failIfUnhealthy();
+
+    try std.testing.expectEqual(@as(u64, 2), capture.truncate_calls.load(.monotonic));
+    try std.testing.expectEqual(@as(u64, 1), capture.truncated_sequence.load(.monotonic));
+    try std.testing.expectEqual(@as(u64, 1), runtime.snapshotStats().writer_locked_retries);
+    try std.testing.expectEqual(@as(u64, 1), manager.derivedRecoverableRetryStats().writer_locked);
+    const io = runtime.ioContext();
+    runtime.mutex.lockUncancelable(io);
+    defer runtime.mutex.unlock(io);
+    try std.testing.expectEqual(@as(u8, 0), runtime.workers.items[0].recoverable_retry_backoff.failures);
 }
 
 test "io threaded dense catch-up NotFound closes session before retry" {

--- a/zig/pkg/antfly/src/storage/db/types.zig
+++ b/zig/pkg/antfly/src/storage/db/types.zig
@@ -2759,6 +2759,19 @@ pub const AsyncIndexingStats = struct {
     startup: StartupCatchUpStats = .{},
     dense_catch_up: DenseCatchUpStats = .{},
     bulk_coalescing: BulkCoalescingStats = .{},
+    derived_workers: DerivedWorkerStats = .{},
+};
+
+pub const DerivedWorkerStats = struct {
+    workers: u64 = 0,
+    workers_with_replay_debt: u64 = 0,
+    max_replay_lag_sequences: u64 = 0,
+    recoverable_retries: u64 = 0,
+    writer_locked_retries: u64 = 0,
+    resource_budget_retries: u64 = 0,
+    replay_document_not_visible_retries: u64 = 0,
+    artifact_repair_required_retries: u64 = 0,
+    not_found_retries: u64 = 0,
 };
 
 pub const BulkCoalescingStats = struct {
@@ -2896,6 +2909,15 @@ pub fn accumulateAsyncIndexingStats(dst: *AsyncIndexingStats, src: AsyncIndexing
     dst.bulk_coalescing.stage_transforms += src.bulk_coalescing.stage_transforms;
     dst.bulk_coalescing.flush_calls += src.bulk_coalescing.flush_calls;
     dst.bulk_coalescing.flushed_keys += src.bulk_coalescing.flushed_keys;
+    dst.derived_workers.workers += src.derived_workers.workers;
+    dst.derived_workers.workers_with_replay_debt += src.derived_workers.workers_with_replay_debt;
+    dst.derived_workers.max_replay_lag_sequences = @max(dst.derived_workers.max_replay_lag_sequences, src.derived_workers.max_replay_lag_sequences);
+    dst.derived_workers.recoverable_retries += src.derived_workers.recoverable_retries;
+    dst.derived_workers.writer_locked_retries += src.derived_workers.writer_locked_retries;
+    dst.derived_workers.resource_budget_retries += src.derived_workers.resource_budget_retries;
+    dst.derived_workers.replay_document_not_visible_retries += src.derived_workers.replay_document_not_visible_retries;
+    dst.derived_workers.artifact_repair_required_retries += src.derived_workers.artifact_repair_required_retries;
+    dst.derived_workers.not_found_retries += src.derived_workers.not_found_retries;
 }
 
 pub fn freeResolverReplayDiagnostics(alloc: Allocator, stats: ResolverReplayDiagnostics) void {

--- a/zig/pkg/antfly/src/storage/resource_manager.zig
+++ b/zig/pkg/antfly/src/storage/resource_manager.zig
@@ -396,6 +396,47 @@ pub const IndexRepairActivationStats = struct {
     last_budget_ns: u64 = 0,
 };
 
+pub const DerivedRecoverableRetryStats = struct {
+    total: u64 = 0,
+    writer_locked: u64 = 0,
+    resource_budget: u64 = 0,
+    replay_document_not_visible: u64 = 0,
+    artifact_repair_required: u64 = 0,
+    not_found: u64 = 0,
+};
+
+const DerivedRecoverableRetryCounters = struct {
+    total: std.atomic.Value(u64) = .init(0),
+    writer_locked: std.atomic.Value(u64) = .init(0),
+    resource_budget: std.atomic.Value(u64) = .init(0),
+    replay_document_not_visible: std.atomic.Value(u64) = .init(0),
+    artifact_repair_required: std.atomic.Value(u64) = .init(0),
+    not_found: std.atomic.Value(u64) = .init(0),
+
+    fn record(self: *@This(), err: anyerror) void {
+        _ = self.total.fetchAdd(1, .monotonic);
+        switch (err) {
+            error.WriterLocked => _ = self.writer_locked.fetchAdd(1, .monotonic),
+            error.ResourceBudgetExceeded => _ = self.resource_budget.fetchAdd(1, .monotonic),
+            error.ReplayDocumentNotVisible => _ = self.replay_document_not_visible.fetchAdd(1, .monotonic),
+            error.ArtifactRepairRequired => _ = self.artifact_repair_required.fetchAdd(1, .monotonic),
+            error.NotFound => _ = self.not_found.fetchAdd(1, .monotonic),
+            else => {},
+        }
+    }
+
+    fn snapshot(self: *const @This()) DerivedRecoverableRetryStats {
+        return .{
+            .total = self.total.load(.monotonic),
+            .writer_locked = self.writer_locked.load(.monotonic),
+            .resource_budget = self.resource_budget.load(.monotonic),
+            .replay_document_not_visible = self.replay_document_not_visible.load(.monotonic),
+            .artifact_repair_required = self.artifact_repair_required.load(.monotonic),
+            .not_found = self.not_found.load(.monotonic),
+        };
+    }
+};
+
 const MutableSlice = struct {
     budget: Budget = .{},
     policy: Policy = .{},
@@ -423,6 +464,7 @@ pub const ResourceManager = struct {
     query_embedding_cache_ttl_ns: u64,
     query_embedding_max_inflight: usize,
     index_repair_activation: IndexRepairActivationStats = .{},
+    derived_recoverable_retry_counters: DerivedRecoverableRetryCounters = .{},
     capacity_source: ?CapacitySource = null,
 
     pub fn init(options: Options) ResourceManager {
@@ -475,6 +517,17 @@ pub const ResourceManager = struct {
         lockAtomic(&self.mutex);
         defer self.mutex.unlock();
         return self.index_repair_activation;
+    }
+
+    /// Process-lifetime retry counters for the provisioned storage domain.
+    /// Per-DB executors can be evicted and reopened, so Prometheus counters
+    /// must be owned by this longer-lived manager instead of those executors.
+    pub fn recordDerivedRecoverableRetry(self: *ResourceManager, err: anyerror) void {
+        self.derived_recoverable_retry_counters.record(err);
+    }
+
+    pub fn derivedRecoverableRetryStats(self: *const ResourceManager) DerivedRecoverableRetryStats {
+        return self.derived_recoverable_retry_counters.snapshot();
     }
 
     /// Install the capacity source for this manager's storage domain.


### PR DESCRIPTION
Codex (GPT-5): This fixes a derived-index worker retry loop that can consume an entire CPU core after productive import and index work has finished.

## What changed

- apply a bounded 10–250 ms exponential backoff to every recoverable derived-worker failure in both async and io-threaded runtimes
- rate-limit retry logs while including the worker name, concrete error, failure count, and retry delay
- expose derived-worker counts, replay debt, maximum replay lag, and retry counters labeled by failure reason
- expose process user/system CPU time so operators and customers can graph Antfly CPU consumption directly
- serve cached indexing and text-merge snapshots when live write-cache locks are busy, avoiding misleading zero-valued metrics

## Root cause

The previous recovery path only backed off `ResourceBudgetExceeded`. Other recoverable errors, including `WriterLocked`, reset the backoff and immediately yielded before retrying. A persistent recoverable condition could therefore turn into a tight worker loop with no useful progress and very little logging.

A large initial import can activate this path after the import, merge, and compaction work itself has completed.

## Impact

Persistent recoverable failures no longer hot-spin. The added reason-specific counters and replay-debt gauges make the active failure mode and remaining index work visible without requiring a live profiler.

## Validation

- `zig build db-test -- --test-filter 'writer-locked derived-worker retries are counted and backoffed'`
- `zig build db-test -- --test-filter 'io threaded'`
- `zig build api-table-writes-docid-test -- --test-filter 'metrics serve cached snapshot while write cache lock is busy'`
- `zig build lib-data-runtime-test -- --test-filter 'data runtime health metrics include replay debt and provisioned warmup counters'`
- `zig fmt --check` on all changed Zig files
- `git diff --check`