### PR TITLE
Harden StreamVByte decoding and add native ARM64 gate

### DIFF
--- a/.github/workflows/zig-tests.yml
+++ b/.github/workflows/zig-tests.yml
@@ -30,6 +30,7 @@ jobs:
     runs-on: arc-antfly-standard
     outputs:
       zig_tests: ${{ steps.detect.outputs.zig_tests }}
+      arm64_codec: ${{ steps.detect.outputs.arm64_codec }}
       e2e: ${{ steps.detect.outputs.e2e }}
       model_check: ${{ steps.detect.outputs.model_check }}
       trace_validate: ${{ steps.detect.outputs.trace_validate }}
@@ -48,6 +49,7 @@ jobs:
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             {
               echo "zig_tests=true"
+              echo "arm64_codec=true"
               echo "e2e=true"
               echo "model_check=true"
               echo "trace_validate=true"
@@ -58,6 +60,7 @@ jobs:
 
           if [[ "${{ github.event_name }}" == "schedule" ]]; then
             echo "zig_tests=false" >> "$GITHUB_OUTPUT"
+            echo "arm64_codec=false" >> "$GITHUB_OUTPUT"
             if [[ "${{ github.event.schedule }}" == "0 3 * * 0" ]]; then
               {
                 echo "e2e=false"
@@ -83,6 +86,7 @@ jobs:
           else
             {
               echo "zig_tests=true"
+              echo "arm64_codec=true"
               echo "e2e=true"
               echo "model_check=true"
               echo "trace_validate=true"
@@ -102,6 +106,18 @@ jobs:
             echo "zig_tests=false" >> "$GITHUB_OUTPUT"
           else
             echo "zig_tests=true" >> "$GITHUB_OUTPUT"
+          fi
+
+          if git diff --quiet "$base" "${{ github.sha }}" -- \
+            zig/build.zig \
+            zig/build.zig.zon \
+            zig/pkg/antfly/src/encoding/streamvbyte.zig \
+            zig/pkg/antfly/src/encoding/chunked_coder.zig \
+            .github/workflows/zig-tests.yml
+          then
+            echo "arm64_codec=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "arm64_codec=true" >> "$GITHUB_OUTPUT"
           fi
 
           if git diff --quiet "$base" "${{ github.sha }}" -- \
@@ -184,6 +200,51 @@ jobs:
 
       - name: Run backup listing against MinIO
         run: scripts/test-backup-s3-integration.sh
+
+  arm64-codec:
+    name: arm64-codec
+    needs: changes
+    if: needs.changes.outputs.arm64_codec == 'true'
+    runs-on: arc-antfly-publish-arm64
+    timeout-minutes: 20
+    env:
+      ZIG_VERSION: "0.16.0"
+      ZIG_LOCAL_CACHE_DIR: ${{ github.workspace }}/.zig-cache-arm64-codec
+      ZIG_GLOBAL_CACHE_DIR: ${{ github.workspace }}/.zig-global-cache-arm64-codec
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Verify native Linux ARM64 runner
+        run: |
+          set -euo pipefail
+          uname -srm
+          test "$(uname -s)" = "Linux"
+          test "$(uname -m)" = "aarch64"
+
+      - name: Install Zig
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y ca-certificates curl xz-utils
+          curl -fsSL \
+            "https://ziglang.org/download/${ZIG_VERSION}/zig-aarch64-linux-${ZIG_VERSION}.tar.xz" \
+            -o "$RUNNER_TEMP/zig.tar.xz"
+          mkdir -p "$RUNNER_TEMP/zig"
+          tar -xJf "$RUNNER_TEMP/zig.tar.xz" \
+            -C "$RUNNER_TEMP/zig" \
+            --strip-components=1
+          echo "$RUNNER_TEMP/zig" >> "$GITHUB_PATH"
+
+      - name: Verify Zig version
+        run: test "$(zig version)" = "$ZIG_VERSION"
+
+      - name: Run StreamVByte codec tests
+        run: |
+          set -euo pipefail
+          zig test zig/pkg/antfly/src/encoding/streamvbyte.zig
+          zig test -O ReleaseFast zig/pkg/antfly/src/encoding/streamvbyte.zig
+          zig test zig/pkg/antfly/src/encoding/chunked_coder.zig
+          zig test -O ReleaseFast zig/pkg/antfly/src/encoding/chunked_coder.zig
 
   zig-base:
     name: zig-base

--- a/zig/pkg/antfly/src/encoding/chunked_coder.zig
+++ b/zig/pkg/antfly/src/encoding/chunked_coder.zig
@@ -430,7 +430,9 @@ pub const ChunkedIntDecoder = struct {
 
         const control = chunk_bytes[offset..][0..@intCast(control_len)];
         const data_bytes = chunk_bytes[offset + @as(usize, @intCast(control_len)) ..];
-        if (svb.dataLength(control) != data_bytes.len) return error.TruncatedInput;
+        // Partial final groups may omit bytes for unused values, while the
+        // canonical encoder includes zero padding for them.
+        if (data_bytes.len > svb.dataLength(control)) return error.TruncatedInput;
 
         // Ensure capacity
         self.values.clearRetainingCapacity();
@@ -818,6 +820,28 @@ test "ChunkedIntDecoder rejects truncated chunk metadata" {
     defer empty_dec.deinit();
     try empty_dec.loadChunk(0);
     try std.testing.expectEqual(@as(usize, 0), empty_dec.remaining());
+}
+
+test "ChunkedIntDecoder accepts omitted unused partial-group padding" {
+    const alloc = std.testing.allocator;
+
+    const unpadded = [_]u8{ 0x01, 0x06, 0x01, 0x01, 0x01, 0x01, 0x34, 0x12 };
+    var unpadded_dec = try ChunkedIntDecoder.init(alloc, &unpadded, 0);
+    defer unpadded_dec.deinit();
+    try unpadded_dec.loadChunk(0);
+    try std.testing.expectEqual(@as(?u32, 0x1234), unpadded_dec.readValue());
+    try std.testing.expectEqual(@as(?u32, null), unpadded_dec.readValue());
+
+    const padded = [_]u8{ 0x01, 0x09, 0x01, 0x01, 0x01, 0x01, 0x34, 0x12, 0x00, 0x00, 0x00 };
+    var padded_dec = try ChunkedIntDecoder.init(alloc, &padded, 0);
+    defer padded_dec.deinit();
+    try padded_dec.loadChunk(0);
+    try std.testing.expectEqual(@as(?u32, 0x1234), padded_dec.readValue());
+
+    const truncated = [_]u8{ 0x01, 0x05, 0x01, 0x01, 0x01, 0x01, 0x34 };
+    var truncated_dec = try ChunkedIntDecoder.init(alloc, &truncated, 0);
+    defer truncated_dec.deinit();
+    try std.testing.expectError(error.TruncatedInput, truncated_dec.loadChunk(0));
 }
 
 test "prependEmptyChunks shifts chunk table without reencoding payload" {

--- a/zig/pkg/antfly/src/encoding/chunked_coder.zig
+++ b/zig/pkg/antfly/src/encoding/chunked_coder.zig
@@ -456,62 +456,72 @@ pub const ChunkedIntDecoder = struct {
         const num_docs = try readUvarint(chunk_bytes, &offset);
         const num_locs = try readUvarint(chunk_bytes, &offset);
         const num_array_pos = try readUvarint(chunk_bytes, &offset);
+        const num_docs_usize = std.math.cast(usize, num_docs) orelse return error.InvalidChunk;
+        const num_locs_usize = std.math.cast(usize, num_locs) orelse return error.InvalidChunk;
+        const num_array_pos_usize = std.math.cast(usize, num_array_pos) orelse return error.InvalidChunk;
 
         // Read columns
-        const col_counts = try self.readColumn(chunk_bytes, &offset, @intCast(num_docs));
+        const col_counts = try self.readColumn(chunk_bytes, &offset, num_docs_usize);
         defer self.alloc.free(col_counts);
-        const col_field_ids = try self.readColumn(chunk_bytes, &offset, @intCast(num_locs));
+        const col_field_ids = try self.readColumn(chunk_bytes, &offset, num_locs_usize);
         defer self.alloc.free(col_field_ids);
-        const col_positions = try self.readColumn(chunk_bytes, &offset, @intCast(num_locs));
+        const col_positions = try self.readColumn(chunk_bytes, &offset, num_locs_usize);
         defer self.alloc.free(col_positions);
-        const start_deltas = try self.readColumn(chunk_bytes, &offset, @intCast(num_locs));
+        const start_deltas = try self.readColumn(chunk_bytes, &offset, num_locs_usize);
         defer self.alloc.free(start_deltas);
-        const end_deltas = try self.readColumn(chunk_bytes, &offset, @intCast(num_locs));
+        const end_deltas = try self.readColumn(chunk_bytes, &offset, num_locs_usize);
         defer self.alloc.free(end_deltas);
-        const col_num_aps = try self.readColumn(chunk_bytes, &offset, @intCast(num_locs));
+        const col_num_aps = try self.readColumn(chunk_bytes, &offset, num_locs_usize);
         defer self.alloc.free(col_num_aps);
 
         var col_array_pos: []u32 = &.{};
         defer if (col_array_pos.len > 0) self.alloc.free(col_array_pos);
         if (num_array_pos > 0) {
-            col_array_pos = try self.readColumn(chunk_bytes, &offset, @intCast(num_array_pos));
+            col_array_pos = try self.readColumn(chunk_bytes, &offset, num_array_pos_usize);
         }
+        if (offset != chunk_bytes.len) return error.InvalidChunk;
 
         // Delta decode starts and ends
         svb.deltaDecode(start_deltas);
         svb.deltaDecode(end_deltas);
 
         // Reconstruct interleaved format
-        const total_values = @as(usize, @intCast(num_docs)) + @as(usize, @intCast(num_locs)) * 5 + @as(usize, @intCast(num_array_pos));
+        const location_values = std.math.mul(usize, num_locs_usize, 5) catch return error.InvalidChunk;
+        const base_values = std.math.add(usize, num_docs_usize, location_values) catch return error.InvalidChunk;
+        const total_values = std.math.add(usize, base_values, num_array_pos_usize) catch return error.InvalidChunk;
         self.values.clearRetainingCapacity();
         try self.values.ensureTotalCapacity(self.alloc, total_values);
 
         var loc_idx: usize = 0;
         var ap_idx: usize = 0;
-        for (0..@as(usize, @intCast(num_docs))) |doc_idx| {
+        for (0..num_docs_usize) |doc_idx| {
             const count = col_counts[doc_idx];
             self.values.appendAssumeCapacity(count);
 
             var rem: i64 = @intCast(count);
-            while (rem > 0 and loc_idx < @as(usize, @intCast(num_locs))) {
+            while (rem > 0) {
+                if (loc_idx >= num_locs_usize) return error.InvalidChunk;
+                const num_ap: usize = col_num_aps[loc_idx];
+                const location_len = 5 + num_ap;
+                if (location_len > rem) return error.InvalidChunk;
+                if (num_ap > num_array_pos_usize - ap_idx) return error.InvalidChunk;
+
                 self.values.appendAssumeCapacity(col_field_ids[loc_idx]);
                 self.values.appendAssumeCapacity(col_positions[loc_idx]);
                 self.values.appendAssumeCapacity(start_deltas[loc_idx]);
                 self.values.appendAssumeCapacity(end_deltas[loc_idx]);
                 self.values.appendAssumeCapacity(col_num_aps[loc_idx]);
 
-                const num_ap = col_num_aps[loc_idx];
                 for (0..num_ap) |_| {
-                    if (ap_idx < @as(usize, @intCast(num_array_pos))) {
-                        self.values.appendAssumeCapacity(col_array_pos[ap_idx]);
-                        ap_idx += 1;
-                    }
+                    self.values.appendAssumeCapacity(col_array_pos[ap_idx]);
+                    ap_idx += 1;
                 }
 
-                rem -= @as(i64, 5 + @as(i64, @intCast(num_ap)));
+                rem -= @intCast(location_len);
                 loc_idx += 1;
             }
         }
+        if (loc_idx != num_locs_usize or ap_idx != num_array_pos_usize) return error.InvalidChunk;
 
         self.pos = 0;
     }
@@ -708,6 +718,32 @@ test "ChunkedIntEncoder/Decoder with array positions" {
     try std.testing.expectEqual(@as(?u32, 2), dec.readValue()); // numAP
     try std.testing.expectEqual(@as(?u32, 0), dec.readValue()); // arrayPos[0]
     try std.testing.expectEqual(@as(?u32, 1), dec.readValue()); // arrayPos[1]
+}
+
+test "ChunkedIntDecoder rejects inconsistent columnar cardinalities" {
+    const alloc = std.testing.allocator;
+
+    var enc = try ChunkedIntEncoder.init(alloc, 1024, 1);
+    defer enc.deinit();
+    try enc.add(0, &[_]u32{ 7, 2, 5, 50, 60, 2, 0, 1 });
+    try enc.close();
+
+    const bytes = try enc.toBytes();
+    defer alloc.free(bytes);
+
+    var header_pos: usize = 0;
+    _ = try readUvarint(bytes, &header_pos); // numChunks
+    _ = try readUvarint(bytes, &header_pos); // chunk offset
+    try std.testing.expectEqual(@as(u8, @intFromEnum(ChunkFormat.columnar)), bytes[header_pos]);
+    header_pos += 1;
+    _ = try readUvarint(bytes, &header_pos); // numDocs
+    _ = try readUvarint(bytes, &header_pos); // numLocs
+    try std.testing.expectEqual(@as(u8, 2), bytes[header_pos]); // numArrayPos
+    bytes[header_pos] = 1;
+
+    var dec = try ChunkedIntDecoder.init(alloc, bytes, 0);
+    defer dec.deinit();
+    try std.testing.expectError(error.InvalidChunk, dec.loadChunk(0));
 }
 
 test "ChunkedIntEncoder/Decoder multi-chunk" {

--- a/zig/pkg/antfly/src/encoding/chunked_coder.zig
+++ b/zig/pkg/antfly/src/encoding/chunked_coder.zig
@@ -820,6 +820,17 @@ test "ChunkedIntDecoder rejects truncated chunk metadata" {
     defer empty_dec.deinit();
     try empty_dec.loadChunk(0);
     try std.testing.expectEqual(@as(usize, 0), empty_dec.remaining());
+
+    const maximal_value_count = [_]u8{
+        0x01, 0x0c, 0x01,
+        0xff, 0xff, 0xff,
+        0xff, 0xff, 0xff,
+        0xff, 0xff, 0xff,
+        0x01, 0x00,
+    };
+    var maximal_dec = try ChunkedIntDecoder.init(alloc, &maximal_value_count, 0);
+    defer maximal_dec.deinit();
+    try std.testing.expectError(error.InvalidChunk, maximal_dec.loadChunk(0));
 }
 
 test "ChunkedIntDecoder accepts omitted unused partial-group padding" {

--- a/zig/pkg/antfly/src/encoding/chunked_coder.zig
+++ b/zig/pkg/antfly/src/encoding/chunked_coder.zig
@@ -393,8 +393,9 @@ pub const ChunkedIntDecoder = struct {
         if (chunk >= self.chunk_offsets.len) return error.InvalidChunk;
 
         // Calculate chunk byte range
-        const start_off = self.data_start_offset + if (chunk > 0) self.chunk_offsets[chunk - 1] else 0;
-        const end_off = self.data_start_offset + self.chunk_offsets[chunk];
+        const start_off = std.math.add(u64, self.data_start_offset, if (chunk > 0) self.chunk_offsets[chunk - 1] else 0) catch return error.InvalidChunk;
+        const end_off = std.math.add(u64, self.data_start_offset, self.chunk_offsets[chunk]) catch return error.InvalidChunk;
+        if (start_off > end_off or end_off > self.data.len) return error.TruncatedInput;
         const chunk_bytes = self.data[@intCast(start_off)..@intCast(end_off)];
 
         if (chunk_bytes.len == 0) {
@@ -417,16 +418,20 @@ pub const ChunkedIntDecoder = struct {
 
         const num_values = readUvarint(chunk_bytes, &offset);
         const control_len = readUvarint(chunk_bytes, &offset);
+        if (control_len != svb.encodedControlLen(@intCast(num_values))) return error.InvalidChunk;
+        if (control_len > chunk_bytes.len -| offset) return error.TruncatedInput;
 
         const control = chunk_bytes[offset..][0..@intCast(control_len)];
         const data_bytes = chunk_bytes[offset + @as(usize, @intCast(control_len)) ..];
+        if (svb.dataLength(control) != data_bytes.len) return error.TruncatedInput;
 
         // Ensure capacity
         self.values.clearRetainingCapacity();
         try self.values.ensureTotalCapacity(self.alloc, @intCast(num_values));
         self.values.items.len = @intCast(num_values);
 
-        _ = svb.decodeInto(control, data_bytes, self.values.items);
+        const decoded = svb.decodeInto(control, data_bytes, self.values.items);
+        if (decoded.decoded != self.values.items.len) return error.TruncatedInput;
 
         // Delta decode if needed
         if (self.format == .stream_vbyte_delta) {
@@ -505,19 +510,25 @@ pub const ChunkedIntDecoder = struct {
     fn readColumn(self: *ChunkedIntDecoder, chunk_bytes: []const u8, offset: *usize, num_values: usize) ![]u32 {
         const ctrl_len = readUvarint(chunk_bytes, offset);
         if (ctrl_len == 0) {
+            if (num_values != 0) return error.InvalidChunk;
             return try self.alloc.alloc(u32, 0);
         }
+        if (ctrl_len != svb.encodedControlLen(num_values)) return error.InvalidChunk;
+        if (ctrl_len > chunk_bytes.len -| offset.*) return error.TruncatedInput;
 
         const control = chunk_bytes[offset.*..][0..@intCast(ctrl_len)];
         offset.* += @intCast(ctrl_len);
 
         // Calculate data length from control bytes
         const data_len = svb.dataLength(control);
+        if (data_len > chunk_bytes.len -| offset.*) return error.TruncatedInput;
         const data_bytes = chunk_bytes[offset.*..][0..data_len];
         offset.* += data_len;
 
         const result = try self.alloc.alloc(u32, num_values);
-        _ = svb.decodeInto(control, data_bytes, result);
+        errdefer self.alloc.free(result);
+        const decoded = svb.decodeInto(control, data_bytes, result);
+        if (decoded.decoded != num_values) return error.TruncatedInput;
         return result;
     }
 
@@ -756,6 +767,20 @@ test "ChunkedIntDecoder readValues batch" {
     try std.testing.expectEqual(@as(u32, 100), batch.?[2]); // start
     try std.testing.expectEqual(@as(u32, 110), batch.?[3]); // end
     try std.testing.expectEqual(@as(u32, 0), batch.?[4]); // numAP
+}
+
+test "ChunkedIntDecoder rejects a truncated StreamVByte value" {
+    const alloc = std.testing.allocator;
+    var enc = try ChunkedIntEncoder.initWithMode(alloc, 1024, 1, .stream_vbyte);
+    defer enc.deinit();
+    try enc.add(0, &[_]u32{ 0x1234, 0x5678, 0x9abc, 0xdef0 });
+    try enc.close();
+
+    const bytes = try enc.toBytes();
+    defer alloc.free(bytes);
+    var dec = try ChunkedIntDecoder.init(alloc, bytes[0 .. bytes.len - 1], 0);
+    defer dec.deinit();
+    try std.testing.expectError(error.TruncatedInput, dec.loadChunk(0));
 }
 
 test "prependEmptyChunks shifts chunk table without reencoding payload" {

--- a/zig/pkg/antfly/src/encoding/chunked_coder.zig
+++ b/zig/pkg/antfly/src/encoding/chunked_coder.zig
@@ -36,17 +36,20 @@ pub const ChunkFormat = enum(u8) {
 // Uvarint helpers (protobuf-style, matching Go's binary.Uvarint)
 // ============================================================================
 
-fn readUvarint(data: []const u8, pos: *usize) u64 {
+fn readUvarint(data: []const u8, pos: *usize) !u64 {
+    if (pos.* > data.len) return error.TruncatedInput;
+
     var result: u64 = 0;
-    var shift: u6 = 0;
+    var shift: u7 = 0;
     while (pos.* < data.len) {
         const b = data[pos.*];
         pos.* += 1;
-        result |= @as(u64, b & 0x7F) << shift;
-        if (b & 0x80 == 0) break;
-        shift +|= 7;
+        if (shift == 63 and b > 1) return error.InvalidVarint;
+        result |= @as(u64, b & 0x7F) << @intCast(shift);
+        if (b & 0x80 == 0) return result;
+        shift += 7;
     }
-    return result;
+    return error.TruncatedInput;
 }
 
 fn uvarintSize(value: u64) usize {
@@ -368,13 +371,17 @@ pub const ChunkedIntDecoder = struct {
             .alloc = alloc,
         };
 
+        if (offset > data.len) return error.TruncatedInput;
         var read_pos = @as(usize, @intCast(offset));
-        const num_chunks = readUvarint(data, &read_pos);
+        const num_chunks = try readUvarint(data, &read_pos);
 
         if (num_chunks > 0) {
+            // Every declared chunk requires at least one offset byte.
+            if (num_chunks > @as(u64, @intCast(data.len - read_pos))) return error.TruncatedInput;
             self.chunk_offsets = try alloc.alloc(u64, @intCast(num_chunks));
+            errdefer alloc.free(self.chunk_offsets);
             for (0..@as(usize, @intCast(num_chunks))) |i| {
-                self.chunk_offsets[i] = readUvarint(data, &read_pos);
+                self.chunk_offsets[i] = try readUvarint(data, &read_pos);
             }
         }
 
@@ -404,7 +411,7 @@ pub const ChunkedIntDecoder = struct {
             return;
         }
 
-        self.format = @enumFromInt(chunk_bytes[0]);
+        self.format = std.enums.fromInt(ChunkFormat, chunk_bytes[0]) orelse return error.InvalidChunk;
 
         switch (self.format) {
             .columnar => try self.loadChunkColumnar(chunk_bytes),
@@ -416,8 +423,8 @@ pub const ChunkedIntDecoder = struct {
     fn loadChunkStreamVByte(self: *ChunkedIntDecoder, chunk_bytes: []const u8) !void {
         var offset: usize = 1;
 
-        const num_values = readUvarint(chunk_bytes, &offset);
-        const control_len = readUvarint(chunk_bytes, &offset);
+        const num_values = try readUvarint(chunk_bytes, &offset);
+        const control_len = try readUvarint(chunk_bytes, &offset);
         if (control_len != svb.encodedControlLen(@intCast(num_values))) return error.InvalidChunk;
         if (control_len > chunk_bytes.len -| offset) return error.TruncatedInput;
 
@@ -444,9 +451,9 @@ pub const ChunkedIntDecoder = struct {
     fn loadChunkColumnar(self: *ChunkedIntDecoder, chunk_bytes: []const u8) !void {
         var offset: usize = 1;
 
-        const num_docs = readUvarint(chunk_bytes, &offset);
-        const num_locs = readUvarint(chunk_bytes, &offset);
-        const num_array_pos = readUvarint(chunk_bytes, &offset);
+        const num_docs = try readUvarint(chunk_bytes, &offset);
+        const num_locs = try readUvarint(chunk_bytes, &offset);
+        const num_array_pos = try readUvarint(chunk_bytes, &offset);
 
         // Read columns
         const col_counts = try self.readColumn(chunk_bytes, &offset, @intCast(num_docs));
@@ -508,7 +515,7 @@ pub const ChunkedIntDecoder = struct {
     }
 
     fn readColumn(self: *ChunkedIntDecoder, chunk_bytes: []const u8, offset: *usize, num_values: usize) ![]u32 {
-        const ctrl_len = readUvarint(chunk_bytes, offset);
+        const ctrl_len = try readUvarint(chunk_bytes, offset);
         if (ctrl_len == 0) {
             if (num_values != 0) return error.InvalidChunk;
             return try self.alloc.alloc(u32, 0);
@@ -537,7 +544,7 @@ pub const ChunkedIntDecoder = struct {
         self.values.clearRetainingCapacity();
         var offset: usize = 0;
         while (offset < chunk_bytes.len) {
-            const val = readUvarint(chunk_bytes, &offset);
+            const val = try readUvarint(chunk_bytes, &offset);
             try self.values.append(self.alloc, @intCast(val));
         }
         self.pos = 0;
@@ -580,12 +587,12 @@ pub const ChunkedIntDecoder = struct {
 /// Useful when document IDs move by an exact multiple of chunk_size.
 pub fn prependEmptyChunks(alloc: Allocator, data: []const u8, chunk_delta: usize, total_chunks: usize) ![]u8 {
     var pos: usize = 0;
-    const old_num_chunks = readUvarint(data, &pos);
+    const old_num_chunks = try readUvarint(data, &pos);
     if (total_chunks < chunk_delta + old_num_chunks) return error.InvalidChunk;
 
     var old_total_len: u64 = 0;
     for (0..@as(usize, @intCast(old_num_chunks))) |_| {
-        old_total_len = readUvarint(data, &pos);
+        old_total_len = try readUvarint(data, &pos);
     }
 
     const chunk_data = data[pos..];
@@ -597,7 +604,7 @@ pub fn prependEmptyChunks(alloc: Allocator, data: []const u8, chunk_delta: usize
         const offset: u64 = if (chunk_idx < chunk_delta)
             0
         else if (exact_shifted_idx < old_num_chunks) blk: {
-            const val = readUvarint(data, &size_pos);
+            const val = try readUvarint(data, &size_pos);
             exact_shifted_idx += 1;
             break :blk val;
         } else old_total_len;
@@ -616,7 +623,7 @@ pub fn prependEmptyChunks(alloc: Allocator, data: []const u8, chunk_delta: usize
         const offset: u64 = if (chunk_idx < chunk_delta)
             0
         else if (shifted_idx < old_num_chunks) blk: {
-            next_offset = readUvarint(data, &src_pos);
+            next_offset = try readUvarint(data, &src_pos);
             shifted_idx += 1;
             break :blk next_offset;
         } else old_total_len;
@@ -781,6 +788,36 @@ test "ChunkedIntDecoder rejects a truncated StreamVByte value" {
     var dec = try ChunkedIntDecoder.init(alloc, bytes[0 .. bytes.len - 1], 0);
     defer dec.deinit();
     try std.testing.expectError(error.TruncatedInput, dec.loadChunk(0));
+}
+
+test "ChunkedIntDecoder rejects truncated chunk metadata" {
+    const alloc = std.testing.allocator;
+
+    try std.testing.expectError(error.TruncatedInput, ChunkedIntDecoder.init(alloc, &.{}, 0));
+    try std.testing.expectError(error.TruncatedInput, ChunkedIntDecoder.init(alloc, &.{0x01}, 0));
+
+    const truncated_chunks = [_][]const u8{
+        &.{ 0x01, 0x01, 0x01 },
+        &.{ 0x01, 0x01, 0x02 },
+        &.{ 0x01, 0x01, 0x03 },
+        &.{ 0x01, 0x02, 0x01, 0x80 },
+    };
+    for (truncated_chunks) |bytes| {
+        var dec = try ChunkedIntDecoder.init(alloc, bytes, 0);
+        defer dec.deinit();
+        try std.testing.expectError(error.TruncatedInput, dec.loadChunk(0));
+    }
+
+    const invalid_format = [_]u8{ 0x01, 0x01, 0xff };
+    var invalid_dec = try ChunkedIntDecoder.init(alloc, &invalid_format, 0);
+    defer invalid_dec.deinit();
+    try std.testing.expectError(error.InvalidChunk, invalid_dec.loadChunk(0));
+
+    const empty_chunk = [_]u8{ 0x01, 0x00 };
+    var empty_dec = try ChunkedIntDecoder.init(alloc, &empty_chunk, 0);
+    defer empty_dec.deinit();
+    try empty_dec.loadChunk(0);
+    try std.testing.expectEqual(@as(usize, 0), empty_dec.remaining());
 }
 
 test "prependEmptyChunks shifts chunk table without reencoding payload" {

--- a/zig/pkg/antfly/src/encoding/streamvbyte.zig
+++ b/zig/pkg/antfly/src/encoding/streamvbyte.zig
@@ -28,6 +28,8 @@
 const std = @import("std");
 const Allocator = std.mem.Allocator;
 
+pub const DecodeError = error{TruncatedInput};
+
 // ============================================================================
 // Lookup tables (computed at comptime)
 // ============================================================================
@@ -324,16 +326,38 @@ pub fn encode(alloc: Allocator, values: []const u32) !struct { control: []u8, da
 /// Decode StreamVByte format back to uint32 values.
 /// `n` is the number of values to decode.
 /// Returns owned slice. Caller must free with `alloc`.
-pub fn decode(alloc: Allocator, control: []const u8, data: []const u8, n: usize) ![]u32 {
+pub fn decode(alloc: Allocator, control: []const u8, data: []const u8, n: usize) (Allocator.Error || DecodeError)![]u32 {
     if (n == 0) return &.{};
 
     const result = try alloc.alloc(u32, n);
     errdefer alloc.free(result);
 
     const decoded = decodeInto(control, data, result);
-    _ = decoded;
+    if (decoded.decoded != n) return error.TruncatedInput;
 
     return result;
+}
+
+/// A deliberately scalar test oracle. Keep this separate from the vector
+/// implementation so differential tests do not share its shuffle path.
+fn decodeScalarReference(control: []const u8, data: []const u8, dst: []u32) DecodeError!struct { decoded: usize, data_consumed: usize } {
+    var data_pos: usize = 0;
+    var dst_pos: usize = 0;
+
+    for (control) |ctrl| {
+        for (0..4) |i| {
+            if (dst_pos == dst.len) return .{ .decoded = dst_pos, .data_consumed = data_pos };
+            const length: usize = @as(usize, ((ctrl >> @intCast(i * 2)) & 0x3)) + 1;
+            if (data_pos + length > data.len) return error.TruncatedInput;
+
+            var value: u32 = 0;
+            for (0..length) |b| value |= @as(u32, data[data_pos + b]) << @intCast(8 * b);
+            dst[dst_pos] = value;
+            dst_pos += 1;
+            data_pos += length;
+        }
+    }
+    return .{ .decoded = dst_pos, .data_consumed = data_pos };
 }
 
 /// Decode into a pre-allocated destination buffer.
@@ -543,6 +567,83 @@ test "decodeInto" {
     const result = decodeInto(encoded.control, encoded.data, &dst);
     try std.testing.expectEqual(@as(usize, 6), result.decoded);
     try std.testing.expectEqualSlices(u32, &values, &dst);
+}
+
+test "historical short tail fixture decodes without zero-filled output" {
+    const control = [_]u8{0xe4};
+    const data = [_]u8{ 0x00, 0x00, 0x01, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x03 };
+    const expected = [_]u32{ 0, 256, 131072, 50331648 };
+    var destination = [_]u32{0xDEADBEEF} ** 4;
+
+    const result = decodeInto(&control, &data, &destination);
+    try std.testing.expectEqual(@as(usize, 4), result.decoded);
+    try std.testing.expectEqual(@as(usize, 10), result.data_consumed);
+    try std.testing.expectEqualSlices(u32, &expected, &destination);
+    for (destination) |value| try std.testing.expect(value != 0xDEADBEEF);
+    try std.testing.expect(destination[1] != 0 and destination[2] != 0 and destination[3] != 0);
+}
+
+test "decodeInto matches independent scalar reference across controls and short tails" {
+    var prng = std.Random.DefaultPrng.init(0x5eed_c0de);
+    const random = prng.random();
+    const counts = [_]usize{ 1, 2, 3, 4, 5, 15, 16, 17, 31, 32, 33 };
+
+    for (0..256) |control_value| {
+        const control = [_]u8{@intCast(control_value)};
+        var data: [16]u8 = undefined;
+        for (&data) |*byte| byte.* = random.int(u8);
+
+        var production_storage = [_]u32{0xDEADBEEF} ** 6;
+        var reference_storage = [_]u32{0xDEADBEEF} ** 6;
+        const production = decodeInto(&control, data[0..data_len_table[control[0]]], production_storage[1..5]);
+        const reference = try decodeScalarReference(&control, data[0..data_len_table[control[0]]], reference_storage[1..5]);
+        try std.testing.expectEqual(reference.decoded, production.decoded);
+        try std.testing.expectEqual(reference.data_consumed, production.data_consumed);
+        try std.testing.expectEqualSlices(u32, reference_storage[1..5], production_storage[1..5]);
+    }
+
+    for (counts) |count| {
+        const values = try std.testing.allocator.alloc(u32, count);
+        defer std.testing.allocator.free(values);
+        for (values, 0..) |*value, i| {
+            value.* = switch (i % 4) {
+                0 => random.intRangeAtMost(u32, 0, 0xff),
+                1 => random.intRangeAtMost(u32, 0x100, 0xffff),
+                2 => random.intRangeAtMost(u32, 0x1_0000, 0xff_ffff),
+                else => random.intRangeAtMost(u32, 0x1_000000, 0xffff_ffff),
+            };
+        }
+        const encoded = try encode(std.testing.allocator, values);
+        defer std.testing.allocator.free(encoded.control);
+        defer std.testing.allocator.free(encoded.data);
+
+        var input_storage: [133]u8 = undefined;
+        @memcpy(input_storage[1..][0..encoded.data.len], encoded.data);
+        const input = input_storage[1..][0..encoded.data.len];
+        const output_storage = try std.testing.allocator.alloc(u32, count + 2);
+        defer std.testing.allocator.free(output_storage);
+        const reference = try std.testing.allocator.alloc(u32, count);
+        defer std.testing.allocator.free(reference);
+        @memset(output_storage, 0xDEADBEEF);
+        @memset(reference, 0xDEADBEEF);
+
+        const production = decodeInto(encoded.control, input, output_storage[1..][0..count]);
+        const scalar = try decodeScalarReference(encoded.control, input, reference);
+        try std.testing.expectEqual(scalar.decoded, production.decoded);
+        try std.testing.expectEqual(scalar.data_consumed, production.data_consumed);
+        try std.testing.expectEqualSlices(u32, values, output_storage[1..][0..count]);
+        try std.testing.expectEqualSlices(u32, reference, output_storage[1..][0..count]);
+    }
+}
+
+test "decode rejects truncation inside a value but permits omitted unused partial padding" {
+    const control = [_]u8{0x01}; // first value is two bytes; the remaining slots are unused padding
+    const data = [_]u8{ 0x34, 0x12, 0x00, 0x00, 0x00 };
+
+    const decoded = try decode(std.testing.allocator, &control, data[0..2], 1);
+    defer std.testing.allocator.free(decoded);
+    try std.testing.expectEqualSlices(u32, &[_]u32{0x1234}, decoded);
+    try std.testing.expectError(error.TruncatedInput, decode(std.testing.allocator, &control, data[0..1], 1));
 }
 
 test "SIMD group decoder handles every control byte" {

--- a/zig/pkg/antfly/src/encoding/streamvbyte.zig
+++ b/zig/pkg/antfly/src/encoding/streamvbyte.zig
@@ -260,7 +260,7 @@ fn encodeGroupScalar(values: []const u32, dst: []u8) struct { ctrl: u8, n: usize
 // ============================================================================
 
 pub fn encodedControlLen(value_count: usize) usize {
-    return (value_count + 3) / 4;
+    return value_count / 4 + @intFromBool(value_count % 4 != 0);
 }
 
 pub fn encodedDataCapacity(value_count: usize) usize {
@@ -451,6 +451,10 @@ test "encodedLength" {
     try std.testing.expectEqual(@as(u3, 3), encodedLength(0xFFFFFF));
     try std.testing.expectEqual(@as(u3, 4), encodedLength(0x1000000));
     try std.testing.expectEqual(@as(u3, 4), encodedLength(0xFFFFFFFF));
+}
+
+test "encodedControlLen does not overflow at maximum input" {
+    try std.testing.expectEqual(std.math.maxInt(usize) / 4 + 1, encodedControlLen(std.math.maxInt(usize)));
 }
 
 test "encode and decode roundtrip - small values" {


### PR DESCRIPTION
Codex (GPT-5):

## Summary

- add the exact historical unpadded StreamVByte tail fixture (`control=e4`, 10 data bytes, sentinel-filled destination)
- differentially test the production decoder against an independent scalar oracle across all 256 control bytes, every encoded width, partial groups, deterministic randomized values, short tails, and offset slices
- reject truncation inside requested values and mandatory chunk metadata
- accept valid omitted padding for unused partial-group values
- validate chunk/control/data boundaries, count arithmetic, and columnar cardinalities before accepting persisted postings
- add a path-scoped native Linux ARM64 codec job using the existing ARM64 runner

## Root cause

The low-level Zig decoder already routes groups without a complete 16-byte input window through its scalar tail path, avoiding the historical SIMD-tail mechanism. However, several callers ignored `decodeInto`'s returned decoded and consumed counts. A data buffer cut inside a real encoded value could therefore return a full allocation containing unwritten allocator-filled data as successful output.

Review then exposed four related integrity/compatibility gaps at the chunk boundary:

1. Missing or unterminated metadata varints could be accepted as zero.
2. Valid partial groups were rejected when unused final-group padding was omitted.
3. A maximal declared value count could overflow control-length arithmetic before rejection.
4. Columnar reconstruction could accept inconsistent document, location, and array-position cardinalities.

This change validates completion at existing error-returning boundaries, uses overflow-safe sizing, and requires exact structural consumption without changing the low-level count-returning API.

## Validation

At exact head `466b6181f195ec886ec4c8d96cd525cf6c05dca6`:

- `zig test zig/pkg/antfly/src/encoding/streamvbyte.zig` — 18/18 passed
- `zig test -O ReleaseFast zig/pkg/antfly/src/encoding/streamvbyte.zig` — 18/18 passed
- `zig test zig/pkg/antfly/src/encoding/chunked_coder.zig` — 27/27 passed
- `zig test -O ReleaseFast zig/pkg/antfly/src/encoding/chunked_coder.zig` — 27/27 passed
- `zig fmt --check ...` and `git diff --check` — passed
- `actionlint -ignore 'SC2009|SC2086' .github/workflows/zig-tests.yml` — passed; the ignored notices predate this change

Two fresh blind final-head reviews found no confirmed or unresolved P0/P1. A separate closure verifier reproduced all four prior findings as closed, and the final adjudicator returned `CLEAR`.

## Native Linux ARM64 result

The new gate passed at exact head `466b6181f195ec886ec4c8d96cd525cf6c05dca6`: [workflow run](https://github.com/antflydb/antfly/actions/runs/30497960297), [arm64-codec job](https://github.com/antflydb/antfly/actions/runs/30497960297/job/90731307825).

- `Verify native Linux ARM64 runner` passed, including explicit `uname -s == Linux` and `uname -m == aarch64` assertions.
- Zig `0.16.0` installation and exact-version verification passed.
- The Debug and ReleaseFast StreamVByte and chunked-coder commands all passed natively.

This is native Linux ARM64 runtime evidence. It is not AWS Graviton or managed-cloud evidence. Cross-compilation and artifact construction are not counted as runtime validation.

Public historical context: [Antfly PR 381](https://github.com/antflydb/antfly/pull/381), [zapx scalar-tail fix](https://github.com/blevesearch/zapx/commit/5ac63903d25d458bf1f1393d3a9e616f070cdf25), and [zapx regression coverage](https://github.com/blevesearch/zapx/commit/17bc6e6d14bc1afa3f61caf10c78bcb152f3dba4).
