### PR TITLE
Protect rebuild cursors against silent corruption

### DIFF
--- a/zig/pkg/antfly/src/metadata/service.zig
+++ b/zig/pkg/antfly/src/metadata/service.zig
@@ -6166,6 +6166,14 @@ fn collectLocalStoreStatusReport(
         const millis = std.math.clamp(avg_progress * 1000.0, 0.0, 1000.0);
         report.backfill_progress_millis = @intFromFloat(millis);
     }
+    report.runtime_statuses = try collectQuarantinedBackfillRuntimeStatuses(
+        alloc,
+        backfill_markers,
+        store.store_id,
+        store.node_id,
+        true,
+    );
+    errdefer metadata_table_manager.freeRuntimeGroupStatusReports(alloc, report.runtime_statuses);
     report.group_statuses = try metadata_table_manager.cloneGroupStatuses(alloc, group_statuses);
     return report;
 }
@@ -6185,7 +6193,13 @@ fn collectSharedRootLocalStoreStatusReports(
 ) ![]metadata_table_manager.StoreStatusReport {
     _ = service;
     var reports = try alloc.alloc(metadata_table_manager.StoreStatusReport, stores.len);
-    errdefer alloc.free(reports);
+    errdefer {
+        for (reports) |report| {
+            metadata_table_manager.freeGroupStatuses(alloc, report.group_statuses);
+            metadata_table_manager.freeRuntimeGroupStatusReports(alloc, report.runtime_statuses);
+        }
+        alloc.free(reports);
+    }
     for (stores, 0..) |store, i| {
         reports[i] = .{
             .store_id = store.store_id,
@@ -6206,6 +6220,10 @@ fn collectSharedRootLocalStoreStatusReports(
     var progress_sum = try alloc.alloc(f64, stores.len);
     defer alloc.free(progress_sum);
     @memset(progress_sum, 0.0);
+    var quarantined = try alloc.alloc(std.ArrayListUnmanaged(StoreStatusBackfillMarker), stores.len);
+    defer alloc.free(quarantined);
+    for (quarantined) |*list| list.* = .empty;
+    defer for (quarantined) |*list| list.deinit(alloc);
 
     for (backfill_markers) |marker| {
         if (marker.store_id != null) continue;
@@ -6219,6 +6237,7 @@ fn collectSharedRootLocalStoreStatusReports(
             &reports[report_index].active_backfills,
             &progress_sum[report_index],
         );
+        if (marker.state == .corrupt) try quarantined[report_index].append(alloc, marker);
     }
 
     for (reports, 0..) |*report, i| {
@@ -6229,6 +6248,15 @@ fn collectSharedRootLocalStoreStatusReports(
     }
     for (reports) |*report| {
         report.group_statuses = try metadata_table_manager.cloneGroupStatuses(alloc, group_statuses);
+    }
+    for (reports, 0..) |*report, i| {
+        report.runtime_statuses = try collectQuarantinedBackfillRuntimeStatuses(
+            alloc,
+            quarantined[i].items,
+            report.store_id,
+            stores[i].node_id,
+            true,
+        );
     }
     return reports;
 }
@@ -6762,7 +6790,21 @@ const StoreStatusBackfillMarker = struct {
     store_id: ?u64,
     group_id: u64,
     path: []const u8,
-    resume_key: ?[]const u8 = null,
+    state: State = .absent,
+
+    const State = union(enum) {
+        absent,
+        legacy,
+        corrupt,
+        valid: []const u8,
+
+        fn deinit(self: State, alloc: std.mem.Allocator) void {
+            switch (self) {
+                .valid => |resume_key| alloc.free(resume_key),
+                else => {},
+            }
+        }
+    };
 };
 
 const StoreStatusBackfillMarkerCache = struct {
@@ -6801,9 +6843,9 @@ fn maybeRefreshStoreStatusBackfillMarkerCache(
     if (!should_rescan) return;
 
     const markers = try collectStoreStatusBackfillMarkers(alloc, replica_root_dir);
-    const markers_missing_resume_keys = storeStatusBackfillMarkersHaveMissingResumeKeys(markers);
+    const markers_missing_state = storeStatusBackfillMarkersHaveMissingState(markers);
     cache.replace(alloc, markers, now_ms);
-    cache.rescan_requested = markers_missing_resume_keys;
+    cache.rescan_requested = markers_missing_state;
     probe_ticks.* = 0;
 }
 
@@ -6814,9 +6856,9 @@ fn refreshStoreStatusBackfillMarkerCacheNow(
     cache: *StoreStatusBackfillMarkerCache,
 ) !void {
     const markers = try collectStoreStatusBackfillMarkers(alloc, replica_root_dir);
-    const markers_missing_resume_keys = storeStatusBackfillMarkersHaveMissingResumeKeys(markers);
+    const markers_missing_state = storeStatusBackfillMarkersHaveMissingState(markers);
     cache.replace(alloc, markers, monotonicMs());
-    cache.rescan_requested = markers_missing_resume_keys;
+    cache.rescan_requested = markers_missing_state;
     probe_ticks.* = 0;
 }
 
@@ -6824,27 +6866,29 @@ fn monotonicMs() u64 {
     return @intCast(@divTrunc(platform_time.monotonicNs(), std.time.ns_per_ms));
 }
 
-fn scanStoreStatusBackfillMarkers(alloc: std.mem.Allocator, replica_root_dir: []const u8) ![]StoreStatusBackfillMarker {
-    var io_impl = std.Io.Threaded.init(alloc, .{});
-    defer io_impl.deinit();
-    var root_dir = std.Io.Dir.cwd().openDir(io_impl.io(), replica_root_dir, .{ .iterate = true }) catch |err| switch (err) {
+fn scanStoreStatusBackfillMarkersWithIo(
+    alloc: std.mem.Allocator,
+    io: std.Io,
+    replica_root_dir: []const u8,
+) ![]StoreStatusBackfillMarker {
+    var root_dir = std.Io.Dir.cwd().openDir(io, replica_root_dir, .{ .iterate = true }) catch |err| switch (err) {
         error.FileNotFound => return &.{},
         else => return err,
     };
-    defer root_dir.close(io_impl.io());
+    defer root_dir.close(io);
 
     var markers = std.ArrayListUnmanaged(StoreStatusBackfillMarker).empty;
     errdefer {
         for (markers.items) |marker| {
             alloc.free(marker.path);
-            if (marker.resume_key) |resume_key| alloc.free(resume_key);
+            marker.state.deinit(alloc);
         }
         markers.deinit(alloc);
     }
 
     var walker = try root_dir.walk(alloc);
     defer walker.deinit();
-    while (try walker.next(io_impl.io())) |entry| {
+    while (try walker.next(io)) |entry| {
         if (entry.kind != .file) continue;
         if (!std.mem.endsWith(u8, entry.path, "/rebuild.state")) continue;
         const parsed = parseStoreStatusBackfillMarkerPath(entry.path) orelse continue;
@@ -6863,31 +6907,40 @@ fn scanStoreStatusBackfillMarkers(alloc: std.mem.Allocator, replica_root_dir: []
 
 fn loadStoreStatusBackfillMarkerResumeKeys(
     alloc: std.mem.Allocator,
+    io: std.Io,
     replica_root_dir: []const u8,
     markers: []StoreStatusBackfillMarker,
 ) !void {
-    _ = try refreshStoreStatusBackfillMarkerResumeKeys(alloc, replica_root_dir, markers);
+    _ = try refreshStoreStatusBackfillMarkerResumeKeys(alloc, io, replica_root_dir, markers);
 }
 
 fn refreshStoreStatusBackfillMarkerResumeKeys(
     alloc: std.mem.Allocator,
+    io: std.Io,
     replica_root_dir: []const u8,
     markers: []StoreStatusBackfillMarker,
 ) !bool {
     var any_missing = false;
 
     for (markers) |*marker| {
-        if (marker.resume_key) |resume_key| {
-            alloc.free(resume_key);
-            marker.resume_key = null;
-        }
+        marker.state.deinit(alloc);
+        marker.state = .absent;
         const state_path = try std.fmt.allocPrint(alloc, "{s}/{s}", .{ replica_root_dir, marker.path });
         defer alloc.free(state_path);
-        marker.resume_key = rebuildStateForPath(state_path).check(alloc) catch |err| switch (err) {
-            error.InvalidRebuildState => null,
-            else => return err,
+        var loaded = try rebuildStateForPath(state_path).loadWithIo(alloc, io);
+        marker.state = switch (loaded) {
+            .absent => .absent,
+            .legacy => .legacy,
+            .corrupt => blk: {
+                std.log.warn("derived index rebuild state quarantined path={s}", .{state_path});
+                break :blk .corrupt;
+            },
+            .valid => |resume_key| blk: {
+                loaded = undefined;
+                break :blk .{ .valid = resume_key };
+            },
         };
-        if (marker.resume_key == null) any_missing = true;
+        if (marker.state == .absent) any_missing = true;
     }
     return any_missing;
 }
@@ -6897,17 +6950,35 @@ fn rebuildStateForPath(path: []const u8) backfill_state_mod.RebuildState {
 }
 
 fn collectStoreStatusBackfillMarkers(alloc: std.mem.Allocator, replica_root_dir: []const u8) ![]StoreStatusBackfillMarker {
-    const markers = try scanStoreStatusBackfillMarkers(alloc, replica_root_dir);
+    var io_impl = std.Io.Threaded.init(alloc, .{});
+    defer io_impl.deinit();
+    const io = io_impl.io();
+    const markers = try scanStoreStatusBackfillMarkersWithIo(alloc, io, replica_root_dir);
     errdefer freeStoreStatusBackfillMarkers(alloc, markers);
-    try loadStoreStatusBackfillMarkerResumeKeys(alloc, replica_root_dir, markers);
+    try loadStoreStatusBackfillMarkerResumeKeys(alloc, io, replica_root_dir, markers);
     return markers;
 }
 
-fn storeStatusBackfillMarkersHaveMissingResumeKeys(markers: []const StoreStatusBackfillMarker) bool {
+fn storeStatusBackfillMarkersHaveMissingState(markers: []const StoreStatusBackfillMarker) bool {
     for (markers) |marker| {
-        if (marker.resume_key == null) return true;
+        if (marker.state == .absent) return true;
     }
     return false;
+}
+
+fn backfillMarkerStateFileExistsWithIo(
+    alloc: std.mem.Allocator,
+    io: std.Io,
+    replica_root_dir: []const u8,
+    marker: StoreStatusBackfillMarker,
+) !bool {
+    const state_path = try std.fmt.allocPrint(alloc, "{s}/{s}", .{ replica_root_dir, marker.path });
+    defer alloc.free(state_path);
+    std.Io.Dir.cwd().access(io, state_path, .{}) catch |err| switch (err) {
+        error.FileNotFound => return false,
+        else => return err,
+    };
+    return true;
 }
 
 fn backfillMarkerStateFileExists(
@@ -6917,13 +6988,7 @@ fn backfillMarkerStateFileExists(
 ) !bool {
     var io_impl = std.Io.Threaded.init(alloc, .{});
     defer io_impl.deinit();
-    const state_path = try std.fmt.allocPrint(alloc, "{s}/{s}", .{ replica_root_dir, marker.path });
-    defer alloc.free(state_path);
-    std.Io.Dir.cwd().access(io_impl.io(), state_path, .{}) catch |err| switch (err) {
-        error.FileNotFound => return false,
-        else => return err,
-    };
-    return true;
+    return try backfillMarkerStateFileExistsWithIo(alloc, io_impl.io(), replica_root_dir, marker);
 }
 
 fn maybeRequestStoreStatusBackfillMarkerRescan(
@@ -6936,12 +7001,14 @@ fn maybeRequestStoreStatusBackfillMarkerRescan(
     if (active_backfill_markers.len == 0) return;
     if (service.store_status_backfill_marker_cache.rescan_requested) return;
 
+    var io_impl = std.Io.Threaded.init(service.alloc, .{});
+    defer io_impl.deinit();
     for (active_backfill_markers) |marker| {
-        if (marker.resume_key == null) {
+        if (marker.state == .absent) {
             service.store_status_backfill_marker_cache.rescan_requested = true;
             return;
         }
-        if (!try backfillMarkerStateFileExists(service.alloc, replica_root_dir, marker)) {
+        if (!try backfillMarkerStateFileExistsWithIo(service.alloc, io_impl.io(), replica_root_dir, marker)) {
             service.store_status_backfill_marker_cache.rescan_requested = true;
             return;
         }
@@ -6951,7 +7018,7 @@ fn maybeRequestStoreStatusBackfillMarkerRescan(
 fn freeStoreStatusBackfillMarkers(alloc: std.mem.Allocator, markers: []const StoreStatusBackfillMarker) void {
     for (markers) |marker| {
         alloc.free(marker.path);
-        if (marker.resume_key) |resume_key| alloc.free(resume_key);
+        marker.state.deinit(alloc);
     }
     if (markers.len > 0) alloc.free(markers);
 }
@@ -6980,6 +7047,75 @@ fn storeStatusBackfillMarkerMatchesStore(marker: StoreStatusBackfillMarker, stor
     return include_unassigned;
 }
 
+fn collectQuarantinedBackfillRuntimeStatuses(
+    alloc: std.mem.Allocator,
+    markers: []const StoreStatusBackfillMarker,
+    store_id: u64,
+    node_id: u64,
+    include_unassigned: bool,
+) ![]metadata_table_manager.RuntimeGroupStatusReport {
+    var statuses = std.ArrayListUnmanaged(metadata_table_manager.RuntimeGroupStatusReport).empty;
+    errdefer {
+        for (statuses.items) |status| metadata_table_manager.freeRuntimeGroupStatusReport(alloc, status);
+        statuses.deinit(alloc);
+    }
+    for (markers) |marker| {
+        if (marker.state != .corrupt) continue;
+        if (!storeStatusBackfillMarkerMatchesStore(marker, store_id, include_unassigned)) continue;
+        const status = try quarantinedBackfillRuntimeStatus(alloc, marker, store_id, node_id);
+        errdefer metadata_table_manager.freeRuntimeGroupStatusReport(alloc, status);
+        try statuses.append(alloc, status);
+    }
+    if (statuses.items.len == 0) {
+        statuses.deinit(alloc);
+        return &.{};
+    }
+    return try statuses.toOwnedSlice(alloc);
+}
+
+fn quarantinedBackfillRuntimeStatus(
+    alloc: std.mem.Allocator,
+    marker: StoreStatusBackfillMarker,
+    store_id: u64,
+    node_id: u64,
+) !metadata_table_manager.RuntimeGroupStatusReport {
+    const index_dir = std.fs.path.dirname(marker.path) orelse return error.InvalidBackfillMarkerPath;
+    const index_name = std.fs.path.basename(index_dir);
+    const table_name = try alloc.dupe(u8, "");
+    errdefer alloc.free(table_name);
+    const source = try alloc.dupe(u8, "rebuild_state_quarantine");
+    errdefer alloc.free(source);
+    const freshness = try alloc.dupe(u8, "quarantined");
+    errdefer alloc.free(freshness);
+    const projection_checkpoint_status = try alloc.dupe(u8, "clean");
+    errdefer alloc.free(projection_checkpoint_status);
+    const owned_index_name = try alloc.dupe(u8, index_name);
+    errdefer alloc.free(owned_index_name);
+    const index_kind = try alloc.dupe(u8, "unknown");
+    errdefer alloc.free(index_kind);
+    const indexes = try alloc.alloc(metadata_table_manager.RuntimeIndexStatusReport, 1);
+    errdefer alloc.free(indexes);
+    indexes[0] = .{
+        .name = owned_index_name,
+        .kind = index_kind,
+        .backfill_active = true,
+        .backfill_progress_millis = 0,
+    };
+
+    var status: metadata_table_manager.RuntimeGroupStatusReport = .{
+        .table_name = table_name,
+        .group_id = marker.group_id,
+        .store_id = store_id,
+        .node_id = node_id,
+        .source = source,
+        .freshness = freshness,
+        .index_count = 1,
+        .indexes = indexes,
+    };
+    status.enrichment.projection_checkpoint_status = projection_checkpoint_status;
+    return status;
+}
+
 fn accumulateStoreStatusBackfillProgress(
     alloc: std.mem.Allocator,
     ranges: []const metadata_table_manager.RangeRecord,
@@ -6989,7 +7125,10 @@ fn accumulateStoreStatusBackfillProgress(
 ) !void {
     const range = findRangeByGroupId(ranges, marker.group_id) orelse return;
     active_backfills.* += 1;
-    const resume_key = marker.resume_key orelse return;
+    const resume_key = switch (marker.state) {
+        .valid => |key| key,
+        .absent, .legacy, .corrupt => return,
+    };
     const range_start = try internal_keys.documentRangeLowerAlloc(alloc, range.start_key);
     defer alloc.free(range_start);
     const range_end = if (range.end_key) |key| try internal_keys.documentRangeUpperAlloc(alloc, key) else null;
@@ -10677,6 +10816,82 @@ test "metadata service cached backfill markers rescan immediately after disappea
         &service.store_status_backfill_marker_cache,
     );
     try std.testing.expectEqual(@as(usize, 0), service.store_status_backfill_marker_cache.markers.len);
+}
+
+test "metadata service caches corrupt rebuild state and publishes quarantine status" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const cwd = try std.process.currentPathAlloc(std.testing.io, std.testing.allocator);
+    defer std.testing.allocator.free(cwd);
+    const replica_root = try std.fmt.allocPrint(std.testing.allocator, "{s}/.zig-cache/tmp/{s}/metadata-corrupt-backfill-marker-cache", .{ cwd, tmp.sub_path });
+    defer std.testing.allocator.free(replica_root);
+    const index_root = try std.fmt.allocPrint(std.testing.allocator, "{s}/group-9501/table-db/indexes/search_idx", .{replica_root});
+    defer std.testing.allocator.free(index_root);
+
+    var io_impl = std.Io.Threaded.init(std.testing.allocator, .{});
+    defer io_impl.deinit();
+    try fs_paths.createDirPathPortable(io_impl.io(), index_root);
+    const rebuild_state = backfill_state_mod.RebuildState.init(index_root);
+    try rebuild_state.updateWithIo(io_impl.io(), "doc:m");
+    const state_path = try rebuild_state.pathAlloc(std.testing.allocator);
+    defer std.testing.allocator.free(state_path);
+    const encoded = try std.Io.Dir.cwd().readFileAlloc(
+        io_impl.io(),
+        state_path,
+        std.testing.allocator,
+        .limited(64 * 1024 + 64),
+    );
+    defer std.testing.allocator.free(encoded);
+    encoded[encoded.len - 1] ^= 0xff;
+    try std.Io.Dir.cwd().writeFile(io_impl.io(), .{ .sub_path = state_path, .data = encoded });
+
+    var cache = StoreStatusBackfillMarkerCache{};
+    defer cache.deinit(std.testing.allocator);
+    var probe_ticks: usize = 0;
+    try maybeRefreshStoreStatusBackfillMarkerCache(
+        std.testing.allocator,
+        replica_root,
+        0,
+        &probe_ticks,
+        &cache,
+    );
+    try std.testing.expectEqual(@as(usize, 1), cache.markers.len);
+    try std.testing.expect(cache.markers[0].state == .corrupt);
+    try std.testing.expect(!cache.rescan_requested);
+
+    const ranges = [_]metadata_table_manager.RangeRecord{
+        .{ .group_id = 9501, .table_id = 95, .start_key = "doc:a", .end_key = "doc:z" },
+    };
+    const report = try collectLocalStoreStatusReport(
+        .{},
+        std.testing.allocator,
+        replica_root,
+        .{ .store_id = 95, .node_id = 5 },
+        &ranges,
+        &.{},
+        cache.markers,
+    );
+    defer freeOwnedStoreStatusReport(std.testing.allocator, report);
+    try std.testing.expectEqual(@as(u32, 1), report.active_backfills);
+    try std.testing.expectEqual(@as(u16, 0), report.backfill_progress_millis);
+    try std.testing.expectEqual(@as(usize, 1), report.runtime_statuses.len);
+    try std.testing.expectEqualStrings("rebuild_state_quarantine", report.runtime_statuses[0].source);
+    try std.testing.expectEqualStrings("quarantined", report.runtime_statuses[0].freshness);
+    try std.testing.expectEqual(@as(usize, 1), report.runtime_statuses[0].indexes.len);
+    try std.testing.expectEqualStrings("search_idx", report.runtime_statuses[0].indexes[0].name);
+
+    cache.scanned_at_ms = monotonicMs();
+    const scanned_at_ms = cache.scanned_at_ms;
+    try rebuild_state.updateWithIo(io_impl.io(), "doc:z");
+    try maybeRefreshStoreStatusBackfillMarkerCache(
+        std.testing.allocator,
+        replica_root,
+        0,
+        &probe_ticks,
+        &cache,
+    );
+    try std.testing.expectEqual(scanned_at_ms, cache.scanned_at_ms);
+    try std.testing.expect(cache.markers[0].state == .corrupt);
 }
 
 test "metadata service does not rescan empty backfill markers before idle interval" {

--- a/zig/pkg/antfly/src/metadata/service.zig
+++ b/zig/pkg/antfly/src/metadata/service.zig
@@ -6874,8 +6874,6 @@ fn refreshStoreStatusBackfillMarkerResumeKeys(
     replica_root_dir: []const u8,
     markers: []StoreStatusBackfillMarker,
 ) !bool {
-    var io_impl = std.Io.Threaded.init(alloc, .{});
-    defer io_impl.deinit();
     var any_missing = false;
 
     for (markers) |*marker| {
@@ -6885,15 +6883,17 @@ fn refreshStoreStatusBackfillMarkerResumeKeys(
         }
         const state_path = try std.fmt.allocPrint(alloc, "{s}/{s}", .{ replica_root_dir, marker.path });
         defer alloc.free(state_path);
-        marker.resume_key = std.Io.Dir.cwd().readFileAlloc(io_impl.io(), state_path, alloc, .limited(64 * 1024)) catch |err| switch (err) {
-            error.FileNotFound => blk: {
-                any_missing = true;
-                break :blk null;
-            },
+        marker.resume_key = rebuildStateForPath(state_path).check(alloc) catch |err| switch (err) {
+            error.InvalidRebuildState => null,
             else => return err,
         };
+        if (marker.resume_key == null) any_missing = true;
     }
     return any_missing;
+}
+
+fn rebuildStateForPath(path: []const u8) backfill_state_mod.RebuildState {
+    return backfill_state_mod.RebuildState.init(std.fs.path.dirname(path) orelse ".");
 }
 
 fn collectStoreStatusBackfillMarkers(alloc: std.mem.Allocator, replica_root_dir: []const u8) ![]StoreStatusBackfillMarker {
@@ -9779,14 +9779,7 @@ test "metadata service auto-reports local store backfill status during runRound"
 
     const state_path = try std.fmt.allocPrint(std.testing.allocator, "{s}/indexes/search_idx/rebuild.state", .{db_path});
     defer std.testing.allocator.free(state_path);
-    {
-        var file = try std.Io.Dir.cwd().createFile(io_impl.io(), state_path, .{ .truncate = true });
-        defer file.close(io_impl.io());
-        var buf: [128]u8 = undefined;
-        var writer = file.writer(io_impl.io(), &buf);
-        try writer.interface.writeAll("doc:m");
-        try writer.end();
-    }
+    try rebuildStateForPath(state_path).update("doc:m");
 
     svc.store_status_backfill_marker_cache.rescan_requested = true;
     try svc.runLifecycleRound();
@@ -9903,14 +9896,7 @@ test "metadata service reports automatic store status across shared multi-store 
 
     const state_path = try std.fmt.allocPrint(std.testing.allocator, "{s}/indexes/search_idx/rebuild.state", .{db_path});
     defer std.testing.allocator.free(state_path);
-    {
-        var file = try std.Io.Dir.cwd().createFile(io_impl.io(), state_path, .{ .truncate = true });
-        defer file.close(io_impl.io());
-        var buf: [128]u8 = undefined;
-        var writer = file.writer(io_impl.io(), &buf);
-        try writer.interface.writeAll("doc:m");
-        try writer.end();
-    }
+    try rebuildStateForPath(state_path).update("doc:m");
 
     svc.store_status_backfill_marker_cache.rescan_requested = true;
     try svc.runLifecycleRound();
@@ -10050,14 +10036,7 @@ test "metadata service reports automatic store status across explicit multi-stor
 
     const left_state_path = try std.fmt.allocPrint(std.testing.allocator, "{s}/indexes/search_idx/rebuild.state", .{left_db_path});
     defer std.testing.allocator.free(left_state_path);
-    {
-        var file = try std.Io.Dir.cwd().createFile(io_impl.io(), left_state_path, .{ .truncate = true });
-        defer file.close(io_impl.io());
-        var buf: [128]u8 = undefined;
-        var writer = file.writer(io_impl.io(), &buf);
-        try writer.interface.writeAll("doc:g");
-        try writer.end();
-    }
+    try rebuildStateForPath(left_state_path).update("doc:g");
 
     svc.store_status_backfill_marker_cache.rescan_requested = true;
     try svc.runLifecycleRound();
@@ -10177,14 +10156,7 @@ test "metadata service prefers placement-role-compatible store affinity in share
 
     const state_path = try std.fmt.allocPrint(std.testing.allocator, "{s}/indexes/search_idx/rebuild.state", .{db_path});
     defer std.testing.allocator.free(state_path);
-    {
-        var file = try std.Io.Dir.cwd().createFile(io_impl.io(), state_path, .{ .truncate = true });
-        defer file.close(io_impl.io());
-        var buf: [128]u8 = undefined;
-        var writer = file.writer(io_impl.io(), &buf);
-        try writer.interface.writeAll("doc:m");
-        try writer.end();
-    }
+    try rebuildStateForPath(state_path).update("doc:m");
 
     svc.store_status_backfill_marker_cache.rescan_requested = true;
     try svc.runLifecycleRound();
@@ -10224,14 +10196,7 @@ test "metadata service shared-root reports survive transient rebuild marker remo
 
     const state_path = try std.fmt.allocPrint(std.testing.allocator, "{s}/indexes/search_idx/rebuild.state", .{db_path});
     defer std.testing.allocator.free(state_path);
-    {
-        var file = try std.Io.Dir.cwd().createFile(io_impl.io(), state_path, .{ .truncate = true });
-        defer file.close(io_impl.io());
-        var buf: [128]u8 = undefined;
-        var writer = file.writer(io_impl.io(), &buf);
-        try writer.interface.writeAll("doc:m");
-        try writer.end();
-    }
+    try rebuildStateForPath(state_path).update("doc:m");
 
     const markers = try collectStoreStatusBackfillMarkers(std.testing.allocator, replica_root);
     defer freeStoreStatusBackfillMarkers(std.testing.allocator, markers);
@@ -10412,14 +10377,7 @@ test "metadata service lifecycle round uses cached backfill markers" {
 
     const state_path = try std.fmt.allocPrint(std.testing.allocator, "{s}/indexes/search_idx/rebuild.state", .{db_path});
     defer std.testing.allocator.free(state_path);
-    {
-        var file = try std.Io.Dir.cwd().createFile(io_impl.io(), state_path, .{ .truncate = true });
-        defer file.close(io_impl.io());
-        var buf: [128]u8 = undefined;
-        var writer = file.writer(io_impl.io(), &buf);
-        try writer.interface.writeAll("doc:m");
-        try writer.end();
-    }
+    try rebuildStateForPath(state_path).update("doc:m");
 
     svc.store_status_backfill_marker_cache.replace(
         std.testing.allocator,
@@ -10540,14 +10498,7 @@ test "metadata service lifecycle round discovers backfill markers immediately" {
 
     const state_path = try std.fmt.allocPrint(std.testing.allocator, "{s}/indexes/search_idx/rebuild.state", .{db_path});
     defer std.testing.allocator.free(state_path);
-    {
-        var file = try std.Io.Dir.cwd().createFile(io_impl.io(), state_path, .{ .truncate = true });
-        defer file.close(io_impl.io());
-        var buf: [128]u8 = undefined;
-        var writer = file.writer(io_impl.io(), &buf);
-        try writer.interface.writeAll("doc:m");
-        try writer.end();
-    }
+    try rebuildStateForPath(state_path).update("doc:m");
 
     try std.testing.expectEqual(@as(usize, 0), svc.store_status_backfill_marker_cache.markers.len);
     svc.store_status_backfill_marker_cache.rescan_requested = true;
@@ -10682,14 +10633,7 @@ test "metadata service cached backfill markers rescan immediately after disappea
 
     const state_path = try std.fmt.allocPrint(std.testing.allocator, "{s}/indexes/search_idx/rebuild.state", .{db_path});
     defer std.testing.allocator.free(state_path);
-    {
-        var file = try std.Io.Dir.cwd().createFile(io_impl.io(), state_path, .{ .truncate = true });
-        defer file.close(io_impl.io());
-        var buf: [128]u8 = undefined;
-        var writer = file.writer(io_impl.io(), &buf);
-        try writer.interface.writeAll("doc:m");
-        try writer.end();
-    }
+    try rebuildStateForPath(state_path).update("doc:m");
 
     var cache = StoreStatusBackfillMarkerCache{};
     defer cache.deinit(std.testing.allocator);
@@ -10792,14 +10736,7 @@ test "metadata service prefers planned store affinity in shared roots" {
 
     const state_path = try std.fmt.allocPrint(std.testing.allocator, "{s}/indexes/search_idx/rebuild.state", .{db_path});
     defer std.testing.allocator.free(state_path);
-    {
-        var file = try std.Io.Dir.cwd().createFile(io_impl.io(), state_path, .{ .truncate = true });
-        defer file.close(io_impl.io());
-        var buf: [128]u8 = undefined;
-        var writer = file.writer(io_impl.io(), &buf);
-        try writer.interface.writeAll("doc:m");
-        try writer.end();
-    }
+    try rebuildStateForPath(state_path).update("doc:m");
 
     const stores = [_]metadata_table_manager.StoreRecord{
         .{ .store_id = 91, .node_id = 1, .role = "data", .live = true, .capacity_bytes = 1024, .available_bytes = 880 },

--- a/zig/pkg/antfly/src/metadata/table_provisioner.zig
+++ b/zig/pkg/antfly/src/metadata/table_provisioner.zig
@@ -3352,8 +3352,9 @@ test "table provisioner schema progress returns not ready from rebuild marker wi
     defer alloc.free(db_path);
     const index_root = try std.fmt.allocPrint(alloc, "{s}/indexes/full_text_index_v2", .{db_path});
     defer alloc.free(index_root);
+    try fs_paths.createDirPathPortable(io_impl.io(), index_root);
     const rebuild_state = db_mod.backfill_state.RebuildState.init(index_root);
-    try rebuild_state.update("doc:m");
+    try rebuild_state.updateWithIo(io_impl.io(), "doc:m");
 
     // There is deliberately no DB at db_path. If the progress probe attempts
     // DB.open instead of trusting the durable marker, this call fails rather

--- a/zig/pkg/antfly/src/storage/db/backfill_state.zig
+++ b/zig/pkg/antfly/src/storage/db/backfill_state.zig
@@ -16,7 +16,6 @@ const std = @import("std");
 const builtin = @import("builtin");
 const Allocator = std.mem.Allocator;
 const fs_paths = @import("../../common/fs_paths.zig");
-const storage_io = @import("../lsm_backend/storage_io.zig");
 
 const rebuild_state_name = "rebuild.state";
 const rebuild_state_magic = "AFRBST01";
@@ -27,7 +26,22 @@ const rebuild_state_header_bytes = rebuild_state_magic.len + @sizeOf(@TypeOf(reb
 const rebuild_state_max_key_bytes = 64 * 1024;
 const rebuild_state_max_encoded_bytes = rebuild_state_header_bytes + rebuild_state_max_key_bytes + rebuild_state_checksum_bytes;
 const rebuild_state_max_read_bytes = rebuild_state_max_encoded_bytes + 1;
-var temp_nonce: u64 = 0;
+const rebuild_state_temp_attempts = 16;
+
+pub const LoadResult = union(enum) {
+    absent,
+    legacy,
+    corrupt,
+    valid: []u8,
+
+    pub fn deinit(self: *LoadResult, alloc: Allocator) void {
+        switch (self.*) {
+            .valid => |key| alloc.free(key),
+            else => {},
+        }
+        self.* = undefined;
+    }
+};
 
 pub const RebuildState = struct {
     root_path: []const u8,
@@ -40,112 +54,85 @@ pub const RebuildState = struct {
         if (builtin.os.tag == .freestanding) {
             return null;
         }
-        const path = try self.pathAlloc(alloc);
-        defer alloc.free(path);
-
         var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
         defer io_impl.deinit();
-        const encoded = std.Io.Dir.cwd().readFileAlloc(io_impl.io(), path, alloc, .limited(rebuild_state_max_read_bytes)) catch |err| switch (err) {
-            error.FileNotFound => return null,
-            error.NotDir => return null,
-            error.StreamTooLong => return error.InvalidRebuildState,
-            else => return err,
+        return try self.checkWithIo(alloc, io_impl.io());
+    }
+
+    pub fn checkWithIo(self: RebuildState, alloc: Allocator, io: std.Io) !?[]u8 {
+        var loaded = try self.loadWithIo(alloc, io);
+        return switch (loaded) {
+            .absent => null,
+            .valid => |key| blk: {
+                loaded = undefined;
+                break :blk key;
+            },
+            .legacy => blk: {
+                // Pre-v1 cursors have no integrity envelope. Their position
+                // cannot be trusted after an upgrade, so preserve the active
+                // marker while forcing a safe rebuild from the beginning.
+                try self.updateWithIo(io, "");
+                break :blk try alloc.dupe(u8, "");
+            },
+            .corrupt => error.InvalidRebuildState,
         };
-        defer alloc.free(encoded);
-        return try decodeState(alloc, encoded);
+    }
+
+    pub fn loadWithIo(self: RebuildState, alloc: Allocator, io: std.Io) !LoadResult {
+        if (builtin.os.tag == .freestanding) return .absent;
+        const path = try self.pathAlloc(alloc);
+        defer alloc.free(path);
+        return try loadPathWithIo(alloc, io, path);
     }
 
     pub fn update(self: RebuildState, key: []const u8) !void {
         if (builtin.os.tag == .freestanding) {
             return;
         }
-        const encoded = try encodeState(std.heap.page_allocator, key);
-        defer std.heap.page_allocator.free(encoded);
-
-        const path = try self.pathAlloc(std.heap.page_allocator);
-        defer std.heap.page_allocator.free(path);
-        temp_nonce +%= 1;
-        const tmp_path = try std.fmt.allocPrint(std.heap.page_allocator, "{s}.tmp-{d}", .{
-            path,
-            temp_nonce,
-        });
-        defer std.heap.page_allocator.free(tmp_path);
-
         var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
         defer io_impl.deinit();
-        const io = io_impl.io();
-        ensureParentDir(io, path) catch |err| switch (err) {
-            error.NotDir => return,
-            else => return err,
-        };
-        ensureParentDir(io, tmp_path) catch |err| switch (err) {
-            error.NotDir => return,
-            else => return err,
-        };
+        try self.updateWithIo(io_impl.io(), key);
+    }
 
-        writeStateFile(io, tmp_path, encoded) catch |err| switch (err) {
-            error.NotDir => return,
+    pub fn updateWithIo(self: RebuildState, io: std.Io, key: []const u8) !void {
+        if (builtin.os.tag == .freestanding) return;
+        const alloc = std.heap.page_allocator;
+        const encoded = try encodeState(alloc, key);
+        defer alloc.free(encoded);
+        const path = try self.pathAlloc(alloc);
+        defer alloc.free(path);
+
+        const tmp_path = try writeExclusiveTempStateFile(alloc, io, path, encoded);
+        defer alloc.free(tmp_path);
+        var tmp_exists = true;
+        defer if (tmp_exists) deleteFileWithIo(io, tmp_path) catch {};
+
+        renameWithIo(io, tmp_path, path) catch |err| switch (err) {
+            error.FileNotFound, error.NotDir => return error.RebuildStateOwnerStale,
             else => return err,
         };
-
-        if (std.fs.path.isAbsolute(path)) {
-            renameAbsolutePortable(tmp_path, path) catch |err| switch (err) {
-                error.FileNotFound => {
-                    ensureParentDir(io, path) catch |parent_err| switch (parent_err) {
-                        error.NotDir => return,
-                        else => return parent_err,
-                    };
-                    writeStateFile(io, path, encoded) catch |write_err| switch (write_err) {
-                        error.NotDir => return,
-                        else => return write_err,
-                    };
-                    std.Io.Dir.deleteFileAbsolute(io, tmp_path) catch {};
-                },
-                error.NotDir => return,
-                else => return err,
-            };
-        } else {
-            std.Io.Dir.rename(std.Io.Dir.cwd(), tmp_path, std.Io.Dir.cwd(), path, io) catch |err| switch (err) {
-                error.FileNotFound => {
-                    ensureParentDir(io, path) catch |parent_err| switch (parent_err) {
-                        error.NotDir => return,
-                        else => return parent_err,
-                    };
-                    writeStateFile(io, path, encoded) catch |write_err| switch (write_err) {
-                        error.NotDir => return,
-                        else => return write_err,
-                    };
-                    std.Io.Dir.cwd().deleteFile(io, tmp_path) catch {};
-                },
-                error.NotDir => return,
-                else => return err,
-            };
-        }
-        try fs_paths.syncDirPortable(io, std.fs.path.dirname(path) orelse ".");
+        tmp_exists = false;
+        try syncPublishedParent(io, path);
     }
 
     pub fn clear(self: RebuildState) !void {
         if (builtin.os.tag == .freestanding) {
             return;
         }
-        const path = try self.pathAlloc(std.heap.page_allocator);
-        defer std.heap.page_allocator.free(path);
-
         var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
         defer io_impl.deinit();
-        if (std.fs.path.isAbsolute(path)) {
-            std.Io.Dir.deleteFileAbsolute(io_impl.io(), path) catch |err| switch (err) {
-                error.FileNotFound => {},
-                error.NotDir => {},
-                else => return err,
-            };
-        } else {
-            std.Io.Dir.cwd().deleteFile(io_impl.io(), path) catch |err| switch (err) {
-                error.FileNotFound => {},
-                error.NotDir => {},
-                else => return err,
-            };
-        }
+        try self.clearWithIo(io_impl.io());
+    }
+
+    pub fn clearWithIo(self: RebuildState, io: std.Io) !void {
+        if (builtin.os.tag == .freestanding) return;
+        const path = try self.pathAlloc(std.heap.page_allocator);
+        defer std.heap.page_allocator.free(path);
+        deleteFileWithIo(io, path) catch |err| switch (err) {
+            error.FileNotFound, error.NotDir => return,
+            else => return err,
+        };
+        try syncPublishedParent(io, path);
     }
 
     pub fn estimateProgress(self: RebuildState, range_start: []const u8, range_end: []const u8, alloc: Allocator) !?f64 {
@@ -159,41 +146,75 @@ pub const RebuildState = struct {
     }
 };
 
-fn ensureParentDir(io: std.Io, path: []const u8) !void {
-    if (std.fs.path.dirname(path)) |parent| {
-        try storage_io.createDirPathPortable(io, parent);
+fn loadPathWithIo(alloc: Allocator, io: std.Io, path: []const u8) !LoadResult {
+    const encoded = std.Io.Dir.cwd().readFileAlloc(io, path, alloc, .limited(rebuild_state_max_read_bytes)) catch |err| switch (err) {
+        error.FileNotFound, error.NotDir => return .absent,
+        error.StreamTooLong => return .corrupt,
+        else => return err,
+    };
+    defer alloc.free(encoded);
+
+    if (!std.mem.startsWith(u8, encoded, rebuild_state_magic)) {
+        // The old on-disk format was exactly the raw resume key.
+        return if (encoded.len <= rebuild_state_max_key_bytes) .legacy else .corrupt;
+    }
+    const key = decodeState(alloc, encoded) catch |err| switch (err) {
+        error.InvalidRebuildState => return .corrupt,
+        else => return err,
+    };
+    return .{ .valid = key };
+}
+
+fn writeExclusiveTempStateFile(alloc: Allocator, io: std.Io, path: []const u8, contents: []const u8) ![]u8 {
+    for (0..rebuild_state_temp_attempts) |_| {
+        var entropy: [@sizeOf(u128)]u8 = undefined;
+        try io.randomSecure(&entropy);
+        const nonce = std.mem.readInt(u128, &entropy, .little);
+        const tmp_path = try std.fmt.allocPrint(alloc, "{s}.tmp-{x}", .{ path, nonce });
+        writeStateFile(io, tmp_path, contents, true) catch |err| switch (err) {
+            error.PathAlreadyExists => {
+                alloc.free(tmp_path);
+                continue;
+            },
+            error.FileNotFound, error.NotDir => {
+                alloc.free(tmp_path);
+                return error.RebuildStateOwnerStale;
+            },
+            else => {
+                deleteFileWithIo(io, tmp_path) catch {};
+                alloc.free(tmp_path);
+                return err;
+            },
+        };
+        return tmp_path;
+    }
+    return error.RebuildStateTempCollision;
+}
+
+fn renameWithIo(io: std.Io, old_path: []const u8, new_path: []const u8) !void {
+    if (std.fs.path.isAbsolute(new_path)) {
+        try std.Io.Dir.renameAbsolute(old_path, new_path, io);
+    } else {
+        try std.Io.Dir.rename(std.Io.Dir.cwd(), old_path, std.Io.Dir.cwd(), new_path, io);
     }
 }
 
-fn renameAbsolutePortable(old_path: []const u8, new_path: []const u8) !void {
-    const allocator = std.heap.page_allocator;
-    const old_path_z = try allocator.dupeZ(u8, old_path);
-    defer allocator.free(old_path_z);
-    const new_path_z = try allocator.dupeZ(u8, new_path);
-    defer allocator.free(new_path_z);
-
-    while (true) {
-        const rc = std.posix.system.rename(old_path_z, new_path_z);
-        switch (std.posix.errno(rc)) {
-            .SUCCESS => return,
-            .INTR => continue,
-            .ACCES, .PERM, .ROFS => return error.AccessDenied,
-            .BUSY => return error.FileBusy,
-            .IO => return error.InputOutput,
-            .INVAL => return error.InvalidArgument,
-            .ISDIR => return error.IsDir,
-            .LOOP => return error.SymLinkLoop,
-            .MLINK => return error.LinkQuotaExceeded,
-            .NAMETOOLONG => return error.NameTooLong,
-            .NOENT => return error.FileNotFound,
-            .NOTDIR => return error.NotDir,
-            .NOMEM => return error.SystemResources,
-            .NOSPC => return error.NoSpaceLeft,
-            .NOTEMPTY, .EXIST => return error.PathAlreadyExists,
-            .XDEV => return error.RenameAcrossMountPoints,
-            else => |err| return std.posix.unexpectedErrno(err),
-        }
+fn deleteFileWithIo(io: std.Io, path: []const u8) !void {
+    if (std.fs.path.isAbsolute(path)) {
+        try std.Io.Dir.deleteFileAbsolute(io, path);
+    } else {
+        try std.Io.Dir.cwd().deleteFile(io, path);
     }
+}
+
+fn syncPublishedParent(io: std.Io, path: []const u8) !void {
+    fs_paths.syncDirPortable(io, std.fs.path.dirname(path) orelse ".") catch |err| switch (err) {
+        // Platforms without durable directory sync have an explicit
+        // best-effort publication policy. Do not report an ordinary write
+        // failure after the atomic replacement is already visible.
+        error.DurableDirectorySyncUnsupported => return,
+        else => return error.RebuildStateDurabilityUncertain,
+    };
 }
 
 fn encodeState(alloc: Allocator, key: []const u8) ![]u8 {
@@ -242,8 +263,8 @@ fn decodeState(alloc: Allocator, encoded: []const u8) ![]u8 {
     return try alloc.dupe(u8, encoded[pos..checksum_offset]);
 }
 
-fn writeStateFile(io: std.Io, path: []const u8, contents: []const u8) !void {
-    var file = try fs_paths.createFilePortable(io, path, .{ .truncate = true });
+fn writeStateFile(io: std.Io, path: []const u8, contents: []const u8, exclusive: bool) !void {
+    var file = try fs_paths.createFilePortable(io, path, .{ .truncate = true, .exclusive = exclusive });
     defer file.close(io);
 
     var buf: [4096]u8 = undefined;
@@ -275,6 +296,10 @@ fn keyToU64(key: []const u8) u64 {
     return std.mem.readInt(u64, &buf, .big);
 }
 
+fn createTestStateRoot(path: []const u8) !void {
+    try fs_paths.createDirPathPortable(std.testing.io, path);
+}
+
 test "rebuild state round trips and clears" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -283,6 +308,7 @@ test "rebuild state round trips and clears" {
 
     const state = RebuildState.init(path);
     try std.testing.expect((try state.check(std.testing.allocator)) == null);
+    try createTestStateRoot(path);
     try state.update("doc:m");
     const loaded = (try state.check(std.testing.allocator)) orelse return error.TestExpectedEqual;
     defer std.testing.allocator.free(loaded);
@@ -302,6 +328,7 @@ test "rebuild state rejects key corruption" {
     defer std.testing.allocator.free(path);
 
     const state = RebuildState.init(path);
+    try createTestStateRoot(path);
     try state.update("doc:m");
     const state_path = try state.pathAlloc(std.testing.allocator);
     defer std.testing.allocator.free(state_path);
@@ -327,6 +354,7 @@ test "rebuild state rejects truncation" {
     defer std.testing.allocator.free(path);
 
     const state = RebuildState.init(path);
+    try createTestStateRoot(path);
     try state.update("doc:m");
     const state_path = try state.pathAlloc(std.testing.allocator);
     defer std.testing.allocator.free(state_path);
@@ -340,6 +368,47 @@ test "rebuild state rejects truncation" {
     try std.Io.Dir.cwd().writeFile(std.testing.io, .{ .sub_path = state_path, .data = encoded[0 .. encoded.len - 1] });
 
     try std.testing.expectError(error.InvalidRebuildState, state.check(std.testing.allocator));
+}
+
+test "rebuild state upgrades legacy cursor by restarting from scratch" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const path = try std.fmt.allocPrint(std.testing.allocator, ".zig-cache/tmp/{s}/rebuild-state-legacy", .{tmp.sub_path});
+    defer std.testing.allocator.free(path);
+    try createTestStateRoot(path);
+
+    const state = RebuildState.init(path);
+    const state_path = try state.pathAlloc(std.testing.allocator);
+    defer std.testing.allocator.free(state_path);
+    try std.Io.Dir.cwd().writeFile(std.testing.io, .{ .sub_path = state_path, .data = "doc:m" });
+
+    var legacy = try state.loadWithIo(std.testing.allocator, std.testing.io);
+    defer legacy.deinit(std.testing.allocator);
+    try std.testing.expect(legacy == .legacy);
+
+    const restart_key = (try state.checkWithIo(std.testing.allocator, std.testing.io)) orelse return error.TestExpectedEqual;
+    defer std.testing.allocator.free(restart_key);
+    try std.testing.expectEqualStrings("", restart_key);
+
+    var migrated = try state.loadWithIo(std.testing.allocator, std.testing.io);
+    defer migrated.deinit(std.testing.allocator);
+    switch (migrated) {
+        .valid => |key| try std.testing.expectEqualStrings("", key),
+        else => return error.TestExpectedValidRebuildState,
+    }
+}
+
+test "rebuild state update does not recreate vanished owner directory" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const path = try std.fmt.allocPrint(std.testing.allocator, ".zig-cache/tmp/{s}/rebuild-state-stale-owner", .{tmp.sub_path});
+    defer std.testing.allocator.free(path);
+    try createTestStateRoot(path);
+    try std.Io.Dir.cwd().deleteTree(std.testing.io, path);
+
+    const state = RebuildState.init(path);
+    try std.testing.expectError(error.RebuildStateOwnerStale, state.updateWithIo(std.testing.io, "doc:m"));
+    try std.testing.expectError(error.FileNotFound, std.Io.Dir.cwd().access(std.testing.io, path, .{}));
 }
 
 test "rebuild state estimates progress from resume key" {

--- a/zig/pkg/antfly/src/storage/db/backfill_state.zig
+++ b/zig/pkg/antfly/src/storage/db/backfill_state.zig
@@ -19,6 +19,14 @@ const fs_paths = @import("../../common/fs_paths.zig");
 const storage_io = @import("../lsm_backend/storage_io.zig");
 
 const rebuild_state_name = "rebuild.state";
+const rebuild_state_magic = "AFRBST01";
+const rebuild_state_version: u32 = 1;
+const rebuild_state_key_length_bytes = @sizeOf(u32);
+const rebuild_state_checksum_bytes = @sizeOf(u32);
+const rebuild_state_header_bytes = rebuild_state_magic.len + @sizeOf(@TypeOf(rebuild_state_version)) + rebuild_state_key_length_bytes;
+const rebuild_state_max_key_bytes = 64 * 1024;
+const rebuild_state_max_encoded_bytes = rebuild_state_header_bytes + rebuild_state_max_key_bytes + rebuild_state_checksum_bytes;
+const rebuild_state_max_read_bytes = rebuild_state_max_encoded_bytes + 1;
 var temp_nonce: u64 = 0;
 
 pub const RebuildState = struct {
@@ -37,17 +45,23 @@ pub const RebuildState = struct {
 
         var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
         defer io_impl.deinit();
-        return std.Io.Dir.cwd().readFileAlloc(io_impl.io(), path, alloc, .limited(64 * 1024)) catch |err| switch (err) {
-            error.FileNotFound => null,
-            error.NotDir => null,
+        const encoded = std.Io.Dir.cwd().readFileAlloc(io_impl.io(), path, alloc, .limited(rebuild_state_max_read_bytes)) catch |err| switch (err) {
+            error.FileNotFound => return null,
+            error.NotDir => return null,
+            error.StreamTooLong => return error.InvalidRebuildState,
             else => return err,
         };
+        defer alloc.free(encoded);
+        return try decodeState(alloc, encoded);
     }
 
     pub fn update(self: RebuildState, key: []const u8) !void {
         if (builtin.os.tag == .freestanding) {
             return;
         }
+        const encoded = try encodeState(std.heap.page_allocator, key);
+        defer std.heap.page_allocator.free(encoded);
+
         const path = try self.pathAlloc(std.heap.page_allocator);
         defer std.heap.page_allocator.free(path);
         temp_nonce +%= 1;
@@ -69,7 +83,7 @@ pub const RebuildState = struct {
             else => return err,
         };
 
-        writeStateFile(io, tmp_path, key) catch |err| switch (err) {
+        writeStateFile(io, tmp_path, encoded) catch |err| switch (err) {
             error.NotDir => return,
             else => return err,
         };
@@ -81,7 +95,7 @@ pub const RebuildState = struct {
                         error.NotDir => return,
                         else => return parent_err,
                     };
-                    writeStateFile(io, path, key) catch |write_err| switch (write_err) {
+                    writeStateFile(io, path, encoded) catch |write_err| switch (write_err) {
                         error.NotDir => return,
                         else => return write_err,
                     };
@@ -97,7 +111,7 @@ pub const RebuildState = struct {
                         error.NotDir => return,
                         else => return parent_err,
                     };
-                    writeStateFile(io, path, key) catch |write_err| switch (write_err) {
+                    writeStateFile(io, path, encoded) catch |write_err| switch (write_err) {
                         error.NotDir => return,
                         else => return write_err,
                     };
@@ -107,6 +121,7 @@ pub const RebuildState = struct {
                 else => return err,
             };
         }
+        try fs_paths.syncDirPortable(io, std.fs.path.dirname(path) orelse ".");
     }
 
     pub fn clear(self: RebuildState) !void {
@@ -181,14 +196,61 @@ fn renameAbsolutePortable(old_path: []const u8, new_path: []const u8) !void {
     }
 }
 
-fn writeStateFile(io: std.Io, path: []const u8, key: []const u8) !void {
+fn encodeState(alloc: Allocator, key: []const u8) ![]u8 {
+    if (key.len > rebuild_state_max_key_bytes or key.len > std.math.maxInt(u32)) {
+        return error.RebuildStateTooLarge;
+    }
+
+    const encoded = try alloc.alloc(u8, rebuild_state_header_bytes + key.len + rebuild_state_checksum_bytes);
+    @memcpy(encoded[0..rebuild_state_magic.len], rebuild_state_magic);
+
+    var pos = rebuild_state_magic.len;
+    std.mem.writeInt(u32, encoded[pos..][0..@sizeOf(@TypeOf(rebuild_state_version))], rebuild_state_version, .little);
+    pos += @sizeOf(@TypeOf(rebuild_state_version));
+    std.mem.writeInt(u32, encoded[pos..][0..rebuild_state_key_length_bytes], @intCast(key.len), .little);
+    pos += rebuild_state_key_length_bytes;
+    @memcpy(encoded[pos .. pos + key.len], key);
+    pos += key.len;
+    std.mem.writeInt(u32, encoded[pos..][0..rebuild_state_checksum_bytes], std.hash.Crc32.hash(encoded[0..pos]), .little);
+    return encoded;
+}
+
+fn decodeState(alloc: Allocator, encoded: []const u8) ![]u8 {
+    if (encoded.len < rebuild_state_header_bytes + rebuild_state_checksum_bytes) {
+        return error.InvalidRebuildState;
+    }
+    if (!std.mem.eql(u8, encoded[0..rebuild_state_magic.len], rebuild_state_magic)) {
+        return error.InvalidRebuildState;
+    }
+
+    var pos = rebuild_state_magic.len;
+    const version = std.mem.readInt(u32, encoded[pos..][0..@sizeOf(@TypeOf(rebuild_state_version))], .little);
+    if (version != rebuild_state_version) return error.InvalidRebuildState;
+    pos += @sizeOf(@TypeOf(rebuild_state_version));
+
+    const key_len: usize = std.mem.readInt(u32, encoded[pos..][0..rebuild_state_key_length_bytes], .little);
+    pos += rebuild_state_key_length_bytes;
+    if (key_len > rebuild_state_max_key_bytes or encoded.len - pos - rebuild_state_checksum_bytes != key_len) {
+        return error.InvalidRebuildState;
+    }
+
+    const checksum_offset = encoded.len - rebuild_state_checksum_bytes;
+    const stored_checksum = std.mem.readInt(u32, encoded[checksum_offset..][0..rebuild_state_checksum_bytes], .little);
+    if (stored_checksum != std.hash.Crc32.hash(encoded[0..checksum_offset])) {
+        return error.InvalidRebuildState;
+    }
+    return try alloc.dupe(u8, encoded[pos..checksum_offset]);
+}
+
+fn writeStateFile(io: std.Io, path: []const u8, contents: []const u8) !void {
     var file = try fs_paths.createFilePortable(io, path, .{ .truncate = true });
     defer file.close(io);
 
     var buf: [4096]u8 = undefined;
     var writer = file.writer(io, &buf);
-    try writer.interface.writeAll(key);
+    try writer.interface.writeAll(contents);
     try writer.end();
+    try file.sync(io);
 }
 
 pub fn estimateProgressForKey(range_start: []const u8, range_end: []const u8, current_key: []const u8) f64 {
@@ -214,12 +276,10 @@ fn keyToU64(key: []const u8) u64 {
 }
 
 test "rebuild state round trips and clears" {
-    const path = "/tmp/antfly-backfill-state-test";
-    var io_impl = std.Io.Threaded.init(std.testing.allocator, .{});
-    defer io_impl.deinit();
-    std.Io.Dir.cwd().deleteTree(io_impl.io(), path) catch {};
-    defer std.Io.Dir.cwd().deleteTree(io_impl.io(), path) catch {};
-    try fs_paths.createDirPathPortable(io_impl.io(), path);
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const path = try std.fmt.allocPrint(std.testing.allocator, ".zig-cache/tmp/{s}/rebuild-state", .{tmp.sub_path});
+    defer std.testing.allocator.free(path);
 
     const state = RebuildState.init(path);
     try std.testing.expect((try state.check(std.testing.allocator)) == null);
@@ -227,8 +287,59 @@ test "rebuild state round trips and clears" {
     const loaded = (try state.check(std.testing.allocator)) orelse return error.TestExpectedEqual;
     defer std.testing.allocator.free(loaded);
     try std.testing.expectEqualStrings("doc:m", loaded);
+    try state.update("");
+    const empty = (try state.check(std.testing.allocator)) orelse return error.TestExpectedEqual;
+    defer std.testing.allocator.free(empty);
+    try std.testing.expectEqualStrings("", empty);
     try state.clear();
     try std.testing.expect((try state.check(std.testing.allocator)) == null);
+}
+
+test "rebuild state rejects key corruption" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const path = try std.fmt.allocPrint(std.testing.allocator, ".zig-cache/tmp/{s}/rebuild-state-corrupt", .{tmp.sub_path});
+    defer std.testing.allocator.free(path);
+
+    const state = RebuildState.init(path);
+    try state.update("doc:m");
+    const state_path = try state.pathAlloc(std.testing.allocator);
+    defer std.testing.allocator.free(state_path);
+    const encoded = try std.Io.Dir.cwd().readFileAlloc(
+        std.testing.io,
+        state_path,
+        std.testing.allocator,
+        .limited(rebuild_state_max_encoded_bytes),
+    );
+    defer std.testing.allocator.free(encoded);
+    encoded[rebuild_state_header_bytes + 4] = 'z';
+    try std.Io.Dir.cwd().writeFile(std.testing.io, .{ .sub_path = state_path, .data = encoded });
+
+    try std.testing.expectError(error.InvalidRebuildState, state.check(std.testing.allocator));
+    // Validation quarantines the cursor; it must not silently clear it.
+    try std.testing.expectError(error.InvalidRebuildState, state.check(std.testing.allocator));
+}
+
+test "rebuild state rejects truncation" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const path = try std.fmt.allocPrint(std.testing.allocator, ".zig-cache/tmp/{s}/rebuild-state-truncated", .{tmp.sub_path});
+    defer std.testing.allocator.free(path);
+
+    const state = RebuildState.init(path);
+    try state.update("doc:m");
+    const state_path = try state.pathAlloc(std.testing.allocator);
+    defer std.testing.allocator.free(state_path);
+    const encoded = try std.Io.Dir.cwd().readFileAlloc(
+        std.testing.io,
+        state_path,
+        std.testing.allocator,
+        .limited(rebuild_state_max_encoded_bytes),
+    );
+    defer std.testing.allocator.free(encoded);
+    try std.Io.Dir.cwd().writeFile(std.testing.io, .{ .sub_path = state_path, .data = encoded[0 .. encoded.len - 1] });
+
+    try std.testing.expectError(error.InvalidRebuildState, state.check(std.testing.allocator));
 }
 
 test "rebuild state estimates progress from resume key" {

--- a/zig/pkg/antfly/src/storage/db/catalog/index_manager.zig
+++ b/zig/pkg/antfly/src/storage/db/catalog/index_manager.zig
@@ -1935,7 +1935,7 @@ pub const IndexManager = struct {
         const rebuild_state = backfill_state_mod.RebuildState.init(entry.rebuild_root_path);
 
         try entry.persistent.resetAllForRebuild();
-        try rebuild_state.update("");
+        try rebuild_state.updateWithIo(self.checkpointIo(), "");
         try self.backfillTextIndex(store, entry, null);
         try entry.persistent.sync(true);
         try self.saveBackfilledAppliedSequence(store, entry.config);
@@ -1980,7 +1980,7 @@ pub const IndexManager = struct {
 
         try checkRepairCancelled(cancel_check);
         try entry.persistent.resetAllForRebuild();
-        try rebuild_state.update("");
+        try rebuild_state.updateWithIo(self.checkpointIo(), "");
         try self.backfillTextIndexFromReadTxn(store, read_txn, entry, null, cancel_check, capacity_check);
         try checkRepairCancelled(cancel_check);
         try entry.persistent.sync(true);
@@ -7990,7 +7990,7 @@ pub const IndexManager = struct {
                     .compact_text = false,
                     .compact_text_segment_threshold = text_backfill_compact_segment_threshold,
                 }, stats);
-                try rebuild.update(last_doc_key);
+                try rebuild.updateWithIo(manager.checkpointIo(), last_doc_key);
                 for (docs_buf.items) |doc| {
                     manager.alloc.free(@constCast(doc.key));
                     manager.alloc.free(@constCast(doc.value));
@@ -8132,7 +8132,7 @@ pub const IndexManager = struct {
         }
 
         if (flushed_batches > 0) try self.compactTextIndex(&entry.persistent, activeTextMergePolicy());
-        if (!saw_visible_doc or flushed_batches > 0) try rebuild_state.clear();
+        if (!saw_visible_doc or flushed_batches > 0) try rebuild_state.clearWithIo(self.checkpointIo());
         if (flushed_batches > 0) try entry.persistent.checkpointLsmWalAfterDurableBoundary();
     }
 
@@ -8198,7 +8198,7 @@ pub const IndexManager = struct {
                     .compact_text = false,
                     .compact_text_segment_threshold = text_backfill_compact_segment_threshold,
                 }, stats);
-                try rebuild.update(last_doc_key);
+                try rebuild.updateWithIo(manager.checkpointIo(), last_doc_key);
                 for (docs_buf.items) |doc| {
                     manager.alloc.free(@constCast(doc.key));
                     manager.alloc.free(@constCast(doc.value));
@@ -8347,7 +8347,7 @@ pub const IndexManager = struct {
         }
 
         if (flushed_batches > 0) try self.compactTextIndex(&entry.persistent, activeTextMergePolicy());
-        if (!saw_visible_doc or flushed_batches > 0) try rebuild_state.clear();
+        if (!saw_visible_doc or flushed_batches > 0) try rebuild_state.clearWithIo(self.checkpointIo());
         if (flushed_batches > 0) try entry.persistent.checkpointLsmWalAfterDurableBoundary();
     }
 
@@ -8918,7 +8918,7 @@ pub const IndexManager = struct {
                 }
 
                 const rebuild_state = backfill_state_mod.RebuildState.init(entry.rebuild_root_path);
-                var resume_from = rebuild_state.check(self.alloc) catch |err| {
+                var resume_from = rebuild_state.checkWithIo(self.alloc, self.checkpointIo()) catch |err| {
                     std.log.warn("full_text open failed step=rebuild_state_check name={s} err={s}", .{
                         cfg.name,
                         @errorName(err),
@@ -8937,7 +8937,7 @@ pub const IndexManager = struct {
 
                 if (allow_full_text_backfill and (rebuild_from_scratch_after_interruption or resume_from != null or (entry.persistent.snapshot().global_doc_count == 0 and persisted_ranges.len == 0))) {
                     const backfill_started_ns = nowNs();
-                    try rebuild_state.update(if (resume_from) |buf| buf else "");
+                    try rebuild_state.updateWithIo(self.checkpointIo(), if (resume_from) |buf| buf else "");
                     try self.backfillTextIndex(store, &entry, resume_from);
                     try self.saveBackfilledAppliedSequence(store, cfg);
                     backfill_ns += elapsedSince(backfill_started_ns);
@@ -9145,12 +9145,12 @@ pub const IndexManager = struct {
                 errdefer self.freeSparseIndexEntry(&entry);
 
                 const rebuild_state = backfill_state_mod.RebuildState.init(entry.rebuild_root_path);
-                const resume_from = try rebuild_state.check(self.alloc);
+                const resume_from = try rebuild_state.checkWithIo(self.alloc, self.checkpointIo());
                 defer if (resume_from) |buf| self.alloc.free(buf);
 
                 if (allow_backfill and (resume_from != null or entry.index.next_doc_num == 0)) {
                     const backfill_started_ns = nowNs();
-                    try rebuild_state.update(if (resume_from) |buf| buf else "");
+                    try rebuild_state.updateWithIo(self.checkpointIo(), if (resume_from) |buf| buf else "");
                     try self.backfillSparseIndex(store, &entry, resume_from);
                     try self.saveBackfilledAppliedSequence(store, cfg);
                     backfill_ns += elapsedSince(backfill_started_ns);
@@ -9243,7 +9243,7 @@ pub const IndexManager = struct {
                 errdefer self.freeGraphIndexEntry(&entry);
 
                 const rebuild_state = backfill_state_mod.RebuildState.init(entry.rebuild_root_path);
-                const resume_from = try rebuild_state.check(self.alloc);
+                const resume_from = try rebuild_state.checkWithIo(self.alloc, self.checkpointIo());
                 defer if (resume_from) |buf| self.alloc.free(buf);
                 const reverse_edges = (try entry.index.stats(self.alloc)).edge_count;
 
@@ -9259,7 +9259,7 @@ pub const IndexManager = struct {
                 const has_replay_history = latest_replay_sequence != 0;
                 if (allow_backfill and (resume_from != null or (has_replay_history and (reverse_store_missing or reverse_edges == 0) and !graph_replay_pending))) {
                     const backfill_started_ns = nowNs();
-                    try rebuild_state.update(if (resume_from) |buf| buf else "");
+                    try rebuild_state.updateWithIo(self.checkpointIo(), if (resume_from) |buf| buf else "");
                     _ = try entry.index.rebuildReverseFromOwnedOutgoingEdgesResume(self.alloc, self.byte_range.start, self.byte_range.end, resume_from);
                     backfill_ns += elapsedSince(backfill_started_ns);
                 }
@@ -10427,7 +10427,7 @@ pub const IndexManager = struct {
                     manager.alloc.free(@constCast(item.vec.values));
                 }
                 writes_buf.clearRetainingCapacity();
-                try rebuild.update(last_doc_key);
+                try rebuild.updateWithIo(manager.checkpointIo(), last_doc_key);
                 flush_count.* += 1;
                 if (@import("builtin").is_test) {
                     if (test_abort_sparse_backfill_after_batches) |limit| {
@@ -10470,7 +10470,7 @@ pub const IndexManager = struct {
             try flush_batch(self, store, entry, rebuild_state, &writes, max_flushed_key.?, &flushed_batches, &backfilled_doc_count);
         }
 
-        if (!saw_visible_doc or flushed_batches > 0) try rebuild_state.clear();
+        if (!saw_visible_doc or flushed_batches > 0) try rebuild_state.clearWithIo(self.checkpointIo());
         if (flushed_batches > 0) try entry.index.checkpointLsmWalAfterDurableBoundary();
     }
 

--- a/zig/pkg/antfly/src/storage/db/db.zig
+++ b/zig/pkg/antfly/src/storage/db/db.zig
@@ -16656,7 +16656,7 @@ pub const DB = struct {
             const rebuild_root_path = try self.denseIndexRebuildStatePathAlloc(alloc, entry.config.name);
             defer alloc.free(rebuild_root_path);
             const rebuild_state = backfill_state_mod.RebuildState.init(rebuild_root_path);
-            const persisted_resume = try rebuild_state.check(alloc);
+            const persisted_resume = try rebuild_state.checkWithIo(alloc, self.core.index_manager.checkpointIo());
             errdefer if (persisted_resume) |buf| alloc.free(buf);
             const projection_checkpoint = try self.core.loadProjectionCheckpoint(alloc, entry.config.name);
             const config_hash = types.indexConfigHash(entry.config);
@@ -16724,7 +16724,7 @@ pub const DB = struct {
                     .trigger = .projection_generation_invalid,
                     .last_error = last_error,
                 });
-                if (candidate.persisted_resume != null) try rebuild_state.clear();
+                if (candidate.persisted_resume != null) try rebuild_state.clearWithIo(self.core.index_manager.checkpointIo());
                 continue;
             }
             if (candidate.artifact_counter_required and
@@ -16735,7 +16735,7 @@ pub const DB = struct {
                     .trigger = .artifact_counter_missing,
                     .last_error = "dense_artifact_counter_missing",
                 });
-                if (candidate.persisted_resume != null) try rebuild_state.clear();
+                if (candidate.persisted_resume != null) try rebuild_state.clearWithIo(self.core.index_manager.checkpointIo());
                 continue;
             }
             const artifact_target_count = if (target_counts.authoritative_targets.contains(dense_index_idx))
@@ -16756,7 +16756,7 @@ pub const DB = struct {
                     .trigger = .artifact_coverage_mismatch,
                     .last_error = "dense_artifact_coverage_surplus",
                 });
-                if (candidate.persisted_resume != null) try rebuild_state.clear();
+                if (candidate.persisted_resume != null) try rebuild_state.clearWithIo(self.core.index_manager.checkpointIo());
                 continue;
             }
             const already_repaired = denseCoverageMatchesTarget(active_count, artifact_target_count) and
@@ -16764,11 +16764,11 @@ pub const DB = struct {
 
             if (candidate.persisted_resume) |buf| {
                 if (artifact_target_count == 0) {
-                    try rebuild_state.clear();
+                    try rebuild_state.clearWithIo(self.core.index_manager.checkpointIo());
                     continue;
                 }
                 if (already_repaired) {
-                    try rebuild_state.clear();
+                    try rebuild_state.clearWithIo(self.core.index_manager.checkpointIo());
                     continue;
                 }
                 try targets.append(alloc, .{
@@ -16839,7 +16839,7 @@ pub const DB = struct {
             const rebuild_root_path = try self.denseIndexRebuildStatePathAlloc(self.alloc, entry.config.name);
             defer self.alloc.free(rebuild_root_path);
             const rebuild_state = backfill_state_mod.RebuildState.init(rebuild_root_path);
-            try rebuild_state.update(target.resume_from orelse "");
+            try rebuild_state.updateWithIo(self.core.index_manager.checkpointIo(), target.resume_from orelse "");
         }
     }
 
@@ -16862,7 +16862,7 @@ pub const DB = struct {
             const repaired = denseCoverageMatchesTarget(entry.index.stats().active_count, target.artifact_target_count) and
                 applied_sequence >= target_sequence;
             if (repaired) {
-                try rebuild_state.clear();
+                try rebuild_state.clearWithIo(self.core.index_manager.checkpointIo());
                 const checkpoint = try self.core.loadProjectionCheckpoint(alloc, entry.config.name);
                 try self.core.saveProjectionCheckpoint(entry.config.name, .{
                     .applied_sequence = applied_sequence,
@@ -16916,7 +16916,7 @@ pub const DB = struct {
                 const rebuild_root_path = try self.denseIndexRebuildStatePathAlloc(alloc, entry.config.name);
                 defer alloc.free(rebuild_root_path);
                 const rebuild_state = backfill_state_mod.RebuildState.init(rebuild_root_path);
-                try rebuild_state.clear();
+                try rebuild_state.clearWithIo(self.core.index_manager.checkpointIo());
                 try self.core.saveProjectionCheckpoint(entry.config.name, .{
                     .applied_sequence = target_sequence,
                     .status = .clean,
@@ -17217,7 +17217,7 @@ pub const DB = struct {
                     const rebuild_root_path = try persist.db.denseIndexRebuildStatePathAlloc(persist.alloc, entry.config.name);
                     defer persist.alloc.free(rebuild_root_path);
                     const rebuild_state = backfill_state_mod.RebuildState.init(rebuild_root_path);
-                    try rebuild_state.update(last_key);
+                    try rebuild_state.updateWithIo(persist.db.core.index_manager.checkpointIo(), last_key);
                     const owned_key = try persist.alloc.dupe(u8, last_key);
                     errdefer persist.alloc.free(owned_key);
                     if (target.resume_from) |resume_from| persist.alloc.free(resume_from);


### PR DESCRIPTION
Stacked on #371.

## What changed

- Store `rebuild.state` as a versioned envelope with a key length and CRC32.
- Sync the state file and its parent directory before considering an update durable.
- Reject malformed, truncated, oversized, or checksum-invalid cursors without clearing them.
- Route metadata status reporting through the same decoder instead of reading raw cursor bytes.
- Update metadata fixtures and add round-trip, mutation, and truncation regression tests.

## Why

The derived-index rebuild cursor was previously an unprotected raw key. A bit flip or partial write could turn a valid cursor into a later valid-looking key, permanently advancing the rebuild past documents that had not been indexed. The new format fails closed instead of silently publishing incomplete derived indexes.

## User impact

Corrupt rebuild progress now stops/quarantines the affected rebuild for repair rather than silently leaving search, vector, graph, or other derived indexes incomplete.

## Validation

- ReleaseSafe Antfly binary builds successfully.
- 6/6 focused rebuild-state tests pass in ReleaseSafe.
- 33/33 metadata-service consumer tests pass in ReleaseSafe.
- Formatting, AST checks, and `git diff --check` pass.
- A broader ReleaseSafe aggregate was run partially; many storage/indexing/recall suites passed, while independent split/merge simulation and broad unit failures remain on the stacked PR and were not addressed here.
