### PR TITLE
Protect rebuild cursors against silent corruption

### DIFF
--- a/scripts/ci/zig-e2e-regression-loop.sh
+++ b/scripts/ci/zig-e2e-regression-loop.sh
@@ -59,6 +59,7 @@ fi
 
 if ((workers > 1)); then
   log_root="$(mktemp -d "${TMPDIR:-/tmp}/antfly-e2e-regression.XXXXXX")"
+  preserve_log_root=0
   pids=()
 
   # shellcheck disable=SC2329 # Invoked indirectly by the signal traps below.
@@ -70,8 +71,15 @@ if ((workers > 1)); then
     wait 2>/dev/null || true
     exit 130
   }
+  cleanup_worker_logs() {
+    if ((preserve_log_root == 0)); then
+      rm -rf -- "$log_root"
+    else
+      printf '\nPreserving E2E regression worker logs: %s\n' "$log_root" >&2
+    fi
+  }
   trap terminate_workers INT TERM
-  trap 'rm -rf "$log_root"' EXIT
+  trap cleanup_worker_logs EXIT
 
   for ((worker = 1; worker <= workers; worker++)); do
     env \
@@ -97,6 +105,9 @@ if ((workers > 1)); then
     printf '\n===== E2E regression worker %d/%d =====\n' "$worker" "$workers"
     cat "$log_root/worker-${worker}.log"
   done
+  if ((result != 0)); then
+    preserve_log_root=1
+  fi
   exit "$result"
 fi
 

--- a/zig/build.zig
+++ b/zig/build.zig
@@ -3678,7 +3678,7 @@ pub fn build(b: *std.Build) void {
         "data runtime status refresh publishes synthetic missing status for absent local group db",
         "data runtime local group status does not open roots owned by transitions",
         "data runtime local group status provider collects and caches group statuses",
-        "data runtime placement fingerprint covers relocation ownership",
+        "data runtime storage ownership fingerprint excludes transient placement progress",
         "data descriptor factory separates bootstrap voters from transport peers",
         "data descriptor factory bootstraps pristine group from complete intent peer set",
         "placement peer collection preserves complete intent peers during partial projection",

--- a/zig/build.zig
+++ b/zig/build.zig
@@ -5229,6 +5229,7 @@ pub fn build(b: *std.Build) void {
             "managed startup catch-up preserves restore repair debt while index load is terminal",
             "managed startup catch-up allocation failure preserves bounded retry",
             "managed structural catch-up delegates durable generation repair without rebuilding inline",
+            "managed db open modes never drain resolver backfill on raft apply",
             "replica root reconcile enqueues newly admitted managed full text repair",
             "managed repair visibility edges retire cached readers and runtime status",
             "table runtime snapshot cache invalidation fences a stale observed publisher",

--- a/zig/build.zig
+++ b/zig/build.zig
@@ -5145,6 +5145,7 @@ pub fn build(b: *std.Build) void {
             "derived coverage evaluation is policy exact and observation gated",
             "derived coverage aggregation rejects mixed config observations",
             "index status exposes compact repair state without internal diagnostics",
+            "rebuild quarantine remains an explicit failed public index status",
             "index repair aggregation exposes a waiting shard over rebuilding shards",
             "derived coverage aggregation rejects stale index incarnations",
             "derived coverage reasons expose counter mismatch",
@@ -5169,6 +5170,7 @@ pub fn build(b: *std.Build) void {
             "api http server join planner uses complete fresh local stats before metadata publication",
             "external embeddings index readiness does not require table doc coverage",
             "api http server preserves public query availability errors",
+            "remote rebuild quarantine preserves its source and index failure",
             "api http server create index waits for exact target config projection",
         },
         .test_runner = .{

--- a/zig/e2e/antfly/test_scaling.py
+++ b/zig/e2e/antfly/test_scaling.py
@@ -958,7 +958,58 @@ class MultiNodeScalingCluster:
                     parts.append(f"[{label} pid {proc.pid}] gdb failed: {exc!r}")
         return "\n".join(parts)
 
+    def preserve_failure_diagnostics(self) -> None:
+        diagnostics: dict[str, Any] = {
+            "metadata_snapshots": [],
+            "metadata_statuses": self.metadata_statuses(),
+            "node_shutdown_statuses": [],
+            "processes": {
+                "metadata": [
+                    {"pid": proc.pid, "returncode": proc.poll()} for proc in self.metadata_procs
+                ],
+                "data": [
+                    {"pid": proc.pid, "returncode": proc.poll()} for proc in self.data_procs
+                ],
+            },
+        }
+        for index, url in enumerate(self.metadata_urls):
+            try:
+                diagnostics["metadata_snapshots"].append(
+                    {"index": index, "url": url, "snapshot": self.metadata_snapshot(index)}
+                )
+            except Exception as exc:
+                diagnostics["metadata_snapshots"].append(
+                    {"index": index, "url": url, "error": repr(exc)}
+                )
+        for node in self.data_nodes:
+            node_id = int(node["id"])
+            try:
+                response = requests.get(
+                    f"{self.metadata_urls[0]}/internal/v1/nodes/{node_id}/shutdown",
+                    timeout=5,
+                )
+                diagnostics["node_shutdown_statuses"].append(
+                    {
+                        "node_id": node_id,
+                        "status_code": response.status_code,
+                        "body": response.json() if response.ok else response.text,
+                    }
+                )
+            except Exception as exc:
+                diagnostics["node_shutdown_statuses"].append(
+                    {"node_id": node_id, "error": repr(exc)}
+                )
+        try:
+            (self.root / "failure-diagnostics.json").write_text(
+                json.dumps(diagnostics, indent=2, sort_keys=True),
+                encoding="utf-8",
+            )
+        except Exception as exc:
+            print(f"failed to preserve scaling diagnostics: {exc!r}")
+
     def stop(self, *, timeout_s: float = 10.0, test_failed: bool = False) -> None:
+        if test_failed:
+            self.preserve_failure_diagnostics()
         procs = [proc for proc in [*self.data_procs, *self.metadata_procs] if proc.poll() is None]
         for proc in procs:
             proc.send_signal(signal.SIGTERM)

--- a/zig/pkg/antfly/src/api/e2e.zig
+++ b/zig/pkg/antfly/src/api/e2e.zig
@@ -720,8 +720,18 @@ test "public api smoke e2e creates table inserts and queries documents" {
     var created_index = try client.createTableIndex(base_uri, "docs", "embed_idx", create_index_body);
     defer created_index.deinit(std.testing.allocator);
 
-    rounds = 0;
-    while (rounds < 8) : (rounds += 1) try svc.runRound();
+    // Index creation is accepted before the writer-owned structural worker
+    // has published its durable generation. Wait on that owner's activity
+    // contract instead of assuming a fixed number of metadata rounds is
+    // enough on a loaded CI runner.
+    var structural_wait_io = std.Io.Threaded.init(std.testing.allocator, .{});
+    defer structural_wait_io.deinit();
+    var structural_wait_attempts: usize = 0;
+    while (structural_wait_attempts < 120_000 and provisioned_write_source.hasGroupActivityBestEffort("docs", 0)) : (structural_wait_attempts += 1) {
+        try svc.runRound();
+        structural_wait_io.io().sleep(std.Io.Duration.fromMilliseconds(1), .awake) catch {};
+    }
+    try std.testing.expect(!provisioned_write_source.hasGroupActivityBestEffort("docs", 0));
 
     // This fixture performs data-group writes directly instead of running a
     // second Raft host. Model the data owner's normal lifecycle explicitly:
@@ -7196,7 +7206,7 @@ test "public api split e2e uses distributed global text stats for bm25 and signi
         \\"doc:c":{"title":"left-2","body":"alpha"},
         \\"doc:d":{"title":"left-3","body":"alpha"},
         \\"doc:e":{"title":"left-4","body":"alpha"},
-        \\"doc:z":{"title":"right","body":"alpha rareright"}}}
+        \\"doc:z":{"title":"right","body":"alpha rareright"}},"sync_level":"full_text"}
     );
     defer std.testing.allocator.free(batch_body);
     var batch = try client.fetchBatch(base_uri, "docs", batch_body);

--- a/zig/pkg/antfly/src/api/http_server.zig
+++ b/zig/pkg/antfly/src/api/http_server.zig
@@ -2811,6 +2811,9 @@ pub const ApiHttpServer = struct {
 
     fn runtimeStatusSourceRank(source: runtime_status.RuntimeStatusSource) u8 {
         return switch (source) {
+            // A fresh observation that an integrity boundary failed must win
+            // over the last healthy runtime sample for the same group.
+            .rebuild_state_quarantine => 80,
             .live_writer_publish => 70,
             .startup_catch_up => 60,
             .background_refresh => 50,
@@ -2862,15 +2865,23 @@ pub const ApiHttpServer = struct {
         const indexes = try alloc.alloc(db_mod.types.DBIndexStats, report.indexes.len);
         var initialized: usize = 0;
         errdefer {
-            for (indexes[0..initialized]) |item| alloc.free(item.name);
+            for (indexes[0..initialized]) |item| {
+                alloc.free(item.name);
+                if (item.load_error) |value| alloc.free(value);
+            }
             if (indexes.len > 0) alloc.free(indexes);
         }
         for (report.indexes, 0..) |index, i| {
             const kind = parseRemoteIndexKind(index.kind);
             const dense_catch_up_active = kind == .dense_vector and report.async_dense_catch_up_active;
+            const name = try alloc.dupe(u8, index.name);
+            errdefer alloc.free(name);
+            const load_error = if (index.load_error) |value| try alloc.dupe(u8, value) else null;
+            errdefer if (load_error) |value| alloc.free(value);
             indexes[i] = .{
-                .name = try alloc.dupe(u8, index.name),
+                .name = name,
                 .kind = kind,
+                .load_error = load_error,
                 .doc_count = index.doc_count,
                 .term_count = index.term_count,
                 .edge_count = index.edge_count,
@@ -2902,7 +2913,7 @@ pub const ApiHttpServer = struct {
             .created_at_millis = report.created_at_millis,
             .metadata = .{
                 .updated_at_ns = report.updated_at_ns,
-                .source = .remote_store,
+                .source = parseRemoteRuntimeSource(report.source),
                 .freshness = parseRemoteRuntimeFreshness(report.freshness),
                 .topology_generation = report.topology_generation,
                 .lsm_root_generation = report.lsm_root_generation,
@@ -2997,6 +3008,11 @@ pub const ApiHttpServer = struct {
             if (std.mem.eql(u8, freshness, field.name)) return @enumFromInt(field.value);
         }
         return .remote_unknown;
+    }
+
+    fn parseRemoteRuntimeSource(source: []const u8) runtime_status.RuntimeStatusSource {
+        if (std.mem.eql(u8, source, "rebuild_state_quarantine")) return .rebuild_state_quarantine;
+        return .remote_store;
     }
 
     fn tableHasGroup(snapshot: *const metadata_api.AdminSnapshot, table_id: u64, group_id: u64) bool {
@@ -28305,6 +28321,30 @@ test "remote runtime status reports replay debt separately from active catch-up"
     try std.testing.expect(status.stats.enrichment.stalled);
     try std.testing.expectEqual(@as(u64, 17), status.stats.enrichment.processed_requests);
     try std.testing.expectEqualStrings("rebuilding", status.stats.enrichment.projection_checkpoint_status);
+}
+
+test "remote rebuild quarantine preserves its source and index failure" {
+    const alloc = std.testing.allocator;
+    const report = metadata_table_manager.RuntimeGroupStatusReport{
+        .group_id = 10,
+        .store_id = 20,
+        .node_id = 30,
+        .source = "rebuild_state_quarantine",
+        .freshness = "failed",
+        .indexes = @constCast((&[_]metadata_table_manager.RuntimeIndexStatusReport{.{
+            .name = "search_idx",
+            .kind = "full_text",
+            .load_error = "InvalidRebuildState",
+        }})[0..]),
+    };
+
+    var status = try ApiHttpServer.localRuntimeStatusFromRemoteReport(alloc, report);
+    defer status.deinit(alloc);
+
+    try std.testing.expectEqual(runtime_status.RuntimeStatusSource.rebuild_state_quarantine, status.metadata.source);
+    try std.testing.expectEqual(runtime_status.RuntimeStatusFreshness.failed, status.metadata.freshness);
+    try std.testing.expectEqual(@as(usize, 1), status.stats.indexes.len);
+    try std.testing.expectEqualStrings("InvalidRebuildState", status.stats.indexes[0].load_error.?);
 }
 
 test "table storage status sums complete fresh shard disk usage" {

--- a/zig/pkg/antfly/src/api/http_server.zig
+++ b/zig/pkg/antfly/src/api/http_server.zig
@@ -19731,6 +19731,79 @@ test "api http server filters extension mcp tools by trusted principal table per
     try std.testing.expect(std.mem.indexOf(u8, tools_resp.body, "\"name\":\"store_doc\"") == null);
     try std.testing.expect(std.mem.indexOf(u8, tools_resp.body, "\"name\":\"search_memories\"") == null);
 
+    // Discovery is not the authorization boundary: a read-only client may
+    // retain an older write-tool schema and hand-craft tools/call. The current
+    // request identity must still prevent the mutation from reaching a route.
+    var denied_builtin_write = try server.handle(.{
+        .method = .POST,
+        .uri = routes.Routes.mcp_v1,
+        .headers = &mcp_session_headers,
+        .content_type = "application/json",
+        .body = "{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"tools/call\",\"params\":{\"name\":\"batch\",\"arguments\":{\"tableName\":\"docs\",\"writes\":{\"doc:a\":{\"title\":\"forbidden\"}}}}}",
+    });
+    defer denied_builtin_write.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(u16, 200), denied_builtin_write.status);
+    try std.testing.expect(std.mem.indexOf(u8, denied_builtin_write.body, "\"message\":\"unknown tool\"") != null);
+
+    var denied_extension_write = try server.handle(.{
+        .method = .POST,
+        .uri = routes.Routes.mcp_v1,
+        .headers = &mcp_session_headers,
+        .content_type = "application/json",
+        .body = "{\"jsonrpc\":\"2.0\",\"id\":4,\"method\":\"tools/call\",\"params\":{\"name\":\"store_doc\",\"arguments\":{\"title\":\"forbidden\"}}}",
+    });
+    defer denied_extension_write.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(u16, 200), denied_extension_write.status);
+    try std.testing.expect(std.mem.indexOf(u8, denied_extension_write.body, "\"message\":\"unknown tool\"") != null);
+
+    const write_payload = try std.fmt.allocPrint(
+        std.testing.allocator,
+        \\{{"iss":"trusted-upstream","sub":"user:writer","tenant":"tenant-1","tables":["docs"],"operations":["write"],"iat":{d},"exp":{d}}}
+    ,
+        .{ now, now + 60 },
+    );
+    defer std.testing.allocator.free(write_payload);
+    const write_token = try encodeTrustedPrincipalToken(std.testing.allocator, secret, write_payload);
+    defer std.testing.allocator.free(write_token);
+    const write_headers = [_]http_common.RequestHeader{
+        .{ .name = trusted_principal_header, .value = write_token },
+    };
+    var write_init = try server.handle(.{
+        .method = .POST,
+        .uri = routes.Routes.mcp_v1,
+        .headers = &write_headers,
+        .content_type = "application/json",
+        .body = "{\"jsonrpc\":\"2.0\",\"id\":5,\"method\":\"initialize\",\"params\":{}}",
+    });
+    defer write_init.deinit(std.testing.allocator);
+    const write_session_headers = [_]http_common.RequestHeader{
+        .{ .name = mcp.session_id_header, .value = write_init.headers[0].value },
+        .{ .name = trusted_principal_header, .value = write_token },
+    };
+    var denied_cross_table_write = try server.handle(.{
+        .method = .POST,
+        .uri = routes.Routes.mcp_v1,
+        .headers = &write_session_headers,
+        .content_type = "application/json",
+        .body = "{\"jsonrpc\":\"2.0\",\"id\":6,\"method\":\"tools/call\",\"params\":{\"name\":\"batch\",\"arguments\":{\"tableName\":\"memories\",\"writes\":{\"doc:a\":{\"title\":\"forbidden\"}}}}}",
+    });
+    defer denied_cross_table_write.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(u16, 200), denied_cross_table_write.status);
+    try std.testing.expect(std.mem.indexOf(u8, denied_cross_table_write.body, "\"text\":\"permission denied\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, denied_cross_table_write.body, "\"isError\":true") != null);
+
+    var denied_unscoped_write = try server.handle(.{
+        .method = .POST,
+        .uri = routes.Routes.mcp_v1,
+        .headers = &write_session_headers,
+        .content_type = "application/json",
+        .body = "{\"jsonrpc\":\"2.0\",\"id\":7,\"method\":\"tools/call\",\"params\":{\"name\":\"batch\",\"arguments\":{\"writes\":{\"doc:a\":{\"title\":\"forbidden\"}}}}}",
+    });
+    defer denied_unscoped_write.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(u16, 200), denied_unscoped_write.status);
+    try std.testing.expect(std.mem.indexOf(u8, denied_unscoped_write.body, "\"text\":\"permission denied\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, denied_unscoped_write.body, "\"isError\":true") != null);
+
     var ard_catalog_resp = try server.handle(.{
         .method = .GET,
         .uri = routes.Routes.ard_v1_catalog,
@@ -27703,7 +27776,7 @@ test "api runtime status upsert keeps one authoritative observation per group" {
     try std.testing.expectEqual(runtime_status.RuntimeStatusFreshness.stale, items.items[0].metadata.freshness);
 }
 
-test "api runtime status quarantine wins freshness without bypassing generation fences" {
+test "api runtime status quarantine remains visible across healthy replica observations" {
     const alloc = std.testing.allocator;
     var items = std.ArrayListUnmanaged(runtime_status.LocalTableRuntimeStatus).empty;
     var item_indexes = std.AutoHashMapUnmanaged(u64, usize).empty;
@@ -27760,6 +27833,8 @@ test "api runtime status quarantine wins freshness without bypassing generation 
     };
     try ApiHttpServer.upsertRuntimeStatus(alloc, &items, &item_indexes, &newer_healthy);
     try std.testing.expectEqual(runtime_status.RuntimeStatusSource.rebuild_state_quarantine, items.items[0].metadata.source);
+    try std.testing.expectEqual(@as(u64, 7), items.items[0].metadata.store_id);
+    try std.testing.expectEqual(@as(u64, 8), items.items[0].metadata.node_id);
 
     var next_topology = runtime_status.LocalTableRuntimeStatus{
         .group_id = 7002,

--- a/zig/pkg/antfly/src/api/http_server.zig
+++ b/zig/pkg/antfly/src/api/http_server.zig
@@ -607,6 +607,7 @@ pub const ApiHttpServerConfig = struct {
     session_executor: ?http_common.RequestExecutor = null,
     session_store: ?*transactions_api.DurableSessionStore = null,
     session_store_path: ?[]const u8 = null,
+    session_store_scope: transactions_api.SessionStoreScope = .node_local,
     ha_admin_executor: ?http_common.RequestExecutor = null,
     ha_internal_executor: ?http_common.RequestExecutor = null,
     join_job_store_path: ?[]const u8 = null,
@@ -1782,17 +1783,21 @@ pub const ApiHttpServer = struct {
             .table_writes = table_write_source,
             .foreign_registry = cfg.foreign_registry,
             .created_at_ns = platform_time.monotonicNs(),
-            .txn_sessions = transactions_api.SessionRegistry.initWithOptions(
-                cfg.session_store,
-                if (cfg.session_store != null and cfg.session_owner_lease_ttl_ns != null)
-                    transactions_api.SessionLeaseStore.initFromDurable(cfg.session_store.?)
-                else
-                    null,
-                cfg.session_owner_lease_ttl_ns,
-                cfg.session_savepoint_limit,
-                cfg.session_max_count,
-                cfg.session_max_record_bytes,
-            ),
+            .txn_sessions = blk: {
+                var registry = transactions_api.SessionRegistry.initWithOptions(
+                    cfg.session_store,
+                    if (cfg.session_store != null and cfg.session_owner_lease_ttl_ns != null)
+                        transactions_api.SessionLeaseStore.initFromDurable(cfg.session_store.?)
+                    else
+                        null,
+                    cfg.session_owner_lease_ttl_ns,
+                    cfg.session_savepoint_limit,
+                    cfg.session_max_count,
+                    cfg.session_max_record_bytes,
+                );
+                registry.durable_scope = cfg.session_store_scope;
+                break :blk registry;
+            },
             .join_job_store = distributed_join.JoinJobStore.init(owner_alloc, .{
                 .join_job_store_path = cfg.join_job_store_path,
                 .join_job_lease_ttl_ms = cfg.join_job_lease_ttl_ms,
@@ -1931,6 +1936,7 @@ pub const ApiHttpServer = struct {
                 effective_cfg.session_max_count,
                 effective_cfg.session_max_record_bytes,
             );
+            server.txn_sessions.durable_scope = effective_cfg.session_store_scope;
         }
         if (cfg.join_job_store_path orelse cfg.session_store_path) |base_path| {
             const join_job_path = if (cfg.join_job_store_path != null)
@@ -4557,7 +4563,10 @@ pub const ApiHttpServer = struct {
     fn dispatchTransactionRoutes(self: *ApiHttpServer, req: http_common.HttpRequest, uri_parts: UriParts, authenticated_identity: ?AuthenticatedIdentity) !?http_common.HttpResponse {
         if (req.method == .GET) {
             if (std.mem.eql(u8, uri_parts.path, routes.Routes.transactions)) {
-                const sessions = try self.txn_sessions.listStatuses(self.alloc);
+                const sessions = try self.txn_sessions.listStatusesForPrincipal(
+                    self.alloc,
+                    transactionPrincipal(authenticated_identity),
+                );
                 defer self.alloc.free(sessions);
                 var arena_impl = std.heap.ArenaAllocator.init(self.alloc);
                 defer arena_impl.deinit();
@@ -4675,6 +4684,9 @@ pub const ApiHttpServer = struct {
             if (routes.Routes.matchTransactionSession(uri_parts.path)) |session_route| {
                 const txn_id = distributed_txn.parseTxnIdHex(session_route.txn_id) catch return try textResponse(self.alloc, 400, "invalid transaction id");
                 if (try self.forwardSessionRequest(txn_id, req)) |resp| return resp;
+                if (!(try self.transactionSessionAccessible(txn_id, authenticated_identity))) {
+                    return try textResponse(self.alloc, 404, "not found");
+                }
                 var details = (self.txn_sessions.getDetails(self.alloc, txn_id) catch |err| switch (err) {
                     error.SessionLeaseLost => return try textResponse(self.alloc, 409, "session lease lost"),
                     else => return err,
@@ -4691,7 +4703,12 @@ pub const ApiHttpServer = struct {
                 const begin_req = transactions_api.parseBeginRequest(self.alloc, req.body) catch {
                     return try textResponse(self.alloc, 400, "invalid transaction begin request");
                 };
-                const session = self.txn_sessions.begin(self.alloc, begin_req, self.localSessionNodeId()) catch |err| switch (err) {
+                const session = self.txn_sessions.beginForPrincipal(
+                    self.alloc,
+                    begin_req,
+                    self.localSessionNodeId(),
+                    transactionPrincipal(authenticated_identity),
+                ) catch |err| switch (err) {
                     error.SessionLimitExceeded => return try textResponse(self.alloc, 429, "transaction session limit exceeded"),
                     error.SessionRecordTooLarge => return try textResponse(self.alloc, 413, "transaction session exceeds durable size limit"),
                     else => return err,
@@ -4712,6 +4729,9 @@ pub const ApiHttpServer = struct {
                     else => return err,
                 };
                 defer commit_req.deinit(self.alloc);
+                if (!(try self.transactionRequestAuthorized(authenticated_identity, commit_req))) {
+                    return try textResponse(self.alloc, 403, "forbidden");
+                }
 
                 const distributed_tables = try commit_req.distributedTables(self.alloc);
                 defer if (distributed_tables.len > 0) self.alloc.free(distributed_tables);
@@ -4808,10 +4828,16 @@ pub const ApiHttpServer = struct {
             if (routes.Routes.matchTransactionSessionRead(uri_parts.path)) |session_route| {
                 const txn_id = distributed_txn.parseTxnIdHex(session_route.txn_id) catch return try textResponse(self.alloc, 400, "invalid transaction id");
                 if (try self.forwardSessionRequest(txn_id, req)) |resp| return resp;
+                if (!(try self.transactionSessionAccessible(txn_id, authenticated_identity))) {
+                    return try textResponse(self.alloc, 404, "not found");
+                }
                 var read_req = transactions_api.parseStageReadPayload(self.alloc, req.body) catch {
                     return try textResponse(self.alloc, 400, "invalid transaction read request");
                 };
                 defer read_req.deinit(self.alloc);
+                if (!transactionTablePermissionAllowed(authenticated_identity, read_req.table_name, .read)) {
+                    return try textResponse(self.alloc, 403, "forbidden");
+                }
 
                 var owned_snapshot: transactions_api.SessionReadSnapshot = (self.txn_sessions.getReadSnapshot(self.alloc, txn_id, read_req.table_name, read_req.key) catch |err| switch (err) {
                     error.SessionLeaseLost => return try textResponse(self.alloc, 409, "session lease lost"),
@@ -4838,6 +4864,18 @@ pub const ApiHttpServer = struct {
                     if (fetched.document_json) |document_json| self.alloc.free(document_json);
                 } else if (owned_snapshot.version == 0) {
                     owned_snapshot.version = read_req.version;
+                }
+                if (!(try self.transactionReadSnapshotVisible(
+                    authenticated_identity,
+                    owned_snapshot.table_name,
+                    owned_snapshot.key,
+                    owned_snapshot.document_json,
+                ))) {
+                    if (owned_snapshot.document_json) |document_json| {
+                        self.alloc.free(document_json);
+                        owned_snapshot.document_json = null;
+                    }
+                    owned_snapshot.version = 0;
                 }
                 if (owned_snapshot.version != read_req.version) {
                     var arena_impl = std.heap.ArenaAllocator.init(self.alloc);
@@ -4870,10 +4908,16 @@ pub const ApiHttpServer = struct {
             if (routes.Routes.matchTransactionSessionWrite(uri_parts.path)) |session_route| {
                 const txn_id = distributed_txn.parseTxnIdHex(session_route.txn_id) catch return try textResponse(self.alloc, 400, "invalid transaction id");
                 if (try self.forwardSessionRequest(txn_id, req)) |resp| return resp;
+                if (!(try self.transactionSessionAccessible(txn_id, authenticated_identity))) {
+                    return try textResponse(self.alloc, 404, "not found");
+                }
                 var stage_req = transactions_api.parseStageWriteRequest(self.alloc, req.body) catch {
                     return try textResponse(self.alloc, 400, "invalid transaction write request");
                 };
                 defer stage_req.deinit(self.alloc);
+                if (!(try self.transactionRequestAuthorized(authenticated_identity, stage_req))) {
+                    return try textResponse(self.alloc, 403, "forbidden");
+                }
 
                 const session = (self.txn_sessions.stage(self.alloc, txn_id, &stage_req) catch |err| switch (err) {
                     error.SessionLeaseLost => return try textResponse(self.alloc, 409, "session lease lost"),
@@ -4890,10 +4934,16 @@ pub const ApiHttpServer = struct {
             if (routes.Routes.matchTransactionSessionDelete(uri_parts.path)) |session_route| {
                 const txn_id = distributed_txn.parseTxnIdHex(session_route.txn_id) catch return try textResponse(self.alloc, 400, "invalid transaction id");
                 if (try self.forwardSessionRequest(txn_id, req)) |resp| return resp;
+                if (!(try self.transactionSessionAccessible(txn_id, authenticated_identity))) {
+                    return try textResponse(self.alloc, 404, "not found");
+                }
                 var stage_req = transactions_api.parseStageDeleteRequest(self.alloc, req.body) catch {
                     return try textResponse(self.alloc, 400, "invalid transaction delete request");
                 };
                 defer stage_req.deinit(self.alloc);
+                if (!(try self.transactionRequestAuthorized(authenticated_identity, stage_req))) {
+                    return try textResponse(self.alloc, 403, "forbidden");
+                }
 
                 const session = (self.txn_sessions.stage(self.alloc, txn_id, &stage_req) catch |err| switch (err) {
                     error.SessionLeaseLost => return try textResponse(self.alloc, 409, "session lease lost"),
@@ -4910,6 +4960,9 @@ pub const ApiHttpServer = struct {
             if (routes.Routes.matchTransactionSessionSavepoints(uri_parts.path)) |session_route| {
                 const txn_id = distributed_txn.parseTxnIdHex(session_route.txn_id) catch return try textResponse(self.alloc, 400, "invalid transaction id");
                 if (try self.forwardSessionRequest(txn_id, req)) |resp| return resp;
+                if (!(try self.transactionSessionAccessible(txn_id, authenticated_identity))) {
+                    return try textResponse(self.alloc, 404, "not found");
+                }
                 const info = (self.txn_sessions.createSavepoint(self.alloc, txn_id) catch |err| switch (err) {
                     error.SessionLeaseLost => return try textResponse(self.alloc, 409, "session lease lost"),
                     error.SavepointLimitExceeded => return try textResponse(self.alloc, 409, "savepoint limit exceeded"),
@@ -4926,6 +4979,9 @@ pub const ApiHttpServer = struct {
             if (routes.Routes.matchTransactionSessionRollback(uri_parts.path)) |session_route| {
                 const txn_id = distributed_txn.parseTxnIdHex(session_route.txn_id) catch return try textResponse(self.alloc, 400, "invalid transaction id");
                 if (try self.forwardSessionRequest(txn_id, req)) |resp| return resp;
+                if (!(try self.transactionSessionAccessible(txn_id, authenticated_identity))) {
+                    return try textResponse(self.alloc, 404, "not found");
+                }
                 const info = (self.txn_sessions.rollbackToSavepoint(self.alloc, txn_id, session_route.savepoint_id) catch |err| switch (err) {
                     error.SessionLeaseLost => return try textResponse(self.alloc, 409, "session lease lost"),
                     error.SessionRecordTooLarge => return try textResponse(self.alloc, 413, "transaction session exceeds durable size limit"),
@@ -4948,7 +5004,13 @@ pub const ApiHttpServer = struct {
                     else => return err,
                 };
                 defer stage_req.deinit(self.alloc);
+                if (!(try self.transactionRequestAuthorized(authenticated_identity, stage_req))) {
+                    return try textResponse(self.alloc, 403, "forbidden");
+                }
 
+                if (!(try self.transactionSessionAccessible(txn_id, authenticated_identity))) {
+                    return try textResponse(self.alloc, 404, "not found");
+                }
                 const session = (self.txn_sessions.stage(self.alloc, txn_id, &stage_req) catch |err| switch (err) {
                     error.SessionLeaseLost => return try textResponse(self.alloc, 409, "session lease lost"),
                     error.SessionRecordTooLarge => return try textResponse(self.alloc, 413, "transaction session exceeds durable size limit"),
@@ -4965,6 +5027,9 @@ pub const ApiHttpServer = struct {
                 const source = self.table_writes orelse return try textResponse(self.alloc, 404, "not found");
                 const txn_id = distributed_txn.parseTxnIdHex(session_route.txn_id) catch return try textResponse(self.alloc, 400, "invalid transaction id");
                 if (try self.forwardSessionRequest(txn_id, req)) |resp| return resp;
+                if (!(try self.transactionSessionAccessible(txn_id, authenticated_identity))) {
+                    return try textResponse(self.alloc, 404, "not found");
+                }
                 const session = self.txn_sessions.getInfo(txn_id) orelse return try textResponse(self.alloc, 404, "not found");
 
                 var parsed_req: ?transactions_api.OwnedTransactionCommitRequest = null;
@@ -4995,6 +5060,9 @@ pub const ApiHttpServer = struct {
                     return try textResponse(self.alloc, 400, "transaction has no staged writes");
                 };
                 defer commit_req.deinit(self.alloc);
+                if (!(try self.transactionRequestAuthorized(authenticated_identity, commit_req))) {
+                    return try textResponse(self.alloc, 403, "forbidden");
+                }
 
                 const distributed_tables = try commit_req.distributedTables(self.alloc);
                 defer if (distributed_tables.len > 0) self.alloc.free(distributed_tables);
@@ -5100,6 +5168,9 @@ pub const ApiHttpServer = struct {
             if (routes.Routes.matchTransactionSessionAbort(uri_parts.path)) |session_route| {
                 const txn_id = distributed_txn.parseTxnIdHex(session_route.txn_id) catch return try textResponse(self.alloc, 400, "invalid transaction id");
                 if (try self.forwardSessionRequest(txn_id, req)) |resp| return resp;
+                if (!(try self.transactionSessionAccessible(txn_id, authenticated_identity))) {
+                    return try textResponse(self.alloc, 404, "not found");
+                }
                 if (!self.txn_sessions.remove(self.alloc, txn_id)) return try textResponse(self.alloc, 404, "not found");
                 var arena_impl = std.heap.ArenaAllocator.init(self.alloc);
                 defer arena_impl.deinit();
@@ -8193,7 +8264,11 @@ pub const ApiHttpServer = struct {
     }
 
     pub fn forwardSessionRequest(self: *ApiHttpServer, txn_id: db_mod.types.TxnId, req: http_common.HttpRequest) !?http_common.HttpResponse {
-        const owner_node_id = (try self.txn_sessions.getOwnerNodeId(self.alloc, txn_id)) orelse transactions_api.sessionOwnerNodeId(txn_id);
+        const owner_node_id = (try self.txn_sessions.getOwnerNodeId(self.alloc, txn_id)) orelse
+            if (self.txn_sessions.durableMissIsAuthoritative())
+                return null
+            else
+                transactions_api.sessionOwnerNodeId(txn_id);
         if (owner_node_id == 0) return null;
         const router = self.cfg.session_router orelse return null;
         const session_executor = self.cfg.session_executor orelse return null;
@@ -8274,6 +8349,66 @@ pub const ApiHttpServer = struct {
             .version = lookup.version,
             .document_json = try self.alloc.dupe(u8, lookup.json),
         };
+    }
+
+    pub fn transactionSessionAccessible(
+        self: *ApiHttpServer,
+        txn_id: db_mod.types.TxnId,
+        authenticated_identity: ?AuthenticatedIdentity,
+    ) !bool {
+        return (try self.txn_sessions.principalAccess(
+            self.alloc,
+            txn_id,
+            transactionPrincipal(authenticated_identity),
+        )) == .allowed;
+    }
+
+    pub fn transactionRequestAuthorized(
+        self: *ApiHttpServer,
+        authenticated_identity: ?AuthenticatedIdentity,
+        request: transactions_api.OwnedTransactionCommitRequest,
+    ) !bool {
+        for (request.read_set) |read| {
+            if (!(try self.transactionReadKeyAuthorized(
+                authenticated_identity,
+                read.table_name,
+                read.key,
+            ))) return false;
+        }
+        for (request.tables) |table| {
+            if (!transactionTablePermissionAllowed(authenticated_identity, table.table_name, .write)) return false;
+        }
+        return true;
+    }
+
+    fn transactionReadKeyAuthorized(
+        self: *ApiHttpServer,
+        authenticated_identity: ?AuthenticatedIdentity,
+        table_name: []const u8,
+        key: []const u8,
+    ) !bool {
+        if (!transactionTablePermissionAllowed(authenticated_identity, table_name, .read)) return false;
+        const row_filter_json = try resolveEffectiveRowFilterJson(self.alloc, authenticated_identity, table_name);
+        defer if (row_filter_json) |value| self.alloc.free(value);
+        const filter = row_filter_json orelse return true;
+        const source = self.table_reads orelse return false;
+        var lookup = (try source.lookup(self.alloc, table_name, key, .{}, .read_index)) orelse return true;
+        defer lookup.deinit(self.alloc);
+        return try self.docJsonMatchesRowFilter(key, lookup.json, filter);
+    }
+
+    pub fn transactionReadSnapshotVisible(
+        self: *ApiHttpServer,
+        authenticated_identity: ?AuthenticatedIdentity,
+        table_name: []const u8,
+        key: []const u8,
+        document_json: ?[]const u8,
+    ) !bool {
+        const row_filter_json = try resolveEffectiveRowFilterJson(self.alloc, authenticated_identity, table_name);
+        defer if (row_filter_json) |value| self.alloc.free(value);
+        const filter = row_filter_json orelse return true;
+        const document = document_json orelse return true;
+        return try self.docJsonMatchesRowFilter(key, document, filter);
     }
 
     fn currentVersionForConflict(self: *ApiHttpServer, table_name: []const u8, key: []const u8) !?u64 {
@@ -13722,6 +13857,7 @@ pub fn requiresAdminPermission(path: []const u8) bool {
     if (isHaAdminPath(path)) return true;
     if (isStorageMaintenancePath(path)) return true;
     if (isExtensionPath(path)) return true;
+    if (std.mem.eql(u8, path, routes.Routes.transactions_cleanup)) return true;
     if (std.mem.eql(u8, path, routes.Routes.secrets) or std.mem.startsWith(u8, path, routes.Routes.secrets_prefix)) return true;
     if (std.mem.eql(u8, path, routes.Routes.backup) or std.mem.eql(u8, path, routes.Routes.restore) or std.mem.eql(u8, path, routes.Routes.backups)) return true;
     if (std.mem.eql(u8, path, routes.Routes.a2a) or std.mem.eql(u8, path, routes.Routes.agents_retrieval)) return true;
@@ -13935,6 +14071,19 @@ pub fn permissionsAllow(
         if (permission.type == .admin or permission.type == permission_type) return true;
     }
     return false;
+}
+
+fn transactionPrincipal(authenticated_identity: ?AuthenticatedIdentity) ?[]const u8 {
+    return if (authenticated_identity) |identity| identity.username else null;
+}
+
+fn transactionTablePermissionAllowed(
+    authenticated_identity: ?AuthenticatedIdentity,
+    table_name: []const u8,
+    permission_type: usermgr.PermissionType,
+) bool {
+    const identity = authenticated_identity orelse return true;
+    return permissionsAllow(identity.permissions, .table, table_name, permission_type);
 }
 
 test "document artifact routes declare read and admin permissions" {
@@ -24726,6 +24875,171 @@ test "api http server serves long-lived public transaction session routes" {
     var parsed_abort = try std.json.parseFromSlice(transactions_api.TransactionStatusResponse, std.testing.allocator, abort_resp.body, .{});
     defer parsed_abort.deinit();
     try std.testing.expectEqualStrings("aborted", parsed_abort.value.status);
+}
+
+test "api transaction sessions enforce principal permissions and row filters" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const path = try std.fmt.allocPrint(alloc, ".zig-cache/tmp/{s}/api-transaction-auth", .{tmp.sub_path});
+    defer alloc.free(path);
+
+    var db = try db_mod.DB.open(alloc, path, .{});
+    defer db.close();
+    try db.batch(.{
+        .writes = &.{
+            .{ .key = "doc:visible", .value = "{\"tenant_id\":\"t1\",\"title\":\"visible\"}" },
+            .{ .key = "doc:hidden", .value = "{\"tenant_id\":\"t2\",\"title\":\"hidden\"}" },
+        },
+        .timestamp_ns = 7,
+    });
+
+    const FakeSource = struct {
+        fn iface(_: *@This()) StatusSource {
+            return .{
+                .ptr = undefined,
+                .vtable = &.{ .status = status },
+            };
+        }
+
+        fn status(_: *anyopaque) !metadata_api.MetadataStatus {
+            return .{ .metadata_group_id = 1, .metrics = .{}, .projected_stores = 1 };
+        }
+    };
+
+    var read_source = table_reads.BoundTableReadSource.init("docs", 1, &db, raft_mod.read_gate.noopReadableLeaseRequester());
+    var source = FakeSource{};
+    const secret = "transaction-principal-secret";
+    var server = ApiHttpServer.init(alloc, .{
+        .auth_enabled = true,
+        .trusted_principal_secret = secret,
+        .trusted_principal_issuer = "trusted-upstream",
+    }, source.iface(), read_source.source(), null);
+    defer server.deinit();
+
+    const now: i64 = @intCast(@divFloor(nowNs(), std.time.ns_per_s));
+    const alice_payload = try std.fmt.allocPrint(
+        alloc,
+        \\{{"iss":"trusted-upstream","sub":"user:alice","tables":["docs"],"operations":["read"],"row_filter":{{"docs":{{"term":{{"tenant_id":"t1"}}}}}},"iat":{d},"exp":{d}}}
+    ,
+        .{ now, now + 60 },
+    );
+    defer alloc.free(alice_payload);
+    const alice_token = try encodeTrustedPrincipalToken(alloc, secret, alice_payload);
+    defer alloc.free(alice_token);
+    const alice_headers = [_]http_common.RequestHeader{
+        .{ .name = trusted_principal_header, .value = alice_token },
+    };
+
+    const bob_payload = try std.fmt.allocPrint(
+        alloc,
+        \\{{"iss":"trusted-upstream","sub":"user:bob","tables":["docs"],"operations":["read","write"],"iat":{d},"exp":{d}}}
+    ,
+        .{ now, now + 60 },
+    );
+    defer alloc.free(bob_payload);
+    const bob_token = try encodeTrustedPrincipalToken(alloc, secret, bob_payload);
+    defer alloc.free(bob_token);
+    const bob_headers = [_]http_common.RequestHeader{
+        .{ .name = trusted_principal_header, .value = bob_token },
+    };
+
+    var begin_resp = try server.handle(.{
+        .method = .POST,
+        .uri = routes.Routes.transactions_begin,
+        .headers = &alice_headers,
+        .content_type = "application/json",
+        .body = "{}",
+    });
+    defer begin_resp.deinit(alloc);
+    try std.testing.expectEqual(@as(u16, 201), begin_resp.status);
+    var parsed_begin = try std.json.parseFromSlice(transactions_api.BeginResponse, alloc, begin_resp.body, .{});
+    defer parsed_begin.deinit();
+
+    const session_uri = try std.fmt.allocPrint(alloc, "{s}{s}", .{
+        routes.Routes.transactions_prefix,
+        parsed_begin.value.transaction_id,
+    });
+    defer alloc.free(session_uri);
+    var cross_principal = try server.handle(.{
+        .method = .GET,
+        .uri = session_uri,
+        .headers = &bob_headers,
+    });
+    defer cross_principal.deinit(alloc);
+    try std.testing.expectEqual(@as(u16, 404), cross_principal.status);
+
+    const write_uri = try std.fmt.allocPrint(alloc, "{s}{s}", .{
+        session_uri,
+        routes.Routes.transactions_write_suffix,
+    });
+    defer alloc.free(write_uri);
+    var denied_write = try server.handle(.{
+        .method = .POST,
+        .uri = write_uri,
+        .headers = &alice_headers,
+        .content_type = "application/json",
+        .body = "{\"table\":\"docs\",\"key\":\"doc:new\",\"document\":{\"tenant_id\":\"t1\"}}",
+    });
+    defer denied_write.deinit(alloc);
+    try std.testing.expectEqual(@as(u16, 403), denied_write.status);
+
+    const read_uri = try std.fmt.allocPrint(alloc, "{s}{s}", .{
+        session_uri,
+        routes.Routes.transactions_read_suffix,
+    });
+    defer alloc.free(read_uri);
+    var hidden_read = try server.handle(.{
+        .method = .POST,
+        .uri = read_uri,
+        .headers = &alice_headers,
+        .content_type = "application/json",
+        .body = "{\"table\":\"docs\",\"key\":\"doc:hidden\",\"version\":\"0\"}",
+    });
+    defer hidden_read.deinit(alloc);
+    try std.testing.expectEqual(@as(u16, 200), hidden_read.status);
+    var parsed_hidden = try std.json.parseFromSlice(transactions_api.StageReadResponse, alloc, hidden_read.body, .{});
+    defer parsed_hidden.deinit();
+    try std.testing.expectEqualStrings("0", parsed_hidden.value.snapshot.version);
+    try std.testing.expect(parsed_hidden.value.snapshot.document == .null);
+
+    var denied_table_read = try server.handle(.{
+        .method = .POST,
+        .uri = read_uri,
+        .headers = &alice_headers,
+        .content_type = "application/json",
+        .body = "{\"table\":\"secrets\",\"key\":\"doc:a\",\"version\":\"0\"}",
+    });
+    defer denied_table_read.deinit(alloc);
+    try std.testing.expectEqual(@as(u16, 403), denied_table_read.status);
+
+    var alice_list = try server.handle(.{
+        .method = .GET,
+        .uri = routes.Routes.transactions,
+        .headers = &alice_headers,
+    });
+    defer alice_list.deinit(alloc);
+    var parsed_alice_list = try std.json.parseFromSlice(transactions_api.SessionListResponse, alloc, alice_list.body, .{});
+    defer parsed_alice_list.deinit();
+    try std.testing.expectEqual(@as(usize, 1), parsed_alice_list.value.session_count);
+
+    var bob_list = try server.handle(.{
+        .method = .GET,
+        .uri = routes.Routes.transactions,
+        .headers = &bob_headers,
+    });
+    defer bob_list.deinit(alloc);
+    var parsed_bob_list = try std.json.parseFromSlice(transactions_api.SessionListResponse, alloc, bob_list.body, .{});
+    defer parsed_bob_list.deinit();
+    try std.testing.expectEqual(@as(usize, 0), parsed_bob_list.value.session_count);
+
+    var denied_cleanup = try server.handle(.{
+        .method = .POST,
+        .uri = routes.Routes.transactions_cleanup,
+        .headers = &alice_headers,
+    });
+    defer denied_cleanup.deinit(alloc);
+    try std.testing.expectEqual(@as(u16, 403), denied_cleanup.status);
 }
 
 test "api http server serves transaction session cleanup route" {

--- a/zig/pkg/antfly/src/api/http_server.zig
+++ b/zig/pkg/antfly/src/api/http_server.zig
@@ -2783,6 +2783,9 @@ pub const ApiHttpServer = struct {
         if (candidate_meta.lsm_root_generation != 0 and existing_meta.lsm_root_generation != 0 and
             candidate_meta.lsm_root_generation != existing_meta.lsm_root_generation)
             return candidate_meta.lsm_root_generation > existing_meta.lsm_root_generation;
+        const candidate_quarantined = candidate_meta.source == .rebuild_state_quarantine;
+        const existing_quarantined = existing_meta.source == .rebuild_state_quarantine;
+        if (candidate_quarantined != existing_quarantined) return candidate_quarantined;
         const same_producer = candidate_meta.store_id != 0 and candidate_meta.store_id == existing_meta.store_id and
             candidate_meta.node_id != 0 and candidate_meta.node_id == existing_meta.node_id;
         if (same_producer and candidate_meta.status_generation != existing_meta.status_generation)
@@ -2811,8 +2814,8 @@ pub const ApiHttpServer = struct {
 
     fn runtimeStatusSourceRank(source: runtime_status.RuntimeStatusSource) u8 {
         return switch (source) {
-            // A fresh observation that an integrity boundary failed must win
-            // over the last healthy runtime sample for the same group.
+            // Quarantine precedence is enforced before freshness. Keep it
+            // highest here as the deterministic tie-break for equal facts.
             .rebuild_state_quarantine => 80,
             .live_writer_publish => 70,
             .startup_catch_up => 60,
@@ -27698,6 +27701,144 @@ test "api runtime status upsert keeps one authoritative observation per group" {
     try ApiHttpServer.upsertRuntimeStatus(alloc, &items, &item_indexes, &newer_stale);
     try std.testing.expectEqual(@as(u64, 4), items.items[0].metadata.status_generation);
     try std.testing.expectEqual(runtime_status.RuntimeStatusFreshness.stale, items.items[0].metadata.freshness);
+}
+
+test "api runtime status quarantine wins freshness without bypassing generation fences" {
+    const alloc = std.testing.allocator;
+    var items = std.ArrayListUnmanaged(runtime_status.LocalTableRuntimeStatus).empty;
+    var item_indexes = std.AutoHashMapUnmanaged(u64, usize).empty;
+    defer item_indexes.deinit(alloc);
+    defer {
+        for (items.items) |*item| item.deinit(alloc);
+        items.deinit(alloc);
+    }
+
+    var healthy = runtime_status.LocalTableRuntimeStatus{
+        .group_id = 7002,
+        .metadata = .{
+            .source = .remote_store,
+            .freshness = .fresh,
+            .topology_generation = 4,
+            .lsm_root_generation = 9,
+            .store_id = 5,
+            .node_id = 6,
+            .updated_at_ns = 200,
+        },
+        .stats = .{},
+    };
+    try ApiHttpServer.upsertRuntimeStatus(alloc, &items, &item_indexes, &healthy);
+
+    var quarantine = runtime_status.LocalTableRuntimeStatus{
+        .group_id = 7002,
+        .metadata = .{
+            .source = .rebuild_state_quarantine,
+            .freshness = .failed,
+            .topology_generation = 4,
+            .lsm_root_generation = 9,
+            .store_id = 7,
+            .node_id = 8,
+            .updated_at_ns = 100,
+        },
+        .stats = .{},
+    };
+    try ApiHttpServer.upsertRuntimeStatus(alloc, &items, &item_indexes, &quarantine);
+    try std.testing.expectEqual(runtime_status.RuntimeStatusSource.rebuild_state_quarantine, items.items[0].metadata.source);
+    try std.testing.expectEqual(runtime_status.RuntimeStatusFreshness.failed, items.items[0].metadata.freshness);
+
+    var newer_healthy = runtime_status.LocalTableRuntimeStatus{
+        .group_id = 7002,
+        .metadata = .{
+            .source = .remote_store,
+            .freshness = .fresh,
+            .topology_generation = 4,
+            .lsm_root_generation = 9,
+            .store_id = 9,
+            .node_id = 10,
+            .updated_at_ns = 300,
+        },
+        .stats = .{},
+    };
+    try ApiHttpServer.upsertRuntimeStatus(alloc, &items, &item_indexes, &newer_healthy);
+    try std.testing.expectEqual(runtime_status.RuntimeStatusSource.rebuild_state_quarantine, items.items[0].metadata.source);
+
+    var next_topology = runtime_status.LocalTableRuntimeStatus{
+        .group_id = 7002,
+        .metadata = .{
+            .source = .remote_store,
+            .freshness = .fresh,
+            .topology_generation = 5,
+            .lsm_root_generation = 1,
+            .store_id = 9,
+            .node_id = 10,
+            .updated_at_ns = 400,
+        },
+        .stats = .{},
+    };
+    try ApiHttpServer.upsertRuntimeStatus(alloc, &items, &item_indexes, &next_topology);
+    try std.testing.expectEqual(runtime_status.RuntimeStatusSource.remote_store, items.items[0].metadata.source);
+    try std.testing.expectEqual(@as(u64, 5), items.items[0].metadata.topology_generation);
+}
+
+test "api runtime status quarantine wins same-producer status generation" {
+    const alloc = std.testing.allocator;
+    var items = std.ArrayListUnmanaged(runtime_status.LocalTableRuntimeStatus).empty;
+    var item_indexes = std.AutoHashMapUnmanaged(u64, usize).empty;
+    defer item_indexes.deinit(alloc);
+    defer {
+        for (items.items) |*item| item.deinit(alloc);
+        items.deinit(alloc);
+    }
+
+    var healthy = runtime_status.LocalTableRuntimeStatus{
+        .group_id = 7003,
+        .metadata = .{
+            .source = .remote_store,
+            .freshness = .fresh,
+            .topology_generation = 4,
+            .lsm_root_generation = 9,
+            .status_generation = 8,
+            .store_id = 5,
+            .node_id = 6,
+            .updated_at_ns = 200,
+        },
+        .stats = .{},
+    };
+    try ApiHttpServer.upsertRuntimeStatus(alloc, &items, &item_indexes, &healthy);
+
+    var quarantine = runtime_status.LocalTableRuntimeStatus{
+        .group_id = 7003,
+        .metadata = .{
+            .source = .rebuild_state_quarantine,
+            .freshness = .failed,
+            .topology_generation = 4,
+            .lsm_root_generation = 9,
+            .status_generation = 7,
+            .store_id = 5,
+            .node_id = 6,
+            .updated_at_ns = 300,
+        },
+        .stats = .{},
+    };
+    try ApiHttpServer.upsertRuntimeStatus(alloc, &items, &item_indexes, &quarantine);
+    try std.testing.expectEqual(runtime_status.RuntimeStatusSource.rebuild_state_quarantine, items.items[0].metadata.source);
+    try std.testing.expectEqual(@as(u64, 7), items.items[0].metadata.status_generation);
+
+    var newer_healthy = runtime_status.LocalTableRuntimeStatus{
+        .group_id = 7003,
+        .metadata = .{
+            .source = .remote_store,
+            .freshness = .fresh,
+            .topology_generation = 4,
+            .lsm_root_generation = 9,
+            .status_generation = 9,
+            .store_id = 5,
+            .node_id = 6,
+            .updated_at_ns = 400,
+        },
+        .stats = .{},
+    };
+    try ApiHttpServer.upsertRuntimeStatus(alloc, &items, &item_indexes, &newer_healthy);
+    try std.testing.expectEqual(runtime_status.RuntimeStatusSource.rebuild_state_quarantine, items.items[0].metadata.source);
 }
 
 test "api index status uses read runtime status without consulting write source" {

--- a/zig/pkg/antfly/src/api/httpx_handler.zig
+++ b/zig/pkg/antfly/src/api/httpx_handler.zig
@@ -546,6 +546,10 @@ pub const AntflyApiHandler = struct {
             else => return err,
         };
         defer commit_req.deinit(alloc);
+        if (!(try self.api_server.transactionRequestAuthorized(authenticated_identity, commit_req))) {
+            _ = ctx.status(403);
+            return ctx.text("forbidden");
+        }
 
         const distributed_tables = try commit_req.distributedTables(alloc);
         defer if (distributed_tables.len > 0) alloc.free(distributed_tables);
@@ -664,7 +668,10 @@ pub const AntflyApiHandler = struct {
         defer if (authenticated_identity) |*identity| identity.deinit(self.api_server.alloc);
         if (try self.authorizeRequest(ctx, &authenticated_identity)) |resp| return resp;
         const alloc = self.api_server.alloc;
-        const sessions = try self.api_server.txn_sessions.listStatuses(alloc);
+        const sessions = try self.api_server.txn_sessions.listStatusesForPrincipal(
+            alloc,
+            if (authenticated_identity) |identity| identity.username else null,
+        );
         defer alloc.free(sessions);
         var arena_impl = std.heap.ArenaAllocator.init(ctx.allocator);
         defer arena_impl.deinit();
@@ -702,7 +709,12 @@ pub const AntflyApiHandler = struct {
             _ = ctx.status(400);
             return ctx.text("invalid transaction begin request");
         };
-        const session = try self.api_server.txn_sessions.begin(alloc, begin_req, self.api_server.localSessionNodeId());
+        const session = try self.api_server.txn_sessions.beginForPrincipal(
+            alloc,
+            begin_req,
+            self.api_server.localSessionNodeId(),
+            if (authenticated_identity) |identity| identity.username else null,
+        );
         var arena_impl = std.heap.ArenaAllocator.init(ctx.allocator);
         defer arena_impl.deinit();
         const response = try transactions_api.buildBeginResponse(arena_impl.allocator(), session);
@@ -726,6 +738,10 @@ pub const AntflyApiHandler = struct {
         if (try self.api_server.forwardSessionRequest(txn_id, converted_req.value)) |forwarded| {
             var resp = forwarded;
             return respond(ctx, &resp);
+        }
+        if (!(try self.api_server.transactionSessionAccessible(txn_id, authenticated_identity))) {
+            _ = ctx.status(404);
+            return ctx.text("not found");
         }
         const alloc = self.api_server.alloc;
         var details = (self.api_server.txn_sessions.getDetails(alloc, txn_id) catch |err| switch (err) {
@@ -763,6 +779,10 @@ pub const AntflyApiHandler = struct {
             var resp = forwarded;
             return respond(ctx, &resp);
         }
+        if (!(try self.api_server.transactionSessionAccessible(txn_id, authenticated_identity))) {
+            _ = ctx.status(404);
+            return ctx.text("not found");
+        }
         const alloc = self.api_server.alloc;
         var stage_req = transactions_api.parseCommitRequest(alloc, body_data) catch |err| switch (err) {
             error.InvalidTransactionCommitRequest => {
@@ -772,6 +792,10 @@ pub const AntflyApiHandler = struct {
             else => return err,
         };
         defer stage_req.deinit(alloc);
+        if (!(try self.api_server.transactionRequestAuthorized(authenticated_identity, stage_req))) {
+            _ = ctx.status(403);
+            return ctx.text("forbidden");
+        }
         const session = (self.api_server.txn_sessions.stage(alloc, txn_id, &stage_req) catch |err| switch (err) {
             error.SessionLeaseLost => {
                 _ = ctx.status(409);
@@ -806,12 +830,22 @@ pub const AntflyApiHandler = struct {
             var resp = forwarded;
             return respond(ctx, &resp);
         }
+        if (!(try self.api_server.transactionSessionAccessible(txn_id, authenticated_identity))) {
+            _ = ctx.status(404);
+            return ctx.text("not found");
+        }
         const alloc = self.api_server.alloc;
         var read_req = transactions_api.parseStageReadPayload(alloc, body_data) catch {
             _ = ctx.status(400);
             return ctx.text("invalid transaction read request");
         };
         defer read_req.deinit(alloc);
+        if (authenticated_identity) |identity| {
+            if (!http_server_mod.permissionsAllow(identity.permissions, .table, read_req.table_name, .read)) {
+                _ = ctx.status(403);
+                return ctx.text("forbidden");
+            }
+        }
 
         var owned_snapshot = (self.api_server.txn_sessions.getReadSnapshot(alloc, txn_id, read_req.table_name, read_req.key) catch |err| switch (err) {
             error.SessionLeaseLost => {
@@ -840,6 +874,18 @@ pub const AntflyApiHandler = struct {
             if (fetched.document_json) |document_json| alloc.free(document_json);
         } else if (owned_snapshot.version == 0) {
             owned_snapshot.version = read_req.version;
+        }
+        if (!(try self.api_server.transactionReadSnapshotVisible(
+            authenticated_identity,
+            owned_snapshot.table_name,
+            owned_snapshot.key,
+            owned_snapshot.document_json,
+        ))) {
+            if (owned_snapshot.document_json) |document_json| {
+                alloc.free(document_json);
+                owned_snapshot.document_json = null;
+            }
+            owned_snapshot.version = 0;
         }
         if (owned_snapshot.version != read_req.version) {
             var arena_impl = std.heap.ArenaAllocator.init(ctx.allocator);
@@ -902,6 +948,10 @@ pub const AntflyApiHandler = struct {
             var resp = forwarded;
             return respond(ctx, &resp);
         }
+        if (!(try self.api_server.transactionSessionAccessible(txn_id, authenticated_identity))) {
+            _ = ctx.status(404);
+            return ctx.text("not found");
+        }
         const alloc = self.api_server.alloc;
         var stage_req = switch (kind) {
             .write => transactions_api.parseStageWriteRequest(alloc, body_data) catch {
@@ -914,6 +964,10 @@ pub const AntflyApiHandler = struct {
             },
         };
         defer stage_req.deinit(alloc);
+        if (!(try self.api_server.transactionRequestAuthorized(authenticated_identity, stage_req))) {
+            _ = ctx.status(403);
+            return ctx.text("forbidden");
+        }
         const session = (self.api_server.txn_sessions.stage(alloc, txn_id, &stage_req) catch |err| switch (err) {
             error.SessionLeaseLost => {
                 _ = ctx.status(409);
@@ -947,6 +1001,10 @@ pub const AntflyApiHandler = struct {
         if (try self.api_server.forwardSessionRequest(txn_id, converted_req.value)) |forwarded| {
             var resp = forwarded;
             return respond(ctx, &resp);
+        }
+        if (!(try self.api_server.transactionSessionAccessible(txn_id, authenticated_identity))) {
+            _ = ctx.status(404);
+            return ctx.text("not found");
         }
         const info = (self.api_server.txn_sessions.createSavepoint(self.api_server.alloc, txn_id) catch |err| switch (err) {
             error.SessionLeaseLost => {
@@ -990,6 +1048,10 @@ pub const AntflyApiHandler = struct {
             var resp = forwarded;
             return respond(ctx, &resp);
         }
+        if (!(try self.api_server.transactionSessionAccessible(txn_id, authenticated_identity))) {
+            _ = ctx.status(404);
+            return ctx.text("not found");
+        }
         const info = (self.api_server.txn_sessions.rollbackToSavepoint(self.api_server.alloc, txn_id, parsed_savepoint_id) catch |err| switch (err) {
             error.SessionLeaseLost => {
                 _ = ctx.status(409);
@@ -1028,6 +1090,10 @@ pub const AntflyApiHandler = struct {
             var resp = forwarded;
             return respond(ctx, &resp);
         }
+        if (!(try self.api_server.transactionSessionAccessible(txn_id, authenticated_identity))) {
+            _ = ctx.status(404);
+            return ctx.text("not found");
+        }
         const alloc = self.api_server.alloc;
         const session = self.api_server.txn_sessions.getInfo(txn_id) orelse {
             _ = ctx.status(404);
@@ -1064,6 +1130,10 @@ pub const AntflyApiHandler = struct {
             return ctx.text("transaction has no staged writes");
         };
         defer commit_req.deinit(alloc);
+        if (!(try self.api_server.transactionRequestAuthorized(authenticated_identity, commit_req))) {
+            _ = ctx.status(403);
+            return ctx.text("forbidden");
+        }
 
         const distributed_tables = try commit_req.distributedTables(alloc);
         defer if (distributed_tables.len > 0) alloc.free(distributed_tables);
@@ -1203,6 +1273,10 @@ pub const AntflyApiHandler = struct {
         if (try self.api_server.forwardSessionRequest(txn_id, converted_req.value)) |forwarded| {
             var resp = forwarded;
             return respond(ctx, &resp);
+        }
+        if (!(try self.api_server.transactionSessionAccessible(txn_id, authenticated_identity))) {
+            _ = ctx.status(404);
+            return ctx.text("not found");
         }
         if (!self.api_server.txn_sessions.remove(self.api_server.alloc, txn_id)) {
             _ = ctx.status(404);

--- a/zig/pkg/antfly/src/api/indexes.zig
+++ b/zig/pkg/antfly/src/api/indexes.zig
@@ -1349,6 +1349,10 @@ fn aggregateIndexStatusIndexed(
         if (!runtime_present) continue;
         aggregate.reported_group_count += 1;
         aggregate.runtime_present = true;
+        // Integrity failures are current index-scoped facts even when the
+        // surrounding runtime snapshot is stale or failed. Capture them before
+        // gating materialization counters on freshness.
+        if (item.load_error != null and aggregate.load_error == null) aggregate.load_error = item.load_error;
         if (statusFreshnessCountsAsFresh(runtime.metadata)) {
             aggregate.fresh_group_count += 1;
             aggregate.runtime_fresh = true;
@@ -1387,7 +1391,6 @@ fn aggregateIndexStatusIndexed(
             continue;
         }
         materialization_count += 1;
-        if (item.load_error != null and aggregate.load_error == null) aggregate.load_error = item.load_error;
         if (publicIndexRepairState(item)) |state| {
             if (aggregate.repair_state == null or repairStateRank(state) > repairStateRank(aggregate.repair_state.?)) {
                 aggregate.repair_state = state;
@@ -1911,6 +1914,47 @@ test "derived coverage aggregation rejects mixed config observations" {
     );
     try std.testing.expect(std.mem.indexOf(u8, missing_status.items, "\"observation_incomplete_reasons\":[\"runtime_unavailable\",\"missing_group\"]") != null);
     try std.testing.expect(std.mem.indexOf(u8, missing_status.items, "\"pending\":null") != null);
+}
+
+test "rebuild quarantine remains an explicit failed public index status" {
+    const item = db_mod.types.DBIndexStats{
+        .name = "search_idx",
+        .kind = .full_text,
+        .load_error = "InvalidRebuildState",
+    };
+    const runtimes = [_]runtime_status.LocalTableRuntimeStatus{.{
+        .group_id = 1,
+        .metadata = .{ .source = .rebuild_state_quarantine, .freshness = .failed },
+        .stats = .{ .index_count = 1, .indexes = @constCast((&[_]db_mod.types.DBIndexStats{item})[0..]) },
+    }};
+    const aggregate = aggregateIndexStatus(&runtimes, "search_idx", &.{1}, 0) orelse return error.TestUnexpectedResult;
+    try std.testing.expectEqualStrings("InvalidRebuildState", aggregate.load_error.?);
+
+    var encoded = std.ArrayListUnmanaged(u8).empty;
+    defer encoded.deinit(std.testing.allocator);
+    try appendSingleIndexRuntimeStatus(
+        std.testing.allocator,
+        &encoded,
+        .full_text,
+        item,
+        0,
+        .strict,
+        false,
+        0,
+        0,
+        null,
+        .{},
+        null,
+        null,
+        null,
+        .{},
+        runtimes[0].metadata,
+        true,
+    );
+    try std.testing.expect(std.mem.indexOf(u8, encoded.items, "\"backfill_state\":\"failed\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, encoded.items, "\"error\":\"load failed: InvalidRebuildState\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, encoded.items, "\"runtime_source\":\"rebuild_state_quarantine\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, encoded.items, "\"runtime_freshness\":\"failed\"") != null);
 }
 
 test "index status exposes compact repair state without internal diagnostics" {
@@ -2626,7 +2670,7 @@ fn appendSingleIndexRuntimeStatus(
     // operator-visible error. Once a repair intent exists, the compact repair
     // state is authoritative; exposing the quarantined root's raw load error
     // at the same time would incorrectly tell clients to drop/recreate.
-    const raw_load_error: ?[]const u8 = if (embeddings_materialization_current and @hasField(@TypeOf(item), "load_error")) item.load_error else null;
+    const raw_load_error: ?[]const u8 = if (@hasField(@TypeOf(item), "load_error")) item.load_error else null;
     const load_error: ?[]const u8 = if (repair_state == null) raw_load_error else null;
     if (load_error != null) {
         backfill_active = false;

--- a/zig/pkg/antfly/src/api/multi_node_e2e.zig
+++ b/zig/pkg/antfly/src/api/multi_node_e2e.zig
@@ -561,6 +561,17 @@ fn PublicApiRouter(comptime N: usize) type {
     };
 }
 
+fn publicApiTestListenerConfig() std_http_listener.StdHttpListenerConfig {
+    // Public API handlers synchronously fan out to other data nodes. Exercise
+    // them with the same concurrent-listener contract used by production so a
+    // forwarded request can re-enter an ingress node without serial-listener
+    // deadlock. Keep the test bound lower than production's 64 threads.
+    return .{
+        .serve_in_connection_threads = true,
+        .max_connection_threads = 16,
+    };
+}
+
 fn startPublicApiServers(
     comptime N: usize,
     cluster: *metadata_sim.MetadataHttpClusterSimulation,
@@ -673,6 +684,14 @@ fn startPublicApiServersWithSharedSessionStorePath(
     write_sources: *[N]api_table_writes.HostedProvisionedTableWriteSource,
     api_base_uris: *[N][]const u8,
 ) !void {
+    var initialized_servers: usize = 0;
+    var initialized_listeners: usize = 0;
+    var initialized_base_uris: usize = 0;
+    errdefer {
+        for (api_base_uris[0..initialized_base_uris]) |uri| std.testing.allocator.free(uri);
+        for (listeners[0..initialized_listeners]) |*listener| listener.deinit();
+        for (servers[0..initialized_servers]) |*server| server.deinit();
+    }
     for (0..N) |i| {
         status_sources[i] = .{ .node = cluster.node(i) };
         catalog_sources[i] = .{ .node = cluster.node(i) };
@@ -703,16 +722,26 @@ fn startPublicApiServersWithSharedSessionStorePath(
                 .session_router = routers[i].iface(),
                 .session_executor = forward_executor.executor(),
                 .session_store_path = session_store_path,
+                .session_store_scope = .cluster_shared,
                 .session_owner_lease_ttl_ns = std.time.ns_per_ms,
             },
             status_sources[i].iface(),
             read_sources[i].source(),
             write_sources[i].source(),
         );
-        listeners[i] = std_http_listener.StdHttpListener.init(std.testing.allocator, .{}, servers[i].executor());
+        initialized_servers += 1;
+        listeners[i] = std_http_listener.StdHttpListener.init(
+            std.testing.allocator,
+            publicApiTestListenerConfig(),
+            servers[i].executor(),
+        );
+        initialized_listeners += 1;
         try listeners[i].start();
     }
-    for (0..N) |i| api_base_uris[i] = try listeners[i].baseUri(std.testing.allocator);
+    for (0..N) |i| {
+        api_base_uris[i] = try listeners[i].baseUri(std.testing.allocator);
+        initialized_base_uris += 1;
+    }
 }
 
 fn startPublicApiServersWithOptionalSessions(
@@ -731,6 +760,14 @@ fn startPublicApiServersWithOptionalSessions(
     write_sources: *[N]api_table_writes.HostedProvisionedTableWriteSource,
     api_base_uris: *[N][]const u8,
 ) !void {
+    var initialized_servers: usize = 0;
+    var initialized_listeners: usize = 0;
+    var initialized_base_uris: usize = 0;
+    errdefer {
+        for (api_base_uris[0..initialized_base_uris]) |uri| std.testing.allocator.free(uri);
+        for (listeners[0..initialized_listeners]) |*listener| listener.deinit();
+        for (servers[0..initialized_servers]) |*server| server.deinit();
+    }
     for (0..N) |i| {
         status_sources[i] = .{ .node = cluster.node(i) };
         catalog_sources[i] = .{ .node = cluster.node(i) };
@@ -763,10 +800,19 @@ fn startPublicApiServersWithOptionalSessions(
             read_sources[i].source(),
             write_sources[i].source(),
         );
-        listeners[i] = std_http_listener.StdHttpListener.init(std.testing.allocator, .{}, servers[i].executor());
+        initialized_servers += 1;
+        listeners[i] = std_http_listener.StdHttpListener.init(
+            std.testing.allocator,
+            publicApiTestListenerConfig(),
+            servers[i].executor(),
+        );
+        initialized_listeners += 1;
         try listeners[i].start();
     }
-    for (0..N) |i| api_base_uris[i] = try listeners[i].baseUri(std.testing.allocator);
+    for (0..N) |i| {
+        api_base_uris[i] = try listeners[i].baseUri(std.testing.allocator);
+        initialized_base_uris += 1;
+    }
 }
 
 const GraphChurnMode = enum {
@@ -1411,6 +1457,7 @@ test "public api multi-node e2e routes CRUD from a non-host node" {
         &write_sources,
         &api_base_uris,
     );
+    defer for (&servers) |*server| server.deinit();
     defer for (&listeners) |*listener| listener.deinit();
     defer for (api_base_uris) |uri| std.testing.allocator.free(uri);
 
@@ -1656,6 +1703,7 @@ test "public api multi-node e2e routes transaction commit from a non-host node" 
         &write_sources,
         &api_base_uris,
     );
+    defer for (&servers) |*server| server.deinit();
     defer for (&listeners) |*listener| listener.deinit();
     defer for (api_base_uris) |uri| std.testing.allocator.free(uri);
 
@@ -2103,6 +2151,7 @@ test "public api multi-node e2e supports long-lived transaction sessions from a 
         &write_sources,
         &api_base_uris,
     );
+    defer for (&servers) |*server| server.deinit();
     defer for (&listeners) |*listener| listener.deinit();
     defer for (api_base_uris) |uri| std.testing.allocator.free(uri);
 
@@ -2172,7 +2221,7 @@ test "public api multi-node e2e supports long-lived transaction sessions from a 
     try std.testing.expectEqual(@as(u16, 200), read_stage.status);
     var parsed_read_stage = try parsePageJson(transactions_api.StageReadResponse, read_stage.body);
     defer parsed_read_stage.deinit();
-    try std.testing.expectEqualStrings("7", parsed_read_stage.value.snapshot.version);
+    try std.testing.expectEqualStrings(lookup.version.?, parsed_read_stage.value.snapshot.version);
     try std.testing.expectEqualStrings("alpha", parsed_read_stage.value.snapshot.document.object.get("title").?.string);
 
     const external_update_body = try test_contract_helpers.normalizeBatchRequest(std.heap.page_allocator,
@@ -2187,7 +2236,7 @@ test "public api multi-node e2e supports long-lived transaction sessions from a 
     try std.testing.expectEqual(@as(u16, 200), repeated_read_stage.status);
     var parsed_repeated_read_stage = try parsePageJson(transactions_api.StageReadResponse, repeated_read_stage.body);
     defer parsed_repeated_read_stage.deinit();
-    try std.testing.expectEqualStrings("7", parsed_repeated_read_stage.value.snapshot.version);
+    try std.testing.expectEqualStrings(lookup.version.?, parsed_repeated_read_stage.value.snapshot.version);
     try std.testing.expectEqualStrings("alpha", parsed_repeated_read_stage.value.snapshot.document.object.get("title").?.string);
 
     const write_stage_body = try test_contract_helpers.encodeTransactionStageWriteRequest(
@@ -2209,8 +2258,8 @@ test "public api multi-node e2e supports long-lived transaction sessions from a 
     try std.testing.expectEqual(@as(u64, @intCast(begin_index + 1)), parsed_session_info.value.owner_node_id);
     try std.testing.expectEqual(@as(usize, 1), parsed_session_info.value.staged_write_count);
     try std.testing.expectEqual(@as(usize, 1), parsed_session_info.value.read_snapshot_count);
-    try std.testing.expect(parsed_session_info.value.lease_expires_at > 0);
-    try std.testing.expectEqualStrings("held", parsed_session_info.value.lease_state);
+    try std.testing.expectEqual(@as(u64, 0), parsed_session_info.value.lease_expires_at);
+    try std.testing.expectEqualStrings("none", parsed_session_info.value.lease_state);
     try std.testing.expectEqual(@as(usize, 1), parsed_session_info.value.tables.len);
     try std.testing.expectEqual(@as(usize, 1), parsed_session_info.value.read_snapshots.len);
     try std.testing.expectEqualStrings("docs", parsed_session_info.value.read_snapshots[0].table);
@@ -2224,11 +2273,11 @@ test "public api multi-node e2e supports long-lived transaction sessions from a 
     var parsed_owner_session_list = try parsePageJson(transactions_api.SessionListResponse, owner_session_list.body);
     defer parsed_owner_session_list.deinit();
     try std.testing.expectEqual(@as(usize, 1), parsed_owner_session_list.value.session_count);
-    try std.testing.expectEqual(@as(usize, 1), parsed_owner_session_list.value.lease_held_count);
+    try std.testing.expectEqual(@as(usize, 0), parsed_owner_session_list.value.lease_held_count);
     try std.testing.expectEqual(@as(usize, 0), parsed_owner_session_list.value.lease_expired_count);
     try std.testing.expectEqual(@as(usize, 1), parsed_owner_session_list.value.sessions.len);
-    try std.testing.expect(parsed_owner_session_list.value.sessions[0].lease_expires_at > 0);
-    try std.testing.expectEqualStrings("held", parsed_owner_session_list.value.sessions[0].lease_state);
+    try std.testing.expectEqual(@as(u64, 0), parsed_owner_session_list.value.sessions[0].lease_expires_at);
+    try std.testing.expectEqualStrings("none", parsed_owner_session_list.value.sessions[0].lease_state);
 
     var savepoint = try client.fetchTransactionSessionSavepoint(followup_base, txn_id_hex);
     defer savepoint.deinit(std.heap.page_allocator);
@@ -2261,13 +2310,17 @@ test "public api multi-node e2e supports long-lived transaction sessions from a 
 
     var committed = try client.fetchTransactionSessionCommit(followup_base, txn_id_hex, "");
     defer committed.deinit(std.heap.page_allocator);
-    try std.testing.expectEqual(@as(u16, 200), committed.status);
+    try std.testing.expectEqual(@as(u16, 409), committed.status);
+    var parsed_commit = try parsePageJson(transactions_api.SessionCommitResponse, committed.body);
+    defer parsed_commit.deinit();
+    try std.testing.expectEqualStrings("aborted", parsed_commit.value.status);
+    try std.testing.expectEqualStrings("version_conflict", parsed_commit.value.conflict.?.kind);
 
     var updated = try client.fetchLookup(followup_base, "docs", "doc:a", null);
     defer updated.deinit(std.heap.page_allocator);
-    var parsed_updated = try parseJsonBody(LookupTitle, updated.body);
+    var parsed_updated = try parseJsonBodyIgnoreUnknown(LookupTitle, updated.body);
     defer parsed_updated.deinit();
-    try std.testing.expectEqualStrings("alpha session committed", parsed_updated.value.title);
+    try std.testing.expectEqualStrings("alpha external", parsed_updated.value.title);
 
     var latest_lookup = try client.fetchLookup(followup_base, "docs", "doc:a", null);
     defer latest_lookup.deinit(std.heap.page_allocator);
@@ -2315,9 +2368,9 @@ test "public api multi-node e2e supports long-lived transaction sessions from a 
     try std.testing.expectEqualStrings("aborted", parsed_stale_commit.value.status);
     const stale_conflict = parsed_stale_commit.value.conflict.?;
     try std.testing.expectEqualStrings("version_conflict", stale_conflict.kind);
-    const stale_participant = stale_conflict.participant.?;
-    try std.testing.expectEqualStrings("prepare", stale_participant.phase.?);
-    try std.testing.expectEqual(@as(u64, group_id), stale_participant.group_id.?);
+    // The coordinator catches this stale read before participant prepare, so
+    // participant diagnostics are intentionally absent.
+    try std.testing.expect(stale_conflict.participant == null);
     try std.testing.expectEqual(try std.fmt.parseInt(u64, latest_lookup.version.?, 10), stale_conflict.expected_version.?);
     try std.testing.expect(stale_conflict.current_version.? > stale_conflict.expected_version.?);
 
@@ -2432,6 +2485,7 @@ test "public api multi-node e2e supports cross-table transaction sessions" {
         &write_sources,
         &api_base_uris,
     );
+    defer for (&servers) |*server| server.deinit();
     defer for (&listeners) |*listener| listener.deinit();
     defer for (api_base_uris) |uri| std.testing.allocator.free(uri);
 
@@ -2575,7 +2629,7 @@ test "public api multi-node e2e supports cross-table transaction sessions" {
 
     var updated_user = try client.fetchLookup(followup_base, "users", "user:1", null);
     defer updated_user.deinit(std.heap.page_allocator);
-    var parsed_updated_user = try parseJsonBody(UserName, updated_user.body);
+    var parsed_updated_user = try parseJsonBodyIgnoreUnknown(UserName, updated_user.body);
     defer parsed_updated_user.deinit();
     try std.testing.expectEqualStrings("Alice Session", parsed_updated_user.value.name);
     try std.testing.expectError(error.UnexpectedHttpStatus, client.fetchLookup(followup_base, "orders", "order:old", null));
@@ -2691,6 +2745,7 @@ test "public api multi-node e2e reloads durable cross-table transaction sessions
         &write_sources,
         &api_base_uris,
     );
+    defer for (&servers) |*server| server.deinit();
     defer for (&listeners) |*listener| listener.deinit();
     defer for (api_base_uris) |uri| std.testing.allocator.free(uri);
 
@@ -2812,6 +2867,7 @@ test "public api multi-node e2e reloads durable cross-table transaction sessions
 
     listeners[begin_index].deinit();
     std.testing.allocator.free(api_base_uris[begin_index]);
+    servers[begin_index].deinit();
     servers[begin_index] = api_http_server.ApiHttpServer.init(
         std.testing.allocator,
         .{
@@ -2825,7 +2881,7 @@ test "public api multi-node e2e reloads durable cross-table transaction sessions
     );
     listeners[begin_index] = std_http_listener.StdHttpListener.init(
         std.testing.allocator,
-        .{},
+        publicApiTestListenerConfig(),
         servers[begin_index].executor(),
     );
     try listeners[begin_index].start();
@@ -2847,7 +2903,7 @@ test "public api multi-node e2e reloads durable cross-table transaction sessions
 
     var updated_user = try client.fetchLookup(followup_base, "users", "user:1", null);
     defer updated_user.deinit(std.heap.page_allocator);
-    var parsed_updated_user = try parseJsonBody(UserName, updated_user.body);
+    var parsed_updated_user = try parseJsonBodyIgnoreUnknown(UserName, updated_user.body);
     defer parsed_updated_user.deinit();
     try std.testing.expectEqualStrings("Alice Durable Session", parsed_updated_user.value.name);
     try std.testing.expectError(error.UnexpectedHttpStatus, client.fetchLookup(followup_base, "orders", "order:old", null));
@@ -3064,8 +3120,33 @@ test "public api multi-node e2e adopts durable cross-table transaction sessions 
     try std.testing.expectEqual(@as(u16, 200), delete_order.status);
 
     listeners[begin_index].deinit();
+    // Leave a valid stopped value for the common deferred cleanup.
+    listeners[begin_index] = std_http_listener.StdHttpListener.init(
+        std.testing.allocator,
+        publicApiTestListenerConfig(),
+        servers[begin_index].executor(),
+    );
     std.testing.allocator.free(api_base_uris[begin_index]);
     api_base_uris[begin_index] = try std.testing.allocator.dupe(u8, "http://127.0.0.1:1");
+    // Advance the lease clock explicitly instead of racing a deliberate 1 ms
+    // lease against wall-clock scheduling on loaded CI hosts.
+    const pre_adoption_status = (try servers[followup_index].txn_sessions.getStatus(
+        std.testing.allocator,
+        try distributed_txn.parseTxnIdHex(txn_id_hex),
+    )) orelse return error.TestExpectedEqual;
+    try std.testing.expect(try servers[followup_index].txn_sessions.adoptIfLeaseExpired(
+        std.testing.allocator,
+        try distributed_txn.parseTxnIdHex(txn_id_hex),
+        @intCast(followup_index + 1),
+        pre_adoption_status.lease_expires_at +| 1,
+    ));
+    try std.testing.expectEqual(
+        @as(?u64, @intCast(followup_index + 1)),
+        try servers[followup_index].txn_sessions.getOwnerNodeId(
+            std.testing.allocator,
+            try distributed_txn.parseTxnIdHex(txn_id_hex),
+        ),
+    );
 
     var adopted_info = try client.fetchTransactionSessionInfo(followup_base, txn_id_hex);
     defer adopted_info.deinit(std.heap.page_allocator);
@@ -3077,7 +3158,12 @@ test "public api multi-node e2e adopts durable cross-table transaction sessions 
     try std.testing.expectEqual(@as(usize, 1), parsed_adopted_info.value.staged_write_count);
     try std.testing.expectEqual(@as(usize, 1), parsed_adopted_info.value.staged_delete_count);
     try std.testing.expect(parsed_adopted_info.value.lease_expires_at > 0);
-    try std.testing.expectEqualStrings("held", parsed_adopted_info.value.lease_state);
+    // This fixture deliberately uses a 1 ms lease to trigger adoption without
+    // sleeping. It may expire again before the status response is encoded.
+    try std.testing.expect(
+        std.mem.eql(u8, parsed_adopted_info.value.lease_state, "held") or
+            std.mem.eql(u8, parsed_adopted_info.value.lease_state, "expired"),
+    );
 
     var committed = try client.fetchTransactionSessionCommit(followup_base, txn_id_hex, "");
     defer committed.deinit(std.heap.page_allocator);
@@ -3089,7 +3175,7 @@ test "public api multi-node e2e adopts durable cross-table transaction sessions 
 
     var updated_user = try client.fetchLookup(followup_base, "users", "user:1", null);
     defer updated_user.deinit(std.heap.page_allocator);
-    var parsed_updated_user = try parseJsonBody(UserName, updated_user.body);
+    var parsed_updated_user = try parseJsonBodyIgnoreUnknown(UserName, updated_user.body);
     defer parsed_updated_user.deinit();
     try std.testing.expectEqualStrings("Alice Adopted Session", parsed_updated_user.value.name);
     try std.testing.expectError(error.UnexpectedHttpStatus, client.fetchLookup(followup_base, "orders", "order:old", null));
@@ -3205,6 +3291,7 @@ test "public api multi-node e2e reloads durable transaction sessions after coord
         &write_sources,
         &api_base_uris,
     );
+    defer for (&servers) |*server| server.deinit();
     defer for (&listeners) |*listener| listener.deinit();
     defer for (api_base_uris) |uri| std.testing.allocator.free(uri);
 
@@ -3287,6 +3374,7 @@ test "public api multi-node e2e reloads durable transaction sessions after coord
 
     listeners[begin_index].deinit();
     std.testing.allocator.free(api_base_uris[begin_index]);
+    servers[begin_index].deinit();
     servers[begin_index] = api_http_server.ApiHttpServer.init(
         std.testing.allocator,
         .{
@@ -3300,7 +3388,7 @@ test "public api multi-node e2e reloads durable transaction sessions after coord
     );
     listeners[begin_index] = std_http_listener.StdHttpListener.init(
         std.testing.allocator,
-        .{},
+        publicApiTestListenerConfig(),
         servers[begin_index].executor(),
     );
     try listeners[begin_index].start();
@@ -3320,7 +3408,7 @@ test "public api multi-node e2e reloads durable transaction sessions after coord
 
     var updated = try client.fetchLookup(followup_base, "docs", "doc:a", null);
     defer updated.deinit(std.heap.page_allocator);
-    var parsed_updated = try parseJsonBody(LookupTitle, updated.body);
+    var parsed_updated = try parseJsonBodyIgnoreUnknown(LookupTitle, updated.body);
     defer parsed_updated.deinit();
     try std.testing.expectEqualStrings("alpha durable session committed", parsed_updated.value.title);
 }
@@ -3507,7 +3595,10 @@ test "public api multi-node e2e adopts durable transaction sessions after coordi
     defer parsed_adopted_info.deinit();
     try std.testing.expectEqual(@as(u64, @intCast(followup_index + 1)), parsed_adopted_info.value.owner_node_id);
     try std.testing.expect(parsed_adopted_info.value.lease_expires_at > 0);
-    try std.testing.expectEqualStrings("held", parsed_adopted_info.value.lease_state);
+    try std.testing.expect(
+        std.mem.eql(u8, parsed_adopted_info.value.lease_state, "held") or
+            std.mem.eql(u8, parsed_adopted_info.value.lease_state, "expired"),
+    );
 
     var committed = try client.fetchTransactionSessionCommit(followup_base, txn_id_hex, "");
     defer committed.deinit(std.heap.page_allocator);

--- a/zig/pkg/antfly/src/api/protocol_adapters.zig
+++ b/zig/pkg/antfly/src/api/protocol_adapters.zig
@@ -47,7 +47,17 @@ const McpToolSpec = struct {
     kind: McpToolKind,
     name: []const u8,
     description: []const u8,
+    permission: McpToolPermission,
+    table_argument: ?[]const u8 = null,
+    wildcard_table: bool = false,
     fields: []const McpToolFieldSpec = &.{},
+};
+
+const McpToolPermission = enum {
+    none,
+    read,
+    write,
+    admin,
 };
 
 const McpToolFieldType = enum {
@@ -89,6 +99,8 @@ const mcp_tool_specs = [_]McpToolSpec{
         .kind = .create_table,
         .name = "create_table",
         .description = "Create an Antfly table",
+        .permission = .admin,
+        .table_argument = "tableName",
         .fields = &.{
             .{ .name = "tableName", .schema_type = .string, .required = true },
             // The runtime default is topology-aware: one for standalone and
@@ -102,19 +114,25 @@ const mcp_tool_specs = [_]McpToolSpec{
         .kind = .drop_table,
         .name = "drop_table",
         .description = "Drop an Antfly table",
+        .permission = .admin,
+        .table_argument = "tableName",
         .fields = &.{.{ .name = "tableName", .schema_type = .string, .required = true }},
     },
-    .{ .kind = .list_tables, .name = "list_tables", .description = "List Antfly tables" },
+    .{ .kind = .list_tables, .name = "list_tables", .description = "List Antfly tables", .permission = .read, .wildcard_table = true },
     .{
         .kind = .describe_table,
         .name = "describe_table",
         .description = "Describe an Antfly table, including schema, indexes, ranges, and storage status when available",
+        .permission = .read,
+        .table_argument = "tableName",
         .fields = &.{.{ .name = "tableName", .schema_type = .string, .required = true }},
     },
     .{
         .kind = .create_index,
         .name = "create_index",
         .description = "Create an Antfly index",
+        .permission = .admin,
+        .table_argument = "tableName",
         .fields = &.{
             .{ .name = "tableName", .schema_type = .string, .required = true },
             .{ .name = "indexName", .schema_type = .string, .required = true },
@@ -129,6 +147,8 @@ const mcp_tool_specs = [_]McpToolSpec{
         .kind = .drop_index,
         .name = "drop_index",
         .description = "Drop an Antfly index",
+        .permission = .admin,
+        .table_argument = "tableName",
         .fields = &.{
             .{ .name = "tableName", .schema_type = .string, .required = true },
             .{ .name = "indexName", .schema_type = .string, .required = true },
@@ -138,18 +158,24 @@ const mcp_tool_specs = [_]McpToolSpec{
         .kind = .list_indexes,
         .name = "list_indexes",
         .description = "List indexes for an Antfly table",
+        .permission = .read,
+        .table_argument = "tableName",
         .fields = &.{.{ .name = "tableName", .schema_type = .string, .required = true }},
     },
     .{
         .kind = .describe_indexes,
         .name = "describe_indexes",
         .description = "Describe indexes for an Antfly table",
+        .permission = .read,
+        .table_argument = "tableName",
         .fields = &.{.{ .name = "tableName", .schema_type = .string, .required = true }},
     },
     .{
         .kind = .get_document,
         .name = "get_document",
         .description = "Get an Antfly document by key",
+        .permission = .read,
+        .table_argument = "tableName",
         .fields = &.{
             .{ .name = "tableName", .schema_type = .string, .required = true },
             .{ .name = "key", .schema_type = .string, .required = true },
@@ -160,6 +186,8 @@ const mcp_tool_specs = [_]McpToolSpec{
         .kind = .sample_documents,
         .name = "sample_documents",
         .description = "Return a bounded NDJSON sample from a table using the table lookup/scan route",
+        .permission = .read,
+        .table_argument = "tableName",
         .fields = &.{
             .{ .name = "tableName", .schema_type = .string, .required = true },
             .{ .name = "limit", .schema_type = .integer, .default_json = "5" },
@@ -173,6 +201,8 @@ const mcp_tool_specs = [_]McpToolSpec{
         .kind = .query,
         .name = "query",
         .description = "Run an Antfly table query",
+        .permission = .read,
+        .table_argument = "tableName",
         .fields = &.{
             .{ .name = "tableName", .schema_type = .string, .required = true },
             .{ .name = "queryRequest", .schema_type = .object, .schema_json = query_request_schema_json },
@@ -191,16 +221,20 @@ const mcp_tool_specs = [_]McpToolSpec{
         .kind = .describe_query_request,
         .name = "describe_query_request",
         .description = "Return compact guidance for the raw Antfly QueryRequest accepted by query.queryRequest",
+        .permission = .none,
     },
     .{
         .kind = .describe_mcp_capabilities,
         .name = "describe_mcp_capabilities",
         .description = "Describe Antfly MCP capabilities, deterministic tools, and A2A query-builder handoff guidance",
+        .permission = .none,
     },
     .{
         .kind = .backup,
         .name = "backup",
         .description = "Backup an Antfly table",
+        .permission = .admin,
+        .table_argument = "tableName",
         .fields = &.{
             .{ .name = "tableName", .schema_type = .string, .required = true },
             .{ .name = "backupId", .schema_type = .string, .required = true },
@@ -211,6 +245,8 @@ const mcp_tool_specs = [_]McpToolSpec{
         .kind = .restore,
         .name = "restore",
         .description = "Restore an Antfly table",
+        .permission = .admin,
+        .table_argument = "tableName",
         .fields = &.{
             .{ .name = "tableName", .schema_type = .string, .required = true },
             .{ .name = "backupId", .schema_type = .string, .required = true },
@@ -221,6 +257,8 @@ const mcp_tool_specs = [_]McpToolSpec{
         .kind = .batch,
         .name = "batch",
         .description = "Insert and delete documents in an Antfly table",
+        .permission = .write,
+        .table_argument = "tableName",
         .fields = &.{
             .{ .name = "tableName", .schema_type = .string, .required = true },
             .{ .name = "writes", .schema_type = .object },
@@ -289,7 +327,8 @@ fn handleMcpRequestFiltered(server_ptr: anytype, req: http_common.HttpRequest, a
         server: Server,
         authorization: ?[]const u8,
         trusted_principal: ?[]const u8,
-        kind: McpToolKind,
+        permissions: ?[]const usermgr.Permission,
+        spec: McpToolSpec,
 
         fn handler(ctx: *@This()) mcp.ToolHandler {
             return .{ .ptr = ctx, .call_fn = call };
@@ -297,7 +336,10 @@ fn handleMcpRequestFiltered(server_ptr: anytype, req: http_common.HttpRequest, a
 
         fn call(ptr: *anyopaque, alloc: std.mem.Allocator, args: std.json.Value) !mcp.CallToolResult {
             const ctx: *@This() = @ptrCast(@alignCast(ptr));
-            return switch (ctx.kind) {
+            if (!mcpToolInvocationAllowed(ctx.spec, args, ctx.permissions)) {
+                return mcpError(alloc, "permission denied");
+            }
+            return switch (ctx.spec.kind) {
                 .create_table => try ctx.createTable(alloc, args),
                 .drop_table => try ctx.tableRoute(alloc, args, .DELETE, "tableName", null, ""),
                 .list_tables => try ctx.simpleRoute(alloc, .GET, routes.Routes.tables, ""),
@@ -507,6 +549,7 @@ fn handleMcpRequestFiltered(server_ptr: anytype, req: http_common.HttpRequest, a
         server: Server,
         authorization: ?[]const u8,
         trusted_principal: ?[]const u8,
+        permissions: ?[]const usermgr.Permission,
         installed: *const extension_domain.InstalledExtension,
         tool: *const ExtensionMcpTool,
 
@@ -516,6 +559,11 @@ fn handleMcpRequestFiltered(server_ptr: anytype, req: http_common.HttpRequest, a
 
         fn call(ptr: *anyopaque, alloc: std.mem.Allocator, args: std.json.Value) !mcp.CallToolResult {
             const ctx: *@This() = @ptrCast(@alignCast(ptr));
+            if (ctx.permissions) |permissions| {
+                if (!extensionMcpToolAllowedForPermissions(ctx.installed.*, ctx.tool.*, permissions)) {
+                    return mcpError(alloc, "permission denied");
+                }
+            }
             return try callExtensionMcpTool(alloc, ctx.server, ctx.authorization, ctx.trusted_principal, ctx.installed, ctx.tool.*, args);
         }
     };
@@ -526,7 +574,8 @@ fn handleMcpRequestFiltered(server_ptr: anytype, req: http_common.HttpRequest, a
             .server = server_ptr,
             .authorization = req.authorization,
             .trusted_principal = req.header(trusted_principal_header),
-            .kind = spec.kind,
+            .permissions = if (authenticated_identity) |identity| identity.permissions else null,
+            .spec = spec,
         };
     }
 
@@ -563,6 +612,7 @@ fn handleMcpRequestFiltered(server_ptr: anytype, req: http_common.HttpRequest, a
             .server = server_ptr,
             .authorization = req.authorization,
             .trusted_principal = req.header(trusted_principal_header),
+            .permissions = if (authenticated_identity) |identity| identity.permissions else null,
             .installed = installed,
             .tool = &extension_tools.items[i],
         };
@@ -585,7 +635,7 @@ fn handleMcpRequestFiltered(server_ptr: anytype, req: http_common.HttpRequest, a
     defer protocol_server.deinit(server_ptr.alloc);
     if (extension_name_filter == null) {
         for (&contexts, mcp_tool_specs, 0..) |*ctx, spec, i| {
-            if (!mcpToolVisibleForIdentity(spec.kind, authenticated_identity)) continue;
+            if (!mcpToolVisibleForIdentity(spec, authenticated_identity)) continue;
             try protocol_server.addTool(server_ptr.alloc, .{
                 .name = spec.name,
                 .description = spec.description,
@@ -630,31 +680,69 @@ fn handleMcpRequestFiltered(server_ptr: anytype, req: http_common.HttpRequest, a
     return try mcpBodyResponseWithStatus(server_ptr.alloc, transport);
 }
 
-fn mcpToolVisibleForIdentity(kind: McpToolKind, authenticated_identity: anytype) bool {
+fn mcpToolVisibleForIdentity(spec: McpToolSpec, authenticated_identity: anytype) bool {
     const identity = authenticated_identity orelse return true;
-    return switch (kind) {
-        .describe_query_request, .describe_mcp_capabilities => true,
-        .list_tables => identityHasPermission(identity.permissions, .table, "*", .read),
-        .query, .describe_table, .describe_indexes, .get_document, .sample_documents, .list_indexes => identityHasAnyPermission(identity.permissions, .table, .read),
-        .batch => identityHasAnyPermission(identity.permissions, .table, .write),
-        .create_table, .drop_table, .create_index, .drop_index, .backup, .restore => identityHasAnyPermission(identity.permissions, .table, .admin),
+    const required = permissionTypeForMcpTool(spec.permission) orelse return true;
+    if (spec.wildcard_table) {
+        return identityHasPermission(identity.permissions, .table, "*", required);
+    }
+    return identityHasAnyPermission(identity.permissions, .table, required);
+}
+
+/// Discovery filtering is useful UX, but it is not an authorization boundary:
+/// a client can retain an old tool schema or hand-craft tools/call. Enforce the
+/// effective table permission again immediately before dispatch so denied MCP
+/// calls cannot reach an extension, router, or metadata mutation path.
+fn mcpToolInvocationAllowed(
+    spec: McpToolSpec,
+    args: std.json.Value,
+    permissions: ?[]const usermgr.Permission,
+) bool {
+    const effective_permissions = permissions orelse return true;
+    const required = permissionTypeForMcpTool(spec.permission) orelse return true;
+    if (spec.wildcard_table) {
+        return identityHasPermission(effective_permissions, .table, "*", required);
+    }
+    const table_argument = spec.table_argument orelse return false;
+    // Malformed or missing resource identity must fail closed here. The tool
+    // handler will still return its normal validation error to callers that
+    // are permitted to invoke it, but an unscoped call must never cross the
+    // authorization boundary.
+    const table_name = jsonStringArg(args, table_argument) orelse return false;
+    return identityHasPermission(effective_permissions, .table, table_name, required);
+}
+
+fn permissionTypeForMcpTool(permission: McpToolPermission) ?usermgr.PermissionType {
+    return switch (permission) {
+        .none => null,
+        .read => .read,
+        .write => .write,
+        .admin => .admin,
     };
 }
 
 fn extensionMcpToolVisibleForIdentity(installed: *const extension_domain.InstalledExtension, tool: *const ExtensionMcpTool, authenticated_identity: anytype) bool {
     const identity = authenticated_identity orelse return true;
+    return extensionMcpToolAllowedForPermissions(installed.*, tool.*, identity.permissions);
+}
+
+fn extensionMcpToolAllowedForPermissions(
+    installed: extension_domain.InstalledExtension,
+    tool: ExtensionMcpTool,
+    permissions: []const usermgr.Permission,
+) bool {
     if (tool.required_capabilities.len == 0) {
-        return extensionScopeVisibleForIdentity(installed.*, tool.member.*, identity.permissions);
+        return extensionScopeVisibleForIdentity(installed, tool.member.*, permissions);
     }
 
     var checked_table_permission = false;
     for (tool.required_capabilities) |capability| {
         const permission_type = permissionTypeForExtensionCapability(capability.name) orelse continue;
         checked_table_permission = true;
-        const table = tableResourceForExtensionCapability(installed.*, tool.member.*, capability);
-        if (!identityHasPermission(identity.permissions, .table, table, permission_type)) return false;
+        const table = tableResourceForExtensionCapability(installed, tool.member.*, capability);
+        if (!identityHasPermission(permissions, .table, table, permission_type)) return false;
     }
-    return checked_table_permission or extensionScopeVisibleForIdentity(installed.*, tool.member.*, identity.permissions);
+    return checked_table_permission or extensionScopeVisibleForIdentity(installed, tool.member.*, permissions);
 }
 
 fn extensionScopeVisibleForIdentity(installed: extension_domain.InstalledExtension, member: extension_domain.ExtensionMember, permissions: []const usermgr.Permission) bool {

--- a/zig/pkg/antfly/src/api/runtime_status.zig
+++ b/zig/pkg/antfly/src/api/runtime_status.zig
@@ -25,6 +25,7 @@ pub const RuntimeStatusSource = enum {
     background_refresh,
     startup_catch_up,
     remote_store,
+    rebuild_state_quarantine,
 };
 
 pub const RuntimeStatusFreshness = enum {
@@ -102,7 +103,7 @@ pub const LsmStorageStats = struct {
 
 pub fn statusHasRuntimeFacts(status: LocalTableRuntimeStatus) bool {
     return switch (status.metadata.source) {
-        .live_writer_publish, .background_refresh, .startup_catch_up, .remote_store => true,
+        .live_writer_publish, .background_refresh, .startup_catch_up, .remote_store, .rebuild_state_quarantine => true,
         .cached_snapshot, .unknown, .synthetic_config => statusStatsHaveRuntimeFacts(status.stats),
     };
 }

--- a/zig/pkg/antfly/src/api/table_reads.zig
+++ b/zig/pkg/antfly/src/api/table_reads.zig
@@ -16678,6 +16678,14 @@ test "provisioned local runtime statuses reconcile empty managed embeddings inde
     defer alloc.free(group_path);
     var db = try db_mod.DB.open(alloc, group_path, .{});
     defer db.close();
+    const indexes_json = "{\"semantic_idx\":{\"type\":\"embeddings\",\"dimension\":3,\"external\":true}}";
+    const reconcile_summary = try metadata_table_provisioner.reconcileDbIndexesWithOptions(
+        alloc,
+        &db,
+        indexes_json,
+        .{},
+    );
+    try std.testing.expectEqual(@as(usize, 1), reconcile_summary.indexes_added);
 
     const FakeCatalog = struct {
         fn iface() table_catalog.CatalogSource {
@@ -16718,7 +16726,23 @@ test "provisioned local runtime statuses reconcile empty managed embeddings inde
     source.cache = &cache;
     var db_lease = try cache.getOrOpen(path, FakeCatalog.iface(), 7001, 0, "docs");
     defer db_lease.release();
-    var statuses = (try source.source().localRuntimeStatuses(alloc, "docs")).?;
+
+    // Provisioned read sources intentionally publish status only from the
+    // shared snapshot cache; query-cache handles are not an authoritative
+    // status source. Model the production refresher by publishing the
+    // reconciled empty managed index from the writer-owned group.
+    var snapshot_cache = runtime_status.TableRuntimeSnapshotCache.init(alloc);
+    defer snapshot_cache.deinit();
+    var live_status = runtime_status.LocalTableRuntimeStatus{
+        .group_id = 7001,
+        .stats = try db.runtimeStatusStatsConsistent(alloc),
+    };
+    defer live_status.deinit(alloc);
+    try publishRuntimeStatusGroupForTest(&snapshot_cache, "docs", live_status);
+    source.runtime_status_cache = &snapshot_cache;
+
+    var statuses = (try source.source().localRuntimeStatuses(alloc, "docs")) orelse
+        return error.MissingRuntimeStatusSnapshot;
     defer statuses.deinit(alloc);
 
     try std.testing.expectEqual(@as(usize, 1), statuses.items.len);

--- a/zig/pkg/antfly/src/api/table_writes.zig
+++ b/zig/pkg/antfly/src/api/table_writes.zig
@@ -9266,6 +9266,41 @@ pub const ProvisionedTableWriteSource = struct {
         }
     }
 
+    fn snapshotRuntimeStatusesFromStorageBestEffort(
+        self: *ProvisionedTableWriteSource,
+        alloc: std.mem.Allocator,
+        table_name: []const u8,
+    ) !?runtime_status.LocalTableRuntimeStatuses {
+        // Cold inspection may open the same logical root as a foreground
+        // writer. Never block the status path or race an in-process writer;
+        // the next poll can retry after the owner releases the source lock.
+        if (!self.local_db_mutex.tryLock()) return null;
+        defer self.local_db_mutex.unlock();
+
+        var recovered = (try snapshotLocalTableRuntimeStatusesUncachedMode(
+            alloc,
+            self.catalog,
+            self.replica_root_dir,
+            self.backend_runtime,
+            table_name,
+            .status_only,
+        )) orelse return null;
+        errdefer recovered.deinit(alloc);
+        if (runtimeStatusesNeedColdVisibilityRefresh(&recovered)) {
+            recovered.deinit(alloc);
+            recovered = (try snapshotLocalTableRuntimeStatusesUncachedMode(
+                alloc,
+                self.catalog,
+                self.replica_root_dir,
+                self.backend_runtime,
+                table_name,
+                .query_readonly,
+            )) orelse return null;
+        }
+        markRecoveredRuntimeStatuses(&recovered);
+        return recovered;
+    }
+
     fn recoverRuntimeStatusesFromStorage(
         self: *ProvisionedTableWriteSource,
         alloc: std.mem.Allocator,
@@ -9273,13 +9308,8 @@ pub const ProvisionedTableWriteSource = struct {
     ) !?runtime_status.LocalTableRuntimeStatuses {
         const snapshot_cache = self.runtime_status_cache orelse return null;
         const publication_token = try snapshot_cache.capturePublicationToken(table_name);
-        var recovered = (try snapshotLocalTableRuntimeStatusesUncachedMode(alloc, self.catalog, self.replica_root_dir, self.backend_runtime, table_name, .status_only)) orelse return null;
+        var recovered = (try self.snapshotRuntimeStatusesFromStorageBestEffort(alloc, table_name)) orelse return null;
         errdefer recovered.deinit(alloc);
-        if (runtimeStatusesNeedColdVisibilityRefresh(&recovered)) {
-            recovered.deinit(alloc);
-            recovered = (try snapshotLocalTableRuntimeStatusesUncachedMode(alloc, self.catalog, self.replica_root_dir, self.backend_runtime, table_name, .query_readonly)) orelse return null;
-        }
-        markRecoveredRuntimeStatuses(&recovered);
         for (recovered.items) |item| _ = try snapshot_cache.publishGroup(publication_token, table_name, item);
         self.overlayManagedWriterReplayTargetsBestEffort(alloc, table_name, &recovered);
         return recovered;
@@ -9290,44 +9320,39 @@ pub const ProvisionedTableWriteSource = struct {
         alloc: std.mem.Allocator,
         table_name: []const u8,
     ) !?runtime_status.LocalTableRuntimeStatuses {
+        if (self.structuralStatusSnapshotOnlyBestEffort(table_name)) {
+            const snapshot_cache = self.runtime_status_cache orelse return null;
+            return try snapshot_cache.snapshot(alloc, table_name);
+        }
         if (self.runtime_status_cache == null) {
             // Standalone/uncached sources have no owner-published status plane
             // to consult. Their caller holds status admission, so a cold
             // read-only inspection is serialized with structural publication
             // without opening a competing writer or changing cache semantics.
-            var recovered = (try snapshotLocalTableRuntimeStatusesUncachedMode(
-                alloc,
-                self.catalog,
-                self.replica_root_dir,
-                self.backend_runtime,
-                table_name,
-                .status_only,
-            )) orelse return null;
-            errdefer recovered.deinit(alloc);
-            if (runtimeStatusesNeedColdVisibilityRefresh(&recovered)) {
-                recovered.deinit(alloc);
-                recovered = (try snapshotLocalTableRuntimeStatusesUncachedMode(
-                    alloc,
-                    self.catalog,
-                    self.replica_root_dir,
-                    self.backend_runtime,
-                    table_name,
-                    .query_readonly,
-                )) orelse return null;
-            }
-            markRecoveredRuntimeStatuses(&recovered);
-            return recovered;
+            return try self.snapshotRuntimeStatusesFromStorageBestEffort(alloc, table_name);
         }
         // Keep the hot HTTP status path on the cached status plane. After a
         // process restart the cache is empty, or can contain only a synthetic
-        // dense placeholder; recover once from durable status snapshots, and
-        // only load query-visible index state when the cheap snapshot is
-        // clearly missing dense visibility for existing primary documents.
+        // dense placeholder. Production sources delegate recovery to the
+        // coalesced runtime owner so status polling never opens a DB inline.
+        // Standalone sources without that owner retain guarded synchronous
+        // recovery for compatibility.
         const snapshot_cache = self.runtime_status_cache.?;
-        var cached = (try snapshot_cache.snapshot(alloc, table_name)) orelse return try self.recoverRuntimeStatusesFromStorage(alloc, table_name);
+        var cached = (try snapshot_cache.snapshot(alloc, table_name)) orelse {
+            if (self.local_change_hook != null) {
+                self.notifyLocalChange(table_name, .runtime_status);
+                return null;
+            }
+            return try self.recoverRuntimeStatusesFromStorage(alloc, table_name);
+        };
         errdefer cached.deinit(alloc);
         const needs_cold_refresh = runtimeStatusesNeedColdVisibilityRefresh(&cached);
         if (needs_cold_refresh) {
+            if (self.local_change_hook != null) {
+                for (cached.items) |*status| status.metadata.freshness = .stale;
+                self.notifyLocalChange(table_name, .runtime_status);
+                return cached;
+            }
             cached.deinit(alloc);
             return try self.recoverRuntimeStatusesFromStorage(alloc, table_name);
         }
@@ -18119,6 +18144,17 @@ const RuntimeStatusPublicationKind = enum {
     terminal_startup,
 };
 
+fn refreshRuntimeStatusStatsIfAvailable(
+    alloc: std.mem.Allocator,
+    status: *runtime_status.LocalTableRuntimeStatus,
+    db: *db_mod.DB,
+) !bool {
+    const fresh_stats = (try db.runtimeStatusStatsConsistentIfAvailable(alloc)) orelse return false;
+    db_mod.types.freeDBStats(alloc, status.stats);
+    status.stats = fresh_stats;
+    return true;
+}
+
 fn publishRuntimeStatusSnapshotWithStartupPhaseMode(
     source: *ProvisionedTableWriteSource,
     alloc: std.mem.Allocator,
@@ -18215,7 +18251,17 @@ fn publishRuntimeStatusSnapshotToCacheWithStartupPhaseMode(
         if (try snapshot_cache.snapshotGroupStatus(alloc, table_name, group_id)) |cached_status| {
             var status = cached_status;
             defer status.deinit(alloc);
-            const startup = startupCatchUpStatsForPhase(phase, db);
+            var startup = startupCatchUpStatsForPhase(phase, db);
+            const cached_startup = status.stats.async_indexing.startup;
+            if (!startup.wal_retention_known and cached_startup.wal_retention_known) {
+                startup.wal_retention_known = true;
+                startup.wal_retained_segments = cached_startup.wal_retained_segments;
+                startup.wal_retained_bytes = cached_startup.wal_retained_bytes;
+            }
+            // Startup publication must remain non-blocking, but when the
+            // writer is immediately readable replace stale table counters
+            // before layering the startup progress fields onto them.
+            _ = try refreshRuntimeStatusStatsIfAvailable(alloc, &status, db);
             applyStartupCatchUpAsyncOverlay(&status, async_stats, startup);
             markStartupRuntimeStatus(&status, startup);
             status.metadata.lsm_root_generation = lsm_root_generation;
@@ -18256,7 +18302,16 @@ fn publishRuntimeStatusSnapshotToCacheWithStartupPhaseMode(
                 status = cached_status;
                 status_initialized = true;
                 status_from_cached_best_effort = true;
-                if (runtimeStatusNeedsAuthoritativeLifecycleRefresh(status)) {
+                if (cached_best_effort_source == .startup_catch_up or
+                    status.stats.async_indexing.startup.active)
+                {
+                    // Crossing out of startup is a lifecycle edge. Refresh
+                    // exact counters opportunistically, but preserve the
+                    // cached observation if a foreground apply owns the DB.
+                    if (!try refreshRuntimeStatusStatsIfAvailable(alloc, &status, db)) {
+                        db.overlayRuntimeStatusBestEffort(alloc, &status.stats);
+                    }
+                } else if (runtimeStatusNeedsAuthoritativeLifecycleRefresh(status)) {
                     const fresh_stats = (try db.runtimeStatusStatsConsistentIfAvailable(alloc)) orelse
                         return error.WriterLocked;
                     db_mod.types.freeDBStats(alloc, status.stats);
@@ -18897,6 +18952,9 @@ fn publishStartupCatchUpRuntimeStatusSnapshot(
             }
             var merged_existing = status.stats.async_indexing.startup;
             db_mod.types.accumulateStartupCatchUpStats(&merged_existing, merged_startup);
+            if (db) |managed_db| {
+                _ = try refreshRuntimeStatusStatsIfAvailable(alloc, &status, managed_db);
+            }
             status.stats.async_indexing.startup = merged_existing;
             if (db) |managed_db| {
                 applyStartupCatchUpAsyncOverlay(&status, managed_db.snapshotAsyncIndexingStats(), status.stats.async_indexing.startup);
@@ -26480,6 +26538,58 @@ test "provisioned table write source runtime status is best effort when local db
     try std.testing.expect(statuses == null);
 }
 
+test "provisioned table write source cold status delegates to refresh owner" {
+    const alloc = std.testing.allocator;
+
+    const NoCatalog = struct {
+        fn iface() table_catalog.CatalogSource {
+            return .{
+                .ptr = undefined,
+                .vtable = &.{
+                    .admin_snapshot = adminSnapshot,
+                    .free_admin_snapshot = freeAdminSnapshot,
+                },
+            };
+        }
+
+        fn adminSnapshot(_: *anyopaque) !metadata_api.AdminSnapshot {
+            return error.UnexpectedCatalogCall;
+        }
+
+        fn freeAdminSnapshot(_: *anyopaque, _: *metadata_api.AdminSnapshot) void {}
+    };
+
+    const Hook = struct {
+        calls: usize = 0,
+        kind: ?ProvisionedTableWriteSource.LocalChangeKind = null,
+
+        fn onChange(ptr: *anyopaque, _: []const u8, kind: ProvisionedTableWriteSource.LocalChangeKind) void {
+            const self: *@This() = @ptrCast(@alignCast(ptr));
+            self.calls += 1;
+            self.kind = kind;
+        }
+    };
+
+    var snapshot_cache = runtime_status.TableRuntimeSnapshotCache.init(alloc);
+    defer snapshot_cache.deinit();
+    var source = ProvisionedTableWriteSource.init("/tmp/unused-antfly-cold-status-delegation", NoCatalog.iface());
+    defer source.deinit();
+    source.runtime_status_cache = &snapshot_cache;
+    var hook = Hook{};
+    source.setLocalChangeHook(.{
+        .ptr = &hook,
+        .on_change = Hook.onChange,
+    });
+
+    if (try source.source().localRuntimeStatuses(alloc, "docs")) |owned_statuses| {
+        var statuses = owned_statuses;
+        defer statuses.deinit(alloc);
+        return error.TestUnexpectedResult;
+    }
+    try std.testing.expectEqual(@as(usize, 1), hook.calls);
+    try std.testing.expectEqual(ProvisionedTableWriteSource.LocalChangeKind.runtime_status, hook.kind.?);
+}
+
 test "provisioned table write source runtime statuses reconcile empty embeddings indexes" {
     const alloc = std.testing.allocator;
 
@@ -26646,9 +26756,17 @@ test "provisioned table write source runtime status repairs cold dense placehold
     try std.testing.expect(statuses.items[0].stats.indexes[0].doc_count > 0 or statuses.items[0].stats.indexes[0].node_count > 0 or statuses.items[0].stats.indexes[0].root_node > 0);
 }
 
-test "provisioned table write source runtime status stays cache-only without shared snapshot" {
+test "provisioned table write source recovers durable status without shared snapshot" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-provisioned-write-runtime-cache";
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const path = try std.fmt.allocPrint(
+        alloc,
+        ".zig-cache/tmp/{s}/antfly-api-provisioned-write-runtime-cache",
+        .{tmp.sub_path},
+    );
+    defer alloc.free(path);
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -26691,27 +26809,9 @@ test "provisioned table write source runtime status stays cache-only without sha
         fn freeAdminSnapshot(_: *anyopaque, _: *metadata_api.AdminSnapshot) void {}
     };
 
-    const NoCatalog = struct {
-        fn iface() table_catalog.CatalogSource {
-            return .{
-                .ptr = undefined,
-                .vtable = &.{
-                    .admin_snapshot = adminSnapshot,
-                    .free_admin_snapshot = freeAdminSnapshot,
-                },
-            };
-        }
-
-        fn adminSnapshot(_: *anyopaque) !metadata_api.AdminSnapshot {
-            return error.UnexpectedCatalogCall;
-        }
-
-        fn freeAdminSnapshot(_: *anyopaque, _: *metadata_api.AdminSnapshot) void {}
-    };
-
     var write_cache = ProvisionedTableWriteCache.init(alloc);
     defer write_cache.deinit();
-    var source = ProvisionedTableWriteSource.init(path, NoCatalog.iface());
+    var source = ProvisionedTableWriteSource.init(path, WarmCatalog.iface());
     source.write_cache = &write_cache;
 
     lockAtomic(&source.local_db_mutex);
@@ -26719,7 +26819,12 @@ test "provisioned table write source runtime status stays cache-only without sha
     source.local_db_mutex.unlock();
     defer cached.deinit(alloc);
 
-    try std.testing.expect((try source.source().localRuntimeStatuses(alloc, "docs")) == null);
+    var statuses = (try source.source().localRuntimeStatuses(alloc, "docs")) orelse
+        return error.MissingRuntimeStatusSnapshot;
+    defer statuses.deinit(alloc);
+    try std.testing.expectEqual(@as(usize, 1), statuses.items.len);
+    try std.testing.expectEqual(@as(usize, 1), statuses.items[0].stats.indexes.len);
+    try std.testing.expectEqualStrings("semantic_idx", statuses.items[0].stats.indexes[0].name);
 }
 
 test "provisioned table write cache retires stale db when index metadata changes" {
@@ -30533,11 +30638,18 @@ test "provisioned replicated sync marks local runtime status dirty" {
 
     const Hook = struct {
         calls: usize = 0,
+        data_calls: usize = 0,
+        runtime_status_calls: usize = 0,
         kind: ?ProvisionedTableWriteSource.LocalChangeKind = null,
 
         fn onChange(ptr: *anyopaque, _: []const u8, kind: ProvisionedTableWriteSource.LocalChangeKind) void {
             const self: *@This() = @ptrCast(@alignCast(ptr));
             self.calls += 1;
+            switch (kind) {
+                .data => self.data_calls += 1,
+                .runtime_status => self.runtime_status_calls += 1,
+                else => {},
+            }
             self.kind = kind;
         }
     };
@@ -30568,12 +30680,17 @@ test "provisioned replicated sync marks local runtime status dirty" {
         .sync_level = .full_index,
     });
     try std.testing.expectEqual(@as(usize, 1), hook.calls);
+    try std.testing.expectEqual(@as(usize, 1), hook.data_calls);
 
     hook.calls = 0;
+    hook.data_calls = 0;
+    hook.runtime_status_calls = 0;
     hook.kind = null;
     try source.syncReplicatedBatchGroupLocal(alloc, 7001, "docs", .full_index);
 
-    try std.testing.expectEqual(@as(usize, 1), hook.calls);
+    try std.testing.expectEqual(@as(usize, 1), hook.data_calls);
+    try std.testing.expect(hook.runtime_status_calls > 0);
+    try std.testing.expectEqual(hook.data_calls + hook.runtime_status_calls, hook.calls);
     try std.testing.expectEqual(ProvisionedTableWriteSource.LocalChangeKind.data, hook.kind.?);
 }
 
@@ -31425,31 +31542,12 @@ test "provisioned table read source serves profiled dense query without runtime 
 
     const replica_root_dir = try std.fmt.allocPrint(alloc, ".zig-cache/tmp/{s}/runtime-status-warmed-read-cache-profiled-query", .{tmp.sub_path});
     defer alloc.free(replica_root_dir);
-    const path = try std.fmt.allocPrint(alloc, "{s}/group-7001/table-db", .{replica_root_dir});
-    defer alloc.free(path);
-
-    {
-        var db = try openManagedDbWithIndexesJson(
-            alloc,
-            path,
-            "{\"indexes\":[{\"name\":\"semantic_idx\",\"type\":\"embeddings\",\"config\":{\"field\":\"embedding\",\"dims\":2}}]}",
-        );
-        defer db.close();
-        try db.batch(.{
-            .writes = &.{
-                .{ .key = "doc:a", .value = "{\"_embeddings\":{\"semantic_idx\":[1,2]}}" },
-                .{ .key = "doc:b", .value = "{\"_embeddings\":{\"semantic_idx\":[2,1]}}" },
-            },
-            .sync_level = .full_index,
-        });
-    }
 
     var read_cache = table_reads.ProvisionedTableReadCache.init(alloc);
     defer read_cache.deinit();
 
     var write_cache = ProvisionedTableWriteCache.init(alloc);
     defer write_cache.deinit();
-    _ = try write_cache.getOrOpenLocked(path, Catalog.iface(), 7001, 0, "docs");
 
     var snapshot_cache = runtime_status.TableRuntimeSnapshotCache.init(alloc);
     defer snapshot_cache.deinit();
@@ -31458,9 +31556,14 @@ test "provisioned table read source serves profiled dense query without runtime 
     write_source.read_cache = &read_cache;
     write_source.write_cache = &write_cache;
     write_source.runtime_status_cache = &snapshot_cache;
-    write_source.markWriteCacheDirty("docs");
-
-    try std.testing.expect((try write_source.source().localRuntimeStatuses(alloc, "docs")) == null);
+    _ = try write_source.applyReplicatedBatchGroupLocal(alloc, 7001, "docs", .{
+        .writes = &.{
+            .{ .key = "doc:a", .value = "{\"title\":\"alpha\",\"_embeddings\":{\"semantic_idx\":[1,2]}}" },
+            .{ .key = "doc:b", .value = "{\"title\":\"beta\",\"_embeddings\":{\"semantic_idx\":[2,1]}}" },
+        },
+        .sync_level = .full_index,
+    });
+    try write_source.syncReplicatedBatchGroupLocal(alloc, 7001, "docs", .full_index);
 
     var read_source = table_reads.ProvisionedTableReadSource.init(replica_root_dir, Catalog.iface(), raft_mod.read_gate.noopReadableLeaseRequester());
     read_source.cache = &read_cache;
@@ -32591,7 +32694,8 @@ test "runtime status snapshot with startup phase refreshes live table stats for 
     try std.testing.expectEqual(@as(usize, 1), statuses.items.len);
     try std.testing.expectEqual(runtime_status.RuntimeStatusSource.startup_catch_up, statuses.items[0].metadata.source);
     try std.testing.expectEqual(runtime_status.RuntimeStatusFreshness.catching_up, statuses.items[0].metadata.freshness);
-    try std.testing.expectEqual(@as(u64, 1), statuses.items[0].stats.doc_count);
+    try std.testing.expectEqual(@as(u64, 0), statuses.items[0].stats.doc_count);
+    try std.testing.expectEqual(@as(u64, 1), statuses.items[0].stats.source_doc_count);
     try std.testing.expectEqual(db_mod.types.StartupCatchUpPhase.artifact_rebuild, statuses.items[0].stats.async_indexing.startup.phase);
     try std.testing.expect(statuses.items[0].stats.async_indexing.startup.active);
     try std.testing.expect(statuses.items[0].stats.async_indexing.startup.wal_retention_known);
@@ -32674,7 +32778,8 @@ test "startup runtime status snapshot with live db refreshes table stats during 
     defer statuses.deinit(alloc);
 
     try std.testing.expectEqual(@as(usize, 1), statuses.items.len);
-    try std.testing.expectEqual(@as(u64, 1), statuses.items[0].stats.doc_count);
+    try std.testing.expectEqual(@as(u64, 0), statuses.items[0].stats.doc_count);
+    try std.testing.expectEqual(@as(u64, 1), statuses.items[0].stats.source_doc_count);
     try std.testing.expectEqual(db_mod.types.StartupCatchUpPhase.artifact_rebuild, statuses.items[0].stats.async_indexing.startup.phase);
     try std.testing.expect(statuses.items[0].stats.async_indexing.startup.active);
     try std.testing.expect(statuses.items[0].stats.async_indexing.startup.wal_retention_known);
@@ -32869,12 +32974,15 @@ test "runtime status snapshot with idle phase refreshes live stats after startup
     defer statuses.deinit(alloc);
 
     try std.testing.expectEqual(@as(usize, 1), statuses.items.len);
-    try std.testing.expectEqual(@as(u64, 1), statuses.items[0].stats.doc_count);
+    try std.testing.expectEqual(@as(u64, 0), statuses.items[0].stats.doc_count);
+    try std.testing.expectEqual(@as(u64, 1), statuses.items[0].stats.source_doc_count);
     try std.testing.expectEqual(db_mod.types.StartupCatchUpPhase.idle, statuses.items[0].stats.async_indexing.startup.phase);
     try std.testing.expect(!statuses.items[0].stats.async_indexing.startup.active);
     try std.testing.expect(statuses.items[0].stats.async_indexing.startup.wal_retention_known);
-    try std.testing.expectEqual(@as(u64, 7), statuses.items[0].stats.async_indexing.startup.wal_retained_segments);
-    try std.testing.expectEqual(@as(u64, 456), statuses.items[0].stats.async_indexing.startup.wal_retained_bytes);
+    try std.testing.expect(statuses.items[0].stats.async_indexing.startup.wal_retained_segments > 0);
+    try std.testing.expect(statuses.items[0].stats.async_indexing.startup.wal_retained_bytes > 0);
+    try std.testing.expect(statuses.items[0].stats.async_indexing.startup.wal_retained_segments != 7);
+    try std.testing.expect(statuses.items[0].stats.async_indexing.startup.wal_retained_bytes != 456);
 }
 
 test "idle startup runtime status publish is live when startup flag is still set" {

--- a/zig/pkg/antfly/src/api/table_writes.zig
+++ b/zig/pkg/antfly/src/api/table_writes.zig
@@ -1706,7 +1706,9 @@ pub const ProvisionedTableWriteCache = struct {
             .schema_json = owned_entry.schema_json,
         };
         errdefer self.retireFailedOpenLocked(&cached);
-        try owned_entry.db.drainResolverBackfill();
+        if (managedDbOpenModeDrainsResolverBackfill(mode)) {
+            try owned_entry.db.drainResolverBackfill();
+        }
         return cached;
     }
 
@@ -7176,7 +7178,9 @@ pub const ProvisionedTableWriteSource = struct {
         // cluster-wide) in the multinode autograph e2e. The promotion and
         // resolution workers started by this open drain the same backlog
         // asynchronously instead.
-        if (mode != .default_async) try cached.db.drainResolverBackfill();
+        if (managedDbOpenModeDrainsResolverBackfill(mode)) {
+            try cached.db.drainResolverBackfill();
+        }
         // DB.open starts and resumes derived workers before the cache can
         // attach its provisioned visibility hook. A short persisted replay
         // tail can therefore finish during open and miss the post-watermark
@@ -14502,7 +14506,9 @@ pub const HostedProvisionedTableWriteSource = struct {
             defer cache.mutex.unlock();
             cache.write_cache.retireFailedOpenLocked(&cached);
         }
-        try cached.db.drainResolverBackfill();
+        if (managedDbOpenModeDrainsResolverBackfill(mode)) {
+            try cached.db.drainResolverBackfill();
+        }
         return cached;
     }
 
@@ -17167,6 +17173,25 @@ const ManagedDbOpenMode = enum {
     query_readonly,
     status_only,
 };
+
+fn managedDbOpenModeDrainsResolverBackfill(mode: ManagedDbOpenMode) bool {
+    // default_async is the Raft apply path. Resolver/promotion catch-up can
+    // issue cross-shard writes whose completion requires future Raft applies,
+    // so waiting here creates a cyclic dependency and wedges every group on
+    // this apply thread. DB.open already starts the background workers that
+    // drain the same backlog without blocking replicated application.
+    return mode != .default_async;
+}
+
+test "managed db open modes never drain resolver backfill on raft apply" {
+    try std.testing.expect(!managedDbOpenModeDrainsResolverBackfill(.default_async));
+    try std.testing.expect(managedDbOpenModeDrainsResolverBackfill(.default));
+    try std.testing.expect(managedDbOpenModeDrainsResolverBackfill(.writer_no_replay));
+    try std.testing.expect(managedDbOpenModeDrainsResolverBackfill(.startup_catch_up));
+    try std.testing.expect(managedDbOpenModeDrainsResolverBackfill(.restore_repair));
+    try std.testing.expect(managedDbOpenModeDrainsResolverBackfill(.query_readonly));
+    try std.testing.expect(managedDbOpenModeDrainsResolverBackfill(.status_only));
+}
 
 fn haMirrorForManagedDbOpenMode(mode: ManagedDbOpenMode, mirror: ?db_mod.HAAsyncEffectMirror) ?db_mod.HAAsyncEffectMirror {
     return switch (mode) {

--- a/zig/pkg/antfly/src/api/table_writes.zig
+++ b/zig/pkg/antfly/src/api/table_writes.zig
@@ -18418,7 +18418,7 @@ fn statusHasRuntimeFactsIgnoringMetadataSource(status: runtime_status.LocalTable
 
 fn cachedBestEffortStartupPlaceholderSource(source: runtime_status.RuntimeStatusSource) bool {
     return switch (source) {
-        .live_writer_publish, .background_refresh, .remote_store => false,
+        .live_writer_publish, .background_refresh, .remote_store, .rebuild_state_quarantine => false,
         .unknown, .synthetic_config, .cached_snapshot, .startup_catch_up => true,
     };
 }
@@ -18848,7 +18848,7 @@ fn markClearedStartupRuntimeStatus(status: *runtime_status.LocalTableRuntimeStat
     clearStartupRuntimeStatus(status);
     if (status.metadata.freshness == .fresh) {
         switch (status.metadata.source) {
-            .cached_snapshot, .live_writer_publish, .background_refresh, .remote_store => return,
+            .cached_snapshot, .live_writer_publish, .background_refresh, .remote_store, .rebuild_state_quarantine => return,
             .unknown, .synthetic_config, .startup_catch_up => {},
         }
     }

--- a/zig/pkg/antfly/src/api/transactions.zig
+++ b/zig/pkg/antfly/src/api/transactions.zig
@@ -282,12 +282,7 @@ pub const SessionReadSnapshot = struct {
     document_json: ?[]u8 = null,
 
     pub fn clone(self: SessionReadSnapshot, alloc: std.mem.Allocator) !SessionReadSnapshot {
-        return .{
-            .table_name = try alloc.dupe(u8, self.table_name),
-            .key = try alloc.dupe(u8, self.key),
-            .version = self.version,
-            .document_json = if (self.document_json) |document_json| try alloc.dupe(u8, document_json) else null,
-        };
+        return ownReadSnapshot(alloc, self.stage());
     }
 
     pub fn deinit(self: *SessionReadSnapshot, alloc: std.mem.Allocator) void {
@@ -497,6 +492,10 @@ pub const Savepoint = struct {
 pub const Session = struct {
     txn_id: db_mod.types.TxnId,
     owner_node_id: u64,
+    /// Stable authenticated subject that created this session. `null` is the
+    /// anonymous principal used only when authentication is disabled. The
+    /// binding is immutable across node-owner lease transfers.
+    principal: ?[]u8 = null,
     begin_timestamp: u64,
     last_touched_timestamp: u64,
     sync_level: db_mod.types.SyncLevel,
@@ -514,6 +513,7 @@ pub const Session = struct {
     }
 
     pub fn deinit(self: *Session, alloc: std.mem.Allocator) void {
+        if (self.principal) |principal| alloc.free(principal);
         if (self.staged) |*staged| staged.deinit(alloc);
         deinitReadSnapshotMap(alloc, &self.read_snapshots);
         var it = self.savepoints.iterator();
@@ -526,6 +526,7 @@ pub const Session = struct {
         var out: Session = .{
             .txn_id = self.txn_id,
             .owner_node_id = self.owner_node_id,
+            .principal = if (self.principal) |principal| try alloc.dupe(u8, principal) else null,
             .begin_timestamp = self.begin_timestamp,
             .last_touched_timestamp = self.last_touched_timestamp,
             .sync_level = self.sync_level,
@@ -908,6 +909,15 @@ pub const OpenedSessionStore = struct {
     }
 };
 
+pub const SessionStoreScope = enum {
+    /// Session records are persisted by their owner node. A miss on another
+    /// node must still route to the owner encoded in the transaction ID.
+    node_local,
+    /// Every node observes the same durable keyspace, so a miss is
+    /// authoritative and must not resurrect routing to an obsolete owner.
+    cluster_shared,
+};
+
 pub const SessionLeaseStore = struct {
     alloc: std.mem.Allocator,
     backend: DurableSessionStore.Backend,
@@ -973,6 +983,7 @@ pub const SessionRegistry = struct {
     max_savepoints: ?usize = null,
     max_sessions: ?usize = null,
     max_record_bytes: ?usize = null,
+    durable_scope: SessionStoreScope = .node_local,
     known_durable_session_count: ?usize = null,
     reserved_session_count: usize = 0,
 
@@ -1009,16 +1020,37 @@ pub const SessionRegistry = struct {
         self.* = .{};
     }
 
+    pub fn hasDurableStore(self: *const SessionRegistry) bool {
+        return self.durable != null;
+    }
+
+    pub fn durableMissIsAuthoritative(self: *const SessionRegistry) bool {
+        return self.durable != null and self.durable_scope == .cluster_shared;
+    }
+
     pub fn begin(self: *SessionRegistry, alloc: std.mem.Allocator, req: BeginRequest, owner_node_id: u64) !SessionInfo {
+        return try self.beginForPrincipal(alloc, req, owner_node_id, null);
+    }
+
+    pub fn beginForPrincipal(
+        self: *SessionRegistry,
+        alloc: std.mem.Allocator,
+        req: BeginRequest,
+        owner_node_id: u64,
+        principal: ?[]const u8,
+    ) !SessionInfo {
         const txn_id = newSessionTxnId(owner_node_id);
         const now = nextTxnTimestamp();
-        const session: Session = .{
+        var session: Session = .{
             .txn_id = txn_id,
             .owner_node_id = owner_node_id,
+            .principal = if (principal) |value| try alloc.dupe(u8, value) else null,
             .begin_timestamp = now,
             .last_touched_timestamp = now,
             .sync_level = req.sync_level,
         };
+        var session_owned = true;
+        errdefer if (session_owned) session.deinit(alloc);
         try self.initializeDurableSessionCount();
         self.mutex.lock();
         self.ensureSessionCapacityLocked() catch |err| {
@@ -1047,10 +1079,44 @@ pub const SessionRegistry = struct {
         self.mutex.lock();
         defer self.mutex.unlock();
         self.sessions.putAssumeCapacity(txn_id, session);
+        session_owned = false;
         self.reserved_session_count -= 1;
         reservation_active = false;
         if (self.known_durable_session_count) |count| self.known_durable_session_count = count + 1;
         return session.info();
+    }
+
+    pub const PrincipalAccess = enum {
+        missing,
+        allowed,
+        denied,
+    };
+
+    /// Checks the immutable authenticated-subject binding without cloning a
+    /// potentially large staged transaction. A legacy unbound record therefore
+    /// fails closed for every authenticated principal.
+    pub fn principalAccess(
+        self: *SessionRegistry,
+        _: std.mem.Allocator,
+        txn_id: db_mod.types.TxnId,
+        principal: ?[]const u8,
+    ) !PrincipalAccess {
+        const session_lock = self.sessionLock(txn_id);
+        session_lock.lock();
+        defer session_lock.unlock();
+
+        self.mutex.lock();
+        if (self.sessions.getPtr(txn_id)) |session| {
+            const allowed = principalsEqual(session.principal, principal);
+            self.mutex.unlock();
+            return if (allowed) .allowed else .denied;
+        }
+        self.mutex.unlock();
+
+        const durable = self.durable orelse return .missing;
+        var loaded = (try durable.load(txn_id)) orelse return .missing;
+        defer loaded.deinit(durable.alloc);
+        return if (principalsEqual(loaded.principal, principal)) .allowed else .denied;
     }
 
     pub fn getInfo(self: *SessionRegistry, txn_id: db_mod.types.TxnId) ?SessionInfo {
@@ -1251,6 +1317,27 @@ pub const SessionRegistry = struct {
     }
 
     pub fn listStatuses(self: *SessionRegistry, alloc: std.mem.Allocator) ![]SessionStatus {
+        return try self.listStatusesFiltered(alloc, .all);
+    }
+
+    pub fn listStatusesForPrincipal(
+        self: *SessionRegistry,
+        alloc: std.mem.Allocator,
+        principal: ?[]const u8,
+    ) ![]SessionStatus {
+        return try self.listStatusesFiltered(alloc, .{ .principal = principal });
+    }
+
+    const StatusPrincipalFilter = union(enum) {
+        all,
+        principal: ?[]const u8,
+    };
+
+    fn listStatusesFiltered(
+        self: *SessionRegistry,
+        alloc: std.mem.Allocator,
+        principal_filter: StatusPrincipalFilter,
+    ) ![]SessionStatus {
         var statuses = std.ArrayListUnmanaged(SessionStatus).empty;
         errdefer statuses.deinit(alloc);
 
@@ -1261,6 +1348,7 @@ pub const SessionRegistry = struct {
                 registry: *SessionRegistry,
                 allocator: std.mem.Allocator,
                 statuses: *std.ArrayListUnmanaged(SessionStatus),
+                principal_filter: StatusPrincipalFilter,
 
                 fn visit(raw: *anyopaque, key: []const u8, value: []const u8) anyerror!bool {
                     const scan: *@This() = @ptrCast(@alignCast(raw));
@@ -1268,6 +1356,10 @@ pub const SessionRegistry = struct {
                     const txn_id = distributed_txn.parseTxnIdHex(key[session_prefix.len..]) catch return true;
                     var session = decodeSessionRecord(scan.allocator, txn_id, value) catch return true;
                     defer session.deinit(scan.allocator);
+                    switch (scan.principal_filter) {
+                        .all => {},
+                        .principal => |principal| if (!principalsEqual(session.principal, principal)) return true,
+                    }
                     const counts = stagedCounts(session.staged);
                     const savepoint_count = session.savepoints.count();
                     try scan.statuses.append(scan.allocator, .{
@@ -1290,7 +1382,12 @@ pub const SessionRegistry = struct {
                     return true;
                 }
             };
-            var scan = Scan{ .registry = self, .allocator = alloc, .statuses = &statuses };
+            var scan = Scan{
+                .registry = self,
+                .allocator = alloc,
+                .statuses = &statuses,
+                .principal_filter = principal_filter,
+            };
             try durable.scanPrefixWithContext(session_prefix, &scan, Scan.visit);
             // Avoid nested backend reads by loading lease metadata only after
             // the scan transaction has closed.
@@ -1303,42 +1400,56 @@ pub const SessionRegistry = struct {
         var it = self.sessions.iterator();
         while (it.next()) |entry| {
             const session = entry.value_ptr.*;
+            switch (principal_filter) {
+                .all => {},
+                .principal => |principal| if (!principalsEqual(session.principal, principal)) continue,
+            }
             try statuses.append(alloc, try sessionStatusFromSession(self, alloc, &session));
         }
         return try statuses.toOwnedSlice(alloc);
     }
 
-    pub fn getOwnerNodeId(self: *SessionRegistry, alloc: std.mem.Allocator, txn_id: db_mod.types.TxnId) !?u64 {
+    pub fn getOwnerNodeId(self: *SessionRegistry, _: std.mem.Allocator, txn_id: db_mod.types.TxnId) !?u64 {
         const session_lock = self.sessionLock(txn_id);
         session_lock.lock();
         defer session_lock.unlock();
-        var session = (try self.loadSessionCloneAssumeStripe(alloc, txn_id)) orelse return null;
-        defer session.deinit(alloc);
-        return session.owner_node_id;
+        self.mutex.lock();
+        if (self.sessions.getPtr(txn_id)) |session| {
+            const owner_node_id = session.owner_node_id;
+            self.mutex.unlock();
+            return owner_node_id;
+        }
+        self.mutex.unlock();
+        if (self.durable) |durable| {
+            var session = (try durable.load(txn_id)) orelse return null;
+            defer session.deinit(durable.alloc);
+            return session.owner_node_id;
+        }
+        return null;
     }
 
     pub fn adopt(self: *SessionRegistry, alloc: std.mem.Allocator, txn_id: db_mod.types.TxnId, owner_node_id: u64) !bool {
         const session_lock = self.sessionLock(txn_id);
         session_lock.lock();
         defer session_lock.unlock();
-        if (self.durable == null) {
-            return false;
-        }
-        var candidate = (try self.loadSessionCloneAssumeStripe(alloc, txn_id)) orelse return false;
+        const durable = self.durable orelse return false;
+        var persisted = (try durable.load(txn_id)) orelse return false;
+        defer persisted.deinit(durable.alloc);
+        var candidate = try persisted.clone(alloc);
         errdefer candidate.deinit(alloc);
-        if (candidate.owner_node_id == owner_node_id) return true;
+        if (candidate.owner_node_id == owner_node_id) {
+            try self.publishAdoptedCandidateAssumeStripe(alloc, txn_id, &candidate);
+            return true;
+        }
         const expected_owner = candidate.owner_node_id;
         candidate.owner_node_id = owner_node_id;
         touchSession(&candidate);
         if (self.lease_store != null and self.owner_lease_ttl_ns != null) {
             const now_ns = nextTxnTimestamp();
             const ttl_ms = @max(@as(u64, 1), self.owner_lease_ttl_ns.? / std.time.ns_per_ms);
-            if (!(try self.durable.?.saveWithLease(candidate, expected_owner, now_ns / std.time.ns_per_ms, ttl_ms, false, self.max_record_bytes))) return false;
+            if (!(try durable.saveWithLease(candidate, expected_owner, now_ns / std.time.ns_per_ms, ttl_ms, false, self.max_record_bytes))) return false;
         } else try self.persistLocked(candidate);
-        self.mutex.lock();
-        defer self.mutex.unlock();
-        const publish_target = self.sessions.getPtr(txn_id) orelse return error.SessionRemovedDuringMutation;
-        self.publishCandidateLocked(alloc, publish_target, &candidate);
+        try self.publishAdoptedCandidateAssumeStripe(alloc, txn_id, &candidate);
         return true;
     }
 
@@ -1352,22 +1463,28 @@ pub const SessionRegistry = struct {
         const session_lock = self.sessionLock(txn_id);
         session_lock.lock();
         defer session_lock.unlock();
-        if (self.durable == null or self.lease_store == null or self.owner_lease_ttl_ns == null) {
+        const durable = self.durable orelse return false;
+        if (self.lease_store == null or self.owner_lease_ttl_ns == null) {
             return false;
         }
-        var candidate = (try self.loadSessionCloneAssumeStripe(alloc, txn_id)) orelse return false;
+        // A routing/principal lookup may have cached an older non-owner copy.
+        // Adoption must always fence and transfer the latest durable record or
+        // it can overwrite staged work that the previous owner published.
+        var persisted = (try durable.load(txn_id)) orelse return false;
+        defer persisted.deinit(durable.alloc);
+        var candidate = try persisted.clone(alloc);
         errdefer candidate.deinit(alloc);
-        if (candidate.owner_node_id == owner_node_id) return true;
+        if (candidate.owner_node_id == owner_node_id) {
+            try self.publishAdoptedCandidateAssumeStripe(alloc, txn_id, &candidate);
+            return true;
+        }
         const expected_owner = candidate.owner_node_id;
         const effective_now = now_ns orelse nextTxnTimestamp();
         candidate.owner_node_id = owner_node_id;
         touchSession(&candidate);
         const ttl_ms = @max(@as(u64, 1), self.owner_lease_ttl_ns.? / std.time.ns_per_ms);
-        if (!(try self.durable.?.saveWithLease(candidate, expected_owner, effective_now / std.time.ns_per_ms, ttl_ms, true, self.max_record_bytes))) return false;
-        self.mutex.lock();
-        defer self.mutex.unlock();
-        const publish_target = self.sessions.getPtr(txn_id) orelse return error.SessionRemovedDuringMutation;
-        self.publishCandidateLocked(alloc, publish_target, &candidate);
+        if (!(try durable.saveWithLease(candidate, expected_owner, effective_now / std.time.ns_per_ms, ttl_ms, true, self.max_record_bytes))) return false;
+        try self.publishAdoptedCandidateAssumeStripe(alloc, txn_id, &candidate);
         return true;
     }
 
@@ -1450,6 +1567,28 @@ pub const SessionRegistry = struct {
         var previous = current.*;
         current.* = candidate.*;
         previous.deinit(alloc);
+    }
+
+    /// Publishes an authoritative durable ownership transition into this
+    /// registry. The transaction stripe is held by the caller.
+    fn publishAdoptedCandidateAssumeStripe(
+        self: *SessionRegistry,
+        alloc: std.mem.Allocator,
+        txn_id: db_mod.types.TxnId,
+        candidate: *Session,
+    ) !void {
+        self.mutex.lock();
+        if (self.sessions.getPtr(txn_id)) |current| {
+            self.publishCandidateLocked(alloc, current, candidate);
+            self.mutex.unlock();
+            return;
+        }
+        self.sessions.put(alloc, txn_id, candidate.*) catch |err| {
+            self.mutex.unlock();
+            return err;
+        };
+        candidate.* = undefined;
+        self.mutex.unlock();
     }
 
     fn persistLocked(self: *SessionRegistry, session: Session) !void {
@@ -1569,7 +1708,9 @@ pub const SessionRegistry = struct {
         const lease_store = self.lease_store orelse return 0;
         var record = (try lease_store.load(alloc, txn_id)) orelse return 0;
         defer lease_mod.deinitRecord(alloc, &record);
-        return record.expires_at_ms * std.time.ns_per_ms;
+        // Durable lease records are external state. A corrupt or future-format
+        // millisecond value must not panic a request handler during conversion.
+        return leaseExpiryNs(record.expires_at_ms);
     }
 };
 
@@ -2577,19 +2718,34 @@ fn upsertReadSnapshot(
     snapshot: StageReadSnapshot,
 ) !void {
     const map_key = try readSnapshotMapKey(alloc, snapshot.table_name, snapshot.key);
-    errdefer alloc.free(map_key);
-    const gop = try map.getOrPut(alloc, map_key);
-    if (gop.found_existing) {
-        alloc.free(map_key);
-        if (gop.value_ptr.version == snapshot.version) return;
-        gop.value_ptr.deinit(alloc);
+    if (map.getPtr(map_key)) |existing| {
+        defer alloc.free(map_key);
+        if (existing.version == snapshot.version) return;
+        const replacement = try ownReadSnapshot(alloc, snapshot);
+        const previous = existing.*;
+        existing.* = replacement;
+        var old = previous;
+        old.deinit(alloc);
+        return;
     }
-    gop.key_ptr.* = map_key;
-    gop.value_ptr.* = .{
-        .table_name = try alloc.dupe(u8, snapshot.table_name),
-        .key = try alloc.dupe(u8, snapshot.key),
+
+    errdefer alloc.free(map_key);
+    var owned = try ownReadSnapshot(alloc, snapshot);
+    errdefer owned.deinit(alloc);
+    try map.putNoClobber(alloc, map_key, owned);
+}
+
+fn ownReadSnapshot(alloc: std.mem.Allocator, snapshot: StageReadSnapshot) !SessionReadSnapshot {
+    const table_name = try alloc.dupe(u8, snapshot.table_name);
+    errdefer alloc.free(table_name);
+    const key = try alloc.dupe(u8, snapshot.key);
+    errdefer alloc.free(key);
+    const document_json = if (snapshot.document_json) |json| try alloc.dupe(u8, json) else null;
+    return .{
+        .table_name = table_name,
+        .key = key,
         .version = snapshot.version,
-        .document_json = if (snapshot.document_json) |document_json| try alloc.dupe(u8, document_json) else null,
+        .document_json = document_json,
     };
 }
 
@@ -2631,7 +2787,7 @@ fn decodeReadSnapshotsInto(
         const key = requireString(obj, "key");
         if (table_name.len == 0 or key.len == 0) return error.InvalidTransactionSessionRecord;
         const version = switch (obj.get("version") orelse return error.InvalidTransactionSessionRecord) {
-            .integer => |v| @as(u64, @intCast(v)),
+            .integer => |v| try nonNegativeRecordInteger(v),
             .string => |s| try parseVersionString(s),
             else => return error.InvalidTransactionSessionRecord,
         };
@@ -2639,7 +2795,7 @@ fn decodeReadSnapshotsInto(
             .null => null,
             else => try std.json.Stringify.valueAlloc(alloc, document, .{}),
         } else null;
-        errdefer if (document_json) |json| alloc.free(json);
+        defer if (document_json) |json| alloc.free(json);
         try upsertReadSnapshot(alloc, map, .{
             .table_name = table_name,
             .key = key,
@@ -2918,6 +3074,10 @@ fn sessionLeaseState(lease_expires_at: u64, now_ns: u64) SessionLeaseState {
     return .held;
 }
 
+fn leaseExpiryNs(expires_at_ms: u64) u64 {
+    return std.math.mul(u64, expires_at_ms, std.time.ns_per_ms) catch std.math.maxInt(u64);
+}
+
 fn sessionStatusFromSession(self: *SessionRegistry, alloc: std.mem.Allocator, session: *const Session) !SessionStatus {
     const counts = stagedCounts(session.staged);
     const savepoint_count = session.savepoints.count();
@@ -3079,6 +3239,12 @@ fn encodeSessionRecord(alloc: std.mem.Allocator, session: Session) ![]u8 {
     defer out.deinit(alloc);
     try out.appendSlice(alloc, "{\"owner_node_id\":");
     try out.print(alloc, "{d}", .{session.owner_node_id});
+    try out.appendSlice(alloc, ",\"principal\":");
+    if (session.principal) |principal| {
+        try appendJsonString(alloc, &out, principal);
+    } else {
+        try out.appendSlice(alloc, "null");
+    }
     try out.appendSlice(alloc, ",\"begin_timestamp\":");
     try out.print(alloc, "{d}", .{session.begin_timestamp});
     try out.appendSlice(alloc, ",\"last_touched_timestamp\":");
@@ -3142,26 +3308,34 @@ fn decodeSessionRecord(alloc: std.mem.Allocator, txn_id: db_mod.types.TxnId, bod
         .txn_id = txn_id,
         .owner_node_id = if (obj.get("owner_node_id")) |value|
             switch (value) {
-                .integer => |v| @intCast(v),
+                .integer => |v| try nonNegativeRecordInteger(v),
                 else => return error.InvalidTransactionSessionRecord,
             }
         else
             sessionOwnerNodeId(txn_id),
+        .principal = if (obj.get("principal")) |value|
+            switch (value) {
+                .string => |principal| try alloc.dupe(u8, principal),
+                .null => null,
+                else => return error.InvalidTransactionSessionRecord,
+            }
+        else
+            null,
         .begin_timestamp = switch (obj.get("begin_timestamp") orelse return error.InvalidTransactionSessionRecord) {
-            .integer => |v| @intCast(v),
+            .integer => |v| try nonNegativeRecordInteger(v),
             else => return error.InvalidTransactionSessionRecord,
         },
         .last_touched_timestamp = 0,
         .sync_level = parseSyncLevel(obj.get("sync_level") orelse return error.InvalidTransactionSessionRecord) orelse return error.InvalidTransactionSessionRecord,
         .next_savepoint_id = switch (obj.get("next_savepoint_id") orelse return error.InvalidTransactionSessionRecord) {
-            .integer => |v| @intCast(v),
+            .integer => |v| try nonNegativeRecordInteger(v),
             else => return error.InvalidTransactionSessionRecord,
         },
     };
     errdefer session.deinit(alloc);
     session.last_touched_timestamp = if (obj.get("last_touched_timestamp")) |value|
         switch (value) {
-            .integer => |v| @intCast(v),
+            .integer => |v| try nonNegativeRecordInteger(v),
             else => return error.InvalidTransactionSessionRecord,
         }
     else
@@ -3183,7 +3357,7 @@ fn decodeSessionRecord(alloc: std.mem.Allocator, txn_id: db_mod.types.TxnId, bod
             else => return error.InvalidTransactionSessionRecord,
         };
         const id: u64 = switch (entry_obj.get("id") orelse return error.InvalidTransactionSessionRecord) {
-            .integer => |v| @intCast(v),
+            .integer => |v| try nonNegativeRecordInteger(v),
             else => return error.InvalidTransactionSessionRecord,
         };
         const snapshot = try parseCommitValue(alloc, entry_obj.get("snapshot") orelse return error.InvalidTransactionSessionRecord);
@@ -3201,6 +3375,11 @@ fn decodeSessionRecord(alloc: std.mem.Allocator, txn_id: db_mod.types.TxnId, bod
     return session;
 }
 
+fn principalsEqual(left: ?[]const u8, right: ?[]const u8) bool {
+    if (left == null or right == null) return left == null and right == null;
+    return std.mem.eql(u8, left.?, right.?);
+}
+
 fn newSessionTxnId(owner_node_id: u64) db_mod.types.TxnId {
     var txn_id: db_mod.types.TxnId = undefined;
     const nonce = txn_id_nonce.fetchAdd(1, .monotonic);
@@ -3212,6 +3391,11 @@ fn newSessionTxnId(owner_node_id: u64) db_mod.types.TxnId {
 
 fn parseVersionString(text: []const u8) !u64 {
     return try std.fmt.parseUnsigned(u64, text, 10);
+}
+
+fn nonNegativeRecordInteger(value: i64) !u64 {
+    if (value < 0) return error.InvalidTransactionSessionRecord;
+    return @intCast(value);
 }
 
 fn requireString(obj: std.json.ObjectMap, key: []const u8) []const u8 {
@@ -3265,6 +3449,63 @@ test "transaction session registry begins and removes sessions" {
     try std.testing.expectEqual(@as(u64, 7), sessionOwnerNodeId(session.txn_id));
     try std.testing.expect(registry.remove(std.testing.allocator, session.txn_id));
     try std.testing.expect(registry.getInfo(session.txn_id) == null);
+}
+
+test "durable transaction sessions preserve and enforce principal bindings" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const path = try std.fmt.allocPrint(std.testing.allocator, ".zig-cache/tmp/{s}/txn-session-principal", .{tmp.sub_path});
+    defer std.testing.allocator.free(path);
+    const path_z = try std.testing.allocator.dupeZ(u8, path);
+    defer std.testing.allocator.free(path_z);
+
+    var store = try docstore_mod.DocStore.open(std.testing.allocator, path_z, .{});
+    defer store.close();
+    var durable = DurableSessionStore.init(std.testing.allocator, &store);
+
+    var alice_txn_id: db_mod.types.TxnId = undefined;
+    {
+        var writer = SessionRegistry.init(&durable);
+        defer writer.deinit(std.testing.allocator);
+        const alice = try writer.beginForPrincipal(
+            std.testing.allocator,
+            .{ .sync_level = .write },
+            7,
+            "user:alice",
+        );
+        alice_txn_id = alice.txn_id;
+        _ = try writer.beginForPrincipal(
+            std.testing.allocator,
+            .{ .sync_level = .write },
+            7,
+            "user:bob",
+        );
+        _ = try writer.begin(std.testing.allocator, .{ .sync_level = .write }, 7);
+    }
+
+    var reader = SessionRegistry.init(&durable);
+    defer reader.deinit(std.testing.allocator);
+    try std.testing.expectEqual(
+        SessionRegistry.PrincipalAccess.allowed,
+        try reader.principalAccess(std.testing.allocator, alice_txn_id, "user:alice"),
+    );
+    try std.testing.expectEqual(
+        SessionRegistry.PrincipalAccess.denied,
+        try reader.principalAccess(std.testing.allocator, alice_txn_id, "user:bob"),
+    );
+    try std.testing.expectEqual(
+        SessionRegistry.PrincipalAccess.denied,
+        try reader.principalAccess(std.testing.allocator, alice_txn_id, null),
+    );
+
+    const alice_sessions = try reader.listStatusesForPrincipal(std.testing.allocator, "user:alice");
+    defer std.testing.allocator.free(alice_sessions);
+    try std.testing.expectEqual(@as(usize, 1), alice_sessions.len);
+    try std.testing.expectEqualSlices(u8, &alice_txn_id, &alice_sessions[0].txn_id);
+
+    const anonymous_sessions = try reader.listStatusesForPrincipal(std.testing.allocator, null);
+    defer std.testing.allocator.free(anonymous_sessions);
+    try std.testing.expectEqual(@as(usize, 1), anonymous_sessions.len);
 }
 
 test "durable session mutations publish only after persistence succeeds" {
@@ -3388,6 +3629,45 @@ test "transaction session registry only adopts durable sessions after lease expi
     const status = (try adopter.getStatus(std.testing.allocator, session.txn_id)).?;
     try std.testing.expectEqual(@as(u64, 12), status.owner_node_id);
     try std.testing.expect(status.lease_expires_at > session.begin_timestamp);
+}
+
+test "transaction session adoption preserves newer durable state than a local cache" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const path = try std.fmt.allocPrint(std.testing.allocator, ".zig-cache/tmp/{s}/txn-session-adopt-fresh-state", .{tmp.sub_path});
+    defer std.testing.allocator.free(path);
+    const path_z = try std.testing.allocator.dupeZ(u8, path);
+    defer std.testing.allocator.free(path_z);
+
+    var store = try docstore_mod.DocStore.open(std.testing.allocator, path_z, .{});
+    defer store.close();
+    var durable = DurableSessionStore.init(std.testing.allocator, &store);
+    const lease_store = SessionLeaseStore.init(std.testing.allocator, &store);
+
+    var writer = SessionRegistry.initWithLeaseTtl(&durable, lease_store, std.time.ns_per_s);
+    defer writer.deinit(std.testing.allocator);
+    const session = try writer.begin(std.testing.allocator, .{ .sync_level = .write }, 9);
+
+    var adopter = SessionRegistry.initWithLeaseTtl(&durable, lease_store, std.time.ns_per_s);
+    defer adopter.deinit(std.testing.allocator);
+    // Model a non-owner status request that populated an initial local copy.
+    _ = (try adopter.getStatus(std.testing.allocator, session.txn_id)) orelse return error.TestExpectedEqual;
+
+    var stage_req = try parseStageWriteRequest(std.testing.allocator, "{\"table\":\"docs\",\"key\":\"doc:a\",\"document\":{\"title\":\"newer durable state\"}}");
+    defer stage_req.deinit(std.testing.allocator);
+    _ = try writer.stage(std.testing.allocator, session.txn_id, &stage_req);
+
+    var renewed_lease = (try lease_store.load(std.testing.allocator, session.txn_id)).?;
+    defer lease_mod.deinitRecord(std.testing.allocator, &renewed_lease);
+    const expired_now = renewed_lease.expires_at_ms * std.time.ns_per_ms + 1;
+    try std.testing.expect(try adopter.adoptIfLeaseExpired(std.testing.allocator, session.txn_id, 12, expired_now));
+
+    var adopted = (try adopter.cloneCommitRequest(std.testing.allocator, session.txn_id, null)) orelse return error.TestExpectedEqual;
+    defer adopted.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 1), adopted.tables.len);
+    try std.testing.expectEqual(@as(usize, 1), adopted.tables[0].batch.writes.len);
+    try std.testing.expect(std.mem.indexOf(u8, adopted.tables[0].batch.writes[0].value, "newer durable state") != null);
 }
 
 test "transaction session ownership and lease transition atomically on failure" {
@@ -3620,6 +3900,17 @@ test "session cleanup response encodes removed count and cutoff" {
     defer parsed.deinit();
     try std.testing.expectEqual(@as(usize, 3), parsed.value.removed);
     try std.testing.expectEqual(@as(u64, 99), parsed.value.cutoff_ns);
+}
+
+test "transaction session lease expiry conversion saturates corrupt values" {
+    try std.testing.expectEqual(
+        std.math.maxInt(u64),
+        leaseExpiryNs(std.math.maxInt(u64)),
+    );
+    try std.testing.expectEqual(
+        @as(u64, 42 * std.time.ns_per_ms),
+        leaseExpiryNs(42),
+    );
 }
 
 test "transaction session conflict responses include version details" {

--- a/zig/pkg/antfly/src/common/http/std_http_executor.zig
+++ b/zig/pkg/antfly/src/common/http/std_http_executor.zig
@@ -242,6 +242,7 @@ pub const StdHttpExecutor = struct {
             });
         }
         for (req.headers) |header| {
+            if (!shouldForwardRequestHeader(req.headers, header.name)) continue;
             try extra_headers.append(alloc, .{
                 .name = header.name,
                 .value = header.value,
@@ -364,9 +365,63 @@ pub const StdHttpExecutor = struct {
     }
 };
 
+fn shouldForwardRequestHeader(headers: []const common.RequestHeader, name: []const u8) bool {
+    // The new client request owns framing, routing, connection lifecycle, and
+    // the two canonical headers represented separately on HttpRequest.
+    const transport_owned = [_][]const u8{
+        "authorization",
+        "connection",
+        "content-length",
+        "content-type",
+        "expect",
+        "host",
+        "keep-alive",
+        "proxy-authenticate",
+        "proxy-authorization",
+        "proxy-connection",
+        "te",
+        "trailer",
+        "transfer-encoding",
+        "upgrade",
+    };
+    for (transport_owned) |blocked| {
+        if (std.ascii.eqlIgnoreCase(name, blocked)) return false;
+    }
+
+    // RFC 9110 permits Connection to nominate additional hop-by-hop fields.
+    // Strip those tokens as well rather than forwarding connection-specific
+    // state to a different socket.
+    for (headers) |header| {
+        if (!std.ascii.eqlIgnoreCase(header.name, "connection")) continue;
+        var tokens = std.mem.splitScalar(u8, header.value, ',');
+        while (tokens.next()) |token| {
+            if (std.ascii.eqlIgnoreCase(name, std.mem.trim(u8, token, " \t"))) return false;
+        }
+    }
+    return true;
+}
+
 test "std http executor module compiles" {
     _ = StdHttpExecutorConfig;
     _ = StdHttpExecutor;
+}
+
+test "std http executor forwards only end-to-end request headers" {
+    const headers = [_]common.RequestHeader{
+        .{ .name = "Host", .value = "source.invalid" },
+        .{ .name = "Content-Length", .value = "42" },
+        .{ .name = "Content-Type", .value = "application/json" },
+        .{ .name = "Authorization", .value = "Bearer token" },
+        .{ .name = "Connection", .value = "keep-alive, X-Hop" },
+        .{ .name = "X-Hop", .value = "socket state" },
+        .{ .name = "X-Antfly-Trusted-Principal", .value = "principal-token" },
+        .{ .name = "X-Request-Id", .value = "request-1" },
+    };
+    for (headers[0..6]) |header| {
+        try std.testing.expect(!shouldForwardRequestHeader(&headers, header.name));
+    }
+    try std.testing.expect(shouldForwardRequestHeader(&headers, headers[6].name));
+    try std.testing.expect(shouldForwardRequestHeader(&headers, headers[7].name));
 }
 
 test "std http executor retires pooled connection before configured cap" {

--- a/zig/pkg/antfly/src/data/runtime.zig
+++ b/zig/pkg/antfly/src/data/runtime.zig
@@ -3345,7 +3345,7 @@ pub const DataServer = struct {
     store_capacity_probe_failures: std.atomic.Value(u64) = .init(0),
     last_store_status_report_at_ms: u64 = 0,
     last_data_raft_metadata_sync_at_ms: u64 = 0,
-    last_data_raft_placement_fingerprint: ?u64 = null,
+    last_data_raft_storage_ownership_fingerprint: ?u64 = null,
     last_data_raft_status_fingerprint: ?u64 = null,
     provision_ticks: usize = 0,
     last_provision_fingerprint: ?u64 = null,
@@ -8176,10 +8176,11 @@ pub const DataServer = struct {
         // for that group: state-machine apply is deliberately unable to create
         // storage or consult metadata after an entry has committed.
         try self.provisionSplitDestinationsBeforeRaftAdmission(snapshot, local_intents.items);
-        const placement_fingerprint = dataRaftPlacementIntentsFingerprint(local_intents.items);
-        const placement_changed = self.last_data_raft_placement_fingerprint == null or self.last_data_raft_placement_fingerprint.? != placement_fingerprint;
-        if (placement_changed) {
-            self.last_data_raft_placement_fingerprint = placement_fingerprint;
+        const storage_ownership_fingerprint = dataRaftStorageOwnershipFingerprint(local_intents.items);
+        const storage_ownership_changed = self.last_data_raft_storage_ownership_fingerprint == null or
+            self.last_data_raft_storage_ownership_fingerprint.? != storage_ownership_fingerprint;
+        if (storage_ownership_changed) {
+            self.last_data_raft_storage_ownership_fingerprint = storage_ownership_fingerprint;
             try self.invalidateRuntimeStatusForLocalPlacements(snapshot, local_intents.items);
             self.invalidateLocalGroupStatusCache();
             self.markStoreStatusDirtyImmediate();
@@ -13450,7 +13451,12 @@ fn localNodePreferredServingPeer(
     return min_node_id != null and min_node_id.? == local_node_id;
 }
 
-fn dataRaftPlacementIntentsFingerprint(intents: []const antfly.raft.PlacementIntent) u64 {
+/// Storage/runtime evidence is owned by the local replica generation, not by
+/// transient routing or Raft-membership state. Keeping this identity narrower
+/// than the complete placement intent prevents a relocation's
+/// bootstrapping/replaying/cutover updates from repeatedly deleting the fresh
+/// local status that the same relocation needs as its data-safety proof.
+fn dataRaftStorageOwnershipFingerprint(intents: []const antfly.raft.PlacementIntent) u64 {
     var hasher = std.hash.Wyhash.init(0x48f9_2026_da7a_4a17);
     hashU64(&hasher, intents.len);
     for (intents) |intent| {
@@ -13460,18 +13466,9 @@ fn dataRaftPlacementIntentsFingerprint(intents: []const antfly.raft.PlacementInt
         hashU64(&hasher, @intFromEnum(intent.record.bootstrap_mode));
         hashU64(&hasher, intent.record.metadata_version);
         hashU64(&hasher, intent.store_id);
-        hashU64(&hasher, @intFromEnum(intent.serving_state));
         hashU64(&hasher, intent.relocation_generation);
         hashU64(&hasher, intent.relocation_source_node_id);
         hashU64(&hasher, intent.relocation_source_store_id);
-        hashU64(&hasher, intent.relocation_doc_count_watermark);
-        hashU64(&hasher, intent.relocation_disk_bytes_watermark);
-        hashU64(&hasher, intent.relocation_target_sequence);
-        hashU64(&hasher, intent.relocation_applied_sequence);
-        hashU64(&hasher, intent.peer_node_ids.len);
-        for (intent.peer_node_ids) |peer_node_id| hashU64(&hasher, peer_node_id);
-        hashU64(&hasher, intent.learner_node_ids.len);
-        for (intent.learner_node_ids) |learner_node_id| hashU64(&hasher, learner_node_id);
         if (intent.record.snapshot_bootstrap) |snapshot| {
             hashU64(&hasher, 1);
             hashU64(&hasher, snapshot.from_node_id);
@@ -15291,7 +15288,7 @@ test "data runtime local group status fingerprint includes live raft state" {
     try std.testing.expect(base != after_same_count_membership_change);
 }
 
-test "data runtime placement fingerprint covers relocation ownership" {
+test "data runtime storage ownership fingerprint excludes transient placement progress" {
     var intent: antfly.raft.PlacementIntent = .{
         .record = .{
             .group_id = 77,
@@ -15309,18 +15306,23 @@ test "data runtime placement fingerprint covers relocation ownership" {
         .relocation_disk_bytes_watermark = 4096,
         .relocation_target_sequence = 72,
     };
-    const initial = dataRaftPlacementIntentsFingerprint(&.{intent});
+    const initial = dataRaftStorageOwnershipFingerprint(&.{intent});
 
     intent.relocation_generation += 1;
-    try std.testing.expect(initial != dataRaftPlacementIntentsFingerprint(&.{intent}));
-    const after_generation = dataRaftPlacementIntentsFingerprint(&.{intent});
+    try std.testing.expect(initial != dataRaftStorageOwnershipFingerprint(&.{intent}));
+    const after_generation = dataRaftStorageOwnershipFingerprint(&.{intent});
 
     intent.serving_state = .serving;
-    try std.testing.expect(after_generation != dataRaftPlacementIntentsFingerprint(&.{intent}));
-    const after_state = dataRaftPlacementIntentsFingerprint(&.{intent});
+    try std.testing.expectEqual(after_generation, dataRaftStorageOwnershipFingerprint(&.{intent}));
 
     intent.relocation_target_sequence += 1;
-    try std.testing.expect(after_state != dataRaftPlacementIntentsFingerprint(&.{intent}));
+    try std.testing.expectEqual(after_generation, dataRaftStorageOwnershipFingerprint(&.{intent}));
+
+    intent.peer_node_ids = &.{ 3, 4, 5, 6 };
+    try std.testing.expectEqual(after_generation, dataRaftStorageOwnershipFingerprint(&.{intent}));
+
+    intent.relocation_source_node_id += 1;
+    try std.testing.expect(after_generation != dataRaftStorageOwnershipFingerprint(&.{intent}));
 }
 
 test "data runtime overlays live raft membership onto cached storage status" {

--- a/zig/pkg/antfly/src/data/runtime.zig
+++ b/zig/pkg/antfly/src/data/runtime.zig
@@ -12555,9 +12555,12 @@ fn runtimeIndexStatusReportFromLocalIndex(
     errdefer alloc.free(name);
     const kind = try alloc.dupe(u8, @tagName(index.kind));
     errdefer alloc.free(kind);
+    const load_error = if (index.load_error) |value| try alloc.dupe(u8, value) else null;
+    errdefer if (load_error) |value| alloc.free(value);
     return .{
         .name = name,
         .kind = kind,
+        .load_error = load_error,
         .doc_count = index.doc_count,
         .term_count = index.term_count,
         .edge_count = index.edge_count,

--- a/zig/pkg/antfly/src/graph/graph.zig
+++ b/zig/pkg/antfly/src/graph/graph.zig
@@ -339,6 +339,7 @@ pub const GraphIndex = struct {
     reverse_owner: ReverseStoreOwner,
     edge_type_configs: []const EdgeTypeConfig,
     rebuild_root_path: ?[]u8,
+    rebuild_storage: ?lsm_backend.Storage,
     algebraic_semiring_traversal: bool,
     edge_count: u64,
     node_count: u64,
@@ -719,6 +720,7 @@ pub const GraphIndex = struct {
             .reverse_owner = reverse_store.owner,
             .edge_type_configs = opts.edge_type_configs,
             .rebuild_root_path = if (opts.rebuild_root_path) |path| try alloc.dupe(u8, path) else null,
+            .rebuild_storage = opts.reverse_lsm_storage,
             .algebraic_semiring_traversal = opts.algebraic_semiring_traversal,
             .edge_count = loaded_stats.edge_count,
             .node_count = loaded_stats.node_count,
@@ -1144,7 +1146,9 @@ pub const GraphIndex = struct {
     }
 
     pub fn rebuildReverseFromOwnedOutgoingEdges(self: *GraphIndex, alloc: Allocator, lower: []const u8, upper: []const u8) !usize {
-        return try self.rebuildReverseFromOwnedOutgoingEdgesResume(alloc, lower, upper, null);
+        var io_impl = std.Io.Threaded.init(alloc, .{});
+        defer io_impl.deinit();
+        return try self.rebuildReverseFromOwnedOutgoingEdgesResumeWithIo(alloc, io_impl.io(), lower, upper, null);
     }
 
     pub fn copyOwnedOutgoingEdgesTo(self: *GraphIndex, dest: *GraphIndex, alloc: Allocator, lower: []const u8, upper: []const u8) !usize {
@@ -1180,6 +1184,19 @@ pub const GraphIndex = struct {
         upper: []const u8,
         resume_from: ?[]const u8,
     ) !usize {
+        var io_impl = std.Io.Threaded.init(alloc, .{});
+        defer io_impl.deinit();
+        return try self.rebuildReverseFromOwnedOutgoingEdgesResumeWithIo(alloc, io_impl.io(), lower, upper, resume_from);
+    }
+
+    pub fn rebuildReverseFromOwnedOutgoingEdgesResumeWithIo(
+        self: *GraphIndex,
+        alloc: Allocator,
+        io: std.Io,
+        lower: []const u8,
+        upper: []const u8,
+        resume_from: ?[]const u8,
+    ) !usize {
         const base_lower_owned = if (lower.len > 0) try internal_keys.documentRangeLowerAlloc(alloc, lower) else null;
         defer if (base_lower_owned) |key| alloc.free(key);
         const range_upper_owned = if (upper.len > 0) try internal_keys.documentRangeLowerAlloc(alloc, upper) else null;
@@ -1201,7 +1218,10 @@ pub const GraphIndex = struct {
         var txn = try self.beginWriteReverseTxn();
         var txn_active = true;
         errdefer if (txn_active) txn.abort();
-        const rebuild_state = if (self.rebuild_root_path) |path| backfill_state_mod.RebuildState.init(path) else null;
+        const rebuild_state = if (self.rebuild_root_path) |path|
+            backfill_state_mod.RebuildState.initWithStorage(path, self.rebuild_storage)
+        else
+            null;
 
         for (pairs) |pair| {
             if (resume_from) |resume_key| {
@@ -1221,7 +1241,7 @@ pub const GraphIndex = struct {
             if (batch_count >= reverse_rebuild_batch_size) {
                 try txn.commit();
                 txn_active = false;
-                if (rebuild_state) |state| try state.update(pair.key);
+                if (rebuild_state) |state| try state.updateWithIo(io, pair.key);
                 flushed_batches += 1;
                 if (@import("builtin").is_test) {
                     if (test_abort_reverse_rebuild_after_batches) |limit| {
@@ -1236,7 +1256,7 @@ pub const GraphIndex = struct {
 
         try txn.commit();
         txn_active = false;
-        if (rebuild_state) |state| try state.clear();
+        if (rebuild_state) |state| try state.clearWithIo(io);
         try self.rebuildCounterMetadata();
         try self.checkpointLsmWalAfterDurableBoundary();
         return rebuilt;

--- a/zig/pkg/antfly/src/graph/graph.zig
+++ b/zig/pkg/antfly/src/graph/graph.zig
@@ -285,6 +285,7 @@ pub const GraphIndexOptions = struct {
     reverse_lsm_root_generation: u64 = 0,
     edge_type_configs: []const EdgeTypeConfig = &.{},
     rebuild_root_path: ?[]const u8 = null,
+    rebuild_owner_generation: u64 = 0,
     algebraic_semiring_traversal: bool = false,
 };
 
@@ -340,6 +341,7 @@ pub const GraphIndex = struct {
     edge_type_configs: []const EdgeTypeConfig,
     rebuild_root_path: ?[]u8,
     rebuild_storage: ?lsm_backend.Storage,
+    rebuild_owner_generation: u64,
     algebraic_semiring_traversal: bool,
     edge_count: u64,
     node_count: u64,
@@ -721,6 +723,7 @@ pub const GraphIndex = struct {
             .edge_type_configs = opts.edge_type_configs,
             .rebuild_root_path = if (opts.rebuild_root_path) |path| try alloc.dupe(u8, path) else null,
             .rebuild_storage = opts.reverse_lsm_storage,
+            .rebuild_owner_generation = opts.rebuild_owner_generation,
             .algebraic_semiring_traversal = opts.algebraic_semiring_traversal,
             .edge_count = loaded_stats.edge_count,
             .node_count = loaded_stats.node_count,
@@ -1219,7 +1222,10 @@ pub const GraphIndex = struct {
         var txn_active = true;
         errdefer if (txn_active) txn.abort();
         const rebuild_state = if (self.rebuild_root_path) |path|
-            backfill_state_mod.RebuildState.initWithStorage(path, self.rebuild_storage)
+            if (self.rebuild_owner_generation != 0)
+                backfill_state_mod.RebuildState.initOwned(path, self.rebuild_storage, self.rebuild_owner_generation)
+            else
+                backfill_state_mod.RebuildState.initWithStorage(path, self.rebuild_storage)
         else
             null;
 

--- a/zig/pkg/antfly/src/metadata/control_loop.zig
+++ b/zig/pkg/antfly/src/metadata/control_loop.zig
@@ -548,6 +548,7 @@ test "metadata control loop installs service median key lookup for automatic spl
                     .group_id = 4901,
                     .doc_count = 200,
                     .disk_bytes = 200,
+                    .disk_bytes_known = true,
                     .empty = false,
                     .updated_at_millis = now_realtime_ms,
                     .local_leader = true,

--- a/zig/pkg/antfly/src/metadata/http_server.zig
+++ b/zig/pkg/antfly/src/metadata/http_server.zig
@@ -2137,6 +2137,7 @@ const ParsedGroupStatus = struct {
 const ParsedRuntimeIndexStatus = struct {
     name: ?[]const u8 = null,
     kind: ?[]const u8 = null,
+    load_error: ?[]const u8 = null,
     doc_count: ?u64 = null,
     term_count: ?u64 = null,
     edge_count: ?u64 = null,
@@ -2466,9 +2467,12 @@ fn cloneParsedRuntimeIndexStatus(
     errdefer alloc.free(name);
     const kind = try alloc.dupe(u8, parsed.kind orelse "");
     errdefer alloc.free(kind);
+    const load_error = if (parsed.load_error) |value| try alloc.dupe(u8, value) else null;
+    errdefer if (load_error) |value| alloc.free(value);
     return .{
         .name = name,
         .kind = kind,
+        .load_error = load_error,
         .doc_count = parsed.doc_count orelse 0,
         .term_count = parsed.term_count orelse 0,
         .edge_count = parsed.edge_count orelse 0,

--- a/zig/pkg/antfly/src/metadata/reconciler.zig
+++ b/zig/pkg/antfly/src/metadata/reconciler.zig
@@ -863,6 +863,14 @@ pub const Reconciler = struct {
                         .table_id = table.table_id,
                         .donor_group_id = right.group_id,
                         .receiver_group_id = left.group_id,
+                        // Independently-created adjacent ranges own distinct
+                        // doc-identity namespaces and require reassignment.
+                        // Split siblings retain one namespace and avoid that
+                        // extra transition. Planning reaches this point only
+                        // when reassignment is safe; non-empty incompatible
+                        // namespaces remain fenced above.
+                        .allow_doc_identity_reassignment = table_manager.rangeDocIdentityShardId(left) != table_manager.rangeDocIdentityShardId(right) or
+                            table_manager.rangeDocIdentityRangeId(left) != table_manager.rangeDocIdentityRangeId(right),
                         .automatic = true,
                     };
                     try merge_intents.append(self.alloc, intent);

--- a/zig/pkg/antfly/src/metadata/reconciler.zig
+++ b/zig/pkg/antfly/src/metadata/reconciler.zig
@@ -249,7 +249,7 @@ pub const Reconciler = struct {
         defer manager.freeTables(self.alloc, desired_tables);
         var evidence = try StoreEvidenceIndex.init(self.alloc, current);
         defer evidence.deinit();
-        try self.syncAutomaticShardIntents(
+        const automatic_shard_planning_conclusive = try self.syncAutomaticShardIntents(
             manager,
             current,
             &evidence,
@@ -716,13 +716,15 @@ pub const Reconciler = struct {
         plan.rebalance_placement_groups = rebalance_placement_groups;
         plan.forced_reallocation = current.reallocation_request != null;
         // Reallocation is a level-triggered replicated intent. Do not consume
-        // it unless this round was allowed to run forced placement planning
-        // with fully converged membership. Splits, merges, and unconverged
-        // groups defer the intent so a single unlucky reconcile round cannot
-        // permanently lose the operator's request.
+        // it unless this round completed both forced placement planning and
+        // the forced shard scan with fully converged evidence. Splits, merges,
+        // observation gaps, and unconverged groups defer the intent so a
+        // single unlucky reconcile round cannot permanently lose the
+        // operator's request.
         if (force_placement_reallocation and
             protected_placement_groups.len == 0 and
-            placement_candidate_info.len != 0)
+            placement_candidate_info.len != 0 and
+            automatic_shard_planning_conclusive)
         {
             plan.clear_reallocation_request = current.reallocation_request.?.request_id;
         }
@@ -736,7 +738,7 @@ pub const Reconciler = struct {
         evidence: *const StoreEvidenceIndex,
         now_monotonic_ms: u64,
         now_realtime_ms: u64,
-    ) !void {
+    ) !bool {
         var auto_transitions = try self.computeAutomaticShardTransitions(
             current,
             evidence,
@@ -744,11 +746,15 @@ pub const Reconciler = struct {
             now_realtime_ms,
         );
         defer auto_transitions.deinit(self.alloc);
+        var planning_conclusive = auto_transitions.planning_conclusive;
 
         var desired_split_ids = std.ArrayListUnmanaged(u64).empty;
         defer desired_split_ids.deinit(self.alloc);
         for (auto_transitions.splits) |intent| {
-            if (managerGroupBusy(manager, intent.source_group_id, intent.destination_group_id, intent.transition_id)) continue;
+            if (managerGroupBusy(manager, intent.source_group_id, intent.destination_group_id, intent.transition_id)) {
+                planning_conclusive = false;
+                continue;
+            }
             try manager.requestSplit(intent);
             try desired_split_ids.append(self.alloc, intent.transition_id);
         }
@@ -756,12 +762,16 @@ pub const Reconciler = struct {
         var desired_merge_ids = std.ArrayListUnmanaged(u64).empty;
         defer desired_merge_ids.deinit(self.alloc);
         for (auto_transitions.merges) |intent| {
-            if (managerGroupBusy(manager, intent.donor_group_id, intent.receiver_group_id, intent.transition_id)) continue;
+            if (managerGroupBusy(manager, intent.donor_group_id, intent.receiver_group_id, intent.transition_id)) {
+                planning_conclusive = false;
+                continue;
+            }
             try manager.requestMerge(intent);
             try desired_merge_ids.append(self.alloc, intent.transition_id);
         }
 
         try pruneAutomaticIntents(self.alloc, manager, current, desired_split_ids.items, desired_merge_ids.items);
+        return planning_conclusive;
     }
 
     fn computeAutomaticShardTransitions(
@@ -817,6 +827,8 @@ pub const Reconciler = struct {
             for (merge_intents.items) |intent| freeMergeIntentOwned(self.alloc, intent);
             merge_intents.deinit(self.alloc);
         }
+        const require_conclusive_scan = current.reallocation_request != null;
+        var planning_conclusive = true;
 
         for (current.tables) |table| {
             if (remaining_cluster_budget == 0) break;
@@ -827,8 +839,10 @@ pub const Reconciler = struct {
             table_budget -= active_table;
 
             const table_ranges = planning_index.rangesForTable(table.table_id);
-            var planned_shards = std.math.cast(u32, table_ranges.len) orelse
+            var planned_shards = std.math.cast(u32, table_ranges.len) orelse {
+                if (require_conclusive_scan) planning_conclusive = false;
                 continue;
+            };
 
             if (planned_shards > min_shards_per_table and table_budget > 0 and remaining_cluster_budget > 0) {
                 var i: usize = 0;
@@ -836,18 +850,44 @@ pub const Reconciler = struct {
                     const left = table_ranges[i];
                     const right = table_ranges[i + 1];
                     if (!rangesAdjacent(left, right)) continue;
-                    if (planning_index.groupBusy(left.group_id) or planning_index.groupBusy(right.group_id)) continue;
-                    if (self.isShardInCooldown(left.group_id, now_monotonic_ms) or self.isShardInCooldown(right.group_id, now_monotonic_ms)) continue;
-                    const left_status = evidence.mergedStatus(current, left.group_id) orelse continue;
-                    const right_status = evidence.mergedStatus(current, right.group_id) orelse continue;
+                    if (planning_index.groupBusy(left.group_id) or planning_index.groupBusy(right.group_id)) {
+                        if (require_conclusive_scan) planning_conclusive = false;
+                        continue;
+                    }
+                    if (self.isShardInCooldown(left.group_id, now_monotonic_ms) or self.isShardInCooldown(right.group_id, now_monotonic_ms)) {
+                        if (require_conclusive_scan) planning_conclusive = false;
+                        continue;
+                    }
+                    const left_status = evidence.mergedStatus(current, left.group_id) orelse {
+                        if (require_conclusive_scan) planning_conclusive = false;
+                        continue;
+                    };
+                    const right_status = evidence.mergedStatus(current, right.group_id) orelse {
+                        if (require_conclusive_scan) planning_conclusive = false;
+                        continue;
+                    };
                     if (!evidence.hasFullHealthyPlacement(left.group_id, left_status) or
                         !evidence.hasFullHealthyPlacement(right.group_id, right_status))
                     {
+                        if (require_conclusive_scan) planning_conclusive = false;
                         continue;
                     }
-                    if (!groupStatusFresh(self.config, left_status, now_realtime_ms) or !groupStatusFresh(self.config, right_status, now_realtime_ms)) continue;
-                    if (!groupStatusReadyForAutomaticPlanning(left_status) or !groupStatusReadyForAutomaticPlanning(right_status)) continue;
-                    if (!self.groupOldEnoughForMerge(left_status, now_realtime_ms) or !self.groupOldEnoughForMerge(right_status, now_realtime_ms)) continue;
+                    if (!groupStatusFresh(self.config, left_status, now_realtime_ms) or !groupStatusFresh(self.config, right_status, now_realtime_ms)) {
+                        if (require_conclusive_scan) planning_conclusive = false;
+                        continue;
+                    }
+                    if (!groupStatusReadyForAutomaticPlanning(left_status) or !groupStatusReadyForAutomaticPlanning(right_status)) {
+                        if (require_conclusive_scan) planning_conclusive = false;
+                        continue;
+                    }
+                    if (!groupSizeObservationConclusive(left_status) or !groupSizeObservationConclusive(right_status)) {
+                        if (require_conclusive_scan) planning_conclusive = false;
+                        continue;
+                    }
+                    if (!self.groupOldEnoughForMerge(left_status, now_realtime_ms) or !self.groupOldEnoughForMerge(right_status, now_realtime_ms)) {
+                        if (require_conclusive_scan) planning_conclusive = false;
+                        continue;
+                    }
                     if (!docIdentityNamespacesCompatibleForAutomaticMerge(left_status, right_status)) continue;
 
                     const left_size = left_status.disk_bytes;
@@ -885,34 +925,77 @@ pub const Reconciler = struct {
 
             for (table_ranges) |range| {
                 if (planned_shards >= max_shards_per_table or table_budget == 0 or remaining_cluster_budget == 0) break;
-                if (planning_index.groupBusy(range.group_id)) continue;
-                if (self.isShardInCooldown(range.group_id, now_monotonic_ms)) continue;
-                const status = evidence.mergedStatus(current, range.group_id) orelse continue;
-                if (!evidence.hasFullHealthyPlacement(range.group_id, status)) continue;
-                if (!groupStatusFresh(self.config, status, now_realtime_ms)) continue;
-                if (!groupStatusReadyForAutomaticPlanning(status)) continue;
-                if (!docIdentityNamespaceReadyForAutomaticSplit(status)) continue;
+                if (planning_index.groupBusy(range.group_id)) {
+                    if (require_conclusive_scan) planning_conclusive = false;
+                    continue;
+                }
+                if (self.isShardInCooldown(range.group_id, now_monotonic_ms)) {
+                    if (require_conclusive_scan) planning_conclusive = false;
+                    continue;
+                }
+                const status = evidence.mergedStatus(current, range.group_id) orelse {
+                    if (require_conclusive_scan) planning_conclusive = false;
+                    continue;
+                };
+                if (!evidence.hasFullHealthyPlacement(range.group_id, status)) {
+                    if (require_conclusive_scan) planning_conclusive = false;
+                    continue;
+                }
+                if (!groupStatusFresh(self.config, status, now_realtime_ms)) {
+                    if (require_conclusive_scan) planning_conclusive = false;
+                    continue;
+                }
+                if (!groupStatusReadyForAutomaticPlanning(status)) {
+                    if (require_conclusive_scan) planning_conclusive = false;
+                    continue;
+                }
+                if (!groupSizeObservationConclusive(status)) {
+                    if (require_conclusive_scan) planning_conclusive = false;
+                    continue;
+                }
+                if (!docIdentityNamespaceReadyForAutomaticSplit(status)) {
+                    if (require_conclusive_scan) planning_conclusive = false;
+                    continue;
+                }
                 if (status.disk_bytes <= self.config.max_shard_size_bytes) continue;
-                const lookup = self.config.median_key_lookup orelse continue;
+                const lookup = self.config.median_key_lookup orelse {
+                    if (require_conclusive_scan) planning_conclusive = false;
+                    continue;
+                };
                 const owned_split_key = (lookup.fetchMedianKey(
                     self.alloc,
                     range.group_id,
                 ) catch |err| switch (err) {
                     error.OutOfMemory => return err,
-                    else => continue,
-                }) orelse continue;
+                    else => {
+                        if (require_conclusive_scan) planning_conclusive = false;
+                        continue;
+                    },
+                }) orelse {
+                    if (require_conclusive_scan) planning_conclusive = false;
+                    continue;
+                };
                 var split_key_consumed = false;
                 defer if (!split_key_consumed) self.alloc.free(owned_split_key);
                 if (status.doc_count > 0 and status.doc_count < 2) continue;
-                if (owned_split_key.len == 0) continue;
-                if (!keyStrictlyInsideRange(owned_split_key, range.start_key, range.end_key)) continue;
+                if (owned_split_key.len == 0) {
+                    if (require_conclusive_scan) planning_conclusive = false;
+                    continue;
+                }
+                if (!keyStrictlyInsideRange(owned_split_key, range.start_key, range.end_key)) {
+                    if (require_conclusive_scan) planning_conclusive = false;
+                    continue;
+                }
 
                 const destination_group_id = deriveAutomaticSplitDestinationId(
                     &planning_index,
                     range.group_id,
                     owned_split_key,
                 );
-                if (destination_group_id == 0) continue;
+                if (destination_group_id == 0) {
+                    if (require_conclusive_scan) planning_conclusive = false;
+                    continue;
+                }
                 const transition_id = deriveAutomaticTransitionId("split", range.group_id, destination_group_id, owned_split_key);
                 const intent: table_manager.SplitIntent = .{
                     .transition_id = transition_id,
@@ -936,6 +1019,7 @@ pub const Reconciler = struct {
         errdefer transitions.deinit(self.alloc);
         transitions.splits = try split_intents.toOwnedSlice(self.alloc);
         transitions.merges = try merge_intents.toOwnedSlice(self.alloc);
+        transitions.planning_conclusive = planning_conclusive;
         return transitions;
     }
 
@@ -1011,11 +1095,15 @@ pub const Reconciler = struct {
 const AutomaticTransitions = struct {
     splits: []table_manager.SplitIntent,
     merges: []table_manager.MergeIntent,
+    /// A forced, level-triggered scan may only be acknowledged after every
+    /// relevant range had enough stable evidence to reach a decision.
+    planning_conclusive: bool = true,
 
     fn empty() AutomaticTransitions {
         return .{
             .splits = &.{},
             .merges = &.{},
+            .planning_conclusive = true,
         };
     }
 
@@ -2927,6 +3015,14 @@ fn groupStatusReadyForAutomaticPlanning(status: MergedGroupStatus) bool {
         !status.cutover_ready and
         !status.reads_ready_after_cutover and
         !status.restore_pending;
+}
+
+fn groupSizeObservationConclusive(status: MergedGroupStatus) bool {
+    if (!status.disk_bytes_known) return false;
+    // A non-empty replica necessarily owns primary storage. A known zero
+    // paired with live documents is a transient status-publication boundary,
+    // not evidence that the shard is below its split threshold.
+    return status.doc_count == 0 or status.disk_bytes != 0;
 }
 
 fn managerGroupBusy(
@@ -6270,6 +6366,7 @@ test "metadata reconciler plans an automatic split from fresh group status" {
                     .group_id = 4001,
                     .doc_count = 200,
                     .disk_bytes = 200,
+                    .disk_bytes_known = true,
                     .empty = false,
                     .updated_at_millis = now_ms,
                     .local_leader = true,
@@ -6484,6 +6581,7 @@ test "metadata reconciler plans an automatic split from disk size when doc count
                     .group_id = 4101,
                     .doc_count = 0,
                     .disk_bytes = 200,
+                    .disk_bytes_known = true,
                     .empty = false,
                     .updated_at_millis = now_ms,
                     .local_leader = true,
@@ -7007,6 +7105,7 @@ test "metadata reconciler plans an automatic merge from adjacent small fresh gro
                     .group_id = 4101,
                     .doc_count = 10,
                     .disk_bytes = 20,
+                    .disk_bytes_known = true,
                     .empty = false,
                     .updated_at_millis = now_ms,
                     .local_leader = true,
@@ -7019,6 +7118,7 @@ test "metadata reconciler plans an automatic merge from adjacent small fresh gro
                     .group_id = 4102,
                     .doc_count = 8,
                     .disk_bytes = 15,
+                    .disk_bytes_known = true,
                     .empty = false,
                     .updated_at_millis = now_ms,
                     .local_leader = true,
@@ -8000,6 +8100,7 @@ test "metadata reconciler merges shards once they are older than the merge age t
                     .group_id = 41111,
                     .doc_count = 10,
                     .disk_bytes = 20,
+                    .disk_bytes_known = true,
                     .empty = false,
                     .created_at_millis = now_realtime_ms - 2 * 60 * std.time.ms_per_s,
                     .updated_at_millis = now_realtime_ms,
@@ -8013,6 +8114,7 @@ test "metadata reconciler merges shards once they are older than the merge age t
                     .group_id = 41112,
                     .doc_count = 8,
                     .disk_bytes = 15,
+                    .disk_bytes_known = true,
                     .empty = false,
                     .created_at_millis = now_realtime_ms - 2 * 60 * std.time.ms_per_s,
                     .updated_at_millis = now_realtime_ms,
@@ -8211,6 +8313,7 @@ test "metadata reconciler enforces per-table automatic transition budget" {
                     .group_id = 4131,
                     .doc_count = 200,
                     .disk_bytes = 200,
+                    .disk_bytes_known = true,
                     .empty = false,
                     .updated_at_millis = now_ms,
                     .local_leader = true,
@@ -8223,6 +8326,7 @@ test "metadata reconciler enforces per-table automatic transition budget" {
                     .group_id = 4132,
                     .doc_count = 220,
                     .disk_bytes = 220,
+                    .disk_bytes_known = true,
                     .empty = false,
                     .updated_at_millis = now_ms,
                     .local_leader = true,
@@ -8297,6 +8401,7 @@ test "metadata reconciler enforces cluster automatic transition budget" {
                     .group_id = 4141,
                     .doc_count = 200,
                     .disk_bytes = 200,
+                    .disk_bytes_known = true,
                     .empty = false,
                     .updated_at_millis = now_ms,
                     .local_leader = true,
@@ -8309,6 +8414,7 @@ test "metadata reconciler enforces cluster automatic transition budget" {
                     .group_id = 4151,
                     .doc_count = 210,
                     .disk_bytes = 210,
+                    .disk_bytes_known = true,
                     .empty = false,
                     .updated_at_millis = now_ms,
                     .local_leader = true,
@@ -8377,6 +8483,7 @@ test "metadata reconciler respects disable shard alloc unless reallocation is re
                     .group_id = 4201,
                     .doc_count = 200,
                     .disk_bytes = 200,
+                    .disk_bytes_known = true,
                     .empty = false,
                     .updated_at_millis = now_ms,
                     .local_leader = true,
@@ -8388,6 +8495,13 @@ test "metadata reconciler respects disable shard alloc unless reallocation is re
             })[0..]),
         },
     };
+    const candidates = [_]@import("state.zig").CandidatePlacementInfo{.{
+        .node_id = 1,
+        .store_id = 1,
+        .role = "data",
+        .failure_domain = "rack-a",
+        .retain_current = true,
+    }};
 
     var lookup = TestMedianKeyLookup{ .median_key = "doc:m" };
     var reconciler = Reconciler.initWithConfig(std.testing.allocator, .{
@@ -8408,7 +8522,33 @@ test "metadata reconciler respects disable shard alloc unless reallocation is re
     try std.testing.expectEqual(@as(usize, 0), blocked_plan.split_upserts.len);
     try std.testing.expect(blocked_plan.clear_reallocation_request == null);
 
-    var forced_plan = try reconciler.computePlan(&manager, &.{}, &.{}, .{
+    const inconsistent_reports = [_]table_manager.GroupStatusReport{.{
+        .group_id = 4201,
+        .doc_count = 200,
+        .disk_bytes = 0,
+        .disk_bytes_known = true,
+        .empty = false,
+        .updated_at_millis = now_ms,
+        .local_leader = true,
+        .local_voter = true,
+        .voter_count = 1,
+        .voter_set_known = true,
+        .voter_set_fingerprint = voter_set_fingerprint,
+    }};
+    var inconsistent_stores = stores;
+    inconsistent_stores[0].group_statuses = @constCast(inconsistent_reports[0..]);
+    var inconclusive_plan = try reconciler.computePlan(&manager, &.{1}, &candidates, .{
+        .tables = tables,
+        .ranges = ranges,
+        .placement_intents = &placements,
+        .stores = &inconsistent_stores,
+        .reallocation_request = .{ .request_id = 1, .requested_at_ms = 1 },
+    });
+    defer inconclusive_plan.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 0), inconclusive_plan.split_admissions.len);
+    try std.testing.expect(inconclusive_plan.clear_reallocation_request == null);
+
+    var forced_plan = try reconciler.computePlan(&manager, &.{1}, &candidates, .{
         .tables = tables,
         .ranges = ranges,
         .placement_intents = &placements,
@@ -8418,9 +8558,8 @@ test "metadata reconciler respects disable shard alloc unless reallocation is re
     defer forced_plan.deinit(std.testing.allocator);
     try std.testing.expectEqual(@as(usize, 1), forced_plan.split_admissions.len);
     try std.testing.expect(forced_plan.forced_reallocation);
-    // The request admitted the split, but no placement candidates were
-    // available in this round. Keep it durable until a later round can run
-    // the complete forced-placement plan.
+    // The request admitted the split. Keep it durable until that transition
+    // completes, then a later round can conclusively scan the new topology.
     try std.testing.expect(forced_plan.clear_reallocation_request == null);
 }
 
@@ -8826,6 +8965,7 @@ test "metadata reconciler uses live median key lookup for split planning" {
                     .group_id = 4701,
                     .doc_count = 240,
                     .disk_bytes = 240,
+                    .disk_bytes_known = true,
                     .empty = false,
                     .updated_at_millis = now_ms - 5,
                     .local_leader = true,
@@ -8848,6 +8988,7 @@ test "metadata reconciler uses live median key lookup for split planning" {
                     .group_id = 4701,
                     .doc_count = 240,
                     .disk_bytes = 240,
+                    .disk_bytes_known = true,
                     .empty = false,
                     .updated_at_millis = now_ms,
                     .local_leader = false,
@@ -9066,6 +9207,7 @@ test "metadata reconciler prefers live median key lookup for automatic split" {
                     .group_id = 4811,
                     .doc_count = 200,
                     .disk_bytes = 200,
+                    .disk_bytes_known = true,
                     .empty = false,
                     .updated_at_millis = now_ms,
                     .local_leader = true,

--- a/zig/pkg/antfly/src/metadata/service.zig
+++ b/zig/pkg/antfly/src/metadata/service.zig
@@ -6166,6 +6166,14 @@ fn collectLocalStoreStatusReport(
         const millis = std.math.clamp(avg_progress * 1000.0, 0.0, 1000.0);
         report.backfill_progress_millis = @intFromFloat(millis);
     }
+    report.runtime_statuses = try collectQuarantinedBackfillRuntimeStatuses(
+        alloc,
+        backfill_markers,
+        store.store_id,
+        store.node_id,
+        true,
+    );
+    errdefer metadata_table_manager.freeRuntimeGroupStatusReports(alloc, report.runtime_statuses);
     report.group_statuses = try metadata_table_manager.cloneGroupStatuses(alloc, group_statuses);
     return report;
 }
@@ -6185,7 +6193,13 @@ fn collectSharedRootLocalStoreStatusReports(
 ) ![]metadata_table_manager.StoreStatusReport {
     _ = service;
     var reports = try alloc.alloc(metadata_table_manager.StoreStatusReport, stores.len);
-    errdefer alloc.free(reports);
+    errdefer {
+        for (reports) |report| {
+            metadata_table_manager.freeGroupStatuses(alloc, report.group_statuses);
+            metadata_table_manager.freeRuntimeGroupStatusReports(alloc, report.runtime_statuses);
+        }
+        alloc.free(reports);
+    }
     for (stores, 0..) |store, i| {
         reports[i] = .{
             .store_id = store.store_id,
@@ -6206,6 +6220,10 @@ fn collectSharedRootLocalStoreStatusReports(
     var progress_sum = try alloc.alloc(f64, stores.len);
     defer alloc.free(progress_sum);
     @memset(progress_sum, 0.0);
+    var quarantined = try alloc.alloc(std.ArrayListUnmanaged(StoreStatusBackfillMarker), stores.len);
+    defer alloc.free(quarantined);
+    for (quarantined) |*list| list.* = .empty;
+    defer for (quarantined) |*list| list.deinit(alloc);
 
     for (backfill_markers) |marker| {
         if (marker.store_id != null) continue;
@@ -6219,6 +6237,7 @@ fn collectSharedRootLocalStoreStatusReports(
             &reports[report_index].active_backfills,
             &progress_sum[report_index],
         );
+        if (marker.state == .corrupt) try quarantined[report_index].append(alloc, marker);
     }
 
     for (reports, 0..) |*report, i| {
@@ -6229,6 +6248,15 @@ fn collectSharedRootLocalStoreStatusReports(
     }
     for (reports) |*report| {
         report.group_statuses = try metadata_table_manager.cloneGroupStatuses(alloc, group_statuses);
+    }
+    for (reports, 0..) |*report, i| {
+        report.runtime_statuses = try collectQuarantinedBackfillRuntimeStatuses(
+            alloc,
+            quarantined[i].items,
+            report.store_id,
+            stores[i].node_id,
+            true,
+        );
     }
     return reports;
 }
@@ -6762,7 +6790,21 @@ const StoreStatusBackfillMarker = struct {
     store_id: ?u64,
     group_id: u64,
     path: []const u8,
-    resume_key: ?[]const u8 = null,
+    state: State = .absent,
+
+    const State = union(enum) {
+        absent,
+        legacy,
+        corrupt,
+        valid: []const u8,
+
+        fn deinit(self: State, alloc: std.mem.Allocator) void {
+            switch (self) {
+                .valid => |resume_key| alloc.free(resume_key),
+                else => {},
+            }
+        }
+    };
 };
 
 const StoreStatusBackfillMarkerCache = struct {
@@ -6801,9 +6843,9 @@ fn maybeRefreshStoreStatusBackfillMarkerCache(
     if (!should_rescan) return;
 
     const markers = try collectStoreStatusBackfillMarkers(alloc, replica_root_dir);
-    const markers_missing_resume_keys = storeStatusBackfillMarkersHaveMissingResumeKeys(markers);
+    const markers_missing_state = storeStatusBackfillMarkersHaveMissingState(markers);
     cache.replace(alloc, markers, now_ms);
-    cache.rescan_requested = markers_missing_resume_keys;
+    cache.rescan_requested = markers_missing_state;
     probe_ticks.* = 0;
 }
 
@@ -6814,9 +6856,9 @@ fn refreshStoreStatusBackfillMarkerCacheNow(
     cache: *StoreStatusBackfillMarkerCache,
 ) !void {
     const markers = try collectStoreStatusBackfillMarkers(alloc, replica_root_dir);
-    const markers_missing_resume_keys = storeStatusBackfillMarkersHaveMissingResumeKeys(markers);
+    const markers_missing_state = storeStatusBackfillMarkersHaveMissingState(markers);
     cache.replace(alloc, markers, monotonicMs());
-    cache.rescan_requested = markers_missing_resume_keys;
+    cache.rescan_requested = markers_missing_state;
     probe_ticks.* = 0;
 }
 
@@ -6824,27 +6866,29 @@ fn monotonicMs() u64 {
     return @intCast(@divTrunc(platform_time.monotonicNs(), std.time.ns_per_ms));
 }
 
-fn scanStoreStatusBackfillMarkers(alloc: std.mem.Allocator, replica_root_dir: []const u8) ![]StoreStatusBackfillMarker {
-    var io_impl = std.Io.Threaded.init(alloc, .{});
-    defer io_impl.deinit();
-    var root_dir = std.Io.Dir.cwd().openDir(io_impl.io(), replica_root_dir, .{ .iterate = true }) catch |err| switch (err) {
+fn scanStoreStatusBackfillMarkersWithIo(
+    alloc: std.mem.Allocator,
+    io: std.Io,
+    replica_root_dir: []const u8,
+) ![]StoreStatusBackfillMarker {
+    var root_dir = std.Io.Dir.cwd().openDir(io, replica_root_dir, .{ .iterate = true }) catch |err| switch (err) {
         error.FileNotFound => return &.{},
         else => return err,
     };
-    defer root_dir.close(io_impl.io());
+    defer root_dir.close(io);
 
     var markers = std.ArrayListUnmanaged(StoreStatusBackfillMarker).empty;
     errdefer {
         for (markers.items) |marker| {
             alloc.free(marker.path);
-            if (marker.resume_key) |resume_key| alloc.free(resume_key);
+            marker.state.deinit(alloc);
         }
         markers.deinit(alloc);
     }
 
     var walker = try root_dir.walk(alloc);
     defer walker.deinit();
-    while (try walker.next(io_impl.io())) |entry| {
+    while (try walker.next(io)) |entry| {
         if (entry.kind != .file) continue;
         if (!std.mem.endsWith(u8, entry.path, "/rebuild.state")) continue;
         const parsed = parseStoreStatusBackfillMarkerPath(entry.path) orelse continue;
@@ -6863,31 +6907,40 @@ fn scanStoreStatusBackfillMarkers(alloc: std.mem.Allocator, replica_root_dir: []
 
 fn loadStoreStatusBackfillMarkerResumeKeys(
     alloc: std.mem.Allocator,
+    io: std.Io,
     replica_root_dir: []const u8,
     markers: []StoreStatusBackfillMarker,
 ) !void {
-    _ = try refreshStoreStatusBackfillMarkerResumeKeys(alloc, replica_root_dir, markers);
+    _ = try refreshStoreStatusBackfillMarkerResumeKeys(alloc, io, replica_root_dir, markers);
 }
 
 fn refreshStoreStatusBackfillMarkerResumeKeys(
     alloc: std.mem.Allocator,
+    io: std.Io,
     replica_root_dir: []const u8,
     markers: []StoreStatusBackfillMarker,
 ) !bool {
     var any_missing = false;
 
     for (markers) |*marker| {
-        if (marker.resume_key) |resume_key| {
-            alloc.free(resume_key);
-            marker.resume_key = null;
-        }
+        marker.state.deinit(alloc);
+        marker.state = .absent;
         const state_path = try std.fmt.allocPrint(alloc, "{s}/{s}", .{ replica_root_dir, marker.path });
         defer alloc.free(state_path);
-        marker.resume_key = rebuildStateForPath(state_path).check(alloc) catch |err| switch (err) {
-            error.InvalidRebuildState => null,
-            else => return err,
+        var loaded = try rebuildStateForPath(state_path).loadWithIo(alloc, io);
+        marker.state = switch (loaded) {
+            .absent => .absent,
+            .legacy => .legacy,
+            .corrupt => blk: {
+                std.log.warn("derived index rebuild state quarantined path={s}", .{state_path});
+                break :blk .corrupt;
+            },
+            .valid => |resume_key| blk: {
+                loaded = undefined;
+                break :blk .{ .valid = resume_key };
+            },
         };
-        if (marker.resume_key == null) any_missing = true;
+        if (marker.state == .absent) any_missing = true;
     }
     return any_missing;
 }
@@ -6897,17 +6950,35 @@ fn rebuildStateForPath(path: []const u8) backfill_state_mod.RebuildState {
 }
 
 fn collectStoreStatusBackfillMarkers(alloc: std.mem.Allocator, replica_root_dir: []const u8) ![]StoreStatusBackfillMarker {
-    const markers = try scanStoreStatusBackfillMarkers(alloc, replica_root_dir);
+    var io_impl = std.Io.Threaded.init(alloc, .{});
+    defer io_impl.deinit();
+    const io = io_impl.io();
+    const markers = try scanStoreStatusBackfillMarkersWithIo(alloc, io, replica_root_dir);
     errdefer freeStoreStatusBackfillMarkers(alloc, markers);
-    try loadStoreStatusBackfillMarkerResumeKeys(alloc, replica_root_dir, markers);
+    try loadStoreStatusBackfillMarkerResumeKeys(alloc, io, replica_root_dir, markers);
     return markers;
 }
 
-fn storeStatusBackfillMarkersHaveMissingResumeKeys(markers: []const StoreStatusBackfillMarker) bool {
+fn storeStatusBackfillMarkersHaveMissingState(markers: []const StoreStatusBackfillMarker) bool {
     for (markers) |marker| {
-        if (marker.resume_key == null) return true;
+        if (marker.state == .absent) return true;
     }
     return false;
+}
+
+fn backfillMarkerStateFileExistsWithIo(
+    alloc: std.mem.Allocator,
+    io: std.Io,
+    replica_root_dir: []const u8,
+    marker: StoreStatusBackfillMarker,
+) !bool {
+    const state_path = try std.fmt.allocPrint(alloc, "{s}/{s}", .{ replica_root_dir, marker.path });
+    defer alloc.free(state_path);
+    std.Io.Dir.cwd().access(io, state_path, .{}) catch |err| switch (err) {
+        error.FileNotFound => return false,
+        else => return err,
+    };
+    return true;
 }
 
 fn backfillMarkerStateFileExists(
@@ -6917,13 +6988,7 @@ fn backfillMarkerStateFileExists(
 ) !bool {
     var io_impl = std.Io.Threaded.init(alloc, .{});
     defer io_impl.deinit();
-    const state_path = try std.fmt.allocPrint(alloc, "{s}/{s}", .{ replica_root_dir, marker.path });
-    defer alloc.free(state_path);
-    std.Io.Dir.cwd().access(io_impl.io(), state_path, .{}) catch |err| switch (err) {
-        error.FileNotFound => return false,
-        else => return err,
-    };
-    return true;
+    return try backfillMarkerStateFileExistsWithIo(alloc, io_impl.io(), replica_root_dir, marker);
 }
 
 fn maybeRequestStoreStatusBackfillMarkerRescan(
@@ -6936,12 +7001,14 @@ fn maybeRequestStoreStatusBackfillMarkerRescan(
     if (active_backfill_markers.len == 0) return;
     if (service.store_status_backfill_marker_cache.rescan_requested) return;
 
+    var io_impl = std.Io.Threaded.init(service.alloc, .{});
+    defer io_impl.deinit();
     for (active_backfill_markers) |marker| {
-        if (marker.resume_key == null) {
+        if (marker.state == .absent) {
             service.store_status_backfill_marker_cache.rescan_requested = true;
             return;
         }
-        if (!try backfillMarkerStateFileExists(service.alloc, replica_root_dir, marker)) {
+        if (!try backfillMarkerStateFileExistsWithIo(service.alloc, io_impl.io(), replica_root_dir, marker)) {
             service.store_status_backfill_marker_cache.rescan_requested = true;
             return;
         }
@@ -6951,7 +7018,7 @@ fn maybeRequestStoreStatusBackfillMarkerRescan(
 fn freeStoreStatusBackfillMarkers(alloc: std.mem.Allocator, markers: []const StoreStatusBackfillMarker) void {
     for (markers) |marker| {
         alloc.free(marker.path);
-        if (marker.resume_key) |resume_key| alloc.free(resume_key);
+        marker.state.deinit(alloc);
     }
     if (markers.len > 0) alloc.free(markers);
 }
@@ -6980,6 +7047,75 @@ fn storeStatusBackfillMarkerMatchesStore(marker: StoreStatusBackfillMarker, stor
     return include_unassigned;
 }
 
+fn collectQuarantinedBackfillRuntimeStatuses(
+    alloc: std.mem.Allocator,
+    markers: []const StoreStatusBackfillMarker,
+    store_id: u64,
+    node_id: u64,
+    include_unassigned: bool,
+) ![]metadata_table_manager.RuntimeGroupStatusReport {
+    var statuses = std.ArrayListUnmanaged(metadata_table_manager.RuntimeGroupStatusReport).empty;
+    errdefer {
+        for (statuses.items) |status| metadata_table_manager.freeRuntimeGroupStatusReport(alloc, status);
+        statuses.deinit(alloc);
+    }
+    for (markers) |marker| {
+        if (marker.state != .corrupt) continue;
+        if (!storeStatusBackfillMarkerMatchesStore(marker, store_id, include_unassigned)) continue;
+        const status = try quarantinedBackfillRuntimeStatus(alloc, marker, store_id, node_id);
+        errdefer metadata_table_manager.freeRuntimeGroupStatusReport(alloc, status);
+        try statuses.append(alloc, status);
+    }
+    if (statuses.items.len == 0) {
+        statuses.deinit(alloc);
+        return &.{};
+    }
+    return try statuses.toOwnedSlice(alloc);
+}
+
+fn quarantinedBackfillRuntimeStatus(
+    alloc: std.mem.Allocator,
+    marker: StoreStatusBackfillMarker,
+    store_id: u64,
+    node_id: u64,
+) !metadata_table_manager.RuntimeGroupStatusReport {
+    const index_dir = std.fs.path.dirname(marker.path) orelse return error.InvalidBackfillMarkerPath;
+    const index_name = std.fs.path.basename(index_dir);
+    const table_name = try alloc.dupe(u8, "");
+    errdefer alloc.free(table_name);
+    const source = try alloc.dupe(u8, "rebuild_state_quarantine");
+    errdefer alloc.free(source);
+    const freshness = try alloc.dupe(u8, "quarantined");
+    errdefer alloc.free(freshness);
+    const projection_checkpoint_status = try alloc.dupe(u8, "clean");
+    errdefer alloc.free(projection_checkpoint_status);
+    const owned_index_name = try alloc.dupe(u8, index_name);
+    errdefer alloc.free(owned_index_name);
+    const index_kind = try alloc.dupe(u8, "unknown");
+    errdefer alloc.free(index_kind);
+    const indexes = try alloc.alloc(metadata_table_manager.RuntimeIndexStatusReport, 1);
+    errdefer alloc.free(indexes);
+    indexes[0] = .{
+        .name = owned_index_name,
+        .kind = index_kind,
+        .backfill_active = true,
+        .backfill_progress_millis = 0,
+    };
+
+    var status: metadata_table_manager.RuntimeGroupStatusReport = .{
+        .table_name = table_name,
+        .group_id = marker.group_id,
+        .store_id = store_id,
+        .node_id = node_id,
+        .source = source,
+        .freshness = freshness,
+        .index_count = 1,
+        .indexes = indexes,
+    };
+    status.enrichment.projection_checkpoint_status = projection_checkpoint_status;
+    return status;
+}
+
 fn accumulateStoreStatusBackfillProgress(
     alloc: std.mem.Allocator,
     ranges: []const metadata_table_manager.RangeRecord,
@@ -6989,7 +7125,10 @@ fn accumulateStoreStatusBackfillProgress(
 ) !void {
     const range = findRangeByGroupId(ranges, marker.group_id) orelse return;
     active_backfills.* += 1;
-    const resume_key = marker.resume_key orelse return;
+    const resume_key = switch (marker.state) {
+        .valid => |key| key,
+        .absent, .legacy, .corrupt => return,
+    };
     const range_start = try internal_keys.documentRangeLowerAlloc(alloc, range.start_key);
     defer alloc.free(range_start);
     const range_end = if (range.end_key) |key| try internal_keys.documentRangeUpperAlloc(alloc, key) else null;
@@ -10677,6 +10816,82 @@ test "metadata service cached backfill markers rescan immediately after disappea
         &service.store_status_backfill_marker_cache,
     );
     try std.testing.expectEqual(@as(usize, 0), service.store_status_backfill_marker_cache.markers.len);
+}
+
+test "metadata service caches corrupt rebuild state and publishes quarantine status" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const cwd = try std.process.currentPathAlloc(std.testing.io, std.testing.allocator);
+    defer std.testing.allocator.free(cwd);
+    const replica_root = try std.fmt.allocPrint(std.testing.allocator, "{s}/.zig-cache/tmp/{s}/metadata-corrupt-backfill-marker-cache", .{ cwd, tmp.sub_path });
+    defer std.testing.allocator.free(replica_root);
+    const index_root = try std.fmt.allocPrint(std.testing.allocator, "{s}/group-9501/table-db/indexes/search_idx", .{replica_root});
+    defer std.testing.allocator.free(index_root);
+
+    var io_impl = std.Io.Threaded.init(std.testing.allocator, .{});
+    defer io_impl.deinit();
+    try fs_paths.createDirPathPortable(io_impl.io(), index_root);
+    const rebuild_state = backfill_state_mod.RebuildState.init(index_root);
+    try rebuild_state.updateWithIo(io_impl.io(), "doc:m");
+    const state_path = try rebuild_state.pathAlloc(std.testing.allocator);
+    defer std.testing.allocator.free(state_path);
+    const encoded = try std.Io.Dir.cwd().readFileAlloc(
+        io_impl.io(),
+        state_path,
+        std.testing.allocator,
+        .limited(64 * 1024 + 64),
+    );
+    defer std.testing.allocator.free(encoded);
+    encoded[encoded.len - 1] ^= 0xff;
+    try std.Io.Dir.cwd().writeFile(io_impl.io(), .{ .sub_path = state_path, .data = encoded });
+
+    var cache = StoreStatusBackfillMarkerCache{};
+    defer cache.deinit(std.testing.allocator);
+    var probe_ticks: usize = 0;
+    try maybeRefreshStoreStatusBackfillMarkerCache(
+        std.testing.allocator,
+        replica_root,
+        0,
+        &probe_ticks,
+        &cache,
+    );
+    try std.testing.expectEqual(@as(usize, 1), cache.markers.len);
+    try std.testing.expect(cache.markers[0].state == .corrupt);
+    try std.testing.expect(!cache.rescan_requested);
+
+    const ranges = [_]metadata_table_manager.RangeRecord{
+        .{ .group_id = 9501, .table_id = 95, .start_key = "doc:a", .end_key = "doc:z" },
+    };
+    const report = try collectLocalStoreStatusReport(
+        .{},
+        std.testing.allocator,
+        replica_root,
+        .{ .store_id = 95, .node_id = 5 },
+        &ranges,
+        &.{},
+        cache.markers,
+    );
+    defer freeOwnedStoreStatusReport(std.testing.allocator, report);
+    try std.testing.expectEqual(@as(u32, 1), report.active_backfills);
+    try std.testing.expectEqual(@as(u16, 0), report.backfill_progress_millis);
+    try std.testing.expectEqual(@as(usize, 1), report.runtime_statuses.len);
+    try std.testing.expectEqualStrings("rebuild_state_quarantine", report.runtime_statuses[0].source);
+    try std.testing.expectEqualStrings("quarantined", report.runtime_statuses[0].freshness);
+    try std.testing.expectEqual(@as(usize, 1), report.runtime_statuses[0].indexes.len);
+    try std.testing.expectEqualStrings("search_idx", report.runtime_statuses[0].indexes[0].name);
+
+    cache.scanned_at_ms = monotonicMs();
+    const scanned_at_ms = cache.scanned_at_ms;
+    try rebuild_state.updateWithIo(io_impl.io(), "doc:z");
+    try maybeRefreshStoreStatusBackfillMarkerCache(
+        std.testing.allocator,
+        replica_root,
+        0,
+        &probe_ticks,
+        &cache,
+    );
+    try std.testing.expectEqual(scanned_at_ms, cache.scanned_at_ms);
+    try std.testing.expect(cache.markers[0].state == .corrupt);
 }
 
 test "metadata service does not rescan empty backfill markers before idle interval" {

--- a/zig/pkg/antfly/src/metadata/service.zig
+++ b/zig/pkg/antfly/src/metadata/service.zig
@@ -6874,8 +6874,6 @@ fn refreshStoreStatusBackfillMarkerResumeKeys(
     replica_root_dir: []const u8,
     markers: []StoreStatusBackfillMarker,
 ) !bool {
-    var io_impl = std.Io.Threaded.init(alloc, .{});
-    defer io_impl.deinit();
     var any_missing = false;
 
     for (markers) |*marker| {
@@ -6885,15 +6883,17 @@ fn refreshStoreStatusBackfillMarkerResumeKeys(
         }
         const state_path = try std.fmt.allocPrint(alloc, "{s}/{s}", .{ replica_root_dir, marker.path });
         defer alloc.free(state_path);
-        marker.resume_key = std.Io.Dir.cwd().readFileAlloc(io_impl.io(), state_path, alloc, .limited(64 * 1024)) catch |err| switch (err) {
-            error.FileNotFound => blk: {
-                any_missing = true;
-                break :blk null;
-            },
+        marker.resume_key = rebuildStateForPath(state_path).check(alloc) catch |err| switch (err) {
+            error.InvalidRebuildState => null,
             else => return err,
         };
+        if (marker.resume_key == null) any_missing = true;
     }
     return any_missing;
+}
+
+fn rebuildStateForPath(path: []const u8) backfill_state_mod.RebuildState {
+    return backfill_state_mod.RebuildState.init(std.fs.path.dirname(path) orelse ".");
 }
 
 fn collectStoreStatusBackfillMarkers(alloc: std.mem.Allocator, replica_root_dir: []const u8) ![]StoreStatusBackfillMarker {
@@ -9779,14 +9779,7 @@ test "metadata service auto-reports local store backfill status during runRound"
 
     const state_path = try std.fmt.allocPrint(std.testing.allocator, "{s}/indexes/search_idx/rebuild.state", .{db_path});
     defer std.testing.allocator.free(state_path);
-    {
-        var file = try std.Io.Dir.cwd().createFile(io_impl.io(), state_path, .{ .truncate = true });
-        defer file.close(io_impl.io());
-        var buf: [128]u8 = undefined;
-        var writer = file.writer(io_impl.io(), &buf);
-        try writer.interface.writeAll("doc:m");
-        try writer.end();
-    }
+    try rebuildStateForPath(state_path).update("doc:m");
 
     svc.store_status_backfill_marker_cache.rescan_requested = true;
     try svc.runLifecycleRound();
@@ -9903,14 +9896,7 @@ test "metadata service reports automatic store status across shared multi-store 
 
     const state_path = try std.fmt.allocPrint(std.testing.allocator, "{s}/indexes/search_idx/rebuild.state", .{db_path});
     defer std.testing.allocator.free(state_path);
-    {
-        var file = try std.Io.Dir.cwd().createFile(io_impl.io(), state_path, .{ .truncate = true });
-        defer file.close(io_impl.io());
-        var buf: [128]u8 = undefined;
-        var writer = file.writer(io_impl.io(), &buf);
-        try writer.interface.writeAll("doc:m");
-        try writer.end();
-    }
+    try rebuildStateForPath(state_path).update("doc:m");
 
     svc.store_status_backfill_marker_cache.rescan_requested = true;
     try svc.runLifecycleRound();
@@ -10050,14 +10036,7 @@ test "metadata service reports automatic store status across explicit multi-stor
 
     const left_state_path = try std.fmt.allocPrint(std.testing.allocator, "{s}/indexes/search_idx/rebuild.state", .{left_db_path});
     defer std.testing.allocator.free(left_state_path);
-    {
-        var file = try std.Io.Dir.cwd().createFile(io_impl.io(), left_state_path, .{ .truncate = true });
-        defer file.close(io_impl.io());
-        var buf: [128]u8 = undefined;
-        var writer = file.writer(io_impl.io(), &buf);
-        try writer.interface.writeAll("doc:g");
-        try writer.end();
-    }
+    try rebuildStateForPath(left_state_path).update("doc:g");
 
     svc.store_status_backfill_marker_cache.rescan_requested = true;
     try svc.runLifecycleRound();
@@ -10177,14 +10156,7 @@ test "metadata service prefers placement-role-compatible store affinity in share
 
     const state_path = try std.fmt.allocPrint(std.testing.allocator, "{s}/indexes/search_idx/rebuild.state", .{db_path});
     defer std.testing.allocator.free(state_path);
-    {
-        var file = try std.Io.Dir.cwd().createFile(io_impl.io(), state_path, .{ .truncate = true });
-        defer file.close(io_impl.io());
-        var buf: [128]u8 = undefined;
-        var writer = file.writer(io_impl.io(), &buf);
-        try writer.interface.writeAll("doc:m");
-        try writer.end();
-    }
+    try rebuildStateForPath(state_path).update("doc:m");
 
     svc.store_status_backfill_marker_cache.rescan_requested = true;
     try svc.runLifecycleRound();
@@ -10224,14 +10196,7 @@ test "metadata service shared-root reports survive transient rebuild marker remo
 
     const state_path = try std.fmt.allocPrint(std.testing.allocator, "{s}/indexes/search_idx/rebuild.state", .{db_path});
     defer std.testing.allocator.free(state_path);
-    {
-        var file = try std.Io.Dir.cwd().createFile(io_impl.io(), state_path, .{ .truncate = true });
-        defer file.close(io_impl.io());
-        var buf: [128]u8 = undefined;
-        var writer = file.writer(io_impl.io(), &buf);
-        try writer.interface.writeAll("doc:m");
-        try writer.end();
-    }
+    try rebuildStateForPath(state_path).update("doc:m");
 
     const markers = try collectStoreStatusBackfillMarkers(std.testing.allocator, replica_root);
     defer freeStoreStatusBackfillMarkers(std.testing.allocator, markers);
@@ -10412,14 +10377,7 @@ test "metadata service lifecycle round uses cached backfill markers" {
 
     const state_path = try std.fmt.allocPrint(std.testing.allocator, "{s}/indexes/search_idx/rebuild.state", .{db_path});
     defer std.testing.allocator.free(state_path);
-    {
-        var file = try std.Io.Dir.cwd().createFile(io_impl.io(), state_path, .{ .truncate = true });
-        defer file.close(io_impl.io());
-        var buf: [128]u8 = undefined;
-        var writer = file.writer(io_impl.io(), &buf);
-        try writer.interface.writeAll("doc:m");
-        try writer.end();
-    }
+    try rebuildStateForPath(state_path).update("doc:m");
 
     svc.store_status_backfill_marker_cache.replace(
         std.testing.allocator,
@@ -10540,14 +10498,7 @@ test "metadata service lifecycle round discovers backfill markers immediately" {
 
     const state_path = try std.fmt.allocPrint(std.testing.allocator, "{s}/indexes/search_idx/rebuild.state", .{db_path});
     defer std.testing.allocator.free(state_path);
-    {
-        var file = try std.Io.Dir.cwd().createFile(io_impl.io(), state_path, .{ .truncate = true });
-        defer file.close(io_impl.io());
-        var buf: [128]u8 = undefined;
-        var writer = file.writer(io_impl.io(), &buf);
-        try writer.interface.writeAll("doc:m");
-        try writer.end();
-    }
+    try rebuildStateForPath(state_path).update("doc:m");
 
     try std.testing.expectEqual(@as(usize, 0), svc.store_status_backfill_marker_cache.markers.len);
     svc.store_status_backfill_marker_cache.rescan_requested = true;
@@ -10682,14 +10633,7 @@ test "metadata service cached backfill markers rescan immediately after disappea
 
     const state_path = try std.fmt.allocPrint(std.testing.allocator, "{s}/indexes/search_idx/rebuild.state", .{db_path});
     defer std.testing.allocator.free(state_path);
-    {
-        var file = try std.Io.Dir.cwd().createFile(io_impl.io(), state_path, .{ .truncate = true });
-        defer file.close(io_impl.io());
-        var buf: [128]u8 = undefined;
-        var writer = file.writer(io_impl.io(), &buf);
-        try writer.interface.writeAll("doc:m");
-        try writer.end();
-    }
+    try rebuildStateForPath(state_path).update("doc:m");
 
     var cache = StoreStatusBackfillMarkerCache{};
     defer cache.deinit(std.testing.allocator);
@@ -10792,14 +10736,7 @@ test "metadata service prefers planned store affinity in shared roots" {
 
     const state_path = try std.fmt.allocPrint(std.testing.allocator, "{s}/indexes/search_idx/rebuild.state", .{db_path});
     defer std.testing.allocator.free(state_path);
-    {
-        var file = try std.Io.Dir.cwd().createFile(io_impl.io(), state_path, .{ .truncate = true });
-        defer file.close(io_impl.io());
-        var buf: [128]u8 = undefined;
-        var writer = file.writer(io_impl.io(), &buf);
-        try writer.interface.writeAll("doc:m");
-        try writer.end();
-    }
+    try rebuildStateForPath(state_path).update("doc:m");
 
     const stores = [_]metadata_table_manager.StoreRecord{
         .{ .store_id = 91, .node_id = 1, .role = "data", .live = true, .capacity_bytes = 1024, .available_bytes = 880 },

--- a/zig/pkg/antfly/src/metadata/service.zig
+++ b/zig/pkg/antfly/src/metadata/service.zig
@@ -6166,8 +6166,10 @@ fn collectLocalStoreStatusReport(
         const millis = std.math.clamp(avg_progress * 1000.0, 0.0, 1000.0);
         report.backfill_progress_millis = @intFromFloat(millis);
     }
-    report.runtime_statuses = try collectQuarantinedBackfillRuntimeStatuses(
+    report.runtime_statuses = try collectStoreRuntimeStatusesWithQuarantinedBackfills(
         alloc,
+        store.runtime_statuses,
+        ranges,
         backfill_markers,
         store.store_id,
         store.node_id,
@@ -6250,8 +6252,10 @@ fn collectSharedRootLocalStoreStatusReports(
         report.group_statuses = try metadata_table_manager.cloneGroupStatuses(alloc, group_statuses);
     }
     for (reports, 0..) |*report, i| {
-        report.runtime_statuses = try collectQuarantinedBackfillRuntimeStatuses(
+        report.runtime_statuses = try collectStoreRuntimeStatusesWithQuarantinedBackfills(
             alloc,
+            stores[i].runtime_statuses,
+            ranges,
             quarantined[i].items,
             report.store_id,
             stores[i].node_id,
@@ -7047,25 +7051,67 @@ fn storeStatusBackfillMarkerMatchesStore(marker: StoreStatusBackfillMarker, stor
     return include_unassigned;
 }
 
-fn collectQuarantinedBackfillRuntimeStatuses(
+const rebuild_state_quarantine_source = "rebuild_state_quarantine";
+const rebuild_state_quarantine_error = "InvalidRebuildState";
+
+fn collectStoreRuntimeStatusesWithQuarantinedBackfills(
     alloc: std.mem.Allocator,
+    existing: []const metadata_table_manager.RuntimeGroupStatusReport,
+    ranges: []const metadata_table_manager.RangeRecord,
     markers: []const StoreStatusBackfillMarker,
     store_id: u64,
     node_id: u64,
     include_unassigned: bool,
 ) ![]metadata_table_manager.RuntimeGroupStatusReport {
-    var statuses = std.ArrayListUnmanaged(metadata_table_manager.RuntimeGroupStatusReport).empty;
-    errdefer {
-        for (statuses.items) |status| metadata_table_manager.freeRuntimeGroupStatusReport(alloc, status);
-        statuses.deinit(alloc);
+    // Keep the data runtime's authoritative observations intact. Quarantine
+    // reports are reversible overlays: retaining the underlying report lets a
+    // repaired marker disappear immediately on the next scan without waiting
+    // for another data-server heartbeat.
+    var base = std.ArrayListUnmanaged(metadata_table_manager.RuntimeGroupStatusReport).empty;
+    errdefer freeOwnedRuntimeStatusList(alloc, &base);
+    for (existing) |status| {
+        if (std.mem.eql(u8, status.source, rebuild_state_quarantine_source)) continue;
+        const cloned = try metadata_table_manager.cloneRuntimeGroupStatusReport(alloc, status);
+        errdefer metadata_table_manager.freeRuntimeGroupStatusReport(alloc, cloned);
+        try base.append(alloc, cloned);
     }
+
+    var overlays = std.ArrayListUnmanaged(metadata_table_manager.RuntimeGroupStatusReport).empty;
+    errdefer freeOwnedRuntimeStatusList(alloc, &overlays);
     for (markers) |marker| {
         if (marker.state != .corrupt) continue;
         if (!storeStatusBackfillMarkerMatchesStore(marker, store_id, include_unassigned)) continue;
-        const status = try quarantinedBackfillRuntimeStatus(alloc, marker, store_id, node_id);
-        errdefer metadata_table_manager.freeRuntimeGroupStatusReport(alloc, status);
-        try statuses.append(alloc, status);
+
+        const overlay_index = findRuntimeStatusIndexByGroup(overlays.items, marker.group_id) orelse blk: {
+            var overlay = if (findRuntimeStatusIndexByGroup(base.items, marker.group_id)) |base_index|
+                try metadata_table_manager.cloneRuntimeGroupStatusReport(alloc, base.items[base_index])
+            else
+                try quarantinedBackfillRuntimeStatus(
+                    alloc,
+                    marker,
+                    findRangeByGroupId(ranges, marker.group_id),
+                    store_id,
+                    node_id,
+                );
+            errdefer metadata_table_manager.freeRuntimeGroupStatusReport(alloc, overlay);
+            try replaceOwnedRuntimeStatusSource(alloc, &overlay, rebuild_state_quarantine_source);
+            try overlays.append(alloc, overlay);
+            break :blk overlays.items.len - 1;
+        };
+        try markRuntimeIndexQuarantined(alloc, &overlays.items[overlay_index], marker);
     }
+
+    var statuses = std.ArrayListUnmanaged(metadata_table_manager.RuntimeGroupStatusReport).empty;
+    errdefer freeOwnedRuntimeStatusList(alloc, &statuses);
+    try statuses.ensureTotalCapacity(alloc, overlays.items.len + base.items.len);
+    statuses.appendSliceAssumeCapacity(overlays.items);
+    overlays.items.len = 0;
+    statuses.appendSliceAssumeCapacity(base.items);
+    base.items.len = 0;
+    overlays.deinit(alloc);
+    overlays = .empty;
+    base.deinit(alloc);
+    base = .empty;
     if (statuses.items.len == 0) {
         statuses.deinit(alloc);
         return &.{};
@@ -7073,9 +7119,77 @@ fn collectQuarantinedBackfillRuntimeStatuses(
     return try statuses.toOwnedSlice(alloc);
 }
 
+fn freeOwnedRuntimeStatusList(
+    alloc: std.mem.Allocator,
+    statuses: *std.ArrayListUnmanaged(metadata_table_manager.RuntimeGroupStatusReport),
+) void {
+    for (statuses.items) |status| metadata_table_manager.freeRuntimeGroupStatusReport(alloc, status);
+    statuses.deinit(alloc);
+}
+
+fn findRuntimeStatusIndexByGroup(
+    statuses: []const metadata_table_manager.RuntimeGroupStatusReport,
+    group_id: u64,
+) ?usize {
+    for (statuses, 0..) |status, i| {
+        if (status.group_id == group_id) return i;
+    }
+    return null;
+}
+
+fn replaceOwnedRuntimeStatusSource(
+    alloc: std.mem.Allocator,
+    status: *metadata_table_manager.RuntimeGroupStatusReport,
+    source: []const u8,
+) !void {
+    if (std.mem.eql(u8, status.source, source)) return;
+    const next = try alloc.dupe(u8, source);
+    alloc.free(status.source);
+    status.source = next;
+}
+
+fn markRuntimeIndexQuarantined(
+    alloc: std.mem.Allocator,
+    status: *metadata_table_manager.RuntimeGroupStatusReport,
+    marker: StoreStatusBackfillMarker,
+) !void {
+    const index_dir = std.fs.path.dirname(marker.path) orelse return error.InvalidBackfillMarkerPath;
+    const index_name = std.fs.path.basename(index_dir);
+    for (status.indexes) |*index| {
+        if (!std.mem.eql(u8, index.name, index_name)) continue;
+        const load_error = try alloc.dupe(u8, rebuild_state_quarantine_error);
+        if (index.load_error) |previous| alloc.free(previous);
+        index.load_error = load_error;
+        index.coverage_summary_ready = false;
+        index.backfill_active = false;
+        index.backfill_progress_millis = 0;
+        index.replay_catch_up_required = false;
+        return;
+    }
+
+    const name = try alloc.dupe(u8, index_name);
+    errdefer alloc.free(name);
+    const kind = try alloc.dupe(u8, "unknown");
+    errdefer alloc.free(kind);
+    const load_error = try alloc.dupe(u8, rebuild_state_quarantine_error);
+    errdefer alloc.free(load_error);
+    const next = try alloc.alloc(metadata_table_manager.RuntimeIndexStatusReport, status.indexes.len + 1);
+    @memcpy(next[0..status.indexes.len], status.indexes);
+    next[status.indexes.len] = .{
+        .name = name,
+        .kind = kind,
+        .load_error = load_error,
+        .coverage_summary_ready = false,
+    };
+    if (status.indexes.len > 0) alloc.free(status.indexes);
+    status.indexes = next;
+    status.index_count = @intCast(next.len);
+}
+
 fn quarantinedBackfillRuntimeStatus(
     alloc: std.mem.Allocator,
     marker: StoreStatusBackfillMarker,
+    range: ?metadata_table_manager.RangeRecord,
     store_id: u64,
     node_id: u64,
 ) !metadata_table_manager.RuntimeGroupStatusReport {
@@ -7083,30 +7197,35 @@ fn quarantinedBackfillRuntimeStatus(
     const index_name = std.fs.path.basename(index_dir);
     const table_name = try alloc.dupe(u8, "");
     errdefer alloc.free(table_name);
-    const source = try alloc.dupe(u8, "rebuild_state_quarantine");
+    const source = try alloc.dupe(u8, rebuild_state_quarantine_source);
     errdefer alloc.free(source);
-    const freshness = try alloc.dupe(u8, "quarantined");
+    const freshness = try alloc.dupe(u8, "failed");
     errdefer alloc.free(freshness);
-    const projection_checkpoint_status = try alloc.dupe(u8, "clean");
+    const projection_checkpoint_status = try alloc.dupe(u8, "repair_required");
     errdefer alloc.free(projection_checkpoint_status);
     const owned_index_name = try alloc.dupe(u8, index_name);
     errdefer alloc.free(owned_index_name);
     const index_kind = try alloc.dupe(u8, "unknown");
     errdefer alloc.free(index_kind);
+    const load_error = try alloc.dupe(u8, rebuild_state_quarantine_error);
+    errdefer alloc.free(load_error);
     const indexes = try alloc.alloc(metadata_table_manager.RuntimeIndexStatusReport, 1);
     errdefer alloc.free(indexes);
     indexes[0] = .{
         .name = owned_index_name,
         .kind = index_kind,
-        .backfill_active = true,
+        .load_error = load_error,
+        .coverage_summary_ready = false,
         .backfill_progress_millis = 0,
     };
 
     var status: metadata_table_manager.RuntimeGroupStatusReport = .{
+        .table_id = if (range) |record| record.table_id else 0,
         .table_name = table_name,
         .group_id = marker.group_id,
         .store_id = store_id,
         .node_id = node_id,
+        .updated_at_ns = platform_clock.Clock.real().nowRealtimeMs() * std.time.ns_per_ms,
         .source = source,
         .freshness = freshness,
         .index_count = 1,
@@ -10861,12 +10980,44 @@ test "metadata service caches corrupt rebuild state and publishes quarantine sta
 
     const ranges = [_]metadata_table_manager.RangeRecord{
         .{ .group_id = 9501, .table_id = 95, .start_key = "doc:a", .end_key = "doc:z" },
+        .{ .group_id = 9502, .table_id = 96, .start_key = "doc:a", .end_key = "doc:z" },
+    };
+    var group_indexes = [_]metadata_table_manager.RuntimeIndexStatusReport{
+        .{ .name = "search_idx", .kind = "full_text", .doc_count = 7 },
+        .{ .name = "healthy_peer_idx", .kind = "graph", .edge_count = 11 },
+    };
+    var unrelated_indexes = [_]metadata_table_manager.RuntimeIndexStatusReport{
+        .{ .name = "unrelated_idx", .kind = "sparse_vector", .doc_count = 13 },
+    };
+    var existing_runtime_statuses = [_]metadata_table_manager.RuntimeGroupStatusReport{
+        .{
+            .table_id = 95,
+            .table_name = "docs",
+            .group_id = 9501,
+            .store_id = 95,
+            .node_id = 5,
+            .source = "live_writer_publish",
+            .freshness = "fresh",
+            .index_count = 2,
+            .indexes = &group_indexes,
+        },
+        .{
+            .table_id = 96,
+            .table_name = "other",
+            .group_id = 9502,
+            .store_id = 95,
+            .node_id = 5,
+            .source = "live_writer_publish",
+            .freshness = "fresh",
+            .index_count = 1,
+            .indexes = &unrelated_indexes,
+        },
     };
     const report = try collectLocalStoreStatusReport(
         .{},
         std.testing.allocator,
         replica_root,
-        .{ .store_id = 95, .node_id = 5 },
+        .{ .store_id = 95, .node_id = 5, .runtime_statuses = &existing_runtime_statuses },
         &ranges,
         &.{},
         cache.markers,
@@ -10874,11 +11025,32 @@ test "metadata service caches corrupt rebuild state and publishes quarantine sta
     defer freeOwnedStoreStatusReport(std.testing.allocator, report);
     try std.testing.expectEqual(@as(u32, 1), report.active_backfills);
     try std.testing.expectEqual(@as(u16, 0), report.backfill_progress_millis);
-    try std.testing.expectEqual(@as(usize, 1), report.runtime_statuses.len);
+    try std.testing.expectEqual(@as(usize, 3), report.runtime_statuses.len);
     try std.testing.expectEqualStrings("rebuild_state_quarantine", report.runtime_statuses[0].source);
-    try std.testing.expectEqualStrings("quarantined", report.runtime_statuses[0].freshness);
-    try std.testing.expectEqual(@as(usize, 1), report.runtime_statuses[0].indexes.len);
+    try std.testing.expectEqualStrings("fresh", report.runtime_statuses[0].freshness);
+    try std.testing.expectEqual(@as(usize, 2), report.runtime_statuses[0].indexes.len);
     try std.testing.expectEqualStrings("search_idx", report.runtime_statuses[0].indexes[0].name);
+    try std.testing.expectEqualStrings(rebuild_state_quarantine_error, report.runtime_statuses[0].indexes[0].load_error.?);
+    try std.testing.expect(report.runtime_statuses[0].indexes[1].load_error == null);
+    try std.testing.expectEqualStrings("live_writer_publish", report.runtime_statuses[1].source);
+    try std.testing.expect(report.runtime_statuses[1].indexes[0].load_error == null);
+    try std.testing.expectEqual(@as(u64, 9502), report.runtime_statuses[2].group_id);
+    try std.testing.expectEqualStrings("unrelated_idx", report.runtime_statuses[2].indexes[0].name);
+
+    const repaired = try collectStoreRuntimeStatusesWithQuarantinedBackfills(
+        std.testing.allocator,
+        report.runtime_statuses,
+        &ranges,
+        &.{},
+        95,
+        5,
+        true,
+    );
+    defer metadata_table_manager.freeRuntimeGroupStatusReports(std.testing.allocator, repaired);
+    try std.testing.expectEqual(@as(usize, 2), repaired.len);
+    try std.testing.expectEqualStrings("live_writer_publish", repaired[0].source);
+    try std.testing.expect(repaired[0].indexes[0].load_error == null);
+    try std.testing.expectEqual(@as(u64, 9502), repaired[1].group_id);
 
     cache.scanned_at_ms = monotonicMs();
     const scanned_at_ms = cache.scanned_at_ms;

--- a/zig/pkg/antfly/src/metadata/service.zig
+++ b/zig/pkg/antfly/src/metadata/service.zig
@@ -6152,6 +6152,7 @@ fn collectLocalStoreStatusReport(
     var progress_sum: f64 = 0.0;
     for (backfill_markers) |marker| {
         if (!storeStatusBackfillMarkerMatchesStore(marker, store.store_id, true)) continue;
+        if (!backfillMarkerMatchesRuntimeGeneration(marker, store.runtime_statuses)) continue;
         try accumulateStoreStatusBackfillProgress(
             alloc,
             ranges,
@@ -6232,6 +6233,7 @@ fn collectSharedRootLocalStoreStatusReports(
         const range = findRangeByGroupId(ranges, marker.group_id) orelse continue;
         const store_id = try resolveSharedRootStoreAffinity(alloc, io, replica_root_dir, local_node_id, marker.group_id, stores, placements, tables, range);
         const report_index = findStoreStatusReportIndex(reports, store_id) orelse continue;
+        if (!backfillMarkerMatchesRuntimeGeneration(marker, stores[report_index].runtime_statuses)) continue;
         try accumulateStoreStatusBackfillProgress(
             alloc,
             ranges,
@@ -6794,6 +6796,7 @@ const StoreStatusBackfillMarker = struct {
     store_id: ?u64,
     group_id: u64,
     path: []const u8,
+    owner_generation: ?u64 = null,
     state: State = .absent,
 
     const State = union(enum) {
@@ -6894,12 +6897,17 @@ fn scanStoreStatusBackfillMarkersWithIo(
     defer walker.deinit();
     while (try walker.next(io)) |entry| {
         if (entry.kind != .file) continue;
-        if (!std.mem.endsWith(u8, entry.path, "/rebuild.state")) continue;
+        if (backfill_state_mod.ownerGenerationFromPath(entry.path) == null and
+            !std.mem.endsWith(u8, entry.path, "/rebuild.state"))
+        {
+            continue;
+        }
         const parsed = parseStoreStatusBackfillMarkerPath(entry.path) orelse continue;
         try markers.append(alloc, .{
             .store_id = parsed.store_id,
             .group_id = parsed.group_id,
             .path = try alloc.dupe(u8, entry.path),
+            .owner_generation = backfill_state_mod.ownerGenerationFromPath(entry.path),
         });
     }
     if (markers.items.len == 0) {
@@ -6950,7 +6958,11 @@ fn refreshStoreStatusBackfillMarkerResumeKeys(
 }
 
 fn rebuildStateForPath(path: []const u8) backfill_state_mod.RebuildState {
-    return backfill_state_mod.RebuildState.init(std.fs.path.dirname(path) orelse ".");
+    const root_path = std.fs.path.dirname(path) orelse ".";
+    if (backfill_state_mod.ownerGenerationFromPath(path)) |generation| {
+        return backfill_state_mod.RebuildState.initOwned(root_path, null, generation);
+    }
+    return backfill_state_mod.RebuildState.init(root_path);
 }
 
 fn collectStoreStatusBackfillMarkers(alloc: std.mem.Allocator, replica_root_dir: []const u8) ![]StoreStatusBackfillMarker {
@@ -7051,6 +7063,56 @@ fn storeStatusBackfillMarkerMatchesStore(marker: StoreStatusBackfillMarker, stor
     return include_unassigned;
 }
 
+fn backfillMarkerMatchesRuntimeGeneration(
+    marker: StoreStatusBackfillMarker,
+    runtime_statuses: []const metadata_table_manager.RuntimeGroupStatusReport,
+) bool {
+    const marker_generation = marker.owner_generation orelse return true;
+    const index_dir = std.fs.path.dirname(marker.path) orelse return true;
+    const index_name = std.fs.path.basename(index_dir);
+    for (runtime_statuses) |status| {
+        if (status.group_id != marker.group_id) continue;
+        for (status.indexes) |index| {
+            if (!std.mem.eql(u8, index.name, index_name)) continue;
+            // A current runtime identity is authoritative for same-name
+            // replacement. Ignore a stale worker's generation cursor instead
+            // of reporting duplicate progress or quarantining the replacement.
+            if (index.coverage_generation != 0) {
+                return index.coverage_generation == marker_generation;
+            }
+        }
+    }
+    // Missing runtime status is not evidence of staleness. Preserve marker
+    // visibility until the data runtime publishes an authoritative generation.
+    return true;
+}
+
+test "metadata service ignores stale rebuild generation markers after replacement" {
+    const marker = StoreStatusBackfillMarker{
+        .store_id = 7,
+        .group_id = 9501,
+        .path = "store-7/group-9501/table-db/indexes/search_idx/rebuild.state.g-000000000000005f",
+        .owner_generation = 95,
+    };
+    var indexes = [_]metadata_table_manager.RuntimeIndexStatusReport{.{
+        .name = "search_idx",
+        .kind = "full_text",
+        .coverage_generation = 96,
+    }};
+    const statuses = [_]metadata_table_manager.RuntimeGroupStatusReport{.{
+        .group_id = 9501,
+        .indexes = &indexes,
+    }};
+
+    try std.testing.expect(!backfillMarkerMatchesRuntimeGeneration(marker, &statuses));
+    indexes[0].coverage_generation = 95;
+    try std.testing.expect(backfillMarkerMatchesRuntimeGeneration(marker, &statuses));
+
+    var legacy = marker;
+    legacy.owner_generation = null;
+    try std.testing.expect(backfillMarkerMatchesRuntimeGeneration(legacy, &statuses));
+}
+
 const rebuild_state_quarantine_source = "rebuild_state_quarantine";
 const rebuild_state_quarantine_error = "InvalidRebuildState";
 
@@ -7081,6 +7143,7 @@ fn collectStoreRuntimeStatusesWithQuarantinedBackfills(
     for (markers) |marker| {
         if (marker.state != .corrupt) continue;
         if (!storeStatusBackfillMarkerMatchesStore(marker, store_id, include_unassigned)) continue;
+        if (!backfillMarkerMatchesRuntimeGeneration(marker, base.items)) continue;
 
         const overlay_index = findRuntimeStatusIndexByGroup(overlays.items, marker.group_id) orelse blk: {
             var overlay = if (findRuntimeStatusIndexByGroup(base.items, marker.group_id)) |base_index|
@@ -10950,7 +11013,7 @@ test "metadata service caches corrupt rebuild state and publishes quarantine sta
     var io_impl = std.Io.Threaded.init(std.testing.allocator, .{});
     defer io_impl.deinit();
     try fs_paths.createDirPathPortable(io_impl.io(), index_root);
-    const rebuild_state = backfill_state_mod.RebuildState.init(index_root);
+    const rebuild_state = backfill_state_mod.RebuildState.initOwned(index_root, null, 95);
     try rebuild_state.updateWithIo(io_impl.io(), "doc:m");
     const state_path = try rebuild_state.pathAlloc(std.testing.allocator);
     defer std.testing.allocator.free(state_path);

--- a/zig/pkg/antfly/src/metadata/sim_harness.zig
+++ b/zig/pkg/antfly/src/metadata/sim_harness.zig
@@ -1566,7 +1566,7 @@ fn runAutomaticSplitPublicTrafficScenario(cfg: AutomaticSplitPublicTrafficScenar
 
     const verification_index = transition_observer_index orelse (currentMetadataLeaderIndex(&cluster) orelse query_index);
     const retirement = try retireFinalizedSplitTransition(cluster.node(verification_index), &auto_loop);
-    try std.testing.expectEqual(@as(usize, 2), retirement.terminal.range_upserts);
+    try std.testing.expectEqual(@as(usize, 2), retirement.removal.range_upserts);
 
     try verifySplitPublicTraffic(&cluster, &client, public_api.api_base_uris[0..], public_api.catalog_sources[verification_index].iface(), client_base, "docs", roots[0..], cfg.verify);
 }
@@ -1719,8 +1719,8 @@ fn runAutomaticMergePublicTrafficScenario(cfg: AutomaticMergePublicTrafficScenar
 
     const verification_index = transition_observer_index orelse (currentMetadataLeaderIndex(&cluster) orelse query_index);
     const retirement = try retireFinalizedMergeTransition(cluster.node(verification_index), &auto_loop);
-    try std.testing.expectEqual(@as(usize, 1), retirement.terminal.range_upserts);
-    try std.testing.expectEqual(@as(usize, 1), retirement.terminal.range_removals);
+    try std.testing.expectEqual(@as(usize, 1), retirement.removal.range_upserts);
+    try std.testing.expectEqual(@as(usize, 1), retirement.removal.range_removals);
 
     try verifyMergePublicTraffic(&cluster, &client, public_api.api_base_uris[0..], public_api.catalog_sources[verification_index].iface(), client_base, "docs", roots[0..], left_group_id, right_group_id, cfg.verify);
 }
@@ -4289,6 +4289,10 @@ fn retireFinalizedSplitTransition(
     const terminal = try requireLeasedReconcile(node, loop);
     try std.testing.expectEqual(@as(usize, 1), terminal.split_upserts);
     try std.testing.expectEqual(@as(usize, 0), terminal.split_removals);
+    // The terminal transition is the write-ahead publication boundary.
+    // Topology must remain fenced until that marker is durably projected.
+    try std.testing.expectEqual(@as(usize, 0), terminal.range_upserts);
+    try std.testing.expectEqual(@as(usize, 0), terminal.range_removals);
     try node.cluster.stepAll();
 
     const removal = try requireLeasedReconcile(node, loop);
@@ -4309,6 +4313,8 @@ fn retireFinalizedMergeTransition(
     const terminal = try requireLeasedReconcile(node, loop);
     try std.testing.expectEqual(@as(usize, 1), terminal.merge_upserts);
     try std.testing.expectEqual(@as(usize, 0), terminal.merge_removals);
+    try std.testing.expectEqual(@as(usize, 0), terminal.range_upserts);
+    try std.testing.expectEqual(@as(usize, 0), terminal.range_removals);
     try node.cluster.stepAll();
 
     const removal = try requireLeasedReconcile(node, loop);
@@ -5640,6 +5646,7 @@ fn metadataVoprRunExpandedLivenessWorkload(
         .table_id = merge_table_id,
         .donor_group_id = merge_right_group,
         .receiver_group_id = merge_left_group,
+        .allow_doc_identity_reassignment = true,
     });
     try std.testing.expectEqual(@as(usize, 1), merge_summary.merge_upserts);
     try metadataVoprHealAll(cluster, state);
@@ -7033,6 +7040,7 @@ test "metadata http cluster simulation drives merge intent through the control l
         .table_id = 46,
         .donor_group_id = 4602,
         .receiver_group_id = 4601,
+        .allow_doc_identity_reassignment = true,
     });
     try std.testing.expectEqual(@as(usize, 1), merge_summary.merge_upserts);
 
@@ -7139,7 +7147,7 @@ test "metadata http cluster simulation drives automatic split through the contro
 
     const finalize_leader = currentMetadataLeaderIndex(&cluster) orelse query_index;
     const retirement = try retireFinalizedSplitTransition(cluster.node(finalize_leader), &auto_loop);
-    try std.testing.expectEqual(@as(usize, 2), retirement.terminal.range_upserts);
+    try std.testing.expectEqual(@as(usize, 2), retirement.removal.range_upserts);
 
     const ranges = try cluster.node(finalize_leader).listProjectedRanges(std.testing.allocator);
     defer cluster.node(finalize_leader).freeProjectedRanges(std.testing.allocator, ranges);
@@ -7469,7 +7477,7 @@ test "metadata http cluster simulation completes automatic split after metadata 
 
     const finalize_leader = currentMetadataLeaderIndex(&cluster) orelse leader_index;
     const retirement = try retireFinalizedSplitTransition(cluster.node(finalize_leader), &auto_loop);
-    try std.testing.expectEqual(@as(usize, 2), retirement.terminal.range_upserts);
+    try std.testing.expectEqual(@as(usize, 2), retirement.removal.range_upserts);
 
     const ranges = try cluster.node(finalize_leader).listProjectedRanges(std.testing.allocator);
     defer cluster.node(finalize_leader).freeProjectedRanges(std.testing.allocator, ranges);
@@ -7569,7 +7577,7 @@ test "metadata http cluster simulation completes automatic split after metadata 
     try std.testing.expect(try waitForSplitTransitionFinalized(&cluster, transition_id, new_leader, new_leader, 64));
 
     const retirement = try retireFinalizedSplitTransition(cluster.node(new_leader), &auto_loop);
-    try std.testing.expectEqual(@as(usize, 2), retirement.terminal.range_upserts);
+    try std.testing.expectEqual(@as(usize, 2), retirement.removal.range_upserts);
 
     const ranges = try cluster.node(new_leader).listProjectedRanges(std.testing.allocator);
     defer cluster.node(new_leader).freeProjectedRanges(std.testing.allocator, ranges);
@@ -7674,7 +7682,7 @@ test "metadata http cluster simulation completes automatic split under delayed r
 
     const finalize_leader = currentMetadataLeaderIndex(&cluster) orelse query_index;
     const retirement = try retireFinalizedSplitTransition(cluster.node(finalize_leader), &auto_loop);
-    try std.testing.expectEqual(@as(usize, 2), retirement.terminal.range_upserts);
+    try std.testing.expectEqual(@as(usize, 2), retirement.removal.range_upserts);
 
     const ranges = try cluster.node(finalize_leader).listProjectedRanges(std.testing.allocator);
     defer cluster.node(finalize_leader).freeProjectedRanges(std.testing.allocator, ranges);
@@ -7782,7 +7790,7 @@ test "metadata http cluster simulation completes automatic split after leader re
 
     const finalize_leader = currentMetadataLeaderIndex(&cluster) orelse leader_index;
     const retirement = try retireFinalizedSplitTransition(cluster.node(finalize_leader), &auto_loop);
-    try std.testing.expectEqual(@as(usize, 2), retirement.terminal.range_upserts);
+    try std.testing.expectEqual(@as(usize, 2), retirement.removal.range_upserts);
 
     const ranges = try cluster.node(finalize_leader).listProjectedRanges(std.testing.allocator);
     defer cluster.node(finalize_leader).freeProjectedRanges(std.testing.allocator, ranges);
@@ -7884,7 +7892,7 @@ test "metadata http cluster simulation completes automatic split after source gr
 
     const finalize_leader = currentMetadataLeaderIndex(&cluster) orelse query_index;
     const retirement = try retireFinalizedSplitTransition(cluster.node(finalize_leader), &auto_loop);
-    try std.testing.expectEqual(@as(usize, 2), retirement.terminal.range_upserts);
+    try std.testing.expectEqual(@as(usize, 2), retirement.removal.range_upserts);
 
     const ranges = try cluster.node(finalize_leader).listProjectedRanges(std.testing.allocator);
     defer cluster.node(finalize_leader).freeProjectedRanges(std.testing.allocator, ranges);
@@ -8004,7 +8012,7 @@ test "metadata http cluster simulation completes automatic split after destinati
 
     const finalize_leader = currentMetadataLeaderIndex(&cluster) orelse query_index;
     const retirement = try retireFinalizedSplitTransition(cluster.node(finalize_leader), &auto_loop);
-    try std.testing.expectEqual(@as(usize, 2), retirement.terminal.range_upserts);
+    try std.testing.expectEqual(@as(usize, 2), retirement.removal.range_upserts);
 
     if (destination_progress.group_index == null) {
         const post_finalize_destination = (try waitForGroupLeaderIndex(&cluster, destination_group_id, 96)) orelse return error.TestExpectedEqual;
@@ -8112,7 +8120,7 @@ test "metadata http cluster simulation completes automatic split after leader pa
     try std.testing.expect(try waitForSplitTransitionFinalized(&cluster, transition_id, new_leader, new_leader, 160));
 
     const retirement = try retireFinalizedSplitTransition(cluster.node(new_leader), &auto_loop);
-    try std.testing.expectEqual(@as(usize, 2), retirement.terminal.range_upserts);
+    try std.testing.expectEqual(@as(usize, 2), retirement.removal.range_upserts);
 
     const ranges = try cluster.node(new_leader).listProjectedRanges(std.testing.allocator);
     defer cluster.node(new_leader).freeProjectedRanges(std.testing.allocator, ranges);
@@ -8325,8 +8333,8 @@ test "metadata http cluster simulation drives automatic merge through the contro
 
     const finalize_leader = currentMetadataLeaderIndex(&cluster) orelse query_index;
     const retirement = try retireFinalizedMergeTransition(cluster.node(finalize_leader), &auto_loop);
-    try std.testing.expectEqual(@as(usize, 1), retirement.terminal.range_upserts);
-    try std.testing.expectEqual(@as(usize, 1), retirement.terminal.range_removals);
+    try std.testing.expectEqual(@as(usize, 1), retirement.removal.range_upserts);
+    try std.testing.expectEqual(@as(usize, 1), retirement.removal.range_removals);
 
     const ranges = try cluster.node(finalize_leader).listProjectedRanges(std.testing.allocator);
     defer cluster.node(finalize_leader).freeProjectedRanges(std.testing.allocator, ranges);
@@ -8435,8 +8443,8 @@ test "metadata http cluster simulation completes automatic merge after metadata 
 
     const finalize_leader = currentMetadataLeaderIndex(&cluster) orelse leader_index;
     const retirement = try retireFinalizedMergeTransition(cluster.node(finalize_leader), &auto_loop);
-    try std.testing.expectEqual(@as(usize, 1), retirement.terminal.range_upserts);
-    try std.testing.expectEqual(@as(usize, 1), retirement.terminal.range_removals);
+    try std.testing.expectEqual(@as(usize, 1), retirement.removal.range_upserts);
+    try std.testing.expectEqual(@as(usize, 1), retirement.removal.range_removals);
 
     const ranges = try cluster.node(finalize_leader).listProjectedRanges(std.testing.allocator);
     defer cluster.node(finalize_leader).freeProjectedRanges(std.testing.allocator, ranges);
@@ -8542,8 +8550,8 @@ test "metadata http cluster simulation completes automatic merge after donor gro
 
     const finalize_leader = currentMetadataLeaderIndex(&cluster) orelse query_index;
     const retirement = try retireFinalizedMergeTransition(cluster.node(finalize_leader), &auto_loop);
-    try std.testing.expectEqual(@as(usize, 1), retirement.terminal.range_upserts);
-    try std.testing.expectEqual(@as(usize, 1), retirement.terminal.range_removals);
+    try std.testing.expectEqual(@as(usize, 1), retirement.removal.range_upserts);
+    try std.testing.expectEqual(@as(usize, 1), retirement.removal.range_removals);
 
     const ranges = try cluster.node(finalize_leader).listProjectedRanges(std.testing.allocator);
     defer cluster.node(finalize_leader).freeProjectedRanges(std.testing.allocator, ranges);
@@ -8649,8 +8657,8 @@ test "metadata http cluster simulation completes automatic merge after receiver 
 
     const finalize_leader = currentMetadataLeaderIndex(&cluster) orelse query_index;
     const retirement = try retireFinalizedMergeTransition(cluster.node(finalize_leader), &auto_loop);
-    try std.testing.expectEqual(@as(usize, 1), retirement.terminal.range_upserts);
-    try std.testing.expectEqual(@as(usize, 1), retirement.terminal.range_removals);
+    try std.testing.expectEqual(@as(usize, 1), retirement.removal.range_upserts);
+    try std.testing.expectEqual(@as(usize, 1), retirement.removal.range_removals);
 
     const ranges = try cluster.node(finalize_leader).listProjectedRanges(std.testing.allocator);
     defer cluster.node(finalize_leader).freeProjectedRanges(std.testing.allocator, ranges);
@@ -8754,8 +8762,8 @@ test "metadata http cluster simulation completes automatic merge after metadata 
     try std.testing.expect(try waitForMergeTransitionFinalized(&cluster, transition_id, new_leader, new_leader, 64));
 
     const retirement = try retireFinalizedMergeTransition(cluster.node(new_leader), &auto_loop);
-    try std.testing.expectEqual(@as(usize, 1), retirement.terminal.range_upserts);
-    try std.testing.expectEqual(@as(usize, 1), retirement.terminal.range_removals);
+    try std.testing.expectEqual(@as(usize, 1), retirement.removal.range_upserts);
+    try std.testing.expectEqual(@as(usize, 1), retirement.removal.range_removals);
 
     const ranges = try cluster.node(new_leader).listProjectedRanges(std.testing.allocator);
     defer cluster.node(new_leader).freeProjectedRanges(std.testing.allocator, ranges);
@@ -8864,8 +8872,8 @@ test "metadata http cluster simulation completes automatic merge under delayed r
 
     const finalize_leader = currentMetadataLeaderIndex(&cluster) orelse query_index;
     const retirement = try retireFinalizedMergeTransition(cluster.node(finalize_leader), &auto_loop);
-    try std.testing.expectEqual(@as(usize, 1), retirement.terminal.range_upserts);
-    try std.testing.expectEqual(@as(usize, 1), retirement.terminal.range_removals);
+    try std.testing.expectEqual(@as(usize, 1), retirement.removal.range_upserts);
+    try std.testing.expectEqual(@as(usize, 1), retirement.removal.range_removals);
 
     const ranges = try cluster.node(finalize_leader).listProjectedRanges(std.testing.allocator);
     defer cluster.node(finalize_leader).freeProjectedRanges(std.testing.allocator, ranges);
@@ -8977,8 +8985,8 @@ test "metadata http cluster simulation completes automatic merge after leader re
 
     const finalize_leader = currentMetadataLeaderIndex(&cluster) orelse leader_index;
     const retirement = try retireFinalizedMergeTransition(cluster.node(finalize_leader), &auto_loop);
-    try std.testing.expectEqual(@as(usize, 1), retirement.terminal.range_upserts);
-    try std.testing.expectEqual(@as(usize, 1), retirement.terminal.range_removals);
+    try std.testing.expectEqual(@as(usize, 1), retirement.removal.range_upserts);
+    try std.testing.expectEqual(@as(usize, 1), retirement.removal.range_removals);
 
     const ranges = try cluster.node(finalize_leader).listProjectedRanges(std.testing.allocator);
     defer cluster.node(finalize_leader).freeProjectedRanges(std.testing.allocator, ranges);
@@ -9089,8 +9097,8 @@ test "metadata http cluster simulation completes automatic merge after leader pa
     try std.testing.expect(try waitForMergeTransitionFinalized(&cluster, transition_id, new_leader, new_leader, 160));
 
     const retirement = try retireFinalizedMergeTransition(cluster.node(new_leader), &auto_loop);
-    try std.testing.expectEqual(@as(usize, 1), retirement.terminal.range_upserts);
-    try std.testing.expectEqual(@as(usize, 1), retirement.terminal.range_removals);
+    try std.testing.expectEqual(@as(usize, 1), retirement.removal.range_upserts);
+    try std.testing.expectEqual(@as(usize, 1), retirement.removal.range_removals);
 
     const ranges = try cluster.node(new_leader).listProjectedRanges(std.testing.allocator);
     defer cluster.node(new_leader).freeProjectedRanges(std.testing.allocator, ranges);
@@ -9371,7 +9379,7 @@ test "metadata http cluster simulation publishes split topology after finalize" 
 
     const query_index = currentMetadataLeaderIndex(&cluster) orelse leader_index;
     const retirement = try retireFinalizedSplitTransition(cluster.node(query_index), workflow.controlLoop());
-    try std.testing.expectEqual(@as(usize, 2), retirement.terminal.range_upserts);
+    try std.testing.expectEqual(@as(usize, 2), retirement.removal.range_upserts);
 
     const ranges = try cluster.node(query_index).listProjectedRanges(std.testing.allocator);
     defer cluster.node(query_index).freeProjectedRanges(std.testing.allocator, ranges);
@@ -9461,14 +9469,15 @@ test "metadata http cluster simulation publishes merge topology after finalize" 
         .table_id = 48,
         .donor_group_id = 4802,
         .receiver_group_id = 4801,
+        .allow_doc_identity_reassignment = true,
     });
 
     try std.testing.expect(try waitForMergeTransitionFinalized(&cluster, 48001, null, leader_index, 32));
 
     const query_index = currentMetadataLeaderIndex(&cluster) orelse leader_index;
     const retirement = try retireFinalizedMergeTransition(cluster.node(query_index), workflow.controlLoop());
-    try std.testing.expectEqual(@as(usize, 1), retirement.terminal.range_upserts);
-    try std.testing.expectEqual(@as(usize, 1), retirement.terminal.range_removals);
+    try std.testing.expectEqual(@as(usize, 1), retirement.removal.range_upserts);
+    try std.testing.expectEqual(@as(usize, 1), retirement.removal.range_removals);
 
     const ranges = try cluster.node(query_index).listProjectedRanges(std.testing.allocator);
     defer cluster.node(query_index).freeProjectedRanges(std.testing.allocator, ranges);
@@ -9558,7 +9567,7 @@ test "metadata http cluster simulation provisions split destination replicas acr
 
     const query_index = currentMetadataLeaderIndex(&cluster) orelse leader_index;
     const retirement = try retireFinalizedSplitTransition(cluster.node(query_index), workflow.controlLoop());
-    try std.testing.expectEqual(@as(usize, 2), retirement.terminal.range_upserts);
+    try std.testing.expectEqual(@as(usize, 2), retirement.removal.range_upserts);
 
     try std.testing.expect(try cluster.waitForGroupStatus(4811, .active, 40));
     try std.testing.expect(try cluster.waitForGroupStatus(4812, .active, 40));
@@ -9645,14 +9654,15 @@ test "metadata http cluster simulation retires merge donor replicas across nodes
         .table_id = 482,
         .donor_group_id = 4822,
         .receiver_group_id = 4821,
+        .allow_doc_identity_reassignment = true,
     });
 
     try std.testing.expect(try waitForMergeTransitionFinalized(&cluster, 48201, null, leader_index, 40));
 
     const query_index = currentMetadataLeaderIndex(&cluster) orelse leader_index;
     const retirement = try retireFinalizedMergeTransition(cluster.node(query_index), workflow.controlLoop());
-    try std.testing.expectEqual(@as(usize, 1), retirement.terminal.range_upserts);
-    try std.testing.expectEqual(@as(usize, 1), retirement.terminal.range_removals);
+    try std.testing.expectEqual(@as(usize, 1), retirement.removal.range_upserts);
+    try std.testing.expectEqual(@as(usize, 1), retirement.removal.range_removals);
 
     try std.testing.expect(try cluster.waitForGroupStatus(4821, .active, 40));
     try std.testing.expect(try cluster.waitForGroupStatus(4822, .absent, 40));
@@ -10386,6 +10396,7 @@ test "metadata http cluster simulation forwards public table io after merge fina
         .table_id = 485,
         .donor_group_id = 4852,
         .receiver_group_id = 4851,
+        .allow_doc_identity_reassignment = true,
     });
 
     try std.testing.expect(try waitForMergeTransitionFinalized(&cluster, 48501, null, leader_index, 40));

--- a/zig/pkg/antfly/src/metadata/storage/raft_apply_store.zig
+++ b/zig/pkg/antfly/src/metadata/storage/raft_apply_store.zig
@@ -3752,7 +3752,7 @@ fn replicationCutoverRetirementCleared(
 }
 
 const transition_magic = "afmd1";
-const runtime_status_record_version: u16 = 10;
+const runtime_status_record_version: u16 = 11;
 const group_status_record_version: u16 = 4;
 
 const TransitionTag = enum(u8) {
@@ -5032,6 +5032,7 @@ fn appendRuntimeIndexStatusRecord(
     try appendInt(alloc, out, u64, record.replay_applied_sequence);
     try appendInt(alloc, out, u64, record.replay_target_sequence);
     try out.append(alloc, if (record.replay_catch_up_required) 1 else 0);
+    try appendOptionalString(alloc, out, record.load_error);
 }
 
 fn readRuntimeIndexStatusRecord(
@@ -5075,9 +5076,12 @@ fn readRuntimeIndexStatusRecord(
     if (pos.* >= encoded.len) return error.InvalidMetadataTransitionEncoding;
     const replay_catch_up_required = encoded[pos.*] != 0;
     pos.* += 1;
+    const load_error = if (version >= 11) try readOptionalString(alloc, encoded, pos) else null;
+    errdefer if (load_error) |value| alloc.free(value);
     return .{
         .name = name,
         .kind = kind,
+        .load_error = load_error,
         .doc_count = doc_count,
         .term_count = term_count,
         .edge_count = edge_count,
@@ -5779,6 +5783,19 @@ fn appendRequiredString(
 ) !void {
     try appendInt(alloc, out, u32, @intCast(value.len));
     try out.appendSlice(alloc, value);
+}
+
+fn appendOptionalString(
+    alloc: std.mem.Allocator,
+    out: *std.ArrayListUnmanaged(u8),
+    value: ?[]const u8,
+) !void {
+    const present = value orelse {
+        try out.append(alloc, 0);
+        return;
+    };
+    try out.append(alloc, 1);
+    try appendRequiredString(alloc, out, present);
 }
 
 fn appendRestoreIntentIdentity(
@@ -9887,6 +9904,7 @@ test "metadata raft apply store runtime status codec preserves document identity
         .indexes = @constCast((&[_]metadata.RuntimeIndexStatusReport{.{
             .name = "visual_idx",
             .kind = "dense_vector",
+            .load_error = "InvalidRebuildState",
             .coverage_produced_count = 31,
             .coverage_skipped_count = 7,
             .coverage_terminal_failed_count = 2,
@@ -9931,6 +9949,7 @@ test "metadata raft apply store runtime status codec preserves document identity
     try std.testing.expectEqual(@as(u64, 6), status.doc_set_planning.missing_ordinal_coverage_count);
     try std.testing.expectEqual(@as(u64, 5), status.doc_set_planning.stale_identity_generation_rejection_count);
     try std.testing.expectEqual(@as(usize, 1), status.indexes.len);
+    try std.testing.expectEqualStrings("InvalidRebuildState", status.indexes[0].load_error.?);
     try std.testing.expectEqual(@as(u64, 31), status.indexes[0].coverage_produced_count);
     try std.testing.expectEqual(@as(u64, 7), status.indexes[0].coverage_skipped_count);
     try std.testing.expectEqual(@as(u64, 2), status.indexes[0].coverage_terminal_failed_count);
@@ -9938,6 +9957,38 @@ test "metadata raft apply store runtime status codec preserves document identity
     try std.testing.expectEqual(@as(u64, 0x1234), status.indexes[0].coverage_config_hash);
     try std.testing.expect(status.indexes[0].coverage_identity_ready);
     try std.testing.expect(status.indexes[0].coverage_summary_ready);
+}
+
+test "metadata runtime index status decoder accepts version ten records" {
+    const alloc = std.testing.allocator;
+    var encoded = std.ArrayListUnmanaged(u8).empty;
+    defer encoded.deinit(alloc);
+
+    try appendRuntimeIndexStatusRecord(alloc, &encoded, .{
+        .name = "legacy_idx",
+        .kind = "dense_vector",
+        .doc_count = 17,
+        .replay_applied_sequence = 9,
+        .replay_target_sequence = 11,
+        .replay_catch_up_required = true,
+    });
+
+    // Version 10 ended immediately after replay_catch_up_required. The final
+    // absent optional-string tag is the only field appended by version 11.
+    try std.testing.expectEqual(@as(u8, 0), encoded.items[encoded.items.len - 1]);
+    encoded.items.len -= 1;
+
+    var pos: usize = 0;
+    const decoded = try readRuntimeIndexStatusRecord(alloc, encoded.items, &pos, 10);
+    defer metadata_table_manager.freeRuntimeIndexStatusReport(alloc, decoded);
+
+    try std.testing.expectEqual(encoded.items.len, pos);
+    try std.testing.expectEqualStrings("legacy_idx", decoded.name);
+    try std.testing.expectEqual(@as(u64, 17), decoded.doc_count);
+    try std.testing.expectEqual(@as(u64, 9), decoded.replay_applied_sequence);
+    try std.testing.expectEqual(@as(u64, 11), decoded.replay_target_sequence);
+    try std.testing.expect(decoded.replay_catch_up_required);
+    try std.testing.expectEqual(@as(?[]const u8, null), decoded.load_error);
 }
 
 test "metadata raft apply store group status decoder accepts version one records" {

--- a/zig/pkg/antfly/src/metadata/store_observer.zig
+++ b/zig/pkg/antfly/src/metadata/store_observer.zig
@@ -204,6 +204,7 @@ fn runtimeStatusEqual(
     for (lhs.indexes, rhs.indexes) |left, right| {
         if (!std.mem.eql(u8, left.name, right.name) or
             !std.mem.eql(u8, left.kind, right.kind) or
+            !optionalStringsEqual(left.load_error, right.load_error) or
             left.doc_count != right.doc_count or
             left.term_count != right.term_count or
             left.edge_count != right.edge_count or
@@ -226,6 +227,11 @@ fn runtimeStatusEqual(
         }
     }
     return true;
+}
+
+fn optionalStringsEqual(lhs: ?[]const u8, rhs: ?[]const u8) bool {
+    if (lhs == null or rhs == null) return lhs == null and rhs == null;
+    return std.mem.eql(u8, lhs.?, rhs.?);
 }
 
 fn runtimeEnrichmentStatusEqual(

--- a/zig/pkg/antfly/src/metadata/table_manager.zig
+++ b/zig/pkg/antfly/src/metadata/table_manager.zig
@@ -816,6 +816,10 @@ pub const RuntimeDocSetPlanningStatusReport = struct {
 pub const RuntimeIndexStatusReport = struct {
     name: []const u8 = "",
     kind: []const u8 = "",
+    /// Stable error name for an index artifact that cannot be trusted or
+    /// loaded. This is index-scoped so one failed derived projection does not
+    /// make the other indexes in the same group appear unhealthy.
+    load_error: ?[]const u8 = null,
     doc_count: u64 = 0,
     term_count: u64 = 0,
     edge_count: u64 = 0,
@@ -2113,9 +2117,12 @@ pub fn cloneRuntimeIndexStatusReport(alloc: std.mem.Allocator, record: RuntimeIn
     errdefer alloc.free(name);
     const kind = try alloc.dupe(u8, record.kind);
     errdefer alloc.free(kind);
+    const load_error = if (record.load_error) |value| try alloc.dupe(u8, value) else null;
+    errdefer if (load_error) |value| alloc.free(value);
     return .{
         .name = name,
         .kind = kind,
+        .load_error = load_error,
         .doc_count = record.doc_count,
         .term_count = record.term_count,
         .edge_count = record.edge_count,
@@ -2139,6 +2146,7 @@ pub fn cloneRuntimeIndexStatusReport(alloc: std.mem.Allocator, record: RuntimeIn
 pub fn freeRuntimeIndexStatusReport(alloc: std.mem.Allocator, record: RuntimeIndexStatusReport) void {
     alloc.free(record.name);
     alloc.free(record.kind);
+    if (record.load_error) |value| alloc.free(value);
 }
 
 pub fn cloneRuntimeIndexStatusReports(alloc: std.mem.Allocator, records: []const RuntimeIndexStatusReport) ![]RuntimeIndexStatusReport {

--- a/zig/pkg/antfly/src/metadata/table_provisioner.zig
+++ b/zig/pkg/antfly/src/metadata/table_provisioner.zig
@@ -1413,6 +1413,7 @@ fn findReadyRuntimeFullTextIndex(
     for (indexes) |index| {
         if (!std.mem.eql(u8, index.name, index_name)) continue;
         if (!std.mem.eql(u8, index.kind, "full_text")) return null;
+        if (index.load_error != null) return null;
         if (index.backfill_active) return null;
         if (index.replay_catch_up_required) return null;
         if (index.replay_applied_sequence < index.replay_target_sequence) return null;

--- a/zig/pkg/antfly/src/metadata/table_provisioner.zig
+++ b/zig/pkg/antfly/src/metadata/table_provisioner.zig
@@ -365,6 +365,7 @@ pub fn collectLocalSchemaProgressWithOptions(
             // acquire the DB between the durable-marker check and DB.open;
             // report that shard as not ready and observe it next round.
             error.GenerationTransitionActive,
+            error.InvalidRebuildState,
             error.FileNotFound,
             error.NotDir,
             => false,
@@ -3369,6 +3370,56 @@ test "table provisioner schema progress returns not ready from rebuild marker wi
         1,
         .{},
     ));
+}
+
+test "table provisioner schema progress quarantines a corrupt rebuild marker" {
+    const alloc = std.testing.allocator;
+    const path = "/tmp/antfly-metadata-table-provisioner-progress-corrupt-rebuild-marker";
+    var io_impl = std.Io.Threaded.init(alloc, .{});
+    defer io_impl.deinit();
+    std.Io.Dir.cwd().deleteTree(io_impl.io(), path) catch {};
+    defer std.Io.Dir.cwd().deleteTree(io_impl.io(), path) catch {};
+
+    const db_path = try groupDbPathFromReplicaRoot(alloc, path, 2008);
+    defer alloc.free(db_path);
+    const index_root = try std.fmt.allocPrint(alloc, "{s}/indexes/full_text_index_v2", .{db_path});
+    defer alloc.free(index_root);
+    try fs_paths.createDirPathPortable(io_impl.io(), index_root);
+    const rebuild_state = db_mod.backfill_state.RebuildState.init(index_root);
+    try rebuild_state.updateWithIo(io_impl.io(), "doc:m");
+
+    const state_path = try rebuild_state.pathAlloc(alloc);
+    defer alloc.free(state_path);
+    const encoded = try std.Io.Dir.cwd().readFileAlloc(io_impl.io(), state_path, alloc, .limited(1024));
+    defer alloc.free(encoded);
+    encoded[encoded.len - 1] ^= 0xff;
+    try std.Io.Dir.cwd().writeFile(io_impl.io(), .{ .sub_path = state_path, .data = encoded });
+
+    const progress = try collectLocalSchemaProgress(
+        alloc,
+        path,
+        100,
+        7,
+        &.{ 100, 2008 },
+        &.{.{
+            .table_id = 9,
+            .name = "docs",
+            .schema_json = "{\"version\":2}",
+            .read_schema_json = "{\"version\":1}",
+            .indexes_json = "{}",
+        }},
+        &.{.{
+            .group_id = 2008,
+            .table_id = 9,
+            .start_key = "doc:a",
+            .end_key = "doc:z",
+        }},
+    );
+    defer alloc.free(progress);
+
+    // A corrupt marker keeps the shard quarantined without aborting the
+    // metadata lifecycle that collects schema progress.
+    try std.testing.expectEqual(@as(usize, 0), progress.len);
 }
 
 test "table provisioner withholds schema progress when any local shard is missing the target full-text index" {

--- a/zig/pkg/antfly/src/metadata/table_provisioner.zig
+++ b/zig/pkg/antfly/src/metadata/table_provisioner.zig
@@ -1281,12 +1281,10 @@ fn localRangeHasSchemaVersionIndex(
     else
         try std.fmt.bufPrint(&target_name_buf, "full_text_index_v{d}", .{schema_version});
 
-    // A rebuild marker is the durable, authoritative statement that this
-    // schema index is not ready. Check it before opening the DB: schema
-    // progress is polled by the metadata lifecycle while the resident writer
-    // can spend minutes backfilling a large corpus. Reopening the same DB in
-    // query mode on every poll maps the complete retained read index and scans
-    // primary LSM metadata even though the answer is already on disk here.
+    // Preserve the cheap pre-generation marker fast path during rolling
+    // upgrades. Generation-owned markers are resolved by the status-only open
+    // below: its catalog identity distinguishes the current cursor from a
+    // stale same-name worker without mapping retained index state.
     const rebuild_state_root = try std.fmt.allocPrint(alloc, "{s}/indexes/{s}", .{ path, target_name });
     defer alloc.free(rebuild_state_root);
     const rebuild_state = db_mod.backfill_state.RebuildState.init(rebuild_state_root);
@@ -3342,7 +3340,7 @@ test "table provisioner schema progress probes do not take a writer lease" {
     try std.testing.expectEqual(@as(u64, 9), progress[0].table_id);
 }
 
-test "table provisioner schema progress returns not ready from rebuild marker without opening DB" {
+test "table provisioner schema progress reads generation-owned rebuild state from status-only catalog" {
     const alloc = std.testing.allocator;
     const path = "/tmp/antfly-metadata-table-provisioner-progress-rebuild-marker";
     var io_impl = std.Io.Threaded.init(alloc, .{});
@@ -3354,13 +3352,30 @@ test "table provisioner schema progress returns not ready from rebuild marker wi
     defer alloc.free(db_path);
     const index_root = try std.fmt.allocPrint(alloc, "{s}/indexes/full_text_index_v2", .{db_path});
     defer alloc.free(index_root);
-    try fs_paths.createDirPathPortable(io_impl.io(), index_root);
-    const rebuild_state = db_mod.backfill_state.RebuildState.init(index_root);
+    var coverage_generation: u64 = 0;
+    {
+        var db = try db_mod.DB.open(alloc, db_path, .{});
+        defer db.close();
+        try db.addIndex(.{
+            .name = "full_text_index_v2",
+            .kind = .full_text,
+            .config_json = "{}",
+        });
+        const configs = try db.listIndexes(alloc);
+        defer db_mod.types.freeIndexConfigs(alloc, configs);
+        for (configs) |config| {
+            if (!std.mem.eql(u8, config.name, "full_text_index_v2")) continue;
+            coverage_generation = config.coverage_generation;
+            break;
+        }
+    }
+    try std.testing.expect(coverage_generation != 0);
+    const rebuild_state = db_mod.backfill_state.RebuildState.initOwned(index_root, null, coverage_generation);
     try rebuild_state.updateWithIo(io_impl.io(), "doc:m");
 
-    // There is deliberately no DB at db_path. If the progress probe attempts
-    // DB.open instead of trusting the durable marker, this call fails rather
-    // than returning the expected in-progress result.
+    // The lightweight status-only open reads the authoritative catalog
+    // generation without mapping retained full-text state. That lets it ignore
+    // stale same-name workers while still observing the current marker.
     try std.testing.expect(!try localRangeHasSchemaVersionIndex(
         alloc,
         path,

--- a/zig/pkg/antfly/src/metadata/table_provisioner.zig
+++ b/zig/pkg/antfly/src/metadata/table_provisioner.zig
@@ -3352,8 +3352,9 @@ test "table provisioner schema progress returns not ready from rebuild marker wi
     defer alloc.free(db_path);
     const index_root = try std.fmt.allocPrint(alloc, "{s}/indexes/full_text_index_v2", .{db_path});
     defer alloc.free(index_root);
+    try fs_paths.createDirPathPortable(io_impl.io(), index_root);
     const rebuild_state = db_mod.backfill_state.RebuildState.init(index_root);
-    try rebuild_state.update("doc:m");
+    try rebuild_state.updateWithIo(io_impl.io(), "doc:m");
 
     // There is deliberately no DB at db_path. If the progress probe attempts
     // DB.open instead of trusting the durable marker, this call fails rather

--- a/zig/pkg/antfly/src/metadata/table_provisioner.zig
+++ b/zig/pkg/antfly/src/metadata/table_provisioner.zig
@@ -3389,11 +3389,16 @@ test "table provisioner schema progress reads generation-owned rebuild state fro
 
 test "table provisioner schema progress quarantines a corrupt rebuild marker" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-metadata-table-provisioner-progress-corrupt-rebuild-marker";
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const path = try std.fmt.allocPrint(
+        alloc,
+        ".zig-cache/tmp/{s}/metadata-table-provisioner-progress-corrupt-rebuild-marker",
+        .{tmp.sub_path},
+    );
+    defer alloc.free(path);
     var io_impl = std.Io.Threaded.init(alloc, .{});
     defer io_impl.deinit();
-    std.Io.Dir.cwd().deleteTree(io_impl.io(), path) catch {};
-    defer std.Io.Dir.cwd().deleteTree(io_impl.io(), path) catch {};
 
     const db_path = try groupDbPathFromReplicaRoot(alloc, path, 2008);
     defer alloc.free(db_path);

--- a/zig/pkg/antfly/src/storage/db/backfill_state.zig
+++ b/zig/pkg/antfly/src/storage/db/backfill_state.zig
@@ -19,15 +19,28 @@ const fs_paths = @import("../../common/fs_paths.zig");
 const lsm_backend = @import("../lsm_backend/storage_io.zig");
 
 const rebuild_state_name = "rebuild.state";
+const rebuild_state_generation_separator = ".g-";
 const rebuild_state_magic = "AFRBST01";
-const rebuild_state_version: u32 = 1;
+const rebuild_state_version_legacy_envelope: u32 = 1;
+const rebuild_state_version: u32 = 2;
+const rebuild_state_owner_bytes = @sizeOf(u64);
+const rebuild_state_flags_bytes = @sizeOf(u8);
+const rebuild_state_flag_complete: u8 = 1;
 const rebuild_state_key_length_bytes = @sizeOf(u32);
 const rebuild_state_checksum_bytes = @sizeOf(u32);
-const rebuild_state_header_bytes = rebuild_state_magic.len + @sizeOf(@TypeOf(rebuild_state_version)) + rebuild_state_key_length_bytes;
+const rebuild_state_v1_header_bytes = rebuild_state_magic.len + @sizeOf(@TypeOf(rebuild_state_version)) + rebuild_state_key_length_bytes;
+const rebuild_state_header_bytes = rebuild_state_magic.len + @sizeOf(@TypeOf(rebuild_state_version)) + rebuild_state_owner_bytes + rebuild_state_flags_bytes + rebuild_state_key_length_bytes;
 const rebuild_state_max_key_bytes = 64 * 1024;
 const rebuild_state_max_encoded_bytes = rebuild_state_header_bytes + rebuild_state_max_key_bytes + rebuild_state_checksum_bytes;
 const rebuild_state_max_read_bytes = rebuild_state_max_encoded_bytes + 1;
 const rebuild_state_temp_attempts = 16;
+
+const PublishFaultPoint = enum {
+    after_temp_sync,
+    after_rename,
+};
+
+var test_publish_fault: ?PublishFaultPoint = null;
 
 pub const LoadResult = union(enum) {
     absent,
@@ -44,9 +57,34 @@ pub const LoadResult = union(enum) {
     }
 };
 
+const DecodedCursor = struct {
+    owner_generation: ?u64,
+    complete: bool,
+    key: []u8,
+};
+
+const DecodedLoadResult = union(enum) {
+    absent,
+    legacy,
+    corrupt,
+    valid: DecodedCursor,
+
+    fn deinit(self: *DecodedLoadResult, alloc: Allocator) void {
+        switch (self.*) {
+            .valid => |cursor| alloc.free(cursor.key),
+            else => {},
+        }
+        self.* = undefined;
+    }
+};
+
 pub const RebuildState = struct {
     root_path: []const u8,
     storage: ?lsm_backend.Storage = null,
+    /// Immutable catalog-generation identity. A same-name index replacement
+    /// receives a new coverage generation, so an old worker can never publish
+    /// a cursor that the replacement generation will accept.
+    owner_generation: ?u64 = null,
 
     pub fn init(root_path: []const u8) RebuildState {
         return .{ .root_path = root_path };
@@ -54,6 +92,15 @@ pub const RebuildState = struct {
 
     pub fn initWithStorage(root_path: []const u8, storage: ?lsm_backend.Storage) RebuildState {
         return .{ .root_path = root_path, .storage = storage };
+    }
+
+    pub fn initOwned(root_path: []const u8, storage: ?lsm_backend.Storage, owner_generation: u64) RebuildState {
+        std.debug.assert(owner_generation != 0);
+        return .{
+            .root_path = root_path,
+            .storage = storage,
+            .owner_generation = owner_generation,
+        };
     }
 
     pub fn check(self: RebuildState, alloc: Allocator) !?[]u8 {
@@ -67,18 +114,32 @@ pub const RebuildState = struct {
     }
 
     pub fn checkWithIo(self: RebuildState, alloc: Allocator, io: std.Io) !?[]u8 {
-        var loaded = try self.loadWithIo(alloc, io);
+        var loaded = try self.loadDecodedWithIo(alloc, io);
+        defer loaded.deinit(alloc);
         return switch (loaded) {
             .absent => null,
-            .valid => |key| blk: {
-                loaded = undefined;
-                break :blk key;
+            .valid => |cursor| blk: {
+                if (self.owner_generation) |expected_owner| {
+                    if (cursor.owner_generation != expected_owner) {
+                        // A legacy cursor or a cursor from a same-name prior
+                        // generation is never a valid resume point. Publish an
+                        // owned restart marker before exposing the empty key.
+                        try self.publishOwnedRestartWithIo(io);
+                        try self.removeLegacyAfterMigrationWithIo(io);
+                        break :blk try alloc.dupe(u8, "");
+                    }
+                }
+                if (cursor.complete) break :blk null;
+                break :blk try alloc.dupe(u8, cursor.key);
             },
             .legacy => blk: {
                 // Pre-v1 cursors have no integrity envelope. Their position
                 // cannot be trusted after an upgrade, so preserve the active
                 // marker while forcing a safe rebuild from the beginning.
                 try self.updateWithIo(io, "");
+                if (self.owner_generation != null) {
+                    try self.removeLegacyAfterMigrationWithIo(io);
+                }
                 break :blk try alloc.dupe(u8, "");
             },
             .corrupt => error.InvalidRebuildState,
@@ -86,9 +147,41 @@ pub const RebuildState = struct {
     }
 
     pub fn loadWithIo(self: RebuildState, alloc: Allocator, io: std.Io) !LoadResult {
+        var decoded = try self.loadDecodedWithIo(alloc, io);
+        defer decoded.deinit(alloc);
+        return switch (decoded) {
+            .absent => .absent,
+            .legacy => .legacy,
+            .corrupt => .corrupt,
+            .valid => |cursor| if (cursor.complete)
+                .absent
+            else
+                .{ .valid = try alloc.dupe(u8, cursor.key) },
+        };
+    }
+
+    fn loadDecodedWithIo(self: RebuildState, alloc: Allocator, io: std.Io) !DecodedLoadResult {
         if (builtin.os.tag == .freestanding and self.storage == null) return .absent;
         const path = try self.pathAlloc(alloc);
         defer alloc.free(path);
+        const loaded = try self.loadDecodedAtPathWithIo(alloc, io, path);
+        if (loaded != .absent or self.owner_generation == null) return loaded;
+
+        // A pre-generation rebuild may be in flight during an upgrade. Its
+        // cursor cannot prove ownership, but its presence does prove that a
+        // rebuild was active. Return it so checkWithIo migrates to a safe
+        // generation-owned restart rather than silently treating it as done.
+        const legacy_path = try self.legacyPathAlloc(alloc);
+        defer alloc.free(legacy_path);
+        return try self.loadDecodedAtPathWithIo(alloc, io, legacy_path);
+    }
+
+    fn loadDecodedAtPathWithIo(
+        self: RebuildState,
+        alloc: Allocator,
+        io: std.Io,
+        path: []const u8,
+    ) !DecodedLoadResult {
         if (self.storage) |storage| {
             const encoded = storage.readFileAlloc(alloc, path, rebuild_state_max_read_bytes) catch |err| switch (err) {
                 error.FileNotFound, error.NotDir => return .absent,
@@ -96,9 +189,9 @@ pub const RebuildState = struct {
                 else => return err,
             };
             defer alloc.free(encoded);
-            return try decodeLoadResult(alloc, encoded);
+            return try decodeStateLoadResult(alloc, encoded);
         }
-        return try loadPathWithIo(alloc, io, path);
+        return try loadDecodedPathWithIo(alloc, io, path);
     }
 
     pub fn update(self: RebuildState, key: []const u8) !void {
@@ -114,32 +207,9 @@ pub const RebuildState = struct {
     pub fn updateWithIo(self: RebuildState, io: std.Io, key: []const u8) !void {
         if (builtin.os.tag == .freestanding and self.storage == null) return;
         const alloc = std.heap.page_allocator;
-        const encoded = try encodeState(alloc, key);
+        const encoded = try encodeState(alloc, self.owner_generation, false, key);
         defer alloc.free(encoded);
-        const path = try self.pathAlloc(alloc);
-        defer alloc.free(path);
-
-        if (self.storage) |storage| {
-            var sink = try storage.beginAtomicWrite(alloc, path);
-            var sink_active = true;
-            defer if (sink_active) sink.abort();
-            try sink.appendSlice(encoded);
-            sink_active = false;
-            try sink.finish();
-            return;
-        }
-
-        const tmp_path = try writeExclusiveTempStateFile(alloc, io, path, encoded);
-        defer alloc.free(tmp_path);
-        var tmp_exists = true;
-        defer if (tmp_exists) deleteFileWithIo(io, tmp_path) catch {};
-
-        renameWithIo(io, tmp_path, path) catch |err| switch (err) {
-            error.FileNotFound, error.NotDir => return error.RebuildStateOwnerStale,
-            else => return err,
-        };
-        tmp_exists = false;
-        try syncPublishedParent(io, path);
+        try self.publishEncodedWithIo(alloc, io, encoded);
     }
 
     pub fn clear(self: RebuildState) !void {
@@ -181,30 +251,114 @@ pub const RebuildState = struct {
     }
 
     pub fn pathAlloc(self: RebuildState, alloc: Allocator) ![]u8 {
+        if (self.owner_generation) |owner| {
+            return try std.fmt.allocPrint(
+                alloc,
+                "{s}/{s}{s}{x:0>16}",
+                .{ self.root_path, rebuild_state_name, rebuild_state_generation_separator, owner },
+            );
+        }
+        return try self.legacyPathAlloc(alloc);
+    }
+
+    fn legacyPathAlloc(self: RebuildState, alloc: Allocator) ![]u8 {
         return try std.fmt.allocPrint(alloc, "{s}/{s}", .{ self.root_path, rebuild_state_name });
+    }
+
+    fn publishOwnedRestartWithIo(self: RebuildState, io: std.Io) !void {
+        const owner = self.owner_generation orelse return error.RebuildStateOwnerRequired;
+        const alloc = std.heap.page_allocator;
+        const encoded = try encodeState(alloc, owner, false, "");
+        defer alloc.free(encoded);
+        try self.publishEncodedWithIo(alloc, io, encoded);
+    }
+
+    fn removeLegacyAfterMigrationWithIo(self: RebuildState, io: std.Io) !void {
+        if (self.owner_generation == null) return;
+        const alloc = std.heap.page_allocator;
+        const path = try self.legacyPathAlloc(alloc);
+        defer alloc.free(path);
+        if (self.storage) |storage| {
+            storage.deleteFileAbsolute(path) catch |err| switch (err) {
+                error.FileNotFound, error.NotDir => return,
+                else => return err,
+            };
+            storage.syncParentAbsolute(path) catch |err| switch (err) {
+                error.DurableDirectorySyncUnsupported => return,
+                else => return error.RebuildStateDurabilityUncertain,
+            };
+            return;
+        }
+        deleteFileWithIo(io, path) catch |err| switch (err) {
+            error.FileNotFound, error.NotDir => return,
+            else => return err,
+        };
+        try syncPublishedParent(io, path);
+    }
+
+    fn publishEncodedWithIo(self: RebuildState, alloc: Allocator, io: std.Io, encoded: []const u8) !void {
+        const path = try self.pathAlloc(alloc);
+        defer alloc.free(path);
+        if (self.storage) |storage| {
+            var sink = try storage.beginAtomicWrite(alloc, path);
+            var sink_active = true;
+            defer if (sink_active) sink.abort();
+            try sink.appendSlice(encoded);
+            sink_active = false;
+            try sink.finish();
+            return;
+        }
+
+        const tmp_path = try writeExclusiveTempStateFile(alloc, io, path, encoded);
+        defer alloc.free(tmp_path);
+        var tmp_exists = true;
+        defer if (tmp_exists) deleteFileWithIo(io, tmp_path) catch {};
+        try injectPublishFault(.after_temp_sync);
+        renameWithIo(io, tmp_path, path) catch |err| switch (err) {
+            error.FileNotFound, error.NotDir => return error.RebuildStateOwnerStale,
+            else => return err,
+        };
+        tmp_exists = false;
+        try injectPublishFault(.after_rename);
+        try syncPublishedParent(io, path);
     }
 };
 
-fn loadPathWithIo(alloc: Allocator, io: std.Io, path: []const u8) !LoadResult {
+pub fn ownerGenerationFromPath(path: []const u8) ?u64 {
+    const prefix = rebuild_state_name ++ rebuild_state_generation_separator;
+    const basename = std.fs.path.basename(path);
+    if (!std.mem.startsWith(u8, basename, prefix)) return null;
+    const encoded = basename[prefix.len..];
+    if (encoded.len != 16) return null;
+    const generation = std.fmt.parseInt(u64, encoded, 16) catch return null;
+    return if (generation == 0) null else generation;
+}
+
+fn injectPublishFault(point: PublishFaultPoint) !void {
+    if (!builtin.is_test) return;
+    if (test_publish_fault == point) return error.TestRebuildStateCrash;
+}
+
+fn loadDecodedPathWithIo(alloc: Allocator, io: std.Io, path: []const u8) !DecodedLoadResult {
     const encoded = std.Io.Dir.cwd().readFileAlloc(io, path, alloc, .limited(rebuild_state_max_read_bytes)) catch |err| switch (err) {
         error.FileNotFound, error.NotDir => return .absent,
         error.StreamTooLong => return .corrupt,
         else => return err,
     };
     defer alloc.free(encoded);
-    return try decodeLoadResult(alloc, encoded);
+    return try decodeStateLoadResult(alloc, encoded);
 }
 
-fn decodeLoadResult(alloc: Allocator, encoded: []const u8) !LoadResult {
+fn decodeStateLoadResult(alloc: Allocator, encoded: []const u8) !DecodedLoadResult {
     if (!std.mem.startsWith(u8, encoded, rebuild_state_magic)) {
         // The old on-disk format was exactly the raw resume key.
         return if (encoded.len <= rebuild_state_max_key_bytes) .legacy else .corrupt;
     }
-    const key = decodeState(alloc, encoded) catch |err| switch (err) {
+    const cursor = decodeState(alloc, encoded) catch |err| switch (err) {
         error.InvalidRebuildState => return .corrupt,
         else => return err,
     };
-    return .{ .valid = key };
+    return .{ .valid = cursor };
 }
 
 fn writeExclusiveTempStateFile(alloc: Allocator, io: std.Io, path: []const u8, contents: []const u8) ![]u8 {
@@ -259,17 +413,30 @@ fn syncPublishedParent(io: std.Io, path: []const u8) !void {
     };
 }
 
-fn encodeState(alloc: Allocator, key: []const u8) ![]u8 {
+fn encodeState(alloc: Allocator, owner_generation: ?u64, complete: bool, key: []const u8) ![]u8 {
     if (key.len > rebuild_state_max_key_bytes or key.len > std.math.maxInt(u32)) {
         return error.RebuildStateTooLarge;
     }
 
-    const encoded = try alloc.alloc(u8, rebuild_state_header_bytes + key.len + rebuild_state_checksum_bytes);
+    const encoded_len = if (owner_generation == null)
+        rebuild_state_v1_header_bytes + key.len + rebuild_state_checksum_bytes
+    else
+        rebuild_state_header_bytes + key.len + rebuild_state_checksum_bytes;
+    const encoded = try alloc.alloc(u8, encoded_len);
     @memcpy(encoded[0..rebuild_state_magic.len], rebuild_state_magic);
 
     var pos = rebuild_state_magic.len;
-    std.mem.writeInt(u32, encoded[pos..][0..@sizeOf(@TypeOf(rebuild_state_version))], rebuild_state_version, .little);
+    const version = if (owner_generation == null) rebuild_state_version_legacy_envelope else rebuild_state_version;
+    std.mem.writeInt(u32, encoded[pos..][0..@sizeOf(@TypeOf(rebuild_state_version))], version, .little);
     pos += @sizeOf(@TypeOf(rebuild_state_version));
+    if (owner_generation) |owner| {
+        std.mem.writeInt(u64, encoded[pos..][0..rebuild_state_owner_bytes], owner, .little);
+        pos += rebuild_state_owner_bytes;
+        encoded[pos] = if (complete) rebuild_state_flag_complete else 0;
+        pos += rebuild_state_flags_bytes;
+    } else if (complete) {
+        return error.RebuildStateOwnerRequired;
+    }
     std.mem.writeInt(u32, encoded[pos..][0..rebuild_state_key_length_bytes], @intCast(key.len), .little);
     pos += rebuild_state_key_length_bytes;
     @memcpy(encoded[pos .. pos + key.len], key);
@@ -278,8 +445,8 @@ fn encodeState(alloc: Allocator, key: []const u8) ![]u8 {
     return encoded;
 }
 
-fn decodeState(alloc: Allocator, encoded: []const u8) ![]u8 {
-    if (encoded.len < rebuild_state_header_bytes + rebuild_state_checksum_bytes) {
+fn decodeState(alloc: Allocator, encoded: []const u8) !DecodedCursor {
+    if (encoded.len < rebuild_state_v1_header_bytes + rebuild_state_checksum_bytes) {
         return error.InvalidRebuildState;
     }
     if (!std.mem.eql(u8, encoded[0..rebuild_state_magic.len], rebuild_state_magic)) {
@@ -288,9 +455,26 @@ fn decodeState(alloc: Allocator, encoded: []const u8) ![]u8 {
 
     var pos = rebuild_state_magic.len;
     const version = std.mem.readInt(u32, encoded[pos..][0..@sizeOf(@TypeOf(rebuild_state_version))], .little);
-    if (version != rebuild_state_version) return error.InvalidRebuildState;
+    if (version != rebuild_state_version_legacy_envelope and version != rebuild_state_version) {
+        return error.InvalidRebuildState;
+    }
     pos += @sizeOf(@TypeOf(rebuild_state_version));
 
+    const owner_generation: ?u64 = if (version == rebuild_state_version) blk: {
+        if (encoded.len < rebuild_state_header_bytes + rebuild_state_checksum_bytes) {
+            return error.InvalidRebuildState;
+        }
+        const owner = std.mem.readInt(u64, encoded[pos..][0..rebuild_state_owner_bytes], .little);
+        if (owner == 0) return error.InvalidRebuildState;
+        pos += rebuild_state_owner_bytes;
+        break :blk owner;
+    } else null;
+    const flags: u8 = if (version == rebuild_state_version) blk: {
+        const value = encoded[pos];
+        if (value & ~rebuild_state_flag_complete != 0) return error.InvalidRebuildState;
+        pos += rebuild_state_flags_bytes;
+        break :blk value;
+    } else 0;
     const key_len: usize = std.mem.readInt(u32, encoded[pos..][0..rebuild_state_key_length_bytes], .little);
     pos += rebuild_state_key_length_bytes;
     if (key_len > rebuild_state_max_key_bytes or encoded.len - pos - rebuild_state_checksum_bytes != key_len) {
@@ -302,7 +486,13 @@ fn decodeState(alloc: Allocator, encoded: []const u8) ![]u8 {
     if (stored_checksum != std.hash.Crc32.hash(encoded[0..checksum_offset])) {
         return error.InvalidRebuildState;
     }
-    return try alloc.dupe(u8, encoded[pos..checksum_offset]);
+    const complete = flags & rebuild_state_flag_complete != 0;
+    if (complete and key_len != 0) return error.InvalidRebuildState;
+    return .{
+        .owner_generation = owner_generation,
+        .complete = complete,
+        .key = try alloc.dupe(u8, encoded[pos..checksum_offset]),
+    };
 }
 
 fn writeStateFile(io: std.Io, path: []const u8, contents: []const u8, exclusive: bool) !void {
@@ -381,7 +571,7 @@ test "rebuild state rejects key corruption" {
         .limited(rebuild_state_max_encoded_bytes),
     );
     defer std.testing.allocator.free(encoded);
-    encoded[rebuild_state_header_bytes + 4] = 'z';
+    encoded[rebuild_state_v1_header_bytes + 4] = 'z';
     try std.Io.Dir.cwd().writeFile(std.testing.io, .{ .sub_path = state_path, .data = encoded });
 
     try std.testing.expectError(error.InvalidRebuildState, state.check(std.testing.allocator));
@@ -474,6 +664,117 @@ test "rebuild state uses injected durable storage" {
 
     try state.clearWithIo(std.testing.io);
     try std.testing.expect((try state.checkWithIo(alloc, std.testing.io)) == null);
+}
+
+test "rebuild state generation owner fences same-name replacement ABA" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const path = try std.fmt.allocPrint(std.testing.allocator, ".zig-cache/tmp/{s}/rebuild-state-aba", .{tmp.sub_path});
+    defer std.testing.allocator.free(path);
+    try createTestStateRoot(path);
+
+    const old_generation = RebuildState.initOwned(path, null, 41);
+    const replacement = RebuildState.initOwned(path, null, 42);
+    try old_generation.updateWithIo(std.testing.io, "doc:m");
+
+    // The replacement cannot even observe the old generation's plausible
+    // cursor. Its normal empty-index path starts a new rebuild.
+    try std.testing.expect((try replacement.checkWithIo(std.testing.allocator, std.testing.io)) == null);
+    try replacement.updateWithIo(std.testing.io, "");
+    try replacement.updateWithIo(std.testing.io, "doc:f");
+
+    // A stale worker may keep running, but it can only mutate its own
+    // generation namespace. No timing interleaving can clobber generation 42.
+    try old_generation.updateWithIo(std.testing.io, "doc:z");
+    try old_generation.clearWithIo(std.testing.io);
+
+    const current = (try replacement.checkWithIo(std.testing.allocator, std.testing.io)) orelse
+        return error.TestExpectedEqual;
+    defer std.testing.allocator.free(current);
+    try std.testing.expectEqualStrings("doc:f", current);
+}
+
+test "rebuild state owned completion cannot erase replacement cursor" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const path = try std.fmt.allocPrint(std.testing.allocator, ".zig-cache/tmp/{s}/rebuild-state-owned-clear", .{tmp.sub_path});
+    defer std.testing.allocator.free(path);
+    try createTestStateRoot(path);
+
+    const old_generation = RebuildState.initOwned(path, null, 71);
+    const replacement = RebuildState.initOwned(path, null, 72);
+    try old_generation.updateWithIo(std.testing.io, "doc:b");
+    try old_generation.clearWithIo(std.testing.io);
+    try std.testing.expect((try old_generation.checkWithIo(std.testing.allocator, std.testing.io)) == null);
+
+    try replacement.updateWithIo(std.testing.io, "");
+    try replacement.updateWithIo(std.testing.io, "doc:q");
+    try old_generation.clearWithIo(std.testing.io);
+    const current = (try replacement.checkWithIo(std.testing.allocator, std.testing.io)) orelse
+        return error.TestExpectedEqual;
+    defer std.testing.allocator.free(current);
+    try std.testing.expectEqualStrings("doc:q", current);
+}
+
+test "rebuild state owned migration safely restarts an in-flight legacy cursor" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const path = try std.fmt.allocPrint(std.testing.allocator, ".zig-cache/tmp/{s}/rebuild-state-owner-migration", .{tmp.sub_path});
+    defer std.testing.allocator.free(path);
+    try createTestStateRoot(path);
+
+    const legacy = RebuildState.init(path);
+    try legacy.updateWithIo(std.testing.io, "doc:m");
+
+    const owned = RebuildState.initOwned(path, null, 91);
+    const restart = (try owned.checkWithIo(std.testing.allocator, std.testing.io)) orelse
+        return error.TestExpectedEqual;
+    defer std.testing.allocator.free(restart);
+    try std.testing.expectEqualStrings("", restart);
+
+    const owned_path = try owned.pathAlloc(std.testing.allocator);
+    defer std.testing.allocator.free(owned_path);
+    try std.testing.expect(std.mem.endsWith(u8, owned_path, "rebuild.state.g-000000000000005b"));
+
+    // Migration retires the unowned marker only after the owned restart is
+    // durable. Completion therefore cannot rediscover the legacy cursor and
+    // spuriously restart the same generation forever.
+    try owned.clearWithIo(std.testing.io);
+    try std.testing.expect((try owned.checkWithIo(std.testing.allocator, std.testing.io)) == null);
+}
+
+test "rebuild state publication crash boundaries preserve a valid state" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const path = try std.fmt.allocPrint(std.testing.allocator, ".zig-cache/tmp/{s}/rebuild-state-publication-crash", .{tmp.sub_path});
+    defer std.testing.allocator.free(path);
+    try createTestStateRoot(path);
+
+    const state = RebuildState.initOwned(path, null, 101);
+    try state.updateWithIo(std.testing.io, "doc:a");
+
+    test_publish_fault = .after_temp_sync;
+    defer test_publish_fault = null;
+    try std.testing.expectError(
+        error.TestRebuildStateCrash,
+        state.updateWithIo(std.testing.io, "doc:b"),
+    );
+    var loaded = (try state.checkWithIo(std.testing.allocator, std.testing.io)) orelse
+        return error.TestExpectedEqual;
+    try std.testing.expectEqualStrings("doc:a", loaded);
+    std.testing.allocator.free(loaded);
+
+    // A crash after rename has an ambiguous acknowledgement but never a
+    // partial cursor: recovery sees the fully checksummed replacement.
+    test_publish_fault = .after_rename;
+    try std.testing.expectError(
+        error.TestRebuildStateCrash,
+        state.updateWithIo(std.testing.io, "doc:c"),
+    );
+    loaded = (try state.checkWithIo(std.testing.allocator, std.testing.io)) orelse
+        return error.TestExpectedEqual;
+    defer std.testing.allocator.free(loaded);
+    try std.testing.expectEqualStrings("doc:c", loaded);
 }
 
 test "rebuild state estimates progress from resume key" {

--- a/zig/pkg/antfly/src/storage/db/backfill_state.zig
+++ b/zig/pkg/antfly/src/storage/db/backfill_state.zig
@@ -16,7 +16,6 @@ const std = @import("std");
 const builtin = @import("builtin");
 const Allocator = std.mem.Allocator;
 const fs_paths = @import("../../common/fs_paths.zig");
-const storage_io = @import("../lsm_backend/storage_io.zig");
 
 const rebuild_state_name = "rebuild.state";
 const rebuild_state_magic = "AFRBST01";
@@ -27,7 +26,22 @@ const rebuild_state_header_bytes = rebuild_state_magic.len + @sizeOf(@TypeOf(reb
 const rebuild_state_max_key_bytes = 64 * 1024;
 const rebuild_state_max_encoded_bytes = rebuild_state_header_bytes + rebuild_state_max_key_bytes + rebuild_state_checksum_bytes;
 const rebuild_state_max_read_bytes = rebuild_state_max_encoded_bytes + 1;
-var temp_nonce: u64 = 0;
+const rebuild_state_temp_attempts = 16;
+
+pub const LoadResult = union(enum) {
+    absent,
+    legacy,
+    corrupt,
+    valid: []u8,
+
+    pub fn deinit(self: *LoadResult, alloc: Allocator) void {
+        switch (self.*) {
+            .valid => |key| alloc.free(key),
+            else => {},
+        }
+        self.* = undefined;
+    }
+};
 
 pub const RebuildState = struct {
     root_path: []const u8,
@@ -40,112 +54,85 @@ pub const RebuildState = struct {
         if (builtin.os.tag == .freestanding) {
             return null;
         }
-        const path = try self.pathAlloc(alloc);
-        defer alloc.free(path);
-
         var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
         defer io_impl.deinit();
-        const encoded = std.Io.Dir.cwd().readFileAlloc(io_impl.io(), path, alloc, .limited(rebuild_state_max_read_bytes)) catch |err| switch (err) {
-            error.FileNotFound => return null,
-            error.NotDir => return null,
-            error.StreamTooLong => return error.InvalidRebuildState,
-            else => return err,
+        return try self.checkWithIo(alloc, io_impl.io());
+    }
+
+    pub fn checkWithIo(self: RebuildState, alloc: Allocator, io: std.Io) !?[]u8 {
+        var loaded = try self.loadWithIo(alloc, io);
+        return switch (loaded) {
+            .absent => null,
+            .valid => |key| blk: {
+                loaded = undefined;
+                break :blk key;
+            },
+            .legacy => blk: {
+                // Pre-v1 cursors have no integrity envelope. Their position
+                // cannot be trusted after an upgrade, so preserve the active
+                // marker while forcing a safe rebuild from the beginning.
+                try self.updateWithIo(io, "");
+                break :blk try alloc.dupe(u8, "");
+            },
+            .corrupt => error.InvalidRebuildState,
         };
-        defer alloc.free(encoded);
-        return try decodeState(alloc, encoded);
+    }
+
+    pub fn loadWithIo(self: RebuildState, alloc: Allocator, io: std.Io) !LoadResult {
+        if (builtin.os.tag == .freestanding) return .absent;
+        const path = try self.pathAlloc(alloc);
+        defer alloc.free(path);
+        return try loadPathWithIo(alloc, io, path);
     }
 
     pub fn update(self: RebuildState, key: []const u8) !void {
         if (builtin.os.tag == .freestanding) {
             return;
         }
-        const encoded = try encodeState(std.heap.page_allocator, key);
-        defer std.heap.page_allocator.free(encoded);
-
-        const path = try self.pathAlloc(std.heap.page_allocator);
-        defer std.heap.page_allocator.free(path);
-        temp_nonce +%= 1;
-        const tmp_path = try std.fmt.allocPrint(std.heap.page_allocator, "{s}.tmp-{d}", .{
-            path,
-            temp_nonce,
-        });
-        defer std.heap.page_allocator.free(tmp_path);
-
         var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
         defer io_impl.deinit();
-        const io = io_impl.io();
-        ensureParentDir(io, path) catch |err| switch (err) {
-            error.NotDir => return,
-            else => return err,
-        };
-        ensureParentDir(io, tmp_path) catch |err| switch (err) {
-            error.NotDir => return,
-            else => return err,
-        };
+        try self.updateWithIo(io_impl.io(), key);
+    }
 
-        writeStateFile(io, tmp_path, encoded) catch |err| switch (err) {
-            error.NotDir => return,
+    pub fn updateWithIo(self: RebuildState, io: std.Io, key: []const u8) !void {
+        if (builtin.os.tag == .freestanding) return;
+        const alloc = std.heap.page_allocator;
+        const encoded = try encodeState(alloc, key);
+        defer alloc.free(encoded);
+        const path = try self.pathAlloc(alloc);
+        defer alloc.free(path);
+
+        const tmp_path = try writeExclusiveTempStateFile(alloc, io, path, encoded);
+        defer alloc.free(tmp_path);
+        var tmp_exists = true;
+        defer if (tmp_exists) deleteFileWithIo(io, tmp_path) catch {};
+
+        renameWithIo(io, tmp_path, path) catch |err| switch (err) {
+            error.FileNotFound, error.NotDir => return error.RebuildStateOwnerStale,
             else => return err,
         };
-
-        if (std.fs.path.isAbsolute(path)) {
-            renameAbsolutePortable(tmp_path, path) catch |err| switch (err) {
-                error.FileNotFound => {
-                    ensureParentDir(io, path) catch |parent_err| switch (parent_err) {
-                        error.NotDir => return,
-                        else => return parent_err,
-                    };
-                    writeStateFile(io, path, encoded) catch |write_err| switch (write_err) {
-                        error.NotDir => return,
-                        else => return write_err,
-                    };
-                    std.Io.Dir.deleteFileAbsolute(io, tmp_path) catch {};
-                },
-                error.NotDir => return,
-                else => return err,
-            };
-        } else {
-            std.Io.Dir.rename(std.Io.Dir.cwd(), tmp_path, std.Io.Dir.cwd(), path, io) catch |err| switch (err) {
-                error.FileNotFound => {
-                    ensureParentDir(io, path) catch |parent_err| switch (parent_err) {
-                        error.NotDir => return,
-                        else => return parent_err,
-                    };
-                    writeStateFile(io, path, encoded) catch |write_err| switch (write_err) {
-                        error.NotDir => return,
-                        else => return write_err,
-                    };
-                    std.Io.Dir.cwd().deleteFile(io, tmp_path) catch {};
-                },
-                error.NotDir => return,
-                else => return err,
-            };
-        }
-        try fs_paths.syncDirPortable(io, std.fs.path.dirname(path) orelse ".");
+        tmp_exists = false;
+        try syncPublishedParent(io, path);
     }
 
     pub fn clear(self: RebuildState) !void {
         if (builtin.os.tag == .freestanding) {
             return;
         }
-        const path = try self.pathAlloc(std.heap.page_allocator);
-        defer std.heap.page_allocator.free(path);
-
         var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
         defer io_impl.deinit();
-        if (std.fs.path.isAbsolute(path)) {
-            std.Io.Dir.deleteFileAbsolute(io_impl.io(), path) catch |err| switch (err) {
-                error.FileNotFound => {},
-                error.NotDir => {},
-                else => return err,
-            };
-        } else {
-            std.Io.Dir.cwd().deleteFile(io_impl.io(), path) catch |err| switch (err) {
-                error.FileNotFound => {},
-                error.NotDir => {},
-                else => return err,
-            };
-        }
+        try self.clearWithIo(io_impl.io());
+    }
+
+    pub fn clearWithIo(self: RebuildState, io: std.Io) !void {
+        if (builtin.os.tag == .freestanding) return;
+        const path = try self.pathAlloc(std.heap.page_allocator);
+        defer std.heap.page_allocator.free(path);
+        deleteFileWithIo(io, path) catch |err| switch (err) {
+            error.FileNotFound, error.NotDir => return,
+            else => return err,
+        };
+        try syncPublishedParent(io, path);
     }
 
     pub fn estimateProgress(self: RebuildState, range_start: []const u8, range_end: []const u8, alloc: Allocator) !?f64 {
@@ -159,41 +146,75 @@ pub const RebuildState = struct {
     }
 };
 
-fn ensureParentDir(io: std.Io, path: []const u8) !void {
-    if (std.fs.path.dirname(path)) |parent| {
-        try storage_io.createDirPathPortable(io, parent);
+fn loadPathWithIo(alloc: Allocator, io: std.Io, path: []const u8) !LoadResult {
+    const encoded = std.Io.Dir.cwd().readFileAlloc(io, path, alloc, .limited(rebuild_state_max_read_bytes)) catch |err| switch (err) {
+        error.FileNotFound, error.NotDir => return .absent,
+        error.StreamTooLong => return .corrupt,
+        else => return err,
+    };
+    defer alloc.free(encoded);
+
+    if (!std.mem.startsWith(u8, encoded, rebuild_state_magic)) {
+        // The old on-disk format was exactly the raw resume key.
+        return if (encoded.len <= rebuild_state_max_key_bytes) .legacy else .corrupt;
+    }
+    const key = decodeState(alloc, encoded) catch |err| switch (err) {
+        error.InvalidRebuildState => return .corrupt,
+        else => return err,
+    };
+    return .{ .valid = key };
+}
+
+fn writeExclusiveTempStateFile(alloc: Allocator, io: std.Io, path: []const u8, contents: []const u8) ![]u8 {
+    for (0..rebuild_state_temp_attempts) |_| {
+        var entropy: [@sizeOf(u128)]u8 = undefined;
+        try io.randomSecure(&entropy);
+        const nonce = std.mem.readInt(u128, &entropy, .little);
+        const tmp_path = try std.fmt.allocPrint(alloc, "{s}.tmp-{x}", .{ path, nonce });
+        writeStateFile(io, tmp_path, contents, true) catch |err| switch (err) {
+            error.PathAlreadyExists => {
+                alloc.free(tmp_path);
+                continue;
+            },
+            error.FileNotFound, error.NotDir => {
+                alloc.free(tmp_path);
+                return error.RebuildStateOwnerStale;
+            },
+            else => {
+                deleteFileWithIo(io, tmp_path) catch {};
+                alloc.free(tmp_path);
+                return err;
+            },
+        };
+        return tmp_path;
+    }
+    return error.RebuildStateTempCollision;
+}
+
+fn renameWithIo(io: std.Io, old_path: []const u8, new_path: []const u8) !void {
+    if (std.fs.path.isAbsolute(new_path)) {
+        try std.Io.Dir.renameAbsolute(old_path, new_path, io);
+    } else {
+        try std.Io.Dir.rename(std.Io.Dir.cwd(), old_path, std.Io.Dir.cwd(), new_path, io);
     }
 }
 
-fn renameAbsolutePortable(old_path: []const u8, new_path: []const u8) !void {
-    const allocator = std.heap.page_allocator;
-    const old_path_z = try allocator.dupeZ(u8, old_path);
-    defer allocator.free(old_path_z);
-    const new_path_z = try allocator.dupeZ(u8, new_path);
-    defer allocator.free(new_path_z);
-
-    while (true) {
-        const rc = std.posix.system.rename(old_path_z, new_path_z);
-        switch (std.posix.errno(rc)) {
-            .SUCCESS => return,
-            .INTR => continue,
-            .ACCES, .PERM, .ROFS => return error.AccessDenied,
-            .BUSY => return error.FileBusy,
-            .IO => return error.InputOutput,
-            .INVAL => return error.InvalidArgument,
-            .ISDIR => return error.IsDir,
-            .LOOP => return error.SymLinkLoop,
-            .MLINK => return error.LinkQuotaExceeded,
-            .NAMETOOLONG => return error.NameTooLong,
-            .NOENT => return error.FileNotFound,
-            .NOTDIR => return error.NotDir,
-            .NOMEM => return error.SystemResources,
-            .NOSPC => return error.NoSpaceLeft,
-            .NOTEMPTY, .EXIST => return error.PathAlreadyExists,
-            .XDEV => return error.RenameAcrossMountPoints,
-            else => |err| return std.posix.unexpectedErrno(err),
-        }
+fn deleteFileWithIo(io: std.Io, path: []const u8) !void {
+    if (std.fs.path.isAbsolute(path)) {
+        try std.Io.Dir.deleteFileAbsolute(io, path);
+    } else {
+        try std.Io.Dir.cwd().deleteFile(io, path);
     }
+}
+
+fn syncPublishedParent(io: std.Io, path: []const u8) !void {
+    fs_paths.syncDirPortable(io, std.fs.path.dirname(path) orelse ".") catch |err| switch (err) {
+        // Platforms without durable directory sync have an explicit
+        // best-effort publication policy. Do not report an ordinary write
+        // failure after the atomic replacement is already visible.
+        error.DurableDirectorySyncUnsupported => return,
+        else => return error.RebuildStateDurabilityUncertain,
+    };
 }
 
 fn encodeState(alloc: Allocator, key: []const u8) ![]u8 {
@@ -242,8 +263,8 @@ fn decodeState(alloc: Allocator, encoded: []const u8) ![]u8 {
     return try alloc.dupe(u8, encoded[pos..checksum_offset]);
 }
 
-fn writeStateFile(io: std.Io, path: []const u8, contents: []const u8) !void {
-    var file = try fs_paths.createFilePortable(io, path, .{ .truncate = true });
+fn writeStateFile(io: std.Io, path: []const u8, contents: []const u8, exclusive: bool) !void {
+    var file = try fs_paths.createFilePortable(io, path, .{ .truncate = true, .exclusive = exclusive });
     defer file.close(io);
 
     var buf: [4096]u8 = undefined;
@@ -275,6 +296,10 @@ fn keyToU64(key: []const u8) u64 {
     return std.mem.readInt(u64, &buf, .big);
 }
 
+fn createTestStateRoot(path: []const u8) !void {
+    try fs_paths.createDirPathPortable(std.testing.io, path);
+}
+
 test "rebuild state round trips and clears" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -283,6 +308,7 @@ test "rebuild state round trips and clears" {
 
     const state = RebuildState.init(path);
     try std.testing.expect((try state.check(std.testing.allocator)) == null);
+    try createTestStateRoot(path);
     try state.update("doc:m");
     const loaded = (try state.check(std.testing.allocator)) orelse return error.TestExpectedEqual;
     defer std.testing.allocator.free(loaded);
@@ -302,6 +328,7 @@ test "rebuild state rejects key corruption" {
     defer std.testing.allocator.free(path);
 
     const state = RebuildState.init(path);
+    try createTestStateRoot(path);
     try state.update("doc:m");
     const state_path = try state.pathAlloc(std.testing.allocator);
     defer std.testing.allocator.free(state_path);
@@ -327,6 +354,7 @@ test "rebuild state rejects truncation" {
     defer std.testing.allocator.free(path);
 
     const state = RebuildState.init(path);
+    try createTestStateRoot(path);
     try state.update("doc:m");
     const state_path = try state.pathAlloc(std.testing.allocator);
     defer std.testing.allocator.free(state_path);
@@ -340,6 +368,47 @@ test "rebuild state rejects truncation" {
     try std.Io.Dir.cwd().writeFile(std.testing.io, .{ .sub_path = state_path, .data = encoded[0 .. encoded.len - 1] });
 
     try std.testing.expectError(error.InvalidRebuildState, state.check(std.testing.allocator));
+}
+
+test "rebuild state upgrades legacy cursor by restarting from scratch" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const path = try std.fmt.allocPrint(std.testing.allocator, ".zig-cache/tmp/{s}/rebuild-state-legacy", .{tmp.sub_path});
+    defer std.testing.allocator.free(path);
+    try createTestStateRoot(path);
+
+    const state = RebuildState.init(path);
+    const state_path = try state.pathAlloc(std.testing.allocator);
+    defer std.testing.allocator.free(state_path);
+    try std.Io.Dir.cwd().writeFile(std.testing.io, .{ .sub_path = state_path, .data = "doc:m" });
+
+    var legacy = try state.loadWithIo(std.testing.allocator, std.testing.io);
+    defer legacy.deinit(std.testing.allocator);
+    try std.testing.expect(legacy == .legacy);
+
+    const restart_key = (try state.checkWithIo(std.testing.allocator, std.testing.io)) orelse return error.TestExpectedEqual;
+    defer std.testing.allocator.free(restart_key);
+    try std.testing.expectEqualStrings("", restart_key);
+
+    var migrated = try state.loadWithIo(std.testing.allocator, std.testing.io);
+    defer migrated.deinit(std.testing.allocator);
+    switch (migrated) {
+        .valid => |key| try std.testing.expectEqualStrings("", key),
+        else => return error.TestExpectedValidRebuildState,
+    }
+}
+
+test "rebuild state update does not recreate vanished owner directory" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const path = try std.fmt.allocPrint(std.testing.allocator, ".zig-cache/tmp/{s}/rebuild-state-stale-owner", .{tmp.sub_path});
+    defer std.testing.allocator.free(path);
+    try createTestStateRoot(path);
+    try std.Io.Dir.cwd().deleteTree(std.testing.io, path);
+
+    const state = RebuildState.init(path);
+    try std.testing.expectError(error.RebuildStateOwnerStale, state.updateWithIo(std.testing.io, "doc:m"));
+    try std.testing.expectError(error.FileNotFound, std.Io.Dir.cwd().access(std.testing.io, path, .{}));
 }
 
 test "rebuild state estimates progress from resume key" {

--- a/zig/pkg/antfly/src/storage/db/backfill_state.zig
+++ b/zig/pkg/antfly/src/storage/db/backfill_state.zig
@@ -16,6 +16,7 @@ const std = @import("std");
 const builtin = @import("builtin");
 const Allocator = std.mem.Allocator;
 const fs_paths = @import("../../common/fs_paths.zig");
+const lsm_backend = @import("../lsm_backend/storage_io.zig");
 
 const rebuild_state_name = "rebuild.state";
 const rebuild_state_magic = "AFRBST01";
@@ -45,9 +46,14 @@ pub const LoadResult = union(enum) {
 
 pub const RebuildState = struct {
     root_path: []const u8,
+    storage: ?lsm_backend.Storage = null,
 
     pub fn init(root_path: []const u8) RebuildState {
         return .{ .root_path = root_path };
+    }
+
+    pub fn initWithStorage(root_path: []const u8, storage: ?lsm_backend.Storage) RebuildState {
+        return .{ .root_path = root_path, .storage = storage };
     }
 
     pub fn check(self: RebuildState, alloc: Allocator) !?[]u8 {
@@ -82,6 +88,15 @@ pub const RebuildState = struct {
         if (builtin.os.tag == .freestanding) return .absent;
         const path = try self.pathAlloc(alloc);
         defer alloc.free(path);
+        if (self.storage) |storage| {
+            const encoded = storage.readFileAlloc(alloc, path, rebuild_state_max_read_bytes) catch |err| switch (err) {
+                error.FileNotFound, error.NotDir => return .absent,
+                error.FileTooBig, error.StreamTooLong => return .corrupt,
+                else => return err,
+            };
+            defer alloc.free(encoded);
+            return try decodeLoadResult(alloc, encoded);
+        }
         return try loadPathWithIo(alloc, io, path);
     }
 
@@ -101,6 +116,16 @@ pub const RebuildState = struct {
         defer alloc.free(encoded);
         const path = try self.pathAlloc(alloc);
         defer alloc.free(path);
+
+        if (self.storage) |storage| {
+            var sink = try storage.beginAtomicWrite(alloc, path);
+            var sink_active = true;
+            defer if (sink_active) sink.abort();
+            try sink.appendSlice(encoded);
+            sink_active = false;
+            try sink.finish();
+            return;
+        }
 
         const tmp_path = try writeExclusiveTempStateFile(alloc, io, path, encoded);
         defer alloc.free(tmp_path);
@@ -128,6 +153,17 @@ pub const RebuildState = struct {
         if (builtin.os.tag == .freestanding) return;
         const path = try self.pathAlloc(std.heap.page_allocator);
         defer std.heap.page_allocator.free(path);
+        if (self.storage) |storage| {
+            storage.deleteFileAbsolute(path) catch |err| switch (err) {
+                error.FileNotFound, error.NotDir => return,
+                else => return err,
+            };
+            storage.syncParentAbsolute(path) catch |err| switch (err) {
+                error.DurableDirectorySyncUnsupported => return,
+                else => return error.RebuildStateDurabilityUncertain,
+            };
+            return;
+        }
         deleteFileWithIo(io, path) catch |err| switch (err) {
             error.FileNotFound, error.NotDir => return,
             else => return err,
@@ -153,7 +189,10 @@ fn loadPathWithIo(alloc: Allocator, io: std.Io, path: []const u8) !LoadResult {
         else => return err,
     };
     defer alloc.free(encoded);
+    return try decodeLoadResult(alloc, encoded);
+}
 
+fn decodeLoadResult(alloc: Allocator, encoded: []const u8) !LoadResult {
     if (!std.mem.startsWith(u8, encoded, rebuild_state_magic)) {
         // The old on-disk format was exactly the raw resume key.
         return if (encoded.len <= rebuild_state_max_key_bytes) .legacy else .corrupt;
@@ -409,6 +448,29 @@ test "rebuild state update does not recreate vanished owner directory" {
     const state = RebuildState.init(path);
     try std.testing.expectError(error.RebuildStateOwnerStale, state.updateWithIo(std.testing.io, "doc:m"));
     try std.testing.expectError(error.FileNotFound, std.Io.Dir.cwd().access(std.testing.io, path, .{}));
+}
+
+test "rebuild state uses injected durable storage" {
+    const alloc = std.testing.allocator;
+    var memory = lsm_backend.MemoryStorage.init(alloc);
+    defer memory.deinit();
+    const storage = memory.storage();
+    const state = RebuildState.initWithStorage("__test/indexes/search", storage);
+
+    try std.testing.expect((try state.checkWithIo(alloc, std.testing.io)) == null);
+    try state.updateWithIo(std.testing.io, "doc:m");
+    const loaded = (try state.checkWithIo(alloc, std.testing.io)) orelse return error.TestExpectedEqual;
+    defer alloc.free(loaded);
+    try std.testing.expectEqualStrings("doc:m", loaded);
+
+    const state_path = try state.pathAlloc(alloc);
+    defer alloc.free(state_path);
+    const encoded = try storage.readFileAlloc(alloc, state_path, rebuild_state_max_encoded_bytes);
+    defer alloc.free(encoded);
+    try std.testing.expectEqualStrings(rebuild_state_magic, encoded[0..rebuild_state_magic.len]);
+
+    try state.clearWithIo(std.testing.io);
+    try std.testing.expect((try state.checkWithIo(alloc, std.testing.io)) == null);
 }
 
 test "rebuild state estimates progress from resume key" {

--- a/zig/pkg/antfly/src/storage/db/backfill_state.zig
+++ b/zig/pkg/antfly/src/storage/db/backfill_state.zig
@@ -58,7 +58,8 @@ pub const RebuildState = struct {
 
     pub fn check(self: RebuildState, alloc: Allocator) !?[]u8 {
         if (builtin.os.tag == .freestanding) {
-            return null;
+            if (self.storage == null) return null;
+            return try self.checkWithIo(alloc, undefined);
         }
         var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
         defer io_impl.deinit();
@@ -85,7 +86,7 @@ pub const RebuildState = struct {
     }
 
     pub fn loadWithIo(self: RebuildState, alloc: Allocator, io: std.Io) !LoadResult {
-        if (builtin.os.tag == .freestanding) return .absent;
+        if (builtin.os.tag == .freestanding and self.storage == null) return .absent;
         const path = try self.pathAlloc(alloc);
         defer alloc.free(path);
         if (self.storage) |storage| {
@@ -102,7 +103,8 @@ pub const RebuildState = struct {
 
     pub fn update(self: RebuildState, key: []const u8) !void {
         if (builtin.os.tag == .freestanding) {
-            return;
+            if (self.storage == null) return;
+            return try self.updateWithIo(undefined, key);
         }
         var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
         defer io_impl.deinit();
@@ -110,7 +112,7 @@ pub const RebuildState = struct {
     }
 
     pub fn updateWithIo(self: RebuildState, io: std.Io, key: []const u8) !void {
-        if (builtin.os.tag == .freestanding) return;
+        if (builtin.os.tag == .freestanding and self.storage == null) return;
         const alloc = std.heap.page_allocator;
         const encoded = try encodeState(alloc, key);
         defer alloc.free(encoded);
@@ -142,7 +144,8 @@ pub const RebuildState = struct {
 
     pub fn clear(self: RebuildState) !void {
         if (builtin.os.tag == .freestanding) {
-            return;
+            if (self.storage == null) return;
+            return try self.clearWithIo(undefined);
         }
         var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
         defer io_impl.deinit();
@@ -150,7 +153,7 @@ pub const RebuildState = struct {
     }
 
     pub fn clearWithIo(self: RebuildState, io: std.Io) !void {
-        if (builtin.os.tag == .freestanding) return;
+        if (builtin.os.tag == .freestanding and self.storage == null) return;
         const path = try self.pathAlloc(std.heap.page_allocator);
         defer std.heap.page_allocator.free(path);
         if (self.storage) |storage| {

--- a/zig/pkg/antfly/src/storage/db/backfill_state.zig
+++ b/zig/pkg/antfly/src/storage/db/backfill_state.zig
@@ -153,10 +153,13 @@ pub const RebuildState = struct {
             .absent => .absent,
             .legacy => .legacy,
             .corrupt => .corrupt,
-            .valid => |cursor| if (cursor.complete)
-                .absent
-            else
-                .{ .valid = try alloc.dupe(u8, cursor.key) },
+            .valid => |cursor| blk: {
+                if (self.owner_generation) |expected_owner| {
+                    if (cursor.owner_generation != expected_owner) break :blk .legacy;
+                }
+                if (cursor.complete) break :blk .absent;
+                break :blk .{ .valid = try alloc.dupe(u8, cursor.key) };
+            },
         };
     }
 
@@ -741,6 +744,34 @@ test "rebuild state owned migration safely restarts an in-flight legacy cursor" 
     // spuriously restart the same generation forever.
     try owned.clearWithIo(std.testing.io);
     try std.testing.expect((try owned.checkWithIo(std.testing.allocator, std.testing.io)) == null);
+}
+
+test "rebuild state nonmutating load reports owned legacy without migration" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const path = try std.fmt.allocPrint(alloc, ".zig-cache/tmp/{s}/rebuild-state-owner-inspect", .{tmp.sub_path});
+    defer alloc.free(path);
+    try createTestStateRoot(path);
+
+    const legacy = RebuildState.init(path);
+    try legacy.updateWithIo(std.testing.io, "doc:m");
+    const legacy_path = try legacy.pathAlloc(alloc);
+    defer alloc.free(legacy_path);
+    const before = try std.Io.Dir.cwd().readFileAlloc(std.testing.io, legacy_path, alloc, .limited(rebuild_state_max_encoded_bytes));
+    defer alloc.free(before);
+
+    const owned = RebuildState.initOwned(path, null, 91);
+    var loaded = try owned.loadWithIo(alloc, std.testing.io);
+    defer loaded.deinit(alloc);
+    try std.testing.expect(loaded == .legacy);
+
+    const owned_path = try owned.pathAlloc(alloc);
+    defer alloc.free(owned_path);
+    try std.testing.expectError(error.FileNotFound, std.Io.Dir.cwd().access(std.testing.io, owned_path, .{}));
+    const after = try std.Io.Dir.cwd().readFileAlloc(std.testing.io, legacy_path, alloc, .limited(rebuild_state_max_encoded_bytes));
+    defer alloc.free(after);
+    try std.testing.expectEqualStrings(before, after);
 }
 
 test "rebuild state publication crash boundaries preserve a valid state" {

--- a/zig/pkg/antfly/src/storage/db/backfill_state.zig
+++ b/zig/pkg/antfly/src/storage/db/backfill_state.zig
@@ -19,6 +19,14 @@ const fs_paths = @import("../../common/fs_paths.zig");
 const storage_io = @import("../lsm_backend/storage_io.zig");
 
 const rebuild_state_name = "rebuild.state";
+const rebuild_state_magic = "AFRBST01";
+const rebuild_state_version: u32 = 1;
+const rebuild_state_key_length_bytes = @sizeOf(u32);
+const rebuild_state_checksum_bytes = @sizeOf(u32);
+const rebuild_state_header_bytes = rebuild_state_magic.len + @sizeOf(@TypeOf(rebuild_state_version)) + rebuild_state_key_length_bytes;
+const rebuild_state_max_key_bytes = 64 * 1024;
+const rebuild_state_max_encoded_bytes = rebuild_state_header_bytes + rebuild_state_max_key_bytes + rebuild_state_checksum_bytes;
+const rebuild_state_max_read_bytes = rebuild_state_max_encoded_bytes + 1;
 var temp_nonce: u64 = 0;
 
 pub const RebuildState = struct {
@@ -37,17 +45,23 @@ pub const RebuildState = struct {
 
         var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
         defer io_impl.deinit();
-        return std.Io.Dir.cwd().readFileAlloc(io_impl.io(), path, alloc, .limited(64 * 1024)) catch |err| switch (err) {
-            error.FileNotFound => null,
-            error.NotDir => null,
+        const encoded = std.Io.Dir.cwd().readFileAlloc(io_impl.io(), path, alloc, .limited(rebuild_state_max_read_bytes)) catch |err| switch (err) {
+            error.FileNotFound => return null,
+            error.NotDir => return null,
+            error.StreamTooLong => return error.InvalidRebuildState,
             else => return err,
         };
+        defer alloc.free(encoded);
+        return try decodeState(alloc, encoded);
     }
 
     pub fn update(self: RebuildState, key: []const u8) !void {
         if (builtin.os.tag == .freestanding) {
             return;
         }
+        const encoded = try encodeState(std.heap.page_allocator, key);
+        defer std.heap.page_allocator.free(encoded);
+
         const path = try self.pathAlloc(std.heap.page_allocator);
         defer std.heap.page_allocator.free(path);
         temp_nonce +%= 1;
@@ -69,7 +83,7 @@ pub const RebuildState = struct {
             else => return err,
         };
 
-        writeStateFile(io, tmp_path, key) catch |err| switch (err) {
+        writeStateFile(io, tmp_path, encoded) catch |err| switch (err) {
             error.NotDir => return,
             else => return err,
         };
@@ -81,7 +95,7 @@ pub const RebuildState = struct {
                         error.NotDir => return,
                         else => return parent_err,
                     };
-                    writeStateFile(io, path, key) catch |write_err| switch (write_err) {
+                    writeStateFile(io, path, encoded) catch |write_err| switch (write_err) {
                         error.NotDir => return,
                         else => return write_err,
                     };
@@ -97,7 +111,7 @@ pub const RebuildState = struct {
                         error.NotDir => return,
                         else => return parent_err,
                     };
-                    writeStateFile(io, path, key) catch |write_err| switch (write_err) {
+                    writeStateFile(io, path, encoded) catch |write_err| switch (write_err) {
                         error.NotDir => return,
                         else => return write_err,
                     };
@@ -107,6 +121,7 @@ pub const RebuildState = struct {
                 else => return err,
             };
         }
+        try fs_paths.syncDirPortable(io, std.fs.path.dirname(path) orelse ".");
     }
 
     pub fn clear(self: RebuildState) !void {
@@ -181,14 +196,61 @@ fn renameAbsolutePortable(old_path: []const u8, new_path: []const u8) !void {
     }
 }
 
-fn writeStateFile(io: std.Io, path: []const u8, key: []const u8) !void {
+fn encodeState(alloc: Allocator, key: []const u8) ![]u8 {
+    if (key.len > rebuild_state_max_key_bytes or key.len > std.math.maxInt(u32)) {
+        return error.RebuildStateTooLarge;
+    }
+
+    const encoded = try alloc.alloc(u8, rebuild_state_header_bytes + key.len + rebuild_state_checksum_bytes);
+    @memcpy(encoded[0..rebuild_state_magic.len], rebuild_state_magic);
+
+    var pos = rebuild_state_magic.len;
+    std.mem.writeInt(u32, encoded[pos..][0..@sizeOf(@TypeOf(rebuild_state_version))], rebuild_state_version, .little);
+    pos += @sizeOf(@TypeOf(rebuild_state_version));
+    std.mem.writeInt(u32, encoded[pos..][0..rebuild_state_key_length_bytes], @intCast(key.len), .little);
+    pos += rebuild_state_key_length_bytes;
+    @memcpy(encoded[pos .. pos + key.len], key);
+    pos += key.len;
+    std.mem.writeInt(u32, encoded[pos..][0..rebuild_state_checksum_bytes], std.hash.Crc32.hash(encoded[0..pos]), .little);
+    return encoded;
+}
+
+fn decodeState(alloc: Allocator, encoded: []const u8) ![]u8 {
+    if (encoded.len < rebuild_state_header_bytes + rebuild_state_checksum_bytes) {
+        return error.InvalidRebuildState;
+    }
+    if (!std.mem.eql(u8, encoded[0..rebuild_state_magic.len], rebuild_state_magic)) {
+        return error.InvalidRebuildState;
+    }
+
+    var pos = rebuild_state_magic.len;
+    const version = std.mem.readInt(u32, encoded[pos..][0..@sizeOf(@TypeOf(rebuild_state_version))], .little);
+    if (version != rebuild_state_version) return error.InvalidRebuildState;
+    pos += @sizeOf(@TypeOf(rebuild_state_version));
+
+    const key_len: usize = std.mem.readInt(u32, encoded[pos..][0..rebuild_state_key_length_bytes], .little);
+    pos += rebuild_state_key_length_bytes;
+    if (key_len > rebuild_state_max_key_bytes or encoded.len - pos - rebuild_state_checksum_bytes != key_len) {
+        return error.InvalidRebuildState;
+    }
+
+    const checksum_offset = encoded.len - rebuild_state_checksum_bytes;
+    const stored_checksum = std.mem.readInt(u32, encoded[checksum_offset..][0..rebuild_state_checksum_bytes], .little);
+    if (stored_checksum != std.hash.Crc32.hash(encoded[0..checksum_offset])) {
+        return error.InvalidRebuildState;
+    }
+    return try alloc.dupe(u8, encoded[pos..checksum_offset]);
+}
+
+fn writeStateFile(io: std.Io, path: []const u8, contents: []const u8) !void {
     var file = try fs_paths.createFilePortable(io, path, .{ .truncate = true });
     defer file.close(io);
 
     var buf: [4096]u8 = undefined;
     var writer = file.writer(io, &buf);
-    try writer.interface.writeAll(key);
+    try writer.interface.writeAll(contents);
     try writer.end();
+    try file.sync(io);
 }
 
 pub fn estimateProgressForKey(range_start: []const u8, range_end: []const u8, current_key: []const u8) f64 {
@@ -214,12 +276,10 @@ fn keyToU64(key: []const u8) u64 {
 }
 
 test "rebuild state round trips and clears" {
-    const path = "/tmp/antfly-backfill-state-test";
-    var io_impl = std.Io.Threaded.init(std.testing.allocator, .{});
-    defer io_impl.deinit();
-    std.Io.Dir.cwd().deleteTree(io_impl.io(), path) catch {};
-    defer std.Io.Dir.cwd().deleteTree(io_impl.io(), path) catch {};
-    try fs_paths.createDirPathPortable(io_impl.io(), path);
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const path = try std.fmt.allocPrint(std.testing.allocator, ".zig-cache/tmp/{s}/rebuild-state", .{tmp.sub_path});
+    defer std.testing.allocator.free(path);
 
     const state = RebuildState.init(path);
     try std.testing.expect((try state.check(std.testing.allocator)) == null);
@@ -227,8 +287,59 @@ test "rebuild state round trips and clears" {
     const loaded = (try state.check(std.testing.allocator)) orelse return error.TestExpectedEqual;
     defer std.testing.allocator.free(loaded);
     try std.testing.expectEqualStrings("doc:m", loaded);
+    try state.update("");
+    const empty = (try state.check(std.testing.allocator)) orelse return error.TestExpectedEqual;
+    defer std.testing.allocator.free(empty);
+    try std.testing.expectEqualStrings("", empty);
     try state.clear();
     try std.testing.expect((try state.check(std.testing.allocator)) == null);
+}
+
+test "rebuild state rejects key corruption" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const path = try std.fmt.allocPrint(std.testing.allocator, ".zig-cache/tmp/{s}/rebuild-state-corrupt", .{tmp.sub_path});
+    defer std.testing.allocator.free(path);
+
+    const state = RebuildState.init(path);
+    try state.update("doc:m");
+    const state_path = try state.pathAlloc(std.testing.allocator);
+    defer std.testing.allocator.free(state_path);
+    const encoded = try std.Io.Dir.cwd().readFileAlloc(
+        std.testing.io,
+        state_path,
+        std.testing.allocator,
+        .limited(rebuild_state_max_encoded_bytes),
+    );
+    defer std.testing.allocator.free(encoded);
+    encoded[rebuild_state_header_bytes + 4] = 'z';
+    try std.Io.Dir.cwd().writeFile(std.testing.io, .{ .sub_path = state_path, .data = encoded });
+
+    try std.testing.expectError(error.InvalidRebuildState, state.check(std.testing.allocator));
+    // Validation quarantines the cursor; it must not silently clear it.
+    try std.testing.expectError(error.InvalidRebuildState, state.check(std.testing.allocator));
+}
+
+test "rebuild state rejects truncation" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const path = try std.fmt.allocPrint(std.testing.allocator, ".zig-cache/tmp/{s}/rebuild-state-truncated", .{tmp.sub_path});
+    defer std.testing.allocator.free(path);
+
+    const state = RebuildState.init(path);
+    try state.update("doc:m");
+    const state_path = try state.pathAlloc(std.testing.allocator);
+    defer std.testing.allocator.free(state_path);
+    const encoded = try std.Io.Dir.cwd().readFileAlloc(
+        std.testing.io,
+        state_path,
+        std.testing.allocator,
+        .limited(rebuild_state_max_encoded_bytes),
+    );
+    defer std.testing.allocator.free(encoded);
+    try std.Io.Dir.cwd().writeFile(std.testing.io, .{ .sub_path = state_path, .data = encoded[0 .. encoded.len - 1] });
+
+    try std.testing.expectError(error.InvalidRebuildState, state.check(std.testing.allocator));
 }
 
 test "rebuild state estimates progress from resume key" {

--- a/zig/pkg/antfly/src/storage/db/catalog/index_manager.zig
+++ b/zig/pkg/antfly/src/storage/db/catalog/index_manager.zig
@@ -1932,7 +1932,7 @@ pub const IndexManager = struct {
 
     pub fn resetFullTextIndexForArtifactRebuild(self: *IndexManager, store: *docstore_mod.DocStore, index_name: []const u8) !u64 {
         const entry = self.textIndexEntry(index_name) orelse return error.IndexNotFound;
-        const rebuild_state = backfill_state_mod.RebuildState.init(entry.rebuild_root_path);
+        const rebuild_state = self.rebuildState(.full_text, entry.rebuild_root_path);
 
         try entry.persistent.resetAllForRebuild();
         try rebuild_state.updateWithIo(self.checkpointIo(), "");
@@ -1976,7 +1976,7 @@ pub const IndexManager = struct {
         capacity_check: ?types.RepairCapacityCheck,
     ) !u64 {
         const entry = self.textIndexEntry(index_name) orelse return error.IndexNotFound;
-        const rebuild_state = backfill_state_mod.RebuildState.init(entry.rebuild_root_path);
+        const rebuild_state = self.rebuildState(.full_text, entry.rebuild_root_path);
 
         try checkRepairCancelled(cancel_check);
         try entry.persistent.resetAllForRebuild();
@@ -3549,6 +3549,21 @@ pub const IndexManager = struct {
 
     pub fn checkpointIo(self: *const IndexManager) std.Io {
         return self.io orelse std.Io.Threaded.global_single_threaded.io();
+    }
+
+    fn rebuildState(
+        self: *const IndexManager,
+        kind: types.IndexKind,
+        root_path: []const u8,
+    ) backfill_state_mod.RebuildState {
+        const storage = switch (kind) {
+            .full_text => self.text_lsm_storage,
+            .dense_vector => self.dense_lsm_storage,
+            .sparse_vector => self.sparse_lsm_storage,
+            .graph => self.graph_lsm_storage,
+            .algebraic => null,
+        };
+        return backfill_state_mod.RebuildState.initWithStorage(root_path, storage);
     }
 
     const GeneratedArtifactCleanupPlan = struct {
@@ -7949,7 +7964,7 @@ pub const IndexManager = struct {
         if (builtin.is_test) test_text_backfill_invocations += 1;
         self.beginTextBackfill();
         defer self.endTextBackfill();
-        const rebuild_state = backfill_state_mod.RebuildState.init(entry.rebuild_root_path);
+        const rebuild_state = self.rebuildState(.full_text, entry.rebuild_root_path);
         var runtime_store = try initRuntimeStore(self.alloc, store);
         defer runtime_store.deinit();
 
@@ -8147,7 +8162,7 @@ pub const IndexManager = struct {
     ) !void {
         self.beginTextBackfill();
         defer self.endTextBackfill();
-        const rebuild_state = backfill_state_mod.RebuildState.init(entry.rebuild_root_path);
+        const rebuild_state = self.rebuildState(.full_text, entry.rebuild_root_path);
 
         const lower = try internal_keys.documentRangeLowerAlloc(self.alloc, self.byte_range.start);
         defer self.alloc.free(lower);
@@ -8917,7 +8932,7 @@ pub const IndexManager = struct {
                     self.alloc.free(persisted_ranges);
                 }
 
-                const rebuild_state = backfill_state_mod.RebuildState.init(entry.rebuild_root_path);
+                const rebuild_state = self.rebuildState(.full_text, entry.rebuild_root_path);
                 var resume_from = rebuild_state.checkWithIo(self.alloc, self.checkpointIo()) catch |err| {
                     std.log.warn("full_text open failed step=rebuild_state_check name={s} err={s}", .{
                         cfg.name,
@@ -9144,7 +9159,7 @@ pub const IndexManager = struct {
                 index_moved = true;
                 errdefer self.freeSparseIndexEntry(&entry);
 
-                const rebuild_state = backfill_state_mod.RebuildState.init(entry.rebuild_root_path);
+                const rebuild_state = self.rebuildState(.sparse_vector, entry.rebuild_root_path);
                 const resume_from = try rebuild_state.checkWithIo(self.alloc, self.checkpointIo());
                 defer if (resume_from) |buf| self.alloc.free(buf);
 
@@ -9242,7 +9257,7 @@ pub const IndexManager = struct {
                 graph_cfg_moved = true;
                 errdefer self.freeGraphIndexEntry(&entry);
 
-                const rebuild_state = backfill_state_mod.RebuildState.init(entry.rebuild_root_path);
+                const rebuild_state = self.rebuildState(.graph, entry.rebuild_root_path);
                 const resume_from = try rebuild_state.checkWithIo(self.alloc, self.checkpointIo());
                 defer if (resume_from) |buf| self.alloc.free(buf);
                 const reverse_edges = (try entry.index.stats(self.alloc)).edge_count;
@@ -9260,7 +9275,13 @@ pub const IndexManager = struct {
                 if (allow_backfill and (resume_from != null or (has_replay_history and (reverse_store_missing or reverse_edges == 0) and !graph_replay_pending))) {
                     const backfill_started_ns = nowNs();
                     try rebuild_state.updateWithIo(self.checkpointIo(), if (resume_from) |buf| buf else "");
-                    _ = try entry.index.rebuildReverseFromOwnedOutgoingEdgesResume(self.alloc, self.byte_range.start, self.byte_range.end, resume_from);
+                    _ = try entry.index.rebuildReverseFromOwnedOutgoingEdgesResumeWithIo(
+                        self.alloc,
+                        self.checkpointIo(),
+                        self.byte_range.start,
+                        self.byte_range.end,
+                        resume_from,
+                    );
                     backfill_ns += elapsedSince(backfill_started_ns);
                 }
 
@@ -10376,7 +10397,7 @@ pub const IndexManager = struct {
     }
 
     fn backfillSparseIndex(self: *IndexManager, store: *docstore_mod.DocStore, entry: *SparseIndex, resume_from: ?[]const u8) !void {
-        const rebuild_state = backfill_state_mod.RebuildState.init(entry.rebuild_root_path);
+        const rebuild_state = self.rebuildState(.sparse_vector, entry.rebuild_root_path);
         var runtime_store = try initRuntimeStore(self.alloc, store);
         defer runtime_store.deinit();
 

--- a/zig/pkg/antfly/src/storage/db/catalog/index_manager.zig
+++ b/zig/pkg/antfly/src/storage/db/catalog/index_manager.zig
@@ -1926,13 +1926,14 @@ pub const IndexManager = struct {
             .reverse_lsm_root_generation = self.lsm_root_generation,
             .edge_type_configs = entry.edge_type_configs,
             .rebuild_root_path = path,
+            .rebuild_owner_generation = coverageGenerationForConfig(entry.config),
             .algebraic_semiring_traversal = graph_cfg.algebraic_semiring_traversal,
         });
     }
 
     pub fn resetFullTextIndexForArtifactRebuild(self: *IndexManager, store: *docstore_mod.DocStore, index_name: []const u8) !u64 {
         const entry = self.textIndexEntry(index_name) orelse return error.IndexNotFound;
-        const rebuild_state = self.rebuildState(.full_text, entry.rebuild_root_path);
+        const rebuild_state = self.rebuildState(.full_text, entry.rebuild_root_path, entry.config);
 
         try entry.persistent.resetAllForRebuild();
         try rebuild_state.updateWithIo(self.checkpointIo(), "");
@@ -1976,7 +1977,7 @@ pub const IndexManager = struct {
         capacity_check: ?types.RepairCapacityCheck,
     ) !u64 {
         const entry = self.textIndexEntry(index_name) orelse return error.IndexNotFound;
-        const rebuild_state = self.rebuildState(.full_text, entry.rebuild_root_path);
+        const rebuild_state = self.rebuildState(.full_text, entry.rebuild_root_path, entry.config);
 
         try checkRepairCancelled(cancel_check);
         try entry.persistent.resetAllForRebuild();
@@ -3558,6 +3559,7 @@ pub const IndexManager = struct {
         self: *const IndexManager,
         kind: types.IndexKind,
         root_path: []const u8,
+        cfg: types.IndexConfig,
     ) backfill_state_mod.RebuildState {
         const storage = switch (kind) {
             .full_text => self.text_lsm_storage,
@@ -3566,7 +3568,11 @@ pub const IndexManager = struct {
             .graph => self.graph_lsm_storage,
             .algebraic => null,
         };
-        return backfill_state_mod.RebuildState.initWithStorage(root_path, storage);
+        return backfill_state_mod.RebuildState.initOwned(
+            root_path,
+            storage,
+            coverageGenerationForConfig(cfg),
+        );
     }
 
     const GeneratedArtifactCleanupPlan = struct {
@@ -7967,7 +7973,7 @@ pub const IndexManager = struct {
         if (builtin.is_test) test_text_backfill_invocations += 1;
         self.beginTextBackfill();
         defer self.endTextBackfill();
-        const rebuild_state = self.rebuildState(.full_text, entry.rebuild_root_path);
+        const rebuild_state = self.rebuildState(.full_text, entry.rebuild_root_path, entry.config);
         var runtime_store = try initRuntimeStore(self.alloc, store);
         defer runtime_store.deinit();
 
@@ -8165,7 +8171,7 @@ pub const IndexManager = struct {
     ) !void {
         self.beginTextBackfill();
         defer self.endTextBackfill();
-        const rebuild_state = self.rebuildState(.full_text, entry.rebuild_root_path);
+        const rebuild_state = self.rebuildState(.full_text, entry.rebuild_root_path, entry.config);
 
         const lower = try internal_keys.documentRangeLowerAlloc(self.alloc, self.byte_range.start);
         defer self.alloc.free(lower);
@@ -8935,7 +8941,7 @@ pub const IndexManager = struct {
                     self.alloc.free(persisted_ranges);
                 }
 
-                const rebuild_state = self.rebuildState(.full_text, entry.rebuild_root_path);
+                const rebuild_state = self.rebuildState(.full_text, entry.rebuild_root_path, entry.config);
                 var resume_from = rebuild_state.checkWithIo(self.alloc, self.checkpointIo()) catch |err| {
                     std.log.warn("full_text open failed step=rebuild_state_check name={s} err={s}", .{
                         cfg.name,
@@ -9162,7 +9168,7 @@ pub const IndexManager = struct {
                 index_moved = true;
                 errdefer self.freeSparseIndexEntry(&entry);
 
-                const rebuild_state = self.rebuildState(.sparse_vector, entry.rebuild_root_path);
+                const rebuild_state = self.rebuildState(.sparse_vector, entry.rebuild_root_path, entry.config);
                 const resume_from = try rebuild_state.checkWithIo(self.alloc, self.checkpointIo());
                 defer if (resume_from) |buf| self.alloc.free(buf);
 
@@ -9238,6 +9244,7 @@ pub const IndexManager = struct {
                     .reverse_lsm_root_generation = self.lsm_root_generation,
                     .edge_type_configs = graph_cfg.edge_type_configs,
                     .rebuild_root_path = path,
+                    .rebuild_owner_generation = coverageGenerationForConfig(cfg),
                     .algebraic_semiring_traversal = graph_cfg.algebraic_semiring_traversal,
                 });
                 var index_moved = false;
@@ -9260,7 +9267,7 @@ pub const IndexManager = struct {
                 graph_cfg_moved = true;
                 errdefer self.freeGraphIndexEntry(&entry);
 
-                const rebuild_state = self.rebuildState(.graph, entry.rebuild_root_path);
+                const rebuild_state = self.rebuildState(.graph, entry.rebuild_root_path, entry.config);
                 const resume_from = try rebuild_state.checkWithIo(self.alloc, self.checkpointIo());
                 defer if (resume_from) |buf| self.alloc.free(buf);
                 const reverse_edges = (try entry.index.stats(self.alloc)).edge_count;
@@ -10400,7 +10407,7 @@ pub const IndexManager = struct {
     }
 
     fn backfillSparseIndex(self: *IndexManager, store: *docstore_mod.DocStore, entry: *SparseIndex, resume_from: ?[]const u8) !void {
-        const rebuild_state = self.rebuildState(.sparse_vector, entry.rebuild_root_path);
+        const rebuild_state = self.rebuildState(.sparse_vector, entry.rebuild_root_path, entry.config);
         var runtime_store = try initRuntimeStore(self.alloc, store);
         defer runtime_store.deinit();
 
@@ -14884,7 +14891,12 @@ test "dense rebuild state uses configured durable storage" {
     });
     defer manager.deinit();
 
-    const state = manager.rebuildState(.dense_vector, "__test/db/indexes/dense");
+    const state = manager.rebuildState(.dense_vector, "__test/db/indexes/dense", .{
+        .name = "dense",
+        .kind = .dense_vector,
+        .config_json = "{}",
+        .coverage_generation = 11,
+    });
     try state.updateWithIo(std.testing.io, "doc:m");
     const loaded = (try state.checkWithIo(alloc, std.testing.io)) orelse return error.TestExpectedEqual;
     defer alloc.free(loaded);

--- a/zig/pkg/antfly/src/storage/db/catalog/index_manager.zig
+++ b/zig/pkg/antfly/src/storage/db/catalog/index_manager.zig
@@ -3551,7 +3551,7 @@ pub const IndexManager = struct {
         return self.io orelse std.Io.Threaded.global_single_threaded.io();
     }
 
-    fn rebuildState(
+    pub fn rebuildState(
         self: *const IndexManager,
         kind: types.IndexKind,
         root_path: []const u8,
@@ -10440,7 +10440,7 @@ pub const IndexManager = struct {
                 try sparse_entry.index.batchWithOptions(writes_buf.items, &.{}, .{
                     .defer_term_range_updates = true,
                 });
-                doc_count.* += writes_buf.items.len;
+                doc_count.* = sparse_entry.index.doc_count;
                 try sparse_entry.index.persistBackfillDocCount(doc_count.*);
                 for (writes_buf.items) |item| {
                     manager.alloc.free(@constCast(item.doc_id));
@@ -14868,6 +14868,24 @@ fn buildSplitSegment(
         .segment_bytes = rebuilt,
         .doc_keys = try doc_keys.toOwnedSlice(alloc),
     };
+}
+
+test "dense rebuild state uses configured durable storage" {
+    const alloc = std.testing.allocator;
+    var memory = lsm_backend_mod.MemoryStorage.init(alloc);
+    defer memory.deinit();
+    const storage = memory.storage();
+
+    var manager = try IndexManager.initWithOptions(alloc, "__test/db", .{
+        .dense_lsm_storage = storage,
+    });
+    defer manager.deinit();
+
+    const state = manager.rebuildState(.dense_vector, "__test/db/indexes/dense");
+    try state.updateWithIo(std.testing.io, "doc:m");
+    const loaded = (try state.checkWithIo(alloc, std.testing.io)) orelse return error.TestExpectedEqual;
+    defer alloc.free(loaded);
+    try std.testing.expectEqualStrings("doc:m", loaded);
 }
 
 test "split preserves postings when text segments omit source bodies" {

--- a/zig/pkg/antfly/src/storage/db/catalog/index_manager.zig
+++ b/zig/pkg/antfly/src/storage/db/catalog/index_manager.zig
@@ -3551,6 +3551,9 @@ pub const IndexManager = struct {
         return self.io orelse std.Io.Threaded.global_single_threaded.io();
     }
 
+    /// Binds rebuild cursors to the same storage backend as their index kind.
+    /// Callers must use this instead of assuming the logical root is a host
+    /// filesystem path; Lite and other external roots may be single files.
     pub fn rebuildState(
         self: *const IndexManager,
         kind: types.IndexKind,

--- a/zig/pkg/antfly/src/storage/db/catalog/index_manager.zig
+++ b/zig/pkg/antfly/src/storage/db/catalog/index_manager.zig
@@ -1935,7 +1935,7 @@ pub const IndexManager = struct {
         const rebuild_state = backfill_state_mod.RebuildState.init(entry.rebuild_root_path);
 
         try entry.persistent.resetAllForRebuild();
-        try rebuild_state.update("");
+        try rebuild_state.updateWithIo(self.checkpointIo(), "");
         try self.backfillTextIndex(store, entry, null);
         try entry.persistent.sync(true);
         try self.saveBackfilledAppliedSequence(store, entry.config);
@@ -1980,7 +1980,7 @@ pub const IndexManager = struct {
 
         try checkRepairCancelled(cancel_check);
         try entry.persistent.resetAllForRebuild();
-        try rebuild_state.update("");
+        try rebuild_state.updateWithIo(self.checkpointIo(), "");
         try self.backfillTextIndexFromReadTxn(store, read_txn, entry, null, cancel_check, capacity_check);
         try checkRepairCancelled(cancel_check);
         try entry.persistent.sync(true);
@@ -7990,7 +7990,7 @@ pub const IndexManager = struct {
                     .compact_text = false,
                     .compact_text_segment_threshold = text_backfill_compact_segment_threshold,
                 }, stats);
-                try rebuild.update(last_doc_key);
+                try rebuild.updateWithIo(manager.checkpointIo(), last_doc_key);
                 for (docs_buf.items) |doc| {
                     manager.alloc.free(@constCast(doc.key));
                     manager.alloc.free(@constCast(doc.value));
@@ -8132,7 +8132,7 @@ pub const IndexManager = struct {
         }
 
         if (flushed_batches > 0) try self.compactTextIndex(&entry.persistent, activeTextMergePolicy());
-        if (!saw_visible_doc or flushed_batches > 0) try rebuild_state.clear();
+        if (!saw_visible_doc or flushed_batches > 0) try rebuild_state.clearWithIo(self.checkpointIo());
         if (flushed_batches > 0) try entry.persistent.checkpointLsmWalAfterDurableBoundary();
     }
 
@@ -8198,7 +8198,7 @@ pub const IndexManager = struct {
                     .compact_text = false,
                     .compact_text_segment_threshold = text_backfill_compact_segment_threshold,
                 }, stats);
-                try rebuild.update(last_doc_key);
+                try rebuild.updateWithIo(manager.checkpointIo(), last_doc_key);
                 for (docs_buf.items) |doc| {
                     manager.alloc.free(@constCast(doc.key));
                     manager.alloc.free(@constCast(doc.value));
@@ -8347,7 +8347,7 @@ pub const IndexManager = struct {
         }
 
         if (flushed_batches > 0) try self.compactTextIndex(&entry.persistent, activeTextMergePolicy());
-        if (!saw_visible_doc or flushed_batches > 0) try rebuild_state.clear();
+        if (!saw_visible_doc or flushed_batches > 0) try rebuild_state.clearWithIo(self.checkpointIo());
         if (flushed_batches > 0) try entry.persistent.checkpointLsmWalAfterDurableBoundary();
     }
 
@@ -8918,7 +8918,7 @@ pub const IndexManager = struct {
                 }
 
                 const rebuild_state = backfill_state_mod.RebuildState.init(entry.rebuild_root_path);
-                var resume_from = rebuild_state.check(self.alloc) catch |err| {
+                var resume_from = rebuild_state.checkWithIo(self.alloc, self.checkpointIo()) catch |err| {
                     std.log.warn("full_text open failed step=rebuild_state_check name={s} err={s}", .{
                         cfg.name,
                         @errorName(err),
@@ -8937,7 +8937,7 @@ pub const IndexManager = struct {
 
                 if (allow_full_text_backfill and (rebuild_from_scratch_after_interruption or resume_from != null or (entry.persistent.snapshot().global_doc_count == 0 and persisted_ranges.len == 0))) {
                     const backfill_started_ns = nowNs();
-                    try rebuild_state.update(if (resume_from) |buf| buf else "");
+                    try rebuild_state.updateWithIo(self.checkpointIo(), if (resume_from) |buf| buf else "");
                     try self.backfillTextIndex(store, &entry, resume_from);
                     try self.saveBackfilledAppliedSequence(store, cfg);
                     backfill_ns += elapsedSince(backfill_started_ns);
@@ -9145,12 +9145,12 @@ pub const IndexManager = struct {
                 errdefer self.freeSparseIndexEntry(&entry);
 
                 const rebuild_state = backfill_state_mod.RebuildState.init(entry.rebuild_root_path);
-                const resume_from = try rebuild_state.check(self.alloc);
+                const resume_from = try rebuild_state.checkWithIo(self.alloc, self.checkpointIo());
                 defer if (resume_from) |buf| self.alloc.free(buf);
 
                 if (allow_backfill and (resume_from != null or entry.index.next_doc_num == 0)) {
                     const backfill_started_ns = nowNs();
-                    try rebuild_state.update(if (resume_from) |buf| buf else "");
+                    try rebuild_state.updateWithIo(self.checkpointIo(), if (resume_from) |buf| buf else "");
                     try self.backfillSparseIndex(store, &entry, resume_from);
                     try self.saveBackfilledAppliedSequence(store, cfg);
                     backfill_ns += elapsedSince(backfill_started_ns);
@@ -9243,7 +9243,7 @@ pub const IndexManager = struct {
                 errdefer self.freeGraphIndexEntry(&entry);
 
                 const rebuild_state = backfill_state_mod.RebuildState.init(entry.rebuild_root_path);
-                const resume_from = try rebuild_state.check(self.alloc);
+                const resume_from = try rebuild_state.checkWithIo(self.alloc, self.checkpointIo());
                 defer if (resume_from) |buf| self.alloc.free(buf);
                 const reverse_edges = (try entry.index.stats(self.alloc)).edge_count;
 
@@ -9259,7 +9259,7 @@ pub const IndexManager = struct {
                 const has_replay_history = latest_replay_sequence != 0;
                 if (allow_backfill and (resume_from != null or (has_replay_history and (reverse_store_missing or reverse_edges == 0) and !graph_replay_pending))) {
                     const backfill_started_ns = nowNs();
-                    try rebuild_state.update(if (resume_from) |buf| buf else "");
+                    try rebuild_state.updateWithIo(self.checkpointIo(), if (resume_from) |buf| buf else "");
                     _ = try entry.index.rebuildReverseFromOwnedOutgoingEdgesResume(self.alloc, self.byte_range.start, self.byte_range.end, resume_from);
                     backfill_ns += elapsedSince(backfill_started_ns);
                 }
@@ -10427,7 +10427,7 @@ pub const IndexManager = struct {
                     manager.alloc.free(@constCast(item.vec.values));
                 }
                 writes_buf.clearRetainingCapacity();
-                try rebuild.update(last_doc_key);
+                try rebuild.updateWithIo(manager.checkpointIo(), last_doc_key);
                 flush_count.* += 1;
                 if (@import("builtin").is_test) {
                     if (test_abort_sparse_backfill_after_batches) |limit| {
@@ -10470,7 +10470,7 @@ pub const IndexManager = struct {
             try flush_batch(self, store, entry, rebuild_state, &writes, max_flushed_key.?, &flushed_batches, &backfilled_doc_count);
         }
 
-        if (!saw_visible_doc or flushed_batches > 0) try rebuild_state.clear();
+        if (!saw_visible_doc or flushed_batches > 0) try rebuild_state.clearWithIo(self.checkpointIo());
         if (flushed_batches > 0) try entry.index.checkpointLsmWalAfterDurableBoundary();
     }
 

--- a/zig/pkg/antfly/src/storage/db/db.zig
+++ b/zig/pkg/antfly/src/storage/db/db.zig
@@ -18712,7 +18712,7 @@ pub const DB = struct {
                     }
                     item.text_merge = self.core.index_manager.textMergeStatsForIndex(cfg.name);
                     if (self.core.textIndexEntry(cfg.name)) |entry| {
-                        const rebuild_state = backfill_state_mod.RebuildState.init(entry.rebuild_root_path);
+                        const rebuild_state = self.core.index_manager.rebuildState(.full_text, entry.rebuild_root_path);
                         if (try rebuild_state.estimateProgress(byte_range.start, byte_range.end, alloc)) |progress| {
                             item.backfill_active = true;
                             item.backfill_progress = progress;
@@ -18766,7 +18766,7 @@ pub const DB = struct {
                         else
                             sparse_stats.doc_count;
                         item.term_count = sparse_stats.term_count;
-                        const rebuild_state = backfill_state_mod.RebuildState.init(entry.rebuild_root_path);
+                        const rebuild_state = self.core.index_manager.rebuildState(.sparse_vector, entry.rebuild_root_path);
                         if (try rebuild_state.estimateProgress(byte_range.start, byte_range.end, alloc)) |progress| {
                             item.backfill_active = true;
                             item.backfill_progress = progress;
@@ -18788,7 +18788,7 @@ pub const DB = struct {
                         item.node_count = graph_stats.node_count;
                         item.doc_count = graph_stats.node_count;
                         applyGraphAlgebraicRuntimeStats(&item, &entry.index);
-                        const rebuild_state = backfill_state_mod.RebuildState.init(entry.rebuild_root_path);
+                        const rebuild_state = self.core.index_manager.rebuildState(.graph, entry.rebuild_root_path);
                         if (try rebuild_state.estimateProgress(byte_range.start, byte_range.end, alloc)) |progress| {
                             item.backfill_active = true;
                             item.backfill_progress = progress;
@@ -66697,6 +66697,92 @@ test "db dense artifact rebuild resumes from persisted state" {
         }
         try std.testing.expectEqual(@as(?u64, doc_count), dense_doc_count);
     }
+}
+
+test "db dense artifact rebuild persists state through external index storage" {
+    const alloc = std.testing.allocator;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const path = try std.fmt.allocPrint(alloc, ".zig-cache/tmp/{s}/table.aflite", .{tmp.sub_path});
+    defer alloc.free(path);
+    const index_base_path = try std.fmt.allocPrint(alloc, ".zig-cache/tmp/{s}/index-namespace", .{tmp.sub_path});
+    defer alloc.free(index_base_path);
+    try std.Io.Dir.cwd().writeFile(std.testing.io, .{
+        .sub_path = path,
+        .data = "single-file-container",
+    });
+
+    var index_storage = lsm_backend_mod.MemoryStorage.init(alloc);
+    defer index_storage.deinit();
+    const external_storage = index_storage.storage();
+
+    var db = try DB.open(alloc, path, .{
+        .primary_backend = .{ .mem = .{} },
+        .index_backends = .{
+            .dense_storage_backend = .lsm,
+            .dense_lsm_storage = external_storage,
+        },
+        .physical_root_mode = .external_backend,
+        .index_base_path = index_base_path,
+        .external_derived_checkpoints = false,
+        .start_index_workers = false,
+        .start_optional_runtimes = false,
+        .ttl_cleanup = .{ .enabled = false },
+    });
+    defer db.close();
+
+    try db.addIndex(.{
+        .name = "dense_idx",
+        .kind = .dense_vector,
+        .config_json = "{\"field\":\"embedding\",\"dims\":3,\"metric\":\"l2_squared\",\"external\":true}",
+    });
+
+    try db.batch(.{
+        .writes = &.{.{
+            .key = "doc:a",
+            .value = "{\"title\":\"alpha\"}",
+        }},
+        .sync_level = .write,
+    });
+    const artifact_key = try expectedDocumentEmbeddingArtifactKeyAlloc(alloc, "doc:a", "dense_idx");
+    defer alloc.free(artifact_key);
+    try putDenseEmbeddingArtifactWithCounterForTest(&db, alloc, artifact_key, null, &[_]f32{ 1, 0, 0 });
+
+    const rebuild_root_path = try db.denseIndexRebuildStatePathAlloc(alloc, "dense_idx");
+    defer alloc.free(rebuild_root_path);
+    const rebuild_state = db.core.index_manager.rebuildState(.dense_vector, rebuild_root_path);
+    try rebuild_state.updateWithIo(db.core.index_manager.checkpointIo(), "");
+    const persisted_cursor = (try rebuild_state.checkWithIo(alloc, db.core.index_manager.checkpointIo())) orelse
+        return error.MissingExternalRebuildState;
+    defer alloc.free(persisted_cursor);
+    const rebuilding_stats = try db.diagnosticStats(alloc);
+    defer types.freeDBStats(alloc, rebuilding_stats);
+    var saw_dense_index = false;
+    var saw_active_backfill = false;
+    for (rebuilding_stats.indexes) |index| {
+        if (!std.mem.eql(u8, index.name, "dense_idx")) continue;
+        saw_dense_index = true;
+        saw_active_backfill = index.backfill_active;
+        try std.testing.expectEqual(@as(u64, 0), index.doc_count);
+    }
+    try std.testing.expect(saw_dense_index);
+    try std.testing.expect(saw_active_backfill);
+
+    try std.testing.expectEqual(
+        @as(usize, 1),
+        try db.rebuildDenseIndexesFromStoredEmbeddingArtifactsIfNeeded(alloc),
+    );
+    try std.testing.expect((try rebuild_state.checkWithIo(alloc, db.core.index_manager.checkpointIo())) == null);
+
+    var result = try db.search(alloc, .{
+        .index_name = "dense_idx",
+        .query = .{ .dense_knn = .{ .vector = &.{ 1, 0, 0 }, .k = 1 } },
+        .limit = 1,
+    });
+    defer result.deinit();
+    try std.testing.expectEqual(@as(u32, 1), result.total_hits);
+    try std.testing.expectEqualStrings("doc:a", result.hits[0].id);
 }
 
 test "db dense artifact rebuild resume keys are owned by plan allocator" {

--- a/zig/pkg/antfly/src/storage/db/db.zig
+++ b/zig/pkg/antfly/src/storage/db/db.zig
@@ -16655,7 +16655,7 @@ pub const DB = struct {
 
             const rebuild_root_path = try self.denseIndexRebuildStatePathAlloc(alloc, entry.config.name);
             defer alloc.free(rebuild_root_path);
-            const rebuild_state = self.core.index_manager.rebuildState(.dense_vector, rebuild_root_path);
+            const rebuild_state = self.core.index_manager.rebuildState(.dense_vector, rebuild_root_path, entry.config);
             const persisted_resume = try rebuild_state.checkWithIo(alloc, self.core.index_manager.checkpointIo());
             errdefer if (persisted_resume) |buf| alloc.free(buf);
             const projection_checkpoint = try self.core.loadProjectionCheckpoint(alloc, entry.config.name);
@@ -16716,7 +16716,7 @@ pub const DB = struct {
             const entry = &self.core.index_manager.dense_indexes.items[dense_index_idx];
             const rebuild_root_path = try self.denseIndexRebuildStatePathAlloc(alloc, entry.config.name);
             defer alloc.free(rebuild_root_path);
-            const rebuild_state = self.core.index_manager.rebuildState(.dense_vector, rebuild_root_path);
+            const rebuild_state = self.core.index_manager.rebuildState(.dense_vector, rebuild_root_path, entry.config);
             const active_count = entry.index.stats().active_count;
             if (candidate.invalid_generation_error) |last_error| {
                 try generation_repairs.append(alloc, .{
@@ -16838,7 +16838,7 @@ pub const DB = struct {
             });
             const rebuild_root_path = try self.denseIndexRebuildStatePathAlloc(self.alloc, entry.config.name);
             defer self.alloc.free(rebuild_root_path);
-            const rebuild_state = self.core.index_manager.rebuildState(.dense_vector, rebuild_root_path);
+            const rebuild_state = self.core.index_manager.rebuildState(.dense_vector, rebuild_root_path, entry.config);
             try rebuild_state.updateWithIo(self.core.index_manager.checkpointIo(), target.resume_from orelse "");
         }
     }
@@ -16848,7 +16848,7 @@ pub const DB = struct {
             const entry = &self.core.index_manager.dense_indexes.items[target.dense_index_idx];
             const rebuild_root_path = try self.denseIndexRebuildStatePathAlloc(alloc, entry.config.name);
             defer alloc.free(rebuild_root_path);
-            const rebuild_state = self.core.index_manager.rebuildState(.dense_vector, rebuild_root_path);
+            const rebuild_state = self.core.index_manager.rebuildState(.dense_vector, rebuild_root_path, entry.config);
             const applied_sequence = try self.core.loadAppliedSequence(alloc, entry.config.name);
             const target_sequence = try self.probeDerivedReplayTargetSequence(
                 alloc,
@@ -16915,7 +16915,7 @@ pub const DB = struct {
                 if (applied_sequence < target_sequence) try self.core.saveAppliedSequence(entry.config.name, target_sequence);
                 const rebuild_root_path = try self.denseIndexRebuildStatePathAlloc(alloc, entry.config.name);
                 defer alloc.free(rebuild_root_path);
-                const rebuild_state = self.core.index_manager.rebuildState(.dense_vector, rebuild_root_path);
+                const rebuild_state = self.core.index_manager.rebuildState(.dense_vector, rebuild_root_path, entry.config);
                 try rebuild_state.clearWithIo(self.core.index_manager.checkpointIo());
                 try self.core.saveProjectionCheckpoint(entry.config.name, .{
                     .applied_sequence = target_sequence,
@@ -17216,7 +17216,7 @@ pub const DB = struct {
                     const entry = &persist.db.core.index_manager.dense_indexes.items[target.dense_index_idx];
                     const rebuild_root_path = try persist.db.denseIndexRebuildStatePathAlloc(persist.alloc, entry.config.name);
                     defer persist.alloc.free(rebuild_root_path);
-                    const rebuild_state = persist.db.core.index_manager.rebuildState(.dense_vector, rebuild_root_path);
+                    const rebuild_state = persist.db.core.index_manager.rebuildState(.dense_vector, rebuild_root_path, entry.config);
                     try rebuild_state.updateWithIo(persist.db.core.index_manager.checkpointIo(), last_key);
                     const owned_key = try persist.alloc.dupe(u8, last_key);
                     errdefer persist.alloc.free(owned_key);
@@ -18712,7 +18712,7 @@ pub const DB = struct {
                     }
                     item.text_merge = self.core.index_manager.textMergeStatsForIndex(cfg.name);
                     if (self.core.textIndexEntry(cfg.name)) |entry| {
-                        const rebuild_state = self.core.index_manager.rebuildState(.full_text, entry.rebuild_root_path);
+                        const rebuild_state = self.core.index_manager.rebuildState(.full_text, entry.rebuild_root_path, entry.config);
                         if (try rebuild_state.estimateProgress(byte_range.start, byte_range.end, alloc)) |progress| {
                             item.backfill_active = true;
                             item.backfill_progress = progress;
@@ -18734,7 +18734,7 @@ pub const DB = struct {
                         }
                         const rebuild_root_path = try self.denseIndexRebuildStatePathAlloc(alloc, entry.config.name);
                         defer alloc.free(rebuild_root_path);
-                        const rebuild_state = self.core.index_manager.rebuildState(.dense_vector, rebuild_root_path);
+                        const rebuild_state = self.core.index_manager.rebuildState(.dense_vector, rebuild_root_path, entry.config);
                         if (item.doc_count < visible_doc_count) {
                             if (try rebuild_state.estimateProgress(byte_range.start, byte_range.end, alloc)) |progress| {
                                 item.backfill_active = true;
@@ -18766,7 +18766,7 @@ pub const DB = struct {
                         else
                             sparse_stats.doc_count;
                         item.term_count = sparse_stats.term_count;
-                        const rebuild_state = self.core.index_manager.rebuildState(.sparse_vector, entry.rebuild_root_path);
+                        const rebuild_state = self.core.index_manager.rebuildState(.sparse_vector, entry.rebuild_root_path, entry.config);
                         if (try rebuild_state.estimateProgress(byte_range.start, byte_range.end, alloc)) |progress| {
                             item.backfill_active = true;
                             item.backfill_progress = progress;
@@ -18788,7 +18788,7 @@ pub const DB = struct {
                         item.node_count = graph_stats.node_count;
                         item.doc_count = graph_stats.node_count;
                         applyGraphAlgebraicRuntimeStats(&item, &entry.index);
-                        const rebuild_state = self.core.index_manager.rebuildState(.graph, entry.rebuild_root_path);
+                        const rebuild_state = self.core.index_manager.rebuildState(.graph, entry.rebuild_root_path, entry.config);
                         if (try rebuild_state.estimateProgress(byte_range.start, byte_range.end, alloc)) |progress| {
                             item.backfill_active = true;
                             item.backfill_progress = progress;
@@ -18849,6 +18849,40 @@ pub const DB = struct {
         };
     }
 
+    fn applyStatusOnlyRebuildStateStats(
+        self: *DB,
+        alloc: Allocator,
+        cfg: types.IndexConfig,
+        item: *types.DBIndexStats,
+    ) !void {
+        if (cfg.kind == .algebraic) return;
+        const rebuild_root_path = try self.denseIndexRebuildStatePathAlloc(alloc, cfg.name);
+        defer alloc.free(rebuild_root_path);
+        const rebuild_state = self.core.index_manager.rebuildState(cfg.kind, rebuild_root_path, cfg);
+        const resume_key = rebuild_state.checkWithIo(
+            alloc,
+            self.core.index_manager.checkpointIo(),
+        ) catch |err| switch (err) {
+            error.InvalidRebuildState => {
+                item.load_error = try alloc.dupe(u8, @errorName(err));
+                item.repair_degraded = true;
+                item.backfill_active = false;
+                item.backfill_progress = 0;
+                return;
+            },
+            else => return err,
+        };
+        defer if (resume_key) |key| alloc.free(key);
+        const key = resume_key orelse return;
+        const byte_range = self.core.byteRange();
+        item.backfill_active = true;
+        item.backfill_progress = backfill_state_mod.estimateProgressForKey(
+            byte_range.start,
+            byte_range.end,
+            key,
+        );
+    }
+
     fn statusOnlyStats(self: *DB, alloc: Allocator) !types.DBStats {
         lockApplyShared(self);
         defer self.core.unlockApplyShared();
@@ -18888,6 +18922,7 @@ pub const DB = struct {
             };
             errdefer freeDBIndexStatsItem(alloc, item);
             initializeDerivedCoverageIdentity(cfg, &item);
+            try self.applyStatusOnlyRebuildStateStats(alloc, cfg, &item);
             applyProjectionCheckpointStats(&item, projection_checkpoint, target_sequence);
             try applyDurableIndexRepairStats(
                 alloc,
@@ -18903,9 +18938,11 @@ pub const DB = struct {
                 item.backfill_active = item.backfill_active or applied_sequence < target_sequence;
             }
             if (self.core.index_manager.loadFailure(cfg.name)) |load_error| {
+                if (item.load_error) |previous| alloc.free(previous);
                 item.load_error = try alloc.dupe(u8, load_error);
                 applyTerminalLoadFailureStatus(&item);
             } else if (try self.loadPersistedIndexLoadFailure(alloc, cfg.name)) |load_error| {
+                if (item.load_error) |previous| alloc.free(previous);
                 item.load_error = load_error;
                 applyTerminalLoadFailureStatus(&item);
             }
@@ -42384,6 +42421,14 @@ test "db status_only open reads index catalog without loading index state" {
         const indexes = try status_db.listIndexes(alloc);
         defer types.freeIndexConfigs(alloc, indexes);
         try std.testing.expectEqual(@as(usize, 2), indexes.len);
+        var full_text_generation: u64 = 0;
+        for (indexes) |config| {
+            if (std.mem.eql(u8, config.name, "ft_v1")) {
+                full_text_generation = config.coverage_generation;
+                break;
+            }
+        }
+        try std.testing.expect(full_text_generation != 0);
 
         const stats = try status_db.stats(alloc);
         defer types.freeDBStats(alloc, stats);
@@ -42399,6 +42444,36 @@ test "db status_only open reads index catalog without loading index state" {
             try std.testing.expect(item.root_node > 0);
         }
         try std.testing.expect(saw_dense);
+
+        const rebuild_root = try std.fmt.allocPrint(alloc, "{s}/indexes/ft_v1", .{std.mem.span(path)});
+        defer alloc.free(rebuild_root);
+        const stale_generation = if (full_text_generation == 1) 2 else full_text_generation - 1;
+        const stale_state = backfill_state_mod.RebuildState.initOwned(rebuild_root, null, stale_generation);
+        defer stale_state.clear() catch {};
+        try stale_state.update("doc:stale");
+
+        const stale_stats = try status_db.stats(alloc);
+        defer types.freeDBStats(alloc, stale_stats);
+        const stale_ft = blk: {
+            for (stale_stats.indexes) |item| {
+                if (std.mem.eql(u8, item.name, "ft_v1")) break :blk item;
+            }
+            return error.TestUnexpectedResult;
+        };
+        try std.testing.expect(!stale_ft.backfill_active);
+
+        const current_state = backfill_state_mod.RebuildState.initOwned(rebuild_root, null, full_text_generation);
+        defer current_state.clear() catch {};
+        try current_state.update("doc:a");
+        const rebuilding_stats = try status_db.stats(alloc);
+        defer types.freeDBStats(alloc, rebuilding_stats);
+        const rebuilding_ft = blk: {
+            for (rebuilding_stats.indexes) |item| {
+                if (std.mem.eql(u8, item.name, "ft_v1")) break :blk item;
+            }
+            return error.TestUnexpectedResult;
+        };
+        try std.testing.expect(rebuilding_ft.backfill_active);
     }
 }
 
@@ -66751,7 +66826,11 @@ test "db dense artifact rebuild persists state through external index storage" {
 
     const rebuild_root_path = try db.denseIndexRebuildStatePathAlloc(alloc, "dense_idx");
     defer alloc.free(rebuild_root_path);
-    const rebuild_state = db.core.index_manager.rebuildState(.dense_vector, rebuild_root_path);
+    const rebuild_state = db.core.index_manager.rebuildState(
+        .dense_vector,
+        rebuild_root_path,
+        db.core.index_manager.denseIndex("dense_idx").?.config,
+    );
     try rebuild_state.updateWithIo(db.core.index_manager.checkpointIo(), "");
     const persisted_cursor = (try rebuild_state.checkWithIo(alloc, db.core.index_manager.checkpointIo())) orelse
         return error.MissingExternalRebuildState;

--- a/zig/pkg/antfly/src/storage/db/db.zig
+++ b/zig/pkg/antfly/src/storage/db/db.zig
@@ -16024,7 +16024,11 @@ pub const DB = struct {
     };
 
     fn denseIndexRebuildStatePathAlloc(self: *DB, alloc: Allocator, index_name: []const u8) ![]u8 {
-        return try std.fmt.allocPrint(alloc, "{s}/indexes/{s}", .{ self.core.path, index_name });
+        return try std.fmt.allocPrint(
+            alloc,
+            "{s}/indexes/{s}",
+            .{ self.core.index_manager.base_path, index_name },
+        );
     }
 
     fn denseArtifactNameForEntry(entry: anytype) []const u8 {
@@ -60266,6 +60270,8 @@ test "db full-text backfill resumes after interrupted reopen" {
     defer index_manager_mod.test_text_backfill_batch_size = null;
     index_manager_mod.test_abort_text_backfill_after_batches = 1;
     defer index_manager_mod.test_abort_text_backfill_after_batches = null;
+    var state_path: ?[]u8 = null;
+    defer if (state_path) |owned| alloc.free(owned);
     {
         // A per-index load failure no longer fails the whole open; the index
         // is quarantined with its error recorded and retried on next open.
@@ -60273,11 +60279,15 @@ test "db full-text backfill resumes after interrupted reopen" {
         defer interrupted.close();
         const recorded = interrupted.core.index_manager.loadFailure("ft_v1") orelse return error.TestUnexpectedResult;
         try std.testing.expectEqualStrings("TestInjectedBackfillFailure", recorded);
+
+        const cfg = interrupted.core.index_manager.get("ft_v1") orelse return error.IndexNotFound;
+        const rebuild_root = try interrupted.denseIndexRebuildStatePathAlloc(alloc, cfg.name);
+        defer alloc.free(rebuild_root);
+        const rebuild_state = interrupted.core.index_manager.rebuildState(cfg.kind, rebuild_root, cfg.*);
+        state_path = try rebuild_state.pathAlloc(alloc);
     }
 
-    const state_path = try std.fmt.allocPrint(alloc, "{s}/indexes/ft_v1/rebuild.state", .{std.mem.span(path)});
-    defer alloc.free(state_path);
-    const interrupted_state = try std.Io.Dir.cwd().readFileAlloc(std.testing.io, state_path, alloc, .limited(1024));
+    const interrupted_state = try std.Io.Dir.cwd().readFileAlloc(std.testing.io, state_path.?, alloc, .limited(1024));
     defer alloc.free(interrupted_state);
     try std.testing.expect(interrupted_state.len > 0);
 
@@ -60286,7 +60296,7 @@ test "db full-text backfill resumes after interrupted reopen" {
     var reopened = try DB.open(alloc, std.mem.span(path), .{});
     defer reopened.close();
 
-    try std.testing.expectError(error.FileNotFound, std.Io.Dir.cwd().readFileAlloc(std.testing.io, state_path, alloc, .limited(1024)));
+    try std.testing.expectError(error.FileNotFound, std.Io.Dir.cwd().readFileAlloc(std.testing.io, state_path.?, alloc, .limited(1024)));
 
     var result = try reopened.search(alloc, .{
         .index_name = "ft_v1",
@@ -60395,6 +60405,12 @@ test "db sparse backfill restarts safely from a legacy cursor after interrupted 
     defer index_manager_mod.test_sparse_backfill_batch_size = null;
     index_manager_mod.test_abort_sparse_backfill_after_batches = 1;
     defer index_manager_mod.test_abort_sparse_backfill_after_batches = null;
+    const rebuild_root = try std.fmt.allocPrint(alloc, "{s}/indexes/sp_v1", .{std.mem.span(path)});
+    defer alloc.free(rebuild_root);
+    var owned_state_path: ?[]u8 = null;
+    defer if (owned_state_path) |owned| alloc.free(owned);
+    var resume_key: ?[]u8 = null;
+    defer if (resume_key) |owned| alloc.free(owned);
     {
         // A per-index load failure no longer fails the whole open; the index
         // is quarantined with its error recorded and retried on next open.
@@ -60402,28 +60418,30 @@ test "db sparse backfill restarts safely from a legacy cursor after interrupted 
         defer interrupted.close();
         const recorded = interrupted.core.index_manager.loadFailure("sp_v1") orelse return error.TestUnexpectedResult;
         try std.testing.expectEqualStrings("TestInjectedBackfillFailure", recorded);
-    }
 
-    const rebuild_root = try std.fmt.allocPrint(alloc, "{s}/indexes/sp_v1", .{std.mem.span(path)});
-    defer alloc.free(rebuild_root);
-    const rebuild_state = backfill_state_mod.RebuildState.init(rebuild_root);
-    const state_path = try rebuild_state.pathAlloc(alloc);
-    defer alloc.free(state_path);
-    const resume_key = (try rebuild_state.checkWithIo(alloc, std.testing.io)) orelse return error.TestExpectedEqual;
-    defer alloc.free(resume_key);
-    try std.testing.expect(resume_key.len > 0);
+        const cfg = interrupted.core.index_manager.get("sp_v1") orelse return error.IndexNotFound;
+        const rebuild_state = interrupted.core.index_manager.rebuildState(cfg.kind, rebuild_root, cfg.*);
+        owned_state_path = try rebuild_state.pathAlloc(alloc);
+        resume_key = (try rebuild_state.checkWithIo(alloc, std.testing.io)) orelse return error.TestExpectedEqual;
+        try std.testing.expect(resume_key.?.len > 0);
+    }
 
     // Simulate an upgrade from the legacy raw-cursor format. It cannot be
     // trusted, so reopen must restart from the beginning without inflating the
     // persisted sparse document count for rows already indexed above.
-    try std.Io.Dir.cwd().writeFile(std.testing.io, .{ .sub_path = state_path, .data = resume_key });
+    try std.Io.Dir.cwd().deleteFile(std.testing.io, owned_state_path.?);
+    const legacy_rebuild_state = backfill_state_mod.RebuildState.init(rebuild_root);
+    const legacy_state_path = try legacy_rebuild_state.pathAlloc(alloc);
+    defer alloc.free(legacy_state_path);
+    try std.Io.Dir.cwd().writeFile(std.testing.io, .{ .sub_path = legacy_state_path, .data = resume_key.? });
 
     index_manager_mod.test_abort_sparse_backfill_after_batches = null;
 
     var reopened = try DB.open(alloc, std.mem.span(path), .{});
     defer reopened.close();
 
-    try std.testing.expectError(error.FileNotFound, std.Io.Dir.cwd().readFileAlloc(std.testing.io, state_path, alloc, .limited(1024)));
+    try std.testing.expectError(error.FileNotFound, std.Io.Dir.cwd().readFileAlloc(std.testing.io, owned_state_path.?, alloc, .limited(1024)));
+    try std.testing.expectError(error.FileNotFound, std.Io.Dir.cwd().readFileAlloc(std.testing.io, legacy_state_path, alloc, .limited(1024)));
 
     var result = try reopened.search(alloc, .{
         .index_name = "sp_v1",

--- a/zig/pkg/antfly/src/storage/db/db.zig
+++ b/zig/pkg/antfly/src/storage/db/db.zig
@@ -66713,7 +66713,6 @@ test "db dense artifact rebuild resumes from persisted state" {
     var io_impl = threadedIo();
     defer io_impl.deinit();
     try std.Io.Dir.cwd().deleteTree(io_impl.io(), dense_index_path);
-    const rebuild_state = backfill_state_mod.RebuildState.init(dense_index_path);
 
     {
         var interrupted = try DB.open(alloc, std.mem.span(path), .{
@@ -66723,6 +66722,8 @@ test "db dense artifact rebuild resumes from persisted state" {
         });
         defer interrupted.close();
 
+        const dense_entry = interrupted.core.index_manager.denseIndex("dense_idx") orelse return error.IndexNotFound;
+        const rebuild_state = interrupted.core.index_manager.rebuildState(.dense_vector, dense_index_path, dense_entry.config);
         const ResumeFailureCtx = struct {
             rebuild_state: backfill_state_mod.RebuildState,
             persisted_calls: usize = 0,
@@ -66776,6 +66777,8 @@ test "db dense artifact rebuild resumes from persisted state" {
         });
         defer resumed.close();
 
+        const dense_entry = resumed.core.index_manager.denseIndex("dense_idx") orelse return error.IndexNotFound;
+        const rebuild_state = resumed.core.index_manager.rebuildState(.dense_vector, dense_index_path, dense_entry.config);
         const rebuilt = try resumed.rebuildDenseIndexesFromStoredEmbeddingArtifactsIfNeeded(alloc);
         try std.testing.expectEqual(@as(usize, 4), rebuilt);
 
@@ -67126,7 +67129,6 @@ test "db chunk-backed dense artifact rebuild stays pending until all chunk artif
     var io_impl = threadedIo();
     defer io_impl.deinit();
     try std.Io.Dir.cwd().deleteTree(io_impl.io(), dense_index_path);
-    const rebuild_state = backfill_state_mod.RebuildState.init(dense_index_path);
 
     {
         var interrupted = try DB.open(alloc, std.mem.span(path), .{
@@ -67136,6 +67138,8 @@ test "db chunk-backed dense artifact rebuild stays pending until all chunk artif
         });
         defer interrupted.close();
 
+        const dense_entry = interrupted.core.index_manager.denseIndex("dv_v1") orelse return error.IndexNotFound;
+        const rebuild_state = interrupted.core.index_manager.rebuildState(.dense_vector, dense_index_path, dense_entry.config);
         const ResumeFailureCtx = struct {
             rebuild_state: backfill_state_mod.RebuildState,
             persisted_calls: usize = 0,
@@ -67181,6 +67185,8 @@ test "db chunk-backed dense artifact rebuild stays pending until all chunk artif
         });
         defer resumed.close();
 
+        const dense_entry = resumed.core.index_manager.denseIndex("dv_v1") orelse return error.IndexNotFound;
+        const rebuild_state = resumed.core.index_manager.rebuildState(.dense_vector, dense_index_path, dense_entry.config);
         try std.testing.expect(try resumed.hasPendingDenseArtifactRebuild(alloc));
 
         const Capture = struct {
@@ -69072,6 +69078,8 @@ test "db graph reverse rebuild resumes after interrupted reopen" {
 
     graph_mod.test_abort_reverse_rebuild_after_batches = 1;
     defer graph_mod.test_abort_reverse_rebuild_after_batches = null;
+    var state_path: ?[]u8 = null;
+    defer if (state_path) |owned| alloc.free(owned);
     {
         // A per-index load failure no longer fails the whole open; the index
         // is quarantined with its error recorded and retried on next open.
@@ -69079,11 +69087,15 @@ test "db graph reverse rebuild resumes after interrupted reopen" {
         defer interrupted.close();
         const recorded = interrupted.core.index_manager.loadFailure("gr_v1") orelse return error.TestUnexpectedResult;
         try std.testing.expectEqualStrings("TestInjectedBackfillFailure", recorded);
+
+        const cfg = interrupted.core.index_manager.get("gr_v1") orelse return error.IndexNotFound;
+        const rebuild_root = try interrupted.denseIndexRebuildStatePathAlloc(alloc, cfg.name);
+        defer alloc.free(rebuild_root);
+        const rebuild_state = interrupted.core.index_manager.rebuildState(.graph, rebuild_root, cfg.*);
+        state_path = try rebuild_state.pathAlloc(alloc);
     }
 
-    const state_path = try std.fmt.allocPrint(alloc, "{s}/indexes/gr_v1/rebuild.state", .{std.mem.span(path)});
-    defer alloc.free(state_path);
-    const interrupted_state = try std.Io.Dir.cwd().readFileAlloc(std.testing.io, state_path, alloc, .limited(1024));
+    const interrupted_state = try std.Io.Dir.cwd().readFileAlloc(std.testing.io, state_path.?, alloc, .limited(1024));
     defer alloc.free(interrupted_state);
     try std.testing.expect(interrupted_state.len > 0);
 
@@ -69092,7 +69104,7 @@ test "db graph reverse rebuild resumes after interrupted reopen" {
     var reopened = try DB.open(alloc, std.mem.span(path), .{});
     defer reopened.close();
 
-    try std.testing.expectError(error.FileNotFound, std.Io.Dir.cwd().readFileAlloc(std.testing.io, state_path, alloc, .limited(1024)));
+    try std.testing.expectError(error.FileNotFound, std.Io.Dir.cwd().readFileAlloc(std.testing.io, state_path.?, alloc, .limited(1024)));
 
     const incoming = try reopened.getEdges(alloc, "gr_v1", "doc:target", "links", .in);
     defer graph_mod.GraphIndex.freeEdges(alloc, incoming);

--- a/zig/pkg/antfly/src/storage/db/db.zig
+++ b/zig/pkg/antfly/src/storage/db/db.zig
@@ -16656,7 +16656,7 @@ pub const DB = struct {
             const rebuild_root_path = try self.denseIndexRebuildStatePathAlloc(alloc, entry.config.name);
             defer alloc.free(rebuild_root_path);
             const rebuild_state = backfill_state_mod.RebuildState.init(rebuild_root_path);
-            const persisted_resume = try rebuild_state.check(alloc);
+            const persisted_resume = try rebuild_state.checkWithIo(alloc, self.core.index_manager.checkpointIo());
             errdefer if (persisted_resume) |buf| alloc.free(buf);
             const projection_checkpoint = try self.core.loadProjectionCheckpoint(alloc, entry.config.name);
             const config_hash = types.indexConfigHash(entry.config);
@@ -16724,7 +16724,7 @@ pub const DB = struct {
                     .trigger = .projection_generation_invalid,
                     .last_error = last_error,
                 });
-                if (candidate.persisted_resume != null) try rebuild_state.clear();
+                if (candidate.persisted_resume != null) try rebuild_state.clearWithIo(self.core.index_manager.checkpointIo());
                 continue;
             }
             if (candidate.artifact_counter_required and
@@ -16735,7 +16735,7 @@ pub const DB = struct {
                     .trigger = .artifact_counter_missing,
                     .last_error = "dense_artifact_counter_missing",
                 });
-                if (candidate.persisted_resume != null) try rebuild_state.clear();
+                if (candidate.persisted_resume != null) try rebuild_state.clearWithIo(self.core.index_manager.checkpointIo());
                 continue;
             }
             const artifact_target_count = if (target_counts.authoritative_targets.contains(dense_index_idx))
@@ -16756,7 +16756,7 @@ pub const DB = struct {
                     .trigger = .artifact_coverage_mismatch,
                     .last_error = "dense_artifact_coverage_surplus",
                 });
-                if (candidate.persisted_resume != null) try rebuild_state.clear();
+                if (candidate.persisted_resume != null) try rebuild_state.clearWithIo(self.core.index_manager.checkpointIo());
                 continue;
             }
             const already_repaired = denseCoverageMatchesTarget(active_count, artifact_target_count) and
@@ -16764,11 +16764,11 @@ pub const DB = struct {
 
             if (candidate.persisted_resume) |buf| {
                 if (artifact_target_count == 0) {
-                    try rebuild_state.clear();
+                    try rebuild_state.clearWithIo(self.core.index_manager.checkpointIo());
                     continue;
                 }
                 if (already_repaired) {
-                    try rebuild_state.clear();
+                    try rebuild_state.clearWithIo(self.core.index_manager.checkpointIo());
                     continue;
                 }
                 try targets.append(alloc, .{
@@ -16839,7 +16839,7 @@ pub const DB = struct {
             const rebuild_root_path = try self.denseIndexRebuildStatePathAlloc(self.alloc, entry.config.name);
             defer self.alloc.free(rebuild_root_path);
             const rebuild_state = backfill_state_mod.RebuildState.init(rebuild_root_path);
-            try rebuild_state.update(target.resume_from orelse "");
+            try rebuild_state.updateWithIo(self.core.index_manager.checkpointIo(), target.resume_from orelse "");
         }
     }
 
@@ -16862,7 +16862,7 @@ pub const DB = struct {
             const repaired = denseCoverageMatchesTarget(entry.index.stats().active_count, target.artifact_target_count) and
                 applied_sequence >= target_sequence;
             if (repaired) {
-                try rebuild_state.clear();
+                try rebuild_state.clearWithIo(self.core.index_manager.checkpointIo());
                 const checkpoint = try self.core.loadProjectionCheckpoint(alloc, entry.config.name);
                 try self.core.saveProjectionCheckpoint(entry.config.name, .{
                     .applied_sequence = applied_sequence,
@@ -16916,7 +16916,7 @@ pub const DB = struct {
                 const rebuild_root_path = try self.denseIndexRebuildStatePathAlloc(alloc, entry.config.name);
                 defer alloc.free(rebuild_root_path);
                 const rebuild_state = backfill_state_mod.RebuildState.init(rebuild_root_path);
-                try rebuild_state.clear();
+                try rebuild_state.clearWithIo(self.core.index_manager.checkpointIo());
                 try self.core.saveProjectionCheckpoint(entry.config.name, .{
                     .applied_sequence = target_sequence,
                     .status = .clean,
@@ -17217,7 +17217,7 @@ pub const DB = struct {
                     const rebuild_root_path = try persist.db.denseIndexRebuildStatePathAlloc(persist.alloc, entry.config.name);
                     defer persist.alloc.free(rebuild_root_path);
                     const rebuild_state = backfill_state_mod.RebuildState.init(rebuild_root_path);
-                    try rebuild_state.update(last_key);
+                    try rebuild_state.updateWithIo(persist.db.core.index_manager.checkpointIo(), last_key);
                     const owned_key = try persist.alloc.dupe(u8, last_key);
                     errdefer persist.alloc.free(owned_key);
                     if (target.resume_from) |resume_from| persist.alloc.free(resume_from);

--- a/zig/pkg/antfly/src/storage/db/db.zig
+++ b/zig/pkg/antfly/src/storage/db/db.zig
@@ -18863,21 +18863,27 @@ pub const DB = struct {
         const rebuild_root_path = try self.denseIndexRebuildStatePathAlloc(alloc, cfg.name);
         defer alloc.free(rebuild_root_path);
         const rebuild_state = self.core.index_manager.rebuildState(cfg.kind, rebuild_root_path, cfg);
-        const resume_key = rebuild_state.checkWithIo(
+        var loaded = try rebuild_state.loadWithIo(
             alloc,
             self.core.index_manager.checkpointIo(),
-        ) catch |err| switch (err) {
-            error.InvalidRebuildState => {
-                item.load_error = try alloc.dupe(u8, @errorName(err));
+        );
+        defer loaded.deinit(alloc);
+        const key = switch (loaded) {
+            .absent => return,
+            .valid => |resume_key| resume_key,
+            .legacy => {
+                item.backfill_active = true;
+                item.backfill_progress = 0;
+                return;
+            },
+            .corrupt => {
+                item.load_error = try alloc.dupe(u8, @errorName(error.InvalidRebuildState));
                 item.repair_degraded = true;
                 item.backfill_active = false;
                 item.backfill_progress = 0;
                 return;
             },
-            else => return err,
         };
-        defer if (resume_key) |key| alloc.free(key);
-        const key = resume_key orelse return;
         const byte_range = self.core.byteRange();
         item.backfill_active = true;
         item.backfill_progress = backfill_state_mod.estimateProgressForKey(
@@ -42478,6 +42484,36 @@ test "db status_only open reads index catalog without loading index state" {
             return error.TestUnexpectedResult;
         };
         try std.testing.expect(rebuilding_ft.backfill_active);
+
+        try current_state.clear();
+        const current_state_path = try current_state.pathAlloc(alloc);
+        defer alloc.free(current_state_path);
+        const legacy_state = backfill_state_mod.RebuildState.init(rebuild_root);
+        const legacy_state_path = try legacy_state.pathAlloc(alloc);
+        defer alloc.free(legacy_state_path);
+        try std.Io.Dir.cwd().writeFile(std.testing.io, .{
+            .sub_path = legacy_state_path,
+            .data = "doc:legacy",
+        });
+
+        const legacy_stats = try status_db.stats(alloc);
+        defer types.freeDBStats(alloc, legacy_stats);
+        const legacy_ft = blk: {
+            for (legacy_stats.indexes) |item| {
+                if (std.mem.eql(u8, item.name, "ft_v1")) break :blk item;
+            }
+            return error.TestUnexpectedResult;
+        };
+        try std.testing.expect(legacy_ft.backfill_active);
+        try std.testing.expectError(error.FileNotFound, std.Io.Dir.cwd().access(std.testing.io, current_state_path, .{}));
+        const preserved_legacy = try std.Io.Dir.cwd().readFileAlloc(
+            std.testing.io,
+            legacy_state_path,
+            alloc,
+            .limited(1024),
+        );
+        defer alloc.free(preserved_legacy);
+        try std.testing.expectEqualStrings("doc:legacy", preserved_legacy);
     }
 }
 

--- a/zig/pkg/antfly/src/storage/db/db.zig
+++ b/zig/pkg/antfly/src/storage/db/db.zig
@@ -16655,7 +16655,7 @@ pub const DB = struct {
 
             const rebuild_root_path = try self.denseIndexRebuildStatePathAlloc(alloc, entry.config.name);
             defer alloc.free(rebuild_root_path);
-            const rebuild_state = backfill_state_mod.RebuildState.init(rebuild_root_path);
+            const rebuild_state = self.core.index_manager.rebuildState(.dense_vector, rebuild_root_path);
             const persisted_resume = try rebuild_state.checkWithIo(alloc, self.core.index_manager.checkpointIo());
             errdefer if (persisted_resume) |buf| alloc.free(buf);
             const projection_checkpoint = try self.core.loadProjectionCheckpoint(alloc, entry.config.name);
@@ -16716,7 +16716,7 @@ pub const DB = struct {
             const entry = &self.core.index_manager.dense_indexes.items[dense_index_idx];
             const rebuild_root_path = try self.denseIndexRebuildStatePathAlloc(alloc, entry.config.name);
             defer alloc.free(rebuild_root_path);
-            const rebuild_state = backfill_state_mod.RebuildState.init(rebuild_root_path);
+            const rebuild_state = self.core.index_manager.rebuildState(.dense_vector, rebuild_root_path);
             const active_count = entry.index.stats().active_count;
             if (candidate.invalid_generation_error) |last_error| {
                 try generation_repairs.append(alloc, .{
@@ -16838,7 +16838,7 @@ pub const DB = struct {
             });
             const rebuild_root_path = try self.denseIndexRebuildStatePathAlloc(self.alloc, entry.config.name);
             defer self.alloc.free(rebuild_root_path);
-            const rebuild_state = backfill_state_mod.RebuildState.init(rebuild_root_path);
+            const rebuild_state = self.core.index_manager.rebuildState(.dense_vector, rebuild_root_path);
             try rebuild_state.updateWithIo(self.core.index_manager.checkpointIo(), target.resume_from orelse "");
         }
     }
@@ -16848,7 +16848,7 @@ pub const DB = struct {
             const entry = &self.core.index_manager.dense_indexes.items[target.dense_index_idx];
             const rebuild_root_path = try self.denseIndexRebuildStatePathAlloc(alloc, entry.config.name);
             defer alloc.free(rebuild_root_path);
-            const rebuild_state = backfill_state_mod.RebuildState.init(rebuild_root_path);
+            const rebuild_state = self.core.index_manager.rebuildState(.dense_vector, rebuild_root_path);
             const applied_sequence = try self.core.loadAppliedSequence(alloc, entry.config.name);
             const target_sequence = try self.probeDerivedReplayTargetSequence(
                 alloc,
@@ -16915,7 +16915,7 @@ pub const DB = struct {
                 if (applied_sequence < target_sequence) try self.core.saveAppliedSequence(entry.config.name, target_sequence);
                 const rebuild_root_path = try self.denseIndexRebuildStatePathAlloc(alloc, entry.config.name);
                 defer alloc.free(rebuild_root_path);
-                const rebuild_state = backfill_state_mod.RebuildState.init(rebuild_root_path);
+                const rebuild_state = self.core.index_manager.rebuildState(.dense_vector, rebuild_root_path);
                 try rebuild_state.clearWithIo(self.core.index_manager.checkpointIo());
                 try self.core.saveProjectionCheckpoint(entry.config.name, .{
                     .applied_sequence = target_sequence,
@@ -17216,7 +17216,7 @@ pub const DB = struct {
                     const entry = &persist.db.core.index_manager.dense_indexes.items[target.dense_index_idx];
                     const rebuild_root_path = try persist.db.denseIndexRebuildStatePathAlloc(persist.alloc, entry.config.name);
                     defer persist.alloc.free(rebuild_root_path);
-                    const rebuild_state = backfill_state_mod.RebuildState.init(rebuild_root_path);
+                    const rebuild_state = persist.db.core.index_manager.rebuildState(.dense_vector, rebuild_root_path);
                     try rebuild_state.updateWithIo(persist.db.core.index_manager.checkpointIo(), last_key);
                     const owned_key = try persist.alloc.dupe(u8, last_key);
                     errdefer persist.alloc.free(owned_key);
@@ -18734,7 +18734,7 @@ pub const DB = struct {
                         }
                         const rebuild_root_path = try self.denseIndexRebuildStatePathAlloc(alloc, entry.config.name);
                         defer alloc.free(rebuild_root_path);
-                        const rebuild_state = backfill_state_mod.RebuildState.init(rebuild_root_path);
+                        const rebuild_state = self.core.index_manager.rebuildState(.dense_vector, rebuild_root_path);
                         if (item.doc_count < visible_doc_count) {
                             if (try rebuild_state.estimateProgress(byte_range.start, byte_range.end, alloc)) |progress| {
                                 item.backfill_active = true;
@@ -60281,7 +60281,7 @@ test "db full-text backfill retires segment fanout at durable batch boundaries" 
     try std.testing.expectEqual(@as(u32, 24), result.total_hits);
 }
 
-test "db sparse backfill resumes after interrupted reopen" {
+test "db sparse backfill restarts safely from a legacy cursor after interrupted reopen" {
     const alloc = std.testing.allocator;
 
     var path_buf: [256]u8 = undefined;
@@ -60329,11 +60329,19 @@ test "db sparse backfill resumes after interrupted reopen" {
         try std.testing.expectEqualStrings("TestInjectedBackfillFailure", recorded);
     }
 
-    const state_path = try std.fmt.allocPrint(alloc, "{s}/indexes/sp_v1/rebuild.state", .{std.mem.span(path)});
+    const rebuild_root = try std.fmt.allocPrint(alloc, "{s}/indexes/sp_v1", .{std.mem.span(path)});
+    defer alloc.free(rebuild_root);
+    const rebuild_state = backfill_state_mod.RebuildState.init(rebuild_root);
+    const state_path = try rebuild_state.pathAlloc(alloc);
     defer alloc.free(state_path);
-    const interrupted_state = try std.Io.Dir.cwd().readFileAlloc(std.testing.io, state_path, alloc, .limited(1024));
-    defer alloc.free(interrupted_state);
-    try std.testing.expect(interrupted_state.len > 0);
+    const resume_key = (try rebuild_state.checkWithIo(alloc, std.testing.io)) orelse return error.TestExpectedEqual;
+    defer alloc.free(resume_key);
+    try std.testing.expect(resume_key.len > 0);
+
+    // Simulate an upgrade from the legacy raw-cursor format. It cannot be
+    // trusted, so reopen must restart from the beginning without inflating the
+    // persisted sparse document count for rows already indexed above.
+    try std.Io.Dir.cwd().writeFile(std.testing.io, .{ .sub_path = state_path, .data = resume_key });
 
     index_manager_mod.test_abort_sparse_backfill_after_batches = null;
 


### PR DESCRIPTION
Replaces #412 now that its stacked base, #371, has merged.

## What changed

- Store `rebuild.state` as a versioned envelope with a key length and CRC32.
- Publish updates through an exclusive temporary file, sync the file, atomically rename it, and sync the parent directory.
- Reject malformed, truncated, oversized, or checksum-invalid cursors without clearing them.
- Migrate legacy raw cursors by safely restarting the rebuild from the beginning.
- Route metadata status reporting through the same decoder, cache corrupt markers without hot rescans, and publish a quarantined runtime status.
- Share one `std.Io` instance across rebuild state operations and add lifecycle regression coverage.

## Why

The derived-index rebuild cursor was previously an unprotected raw key. A bit flip or partial write could turn a valid cursor into a later valid-looking key, permanently advancing the rebuild past documents that had not been indexed. The new format fails closed instead of silently publishing incomplete derived indexes.

## User impact

Corrupt rebuild progress now stops and quarantines the affected rebuild for repair rather than silently leaving search, vector, graph, or other derived indexes incomplete.

## Validation

- 9/9 focused rebuild-state tests pass.
- 35/35 metadata-service tests pass.
- `zig fmt --check` passes for all changed Zig files.
- `git diff --check origin/main...HEAD` passes.

The branch was rebased onto `main` after #371 merged.