### PR TITLE
Fix Zig full and inference CI regressions

### DIFF
--- a/.github/workflows/zig-tests.yml
+++ b/.github/workflows/zig-tests.yml
@@ -30,7 +30,6 @@ jobs:
     runs-on: arc-antfly-standard
     outputs:
       zig_tests: ${{ steps.detect.outputs.zig_tests }}
-      arm64_codec: ${{ steps.detect.outputs.arm64_codec }}
       e2e: ${{ steps.detect.outputs.e2e }}
       model_check: ${{ steps.detect.outputs.model_check }}
       trace_validate: ${{ steps.detect.outputs.trace_validate }}
@@ -49,7 +48,6 @@ jobs:
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             {
               echo "zig_tests=true"
-              echo "arm64_codec=true"
               echo "e2e=true"
               echo "model_check=true"
               echo "trace_validate=true"
@@ -60,7 +58,6 @@ jobs:
 
           if [[ "${{ github.event_name }}" == "schedule" ]]; then
             echo "zig_tests=false" >> "$GITHUB_OUTPUT"
-            echo "arm64_codec=false" >> "$GITHUB_OUTPUT"
             if [[ "${{ github.event.schedule }}" == "0 3 * * 0" ]]; then
               {
                 echo "e2e=false"
@@ -86,7 +83,6 @@ jobs:
           else
             {
               echo "zig_tests=true"
-              echo "arm64_codec=true"
               echo "e2e=true"
               echo "model_check=true"
               echo "trace_validate=true"
@@ -106,18 +102,6 @@ jobs:
             echo "zig_tests=false" >> "$GITHUB_OUTPUT"
           else
             echo "zig_tests=true" >> "$GITHUB_OUTPUT"
-          fi
-
-          if git diff --quiet "$base" "${{ github.sha }}" -- \
-            zig/build.zig \
-            zig/build.zig.zon \
-            zig/pkg/antfly/src/encoding/streamvbyte.zig \
-            zig/pkg/antfly/src/encoding/chunked_coder.zig \
-            .github/workflows/zig-tests.yml
-          then
-            echo "arm64_codec=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "arm64_codec=true" >> "$GITHUB_OUTPUT"
           fi
 
           if git diff --quiet "$base" "${{ github.sha }}" -- \
@@ -202,9 +186,21 @@ jobs:
         run: scripts/test-backup-s3-integration.sh
 
   arm64-codec:
-    name: arm64-codec
+    name: ${{ (github.event_name == 'pull_request' || github.event.schedule == '0 3 * * 0') && 'zig-base / arm64-codec' || 'zig-full / arm64-codec' }}
     needs: changes
-    if: needs.changes.outputs.arm64_codec == 'true'
+    if: |
+      (
+        (github.event_name == 'pull_request' || github.event.schedule == '0 3 * * 0') &&
+        (
+          needs.changes.outputs.zig_tests == 'true' ||
+          needs.changes.outputs.model_check == 'true' ||
+          needs.changes.outputs.trace_validate == 'true'
+        )
+      ) ||
+      github.event_name == 'merge_group' ||
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      github.event_name == 'workflow_dispatch' ||
+      github.event.schedule == '0 8 * * *'
     runs-on: arc-antfly-publish-arm64
     timeout-minutes: 20
     env:

--- a/.github/workflows/zig-tests.yml
+++ b/.github/workflows/zig-tests.yml
@@ -242,8 +242,8 @@ jobs:
           zig test zig/pkg/antfly/src/encoding/chunked_coder.zig
           zig test -O ReleaseFast zig/pkg/antfly/src/encoding/chunked_coder.zig
 
-  zig-base:
-    name: zig-base
+  zig-base-tests:
+    name: zig-base / x86_64
     needs: changes
     if: (github.event_name == 'pull_request' || github.event.schedule == '0 3 * * 0') && (needs.changes.outputs.zig_tests == 'true' || needs.changes.outputs.model_check == 'true' || needs.changes.outputs.trace_validate == 'true')
     runs-on: arc-antfly-heavy
@@ -475,8 +475,8 @@ jobs:
           ANTFLY_TLA_TRACE_VALIDATE: ${{ needs.changes.outputs.trace_validate }}
         run: scripts/ci/zig-tla-verify.sh
 
-  zig-full:
-    name: zig-full
+  zig-full-tests:
+    name: zig-full / x86_64
     needs: changes
     if: github.event_name == 'merge_group' || (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch' || github.event.schedule == '0 8 * * *'
     runs-on: arc-antfly-heavy
@@ -594,6 +594,55 @@ jobs:
       - name: Run Zig chaos tests
         working-directory: zig
         run: taskset -c ${{ steps.cpus.outputs.list }} zig build chaos-test ${ZIG_BUILD_FLAGS}
+
+  zig-base:
+    name: zig-base
+    needs: [changes, zig-base-tests, arm64-codec]
+    if: |
+      always() &&
+      (github.event_name == 'pull_request' || github.event.schedule == '0 3 * * 0') &&
+      (
+        needs.changes.result != 'success' ||
+        needs.changes.outputs.zig_tests == 'true' ||
+        needs.changes.outputs.model_check == 'true' ||
+        needs.changes.outputs.trace_validate == 'true'
+      )
+    runs-on: arc-antfly-standard
+    steps:
+      - name: Verify zig-base shards
+        env:
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          X86_64_RESULT: ${{ needs.zig-base-tests.result }}
+          ARM64_CODEC_RESULT: ${{ needs.arm64-codec.result }}
+        run: |
+          set -euo pipefail
+          test "$CHANGES_RESULT" = "success"
+          test "$X86_64_RESULT" = "success"
+          test "$ARM64_CODEC_RESULT" = "success"
+
+  zig-full:
+    name: zig-full
+    needs: [changes, zig-full-tests, arm64-codec]
+    if: |
+      always() &&
+      (
+        github.event_name == 'merge_group' ||
+        (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+        github.event_name == 'workflow_dispatch' ||
+        github.event.schedule == '0 8 * * *'
+      )
+    runs-on: arc-antfly-standard
+    steps:
+      - name: Verify zig-full shards
+        env:
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          X86_64_RESULT: ${{ needs.zig-full-tests.result }}
+          ARM64_CODEC_RESULT: ${{ needs.arm64-codec.result }}
+        run: |
+          set -euo pipefail
+          test "$CHANGES_RESULT" = "success"
+          test "$X86_64_RESULT" = "success"
+          test "$ARM64_CODEC_RESULT" = "success"
 
   e2e-base:
     name: e2e-base

--- a/zig/e2e/antfly/test_scaling.py
+++ b/zig/e2e/antfly/test_scaling.py
@@ -1439,7 +1439,10 @@ def _wait_node_drained_for_groups(
                     continue
                 if int(record.get("local_node_id", 0)) != node_id:
                     continue
-                if intent.get("serving_state") == "draining":
+                # Both states are excluded from request routing. `retiring`
+                # is the later, safer phase: the survivor set is latched and
+                # the local replica is completing leader transfer/removal.
+                if intent.get("serving_state") in {"draining", "retiring"}:
                     continue
                 return None
         return snapshots[0]

--- a/zig/e2e/antfly/test_standalone_lifecycle.py
+++ b/zig/e2e/antfly/test_standalone_lifecycle.py
@@ -60,12 +60,20 @@ def _json_request(
     *,
     payload: dict | None = None,
 ) -> dict | list:
-    response = session.request(
-        method,
-        f"{server.url}{path}",
-        json=payload,
-        timeout=30,
-    )
+    try:
+        response = session.request(
+            method,
+            f"{server.url}{path}",
+            json=payload,
+            timeout=30,
+        )
+    except requests.RequestException as exc:
+        process_status = server.proc.poll() if server.proc is not None else None
+        raise AssertionError(
+            f"{method} {path} failed before receiving a response: {exc!r}; "
+            f"server_exit_status={process_status}\n"
+            f"server logs:\n{server.debug_logs()}"
+        ) from exc
     if response.status_code >= 400:
         raise AssertionError(
             f"{method} {path} failed: {response.status_code} {response.text}\n"

--- a/zig/e2e/inference/models.py
+++ b/zig/e2e/inference/models.py
@@ -29,12 +29,17 @@ import json
 import os
 import subprocess
 from dataclasses import dataclass, field
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_ANTFLY_BIN_CANDIDATES = (
     REPO_ROOT / "zig-out" / "bin" / "antfly",
 )
+MANAGED_DOWNLOAD_IN_PROGRESS = ".antfly-download-in-progress"
+MANAGED_DOWNLOAD_PLAN = ".antfly-download-plan.json"
+MANAGED_DOWNLOAD_COMPLETE = ".antfly-download-complete.json"
+MAX_MANAGED_DOWNLOAD_RECEIPT_BYTES = 16 * 1024 * 1024
+SUPPORTED_MODEL_SUFFIXES = (".gguf", ".onnx", ".safetensors")
 
 MODEL_TASKS = (
     "embedders",
@@ -362,15 +367,73 @@ def _looks_like_model_dir(path: Path) -> bool:
     if not path.is_dir():
         return False
 
+    if (path / MANAGED_DOWNLOAD_IN_PROGRESS).exists() or (path / MANAGED_DOWNLOAD_PLAN).exists():
+        return False
+
+    completion_path = path / MANAGED_DOWNLOAD_COMPLETE
+    if completion_path.exists():
+        root = path.resolve()
+        try:
+            with completion_path.open(encoding="utf-8") as receipt:
+                serialized = receipt.read(MAX_MANAGED_DOWNLOAD_RECEIPT_BYTES + 1)
+            if len(serialized) > MAX_MANAGED_DOWNLOAD_RECEIPT_BYTES:
+                return False
+            completion = json.loads(serialized)
+            artifacts = completion["artifacts"]
+        except (OSError, KeyError, TypeError, UnicodeError, json.JSONDecodeError):
+            return False
+        if type(completion.get("version")) is not int or completion["version"] != 1:
+            return False
+        if not isinstance(artifacts, list) or not artifacts:
+            return False
+
+        has_supported_payload = False
+        for artifact in artifacts:
+            if not isinstance(artifact, dict):
+                return False
+            artifact_path = artifact.get("path")
+            artifact_size = artifact.get("size")
+            if not isinstance(artifact_path, str) or type(artifact_size) is not int or artifact_size < 0:
+                return False
+            relative = PurePosixPath(artifact_path)
+            if (
+                relative.is_absolute()
+                or not relative.parts
+                or any(part in ("", ".", "..") for part in relative.parts)
+                or "\\" in artifact_path
+            ):
+                return False
+            candidate = path.joinpath(*relative.parts)
+            try:
+                resolved = candidate.resolve(strict=True)
+                if not resolved.is_relative_to(root) or not resolved.is_file():
+                    return False
+                if resolved.stat().st_size != artifact_size:
+                    return False
+            except OSError:
+                return False
+            if candidate.name.endswith(SUPPORTED_MODEL_SUFFIXES):
+                has_supported_payload = True
+        return has_supported_payload and not (
+            (path / MANAGED_DOWNLOAD_IN_PROGRESS).exists()
+            or (path / MANAGED_DOWNLOAD_PLAN).exists()
+        )
+
+    # Legacy or externally provisioned model directories do not have Antfly's
+    # completion receipt. Preserve compatibility while still rejecting an
+    # interrupted file that is visibly in progress.
     has_supported_payload = False
     for candidate in path.rglob("*"):
         if not candidate.is_file():
             continue
         if candidate.name.endswith(".part"):
             return False
-        if candidate.name.endswith((".gguf", ".onnx", ".safetensors")):
+        if candidate.name.endswith(SUPPORTED_MODEL_SUFFIXES):
             has_supported_payload = True
-    return has_supported_payload
+    return has_supported_payload and not (
+        (path / MANAGED_DOWNLOAD_IN_PROGRESS).exists()
+        or (path / MANAGED_DOWNLOAD_PLAN).exists()
+    )
 
 
 def model_available(spec: ModelSpec) -> bool:

--- a/zig/e2e/inference/models.py
+++ b/zig/e2e/inference/models.py
@@ -359,16 +359,15 @@ def _model_path(spec: ModelSpec) -> Path:
 
 
 def _looks_like_model_dir(path: Path) -> bool:
-    if not path.exists():
+    if not path.is_dir():
         return False
-    for filename in ("config.json", "tokenizer.json", "genai_config.json", "antfly_metadata.json"):
-        if (path / filename).exists():
-            return True
-    if any(path.glob("*.gguf")):
-        return True
-    if (path / "onnx").is_dir():
-        return True
-    return False
+    if any(path.rglob("*.part")):
+        return False
+    payload_suffixes = (".gguf", ".onnx", ".safetensors", ".bin")
+    return any(
+        candidate.is_file() and candidate.name.endswith(payload_suffixes)
+        for candidate in path.rglob("*")
+    )
 
 
 def model_available(spec: ModelSpec) -> bool:

--- a/zig/e2e/inference/models.py
+++ b/zig/e2e/inference/models.py
@@ -361,13 +361,16 @@ def _model_path(spec: ModelSpec) -> Path:
 def _looks_like_model_dir(path: Path) -> bool:
     if not path.is_dir():
         return False
-    if any(path.rglob("*.part")):
-        return False
-    payload_suffixes = (".gguf", ".onnx", ".safetensors", ".bin")
-    return any(
-        candidate.is_file() and candidate.name.endswith(payload_suffixes)
-        for candidate in path.rglob("*")
-    )
+
+    has_supported_payload = False
+    for candidate in path.rglob("*"):
+        if not candidate.is_file():
+            continue
+        if candidate.name.endswith(".part"):
+            return False
+        if candidate.name.endswith((".gguf", ".onnx", ".safetensors")):
+            has_supported_payload = True
+    return has_supported_payload
 
 
 def model_available(spec: ModelSpec) -> bool:

--- a/zig/e2e/inference/test_model_helpers.py
+++ b/zig/e2e/inference/test_model_helpers.py
@@ -1,0 +1,27 @@
+# Copyright 2026 Antfly, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+from .models import _looks_like_model_dir
+
+
+def test_partial_model_directory_is_not_available(tmp_path):
+    model_dir = tmp_path / "BAAI" / "bge-small-en-v1.5"
+    (model_dir / "onnx").mkdir(parents=True)
+    (model_dir / "config.json").write_text("{}")
+    (model_dir / "onnx" / "model.onnx.part").write_bytes(b"incomplete")
+
+    assert not _looks_like_model_dir(model_dir)
+
+
+def test_completed_nested_model_payload_is_available(tmp_path):
+    model_dir = tmp_path / "BAAI" / "bge-small-en-v1.5"
+    (model_dir / "onnx").mkdir(parents=True)
+    (model_dir / "config.json").write_text("{}")
+    (model_dir / "onnx" / "model.onnx").write_bytes(b"complete")
+
+    assert _looks_like_model_dir(model_dir)

--- a/zig/e2e/inference/test_model_helpers.py
+++ b/zig/e2e/inference/test_model_helpers.py
@@ -6,6 +6,8 @@
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
 
+import json
+
 from .models import _looks_like_model_dir
 
 
@@ -41,5 +43,60 @@ def test_partial_file_invalidates_an_otherwise_complete_model(tmp_path):
     model_dir.mkdir(parents=True)
     (model_dir / "model.safetensors").write_bytes(b"complete")
     (model_dir / "adapter_model.safetensors.part").write_bytes(b"incomplete")
+
+    assert not _looks_like_model_dir(model_dir)
+
+
+def test_managed_download_in_progress_invalidates_completed_first_shard(tmp_path):
+    model_dir = tmp_path / "owner" / "interrupted-between-files"
+    model_dir.mkdir(parents=True)
+    (model_dir / "model-00001-of-00002.safetensors").write_bytes(b"first")
+    (model_dir / ".antfly-download-in-progress").write_text('{"version":1,"state":"in_progress"}')
+
+    assert not _looks_like_model_dir(model_dir)
+
+
+def test_managed_completion_receipt_requires_every_artifact(tmp_path):
+    model_dir = tmp_path / "owner" / "missing-shard"
+    model_dir.mkdir(parents=True)
+    (model_dir / "model-00001-of-00002.safetensors").write_bytes(b"first")
+    receipt = {
+        "version": 1,
+        "artifacts": [
+            {"path": "model-00001-of-00002.safetensors", "size": 5},
+            {"path": "model-00002-of-00002.safetensors", "size": 6},
+        ],
+    }
+    (model_dir / ".antfly-download-complete.json").write_text(json.dumps(receipt))
+
+    assert not _looks_like_model_dir(model_dir)
+
+
+def test_managed_completion_receipt_accepts_complete_artifact_set(tmp_path):
+    model_dir = tmp_path / "owner" / "complete-shards"
+    model_dir.mkdir(parents=True)
+    (model_dir / "model-00001-of-00002.safetensors").write_bytes(b"first")
+    (model_dir / "model-00002-of-00002.safetensors").write_bytes(b"second")
+    receipt = {
+        "version": 1,
+        "artifacts": [
+            {"path": "model-00001-of-00002.safetensors", "size": 5},
+            {"path": "model-00002-of-00002.safetensors", "size": 6},
+        ],
+    }
+    (model_dir / ".antfly-download-complete.json").write_text(json.dumps(receipt))
+
+    assert _looks_like_model_dir(model_dir)
+
+
+def test_managed_completion_receipt_rejects_boolean_numeric_fields(tmp_path):
+    model_dir = tmp_path / "owner" / "invalid-numeric-types"
+    model_dir.mkdir(parents=True)
+    (model_dir / "model.onnx").write_bytes(b"x")
+    receipt = {
+        "version": True,
+        "artifacts": [{"path": "model.onnx", "size": True}],
+    }
+    (model_dir / ".antfly-download-complete.json").write_text(json.dumps(receipt))
 
     assert not _looks_like_model_dir(model_dir)

--- a/zig/e2e/inference/test_model_helpers.py
+++ b/zig/e2e/inference/test_model_helpers.py
@@ -25,3 +25,21 @@ def test_completed_nested_model_payload_is_available(tmp_path):
     (model_dir / "onnx" / "model.onnx").write_bytes(b"complete")
 
     assert _looks_like_model_dir(model_dir)
+
+
+def test_unsupported_framework_bin_is_not_a_completed_model(tmp_path):
+    model_dir = tmp_path / "owner" / "framework-only"
+    model_dir.mkdir(parents=True)
+    (model_dir / "config.json").write_text("{}")
+    (model_dir / "pytorch_model.bin").write_bytes(b"unsupported")
+
+    assert not _looks_like_model_dir(model_dir)
+
+
+def test_partial_file_invalidates_an_otherwise_complete_model(tmp_path):
+    model_dir = tmp_path / "owner" / "interrupted"
+    model_dir.mkdir(parents=True)
+    (model_dir / "model.safetensors").write_bytes(b"complete")
+    (model_dir / "adapter_model.safetensors.part").write_bytes(b"incomplete")
+
+    assert not _looks_like_model_dir(model_dir)

--- a/zig/pkg/antfly/src/api/httpx_handler.zig
+++ b/zig/pkg/antfly/src/api/httpx_handler.zig
@@ -210,9 +210,15 @@ pub const AntflyApiHandler = struct {
         const runtime = backend_runtime orelse return handleTableBatchInline(ctx, ctx.allocator, table_name, body_data, api);
         var runtime_io = runtime.io() orelse return handleTableBatchInline(ctx, ctx.allocator, table_name, body_data, api);
         const job_alloc = std.heap.page_allocator;
-        const owned_table_name = try job_alloc.dupe(u8, table_name);
+        const owned_table_name = job_alloc.dupe(u8, table_name) catch |err| {
+            std.log.warn("batch offload table-name allocation failed; executing inline err={s}", .{@errorName(err)});
+            return handleTableBatchInline(ctx, ctx.allocator, table_name, body_data, api);
+        };
         defer job_alloc.free(owned_table_name);
-        const owned_body_data = try job_alloc.dupe(u8, body_data);
+        const owned_body_data = job_alloc.dupe(u8, body_data) catch |err| {
+            std.log.warn("batch offload body allocation failed; executing inline err={s}", .{@errorName(err)});
+            return handleTableBatchInline(ctx, ctx.allocator, table_name, body_data, api);
+        };
         defer job_alloc.free(owned_body_data);
         var job = OffloadedTableBatch{
             .alloc = job_alloc,
@@ -220,7 +226,13 @@ pub const AntflyApiHandler = struct {
             .body_data = owned_body_data,
             .api = api,
         };
-        var future = try runtime_io.concurrent(OffloadedTableBatch.run, .{&job});
+        var future = runtime_io.concurrent(OffloadedTableBatch.run, .{&job}) catch |err| {
+            // Saturating the backend executor must not turn a valid write into
+            // an empty HTTP disconnect. The request still owns its buffers, so
+            // executing synchronously is a safe bounded degradation path.
+            std.log.warn("batch offload scheduling failed; executing inline err={s}", .{@errorName(err)});
+            return handleTableBatchInline(ctx, ctx.allocator, table_name, body_data, api);
+        };
         while (!job.done.load(.acquire)) {
             ctx.io.sleep(std.Io.Duration.fromMilliseconds(1), .awake) catch {};
         }

--- a/zig/pkg/antfly/src/inference_runtime/runtime.zig
+++ b/zig/pkg/antfly/src/inference_runtime/runtime.zig
@@ -345,6 +345,8 @@ fn pullModel(alloc: std.mem.Allocator, io: std.Io, args: *std.process.Args.Itera
     var tasks_csv: ?[]const u8 = null;
     var capabilities_csv: ?[]const u8 = null;
     var projector_selection: inference.registry.download.ProjectorSelection = .auto;
+    var max_artifact_bytes = inference.registry.download.default_max_artifact_bytes;
+    var max_model_bytes = inference.registry.download.default_max_model_bytes;
     var predictor_pull = false;
     var first_ai_only_flag: ?[]const u8 = null;
     var first_predictor_only_flag: ?[]const u8 = null;
@@ -399,6 +401,10 @@ fn pullModel(alloc: std.mem.Allocator, io: std.Io, args: *std.process.Args.Itera
             capabilities_csv = value;
         } else if (std.mem.eql(u8, arg, "--projector")) {
             projector_selection = inference.registry.download.parseProjectorSelection(value) orelse return error.InvalidArguments;
+        } else if (std.mem.eql(u8, arg, "--max-artifact-bytes")) {
+            max_artifact_bytes = try parsePositiveDownloadBytes(value);
+        } else if (std.mem.eql(u8, arg, "--max-model-bytes")) {
+            max_model_bytes = try parsePositiveDownloadBytes(value);
         } else {
             if (std.mem.eql(u8, arg, "--type") and (std.mem.eql(u8, value, "predictor") or std.mem.eql(u8, value, "predictors"))) predictor_pull = true;
             try passthrough.appendSlice(alloc, &.{ arg, value });
@@ -433,6 +439,11 @@ fn pullModel(alloc: std.mem.Allocator, io: std.Io, args: *std.process.Args.Itera
 
     var reg = inference.registry.ModelRegistry.init(alloc, models_dir);
     defer reg.deinit();
+    const hub_config = inference.registry.download.HubConfig{
+        .token = token,
+        .max_artifact_bytes = max_artifact_bytes,
+        .max_model_bytes = max_model_bytes,
+    };
     for (refs.items) |ref| {
         if (variants_csv) |raw_variants| {
             var variants = std.mem.splitScalar(u8, raw_variants, ',');
@@ -443,11 +454,11 @@ fn pullModel(alloc: std.mem.Allocator, io: std.Io, args: *std.process.Args.Itera
                 pulled_any = true;
                 const qualified_ref = try std.fmt.allocPrint(alloc, "{s}:{s}", .{ ref, variant });
                 defer alloc.free(qualified_ref);
-                try pullOneModel(&reg, io, qualified_ref, token, tasks_csv, capabilities_csv, projector_selection);
+                try pullOneModel(&reg, io, qualified_ref, hub_config, tasks_csv, capabilities_csv, projector_selection);
             }
             if (!pulled_any) return error.InvalidArguments;
         } else {
-            try pullOneModel(&reg, io, ref, token, tasks_csv, capabilities_csv, projector_selection);
+            try pullOneModel(&reg, io, ref, hub_config, tasks_csv, capabilities_csv, projector_selection);
         }
     }
 }
@@ -456,20 +467,21 @@ fn pullOneModel(
     registry: *inference.registry.ModelRegistry,
     io: std.Io,
     ref: []const u8,
-    token: ?[]const u8,
+    hub_config: inference.registry.download.HubConfig,
     tasks_csv: ?[]const u8,
     capabilities_csv: ?[]const u8,
     projector_selection: inference.registry.download.ProjectorSelection,
 ) !void {
     std.debug.print("pulling {s}...\n", .{ref});
-    try registry.pull(io, ref, token, tasks_csv, capabilities_csv, projector_selection);
+    try registry.pull(io, ref, hub_config, tasks_csv, capabilities_csv, projector_selection);
     std.debug.print("done.\n", .{});
 }
 
 fn pullFlagTakesValue(arg: []const u8) bool {
     const flags = [_][]const u8{
-        "--variants", "--token", "--models-dir", "--ml-dir",    "--tasks",               "--capabilities", "--projector",
-        "--type",     "--name",  "--file",       "--framework", "--dead-leaf-threshold",
+        "--variants",  "--token",               "--models-dir",      "--ml-dir", "--tasks", "--capabilities",
+        "--projector", "--max-artifact-bytes",  "--max-model-bytes", "--type",   "--name",  "--file",
+        "--framework", "--dead-leaf-threshold",
     };
     for (flags) |flag| if (std.mem.eql(u8, arg, flag)) return true;
     return false;
@@ -480,7 +492,7 @@ const PullFlagDomain = enum { shared, ai, predictor };
 fn pullFlagDomain(arg: []const u8) PullFlagDomain {
     if (std.mem.eql(u8, arg, "--token")) return .shared;
     const ai_flags = [_][]const u8{
-        "--variants", "--models-dir", "--tasks", "--capabilities", "--projector",
+        "--variants", "--models-dir", "--tasks", "--capabilities", "--projector", "--max-artifact-bytes", "--max-model-bytes",
     };
     for (ai_flags) |flag| if (std.mem.eql(u8, arg, flag)) return .ai;
     return .predictor;
@@ -508,8 +520,14 @@ fn isHelpArg(arg: []const u8) bool {
     return std.mem.eql(u8, arg, "--help") or std.mem.eql(u8, arg, "-h") or std.mem.eql(u8, arg, "help");
 }
 
+fn parsePositiveDownloadBytes(value: []const u8) !u64 {
+    const parsed = try std.fmt.parseInt(u64, value, 10);
+    if (parsed == 0) return error.InvalidArguments;
+    return parsed;
+}
+
 fn printPullUsage() void {
-    std.debug.print("usage: antfly inference pull [--variants <csv>] <model-ref>... [--token <hf-token>] [--models-dir <dir>] [--tasks <csv>] [--capabilities <csv>] [--projector <auto|none|Q8_0|filename>]\n", .{});
+    std.debug.print("usage: antfly inference pull [--variants <csv>] <model-ref>... [--token <hf-token>] [--models-dir <dir>] [--tasks <csv>] [--capabilities <csv>] [--projector <auto|none|Q8_0|filename>] [--max-artifact-bytes <n>] [--max-model-bytes <n>]\n", .{});
     std.debug.print("       antfly inference pull hf:<owner>/<repo> --type predictor [--name <predictor-name>] [--ml-dir <dir>] [--file <repo-path>] [--framework auto|onnx|xgboost|lightgbm]\n", .{});
     std.debug.print("       antfly inference pull <https-url-to-tabular-artifact> --name <predictor-name> [--ml-dir <dir>] [--token <bearer-token>]\n", .{});
     std.debug.print("variants: <model-ref>:gguf, <model-ref>:gguf:Q4_K, <model-ref>:onnx, <model-ref>:hybrid, <model-ref>:safetensors\n", .{});
@@ -595,6 +613,8 @@ fn printUsage() void {
         \\  --tasks <list>   Comma-separated task hints for the pulled model
         \\  --capabilities <list> Comma-separated capability hints for the pulled model
         \\  --projector <value> Projector sidecar selection for GGUF pulls: auto, none, quant suffix, or filename
+        \\  --max-artifact-bytes <n> Maximum bytes accepted for one model artifact (default: 68719476736)
+        \\  --max-model-bytes <n> Maximum aggregate bytes accepted for one pull (default: 137438953472)
         \\  --models-dir <dir> AI models directory (default: ~/.antfly/inference/models)
         \\  --ml-dir <dir>     Traditional ML directory for URL pulls (default: ~/.antfly/inference/ml)
         \\
@@ -617,6 +637,7 @@ test "inference pull recognizes help before model resolution" {
 test "inference pull classifies order independent value flags" {
     try std.testing.expect(pullFlagTakesValue("--variants"));
     try std.testing.expect(pullFlagTakesValue("--models-dir"));
+    try std.testing.expect(pullFlagTakesValue("--max-model-bytes"));
     try std.testing.expect(pullFlagTakesValue("--framework"));
     try std.testing.expect(!pullFlagTakesValue("--optimize"));
     try std.testing.expect(!pullFlagTakesValue("--unknown"));

--- a/zig/pkg/antfly/src/metadata/sim_harness.zig
+++ b/zig/pkg/antfly/src/metadata/sim_harness.zig
@@ -6326,8 +6326,7 @@ test "metadata http cluster simulation forwards public split flow from a non-hos
     defer workflow.deinit();
     const reconcile_index = currentMetadataLeaderIndex(&cluster) orelse leader_index;
     try workflow.bootstrapDesiredFromCommitted(&cluster.node(reconcile_index));
-    _ = try requireLeasedReconcile(cluster.node(reconcile_index), workflow.controlLoop());
-    try cluster.stepAll();
+    _ = try retireFinalizedSplitTransition(cluster.node(reconcile_index), workflow.controlLoop());
 
     const split_route = try waitForPublicSplitRoute(&cluster, catalog_sources[0..], "docs", leader_index, 48);
     const left_group = split_route.left_group;
@@ -6523,8 +6522,7 @@ test "metadata http cluster simulation forwards public merge flow from a non-hos
     defer workflow.deinit();
     const reconcile_index = currentMetadataLeaderIndex(&cluster) orelse leader_index;
     try workflow.bootstrapDesiredFromCommitted(&cluster.node(reconcile_index));
-    _ = try requireLeasedReconcile(cluster.node(reconcile_index), workflow.controlLoop());
-    try cluster.stepAll();
+    _ = try retireFinalizedSplitTransition(cluster.node(reconcile_index), workflow.controlLoop());
 
     const split_route = try waitForPublicSplitRoute(&cluster, catalog_sources[0..], "docs", leader_index, 48);
     const left_group = split_route.left_group;
@@ -6563,8 +6561,7 @@ test "metadata http cluster simulation forwards public merge flow from a non-hos
     defer merge_workflow.deinit();
     const merge_reconcile_index = currentMetadataLeaderIndex(&cluster) orelse leader_index;
     try merge_workflow.bootstrapDesiredFromCommitted(&cluster.node(merge_reconcile_index));
-    _ = try requireLeasedReconcile(cluster.node(merge_reconcile_index), merge_workflow.controlLoop());
-    try cluster.stepAll();
+    _ = try retireFinalizedMergeTransition(cluster.node(merge_reconcile_index), merge_workflow.controlLoop());
     try std.testing.expect(try cluster.waitForGroupStatusCount(left_group, .active, 3, 48));
     try std.testing.expect(try cluster.waitForGroupStatus(right_group, .absent, 48));
 
@@ -10103,8 +10100,7 @@ test "metadata http cluster simulation forwards public table io across split ran
     try std.testing.expect(try waitForSplitTransitionFinalized(&cluster, 48401, null, leader_index, 40));
 
     const query_index = currentMetadataLeaderIndex(&cluster) orelse leader_index;
-    _ = try requireLeasedReconcile(cluster.node(query_index), workflow.controlLoop());
-    try cluster.stepAll();
+    _ = try retireFinalizedSplitTransition(cluster.node(query_index), workflow.controlLoop());
 
     var left_host: ?usize = null;
     var right_host: ?usize = null;
@@ -10391,8 +10387,7 @@ test "metadata http cluster simulation forwards public table io after merge fina
     try std.testing.expect(try waitForMergeTransitionFinalized(&cluster, 48501, null, leader_index, 40));
 
     const query_index = currentMetadataLeaderIndex(&cluster) orelse leader_index;
-    _ = try requireLeasedReconcile(cluster.node(query_index), workflow.controlLoop());
-    try cluster.stepAll();
+    _ = try retireFinalizedMergeTransition(cluster.node(query_index), workflow.controlLoop());
 
     var receiver_host: ?usize = null;
     for (0..3) |i| {

--- a/zig/pkg/antfly/src/metadata/table_manager.zig
+++ b/zig/pkg/antfly/src/metadata/table_manager.zig
@@ -1159,6 +1159,17 @@ pub const TableManager = struct {
         try self.merge_intents.put(self.alloc, intent.transition_id, owned);
     }
 
+    pub fn mergeRequiresDocIdentityReassignment(
+        self: *const TableManager,
+        donor_group_id: u64,
+        receiver_group_id: u64,
+    ) !bool {
+        const donor = self.ranges.get(donor_group_id) orelse return error.UnknownDonorRange;
+        const receiver = self.ranges.get(receiver_group_id) orelse return error.UnknownReceiverRange;
+        return rangeDocIdentityShardId(donor) != rangeDocIdentityShardId(receiver) or
+            rangeDocIdentityRangeId(donor) != rangeDocIdentityRangeId(receiver);
+    }
+
     /// Rehydrate active split intents from replicated metadata after a
     /// reconciliation-authority handoff. Projected records are authoritative:
     /// they replace a local copy with the same transition ID without allocating

--- a/zig/pkg/antfly/src/metadata/table_workflow.zig
+++ b/zig/pkg/antfly/src/metadata/table_workflow.zig
@@ -95,8 +95,16 @@ pub const TableWorkflow = struct {
         try self.bootstrapDesiredFromCommitted(service);
         var current = try self.loop.stateRef().captureCurrent(service);
         defer current.deinit(self.loop.alloc);
-        try validateMergeIntentDocIdentity(current.current, intent);
-        try self.loop.stateRef().tableManager().requestMerge(intent);
+        const requires_reassignment = try self.loop.stateRef().tableManager().mergeRequiresDocIdentityReassignment(
+            intent.donor_group_id,
+            intent.receiver_group_id,
+        );
+        const normalized_intent = try normalizeMergeIntentDocIdentity(
+            current.current,
+            intent,
+            requires_reassignment,
+        );
+        try self.loop.stateRef().tableManager().requestMerge(normalized_intent);
         return try reconcileForService(&self.loop, service);
     }
 
@@ -198,6 +206,22 @@ fn validateMergeIntentDocIdentity(current: metadata_reconciler.CurrentMetadataSt
     if (!runtimeDocIdentityHasOrdinalRows(donor.doc_identity) or !runtimeDocIdentityHasOrdinalRows(receiver.doc_identity)) return;
     if (intent.allow_doc_identity_reassignment) return;
     if (!runtimeDocIdentitySameNamespace(donor.doc_identity, receiver.doc_identity)) return error.DocIdentityNamespaceMismatch;
+}
+
+fn normalizeMergeIntentDocIdentity(
+    current: metadata_reconciler.CurrentMetadataState,
+    intent: table_manager.MergeIntent,
+    requires_reassignment: bool,
+) !table_manager.MergeIntent {
+    try validateMergeIntentDocIdentity(current, intent);
+    if (intent.allow_doc_identity_reassignment or !requires_reassignment) return intent;
+
+    // A merge approved by the runtime guard may still join distinct committed
+    // range identities. Record that reassignment so the durable contract
+    // explicitly identifies which namespace wins.
+    var normalized = intent;
+    normalized.allow_doc_identity_reassignment = true;
+    return normalized;
 }
 
 fn findMergedGroupStatus(
@@ -366,6 +390,13 @@ test "table workflow doc identity lifecycle handles mixed-version transition sta
         .donor_group_id = 102,
         .receiver_group_id = 101,
     });
+    const normalized = try normalizeMergeIntentDocIdentity(current, .{
+        .transition_id = 11,
+        .table_id = 10,
+        .donor_group_id = 102,
+        .receiver_group_id = 101,
+    }, true);
+    try std.testing.expect(normalized.allow_doc_identity_reassignment);
 
     try std.testing.expectError(error.DocIdentityNamespaceMismatch, validateSplitIntentDocIdentity(.{ .merged_group_statuses = &.{} }, .{
         .transition_id = 12,

--- a/zig/pkg/inference/src/main.zig
+++ b/zig/pkg/inference/src/main.zig
@@ -126,6 +126,12 @@ fn parsePositiveUsize(value: []const u8) !usize {
     return parsed;
 }
 
+fn parsePositiveU64(value: []const u8) !u64 {
+    const parsed = try std.fmt.parseInt(u64, value, 10);
+    if (parsed == 0) return error.InvalidArguments;
+    return parsed;
+}
+
 fn preloadModelsFromConfig(allocator: std.mem.Allocator, values: []const RunConfig.WarmModelConfig) ![]inference.server.WarmModel {
     if (values.len == 0) return &.{};
     const out = try allocator.alloc(inference.server.WarmModel, values.len);
@@ -363,7 +369,7 @@ fn listModels(allocator: std.mem.Allocator, io: std.Io, args: []const []const u8
 
 fn pullModel(allocator: std.mem.Allocator, io: std.Io, usage_name: []const u8, args: []const []const u8) !void {
     if (args.len == 0) {
-        print("usage: {s} pull <owner/name|hf:owner/name>[:gguf|:gguf:Q4_K_M|:mmproj] [--token <hf-token>] [--models-dir <dir>] [--tasks <task1,task2>] [--capabilities <cap1,cap2>] [--projector <auto|none|Q8_0|filename>]\n", .{usage_name});
+        print("usage: {s} pull <owner/name|hf:owner/name>[:gguf|:gguf:Q4_K_M|:mmproj] [--token <hf-token>] [--models-dir <dir>] [--tasks <task1,task2>] [--capabilities <cap1,cap2>] [--projector <auto|none|Q8_0|filename>] [--max-artifact-bytes <n>] [--max-model-bytes <n>]\n", .{usage_name});
         print("       {s} pull hf:<owner>/<repo> --type predictor [--name <predictor-name>] [--ml-dir <dir>] [--file <repo-path>] [--framework auto|onnx|xgboost|lightgbm]\n", .{usage_name});
         print("       {s} pull <https-url-to-tabular-artifact> --name <predictor-name> [--ml-dir <dir>] [--token <bearer-token>]\n", .{usage_name});
         print("variants: <model-ref>:gguf, <model-ref>:gguf:Q4_K, <model-ref>:onnx, <model-ref>:hybrid, <model-ref>:safetensors\n", .{});
@@ -382,6 +388,8 @@ fn pullModel(allocator: std.mem.Allocator, io: std.Io, usage_name: []const u8, a
     var capabilities_csv: ?[]const u8 = null;
     var models_dir: []const u8 = defaultModelsDir(allocator);
     var projector_selection: inference.registry.download.ProjectorSelection = .auto;
+    var max_artifact_bytes = inference.registry.download.default_max_artifact_bytes;
+    var max_model_bytes = inference.registry.download.default_max_model_bytes;
     var i: usize = 1;
     while (i < args.len) : (i += 1) {
         if (std.mem.eql(u8, args[i], "--token") and i + 1 < args.len) {
@@ -401,6 +409,12 @@ fn pullModel(allocator: std.mem.Allocator, io: std.Io, usage_name: []const u8, a
         } else if (std.mem.eql(u8, args[i], "--projector") and i + 1 < args.len) {
             projector_selection = inference.registry.download.parseProjectorSelection(args[i + 1]) orelse return error.InvalidArguments;
             i += 1;
+        } else if (std.mem.eql(u8, args[i], "--max-artifact-bytes") and i + 1 < args.len) {
+            max_artifact_bytes = try parsePositiveU64(args[i + 1]);
+            i += 1;
+        } else if (std.mem.eql(u8, args[i], "--max-model-bytes") and i + 1 < args.len) {
+            max_model_bytes = try parsePositiveU64(args[i + 1]);
+            i += 1;
         }
     }
 
@@ -413,7 +427,11 @@ fn pullModel(allocator: std.mem.Allocator, io: std.Io, usage_name: []const u8, a
 
     var reg = inference.registry.ModelRegistry.init(allocator, models_dir);
     defer reg.deinit();
-    try reg.pull(io, ref, token, tasks_csv, capabilities_csv, projector_selection);
+    try reg.pull(io, ref, .{
+        .token = token,
+        .max_artifact_bytes = max_artifact_bytes,
+        .max_model_bytes = max_model_bytes,
+    }, tasks_csv, capabilities_csv, projector_selection);
 
     print("done.\n", .{});
 }
@@ -483,6 +501,8 @@ fn printUsage(usage_name: []const u8) void {
         \\  --tasks <list>    Comma-separated task hints for the pulled model
         \\  --capabilities <list> Comma-separated capability hints for the pulled model
         \\  --projector <value> Projector sidecar selection for GGUF pulls: auto, none, quant suffix, or filename
+        \\  --max-artifact-bytes <n> Maximum bytes accepted for one model artifact (default: 68719476736)
+        \\  --max-model-bytes <n> Maximum aggregate bytes accepted for one pull (default: 137438953472)
         \\  --models-dir <dir>    AI models directory (default: ~/.antfly/inference/models)
         \\  --ml-dir <dir>        Traditional ML directory for URL pulls (default: ~/.antfly/inference/ml)
         \\  variants          <model-ref>:gguf, <model-ref>:gguf:Q4_K, <model-ref>:onnx, <model-ref>:hybrid, <model-ref>:safetensors
@@ -541,4 +561,6 @@ test "run max concurrent request parser rejects zero" {
     try std.testing.expectEqual(@as(usize, 6), try parsePositiveUsize("6"));
     try std.testing.expectError(error.InvalidArguments, parsePositiveUsize("0"));
     try std.testing.expectError(error.InvalidCharacter, parsePositiveUsize("six"));
+    try std.testing.expectEqual(@as(u64, 137438953472), try parsePositiveU64("137438953472"));
+    try std.testing.expectError(error.InvalidArguments, parsePositiveU64("0"));
 }

--- a/zig/pkg/inference/src/registry/download.zig
+++ b/zig/pkg/inference/src/registry/download.zig
@@ -26,6 +26,12 @@ pub const HubConfig = struct {
     token: ?[]const u8 = null,
     /// Base URL for the Hub API.
     base_url: []const u8 = "https://huggingface.co",
+    /// Maximum bytes accepted for one downloaded model artifact.
+    ///
+    /// Downloads stream directly to disk, so this is a disk-safety boundary
+    /// rather than an in-memory response limit. Keep it high enough for large
+    /// unsharded checkpoints while remaining finite for untrusted responses.
+    max_artifact_bytes: u64 = 64 * 1024 * 1024 * 1024,
 };
 
 pub const ProjectorSelection = union(enum) {
@@ -1009,10 +1015,14 @@ const OffsetFileWriter = struct {
     file: std.Io.File,
     io: std.Io,
     offset: u64,
+    max_offset: u64,
 
     pub fn writeAll(self: *OffsetFileWriter, data: []const u8) !void {
+        const next_offset = std.math.add(u64, self.offset, data.len) catch
+            return error.DownloadSizeLimitExceeded;
+        if (next_offset > self.max_offset) return error.DownloadSizeLimitExceeded;
         try self.file.writePositionalAll(self.io, data, self.offset);
-        self.offset += data.len;
+        self.offset = next_offset;
     }
 };
 
@@ -1174,7 +1184,11 @@ pub fn downloadModel(
         const filename = file_meta.name;
         const total_bytes = if (file_meta.size) |declared_size| blk: {
             if (shouldProbeLinkedPayloadSize(filename, declared_size)) {
-                break :blk probeDownloadSize(allocator, io, owner, name, filename, config) catch declared_size;
+                // A small size for a binary artifact is normally the Git LFS
+                // pointer size, not the payload size. If probing fails, leave
+                // the size unknown rather than treating the pointer as a
+                // trustworthy completion boundary.
+                break :blk probeDownloadSize(allocator, io, owner, name, filename, config) catch null;
             }
             break :blk declared_size;
         } else (probeDownloadSize(allocator, io, owner, name, filename, config) catch null);
@@ -1481,12 +1495,25 @@ fn resolveDownloadUrl(
     }
 }
 
-fn downloadClientConfig() httpx.ClientConfig {
+fn downloadResponseLimit(config: HubConfig) !usize {
+    if (config.max_artifact_bytes == 0) return error.InvalidDownloadSizeLimit;
+    const artifact_limit = std.math.cast(usize, config.max_artifact_bytes) orelse
+        return error.InvalidDownloadSizeLimit;
+    // httpx counts the initial receive buffer, which can contain both response
+    // headers and body bytes, against its client-wide limit. Reserve one full
+    // receive buffer for framing; OffsetFileWriter remains the authoritative
+    // artifact-size boundary.
+    return std.math.add(usize, artifact_limit, 16 * 1024) catch
+        return error.InvalidDownloadSizeLimit;
+}
+
+fn downloadClientConfig(max_response_size: usize) httpx.ClientConfig {
     return .{
         .keep_alive = false,
         // Model artifacts are streamed directly to disk. The client's
-        // in-memory 100 MiB default would otherwise truncate larger payloads.
-        .max_response_size = std.math.maxInt(usize),
+        // in-memory 100 MiB default is inappropriate, but the disk stream must
+        // retain a finite response ceiling.
+        .max_response_size = max_response_size,
     };
 }
 
@@ -1505,6 +1532,11 @@ fn downloadFile(
     total_bytes: ?u64,
     expected_sha256: ?[]const u8,
 ) !void {
+    const max_response_size = try downloadResponseLimit(config);
+    if (total_bytes) |total| {
+        if (total > config.max_artifact_bytes) return error.DownloadSizeLimitExceeded;
+    }
+
     var dest = std.Io.Dir.cwd();
     const dest_path = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ dest_dir, filename });
     defer allocator.free(dest_path);
@@ -1533,12 +1565,6 @@ fn downloadFile(
     const url = try std.fmt.allocPrint(allocator, "{s}/{s}/{s}/resolve/main/{s}", .{ config.base_url, owner, name, filename });
     defer allocator.free(url);
 
-    var client = httpx.Client.initWithConfig(allocator, io, downloadClientConfig());
-    defer client.deinit();
-
-    const download_url = try resolveDownloadUrl(allocator, &client, url, headers_buf[0..n_headers]);
-    defer allocator.free(download_url);
-
     // Create parent dirs if filename has slashes (e.g., "onnx/model.onnx")
     if (std.mem.lastIndexOfScalar(u8, filename, '/')) |last_slash| {
         const parent = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ dest_dir, filename[0..last_slash] });
@@ -1550,12 +1576,30 @@ fn downloadFile(
     defer allocator.free(temp_path);
 
     var resume_from = existingFileSize(dest, io, temp_path) catch 0;
+    if (resume_from > config.max_artifact_bytes) {
+        dest.deleteFile(io, temp_path) catch {};
+        return error.DownloadSizeLimitExceeded;
+    }
     if (total_bytes) |total| {
-        if (resume_from >= total) {
-            try std.Io.Dir.rename(dest, temp_path, dest, dest_path, io);
+        if (resume_from == total) {
+            try finalizeDownloadedFile(dest, io, temp_path, dest_path, expected_sha256);
             return;
         }
+        if (resume_from > total) {
+            dest.deleteFile(io, temp_path) catch {};
+            resume_from = 0;
+        }
     }
+
+    var client = httpx.Client.initWithConfig(
+        allocator,
+        io,
+        downloadClientConfig(max_response_size),
+    );
+    defer client.deinit();
+
+    const download_url = try resolveDownloadUrl(allocator, &client, url, headers_buf[0..n_headers]);
+    defer allocator.free(download_url);
 
     while (true) {
         if (range_header) |range| {
@@ -1584,6 +1628,7 @@ fn downloadFile(
             .file = file,
             .io = io,
             .offset = resume_from,
+            .max_offset = config.max_artifact_bytes,
         };
 
         var progress_ctx = FileProgressCtx{
@@ -1608,10 +1653,22 @@ fn downloadFile(
             }
         }
 
-        var streamed = try client.getToWriter(download_url, .{
+        var streamed = client.getToWriter(download_url, .{
             .headers = headers_buf[0..n_headers],
             .follow_redirects = false,
-        }, &resume_writer, FileProgressCtx.onWriterProgress, &progress_ctx);
+        }, &resume_writer, FileProgressCtx.onWriterProgress, &progress_ctx) catch |err| {
+            // A server that ignores Range can send a complete response after
+            // the existing prefix, making the temporary file exceed the
+            // artifact limit before its HTTP 200 status is available here.
+            // Retry once without the stale prefix; a genuinely oversized
+            // response will then fail at the same finite limit.
+            if (err == error.DownloadSizeLimitExceeded and resume_from > 0) {
+                dest.deleteFile(io, temp_path) catch {};
+                resume_from = 0;
+                continue;
+            }
+            return err;
+        };
         defer streamed.deinit();
 
         if (!streamed.ok()) {
@@ -1625,16 +1682,34 @@ fn downloadFile(
             continue;
         }
 
+        if (total_bytes) |total| {
+            if (resume_writer.offset != total) {
+                if (resume_writer.offset > total) {
+                    dest.deleteFile(io, temp_path) catch {};
+                }
+                return error.DownloadSizeMismatch;
+            }
+        }
+
         break;
     }
 
+    try finalizeDownloadedFile(dest, io, temp_path, dest_path, expected_sha256);
+}
+
+fn finalizeDownloadedFile(
+    dest: std.Io.Dir,
+    io: std.Io,
+    temp_path: []const u8,
+    dest_path: []const u8,
+    expected_sha256: ?[]const u8,
+) !void {
     if (expected_sha256) |sum| {
         verifyFileSha256(dest, io, temp_path, sum) catch |err| {
             dest.deleteFile(io, temp_path) catch {};
             return err;
         };
     }
-
     dest.deleteFile(io, dest_path) catch |err| switch (err) {
         error.FileNotFound => {},
         else => return err,
@@ -2180,9 +2255,139 @@ fn testTmpPath(allocator: std.mem.Allocator, tmp: anytype, tail: []const u8) ![]
     return std.fs.path.join(allocator, &.{ ".zig-cache", "tmp", tmp.sub_path[0..], tail });
 }
 
-test "streaming model downloads are not capped by the in-memory response limit" {
-    const config = downloadClientConfig();
-    try std.testing.expectEqual(std.math.maxInt(usize), config.max_response_size);
+test "streaming model downloads use a finite disk-oriented response limit" {
+    const response_limit = try downloadResponseLimit(.{ .max_artifact_bytes = 1024 });
+    try std.testing.expectEqual(@as(usize, 17 * 1024), response_limit);
+    try std.testing.expectEqual(
+        response_limit,
+        downloadClientConfig(response_limit).max_response_size,
+    );
+    try std.testing.expectError(
+        error.InvalidDownloadSizeLimit,
+        downloadResponseLimit(.{ .max_artifact_bytes = 0 }),
+    );
+    try std.testing.expectError(
+        error.InvalidDownloadSizeLimit,
+        downloadResponseLimit(.{ .max_artifact_bytes = std.math.maxInt(u64) }),
+    );
+}
+
+test "downloadFile rejects artifacts above the configured disk limit before network access" {
+    try std.testing.expectError(
+        error.DownloadSizeLimitExceeded,
+        downloadFile(
+            std.testing.allocator,
+            std.testing.io,
+            "owner",
+            "name",
+            "model.onnx",
+            ".",
+            .{
+                .base_url = "http://127.0.0.1:1",
+                .max_artifact_bytes = 128,
+            },
+            .{},
+            0,
+            1,
+            129,
+            null,
+        ),
+    );
+}
+
+test "downloadFile removes an oversized partial before network access" {
+    const allocator = std.testing.allocator;
+    const io = std.testing.io;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const dest_dir = try testTmpPath(allocator, tmp, "downloads");
+    defer allocator.free(dest_dir);
+    try std.Io.Dir.cwd().createDirPath(io, dest_dir);
+    const part_path = try std.fs.path.join(allocator, &.{ dest_dir, "model.onnx.part" });
+    defer allocator.free(part_path);
+    try std.Io.Dir.cwd().writeFile(io, .{ .sub_path = part_path, .data = "oversized" });
+
+    try std.testing.expectError(
+        error.DownloadSizeLimitExceeded,
+        downloadFile(
+            allocator,
+            io,
+            "owner",
+            "name",
+            "model.onnx",
+            dest_dir,
+            .{
+                .base_url = "http://127.0.0.1:1",
+                .max_artifact_bytes = 4,
+            },
+            .{},
+            0,
+            1,
+            null,
+            null,
+        ),
+    );
+    try std.testing.expectError(
+        error.FileNotFound,
+        std.Io.Dir.cwd().openFile(io, part_path, .{}),
+    );
+}
+
+test "downloadFile verifies a complete partial before installing it" {
+    const allocator = std.testing.allocator;
+    const io = std.testing.io;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const dest_dir = try testTmpPath(allocator, tmp, "downloads");
+    defer allocator.free(dest_dir);
+    try std.Io.Dir.cwd().createDirPath(io, dest_dir);
+    const part_path = try std.fs.path.join(allocator, &.{ dest_dir, "model.onnx.part" });
+    defer allocator.free(part_path);
+    try std.Io.Dir.cwd().writeFile(io, .{ .sub_path = part_path, .data = "bad" });
+
+    try std.testing.expectError(
+        error.ChecksumMismatch,
+        downloadFile(
+            allocator,
+            io,
+            "owner",
+            "name",
+            "model.onnx",
+            dest_dir,
+            .{ .base_url = "http://127.0.0.1:1" },
+            .{},
+            0,
+            1,
+            3,
+            "0000000000000000000000000000000000000000000000000000000000000000",
+        ),
+    );
+    try std.testing.expectError(
+        error.FileNotFound,
+        std.Io.Dir.cwd().openFile(io, part_path, .{}),
+    );
+}
+
+test "offset file writer enforces the final artifact size across resumed writes" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    var file = try tmp.dir.createFile(std.testing.io, "bounded.bin", .{ .read = true });
+    defer file.close(std.testing.io);
+    var writer = OffsetFileWriter{
+        .file = file,
+        .io = std.testing.io,
+        .offset = 3,
+        .max_offset = 5,
+    };
+    try writer.writeAll("ok");
+    try std.testing.expectEqual(@as(u64, 5), writer.offset);
+    try std.testing.expectError(error.DownloadSizeLimitExceeded, writer.writeAll("!"));
+    try std.testing.expectEqual(@as(u64, 5), writer.offset);
 }
 
 test "downloadFile resumes from partial file with 206 response" {
@@ -2375,6 +2580,9 @@ test "downloadFile restarts cleanly when range is ignored" {
     defer allocator.free(base_url);
     try downloadFile(allocator, io, "owner", "name", "tokenizer.json", dest_dir, .{
         .base_url = base_url,
+        // Force the bounded writer to detect the ignored Range response before
+        // getToWriter can return its HTTP 200 status.
+        .max_artifact_bytes = payload.len,
     }, .{}, 0, 1, payload.len, null);
 
     const final_path = try std.fs.path.join(allocator, &.{ dest_dir, "tokenizer.json" });

--- a/zig/pkg/inference/src/registry/download.zig
+++ b/zig/pkg/inference/src/registry/download.zig
@@ -1481,6 +1481,15 @@ fn resolveDownloadUrl(
     }
 }
 
+fn downloadClientConfig() httpx.ClientConfig {
+    return .{
+        .keep_alive = false,
+        // Model artifacts are streamed directly to disk. The client's
+        // in-memory 100 MiB default would otherwise truncate larger payloads.
+        .max_response_size = std.math.maxInt(usize),
+    };
+}
+
 /// Download a single file from HuggingFace Hub.
 fn downloadFile(
     allocator: std.mem.Allocator,
@@ -1524,9 +1533,7 @@ fn downloadFile(
     const url = try std.fmt.allocPrint(allocator, "{s}/{s}/{s}/resolve/main/{s}", .{ config.base_url, owner, name, filename });
     defer allocator.free(url);
 
-    var client = httpx.Client.initWithConfig(allocator, io, .{
-        .keep_alive = false,
-    });
+    var client = httpx.Client.initWithConfig(allocator, io, downloadClientConfig());
     defer client.deinit();
 
     const download_url = try resolveDownloadUrl(allocator, &client, url, headers_buf[0..n_headers]);
@@ -2171,6 +2178,11 @@ fn reserveEphemeralPort(io: std.Io) !u16 {
 
 fn testTmpPath(allocator: std.mem.Allocator, tmp: anytype, tail: []const u8) ![]u8 {
     return std.fs.path.join(allocator, &.{ ".zig-cache", "tmp", tmp.sub_path[0..], tail });
+}
+
+test "streaming model downloads are not capped by the in-memory response limit" {
+    const config = downloadClientConfig();
+    try std.testing.expectEqual(std.math.maxInt(usize), config.max_response_size);
 }
 
 test "downloadFile resumes from partial file with 206 response" {

--- a/zig/pkg/inference/src/registry/download.zig
+++ b/zig/pkg/inference/src/registry/download.zig
@@ -20,6 +20,10 @@
 
 const std = @import("std");
 const httpx = @import("httpx");
+const builtin = @import("builtin");
+
+pub const default_max_artifact_bytes: u64 = 64 * 1024 * 1024 * 1024;
+pub const default_max_model_bytes: u64 = 128 * 1024 * 1024 * 1024;
 
 pub const HubConfig = struct {
     /// HuggingFace Hub API token (optional, for private/gated models).
@@ -31,8 +35,52 @@ pub const HubConfig = struct {
     /// Downloads stream directly to disk, so this is a disk-safety boundary
     /// rather than an in-memory response limit. Keep it high enough for large
     /// unsharded checkpoints while remaining finite for untrusted responses.
-    max_artifact_bytes: u64 = 64 * 1024 * 1024 * 1024,
+    max_artifact_bytes: u64 = default_max_artifact_bytes,
+    /// Maximum aggregate bytes accepted for the selected model artifact set.
+    ///
+    /// This prevents a repository with many individually valid shards from
+    /// exhausting the model volume.
+    max_model_bytes: u64 = default_max_model_bytes,
 };
+
+pub const managed_download_in_progress_filename = ".antfly-download-in-progress";
+pub const managed_download_plan_filename = ".antfly-download-plan.json";
+pub const managed_download_complete_filename = ".antfly-download-complete.json";
+pub const managed_download_lock_filename = ".antfly-download.lock";
+
+const ManagedArtifactReceipt = struct {
+    path: []const u8,
+    size: u64,
+    sha256: ?[]const u8 = null,
+};
+
+const ManagedDownloadReceipt = struct {
+    version: u32 = 1,
+    artifacts: []const ManagedArtifactReceipt,
+};
+
+pub const ManagedDownloadState = enum {
+    unmanaged,
+    incomplete,
+    complete,
+};
+
+const ResolvedArtifact = struct {
+    file: HubFile,
+    total_bytes: ?u64,
+};
+
+fn addKnownModelBytes(current: u64, artifact_bytes: u64, limit: u64) !u64 {
+    const next = std.math.add(u64, current, artifact_bytes) catch
+        return error.ModelSizeLimitExceeded;
+    if (next > limit) return error.ModelSizeLimitExceeded;
+    return next;
+}
+
+fn consumeModelBudget(remaining: u64, artifact_bytes: u64) !u64 {
+    if (artifact_bytes > remaining) return error.ModelSizeLimitExceeded;
+    return remaining - artifact_bytes;
+}
 
 pub const ProjectorSelection = union(enum) {
     auto,
@@ -1056,6 +1104,262 @@ const FileProgressCtx = struct {
     }
 };
 
+fn managedPath(
+    allocator: std.mem.Allocator,
+    dest_dir: []const u8,
+    filename: []const u8,
+) ![]u8 {
+    return std.fs.path.join(allocator, &.{ dest_dir, filename });
+}
+
+fn writeFileAtomically(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    path: []const u8,
+    data: []const u8,
+) !void {
+    const temp_path = try std.fmt.allocPrint(allocator, "{s}.tmp", .{path});
+    defer allocator.free(temp_path);
+
+    var cwd = std.Io.Dir.cwd();
+    cwd.deleteFile(io, temp_path) catch {};
+    errdefer cwd.deleteFile(io, temp_path) catch {};
+    {
+        var file = try cwd.createFile(io, temp_path, .{ .read = true });
+        defer file.close(io);
+        try file.writePositionalAll(io, data, 0);
+        try file.sync(io);
+    }
+    try std.Io.Dir.rename(cwd, temp_path, cwd, path, io);
+    try syncManagedDirectory(io, std.fs.path.dirname(path) orelse ".");
+}
+
+fn syncManagedDirectory(io: std.Io, path: []const u8) !void {
+    // Windows does not expose directory FlushFileBuffers through std.Io.
+    // Atomic rename still provides fail-safe visibility there; POSIX targets
+    // additionally persist directory-entry ordering across power loss.
+    if (builtin.os.tag == .windows or
+        builtin.os.tag == .wasi or
+        builtin.os.tag == .freestanding)
+    {
+        return;
+    }
+    var dir = if (std.fs.path.isAbsolute(path))
+        try std.Io.Dir.openDirAbsolute(io, path, .{})
+    else
+        try std.Io.Dir.cwd().openDir(io, path, .{});
+    defer dir.close(io);
+    while (true) switch (std.posix.errno(std.posix.system.fsync(dir.handle))) {
+        .SUCCESS => return,
+        .INTR => continue,
+        .INVAL => return,
+        .BADF => return error.InvalidFileDescriptor,
+        .IO => return error.InputOutput,
+        .NOSPC => return error.NoSpaceLeft,
+        .DQUOT => return error.DiskQuota,
+        else => |err| return std.posix.unexpectedErrno(err),
+    };
+}
+
+pub fn beginManagedDownload(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    dest_dir: []const u8,
+) !void {
+    try std.Io.Dir.cwd().createDirPath(io, dest_dir);
+    const in_progress_path = try managedPath(allocator, dest_dir, managed_download_in_progress_filename);
+    defer allocator.free(in_progress_path);
+    const plan_path = try managedPath(allocator, dest_dir, managed_download_plan_filename);
+    defer allocator.free(plan_path);
+    const complete_path = try managedPath(allocator, dest_dir, managed_download_complete_filename);
+    defer allocator.free(complete_path);
+
+    try writeFileAtomically(
+        allocator,
+        io,
+        in_progress_path,
+        "{\"version\":1,\"state\":\"in_progress\"}\n",
+    );
+    var cwd = std.Io.Dir.cwd();
+    cwd.deleteFile(io, plan_path) catch {};
+    cwd.deleteFile(io, complete_path) catch {};
+    try syncManagedDirectory(io, dest_dir);
+}
+
+pub fn completeManagedDownload(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    dest_dir: []const u8,
+) !void {
+    const in_progress_path = try managedPath(allocator, dest_dir, managed_download_in_progress_filename);
+    defer allocator.free(in_progress_path);
+    const plan_path = try managedPath(allocator, dest_dir, managed_download_plan_filename);
+    defer allocator.free(plan_path);
+    const complete_path = try managedPath(allocator, dest_dir, managed_download_complete_filename);
+    defer allocator.free(complete_path);
+
+    var cwd = std.Io.Dir.cwd();
+    try std.Io.Dir.rename(cwd, plan_path, cwd, complete_path, io);
+    // Persist the completion receipt before removing the fail-closed marker.
+    try syncManagedDirectory(io, dest_dir);
+    try cwd.deleteFile(io, in_progress_path);
+    try syncManagedDirectory(io, dest_dir);
+}
+
+fn managedArtifactPathIsSafe(path: []const u8) bool {
+    if (path.len == 0 or std.fs.path.isAbsolute(path)) return false;
+    // Hub repository paths are POSIX-style on every platform. Rejecting
+    // backslashes avoids treating an attacker-controlled receipt differently
+    // on Windows.
+    if (std.mem.indexOfScalar(u8, path, '\\') != null) return false;
+    var parts = std.mem.splitScalar(u8, path, '/');
+    while (parts.next()) |part| {
+        if (part.len == 0 or
+            std.mem.eql(u8, part, ".") or
+            std.mem.eql(u8, part, ".."))
+        {
+            return false;
+        }
+    }
+    return true;
+}
+
+/// Return the publication state of a model directory managed by `pull`.
+///
+/// A completion receipt is accepted only when every recorded artifact still
+/// exists at the recorded size. This is intentionally metadata-only: hashing
+/// multi-gigabyte model files on every discovery would make startup
+/// prohibitively expensive, while downloads are digest-verified before the
+/// receipt is published.
+pub fn managedDownloadState(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    dest_dir: []const u8,
+) ManagedDownloadState {
+    const in_progress_path = managedPath(
+        allocator,
+        dest_dir,
+        managed_download_in_progress_filename,
+    ) catch return .incomplete;
+    defer allocator.free(in_progress_path);
+    const plan_path = managedPath(
+        allocator,
+        dest_dir,
+        managed_download_plan_filename,
+    ) catch return .incomplete;
+    defer allocator.free(plan_path);
+    const complete_path = managedPath(
+        allocator,
+        dest_dir,
+        managed_download_complete_filename,
+    ) catch return .incomplete;
+    defer allocator.free(complete_path);
+
+    const cwd = std.Io.Dir.cwd();
+    if (cwd.access(io, in_progress_path, .{})) |_| return .incomplete else |err| switch (err) {
+        error.FileNotFound => {},
+        else => return .incomplete,
+    }
+    if (cwd.access(io, plan_path, .{})) |_| return .incomplete else |err| switch (err) {
+        error.FileNotFound => {},
+        else => return .incomplete,
+    }
+
+    const receipt_json = cwd.readFileAlloc(
+        io,
+        complete_path,
+        allocator,
+        .limited(16 * 1024 * 1024),
+    ) catch |err| switch (err) {
+        error.FileNotFound => {
+            // Close the race with beginManagedDownload, which publishes the
+            // marker before deleting an old completion receipt.
+            if (managedPublicationFilesBlocked(cwd, io, in_progress_path, plan_path)) {
+                return .incomplete;
+            }
+            return .unmanaged;
+        },
+        else => return .incomplete,
+    };
+    defer allocator.free(receipt_json);
+    var parsed = std.json.parseFromSlice(
+        ManagedDownloadReceipt,
+        allocator,
+        receipt_json,
+        .{ .ignore_unknown_fields = true },
+    ) catch return .incomplete;
+    defer parsed.deinit();
+    if (parsed.value.version != 1 or parsed.value.artifacts.len == 0) {
+        return .incomplete;
+    }
+
+    var has_supported_payload = false;
+    for (parsed.value.artifacts) |artifact| {
+        if (!managedArtifactPathIsSafe(artifact.path)) return .incomplete;
+        const artifact_path = std.fs.path.join(
+            allocator,
+            &.{ dest_dir, artifact.path },
+        ) catch return .incomplete;
+        defer allocator.free(artifact_path);
+        const actual_size = requiredFileSize(cwd, io, artifact_path) catch
+            return .incomplete;
+        if (actual_size != artifact.size) return .incomplete;
+        if (std.mem.endsWith(u8, artifact.path, ".gguf") or
+            std.mem.endsWith(u8, artifact.path, ".onnx") or
+            std.mem.endsWith(u8, artifact.path, ".safetensors"))
+        {
+            has_supported_payload = true;
+        }
+    }
+    if (!has_supported_payload) return .incomplete;
+    if (managedPublicationFilesBlocked(cwd, io, in_progress_path, plan_path)) {
+        return .incomplete;
+    }
+    return .complete;
+}
+
+fn managedPublicationFilesBlocked(
+    cwd: std.Io.Dir,
+    io: std.Io,
+    in_progress_path: []const u8,
+    plan_path: []const u8,
+) bool {
+    if (cwd.access(io, in_progress_path, .{})) |_| return true else |err| switch (err) {
+        error.FileNotFound => {},
+        else => return true,
+    }
+    if (cwd.access(io, plan_path, .{})) |_| return true else |err| switch (err) {
+        error.FileNotFound => {},
+        else => return true,
+    }
+    return false;
+}
+
+pub fn managedDownloadPublicationBlocked(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    dest_dir: []const u8,
+) bool {
+    const in_progress_path = managedPath(
+        allocator,
+        dest_dir,
+        managed_download_in_progress_filename,
+    ) catch return true;
+    defer allocator.free(in_progress_path);
+    const plan_path = managedPath(
+        allocator,
+        dest_dir,
+        managed_download_plan_filename,
+    ) catch return true;
+    defer allocator.free(plan_path);
+    return managedPublicationFilesBlocked(
+        std.Io.Dir.cwd(),
+        io,
+        in_progress_path,
+        plan_path,
+    );
+}
+
 /// Download a model from HuggingFace Hub.
 pub fn downloadModel(
     allocator: std.mem.Allocator,
@@ -1068,6 +1372,10 @@ pub fn downloadModel(
     projector_selection: ProjectorSelection,
     progress: ProgressSink,
 ) !void {
+    if (config.max_artifact_bytes == 0 or config.max_model_bytes == 0) {
+        return error.InvalidDownloadSizeLimit;
+    }
+
     // Create destination directory (pure Zig, cross-platform)
     try std.Io.Dir.cwd().createDirPath(io, dest_dir);
 
@@ -1179,8 +1487,10 @@ pub fn downloadModel(
         return error.NoModelFilesFound;
     }
 
-    // Download each file
-    for (to_download.items, 0..) |file_meta, i| {
+    var resolved = std.ArrayListUnmanaged(ResolvedArtifact).empty;
+    defer resolved.deinit(allocator);
+    var known_model_bytes: u64 = 0;
+    for (to_download.items) |file_meta| {
         const filename = file_meta.name;
         const total_bytes = if (file_meta.size) |declared_size| blk: {
             if (shouldProbeLinkedPayloadSize(filename, declared_size)) {
@@ -1192,6 +1502,45 @@ pub fn downloadModel(
             }
             break :blk declared_size;
         } else (probeDownloadSize(allocator, io, owner, name, filename, config) catch null);
+        if (total_bytes) |total| {
+            if (total > config.max_artifact_bytes) {
+                return error.DownloadSizeLimitExceeded;
+            }
+            known_model_bytes = try addKnownModelBytes(
+                known_model_bytes,
+                total,
+                config.max_model_bytes,
+            );
+        }
+        try resolved.append(allocator, .{
+            .file = file_meta,
+            .total_bytes = total_bytes,
+        });
+    }
+
+    var receipts = std.ArrayListUnmanaged(ManagedArtifactReceipt).empty;
+    defer receipts.deinit(allocator);
+    var remaining_model_bytes = config.max_model_bytes;
+
+    // Download each file. Unknown-size artifacts receive the remaining model
+    // budget as their tighter streaming ceiling.
+    for (resolved.items, 0..) |artifact, i| {
+        const file_meta = artifact.file;
+        const filename = file_meta.name;
+        const total_bytes = artifact.total_bytes;
+        if (total_bytes) |total| {
+            if (total > remaining_model_bytes) return error.ModelSizeLimitExceeded;
+        }
+
+        var artifact_config = config;
+        artifact_config.max_artifact_bytes = @min(
+            config.max_artifact_bytes,
+            remaining_model_bytes,
+        );
+        if (artifact_config.max_artifact_bytes == 0) {
+            return error.ModelSizeLimitExceeded;
+        }
+
         const progress_total_bytes = existingFinalFileProgressSize(
             allocator,
             io,
@@ -1209,7 +1558,25 @@ pub fn downloadModel(
             }, progress.context);
         }
 
-        try downloadFile(allocator, io, owner, name, filename, dest_dir, config, progress, i, to_download.items.len, total_bytes, file_meta.sha256);
+        try downloadFile(allocator, io, owner, name, filename, dest_dir, artifact_config, progress, i, resolved.items.len, total_bytes, file_meta.sha256);
+
+        const dest_path = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ dest_dir, filename });
+        defer allocator.free(dest_path);
+        const artifact_size = try requiredFileSize(std.Io.Dir.cwd(), io, dest_path);
+        remaining_model_bytes = try consumeModelBudget(
+            remaining_model_bytes,
+            artifact_size,
+        );
+        // Registry.pull may rewrite model_manifest.json after this function
+        // returns, so it is deliberately excluded from the immutable artifact
+        // receipt finalized by the registry.
+        if (!std.mem.eql(u8, filename, "model_manifest.json")) {
+            try receipts.append(allocator, .{
+                .path = filename,
+                .size = artifact_size,
+                .sha256 = file_meta.sha256,
+            });
+        }
 
         if (progress.callback) |cb| {
             cb(.{
@@ -1223,6 +1590,16 @@ pub fn downloadModel(
     }
 
     try writeSyntheticMetadata(allocator, io, dest_dir, synthetic_metadata);
+
+    const receipt_json = try std.json.Stringify.valueAlloc(
+        allocator,
+        ManagedDownloadReceipt{ .artifacts = receipts.items },
+        .{},
+    );
+    defer allocator.free(receipt_json);
+    const plan_path = try managedPath(allocator, dest_dir, managed_download_plan_filename);
+    defer allocator.free(plan_path);
+    try writeFileAtomically(allocator, io, plan_path, receipt_json);
 }
 
 fn probeDownloadSize(
@@ -1260,11 +1637,29 @@ fn probeDownloadSize(
     });
     defer resp.deinit();
 
-    if (!resp.ok() and !resp.isRedirect()) return null;
-    if (resp.header("x-linked-size")) |value| {
+    return chooseProbedDownloadSize(
+        resp.ok(),
+        resp.isRedirect(),
+        resp.header("x-linked-size"),
+        resp.contentLength(),
+    );
+}
+
+fn chooseProbedDownloadSize(
+    response_ok: bool,
+    response_is_redirect: bool,
+    linked_size: ?[]const u8,
+    content_length: ?u64,
+) ?u64 {
+    if (!response_ok and !response_is_redirect) return null;
+    if (linked_size) |value| {
         return std.fmt.parseInt(u64, value, 10) catch null;
     }
-    return resp.contentLength();
+    // Content-Length on a redirect describes the redirect response, not the
+    // target artifact. Treat it as unknown unless the Hub supplies its
+    // explicit linked-object size.
+    if (!response_ok) return null;
+    return content_length;
 }
 
 fn shouldProbeLinkedPayloadSize(filename: []const u8, declared_size: u64) bool {
@@ -1430,9 +1825,21 @@ pub fn readModelFileAlloc(
         n_headers += 1;
     }
 
-    var resp = try client.get(url, .{
-        .headers = headers_buf[0..n_headers],
-        .follow_redirects = true,
+    const download_url = try resolveDownloadUrl(
+        allocator,
+        &client,
+        url,
+        headers_buf[0..n_headers],
+        headers_buf[0..2],
+    );
+    defer allocator.free(download_url);
+    const request_headers = if (sameHttpOrigin(url, download_url))
+        headers_buf[0..n_headers]
+    else
+        headers_buf[0..2];
+    var resp = try client.get(download_url, .{
+        .headers = request_headers,
+        .follow_redirects = false,
         .timeout_ms = 300_000,
     });
     defer resp.deinit();
@@ -1467,17 +1874,43 @@ fn resolveRedirectUrl(allocator: std.mem.Allocator, base_url: []const u8, locati
     return std.fmt.allocPrint(allocator, "{s}://{s}:{d}{s}{s}", .{ scheme, host, port, prefix, location });
 }
 
+fn sameHttpOrigin(left_url: []const u8, right_url: []const u8) bool {
+    const left = httpx.Uri.parse(left_url) catch return false;
+    const right = httpx.Uri.parse(right_url) catch return false;
+    const left_scheme = left.scheme orelse return false;
+    const right_scheme = right.scheme orelse return false;
+    const left_host = left.host orelse return false;
+    const right_host = right.host orelse return false;
+    return std.ascii.eqlIgnoreCase(left_scheme, right_scheme) and
+        std.ascii.eqlIgnoreCase(left_host, right_host) and
+        left.effectivePort() == right.effectivePort();
+}
+
+fn redirectDowngradesTransport(current_url: []const u8, next_url: []const u8) bool {
+    const current = httpx.Uri.parse(current_url) catch return true;
+    const next = httpx.Uri.parse(next_url) catch return true;
+    const current_scheme = current.scheme orelse return true;
+    const next_scheme = next.scheme orelse return true;
+    return std.ascii.eqlIgnoreCase(current_scheme, "https") and
+        !std.ascii.eqlIgnoreCase(next_scheme, "https");
+}
+
 fn resolveDownloadUrl(
     allocator: std.mem.Allocator,
     client: *httpx.Client,
     start_url: []const u8,
-    headers: []const [2][]const u8,
+    authenticated_headers: []const [2][]const u8,
+    anonymous_headers: []const [2][]const u8,
 ) ![]u8 {
     var current_url = try allocator.dupe(u8, start_url);
     errdefer allocator.free(current_url);
 
     var redirects: u32 = 0;
     while (true) {
+        const headers = if (sameHttpOrigin(start_url, current_url))
+            authenticated_headers
+        else
+            anonymous_headers;
         var resp = try client.request(.HEAD, current_url, .{
             .headers = headers,
             .follow_redirects = false,
@@ -1489,6 +1922,10 @@ fn resolveDownloadUrl(
 
         const location = resp.header("Location") orelse return error.InvalidResponse;
         const next_url = try resolveRedirectUrl(allocator, current_url, location);
+        if (redirectDowngradesTransport(current_url, next_url)) {
+            allocator.free(next_url);
+            return error.UnsafeRedirect;
+        }
         allocator.free(current_url);
         current_url = next_url;
         redirects += 1;
@@ -1517,6 +1954,45 @@ fn downloadClientConfig(max_response_size: usize) httpx.ClientConfig {
     };
 }
 
+const ParsedContentRange = struct {
+    start: u64,
+    end: u64,
+    total: u64,
+};
+
+fn parseContentRange(value: []const u8) ?ParsedContentRange {
+    const prefix = "bytes ";
+    if (!std.mem.startsWith(u8, value, prefix)) return null;
+    const range_and_total = value[prefix.len..];
+    const slash = std.mem.indexOfScalar(u8, range_and_total, '/') orelse return null;
+    const range = range_and_total[0..slash];
+    const total_text = range_and_total[slash + 1 ..];
+    if (std.mem.eql(u8, total_text, "*")) return null;
+    const dash = std.mem.indexOfScalar(u8, range, '-') orelse return null;
+    const start = std.fmt.parseInt(u64, range[0..dash], 10) catch return null;
+    const end = std.fmt.parseInt(u64, range[dash + 1 ..], 10) catch return null;
+    const total = std.fmt.parseInt(u64, total_text, 10) catch return null;
+    if (end < start or total == 0 or end >= total) return null;
+    return .{ .start = start, .end = end, .total = total };
+}
+
+fn contentRangeMatches(
+    value: ?[]const u8,
+    expected_start: u64,
+    final_offset: u64,
+    expected_total: ?u64,
+) bool {
+    const parsed = parseContentRange(value orelse return false) orelse return false;
+    if (parsed.start != expected_start) return false;
+    if (final_offset == 0 or parsed.end != final_offset - 1) return false;
+    if (expected_total) |total| {
+        if (parsed.total != total) return false;
+    }
+    // The client asks for an open-ended range (`bytes=N-`), so a valid
+    // response must reach the representation's declared end.
+    return final_offset == parsed.total;
+}
+
 /// Download a single file from HuggingFace Hub.
 fn downloadFile(
     allocator: std.mem.Allocator,
@@ -1540,7 +2016,7 @@ fn downloadFile(
     var dest = std.Io.Dir.cwd();
     const dest_path = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ dest_dir, filename });
     defer allocator.free(dest_path);
-    if (try existingFinalFileSatisfies(dest, io, dest_path, filename, total_bytes, expected_sha256)) {
+    if (try existingFinalFileSatisfies(dest, io, dest_path, expected_sha256)) {
         return;
     }
 
@@ -1580,6 +2056,14 @@ fn downloadFile(
         dest.deleteFile(io, temp_path) catch {};
         return error.DownloadSizeLimitExceeded;
     }
+    // Without a stable content digest, a partial cannot be proven to belong
+    // to the current revision—even when its size happens to equal the
+    // advertised size. Small non-LFS sidecars are restarted instead of
+    // risking a mixed-version artifact.
+    if (resume_from > 0 and expected_sha256 == null) {
+        dest.deleteFile(io, temp_path) catch {};
+        resume_from = 0;
+    }
     if (total_bytes) |total| {
         if (resume_from == total) {
             try finalizeDownloadedFile(dest, io, temp_path, dest_path, expected_sha256);
@@ -1598,7 +2082,13 @@ fn downloadFile(
     );
     defer client.deinit();
 
-    const download_url = try resolveDownloadUrl(allocator, &client, url, headers_buf[0..n_headers]);
+    const download_url = try resolveDownloadUrl(
+        allocator,
+        &client,
+        url,
+        headers_buf[0..n_headers],
+        headers_buf[0..2],
+    );
     defer allocator.free(download_url);
 
     while (true) {
@@ -1612,8 +2102,10 @@ fn downloadFile(
         headers_buf[n_headers] = .{ "Accept-Encoding", "identity" };
         n_headers += 1;
         if (auth_header) |auth| {
-            headers_buf[n_headers] = .{ "Authorization", auth };
-            n_headers += 1;
+            if (sameHttpOrigin(url, download_url)) {
+                headers_buf[n_headers] = .{ "Authorization", auth };
+                n_headers += 1;
+            }
         }
         if (resume_from > 0) {
             range_header = try std.fmt.allocPrint(allocator, "bytes={d}-", .{resume_from});
@@ -1622,7 +2114,6 @@ fn downloadFile(
         }
 
         var file = try dest.createFile(io, temp_path, .{ .truncate = resume_from == 0 });
-        defer file.close(io);
 
         var resume_writer = OffsetFileWriter{
             .file = file,
@@ -1657,33 +2148,63 @@ fn downloadFile(
             .headers = headers_buf[0..n_headers],
             .follow_redirects = false,
         }, &resume_writer, FileProgressCtx.onWriterProgress, &progress_ctx) catch |err| {
+            file.close(io);
             // A server that ignores Range can send a complete response after
             // the existing prefix, making the temporary file exceed the
             // artifact limit before its HTTP 200 status is available here.
             // Retry once without the stale prefix; a genuinely oversized
             // response will then fail at the same finite limit.
-            if (err == error.DownloadSizeLimitExceeded and resume_from > 0) {
+            if (err == error.DownloadSizeLimitExceeded or err == error.ResponseTooLarge) {
                 dest.deleteFile(io, temp_path) catch {};
-                resume_from = 0;
-                continue;
+                if (resume_from > 0) {
+                    resume_from = 0;
+                    continue;
+                }
             }
             return err;
         };
-        defer streamed.deinit();
 
         if (!streamed.ok()) {
             std.debug.print("download failed for {s}: HTTP {d}\n", .{ filename, streamed.status.code });
+            streamed.deinit();
+            file.close(io);
+            // The streaming client may already have written the error body.
+            // Never preserve it as a resumable artifact prefix.
+            dest.deleteFile(io, temp_path) catch {};
+            if (resume_from > 0) {
+                resume_from = 0;
+                continue;
+            }
             return error.DownloadFailed;
         }
 
         if (resume_from > 0 and streamed.status.code != 206) {
+            streamed.deinit();
+            file.close(io);
             dest.deleteFile(io, temp_path) catch {};
             resume_from = 0;
             continue;
         }
+        if (streamed.status.code == 206 and !contentRangeMatches(
+            streamed.header("Content-Range"),
+            resume_from,
+            resume_writer.offset,
+            total_bytes,
+        )) {
+            streamed.deinit();
+            file.close(io);
+            dest.deleteFile(io, temp_path) catch {};
+            if (resume_from > 0) {
+                resume_from = 0;
+                continue;
+            }
+            return error.InvalidContentRange;
+        }
 
         if (total_bytes) |total| {
             if (resume_writer.offset != total) {
+                streamed.deinit();
+                file.close(io);
                 if (resume_writer.offset > total) {
                     dest.deleteFile(io, temp_path) catch {};
                 }
@@ -1691,6 +2212,8 @@ fn downloadFile(
             }
         }
 
+        streamed.deinit();
+        file.close(io);
         break;
     }
 
@@ -1710,22 +2233,24 @@ fn finalizeDownloadedFile(
             return err;
         };
     }
-    dest.deleteFile(io, dest_path) catch |err| switch (err) {
-        error.FileNotFound => {},
-        else => return err,
-    };
+    {
+        var file = try dest.openFile(io, temp_path, .{ .mode = .read_write });
+        defer file.close(io);
+        try file.sync(io);
+    }
+    // Dir.rename replaces an existing destination atomically. Do not unlink a
+    // known-good model first: a failed rename must leave it intact.
     try std.Io.Dir.rename(dest, temp_path, dest, dest_path, io);
+    try syncManagedDirectory(io, std.fs.path.dirname(dest_path) orelse ".");
 }
 
 fn existingFinalFileSatisfies(
     dir: std.Io.Dir,
     io: std.Io,
     path: []const u8,
-    filename: []const u8,
-    total_bytes: ?u64,
     expected_sha256: ?[]const u8,
 ) !bool {
-    const size = existingFileSize(dir, io, path) catch |err| switch (err) {
+    dir.access(io, path, .{}) catch |err| switch (err) {
         error.FileNotFound => return false,
         else => return err,
     };
@@ -1733,10 +2258,9 @@ fn existingFinalFileSatisfies(
         verifyFileSha256(dir, io, path, sum) catch return false;
         return true;
     }
-    if (total_bytes) |total| {
-        if (size == total) return true;
-        if (shouldProbeLinkedPayloadSize(filename, total) and size > total) return true;
-    }
+    // A size match alone is not an identity check. Re-fetch artifacts without
+    // a repository digest so repeated pulls cannot silently retain stale
+    // same-size metadata from a newer Hub revision.
     return false;
 }
 
@@ -1748,6 +2272,12 @@ fn existingFileSize(dir: std.Io.Dir, io: std.Io, path: []const u8) !u64 {
     defer file.close(io);
     const stat = try file.stat(io);
     return stat.size;
+}
+
+fn requiredFileSize(dir: std.Io.Dir, io: std.Io, path: []const u8) !u64 {
+    var file = try dir.openFile(io, path, .{});
+    defer file.close(io);
+    return (try file.stat(io)).size;
 }
 
 fn verifyFileSha256(dir: std.Io.Dir, io: std.Io, path: []const u8, expected_hex: []const u8) !void {
@@ -2230,6 +2760,24 @@ const python_download_server_script =
     "            self.end_headers()\n" ++
     "            self.wfile.write(body)\n" ++
     "            return\n" ++
+    "        if mode == 'range-error' and rng and rng.startswith('bytes='):\n" ++
+    "            body = b'range rejected'\n" ++
+    "            self.send_response(416)\n" ++
+    "            self.send_header('Content-Length', str(len(body)))\n" ++
+    "            self.send_header('Connection', 'close')\n" ++
+    "            self.end_headers()\n" ++
+    "            self.wfile.write(body)\n" ++
+    "            return\n" ++
+    "        if mode == 'wrong-range' and rng and rng.startswith('bytes='):\n" ++
+    "            start = int(rng[6:].split('-', 1)[0])\n" ++
+    "            body = payload[start:]\n" ++
+    "            self.send_response(206)\n" ++
+    "            self.send_header('Content-Length', str(len(body)))\n" ++
+    "            self.send_header('Content-Range', f'bytes 0-{len(body)-1}/{len(payload)}')\n" ++
+    "            self.send_header('Connection', 'close')\n" ++
+    "            self.end_headers()\n" ++
+    "            self.wfile.write(body)\n" ++
+    "            return\n" ++
     "        self.send_response(200)\n" ++
     "        self.send_header('Content-Length', str(len(payload)))\n" ++
     "        self.send_header('Connection', 'close')\n" ++
@@ -2270,6 +2818,138 @@ test "streaming model downloads use a finite disk-oriented response limit" {
         error.InvalidDownloadSizeLimit,
         downloadResponseLimit(.{ .max_artifact_bytes = std.math.maxInt(u64) }),
     );
+}
+
+test "aggregate model budget uses checked arithmetic" {
+    try std.testing.expectEqual(
+        @as(u64, 7),
+        try addKnownModelBytes(3, 4, 7),
+    );
+    try std.testing.expectError(
+        error.ModelSizeLimitExceeded,
+        addKnownModelBytes(3, 5, 7),
+    );
+    try std.testing.expectError(
+        error.ModelSizeLimitExceeded,
+        addKnownModelBytes(std.math.maxInt(u64), 1, std.math.maxInt(u64)),
+    );
+    try std.testing.expectEqual(@as(u64, 3), try consumeModelBudget(7, 4));
+    try std.testing.expectError(
+        error.ModelSizeLimitExceeded,
+        consumeModelBudget(7, 8),
+    );
+}
+
+test "managed download publication keeps incomplete state fail closed" {
+    const allocator = std.testing.allocator;
+    const io = std.testing.io;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const dest_dir = try testTmpPath(allocator, tmp, "managed");
+    defer allocator.free(dest_dir);
+    try std.Io.Dir.cwd().createDirPath(io, dest_dir);
+    const complete_path = try managedPath(allocator, dest_dir, managed_download_complete_filename);
+    defer allocator.free(complete_path);
+    try std.Io.Dir.cwd().writeFile(io, .{ .sub_path = complete_path, .data = "old" });
+
+    try beginManagedDownload(allocator, io, dest_dir);
+    try std.testing.expectEqual(
+        ManagedDownloadState.incomplete,
+        managedDownloadState(allocator, io, dest_dir),
+    );
+    const in_progress_path = try managedPath(allocator, dest_dir, managed_download_in_progress_filename);
+    defer allocator.free(in_progress_path);
+    try std.Io.Dir.cwd().access(io, in_progress_path, .{});
+    try std.testing.expectError(
+        error.FileNotFound,
+        std.Io.Dir.cwd().openFile(io, complete_path, .{}),
+    );
+
+    const plan_path = try managedPath(allocator, dest_dir, managed_download_plan_filename);
+    defer allocator.free(plan_path);
+    const artifact_path = try std.fs.path.join(allocator, &.{ dest_dir, "model.onnx" });
+    defer allocator.free(artifact_path);
+    try std.Io.Dir.cwd().writeFile(io, .{ .sub_path = artifact_path, .data = "payload" });
+    try writeFileAtomically(
+        allocator,
+        io,
+        plan_path,
+        "{\"version\":1,\"artifacts\":[{\"path\":\"model.onnx\",\"size\":7}]}",
+    );
+    try completeManagedDownload(allocator, io, dest_dir);
+    try std.testing.expectEqual(
+        ManagedDownloadState.complete,
+        managedDownloadState(allocator, io, dest_dir),
+    );
+    try std.Io.Dir.cwd().access(io, complete_path, .{});
+    try std.testing.expectError(
+        error.FileNotFound,
+        std.Io.Dir.cwd().openFile(io, in_progress_path, .{}),
+    );
+
+    try std.Io.Dir.cwd().writeFile(io, .{
+        .sub_path = complete_path,
+        .data = "{\"version\":1,\"artifacts\":[{\"path\":\"config.json\",\"size\":2}]}",
+    });
+    const config_path = try std.fs.path.join(allocator, &.{ dest_dir, "config.json" });
+    defer allocator.free(config_path);
+    try std.Io.Dir.cwd().writeFile(io, .{ .sub_path = config_path, .data = "{}" });
+    try std.testing.expectEqual(
+        ManagedDownloadState.incomplete,
+        managedDownloadState(allocator, io, dest_dir),
+    );
+}
+
+test "content range validation requires exact resume boundaries" {
+    try std.testing.expect(contentRangeMatches("bytes 6-18/19", 6, 19, 19));
+    try std.testing.expect(!contentRangeMatches("bytes 0-12/19", 6, 19, 19));
+    try std.testing.expect(!contentRangeMatches("bytes 6-17/19", 6, 19, 19));
+    try std.testing.expect(!contentRangeMatches("bytes 6-18/20", 6, 19, 19));
+    try std.testing.expect(!contentRangeMatches("bytes 6-17/19", 6, 18, null));
+    try std.testing.expect(!contentRangeMatches(null, 6, 19, 19));
+}
+
+test "download size probe ignores redirect response body length" {
+    try std.testing.expectEqual(
+        @as(?u64, 4096),
+        chooseProbedDownloadSize(false, true, "4096", 128),
+    );
+    try std.testing.expectEqual(
+        @as(?u64, null),
+        chooseProbedDownloadSize(false, true, null, 128),
+    );
+    try std.testing.expectEqual(
+        @as(?u64, 4096),
+        chooseProbedDownloadSize(true, false, null, 4096),
+    );
+    try std.testing.expectEqual(
+        @as(?u64, null),
+        chooseProbedDownloadSize(false, false, "4096", 128),
+    );
+}
+
+test "redirect origin policy protects authorization and transport" {
+    try std.testing.expect(sameHttpOrigin(
+        "https://huggingface.co/owner/model",
+        "https://HUGGINGFACE.CO:443/redirected",
+    ));
+    try std.testing.expect(!sameHttpOrigin(
+        "https://huggingface.co/owner/model",
+        "https://cdn.example/model",
+    ));
+    try std.testing.expect(!sameHttpOrigin(
+        "https://huggingface.co/owner/model",
+        "https://huggingface.co:8443/model",
+    ));
+    try std.testing.expect(redirectDowngradesTransport(
+        "https://huggingface.co/owner/model",
+        "http://huggingface.co/model",
+    ));
+    try std.testing.expect(!redirectDowngradesTransport(
+        "http://127.0.0.1:8080/model",
+        "http://127.0.0.1:8081/model",
+    ));
 }
 
 test "downloadFile rejects artifacts above the configured disk limit before network access" {
@@ -2335,6 +3015,64 @@ test "downloadFile removes an oversized partial before network access" {
     );
 }
 
+test "downloadFile removes a fresh partial after streamed size overflow" {
+    const allocator = std.testing.allocator;
+    const io = std.testing.io;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.writeFile(io, .{ .sub_path = "payload.bin", .data = "oversized payload" });
+    try tmp.dir.writeFile(io, .{ .sub_path = "server.py", .data = python_download_server_script });
+    try tmp.dir.writeFile(io, .{ .sub_path = "requests.log", .data = "" });
+
+    const port = try reserveEphemeralPort(io);
+    var port_buf: [16]u8 = undefined;
+    const port_arg = try std.fmt.bufPrint(&port_buf, "{d}", .{port});
+    var child = try std.process.spawn(io, .{
+        .argv = &.{ "python3", "server.py", port_arg, "ignore", "payload.bin", "requests.log" },
+        .cwd = .{ .dir = tmp.dir },
+        .stdin = .ignore,
+        .stdout = .inherit,
+        .stderr = .inherit,
+    });
+    defer child.kill(io);
+    io.sleep(std.Io.Duration.fromMilliseconds(200), .awake) catch {};
+
+    const dest_dir = try testTmpPath(allocator, tmp, "downloads");
+    defer allocator.free(dest_dir);
+    try std.Io.Dir.cwd().createDirPath(io, dest_dir);
+    const base_url = try std.fmt.allocPrint(allocator, "http://127.0.0.1:{d}", .{port});
+    defer allocator.free(base_url);
+
+    try std.testing.expectError(
+        error.DownloadSizeLimitExceeded,
+        downloadFile(
+            allocator,
+            io,
+            "owner",
+            "name",
+            "model.onnx",
+            dest_dir,
+            .{
+                .base_url = base_url,
+                .max_artifact_bytes = 4,
+            },
+            .{},
+            0,
+            1,
+            null,
+            null,
+        ),
+    );
+    const part_path = try std.fs.path.join(allocator, &.{ dest_dir, "model.onnx.part" });
+    defer allocator.free(part_path);
+    try std.testing.expectError(
+        error.FileNotFound,
+        std.Io.Dir.cwd().openFile(io, part_path, .{}),
+    );
+}
+
 test "downloadFile verifies a complete partial before installing it" {
     const allocator = std.testing.allocator;
     const io = std.testing.io;
@@ -2348,6 +3086,9 @@ test "downloadFile verifies a complete partial before installing it" {
     const part_path = try std.fs.path.join(allocator, &.{ dest_dir, "model.onnx.part" });
     defer allocator.free(part_path);
     try std.Io.Dir.cwd().writeFile(io, .{ .sub_path = part_path, .data = "bad" });
+    const final_path = try std.fs.path.join(allocator, &.{ dest_dir, "model.onnx" });
+    defer allocator.free(final_path);
+    try std.Io.Dir.cwd().writeFile(io, .{ .sub_path = final_path, .data = "known-good" });
 
     try std.testing.expectError(
         error.ChecksumMismatch,
@@ -2370,6 +3111,11 @@ test "downloadFile verifies a complete partial before installing it" {
         error.FileNotFound,
         std.Io.Dir.cwd().openFile(io, part_path, .{}),
     );
+    var final_file = try std.Io.Dir.cwd().openFile(io, final_path, .{});
+    defer final_file.close(io);
+    var final_buf: [16]u8 = undefined;
+    const final_len = try final_file.readStreaming(io, &.{final_buf[0..]});
+    try std.testing.expectEqualStrings("known-good", final_buf[0..final_len]);
 }
 
 test "offset file writer enforces the final artifact size across resumed writes" {
@@ -2430,7 +3176,7 @@ test "downloadFile resumes from partial file with 206 response" {
     defer allocator.free(base_url);
     try downloadFile(allocator, io, "owner", "name", "tokenizer.json", dest_dir, .{
         .base_url = base_url,
-    }, .{}, 0, 1, payload.len, null);
+    }, .{}, 0, 1, payload.len, "f6b6d844d9e70a622a4b1f2eab9cd77aa2b09280930adc897fad746fdf2c6a1c");
 
     const final_path = try std.fs.path.join(allocator, &.{ dest_dir, "tokenizer.json" });
     defer allocator.free(final_path);
@@ -2447,6 +3193,113 @@ test "downloadFile resumes from partial file with 206 response" {
     var log_buf: [128]u8 = undefined;
     const log_n = try log_file.readStreaming(io, &.{log_buf[0..]});
     try std.testing.expect(std.mem.indexOf(u8, log_buf[0..log_n], "bytes=6-") != null);
+}
+
+test "downloadFile restarts when a 206 content range is inconsistent" {
+    const allocator = std.testing.allocator;
+    const io = std.testing.io;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const payload = "hello resumed world";
+    try tmp.dir.writeFile(io, .{ .sub_path = "payload.bin", .data = payload });
+    try tmp.dir.writeFile(io, .{ .sub_path = "server.py", .data = python_download_server_script });
+    try tmp.dir.writeFile(io, .{ .sub_path = "requests.log", .data = "" });
+
+    const port = try reserveEphemeralPort(io);
+    var port_buf: [16]u8 = undefined;
+    const port_arg = try std.fmt.bufPrint(&port_buf, "{d}", .{port});
+
+    var child = std.process.spawn(io, .{
+        .argv = &.{ "python3", "server.py", port_arg, "wrong-range", "payload.bin", "requests.log" },
+        .cwd = .{ .dir = tmp.dir },
+        .stdin = .ignore,
+        .stdout = .inherit,
+        .stderr = .inherit,
+    }) catch |err| switch (err) {
+        error.FileNotFound => return,
+        else => return err,
+    };
+    defer child.kill(io);
+    io.sleep(std.Io.Duration.fromMilliseconds(200), .awake) catch {};
+
+    const dest_dir = try testTmpPath(allocator, tmp, "downloads");
+    defer allocator.free(dest_dir);
+    try std.Io.Dir.cwd().createDirPath(io, dest_dir);
+    const partial_path = try std.fs.path.join(allocator, &.{ dest_dir, "tokenizer.json.part" });
+    defer allocator.free(partial_path);
+    try std.Io.Dir.cwd().writeFile(io, .{ .sub_path = partial_path, .data = payload[0..6] });
+
+    const base_url = try std.fmt.allocPrint(allocator, "http://127.0.0.1:{d}", .{port});
+    defer allocator.free(base_url);
+    try downloadFile(allocator, io, "owner", "name", "tokenizer.json", dest_dir, .{
+        .base_url = base_url,
+    }, .{}, 0, 1, payload.len, "f6b6d844d9e70a622a4b1f2eab9cd77aa2b09280930adc897fad746fdf2c6a1c");
+
+    const final_path = try std.fs.path.join(allocator, &.{ dest_dir, "tokenizer.json" });
+    defer allocator.free(final_path);
+    var file = try std.Io.Dir.cwd().openFile(io, final_path, .{});
+    defer file.close(io);
+    var buf: [64]u8 = undefined;
+    const n = try file.readStreaming(io, &.{buf[0..]});
+    try std.testing.expectEqualStrings(payload, buf[0..n]);
+
+    const log_path = try testTmpPath(allocator, tmp, "requests.log");
+    defer allocator.free(log_path);
+    var log_file = try std.Io.Dir.cwd().openFile(io, log_path, .{});
+    defer log_file.close(io);
+    var log_buf: [128]u8 = undefined;
+    const log_n = try log_file.readStreaming(io, &.{log_buf[0..]});
+    try std.testing.expect(std.mem.indexOf(u8, log_buf[0..log_n], "bytes=6-") != null);
+    try std.testing.expect(std.mem.endsWith(u8, log_buf[0..log_n], "-\n"));
+}
+
+test "downloadFile discards a streamed range error before retrying fresh" {
+    const allocator = std.testing.allocator;
+    const io = std.testing.io;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const payload = "hello resumed world";
+    try tmp.dir.writeFile(io, .{ .sub_path = "payload.bin", .data = payload });
+    try tmp.dir.writeFile(io, .{ .sub_path = "server.py", .data = python_download_server_script });
+    try tmp.dir.writeFile(io, .{ .sub_path = "requests.log", .data = "" });
+
+    const port = try reserveEphemeralPort(io);
+    var port_buf: [16]u8 = undefined;
+    const port_arg = try std.fmt.bufPrint(&port_buf, "{d}", .{port});
+    var child = try std.process.spawn(io, .{
+        .argv = &.{ "python3", "server.py", port_arg, "range-error", "payload.bin", "requests.log" },
+        .cwd = .{ .dir = tmp.dir },
+        .stdin = .ignore,
+        .stdout = .inherit,
+        .stderr = .inherit,
+    });
+    defer child.kill(io);
+    io.sleep(std.Io.Duration.fromMilliseconds(200), .awake) catch {};
+
+    const dest_dir = try testTmpPath(allocator, tmp, "downloads");
+    defer allocator.free(dest_dir);
+    try std.Io.Dir.cwd().createDirPath(io, dest_dir);
+    const partial_path = try std.fs.path.join(allocator, &.{ dest_dir, "tokenizer.json.part" });
+    defer allocator.free(partial_path);
+    try std.Io.Dir.cwd().writeFile(io, .{ .sub_path = partial_path, .data = payload[0..6] });
+
+    const base_url = try std.fmt.allocPrint(allocator, "http://127.0.0.1:{d}", .{port});
+    defer allocator.free(base_url);
+    try downloadFile(allocator, io, "owner", "name", "tokenizer.json", dest_dir, .{
+        .base_url = base_url,
+    }, .{}, 0, 1, payload.len, "f6b6d844d9e70a622a4b1f2eab9cd77aa2b09280930adc897fad746fdf2c6a1c");
+
+    const final_path = try std.fs.path.join(allocator, &.{ dest_dir, "tokenizer.json" });
+    defer allocator.free(final_path);
+    var file = try std.Io.Dir.cwd().openFile(io, final_path, .{});
+    defer file.close(io);
+    var buf: [64]u8 = undefined;
+    const n = try file.readStreaming(io, &.{buf[0..]});
+    try std.testing.expectEqualStrings(payload, buf[0..n]);
 }
 
 test "downloadFile skips existing complete destination before network" {
@@ -2466,7 +3319,7 @@ test "downloadFile skips existing complete destination before network" {
 
     try downloadFile(allocator, io, "owner", "name", "model.gguf", dest_dir, .{
         .base_url = "http://127.0.0.1:1",
-    }, .{}, 0, 1, payload.len, null);
+    }, .{}, 0, 1, payload.len, "5d4601650452897026e60f1d6996d5b2941f3e3634ffebe6cc11458508c756f2");
 
     const part_path = try std.fs.path.join(allocator, &.{ dest_dir, "model.gguf.part" });
     defer allocator.free(part_path);
@@ -2496,7 +3349,7 @@ test "downloadFile skips existing large artifact with pointer-sized metadata" {
 
     try downloadFile(allocator, io, "owner", "name", "model.gguf", dest_dir, .{
         .base_url = "http://127.0.0.1:1",
-    }, .{}, 0, 1, 102, null);
+    }, .{}, 0, 1, 102, "8fc662ff2c1d2293998c59eff63476a828c715345d33d0219a1260be634422d1");
 
     const part_path = try std.fs.path.join(allocator, &.{ dest_dir, "model.gguf.part" });
     defer allocator.free(part_path);
@@ -2583,7 +3436,7 @@ test "downloadFile restarts cleanly when range is ignored" {
         // Force the bounded writer to detect the ignored Range response before
         // getToWriter can return its HTTP 200 status.
         .max_artifact_bytes = payload.len,
-    }, .{}, 0, 1, payload.len, null);
+    }, .{}, 0, 1, payload.len, "b237163979797d22f20311e364eb817ae436427249a000f222051f65b6fcadc9");
 
     const final_path = try std.fs.path.join(allocator, &.{ dest_dir, "tokenizer.json" });
     defer allocator.free(final_path);

--- a/zig/pkg/inference/src/registry/download.zig
+++ b/zig/pkg/inference/src/registry/download.zig
@@ -1144,10 +1144,14 @@ fn syncManagedDirectory(io: std.Io, path: []const u8) !void {
     {
         return;
     }
+    // On Linux, a non-iterable std.Io.Dir is opened with O_PATH. fsync(2)
+    // rejects O_PATH descriptors with EBADF, so request a regular O_RDONLY
+    // directory descriptor even though no iteration is performed.
+    const open_options: std.Io.Dir.OpenOptions = .{ .iterate = true };
     var dir = if (std.fs.path.isAbsolute(path))
-        try std.Io.Dir.openDirAbsolute(io, path, .{})
+        try std.Io.Dir.openDirAbsolute(io, path, open_options)
     else
-        try std.Io.Dir.cwd().openDir(io, path, .{});
+        try std.Io.Dir.cwd().openDir(io, path, open_options);
     defer dir.close(io);
     while (true) switch (std.posix.errno(std.posix.system.fsync(dir.handle))) {
         .SUCCESS => return,

--- a/zig/pkg/inference/src/registry/registry.zig
+++ b/zig/pkg/inference/src/registry/registry.zig
@@ -226,7 +226,7 @@ pub const ModelRegistry = struct {
         self: *ModelRegistry,
         io: std.Io,
         ref_str: []const u8,
-        token: ?[]const u8,
+        hub_config: download.HubConfig,
         tasks_csv: ?[]const u8,
         capabilities_csv: ?[]const u8,
         projector_selection: download.ProjectorSelection,
@@ -238,15 +238,25 @@ pub const ModelRegistry = struct {
         // Destination: models_dir/owner/name
         const dest = try std.fmt.allocPrint(self.allocator, "{s}/{s}/{s}", .{ resolved_models_dir, ref.owner, ref.name });
         defer self.allocator.free(dest);
+        try std.Io.Dir.cwd().createDirPath(io, dest);
+
+        const lock_path = try std.fs.path.join(self.allocator, &.{ dest, download.managed_download_lock_filename });
+        defer self.allocator.free(lock_path);
+        var download_lock = try std.Io.Dir.cwd().createFile(io, lock_path, .{
+            .truncate = false,
+            .lock = .exclusive,
+        });
+        defer download_lock.close(io);
+
+        try download.beginManagedDownload(self.allocator, io, dest);
 
         var progress = ProgressPrinter{};
-        try download.downloadModel(self.allocator, io, ref.owner, ref.name, ref.variant, dest, .{
-            .token = token,
-        }, projector_selection, .{
+        try download.downloadModel(self.allocator, io, ref.owner, ref.name, ref.variant, dest, hub_config, projector_selection, .{
             .callback = ProgressPrinter.onProgress,
             .context = &progress,
         });
         try self.writePulledModelManifest(io, dest, tasks_csv, capabilities_csv);
+        try download.completeManagedDownload(self.allocator, io, dest);
     }
 
     fn appendDiscoveredModel(
@@ -864,27 +874,36 @@ fn synthesizePulledModelManifestJson(
 /// A model dir contains config.json, tokenizer.json, genai_config.json, a GGUF file, or an onnx/ subdir.
 fn isModelDir(io: Io, path: []const u8) bool {
     const allocator = if (build_options.link_libc) std.heap.c_allocator else std.heap.smp_allocator;
+    if (download.managedDownloadState(allocator, io, path) == .incomplete) {
+        return false;
+    }
+    const publicationStable = struct {
+        fn check(alloc: std.mem.Allocator, check_io: Io, model_path: []const u8) bool {
+            return !download.managedDownloadPublicationBlocked(alloc, check_io, model_path);
+        }
+    }.check;
     const indicators = [_][]const u8{ "config.json", "tokenizer.json", "genai_config.json", "antfly_metadata.json" };
     for (indicators) |filename| {
         const file_path = std.fs.path.join(allocator, &.{ path, filename }) catch continue;
         defer allocator.free(file_path);
         var f = Dir.cwd().openFile(io, file_path, .{}) catch continue;
         f.close(io);
-        return true;
+        return publicationStable(allocator, io, path);
     }
     // Check for top-level .gguf file
     var dir = Dir.cwd().openDir(io, path, .{ .iterate = true }) catch return false;
     defer dir.close(io);
     var iter = dir.iterate();
     while (iter.next(io) catch null) |entry| {
-        if (entry.kind == .file and std.mem.endsWith(u8, entry.name, ".gguf")) return true;
+        if (entry.kind == .file and std.mem.endsWith(u8, entry.name, ".gguf"))
+            return publicationStable(allocator, io, path);
     }
     // Check for onnx/ subdirectory
     const onnx_path = std.fs.path.join(allocator, &.{ path, "onnx" }) catch return false;
     defer allocator.free(onnx_path);
     var onnx_dir = Dir.cwd().openDir(io, onnx_path, .{}) catch return false;
     onnx_dir.close(io);
-    return true;
+    return publicationStable(allocator, io, path);
 }
 
 test "parse model ref" {
@@ -959,6 +978,45 @@ test "discover skips empty owner subdirectories and keeps multistage readers" {
 
     try std.testing.expectEqual(@as(usize, 1), models.len);
     try std.testing.expectEqualStrings("monkt/paddleocr-onnx", models[0].name);
+}
+
+test "model discovery rejects incomplete or invalid managed downloads" {
+    const allocator = std.testing.allocator;
+    const io = std.testing.io;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.createDirPath(io, "models/owner/model");
+    try tmp.dir.writeFile(io, .{
+        .sub_path = "models/owner/model/config.json",
+        .data = "{}",
+    });
+    try tmp.dir.writeFile(io, .{
+        .sub_path = "models/owner/model/.antfly-download-in-progress",
+        .data = "{\"version\":1,\"state\":\"in_progress\"}",
+    });
+
+    const model_dir = try std.fs.path.join(
+        allocator,
+        &.{ ".zig-cache", "tmp", tmp.sub_path[0..], "models/owner/model" },
+    );
+    defer allocator.free(model_dir);
+    try std.testing.expect(!isModelDir(io, model_dir));
+
+    try tmp.dir.deleteFile(io, "models/owner/model/.antfly-download-in-progress");
+    try tmp.dir.writeFile(io, .{
+        .sub_path = "models/owner/model/model.onnx",
+        .data = "payload",
+    });
+    try tmp.dir.writeFile(io, .{
+        .sub_path = "models/owner/model/.antfly-download-complete.json",
+        .data = "{\"version\":1,\"artifacts\":[{\"path\":\"config.json\",\"size\":2},{\"path\":\"model.onnx\",\"size\":7}]}",
+    });
+    try std.testing.expect(isModelDir(io, model_dir));
+
+    try tmp.dir.deleteFile(io, "models/owner/model/model.onnx");
+    try std.testing.expect(!isModelDir(io, model_dir));
 }
 
 test "synthesized pulled manifest marks splade embedders as sparse" {


### PR DESCRIPTION
## Summary

- complete both durable split/merge retirement phases before asserting routed topology in metadata simulations, and record safe document-identity reassignment for approved cross-range merges
- publish pulled models transactionally with an exclusive pull lock, fail-closed in-progress state, synced atomic artifacts, and a validated completion receipt
- enforce configurable 64 GiB per-artifact and 128 GiB aggregate limits with checked arithmetic, exact range validation, digest-gated resume, bounded streaming, and atomic replacement
- prevent authorization forwarding across redirect origins and reject HTTPS downgrade redirects
- validate complete managed model caches in both native discovery and Python E2E helpers while retaining legacy externally provisioned model compatibility
- expose pull size limits in both inference CLIs
- make the native ARM64 codec shard a required dependency of stable zig-base and zig-full aggregate checks
- accept both non-routing draining and retiring states in the node-churn availability gate

## Validation

- zig build lib-metadata-logic-test -Dha-tests=false -j1 (220 passed)
- zig build lib-metadata-sim-forward-test -Dha-tests=false -j1 (3 passed)
- zig build lib-metadata-sim-public-test -Dha-tests=false -j1 (4 passed)
- focused inference downloader and native discovery suite (52 passed)
- inference model helper pytest (8 passed)
- exact autoscaling node-churn regression (1 passed)
- standalone inference zig build -j1
- full Antfly zig build -Dedition=full install -j1
- make zig-generated-check
- actionlint (existing SC2009/SC2086 informational findings ignored)
- zig fmt and git diff --check