### PR TITLE
Strip Zig production release artifacts

### DIFF
--- a/scripts/diagnose-zig-build-memory.sh
+++ b/scripts/diagnose-zig-build-memory.sh
@@ -15,6 +15,7 @@ Options:
   --prefix DIR           Zig install prefix. Default: /tmp/antfly-zig-build-memory-prefix
   --target TARGET        Zig target. Default: aarch64-linux-musl
   --optimize MODE        Zig optimize mode. Default: ReleaseFast
+  --strip true|false     Omit debug information. Default: false
   --install-step STEP    Build step. Default: install
   --jobs N               Zig build jobs. Default: 1
   --interval SEC         Sampling interval. Default: 1
@@ -40,6 +41,7 @@ out_dir="/tmp/antfly-zig-build-memory"
 prefix="/tmp/antfly-zig-build-memory-prefix"
 target="aarch64-linux-musl"
 optimize="ReleaseFast"
+strip="false"
 install_step="install"
 jobs="1"
 interval="1"
@@ -70,6 +72,10 @@ while [ "$#" -gt 0 ]; do
             ;;
         --optimize)
             optimize="$2"
+            shift 2
+            ;;
+        --strip)
+            strip="$2"
             shift 2
             ;;
         --install-step)
@@ -122,6 +128,14 @@ if [ ! -f "${zig_dir}/build.zig" ]; then
     exit 2
 fi
 
+case "${strip}" in
+    true|false) ;;
+    *)
+        echo "--strip must be true or false, got: ${strip}" >&2
+        exit 2
+        ;;
+esac
+
 mkdir -p "${out_dir}" "${prefix}"
 
 if [ -z "${label}" ]; then
@@ -141,11 +155,26 @@ rss_kb_for_pid() {
     ps -o rss= -p "$1" 2>/dev/null | awk '{print $1}'
 }
 
-find_build_exe_pids() {
-    ps -Ao pid=,comm=,args= | awk '
-        /zig build-exe/ {
-            pid=$1
-            print pid
+find_zig_compile_pids() {
+    local root_pid="$1"
+    ps -Ao pid=,ppid=,comm=,args= | awk -v root_pid="${root_pid}" '
+        {
+            parents[$1]=$2
+            if ($0 ~ /zig build-(exe|lib|obj)/) candidates[$1]=1
+        }
+        END {
+            for (pid in candidates) {
+                current=pid
+                delete seen
+                while (current in parents && !seen[current]) {
+                    if (current == root_pid) {
+                        print pid
+                        break
+                    }
+                    seen[current]=1
+                    current=parents[current]
+                }
+            }
         }
     '
 }
@@ -165,7 +194,7 @@ max_cmd=""
 
 (
     cd "${zig_dir}"
-    "${zig_bin}" build "-j${jobs}" "-Dtarget=${target}" "-Doptimize=${optimize}" "${install_step}" --prefix "${prefix}" "${extra_args[@]}"
+    "${zig_bin}" build "-j${jobs}" "-Dtarget=${target}" "-Doptimize=${optimize}" "-Dstrip=${strip}" "${install_step}" --prefix "${prefix}" "${extra_args[@]}"
 ) >"${build_log}" 2>&1 &
 build_pid="$!"
 
@@ -203,7 +232,7 @@ while kill -0 "${build_pid}" 2>/dev/null; do
                 sample "${pid}" "${sample_seconds}" -file "${sample_file}" >/dev/null 2>&1 || true
             fi
         fi
-    done < <(find_build_exe_pids)
+    done < <(find_zig_compile_pids "${build_pid}")
 
     sleep "${interval}"
 done
@@ -224,6 +253,7 @@ max_rss_mb="$(rss_mb_from_kb "${max_rss_kb}")"
     echo "zig_dir=${zig_dir}"
     echo "target=${target}"
     echo "optimize=${optimize}"
+    echo "strip=${strip}"
     echo "install_step=${install_step}"
     echo "jobs=${jobs}"
     echo "max_rss_kb=${max_rss_kb}"

--- a/scripts/packaging/build_zig_release_archive.sh
+++ b/scripts/packaging/build_zig_release_archive.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 usage() {
   cat >&2 <<'EOF'
-usage: build_zig_release_archive.sh --version VERSION --target TARGET --archive-name NAME --out-dir DIR [--metal true|false] [--system-blas true|false] [--optimize MODE] [--jobs N]
+usage: build_zig_release_archive.sh --version VERSION --target TARGET --archive-name NAME --out-dir DIR [--metal true|false] [--system-blas true|false] [--optimize MODE] [--strip true|false] [--jobs N]
 
 Builds the native Antfly Zig runtime and writes a release archive whose root
 contains:
@@ -23,6 +23,7 @@ out_dir=
 metal=false
 system_blas=false
 optimize=ReleaseFast
+strip=true
 jobs=
 
 while [ "$#" -gt 0 ]; do
@@ -53,6 +54,10 @@ while [ "$#" -gt 0 ]; do
       ;;
     --optimize)
       optimize="${2:?missing --optimize value}"
+      shift 2
+      ;;
+    --strip)
+      strip="${2:?missing --strip value}"
       shift 2
       ;;
     --jobs)
@@ -87,6 +92,15 @@ case "$optimize" in
   *)
     usage
     echo "--optimize must be one of Debug, ReleaseSafe, ReleaseFast, ReleaseSmall; got: $optimize" >&2
+    exit 2
+    ;;
+esac
+
+case "$strip" in
+  true|false) ;;
+  *)
+    usage
+    echo "--strip must be true or false, got: $strip" >&2
     exit 2
     ;;
 esac
@@ -127,6 +141,7 @@ mkdir -p "$prefix" "$stage" "$local_cache" "$cache_root/global" "$out_dir"
 zig_build_options=(
   -Dtarget="$target"
   -Doptimize="$optimize"
+  -Dstrip="$strip"
   -Dcpu=baseline
   -Dedition=full
   -Dantfly-bin-name=antfly

--- a/zig/build.zig
+++ b/zig/build.zig
@@ -465,6 +465,16 @@ fn addLocalHttpxModule(
     });
 }
 
+fn setStripRecursively(module: *std.Build.Module, visited: *std.AutoHashMap(*std.Build.Module, void)) void {
+    const result = visited.getOrPut(module) catch @panic("OOM");
+    if (result.found_existing) return;
+
+    module.strip = true;
+    for (module.import_table.values()) |imported_module| {
+        setStripRecursively(imported_module, visited);
+    }
+}
+
 const AntflyRootImports = struct {
     build_options: *std.Build.Step.Options,
     lmdb_engine: *std.Build.Module,
@@ -1148,6 +1158,7 @@ pub fn build(b: *std.Build) void {
         .{};
     const target = b.standardTargetOptions(.{ .default_target = default_target });
     const optimize = b.standardOptimizeOption(.{});
+    const strip = b.option(bool, "strip", "Omit debug information from release artifacts") orelse false;
     const wasm_target = b.resolveTargetQuery(.{
         .cpu_arch = .wasm32,
         .os_tag = .freestanding,
@@ -8295,6 +8306,12 @@ pub fn build(b: *std.Build) void {
         .name = "antfly",
         .root_module = antfly_main_mod,
     });
+    if (strip) {
+        var visited = std.AutoHashMap(*std.Build.Module, void).init(b.allocator);
+        defer visited.deinit();
+        setStripRecursively(antfly_main_mod, &visited);
+        setStripRecursively(lite_capi_mod, &visited);
+    }
     const antfly_main_tests = b.addTest(.{
         .root_module = antfly_main_mod,
         .test_runner = .{


### PR DESCRIPTION
## Summary
- make release packaging strip Zig artifacts while keeping local builds debuggable by default
- apply stripping to the full imported module graph so LLVM omits debug generation rather than post-processing an already oversized binary
- extend the memory reproduction script with the strip mode and restrict sampling to compiler descendants of the measured build

## Root cause
The prior Linux x86 release executable was 265 MiB, included debug information, and was not stripped. Roughly 200 MiB consisted of DWARF/debug sections. On rc.24, LLVM failed while allocating a large final buffer even on the deployed 48 GiB runner.

## Validation
- fresh-cache Linux x86_64 ReleaseFast install with strip=true: success in 538s, peak RSS 4.82 GiB
- emitted antfly executable: 54 MiB, statically linked, stripped, no debug/symbol-table sections
- fresh-cache Linux x86_64 ReleaseFast lite-capi with strip=true: success in 192s, peak RSS 1.71 GiB
- emitted libantfly.so: 18 MiB, stripped, no debug/symbol-table sections
- zig fmt --check zig/build.zig
- bash -n on both modified scripts
- zig build -Dstrip=true --help

Infra companion: antflydb/colony#418 raises the serialized x86 publish runner from 24,000 MiB to 48,000 MiB and is already deployed.