### PR TITLE
Use ReleaseFast for ARM64 release archives

### DIFF
--- a/.github/workflows/antfly-release.yml
+++ b/.github/workflows/antfly-release.yml
@@ -43,8 +43,8 @@ jobs:
             archive_arch: arm64
             metal: "false"
             system_blas: "false"
-            zig_optimize: ReleaseSmall
-            zig_jobs: "1"
+            zig_optimize: ReleaseFast
+            zig_jobs: ""
           - artifact_name: antfly-zig-darwin-arm64
             runner: macos-15
             os: darwin


### PR DESCRIPTION
## Summary

- build Linux ARM64 release archives with stripped `ReleaseFast` instead of `ReleaseSmall`
- remove the single-job cap so the dedicated ARM64 publish runner can use its available parallelism
- keep the release packaging path and `strip=true` behavior unchanged

## Why

The prior ARM64 settings were an OOM workaround for LLVM debug-information pressure. Stripping release artifacts removes that amplification, and antflydb/colony#420 moves ARM64 publishing to a dedicated 24 GiB C4A runner rather than the shared pool.

## Validation

- workflow YAML/action lint passed
- clean ARM64 Linux `ReleaseFast` + strip diagnostic build passed in 10m15s with 7,804.95 MiB peak RSS at 12 jobs
- exact fresh-cache `build_zig_release_archive.sh` packaging path passed with natural parallelism
- resulting 29 MiB archive contains the expected Antfly executable and C API library; both are stripped AArch64 ELF artifacts

Colony runner change: antflydb/colony#420