### PR TITLE
Harden overload recovery and keyword recall across restart

### DIFF
--- a/go/pkg/antfly/go.mod
+++ b/go/pkg/antfly/go.mod
@@ -15,8 +15,8 @@ replace (
 replace github.com/danaugrs/go-tsne => github.com/danaugrs/go-tsne/tsne v0.0.0-20220306155740-2250969e057f
 
 replace (
-	github.com/blevesearch/bleve/v2 => github.com/antflydb/bleve/v2 v2.5.8-antfly002
-	github.com/blevesearch/zapx/v17 => github.com/antflydb/zapx/v17 v17.0.2-antfly004
+	github.com/blevesearch/bleve/v2 => github.com/antflydb/bleve/v2 v2.5.8-antfly004
+	github.com/blevesearch/zapx/v17 => github.com/antflydb/zapx/v17 v17.0.2-antfly006
 )
 
 replace github.com/tidwall/wal => github.com/ajroetker/wal v0.0.0-antfly000

--- a/go/pkg/antfly/go.sum
+++ b/go/pkg/antfly/go.sum
@@ -202,10 +202,14 @@ github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFI
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
 github.com/antflydb/bleve/v2 v2.5.8-antfly002 h1:Qxw/E9+RJoQR4I30szCinKPLQMQMSII6PCs4xGR/RbI=
 github.com/antflydb/bleve/v2 v2.5.8-antfly002/go.mod h1:nnAd/6gGfLQXE5MBwd6sbX+HwI4xVRFQsWiskvnnbBU=
+github.com/antflydb/bleve/v2 v2.5.8-antfly004 h1:0p4e8BFdg/NkIZTEzP+friH0eEQW2pTQ+VaPUEFQXM0=
+github.com/antflydb/bleve/v2 v2.5.8-antfly004/go.mod h1:nnAd/6gGfLQXE5MBwd6sbX+HwI4xVRFQsWiskvnnbBU=
 github.com/antflydb/imaging v1.8.21-antfly001 h1:C87ErwwF6qsT1IZ+SwIXHzTulL2P/KzZgbckW6CN4hU=
 github.com/antflydb/imaging v1.8.21-antfly001/go.mod h1:X1MZgjqhKafuqgyoZIOcOxJqC7UplRgw/tFkIR0s/uw=
 github.com/antflydb/zapx/v17 v17.0.2-antfly004 h1:t2yAV+LAb8sbNKQB9EEu0UL0gzSCqbI1kHxY0ySxpf4=
 github.com/antflydb/zapx/v17 v17.0.2-antfly004/go.mod h1:BIWKP0dHMgBVdFUSOsMCGrf+amY4L+ihYDEhNbLsVaQ=
+github.com/antflydb/zapx/v17 v17.0.2-antfly006 h1:tE40FCdCJzPP6i6aOc4A45mU4zQ+s+YPKRPAOLb/h/w=
+github.com/antflydb/zapx/v17 v17.0.2-antfly006/go.mod h1:BIWKP0dHMgBVdFUSOsMCGrf+amY4L+ihYDEhNbLsVaQ=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0 h1:axGnT1gRIfimI7gJifB699GoE/oq+F2MU7Dml6nw9rQ=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0/go.mod h1:lvDnEdqiQrp0O42VQGgmlKpxL1AP2+08jFMw88y4klk=
 github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de h1:FxWPpzIjnTlhPwqqXc4/vE0f7GvRjuAsbW+HOIe8KnA=

--- a/go/pkg/antfly/src/store/api.go
+++ b/go/pkg/antfly/src/store/api.go
@@ -56,6 +56,7 @@ type StoreAPI struct {
 
 	startMu        sync.Mutex
 	startingShards map[types.ID]struct{}
+	queryAdmission *queryAdmission
 }
 
 func (store *Store) NewHttpAPI() http.Handler {
@@ -64,6 +65,7 @@ func (store *Store) NewHttpAPI() http.Handler {
 		store:          store,
 		antflyConfig:   store.antflyConfig,
 		startingShards: make(map[types.ID]struct{}),
+		queryAdmission: newQueryAdmission(concurrentQueriesFromEnv(os.Getenv("ANTFLY_MAX_CONCURRENT_QUERIES"))),
 	}
 	return api.setupRoutes()
 }
@@ -2051,6 +2053,11 @@ func (h *StoreAPI) handleGetEdges(w http.ResponseWriter, r *http.Request) {
 
 // setupRoutes sets up the HTTP routes for the API
 func (h *StoreAPI) setupRoutes() *http.ServeMux {
+	// Keep direct StoreAPI construction in tests and small in-process users
+	// protected as well as the production constructor.
+	if h.queryAdmission == nil {
+		h.queryAdmission = newQueryAdmission(defaultConcurrentQueries)
+	}
 	mux := http.NewServeMux()
 	// Special command endpoints
 	mux.HandleFunc("POST /shard", h.handleStartShard)
@@ -2072,7 +2079,7 @@ func (h *StoreAPI) setupRoutes() *http.ServeMux {
 	mux.HandleFunc("GET /shard/isremoved/{id}", h.handleIsIDRemoved)
 	mux.HandleFunc("GET /shard/mediankey", h.handleGetMedianKey)
 	mux.HandleFunc("GET /status", h.handleGetStoreStatus)
-	mux.HandleFunc("POST /search", h.handleSearch)
+	mux.Handle("POST /search", h.queryAdmission.wrap(http.HandlerFunc(h.handleSearch)))
 	mux.HandleFunc("POST /batch", h.handleBatchWrite)
 	mux.HandleFunc("POST /shard/merge-chunk", h.handleApplyMergeChunk)
 	mux.HandleFunc("POST /scan", h.handleScan)

--- a/go/pkg/antfly/src/store/db/indexes/full_text_index_test.go
+++ b/go/pkg/antfly/src/store/db/indexes/full_text_index_test.go
@@ -362,6 +362,58 @@ func TestBleveIndexV2_Search(t *testing.T) {
 	assert.Error(t, err)
 }
 
+// TestKeywordPostingRecallSurvivesRepeatedRestart exercises the large-posting
+// representation used by keyword fields.  A previous index dependency could
+// reopen the document store and general full-text data while omitting this
+// high-frequency posting list; keep this fixture at the observed cardinality.
+func TestKeywordPostingRecallSurvivesRepeatedRestart(t *testing.T) {
+	const published = 4237
+	const total = 5000
+	path := filepath.Join(t.TempDir(), "keyword-restart")
+
+	mapping := bleve.NewIndexMapping()
+	docMapping := bleve.NewDocumentMapping()
+	docMapping.AddFieldMappingsAt("state", bleve.NewKeywordFieldMapping())
+	mapping.DefaultMapping = docMapping
+
+	idx, err := bleve.New(path, mapping)
+	require.NoError(t, err)
+	batch := idx.NewBatch()
+	for i := range total {
+		state := "draft"
+		if i < published {
+			state = "published"
+		}
+		batch.Index(fmt.Sprintf("doc-%04d", i), map[string]string{
+			"state": state,
+			"body":  "restart fixture",
+		})
+	}
+	require.NoError(t, idx.Batch(batch))
+	require.NoError(t, idx.Close())
+
+	for restart := range 2 {
+		idx, err = bleve.Open(path)
+		require.NoError(t, err)
+		assertKeywordCount := func(value string, expected uint64) {
+			term := query.NewTermQuery(value)
+			term.SetField("state")
+			result, searchErr := idx.Search(bleve.NewSearchRequest(term))
+			require.NoError(t, searchErr)
+			require.Equal(t, expected, result.Total, "restart %d, state=%s", restart, value)
+		}
+		assertKeywordCount("published", published)
+		assertKeywordCount("draft", total-published)
+
+		all, searchErr := idx.Search(bleve.NewSearchRequest(bleve.NewMatchAllQuery()))
+		require.NoError(t, searchErr)
+		require.Equal(t, uint64(total), all.Total)
+		_, err = idx.Document("doc-0000")
+		require.NoError(t, err)
+		require.NoError(t, idx.Close())
+	}
+}
+
 func TestSerializationErr(t *testing.T) {
 	testData := `{"url":"https://en.wikipedia.org/wiki?curid=12559133","title":"184th Ordnance Battalion (EOD)","body":"\n184th Ordnance Battalion (EOD)\n\nThe 184th Ordnance Battalion (EOD) accomplish the explosive ordnance disposal (EOD) support activity. The EOD battalion operates under United States Army Forces Command (52nd Ordnance Group (EOD)) command and control with several companies (EOD) strategically located within each control area. Installations and MACOMs do not have a direct area support EOD responsibility.\nOrganization.\nSeven Ordnance Companies (EOD).\nFort Campbell, Kentucky\n-49th OD CO (EOD)\n-717th OD CO (EOD)\n-723rd OD CO (EOD)\n-744th OD CO (EOD)\n-788th OD CO (EOD)\nFort Knox, Kentucky\n-703rd OD CO (EOD)\nFort Benning, Georgia\n-789th OD CO (EOD)\n\n"}`
 	v := map[string]any{}

--- a/go/pkg/antfly/src/store/query_admission.go
+++ b/go/pkg/antfly/src/store/query_admission.go
@@ -1,0 +1,73 @@
+// Copyright 2026 Antfly, Inc.
+//
+// Licensed under the Elastic License 2.0 (ELv2); you may not use this file
+// except in compliance with the Elastic License 2.0. You may obtain a copy of
+// the Elastic License 2.0 at
+//
+//     https://www.antfly.io/licensing/ELv2-license
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Elastic License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package store
+
+import (
+	"net/http"
+	"strconv"
+)
+
+// queryAdmission is deliberately a non-queueing semaphore.  Queuing a search
+// after the client has timed out is precisely the overload failure mode this
+// protects against: it consumes a connection and eventually starts work that
+// no client is waiting for.  Control and health endpoints do not use it.
+type queryAdmission struct {
+	slots chan struct{}
+}
+
+func newQueryAdmission(limit int) *queryAdmission {
+	if limit < 1 {
+		limit = 1
+	}
+	return &queryAdmission{slots: make(chan struct{}, limit)}
+}
+
+func (a *queryAdmission) wrap(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Do not admit work for a request that has already been abandoned.
+		if err := r.Context().Err(); err != nil {
+			return
+		}
+
+		select {
+		case a.slots <- struct{}{}:
+			defer func() { <-a.slots }()
+		default:
+			w.Header().Set("Retry-After", "1")
+			w.Header().Set("X-Antfly-Overload", "query-admission")
+			http.Error(w, "query capacity exhausted; retry shortly", http.StatusServiceUnavailable)
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+func (a *queryAdmission) inFlight() int { return len(a.slots) }
+
+const defaultConcurrentQueries = 32
+
+// concurrentQueriesFromEnv accepts a small, explicit operational override
+// without allowing an invalid value to disable overload protection.
+func concurrentQueriesFromEnv(value string) int {
+	if value == "" {
+		return defaultConcurrentQueries
+	}
+	limit, err := strconv.Atoi(value)
+	if err != nil || limit < 1 {
+		return defaultConcurrentQueries
+	}
+	return limit
+}

--- a/go/pkg/antfly/src/store/query_admission_test.go
+++ b/go/pkg/antfly/src/store/query_admission_test.go
@@ -1,0 +1,109 @@
+// Copyright 2026 Antfly, Inc.
+//
+// Licensed under the Elastic License 2.0 (ELv2); you may not use this file
+// except in compliance with the Elastic License 2.0. You may obtain a copy of
+// the Elastic License 2.0 at
+//
+//     https://www.antfly.io/licensing/ELv2-license
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Elastic License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package store
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestQueryAdmissionBounds128TimedOutClientsAndRecovers(t *testing.T) {
+	const limit = 8
+	admission := newQueryAdmission(limit)
+	release := make(chan struct{})
+	started := make(chan struct{}, limit)
+	var active atomic.Int32
+	var maxActive atomic.Int32
+
+	handler := admission.wrap(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		current := active.Add(1)
+		defer active.Add(-1)
+		for {
+			previous := maxActive.Load()
+			if current <= previous || maxActive.CompareAndSwap(previous, current) {
+				break
+			}
+		}
+		started <- struct{}{}
+		select {
+		case <-r.Context().Done():
+		case <-release:
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	// Hold the admitted work open, then simulate 128 clients whose deadlines
+	// expire.  Excess clients must be rejected without creating work.
+	var wg sync.WaitGroup
+	var overloaded atomic.Int32
+	for range 128 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+			req := httptest.NewRequest(http.MethodPost, "/search", nil).WithContext(ctx)
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+			if rr.Code == http.StatusServiceUnavailable {
+				overloaded.Add(1)
+			}
+		}()
+	}
+
+	for range limit {
+		select {
+		case <-started:
+		case <-time.After(time.Second):
+			t.Fatal("admitted search did not start")
+		}
+	}
+	wg.Wait()
+	close(release)
+
+	require.LessOrEqual(t, maxActive.Load(), int32(limit))
+	require.GreaterOrEqual(t, overloaded.Load(), int32(128-limit))
+	require.Eventually(t, func() bool { return admission.inFlight() == 0 }, time.Second, time.Millisecond)
+
+	// Once timed-out work has drained, a normal query is admitted immediately.
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, httptest.NewRequest(http.MethodPost, "/search", nil))
+	require.Equal(t, http.StatusNoContent, rr.Code)
+}
+
+func TestQueryAdmissionNeverStartsCanceledRequest(t *testing.T) {
+	admission := newQueryAdmission(1)
+	called := atomic.Bool{}
+	handler := admission.wrap(http.HandlerFunc(func(http.ResponseWriter, *http.Request) { called.Store(true) }))
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/search", nil).WithContext(ctx))
+	require.False(t, called.Load())
+	require.Zero(t, admission.inFlight())
+}
+
+func TestConcurrentQueriesFromEnv(t *testing.T) {
+	require.Equal(t, defaultConcurrentQueries, concurrentQueriesFromEnv(""))
+	require.Equal(t, 12, concurrentQueriesFromEnv("12"))
+	require.Equal(t, defaultConcurrentQueries, concurrentQueriesFromEnv("0"))
+	require.Equal(t, defaultConcurrentQueries, concurrentQueriesFromEnv("bad"))
+}

--- a/go/pkg/antfly/src/store/runner.go
+++ b/go/pkg/antfly/src/store/runner.go
@@ -249,9 +249,12 @@ func RunAsStore(
 			defer func() { _ = server.Close() }()
 		} else {
 			server := &http.Server{
-				Addr:        url.Host,
-				Handler:     runtime.HTTPHandler(),
-				ReadTimeout: time.Minute,
+				Addr:              url.Host,
+				Handler:           runtime.HTTPHandler(),
+				ReadHeaderTimeout: 10 * time.Second,
+				ReadTimeout:       time.Minute,
+				IdleTimeout:       time.Minute,
+				MaxHeaderBytes:    1 << 20,
 			}
 			eg.Go(func() error {
 				wg.Done()


### PR DESCRIPTION
Codex (GPT-5.6-terra):

- Gate `/search` behind a fail-fast, cancel-aware admission limit so excess work receives an explicit 503 while control/status routes retain capacity.
- Set HTTP header and idle deadlines to reclaim abandoned connections.
- Upgrade the pinned Bleve/Zapx recovery dependencies and add 128-client overload plus repeated 5K keyword-posting restart regressions.

Tests:

- `go test ./src/store -count=1`
- `go test ./src/store/db/indexes -run 'TestKeywordPostingRecallSurvivesRepeatedRestart|TestBleveIndexV2_(Search|Open|Batch)' -count=1`

Closes #422
