### PR TITLE
Fix restart keyword recall through initial schema binding

### DIFF
--- a/zig/build.zig
+++ b/zig/build.zig
@@ -4109,6 +4109,7 @@ pub fn build(b: *std.Build) void {
             "storage.db.db.test.db phrase query survives",
             "storage.db.db.test.db prefix wildcard and regexp",
             "storage.db.db.test.db typed and dictionary queries survive",
+            "storage.db.db.test.db schema installed after text index open keeps exact keyword filters across reopen",
             "storage.db.db.test.db mixed-type stored fields survive",
             "storage.db.db.test.db persists byte range across reopen",
             "storage.db.db.test.db snapshot copies current store and derived log",

--- a/zig/pkg/antfly/src/storage/db/catalog/index_manager.zig
+++ b/zig/pkg/antfly/src/storage/db/catalog/index_manager.zig
@@ -16011,6 +16011,43 @@ fn loadRuntimeSchemaForTextIndex(alloc: Allocator, store: anytype, index_name: [
     return try schema_mod.loadSchemaVersion(store, alloc, explicit_version.?);
 }
 
+pub fn bindSchemaToEmptyTextIndexes(self: *IndexManager, schema: schema_mod.TableSchema) !void {
+    for (self.text_indexes.items) |*entry| {
+        if (entry.runtime_schema != null) continue;
+        const snapshot = entry.persistent.snapshot();
+        var has_documents = false;
+        for (snapshot.segments) |segment| {
+            if (segment.reader.doc_count != 0) {
+                has_documents = true;
+                break;
+            }
+        }
+        if (has_documents) continue;
+        if (textIndexSchemaVersion(entry.config.name)) |version| {
+            if (version != schema.version) continue;
+        }
+
+        const runtime_schema = try schema_mod.cloneSchema(self.alloc, schema);
+        var runtime_schema_moved = false;
+        errdefer if (!runtime_schema_moved) schema_mod.freeSchema(self.alloc, runtime_schema);
+
+        var text_analysis = try parseTextAnalysisForIndexConfig(
+            self.alloc,
+            entry.config.config_json,
+            runtime_schema,
+        );
+        var text_analysis_moved = false;
+        errdefer if (!text_analysis_moved) introducer_mod.freeTextAnalysisConfig(self.alloc, text_analysis);
+        try appendObservedFieldAnalyzers(self.alloc, &text_analysis, entry.observed_field_analyzers);
+
+        introducer_mod.freeTextAnalysisConfig(self.alloc, entry.text_analysis);
+        entry.text_analysis = text_analysis;
+        entry.runtime_schema = runtime_schema;
+        text_analysis_moved = true;
+        runtime_schema_moved = true;
+    }
+}
+
 fn textIndexSchemaVersion(index_name: []const u8) ?u32 {
     if (std.mem.eql(u8, index_name, "default") or std.mem.eql(u8, index_name, "full_text_index")) return 0;
     const prefix = "full_text_index_v";

--- a/zig/pkg/antfly/src/storage/db/core.zig
+++ b/zig/pkg/antfly/src/storage/db/core.zig
@@ -990,7 +990,9 @@ pub const DBCore = struct {
     }
 
     pub fn setSchema(self: *DBCore, table_schema: schema_mod.TableSchema) !void {
-        if (!try schema_mod.saveSchema(self.store, self.alloc, table_schema)) return;
+        const changed = try schema_mod.saveSchema(self.store, self.alloc, table_schema);
+        try index_manager_mod.bindSchemaToEmptyTextIndexes(self.index_manager, table_schema);
+        if (!changed) return;
         const next_schema = try schema_mod.loadSchema(self.store, self.alloc);
         if (self.schema) |existing| schema_mod.freeSchema(self.alloc, existing);
         self.schema = next_schema;

--- a/zig/pkg/antfly/src/storage/db/db.zig
+++ b/zig/pkg/antfly/src/storage/db/db.zig
@@ -70827,6 +70827,58 @@ test "db versioned full text indexes reload matching schema mappings after reope
     }
 }
 
+test "db schema installed after text index open keeps exact keyword filters across reopen" {
+    const alloc = std.testing.allocator;
+
+    var path_buf: [256]u8 = undefined;
+    const path = tempPath(&path_buf);
+    defer cleanupTempDir(path);
+
+    const schema_json =
+        \\{"version":0,"default_type":"asset","document_schemas":{"asset":{"schema":{"type":"object","properties":{"state":{"type":"string","x-antfly-types":["keyword"]},"title":{"type":"string","x-antfly-types":["text"]}}}}}}
+    ;
+    const filter_json = "{\"term\":{\"state\":\"published\"}}";
+
+    {
+        var db = try DB.open(alloc, std.mem.span(path), .{ .start_index_workers = false });
+        defer db.close();
+        try db.addIndex(.{
+            .name = "full_text_index_v0",
+            .kind = .full_text,
+            .config_json = "{}",
+        });
+        try db.setSchemaJson(alloc, schema_json);
+        try db.batch(.{
+            .writes = &.{
+                .{ .key = "asset:1", .value = "{\"_type\":\"asset\",\"state\":\"published\",\"title\":\"open archive\"}" },
+                .{ .key = "asset:2", .value = "{\"_type\":\"asset\",\"state\":\"draft\",\"title\":\"closed archive\"}" },
+            },
+            .sync_level = .full_index,
+        });
+        var before = try db.search(alloc, .{
+            .index_name = "full_text_index_v0",
+            .query = .{ .match_all = {} },
+            .filter_query_json = filter_json,
+            .limit = 10,
+        });
+        defer before.deinit();
+        try std.testing.expectEqual(@as(u32, 1), before.total_hits);
+    }
+
+    {
+        var reopened = try DB.open(alloc, std.mem.span(path), .{ .start_index_workers = false });
+        defer reopened.close();
+        var after = try reopened.search(alloc, .{
+            .index_name = "full_text_index_v0",
+            .query = .{ .match_all = {} },
+            .filter_query_json = filter_json,
+            .limit = 10,
+        });
+        defer after.deinit();
+        try std.testing.expectEqual(@as(u32, 1), after.total_hits);
+    }
+}
+
 test "db additionalProperties true nested text fields survive reopen" {
     const alloc = std.testing.allocator;
     const table_schema_api = @import("../../schema/mod.zig");

--- a/zig/pkg/antfly/src/storage/schema.zig
+++ b/zig/pkg/antfly/src/storage/schema.zig
@@ -575,6 +575,12 @@ pub fn freeSchema(alloc: Allocator, s: TableSchema) void {
     if (s.index_sort.len > 0) alloc.free(s.index_sort);
 }
 
+pub fn cloneSchema(alloc: Allocator, schema: TableSchema) !TableSchema {
+    const encoded = try serializeSchema(alloc, schema);
+    defer alloc.free(encoded);
+    return try deserializeSchema(alloc, encoded);
+}
+
 /// Save a schema to DocStore. Returns whether durable state changed.
 pub fn saveSchema(store: anytype, alloc: Allocator, schema: TableSchema) !bool {
     const data = try serializeSchema(alloc, schema);


### PR DESCRIPTION
> ## Summary
> 
> This stacked draft fixes the real API-ingest → clean restart keyword-recall failure that #424 intends to close.
> 
> It binds an installed table schema to schema-less, empty text indexes before their first documents are indexed. The binding deep-clones the runtime schema, rebuilds the index's text-analysis configuration, retains observed analyzers, respects versioned index names, and refuses to reinterpret an index that already contains documents.
> 
> ## Root cause
> 
> The production table lifecycle opens `full_text_index_v0` before installing the table schema. Initial documents were therefore indexed schema-less:
> 
> - base `state` used the standard analyzer (`published` became `publish`);
> - `state.keyword` retained the exact `published` value;
> - before restart, exact-term resolution targeted `state.keyword`;
> - after reopen, the persisted runtime schema made resolution target base `state`, so exact `published` returned zero.
> 
> The postings and source documents were never lost. `draft` appeared healthy only because stemming leaves that word unchanged. The failure reproduces with two documents, so it is deterministic rather than a high-frequency/postings threshold issue.
> 
> This also explains why #424's existing synthetic persistence test passes: it constructs a keyword field directly and bypasses the index-open → schema-install → ingest → reopen binding transition.
> 
> ## Regression coverage
> 
> Adds a two-document DB lifecycle test that:
> 
> 1. opens a DB and creates `full_text_index_v0`;
> 2. installs a schema declaring `state` as keyword;
> 3. writes `published` and `draft` documents;
> 4. verifies `state=published` before close;
> 5. reopens and verifies the same exact filter again.
> 
> Before this fix the post-reopen assertion reports `expected 1, found 0`.
> 
> ## Validation
> 
> - Exact #424 head `ae69344f`: real 5K reproducer fails across two restarts (`published 4,237 → 0`; exact physical postings and source documents remain intact).
> - Candidate build: preserves `4,237 published`, `763 draft`, `229 open+published`, and `57 open+draft` across two clean restarts.
> - Focused DB lifecycle regression passes with no leaks.
> - 14/14 valid DB reopen/dictionary regression selections pass with no leaks.
> - The patch applies cleanly to PR #420 head `ceeb16f0`; a combined ReleaseFast build preserves the same 5K counts across two restarts.
> - `git diff --check` passes.
> 
> The existing `lib-db-reopen-test` build target still exits nonzero because two pre-existing filters name tests that no longer exist (`db compacts tiny text segments` and `db snapshot copies current store and derived log`). Running the compiled test artifact with all valid configured selections is green.
> 