### PR TITLE
Restore release-safe ARM64 archive settings

### DIFF
--- a/.github/workflows/antfly-release.yml
+++ b/.github/workflows/antfly-release.yml
@@ -43,8 +43,8 @@ jobs:
             archive_arch: arm64
             metal: "false"
             system_blas: "false"
-            zig_optimize: ReleaseFast
-            zig_jobs: ""
+            zig_optimize: ReleaseSmall
+            zig_jobs: "1"
           - artifact_name: antfly-zig-darwin-arm64
             runner: macos-15
             os: darwin


### PR DESCRIPTION
## Summary

- restore Linux ARM64 release archives to `ReleaseSmall`
- restore the single-job cap for ARM64 release builds
- leave amd64 and Darwin release settings unchanged

## Why

PR #421 changed ARM64 archives to `ReleaseFast` with natural parallelism. The v0.2.0-rc.25 release failed twice with Zig/LLVM `std::bad_alloc`, including after the ARM64 runner was moved to dedicated Performance/C4A placement with a 24,000 MiB request. Restore the previously known-good release settings to unblock the release.

## Validation

- `git diff --check`
- `actionlint .github/workflows/antfly-release.yml`