### PR TITLE
Fix projected graph pushes and index deletion races

### DIFF
--- a/zig/pkg/antfly/src/api/http_server.zig
+++ b/zig/pkg/antfly/src/api/http_server.zig
@@ -4745,7 +4745,11 @@ pub const ApiHttpServer = struct {
                 const distributed_tables = try commit_req.distributedTables(self.alloc);
                 defer if (distributed_tables.len > 0) self.alloc.free(distributed_tables);
                 self.validateCommitTablesAgainstSchema(distributed_tables) catch |err| switch (err) {
-                    error.InvalidBatchRequest => return try textResponse(self.alloc, 400, "invalid transaction commit request"),
+                    error.InvalidBatchRequest,
+                    error.InvalidArgument,
+                    error.InvalidGraphEdges,
+                    error.UnsupportedTransformOperation,
+                    => return try textResponse(self.alloc, 400, "invalid transaction commit request"),
                     else => return err,
                 };
                 if (try self.validateCommitReadSet(commit_req)) |conflict| {
@@ -4761,7 +4765,11 @@ pub const ApiHttpServer = struct {
                 }
 
                 const outcome = (source.commitTransaction(self.alloc, distributed_tables, commit_req.sync_level) catch |err| switch (err) {
-                    error.InvalidBatchRequest => return try textResponse(self.alloc, 400, "invalid transaction commit request"),
+                    error.InvalidBatchRequest,
+                    error.InvalidArgument,
+                    error.InvalidGraphEdges,
+                    error.UnsupportedTransformOperation,
+                    => return try textResponse(self.alloc, 400, "invalid transaction commit request"),
                     error.TopologyChanged => {
                         var arena_impl = std.heap.ArenaAllocator.init(self.alloc);
                         defer arena_impl.deinit();
@@ -5094,7 +5102,17 @@ pub const ApiHttpServer = struct {
                 }
 
                 const outcome = (source.commitTransactionWithId(self.alloc, txn_id, session.begin_timestamp, distributed_tables, session.sync_level) catch |err| switch (err) {
-                    error.InvalidBatchRequest => return try textResponse(self.alloc, 400, "invalid transaction commit request"),
+                    error.InvalidBatchRequest,
+                    error.InvalidArgument,
+                    error.InvalidGraphEdges,
+                    error.UnsupportedTransformOperation,
+                    => {
+                        // The participant has terminally aborted a transaction
+                        // that reached write validation; do not retain a local
+                        // session that can no longer be committed with its ID.
+                        _ = self.txn_sessions.remove(self.alloc, txn_id);
+                        return try textResponse(self.alloc, 400, "invalid transaction commit request");
+                    },
                     error.TopologyChanged => {
                         var arena_impl = std.heap.ArenaAllocator.init(self.alloc);
                         defer arena_impl.deinit();
@@ -24171,6 +24189,26 @@ test "api http graph push preserves projected edges across restart" {
             defer invalid_resp.deinit(alloc);
             try std.testing.expectEqual(@as(u16, 400), invalid_resp.status);
         }
+
+        const invalid_txn_batch = try test_contract_helpers.normalizeBatchRequest(alloc,
+            \\{"transforms":[{"key":"a","operations":[{"op":"$set","path":"title","value":"must-not-commit"},{"op":"$set","path":"$._edges.graph.FRIEND","value":[]}]}],"sync_level":"full_index"}
+        );
+        defer alloc.free(invalid_txn_batch);
+        const invalid_txn_body = try test_contract_helpers.encodeTransactionCommitRequest(
+            alloc,
+            &.{},
+            &.{.{ .table_name = "docs", .batch_json = invalid_txn_batch }},
+            "full_index",
+        );
+        defer alloc.free(invalid_txn_body);
+        var invalid_txn_resp = try server.handle(.{
+            .method = .POST,
+            .uri = routes.Routes.transactions_commit,
+            .content_type = "application/json",
+            .body = invalid_txn_body,
+        });
+        defer invalid_txn_resp.deinit(alloc);
+        try std.testing.expectEqual(@as(u16, 400), invalid_txn_resp.status);
 
         const stored = (try db.get(alloc, "a")) orelse return error.TestExpectedEqual;
         defer alloc.free(stored);

--- a/zig/pkg/antfly/src/api/http_server.zig
+++ b/zig/pkg/antfly/src/api/http_server.zig
@@ -45,6 +45,7 @@ const raft_host = @import("../raft/host.zig");
 const raft_mod = @import("../raft/mod.zig");
 const raft_reconciler = @import("../raft/reconciler.zig");
 const db_mod = @import("../storage/db/mod.zig");
+const graph_mod = @import("../graph/graph.zig");
 const backend_erased = @import("../storage/backend_erased.zig");
 const db_query_search = @import("../storage/db/query/search_exec.zig");
 const storage_schema = @import("../storage/schema.zig");
@@ -8550,7 +8551,11 @@ pub const ApiHttpServer = struct {
             },
         };
         _ = (source.batch(alloc, table_name, req) catch |err| switch (err) {
-            error.InvalidBatchRequest => return error.InvalidBatchRequest,
+            error.InvalidBatchRequest,
+            error.InvalidArgument,
+            error.InvalidGraphEdges,
+            error.UnsupportedTransformOperation,
+            => return error.InvalidBatchRequest,
             error.TableNotFound => return error.NotFound,
             error.DocIdentityNamespaceMismatch => return error.DocIdentityUnavailable,
             error.EnrichmentRetryInProgress, error.ResourceBudgetExceeded => return error.Backpressured,
@@ -24083,6 +24088,110 @@ test "api http server serves table batch transforms" {
     const stored = parsed_stored.value;
     try std.testing.expectEqualStrings("updated", stored.status);
     try std.testing.expectEqual(@as(i64, 3), stored.version);
+}
+
+test "api http graph push preserves projected edges across restart" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const path = try std.fmt.allocPrint(alloc, ".zig-cache/tmp/{s}/graph-push-restart", .{tmp.sub_path});
+    defer alloc.free(path);
+
+    const FakeSource = struct {
+        fn iface(_: *@This()) StatusSource {
+            return .{
+                .ptr = undefined,
+                .vtable = &.{ .status = status },
+            };
+        }
+
+        fn status(_: *anyopaque) !metadata_api.MetadataStatus {
+            return .{ .metadata_group_id = 1, .metrics = .{}, .projected_stores = 1 };
+        }
+    };
+
+    {
+        var db = try db_mod.DB.open(alloc, path, .{});
+        defer db.close();
+        var table_source = table_writes.BoundTableWriteSource.init("docs", &db);
+        var create_req = tables_api.CreateTableRequest{
+            .indexes_json = try alloc.dupe(u8, "{\"graph\":{\"type\":\"graph\"}}"),
+        };
+        defer create_req.deinit(alloc);
+        _ = try table_source.source().createTable(alloc, "docs", create_req);
+
+        var source = FakeSource{};
+        var server = ApiHttpServer.init(alloc, .{}, source.iface(), null, table_source.source());
+
+        const insert_body = try test_contract_helpers.normalizeBatchRequest(alloc,
+            \\{"inserts":{"a":{"title":"A","_edges":{"graph":{"FRIEND":[{"target":"b","weight":2,"metadata":{"since":2024}}]}}},"b":{"title":"B"},"c":{"title":"C"}},"sync_level":"full_index"}
+        );
+        defer alloc.free(insert_body);
+        var insert_resp = try server.handle(.{
+            .method = .POST,
+            .uri = "/tables/docs/batch",
+            .content_type = "application/json",
+            .body = insert_body,
+        });
+        defer insert_resp.deinit(alloc);
+        try std.testing.expectEqual(@as(u16, 201), insert_resp.status);
+
+        const transform_body = try test_contract_helpers.normalizeBatchRequest(alloc,
+            \\{"transforms":[{"key":"a","operations":[{"op":"$push","path":"$._edges.graph.FRIEND","value":{"target":"c","weight":3}}]}],"sync_level":"full_index"}
+        );
+        defer alloc.free(transform_body);
+        var transform_resp = try server.handle(.{
+            .method = .POST,
+            .uri = "/tables/docs/batch",
+            .content_type = "application/json",
+            .body = transform_body,
+        });
+        defer transform_resp.deinit(alloc);
+        try std.testing.expectEqual(@as(u16, 201), transform_resp.status);
+
+        const invalid_transforms = [_][]const u8{
+            \\{"transforms":[{"key":"a","operations":[{"op":"$set","path":"title","value":"must-not-commit"},{"op":"$set","path":"$._edges.graph.FRIEND","value":[]}]}],"sync_level":"full_index"}
+            ,
+            \\{"transforms":[{"key":"a","operations":[{"op":"$set","path":"title","value":"must-not-commit"},{"op":"$inc","path":"$._edges.graph.FRIEND","value":1}]}],"sync_level":"full_index"}
+            ,
+            \\{"transforms":[{"key":"a","operations":[{"op":"$set","path":"title","value":"must-not-commit"},{"op":"$push","path":"$._edges.graph.FRIEND","value":{"weight":4}}]}],"sync_level":"full_index"}
+            ,
+            \\{"transforms":[{"key":"a","operations":[{"op":"$set","path":"title","value":"must-not-commit"},{"op":"$push","path":"$._edges.graph","value":{"target":"d"}}]}],"sync_level":"full_index"}
+            ,
+        };
+        for (invalid_transforms) |invalid_body_json| {
+            const invalid_body = try test_contract_helpers.normalizeBatchRequest(alloc, invalid_body_json);
+            defer alloc.free(invalid_body);
+            var invalid_resp = try server.handle(.{
+                .method = .POST,
+                .uri = "/tables/docs/batch",
+                .content_type = "application/json",
+                .body = invalid_body,
+            });
+            defer invalid_resp.deinit(alloc);
+            try std.testing.expectEqual(@as(u16, 400), invalid_resp.status);
+        }
+
+        const stored = (try db.get(alloc, "a")) orelse return error.TestExpectedEqual;
+        defer alloc.free(stored);
+        try std.testing.expect(std.mem.indexOf(u8, stored, "must-not-commit") == null);
+        const edges = try db.getEdges(alloc, "graph", "a", "FRIEND", .out);
+        defer graph_mod.GraphIndex.freeEdges(alloc, edges);
+        try std.testing.expectEqual(@as(usize, 2), edges.len);
+    }
+
+    var reopened = try db_mod.DB.open(alloc, path, .{});
+    defer reopened.close();
+    const reopened_edges = try reopened.getEdges(alloc, "graph", "a", "FRIEND", .out);
+    defer graph_mod.GraphIndex.freeEdges(alloc, reopened_edges);
+    try std.testing.expectEqual(@as(usize, 2), reopened_edges.len);
+    var saw_b = false;
+    var saw_c = false;
+    for (reopened_edges) |edge| {
+        if (std.mem.eql(u8, edge.target, "b")) saw_b = true;
+        if (std.mem.eql(u8, edge.target, "c")) saw_c = true;
+    }
+    try std.testing.expect(saw_b and saw_c);
 }
 
 test "api http server updates local table schema through bound write source" {

--- a/zig/pkg/antfly/src/api/table_writes.zig
+++ b/zig/pkg/antfly/src/api/table_writes.zig
@@ -33,6 +33,7 @@ const raft_reconciler = @import("../raft/reconciler.zig");
 const shard_state_store = @import("../data/storage/shard_state_store.zig");
 const db_mod = @import("../storage/db/mod.zig");
 const doc_identity = @import("../storage/db/doc_identity.zig");
+const graph_mod = @import("../graph/graph.zig");
 const range_state_mod = @import("../storage/db/range_state.zig");
 const index_manager_mod = @import("../storage/db/catalog/index_manager.zig");
 const change_journal_mod = @import("../storage/db/derived/change_journal.zig");
@@ -4585,12 +4586,27 @@ pub const BoundTableWriteSource = struct {
             .deletes = table.deletes,
             .transforms = table.transforms,
             .predicates = table.predicates,
-        }) catch |err| switch (err) {
-            error.VersionConflict, error.IntentConflict => {
-                db.resolveTransactionIntents(txn_id, .aborted, commit_version) catch {};
-                return .{ .conflict = boundConflict(table, err) };
-            },
-            else => return err,
+        }) catch |err| {
+            // A begun local transaction must reach a terminal state on every
+            // rejected write. In particular, graph transform validation is
+            // performed by DB.writeTransaction after begin, so returning the
+            // validation error without aborting would strand its transaction.
+            db.resolveTransactionIntents(txn_id, .aborted, commit_version) catch |abort_err| {
+                std.log.err("failed to abort rejected bound transaction write_err={s} abort_err={s}", .{
+                    @errorName(err),
+                    @errorName(abort_err),
+                });
+                return abort_err;
+            };
+            switch (err) {
+                error.VersionConflict, error.IntentConflict => return .{ .conflict = boundConflict(table, err) },
+                error.InvalidBatchRequest,
+                error.InvalidArgument,
+                error.InvalidGraphEdges,
+                error.UnsupportedTransformOperation,
+                => return error.InvalidBatchRequest,
+                else => return err,
+            }
         };
         try db.resolveTransactionIntents(txn_id, .committed, commit_version);
         return .{ .committed = .{ .participant_count = 1 } };
@@ -24765,6 +24781,44 @@ test "bound table write source rejects invalid commit transforms against persist
             },
         }},
     }}, .write));
+}
+
+test "bound table write source aborts graph transform transaction on validation failure" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const path = try std.fmt.allocPrint(alloc, ".zig-cache/tmp/{s}/bound-graph-transform-txn", .{tmp.sub_path});
+    defer alloc.free(path);
+
+    var db = try db_mod.DB.open(alloc, path, .{});
+    defer db.close();
+    try db.addIndex(.{ .name = "graph", .kind = .graph, .config_json = "{}" });
+    try db.batch(.{
+        .writes = &.{.{ .key = "a", .value = "{\"title\":\"A\",\"_edges\":{\"graph\":{\"FRIEND\":[{\"target\":\"b\"}]}}}" }},
+        .sync_level = .full_index,
+    });
+
+    var source = BoundTableWriteSource.init("docs", &db);
+    const txn_id = try distributed_txn.parseTxnIdHex("102132435465768798a9bacbdcedfe0f");
+    try std.testing.expectError(error.InvalidBatchRequest, source.source().commitTransactionWithId(
+        alloc,
+        txn_id,
+        20_000,
+        &.{.{
+            .table_name = "docs",
+            .transforms = &.{.{
+                .key = "a",
+                .operations = &.{.{ .op = .set, .path = "$._edges.graph.FRIEND", .value_json = "[]" }},
+            }},
+        }},
+        .full_index,
+    ));
+    try std.testing.expectEqual(db_mod.types.TxnStatus.aborted, try db.getTransactionStatus(txn_id));
+
+    const edges = try db.getEdges(alloc, "graph", "a", "FRIEND", .out);
+    defer graph_mod.GraphIndex.freeEdges(alloc, edges);
+    try std.testing.expectEqual(@as(usize, 1), edges.len);
+    try std.testing.expectEqualStrings("b", edges[0].target);
 }
 
 test "bound table write source rejects invalid txn prepare writes against persisted schema" {

--- a/zig/pkg/antfly/src/storage/db/apply_rw_lock.zig
+++ b/zig/pkg/antfly/src/storage/db/apply_rw_lock.zig
@@ -18,6 +18,9 @@ const platform = @import("antfly_platform");
 const platform_time = @import("antfly_platform").time;
 const AtomicU64 = platform.atomic.Value(u64);
 
+/// Writer-preferring service fence. Shared acquisition is intentionally not
+/// reentrant: once a writer owns `reader_gate`, a call tree that already holds
+/// shared must use lock-assuming helpers instead of acquiring shared again.
 pub const ApplyRwLock = struct {
     pub const Stats = struct {
         shared_lock_calls: u64 = 0,
@@ -183,7 +186,7 @@ fn atomicMaxU64(value: *AtomicU64, candidate: u64) void {
     }
 }
 
-test "apply rw lock supports repeated shared acquisition" {
+test "apply rw lock permits nested shared acquisition while no writer is queued" {
     var lock: ApplyRwLock = .{};
 
     lock.lockShared();

--- a/zig/pkg/antfly/src/storage/db/catalog/index_manager.zig
+++ b/zig/pkg/antfly/src/storage/db/catalog/index_manager.zig
@@ -595,6 +595,20 @@ const TextMergeScheduler = struct {
         }
     }
 
+    fn removeIndex(self: *TextMergeScheduler, alloc: Allocator, index_name: []const u8) void {
+        self.supersedeInFlightForIndex(alloc, index_name);
+        var i: usize = 0;
+        while (i < self.quarantined.items.len) {
+            const merge = &self.quarantined.items[i];
+            if (!std.mem.eql(u8, merge.index_name, index_name)) {
+                i += 1;
+                continue;
+            }
+            merge.deinit(alloc);
+            _ = self.quarantined.orderedRemove(i);
+        }
+    }
+
     fn pruneExpiredQuarantines(self: *TextMergeScheduler, alloc: Allocator, now_ns: u64) void {
         var i: usize = 0;
         while (i < self.quarantined.items.len) {
@@ -4489,6 +4503,7 @@ pub const IndexManager = struct {
                     name,
                     try combineRemovalCatalogMutation(atomic_mutation, &cleanup),
                 );
+                self.text_merge_scheduler.removeIndex(self.alloc, name);
                 self.freeTextIndexEntry(entry);
                 _ = self.text_indexes.orderedRemove(i);
                 defer self.dropIndexLoadStateNoLock(name);

--- a/zig/pkg/antfly/src/storage/db/catalog/index_manager.zig
+++ b/zig/pkg/antfly/src/storage/db/catalog/index_manager.zig
@@ -2393,6 +2393,24 @@ pub const IndexManager = struct {
         remaining: usize = 0,
     };
 
+    /// DB-owned service fence for publishing a newly opened quarantined
+    /// index. Opening and backfill happen outside this fence; only the final
+    /// catalog commit excludes readers that borrow pointers into inline index
+    /// arrays.
+    pub const CatalogPublicationFence = struct {
+        ptr: *anyopaque,
+        lock_fn: *const fn (*anyopaque) void,
+        unlock_fn: *const fn (*anyopaque) void,
+
+        fn lock(self: @This()) void {
+            self.lock_fn(self.ptr);
+        }
+
+        fn unlock(self: @This()) void {
+            self.unlock_fn(self.ptr);
+        }
+    };
+
     /// Re-attempts opening quarantined indexes whose backoff deadline has
     /// passed (all of them when `force` is set). A successful open registers
     /// the runtime index, removes the quarantined config from the
@@ -2401,7 +2419,13 @@ pub const IndexManager = struct {
     /// recorded error and pushes the next attempt out exponentially
     /// (30s..10min). `remaining` is the quarantine count after this pass,
     /// read under the catalog lock so callers can stop polling at zero.
-    pub fn retryFailedIndexLoads(self: *IndexManager, store: anytype, now_ns: u64, force: bool) !QuarantineRetryResult {
+    pub fn retryFailedIndexLoads(
+        self: *IndexManager,
+        store: anytype,
+        now_ns: u64,
+        force: bool,
+        publication_fence: CatalogPublicationFence,
+    ) !QuarantineRetryResult {
         const RetryTask = struct {
             name: []u8,
             cfg: types.IndexConfig,
@@ -2481,64 +2505,73 @@ pub const IndexManager = struct {
                 continue;
             };
 
-            self.catalog_mutex.lockExclusive();
-            if (self.failed_index_loads.get(task.name) == null) {
-                self.completeIndexLoadNoLock(task.name);
-                self.catalog_mutex.unlockExclusive();
-                opened.deinit(self);
-                continue;
-            }
-            var remove_idx: ?usize = null;
-            for (self.status_only_index_configs, 0..) |old_cfg, i| {
-                if (std.mem.eql(u8, old_cfg.name, task.name)) {
-                    remove_idx = i;
-                    break;
+            {
+                // Lock order is structural/service fence -> catalog. The DB
+                // fence drains maintenance and takes apply exclusive, matching
+                // every other live index publication. Keep slow open/backfill
+                // work above this scope so recovery does not stall queries.
+                publication_fence.lock();
+                defer publication_fence.unlock();
+
+                self.catalog_mutex.lockExclusive();
+                if (self.failed_index_loads.get(task.name) == null) {
+                    self.completeIndexLoadNoLock(task.name);
+                    self.catalog_mutex.unlockExclusive();
+                    opened.deinit(self);
+                    continue;
                 }
-            }
-            if (remove_idx == null) {
-                self.completeIndexLoadNoLock(task.name);
-                self.dropFailedIndexLoad(task.name);
-                self.catalog_mutex.unlockExclusive();
-                opened.deinit(self);
-                continue;
-            }
-            // Pre-allocate the shrunken status-only list so registration and
-            // de-quarantine commit together once the open has succeeded.
-            const old = self.status_only_index_configs;
-            const replacement: []types.IndexConfig = if (old.len <= 1)
-                &.{}
-            else
-                self.alloc.alloc(types.IndexConfig, old.len - 1) catch |err| {
+                var remove_idx: ?usize = null;
+                for (self.status_only_index_configs, 0..) |old_cfg, i| {
+                    if (std.mem.eql(u8, old_cfg.name, task.name)) {
+                        remove_idx = i;
+                        break;
+                    }
+                }
+                if (remove_idx == null) {
+                    self.completeIndexLoadNoLock(task.name);
+                    self.dropFailedIndexLoad(task.name);
+                    self.catalog_mutex.unlockExclusive();
+                    opened.deinit(self);
+                    continue;
+                }
+                // Pre-allocate the shrunken status-only list so registration
+                // and de-quarantine commit together once the open succeeded.
+                const old = self.status_only_index_configs;
+                const replacement: []types.IndexConfig = if (old.len <= 1)
+                    &.{}
+                else
+                    self.alloc.alloc(types.IndexConfig, old.len - 1) catch |err| {
+                        self.completeIndexLoadNoLock(task.name);
+                        self.catalog_mutex.unlockExclusive();
+                        opened.deinit(self);
+                        return err;
+                    };
+                self.appendOpenedIndex(opened) catch |err| {
+                    if (replacement.len > 0) self.alloc.free(replacement);
                     self.completeIndexLoadNoLock(task.name);
                     self.catalog_mutex.unlockExclusive();
                     opened.deinit(self);
                     return err;
                 };
-            self.appendOpenedIndex(opened) catch |err| {
-                if (replacement.len > 0) self.alloc.free(replacement);
                 self.completeIndexLoadNoLock(task.name);
-                self.catalog_mutex.unlockExclusive();
-                opened.deinit(self);
-                return err;
-            };
-            self.completeIndexLoadNoLock(task.name);
-            var wi: usize = 0;
-            for (old, 0..) |old_cfg, i| {
-                if (i == remove_idx.?) {
-                    var removed = old_cfg;
-                    removed.deinit(self.alloc);
-                    continue;
+                var wi: usize = 0;
+                for (old, 0..) |old_cfg, i| {
+                    if (i == remove_idx.?) {
+                        var removed = old_cfg;
+                        removed.deinit(self.alloc);
+                        continue;
+                    }
+                    replacement[wi] = old_cfg;
+                    wi += 1;
                 }
-                replacement[wi] = old_cfg;
-                wi += 1;
+                if (old.len > 0) self.alloc.free(old);
+                self.status_only_index_configs = replacement;
+                // Log before dropFailedIndexLoad frees the `name` key buffer.
+                std.log.info("quarantined index recovered name={s} kind={s}", .{ task.name, @tagName(task.cfg.kind) });
+                self.dropFailedIndexLoad(task.name);
+                self.catalog_mutex.unlockExclusive();
+                recovered += 1;
             }
-            if (old.len > 0) self.alloc.free(old);
-            self.status_only_index_configs = replacement;
-            // Log before dropFailedIndexLoad frees the `name` key buffer.
-            std.log.info("quarantined index recovered name={s} kind={s}", .{ task.name, @tagName(task.cfg.kind) });
-            self.dropFailedIndexLoad(task.name);
-            self.catalog_mutex.unlockExclusive();
-            recovered += 1;
         }
 
         self.catalog_mutex.lockExclusive();

--- a/zig/pkg/antfly/src/storage/db/db.zig
+++ b/zig/pkg/antfly/src/storage/db/db.zig
@@ -706,7 +706,9 @@ const AsyncContext = struct {
     dense_maintenance_last_ns: std.StringHashMapUnmanaged(u64) = .empty,
     target_advance_repair_last_ns: std.StringHashMapUnmanaged(u64) = .empty,
     text_merge_runtime: ?*text_merge_runtime_mod.TextMergeRuntime = null,
+    text_merge_restart_state: std.atomic.Value(u8) = .init(0),
     sparse_compaction_runtime: ?*sparse_compaction_runtime_mod.SparseCompactionRuntime = null,
+    sparse_compaction_restart_state: std.atomic.Value(u8) = .init(0),
     resolution_runtime: ?*resolution_runtime_mod.ResolutionRuntime = null,
     promotion_runtime: ?*promotion_runtime_mod.PromotionRuntime = null,
     repair_options: types.ArtifactRepairRunOptions = .{},
@@ -6432,6 +6434,125 @@ pub const DB = struct {
         };
     }
 
+    const MaintenanceRuntimeKind = enum {
+        text_merge,
+        sparse_compaction,
+    };
+
+    fn maintenanceRestartState(ctx: *AsyncContext, kind: MaintenanceRuntimeKind) *std.atomic.Value(u8) {
+        return switch (kind) {
+            .text_merge => &ctx.text_merge_restart_state,
+            .sparse_compaction => &ctx.sparse_compaction_restart_state,
+        };
+    }
+
+    fn ensureMaintenanceRuntimeRunning(ctx: *AsyncContext, kind: MaintenanceRuntimeKind) !bool {
+        return switch (kind) {
+            .text_merge => if (ctx.text_merge_runtime) |runtime| try runtime.ensureRunning() else true,
+            .sparse_compaction => if (ctx.sparse_compaction_runtime) |runtime| try runtime.ensureRunning() else true,
+        };
+    }
+
+    const MaintenanceRestartWork = struct {
+        ctx: *AsyncContext,
+        lane: background_runtime_mod.DurableJobLane,
+        owner_id: u64,
+        kind: MaintenanceRuntimeKind,
+
+        const retry_initial_ms: i64 = 25;
+        const retry_max_ms: i64 = 1000;
+        const retries_per_job: usize = 8;
+
+        fn run(ptr: *anyopaque) anyerror!void {
+            const work: *@This() = @ptrCast(@alignCast(ptr));
+            const restart_state = maintenanceRestartState(work.ctx, work.kind);
+            var retries: usize = 0;
+            while (true) {
+                if (work.ctx.background_closing.load(.acquire)) {
+                    restart_state.store(0, .release);
+                    return;
+                }
+
+                var start_error: ?anyerror = null;
+                const running = ensureMaintenanceRuntimeRunning(work.ctx, work.kind) catch |err| blk: {
+                    start_error = err;
+                    break :blk false;
+                };
+                if (running) {
+                    if (restart_state.cmpxchgStrong(1, 0, .acq_rel, .acquire) == null) return;
+                    if (restart_state.cmpxchgStrong(2, 1, .acq_rel, .acquire) == null) {
+                        retries = 0;
+                        continue;
+                    }
+                    return;
+                }
+
+                retries += 1;
+                if (start_error) |err| {
+                    if (retries == 1 or std.math.isPowerOfTwo(retries)) {
+                        std.log.warn("{s} runtime restart retry attempt={} err={s}", .{
+                            @tagName(work.kind),
+                            retries,
+                            @errorName(err),
+                        });
+                    }
+                }
+                // A paused runtime is owned by a subsequent structural
+                // mutation. Wait without starting it behind that mutation.
+                if (work.ctx.io) |io| {
+                    const shift: u6 = @intCast(@min(retries - 1, 5));
+                    const delay_ms = if (builtin.is_test) 1 else @min(retry_initial_ms << shift, retry_max_ms);
+                    io.sleep(std.Io.Duration.fromMilliseconds(delay_ms), .awake) catch {};
+                } else {
+                    restart_state.store(0, .release);
+                    return error.MaintenanceRuntimeUnavailable;
+                }
+                if (retries >= retries_per_job) {
+                    // Yield the shared durable lane during persistent failure;
+                    // the desired-running bit makes resubmission idempotent.
+                    restart_state.store(0, .release);
+                    scheduleMaintenanceRestartContext(work.ctx, work.lane, work.owner_id, work.kind);
+                    return;
+                }
+            }
+        }
+
+        fn deinit(ptr: *anyopaque) void {
+            const work: *@This() = @ptrCast(@alignCast(ptr));
+            std.heap.page_allocator.destroy(work);
+        }
+    };
+
+    fn scheduleMaintenanceRestartContext(
+        ctx: *AsyncContext,
+        lane: background_runtime_mod.DurableJobLane,
+        owner_id: u64,
+        kind: MaintenanceRuntimeKind,
+    ) void {
+        if (ctx.background_closing.load(.acquire)) return;
+        const restart_state = maintenanceRestartState(ctx, kind);
+        if (restart_state.cmpxchgStrong(0, 1, .acq_rel, .acquire) != null) {
+            _ = restart_state.cmpxchgStrong(1, 2, .acq_rel, .acquire);
+            return;
+        }
+        const work = std.heap.page_allocator.create(MaintenanceRestartWork) catch {
+            restart_state.store(0, .release);
+            return;
+        };
+        work.* = .{ .ctx = ctx, .lane = lane, .owner_id = owner_id, .kind = kind };
+        lane.submit(.{
+            .owner_id = owner_id,
+            .class = .maintenance,
+            .ptr = work,
+            .run = MaintenanceRestartWork.run,
+            .deinit = MaintenanceRestartWork.deinit,
+        }) catch |err| {
+            std.heap.page_allocator.destroy(work);
+            restart_state.store(0, .release);
+            std.log.warn("{s} runtime restart was not scheduled err={s}", .{ @tagName(kind), @errorName(err) });
+        };
+    }
+
     fn quiesceEnrichmentForStructuralMutation(self: *DB) bool {
         const desired = self.async_context.enrichment_desired_running.swap(false, .acq_rel);
         lockAtomicWithBackoff(&self.async_context.enrichment_lifecycle_mutex);
@@ -6444,28 +6565,40 @@ pub const DB = struct {
 
     fn quiesceTextMergeForStructuralMutation(self: *DB) bool {
         const runtime = self.text_merge_runtime orelse return false;
-        return runtime.stop();
+        return runtime.pause();
     }
 
     fn quiesceSparseCompactionForStructuralMutation(self: *DB) bool {
         const runtime = self.sparse_compaction_runtime orelse return false;
-        return runtime.stop();
+        return runtime.pause();
     }
 
     fn restartTextMergeAfterStructuralMutation(self: *DB, operation: []const u8, index_name: []const u8) void {
         const runtime = self.text_merge_runtime orelse return;
-        runtime.start() catch |err| {
+        runtime.resumeAfterPause() catch |err| {
             // Index catalog durability is already decided at this point.
             // Queries and foreground indexing remain available; surface the
             // maintenance degradation without misreporting the mutation.
             std.log.err("failed to restart text merge runtime after {s} index={s} err={s}", .{ operation, index_name, @errorName(err) });
+            scheduleMaintenanceRestartContext(
+                self.async_context,
+                self.backend_runtime.durable_jobs,
+                self.repair_cleanup_owner_id,
+                .text_merge,
+            );
         };
     }
 
     fn restartSparseCompactionAfterStructuralMutation(self: *DB, operation: []const u8, index_name: []const u8) void {
         const runtime = self.sparse_compaction_runtime orelse return;
-        runtime.start() catch |err| {
+        runtime.resumeAfterPause() catch |err| {
             std.log.err("failed to restart sparse compaction runtime after {s} index={s} err={s}", .{ operation, index_name, @errorName(err) });
+            scheduleMaintenanceRestartContext(
+                self.async_context,
+                self.backend_runtime.durable_jobs,
+                self.repair_cleanup_owner_id,
+                .sparse_compaction,
+            );
         };
     }
 
@@ -6475,8 +6608,15 @@ pub const DB = struct {
         index_name: []const u8,
         restart_text_merge: bool,
         restart_sparse_compaction: bool,
-        catalog_barrier_held: bool = true,
+        catalog_barrier_held: bool = false,
         active: bool = true,
+
+        fn acquireCatalogBarrierUntil(self: *@This(), deadline_ns: u64) bool {
+            std.debug.assert(self.active and !self.catalog_barrier_held);
+            if (!self.db.beginIndexCatalogBarrierUntil(deadline_ns)) return false;
+            self.catalog_barrier_held = true;
+            return true;
+        }
 
         fn releaseCatalogBarrier(self: *@This()) void {
             if (!self.catalog_barrier_held) return;
@@ -6548,23 +6688,17 @@ pub const DB = struct {
         operation: []const u8,
         index_name: []const u8,
     ) IndexStructuralMutationGuard {
-        return self.beginIndexStructuralMutationUntil(operation, index_name, std.math.maxInt(u64)) orelse unreachable;
+        var guard = self.beginDrainedIndexStructuralMutation(operation, index_name);
+        if (!guard.acquireCatalogBarrierUntil(std.math.maxInt(u64))) unreachable;
+        return guard;
     }
 
-    fn beginIndexStructuralMutationUntil(
+    fn beginDrainedIndexStructuralMutation(
         self: *DB,
         operation: []const u8,
         index_name: []const u8,
-        deadline_ns: u64,
-    ) ?IndexStructuralMutationGuard {
+    ) IndexStructuralMutationGuard {
         lockAtomicWithBackoff(&self.index_structural_mutation_mutex);
-        // Published dense searches intentionally bypass the apply lock. Raise
-        // their catalog barrier before draining maintenance so no lock-free
-        // reader can retain a pointer across an inline-array reallocation.
-        if (!self.beginIndexCatalogBarrierUntil(deadline_ns)) {
-            self.index_structural_mutation_mutex.unlock();
-            return null;
-        }
         return .{
             .db = self,
             .operation = operation,
@@ -11898,17 +12032,20 @@ pub const DB = struct {
         );
         if (ready_sequence != converged_sequence) return error.IndexGenerationManifestMismatch;
         try checkArtifactRepairActivationOwner(options);
-        const activation_started_ns = monotonicTimeNs();
-        const activation_deadline_ns = activation_started_ns +| max_activation_pause_ns;
         // Final publication detaches and later destroys the active inline
-        // generation. Drain maintenance before taking the apply lock so a
-        // task cannot retain a pointer into that generation across the swap.
-        var structural_guard = self.beginIndexStructuralMutationUntil(
+        // generation. Drain maintenance before starting the bounded reader
+        // pause: this work has no catalog effect and may wait for an active
+        // merge or compaction whose duration is not part of query downtime.
+        var structural_guard = self.beginDrainedIndexStructuralMutation(
             "index repair activation",
             cfg.name,
-            activation_deadline_ns,
-        ) orelse return error.ShadowIndexCatchUpIncomplete;
+        );
         defer structural_guard.deinit();
+        const activation_started_ns = monotonicTimeNs();
+        const activation_deadline_ns = activation_started_ns +| max_activation_pause_ns;
+        if (!structural_guard.acquireCatalogBarrierUntil(activation_deadline_ns)) {
+            return error.ShadowIndexCatchUpIncomplete;
+        }
         var unpublished_replacement: ?index_manager_mod.IndexManager.DetachedIndex = null;
         defer if (unpublished_replacement) |*replacement| {
             shadow_manager.destroyDetachedReplacementIndex(replacement);
@@ -69787,6 +69924,50 @@ test "db delete full text index drains active merge before closing generation" {
         .index_name = "ft_v1",
         .query = .{ .match = .{ .field = "body", .text = "common" } },
     }));
+}
+
+test "db structural mutation autonomously retries transient maintenance restart failures" {
+    const alloc = std.testing.allocator;
+    var path_buf: [256]u8 = undefined;
+    const path = tempPath(&path_buf);
+    defer cleanupTempDir(path);
+
+    var db = try DB.open(alloc, std.mem.span(path), .{
+        .text_merge = .{ .enabled = true, .idle_interval_ms = 10_000, .error_interval_ms = 10_000 },
+        .sparse_compaction = .{ .enabled = true, .idle_interval_ms = 10_000, .error_interval_ms = 10_000 },
+    });
+    defer db.close();
+    const text_runtime = db.text_merge_runtime orelse return error.TestUnexpectedResult;
+    const sparse_runtime = db.sparse_compaction_runtime orelse return error.TestUnexpectedResult;
+    try std.testing.expect(text_runtime.isStarted());
+    try std.testing.expect(sparse_runtime.isStarted());
+
+    // Inject only the first post-drain spawn in each runtime. The structural
+    // mutation remains successful, and the durable supervisor must restore
+    // both workers without another foreground mutation.
+    text_merge_runtime_mod.test_start_failures_remaining.store(1, .release);
+    sparse_compaction_runtime_mod.test_start_failures_remaining.store(1, .release);
+    defer {
+        text_merge_runtime_mod.test_start_failures_remaining.store(0, .release);
+        sparse_compaction_runtime_mod.test_start_failures_remaining.store(0, .release);
+    }
+    try db.addIndex(.{ .name = "graph", .kind = .graph, .config_json = "{}" });
+
+    var recovered = false;
+    for (0..500) |_| {
+        if (text_runtime.isStarted() and
+            sparse_runtime.isStarted() and
+            db.async_context.text_merge_restart_state.load(.acquire) == 0 and
+            db.async_context.sparse_compaction_restart_state.load(.acquire) == 0)
+        {
+            recovered = true;
+            break;
+        }
+        try db.async_context.io.?.sleep(std.Io.Duration.fromMilliseconds(1), .awake);
+    }
+    try std.testing.expect(recovered);
+    try std.testing.expectEqual(@as(u32, 0), text_merge_runtime_mod.test_start_failures_remaining.load(.acquire));
+    try std.testing.expectEqual(@as(u32, 0), sparse_compaction_runtime_mod.test_start_failures_remaining.load(.acquire));
 }
 
 test "db post-delete filter reader does not deadlock behind queued cleanup writer" {

--- a/zig/pkg/antfly/src/storage/db/db.zig
+++ b/zig/pkg/antfly/src/storage/db/db.zig
@@ -871,6 +871,10 @@ const graph_repair_rebuild_batch_size: usize = 2048;
 var test_graph_repair_stream_flushes: std.atomic.Value(u64) = .init(0);
 var test_dense_repair_rebuild_batch_size: ?usize = null;
 var test_index_repair_catch_up_max_records_per_window: ?usize = null;
+var test_quarantine_publication_fence_entered: std.atomic.Value(bool) = .init(false);
+var test_block_match_all_ordinal_lookup: std.atomic.Value(bool) = .init(false);
+var test_match_all_ordinal_lookup_entered: std.atomic.Value(bool) = .init(false);
+var test_release_match_all_ordinal_lookup: std.atomic.Value(bool) = .init(false);
 const dense_posting_idle_default_max_postings_per_index: usize = 64;
 const dense_posting_idle_default_max_layout_changes_per_index: usize = 8;
 const dense_posting_idle_default_max_boundary_reassignments_per_index: usize = 64;
@@ -2994,7 +2998,7 @@ pub const DB = struct {
     bulk_ingest_seen_doc_keys: std.StringHashMapUnmanaged(void) = .{},
     doc_set_planning_stats: DocSetPlanningRuntimeStats = .{},
     visibility_runtime_stats: VisibilityRuntimeStats = .{},
-    index_repair_barriers: std.atomic.Value(u32) = .init(0),
+    index_catalog_barriers: std.atomic.Value(u32) = .init(0),
     // Managed admission is a durable outbox. Requested/completed generations
     // prevent a drain from erasing work committed while its marker snapshot is
     // in flight; the mutex makes concurrent drainers a single-flight loop.
@@ -6462,6 +6466,111 @@ pub const DB = struct {
         const runtime = self.sparse_compaction_runtime orelse return;
         runtime.start() catch |err| {
             std.log.err("failed to restart sparse compaction runtime after {s} index={s} err={s}", .{ operation, index_name, @errorName(err) });
+        };
+    }
+
+    const IndexStructuralMutationGuard = struct {
+        db: *DB,
+        operation: []const u8,
+        index_name: []const u8,
+        restart_text_merge: bool,
+        restart_sparse_compaction: bool,
+        catalog_barrier_held: bool = true,
+        active: bool = true,
+
+        fn releaseCatalogBarrier(self: *@This()) void {
+            if (!self.catalog_barrier_held) return;
+            self.db.endIndexCatalogBarrier();
+            self.catalog_barrier_held = false;
+        }
+
+        fn release(self: *@This()) void {
+            if (!self.active) return;
+            // The catalog is stable once the caller releases apply exclusive;
+            // let lock-free dense searches resume before runtime startup work.
+            self.releaseCatalogBarrier();
+            // Restart while serialization is still held: another structural
+            // mutation must not stop a runtime between this restart and the
+            // corresponding unlock.
+            if (self.restart_sparse_compaction) {
+                self.db.restartSparseCompactionAfterStructuralMutation(self.operation, self.index_name);
+            }
+            if (self.restart_text_merge) {
+                self.db.restartTextMergeAfterStructuralMutation(self.operation, self.index_name);
+            }
+            self.db.index_structural_mutation_mutex.unlock();
+            self.active = false;
+        }
+
+        fn deinit(self: *@This()) void {
+            self.release();
+        }
+    };
+
+    const QuarantineIndexPublicationFence = struct {
+        db: *DB,
+        structural_guard: ?IndexStructuralMutationGuard = null,
+        apply_locked: bool = false,
+
+        fn iface(self: *@This()) index_manager_mod.IndexManager.CatalogPublicationFence {
+            return .{
+                .ptr = self,
+                .lock_fn = lockOpaque,
+                .unlock_fn = unlockOpaque,
+            };
+        }
+
+        fn lockOpaque(ptr: *anyopaque) void {
+            const self: *@This() = @ptrCast(@alignCast(ptr));
+            std.debug.assert(self.structural_guard == null and !self.apply_locked);
+            self.structural_guard = self.db.beginIndexStructuralMutation("quarantined index publication", "*");
+            if (builtin.is_test) test_quarantine_publication_fence_entered.store(true, .release);
+            lockApply(self.db);
+            self.apply_locked = true;
+        }
+
+        fn unlockOpaque(ptr: *anyopaque) void {
+            const self: *@This() = @ptrCast(@alignCast(ptr));
+            std.debug.assert(self.apply_locked and self.structural_guard != null);
+            self.db.core.unlockApply();
+            self.apply_locked = false;
+            self.structural_guard.?.release();
+            self.structural_guard = null;
+        }
+    };
+
+    /// Serializes every live index-catalog publication and drains background
+    /// tasks that borrow inline index generations. Callers must acquire this
+    /// before the DB apply lock; active tasks retire under that lock while the
+    /// guard waits for their workers to stop.
+    fn beginIndexStructuralMutation(
+        self: *DB,
+        operation: []const u8,
+        index_name: []const u8,
+    ) IndexStructuralMutationGuard {
+        return self.beginIndexStructuralMutationUntil(operation, index_name, std.math.maxInt(u64)) orelse unreachable;
+    }
+
+    fn beginIndexStructuralMutationUntil(
+        self: *DB,
+        operation: []const u8,
+        index_name: []const u8,
+        deadline_ns: u64,
+    ) ?IndexStructuralMutationGuard {
+        lockAtomicWithBackoff(&self.index_structural_mutation_mutex);
+        // Published dense searches intentionally bypass the apply lock. Raise
+        // their catalog barrier before draining maintenance so no lock-free
+        // reader can retain a pointer across an inline-array reallocation.
+        if (!self.beginIndexCatalogBarrierUntil(deadline_ns)) {
+            self.index_structural_mutation_mutex.unlock();
+            return null;
+        }
+        return .{
+            .db = self,
+            .operation = operation,
+            .index_name = index_name,
+            .restart_text_merge = self.quiesceTextMergeForStructuralMutation(),
+            .restart_sparse_compaction = self.quiesceSparseCompactionForStructuralMutation(),
         };
     }
 
@@ -10104,11 +10213,17 @@ pub const DB = struct {
         if (!entry.intent.previous_pointer_captured) return false;
         const candidate = entry.intent.candidate_relative_path orelse return false;
         if (!try self.core.index_manager.isRepairCandidateActive(entry.intent.index_name, candidate)) return false;
-        try self.core.index_manager.restoreActiveIndexRootPointer(
-            entry.intent.index_name,
-            candidate,
-            entry.intent.previous_active_relative_path,
-        );
+        {
+            var structural_guard = self.beginIndexStructuralMutation("index repair rollback", entry.intent.index_name);
+            defer structural_guard.deinit();
+            lockApply(self);
+            defer self.core.unlockApply();
+            try self.core.index_manager.restoreActiveIndexRootPointer(
+                entry.intent.index_name,
+                candidate,
+                entry.intent.previous_active_relative_path,
+            );
+        }
         _ = try self.retryQuarantinedIndexLoads(true);
         try self.discardInactiveIndexRepairCandidate(alloc, repair_id);
         return true;
@@ -11686,7 +11801,6 @@ pub const DB = struct {
             .target_sequence = self.core.nextDerivedSequence(),
         });
 
-        const use_dense_search_barrier = cfg.kind == .dense_vector;
         if (durable_repair_id) |repair_id| try self.updateIndexRepairIntent(alloc, repair_id, .{
             .phase = .waiting_for_convergence,
             .candidate_applied_sequence = converged_sequence,
@@ -11786,6 +11900,15 @@ pub const DB = struct {
         try checkArtifactRepairActivationOwner(options);
         const activation_started_ns = monotonicTimeNs();
         const activation_deadline_ns = activation_started_ns +| max_activation_pause_ns;
+        // Final publication detaches and later destroys the active inline
+        // generation. Drain maintenance before taking the apply lock so a
+        // task cannot retain a pointer into that generation across the swap.
+        var structural_guard = self.beginIndexStructuralMutationUntil(
+            "index repair activation",
+            cfg.name,
+            activation_deadline_ns,
+        ) orelse return error.ShadowIndexCatchUpIncomplete;
+        defer structural_guard.deinit();
         var unpublished_replacement: ?index_manager_mod.IndexManager.DetachedIndex = null;
         defer if (unpublished_replacement) |*replacement| {
             shadow_manager.destroyDetachedReplacementIndex(replacement);
@@ -11800,15 +11923,6 @@ pub const DB = struct {
                 manager.recordIndexRepairActivation(monotonicTimeNs() -| activation_started_ns, max_activation_pause_ns);
             }
         };
-        var repair_barrier_held = false;
-        if (use_dense_search_barrier) {
-            if (!self.beginIndexRepairBarrierUntil(activation_deadline_ns)) {
-                return error.ShadowIndexCatchUpIncomplete;
-            }
-            repair_barrier_held = true;
-        }
-        defer if (repair_barrier_held) self.endIndexRepairBarrier();
-
         try checkArtifactRepairCancelled(options);
         if (!self.lockApplyUntil(activation_deadline_ns)) return error.ShadowIndexCatchUpIncomplete;
         var apply_lock_held = true;
@@ -11938,18 +12052,15 @@ pub const DB = struct {
         });
 
         // The pointer and clean checkpoint are now ordered before any later
-        // foreground apply. Release write and dense-search fencing before
-        // operator hooks, intent cleanup, and generation garbage collection.
-        // Capture the actual service pause before releasing either fence.
+        // foreground apply. Release the write fence before operator hooks,
+        // intent cleanup, and generation garbage collection. Capture the
+        // actual service pause before releasing it.
         // Generation teardown and other post-commit work are measured
         // separately and cannot produce false pause-budget alarms.
         const activation_pause_ns = monotonicTimeNs() -| activation_started_ns;
         self.core.unlockApply();
         apply_lock_held = false;
-        if (repair_barrier_held) {
-            self.endIndexRepairBarrier();
-            repair_barrier_held = false;
-        }
+        structural_guard.releaseCatalogBarrier();
         if (retired_generation) |*retired| {
             self.core.index_manager.destroyDetachedReplacementIndex(retired);
             retired_generation = null;
@@ -11958,6 +12069,7 @@ pub const DB = struct {
             shadow_manager.deinit();
             shadow_manager_open = false;
         }
+        structural_guard.release();
         if (self.core.index_manager.resource_manager) |manager| {
             manager.recordIndexRepairActivation(activation_pause_ns, max_activation_pause_ns);
         }
@@ -14188,17 +14300,13 @@ pub const DB = struct {
 
     fn addIndexWithAdmission(self: *DB, cfg: types.IndexConfig, admission_mode: IndexAdmissionMode) !?u128 {
         if (openModeRequiresReadOnlyBackends(self.open_mode)) return error.ReadOnly;
-        lockAtomicWithBackoff(&self.index_structural_mutation_mutex);
-        defer self.index_structural_mutation_mutex.unlock();
+        var structural_guard = self.beginIndexStructuralMutation("index creation", cfg.name);
+        defer structural_guard.deinit();
         // Generated artifact namespaces can be shared across differently named
         // indexes. Cleanup is durable and owner-driven; never turn index
         // admission into an unbounded corpus scan. Metadata reconciliation can
         // retry after the conflicting generation's tombstone is retired.
         try self.rejectConflictingRetiredIndexCleanupForAdmission(cfg);
-        const restart_text_merge = self.quiesceTextMergeForStructuralMutation();
-        defer if (restart_text_merge) self.restartTextMergeAfterStructuralMutation("index creation", cfg.name);
-        const restart_sparse_compaction = self.quiesceSparseCompactionForStructuralMutation();
-        defer if (restart_sparse_compaction) self.restartSparseCompactionAfterStructuralMutation("index creation", cfg.name);
         const restart_enrichment = self.quiesceEnrichmentForStructuralMutation();
         var enrichment_restarted = false;
         errdefer if (restart_enrichment and !enrichment_restarted) {
@@ -15459,12 +15567,8 @@ pub const DB = struct {
 
     pub fn deleteIndex(self: *DB, name: []const u8) !bool {
         if (openModeRequiresReadOnlyBackends(self.open_mode)) return error.ReadOnly;
-        lockAtomicWithBackoff(&self.index_structural_mutation_mutex);
-        defer self.index_structural_mutation_mutex.unlock();
-        const restart_text_merge = self.quiesceTextMergeForStructuralMutation();
-        defer if (restart_text_merge) self.restartTextMergeAfterStructuralMutation("index deletion", name);
-        const restart_sparse_compaction = self.quiesceSparseCompactionForStructuralMutation();
-        defer if (restart_sparse_compaction) self.restartSparseCompactionAfterStructuralMutation("index deletion", name);
+        var structural_guard = self.beginIndexStructuralMutation("index deletion", name);
+        defer structural_guard.deinit();
         const restart_enrichment = self.quiesceEnrichmentForStructuralMutation();
         const removed = self.deleteIndexWhileEnrichmentQuiesced(name) catch |delete_err| {
             if (restart_enrichment) self.restartEnrichmentAfterStructuralMutation("failed index deletion", name) catch |restart_err| {
@@ -15905,7 +16009,13 @@ pub const DB = struct {
     /// the initial load, so a recovered full-text/sparse/graph index resumes
     /// its persisted rebuild state and catches up before registering.
     pub fn retryQuarantinedIndexLoads(self: *DB, force: bool) !index_manager_mod.IndexManager.QuarantineRetryResult {
-        return try self.core.index_manager.retryFailedIndexLoads(self.core.store, monotonicTimeNs(), force);
+        var publication_fence = QuarantineIndexPublicationFence{ .db = self };
+        return try self.core.index_manager.retryFailedIndexLoads(
+            self.core.store,
+            monotonicTimeNs(),
+            force,
+            publication_fence.iface(),
+        );
     }
 
     fn runArtifactRepairMetadataMaintenancePass(self: *DB) !bool {
@@ -21430,9 +21540,9 @@ pub const DB = struct {
     }
 
     fn beginPublishedDenseSearch(self: *DB) bool {
-        if (self.index_repair_barriers.load(.acquire) != 0) return false;
+        if (self.index_catalog_barriers.load(.acquire) != 0) return false;
         _ = self.published_dense_searches.fetchAdd(1, .acq_rel);
-        if (self.index_repair_barriers.load(.acquire) != 0) {
+        if (self.index_catalog_barriers.load(.acquire) != 0) {
             _ = self.published_dense_searches.fetchSub(1, .acq_rel);
             return false;
         }
@@ -21443,12 +21553,12 @@ pub const DB = struct {
         _ = self.published_dense_searches.fetchSub(1, .acq_rel);
     }
 
-    fn beginIndexRepairBarrierUntil(self: *DB, deadline_ns: u64) bool {
-        _ = self.index_repair_barriers.fetchAdd(1, .acq_rel);
+    fn beginIndexCatalogBarrierUntil(self: *DB, deadline_ns: u64) bool {
+        _ = self.index_catalog_barriers.fetchAdd(1, .acq_rel);
         var spins: usize = 0;
         while (self.published_dense_searches.load(.acquire) != 0) : (spins += 1) {
             if (monotonicTimeNs() >= deadline_ns) {
-                _ = self.index_repair_barriers.fetchSub(1, .acq_rel);
+                _ = self.index_catalog_barriers.fetchSub(1, .acq_rel);
                 return false;
             }
             if (spins < 64) {
@@ -21460,8 +21570,8 @@ pub const DB = struct {
         return true;
     }
 
-    fn endIndexRepairBarrier(self: *DB) void {
-        _ = self.index_repair_barriers.fetchSub(1, .acq_rel);
+    fn endIndexCatalogBarrier(self: *DB) void {
+        _ = self.index_catalog_barriers.fetchSub(1, .acq_rel);
     }
 
     fn lockApplyUntil(self: *DB, deadline_ns: u64) bool {
@@ -21586,7 +21696,10 @@ pub const DB = struct {
             .scan_store_range = scanStoreRangeCallback,
             .scan_store_range_with_context = scanStoreRangeWithContextCallback,
             .is_expired_key = isExpiredDocumentKeyCallback,
-            .lookup_doc_ordinal = lookupLiveDocOrdinalCallback,
+            // searchMatchAll is entered under the outer DB apply lease. The
+            // lock is not reentrant once an exclusive writer closes its reader
+            // gate, so callbacks in this call tree must use lock-assuming APIs.
+            .lookup_doc_ordinal = lookupLiveDocOrdinalNoLockCallback,
         }, options);
     }
 
@@ -21604,20 +21717,10 @@ pub const DB = struct {
             .scan_store_range = scanStoreRangeCallback,
             .scan_store_range_with_context = scanStoreRangeWithContextCallback,
             .is_expired_key = isExpiredDocumentKeyCallback,
-            .lookup_doc_ordinal = lookupLiveDocOrdinalCallback,
+            // See collectSearchMatchAllCandidatesCallback: the caller owns the
+            // apply lease for the full streaming traversal.
+            .lookup_doc_ordinal = lookupLiveDocOrdinalNoLockCallback,
         }, options, consumer_ctx, consumer);
-    }
-
-    fn lookupLiveDocOrdinalCallback(
-        ctx: ?*anyopaque,
-        alloc: Allocator,
-        doc_id: []const u8,
-        generation: ?u64,
-    ) anyerror!?doc_set.DocOrdinal {
-        const self: *DB = @ptrCast(@alignCast(ctx orelse return error.InvalidArgument));
-        lockApplyShared(self);
-        defer self.core.unlockApplyShared();
-        return try self.lookupLiveDocOrdinalNoLock(alloc, doc_id, generation);
     }
 
     fn lookupLiveDocOrdinalNoLockCallback(
@@ -21627,6 +21730,10 @@ pub const DB = struct {
         generation: ?u64,
     ) anyerror!?doc_set.DocOrdinal {
         const self: *DB = @ptrCast(@alignCast(ctx orelse return error.InvalidArgument));
+        if (builtin.is_test and test_block_match_all_ordinal_lookup.load(.acquire)) {
+            test_match_all_ordinal_lookup_entered.store(true, .release);
+            while (!test_release_match_all_ordinal_lookup.load(.acquire)) std.Thread.yield() catch {};
+        }
         return try self.lookupLiveDocOrdinalNoLock(alloc, doc_id, generation);
     }
 
@@ -41636,7 +41743,7 @@ test "db sparse hits resolve doc ordinals through identity not sparse doc nums" 
     try std.testing.expectEqual(@as(?doc_set.DocOrdinal, ordinal), result.hits[0].doc_ordinal);
 }
 
-test "db index repair barrier disables published dense fast path" {
+test "db index catalog barrier disables published dense fast path" {
     const alloc = std.testing.allocator;
     var path_buf: [256]u8 = undefined;
     const path = tempPath(&path_buf);
@@ -41648,12 +41755,12 @@ test "db index repair barrier disables published dense fast path" {
     try std.testing.expect(db.beginPublishedDenseSearch());
     db.endPublishedDenseSearch();
 
-    try std.testing.expect(db.beginIndexRepairBarrierUntil(monotonicTimeNs() + std.time.ns_per_s));
-    defer db.endIndexRepairBarrier();
+    try std.testing.expect(db.beginIndexCatalogBarrierUntil(monotonicTimeNs() + std.time.ns_per_s));
+    defer db.endIndexCatalogBarrier();
     try std.testing.expect(!db.beginPublishedDenseSearch());
 }
 
-test "db index repair barrier and apply acquisition honor activation deadline" {
+test "db index catalog barrier and apply acquisition honor activation deadline" {
     const alloc = std.testing.allocator;
     var path_buf: [256]u8 = undefined;
     const path = tempPath(&path_buf);
@@ -41663,8 +41770,8 @@ test "db index repair barrier and apply acquisition honor activation deadline" {
     defer db.close();
 
     try std.testing.expect(db.beginPublishedDenseSearch());
-    try std.testing.expect(!db.beginIndexRepairBarrierUntil(monotonicTimeNs() + std.time.ns_per_ms));
-    try std.testing.expectEqual(@as(u32, 0), db.index_repair_barriers.load(.acquire));
+    try std.testing.expect(!db.beginIndexCatalogBarrierUntil(monotonicTimeNs() + std.time.ns_per_ms));
+    try std.testing.expectEqual(@as(u32, 0), db.index_catalog_barriers.load(.acquire));
     db.endPublishedDenseSearch();
 
     db.core.lockApplyExclusive();
@@ -52494,8 +52601,51 @@ test "db quarantined index self-heals via retryQuarantinedIndexLoads" {
     }
 
     // Forced retry recovers the index in-process — no reopen, no
-    // drop+recreate — resuming the persisted rebuild state.
-    const result = try db.retryQuarantinedIndexLoads(true);
+    // drop+recreate — resuming the persisted rebuild state. Hold a simulated
+    // query lease across the final publication and prove recovery waits for
+    // it rather than reallocating the inline catalog beneath a reader.
+    const RetryState = struct {
+        db: *DB,
+        result: ?index_manager_mod.IndexManager.QuarantineRetryResult = null,
+        err: ?anyerror = null,
+        completed: std.atomic.Value(bool) = .init(false),
+
+        fn run(state: *@This()) void {
+            state.result = state.db.retryQuarantinedIndexLoads(true) catch |err| {
+                state.err = err;
+                state.completed.store(true, .release);
+                return;
+            };
+            state.completed.store(true, .release);
+        }
+    };
+    test_quarantine_publication_fence_entered.store(false, .release);
+    defer test_quarantine_publication_fence_entered.store(false, .release);
+    lockApplyShared(&db);
+    var apply_shared_held = true;
+    var retry_state = RetryState{ .db = &db };
+    var retry_thread = try std.Thread.spawn(.{}, RetryState.run, .{&retry_state});
+    var retry_thread_joined = false;
+    defer {
+        if (apply_shared_held) db.core.unlockApplyShared();
+        if (!retry_thread_joined) retry_thread.join();
+    }
+
+    const publication_deadline = monotonicTimeNs() +| 30 * std.time.ns_per_s;
+    while (!test_quarantine_publication_fence_entered.load(.acquire) and monotonicTimeNs() < publication_deadline) {
+        sleepNs(100 * std.time.ns_per_us);
+    }
+    const publication_fence_entered = test_quarantine_publication_fence_entered.load(.acquire);
+    const publication_waited_for_reader = publication_fence_entered and !retry_state.completed.load(.acquire);
+    db.core.unlockApplyShared();
+    apply_shared_held = false;
+    retry_thread.join();
+    retry_thread_joined = true;
+
+    try std.testing.expect(publication_fence_entered);
+    try std.testing.expect(publication_waited_for_reader);
+    if (retry_state.err) |err| return err;
+    const result = retry_state.result orelse return error.TestUnexpectedResult;
     try std.testing.expectEqual(@as(usize, 1), result.recovered);
     try std.testing.expectEqual(@as(usize, 0), result.remaining);
     try std.testing.expect(db.core.index_manager.loadFailure("ft_v1") == null);
@@ -69568,9 +69718,11 @@ test "db delete full text index drains active merge before closing generation" {
     text_merge_runtime_mod.test_task_begin_entered.store(false, .release);
     text_merge_runtime_mod.test_release_after_task_begin.store(false, .release);
     text_merge_runtime_mod.test_block_after_task_begin.store(true, .release);
+    text_merge_runtime_mod.test_stop_entered.store(false, .release);
     defer {
         text_merge_runtime_mod.test_release_after_task_begin.store(true, .release);
         text_merge_runtime_mod.test_block_after_task_begin.store(false, .release);
+        text_merge_runtime_mod.test_stop_entered.store(false, .release);
     }
     try db.finishBulkIngestSessionWithOptions(.{ .compact = false });
 
@@ -69607,9 +69759,19 @@ test "db delete full text index drains active merge before closing generation" {
         delete_thread.join();
     };
 
-    // Deletion must wait for the task that borrowed the index runtime; it may
-    // not acknowledge catalog removal and close storage underneath that task.
-    for (0..512) |_| std.Thread.yield() catch {};
+    var stop_entered = false;
+    for (0..200_000) |_| {
+        if (text_merge_runtime_mod.test_stop_entered.load(.acquire)) {
+            stop_entered = true;
+            break;
+        }
+        std.Thread.yield() catch {};
+    }
+    if (!stop_entered) return error.TestTimeout;
+
+    // The delete thread is now inside the maintenance stopper. It must wait
+    // for the task that borrowed the index generation rather than acknowledge
+    // removal and close storage underneath that task.
     try std.testing.expect(!deletion.completed.load(.acquire));
 
     text_merge_runtime_mod.test_release_after_task_begin.store(true, .release);
@@ -69625,6 +69787,133 @@ test "db delete full text index drains active merge before closing generation" {
         .index_name = "ft_v1",
         .query = .{ .match = .{ .field = "body", .text = "common" } },
     }));
+}
+
+test "db post-delete filter reader does not deadlock behind queued cleanup writer" {
+    if (builtin.single_threaded or builtin.os.tag == .freestanding) return error.SkipZigTest;
+    const alloc = std.testing.allocator;
+    const doc_count: u32 = 40;
+    var path_buf: [256]u8 = undefined;
+    const path = tempPath(&path_buf);
+    defer cleanupTempDir(path);
+
+    {
+        var initial = try DB.open(alloc, std.mem.span(path), .{});
+        defer initial.close();
+        try initial.addIndex(.{ .name = "ft_v1", .kind = .full_text, .config_json = "{}" });
+        var writes = std.ArrayListUnmanaged(types.BatchWrite).empty;
+        defer {
+            for (writes.items) |write| alloc.free(@constCast(write.key));
+            writes.deinit(alloc);
+        }
+        for (0..doc_count) |i| try writes.append(alloc, .{
+            .key = try std.fmt.allocPrint(alloc, "doc:{d:0>3}", .{i}),
+            .value = "{\"state\":\"published\",\"title\":\"catalog item\"}",
+        });
+        try initial.batch(.{ .writes = writes.items, .sync_level = .full_index });
+    }
+
+    var db = try DB.open(alloc, std.mem.span(path), .{});
+    defer db.close();
+    {
+        var warm = try db.search(alloc, .{
+            .filter_query_json = "{\"term\":{\"state\":\"published\"}}",
+            .limit = doc_count,
+        });
+        defer warm.deinit();
+        try std.testing.expectEqual(doc_count, warm.total_hits);
+    }
+    try std.testing.expect(try db.deleteIndex("ft_v1"));
+
+    test_block_match_all_ordinal_lookup.store(true, .release);
+    test_match_all_ordinal_lookup_entered.store(false, .release);
+    test_release_match_all_ordinal_lookup.store(false, .release);
+    defer {
+        test_release_match_all_ordinal_lookup.store(true, .release);
+        test_block_match_all_ordinal_lookup.store(false, .release);
+        test_match_all_ordinal_lookup_entered.store(false, .release);
+    }
+
+    const Reader = struct {
+        db: *DB,
+        total_hits: u32 = 0,
+        completed: std.atomic.Value(bool) = .init(false),
+        err: ?anyerror = null,
+
+        fn run(reader: *@This()) void {
+            var result = reader.db.search(std.heap.smp_allocator, .{
+                .filter_query_json = "{\"term\":{\"state\":\"published\"}}",
+                .limit = doc_count,
+            }) catch |err| {
+                reader.err = err;
+                reader.completed.store(true, .release);
+                return;
+            };
+            defer result.deinit();
+            reader.total_hits = result.total_hits;
+            reader.completed.store(true, .release);
+        }
+    };
+    var reader = Reader{ .db = &db };
+    var reader_thread = try std.Thread.spawn(.{}, Reader.run, .{&reader});
+    var reader_joined = false;
+    defer if (!reader_joined) {
+        test_release_match_all_ordinal_lookup.store(true, .release);
+        reader_thread.join();
+    };
+    var lookup_entered = false;
+    for (0..200_000) |_| {
+        if (test_match_all_ordinal_lookup_entered.load(.acquire)) {
+            lookup_entered = true;
+            break;
+        }
+        std.Thread.yield() catch {};
+    }
+    if (!lookup_entered) return error.TestTimeout;
+
+    const Writer = struct {
+        db: *DB,
+        completed: std.atomic.Value(bool) = .init(false),
+
+        fn run(writer: *@This()) void {
+            lockApply(writer.db);
+            writer.db.core.unlockApply();
+            writer.completed.store(true, .release);
+        }
+    };
+    var writer = Writer{ .db = &db };
+    var writer_thread = try std.Thread.spawn(.{}, Writer.run, .{&writer});
+    var writer_joined = false;
+    defer if (!writer_joined) {
+        test_release_match_all_ordinal_lookup.store(true, .release);
+        writer_thread.join();
+    };
+
+    // Wait until a cleanup-style writer owns the reader gate and is blocked on
+    // the outer query lease. A recursive shared acquisition from the ordinal
+    // callback would now deadlock: it cannot cross the gate, while the writer
+    // cannot pass the lease held by that same query.
+    var writer_queued = false;
+    for (0..200_000) |_| {
+        if (!db.core.tryLockApplyShared()) {
+            writer_queued = true;
+            break;
+        }
+        db.core.unlockApplyShared();
+        std.Thread.yield() catch {};
+    }
+    if (!writer_queued) return error.TestTimeout;
+    try std.testing.expect(!reader.completed.load(.acquire));
+    try std.testing.expect(!writer.completed.load(.acquire));
+
+    test_release_match_all_ordinal_lookup.store(true, .release);
+    reader_thread.join();
+    reader_joined = true;
+    writer_thread.join();
+    writer_joined = true;
+    if (reader.err) |err| return err;
+    try std.testing.expectEqual(doc_count, reader.total_hits);
+    try std.testing.expect(writer.completed.load(.acquire));
 }
 
 test "db delete index persists across reopen with durable lsm primary backend" {

--- a/zig/pkg/antfly/src/storage/db/db.zig
+++ b/zig/pkg/antfly/src/storage/db/db.zig
@@ -3001,6 +3001,7 @@ pub const DB = struct {
     managed_admission_materialization_requested: std.atomic.Value(u64) = .init(0),
     managed_admission_materialization_completed: std.atomic.Value(u64) = .init(0),
     managed_admission_materialization_mutex: std.atomic.Mutex = .unlocked,
+    index_structural_mutation_mutex: std.atomic.Mutex = .unlocked,
     published_dense_searches: std.atomic.Value(u32) = .init(0),
     index_repair_mutex: std.atomic.Mutex = .unlocked,
     generation_replace_mutex: std.atomic.Mutex = .unlocked,
@@ -5374,10 +5375,22 @@ pub const DB = struct {
 
         const merge_effective_req_start_ns = monotonicTimeNs();
 
+        var owned_effective_graph_writes: ?[]types.GraphEdgeWrite = null;
+        defer if (owned_effective_graph_writes) |owned| self.alloc.free(owned);
+        const effective_graph_writes = if (effective_ops.graph_writes.items.len == 0)
+            req.graph_writes
+        else blk: {
+            const combined = try self.alloc.alloc(types.GraphEdgeWrite, req.graph_writes.len + effective_ops.graph_writes.items.len);
+            @memcpy(combined[0..req.graph_writes.len], req.graph_writes);
+            @memcpy(combined[req.graph_writes.len..], effective_ops.graph_writes.items);
+            owned_effective_graph_writes = combined;
+            break :blk combined;
+        };
+
         const effective_req: types.BatchRequest = .{
             .writes = effective_ops.writes,
             .deletes = effective_ops.deletes,
-            .graph_writes = req.graph_writes,
+            .graph_writes = effective_graph_writes,
             .graph_deletes = req.graph_deletes,
             .transforms = &.{},
             .predicates = req.predicates,
@@ -6425,6 +6438,33 @@ pub const DB = struct {
         return desired or started;
     }
 
+    fn quiesceTextMergeForStructuralMutation(self: *DB) bool {
+        const runtime = self.text_merge_runtime orelse return false;
+        return runtime.stop();
+    }
+
+    fn quiesceSparseCompactionForStructuralMutation(self: *DB) bool {
+        const runtime = self.sparse_compaction_runtime orelse return false;
+        return runtime.stop();
+    }
+
+    fn restartTextMergeAfterStructuralMutation(self: *DB, operation: []const u8, index_name: []const u8) void {
+        const runtime = self.text_merge_runtime orelse return;
+        runtime.start() catch |err| {
+            // Index catalog durability is already decided at this point.
+            // Queries and foreground indexing remain available; surface the
+            // maintenance degradation without misreporting the mutation.
+            std.log.err("failed to restart text merge runtime after {s} index={s} err={s}", .{ operation, index_name, @errorName(err) });
+        };
+    }
+
+    fn restartSparseCompactionAfterStructuralMutation(self: *DB, operation: []const u8, index_name: []const u8) void {
+        const runtime = self.sparse_compaction_runtime orelse return;
+        runtime.start() catch |err| {
+            std.log.err("failed to restart sparse compaction runtime after {s} index={s} err={s}", .{ operation, index_name, @errorName(err) });
+        };
+    }
+
     fn scheduleGeneratedArtifactCleanup(self: *DB) void {
         scheduleGeneratedArtifactCleanupContext(
             self.async_context,
@@ -6642,6 +6682,7 @@ pub const DB = struct {
             entries: []Entry = &.{},
             writes: []T = &.{},
             deletes: [][]const u8 = &.{},
+            graph_writes: std.ArrayListUnmanaged(types.GraphEdgeWrite) = .empty,
 
             fn deinit(self: *@This(), alloc: Allocator) void {
                 for (self.entries) |entry| {
@@ -6651,9 +6692,67 @@ pub const DB = struct {
                 if (self.entries.len > 0) alloc.free(self.entries);
                 if (self.writes.len > 0) alloc.free(self.writes);
                 if (self.deletes.len > 0) alloc.free(self.deletes);
+                for (self.graph_writes.items) |*write| deinitOwnedGraphEdgeWrite(alloc, write);
+                self.graph_writes.deinit(alloc);
                 self.* = .{};
             }
         };
+    }
+
+    fn deinitOwnedGraphEdgeWrite(alloc: Allocator, write: *types.GraphEdgeWrite) void {
+        alloc.free(@constCast(write.index_name));
+        alloc.free(@constCast(write.source));
+        alloc.free(@constCast(write.target));
+        alloc.free(@constCast(write.edge_type));
+        if (write.metadata_json.len > 0) alloc.free(@constCast(write.metadata_json));
+        write.* = undefined;
+    }
+
+    fn appendGraphTransformWrite(
+        self: *DB,
+        writes: *std.ArrayListUnmanaged(types.GraphEdgeWrite),
+        source: []const u8,
+        path: transform_mod.GraphProjectionPath,
+        value_json: []const u8,
+    ) !void {
+        var parsed = try std.json.parseFromSlice(std.json.Value, self.alloc, value_json, .{});
+        defer parsed.deinit();
+        if (parsed.value != .object) return error.InvalidGraphEdges;
+
+        const target_value = parsed.value.object.get("target") orelse return error.InvalidGraphEdges;
+        if (target_value != .string or target_value.string.len == 0) return error.InvalidGraphEdges;
+
+        const weight: f64 = if (parsed.value.object.get("weight")) |value| switch (value) {
+            .integer => |integer| @floatFromInt(integer),
+            .float => |float| float,
+            .number_string => |number| try std.fmt.parseFloat(f64, number),
+            else => return error.InvalidGraphEdges,
+        } else 1.0;
+        if (!std.math.isFinite(weight)) return error.InvalidGraphEdges;
+
+        const metadata_json: []const u8 = if (parsed.value.object.get("metadata")) |metadata|
+            try std.json.Stringify.valueAlloc(self.alloc, metadata, .{})
+        else
+            "";
+        errdefer if (metadata_json.len > 0) self.alloc.free(@constCast(metadata_json));
+
+        const index_name = try self.alloc.dupe(u8, path.index_name);
+        errdefer self.alloc.free(index_name);
+        const owned_source = try self.alloc.dupe(u8, source);
+        errdefer self.alloc.free(owned_source);
+        const target = try self.alloc.dupe(u8, target_value.string);
+        errdefer self.alloc.free(target);
+        const edge_type = try self.alloc.dupe(u8, path.edge_type);
+        errdefer self.alloc.free(edge_type);
+
+        try writes.append(self.alloc, .{
+            .index_name = index_name,
+            .source = owned_source,
+            .target = target,
+            .edge_type = edge_type,
+            .weight = weight,
+            .metadata_json = metadata_json,
+        });
     }
 
     const BulkIngestCoalescer = struct {
@@ -6915,13 +7014,16 @@ pub const DB = struct {
     ) !CoalescedKeyValueRequest(T) {
         var result = CoalescedKeyValueRequest(T){};
         var order = std.ArrayListUnmanaged(CoalescedKeyValueRequest(T).Entry).empty;
+        defer order.deinit(self.alloc);
+        var entries_transferred = false;
         errdefer {
-            result.entries = order.items;
-            order.items = &.{};
-            order.capacity = 0;
+            if (!entries_transferred) {
+                result.entries = order.items;
+                order.items = &.{};
+                order.capacity = 0;
+            }
             result.deinit(self.alloc);
         }
-        defer order.deinit(self.alloc);
 
         var positions = std.StringHashMapUnmanaged(usize){};
         defer positions.deinit(self.alloc);
@@ -6972,30 +7074,87 @@ pub const DB = struct {
                 if (base_json) |body| self.alloc.free(body);
             };
 
-            const resolved = try transform_mod.resolveDocumentTransform(self.alloc, base_json, transform) orelse {
-                if (maybe_index == null) continue;
-                const entry = order.items[maybe_index.?];
-                if (entry.kind == .delete) continue;
-                continue;
+            var document_operations = std.ArrayListUnmanaged(types.TransformOp).empty;
+            defer document_operations.deinit(self.alloc);
+            var graph_operations = std.ArrayListUnmanaged(struct {
+                path: transform_mod.GraphProjectionPath,
+                value_json: []const u8,
+            }).empty;
+            defer graph_operations.deinit(self.alloc);
+            for (transform.operations) |operation| {
+                const graph_path = try transform_mod.graphProjectionPath(operation.path);
+                if (graph_path) |path| {
+                    switch (operation.op) {
+                        .push, .add_to_set => {},
+                        else => return error.UnsupportedTransformOperation,
+                    }
+                    try graph_operations.append(self.alloc, .{
+                        .path = path,
+                        .value_json = operation.value_json orelse return error.InvalidArgument,
+                    });
+                } else {
+                    try document_operations.append(self.alloc, operation);
+                }
+            }
+
+            const graph_writes_start = result.graph_writes.items.len;
+            for (graph_operations.items) |operation| {
+                try self.appendGraphTransformWrite(
+                    &result.graph_writes,
+                    transform.key,
+                    operation.path,
+                    operation.value_json,
+                );
+            }
+
+            const document_transform: types.DocumentTransform = .{
+                .key = transform.key,
+                .operations = document_operations.items,
+                .upsert = transform.upsert,
             };
-            errdefer self.alloc.free(resolved);
+
+            // A non-upsert transform against an absent (or same-batch deleted)
+            // document is a no-op, but malformed document operations remain
+            // errors independent of state. Graph operands were validated while
+            // constructing their pending deltas above.
+            if (base_json == null and !transform.upsert) {
+                try transform_mod.validateDocumentTransform(self.alloc, document_transform);
+                for (result.graph_writes.items[graph_writes_start..]) |*write| {
+                    deinitOwnedGraphEdgeWrite(self.alloc, write);
+                }
+                result.graph_writes.shrinkRetainingCapacity(graph_writes_start);
+                continue;
+            }
+
+            // Even a graph-only transform remains a logical document write:
+            // preserve source version/timestamp and change-journal semantics
+            // while applying the projected edge as a delta. The mapper sees
+            // the unchanged stripped document and therefore does not clear
+            // the graph generation.
+            const resolved = try transform_mod.resolveDocumentTransform(self.alloc, base_json, document_transform);
+
+            const resolved_document = resolved orelse continue;
+            var resolved_document_owned = true;
+            defer if (resolved_document_owned) self.alloc.free(resolved_document);
 
             const gop = try positions.getOrPut(self.alloc, transform.key);
             if (!gop.found_existing) {
                 gop.value_ptr.* = order.items.len;
                 try order.append(self.alloc, .{
                     .key = try self.alloc.dupe(u8, transform.key),
-                    .value = resolved,
+                    .value = resolved_document,
                     .kind = .write,
                     .owned_key = true,
                     .owned_value = true,
                 });
+                resolved_document_owned = false;
                 continue;
             }
 
             const entry = &order.items[gop.value_ptr.*];
             if (entry.owned_value) self.alloc.free(@constCast(entry.value.?));
-            try setCoalescedEntryToOwnedWrite(T, self.alloc, entry, transform.key, resolved);
+            try setCoalescedEntryToOwnedWrite(T, self.alloc, entry, transform.key, resolved_document);
+            resolved_document_owned = false;
         }
 
         var write_count: usize = 0;
@@ -7009,6 +7168,7 @@ pub const DB = struct {
 
         const final_entries = try order.toOwnedSlice(self.alloc);
         result.entries = final_entries;
+        entries_transferred = true;
         if (write_count > 0) result.writes = try self.alloc.alloc(T, write_count);
         if (delete_count > 0) result.deletes = try self.alloc.alloc([]const u8, delete_count);
 
@@ -13248,6 +13408,11 @@ pub const DB = struct {
     pub fn writeTransaction(self: *DB, txn_id: types.TxnId, req: types.TransactionIntentRequest) !void {
         var effective_ops = try coalesceKeyValueRequest(self, types.TransactionWrite, req.writes, req.deletes, req.transforms);
         defer effective_ops.deinit(self.alloc);
+        // Graph projections are maintained as artifact deltas, while the
+        // transaction intent format currently carries only primary key/value
+        // rows. Refuse this combination rather than acknowledging a transform
+        // whose graph half cannot participate in the transaction commit.
+        if (effective_ops.graph_writes.items.len != 0) return error.UnsupportedTransformOperation;
 
         var intents = std.ArrayListUnmanaged(transactions_mod.WriteIntent).empty;
         defer intents.deinit(self.alloc);
@@ -14023,11 +14188,17 @@ pub const DB = struct {
 
     fn addIndexWithAdmission(self: *DB, cfg: types.IndexConfig, admission_mode: IndexAdmissionMode) !?u128 {
         if (openModeRequiresReadOnlyBackends(self.open_mode)) return error.ReadOnly;
+        lockAtomicWithBackoff(&self.index_structural_mutation_mutex);
+        defer self.index_structural_mutation_mutex.unlock();
         // Generated artifact namespaces can be shared across differently named
         // indexes. Cleanup is durable and owner-driven; never turn index
         // admission into an unbounded corpus scan. Metadata reconciliation can
         // retry after the conflicting generation's tombstone is retired.
         try self.rejectConflictingRetiredIndexCleanupForAdmission(cfg);
+        const restart_text_merge = self.quiesceTextMergeForStructuralMutation();
+        defer if (restart_text_merge) self.restartTextMergeAfterStructuralMutation("index creation", cfg.name);
+        const restart_sparse_compaction = self.quiesceSparseCompactionForStructuralMutation();
+        defer if (restart_sparse_compaction) self.restartSparseCompactionAfterStructuralMutation("index creation", cfg.name);
         const restart_enrichment = self.quiesceEnrichmentForStructuralMutation();
         var enrichment_restarted = false;
         errdefer if (restart_enrichment and !enrichment_restarted) {
@@ -15288,6 +15459,12 @@ pub const DB = struct {
 
     pub fn deleteIndex(self: *DB, name: []const u8) !bool {
         if (openModeRequiresReadOnlyBackends(self.open_mode)) return error.ReadOnly;
+        lockAtomicWithBackoff(&self.index_structural_mutation_mutex);
+        defer self.index_structural_mutation_mutex.unlock();
+        const restart_text_merge = self.quiesceTextMergeForStructuralMutation();
+        defer if (restart_text_merge) self.restartTextMergeAfterStructuralMutation("index deletion", name);
+        const restart_sparse_compaction = self.quiesceSparseCompactionForStructuralMutation();
+        defer if (restart_sparse_compaction) self.restartSparseCompactionAfterStructuralMutation("index deletion", name);
         const restart_enrichment = self.quiesceEnrichmentForStructuralMutation();
         const removed = self.deleteIndexWhileEnrichmentQuiesced(name) catch |delete_err| {
             if (restart_enrichment) self.restartEnrichmentAfterStructuralMutation("failed index deletion", name) catch |restart_err| {
@@ -69359,6 +69536,97 @@ test "db delete index persists across reopen" {
     }
 }
 
+test "db delete full text index drains active merge before closing generation" {
+    const alloc = std.testing.allocator;
+    var path_buf: [256]u8 = undefined;
+    const path = tempPath(&path_buf);
+    defer cleanupTempDir(path);
+
+    var db = try DB.open(alloc, std.mem.span(path), .{
+        .text_merge = .{
+            .enabled = true,
+            .idle_interval_ms = 1,
+            .error_interval_ms = 1,
+        },
+    });
+    defer db.close();
+    try db.addIndex(.{ .name = "ft_v1", .kind = .full_text, .config_json = "{}" });
+
+    try db.beginBulkIngestSession();
+    errdefer db.abortBulkIngestSession();
+    for (0..12) |i| {
+        const key = try std.fmt.allocPrint(alloc, "doc:{d}", .{i});
+        defer alloc.free(key);
+        const value = try std.fmt.allocPrint(alloc, "{{\"body\":\"common token {d}\"}}", .{i});
+        defer alloc.free(value);
+        try db.batch(.{
+            .writes = &.{.{ .key = key, .value = value }},
+            .sync_level = .full_text,
+        });
+    }
+
+    text_merge_runtime_mod.test_task_begin_entered.store(false, .release);
+    text_merge_runtime_mod.test_release_after_task_begin.store(false, .release);
+    text_merge_runtime_mod.test_block_after_task_begin.store(true, .release);
+    defer {
+        text_merge_runtime_mod.test_release_after_task_begin.store(true, .release);
+        text_merge_runtime_mod.test_block_after_task_begin.store(false, .release);
+    }
+    try db.finishBulkIngestSessionWithOptions(.{ .compact = false });
+
+    var merge_started = false;
+    for (0..200_000) |_| {
+        if (text_merge_runtime_mod.test_task_begin_entered.load(.acquire)) {
+            merge_started = true;
+            break;
+        }
+        std.Thread.yield() catch {};
+    }
+    if (!merge_started) return error.TestTimeout;
+
+    const Delete = struct {
+        db: *DB,
+        completed: std.atomic.Value(bool) = .init(false),
+        removed: bool = false,
+        err: ?anyerror = null,
+
+        fn run(self: *@This()) void {
+            self.removed = self.db.deleteIndex("ft_v1") catch |err| {
+                self.err = err;
+                self.completed.store(true, .release);
+                return;
+            };
+            self.completed.store(true, .release);
+        }
+    };
+    var deletion = Delete{ .db = &db };
+    var delete_thread = try std.Thread.spawn(.{}, Delete.run, .{&deletion});
+    var joined = false;
+    defer if (!joined) {
+        text_merge_runtime_mod.test_release_after_task_begin.store(true, .release);
+        delete_thread.join();
+    };
+
+    // Deletion must wait for the task that borrowed the index runtime; it may
+    // not acknowledge catalog removal and close storage underneath that task.
+    for (0..512) |_| std.Thread.yield() catch {};
+    try std.testing.expect(!deletion.completed.load(.acquire));
+
+    text_merge_runtime_mod.test_release_after_task_begin.store(true, .release);
+    delete_thread.join();
+    joined = true;
+    try std.testing.expect(deletion.err == null);
+    try std.testing.expect(deletion.removed);
+
+    const source_doc = (try db.get(alloc, "doc:0")) orelse return error.TestExpectedEqual;
+    defer alloc.free(source_doc);
+    try std.testing.expect(std.mem.indexOf(u8, source_doc, "common token") != null);
+    try std.testing.expectError(error.IndexNotFound, db.search(alloc, .{
+        .index_name = "ft_v1",
+        .query = .{ .match = .{ .field = "body", .text = "common" } },
+    }));
+}
+
 test "db delete index persists across reopen with durable lsm primary backend" {
     const alloc = std.testing.allocator;
 
@@ -73757,6 +74025,110 @@ test "db batch resolves transforms against pending same-batch writes" {
         else => return error.TestExpectedEqual,
     }
     try std.testing.expectEqual(@as(usize, 2), parsed.value.object.get("tags").?.array.items.len);
+}
+
+test "db graph push transform appends projected edge across restart" {
+    const alloc = std.testing.allocator;
+
+    var path_buf: [256]u8 = undefined;
+    const path = tempPath(&path_buf);
+    defer cleanupTempDir(path);
+
+    {
+        var db = try DB.open(alloc, std.mem.span(path), .{});
+        defer db.close();
+
+        try db.addIndex(.{
+            .name = "graph",
+            .kind = .graph,
+            .config_json = "{}",
+        });
+        try db.batch(.{
+            .writes = &.{
+                .{ .key = "a", .value = "{\"title\":\"A\",\"_edges\":{\"graph\":{\"FRIEND\":[{\"target\":\"b\",\"weight\":2,\"metadata\":{\"since\":2024}}]}}}" },
+                .{ .key = "b", .value = "{\"title\":\"B\"}" },
+                .{ .key = "c", .value = "{\"title\":\"C\"}" },
+            },
+            .sync_level = .full_index,
+        });
+
+        try db.batch(.{
+            .transforms = &.{.{
+                .key = "a",
+                .operations = &.{
+                    .{ .op = .push, .path = "$._edges.graph.FRIEND", .value_json = "{\"target\":\"c\",\"weight\":3}" },
+                    .{ .op = .set, .path = "title", .value_json = "\"A updated\"" },
+                },
+            }},
+            .sync_level = .full_index,
+        });
+
+        const stored = (try db.get(alloc, "a")) orelse return error.TestExpectedEqual;
+        defer alloc.free(stored);
+        try std.testing.expect(std.mem.indexOf(u8, stored, "A updated") != null);
+
+        const edges = try db.getEdges(alloc, "graph", "a", "FRIEND", .out);
+        defer graph_mod.GraphIndex.freeEdges(alloc, edges);
+        try std.testing.expectEqual(@as(usize, 2), edges.len);
+        var saw_b = false;
+        var saw_c = false;
+        for (edges) |edge| {
+            if (std.mem.eql(u8, edge.target, "b")) {
+                saw_b = true;
+                try std.testing.expectEqual(@as(f64, 2), edge.weight);
+                try std.testing.expect(std.mem.indexOf(u8, edge.metadata, "2024") != null);
+            }
+            if (std.mem.eql(u8, edge.target, "c")) {
+                saw_c = true;
+                try std.testing.expectEqual(@as(f64, 3), edge.weight);
+            }
+        }
+        try std.testing.expect(saw_b and saw_c);
+    }
+
+    var reopened = try DB.open(alloc, std.mem.span(path), .{});
+    defer reopened.close();
+    const reopened_edges = try reopened.getEdges(alloc, "graph", "a", "FRIEND", .out);
+    defer graph_mod.GraphIndex.freeEdges(alloc, reopened_edges);
+    try std.testing.expectEqual(@as(usize, 2), reopened_edges.len);
+}
+
+test "db graph transforms fail closed for replacement operations" {
+    const alloc = std.testing.allocator;
+    var path_buf: [256]u8 = undefined;
+    const path = tempPath(&path_buf);
+    defer cleanupTempDir(path);
+
+    var db = try DB.open(alloc, std.mem.span(path), .{});
+    defer db.close();
+    try db.addIndex(.{ .name = "graph", .kind = .graph, .config_json = "{}" });
+    try db.batch(.{
+        .writes = &.{.{ .key = "a", .value = "{\"title\":\"A\",\"_edges\":{\"graph\":{\"FRIEND\":[{\"target\":\"b\"}]}}}" }},
+        .sync_level = .full_index,
+    });
+
+    try std.testing.expectError(error.UnsupportedTransformOperation, db.batch(.{
+        .transforms = &.{.{
+            .key = "a",
+            .operations = &.{.{ .op = .set, .path = "$._edges.graph.FRIEND", .value_json = "[]" }},
+        }},
+        .sync_level = .full_index,
+    }));
+
+    // Validation is state-independent: an invalid projected edge cannot be
+    // acknowledged as a no-op just because its source document is absent.
+    try std.testing.expectError(error.InvalidGraphEdges, db.batch(.{
+        .transforms = &.{.{
+            .key = "missing",
+            .operations = &.{.{ .op = .push, .path = "$._edges.graph.FRIEND", .value_json = "{\"weight\":2}" }},
+        }},
+        .sync_level = .full_index,
+    }));
+
+    const edges = try db.getEdges(alloc, "graph", "a", "FRIEND", .out);
+    defer graph_mod.GraphIndex.freeEdges(alloc, edges);
+    try std.testing.expectEqual(@as(usize, 1), edges.len);
+    try std.testing.expectEqualStrings("b", edges[0].target);
 }
 
 test "db batch keeps delete when same-batch transform targets deleted key" {

--- a/zig/pkg/antfly/src/storage/db/maintenance/sparse_compaction_runtime.zig
+++ b/zig/pkg/antfly/src/storage/db/maintenance/sparse_compaction_runtime.zig
@@ -28,6 +28,8 @@ pub const Config = struct {
     clock: platform_clock.Clock = platform_clock.Clock.real(),
 };
 
+pub var test_start_failures_remaining: std.atomic.Value(u32) = .init(0);
+
 pub const SparseCompactionRuntime = if (builtin.os.tag == .freestanding) struct {
     config: Config,
 
@@ -53,6 +55,20 @@ pub const SparseCompactionRuntime = if (builtin.os.tag == .freestanding) struct 
         return false;
     }
 
+    pub fn pause(_: *@This()) bool {
+        return false;
+    }
+
+    pub fn resumeAfterPause(_: *@This()) !void {}
+
+    pub fn ensureRunning(_: *@This()) !bool {
+        return true;
+    }
+
+    pub fn isStarted(_: *const @This()) bool {
+        return false;
+    }
+
     pub fn notify(self: *@This()) void {
         _ = self;
     }
@@ -70,6 +86,8 @@ pub const SparseCompactionRuntime = if (builtin.os.tag == .freestanding) struct 
     mutex: Io.Mutex = .init,
     cond: Io.Condition = .init,
     lifecycle_mutex: std.atomic.Mutex = .unlocked,
+    desired_running: bool = false,
+    paused: bool = false,
     shutdown: bool = false,
     notified: bool = false,
     future: ?Io.Future(void) = null,
@@ -101,9 +119,59 @@ pub const SparseCompactionRuntime = if (builtin.os.tag == .freestanding) struct 
         if (!self.config.enabled) return;
         lockAtomicWithBackoff(&self.lifecycle_mutex);
         defer self.lifecycle_mutex.unlock();
-        if (self.future != null) return;
+        self.desired_running = true;
+        self.paused = false;
+        try self.startLocked();
+    }
+
+    pub fn stop(self: *SparseCompactionRuntime) bool {
+        if (!self.config.enabled) return false;
+        lockAtomicWithBackoff(&self.lifecycle_mutex);
+        defer self.lifecycle_mutex.unlock();
+        self.desired_running = false;
+        self.paused = true;
+        return self.stopLocked();
+    }
+
+    pub fn pause(self: *SparseCompactionRuntime) bool {
+        if (!self.config.enabled) return false;
+        lockAtomicWithBackoff(&self.lifecycle_mutex);
+        defer self.lifecycle_mutex.unlock();
+        self.paused = true;
+        const desired = self.desired_running;
+        _ = self.stopLocked();
+        return desired;
+    }
+
+    pub fn resumeAfterPause(self: *SparseCompactionRuntime) !void {
+        if (!self.config.enabled) return;
+        lockAtomicWithBackoff(&self.lifecycle_mutex);
+        defer self.lifecycle_mutex.unlock();
+        self.paused = false;
+        if (self.desired_running) try self.startLocked();
+    }
+
+    pub fn ensureRunning(self: *SparseCompactionRuntime) !bool {
+        if (!self.config.enabled) return true;
+        lockAtomicWithBackoff(&self.lifecycle_mutex);
+        defer self.lifecycle_mutex.unlock();
+        if (!self.desired_running) return true;
+        if (self.paused) return false;
+        try self.startLocked();
+        return true;
+    }
+
+    pub fn isStarted(self: *SparseCompactionRuntime) bool {
+        lockAtomicWithBackoff(&self.lifecycle_mutex);
+        defer self.lifecycle_mutex.unlock();
+        return self.future != null;
+    }
+
+    fn startLocked(self: *SparseCompactionRuntime) !void {
+        if (self.future != null or self.paused or !self.desired_running) return;
         const io_impl = self.io_impl orelse return error.MissingBackendRuntimeIo;
         const io = io_impl.io();
+        if (builtin.is_test and consumeTestStartFailure()) return error.TestTransientMaintenanceRestart;
         self.mutex.lockUncancelable(io);
         self.shutdown = false;
         self.notified = true;
@@ -111,10 +179,7 @@ pub const SparseCompactionRuntime = if (builtin.os.tag == .freestanding) struct 
         self.future = try io.concurrent(workerMain, .{self});
     }
 
-    pub fn stop(self: *SparseCompactionRuntime) bool {
-        if (!self.config.enabled) return false;
-        lockAtomicWithBackoff(&self.lifecycle_mutex);
-        defer self.lifecycle_mutex.unlock();
+    fn stopLocked(self: *SparseCompactionRuntime) bool {
         const io_impl = self.io_impl orelse return false;
         const io = io_impl.io();
         if (self.future == null) return false;
@@ -244,4 +309,21 @@ fn lockApplyExclusive(lock: *apply_rw_lock_mod.ApplyRwLock) void {
 
 fn lockAtomicWithBackoff(mutex: *std.atomic.Mutex) void {
     while (!mutex.tryLock()) std.Thread.yield() catch {};
+}
+
+fn consumeTestStartFailure() bool {
+    var remaining = test_start_failures_remaining.load(.acquire);
+    while (remaining != 0) {
+        if (test_start_failures_remaining.cmpxchgWeak(
+            remaining,
+            remaining - 1,
+            .acq_rel,
+            .acquire,
+        )) |actual| {
+            remaining = actual;
+            continue;
+        }
+        return true;
+    }
+    return false;
 }

--- a/zig/pkg/antfly/src/storage/db/maintenance/sparse_compaction_runtime.zig
+++ b/zig/pkg/antfly/src/storage/db/maintenance/sparse_compaction_runtime.zig
@@ -49,6 +49,10 @@ pub const SparseCompactionRuntime = if (builtin.os.tag == .freestanding) struct 
         if (self.config.enabled) return error.UnsupportedPlatform;
     }
 
+    pub fn stop(_: *@This()) bool {
+        return false;
+    }
+
     pub fn notify(self: *@This()) void {
         _ = self;
     }
@@ -65,6 +69,7 @@ pub const SparseCompactionRuntime = if (builtin.os.tag == .freestanding) struct 
     config: Config,
     mutex: Io.Mutex = .init,
     cond: Io.Condition = .init,
+    lifecycle_mutex: std.atomic.Mutex = .unlocked,
     shutdown: bool = false,
     notified: bool = false,
     future: ?Io.Future(void) = null,
@@ -88,24 +93,41 @@ pub const SparseCompactionRuntime = if (builtin.os.tag == .freestanding) struct 
     }
 
     pub fn deinit(self: *SparseCompactionRuntime) void {
-        if (self.io_impl) |io_impl| {
-            const io = io_impl.io();
-            self.mutex.lockUncancelable(io);
-            self.shutdown = true;
-            self.notified = true;
-            self.cond.broadcast(io);
-            self.mutex.unlock(io);
-
-            if (self.future) |*future| _ = future.await(io);
-        }
-        self.future = null;
+        _ = self.stop();
         self.* = undefined;
     }
 
     pub fn start(self: *SparseCompactionRuntime) !void {
         if (!self.config.enabled) return;
+        lockAtomicWithBackoff(&self.lifecycle_mutex);
+        defer self.lifecycle_mutex.unlock();
+        if (self.future != null) return;
         const io_impl = self.io_impl orelse return error.MissingBackendRuntimeIo;
-        self.future = try io_impl.io().concurrent(workerMain, .{self});
+        const io = io_impl.io();
+        self.mutex.lockUncancelable(io);
+        self.shutdown = false;
+        self.notified = true;
+        self.mutex.unlock(io);
+        self.future = try io.concurrent(workerMain, .{self});
+    }
+
+    pub fn stop(self: *SparseCompactionRuntime) bool {
+        if (!self.config.enabled) return false;
+        lockAtomicWithBackoff(&self.lifecycle_mutex);
+        defer self.lifecycle_mutex.unlock();
+        const io_impl = self.io_impl orelse return false;
+        const io = io_impl.io();
+        if (self.future == null) return false;
+
+        self.mutex.lockUncancelable(io);
+        self.shutdown = true;
+        self.notified = true;
+        self.cond.broadcast(io);
+        self.mutex.unlock(io);
+
+        _ = self.future.?.await(io);
+        self.future = null;
+        return true;
     }
 
     pub fn notify(self: *SparseCompactionRuntime) void {
@@ -139,7 +161,9 @@ pub const SparseCompactionRuntime = if (builtin.os.tag == .freestanding) struct 
         };
         defer result.deinit(work_alloc);
 
-        if (!lockApplyExclusiveBackoff(self)) return false;
+        // A started task must retire before structural mutation can close its
+        // generation. The stopper waits without holding the apply lock.
+        lockApplyExclusive(self.apply_mutex);
         defer self.apply_mutex.unlockExclusive();
         _ = try self.index_manager.finishSparseCompactionTask(&task, &result);
         return true;
@@ -212,4 +236,12 @@ fn lockApplyExclusiveBackoff(runtime: *SparseCompactionRuntime) bool {
         sleepMs(runtime, 1);
     }
     return true;
+}
+
+fn lockApplyExclusive(lock: *apply_rw_lock_mod.ApplyRwLock) void {
+    lock.lockExclusive();
+}
+
+fn lockAtomicWithBackoff(mutex: *std.atomic.Mutex) void {
+    while (!mutex.tryLock()) std.Thread.yield() catch {};
 }

--- a/zig/pkg/antfly/src/storage/db/maintenance/text_merge_runtime.zig
+++ b/zig/pkg/antfly/src/storage/db/maintenance/text_merge_runtime.zig
@@ -33,6 +33,10 @@ pub const Config = struct {
     clock: platform_clock.Clock = platform_clock.Clock.real(),
 };
 
+pub var test_block_after_task_begin: std.atomic.Value(bool) = .init(false);
+pub var test_task_begin_entered: std.atomic.Value(bool) = .init(false);
+pub var test_release_after_task_begin: std.atomic.Value(bool) = .init(false);
+
 pub const TextMergeRuntime = if (builtin.os.tag == .freestanding) struct {
     config: Config,
     defer_flag: ?*const std.atomic.Value(bool),
@@ -57,6 +61,10 @@ pub const TextMergeRuntime = if (builtin.os.tag == .freestanding) struct {
 
     pub fn start(self: *@This()) !void {
         if (self.config.enabled) return error.UnsupportedPlatform;
+    }
+
+    pub fn stop(_: *@This()) bool {
+        return false;
     }
 
     pub fn notify(self: *@This()) void {
@@ -92,6 +100,7 @@ pub const TextMergeRuntime = if (builtin.os.tag == .freestanding) struct {
     config: Config,
     mutex: Io.Mutex = .init,
     cond: Io.Condition = .init,
+    lifecycle_mutex: std.atomic.Mutex = .unlocked,
     shutdown: bool = false,
     notified: bool = false,
     backpressure_events: u64 = 0,
@@ -119,25 +128,44 @@ pub const TextMergeRuntime = if (builtin.os.tag == .freestanding) struct {
     }
 
     pub fn deinit(self: *TextMergeRuntime) void {
-        if (self.io_impl) |io_impl| {
-            const io = io_impl.io();
-            self.mutex.lockUncancelable(io);
-            self.shutdown = true;
-            self.notified = true;
-            self.cond.broadcast(io);
-            self.mutex.unlock(io);
-
-            if (self.future) |*future| _ = future.await(io);
-        }
-        self.future = null;
+        _ = self.stop();
         self.* = undefined;
     }
 
     pub fn start(self: *TextMergeRuntime) !void {
         if (!self.config.enabled) return;
+        lockAtomicWithBackoff(&self.lifecycle_mutex);
+        defer self.lifecycle_mutex.unlock();
+        if (self.future != null) return;
         const io_impl = self.io_impl orelse return error.MissingBackendRuntimeIo;
         const io = io_impl.io();
+        self.mutex.lockUncancelable(io);
+        self.shutdown = false;
+        self.notified = true;
+        self.mutex.unlock(io);
         self.future = try io.concurrent(workerMain, .{self});
+    }
+
+    /// Gracefully drains the active merge, if any, and stops the worker.
+    /// Structural catalog mutations call this before moving or closing an
+    /// inline index runtime, so no task can retain a pointer across mutation.
+    pub fn stop(self: *TextMergeRuntime) bool {
+        if (!self.config.enabled) return false;
+        lockAtomicWithBackoff(&self.lifecycle_mutex);
+        defer self.lifecycle_mutex.unlock();
+        const io_impl = self.io_impl orelse return false;
+        const io = io_impl.io();
+        if (self.future == null) return false;
+
+        self.mutex.lockUncancelable(io);
+        self.shutdown = true;
+        self.notified = true;
+        self.cond.broadcast(io);
+        self.mutex.unlock(io);
+
+        _ = self.future.?.await(io);
+        self.future = null;
+        return true;
     }
 
     pub fn notify(self: *TextMergeRuntime) void {
@@ -164,8 +192,17 @@ pub const TextMergeRuntime = if (builtin.os.tag == .freestanding) struct {
         const work_alloc = self.index_manager.alloc;
         defer task.deinit(work_alloc);
 
+        if (builtin.is_test and test_block_after_task_begin.load(.acquire)) {
+            test_task_begin_entered.store(true, .release);
+            while (!test_release_after_task_begin.load(.acquire)) std.Thread.yield() catch {};
+        }
+
         var result = index_manager_mod.IndexManager.executeTextMergeTask(work_alloc, &task) catch |err| {
-            if (!lockApplyExclusiveBackoff(self)) return false;
+            // Once a task has borrowed an index runtime it must retire its
+            // scheduler state before a graceful stop can complete. Structural
+            // mutation waits for stop before taking the apply lock, so this
+            // acquisition cannot form a shutdown lock cycle.
+            lockApplyExclusive(self.apply_mutex);
             if (err == error.ResourceBudgetExceeded) {
                 self.index_manager.cancelTextMergeTask(&task);
                 self.apply_mutex.unlockExclusive();
@@ -177,7 +214,7 @@ pub const TextMergeRuntime = if (builtin.os.tag == .freestanding) struct {
         };
         defer result.deinit(work_alloc);
 
-        if (!lockApplyExclusiveBackoff(self)) return false;
+        lockApplyExclusive(self.apply_mutex);
         defer self.apply_mutex.unlockExclusive();
         _ = self.index_manager.finishTextMergeTask(&task, &result) catch |err| {
             self.index_manager.noteTextMergeFailure(&task, err);
@@ -317,12 +354,8 @@ fn lockApplyExclusive(lock: *apply_rw_lock_mod.ApplyRwLock) void {
     lock.lockExclusive();
 }
 
-fn lockApplyExclusiveBackoff(runtime: *TextMergeRuntime) bool {
-    while (!runtime.apply_mutex.tryLockExclusive()) {
-        if (isShutdown(runtime)) return false;
-        sleepMs(runtime, 1);
-    }
-    return true;
+fn lockAtomicWithBackoff(mutex: *std.atomic.Mutex) void {
+    while (!mutex.tryLock()) std.Thread.yield() catch {};
 }
 
 fn lockApplyShared(lock: *apply_rw_lock_mod.ApplyRwLock) void {

--- a/zig/pkg/antfly/src/storage/db/maintenance/text_merge_runtime.zig
+++ b/zig/pkg/antfly/src/storage/db/maintenance/text_merge_runtime.zig
@@ -37,6 +37,7 @@ pub var test_block_after_task_begin: std.atomic.Value(bool) = .init(false);
 pub var test_task_begin_entered: std.atomic.Value(bool) = .init(false);
 pub var test_release_after_task_begin: std.atomic.Value(bool) = .init(false);
 pub var test_stop_entered: std.atomic.Value(bool) = .init(false);
+pub var test_start_failures_remaining: std.atomic.Value(u32) = .init(0);
 
 pub const TextMergeRuntime = if (builtin.os.tag == .freestanding) struct {
     config: Config,
@@ -65,6 +66,20 @@ pub const TextMergeRuntime = if (builtin.os.tag == .freestanding) struct {
     }
 
     pub fn stop(_: *@This()) bool {
+        return false;
+    }
+
+    pub fn pause(_: *@This()) bool {
+        return false;
+    }
+
+    pub fn resumeAfterPause(_: *@This()) !void {}
+
+    pub fn ensureRunning(_: *@This()) !bool {
+        return true;
+    }
+
+    pub fn isStarted(_: *const @This()) bool {
         return false;
     }
 
@@ -102,6 +117,8 @@ pub const TextMergeRuntime = if (builtin.os.tag == .freestanding) struct {
     mutex: Io.Mutex = .init,
     cond: Io.Condition = .init,
     lifecycle_mutex: std.atomic.Mutex = .unlocked,
+    desired_running: bool = false,
+    paused: bool = false,
     shutdown: bool = false,
     notified: bool = false,
     backpressure_events: u64 = 0,
@@ -137,14 +154,9 @@ pub const TextMergeRuntime = if (builtin.os.tag == .freestanding) struct {
         if (!self.config.enabled) return;
         lockAtomicWithBackoff(&self.lifecycle_mutex);
         defer self.lifecycle_mutex.unlock();
-        if (self.future != null) return;
-        const io_impl = self.io_impl orelse return error.MissingBackendRuntimeIo;
-        const io = io_impl.io();
-        self.mutex.lockUncancelable(io);
-        self.shutdown = false;
-        self.notified = true;
-        self.mutex.unlock(io);
-        self.future = try io.concurrent(workerMain, .{self});
+        self.desired_running = true;
+        self.paused = false;
+        try self.startLocked();
     }
 
     /// Gracefully drains the active merge, if any, and stops the worker.
@@ -154,6 +166,64 @@ pub const TextMergeRuntime = if (builtin.os.tag == .freestanding) struct {
         if (!self.config.enabled) return false;
         lockAtomicWithBackoff(&self.lifecycle_mutex);
         defer self.lifecycle_mutex.unlock();
+        self.desired_running = false;
+        self.paused = true;
+        return self.stopLocked();
+    }
+
+    /// Temporarily prevents worker publication while preserving the desired
+    /// running state. A failed resume can therefore be retried safely without
+    /// racing a later structural catalog mutation.
+    pub fn pause(self: *TextMergeRuntime) bool {
+        if (!self.config.enabled) return false;
+        lockAtomicWithBackoff(&self.lifecycle_mutex);
+        defer self.lifecycle_mutex.unlock();
+        self.paused = true;
+        const desired = self.desired_running;
+        _ = self.stopLocked();
+        return desired;
+    }
+
+    pub fn resumeAfterPause(self: *TextMergeRuntime) !void {
+        if (!self.config.enabled) return;
+        lockAtomicWithBackoff(&self.lifecycle_mutex);
+        defer self.lifecycle_mutex.unlock();
+        self.paused = false;
+        if (self.desired_running) try self.startLocked();
+    }
+
+    /// Used by the DB restart supervisor. False means a structural mutation
+    /// currently owns the pause; true means the runtime is running or no
+    /// longer desires a worker.
+    pub fn ensureRunning(self: *TextMergeRuntime) !bool {
+        if (!self.config.enabled) return true;
+        lockAtomicWithBackoff(&self.lifecycle_mutex);
+        defer self.lifecycle_mutex.unlock();
+        if (!self.desired_running) return true;
+        if (self.paused) return false;
+        try self.startLocked();
+        return true;
+    }
+
+    pub fn isStarted(self: *TextMergeRuntime) bool {
+        lockAtomicWithBackoff(&self.lifecycle_mutex);
+        defer self.lifecycle_mutex.unlock();
+        return self.future != null;
+    }
+
+    fn startLocked(self: *TextMergeRuntime) !void {
+        if (self.future != null or self.paused or !self.desired_running) return;
+        const io_impl = self.io_impl orelse return error.MissingBackendRuntimeIo;
+        const io = io_impl.io();
+        if (builtin.is_test and consumeTestStartFailure()) return error.TestTransientMaintenanceRestart;
+        self.mutex.lockUncancelable(io);
+        self.shutdown = false;
+        self.notified = true;
+        self.mutex.unlock(io);
+        self.future = try io.concurrent(workerMain, .{self});
+    }
+
+    fn stopLocked(self: *TextMergeRuntime) bool {
         const io_impl = self.io_impl orelse return false;
         const io = io_impl.io();
         if (self.future == null) return false;
@@ -358,6 +428,23 @@ fn lockApplyExclusive(lock: *apply_rw_lock_mod.ApplyRwLock) void {
 
 fn lockAtomicWithBackoff(mutex: *std.atomic.Mutex) void {
     while (!mutex.tryLock()) std.Thread.yield() catch {};
+}
+
+fn consumeTestStartFailure() bool {
+    var remaining = test_start_failures_remaining.load(.acquire);
+    while (remaining != 0) {
+        if (test_start_failures_remaining.cmpxchgWeak(
+            remaining,
+            remaining - 1,
+            .acq_rel,
+            .acquire,
+        )) |actual| {
+            remaining = actual;
+            continue;
+        }
+        return true;
+    }
+    return false;
 }
 
 fn lockApplyShared(lock: *apply_rw_lock_mod.ApplyRwLock) void {

--- a/zig/pkg/antfly/src/storage/db/maintenance/text_merge_runtime.zig
+++ b/zig/pkg/antfly/src/storage/db/maintenance/text_merge_runtime.zig
@@ -36,6 +36,7 @@ pub const Config = struct {
 pub var test_block_after_task_begin: std.atomic.Value(bool) = .init(false);
 pub var test_task_begin_entered: std.atomic.Value(bool) = .init(false);
 pub var test_release_after_task_begin: std.atomic.Value(bool) = .init(false);
+pub var test_stop_entered: std.atomic.Value(bool) = .init(false);
 
 pub const TextMergeRuntime = if (builtin.os.tag == .freestanding) struct {
     config: Config,
@@ -156,6 +157,7 @@ pub const TextMergeRuntime = if (builtin.os.tag == .freestanding) struct {
         const io_impl = self.io_impl orelse return false;
         const io = io_impl.io();
         if (self.future == null) return false;
+        if (builtin.is_test) test_stop_entered.store(true, .release);
 
         self.mutex.lockUncancelable(io);
         self.shutdown = true;

--- a/zig/pkg/antfly/src/storage/db/transform.zig
+++ b/zig/pkg/antfly/src/storage/db/transform.zig
@@ -278,6 +278,29 @@ fn normalizeJsonPath(path: []const u8) !NormalizedJsonPath {
     return parts;
 }
 
+pub const GraphProjectionPath = struct {
+    index_name: []const u8,
+    edge_type: []const u8,
+};
+
+/// Recognizes the logical graph-array paths exposed by document transforms.
+///
+/// `_edges` is projected out of the primary document and stored as graph edge
+/// artifacts. Callers must therefore apply append-like operations as graph
+/// deltas instead of resolving them against the stripped primary JSON. Any
+/// other path rooted at `_edges` is rejected: resolving it as ordinary JSON
+/// would silently reinterpret a partial projection as the complete edge set.
+pub fn graphProjectionPath(path: []const u8) !?GraphProjectionPath {
+    const normalized = try normalizeJsonPath(path);
+    const parts = normalized.slice();
+    if (parts.len == 0 or !std.mem.eql(u8, parts[0], "_edges")) return null;
+    if (parts.len != 3) return error.InvalidArgument;
+    return .{
+        .index_name = parts[1],
+        .edge_type = parts[2],
+    };
+}
+
 const NumericTransform = enum { add, max };
 
 fn applyNumericOp(


### PR DESCRIPTION
## Summary

- route append-like transforms on projected `_edges.<index>.<type>` paths into durable graph-edge deltas, preserving existing edges and source document version/timestamp semantics
- fail closed for replacement-style graph transforms and transactional graph transforms that cannot yet be represented atomically
- serialize structural index mutations and gracefully drain/restart text-merge and sparse-compaction workers before catalog entries move or close
- retire text-merge scheduler state when an index is removed

## Regression coverage

- graph `$push` preserves the existing weighted/metadata-bearing edge, appends the new edge, and survives reopen
- invalid/replacement graph transforms fail atomically without changing existing edges
- deterministic active-merge hook proves index deletion waits for the borrowed generation, then leaves source documents queryable and the deleted index unavailable

## Validation

- `zig build lib-db-test -- --test-filter "db graph"` (30/30)
- `zig build lib-db-test -- --test-filter "db delete"` (6/6)
- `zig build lib-db-test -- --test-filter "text merge"` (16/16)
- focused final Debug regression gates
- focused ReleaseSafe active-merge deletion gate