### PR TITLE
fix(inference): serialize GPU embedding execution

### DIFF
--- a/zig/pkg/inference/src/pipelines/embedding.zig
+++ b/zig/pkg/inference/src/pipelines/embedding.zig
@@ -702,7 +702,10 @@ pub const EmbeddingPipeline = struct {
             alloc.free(embeddings);
         }
         for (images, 0..) |img, i| {
-            const single = try self.embedImages(&.{img});
+            // The public entry point already owns execution_lock while it
+            // evaluates the batch fallback. Call the unlocked implementation
+            // directly so the non-reentrant mutex is not acquired twice.
+            const single = try self.embedImagesBatch(&.{img});
             defer alloc.free(single);
             embeddings[i] = single[0];
             initialized += 1;
@@ -992,7 +995,9 @@ pub const EmbeddingPipeline = struct {
         }
 
         for (audio_clips, 0..) |_, i| {
-            const one = try self.embedAudioPcm(audio_clips[i .. i + 1]);
+            // embedAudioPcm holds execution_lock across the complete fallback,
+            // so individual attempts must use the unlocked batch primitive.
+            const one = try self.embedAudioPcmBatch(audio_clips[i .. i + 1]);
             defer alloc.free(one);
             if (one.len != 1) return error.UnexpectedOutputShape;
             embeddings[i] = one[0];
@@ -2491,11 +2496,13 @@ test "embedImages falls back to per-image runs when batched image shape collapse
     const allocator = std.testing.allocator;
 
     var fake = FakeCollapsingVisionSession{};
+    var execution_gate: std.atomic.Mutex = .unlocked;
     var pipeline = EmbeddingPipeline{
         .allocator = allocator,
         .session = fake.session(),
         .tok = undefined,
         .config = .{ .normalize = false, .image_size = 2 },
+        .execution_lock = &execution_gate,
         .vision_session = fake.session(),
     };
 
@@ -2508,6 +2515,39 @@ test "embedImages falls back to per-image runs when batched image shape collapse
     try std.testing.expectEqual(@as(usize, 2), embeddings.len);
     try std.testing.expectEqualSlices(f32, &.{ 1.0, 2.0 }, embeddings[0]);
     try std.testing.expectEqualSlices(f32, &.{ 1.0, 2.0 }, embeddings[1]);
+    try std.testing.expect(execution_gate.tryLock());
+    execution_gate.unlock();
+}
+
+test "embedAudioPcm falls back under the execution gate without re-entry" {
+    const allocator = std.testing.allocator;
+
+    var fake = FakeCollapsingAudioSession{};
+    var execution_gate: std.atomic.Mutex = .unlocked;
+    var pipeline = EmbeddingPipeline{
+        .allocator = allocator,
+        .session = fake.session(),
+        .tok = undefined,
+        .config = .{ .normalize = false },
+        .execution_lock = &execution_gate,
+        .audio_session = fake.session(),
+    };
+
+    const samples = [_]f32{0.0} ** 1024;
+    const clips = [_]audio.PcmAudio{
+        .{ .samples = &samples, .sample_rate = audio.CLAP_CONFIG.sample_rate },
+        .{ .samples = &samples, .sample_rate = audio.CLAP_CONFIG.sample_rate },
+    };
+    const embeddings = try pipeline.embedAudioPcm(&clips);
+    defer freeEmbeddingSlices(allocator, embeddings);
+
+    try std.testing.expectEqual(@as(usize, 3), fake.run_count);
+    try std.testing.expectEqual(@as(usize, 2), fake.collapsed_batch_attempts);
+    try std.testing.expectEqual(@as(usize, 2), embeddings.len);
+    try std.testing.expectEqualSlices(f32, &.{ 1.0, 2.0 }, embeddings[0]);
+    try std.testing.expectEqualSlices(f32, &.{ 1.0, 2.0 }, embeddings[1]);
+    try std.testing.expect(execution_gate.tryLock());
+    execution_gate.unlock();
 }
 
 test "selectProjectedOutput skips collapsed pooled output for image batch" {
@@ -2592,6 +2632,52 @@ const FakeCollapsingVisionSession = struct {
         out[0] = try Tensor.initFloat32(allocator, "image_embeds", &.{ @intCast(actual_batch), 2 }, data[0 .. actual_batch * 2]);
         return out;
     }
+};
+
+const FakeCollapsingAudioSession = struct {
+    run_count: usize = 0,
+    collapsed_batch_attempts: usize = 0,
+
+    fn session(self: *FakeCollapsingAudioSession) backends.Session {
+        return .{
+            .ptr = self,
+            .vtable = &.{
+                .run = run,
+                .inputInfo = inputInfo,
+                .outputInfo = outputInfo,
+                .backend = backend,
+                .close = close,
+            },
+        };
+    }
+
+    fn run(ptr: *anyopaque, inputs: []const Tensor, allocator: std.mem.Allocator) anyerror![]Tensor {
+        const self: *FakeCollapsingAudioSession = @ptrCast(@alignCast(ptr));
+        try std.testing.expectEqual(@as(usize, 1), inputs.len);
+        const requested_batch: usize = @intCast(inputs[0].shape[0]);
+        self.run_count += 1;
+        if (requested_batch > 1) self.collapsed_batch_attempts = requested_batch;
+
+        const actual_batch: usize = if (requested_batch > 1) 1 else requested_batch;
+        const data = [_]f32{ 1.0, 2.0 };
+        const out = try allocator.alloc(Tensor, 1);
+        out[0] = try Tensor.initFloat32(allocator, "audio_embeds", &.{ @intCast(actual_batch), 2 }, data[0 .. actual_batch * 2]);
+        return out;
+    }
+
+    fn inputInfo(_: *anyopaque) []const backends.TensorInfo {
+        return &.{.{ .name = "input_features", .dtype = .f32, .shape = &.{ -1, 1, 1001, 64 } }};
+    }
+
+    fn outputInfo(_: *anyopaque) []const backends.TensorInfo {
+        return &.{.{ .name = "audio_embeds", .dtype = .f32, .shape = &.{ -1, 2 } }};
+    }
+
+    fn backend(_: *anyopaque) backends.BackendType {
+        return .native;
+    }
+
+    fn close(_: *anyopaque) void {}
 };
 
 fn fakeVisionSession(ptr: anytype, comptime runFn: anytype) backends.Session {

--- a/zig/pkg/inference/src/pipelines/embedding.zig
+++ b/zig/pkg/inference/src/pipelines/embedding.zig
@@ -164,6 +164,10 @@ pub const EmbeddingPipeline = struct {
     session: backends.Session,
     tok: Tokenizer,
     config: EmbeddingConfig,
+    /// Optional owner-provided gate for stateful backend sessions. Metal and
+    /// CUDA sessions share mutable backend state across request pipelines and
+    /// must not execute overlapping forward passes.
+    execution_lock: ?*std.atomic.Mutex = null,
     /// Optional vision encoder session for CLIP/SigLIP multimodal embedding.
     vision_session: ?backends.Session = null,
     /// Optional audio encoder session for CLAP multimodal embedding.
@@ -214,6 +218,8 @@ pub const EmbeddingPipeline = struct {
     /// Caller owns the returned slices and must free them with the allocator.
     pub fn embed(self: *EmbeddingPipeline, texts: []const []const u8) ![][]f32 {
         if (texts.len == 0) return try self.allocator.alloc([]f32, 0);
+        self.lockExecution();
+        defer self.unlockExecution();
         const text_session = self.textEncodingSession();
         if (textSessionBatchPlan(text_session, texts.len)) |plan| {
             return try self.embedWithBatchPlan(texts, plan);
@@ -543,6 +549,8 @@ pub const EmbeddingPipeline = struct {
     /// Requires a vision_session (CLIP/SigLIP model).
     pub fn embedImages(self: *EmbeddingPipeline, images: []const []const u8) anyerror![][]f32 {
         if (images.len == 0) return try self.allocator.alloc([]f32, 0);
+        self.lockExecution();
+        defer self.unlockExecution();
         return self.embedImagesBatch(images) catch |err| {
             if (images.len > 1 and shouldFallbackBatchedImageError(err)) {
                 return self.embedImagesIndividually(images);
@@ -786,12 +794,24 @@ pub const EmbeddingPipeline = struct {
     /// Requires an audio_session (CLAP model).
     pub fn embedAudioPcm(self: *EmbeddingPipeline, audio_clips: []const audio.PcmAudio) anyerror![][]f32 {
         if (audio_clips.len == 0) return try self.allocator.alloc([]f32, 0);
+        self.lockExecution();
+        defer self.unlockExecution();
         return self.embedAudioPcmBatch(audio_clips) catch |err| {
             if (audio_clips.len > 1 and err == error.BatchedAudioOutputCollapsed) {
                 return self.embedAudioPcmIndividually(audio_clips);
             }
             return err;
         };
+    }
+
+    fn lockExecution(self: *EmbeddingPipeline) void {
+        const mutex = self.execution_lock orelse return;
+        platform.sync.lockYielding(mutex);
+    }
+
+    fn unlockExecution(self: *EmbeddingPipeline) void {
+        const mutex = self.execution_lock orelse return;
+        mutex.unlock();
     }
 
     fn embedAudioPcmBatch(self: *EmbeddingPipeline, audio_clips: []const audio.PcmAudio) ![][]f32 {
@@ -2060,6 +2080,24 @@ fn selectProjectedOutput(outputs: []Tensor, expected_dim: usize, expected_batch:
         }
     }
     return null;
+}
+
+test "embedding execution gate owns the supplied mutex" {
+    var gate: std.atomic.Mutex = .unlocked;
+    var pipeline = EmbeddingPipeline{
+        .allocator = undefined,
+        .session = undefined,
+        .tok = undefined,
+        .config = .{},
+        .execution_lock = &gate,
+    };
+
+    pipeline.lockExecution();
+    try std.testing.expect(!gate.tryLock());
+    pipeline.unlockExecution();
+
+    try std.testing.expect(gate.tryLock());
+    gate.unlock();
 }
 
 test "projectEmbeddings runs projection as a single batch" {

--- a/zig/pkg/inference/src/pipelines/sparse_embedding.zig
+++ b/zig/pkg/inference/src/pipelines/sparse_embedding.zig
@@ -26,6 +26,7 @@
 // Matches Go inference's lib/pipelines/sparse_embedding.go.
 
 const std = @import("std");
+const platform = @import("antfly_platform");
 const backends = @import("../backends/backends.zig");
 const manifest_mod = @import("../models/manifest.zig");
 const embedding_mod = @import("embedding.zig");
@@ -66,11 +67,17 @@ pub const SparseEmbeddingPipeline = struct {
     session: backends.Session,
     tok: Tokenizer,
     config: SparseEmbeddingConfig,
+    /// Optional owner-provided gate for stateful backend sessions.
+    execution_lock: ?*std.atomic.Mutex = null,
 
     /// Generate sparse embeddings for a batch of texts.
     /// Caller owns the returned SparseVectors and must call deinit on each.
     pub fn embed(self: *SparseEmbeddingPipeline, texts: []const []const u8) ![]SparseVector {
         if (texts.len == 0) return try self.allocator.alloc(SparseVector, 0);
+        if (self.execution_lock) |mutex| {
+            platform.sync.lockYielding(mutex);
+        }
+        defer if (self.execution_lock) |mutex| mutex.unlock();
         if (embedding_mod.textSessionBatchPlan(self.session, texts.len)) |plan| {
             return self.embedWithBatchPlan(texts, plan);
         }

--- a/zig/pkg/inference/src/server/model_manager.zig
+++ b/zig/pkg/inference/src/server/model_manager.zig
@@ -1851,6 +1851,10 @@ pub const LoadedModel = struct {
     native_generate_lock: std.atomic.Mutex = .unlocked,
     // Multimodal sessions (CLIP/CLAP/CLIPCLAP)
     embedding_session_lock: std.atomic.Mutex = .unlocked,
+    /// Stateful GPU embedding sessions share mutable weight-store and command
+    /// state. Cold-load waiters are released together, so serialize their
+    /// forward passes without constraining thread-safe CPU sessions.
+    embedding_run_lock: std.atomic.Mutex = .unlocked,
     reranking_session_lock: std.atomic.Mutex = .unlocked,
     vision_session: ?backends.Session = null,
     audio_session: ?backends.Session = null,
@@ -2023,7 +2027,13 @@ pub const LoadedModel = struct {
         pipeline.visual_projection = self.visual_projection;
         pipeline.audio_projection = self.audio_projection;
         pipeline.resident_projection_stats = &self.resident_projection_stats;
+        pipeline.execution_lock = self.embeddingExecutionLock();
         return pipeline;
+    }
+
+    pub fn embeddingExecutionLock(self: *LoadedModel) ?*std.atomic.Mutex {
+        if (!embeddingBackendNeedsRunLock(self.session.backend())) return null;
+        return &self.embedding_run_lock;
     }
 
     pub fn rerankingPipeline(self: *LoadedModel, allocator: std.mem.Allocator) RerankingPipeline {
@@ -2190,6 +2200,18 @@ pub const LoadedModel = struct {
 fn isJinaStyleEmbeddingManifest(manifest: *const manifest_mod.ModelManifest) bool {
     return std.mem.eql(u8, manifest.config_model_arch, "jina_embeddings_v5") or
         (manifest.pooling == .last and std.mem.eql(u8, manifest.embedding_text_prefix, "Document: "));
+}
+
+fn embeddingBackendNeedsRunLock(backend: backends.BackendType) bool {
+    return backend.usesGpuHostedSession();
+}
+
+test "embedding run gate is limited to stateful GPU backends" {
+    try std.testing.expect(embeddingBackendNeedsRunLock(.metal));
+    try std.testing.expect(embeddingBackendNeedsRunLock(.cuda));
+    try std.testing.expect(!embeddingBackendNeedsRunLock(.native));
+    try std.testing.expect(!embeddingBackendNeedsRunLock(.onnx));
+    try std.testing.expect(!embeddingBackendNeedsRunLock(.wasm));
 }
 
 fn usesClipImagePreprocessProfile(manifest: *const manifest_mod.ModelManifest) bool {

--- a/zig/pkg/inference/src/server/server.zig
+++ b/zig/pkg/inference/src/server/server.zig
@@ -1709,6 +1709,7 @@ pub const Node = struct {
             .session = model.session,
             .tok = model.getTokenizer(),
             .config = sparse_embedding_mod.SparseEmbeddingConfig.fromManifest(&model.manifest),
+            .execution_lock = model.embeddingExecutionLock(),
         };
         return try pipeline.embed(texts);
     }
@@ -2046,6 +2047,7 @@ pub const Node = struct {
                 .session = model.session,
                 .tok = model.getTokenizer(),
                 .config = sparse_embedding_mod.SparseEmbeddingConfig.fromManifest(&model.manifest),
+                .execution_lock = model.embeddingExecutionLock(),
             };
             const sparse = try pipeline.embed(&texts);
             defer {
@@ -2731,6 +2733,7 @@ pub const Node = struct {
                 .session = model.session,
                 .tok = model.getTokenizer(),
                 .config = sparse_embedding_mod.SparseEmbeddingConfig.fromManifest(&model.manifest),
+                .execution_lock = model.embeddingExecutionLock(),
             };
             const sparse_vecs = pipeline.embed(sparse_texts) catch |err|
                 return inferenceFailureResponse(ctx, err);


### PR DESCRIPTION
Closes #435

## Summary
- add a per-model execution gate for stateful Metal and CUDA embedding sessions
- apply the gate to dense, sparse, image, and audio embedding paths
- keep native, ONNX, and WASM embedding execution concurrent

Cold-load requests are coalesced, which releases all waiters onto the same loaded GPU session at once. The GPU-hosted session shares mutable weight-store and command state, so overlapping forward passes could corrupt allocator state. This change serializes those forward passes at the loaded-model boundary.

## Validation
- `zig fmt --check` on all changed Zig files
- `git diff --check`
- `zig build inference-test -- --test-filter embedding` (52 passed, 7 skipped)
- exact issue reproduction with eight concurrent cold-load `/ai/v1/embeddings` requests using `antflydb/clipclap`: all returned HTTP 200 and the server remained alive

The repository-wide ReleaseFast build was also attempted, but this machine fails earlier in the LMDB C import because the local SDK cannot resolve `pthread.h`; the inference-server binary used for the regression test built successfully.