### PR TITLE
Fix strict multimodal admission and retained HTTP workers

### DIFF
--- a/.github/workflows/zig-tests.yml
+++ b/.github/workflows/zig-tests.yml
@@ -827,6 +827,7 @@ jobs:
           # This is a release contract, not an optional capability probe. Keep
           # it targeted so unrelated large-model suites do not inflate this job.
           RUN_MULTIMODAL_GENERATOR_TESTS: "1"
+          RUN_CLIPCLAP_CONTRACT_TESTS: "1"
         run: |
           chmod +x ./zig-out/bin/antfly
           taskset -c ${{ steps.e2e_cpus.outputs.list }} uv run --project e2e/inference pytest -q --continue-on-collection-errors e2e/inference

--- a/.github/workflows/zig-tests.yml
+++ b/.github/workflows/zig-tests.yml
@@ -704,6 +704,14 @@ jobs:
           SKIP_BUILD: "1"
         run: taskset -c ${{ steps.e2e_cpus.outputs.list }} scripts/ci/zig-e2e-base-linux.sh
 
+      - name: Run low-FD HTTP worker ratchet regression
+        working-directory: zig
+        env:
+          ANTFLY_REQUIRE_LOW_FD_HTTP_RATCHET: "1"
+        run: |
+          ulimit -n 256
+          taskset -c ${{ steps.e2e_cpus.outputs.list }} zig build http-low-fd-ratchet-test
+
       - name: Run low-FD Autograph regression
         env:
           SKIP_BUILD: "1"
@@ -816,6 +824,9 @@ jobs:
           ANTFLY_INFERENCE_FLORENCE_MODEL: antflydb/florence-2-base
           ANTFLY_INFERENCE_REQUEST_TIMEOUT: "300"
           ANTFLY_INFERENCE_MAX_LOADED_MODELS: "1"
+          # This is a release contract, not an optional capability probe. Keep
+          # it targeted so unrelated large-model suites do not inflate this job.
+          RUN_MULTIMODAL_GENERATOR_TESTS: "1"
         run: |
           chmod +x ./zig-out/bin/antfly
           taskset -c ${{ steps.e2e_cpus.outputs.list }} uv run --project e2e/inference pytest -q --continue-on-collection-errors e2e/inference

--- a/zig/TESTING.md
+++ b/zig/TESTING.md
@@ -296,7 +296,10 @@ Common inference E2E environment variables:
   inference pull` when tests request unavailable models.
 - `RUN_LARGE_MODEL_TESTS=1`: opt into large-model tests.
 - `RUN_MULTIMODAL_GENERATOR_TESTS=1`: require the shipped multimodal generator
-  to be advertised, loadable, and able to complete live image inference.
+  to be advertised, loadable, and able to complete live image and audio
+  inference.
+- `RUN_CLIPCLAP_CONTRACT_TESTS=1`: require the published ClipClap GGUF pair to
+  pass strict server admission and complete live image and audio embedding.
 
 ## TypeScript Components
 

--- a/zig/TESTING.md
+++ b/zig/TESTING.md
@@ -295,6 +295,8 @@ Common inference E2E environment variables:
 - `ANTFLY_INFERENCE_DOWNLOAD=1`: allow model downloads through `antfly
   inference pull` when tests request unavailable models.
 - `RUN_LARGE_MODEL_TESTS=1`: opt into large-model tests.
+- `RUN_MULTIMODAL_GENERATOR_TESTS=1`: require the shipped multimodal generator
+  to be advertised, loadable, and able to complete live image inference.
 
 ## TypeScript Components
 

--- a/zig/build.zig
+++ b/zig/build.zig
@@ -4749,6 +4749,7 @@ pub fn build(b: *std.Build) void {
             "cluster backup maintenance queue expires inactive repositories",
             "restore repository contention backoff is bounded and increasing",
             "restore retry deadline wakeup is interruptible without polling",
+            "owned backup runtime has a finite worker ceiling",
             "backup staging uses configured storage authority and exclusive generations",
             "owned restore verifies declared artifact identity instead of accepting staged bytes",
             "cluster restore repository errors preserve operational failure semantics",
@@ -5045,6 +5046,7 @@ pub fn build(b: *std.Build) void {
         .root_module = api_table_writes_docid_test_mod,
         .filters = selectTestFilters(b, &.{
             "auto bulk group writes release leases so idle finish can publish",
+            "provisioned table write source has a finite worker ceiling",
             "provisioned native storage metrics bypass an empty busy write cache",
             "provisioned table write source rejects stale doc identity namespace before write",
             "replicated split destination seeds inherited doc identity before range publication",
@@ -5125,6 +5127,7 @@ pub fn build(b: *std.Build) void {
         .root_module = api_table_reads_docid_test_mod,
         .filters = &.{
             "aggregation completeness requires exact total relation",
+            "provisioned table read cache has a finite worker ceiling",
             "provisioned read cache invalidates repeated ownership moves with pinned leases",
             "provisioned read cache exclusive access drains active read leases",
             "provisioned read cache group exclusive drains only the published group",

--- a/zig/build.zig
+++ b/zig/build.zig
@@ -3511,21 +3511,18 @@ pub fn build(b: *std.Build) void {
 
     const raft_transport_tests = b.addTest(.{
         .root_module = lib_test_mod,
-        // The top-level declaration walk makes the transport and shared HTTP
-        // tests reachable; qualified filters keep this focused bucket scoped
-        // to those layers.
-        .filters = &.{ "raft integration module compiles", "raft.transport.", "common.http." },
+        .filters = &.{ "raft integration module compiles", "raft.transport." },
     });
     const run_raft_transport_tests = addFilteredTestRunArtifact(b, raft_transport_tests);
 
     const http_low_fd_ratchet_filter = "std http listener process threads and descriptors recover after cancellation storms";
     const http_low_fd_ratchet_tests = b.addTest(.{
         .root_module = lib_test_mod,
-        // Keep the Raft integration anchor for declaration reachability, but
-        // execute only the process-level regression below. The wider transport
-        // bucket contains high-cardinality socket tests that intentionally do
+        // Compile the shared HTTP module for declaration reachability, but
+        // execute only the process-level regression below. The wider common
+        // and transport buckets contain high-cardinality socket tests that do
         // not fit inside this target's 256-descriptor process limit.
-        .filters = &.{ "raft integration module compiles", http_low_fd_ratchet_filter },
+        .filters = &.{ "common.", http_low_fd_ratchet_filter },
     });
     const run_http_low_fd_ratchet_tests = addFilteredTestRunArtifactWithRuntimeFilters(
         b,

--- a/zig/build.zig
+++ b/zig/build.zig
@@ -3518,6 +3518,26 @@ pub fn build(b: *std.Build) void {
     });
     const run_raft_transport_tests = addFilteredTestRunArtifact(b, raft_transport_tests);
 
+    const http_low_fd_ratchet_filter = "std http listener process threads and descriptors recover after cancellation storms";
+    const http_low_fd_ratchet_tests = b.addTest(.{
+        .root_module = lib_test_mod,
+        // Keep the Raft integration anchor for declaration reachability, but
+        // execute only the process-level regression below. The wider transport
+        // bucket contains high-cardinality socket tests that intentionally do
+        // not fit inside this target's 256-descriptor process limit.
+        .filters = &.{ "raft integration module compiles", http_low_fd_ratchet_filter },
+    });
+    const run_http_low_fd_ratchet_tests = addFilteredTestRunArtifactWithRuntimeFilters(
+        b,
+        http_low_fd_ratchet_tests,
+        &.{http_low_fd_ratchet_filter},
+    );
+    const http_low_fd_ratchet_test_step = b.step(
+        "http-low-fd-ratchet-test",
+        "Run the process-level low-FD HTTP worker ratchet regression",
+    );
+    http_low_fd_ratchet_test_step.dependOn(&run_http_low_fd_ratchet_tests.step);
+
     const lib_raft_sim_default_filters = [_][]const u8{
         "managed host simulation drives add and peer refresh through deterministic steps",
         "managed host simulation restores through both raft state backends",

--- a/zig/build.zig
+++ b/zig/build.zig
@@ -5127,6 +5127,8 @@ pub fn build(b: *std.Build) void {
         .root_module = api_table_reads_docid_test_mod,
         .filters = &.{
             "aggregation completeness requires exact total relation",
+            "api http client forwards internal query controls and maps remote timeout",
+            "remote shard query phases propagate deadline and request cancellation",
             "provisioned table read cache has a finite worker ceiling",
             "provisioned read cache invalidates repeated ownership moves with pinned leases",
             "provisioned read cache exclusive access drains active read leases",

--- a/zig/build.zig
+++ b/zig/build.zig
@@ -3511,10 +3511,10 @@ pub fn build(b: *std.Build) void {
 
     const raft_transport_tests = b.addTest(.{
         .root_module = lib_test_mod,
-        // The top-level Raft declaration walk makes the nested transport test
-        // declarations reachable; the qualified filter then keeps execution
-        // scoped to the transport package.
-        .filters = &.{ "raft integration module compiles", "raft.transport." },
+        // The top-level declaration walk makes the transport and shared HTTP
+        // tests reachable; qualified filters keep this focused bucket scoped
+        // to those layers.
+        .filters = &.{ "raft integration module compiles", "raft.transport.", "common.http." },
     });
     const run_raft_transport_tests = addFilteredTestRunArtifact(b, raft_transport_tests);
 
@@ -6034,6 +6034,7 @@ pub fn build(b: *std.Build) void {
     unit_test_step.dependOn(&run_raft_runtime_tests.step);
     unit_test_step.dependOn(&run_raft_restore_tests.step);
     unit_test_step.dependOn(&run_raft_ready_continuation_tests.step);
+    unit_test_step.dependOn(&run_raft_transport_tests.step);
 
     // Progress mode uses one union-filtered root artifact too. Storage and
     // metadata module paths overlap, while raft-transport is a strict subset

--- a/zig/e2e/inference/models.py
+++ b/zig/e2e/inference/models.py
@@ -379,6 +379,15 @@ def run_multimodal_generator_tests() -> bool:
     )
 
 
+def run_clipclap_contract_tests() -> bool:
+    """Require the published ClipClap pair to pass live server admission."""
+
+    value = os.environ.get("RUN_CLIPCLAP_CONTRACT_TESTS", "")
+    return run_large_model_tests() or (
+        value != "" and value not in {"0", "false", "False"}
+    )
+
+
 def inference_command() -> list[str]:
     explicit = os.environ.get("ANTFLY_BIN")
     if explicit:

--- a/zig/e2e/inference/models.py
+++ b/zig/e2e/inference/models.py
@@ -370,6 +370,15 @@ def run_large_model_tests() -> bool:
     return value != "" and value not in {"0", "false", "False"}
 
 
+def run_multimodal_generator_tests() -> bool:
+    """Enable the targeted large Gemma smoke without enabling every large model."""
+
+    value = os.environ.get("RUN_MULTIMODAL_GENERATOR_TESTS", "")
+    return run_large_model_tests() or (
+        value != "" and value not in {"0", "false", "False"}
+    )
+
+
 def inference_command() -> list[str]:
     explicit = os.environ.get("ANTFLY_BIN")
     if explicit:

--- a/zig/e2e/inference/test_embed.py
+++ b/zig/e2e/inference/test_embed.py
@@ -42,6 +42,7 @@ from .models import (
     inference_command,
     inference_download_enabled,
     local_model_exists,
+    run_clipclap_contract_tests,
 )
 
 pytestmark = pytest.mark.model_integration
@@ -169,6 +170,44 @@ def _assert_distinct_rows(*embs):
         for j in range(i + 1, len(embs)):
             delta = sum(abs(a - b) for a, b in zip(embs[i], embs[j]))
             assert delta > 1e-5
+
+
+@pytest.mark.multimodal
+@pytest.mark.slow
+def test_published_clipclap_pair_server_contract(api):
+    """The shipped CLIP and CLAP artifacts must admit and execute as one model."""
+    if not run_clipclap_contract_tests():
+        pytest.skip(
+            "ClipClap uses a large paired model; set "
+            "RUN_CLIPCLAP_CONTRACT_TESTS=1 to require its release contract"
+        )
+
+    response = api.post(
+        "/embed",
+        json={
+            "model": CLIPCLAP_MODEL,
+            "input": [
+                _image_part(make_solid_png_uri(255, 255, 255)),
+                _media_wav_part(),
+            ],
+        },
+    )
+    assert response.status_code == 200, (
+        "published ClipClap pair failed server admission or inference: "
+        f"{response.status_code} {response.text[:2000]}"
+    )
+    embeddings = [item["embedding"] for item in response.json()["data"]]
+    _assert_clipclap_embeddings(embeddings, 2)
+    _assert_distinct_rows(*embeddings)
+    for embedding in embeddings:
+        assert all(math.isfinite(value) for value in embedding)
+        assert abs(l2_norm(embedding) - 1.0) < 1e-4
+
+    embedders = api.models().get("embedders", {})
+    assert CLIPCLAP_MODEL in embedders, (
+        f"{CLIPCLAP_MODEL} executed but is absent from /models embedders: "
+        f"{sorted(embedders)}"
+    )
 
 
 @pytest.mark.multimodal

--- a/zig/e2e/inference/test_generate.py
+++ b/zig/e2e/inference/test_generate.py
@@ -352,7 +352,7 @@ def test_stream_delta_structure(api):
 @pytest.mark.multimodal
 @pytest.mark.slow
 def test_multimodal_generation(api):
-    """Multimodal generation should either succeed or fail explicitly."""
+    """The shipped Gemma decoder/projector pair must execute image inference."""
     if not run_large_model_tests():
         pytest.skip("Multimodal generation uses a large model; set RUN_LARGE_MODEL_TESTS=1 to run it")
     model = _first_multimodal_generator_model(api)
@@ -370,12 +370,6 @@ def test_multimodal_generation(api):
         "max_tokens": 20,
     })
     _skip_missing_generator_response(r)
-    if r.status_code == 400:
-        payload = r.json()
-        assert payload.get("error") == "INVALID_REQUEST", payload
-        assert "native multimodal generation is not implemented yet" in payload.get("message", ""), payload
-        return
-
     r.raise_for_status()
     resp = r.json()
     content = _message_content(resp)

--- a/zig/e2e/inference/test_generate.py
+++ b/zig/e2e/inference/test_generate.py
@@ -29,7 +29,7 @@ from .models import (
     find_multimodal_generator_model_name,
     find_tool_model_name,
     response_indicates_missing_model,
-    run_large_model_tests,
+    run_multimodal_generator_tests,
 )
 
 pytestmark = pytest.mark.model_integration
@@ -101,7 +101,10 @@ def _first_multimodal_generator_model(api):
         return model
     if os.environ.get("ANTFLY_INFERENCE_MULTIMODAL_GENERATOR_MODEL"):
         return os.environ["ANTFLY_INFERENCE_MULTIMODAL_GENERATOR_MODEL"]
-    pytest.skip("No multimodal generator model available; set ANTFLY_INFERENCE_MULTIMODAL_GENERATOR_MODEL or place one under models")
+    pytest.fail(
+        "Required multimodal generator is absent from /models; set "
+        "ANTFLY_INFERENCE_MULTIMODAL_GENERATOR_MODEL or install the shipped default"
+    )
 
 
 def _assert_chat_completion(resp: dict) -> dict:
@@ -353,8 +356,11 @@ def test_stream_delta_structure(api):
 @pytest.mark.slow
 def test_multimodal_generation(api):
     """The shipped Gemma decoder/projector pair must execute image inference."""
-    if not run_large_model_tests():
-        pytest.skip("Multimodal generation uses a large model; set RUN_LARGE_MODEL_TESTS=1 to run it")
+    if not run_multimodal_generator_tests():
+        pytest.skip(
+            "Multimodal generation uses a large model; set "
+            "RUN_MULTIMODAL_GENERATOR_TESTS=1 to run it"
+        )
     model = _first_multimodal_generator_model(api)
     messages = [{
         "role": "user",
@@ -369,7 +375,6 @@ def test_multimodal_generation(api):
         "messages": messages,
         "max_tokens": 20,
     })
-    _skip_missing_generator_response(r)
     r.raise_for_status()
     resp = r.json()
     content = _message_content(resp)

--- a/zig/e2e/inference/test_generate.py
+++ b/zig/e2e/inference/test_generate.py
@@ -23,7 +23,7 @@ import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 import pytest
-from .helpers import TINY_PNG_URI
+from .helpers import TINY_PNG_URI, make_wav_b64
 from .models import (
     default_generator_model_name,
     find_multimodal_generator_model_name,
@@ -379,6 +379,42 @@ def test_multimodal_generation(api):
     resp = r.json()
     content = _message_content(resp)
     assert content, f"No multimodal generated content in response: {resp}"
+
+
+@pytest.mark.multimodal
+@pytest.mark.slow
+def test_multimodal_audio_generation(api):
+    """The shipped unified Gemma projector must execute audio inference."""
+    if not run_multimodal_generator_tests():
+        pytest.skip(
+            "Multimodal generation uses a large model; set "
+            "RUN_MULTIMODAL_GENERATOR_TESTS=1 to run it"
+        )
+    model = _first_multimodal_generator_model(api)
+    messages = [{
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "Describe this audio in one short sentence."},
+            {
+                "type": "media",
+                "mime_type": "audio/wav",
+                "data": make_wav_b64(0.1, 16000),
+            },
+        ],
+    }]
+
+    response = api.post("/generate", json={
+        "model": model,
+        "messages": messages,
+        "max_tokens": 20,
+    })
+    assert response.status_code == 200, (
+        "shipped Gemma decoder/projector failed audio inference: "
+        f"{response.status_code} {response.text[:2000]}"
+    )
+    resp = response.json()
+    content = _message_content(resp)
+    assert content, f"No audio-conditioned generated content in response: {resp}"
 
 
 def test_generate_rejects_tool_choice_without_tools(api):

--- a/zig/e2e/inference/test_model_helpers.py
+++ b/zig/e2e/inference/test_model_helpers.py
@@ -260,6 +260,19 @@ def test_generation_defaults_share_one_model():
     assert DEFAULT_GENERATOR_MODEL == DEFAULT_MULTIMODAL_GENERATOR_MODEL
 
 
+def test_targeted_multimodal_generator_gate(monkeypatch):
+    monkeypatch.delenv("RUN_LARGE_MODEL_TESTS", raising=False)
+    monkeypatch.delenv("RUN_MULTIMODAL_GENERATOR_TESTS", raising=False)
+    assert not models.run_multimodal_generator_tests()
+
+    monkeypatch.setenv("RUN_MULTIMODAL_GENERATOR_TESTS", "1")
+    assert models.run_multimodal_generator_tests()
+
+    monkeypatch.setenv("RUN_MULTIMODAL_GENERATOR_TESTS", "false")
+    monkeypatch.setenv("RUN_LARGE_MODEL_TESTS", "1")
+    assert models.run_multimodal_generator_tests()
+
+
 def test_multimodal_model_selection_uses_shared_gemma_default(monkeypatch, tmp_path):
     monkeypatch.delenv("ANTFLY_INFERENCE_MULTIMODAL_GENERATOR_MODEL", raising=False)
     monkeypatch.setenv("ANTFLY_INFERENCE_MODELS_DIR", str(tmp_path))

--- a/zig/e2e/inference/test_model_helpers.py
+++ b/zig/e2e/inference/test_model_helpers.py
@@ -273,6 +273,19 @@ def test_targeted_multimodal_generator_gate(monkeypatch):
     assert models.run_multimodal_generator_tests()
 
 
+def test_targeted_clipclap_contract_gate(monkeypatch):
+    monkeypatch.delenv("RUN_LARGE_MODEL_TESTS", raising=False)
+    monkeypatch.delenv("RUN_CLIPCLAP_CONTRACT_TESTS", raising=False)
+    assert not models.run_clipclap_contract_tests()
+
+    monkeypatch.setenv("RUN_CLIPCLAP_CONTRACT_TESTS", "1")
+    assert models.run_clipclap_contract_tests()
+
+    monkeypatch.setenv("RUN_CLIPCLAP_CONTRACT_TESTS", "false")
+    monkeypatch.setenv("RUN_LARGE_MODEL_TESTS", "1")
+    assert models.run_clipclap_contract_tests()
+
+
 def test_multimodal_model_selection_uses_shared_gemma_default(monkeypatch, tmp_path):
     monkeypatch.delenv("ANTFLY_INFERENCE_MULTIMODAL_GENERATOR_MODEL", raising=False)
     monkeypatch.setenv("ANTFLY_INFERENCE_MODELS_DIR", str(tmp_path))

--- a/zig/pkg/antfly/src/api/backups.zig
+++ b/zig/pkg/antfly/src/api/backups.zig
@@ -17,6 +17,7 @@ const platform_time = @import("antfly_platform").time;
 const metadata_openapi = @import("antfly_metadata_openapi");
 const fs_paths = @import("../common/fs_paths.zig");
 const group_ids = @import("../common/group_ids.zig");
+const threaded_io_limits = @import("../common/threaded_io_limits.zig");
 const metadata_table_manager = @import("../metadata/table_manager.zig");
 const object_storage = @import("../storage/object_storage.zig");
 const remote_uri = @import("../serverless/remote_uri.zig");
@@ -363,6 +364,26 @@ pub const OpenOptions = struct {
     io: ?std.Io = null,
 };
 
+fn createOwnedThreadedIo(alloc: std.mem.Allocator) !*std.Io.Threaded {
+    const owned = try alloc.create(std.Io.Threaded);
+    // CLI and embedded backup stores can live for the whole operation and
+    // issue concurrent HTTP work. Keep the fallback finite when a server
+    // runtime was not supplied.
+    owned.* = threaded_io_limits.initService(alloc);
+    return owned;
+}
+
+test "owned backup runtime has a finite worker ceiling" {
+    const owned = try createOwnedThreadedIo(std.testing.allocator);
+    defer std.testing.allocator.destroy(owned);
+    defer owned.deinit();
+
+    try std.testing.expectEqual(
+        std.Io.Limit.limited(threaded_io_limits.service),
+        owned.concurrent_limit,
+    );
+}
+
 const AwsCredentialContext = struct {
     alloc: std.mem.Allocator,
     io_impl: ?*std.Io.Threaded,
@@ -375,9 +396,7 @@ const AwsCredentialContext = struct {
         const owned_region = try alloc.dupe(u8, region);
         errdefer alloc.free(owned_region);
         const io_impl: ?*std.Io.Threaded = if (shared_io == null) blk: {
-            const owned = try alloc.create(std.Io.Threaded);
-            owned.* = std.Io.Threaded.init(alloc, .{});
-            break :blk owned;
+            break :blk try createOwnedThreadedIo(alloc);
         } else null;
         errdefer if (io_impl) |owned| {
             owned.deinit();
@@ -564,9 +583,7 @@ const RemoteBackupStore = struct {
 
     fn initGcsUri(alloc: std.mem.Allocator, bucket: []const u8, prefix: []const u8, options: OpenOptions) !RemoteBackupStore {
         const io_impl: ?*std.Io.Threaded = if (options.io == null) blk: {
-            const owned = try alloc.create(std.Io.Threaded);
-            owned.* = std.Io.Threaded.init(alloc, .{});
-            break :blk owned;
+            break :blk try createOwnedThreadedIo(alloc);
         } else null;
         errdefer if (io_impl) |owned| {
             owned.deinit();
@@ -624,9 +641,7 @@ const RemoteBackupStore = struct {
         options: OpenOptions,
     ) !RemoteBackupStore {
         const io_impl: ?*std.Io.Threaded = if (options.io == null) blk: {
-            const owned = try alloc.create(std.Io.Threaded);
-            owned.* = std.Io.Threaded.init(alloc, .{});
-            break :blk owned;
+            break :blk try createOwnedThreadedIo(alloc);
         } else null;
         errdefer if (io_impl) |owned| {
             owned.deinit();
@@ -692,9 +707,8 @@ const RemoteBackupStore = struct {
         bucket: []const u8,
         prefix: []const u8,
     ) !RemoteBackupStore {
-        const io_impl = try alloc.create(std.Io.Threaded);
+        const io_impl = try createOwnedThreadedIo(alloc);
         errdefer alloc.destroy(io_impl);
-        io_impl.* = std.Io.Threaded.init(alloc, .{});
         errdefer io_impl.deinit();
         const owned_bucket = try alloc.dupe(u8, bucket);
         errdefer alloc.free(owned_bucket);
@@ -1883,7 +1897,10 @@ fn resolveFilesystemLocationAlloc(alloc: std.mem.Allocator, configured_root: []c
     const relative = std.mem.trimStart(u8, uri_path, "/");
     if (relative.len > 0) try validateArtifactRelativePath(relative);
 
-    var io_impl: ?std.Io.Threaded = if (shared_io == null) std.Io.Threaded.init(alloc, .{}) else null;
+    var io_impl: ?std.Io.Threaded = if (shared_io == null)
+        threaded_io_limits.initService(alloc)
+    else
+        null;
     defer if (io_impl) |*owned| owned.deinit();
     const io = shared_io orelse io_impl.?.io();
     const canonical_root = try std.Io.Dir.realPathFileAbsoluteAlloc(io, configured_root, alloc);

--- a/zig/pkg/antfly/src/api/http_client.zig
+++ b/zig/pkg/antfly/src/api/http_client.zig
@@ -604,6 +604,18 @@ pub const ApiHttpClient = struct {
         table_name: []const u8,
         body: []const u8,
     ) !QueryResponse {
+        return self.fetchGroupQueryWithControl(base_uri, group_id, table_name, body, null, null);
+    }
+
+    pub fn fetchGroupQueryWithControl(
+        self: *ApiHttpClient,
+        base_uri: []const u8,
+        group_id: u64,
+        table_name: []const u8,
+        body: []const u8,
+        timeout_ms: ?u32,
+        cancellation: ?*const http_common.RequestCancellation,
+    ) !QueryResponse {
         const suffix = try std.fmt.allocPrint(self.alloc, "{s}{s}{s}", .{
             routes.Routes.tables_prefix,
             table_name,
@@ -620,10 +632,13 @@ pub const ApiHttpClient = struct {
             .uri = uri,
             .content_type = "application/json",
             .body = body,
+            .timeout_ms = timeout_ms,
+            .cancellation = cancellation,
         });
         defer resp.deinit(self.alloc);
         switch (resp.status) {
             200 => {},
+            408 => return error.Timeout,
             409 => return remoteGroupConflictError(resp.body),
             else => return error.UnexpectedHttpStatus,
         }
@@ -637,6 +652,19 @@ pub const ApiHttpClient = struct {
         table_name: []const u8,
         body: []const u8,
         max_work: u32,
+    ) !db_mod.RuntimePreflightSummary {
+        return self.fetchGroupQueryPreflightWithControl(base_uri, group_id, table_name, body, max_work, null, null);
+    }
+
+    pub fn fetchGroupQueryPreflightWithControl(
+        self: *ApiHttpClient,
+        base_uri: []const u8,
+        group_id: u64,
+        table_name: []const u8,
+        body: []const u8,
+        max_work: u32,
+        timeout_ms: ?u32,
+        cancellation: ?*const http_common.RequestCancellation,
     ) !db_mod.RuntimePreflightSummary {
         const suffix = try std.fmt.allocPrint(self.alloc, "{s}{s}{s}", .{
             routes.Routes.tables_prefix,
@@ -666,10 +694,13 @@ pub const ApiHttpClient = struct {
             .uri = uri,
             .content_type = "application/json",
             .body = preflight_body,
+            .timeout_ms = timeout_ms,
+            .cancellation = cancellation,
         });
         defer resp.deinit(self.alloc);
         switch (resp.status) {
             200 => {},
+            408 => return error.Timeout,
             400 => return remotePreflightError(resp.body),
             404 => return remotePreflightError(resp.body),
             409 => return remotePreflightError(resp.body),
@@ -892,6 +923,18 @@ pub const ApiHttpClient = struct {
         table_name: []const u8,
         body: []const u8,
     ) !QueryResponse {
+        return self.fetchGroupTextStatsWithControl(base_uri, group_id, table_name, body, null, null);
+    }
+
+    pub fn fetchGroupTextStatsWithControl(
+        self: *ApiHttpClient,
+        base_uri: []const u8,
+        group_id: u64,
+        table_name: []const u8,
+        body: []const u8,
+        timeout_ms: ?u32,
+        cancellation: ?*const http_common.RequestCancellation,
+    ) !QueryResponse {
         const suffix = try std.fmt.allocPrint(self.alloc, "{s}{s}{s}", .{
             routes.Routes.tables_prefix,
             table_name,
@@ -908,10 +951,13 @@ pub const ApiHttpClient = struct {
             .uri = uri,
             .content_type = "application/json",
             .body = body,
+            .timeout_ms = timeout_ms,
+            .cancellation = cancellation,
         });
         defer resp.deinit(self.alloc);
         switch (resp.status) {
             200 => {},
+            408 => return error.Timeout,
             409 => return remoteGroupConflictError(resp.body),
             else => return error.UnexpectedHttpStatus,
         }
@@ -924,6 +970,18 @@ pub const ApiHttpClient = struct {
         group_id: u64,
         table_name: []const u8,
         body: []const u8,
+    ) !QueryResponse {
+        return self.fetchGroupAlgebraicPartialsWithControl(base_uri, group_id, table_name, body, null, null);
+    }
+
+    pub fn fetchGroupAlgebraicPartialsWithControl(
+        self: *ApiHttpClient,
+        base_uri: []const u8,
+        group_id: u64,
+        table_name: []const u8,
+        body: []const u8,
+        timeout_ms: ?u32,
+        cancellation: ?*const http_common.RequestCancellation,
     ) !QueryResponse {
         const suffix = try std.fmt.allocPrint(self.alloc, "{s}{s}{s}", .{
             routes.Routes.tables_prefix,
@@ -941,10 +999,13 @@ pub const ApiHttpClient = struct {
             .uri = uri,
             .content_type = "application/json",
             .body = body,
+            .timeout_ms = timeout_ms,
+            .cancellation = cancellation,
         });
         defer resp.deinit(self.alloc);
         switch (resp.status) {
             200 => {},
+            408 => return error.Timeout,
             409 => return remoteGroupConflictError(resp.body),
             else => return error.UnexpectedHttpStatus,
         }
@@ -1184,6 +1245,18 @@ pub const ApiHttpClient = struct {
         table_name: []const u8,
         body: []const u8,
     ) !QueryResponse {
+        return self.fetchGroupVectorWorkerWithControl(base_uri, group_id, table_name, body, null, null);
+    }
+
+    pub fn fetchGroupVectorWorkerWithControl(
+        self: *ApiHttpClient,
+        base_uri: []const u8,
+        group_id: u64,
+        table_name: []const u8,
+        body: []const u8,
+        timeout_ms: ?u32,
+        cancellation: ?*const http_common.RequestCancellation,
+    ) !QueryResponse {
         const suffix = try std.fmt.allocPrint(self.alloc, "{s}{s}{s}", .{
             routes.Routes.tables_prefix,
             table_name,
@@ -1200,10 +1273,13 @@ pub const ApiHttpClient = struct {
             .uri = uri,
             .content_type = "application/json",
             .body = body,
+            .timeout_ms = timeout_ms,
+            .cancellation = cancellation,
         });
         defer resp.deinit(self.alloc);
         switch (resp.status) {
             200 => {},
+            408 => return error.Timeout,
             404 => return error.UnknownGroup,
             409 => return remoteGroupConflictError(resp.body),
             else => return error.UnexpectedHttpStatus,
@@ -2766,7 +2842,7 @@ test "api http client forwards internal query controls and maps remote timeout" 
             self.calls += 1;
             try std.testing.expectEqual(@as(u32, 37), req.timeout_ms.?);
             try std.testing.expectEqual(http_common.Method.POST, req.method);
-            if (std.mem.indexOf(u8, req.uri, "/graph-") != null) {
+            if (std.mem.indexOf(u8, req.uri, "/join-") == null) {
                 try std.testing.expect(req.cancellation != null);
             }
             return .{
@@ -2779,15 +2855,20 @@ test "api http client forwards internal query controls and maps remote timeout" 
     var executor = TimeoutExecutor{};
     var client = ApiHttpClient.init(std.testing.allocator, executor.executor());
     const base_uri = "http://127.0.0.1:1";
+    var cancellation = http_common.RequestCancellation{};
+    try std.testing.expectError(error.Timeout, client.fetchGroupQueryWithControl(base_uri, 7, "docs", "{}", 37, &cancellation));
+    try std.testing.expectError(error.Timeout, client.fetchGroupQueryPreflightWithControl(base_uri, 7, "docs", "{}", 0, 37, &cancellation));
+    try std.testing.expectError(error.Timeout, client.fetchGroupTextStatsWithControl(base_uri, 7, "docs", "{}", 37, &cancellation));
+    try std.testing.expectError(error.Timeout, client.fetchGroupVectorWorkerWithControl(base_uri, 7, "docs", "{}", 37, &cancellation));
+    try std.testing.expectError(error.Timeout, client.fetchGroupAlgebraicPartialsWithControl(base_uri, 7, "docs", "{}", 37, &cancellation));
     try std.testing.expectError(error.Timeout, client.fetchGroupJoinPartitionWithTimeout(base_uri, 7, "docs", "{}", 37));
     try std.testing.expectError(error.Timeout, client.fetchGroupJoinRowsWithTimeout(base_uri, 7, "docs", "{}", 37));
     try std.testing.expectError(error.Timeout, client.fetchGroupJoinUnmatchedWithTimeout(base_uri, 7, "docs", "{}", 37));
     try std.testing.expectError(error.Timeout, client.fetchGroupJoinFinalizeWithTimeout(base_uri, 7, "docs", "{}", 37));
-    var cancellation = http_common.RequestCancellation{};
     try std.testing.expectError(error.Timeout, client.fetchGroupGraphExpandWithControl(base_uri, 7, "docs", "{}", 37, &cancellation));
     try std.testing.expectError(error.Timeout, client.fetchGroupGraphHydrateWithControl(base_uri, 7, "docs", "{}", 37, &cancellation));
     try std.testing.expectError(error.Timeout, client.fetchGroupGraphEdgesWithControl(base_uri, 7, "docs", "{}", 37, &cancellation));
-    try std.testing.expectEqual(@as(usize, 7), executor.calls);
+    try std.testing.expectEqual(@as(usize, 12), executor.calls);
 }
 
 test "api http client encodes table name for repair cancel callback" {

--- a/zig/pkg/antfly/src/api/table_reads.zig
+++ b/zig/pkg/antfly/src/api/table_reads.zig
@@ -125,6 +125,23 @@ fn checkQueryDeadline(req: db_mod.types.SearchRequest) !void {
     if (platform_time.monotonicNs() >= deadline_ns) return error.Timeout;
 }
 
+fn queryRemainingTimeoutMs(req: db_mod.types.SearchRequest) !?u32 {
+    try checkQueryDeadline(req);
+    const deadline_ns = req.execution_deadline_ns orelse return null;
+    const now_ns = platform_time.monotonicNs();
+    if (now_ns >= deadline_ns) return error.Timeout;
+    const remaining_ns = deadline_ns - now_ns;
+    const rounded_ms = @max(
+        @as(u64, 1),
+        std.math.divCeil(u64, remaining_ns, std.time.ns_per_ms) catch 1,
+    );
+    return @intCast(@min(rounded_ms, @as(u64, std.math.maxInt(u32))));
+}
+
+fn queryRequestCancellation(req: db_mod.types.SearchRequest) http_common.RequestCancellation {
+    return .{ .borrowed = req.cancellation };
+}
+
 fn nsToUsFloat(ns: u64) f64 {
     return @as(f64, @floatFromInt(ns)) / 1000.0;
 }
@@ -4664,6 +4681,7 @@ fn collectHostedSearchRequestTextStatsParallel(
     group_ids: []const u64,
     table_name: []const u8,
     body: []const u8,
+    req: db_mod.types.SearchRequest,
     consistency: raft_mod.ReadConsistency,
 ) ![]const distributed_stats_mod.TextFieldStats {
     const start_ns = platform_time.monotonicNs();
@@ -4681,6 +4699,7 @@ fn collectHostedSearchRequestTextStatsParallel(
             group_id: u64,
             table_name_inner: []const u8,
             body_inner: []const u8,
+            req_inner: db_mod.types.SearchRequest,
         ) void {
             const arena = slot.arena.allocator();
             var response = switch (route) {
@@ -4695,7 +4714,7 @@ fn collectHostedSearchRequestTextStatsParallel(
                     table_name_inner,
                     body_inner,
                 ),
-                .remote => |remote| textStatsRemote(source.executor, arena, remote.base_uri, group_id, table_name_inner, body_inner),
+                .remote => |remote| textStatsRemote(source.executor, arena, remote.base_uri, group_id, table_name_inner, body_inner, req_inner),
             } catch |err| {
                 slot.err = err;
                 return;
@@ -4716,7 +4735,7 @@ fn collectHostedSearchRequestTextStatsParallel(
         const end = @min(start + width, group_ids.len);
         var group: std.Io.Group = .init;
         for (group_ids[start..end], start..end) |group_id, i| {
-            group.async(io, Fiber.run, .{ self, &slots[i], routes[i], group_id, table_name, body });
+            group.async(io, Fiber.run, .{ self, &slots[i], routes[i], group_id, table_name, body, req });
         }
         group.await(io) catch {};
     }
@@ -11556,7 +11575,7 @@ fn collectHostedAlgebraicDistributedPartials(
                 break :blk try collectAlgebraicPartialsFromDbForRequest(alloc, &db, parsed);
             },
             .remote => |remote| blk: {
-                var response = (algebraicPartialsRemote(self.executor, alloc, remote.base_uri, group_id, table_name, body) catch return null) orelse return null;
+                var response = (algebraicPartialsRemote(self.executor, alloc, remote.base_uri, group_id, table_name, body, req) catch return null) orelse return null;
                 defer response.deinit(alloc);
                 break :blk try parseAlgebraicPartialsResponse(alloc, response.json);
             },
@@ -13011,7 +13030,7 @@ fn collectHostedSearchRequestTextStats(
     const plan = planFanout(.text_stats, self.io_impl, group_ids.len);
     recordFanoutPlan(.text_stats, plan);
     if (plan.parallel) {
-        return try collectHostedSearchRequestTextStatsParallel(self, alloc, self.io_impl.?.io(), plan.width, group_ids, table_name, body, consistency);
+        return try collectHostedSearchRequestTextStatsParallel(self, alloc, self.io_impl.?.io(), plan.width, group_ids, table_name, body, req, consistency);
     }
     if (plan.reason == .no_io) recordParallelFanoutFallback(.text_stats);
 
@@ -13027,7 +13046,7 @@ fn collectHostedSearchRequestTextStats(
         defer route.deinit(alloc);
         var response = switch (route) {
             .local => (try collectProvisionedHostedLocalTextStats(null, self.replica_root_dir, self.catalog, alloc, group_id, self.visibleRootGeneration(group_id), self.backend_runtime, table_name, body)) orelse return error.TableNotFound,
-            .remote => |remote| (try textStatsRemote(self.executor, alloc, remote.base_uri, group_id, table_name, body)) orelse return error.TableNotFound,
+            .remote => |remote| (try textStatsRemote(self.executor, alloc, remote.base_uri, group_id, table_name, body, req)) orelse return error.TableNotFound,
         };
         defer response.deinit(alloc);
         shard_stats[i] = try parseTextStatsResponse(alloc, response.json);
@@ -13145,7 +13164,7 @@ fn collectHostedAggregationTextStats(
         defer route.deinit(alloc);
         var response = switch (route) {
             .local => (try collectProvisionedHostedLocalTextStats(null, self.replica_root_dir, self.catalog, alloc, group_id, self.visibleRootGeneration(group_id), self.backend_runtime, table_name, body)) orelse return error.TableNotFound,
-            .remote => |remote| (try textStatsRemote(self.executor, alloc, remote.base_uri, group_id, table_name, body)) orelse return error.TableNotFound,
+            .remote => |remote| (try textStatsRemote(self.executor, alloc, remote.base_uri, group_id, table_name, body, req)) orelse return error.TableNotFound,
         };
         defer response.deinit(alloc);
         shard_stats[i] = try parseTextStatsResponse(alloc, response.json);
@@ -13188,7 +13207,7 @@ fn collectHostedAggregationBackgroundTextStats(
         defer route.deinit(alloc);
         var response = switch (route) {
             .local => (try collectProvisionedHostedLocalTextStats(null, self.replica_root_dir, self.catalog, alloc, group_id, self.visibleRootGeneration(group_id), self.backend_runtime, table_name, body)) orelse return error.TableNotFound,
-            .remote => |remote| (try textStatsRemote(self.executor, alloc, remote.base_uri, group_id, table_name, body)) orelse return error.TableNotFound,
+            .remote => |remote| (try textStatsRemote(self.executor, alloc, remote.base_uri, group_id, table_name, body, req)) orelse return error.TableNotFound,
         };
         defer response.deinit(alloc);
         shard_stats[i] = try parseBackgroundTextStatsResponse(alloc, response.json);
@@ -13557,9 +13576,12 @@ fn queryRemote(
 ) !db_mod.types.SearchResult {
     var client = http_client.ApiHttpClient.init(alloc, executor);
     if (searchRequestHasUnserializableResolvedDocFilter(req)) return error.UnsupportedQueryRequest;
+    const timeout_ms = try queryRemainingTimeoutMs(req);
+    var cancellation = queryRequestCancellation(req);
+    const cancellation_ptr = if (req.cancellation != null) &cancellation else null;
     if (try encodeAlgebraicVectorWorkerRequestForSearchRequestAlloc(alloc, req)) |body| {
         defer alloc.free(body);
-        var result = try client.fetchGroupVectorWorker(base_uri, group_id, table_name, body);
+        var result = try client.fetchGroupVectorWorkerWithControl(base_uri, group_id, table_name, body, timeout_ms, cancellation_ptr);
         defer result.deinit(alloc);
         var parsed = try parseRemoteSearchResult(alloc, result.body);
         parsed.identity_read_generation = req.identity_read_generation;
@@ -13567,7 +13589,7 @@ fn queryRemote(
     }
     const body = try encodeQueryRequest(alloc, req);
     defer alloc.free(body);
-    var result = try client.fetchGroupQuery(base_uri, group_id, table_name, body);
+    var result = try client.fetchGroupQueryWithControl(base_uri, group_id, table_name, body, timeout_ms, cancellation_ptr);
     defer result.deinit(alloc);
     var parsed = try parseRemoteSearchResult(alloc, result.body);
     parsed.identity_read_generation = req.identity_read_generation;
@@ -13585,9 +13607,12 @@ fn preflightRemote(
 ) !db_mod.RuntimePreflightSummary {
     var client = http_client.ApiHttpClient.init(alloc, executor);
     if (searchRequestHasUnserializableResolvedDocFilter(req)) return error.UnsupportedQueryRequest;
+    const timeout_ms = try queryRemainingTimeoutMs(req);
+    var cancellation = queryRequestCancellation(req);
+    const cancellation_ptr = if (req.cancellation != null) &cancellation else null;
     const body = try encodeQueryRequest(alloc, req);
     defer alloc.free(body);
-    var summary = try client.fetchGroupQueryPreflight(base_uri, group_id, table_name, body, max_work);
+    var summary = try client.fetchGroupQueryPreflightWithControl(base_uri, group_id, table_name, body, max_work, timeout_ms, cancellation_ptr);
     summary.remote_shard_count = summary.shard_count;
     return summary;
 }
@@ -13599,9 +13624,13 @@ fn textStatsRemote(
     group_id: u64,
     table_name: []const u8,
     body: []const u8,
+    req: db_mod.types.SearchRequest,
 ) !?query_api.QueryResponse {
     var client = http_client.ApiHttpClient.init(alloc, executor);
-    var result = try client.fetchGroupTextStats(base_uri, group_id, table_name, body);
+    const timeout_ms = try queryRemainingTimeoutMs(req);
+    var cancellation = queryRequestCancellation(req);
+    const cancellation_ptr = if (req.cancellation != null) &cancellation else null;
+    var result = try client.fetchGroupTextStatsWithControl(base_uri, group_id, table_name, body, timeout_ms, cancellation_ptr);
     defer result.deinit(alloc);
     return .{ .json = try alloc.dupe(u8, result.body) };
 }
@@ -13613,9 +13642,13 @@ fn algebraicPartialsRemote(
     group_id: u64,
     table_name: []const u8,
     body: []const u8,
+    req: db_mod.types.SearchRequest,
 ) !?query_api.QueryResponse {
     var client = http_client.ApiHttpClient.init(alloc, executor);
-    var result = try client.fetchGroupAlgebraicPartials(base_uri, group_id, table_name, body);
+    const timeout_ms = try queryRemainingTimeoutMs(req);
+    var cancellation = queryRequestCancellation(req);
+    const cancellation_ptr = if (req.cancellation != null) &cancellation else null;
+    var result = try client.fetchGroupAlgebraicPartialsWithControl(base_uri, group_id, table_name, body, timeout_ms, cancellation_ptr);
     defer result.deinit(alloc);
     return .{ .json = try alloc.dupe(u8, result.body) };
 }
@@ -18304,6 +18337,89 @@ test "vector worker preflight annotation tracks eligibility and symbolic filters
     annotateVectorWorkerPreflight(alloc, &non_vector, .{ .query = .{ .match_all = {} } });
     try std.testing.expectEqual(@as(u32, 0), non_vector.vector_worker_candidate_count);
     try std.testing.expectEqual(@as(u32, 0), non_vector.vector_worker_fallback_count);
+}
+
+test "remote shard query phases propagate deadline and request cancellation" {
+    const alloc = std.testing.allocator;
+
+    const ExecutorState = struct {
+        signal: *const std.atomic.Value(bool),
+        calls: usize = 0,
+
+        fn iface(self: *@This()) http_common.RequestExecutor {
+            return .{
+                .ptr = self,
+                .vtable = &.{ .execute = execute },
+            };
+        }
+
+        fn execute(ptr: *anyopaque, _: std.mem.Allocator, req: http_common.HttpRequest) !http_common.HttpResponse {
+            const self: *@This() = @ptrCast(@alignCast(ptr));
+            self.calls += 1;
+            try std.testing.expect(req.timeout_ms != null);
+            try std.testing.expect(req.timeout_ms.? > 0);
+            try std.testing.expect(req.timeout_ms.? <= 60_000);
+            const cancellation = req.cancellation orelse return error.TestExpectedCancellation;
+            try std.testing.expect(cancellation.signal() == self.signal);
+            try std.testing.expect(!cancellation.isCancelled());
+            return error.Timeout;
+        }
+    };
+
+    var cancelled = std.atomic.Value(bool).init(false);
+    var state = ExecutorState{ .signal = &cancelled };
+    const controlled_request = db_mod.types.SearchRequest{
+        .execution_deadline_ns = platform_time.monotonicNs() + 60 * std.time.ns_per_s,
+        .cancellation = &cancelled,
+    };
+    try std.testing.expectError(error.Timeout, queryRemote(
+        state.iface(),
+        alloc,
+        "http://remote.test",
+        11,
+        "docs",
+        controlled_request,
+    ));
+
+    var vector_request = controlled_request;
+    vector_request.index_name = "dense_idx";
+    vector_request.query = .{ .dense_knn = .{ .vector = &.{ 0.25, 0.5 }, .k = 7 } };
+    try std.testing.expectError(error.Timeout, queryRemote(
+        state.iface(),
+        alloc,
+        "http://remote.test",
+        11,
+        "docs",
+        vector_request,
+    ));
+    try std.testing.expectError(error.Timeout, preflightRemote(
+        state.iface(),
+        alloc,
+        "http://remote.test",
+        11,
+        "docs",
+        controlled_request,
+        0,
+    ));
+    try std.testing.expectError(error.Timeout, textStatsRemote(
+        state.iface(),
+        alloc,
+        "http://remote.test",
+        11,
+        "docs",
+        "{}",
+        controlled_request,
+    ));
+    try std.testing.expectError(error.Timeout, algebraicPartialsRemote(
+        state.iface(),
+        alloc,
+        "http://remote.test",
+        11,
+        "docs",
+        "{}",
+        controlled_request,
+    ));
+    try std.testing.expectEqual(@as(usize, 5), state.calls);
 }
 
 test "remote simple vector query uses vector worker route" {

--- a/zig/pkg/antfly/src/api/table_reads.zig
+++ b/zig/pkg/antfly/src/api/table_reads.zig
@@ -22,6 +22,7 @@ const metadata_api = @import("../metadata/api.zig");
 const metadata_mod = @import("../metadata/mod.zig");
 const metadata_reconciler = @import("../metadata/reconciler.zig");
 const common_secrets = @import("../common/secrets.zig");
+const threaded_io_limits = @import("../common/threaded_io_limits.zig");
 const metadata_table_manager = @import("../metadata/table_manager.zig");
 const metadata_table_provisioner = @import("../metadata/table_provisioner.zig");
 const metadata_transition_state = @import("../metadata/transition_state.zig");
@@ -334,7 +335,7 @@ pub const ProvisionedTableReadCache = struct {
     pub fn init(alloc: std.mem.Allocator) ProvisionedTableReadCache {
         return .{
             .alloc = alloc,
-            .threaded = Io.Threaded.init(alloc, .{}),
+            .threaded = threaded_io_limits.initService(alloc),
         };
     }
 
@@ -1005,6 +1006,16 @@ pub const ProvisionedTableReadCache = struct {
         unreachable;
     }
 };
+
+test "provisioned table read cache has a finite worker ceiling" {
+    var cache = ProvisionedTableReadCache.init(std.testing.allocator);
+    defer cache.deinit();
+
+    try std.testing.expectEqual(
+        std.Io.Limit.limited(threaded_io_limits.service),
+        cache.threaded.concurrent_limit,
+    );
+}
 
 fn identityNamespacesEqual(left: ?db_mod.DocIdentityNamespace, right: ?db_mod.DocIdentityNamespace) bool {
     if (left == null or right == null) return left == null and right == null;

--- a/zig/pkg/antfly/src/api/table_writes.zig
+++ b/zig/pkg/antfly/src/api/table_writes.zig
@@ -20,6 +20,7 @@ const metadata_openapi = @import("antfly_metadata_openapi");
 const scraping = @import("antfly_scraping");
 const common_secrets = @import("../common/secrets.zig");
 const fs_paths = @import("../common/fs_paths.zig");
+const threaded_io_limits = @import("../common/threaded_io_limits.zig");
 const backups_api = @import("backups.zig");
 const metadata_admin = @import("../metadata/admin.zig");
 const metadata_mod = @import("../metadata/mod.zig");
@@ -5271,7 +5272,7 @@ pub const ProvisionedTableWriteSource = struct {
         return .{
             .replica_root_dir = replica_root_dir,
             .catalog = catalog,
-            .table_activity_threaded = Io.Threaded.init(std.heap.page_allocator, .{}),
+            .table_activity_threaded = threaded_io_limits.initService(std.heap.page_allocator),
         };
     }
 
@@ -14517,6 +14518,16 @@ pub const ProvisionedTableWriteSource = struct {
         return result;
     }
 };
+
+test "provisioned table write source has a finite worker ceiling" {
+    var source = ProvisionedTableWriteSource.init("unused", table_catalog.emptyCatalogSource());
+    defer source.deinit();
+
+    try std.testing.expectEqual(
+        std.Io.Limit.limited(threaded_io_limits.service),
+        source.table_activity_threaded.concurrent_limit,
+    );
+}
 
 fn enforceHAWriteGateOptional(gate: ?db_mod.HAWriteGate) !void {
     const configured = gate orelse return;

--- a/zig/pkg/antfly/src/common/health_server.zig
+++ b/zig/pkg/antfly/src/common/health_server.zig
@@ -239,7 +239,11 @@ pub const HealthServer = struct {
         if (self.metrics == null or self.metrics_refresh_future != null) return;
         self.metrics_refresh_stop.store(false, .release);
         if (self.metrics_refresh_io == null) {
-            self.metrics_refresh_io = Io.Threaded.init(self.alloc, .{ .stack_size = health_thread_stack_size });
+            self.metrics_refresh_io = Io.Threaded.init(self.alloc, .{
+                .stack_size = health_thread_stack_size,
+                // This executor owns exactly one long-lived refresh future.
+                .concurrent_limit = .limited(1),
+            });
         }
         const io = self.metrics_refresh_io.?.io();
         self.metrics_refresh_future = try io.concurrent(metricsRefreshTask, .{self});

--- a/zig/pkg/antfly/src/common/http/peer_disconnect_observer.zig
+++ b/zig/pkg/antfly/src/common/http/peer_disconnect_observer.zig
@@ -46,6 +46,12 @@ fn monotonicNowNs() ?u64 {
 /// threads per listener while retaining O(n) descriptors and a small, fixed
 /// polling cadence.
 pub const Observer = struct {
+    pub const DeadlineOutcome = enum {
+        completed,
+        expired,
+        observer_failed,
+    };
+
     pub const Deadline = struct {
         const State = enum(u8) {
             pending,
@@ -96,6 +102,19 @@ pub const Observer = struct {
             const observer = self.observer orelse return;
             observer.unregister(self.id);
             self.* = .{};
+        }
+
+        /// Atomically retires a deadline registration before publishing its
+        /// terminal outcome to the socket owner. A pending deadline becomes a
+        /// successful completion only after unregister() has excluded the
+        /// observer from any later shutdown of the descriptor.
+        pub fn finishDeadline(self: *Registration, deadline: *const Deadline) DeadlineOutcome {
+            self.deinit();
+            return switch (deadline.state.load(.acquire)) {
+                .pending => .completed,
+                .expired => .expired,
+                .observer_failed => .observer_failed,
+            };
         }
     };
 
@@ -628,12 +647,18 @@ test "std http listener socket observer unregisters completed deadline without f
     defer observer.deinit();
     var deadline: Observer.Deadline = .{};
     var registration = try observer.registerDeadline(sockets[1], 50, &deadline, null);
-    registration.deinit();
+    try std.testing.expectEqual(Observer.DeadlineOutcome.completed, registration.finishDeadline(&deadline));
     sleepMs(100);
 
     try std.testing.expect(!deadline.didExpire());
     try std.testing.expectEqual(@as(usize, 0), observer.activeCount());
     try std.testing.expectEqual(@as(u64, 0), observer.deadlineExpirationsTotal());
+    // Completion owns the socket once unregister returns; a stale observer
+    // must never shut it down after the stack-backed deadline leaves scope.
+    try std.testing.expectEqual(@as(isize, 1), std.c.send(sockets[0], "C", 1, 0));
+    var received: [1]u8 = undefined;
+    try std.testing.expectEqual(@as(isize, 1), std.c.recv(sockets[1], &received, received.len, 0));
+    try std.testing.expectEqualStrings("C", &received);
 }
 
 test "std http listener socket observer distinguishes observer failure from timeout" {

--- a/zig/pkg/antfly/src/common/http/peer_disconnect_observer.zig
+++ b/zig/pkg/antfly/src/common/http/peer_disconnect_observer.zig
@@ -28,20 +28,63 @@ fn sleepMs(ms: u64) void {
     };
 }
 
-/// A bounded, multiplexed H1 peer-lifetime observer.
+fn monotonicNowNs() ?u64 {
+    if (comptime builtin.os.tag == .windows or builtin.os.tag == .freestanding) return null;
+    var ts: std.posix.timespec = undefined;
+    if (std.posix.errno(std.posix.system.clock_gettime(.MONOTONIC, &ts)) != .SUCCESS) return null;
+    const seconds = std.math.cast(u64, ts.sec) orelse return null;
+    const nanos = std.math.cast(u64, ts.nsec) orelse return null;
+    return std.math.add(u64, std.math.mul(u64, seconds, std.time.ns_per_s) catch return null, nanos) catch null;
+}
+
+/// A bounded, multiplexed H1 socket-lifetime observer.
 ///
-/// One owner thread watches every admitted request. This deliberately avoids
-/// `Io.concurrent`: the threaded Io backend assigns a blocking poll to one
-/// worker and permanently grows its worker pool for each simultaneous request.
-/// The registry therefore keeps cancellation O(1) threads per listener while
-/// retaining O(n) descriptors and a small, fixed polling cadence.
+/// One owner thread watches every admitted request for peer disconnects and
+/// enforces header/body deadlines. This deliberately avoids `Io.concurrent`:
+/// the threaded Io backend permanently retains one worker for every concurrent
+/// blocking timeout race. The registry therefore keeps observation O(1)
+/// threads per listener while retaining O(n) descriptors and a small, fixed
+/// polling cadence.
 pub const Observer = struct {
-    const Entry = struct {
-        id: u64,
-        fd: std.posix.fd_t,
+    pub const Deadline = struct {
+        const State = enum(u8) {
+            pending,
+            expired,
+            observer_failed,
+        };
+
+        state: std.atomic.Value(State) = .init(.pending),
+
+        pub fn didExpire(self: *const Deadline) bool {
+            return self.state.load(.acquire) == .expired;
+        }
+
+        pub fn observerFailed(self: *const Deadline) bool {
+            return self.state.load(.acquire) == .observer_failed;
+        }
+    };
+
+    const PeerAction = struct {
         cancellation: *http_common.RequestCancellation,
         peer_disconnects_total: ?*std.atomic.Value(u64),
         observer_failures_total: ?*std.atomic.Value(u64),
+    };
+
+    const DeadlineAction = struct {
+        state: *Deadline,
+        expires_at_ns: u64,
+        expirations_total: ?*std.atomic.Value(u64),
+    };
+
+    const Action = union(enum) {
+        peer: PeerAction,
+        deadline: DeadlineAction,
+    };
+
+    const Entry = struct {
+        id: u64,
+        fd: std.posix.fd_t,
+        action: Action,
         unread_input: bool = false,
     };
 
@@ -62,6 +105,9 @@ pub const Observer = struct {
     entries: std.ArrayListUnmanaged(Entry) = .empty,
     next_id: u64 = 1,
     active_count: std.atomic.Value(usize) = .init(0),
+    active_peer_count: std.atomic.Value(usize) = .init(0),
+    active_deadline_count: std.atomic.Value(usize) = .init(0),
+    deadline_expirations_total: std.atomic.Value(u64) = .init(0),
     stopping: std.atomic.Value(bool) = .init(false),
     thread: ?std.Thread = null,
     /// A single kqueue observes EOF behind unread pipelined bytes on Darwin.
@@ -100,6 +146,8 @@ pub const Observer = struct {
         // scope. Any residue here indicates a lifecycle bug and cannot be read.
         std.debug.assert(self.entries.items.len == 0);
         std.debug.assert(self.active_count.load(.acquire) == 0);
+        std.debug.assert(self.active_peer_count.load(.acquire) == 0);
+        std.debug.assert(self.active_deadline_count.load(.acquire) == 0);
         self.entries.deinit(self.alloc);
     }
 
@@ -115,6 +163,10 @@ pub const Observer = struct {
 
         platform_sync.lockYielding(&self.mutex);
         defer self.mutex.unlock();
+        // Close the check/register race with deinit() and fatal observer
+        // failures. Once stopping is published, no stack-backed action may be
+        // admitted because no owner thread is guaranteed to retire it.
+        if (self.stopping.load(.acquire)) return error.ObserverUnavailable;
         if (self.entries.items.len >= self.capacity) return error.ObserverCapacityExceeded;
 
         const id = self.nextId();
@@ -122,16 +174,66 @@ pub const Observer = struct {
         self.entries.appendAssumeCapacity(.{
             .id = id,
             .fd = fd,
-            .cancellation = cancellation,
-            .peer_disconnects_total = peer_disconnects_total,
-            .observer_failures_total = observer_failures_total,
+            .action = .{ .peer = .{
+                .cancellation = cancellation,
+                .peer_disconnects_total = peer_disconnects_total,
+                .observer_failures_total = observer_failures_total,
+            } },
         });
         _ = self.active_count.fetchAdd(1, .release);
+        _ = self.active_peer_count.fetchAdd(1, .release);
+        return .{ .observer = self, .id = id };
+    }
+
+    pub fn registerDeadline(
+        self: *Observer,
+        fd: std.posix.fd_t,
+        timeout_ms: u32,
+        state: *Deadline,
+        expirations_total: ?*std.atomic.Value(u64),
+    ) !Registration {
+        if (comptime builtin.os.tag == .windows or builtin.os.tag == .freestanding)
+            return error.ObserverUnavailable;
+        if (self.thread == null or self.stopping.load(.acquire)) return error.ObserverUnavailable;
+        const now_ns = monotonicNowNs() orelse return error.ObserverUnavailable;
+        const timeout_ns = std.math.mul(u64, timeout_ms, std.time.ns_per_ms) catch std.math.maxInt(u64);
+        const expires_at_ns = std.math.add(u64, now_ns, timeout_ns) catch std.math.maxInt(u64);
+        state.state.store(.pending, .release);
+
+        platform_sync.lockYielding(&self.mutex);
+        defer self.mutex.unlock();
+        if (self.stopping.load(.acquire)) return error.ObserverUnavailable;
+        if (self.entries.items.len >= self.capacity) return error.ObserverCapacityExceeded;
+
+        const id = self.nextId();
+        self.entries.appendAssumeCapacity(.{
+            .id = id,
+            .fd = fd,
+            .action = .{ .deadline = .{
+                .state = state,
+                .expires_at_ns = expires_at_ns,
+                .expirations_total = expirations_total,
+            } },
+        });
+        _ = self.active_count.fetchAdd(1, .release);
+        _ = self.active_deadline_count.fetchAdd(1, .release);
         return .{ .observer = self, .id = id };
     }
 
     pub fn activeCount(self: *const Observer) usize {
         return self.active_count.load(.acquire);
+    }
+
+    pub fn activePeerCount(self: *const Observer) usize {
+        return self.active_peer_count.load(.acquire);
+    }
+
+    pub fn activeDeadlineCount(self: *const Observer) usize {
+        return self.active_deadline_count.load(.acquire);
+    }
+
+    pub fn deadlineExpirationsTotal(self: *const Observer) u64 {
+        return self.deadline_expirations_total.load(.acquire);
     }
 
     fn nextId(self: *Observer) u64 {
@@ -148,9 +250,7 @@ pub const Observer = struct {
         defer self.mutex.unlock();
         for (self.entries.items, 0..) |entry, index| {
             if (entry.id != id) continue;
-            if (comptime builtin.os.tag == .macos) self.updateKqueue(entry.fd, id, false) catch {};
-            _ = self.entries.swapRemove(index);
-            _ = self.active_count.fetchSub(1, .release);
+            self.removeEntryLocked(index);
             return;
         }
     }
@@ -179,6 +279,7 @@ pub const Observer = struct {
                 continue;
             }
             for (self.entries.items) |entry| {
+                if (entry.action != .peer) continue;
                 // POLL constants are comptime integers. Give the mutable mask
                 // the ABI type used by pollfd.events so Linux can add RDHUP at
                 // runtime without leaving `events` inferred as comptime_int.
@@ -199,6 +300,11 @@ pub const Observer = struct {
             if (ready > 0) {
                 platform_sync.lockYielding(&self.mutex);
                 self.processPollEventsLocked(fds.items, ids.items);
+                self.expireDeadlinesLocked();
+                self.mutex.unlock();
+            } else {
+                platform_sync.lockYielding(&self.mutex);
+                self.expireDeadlinesLocked();
                 self.mutex.unlock();
             }
         }
@@ -258,6 +364,7 @@ pub const Observer = struct {
                     self.peekEntryLocked(index);
                 }
             }
+            self.expireDeadlinesLocked();
             self.mutex.unlock();
         }
     }
@@ -287,6 +394,7 @@ pub const Observer = struct {
 
     fn peekEntryLocked(self: *Observer, index: usize) void {
         const entry = &self.entries.items[index];
+        std.debug.assert(entry.action == .peer);
         var byte: [1]u8 = undefined;
         const n = std.c.recv(entry.fd, &byte, byte.len, @intCast(std.posix.MSG.PEEK | std.posix.MSG.DONTWAIT));
         if (n == 0) {
@@ -318,54 +426,105 @@ pub const Observer = struct {
 
     fn cancelEntryLocked(self: *Observer, index: usize, peer_disconnect: bool) void {
         const entry = self.entries.items[index];
+        const peer = switch (entry.action) {
+            .peer => |value| value,
+            .deadline => unreachable,
+        };
         if (peer_disconnect) {
-            if (entry.peer_disconnects_total) |counter| _ = counter.fetchAdd(1, .monotonic);
+            if (peer.peer_disconnects_total) |counter| _ = counter.fetchAdd(1, .monotonic);
         } else {
-            if (entry.observer_failures_total) |counter| _ = counter.fetchAdd(1, .monotonic);
+            if (peer.observer_failures_total) |counter| _ = counter.fetchAdd(1, .monotonic);
         }
-        entry.cancellation.cancel();
-        if (comptime builtin.os.tag == .macos) self.updateKqueue(entry.fd, entry.id, false) catch {};
+        peer.cancellation.cancel();
+        self.removeEntryLocked(index);
+    }
+
+    fn expireDeadlinesLocked(self: *Observer) void {
+        const now_ns = monotonicNowNs() orelse {
+            self.failAllLocked();
+            self.stopping.store(true, .release);
+            return;
+        };
+        var index: usize = 0;
+        while (index < self.entries.items.len) {
+            const entry = self.entries.items[index];
+            const deadline = switch (entry.action) {
+                .deadline => |value| value,
+                .peer => {
+                    index += 1;
+                    continue;
+                },
+            };
+            if (now_ns < deadline.expires_at_ns) {
+                index += 1;
+                continue;
+            }
+            deadline.state.state.store(.expired, .release);
+            _ = self.deadline_expirations_total.fetchAdd(1, .monotonic);
+            if (deadline.expirations_total) |counter| _ = counter.fetchAdd(1, .monotonic);
+            _ = std.c.shutdown(entry.fd, std.c.SHUT.RDWR);
+            self.removeEntryLocked(index);
+        }
+    }
+
+    fn removeEntryLocked(self: *Observer, index: usize) void {
+        const entry = self.entries.items[index];
+        switch (entry.action) {
+            .peer => {
+                if (comptime builtin.os.tag == .macos) self.updateKqueue(entry.fd, entry.id, false) catch {};
+                _ = self.active_peer_count.fetchSub(1, .release);
+            },
+            .deadline => {
+                _ = self.active_deadline_count.fetchSub(1, .release);
+            },
+        }
         _ = self.entries.swapRemove(index);
         _ = self.active_count.fetchSub(1, .release);
     }
 
     fn failAllLocked(self: *Observer) void {
-        while (self.entries.items.len > 0) self.cancelEntryLocked(self.entries.items.len - 1, false);
+        while (self.entries.items.len > 0) {
+            const index = self.entries.items.len - 1;
+            const entry = self.entries.items[index];
+            switch (entry.action) {
+                .peer => self.cancelEntryLocked(index, false),
+                .deadline => |deadline| {
+                    deadline.state.state.store(.observer_failed, .release);
+                    _ = std.c.shutdown(entry.fd, std.c.SHUT.RDWR);
+                    self.removeEntryLocked(index);
+                },
+            }
+        }
     }
 };
 
 test "std http listener multiplexed peer observer cancels many disconnected sockets with one owner thread" {
     if (comptime builtin.os.tag == .windows or builtin.os.tag == .freestanding) return;
-    const io = std.Io.Threaded.global_single_threaded.io();
-    var listener = try (std.Io.net.IpAddress{ .ip4 = .{ .bytes = .{ 127, 0, 0, 1 }, .port = 0 } }).listen(io, .{});
-    defer listener.deinit(io);
-
     var observer = Observer.init(std.testing.allocator, 32);
     try observer.start();
     defer observer.deinit();
 
-    var clients: [32]std.Io.net.Stream = undefined;
-    var servers: [32]std.Io.net.Stream = undefined;
+    var sockets: [32][2]std.posix.fd_t = undefined;
     var cancellations = [_]http_common.RequestCancellation{.{}} ** 32;
     var registrations: [32]Observer.Registration = undefined;
     var initialized: usize = 0;
-    var clients_open = true;
+    var clients_open: usize = 0;
     defer {
         for (registrations[0..initialized]) |*registration| registration.deinit();
-        if (clients_open) for (clients[0..initialized]) |*stream| stream.close(io);
-        for (servers[0..initialized]) |*stream| stream.close(io);
+        for (sockets[clients_open..initialized]) |pair| _ = std.posix.system.close(pair[0]);
+        for (sockets[0..initialized]) |pair| _ = std.posix.system.close(pair[1]);
     }
     for (0..32) |index| {
-        clients[index] = try listener.socket.address.connect(io, .{ .mode = .stream });
-        servers[index] = try listener.accept(io);
-        registrations[index] = try observer.register(servers[index].socket.handle, &cancellations[index], null, null);
+        if (std.c.socketpair(std.c.AF.UNIX, std.c.SOCK.STREAM, 0, &sockets[index]) != 0)
+            return error.Unexpected;
+        registrations[index] = try observer.register(sockets[index][1], &cancellations[index], null, null);
         initialized += 1;
     }
     try std.testing.expectEqual(@as(usize, 32), observer.activeCount());
-    for (&clients) |*stream| {
-        stream.close(io);
+    for (&sockets) |pair| {
+        _ = std.posix.system.close(pair[0]);
+        clients_open += 1;
     }
-    clients_open = false;
 
     for (0..400) |_| {
         var cancelled: usize = 0;
@@ -380,33 +539,144 @@ test "std http listener multiplexed peer observer cancels many disconnected sock
 
 test "std http listener peer observer sees FIN behind unread bytes without consuming them" {
     if (comptime builtin.os.tag == .windows or builtin.os.tag == .freestanding) return;
-    const io = std.Io.Threaded.global_single_threaded.io();
-    var listener = try (std.Io.net.IpAddress{ .ip4 = .{ .bytes = .{ 127, 0, 0, 1 }, .port = 0 } }).listen(io, .{});
-    defer listener.deinit(io);
-    var client = try listener.socket.address.connect(io, .{ .mode = .stream });
-    defer client.close(io);
-    var server = try listener.accept(io);
-    defer server.close(io);
+    var sockets: [2]std.posix.fd_t = undefined;
+    if (std.c.socketpair(std.c.AF.UNIX, std.c.SOCK.STREAM, 0, &sockets) != 0)
+        return error.Unexpected;
+    defer _ = std.posix.system.close(sockets[0]);
+    defer _ = std.posix.system.close(sockets[1]);
 
     var observer = Observer.init(std.testing.allocator, 1);
     try observer.start();
     defer observer.deinit();
     var cancellation: http_common.RequestCancellation = .{};
-    var registration = try observer.register(server.socket.handle, &cancellation, null, null);
+    var registration = try observer.register(sockets[1], &cancellation, null, null);
     defer registration.deinit();
 
-    var write_buffer: [1]u8 = undefined;
-    var writer = client.writer(io, &write_buffer);
-    try writer.interface.writeAll("B");
-    try writer.interface.flush();
-    try io.vtable.netShutdown(io.userdata, client.socket.handle, .send);
+    try std.testing.expectEqual(@as(isize, 1), std.c.send(sockets[0], "B", 1, 0));
+    try std.testing.expectEqual(@as(c_int, 0), std.c.shutdown(sockets[0], std.c.SHUT.WR));
     for (0..400) |_| {
         if (cancellation.isCancelled()) break;
         sleepMs(5);
     }
     try std.testing.expect(cancellation.isCancelled());
     var queued: [1]u8 = undefined;
-    const read_len = std.c.recv(server.socket.handle, &queued, queued.len, 0);
+    const read_len = std.c.recv(sockets[1], &queued, queued.len, 0);
     try std.testing.expectEqual(@as(isize, 1), read_len);
     try std.testing.expectEqualStrings("B", &queued);
+}
+
+fn runDeadlineStormRound(observer: *Observer) !void {
+    const batch_size = 32;
+    var sockets: [32][2]std.posix.fd_t = undefined;
+    var deadlines = [_]Observer.Deadline{.{}} ** 32;
+    var registrations: [32]Observer.Registration = undefined;
+    var initialized: usize = 0;
+    defer {
+        for (registrations[0..initialized]) |*registration| registration.deinit();
+        for (sockets[0..initialized]) |pair| {
+            _ = std.posix.system.close(pair[0]);
+            _ = std.posix.system.close(pair[1]);
+        }
+    }
+
+    for (0..32) |index| {
+        if (std.c.socketpair(std.c.AF.UNIX, std.c.SOCK.STREAM, 0, &sockets[index]) != 0)
+            return error.Unexpected;
+        registrations[index] = try observer.registerDeadline(
+            sockets[index][1],
+            250,
+            &deadlines[index],
+            null,
+        );
+        initialized += 1;
+    }
+    try std.testing.expectEqual(@as(usize, batch_size), observer.activeDeadlineCount());
+
+    for (0..400) |_| {
+        if (observer.activeDeadlineCount() == 0) break;
+        sleepMs(5);
+    }
+    for (&deadlines) |*deadline| try std.testing.expect(deadline.didExpire());
+    try std.testing.expectEqual(@as(usize, 0), observer.activeCount());
+    try std.testing.expectEqual(@as(usize, 0), observer.activePeerCount());
+    try std.testing.expectEqual(@as(usize, 0), observer.activeDeadlineCount());
+}
+
+test "std http listener socket observer does not ratchet workers across deadline storms" {
+    if (comptime builtin.os.tag == .windows or builtin.os.tag == .freestanding) return;
+
+    var observer = Observer.init(std.testing.allocator, 32);
+    try observer.start();
+    defer observer.deinit();
+
+    for (0..4) |round| {
+        try runDeadlineStormRound(&observer);
+        try std.testing.expectEqual(@as(u64, @intCast((round + 1) * 32)), observer.deadlineExpirationsTotal());
+    }
+}
+
+test "std http listener socket observer unregisters completed deadline without firing" {
+    if (comptime builtin.os.tag == .windows or builtin.os.tag == .freestanding) return;
+    var sockets: [2]std.posix.fd_t = undefined;
+    if (std.c.socketpair(std.c.AF.UNIX, std.c.SOCK.STREAM, 0, &sockets) != 0)
+        return error.Unexpected;
+    defer _ = std.posix.system.close(sockets[0]);
+    defer _ = std.posix.system.close(sockets[1]);
+
+    var observer = Observer.init(std.testing.allocator, 1);
+    try observer.start();
+    defer observer.deinit();
+    var deadline: Observer.Deadline = .{};
+    var registration = try observer.registerDeadline(sockets[1], 50, &deadline, null);
+    registration.deinit();
+    sleepMs(100);
+
+    try std.testing.expect(!deadline.didExpire());
+    try std.testing.expectEqual(@as(usize, 0), observer.activeCount());
+    try std.testing.expectEqual(@as(u64, 0), observer.deadlineExpirationsTotal());
+}
+
+test "std http listener socket observer distinguishes observer failure from timeout" {
+    if (comptime builtin.os.tag == .windows or builtin.os.tag == .freestanding) return;
+    var sockets: [2]std.posix.fd_t = undefined;
+    if (std.c.socketpair(std.c.AF.UNIX, std.c.SOCK.STREAM, 0, &sockets) != 0)
+        return error.Unexpected;
+    defer _ = std.posix.system.close(sockets[0]);
+    defer _ = std.posix.system.close(sockets[1]);
+
+    var observer = Observer.init(std.testing.allocator, 1);
+    try observer.start();
+    defer observer.deinit();
+    var deadline: Observer.Deadline = .{};
+    var registration = try observer.registerDeadline(sockets[1], 60_000, &deadline, null);
+    defer registration.deinit();
+
+    platform_sync.lockYielding(&observer.mutex);
+    observer.failAllLocked();
+    observer.mutex.unlock();
+    try std.testing.expect(deadline.observerFailed());
+    try std.testing.expect(!deadline.didExpire());
+    try std.testing.expectEqual(@as(u64, 0), observer.deadlineExpirationsTotal());
+    try std.testing.expectEqual(@as(usize, 0), observer.activeCount());
+}
+
+test "std http listener socket observer rejects registration after fatal stop" {
+    if (comptime builtin.os.tag == .windows or builtin.os.tag == .freestanding) return;
+    var sockets: [2]std.posix.fd_t = undefined;
+    if (std.c.socketpair(std.c.AF.UNIX, std.c.SOCK.STREAM, 0, &sockets) != 0)
+        return error.Unexpected;
+    defer _ = std.posix.system.close(sockets[0]);
+    defer _ = std.posix.system.close(sockets[1]);
+
+    var observer = Observer.init(std.testing.allocator, 1);
+    try observer.start();
+    defer observer.deinit();
+    observer.stopAfterRuntimeFailure();
+
+    var deadline: Observer.Deadline = .{};
+    try std.testing.expectError(
+        error.ObserverUnavailable,
+        observer.registerDeadline(sockets[1], 60_000, &deadline, null),
+    );
+    try std.testing.expectEqual(@as(usize, 0), observer.activeCount());
 }

--- a/zig/pkg/antfly/src/common/http/std_http_executor.zig
+++ b/zig/pkg/antfly/src/common/http/std_http_executor.zig
@@ -613,3 +613,86 @@ test "std http executor cancellation interrupts a request queued for the pooled 
     try std.testing.expect(cancelled_while_queued);
     try std.testing.expectEqual(@as(u8, 1), request_state.outcome.load(.acquire));
 }
+
+test "std http executor cancellation interrupts an active response wait" {
+    const App = struct {
+        entered: std.atomic.Value(bool) = .init(false),
+        exited: std.atomic.Value(bool) = .init(false),
+
+        fn executor(self: *@This()) common.RequestExecutor {
+            return .{ .ptr = self, .vtable = &.{ .execute = execute } };
+        }
+
+        fn execute(ptr: *anyopaque, alloc: std.mem.Allocator, req: common.HttpRequest) !common.HttpResponse {
+            const self: *@This() = @ptrCast(@alignCast(ptr));
+            const cancellation = req.cancellation orelse return error.TestExpectedCancellation;
+            self.entered.store(true, .release);
+            while (!cancellation.isCancelled()) {
+                sleepTestMs(std.Io.Threaded.global_single_threaded.io(), 1);
+            }
+            self.exited.store(true, .release);
+            return .{ .status = 200, .body = try alloc.dupe(u8, "cancelled") };
+        }
+    };
+
+    const RequestTask = struct {
+        executor: common.RequestExecutor,
+        uri: []const u8,
+        cancellation: *const common.RequestCancellation,
+        outcome: std.atomic.Value(u8) = .init(0),
+
+        fn run(self: *@This()) void {
+            var response = self.executor.execute(std.heap.page_allocator, .{
+                .method = .GET,
+                .uri = self.uri,
+                .cancellation = self.cancellation,
+            }) catch |err| {
+                self.outcome.store(if (err == error.Cancelled) 1 else 2, .release);
+                return;
+            };
+            response.deinit(std.heap.page_allocator);
+            self.outcome.store(3, .release);
+        }
+    };
+
+    var app = App{};
+    var listener = std_http_listener.StdHttpListener.init(std.testing.allocator, .{
+        .serve_in_connection_threads = true,
+    }, app.executor());
+    defer listener.deinit();
+    try listener.start();
+
+    const uri = try listener.baseUri(std.testing.allocator);
+    defer std.testing.allocator.free(uri);
+    var executor = StdHttpExecutor.init(std.testing.allocator, .{});
+    defer executor.deinit();
+    var cancellation = common.RequestCancellation{};
+    var task = RequestTask{
+        .executor = executor.executor(),
+        .uri = uri,
+        .cancellation = &cancellation,
+    };
+    var task_io = std.Io.Threaded.init(std.testing.allocator, .{
+        .concurrent_limit = .limited(1),
+    });
+    defer task_io.deinit();
+    var group: std.Io.Group = .init;
+    try group.concurrent(task_io.io(), RequestTask.run, .{&task});
+    var group_active = true;
+    defer if (group_active) group.cancel(task_io.io());
+
+    for (0..2_000) |_| {
+        if (app.entered.load(.acquire)) break;
+        sleepTestMs(std.Io.Threaded.global_single_threaded.io(), 1);
+    }
+    try std.testing.expect(app.entered.load(.acquire));
+    cancellation.cancel();
+    for (0..2_000) |_| {
+        if (task.outcome.load(.acquire) != 0 and app.exited.load(.acquire)) break;
+        sleepTestMs(std.Io.Threaded.global_single_threaded.io(), 1);
+    }
+    try std.testing.expectEqual(@as(u8, 1), task.outcome.load(.acquire));
+    try std.testing.expect(app.exited.load(.acquire));
+    try group.await(task_io.io());
+    group_active = false;
+}

--- a/zig/pkg/antfly/src/common/http/std_http_executor.zig
+++ b/zig/pkg/antfly/src/common/http/std_http_executor.zig
@@ -24,6 +24,11 @@ pub const StdHttpExecutorConfig = struct {
     write_buffer_size: usize = 1024,
     max_response_bytes: usize = 4 << 20,
     thread_stack_size: usize = std_http_listener.default_request_stack_size,
+    /// Hard ceiling for retained workers used by timeout/cancellation-aware
+    /// requests. Callers normally stay well below this through listener and
+    /// query admission; the finite limit prevents an abnormal fan-out from
+    /// permanently growing the owned Threaded executor without bound.
+    io_concurrent_limit: u32 = std_http_listener.default_process_io_concurrent_limit,
     keep_alive: bool = false,
     /// Proactively retire pooled HTTP/1.1 connections before a server-side
     /// keep-alive cap closes them. 0 means unlimited client-side reuse.
@@ -52,7 +57,10 @@ pub const StdHttpExecutor = struct {
 
     pub fn initInPlace(self: *StdHttpExecutor, alloc: std.mem.Allocator, cfg: StdHttpExecutorConfig) void {
         const io_impl = alloc.create(std.Io.Threaded) catch @panic("OOM");
-        io_impl.* = std.Io.Threaded.init(alloc, .{ .stack_size = cfg.thread_stack_size });
+        io_impl.* = std.Io.Threaded.init(alloc, .{
+            .stack_size = cfg.thread_stack_size,
+            .concurrent_limit = .limited(cfg.io_concurrent_limit),
+        });
         const io_vtable = threaded_connect_io.createVTable(alloc, io_impl) catch @panic("OOM");
         self.* = .{
             .alloc = alloc,
@@ -471,6 +479,15 @@ fn shouldForwardRequestHeader(headers: []const common.RequestHeader, name: []con
 test "std http executor module compiles" {
     _ = StdHttpExecutorConfig;
     _ = StdHttpExecutor;
+}
+
+test "std http executor owns a finite controlled request worker budget" {
+    var executor = StdHttpExecutor.init(std.testing.allocator, .{
+        .io_concurrent_limit = 7,
+    });
+    defer executor.deinit();
+
+    try std.testing.expectEqual(std.Io.Limit.limited(7), executor.io_impl.concurrent_limit);
 }
 
 test "std http executor forwards only end-to-end request headers" {

--- a/zig/pkg/antfly/src/common/http/std_http_listener.zig
+++ b/zig/pkg/antfly/src/common/http/std_http_listener.zig
@@ -2364,7 +2364,7 @@ test "std http listener process threads and descriptors recover after cancellati
     sleepMs(100);
     const baseline_threads = try countLinuxProcEntries("/proc/self/task");
     const baseline_fds = try countLinuxProcEntries("/proc/self/fd");
-    var recovered_thread_min = std.math.maxInt(usize);
+    var recovered_thread_min: usize = std.math.maxInt(usize);
     var recovered_thread_max: usize = 0;
 
     for (0..rounds) |_| {

--- a/zig/pkg/antfly/src/common/http/std_http_listener.zig
+++ b/zig/pkg/antfly/src/common/http/std_http_listener.zig
@@ -17,6 +17,7 @@ const std = @import("std");
 const platform_sync = @import("antfly_platform").sync;
 const common = @import("http_common.zig");
 const PeerObserver = @import("peer_disconnect_observer.zig").Observer;
+const threaded_io_limits = @import("../threaded_io_limits.zig");
 
 pub const default_max_request_bytes: usize = 32 * 1024 * 1024;
 pub const default_request_stack_size: usize = 8 * 1024 * 1024;
@@ -24,7 +25,7 @@ pub const default_header_read_timeout_ms: u32 = 30_000;
 pub const default_body_read_timeout_ms: u32 = 120_000;
 pub const default_accept_error_backoff_initial_ms: u32 = 5;
 pub const default_accept_error_backoff_max_ms: u32 = 1_000;
-pub const default_process_io_concurrent_limit: u32 = 256;
+pub const default_process_io_concurrent_limit: u32 = threaded_io_limits.service;
 
 const ProcessIo = struct {
     var lock: std.atomic.Mutex = .unlocked;

--- a/zig/pkg/antfly/src/common/http/std_http_listener.zig
+++ b/zig/pkg/antfly/src/common/http/std_http_listener.zig
@@ -547,17 +547,23 @@ pub const StdHttpListener = struct {
                 _ = self.deadline_observer_failures_total.fetchAdd(1, .monotonic);
                 return err;
             };
-            defer registration.deinit();
-
             const receive_result = server.receiveHead();
-            if (deadline.observerFailed()) {
-                _ = self.deadline_observer_failures_total.fetchAdd(1, .monotonic);
-                _ = receive_result catch {};
-                return error.ObserverUnavailable;
-            }
-            if (deadline.didExpire()) {
-                _ = receive_result catch {};
-                return error.Timeout;
+            // Retire the registration before inspecting its outcome. This is
+            // the completion/expiration arbitration point: once deinit()
+            // returns, the observer no longer owns the stack-backed deadline
+            // and cannot shut down a successfully completed socket between
+            // the state check and this function returning.
+            switch (registration.finishDeadline(&deadline)) {
+                .completed => {},
+                .observer_failed => {
+                    _ = self.deadline_observer_failures_total.fetchAdd(1, .monotonic);
+                    _ = receive_result catch {};
+                    return error.ObserverUnavailable;
+                },
+                .expired => {
+                    _ = receive_result catch {};
+                    return error.Timeout;
+                },
             }
             return try receive_result;
         }
@@ -953,17 +959,20 @@ pub const StdHttpListener = struct {
                 _ = self.deadline_observer_failures_total.fetchAdd(1, .monotonic);
                 return err;
             };
-            defer registration.deinit();
-
             const read_result = body_reader.allocRemaining(self.alloc, .limited(self.cfg.max_request_bytes));
-            if (deadline.observerFailed()) {
-                _ = self.deadline_observer_failures_total.fetchAdd(1, .monotonic);
-                if (read_result) |body| self.alloc.free(body) else |_| {}
-                return error.ObserverUnavailable;
-            }
-            if (deadline.didExpire()) {
-                if (read_result) |body| self.alloc.free(body) else |_| {}
-                return error.Timeout;
+            // See receiveHeadWithTimeout: unregister synchronously so normal
+            // completion and expiration have one mutex-ordered winner.
+            switch (registration.finishDeadline(&deadline)) {
+                .completed => {},
+                .observer_failed => {
+                    _ = self.deadline_observer_failures_total.fetchAdd(1, .monotonic);
+                    if (read_result) |body| self.alloc.free(body) else |_| {}
+                    return error.ObserverUnavailable;
+                },
+                .expired => {
+                    if (read_result) |body| self.alloc.free(body) else |_| {}
+                    return error.Timeout;
+                },
             }
             return try read_result;
         }
@@ -2303,6 +2312,114 @@ test "std http listener body timeout releases accepted slow body connection slot
     try std.testing.expect(stats.deadline_expirations_total >= 1);
     try std.testing.expectEqual(@as(u64, 0), stats.deadline_observer_failures_total);
     try std.testing.expectEqual(@as(usize, 0), stats.active_deadline_observers);
+}
+
+fn countLinuxProcEntries(path: []const u8) !usize {
+    const io = std.Io.Threaded.global_single_threaded.io();
+    var dir = try std.Io.Dir.openDirAbsolute(io, path, .{ .iterate = true });
+    defer dir.close(io);
+    var iterator = dir.iterate();
+    var count: usize = 0;
+    while (try iterator.next(io)) |_| count += 1;
+    return count;
+}
+
+test "std http listener process threads and descriptors recover after cancellation storms" {
+    if (comptime builtin.os.tag != .linux) return;
+
+    if (std.c.getenv("ANTFLY_REQUIRE_LOW_FD_HTTP_RATCHET") != null) {
+        const nofile = try std.posix.getrlimit(.NOFILE);
+        try std.testing.expectEqual(@as(u64, 256), nofile.cur);
+    }
+
+    const App = struct {
+        fn executor(self: *@This()) common.RequestExecutor {
+            return .{ .ptr = self, .vtable = &.{ .execute = execute } };
+        }
+
+        fn execute(_: *anyopaque, alloc: std.mem.Allocator, _: common.HttpRequest) !common.HttpResponse {
+            return .{ .status = 200, .body = try alloc.dupe(u8, "ok") };
+        }
+    };
+
+    const batch_size = 48;
+    const rounds = 4;
+    const thread_slack = 4;
+    const fd_slack = 8;
+    var app = App{};
+    var listener = StdHttpListener.init(std.heap.page_allocator, .{
+        .serve_in_connection_threads = true,
+        .max_connection_threads = 64,
+        .header_read_timeout_ms = 30_000,
+    }, app.executor());
+    defer listener.deinit();
+    try listener.start();
+    const bound_addr = listener.boundAddress().?;
+    const client_io = std.Io.Threaded.global_single_threaded.io();
+
+    // Let the accept and observer owners reach their steady idle state before
+    // measuring the process. The accept loop reserves one connection slot
+    // while blocked in accept(); no client socket is active at this point.
+    sleepMs(100);
+    const baseline_threads = try countLinuxProcEntries("/proc/self/task");
+    const baseline_fds = try countLinuxProcEntries("/proc/self/fd");
+    var recovered_thread_min = std.math.maxInt(usize);
+    var recovered_thread_max: usize = 0;
+
+    for (0..rounds) |_| {
+        var clients = [_]?std.Io.net.Stream{null} ** batch_size;
+        defer for (&clients) |*maybe_stream| {
+            if (maybe_stream.*) |*stream| stream.close(client_io);
+        };
+
+        for (&clients) |*slot| slot.* = try bound_addr.connect(client_io, .{ .mode = .stream });
+
+        var loaded = false;
+        for (0..400) |_| {
+            const stats = listener.runtimeStats();
+            if (stats.active_deadline_observers >= batch_size and
+                stats.active_connection_threads >= batch_size)
+            {
+                loaded = true;
+                break;
+            }
+            sleepMs(5);
+        }
+        try std.testing.expect(loaded);
+        try std.testing.expect((try countLinuxProcEntries("/proc/self/task")) >= baseline_threads + batch_size);
+
+        for (&clients) |*maybe_stream| {
+            if (maybe_stream.*) |*stream| {
+                stream.shutdown(client_io, .both) catch {};
+                stream.close(client_io);
+                maybe_stream.* = null;
+            }
+        }
+
+        var recovered = false;
+        var recovered_threads: usize = 0;
+        for (0..2_000) |_| {
+            const stats = listener.runtimeStats();
+            const threads = try countLinuxProcEntries("/proc/self/task");
+            const fds = try countLinuxProcEntries("/proc/self/fd");
+            if (stats.active_deadline_observers == 0 and
+                stats.active_peer_observers == 0 and
+                stats.active_connection_threads <= 1 and
+                threads <= baseline_threads + thread_slack and
+                fds <= baseline_fds + fd_slack)
+            {
+                recovered = true;
+                recovered_threads = threads;
+                break;
+            }
+            sleepMs(5);
+        }
+        try std.testing.expect(recovered);
+        recovered_thread_min = @min(recovered_thread_min, recovered_threads);
+        recovered_thread_max = @max(recovered_thread_max, recovered_threads);
+    }
+
+    try std.testing.expect(recovered_thread_max - recovered_thread_min <= thread_slack);
 }
 
 test "std http listener stop interrupts accepted header read" {

--- a/zig/pkg/antfly/src/common/http/std_http_listener.zig
+++ b/zig/pkg/antfly/src/common/http/std_http_listener.zig
@@ -24,6 +24,7 @@ pub const default_header_read_timeout_ms: u32 = 30_000;
 pub const default_body_read_timeout_ms: u32 = 120_000;
 pub const default_accept_error_backoff_initial_ms: u32 = 5;
 pub const default_accept_error_backoff_max_ms: u32 = 1_000;
+pub const default_process_io_concurrent_limit: u32 = 256;
 
 const ProcessIo = struct {
     var lock: std.atomic.Mutex = .unlocked;
@@ -38,6 +39,10 @@ const ProcessIo = struct {
             const io_impl = std.heap.page_allocator.create(std.Io.Threaded) catch @panic("OOM");
             io_impl.* = std.Io.Threaded.init(std.heap.page_allocator, .{
                 .stack_size = default_request_stack_size,
+                // Public listeners multiplex deadlines and peer observation
+                // outside the executor. Keep a finite backstop for any other
+                // concurrent work submitted through this process-wide runtime.
+                .concurrent_limit = .limited(default_process_io_concurrent_limit),
             });
             runtime = io_impl;
         }
@@ -108,8 +113,11 @@ pub const StdHttpListener = struct {
         rejected_requests_total: u64,
         accept_errors_total: u64,
         cancellation_watcher_start_failures_total: u64,
+        deadline_observer_failures_total: u64,
+        deadline_expirations_total: u64,
         peer_disconnects_total: u64,
         active_peer_observers: usize,
+        active_deadline_observers: usize,
     };
 
     const IoOwner = enum {
@@ -133,6 +141,8 @@ pub const StdHttpListener = struct {
     rejected_requests_total: std.atomic.Value(u64) = .init(0),
     accept_errors_total: std.atomic.Value(u64) = .init(0),
     cancellation_watcher_start_failures_total: std.atomic.Value(u64) = .init(0),
+    deadline_observer_failures_total: std.atomic.Value(u64) = .init(0),
+    deadline_expirations_total: std.atomic.Value(u64) = .init(0),
     peer_disconnects_total: std.atomic.Value(u64) = .init(0),
     peer_observer: ?PeerObserver = null,
     active_streams_lock: std.atomic.Mutex = .unlocked,
@@ -304,8 +314,11 @@ pub const StdHttpListener = struct {
             .rejected_requests_total = self.rejected_requests_total.load(.acquire),
             .accept_errors_total = self.accept_errors_total.load(.acquire),
             .cancellation_watcher_start_failures_total = self.cancellation_watcher_start_failures_total.load(.acquire),
+            .deadline_observer_failures_total = self.deadline_observer_failures_total.load(.acquire),
+            .deadline_expirations_total = self.deadline_expirations_total.load(.acquire),
             .peer_disconnects_total = self.peer_disconnects_total.load(.acquire),
-            .active_peer_observers = if (self.peer_observer) |*observer| observer.activeCount() else 0,
+            .active_peer_observers = if (self.peer_observer) |*observer| observer.activePeerCount() else 0,
+            .active_deadline_observers = if (self.peer_observer) |*observer| observer.activeDeadlineCount() else 0,
         };
     }
 
@@ -519,6 +532,39 @@ pub const StdHttpListener = struct {
         const timeout_ms = self.cfg.header_read_timeout_ms;
         if (timeout_ms == 0) return try server.receiveHead();
 
+        if (comptime builtin.os.tag != .windows and builtin.os.tag != .freestanding) {
+            var deadline: PeerObserver.Deadline = .{};
+            const observer = if (self.peer_observer) |*value| value else {
+                _ = self.deadline_observer_failures_total.fetchAdd(1, .monotonic);
+                return error.ObserverUnavailable;
+            };
+            var registration = observer.registerDeadline(
+                stream.socket.handle,
+                timeout_ms,
+                &deadline,
+                &self.deadline_expirations_total,
+            ) catch |err| {
+                _ = self.deadline_observer_failures_total.fetchAdd(1, .monotonic);
+                return err;
+            };
+            defer registration.deinit();
+
+            const receive_result = server.receiveHead();
+            if (deadline.observerFailed()) {
+                _ = self.deadline_observer_failures_total.fetchAdd(1, .monotonic);
+                _ = receive_result catch {};
+                return error.ObserverUnavailable;
+            }
+            if (deadline.didExpire()) {
+                _ = receive_result catch {};
+                return error.Timeout;
+            }
+            return try receive_result;
+        }
+
+        // Windows retains the threaded timeout race until the socket observer
+        // has a native wait-set implementation there. POSIX production paths
+        // never submit one sleeping Io.concurrent task per connection.
         const RaceState = enum(u8) {
             pending,
             receive_complete,
@@ -892,6 +938,37 @@ pub const StdHttpListener = struct {
         const timeout_ms = self.cfg.body_read_timeout_ms;
         if (timeout_ms == 0 or stream == null) return try body_reader.allocRemaining(self.alloc, .limited(self.cfg.max_request_bytes));
 
+        if (comptime builtin.os.tag != .windows and builtin.os.tag != .freestanding) {
+            var deadline: PeerObserver.Deadline = .{};
+            const observer = if (self.peer_observer) |*value| value else {
+                _ = self.deadline_observer_failures_total.fetchAdd(1, .monotonic);
+                return error.ObserverUnavailable;
+            };
+            var registration = observer.registerDeadline(
+                stream.?.socket.handle,
+                timeout_ms,
+                &deadline,
+                &self.deadline_expirations_total,
+            ) catch |err| {
+                _ = self.deadline_observer_failures_total.fetchAdd(1, .monotonic);
+                return err;
+            };
+            defer registration.deinit();
+
+            const read_result = body_reader.allocRemaining(self.alloc, .limited(self.cfg.max_request_bytes));
+            if (deadline.observerFailed()) {
+                _ = self.deadline_observer_failures_total.fetchAdd(1, .monotonic);
+                if (read_result) |body| self.alloc.free(body) else |_| {}
+                return error.ObserverUnavailable;
+            }
+            if (deadline.didExpire()) {
+                if (read_result) |body| self.alloc.free(body) else |_| {}
+                return error.Timeout;
+            }
+            return try read_result;
+        }
+
+        // See receiveHeadWithTimeout: this fallback is non-POSIX only.
         const RaceState = enum(u8) {
             pending,
             read_complete,
@@ -2014,7 +2091,7 @@ test "std http listener saturated connection slots queue instead of resetting" {
     try std.testing.expectEqual(@as(u16, 200), slow_req.status.load(.acquire));
 }
 
-test "std http listener responds before header timeout without async capacity" {
+test "std http listener serves timed requests without threaded async or concurrent capacity" {
     const std_http_executor = @import("std_http_executor.zig");
 
     const App = struct {
@@ -2039,13 +2116,17 @@ test "std http listener responds before header timeout without async capacity" {
     defer executor.deinit();
     const request_executor = executor.executor();
 
-    var listener = StdHttpListener.init(std.heap.page_allocator, .{
+    var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{
+        .async_limit = .nothing,
+        .concurrent_limit = .nothing,
+    });
+    defer io_impl.deinit();
+    var listener = StdHttpListener.initShared(std.heap.page_allocator, .{
         .serve_in_connection_threads = true,
         .header_read_timeout_ms = 10_000,
         .body_read_timeout_ms = 10_000,
-    }, app.executor());
+    }, app.executor(), &io_impl);
     defer listener.deinit();
-    listener.io_impl.setAsyncLimit(.nothing);
     try listener.start();
 
     const base_uri = try listener.baseUri(std.testing.allocator);
@@ -2098,11 +2179,16 @@ test "std http listener header timeout releases accepted idle connection slot" {
     defer executor.deinit();
     const request_executor = executor.executor();
 
-    var listener = StdHttpListener.init(std.heap.page_allocator, .{
+    var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{
+        .async_limit = .nothing,
+        .concurrent_limit = .nothing,
+    });
+    defer io_impl.deinit();
+    var listener = StdHttpListener.initShared(std.heap.page_allocator, .{
         .serve_in_connection_threads = true,
         .max_connection_threads = 1,
         .header_read_timeout_ms = 25,
-    }, app.executor());
+    }, app.executor(), &io_impl);
     defer listener.deinit();
     try listener.start();
 
@@ -2131,6 +2217,10 @@ test "std http listener header timeout releases accepted idle connection slot" {
     });
     defer response.deinit(std.testing.allocator);
     try std.testing.expectEqual(@as(u16, 200), response.status);
+    const stats = listener.runtimeStats();
+    try std.testing.expect(stats.deadline_expirations_total >= 1);
+    try std.testing.expectEqual(@as(u64, 0), stats.deadline_observer_failures_total);
+    try std.testing.expectEqual(@as(usize, 0), stats.active_deadline_observers);
 }
 
 test "std http listener body timeout releases accepted slow body connection slot" {
@@ -2160,12 +2250,17 @@ test "std http listener body timeout releases accepted slow body connection slot
     defer executor.deinit();
     const request_executor = executor.executor();
 
-    var listener = StdHttpListener.init(std.heap.page_allocator, .{
+    var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{
+        .async_limit = .nothing,
+        .concurrent_limit = .nothing,
+    });
+    defer io_impl.deinit();
+    var listener = StdHttpListener.initShared(std.heap.page_allocator, .{
         .serve_in_connection_threads = true,
         .max_connection_threads = 1,
         .header_read_timeout_ms = 5_000,
         .body_read_timeout_ms = 50,
-    }, app.executor());
+    }, app.executor(), &io_impl);
     defer listener.deinit();
     try listener.start();
 
@@ -2204,6 +2299,10 @@ test "std http listener body timeout releases accepted slow body connection slot
     });
     defer response.deinit(std.testing.allocator);
     try std.testing.expectEqual(@as(u16, 200), response.status);
+    const stats = listener.runtimeStats();
+    try std.testing.expect(stats.deadline_expirations_total >= 1);
+    try std.testing.expectEqual(@as(u64, 0), stats.deadline_observer_failures_total);
+    try std.testing.expectEqual(@as(usize, 0), stats.active_deadline_observers);
 }
 
 test "std http listener stop interrupts accepted header read" {

--- a/zig/pkg/antfly/src/common/mod.zig
+++ b/zig/pkg/antfly/src/common/mod.zig
@@ -25,6 +25,7 @@ pub const data_format = @import("data_format.zig");
 pub const fs_paths = @import("fs_paths.zig");
 pub const byte_copy = @import("byte_copy.zig");
 pub const cache_budget = @import("cache_budget.zig");
+pub const threaded_io_limits = @import("threaded_io_limits.zig");
 
 test {
     _ = provider_registry;
@@ -40,4 +41,5 @@ test {
     _ = fs_paths;
     _ = byte_copy;
     _ = cache_budget;
+    _ = threaded_io_limits;
 }

--- a/zig/pkg/antfly/src/common/threaded_io_limits.zig
+++ b/zig/pkg/antfly/src/common/threaded_io_limits.zig
@@ -1,0 +1,60 @@
+// Copyright 2026 Antfly, Inc.
+//
+// Licensed under the Elastic License 2.0 (ELv2); you may not use this file
+// except in compliance with the Elastic License 2.0. You may obtain a copy of
+// the Elastic License 2.0 at
+//
+//     https://www.antfly.io/licensing/ELv2-license
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the Elastic License 2.0 is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// Elastic License 2.0 for the specific language governing permissions and
+// limitations.
+
+//! Process-lifetime `std.Io.Threaded` concurrency ceilings.
+//!
+//! Threaded executors retain workers until deinitialization. Long-lived owners
+//! must therefore use a finite limit even when their normal workload has tighter
+//! admission control. These values are backstops, not scheduling targets.
+
+const std = @import("std");
+
+/// General ceiling for process- or database-lifetime executors. Production
+/// request, query, Raft, and index-worker admission stays below this value.
+pub const service: u32 = 256;
+
+/// The serverless object-store pool is shared by five storage lanes behind a
+/// listener admitting at most 64 connection handlers by default. Fourfold
+/// headroom covers background lanes and larger configured listeners without
+/// allowing unbounded retention.
+pub const serverless_object_store: u32 = service;
+
+pub fn initService(alloc: std.mem.Allocator) std.Io.Threaded {
+    return std.Io.Threaded.init(alloc, .{
+        .concurrent_limit = .limited(service),
+    });
+}
+
+pub fn initServerlessObjectStore(alloc: std.mem.Allocator) std.Io.Threaded {
+    return std.Io.Threaded.init(alloc, .{
+        .concurrent_limit = .limited(serverless_object_store),
+    });
+}
+
+test "threaded io production limits are finite" {
+    try std.testing.expect(service > 0);
+    try std.testing.expect(serverless_object_store > 0);
+    try std.testing.expect(serverless_object_store <= service);
+
+    var service_io = initService(std.testing.allocator);
+    defer service_io.deinit();
+    try std.testing.expectEqual(std.Io.Limit.limited(service), service_io.concurrent_limit);
+
+    var object_store_io = initServerlessObjectStore(std.testing.allocator);
+    defer object_store_io.deinit();
+    try std.testing.expectEqual(
+        std.Io.Limit.limited(serverless_object_store),
+        object_store_io.concurrent_limit,
+    );
+}

--- a/zig/pkg/antfly/src/data/runtime.zig
+++ b/zig/pkg/antfly/src/data/runtime.zig
@@ -1063,6 +1063,9 @@ pub const HealthSource = struct {
             try health_metrics.appendPromMetric(writer, "antfly_query_rejected_total", "counter", "Public queries rejected by admission control", http.rejected_requests_total);
             try health_metrics.appendPromMetric(writer, "antfly_http_accept_errors_total", "counter", "Public HTTP listener accept failures", http.accept_errors_total);
             try health_metrics.appendPromMetric(writer, "antfly_http_cancellation_watcher_start_failures_total", "counter", "Public requests cancelled because peer observation could not be scheduled", http.cancellation_watcher_start_failures_total);
+            try health_metrics.appendPromMetric(writer, "antfly_http_deadline_observer_failures_total", "counter", "Public requests closed because deadline observation could not be scheduled", http.deadline_observer_failures_total);
+            try health_metrics.appendPromMetric(writer, "antfly_http_deadline_expirations_total", "counter", "Public request sockets closed after header or body deadlines", http.deadline_expirations_total);
+            try health_metrics.appendPromMetric(writer, "antfly_http_active_deadline_observers", "gauge", "Public request sockets currently watched for header or body deadlines", http.active_deadline_observers);
             try health_metrics.appendPromMetric(writer, "antfly_http_peer_disconnects_total", "counter", "Public request peer disconnects propagated to cancellation", http.peer_disconnects_total);
             try health_metrics.appendPromMetric(writer, "antfly_http_active_peer_observers", "gauge", "Public request sockets currently watched for disconnect", http.active_peer_observers);
         }
@@ -4054,6 +4057,7 @@ pub const DataServer = struct {
         if (self.query_io_impl == null) {
             self.query_io_impl = std.Io.Threaded.init(self.alloc, .{
                 .async_limit = self.query_async_limit,
+                .concurrent_limit = .limited(backend_runtime_mod.default_io_concurrent_limit),
             });
         }
         _ = self.read_source.withIo(&self.query_io_impl.?);

--- a/zig/pkg/antfly/src/data/runtime.zig
+++ b/zig/pkg/antfly/src/data/runtime.zig
@@ -10300,7 +10300,10 @@ pub const DataServer = struct {
         defer self.auto_bulk_finish_mutex.unlock();
         if (self.auto_bulk_finish_future != null) return;
         if (self.auto_bulk_finish_io == null) {
-            self.auto_bulk_finish_io = std.Io.Threaded.init(self.alloc, .{});
+            self.auto_bulk_finish_io = std.Io.Threaded.init(self.alloc, .{
+                // requestAutoBulkFinishBackground serializes one worker.
+                .concurrent_limit = .limited(1),
+            });
         }
         self.auto_bulk_finish_stop.store(false, .release);
         const io = self.auto_bulk_finish_io.?.io();

--- a/zig/pkg/antfly/src/data/storage/db_split_handoff.zig
+++ b/zig/pkg/antfly/src/data/storage/db_split_handoff.zig
@@ -15,6 +15,7 @@
 const std = @import("std");
 const data_store = @import("raft_apply_store.zig");
 const fs_paths = @import("../../common/fs_paths.zig");
+const threaded_io_limits = @import("../../common/threaded_io_limits.zig");
 const shard_state_store = @import("shard_state_store.zig");
 const internal_keys = @import("../../storage/internal_keys.zig");
 const shard_mod = @import("../../storage/shard.zig");
@@ -189,7 +190,7 @@ pub const Destination = struct {
     }
 
     fn initWithCreateRoot(alloc: std.mem.Allocator, cfg: DestinationConfig, create_root: bool) !Destination {
-        var io_impl = std.Io.Threaded.init(alloc, .{});
+        var io_impl = threaded_io_limits.initService(alloc);
         errdefer io_impl.deinit();
 
         const root_dir = try alloc.dupe(u8, cfg.root_dir);
@@ -214,7 +215,7 @@ pub const Destination = struct {
     }
 
     pub fn initBorrowed(alloc: std.mem.Allocator, root_dir_raw: []const u8, lease: BorrowedDestinationDb) !Destination {
-        var io_impl = std.Io.Threaded.init(alloc, .{});
+        var io_impl = threaded_io_limits.initService(alloc);
         errdefer io_impl.deinit();
         return .{
             .alloc = alloc,

--- a/zig/pkg/antfly/src/data/storage/raft_apply_store.zig
+++ b/zig/pkg/antfly/src/data/storage/raft_apply_store.zig
@@ -17,6 +17,7 @@ const builtin = @import("builtin");
 const raft_engine = @import("raft_engine");
 const platform = @import("antfly_platform");
 const fs_paths = @import("../../common/fs_paths.zig");
+const threaded_io_limits = @import("../../common/threaded_io_limits.zig");
 const background_runtime = @import("../../storage/background_runtime.zig");
 const docstore = @import("../../storage/docstore.zig");
 const generation_lifecycle = @import("../../storage/db/generation_lifecycle.zig");
@@ -172,7 +173,7 @@ pub const RaftApplyStore = struct {
     };
 
     pub fn init(alloc: std.mem.Allocator, cfg: RaftApplyStoreConfig) !RaftApplyStore {
-        var io_impl = std.Io.Threaded.init(alloc, .{});
+        var io_impl = threaded_io_limits.initService(alloc);
         errdefer io_impl.deinit();
 
         const root_dir = try alloc.dupe(u8, cfg.root_dir);

--- a/zig/pkg/antfly/src/lmdb/env.zig
+++ b/zig/pkg/antfly/src/lmdb/env.zig
@@ -65,6 +65,10 @@ const use_evented_async_runtime =
     std.Io.Evented != void;
 
 const AsyncRuntime = if (use_evented_async_runtime) std.Io.Evented else std.Io.Threaded;
+// This module is built independently from the Antfly root module, so it cannot
+// import common/threaded_io_limits.zig. Keep the LMDB commit runtime finite at
+// the same conservative process-lifetime ceiling.
+const threaded_async_runtime_concurrent_limit: u32 = 256;
 pub const uses_evented_async_runtime = use_evented_async_runtime;
 pub const AsyncRuntimeType = AsyncRuntime;
 
@@ -626,8 +630,22 @@ pub fn initAsyncRuntime(runtime: *AsyncRuntime) Error!void {
     if (comptime use_evented_async_runtime) {
         try AsyncRuntime.init(runtime, heapAllocator(), .{});
     } else {
-        runtime.* = AsyncRuntime.init(heapAllocator(), .{});
+        runtime.* = AsyncRuntime.init(heapAllocator(), .{
+            .concurrent_limit = .limited(threaded_async_runtime_concurrent_limit),
+        });
     }
+}
+
+test "lmdb threaded async runtime has a finite worker ceiling" {
+    if (comptime use_evented_async_runtime) return error.SkipZigTest;
+
+    var runtime: AsyncRuntime = undefined;
+    try initAsyncRuntime(&runtime);
+    defer deinitAsyncRuntime(&runtime);
+    try std.testing.expectEqual(
+        std.Io.Limit.limited(threaded_async_runtime_concurrent_limit),
+        runtime.concurrent_limit,
+    );
 }
 
 pub fn deinitAsyncRuntime(runtime: *AsyncRuntime) void {

--- a/zig/pkg/antfly/src/metadata/storage/raft_apply_store.zig
+++ b/zig/pkg/antfly/src/metadata/storage/raft_apply_store.zig
@@ -15,6 +15,7 @@
 const std = @import("std");
 const raft_engine = @import("raft_engine");
 const fs_paths = @import("../../common/fs_paths.zig");
+const threaded_io_limits = @import("../../common/threaded_io_limits.zig");
 const group_ids = @import("../../common/group_ids.zig");
 const docstore = @import("../../storage/docstore.zig");
 const lsm_backend = @import("../../storage/lsm_backend.zig");
@@ -1007,7 +1008,7 @@ pub const RaftApplyStore = struct {
     };
 
     pub fn init(alloc: std.mem.Allocator, cfg: RaftApplyStoreConfig) !RaftApplyStore {
-        var io_impl = std.Io.Threaded.init(alloc, .{});
+        var io_impl = threaded_io_limits.initService(alloc);
         errdefer io_impl.deinit();
 
         const root_dir = try alloc.dupe(u8, cfg.root_dir);

--- a/zig/pkg/antfly/src/raft/enrichment_runtime.zig
+++ b/zig/pkg/antfly/src/raft/enrichment_runtime.zig
@@ -16,6 +16,7 @@ const builtin = @import("builtin");
 const std = @import("std");
 const leader_runtime = @import("leader_runtime.zig");
 const read_state_observer_mod = @import("state_machine/read_state_observer.zig");
+const threaded_io_limits = @import("../common/threaded_io_limits.zig");
 
 pub const ExecutorBackend = enum {
     simulated,
@@ -141,7 +142,7 @@ pub const ThreadedExecutor = struct {
     pub fn init(alloc: std.mem.Allocator) ThreadedExecutor {
         return .{
             .alloc = alloc,
-            .threaded = std.Io.Threaded.init(alloc, .{}),
+            .threaded = threaded_io_limits.initService(alloc),
         };
     }
 

--- a/zig/pkg/antfly/src/raft/state_machine/store_common.zig
+++ b/zig/pkg/antfly/src/raft/state_machine/store_common.zig
@@ -14,6 +14,7 @@
 
 const std = @import("std");
 const fs_paths = @import("../../common/fs_paths.zig");
+const threaded_io_limits = @import("../../common/threaded_io_limits.zig");
 const mod = @import("mod.zig");
 
 pub fn ApplyStore(comptime namespace: []const u8) type {
@@ -42,7 +43,7 @@ pub fn ApplyStore(comptime namespace: []const u8) type {
         pub fn init(alloc: std.mem.Allocator, cfg: Config) !Self {
             return .{
                 .alloc = alloc,
-                .io_impl = std.Io.Threaded.init(alloc, .{}),
+                .io_impl = threaded_io_limits.initService(alloc),
                 .root_dir = try alloc.dupe(u8, cfg.root_dir),
             };
         }

--- a/zig/pkg/antfly/src/raft/storage/backup_restore.zig
+++ b/zig/pkg/antfly/src/raft/storage/backup_restore.zig
@@ -14,6 +14,7 @@
 
 const std = @import("std");
 const fs_paths = @import("../../common/fs_paths.zig");
+const threaded_io_limits = @import("../../common/threaded_io_limits.zig");
 const backups_api = @import("../../api/backups.zig");
 const db_mod = @import("../../storage/db/mod.zig");
 const doc_identity = @import("../../storage/db/doc_identity.zig");
@@ -51,7 +52,7 @@ const RestoreIoScope = struct {
         }
         const owned = try alloc.create(std.Io.Threaded);
         errdefer alloc.destroy(owned);
-        owned.* = std.Io.Threaded.init(alloc, .{});
+        owned.* = threaded_io_limits.initService(alloc);
         return .{ .alloc = alloc, .io_value = owned.io(), .owned = owned };
     }
 

--- a/zig/pkg/antfly/src/raft/storage/catalog.zig
+++ b/zig/pkg/antfly/src/raft/storage/catalog.zig
@@ -14,6 +14,7 @@
 
 const std = @import("std");
 const fs_paths = @import("../../common/fs_paths.zig");
+const threaded_io_limits = @import("../../common/threaded_io_limits.zig");
 const raft_engine = @import("raft_engine");
 const platform_sync = @import("antfly_platform").sync;
 
@@ -471,7 +472,7 @@ pub const FileReplicaCatalog = struct {
     pub fn init(alloc: std.mem.Allocator, path: []const u8) !FileReplicaCatalog {
         var self = FileReplicaCatalog{
             .alloc = alloc,
-            .io_impl = std.Io.Threaded.init(alloc, .{}),
+            .io_impl = threaded_io_limits.initService(alloc),
             .path = try alloc.dupe(u8, path),
         };
         errdefer {

--- a/zig/pkg/antfly/src/raft/storage/file_snapshot_store.zig
+++ b/zig/pkg/antfly/src/raft/storage/file_snapshot_store.zig
@@ -14,6 +14,7 @@
 
 const std = @import("std");
 const fs_paths = @import("../../common/fs_paths.zig");
+const threaded_io_limits = @import("../../common/threaded_io_limits.zig");
 const http_server = @import("../transport/http_server.zig");
 
 pub const FileSnapshotStoreConfig = struct {
@@ -31,7 +32,7 @@ pub const FileSnapshotStore = struct {
         return .{
             .alloc = alloc,
             .cfg = cfg,
-            .io_impl = std.Io.Threaded.init(alloc, .{}),
+            .io_impl = threaded_io_limits.initService(alloc),
             .root_dir = try alloc.dupe(u8, cfg.root_dir),
         };
     }

--- a/zig/pkg/antfly/src/raft/storage/replica_state.zig
+++ b/zig/pkg/antfly/src/raft/storage/replica_state.zig
@@ -14,6 +14,7 @@
 
 const std = @import("std");
 const fs_paths = @import("../../common/fs_paths.zig");
+const threaded_io_limits = @import("../../common/threaded_io_limits.zig");
 const raft_engine = @import("raft_engine");
 const storage_mod = @import("mod.zig");
 const snapshot_payload_store = @import("snapshot_payload_store.zig");
@@ -51,7 +52,7 @@ pub const PersistentReplicaState = struct {
         alloc: std.mem.Allocator,
         layout: storage_mod.ReplicaPathLayout,
     ) !PersistentReplicaState {
-        var io_impl = std.Io.Threaded.init(alloc, .{});
+        var io_impl = threaded_io_limits.initService(alloc);
         var io_owned = true;
         errdefer if (io_owned) io_impl.deinit();
         const root_dir = try alloc.dupe(u8, layout.root_dir);

--- a/zig/pkg/antfly/src/raft/storage/wal_replica_state.zig
+++ b/zig/pkg/antfly/src/raft/storage/wal_replica_state.zig
@@ -14,6 +14,7 @@
 
 const std = @import("std");
 const fs_paths = @import("../../common/fs_paths.zig");
+const threaded_io_limits = @import("../../common/threaded_io_limits.zig");
 const raft_engine = @import("raft_engine");
 const platform_time = @import("antfly_platform").time;
 const wal_mod = @import("../../storage/wal.zig");
@@ -116,7 +117,7 @@ pub const WalReplicaState = struct {
         layout: storage_mod.ReplicaPathLayout,
         cfg: WalReplicaStateConfig,
     ) !WalReplicaState {
-        var io_impl = std.Io.Threaded.init(alloc, .{});
+        var io_impl = threaded_io_limits.initService(alloc);
         var io_owned = true;
         errdefer if (io_owned) io_impl.deinit();
 

--- a/zig/pkg/antfly/src/raft/transport/http_driver.zig
+++ b/zig/pkg/antfly/src/raft/transport/http_driver.zig
@@ -643,6 +643,7 @@ test "http frame driver propagates isolated worker executor configuration" {
         .read_buffer_size = 12_345,
         .write_buffer_size = 2_345,
         .max_response_bytes = 65_535,
+        .io_concurrent_limit = 23,
         .keep_alive = true,
         .max_requests_per_connection = 17,
     };
@@ -659,6 +660,7 @@ test "http frame driver propagates isolated worker executor configuration" {
     try std.testing.expectEqual(executor_config.read_buffer_size, actual.read_buffer_size);
     try std.testing.expectEqual(executor_config.write_buffer_size, actual.write_buffer_size);
     try std.testing.expectEqual(executor_config.max_response_bytes, actual.max_response_bytes);
+    try std.testing.expectEqual(executor_config.io_concurrent_limit, actual.io_concurrent_limit);
     try std.testing.expectEqual(executor_config.keep_alive, actual.keep_alive);
     try std.testing.expectEqual(executor_config.max_requests_per_connection, actual.max_requests_per_connection);
 }

--- a/zig/pkg/antfly/src/raft/transport/stack.zig
+++ b/zig/pkg/antfly/src/raft/transport/stack.zig
@@ -18,6 +18,7 @@ const http_common = @import("http_common.zig");
 const http_driver = @import("http_driver.zig");
 const http_server = @import("http_server.zig");
 const http_snapshot = @import("http_snapshot.zig");
+const threaded_io_limits = @import("../../common/threaded_io_limits.zig");
 
 pub const HttpTransportStackConfig = struct {
     driver: http_driver.HttpDriverConfig = .{},
@@ -47,7 +48,9 @@ pub const HttpTransportStack = struct {
         const driver_io = io orelse blk: {
             const io_impl = try alloc.create(std.Io.Threaded);
             errdefer alloc.destroy(io_impl);
-            io_impl.* = std.Io.Threaded.init(alloc, .{});
+            // Embedded hosts may omit a shared backend runtime. Keep that
+            // process-lifetime fallback finite as well.
+            io_impl.* = threaded_io_limits.initService(alloc);
             owned_io_impl = io_impl;
             break :blk io_impl.io();
         };
@@ -147,4 +150,8 @@ test "http transport stack compiles" {
     const hooks = stack.runtimeHooks();
     try std.testing.expect(hooks.transport != null);
     try std.testing.expect(hooks.snapshot_transport != null);
+    try std.testing.expectEqual(
+        std.Io.Limit.limited(threaded_io_limits.service),
+        stack.owned_io_impl.?.concurrent_limit,
+    );
 }

--- a/zig/pkg/antfly/src/root.zig
+++ b/zig/pkg/antfly/src/root.zig
@@ -284,8 +284,6 @@ test {
     _ = bloom;
     _ = jsonschema;
     _ = common;
-    _ = @import("common/http/peer_disconnect_observer.zig");
-    _ = @import("common/http/std_http_listener.zig");
     _ = foreign;
     _ = @import("foreign/postgres_libpq.zig");
     _ = embeddings;

--- a/zig/pkg/antfly/src/root.zig
+++ b/zig/pkg/antfly/src/root.zig
@@ -284,6 +284,8 @@ test {
     _ = bloom;
     _ = jsonschema;
     _ = common;
+    _ = @import("common/http/peer_disconnect_observer.zig");
+    _ = @import("common/http/std_http_listener.zig");
     _ = foreign;
     _ = @import("foreign/postgres_libpq.zig");
     _ = embeddings;

--- a/zig/pkg/antfly/src/serverless/runtime/bootstrap.zig
+++ b/zig/pkg/antfly/src/serverless/runtime/bootstrap.zig
@@ -36,6 +36,7 @@ const bedrock = @import("../../inference/bedrock.zig");
 const foreign_mod = @import("../../foreign/mod.zig");
 const scraping = @import("antfly_scraping");
 const object_store_support = @import("../object_store_support.zig");
+const threaded_io_limits = @import("../../common/threaded_io_limits.zig");
 
 pub const BootstrapConfig = struct {
     pub const S3Options = object_store_support.S3Options;
@@ -126,7 +127,10 @@ const S3ClientPool = struct {
     fn init(alloc: Allocator) !S3ClientPool {
         const io_impl = try alloc.create(std.Io.Threaded);
         errdefer alloc.destroy(io_impl);
-        io_impl.* = std.Io.Threaded.init(alloc, .{});
+        // This pool lives for the complete serverless process and is shared by
+        // every object-store lane. Threaded retains concurrent workers, so
+        // give it finite headroom over the listener's default admitted fan-out.
+        io_impl.* = threaded_io_limits.initServerlessObjectStore(alloc);
         return .{ .alloc = alloc, .io_impl = io_impl };
     }
 
@@ -187,6 +191,16 @@ const S3ClientPool = struct {
         return client;
     }
 };
+
+test "serverless S3 client pool has a finite retained-worker ceiling" {
+    var pool = try S3ClientPool.init(std.testing.allocator);
+    defer pool.deinit();
+
+    try std.testing.expectEqual(
+        std.Io.Limit.limited(threaded_io_limits.serverless_object_store),
+        pool.io_impl.concurrent_limit,
+    );
+}
 
 fn s3OptionsEql(a: object_store_support.S3Options, b: object_store_support.S3Options) bool {
     return optionalStringEql(a.endpoint, b.endpoint) and

--- a/zig/pkg/antfly/src/standalone/runtime.zig
+++ b/zig/pkg/antfly/src/standalone/runtime.zig
@@ -18,6 +18,7 @@ const platform_sync = @import("antfly_platform").sync;
 const httpx = @import("httpx");
 const antfly = @import("../root.zig");
 const group_ids = @import("../common/group_ids.zig");
+const threaded_io_limits = @import("../common/threaded_io_limits.zig");
 const inference = @import("inference_server");
 const metadata_openapi = @import("antfly_metadata_openapi");
 const usermgr_openapi = @import("antfly_usermgr_openapi");
@@ -334,7 +335,7 @@ const PublicListenerLease = struct {
     path: []u8,
 
     fn acquire(alloc: std.mem.Allocator, bind_port: u16) !PublicListenerLease {
-        var io_impl = std.Io.Threaded.init(alloc, .{});
+        var io_impl = threaded_io_limits.initService(alloc);
         errdefer io_impl.deinit();
         // Lease by port rather than host spelling: wildcard/specific binds and
         // IPv6 aliases can overlap even when their input strings differ.

--- a/zig/pkg/antfly/src/storage/background_runtime.zig
+++ b/zig/pkg/antfly/src/storage/background_runtime.zig
@@ -17,6 +17,7 @@ const std = @import("std");
 const platform = @import("antfly_platform");
 const runtime_backend = @import("runtime_backend.zig");
 const storage_io = @import("lsm_backend/storage_io.zig");
+const threaded_io_limits = @import("../common/threaded_io_limits.zig");
 
 const Allocator = std.mem.Allocator;
 const Io = std.Io;
@@ -24,7 +25,7 @@ const AtomicU64 = platform.atomic.Value(u64);
 
 pub const Backend = runtime_backend.Backend;
 pub const IoImpl = if (builtin.os.tag == .freestanding) void else Io.Threaded;
-pub const default_io_concurrent_limit: u32 = 256;
+pub const default_io_concurrent_limit: u32 = threaded_io_limits.service;
 
 pub const Config = struct {
     backend: Backend = runtime_backend.defaultExecutorBackend(),

--- a/zig/pkg/antfly/src/storage/background_runtime.zig
+++ b/zig/pkg/antfly/src/storage/background_runtime.zig
@@ -24,6 +24,7 @@ const AtomicU64 = platform.atomic.Value(u64);
 
 pub const Backend = runtime_backend.Backend;
 pub const IoImpl = if (builtin.os.tag == .freestanding) void else Io.Threaded;
+pub const default_io_concurrent_limit: u32 = 256;
 
 pub const Config = struct {
     backend: Backend = runtime_backend.defaultExecutorBackend(),
@@ -92,7 +93,13 @@ fn initIoLane(alloc: Allocator) !*IoImpl {
     } else {
         const io_impl = try alloc.create(IoImpl);
         errdefer alloc.destroy(io_impl);
-        io_impl.* = Io.Threaded.init(alloc, .{});
+        // Backend runtimes are process-long and own several independent I/O
+        // lanes. Threaded retains concurrent workers until deinit, so a finite
+        // ceiling prevents any lane from converting a transient fan-out spike
+        // into an unbounded kernel-thread/stack reservation ratchet.
+        io_impl.* = Io.Threaded.init(alloc, .{
+            .concurrent_limit = .limited(default_io_concurrent_limit),
+        });
         return io_impl;
     }
 }

--- a/zig/pkg/antfly/src/storage/db/derived/io_threaded_runtime.zig
+++ b/zig/pkg/antfly/src/storage/db/derived/io_threaded_runtime.zig
@@ -26,6 +26,7 @@ const types = @import("../types.zig");
 const async_runtime_mod = @import("async_runtime.zig");
 const change_journal_mod = @import("change_journal.zig");
 const derived_types = @import("derived_types.zig");
+const threaded_io_limits = @import("../../../common/threaded_io_limits.zig");
 
 pub const RuntimeError = async_runtime_mod.RuntimeError;
 pub const ApplyFn = async_runtime_mod.ApplyFn;
@@ -239,7 +240,10 @@ pub const DerivedRuntime = if (builtin.os.tag == .freestanding) struct {
     ) !DerivedRuntime {
         const threaded = try alloc.create(Io.Threaded);
         errdefer alloc.destroy(threaded);
-        threaded.* = Io.Threaded.init(alloc, .{});
+        // The owned fallback retains one concurrent worker per derived index.
+        // Database-backed production normally borrows the bounded background
+        // runtime, but standalone users require the same hard ceiling.
+        threaded.* = threaded_io_limits.initService(alloc);
         return initWithIo(
             alloc,
             threaded,
@@ -1357,6 +1361,11 @@ test "io threaded applied callback observes published watermark outside runtime 
     );
     capture.runtime = &runtime;
     defer runtime.deinit();
+
+    try std.testing.expectEqual(
+        Io.Limit.limited(threaded_io_limits.service),
+        runtime.threaded.concurrent_limit,
+    );
 
     try runtime.addWorker("text_idx", .{ .name = "text_idx", .kind = .full_text }, 0);
     runtime.notifySequence(1);

--- a/zig/pkg/antfly/src/storage/lite/bridge.zig
+++ b/zig/pkg/antfly/src/storage/lite/bridge.zig
@@ -23,6 +23,7 @@ const std = @import("std");
 const builtin = @import("builtin");
 const byte_copy = @import("../../common/byte_copy.zig");
 const fs_paths = @import("../../common/fs_paths.zig");
+const threaded_io_limits = @import("../../common/threaded_io_limits.zig");
 const platform_sync = @import("antfly_platform").sync;
 const storage_io = @import("../lsm_backend/storage_io.zig");
 
@@ -105,7 +106,7 @@ pub const ContainerStorage = struct {
     }
 
     pub fn openWithOptions(allocator: Allocator, path: []const u8, options: Options) !ContainerStorage {
-        var io_impl = std.Io.Threaded.init(allocator, .{});
+        var io_impl = threaded_io_limits.initService(allocator);
         errdefer io_impl.deinit();
 
         const owned_path = try allocator.dupe(u8, path);

--- a/zig/pkg/antfly/src/storage/lite/native.zig
+++ b/zig/pkg/antfly/src/storage/lite/native.zig
@@ -21,6 +21,7 @@ const std = @import("std");
 const antfly_platform = @import("antfly_platform");
 const platform_sync = antfly_platform.sync;
 const fs_paths = @import("../../common/fs_paths.zig");
+const threaded_io_limits = @import("../../common/threaded_io_limits.zig");
 const resource_manager_mod = @import("../resource_manager.zig");
 const lsm_backend = @import("../lsm_backend.zig");
 const backend_types = @import("../backend_types.zig");
@@ -786,7 +787,7 @@ pub const NativeFile = struct {
     }
 
     pub fn openWithOptions(allocator: Allocator, path: []const u8, opts: OpenOptions) !NativeFile {
-        var io_impl = std.Io.Threaded.init(allocator, .{});
+        var io_impl = threaded_io_limits.initService(allocator);
         errdefer io_impl.deinit();
         const io = io_impl.io();
 
@@ -844,7 +845,7 @@ pub const NativeFile = struct {
         no_sync: bool,
         resource_manager: ?*resource_manager_mod.ResourceManager,
     ) !NativeFile {
-        var io_impl = std.Io.Threaded.init(allocator, .{});
+        var io_impl = threaded_io_limits.initService(allocator);
         errdefer io_impl.deinit();
         const io = io_impl.io();
 
@@ -3867,7 +3868,7 @@ pub fn create(io: std.Io, path: []const u8) !void {
 }
 
 pub fn lockWriterPath(allocator: Allocator, path: []const u8) !PathWriterLock {
-    var io_impl = std.Io.Threaded.init(allocator, .{});
+    var io_impl = threaded_io_limits.initService(allocator);
     errdefer io_impl.deinit();
 
     const file = (try acquireWriterLock(allocator, io_impl.io(), path)).file;

--- a/zig/pkg/antfly/src/storage/lsm_backend/storage_io.zig
+++ b/zig/pkg/antfly/src/storage/lsm_backend/storage_io.zig
@@ -18,6 +18,7 @@ const builtin = @import("builtin");
 const platform = @import("antfly_platform");
 const byte_copy = @import("../../common/byte_copy.zig");
 const fs_paths = @import("../../common/fs_paths.zig");
+const threaded_io_limits = @import("../../common/threaded_io_limits.zig");
 
 const Allocator = std.mem.Allocator;
 const CounterU64 = platform.atomic.Value(u64);
@@ -339,7 +340,7 @@ fn openNativePathLockFileWithCache(
     options: NativePathLockFileOptions,
     fd_cache: *FdCache,
 ) !NativePathLockFile {
-    var io_impl = std.Io.Threaded.init(allocator, .{});
+    var io_impl = threaded_io_limits.initService(allocator);
     errdefer io_impl.deinit();
 
     const open_descriptor_count = createPathDescriptorCount(path);
@@ -1470,7 +1471,9 @@ const NativeStorageState = struct {
         state.allocator = allocator;
         state.refs = .init(1);
         state.closing = .init(false);
-        state.threaded = std.Io.Threaded.init(allocator, .{});
+        // Native storage state may outlive its owning DB while range futures
+        // drain. Prevent that retained runtime from growing without a bound.
+        state.threaded = threaded_io_limits.initService(allocator);
         errdefer state.threaded.deinit();
         // NativeStorage.init is used by repository, recovery, and status
         // helpers as well as BackendRuntime-owned stores. All production
@@ -1783,7 +1786,7 @@ else blk: {
 
             pub fn initWithPool(allocator: Allocator, kind: RuntimeKind, pool: ?*NativeStoragePool) !NativeStorage {
                 var runtime = switch (kind) {
-                    .threaded => .{ .threaded = std.Io.Threaded.init(allocator, .{}) },
+                    .threaded => .{ .threaded = threaded_io_limits.initService(allocator) },
                     .evented => blk2: {
                         var evented: std.Io.Evented = undefined;
                         try std.Io.Evented.init(&evented, allocator, .{});
@@ -3435,6 +3438,17 @@ test "native atomic write sink supports patching and crc before finish" {
     try std.testing.expectEqualStrings("hello world", written);
 }
 
+test "native storage retained runtime has a finite worker ceiling" {
+    if (!supports_native_storage) return error.SkipZigTest;
+
+    var native = try NativeStorage.init(std.testing.allocator, .threaded);
+    defer native.deinit();
+    try std.testing.expectEqual(
+        std.Io.Limit.limited(threaded_io_limits.service),
+        native.state.threaded.concurrent_limit,
+    );
+}
+
 test "native fd cache retries an open that straddles a mutation fence" {
     if (!supports_posix_fd_cache or builtin.single_threaded) return error.SkipZigTest;
 
@@ -3442,6 +3456,7 @@ test "native fd cache retries an open that straddles a mutation fence" {
     defer pool.deinit();
     var native = try NativeStorage.initWithPool(std.testing.allocator, .threaded, &pool);
     defer native.deinit();
+
     var io_impl = std.Io.Threaded.init(std.testing.allocator, .{});
     defer io_impl.deinit();
     const io = io_impl.io();

--- a/zig/pkg/inference/src/architectures/clipclap_format.zig
+++ b/zig/pkg/inference/src/architectures/clipclap_format.zig
@@ -1,0 +1,741 @@
+// Copyright 2026 Antfly, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Strict admission contract for Antfly's ClipClap GGUF bundle.
+//!
+//! ClipClap is not a decoder plus projector. It is a pair of independently
+//! quantized dual encoders: CLIP owns text/image and CLAP owns audio. The only
+//! safe pairing invariant is their shared projection width. This module checks
+//! that invariant together with every metadata dimension and tensor family the
+//! native pipeline will consume, using headers only and without materializing
+//! weights.
+
+const std = @import("std");
+const gguf_format = @import("../gguf/format.zig");
+const gguf_metadata = @import("../gguf/metadata.zig");
+const gguf_tensor_catalog = @import("../gguf/tensor_catalog.zig");
+const c_file = @import("../util/c_file.zig");
+
+pub const Contract = struct {
+    projection_dim: u32,
+    clip_text_hidden: u32,
+    clip_vision_hidden: u32,
+    clap_audio_hidden: u32,
+};
+
+const ClipContract = struct {
+    projection_dim: u32,
+    text_hidden: u32,
+    vision_hidden: u32,
+};
+
+const ClapContract = struct {
+    projection_dim: u32,
+    audio_hidden: u32,
+};
+
+pub fn inspectFilePair(
+    clip_file: *const gguf_format.File,
+    clap_file: *const gguf_format.File,
+) !Contract {
+    const clip_view = gguf_metadata.View.init(clip_file);
+    const clap_view = gguf_metadata.View.init(clap_file);
+    try requireArchitecture(clip_view, "clip");
+    try requireArchitecture(clap_view, "clap");
+    if (try positiveU32(clip_view, "clip.projection_dim") !=
+        try positiveU32(clap_view, "clap.projection_dim"))
+    {
+        return error.ClipclapProjectionMismatch;
+    }
+    const clip = try inspectClip(clip_file);
+    const clap = try inspectClap(clap_file);
+    if (clip.projection_dim != clap.projection_dim)
+        return error.ClipclapProjectionMismatch;
+    return .{
+        .projection_dim = clip.projection_dim,
+        .clip_text_hidden = clip.text_hidden,
+        .clip_vision_hidden = clip.vision_hidden,
+        .clap_audio_hidden = clap.audio_hidden,
+    };
+}
+
+fn inspectClip(file: *const gguf_format.File) !ClipContract {
+    const view = gguf_metadata.View.init(file);
+    try requireArchitecture(view, "clip");
+    const family = view.getString("clip.family") orelse return error.InvalidClipclapContract;
+    if (!std.mem.eql(u8, family, "clip")) return error.UnsupportedClipclapArchitecture;
+
+    const text_hidden = try positiveU32(view, "clip.text.embedding_length");
+    const text_layers = try positiveU32(view, "clip.text.block_count");
+    const text_heads = try positiveU32(view, "clip.text.attention.head_count");
+    const text_ffn = try positiveU32(view, "clip.text.feed_forward_length");
+    const text_context = try positiveU32(view, "clip.text.context_length");
+    const vocab_size = try positiveU32(view, "clip.text.vocab_size");
+    const vision_hidden = try positiveU32(view, "clip.vision.embedding_length");
+    const vision_layers = try positiveU32(view, "clip.vision.block_count");
+    const vision_heads = try positiveU32(view, "clip.vision.attention.head_count");
+    const vision_ffn = try positiveU32(view, "clip.vision.feed_forward_length");
+    const image_size = try positiveU32(view, "clip.vision.image_size");
+    const patch_size = try positiveU32(view, "clip.vision.patch_size");
+    const projection_dim = try positiveU32(view, "clip.projection_dim");
+    if (text_hidden % text_heads != 0 or vision_hidden % vision_heads != 0 or
+        image_size % patch_size != 0 or text_layers > file.tensors.len or
+        vision_layers > file.tensors.len)
+    {
+        return error.InvalidClipclapContract;
+    }
+
+    const tensors = TensorValidator.init(file);
+    try tensors.requireMatrix("text_model.embeddings.token_embedding.weight", text_hidden, vocab_size);
+    try tensors.requireMatrix("text_model.embeddings.position_embedding.weight", text_hidden, text_context);
+    try tensors.requireVector("text_model.final_layer_norm.weight", text_hidden);
+    try tensors.requireVector("text_model.final_layer_norm.bias", text_hidden);
+    try tensors.requireMatrix("text_projection.weight", text_hidden, projection_dim);
+    try validateClipTransformer(tensors, "text_model.encoder.layers", text_layers, text_hidden, text_ffn);
+
+    try tensors.requireConv2dElements(
+        "vision_model.embeddings.patch_embedding.weight",
+        patch_size,
+        patch_size,
+        3,
+        vision_hidden,
+    );
+    try tensors.requireVector("vision_model.embeddings.class_embedding", vision_hidden);
+    const patch_grid = image_size / patch_size;
+    const patch_count = try checkedMul(patch_grid, patch_grid);
+    try tensors.requireMatrix(
+        "vision_model.embeddings.position_embedding.weight",
+        vision_hidden,
+        patch_count + 1,
+    );
+    try tensors.requireVector("vision_model.pre_layrnorm.weight", vision_hidden);
+    try tensors.requireVector("vision_model.pre_layrnorm.bias", vision_hidden);
+    try tensors.requireVector("vision_model.post_layernorm.weight", vision_hidden);
+    try tensors.requireVector("vision_model.post_layernorm.bias", vision_hidden);
+    try tensors.requireMatrix("visual_projection.weight", vision_hidden, projection_dim);
+    try validateClipTransformer(tensors, "vision_model.encoder.layers", vision_layers, vision_hidden, vision_ffn);
+
+    return .{
+        .projection_dim = projection_dim,
+        .text_hidden = text_hidden,
+        .vision_hidden = vision_hidden,
+    };
+}
+
+fn validateClipTransformer(
+    tensors: TensorValidator,
+    prefix: []const u8,
+    layer_count: u32,
+    hidden: u32,
+    ffn: u32,
+) !void {
+    var name_buf: [192]u8 = undefined;
+    for (0..layer_count) |layer| {
+        try tensors.requireVector(try layerName(&name_buf, prefix, layer, "layer_norm1.weight"), hidden);
+        try tensors.requireVector(try layerName(&name_buf, prefix, layer, "layer_norm1.bias"), hidden);
+        try tensors.requireVector(try layerName(&name_buf, prefix, layer, "layer_norm2.weight"), hidden);
+        try tensors.requireVector(try layerName(&name_buf, prefix, layer, "layer_norm2.bias"), hidden);
+        inline for (.{ "q_proj", "k_proj", "v_proj", "out_proj" }) |projection| {
+            try tensors.requireMatrix(
+                try std.fmt.bufPrint(&name_buf, "{s}.{d}.self_attn.{s}.weight", .{ prefix, layer, projection }),
+                hidden,
+                hidden,
+            );
+            try tensors.requireVector(
+                try std.fmt.bufPrint(&name_buf, "{s}.{d}.self_attn.{s}.bias", .{ prefix, layer, projection }),
+                hidden,
+            );
+        }
+        try tensors.requireMatrix(try layerName(&name_buf, prefix, layer, "mlp.fc1.weight"), hidden, ffn);
+        try tensors.requireVector(try layerName(&name_buf, prefix, layer, "mlp.fc1.bias"), ffn);
+        try tensors.requireMatrix(try layerName(&name_buf, prefix, layer, "mlp.fc2.weight"), ffn, hidden);
+        try tensors.requireVector(try layerName(&name_buf, prefix, layer, "mlp.fc2.bias"), hidden);
+    }
+}
+
+fn inspectClap(file: *const gguf_format.File) !ClapContract {
+    const view = gguf_metadata.View.init(file);
+    try requireArchitecture(view, "clap");
+    const projection_dim = try positiveU32(view, "clap.projection_dim");
+    const audio_hidden = try positiveU32(view, "clap.audio.embedding_length");
+    const patch_hidden = try positiveU32(view, "clap.audio.patch_embeds_hidden_size");
+    const input_channels = try positiveU32(view, "clap.audio.patch_embed_input_channels");
+    const patch_size = try positiveU32(view, "clap.audio.patch_size");
+    const num_mel_bins = try positiveU32(view, "clap.audio.num_mel_bins");
+    const spec_size = try positiveU32(view, "clap.audio.spec_size");
+    const window_size = try positiveU32(view, "clap.audio.window_size");
+    const patch_stride = try requiredU32Array(2, view, "clap.audio.patch_stride");
+    const depths = try requiredU32Array(4, view, "clap.audio.depths");
+    const heads = try requiredU32Array(4, view, "clap.audio.attention_head_counts");
+
+    const mlp_ratio = view.getF32("clap.audio.mlp_ratio") orelse
+        return error.InvalidClipclapContract;
+    const audio_fusion = view.getBool("clap.audio.enable_fusion") orelse
+        return error.InvalidClipclapContract;
+    const bundle_fusion = view.getBool("clap.enable_fusion") orelse
+        return error.InvalidClipclapContract;
+    const projection_activation = view.getString("clap.projection_hidden_act") orelse
+        return error.InvalidClipclapContract;
+    const audio_activation = view.getString("clap.audio.hidden_act") orelse
+        return error.InvalidClipclapContract;
+    const layer_norm_epsilon = view.getF32("clap.audio.layer_norm_epsilon") orelse
+        return error.InvalidClipclapContract;
+    const qkv_bias = view.getBool("clap.audio.qkv_bias") orelse
+        return error.InvalidClipclapContract;
+    const patch_fusion = view.getBool("clap.audio.enable_patch_fusion") orelse
+        return error.InvalidClipclapContract;
+    const patch_layer_norm = view.getBool("clap.audio.enable_patch_layer_norm") orelse
+        return error.InvalidClipclapContract;
+    if (mlp_ratio != 4.0 or audio_fusion or bundle_fusion or
+        !(std.mem.eql(u8, projection_activation, "relu") or
+            std.mem.eql(u8, projection_activation, "gelu")) or
+        !std.mem.eql(u8, audio_activation, "gelu") or
+        !std.math.isFinite(layer_norm_epsilon) or layer_norm_epsilon <= 0 or
+        !qkv_bias or patch_fusion or !patch_layer_norm or input_channels != 1)
+    {
+        // The v1 bundle runtime uses a fixed 4x MLP and a single-channel audio
+        // path. Reject metadata that would make the loader and execution
+        // geometry disagree instead of silently inheriting parser defaults.
+        return error.UnsupportedClipclapArchitecture;
+    }
+    if (patch_size > spec_size or patch_stride[0] == 0 or patch_stride[1] == 0 or
+        num_mel_bins == 0 or window_size == 0 or spec_size % num_mel_bins != 0)
+    {
+        return error.InvalidClipclapContract;
+    }
+    const patch_span = spec_size - patch_size;
+    if (patch_span % patch_stride[0] != 0 or patch_span % patch_stride[1] != 0)
+        return error.InvalidClipclapContract;
+    const patch_height = patch_span / patch_stride[0] + 1;
+    const patch_width = patch_span / patch_stride[1] + 1;
+    const downsample_factor = @as(u32, 1) << 3;
+    if (patch_height % downsample_factor != 0 or patch_width % downsample_factor != 0 or
+        patch_height / downsample_factor < window_size or
+        patch_width / downsample_factor < window_size)
+    {
+        return error.InvalidClipclapContract;
+    }
+    for (0..4) |stage| {
+        const stage_dim = checkedShift(patch_hidden, stage) orelse return error.InvalidClipclapContract;
+        if (depths[stage] == 0 or heads[stage] == 0 or stage_dim % heads[stage] != 0)
+            return error.InvalidClipclapContract;
+    }
+    var total_blocks: u64 = 0;
+    for (depths) |depth| total_blocks += depth;
+    if (total_blocks > file.tensors.len) return error.InvalidClipclapContract;
+    if (checkedShift(patch_hidden, 3) != audio_hidden) return error.InvalidClipclapContract;
+
+    const tensors = TensorValidator.init(file);
+    try tensors.requireConv2dElements(
+        "audio_model.audio_encoder.patch_embed.proj.weight",
+        patch_size,
+        patch_size,
+        input_channels,
+        patch_hidden,
+    );
+    try tensors.requireVector("audio_model.audio_encoder.patch_embed.proj.bias", patch_hidden);
+    try tensors.requireVector("audio_model.audio_encoder.patch_embed.norm.weight", patch_hidden);
+    try tensors.requireVector("audio_model.audio_encoder.patch_embed.norm.bias", patch_hidden);
+    inline for (.{ "weight", "bias", "running_mean", "running_var" }) |suffix| {
+        var name_buf: [96]u8 = undefined;
+        try tensors.requireVector(
+            try std.fmt.bufPrint(
+                &name_buf,
+                "audio_model.audio_encoder.batch_norm.{s}",
+                .{suffix},
+            ),
+            num_mel_bins,
+        );
+    }
+    try tensors.requireVector("audio_model.audio_encoder.norm.weight", audio_hidden);
+    try tensors.requireVector("audio_model.audio_encoder.norm.bias", audio_hidden);
+    try tensors.requireMatrix("audio_projection.linear1.weight", audio_hidden, projection_dim);
+    try tensors.requireVector("audio_projection.linear1.bias", projection_dim);
+    try tensors.requireMatrix("audio_projection.linear2.weight", projection_dim, projection_dim);
+    try tensors.requireVector("audio_projection.linear2.bias", projection_dim);
+
+    try validateClapStages(tensors, patch_hidden, &depths, &heads, window_size);
+    return .{ .projection_dim = projection_dim, .audio_hidden = audio_hidden };
+}
+
+fn validateClapStages(
+    tensors: TensorValidator,
+    patch_hidden: u32,
+    depths: []const u32,
+    heads: []const u32,
+    window_size: u32,
+) !void {
+    var name_buf: [224]u8 = undefined;
+    for (0..4) |stage| {
+        const dim: u64 = checkedShift(patch_hidden, stage) orelse return error.InvalidClipclapContract;
+        const relative_side = @as(u64, window_size) * 2 - 1;
+        const relative_positions = try checkedMul(relative_side, relative_side);
+        const relative_bias_elements = try checkedMul(relative_positions, heads[stage]);
+        for (0..depths[stage]) |block| {
+            const prefix = try std.fmt.bufPrint(
+                &name_buf,
+                "audio_model.audio_encoder.layers.{d}.blocks.{d}",
+                .{ stage, block },
+            );
+            var field_buf: [256]u8 = undefined;
+            try tensors.requireVector(try fieldName(&field_buf, prefix, "layernorm_before.weight"), dim);
+            try tensors.requireVector(try fieldName(&field_buf, prefix, "layernorm_before.bias"), dim);
+            try tensors.requireVector(try fieldName(&field_buf, prefix, "layernorm_after.weight"), dim);
+            try tensors.requireVector(try fieldName(&field_buf, prefix, "layernorm_after.bias"), dim);
+            inline for (.{ "query", "key", "value" }) |projection| {
+                try tensors.requireMatrix(
+                    try std.fmt.bufPrint(&field_buf, "{s}.attention.self.{s}.weight", .{ prefix, projection }),
+                    dim,
+                    dim,
+                );
+                try tensors.requireVector(
+                    try std.fmt.bufPrint(&field_buf, "{s}.attention.self.{s}.bias", .{ prefix, projection }),
+                    dim,
+                );
+            }
+            try tensors.validateOptionalElementCount(
+                try fieldName(&field_buf, prefix, "attention.self.relative_position_bias_table"),
+                relative_bias_elements,
+            );
+            try tensors.requireMatrix(try fieldName(&field_buf, prefix, "attention.output.dense.weight"), dim, dim);
+            try tensors.requireVector(try fieldName(&field_buf, prefix, "attention.output.dense.bias"), dim);
+            try tensors.requireMatrix(try fieldName(&field_buf, prefix, "intermediate.dense.weight"), dim, dim * 4);
+            try tensors.requireVector(try fieldName(&field_buf, prefix, "intermediate.dense.bias"), dim * 4);
+            try tensors.requireMatrix(try fieldName(&field_buf, prefix, "output.dense.weight"), dim * 4, dim);
+            try tensors.requireVector(try fieldName(&field_buf, prefix, "output.dense.bias"), dim);
+        }
+        if (stage + 1 < 4) {
+            const prefix = try std.fmt.bufPrint(
+                &name_buf,
+                "audio_model.audio_encoder.layers.{d}.downsample",
+                .{stage},
+            );
+            var field_buf: [256]u8 = undefined;
+            try tensors.requireVector(try fieldName(&field_buf, prefix, "norm.weight"), dim * 4);
+            try tensors.requireVector(try fieldName(&field_buf, prefix, "norm.bias"), dim * 4);
+            try tensors.requireMatrix(try fieldName(&field_buf, prefix, "reduction.weight"), dim * 4, dim * 2);
+        }
+    }
+}
+
+const TensorValidator = struct {
+    catalog: gguf_tensor_catalog.Catalog,
+
+    fn init(file: *const gguf_format.File) TensorValidator {
+        return .{ .catalog = .init(file) };
+    }
+
+    fn require(self: TensorValidator, name: []const u8) !*const gguf_format.TensorInfo {
+        return self.catalog.find(name) orelse error.InvalidClipclapTensorContract;
+    }
+
+    fn requireVector(self: TensorValidator, name: []const u8, length: u64) !void {
+        const tensor = try self.require(name);
+        if (tensor.dimensions.len != 1 or tensor.dimensions[0] != length)
+            return error.InvalidClipclapTensorContract;
+    }
+
+    fn requireMatrix(self: TensorValidator, name: []const u8, a: u64, b: u64) !void {
+        const tensor = try self.require(name);
+        if (tensor.dimensions.len != 2 or
+            !((tensor.dimensions[0] == a and tensor.dimensions[1] == b) or
+                (tensor.dimensions[0] == b and tensor.dimensions[1] == a)))
+        {
+            return error.InvalidClipclapTensorContract;
+        }
+    }
+
+    fn validateOptionalElementCount(self: TensorValidator, name: []const u8, expected: u64) !void {
+        const tensor = self.catalog.find(name) orelse return;
+        var count: u64 = 1;
+        for (tensor.dimensions) |dimension| {
+            if (dimension == 0) return error.InvalidClipclapTensorContract;
+            count = std.math.mul(u64, count, dimension) catch
+                return error.InvalidClipclapTensorContract;
+        }
+        if (count != expected) return error.InvalidClipclapTensorContract;
+    }
+
+    fn requireConv2dElements(
+        self: TensorValidator,
+        name: []const u8,
+        kernel_h: u64,
+        kernel_w: u64,
+        input_channels: u64,
+        output_channels: u64,
+    ) !void {
+        const tensor = try self.require(name);
+        if (tensor.dimensions.len != 4 or
+            tensor.dimensions[0] != kernel_w or
+            tensor.dimensions[1] != kernel_h or
+            tensor.dimensions[2] != input_channels or
+            tensor.dimensions[3] != output_channels)
+        {
+            return error.InvalidClipclapTensorContract;
+        }
+    }
+};
+
+fn requireArchitecture(view: gguf_metadata.View, expected: []const u8) !void {
+    const actual = view.getString("general.architecture") orelse return error.InvalidClipclapContract;
+    if (!std.mem.eql(u8, actual, expected)) return error.UnsupportedClipclapArchitecture;
+}
+
+fn positiveU32(view: gguf_metadata.View, key: []const u8) !u32 {
+    const value = view.getU64(key) orelse return error.InvalidClipclapContract;
+    if (value == 0 or value > std.math.maxInt(i32)) return error.InvalidClipclapContract;
+    return @intCast(value);
+}
+
+fn requiredU32Array(
+    comptime expected_len: usize,
+    view: gguf_metadata.View,
+    key: []const u8,
+) ![expected_len]u32 {
+    const entry = view.find(key) orelse return error.InvalidClipclapContract;
+    if (entry.value != .array or entry.value.array.values.len != expected_len)
+        return error.InvalidClipclapContract;
+    var values: [expected_len]u32 = undefined;
+    for (entry.value.array.values, 0..) |value, index| {
+        values[index] = switch (value) {
+            .u8 => |v| v,
+            .u16 => |v| v,
+            .u32 => |v| v,
+            .u64 => |v| std.math.cast(u32, v) orelse return error.InvalidClipclapContract,
+            else => return error.InvalidClipclapContract,
+        };
+    }
+    return values;
+}
+
+fn checkedMul(a: anytype, b: anytype) !u64 {
+    return std.math.mul(u64, @intCast(a), @intCast(b)) catch error.InvalidClipclapContract;
+}
+
+fn checkedShift(value: u32, shift: usize) ?u32 {
+    const max_value: u32 = std.math.maxInt(u32);
+    if (shift >= @bitSizeOf(u32) or value > (max_value >> @intCast(shift))) return null;
+    return value << @intCast(shift);
+}
+
+fn layerName(buf: []u8, prefix: []const u8, layer: usize, suffix: []const u8) ![]const u8 {
+    return std.fmt.bufPrint(buf, "{s}.{d}.{s}", .{ prefix, layer, suffix }) catch
+        error.InvalidClipclapContract;
+}
+
+fn fieldName(buf: []u8, prefix: []const u8, suffix: []const u8) ![]const u8 {
+    return std.fmt.bufPrint(buf, "{s}.{s}", .{ prefix, suffix }) catch
+        error.InvalidClipclapContract;
+}
+
+const TestTensors = struct {
+    allocator: std.mem.Allocator,
+    items: std.ArrayListUnmanaged(gguf_format.TensorInfo) = .empty,
+
+    fn deinit(self: *TestTensors) void {
+        for (self.items.items) |tensor| {
+            self.allocator.free(tensor.name);
+            self.allocator.free(tensor.dimensions);
+        }
+        self.items.deinit(self.allocator);
+    }
+
+    fn add(self: *TestTensors, name: []const u8, dimensions: []const u64) !void {
+        const owned_name = try self.allocator.dupe(u8, name);
+        errdefer self.allocator.free(owned_name);
+        const owned_dimensions = try self.allocator.dupe(u64, dimensions);
+        errdefer self.allocator.free(owned_dimensions);
+        try self.items.append(self.allocator, .{
+            .name = owned_name,
+            .dimensions = owned_dimensions,
+            .tensor_type = .{ .known = .F32 },
+            .offset = 0,
+            .data_offset = 0,
+        });
+    }
+
+    fn vector(self: *TestTensors, name: []const u8, length: u64) !void {
+        try self.add(name, &.{length});
+    }
+
+    fn matrix(self: *TestTensors, name: []const u8, input: u64, output: u64) !void {
+        try self.add(name, &.{ input, output });
+    }
+};
+
+fn addTestClipTransformer(
+    tensors: *TestTensors,
+    prefix: []const u8,
+    hidden: u64,
+    ffn: u64,
+) !void {
+    inline for (.{ "layer_norm1.weight", "layer_norm1.bias", "layer_norm2.weight", "layer_norm2.bias" }) |suffix| {
+        const name = try std.fmt.allocPrint(tensors.allocator, "{s}.0.{s}", .{ prefix, suffix });
+        defer tensors.allocator.free(name);
+        try tensors.vector(name, hidden);
+    }
+    inline for (.{ "q_proj", "k_proj", "v_proj", "out_proj" }) |projection| {
+        const weight = try std.fmt.allocPrint(tensors.allocator, "{s}.0.self_attn.{s}.weight", .{ prefix, projection });
+        defer tensors.allocator.free(weight);
+        try tensors.matrix(weight, hidden, hidden);
+        const bias = try std.fmt.allocPrint(tensors.allocator, "{s}.0.self_attn.{s}.bias", .{ prefix, projection });
+        defer tensors.allocator.free(bias);
+        try tensors.vector(bias, hidden);
+    }
+    const fc1_weight = try std.fmt.allocPrint(tensors.allocator, "{s}.0.mlp.fc1.weight", .{prefix});
+    defer tensors.allocator.free(fc1_weight);
+    try tensors.matrix(fc1_weight, hidden, ffn);
+    const fc1_bias = try std.fmt.allocPrint(tensors.allocator, "{s}.0.mlp.fc1.bias", .{prefix});
+    defer tensors.allocator.free(fc1_bias);
+    try tensors.vector(fc1_bias, ffn);
+    const fc2_weight = try std.fmt.allocPrint(tensors.allocator, "{s}.0.mlp.fc2.weight", .{prefix});
+    defer tensors.allocator.free(fc2_weight);
+    try tensors.matrix(fc2_weight, ffn, hidden);
+    const fc2_bias = try std.fmt.allocPrint(tensors.allocator, "{s}.0.mlp.fc2.bias", .{prefix});
+    defer tensors.allocator.free(fc2_bias);
+    try tensors.vector(fc2_bias, hidden);
+}
+
+fn addTestClipTensors(tensors: *TestTensors) !void {
+    try tensors.matrix("text_model.embeddings.token_embedding.weight", 4, 8);
+    try tensors.matrix("text_model.embeddings.position_embedding.weight", 4, 4);
+    try tensors.vector("text_model.final_layer_norm.weight", 4);
+    try tensors.vector("text_model.final_layer_norm.bias", 4);
+    try tensors.matrix("text_projection.weight", 4, 3);
+    try addTestClipTransformer(tensors, "text_model.encoder.layers", 4, 8);
+    try tensors.add("vision_model.embeddings.patch_embedding.weight", &.{ 2, 2, 3, 4 });
+    try tensors.vector("vision_model.embeddings.class_embedding", 4);
+    try tensors.matrix("vision_model.embeddings.position_embedding.weight", 4, 5);
+    inline for (.{
+        "vision_model.pre_layrnorm.weight",
+        "vision_model.pre_layrnorm.bias",
+        "vision_model.post_layernorm.weight",
+        "vision_model.post_layernorm.bias",
+    }) |name| try tensors.vector(name, 4);
+    try tensors.matrix("visual_projection.weight", 4, 3);
+    try addTestClipTransformer(tensors, "vision_model.encoder.layers", 4, 8);
+}
+
+fn addTestClapTensors(tensors: *TestTensors) !void {
+    try tensors.add("audio_model.audio_encoder.patch_embed.proj.weight", &.{ 2, 2, 1, 1 });
+    inline for (.{
+        "audio_model.audio_encoder.patch_embed.proj.bias",
+        "audio_model.audio_encoder.patch_embed.norm.weight",
+        "audio_model.audio_encoder.patch_embed.norm.bias",
+    }) |name| try tensors.vector(name, 1);
+    try tensors.vector("audio_model.audio_encoder.norm.weight", 8);
+    try tensors.vector("audio_model.audio_encoder.norm.bias", 8);
+    inline for (.{ "weight", "bias", "running_mean", "running_var" }) |suffix| {
+        const name = try std.fmt.allocPrint(
+            tensors.allocator,
+            "audio_model.audio_encoder.batch_norm.{s}",
+            .{suffix},
+        );
+        defer tensors.allocator.free(name);
+        try tensors.vector(name, 4);
+    }
+    try tensors.matrix("audio_projection.linear1.weight", 8, 3);
+    try tensors.vector("audio_projection.linear1.bias", 3);
+    try tensors.matrix("audio_projection.linear2.weight", 3, 3);
+    try tensors.vector("audio_projection.linear2.bias", 3);
+
+    for (0..4) |stage| {
+        const dim: u64 = @as(u64, 1) << @intCast(stage);
+        const prefix = try std.fmt.allocPrint(
+            tensors.allocator,
+            "audio_model.audio_encoder.layers.{d}.blocks.0",
+            .{stage},
+        );
+        defer tensors.allocator.free(prefix);
+        inline for (.{ "layernorm_before.weight", "layernorm_before.bias", "layernorm_after.weight", "layernorm_after.bias" }) |suffix| {
+            const name = try std.fmt.allocPrint(tensors.allocator, "{s}.{s}", .{ prefix, suffix });
+            defer tensors.allocator.free(name);
+            try tensors.vector(name, dim);
+        }
+        inline for (.{ "query", "key", "value" }) |projection| {
+            const weight = try std.fmt.allocPrint(tensors.allocator, "{s}.attention.self.{s}.weight", .{ prefix, projection });
+            defer tensors.allocator.free(weight);
+            try tensors.matrix(weight, dim, dim);
+            const bias = try std.fmt.allocPrint(tensors.allocator, "{s}.attention.self.{s}.bias", .{ prefix, projection });
+            defer tensors.allocator.free(bias);
+            try tensors.vector(bias, dim);
+        }
+        const relative_bias = try std.fmt.allocPrint(
+            tensors.allocator,
+            "{s}.attention.self.relative_position_bias_table",
+            .{prefix},
+        );
+        defer tensors.allocator.free(relative_bias);
+        try tensors.vector(relative_bias, 1);
+        const specs = [_]struct { suffix: []const u8, input: u64, output: u64, bias: bool }{
+            .{ .suffix = "attention.output.dense", .input = dim, .output = dim, .bias = true },
+            .{ .suffix = "intermediate.dense", .input = dim, .output = dim * 4, .bias = true },
+            .{ .suffix = "output.dense", .input = dim * 4, .output = dim, .bias = true },
+        };
+        for (specs) |spec| {
+            const weight = try std.fmt.allocPrint(tensors.allocator, "{s}.{s}.weight", .{ prefix, spec.suffix });
+            defer tensors.allocator.free(weight);
+            try tensors.matrix(weight, spec.input, spec.output);
+            if (spec.bias) {
+                const bias = try std.fmt.allocPrint(tensors.allocator, "{s}.{s}.bias", .{ prefix, spec.suffix });
+                defer tensors.allocator.free(bias);
+                try tensors.vector(bias, spec.output);
+            }
+        }
+        if (stage < 3) {
+            const downsample = try std.fmt.allocPrint(
+                tensors.allocator,
+                "audio_model.audio_encoder.layers.{d}.downsample",
+                .{stage},
+            );
+            defer tensors.allocator.free(downsample);
+            inline for (.{ "norm.weight", "norm.bias" }) |suffix| {
+                const name = try std.fmt.allocPrint(tensors.allocator, "{s}.{s}", .{ downsample, suffix });
+                defer tensors.allocator.free(name);
+                try tensors.vector(name, dim * 4);
+            }
+            const reduction = try std.fmt.allocPrint(tensors.allocator, "{s}.reduction.weight", .{downsample});
+            defer tensors.allocator.free(reduction);
+            try tensors.matrix(reduction, dim * 4, dim * 2);
+        }
+    }
+}
+
+test "ClipClap GGUF contract validates paired encoder fixtures" {
+    const allocator = std.testing.allocator;
+    var patch_stride = [_]gguf_format.MetadataValue{ .{ .u32 = 2 }, .{ .u32 = 2 } };
+    var depths = [_]gguf_format.MetadataValue{ .{ .u32 = 1 }, .{ .u32 = 1 }, .{ .u32 = 1 }, .{ .u32 = 1 } };
+    var heads = [_]gguf_format.MetadataValue{ .{ .u32 = 1 }, .{ .u32 = 1 }, .{ .u32 = 1 }, .{ .u32 = 1 } };
+    var clip_metadata = [_]gguf_format.MetadataEntry{
+        .{ .key = "general.architecture", .value = .{ .string = "clip" } },
+        .{ .key = "clip.family", .value = .{ .string = "clip" } },
+        .{ .key = "clip.text.embedding_length", .value = .{ .u32 = 4 } },
+        .{ .key = "clip.text.block_count", .value = .{ .u32 = 1 } },
+        .{ .key = "clip.text.attention.head_count", .value = .{ .u32 = 2 } },
+        .{ .key = "clip.text.feed_forward_length", .value = .{ .u32 = 8 } },
+        .{ .key = "clip.text.context_length", .value = .{ .u32 = 4 } },
+        .{ .key = "clip.text.vocab_size", .value = .{ .u32 = 8 } },
+        .{ .key = "clip.vision.embedding_length", .value = .{ .u32 = 4 } },
+        .{ .key = "clip.vision.block_count", .value = .{ .u32 = 1 } },
+        .{ .key = "clip.vision.attention.head_count", .value = .{ .u32 = 2 } },
+        .{ .key = "clip.vision.feed_forward_length", .value = .{ .u32 = 8 } },
+        .{ .key = "clip.vision.image_size", .value = .{ .u32 = 4 } },
+        .{ .key = "clip.vision.patch_size", .value = .{ .u32 = 2 } },
+        .{ .key = "clip.projection_dim", .value = .{ .u32 = 3 } },
+    };
+    var clap_metadata = [_]gguf_format.MetadataEntry{
+        .{ .key = "general.architecture", .value = .{ .string = "clap" } },
+        .{ .key = "clap.projection_dim", .value = .{ .u32 = 3 } },
+        .{ .key = "clap.projection_hidden_act", .value = .{ .string = "relu" } },
+        .{ .key = "clap.audio.embedding_length", .value = .{ .u32 = 8 } },
+        .{ .key = "clap.audio.patch_embeds_hidden_size", .value = .{ .u32 = 1 } },
+        .{ .key = "clap.audio.patch_embed_input_channels", .value = .{ .u32 = 1 } },
+        .{ .key = "clap.audio.patch_size", .value = .{ .u32 = 2 } },
+        .{ .key = "clap.audio.patch_stride", .value = .{ .array = .{ .element_type = .u32, .values = &patch_stride } } },
+        .{ .key = "clap.audio.num_mel_bins", .value = .{ .u32 = 4 } },
+        .{ .key = "clap.audio.spec_size", .value = .{ .u32 = 16 } },
+        .{ .key = "clap.audio.window_size", .value = .{ .u32 = 1 } },
+        .{ .key = "clap.audio.depths", .value = .{ .array = .{ .element_type = .u32, .values = &depths } } },
+        .{ .key = "clap.audio.attention_head_counts", .value = .{ .array = .{ .element_type = .u32, .values = &heads } } },
+        .{ .key = "clap.audio.mlp_ratio", .value = .{ .f32 = 4.0 } },
+        .{ .key = "clap.audio.layer_norm_epsilon", .value = .{ .f32 = 1e-5 } },
+        .{ .key = "clap.audio.hidden_act", .value = .{ .string = "gelu" } },
+        .{ .key = "clap.audio.qkv_bias", .value = .{ .bool_ = true } },
+        .{ .key = "clap.audio.enable_patch_fusion", .value = .{ .bool_ = false } },
+        .{ .key = "clap.audio.enable_patch_layer_norm", .value = .{ .bool_ = true } },
+        .{ .key = "clap.audio.enable_fusion", .value = .{ .bool_ = false } },
+        .{ .key = "clap.enable_fusion", .value = .{ .bool_ = false } },
+    };
+    var clip_tensors = TestTensors{ .allocator = allocator };
+    defer clip_tensors.deinit();
+    try addTestClipTensors(&clip_tensors);
+    var clap_tensors = TestTensors{ .allocator = allocator };
+    defer clap_tensors.deinit();
+    try addTestClapTensors(&clap_tensors);
+
+    var clip_file = gguf_format.File{
+        .header = .{ .version = 3, .tensor_count = clip_tensors.items.items.len, .metadata_count = clip_metadata.len },
+        .metadata = &clip_metadata,
+        .tensors = clip_tensors.items.items,
+        .alignment = 32,
+        .data_region_offset = 0,
+    };
+    var clap_file = gguf_format.File{
+        .header = .{ .version = 3, .tensor_count = clap_tensors.items.items.len, .metadata_count = clap_metadata.len },
+        .metadata = &clap_metadata,
+        .tensors = clap_tensors.items.items,
+        .alignment = 32,
+        .data_region_offset = 0,
+    };
+    const contract = try inspectFilePair(&clip_file, &clap_file);
+    try std.testing.expectEqual(@as(u32, 3), contract.projection_dim);
+
+    depths[0] = .{ .u32 = 0 };
+    try std.testing.expectError(error.InvalidClipclapContract, inspectFilePair(&clip_file, &clap_file));
+    depths[0] = .{ .u32 = 1 };
+
+    const patch_tensor = gguf_tensor_catalog.Catalog.init(&clap_file).find(
+        "audio_model.audio_encoder.patch_embed.proj.weight",
+    ).?;
+    patch_tensor.dimensions[0] = 3;
+    try std.testing.expectError(error.InvalidClipclapTensorContract, inspectFilePair(&clip_file, &clap_file));
+    patch_tensor.dimensions[0] = 2;
+
+    const relative_bias = gguf_tensor_catalog.Catalog.init(&clap_file).find(
+        "audio_model.audio_encoder.layers.0.blocks.0.attention.self.relative_position_bias_table",
+    ).?;
+    relative_bias.dimensions[0] = 2;
+    try std.testing.expectError(error.InvalidClipclapTensorContract, inspectFilePair(&clip_file, &clap_file));
+    relative_bias.dimensions[0] = 1;
+
+    clap_metadata[17].value = .{ .bool_ = true };
+    try std.testing.expectError(error.UnsupportedClipclapArchitecture, inspectFilePair(&clip_file, &clap_file));
+    clap_metadata[17].value = .{ .bool_ = false };
+
+    clap_metadata[1].value = .{ .u32 = 5 };
+    try std.testing.expectError(error.ClipclapProjectionMismatch, inspectFilePair(&clip_file, &clap_file));
+    clap_metadata[1].value = .{ .u32 = 3 };
+
+    const full_clap_tensors = clap_file.tensors;
+    clap_file.tensors = clap_file.tensors[0 .. clap_file.tensors.len - 1];
+    try std.testing.expectError(error.InvalidClipclapTensorContract, inspectFilePair(&clip_file, &clap_file));
+    clap_file.tensors = full_clap_tensors;
+
+    clip_metadata[0].value = .{ .string = "clap" };
+    try std.testing.expectError(error.UnsupportedClipclapArchitecture, inspectFilePair(&clip_file, &clap_file));
+}
+
+test "ClipClap GGUF contract validates published artifacts when configured" {
+    const allocator = std.testing.allocator;
+    const clip_env = std.c.getenv("ANTFLY_TEST_CLIPCLAP_CLIP_GGUF") orelse return error.SkipZigTest;
+    const clip_path = try allocator.dupe(u8, std.mem.span(clip_env));
+    defer allocator.free(clip_path);
+    const clap_env = std.c.getenv("ANTFLY_TEST_CLIPCLAP_CLAP_GGUF") orelse return error.SkipZigTest;
+    const clap_path = try allocator.dupe(u8, std.mem.span(clap_env));
+    defer allocator.free(clap_path);
+
+    var clip_mapped = try c_file.MmapRegion.init(allocator, clip_path);
+    defer clip_mapped.deinit();
+    var clap_mapped = try c_file.MmapRegion.init(allocator, clap_path);
+    defer clap_mapped.deinit();
+    var clip_file = try gguf_format.parseStructure(allocator, clip_mapped.data);
+    defer clip_file.deinit(allocator);
+    var clap_file = try gguf_format.parseStructure(allocator, clap_mapped.data);
+    defer clap_file.deinit(allocator);
+    try gguf_format.validateTensorDataRanges(&clip_file, clip_mapped.data.len);
+    try gguf_format.validateTensorDataRanges(&clap_file, clap_mapped.data.len);
+
+    const contract = try inspectFilePair(&clip_file, &clap_file);
+    try std.testing.expect(contract.projection_dim > 0);
+}

--- a/zig/pkg/inference/src/architectures/clipclap_format.zig
+++ b/zig/pkg/inference/src/architectures/clipclap_format.zig
@@ -304,7 +304,7 @@ fn validateClapStages(
                     dim,
                 );
             }
-            try tensors.validateOptionalElementCount(
+            try tensors.validateOptionalVector(
                 try fieldName(&field_buf, prefix, "attention.self.relative_position_bias_table"),
                 relative_bias_elements,
             );
@@ -346,25 +346,23 @@ const TensorValidator = struct {
             return error.InvalidClipclapTensorContract;
     }
 
-    fn requireMatrix(self: TensorValidator, name: []const u8, a: u64, b: u64) !void {
+    fn requireMatrix(self: TensorValidator, name: []const u8, gguf_axis_0: u64, gguf_axis_1: u64) !void {
         const tensor = try self.require(name);
         if (tensor.dimensions.len != 2 or
-            !((tensor.dimensions[0] == a and tensor.dimensions[1] == b) or
-                (tensor.dimensions[0] == b and tensor.dimensions[1] == a)))
+            tensor.dimensions[0] != gguf_axis_0 or
+            tensor.dimensions[1] != gguf_axis_1)
         {
             return error.InvalidClipclapTensorContract;
         }
     }
 
-    fn validateOptionalElementCount(self: TensorValidator, name: []const u8, expected: u64) !void {
+    fn validateOptionalVector(self: TensorValidator, name: []const u8, expected: u64) !void {
         const tensor = self.catalog.find(name) orelse return;
-        var count: u64 = 1;
-        for (tensor.dimensions) |dimension| {
-            if (dimension == 0) return error.InvalidClipclapTensorContract;
-            count = std.math.mul(u64, count, dimension) catch
-                return error.InvalidClipclapTensorContract;
-        }
-        if (count != expected) return error.InvalidClipclapTensorContract;
+        // GGUF axes are reversed once by the tensor store. The graph runtime
+        // binds this optional parameter as a vector, so accepting an arbitrary
+        // equal-element layout would pass admission and then fail graph binding.
+        if (tensor.dimensions.len != 1 or tensor.dimensions[0] != expected)
+            return error.InvalidClipclapTensorContract;
     }
 
     fn requireConv2dElements(
@@ -681,6 +679,15 @@ test "ClipClap GGUF contract validates paired encoder fixtures" {
     const contract = try inspectFilePair(&clip_file, &clap_file);
     try std.testing.expectEqual(@as(u32, 3), contract.projection_dim);
 
+    const text_projection = gguf_tensor_catalog.Catalog.init(&clip_file).find(
+        "text_projection.weight",
+    ).?;
+    text_projection.dimensions[0] = 3;
+    text_projection.dimensions[1] = 4;
+    try std.testing.expectError(error.InvalidClipclapTensorContract, inspectFilePair(&clip_file, &clap_file));
+    text_projection.dimensions[0] = 4;
+    text_projection.dimensions[1] = 3;
+
     depths[0] = .{ .u32 = 0 };
     try std.testing.expectError(error.InvalidClipclapContract, inspectFilePair(&clip_file, &clap_file));
     depths[0] = .{ .u32 = 1 };
@@ -698,6 +705,15 @@ test "ClipClap GGUF contract validates paired encoder fixtures" {
     relative_bias.dimensions[0] = 2;
     try std.testing.expectError(error.InvalidClipclapTensorContract, inspectFilePair(&clip_file, &clap_file));
     relative_bias.dimensions[0] = 1;
+
+    const mutable_relative_bias = @constCast(relative_bias);
+    const vector_dimensions = mutable_relative_bias.dimensions;
+    mutable_relative_bias.dimensions = try allocator.dupe(u64, &.{ 1, 1 });
+    allocator.free(vector_dimensions);
+    try std.testing.expectError(error.InvalidClipclapTensorContract, inspectFilePair(&clip_file, &clap_file));
+    const matrix_dimensions = mutable_relative_bias.dimensions;
+    mutable_relative_bias.dimensions = try allocator.dupe(u64, &.{1});
+    allocator.free(matrix_dimensions);
 
     clap_metadata[17].value = .{ .bool_ = true };
     try std.testing.expectError(error.UnsupportedClipclapArchitecture, inspectFilePair(&clip_file, &clap_file));

--- a/zig/pkg/inference/src/architectures/projector_format.zig
+++ b/zig/pkg/inference/src/architectures/projector_format.zig
@@ -992,3 +992,35 @@ test "detect unknown projector metadata" {
 
     try std.testing.expectEqual(Kind.unknown, try detectPath(allocator, path));
 }
+
+test "published Gemma 4 E2B decoder and projector satisfy the paired strict contract when configured" {
+    const allocator = std.testing.allocator;
+    const decoder_env = std.c.getenv("ANTFLY_TEST_GEMMA4_E2B_DECODER_GGUF") orelse
+        return error.SkipZigTest;
+    const path_env = std.c.getenv("ANTFLY_TEST_GEMMA4_E2B_PROJECTOR_GGUF") orelse
+        return error.SkipZigTest;
+    const decoder_path = std.mem.span(decoder_env);
+    const path = std.mem.span(path_env);
+    var decoder_mapped = try c_file.MmapRegion.init(allocator, decoder_path);
+    defer decoder_mapped.deinit();
+    var decoder = try gguf_format.parseStructure(allocator, decoder_mapped.data);
+    defer decoder.deinit(allocator);
+    try gguf_format.validateTensorDataRanges(&decoder, decoder_mapped.data.len);
+    var mapped = try c_file.MmapRegion.init(allocator, path);
+    defer mapped.deinit();
+    var file = try gguf_format.parseStructure(allocator, mapped.data);
+    defer file.deinit(allocator);
+    try gguf_format.validateTensorDataRanges(&file, mapped.data.len);
+
+    const contract = try inspectFileContract(&file);
+    const decoder_view = gguf_metadata.View.init(&decoder);
+    try std.testing.expectEqualStrings("gemma4", decoder_view.getString("general.architecture").?);
+    const decoder_hidden = decoder_view.getU64("gemma4.embedding_length") orelse
+        return error.InvalidProjectorContract;
+    try std.testing.expectEqual(Kind.clip_gemma4_image_audio, contract.kind);
+    try std.testing.expectEqual(@as(u32, 1536), contract.text_hidden_size);
+    try std.testing.expectEqual(decoder_hidden, @as(u64, contract.text_hidden_size));
+    try std.testing.expect(decoder.tensors.len > 0);
+    try std.testing.expect(contract.supports_image);
+    try std.testing.expect(contract.supports_audio);
+}

--- a/zig/pkg/inference/src/inference.zig
+++ b/zig/pkg/inference/src/inference.zig
@@ -40,8 +40,10 @@ pub const codecs = @import("codecs/codecs.zig");
 pub const compiled_artifact = @import("compiled_artifact.zig");
 pub const graph = @import("graph/root.zig");
 pub const architectures = struct {
+    pub const clipclap_format = @import("architectures/clipclap_format.zig");
     pub const deberta = @import("architectures/deberta.zig");
     pub const deberta_graph = @import("architectures/deberta_graph.zig");
+    pub const projector_format = @import("architectures/projector_format.zig");
 };
 pub const finetune = @import("finetune/root.zig");
 pub const finetune_cli = @import("finetune/cli/root.zig");
@@ -101,6 +103,9 @@ test {
     _ = linalg;
     _ = graph;
     _ = architectures;
+    _ = architectures.clipclap_format;
+    _ = architectures.projector_format;
+    _ = @import("server/model_manager.zig");
     _ = finetune;
     _ = finetune_cli;
     _ = run;

--- a/zig/pkg/inference/src/native_export_gguf.zig
+++ b/zig/pkg/inference/src/native_export_gguf.zig
@@ -2541,11 +2541,12 @@ fn buildClapPlannedExportFiltered(
             TensorTransform.none
         else
             clipClapOnnxDenseExportTransformForTensor(record.descriptor.name, record.descriptor.shape);
-        const dimensions = switch (transform) {
-            .none => try reversedDimsFromShape(allocator, record.descriptor.shape),
-            .transpose_2d_dense => try dimsFromShape(allocator, record.descriptor.shape),
-            .onnx_gru_zrh_to_rzn => return error.UnsupportedDenseArchitectureForGgufExport,
-        };
+        const dimensions = try clapGgufDimensions(
+            allocator,
+            output_name_result.name,
+            record.descriptor.shape,
+            transform,
+        );
         errdefer allocator.free(dimensions);
 
         const tensor_quantization = if (source_is_gguf)
@@ -3848,6 +3849,35 @@ fn reversedDimsFromShape(allocator: std.mem.Allocator, shape: []const i64) ![]u6
         dims[i] = @intCast(dim);
     }
     return dims;
+}
+
+fn clapGgufDimensions(
+    allocator: std.mem.Allocator,
+    output_name: []const u8,
+    shape: []const i64,
+    transform: TensorTransform,
+) ![]u64 {
+    if (transform == .none and
+        std.mem.startsWith(u8, output_name, "audio_model.audio_encoder.layers.") and
+        std.mem.endsWith(u8, output_name, ".attention.self.relative_position_bias_table"))
+    {
+        if (shape.len == 0) return error.InvalidTensorShape;
+        var element_count: u64 = 1;
+        for (shape) |dim| {
+            if (dim <= 0) return error.InvalidTensorShape;
+            element_count = std.math.mul(u64, element_count, @intCast(dim)) catch
+                return error.InvalidTensorShape;
+        }
+        const dimensions = try allocator.alloc(u64, 1);
+        dimensions[0] = element_count;
+        return dimensions;
+    }
+
+    return switch (transform) {
+        .none => reversedDimsFromShape(allocator, shape),
+        .transpose_2d_dense => dimsFromShape(allocator, shape),
+        .onnx_gru_zrh_to_rzn => error.UnsupportedDenseArchitectureForGgufExport,
+    };
 }
 
 fn resolveExportArchitecture(
@@ -6550,7 +6580,7 @@ test "dense clap export writes clap metadata and tensors" {
     try compat.cwd().writeFile(compat.io(), .{
         .sub_path = config_path,
         .data =
-        \\{"model_type":"clap","projection_dim":4,"projection_hidden_act":"relu","logit_scale_init_value":14.285714,"text_config":{"vocab_size":32,"hidden_size":4,"num_hidden_layers":1,"num_attention_heads":2,"intermediate_size":8,"max_position_embeddings":16,"type_vocab_size":1,"pad_token_id":1},"audio_config":{"hidden_size":8,"patch_embeds_hidden_size":4,"patch_embed_input_channels":1,"patch_size":4,"patch_stride":[4,4],"num_mel_bins":8,"spec_size":16,"window_size":4,"depths":[1,1,1,1],"num_attention_heads":[1,1,1,2],"mlp_ratio":2.0,"layer_norm_eps":1e-5,"enable_fusion":false}}
+        \\{"model_type":"clap","projection_dim":4,"projection_hidden_act":"relu","logit_scale_init_value":14.285714,"text_config":{"vocab_size":32,"hidden_size":4,"num_hidden_layers":1,"num_attention_heads":2,"intermediate_size":8,"max_position_embeddings":16,"type_vocab_size":1,"pad_token_id":1},"audio_config":{"hidden_size":8,"patch_embeds_hidden_size":4,"patch_embed_input_channels":1,"patch_size":4,"patch_stride":[4,4],"num_mel_bins":8,"spec_size":16,"window_size":2,"depths":[1,1,1,1],"num_attention_heads":[2,1,1,2],"mlp_ratio":2.0,"layer_norm_eps":1e-5,"enable_fusion":false}}
         ,
     });
 
@@ -6566,6 +6596,11 @@ test "dense clap export writes clap metadata and tensors" {
         .{ .name = "clap.text_projection.linear2.bias", .shape = &.{4}, .data = &[_]f32{ 0, 0, 0, 0 } },
         .{ .name = "clap.audio_model.audio_encoder.patch_embed.proj.weight", .shape = &.{ 4, 1, 4, 4 }, .data = &([_]f32{0.0} ** (4 * 1 * 4 * 4)) },
         .{ .name = "clap.audio_model.audio_encoder.patch_embed.proj.bias", .shape = &.{4}, .data = &[_]f32{ 0, 0, 0, 0 } },
+        .{ .name = "clap.audio_model.audio_encoder.layers.0.blocks.0.attention.self.relative_position_bias_table", .shape = &.{ 9, 2 }, .data = &[_]f32{
+            0,  1,  2,  3,  4,  5,
+            6,  7,  8,  9,  10, 11,
+            12, 13, 14, 15, 16, 17,
+        } },
         .{ .name = "clap.audio_model.audio_encoder.batch_norm.weight", .shape = &.{8}, .data = &([_]f32{1.0} ** 8) },
         .{ .name = "clap.audio_model.audio_encoder.batch_norm.bias", .shape = &.{8}, .data = &([_]f32{0.0} ** 8) },
         .{ .name = "clap.audio_model.audio_encoder.batch_norm.running_mean", .shape = &.{8}, .data = &([_]f32{0.0} ** 8) },
@@ -6599,6 +6634,41 @@ test "dense clap export writes clap metadata and tensors" {
     try std.testing.expect(catalog.find("audio_model.audio_encoder.patch_embed.proj.weight") != null);
     try std.testing.expect(catalog.find("audio_projection.linear1.weight") != null);
     try std.testing.expect(catalog.find("logit_scale") != null);
+
+    const relative_bias_name = "audio_model.audio_encoder.layers.0.blocks.0.attention.self.relative_position_bias_table";
+    const relative_bias = catalog.find(relative_bias_name).?;
+    try std.testing.expectEqualSlices(u64, &.{18}, relative_bias.dimensions);
+    const relative_bias_len = gguf_mod.tensor_types.byteLen(relative_bias.tensor_type, relative_bias.dimensions).?;
+    const relative_bias_bytes = try c_file.readRegion(allocator, out_path, relative_bias.data_offset, @intCast(relative_bias_len));
+    defer allocator.free(relative_bias_bytes);
+    try std.testing.expectEqualSlices(
+        u8,
+        std.mem.sliceAsBytes(&[_]f32{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17 }),
+        relative_bias_bytes,
+    );
+
+    // GGUF-to-GGUF export applies the same canonical layout, so artifacts
+    // produced by older exporters are repaired without touching tensor data.
+    const roundtrip_dir = try std.fs.path.join(allocator, &.{ dir_path, "roundtrip" });
+    defer allocator.free(roundtrip_dir);
+    try compat.cwd().createDirPath(compat.io(), roundtrip_dir);
+    const roundtrip_source = try std.fs.path.join(allocator, &.{ roundtrip_dir, "model.gguf" });
+    defer allocator.free(roundtrip_source);
+    try compat.cwd().writeFile(compat.io(), .{ .sub_path = roundtrip_source, .data = raw });
+    const roundtrip_path = try std.fs.path.join(allocator, &.{ roundtrip_dir, "roundtrip.gguf" });
+    defer allocator.free(roundtrip_path);
+    try exportModelDirToGguf(allocator, roundtrip_dir, roundtrip_path, .none);
+
+    const roundtrip_raw = try c_file.readFile(allocator, roundtrip_path);
+    defer allocator.free(roundtrip_raw);
+    var roundtrip_parsed = try gguf_mod.format.parse(allocator, roundtrip_raw);
+    defer roundtrip_parsed.deinit(allocator);
+    const roundtrip_bias = gguf_mod.tensor_catalog.Catalog.init(&roundtrip_parsed).find(relative_bias_name).?;
+    try std.testing.expectEqualSlices(u64, &.{18}, roundtrip_bias.dimensions);
+    const roundtrip_bias_len = gguf_mod.tensor_types.byteLen(roundtrip_bias.tensor_type, roundtrip_bias.dimensions).?;
+    const roundtrip_bias_bytes = try c_file.readRegion(allocator, roundtrip_path, roundtrip_bias.data_offset, @intCast(roundtrip_bias_len));
+    defer allocator.free(roundtrip_bias_bytes);
+    try std.testing.expectEqualSlices(u8, relative_bias_bytes, roundtrip_bias_bytes);
 }
 
 test "exported clap gguf loads and runs through native text path" {

--- a/zig/pkg/inference/src/server/model_manager.zig
+++ b/zig/pkg/inference/src/server/model_manager.zig
@@ -31,6 +31,7 @@ const gguf_format = @import("../gguf/format.zig");
 const gguf_metadata = @import("../gguf/metadata.zig");
 const gguf_tensor_types = @import("../gguf/tensor_types.zig");
 const gguf_writer = @import("../gguf/writer.zig");
+const clipclap_format_mod = @import("../architectures/clipclap_format.zig");
 const projector_format_mod = @import("../architectures/projector_format.zig");
 const hf_tokenizer = @import("inference_hf_tokenizer");
 const sentencepiece = @import("inference_tokenizer").sentencepiece;
@@ -315,6 +316,25 @@ fn validateNativeCompanionsForBackend(
     // sessions, so all of those are part of the compatibility contract.
     if (candidate == .onnx) return null;
 
+    // ClipClap is a paired encoder contract, not a decoder/projector contract.
+    // Validate both headers together so two individually valid GGUFs with
+    // incompatible shared embedding widths can never be advertised or loaded.
+    const clipclap_audio_validated = candidate == .gguf and man.isClipclapGgufBundle();
+    if (clipclap_audio_validated) {
+        const clip_path = man.gguf_path orelse return .{
+            .level = .incompatible,
+            .code = .artifact_unreadable,
+            .message = "the ClipClap bundle is missing its CLIP GGUF",
+        };
+        const clap_path = man.audio_model_path orelse return .{
+            .level = .incompatible,
+            .code = .artifact_unreadable,
+            .message = "the ClipClap bundle is missing its CLAP GGUF",
+        };
+        if (try validateClipclapBundleForBackend(allocator, clip_path, clap_path, backend)) |summary|
+            return summary;
+    }
+
     var companions: [8]NativeCompanion = undefined;
     var companion_count: usize = 0;
     if (man.gguf_projector_path) |path| {
@@ -344,6 +364,11 @@ fn validateNativeCompanionsForBackend(
     };
     for (lazy_component_paths) |maybe_path| {
         const path = maybe_path orelse continue;
+        if (clipclap_audio_validated and man.audio_model_path != null and
+            std.mem.eql(u8, path, man.audio_model_path.?))
+        {
+            continue;
+        }
         const kind: NativeCompanionKind = if (std.mem.endsWith(u8, path, ".gguf"))
             .gguf
         else if (std.mem.endsWith(u8, path, ".safetensors"))
@@ -384,6 +409,96 @@ fn validateNativeCompanionsForBackend(
                     .message = "a required companion safetensors file is invalid or unreadable",
                 };
             },
+        }
+    }
+    return null;
+}
+
+fn validateClipclapBundleForBackend(
+    allocator: std.mem.Allocator,
+    clip_path: []const u8,
+    clap_path: []const u8,
+    backend: backends.BackendType,
+) !?CompatibilitySummary {
+    var clip_mapped = c_file.MmapRegion.init(allocator, clip_path) catch |err| {
+        if (err == error.OutOfMemory) return err;
+        return .{
+            .level = .incompatible,
+            .code = .artifact_unreadable,
+            .message = "the ClipClap CLIP GGUF is missing or unreadable",
+        };
+    };
+    defer clip_mapped.deinit();
+    var clap_mapped = c_file.MmapRegion.init(allocator, clap_path) catch |err| {
+        if (err == error.OutOfMemory) return err;
+        return .{
+            .level = .incompatible,
+            .code = .artifact_unreadable,
+            .message = "the ClipClap CLAP GGUF is missing or unreadable",
+        };
+    };
+    defer clap_mapped.deinit();
+
+    var clip_file = gguf_format.parseStructure(allocator, clip_mapped.data) catch |err| {
+        if (err == error.OutOfMemory) return err;
+        return .{
+            .level = .incompatible,
+            .code = .artifact_unreadable,
+            .message = "the ClipClap CLIP GGUF has invalid structure",
+        };
+    };
+    defer clip_file.deinit(allocator);
+    var clap_file = gguf_format.parseStructure(allocator, clap_mapped.data) catch |err| {
+        if (err == error.OutOfMemory) return err;
+        return .{
+            .level = .incompatible,
+            .code = .artifact_unreadable,
+            .message = "the ClipClap CLAP GGUF has invalid structure",
+        };
+    };
+    defer clap_file.deinit(allocator);
+
+    gguf_format.validateTensorDataRanges(&clip_file, clip_mapped.data.len) catch return .{
+        .level = .incompatible,
+        .code = .artifact_unreadable,
+        .message = "the ClipClap CLIP GGUF has invalid or truncated tensor data",
+    };
+    gguf_format.validateTensorDataRanges(&clap_file, clap_mapped.data.len) catch return .{
+        .level = .incompatible,
+        .code = .artifact_unreadable,
+        .message = "the ClipClap CLAP GGUF has invalid or truncated tensor data",
+    };
+    clip_mapped.adviseSequentialPrefix(@min(
+        std.math.cast(usize, clip_file.data_region_offset) orelse clip_mapped.data.len,
+        clip_mapped.data.len,
+    ));
+    clap_mapped.adviseSequentialPrefix(@min(
+        std.math.cast(usize, clap_file.data_region_offset) orelse clap_mapped.data.len,
+        clap_mapped.data.len,
+    ));
+
+    _ = clipclap_format_mod.inspectFilePair(&clip_file, &clap_file) catch |err| return switch (err) {
+        error.UnsupportedClipclapArchitecture, error.ClipclapProjectionMismatch => .{
+            .level = .incompatible,
+            .code = .unsupported_backend,
+            .message = "the ClipClap GGUF pair declares incompatible encoder architectures or projection widths",
+        },
+        else => .{
+            .level = .incompatible,
+            .code = .missing_required_tensor,
+            .message = "the ClipClap GGUF pair is missing required metadata or tensors, or declares an invalid tensor layout",
+        },
+    };
+
+    for ([_]*const gguf_format.File{ &clip_file, &clap_file }) |file| {
+        for (file.tensors) |tensor| {
+            if (!session_factory.ggufTensorTypeSupportsBackend(tensor.tensor_type, backend)) {
+                return .{
+                    .level = .incompatible,
+                    .code = .unsupported_tensor_type,
+                    .message = "the selected backend cannot materialize the ClipClap GGUF tensor contract",
+                };
+            }
         }
     }
     return null;
@@ -5372,6 +5487,50 @@ test "native compatibility rejects unsupported companion GGUF tensor types" {
     )).?;
     try std.testing.expectEqual(model_compatibility.Level.incompatible, summary.level);
     try std.testing.expectEqual(model_compatibility.Code.unsupported_tensor_type, summary.code);
+}
+
+test "published Gemma 4 E2B decoder and projector pass native admission when configured" {
+    const allocator = std.testing.allocator;
+    const decoder_env = std.c.getenv("ANTFLY_TEST_GEMMA4_E2B_DECODER_GGUF") orelse
+        return error.SkipZigTest;
+    const projector_env = std.c.getenv("ANTFLY_TEST_GEMMA4_E2B_PROJECTOR_GGUF") orelse
+        return error.SkipZigTest;
+    const decoder_path = std.mem.span(decoder_env);
+    const projector_path = std.mem.span(projector_env);
+    const model_dir = std.fs.path.dirname(decoder_path) orelse ".";
+
+    var man = manifest_mod.ModelManifest{
+        .allocator = allocator,
+        .model_type = .generator,
+        .config_model_arch = try allocator.dupe(u8, "gemma4"),
+        .gguf_path = try allocator.dupe(u8, decoder_path),
+        .gguf_projector_path = try allocator.dupe(u8, projector_path),
+    };
+    defer man.deinit();
+
+    const summary = (try compatibilitySummaryForBackend(
+        allocator,
+        model_dir,
+        &man,
+        .native,
+    )).?;
+    try std.testing.expectEqual(model_compatibility.Level.compatible, summary.level);
+}
+
+test "published ClipClap GGUF pair passes native admission when configured" {
+    const allocator = std.testing.allocator;
+    const clip_env = std.c.getenv("ANTFLY_TEST_CLIPCLAP_CLIP_GGUF") orelse
+        return error.SkipZigTest;
+    const clap_env = std.c.getenv("ANTFLY_TEST_CLIPCLAP_CLAP_GGUF") orelse
+        return error.SkipZigTest;
+
+    const summary = try validateClipclapBundleForBackend(
+        allocator,
+        std.mem.span(clip_env),
+        std.mem.span(clap_env),
+        .native,
+    );
+    try std.testing.expect(summary == null);
 }
 
 test "native compatibility rejects a malformed split GLiNER safetensors head" {


### PR DESCRIPTION
## Summary

- add strict, pair-aware ClipClap GGUF admission while preserving fail-closed Gemma decoder/projector validation
- replace POSIX per-request `Io.concurrent` timeout races with one bounded, multiplexed deadline observer per listener
- centralize finite concurrency ceilings for every audited process-, database-, and storage-lifetime `std.Io.Threaded` owner, including provisioned reads/writes, backup fallbacks, Raft stores, native/lite storage, serverless S3, and LMDB
- expose timeout and observer metrics and wire cancellation-storm coverage into the default unit graph
- require the shipped Gemma multimodal E2E to execute successfully instead of accepting an unimplemented response

## Validation

- exact current Gemma 4 E2B Q4_0 decoder + Q8_0 projector paired contract and native admission
- published antflydb/clipclap Q4_K pair contract, strict tensor-layout validation, canonical GGUF export, and native admission
- live native ClipClap text embedding smoke
- `make generate` and `make zig-generated-check`
- focused Debug suites: common HTTP observer/listener, serverless, LMDB, LSM backend, lite native, data storage, Raft, backup/storage authority, standalone runtime, API table reads, and API table writes
- final API table-read suite: 13 passed, 0 failed, 0 leaked
- final API table-write suite: 70 passed, 2 sandbox-only local-bind skips, 0 failed, 0 leaked
- `zig fmt` and `git diff --check`

The large-model CI smoke requires real Gemma image inference. Compatibility validation remains strict and fail-closed; ClipClap is validated as its own dual-model contract rather than being treated as a Gemma-style projector.