### PR TITLE
Fix inference run help starting the server

### DIFF
--- a/zig/pkg/antfly/src/inference_runtime/runtime.zig
+++ b/zig/pkg/antfly/src/inference_runtime/runtime.zig
@@ -664,7 +664,7 @@ test "inference runtime module compiles" {
     _ = spawnServerProcess;
 }
 
-test "inference run recognizes help before server startup" {
+test "inference run detects trailing help without consuming arguments" {
     var argv = [_][*:0]const u8{ "--host", "127.0.0.1", "--help" };
     var args = std.process.Args.Iterator.init(.{ .vector = argv[0..] });
     try std.testing.expect(runHelpRequested(&args));

--- a/zig/pkg/antfly/src/inference_runtime/runtime.zig
+++ b/zig/pkg/antfly/src/inference_runtime/runtime.zig
@@ -144,6 +144,10 @@ pub fn runFromIterator(
     const command = args.next() orelse "run";
 
     if (std.mem.eql(u8, command, "run")) {
+        if (runHelpRequested(args)) {
+            printUsage();
+            return;
+        }
         return try runServer(alloc, io, args);
     } else if (std.mem.eql(u8, command, "embed")) {
         return try inference.native_embed.main(alloc, io, try collectArgs(alloc, args));
@@ -198,6 +202,14 @@ pub fn runFromIterator(
         printUsage();
         return error.InvalidArguments;
     }
+}
+
+fn runHelpRequested(args: *std.process.Args.Iterator) bool {
+    var probe = args.*;
+    while (probe.next()) |arg| {
+        if (isHelpArg(arg)) return true;
+    }
+    return false;
 }
 
 fn runServer(alloc: std.mem.Allocator, io: std.Io, args: *std.process.Args.Iterator) !void {
@@ -650,6 +662,17 @@ test "inference runtime module compiles" {
     _ = run;
     _ = runFromIterator;
     _ = spawnServerProcess;
+}
+
+test "inference run recognizes help before server startup" {
+    var argv = [_][*:0]const u8{ "--host", "127.0.0.1", "--help" };
+    var args = std.process.Args.Iterator.init(.{ .vector = argv[0..] });
+    try std.testing.expect(runHelpRequested(&args));
+    try std.testing.expectEqualStrings("--host", args.next().?);
+
+    var no_help_argv = [_][*:0]const u8{ "--host", "127.0.0.1" };
+    var no_help_args = std.process.Args.Iterator.init(.{ .vector = no_help_argv[0..] });
+    try std.testing.expect(!runHelpRequested(&no_help_args));
 }
 
 test "inference pull recognizes help before model resolution" {


### PR DESCRIPTION
## Summary

- recognize `--help`, `-h`, and `help` in `antfly inference run` arguments
- print inference usage and return before initializing or starting the server
- cover both the full Antfly runtime and inference-edition CLI paths
- add regression tests for help detection without consuming the original argument iterator

## Root cause

The inference dispatcher handled help only when it appeared in the command position. Once `run` was selected, its option parser silently ignored help tokens and continued into node initialization and `serve`.

## User impact

`antfly inference run --help` now displays usage and exits instead of starting an inference server.

## Checks

- `zig fmt --check zig/pkg/antfly/src/inference_runtime/runtime.zig zig/pkg/inference/src/main.zig`
- `git diff --check`

The full Zig test/build aggregate was not run locally because this checkout has a known risk of exhausting the available memory during Zig builds.
