### PR TITLE
Fix fused aggregations on truncated result pages

### DIFF
--- a/zig/build.zig
+++ b/zig/build.zig
@@ -4132,6 +4132,8 @@ pub fn build(b: *std.Build) void {
             "executeSearchGraphWithSets preserves node ordinals",
             "cloneNamedSetAsResult preserves hit ordinals",
             "fuseNamedSets preserves source hit ordinals",
+            "fuseNamedSets reports a lower bound while any source window is truncated",
+            "db search marks a truncated fused candidate union as a lower bound",
             "fuseNamedSets deduplicates aliases by ordinal when complete",
             "fuseNamedSets drops conflicting source hit ordinals",
             "applyGraphUnion deduplicates by ordinals when hit pages are complete",

--- a/zig/pkg/antfly/src/storage/db/db.zig
+++ b/zig/pkg/antfly/src/storage/db/db.zig
@@ -70916,6 +70916,69 @@ test "db search fuses full_text and dense named searches before graph expansion"
     try std.testing.expectEqualStrings("doc:c", result.graph_results[0].hits[0].id);
 }
 
+test "db search marks a truncated fused candidate union as a lower bound" {
+    const alloc = std.testing.allocator;
+
+    var path_buf: [256]u8 = undefined;
+    const path = tempPath(&path_buf);
+    defer cleanupTempDir(path);
+
+    var db = try DB.open(alloc, std.mem.span(path), .{});
+    defer db.close();
+
+    try db.addIndex(.{ .name = "ft_v1", .kind = .full_text, .config_json = "{}" });
+    try db.addIndex(.{
+        .name = "dv_v1",
+        .kind = .dense_vector,
+        .config_json = "{\"field\":\"embedding\",\"dims\":3,\"metric\":\"l2_squared\"}",
+    });
+    try db.batch(.{
+        .writes = &.{
+            .{ .key = "doc:a", .value = "{\"body\":\"common alpha\",\"_embeddings\":{\"dv_v1\":[1,0,0]}}" },
+            .{ .key = "doc:b", .value = "{\"body\":\"common beta\",\"_embeddings\":{\"dv_v1\":[0,1,0]}}" },
+            .{ .key = "doc:c", .value = "{\"body\":\"common gamma\",\"_embeddings\":{\"dv_v1\":[0,0,1]}}" },
+        },
+        .sync_level = .full_index,
+    });
+
+    const dense_queries = [_]types.NamedDenseQuery{.{
+        .name = "dv_v1",
+        .index_name = "dv_v1",
+        .query = .{ .vector = &.{ 1.0, 0.0, 0.0 }, .k = 1 },
+    }};
+    const merge_config = types.MergeConfig{
+        .strategy = .rrf,
+        .weights = &.{
+            .{ .name = "full_text", .weight = 1.0 },
+            .{ .name = "dv_v1", .weight = 1.0 },
+        },
+    };
+
+    var first_page = try db.search(alloc, .{
+        .full_text = .{ .match = .{ .field = "body", .text = "common" } },
+        .index_name = "ft_v1",
+        .dense_queries = &dense_queries,
+        .merge_config = merge_config,
+        .include_stored = false,
+        .limit = 1,
+    });
+    defer first_page.deinit();
+    try std.testing.expectEqual(@as(usize, 1), first_page.hits.len);
+    try std.testing.expectEqual(types.TotalHitsRelation.gte, first_page.total_hits_relation);
+
+    var full_window = try db.search(alloc, .{
+        .full_text = .{ .match = .{ .field = "body", .text = "common" } },
+        .index_name = "ft_v1",
+        .dense_queries = &dense_queries,
+        .merge_config = merge_config,
+        .include_stored = false,
+        .limit = 10,
+    });
+    defer full_window.deinit();
+    try std.testing.expectEqual(@as(usize, 3), full_window.hits.len);
+    try std.testing.expectEqual(types.TotalHitsRelation.exact, full_window.total_hits_relation);
+}
+
 test "db hybrid search does not hard-filter dense leg with scoring full_text" {
     const alloc = std.testing.allocator;
 

--- a/zig/pkg/antfly/src/storage/db/query/graph_exec.zig
+++ b/zig/pkg/antfly/src/storage/db/query/graph_exec.zig
@@ -31,6 +31,7 @@ pub const NamedResultSet = struct {
     name: []const u8,
     hits: []const types.SearchHit,
     total_hits: u32,
+    total_hits_relation: types.TotalHitsRelation = .exact,
     resolved_doc_set: ?*const doc_set.ResolvedDocSet = null,
     resolved_doc_set_complete: bool = false,
 };
@@ -668,6 +669,7 @@ pub fn cloneNamedSetAsResult(alloc: Allocator, set: NamedResultSet, include_stor
         .alloc = alloc,
         .hits = hits,
         .total_hits = set.total_hits,
+        .total_hits_relation = set.total_hits_relation,
         .graph_results = &.{},
     };
 }
@@ -777,8 +779,19 @@ pub fn fuseNamedSets(
         .alloc = alloc,
         .hits = hits,
         .total_hits = @intCast(pruned.len),
+        .total_hits_relation = fusedTotalHitsRelation(named_sets),
         .graph_results = &.{},
     };
+}
+
+fn fusedTotalHitsRelation(named_sets: []const NamedResultSet) types.TotalHitsRelation {
+    for (named_sets) |set| {
+        // Fusion only sees each source's returned window. Even when a source
+        // knows its exact total, the union cannot be exact until that entire
+        // source is present and can be deduplicated against the other legs.
+        if (set.total_hits_relation != .exact or set.hits.len != set.total_hits) return .gte;
+    }
+    return .exact;
 }
 
 const OrdinalFusionEntry = struct {
@@ -4422,6 +4435,7 @@ test "cloneNamedSetAsResult preserves hit ordinals" {
         .name = "dense",
         .hits = &source_hits,
         .total_hits = 1,
+        .total_hits_relation = .gte,
     };
 
     var without_stored = try cloneNamedSetAsResult(alloc, set, false);
@@ -4430,6 +4444,7 @@ test "cloneNamedSetAsResult preserves hit ordinals" {
     try std.testing.expectEqualStrings("doc:a", without_stored.hits[0].id);
     try std.testing.expectEqual(@as(?doc_set.DocOrdinal, 11), without_stored.hits[0].doc_ordinal);
     try std.testing.expect(without_stored.hits[0].stored_data == null);
+    try std.testing.expectEqual(types.TotalHitsRelation.gte, without_stored.total_hits_relation);
 
     var with_stored = try cloneNamedSetAsResult(alloc, set, true);
     defer with_stored.deinit();
@@ -4570,6 +4585,57 @@ test "fuseNamedSets preserves source hit ordinals" {
     try std.testing.expectEqual(@as(?doc_set.DocOrdinal, 11), result.hits[0].doc_ordinal);
     try std.testing.expectEqualStrings("doc:b", result.hits[1].id);
     try std.testing.expectEqual(@as(?doc_set.DocOrdinal, 12), result.hits[1].doc_ordinal);
+    try std.testing.expectEqual(types.TotalHitsRelation.exact, result.total_hits_relation);
+}
+
+test "fuseNamedSets reports a lower bound while any source window is truncated" {
+    const alloc = std.testing.allocator;
+
+    const left_hits = [_]types.SearchHit{
+        .{ .id = @constCast("doc:a"), .score = 1.0 },
+        .{ .id = @constCast("doc:b"), .score = 0.5 },
+    };
+    const right_hits = [_]types.SearchHit{
+        .{ .id = @constCast("doc:b"), .score = 1.0 },
+        .{ .id = @constCast("doc:c"), .score = 0.5 },
+    };
+    const named_sets = [_]NamedResultSet{
+        .{
+            .name = "$full_text_results",
+            .hits = &left_hits,
+            .total_hits = 3,
+            .total_hits_relation = .exact,
+        },
+        .{
+            .name = "dense_idx",
+            .hits = &right_hits,
+            .total_hits = right_hits.len,
+            .total_hits_relation = .exact,
+        },
+    };
+
+    const Harness = struct {
+        fn loadProjectedDocument(
+            _: ?*anyopaque,
+            _: Allocator,
+            _: types.SearchRequest,
+            _: []const u8,
+        ) anyerror!?[]u8 {
+            return error.TestUnexpectedResult;
+        }
+    };
+
+    var result = try fuseNamedSets(alloc, .{
+        .limit = 3,
+        .include_stored = false,
+    }, &named_sets, .{
+        .ctx = null,
+        .load_projected_document = Harness.loadProjectedDocument,
+    });
+    defer result.deinit();
+
+    try std.testing.expectEqual(@as(u32, 3), result.total_hits);
+    try std.testing.expectEqual(types.TotalHitsRelation.gte, result.total_hits_relation);
 }
 
 test "fuseNamedSets rejects unknown merge weights" {

--- a/zig/pkg/antfly/src/storage/db/query/search_exec.zig
+++ b/zig/pkg/antfly/src/storage/db/query/search_exec.zig
@@ -1131,6 +1131,7 @@ pub fn searchComposed(
                 .name = "$full_text_results",
                 .hits = text_result.hits,
                 .total_hits = text_result.total_hits,
+                .total_hits_relation = text_result.total_hits_relation,
                 .resolved_doc_set = resolved_doc_set,
             });
             try owned_results.append(alloc, text_result);
@@ -1148,6 +1149,7 @@ pub fn searchComposed(
                 .name = "$full_text_results",
                 .hits = text_result.hits,
                 .total_hits = text_result.total_hits,
+                .total_hits_relation = text_result.total_hits_relation,
                 .resolved_doc_set = resolved_doc_set,
             });
             try owned_results.append(alloc, text_result);
@@ -1169,6 +1171,7 @@ pub fn searchComposed(
                 .name = full_text_query.name,
                 .hits = text_result.hits,
                 .total_hits = text_result.total_hits,
+                .total_hits_relation = text_result.total_hits_relation,
                 .resolved_doc_set = resolved_doc_set,
             });
             try owned_results.append(alloc, text_result);
@@ -1188,6 +1191,7 @@ pub fn searchComposed(
             .name = if (vector_req.sparse == null) "$embeddings_results" else "dense",
             .hits = dense_result.hits,
             .total_hits = dense_result.total_hits,
+            .total_hits_relation = dense_result.total_hits_relation,
             .resolved_doc_set = resolved_doc_set,
         });
         try owned_results.append(alloc, dense_result);
@@ -1204,6 +1208,7 @@ pub fn searchComposed(
                 .name = dense_query.name,
                 .hits = dense_result.hits,
                 .total_hits = dense_result.total_hits,
+                .total_hits_relation = dense_result.total_hits_relation,
                 .resolved_doc_set = resolved_doc_set,
             });
             try owned_results.append(alloc, dense_result);
@@ -1220,6 +1225,7 @@ pub fn searchComposed(
             .name = if (vector_req.dense == null) "$embeddings_results" else "sparse",
             .hits = sparse_result.hits,
             .total_hits = sparse_result.total_hits,
+            .total_hits_relation = sparse_result.total_hits_relation,
             .resolved_doc_set = resolved_doc_set,
         });
         try owned_results.append(alloc, sparse_result);
@@ -1236,6 +1242,7 @@ pub fn searchComposed(
                 .name = sparse_query.name,
                 .hits = sparse_result.hits,
                 .total_hits = sparse_result.total_hits,
+                .total_hits_relation = sparse_result.total_hits_relation,
                 .resolved_doc_set = resolved_doc_set,
             });
             try owned_results.append(alloc, sparse_result);
@@ -1257,6 +1264,7 @@ pub fn searchComposed(
         .name = "$fused_results",
         .hits = base.hits,
         .total_hits = base.total_hits,
+        .total_hits_relation = base.total_hits_relation,
         .resolved_doc_set = fused_resolved_doc_set,
     });
 
@@ -1419,6 +1427,7 @@ fn appendEmbeddingsResultAlias(
             .name = "$embeddings_results",
             .hits = embedding_sets.items[0].hits,
             .total_hits = embedding_sets.items[0].total_hits,
+            .total_hits_relation = embedding_sets.items[0].total_hits_relation,
             .resolved_doc_set = embedding_sets.items[0].resolved_doc_set,
         });
         return;
@@ -1433,6 +1442,7 @@ fn appendEmbeddingsResultAlias(
         .name = "$embeddings_results",
         .hits = embeddings_result.hits,
         .total_hits = embeddings_result.total_hits,
+        .total_hits_relation = embeddings_result.total_hits_relation,
         .resolved_doc_set = resolved_doc_set,
     });
     try owned_results.append(alloc, embeddings_result);


### PR DESCRIPTION
## Summary

- preserve each retrieval leg total-hits relation through composed query execution
- report a fused union as a lower bound until every source window is complete
- let the existing bounded aggregation rerun expand to its configured budget, so hybrid facets converge instead of returning a generic 400
- retain the existing 422 candidate-budget response when the complete union genuinely exceeds the safety cap

## UX

Clients can keep normal page sizes for hybrid queries with aggregations. The response returns the requested page plus aggregations over the complete fused result set; callers no longer need to drop semantic search or facets as a fallback.

## Tests

- `zig build lib-db-result-shape-test` (22 passed)
- `zig build api-table-reads-docid-test` (15 passed)
- `zig build lib-db-query-test` (181 passed, 2 expected skips)

## Related issue

Closes https://github.com/antflydb/antfly/issues/463