### PR TITLE
fix(api): handle missing tables in HTTPX reads

### DIFF
--- a/zig/build.zig
+++ b/zig/build.zig
@@ -4541,6 +4541,7 @@ pub fn build(b: *std.Build) void {
         "distributed join applies auth row filter to right table filter query",
         "distributed join preserves native public filters when adding join predicates",
         "scan request errors map to stable client responses",
+        "httpx antfly reads map missing table errors to not found",
         "httpx antfly scan honors optional body and documented bad requests",
         "httpx multi batch route uses the batch commit hook and public response contract",
         "httpx stable transaction commit durably hands off recovery before acknowledgement",

--- a/zig/pkg/antfly/src/api/httpx_handler.zig
+++ b/zig/pkg/antfly/src/api/httpx_handler.zig
@@ -2695,6 +2695,10 @@ pub const AntflyApiHandler = struct {
             scan_req.opts,
             .read_index,
         ) catch |err| switch (err) {
+            error.TableNotFound => {
+                _ = ctx.status(404);
+                return ctx.text("not found");
+            },
             error.HAReadRequiresPrimary, error.ReadRequiresPrimary => {
                 _ = ctx.status(503);
                 return ctx.text("read requires primary");
@@ -2753,6 +2757,10 @@ pub const AntflyApiHandler = struct {
         };
 
         var result = (source.lookup(alloc, decoded_table_name, decoded_key, lookup_opts.opts, consistency) catch |err| switch (err) {
+            error.TableNotFound => {
+                _ = ctx.status(404);
+                return ctx.text("not found");
+            },
             error.HAReadRequiresPrimary, error.ReadRequiresPrimary => {
                 _ = ctx.status(503);
                 return ctx.text("read requires primary");
@@ -4856,6 +4864,80 @@ test "httpx antfly lookup route preserves projection and headers" {
     var parsed = try std.json.parseFromSlice(LookupResponse, alloc, resp.body.?, .{});
     defer parsed.deinit();
     try std.testing.expectEqualStrings("alpha", parsed.value.title);
+}
+
+test "httpx antfly reads map missing table errors to not found" {
+    const MissingTableReads = struct {
+        fn source() table_reads.TableReadSource {
+            return .{ .ptr = undefined, .vtable = &vtable };
+        }
+
+        const vtable = table_reads.TableReadSource.VTable{
+            .lookup = lookup,
+            .scan = scan,
+            .query = query,
+        };
+
+        fn lookup(
+            _: *anyopaque,
+            _: std.mem.Allocator,
+            _: []const u8,
+            _: []const u8,
+            _: db_mod.types.LookupOptions,
+            _: raft_mod.ReadConsistency,
+        ) anyerror!?table_reads.LookupResponse {
+            return error.TableNotFound;
+        }
+
+        fn scan(
+            _: *anyopaque,
+            _: std.mem.Allocator,
+            _: []const u8,
+            _: []const u8,
+            _: []const u8,
+            _: db_mod.types.ScanOptions,
+            _: raft_mod.ReadConsistency,
+        ) anyerror!?table_reads.ScanResponse {
+            return error.TableNotFound;
+        }
+
+        fn query(
+            _: *anyopaque,
+            _: std.mem.Allocator,
+            _: []const u8,
+            _: db_mod.types.SearchRequest,
+            _: raft_mod.ReadConsistency,
+        ) anyerror!?query_api.QueryResponse {
+            return error.UnexpectedTestCall;
+        }
+    };
+
+    const alloc = std.testing.allocator;
+    var status_source = LookupStatusSource{};
+    var api_server = ApiHttpServer.init(alloc, .{}, status_source.iface(), MissingTableReads.source(), null);
+    var handler = AntflyApiHandler{ .api_server = &api_server };
+
+    var request = try httpx.Request.init(alloc, .GET, "http://127.0.0.1/db/v1/tables/docs/documents/doc:a");
+    defer request.deinit();
+    var ctx = httpx.Context.init(alloc, undefined, &request);
+    defer ctx.deinit();
+
+    var response = try handler.lookupKey(&ctx, "docs", "doc:a", .{});
+    defer response.deinit();
+    try std.testing.expectEqual(@as(u16, 404), response.status.code);
+    try std.testing.expectEqualStrings("text/plain; charset=utf-8", response.contentType().?);
+    try std.testing.expectEqualStrings("not found", response.body.?);
+
+    var scan_request = try httpx.Request.init(alloc, .POST, "http://127.0.0.1/db/v1/tables/docs/documents");
+    defer scan_request.deinit();
+    var scan_ctx = httpx.Context.init(alloc, undefined, &scan_request);
+    defer scan_ctx.deinit();
+
+    var scan_response = try handler.scanKeys(&scan_ctx, "docs");
+    defer scan_response.deinit();
+    try std.testing.expectEqual(@as(u16, 404), scan_response.status.code);
+    try std.testing.expectEqualStrings("text/plain; charset=utf-8", scan_response.contentType().?);
+    try std.testing.expectEqualStrings("not found", scan_response.body.?);
 }
 
 test "httpx antfly scan honors optional body and documented bad requests" {


### PR DESCRIPTION
## Summary

- map `TableNotFound` from the HTTPX lookup route to a stable `404 not found` response instead of letting it escape the route handler
- fix the same missing-table mismatch in the sibling scan route found during the audit
- add deterministic parity coverage for both routes and include it in the default public API parity target

## CI failure

In Actions job 93645626390, `test_multi_batch_abort_on_invalid_table` completed the expected invalid batch and then its follow-up lookup lost the connection. The server log ended with `Route handler error: error.TableNotFound`, showing the lookup handler allowed that expected domain error to escape.

## Verification

- `zig build public-api-parity-test`: 157 passed, 0 failed, 0 leaked
- focused adjacent lookup/scan parity tests: 3 passed
- rebuilt full-edition Antfly binary
- post-fix flake loop: 20/20 passed for `test_multi_batch_abort_on_invalid_table`

The rare reset did not reproduce in 80 pre-fix local repetitions, but the handler mismatch is deterministic and directly covered by the added regression.
