### PR TITLE
Fix lost forced autosplit scans

### DIFF
--- a/go/pkg/operator/controllers/antfly/antflycluster_controller.go
+++ b/go/pkg/operator/controllers/antfly/antflycluster_controller.go
@@ -3600,8 +3600,13 @@ func (r *AntflyClusterReconciler) buildMetadataClusterConfig(cluster *antflyv1.A
 		if i > 1 {
 			config.WriteString(", ")
 		}
-		fmt.Fprintf(&config, `"%d": "http://%s-metadata-%d.%s-metadata.%s.svc.cluster.local:%d"`,
-			i, cluster.Name, i-1, cluster.Name, cluster.Namespace, cluster.Spec.MetadataNodes.MetadataRaft.Port)
+		fmt.Fprintf(
+			&config,
+			`"%d": {"raft_url":"http://%s-metadata-%d.%s-metadata.%s.svc.cluster.local:%d","orchestration_url":"http://%s-metadata-%d.%s-metadata.%s.svc.cluster.local:%d"}`,
+			i,
+			cluster.Name, i-1, cluster.Name, cluster.Namespace, cluster.Spec.MetadataNodes.MetadataRaft.Port,
+			cluster.Name, i-1, cluster.Name, cluster.Namespace, cluster.Spec.MetadataNodes.MetadataAPI.Port,
+		)
 	}
 	config.WriteString(" }")
 	return config.String()

--- a/go/pkg/operator/controllers/antfly/antflycluster_controller_test.go
+++ b/go/pkg/operator/controllers/antfly/antflycluster_controller_test.go
@@ -12299,6 +12299,39 @@ func TestGenerateCompleteConfig(t *testing.T) {
 	g.Expect(config["max_shards_per_table"]).To(Equal(float64(0)))
 }
 
+func TestBuildMetadataClusterConfigIncludesRaftAndOrchestrationEndpoints(t *testing.T) {
+	g := NewWithT(t)
+	reconciler := &AntflyClusterReconciler{}
+	cluster := &antflyv1.AntflyCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster",
+			Namespace: "antfly-system",
+		},
+		Spec: antflyv1.AntflyClusterSpec{
+			MetadataNodes: antflyv1.MetadataNodesSpec{
+				MetadataAPI:  antflyv1.APISpec{Port: 12377},
+				MetadataRaft: antflyv1.APISpec{Port: 9017},
+			},
+		},
+	}
+
+	type metadataPeerEndpoints struct {
+		RaftURL          string `json:"raft_url"`
+		OrchestrationURL string `json:"orchestration_url"`
+	}
+	var peers map[string]metadataPeerEndpoints
+	g.Expect(json.Unmarshal([]byte(reconciler.buildMetadataClusterConfig(cluster, 3)), &peers)).To(Succeed())
+	g.Expect(peers).To(HaveLen(3))
+	g.Expect(peers["1"]).To(Equal(metadataPeerEndpoints{
+		RaftURL:          "http://test-cluster-metadata-0.test-cluster-metadata.antfly-system.svc.cluster.local:9017",
+		OrchestrationURL: "http://test-cluster-metadata-0.test-cluster-metadata.antfly-system.svc.cluster.local:12377",
+	}))
+	g.Expect(peers["3"]).To(Equal(metadataPeerEndpoints{
+		RaftURL:          "http://test-cluster-metadata-2.test-cluster-metadata.antfly-system.svc.cluster.local:9017",
+		OrchestrationURL: "http://test-cluster-metadata-2.test-cluster-metadata.antfly-system.svc.cluster.local:12377",
+	}))
+}
+
 func TestGenerateCompleteConfig_Standalone(t *testing.T) {
 	g := NewWithT(t)
 

--- a/zig/build.zig
+++ b/zig/build.zig
@@ -3950,6 +3950,7 @@ pub fn build(b: *std.Build) void {
         "data runtime repair queue links and removes debt in constant time",
         "data runtime startup catch-up parks scheduler when only quarantined debt remains",
         "data runtime raft status changes force immediate store status publication",
+        "data runtime reallocation request refreshes group status once per request",
         "data runtime replicated split policy is identity and phase aware",
         "data runtime structural changes preserve physical root generations",
         "data raft draining leader remains stable through membership expansion",

--- a/zig/build.zig
+++ b/zig/build.zig
@@ -3970,7 +3970,7 @@ pub fn build(b: *std.Build) void {
         "data runtime metadata bootstrap retry delay is bounded and jittered",
         "idle cached runtime status stays fresh only for the published root generation",
         "runtime status disk usage cache is scoped to one root generation",
-        "runtime status disk scan retries only when maintenance invalidates its group",
+        "runtime status disk scan retries across a reallocation fence and group invalidation remains scoped",
         "data runtime stamps one producer generation on every reported group",
         "data runtime live writer source follows raft apply ownership",
         "placement topology promotes cutover-ready learners to voters",

--- a/zig/e2e/antfly/test_scaling.py
+++ b/zig/e2e/antfly/test_scaling.py
@@ -894,7 +894,7 @@ class MultiNodeScalingCluster:
         )
 
     def trigger_reallocate(self) -> None:
-        response = self.post_metadata("/internal/v1/reallocate")
+        response = self.post_metadata("/internal/v2/reallocate")
         response.raise_for_status()
 
     def request_split(self, table_name: str, split_key: str) -> None:

--- a/zig/pkg/antfly/src/api/runtime_status.zig
+++ b/zig/pkg/antfly/src/api/runtime_status.zig
@@ -66,11 +66,10 @@ pub const LocalTableRuntimeStatus = struct {
     // deliberately separate from metadata.status_generation, which identifies
     // externally published store snapshots.
     cache_observation_generation: u64 = 0,
-    // Identifies the live local observation that produced these facts. Unlike
-    // cache_observation_generation, this value survives cache-to-cache
-    // refreshes so callers can establish a causal fence without allowing a
-    // recycled snapshot to masquerade as a new DB observation.
-    causal_observation_generation: u64 = 0,
+    // Identifies the filesystem observation that produced disk_bytes. Disk
+    // usage has a separate causal lifetime from DB/runtime facts: a cached or
+    // startup status can still carry a freshly scanned, authoritative size.
+    disk_observation_generation: u64 = 0,
     metadata: RuntimeStatusMetadata = .{},
     disk_bytes: u64 = 0,
     disk_bytes_known: bool = false,
@@ -87,7 +86,7 @@ pub const LocalTableRuntimeStatus = struct {
         return .{
             .group_id = self.group_id,
             .cache_observation_generation = self.cache_observation_generation,
-            .causal_observation_generation = self.causal_observation_generation,
+            .disk_observation_generation = self.disk_observation_generation,
             .metadata = self.metadata,
             .disk_bytes = self.disk_bytes,
             .disk_bytes_known = self.disk_bytes_known,
@@ -288,15 +287,6 @@ pub const TableRuntimeSnapshotCache = struct {
         };
     }
 
-    /// Establishes an ordering point in the same generation domain used by
-    /// live status publications. A status can prove it observed work after
-    /// this call only when its causal generation is greater than the result.
-    pub fn captureCausalObservationFence(self: *@This()) u64 {
-        lockAtomic(&self.mutex);
-        defer self.mutex.unlock();
-        return self.takeObservationGenerationLocked();
-    }
-
     /// Captures all catalog tables in one lock acquisition before refresh DB
     /// inspection begins. `table_names` need only live for this call.
     pub fn captureCatalogToken(
@@ -351,7 +341,6 @@ pub const TableRuntimeSnapshotCache = struct {
         errdefer owned.deinit(self.alloc);
         owned.cache_observation_generation = token.observation_generation;
         owned.withMetadataDefaults(.live_writer_publish, platform_time.monotonicNs());
-        markNewCausalObservation(&owned, token.observation_generation);
 
         lockAtomic(&self.mutex);
         defer self.mutex.unlock();
@@ -425,7 +414,6 @@ pub const TableRuntimeSnapshotCache = struct {
         for (owned, statuses) |*next, status| {
             next.cache_observation_generation = token.observation_generation;
             next.withMetadataDefaults(.live_writer_publish, now_ns);
-            markNewCausalObservation(next, token.observation_generation);
             if (state.groups.getPtr(status.group_id)) |previous| {
                 if (previous.cache_observation_generation > token.observation_generation) {
                     next.deinit(self.alloc);
@@ -487,7 +475,6 @@ pub const TableRuntimeSnapshotCache = struct {
         while (replacement_it.next()) |status| {
             status.cache_observation_generation = observation_generation;
             status.withMetadataDefaults(.live_writer_publish, now_ns);
-            markNewCausalObservation(status, observation_generation);
         }
 
         self.advanceInvalidationEpochLocked();
@@ -700,7 +687,6 @@ pub const TableRuntimeSnapshotCache = struct {
             moved += 1;
             owned.cache_observation_generation = observation_generation;
             owned.withMetadataDefaults(.background_refresh, now_ns);
-            markNewCausalObservation(&owned, observation_generation);
             owned = try self.prepareRefreshStatusLocked(state.groups.getPtr(owned.group_id), owned, now_ns);
             if (replacement.getPtr(owned.group_id)) |duplicate| {
                 duplicate.deinit(self.alloc);
@@ -777,14 +763,6 @@ pub const TableRuntimeSnapshotCache = struct {
 
 fn lessThanGroupId(_: void, lhs: LocalTableRuntimeStatus, rhs: LocalTableRuntimeStatus) bool {
     return lhs.group_id < rhs.group_id;
-}
-
-fn markNewCausalObservation(status: *LocalTableRuntimeStatus, generation: u64) void {
-    if (status.causal_observation_generation != 0 or !statusRuntimeFresh(status.*)) return;
-    switch (status.metadata.source) {
-        .live_writer_publish, .background_refresh, .startup_catch_up => status.causal_observation_generation = generation,
-        .unknown, .synthetic_config, .cached_snapshot, .remote_store, .rebuild_state_quarantine => {},
-    }
 }
 
 fn preserveArtifactVisibilityOnReplayRegression(previous: LocalTableRuntimeStatus, incoming: *LocalTableRuntimeStatus) void {

--- a/zig/pkg/antfly/src/api/runtime_status.zig
+++ b/zig/pkg/antfly/src/api/runtime_status.zig
@@ -66,6 +66,11 @@ pub const LocalTableRuntimeStatus = struct {
     // deliberately separate from metadata.status_generation, which identifies
     // externally published store snapshots.
     cache_observation_generation: u64 = 0,
+    // Identifies the live local observation that produced these facts. Unlike
+    // cache_observation_generation, this value survives cache-to-cache
+    // refreshes so callers can establish a causal fence without allowing a
+    // recycled snapshot to masquerade as a new DB observation.
+    causal_observation_generation: u64 = 0,
     metadata: RuntimeStatusMetadata = .{},
     disk_bytes: u64 = 0,
     disk_bytes_known: bool = false,
@@ -82,6 +87,7 @@ pub const LocalTableRuntimeStatus = struct {
         return .{
             .group_id = self.group_id,
             .cache_observation_generation = self.cache_observation_generation,
+            .causal_observation_generation = self.causal_observation_generation,
             .metadata = self.metadata,
             .disk_bytes = self.disk_bytes,
             .disk_bytes_known = self.disk_bytes_known,
@@ -282,6 +288,15 @@ pub const TableRuntimeSnapshotCache = struct {
         };
     }
 
+    /// Establishes an ordering point in the same generation domain used by
+    /// live status publications. A status can prove it observed work after
+    /// this call only when its causal generation is greater than the result.
+    pub fn captureCausalObservationFence(self: *@This()) u64 {
+        lockAtomic(&self.mutex);
+        defer self.mutex.unlock();
+        return self.takeObservationGenerationLocked();
+    }
+
     /// Captures all catalog tables in one lock acquisition before refresh DB
     /// inspection begins. `table_names` need only live for this call.
     pub fn captureCatalogToken(
@@ -336,6 +351,7 @@ pub const TableRuntimeSnapshotCache = struct {
         errdefer owned.deinit(self.alloc);
         owned.cache_observation_generation = token.observation_generation;
         owned.withMetadataDefaults(.live_writer_publish, platform_time.monotonicNs());
+        markNewCausalObservation(&owned, token.observation_generation);
 
         lockAtomic(&self.mutex);
         defer self.mutex.unlock();
@@ -409,6 +425,7 @@ pub const TableRuntimeSnapshotCache = struct {
         for (owned, statuses) |*next, status| {
             next.cache_observation_generation = token.observation_generation;
             next.withMetadataDefaults(.live_writer_publish, now_ns);
+            markNewCausalObservation(next, token.observation_generation);
             if (state.groups.getPtr(status.group_id)) |previous| {
                 if (previous.cache_observation_generation > token.observation_generation) {
                     next.deinit(self.alloc);
@@ -470,6 +487,7 @@ pub const TableRuntimeSnapshotCache = struct {
         while (replacement_it.next()) |status| {
             status.cache_observation_generation = observation_generation;
             status.withMetadataDefaults(.live_writer_publish, now_ns);
+            markNewCausalObservation(status, observation_generation);
         }
 
         self.advanceInvalidationEpochLocked();
@@ -682,6 +700,7 @@ pub const TableRuntimeSnapshotCache = struct {
             moved += 1;
             owned.cache_observation_generation = observation_generation;
             owned.withMetadataDefaults(.background_refresh, now_ns);
+            markNewCausalObservation(&owned, observation_generation);
             owned = try self.prepareRefreshStatusLocked(state.groups.getPtr(owned.group_id), owned, now_ns);
             if (replacement.getPtr(owned.group_id)) |duplicate| {
                 duplicate.deinit(self.alloc);
@@ -758,6 +777,14 @@ pub const TableRuntimeSnapshotCache = struct {
 
 fn lessThanGroupId(_: void, lhs: LocalTableRuntimeStatus, rhs: LocalTableRuntimeStatus) bool {
     return lhs.group_id < rhs.group_id;
+}
+
+fn markNewCausalObservation(status: *LocalTableRuntimeStatus, generation: u64) void {
+    if (status.causal_observation_generation != 0 or !statusRuntimeFresh(status.*)) return;
+    switch (status.metadata.source) {
+        .live_writer_publish, .background_refresh, .startup_catch_up => status.causal_observation_generation = generation,
+        .unknown, .synthetic_config, .cached_snapshot, .remote_store, .rebuild_state_quarantine => {},
+    }
 }
 
 fn preserveArtifactVisibilityOnReplayRegression(previous: LocalTableRuntimeStatus, incoming: *LocalTableRuntimeStatus) void {

--- a/zig/pkg/antfly/src/api/table_writes.zig
+++ b/zig/pkg/antfly/src/api/table_writes.zig
@@ -9854,6 +9854,10 @@ pub const ProvisionedTableWriteSource = struct {
         _: *ProvisionedTableWriteSource,
         status: *runtime_status.LocalTableRuntimeStatus,
     ) void {
+        // The caller just sampled the live writer. Discard any causal identity
+        // inherited from a cached seed so the next cache publication assigns
+        // this observation its own generation.
+        status.causal_observation_generation = 0;
         status.metadata = .{
             .updated_at_ns = platform_time.monotonicNs(),
             .source = .live_writer_publish,
@@ -19810,6 +19814,11 @@ fn publishStructuralRuntimeObservations(
     std.debug.assert(observations.len <= ProvisionedTableWriteSource.structural_reconcile_groups_per_quantum);
     var statuses: [ProvisionedTableWriteSource.structural_reconcile_groups_per_quantum]runtime_status.LocalTableRuntimeStatus = undefined;
     for (observations, 0..) |observation, index| statuses[index] = observation.status;
+    for (statuses[0..observations.len]) |*status| {
+        if (runtime_status.statusRuntimeFresh(status.*)) {
+            status.causal_observation_generation = token.observation_generation;
+        }
+    }
     const result = if (lifecycle_transition)
         try snapshot_cache.publishLifecycleTransition(completed, table_name, statuses[0..observations.len])
     else
@@ -20107,6 +20116,12 @@ fn publishRuntimeStatusSnapshotToCacheWithStartupPhaseMode(
         else
             markRuntimeStatusFromDb(&status, phase);
         status.metadata.lsm_root_generation = lsm_root_generation;
+        if (runtime_status.statusRuntimeFresh(status)) {
+            // publishRuntimeStatusGroupAfterObservation uses a second token
+            // for cache ordering. Retain the token captured before DB
+            // inspection as the observation's causal identity.
+            status.causal_observation_generation = publication_token.observation_generation;
+        }
         try publishRuntimeStatusGroupAfterObservation(snapshot_cache, publication_token, table_name, status);
     }
 }
@@ -20166,6 +20181,7 @@ fn markRuntimeStatusFromDb(
     status: *runtime_status.LocalTableRuntimeStatus,
     phase: db_mod.types.StartupCatchUpPhase,
 ) void {
+    status.causal_observation_generation = 0;
     status.metadata = .{
         .updated_at_ns = platform_time.monotonicNs(),
         .source = if (phase != .idle)

--- a/zig/pkg/antfly/src/api/table_writes.zig
+++ b/zig/pkg/antfly/src/api/table_writes.zig
@@ -9854,10 +9854,6 @@ pub const ProvisionedTableWriteSource = struct {
         _: *ProvisionedTableWriteSource,
         status: *runtime_status.LocalTableRuntimeStatus,
     ) void {
-        // The caller just sampled the live writer. Discard any causal identity
-        // inherited from a cached seed so the next cache publication assigns
-        // this observation its own generation.
-        status.causal_observation_generation = 0;
         status.metadata = .{
             .updated_at_ns = platform_time.monotonicNs(),
             .source = .live_writer_publish,
@@ -19814,11 +19810,6 @@ fn publishStructuralRuntimeObservations(
     std.debug.assert(observations.len <= ProvisionedTableWriteSource.structural_reconcile_groups_per_quantum);
     var statuses: [ProvisionedTableWriteSource.structural_reconcile_groups_per_quantum]runtime_status.LocalTableRuntimeStatus = undefined;
     for (observations, 0..) |observation, index| statuses[index] = observation.status;
-    for (statuses[0..observations.len]) |*status| {
-        if (runtime_status.statusRuntimeFresh(status.*)) {
-            status.causal_observation_generation = token.observation_generation;
-        }
-    }
     const result = if (lifecycle_transition)
         try snapshot_cache.publishLifecycleTransition(completed, table_name, statuses[0..observations.len])
     else
@@ -20116,12 +20107,6 @@ fn publishRuntimeStatusSnapshotToCacheWithStartupPhaseMode(
         else
             markRuntimeStatusFromDb(&status, phase);
         status.metadata.lsm_root_generation = lsm_root_generation;
-        if (runtime_status.statusRuntimeFresh(status)) {
-            // publishRuntimeStatusGroupAfterObservation uses a second token
-            // for cache ordering. Retain the token captured before DB
-            // inspection as the observation's causal identity.
-            status.causal_observation_generation = publication_token.observation_generation;
-        }
         try publishRuntimeStatusGroupAfterObservation(snapshot_cache, publication_token, table_name, status);
     }
 }
@@ -20181,7 +20166,6 @@ fn markRuntimeStatusFromDb(
     status: *runtime_status.LocalTableRuntimeStatus,
     phase: db_mod.types.StartupCatchUpPhase,
 ) void {
-    status.causal_observation_generation = 0;
     status.metadata = .{
         .updated_at_ns = platform_time.monotonicNs(),
         .source = if (phase != .idle)

--- a/zig/pkg/antfly/src/data/runtime.zig
+++ b/zig/pkg/antfly/src/data/runtime.zig
@@ -3869,6 +3869,8 @@ pub const DataServer = struct {
     last_data_raft_reconciled_metadata_epoch: ?u64 = null,
     last_data_raft_storage_ownership_fingerprint: ?u64 = null,
     last_data_raft_status_fingerprint: ?u64 = null,
+    reallocation_request_observation_mutex: std.atomic.Mutex = .unlocked,
+    last_observed_reallocation_request_id: ?u128 = null,
     provision_ticks: usize = 0,
     last_provision_fingerprint: ?u64 = null,
     last_provision_metadata_epoch: ?u64 = null,
@@ -7324,6 +7326,34 @@ pub const DataServer = struct {
         self.markStoreStatusDirtyImmediate();
     }
 
+    fn observeReallocationRequest(
+        self: *DataServer,
+        request: ?antfly.metadata.ReallocationRequestRecord,
+    ) void {
+        const request_id = if (request) |record| record.request_id else null;
+        const changed = changed: {
+            lockAtomic(&self.reallocation_request_observation_mutex);
+            defer self.reallocation_request_observation_mutex.unlock();
+            if (request_id == null) {
+                self.last_observed_reallocation_request_id = null;
+                break :changed false;
+            }
+            if (self.last_observed_reallocation_request_id != null and
+                self.last_observed_reallocation_request_id.? == request_id.?)
+            {
+                break :changed false;
+            }
+            self.last_observed_reallocation_request_id = request_id;
+            break :changed true;
+        };
+        if (!changed) return;
+        // A forced split/merge scan must be based on observations produced
+        // after its durable request. Refresh exactly once per request instead
+        // of coupling operator latency to the normal 60-second cache TTL.
+        self.invalidateLocalGroupStatusCache();
+        self.markStoreStatusDirtyImmediate();
+    }
+
     fn markRuntimeStatusDirty(
         self: *DataServer,
         table_name: []const u8,
@@ -9733,6 +9763,7 @@ pub const DataServer = struct {
             registration.node_id,
             registration.store_id,
         );
+        annotateReallocationRequestObservation(group_statuses, snapshot.reallocation_request);
         const runtime_statuses = try self.collectStoreRuntimeStatusReports(
             self.alloc,
             local_group_ids,
@@ -9825,6 +9856,7 @@ pub const DataServer = struct {
     }
 
     fn syncDataRaftFromSnapshot(self: *DataServer, snapshot: *const antfly.metadata_api.AdminSnapshot) !void {
+        self.observeReallocationRequest(snapshot.reallocation_request);
         const raft = self.data_raft orelse return;
         const factory = self.data_raft_factory orelse return;
         const registration = self.store_registration orelse return;
@@ -14161,6 +14193,7 @@ fn remoteGroupReadyForTableLifecycle(
 fn cloneAdminSnapshotOwned(alloc: std.mem.Allocator, snapshot: antfly.metadata_api.AdminSnapshot) !antfly.metadata_api.AdminSnapshot {
     return .{
         .status = snapshot.status,
+        .reallocation_request = snapshot.reallocation_request,
         .tables = try cloneTablesOwned(alloc, snapshot.tables),
         .ranges = try cloneRangesOwned(alloc, snapshot.ranges),
         .stores = try cloneStoresOwned(alloc, snapshot.stores),
@@ -14180,6 +14213,21 @@ fn cloneAdminSnapshotOwned(alloc: std.mem.Allocator, snapshot: antfly.metadata_a
         .merge_observations = try cloneMergeObservationsOwned(alloc, snapshot.merge_observations),
         .merged_group_statuses = try cloneMergedGroupStatusesOwned(alloc, snapshot.merged_group_statuses),
     };
+}
+
+fn annotateReallocationRequestObservation(
+    statuses: []antfly.metadata.table_manager.GroupStatusReport,
+    request: ?antfly.metadata.ReallocationRequestRecord,
+) void {
+    const record = request orelse return;
+    for (statuses) |*status| {
+        // Unknown-size Raft fallbacks are deliberately not allowed to
+        // acknowledge the scan; the background refresh will publish
+        // authoritative size evidence with this request ID.
+        if (status.disk_bytes_known) {
+            status.observed_reallocation_request_id = record.request_id;
+        }
+    }
 }
 
 fn localGroupStatusFingerprint(
@@ -17524,6 +17572,67 @@ test "data runtime raft status changes force immediate store status publication"
     server.observeDataRaftStatusFingerprint(12);
     try std.testing.expect(server.store_status_dirty.load(.acquire));
     try std.testing.expectEqual(store_status_report_interval_ticks, server.store_status_ticks.load(.acquire));
+}
+
+test "data runtime reallocation request refreshes group status once per request" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const replica_root_dir = try std.fmt.allocPrint(std.testing.allocator, ".zig-cache/tmp/{s}/data-runtime-reallocation-status-refresh", .{tmp.sub_path});
+    defer std.testing.allocator.free(replica_root_dir);
+
+    var server: DataServer = .{
+        .alloc = std.testing.allocator,
+        .provisioned_storage = antfly.public_api.ProvisionedGroupStorage.init(std.testing.allocator),
+        .read_source = antfly.public_api.ProvisionedTableReadSource.init(
+            replica_root_dir,
+            antfly.public_api.table_catalog.emptyCatalogSource(),
+            antfly.raft.read_gate.noopReadableLeaseRequester(),
+        ),
+        .write_source = antfly.public_api.ProvisionedTableWriteSource.init(
+            replica_root_dir,
+            antfly.public_api.table_catalog.emptyCatalogSource(),
+        ),
+        .status_source = undefined,
+        .api_server_cfg = undefined,
+        .query_async_limit = .limited(8),
+        .listener_cfg = undefined,
+    };
+    defer server.deinit();
+
+    const initial_generation = server.local_group_status_generation.load(.acquire);
+    try server.storeCachedLocalGroupStatuses(initial_generation, 99, &.{});
+    server.store_status_dirty.store(false, .release);
+    server.store_status_ticks.store(0, .release);
+
+    const request: antfly.metadata.ReallocationRequestRecord = .{
+        .request_id = 123,
+        .requested_at_ms = 456,
+    };
+    server.observeReallocationRequest(request);
+    const request_generation = server.local_group_status_generation.load(.acquire);
+    try std.testing.expectEqual(initial_generation + 1, request_generation);
+    try std.testing.expect(server.localGroupStatusCacheStale(@intCast(@divTrunc(platform_time.monotonicNs(), std.time.ns_per_ms))));
+    try std.testing.expect(server.store_status_dirty.load(.acquire));
+    try std.testing.expectEqual(store_status_report_interval_ticks, server.store_status_ticks.load(.acquire));
+
+    server.store_status_dirty.store(false, .release);
+    server.store_status_ticks.store(0, .release);
+    server.observeReallocationRequest(request);
+    try std.testing.expectEqual(request_generation, server.local_group_status_generation.load(.acquire));
+    try std.testing.expect(!server.store_status_dirty.load(.acquire));
+    try std.testing.expectEqual(@as(usize, 0), server.store_status_ticks.load(.acquire));
+
+    server.observeReallocationRequest(null);
+    try std.testing.expectEqual(request_generation, server.local_group_status_generation.load(.acquire));
+
+    var statuses = [_]antfly.metadata.table_manager.GroupStatusReport{
+        .{ .group_id = 1, .disk_bytes_known = true },
+        .{ .group_id = 2, .disk_bytes_known = false },
+    };
+    annotateReallocationRequestObservation(&statuses, request);
+    try std.testing.expectEqual(@as(u128, 123), statuses[0].observed_reallocation_request_id);
+    try std.testing.expectEqual(@as(u128, 0), statuses[1].observed_reallocation_request_id);
 }
 
 test "data runtime local split fallback preserves source identity namespace" {

--- a/zig/pkg/antfly/src/data/runtime.zig
+++ b/zig/pkg/antfly/src/data/runtime.zig
@@ -3871,6 +3871,7 @@ pub const DataServer = struct {
     last_data_raft_status_fingerprint: ?u64 = null,
     reallocation_request_observation_mutex: std.atomic.Mutex = .unlocked,
     last_observed_reallocation_request_id: ?u128 = null,
+    reallocation_runtime_status_fence: u64 = 0,
     provision_ticks: usize = 0,
     last_provision_fingerprint: ?u64 = null,
     last_provision_metadata_epoch: ?u64 = null,
@@ -3992,6 +3993,7 @@ pub const DataServer = struct {
     provisioned_index_repair_routes: IndexRepairRoutingIndex = .{},
     provisioned_index_repair_last_fallback_at_ms: std.atomic.Value(u64) = .init(0),
     runtime_status_dirty: std.atomic.Value(bool) = .init(true),
+    runtime_status_force_refresh: std.atomic.Value(bool) = .init(false),
     runtime_status_last_refresh_at_ms: std.atomic.Value(u64) = .init(0),
     runtime_status_disk_usage_cache_mutex: std.atomic.Mutex = .unlocked,
     runtime_status_disk_usage_cache: std.AutoHashMapUnmanaged(u64, RuntimeStatusDiskUsageCacheEntry) = .empty,
@@ -7336,6 +7338,7 @@ pub const DataServer = struct {
             defer self.reallocation_request_observation_mutex.unlock();
             if (request_id == null) {
                 self.last_observed_reallocation_request_id = null;
+                self.reallocation_runtime_status_fence = 0;
                 break :changed false;
             }
             if (self.last_observed_reallocation_request_id != null and
@@ -7343,6 +7346,7 @@ pub const DataServer = struct {
             {
                 break :changed false;
             }
+            self.reallocation_runtime_status_fence = self.provisioned_storage.runtime_status_cache.captureCausalObservationFence();
             self.last_observed_reallocation_request_id = request_id;
             break :changed true;
         };
@@ -7351,7 +7355,50 @@ pub const DataServer = struct {
         // after its durable request. Refresh exactly once per request instead
         // of coupling operator latency to the normal 60-second cache TTL.
         self.invalidateLocalGroupStatusCache();
+        self.runtime_status_dirty.store(true, .release);
+        self.runtime_status_force_refresh.store(true, .release);
         self.markStoreStatusDirtyImmediate();
+    }
+
+    const ReallocationObservationRequirement = struct {
+        request_id: u128,
+        runtime_status_fence: u64,
+    };
+
+    fn currentReallocationObservationRequirement(self: *DataServer) ?ReallocationObservationRequirement {
+        lockAtomic(&self.reallocation_request_observation_mutex);
+        defer self.reallocation_request_observation_mutex.unlock();
+        return .{
+            .request_id = self.last_observed_reallocation_request_id orelse return null,
+            .runtime_status_fence = self.reallocation_runtime_status_fence,
+        };
+    }
+
+    fn annotateFreshReallocationObservation(
+        self: *DataServer,
+        report: *antfly.metadata.table_manager.GroupStatusReport,
+        observed_requirement: ?ReallocationObservationRequirement,
+    ) void {
+        if (!report.disk_bytes_known) return;
+        const observed = observed_requirement orelse return;
+        const current = self.currentReallocationObservationRequirement() orelse return;
+        if (current.request_id != observed.request_id or
+            current.runtime_status_fence != observed.runtime_status_fence)
+        {
+            return;
+        }
+        report.observed_reallocation_request_id = observed.request_id;
+    }
+
+    fn annotateRuntimeReallocationObservation(
+        self: *DataServer,
+        report: *antfly.metadata.table_manager.GroupStatusReport,
+        status: runtime_status.LocalTableRuntimeStatus,
+    ) void {
+        if (!report.disk_bytes_known or !runtime_status.statusRuntimeFresh(status)) return;
+        const requirement = self.currentReallocationObservationRequirement() orelse return;
+        if (status.causal_observation_generation <= requirement.runtime_status_fence) return;
+        report.observed_reallocation_request_id = requirement.request_id;
     }
 
     fn markRuntimeStatusDirty(
@@ -9411,7 +9458,7 @@ pub const DataServer = struct {
                         var runtime_status_owned = runtime_cached;
                         defer runtime_status_owned.deinit(alloc);
                         const cached_group = try self.snapshotCachedLocalGroupStatusReport(alloc, group_id, generation, fingerprint, true);
-                        try reports.append(alloc, collectLocalGroupStatusFromRuntimeStatus(
+                        var report = collectLocalGroupStatusFromRuntimeStatus(
                             runtime_status_owned,
                             cached_group,
                             group_id,
@@ -9423,7 +9470,9 @@ pub const DataServer = struct {
                             merge_transitions,
                             split_observations,
                             merge_observations,
-                        ));
+                        );
+                        self.annotateRuntimeReallocationObservation(&report, runtime_status_owned);
+                        try reports.append(alloc, report);
                         continue;
                     }
 
@@ -9520,7 +9569,12 @@ pub const DataServer = struct {
                         return err;
                     };
                     defer db.close();
-                    const report = collectLocalGroupStatusFromDb(
+                    // Capture the request before reading the DB. A request
+                    // arriving during this scan must trigger another scan;
+                    // the already-running read cannot prove it observed work
+                    // causally after that request.
+                    const reallocation_requirement = self.currentReallocationObservationRequirement();
+                    var report = collectLocalGroupStatusFromDb(
                         alloc,
                         &db,
                         db_path,
@@ -9548,6 +9602,7 @@ pub const DataServer = struct {
                         ));
                         continue;
                     };
+                    self.annotateFreshReallocationObservation(&report, reallocation_requirement);
                     try reports.append(alloc, report);
                     continue;
                 }
@@ -9572,7 +9627,8 @@ pub const DataServer = struct {
                 continue;
             }
 
-            const report = collectLocalGroupStatus(
+            const reallocation_requirement = self.currentReallocationObservationRequirement();
+            var report = collectLocalGroupStatus(
                 alloc,
                 db_path,
                 group_id,
@@ -9590,9 +9646,9 @@ pub const DataServer = struct {
                 merge_transitions,
                 split_observations,
                 merge_observations,
-            ) catch |err| blk: {
+            ) catch |err| {
                 if (!isTransientStatusDbConflict(err)) return err;
-                break :blk collectLocalGroupStatusWithoutDb(
+                try reports.append(alloc, collectLocalGroupStatusWithoutDb(
                     group_id,
                     group_leadership_source,
                     group_membership_source,
@@ -9602,8 +9658,10 @@ pub const DataServer = struct {
                     merge_transitions,
                     split_observations,
                     merge_observations,
-                );
+                ));
+                continue;
             };
+            self.annotateFreshReallocationObservation(&report, reallocation_requirement);
             try reports.append(alloc, report);
         }
 
@@ -9763,7 +9821,7 @@ pub const DataServer = struct {
             registration.node_id,
             registration.store_id,
         );
-        annotateReallocationRequestObservation(group_statuses, snapshot.reallocation_request);
+        retainCurrentReallocationRequestObservations(group_statuses, snapshot.reallocation_request);
         const runtime_statuses = try self.collectStoreRuntimeStatusReports(
             self.alloc,
             local_group_ids,
@@ -11613,7 +11671,11 @@ pub const DataServer = struct {
 
         const now_ms: u64 = @intCast(@divTrunc(platform_time.monotonicNs(), std.time.ns_per_ms));
         const last_at_ms = self.runtime_status_last_refresh_at_ms.load(.monotonic);
-        if (last_at_ms != 0 and now_ms -| last_at_ms < runtime_status_refresh_interval_ms) return;
+        if (!self.runtime_status_force_refresh.load(.acquire) and
+            last_at_ms != 0 and now_ms -| last_at_ms < runtime_status_refresh_interval_ms)
+        {
+            return;
+        }
         try self.requestRuntimeStatusRefresh();
     }
 
@@ -11951,8 +12013,12 @@ pub const DataServer = struct {
         // A lifecycle notification that arrives after this exchange must remain
         // set for the next pass; never overwrite it with false at completion.
         _ = self.runtime_status_dirty.swap(false, .acq_rel);
+        const forced_refresh = self.runtime_status_force_refresh.swap(false, .acq_rel);
         var refresh_completed = false;
-        defer if (!refresh_completed) self.runtime_status_dirty.store(true, .release);
+        defer if (!refresh_completed) {
+            self.runtime_status_dirty.store(true, .release);
+            if (forced_refresh) self.runtime_status_force_refresh.store(true, .release);
+        };
         var stats: RuntimeStatusRefreshStats = .{};
         var budget: RuntimeStatusRefreshBudget = .{ .max_db_opens = max_db_opens };
         var pending_runtime_work = false;
@@ -14215,17 +14281,17 @@ fn cloneAdminSnapshotOwned(alloc: std.mem.Allocator, snapshot: antfly.metadata_a
     };
 }
 
-fn annotateReallocationRequestObservation(
+fn retainCurrentReallocationRequestObservations(
     statuses: []antfly.metadata.table_manager.GroupStatusReport,
     request: ?antfly.metadata.ReallocationRequestRecord,
 ) void {
-    const record = request orelse return;
     for (statuses) |*status| {
-        // Unknown-size Raft fallbacks are deliberately not allowed to
-        // acknowledge the scan; the background refresh will publish
-        // authoritative size evidence with this request ID.
-        if (status.disk_bytes_known) {
-            status.observed_reallocation_request_id = record.request_id;
+        const record = request orelse {
+            status.observed_reallocation_request_id = 0;
+            continue;
+        };
+        if (status.observed_reallocation_request_id != record.request_id) {
+            status.observed_reallocation_request_id = 0;
         }
     }
 }
@@ -17609,30 +17675,129 @@ test "data runtime reallocation request refreshes group status once per request"
         .request_id = 123,
         .requested_at_ms = 456,
     };
+    const pre_request_token = try server.provisioned_storage.runtime_status_cache.capturePublicationToken("docs");
+    try std.testing.expectEqual(
+        runtime_status.TableRuntimeSnapshotCache.PublishResult.published,
+        try server.provisioned_storage.runtime_status_cache.publishGroup(pre_request_token, "docs", .{
+            .group_id = 1,
+            .disk_bytes = 50,
+            .disk_bytes_known = true,
+            .metadata = .{ .source = .live_writer_publish, .freshness = .fresh },
+            .stats = .{},
+        }),
+    );
+    const straddled_observation_token = try server.provisioned_storage.runtime_status_cache.capturePublicationToken("docs");
     server.observeReallocationRequest(request);
     const request_generation = server.local_group_status_generation.load(.acquire);
     try std.testing.expectEqual(initial_generation + 1, request_generation);
     try std.testing.expect(server.localGroupStatusCacheStale(@intCast(@divTrunc(platform_time.monotonicNs(), std.time.ns_per_ms))));
     try std.testing.expect(server.store_status_dirty.load(.acquire));
     try std.testing.expectEqual(store_status_report_interval_ticks, server.store_status_ticks.load(.acquire));
+    try std.testing.expect(server.runtime_status_dirty.load(.acquire));
+    try std.testing.expect(server.runtime_status_force_refresh.swap(false, .acq_rel));
 
     server.store_status_dirty.store(false, .release);
     server.store_status_ticks.store(0, .release);
+    server.runtime_status_dirty.store(false, .release);
     server.observeReallocationRequest(request);
     try std.testing.expectEqual(request_generation, server.local_group_status_generation.load(.acquire));
     try std.testing.expect(!server.store_status_dirty.load(.acquire));
     try std.testing.expectEqual(@as(usize, 0), server.store_status_ticks.load(.acquire));
+    try std.testing.expect(!server.runtime_status_dirty.load(.acquire));
+    try std.testing.expect(!server.runtime_status_force_refresh.load(.acquire));
 
     server.observeReallocationRequest(null);
     try std.testing.expectEqual(request_generation, server.local_group_status_generation.load(.acquire));
 
-    var statuses = [_]antfly.metadata.table_manager.GroupStatusReport{
-        .{ .group_id = 1, .disk_bytes_known = true },
-        .{ .group_id = 2, .disk_bytes_known = false },
+    server.observeReallocationRequest(request);
+    const straddled_publication_token = try server.provisioned_storage.runtime_status_cache.capturePublicationToken("docs");
+    try std.testing.expectEqual(
+        runtime_status.TableRuntimeSnapshotCache.PublishResult.published,
+        try server.provisioned_storage.runtime_status_cache.publishGroup(straddled_publication_token, "docs", .{
+            .group_id = 1,
+            .causal_observation_generation = straddled_observation_token.observation_generation,
+            .disk_bytes = 100,
+            .disk_bytes_known = true,
+            .metadata = .{ .source = .live_writer_publish, .freshness = .fresh },
+            .stats = .{},
+        }),
+    );
+    var straddled_runtime = (try server.provisioned_storage.runtime_status_cache.snapshotGroupStatus(
+        std.testing.allocator,
+        "docs",
+        1,
+    )).?;
+    defer straddled_runtime.deinit(std.testing.allocator);
+    var straddled_report = antfly.metadata.table_manager.GroupStatusReport{ .group_id = 1, .disk_bytes_known = true };
+    server.annotateRuntimeReallocationObservation(&straddled_report, straddled_runtime);
+    try std.testing.expectEqual(@as(u128, 0), straddled_report.observed_reallocation_request_id);
+
+    var stale_runtime = (try server.provisioned_storage.runtime_status_cache.snapshotGroupStatus(
+        std.testing.allocator,
+        "docs",
+        1,
+    )).?;
+    defer stale_runtime.deinit(std.testing.allocator);
+    var stale_report = antfly.metadata.table_manager.GroupStatusReport{ .group_id = 1, .disk_bytes_known = true };
+    server.annotateRuntimeReallocationObservation(&stale_report, stale_runtime);
+    try std.testing.expectEqual(@as(u128, 0), stale_report.observed_reallocation_request_id);
+
+    const recycled_token = try server.provisioned_storage.runtime_status_cache.capturePublicationToken("docs");
+    try std.testing.expectEqual(
+        runtime_status.TableRuntimeSnapshotCache.PublishResult.published,
+        try server.provisioned_storage.runtime_status_cache.publishGroup(recycled_token, "docs", stale_runtime),
+    );
+    var recycled_runtime = (try server.provisioned_storage.runtime_status_cache.snapshotGroupStatus(
+        std.testing.allocator,
+        "docs",
+        1,
+    )).?;
+    defer recycled_runtime.deinit(std.testing.allocator);
+    var recycled_report = antfly.metadata.table_manager.GroupStatusReport{ .group_id = 1, .disk_bytes_known = true };
+    server.annotateRuntimeReallocationObservation(&recycled_report, recycled_runtime);
+    try std.testing.expectEqual(@as(u128, 0), recycled_report.observed_reallocation_request_id);
+
+    const post_request_token = try server.provisioned_storage.runtime_status_cache.capturePublicationToken("docs");
+    try std.testing.expectEqual(
+        runtime_status.TableRuntimeSnapshotCache.PublishResult.published,
+        try server.provisioned_storage.runtime_status_cache.publishGroup(post_request_token, "docs", .{
+            .group_id = 1,
+            .disk_bytes = 200,
+            .disk_bytes_known = true,
+            .metadata = .{ .source = .live_writer_publish, .freshness = .fresh },
+            .stats = .{},
+        }),
+    );
+    var fresh_runtime = (try server.provisioned_storage.runtime_status_cache.snapshotGroupStatus(
+        std.testing.allocator,
+        "docs",
+        1,
+    )).?;
+    defer fresh_runtime.deinit(std.testing.allocator);
+    var fresh_report = antfly.metadata.table_manager.GroupStatusReport{ .group_id = 1, .disk_bytes_known = true };
+    server.annotateRuntimeReallocationObservation(&fresh_report, fresh_runtime);
+    try std.testing.expectEqual(@as(u128, 123), fresh_report.observed_reallocation_request_id);
+
+    var statuses = [_]antfly.metadata.table_manager.GroupStatusReport{fresh_report};
+    retainCurrentReallocationRequestObservations(&statuses, null);
+    try std.testing.expectEqual(@as(u128, 0), statuses[0].observed_reallocation_request_id);
+
+    server.observeReallocationRequest(null);
+    const before_request_scan = server.currentReallocationObservationRequirement();
+    server.observeReallocationRequest(.{
+        .request_id = 456,
+        .requested_at_ms = 789,
+    });
+    var overlapping_scan_report = antfly.metadata.table_manager.GroupStatusReport{
+        .group_id = 1,
+        .disk_bytes_known = true,
     };
-    annotateReallocationRequestObservation(&statuses, request);
-    try std.testing.expectEqual(@as(u128, 123), statuses[0].observed_reallocation_request_id);
-    try std.testing.expectEqual(@as(u128, 0), statuses[1].observed_reallocation_request_id);
+    server.annotateFreshReallocationObservation(&overlapping_scan_report, before_request_scan);
+    try std.testing.expectEqual(@as(u128, 0), overlapping_scan_report.observed_reallocation_request_id);
+
+    const after_request_scan = server.currentReallocationObservationRequirement();
+    server.annotateFreshReallocationObservation(&overlapping_scan_report, after_request_scan);
+    try std.testing.expectEqual(@as(u128, 456), overlapping_scan_report.observed_reallocation_request_id);
 }
 
 test "data runtime local split fallback preserves source identity namespace" {

--- a/zig/pkg/antfly/src/data/runtime.zig
+++ b/zig/pkg/antfly/src/data/runtime.zig
@@ -2276,11 +2276,17 @@ test "data server rejects replicated transition admission after owner shutdown" 
 
 const RuntimeStatusDiskUsageCacheEntry = struct {
     disk_bytes: u64 = 0,
+    observation_generation: u64 = 0,
     checked_at_ns: u64 = 0,
     lsm_root_generation: u64 = 0,
     storage_change_token: u64 = 0,
     invalidation_generation: u64 = 0,
     valid: bool = false,
+};
+
+const RuntimeStatusDiskUsageObservation = struct {
+    disk_bytes: u64,
+    observation_generation: u64,
 };
 
 const RuntimeStatusDiskUsageScanner = struct {
@@ -3223,7 +3229,7 @@ test "runtime status disk usage cache is scoped to one root generation and group
     try std.testing.expectEqual(@as(u64, 800), server.runtime_status_disk_usage_cache.get(8).?.disk_bytes);
 }
 
-test "runtime status disk scan retries only when maintenance invalidates its group" {
+test "runtime status disk scan retries across a reallocation fence and group invalidation remains scoped" {
     const ControlledScanner = struct {
         entered: std.atomic.Value(bool) = .init(false),
         release: std.atomic.Value(bool) = .init(false),
@@ -3247,7 +3253,7 @@ test "runtime status disk scan retries only when maintenance invalidates its gro
     const ScanThread = struct {
         server: *DataServer,
         scanner: RuntimeStatusDiskUsageScanner,
-        result: ?u64 = null,
+        result: ?RuntimeStatusDiskUsageObservation = null,
 
         fn run(self: *@This()) void {
             self.result = self.server.runtimeStatusDiskUsageBytesBestEffortWithScanner(
@@ -3289,13 +3295,31 @@ test "runtime status disk scan retries only when maintenance invalidates its gro
     const thread = try std.Thread.spawn(.{}, ScanThread.run, .{&scan_thread});
     while (!controlled.entered.load(.acquire)) std.Thread.yield() catch {};
 
-    // This models a completed flush/compaction publishing a new storage view
-    // while the status scan still observes the old directory contents.
-    server.invalidateRuntimeStatusDiskUsageCacheForGroup(7);
+    // A request arriving during the scan fences its observation and
+    // invalidates the entry. Only the retry may acknowledge the request.
+    server.observeReallocationRequest(.{ .request_id = 44, .requested_at_ms = 55 });
     controlled.release.store(true, .release);
     thread.join();
 
-    try std.testing.expectEqual(@as(?u64, 222), scan_thread.result);
+    try std.testing.expectEqual(@as(u64, 222), scan_thread.result.?.disk_bytes);
+    try std.testing.expect(
+        scan_thread.result.?.observation_generation >
+            server.currentReallocationObservationRequirement().?.disk_observation_fence,
+    );
+    var stale_runtime_with_fresh_disk = runtime_status.LocalTableRuntimeStatus{
+        .group_id = 7,
+        .disk_bytes = scan_thread.result.?.disk_bytes,
+        .disk_bytes_known = true,
+        .disk_observation_generation = scan_thread.result.?.observation_generation,
+        .metadata = .{ .source = .cached_snapshot, .freshness = .stale },
+        .stats = .{},
+    };
+    defer stale_runtime_with_fresh_disk.deinit(alloc);
+    var report = antfly.metadata.table_manager.GroupStatusReport{ .group_id = 7 };
+    server.annotateRuntimeReallocationObservation(&report, stale_runtime_with_fresh_disk);
+    try std.testing.expect(report.disk_bytes_known);
+    try std.testing.expectEqual(@as(u64, 222), report.disk_bytes);
+    try std.testing.expectEqual(@as(u128, 44), report.observed_reallocation_request_id);
     try std.testing.expectEqual(@as(u32, 2), controlled.calls.load(.acquire));
     const cached = server.runtime_status_disk_usage_cache.get(7).?;
     try std.testing.expect(cached.valid);
@@ -3314,7 +3338,7 @@ test "runtime status disk scan retries only when maintenance invalidates its gro
     controlled.release.store(true, .release);
     unrelated_thread.join();
 
-    try std.testing.expectEqual(@as(?u64, 111), unrelated_scan_thread.result);
+    try std.testing.expectEqual(@as(u64, 111), unrelated_scan_thread.result.?.disk_bytes);
     try std.testing.expectEqual(@as(u32, 1), controlled.calls.load(.acquire));
 }
 
@@ -3871,7 +3895,7 @@ pub const DataServer = struct {
     last_data_raft_status_fingerprint: ?u64 = null,
     reallocation_request_observation_mutex: std.atomic.Mutex = .unlocked,
     last_observed_reallocation_request_id: ?u128 = null,
-    reallocation_runtime_status_fence: u64 = 0,
+    reallocation_disk_observation_fence: u64 = 0,
     provision_ticks: usize = 0,
     last_provision_fingerprint: ?u64 = null,
     last_provision_metadata_epoch: ?u64 = null,
@@ -3997,6 +4021,7 @@ pub const DataServer = struct {
     runtime_status_last_refresh_at_ms: std.atomic.Value(u64) = .init(0),
     runtime_status_disk_usage_cache_mutex: std.atomic.Mutex = .unlocked,
     runtime_status_disk_usage_cache: std.AutoHashMapUnmanaged(u64, RuntimeStatusDiskUsageCacheEntry) = .empty,
+    runtime_status_disk_observation_generation: std.atomic.Value(u64) = .init(1),
     // Detect an invalidation racing a directory scan before it can publish a
     // stale result. Per-group cache entries remain independently reusable.
     runtime_status_disk_usage_invalidation_generation: std.atomic.Value(u64) = .init(1),
@@ -7338,7 +7363,7 @@ pub const DataServer = struct {
             defer self.reallocation_request_observation_mutex.unlock();
             if (request_id == null) {
                 self.last_observed_reallocation_request_id = null;
-                self.reallocation_runtime_status_fence = 0;
+                self.reallocation_disk_observation_fence = 0;
                 break :changed false;
             }
             if (self.last_observed_reallocation_request_id != null and
@@ -7346,7 +7371,7 @@ pub const DataServer = struct {
             {
                 break :changed false;
             }
-            self.reallocation_runtime_status_fence = self.provisioned_storage.runtime_status_cache.captureCausalObservationFence();
+            self.reallocation_disk_observation_fence = self.runtime_status_disk_observation_generation.load(.seq_cst);
             self.last_observed_reallocation_request_id = request_id;
             break :changed true;
         };
@@ -7355,6 +7380,7 @@ pub const DataServer = struct {
         // after its durable request. Refresh exactly once per request instead
         // of coupling operator latency to the normal 60-second cache TTL.
         self.invalidateLocalGroupStatusCache();
+        self.invalidateAllRuntimeStatusDiskUsageCacheEntries();
         self.runtime_status_dirty.store(true, .release);
         self.runtime_status_force_refresh.store(true, .release);
         self.markStoreStatusDirtyImmediate();
@@ -7362,7 +7388,7 @@ pub const DataServer = struct {
 
     const ReallocationObservationRequirement = struct {
         request_id: u128,
-        runtime_status_fence: u64,
+        disk_observation_fence: u64,
     };
 
     fn currentReallocationObservationRequirement(self: *DataServer) ?ReallocationObservationRequirement {
@@ -7370,7 +7396,7 @@ pub const DataServer = struct {
         defer self.reallocation_request_observation_mutex.unlock();
         return .{
             .request_id = self.last_observed_reallocation_request_id orelse return null,
-            .runtime_status_fence = self.reallocation_runtime_status_fence,
+            .disk_observation_fence = self.reallocation_disk_observation_fence,
         };
     }
 
@@ -7383,7 +7409,7 @@ pub const DataServer = struct {
         const observed = observed_requirement orelse return;
         const current = self.currentReallocationObservationRequirement() orelse return;
         if (current.request_id != observed.request_id or
-            current.runtime_status_fence != observed.runtime_status_fence)
+            current.disk_observation_fence != observed.disk_observation_fence)
         {
             return;
         }
@@ -7395,10 +7421,38 @@ pub const DataServer = struct {
         report: *antfly.metadata.table_manager.GroupStatusReport,
         status: runtime_status.LocalTableRuntimeStatus,
     ) void {
-        if (!report.disk_bytes_known or !runtime_status.statusRuntimeFresh(status)) return;
+        if (!status.disk_bytes_known) return;
         const requirement = self.currentReallocationObservationRequirement() orelse return;
-        if (status.causal_observation_generation <= requirement.runtime_status_fence) return;
+        if (status.disk_observation_generation <= requirement.disk_observation_fence) return;
+        // Disk usage is independently authoritative from the rest of the
+        // runtime snapshot. Promote only that observed fact so a startup or
+        // transition owner can remain exclusive while autoscaling receives
+        // its post-request size measurement.
+        report.disk_bytes = status.disk_bytes;
+        report.disk_bytes_known = true;
         report.observed_reallocation_request_id = requirement.request_id;
+    }
+
+    fn overlayRuntimeReallocationObservations(
+        self: *DataServer,
+        alloc: std.mem.Allocator,
+        reports: []antfly.metadata.table_manager.GroupStatusReport,
+        tables: []const antfly.metadata.table_manager.TableRecord,
+        ranges: []const antfly.metadata.table_manager.RangeRecord,
+    ) !void {
+        if (self.currentReallocationObservationRequirement() == null) return;
+        for (reports) |*report| {
+            const range = findRangeByGroupId(ranges, report.group_id) orelse continue;
+            const table = findTableById(tables, range.table_id) orelse continue;
+            const cached = try self.provisioned_storage.runtime_status_cache.snapshotGroupStatus(
+                alloc,
+                table.name,
+                report.group_id,
+            );
+            var status = cached orelse continue;
+            defer status.deinit(alloc);
+            self.annotateRuntimeReallocationObservation(report, status);
+        }
     }
 
     fn markRuntimeStatusDirty(
@@ -9815,6 +9869,12 @@ pub const DataServer = struct {
             self.group_membership_source,
         );
         defer freeGroupStatusesOwned(self.alloc, group_statuses);
+        try self.overlayRuntimeReallocationObservations(
+            self.alloc,
+            group_statuses,
+            snapshot.tables,
+            snapshot.ranges,
+        );
         self.annotateLocalPlacementStatus(
             group_statuses,
             snapshot.placement_intents,
@@ -10356,9 +10416,10 @@ pub const DataServer = struct {
         if (group_id == 0) return;
         const db_path = antfly.metadata.groupDbPathFromReplicaRoot(self.alloc, self.write_source.replica_root_dir, group_id) catch return;
         defer self.alloc.free(db_path);
-        if (self.runtimeStatusDiskUsageBytesBestEffort(group_id, db_path, status.*)) |disk_bytes| {
-            status.disk_bytes = disk_bytes;
+        if (self.runtimeStatusDiskUsageBytesBestEffort(group_id, db_path, status.*)) |observation| {
+            status.disk_bytes = observation.disk_bytes;
             status.disk_bytes_known = true;
+            status.disk_observation_generation = observation.observation_generation;
         }
         if (status.created_at_millis == 0) {
             if (db) |ptr| {
@@ -10372,7 +10433,7 @@ pub const DataServer = struct {
         group_id: u64,
         db_path: []const u8,
         status: runtime_status.LocalTableRuntimeStatus,
-    ) ?u64 {
+    ) ?RuntimeStatusDiskUsageObservation {
         return self.runtimeStatusDiskUsageBytesBestEffortWithScanner(group_id, db_path, status, .directory());
     }
 
@@ -10382,7 +10443,7 @@ pub const DataServer = struct {
         db_path: []const u8,
         status: runtime_status.LocalTableRuntimeStatus,
         scanner: RuntimeStatusDiskUsageScanner,
-    ) ?u64 {
+    ) ?RuntimeStatusDiskUsageObservation {
         const active = runtimeStatusHasActiveBackgroundWork(status);
         const lsm_root_generation = if (status.metadata.lsm_root_generation != 0)
             status.metadata.lsm_root_generation
@@ -10406,13 +10467,21 @@ pub const DataServer = struct {
                 status.stats.doc_count,
                 status.stats.storage_change_token,
             )) {
-                const disk_bytes = state.value_ptr.disk_bytes;
+                const observation = RuntimeStatusDiskUsageObservation{
+                    .disk_bytes = state.value_ptr.disk_bytes,
+                    .observation_generation = state.value_ptr.observation_generation,
+                };
                 self.runtime_status_disk_usage_cache_mutex.unlock();
-                return disk_bytes;
+                return observation;
             }
             self.runtime_status_disk_usage_cache_mutex.unlock();
 
             if (active and status.stats.doc_count == 0) return null;
+            // Take the generation before scanning. A request that arrives
+            // during the scan fences this generation and invalidates the
+            // cache entry, so the retry below is the first observation that
+            // may acknowledge that request.
+            const observation_generation = self.runtime_status_disk_observation_generation.fetchAdd(1, .seq_cst) +| 1;
             const disk_bytes = scanner.scan(self.alloc, db_path) catch return null;
 
             lockAtomic(&self.runtime_status_disk_usage_cache_mutex);
@@ -10429,6 +10498,7 @@ pub const DataServer = struct {
             }
             current.* = .{
                 .disk_bytes = disk_bytes,
+                .observation_generation = observation_generation,
                 .checked_at_ns = now_ns,
                 .lsm_root_generation = lsm_root_generation,
                 .storage_change_token = status.stats.storage_change_token,
@@ -10436,7 +10506,10 @@ pub const DataServer = struct {
                 .valid = true,
             };
             self.runtime_status_disk_usage_cache_mutex.unlock();
-            return disk_bytes;
+            return .{
+                .disk_bytes = disk_bytes,
+                .observation_generation = observation_generation,
+            };
         }
         return null;
     }
@@ -17686,7 +17759,6 @@ test "data runtime reallocation request refreshes group status once per request"
             .stats = .{},
         }),
     );
-    const straddled_observation_token = try server.provisioned_storage.runtime_status_cache.capturePublicationToken("docs");
     server.observeReallocationRequest(request);
     const request_generation = server.local_group_status_generation.load(.acquire);
     try std.testing.expectEqual(initial_generation + 1, request_generation);
@@ -17715,7 +17787,7 @@ test "data runtime reallocation request refreshes group status once per request"
         runtime_status.TableRuntimeSnapshotCache.PublishResult.published,
         try server.provisioned_storage.runtime_status_cache.publishGroup(straddled_publication_token, "docs", .{
             .group_id = 1,
-            .causal_observation_generation = straddled_observation_token.observation_generation,
+            .disk_observation_generation = 1,
             .disk_bytes = 100,
             .disk_bytes_known = true,
             .metadata = .{ .source = .live_writer_publish, .freshness = .fresh },
@@ -17762,6 +17834,7 @@ test "data runtime reallocation request refreshes group status once per request"
         runtime_status.TableRuntimeSnapshotCache.PublishResult.published,
         try server.provisioned_storage.runtime_status_cache.publishGroup(post_request_token, "docs", .{
             .group_id = 1,
+            .disk_observation_generation = 2,
             .disk_bytes = 200,
             .disk_bytes_known = true,
             .metadata = .{ .source = .live_writer_publish, .freshness = .fresh },

--- a/zig/pkg/antfly/src/metadata/api.zig
+++ b/zig/pkg/antfly/src/metadata/api.zig
@@ -28,6 +28,8 @@ pub const MetadataClusterIncarnation = metadata_incarnation.MetadataClusterIncar
 
 pub const MetadataStatus = struct {
     metadata_group_id: u64,
+    /// Zero means the peer predates the causal reallocation barrier.
+    reallocation_barrier_protocol_version: u16 = 0,
     metadata_incarnation: ?MetadataClusterIncarnation = null,
     metadata_epoch: u64 = 0,
     metadata_raft_local_node_id: u64 = 0,

--- a/zig/pkg/antfly/src/metadata/api.zig
+++ b/zig/pkg/antfly/src/metadata/api.zig
@@ -22,6 +22,7 @@ const raft_reconciler = @import("../raft/reconciler.zig");
 const raft_service = @import("../raft/service.zig");
 const transition_state = @import("transition_state.zig");
 const metadata_incarnation = @import("incarnation.zig");
+const reallocation_request = @import("reallocation_request.zig");
 
 pub const MetadataClusterIncarnation = metadata_incarnation.MetadataClusterIncarnation;
 
@@ -142,6 +143,7 @@ pub const ReplicationSourceActionHint = struct {
 
 pub const AdminSnapshot = struct {
     status: MetadataStatus,
+    reallocation_request: ?reallocation_request.ReallocationRequestRecord = null,
     tables: []table_manager.TableRecord,
     ranges: []table_manager.RangeRecord,
     nodes: []table_manager.NodeRecord = &.{},
@@ -526,6 +528,9 @@ pub fn captureSnapshot(alloc: std.mem.Allocator, source: anytype) !AdminSnapshot
         .merge_transitions = &.{},
     };
     errdefer freeSnapshot(alloc, source, &snapshot);
+    if (@hasDecl(SourceDeclType, "getProjectedReallocationRequest")) {
+        snapshot.reallocation_request = try source.getProjectedReallocationRequest();
+    }
     snapshot.tables = try source.listProjectedTables(alloc);
     snapshot.ranges = try source.listProjectedRanges(alloc);
     if (@hasDecl(SourceDeclType, "listProjectedNodes")) {

--- a/zig/pkg/antfly/src/metadata/http_client.zig
+++ b/zig/pkg/antfly/src/metadata/http_client.zig
@@ -78,6 +78,14 @@ pub const MetadataHttpClient = struct {
         return try self.getJsonValue(metadata_api.MetadataStatus, base_uri, routes.Routes.status);
     }
 
+    pub fn fetchStatusWithBudget(
+        self: *MetadataHttpClient,
+        base_uri: []const u8,
+        budget: RequestBudget,
+    ) !metadata_api.MetadataStatus {
+        return try self.getJsonValueWithBudget(metadata_api.MetadataStatus, base_uri, routes.Routes.status, budget);
+    }
+
     pub fn fetchHead(self: *MetadataHttpClient, base_uri: []const u8) !metadata_api.MetadataHead {
         return try self.fetchHeadWithBudget(base_uri, null);
     }
@@ -171,7 +179,19 @@ pub const MetadataHttpClient = struct {
     }
 
     pub fn triggerReallocate(self: *MetadataHttpClient, base_uri: []const u8) !void {
-        try self.postNoContent(base_uri, routes.Routes.internal_reallocate, "");
+        const uri = try join(self.alloc, base_uri, routes.Routes.internal_reallocate_v2);
+        defer self.alloc.free(uri);
+
+        var resp = try self.executeWithRetry(.{
+            .method = .POST,
+            .uri = uri,
+            .body = "",
+            .content_type = "application/json",
+            .timeout_ms = default_request_timeout_ms,
+        });
+        defer resp.deinit(self.alloc);
+        if (resp.status == 503) return error.ReallocationProtocolUpgradeRequired;
+        try mapStatus(resp.status, null, null, null);
     }
 
     pub fn upsertNode(
@@ -538,10 +558,6 @@ pub const MetadataHttpClient = struct {
         return try std.json.parseFromSliceLeaky(T, self.alloc, resp.body, .{ .ignore_unknown_fields = true });
     }
 
-    fn postNoContent(self: *MetadataHttpClient, base_uri: []const u8, path: []const u8, body: []const u8) !void {
-        try self.requestWithBody(base_uri, .POST, path, body, null, null, null);
-    }
-
     fn requestWithBody(
         self: *MetadataHttpClient,
         base_uri: []const u8,
@@ -713,6 +729,34 @@ fn nodeStatusRouteForBody(alloc: std.mem.Allocator, body: []const u8) ![]u8 {
     });
 }
 
+test "metadata http client uses the versioned reallocation route and maps upgrade gating" {
+    const UpgradeRequiredExecutor = struct {
+        fn executor(_: *@This()) http_common.RequestExecutor {
+            return .{
+                .ptr = undefined,
+                .vtable = &.{ .execute = execute },
+            };
+        }
+
+        fn execute(_: *anyopaque, alloc: std.mem.Allocator, req: http_common.HttpRequest) !http_common.HttpResponse {
+            try std.testing.expectEqual(http_common.Method.POST, req.method);
+            try std.testing.expect(std.mem.endsWith(u8, req.uri, routes.Routes.internal_reallocate_v2));
+            return .{
+                .status = 503,
+                .content_type = try alloc.dupe(u8, "text/plain"),
+                .body = try alloc.dupe(u8, "metadata voter upgrade required"),
+            };
+        }
+    };
+
+    var executor = UpgradeRequiredExecutor{};
+    var client = MetadataHttpClient.init(std.testing.allocator, executor.executor());
+    try std.testing.expectError(
+        error.ReallocationProtocolUpgradeRequired,
+        client.triggerReallocate("http://127.0.0.1:9000"),
+    );
+}
+
 test "metadata http client retries transient connection close on fetch status" {
     const FlakyExecutor = struct {
         attempts: usize = 0,
@@ -780,6 +824,7 @@ test "metadata http client retries bounded timeout on fetch status" {
     var client = MetadataHttpClient.init(std.testing.allocator, timeout_executor.executor());
     const status = try client.fetchStatus("http://127.0.0.1:9000");
     try std.testing.expectEqual(@as(u64, 88), status.metadata_group_id);
+    try std.testing.expectEqual(@as(u16, 0), status.reallocation_barrier_protocol_version);
     try std.testing.expectEqual(@as(usize, 2), timeout_executor.attempts);
 }
 

--- a/zig/pkg/antfly/src/metadata/http_routes.zig
+++ b/zig/pkg/antfly/src/metadata/http_routes.zig
@@ -27,6 +27,9 @@ pub const Routes = struct {
     pub const group_placement_prefix = "/metadata/v1/groups/";
     pub const group_placement_suffix = "/placement";
     pub const internal_reallocate = "/internal/v1/reallocate";
+    /// Versioned separately so upgraded clients cannot accidentally submit a
+    /// causal-barrier request to an older metadata leader.
+    pub const internal_reallocate_v2 = "/internal/v2/reallocate";
     pub const internal_nodes = "/internal/v1/nodes";
     pub const internal_nodes_prefix = "/internal/v1/nodes/";
     pub const internal_node_shutdown_suffix = "/shutdown";

--- a/zig/pkg/antfly/src/metadata/http_server.zig
+++ b/zig/pkg/antfly/src/metadata/http_server.zig
@@ -1216,9 +1216,12 @@ pub const MetadataHttpServer = struct {
                     };
                     return try textResponse(alloc, if (valid) 204 else 409, "");
                 }
-                if (std.mem.eql(u8, req.uri, routes.Routes.internal_reallocate)) {
+                if (std.mem.eql(u8, req.uri, routes.Routes.internal_reallocate) or
+                    std.mem.eql(u8, req.uri, routes.Routes.internal_reallocate_v2))
+                {
                     self.source.triggerReallocate() catch |err| switch (err) {
                         error.UnsupportedOperation => return try textResponse(alloc, 405, "unsupported operation"),
+                        error.ReallocationProtocolUpgradeRequired => return try textResponse(alloc, 503, "metadata voter upgrade required"),
                         else => return err,
                     };
                     return try textResponse(alloc, 202, "accepted");
@@ -1644,7 +1647,7 @@ pub const MetadataHttpServer = struct {
         if (self.source.vtable.request_node_shutdown) |_| {
             try self.source.requestNodeShutdown(node_id);
             self.source.triggerReallocate() catch |err| switch (err) {
-                error.UnsupportedOperation => {},
+                error.UnsupportedOperation, error.ReallocationProtocolUpgradeRequired => {},
                 else => return err,
             };
             return;
@@ -1702,7 +1705,7 @@ pub const MetadataHttpServer = struct {
 
         if (changed) {
             self.source.triggerReallocate() catch |err| switch (err) {
-                error.UnsupportedOperation => {},
+                error.UnsupportedOperation, error.ReallocationProtocolUpgradeRequired => {},
                 else => return err,
             };
         }
@@ -1712,7 +1715,7 @@ pub const MetadataHttpServer = struct {
         if (self.source.vtable.cancel_node_shutdown) |_| {
             try self.source.cancelNodeShutdown(node_id);
             self.source.triggerReallocate() catch |err| switch (err) {
-                error.UnsupportedOperation => {},
+                error.UnsupportedOperation, error.ReallocationProtocolUpgradeRequired => {},
                 else => return err,
             };
             return;
@@ -1754,7 +1757,7 @@ pub const MetadataHttpServer = struct {
 
         if (changed) {
             self.source.triggerReallocate() catch |err| switch (err) {
-                error.UnsupportedOperation => {},
+                error.UnsupportedOperation, error.ReallocationProtocolUpgradeRequired => {},
                 else => return err,
             };
         }
@@ -1768,7 +1771,7 @@ pub const MetadataHttpServer = struct {
             if (finalizeWouldDeleteActiveNodeOrStore(&snapshot, node_id)) return error.ActiveNodeFinalizeRejected;
             try self.source.finalizeNodeShutdown(node_id);
             self.source.triggerReallocate() catch |err| switch (err) {
-                error.UnsupportedOperation => {},
+                error.UnsupportedOperation, error.ReallocationProtocolUpgradeRequired => {},
                 else => return err,
             };
             return;
@@ -3019,6 +3022,47 @@ fn freeStoreStatusReport(alloc: std.mem.Allocator, report: metadata_table_manage
     alloc.free(report.health_class);
     metadata_table_manager.freeGroupStatuses(alloc, report.group_statuses);
     metadata_table_manager.freeRuntimeGroupStatusReports(alloc, report.runtime_statuses);
+}
+
+test "metadata http server reports reallocation protocol upgrade gating" {
+    const UpgradeGatedSource = struct {
+        fn iface(_: *@This()) AdminSource {
+            return .{
+                .ptr = undefined,
+                .vtable = &.{
+                    .status = status,
+                    .admin_snapshot = adminSnapshot,
+                    .free_admin_snapshot = freeAdminSnapshot,
+                    .trigger_reallocate = triggerReallocate,
+                },
+            };
+        }
+
+        fn status(_: *anyopaque) !metadata_api.MetadataStatus {
+            return error.TestUnexpectedResult;
+        }
+
+        fn adminSnapshot(_: *anyopaque) !metadata_api.AdminSnapshot {
+            return error.TestUnexpectedResult;
+        }
+
+        fn freeAdminSnapshot(_: *anyopaque, _: *metadata_api.AdminSnapshot) void {}
+
+        fn triggerReallocate(_: *anyopaque) !void {
+            return error.ReallocationProtocolUpgradeRequired;
+        }
+    };
+
+    var source = UpgradeGatedSource{};
+    var server = MetadataHttpServer.init(std.testing.allocator, .{}, source.iface());
+    var response = try server.handle(.{
+        .method = .POST,
+        .uri = routes.Routes.internal_reallocate_v2,
+        .body = "",
+    });
+    defer response.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(u16, 503), response.status);
+    try std.testing.expectEqualStrings("metadata voter upgrade required", response.body);
 }
 
 test "metadata http server serves status and filtered admin routes" {

--- a/zig/pkg/antfly/src/metadata/http_server.zig
+++ b/zig/pkg/antfly/src/metadata/http_server.zig
@@ -2123,6 +2123,7 @@ const ParsedGroupStatus = struct {
     empty: ?bool = null,
     created_at_millis: ?u64 = null,
     updated_at_millis: ?u64 = null,
+    observed_reallocation_request_id: ?u128 = null,
     local_leader: ?bool = null,
     local_voter: ?bool = null,
     voter_count: ?u16 = null,
@@ -2367,6 +2368,7 @@ fn cloneParsedGroupStatuses(
             .empty = parsed.empty orelse true,
             .created_at_millis = parsed.created_at_millis orelse 0,
             .updated_at_millis = parsed.updated_at_millis orelse 0,
+            .observed_reallocation_request_id = parsed.observed_reallocation_request_id orelse 0,
             .local_leader = parsed.local_leader orelse false,
             .local_voter = parsed.local_voter orelse false,
             .voter_count = parsed.voter_count orelse 0,
@@ -4215,6 +4217,12 @@ test "metadata http server accepts internal reallocate and split merge routes" {
             const self: *@This() = @ptrCast(@alignCast(ptr));
             try std.testing.expectEqual(@as(u64, 7), report.store_id);
             try std.testing.expectEqualStrings("healthy", report.health_class);
+            try std.testing.expectEqual(@as(usize, 1), report.group_statuses.len);
+            try std.testing.expectEqual(@as(u64, 9), report.group_statuses[0].group_id);
+            try std.testing.expectEqual(
+                @as(u128, 0x1234_5678_9abc_def0_1234_5678_9abc_def0),
+                report.group_statuses[0].observed_reallocation_request_id,
+            );
             self.store_status_count += 1;
         }
 
@@ -4317,7 +4325,7 @@ test "metadata http server accepts internal reallocate and split merge routes" {
     var store_status = try server.handle(.{
         .method = .POST,
         .uri = "/internal/v1/nodes/7/status",
-        .body = "{\"store_id\":7,\"health_class\":\"healthy\"}",
+        .body = "{\"store_id\":7,\"health_class\":\"healthy\",\"group_statuses\":[{\"group_id\":9,\"observed_reallocation_request_id\":24197857203266734864793317670504947440}]}",
         .content_type = "application/json",
     });
     defer store_status.deinit(std.testing.allocator);

--- a/zig/pkg/antfly/src/metadata/http_server.zig
+++ b/zig/pkg/antfly/src/metadata/http_server.zig
@@ -29,6 +29,7 @@ const backups_api = @import("../api/backups.zig");
 const http_route_helpers = @import("../api/http_route_helpers.zig");
 const indexes_api = @import("../api/indexes.zig");
 const tables_api = @import("../api/tables.zig");
+const platform_clock = @import("antfly_platform").clock;
 const platform_time = @import("antfly_platform").time;
 const routes = @import("http_routes.zig");
 const service = @import("service.zig");
@@ -634,7 +635,7 @@ pub const AdminSource = struct {
 
     fn metadataServiceTriggerReallocate(ptr: *anyopaque) !void {
         const svc: *service.MetadataService = @ptrCast(@alignCast(ptr));
-        try svc.requestReallocation(@intCast(@divTrunc(platform_time.monotonicNs(), std.time.ns_per_ms)));
+        try svc.requestReallocation(platform_clock.Clock.real().nowRealtimeMs());
         try flushMetadataServiceMutation(svc);
     }
 
@@ -963,7 +964,7 @@ pub const AdminSource = struct {
 
     fn metadataHttpServiceTriggerReallocate(ptr: *anyopaque) !void {
         const svc: *service.MetadataHttpService = @ptrCast(@alignCast(ptr));
-        try svc.requestReallocation(@intCast(@divTrunc(platform_time.monotonicNs(), std.time.ns_per_ms)));
+        try svc.requestReallocation(platform_clock.Clock.real().nowRealtimeMs());
         try flushMetadataHttpServiceMutation(svc);
     }
 

--- a/zig/pkg/antfly/src/metadata/reallocation_request.zig
+++ b/zig/pkg/antfly/src/metadata/reallocation_request.zig
@@ -14,6 +14,11 @@
 
 const std = @import("std");
 
+/// Every metadata voter must advertise at least this version before a forced
+/// reallocation request can be admitted. Older reconcilers do not understand
+/// the causal acknowledgement barrier and may clear the request prematurely.
+pub const barrier_protocol_version: u16 = 1;
+
 pub const ReallocationRequestRecord = struct {
     request_id: u128,
     requested_at_ms: u64,

--- a/zig/pkg/antfly/src/metadata/reallocation_request.zig
+++ b/zig/pkg/antfly/src/metadata/reallocation_request.zig
@@ -13,15 +13,25 @@
 // limitations.
 
 const std = @import("std");
+const metadata_incarnation = @import("incarnation.zig");
 
 /// Every metadata voter must advertise at least this version before a forced
 /// reallocation request can be admitted. Older reconcilers do not understand
 /// the causal acknowledgement barrier and may clear the request prematurely.
 pub const barrier_protocol_version: u16 = 1;
+pub const MembershipFingerprint = [std.crypto.hash.sha2.Sha256.digest_length]u8;
+pub const zero_membership_fingerprint = [_]u8{0} ** std.crypto.hash.sha2.Sha256.digest_length;
 
 pub const ReallocationRequestRecord = struct {
     request_id: u128,
     requested_at_ms: u64,
+    /// A zero version denotes a request created before the durable membership
+    /// barrier. Such a request remains valid, but metadata membership changes
+    /// must fail closed until it is consumed.
+    barrier_protocol_version: u16 = 0,
+    metadata_incarnation: ?metadata_incarnation.MetadataClusterIncarnation = null,
+    protected_metadata_member_count: u32 = 0,
+    protected_metadata_membership_fingerprint: MembershipFingerprint = zero_membership_fingerprint,
 };
 
 pub fn generateRequestId(io: std.Io) !u128 {
@@ -31,5 +41,58 @@ pub fn generateRequestId(io: std.Io) !u128 {
 }
 
 pub fn isValid(record: ReallocationRequestRecord) bool {
-    return record.request_id != 0;
+    if (record.request_id == 0) return false;
+    if (record.barrier_protocol_version == 0) {
+        return record.metadata_incarnation == null and
+            record.protected_metadata_member_count == 0 and
+            std.mem.eql(u8, &record.protected_metadata_membership_fingerprint, &zero_membership_fingerprint);
+    }
+    const incarnation = record.metadata_incarnation orelse return false;
+    return metadata_incarnation.isValid(incarnation) and
+        record.protected_metadata_member_count != 0 and
+        !std.mem.eql(u8, &record.protected_metadata_membership_fingerprint, &zero_membership_fingerprint);
+}
+
+/// Hashes one sorted, duplicate-free metadata membership. Callers construct
+/// the canonical set before invoking this function so the digest is stable
+/// across voters, learners, restarts, and configuration ordering.
+pub fn membershipFingerprint(sorted_node_ids: []const u64) MembershipFingerprint {
+    var hasher = std.crypto.hash.sha2.Sha256.init(.{});
+    hasher.update("antfly-metadata-reallocation-membership-v1");
+    var count_bytes: [8]u8 = undefined;
+    std.mem.writeInt(u64, &count_bytes, sorted_node_ids.len, .little);
+    hasher.update(&count_bytes);
+    for (sorted_node_ids) |node_id| {
+        var node_bytes: [8]u8 = undefined;
+        std.mem.writeInt(u64, &node_bytes, node_id, .little);
+        hasher.update(&node_bytes);
+    }
+    var digest: MembershipFingerprint = undefined;
+    hasher.final(&digest);
+    return digest;
+}
+
+pub fn protectsMembership(record: ReallocationRequestRecord, sorted_node_ids: []const u64) bool {
+    if (record.barrier_protocol_version != barrier_protocol_version) return false;
+    const member_count = std.math.cast(u32, sorted_node_ids.len) orelse return false;
+    if (record.protected_metadata_member_count != member_count) return false;
+    const fingerprint = membershipFingerprint(sorted_node_ids);
+    return std.mem.eql(u8, &record.protected_metadata_membership_fingerprint, &fingerprint);
+}
+
+test "reallocation request membership contract is canonical and fail closed for legacy records" {
+    const incarnation: metadata_incarnation.MetadataClusterIncarnation = "0123456789abcdef0123456789abcdef".*;
+    const fingerprint = membershipFingerprint(&.{ 1, 2, 3 });
+    const record: ReallocationRequestRecord = .{
+        .request_id = 7,
+        .requested_at_ms = 11,
+        .barrier_protocol_version = barrier_protocol_version,
+        .metadata_incarnation = incarnation,
+        .protected_metadata_member_count = 3,
+        .protected_metadata_membership_fingerprint = fingerprint,
+    };
+    try std.testing.expect(isValid(record));
+    try std.testing.expect(protectsMembership(record, &.{ 1, 2, 3 }));
+    try std.testing.expect(!protectsMembership(record, &.{ 1, 2, 4 }));
+    try std.testing.expect(!protectsMembership(.{ .request_id = 7, .requested_at_ms = 11 }, &.{ 1, 2, 3 }));
 }

--- a/zig/pkg/antfly/src/metadata/reconciler.zig
+++ b/zig/pkg/antfly/src/metadata/reconciler.zig
@@ -1380,7 +1380,6 @@ const StoreEvidenceIndex = struct {
         status: ?*const table_manager.GroupStatusReport = null,
         status_ambiguous: bool = false,
         runtime_reported: bool = false,
-        latest_runtime_updated_at_millis: u64 = 0,
     };
 
     const PlacementTopology = struct {
@@ -1433,10 +1432,6 @@ const StoreEvidenceIndex = struct {
                 const entry = try self.reports_by_store_group.getOrPut(alloc, placementStoreKey(status.group_id, store.store_id));
                 if (!entry.found_existing) entry.value_ptr.* = .{};
                 entry.value_ptr.runtime_reported = true;
-                entry.value_ptr.latest_runtime_updated_at_millis = @max(
-                    entry.value_ptr.latest_runtime_updated_at_millis,
-                    @divTrunc(status.updated_at_ns, std.time.ns_per_ms),
-                );
             }
         }
         for (current.placement_intents) |*intent| {

--- a/zig/pkg/antfly/src/metadata/reconciler.zig
+++ b/zig/pkg/antfly/src/metadata/reconciler.zig
@@ -876,6 +876,13 @@ pub const Reconciler = struct {
                         if (require_conclusive_scan) planning_conclusive = false;
                         continue;
                     }
+                    if (require_conclusive_scan and
+                        (!evidence.hasFullHealthyPlacementObservedFor(current, left.group_id, current.reallocation_request.?) or
+                            !evidence.hasFullHealthyPlacementObservedFor(current, right.group_id, current.reallocation_request.?)))
+                    {
+                        planning_conclusive = false;
+                        continue;
+                    }
                     if (!groupStatusReadyForAutomaticPlanning(left_status) or !groupStatusReadyForAutomaticPlanning(right_status)) {
                         if (require_conclusive_scan) planning_conclusive = false;
                         continue;
@@ -943,6 +950,12 @@ pub const Reconciler = struct {
                 }
                 if (!groupStatusFresh(self.config, status, now_realtime_ms)) {
                     if (require_conclusive_scan) planning_conclusive = false;
+                    continue;
+                }
+                if (require_conclusive_scan and
+                    !evidence.hasFullHealthyPlacementObservedFor(current, range.group_id, current.reallocation_request.?))
+                {
+                    planning_conclusive = false;
                     continue;
                 }
                 if (!groupStatusReadyForAutomaticPlanning(status)) {
@@ -1367,6 +1380,7 @@ const StoreEvidenceIndex = struct {
         status: ?*const table_manager.GroupStatusReport = null,
         status_ambiguous: bool = false,
         runtime_reported: bool = false,
+        latest_runtime_updated_at_millis: u64 = 0,
     };
 
     const PlacementTopology = struct {
@@ -1419,6 +1433,10 @@ const StoreEvidenceIndex = struct {
                 const entry = try self.reports_by_store_group.getOrPut(alloc, placementStoreKey(status.group_id, store.store_id));
                 if (!entry.found_existing) entry.value_ptr.* = .{};
                 entry.value_ptr.runtime_reported = true;
+                entry.value_ptr.latest_runtime_updated_at_millis = @max(
+                    entry.value_ptr.latest_runtime_updated_at_millis,
+                    @divTrunc(status.updated_at_ns, std.time.ns_per_ms),
+                );
             }
         }
         for (current.placement_intents) |*intent| {
@@ -1548,6 +1566,42 @@ const StoreEvidenceIndex = struct {
                 &status.voter_set_fingerprint,
                 &topology.voter_set_fingerprint,
             );
+    }
+
+    /// A forced scan may only consume its level-trigger after every placed
+    /// voter has published observations at or after the request. Without this
+    /// barrier, a reconcile snapshot can acknowledge an under-threshold view
+    /// while a newer oversized report is still being projected, permanently
+    /// losing the operator's one-shot request when shard allocation is disabled.
+    fn hasFullHealthyPlacementObservedFor(
+        self: *const StoreEvidenceIndex,
+        current: CurrentMetadataState,
+        group_id: u64,
+        request: reallocation_request.ReallocationRequestRecord,
+    ) bool {
+        var saw_placement = false;
+        for (current.placement_intents) |intent| {
+            if (intent.record.group_id != group_id) continue;
+            saw_placement = true;
+            const store = self.storeForIntent(intent) orelse return false;
+            if (!healthyStore(store.*)) return false;
+            const evidence = self.reports_by_store_group.get(
+                placementStoreKey(group_id, store.store_id),
+            ) orelse return false;
+            if (evidence.status_ambiguous) return false;
+            const status = evidence.status orelse return false;
+            if (status.observed_reallocation_request_id != 0) {
+                if (status.observed_reallocation_request_id != request.request_id) return false;
+                continue;
+            }
+            // Rolling-upgrade compatibility for reporters that do not yet
+            // carry the causal request ID. New reporters never rely on clocks.
+            if (status.updated_at_millis < request.requested_at_ms) return false;
+            if (evidence.runtime_reported and
+                evidence.latest_runtime_updated_at_millis < request.requested_at_ms)
+                return false;
+        }
+        return saw_placement;
     }
 
     fn relocationSource(self: *const StoreEvidenceIndex, group_id: u64) ?raft_reconciler.PlacementIntent {
@@ -6369,6 +6423,7 @@ test "metadata reconciler plans an automatic split from fresh group status" {
                     .disk_bytes_known = true,
                     .empty = false,
                     .updated_at_millis = now_ms,
+                    .observed_reallocation_request_id = 1,
                     .local_leader = true,
                     .local_voter = true,
                     .voter_count = 1,
@@ -6500,6 +6555,7 @@ test "metadata reconciler waits for placement convergence before automatic split
         .disk_bytes = 200,
         .empty = false,
         .updated_at_millis = now_ms,
+        .observed_reallocation_request_id = 1,
         .local_leader = true,
     }})[0..]);
     const stores = [_]table_manager.StoreRecord{.{
@@ -8529,6 +8585,7 @@ test "metadata reconciler respects disable shard alloc unless reallocation is re
         .disk_bytes_known = true,
         .empty = false,
         .updated_at_millis = now_ms,
+        .observed_reallocation_request_id = 2,
         .local_leader = true,
         .local_voter = true,
         .voter_count = 1,
@@ -8547,6 +8604,59 @@ test "metadata reconciler respects disable shard alloc unless reallocation is re
     defer inconclusive_plan.deinit(std.testing.allocator);
     try std.testing.expectEqual(@as(usize, 0), inconclusive_plan.split_admissions.len);
     try std.testing.expect(inconclusive_plan.clear_reallocation_request == null);
+
+    // A request can become visible to the reconcile loop before a store
+    // report that another metadata replica already exposed. Do not consume
+    // that request (or act on its stale size view) until every placed voter
+    // has published a post-request observation.
+    var stale_observation_plan = try reconciler.computePlan(&manager, &.{1}, &candidates, .{
+        .tables = tables,
+        .ranges = ranges,
+        .placement_intents = &placements,
+        .stores = &stores,
+        .reallocation_request = .{ .request_id = 2, .requested_at_ms = now_ms + 1 },
+    });
+    defer stale_observation_plan.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 0), stale_observation_plan.split_admissions.len);
+    try std.testing.expect(stale_observation_plan.clear_reallocation_request == null);
+
+    const under_threshold_reports = [_]table_manager.GroupStatusReport{.{
+        .group_id = 4201,
+        .doc_count = 50,
+        .disk_bytes = 50,
+        .disk_bytes_known = true,
+        .empty = false,
+        .updated_at_millis = now_ms,
+        .local_leader = true,
+        .local_voter = true,
+        .voter_count = 1,
+        .voter_set_known = true,
+        .voter_set_fingerprint = voter_set_fingerprint,
+    }};
+    var under_threshold_stores = stores;
+    under_threshold_stores[0].group_statuses = @constCast(under_threshold_reports[0..]);
+    var stale_under_threshold_plan = try reconciler.computePlan(&manager, &.{1}, &candidates, .{
+        .tables = tables,
+        .ranges = ranges,
+        .placement_intents = &placements,
+        .stores = &under_threshold_stores,
+        .reallocation_request = .{ .request_id = 3, .requested_at_ms = now_ms + 1 },
+    });
+    defer stale_under_threshold_plan.deinit(std.testing.allocator);
+    try std.testing.expect(stale_under_threshold_plan.clear_reallocation_request == null);
+
+    var fresh_under_threshold_reports = under_threshold_reports;
+    fresh_under_threshold_reports[0].observed_reallocation_request_id = 3;
+    under_threshold_stores[0].group_statuses = @constCast(fresh_under_threshold_reports[0..]);
+    var fresh_under_threshold_plan = try reconciler.computePlan(&manager, &.{1}, &candidates, .{
+        .tables = tables,
+        .ranges = ranges,
+        .placement_intents = &placements,
+        .stores = &under_threshold_stores,
+        .reallocation_request = .{ .request_id = 3, .requested_at_ms = now_ms + 1 },
+    });
+    defer fresh_under_threshold_plan.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(?u128, 3), fresh_under_threshold_plan.clear_reallocation_request);
 
     var forced_plan = try reconciler.computePlan(&manager, &.{1}, &candidates, .{
         .tables = tables,

--- a/zig/pkg/antfly/src/metadata/reconciler.zig
+++ b/zig/pkg/antfly/src/metadata/reconciler.zig
@@ -1590,16 +1590,12 @@ const StoreEvidenceIndex = struct {
             ) orelse return false;
             if (evidence.status_ambiguous) return false;
             const status = evidence.status orelse return false;
-            if (status.observed_reallocation_request_id != 0) {
-                if (status.observed_reallocation_request_id != request.request_id) return false;
-                continue;
-            }
-            // Rolling-upgrade compatibility for reporters that do not yet
-            // carry the causal request ID. New reporters never rely on clocks.
-            if (status.updated_at_millis < request.requested_at_ms) return false;
-            if (evidence.runtime_reported and
-                evidence.latest_runtime_updated_at_millis < request.requested_at_ms)
-                return false;
+            // Legacy reporters fail closed. Their timestamps may use a
+            // different clock domain from the request, and wall clocks across
+            // hosts are not a causal ordering. The durable request remains
+            // pending through a rolling upgrade until every placed voter can
+            // echo the exact request ID.
+            if (status.observed_reallocation_request_id != request.request_id) return false;
         }
         return saw_placement;
     }
@@ -8658,11 +8654,29 @@ test "metadata reconciler respects disable shard alloc unless reallocation is re
     defer fresh_under_threshold_plan.deinit(std.testing.allocator);
     try std.testing.expectEqual(@as(?u128, 3), fresh_under_threshold_plan.clear_reallocation_request);
 
-    var forced_plan = try reconciler.computePlan(&manager, &.{1}, &candidates, .{
+    // Legacy reports used wall-clock status timestamps while origin/main
+    // stamped requests with monotonic uptime. Even an apparently much newer
+    // timestamp cannot prove that the reporter observed this request.
+    var legacy_timestamp_plan = try reconciler.computePlan(&manager, &.{1}, &candidates, .{
         .tables = tables,
         .ranges = ranges,
         .placement_intents = &placements,
         .stores = &stores,
+        .reallocation_request = .{ .request_id = 1, .requested_at_ms = 1 },
+    });
+    defer legacy_timestamp_plan.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 0), legacy_timestamp_plan.split_admissions.len);
+    try std.testing.expect(legacy_timestamp_plan.clear_reallocation_request == null);
+
+    var acknowledged_reports = [_]table_manager.GroupStatusReport{stores[0].group_statuses[0]};
+    acknowledged_reports[0].observed_reallocation_request_id = 1;
+    var acknowledged_stores = stores;
+    acknowledged_stores[0].group_statuses = @constCast(acknowledged_reports[0..]);
+    var forced_plan = try reconciler.computePlan(&manager, &.{1}, &candidates, .{
+        .tables = tables,
+        .ranges = ranges,
+        .placement_intents = &placements,
+        .stores = &acknowledged_stores,
         .reallocation_request = .{ .request_id = 1, .requested_at_ms = 1 },
     });
     defer forced_plan.deinit(std.testing.allocator);

--- a/zig/pkg/antfly/src/metadata/runtime.zig
+++ b/zig/pkg/antfly/src/metadata/runtime.zig
@@ -402,7 +402,6 @@ pub const Server = struct {
     raft_storage_diagnostics: MetadataRaftStorageDiagnosticsCache = .{},
 
     pub fn init(alloc: std.mem.Allocator, cfg: ServerConfig) !Server {
-        try validateMetadataClusterOrchestrationPeers(cfg.metadata_cluster_peers, cfg.local_node_id);
         var result: Server = undefined;
         result.alloc = alloc;
         result.raft_storage_diagnostics = .{};
@@ -1304,24 +1303,21 @@ fn reallocationProtocolPeersFromClusterPeers(
     alloc: std.mem.Allocator,
     cluster_peers: []const MetadataClusterPeer,
 ) ![]antfly.metadata_service.ReallocationProtocolPeer {
-    var count: usize = 0;
-    for (cluster_peers) |peer| count += @intFromBool(peer.orchestration_url != null);
-    if (count == 0) return &.{};
-    const peers = try alloc.alloc(antfly.metadata_service.ReallocationProtocolPeer, count);
+    if (cluster_peers.len == 0) return &.{};
+    const peers = try alloc.alloc(antfly.metadata_service.ReallocationProtocolPeer, cluster_peers.len);
     var initialized: usize = 0;
     errdefer {
-        for (peers[0..initialized]) |peer| alloc.free(peer.orchestration_url);
+        for (peers[0..initialized]) |peer| {
+            if (peer.orchestration_url) |url| alloc.free(url);
+        }
         alloc.free(peers);
     }
-    var index: usize = 0;
-    for (cluster_peers) |peer| {
-        const orchestration_url = peer.orchestration_url orelse continue;
+    for (cluster_peers, 0..) |peer, index| {
         peers[index] = .{
             .node_id = peer.node_id,
-            .orchestration_url = try alloc.dupe(u8, orchestration_url),
+            .orchestration_url = if (peer.orchestration_url) |url| try alloc.dupe(u8, url) else null,
         };
         initialized += 1;
-        index += 1;
     }
     return peers;
 }
@@ -1330,20 +1326,10 @@ fn freeReallocationProtocolPeers(
     alloc: std.mem.Allocator,
     peers: []antfly.metadata_service.ReallocationProtocolPeer,
 ) void {
-    for (peers) |peer| alloc.free(peer.orchestration_url);
-    if (peers.len > 0) alloc.free(peers);
-}
-
-fn validateMetadataClusterOrchestrationPeers(
-    cluster_peers: []const MetadataClusterPeer,
-    local_node_id: u64,
-) !void {
-    if (cluster_peers.len <= 1) return;
-    for (cluster_peers) |peer| {
-        if (peer.node_id == local_node_id) continue;
-        const orchestration_url = peer.orchestration_url orelse return error.MissingMetadataOrchestrationPeer;
-        if (orchestration_url.len == 0) return error.MissingMetadataOrchestrationPeer;
+    for (peers) |peer| {
+        if (peer.orchestration_url) |url| alloc.free(url);
     }
+    if (peers.len > 0) alloc.free(peers);
 }
 
 pub fn metadataClusterPeersFromConfig(
@@ -1660,15 +1646,11 @@ test "metadata runtime cluster json carries raft and orchestration endpoints" {
 
     const protocol_peers = try reallocationProtocolPeersFromClusterPeers(alloc, peers);
     defer freeReallocationProtocolPeers(alloc, protocol_peers);
-    try std.testing.expectEqual(@as(usize, 1), protocol_peers.len);
+    try std.testing.expectEqual(@as(usize, 2), protocol_peers.len);
     try std.testing.expectEqual(@as(u64, 1), protocol_peers[0].node_id);
-    try std.testing.expectEqualStrings("http://127.0.0.1:12377", protocol_peers[0].orchestration_url);
-
-    try std.testing.expectError(
-        error.MissingMetadataOrchestrationPeer,
-        validateMetadataClusterOrchestrationPeers(peers, 1),
-    );
-    try validateMetadataClusterOrchestrationPeers(peers[0..1], 1);
+    try std.testing.expectEqualStrings("http://127.0.0.1:12377", protocol_peers[0].orchestration_url.?);
+    try std.testing.expectEqual(@as(u64, 2), protocol_peers[1].node_id);
+    try std.testing.expect(protocol_peers[1].orchestration_url == null);
 
     var cfg = try antfly.common.config.Config.parseFromSlice(alloc,
         \\{
@@ -1684,7 +1666,6 @@ test "metadata runtime cluster json carries raft and orchestration endpoints" {
     const legacy_cluster_json = "{\"1\":\"http://127.0.0.1:9017\",\"2\":\"http://127.0.0.1:9018\"}";
     const merged_peers = try resolveMetadataClusterPeers(alloc, legacy_cluster_json, &cfg);
     defer freeMetadataClusterPeers(alloc, merged_peers);
-    try validateMetadataClusterOrchestrationPeers(merged_peers, 1);
     for (merged_peers) |peer| {
         try std.testing.expectEqualStrings(
             if (peer.node_id == 1) "http://127.0.0.1:12377" else "http://127.0.0.1:12378",
@@ -1802,6 +1783,35 @@ test "metadata runtime server uses wal replica state backend by default" {
 
     try std.testing.expect(server.server.svc.raft.host.owned_wal_replica_provider != null);
     try std.testing.expect(server.server.svc.raft.host.owned_file_replica_provider == null);
+}
+
+test "metadata runtime legacy multi-node cluster config does not require orchestration endpoints at startup" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const replica_root = try std.fmt.allocPrint(std.testing.allocator, ".zig-cache/tmp/{s}/metadata-runtime-legacy-cluster/replicas", .{tmp.sub_path});
+    defer std.testing.allocator.free(replica_root);
+    const replica_catalog_path = try std.fmt.allocPrint(std.testing.allocator, ".zig-cache/tmp/{s}/metadata-runtime-legacy-cluster/catalog.txt", .{tmp.sub_path});
+    defer std.testing.allocator.free(replica_catalog_path);
+    const snapshot_root = try std.fmt.allocPrint(std.testing.allocator, ".zig-cache/tmp/{s}/metadata-runtime-legacy-cluster/snapshots", .{tmp.sub_path});
+    defer std.testing.allocator.free(snapshot_root);
+    const peers = [_]MetadataClusterPeer{
+        .{ .node_id = 1, .raft_url = "http://127.0.0.1:19017" },
+        .{ .node_id = 2, .raft_url = "http://127.0.0.1:19018" },
+    };
+
+    var server = try Server.init(std.testing.allocator, .{
+        .local_node_id = 1,
+        .metadata_cluster_peers = &peers,
+        .replica_root_dir = replica_root,
+        .replica_catalog_path = replica_catalog_path,
+        .snapshot_root_dir = snapshot_root,
+    });
+    defer server.deinit();
+
+    try std.testing.expectEqual(@as(usize, 2), server.reallocation_protocol_peers.len);
+    try std.testing.expect(server.reallocation_protocol_peers[0].orchestration_url == null);
+    try std.testing.expect(server.reallocation_protocol_peers[1].orchestration_url == null);
 }
 
 test "metadata runtime enables bounded raft storage compaction for multi-node groups" {

--- a/zig/pkg/antfly/src/metadata/runtime.zig
+++ b/zig/pkg/antfly/src/metadata/runtime.zig
@@ -318,6 +318,7 @@ pub const ServerConfig = struct {
     local_node_id: u64 = 1,
     metadata_group_id: u64 = group_ids.main_metadata_group_id,
     metadata_cluster_peers: []const MetadataClusterPeer = &.{},
+    reallocation_protocol_peers: []const antfly.metadata_service.ReallocationProtocolPeer = &.{},
     replica_root_dir: []const u8,
     replica_catalog_path: []const u8,
     snapshot_root_dir: []const u8,
@@ -430,6 +431,7 @@ pub const Server = struct {
             .observe_local_replica_root = cfg.observe_local_replica_root,
             .backend_runtime = cfg.backend_runtime,
             .secret_store = cfg.secret_store,
+            .reallocation_protocol_peers = cfg.reallocation_protocol_peers,
         };
         result.server = try antfly.metadata_server.MetadataServer.init(alloc, .{
             .http = .{
@@ -872,6 +874,8 @@ pub fn runFromIterator(
     const metadata_group_id = group_ids.main_metadata_group_id;
     const cluster_peers = try resolveMetadataClusterPeers(alloc, cli.cluster_json, if (loaded_config) |*cfg| cfg else null);
     defer freeMetadataClusterPeers(alloc, cluster_peers);
+    const reallocation_protocol_peers = try reallocationProtocolPeersFromConfig(alloc, if (loaded_config) |*cfg| cfg else null);
+    defer if (reallocation_protocol_peers.len > 0) alloc.free(reallocation_protocol_peers);
     const listener = resolveRaftListener(cli, if (loaded_config) |*cfg| cfg else null);
     const admin_listener = resolveAdminListener(cli, if (loaded_config) |*cfg| cfg else null, local_node_id, listener.bind_host);
 
@@ -879,6 +883,7 @@ pub fn runFromIterator(
         .local_node_id = local_node_id,
         .metadata_group_id = metadata_group_id,
         .metadata_cluster_peers = cluster_peers,
+        .reallocation_protocol_peers = reallocation_protocol_peers,
         .replica_root_dir = resolved.replica_root_dir,
         .replica_catalog_path = resolved.replica_catalog_path,
         .snapshot_root_dir = resolved.snapshot_root_dir,
@@ -1280,6 +1285,25 @@ fn resolveMetadataClusterPeers(
     if (cluster_json) |raw| return try parseMetadataClusterJson(alloc, raw);
     if (cfg) |loaded| return try metadataClusterPeersFromConfig(alloc, loaded);
     return &.{};
+}
+
+fn reallocationProtocolPeersFromConfig(
+    alloc: std.mem.Allocator,
+    cfg: ?*const antfly.common.config.Config,
+) ![]antfly.metadata_service.ReallocationProtocolPeer {
+    const loaded = cfg orelse return &.{};
+    if (loaded.metadata.orchestration_urls.len == 0) return &.{};
+    const peers = try alloc.alloc(
+        antfly.metadata_service.ReallocationProtocolPeer,
+        loaded.metadata.orchestration_urls.len,
+    );
+    for (loaded.metadata.orchestration_urls, 0..) |entry, index| {
+        peers[index] = .{
+            .node_id = entry.node_id,
+            .orchestration_url = entry.url,
+        };
+    }
+    return peers;
 }
 
 pub fn metadataClusterPeersFromConfig(

--- a/zig/pkg/antfly/src/metadata/runtime.zig
+++ b/zig/pkg/antfly/src/metadata/runtime.zig
@@ -312,13 +312,13 @@ pub const ListenerConfig = struct {
 pub const MetadataClusterPeer = struct {
     node_id: u64,
     raft_url: []const u8,
+    orchestration_url: ?[]const u8 = null,
 };
 
 pub const ServerConfig = struct {
     local_node_id: u64 = 1,
     metadata_group_id: u64 = group_ids.main_metadata_group_id,
     metadata_cluster_peers: []const MetadataClusterPeer = &.{},
-    reallocation_protocol_peers: []const antfly.metadata_service.ReallocationProtocolPeer = &.{},
     replica_root_dir: []const u8,
     replica_catalog_path: []const u8,
     snapshot_root_dir: []const u8,
@@ -398,9 +398,11 @@ pub const Server = struct {
     snapshot_root_dir: []u8,
     bind_host: []u8,
     admin_bind_host: []u8,
+    reallocation_protocol_peers: []antfly.metadata_service.ReallocationProtocolPeer,
     raft_storage_diagnostics: MetadataRaftStorageDiagnosticsCache = .{},
 
     pub fn init(alloc: std.mem.Allocator, cfg: ServerConfig) !Server {
+        try validateMetadataClusterOrchestrationPeers(cfg.metadata_cluster_peers, cfg.local_node_id);
         var result: Server = undefined;
         result.alloc = alloc;
         result.raft_storage_diagnostics = .{};
@@ -427,11 +429,13 @@ pub const Server = struct {
         errdefer alloc.free(result.bind_host);
         result.admin_bind_host = try alloc.dupe(u8, cfg.admin_bind_host);
         errdefer alloc.free(result.admin_bind_host);
+        result.reallocation_protocol_peers = try reallocationProtocolPeersFromClusterPeers(alloc, cfg.metadata_cluster_peers);
+        errdefer freeReallocationProtocolPeers(alloc, result.reallocation_protocol_peers);
         const service_cfg = antfly.metadata_service.MetadataServiceConfig{
             .observe_local_replica_root = cfg.observe_local_replica_root,
             .backend_runtime = cfg.backend_runtime,
             .secret_store = cfg.secret_store,
-            .reallocation_protocol_peers = cfg.reallocation_protocol_peers,
+            .reallocation_protocol_peers = result.reallocation_protocol_peers,
         };
         result.server = try antfly.metadata_server.MetadataServer.init(alloc, .{
             .http = .{
@@ -480,6 +484,7 @@ pub const Server = struct {
 
     pub fn deinit(self: *Server) void {
         self.server.deinit();
+        freeReallocationProtocolPeers(self.alloc, self.reallocation_protocol_peers);
         self.alloc.free(self.admin_bind_host);
         self.alloc.free(self.bind_host);
         self.alloc.free(self.snapshot_root_dir);
@@ -874,8 +879,6 @@ pub fn runFromIterator(
     const metadata_group_id = group_ids.main_metadata_group_id;
     const cluster_peers = try resolveMetadataClusterPeers(alloc, cli.cluster_json, if (loaded_config) |*cfg| cfg else null);
     defer freeMetadataClusterPeers(alloc, cluster_peers);
-    const reallocation_protocol_peers = try reallocationProtocolPeersFromConfig(alloc, if (loaded_config) |*cfg| cfg else null);
-    defer if (reallocation_protocol_peers.len > 0) alloc.free(reallocation_protocol_peers);
     const listener = resolveRaftListener(cli, if (loaded_config) |*cfg| cfg else null);
     const admin_listener = resolveAdminListener(cli, if (loaded_config) |*cfg| cfg else null, local_node_id, listener.bind_host);
 
@@ -883,7 +886,6 @@ pub fn runFromIterator(
         .local_node_id = local_node_id,
         .metadata_group_id = metadata_group_id,
         .metadata_cluster_peers = cluster_peers,
-        .reallocation_protocol_peers = reallocation_protocol_peers,
         .replica_root_dir = resolved.replica_root_dir,
         .replica_catalog_path = resolved.replica_catalog_path,
         .snapshot_root_dir = resolved.snapshot_root_dir,
@@ -1282,28 +1284,66 @@ fn resolveMetadataClusterPeers(
     cluster_json: ?[]const u8,
     cfg: ?*const antfly.common.config.Config,
 ) ![]MetadataClusterPeer {
-    if (cluster_json) |raw| return try parseMetadataClusterJson(alloc, raw);
+    if (cluster_json) |raw| {
+        const peers = try parseMetadataClusterJson(alloc, raw);
+        errdefer freeMetadataClusterPeers(alloc, peers);
+        if (cfg) |loaded| {
+            for (peers) |*peer| {
+                if (peer.orchestration_url != null) continue;
+                const orchestration_url = metadataOrchestrationPeerUrl(loaded, peer.node_id) orelse continue;
+                peer.orchestration_url = try alloc.dupe(u8, orchestration_url);
+            }
+        }
+        return peers;
+    }
     if (cfg) |loaded| return try metadataClusterPeersFromConfig(alloc, loaded);
     return &.{};
 }
 
-fn reallocationProtocolPeersFromConfig(
+fn reallocationProtocolPeersFromClusterPeers(
     alloc: std.mem.Allocator,
-    cfg: ?*const antfly.common.config.Config,
+    cluster_peers: []const MetadataClusterPeer,
 ) ![]antfly.metadata_service.ReallocationProtocolPeer {
-    const loaded = cfg orelse return &.{};
-    if (loaded.metadata.orchestration_urls.len == 0) return &.{};
-    const peers = try alloc.alloc(
-        antfly.metadata_service.ReallocationProtocolPeer,
-        loaded.metadata.orchestration_urls.len,
-    );
-    for (loaded.metadata.orchestration_urls, 0..) |entry, index| {
+    var count: usize = 0;
+    for (cluster_peers) |peer| count += @intFromBool(peer.orchestration_url != null);
+    if (count == 0) return &.{};
+    const peers = try alloc.alloc(antfly.metadata_service.ReallocationProtocolPeer, count);
+    var initialized: usize = 0;
+    errdefer {
+        for (peers[0..initialized]) |peer| alloc.free(peer.orchestration_url);
+        alloc.free(peers);
+    }
+    var index: usize = 0;
+    for (cluster_peers) |peer| {
+        const orchestration_url = peer.orchestration_url orelse continue;
         peers[index] = .{
-            .node_id = entry.node_id,
-            .orchestration_url = entry.url,
+            .node_id = peer.node_id,
+            .orchestration_url = try alloc.dupe(u8, orchestration_url),
         };
+        initialized += 1;
+        index += 1;
     }
     return peers;
+}
+
+fn freeReallocationProtocolPeers(
+    alloc: std.mem.Allocator,
+    peers: []antfly.metadata_service.ReallocationProtocolPeer,
+) void {
+    for (peers) |peer| alloc.free(peer.orchestration_url);
+    if (peers.len > 0) alloc.free(peers);
+}
+
+fn validateMetadataClusterOrchestrationPeers(
+    cluster_peers: []const MetadataClusterPeer,
+    local_node_id: u64,
+) !void {
+    if (cluster_peers.len <= 1) return;
+    for (cluster_peers) |peer| {
+        if (peer.node_id == local_node_id) continue;
+        const orchestration_url = peer.orchestration_url orelse return error.MissingMetadataOrchestrationPeer;
+        if (orchestration_url.len == 0) return error.MissingMetadataOrchestrationPeer;
+    }
 }
 
 pub fn metadataClusterPeersFromConfig(
@@ -1314,13 +1354,24 @@ pub fn metadataClusterPeersFromConfig(
     var out = try alloc.alloc(MetadataClusterPeer, cfg.metadata.raft_urls.len);
     var initialized: usize = 0;
     errdefer {
-        for (out[0..initialized]) |peer| alloc.free(peer.raft_url);
+        for (out[0..initialized]) |peer| {
+            alloc.free(peer.raft_url);
+            if (peer.orchestration_url) |url| alloc.free(url);
+        }
         alloc.free(out);
     }
     for (cfg.metadata.raft_urls, 0..) |entry, index| {
-        out[index] = .{
-            .node_id = entry.node_id,
-            .raft_url = try alloc.dupe(u8, entry.url),
+        const orchestration_url = metadataOrchestrationPeerUrl(cfg, entry.node_id);
+        out[index] = owned: {
+            const raft_url = try alloc.dupe(u8, entry.url);
+            errdefer alloc.free(raft_url);
+            const owned_orchestration_url = if (orchestration_url) |url| try alloc.dupe(u8, url) else null;
+            errdefer if (owned_orchestration_url) |url| alloc.free(url);
+            break :owned .{
+                .node_id = entry.node_id,
+                .raft_url = raft_url,
+                .orchestration_url = owned_orchestration_url,
+            };
         };
         initialized += 1;
     }
@@ -1348,6 +1399,10 @@ pub fn metadataOrchestrationPeerUrl(
 }
 
 pub fn parseMetadataClusterJson(alloc: std.mem.Allocator, raw: []const u8) ![]MetadataClusterPeer {
+    const ParsedPeerUrls = struct {
+        raft: []const u8,
+        orchestration: ?[]const u8,
+    };
     var parsed = try std.json.parseFromSlice(std.json.Value, alloc, raw, .{ .allocate = .alloc_always });
     defer parsed.deinit();
     const object = switch (parsed.value) {
@@ -1359,19 +1414,41 @@ pub fn parseMetadataClusterJson(alloc: std.mem.Allocator, raw: []const u8) ![]Me
     var out = try alloc.alloc(MetadataClusterPeer, object.count());
     var initialized: usize = 0;
     errdefer {
-        for (out[0..initialized]) |peer| alloc.free(peer.raft_url);
+        for (out[0..initialized]) |peer| {
+            alloc.free(peer.raft_url);
+            if (peer.orchestration_url) |url| alloc.free(url);
+        }
         alloc.free(out);
     }
 
     var it = object.iterator();
     while (it.next()) |entry| {
-        const url = switch (entry.value_ptr.*) {
-            .string => |value| value,
+        const urls: ParsedPeerUrls = switch (entry.value_ptr.*) {
+            .string => |value| .{ .raft = value, .orchestration = @as(?[]const u8, null) },
+            .object => |value| blk: {
+                const raft_value = value.get("raft_url") orelse return error.InvalidArguments;
+                const raft_url = switch (raft_value) {
+                    .string => |url| url,
+                    else => return error.InvalidArguments,
+                };
+                const orchestration_url = if (value.get("orchestration_url")) |orchestration_value| switch (orchestration_value) {
+                    .string => |url| url,
+                    else => return error.InvalidArguments,
+                } else null;
+                break :blk .{ .raft = raft_url, .orchestration = orchestration_url };
+            },
             else => return error.InvalidArguments,
         };
-        out[initialized] = .{
-            .node_id = try parseMetadataNodeId(entry.key_ptr.*),
-            .raft_url = try alloc.dupe(u8, url),
+        out[initialized] = owned: {
+            const raft_url = try alloc.dupe(u8, urls.raft);
+            errdefer alloc.free(raft_url);
+            const orchestration_url = if (urls.orchestration) |url| try alloc.dupe(u8, url) else null;
+            errdefer if (orchestration_url) |url| alloc.free(url);
+            break :owned .{
+                .node_id = try parseMetadataNodeId(entry.key_ptr.*),
+                .raft_url = raft_url,
+                .orchestration_url = orchestration_url,
+            };
         };
         initialized += 1;
     }
@@ -1385,7 +1462,10 @@ fn parseMetadataNodeId(raw: []const u8) !u64 {
 }
 
 pub fn freeMetadataClusterPeers(alloc: std.mem.Allocator, peers: []MetadataClusterPeer) void {
-    for (peers) |peer| alloc.free(peer.raft_url);
+    for (peers) |peer| {
+        alloc.free(peer.raft_url);
+        if (peer.orchestration_url) |url| alloc.free(url);
+    }
     if (peers.len > 0) alloc.free(peers);
 }
 
@@ -1417,7 +1497,7 @@ fn printUsage(argv0: []const u8) void {
         \\  --raft-port <port>             Metadata raft bind port (default: 0)
         \\  --api-host <host>              Metadata admin API bind host (default: raft host)
         \\  --api-port <port>              Metadata admin API bind port (default: 0)
-        \\  --cluster <json>               Metadata raft peer URLs, e.g. {{"1":"http://127.0.0.1:9017"}}
+        \\  --cluster <json>               Metadata peer endpoints, e.g. {{"1":{{"raft_url":"http://127.0.0.1:9017","orchestration_url":"http://127.0.0.1:12377"}}}}
         \\  --health <true|false>          Enable health/metrics server (default: true)
         \\  --health-port <port>           Dedicated health/metrics bind port (default: 4200)
         \\  --experimental                 Enable experimental A2A protocol surfaces
@@ -1551,6 +1631,66 @@ test "metadata runtime cli accepts experimental flag" {
     var cfg = try parseCli(std.testing.allocator, &iter);
     defer cfg.deinit(std.testing.allocator);
     try std.testing.expect(cfg.experimental);
+}
+
+test "metadata runtime cluster json carries raft and orchestration endpoints" {
+    const alloc = std.testing.allocator;
+    const peers = try parseMetadataClusterJson(alloc,
+        \\{
+        \\  "1": {
+        \\    "raft_url": "http://127.0.0.1:9017",
+        \\    "orchestration_url": "http://127.0.0.1:12377"
+        \\  },
+        \\  "2": "http://127.0.0.1:9018"
+        \\}
+    );
+    defer freeMetadataClusterPeers(alloc, peers);
+
+    try std.testing.expectEqual(@as(usize, 2), peers.len);
+    var structured: ?MetadataClusterPeer = null;
+    var legacy: ?MetadataClusterPeer = null;
+    for (peers) |peer| {
+        if (peer.node_id == 1) structured = peer;
+        if (peer.node_id == 2) legacy = peer;
+    }
+    try std.testing.expectEqualStrings("http://127.0.0.1:9017", structured.?.raft_url);
+    try std.testing.expectEqualStrings("http://127.0.0.1:12377", structured.?.orchestration_url.?);
+    try std.testing.expectEqualStrings("http://127.0.0.1:9018", legacy.?.raft_url);
+    try std.testing.expect(legacy.?.orchestration_url == null);
+
+    const protocol_peers = try reallocationProtocolPeersFromClusterPeers(alloc, peers);
+    defer freeReallocationProtocolPeers(alloc, protocol_peers);
+    try std.testing.expectEqual(@as(usize, 1), protocol_peers.len);
+    try std.testing.expectEqual(@as(u64, 1), protocol_peers[0].node_id);
+    try std.testing.expectEqualStrings("http://127.0.0.1:12377", protocol_peers[0].orchestration_url);
+
+    try std.testing.expectError(
+        error.MissingMetadataOrchestrationPeer,
+        validateMetadataClusterOrchestrationPeers(peers, 1),
+    );
+    try validateMetadataClusterOrchestrationPeers(peers[0..1], 1);
+
+    var cfg = try antfly.common.config.Config.parseFromSlice(alloc,
+        \\{
+        \\  "metadata": {
+        \\    "orchestration_urls": {
+        \\      "1": "http://127.0.0.1:12377",
+        \\      "2": "http://127.0.0.1:12378"
+        \\    }
+        \\  }
+        \\}
+    );
+    defer cfg.deinit();
+    const legacy_cluster_json = "{\"1\":\"http://127.0.0.1:9017\",\"2\":\"http://127.0.0.1:9018\"}";
+    const merged_peers = try resolveMetadataClusterPeers(alloc, legacy_cluster_json, &cfg);
+    defer freeMetadataClusterPeers(alloc, merged_peers);
+    try validateMetadataClusterOrchestrationPeers(merged_peers, 1);
+    for (merged_peers) |peer| {
+        try std.testing.expectEqualStrings(
+            if (peer.node_id == 1) "http://127.0.0.1:12377" else "http://127.0.0.1:12378",
+            peer.orchestration_url.?,
+        );
+    }
 }
 
 test "metadata runtime preserves trusted principal auth material bytes" {

--- a/zig/pkg/antfly/src/metadata/service.zig
+++ b/zig/pkg/antfly/src/metadata/service.zig
@@ -4491,6 +4491,7 @@ pub const MetadataHttpService = struct {
             const catalog = try self.catalogValidationSnapshotLocked();
             const core = try self.projectedCoreSnapshotLocked();
             const store = self.projectedStore() orelse return error.MissingMetadataStore;
+            snapshot.reallocation_request = try store.getReallocationRequest(self.metadata_group_id);
             snapshot.tables = try cloneProjectedTablesOwned(self.alloc, catalog.tables);
             snapshot.ranges = try cloneProjectedRangesOwned(self.alloc, catalog.ranges);
             snapshot.nodes = try store.listNodes(self.alloc, self.metadata_group_id);
@@ -9978,6 +9979,9 @@ test "metadata service persists and clears reallocation requests" {
     try std.testing.expect(requested != null);
     try std.testing.expect(requested.?.request_id != 0);
     try std.testing.expectEqual(@as(u64, 77_000), requested.?.requested_at_ms);
+    var requested_snapshot = try svc.adminSnapshot();
+    defer svc.freeAdminSnapshot(&requested_snapshot);
+    try std.testing.expectEqual(requested, requested_snapshot.reallocation_request);
 
     var stale_plan = metadata_reconciler.ReconciliationPlan.empty();
     stale_plan.clear_reallocation_request = requested.?.request_id;
@@ -12070,6 +12074,13 @@ test "metadata http service catalog cache is independent from volatile projectio
     defer svc.freeProjectedTables(std.testing.allocator, after);
     try std.testing.expectEqual(@as(usize, 0), after.len);
     try std.testing.expectEqual(catalog_epoch_after, svc.catalog_validation_cache.catalog_epoch);
+
+    try svc.requestReallocation(77_000);
+    try svc.runRound();
+    var admin_snapshot = try svc.adminSnapshot();
+    defer svc.freeAdminSnapshot(&admin_snapshot);
+    try std.testing.expect(admin_snapshot.reallocation_request != null);
+    try std.testing.expectEqual(@as(u64, 77_000), admin_snapshot.reallocation_request.?.requested_at_ms);
 }
 
 test "metadata http service linearizable read waits for leader discovery" {

--- a/zig/pkg/antfly/src/metadata/service.zig
+++ b/zig/pkg/antfly/src/metadata/service.zig
@@ -9740,6 +9740,12 @@ test "metadata service reports store status without losing placement attributes"
     });
     try svc.runRound();
 
+    var group_statuses = [_]metadata_table_manager.GroupStatusReport{.{
+        .group_id = 4201,
+        .disk_bytes = 4096,
+        .disk_bytes_known = true,
+        .updated_at_millis = 1_700_000_000_000,
+    }};
     try svc.reportStoreStatus(.{
         .store_id = 11,
         .live = false,
@@ -9751,6 +9757,25 @@ test "metadata service reports store status without losing placement attributes"
         .write_load = 130,
         .active_backfills = 2,
         .backfill_progress_millis = 375,
+        .group_statuses = group_statuses[0..],
+    });
+    try svc.runRound();
+
+    // The acknowledgement itself must be enough to publish another store
+    // record even when all coalesced status and capacity fields are unchanged.
+    group_statuses[0].observed_reallocation_request_id = 0x123456789abcdef00123456789abcdef;
+    try svc.reportStoreStatus(.{
+        .store_id = 11,
+        .live = false,
+        .health_class = "degraded",
+        .capacity_bytes = 2048,
+        .available_bytes = 0,
+        .lease_pressure = 92,
+        .read_load = 210,
+        .write_load = 130,
+        .active_backfills = 2,
+        .backfill_progress_millis = 375,
+        .group_statuses = group_statuses[0..],
     });
     try svc.runRound();
 
@@ -9771,6 +9796,11 @@ test "metadata service reports store status without losing placement attributes"
     try std.testing.expectEqual(@as(u32, 130), projected[0].write_load);
     try std.testing.expectEqual(@as(u32, 2), projected[0].active_backfills);
     try std.testing.expectEqual(@as(u16, 375), projected[0].backfill_progress_millis);
+    try std.testing.expectEqual(@as(usize, 1), projected[0].group_statuses.len);
+    try std.testing.expectEqual(
+        @as(u128, 0x123456789abcdef00123456789abcdef),
+        projected[0].group_statuses[0].observed_reallocation_request_id,
+    );
 
     const status = try svc.status();
     try std.testing.expectEqual(@as(usize, 1), status.backfill_stores);

--- a/zig/pkg/antfly/src/metadata/service.zig
+++ b/zig/pkg/antfly/src/metadata/service.zig
@@ -19,6 +19,7 @@ const common_secrets = @import("../common/secrets.zig");
 const metadata_mod = @import("domain.zig");
 const extension_domain = @import("../extensions/mod.zig");
 const metadata_api = @import("api.zig");
+const metadata_http_client = @import("http_client.zig");
 const raft_engine = @import("raft_engine");
 const metadata_control_loop = @import("control_loop.zig");
 const metadata_reconcile_lease = @import("reconcile_lease.zig");
@@ -59,6 +60,7 @@ const metadata_run_round_trace_max_phases: usize = 32;
 const linearizable_metadata_read_prefix = "metadata:linearizable-read:";
 const linearizable_metadata_read_timeout_ns: u64 = 5 * std.time.ns_per_s;
 const linearizable_metadata_read_retry_ns: u64 = 50 * std.time.ns_per_ms;
+const reallocation_protocol_probe_timeout_ns: u64 = 5 * std.time.ns_per_s;
 
 fn logMetadataRunRoundPhase(name: []const u8, elapsed_ns: u64) void {
     if (elapsed_ns > metadata_run_round_slow_phase_threshold_ns) {
@@ -431,7 +433,26 @@ pub const MetadataServiceConfig = struct {
     observe_local_replica_root: bool = true,
     backend_runtime: ?*backend_runtime_mod.BackendRuntime = null,
     secret_store: ?*common_secrets.FileStore = null,
+    reallocation_protocol_peers: []const ReallocationProtocolPeer = &.{},
 };
+
+pub const ReallocationProtocolPeer = struct {
+    node_id: u64,
+    orchestration_url: []const u8,
+};
+
+fn findReallocationProtocolPeer(peers: []const ReallocationProtocolPeer, node_id: u64) ?ReallocationProtocolPeer {
+    for (peers) |peer| {
+        if (peer.node_id == node_id) return peer;
+    }
+    return null;
+}
+
+fn reallocationBarrierStatusCompatible(peer_status: MetadataStatus, metadata_group_id: u64, node_id: u64) bool {
+    return peer_status.metadata_group_id == metadata_group_id and
+        peer_status.metadata_raft_local_node_id == node_id and
+        peer_status.reallocation_barrier_protocol_version >= metadata_reallocation_request.barrier_protocol_version;
+}
 
 pub const MetadataServiceDeps = struct {
     host: raft_managed_host.ManagedHostDeps = .{},
@@ -3112,6 +3133,7 @@ pub const MetadataHttpService = struct {
     metadata_group_id: u64,
     replica_root_dir: ?[]const u8,
     observe_local_replica_root: bool,
+    reallocation_protocol_peers: []const ReallocationProtocolPeer,
     store_status_ticks: usize,
     projection_epoch: std.atomic.Value(u64) = .init(1),
     catalog_epoch: std.atomic.Value(u64) = .init(1),
@@ -3216,6 +3238,7 @@ pub const MetadataHttpService = struct {
             .metadata_group_id = metadata_group_id,
             .replica_root_dir = host_cfg.http.host.replica_root_dir,
             .observe_local_replica_root = cfg.observe_local_replica_root,
+            .reallocation_protocol_peers = cfg.reallocation_protocol_peers,
             .store_status_ticks = 0,
             .local_placement_epoch = null,
             .last_local_placement_refresh_at_ms = 0,
@@ -3833,12 +3856,65 @@ pub const MetadataHttpService = struct {
     }
 
     pub fn requestReallocation(self: *MetadataHttpService, requested_at_ms: u64) !void {
+        try self.ensureReallocationBarrierProtocolReady();
         const runtime = try self.ensureBackendRuntime();
         const request_id = try metadata_reallocation_request.generateRequestId(runtime.io() orelse std.Options.debug_io);
         try self.proposeTransitionCommand(.{ .upsert_reallocation_request = .{
             .request_id = request_id,
             .requested_at_ms = requested_at_ms,
         } });
+    }
+
+    fn ensureReallocationBarrierProtocolReady(self: *MetadataHttpService) !void {
+        const raft_status = self.raft.host.http_host.host.raftStatus(self.metadata_group_id) orelse
+            return error.ReallocationProtocolUpgradeRequired;
+        const local_node_id = self.raft.host.http_host.host.cfg.local_node_id;
+        var client = metadata_http_client.MetadataHttpClient.init(
+            self.alloc,
+            self.raft.host.http_host.request_executor,
+        );
+        const probe_budget = metadata_http_client.RequestBudget{
+            .deadline_ns = platform_time.monotonicNs() +| reallocation_protocol_probe_timeout_ns,
+        };
+
+        var local_voter = false;
+        for (raft_status.conf_state.voters) |node_id| {
+            local_voter = local_voter or node_id == local_node_id;
+            try self.requireReallocationBarrierPeer(&client, probe_budget, local_node_id, node_id);
+        }
+        // During joint consensus an outgoing voter can still become leader, so
+        // it participates in the compatibility barrier until it is removed.
+        for (raft_status.conf_state.voters_outgoing) |node_id| {
+            local_voter = local_voter or node_id == local_node_id;
+            if (std.mem.indexOfScalar(u64, raft_status.conf_state.voters, node_id) != null) continue;
+            try self.requireReallocationBarrierPeer(&client, probe_budget, local_node_id, node_id);
+        }
+        if (!local_voter) return error.ReallocationProtocolUpgradeRequired;
+    }
+
+    fn requireReallocationBarrierPeer(
+        self: *MetadataHttpService,
+        client: *metadata_http_client.MetadataHttpClient,
+        probe_budget: metadata_http_client.RequestBudget,
+        local_node_id: u64,
+        node_id: u64,
+    ) !void {
+        if (node_id == local_node_id) return;
+        const peer = findReallocationProtocolPeer(self.reallocation_protocol_peers, node_id) orelse {
+            std.log.warn("reallocation barrier blocked: metadata voter {d} has no orchestration URL", .{node_id});
+            return error.ReallocationProtocolUpgradeRequired;
+        };
+        const peer_status = client.fetchStatusWithBudget(peer.orchestration_url, probe_budget) catch |err| {
+            std.log.warn("reallocation barrier blocked: metadata voter {d} capability probe failed: {s}", .{ node_id, @errorName(err) });
+            return error.ReallocationProtocolUpgradeRequired;
+        };
+        if (!reallocationBarrierStatusCompatible(peer_status, self.metadata_group_id, node_id)) {
+            std.log.warn(
+                "reallocation barrier blocked: metadata voter {d} reports node={d} group={d} protocol={d}",
+                .{ node_id, peer_status.metadata_raft_local_node_id, peer_status.metadata_group_id, peer_status.reallocation_barrier_protocol_version },
+            );
+            return error.ReallocationProtocolUpgradeRequired;
+        }
     }
 
     pub fn clearReallocationRequest(self: *MetadataHttpService, expected_request_id: u128) !void {
@@ -4189,6 +4265,7 @@ pub const MetadataHttpService = struct {
     fn fallbackStatus(self: *MetadataHttpService) MetadataStatus {
         return .{
             .metadata_group_id = self.metadata_group_id,
+            .reallocation_barrier_protocol_version = metadata_reallocation_request.barrier_protocol_version,
             .metadata_epoch = self.lifecycle_signal.currentEpoch(),
             .metrics = self.metrics(),
         };
@@ -5518,6 +5595,21 @@ fn cdcLocalMetadataLeader(service: anytype) bool {
     service.lockRuntime();
     defer service.unlockRuntime();
     return service.raft.host.http_host.host.isLocalLeader(service.metadata_group_id);
+}
+
+test "metadata service reallocation barrier requires a current protocol from the exact metadata voter" {
+    const legacy_status = MetadataStatus{
+        .metadata_group_id = 42,
+        .metadata_raft_local_node_id = 7,
+        .metrics = .{},
+    };
+    try std.testing.expect(!reallocationBarrierStatusCompatible(legacy_status, 42, 7));
+
+    var current_status = legacy_status;
+    current_status.reallocation_barrier_protocol_version = metadata_reallocation_request.barrier_protocol_version;
+    try std.testing.expect(reallocationBarrierStatusCompatible(current_status, 42, 7));
+    try std.testing.expect(!reallocationBarrierStatusCompatible(current_status, 43, 7));
+    try std.testing.expect(!reallocationBarrierStatusCompatible(current_status, 42, 8));
 }
 
 fn shutdownCdcRuntimeJobs(service: anytype) void {
@@ -8424,6 +8516,7 @@ pub fn snapshotStatusWithOptions(
 
     return .{
         .metadata_group_id = metadata_group_id,
+        .reallocation_barrier_protocol_version = metadata_reallocation_request.barrier_protocol_version,
         .metadata_incarnation = metadata_incarnation,
         .metadata_raft_local_node_id = metadata_raft.local_node_id,
         .metadata_raft_role = metadata_raft.role,

--- a/zig/pkg/antfly/src/metadata/service.zig
+++ b/zig/pkg/antfly/src/metadata/service.zig
@@ -479,9 +479,37 @@ fn collectReallocationBarrierNodeIds(
     return node_ids;
 }
 
-fn reallocationBarrierStatusCompatible(peer_status: MetadataStatus, metadata_group_id: u64, node_id: u64) bool {
+const ReallocationBarrierContract = struct {
+    metadata_incarnation: metadata_mod.MetadataClusterIncarnation,
+    protected_metadata_member_count: u32,
+    protected_metadata_membership_fingerprint: metadata_reallocation_request.MembershipFingerprint,
+};
+
+fn reallocationBarrierContract(
+    incarnation: metadata_mod.MetadataClusterIncarnation,
+    sorted_node_ids: []const u64,
+) !ReallocationBarrierContract {
+    if (!metadata_mod.incarnation.isValid(incarnation) or sorted_node_ids.len == 0) {
+        return error.ReallocationProtocolUpgradeRequired;
+    }
+    return .{
+        .metadata_incarnation = incarnation,
+        .protected_metadata_member_count = std.math.cast(u32, sorted_node_ids.len) orelse
+            return error.ReallocationProtocolUpgradeRequired,
+        .protected_metadata_membership_fingerprint = metadata_reallocation_request.membershipFingerprint(sorted_node_ids),
+    };
+}
+
+fn reallocationBarrierStatusCompatible(
+    peer_status: MetadataStatus,
+    metadata_group_id: u64,
+    node_id: u64,
+    incarnation: metadata_mod.MetadataClusterIncarnation,
+) bool {
+    const peer_incarnation = peer_status.metadata_incarnation orelse return false;
     return peer_status.metadata_group_id == metadata_group_id and
         peer_status.metadata_raft_local_node_id == node_id and
+        std.mem.eql(u8, &peer_incarnation, &incarnation) and
         peer_status.reallocation_barrier_protocol_version >= metadata_reallocation_request.barrier_protocol_version;
 }
 
@@ -2176,11 +2204,33 @@ pub const MetadataService = struct {
     }
 
     pub fn requestReallocation(self: *MetadataService, requested_at_ms: u64) !void {
+        const raft_status = self.raft.host.host.raftStatus(self.metadata_group_id) orelse
+            return error.ReallocationProtocolUpgradeRequired;
+        const local_node_id = self.raft.host.host.cfg.local_node_id;
+        const required_node_ids = try collectReallocationBarrierNodeIds(
+            self.alloc,
+            raft_status.conf_state,
+            &.{},
+        );
+        defer if (required_node_ids.len > 0) self.alloc.free(required_node_ids);
+        // The non-HTTP service has no authenticated orchestration channel for
+        // remote capability probes. Keep it safe for its single-node use and
+        // require the HTTP service for multi-node request admission.
+        if (required_node_ids.len != 1 or required_node_ids[0] != local_node_id) {
+            return error.ReallocationProtocolUpgradeRequired;
+        }
+        const incarnation = (try self.metadataIncarnation()) orelse
+            return error.ReallocationProtocolUpgradeRequired;
+        const barrier = try reallocationBarrierContract(incarnation, required_node_ids);
         const runtime = try self.ensureBackendRuntime();
         const request_id = try metadata_reallocation_request.generateRequestId(runtime.io() orelse std.Options.debug_io);
         try self.proposeTransitionCommand(.{ .upsert_reallocation_request = .{
             .request_id = request_id,
             .requested_at_ms = requested_at_ms,
+            .barrier_protocol_version = metadata_reallocation_request.barrier_protocol_version,
+            .metadata_incarnation = barrier.metadata_incarnation,
+            .protected_metadata_member_count = barrier.protected_metadata_member_count,
+            .protected_metadata_membership_fingerprint = barrier.protected_metadata_membership_fingerprint,
         } });
     }
 
@@ -3887,16 +3937,20 @@ pub const MetadataHttpService = struct {
     }
 
     pub fn requestReallocation(self: *MetadataHttpService, requested_at_ms: u64) !void {
-        try self.ensureReallocationBarrierProtocolReady();
+        const barrier = try self.ensureReallocationBarrierProtocolReady();
         const runtime = try self.ensureBackendRuntime();
         const request_id = try metadata_reallocation_request.generateRequestId(runtime.io() orelse std.Options.debug_io);
         try self.proposeTransitionCommand(.{ .upsert_reallocation_request = .{
             .request_id = request_id,
             .requested_at_ms = requested_at_ms,
+            .barrier_protocol_version = metadata_reallocation_request.barrier_protocol_version,
+            .metadata_incarnation = barrier.metadata_incarnation,
+            .protected_metadata_member_count = barrier.protected_metadata_member_count,
+            .protected_metadata_membership_fingerprint = barrier.protected_metadata_membership_fingerprint,
         } });
     }
 
-    fn ensureReallocationBarrierProtocolReady(self: *MetadataHttpService) !void {
+    fn ensureReallocationBarrierProtocolReady(self: *MetadataHttpService) !ReallocationBarrierContract {
         const raft_status = self.raft.host.http_host.host.raftStatus(self.metadata_group_id) orelse
             return error.ReallocationProtocolUpgradeRequired;
         const local_node_id = self.raft.host.http_host.host.cfg.local_node_id;
@@ -3905,6 +3959,8 @@ pub const MetadataHttpService = struct {
         {
             return error.ReallocationProtocolUpgradeRequired;
         }
+        const incarnation = (try self.metadataIncarnation()) orelse
+            return error.ReallocationProtocolUpgradeRequired;
         var client = metadata_http_client.MetadataHttpClient.init(
             self.alloc,
             self.raft.host.http_host.request_executor,
@@ -3920,8 +3976,9 @@ pub const MetadataHttpService = struct {
         );
         defer if (required_node_ids.len > 0) self.alloc.free(required_node_ids);
         for (required_node_ids) |node_id| {
-            try self.requireReallocationBarrierPeer(&client, probe_budget, local_node_id, node_id);
+            try self.requireReallocationBarrierPeer(&client, probe_budget, local_node_id, node_id, incarnation);
         }
+        return try reallocationBarrierContract(incarnation, required_node_ids);
     }
 
     fn requireReallocationBarrierPeer(
@@ -3930,6 +3987,7 @@ pub const MetadataHttpService = struct {
         probe_budget: metadata_http_client.RequestBudget,
         local_node_id: u64,
         node_id: u64,
+        incarnation: metadata_mod.MetadataClusterIncarnation,
     ) !void {
         if (node_id == local_node_id) return;
         const peer = findReallocationProtocolPeer(self.reallocation_protocol_peers, node_id) orelse {
@@ -3948,7 +4006,7 @@ pub const MetadataHttpService = struct {
             std.log.warn("reallocation barrier blocked: metadata member {d} capability probe failed: {s}", .{ node_id, @errorName(err) });
             return error.ReallocationProtocolUpgradeRequired;
         };
-        if (!reallocationBarrierStatusCompatible(peer_status, self.metadata_group_id, node_id)) {
+        if (!reallocationBarrierStatusCompatible(peer_status, self.metadata_group_id, node_id, incarnation)) {
             std.log.warn(
                 "reallocation barrier blocked: metadata voter {d} reports node={d} group={d} protocol={d}",
                 .{ node_id, peer_status.metadata_raft_local_node_id, peer_status.metadata_group_id, peer_status.reallocation_barrier_protocol_version },
@@ -5638,18 +5696,28 @@ fn cdcLocalMetadataLeader(service: anytype) bool {
 }
 
 test "metadata service reallocation barrier requires a current protocol from the exact metadata voter" {
+    const incarnation: metadata_mod.MetadataClusterIncarnation = "0123456789abcdef0123456789abcdef".*;
     const legacy_status = MetadataStatus{
         .metadata_group_id = 42,
+        .metadata_incarnation = incarnation,
         .metadata_raft_local_node_id = 7,
         .metrics = .{},
     };
-    try std.testing.expect(!reallocationBarrierStatusCompatible(legacy_status, 42, 7));
+    try std.testing.expect(!reallocationBarrierStatusCompatible(legacy_status, 42, 7, incarnation));
 
     var current_status = legacy_status;
     current_status.reallocation_barrier_protocol_version = metadata_reallocation_request.barrier_protocol_version;
-    try std.testing.expect(reallocationBarrierStatusCompatible(current_status, 42, 7));
-    try std.testing.expect(!reallocationBarrierStatusCompatible(current_status, 43, 7));
-    try std.testing.expect(!reallocationBarrierStatusCompatible(current_status, 42, 8));
+    try std.testing.expect(reallocationBarrierStatusCompatible(current_status, 42, 7, incarnation));
+    try std.testing.expect(!reallocationBarrierStatusCompatible(current_status, 43, 7, incarnation));
+    try std.testing.expect(!reallocationBarrierStatusCompatible(current_status, 42, 8, incarnation));
+    try std.testing.expect(!reallocationBarrierStatusCompatible(
+        current_status,
+        42,
+        7,
+        "fedcba9876543210fedcba9876543210".*,
+    ));
+    current_status.metadata_incarnation = null;
+    try std.testing.expect(!reallocationBarrierStatusCompatible(current_status, 42, 7, incarnation));
 }
 
 test "metadata service reallocation barrier covers configured and transitional members" {
@@ -10154,7 +10222,7 @@ test "metadata service persists and clears reallocation requests" {
         .bootstrap_mode = .empty,
     });
     try svc.campaignMetadataGroup();
-    try svc.runRound();
+    try runServiceRoundsUntilMetadataReady(&svc);
 
     try svc.requestReallocation(77_000);
     try svc.runRound();
@@ -10162,6 +10230,14 @@ test "metadata service persists and clears reallocation requests" {
     try std.testing.expect(requested != null);
     try std.testing.expect(requested.?.request_id != 0);
     try std.testing.expectEqual(@as(u64, 77_000), requested.?.requested_at_ms);
+    try std.testing.expectEqual(metadata_reallocation_request.barrier_protocol_version, requested.?.barrier_protocol_version);
+    try std.testing.expectEqual(try svc.metadataIncarnation(), requested.?.metadata_incarnation);
+    try std.testing.expectEqual(@as(u32, 1), requested.?.protected_metadata_member_count);
+    try std.testing.expectEqualSlices(
+        u8,
+        &metadata_reallocation_request.membershipFingerprint(&.{1}),
+        &requested.?.protected_metadata_membership_fingerprint,
+    );
     var requested_snapshot = try svc.adminSnapshot();
     defer svc.freeAdminSnapshot(&requested_snapshot);
     try std.testing.expectEqual(requested, requested_snapshot.reallocation_request);
@@ -12258,12 +12334,22 @@ test "metadata http service catalog cache is independent from volatile projectio
     try std.testing.expectEqual(@as(usize, 0), after.len);
     try std.testing.expectEqual(catalog_epoch_after, svc.catalog_validation_cache.catalog_epoch);
 
+    var incarnation_rounds: usize = 0;
+    while (try svc.metadataIncarnation() == null and incarnation_rounds < 32) : (incarnation_rounds += 1) {
+        try svc.runRound();
+    }
+    try std.testing.expect(try svc.metadataIncarnation() != null);
     try svc.requestReallocation(77_000);
     try svc.runRound();
     var admin_snapshot = try svc.adminSnapshot();
     defer svc.freeAdminSnapshot(&admin_snapshot);
     try std.testing.expect(admin_snapshot.reallocation_request != null);
     try std.testing.expectEqual(@as(u64, 77_000), admin_snapshot.reallocation_request.?.requested_at_ms);
+    try std.testing.expectEqual(
+        metadata_reallocation_request.barrier_protocol_version,
+        admin_snapshot.reallocation_request.?.barrier_protocol_version,
+    );
+    try std.testing.expectEqual(try svc.metadataIncarnation(), admin_snapshot.reallocation_request.?.metadata_incarnation);
 }
 
 test "metadata http service linearizable read waits for leader discovery" {

--- a/zig/pkg/antfly/src/metadata/service.zig
+++ b/zig/pkg/antfly/src/metadata/service.zig
@@ -438,7 +438,7 @@ pub const MetadataServiceConfig = struct {
 
 pub const ReallocationProtocolPeer = struct {
     node_id: u64,
-    orchestration_url: []const u8,
+    orchestration_url: ?[]const u8 = null,
 };
 
 fn findReallocationProtocolPeer(peers: []const ReallocationProtocolPeer, node_id: u64) ?ReallocationProtocolPeer {
@@ -446,6 +446,37 @@ fn findReallocationProtocolPeer(peers: []const ReallocationProtocolPeer, node_id
         if (peer.node_id == node_id) return peer;
     }
     return null;
+}
+
+fn collectReallocationBarrierNodeIds(
+    alloc: std.mem.Allocator,
+    conf_state: raft_engine.core.ConfState,
+    configured_peers: []const ReallocationProtocolPeer,
+) ![]u64 {
+    var required = std.AutoHashMapUnmanaged(u64, void).empty;
+    defer required.deinit(alloc);
+
+    const membership_sets = [_][]const u64{
+        conf_state.voters,
+        conf_state.voters_outgoing,
+        conf_state.learners,
+        conf_state.learners_next,
+    };
+    for (membership_sets) |node_ids| {
+        for (node_ids) |node_id| try required.put(alloc, node_id, {});
+    }
+    // The configured peer set is the target membership for this process.
+    // Probing it as well as the currently applied ConfState prevents a
+    // compatible request from racing a configured learner admission and later
+    // being exposed to an older leader after promotion.
+    for (configured_peers) |peer| try required.put(alloc, peer.node_id, {});
+
+    const node_ids = try alloc.alloc(u64, required.count());
+    var index: usize = 0;
+    var it = required.keyIterator();
+    while (it.next()) |node_id| : (index += 1) node_ids[index] = node_id.*;
+    std.mem.sort(u64, node_ids, {}, std.sort.asc(u64));
+    return node_ids;
 }
 
 fn reallocationBarrierStatusCompatible(peer_status: MetadataStatus, metadata_group_id: u64, node_id: u64) bool {
@@ -3869,6 +3900,11 @@ pub const MetadataHttpService = struct {
         const raft_status = self.raft.host.http_host.host.raftStatus(self.metadata_group_id) orelse
             return error.ReallocationProtocolUpgradeRequired;
         const local_node_id = self.raft.host.http_host.host.cfg.local_node_id;
+        if (std.mem.indexOfScalar(u64, raft_status.conf_state.voters, local_node_id) == null and
+            std.mem.indexOfScalar(u64, raft_status.conf_state.voters_outgoing, local_node_id) == null)
+        {
+            return error.ReallocationProtocolUpgradeRequired;
+        }
         var client = metadata_http_client.MetadataHttpClient.init(
             self.alloc,
             self.raft.host.http_host.request_executor,
@@ -3877,19 +3913,15 @@ pub const MetadataHttpService = struct {
             .deadline_ns = platform_time.monotonicNs() +| reallocation_protocol_probe_timeout_ns,
         };
 
-        var local_voter = false;
-        for (raft_status.conf_state.voters) |node_id| {
-            local_voter = local_voter or node_id == local_node_id;
+        const required_node_ids = try collectReallocationBarrierNodeIds(
+            self.alloc,
+            raft_status.conf_state,
+            self.reallocation_protocol_peers,
+        );
+        defer if (required_node_ids.len > 0) self.alloc.free(required_node_ids);
+        for (required_node_ids) |node_id| {
             try self.requireReallocationBarrierPeer(&client, probe_budget, local_node_id, node_id);
         }
-        // During joint consensus an outgoing voter can still become leader, so
-        // it participates in the compatibility barrier until it is removed.
-        for (raft_status.conf_state.voters_outgoing) |node_id| {
-            local_voter = local_voter or node_id == local_node_id;
-            if (std.mem.indexOfScalar(u64, raft_status.conf_state.voters, node_id) != null) continue;
-            try self.requireReallocationBarrierPeer(&client, probe_budget, local_node_id, node_id);
-        }
-        if (!local_voter) return error.ReallocationProtocolUpgradeRequired;
     }
 
     fn requireReallocationBarrierPeer(
@@ -3901,11 +3933,19 @@ pub const MetadataHttpService = struct {
     ) !void {
         if (node_id == local_node_id) return;
         const peer = findReallocationProtocolPeer(self.reallocation_protocol_peers, node_id) orelse {
-            std.log.warn("reallocation barrier blocked: metadata voter {d} has no orchestration URL", .{node_id});
+            std.log.warn("reallocation barrier blocked: metadata member {d} is not in the configured peer set", .{node_id});
             return error.ReallocationProtocolUpgradeRequired;
         };
-        const peer_status = client.fetchStatusWithBudget(peer.orchestration_url, probe_budget) catch |err| {
-            std.log.warn("reallocation barrier blocked: metadata voter {d} capability probe failed: {s}", .{ node_id, @errorName(err) });
+        const orchestration_url = peer.orchestration_url orelse {
+            std.log.warn("reallocation barrier blocked: metadata member {d} has no orchestration URL", .{node_id});
+            return error.ReallocationProtocolUpgradeRequired;
+        };
+        if (orchestration_url.len == 0) {
+            std.log.warn("reallocation barrier blocked: metadata member {d} has an empty orchestration URL", .{node_id});
+            return error.ReallocationProtocolUpgradeRequired;
+        }
+        const peer_status = client.fetchStatusWithBudget(orchestration_url, probe_budget) catch |err| {
+            std.log.warn("reallocation barrier blocked: metadata member {d} capability probe failed: {s}", .{ node_id, @errorName(err) });
             return error.ReallocationProtocolUpgradeRequired;
         };
         if (!reallocationBarrierStatusCompatible(peer_status, self.metadata_group_id, node_id)) {
@@ -5610,6 +5650,26 @@ test "metadata service reallocation barrier requires a current protocol from the
     try std.testing.expect(reallocationBarrierStatusCompatible(current_status, 42, 7));
     try std.testing.expect(!reallocationBarrierStatusCompatible(current_status, 43, 7));
     try std.testing.expect(!reallocationBarrierStatusCompatible(current_status, 42, 8));
+}
+
+test "metadata service reallocation barrier covers configured and transitional members" {
+    const configured_peers = [_]ReallocationProtocolPeer{
+        .{ .node_id = 2, .orchestration_url = "http://127.0.0.1:12378" },
+        .{ .node_id = 6 },
+    };
+    const conf_state = raft_engine.core.ConfState{
+        .voters = @constCast((&[_]u64{ 1, 2 })[0..]),
+        .voters_outgoing = @constCast((&[_]u64{ 2, 3 })[0..]),
+        .learners = @constCast((&[_]u64{4})[0..]),
+        .learners_next = @constCast((&[_]u64{5})[0..]),
+    };
+    const required = try collectReallocationBarrierNodeIds(
+        std.testing.allocator,
+        conf_state,
+        &configured_peers,
+    );
+    defer std.testing.allocator.free(required);
+    try std.testing.expectEqualSlices(u64, &.{ 1, 2, 3, 4, 5, 6 }, required);
 }
 
 fn shutdownCdcRuntimeJobs(service: anytype) void {

--- a/zig/pkg/antfly/src/metadata/storage/raft_apply_store.zig
+++ b/zig/pkg/antfly/src/metadata/storage/raft_apply_store.zig
@@ -4540,9 +4540,13 @@ fn appendStoreRecordExtensions(
     try out.appendSlice(alloc, store_record_extension_magic);
     try appendInt(alloc, out, u16, store_record_extension_version);
     try appendInt(alloc, out, u32, observation_count);
-    for (record.group_statuses) |status| {
+    for (record.group_statuses, 0..) |status, status_index| {
         if (status.observed_reallocation_request_id == 0) continue;
-        try appendInt(alloc, out, u64, status.group_id);
+        // Group reports are intentionally permitted to contain duplicate group
+        // IDs so reconciliation can treat the report as ambiguous and fail
+        // closed. Address the extension by position so that ambiguity remains
+        // representable in the committed command instead of making apply fail.
+        try appendInt(alloc, out, u32, @intCast(status_index));
         try appendInt(alloc, out, u128, status.observed_reallocation_request_id);
     }
 }
@@ -4655,20 +4659,12 @@ fn readStoreRecordExtensions(
     const observation_count = try readInt(encoded, pos, u32);
     var observation_index: u32 = 0;
     while (observation_index < observation_count) : (observation_index += 1) {
-        const group_id = try readInt(encoded, pos, u64);
+        const status_index = try readInt(encoded, pos, u32);
         const request_id = try readInt(encoded, pos, u128);
-        if (request_id == 0) return error.InvalidMetadataTransitionEncoding;
-
-        var matched = false;
-        for (group_statuses) |*status| {
-            if (status.group_id != group_id) continue;
-            if (matched or status.observed_reallocation_request_id != 0) {
-                return error.InvalidMetadataTransitionEncoding;
-            }
-            status.observed_reallocation_request_id = request_id;
-            matched = true;
-        }
-        if (!matched) return error.InvalidMetadataTransitionEncoding;
+        if (request_id == 0 or status_index >= group_statuses.len) return error.InvalidMetadataTransitionEncoding;
+        const status = &group_statuses[status_index];
+        if (status.observed_reallocation_request_id != 0) return error.InvalidMetadataTransitionEncoding;
+        status.observed_reallocation_request_id = request_id;
     }
     if (pos.* != encoded.len) return error.InvalidMetadataTransitionEncoding;
 }
@@ -9714,6 +9710,38 @@ test "metadata raft apply store transition codec preserves exact raft voter iden
     );
     try std.testing.expectEqual(@as(u16, 3), statuses[0].voter_count);
     try std.testing.expectEqualSlices(u8, &fingerprint, &statuses[0].voter_set_fingerprint);
+}
+
+test "metadata raft apply store transition codec preserves duplicate group observations by position" {
+    var group_statuses = [_]metadata.GroupStatusReport{
+        .{
+            .group_id = 5101,
+            .observed_reallocation_request_id = 0x1111,
+        },
+        .{
+            .group_id = 5101,
+            .observed_reallocation_request_id = 0x2222,
+        },
+    };
+    const encoded = try encodeTransitionCommand(std.testing.allocator, .{
+        .upsert_store = .{
+            .store_id = 101,
+            .node_id = 101,
+            .role = "data",
+            .group_statuses = group_statuses[0..],
+        },
+    });
+    defer std.testing.allocator.free(encoded);
+
+    var decoded = (try decodeTransitionCommand(std.testing.allocator, encoded)) orelse
+        return error.InvalidMetadataTransitionEncoding;
+    defer decoded.deinit(std.testing.allocator);
+    const statuses = decoded.upsert_store.group_statuses;
+    try std.testing.expectEqual(@as(usize, 2), statuses.len);
+    try std.testing.expectEqual(@as(u64, 5101), statuses[0].group_id);
+    try std.testing.expectEqual(@as(u64, 5101), statuses[1].group_id);
+    try std.testing.expectEqual(@as(u128, 0x1111), statuses[0].observed_reallocation_request_id);
+    try std.testing.expectEqual(@as(u128, 0x2222), statuses[1].observed_reallocation_request_id);
 }
 
 test "metadata raft apply store projects placement intents from committed entries" {

--- a/zig/pkg/antfly/src/metadata/storage/raft_apply_store.zig
+++ b/zig/pkg/antfly/src/metadata/storage/raft_apply_store.zig
@@ -3764,6 +3764,8 @@ const group_status_record_version: u16 = 4;
 // optional state in a self-identifying trailer that older readers ignore.
 const store_record_extension_magic = "afsx1";
 const store_record_extension_version: u16 = 1;
+const reallocation_request_extension_magic = "afrr1";
+const reallocation_request_extension_version: u16 = 1;
 
 const TransitionTag = enum(u8) {
     initialize_metadata_incarnation = 45,
@@ -5644,6 +5646,13 @@ fn appendReallocationRequestRecord(
     if (!metadata.isValidReallocationRequest(record)) return error.InvalidMetadataRecord;
     try appendInt(alloc, out, u128, record.request_id);
     try appendInt(alloc, out, u64, record.requested_at_ms);
+    if (record.barrier_protocol_version == 0) return;
+    try out.appendSlice(alloc, reallocation_request_extension_magic);
+    try appendInt(alloc, out, u16, reallocation_request_extension_version);
+    try appendInt(alloc, out, u16, record.barrier_protocol_version);
+    try out.appendSlice(alloc, &record.metadata_incarnation.?);
+    try appendInt(alloc, out, u32, record.protected_metadata_member_count);
+    try out.appendSlice(alloc, &record.protected_metadata_membership_fingerprint);
 }
 
 fn readTableRecord(
@@ -6472,10 +6481,37 @@ fn readReallocationRequestRecord(
     encoded: []const u8,
     pos: *usize,
 ) !metadata.ReallocationRequestRecord {
-    const record: metadata.ReallocationRequestRecord = .{
+    var record: metadata.ReallocationRequestRecord = .{
         .request_id = try readInt(encoded, pos, u128),
         .requested_at_ms = try readInt(encoded, pos, u64),
     };
+    if (pos.* < encoded.len) {
+        if (pos.* + reallocation_request_extension_magic.len > encoded.len or
+            !std.mem.eql(
+                u8,
+                encoded[pos.* .. pos.* + reallocation_request_extension_magic.len],
+                reallocation_request_extension_magic,
+            ))
+        {
+            return error.InvalidMetadataRecord;
+        }
+        pos.* += reallocation_request_extension_magic.len;
+        const version = try readInt(encoded, pos, u16);
+        if (version != reallocation_request_extension_version) return error.InvalidMetadataRecord;
+        record.barrier_protocol_version = try readInt(encoded, pos, u16);
+        if (pos.* + @sizeOf(metadata.MetadataClusterIncarnation) > encoded.len) return error.InvalidMetadataRecord;
+        var incarnation: metadata.MetadataClusterIncarnation = undefined;
+        @memcpy(&incarnation, encoded[pos.*..][0..incarnation.len]);
+        pos.* += incarnation.len;
+        record.metadata_incarnation = incarnation;
+        record.protected_metadata_member_count = try readInt(encoded, pos, u32);
+        if (pos.* + record.protected_metadata_membership_fingerprint.len > encoded.len) return error.InvalidMetadataRecord;
+        @memcpy(
+            &record.protected_metadata_membership_fingerprint,
+            encoded[pos.*..][0..record.protected_metadata_membership_fingerprint.len],
+        );
+        pos.* += record.protected_metadata_membership_fingerprint.len;
+    }
     if (!metadata.isValidReallocationRequest(record)) return error.InvalidMetadataRecord;
     return record;
 }
@@ -8857,10 +8893,16 @@ test "metadata schema progress transition command round-trips" {
 }
 
 test "metadata reallocation request transition command round-trips" {
+    const protected_members = [_]u64{ 1, 2, 3 };
+    const fingerprint = metadata.reallocation_request.membershipFingerprint(&protected_members);
     const encoded = try encodeTransitionCommand(std.testing.allocator, .{
         .upsert_reallocation_request = .{
             .request_id = 17,
             .requested_at_ms = 42_000,
+            .barrier_protocol_version = metadata.reallocation_request.barrier_protocol_version,
+            .metadata_incarnation = "0123456789abcdef0123456789abcdef".*,
+            .protected_metadata_member_count = protected_members.len,
+            .protected_metadata_membership_fingerprint = fingerprint,
         },
     });
     defer std.testing.allocator.free(encoded);
@@ -8872,6 +8914,10 @@ test "metadata reallocation request transition command round-trips" {
         .upsert_reallocation_request => |record| {
             try std.testing.expectEqual(@as(u128, 17), record.request_id);
             try std.testing.expectEqual(@as(u64, 42_000), record.requested_at_ms);
+            try std.testing.expectEqual(metadata.reallocation_request.barrier_protocol_version, record.barrier_protocol_version);
+            try std.testing.expectEqualStrings("0123456789abcdef0123456789abcdef", &record.metadata_incarnation.?);
+            try std.testing.expectEqual(@as(u32, 3), record.protected_metadata_member_count);
+            try std.testing.expectEqualSlices(u8, &fingerprint, &record.protected_metadata_membership_fingerprint);
         },
         else => return error.InvalidMetadataTransitionEncoding,
     }
@@ -8892,6 +8938,18 @@ test "metadata reallocation request transition command round-trips" {
         },
         else => return error.InvalidMetadataTransitionEncoding,
     }
+}
+
+test "metadata reallocation request decoder accepts the legacy unfenced record" {
+    var encoded = std.ArrayListUnmanaged(u8).empty;
+    defer encoded.deinit(std.testing.allocator);
+    try appendInt(std.testing.allocator, &encoded, u128, 17);
+    try appendInt(std.testing.allocator, &encoded, u64, 42_000);
+    var pos: usize = 0;
+    const record = try readReallocationRequestRecord(encoded.items, &pos);
+    try std.testing.expectEqual(encoded.items.len, pos);
+    try std.testing.expectEqual(@as(u16, 0), record.barrier_protocol_version);
+    try std.testing.expect(record.metadata_incarnation == null);
 }
 
 test "metadata extension lifecycle transition command round-trips" {

--- a/zig/pkg/antfly/src/metadata/storage/raft_apply_store.zig
+++ b/zig/pkg/antfly/src/metadata/storage/raft_apply_store.zig
@@ -3759,6 +3759,11 @@ fn replicationCutoverRetirementCleared(
 const transition_magic = "afmd1";
 const runtime_status_record_version: u16 = 12;
 const group_status_record_version: u16 = 4;
+// Store records predate framing and are read by mixed-version metadata
+// replicas. Keep the existing prefix byte-for-byte compatible and put new
+// optional state in a self-identifying trailer that older readers ignore.
+const store_record_extension_magic = "afsx1";
+const store_record_extension_version: u16 = 1;
 
 const TransitionTag = enum(u8) {
     initialize_metadata_incarnation = 45,
@@ -4518,6 +4523,28 @@ fn appendStoreRecord(
     try appendInt(alloc, out, u32, @intCast(record.runtime_statuses.len));
     for (record.runtime_statuses) |runtime_status| try appendRuntimeGroupStatusRecord(alloc, out, runtime_status);
     try out.append(alloc, if (record.drain_requested) 1 else 0);
+    try appendStoreRecordExtensions(alloc, out, record);
+}
+
+fn appendStoreRecordExtensions(
+    alloc: std.mem.Allocator,
+    out: *std.ArrayListUnmanaged(u8),
+    record: metadata.StoreRecord,
+) !void {
+    var observation_count: u32 = 0;
+    for (record.group_statuses) |status| {
+        if (status.observed_reallocation_request_id != 0) observation_count += 1;
+    }
+    if (observation_count == 0) return;
+
+    try out.appendSlice(alloc, store_record_extension_magic);
+    try appendInt(alloc, out, u16, store_record_extension_version);
+    try appendInt(alloc, out, u32, observation_count);
+    for (record.group_statuses) |status| {
+        if (status.observed_reallocation_request_id == 0) continue;
+        try appendInt(alloc, out, u64, status.group_id);
+        try appendInt(alloc, out, u128, status.observed_reallocation_request_id);
+    }
 }
 
 fn readStoreRecord(alloc: std.mem.Allocator, encoded: []const u8, pos: *usize) !metadata.StoreRecord {
@@ -4583,6 +4610,7 @@ fn readStoreRecord(alloc: std.mem.Allocator, encoded: []const u8, pos: *usize) !
         pos.* += 1;
         break :blk value;
     } else false;
+    try readStoreRecordExtensions(encoded, pos, group_statuses);
     return .{
         .store_id = store_id,
         .node_id = node_id,
@@ -4603,6 +4631,46 @@ fn readStoreRecord(alloc: std.mem.Allocator, encoded: []const u8, pos: *usize) !
         .group_statuses = group_statuses,
         .runtime_statuses = runtime_statuses,
     };
+}
+
+fn readStoreRecordExtensions(
+    encoded: []const u8,
+    pos: *usize,
+    group_statuses: []metadata.GroupStatusReport,
+) !void {
+    if (pos.* == encoded.len) return;
+    if (pos.* + store_record_extension_magic.len > encoded.len or
+        !std.mem.eql(
+            u8,
+            encoded[pos.* .. pos.* + store_record_extension_magic.len],
+            store_record_extension_magic,
+        ))
+    {
+        return error.InvalidMetadataTransitionEncoding;
+    }
+    pos.* += store_record_extension_magic.len;
+
+    const version = try readInt(encoded, pos, u16);
+    if (version != store_record_extension_version) return error.InvalidMetadataTransitionEncoding;
+    const observation_count = try readInt(encoded, pos, u32);
+    var observation_index: u32 = 0;
+    while (observation_index < observation_count) : (observation_index += 1) {
+        const group_id = try readInt(encoded, pos, u64);
+        const request_id = try readInt(encoded, pos, u128);
+        if (request_id == 0) return error.InvalidMetadataTransitionEncoding;
+
+        var matched = false;
+        for (group_statuses) |*status| {
+            if (status.group_id != group_id) continue;
+            if (matched or status.observed_reallocation_request_id != 0) {
+                return error.InvalidMetadataTransitionEncoding;
+            }
+            status.observed_reallocation_request_id = request_id;
+            matched = true;
+        }
+        if (!matched) return error.InvalidMetadataTransitionEncoding;
+    }
+    if (pos.* != encoded.len) return error.InvalidMetadataTransitionEncoding;
 }
 
 fn appendRuntimeGroupStatusRecord(
@@ -9611,6 +9679,7 @@ test "metadata raft apply store transition codec preserves exact raft voter iden
         .raft_membership_index = 87,
         .disk_bytes = 4096,
         .disk_bytes_known = true,
+        .observed_reallocation_request_id = 0x123456789abcdef00123456789abcdef,
         .local_leader = true,
         .local_voter = true,
         .voter_count = 3,
@@ -9639,6 +9708,10 @@ test "metadata raft apply store transition codec preserves exact raft voter iden
     try std.testing.expectEqual(@as(u64, 91), statuses[0].raft_applied_index);
     try std.testing.expectEqual(@as(u64, 12), statuses[0].raft_term);
     try std.testing.expectEqual(@as(u64, 87), statuses[0].raft_membership_index);
+    try std.testing.expectEqual(
+        @as(u128, 0x123456789abcdef00123456789abcdef),
+        statuses[0].observed_reallocation_request_id,
+    );
     try std.testing.expectEqual(@as(u16, 3), statuses[0].voter_count);
     try std.testing.expectEqualSlices(u8, &fingerprint, &statuses[0].voter_set_fingerprint);
 }

--- a/zig/pkg/antfly/src/metadata/store_observer.zig
+++ b/zig/pkg/antfly/src/metadata/store_observer.zig
@@ -148,6 +148,7 @@ fn groupStatusEqual(
         lhs.empty == rhs.empty and
         lhs.created_at_millis == rhs.created_at_millis and
         timestampMillisCoalesced(lhs.updated_at_millis, rhs.updated_at_millis) and
+        lhs.observed_reallocation_request_id == rhs.observed_reallocation_request_id and
         lhs.local_leader == rhs.local_leader and
         lhs.local_voter == rhs.local_voter and
         lhs.voter_count == rhs.voter_count and
@@ -474,6 +475,12 @@ test "store observer coalesces status heartbeat timestamps" {
         .group_statuses = fresh_groups[0..],
     };
     try std.testing.expect(!observationChangesRecord(existing, observation));
+
+    // Causal acknowledgements are state transitions, not heartbeats. They
+    // must bypass timestamp coalescing even when every storage fact is stable.
+    fresh_groups[0].observed_reallocation_request_id = 0x1234;
+    try std.testing.expect(observationChangesRecord(existing, observation));
+    fresh_groups[0].observed_reallocation_request_id = 0;
 
     observation.group_statuses = stale_groups[0..];
     try std.testing.expect(observationChangesRecord(existing, observation));

--- a/zig/pkg/antfly/src/metadata/table_manager.zig
+++ b/zig/pkg/antfly/src/metadata/table_manager.zig
@@ -320,6 +320,10 @@ pub const GroupStatusReport = struct {
     empty: bool = true,
     created_at_millis: u64 = 0,
     updated_at_millis: u64 = 0,
+    /// Durable reallocation request observed before this status was collected.
+    /// This is a causal barrier; timestamps remain only a rolling-upgrade
+    /// fallback for reporters that predate this field.
+    observed_reallocation_request_id: u128 = 0,
     local_leader: bool = false,
     local_voter: bool = false,
     voter_count: u16 = 0,
@@ -1941,6 +1945,7 @@ pub fn cloneGroupStatus(alloc: std.mem.Allocator, record: GroupStatusReport) !Gr
         .empty = record.empty,
         .created_at_millis = record.created_at_millis,
         .updated_at_millis = record.updated_at_millis,
+        .observed_reallocation_request_id = record.observed_reallocation_request_id,
         .local_leader = record.local_leader,
         .local_voter = record.local_voter,
         .voter_count = record.voter_count,

--- a/zig/pkg/antfly/src/raft/managed_host.zig
+++ b/zig/pkg/antfly/src/raft/managed_host.zig
@@ -21,6 +21,7 @@ const data_storage = @import("../data/storage/mod.zig");
 const host_mod = @import("host.zig");
 const leader_runtime = @import("leader_runtime.zig");
 const metadata_table_provisioner = @import("../metadata/table_provisioner.zig");
+const metadata_reallocation_request = @import("../metadata/reallocation_request.zig");
 const metadata_storage = @import("../metadata/storage/mod.zig");
 const metadata_view = @import("metadata_view.zig");
 const reconciler = @import("reconciler.zig");
@@ -65,6 +66,53 @@ pub const ManagedSyncResult = struct {
     reconcile: reconciler.ReconcileResult,
     runtime: raft_engine.runtime.multi_raft.HostRound,
 };
+
+fn metadataMembershipChangePermit(store: *metadata_storage.RaftApplyStore) reconciler.MembershipChangePermit {
+    return .{
+        .ptr = store,
+        .vtable = &.{ .allows = metadataMembershipChangeAllowed },
+    };
+}
+
+fn metadataMembershipChangeAllowed(
+    ptr: *anyopaque,
+    group_id: u64,
+    voter_node_ids: []const u64,
+    learner_node_ids: []const u64,
+) bool {
+    _ = voter_node_ids;
+    _ = learner_node_ids;
+    const store: *metadata_storage.RaftApplyStore = @ptrCast(@alignCast(ptr));
+    const request = store.getReallocationRequest(group_id) catch return false;
+    return reallocationRequestAllowsMembershipChange(request);
+}
+
+fn reallocationRequestAllowsMembershipChange(
+    request: ?metadata_reallocation_request.ReallocationRequestRecord,
+) bool {
+    // A member can restart into an older binary after admission, so even an
+    // otherwise idempotent membership proposal is unsafe while the replicated
+    // request is active. Clearing that request is the only release signal.
+    return request == null;
+}
+
+test "metadata membership changes remain fenced for the lifetime of a reallocation request" {
+    const protected = [_]u64{ 1, 2, 3 };
+    const request: metadata_reallocation_request.ReallocationRequestRecord = .{
+        .request_id = 7,
+        .requested_at_ms = 11,
+        .barrier_protocol_version = metadata_reallocation_request.barrier_protocol_version,
+        .metadata_incarnation = "0123456789abcdef0123456789abcdef".*,
+        .protected_metadata_member_count = protected.len,
+        .protected_metadata_membership_fingerprint = metadata_reallocation_request.membershipFingerprint(&protected),
+    };
+    try std.testing.expect(!reallocationRequestAllowsMembershipChange(request));
+    try std.testing.expect(!reallocationRequestAllowsMembershipChange(.{
+        .request_id = 7,
+        .requested_at_ms = 11,
+    }));
+    try std.testing.expect(reallocationRequestAllowsMembershipChange(null));
+}
 
 pub const ManagedHost = struct {
     alloc: std.mem.Allocator,
@@ -135,6 +183,10 @@ pub const ManagedHost = struct {
                 .alloc = alloc,
                 .host = host,
                 .provider = view.placementProvider(),
+                .membership_change_permit = if (prepared_deps.owned_metadata_store) |store|
+                    metadataMembershipChangePermit(store)
+                else
+                    null,
             },
         };
     }
@@ -359,6 +411,10 @@ pub const ManagedHttpHost = struct {
                 .alloc = alloc,
                 .host = http_host.host,
                 .provider = view.placementProvider(),
+                .membership_change_permit = if (prepared_deps.owned_metadata_store) |store|
+                    metadataMembershipChangePermit(store)
+                else
+                    null,
             },
         };
     }

--- a/zig/pkg/antfly/src/raft/reconciler.zig
+++ b/zig/pkg/antfly/src/raft/reconciler.zig
@@ -96,6 +96,32 @@ pub const PlacementProvider = struct {
     }
 };
 
+/// Optional durable policy boundary for consensus membership. Returning false
+/// defers the proposal without mutating the desired intent, allowing the
+/// policy owner to release the fence and resume normal reconciliation later.
+pub const MembershipChangePermit = struct {
+    ptr: *anyopaque,
+    vtable: *const VTable,
+
+    pub const VTable = struct {
+        allows: *const fn (
+            ptr: *anyopaque,
+            group_id: u64,
+            voter_node_ids: []const u64,
+            learner_node_ids: []const u64,
+        ) bool,
+    };
+
+    pub fn allows(self: MembershipChangePermit, intent: PlacementIntent) bool {
+        return self.vtable.allows(
+            self.ptr,
+            intent.record.group_id,
+            intent.peer_node_ids,
+            intent.learner_node_ids,
+        );
+    }
+};
+
 pub const MemoryPlacementProvider = struct {
     alloc: std.mem.Allocator,
     intents: std.ArrayListUnmanaged(PlacementIntent) = .empty,
@@ -360,6 +386,7 @@ pub const Reconciler = struct {
     alloc: std.mem.Allocator,
     host: *host_mod.Host,
     provider: PlacementProvider,
+    membership_change_permit: ?MembershipChangePermit = null,
     last_intent_hashes: std.AutoHashMapUnmanaged(u64, u64) = .empty,
 
     pub fn deinit(self: *Reconciler) void {
@@ -465,6 +492,9 @@ pub const Reconciler = struct {
         // the committed joint configuration first; the next reconcile round will
         // calculate any remaining delta from the resulting stable voter set.
         if (status.conf_state.voters_outgoing.len > 0) {
+            if (self.membership_change_permit) |permit| {
+                if (!permit.allows(intent)) return false;
+            }
             self.host.proposeConfChangeV2(intent.record.group_id, .{}) catch |err| return switch (err) {
                 error.PendingConfChange,
                 error.NotInJointState,
@@ -493,6 +523,9 @@ pub const Reconciler = struct {
         );
         defer self.alloc.free(changes);
         if (changes.len == 0) return false;
+        if (self.membership_change_permit) |permit| {
+            if (!permit.allows(intent)) return false;
+        }
 
         self.host.proposeConfChangeV2(intent.record.group_id, .{ .changes = changes }) catch |err| return switch (err) {
             error.PendingConfChange,


### PR DESCRIPTION
## Summary

- retain a forced reallocation request until every healthy placed voter has reported authoritative status after observing that exact request
- publish the durable request in metadata snapshots and refresh each data node group-status cache once per request
- give filesystem disk observations their own causal generation, invalidate them at the request boundary, and promote only fresh disk facts into store status without violating DB/startup ownership
- advertise a reallocation-barrier protocol version and admit requests only after every current or outgoing metadata voter reports support
- use a versioned v2 trigger route so upgraded clients cannot accidentally submit the new protocol to an old metadata leader during a rolling upgrade
- encode per-group acknowledgements by report position, preserving duplicate group reports so reconciliation can reject them as ambiguous without failing Raft apply
- have the operator emit structured metadata peers containing both Raft and orchestration endpoints

This fixes the autosplit E2E flake exposed while validating #475, the PR that fixed #474. A stale under-threshold status could previously clear the one-shot reallocation request before a newer oversized status was projected, permanently losing the split trigger when automatic shard allocation was disabled.

## Validation

- fresh Debug `antfly` binary built with `tools/run_bounded_zig_build.py`
- `zig build lib-data-runtime-test` (102/102 passed)
- `zig build lib-api-derived-coverage-test` (39/39 passed)
- focused metadata service, metadata logic, and HTTP protocol/client regressions
- `env GOWORK=off go test ./controllers/antfly -run 'Test(BuildMetadataClusterConfigIncludesRaftAndOrchestrationEndpoints|GenerateCompleteConfig)$'`
- `SKIP_BUILD=1 ANTFLY_E2E_REGRESSION_WORKERS=3 ANTFLY_E2E_REGRESSION_REPEATS=10 ANTFLY_E2E_PRESERVE_FAILURE_LIMIT=3 scripts/ci/zig-e2e-regression-loop.sh e2e/antfly/test_scaling.py::test_autoscaling_finalizes_shard_split_from_size_threshold` (30/30 passed; split finalization 2.55-5.60 seconds, down from ~63 seconds)
