### PR TITLE
Decode compressed remote content before extraction

### DIFF
--- a/zig/build.zig
+++ b/zig/build.zig
@@ -2503,6 +2503,13 @@ pub fn build(b: *std.Build) void {
     const lib_regex_test_step = b.step("lib-regex-test", "Run standalone lib/regex tests");
     lib_regex_test_step.dependOn(&run_lib_regex_tests.step);
 
+    const lib_scraping_tests = b.addTest(.{
+        .root_module = scraping_mod,
+    });
+    const run_lib_scraping_tests = b.addRunArtifact(lib_scraping_tests);
+    const lib_scraping_test_step = b.step("lib-scraping-test", "Run standalone lib/scraping tests");
+    lib_scraping_test_step.dependOn(&run_lib_scraping_tests.step);
+
     const lib_jsonschema_tests = b.addTest(.{
         .root_module = jsonschema_mod,
     });

--- a/zig/build.zig
+++ b/zig/build.zig
@@ -2804,13 +2804,6 @@ pub fn build(b: *std.Build) void {
     const lib_embeddings_test_step = b.step("lib-embeddings-test", "Run standalone lib/embeddings tests");
     lib_embeddings_test_step.dependOn(&run_lib_embeddings_tests.step);
 
-    const lib_scraping_tests = b.addTest(.{
-        .root_module = scraping_mod,
-    });
-    const run_lib_scraping_tests = b.addRunArtifact(lib_scraping_tests);
-    const lib_scraping_test_step = b.step("lib-scraping-test", "Run standalone lib/scraping tests");
-    lib_scraping_test_step.dependOn(&run_lib_scraping_tests.step);
-
     const lib_vectorindex_tests = b.addTest(.{
         .root_module = vectorindex_mod,
     });

--- a/zig/lib/httpx/src/client/client.zig
+++ b/zig/lib/httpx/src/client/client.zig
@@ -2494,17 +2494,56 @@ pub const Client = struct {
     }
 
     /// RFC 9110 defines `deflate` as a zlib-wrapped stream. Some deployed HTTP
-    /// servers instead send a raw RFC 1951 stream, so recognize a valid RFC 1950
-    /// header and otherwise use the compatibility form.
-    fn deflateContainer(prefix: []const u8) flate.Container {
-        if (prefix.len < 2) return .raw;
+    /// servers instead send a raw RFC 1951 stream. A valid raw stream can begin
+    /// with bytes that also form an RFC 1950 header, so this is only a hint:
+    /// callers must fall back to raw decoding if zlib validation fails.
+    fn hasZlibHeader(prefix: []const u8) bool {
+        if (prefix.len < 2) return false;
         const cmf = prefix[0];
         const flg = prefix[1];
         const header = (@as(u16, cmf) << 8) | flg;
-        const is_deflate = cmf & 0x0f == 8;
-        const valid_window = cmf >> 4 <= 7;
-        const valid_check = header % 31 == 0;
-        return if (is_deflate and valid_window and valid_check) .zlib else .raw;
+        return cmf & 0x0f == 8 and cmf >> 4 <= 7 and header % 31 == 0;
+    }
+
+    fn appendDecompressed(
+        allocator: Allocator,
+        encoded: []const u8,
+        container: flate.Container,
+        output: *std.ArrayListUnmanaged(u8),
+        max_size: usize,
+    ) !void {
+        var encoded_reader: Io.Reader = .fixed(encoded);
+        var decompress_window: [flate.max_window_len]u8 = undefined;
+        var decompressor = flate.Decompress.init(&encoded_reader, container, &decompress_window);
+        var read_buf: [16 * 1024]u8 = undefined;
+
+        while (true) {
+            const n = decompressor.reader.readSliceShort(&read_buf) catch |err| {
+                if (err == error.EndOfStream) break;
+                return error.DecompressionFailed;
+            };
+            if (n == 0) break;
+            _ = try checkedResponseSize(output.items.len, n, max_size);
+            try output.appendSlice(allocator, read_buf[0..n]);
+        }
+    }
+
+    fn appendDeflateDecompressed(
+        allocator: Allocator,
+        encoded: []const u8,
+        output: *std.ArrayListUnmanaged(u8),
+        max_size: usize,
+    ) !void {
+        const original_len = output.items.len;
+        if (hasZlibHeader(encoded)) {
+            appendDecompressed(allocator, encoded, .zlib, output, max_size) catch |err| {
+                output.items.len = original_len;
+                if (err != error.DecompressionFailed) return err;
+                try appendDecompressed(allocator, encoded, .raw, output, max_size);
+            };
+            return;
+        }
+        try appendDecompressed(allocator, encoded, .raw, output, max_size);
     }
 
     /// Builds a Response by streaming the body through an Io.Reader chain.
@@ -2601,22 +2640,20 @@ pub const Client = struct {
                 try compressed.appendSlice(self.allocator, read_buf[0..n]);
             }
 
-            const container: flate.Container = switch (coding) {
-                .gzip => .gzip,
-                .deflate => deflateContainer(compressed.items),
-            };
-            var compressed_reader: Io.Reader = .fixed(compressed.items);
-            var decompress_window: [flate.max_window_len]u8 = undefined;
-            var decompressor = flate.Decompress.init(&compressed_reader, container, &decompress_window);
-
-            while (true) {
-                const n = decompressor.reader.readSliceShort(&read_buf) catch |err| {
-                    if (err == error.EndOfStream) break;
-                    return error.DecompressionFailed;
-                };
-                if (n == 0) break;
-                _ = try checkedResponseSize(result.items.len, n, max_size);
-                try result.appendSlice(self.allocator, read_buf[0..n]);
+            switch (coding) {
+                .gzip => try appendDecompressed(
+                    self.allocator,
+                    compressed.items,
+                    .gzip,
+                    &result,
+                    max_size,
+                ),
+                .deflate => try appendDeflateDecompressed(
+                    self.allocator,
+                    compressed.items,
+                    &result,
+                    max_size,
+                ),
             }
         } else {
             while (true) {
@@ -2739,31 +2776,66 @@ pub const Client = struct {
                 framed_reader,
                 &encoded_prefix_buffer,
             );
-            const container: flate.Container = switch (coding) {
-                .gzip => .gzip,
-                .deflate => deflateContainer(encoded_prefix[0..encoded_prefix_len]),
-            };
-            var decompress_window: [flate.max_window_len]u8 = undefined;
-            var decompressor = flate.Decompress.init(&encoded_reader.reader_iface, container, &decompress_window);
 
-            while (true) {
-                const n = decompressor.reader.readSliceShort(&read_buf) catch |err| {
-                    if (err == error.EndOfStream) break;
-                    if (err == error.ReadFailed and close_delimited_body) break;
-                    return error.DecompressionFailed;
-                };
-                if (n == 0) break;
-                const next_total = try checkedResponseSize(
-                    written_total,
-                    n,
+            if (coding == .deflate and hasZlibHeader(encoded_prefix[0..encoded_prefix_len])) {
+                var encoded = std.ArrayListUnmanaged(u8).empty;
+                defer encoded.deinit(parser.allocator);
+                while (true) {
+                    const n = readSomeOnce(&encoded_reader.reader_iface, &read_buf) catch |err| {
+                        if (err == error.EndOfStream) break;
+                        if (err == error.ReadFailed and close_delimited_body) break;
+                        return error.InvalidResponse;
+                    };
+                    if (n == 0) break;
+                    _ = try checkedResponseSize(encoded.items.len, n, max_response_size);
+                    try encoded.appendSlice(parser.allocator, read_buf[0..n]);
+                }
+
+                var decoded = std.ArrayListUnmanaged(u8).empty;
+                defer decoded.deinit(parser.allocator);
+                try appendDeflateDecompressed(
+                    parser.allocator,
+                    encoded.items,
+                    &decoded,
                     max_response_size,
                 );
-                try writer.writeAll(read_buf[0..n]);
-                written_total = next_total;
+                try writer.writeAll(decoded.items);
+                written_total = decoded.items.len;
                 if (progress_cb) |cb| cb(.{
                     .bytes_written = @intCast(written_total),
                     .total_bytes = null,
                 }, progress_ctx);
+            } else {
+                const container: flate.Container = switch (coding) {
+                    .gzip => .gzip,
+                    .deflate => .raw,
+                };
+                var decompress_window: [flate.max_window_len]u8 = undefined;
+                var decompressor = flate.Decompress.init(
+                    &encoded_reader.reader_iface,
+                    container,
+                    &decompress_window,
+                );
+
+                while (true) {
+                    const n = decompressor.reader.readSliceShort(&read_buf) catch |err| {
+                        if (err == error.EndOfStream) break;
+                        if (err == error.ReadFailed and close_delimited_body) break;
+                        return error.DecompressionFailed;
+                    };
+                    if (n == 0) break;
+                    const next_total = try checkedResponseSize(
+                        written_total,
+                        n,
+                        max_response_size,
+                    );
+                    try writer.writeAll(read_buf[0..n]);
+                    written_total = next_total;
+                    if (progress_cb) |cb| cb(.{
+                        .bytes_written = @intCast(written_total),
+                        .total_bytes = null,
+                    }, progress_ctx);
+                }
             }
         } else {
             while (true) {
@@ -3578,6 +3650,22 @@ test "H2 stream cleanup detaches receiver before resetting a published stream" {
     h2.stream_manager.removeStream(idle.id);
     h2.write_mutex.unlock(std.testing.io);
     allocator.destroy(idle_event);
+}
+
+test "raw deflate fallback handles a valid zlib-looking prefix" {
+    const allocator = std.testing.allocator;
+    var expected: [156]u8 = undefined;
+    for (&expected, 0..) |*byte, i| byte.* = @intCast(i);
+
+    var encoded: [166]u8 = undefined;
+    @memcpy(encoded[0..5], &[_]u8{ 0x78, 0x9c, 0x00, 0x63, 0xff });
+    @memcpy(encoded[5..161], &expected);
+    @memcpy(encoded[161..], &[_]u8{ 0x01, 0x00, 0x00, 0xff, 0xff });
+
+    var decoded = std.ArrayListUnmanaged(u8).empty;
+    defer decoded.deinit(allocator);
+    try Client.appendDeflateDecompressed(allocator, &encoded, &decoded, 1024);
+    try std.testing.expectEqualSlices(u8, &expected, decoded.items);
 }
 
 const test_tls_cert_pem =

--- a/zig/lib/httpx/src/client/client.zig
+++ b/zig/lib/httpx/src/client/client.zig
@@ -2787,7 +2787,7 @@ pub const Client = struct {
             }
         }
 
-        if (container != null) {
+        if (content_coding != null) {
             _ = res.headers.remove(HeaderName.CONTENT_ENCODING);
             _ = res.headers.remove(HeaderName.CONTENT_LENGTH);
         }

--- a/zig/lib/httpx/src/client/client.zig
+++ b/zig/lib/httpx/src/client/client.zig
@@ -2480,6 +2480,32 @@ pub const Client = struct {
         var iov = [_][]u8{buf};
         return reader.readVec(&iov);
     }
+    const ResponseContentCoding = enum {
+        gzip,
+        deflate,
+    };
+
+    fn responseContentCoding(headers: *const Headers) ?ResponseContentCoding {
+        const raw_value = headers.get(HeaderName.CONTENT_ENCODING) orelse return null;
+        const value = std.mem.trim(u8, raw_value, " \t");
+        if (std.ascii.eqlIgnoreCase(value, "gzip") or std.ascii.eqlIgnoreCase(value, "x-gzip")) return .gzip;
+        if (std.ascii.eqlIgnoreCase(value, "deflate")) return .deflate;
+        return null;
+    }
+
+    /// RFC 9110 defines `deflate` as a zlib-wrapped stream. Some deployed HTTP
+    /// servers instead send a raw RFC 1951 stream, so recognize a valid RFC 1950
+    /// header and otherwise use the compatibility form.
+    fn deflateContainer(prefix: []const u8) flate.Container {
+        if (prefix.len < 2) return .raw;
+        const cmf = prefix[0];
+        const flg = prefix[1];
+        const header = (@as(u16, cmf) << 8) | flg;
+        const is_deflate = cmf & 0x0f == 8;
+        const valid_window = cmf >> 4 <= 7;
+        const valid_check = header % 31 == 0;
+        return if (is_deflate and valid_window and valid_check) .zlib else .raw;
+    }
 
     /// Builds a Response by streaming the body through an Io.Reader chain.
     /// After headers are parsed, the chain is: leftover bytes → network → framing → decompress → output.
@@ -2506,13 +2532,7 @@ pub const Client = struct {
             (parser.chunked or (parser.content_length orelse 1) > 0);
         if (!has_body) return res;
 
-        // Detect Content-Encoding for transparent decompression.
-        const container: ?flate.Container = if (res.headers.get(HeaderName.CONTENT_ENCODING)) |raw_enc| blk: {
-            const enc = std.mem.trim(u8, raw_enc, " \t");
-            if (std.ascii.eqlIgnoreCase(enc, "gzip")) break :blk .gzip;
-            if (std.ascii.eqlIgnoreCase(enc, "deflate")) break :blk .raw;
-            break :blk null;
-        } else null;
+        const content_coding = responseContentCoding(&res.headers);
 
         // --- Build the Io.Reader chain (all stack-allocated) ---
 
@@ -2555,7 +2575,7 @@ pub const Client = struct {
         const max_size = max_response_size;
 
         // Pre-allocate hint: use content_length if known (and not compressed).
-        if (container == null) {
+        if (content_coding == null) {
             if (parser.content_length) |len| {
                 if (len > max_size) return error.ResponseTooLarge;
                 if (len <= std.math.maxInt(usize)) {
@@ -2566,7 +2586,7 @@ pub const Client = struct {
 
         var read_buf: [16 * 1024]u8 = undefined;
 
-        if (container) |ctr| {
+        if (content_coding) |coding| {
             var compressed = std.ArrayListUnmanaged(u8).empty;
             defer compressed.deinit(self.allocator);
 
@@ -2581,9 +2601,13 @@ pub const Client = struct {
                 try compressed.appendSlice(self.allocator, read_buf[0..n]);
             }
 
+            const container: flate.Container = switch (coding) {
+                .gzip => .gzip,
+                .deflate => deflateContainer(compressed.items),
+            };
             var compressed_reader: Io.Reader = .fixed(compressed.items);
             var decompress_window: [flate.max_window_len]u8 = undefined;
-            var decompressor = flate.Decompress.init(&compressed_reader, ctr, &decompress_window);
+            var decompressor = flate.Decompress.init(&compressed_reader, container, &decompress_window);
 
             while (true) {
                 const n = decompressor.reader.readSliceShort(&read_buf) catch |err| {
@@ -2613,7 +2637,7 @@ pub const Client = struct {
         }
 
         // Remove encoding/length headers when decompression was applied.
-        if (container != null) {
+        if (content_coding != null) {
             _ = res.headers.remove(HeaderName.CONTENT_ENCODING);
             _ = res.headers.remove(HeaderName.CONTENT_LENGTH);
         }
@@ -2644,12 +2668,7 @@ pub const Client = struct {
             (parser.chunked or (parser.content_length orelse 1) > 0);
         if (!has_body) return res;
 
-        const container: ?flate.Container = if (res.headers.get(HeaderName.CONTENT_ENCODING)) |raw_enc| blk: {
-            const enc = std.mem.trim(u8, raw_enc, " \t");
-            if (std.ascii.eqlIgnoreCase(enc, "gzip")) break :blk .gzip;
-            if (std.ascii.eqlIgnoreCase(enc, "deflate")) break :blk .raw;
-            break :blk null;
-        } else null;
+        const content_coding = responseContentCoding(&res.headers);
 
         var source_io_buf: [8192]u8 = undefined;
         var socket_reader: SocketIoReader = undefined;
@@ -2673,7 +2692,7 @@ pub const Client = struct {
             break :blk &chunked_reader.reader_iface;
         } else if (parser.content_length) |len| blk: {
             if (len > std.math.maxInt(usize)) return error.ResponseTooLarge;
-            if (container == null and len > max_response_size) return error.ResponseTooLarge;
+            if (content_coding == null and len > max_response_size) return error.ResponseTooLarge;
             cl_reader = ContentLengthReader.init(body_source, @intCast(len), &cl_buf);
             break :blk &cl_reader.reader_iface;
         } else blk: {
@@ -2682,7 +2701,7 @@ pub const Client = struct {
 
         const close_delimited_body = !parser.chunked and parser.content_length == null;
         const is_redirect = code >= 300 and code < 400;
-        const progress_total = if (container == null and !parser.chunked) parser.content_length else null;
+        const progress_total = if (content_coding == null and !parser.chunked) parser.content_length else null;
         var written_total: usize = 0;
 
         var read_buf: [16 * 1024]u8 = undefined;
@@ -2701,9 +2720,31 @@ pub const Client = struct {
                     max_response_size,
                 );
             }
-        } else if (container) |ctr| {
+        } else if (content_coding) |coding| {
+            var encoded_prefix: [2]u8 = undefined;
+            var encoded_prefix_len: usize = 0;
+            while (encoded_prefix_len < encoded_prefix.len) {
+                const n = readSomeOnce(framed_reader, encoded_prefix[encoded_prefix_len..]) catch |err| {
+                    if (err == error.EndOfStream) break;
+                    if (err == error.ReadFailed and close_delimited_body) break;
+                    return error.InvalidResponse;
+                };
+                if (n == 0) break;
+                encoded_prefix_len += n;
+            }
+
+            var encoded_prefix_buffer: [8192]u8 = undefined;
+            var encoded_reader = PrefixedReader.init(
+                encoded_prefix[0..encoded_prefix_len],
+                framed_reader,
+                &encoded_prefix_buffer,
+            );
+            const container: flate.Container = switch (coding) {
+                .gzip => .gzip,
+                .deflate => deflateContainer(encoded_prefix[0..encoded_prefix_len]),
+            };
             var decompress_window: [flate.max_window_len]u8 = undefined;
-            var decompressor = flate.Decompress.init(framed_reader, ctr, &decompress_window);
+            var decompressor = flate.Decompress.init(&encoded_reader.reader_iface, container, &decompress_window);
 
             while (true) {
                 const n = decompressor.reader.readSliceShort(&read_buf) catch |err| {
@@ -3628,16 +3669,30 @@ const python_tls_server_script =
     "            continue\n" ++
     "listener.close()\n";
 
-const python_tls_chunked_gzip_server_script =
+const python_tls_chunked_compressed_server_script =
     "import gzip\n" ++
     "import socket\n" ++
     "import ssl\n" ++
     "import sys\n" ++
+    "import zlib\n" ++
     "\n" ++
     "port = int(sys.argv[1])\n" ++
     "cert = sys.argv[2]\n" ++
     "key = sys.argv[3]\n" ++
-    "payload = gzip.compress(b'{\"ok\":true}\\n')\n" ++
+    "mode = sys.argv[4]\n" ++
+    "body = b'{\"ok\":true}\\n'\n" ++
+    "if mode == 'gzip':\n" ++
+    "    payload = gzip.compress(body)\n" ++
+    "    content_encoding = b'GZip'\n" ++
+    "elif mode == 'deflate-zlib':\n" ++
+    "    payload = zlib.compress(body)\n" ++
+    "    content_encoding = b'deflate'\n" ++
+    "elif mode == 'deflate-raw':\n" ++
+    "    compressor = zlib.compressobj(wbits=-zlib.MAX_WBITS)\n" ++
+    "    payload = compressor.compress(body) + compressor.flush()\n" ++
+    "    content_encoding = b'deflate'\n" ++
+    "else:\n" ++
+    "    raise ValueError('unknown compression mode: ' + mode)\n" ++
     "listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)\n" ++
     "listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)\n" ++
     "listener.bind(('127.0.0.1', port))\n" ++
@@ -3661,7 +3716,7 @@ const python_tls_chunked_gzip_server_script =
     "                    b'HTTP/1.1 200 OK\\r\\n'\n" ++
     "                    b'Content-Type: application/json\\r\\n'\n" ++
     "                    b'Transfer-Encoding: chunked\\r\\n'\n" ++
-    "                    b'Content-Encoding: gzip\\r\\n'\n" ++
+    "                    b'Content-Encoding: ' + content_encoding + b'\\r\\n'\n" ++
     "                    b'Connection: close\\r\\n\\r\\n'\n" ++
     "                )\n" ++
     "                tls_conn.sendall(format(len(payload), 'x').encode() + b'\\r\\n')\n" ++
@@ -4049,7 +4104,7 @@ test "HTTPS client round trip via local TLS server" {
     try std.testing.expect(std.mem.indexOf(u8, request, "Connection: close\r\n") != null);
 }
 
-test "HTTPS client handles chunked gzip body via local TLS server" {
+fn expectChunkedCompressedResponse(mode: []const u8, to_writer: bool) !void {
     const allocator = std.testing.allocator;
     const io = std.testing.io;
 
@@ -4059,7 +4114,7 @@ test "HTTPS client handles chunked gzip body via local TLS server" {
     defer tmp.cleanup();
     try tmp.dir.writeFile(io, .{ .sub_path = "cert.pem", .data = test_tls_cert_pem });
     try tmp.dir.writeFile(io, .{ .sub_path = "key.pem", .data = test_tls_key_pem });
-    try tmp.dir.writeFile(io, .{ .sub_path = "server.py", .data = python_tls_chunked_gzip_server_script });
+    try tmp.dir.writeFile(io, .{ .sub_path = "server.py", .data = python_tls_chunked_compressed_server_script });
 
     var port_buf: [16]u8 = undefined;
     const port_arg = try std.fmt.bufPrint(&port_buf, "{d}", .{port});
@@ -4071,6 +4126,7 @@ test "HTTPS client handles chunked gzip body via local TLS server" {
             port_arg,
             "cert.pem",
             "key.pem",
+            mode,
         },
         .cwd = .{ .dir = tmp.dir },
         .stdin = .ignore,
@@ -4095,67 +4151,36 @@ test "HTTPS client handles chunked gzip body via local TLS server" {
     });
     defer client.deinit();
 
-    var resp = try getWithRetry(&client, io, url, 50);
-    defer resp.deinit();
+    if (to_writer) {
+        var out = std.ArrayListUnmanaged(u8).empty;
+        defer out.deinit(allocator);
+        var resp = try client.getToWriter(url, .{}, arrayListWriter(&out, allocator), null, null);
+        defer resp.deinit();
 
-    try std.testing.expectEqual(@as(u16, 200), resp.status.code);
-    try std.testing.expectEqualStrings("{\"ok\":true}\n", resp.body orelse "");
+        try std.testing.expectEqual(@as(u16, 200), resp.status.code);
+        try std.testing.expect(resp.body == null);
+        try std.testing.expectEqualStrings("{\"ok\":true}\n", out.items);
+    } else {
+        var resp = try getWithRetry(&client, io, url, 50);
+        defer resp.deinit();
+
+        try std.testing.expectEqual(@as(u16, 200), resp.status.code);
+        try std.testing.expectEqualStrings("{\"ok\":true}\n", resp.body orelse "");
+        try std.testing.expect(resp.headers.get(HeaderName.CONTENT_ENCODING) == null);
+        try std.testing.expect(resp.headers.get(HeaderName.CONTENT_LENGTH) == null);
+    }
 }
 
-test "HTTPS client streams chunked gzip body to writer via local TLS server" {
-    const allocator = std.testing.allocator;
-    const io = std.testing.io;
+test "HTTPS client handles supported chunked content encodings" {
+    for ([_][]const u8{ "gzip", "deflate-zlib", "deflate-raw" }) |mode| {
+        try expectChunkedCompressedResponse(mode, false);
+    }
+}
 
-    const port = try reserveEphemeralPort(io);
-
-    var tmp = std.testing.tmpDir(.{});
-    defer tmp.cleanup();
-    try tmp.dir.writeFile(io, .{ .sub_path = "cert.pem", .data = test_tls_cert_pem });
-    try tmp.dir.writeFile(io, .{ .sub_path = "key.pem", .data = test_tls_key_pem });
-    try tmp.dir.writeFile(io, .{ .sub_path = "server.py", .data = python_tls_chunked_gzip_server_script });
-
-    var port_buf: [16]u8 = undefined;
-    const port_arg = try std.fmt.bufPrint(&port_buf, "{d}", .{port});
-
-    var child = std.process.spawn(io, .{
-        .argv = &.{
-            "python3",
-            "server.py",
-            port_arg,
-            "cert.pem",
-            "key.pem",
-        },
-        .cwd = .{ .dir = tmp.dir },
-        .stdin = .ignore,
-        .stdout = .inherit,
-        .stderr = .inherit,
-    }) catch |err| switch (err) {
-        error.FileNotFound => return,
-        else => return err,
-    };
-    defer child.kill(io);
-
-    io.sleep(Io.Duration.fromMilliseconds(1000), .awake) catch {};
-
-    const url = try std.fmt.allocPrint(allocator, "https://127.0.0.1:{d}/", .{port});
-    defer allocator.free(url);
-
-    var client = Client.initWithConfig(allocator, io, .{
-        .keep_alive = false,
-        .verify_ssl = false,
-        .retry_policy = .{ .max_retries = 0 },
-        .timeouts = .{ .request_ms = 2_000, .read_ms = 2_000, .write_ms = 2_000 },
-    });
-    defer client.deinit();
-
-    var out = std.ArrayListUnmanaged(u8).empty;
-    defer out.deinit(allocator);
-    var resp = try client.getToWriter(url, .{}, arrayListWriter(&out, allocator), null, null);
-    defer resp.deinit();
-
-    try std.testing.expectEqual(@as(u16, 200), resp.status.code);
-    try std.testing.expect(resp.body == null);
-    try std.testing.expectEqualStrings("{\"ok\":true}\n", out.items);
+test "HTTPS client streams supported chunked content encodings to writer" {
+    for ([_][]const u8{ "gzip", "deflate-zlib", "deflate-raw" }) |mode| {
+        try expectChunkedCompressedResponse(mode, true);
+    }
 }
 
 test "requestToWriter follows redirects without streaming intermediate redirect body" {

--- a/zig/lib/httpx/src/net/socket.zig
+++ b/zig/lib/httpx/src/net/socket.zig
@@ -675,20 +675,24 @@ pub const PrefixedReader = struct {
 
     fn readVec(r: *Io.Reader, bufs: [][]u8) Io.Reader.Error!usize {
         const p = parent(r);
-        const entry = firstNonEmptyBuffer(bufs) orelse return 0;
-        const buf = entry.buf;
+        var iovecs_buffer: [8][]u8 = undefined;
+        const dest_n, const data_size = try r.writableVector(&iovecs_buffer, bufs);
+        const dest = iovecs_buffer[0..dest_n];
+        const entry = firstNonEmptyBuffer(dest) orelse return 0;
 
-        // Drain prefix first.
         const remaining = p.prefix[p.prefix_pos..];
-        if (remaining.len > 0) {
-            const n = @min(buf.len, remaining.len);
-            @memcpy(buf[0..n], remaining[0..n]);
-            p.prefix_pos += n;
-            return n;
-        }
+        const n = if (remaining.len > 0) blk: {
+            const prefix_n = @min(entry.buf.len, remaining.len);
+            @memcpy(entry.buf[0..prefix_n], remaining[0..prefix_n]);
+            p.prefix_pos += prefix_n;
+            break :blk prefix_n;
+        } else try readVecOnce(p.inner, entry.buf);
 
-        // Prefix exhausted — delegate to inner reader.
-        return readVecOnce(p.inner, buf);
+        if (n > data_size) {
+            r.end += n - data_size;
+            return data_size;
+        }
+        return n;
     }
 
     const vtable = IoReaderHelpers.makeVTable(readVec);

--- a/zig/lib/scraping/src/mod.zig
+++ b/zig/lib/scraping/src/mod.zig
@@ -1928,7 +1928,10 @@ fn downloadTestHttpResponseAlloc(
 
     const uri = try std.fmt.allocPrint(alloc, "http://{f}/blob", .{server.socket.address});
     defer alloc.free(uri);
-    var security = ContentSecurityConfig{ .max_download_size_bytes = max_download_size_bytes };
+    var security = ContentSecurityConfig{
+        .block_private_ips = false,
+        .max_download_size_bytes = max_download_size_bytes,
+    };
     var downloaded = downloadContentAlloc(alloc, uri, &security, null) catch |err| {
         thread.join();
         if (fixture.failure) |server_err| return server_err;

--- a/zig/lib/scraping/src/mod.zig
+++ b/zig/lib/scraping/src/mod.zig
@@ -1916,7 +1916,8 @@ fn downloadTestHttpResponseAlloc(
 
     const listen_addr = try std.Io.net.IpAddress.parse("127.0.0.1", 0);
     var server = try listen_addr.listen(io, .{});
-    defer server.deinit(io);
+    var server_open = true;
+    defer if (server_open) server.deinit(io);
 
     var fixture = TestHttpResponseServer{
         .io = io,
@@ -1933,8 +1934,9 @@ fn downloadTestHttpResponseAlloc(
         .max_download_size_bytes = max_download_size_bytes,
     };
     var downloaded = downloadContentAlloc(alloc, uri, &security, null) catch |err| {
+        server.deinit(io);
+        server_open = false;
         thread.join();
-        if (fixture.failure) |server_err| return server_err;
         return err;
     };
     thread.join();

--- a/zig/lib/scraping/src/mod.zig
+++ b/zig/lib/scraping/src/mod.zig
@@ -1859,3 +1859,118 @@ test "HTTP response body ownership transfers without a copy" {
     try std.testing.expectEqual(original, taken.ptr);
     try std.testing.expect(response.body == null);
 }
+
+const TestHttpResponseServer = struct {
+    io: std.Io,
+    server: *std.Io.net.Server,
+    body: []const u8,
+    content_encoding: ?[]const u8,
+    failure: ?anyerror = null,
+
+    fn serve(self: *@This()) void {
+        var stream = self.server.accept(self.io) catch |err| {
+            self.failure = err;
+            return;
+        };
+        defer stream.close(self.io);
+
+        var write_buffer: [1024]u8 = undefined;
+        var writer = stream.writer(self.io, &write_buffer);
+        writer.interface.writeAll(
+            "HTTP/1.1 200 OK\r\n" ++
+                "Content-Type: text/plain; charset=utf-8\r\n" ++
+                "Connection: close\r\n",
+        ) catch |err| {
+            self.failure = err;
+            return;
+        };
+        if (self.content_encoding) |encoding| {
+            writer.interface.print("Content-Encoding: {s}\r\n", .{encoding}) catch |err| {
+                self.failure = err;
+                return;
+            };
+        }
+        writer.interface.print("Content-Length: {d}\r\n\r\n", .{self.body.len}) catch |err| {
+            self.failure = err;
+            return;
+        };
+        writer.interface.writeAll(self.body) catch |err| {
+            self.failure = err;
+            return;
+        };
+        writer.interface.flush() catch |err| {
+            self.failure = err;
+        };
+    }
+};
+
+fn downloadTestHttpResponseAlloc(
+    alloc: Allocator,
+    body: []const u8,
+    content_encoding: ?[]const u8,
+    max_download_size_bytes: u64,
+) !DownloadedContent {
+    var io_impl = std.Io.Threaded.init(alloc, .{});
+    defer io_impl.deinit();
+    const io = io_impl.io();
+
+    const listen_addr = try std.Io.net.IpAddress.parse("127.0.0.1", 0);
+    var server = try listen_addr.listen(io, .{});
+    defer server.deinit(io);
+
+    var fixture = TestHttpResponseServer{
+        .io = io,
+        .server = &server,
+        .body = body,
+        .content_encoding = content_encoding,
+    };
+    const thread = try std.Thread.spawn(.{}, TestHttpResponseServer.serve, .{&fixture});
+
+    const uri = try std.fmt.allocPrint(alloc, "http://{f}/blob", .{server.socket.address});
+    defer alloc.free(uri);
+    var security = ContentSecurityConfig{ .max_download_size_bytes = max_download_size_bytes };
+    var downloaded = downloadContentAlloc(alloc, uri, &security, null) catch |err| {
+        thread.join();
+        if (fixture.failure) |server_err| return server_err;
+        return err;
+    };
+    thread.join();
+    if (fixture.failure) |server_err| {
+        downloaded.deinit(alloc);
+        return server_err;
+    }
+    return downloaded;
+}
+
+test "HTTP download returns identical decoded bytes for supported content encodings" {
+    const alloc = std.testing.allocator;
+    const expected = "GitHub compressed content stays readable.\n";
+    const gzip = [_]u8{ 31, 139, 8, 0, 0, 0, 0, 0, 2, 255, 115, 207, 44, 241, 40, 77, 82, 72, 206, 207, 45, 40, 74, 45, 46, 78, 77, 1, 50, 243, 74, 82, 243, 74, 20, 138, 75, 18, 43, 139, 21, 138, 82, 19, 83, 18, 147, 114, 82, 245, 184, 0, 187, 214, 11, 13, 42, 0, 0, 0 };
+    const deflate = [_]u8{ 120, 156, 115, 207, 44, 241, 40, 77, 82, 72, 206, 207, 45, 40, 74, 45, 46, 78, 77, 1, 50, 243, 74, 82, 243, 74, 20, 138, 75, 18, 43, 139, 21, 138, 82, 19, 83, 18, 147, 114, 82, 245, 184, 0, 87, 78, 15, 144 };
+    const deflate_raw = deflate[2 .. deflate.len - 4];
+    const cases = [_]struct {
+        encoding: ?[]const u8,
+        body: []const u8,
+    }{
+        .{ .encoding = null, .body = expected },
+        .{ .encoding = "gzip", .body = &gzip },
+        .{ .encoding = "deflate", .body = &deflate },
+        .{ .encoding = "deflate", .body = deflate_raw },
+    };
+
+    for (cases) |case| {
+        var downloaded = try downloadTestHttpResponseAlloc(alloc, case.body, case.encoding, 1024);
+        defer downloaded.deinit(alloc);
+        try std.testing.expectEqualStrings("text/plain", downloaded.content_type);
+        try std.testing.expectEqualStrings(expected, downloaded.data);
+    }
+}
+
+test "HTTP download enforces its size limit on decoded bytes" {
+    const alloc = std.testing.allocator;
+    const gzip = [_]u8{ 31, 139, 8, 0, 0, 0, 0, 0, 2, 255, 115, 207, 44, 241, 40, 77, 82, 72, 206, 207, 45, 40, 74, 45, 46, 78, 77, 1, 50, 243, 74, 82, 243, 74, 20, 138, 75, 18, 43, 139, 21, 138, 82, 19, 83, 18, 147, 114, 82, 245, 184, 0, 187, 214, 11, 13, 42, 0, 0, 0 };
+    try std.testing.expectError(
+        error.StreamTooLong,
+        downloadTestHttpResponseAlloc(alloc, &gzip, "gzip", 41),
+    );
+}


### PR DESCRIPTION
> ## Summary
> - decode gzip and deflate HTTP response bodies before returning downloaded content
> - treat standards-compliant zlib-wrapped `deflate` as the primary form while retaining raw-deflate compatibility
> - decode percent-encoded `data:` URLs and enforce download limits on decoded bytes
> - cover gzip, zlib-wrapped deflate, and raw deflate through buffered and writer HTTP paths
> - add a focused scraping test target and downloader regressions
> 
> ## Why
> Remote text sources can be served with `Content-Encoding: gzip` or `deflate`. Passing those encoded bytes into extraction produces UTF-8 replacement characters and corrupts full-text and embedding indexes.
> 
> ## Verification
> - `zig fmt zig/lib/httpx/src/client/client.zig zig/lib/scraping/src/mod.zig zig/build.zig`
> - `zig build lib-scraping-test` passed before the follow-up deflate compatibility expansion
> - Draft CI is the compile/test gate for the final zlib/raw compatibility changes; a new local Zig build was intentionally not started because this checkout documents that local Antfly Zig builds may OOM.
> 
> Piledriver report: `.piledriver/compressed-chunks/report.md` in the Colony investigation workspace.