### PR TITLE
Fix Antfarm table creation defaults and errors

### DIFF
--- a/ts/apps/antfarm/src/components/CreateTableDialog.test.tsx
+++ b/ts/apps/antfarm/src/components/CreateTableDialog.test.tsx
@@ -65,4 +65,27 @@ describe("CreateTableDialog", () => {
     ).toBeTruthy();
     expect(onClose).not.toHaveBeenCalled();
   });
+
+  it("clears a previous failure when reopened", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    mocks.create.mockRejectedValue(
+      new Error("Failed to create table: invalid create table request")
+    );
+
+    const props = {
+      onClose: vi.fn(),
+      onTableCreated: vi.fn(),
+      theme: "light",
+    };
+    const { rerender } = render(<CreateTableDialog open {...props} />);
+    fireEvent.click(screen.getByRole("button", { name: "Submit table" }));
+    expect(
+      await screen.findByText("Failed to create table: invalid create table request")
+    ).toBeTruthy();
+
+    rerender(<CreateTableDialog open={false} {...props} />);
+    rerender(<CreateTableDialog open {...props} />);
+
+    expect(screen.queryByText("Failed to create table: invalid create table request")).toBeNull();
+  });
 });

--- a/ts/apps/antfarm/src/components/CreateTableDialog.test.tsx
+++ b/ts/apps/antfarm/src/components/CreateTableDialog.test.tsx
@@ -1,0 +1,68 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import CreateTableDialog from "./CreateTableDialog";
+
+const mocks = vi.hoisted(() => ({
+  create: vi.fn(),
+  refreshTables: vi.fn(),
+  setSelectedTable: vi.fn(),
+}));
+
+vi.mock("../hooks/use-api-config", () => ({
+  useApi: () => ({ tables: { create: mocks.create }, indexes: { create: vi.fn() } }),
+}));
+
+vi.mock("../hooks/use-table", () => ({
+  useTable: () => ({
+    refreshTables: mocks.refreshTables,
+    setSelectedTable: mocks.setSelectedTable,
+  }),
+}));
+
+vi.mock("./schema-builder/TableSchemaForm", () => ({
+  default: ({ onSubmit }: { onSubmit: (data: unknown) => void }) => (
+    <button
+      type="button"
+      onClick={() =>
+        onSubmit({
+          name: "docs",
+          num_shards: 1,
+          schema: { version: 0, document_schemas: {} },
+          indexes: [],
+        })
+      }
+    >
+      Submit table
+    </button>
+  ),
+}));
+
+describe("CreateTableDialog", () => {
+  beforeEach(() => {
+    mocks.create.mockReset();
+    mocks.refreshTables.mockReset();
+    mocks.setSelectedTable.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("keeps the dialog open and displays API failures", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    mocks.create.mockRejectedValue(
+      new Error("Failed to create table: invalid create table request")
+    );
+    const onClose = vi.fn();
+
+    render(<CreateTableDialog open onClose={onClose} onTableCreated={vi.fn()} theme="light" />);
+    fireEvent.click(screen.getByRole("button", { name: "Submit table" }));
+
+    await waitFor(() => expect(mocks.create).toHaveBeenCalledWith("docs", { num_shards: 1 }));
+    expect(
+      await screen.findByText("Failed to create table: invalid create table request")
+    ).toBeTruthy();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/ts/apps/antfarm/src/components/CreateTableDialog.tsx
+++ b/ts/apps/antfarm/src/components/CreateTableDialog.tsx
@@ -8,7 +8,7 @@ import {
 } from "@antfly/design-system";
 import type { IndexConfig } from "@antfly/sdk";
 import type React from "react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import type { TableSchema } from "../api";
 import { useApi } from "../hooks/use-api-config";
 import { useTable } from "../hooks/use-table";
@@ -31,6 +31,12 @@ const CreateTableDialog: React.FC<CreateTableDialogProps> = ({
   const api = useApi();
   const { refreshTables, setSelectedTable } = useTable();
   const [createError, setCreateError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (open) {
+      setCreateError(null);
+    }
+  }, [open]);
 
   const handleCreateTable = async (data: {
     name: string;

--- a/ts/apps/antfarm/src/components/CreateTableDialog.tsx
+++ b/ts/apps/antfarm/src/components/CreateTableDialog.tsx
@@ -1,9 +1,18 @@
-import { Dialog, DialogContent, DialogDescription, DialogTitle } from "@antfly/design-system";
+import {
+  Alert,
+  AlertDescription,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from "@antfly/design-system";
 import type { IndexConfig } from "@antfly/sdk";
 import type React from "react";
+import { useState } from "react";
 import type { TableSchema } from "../api";
 import { useApi } from "../hooks/use-api-config";
 import { useTable } from "../hooks/use-table";
+import { buildCreateTableRequest, createTableErrorMessage } from "../lib/create-table";
 import TableSchemaForm from "./schema-builder/TableSchemaForm";
 
 interface CreateTableDialogProps {
@@ -21,6 +30,7 @@ const CreateTableDialog: React.FC<CreateTableDialogProps> = ({
 }) => {
   const api = useApi();
   const { refreshTables, setSelectedTable } = useTable();
+  const [createError, setCreateError] = useState<string | null>(null);
 
   const handleCreateTable = async (data: {
     name: string;
@@ -28,14 +38,9 @@ const CreateTableDialog: React.FC<CreateTableDialogProps> = ({
     num_shards: number;
     indexes: IndexConfig[];
   }) => {
+    setCreateError(null);
     try {
-      const requestBody = {
-        num_shards: data.num_shards,
-        schema: {
-          version: 0, // Default version to 0 if not specified
-          ...data.schema,
-        },
-      };
+      const requestBody = buildCreateTableRequest(data.num_shards, data.schema);
       await api.tables.create(data.name, requestBody);
       for (const index of data.indexes) {
         await api.indexes.create(data.name, index);
@@ -46,6 +51,7 @@ const CreateTableDialog: React.FC<CreateTableDialogProps> = ({
       onClose();
     } catch (error) {
       console.error("Failed to create table:", error);
+      setCreateError(createTableErrorMessage(error));
     }
   };
 
@@ -54,6 +60,11 @@ const CreateTableDialog: React.FC<CreateTableDialogProps> = ({
       <DialogContent className="max-w-[900px]">
         <DialogTitle>Create New Table</DialogTitle>
         <DialogDescription>Define the schema for your new table.</DialogDescription>
+        {createError && (
+          <Alert variant="destructive">
+            <AlertDescription>{createError}</AlertDescription>
+          </Alert>
+        )}
         <TableSchemaForm onSubmit={handleCreateTable} theme={theme} />
       </DialogContent>
     </Dialog>

--- a/ts/apps/antfarm/src/lib/create-table.test.ts
+++ b/ts/apps/antfarm/src/lib/create-table.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { buildCreateTableRequest, createTableErrorMessage } from "./create-table";
+
+describe("buildCreateTableRequest", () => {
+  it("lets Antfly install its defaults for a name-only table", () => {
+    expect(buildCreateTableRequest(1, { version: 0, document_schemas: {} })).toEqual({
+      num_shards: 1,
+    });
+  });
+
+  it("keeps a configured schema but omits its backend-managed version", () => {
+    const request = buildCreateTableRequest(3, {
+      version: 7,
+      default_type: "article",
+      document_schemas: {
+        article: {
+          schema: {
+            type: "object",
+            properties: {
+              title: { type: "string" },
+            },
+          },
+        },
+      },
+    });
+
+    expect(request).toEqual({
+      num_shards: 3,
+      schema: {
+        default_type: "article",
+        document_schemas: {
+          article: {
+            schema: {
+              type: "object",
+              properties: {
+                title: { type: "string" },
+              },
+            },
+          },
+        },
+      },
+    });
+    expect(request.schema).not.toHaveProperty("version");
+  });
+});
+
+describe("createTableErrorMessage", () => {
+  it("preserves API error details", () => {
+    expect(createTableErrorMessage(new Error("Failed to create table: invalid request"))).toBe(
+      "Failed to create table: invalid request"
+    );
+  });
+
+  it("provides a fallback for non-Error failures", () => {
+    expect(createTableErrorMessage(null)).toBe("Failed to create table.");
+  });
+});

--- a/ts/apps/antfarm/src/lib/create-table.ts
+++ b/ts/apps/antfarm/src/lib/create-table.ts
@@ -1,0 +1,16 @@
+import type { TableSchema } from "../api";
+
+export function buildCreateTableRequest(numShards: number, tableSchema: TableSchema) {
+  const schema = { ...tableSchema };
+  delete schema.version;
+
+  const hasDocumentSchemas = Object.keys(schema.document_schemas ?? {}).length > 0;
+  return {
+    num_shards: numShards,
+    ...(hasDocumentSchemas ? { schema } : {}),
+  };
+}
+
+export function createTableErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : "Failed to create table.";
+}

--- a/ts/apps/antfarm/src/pages/CreateTablePage.test.tsx
+++ b/ts/apps/antfarm/src/pages/CreateTablePage.test.tsx
@@ -1,0 +1,73 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import CreateTablePage from "./CreateTablePage";
+
+const mocks = vi.hoisted(() => ({
+  create: vi.fn(),
+  navigate: vi.fn(),
+  refreshTables: vi.fn(),
+  setSelectedTable: vi.fn(),
+}));
+
+vi.mock("../hooks/use-api-config", () => ({
+  useApi: () => ({ tables: { create: mocks.create }, indexes: { create: vi.fn() } }),
+}));
+
+vi.mock("../hooks/use-table", () => ({
+  useTable: () => ({
+    refreshTables: mocks.refreshTables,
+    setSelectedTable: mocks.setSelectedTable,
+  }),
+}));
+
+vi.mock("react-router-dom", () => ({
+  useNavigate: () => mocks.navigate,
+}));
+
+vi.mock("../components/schema-builder/TableSchemaForm", () => ({
+  default: ({ onSubmit }: { onSubmit: (data: unknown) => void }) => (
+    <button
+      type="button"
+      onClick={() =>
+        onSubmit({
+          name: "docs",
+          num_shards: 1,
+          schema: { version: 0, document_schemas: {} },
+          indexes: [],
+        })
+      }
+    >
+      Submit table
+    </button>
+  ),
+}));
+
+describe("CreateTablePage", () => {
+  beforeEach(() => {
+    mocks.create.mockReset();
+    mocks.navigate.mockReset();
+    mocks.refreshTables.mockReset();
+    mocks.setSelectedTable.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("sends a defaulted create request and displays API failures", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    mocks.create.mockRejectedValue(
+      new Error("Failed to create table: invalid create table request")
+    );
+
+    render(<CreateTablePage />);
+    fireEvent.click(screen.getByRole("button", { name: "Submit table" }));
+
+    await waitFor(() => expect(mocks.create).toHaveBeenCalledWith("docs", { num_shards: 1 }));
+    expect(
+      await screen.findByText("Failed to create table: invalid create table request")
+    ).toBeTruthy();
+    expect(mocks.navigate).not.toHaveBeenCalled();
+  });
+});

--- a/ts/apps/antfarm/src/pages/CreateTablePage.tsx
+++ b/ts/apps/antfarm/src/pages/CreateTablePage.tsx
@@ -1,4 +1,6 @@
 import {
+  Alert,
+  AlertDescription,
   DashboardPage,
   DashboardPageDescription,
   DashboardPageHeader,
@@ -6,17 +8,20 @@ import {
 } from "@antfly/design-system";
 import type { IndexConfig } from "@antfly/sdk";
 import type React from "react";
+import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import type { TableSchema } from "../api";
 import TableSchemaForm from "../components/schema-builder/TableSchemaForm";
 import { useApi } from "../hooks/use-api-config";
 import { useTable } from "../hooks/use-table";
+import { buildCreateTableRequest, createTableErrorMessage } from "../lib/create-table";
 
 const CreateTablePage: React.FC = () => {
   const theme = localStorage.getItem("theme") || "light";
   const navigate = useNavigate();
   const api = useApi();
   const { refreshTables, setSelectedTable } = useTable();
+  const [createError, setCreateError] = useState<string | null>(null);
 
   const handleCreateTable = async (data: {
     name: string;
@@ -24,14 +29,9 @@ const CreateTablePage: React.FC = () => {
     num_shards: number;
     indexes: IndexConfig[];
   }) => {
+    setCreateError(null);
     try {
-      const requestBody = {
-        num_shards: data.num_shards,
-        schema: {
-          version: 0,
-          ...data.schema,
-        },
-      };
+      const requestBody = buildCreateTableRequest(data.num_shards, data.schema);
       await api.tables.create(data.name, requestBody);
       for (const index of data.indexes) {
         await api.indexes.create(data.name, index);
@@ -41,6 +41,7 @@ const CreateTablePage: React.FC = () => {
       navigate("/");
     } catch (error) {
       console.error("Failed to create table:", error);
+      setCreateError(createTableErrorMessage(error));
     }
   };
 
@@ -56,6 +57,11 @@ const CreateTablePage: React.FC = () => {
           </div>
         </DashboardPageHeader>
       </div>
+      {createError && (
+        <Alert variant="destructive" className="mb-4">
+          <AlertDescription>{createError}</AlertDescription>
+        </Alert>
+      )}
       <TableSchemaForm onSubmit={handleCreateTable} theme={theme} />
     </DashboardPage>
   );


### PR DESCRIPTION
## Summary

- omit empty schemas from name-only table creation so Antfly installs its dynamic default schema
- strip backend-managed schema versions from configured create requests
- share payload construction between the page and dialog
- display create and index setup failures in the Antfarm UI
- cover default, configured-schema, and rendered failure paths

## Testing

- pnpm --dir ts/apps/antfarm test
- pnpm --dir ts/apps/antfarm typecheck
- Biome checks for changed files