### PR TITLE
Fix derived runtime cleanup and catch-up ownership

### DIFF
--- a/zig/build.zig
+++ b/zig/build.zig
@@ -3863,6 +3863,8 @@ pub fn build(b: *std.Build) void {
             "unsupported transforms fail atomically instead of reporting success",
             "supported transform on a missing document remains a no-op without upsert",
             "io threaded applied callback observes published watermark outside runtime lock",
+            "io threaded wait observes worker-owned catch-up close",
+            "io threaded wait requests prompt worker catch-up close",
         }),
         .test_runner = .{
             .path = b.path("pkg/antfly/src/test_runner.zig"),

--- a/zig/build.zig
+++ b/zig/build.zig
@@ -3865,6 +3865,7 @@ pub fn build(b: *std.Build) void {
             "io threaded applied callback observes published watermark outside runtime lock",
             "io threaded wait observes worker-owned catch-up close",
             "io threaded wait requests prompt worker catch-up close",
+            "io threaded wait observes failed worker-owned catch-up close",
         }),
         .test_runner = .{
             .path = b.path("pkg/antfly/src/test_runner.zig"),

--- a/zig/pkg/antfly/src/storage/db/derived/io_threaded_runtime.zig
+++ b/zig/pkg/antfly/src/storage/db/derived/io_threaded_runtime.zig
@@ -47,6 +47,8 @@ const Worker = struct {
     stop: bool = false,
     future: ?Io.Future(void) = null,
     catch_up_open: bool = false,
+    catch_up_close_requested: bool = false,
+    catch_up_close_active: bool = false,
     replay_cursor: ?replay_source_mod.MatchingCursor = null,
     replay_cursor_open_sequence: u64 = 0,
     catch_up_active: bool = false,
@@ -395,7 +397,10 @@ pub const DerivedRuntime = if (builtin.os.tag == .freestanding) struct {
 
         self.mutex.lockUncancelable(io);
         worker.target_sequence = @max(worker.target_sequence, self.last_notified_sequence);
-        try self.workers.append(self.alloc, worker);
+        self.workers.append(self.alloc, worker) catch |err| {
+            self.mutex.unlock(io);
+            return err;
+        };
         self.mutex.unlock(io);
         errdefer {
             self.mutex.lockUncancelable(io);
@@ -564,17 +569,14 @@ pub const DerivedRuntime = if (builtin.os.tag == .freestanding) struct {
 
             var all_applied = true;
             for (self.workers.items) |worker| {
-                if (worker.applied_sequence < sequence or worker.catch_up_active) {
+                if (worker.applied_sequence < sequence or worker.catch_up_active or worker.catch_up_open) {
+                    worker.catch_up_close_requested = true;
+                }
+                if (worker.applied_sequence < sequence or worker.catch_up_active or worker.catch_up_open or worker.catch_up_close_active) {
                     all_applied = false;
-                    break;
                 }
             }
             if (all_applied and self.truncates_in_flight == 0) {
-                self.mutex.unlock(io);
-                for (self.workers.items) |worker| {
-                    try closeWorkerCatchUpState(self, worker, true);
-                }
-                self.mutex.lockUncancelable(io);
                 var all_persisted = true;
                 var snapshots = std.ArrayListUnmanaged(PersistSnapshot).empty;
                 defer snapshots.deinit(self.alloc);
@@ -659,18 +661,14 @@ pub const DerivedRuntime = if (builtin.os.tag == .freestanding) struct {
             var all_applied = true;
             for (self.workers.items) |worker| {
                 if (!indexNameInList(worker.name, index_names)) continue;
-                if (worker.applied_sequence < sequence or worker.catch_up_active) {
+                if (worker.applied_sequence < sequence or worker.catch_up_active or worker.catch_up_open) {
+                    worker.catch_up_close_requested = true;
+                }
+                if (worker.applied_sequence < sequence or worker.catch_up_active or worker.catch_up_open or worker.catch_up_close_active) {
                     all_applied = false;
-                    break;
                 }
             }
             if (all_applied and self.truncates_in_flight == 0) {
-                self.mutex.unlock(io);
-                for (self.workers.items) |worker| {
-                    if (!indexNameInList(worker.name, index_names)) continue;
-                    try closeWorkerCatchUpState(self, worker, true);
-                }
-                self.mutex.lockUncancelable(io);
                 var all_persisted = true;
                 var snapshots = std.ArrayListUnmanaged(PersistSnapshot).empty;
                 defer snapshots.deinit(self.alloc);
@@ -1070,7 +1068,10 @@ fn truncateWithRecoverableRetry(runtime: *DerivedRuntime, worker: *Worker, seque
 fn ensureWorkerCatchUpState(runtime: *DerivedRuntime, worker: *Worker, from_sequence: u64) !void {
     if (!worker.catch_up_open) {
         if (runtime.begin_catch_up_fn) |begin_catch_up| try begin_catch_up(runtime.ctx, worker.kind);
+        const io = runtime.ioContext();
+        runtime.mutex.lockUncancelable(io);
         worker.catch_up_open = true;
+        runtime.mutex.unlock(io);
     }
     if (worker.replay_cursor == null) {
         worker.replay_cursor = try runtime.replay_source.openMatchingCursor(
@@ -1101,11 +1102,19 @@ fn closeWorkerCatchUpState(runtime: *DerivedRuntime, worker: *Worker, success: b
     worker.replay_cursor = null;
     worker.replay_cursor_open_sequence = 0;
     worker.catch_up_open = false;
+    worker.catch_up_close_requested = false;
+    if (catch_up_open) worker.catch_up_close_active = true;
     worker.last_replay_tail_records = 0;
     runtime.mutex.unlock(io);
 
     if (replay_cursor) |*cursor| cursor.deinit(runtime.alloc);
     if (!catch_up_open) return;
+    defer {
+        runtime.mutex.lockUncancelable(io);
+        worker.catch_up_close_active = false;
+        runtime.cond.broadcast(io);
+        runtime.mutex.unlock(io);
+    }
     if (runtime.finish_catch_up_fn) |finish_catch_up| try finish_catch_up(runtime.ctx, worker.kind, success);
 }
 
@@ -1157,8 +1166,10 @@ fn waitForCatchUpSessionReuse(runtime: *DerivedRuntime, worker: *Worker, io: Io)
         const shutdown = runtime.shutdown or worker.stop or runtime.last_error_name != null;
         const target = worker.target_sequence;
         const force_sequence = runtime.force_catch_up_sequence;
+        const close_requested = worker.catch_up_close_requested;
         runtime.mutex.unlock(io);
         if (shutdown) return false;
+        if (close_requested) return false;
         if (target > from_sequence or force_sequence > from_sequence) return true;
         const sleep_ns = @min(delay_ns, idle_wait_ns - waited_ns);
         io.sleep(Io.Duration.fromNanoseconds(@intCast(sleep_ns)), .awake) catch {};
@@ -1255,6 +1266,9 @@ const TestThreadedRuntimeCapture = struct {
     fail_next_apply_resource_budget: std.atomic.Value(bool) = .init(false),
     fail_next_publish: std.atomic.Value(bool) = .init(false),
     fail_next_truncate_writer_locked: std.atomic.Value(bool) = .init(false),
+    block_finish: std.atomic.Value(bool) = .init(false),
+    finish_entered: std.atomic.Value(bool) = .init(false),
+    release_finish: std.atomic.Value(bool) = .init(false),
 };
 
 fn testThreadedRuntimeAppliedSequenceAdvanced(ctx: *anyopaque, index_name: []const u8, sequence: u64) void {
@@ -1304,6 +1318,10 @@ fn testThreadedRuntimeFinishCatchUp(ctx: *anyopaque, index_ref: index_manager_mo
     _ = index_ref;
     const capture: *TestThreadedRuntimeCapture = @ptrCast(@alignCast(ctx));
     _ = capture.finish_calls.fetchAdd(1, .monotonic);
+    if (capture.block_finish.load(.acquire)) {
+        capture.finish_entered.store(true, .release);
+        while (!capture.release_finish.load(.acquire)) std.atomic.spinLoopHint();
+    }
     if (success and capture.fail_next_publish.swap(false, .monotonic)) {
         _ = capture.publish_failures.fetchAdd(1, .monotonic);
         return error.NotFound;
@@ -1413,6 +1431,182 @@ test "io threaded applied callback observes published watermark outside runtime 
 
     try std.testing.expectEqual(@as(u64, 1), capture.advanced_sequence.load(.acquire));
     try std.testing.expectEqual(@as(u64, 1), capture.callback_observed_applied_sequence.load(.acquire));
+}
+
+test "io threaded wait observes worker-owned catch-up close" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const journal_path = try std.fmt.allocPrint(alloc, ".zig-cache/tmp/{s}/io-threaded-worker-lifetime-journal", .{tmp.sub_path});
+    defer alloc.free(journal_path);
+    const journal_path_z = try alloc.dupeZ(u8, journal_path);
+    defer alloc.free(journal_path_z);
+
+    var journal = try change_journal_mod.Journal.open(journal_path_z, testThreadedRuntimeJournalOpenOptions());
+    defer journal.close();
+
+    var capture = TestThreadedRuntimeCapture{};
+    capture.block_finish.store(true, .release);
+    var runtime = try DerivedRuntime.init(
+        alloc,
+        replay_source_mod.Source.fromJournal(&journal),
+        &capture,
+        testThreadedRuntimeApply,
+        testThreadedRuntimePersist,
+        testThreadedRuntimeTruncate,
+        testThreadedRuntimeBeginCatchUp,
+        testThreadedRuntimeFinishCatchUp,
+        null,
+        null,
+        null,
+    );
+    defer runtime.deinit();
+
+    try runtime.addWorker("dense_idx", .{ .name = "dense_idx", .kind = .dense_vector }, 1);
+    const io = runtime.ioContext();
+    runtime.mutex.lockUncancelable(io);
+    const worker = runtime.workers.items[0];
+    worker.catch_up_open = true;
+    runtime.mutex.unlock(io);
+
+    const Race = struct {
+        runtime: *DerivedRuntime,
+        worker: *Worker,
+        close_failed: std.atomic.Value(bool) = .init(false),
+        close_done: std.atomic.Value(bool) = .init(false),
+        wait_started: std.atomic.Value(bool) = .init(false),
+        wait_failed: std.atomic.Value(bool) = .init(false),
+        wait_done: std.atomic.Value(bool) = .init(false),
+
+        fn close(self: *@This()) void {
+            closeWorkerCatchUpState(self.runtime, self.worker, true) catch {
+                self.close_failed.store(true, .release);
+            };
+            self.close_done.store(true, .release);
+        }
+
+        fn wait(self: *@This()) void {
+            self.wait_started.store(true, .release);
+            self.runtime.waitForAll(1) catch {
+                self.wait_failed.store(true, .release);
+            };
+            self.wait_done.store(true, .release);
+        }
+    };
+    var race = Race{ .runtime = &runtime, .worker = worker };
+    const close_thread = try std.Thread.spawn(.{}, Race.close, .{&race});
+    var close_joined = false;
+    defer if (!close_joined) {
+        capture.release_finish.store(true, .release);
+        close_thread.join();
+    };
+
+    for (0..5_000) |_| {
+        if (capture.finish_entered.load(.acquire)) break;
+        io.sleep(Io.Duration.fromMilliseconds(1), .awake) catch {};
+    } else return error.TestTimeout;
+
+    const wait_thread = try std.Thread.spawn(.{}, Race.wait, .{&race});
+    var wait_joined = false;
+    defer if (!wait_joined) {
+        capture.release_finish.store(true, .release);
+        wait_thread.join();
+    };
+    for (0..5_000) |_| {
+        if (race.wait_started.load(.acquire)) break;
+        io.sleep(Io.Duration.fromMilliseconds(1), .awake) catch {};
+    } else return error.TestTimeout;
+
+    // A waiter may observe the applied watermark while its worker still owns
+    // the corresponding publish callback. It must not steal that session or
+    // report completion until the worker finishes closing it.
+    io.sleep(Io.Duration.fromMilliseconds(25), .awake) catch {};
+    try std.testing.expect(!race.wait_done.load(.acquire));
+
+    capture.release_finish.store(true, .release);
+    close_thread.join();
+    close_joined = true;
+    wait_thread.join();
+    wait_joined = true;
+
+    try std.testing.expect(!race.close_failed.load(.acquire));
+    try std.testing.expect(race.close_done.load(.acquire));
+    try std.testing.expect(!race.wait_failed.load(.acquire));
+    try std.testing.expect(race.wait_done.load(.acquire));
+}
+
+test "io threaded wait requests prompt worker catch-up close" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const journal_path = try std.fmt.allocPrint(alloc, ".zig-cache/tmp/{s}/io-threaded-worker-close-request-journal", .{tmp.sub_path});
+    defer alloc.free(journal_path);
+    const journal_path_z = try alloc.dupeZ(u8, journal_path);
+    defer alloc.free(journal_path_z);
+
+    var journal = try change_journal_mod.Journal.open(journal_path_z, testThreadedRuntimeJournalOpenOptions());
+    defer journal.close();
+
+    var capture = TestThreadedRuntimeCapture{};
+    capture.block_finish.store(true, .release);
+    var runtime = try DerivedRuntime.init(
+        alloc,
+        replay_source_mod.Source.fromJournal(&journal),
+        &capture,
+        testThreadedRuntimeApply,
+        testThreadedRuntimePersist,
+        testThreadedRuntimeTruncate,
+        testThreadedRuntimeBeginCatchUp,
+        testThreadedRuntimeFinishCatchUp,
+        null,
+        null,
+        null,
+    );
+    defer runtime.deinit();
+
+    try runtime.addWorker("dense_idx", .{ .name = "dense_idx", .kind = .dense_vector }, 1);
+    const io = runtime.ioContext();
+    runtime.mutex.lockUncancelable(io);
+    runtime.workers.items[0].catch_up_open = true;
+    runtime.cond.broadcast(io);
+    runtime.mutex.unlock(io);
+
+    const Wait = struct {
+        runtime: *DerivedRuntime,
+        failed: std.atomic.Value(bool) = .init(false),
+        done: std.atomic.Value(bool) = .init(false),
+
+        fn run(self: *@This()) void {
+            self.runtime.waitForAll(1) catch {
+                self.failed.store(true, .release);
+            };
+            self.done.store(true, .release);
+        }
+    };
+    var wait = Wait{ .runtime = &runtime };
+    const wait_thread = try std.Thread.spawn(.{}, Wait.run, .{&wait});
+    var wait_joined = false;
+    defer if (!wait_joined) {
+        capture.release_finish.store(true, .release);
+        wait_thread.join();
+    };
+
+    // Dense workers normally retain an idle session for reuse. A synchronous
+    // wait must ask the owner to publish promptly instead of inheriting that
+    // multi-second idle window.
+    for (0..1_000) |_| {
+        if (capture.finish_entered.load(.acquire)) break;
+        io.sleep(Io.Duration.fromMilliseconds(1), .awake) catch {};
+    } else return error.TestTimeout;
+    try std.testing.expect(!wait.done.load(.acquire));
+
+    capture.release_finish.store(true, .release);
+    wait_thread.join();
+    wait_joined = true;
+    try std.testing.expect(!wait.failed.load(.acquire));
+    try std.testing.expect(wait.done.load(.acquire));
 }
 
 test "io threaded worker backoffs and retries replay truncation writer lock" {

--- a/zig/pkg/antfly/src/storage/db/derived/io_threaded_runtime.zig
+++ b/zig/pkg/antfly/src/storage/db/derived/io_threaded_runtime.zig
@@ -577,10 +577,10 @@ pub const DerivedRuntime = if (builtin.os.tag == .freestanding) struct {
                 self.mutex.lockUncancelable(io);
                 var all_persisted = true;
                 var snapshots = std.ArrayListUnmanaged(PersistSnapshot).empty;
+                defer snapshots.deinit(self.alloc);
                 errdefer {
                     for (snapshots.items) |snapshot| self.alloc.free(snapshot.name);
                 }
-                defer snapshots.deinit(self.alloc);
                 for (self.workers.items) |worker| {
                     if (worker.applied_sequence == 0) continue;
                     try appendPersistSnapshot(self.alloc, &snapshots, worker);
@@ -673,10 +673,10 @@ pub const DerivedRuntime = if (builtin.os.tag == .freestanding) struct {
                 self.mutex.lockUncancelable(io);
                 var all_persisted = true;
                 var snapshots = std.ArrayListUnmanaged(PersistSnapshot).empty;
+                defer snapshots.deinit(self.alloc);
                 errdefer {
                     for (snapshots.items) |snapshot| self.alloc.free(snapshot.name);
                 }
-                defer snapshots.deinit(self.alloc);
                 for (self.workers.items) |worker| {
                     if (!indexNameInList(worker.name, index_names)) continue;
                     if (worker.applied_sequence == 0) continue;
@@ -1250,6 +1250,7 @@ const TestThreadedRuntimeCapture = struct {
     truncated_sequence: std.atomic.Value(u64) = .init(0),
     advanced_sequence: std.atomic.Value(u64) = .init(0),
     callback_observed_applied_sequence: std.atomic.Value(u64) = .init(0),
+    fail_next_forced_persist: std.atomic.Value(bool) = .init(false),
     fail_next_dense_apply_not_found: std.atomic.Value(bool) = .init(false),
     fail_next_apply_resource_budget: std.atomic.Value(bool) = .init(false),
     fail_next_publish: std.atomic.Value(bool) = .init(false),
@@ -1280,8 +1281,8 @@ fn testThreadedRuntimeApply(ctx: *anyopaque, batch: derived_types.DerivedBatch, 
 
 fn testThreadedRuntimePersist(ctx: *anyopaque, index_name: []const u8, sequence: u64, force: bool) !bool {
     _ = index_name;
-    _ = force;
     const capture: *TestThreadedRuntimeCapture = @ptrCast(@alignCast(ctx));
+    if (force and capture.fail_next_forced_persist.swap(false, .monotonic)) return error.Canceled;
     capture.persisted_sequence.store(sequence, .monotonic);
     return true;
 }
@@ -1325,6 +1326,44 @@ fn appendTestThreadedRuntimeRecord(log: *change_journal_mod.Journal, alloc: Allo
     const payload = try change_journal_mod.encodeRecord(alloc, record);
     defer alloc.free(payload);
     _ = try log.appendOpaque(payload);
+}
+
+test "io threaded forced persist errors unwind snapshot ownership safely" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const journal_path = try std.fmt.allocPrint(alloc, ".zig-cache/tmp/{s}/io-threaded-forced-persist-error-journal", .{tmp.sub_path});
+    defer alloc.free(journal_path);
+    const journal_path_z = try alloc.dupeZ(u8, journal_path);
+    defer alloc.free(journal_path_z);
+
+    var journal = try change_journal_mod.Journal.open(journal_path_z, testThreadedRuntimeJournalOpenOptions());
+    defer journal.close();
+
+    var capture = TestThreadedRuntimeCapture{};
+    var runtime = try DerivedRuntime.init(
+        alloc,
+        replay_source_mod.Source.fromJournal(&journal),
+        &capture,
+        testThreadedRuntimeApply,
+        testThreadedRuntimePersist,
+        testThreadedRuntimeTruncate,
+        null,
+        null,
+        null,
+        null,
+        null,
+    );
+    defer runtime.deinit();
+
+    try runtime.addWorker("text_idx", .{ .name = "text_idx", .kind = .full_text }, 1);
+
+    capture.fail_next_forced_persist.store(true, .monotonic);
+    try std.testing.expectError(error.Canceled, runtime.waitForAll(1));
+
+    capture.fail_next_forced_persist.store(true, .monotonic);
+    try std.testing.expectError(error.Canceled, runtime.waitForIndexes(1, &.{"text_idx"}));
 }
 
 test "io threaded applied callback observes published watermark outside runtime lock" {

--- a/zig/pkg/antfly/src/storage/db/derived/io_threaded_runtime.zig
+++ b/zig/pkg/antfly/src/storage/db/derived/io_threaded_runtime.zig
@@ -49,6 +49,7 @@ const Worker = struct {
     catch_up_open: bool = false,
     catch_up_close_requested: bool = false,
     catch_up_close_active: bool = false,
+    catch_up_close_failed: bool = false,
     replay_cursor: ?replay_source_mod.MatchingCursor = null,
     replay_cursor_open_sequence: u64 = 0,
     catch_up_active: bool = false,
@@ -569,10 +570,10 @@ pub const DerivedRuntime = if (builtin.os.tag == .freestanding) struct {
 
             var all_applied = true;
             for (self.workers.items) |worker| {
-                if (worker.applied_sequence < sequence or worker.catch_up_active or worker.catch_up_open) {
+                if (worker.catch_up_open) {
                     worker.catch_up_close_requested = true;
                 }
-                if (worker.applied_sequence < sequence or worker.catch_up_active or worker.catch_up_open or worker.catch_up_close_active) {
+                if (worker.applied_sequence < sequence or worker.catch_up_active or worker.catch_up_open or worker.catch_up_close_active or worker.catch_up_close_failed) {
                     all_applied = false;
                 }
             }
@@ -661,10 +662,10 @@ pub const DerivedRuntime = if (builtin.os.tag == .freestanding) struct {
             var all_applied = true;
             for (self.workers.items) |worker| {
                 if (!indexNameInList(worker.name, index_names)) continue;
-                if (worker.applied_sequence < sequence or worker.catch_up_active or worker.catch_up_open) {
+                if (worker.catch_up_open) {
                     worker.catch_up_close_requested = true;
                 }
-                if (worker.applied_sequence < sequence or worker.catch_up_active or worker.catch_up_open or worker.catch_up_close_active) {
+                if (worker.applied_sequence < sequence or worker.catch_up_active or worker.catch_up_open or worker.catch_up_close_active or worker.catch_up_close_failed) {
                     all_applied = false;
                 }
             }
@@ -1067,8 +1068,11 @@ fn truncateWithRecoverableRetry(runtime: *DerivedRuntime, worker: *Worker, seque
 
 fn ensureWorkerCatchUpState(runtime: *DerivedRuntime, worker: *Worker, from_sequence: u64) !void {
     if (!worker.catch_up_open) {
-        if (runtime.begin_catch_up_fn) |begin_catch_up| try begin_catch_up(runtime.ctx, worker.kind);
         const io = runtime.ioContext();
+        runtime.mutex.lockUncancelable(io);
+        worker.catch_up_close_failed = false;
+        runtime.mutex.unlock(io);
+        if (runtime.begin_catch_up_fn) |begin_catch_up| try begin_catch_up(runtime.ctx, worker.kind);
         runtime.mutex.lockUncancelable(io);
         worker.catch_up_open = true;
         runtime.mutex.unlock(io);
@@ -1103,19 +1107,33 @@ fn closeWorkerCatchUpState(runtime: *DerivedRuntime, worker: *Worker, success: b
     worker.replay_cursor_open_sequence = 0;
     worker.catch_up_open = false;
     worker.catch_up_close_requested = false;
-    if (catch_up_open) worker.catch_up_close_active = true;
+    if (catch_up_open) {
+        worker.catch_up_close_active = true;
+        worker.catch_up_close_failed = false;
+    }
     worker.last_replay_tail_records = 0;
     runtime.mutex.unlock(io);
 
     if (replay_cursor) |*cursor| cursor.deinit(runtime.alloc);
     if (!catch_up_open) return;
-    defer {
+
+    if (runtime.finish_catch_up_fn) |finish_catch_up| {
+        finish_catch_up(runtime.ctx, worker.kind, success) catch |err| {
+            runtime.mutex.lockUncancelable(io);
+            worker.catch_up_close_active = false;
+            worker.catch_up_close_failed = true;
+            runtime.cond.broadcast(io);
+            runtime.mutex.unlock(io);
+            return err;
+        };
+    }
+    {
         runtime.mutex.lockUncancelable(io);
         worker.catch_up_close_active = false;
+        worker.catch_up_close_failed = false;
         runtime.cond.broadcast(io);
         runtime.mutex.unlock(io);
     }
-    if (runtime.finish_catch_up_fn) |finish_catch_up| try finish_catch_up(runtime.ctx, worker.kind, success);
 }
 
 fn isRecoverablePublishError(worker: *const Worker, err: anyerror) bool {
@@ -1445,6 +1463,11 @@ test "io threaded wait observes worker-owned catch-up close" {
 
     var journal = try change_journal_mod.Journal.open(journal_path_z, testThreadedRuntimeJournalOpenOptions());
     defer journal.close();
+    try appendTestThreadedRuntimeRecord(&journal, alloc, .{
+        .sequence = 1,
+        .changed_doc_keys = &.{"doc:a"},
+        .target_hints = &.{.dense_vector},
+    });
 
     var capture = TestThreadedRuntimeCapture{};
     capture.block_finish.store(true, .release);
@@ -1463,28 +1486,14 @@ test "io threaded wait observes worker-owned catch-up close" {
     );
     defer runtime.deinit();
 
-    try runtime.addWorker("dense_idx", .{ .name = "dense_idx", .kind = .dense_vector }, 1);
+    try runtime.addWorker("dense_idx", .{ .name = "dense_idx", .kind = .dense_vector }, 0);
     const io = runtime.ioContext();
-    runtime.mutex.lockUncancelable(io);
-    const worker = runtime.workers.items[0];
-    worker.catch_up_open = true;
-    runtime.mutex.unlock(io);
 
     const Race = struct {
         runtime: *DerivedRuntime,
-        worker: *Worker,
-        close_failed: std.atomic.Value(bool) = .init(false),
-        close_done: std.atomic.Value(bool) = .init(false),
         wait_started: std.atomic.Value(bool) = .init(false),
         wait_failed: std.atomic.Value(bool) = .init(false),
         wait_done: std.atomic.Value(bool) = .init(false),
-
-        fn close(self: *@This()) void {
-            closeWorkerCatchUpState(self.runtime, self.worker, true) catch {
-                self.close_failed.store(true, .release);
-            };
-            self.close_done.store(true, .release);
-        }
 
         fn wait(self: *@This()) void {
             self.wait_started.store(true, .release);
@@ -1494,25 +1503,18 @@ test "io threaded wait observes worker-owned catch-up close" {
             self.wait_done.store(true, .release);
         }
     };
-    var race = Race{ .runtime = &runtime, .worker = worker };
-    const close_thread = try std.Thread.spawn(.{}, Race.close, .{&race});
-    var close_joined = false;
-    defer if (!close_joined) {
-        capture.release_finish.store(true, .release);
-        close_thread.join();
-    };
-
-    for (0..5_000) |_| {
-        if (capture.finish_entered.load(.acquire)) break;
-        io.sleep(Io.Duration.fromMilliseconds(1), .awake) catch {};
-    } else return error.TestTimeout;
-
+    var race = Race{ .runtime = &runtime };
     const wait_thread = try std.Thread.spawn(.{}, Race.wait, .{&race});
     var wait_joined = false;
     defer if (!wait_joined) {
         capture.release_finish.store(true, .release);
         wait_thread.join();
     };
+
+    for (0..5_000) |_| {
+        if (capture.finish_entered.load(.acquire)) break;
+        io.sleep(Io.Duration.fromMilliseconds(1), .awake) catch {};
+    } else return error.TestTimeout;
     for (0..5_000) |_| {
         if (race.wait_started.load(.acquire)) break;
         io.sleep(Io.Duration.fromMilliseconds(1), .awake) catch {};
@@ -1520,20 +1522,29 @@ test "io threaded wait observes worker-owned catch-up close" {
 
     // A waiter may observe the applied watermark while its worker still owns
     // the corresponding publish callback. It must not steal that session or
-    // report completion until the worker finishes closing it.
+    // report completion until the worker finishes closing it. It also must not
+    // leave a close request behind for the next session while this one closes.
     io.sleep(Io.Duration.fromMilliseconds(25), .awake) catch {};
     try std.testing.expect(!race.wait_done.load(.acquire));
+    {
+        runtime.mutex.lockUncancelable(io);
+        defer runtime.mutex.unlock(io);
+        try std.testing.expect(runtime.workers.items[0].catch_up_close_active);
+        try std.testing.expect(!runtime.workers.items[0].catch_up_close_requested);
+    }
 
     capture.release_finish.store(true, .release);
-    close_thread.join();
-    close_joined = true;
     wait_thread.join();
     wait_joined = true;
 
-    try std.testing.expect(!race.close_failed.load(.acquire));
-    try std.testing.expect(race.close_done.load(.acquire));
     try std.testing.expect(!race.wait_failed.load(.acquire));
     try std.testing.expect(race.wait_done.load(.acquire));
+    {
+        runtime.mutex.lockUncancelable(io);
+        defer runtime.mutex.unlock(io);
+        try std.testing.expect(!runtime.workers.items[0].catch_up_close_failed);
+        try std.testing.expect(!runtime.workers.items[0].catch_up_close_requested);
+    }
 }
 
 test "io threaded wait requests prompt worker catch-up close" {
@@ -1607,6 +1618,89 @@ test "io threaded wait requests prompt worker catch-up close" {
     wait_joined = true;
     try std.testing.expect(!wait.failed.load(.acquire));
     try std.testing.expect(wait.done.load(.acquire));
+}
+
+test "io threaded wait observes failed worker-owned catch-up close" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const journal_path = try std.fmt.allocPrint(alloc, ".zig-cache/tmp/{s}/io-threaded-worker-close-failure-journal", .{tmp.sub_path});
+    defer alloc.free(journal_path);
+    const journal_path_z = try alloc.dupeZ(u8, journal_path);
+    defer alloc.free(journal_path_z);
+
+    var journal = try change_journal_mod.Journal.open(journal_path_z, testThreadedRuntimeJournalOpenOptions());
+    defer journal.close();
+
+    var capture = TestThreadedRuntimeCapture{};
+    var runtime = try DerivedRuntime.init(
+        alloc,
+        replay_source_mod.Source.fromJournal(&journal),
+        &capture,
+        testThreadedRuntimeApply,
+        testThreadedRuntimePersist,
+        testThreadedRuntimeTruncate,
+        testThreadedRuntimeBeginCatchUp,
+        testThreadedRuntimeFinishCatchUp,
+        null,
+        null,
+        null,
+    );
+    defer runtime.deinit();
+
+    try runtime.addWorker("dense_idx", .{ .name = "dense_idx", .kind = .dense_vector }, 1);
+    const io = runtime.ioContext();
+    runtime.mutex.lockUncancelable(io);
+    const worker = runtime.workers.items[0];
+    worker.catch_up_open = true;
+    runtime.mutex.unlock(io);
+    capture.fail_next_publish.store(true, .release);
+
+    try std.testing.expectError(error.NotFound, closeWorkerCatchUpState(&runtime, worker, true));
+    {
+        runtime.mutex.lockUncancelable(io);
+        defer runtime.mutex.unlock(io);
+        try std.testing.expect(!worker.catch_up_close_active);
+        try std.testing.expect(worker.catch_up_close_failed);
+    }
+
+    const Wait = struct {
+        runtime: *DerivedRuntime,
+        saw_expected_error: std.atomic.Value(bool) = .init(false),
+        done: std.atomic.Value(bool) = .init(false),
+
+        fn run(self: *@This()) void {
+            self.runtime.waitForAll(1) catch |err| {
+                self.saw_expected_error.store(err == RuntimeError.AsyncWorkerFailed, .release);
+            };
+            self.done.store(true, .release);
+        }
+
+        fn failRuntime(self: *@This()) void {
+            const runtime_io = self.runtime.ioContext();
+            self.runtime.mutex.lockUncancelable(runtime_io);
+            if (self.runtime.last_error_name == null) self.runtime.last_error_name = @errorName(error.NotFound);
+            self.runtime.cond.broadcast(runtime_io);
+            self.runtime.mutex.unlock(runtime_io);
+        }
+    };
+    var wait = Wait{ .runtime = &runtime };
+    const wait_thread = try std.Thread.spawn(.{}, Wait.run, .{&wait});
+    var wait_joined = false;
+    defer if (!wait_joined) {
+        wait.failRuntime();
+        wait_thread.join();
+    };
+
+    io.sleep(Io.Duration.fromMilliseconds(25), .awake) catch {};
+    try std.testing.expect(!wait.done.load(.acquire));
+
+    wait.failRuntime();
+    wait_thread.join();
+    wait_joined = true;
+    try std.testing.expect(wait.done.load(.acquire));
+    try std.testing.expect(wait.saw_expected_error.load(.acquire));
 }
 
 test "io threaded worker backoffs and retries replay truncation writer lock" {


### PR DESCRIPTION
## Summary

- fix error unwinding in `DerivedRuntime.waitForAll` and `waitForIndexes`
- keep catch-up session closure worker-owned while synchronous waits request and observe closure
- unlock the runtime mutex if worker registration allocation fails
- add forced-persist cleanup coverage and three wait/close race regressions

## Root cause

The cleanup handlers were registered in an unsafe order. When forced persistence returned an error such as `Canceled`, the normal `defer` released the snapshot list before `errdefer` traversed it to release the owned names. The resulting use-after-free accessed Zig allocator poison memory and was converted by the Zig signal handler into `SIGABRT`.

This explains the public API parity job reaching its successful test summary before aborting: https://github.com/antflydb/antfly/actions/runs/31712998773/job/94491041487?pr=480

## Catch-up ownership hardening

Synchronous waiters could also close a catch-up session while its worker was still finishing the same session. Waiters now request closure only for an open session and wait for the owning worker to publish either a successful or failed close outcome. This prevents stale requests from disabling the next dense session's idle reuse and prevents a waiter from returning success before a close failure is recorded. It still makes `waitForAll` and `waitForIndexes` request a prompt publish rather than inheriting the reuse delay.

The worker-owned protocol is runtime-generic; the practical performance implication is mainly for dense indexes because they retain catch-up sessions for reuse. This PR deliberately excludes the dense-only `NoActiveWriteSession` recovery change from PR 480.

## Validation

- focused io-threaded derived-runtime group: 9/9 passed in `ReleaseSafe`
- three wait/close races: 20 consecutive repetitions, 60/60 test executions passed
- managed-index corruption reproduction for the original abort: 20/20 passed on Linux and 1/1 passed after the final review fixes
- `git diff --check`
