### PR TITLE
test(e2e): reserve scaling cluster ports until startup

### DIFF
--- a/zig/e2e/antfly/conftest.py
+++ b/zig/e2e/antfly/conftest.py
@@ -145,6 +145,48 @@ def find_free_port() -> int:
         return sock.getsockname()[1]
 
 
+class LoopbackPortReservations:
+    """Hold kernel-assigned ports until a child process is ready to bind them.
+
+    `find_free_port()` is appropriate when its caller binds immediately. Cluster
+    fixtures often need several advertised ports before writing configuration or
+    starting children; closing every probe socket makes those port numbers
+    available for reuse in the meantime. This pool keeps each socket bound, which
+    both guarantees uniqueness within the fixture and prevents unrelated
+    port-zero listeners from claiming a later child's advertised port.
+    """
+
+    def __init__(self, host: str = "127.0.0.1") -> None:
+        self.host = host
+        self._sockets: dict[int, socket.socket] = {}
+
+    def reserve(self) -> int:
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        try:
+            sock.bind((self.host, 0))
+            port = int(sock.getsockname()[1])
+            if port in self._sockets:
+                raise RuntimeError(f"kernel returned duplicate reserved port {port}")
+            self._sockets[port] = sock
+            return port
+        except BaseException:
+            sock.close()
+            raise
+
+    def release(self, *ports: int) -> None:
+        for port in ports:
+            sock = self._sockets.pop(port, None)
+            if sock is None:
+                raise RuntimeError(f"port {port} is not reserved")
+            sock.close()
+
+    def close(self) -> None:
+        sockets = list(self._sockets.values())
+        self._sockets.clear()
+        for sock in sockets:
+            sock.close()
+
+
 def wait_for_server(
     url: str,
     timeout: float = float(os.environ.get("ANTFLY_E2E_SERVER_START_TIMEOUT_S", "30.0")),

--- a/zig/e2e/antfly/test_scaling.py
+++ b/zig/e2e/antfly/test_scaling.py
@@ -20,6 +20,7 @@ import json
 import os
 import shutil
 import signal
+import socket
 import subprocess
 import tempfile
 import time
@@ -31,6 +32,7 @@ import requests
 
 from conftest import (
     DEFAULT_ANTFLY_BIN,
+    LoopbackPortReservations,
     REPO_ROOT,
     _read_log_tail,
     antfly_public_api_url,
@@ -64,6 +66,27 @@ class _ClusterStartupDeadline:
         if remaining <= 0.0:
             raise RuntimeError("multi-node cluster startup deadline expired")
         time.sleep(min(duration_s, remaining))
+
+
+def test_loopback_port_reservations_hold_ports_until_release():
+    reservations = LoopbackPortReservations()
+    ports = [reservations.reserve() for _ in range(16)]
+
+    try:
+        assert len(set(ports)) == len(ports)
+        for port in ports:
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as contender:
+                with pytest.raises(OSError):
+                    contender.bind(("127.0.0.1", port))
+
+        assert all(find_free_port() not in ports for _ in range(64))
+
+        released_port = ports.pop()
+        reservations.release(released_port)
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as contender:
+            contender.bind(("127.0.0.1", released_port))
+    finally:
+        reservations.close()
 
 
 def _metadata_admin_url(stateful_api) -> str:
@@ -387,16 +410,9 @@ class MultiNodeScalingCluster:
         self.startup_deadline = (
             _ClusterStartupDeadline(startup_deadline_at) if startup_deadline_at is not None else None
         )
-
-        self.metadata_nodes = [
-            {
-                "id": node_id,
-                "raft_port": find_free_port(),
-                "api_port": find_free_port(),
-            }
-            for node_id in range(1, 4)
-        ]
-        self.data_nodes = [self._new_data_node(node_id) for node_id in range(101, 101 + initial_data_node_count)]
+        self.port_reservations = LoopbackPortReservations(self.host)
+        self.metadata_nodes: list[dict[str, int]] = []
+        self.data_nodes: list[dict[str, int]] = []
         self.config_path = self.root / "antfly.json"
         self.metadata_procs: list[subprocess.Popen[str]] = []
         self.data_procs: list[subprocess.Popen[str]] = []
@@ -404,8 +420,20 @@ class MultiNodeScalingCluster:
         self.log_files: list[Any] = []
         self.log_paths: list[Path] = []
 
-        self._write_config()
         try:
+            self.metadata_nodes = [
+                {
+                    "id": node_id,
+                    "raft_port": self.port_reservations.reserve(),
+                    "api_port": self.port_reservations.reserve(),
+                }
+                for node_id in range(1, 4)
+            ]
+            self.data_nodes = [
+                self._new_data_node(node_id)
+                for node_id in range(101, 101 + initial_data_node_count)
+            ]
+            self._write_config()
             self._start()
         except BaseException:
             self.stop()
@@ -445,8 +473,8 @@ class MultiNodeScalingCluster:
         return {
             "id": node_id,
             "store_id": node_id,
-            "api_port": find_free_port(),
-            "raft_port": find_free_port(),
+            "api_port": self.port_reservations.reserve(),
+            "raft_port": self.port_reservations.reserve(),
         }
 
     def _write_config(self) -> None:
@@ -489,11 +517,10 @@ class MultiNodeScalingCluster:
                 str(self.config_path),
                 "--id",
                 str(node["id"]),
-                "--health-port",
-                # This listener is not addressed by the test. Let the kernel
-                # choose its port atomically so it cannot consume a port that
-                # was preselected for a later metadata/data listener.
-                "0",
+                # This fixture probes the metadata admin listener directly and
+                # does not need a second health listener competing for ports.
+                "--health",
+                "false",
                 "--raft-tick-ms",
                 "25",
                 "--control-tick-ms",
@@ -505,6 +532,7 @@ class MultiNodeScalingCluster:
                 "--snapshot-root-dir",
                 str(self.root / f"metadata-{node['id']}-snapshots"),
             ]
+            self.port_reservations.release(node["raft_port"], node["api_port"])
             self.metadata_procs.append(
                 subprocess.Popen(command, stdout=log, stderr=subprocess.STDOUT, cwd=REPO_ROOT)
             )
@@ -564,13 +592,10 @@ class MultiNodeScalingCluster:
             str(node["id"]),
             "--store-id",
             str(node["store_id"]),
-            "--health-port",
-            # The test probes the public listener's root /healthz endpoint;
-            # the dedicated health listener only needs to start successfully.
-            # Port zero avoids the find-free-port/child-bind race and prevents
-            # collisions with ports reserved earlier for dynamically added
-            # data nodes.
-            "0",
+            # The public listener provides the /healthz route used by this
+            # fixture, so an additional health listener is unnecessary.
+            "--health",
+            "false",
             "--raft-tick-ms",
             "25",
             "--control-tick-ms",
@@ -580,6 +605,7 @@ class MultiNodeScalingCluster:
             "--replica-catalog-path",
             str(self.root / f"data-{node['id']}-catalog.txt"),
         ]
+        self.port_reservations.release(node["api_port"], node["raft_port"])
         proc = subprocess.Popen(command, stdout=log, stderr=subprocess.STDOUT, cwd=REPO_ROOT)
         self.data_procs.append(proc)
         self.data_proc_by_node_id[int(node["id"])] = proc
@@ -1020,6 +1046,7 @@ class MultiNodeScalingCluster:
             print(f"failed to preserve scaling diagnostics: {exc!r}")
 
     def stop(self, *, timeout_s: float = 10.0, test_failed: bool = False) -> None:
+        self.port_reservations.close()
         if test_failed:
             self.preserve_failure_diagnostics()
         procs = [proc for proc in [*self.data_procs, *self.metadata_procs] if proc.poll() is None]


### PR DESCRIPTION
## Summary

- add a reusable loopback port reservation pool for multi-process E2E fixtures
- hold metadata and data API/raft ports while configuration and earlier nodes start, releasing each pair immediately before its owner is spawned
- disable dedicated health listeners in the scaling fixture because its existing API listeners provide the probes it uses
- cover reservation uniqueness, exclusion, and release with a deterministic regression test

## Why

The failing PR #485 Zig E2E job selected all configured listener ports with find_free_port and closed those sockets before any child bound them. Starting earlier health listeners on port zero could then claim a later data nodes configured port, causing error.AddressInUse. Holding the sockets removes that setup window and also guarantees uniqueness within the fixture.

## Validation

- Python compile check for conftest.py and test_scaling.py
- reservation regression test
- test_autoscaling_finalizes_shard_split_from_size_threshold (twice)
- test_autoscaling_adds_data_node_and_assigns_placements
- git diff --check