### PR TITLE
test(e2e): harden multiprocess port handoff

### DIFF
--- a/zig/e2e/antfly/conftest.py
+++ b/zig/e2e/antfly/conftest.py
@@ -41,6 +41,7 @@ import subprocess
 import tempfile
 import threading
 import time
+from contextlib import ExitStack
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from urllib.parse import quote, urlparse
@@ -421,26 +422,30 @@ def _write_remote_content_e2e_config(root: Path) -> Path:
 
 class AntflyServer:
     def __init__(self, binary: str, host: str, port: int):
-        self.port_reservations = LoopbackPortReservations(host)
-        port = self.port_reservations.reserve_requested(port)
-        self.url = f"http://{host}:{port}"
-        self.tempdir = tempfile.TemporaryDirectory(prefix="antfly-zig-e2e-")
-        root = Path(self.tempdir.name)
-        self.log_path = root / "server.log"
-        self.log_file = self.log_path.open("w")
-        env = os.environ.copy()
-        env.update(
-            {
-                "ANTFLY_SERVERLESS_ARTIFACTS_URI": f"file://{root / 'artifacts'}",
-                "ANTFLY_SERVERLESS_MANIFESTS_URI": f"file://{root / 'manifests'}",
-                "ANTFLY_SERVERLESS_WAL_URI": f"file://{root / 'wal'}",
-                "ANTFLY_SERVERLESS_PROGRESS_URI": f"file://{root / 'progress'}",
-                "ANTFLY_SERVERLESS_CATALOG_URI": f"file://{root / 'catalog'}",
-                "ANTFLY_SERVERLESS_QUERY_CACHE_DIR": str(root / "cache"),
-            }
-        )
-        command = _serverless_combined_command(binary, host=host, port=port, root=root)
-        self.proc: subprocess.Popen[str] | None = None
+        with ExitStack() as setup:
+            self.port_reservations = LoopbackPortReservations(host)
+            setup.callback(self.port_reservations.close)
+            port = self.port_reservations.reserve_requested(port)
+            self.url = f"http://{host}:{port}"
+            self.tempdir = tempfile.TemporaryDirectory(prefix="antfly-zig-e2e-")
+            setup.callback(self.tempdir.cleanup)
+            root = Path(self.tempdir.name)
+            self.log_path = root / "server.log"
+            self.log_file = setup.enter_context(self.log_path.open("w"))
+            env = os.environ.copy()
+            env.update(
+                {
+                    "ANTFLY_SERVERLESS_ARTIFACTS_URI": f"file://{root / 'artifacts'}",
+                    "ANTFLY_SERVERLESS_MANIFESTS_URI": f"file://{root / 'manifests'}",
+                    "ANTFLY_SERVERLESS_WAL_URI": f"file://{root / 'wal'}",
+                    "ANTFLY_SERVERLESS_PROGRESS_URI": f"file://{root / 'progress'}",
+                    "ANTFLY_SERVERLESS_CATALOG_URI": f"file://{root / 'catalog'}",
+                    "ANTFLY_SERVERLESS_QUERY_CACHE_DIR": str(root / "cache"),
+                }
+            )
+            command = _serverless_combined_command(binary, host=host, port=port, root=root)
+            self.proc: subprocess.Popen[str] | None = None
+            setup.pop_all()
         try:
             self.proc = self.port_reservations.handoff_to(
                 (port,),
@@ -482,18 +487,22 @@ class PublicAntflyServer:
     def __init__(self, binary: str, host: str, port: int):
         self.binary = binary
         self.host = host
-        self.port_reservations = LoopbackPortReservations(host)
-        port = self.port_reservations.reserve_requested(port)
-        self.port = port
-        self.url = f"http://{host}:{port}"
-        self.tempdir = tempfile.TemporaryDirectory(prefix="antfly-zig-public-e2e-")
-        root = Path(self.tempdir.name)
-        self.root = root
-        self.replica_root = root / "replicas"
-        self.log_path = root / "server.log"
-        self.log_file = self.log_path.open("w")
-        command = _legacy_stateful_command(binary, host=host, port=port, root=root)
-        self.proc: subprocess.Popen[str] | None = None
+        with ExitStack() as setup:
+            self.port_reservations = LoopbackPortReservations(host)
+            setup.callback(self.port_reservations.close)
+            port = self.port_reservations.reserve_requested(port)
+            self.port = port
+            self.url = f"http://{host}:{port}"
+            self.tempdir = tempfile.TemporaryDirectory(prefix="antfly-zig-public-e2e-")
+            setup.callback(self.tempdir.cleanup)
+            root = Path(self.tempdir.name)
+            self.root = root
+            self.replica_root = root / "replicas"
+            self.log_path = root / "server.log"
+            self.log_file = setup.enter_context(self.log_path.open("w"))
+            command = _legacy_stateful_command(binary, host=host, port=port, root=root)
+            self.proc: subprocess.Popen[str] | None = None
+            setup.pop_all()
         try:
             self.proc = self.port_reservations.handoff_to(
                 (port,),
@@ -619,6 +628,8 @@ def _standalone_stateful_command(binary: str, *, host: str, port: int, root: Pat
         str(root),
         "--control-tick-ms",
         "5",
+        "--health",
+        "false",
         "--replica-root-dir",
         str(root / "replicas"),
         "--replica-catalog-path",
@@ -706,30 +717,32 @@ class StatefulAntflyServer:
     def __init__(self, binary: str, host: str, port: int, *, auth_enabled: bool = False):
         self.binary = binary
         self.host = host
-        self.port_reservations = LoopbackPortReservations(host)
-        port = self.port_reservations.reserve_requested(port)
-        self.port = port
         self.auth_enabled = auth_enabled
-        self.url = f"http://{host}:{port}"
-        self.api_url = antfly_public_api_url(self.url, binary=binary)
         self.metadata_admin_url: str | None = None
         self.metadata_proc: subprocess.Popen[str] | None = None
         self.data_proc: subprocess.Popen[str] | None = None
-        self.tempdir = tempfile.TemporaryDirectory(prefix="antfly-zig-stateful-e2e-")
-        self.root = Path(self.tempdir.name)
-        self.replica_root = self.root / "data-replicas"
-        self.metadata_log_path = self.root / "metadata.log"
-        self.data_log_path = self.root / "data.log"
-        self.metadata_log_file = self.metadata_log_path.open("w")
-        self.data_log_file = self.data_log_path.open("w")
-        metadata_port, metadata_admin_port, data_raft_port = (
-            self.port_reservations.reserve_many(3)
-        )
-        self.metadata_port = metadata_port
-        self.metadata_admin_port = metadata_admin_port
-        self.data_raft_port = data_raft_port
-        metadata_admin_url = f"http://{host}:{metadata_admin_port}"
-        self.metadata_admin_url = metadata_admin_url
+        with ExitStack() as setup:
+            self.port_reservations = LoopbackPortReservations(host)
+            setup.callback(self.port_reservations.close)
+            port = self.port_reservations.reserve_requested(port)
+            self.port = port
+            self.url = f"http://{host}:{port}"
+            self.api_url = antfly_public_api_url(self.url, binary=binary)
+            self.tempdir = tempfile.TemporaryDirectory(prefix="antfly-zig-stateful-e2e-")
+            setup.callback(self.tempdir.cleanup)
+            self.root = Path(self.tempdir.name)
+            self.replica_root = self.root / "data-replicas"
+            self.metadata_log_path = self.root / "metadata.log"
+            self.data_log_path = self.root / "data.log"
+            self.metadata_log_file = setup.enter_context(self.metadata_log_path.open("w"))
+            self.data_log_file = setup.enter_context(self.data_log_path.open("w"))
+            (
+                self.metadata_port,
+                self.metadata_admin_port,
+                self.data_raft_port,
+            ) = self.port_reservations.reserve_many(3)
+            self.metadata_admin_url = f"http://{host}:{self.metadata_admin_port}"
+            setup.pop_all()
 
         try:
             self._start_processes(truncate_logs=False)
@@ -863,17 +876,21 @@ class StandaloneAntflyServer:
     def __init__(self, binary: str, host: str, port: int):
         self.binary = binary
         self.host = host
-        self.port_reservations = LoopbackPortReservations(host)
-        port = self.port_reservations.reserve_requested(port)
-        self.port = port
-        self.url = f"http://{host}:{port}"
-        self.api_url = antfly_public_api_url(self.url, binary=binary)
-        self.tempdir = tempfile.TemporaryDirectory(prefix="antfly-zig-standalone-e2e-")
-        self.root = Path(self.tempdir.name)
-        self.replica_root = self.root / "replicas"
-        self.log_path = self.root / "server.log"
-        self.log_file = self.log_path.open("w")
-        self.proc: subprocess.Popen[str] | None = None
+        with ExitStack() as setup:
+            self.port_reservations = LoopbackPortReservations(host)
+            setup.callback(self.port_reservations.close)
+            port = self.port_reservations.reserve_requested(port)
+            self.port = port
+            self.url = f"http://{host}:{port}"
+            self.api_url = antfly_public_api_url(self.url, binary=binary)
+            self.tempdir = tempfile.TemporaryDirectory(prefix="antfly-zig-standalone-e2e-")
+            setup.callback(self.tempdir.cleanup)
+            self.root = Path(self.tempdir.name)
+            self.replica_root = self.root / "replicas"
+            self.log_path = self.root / "server.log"
+            self.log_file = setup.enter_context(self.log_path.open("w"))
+            self.proc: subprocess.Popen[str] | None = None
+            setup.pop_all()
         try:
             self._start_process(truncate_logs=False)
         except BaseException:

--- a/zig/e2e/antfly/conftest.py
+++ b/zig/e2e/antfly/conftest.py
@@ -160,15 +160,15 @@ class LoopbackPortReservations:
         self.host = host
         self._sockets: dict[int, socket.socket] = {}
 
-    def reserve(self) -> int:
+    def reserve(self, port: int = 0) -> int:
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         try:
-            sock.bind((self.host, 0))
-            port = int(sock.getsockname()[1])
-            if port in self._sockets:
-                raise RuntimeError(f"kernel returned duplicate reserved port {port}")
-            self._sockets[port] = sock
-            return port
+            sock.bind((self.host, port))
+            reserved_port = int(sock.getsockname()[1])
+            if reserved_port in self._sockets:
+                raise RuntimeError(f"kernel returned duplicate reserved port {reserved_port}")
+            self._sockets[reserved_port] = sock
+            return reserved_port
         except BaseException:
             sock.close()
             raise
@@ -179,6 +179,12 @@ class LoopbackPortReservations:
             if sock is None:
                 raise RuntimeError(f"port {port} is not reserved")
             sock.close()
+
+    def release_if_reserved(self, *ports: int) -> None:
+        for port in ports:
+            sock = self._sockets.pop(port, None)
+            if sock is not None:
+                sock.close()
 
     def close(self) -> None:
         sockets = list(self._sockets.values())
@@ -641,8 +647,8 @@ def _metadata_command(binary: str, *, host: str, raft_port: int, admin_port: int
         host,
         "--api-port",
         str(admin_port),
-        "--health-port",
-        str(find_free_port()),
+        "--health",
+        "false",
         "--data-dir",
         str(root),
         "--raft-tick-ms",
@@ -679,8 +685,8 @@ def _data_command(
         host,
         "--raft-port",
         str(raft_port),
-        "--health-port",
-        str(find_free_port()),
+        "--health",
+        "false",
         "--metadata-api",
         metadata_admin_base_uri,
         "--node-id",
@@ -707,6 +713,11 @@ class StatefulAntflyServer:
     def __init__(self, binary: str, host: str, port: int, *, auth_enabled: bool = False):
         self.binary = binary
         self.host = host
+        self.port_reservations = LoopbackPortReservations(host)
+        try:
+            self.port_reservations.reserve(port)
+        except OSError:
+            port = self.port_reservations.reserve()
         self.port = port
         self.auth_enabled = auth_enabled
         self.url = f"http://{host}:{port}"
@@ -721,11 +732,11 @@ class StatefulAntflyServer:
         self.data_log_path = self.root / "data.log"
         self.metadata_log_file = self.metadata_log_path.open("w")
         self.data_log_file = self.data_log_path.open("w")
-        metadata_port = find_free_port()
-        metadata_admin_port = find_free_port()
+        metadata_port = self.port_reservations.reserve()
+        metadata_admin_port = self.port_reservations.reserve()
         self.metadata_port = metadata_port
         self.metadata_admin_port = metadata_admin_port
-        self.data_raft_port = find_free_port()
+        self.data_raft_port = self.port_reservations.reserve()
         metadata_admin_url = f"http://{host}:{metadata_admin_port}"
         self.metadata_admin_url = metadata_admin_url
 
@@ -742,6 +753,7 @@ class StatefulAntflyServer:
             admin_port=self.metadata_admin_port,
             root=self.root,
         )
+        self.port_reservations.release_if_reserved(self.metadata_port, self.metadata_admin_port)
         self.metadata_proc = subprocess.Popen(
             metadata_command,
             stdout=self.metadata_log_file,
@@ -767,6 +779,7 @@ class StatefulAntflyServer:
             root=self.root,
             auth_enabled=self.auth_enabled,
         )
+        self.port_reservations.release_if_reserved(self.port, self.data_raft_port)
         self.data_proc = subprocess.Popen(
             data_command,
             stdout=self.data_log_file,
@@ -829,6 +842,7 @@ class StatefulAntflyServer:
         self._start_processes(truncate_logs=False)
 
     def stop(self, *, test_failed: bool = False) -> None:
+        self.port_reservations.close()
         self._stop_processes()
         self.data_log_file.close()
         self.metadata_log_file.close()

--- a/zig/e2e/antfly/conftest.py
+++ b/zig/e2e/antfly/conftest.py
@@ -31,7 +31,6 @@ Usage:
 from __future__ import annotations
 
 import base64
-import errno
 import hashlib
 import json
 import os
@@ -49,6 +48,8 @@ from typing import Any, Callable
 
 import pytest
 import requests
+
+from port_reservations import LoopbackPortReservations, find_free_port
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_ANTFLY_BIN = REPO_ROOT / "zig-out" / "bin" / "antfly"
@@ -138,70 +139,6 @@ def antfly_internal_api_path(path: str) -> str:
 
 def inference_public_api_url(base_url: str) -> str:
     return with_api_root(base_url, INFERENCE_PUBLIC_API_ROOT)
-
-
-def find_free_port() -> int:
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-        sock.bind(("127.0.0.1", 0))
-        return sock.getsockname()[1]
-
-
-class LoopbackPortReservations:
-    """Hold kernel-assigned ports until a child process is ready to bind them.
-
-    `find_free_port()` is appropriate when its caller binds immediately. Cluster
-    fixtures often need several advertised ports before writing configuration or
-    starting children; closing every probe socket makes those port numbers
-    available for reuse in the meantime. This pool keeps each socket bound, which
-    both guarantees uniqueness within the fixture and prevents unrelated
-    port-zero listeners from claiming a later child's advertised port.
-    """
-
-    def __init__(self, host: str = "127.0.0.1") -> None:
-        self.host = host
-        self._sockets: dict[int, socket.socket] = {}
-
-    def reserve(self, port: int = 0) -> int:
-        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        try:
-            sock.bind((self.host, port))
-            reserved_port = int(sock.getsockname()[1])
-            if reserved_port in self._sockets:
-                raise RuntimeError(f"kernel returned duplicate reserved port {reserved_port}")
-            self._sockets[reserved_port] = sock
-            return reserved_port
-        except BaseException:
-            sock.close()
-            raise
-
-    def release(self, *ports: int) -> None:
-        for port in ports:
-            sock = self._sockets.pop(port, None)
-            if sock is None:
-                raise RuntimeError(f"port {port} is not reserved")
-            sock.close()
-
-    def release_if_reserved(self, *ports: int) -> None:
-        for port in ports:
-            sock = self._sockets.pop(port, None)
-            if sock is not None:
-                sock.close()
-
-    def close(self) -> None:
-        sockets = list(self._sockets.values())
-        self._sockets.clear()
-        for sock in sockets:
-            sock.close()
-
-
-def reserve_requested_port(reservations: LoopbackPortReservations, port: int) -> int:
-    """Reserve a requested port, falling back only when another listener owns it."""
-    try:
-        return reservations.reserve(port)
-    except OSError as exc:
-        if exc.errno != errno.EADDRINUSE:
-            raise
-        return reservations.reserve()
 
 
 def wait_for_server(
@@ -725,7 +662,7 @@ class StatefulAntflyServer:
         self.binary = binary
         self.host = host
         self.port_reservations = LoopbackPortReservations(host)
-        port = reserve_requested_port(self.port_reservations, port)
+        port = self.port_reservations.reserve_requested(port)
         self.port = port
         self.auth_enabled = auth_enabled
         self.url = f"http://{host}:{port}"
@@ -740,11 +677,12 @@ class StatefulAntflyServer:
         self.data_log_path = self.root / "data.log"
         self.metadata_log_file = self.metadata_log_path.open("w")
         self.data_log_file = self.data_log_path.open("w")
-        metadata_port = self.port_reservations.reserve()
-        metadata_admin_port = self.port_reservations.reserve()
+        metadata_port, metadata_admin_port, data_raft_port = (
+            self.port_reservations.reserve_many(3)
+        )
         self.metadata_port = metadata_port
         self.metadata_admin_port = metadata_admin_port
-        self.data_raft_port = self.port_reservations.reserve()
+        self.data_raft_port = data_raft_port
         metadata_admin_url = f"http://{host}:{metadata_admin_port}"
         self.metadata_admin_url = metadata_admin_url
 
@@ -769,12 +707,14 @@ class StatefulAntflyServer:
             admin_port=self.metadata_admin_port,
             root=self.root,
         )
-        self.port_reservations.release_if_reserved(self.metadata_port, self.metadata_admin_port)
-        self.metadata_proc = subprocess.Popen(
-            metadata_command,
-            stdout=self.metadata_log_file,
-            stderr=subprocess.STDOUT,
-            cwd=self.root,
+        self.metadata_proc = self.port_reservations.handoff_to(
+            (self.metadata_port, self.metadata_admin_port),
+            lambda: subprocess.Popen(
+                metadata_command,
+                stdout=self.metadata_log_file,
+                stderr=subprocess.STDOUT,
+                cwd=self.root,
+            ),
         )
         if not wait_for_server(
             self.metadata_admin_url,
@@ -795,12 +735,14 @@ class StatefulAntflyServer:
             root=self.root,
             auth_enabled=self.auth_enabled,
         )
-        self.port_reservations.release_if_reserved(self.port, self.data_raft_port)
-        self.data_proc = subprocess.Popen(
-            data_command,
-            stdout=self.data_log_file,
-            stderr=subprocess.STDOUT,
-            cwd=self.root,
+        self.data_proc = self.port_reservations.handoff_to(
+            (self.port, self.data_raft_port),
+            lambda: subprocess.Popen(
+                data_command,
+                stdout=self.data_log_file,
+                stderr=subprocess.STDOUT,
+                cwd=self.root,
+            ),
         )
         if not wait_for_server(
             self.api_url,
@@ -844,7 +786,7 @@ class StatefulAntflyServer:
         self.metadata_proc = None
 
     def restart(self) -> None:
-        self._stop_processes()
+        self.pause()
         self.data_log_file.close()
         self.metadata_log_file.close()
         self.metadata_log_file = self.metadata_log_path.open("a")
@@ -853,6 +795,12 @@ class StatefulAntflyServer:
 
     def pause(self) -> None:
         self._stop_processes()
+        self.port_reservations.ensure_reserved(
+            self.metadata_port,
+            self.metadata_admin_port,
+            self.port,
+            self.data_raft_port,
+        )
 
     def resume(self) -> None:
         self._start_processes(truncate_logs=False)

--- a/zig/e2e/antfly/conftest.py
+++ b/zig/e2e/antfly/conftest.py
@@ -421,6 +421,8 @@ def _write_remote_content_e2e_config(root: Path) -> Path:
 
 class AntflyServer:
     def __init__(self, binary: str, host: str, port: int):
+        self.port_reservations = LoopbackPortReservations(host)
+        port = self.port_reservations.reserve_requested(port)
         self.url = f"http://{host}:{port}"
         self.tempdir = tempfile.TemporaryDirectory(prefix="antfly-zig-e2e-")
         root = Path(self.tempdir.name)
@@ -438,7 +440,21 @@ class AntflyServer:
             }
         )
         command = _serverless_combined_command(binary, host=host, port=port, root=root)
-        self.proc = subprocess.Popen(command, stdout=self.log_file, stderr=subprocess.STDOUT, env=env, cwd=REPO_ROOT)
+        self.proc: subprocess.Popen[str] | None = None
+        try:
+            self.proc = self.port_reservations.handoff_to(
+                (port,),
+                lambda: subprocess.Popen(
+                    command,
+                    stdout=self.log_file,
+                    stderr=subprocess.STDOUT,
+                    env=env,
+                    cwd=REPO_ROOT,
+                ),
+            )
+        except BaseException:
+            self.stop()
+            raise
         if not wait_for_server(self.url):
             self.stop()
             out = _read_log_tail(self.log_path)
@@ -449,6 +465,7 @@ class AntflyServer:
         return _read_log_tail(self.log_path)
 
     def stop(self) -> None:
+        self.port_reservations.close()
         if self.proc and self.proc.poll() is None:
             self.proc.send_signal(signal.SIGTERM)
             try:
@@ -465,6 +482,8 @@ class PublicAntflyServer:
     def __init__(self, binary: str, host: str, port: int):
         self.binary = binary
         self.host = host
+        self.port_reservations = LoopbackPortReservations(host)
+        port = self.port_reservations.reserve_requested(port)
         self.port = port
         self.url = f"http://{host}:{port}"
         self.tempdir = tempfile.TemporaryDirectory(prefix="antfly-zig-public-e2e-")
@@ -474,7 +493,20 @@ class PublicAntflyServer:
         self.log_path = root / "server.log"
         self.log_file = self.log_path.open("w")
         command = _legacy_stateful_command(binary, host=host, port=port, root=root)
-        self.proc = subprocess.Popen(command, stdout=self.log_file, stderr=subprocess.STDOUT, cwd=root)
+        self.proc: subprocess.Popen[str] | None = None
+        try:
+            self.proc = self.port_reservations.handoff_to(
+                (port,),
+                lambda: subprocess.Popen(
+                    command,
+                    stdout=self.log_file,
+                    stderr=subprocess.STDOUT,
+                    cwd=root,
+                ),
+            )
+        except BaseException:
+            self.stop()
+            raise
         if not wait_for_server(self.url):
             self.stop()
             out = _read_log_tail(self.log_path)
@@ -484,7 +516,7 @@ class PublicAntflyServer:
         self.log_file.flush()
         return _read_log_tail(self.log_path)
 
-    def pause(self) -> None:
+    def _stop_process(self) -> None:
         if self.proc and self.proc.poll() is None:
             self.proc.send_signal(signal.SIGTERM)
             try:
@@ -494,16 +526,29 @@ class PublicAntflyServer:
                 self.proc.wait()
         self.proc = None
 
+    def pause(self) -> None:
+        self._stop_process()
+        self.port_reservations.ensure_reserved(self.port)
+
     def resume(self) -> None:
         command = _legacy_stateful_command(self.binary, host=self.host, port=self.port, root=self.root)
-        self.proc = subprocess.Popen(command, stdout=self.log_file, stderr=subprocess.STDOUT, cwd=self.root)
+        self.proc = self.port_reservations.handoff_to(
+            (self.port,),
+            lambda: subprocess.Popen(
+                command,
+                stdout=self.log_file,
+                stderr=subprocess.STDOUT,
+                cwd=self.root,
+            ),
+        )
         if not wait_for_server(self.url):
             out = _read_log_tail(self.log_path)
             self.stop()
             raise RuntimeError(f"Public API server failed to resume at {self.url}\n{out}")
 
     def stop(self, *, test_failed: bool = False) -> None:
-        self.pause()
+        self._stop_process()
+        self.port_reservations.close()
         self.log_file.close()
         if not maybe_preserve_tempdir(self.tempdir, failed=test_failed):
             self.tempdir.cleanup()
@@ -818,6 +863,8 @@ class StandaloneAntflyServer:
     def __init__(self, binary: str, host: str, port: int):
         self.binary = binary
         self.host = host
+        self.port_reservations = LoopbackPortReservations(host)
+        port = self.port_reservations.reserve_requested(port)
         self.port = port
         self.url = f"http://{host}:{port}"
         self.api_url = antfly_public_api_url(self.url, binary=binary)
@@ -827,13 +874,26 @@ class StandaloneAntflyServer:
         self.log_path = self.root / "server.log"
         self.log_file = self.log_path.open("w")
         self.proc: subprocess.Popen[str] | None = None
-        self._start_process(truncate_logs=False)
+        try:
+            self._start_process(truncate_logs=False)
+        except BaseException:
+            if not self.log_file.closed:
+                self.stop()
+            raise
 
     def _start_process(self, *, truncate_logs: bool) -> None:
         if truncate_logs:
             self.log_file = self.log_path.open("w")
         command = _standalone_stateful_command(self.binary, host=self.host, port=self.port, root=self.root)
-        self.proc = subprocess.Popen(command, stdout=self.log_file, stderr=subprocess.STDOUT, cwd=self.root)
+        self.proc = self.port_reservations.handoff_to(
+            (self.port,),
+            lambda: subprocess.Popen(
+                command,
+                stdout=self.log_file,
+                stderr=subprocess.STDOUT,
+                cwd=self.root,
+            ),
+        )
         if not wait_for_server(self.api_url):
             self.stop()
             out = _read_log_tail(self.log_path)
@@ -866,19 +926,21 @@ class StandaloneAntflyServer:
         self.proc = None
 
     def restart(self) -> None:
-        self._stop_process()
+        self.pause()
         self.log_file.close()
         self.log_file = self.log_path.open("a")
         self._start_process(truncate_logs=False)
 
     def pause(self) -> None:
         self._stop_process()
+        self.port_reservations.ensure_reserved(self.port)
 
     def resume(self) -> None:
         self._start_process(truncate_logs=False)
 
     def stop(self, *, test_failed: bool = False) -> None:
         self._stop_process()
+        self.port_reservations.close()
         self.log_file.close()
         if not maybe_preserve_tempdir(self.tempdir, failed=test_failed):
             self.tempdir.cleanup()

--- a/zig/e2e/antfly/conftest.py
+++ b/zig/e2e/antfly/conftest.py
@@ -31,6 +31,7 @@ Usage:
 from __future__ import annotations
 
 import base64
+import errno
 import hashlib
 import json
 import os
@@ -191,6 +192,16 @@ class LoopbackPortReservations:
         self._sockets.clear()
         for sock in sockets:
             sock.close()
+
+
+def reserve_requested_port(reservations: LoopbackPortReservations, port: int) -> int:
+    """Reserve a requested port, falling back only when another listener owns it."""
+    try:
+        return reservations.reserve(port)
+    except OSError as exc:
+        if exc.errno != errno.EADDRINUSE:
+            raise
+        return reservations.reserve()
 
 
 def wait_for_server(
@@ -714,10 +725,7 @@ class StatefulAntflyServer:
         self.binary = binary
         self.host = host
         self.port_reservations = LoopbackPortReservations(host)
-        try:
-            self.port_reservations.reserve(port)
-        except OSError:
-            port = self.port_reservations.reserve()
+        port = reserve_requested_port(self.port_reservations, port)
         self.port = port
         self.auth_enabled = auth_enabled
         self.url = f"http://{host}:{port}"
@@ -740,7 +748,15 @@ class StatefulAntflyServer:
         metadata_admin_url = f"http://{host}:{metadata_admin_port}"
         self.metadata_admin_url = metadata_admin_url
 
-        self._start_processes(truncate_logs=False)
+        try:
+            self._start_processes(truncate_logs=False)
+        except BaseException:
+            # Startup failures inside wait_for_server already call stop(). A
+            # direct Popen failure does not, so release every reservation and
+            # close the fixture's files before propagating the original error.
+            if not self.metadata_log_file.closed or not self.data_log_file.closed:
+                self.stop()
+            raise
 
     def _start_processes(self, *, truncate_logs: bool) -> None:
         if truncate_logs:

--- a/zig/e2e/antfly/port_reservations.py
+++ b/zig/e2e/antfly/port_reservations.py
@@ -1,0 +1,152 @@
+# Copyright 2026 Antfly, Inc.
+#
+# Licensed under the Elastic License 2.0 (ELv2); you may not use this file
+# except in compliance with the Elastic License 2.0. You may obtain a copy of
+# the Elastic License 2.0 at
+#
+#     https://www.antfly.io/licensing/ELv2-license
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the Elastic License 2.0 is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# Elastic License 2.0 for the specific language governing permissions and
+# limitations.
+
+"""Kernel-backed listener-port leases for multi-process E2E fixtures."""
+
+from __future__ import annotations
+
+import errno
+import socket
+from collections.abc import Callable, Collection, Iterable
+from typing import TypeVar
+
+
+T = TypeVar("T")
+
+
+def find_free_port(host: str = "127.0.0.1") -> int:
+    """Return a free port for a caller that will bind it immediately."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind((host, 0))
+        return int(sock.getsockname()[1])
+
+
+class LoopbackPortReservations:
+    """Own loopback ports until a fixture hands them to a child process.
+
+    A pool belongs to one server or cluster fixture. Keeping the reservation
+    sockets open prevents both other tests and port-zero listeners in the same
+    cluster from claiming ports that have been advertised but not bound yet.
+    """
+
+    def __init__(self, host: str = "127.0.0.1") -> None:
+        self.host = host
+        self._sockets: dict[int, socket.socket] = {}
+
+    def __enter__(self) -> LoopbackPortReservations:
+        return self
+
+    def __exit__(self, *_exc_info: object) -> None:
+        self.close()
+
+    def reserve(self, port: int = 0) -> int:
+        return self._reserve(port, reuse_address=False)
+
+    def _reserve(self, port: int, *, reuse_address: bool) -> int:
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        try:
+            if reuse_address:
+                # Match the child listeners' restart semantics so a fixed-port
+                # lease can be reacquired while prior accepted connections
+                # remain in TIME_WAIT.
+                sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            sock.bind((self.host, port))
+            reserved_port = int(sock.getsockname()[1])
+            if reserved_port in self._sockets:
+                raise RuntimeError(f"kernel returned duplicate reserved port {reserved_port}")
+            self._sockets[reserved_port] = sock
+            return reserved_port
+        except BaseException:
+            sock.close()
+            raise
+
+    def reserve_many(self, count: int) -> tuple[int, ...]:
+        if count < 0:
+            raise ValueError("port reservation count must be non-negative")
+        ports: list[int] = []
+        try:
+            for _ in range(count):
+                ports.append(self.reserve())
+        except BaseException:
+            self.release_if_reserved(*ports)
+            raise
+        return tuple(ports)
+
+    def reserve_requested(self, port: int) -> int:
+        """Reserve a requested port, falling back only when it is already owned."""
+        try:
+            return self.reserve(port)
+        except OSError as exc:
+            if exc.errno != errno.EADDRINUSE:
+                raise
+            return self.reserve()
+
+    def reserve_excluding(self, excluded: Collection[int], *, attempts: int = 64) -> int:
+        """Reserve a kernel-selected port outside a fixture's advertised set."""
+        if attempts <= 0:
+            raise ValueError("port reservation attempts must be positive")
+        for _ in range(attempts):
+            port = self.reserve()
+            if port not in excluded:
+                return port
+            self.release(port)
+        raise RuntimeError("could not reserve a port outside the excluded set")
+
+    def ensure_reserved(self, *ports: int) -> None:
+        """Idempotently reacquire fixed ports, rolling back a partial acquisition."""
+        acquired: list[int] = []
+        try:
+            for port in ports:
+                if port in self._sockets:
+                    continue
+                self._reserve(port, reuse_address=True)
+                acquired.append(port)
+        except BaseException:
+            self.release_if_reserved(*acquired)
+            raise
+
+    def handoff_to(self, ports: Iterable[int], start: Callable[[], T]) -> T:
+        """Release fixed ports immediately before starting their child process."""
+        handed_off = tuple(ports)
+        self.ensure_reserved(*handed_off)
+        self.release(*handed_off)
+        try:
+            return start()
+        except BaseException:
+            # Preserve the process-spawn exception if another listener happens
+            # to claim a port before the parent can restore its lease.
+            try:
+                self.ensure_reserved(*handed_off)
+            except OSError:
+                pass
+            raise
+
+    def release(self, *ports: int) -> None:
+        for port in ports:
+            sock = self._sockets.pop(port, None)
+            if sock is None:
+                raise RuntimeError(f"port {port} is not reserved")
+            sock.close()
+
+    def release_if_reserved(self, *ports: int) -> None:
+        for port in ports:
+            sock = self._sockets.pop(port, None)
+            if sock is not None:
+                sock.close()
+
+    def close(self) -> None:
+        sockets = list(self._sockets.values())
+        self._sockets.clear()
+        for sock in sockets:
+            sock.close()

--- a/zig/e2e/antfly/test_auth.py
+++ b/zig/e2e/antfly/test_auth.py
@@ -40,7 +40,7 @@ from conftest import (
     resolve_binary_path,
     wait_for_server,
 )
-from port_reservations import find_free_port
+from port_reservations import LoopbackPortReservations, find_free_port
 
 AUTH_PUBLIC_API_ROOT = "/auth/v1"
 AUTH_STARTUP_TIMEOUT_SECONDS = 30.0
@@ -229,6 +229,8 @@ class AuthApi:
 
 class StandaloneAuthServer:
     def __init__(self, binary: str, host: str, port: int):
+        self.port_reservations = LoopbackPortReservations(host)
+        port = self.port_reservations.reserve_requested(port)
         self.url = f"http://{host}:{port}"
         self.api_url = antfly_public_api_url(self.url)
         self.tempdir = tempfile.TemporaryDirectory(prefix="antfly-zig-auth-e2e-")
@@ -238,12 +240,20 @@ class StandaloneAuthServer:
         self.log_file = self.log_path.open("w")
         command = _standalone_stateful_command(binary, host=host, port=port, root=root)
         command.extend(["--auth", "true"])
-        self.proc = subprocess.Popen(
-            command,
-            stdout=self.log_file,
-            stderr=subprocess.STDOUT,
-            cwd=root,
-        )
+        self.proc: subprocess.Popen[str] | None = None
+        try:
+            self.proc = self.port_reservations.handoff_to(
+                (port,),
+                lambda: subprocess.Popen(
+                    command,
+                    stdout=self.log_file,
+                    stderr=subprocess.STDOUT,
+                    cwd=root,
+                ),
+            )
+        except BaseException:
+            self.stop()
+            raise
         if not wait_for_server(self.api_url, allow_unauthorized=True):
             self.stop()
             out = _read_log_tail(self.log_path)
@@ -269,6 +279,7 @@ class StandaloneAuthServer:
         return ""
 
     def stop(self) -> None:
+        self.port_reservations.close()
         if self.proc and self.proc.poll() is None:
             self.proc.send_signal(signal.SIGTERM)
             try:

--- a/zig/e2e/antfly/test_auth.py
+++ b/zig/e2e/antfly/test_auth.py
@@ -22,6 +22,7 @@ import subprocess
 import tempfile
 import threading
 import time
+from contextlib import ExitStack
 from pathlib import Path
 
 import pytest
@@ -229,18 +230,22 @@ class AuthApi:
 
 class StandaloneAuthServer:
     def __init__(self, binary: str, host: str, port: int):
-        self.port_reservations = LoopbackPortReservations(host)
-        port = self.port_reservations.reserve_requested(port)
-        self.url = f"http://{host}:{port}"
-        self.api_url = antfly_public_api_url(self.url)
-        self.tempdir = tempfile.TemporaryDirectory(prefix="antfly-zig-auth-e2e-")
-        root = Path(self.tempdir.name)
-        self.root = root
-        self.log_path = root / "server.log"
-        self.log_file = self.log_path.open("w")
-        command = _standalone_stateful_command(binary, host=host, port=port, root=root)
-        command.extend(["--auth", "true"])
-        self.proc: subprocess.Popen[str] | None = None
+        with ExitStack() as setup:
+            self.port_reservations = LoopbackPortReservations(host)
+            setup.callback(self.port_reservations.close)
+            port = self.port_reservations.reserve_requested(port)
+            self.url = f"http://{host}:{port}"
+            self.api_url = antfly_public_api_url(self.url)
+            self.tempdir = tempfile.TemporaryDirectory(prefix="antfly-zig-auth-e2e-")
+            setup.callback(self.tempdir.cleanup)
+            root = Path(self.tempdir.name)
+            self.root = root
+            self.log_path = root / "server.log"
+            self.log_file = setup.enter_context(self.log_path.open("w"))
+            command = _standalone_stateful_command(binary, host=host, port=port, root=root)
+            command.extend(["--auth", "true"])
+            self.proc: subprocess.Popen[str] | None = None
+            setup.pop_all()
         try:
             self.proc = self.port_reservations.handoff_to(
                 (port,),

--- a/zig/e2e/antfly/test_auth.py
+++ b/zig/e2e/antfly/test_auth.py
@@ -33,7 +33,6 @@ from conftest import (
     _standalone_stateful_command,
     _read_log_tail,
     antfly_public_api_url,
-    find_free_port,
     lookup_key_path,
     maybe_preserve_tempdir,
     raise_if_server_process_exited,
@@ -41,6 +40,7 @@ from conftest import (
     resolve_binary_path,
     wait_for_server,
 )
+from port_reservations import find_free_port
 
 AUTH_PUBLIC_API_ROOT = "/auth/v1"
 AUTH_STARTUP_TIMEOUT_SECONDS = 30.0

--- a/zig/e2e/antfly/test_backup_restore.py
+++ b/zig/e2e/antfly/test_backup_restore.py
@@ -23,6 +23,7 @@ import subprocess
 import tempfile
 import time
 from concurrent.futures import ThreadPoolExecutor
+from contextlib import ExitStack
 from pathlib import Path
 
 import pytest
@@ -241,30 +242,43 @@ class MultiMetadataBackupCluster:
     def __init__(self, binary: str):
         self.binary = binary
         self.host = "127.0.0.1"
-        self.tempdir = tempfile.TemporaryDirectory(prefix="antfly-zig-metadata-backup-e2e-")
-        self.root = Path(self.tempdir.name)
-        self.port_reservations = LoopbackPortReservations(self.host)
+        with ExitStack() as setup:
+            self.tempdir = tempfile.TemporaryDirectory(
+                prefix="antfly-zig-metadata-backup-e2e-"
+            )
+            setup.callback(self.tempdir.cleanup)
+            self.root = Path(self.tempdir.name)
+            self.port_reservations = LoopbackPortReservations(self.host)
+            setup.callback(self.port_reservations.close)
 
-        self.metadata_raft_ports = list(self.port_reservations.reserve_many(3))
-        self.metadata_admin_ports = list(self.port_reservations.reserve_many(3))
-        self.metadata_admin_urls = [f"http://{self.host}:{port}" for port in self.metadata_admin_ports]
-        self.metadata_public_urls = [
-            antfly_public_api_url(url, root=ANTFLY_PUBLIC_API_ROOT) for url in self.metadata_admin_urls
-        ]
-        self.data_port, self.data_raft_port = self.port_reservations.reserve_many(2)
-        self.data_url = f"http://{self.host}:{self.data_port}"
-        self.data_api_url = antfly_public_api_url(self.data_url, binary=binary)
+            self.metadata_raft_ports = list(self.port_reservations.reserve_many(3))
+            self.metadata_admin_ports = list(self.port_reservations.reserve_many(3))
+            self.metadata_admin_urls = [
+                f"http://{self.host}:{port}" for port in self.metadata_admin_ports
+            ]
+            self.metadata_public_urls = [
+                antfly_public_api_url(url, root=ANTFLY_PUBLIC_API_ROOT)
+                for url in self.metadata_admin_urls
+            ]
+            self.data_port, self.data_raft_port = self.port_reservations.reserve_many(2)
+            self.data_url = f"http://{self.host}:{self.data_port}"
+            self.data_api_url = antfly_public_api_url(self.data_url, binary=binary)
 
-        self.config_path = self.root / "antfly-metadata-cluster.json"
-        self._write_config()
+            self.config_path = self.root / "antfly-metadata-cluster.json"
+            self._write_config()
 
-        self.metadata_log_paths = [self.root / f"metadata-{node_id}.log" for node_id in range(1, 4)]
-        self.metadata_log_files = [path.open("w") for path in self.metadata_log_paths]
-        self.data_log_path = self.root / "data.log"
-        self.data_log_file = self.data_log_path.open("w")
+            self.metadata_log_paths = [
+                self.root / f"metadata-{node_id}.log" for node_id in range(1, 4)
+            ]
+            self.metadata_log_files = [
+                setup.enter_context(path.open("w")) for path in self.metadata_log_paths
+            ]
+            self.data_log_path = self.root / "data.log"
+            self.data_log_file = setup.enter_context(self.data_log_path.open("w"))
 
-        self.metadata_procs: list[subprocess.Popen[str]] = []
-        self.data_proc: subprocess.Popen[str] | None = None
+            self.metadata_procs: list[subprocess.Popen[str]] = []
+            self.data_proc: subprocess.Popen[str] | None = None
+            setup.pop_all()
 
         try:
             self._start()

--- a/zig/e2e/antfly/test_backup_restore.py
+++ b/zig/e2e/antfly/test_backup_restore.py
@@ -31,7 +31,6 @@ import requests
 from conftest import (
     ANTFLY_PUBLIC_API_ROOT,
     DEFAULT_ANTFLY_BIN,
-    LoopbackPortReservations,
     REPO_ROOT,
     _read_log_tail,
     antfly_public_api_url,
@@ -40,6 +39,7 @@ from conftest import (
     wait_for_server,
 )
 from helpers import wait_until
+from port_reservations import LoopbackPortReservations
 
 BACKUP_CONNECTION = "e2e-backups"
 
@@ -245,14 +245,13 @@ class MultiMetadataBackupCluster:
         self.root = Path(self.tempdir.name)
         self.port_reservations = LoopbackPortReservations(self.host)
 
-        self.metadata_raft_ports = [self.port_reservations.reserve() for _ in range(3)]
-        self.metadata_admin_ports = [self.port_reservations.reserve() for _ in range(3)]
+        self.metadata_raft_ports = list(self.port_reservations.reserve_many(3))
+        self.metadata_admin_ports = list(self.port_reservations.reserve_many(3))
         self.metadata_admin_urls = [f"http://{self.host}:{port}" for port in self.metadata_admin_ports]
         self.metadata_public_urls = [
             antfly_public_api_url(url, root=ANTFLY_PUBLIC_API_ROOT) for url in self.metadata_admin_urls
         ]
-        self.data_port = self.port_reservations.reserve()
-        self.data_raft_port = self.port_reservations.reserve()
+        self.data_port, self.data_raft_port = self.port_reservations.reserve_many(2)
         self.data_url = f"http://{self.host}:{self.data_port}"
         self.data_api_url = antfly_public_api_url(self.data_url, binary=binary)
 
@@ -376,15 +375,14 @@ class MultiMetadataBackupCluster:
     def _start(self) -> None:
         for i in range(3):
             command = self._metadata_command(i + 1)
-            self.port_reservations.release(
-                self.metadata_raft_ports[i],
-                self.metadata_admin_ports[i],
-            )
-            proc = subprocess.Popen(
-                command,
-                stdout=self.metadata_log_files[i],
-                stderr=subprocess.STDOUT,
-                cwd=REPO_ROOT,
+            proc = self.port_reservations.handoff_to(
+                (self.metadata_raft_ports[i], self.metadata_admin_ports[i]),
+                lambda: subprocess.Popen(
+                    command,
+                    stdout=self.metadata_log_files[i],
+                    stderr=subprocess.STDOUT,
+                    cwd=REPO_ROOT,
+                ),
             )
             self.metadata_procs.append(proc)
 
@@ -396,12 +394,14 @@ class MultiMetadataBackupCluster:
             raise RuntimeError(f"metadata cluster did not elect a leader\n{self.debug_logs()}")
 
         data_command = self._data_command()
-        self.port_reservations.release(self.data_port, self.data_raft_port)
-        self.data_proc = subprocess.Popen(
-            data_command,
-            stdout=self.data_log_file,
-            stderr=subprocess.STDOUT,
-            cwd=REPO_ROOT,
+        self.data_proc = self.port_reservations.handoff_to(
+            (self.data_port, self.data_raft_port),
+            lambda: subprocess.Popen(
+                data_command,
+                stdout=self.data_log_file,
+                stderr=subprocess.STDOUT,
+                cwd=REPO_ROOT,
+            ),
         )
         if not wait_for_server(self.data_api_url, timeout=30.0):
             raise RuntimeError(f"data server failed to start at {self.data_api_url}\n{self.debug_logs()}")

--- a/zig/e2e/antfly/test_backup_restore.py
+++ b/zig/e2e/antfly/test_backup_restore.py
@@ -31,10 +31,10 @@ import requests
 from conftest import (
     ANTFLY_PUBLIC_API_ROOT,
     DEFAULT_ANTFLY_BIN,
+    LoopbackPortReservations,
     REPO_ROOT,
     _read_log_tail,
     antfly_public_api_url,
-    find_free_port,
     maybe_preserve_tempdir,
     resolve_binary_path,
     wait_for_server,
@@ -243,15 +243,16 @@ class MultiMetadataBackupCluster:
         self.host = "127.0.0.1"
         self.tempdir = tempfile.TemporaryDirectory(prefix="antfly-zig-metadata-backup-e2e-")
         self.root = Path(self.tempdir.name)
+        self.port_reservations = LoopbackPortReservations(self.host)
 
-        self.metadata_raft_ports = [find_free_port() for _ in range(3)]
-        self.metadata_admin_ports = [find_free_port() for _ in range(3)]
+        self.metadata_raft_ports = [self.port_reservations.reserve() for _ in range(3)]
+        self.metadata_admin_ports = [self.port_reservations.reserve() for _ in range(3)]
         self.metadata_admin_urls = [f"http://{self.host}:{port}" for port in self.metadata_admin_ports]
         self.metadata_public_urls = [
             antfly_public_api_url(url, root=ANTFLY_PUBLIC_API_ROOT) for url in self.metadata_admin_urls
         ]
-        self.data_port = find_free_port()
-        self.data_raft_port = find_free_port()
+        self.data_port = self.port_reservations.reserve()
+        self.data_raft_port = self.port_reservations.reserve()
         self.data_url = f"http://{self.host}:{self.data_port}"
         self.data_api_url = antfly_public_api_url(self.data_url, binary=binary)
 
@@ -374,8 +375,13 @@ class MultiMetadataBackupCluster:
 
     def _start(self) -> None:
         for i in range(3):
+            command = self._metadata_command(i + 1)
+            self.port_reservations.release(
+                self.metadata_raft_ports[i],
+                self.metadata_admin_ports[i],
+            )
             proc = subprocess.Popen(
-                self._metadata_command(i + 1),
+                command,
                 stdout=self.metadata_log_files[i],
                 stderr=subprocess.STDOUT,
                 cwd=REPO_ROOT,
@@ -389,8 +395,10 @@ class MultiMetadataBackupCluster:
         if self.metadata_stable_leader_index(timeout_s=30.0) is None:
             raise RuntimeError(f"metadata cluster did not elect a leader\n{self.debug_logs()}")
 
+        data_command = self._data_command()
+        self.port_reservations.release(self.data_port, self.data_raft_port)
         self.data_proc = subprocess.Popen(
-            self._data_command(),
+            data_command,
             stdout=self.data_log_file,
             stderr=subprocess.STDOUT,
             cwd=REPO_ROOT,
@@ -489,6 +497,7 @@ class MultiMetadataBackupCluster:
         return self.metadata_public_urls[leader_index]
 
     def stop(self) -> None:
+        self.port_reservations.close()
         if self.data_proc is not None and self.data_proc.poll() is None:
             self.data_proc.send_signal(signal.SIGTERM)
             try:

--- a/zig/e2e/antfly/test_cdc.py
+++ b/zig/e2e/antfly/test_cdc.py
@@ -27,7 +27,6 @@ from conftest import (
     ANTFLY_PUBLIC_API_ROOT,
     DEFAULT_ANTFLY_BIN,
     StatefulAntflyServer,
-    find_free_port,
     lookup_key_path,
     raise_request_error_with_logs,
     resolve_binary_path,
@@ -35,6 +34,7 @@ from conftest import (
     with_api_root,
 )
 from helpers import wait_until
+from port_reservations import find_free_port
 
 pytestmark = pytest.mark.postgres_integration
 

--- a/zig/e2e/antfly/test_cli.py
+++ b/zig/e2e/antfly/test_cli.py
@@ -33,11 +33,11 @@ import requests
 from conftest import (
     DEFAULT_ANTFLY_BIN,
     StandaloneAntflyServer,
-    find_free_port,
     resolve_binary_path,
     wait_for_server,
 )
 from helpers import wait_until
+from port_reservations import find_free_port
 
 
 @pytest.fixture(scope="module")

--- a/zig/e2e/antfly/test_distributed_status.py
+++ b/zig/e2e/antfly/test_distributed_status.py
@@ -27,7 +27,6 @@ import requests
 
 from conftest import (
     DEFAULT_ANTFLY_BIN,
-    LoopbackPortReservations,
     REPO_ROOT,
     _metadata_command,
     _read_log_tail,
@@ -35,6 +34,7 @@ from conftest import (
     maybe_preserve_tempdir,
     wait_for_server,
 )
+from port_reservations import LoopbackPortReservations
 from helpers import wait_until
 
 
@@ -92,12 +92,14 @@ class SplitStatusCluster:
         self.root = Path(self.tempdir.name)
         self.port_reservations = LoopbackPortReservations(self.host)
 
-        self.metadata_port = self.port_reservations.reserve()
-        self.metadata_admin_port = self.port_reservations.reserve()
-        self.data_port = self.port_reservations.reserve()
-        self.data_raft_port = self.port_reservations.reserve()
-        self.api_port = self.port_reservations.reserve()
-        self.api_raft_port = self.port_reservations.reserve()
+        (
+            self.metadata_port,
+            self.metadata_admin_port,
+            self.data_port,
+            self.data_raft_port,
+            self.api_port,
+            self.api_raft_port,
+        ) = self.port_reservations.reserve_many(6)
 
         self.metadata_admin_url = f"http://{self.host}:{self.metadata_admin_port}"
         self.data_url = f"http://{self.host}:{self.data_port}"
@@ -129,12 +131,14 @@ class SplitStatusCluster:
             admin_port=self.metadata_admin_port,
             root=self.root,
         )
-        self.port_reservations.release(self.metadata_port, self.metadata_admin_port)
-        self.metadata_proc = subprocess.Popen(
-            metadata_command,
-            stdout=self.metadata_log_file,
-            stderr=subprocess.STDOUT,
-            cwd=REPO_ROOT,
+        self.metadata_proc = self.port_reservations.handoff_to(
+            (self.metadata_port, self.metadata_admin_port),
+            lambda: subprocess.Popen(
+                metadata_command,
+                stdout=self.metadata_log_file,
+                stderr=subprocess.STDOUT,
+                cwd=REPO_ROOT,
+            ),
         )
         if not wait_for_server(self.metadata_admin_url, path="/metadata/v1/status"):
             raise RuntimeError(f"Metadata server failed to start\n{self.debug_logs()}")
@@ -150,12 +154,14 @@ class SplitStatusCluster:
             store_id=2,
             store_role="data",
         )
-        self.port_reservations.release(self.data_port, self.data_raft_port)
-        self.data_proc = subprocess.Popen(
-            data_command,
-            stdout=self.data_log_file,
-            stderr=subprocess.STDOUT,
-            cwd=REPO_ROOT,
+        self.data_proc = self.port_reservations.handoff_to(
+            (self.data_port, self.data_raft_port),
+            lambda: subprocess.Popen(
+                data_command,
+                stdout=self.data_log_file,
+                stderr=subprocess.STDOUT,
+                cwd=REPO_ROOT,
+            ),
         )
         if not wait_for_server(self.data_api_url):
             raise RuntimeError(f"Data owner failed to start\n{self.debug_logs()}")
@@ -171,12 +177,14 @@ class SplitStatusCluster:
             store_id=3,
             store_role="api",
         )
-        self.port_reservations.release(self.api_port, self.api_raft_port)
-        self.api_proc = subprocess.Popen(
-            api_command,
-            stdout=self.api_log_file,
-            stderr=subprocess.STDOUT,
-            cwd=REPO_ROOT,
+        self.api_proc = self.port_reservations.handoff_to(
+            (self.api_port, self.api_raft_port),
+            lambda: subprocess.Popen(
+                api_command,
+                stdout=self.api_log_file,
+                stderr=subprocess.STDOUT,
+                cwd=REPO_ROOT,
+            ),
         )
         if not wait_for_server(self.api_url):
             raise RuntimeError(f"API-only node failed to start\n{self.debug_logs()}")

--- a/zig/e2e/antfly/test_distributed_status.py
+++ b/zig/e2e/antfly/test_distributed_status.py
@@ -27,11 +27,11 @@ import requests
 
 from conftest import (
     DEFAULT_ANTFLY_BIN,
+    LoopbackPortReservations,
     REPO_ROOT,
     _metadata_command,
     _read_log_tail,
     antfly_public_api_url,
-    find_free_port,
     maybe_preserve_tempdir,
     wait_for_server,
 )
@@ -61,8 +61,8 @@ def _data_command(
         host,
         "--raft-port",
         str(raft_port),
-        "--health-port",
-        str(find_free_port()),
+        "--health",
+        "false",
         "--metadata-api",
         metadata_admin_base_uri,
         "--node-id",
@@ -90,13 +90,14 @@ class SplitStatusCluster:
         self.host = "127.0.0.1"
         self.tempdir = tempfile.TemporaryDirectory(prefix="antfly-zig-status-e2e-")
         self.root = Path(self.tempdir.name)
+        self.port_reservations = LoopbackPortReservations(self.host)
 
-        self.metadata_port = find_free_port()
-        self.metadata_admin_port = find_free_port()
-        self.data_port = find_free_port()
-        self.data_raft_port = find_free_port()
-        self.api_port = find_free_port()
-        self.api_raft_port = find_free_port()
+        self.metadata_port = self.port_reservations.reserve()
+        self.metadata_admin_port = self.port_reservations.reserve()
+        self.data_port = self.port_reservations.reserve()
+        self.data_raft_port = self.port_reservations.reserve()
+        self.api_port = self.port_reservations.reserve()
+        self.api_raft_port = self.port_reservations.reserve()
 
         self.metadata_admin_url = f"http://{self.host}:{self.metadata_admin_port}"
         self.data_url = f"http://{self.host}:{self.data_port}"
@@ -128,6 +129,7 @@ class SplitStatusCluster:
             admin_port=self.metadata_admin_port,
             root=self.root,
         )
+        self.port_reservations.release(self.metadata_port, self.metadata_admin_port)
         self.metadata_proc = subprocess.Popen(
             metadata_command,
             stdout=self.metadata_log_file,
@@ -148,6 +150,7 @@ class SplitStatusCluster:
             store_id=2,
             store_role="data",
         )
+        self.port_reservations.release(self.data_port, self.data_raft_port)
         self.data_proc = subprocess.Popen(
             data_command,
             stdout=self.data_log_file,
@@ -168,6 +171,7 @@ class SplitStatusCluster:
             store_id=3,
             store_role="api",
         )
+        self.port_reservations.release(self.api_port, self.api_raft_port)
         self.api_proc = subprocess.Popen(
             api_command,
             stdout=self.api_log_file,
@@ -193,6 +197,7 @@ class SplitStatusCluster:
         return payload if isinstance(payload, dict) else {}
 
     def stop(self) -> None:
+        self.port_reservations.close()
         for proc in (self.api_proc, self.data_proc, self.metadata_proc):
             if proc is not None and proc.poll() is None:
                 proc.send_signal(signal.SIGTERM)

--- a/zig/e2e/antfly/test_distributed_status.py
+++ b/zig/e2e/antfly/test_distributed_status.py
@@ -19,6 +19,7 @@ import signal
 import subprocess
 import tempfile
 import time
+from contextlib import ExitStack
 from pathlib import Path
 from typing import Any
 
@@ -88,34 +89,40 @@ class SplitStatusCluster:
     def __init__(self, binary: str):
         self.binary = binary
         self.host = "127.0.0.1"
-        self.tempdir = tempfile.TemporaryDirectory(prefix="antfly-zig-status-e2e-")
-        self.root = Path(self.tempdir.name)
-        self.port_reservations = LoopbackPortReservations(self.host)
+        with ExitStack() as setup:
+            self.tempdir = tempfile.TemporaryDirectory(prefix="antfly-zig-status-e2e-")
+            setup.callback(self.tempdir.cleanup)
+            self.root = Path(self.tempdir.name)
+            self.port_reservations = LoopbackPortReservations(self.host)
+            setup.callback(self.port_reservations.close)
 
-        (
-            self.metadata_port,
-            self.metadata_admin_port,
-            self.data_port,
-            self.data_raft_port,
-            self.api_port,
-            self.api_raft_port,
-        ) = self.port_reservations.reserve_many(6)
+            (
+                self.metadata_port,
+                self.metadata_admin_port,
+                self.data_port,
+                self.data_raft_port,
+                self.api_port,
+                self.api_raft_port,
+            ) = self.port_reservations.reserve_many(6)
 
-        self.metadata_admin_url = f"http://{self.host}:{self.metadata_admin_port}"
-        self.data_url = f"http://{self.host}:{self.data_port}"
-        self.data_api_url = antfly_public_api_url(self.data_url, binary=binary)
-        self.api_url = antfly_public_api_url(f"http://{self.host}:{self.api_port}", binary=binary)
+            self.metadata_admin_url = f"http://{self.host}:{self.metadata_admin_port}"
+            self.data_url = f"http://{self.host}:{self.data_port}"
+            self.data_api_url = antfly_public_api_url(self.data_url, binary=binary)
+            self.api_url = antfly_public_api_url(
+                f"http://{self.host}:{self.api_port}", binary=binary
+            )
 
-        self.metadata_log_path = self.root / "metadata.log"
-        self.data_log_path = self.root / "data-owner.log"
-        self.api_log_path = self.root / "api-node.log"
-        self.metadata_log_file = self.metadata_log_path.open("w")
-        self.data_log_file = self.data_log_path.open("w")
-        self.api_log_file = self.api_log_path.open("w")
+            self.metadata_log_path = self.root / "metadata.log"
+            self.data_log_path = self.root / "data-owner.log"
+            self.api_log_path = self.root / "api-node.log"
+            self.metadata_log_file = setup.enter_context(self.metadata_log_path.open("w"))
+            self.data_log_file = setup.enter_context(self.data_log_path.open("w"))
+            self.api_log_file = setup.enter_context(self.api_log_path.open("w"))
 
-        self.metadata_proc: subprocess.Popen[str] | None = None
-        self.data_proc: subprocess.Popen[str] | None = None
-        self.api_proc: subprocess.Popen[str] | None = None
+            self.metadata_proc: subprocess.Popen[str] | None = None
+            self.data_proc: subprocess.Popen[str] | None = None
+            self.api_proc: subprocess.Popen[str] | None = None
+            setup.pop_all()
 
         try:
             self._start()

--- a/zig/e2e/antfly/test_extensions.py
+++ b/zig/e2e/antfly/test_extensions.py
@@ -27,13 +27,13 @@ import requests
 
 from conftest import (
     DEFAULT_ANTFLY_BIN,
+    LoopbackPortReservations,
     REPO_ROOT,
     _data_command,
     _metadata_command,
     _read_log_tail,
     _write_remote_content_e2e_config,
     antfly_public_api_url,
-    find_free_port,
     maybe_preserve_tempdir,
     wait_for_server,
 )
@@ -62,10 +62,11 @@ class _ExtensionProcess:
         if not (self.package_store / "memoryaf" / "extension.json").exists():
             raise RuntimeError(f"memoryaf extension package not found under {self.package_store}")
 
-        self.public_port = find_free_port()
-        self.metadata_raft_port = find_free_port()
-        self.metadata_admin_port = find_free_port()
-        self.data_raft_port = find_free_port()
+        self.port_reservations = LoopbackPortReservations(self.host)
+        self.public_port = self.port_reservations.reserve()
+        self.metadata_raft_port = self.port_reservations.reserve()
+        self.metadata_admin_port = self.port_reservations.reserve()
+        self.data_raft_port = self.port_reservations.reserve()
         self.url = f"http://{self.host}:{self.public_port}"
         self.api_url = antfly_public_api_url(self.url, binary=binary)
         self.metadata_admin_url = f"http://{self.host}:{self.metadata_admin_port}"
@@ -115,6 +116,7 @@ class _ExtensionProcess:
             "--extension-package-store",
             str(self.package_store),
         ]
+        self.port_reservations.release(self.public_port)
         self.standalone_proc = subprocess.Popen(command, stdout=self.standalone_log_file, stderr=subprocess.STDOUT, cwd=self.root, env=env)
         if not wait_for_server(self.api_url):
             raise RuntimeError(f"standalone extension server failed to start\n{self.debug_logs()}")
@@ -129,6 +131,7 @@ class _ExtensionProcess:
             root=self.root,
         )
         metadata_command.extend(["--extension-package-store", str(self.package_store)])
+        self.port_reservations.release(self.metadata_raft_port, self.metadata_admin_port)
         self.metadata_proc = subprocess.Popen(
             metadata_command,
             stdout=self.metadata_log_file,
@@ -147,6 +150,7 @@ class _ExtensionProcess:
             metadata_admin_base_uri=self.metadata_admin_url,
             root=self.root,
         )
+        self.port_reservations.release(self.public_port, self.data_raft_port)
         self.data_proc = subprocess.Popen(
             data_command,
             stdout=self.data_log_file,
@@ -172,6 +176,7 @@ class _ExtensionProcess:
         )
 
     def stop(self) -> None:
+        self.port_reservations.close()
         for proc in (self.data_proc, self.metadata_proc, self.standalone_proc):
             if proc is not None and proc.poll() is None:
                 proc.send_signal(signal.SIGTERM)

--- a/zig/e2e/antfly/test_extensions.py
+++ b/zig/e2e/antfly/test_extensions.py
@@ -27,7 +27,6 @@ import requests
 
 from conftest import (
     DEFAULT_ANTFLY_BIN,
-    LoopbackPortReservations,
     REPO_ROOT,
     _data_command,
     _metadata_command,
@@ -38,6 +37,7 @@ from conftest import (
     wait_for_server,
 )
 from helpers import wait_until
+from port_reservations import LoopbackPortReservations
 
 pytestmark = pytest.mark.slow
 
@@ -61,15 +61,27 @@ class _ExtensionProcess:
         self.package_store = MEMORYAF_PACKAGE_STORE
         if not (self.package_store / "memoryaf" / "extension.json").exists():
             raise RuntimeError(f"memoryaf extension package not found under {self.package_store}")
+        if mode not in {"standalone", "distributed"}:
+            raise ValueError(mode)
 
         self.port_reservations = LoopbackPortReservations(self.host)
         self.public_port = self.port_reservations.reserve()
-        self.metadata_raft_port = self.port_reservations.reserve()
-        self.metadata_admin_port = self.port_reservations.reserve()
-        self.data_raft_port = self.port_reservations.reserve()
+        self.metadata_raft_port: int | None = None
+        self.metadata_admin_port: int | None = None
+        self.data_raft_port: int | None = None
+        if mode == "distributed":
+            (
+                self.metadata_raft_port,
+                self.metadata_admin_port,
+                self.data_raft_port,
+            ) = self.port_reservations.reserve_many(3)
         self.url = f"http://{self.host}:{self.public_port}"
         self.api_url = antfly_public_api_url(self.url, binary=binary)
-        self.metadata_admin_url = f"http://{self.host}:{self.metadata_admin_port}"
+        self.metadata_admin_url = (
+            f"http://{self.host}:{self.metadata_admin_port}"
+            if self.metadata_admin_port is not None
+            else None
+        )
 
         self.standalone_log_path = self.root / "standalone.log"
         self.metadata_log_path = self.root / "metadata.log"
@@ -84,10 +96,8 @@ class _ExtensionProcess:
         try:
             if mode == "standalone":
                 self._start_standalone()
-            elif mode == "distributed":
-                self._start_distributed()
             else:
-                raise ValueError(mode)
+                self._start_distributed()
         except BaseException:
             self.stop()
             raise
@@ -116,12 +126,24 @@ class _ExtensionProcess:
             "--extension-package-store",
             str(self.package_store),
         ]
-        self.port_reservations.release(self.public_port)
-        self.standalone_proc = subprocess.Popen(command, stdout=self.standalone_log_file, stderr=subprocess.STDOUT, cwd=self.root, env=env)
+        self.standalone_proc = self.port_reservations.handoff_to(
+            (self.public_port,),
+            lambda: subprocess.Popen(
+                command,
+                stdout=self.standalone_log_file,
+                stderr=subprocess.STDOUT,
+                cwd=self.root,
+                env=env,
+            ),
+        )
         if not wait_for_server(self.api_url):
             raise RuntimeError(f"standalone extension server failed to start\n{self.debug_logs()}")
 
     def _start_distributed(self) -> None:
+        assert self.metadata_raft_port is not None
+        assert self.metadata_admin_port is not None
+        assert self.metadata_admin_url is not None
+        assert self.data_raft_port is not None
         env = self._server_env()
         metadata_command = _metadata_command(
             self.binary,
@@ -131,13 +153,15 @@ class _ExtensionProcess:
             root=self.root,
         )
         metadata_command.extend(["--extension-package-store", str(self.package_store)])
-        self.port_reservations.release(self.metadata_raft_port, self.metadata_admin_port)
-        self.metadata_proc = subprocess.Popen(
-            metadata_command,
-            stdout=self.metadata_log_file,
-            stderr=subprocess.STDOUT,
-            cwd=self.root,
-            env=env,
+        self.metadata_proc = self.port_reservations.handoff_to(
+            (self.metadata_raft_port, self.metadata_admin_port),
+            lambda: subprocess.Popen(
+                metadata_command,
+                stdout=self.metadata_log_file,
+                stderr=subprocess.STDOUT,
+                cwd=self.root,
+                env=env,
+            ),
         )
         if not wait_for_server(self.metadata_admin_url, path="/metadata/v1/status"):
             raise RuntimeError(f"metadata extension server failed to start\n{self.debug_logs()}")
@@ -150,13 +174,15 @@ class _ExtensionProcess:
             metadata_admin_base_uri=self.metadata_admin_url,
             root=self.root,
         )
-        self.port_reservations.release(self.public_port, self.data_raft_port)
-        self.data_proc = subprocess.Popen(
-            data_command,
-            stdout=self.data_log_file,
-            stderr=subprocess.STDOUT,
-            cwd=self.root,
-            env=env,
+        self.data_proc = self.port_reservations.handoff_to(
+            (self.public_port, self.data_raft_port),
+            lambda: subprocess.Popen(
+                data_command,
+                stdout=self.data_log_file,
+                stderr=subprocess.STDOUT,
+                cwd=self.root,
+                env=env,
+            ),
         )
         if not wait_for_server(self.api_url):
             raise RuntimeError(f"data extension server failed to start\n{self.debug_logs()}")

--- a/zig/e2e/antfly/test_extensions.py
+++ b/zig/e2e/antfly/test_extensions.py
@@ -19,6 +19,7 @@ import json
 import signal
 import subprocess
 import tempfile
+from contextlib import ExitStack
 from pathlib import Path
 from typing import Any
 
@@ -31,7 +32,7 @@ from conftest import (
     _data_command,
     _metadata_command,
     _read_log_tail,
-    _write_remote_content_e2e_config,
+    _standalone_stateful_command,
     antfly_public_api_url,
     maybe_preserve_tempdir,
     wait_for_server,
@@ -56,42 +57,46 @@ class _ExtensionProcess:
         self.binary = binary
         self.mode = mode
         self.host = "127.0.0.1"
-        self.tempdir = tempfile.TemporaryDirectory(prefix=f"antfly-zig-extensions-{mode}-")
-        self.root = Path(self.tempdir.name)
         self.package_store = MEMORYAF_PACKAGE_STORE
         if not (self.package_store / "memoryaf" / "extension.json").exists():
             raise RuntimeError(f"memoryaf extension package not found under {self.package_store}")
         if mode not in {"standalone", "distributed"}:
             raise ValueError(mode)
 
-        self.port_reservations = LoopbackPortReservations(self.host)
-        self.public_port = self.port_reservations.reserve()
-        self.metadata_raft_port: int | None = None
-        self.metadata_admin_port: int | None = None
-        self.data_raft_port: int | None = None
-        if mode == "distributed":
-            (
-                self.metadata_raft_port,
-                self.metadata_admin_port,
-                self.data_raft_port,
-            ) = self.port_reservations.reserve_many(3)
-        self.url = f"http://{self.host}:{self.public_port}"
-        self.api_url = antfly_public_api_url(self.url, binary=binary)
-        self.metadata_admin_url = (
-            f"http://{self.host}:{self.metadata_admin_port}"
-            if self.metadata_admin_port is not None
-            else None
-        )
+        with ExitStack() as setup:
+            self.tempdir = tempfile.TemporaryDirectory(prefix=f"antfly-zig-extensions-{mode}-")
+            setup.callback(self.tempdir.cleanup)
+            self.root = Path(self.tempdir.name)
+            self.port_reservations = LoopbackPortReservations(self.host)
+            setup.callback(self.port_reservations.close)
+            self.public_port = self.port_reservations.reserve()
+            self.metadata_raft_port: int | None = None
+            self.metadata_admin_port: int | None = None
+            self.data_raft_port: int | None = None
+            if mode == "distributed":
+                (
+                    self.metadata_raft_port,
+                    self.metadata_admin_port,
+                    self.data_raft_port,
+                ) = self.port_reservations.reserve_many(3)
+            self.url = f"http://{self.host}:{self.public_port}"
+            self.api_url = antfly_public_api_url(self.url, binary=binary)
+            self.metadata_admin_url = (
+                f"http://{self.host}:{self.metadata_admin_port}"
+                if self.metadata_admin_port is not None
+                else None
+            )
 
-        self.standalone_log_path = self.root / "standalone.log"
-        self.metadata_log_path = self.root / "metadata.log"
-        self.data_log_path = self.root / "data.log"
-        self.standalone_log_file = self.standalone_log_path.open("w")
-        self.metadata_log_file = self.metadata_log_path.open("w")
-        self.data_log_file = self.data_log_path.open("w")
-        self.standalone_proc: subprocess.Popen[str] | None = None
-        self.metadata_proc: subprocess.Popen[str] | None = None
-        self.data_proc: subprocess.Popen[str] | None = None
+            self.standalone_log_path = self.root / "standalone.log"
+            self.metadata_log_path = self.root / "metadata.log"
+            self.data_log_path = self.root / "data.log"
+            self.standalone_log_file = setup.enter_context(self.standalone_log_path.open("w"))
+            self.metadata_log_file = setup.enter_context(self.metadata_log_path.open("w"))
+            self.data_log_file = setup.enter_context(self.data_log_path.open("w"))
+            self.standalone_proc: subprocess.Popen[str] | None = None
+            self.metadata_proc: subprocess.Popen[str] | None = None
+            self.data_proc: subprocess.Popen[str] | None = None
+            setup.pop_all()
 
         try:
             if mode == "standalone":
@@ -104,28 +109,13 @@ class _ExtensionProcess:
 
     def _start_standalone(self) -> None:
         env = self._server_env()
-        command = [
+        command = _standalone_stateful_command(
             self.binary,
-            "standalone",
-            "--config",
-            str(_write_remote_content_e2e_config(self.root)),
-            "--host",
-            self.host,
-            "--port",
-            str(self.public_port),
-            "--data-dir",
-            str(self.root),
-            "--control-tick-ms",
-            "5",
-            "--replica-root-dir",
-            str(self.root / "replicas"),
-            "--replica-catalog-path",
-            str(self.root / "catalog.txt"),
-            "--snapshot-root-dir",
-            str(self.root / "snapshots"),
-            "--extension-package-store",
-            str(self.package_store),
-        ]
+            host=self.host,
+            port=self.public_port,
+            root=self.root,
+        )
+        command.extend(["--extension-package-store", str(self.package_store)])
         self.standalone_proc = self.port_reservations.handoff_to(
             (self.public_port,),
             lambda: subprocess.Popen(

--- a/zig/e2e/antfly/test_port_reservations.py
+++ b/zig/e2e/antfly/test_port_reservations.py
@@ -35,6 +35,7 @@ from conftest import (
 from port_reservations import LoopbackPortReservations, find_free_port
 from test_auth import StandaloneAuthServer
 from test_standalone import EmbeddedInferenceStandaloneServer
+from test_standby import HAStandaloneNode
 
 
 def test_loopback_port_reservations_hold_ports_until_handoff():
@@ -240,6 +241,42 @@ def test_standalone_fixture_command_disables_unused_health_listener(tmp_path: Pa
 
     health_flag = command.index("--health")
     assert command[health_flag + 1] == "false"
+
+
+def test_ha_standalone_node_reenables_its_reserved_health_listener(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    command: list[str] = []
+
+    class ExitedProcess:
+        def poll(self) -> int:
+            return 0
+
+    def capture_command(args: list[str], **kwargs: Any) -> ExitedProcess:
+        command.extend(args)
+        return ExitedProcess()
+
+    monkeypatch.setattr(subprocess, "Popen", capture_command)
+    monkeypatch.setattr("test_standby.wait_for_server", lambda *args, **kwargs: True)
+    node = HAStandaloneNode(
+        binary="/missing-antfly",
+        root=tmp_path,
+        role="primary",
+        node_id="primary-a",
+        cluster_id=100,
+        timeline_id=1,
+        epoch=1,
+    )
+    try:
+        node.start()
+
+        health_flags = [index for index, arg in enumerate(command) if arg == "--health"]
+        assert command[health_flags[-1] + 1] == "true"
+        health_port_flag = command.index("--health-port")
+        assert command[health_port_flag + 1] == str(node.health_port)
+    finally:
+        node.close()
 
 
 @pytest.mark.parametrize(

--- a/zig/e2e/antfly/test_port_reservations.py
+++ b/zig/e2e/antfly/test_port_reservations.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import errno
 import socket
 import subprocess
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -31,6 +32,7 @@ from conftest import (
 )
 from port_reservations import LoopbackPortReservations, find_free_port
 from test_auth import StandaloneAuthServer
+from test_standalone import EmbeddedInferenceStandaloneServer
 
 
 def test_loopback_port_reservations_hold_ports_until_handoff():
@@ -189,3 +191,34 @@ def test_stateful_server_releases_requested_port_when_spawn_fails(monkeypatch: p
 
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as contender:
         contender.bind(("127.0.0.1", requested_port))
+
+
+def test_embedded_inference_server_releases_listener_ports_when_spawn_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    with LoopbackPortReservations() as reservations:
+        public_port, health_port = reservations.reserve_many(2)
+
+    def reserve_listener_ports(
+        reservations: LoopbackPortReservations,
+        count: int,
+    ) -> tuple[int, ...]:
+        assert count == 2
+        return (
+            reservations.reserve(public_port),
+            reservations.reserve(health_port),
+        )
+
+    def fail_to_spawn(*args: Any, **kwargs: Any) -> subprocess.Popen[str]:
+        raise OSError(errno.ENOEXEC, "cannot execute")
+
+    monkeypatch.setattr(LoopbackPortReservations, "reserve_many", reserve_listener_ports)
+    monkeypatch.setattr(subprocess, "Popen", fail_to_spawn)
+    with pytest.raises(OSError) as exc_info:
+        EmbeddedInferenceStandaloneServer("/missing-antfly", tmp_path, "test-model")
+    assert exc_info.value.errno == errno.ENOEXEC
+
+    for port in (public_port, health_port):
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as contender:
+            contender.bind(("127.0.0.1", port))

--- a/zig/e2e/antfly/test_port_reservations.py
+++ b/zig/e2e/antfly/test_port_reservations.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import errno
 import socket
 import subprocess
+import tempfile
 from pathlib import Path
 from typing import Any
 
@@ -29,6 +30,7 @@ from conftest import (
     PublicAntflyServer,
     StandaloneAntflyServer,
     StatefulAntflyServer,
+    _standalone_stateful_command,
 )
 from port_reservations import LoopbackPortReservations, find_free_port
 from test_auth import StandaloneAuthServer
@@ -141,7 +143,12 @@ def test_handoff_restores_leases_when_process_spawn_fails():
 
 @pytest.mark.parametrize(
     "server_type",
-    (AntflyServer, PublicAntflyServer, StandaloneAntflyServer, StandaloneAuthServer),
+    (
+        AntflyServer,
+        PublicAntflyServer,
+        StandaloneAntflyServer,
+        StandaloneAuthServer,
+    ),
 )
 def test_single_process_servers_release_requested_port_when_spawn_fails(
     monkeypatch: pytest.MonkeyPatch,
@@ -197,28 +204,105 @@ def test_embedded_inference_server_releases_listener_ports_when_spawn_fails(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ):
-    with LoopbackPortReservations() as reservations:
-        public_port, health_port = reservations.reserve_many(2)
+    listener_ports: tuple[int, ...] = ()
+    reserve_many = LoopbackPortReservations.reserve_many
 
-    def reserve_listener_ports(
+    def record_listener_ports(
         reservations: LoopbackPortReservations,
         count: int,
     ) -> tuple[int, ...]:
-        assert count == 2
-        return (
-            reservations.reserve(public_port),
-            reservations.reserve(health_port),
-        )
+        nonlocal listener_ports
+        listener_ports = reserve_many(reservations, count)
+        return listener_ports
 
     def fail_to_spawn(*args: Any, **kwargs: Any) -> subprocess.Popen[str]:
         raise OSError(errno.ENOEXEC, "cannot execute")
 
-    monkeypatch.setattr(LoopbackPortReservations, "reserve_many", reserve_listener_ports)
+    monkeypatch.setattr(LoopbackPortReservations, "reserve_many", record_listener_ports)
     monkeypatch.setattr(subprocess, "Popen", fail_to_spawn)
     with pytest.raises(OSError) as exc_info:
         EmbeddedInferenceStandaloneServer("/missing-antfly", tmp_path, "test-model")
     assert exc_info.value.errno == errno.ENOEXEC
+    assert len(listener_ports) == 2
 
-    for port in (public_port, health_port):
+    for port in listener_ports:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as contender:
+            contender.bind(("127.0.0.1", port))
+
+
+def test_standalone_fixture_command_disables_unused_health_listener(tmp_path: Path):
+    command = _standalone_stateful_command(
+        "/missing-antfly",
+        host="127.0.0.1",
+        port=40000,
+        root=tmp_path,
+    )
+
+    health_flag = command.index("--health")
+    assert command[health_flag + 1] == "false"
+
+
+@pytest.mark.parametrize(
+    "server_type",
+    (
+        AntflyServer,
+        PublicAntflyServer,
+        StandaloneAntflyServer,
+        StandaloneAuthServer,
+        StatefulAntflyServer,
+    ),
+)
+def test_single_process_servers_release_port_when_setup_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    server_type: type,
+):
+    listener_ports: list[int] = []
+    reserve_requested = LoopbackPortReservations.reserve_requested
+
+    def record_listener_port(reservations: LoopbackPortReservations, port: int) -> int:
+        reserved_port = reserve_requested(reservations, port)
+        listener_ports.append(reserved_port)
+        return reserved_port
+
+    def fail_tempdir(*args: Any, **kwargs: Any):
+        raise OSError(errno.ENOSPC, "cannot create temporary directory")
+
+    monkeypatch.setattr(LoopbackPortReservations, "reserve_requested", record_listener_port)
+    monkeypatch.setattr(tempfile, "TemporaryDirectory", fail_tempdir)
+    with pytest.raises(OSError) as exc_info:
+        server_type("/missing-antfly", "127.0.0.1", 0)
+    assert exc_info.value.errno == errno.ENOSPC
+    assert len(listener_ports) == 1
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as contender:
+        contender.bind(("127.0.0.1", listener_ports[0]))
+
+
+def test_embedded_inference_server_releases_ports_when_setup_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    listener_ports: tuple[int, ...] = ()
+    reserve_many = LoopbackPortReservations.reserve_many
+
+    def record_listener_ports(
+        reservations: LoopbackPortReservations,
+        count: int,
+    ) -> tuple[int, ...]:
+        nonlocal listener_ports
+        listener_ports = reserve_many(reservations, count)
+        return listener_ports
+
+    def fail_tempdir(*args: Any, **kwargs: Any):
+        raise OSError(errno.ENOSPC, "cannot create temporary directory")
+
+    monkeypatch.setattr(LoopbackPortReservations, "reserve_many", record_listener_ports)
+    monkeypatch.setattr(tempfile, "TemporaryDirectory", fail_tempdir)
+    with pytest.raises(OSError) as exc_info:
+        EmbeddedInferenceStandaloneServer("/missing-antfly", tmp_path, "test-model")
+    assert exc_info.value.errno == errno.ENOSPC
+    assert len(listener_ports) == 2
+
+    for port in listener_ports:
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as contender:
             contender.bind(("127.0.0.1", port))

--- a/zig/e2e/antfly/test_port_reservations.py
+++ b/zig/e2e/antfly/test_port_reservations.py
@@ -23,8 +23,14 @@ from typing import Any
 
 import pytest
 
-from conftest import StatefulAntflyServer
+from conftest import (
+    AntflyServer,
+    PublicAntflyServer,
+    StandaloneAntflyServer,
+    StatefulAntflyServer,
+)
 from port_reservations import LoopbackPortReservations, find_free_port
+from test_auth import StandaloneAuthServer
 
 
 def test_loopback_port_reservations_hold_ports_until_handoff():
@@ -129,6 +135,45 @@ def test_handoff_restores_leases_when_process_spawn_fails():
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as contender:
             with pytest.raises(OSError):
                 contender.bind(("127.0.0.1", port))
+
+
+@pytest.mark.parametrize(
+    "server_type",
+    (AntflyServer, PublicAntflyServer, StandaloneAntflyServer, StandaloneAuthServer),
+)
+def test_single_process_servers_release_requested_port_when_spawn_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    server_type: type,
+):
+    requested_port = find_free_port()
+
+    def fail_to_spawn(*args: Any, **kwargs: Any) -> subprocess.Popen[str]:
+        raise OSError(errno.ENOEXEC, "cannot execute")
+
+    monkeypatch.setattr(subprocess, "Popen", fail_to_spawn)
+    with pytest.raises(OSError) as exc_info:
+        server_type("/missing-antfly", "127.0.0.1", requested_port)
+    assert exc_info.value.errno == errno.ENOEXEC
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as contender:
+        contender.bind(("127.0.0.1", requested_port))
+
+
+@pytest.mark.parametrize("server_type", (PublicAntflyServer, StandaloneAntflyServer))
+def test_single_process_pause_retains_listener_port(server_type: type):
+    server = object.__new__(server_type)
+    server.proc = None
+    server.port_reservations = LoopbackPortReservations()
+    server.port = server.port_reservations.reserve()
+    server.port_reservations.release(server.port)
+
+    try:
+        server.pause()
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as contender:
+            with pytest.raises(OSError):
+                contender.bind(("127.0.0.1", server.port))
+    finally:
+        server.port_reservations.close()
 
 
 def test_stateful_server_releases_requested_port_when_spawn_fails(monkeypatch: pytest.MonkeyPatch):

--- a/zig/e2e/antfly/test_port_reservations.py
+++ b/zig/e2e/antfly/test_port_reservations.py
@@ -1,0 +1,146 @@
+# Copyright 2026 Antfly, Inc.
+#
+# Licensed under the Elastic License 2.0 (ELv2); you may not use this file
+# except in compliance with the Elastic License 2.0. You may obtain a copy of
+# the Elastic License 2.0 at
+#
+#     https://www.antfly.io/licensing/ELv2-license
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the Elastic License 2.0 is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# Elastic License 2.0 for the specific language governing permissions and
+# limitations.
+
+"""Regression tests for the shared E2E listener-port lease protocol."""
+
+from __future__ import annotations
+
+import errno
+import socket
+import subprocess
+from typing import Any
+
+import pytest
+
+from conftest import StatefulAntflyServer
+from port_reservations import LoopbackPortReservations, find_free_port
+
+
+def test_loopback_port_reservations_hold_ports_until_handoff():
+    with LoopbackPortReservations() as reservations:
+        explicit_port = find_free_port()
+        assert reservations.reserve(explicit_port) == explicit_port
+        ports = [explicit_port, *reservations.reserve_many(16)]
+
+        assert len(set(ports)) == len(ports)
+        for port in ports:
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as contender:
+                with pytest.raises(OSError):
+                    contender.bind(("127.0.0.1", port))
+
+        assert all(find_free_port() not in ports for _ in range(64))
+
+        released_port = ports.pop()
+        reservations.release_if_reserved(released_port)
+        reservations.release_if_reserved(released_port)
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as contender:
+            contender.bind(("127.0.0.1", released_port))
+
+
+def test_reserve_requested_only_falls_back_for_address_in_use():
+    class StubReservations(LoopbackPortReservations):
+        def __init__(self, error: OSError) -> None:
+            self.error = error
+            self.calls: list[int] = []
+
+        def reserve(self, port: int = 0) -> int:
+            self.calls.append(port)
+            if port:
+                raise self.error
+            return 41000
+
+    address_in_use = StubReservations(OSError(errno.EADDRINUSE, "already in use"))
+    assert address_in_use.reserve_requested(40000) == 41000
+    assert address_in_use.calls == [40000, 0]
+
+    permission_denied = StubReservations(OSError(errno.EACCES, "permission denied"))
+    with pytest.raises(OSError) as exc_info:
+        permission_denied.reserve_requested(40000)
+    assert exc_info.value.errno == errno.EACCES
+    assert permission_denied.calls == [40000]
+
+
+def test_reserve_excluding_releases_collisions_and_is_bounded():
+    class StubReservations(LoopbackPortReservations):
+        def __init__(self, ports: tuple[int, ...]) -> None:
+            self.ports = iter(ports)
+            self.released: list[int] = []
+
+        def reserve(self, port: int = 0) -> int:
+            assert port == 0
+            return next(self.ports)
+
+        def release(self, *ports: int) -> None:
+            self.released.extend(ports)
+
+    reservations = StubReservations((40001, 40002, 41000))
+    assert reservations.reserve_excluding({40001, 40002}, attempts=3) == 41000
+    assert reservations.released == [40001, 40002]
+
+    exhausted = StubReservations((40001, 40002))
+    with pytest.raises(RuntimeError, match="outside the excluded set"):
+        exhausted.reserve_excluding({40001, 40002}, attempts=2)
+    assert exhausted.released == [40001, 40002]
+
+
+def test_ensure_reserved_rolls_back_partial_reacquisition():
+    with LoopbackPortReservations() as reservations:
+        first_port, second_port = reservations.reserve_many(2)
+        reservations.release(first_port, second_port)
+
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as owner:
+            owner.bind(("127.0.0.1", second_port))
+            with pytest.raises(OSError) as exc_info:
+                reservations.ensure_reserved(first_port, second_port)
+            assert exc_info.value.errno == errno.EADDRINUSE
+
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as contender:
+                contender.bind(("127.0.0.1", first_port))
+
+        reservations.ensure_reserved(first_port, second_port)
+        for port in (first_port, second_port):
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as contender:
+                with pytest.raises(OSError):
+                    contender.bind(("127.0.0.1", port))
+
+
+def test_handoff_restores_leases_when_process_spawn_fails():
+    with LoopbackPortReservations() as reservations:
+        port = reservations.reserve()
+
+        def fail_to_spawn() -> None:
+            raise OSError(errno.ENOEXEC, "cannot execute")
+
+        with pytest.raises(OSError) as exc_info:
+            reservations.handoff_to((port,), fail_to_spawn)
+        assert exc_info.value.errno == errno.ENOEXEC
+
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as contender:
+            with pytest.raises(OSError):
+                contender.bind(("127.0.0.1", port))
+
+
+def test_stateful_server_releases_requested_port_when_spawn_fails(monkeypatch: pytest.MonkeyPatch):
+    requested_port = find_free_port()
+
+    def fail_to_spawn(*args: Any, **kwargs: Any) -> subprocess.Popen[str]:
+        raise OSError(errno.ENOEXEC, "cannot execute")
+
+    monkeypatch.setattr(subprocess, "Popen", fail_to_spawn)
+    with pytest.raises(OSError) as exc_info:
+        StatefulAntflyServer("/missing-antfly", "127.0.0.1", requested_port)
+    assert exc_info.value.errno == errno.ENOEXEC
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as contender:
+        contender.bind(("127.0.0.1", requested_port))

--- a/zig/e2e/antfly/test_scaling.py
+++ b/zig/e2e/antfly/test_scaling.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import errno
 import json
 import os
 import shutil
@@ -34,11 +35,13 @@ from conftest import (
     DEFAULT_ANTFLY_BIN,
     LoopbackPortReservations,
     REPO_ROOT,
+    StatefulAntflyServer,
     _read_log_tail,
     antfly_public_api_url,
     find_free_port,
     lookup_key_path,
     maybe_preserve_tempdir,
+    reserve_requested_port,
     wait_for_server,
 )
 from helpers import wait_until
@@ -47,6 +50,7 @@ from helpers import wait_until
 MULTI_SHARD_WRITE_ROUTE_TIMEOUT_S = 120.0
 DATA_NODE_REGISTRATION_TIMEOUT_S = 180.0
 DATA_NODE_BIND_ATTEMPTS = 3
+DATA_NODE_RETRY_PORT_ATTEMPTS = 64
 ADDRESS_IN_USE_LOG_MARKER = "listen address is already in use"
 
 
@@ -92,6 +96,44 @@ def test_loopback_port_reservations_hold_ports_until_release():
             contender.bind(("127.0.0.1", released_port))
     finally:
         reservations.close()
+
+
+def test_reserve_requested_port_only_falls_back_for_address_in_use():
+    class StubReservations:
+        def __init__(self, error: OSError) -> None:
+            self.error = error
+            self.calls: list[int] = []
+
+        def reserve(self, port: int = 0) -> int:
+            self.calls.append(port)
+            if port:
+                raise self.error
+            return 41000
+
+    address_in_use = StubReservations(OSError(errno.EADDRINUSE, "already in use"))
+    assert reserve_requested_port(address_in_use, 40000) == 41000
+    assert address_in_use.calls == [40000, 0]
+
+    permission_denied = StubReservations(OSError(errno.EACCES, "permission denied"))
+    with pytest.raises(OSError) as exc_info:
+        reserve_requested_port(permission_denied, 40000)
+    assert exc_info.value.errno == errno.EACCES
+    assert permission_denied.calls == [40000]
+
+
+def test_stateful_server_releases_requested_port_when_spawn_fails(monkeypatch: pytest.MonkeyPatch):
+    requested_port = find_free_port()
+
+    def fail_to_spawn(*args: Any, **kwargs: Any) -> subprocess.Popen[str]:
+        raise OSError(errno.ENOEXEC, "cannot execute")
+
+    monkeypatch.setattr(subprocess, "Popen", fail_to_spawn)
+    with pytest.raises(OSError) as exc_info:
+        StatefulAntflyServer("/missing-antfly", "127.0.0.1", requested_port)
+    assert exc_info.value.errno == errno.ENOEXEC
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as contender:
+        contender.bind(("127.0.0.1", requested_port))
 
 
 def _metadata_admin_url(stateful_api) -> str:
@@ -636,10 +678,30 @@ class MultiNodeScalingCluster:
         if ADDRESS_IN_USE_LOG_MARKER not in _read_log_tail(log_path):
             return False
 
-        node["api_port"] = self.port_reservations.reserve()
-        node["raft_port"] = self.port_reservations.reserve()
+        configured_ports = {
+            int(configured_node[port_key])
+            for configured_node in [*self.metadata_nodes, *self.data_nodes]
+            for port_key in ("api_port", "raft_port")
+        }
+        api_port = self._reserve_retry_port(configured_ports)
+        try:
+            raft_port = self._reserve_retry_port(configured_ports)
+        except BaseException:
+            self.port_reservations.release(api_port)
+            raise
+        node["api_port"] = api_port
+        node["raft_port"] = raft_port
         self._start_data_node(node)
         return True
+
+    def _reserve_retry_port(self, configured_ports: set[int]) -> int:
+        for _ in range(DATA_NODE_RETRY_PORT_ATTEMPTS):
+            port = self.port_reservations.reserve()
+            if port not in configured_ports:
+                configured_ports.add(port)
+                return port
+            self.port_reservations.release(port)
+        raise RuntimeError("could not reserve a data-node retry port outside the cluster configuration")
 
     def add_data_node(self) -> dict[str, int]:
         node = self._new_data_node(max(int(existing["id"]) for existing in self.data_nodes) + 1)
@@ -1111,10 +1173,14 @@ class MultiNodeScalingCluster:
 def test_scaling_cluster_retries_data_node_after_bind_collision(tmp_path: Path):
     class StubReservations:
         def __init__(self) -> None:
-            self.ports = iter((41001, 41002))
+            self.ports = iter((40003, 41001, 41001, 41002))
+            self.released: list[int] = []
 
         def reserve(self) -> int:
             return next(self.ports)
+
+        def release(self, *ports: int) -> None:
+            self.released.extend(ports)
 
     node = {"id": 103, "store_id": 103, "api_port": 40001, "raft_port": 40002}
     log_path = tmp_path / "data-103.log"
@@ -1128,6 +1194,11 @@ def test_scaling_cluster_retries_data_node_after_bind_collision(tmp_path: Path):
     cluster.data_log_handles = {103: log}
     cluster.data_log_paths = {103: log_path}
     cluster.port_reservations = StubReservations()
+    cluster.metadata_nodes = [{"id": 1, "api_port": 30001, "raft_port": 30002}]
+    cluster.data_nodes = [
+        node,
+        {"id": 104, "store_id": 104, "api_port": 40003, "raft_port": 40004},
+    ]
     restarted: list[dict[str, int]] = []
     cluster._start_data_node = lambda retry_node: restarted.append(dict(retry_node))  # type: ignore[method-assign]
 
@@ -1138,6 +1209,7 @@ def test_scaling_cluster_retries_data_node_after_bind_collision(tmp_path: Path):
 
     assert node["api_port"] == 41001
     assert node["raft_port"] == 41002
+    assert cluster.port_reservations.released == [40003, 41001]
     assert restarted == [node]
 
 

--- a/zig/e2e/antfly/test_scaling.py
+++ b/zig/e2e/antfly/test_scaling.py
@@ -16,12 +16,10 @@
 
 from __future__ import annotations
 
-import errno
 import json
 import os
 import shutil
 import signal
-import socket
 import subprocess
 import tempfile
 import time
@@ -33,24 +31,20 @@ import requests
 
 from conftest import (
     DEFAULT_ANTFLY_BIN,
-    LoopbackPortReservations,
     REPO_ROOT,
-    StatefulAntflyServer,
     _read_log_tail,
     antfly_public_api_url,
-    find_free_port,
     lookup_key_path,
     maybe_preserve_tempdir,
-    reserve_requested_port,
     wait_for_server,
 )
 from helpers import wait_until
+from port_reservations import LoopbackPortReservations
 
 
 MULTI_SHARD_WRITE_ROUTE_TIMEOUT_S = 120.0
 DATA_NODE_REGISTRATION_TIMEOUT_S = 180.0
 DATA_NODE_BIND_ATTEMPTS = 3
-DATA_NODE_RETRY_PORT_ATTEMPTS = 64
 ADDRESS_IN_USE_LOG_MARKER = "listen address is already in use"
 
 
@@ -72,68 +66,6 @@ class _ClusterStartupDeadline:
         if remaining <= 0.0:
             raise RuntimeError("multi-node cluster startup deadline expired")
         time.sleep(min(duration_s, remaining))
-
-
-def test_loopback_port_reservations_hold_ports_until_release():
-    reservations = LoopbackPortReservations()
-    explicit_port = find_free_port()
-    assert reservations.reserve(explicit_port) == explicit_port
-    ports = [explicit_port, *(reservations.reserve() for _ in range(16))]
-
-    try:
-        assert len(set(ports)) == len(ports)
-        for port in ports:
-            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as contender:
-                with pytest.raises(OSError):
-                    contender.bind(("127.0.0.1", port))
-
-        assert all(find_free_port() not in ports for _ in range(64))
-
-        released_port = ports.pop()
-        reservations.release_if_reserved(released_port)
-        reservations.release_if_reserved(released_port)
-        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as contender:
-            contender.bind(("127.0.0.1", released_port))
-    finally:
-        reservations.close()
-
-
-def test_reserve_requested_port_only_falls_back_for_address_in_use():
-    class StubReservations:
-        def __init__(self, error: OSError) -> None:
-            self.error = error
-            self.calls: list[int] = []
-
-        def reserve(self, port: int = 0) -> int:
-            self.calls.append(port)
-            if port:
-                raise self.error
-            return 41000
-
-    address_in_use = StubReservations(OSError(errno.EADDRINUSE, "already in use"))
-    assert reserve_requested_port(address_in_use, 40000) == 41000
-    assert address_in_use.calls == [40000, 0]
-
-    permission_denied = StubReservations(OSError(errno.EACCES, "permission denied"))
-    with pytest.raises(OSError) as exc_info:
-        reserve_requested_port(permission_denied, 40000)
-    assert exc_info.value.errno == errno.EACCES
-    assert permission_denied.calls == [40000]
-
-
-def test_stateful_server_releases_requested_port_when_spawn_fails(monkeypatch: pytest.MonkeyPatch):
-    requested_port = find_free_port()
-
-    def fail_to_spawn(*args: Any, **kwargs: Any) -> subprocess.Popen[str]:
-        raise OSError(errno.ENOEXEC, "cannot execute")
-
-    monkeypatch.setattr(subprocess, "Popen", fail_to_spawn)
-    with pytest.raises(OSError) as exc_info:
-        StatefulAntflyServer("/missing-antfly", "127.0.0.1", requested_port)
-    assert exc_info.value.errno == errno.ENOEXEC
-
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as contender:
-        contender.bind(("127.0.0.1", requested_port))
 
 
 def _metadata_admin_url(stateful_api) -> str:
@@ -582,9 +514,16 @@ class MultiNodeScalingCluster:
                 "--snapshot-root-dir",
                 str(self.root / f"metadata-{node['id']}-snapshots"),
             ]
-            self.port_reservations.release(node["raft_port"], node["api_port"])
             self.metadata_procs.append(
-                subprocess.Popen(command, stdout=log, stderr=subprocess.STDOUT, cwd=REPO_ROOT)
+                self.port_reservations.handoff_to(
+                    (node["raft_port"], node["api_port"]),
+                    lambda: subprocess.Popen(
+                        command,
+                        stdout=log,
+                        stderr=subprocess.STDOUT,
+                        cwd=REPO_ROOT,
+                    ),
+                )
             )
 
         for url in self.metadata_urls:
@@ -661,8 +600,15 @@ class MultiNodeScalingCluster:
             "--replica-catalog-path",
             str(self.root / f"data-{node['id']}-catalog.txt"),
         ]
-        self.port_reservations.release(node["api_port"], node["raft_port"])
-        proc = subprocess.Popen(command, stdout=log, stderr=subprocess.STDOUT, cwd=REPO_ROOT)
+        proc = self.port_reservations.handoff_to(
+            (node["api_port"], node["raft_port"]),
+            lambda: subprocess.Popen(
+                command,
+                stdout=log,
+                stderr=subprocess.STDOUT,
+                cwd=REPO_ROOT,
+            ),
+        )
         self.data_procs.append(proc)
         self.data_proc_by_node_id[node_id] = proc
 
@@ -683,9 +629,10 @@ class MultiNodeScalingCluster:
             for configured_node in [*self.metadata_nodes, *self.data_nodes]
             for port_key in ("api_port", "raft_port")
         }
-        api_port = self._reserve_retry_port(configured_ports)
+        api_port = self.port_reservations.reserve_excluding(configured_ports)
+        configured_ports.add(api_port)
         try:
-            raft_port = self._reserve_retry_port(configured_ports)
+            raft_port = self.port_reservations.reserve_excluding(configured_ports)
         except BaseException:
             self.port_reservations.release(api_port)
             raise
@@ -693,15 +640,6 @@ class MultiNodeScalingCluster:
         node["raft_port"] = raft_port
         self._start_data_node(node)
         return True
-
-    def _reserve_retry_port(self, configured_ports: set[int]) -> int:
-        for _ in range(DATA_NODE_RETRY_PORT_ATTEMPTS):
-            port = self.port_reservations.reserve()
-            if port not in configured_ports:
-                configured_ports.add(port)
-                return port
-            self.port_reservations.release(port)
-        raise RuntimeError("could not reserve a data-node retry port outside the cluster configuration")
 
     def add_data_node(self) -> dict[str, int]:
         node = self._new_data_node(max(int(existing["id"]) for existing in self.data_nodes) + 1)
@@ -1181,6 +1119,13 @@ def test_scaling_cluster_retries_data_node_after_bind_collision(tmp_path: Path):
 
         def release(self, *ports: int) -> None:
             self.released.extend(ports)
+
+        def reserve_excluding(self, excluded: set[int]) -> int:
+            while True:
+                port = self.reserve()
+                if port not in excluded:
+                    return port
+                self.release(port)
 
     node = {"id": 103, "store_id": 103, "api_port": 40001, "raft_port": 40002}
     log_path = tmp_path / "data-103.log"

--- a/zig/e2e/antfly/test_scaling.py
+++ b/zig/e2e/antfly/test_scaling.py
@@ -46,6 +46,8 @@ from helpers import wait_until
 
 MULTI_SHARD_WRITE_ROUTE_TIMEOUT_S = 120.0
 DATA_NODE_REGISTRATION_TIMEOUT_S = 180.0
+DATA_NODE_BIND_ATTEMPTS = 3
+ADDRESS_IN_USE_LOG_MARKER = "listen address is already in use"
 
 
 class _ClusterStartupDeadline:
@@ -70,7 +72,9 @@ class _ClusterStartupDeadline:
 
 def test_loopback_port_reservations_hold_ports_until_release():
     reservations = LoopbackPortReservations()
-    ports = [reservations.reserve() for _ in range(16)]
+    explicit_port = find_free_port()
+    assert reservations.reserve(explicit_port) == explicit_port
+    ports = [explicit_port, *(reservations.reserve() for _ in range(16))]
 
     try:
         assert len(set(ports)) == len(ports)
@@ -82,7 +86,8 @@ def test_loopback_port_reservations_hold_ports_until_release():
         assert all(find_free_port() not in ports for _ in range(64))
 
         released_port = ports.pop()
-        reservations.release(released_port)
+        reservations.release_if_reserved(released_port)
+        reservations.release_if_reserved(released_port)
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as contender:
             contender.bind(("127.0.0.1", released_port))
     finally:
@@ -417,6 +422,9 @@ class MultiNodeScalingCluster:
         self.metadata_procs: list[subprocess.Popen[str]] = []
         self.data_procs: list[subprocess.Popen[str]] = []
         self.data_proc_by_node_id: dict[int, subprocess.Popen[str]] = {}
+        self.data_start_attempts: dict[int, int] = {}
+        self.data_log_handles: dict[int, Any] = {}
+        self.data_log_paths: dict[int, Path] = {}
         self.log_files: list[Any] = []
         self.log_paths: list[Path] = []
 
@@ -574,7 +582,13 @@ class MultiNodeScalingCluster:
         self.startup_deadline.sleep(duration_s)
 
     def _start_data_node(self, node: dict[str, int]) -> None:
-        log = self._open_log(f"data-{node['id']}.log")
+        node_id = int(node["id"])
+        attempt = self.data_start_attempts.get(node_id, 0) + 1
+        self.data_start_attempts[node_id] = attempt
+        log_name = f"data-{node_id}.log" if attempt == 1 else f"data-{node_id}-attempt-{attempt}.log"
+        log = self._open_log(log_name)
+        self.data_log_handles[node_id] = log
+        self.data_log_paths[node_id] = self.root / log_name
         command = [
             self.binary,
             "data",
@@ -608,7 +622,24 @@ class MultiNodeScalingCluster:
         self.port_reservations.release(node["api_port"], node["raft_port"])
         proc = subprocess.Popen(command, stdout=log, stderr=subprocess.STDOUT, cwd=REPO_ROOT)
         self.data_procs.append(proc)
-        self.data_proc_by_node_id[int(node["id"])] = proc
+        self.data_proc_by_node_id[node_id] = proc
+
+    def _retry_data_node_after_bind_collision(self, node: dict[str, int]) -> bool:
+        node_id = int(node["id"])
+        attempts = self.data_start_attempts.get(node_id, 0)
+        log = self.data_log_handles.get(node_id)
+        log_path = self.data_log_paths.get(node_id)
+        if log is None or log_path is None or attempts >= DATA_NODE_BIND_ATTEMPTS:
+            return False
+
+        log.flush()
+        if ADDRESS_IN_USE_LOG_MARKER not in _read_log_tail(log_path):
+            return False
+
+        node["api_port"] = self.port_reservations.reserve()
+        node["raft_port"] = self.port_reservations.reserve()
+        self._start_data_node(node)
+        return True
 
     def add_data_node(self) -> dict[str, int]:
         node = self._new_data_node(max(int(existing["id"]) for existing in self.data_nodes) + 1)
@@ -649,6 +680,13 @@ class MultiNodeScalingCluster:
             for node_id, node in list(pending.items()):
                 proc = self.data_proc_by_node_id.get(node_id)
                 if proc is not None and proc.poll() is not None:
+                    if not public_api and self._retry_data_node_after_bind_collision(node):
+                        consecutive_successes[node_id] = 0
+                        last_probe[node_id] = (
+                            f"startup attempt {self.data_start_attempts[node_id] - 1} "
+                            "lost a listener-port race; retrying with new ports"
+                        )
+                        continue
                     raise RuntimeError(
                         f"{label} {node_id} exited before becoming ready rc={proc.returncode}\n"
                         f"{self.debug_logs()}"
@@ -1068,6 +1106,39 @@ class MultiNodeScalingCluster:
                 handle.close()
         if not maybe_preserve_tempdir(self.tempdir, failed=test_failed):
             self.tempdir.cleanup()
+
+
+def test_scaling_cluster_retries_data_node_after_bind_collision(tmp_path: Path):
+    class StubReservations:
+        def __init__(self) -> None:
+            self.ports = iter((41001, 41002))
+
+        def reserve(self) -> int:
+            return next(self.ports)
+
+    node = {"id": 103, "store_id": 103, "api_port": 40001, "raft_port": 40002}
+    log_path = tmp_path / "data-103.log"
+    log_path.write_text(
+        "antfly data: listen address is already in use (error.AddressInUse)\n",
+        encoding="utf-8",
+    )
+    log = log_path.open("a", encoding="utf-8")
+    cluster = object.__new__(MultiNodeScalingCluster)
+    cluster.data_start_attempts = {103: 1}
+    cluster.data_log_handles = {103: log}
+    cluster.data_log_paths = {103: log_path}
+    cluster.port_reservations = StubReservations()
+    restarted: list[dict[str, int]] = []
+    cluster._start_data_node = lambda retry_node: restarted.append(dict(retry_node))  # type: ignore[method-assign]
+
+    try:
+        assert cluster._retry_data_node_after_bind_collision(node) is True
+    finally:
+        log.close()
+
+    assert node["api_port"] == 41001
+    assert node["raft_port"] == 41002
+    assert restarted == [node]
 
 
 @pytest.fixture

--- a/zig/e2e/antfly/test_standalone.py
+++ b/zig/e2e/antfly/test_standalone.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 import json
 import os
 import signal
-import socket
 import subprocess
 import tempfile
 import threading
@@ -31,7 +30,7 @@ from urllib.parse import quote
 import pytest
 import requests
 
-from conftest import antfly_public_api_url, inference_public_api_url
+from conftest import LoopbackPortReservations, antfly_public_api_url, inference_public_api_url
 from helpers import wait_until
 
 
@@ -62,12 +61,6 @@ def _env_int(name: str, default: int) -> int:
     if value is None or value == "":
         return default
     return int(value)
-
-
-def _find_free_port() -> int:
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-        sock.bind(("127.0.0.1", 0))
-        return sock.getsockname()[1]
 
 
 def _wait_for_server(url: str, timeout_s: float = 30.0, path: str = "/status") -> bool:
@@ -156,8 +149,9 @@ class EmbeddedInferenceStandaloneServer:
         self.model_name = model_name
         self.host = host
         self.inference_budget_mb = inference_budget_mb or {}
-        self.public_port = _find_free_port()
-        self.health_port = _find_free_port()
+        self.port_reservations = LoopbackPortReservations(host)
+        self.public_port = self.port_reservations.reserve()
+        self.health_port = self.port_reservations.reserve()
         self.public_url = f"http://{host}:{self.public_port}"
         self.url = antfly_public_api_url(self.public_url)
         self.health_url = f"http://{host}:{self.health_port}"
@@ -201,6 +195,7 @@ class EmbeddedInferenceStandaloneServer:
         ):
             if value > 0:
                 command.extend([flag_name, str(value)])
+        self.port_reservations.release(self.public_port, self.health_port)
         self.proc = subprocess.Popen(
             command,
             stdout=self.log_file,
@@ -221,6 +216,7 @@ class EmbeddedInferenceStandaloneServer:
         return _read_log_tail(self.log_path)
 
     def stop(self) -> None:
+        self.port_reservations.close()
         if self.proc is not None and self.proc.poll() is None:
             self.proc.send_signal(signal.SIGTERM)
             try:

--- a/zig/e2e/antfly/test_standalone.py
+++ b/zig/e2e/antfly/test_standalone.py
@@ -30,8 +30,9 @@ from urllib.parse import quote
 import pytest
 import requests
 
-from conftest import LoopbackPortReservations, antfly_public_api_url, inference_public_api_url
+from conftest import antfly_public_api_url, inference_public_api_url
 from helpers import wait_until
+from port_reservations import LoopbackPortReservations
 
 
 pytestmark = pytest.mark.standalone_integration
@@ -150,8 +151,7 @@ class EmbeddedInferenceStandaloneServer:
         self.host = host
         self.inference_budget_mb = inference_budget_mb or {}
         self.port_reservations = LoopbackPortReservations(host)
-        self.public_port = self.port_reservations.reserve()
-        self.health_port = self.port_reservations.reserve()
+        self.public_port, self.health_port = self.port_reservations.reserve_many(2)
         self.public_url = f"http://{host}:{self.public_port}"
         self.url = antfly_public_api_url(self.public_url)
         self.health_url = f"http://{host}:{self.health_port}"
@@ -195,12 +195,14 @@ class EmbeddedInferenceStandaloneServer:
         ):
             if value > 0:
                 command.extend([flag_name, str(value)])
-        self.port_reservations.release(self.public_port, self.health_port)
-        self.proc = subprocess.Popen(
-            command,
-            stdout=self.log_file,
-            stderr=subprocess.STDOUT,
-            cwd=REPO_ROOT,
+        self.proc = self.port_reservations.handoff_to(
+            (self.public_port, self.health_port),
+            lambda: subprocess.Popen(
+                command,
+                stdout=self.log_file,
+                stderr=subprocess.STDOUT,
+                cwd=REPO_ROOT,
+            ),
         )
         if not _wait_for_server(self.url):
             logs = _read_log_tail(self.log_path)

--- a/zig/e2e/antfly/test_standalone.py
+++ b/zig/e2e/antfly/test_standalone.py
@@ -161,7 +161,12 @@ class EmbeddedInferenceStandaloneServer:
         self.log_path = self.root / "server.log"
         self.log_file = self.log_path.open("w")
         self.proc: subprocess.Popen[str] | None = None
-        self._start()
+        try:
+            self._start()
+        except BaseException:
+            if not self.log_file.closed:
+                self.stop()
+            raise
 
     def _start(self) -> None:
         command = [

--- a/zig/e2e/antfly/test_standalone.py
+++ b/zig/e2e/antfly/test_standalone.py
@@ -23,6 +23,7 @@ import subprocess
 import tempfile
 import threading
 import time
+from contextlib import ExitStack
 from pathlib import Path
 from typing import Any
 from urllib.parse import quote
@@ -150,17 +151,21 @@ class EmbeddedInferenceStandaloneServer:
         self.model_name = model_name
         self.host = host
         self.inference_budget_mb = inference_budget_mb or {}
-        self.port_reservations = LoopbackPortReservations(host)
-        self.public_port, self.health_port = self.port_reservations.reserve_many(2)
-        self.public_url = f"http://{host}:{self.public_port}"
-        self.url = antfly_public_api_url(self.public_url)
-        self.health_url = f"http://{host}:{self.health_port}"
-        self.inference_api_url = inference_public_api_url(self.public_url)
-        self.tempdir = tempfile.TemporaryDirectory(prefix="antfly-standalone-e2e-")
-        self.root = Path(self.tempdir.name)
-        self.log_path = self.root / "server.log"
-        self.log_file = self.log_path.open("w")
-        self.proc: subprocess.Popen[str] | None = None
+        with ExitStack() as setup:
+            self.port_reservations = LoopbackPortReservations(host)
+            setup.callback(self.port_reservations.close)
+            self.public_port, self.health_port = self.port_reservations.reserve_many(2)
+            self.public_url = f"http://{host}:{self.public_port}"
+            self.url = antfly_public_api_url(self.public_url)
+            self.health_url = f"http://{host}:{self.health_port}"
+            self.inference_api_url = inference_public_api_url(self.public_url)
+            self.tempdir = tempfile.TemporaryDirectory(prefix="antfly-standalone-e2e-")
+            setup.callback(self.tempdir.cleanup)
+            self.root = Path(self.tempdir.name)
+            self.log_path = self.root / "server.log"
+            self.log_file = setup.enter_context(self.log_path.open("w"))
+            self.proc: subprocess.Popen[str] | None = None
+            setup.pop_all()
         try:
             self._start()
         except BaseException:

--- a/zig/e2e/antfly/test_standby.py
+++ b/zig/e2e/antfly/test_standby.py
@@ -34,7 +34,6 @@ import requests
 
 from conftest import (
     DEFAULT_ANTFLY_BIN,
-    LoopbackPortReservations,
     _read_log_tail,
     _standalone_stateful_command,
     lookup_key_path,
@@ -42,6 +41,7 @@ from conftest import (
     resolve_binary_path,
     wait_for_server,
 )
+from port_reservations import LoopbackPortReservations
 
 
 HA_ADMIN_ROOT = "/admin/v1/ha"
@@ -80,8 +80,7 @@ class HAStandaloneNode:
         self.node_id = node_id
         self.host = "127.0.0.1"
         self.port_reservations = LoopbackPortReservations(self.host)
-        self.port = self.port_reservations.reserve()
-        self.health_port = self.port_reservations.reserve()
+        self.port, self.health_port = self.port_reservations.reserve_many(2)
         self.url = f"http://{self.host}:{self.port}"
         self.log_path = self.root / f"{role}-{node_id}.log"
         self.log_file = self.log_path.open("a")
@@ -183,13 +182,15 @@ class HAStandaloneNode:
             assert self.admin_token is not None
             env[self.admin_token_env] = self.admin_token
 
-        self.port_reservations.release_if_reserved(self.port, self.health_port)
-        self.proc = subprocess.Popen(
-            command,
-            stdout=self.log_file,
-            stderr=subprocess.STDOUT,
-            cwd=self.root,
-            env=env,
+        self.proc = self.port_reservations.handoff_to(
+            (self.port, self.health_port),
+            lambda: subprocess.Popen(
+                command,
+                stdout=self.log_file,
+                stderr=subprocess.STDOUT,
+                cwd=self.root,
+                env=env,
+            ),
         )
         if not wait_for_server(self.url, path="/readyz", timeout=30.0):
             logs = self.debug_logs()
@@ -201,7 +202,7 @@ class HAStandaloneNode:
         if self.ha_root.exists():
             shutil.rmtree(self.ha_root)
 
-    def stop(self) -> None:
+    def _stop_process(self) -> None:
         if self.proc is not None and self.proc.poll() is None:
             self.proc.send_signal(signal.SIGTERM)
             try:
@@ -211,6 +212,10 @@ class HAStandaloneNode:
                 self.proc.wait()
         self.proc = None
 
+    def stop(self) -> None:
+        self._stop_process()
+        self.port_reservations.ensure_reserved(self.port, self.health_port)
+
     def restart(self, *, enable_replication: bool = True) -> None:
         self.stop()
         self.log_file.close()
@@ -218,8 +223,8 @@ class HAStandaloneNode:
         self.start(enable_replication=enable_replication)
 
     def close(self) -> None:
+        self._stop_process()
         self.port_reservations.close()
-        self.stop()
         self.log_file.close()
 
     def debug_logs(self) -> str:

--- a/zig/e2e/antfly/test_standby.py
+++ b/zig/e2e/antfly/test_standby.py
@@ -115,7 +115,7 @@ class HAStandaloneNode:
     def start(self, *, enable_replication: bool = True) -> None:
         self.node_root.mkdir(parents=True, exist_ok=True)
         command = _standalone_stateful_command(self.binary, host=self.host, port=self.port, root=self.node_root)
-        command.extend(["--health-port", str(self.health_port)])
+        command.extend(["--health", "true", "--health-port", str(self.health_port)])
         if self.role == "primary":
             command.extend(
                 [

--- a/zig/e2e/antfly/test_standby.py
+++ b/zig/e2e/antfly/test_standby.py
@@ -26,6 +26,7 @@ import subprocess
 import tempfile
 import time
 import zlib
+from contextlib import ExitStack
 from pathlib import Path
 from typing import Any
 
@@ -79,11 +80,14 @@ class HAStandaloneNode:
         self.role = role
         self.node_id = node_id
         self.host = "127.0.0.1"
-        self.port_reservations = LoopbackPortReservations(self.host)
-        self.port, self.health_port = self.port_reservations.reserve_many(2)
-        self.url = f"http://{self.host}:{self.port}"
-        self.log_path = self.root / f"{role}-{node_id}.log"
-        self.log_file = self.log_path.open("a")
+        with ExitStack() as setup:
+            self.port_reservations = LoopbackPortReservations(self.host)
+            setup.callback(self.port_reservations.close)
+            self.port, self.health_port = self.port_reservations.reserve_many(2)
+            self.url = f"http://{self.host}:{self.port}"
+            self.log_path = self.root / f"{role}-{node_id}.log"
+            self.log_file = setup.enter_context(self.log_path.open("a"))
+            setup.pop_all()
         self.cluster_id = cluster_id
         self.shard_id = shard_id
         self.table_id = table_id
@@ -316,35 +320,40 @@ class HAStandaloneNode:
 
 class HACluster:
     def __init__(self, binary: str):
-        self.tempdir = tempfile.TemporaryDirectory(prefix="antfly-ha-standby-e2e-")
-        self.root = Path(self.tempdir.name).resolve()
-        self.admin_token_env = "ANTFLY_HA_E2E_ADMIN_TOKEN"
-        self.admin_token = "ha-e2e-secret-token"
-        self.primary = HAStandaloneNode(
-            binary=binary,
-            root=self.root,
-            role="primary",
-            node_id="primary-a",
-            cluster_id=100,
-            timeline_id=1,
-            epoch=1,
-            sync_standby_name="standby-a",
-            admin_token_env=self.admin_token_env,
-            admin_token=self.admin_token,
-        )
-        self.standby = HAStandaloneNode(
-            binary=binary,
-            root=self.root,
-            role="standby",
-            node_id="standby-a",
-            cluster_id=100,
-            timeline_id=1,
-            epoch=1,
-            upstream_url=self.primary.url,
-            slot_name="standby-a",
-            admin_token_env=self.admin_token_env,
-            admin_token=self.admin_token,
-        )
+        with ExitStack() as setup:
+            self.tempdir = tempfile.TemporaryDirectory(prefix="antfly-ha-standby-e2e-")
+            setup.callback(self.tempdir.cleanup)
+            self.root = Path(self.tempdir.name).resolve()
+            self.admin_token_env = "ANTFLY_HA_E2E_ADMIN_TOKEN"
+            self.admin_token = "ha-e2e-secret-token"
+            self.primary = HAStandaloneNode(
+                binary=binary,
+                root=self.root,
+                role="primary",
+                node_id="primary-a",
+                cluster_id=100,
+                timeline_id=1,
+                epoch=1,
+                sync_standby_name="standby-a",
+                admin_token_env=self.admin_token_env,
+                admin_token=self.admin_token,
+            )
+            setup.callback(self.primary.close)
+            self.standby = HAStandaloneNode(
+                binary=binary,
+                root=self.root,
+                role="standby",
+                node_id="standby-a",
+                cluster_id=100,
+                timeline_id=1,
+                epoch=1,
+                upstream_url=self.primary.url,
+                slot_name="standby-a",
+                admin_token_env=self.admin_token_env,
+                admin_token=self.admin_token,
+            )
+            setup.callback(self.standby.close)
+            setup.pop_all()
 
     def configure_table_identity(self, *, shard_id: int, table_id: int) -> None:
         for node in (self.primary, self.standby):

--- a/zig/e2e/antfly/test_standby.py
+++ b/zig/e2e/antfly/test_standby.py
@@ -34,9 +34,9 @@ import requests
 
 from conftest import (
     DEFAULT_ANTFLY_BIN,
+    LoopbackPortReservations,
     _read_log_tail,
     _standalone_stateful_command,
-    find_free_port,
     lookup_key_path,
     maybe_preserve_tempdir,
     resolve_binary_path,
@@ -79,8 +79,9 @@ class HAStandaloneNode:
         self.role = role
         self.node_id = node_id
         self.host = "127.0.0.1"
-        self.port = find_free_port()
-        self.health_port = find_free_port()
+        self.port_reservations = LoopbackPortReservations(self.host)
+        self.port = self.port_reservations.reserve()
+        self.health_port = self.port_reservations.reserve()
         self.url = f"http://{self.host}:{self.port}"
         self.log_path = self.root / f"{role}-{node_id}.log"
         self.log_file = self.log_path.open("a")
@@ -182,6 +183,7 @@ class HAStandaloneNode:
             assert self.admin_token is not None
             env[self.admin_token_env] = self.admin_token
 
+        self.port_reservations.release_if_reserved(self.port, self.health_port)
         self.proc = subprocess.Popen(
             command,
             stdout=self.log_file,
@@ -216,6 +218,7 @@ class HAStandaloneNode:
         self.start(enable_replication=enable_replication)
 
     def close(self) -> None:
+        self.port_reservations.close()
         self.stop()
         self.log_file.close()
 


### PR DESCRIPTION
## Summary

- generalize loopback port reservations across every Antfly E2E fixture that preallocates multiple listener ports
- disable unused dedicated health listeners in shared split-node commands
- retry scaling data-node startup only when the failed attempt logs AddressInUse, with fresh reserved ports and a three-attempt bound
- add deterministic coverage for explicit reservations, idempotent release, and bind-collision retry

## Root cause

The linked PR #485 failure showed data node 103 exiting during fixture setup with error.AddressInUse. PR #489 removed the large allocation-to-launch window in the scaling fixture, but the same preallocation pattern remained in the core stateful, multi-metadata backup, distributed-status, extensions, HA, and embedded-standalone fixtures. There is also an unavoidable short handoff after the parent closes a reservation and before the child binds it; the scaling fixture now recognizes that exact failure and retries with a fresh pair rather than masking unrelated startup failures.

Failure: https://github.com/antflydb/antfly/actions/runs/31901993889/job/95057904748?pr=485

## Validation

- port reservation and retry unit regressions: 2 passed
- original autoscaling test: 30/30 passed across three concurrent workers
- multi-metadata backup live E2E: passed
- distributed status live E2E: passed
- extensions standalone and distributed live E2E: 2 passed
- HA standby live E2E: passed
- shared stateful split-server startup and occupied-port fallback: passed
- Python compilation and collection for all modified E2E modules
- git diff --check