### PR TITLE
Fix inference E2E model discovery after variant publication

### DIFF
--- a/zig/e2e/inference/models.py
+++ b/zig/e2e/inference/models.py
@@ -73,6 +73,12 @@ class ModelSpec:
         return self.repo
 
     @property
+    def listing_name(self) -> str:
+        if self.variant == "auto":
+            return self.repo
+        return f"{self.repo}:{self.variant}"
+
+    @property
     def pull_ref(self) -> str:
         if self.variant == "auto":
             return f"hf:{self.repo}"
@@ -698,19 +704,62 @@ def ensure_model_by_name(name: str, task_hint: str | None = None) -> Path | None
     return ensure_model(spec)
 
 
+def listed_model_name(
+    available_models: set[str], request_name: str
+) -> str | None:
+    """Resolve a bare request name to the exact identifier advertised by /models."""
+
+    exact = next(
+        (name for name in available_models if name.casefold() == request_name.casefold()),
+        None,
+    )
+    if exact is not None:
+        return exact
+
+    spec = spec_for_name(request_name)
+    if spec is not None:
+        preferred = next(
+            (
+                name
+                for name in available_models
+                if name.casefold() == spec.listing_name.casefold()
+            ),
+            None,
+        )
+        if preferred is not None:
+            return preferred
+
+    prefix = f"{request_name}:".casefold()
+    variants = sorted(
+        name for name in available_models if name.casefold().startswith(prefix)
+    )
+    return variants[0] if variants else None
+
+
+def _listed_name_for_model_path(
+    root: Path, model_path: Path, available_models: set[str]
+) -> str | None:
+    relative = model_path.relative_to(root)
+    parts = list(relative.parts)
+    parts[-1] = parts[-1].split("--antfly-", 1)[0]
+    return listed_model_name(available_models, PurePosixPath(*parts).as_posix())
+
+
 def default_generator_model_name(
     available_generators: set[str] | None = None,
 ) -> str | None:
     override = os.environ.get("ANTFLY_INFERENCE_DEFAULT_GENERATOR_MODEL")
     if override:
+        if available_generators is not None:
+            return listed_model_name(available_generators, override) or override
         return override
 
     if available_generators is not None:
         if not available_generators:
             return None
         for candidate in (DEFAULT_GENERATOR_MODEL, DEFAULT_TOOL_GENERATOR_MODEL):
-            if candidate in available_generators:
-                return candidate
+            if listed := listed_model_name(available_generators, candidate):
+                return listed
         return sorted(available_generators)[0]
 
     return DEFAULT_GENERATOR_MODEL
@@ -749,6 +798,8 @@ def find_tool_model_name(available_generators: set[str] | None = None) -> str | 
 
     override = os.environ.get("ANTFLY_INFERENCE_TOOL_MODEL")
     if override:
+        if available_generators is not None:
+            return listed_model_name(available_generators, override) or override
         return override
 
     seen: set[Path] = set()
@@ -766,14 +817,15 @@ def find_tool_model_name(available_generators: set[str] | None = None) -> str | 
                 seen.add(model_path)
                 if detect_tool_call_format(model_path) is None:
                     continue
-                model_name = model_path.relative_to(root).as_posix()
-                if available_generators is None or model_name in available_generators:
+                if available_generators is None:
+                    return model_path.relative_to(root).as_posix()
+                if model_name := _listed_name_for_model_path(
+                    root, model_path, available_generators
+                ):
                     return model_name
 
     if available_generators is not None:
-        if DEFAULT_TOOL_GENERATOR_MODEL in available_generators:
-            return DEFAULT_TOOL_GENERATOR_MODEL
-        return None
+        return listed_model_name(available_generators, DEFAULT_TOOL_GENERATOR_MODEL)
 
     return DEFAULT_TOOL_GENERATOR_MODEL
 
@@ -823,6 +875,8 @@ def find_multimodal_generator_model_name(
 
     override = os.environ.get("ANTFLY_INFERENCE_MULTIMODAL_GENERATOR_MODEL")
     if override:
+        if available_generators is not None:
+            return listed_model_name(available_generators, override) or override
         return override
 
     seen: set[Path] = set()
@@ -837,17 +891,19 @@ def find_multimodal_generator_model_name(
             if not detect_multimodal_generator(model_path):
                 continue
 
-            model_name = model_path.relative_to(root).as_posix()
-
-            if available_generators is None or model_name in available_generators:
+            if available_generators is None:
+                return model_path.relative_to(root).as_posix()
+            if model_name := _listed_name_for_model_path(
+                root, model_path, available_generators
+            ):
                 return model_name
 
     if available_generators is not None:
         # The curated fallback is capability-reviewed and remains usable when
         # a GGUF package does not carry Hugging Face processor metadata.
-        if DEFAULT_MULTIMODAL_GENERATOR_MODEL in available_generators:
-            return DEFAULT_MULTIMODAL_GENERATOR_MODEL
-        return None
+        return listed_model_name(
+            available_generators, DEFAULT_MULTIMODAL_GENERATOR_MODEL
+        )
 
     return DEFAULT_MULTIMODAL_GENERATOR_MODEL
 

--- a/zig/e2e/inference/test_embed.py
+++ b/zig/e2e/inference/test_embed.py
@@ -41,6 +41,7 @@ from .models import (
     ensure_model_by_name,
     inference_command,
     inference_download_enabled,
+    listed_model_name,
     local_model_exists,
     run_clipclap_contract_tests,
 )
@@ -204,7 +205,7 @@ def test_published_clipclap_pair_server_contract(api):
         assert abs(l2_norm(embedding) - 1.0) < 1e-4
 
     embedders = api.models().get("embedders", {})
-    assert CLIPCLAP_MODEL in embedders, (
+    assert listed_model_name(set(embedders), CLIPCLAP_MODEL) is not None, (
         f"{CLIPCLAP_MODEL} executed but is absent from /models embedders: "
         f"{sorted(embedders)}"
     )

--- a/zig/e2e/inference/test_generate.py
+++ b/zig/e2e/inference/test_generate.py
@@ -169,7 +169,7 @@ def test_generate_response_format_json_object(api):
     resp = api.generate(
         [{"role": "user", "content": "Return a tiny JSON object"}],
         model=model,
-        max_tokens=64,
+        max_tokens=16,
         chat_template_kwargs={"enable_thinking": False},
         response_format={"type": "json_object"},
     )

--- a/zig/e2e/inference/test_model_helpers.py
+++ b/zig/e2e/inference/test_model_helpers.py
@@ -369,6 +369,38 @@ def test_multimodal_model_selection_uses_shared_gemma_default(monkeypatch, tmp_p
     )
 
 
+def test_model_selection_returns_advertised_managed_variant(monkeypatch, tmp_path):
+    monkeypatch.delenv("ANTFLY_INFERENCE_DEFAULT_GENERATOR_MODEL", raising=False)
+    monkeypatch.delenv("ANTFLY_INFERENCE_TOOL_MODEL", raising=False)
+    monkeypatch.delenv("ANTFLY_INFERENCE_MULTIMODAL_GENERATOR_MODEL", raising=False)
+    monkeypatch.setenv("ANTFLY_INFERENCE_MODELS_DIR", str(tmp_path))
+
+    spec = models.spec_for_name(DEFAULT_GENERATOR_MODEL, "generators")
+    assert spec is not None
+    model_dir = models._model_path(spec)
+    model_dir.mkdir(parents=True)
+    (model_dir / "config.json").write_text(
+        json.dumps(
+            {
+                "architectures": ["Gemma4ForConditionalGeneration"],
+                "vision_config": {},
+            }
+        )
+    )
+    (model_dir / "genai_config.json").write_text(
+        json.dumps({"tool_call_format": "functiongemma"})
+    )
+    advertised = {spec.listing_name}
+
+    assert models.default_generator_model_name(advertised) == spec.listing_name
+    monkeypatch.setenv(
+        "ANTFLY_INFERENCE_DEFAULT_GENERATOR_MODEL", DEFAULT_GENERATOR_MODEL
+    )
+    assert models.default_generator_model_name(advertised) == spec.listing_name
+    assert models.find_tool_model_name(advertised) == spec.listing_name
+    assert models.find_multimodal_generator_model_name(advertised) == spec.listing_name
+
+
 def test_explicit_large_generator_is_bootstrapped(monkeypatch):
     for env_name in (*models.GENERATOR_ENV_VARS, *models.READER_ENV_VARS):
         monkeypatch.delenv(env_name, raising=False)

--- a/zig/e2e/inference/test_models.py
+++ b/zig/e2e/inference/test_models.py
@@ -17,7 +17,7 @@
 import pytest
 
 from .helpers import make_text_png_uri, make_wav_b64
-from .models import DEFAULT_EXTRACTOR_MODEL
+from .models import DEFAULT_EXTRACTOR_MODEL, listed_model_name
 
 
 CLIPCLAP_MODEL = "antflydb/clipclap"
@@ -51,10 +51,11 @@ def test_models_has_openai_data_field(api):
 
 def test_models_exposes_gliner2_as_extractor(api):
     resp = api.models()
-    if DEFAULT_EXTRACTOR_MODEL in resp["extractors"]:
-        caps = resp["extractors"][DEFAULT_EXTRACTOR_MODEL].get("capabilities", [])
+    model_name = listed_model_name(set(resp["extractors"]), DEFAULT_EXTRACTOR_MODEL)
+    if model_name is not None:
+        caps = resp["extractors"][model_name].get("capabilities", [])
         assert "extraction" in caps
-        inputs = resp["extractors"][DEFAULT_EXTRACTOR_MODEL].get("inputs", [])
+        inputs = resp["extractors"][model_name].get("inputs", [])
         assert "text" in inputs
 
 
@@ -71,8 +72,9 @@ def test_models_exposes_nli_classifiers_as_extractors(api):
 def test_models_exposes_reader_inputs(api):
     resp = api.models()
     readers = resp.get("readers", {})
-    if "antflydb/florence-2-base" in readers:
-        assert "image" in readers["antflydb/florence-2-base"].get("inputs", [])
+    model_name = listed_model_name(set(readers), "antflydb/florence-2-base")
+    if model_name is not None:
+        assert "image" in readers[model_name].get("inputs", [])
 
 
 @pytest.mark.model_integration
@@ -80,7 +82,10 @@ def test_composite_model_eviction_churn_stays_healthy(api):
     """Audio-sidecar teardown and reader eviction must not corrupt the server."""
 
     listing = api.models()
-    if CLIPCLAP_MODEL not in listing.get("embedders", {}):
+    clipclap = listed_model_name(
+        set(listing.get("embedders", {})), CLIPCLAP_MODEL
+    )
+    if clipclap is None:
         pytest.skip(f"{CLIPCLAP_MODEL} is not available")
     reader = next(
         (name for name in listing.get("readers", {}) if "florence" in name.lower()),
@@ -100,7 +105,7 @@ def test_composite_model_eviction_churn_stays_healthy(api):
     # previous composite model. Repeating the transition catches stale sidecar
     # handles and allocator damage at the operation that introduced it.
     for _ in range(3):
-        embedded = api.embed(["a short silent audio clip", audio], model=CLIPCLAP_MODEL)
+        embedded = api.embed(["a short silent audio clip", audio], model=clipclap)
         assert len(embedded["data"]) == 2
         assert all(len(item["embedding"]) == 512 for item in embedded["data"])
 


### PR DESCRIPTION
## Summary
- resolve curated bare model names to the exact variant-qualified identifiers advertised by /models
- restore ClipClap, Gemma multimodal, tool-model, extractor, reader, and eviction-churn coverage for managed variants
- cap the unconstrained JSON-object smoke at 16 tokens so CPU decoding remains within the request deadline

## Root cause
The failing job (https://github.com/antflydb/antfly/actions/runs/31914771899/job/95085025713) was the first main run after managed model publication began preserving explicit variant identities. The API correctly advertised names such as antflydb/clipclap:gguf:Q4_K, while the E2E helpers still compared those keys with bare repository names. The JSON-object smoke separately exhausted its 300-second deadline while decoding up to 64 unconstrained tokens.

## Validation
- 43/43 model-helper tests pass
- all 195 inference E2E tests collect successfully
- git diff --check passes