### PR TITLE
Bound CPU inference generation smokes

### DIFF
--- a/zig/e2e/inference/test_generate.py
+++ b/zig/e2e/inference/test_generate.py
@@ -167,9 +167,12 @@ def test_max_tokens_respected(api):
 def test_generate_response_format_json_object(api):
     model = _first_generator_model(api)
     resp = api.generate(
-        [{"role": "user", "content": "Return a tiny JSON object"}],
+        [{"role": "user", "content": "Return exactly the JSON object {}, with no other text."}],
         model=model,
-        max_tokens=16,
+        # This is a grammar-wiring smoke, not an output-quality benchmark.
+        # Unconstrained JSON permits trailing whitespace, so a CPU-only Gemma
+        # decode can consume the entire budget even after emitting an object.
+        max_tokens=4,
         chat_template_kwargs={"enable_thinking": False},
         response_format={"type": "json_object"},
     )
@@ -380,7 +383,7 @@ def test_multimodal_generation(api):
     messages = [{
         "role": "user",
         "content": [
-            {"type": "text", "text": "Describe this image in one short sentence."},
+            {"type": "text", "text": "Describe this image with one word."},
             {"type": "image_url", "image_url": {"url": TINY_PNG_URI}},
         ],
     }]
@@ -388,7 +391,9 @@ def test_multimodal_generation(api):
     r = api.post("/generate", json={
         "model": model,
         "messages": messages,
-        "max_tokens": 8,
+        # Projector execution and the first decoded content are the contract.
+        # Keep the CPU-only release smoke below the request deadline.
+        "max_tokens": 2,
         "chat_template_kwargs": {"enable_thinking": False},
     })
     r.raise_for_status()


### PR DESCRIPTION
## Summary

- make the JSON-object smoke request an exact empty object and cap it at four tokens
- cap image-conditioned Gemma generation at two tokens while retaining projector execution and content assertions
- keep the large-model validation on CI instead of local developer machines

## Root cause

The full inference rerun for #491 completed 147 tests but timed out after 300 seconds in two CPU-only Gemma smokes:

- `test_generate_response_format_json_object`
- `test_multimodal_generation`

JSON Schema generation and audio-conditioned Gemma generation passed on the same runner and model. The failing tests were spending their budgets on decode work beyond the contract they need to prove. The earlier 64-to-16 token reduction was still too large for the unconstrained JSON grammar on the CPU runner.

Failed rerun: https://github.com/antflydb/antfly/actions/runs/31927321282/job/95197887716

## Validation

- Python compilation
- all 195 inference E2E tests collect
- 43/43 model-helper tests pass
- `git diff --check`

Large-model execution will be verified by the full inference CI job.
