### PR TITLE
perf: optimize exact graph pattern queries

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -21249,7 +21249,9 @@ components:
           description: Starting node(s) for the query
         target_nodes:
           $ref: '#/components/schemas/GraphNodeSelector'
-          description: Target nodes (for pathfinding only)
+          description: Exact target nodes for pathfinding or the final binding of a pattern query. When
+            a pattern endpoint is known, prefer this selector over an exact node_filter.filter_prefix
+            so Antfly can use an exact edge-probe plan.
         params:
           $ref: '#/components/schemas/GraphQueryParams'
           description: Traversal/pathfinding parameters

--- a/specs/openapi/antfly/indexes.yaml
+++ b/specs/openapi/antfly/indexes.yaml
@@ -2209,7 +2209,7 @@ components:
           description: "Starting node(s) for the query"
         target_nodes:
           $ref: '#/components/schemas/GraphNodeSelector'
-          description: "Target nodes (for pathfinding only)"
+          description: "Exact target nodes for pathfinding or the final binding of a pattern query. When a pattern endpoint is known, prefer this selector over an exact node_filter.filter_prefix so Antfly can use an exact edge-probe plan."
         params:
           $ref: '#/components/schemas/GraphQueryParams'
           description: "Traversal/pathfinding parameters"

--- a/ts/packages/sdk/src/public-api.d.ts
+++ b/ts/packages/sdk/src/public-api.d.ts
@@ -11340,7 +11340,7 @@ export interface components {
             index_name: string;
             /** @description Starting node(s) for the query */
             start_nodes?: components["schemas"]["GraphNodeSelector"];
-            /** @description Target nodes (for pathfinding only) */
+            /** @description Exact target nodes for pathfinding or the final binding of a pattern query. When a pattern endpoint is known, prefer this selector over an exact node_filter.filter_prefix so Antfly can use an exact edge-probe plan. */
             target_nodes?: components["schemas"]["GraphNodeSelector"];
             /** @description Traversal/pathfinding parameters */
             params?: components["schemas"]["GraphQueryParams"];

--- a/zig/README.md
+++ b/zig/README.md
@@ -27,6 +27,7 @@ lib/
 
 bench/
   full_text/         Full-text indexing/query/codec benchmarks
+  graph/             Graph-pattern latency and demand-working-set benchmarks
   storage/           LMDB, LSM, WAL, replay, open, and storage-path benches
   vectors/           Dense, HBC, RaBitQ, recall, and sparse vector benches
   baselines/         Checked benchmark baseline JSONL outputs
@@ -136,6 +137,9 @@ Benchmark sources are grouped by domain, while build step names stay stable:
 
 ```sh
 zig build search-bench-build
+zig build graph-pattern-bench-build
+zig build graph-pattern-bench -- --mode exact --fanout 10000 --target-degree 100000
+zig build graph-pattern-bench -- --mode generic --fanout 10000 --target-degree 100000
 zig build text-segment-write-bench
 zig build lsm-backend-bench
 zig build wal-bench
@@ -144,6 +148,10 @@ zig build hbc-read-bench
 zig build json-bench
 zig build regex-bench
 ```
+
+Run each graph-pattern mode in a fresh process. The JSON output reports p50,
+p95, and p99 latency and query-allocation high-water marks. Process RSS is an
+OS high-water mark; use `--warmup 0 --samples 1` for a cold-query RSS comparison.
 
 The `search-benchmark-game/engines/antfly-zig` directory is an adapter for the
 external `search-benchmark-game` harness. It delegates to the root

--- a/zig/bench/graph/pattern_query_bench.zig
+++ b/zig/bench/graph/pattern_query_bench.zig
@@ -1,0 +1,429 @@
+// Copyright 2026 Antfly, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const antfly = @import("antfly_zig");
+
+const graph_mod = antfly.graph;
+const pattern_mod = antfly.graph_pattern;
+
+const Mode = enum {
+    exact,
+    generic,
+};
+
+const Config = struct {
+    mode: Mode = .exact,
+    fanout: usize = 10_000,
+    tags_per_post: usize = 8,
+    target_degree: usize = 100_000,
+    match_every: usize = 10,
+    warmup: usize = 5,
+    samples: usize = 30,
+};
+
+const PhaseAllocStats = struct {
+    current_bytes: usize = 0,
+    peak_bytes: usize = 0,
+    total_alloc_bytes: usize = 0,
+    total_free_bytes: usize = 0,
+    alloc_count: usize = 0,
+    free_count: usize = 0,
+
+    fn noteAlloc(self: *PhaseAllocStats, len: usize) void {
+        self.current_bytes +|= len;
+        self.total_alloc_bytes +|= len;
+        self.alloc_count +|= 1;
+        self.peak_bytes = @max(self.peak_bytes, self.current_bytes);
+    }
+
+    fn noteFree(self: *PhaseAllocStats, len: usize) void {
+        self.current_bytes -|= len;
+        self.total_free_bytes +|= len;
+        self.free_count +|= 1;
+    }
+
+    fn noteResize(self: *PhaseAllocStats, old_len: usize, new_len: usize) void {
+        if (new_len > old_len) {
+            self.noteAlloc(new_len - old_len);
+        } else if (old_len > new_len) {
+            self.noteFree(old_len - new_len);
+        }
+    }
+};
+
+const PhaseTrackingAllocator = struct {
+    backing: std.mem.Allocator,
+    stats: *PhaseAllocStats,
+
+    fn allocator(self: *PhaseTrackingAllocator) std.mem.Allocator {
+        return .{
+            .ptr = self,
+            .vtable = &.{
+                .alloc = alloc,
+                .resize = resize,
+                .remap = remap,
+                .free = free,
+            },
+        };
+    }
+
+    fn alloc(ctx: *anyopaque, len: usize, alignment: std.mem.Alignment, ret_addr: usize) ?[*]u8 {
+        const self: *PhaseTrackingAllocator = @ptrCast(@alignCast(ctx));
+        const ptr = self.backing.rawAlloc(len, alignment, ret_addr) orelse return null;
+        self.stats.noteAlloc(len);
+        return ptr;
+    }
+
+    fn resize(ctx: *anyopaque, memory: []u8, alignment: std.mem.Alignment, new_len: usize, ret_addr: usize) bool {
+        const self: *PhaseTrackingAllocator = @ptrCast(@alignCast(ctx));
+        if (!self.backing.rawResize(memory, alignment, new_len, ret_addr)) return false;
+        self.stats.noteResize(memory.len, new_len);
+        return true;
+    }
+
+    fn remap(ctx: *anyopaque, memory: []u8, alignment: std.mem.Alignment, new_len: usize, ret_addr: usize) ?[*]u8 {
+        const self: *PhaseTrackingAllocator = @ptrCast(@alignCast(ctx));
+        const ptr = self.backing.rawRemap(memory, alignment, new_len, ret_addr) orelse return null;
+        self.stats.noteResize(memory.len, new_len);
+        return ptr;
+    }
+
+    fn free(ctx: *anyopaque, memory: []u8, alignment: std.mem.Alignment, ret_addr: usize) void {
+        const self: *PhaseTrackingAllocator = @ptrCast(@alignCast(ctx));
+        self.backing.rawFree(memory, alignment, ret_addr);
+        self.stats.noteFree(memory.len);
+    }
+};
+
+const ExactReader = struct {
+    graph: *graph_mod.GraphIndex,
+
+    pub fn getEdges(
+        self: @This(),
+        alloc: std.mem.Allocator,
+        table: ?[]const u8,
+        key: []const u8,
+        edge_types: []const []const u8,
+        direction: graph_mod.EdgeDirection,
+    ) ![]graph_mod.Edge {
+        if (table != null) return try alloc.alloc(graph_mod.Edge, 0);
+        return try self.graph.getEdgesByTypes(alloc, key, edge_types, direction);
+    }
+
+    pub fn freeEdges(_: @This(), alloc: std.mem.Allocator, edges: []graph_mod.Edge) void {
+        graph_mod.GraphIndex.freeEdges(alloc, edges);
+    }
+
+    pub fn probeEdges(
+        self: @This(),
+        alloc: std.mem.Allocator,
+        table: ?[]const u8,
+        probes: []const graph_mod.EdgeProbe,
+    ) ![]?graph_mod.Edge {
+        if (table != null) {
+            const missing = try alloc.alloc(?graph_mod.Edge, probes.len);
+            @memset(missing, null);
+            return missing;
+        }
+        return try self.graph.probeEdgesAlloc(alloc, probes);
+    }
+
+    pub fn freeProbedEdges(_: @This(), alloc: std.mem.Allocator, edges: []?graph_mod.Edge) void {
+        graph_mod.GraphIndex.freeProbedEdges(alloc, edges);
+    }
+};
+
+/// Deliberately omits exact probes to force the semantically equivalent
+/// generic expansion plan over the same graph snapshot.
+const GenericReader = struct {
+    graph: *graph_mod.GraphIndex,
+
+    pub fn getEdges(
+        self: @This(),
+        alloc: std.mem.Allocator,
+        table: ?[]const u8,
+        key: []const u8,
+        edge_types: []const []const u8,
+        direction: graph_mod.EdgeDirection,
+    ) ![]graph_mod.Edge {
+        if (table != null) return try alloc.alloc(graph_mod.Edge, 0);
+        return try self.graph.getEdgesByTypes(alloc, key, edge_types, direction);
+    }
+
+    pub fn freeEdges(_: @This(), alloc: std.mem.Allocator, edges: []graph_mod.Edge) void {
+        graph_mod.GraphIndex.freeEdges(alloc, edges);
+    }
+};
+
+const FixtureBatch = struct {
+    writes: std.ArrayListUnmanaged(graph_mod.BatchWrite) = .empty,
+    owned: std.ArrayListUnmanaged([]u8) = .empty,
+
+    fn append(
+        self: *FixtureBatch,
+        alloc: std.mem.Allocator,
+        graph: *graph_mod.GraphIndex,
+        source: []const u8,
+        target: []const u8,
+        edge_type: []const u8,
+    ) !void {
+        const owned_start = self.owned.items.len;
+        const source_copy = try alloc.dupe(u8, source);
+        errdefer alloc.free(source_copy);
+        const target_copy = try alloc.dupe(u8, target);
+        errdefer alloc.free(target_copy);
+        try self.owned.append(alloc, source_copy);
+        errdefer self.owned.shrinkRetainingCapacity(owned_start);
+        try self.owned.append(alloc, target_copy);
+        try self.writes.append(alloc, .{
+            .source = source_copy,
+            .target = target_copy,
+            .edge_type = edge_type,
+        });
+        if (self.writes.items.len >= 1024) try self.flush(alloc, graph);
+    }
+
+    fn flush(self: *FixtureBatch, alloc: std.mem.Allocator, graph: *graph_mod.GraphIndex) !void {
+        if (self.writes.items.len == 0) return;
+        try graph.batchApply(self.writes.items, &.{});
+        for (self.owned.items) |bytes| alloc.free(bytes);
+        self.owned.clearRetainingCapacity();
+        self.writes.clearRetainingCapacity();
+    }
+
+    fn deinit(self: *FixtureBatch, alloc: std.mem.Allocator) void {
+        for (self.owned.items) |bytes| alloc.free(bytes);
+        self.owned.deinit(alloc);
+        self.writes.deinit(alloc);
+    }
+};
+
+const Sample = struct {
+    elapsed_ns: u64,
+    matches: usize,
+    alloc_peak_bytes: usize,
+    alloc_total_bytes: usize,
+    stats: pattern_mod.MatchStats,
+};
+
+pub fn main(init: std.process.Init) !void {
+    const alloc = init.gpa;
+    const cfg = try parseArgs(alloc, init.minimal.args);
+
+    var graph = try graph_mod.GraphIndex.openWithPrivateStores(
+        alloc,
+        "unused-forward",
+        "unused-reverse",
+        "forum_graph",
+        .{ .reverse_backend = .lsm_memory },
+    );
+    defer graph.close();
+    try buildFixture(alloc, &graph, cfg);
+
+    var warmup_index: usize = 0;
+    while (warmup_index < cfg.warmup) : (warmup_index += 1) {
+        var stats = pattern_mod.MatchStats{};
+        const matches = try runQuery(alloc, &graph, cfg.mode, &stats);
+        pattern_mod.freeMatches(alloc, matches);
+    }
+
+    const rss_before_queries = processPeakRssBytes();
+    const latency_samples = try alloc.alloc(u64, cfg.samples);
+    defer alloc.free(latency_samples);
+    const allocation_samples = try alloc.alloc(usize, cfg.samples);
+    defer alloc.free(allocation_samples);
+
+    var last = Sample{
+        .elapsed_ns = 0,
+        .matches = 0,
+        .alloc_peak_bytes = 0,
+        .alloc_total_bytes = 0,
+        .stats = .{},
+    };
+    for (0..cfg.samples) |sample_index| {
+        last = try sampleQuery(alloc, &graph, cfg.mode);
+        latency_samples[sample_index] = last.elapsed_ns;
+        allocation_samples[sample_index] = last.alloc_peak_bytes;
+    }
+    std.mem.sort(u64, latency_samples, {}, std.sort.asc(u64));
+    std.mem.sort(usize, allocation_samples, {}, std.sort.asc(usize));
+    const rss_after_queries = processPeakRssBytes();
+
+    const output = .{
+        .benchmark = "graph_pattern_demand_working_set_v1",
+        .mode = @tagName(cfg.mode),
+        .plan = @tagName(last.stats.plan),
+        .fanout = cfg.fanout,
+        .tags_per_post = cfg.tags_per_post,
+        .target_degree = cfg.target_degree,
+        .match_every = cfg.match_every,
+        .warmup = cfg.warmup,
+        .samples = cfg.samples,
+        .matches = last.matches,
+        .latency_ns = .{
+            .p50 = percentile(u64, latency_samples, 50),
+            .p95 = percentile(u64, latency_samples, 95),
+            .p99 = percentile(u64, latency_samples, 99),
+        },
+        .query_alloc_peak_bytes = .{
+            .p50 = percentile(usize, allocation_samples, 50),
+            .p95 = percentile(usize, allocation_samples, 95),
+            .p99 = percentile(usize, allocation_samples, 99),
+        },
+        .last_query_alloc_total_bytes = last.alloc_total_bytes,
+        .process_peak_rss_before_queries = rss_before_queries,
+        .process_peak_rss_after_queries = rss_after_queries,
+        .process_peak_rss_query_delta = rss_after_queries -| rss_before_queries,
+        .rss_note = "process RSS is a high-water mark; use a fresh process and --warmup 0 --samples 1 for cold-query RSS",
+        .work = last.stats,
+    };
+    const json = try std.json.Stringify.valueAlloc(alloc, output, .{});
+    defer alloc.free(json);
+    var stdout_buffer: [8192]u8 = undefined;
+    var stdout = std.Io.File.stdout().writer(init.io, &stdout_buffer);
+    try stdout.interface.writeAll(json);
+    try stdout.interface.writeByte('\n');
+    try stdout.flush();
+}
+
+fn runQuery(
+    alloc: std.mem.Allocator,
+    graph: *graph_mod.GraphIndex,
+    mode: Mode,
+    stats: *pattern_mod.MatchStats,
+) ![]pattern_mod.PatternMatch {
+    const contains_types = [_][]const u8{"CONTAINS"};
+    const has_tag_types = [_][]const u8{"HAS_TAG"};
+    const pattern = [_]pattern_mod.PatternStep{
+        .{ .alias = "forum" },
+        .{ .alias = "post", .edge = .{ .types = &contains_types } },
+        .{ .alias = "tag", .edge = .{ .types = &has_tag_types } },
+    };
+    const starts = [_][]const u8{"forum:root"};
+    const opts = pattern_mod.MatchOptions{
+        .max_results = 0,
+        .target_nodes = &.{.{ .table = null, .key = "tag:wanted" }},
+        .target_required = true,
+        .include_paths = false,
+        .stats = stats,
+        .max_explored_nodes = std.math.maxInt(usize),
+        .max_explored_edges = std.math.maxInt(usize),
+        .max_intermediate_states = std.math.maxInt(usize),
+    };
+    return switch (mode) {
+        .exact => pattern_mod.matchPatternWithEdgeReader(alloc, ExactReader{ .graph = graph }, &starts, &pattern, opts),
+        .generic => pattern_mod.matchPatternWithEdgeReader(alloc, GenericReader{ .graph = graph }, &starts, &pattern, opts),
+    };
+}
+
+fn sampleQuery(alloc: std.mem.Allocator, graph: *graph_mod.GraphIndex, mode: Mode) !Sample {
+    var alloc_stats = PhaseAllocStats{};
+    var tracking = PhaseTrackingAllocator{ .backing = alloc, .stats = &alloc_stats };
+    const query_alloc = tracking.allocator();
+    var stats = pattern_mod.MatchStats{};
+    const started_ns = antfly.platform_time.monotonicNs();
+    const matches = try runQuery(query_alloc, graph, mode, &stats);
+    const elapsed_ns = antfly.platform_time.monotonicNs() - started_ns;
+    const match_count = matches.len;
+    pattern_mod.freeMatches(query_alloc, matches);
+    if (alloc_stats.current_bytes != 0) return error.BenchmarkQueryLeak;
+    return .{
+        .elapsed_ns = elapsed_ns,
+        .matches = match_count,
+        .alloc_peak_bytes = alloc_stats.peak_bytes,
+        .alloc_total_bytes = alloc_stats.total_alloc_bytes,
+        .stats = stats,
+    };
+}
+
+fn buildFixture(alloc: std.mem.Allocator, graph: *graph_mod.GraphIndex, cfg: Config) !void {
+    var batch = FixtureBatch{};
+    defer batch.deinit(alloc);
+    for (0..cfg.fanout) |post_index| {
+        const post = try std.fmt.allocPrint(alloc, "post:{d:0>8}", .{post_index});
+        defer alloc.free(post);
+        try batch.append(alloc, graph, "forum:root", post, "CONTAINS");
+        for (0..cfg.tags_per_post) |tag_index| {
+            if (tag_index == 0 and post_index % cfg.match_every == 0) {
+                try batch.append(alloc, graph, post, "tag:wanted", "HAS_TAG");
+                continue;
+            }
+            const tag = try std.fmt.allocPrint(alloc, "tag:{d:0>4}:{d:0>8}", .{ tag_index, post_index });
+            defer alloc.free(tag);
+            try batch.append(alloc, graph, post, tag, "HAS_TAG");
+        }
+    }
+    for (0..cfg.target_degree) |source_index| {
+        const source = try std.fmt.allocPrint(alloc, "external:{d:0>8}", .{source_index});
+        defer alloc.free(source);
+        try batch.append(alloc, graph, source, "tag:wanted", "HAS_TAG");
+    }
+    try batch.flush(alloc, graph);
+}
+
+fn parseArgs(alloc: std.mem.Allocator, proc_args: std.process.Args) !Config {
+    var cfg = Config{};
+    var args = try std.process.Args.Iterator.initAllocator(proc_args, alloc);
+    defer args.deinit();
+    _ = args.next();
+    while (args.next()) |arg| {
+        if (std.mem.eql(u8, arg, "--mode")) {
+            const value = args.next() orelse return error.InvalidArgument;
+            cfg.mode = std.meta.stringToEnum(Mode, value) orelse return error.InvalidArgument;
+        } else if (std.mem.eql(u8, arg, "--fanout")) {
+            cfg.fanout = try parseNextUsize(&args, arg);
+        } else if (std.mem.eql(u8, arg, "--tags-per-post")) {
+            cfg.tags_per_post = try parseNextUsize(&args, arg);
+        } else if (std.mem.eql(u8, arg, "--target-degree")) {
+            cfg.target_degree = try parseNextUsize(&args, arg);
+        } else if (std.mem.eql(u8, arg, "--match-every")) {
+            cfg.match_every = try parseNextUsize(&args, arg);
+        } else if (std.mem.eql(u8, arg, "--warmup")) {
+            cfg.warmup = try parseNextUsize(&args, arg);
+        } else if (std.mem.eql(u8, arg, "--samples")) {
+            cfg.samples = try parseNextUsize(&args, arg);
+        } else {
+            return error.InvalidArgument;
+        }
+    }
+    if (cfg.fanout == 0 or cfg.tags_per_post == 0 or cfg.match_every == 0 or cfg.samples == 0) {
+        return error.InvalidArgument;
+    }
+    return cfg;
+}
+
+fn parseNextUsize(args: *std.process.Args.Iterator, flag: []const u8) !usize {
+    const value = args.next() orelse return error.InvalidArgument;
+    return std.fmt.parseInt(usize, value, 10) catch {
+        std.debug.print("invalid value for {s}: {s}\n", .{ flag, value });
+        return error.InvalidArgument;
+    };
+}
+
+fn percentile(comptime T: type, sorted: []const T, percent: usize) T {
+    const rank = @min(sorted.len - 1, ((sorted.len - 1) * percent + 99) / 100);
+    return sorted[rank];
+}
+
+fn processPeakRssBytes() usize {
+    const usage = std.posix.getrusage(std.posix.rusage.SELF);
+    const maxrss: usize = if (usage.maxrss <= 0) 0 else @intCast(usage.maxrss);
+    return switch (builtin.os.tag) {
+        .driverkit, .ios, .maccatalyst, .macos, .tvos, .visionos, .watchos => maxrss,
+        .linux => std.math.mul(usize, maxrss, 1024) catch std.math.maxInt(usize),
+        else => maxrss,
+    };
+}

--- a/zig/build.zig
+++ b/zig/build.zig
@@ -3520,6 +3520,7 @@ pub fn build(b: *std.Build) void {
         "retrieval agent supports roots tree search",
         "retrieval agent isolates query predicates while applying accumulated filters",
         "retrieval agent installs canonical mandatory predicates once",
+        "query builder infers graph multi hop pattern from intent",
         "retrieval root scan pushes row inclusion and exclusion predicates into one filter",
         "retrieval contains filter treats wildcard operators as literals",
         "wildcard matching distinguishes operators from escaped literals",
@@ -3527,7 +3528,21 @@ pub fn build(b: *std.Build) void {
         "wildcard search plans preserve escaped exact literals and prefixes",
         "algebraic wildcard helpers preserve escaped literals",
         "algebraic traversal intersects query-scoped node admission",
+        "exact two-edge pattern uses typed batch probes without paths",
+        "exact two-edge probe plan is equivalent to generic expansion",
+        "exact two-edge probe honors incoming final direction",
+        "exact endpoint constrains the final pattern step before limiting",
+        "exact pattern targets preserve table identity",
+        "inapplicable exact plan does not consume generic fallback budget",
+        "graph exact edge probes stay aligned and preserve payloads",
+        "query merge allocation scales with the selected page",
+        "pattern response omits paths unless requested",
+        "parse supported graph queries accepts pattern requests",
+        "distributed graph edges request preserves typed graph edge access path",
+        "distributed graph edge reader carries identity generation",
+        "pattern hit shaping is lazy but preserves graph dependencies",
         "db unfiltered graph search retains algebraic execution",
+        "db preflightSearchRequest validates live lane bindings",
         "db graph search filters result nodes and hidden traversal intermediates",
         "db graph shortest path searches through admitted alternatives",
         "db graph artifact external node targets return ids without document hydration",
@@ -7640,6 +7655,42 @@ pub fn build(b: *std.Build) void {
     }
     const backend_bench_step = b.step("backend-bench", "Benchmark shared backend workloads across LMDB and LSM backends");
     backend_bench_step.dependOn(&run_backend_bench.step);
+
+    const graph_pattern_bench_mod = b.createModule(.{
+        .root_source_file = b.path("bench/graph/pattern_query_bench.zig"),
+        .target = target,
+        .optimize = .ReleaseFast,
+    });
+    graph_pattern_bench_mod.addImport("antfly_zig", lib_mod);
+    const graph_pattern_bench = b.addExecutable(.{
+        .name = "graph_pattern_query_bench",
+        .root_module = graph_pattern_bench_mod,
+    });
+    const graph_pattern_bench_build_step = b.step(
+        "graph-pattern-bench-build",
+        "Build the local graph-pattern latency and demand-working-set benchmark",
+    );
+    graph_pattern_bench_build_step.dependOn(&graph_pattern_bench.step);
+
+    const run_graph_pattern_bench = b.addRunArtifact(graph_pattern_bench);
+    if (b.args) |args| {
+        run_graph_pattern_bench.addArgs(args);
+    } else {
+        run_graph_pattern_bench.addArgs(&.{
+            "--mode",          "exact",
+            "--fanout",        "10000",
+            "--tags-per-post", "8",
+            "--target-degree", "100000",
+            "--match-every",   "10",
+            "--warmup",        "5",
+            "--samples",       "30",
+        });
+    }
+    const graph_pattern_bench_step = b.step(
+        "graph-pattern-bench",
+        "Benchmark exact or generic graph-pattern latency, allocations, and process peak RSS",
+    );
+    graph_pattern_bench_step.dependOn(&run_graph_pattern_bench.step);
 
     const lsm_backend_bench_mod = b.createModule(.{
         .root_source_file = b.path("bench/storage/lsm_backend_bench.zig"),

--- a/zig/e2e/antfly/test_graph.py
+++ b/zig/e2e/antfly/test_graph.py
@@ -636,6 +636,7 @@ def test_serverless_graph_pattern_two_hop_and_documents(serverless_api):
                 "type": "pattern",
                 "index_name": "graph_idx",
                 "start_nodes": {"keys": ["doc-a"]},
+                "params": {"include_paths": True},
                 "pattern": [
                     {"alias": "a"},
                     {
@@ -942,6 +943,7 @@ def test_stateful_graph_pattern_two_hop_and_documents(backup_api):
                 "type": "pattern",
                 "index_name": "graph_idx",
                 "start_nodes": {"keys": ["doc-a"]},
+                "params": {"include_paths": True},
                 "pattern": [
                     {"alias": "a"},
                     {
@@ -1055,6 +1057,7 @@ def test_stateful_graph_pattern_variable_length_and_cycle(backup_api):
                 "type": "pattern",
                 "index_name": "graph_idx",
                 "start_nodes": {"keys": ["doc-a"]},
+                "params": {"include_paths": True},
                 "pattern": [
                     {"alias": "x"},
                     {

--- a/zig/pkg/antfly/src/api/distributed_graph.zig
+++ b/zig/pkg/antfly/src/api/distributed_graph.zig
@@ -464,6 +464,7 @@ pub const GraphHydrateResponse = struct {
 pub const GraphEdgesRequest = struct {
     index_name: []u8,
     key: []u8,
+    edge_types: [][]const u8 = &.{},
     direction: graph_mod.EdgeDirection,
     tensor_access_path: ?OwnedGraphTensorAccessPath = null,
     tensor_program: ?query_contract.OwnedAlgebraicTensorProgramEnvelope = null,
@@ -475,6 +476,7 @@ pub const GraphEdgesRequest = struct {
     pub fn deinit(self: *GraphEdgesRequest, alloc: std.mem.Allocator) void {
         alloc.free(self.index_name);
         alloc.free(self.key);
+        freeConstStrings(alloc, self.edge_types);
         if (self.tensor_access_path) |*path| path.deinit(alloc);
         if (self.tensor_program) |*program| program.deinit(alloc);
         self.* = undefined;
@@ -663,6 +665,7 @@ const GraphHydrateResponseJson = struct {
 const GraphEdgesRequestJson = struct {
     index_name: []const u8,
     key: []const u8,
+    edge_types: []const []const u8 = &.{},
     direction: []const u8 = "out",
     topology_epoch: u64 = 0,
     identity_read_generation: ?u64 = null,
@@ -1385,6 +1388,7 @@ const DistributedEdgeReader = struct {
         a: std.mem.Allocator,
         table: ?[]const u8,
         key: []const u8,
+        edge_types: []const []const u8,
         direction: graph_mod.EdgeDirection,
     ) ![]graph_mod.Edge {
         const table_name = table orelse self.source_table;
@@ -1413,6 +1417,7 @@ const DistributedEdgeReader = struct {
         var req = GraphEdgesRequest{
             .index_name = index_name,
             .key = owned_key,
+            .edge_types = try dupConstStrings(a, edge_types),
             .direction = direction,
             .tensor_access_path = tensor_access_path,
             .tensor_program = tensor_program,
@@ -1459,6 +1464,17 @@ fn executeDistributedPattern(
         start_nodes[i] = .{ .table = item.table, .key = item.key };
     }
 
+    const target_frontier = if (graph_query.query.target_nodes) |selector|
+        try resolveStartFrontier(alloc, &state, req, base_result, prior_results, selector, false)
+    else
+        try alloc.alloc(FrontierState, 0);
+    defer freeFrontier(alloc, target_frontier);
+    const target_nodes = try alloc.alloc(graph_node_identity.Ref, target_frontier.len);
+    defer alloc.free(target_nodes);
+    for (target_frontier, 0..) |item, i| {
+        target_nodes[i] = .{ .table = item.table, .key = item.key };
+    }
+
     // Build distributed edge reader.
     const edge_reader = DistributedEdgeReader{
         .catalog = catalog,
@@ -1478,6 +1494,9 @@ fn executeDistributedPattern(
         .{
             .max_results = graph_query.query.params.max_results,
             .return_aliases = graph_query.query.return_aliases,
+            .target_nodes = target_nodes,
+            .target_required = graph_query.query.target_nodes != null,
+            .include_paths = graph_query.query.params.include_paths,
             .node_admission = admission.iface(),
         },
     );
@@ -3326,6 +3345,7 @@ pub fn encodeGraphEdgesRequest(alloc: std.mem.Allocator, req: GraphEdgesRequest)
     return try jsonStringifyAlloc(alloc, GraphEdgesRequestJson{
         .index_name = req.index_name,
         .key = req.key,
+        .edge_types = req.edge_types,
         .direction = switch (req.direction) {
             .out => "out",
             .in => "in",
@@ -3354,6 +3374,7 @@ pub fn parseGraphEdgesRequest(alloc: std.mem.Allocator, body: []const u8) !Graph
     return .{
         .index_name = try alloc.dupe(u8, parsed.value.index_name),
         .key = try alloc.dupe(u8, parsed.value.key),
+        .edge_types = try dupConstStrings(alloc, parsed.value.edge_types),
         .direction = if (std.mem.eql(u8, parsed.value.direction, "in"))
             .in
         else if (std.mem.eql(u8, parsed.value.direction, "both"))
@@ -6801,6 +6822,7 @@ test "distributed graph edges request preserves typed graph edge access path" {
     var req = GraphEdgesRequest{
         .index_name = try alloc.dupe(u8, "graph_idx"),
         .key = try alloc.dupe(u8, "doc:a"),
+        .edge_types = try dupConstStrings(alloc, &.{ "links", "mentions" }),
         .direction = .both,
         .topology_epoch = 42,
         .identity_read_generation = 12345,
@@ -6823,6 +6845,9 @@ test "distributed graph edges request preserves typed graph edge access path" {
     var parsed = try parseGraphEdgesRequest(alloc, encoded);
     defer parsed.deinit(alloc);
     try std.testing.expectEqual(graph_mod.EdgeDirection.both, parsed.direction);
+    try std.testing.expectEqual(@as(usize, 2), parsed.edge_types.len);
+    try std.testing.expectEqualStrings("links", parsed.edge_types[0]);
+    try std.testing.expectEqualStrings("mentions", parsed.edge_types[1]);
     try std.testing.expectEqual(@as(u64, 42), parsed.topology_epoch);
     try std.testing.expectEqual(@as(?u64, 12345), parsed.identity_read_generation);
     try std.testing.expect(parsed.tensor_access_path != null);
@@ -6946,6 +6971,8 @@ test "distributed graph edge reader carries identity generation" {
             try std.testing.expectEqual(raft_mod.ReadConsistency.read_index, consistency);
             try std.testing.expectEqualStrings("graph_idx", req.index_name);
             try std.testing.expectEqualStrings("doc:a", req.key);
+            try std.testing.expectEqual(@as(usize, 1), req.edge_types.len);
+            try std.testing.expectEqualStrings("links", req.edge_types[0]);
             try std.testing.expectEqual(graph_mod.EdgeDirection.out, req.direction);
             try std.testing.expectEqual(@as(u64, 0), req.topology_epoch);
             try std.testing.expectEqual(@as(?u64, 12345), req.identity_read_generation);
@@ -6977,7 +7004,7 @@ test "distributed graph edge reader carries identity generation" {
         .admission = &admission,
     };
 
-    const edges = try reader.getEdges(alloc, null, "doc:a", .out);
+    const edges = try reader.getEdges(alloc, null, "doc:a", &.{"links"}, .out);
     defer reader.freeEdges(alloc, edges);
     try std.testing.expectEqual(@as(usize, 0), edges.len);
     try std.testing.expectEqual(@as(u32, 1), state.calls);

--- a/zig/pkg/antfly/src/api/public_graph_query.zig
+++ b/zig/pkg/antfly/src/api/public_graph_query.zig
@@ -262,7 +262,6 @@ fn parseSupportedGraphQuery(
         },
         .pattern => {
             if (pattern.len == 0) return error.UnsupportedQueryRequest;
-            if (target_nodes != null) return error.UnsupportedQueryRequest;
         },
         else => unreachable,
     }
@@ -731,6 +730,7 @@ test "parse supported graph queries accepts pattern requests" {
         \\      "type": "pattern",
         \\      "index_name": "graph_idx",
         \\      "start_nodes": {"keys": ["doc-a"]},
+        \\      "target_nodes": {"keys": ["doc-z"]},
         \\      "pattern": [
         \\        {"alias": "a"},
         \\        {"alias": "b", "edge": {"types": ["links"], "direction": "out", "min_hops": 1, "max_hops": 2}}
@@ -750,6 +750,7 @@ test "parse supported graph queries accepts pattern requests" {
     try std.testing.expectEqual(@as(usize, 1), items.len);
     try std.testing.expectEqual(graph_query_mod.QueryType.pattern, items[0].query.query_type);
     try std.testing.expectEqual(@as(usize, 2), items[0].query.pattern.len);
+    try std.testing.expectEqualStrings("doc-z", items[0].query.target_nodes.?.keys[0]);
     try std.testing.expectEqual(@as(usize, 1), items[0].query.return_aliases.len);
     try std.testing.expect(items[0].query.include_documents);
     try std.testing.expectEqual(@as(usize, 1), items[0].query.fields.len);

--- a/zig/pkg/antfly/src/api/query.zig
+++ b/zig/pkg/antfly/src/api/query.zig
@@ -159,35 +159,50 @@ fn mergeGenericSearchResultsWithRuntimeSchema(
         };
     }
 
-    var merged_hits = std.ArrayListUnmanaged(db_mod.types.SearchHit).empty;
-    defer {
-        for (merged_hits.items) |*hit| hit.deinit(alloc);
-        merged_hits.deinit(alloc);
-    }
+    // Borrow payloads and retain only the requested top-(offset+limit) window.
+    // An unbounded request still needs every reference, but ordinary pages no
+    // longer allocate either payload copies or an O(total candidates) pointer
+    // array at the coordinator.
+    var merged_hits = std.ArrayListUnmanaged(*const db_mod.types.SearchHit).empty;
+    defer merged_hits.deinit(alloc);
+    var bounded_hits = std.PriorityQueue(
+        *const db_mod.types.SearchHit,
+        ScoreMergeOrder,
+        searchHitRefWorstFirst,
+    ).initContext(.{ .use_score = requestUsesScoreOrderedMerge(req) });
+    defer bounded_hits.deinit(alloc);
 
     const score_ordered_merge = requestUsesScoreOrderedMerge(req);
+    var candidate_count: usize = 0;
+    for (results) |result| candidate_count = std.math.add(usize, candidate_count, result.hits.len) catch std.math.maxInt(usize);
+    const retained_window = std.math.add(usize, @as(usize, offset), @as(usize, limit)) catch std.math.maxInt(usize);
+    const use_bounded_window = limit != 0 and retained_window < candidate_count;
+    if (use_bounded_window) try bounded_hits.ensureTotalCapacity(alloc, retained_window);
     for (results) |result| {
-        for (result.hits) |hit| {
-            if (score_ordered_merge) try validateScoreOrderedMergeHit(hit);
-            try merged_hits.append(alloc, try hit.clone(alloc));
+        for (result.hits) |*hit| {
+            if (score_ordered_merge) try validateScoreOrderedMergeHit(hit.*);
+            if (!use_bounded_window) {
+                try merged_hits.append(alloc, hit);
+                continue;
+            }
+            if (bounded_hits.items.len < retained_window) {
+                try bounded_hits.push(alloc, hit);
+                continue;
+            }
+            const worst = bounded_hits.peek().?;
+            if (!searchHitRefComesBefore(.{ .use_score = score_ordered_merge }, hit, worst)) continue;
+            _ = bounded_hits.pop();
+            try bounded_hits.push(alloc, hit);
         }
     }
 
-    std.sort.pdq(db_mod.types.SearchHit, merged_hits.items, ScoreMergeOrder{
+    const candidate_refs = if (use_bounded_window) bounded_hits.items else merged_hits.items;
+    std.sort.pdq(*const db_mod.types.SearchHit, candidate_refs, ScoreMergeOrder{
         .use_score = score_ordered_merge,
-    }, struct {
-        fn lessThan(order: ScoreMergeOrder, a: db_mod.types.SearchHit, b: db_mod.types.SearchHit) bool {
-            if (order.use_score) {
-                const a_score = a.score.?;
-                const b_score = b.score.?;
-                if (a_score != b_score) return a_score > b_score;
-            }
-            return std.mem.order(u8, a.id, b.id) == .lt;
-        }
-    }.lessThan);
+    }, searchHitRefComesBefore);
 
-    const start: usize = @min(offset, merged_hits.items.len);
-    const max_count: usize = if (limit == 0) merged_hits.items.len - start else @min(limit, merged_hits.items.len - start);
+    const start: usize = @min(offset, candidate_refs.len);
+    const max_count: usize = if (limit == 0) candidate_refs.len - start else @min(limit, candidate_refs.len - start);
     const end = start + max_count;
 
     var final_hits = try alloc.alloc(db_mod.types.SearchHit, max_count);
@@ -197,7 +212,7 @@ fn mergeGenericSearchResultsWithRuntimeSchema(
         alloc.free(final_hits);
     }
 
-    for (merged_hits.items[start..end], 0..) |hit, i| {
+    for (candidate_refs[start..end], 0..) |hit, i| {
         final_hits[i] = try hit.clone(alloc);
         moved += 1;
     }
@@ -224,6 +239,29 @@ fn mergeGenericSearchResultsWithRuntimeSchema(
         .identity_read_generation = mergedSearchResultIdentityReadGeneration(req, results),
         .graph_results = graph_results,
     };
+}
+
+fn searchHitRefComesBefore(
+    order: ScoreMergeOrder,
+    a: *const db_mod.types.SearchHit,
+    b: *const db_mod.types.SearchHit,
+) bool {
+    if (order.use_score) {
+        const a_score = a.score.?;
+        const b_score = b.score.?;
+        if (a_score != b_score) return a_score > b_score;
+    }
+    return std.mem.order(u8, a.id, b.id) == .lt;
+}
+
+fn searchHitRefWorstFirst(
+    order: ScoreMergeOrder,
+    a: *const db_mod.types.SearchHit,
+    b: *const db_mod.types.SearchHit,
+) std.math.Order {
+    if (searchHitRefComesBefore(order, a, b)) return .gt;
+    if (searchHitRefComesBefore(order, b, a)) return .lt;
+    return .eq;
 }
 
 fn requestReturnsHierarchyUnitGroups(req: db_mod.types.SearchRequest) bool {
@@ -1988,6 +2026,33 @@ test "query merge applies global score ordering and offset" {
     try std.testing.expectEqual(@as(usize, 1), merged.hits.len);
     try std.testing.expectEqualStrings("doc:b", merged.hits[0].id);
     try std.testing.expectEqual(@as(?u32, null), merged.hits[0].doc_ordinal);
+}
+
+test "query merge allocation scales with the selected page" {
+    const large_stored = "x" ** 1024;
+    var input_hits: [2048]db_mod.types.SearchHit = undefined;
+    for (&input_hits) |*hit| {
+        hit.* = .{
+            .id = @constCast("doc:a"),
+            .stored_data = @constCast(large_stored),
+        };
+    }
+    const input = db_mod.types.SearchResult{
+        .alloc = std.testing.allocator,
+        .hits = &input_hits,
+        .total_hits = input_hits.len,
+    };
+
+    // Enough for a bounded top-one heap plus one cloned page hit, but not for
+    // an O(candidate count) pointer array or cloned stored candidates.
+    var backing: [4096]u8 = undefined;
+    var fba = std.heap.FixedBufferAllocator.init(&backing);
+    var merged = try mergeSearchResults(fba.allocator(), .{}, &.{input}, 0, 1);
+    defer merged.deinit();
+
+    try std.testing.expectEqual(@as(usize, 1), merged.hits.len);
+    try std.testing.expectEqualStrings("doc:a", merged.hits[0].id);
+    try std.testing.expectEqual(@as(usize, large_stored.len), merged.hits[0].stored_data.?.len);
 }
 
 test "query merge rejects score ordered hits without finite scores" {

--- a/zig/pkg/antfly/src/api/query_builder_agent.zig
+++ b/zig/pkg/antfly/src/api/query_builder_agent.zig
@@ -3030,6 +3030,7 @@ fn buildGraphQueryBuilderRepairMessages(
         \\- node_filter is supported in params and pattern steps, but not inside start_nodes or target_nodes.
         \\- Do not include algorithm, algorithm_params, include_edges, or unknown fields.
         \\- shortest_path and k_shortest_paths require target_nodes.
+        \\- Pattern queries may use target_nodes to constrain the final binding; prefer it over an exact node_filter.filter_prefix when the endpoint is known.
         \\- pattern queries require unique aliases, an edge on every step after the first, and return_aliases that exist in the pattern.
     ;
     const repair_prompt = if (feedback) |value|
@@ -3556,7 +3557,7 @@ fn buildGraphQueryBuilderSystemPrompt(
         \\- Neighbors: {"type":"neighbors","index_name":"graph_idx","start_nodes":{"result_ref":"$full_text_results","limit":5},"params":{"edge_types":["links"],"max_depth":1}}
         \\- Traverse: {"type":"traverse","index_name":"graph_idx","start_nodes":{"keys":["doc:a"]},"params":{"edge_types":["references"],"max_depth":2,"deduplicate_nodes":true}}
         \\- Shortest path: {"type":"shortest_path","index_name":"graph_idx","start_nodes":{"keys":["doc:a"]},"target_nodes":{"keys":["doc:b"]},"params":{"edge_types":["depends_on"],"max_depth":6,"include_paths":true}}
-        \\- Pattern: {"type":"pattern","index_name":"graph_idx","start_nodes":{"keys":["doc:a"]},"pattern":[{"alias":"a"},{"alias":"b","edge":{"types":["links"],"direction":"out","min_hops":1,"max_hops":1}}],"return_aliases":["b"]}
+        \\- Pattern with an exact endpoint: {"type":"pattern","index_name":"graph_idx","start_nodes":{"keys":["doc:a"]},"target_nodes":{"keys":["doc:c"]},"pattern":[{"alias":"a"},{"alias":"b","edge":{"types":["links"],"direction":"out","min_hops":1,"max_hops":1}},{"alias":"c","edge":{"types":["links"],"direction":"out","min_hops":1,"max_hops":1}}],"return_aliases":["c"]}
         \\
         \\Always include index_name and start_nodes. Use {"result_ref":"$full_text_results"} when node keys are not explicit. Prefer named graph indexes listed below.
         \\Use fields only from the schema context. Do not invent fields or indexes.
@@ -3695,7 +3696,6 @@ fn validateGeneratedQueryBuilderGraphQuery(
     }
     switch (query.type) {
         .pattern => {
-            if (query.target_nodes != null) return error.InvalidQueryBuilderGeneration;
             const pattern = query.pattern orelse return error.InvalidQueryBuilderGeneration;
             try validateGeneratedGraphPattern(pattern, query.return_aliases);
         },
@@ -9816,6 +9816,10 @@ test "query builder infers graph between nodes and dependency edge type" {
 }
 
 test "query builder infers graph multi hop pattern from intent" {
+    var constraints_tree = try std.json.parseFromSlice(std.json.Value, std.testing.allocator,
+        \\{"graph_target_nodes":"doc:z"}
+    , .{});
+    defer constraints_tree.deinit();
     var arena_impl = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena_impl.deinit();
     const result = try buildQueryBuilderResponseWithContext(arena_impl.allocator(), .{
@@ -9823,6 +9827,7 @@ test "query builder infers graph multi hop pattern from intent" {
         .intent = "find two hop links from doc:a",
         .schema_fields = &.{"body"},
         .mode = "graph",
+        .constraints = constraints_tree.value,
     }, .{
         .graph_index_metadata = &.{.{ .name = "doc_graph" }},
     }, null);
@@ -9831,6 +9836,7 @@ test "query builder infers graph multi hop pattern from intent" {
     const graph_query = result.query_request.?.graph_searches.?.map.get("graph_search").?;
     try std.testing.expectEqual(indexes_openapi.GraphQueryType.pattern, graph_query.type);
     try std.testing.expectEqualStrings("doc:a", graph_query.start_nodes.?.keys.?[0]);
+    try std.testing.expectEqualStrings("doc:z", graph_query.target_nodes.?.keys.?[0]);
     try std.testing.expectEqual(@as(usize, 3), graph_query.pattern.?.len);
     try std.testing.expectEqualStrings("a", graph_query.pattern.?[0].alias.?);
     try std.testing.expect(graph_query.pattern.?[0].edge == null);

--- a/zig/pkg/antfly/src/api/query_contract.zig
+++ b/zig/pkg/antfly/src/api/query_contract.zig
@@ -5071,9 +5071,26 @@ fn buildGraphQueryResults(
 
     for (result.graph_results) |graph_result| {
         const query_type = findGraphQueryType(req.graph_queries, graph_result.name) orelse continue;
-        try out.map.put(alloc, graph_result.name, try toOpenApiGraphQueryResult(alloc, query_type, meta, graph_result));
+        try out.map.put(alloc, graph_result.name, try toOpenApiGraphQueryResult(
+            alloc,
+            query_type,
+            findGraphQueryIncludePaths(req.graph_queries, graph_result.name),
+            meta,
+            graph_result,
+        ));
     }
     return out;
+}
+
+fn findGraphQueryIncludePaths(
+    graph_queries: []const db_mod.types.NamedGraphQuery,
+    name: []const u8,
+) bool {
+    for (graph_queries) |graph_query| {
+        if (std.mem.eql(u8, graph_query.name, name))
+            return graph_query.query.params.include_paths;
+    }
+    return false;
 }
 
 fn findGraphQueryType(
@@ -5096,6 +5113,7 @@ fn findGraphQueryType(
 fn toOpenApiGraphQueryResult(
     alloc: std.mem.Allocator,
     query_type: indexes_openapi.GraphQueryType,
+    include_paths: bool,
     meta: QueryResponseMeta,
     graph_result: db_mod.types.GraphSearchResult,
 ) !indexes_openapi.GraphQueryResult {
@@ -5103,7 +5121,7 @@ fn toOpenApiGraphQueryResult(
         .type = query_type,
         .nodes = try toOpenApiGraphNodes(alloc, graph_result),
         .paths = try toOpenApiPaths(alloc, graph_result.paths),
-        .matches = try toOpenApiPatternMatches(alloc, graph_result),
+        .matches = try toOpenApiPatternMatches(alloc, graph_result, include_paths),
         .total = @intCast(graph_result.total_hits),
         .took = meta.took_ms,
     };
@@ -5112,6 +5130,7 @@ fn toOpenApiGraphQueryResult(
 fn toOpenApiPatternMatches(
     alloc: std.mem.Allocator,
     graph_result: db_mod.types.GraphSearchResult,
+    include_paths: bool,
 ) !?[]const indexes_openapi.PatternMatch {
     if (graph_result.matches.len == 0) return null;
     const out = try alloc.alloc(indexes_openapi.PatternMatch, graph_result.matches.len);
@@ -5139,10 +5158,48 @@ fn toOpenApiPatternMatches(
         }
         out[i] = .{
             .bindings = bindings,
-            .path = try toOpenApiPathEdges(alloc, match.path),
+            .path = if (include_paths) try toOpenApiPathEdges(alloc, match.path) else null,
         };
     }
     return out;
+}
+
+test "pattern response omits paths unless requested" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+    const bindings = [_]db_mod.types.GraphPatternBinding{.{
+        .alias = @constCast("node"),
+        .node = .{
+            .key = @constCast("doc:a"),
+            .depth = 0,
+            .distance = 0,
+            .path = null,
+            .path_edges = null,
+        },
+    }};
+    const path = [_]graph_query_mod.PathEdgeInfo{.{
+        .source = @constCast("doc:a"),
+        .target = @constCast("doc:b"),
+        .edge_type = @constCast("links"),
+        .weight = 1,
+        .metadata = "",
+    }};
+    const matches = [_]db_mod.types.GraphPatternMatch{.{
+        .bindings = @constCast(bindings[0..]),
+        .path = @constCast(path[0..]),
+    }};
+    const graph_result = db_mod.types.GraphSearchResult{
+        .name = @constCast("pattern"),
+        .matches = @constCast(matches[0..]),
+        .hits = &.{},
+        .total_hits = 1,
+    };
+
+    const without_paths = (try toOpenApiPatternMatches(alloc, graph_result, false)).?;
+    try std.testing.expect(without_paths[0].path == null);
+    const with_paths = (try toOpenApiPatternMatches(alloc, graph_result, true)).?;
+    try std.testing.expectEqual(@as(usize, 1), with_paths[0].path.?.len);
 }
 
 fn toOpenApiGraphNodes(
@@ -8244,7 +8301,6 @@ fn parseGraphQuery(
 
     if (query.type == .pattern) {
         if (pattern.len == 0) return error.UnsupportedQueryRequest;
-        if (target_nodes != null) return error.UnsupportedQueryRequest;
     } else {
         if (pattern.len > 0 or return_aliases.len > 0) return error.UnsupportedQueryRequest;
     }

--- a/zig/pkg/antfly/src/api/table_reads.zig
+++ b/zig/pkg/antfly/src/api/table_reads.zig
@@ -2410,7 +2410,8 @@ pub const BoundTableReadSource = struct {
         if (!std.mem.eql(u8, self.table_name, table_name)) return null;
         if (req.topology_epoch != 0) return error.TopologyChanged;
         try distributed_graph.validateGraphEdgesTensorAccessPath(alloc, req);
-        const edges = try self.db.getEdges(alloc, req.index_name, req.key, "", req.direction);
+        const graph_entry = self.db.core.graphIndex(req.index_name) orelse return error.IndexNotFound;
+        const edges = try graph_entry.index.getEdgesByTypes(alloc, req.key, req.edge_types, req.direction);
         return .{ .edges = edges };
     }
 };
@@ -7982,7 +7983,7 @@ fn executeProvisionedGraphGetEdgesAttempt(
     _ = try currentIdentityReadGenerationForDb(req.identity_read_generation, db_owner.db());
 
     const graph_entry = db_owner.db().core.graphIndex(req.index_name) orelse return error.IndexNotFound;
-    return .{ .edges = try graph_entry.index.getEdges(alloc, req.key, "", req.direction) };
+    return .{ .edges = try graph_entry.index.getEdgesByTypes(alloc, req.key, req.edge_types, req.direction) };
 }
 
 fn executeHostedGraphGetEdges(
@@ -8028,7 +8029,7 @@ fn graphGetEdgesLocal(
     try reads.reads.prepareLookupWithConsistency(group_id, req.key, .{}, consistency);
 
     const graph_entry = db.core.graphIndex(req.index_name) orelse return error.IndexNotFound;
-    const edges = try graph_entry.index.getEdges(alloc, req.key, "", req.direction);
+    const edges = try graph_entry.index.getEdgesByTypes(alloc, req.key, req.edge_types, req.direction);
     return .{ .edges = edges };
 }
 

--- a/zig/pkg/antfly/src/graph/graph.zig
+++ b/zig/pkg/antfly/src/graph/graph.zig
@@ -58,6 +58,15 @@ pub const Edge = struct {
     metadata: []const u8, // raw JSON bytes
 };
 
+/// A physical, table-local relationship identity. Graph edge keys are laid out
+/// by this tuple, so a batch of probes can be answered without materializing
+/// either endpoint's complete adjacency list.
+pub const EdgeProbe = struct {
+    source: []const u8,
+    target: []const u8,
+    edge_type: []const u8,
+};
+
 pub const BatchWrite = struct {
     source: []const u8,
     target: []const u8,
@@ -446,6 +455,10 @@ pub const GraphIndex = struct {
 
     fn beginWriteOutgoingBatch(self: *GraphIndex) !backend_erased.Batch {
         return try self.outgoing_store.beginBatch();
+    }
+
+    fn beginReadOutgoingTxn(self: *GraphIndex) !backend_erased.ReadTxn {
+        return try self.outgoing_store.beginRead();
     }
 
     fn beginReadReverseTxn(self: *GraphIndex) !backend_erased.ReadTxn {
@@ -1004,9 +1017,115 @@ pub const GraphIndex = struct {
             try self.scanIncomingEdges(alloc, &results, key, edge_type);
         }
 
-        const owned = try alloc.dupe(Edge, results.items);
-        results.deinit(alloc);
-        return owned;
+        return try results.toOwnedSlice(alloc);
+    }
+
+    /// Get edges connected to a key, restricting storage scans to the requested
+    /// relationship types. An empty type list retains the unfiltered behavior.
+    pub fn getEdgesByTypes(self: *GraphIndex, alloc: Allocator, key: []const u8, edge_types: []const []const u8, direction: EdgeDirection) ![]Edge {
+        if (edge_types.len == 0) return try self.getEdges(alloc, key, "", direction);
+
+        var results = std.ArrayListUnmanaged(Edge).empty;
+        errdefer {
+            for (results.items) |e| freeEdge(alloc, e);
+            results.deinit(alloc);
+        }
+        for (edge_types, 0..) |edge_type, type_index| {
+            var duplicate = false;
+            for (edge_types[0..type_index]) |prior| {
+                if (std.mem.eql(u8, edge_type, prior)) {
+                    duplicate = true;
+                    break;
+                }
+            }
+            if (duplicate) continue;
+            if (direction == .out or direction == .both) {
+                try self.scanOutgoingEdges(alloc, &results, key, edge_type);
+            }
+            if (direction == .in or direction == .both) {
+                try self.scanIncomingEdges(alloc, &results, key, edge_type);
+            }
+        }
+        return try results.toOwnedSlice(alloc);
+    }
+
+    /// Resolve exact physical relationships with one snapshot and one sorted
+    /// backend multi-get. Results remain aligned with `probes`; null means the
+    /// relationship does not exist. Only found edges allocate edge payloads.
+    pub fn probeEdgesAlloc(self: *GraphIndex, alloc: Allocator, probes: []const EdgeProbe) ![]?Edge {
+        const ProbeKey = struct {
+            encoded: []u8,
+            result_index: usize,
+
+            fn lessThan(_: void, left: @This(), right: @This()) bool {
+                return std.mem.order(u8, left.encoded, right.encoded) == .lt;
+            }
+        };
+
+        const results = try alloc.alloc(?Edge, probes.len);
+        errdefer alloc.free(results);
+        @memset(results, null);
+        if (probes.len == 0) return results;
+
+        const keys = try alloc.alloc(ProbeKey, probes.len);
+        var initialized_keys: usize = 0;
+        defer {
+            for (keys[0..initialized_keys]) |item| alloc.free(item.encoded);
+            alloc.free(keys);
+        }
+        for (probes, 0..) |probe, i| {
+            keys[i] = .{
+                .encoded = try edgeKeyAlloc(alloc, probe.source, self.index_name, probe.edge_type, probe.target),
+                .result_index = i,
+            };
+            initialized_keys += 1;
+        }
+        std.mem.sort(ProbeKey, keys, {}, ProbeKey.lessThan);
+
+        const sorted_key_refs = try alloc.alloc([]const u8, keys.len);
+        defer alloc.free(sorted_key_refs);
+        for (keys, 0..) |item, i| sorted_key_refs[i] = item.encoded;
+        const values = try alloc.alloc(?[]const u8, keys.len);
+        defer alloc.free(values);
+
+        var txn = try self.beginReadOutgoingTxn();
+        defer txn.abort();
+        try txn.getManySorted(sorted_key_refs, values);
+
+        errdefer {
+            for (results) |maybe_edge| if (maybe_edge) |edge| freeEdge(alloc, edge);
+        }
+        for (keys, values) |item, maybe_value| {
+            const value = maybe_value orelse continue;
+            const decoded = try decodeEdgeValue(value);
+            const probe = probes[item.result_index];
+            const source = try alloc.dupe(u8, probe.source);
+            errdefer alloc.free(source);
+            const target = try alloc.dupe(u8, probe.target);
+            errdefer alloc.free(target);
+            const edge_type = try alloc.dupe(u8, probe.edge_type);
+            errdefer alloc.free(edge_type);
+            const metadata = if (decoded.metadata.len > 0)
+                try alloc.dupe(u8, decoded.metadata)
+            else
+                "";
+            errdefer if (metadata.len > 0) alloc.free(metadata);
+            results[item.result_index] = .{
+                .source = source,
+                .target = target,
+                .edge_type = edge_type,
+                .weight = decoded.weight,
+                .created_at = decoded.created_at,
+                .updated_at = decoded.updated_at,
+                .metadata = metadata,
+            };
+        }
+        return results;
+    }
+
+    pub fn freeProbedEdges(alloc: Allocator, edges: []?Edge) void {
+        for (edges) |maybe_edge| if (maybe_edge) |edge| freeEdge(alloc, edge);
+        alloc.free(edges);
     }
 
     /// Probe incoming-edge existence for a key batch using one reverse-store
@@ -1039,22 +1158,17 @@ pub const GraphIndex = struct {
         const prefix = try edgePrefixAlloc(alloc, key, self.index_name, edge_type);
         defer alloc.free(prefix);
 
-        const pairs = try self.mainStoreScanPrefix(alloc, prefix);
-        defer backend_scan.freeResults(alloc, pairs);
+        var txn = try self.beginReadOutgoingTxn();
+        defer txn.abort();
+        var cur = try txn.openCursor();
+        defer cur.close();
 
-        for (pairs) |pair| {
-            var parsed = (try parseOutgoingEdgeKeyAlloc(alloc, pair.key)) orelse continue;
-            defer parsed.deinit(alloc);
-            const decoded = try decodeEdgeValue(pair.value);
-            try results.append(alloc, .{
-                .source = try alloc.dupe(u8, parsed.source),
-                .target = try alloc.dupe(u8, parsed.target),
-                .edge_type = try alloc.dupe(u8, parsed.edge_type),
-                .weight = decoded.weight,
-                .created_at = decoded.created_at,
-                .updated_at = decoded.updated_at,
-                .metadata = try alloc.dupe(u8, decoded.metadata),
-            });
+        const first = (try cur.seekAtOrAfter(prefix)) orelse return;
+        if (!std.mem.startsWith(u8, first.key, prefix)) return;
+        try appendEdgeFromKV(alloc, results, first.key, first.value);
+        while (try cur.next()) |entry| {
+            if (!std.mem.startsWith(u8, entry.key, prefix)) break;
+            try appendEdgeFromKV(alloc, results, entry.key, entry.value);
         }
     }
 
@@ -1096,14 +1210,22 @@ pub const GraphIndex = struct {
 
     fn appendParsedEdge(alloc: Allocator, results: *std.ArrayListUnmanaged(Edge), parsed: ParsedGraphEdgeKey, value: []const u8) !void {
         const decoded = try decodeEdgeValue(value);
+        const source = try alloc.dupe(u8, parsed.source);
+        errdefer alloc.free(source);
+        const target = try alloc.dupe(u8, parsed.target);
+        errdefer alloc.free(target);
+        const edge_type = try alloc.dupe(u8, parsed.edge_type);
+        errdefer alloc.free(edge_type);
+        const metadata = if (decoded.metadata.len > 0) try alloc.dupe(u8, decoded.metadata) else "";
+        errdefer if (metadata.len > 0) alloc.free(metadata);
         try results.append(alloc, .{
-            .source = try alloc.dupe(u8, parsed.source),
-            .target = try alloc.dupe(u8, parsed.target),
-            .edge_type = try alloc.dupe(u8, parsed.edge_type),
+            .source = source,
+            .target = target,
+            .edge_type = edge_type,
             .weight = decoded.weight,
             .created_at = decoded.created_at,
             .updated_at = decoded.updated_at,
-            .metadata = try alloc.dupe(u8, decoded.metadata),
+            .metadata = metadata,
         });
     }
 
@@ -1487,6 +1609,39 @@ test "graph addEdge and getEdges in (reverse index)" {
     const incoming = try graph.hasIncomingEdgesManyAlloc(alloc, &keys);
     defer alloc.free(incoming);
     try std.testing.expectEqualSlices(bool, &.{ false, true, false, false }, incoming);
+}
+
+test "graph exact edge probes stay aligned and preserve payloads" {
+    const alloc = std.testing.allocator;
+    var store_buf: [256]u8 = undefined;
+    const store_path = tmpPath(&store_buf, "store-probes");
+    defer cleanupTmp(store_path);
+    var rev_buf: [256]u8 = undefined;
+    const rev_path = tmpPath(&rev_buf, "rev-probes");
+    defer cleanupTmp(rev_path);
+
+    var store = try docstore.DocStore.open(alloc, store_path, .{});
+    defer store.close();
+    var graph = try GraphIndex.open(alloc, &store, rev_path, "links", .{});
+    defer graph.close();
+    try graph.addEdge("post:2", "tag", "HAS_TAG", 0.75, 10, 11, "{\"rank\":1}");
+    try graph.addEdge("post:1", "other", "HAS_TAG", 1, 10, 11, "");
+
+    const probed = try graph.probeEdgesAlloc(alloc, &.{
+        .{ .source = "post:1", .target = "tag", .edge_type = "HAS_TAG" },
+        .{ .source = "post:2", .target = "tag", .edge_type = "HAS_TAG" },
+        .{ .source = "missing", .target = "tag", .edge_type = "HAS_TAG" },
+        .{ .source = "post:2", .target = "tag", .edge_type = "HAS_TAG" },
+    });
+    defer GraphIndex.freeProbedEdges(alloc, probed);
+
+    try std.testing.expect(probed[0] == null);
+    try std.testing.expect(probed[1] != null);
+    try std.testing.expectApproxEqAbs(@as(f64, 0.75), probed[1].?.weight, 0.001);
+    try std.testing.expectEqualStrings("{\"rank\":1}", probed[1].?.metadata);
+    try std.testing.expect(probed[2] == null);
+    try std.testing.expect(probed[3] != null);
+    try std.testing.expectApproxEqAbs(@as(f64, 0.75), probed[3].?.weight, 0.001);
 }
 
 test "graph edge keys support arbitrary document ids and edge types" {

--- a/zig/pkg/antfly/src/graph/pattern.zig
+++ b/zig/pkg/antfly/src/graph/pattern.zig
@@ -78,6 +78,22 @@ pub const PatternMatch = struct {
     }
 };
 
+pub const MatchPlan = enum {
+    generic_expand,
+    exact_two_edge_probe,
+};
+
+/// Optional per-query instrumentation for benchmarks and request diagnostics.
+/// Counters describe logical matcher work rather than backend implementation
+/// details, so they remain comparable across local and serverless readers.
+pub const MatchStats = struct {
+    plan: MatchPlan = .generic_expand,
+    adjacency_reads: usize = 0,
+    adjacency_edges: usize = 0,
+    exact_edge_probes: usize = 0,
+    exact_edge_matches: usize = 0,
+};
+
 pub fn freeMatches(alloc: Allocator, matches: []PatternMatch) void {
     for (matches) |*match| match.deinit(alloc);
     if (matches.len > 0) alloc.free(matches);
@@ -86,8 +102,12 @@ pub fn freeMatches(alloc: Allocator, matches: []PatternMatch) void {
 pub const MatchOptions = struct {
     max_results: u32 = 100,
     return_aliases: []const []const u8 = &.{},
+    target_nodes: []const node_identity.Ref = &.{},
+    target_required: bool = false,
+    include_paths: bool = true,
     evaluator: ?FilterEvaluator = null,
     node_admission: ?NodeAdmission = null,
+    stats: ?*MatchStats = null,
     max_explored_nodes: usize = default_max_explored_nodes,
     max_explored_edges: usize = default_max_explored_edges,
     max_intermediate_states: usize = default_max_intermediate_states,
@@ -163,14 +183,33 @@ pub fn matchPattern(
             a: Allocator,
             table: ?[]const u8,
             key: []const u8,
+            edge_types: []const []const u8,
             direction: graph_mod.EdgeDirection,
         ) ![]graph_mod.Edge {
             if (table != null) return try a.alloc(graph_mod.Edge, 0);
-            return try self.graph_index.getEdges(a, key, "", direction);
+            return try self.graph_index.getEdgesByTypes(a, key, edge_types, direction);
         }
 
         pub fn freeEdges(_: @This(), a: Allocator, edges: []graph_mod.Edge) void {
             graph_mod.GraphIndex.freeEdges(a, edges);
+        }
+
+        pub fn probeEdges(
+            self: @This(),
+            a: Allocator,
+            table: ?[]const u8,
+            probes: []const graph_mod.EdgeProbe,
+        ) ![]?graph_mod.Edge {
+            if (table != null) {
+                const empty = try a.alloc(?graph_mod.Edge, probes.len);
+                @memset(empty, null);
+                return empty;
+            }
+            return try self.graph_index.probeEdgesAlloc(a, probes);
+        }
+
+        pub fn freeProbedEdges(_: @This(), a: Allocator, edges: []?graph_mod.Edge) void {
+            graph_mod.GraphIndex.freeProbedEdges(a, edges);
         }
     };
 
@@ -218,6 +257,9 @@ pub fn matchPatternFromRefsWithEdgeReader(
         if (min_hops > max_hops or max_hops > max_pattern_hops)
             return error.InvalidArgument;
     }
+    if (opts.stats) |stats| stats.* = .{};
+    if (opts.target_required and opts.target_nodes.len == 0)
+        return try alloc.alloc(PatternMatch, 0);
     var work_budget = WorkBudget{
         .remaining_nodes = opts.max_explored_nodes,
         .remaining_edges = opts.max_explored_edges,
@@ -233,6 +275,24 @@ pub fn matchPatternFromRefsWithEdgeReader(
                     std.math.maxInt(usize),
             ),
         );
+
+    // Fast-plan discovery is speculative. A reader may reveal a cross-table
+    // edge that makes the plan inapplicable; never charge that abandoned work
+    // to the generic fallback's public query budget.
+    var exact_budget = work_budget;
+    if (try matchExactTwoEdgePattern(
+        alloc,
+        edge_reader,
+        start_nodes,
+        pattern,
+        opts,
+        intermediate_limit,
+        &exact_budget,
+    )) |matches| {
+        work_budget = exact_budget;
+        if (opts.stats) |stats| stats.plan = .exact_two_edge_probe;
+        return matches;
+    }
 
     var current = std.ArrayListUnmanaged(MatchState).empty;
     defer {
@@ -320,9 +380,13 @@ pub fn matchPatternFromRefsWithEdgeReader(
                 current_binding.table,
                 step.edge,
                 step.node_filter,
+                if (step_idx + 1 == pattern.len) opts.target_nodes else &.{},
+                step_idx + 1 == pattern.len and opts.target_required,
                 opts.max_results,
                 opts.evaluator,
                 opts.node_admission,
+                opts.include_paths,
+                opts.stats,
                 &work_budget,
             );
             defer {
@@ -359,7 +423,10 @@ pub fn matchPatternFromRefsWithEdgeReader(
                     new_bindings = expanded;
                 }
 
-                const new_path = try concatPathEdges(alloc, match.path, reached.path);
+                const new_path = if (opts.include_paths)
+                    try concatPathEdges(alloc, match.path, reached.path)
+                else
+                    @constCast((&[_]paths_mod.PathEdge{})[0..]);
                 errdefer if (state_owned) freePathEdges(alloc, new_path);
                 try next.append(alloc, .{
                     .bindings = new_bindings,
@@ -387,7 +454,17 @@ pub fn matchPatternFromRefsWithEdgeReader(
         if (results.len > 0) alloc.free(results);
     }
 
-    for (current.items[0..limited_len], 0..) |match, i| {
+    for (current.items[0..limited_len], 0..) |*match, i| {
+        if (opts.return_aliases.len == 0) {
+            results[i] = .{
+                .bindings = match.bindings,
+                .path = match.path,
+            };
+            match.bindings = @constCast((&[_]PatternBinding{})[0..]);
+            match.path = @constCast((&[_]paths_mod.PathEdge{})[0..]);
+            initialized += 1;
+            continue;
+        }
         const filtered_bindings = try filterBindings(alloc, match.bindings, opts.return_aliases);
         errdefer {
             for (filtered_bindings) |*binding| binding.deinit(alloc);
@@ -395,12 +472,219 @@ pub fn matchPatternFromRefsWithEdgeReader(
         }
         results[i] = .{
             .bindings = filtered_bindings,
-            .path = try clonePathEdges(alloc, match.path),
+            .path = if (opts.include_paths)
+                try clonePathEdges(alloc, match.path)
+            else
+                @constCast((&[_]paths_mod.PathEdge{})[0..]),
         };
         initialized += 1;
     }
 
+    std.log.debug(
+        "antfly_graph_pattern_plan plan=generic_expand matches={d}",
+        .{results.len},
+    );
     return results;
+}
+
+/// For a fixed two-edge pattern with one exact start and endpoint, scan the
+/// start adjacency once and batch-probe the exact second relationship for each
+/// admitted middle node. The physical graph key already contains
+/// (source,index,type,target), so this plan is independent of global target
+/// degree and does not materialize the target's complete reverse adjacency.
+fn matchExactTwoEdgePattern(
+    alloc: Allocator,
+    edge_reader: anytype,
+    start_nodes: []const node_identity.Ref,
+    pattern: []const PatternStep,
+    opts: MatchOptions,
+    intermediate_limit: usize,
+    work_budget: *WorkBudget,
+) !?[]PatternMatch {
+    if (comptime !@hasDecl(@TypeOf(edge_reader), "probeEdges") or
+        !@hasDecl(@TypeOf(edge_reader), "freeProbedEdges"))
+    {
+        return null;
+    }
+    if (pattern.len != 3 or start_nodes.len != 1 or !opts.target_required or opts.target_nodes.len != 1 or
+        start_nodes[0].table != null or opts.target_nodes[0].table != null or
+        opts.node_admission != null)
+    {
+        return null;
+    }
+    for (pattern[1..]) |step| {
+        if (step.edge.types.len != 1 or step.edge.direction == .both) return null;
+        const min_hops = if (step.edge.min_hops == 0) @as(u32, 1) else step.edge.min_hops;
+        const max_hops = if (step.edge.max_hops == 0) @as(u32, 1) else step.edge.max_hops;
+        if (min_hops != 1 or max_hops != 1) return null;
+    }
+
+    var alias_bufs: [3][32]u8 = undefined;
+    const aliases = [3][]const u8{
+        effectiveAlias(pattern[0].alias, 0, &alias_bufs[0]),
+        effectiveAlias(pattern[1].alias, 1, &alias_bufs[1]),
+        effectiveAlias(pattern[2].alias, 2, &alias_bufs[2]),
+    };
+    if (std.mem.eql(u8, aliases[0], aliases[1]) or
+        std.mem.eql(u8, aliases[0], aliases[2]) or
+        std.mem.eql(u8, aliases[1], aliases[2])) return null;
+
+    const start_key = start_nodes[0].key;
+    const target_key = opts.target_nodes[0].key;
+    if (!(try passesNodeFilter(start_key, pattern[0].node_filter, opts.evaluator)) or
+        !(try passesNodeFilter(target_key, pattern[2].node_filter, opts.evaluator)))
+    {
+        return try alloc.alloc(PatternMatch, 0);
+    }
+
+    const forward_edges = try edge_reader.getEdges(
+        alloc,
+        null,
+        start_key,
+        pattern[1].edge.types,
+        pattern[1].edge.direction,
+    );
+    defer edge_reader.freeEdges(alloc, forward_edges);
+
+    const Candidate = struct {
+        middle_key: []const u8,
+        forward_edge_index: usize,
+    };
+    const expansion_limit: usize = if (opts.max_results == 0)
+        1000
+    else
+        @min(
+            std.math.mul(usize, @as(usize, opts.max_results), 10) catch std.math.maxInt(usize),
+            1000,
+        );
+    var candidates = std.ArrayListUnmanaged(Candidate).empty;
+    defer candidates.deinit(alloc);
+    for (forward_edges, 0..) |graph_edge, edge_index| {
+        if (!edgeMatches(graph_edge, pattern[1].edge)) continue;
+        if (traversal_mod.metadataTargetTable(graph_edge.metadata) != null) return null;
+        const middle_key = edgeTarget(graph_edge, start_key, pattern[1].edge.direction) orelse continue;
+        if (std.mem.eql(u8, middle_key, start_key)) continue;
+        if (edgeTargetTable(null, graph_edge, middle_key) != null) return null;
+        if (!(try passesNodeFilter(middle_key, pattern[1].node_filter, opts.evaluator))) continue;
+        try candidates.append(alloc, .{
+            .middle_key = middle_key,
+            .forward_edge_index = edge_index,
+        });
+        if (candidates.items.len > intermediate_limit)
+            return error.QueryCandidateBudgetExceeded;
+        // Keep the same deterministic first-hop window as generic expansion.
+        // The optimizer must not make nodes beyond that window newly visible.
+        if (candidates.items.len >= expansion_limit) break;
+    }
+
+    // Match generic-expansion accounting: one expanded start node, then one
+    // expanded middle node and one exact relationship probe per candidate.
+    try work_budget.consumeNode();
+    try work_budget.consumeEdges(forward_edges.len);
+    for (candidates.items) |_| try work_budget.consumeNode();
+    try work_budget.consumeEdges(candidates.items.len);
+
+    var matches = std.ArrayListUnmanaged(PatternMatch).empty;
+    errdefer {
+        for (matches.items) |*match| match.deinit(alloc);
+        matches.deinit(alloc);
+    }
+    const result_limit: usize = if (opts.max_results == 0) std.math.maxInt(usize) else opts.max_results;
+    var exact_edge_matches: usize = 0;
+    const probe_batch_size: usize = 256;
+    var candidate_offset: usize = 0;
+    while (candidate_offset < candidates.items.len) {
+        const batch_end = @min(candidate_offset +| probe_batch_size, candidates.items.len);
+        const batch_candidates = candidates.items[candidate_offset..batch_end];
+        const probes = try alloc.alloc(graph_mod.EdgeProbe, batch_candidates.len);
+        defer alloc.free(probes);
+        for (batch_candidates, 0..) |candidate, i| {
+            probes[i] = switch (pattern[2].edge.direction) {
+                .out => .{
+                    .source = candidate.middle_key,
+                    .target = target_key,
+                    .edge_type = pattern[2].edge.types[0],
+                },
+                .in => .{
+                    .source = target_key,
+                    .target = candidate.middle_key,
+                    .edge_type = pattern[2].edge.types[0],
+                },
+                .both => unreachable,
+            };
+        }
+        const probed_edges = try edge_reader.probeEdges(alloc, null, probes);
+        defer edge_reader.freeProbedEdges(alloc, probed_edges);
+        if (probed_edges.len != probes.len) return error.InvalidGraphEdgeProbeResult;
+
+        for (batch_candidates, probed_edges) |candidate, maybe_backward_edge| {
+            const backward_edge = maybe_backward_edge orelse continue;
+            // A physical edge whose metadata changes node-table identity cannot
+            // use this table-local plan. Release already-built results before
+            // the successful null return hands control to generic expansion.
+            if (traversal_mod.metadataTargetTable(backward_edge.metadata) != null) {
+                for (matches.items) |*match| match.deinit(alloc);
+                matches.deinit(alloc);
+                matches = .empty;
+                return null;
+            }
+            if (!edgeMatches(backward_edge, pattern[2].edge)) continue;
+            exact_edge_matches += 1;
+            if (matches.items.len >= result_limit) continue;
+            const forward_edge = forward_edges[candidate.forward_edge_index];
+            const middle_key = candidate.middle_key;
+
+            var all_bindings = try alloc.alloc(PatternBinding, 3);
+            var initialized_bindings: usize = 0;
+            errdefer {
+                for (all_bindings[0..initialized_bindings]) |*binding| binding.deinit(alloc);
+                if (all_bindings.len > 0) alloc.free(all_bindings);
+            }
+            all_bindings[0] = try initPatternBinding(alloc, aliases[0], start_key, null, 0);
+            initialized_bindings += 1;
+            all_bindings[1] = try initPatternBinding(alloc, aliases[1], middle_key, null, 1);
+            initialized_bindings += 1;
+            all_bindings[2] = try initPatternBinding(alloc, aliases[2], target_key, null, 1);
+            initialized_bindings += 1;
+            const filtered_bindings = if (opts.return_aliases.len == 0) blk: {
+                const owned = all_bindings;
+                all_bindings = @constCast((&[_]PatternBinding{})[0..]);
+                initialized_bindings = 0;
+                break :blk owned;
+            } else blk: {
+                const filtered = try filterBindings(alloc, all_bindings, opts.return_aliases);
+                for (all_bindings) |*binding| binding.deinit(alloc);
+                alloc.free(all_bindings);
+                all_bindings = @constCast((&[_]PatternBinding{})[0..]);
+                initialized_bindings = 0;
+                break :blk filtered;
+            };
+            errdefer {
+                for (filtered_bindings) |*binding| binding.deinit(alloc);
+                if (filtered_bindings.len > 0) alloc.free(filtered_bindings);
+            }
+
+            const path = if (opts.include_paths) blk: {
+                const first = try appendPathEdge(alloc, &.{}, forward_edge, start_key, middle_key);
+                defer freePathEdges(alloc, first);
+                break :blk try appendPathEdge(alloc, first, backward_edge, middle_key, target_key);
+            } else @constCast((&[_]paths_mod.PathEdge{})[0..]);
+            errdefer freePathEdges(alloc, path);
+            try matches.append(alloc, .{ .bindings = filtered_bindings, .path = path });
+        }
+        candidate_offset = batch_end;
+    }
+    if (opts.stats) |stats| {
+        stats.adjacency_reads += 1;
+        stats.adjacency_edges += forward_edges.len;
+        stats.exact_edge_probes += candidates.items.len;
+        stats.exact_edge_matches += exact_edge_matches;
+    }
+    std.log.debug(
+        "antfly_graph_pattern_plan plan=exact_two_edge_probe adjacency_edges={d} probes={d} matches={d}",
+        .{ forward_edges.len, candidates.items.len, matches.items.len },
+    );
+    return try matches.toOwnedSlice(alloc);
 }
 
 fn findReachableNodes(
@@ -410,9 +694,13 @@ fn findReachableNodes(
     start_table: ?[]const u8,
     edge: PatternEdgeStep,
     node_filter: NodeFilter,
+    target_nodes: []const node_identity.Ref,
+    target_required: bool,
     max_results: u32,
     evaluator: ?FilterEvaluator,
     node_admission: ?NodeAdmission,
+    include_paths: bool,
+    stats: ?*MatchStats,
     work_budget: *WorkBudget,
 ) ![]ReachableNode {
     const min_hops = if (edge.min_hops == 0) @as(u32, 1) else edge.min_hops;
@@ -465,9 +753,14 @@ fn findReachableNodes(
                 alloc,
                 frontier.table,
                 frontier.key,
+                edge.types,
                 edge.direction,
             );
             defer edge_reader.freeEdges(alloc, edges);
+            if (stats) |active| {
+                active.adjacency_reads += 1;
+                active.adjacency_edges += edges.len;
+            }
             try work_budget.consumeEdges(edges.len);
 
             const admitted_edges = if (node_admission) |admission| blk: {
@@ -522,11 +815,17 @@ fn findReachableNodes(
                     graph_edge,
                     target_key,
                 );
-                const new_path = try appendPathEdge(alloc, frontier.path, graph_edge, frontier.key, target_key);
+                const new_path = if (include_paths)
+                    try appendPathEdge(alloc, frontier.path, graph_edge, frontier.key, target_key)
+                else
+                    @constCast((&[_]paths_mod.PathEdge{})[0..]);
                 var new_path_owned = true;
                 errdefer if (new_path_owned) freePathEdges(alloc, new_path);
 
-                if (new_hops >= min_hops and try passesNodeFilter(target_key, node_filter, evaluator)) {
+                if (new_hops >= min_hops and
+                    targetNodeMatches(.{ .table = target_table, .key = target_key }, target_nodes, target_required) and
+                    try passesNodeFilter(target_key, node_filter, evaluator))
+                {
                     var reached = try initReachableNode(
                         alloc,
                         target_key,
@@ -586,7 +885,7 @@ fn startNodeAdmitted(
     defer alloc.free(admitted);
     if (admitted[0] or direction == .out) return admitted[0];
 
-    const incoming = try edge_reader.getEdges(alloc, null, start_key, .in);
+    const incoming = try edge_reader.getEdges(alloc, null, start_key, &.{}, .in);
     defer edge_reader.freeEdges(alloc, incoming);
     for (incoming) |graph_edge| {
         if (std.mem.eql(u8, graph_edge.target, start_key) and
@@ -595,6 +894,14 @@ fn startNodeAdmitted(
         {
             return true;
         }
+    }
+    return false;
+}
+
+fn targetNodeMatches(node: node_identity.Ref, targets: []const node_identity.Ref, target_required: bool) bool {
+    if (targets.len == 0) return !target_required;
+    for (targets) |target| {
+        if (optionalTableEql(node.table, target.table) and std.mem.eql(u8, node.key, target.key)) return true;
     }
     return false;
 }
@@ -884,6 +1191,284 @@ fn freePathEdgeItems(alloc: Allocator, edges: []const paths_mod.PathEdge) void {
     }
 }
 
+test "exact two-edge pattern uses typed batch probes without paths" {
+    const Reader = struct {
+        forward_calls: *usize,
+        reverse_calls: *usize,
+
+        const forward = [_]graph_mod.Edge{
+            .{ .source = "forum", .target = "post:1", .edge_type = "CONTAINER_OF", .weight = 1, .created_at = 0, .updated_at = 0, .metadata = "" },
+            .{ .source = "forum", .target = "post:2", .edge_type = "CONTAINER_OF", .weight = 1, .created_at = 0, .updated_at = 0, .metadata = "" },
+        };
+        const backward = [_]graph_mod.Edge{
+            .{ .source = "post:2", .target = "tag", .edge_type = "HAS_TAG", .weight = 1, .created_at = 0, .updated_at = 0, .metadata = "" },
+            .{ .source = "post:3", .target = "tag", .edge_type = "HAS_TAG", .weight = 1, .created_at = 0, .updated_at = 0, .metadata = "" },
+        };
+
+        pub fn getEdges(
+            self: @This(),
+            _: Allocator,
+            _: ?[]const u8,
+            key: []const u8,
+            edge_types: []const []const u8,
+            direction: graph_mod.EdgeDirection,
+        ) ![]graph_mod.Edge {
+            try std.testing.expectEqual(@as(usize, 1), edge_types.len);
+            if (std.mem.eql(u8, key, "forum")) {
+                try std.testing.expectEqual(graph_mod.EdgeDirection.out, direction);
+                try std.testing.expectEqualStrings("CONTAINER_OF", edge_types[0]);
+                self.forward_calls.* += 1;
+                return @constCast(forward[0..]);
+            }
+            if (std.mem.eql(u8, key, "tag")) {
+                try std.testing.expectEqual(graph_mod.EdgeDirection.in, direction);
+                try std.testing.expectEqualStrings("HAS_TAG", edge_types[0]);
+                self.reverse_calls.* += 1;
+                return @constCast(backward[0..]);
+            }
+            return error.TestUnexpectedResult;
+        }
+
+        pub fn freeEdges(_: @This(), _: Allocator, _: []graph_mod.Edge) void {}
+
+        pub fn probeEdges(
+            self: @This(),
+            alloc: Allocator,
+            _: ?[]const u8,
+            probes: []const graph_mod.EdgeProbe,
+        ) ![]?graph_mod.Edge {
+            self.reverse_calls.* += 1;
+            const results = try alloc.alloc(?graph_mod.Edge, probes.len);
+            @memset(results, null);
+            for (probes, 0..) |probe, i| {
+                if (std.mem.eql(u8, probe.source, "post:2") and
+                    std.mem.eql(u8, probe.target, "tag") and
+                    std.mem.eql(u8, probe.edge_type, "HAS_TAG"))
+                {
+                    results[i] = backward[0];
+                }
+            }
+            return results;
+        }
+
+        pub fn freeProbedEdges(_: @This(), alloc: Allocator, edges: []?graph_mod.Edge) void {
+            alloc.free(edges);
+        }
+    };
+
+    var forward_calls: usize = 0;
+    var reverse_calls: usize = 0;
+    var stats = MatchStats{};
+    const matches = try matchPatternWithEdgeReader(
+        std.testing.allocator,
+        Reader{ .forward_calls = &forward_calls, .reverse_calls = &reverse_calls },
+        &.{"forum"},
+        &.{
+            .{ .alias = "forum" },
+            .{ .alias = "post", .edge = .{ .types = &.{"CONTAINER_OF"} } },
+            .{ .alias = "tag", .edge = .{ .types = &.{"HAS_TAG"} } },
+        },
+        .{
+            .target_nodes = &.{.{ .table = null, .key = "tag" }},
+            .target_required = true,
+            .include_paths = false,
+            .stats = &stats,
+        },
+    );
+    defer freeMatches(std.testing.allocator, matches);
+
+    try std.testing.expectEqual(@as(usize, 1), forward_calls);
+    try std.testing.expectEqual(@as(usize, 1), reverse_calls);
+    try std.testing.expectEqual(@as(usize, 1), matches.len);
+    try std.testing.expectEqual(MatchPlan.exact_two_edge_probe, stats.plan);
+    try std.testing.expectEqual(@as(usize, 2), stats.exact_edge_probes);
+    try std.testing.expectEqual(@as(usize, 0), matches[0].path.len);
+    try std.testing.expectEqualStrings("post:2", matches[0].bindings[1].key);
+    try std.testing.expectEqualStrings("tag", matches[0].bindings[2].key);
+}
+
+test "exact two-edge probe plan is equivalent to generic expansion" {
+    const GenericReader = struct {
+        const forward = [_]graph_mod.Edge{
+            .{ .source = "forum", .target = "post:1", .edge_type = "CONTAINER_OF", .weight = 1, .created_at = 1, .updated_at = 2, .metadata = "{\"first\":1}" },
+            .{ .source = "forum", .target = "post:2", .edge_type = "CONTAINER_OF", .weight = 1, .created_at = 1, .updated_at = 2, .metadata = "{\"first\":2}" },
+        };
+        const post_one = [_]graph_mod.Edge{
+            .{ .source = "post:1", .target = "tag", .edge_type = "HAS_TAG", .weight = 0.5, .created_at = 3, .updated_at = 4, .metadata = "{\"second\":1}" },
+        };
+        const post_two = [_]graph_mod.Edge{
+            .{ .source = "post:2", .target = "other", .edge_type = "HAS_TAG", .weight = 1, .created_at = 3, .updated_at = 4, .metadata = "" },
+            .{ .source = "post:2", .target = "tag", .edge_type = "HAS_TAG", .weight = 0.8, .created_at = 3, .updated_at = 4, .metadata = "{\"second\":2}" },
+        };
+
+        pub fn getEdges(_: @This(), _: Allocator, _: ?[]const u8, key: []const u8, _: []const []const u8, _: graph_mod.EdgeDirection) ![]graph_mod.Edge {
+            if (std.mem.eql(u8, key, "forum")) return @constCast(forward[0..]);
+            if (std.mem.eql(u8, key, "post:1")) return @constCast(post_one[0..]);
+            if (std.mem.eql(u8, key, "post:2")) return @constCast(post_two[0..]);
+            return @constCast((&[_]graph_mod.Edge{})[0..]);
+        }
+
+        pub fn freeEdges(_: @This(), _: Allocator, _: []graph_mod.Edge) void {}
+    };
+    const ExactReader = struct {
+        pub fn getEdges(_: @This(), alloc: Allocator, table: ?[]const u8, key: []const u8, types: []const []const u8, direction: graph_mod.EdgeDirection) ![]graph_mod.Edge {
+            return (GenericReader{}).getEdges(alloc, table, key, types, direction);
+        }
+
+        pub fn freeEdges(_: @This(), _: Allocator, _: []graph_mod.Edge) void {}
+
+        pub fn probeEdges(_: @This(), alloc: Allocator, _: ?[]const u8, probes: []const graph_mod.EdgeProbe) ![]?graph_mod.Edge {
+            const results = try alloc.alloc(?graph_mod.Edge, probes.len);
+            @memset(results, null);
+            for (probes, 0..) |probe, i| {
+                if (std.mem.eql(u8, probe.source, "post:1") and std.mem.eql(u8, probe.target, "tag")) {
+                    results[i] = GenericReader.post_one[0];
+                } else if (std.mem.eql(u8, probe.source, "post:2") and std.mem.eql(u8, probe.target, "tag")) {
+                    results[i] = GenericReader.post_two[1];
+                }
+            }
+            return results;
+        }
+
+        pub fn freeProbedEdges(_: @This(), alloc: Allocator, edges: []?graph_mod.Edge) void {
+            alloc.free(edges);
+        }
+    };
+
+    const pattern = [_]PatternStep{
+        .{ .alias = "forum" },
+        .{ .alias = "post", .edge = .{ .types = &.{"CONTAINER_OF"} } },
+        .{ .alias = "tag", .edge = .{ .types = &.{"HAS_TAG"}, .min_weight = 0.6 } },
+    };
+    const returned_aliases = [_][]const u8{ "post", "tag" };
+    var exact_stats = MatchStats{};
+    const exact = try matchPatternWithEdgeReader(std.testing.allocator, ExactReader{}, &.{"forum"}, &pattern, .{
+        .target_nodes = &.{.{ .table = null, .key = "tag" }},
+        .target_required = true,
+        .return_aliases = &returned_aliases,
+        .include_paths = true,
+        .stats = &exact_stats,
+    });
+    defer freeMatches(std.testing.allocator, exact);
+    var generic_stats = MatchStats{};
+    const generic = try matchPatternWithEdgeReader(std.testing.allocator, GenericReader{}, &.{"forum"}, &pattern, .{
+        .target_nodes = &.{.{ .table = null, .key = "tag" }},
+        .target_required = true,
+        .return_aliases = &returned_aliases,
+        .include_paths = true,
+        .stats = &generic_stats,
+    });
+    defer freeMatches(std.testing.allocator, generic);
+
+    try std.testing.expectEqual(MatchPlan.exact_two_edge_probe, exact_stats.plan);
+    try std.testing.expectEqual(MatchPlan.generic_expand, generic_stats.plan);
+    try std.testing.expectEqual(generic.len, exact.len);
+    try std.testing.expectEqual(@as(usize, 1), exact.len);
+    try std.testing.expectEqual(generic[0].bindings.len, exact[0].bindings.len);
+    for (generic[0].bindings, exact[0].bindings) |expected, actual| {
+        try std.testing.expectEqualStrings(expected.alias, actual.alias);
+        try std.testing.expectEqualStrings(expected.key, actual.key);
+        try std.testing.expectEqual(expected.depth, actual.depth);
+    }
+    try std.testing.expectEqual(generic[0].path.len, exact[0].path.len);
+    for (generic[0].path, exact[0].path) |expected, actual| {
+        try std.testing.expectEqualStrings(expected.source, actual.source);
+        try std.testing.expectEqualStrings(expected.target, actual.target);
+        try std.testing.expectEqualStrings(expected.edge_type, actual.edge_type);
+        try std.testing.expectEqual(expected.weight, actual.weight);
+        try std.testing.expectEqualStrings(expected.metadata, actual.metadata);
+    }
+}
+
+test "exact two-edge probe honors incoming final direction" {
+    const Reader = struct {
+        const first = [_]graph_mod.Edge{.{
+            .source = "start",
+            .target = "middle",
+            .edge_type = "FIRST",
+            .weight = 1,
+            .created_at = 0,
+            .updated_at = 0,
+            .metadata = "",
+        }};
+        const second = graph_mod.Edge{
+            .source = "target",
+            .target = "middle",
+            .edge_type = "SECOND",
+            .weight = 1,
+            .created_at = 0,
+            .updated_at = 0,
+            .metadata = "",
+        };
+
+        pub fn getEdges(_: @This(), _: Allocator, _: ?[]const u8, key: []const u8, _: []const []const u8, direction: graph_mod.EdgeDirection) ![]graph_mod.Edge {
+            try std.testing.expectEqualStrings("start", key);
+            try std.testing.expectEqual(graph_mod.EdgeDirection.out, direction);
+            return @constCast(first[0..]);
+        }
+
+        pub fn freeEdges(_: @This(), _: Allocator, _: []graph_mod.Edge) void {}
+
+        pub fn probeEdges(_: @This(), alloc: Allocator, _: ?[]const u8, probes: []const graph_mod.EdgeProbe) ![]?graph_mod.Edge {
+            try std.testing.expectEqual(@as(usize, 1), probes.len);
+            try std.testing.expectEqualStrings("target", probes[0].source);
+            try std.testing.expectEqualStrings("middle", probes[0].target);
+            try std.testing.expectEqualStrings("SECOND", probes[0].edge_type);
+            const result = try alloc.alloc(?graph_mod.Edge, 1);
+            result[0] = second;
+            return result;
+        }
+
+        pub fn freeProbedEdges(_: @This(), alloc: Allocator, edges: []?graph_mod.Edge) void {
+            alloc.free(edges);
+        }
+    };
+
+    const matches = try matchPatternWithEdgeReader(std.testing.allocator, Reader{}, &.{"start"}, &.{
+        .{ .alias = "start" },
+        .{ .alias = "middle", .edge = .{ .types = &.{"FIRST"} } },
+        .{ .alias = "target", .edge = .{ .types = &.{"SECOND"}, .direction = .in } },
+    }, .{
+        .target_nodes = &.{.{ .table = null, .key = "target" }},
+        .target_required = true,
+        .include_paths = false,
+    });
+    defer freeMatches(std.testing.allocator, matches);
+    try std.testing.expectEqual(@as(usize, 1), matches.len);
+    try std.testing.expectEqualStrings("target", matches[0].bindings[2].key);
+}
+
+test "exact endpoint constrains the final pattern step before limiting" {
+    const Reader = struct {
+        const edges = [_]graph_mod.Edge{
+            .{ .source = "a", .target = "wrong", .edge_type = "link", .weight = 1, .created_at = 0, .updated_at = 0, .metadata = "" },
+            .{ .source = "a", .target = "wanted", .edge_type = "link", .weight = 1, .created_at = 0, .updated_at = 0, .metadata = "" },
+        };
+
+        pub fn getEdges(_: @This(), _: Allocator, _: ?[]const u8, _: []const u8, types: []const []const u8, _: graph_mod.EdgeDirection) ![]graph_mod.Edge {
+            try std.testing.expectEqualStrings("link", types[0]);
+            return @constCast(edges[0..]);
+        }
+
+        pub fn freeEdges(_: @This(), _: Allocator, _: []graph_mod.Edge) void {}
+    };
+
+    const matches = try matchPatternWithEdgeReader(
+        std.testing.allocator,
+        Reader{},
+        &.{"a"},
+        &.{
+            .{ .alias = "source" },
+            .{ .alias = "target", .edge = .{ .types = &.{"link"} } },
+        },
+        .{ .max_results = 1, .target_nodes = &.{.{ .table = null, .key = "wanted" }}, .target_required = true, .include_paths = false },
+    );
+    defer freeMatches(std.testing.allocator, matches);
+    try std.testing.expectEqual(@as(usize, 1), matches.len);
+    try std.testing.expectEqualStrings("wanted", matches[0].bindings[1].key);
+    try std.testing.expectEqual(@as(usize, 0), matches[0].path.len);
+}
+
 test "pattern matching rejects unbounded hops and exploration" {
     const Reader = struct {
         const edges = [_]graph_mod.Edge{
@@ -891,7 +1476,7 @@ test "pattern matching rejects unbounded hops and exploration" {
             .{ .source = "A", .target = "C", .edge_type = "e", .weight = 1, .created_at = 0, .updated_at = 0, .metadata = "" },
         };
 
-        pub fn getEdges(_: @This(), _: Allocator, _: ?[]const u8, _: []const u8, _: graph_mod.EdgeDirection) ![]graph_mod.Edge {
+        pub fn getEdges(_: @This(), _: Allocator, _: ?[]const u8, _: []const u8, _: []const []const u8, _: graph_mod.EdgeDirection) ![]graph_mod.Edge {
             return @constCast(edges[0..]);
         }
 
@@ -938,7 +1523,7 @@ test "pattern matching keeps equal keys from distinct tables" {
             },
         };
 
-        pub fn getEdges(_: @This(), _: Allocator, _: ?[]const u8, _: []const u8, _: graph_mod.EdgeDirection) ![]graph_mod.Edge {
+        pub fn getEdges(_: @This(), _: Allocator, _: ?[]const u8, _: []const u8, _: []const []const u8, _: graph_mod.EdgeDirection) ![]graph_mod.Edge {
             return @constCast(edges[0..]);
         }
 
@@ -973,6 +1558,83 @@ test "pattern matching keeps equal keys from distinct tables" {
     try std.testing.expectEqual(@as(usize, 1), external_count);
 }
 
+test "exact pattern targets preserve table identity" {
+    const Reader = struct {
+        const edges = [_]graph_mod.Edge{
+            .{ .source = "A", .target = "shared", .edge_type = "local", .weight = 1, .created_at = 0, .updated_at = 0, .metadata = "" },
+            .{ .source = "A", .target = "shared", .edge_type = "external", .weight = 1, .created_at = 0, .updated_at = 0, .metadata = "{\"target_table\":\"entities\"}" },
+        };
+
+        pub fn getEdges(_: @This(), _: Allocator, _: ?[]const u8, _: []const u8, _: []const []const u8, _: graph_mod.EdgeDirection) ![]graph_mod.Edge {
+            return @constCast(edges[0..]);
+        }
+
+        pub fn freeEdges(_: @This(), _: Allocator, _: []graph_mod.Edge) void {}
+    };
+    const matches = try matchPatternWithEdgeReader(
+        std.testing.allocator,
+        Reader{},
+        &.{"A"},
+        &.{
+            .{ .alias = "source" },
+            .{ .alias = "target" },
+        },
+        .{
+            .max_results = 10,
+            .target_required = true,
+            .target_nodes = &.{.{ .table = "entities", .key = "shared" }},
+        },
+    );
+    defer freeMatches(std.testing.allocator, matches);
+
+    try std.testing.expectEqual(@as(usize, 1), matches.len);
+    try std.testing.expectEqualStrings("entities", matches[0].bindings[1].table.?);
+}
+
+test "inapplicable exact plan does not consume generic fallback budget" {
+    const Reader = struct {
+        const start_edges = [_]graph_mod.Edge{
+            .{ .source = "A", .target = "B", .edge_type = "first", .weight = 1, .created_at = 0, .updated_at = 0, .metadata = "" },
+            .{ .source = "A", .target = "X", .edge_type = "first", .weight = 1, .created_at = 0, .updated_at = 0, .metadata = "{\"target_table\":\"entities\"}" },
+        };
+        const middle_edges = [_]graph_mod.Edge{
+            .{ .source = "B", .target = "C", .edge_type = "second", .weight = 1, .created_at = 0, .updated_at = 0, .metadata = "" },
+        };
+
+        pub fn getEdges(_: @This(), _: Allocator, table: ?[]const u8, key: []const u8, _: []const []const u8, _: graph_mod.EdgeDirection) ![]graph_mod.Edge {
+            if (std.mem.eql(u8, key, "A")) return @constCast(start_edges[0..]);
+            if (table == null and std.mem.eql(u8, key, "B")) return @constCast(middle_edges[0..]);
+            return @constCast((&[_]graph_mod.Edge{})[0..]);
+        }
+
+        pub fn freeEdges(_: @This(), _: Allocator, _: []graph_mod.Edge) void {}
+
+        pub fn probeEdges(_: @This(), _: Allocator, _: ?[]const u8, _: []const graph_mod.EdgeProbe) ![]?graph_mod.Edge {
+            return error.TestUnexpectedResult;
+        }
+
+        pub fn freeProbedEdges(_: @This(), _: Allocator, _: []?graph_mod.Edge) void {}
+    };
+    const matches = try matchPatternWithEdgeReader(
+        std.testing.allocator,
+        Reader{},
+        &.{"A"},
+        &.{
+            .{ .alias = "a" },
+            .{ .alias = "b", .edge = .{ .types = &.{"first"} } },
+            .{ .alias = "c", .edge = .{ .types = &.{"second"} } },
+        },
+        .{
+            .target_required = true,
+            .target_nodes = &.{.{ .table = null, .key = "C" }},
+            .max_explored_nodes = 3,
+            .max_explored_edges = 3,
+        },
+    );
+    defer freeMatches(std.testing.allocator, matches);
+    try std.testing.expectEqual(@as(usize, 1), matches.len);
+}
+
 test "pattern matching routes later hops through the bound table" {
     const Reader = struct {
         const source_edges = [_]graph_mod.Edge{.{
@@ -999,6 +1661,7 @@ test "pattern matching routes later hops through the bound table" {
             _: Allocator,
             table: ?[]const u8,
             key: []const u8,
+            _: []const []const u8,
             _: graph_mod.EdgeDirection,
         ) ![]graph_mod.Edge {
             if (std.mem.eql(u8, key, "A")) {
@@ -1050,6 +1713,7 @@ test "pattern matching preserves a table-scoped start reference" {
             _: Allocator,
             table: ?[]const u8,
             key: []const u8,
+            _: []const []const u8,
             _: graph_mod.EdgeDirection,
         ) ![]graph_mod.Edge {
             try std.testing.expectEqualStrings("entities", table.?);

--- a/zig/pkg/antfly/src/graph/pattern.zig
+++ b/zig/pkg/antfly/src/graph/pattern.zig
@@ -618,6 +618,10 @@ fn matchExactTwoEdgePattern(
         if (probed_edges.len != probes.len) return error.InvalidGraphEdgeProbeResult;
 
         for (batch_candidates, probed_edges) |candidate, maybe_backward_edge| {
+            // Generic expansion never traverses a self-loop. Keep the
+            // candidate in the deterministic first-hop window, but do not
+            // admit an exact second edge back to the same middle node.
+            if (std.mem.eql(u8, candidate.middle_key, target_key)) continue;
             const backward_edge = maybe_backward_edge orelse continue;
             // A physical edge whose metadata changes node-table identity cannot
             // use this table-local plan. Release already-built results before
@@ -1436,6 +1440,63 @@ test "exact two-edge probe honors incoming final direction" {
     defer freeMatches(std.testing.allocator, matches);
     try std.testing.expectEqual(@as(usize, 1), matches.len);
     try std.testing.expectEqualStrings("target", matches[0].bindings[2].key);
+}
+
+test "exact two-edge probe excludes final self loops like generic expansion" {
+    const Reader = struct {
+        const first = [_]graph_mod.Edge{.{
+            .source = "start",
+            .target = "middle",
+            .edge_type = "FIRST",
+            .weight = 1,
+            .created_at = 0,
+            .updated_at = 0,
+            .metadata = "",
+        }};
+        const self_loop = graph_mod.Edge{
+            .source = "middle",
+            .target = "middle",
+            .edge_type = "SECOND",
+            .weight = 1,
+            .created_at = 0,
+            .updated_at = 0,
+            .metadata = "",
+        };
+
+        pub fn getEdges(_: @This(), _: Allocator, _: ?[]const u8, key: []const u8, _: []const []const u8, _: graph_mod.EdgeDirection) ![]graph_mod.Edge {
+            try std.testing.expectEqualStrings("start", key);
+            return @constCast(first[0..]);
+        }
+
+        pub fn freeEdges(_: @This(), _: Allocator, _: []graph_mod.Edge) void {}
+
+        pub fn probeEdges(_: @This(), alloc: Allocator, _: ?[]const u8, probes: []const graph_mod.EdgeProbe) ![]?graph_mod.Edge {
+            try std.testing.expectEqual(@as(usize, 1), probes.len);
+            const result = try alloc.alloc(?graph_mod.Edge, 1);
+            result[0] = self_loop;
+            return result;
+        }
+
+        pub fn freeProbedEdges(_: @This(), alloc: Allocator, edges: []?graph_mod.Edge) void {
+            alloc.free(edges);
+        }
+    };
+
+    var stats = MatchStats{};
+    const matches = try matchPatternWithEdgeReader(std.testing.allocator, Reader{}, &.{"start"}, &.{
+        .{ .alias = "start" },
+        .{ .alias = "middle", .edge = .{ .types = &.{"FIRST"} } },
+        .{ .alias = "target", .edge = .{ .types = &.{"SECOND"} } },
+    }, .{
+        .target_nodes = &.{.{ .table = null, .key = "middle" }},
+        .target_required = true,
+        .include_paths = false,
+        .stats = &stats,
+    });
+    defer freeMatches(std.testing.allocator, matches);
+
+    try std.testing.expectEqual(MatchPlan.exact_two_edge_probe, stats.plan);
+    try std.testing.expectEqual(@as(usize, 0), matches.len);
 }
 
 test "exact endpoint constrains the final pattern step before limiting" {

--- a/zig/pkg/antfly/src/openapi/generated/antfly_client_openapi/types.zig
+++ b/zig/pkg/antfly/src/openapi/generated/antfly_client_openapi/types.zig
@@ -3847,7 +3847,7 @@ pub const GraphQuery = struct {
     index_name: []const u8,
     /// Starting node(s) for the query
     start_nodes: ?GraphNodeSelector = null,
-    /// Target nodes (for pathfinding only)
+    /// Exact target nodes for pathfinding or the final binding of a pattern query. When a pattern endpoint is known, prefer this selector over an exact node_filter.filter_prefix so Antfly can use an exact edge-probe plan.
     target_nodes: ?GraphNodeSelector = null,
     /// Traversal/pathfinding parameters
     params: ?GraphQueryParams = null,

--- a/zig/pkg/antfly/src/openapi/generated/antfly_indexes_openapi/types.zig
+++ b/zig/pkg/antfly/src/openapi/generated/antfly_indexes_openapi/types.zig
@@ -910,7 +910,7 @@ pub const GraphQuery = struct {
     index_name: []const u8,
     /// Starting node(s) for the query
     start_nodes: ?GraphNodeSelector = null,
-    /// Target nodes (for pathfinding only)
+    /// Exact target nodes for pathfinding or the final binding of a pattern query. When a pattern endpoint is known, prefer this selector over an exact node_filter.filter_prefix so Antfly can use an exact edge-probe plan.
     target_nodes: ?GraphNodeSelector = null,
     /// Traversal/pathfinding parameters
     params: ?GraphQueryParams = null,

--- a/zig/pkg/antfly/src/serverless/api/http_handler.zig
+++ b/zig/pkg/antfly/src/serverless/api/http_handler.zig
@@ -38,6 +38,7 @@ const db_query_graph = @import("../../storage/db/query/graph_exec.zig");
 const distributed_stats_mod = @import("../../search/distributed_stats.zig");
 const graph_mod = @import("../../graph/graph.zig");
 const graph_pattern_mod = @import("../../graph/pattern.zig");
+const graph_node_identity = @import("../../graph/node_identity.zig");
 const graph_paths = @import("../../graph/paths.zig");
 const graph_query_mod = @import("../../graph/query.zig");
 const http_routes = @import("http_routes.zig");
@@ -3297,6 +3298,16 @@ pub const HttpHandler = struct {
         defer freeOwnedKeySlice(self.alloc, start_keys);
         const start_key_refs = try castOwnedKeysToConst(self.alloc, start_keys);
         defer self.alloc.free(start_key_refs);
+        const target_keys = if (named_query.query.target_nodes) |selector|
+            try public_graph_query.resolveGraphSelectorAlloc(self.alloc, selector, available_sets)
+        else
+            try self.alloc.alloc([]u8, 0);
+        defer freeOwnedKeySlice(self.alloc, target_keys);
+        const target_key_refs = try castOwnedKeysToConst(self.alloc, target_keys);
+        defer self.alloc.free(target_key_refs);
+        const target_nodes = try self.alloc.alloc(graph_node_identity.Ref, target_key_refs.len);
+        defer self.alloc.free(target_nodes);
+        for (target_key_refs, 0..) |key, i| target_nodes[i] = .{ .table = null, .key = key };
 
         const need_docs = named_query.query.include_documents or patternRequiresDocumentFilter(named_query.query.pattern);
         const docs: []const query_materializer.Document = if (need_docs) try self.allocPublishedDocumentsAlloc(session) else &.{};
@@ -3317,15 +3328,18 @@ pub const HttpHandler = struct {
                 alloc: Allocator,
                 table: ?[]const u8,
                 key: []const u8,
+                edge_types: []const []const u8,
                 direction: graph_mod.EdgeDirection,
             ) ![]graph_mod.Edge {
                 // Serverless snapshots contain one table-local graph segment.
                 if (table != null) return try alloc.alloc(graph_mod.Edge, 0);
                 const adjacency = findGraphSegmentAdjacency(reader.segment.adjacencies, key) orelse return try alloc.alloc(graph_mod.Edge, 0);
-                const edge_count: usize = switch (direction) {
-                    .out => adjacency.out_edges.len,
-                    .in => adjacency.in_edges.len,
-                    .both => adjacency.out_edges.len + adjacency.in_edges.len,
+                var edge_count: usize = 0;
+                if (direction == .out or direction == .both) for (adjacency.out_edges) |edge| {
+                    if (patternEdgeTypeRequested(edge.edge_type, edge_types)) edge_count += 1;
+                };
+                if (direction == .in or direction == .both) for (adjacency.in_edges) |edge| {
+                    if (patternEdgeTypeRequested(edge.edge_type, edge_types)) edge_count += 1;
                 };
                 const edges = try alloc.alloc(graph_mod.Edge, edge_count);
                 var initialized: usize = 0;
@@ -3336,10 +3350,17 @@ pub const HttpHandler = struct {
 
                 if (direction == .out or direction == .both) {
                     for (adjacency.out_edges) |edge| {
+                        if (!patternEdgeTypeRequested(edge.edge_type, edge_types)) continue;
+                        const source = try alloc.dupe(u8, adjacency.node_id);
+                        errdefer alloc.free(source);
+                        const target = try alloc.dupe(u8, edge.neighbor_id);
+                        errdefer alloc.free(target);
+                        const edge_type = try alloc.dupe(u8, edge.edge_type);
+                        errdefer alloc.free(edge_type);
                         edges[initialized] = .{
-                            .source = try alloc.dupe(u8, adjacency.node_id),
-                            .target = try alloc.dupe(u8, edge.neighbor_id),
-                            .edge_type = try alloc.dupe(u8, edge.edge_type),
+                            .source = source,
+                            .target = target,
+                            .edge_type = edge_type,
                             .weight = edge.weight,
                             .created_at = 0,
                             .updated_at = 0,
@@ -3350,10 +3371,17 @@ pub const HttpHandler = struct {
                 }
                 if (direction == .in or direction == .both) {
                     for (adjacency.in_edges) |edge| {
+                        if (!patternEdgeTypeRequested(edge.edge_type, edge_types)) continue;
+                        const source = try alloc.dupe(u8, edge.neighbor_id);
+                        errdefer alloc.free(source);
+                        const target = try alloc.dupe(u8, adjacency.node_id);
+                        errdefer alloc.free(target);
+                        const edge_type = try alloc.dupe(u8, edge.edge_type);
+                        errdefer alloc.free(edge_type);
                         edges[initialized] = .{
-                            .source = try alloc.dupe(u8, edge.neighbor_id),
-                            .target = try alloc.dupe(u8, adjacency.node_id),
-                            .edge_type = try alloc.dupe(u8, edge.edge_type),
+                            .source = source,
+                            .target = target,
+                            .edge_type = edge_type,
                             .weight = edge.weight,
                             .created_at = 0,
                             .updated_at = 0,
@@ -3368,6 +3396,50 @@ pub const HttpHandler = struct {
             pub fn freeEdges(_: @This(), alloc: Allocator, edges: []graph_mod.Edge) void {
                 for (edges) |edge| freeOwnedGraphEdge(alloc, edge);
                 if (edges.len > 0) alloc.free(edges);
+            }
+
+            pub fn probeEdges(
+                reader: @This(),
+                alloc: Allocator,
+                table: ?[]const u8,
+                probes: []const graph_mod.EdgeProbe,
+            ) ![]?graph_mod.Edge {
+                const results = try alloc.alloc(?graph_mod.Edge, probes.len);
+                @memset(results, null);
+                errdefer {
+                    for (results) |maybe_edge| if (maybe_edge) |edge| freeOwnedGraphEdge(alloc, edge);
+                    alloc.free(results);
+                }
+                if (table != null) return results;
+                for (probes, 0..) |probe, probe_index| {
+                    const adjacency = findGraphSegmentAdjacency(reader.segment.adjacencies, probe.source) orelse continue;
+                    for (adjacency.out_edges) |edge| {
+                        if (!std.mem.eql(u8, edge.neighbor_id, probe.target) or
+                            !std.mem.eql(u8, edge.edge_type, probe.edge_type)) continue;
+                        const source = try alloc.dupe(u8, probe.source);
+                        errdefer alloc.free(source);
+                        const target = try alloc.dupe(u8, probe.target);
+                        errdefer alloc.free(target);
+                        const edge_type = try alloc.dupe(u8, probe.edge_type);
+                        errdefer alloc.free(edge_type);
+                        results[probe_index] = .{
+                            .source = source,
+                            .target = target,
+                            .edge_type = edge_type,
+                            .weight = edge.weight,
+                            .created_at = 0,
+                            .updated_at = 0,
+                            .metadata = &.{},
+                        };
+                        break;
+                    }
+                }
+                return results;
+            }
+
+            pub fn freeProbedEdges(_: @This(), alloc: Allocator, edges: []?graph_mod.Edge) void {
+                for (edges) |maybe_edge| if (maybe_edge) |edge| freeOwnedGraphEdge(alloc, edge);
+                alloc.free(edges);
             }
         };
 
@@ -3386,6 +3458,9 @@ pub const HttpHandler = struct {
             .{
                 .max_results = named_query.query.params.max_results,
                 .return_aliases = named_query.query.return_aliases,
+                .target_nodes = target_nodes,
+                .target_required = named_query.query.target_nodes != null,
+                .include_paths = named_query.query.params.include_paths,
                 .evaluator = if (need_docs) .{
                     .ctx = @ptrCast(&filter_ctx),
                     .func = publishedPatternNodeFilterEvaluator,
@@ -4736,6 +4811,14 @@ const PatternDocumentFilterContext = struct {
 fn patternRequiresDocumentFilter(pattern: []const graph_pattern_mod.PatternStep) bool {
     for (pattern) |step| {
         if (step.node_filter.filter_query_json != null) return true;
+    }
+    return false;
+}
+
+fn patternEdgeTypeRequested(edge_type: []const u8, requested: []const []const u8) bool {
+    if (requested.len == 0) return true;
+    for (requested) |item| {
+        if (std.mem.eql(u8, edge_type, item)) return true;
     }
     return false;
 }
@@ -9583,7 +9666,7 @@ test "http handler serves published graph query endpoints" {
         .method = .post,
         .path = "/tables/docs/query",
         .body =
-        \\{"graph_searches":{"two_hop":{"type":"pattern","index_name":"graph_idx","start_nodes":{"keys":["doc-a"]},"pattern":[{"alias":"a"},{"alias":"b","node_filter":{"filter_query":{"term":"beta","field":"title"}},"edge":{"types":["cites"],"direction":"out","min_hops":1,"max_hops":1}},{"alias":"c","node_filter":{"filter_query":{"prefix":"ga","field":"title"}},"edge":{"types":["cites"],"direction":"out","min_hops":1,"max_hops":1}}],"include_documents":true,"fields":["title"]}},"limit":10}
+        \\{"graph_searches":{"two_hop":{"type":"pattern","index_name":"graph_idx","start_nodes":{"keys":["doc-a"]},"target_nodes":{"keys":["doc-c"]},"pattern":[{"alias":"a"},{"alias":"b","node_filter":{"filter_query":{"term":"beta","field":"title"}},"edge":{"types":["cites"],"direction":"out","min_hops":1,"max_hops":1}},{"alias":"c","node_filter":{"filter_query":{"prefix":"ga","field":"title"}},"edge":{"types":["cites"],"direction":"out","min_hops":1,"max_hops":1}}],"params":{"include_paths":false},"include_documents":true,"fields":["title"]}},"limit":10}
         ,
     });
     defer pattern.deinit(alloc);
@@ -9594,6 +9677,7 @@ test "http handler serves published graph query endpoints" {
     try std.testing.expectEqual(indexes_openapi.GraphQueryType.pattern, two_hop.type);
     try std.testing.expectEqual(@as(i64, 1), two_hop.total);
     try std.testing.expectEqual(@as(usize, 1), two_hop.matches.?.len);
+    try std.testing.expect(two_hop.matches.?[0].path == null);
     const bindings = two_hop.matches.?[0].bindings.?;
     try std.testing.expect(bindings.map.get("a") != null);
     try std.testing.expect(bindings.map.get("b") != null);

--- a/zig/pkg/antfly/src/storage/db/db.zig
+++ b/zig/pkg/antfly/src/storage/db/db.zig
@@ -132,6 +132,7 @@ const traversal_mod = @import("../../graph/traversal.zig");
 const paths_mod = @import("../../graph/paths.zig");
 const graph_query_mod = @import("../../graph/query.zig");
 const graph_pattern_mod = @import("../../graph/pattern.zig");
+const graph_node_identity = @import("../../graph/node_identity.zig");
 const mapper = @import("document_mapper.zig");
 const planning_adapter_mod = @import("planning_adapter.zig");
 const planning_bindings_mod = @import("planning_bindings.zig");
@@ -15225,6 +15226,9 @@ pub const DB = struct {
             pattern,
             max_results,
             return_aliases,
+            &.{},
+            false,
+            true,
             null,
         );
     }
@@ -15237,6 +15241,9 @@ pub const DB = struct {
         pattern: []const graph_pattern_mod.PatternStep,
         max_results: u32,
         return_aliases: []const []const u8,
+        target_nodes: []const graph_node_identity.Ref,
+        target_required: bool,
+        include_paths: bool,
         node_admission: ?NodeAdmission,
     ) ![]graph_pattern_mod.PatternMatch {
         if (start_keys.len == 0) return try alloc.alloc(graph_pattern_mod.PatternMatch, 0);
@@ -15245,6 +15252,9 @@ pub const DB = struct {
         return try self.core.graphMatchPattern(alloc, index_name, start_keys, pattern, .{
             .max_results = max_results,
             .return_aliases = return_aliases,
+            .target_nodes = target_nodes,
+            .target_required = target_required,
+            .include_paths = include_paths,
             .evaluator = .{
                 .ctx = &filter_ctx,
                 .func = patternNodeFilterEvaluator,
@@ -24740,15 +24750,20 @@ pub const DB = struct {
         alloc: Allocator,
         named: *const types.NamedGraphQuery,
         start_key_refs: []const []const u8,
+        target_nodes: []const graph_node_identity.Ref,
     ) anyerror![]graph_pattern_mod.PatternMatch {
         const self: *DB = @ptrCast(@alignCast(ctx orelse return error.InvalidArgument));
-        return try self.matchPattern(
+        return try self.matchPatternWithNodeAdmission(
             alloc,
             named.query.index_name,
             start_key_refs,
             named.query.pattern,
             named.query.params.max_results,
             named.query.return_aliases,
+            target_nodes,
+            named.query.target_nodes != null,
+            named.query.params.include_paths,
+            null,
         );
     }
 
@@ -24757,6 +24772,7 @@ pub const DB = struct {
         alloc: Allocator,
         named: *const types.NamedGraphQuery,
         start_key_refs: []const []const u8,
+        target_nodes: []const graph_node_identity.Ref,
     ) anyerror![]graph_pattern_mod.PatternMatch {
         const execution: *GraphPredicateExecutionContext = @ptrCast(@alignCast(ctx orelse return error.InvalidArgument));
         return try execution.db.matchPatternWithNodeAdmission(
@@ -24766,6 +24782,9 @@ pub const DB = struct {
             named.query.pattern,
             named.query.params.max_results,
             named.query.return_aliases,
+            target_nodes,
+            named.query.target_nodes != null,
+            named.query.params.include_paths,
             execution.admission.iface(),
         );
     }
@@ -61105,30 +61124,12 @@ test "db preflightSearchRequest validates live lane bindings" {
     try std.testing.expectError(error.InvalidArgument, db.preflightSearchRequest(alloc, .{
         .graph_queries = &.{
             .{
-                .name = "pattern_with_target",
-                .query = .{
-                    .query_type = .pattern,
-                    .index_name = "graph_v1",
-                    .start_nodes = .{ .keys = &.{"doc:a"} },
-                    .target_nodes = .{ .keys = &.{"doc:b"} },
-                    .pattern = &.{
-                        .{
-                            .alias = "src",
-                            .edge = .{},
-                        },
-                    },
-                },
-            },
-        },
-    }, 0));
-    try std.testing.expectError(error.InvalidArgument, db.preflightSearchRequest(alloc, .{
-        .graph_queries = &.{
-            .{
                 .name = "pattern_missing_type",
                 .query = .{
                     .query_type = .pattern,
                     .index_name = "graph_v1",
                     .start_nodes = .{ .keys = &.{"doc:a"} },
+                    .target_nodes = .{ .keys = &.{"doc:b"} },
                     .pattern = &.{
                         .{
                             .alias = "src",
@@ -61160,6 +61161,7 @@ test "db preflightSearchRequest validates live lane bindings" {
                     .query_type = .pattern,
                     .index_name = "graph_v1",
                     .start_nodes = .{ .keys = &.{"doc:a"} },
+                    .target_nodes = .{ .keys = &.{"doc:b"} },
                     .pattern = &.{
                         .{
                             .alias = "src",

--- a/zig/pkg/antfly/src/storage/db/planning_bindings.zig
+++ b/zig/pkg/antfly/src/storage/db/planning_bindings.zig
@@ -132,7 +132,6 @@ fn validateGraphQueryShape(graph_query: graph_query_mod.GraphQuery) !void {
         },
         .pattern => {
             if (graph_query.pattern.len == 0) return error.InvalidArgument;
-            if (graph_query.target_nodes != null) return error.InvalidArgument;
         },
         .traverse, .neighbors => {
             if (graph_query.pattern.len > 0) return error.InvalidArgument;

--- a/zig/pkg/antfly/src/storage/db/query/graph_exec.zig
+++ b/zig/pkg/antfly/src/storage/db/query/graph_exec.zig
@@ -4555,7 +4555,7 @@ test "buildPatternDocumentHits preserves resolved binding ordinals" {
             _: Allocator,
             _: *const types.NamedGraphQuery,
             _: []const []const u8,
-            _: []const []const u8,
+            _: []const graph_node_identity.Ref,
         ) anyerror![]graph_pattern_mod.PatternMatch {
             return error.TestUnexpectedResult;
         }

--- a/zig/pkg/antfly/src/storage/db/query/graph_exec.zig
+++ b/zig/pkg/antfly/src/storage/db/query/graph_exec.zig
@@ -17,6 +17,7 @@ const Allocator = std.mem.Allocator;
 const types = @import("../types.zig");
 const graph_query_mod = @import("../../../graph/query.zig");
 const graph_pattern_mod = @import("../../../graph/pattern.zig");
+const graph_node_identity = @import("../../../graph/node_identity.zig");
 const paths_mod = @import("../../../graph/paths.zig");
 const fusion_mod = @import("../../../search/fusion.zig");
 const geo_mod = @import("../../../search/geo.zig");
@@ -68,6 +69,7 @@ pub const PatternQueryExecutor = struct {
         alloc: Allocator,
         named: *const types.NamedGraphQuery,
         start_key_refs: []const []const u8,
+        target_nodes: []const graph_node_identity.Ref,
     ) anyerror![]graph_pattern_mod.PatternMatch,
     load_projected_document: *const fn (
         ctx: ?*anyopaque,
@@ -980,11 +982,30 @@ pub fn executeSinglePatternQueryWithSets(
     const start_key_refs = try castOwnedKeysToConst(alloc, start_keys);
     defer alloc.free(start_key_refs);
 
+    var target_keys = if (named.query.target_nodes) |target_nodes|
+        try resolveGraphSelectorFromSets(alloc, target_nodes, named_sets, .{
+            .ctx = executor.ctx,
+            .func = executor.resolve_doc_set_doc_ids,
+            .identity_read_generation = req.identity_read_generation,
+        })
+    else
+        try alloc.alloc([]u8, 0);
+    defer freeOwnedKeySlice(alloc, target_keys);
+    if (!executor.predicate_aware and searchRequestHasGraphPredicates(req)) {
+        target_keys = try filterOwnedGraphKeys(alloc, req, target_keys, executor.ctx, executor.filter_keys);
+    }
+    const target_key_refs = try castOwnedKeysToConst(alloc, target_keys);
+    defer alloc.free(target_key_refs);
+    const target_nodes = try alloc.alloc(graph_node_identity.Ref, target_key_refs.len);
+    defer alloc.free(target_nodes);
+    for (target_key_refs, 0..) |key, i| target_nodes[i] = .{ .table = null, .key = key };
+
     var raw_matches = try executor.match_pattern(
         try graphExecutionContext(executor.predicate_aware, executor.graph_ctx, executor.ctx),
         alloc,
         named,
         start_key_refs,
+        target_nodes,
     );
     defer graph_pattern_mod.freeMatches(alloc, raw_matches);
     if (!executor.predicate_aware and searchRequestHasGraphPredicates(req)) {
@@ -997,7 +1018,10 @@ pub fn executeSinglePatternQueryWithSets(
         if (matches.len > 0) alloc.free(matches);
     }
 
-    const hits = try buildPatternDocumentHits(alloc, named.query, req.identity_read_generation, matches, executor);
+    const hits = if (patternQueryNeedsHits(req, named))
+        try buildPatternDocumentHits(alloc, named.query, req.identity_read_generation, matches, executor)
+    else
+        try alloc.alloc(types.SearchHit, 0);
     errdefer {
         for (hits) |*hit| hit.deinit(alloc);
         if (hits.len > 0) alloc.free(hits);
@@ -1011,6 +1035,57 @@ pub fn executeSinglePatternQueryWithSets(
         .hits = hits,
         .total_hits = @intCast(raw_matches.len),
     };
+}
+
+fn patternQueryNeedsHits(req: types.SearchRequest, named: *const types.NamedGraphQuery) bool {
+    if (named.query.include_documents or req.expand_strategy != null) return true;
+    for (req.graph_queries) |candidate| {
+        if (selectorReferencesGraphResult(candidate.query.start_nodes, named.name)) return true;
+        if (candidate.query.target_nodes) |selector| {
+            if (selectorReferencesGraphResult(selector, named.name)) return true;
+        }
+    }
+    return false;
+}
+
+fn selectorReferencesGraphResult(selector: graph_query_mod.NodeSelector, name: []const u8) bool {
+    return switch (selector) {
+        .keys => false,
+        .result_ref => |result_ref| blk: {
+            if (std.mem.eql(u8, result_ref.ref, name)) break :blk true;
+            const prefix = "$graph_results.";
+            break :blk std.mem.startsWith(u8, result_ref.ref, prefix) and
+                std.mem.eql(u8, result_ref.ref[prefix.len..], name);
+        },
+    };
+}
+
+test "pattern hit shaping is lazy but preserves graph dependencies" {
+    const seed = types.NamedGraphQuery{
+        .name = "seed",
+        .query = .{
+            .query_type = .pattern,
+            .index_name = "graph",
+            .start_nodes = .{ .keys = &.{"doc:a"} },
+            .pattern = &.{ .{ .alias = "a" }, .{ .alias = "b" } },
+        },
+    };
+    try std.testing.expect(!patternQueryNeedsHits(.{ .graph_queries = &.{seed} }, &seed));
+
+    const dependent = types.NamedGraphQuery{
+        .name = "dependent",
+        .query = .{
+            .query_type = .neighbors,
+            .index_name = "graph",
+            .start_nodes = .{ .result_ref = .{ .ref = "$graph_results.seed" } },
+        },
+    };
+    try std.testing.expect(patternQueryNeedsHits(.{ .graph_queries = &.{ seed, dependent } }, &seed));
+
+    var with_documents = seed;
+    with_documents.query.include_documents = true;
+    try std.testing.expect(patternQueryNeedsHits(.{ .graph_queries = &.{with_documents} }, &with_documents));
+    try std.testing.expect(patternQueryNeedsHits(.{ .graph_queries = &.{seed}, .expand_strategy = .@"union" }, &seed));
 }
 
 pub fn executeSingleNonPatternQueryWithSets(
@@ -4479,6 +4554,7 @@ test "buildPatternDocumentHits preserves resolved binding ordinals" {
             _: ?*anyopaque,
             _: Allocator,
             _: *const types.NamedGraphQuery,
+            _: []const []const u8,
             _: []const []const u8,
         ) anyerror![]graph_pattern_mod.PatternMatch {
             return error.TestUnexpectedResult;


### PR DESCRIPTION
## Summary

- add public pattern target_nodes support and an exact two-hop execution plan for anchored graph queries
- batch typed edge probes so exact targets avoid per-candidate final adjacency scans and never materialize the target's reverse adjacency
- suppress unused paths, defer document shaping, stream adjacency reads, and bound coordinator result retention
- add plan telemetry plus a reproducible local latency, allocation, and RSS guardrail benchmark

## Correctness and fallback invariants

- exact planning is restricted to the safe table-local two-hop shape; unsupported filters, directions, admissions, and cross-table cases retain the generic matcher
- target identity remains table-aware across local, distributed, and serverless execution
- abandoned speculative plans use copied work budgets, while the selected plan preserves the existing candidate window and result budget
- include_paths false changes response shaping only and keeps bindings and edge filter/weight semantics intact
- the exact plan preserves generic self-loop exclusion semantics

## Local guardrail

Synthetic fanout 1000, 8 tags per post, target degree 10000, match every 10, 2 warmups, 5 samples:

- exact p95: 7.483 ms; generic p95: 766.551 ms
- exact query allocation peak p95: 226395 bytes; generic: 256775 bytes
- exact process RSS high-water delta: 606208 bytes; generic: 2703360 bytes

These numbers compare two Antfly plans in fresh local benchmark processes. They are not a Neo4j comparison and are not a publishable cross-engine service-memory result.

## Validation

- zig build root-test: 244 passed
- zig build lib-db-test: 698 passed, 6 skipped
- zig build serverless-test: 51 passed, 2 skipped
- focused exact-plan parity tests: 4 passed, 0 leaked
- zig build graph-pattern-bench-build
- exact and generic graph-pattern benchmark runs
- make zig-generated-check
- git diff --check

Coordinated benchmark adapter: antflydb/antfly-circus#47.
