### PR TITLE
perf(algebraic): reduce exact cardinality overhead

### DIFF
--- a/zig/pkg/antfly/src/storage/db/algebraic/index.zig
+++ b/zig/pkg/antfly/src/storage/db/algebraic/index.zig
@@ -4777,8 +4777,10 @@ pub const Index = struct {
             buckets.deinit(self.alloc);
         }
 
+        var constraint_set = try DocIdConstraintSet.init(self.alloc, constraint_ids);
+        defer constraint_set.deinit(self.alloc);
         for (entries) |entry| {
-            if (!cardinalityDocMatchesConstraints(constraint_ids, entry.doc_id)) continue;
+            if (!constraint_set.matches(entry.doc_id)) continue;
             if (live_txn) |*txn| {
                 if (!try self.docVisibleAtGenerationTxn(txn, entry.doc_id, generation)) continue;
             }
@@ -4960,6 +4962,8 @@ pub const Index = struct {
         if (kind == .date and !allow_datetime_string) return null;
         const prefix = try self.keyAlloc(&.{"pathfact"});
         defer self.alloc.free(prefix);
+        var constraint_set = try DocIdConstraintSet.init(self.alloc, constraint_ids);
+        defer constraint_set.deinit(self.alloc);
         var cursor = try txn.openCursor();
         defer cursor.close();
         var entry_opt = try cursor.seekAtOrAfter(prefix);
@@ -4967,7 +4971,7 @@ pub const Index = struct {
             if (!std.mem.startsWith(u8, entry.key, prefix)) break;
             const doc_component = token.componentAt(entry.key, prefix.len) catch continue;
             if (doc_component.next != entry.key.len) continue;
-            if (!cardinalityDocMatchesConstraints(constraint_ids, doc_component.payload)) continue;
+            if (!constraint_set.matches(doc_component.payload)) continue;
             if (generation != null and !try self.docVisibleAtGenerationTxn(&txn, doc_component.payload, generation)) continue;
             var projection = pathfact_mod.decodeProjectionAlloc(self.alloc, entry.value) catch |err| switch (err) {
                 error.InvalidPathFactList => continue,
@@ -5075,8 +5079,10 @@ pub const Index = struct {
         if (generation != null) live_txn = try store.beginReadTxn();
         defer if (live_txn) |*txn| txn.abort();
 
+        var constraint_set = try DocIdConstraintSet.init(self.alloc, constraint_ids);
+        defer constraint_set.deinit(self.alloc);
         for (bucket_entries) |entry| {
-            if (!cardinalityDocMatchesConstraints(constraint_ids, entry.doc_id)) continue;
+            if (!constraint_set.matches(entry.doc_id)) continue;
             if (live_txn) |*txn| {
                 if (!try self.docVisibleAtGenerationTxn(txn, entry.doc_id, generation)) continue;
             }
@@ -5154,6 +5160,8 @@ pub const Index = struct {
         defer self.alloc.free(prefix);
         var txn = try store.beginReadTxn();
         defer txn.abort();
+        var constraint_set = try DocIdConstraintSet.init(self.alloc, constraint_ids);
+        defer constraint_set.deinit(self.alloc);
         var cursor = try txn.openCursor();
         defer cursor.close();
         var entry_opt = try cursor.seekAtOrAfter(prefix);
@@ -5161,7 +5169,7 @@ pub const Index = struct {
             if (!std.mem.startsWith(u8, entry.key, prefix)) break;
             const doc_component = token.componentAt(entry.key, prefix.len) catch continue;
             if (doc_component.next != entry.key.len) continue;
-            if (!cardinalityDocMatchesConstraints(constraint_ids, doc_component.payload)) continue;
+            if (!constraint_set.matches(doc_component.payload)) continue;
             if (generation != null and !try self.docVisibleAtGenerationTxn(&txn, doc_component.payload, generation)) continue;
             var projection = pathfact_mod.decodeProjectionAlloc(self.alloc, entry.value) catch |err| switch (err) {
                 error.InvalidPathFactList => continue,
@@ -5354,13 +5362,15 @@ pub const Index = struct {
         defer txn.abort();
         var cursor = try txn.openCursor();
         defer cursor.close();
+        var constraint_set = try DocIdConstraintSet.init(self.alloc, constraint_ids);
+        defer constraint_set.deinit(self.alloc);
         var entry_opt = try cursor.seekAtOrAfter(prefix);
         while (entry_opt) |entry| : (entry_opt = try cursor.next()) {
             if (!std.mem.startsWith(u8, entry.key, prefix)) break;
             const scalar_component = token.componentAt(entry.key, prefix.len) catch continue;
             const doc_component = token.componentAt(entry.key, scalar_component.next) catch continue;
             if (doc_component.next != entry.key.len) continue;
-            if (!cardinalityDocMatchesConstraints(constraint_ids, doc_component.payload)) continue;
+            if (!constraint_set.matches(doc_component.payload)) continue;
             const gop = try values.getOrPut(self.alloc, scalar_component.payload);
             if (!gop.found_existing) gop.key_ptr.* = try self.alloc.dupe(u8, scalar_component.payload);
         }
@@ -5380,13 +5390,15 @@ pub const Index = struct {
         defer txn.abort();
         var cursor = try txn.openCursor();
         defer cursor.close();
+        var constraint_set = try DocIdConstraintSet.init(self.alloc, constraint_ids);
+        defer constraint_set.deinit(self.alloc);
         var entry_opt = try cursor.seekAtOrAfter(prefix);
         while (entry_opt) |entry| : (entry_opt = try cursor.next()) {
             if (!std.mem.startsWith(u8, entry.key, prefix)) break;
             const scalar_component = token.componentAt(entry.key, prefix.len) catch continue;
             const doc_component = token.componentAt(entry.key, scalar_component.next) catch continue;
             if (doc_component.next != entry.key.len) continue;
-            if (!cardinalityDocMatchesConstraints(constraint_ids, doc_component.payload)) continue;
+            if (!constraint_set.matches(doc_component.payload)) continue;
             if (!try self.docVisibleAtGenerationTxn(&txn, doc_component.payload, generation)) continue;
             const gop = try values.getOrPut(self.alloc, scalar_component.payload);
             if (!gop.found_existing) gop.key_ptr.* = try self.alloc.dupe(u8, scalar_component.payload);
@@ -5439,6 +5451,8 @@ pub const Index = struct {
         defer txn.abort();
         var cursor = try txn.openCursor();
         defer cursor.close();
+        var constraint_set = try DocIdConstraintSet.init(self.alloc, constraint_ids);
+        defer constraint_set.deinit(self.alloc);
         var entry_opt = try cursor.seekAtOrAfter(prefix);
         while (entry_opt) |entry| : (entry_opt = try cursor.next()) {
             if (!std.mem.startsWith(u8, entry.key, prefix)) break;
@@ -5447,7 +5461,7 @@ pub const Index = struct {
             const value_component = token.componentAt(entry.key, kind_component.next) catch continue;
             const doc_component = token.componentAt(entry.key, value_component.next) catch continue;
             if (doc_component.next != entry.key.len) continue;
-            if (!cardinalityDocMatchesConstraints(constraint_ids, doc_component.payload)) continue;
+            if (!constraint_set.matches(doc_component.payload)) continue;
             const value_key = try token.canonicalTupleAlloc(self.alloc, &.{ kind_component.payload, value_component.payload });
             const gop = try values.getOrPut(self.alloc, value_key);
             if (gop.found_existing) {
@@ -5472,6 +5486,8 @@ pub const Index = struct {
         defer txn.abort();
         var cursor = try txn.openCursor();
         defer cursor.close();
+        var constraint_set = try DocIdConstraintSet.init(self.alloc, constraint_ids);
+        defer constraint_set.deinit(self.alloc);
         var entry_opt = try cursor.seekAtOrAfter(prefix);
         while (entry_opt) |entry| : (entry_opt = try cursor.next()) {
             if (!std.mem.startsWith(u8, entry.key, prefix)) break;
@@ -5480,7 +5496,7 @@ pub const Index = struct {
             const value_component = token.componentAt(entry.key, kind_component.next) catch continue;
             const doc_component = token.componentAt(entry.key, value_component.next) catch continue;
             if (doc_component.next != entry.key.len) continue;
-            if (!cardinalityDocMatchesConstraints(constraint_ids, doc_component.payload)) continue;
+            if (!constraint_set.matches(doc_component.payload)) continue;
             if (!try self.docVisibleAtGenerationTxn(&txn, doc_component.payload, generation)) continue;
             const value_key = try token.canonicalTupleAlloc(self.alloc, &.{ kind_component.payload, value_component.payload });
             const gop = try values.getOrPut(self.alloc, value_key);
@@ -5645,6 +5661,39 @@ pub const Index = struct {
         }
         return false;
     }
+
+    // Membership view over a doc-id constraint slice. The slice owns the keys;
+    // this set only borrows them, so it must not outlive `constraint_ids`.
+    //
+    // The cardinality scans below walk the full doc-fact/path-fact prefix for a
+    // field and test each entry against the active constraint set. When that
+    // set is a bucket's doc-id list (histogram/range children) or a constraint
+    // result set (root cardinality), a linear membership test makes the scan
+    // O(entries * constraints), which is quadratic in the document count. A hash
+    // set turns each test into O(1) and the scan back into a single linear pass.
+    const DocIdConstraintSet = struct {
+        set: std.StringHashMapUnmanaged(void) = .empty,
+        active: bool = false,
+
+        fn init(alloc: Allocator, constraint_ids: []const []const u8) !DocIdConstraintSet {
+            if (constraint_ids.len == 0) return .{};
+            var set = std.StringHashMapUnmanaged(void).empty;
+            errdefer set.deinit(alloc);
+            try set.ensureTotalCapacity(alloc, @intCast(constraint_ids.len));
+            for (constraint_ids) |id| set.putAssumeCapacity(id, {});
+            return .{ .set = set, .active = true };
+        }
+
+        fn deinit(self: *DocIdConstraintSet, alloc: Allocator) void {
+            self.set.deinit(alloc);
+            self.* = .{};
+        }
+
+        fn matches(self: *const DocIdConstraintSet, doc_id: []const u8) bool {
+            if (!self.active) return true;
+            return self.set.contains(doc_id);
+        }
+    };
 
     pub fn rawMetricForResolvedDocIdsAlloc(self: *Index, store: *docstore_mod.DocStore, op: algebra.Op, resolved: ResolvedMeasureField, doc_ids: []const []const u8) !?[]u8 {
         if (op == .count) {

--- a/zig/pkg/antfly/src/storage/db/algebraic/index.zig
+++ b/zig/pkg/antfly/src/storage/db/algebraic/index.zig
@@ -5860,14 +5860,6 @@ pub const Index = struct {
             std.mem.eql(u8, kind, "string");
     }
 
-    fn cardinalityDocMatchesConstraints(constraint_ids: []const []const u8, doc_id: []const u8) bool {
-        if (constraint_ids.len == 0) return true;
-        for (constraint_ids) |candidate| {
-            if (std.mem.eql(u8, candidate, doc_id)) return true;
-        }
-        return false;
-    }
-
     // Membership view over a doc-id constraint slice. The slice owns the keys;
     // this set only borrows them, so it must not outlive `constraint_ids`.
     //

--- a/zig/pkg/antfly/src/storage/db/algebraic/index.zig
+++ b/zig/pkg/antfly/src/storage/db/algebraic/index.zig
@@ -4666,6 +4666,9 @@ pub const Index = struct {
             partials.deinit(self.alloc);
         }
 
+        const child_indexes = (try self.buildChildCardinalityIndexesAlloc(store, child_requests)) orelse return null;
+        defer self.freeChildCardinalityIndexes(child_indexes);
+
         for (ranges) |range| {
             const filter_json = try self.rangeCardinalityFilterJsonAlloc(field_or_path, kind, range);
             defer self.alloc.free(filter_json);
@@ -4685,12 +4688,8 @@ pub const Index = struct {
             const axis = try rangeCardinalityAxisAlloc(self.alloc, kind, range);
             defer self.alloc.free(axis);
             try self.appendDistributedCountPartial(&partials, axis, aggregation_name, @intCast(bucket_ids.len));
-            for (child_requests) |child| {
-                const child_partials = (try self.scanDistributedCardinalityPartialsForDocIds(store, child.name, child.field, bucket_ids)) orelse return null;
-                defer distributed_mod.freePartials(self.alloc, child_partials);
-                for (child_partials) |partial| {
-                    try self.appendDistributedPartialForAxis(&partials, axis, partial.metric, partial.law_id, partial.value);
-                }
+            for (child_requests, child_indexes) |child, *child_index| {
+                try self.appendBucketChildCardinalityPartials(&partials, axis, .raw, child.name, child_index, bucket_ids);
             }
         }
 
@@ -4822,14 +4821,12 @@ pub const Index = struct {
             partials.deinit(self.alloc);
         }
 
+        const child_indexes = (try self.buildChildCardinalityIndexesAlloc(store, child_requests)) orelse return null;
+        defer self.freeChildCardinalityIndexes(child_indexes);
         for (buckets.items) |bucket| {
             try self.appendDistributedCountPartial(&partials, bucket.axis, aggregation_name, @intCast(bucket.doc_ids.items.len));
-            for (child_requests) |child| {
-                const child_partials = (try self.scanDistributedCardinalityPartialsForDocIds(store, child.name, child.field, bucket.doc_ids.items)) orelse return null;
-                defer distributed_mod.freePartials(self.alloc, child_partials);
-                for (child_partials) |partial| {
-                    try self.appendDistributedPartialForAxis(&partials, bucket.axis, partial.metric, partial.law_id, partial.value);
-                }
+            for (child_requests, child_indexes) |child, *child_index| {
+                try self.appendBucketChildCardinalityPartials(&partials, bucket.axis, .raw, child.name, child_index, bucket.doc_ids.items);
             }
         }
 
@@ -5015,14 +5012,12 @@ pub const Index = struct {
             }
             partials.deinit(self.alloc);
         }
+        const child_indexes = (try self.buildChildCardinalityIndexesAlloc(store, child_requests)) orelse return null;
+        defer self.freeChildCardinalityIndexes(child_indexes);
         for (buckets.items) |bucket| {
             try self.appendDistributedCountPartial(&partials, bucket.axis, aggregation_name, @intCast(bucket.doc_ids.items.len));
-            for (child_requests) |child| {
-                const child_partials = (try self.scanDistributedCardinalityPartialsForDocIds(store, child.name, child.field, bucket.doc_ids.items)) orelse return null;
-                defer distributed_mod.freePartials(self.alloc, child_partials);
-                for (child_partials) |partial| {
-                    try self.appendDistributedPartialForAxis(&partials, bucket.axis, partial.metric, partial.law_id, partial.value);
-                }
+            for (child_requests, child_indexes) |child, *child_index| {
+                try self.appendBucketChildCardinalityPartials(&partials, bucket.axis, .raw, child.name, child_index, bucket.doc_ids.items);
             }
         }
         return try partials.toOwnedSlice(self.alloc);
@@ -5106,14 +5101,12 @@ pub const Index = struct {
             partials.deinit(self.alloc);
         }
 
+        const child_indexes = (try self.buildChildCardinalityIndexesAlloc(store, child_requests)) orelse return null;
+        defer self.freeChildCardinalityIndexes(child_indexes);
         for (buckets.items) |bucket| {
             try self.appendDistributedCountPartial(&partials, bucket.axis, terms_aggregation_name, @intCast(bucket.doc_ids.items.len));
-            for (child_requests) |child| {
-                const child_partials = (try self.scanDistributedCardinalityPartialsForDocIds(store, child.name, child.field, bucket.doc_ids.items)) orelse return null;
-                defer distributed_mod.freePartials(self.alloc, child_partials);
-                for (child_partials) |partial| {
-                    try self.appendDistributedPartialForAxis(&partials, bucket.axis, partial.metric, partial.law_id, partial.value);
-                }
+            for (child_requests, child_indexes) |child, *child_index| {
+                try self.appendBucketChildCardinalityPartials(&partials, bucket.axis, .raw, child.name, child_index, bucket.doc_ids.items);
             }
         }
 
@@ -5202,20 +5195,184 @@ pub const Index = struct {
             }
             partials.deinit(self.alloc);
         }
+        const child_indexes = (try self.buildChildCardinalityIndexesAlloc(store, child_requests)) orelse return null;
+        defer self.freeChildCardinalityIndexes(child_indexes);
         for (buckets.items) |bucket| {
             const count_value = try algebra.encodeI64Alloc(self.alloc, @intCast(bucket.doc_ids.items.len));
             defer self.alloc.free(count_value);
             try self.appendDistributedPartialForCanonicalAxis(&partials, bucket.axis, terms_aggregation_name, .count, count_value);
-            for (child_requests) |child| {
-                const child_partials = (try self.scanDistributedCardinalityPartialsForDocIds(store, child.name, child.field, bucket.doc_ids.items)) orelse return null;
-                defer distributed_mod.freePartials(self.alloc, child_partials);
-                for (child_partials) |partial| {
-                    try self.appendDistributedPartialForCanonicalAxis(&partials, bucket.axis, partial.metric, partial.law_id, partial.value);
-                }
+            for (child_requests, child_indexes) |child, *child_index| {
+                try self.appendBucketChildCardinalityPartials(&partials, bucket.axis, .canonical, child.name, child_index, bucket.doc_ids.items);
             }
         }
 
         return try partials.toOwnedSlice(self.alloc);
+    }
+
+    // Per-document index of distinct cardinality value-keys for one child
+    // field, populated with a single cursor scan over that field. Bucketed
+    // cardinality (histogram / range / terms children) used to re-scan the
+    // entire child field once per bucket; with this index we scan once and look
+    // up each bucket's documents, turning O(buckets * field_entries) into
+    // O(field_entries + total_bucket_members).
+    const ChildCardinalityIndex = struct {
+        by_doc: std.StringHashMapUnmanaged(std.ArrayListUnmanaged([]u8)) = .empty,
+
+        fn deinit(self: *ChildCardinalityIndex, alloc: Allocator) void {
+            var it = self.by_doc.iterator();
+            while (it.next()) |entry| {
+                for (entry.value_ptr.items) |value_key| alloc.free(value_key);
+                entry.value_ptr.deinit(alloc);
+                alloc.free(entry.key_ptr.*);
+            }
+            self.by_doc.deinit(alloc);
+            self.* = .{};
+        }
+
+        fn add(self: *ChildCardinalityIndex, alloc: Allocator, doc_id: []const u8, value_key: []const u8) !void {
+            const gop = try self.by_doc.getOrPut(alloc, doc_id);
+            if (!gop.found_existing) {
+                errdefer _ = self.by_doc.remove(doc_id);
+                gop.key_ptr.* = try alloc.dupe(u8, doc_id);
+                gop.value_ptr.* = .empty;
+            }
+            for (gop.value_ptr.items) |existing| {
+                if (std.mem.eql(u8, existing, value_key)) return;
+            }
+            try gop.value_ptr.append(alloc, try alloc.dupe(u8, value_key));
+        }
+
+        fn valuesFor(self: *const ChildCardinalityIndex, doc_id: []const u8) []const []u8 {
+            const entry = self.by_doc.getPtr(doc_id) orelse return &.{};
+            return entry.items;
+        }
+    };
+
+    fn buildChildCardinalityIndexAlloc(
+        self: *Index,
+        store: *docstore_mod.DocStore,
+        field_or_path: []const u8,
+    ) !?ChildCardinalityIndex {
+        var index = ChildCardinalityIndex{};
+        errdefer index.deinit(self.alloc);
+        if (isExplicitJsonPointerPath(field_or_path)) {
+            try self.collectPathCardinalityValuesByDoc(store, field_or_path, &index);
+        } else {
+            const field = self.uniqueExistingFactField(field_or_path) orelse return null;
+            try self.collectDocFactCardinalityValuesByDoc(store, field, &index);
+        }
+        return index;
+    }
+
+    // Builds one ChildCardinalityIndex per child request. Returns null (so the
+    // caller falls back to a document scan) if any child field is unsupported,
+    // mirroring the per-bucket scanDistributedCardinalityPartialsForDocIds path.
+    fn buildChildCardinalityIndexesAlloc(
+        self: *Index,
+        store: *docstore_mod.DocStore,
+        child_requests: []const CardinalityChildRequest,
+    ) !?[]ChildCardinalityIndex {
+        const indexes = try self.alloc.alloc(ChildCardinalityIndex, child_requests.len);
+        var built: usize = 0;
+        errdefer {
+            for (indexes[0..built]) |*index| index.deinit(self.alloc);
+            self.alloc.free(indexes);
+        }
+        for (child_requests, 0..) |child, i| {
+            indexes[i] = (try self.buildChildCardinalityIndexAlloc(store, child.field)) orelse return null;
+            built = i + 1;
+        }
+        return indexes;
+    }
+
+    fn freeChildCardinalityIndexes(self: *Index, indexes: []ChildCardinalityIndex) void {
+        for (indexes) |*index| index.deinit(self.alloc);
+        self.alloc.free(indexes);
+    }
+
+    fn collectDocFactCardinalityValuesByDoc(
+        self: *Index,
+        store: *docstore_mod.DocStore,
+        field: ExistsFieldSpec,
+        index: *ChildCardinalityIndex,
+    ) !void {
+        const prefix = try self.docFactScalarFieldPrefixAlloc(field.role, field.field);
+        defer self.alloc.free(prefix);
+        var txn = try store.beginReadTxn();
+        defer txn.abort();
+        var cursor = try txn.openCursor();
+        defer cursor.close();
+        var entry_opt = try cursor.seekAtOrAfter(prefix);
+        while (entry_opt) |entry| : (entry_opt = try cursor.next()) {
+            if (!std.mem.startsWith(u8, entry.key, prefix)) break;
+            const scalar_component = token.componentAt(entry.key, prefix.len) catch continue;
+            const doc_component = token.componentAt(entry.key, scalar_component.next) catch continue;
+            if (doc_component.next != entry.key.len) continue;
+            try index.add(self.alloc, doc_component.payload, scalar_component.payload);
+        }
+    }
+
+    fn collectPathCardinalityValuesByDoc(
+        self: *Index,
+        store: *docstore_mod.DocStore,
+        path: []const u8,
+        index: *ChildCardinalityIndex,
+    ) !void {
+        const prefix = try self.pathLookupPathPrefixAlloc(path);
+        defer self.alloc.free(prefix);
+        var txn = try store.beginReadTxn();
+        defer txn.abort();
+        var cursor = try txn.openCursor();
+        defer cursor.close();
+        var entry_opt = try cursor.seekAtOrAfter(prefix);
+        while (entry_opt) |entry| : (entry_opt = try cursor.next()) {
+            if (!std.mem.startsWith(u8, entry.key, prefix)) break;
+            const kind_component = token.componentAt(entry.key, prefix.len) catch continue;
+            if (!pathLookupKindIsScalarValue(kind_component.payload)) continue;
+            const value_component = token.componentAt(entry.key, kind_component.next) catch continue;
+            const doc_component = token.componentAt(entry.key, value_component.next) catch continue;
+            if (doc_component.next != entry.key.len) continue;
+            const value_key = try token.canonicalTupleAlloc(self.alloc, &.{ kind_component.payload, value_component.payload });
+            defer self.alloc.free(value_key);
+            try index.add(self.alloc, doc_component.payload, value_key);
+        }
+    }
+
+    const BucketAxisKind = enum { raw, canonical };
+
+    // Emits the distinct-value cardinality partials for one bucket and child,
+    // reproducing scanDistributedCardinalityPartialsForDocIds + the parent's
+    // re-wrap of each child partial, but sourced from a prebuilt
+    // ChildCardinalityIndex instead of a fresh per-bucket field scan. The
+    // `axis_kind` selects whether the bucket axis still needs canonical-tuple
+    // wrapping (raw) or is already canonical (path-terms buckets).
+    fn appendBucketChildCardinalityPartials(
+        self: *Index,
+        partials: *std.ArrayListUnmanaged(distributed_mod.Partial),
+        axis: []const u8,
+        axis_kind: BucketAxisKind,
+        child_name: []const u8,
+        child_index: *const ChildCardinalityIndex,
+        bucket_doc_ids: []const []const u8,
+    ) !void {
+        var seen = std.StringHashMapUnmanaged(void).empty;
+        defer seen.deinit(self.alloc);
+        for (bucket_doc_ids) |doc_id| {
+            for (child_index.valuesFor(doc_id)) |value_key| {
+                const gop = try seen.getOrPut(self.alloc, value_key);
+                if (gop.found_existing) continue;
+                // `value_key` is owned by child_index, which outlives `seen`.
+                gop.key_ptr.* = value_key;
+                const metric = try token.canonicalTupleAlloc(self.alloc, &.{ "cardinality:v1", child_name, value_key });
+                defer self.alloc.free(metric);
+                const value = try algebra.encodeI64Alloc(self.alloc, 1);
+                defer self.alloc.free(value);
+                switch (axis_kind) {
+                    .raw => try self.appendDistributedPartialForAxis(partials, axis, metric, .count, value),
+                    .canonical => try self.appendDistributedPartialForCanonicalAxis(partials, axis, metric, .count, value),
+                }
+            }
+        }
     }
 
     pub fn scanDistributedCardinalityPartialsForDocIds(

--- a/zig/pkg/antfly/src/storage/db/algebraic/index.zig
+++ b/zig/pkg/antfly/src/storage/db/algebraic/index.zig
@@ -2376,14 +2376,41 @@ const SymbolCache = struct {
     }
 };
 
+// Running value for one group in a single-law fold. The additive group laws
+// (count/sum/sumsquares/avg) accumulate as native numbers and are formatted to
+// text exactly once in entriesAlloc, instead of round-tripping the running
+// total through decimal text on every contribution. Because encode/parse for
+// i64 and f64 ("{d}") round-trip exactly and contributions are applied in the
+// same order, the formatted result is byte-identical to the previous text
+// merge. The remaining laws (min/max, booleans, set/tuple, timestamps) keep the
+// text-merge path, where order/text identity matters.
+const FoldValue = union(enum) {
+    int: i64,
+    float: f64,
+    avg: algebra.AvgState,
+    text: ?[]u8,
+
+    fn initFor(law_id: law_mod.Id) FoldValue {
+        return switch (law_id) {
+            .count => .{ .int = 0 },
+            .sum, .sumsquares => .{ .float = 0 },
+            .avg => .{ .avg = .{} },
+            else => .{ .text = null },
+        };
+    }
+};
+
 const DerivedJoinFoldAccumulator = struct {
-    values: std.StringHashMapUnmanaged(?[]u8) = .empty,
+    values: std.StringHashMapUnmanaged(FoldValue) = .empty,
 
     fn deinit(self: *@This(), alloc: Allocator) void {
         var it = self.values.iterator();
         while (it.next()) |entry| {
             alloc.free(entry.key_ptr.*);
-            if (entry.value_ptr.*) |value| alloc.free(value);
+            switch (entry.value_ptr.*) {
+                .text => |value| if (value) |bytes| alloc.free(bytes),
+                else => {},
+            }
         }
         self.values.deinit(alloc);
         self.* = .{};
@@ -2403,18 +2430,34 @@ const DerivedJoinFoldAccumulator = struct {
         } else {
             errdefer _ = self.values.remove(group_key);
             gop.key_ptr.* = try alloc.dupe(u8, group_key);
-            gop.value_ptr.* = null;
+            gop.value_ptr.* = FoldValue.initFor(law_id);
         }
-        const next = try tensor_mod.mergeOneSlotValuesAlloc(alloc, law_id, gop.value_ptr.*, contribution);
-        if (gop.value_ptr.*) |old| alloc.free(old);
-        gop.value_ptr.* = next;
+        switch (gop.value_ptr.*) {
+            .int => |*running| running.* += try algebra.parseI64(contribution),
+            .float => |*running| running.* += try algebra.parseF64(contribution),
+            .avg => |*running| {
+                const delta = try algebra.parseAvg(contribution);
+                running.sum += delta.sum;
+                running.count += delta.count;
+            },
+            .text => |*running| {
+                const next = try tensor_mod.mergeOneSlotValuesAlloc(alloc, law_id, running.*, contribution);
+                if (running.*) |old| alloc.free(old);
+                running.* = next;
+            },
+        }
     }
 
     fn entriesAlloc(self: *@This(), alloc: Allocator) ![]FoldEntry {
         var count: usize = 0;
         var count_it = self.values.iterator();
         while (count_it.next()) |entry| {
-            if (entry.value_ptr.* != null) count += 1;
+            switch (entry.value_ptr.*) {
+                .text => |value| if (value != null) {
+                    count += 1;
+                },
+                else => count += 1,
+            }
         }
         const entries = try alloc.alloc(FoldEntry, count);
         var initialized: usize = 0;
@@ -2424,10 +2467,16 @@ const DerivedJoinFoldAccumulator = struct {
         }
         var it = self.values.iterator();
         while (it.next()) |entry| {
-            const value = entry.value_ptr.* orelse continue;
+            const value_bytes = switch (entry.value_ptr.*) {
+                .int => |running| try algebra.encodeI64Alloc(alloc, running),
+                .float => |running| try algebra.encodeF64Alloc(alloc, running),
+                .avg => |running| try algebra.encodeAvgAlloc(alloc, running),
+                .text => |running| try alloc.dupe(u8, running orelse continue),
+            };
+            errdefer alloc.free(value_bytes);
             entries[initialized] = .{
                 .group_key = try alloc.dupe(u8, entry.key_ptr.*),
-                .value = try alloc.dupe(u8, value),
+                .value = value_bytes,
             };
             initialized += 1;
         }

--- a/zig/pkg/antfly/src/storage/db/algebraic/tensor.zig
+++ b/zig/pkg/antfly/src/storage/db/algebraic/tensor.zig
@@ -222,18 +222,12 @@ pub fn mergeOneSlotValuesAlloc(
     left: ?[]const u8,
     right: ?[]const u8,
 ) ![]u8 {
-    var left_row = try rowAlloc(alloc, &.{law_id});
-    defer left_row.deinit(alloc);
-    if (left) |value| left_row.slots[0].value = try alloc.dupe(u8, value);
-
-    var right_row = try rowAlloc(alloc, &.{law_id});
-    defer right_row.deinit(alloc);
-    if (right) |value| right_row.slots[0].value = try alloc.dupe(u8, value);
-
-    var merged = try mergeRowsAlloc(alloc, left_row, right_row);
-    defer merged.deinit(alloc);
-    const value = merged.slots[0].value orelse return try law.identityAlloc(alloc, law_id);
-    return try alloc.dupe(u8, value);
+    // Equivalent to merging two single-slot rows, but without allocating the
+    // surrounding Row/Slot scaffolding (two rows, two value dupes, and a final
+    // dupe). `law.combineAlloc` already returns a freshly owned buffer, so on
+    // the per-contribution fold hot path this drops ~6 allocations down to 1.
+    return (try law.combineAlloc(alloc, law_id, left, right)) orelse
+        try law.identityAlloc(alloc, law_id);
 }
 
 pub fn encodeRowAlloc(alloc: Allocator, row: Row) ![]u8 {


### PR DESCRIPTION
## What changed

- uses hash-set membership for exact doc-id constraints
- makes child cardinality evaluation single-pass
- removes row scaffolding and unused helpers
- accumulates additive results natively

## Why

These PR #141 optimizations are result-preserving and independent of HLL, adaptive materialization, relational storage, and the larger #145 integration.

## Impact

Exact algebraic cardinality paths allocate less and avoid repeated traversal while retaining canonical results.

## Validation

- 3 focused algebraic cardinality/fold/distributed-merge tests passed, no leaks
- `git diff --check`