### PR TITLE
perf(storage): add persistent ordered memory snapshots

### DIFF
--- a/zig/build.zig
+++ b/zig/build.zig
@@ -7222,6 +7222,7 @@ pub fn build(b: *std.Build) void {
             "storage.lmdb_backend.",
             "storage.maintenance.",
             "storage.mem_backend.",
+            "storage.mem_ordered.",
             "storage.object_storage.",
             "storage.persistent.",
             "storage.portable_backup.",

--- a/zig/pkg/antfly/src/storage/backend_conformance_test.zig
+++ b/zig/pkg/antfly/src/storage/backend_conformance_test.zig
@@ -115,6 +115,16 @@ fn expectBoundStoreConformance(runtime: *backend_erased.Store) !void {
         try std.testing.expectEqualStrings("doc:c", (try cur.last()).?.key);
         try std.testing.expectEqualStrings("doc:a", (try cur.seekAtOrBefore("doc:b")).?.key);
         try std.testing.expectEqualStrings("doc:c", (try cur.seekAtOrAfter("doc:b")).?.key);
+
+        try std.testing.expectEqualStrings("doc:a", (try cur.first()).?.key);
+        try std.testing.expect((try cur.prev()) == null);
+        try std.testing.expectEqualStrings("doc:c", (try cur.last()).?.key);
+        try std.testing.expect((try cur.next()) == null);
+
+        try std.testing.expectEqualStrings("doc:a", (try cur.first()).?.key);
+        try std.testing.expectEqualStrings("doc:c", (try cur.next()).?.key);
+        try std.testing.expectEqualStrings("doc:a", (try cur.prev()).?.key);
+        try std.testing.expectEqualStrings("doc:c", (try cur.next()).?.key);
     }
 }
 

--- a/zig/pkg/antfly/src/storage/mem_backend.zig
+++ b/zig/pkg/antfly/src/storage/mem_backend.zig
@@ -19,157 +19,94 @@ const backend_adapter = @import("backend_adapter.zig");
 const backend_erased = @import("backend_erased.zig");
 const backend_types = @import("backend_types.zig");
 const internal_keys = @import("internal_keys.zig");
-const OwnedEntry = struct {
-    namespace_name: ?[]u8,
-    key: []u8,
-    value: []u8,
-
-    fn deinit(self: *OwnedEntry, allocator: Allocator) void {
-        if (self.namespace_name) |name| allocator.free(name);
-        allocator.free(self.key);
-        allocator.free(self.value);
-        self.* = undefined;
-    }
-
-    fn entry(self: *const OwnedEntry) backend_adapter.Entry {
-        return .{
-            .key = self.key,
-            .value = self.value,
-        };
-    }
-};
+const ordered = @import("mem_ordered.zig");
 
 const State = struct {
-    arena: ?std.heap.ArenaAllocator = null,
-    entries: std.ArrayListUnmanaged(OwnedEntry) = .empty,
+    tree: ordered.Tree = .empty,
 
     fn deinit(self: *State, allocator: Allocator) void {
-        if (self.arena) |*arena| {
-            arena.deinit();
-            self.* = .{};
-            return;
-        }
-        for (self.entries.items) |*entry| entry.deinit(allocator);
-        self.entries.deinit(allocator);
+        self.tree.release(allocator);
         self.* = .{};
     }
 
+    // O(1) snapshot: the persistent tree shares structure with the source, so a
+    // transaction starts from the current version without copying it.
     fn clone(self: *const State, allocator: Allocator) !State {
-        var out: State = .{};
-        errdefer out.deinit(allocator);
-        out.arena = std.heap.ArenaAllocator.init(allocator);
-
-        const arena_alloc = out.arena.?.allocator();
-        try out.entries.ensureTotalCapacity(arena_alloc, self.entries.items.len);
-        for (self.entries.items) |entry| {
-            out.entries.appendAssumeCapacity(try cloneEntry(arena_alloc, entry));
-        }
-        return out;
+        _ = allocator;
+        return .{ .tree = self.tree.snapshot() };
     }
 
     fn get(self: *const State, namespace: backend_types.Namespace, key: []const u8) ![]const u8 {
-        const idx = self.findIndex(namespace, key) orelse return error.NotFound;
-        return self.entries.items[idx].value;
+        return self.tree.get(namespace.name, key) orelse error.NotFound;
     }
 
     fn put(self: *State, allocator: Allocator, namespace: backend_types.Namespace, key: []const u8, value: []const u8) !void {
-        const state_alloc = self.stateAllocator(allocator);
-        if (self.findIndex(namespace, key)) |idx| {
-            const replacement = try state_alloc.dupe(u8, value);
-            if (!self.usesArena()) allocator.free(self.entries.items[idx].value);
-            self.entries.items[idx].value = replacement;
-            return;
-        }
-
-        const idx = self.lowerBound(namespace, key);
-        try self.entries.insert(state_alloc, idx, try initEntry(state_alloc, namespace, key, value));
+        const next = try self.tree.put(allocator, namespace.name, key, value);
+        self.tree.release(allocator);
+        self.tree = next;
     }
 
     fn delete(self: *State, allocator: Allocator, namespace: backend_types.Namespace, key: []const u8) !void {
-        const idx = self.findIndex(namespace, key) orelse return;
-        var removed = self.entries.orderedRemove(idx);
-        if (!self.usesArena()) removed.deinit(allocator);
-    }
-
-    fn lowerBound(self: *const State, namespace: backend_types.Namespace, key: []const u8) usize {
-        var lo: usize = 0;
-        var hi: usize = self.entries.items.len;
-        while (lo < hi) {
-            const mid = lo + (hi - lo) / 2;
-            const ord = compareEntryTo(self.entries.items[mid], namespace, key);
-            if (ord == .lt) {
-                lo = mid + 1;
-            } else {
-                hi = mid;
-            }
-        }
-        return lo;
-    }
-
-    fn findIndex(self: *const State, namespace: backend_types.Namespace, key: []const u8) ?usize {
-        const idx = self.lowerBound(namespace, key);
-        if (idx >= self.entries.items.len) return null;
-        if (compareEntryTo(self.entries.items[idx], namespace, key) != .eq) return null;
-        return idx;
-    }
-
-    fn stateAllocator(self: *State, fallback: Allocator) Allocator {
-        if (self.arena) |*arena| return arena.allocator();
-        return fallback;
-    }
-
-    fn usesArena(self: *const State) bool {
-        return self.arena != null;
+        const next = try self.tree.remove(allocator, namespace.name, key);
+        self.tree.release(allocator);
+        self.tree = next;
     }
 };
 
-fn cloneEntry(allocator: Allocator, entry: OwnedEntry) !OwnedEntry {
-    return .{
-        .namespace_name = if (entry.namespace_name) |name| try allocator.dupe(u8, name) else null,
-        .key = try allocator.dupe(u8, entry.key),
-        .value = try allocator.dupe(u8, entry.value),
-    };
+fn sameNamespace(a: ?[]const u8, b: ?[]const u8) bool {
+    if (a == null and b == null) return true;
+    if (a == null or b == null) return false;
+    return std.mem.eql(u8, a.?, b.?);
 }
 
-fn initEntry(
-    allocator: Allocator,
-    namespace: backend_types.Namespace,
-    key: []const u8,
-    value: []const u8,
-) !OwnedEntry {
-    return .{
-        .namespace_name = if (namespace.name) |name| try allocator.dupe(u8, name) else null,
-        .key = try allocator.dupe(u8, key),
-        .value = try allocator.dupe(u8, value),
-    };
-}
-
-fn namespaceOf(entry: OwnedEntry) backend_types.Namespace {
-    return .{ .name = entry.namespace_name };
-}
-
-fn compareNamespace(a: backend_types.Namespace, b: backend_types.Namespace) std.math.Order {
-    if (a.name == null and b.name == null) return .eq;
-    if (a.name == null) return .lt;
-    if (b.name == null) return .gt;
-    return std.mem.order(u8, a.name.?, b.name.?);
-}
-
-fn compareEntryTo(entry: OwnedEntry, namespace: backend_types.Namespace, key: []const u8) std.math.Order {
-    const namespace_order = compareNamespace(namespaceOf(entry), namespace);
-    if (namespace_order != .eq) return namespace_order;
-    return std.mem.order(u8, entry.key, key);
+fn namespaceOrder(a: ?[]const u8, b: ?[]const u8) std.math.Order {
+    if (a == null and b == null) return .eq;
+    if (a == null) return .lt;
+    if (b == null) return .gt;
+    return std.mem.order(u8, a.?, b.?);
 }
 
 pub const Options = struct {
     backend: backend_types.OpenOptions = .{},
 };
 
+// Reference-counted, immutable-while-shared snapshot of the store. Read
+// transactions retain the current snapshot in O(1) instead of cloning the whole
+// entry list; a writer clones into a fresh snapshot and publishes it on commit,
+// so readers opened beforehand keep observing the snapshot they retained until
+// they release it. This keeps snapshot isolation while making reads cheap.
+const RcState = struct {
+    refs: usize,
+    state: State,
+};
+
+fn retainState(rc: *RcState) void {
+    rc.refs += 1;
+}
+
+fn releaseState(allocator: Allocator, rc: *RcState) void {
+    rc.refs -= 1;
+    if (rc.refs == 0) {
+        rc.state.deinit(allocator);
+        allocator.destroy(rc);
+    }
+}
+
 pub const Backend = struct {
     allocator: Allocator,
     open_options: backend_types.OpenOptions,
-    state: State = .{},
+    state: ?*RcState = null,
     mutex: std.atomic.Mutex = .unlocked,
+
+    // Returns the current snapshot, creating an empty one on first use. Must be
+    // called with the backend mutex held.
+    fn ensureStateLocked(self: *Backend) !*RcState {
+        if (self.state) |rc| return rc;
+        const rc = try self.allocator.create(RcState);
+        rc.* = .{ .refs = 1, .state = .{} };
+        self.state = rc;
+        return rc;
+    }
 
     const BoundStore = struct {
         backend: *Backend,
@@ -216,13 +153,17 @@ pub const Backend = struct {
             const upper = internal_keys.replayRangeUpper(lane_ordinal);
 
             lockBackend(self.backend);
-            defer self.backend.mutex.unlock();
+            var snapshot = self.backend.state.?.state.tree.snapshot();
+            self.backend.mutex.unlock();
+            defer snapshot.release(self.backend.allocator);
+
+            var cursor = ordered.Cursor.init(self.backend.allocator);
+            defer cursor.deinit();
 
             var stats = backend_types.ReplayLaneIterationStats{ .scan_batches = 1 };
-            var idx = self.backend.state.lowerBound(self.namespace, lower[0..]);
-            while (idx < self.backend.state.entries.items.len) : (idx += 1) {
-                const entry = self.backend.state.entries.items[idx];
-                if (compareNamespace(namespaceOf(entry), self.namespace) != .eq) break;
+            var found = try cursor.seekAtOrAfter(snapshot, self.namespace.name, lower[0..]);
+            while (found) |entry| : (found = try cursor.next()) {
+                if (namespaceOrder(entry.name, self.namespace.name) != .eq) break;
                 if (std.mem.order(u8, entry.key, upper[0..]) != .lt) break;
                 const sequence = internal_keys.parseReplayEntrySequence(entry.key, lane_ordinal) orelse break;
                 try callback(ctx, sequence, entry.value);
@@ -235,195 +176,205 @@ pub const Backend = struct {
         }
     };
 
+    // Namespace-scoped cursor over a retained tree snapshot. Holding its own
+    // snapshot keeps the nodes alive even if the transaction writes afterwards.
     const BoundCursor = struct {
-        state: *const State,
+        alloc: Allocator,
+        tree: ordered.Tree,
         namespace: backend_types.Namespace,
-        current: ?usize = null,
+        inner: ordered.Cursor,
 
-        pub fn close(_: *@This()) void {}
-
-        pub fn first(self: *@This()) !backend_adapter.Entry {
-            const idx = self.firstIndex() orelse return error.NotFound;
-            self.current = idx;
-            return self.state.entries.items[idx].entry();
+        fn init(alloc: Allocator, tree: ordered.Tree, namespace: backend_types.Namespace) BoundCursor {
+            return .{
+                .alloc = alloc,
+                .tree = tree.snapshot(),
+                .namespace = namespace,
+                .inner = ordered.Cursor.init(alloc),
+            };
         }
 
-        pub fn last(self: *@This()) !backend_adapter.Entry {
-            const idx = self.lastIndex() orelse return error.NotFound;
-            self.current = idx;
-            return self.state.entries.items[idx].entry();
+        pub fn close(self: *@This()) void {
+            self.inner.deinit();
+            self.tree.release(self.alloc);
+            self.* = undefined;
+        }
+
+        fn entryOf(entry: ordered.Entry) backend_adapter.Entry {
+            return .{ .key = entry.key, .value = entry.value };
+        }
+
+        // A forward step lands on the next entry in namespace order; once it
+        // crosses out of this cursor's namespace the scan is exhausted.
+        fn forward(self: *@This(), found: ?ordered.Entry) !backend_adapter.Entry {
+            const entry = found orelse return error.NotFound;
+            if (!sameNamespace(entry.name, self.namespace.name)) return error.NotFound;
+            return entryOf(entry);
+        }
+
+        pub fn first(self: *@This()) !backend_adapter.Entry {
+            return self.forward(try self.inner.seekAtOrAfter(self.tree, self.namespace.name, ""));
+        }
+
+        pub fn seekAtOrAfter(self: *@This(), key: []const u8) !backend_adapter.Entry {
+            return self.forward(try self.inner.seekAtOrAfter(self.tree, self.namespace.name, key));
         }
 
         pub fn next(self: *@This()) !backend_adapter.Entry {
-            const current = self.current orelse return error.NotFound;
-            var idx = current + 1;
-            while (idx < self.state.entries.items.len) : (idx += 1) {
-                if (compareNamespace(namespaceOf(self.state.entries.items[idx]), self.namespace) == .eq) {
-                    self.current = idx;
-                    return self.state.entries.items[idx].entry();
+            return self.forward(try self.inner.next());
+        }
+
+        pub fn last(self: *@This()) !backend_adapter.Entry {
+            var found = try self.inner.last(self.tree);
+            while (found) |entry| {
+                switch (namespaceOrder(entry.name, self.namespace.name)) {
+                    .eq => return entryOf(entry),
+                    .gt => found = try self.inner.prev(),
+                    .lt => return error.NotFound,
                 }
             }
             return error.NotFound;
         }
 
         pub fn prev(self: *@This()) !backend_adapter.Entry {
-            const current = self.current orelse return error.NotFound;
-            if (current == 0) return error.NotFound;
-            var idx = current - 1;
-            while (true) {
-                if (compareNamespace(namespaceOf(self.state.entries.items[idx]), self.namespace) == .eq) {
-                    self.current = idx;
-                    return self.state.entries.items[idx].entry();
-                }
-                if (idx == 0) break;
-                idx -= 1;
-            }
-            return error.NotFound;
-        }
-
-        pub fn seekAtOrAfter(self: *@This(), key: []const u8) !backend_adapter.Entry {
-            const idx = self.state.lowerBound(self.namespace, key);
-            if (idx >= self.state.entries.items.len) return error.NotFound;
-            if (compareNamespace(namespaceOf(self.state.entries.items[idx]), self.namespace) != .eq) return error.NotFound;
-            self.current = idx;
-            return self.state.entries.items[idx].entry();
+            const entry = (try self.inner.prev()) orelse return error.NotFound;
+            if (!sameNamespace(entry.name, self.namespace.name)) return error.NotFound;
+            return entryOf(entry);
         }
 
         pub fn seekAtOrBefore(self: *@This(), key: []const u8) !backend_adapter.Entry {
-            const idx = self.state.lowerBound(self.namespace, key);
-            if (idx < self.state.entries.items.len and compareEntryTo(self.state.entries.items[idx], self.namespace, key) == .eq) {
-                self.current = idx;
-                return self.state.entries.items[idx].entry();
-            }
-            if (idx == 0) return error.NotFound;
-            var probe = idx - 1;
-            while (true) {
-                if (compareNamespace(namespaceOf(self.state.entries.items[probe]), self.namespace) == .eq) {
-                    self.current = probe;
-                    return self.state.entries.items[probe].entry();
-                }
-                if (probe == 0) break;
-                probe -= 1;
-            }
-            return error.NotFound;
-        }
-
-        fn firstIndex(self: *const @This()) ?usize {
-            const idx = self.state.lowerBound(self.namespace, "");
-            if (idx >= self.state.entries.items.len) return null;
-            if (compareNamespace(namespaceOf(self.state.entries.items[idx]), self.namespace) != .eq) return null;
-            return idx;
-        }
-
-        fn lastIndex(self: *const @This()) ?usize {
-            if (self.state.entries.items.len == 0) return null;
-            var idx = self.state.entries.items.len;
-            while (idx > 0) {
-                idx -= 1;
-                if (compareNamespace(namespaceOf(self.state.entries.items[idx]), self.namespace) == .eq) return idx;
-            }
-            return null;
+            const entry = (try self.inner.seekAtOrBefore(self.tree, self.namespace.name, key)) orelse return error.NotFound;
+            if (!sameNamespace(entry.name, self.namespace.name)) return error.NotFound;
+            return entryOf(entry);
         }
     };
 
     const BoundTxn = struct {
         allocator: Allocator,
-        backend: ?*Backend,
+        backend: *Backend,
         namespace: backend_types.Namespace,
-        state: State,
+        read_only: bool,
+        rc: ?*RcState,
 
         fn open(backend: *Backend, namespace: backend_types.Namespace, read_only: bool) !BoundTxn {
             lockBackend(backend);
             defer backend.mutex.unlock();
+            const current = try backend.ensureStateLocked();
+            const rc: *RcState = if (read_only) blk: {
+                retainState(current);
+                break :blk current;
+            } else blk: {
+                var cloned = try current.state.clone(backend.allocator);
+                errdefer cloned.deinit(backend.allocator);
+                const new_rc = try backend.allocator.create(RcState);
+                new_rc.* = .{ .refs = 1, .state = cloned };
+                break :blk new_rc;
+            };
             return .{
                 .allocator = backend.allocator,
-                .backend = if (read_only) null else backend,
+                .backend = backend,
                 .namespace = namespace,
-                .state = try backend.state.clone(backend.allocator),
+                .read_only = read_only,
+                .rc = rc,
             };
         }
 
         pub fn abort(self: *@This()) void {
-            self.state.deinit(self.allocator);
-            self.* = undefined;
+            const rc = self.rc orelse return;
+            lockBackend(self.backend);
+            releaseState(self.allocator, rc);
+            self.backend.mutex.unlock();
+            self.rc = null;
         }
 
         pub fn commit(self: *@This()) !void {
-            const backend = self.backend orelse return error.ReadOnly;
-            lockBackend(backend);
-            defer backend.mutex.unlock();
-            var old_state = backend.state;
-            backend.state = self.state;
-            self.state = .{};
-            old_state.deinit(self.allocator);
-            self.backend = null;
+            if (self.read_only) return error.ReadOnly;
+            const rc = self.rc orelse return error.ReadOnly;
+            lockBackend(self.backend);
+            defer self.backend.mutex.unlock();
+            const old = self.backend.state.?;
+            self.backend.state = rc;
+            releaseState(self.allocator, old);
+            self.rc = null;
         }
 
         pub fn get(self: *@This(), key: []const u8) ![]const u8 {
-            return try self.state.get(self.namespace, key);
+            return try self.rc.?.state.get(self.namespace, key);
         }
 
         pub fn put(self: *@This(), key: []const u8, value: []const u8) !void {
-            if (self.backend == null) return error.ReadOnly;
-            try self.state.put(self.allocator, self.namespace, key, value);
+            if (self.read_only) return error.ReadOnly;
+            try self.rc.?.state.put(self.allocator, self.namespace, key, value);
         }
 
         pub fn delete(self: *@This(), key: []const u8) !void {
-            if (self.backend == null) return error.ReadOnly;
-            try self.state.delete(self.allocator, self.namespace, key);
+            if (self.read_only) return error.ReadOnly;
+            try self.rc.?.state.delete(self.allocator, self.namespace, key);
         }
 
         pub fn openCursor(self: *@This()) !BoundCursor {
-            return .{
-                .state = &self.state,
-                .namespace = self.namespace,
-            };
+            return BoundCursor.init(self.allocator, self.rc.?.state.tree, self.namespace);
         }
     };
 
     const NamespaceTxn = struct {
         allocator: Allocator,
-        backend: ?*Backend,
-        state: State,
+        backend: *Backend,
+        read_only: bool,
+        rc: ?*RcState,
 
         fn open(backend: *Backend, read_only: bool) !NamespaceTxn {
             lockBackend(backend);
             defer backend.mutex.unlock();
+            const current = try backend.ensureStateLocked();
+            const rc: *RcState = if (read_only) blk: {
+                retainState(current);
+                break :blk current;
+            } else blk: {
+                var cloned = try current.state.clone(backend.allocator);
+                errdefer cloned.deinit(backend.allocator);
+                const new_rc = try backend.allocator.create(RcState);
+                new_rc.* = .{ .refs = 1, .state = cloned };
+                break :blk new_rc;
+            };
             return .{
                 .allocator = backend.allocator,
-                .backend = if (read_only) null else backend,
-                .state = try backend.state.clone(backend.allocator),
+                .backend = backend,
+                .read_only = read_only,
+                .rc = rc,
             };
         }
 
         pub fn abort(self: *@This()) void {
-            self.state.deinit(self.allocator);
-            self.* = undefined;
+            const rc = self.rc orelse return;
+            lockBackend(self.backend);
+            releaseState(self.allocator, rc);
+            self.backend.mutex.unlock();
+            self.rc = null;
         }
 
         pub fn commit(self: *@This()) !void {
-            const backend = self.backend orelse return error.ReadOnly;
-            lockBackend(backend);
-            defer backend.mutex.unlock();
-            var old_state = backend.state;
-            backend.state = self.state;
-            self.state = .{};
-            old_state.deinit(self.allocator);
-            self.backend = null;
+            if (self.read_only) return error.ReadOnly;
+            const rc = self.rc orelse return error.ReadOnly;
+            lockBackend(self.backend);
+            defer self.backend.mutex.unlock();
+            const old = self.backend.state.?;
+            self.backend.state = rc;
+            releaseState(self.allocator, old);
+            self.rc = null;
         }
 
         pub fn get(self: *@This(), namespace: backend_types.Namespace, key: []const u8) ![]const u8 {
-            return try self.state.get(namespace, key);
+            return try self.rc.?.state.get(namespace, key);
         }
 
         pub fn put(self: *@This(), namespace: backend_types.Namespace, key: []const u8, value: []const u8) !void {
-            if (self.backend == null) return error.ReadOnly;
-            try self.state.put(self.allocator, namespace, key, value);
+            if (self.read_only) return error.ReadOnly;
+            try self.rc.?.state.put(self.allocator, namespace, key, value);
         }
 
         pub fn delete(self: *@This(), namespace: backend_types.Namespace, key: []const u8) !void {
-            if (self.backend == null) return error.ReadOnly;
-            try self.state.delete(self.allocator, namespace, key);
+            if (self.read_only) return error.ReadOnly;
+            try self.rc.?.state.delete(self.allocator, namespace, key);
         }
     };
 
@@ -436,7 +387,7 @@ pub const Backend = struct {
 
     pub fn close(self: *Backend) void {
         lockBackend(self);
-        self.state.deinit(self.allocator);
+        if (self.state) |rc| releaseState(self.allocator, rc);
         self.mutex.unlock();
         self.* = undefined;
     }

--- a/zig/pkg/antfly/src/storage/mem_backend.zig
+++ b/zig/pkg/antfly/src/storage/mem_backend.zig
@@ -152,9 +152,12 @@ pub const Backend = struct {
             const lower = internal_keys.replayRangeLower(lane_ordinal, from_sequence);
             const upper = internal_keys.replayRangeUpper(lane_ordinal);
 
-            lockBackend(self.backend);
-            var snapshot = self.backend.state.?.state.tree.snapshot();
-            self.backend.mutex.unlock();
+            var snapshot = blk: {
+                lockBackend(self.backend);
+                defer self.backend.mutex.unlock();
+                const state = try self.backend.ensureStateLocked();
+                break :blk state.state.tree.snapshot();
+            };
             defer snapshot.release(self.backend.allocator);
 
             var cursor = ordered.Cursor.init(self.backend.allocator);
@@ -470,6 +473,35 @@ test "memory backend runtime erases namespace store handles" {
         try std.testing.expectEqualStrings("1", try txn.get(.{}, "meta:lsn"));
         try std.testing.expectEqualStrings("A", try txn.get(.{ .name = "docs" }, "doc:a"));
     }
+}
+
+test "memory backend replay scan is empty before first transaction" {
+    var backend = Backend.init(std.testing.allocator, .{});
+    defer backend.close();
+
+    var runtime = try backend.runtimeStore(std.testing.allocator, .{ .name = "docs" });
+    defer runtime.deinit();
+
+    const Context = struct {
+        calls: usize = 0,
+
+        fn handle(self: *@This(), _: u64, _: []const u8) !void {
+            self.calls += 1;
+        }
+    };
+
+    var context: Context = .{};
+    const stats = try runtime.forEachReplayLaneFrom(
+        internal_keys.replay_all_kind,
+        1,
+        0,
+        &context,
+        Context.handle,
+    );
+
+    try std.testing.expectEqual(@as(usize, 0), context.calls);
+    try std.testing.expectEqual(@as(usize, 0), stats.scanned_entries);
+    try std.testing.expectEqual(@as(usize, 0), stats.matched_entries);
 }
 
 test "memory backend runtime erases bound store handles with cursor access" {

--- a/zig/pkg/antfly/src/storage/mem_ordered.zig
+++ b/zig/pkg/antfly/src/storage/mem_ordered.zig
@@ -1,0 +1,664 @@
+// Copyright 2026 Antfly, Inc.
+//
+// Licensed under the Elastic License 2.0 (ELv2); you may not use this file
+// except in compliance with the Elastic License 2.0. You may obtain a copy of
+// the Elastic License 2.0 at
+//
+//     https://www.antfly.io/licensing/ELv2-license
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the Elastic License 2.0 is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// Elastic License 2.0 for the specific language governing permissions and
+// limitations.
+
+//! Persistent ordered map used by the in-memory backend.
+//!
+//! Entries are keyed by `(namespace, key)` and kept in sort order (a null
+//! namespace sorts before any named namespace, then by key bytes). The map is a
+//! treap: a binary search tree on the key with a heap order on a hash-derived
+//! priority, which keeps it balanced in expectation regardless of insertion
+//! order without storing any per-tree RNG state.
+//!
+//! Crucially the tree is *persistent*: insert/delete copy only the O(log n)
+//! nodes on the path and share every untouched subtree, so producing a new
+//! version is O(log n) and taking a read snapshot is O(1) (retain the root).
+//! Nodes are reference counted, so older snapshots stay valid until released.
+//! This replaces an earlier sorted-array store whose every transaction cloned
+//! the whole array (O(n) snapshots, O(n^2) ingest).
+
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const Order = std.math.Order;
+
+const priority_seed: u64 = 0x2545f4914f6cdd1d;
+
+fn priorityFor(name: ?[]const u8, key: []const u8) u64 {
+    var hasher = std.hash.Wyhash.init(priority_seed);
+    if (name) |namespace| {
+        hasher.update(&.{1});
+        hasher.update(namespace);
+    } else {
+        hasher.update(&.{0});
+    }
+    hasher.update(key);
+    return hasher.final();
+}
+
+/// Order of `(a_name, a_key)` relative to `(b_name, b_key)`: a null namespace
+/// sorts first, then namespaces compare by bytes, then keys compare by bytes.
+pub fn compareKeys(a_name: ?[]const u8, a_key: []const u8, b_name: ?[]const u8, b_key: []const u8) Order {
+    const namespace_order = if (a_name == null and b_name == null)
+        Order.eq
+    else if (a_name == null)
+        Order.lt
+    else if (b_name == null)
+        Order.gt
+    else
+        std.mem.order(u8, a_name.?, b_name.?);
+    if (namespace_order != .eq) return namespace_order;
+    return std.mem.order(u8, a_key, b_key);
+}
+
+const Node = struct {
+    // Atomic: nodes are shared across snapshots, and the backend mutates these
+    // refcounts off the backend mutex — a writer `retain`s shared path nodes
+    // during an unlocked `put` while a concurrent reader `releaseNode`s the same
+    // nodes on abort/commit. A non-atomic counter loses updates here, dropping
+    // refs to zero early (use-after-free) or underflowing (the `-= 1` overflow
+    // panic). The node *contents* stay immutable after makeNode (copy-on-write),
+    // so only this counter needs synchronization.
+    refs: usize,
+    name: ?[]const u8,
+    key: []const u8,
+    value: []const u8,
+    priority: u64,
+    left: ?*Node = null,
+    right: ?*Node = null,
+
+    fn order(self: *const Node, name: ?[]const u8, key: []const u8) Order {
+        return compareKeys(self.name, self.key, name, key);
+    }
+};
+
+fn retain(node: ?*Node) ?*Node {
+    // Monotonic suffices: a retain races only with other refcount ops, and the
+    // caller already holds a live reference to `node`, so no ordering against the
+    // node's contents is needed.
+    if (node) |present| _ = @atomicRmw(usize, &present.refs, .Add, 1, .monotonic);
+    return node;
+}
+
+fn releaseNode(alloc: Allocator, node: ?*Node) void {
+    const present = node orelse return;
+    // acq_rel on the decrement: the release half publishes this thread's prior
+    // uses of the node before the drop, and the acquire half makes the thread
+    // that wins the final decrement observe every other thread's uses before it
+    // frees — so the destroy below can't race a still-in-flight reader.
+    if (@atomicRmw(usize, &present.refs, .Sub, 1, .acq_rel) > 1) return;
+    releaseNode(alloc, present.left);
+    releaseNode(alloc, present.right);
+    if (present.name) |namespace| alloc.free(namespace);
+    alloc.free(present.key);
+    alloc.free(present.value);
+    alloc.destroy(present);
+}
+
+/// Builds a fresh node (refs = 1) owning copies of name/key/value and *taking
+/// ownership* of the `left`/`right` child references — on both success and
+/// failure those references are consumed, so callers pass owned (often freshly
+/// `retain`ed) children and never release them afterwards.
+fn makeNode(
+    alloc: Allocator,
+    name: ?[]const u8,
+    key: []const u8,
+    value: []const u8,
+    priority: u64,
+    left: ?*Node,
+    right: ?*Node,
+) !*Node {
+    errdefer {
+        releaseNode(alloc, left);
+        releaseNode(alloc, right);
+    }
+    const node = try alloc.create(Node);
+    errdefer alloc.destroy(node);
+    const name_copy = if (name) |namespace| try alloc.dupe(u8, namespace) else null;
+    errdefer if (name_copy) |namespace| alloc.free(namespace);
+    const key_copy = try alloc.dupe(u8, key);
+    errdefer alloc.free(key_copy);
+    const value_copy = try alloc.dupe(u8, value);
+    node.* = .{
+        .refs = 1,
+        .name = name_copy,
+        .key = key_copy,
+        .value = value_copy,
+        .priority = priority,
+        .left = left,
+        .right = right,
+    };
+    return node;
+}
+
+// Consumes `node` on success; leaves it owned by the caller on error.
+fn rotateRight(alloc: Allocator, node: *Node) !*Node {
+    const left = node.left.?;
+    const new_right = try makeNode(alloc, node.name, node.key, node.value, node.priority, retain(left.right), retain(node.right));
+    const new_root = makeNode(alloc, left.name, left.key, left.value, left.priority, retain(left.left), new_right) catch |err| return err;
+    releaseNode(alloc, node);
+    return new_root;
+}
+
+// Consumes `node` on success; leaves it owned by the caller on error.
+fn rotateLeft(alloc: Allocator, node: *Node) !*Node {
+    const right = node.right.?;
+    const new_left = try makeNode(alloc, node.name, node.key, node.value, node.priority, retain(node.left), retain(right.left));
+    const new_root = makeNode(alloc, right.name, right.key, right.value, right.priority, new_left, retain(right.right)) catch |err| return err;
+    releaseNode(alloc, node);
+    return new_root;
+}
+
+const InsertResult = struct { root: *Node, added: bool };
+
+// Borrows `node` (never consumes it); returns a new owned root sharing untouched
+// subtrees, or an error after cleaning up any partial work.
+fn insert(alloc: Allocator, node: ?*Node, name: ?[]const u8, key: []const u8, value: []const u8, priority: u64) !InsertResult {
+    const current = node orelse {
+        const leaf = try makeNode(alloc, name, key, value, priority, null, null);
+        return .{ .root = leaf, .added = true };
+    };
+    switch (compareKeys(name, key, current.name, current.key)) {
+        .eq => {
+            const updated = try makeNode(alloc, current.name, current.key, value, current.priority, retain(current.left), retain(current.right));
+            return .{ .root = updated, .added = false };
+        },
+        .lt => {
+            const child = try insert(alloc, current.left, name, key, value, priority);
+            var new_node = makeNode(alloc, current.name, current.key, current.value, current.priority, child.root, retain(current.right)) catch |err| return err;
+            if (new_node.left.?.priority > new_node.priority) {
+                new_node = rotateRight(alloc, new_node) catch |err| {
+                    releaseNode(alloc, new_node);
+                    return err;
+                };
+            }
+            return .{ .root = new_node, .added = child.added };
+        },
+        .gt => {
+            const child = try insert(alloc, current.right, name, key, value, priority);
+            var new_node = makeNode(alloc, current.name, current.key, current.value, current.priority, retain(current.left), child.root) catch |err| return err;
+            if (new_node.right.?.priority > new_node.priority) {
+                new_node = rotateLeft(alloc, new_node) catch |err| {
+                    releaseNode(alloc, new_node);
+                    return err;
+                };
+            }
+            return .{ .root = new_node, .added = child.added };
+        },
+    }
+}
+
+// Consumes `left` and `right`; returns their treap merge (heap order preserved).
+fn mergeTreaps(alloc: Allocator, left: ?*Node, right: ?*Node) !?*Node {
+    const l = left orelse return right;
+    const r = right orelse return left;
+    if (l.priority >= r.priority) {
+        const merged_right = mergeTreaps(alloc, retain(l.right), r) catch |err| {
+            releaseNode(alloc, l);
+            return err;
+        };
+        const node = makeNode(alloc, l.name, l.key, l.value, l.priority, retain(l.left), merged_right) catch |err| {
+            releaseNode(alloc, l);
+            return err;
+        };
+        releaseNode(alloc, l);
+        return node;
+    } else {
+        const merged_left = mergeTreaps(alloc, l, retain(r.left)) catch |err| {
+            releaseNode(alloc, r);
+            return err;
+        };
+        const node = makeNode(alloc, r.name, r.key, r.value, r.priority, merged_left, retain(r.right)) catch |err| {
+            releaseNode(alloc, r);
+            return err;
+        };
+        releaseNode(alloc, r);
+        return node;
+    }
+}
+
+const RemoveResult = struct { root: ?*Node, removed: bool };
+
+// Borrows `node`; returns a new owned root (sharing untouched subtrees).
+fn removeKey(alloc: Allocator, node: ?*Node, name: ?[]const u8, key: []const u8) !RemoveResult {
+    const current = node orelse return .{ .root = null, .removed = false };
+    switch (compareKeys(name, key, current.name, current.key)) {
+        .eq => {
+            const merged = try mergeTreaps(alloc, retain(current.left), retain(current.right));
+            return .{ .root = merged, .removed = true };
+        },
+        .lt => {
+            const child = try removeKey(alloc, current.left, name, key);
+            if (!child.removed) {
+                releaseNode(alloc, child.root);
+                return .{ .root = retain(current).?, .removed = false };
+            }
+            const new_node = makeNode(alloc, current.name, current.key, current.value, current.priority, child.root, retain(current.right)) catch |err| return err;
+            return .{ .root = new_node, .removed = true };
+        },
+        .gt => {
+            const child = try removeKey(alloc, current.right, name, key);
+            if (!child.removed) {
+                releaseNode(alloc, child.root);
+                return .{ .root = retain(current).?, .removed = false };
+            }
+            const new_node = makeNode(alloc, current.name, current.key, current.value, current.priority, retain(current.left), child.root) catch |err| return err;
+            return .{ .root = new_node, .removed = true };
+        },
+    }
+}
+
+pub const Entry = struct {
+    name: ?[]const u8,
+    key: []const u8,
+    value: []const u8,
+};
+
+/// A persistent ordered map. Copying a `Tree` value is *not* a snapshot; use
+/// `snapshot()`/`release()` to manage the shared root's lifetime.
+pub const Tree = struct {
+    root: ?*Node = null,
+    len: usize = 0,
+
+    pub const empty: Tree = .{};
+
+    /// O(1) snapshot: shares the current root, kept alive until `release`.
+    pub fn snapshot(self: Tree) Tree {
+        return .{ .root = retain(self.root), .len = self.len };
+    }
+
+    pub fn release(self: *Tree, alloc: Allocator) void {
+        releaseNode(alloc, self.root);
+        self.* = .{};
+    }
+
+    pub fn count(self: Tree) usize {
+        return self.len;
+    }
+
+    pub fn get(self: Tree, name: ?[]const u8, key: []const u8) ?[]const u8 {
+        var node = self.root;
+        while (node) |present| {
+            node = switch (present.order(name, key)) {
+                .eq => return present.value,
+                .gt => present.left,
+                .lt => present.right,
+            };
+        }
+        return null;
+    }
+
+    /// Returns a new tree with `key` set to `value`, sharing untouched subtrees
+    /// with `self`. `self` remains valid (and must still be released).
+    pub fn put(self: Tree, alloc: Allocator, name: ?[]const u8, key: []const u8, value: []const u8) !Tree {
+        const result = try insert(alloc, self.root, name, key, value, priorityFor(name, key));
+        return .{ .root = result.root, .len = self.len + @intFromBool(result.added) };
+    }
+
+    /// Returns a new tree with `key` removed (or `self` re-shared when absent).
+    pub fn remove(self: Tree, alloc: Allocator, name: ?[]const u8, key: []const u8) !Tree {
+        const result = try removeKey(alloc, self.root, name, key);
+        return .{ .root = result.root, .len = self.len - @intFromBool(result.removed) };
+    }
+};
+
+/// Stack-based in-order cursor over a `Tree` snapshot. The cursor borrows the
+/// tree's nodes, so the snapshot must outlive the cursor.
+pub const Cursor = struct {
+    alloc: Allocator,
+    stack: std.ArrayListUnmanaged(*Node) = .empty,
+    current: ?*Node = null,
+
+    pub fn init(alloc: Allocator) Cursor {
+        return .{ .alloc = alloc };
+    }
+
+    pub fn deinit(self: *Cursor) void {
+        self.stack.deinit(self.alloc);
+        self.* = undefined;
+    }
+
+    fn reset(self: *Cursor) void {
+        self.stack.clearRetainingCapacity();
+        self.current = null;
+    }
+
+    fn pushLeftSpine(self: *Cursor, node: ?*Node) !void {
+        var current = node;
+        while (current) |present| {
+            try self.stack.append(self.alloc, present);
+            current = present.left;
+        }
+    }
+
+    fn pushRightSpine(self: *Cursor, node: ?*Node) !void {
+        var current = node;
+        while (current) |present| {
+            try self.stack.append(self.alloc, present);
+            current = present.right;
+        }
+    }
+
+    pub fn first(self: *Cursor, tree: Tree) !?Entry {
+        self.reset();
+        try self.pushLeftSpine(tree.root);
+        return self.settle();
+    }
+
+    pub fn last(self: *Cursor, tree: Tree) !?Entry {
+        self.reset();
+        try self.pushRightSpine(tree.root);
+        return self.settleReverse();
+    }
+
+    /// Positions at the first entry whose key is >= `(name, key)`.
+    pub fn seekAtOrAfter(self: *Cursor, tree: Tree, name: ?[]const u8, key: []const u8) !?Entry {
+        self.reset();
+        var node = tree.root;
+        while (node) |present| {
+            if (present.order(name, key) != .lt) {
+                try self.stack.append(self.alloc, present);
+                node = present.left;
+            } else {
+                node = present.right;
+            }
+        }
+        return self.settle();
+    }
+
+    /// Positions at the last entry whose key is <= `(name, key)`.
+    pub fn seekAtOrBefore(self: *Cursor, tree: Tree, name: ?[]const u8, key: []const u8) !?Entry {
+        self.reset();
+        var node = tree.root;
+        while (node) |present| {
+            if (present.order(name, key) != .gt) {
+                try self.stack.append(self.alloc, present);
+                node = present.right;
+            } else {
+                node = present.left;
+            }
+        }
+        return self.settleReverse();
+    }
+
+    fn settle(self: *Cursor) ?Entry {
+        if (self.stack.items.len == 0) {
+            self.current = null;
+            return null;
+        }
+        self.current = self.stack.items[self.stack.items.len - 1];
+        return entryOf(self.current.?);
+    }
+
+    fn settleReverse(self: *Cursor) ?Entry {
+        return self.settle();
+    }
+
+    pub fn next(self: *Cursor) !?Entry {
+        const node = self.popCurrent() orelse return null;
+        try self.pushLeftSpine(node.right);
+        return self.settle();
+    }
+
+    pub fn prev(self: *Cursor) !?Entry {
+        const node = self.popCurrent() orelse return null;
+        try self.pushRightSpine(node.left);
+        return self.settle();
+    }
+
+    fn popCurrent(self: *Cursor) ?*Node {
+        if (self.stack.items.len == 0) return null;
+        return self.stack.pop();
+    }
+};
+
+fn entryOf(node: *Node) Entry {
+    return .{ .name = node.name, .key = node.key, .value = node.value };
+}
+
+const testing = std.testing;
+
+fn expectGet(tree: Tree, name: ?[]const u8, key: []const u8, expected: ?[]const u8) !void {
+    const got = tree.get(name, key);
+    if (expected) |want| {
+        try testing.expect(got != null);
+        try testing.expectEqualStrings(want, got.?);
+    } else {
+        try testing.expect(got == null);
+    }
+}
+
+test "put/get/remove and update" {
+    const alloc = testing.allocator;
+    var tree: Tree = .empty;
+    defer tree.release(alloc);
+
+    var next_tree = try tree.put(alloc, null, "b", "2");
+    tree.release(alloc);
+    tree = next_tree;
+    next_tree = try tree.put(alloc, null, "a", "1");
+    tree.release(alloc);
+    tree = next_tree;
+    next_tree = try tree.put(alloc, null, "c", "3");
+    tree.release(alloc);
+    tree = next_tree;
+
+    try testing.expectEqual(@as(usize, 3), tree.count());
+    try expectGet(tree, null, "a", "1");
+    try expectGet(tree, null, "b", "2");
+    try expectGet(tree, null, "c", "3");
+    try expectGet(tree, null, "z", null);
+
+    // Update keeps count and replaces the value.
+    next_tree = try tree.put(alloc, null, "b", "22");
+    tree.release(alloc);
+    tree = next_tree;
+    try testing.expectEqual(@as(usize, 3), tree.count());
+    try expectGet(tree, null, "b", "22");
+
+    next_tree = try tree.remove(alloc, null, "b");
+    tree.release(alloc);
+    tree = next_tree;
+    try testing.expectEqual(@as(usize, 2), tree.count());
+    try expectGet(tree, null, "b", null);
+    try expectGet(tree, null, "a", "1");
+    try expectGet(tree, null, "c", "3");
+}
+
+test "snapshots are isolated from later writes" {
+    const alloc = testing.allocator;
+    var base: Tree = .empty;
+    defer base.release(alloc);
+    {
+        const t = try base.put(alloc, null, "k", "v1");
+        base.release(alloc);
+        base = t;
+    }
+
+    var snap = base.snapshot();
+    defer snap.release(alloc);
+
+    // Mutating forward does not change the retained snapshot.
+    {
+        const t = try base.put(alloc, null, "k", "v2");
+        base.release(alloc);
+        base = t;
+    }
+    try expectGet(snap, null, "k", "v1");
+    try expectGet(base, null, "k", "v2");
+}
+
+test "namespaces order before keys and isolate lookups" {
+    const alloc = testing.allocator;
+    var tree: Tree = .empty;
+    defer tree.release(alloc);
+    const pairs = [_]struct { name: ?[]const u8, key: []const u8 }{
+        .{ .name = null, .key = "z" },
+        .{ .name = "ns1", .key = "a" },
+        .{ .name = "ns2", .key = "a" },
+        .{ .name = "ns1", .key = "b" },
+    };
+    for (pairs) |pair| {
+        const t = try tree.put(alloc, pair.name, pair.key, "x");
+        tree.release(alloc);
+        tree = t;
+    }
+    try expectGet(tree, "ns1", "a", "x");
+    try expectGet(tree, "ns2", "a", "x");
+    try expectGet(tree, "ns1", "a", "x");
+    try expectGet(tree, "nsX", "a", null);
+
+    // In-order iteration: null namespace first, then ns1's keys, then ns2.
+    var cursor = Cursor.init(alloc);
+    defer cursor.deinit();
+    var entry = try cursor.first(tree);
+    var seen: usize = 0;
+    var last_name: ?[]const u8 = null;
+    var last_key: []const u8 = "";
+    while (entry) |present| : (entry = try cursor.next()) {
+        if (seen > 0) {
+            try testing.expect(compareKeys(last_name, last_key, present.name, present.key) == .lt);
+        }
+        last_name = present.name;
+        last_key = present.key;
+        seen += 1;
+    }
+    try testing.expectEqual(@as(usize, 4), seen);
+}
+
+test "cursor seek and ranged forward scan" {
+    const alloc = testing.allocator;
+    var tree: Tree = .empty;
+    defer tree.release(alloc);
+    for (0..50) |i| {
+        var buf: [8]u8 = undefined;
+        const key = std.fmt.bufPrint(&buf, "k{d:0>3}", .{i}) catch unreachable;
+        const t = try tree.put(alloc, null, key, "v");
+        tree.release(alloc);
+        tree = t;
+    }
+    var cursor = Cursor.init(alloc);
+    defer cursor.deinit();
+    var entry = try cursor.seekAtOrAfter(tree, null, "k010");
+    try testing.expect(entry != null);
+    try testing.expectEqualStrings("k010", entry.?.key);
+    var count: usize = 0;
+    while (entry) |present| : (entry = try cursor.next()) {
+        try testing.expect(std.mem.order(u8, "k010", present.key) != .gt);
+        count += 1;
+    }
+    try testing.expectEqual(@as(usize, 40), count);
+
+    // seek past the end yields nothing.
+    try testing.expect((try cursor.seekAtOrAfter(tree, null, "z")) == null);
+}
+
+test "randomized operations match a reference map without leaking" {
+    const alloc = testing.allocator;
+    var reference = std.StringHashMapUnmanaged([]const u8).empty;
+    defer {
+        var it = reference.iterator();
+        while (it.next()) |kv| {
+            alloc.free(kv.key_ptr.*);
+            alloc.free(kv.value_ptr.*);
+        }
+        reference.deinit(alloc);
+    }
+    var tree: Tree = .empty;
+    defer tree.release(alloc);
+
+    var prng = std.Random.DefaultPrng.init(0xC0FFEE);
+    const rand = prng.random();
+    for (0..4000) |_| {
+        var key_buf: [4]u8 = undefined;
+        const key = std.fmt.bufPrint(&key_buf, "{d:0>3}", .{rand.intRangeAtMost(u32, 0, 400)}) catch unreachable;
+        if (rand.boolean()) {
+            var value_buf: [8]u8 = undefined;
+            const value = std.fmt.bufPrint(&value_buf, "v{d}", .{rand.int(u16)}) catch unreachable;
+            const t = try tree.put(alloc, null, key, value);
+            tree.release(alloc);
+            tree = t;
+            const gop = try reference.getOrPut(alloc, key);
+            if (!gop.found_existing) gop.key_ptr.* = try alloc.dupe(u8, key) else alloc.free(gop.value_ptr.*);
+            gop.value_ptr.* = try alloc.dupe(u8, value);
+        } else {
+            const t = try tree.remove(alloc, null, key);
+            tree.release(alloc);
+            tree = t;
+            if (reference.fetchRemove(key)) |kv| {
+                alloc.free(kv.key);
+                alloc.free(kv.value);
+            }
+        }
+    }
+
+    try testing.expectEqual(reference.count(), tree.count());
+    var it = reference.iterator();
+    while (it.next()) |kv| {
+        try expectGet(tree, null, kv.key_ptr.*, kv.value_ptr.*);
+    }
+}
+
+// Regression: node refcounts are shared across snapshots and mutated off any
+// lock — the backend `retain`s shared path nodes during an unlocked write while
+// other threads release their own snapshots of the same nodes. A non-atomic
+// counter loses updates under that interleaving and underflows on the next
+// decrement (the `present.refs -= 1` overflow panic seen in derived-replay
+// worker teardown). With an atomic refcount the snapshot/release churn below is
+// clean; the GeneralPurposeAllocator's leak/double-free checks catch a refcount
+// that drops early. The shared base stays read-only, so no data races on
+// contents — only the counter is contended.
+test "concurrent snapshot retain/release does not corrupt the refcount" {
+    if (@import("builtin").single_threaded) return error.SkipZigTest;
+    const alloc = testing.allocator;
+
+    var base: Tree = .empty;
+    defer base.release(alloc);
+    var key_buf: [4]u8 = undefined;
+    for (0..256) |i| {
+        const key = std.fmt.bufPrint(&key_buf, "{d:0>3}", .{i}) catch unreachable;
+        const t = try base.put(alloc, null, key, "v");
+        base.release(alloc);
+        base = t;
+    }
+
+    const Worker = struct {
+        shared: *const Tree,
+        gpa: Allocator,
+        ok: bool = true,
+
+        fn run(self: *@This()) void {
+            // Each iteration takes an O(1) snapshot (retaining the shared root)
+            // and releases it, racing every other worker on the same nodes'
+            // refcounts. A lost update would either free a still-shared node
+            // (allocator double-free) or wrap the counter (overflow panic).
+            for (0..2000) |_| {
+                var snap = self.shared.snapshot();
+                if (snap.get(null, "128") == null) self.ok = false;
+                snap.release(self.gpa);
+            }
+        }
+    };
+
+    var workers: [8]Worker = undefined;
+    for (&workers) |*w| w.* = .{ .shared = &base, .gpa = alloc };
+    var threads: [8]std.Thread = undefined;
+    for (&threads, &workers) |*t, *w| t.* = try std.Thread.spawn(.{}, Worker.run, .{w});
+    for (&threads) |t| t.join();
+
+    for (&workers) |w| try testing.expect(w.ok);
+    // The base must survive with exactly its original single reference: every
+    // worker snapshot was released, so a corrupted count would have freed nodes
+    // out from under `base` (caught by the allocator on the final release).
+    try expectGet(base, null, "128", "v");
+    try testing.expectEqual(@as(usize, 256), base.count());
+}

--- a/zig/pkg/antfly/src/storage/mem_ordered.zig
+++ b/zig/pkg/antfly/src/storage/mem_ordered.zig
@@ -37,6 +37,9 @@ fn priorityFor(name: ?[]const u8, key: []const u8) u64 {
     var hasher = std.hash.Wyhash.init(priority_seed);
     if (name) |namespace| {
         hasher.update(&.{1});
+        var namespace_len: [8]u8 = undefined;
+        std.mem.writeInt(u64, &namespace_len, @intCast(namespace.len), .little);
+        hasher.update(&namespace_len);
         hasher.update(namespace);
     } else {
         hasher.update(&.{0});
@@ -486,6 +489,11 @@ fn entryOf(node: *Node) Entry {
 }
 
 const testing = std.testing;
+
+test "priority encodes namespace and key boundaries unambiguously" {
+    try testing.expect(priorityFor("a", "bc") != priorityFor("ab", "c"));
+    try testing.expectEqual(priorityFor("a", "bc"), priorityFor("a", "bc"));
+}
 
 fn expectGet(tree: Tree, name: ?[]const u8, key: []const u8, expected: ?[]const u8) !void {
     const got = tree.get(name, key);

--- a/zig/pkg/antfly/src/storage/mem_ordered.zig
+++ b/zig/pkg/antfly/src/storage/mem_ordered.zig
@@ -314,9 +314,13 @@ pub const Tree = struct {
 /// Stack-based in-order cursor over a `Tree` snapshot. The cursor borrows the
 /// tree's nodes, so the snapshot must outlive the cursor.
 pub const Cursor = struct {
+    const Direction = enum { forward, reverse };
+
     alloc: Allocator,
     stack: std.ArrayListUnmanaged(*Node) = .empty,
     current: ?*Node = null,
+    tree: Tree = .empty,
+    direction: ?Direction = null,
 
     pub fn init(alloc: Allocator) Cursor {
         return .{ .alloc = alloc };
@@ -327,9 +331,11 @@ pub const Cursor = struct {
         self.* = undefined;
     }
 
-    fn reset(self: *Cursor) void {
+    fn reset(self: *Cursor, tree: Tree, direction: Direction) void {
         self.stack.clearRetainingCapacity();
         self.current = null;
+        self.tree = tree;
+        self.direction = direction;
     }
 
     fn pushLeftSpine(self: *Cursor, node: ?*Node) !void {
@@ -349,20 +355,20 @@ pub const Cursor = struct {
     }
 
     pub fn first(self: *Cursor, tree: Tree) !?Entry {
-        self.reset();
+        self.reset(tree, .forward);
         try self.pushLeftSpine(tree.root);
         return self.settle();
     }
 
     pub fn last(self: *Cursor, tree: Tree) !?Entry {
-        self.reset();
+        self.reset(tree, .reverse);
         try self.pushRightSpine(tree.root);
         return self.settleReverse();
     }
 
     /// Positions at the first entry whose key is >= `(name, key)`.
     pub fn seekAtOrAfter(self: *Cursor, tree: Tree, name: ?[]const u8, key: []const u8) !?Entry {
-        self.reset();
+        self.reset(tree, .forward);
         var node = tree.root;
         while (node) |present| {
             if (present.order(name, key) != .lt) {
@@ -377,7 +383,7 @@ pub const Cursor = struct {
 
     /// Positions at the last entry whose key is <= `(name, key)`.
     pub fn seekAtOrBefore(self: *Cursor, tree: Tree, name: ?[]const u8, key: []const u8) !?Entry {
-        self.reset();
+        self.reset(tree, .reverse);
         var node = tree.root;
         while (node) |present| {
             if (present.order(name, key) != .gt) {
@@ -404,15 +410,69 @@ pub const Cursor = struct {
     }
 
     pub fn next(self: *Cursor) !?Entry {
+        if (self.direction == .reverse) return try self.switchToForward();
         const node = self.popCurrent() orelse return null;
         try self.pushLeftSpine(node.right);
-        return self.settle();
+        if (self.settle()) |entry| return entry;
+        self.stack.appendAssumeCapacity(node);
+        self.current = node;
+        return null;
     }
 
     pub fn prev(self: *Cursor) !?Entry {
+        if (self.direction == .forward) return try self.switchToReverse();
         const node = self.popCurrent() orelse return null;
         try self.pushRightSpine(node.left);
+        if (self.settleReverse()) |entry| return entry;
+        self.stack.appendAssumeCapacity(node);
+        self.current = node;
+        return null;
+    }
+
+    fn switchToForward(self: *Cursor) !?Entry {
+        const previous = self.current orelse return null;
+        self.stack.clearRetainingCapacity();
+        self.direction = .forward;
+
+        var node = self.tree.root;
+        while (node) |present| {
+            switch (present.order(previous.name, previous.key)) {
+                .gt => {
+                    try self.stack.append(self.alloc, present);
+                    node = present.left;
+                },
+                .eq, .lt => node = present.right,
+            }
+        }
+        if (self.stack.items.len == 0) {
+            self.stack.appendAssumeCapacity(previous);
+            self.current = previous;
+            return null;
+        }
         return self.settle();
+    }
+
+    fn switchToReverse(self: *Cursor) !?Entry {
+        const previous = self.current orelse return null;
+        self.stack.clearRetainingCapacity();
+        self.direction = .reverse;
+
+        var node = self.tree.root;
+        while (node) |present| {
+            switch (present.order(previous.name, previous.key)) {
+                .lt => {
+                    try self.stack.append(self.alloc, present);
+                    node = present.right;
+                },
+                .eq, .gt => node = present.left,
+            }
+        }
+        if (self.stack.items.len == 0) {
+            self.stack.appendAssumeCapacity(previous);
+            self.current = previous;
+            return null;
+        }
+        return self.settleReverse();
     }
 
     fn popCurrent(self: *Cursor) ?*Node {
@@ -560,6 +620,38 @@ test "cursor seek and ranged forward scan" {
 
     // seek past the end yields nothing.
     try testing.expect((try cursor.seekAtOrAfter(tree, null, "z")) == null);
+}
+
+test "cursor direction changes preserve ordered position" {
+    const alloc = testing.allocator;
+    var tree: Tree = .empty;
+    defer tree.release(alloc);
+    for (0..64) |i| {
+        var buf: [8]u8 = undefined;
+        const key = std.fmt.bufPrint(&buf, "k{d:0>3}", .{i}) catch unreachable;
+        const next_tree = try tree.put(alloc, null, key, "v");
+        tree.release(alloc);
+        tree = next_tree;
+    }
+
+    var cursor = Cursor.init(alloc);
+    defer cursor.deinit();
+
+    try testing.expectEqualStrings("k000", (try cursor.first(tree)).?.key);
+    try testing.expect((try cursor.prev()) == null);
+    try testing.expectEqualStrings("k001", (try cursor.next()).?.key);
+
+    try testing.expectEqualStrings("k063", (try cursor.last(tree)).?.key);
+    try testing.expect((try cursor.next()) == null);
+    try testing.expectEqualStrings("k062", (try cursor.prev()).?.key);
+
+    try testing.expectEqualStrings("k000", (try cursor.first(tree)).?.key);
+    try testing.expectEqualStrings("k001", (try cursor.next()).?.key);
+    try testing.expectEqualStrings("k000", (try cursor.prev()).?.key);
+
+    try testing.expectEqualStrings("k063", (try cursor.last(tree)).?.key);
+    try testing.expectEqualStrings("k062", (try cursor.prev()).?.key);
+    try testing.expectEqualStrings("k063", (try cursor.next()).?.key);
 }
 
 test "randomized operations match a reference map without leaking" {

--- a/zig/pkg/antfly/src/storage/test_manifest.zig
+++ b/zig/pkg/antfly/src/storage/test_manifest.zig
@@ -184,6 +184,7 @@ comptime {
     _ = @import("lsm_backend_sim_test.zig");
     _ = @import("maintenance.zig");
     _ = @import("mem_backend.zig");
+    _ = @import("mem_ordered.zig");
     _ = @import("object_storage.zig");
     _ = @import("persistent.zig");
     _ = @import("portable_backup.zig");


### PR DESCRIPTION
## What changed

- replaces copied read snapshots with refcounted persistent ordered-tree snapshots
- keeps ordered replay scans without rebuilding entry arrays
- makes snapshot refcounting atomic for concurrent teardown
- registers the new test-bearing module in the authoritative storage manifest and disjoint CI shard filters

## Why

This PR #141 storage optimization is independent of algebraic HLL and the relational/SQL work accumulated in #145.

## Impact

Memory-backend read snapshots become O(1) to acquire while retaining snapshot isolation and deterministic ordering.

## Validation

- ordered-memory tests — 8/8 passed
- memory-backend tests — 4/4 passed
- backend conformance across memory, LSM, and LMDB — 5/5 passed
- snapshot isolation, randomized reference-map, concurrent retain/release, cursor direction changes, and priority tuple encoding coverage passed
- storage test-shard audit passed
- no leaks; `git diff --check` passed
