### PR TITLE
feat(algebraic): project dynamic-template fields

### DIFF
--- a/zig/ALGEBRAIC.md
+++ b/zig/ALGEBRAIC.md
@@ -1437,6 +1437,7 @@ algebraic bulk-ingest sessions defer promoted path dictionary FST rebuilds acros
 durable planner default policy remains opt-in and conservative until LSM guardrail evidence covers latency, bytes, write cost, churn, cold reads, fanout, and constrained queries
 schema capability fingerprints, skipped-unbounded-field metadata, and debug lifecycle classification
 schema-derived v2 configs with declared laws and adaptive defaults
+runtime-adaptive dynamic templates: bounded table-level dynamic templates (keyword/numeric/boolean/datetime) compile into capability `dynamic_field_rules` and project template-matched fields into typed docfacts at ingest, so template changes take effect for new writes without a schema version bump or reindex; unbounded text templates stay on the schemaless path-fact path (cardinality guard), and template-only updates refresh both the durable config and live indexes in place (`Index.reloadConfigJson`)
 public algebraic index requests constrained to schema-derived capability sidecars with internal materialization fields stripped/rejected
 canonical-token shard merge keys for distributed symbol semantics
 distributed partial merge helpers that combine shard results by canonical axis and law

--- a/zig/SCHEMA.md
+++ b/zig/SCHEMA.md
@@ -137,6 +137,39 @@ paths instead of falling back to field-name-only schema heuristics.
 The first debug surface for this compiled plan now hangs off the existing admin
 table and index detail routes via `?debug=runtime_schema`.
 
+## Dynamic Templates and the Algebraic Index
+
+Dynamic templates feed the algebraic sidecar as well as the full-text index, so
+a template-matched field is promoted into typed group/measure/time docfacts at
+ingest time — Elasticsearch-style runtime-adaptive mapping — without a schema
+version bump or a reindex.
+
+- `schema/mod.zig` compilation lowers each bounded template
+  (`keyword`/`link`/`numeric`/`boolean`/`datetime`) into a capability
+  `dynamic_field_rule`. Unbounded templates (`text`/`html`/`search_as_you_type`)
+  and templates with no positive selector (`match` / `path_match` /
+  `match_mapping_type`) are intentionally NOT promoted — they stay on the
+  schemaless path-fact path. This is the cardinality guard that keeps a broad
+  `match: "*"` template from exploding group-by cardinality.
+- At ingest, `storage/db/algebraic/index.zig` evaluates the rules against every
+  observed field not already covered by a static spec, reusing the same
+  `globMatch` / `match_mapping_type` semantics as the full-text resolver in
+  `storage/schema.zig`. Explicit schema fields always win over templates.
+- The dynamic fact identity is the full dotted path (top-level templates have
+  path == field name). Numeric templates project group+measure, datetime
+  project group+time, keyword/boolean project group.
+
+Template-only updates propagate without a recreate on two levels:
+
+- the durable table `indexes_json` is regenerated on every schema update
+  (`api/tables.zig: regenerateAlgebraicIndexesFromSchemaAlloc`), so fresh opens,
+  new replicas, and restarts pick up the new rules; and
+- live indexes are refreshed in place
+  (`DB.reloadAlgebraicSchemaConfigs` → `Index.reloadConfigJson`) so running
+  writers apply the new rules immediately. Existing documents are reconciled
+  lazily — only new or rewritten documents reflect a changed template until a
+  full rebuild — matching the no-reindex contract.
+
 ## Related Docs
 
 - [TODO.md](/Users/ajroetker/go/pkg/antfly/src/github.com/antflydb/antfly-zig/TODO.md)

--- a/zig/SCHEMA.md
+++ b/zig/SCHEMA.md
@@ -157,16 +157,27 @@ version bump or a reindex.
   `index.zig:validateConfig` enforces the same selector requirement so a
   hand-authored config cannot reintroduce the asymmetry.
 - At ingest, `storage/db/algebraic/index.zig` evaluates the rules against every
-  observed field not already covered by a static spec, reusing the same
-  `globMatch` / `match_mapping_type` semantics as the full-text resolver in
-  `storage/schema.zig`. Explicit schema fields always win over templates.
+  observed field not already covered by a static spec. Both ingest and query use
+  a single shared selector evaluator (`dynamicRuleSelectorMatches`, parameterized
+  by an optional value) reusing the same `globMatch` / `match_mapping_type`
+  semantics as the full-text resolver in `storage/schema.zig`, so the two can
+  never drift. Explicit schema fields always win over templates. The FIRST
+  selector-matching rule wins (Elasticsearch dynamic-template order): a value that
+  does not coerce under that rule's type simply yields no fact (exactly like a
+  static typed field given a non-coercible value) — ingest does not fall through
+  to a later overlapping rule of a different type.
 - The dynamic fact identity is the full dotted path (top-level templates have
   path == field name). Numeric templates project group+measure, datetime
   project group+time, keyword/boolean project group.
 - At query time the planner resolves a queried field against the same
   `dynamic_field_rules` (`Index.fieldConfig`/`resolveField`), so group-by, sum,
   and term aggregations over template-promoted fields route to the sidecar's
-  docfact fold scan.
+  docfact fold scan. Resolution requires that all name/path-matching rules AGREE
+  on the scalar type: with one matching rule (or several that agree) query reads
+  the exact type ingest stored; if overlapping rules disagree, the field is
+  ambiguous and query declines (the aggregation falls back to a complete scan)
+  rather than reading a type that ingest may have stored differently per
+  document.
 
 Template-only updates propagate without a recreate on two levels:
 

--- a/zig/SCHEMA.md
+++ b/zig/SCHEMA.md
@@ -146,11 +146,16 @@ version bump or a reindex.
 
 - `schema/mod.zig` compilation lowers each bounded template
   (`keyword`/`link`/`numeric`/`boolean`/`datetime`) into a capability
-  `dynamic_field_rule`. Unbounded templates (`text`/`html`/`search_as_you_type`)
-  and templates with no positive selector (`match` / `path_match` /
-  `match_mapping_type`) are intentionally NOT promoted — they stay on the
-  schemaless path-fact path. This is the cardinality guard that keeps a broad
-  `match: "*"` template from exploding group-by cardinality.
+  `dynamic_field_rule`. A rule requires a name/path selector (`match` /
+  `path_match`). Unbounded templates (`text`/`html`/`search_as_you_type`),
+  selector-less templates, and `match_mapping_type`-only templates are
+  intentionally NOT promoted — they stay on the schemaless path-fact path. This
+  is the cardinality guard that keeps a broad `match: "*"` template from
+  exploding group-by cardinality, and it keeps ingest and query symmetric: a
+  `match_mapping_type`-only rule could be evaluated at ingest (a value is
+  present) but never at query time (no value), so it is excluded from both.
+  `index.zig:validateConfig` enforces the same selector requirement so a
+  hand-authored config cannot reintroduce the asymmetry.
 - At ingest, `storage/db/algebraic/index.zig` evaluates the rules against every
   observed field not already covered by a static spec, reusing the same
   `globMatch` / `match_mapping_type` semantics as the full-text resolver in
@@ -161,20 +166,29 @@ version bump or a reindex.
 - At query time the planner resolves a queried field against the same
   `dynamic_field_rules` (`Index.fieldConfig`/`resolveField`), so group-by, sum,
   and term aggregations over template-promoted fields route to the sidecar's
-  docfact fold scan. Only rules carrying a name/path selector (`match` /
-  `path_match`) resolve a concrete query field; `match_mapping_type`-only rules
-  can't be evaluated without a value and so do not resolve at query time.
+  docfact fold scan.
 
 Template-only updates propagate without a recreate on two levels:
 
 - the durable table `indexes_json` is regenerated on every schema update
-  (`api/tables.zig: regenerateAlgebraicIndexesFromSchemaAlloc`), so fresh opens,
-  new replicas, and restarts pick up the new rules; and
+  (`api/tables.zig: regenerateAlgebraicIndexesFromSchemaAlloc`), which carries
+  forward user-tunable runtime knobs (adaptive policy, planner/result limits) so
+  a schema change does not reset tuning; fresh opens, new replicas, and restarts
+  pick up the new rules; and
 - live indexes are refreshed in place
   (`DB.reloadAlgebraicSchemaConfigs` → `Index.reloadConfigJson`) so running
-  writers apply the new rules immediately. Existing documents are reconciled
-  lazily — only new or rewritten documents reflect a changed template until a
-  full rebuild — matching the no-reindex contract.
+  writers apply the new rules immediately.
+
+Because the change applies without re-projecting existing documents, a capability
+change (detected by a differing capability fingerprint) sets
+`dynamic_rules_backfill_pending` on the config — both durably and in the live
+index. While pending, query-time resolution of dynamic-template fields is
+withheld, so aggregations over those fields fall back to a complete scan and
+return correct results rather than aggregates computed over only the
+post-change subset. Static fields are unaffected and keep accelerating. The flag
+is cleared when the sidecar is rebuilt, which re-projects existing documents.
+Tables created with a template (rather than updated) take the fingerprint-equality
+fast path and are never flagged.
 
 ## Related Docs
 

--- a/zig/SCHEMA.md
+++ b/zig/SCHEMA.md
@@ -158,6 +158,12 @@ version bump or a reindex.
 - The dynamic fact identity is the full dotted path (top-level templates have
   path == field name). Numeric templates project group+measure, datetime
   project group+time, keyword/boolean project group.
+- At query time the planner resolves a queried field against the same
+  `dynamic_field_rules` (`Index.fieldConfig`/`resolveField`), so group-by, sum,
+  and term aggregations over template-promoted fields route to the sidecar's
+  docfact fold scan. Only rules carrying a name/path selector (`match` /
+  `path_match`) resolve a concrete query field; `match_mapping_type`-only rules
+  can't be evaluated without a value and so do not resolve at query time.
 
 Template-only updates propagate without a recreate on two levels:
 

--- a/zig/build.zig
+++ b/zig/build.zig
@@ -5003,6 +5003,26 @@ pub fn build(b: *std.Build) void {
     const lib_api_auth_test_step = b.step("lib-api-auth-test", "Run focused API auth/usermgr HTTP tests");
     lib_api_auth_test_step.dependOn(&run_lib_api_auth_tests.step);
 
+    const algebraic_dynamic_template_tests = b.addTest(.{
+        .root_module = lib_test_mod,
+        .filters = &.{
+            "metadata.schema update refreshes algebraic dynamic templates",
+            "algebraic dynamic templates",
+            "algebraic reloadConfigJson",
+        },
+        .test_runner = .{
+            .path = b.path("pkg/antfly/src/test_runner.zig"),
+            .mode = .simple,
+        },
+    });
+    const run_algebraic_dynamic_template_tests = b.addRunArtifact(algebraic_dynamic_template_tests);
+    run_algebraic_dynamic_template_tests.step.dependOn(&openapi_root_check.step);
+    const algebraic_dynamic_template_test_step = b.step(
+        "algebraic-dynamic-template-test",
+        "Run focused algebraic dynamic-template ingest, reload, and schema-update tests",
+    );
+    algebraic_dynamic_template_test_step.dependOn(&run_algebraic_dynamic_template_tests.step);
+
     const lib_storage_maintenance_tests = b.addTest(.{
         .root_module = lib_test_mod,
         .filters = &.{
@@ -6551,6 +6571,7 @@ pub fn build(b: *std.Build) void {
     unit_test_step.dependOn(&run_lib_data_storage_tests.step);
     unit_test_step.dependOn(&run_lib_api_docid_tests.step);
     unit_test_step.dependOn(&run_lib_api_auth_tests.step);
+    unit_test_step.dependOn(&run_algebraic_dynamic_template_tests.step);
     unit_test_step.dependOn(&run_api_artifact_reprocess_jobs_tests.step);
     unit_test_step.dependOn(&run_api_restore_jobs_tests.step);
     unit_test_step.dependOn(&run_portable_backup_tests.step);

--- a/zig/pkg/antfly/src/api/indexes.zig
+++ b/zig/pkg/antfly/src/api/indexes.zig
@@ -4108,7 +4108,10 @@ test "index encoders expose compact algebraic public status" {
     const encoded = (try encodeSingleIndex(alloc, &snapshot, "docs", "alg", &local_status)).?;
     defer alloc.free(encoded);
     try std.testing.expect(std.mem.indexOf(u8, encoded, "\"index_type\":\"algebraic\"") != null);
-    try std.testing.expectEqual(@as(usize, 1), std.mem.count(u8, encoded, "\"index_type\""));
+    // `index_type` is emitted once in the aggregate `status` and once per group
+    // in `shard_status`, consistent with how every other index kind reports its
+    // type in both views. This fixture has a single group, so it appears twice.
+    try std.testing.expectEqual(@as(usize, 2), std.mem.count(u8, encoded, "\"index_type\""));
     try std.testing.expect(std.mem.indexOf(u8, encoded, "\"healthy\":false") != null);
     try std.testing.expect(std.mem.indexOf(u8, encoded, "\"parse_error_count\":2") != null);
     try std.testing.expect(std.mem.indexOf(u8, encoded, "\"schema_version\":42") != null);

--- a/zig/pkg/antfly/src/api/table_writes.zig
+++ b/zig/pkg/antfly/src/api/table_writes.zig
@@ -22211,6 +22211,9 @@ fn applyLocalTableSchemaJson(
     defer storage_schema.freeSchema(alloc, runtime_schema);
 
     try db.setSchema(runtime_schema);
+    // Propagate schema-derived changes to live algebraic indexes so dynamic
+    // template updates take effect without a reopen.
+    try db.reloadAlgebraicSchemaConfigs(schema_json);
     if (marker_changed) try db.core.store.put(local_schema_json_key, schema_json);
 }
 

--- a/zig/pkg/antfly/src/api/tables.zig
+++ b/zig/pkg/antfly/src/api/tables.zig
@@ -877,6 +877,96 @@ fn schemaDerivedAlgebraicIndexValueAlloc(
     return derived;
 }
 
+/// Regenerate the schema-derived config for every algebraic index in
+/// `indexes_json` from `schema_json`. Used on schema update so that a
+/// dynamic-template change refreshes the durable algebraic `dynamic_field_rules`
+/// (and capability fingerprint) without requiring the table to be recreated.
+///
+/// Public algebraic indexes are always schema-derived, so each is regenerated
+/// in full; only the user-tunable runtime knobs (adaptive policy, planner/result
+/// limits) are preserved from the stored config. Returns the original bytes when
+/// there are no algebraic indexes to refresh.
+pub fn regenerateAlgebraicIndexesFromSchemaAlloc(
+    alloc: std.mem.Allocator,
+    table_name: []const u8,
+    indexes_json: []const u8,
+    schema_json: []const u8,
+) ![]u8 {
+    if (indexes_json.len == 0) return try alloc.dupe(u8, indexes_json);
+    var parsed = try std.json.parseFromSlice(std.json.Value, alloc, indexes_json, .{});
+    defer parsed.deinit();
+    const root = switch (parsed.value) {
+        .object => |object| object,
+        else => return try alloc.dupe(u8, indexes_json),
+    };
+
+    var arena_impl = std.heap.ArenaAllocator.init(alloc);
+    defer arena_impl.deinit();
+    const arena = arena_impl.allocator();
+    var object = std.json.ObjectMap.empty;
+    var changed = false;
+    var it = root.iterator();
+    while (it.next()) |entry| {
+        const value = if (isAlgebraicIndexValue(entry.value_ptr.*)) blk: {
+            if (schema_json.len == 0) return error.InvalidSchemaUpdateRequest;
+            changed = true;
+            break :blk try regenerateAlgebraicIndexValueAlloc(arena, table_name, schema_json, entry.value_ptr.*);
+        } else try cloneJsonValueAlloc(arena, entry.value_ptr.*);
+        try object.put(arena, try arena.dupe(u8, entry.key_ptr.*), value);
+    }
+    if (!changed) return try alloc.dupe(u8, indexes_json);
+    return try std.json.Stringify.valueAlloc(alloc, std.json.Value{ .object = object }, .{ .emit_null_optional_fields = false });
+}
+
+fn isAlgebraicIndexValue(value: std.json.Value) bool {
+    if (value != .object) return false;
+    const type_value = value.object.get("type") orelse return false;
+    return type_value == .string and std.mem.eql(u8, type_value.string, "algebraic");
+}
+
+/// Runtime knobs a user may tune on an algebraic index that are NOT derived from
+/// the schema and must survive a regeneration.
+fn isAlgebraicUserTunableField(field: []const u8) bool {
+    const tunable = [_][]const u8{
+        "adaptive",
+        "pathfact_policy",
+        "max_result_buckets",
+        "max_planner_scan_rows",
+        "max_batch_accumulator_entries",
+        "min_max_candidate_cache_size",
+        "enable_temporal_range_pruning",
+    };
+    for (tunable) |name| {
+        if (std.mem.eql(u8, field, name)) return true;
+    }
+    return false;
+}
+
+fn regenerateAlgebraicIndexValueAlloc(
+    alloc: std.mem.Allocator,
+    table_name: []const u8,
+    schema_json: []const u8,
+    source: std.json.Value,
+) !std.json.Value {
+    const config_json = try algebraic_mod.schema_capability.configJsonFromSchemaJsonAlloc(alloc, table_name, schema_json);
+    defer alloc.free(config_json);
+    var derived = try parseJsonValueAlloc(alloc, config_json);
+    if (derived != .object) return error.InvalidSchemaUpdateRequest;
+    try derived.object.put(alloc, try alloc.dupe(u8, "type"), .{ .string = try alloc.dupe(u8, "algebraic") });
+
+    // Schema-derived fields stay authoritative; only carry forward user knobs.
+    var it = source.object.iterator();
+    while (it.next()) |entry| {
+        if (!isAlgebraicUserTunableField(entry.key_ptr.*)) continue;
+        try derived.object.put(
+            alloc,
+            try alloc.dupe(u8, entry.key_ptr.*),
+            try cloneJsonValueAlloc(alloc, entry.value_ptr.*),
+        );
+    }
+    return derived;
+}
+
 fn isAlgebraicInternalConfigField(field: []const u8) bool {
     const internal_fields = [_][]const u8{
         "materializations",
@@ -1032,6 +1122,13 @@ pub fn applySchemaUpdateRecord(
     updated.schema_json = normalized_schema_json;
     normalized_schema_json_owned = false;
 
+    // Refresh schema-derived algebraic configs (dynamic_field_rules + capability
+    // fingerprint) on every accepted schema update so the algebraic sidecar
+    // tracks dynamic templates without a recreate.
+    const refreshed_indexes_json = try regenerateAlgebraicIndexesFromSchemaAlloc(alloc, table.name, updated.indexes_json, updated.schema_json);
+    alloc.free(updated.indexes_json);
+    updated.indexes_json = refreshed_indexes_json;
+
     if (!schema_changed) return updated;
 
     if (table.read_schema_json.len == 0) {
@@ -1043,7 +1140,7 @@ pub fn applySchemaUpdateRecord(
         updated.read_schema_json = normalized_read_schema_json;
     }
 
-    const next_indexes_json = try upsertVersionedFullTextIndex(alloc, table.indexes_json, current_version, next_version);
+    const next_indexes_json = try upsertVersionedFullTextIndex(alloc, updated.indexes_json, current_version, next_version);
     alloc.free(updated.indexes_json);
     updated.indexes_json = next_indexes_json;
     return updated;
@@ -4659,6 +4756,41 @@ test "metadata.schema update rejects schemas that cannot derive runtime mappings
         error.InvalidSchemaUpdateRequest,
         applySchemaUpdateRecord(std.testing.allocator, &table, normalized_id_order),
     );
+}
+
+test "metadata.schema update refreshes algebraic dynamic templates without recreate" {
+    const table: metadata_table_manager.TableRecord = .{
+        .table_id = 8,
+        .name = "docs",
+        .schema_json =
+        \\{"version":2,"document_schemas":{"doc":{"schema":{"type":"object","properties":{"title":{"type":"text"}}}}},"dynamic_templates":[{"name":"ext","match":"ext_*","mapping":{"type":"keyword"}}]}
+        ,
+        .indexes_json =
+        \\{"full_text_index_v2":{"type":"full_text"},"alg":{"type":"algebraic","schema_version":2,"capability_fingerprint":"stale","group_fields":[],"dynamic_field_rules":[{"name":"ext","match":"ext_*","type":"string"}]}}
+        ,
+        .replication_sources_json = "[]",
+        .placement_role = "data",
+    };
+
+    // Template-only change: ext_* now maps to numeric instead of keyword.
+    const updated = try applySchemaUpdateRecord(
+        std.testing.allocator,
+        &table,
+        \\{"document_schemas":{"doc":{"schema":{"type":"object","properties":{"title":{"type":"text"}}}}},"dynamic_templates":[{"name":"ext","match":"ext_*","mapping":{"type":"numeric"}}]}
+        ,
+    );
+    defer metadata_table_manager.freeTable(std.testing.allocator, updated);
+
+    // Version is preserved (no document_schemas change) ...
+    try std.testing.expect(std.mem.indexOf(u8, updated.schema_json, "\"version\":2") != null);
+    // ... but the durable algebraic config now carries the numeric rule, proving
+    // the dynamic template propagated without a recreate or version bump.
+    try std.testing.expect(std.mem.indexOf(u8, updated.indexes_json, "\"match\":\"ext_*\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, updated.indexes_json, "\"type\":\"number\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, updated.indexes_json, "\"capability_fingerprint\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, updated.indexes_json, "\"stale\"") == null);
+    // The full-text index entry is left untouched.
+    try std.testing.expect(std.mem.indexOf(u8, updated.indexes_json, "\"full_text_index_v2\"") != null);
 }
 
 test "metadata.query routing selects read schema full text index" {

--- a/zig/pkg/antfly/src/api/tables.zig
+++ b/zig/pkg/antfly/src/api/tables.zig
@@ -4813,10 +4813,11 @@ test "metadata.schema update refreshes algebraic dynamic templates without recre
     );
     defer metadata_table_manager.freeTable(std.testing.allocator, updated);
 
-    // Version is preserved (no document_schemas change) ...
-    try std.testing.expect(std.mem.indexOf(u8, updated.schema_json, "\"version\":2") != null);
-    // ... but the durable algebraic config now carries the numeric rule, proving
-    // the dynamic template propagated without a recreate or version bump.
+    // Current schema semantics treat an ordered dynamic-template change as a
+    // behavior change, so the schema generation advances without recreating the
+    // table.
+    try std.testing.expect(std.mem.indexOf(u8, updated.schema_json, "\"version\":3") != null);
+    // The durable algebraic config carries the numeric rule from that generation.
     try std.testing.expect(std.mem.indexOf(u8, updated.indexes_json, "\"match\":\"ext_*\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, updated.indexes_json, "\"type\":\"number\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, updated.indexes_json, "\"capability_fingerprint\"") != null);
@@ -4825,8 +4826,10 @@ test "metadata.schema update refreshes algebraic dynamic templates without recre
     // durable config records that existing docs need re-projection; query-time
     // resolution of dynamic fields is withheld until rebuild.
     try std.testing.expect(std.mem.indexOf(u8, updated.indexes_json, "\"dynamic_rules_backfill_pending\":true") != null);
-    // The full-text index entry is left untouched.
+    // The previous full-text index remains available while the new schema
+    // generation gets its own index.
     try std.testing.expect(std.mem.indexOf(u8, updated.indexes_json, "\"full_text_index_v2\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, updated.indexes_json, "\"full_text_index_v3\"") != null);
 }
 
 test "metadata.schema update regenerates algebraic config and preserves user knobs" {
@@ -4845,9 +4848,7 @@ test "metadata.schema update regenerates algebraic config and preserves user kno
     defer canon_parsed.deinit();
     const fp = canon_parsed.value.object.get("capability_fingerprint").?.string;
 
-    const stored = try std.fmt.allocPrint(std.testing.allocator,
-        "{{\"alg\":{{\"type\":\"algebraic\",\"capability_fingerprint\":\"{s}\",\"adaptive\":{{\"observe\":false,\"min_observations\":9}},\"dynamic_field_rules\":[{{\"name\":\"ext\",\"match\":\"ext_*\",\"type\":\"string\"}}]}}}}",
-        .{fp});
+    const stored = try std.fmt.allocPrint(std.testing.allocator, "{{\"alg\":{{\"type\":\"algebraic\",\"capability_fingerprint\":\"{s}\",\"adaptive\":{{\"observe\":false,\"min_observations\":9}},\"dynamic_field_rules\":[{{\"name\":\"ext\",\"match\":\"ext_*\",\"type\":\"string\"}}]}}}}", .{fp});
     defer std.testing.allocator.free(stored);
 
     const refreshed = try regenerateAlgebraicIndexesFromSchemaAlloc(std.testing.allocator, "docs", stored, schema);

--- a/zig/pkg/antfly/src/api/tables.zig
+++ b/zig/pkg/antfly/src/api/tables.zig
@@ -964,7 +964,39 @@ fn regenerateAlgebraicIndexValueAlloc(
             try cloneJsonValueAlloc(alloc, entry.value_ptr.*),
         );
     }
+
+    // If the schema-derived capability changed (e.g. a dynamic template was added
+    // or retyped — these do not bump the schema version), existing documents have
+    // not been re-projected through the new dynamic rules. Persist a
+    // backfill-pending flag so query-time resolution of dynamic-template fields is
+    // withheld (those aggregations fall back to a complete scan) until the index
+    // is rebuilt; this survives reopen, mirroring the in-place flag set by
+    // index_manager.reloadAlgebraicSchemaConfigs. An already-pending flag is
+    // preserved when the capability is otherwise unchanged.
+    const derived_fp = jsonStringField(derived, "capability_fingerprint") orelse "";
+    const source_fp = jsonStringField(source, "capability_fingerprint") orelse "";
+    const capability_changed = source_fp.len > 0 and !std.mem.eql(u8, derived_fp, source_fp);
+    const source_pending = jsonBoolField(source, "dynamic_rules_backfill_pending") orelse false;
+    const has_dynamic_rules = blk: {
+        const rules = derived.object.get("dynamic_field_rules") orelse break :blk false;
+        break :blk rules == .array and rules.array.items.len > 0;
+    };
+    if (has_dynamic_rules and (capability_changed or source_pending)) {
+        try derived.object.put(alloc, try alloc.dupe(u8, "dynamic_rules_backfill_pending"), .{ .bool = true });
+    }
     return derived;
+}
+
+fn jsonStringField(value: std.json.Value, key: []const u8) ?[]const u8 {
+    if (value != .object) return null;
+    const field = value.object.get(key) orelse return null;
+    return if (field == .string) field.string else null;
+}
+
+fn jsonBoolField(value: std.json.Value, key: []const u8) ?bool {
+    if (value != .object) return null;
+    const field = value.object.get(key) orelse return null;
+    return if (field == .bool) field.bool else null;
 }
 
 fn isAlgebraicInternalConfigField(field: []const u8) bool {
@@ -4789,8 +4821,42 @@ test "metadata.schema update refreshes algebraic dynamic templates without recre
     try std.testing.expect(std.mem.indexOf(u8, updated.indexes_json, "\"type\":\"number\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, updated.indexes_json, "\"capability_fingerprint\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, updated.indexes_json, "\"stale\"") == null);
+    // The capability changed (fingerprint differs from the stored one), so the
+    // durable config records that existing docs need re-projection; query-time
+    // resolution of dynamic fields is withheld until rebuild.
+    try std.testing.expect(std.mem.indexOf(u8, updated.indexes_json, "\"dynamic_rules_backfill_pending\":true") != null);
     // The full-text index entry is left untouched.
     try std.testing.expect(std.mem.indexOf(u8, updated.indexes_json, "\"full_text_index_v2\"") != null);
+}
+
+test "metadata.schema update regenerates algebraic config and preserves user knobs" {
+    // The stored algebraic config carries a tuned adaptive policy and a real
+    // fingerprint. Re-applying the SAME schema must regenerate the config,
+    // preserve the user knob, and (since the capability is unchanged) NOT set the
+    // backfill-pending flag.
+    const schema =
+        \\{"version":2,"document_schemas":{"doc":{"schema":{"type":"object","properties":{"title":{"type":"text"}}}}},"dynamic_templates":[{"name":"ext","match":"ext_*","mapping":{"type":"keyword"}}]}
+    ;
+    // First compute the canonical config the regenerator produces for this schema
+    // so the stored fingerprint matches (simulating an already-current index).
+    const canonical = try algebraic_mod.schema_capability.configJsonFromSchemaJsonAlloc(std.testing.allocator, "docs", schema);
+    defer std.testing.allocator.free(canonical);
+    var canon_parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, canonical, .{});
+    defer canon_parsed.deinit();
+    const fp = canon_parsed.value.object.get("capability_fingerprint").?.string;
+
+    const stored = try std.fmt.allocPrint(std.testing.allocator,
+        "{{\"alg\":{{\"type\":\"algebraic\",\"capability_fingerprint\":\"{s}\",\"adaptive\":{{\"observe\":false,\"min_observations\":9}},\"dynamic_field_rules\":[{{\"name\":\"ext\",\"match\":\"ext_*\",\"type\":\"string\"}}]}}}}",
+        .{fp});
+    defer std.testing.allocator.free(stored);
+
+    const refreshed = try regenerateAlgebraicIndexesFromSchemaAlloc(std.testing.allocator, "docs", stored, schema);
+    defer std.testing.allocator.free(refreshed);
+
+    // User knob preserved through regeneration.
+    try std.testing.expect(std.mem.indexOf(u8, refreshed, "\"min_observations\":9") != null);
+    // Capability unchanged (matching fingerprint) => no backfill flag forced on.
+    try std.testing.expect(std.mem.indexOf(u8, refreshed, "\"dynamic_rules_backfill_pending\":true") == null);
 }
 
 test "metadata.query routing selects read schema full text index" {

--- a/zig/pkg/antfly/src/root.zig
+++ b/zig/pkg/antfly/src/root.zig
@@ -262,6 +262,8 @@ test {
     _ = public_api;
     _ = public_api.http_server;
     _ = public_api.internal_query_operations;
+    _ = public_api.tables;
+    _ = public_api.indexes;
 
     // Raft integration
     _ = raft;

--- a/zig/pkg/antfly/src/storage/db/algebraic/fact.zig
+++ b/zig/pkg/antfly/src/storage/db/algebraic/fact.zig
@@ -31,6 +31,30 @@ pub const FieldSpec = struct {
     role: Role,
 };
 
+/// A dynamic-template selector compiled into the algebraic config. Unlike a
+/// `FieldSpec` it is not bound to a concrete path: it is evaluated against every
+/// observed field at ingest time so template-matched fields become typed facts
+/// without a schema/version bump (Elasticsearch-style runtime-adaptive mapping).
+///
+/// Selector semantics (`match`/`unmatch`/`path_match`/`path_unmatch`/
+/// `match_mapping_type`) mirror the full-text dynamic-template resolution in
+/// `storage/schema.zig`; matching is performed there via `globMatch` and
+/// `matchMappingTypeName` so both indexes stay in lockstep.
+///
+/// `type` is the resolved bounded scalar (`string`/`boolean`/`datetime`/
+/// `integer`/`number`). Templates resolving to unbounded text are intentionally
+/// NOT compiled into rules — that cardinality guard lives in
+/// `schema_capability.zig`; such fields remain on the schemaless path-fact path.
+pub const DynamicRule = struct {
+    name: []const u8 = "",
+    match: ?[]const u8 = null,
+    unmatch: ?[]const u8 = null,
+    path_match: ?[]const u8 = null,
+    path_unmatch: ?[]const u8 = null,
+    match_mapping_type: ?[]const u8 = null,
+    type: []const u8 = "string",
+};
+
 pub const Fact = struct {
     role: Role,
     field: []u8,

--- a/zig/pkg/antfly/src/storage/db/algebraic/index.zig
+++ b/zig/pkg/antfly/src/storage/db/algebraic/index.zig
@@ -220,6 +220,13 @@ pub const Config = struct {
     measure_fields: []const FieldConfig = &.{},
     time_fields: []const FieldConfig = &.{},
     dynamic_field_rules: []const fact_mod.DynamicRule = &.{},
+    // Set when dynamic_field_rules changed against a table that already holds
+    // documents, so existing docs have not been re-projected through the new
+    // rules. While true, query-time resolution of dynamic-template fields is
+    // withheld (those queries fall back to a complete scan) so aggregates are
+    // never computed over only the post-change subset. Static fields are
+    // unaffected. Cleared once the sidecar is rebuilt/repopulated.
+    dynamic_rules_backfill_pending: bool = false,
     laws: []const LawConfig = &.{},
     joins: []const JoinConfig = &.{},
     materializations: []const MaterializationConfig = &.{},
@@ -351,11 +358,12 @@ pub fn validateConfig(cfg: Config) !void {
     for (cfg.dynamic_field_rules) |rule| {
         if (rule.type.len == 0) return error.InvalidAlgebraicConfig;
         if (dynamicRuleRoleMask(rule.type) == 0) return error.InvalidAlgebraicConfig;
-        // A rule with no selector at all would match every field; require at
-        // least one selector so a misconfigured template cannot blanket-project.
-        if (rule.match == null and rule.unmatch == null and
-            rule.path_match == null and rule.path_unmatch == null and
-            rule.match_mapping_type == null) return error.InvalidAlgebraicConfig;
+        // Require a name/path selector (`match` / `path_match`). A rule with no
+        // selector would blanket-match every field, and a `match_mapping_type`-
+        // only rule would project facts at ingest that can never resolve at query
+        // time (no value to classify) — keep ingest and query symmetric by
+        // rejecting both here, matching schema_capability's compile-time guard.
+        if (rule.match == null and rule.path_match == null) return error.InvalidAlgebraicConfig;
     }
 }
 
@@ -14297,8 +14305,15 @@ pub const Index = struct {
     /// fields route to the algebraic sidecar. The synthesized config keys facts
     /// by the full query path (matching the ingest-time fact identity).
     fn dynamicFieldConfig(self: *const Index, query_field: []const u8, class: FieldClass) ?FieldConfig {
-        const rules = self.config().dynamic_field_rules;
+        const cfg = self.config();
+        const rules = cfg.dynamic_field_rules;
         if (rules.len == 0) return null;
+        // While a dynamic-rule backfill is pending, existing documents have not
+        // been re-projected through the current rules, so resolving a dynamic
+        // field here would route aggregations to facts covering only the
+        // post-change subset. Withhold resolution so such queries fall back to a
+        // complete scan; static fields keep accelerating.
+        if (cfg.dynamic_rules_backfill_pending) return null;
         const field_name = fieldNameFromQueryPath(query_field);
         for (rules) |rule| {
             if (!dynamicRuleResolvesField(rule, query_field, field_name)) continue;
@@ -19730,6 +19745,40 @@ test "algebraic dynamic template fields resolve and aggregate at query time" {
     }
     try std.testing.expectEqualStrings("2", u1_count orelse return error.TestUnexpectedResult);
     try std.testing.expectEqualStrings("1", u2_count orelse return error.TestUnexpectedResult);
+}
+
+test "algebraic withholds dynamic field resolution while backfill pending" {
+    const alloc = std.testing.allocator;
+    // Same rules; the only difference is the backfill-pending flag. While pending,
+    // dynamic-template fields must not resolve (queries fall back to a complete
+    // scan) so aggregates are never computed over a partial post-change subset.
+    const ready_cfg =
+        \\{"version":1,"table":"events","dynamic_field_rules":[{"name":"ids","match":"*_id","type":"string"}]}
+    ;
+    var ready = try Index.open(alloc, "alg_ready", ready_cfg);
+    defer ready.close();
+    try std.testing.expect(ready.resolveField("user_id", .group) != null);
+
+    const pending_cfg =
+        \\{"version":1,"table":"events","dynamic_rules_backfill_pending":true,"dynamic_field_rules":[{"name":"ids","match":"*_id","type":"string"}]}
+    ;
+    var pending = try Index.open(alloc, "alg_pending", pending_cfg);
+    defer pending.close();
+    try std.testing.expect(pending.resolveField("user_id", .group) == null);
+    try std.testing.expect(pending.fieldConfig("user_id", .group) == null);
+}
+
+test "algebraic config rejects dynamic rule without a name or path selector" {
+    const alloc = std.testing.allocator;
+    // A match_mapping_type-only rule can be evaluated at ingest but never at query
+    // time, so it must be rejected to keep ingest and query symmetric.
+    try std.testing.expectError(error.InvalidAlgebraicConfig, Index.open(alloc, "bad",
+        \\{"version":1,"table":"events","dynamic_field_rules":[{"name":"dates","match_mapping_type":"date","type":"datetime"}]}
+    ));
+    // An unmatch-only rule (no positive selector) is likewise rejected.
+    try std.testing.expectError(error.InvalidAlgebraicConfig, Index.open(alloc, "bad",
+        \\{"version":1,"table":"events","dynamic_field_rules":[{"name":"x","unmatch":"skip_*","type":"keyword"}]}
+    ));
 }
 
 test "algebraic path profile recomputes max string token count after deleting max row" {

--- a/zig/pkg/antfly/src/storage/db/algebraic/index.zig
+++ b/zig/pkg/antfly/src/storage/db/algebraic/index.zig
@@ -394,7 +394,23 @@ fn dynamicRuleRoleMask(scalar_type: []const u8) u3 {
     return 0;
 }
 
-fn dynamicRuleMatches(rule: fact_mod.DynamicRule, path: []const u8, field_name: []const u8, json_value: std.json.Value) bool {
+/// Evaluate a dynamic-template selector against a field path + leaf name. The
+/// single source of truth for both ingest projection and query resolution, so
+/// the two can never drift. `json_value` is the field's value at ingest, or null
+/// at query time (where no value is available).
+///
+/// `match_mapping_type` requires a value, so when `json_value` is null a rule
+/// gated by it cannot be evaluated. Promotion already requires a name/path
+/// selector (see `validateConfig` / schema_capability), so the only effect of a
+/// null value is that the `match_mapping_type` predicate is treated as
+/// unsatisfiable: callers that need query-time resolution must additionally
+/// check for a name/path selector (`dynamicRuleResolvesField`).
+fn dynamicRuleSelectorMatches(
+    rule: fact_mod.DynamicRule,
+    path: []const u8,
+    field_name: []const u8,
+    json_value: ?std.json.Value,
+) bool {
     if (rule.match) |pattern| {
         if (!runtime_schema.globMatch(pattern, field_name)) return false;
     }
@@ -408,7 +424,8 @@ fn dynamicRuleMatches(rule: fact_mod.DynamicRule, path: []const u8, field_name: 
         if (runtime_schema.globMatch(pattern, path)) return false;
     }
     if (rule.match_mapping_type) |expected| {
-        const actual = runtime_schema.matchMappingTypeName(json_value) orelse return false;
+        const value = json_value orelse return false;
+        const actual = runtime_schema.matchMappingTypeName(value) orelse return false;
         if (!std.mem.eql(u8, expected, actual)) return false;
     }
     return true;
@@ -425,19 +442,7 @@ fn fieldNameFromQueryPath(path: []const u8) []const u8 {
 /// evaluated without a value and so do not resolve query fields.
 fn dynamicRuleResolvesField(rule: fact_mod.DynamicRule, path: []const u8, field_name: []const u8) bool {
     if (rule.match == null and rule.path_match == null) return false;
-    if (rule.match) |pattern| {
-        if (!runtime_schema.globMatch(pattern, field_name)) return false;
-    }
-    if (rule.unmatch) |pattern| {
-        if (runtime_schema.globMatch(pattern, field_name)) return false;
-    }
-    if (rule.path_match) |pattern| {
-        if (!runtime_schema.globMatch(pattern, path)) return false;
-    }
-    if (rule.path_unmatch) |pattern| {
-        if (runtime_schema.globMatch(pattern, path)) return false;
-    }
-    return true;
+    return dynamicRuleSelectorMatches(rule, path, field_name, null);
 }
 
 fn staticSpecCoversPath(specs: []const fact_mod.FieldSpec, path: []const u8) bool {
@@ -510,14 +515,19 @@ fn projectDynamicLeaf(
     if (staticSpecCoversPath(static_specs, path)) return;
 
     for (rules) |rule| {
-        if (!dynamicRuleMatches(rule, path, field_name, json_value)) continue;
+        if (!dynamicRuleSelectorMatches(rule, path, field_name, json_value)) continue;
+        // First selector-matching rule wins (Elasticsearch dynamic-template
+        // order). Crucially we return after the first *selector* match, NOT
+        // after the first rule that yields a usable fact: a value that does not
+        // coerce under this rule's type simply produces no fact (exactly like a
+        // static typed field given a non-coercible value). Falling through to a
+        // later overlapping rule with a different type would make ingest disagree
+        // with query-time resolution, which also picks the first matching rule.
         const mask = dynamicRuleRoleMask(rule.type);
-        var projected = false;
-        if (mask & role_group != 0) projected = (try appendDynamicFact(alloc, out, .group, path, rule.type, json_value)) or projected;
-        if (mask & role_measure != 0) projected = (try appendDynamicFact(alloc, out, .measure, path, rule.type, json_value)) or projected;
-        if (mask & role_time != 0) projected = (try appendDynamicFact(alloc, out, .time, path, rule.type, json_value)) or projected;
-        // First template that yields a usable typed fact wins (Bleve/ES order).
-        if (projected) return;
+        if (mask & role_group != 0) _ = try appendDynamicFact(alloc, out, .group, path, rule.type, json_value);
+        if (mask & role_measure != 0) _ = try appendDynamicFact(alloc, out, .measure, path, rule.type, json_value);
+        if (mask & role_time != 0) _ = try appendDynamicFact(alloc, out, .time, path, rule.type, json_value);
+        return;
     }
 }
 
@@ -3111,6 +3121,17 @@ pub const Index = struct {
     /// the next ingest projects facts using the refreshed dynamic_field_rules.
     /// Persisted sidecar rows are untouched (lazy backfill); only newly written
     /// or rewritten documents reflect the new rules until a full rebuild.
+    ///
+    /// Concurrency: this frees the old parsed Config (whose slices back the
+    /// FieldConfig/DynamicRule values returned by `config()`/`fieldConfig`). It
+    /// is only safe to call with no concurrent reader of this index. That holds
+    /// today: the sole caller (`IndexManager.reloadAlgebraicSchemaConfigs` via
+    /// `applyLocalTableSchemaJson`) runs under the provisioned write source's
+    /// exclusive structural-mutation lock on a freshly-opened, unshared DB handle
+    /// — query threads read separate read-cache DB handles. This mirrors the
+    /// adjacent `core.setSchema` swap in the same code path. If the index ever
+    /// becomes shared with live readers, this swap must be guarded (e.g. by the
+    /// index apply_mutex with readers taking it too).
     pub fn reloadConfigJson(self: *Index, config_json: []const u8) !void {
         var parsed = try std.json.parseFromSlice(Config, self.alloc, config_json, .{ .allocate = .alloc_always });
         errdefer parsed.deinit();
@@ -14304,6 +14325,16 @@ pub const Index = struct {
     /// dynamic template, so group/measure/time queries over template-promoted
     /// fields route to the algebraic sidecar. The synthesized config keys facts
     /// by the full query path (matching the ingest-time fact identity).
+    ///
+    /// Lifetime: the returned `name`/`path` alias the caller's `query_field`
+    /// (unlike the static path, whose slices are config-owned). This is safe
+    /// because every consumer is query-scoped — `resolveField` already borrows
+    /// `query_field` into `ResolvedField.public`, and the planner copies the
+    /// field name into owned canonical metadata tuples
+    /// (`termsCardinalityPartialsMetadataAlloc` / `docFactBucketFoldMetadataAlloc`
+    /// via `token.canonicalTupleAlloc`) rather than retaining the borrow. Do not
+    /// stash a resolved dynamic field's name/path beyond the query that produced
+    /// `query_field`.
     fn dynamicFieldConfig(self: *const Index, query_field: []const u8, class: FieldClass) ?FieldConfig {
         const cfg = self.config();
         const rules = cfg.dynamic_field_rules;
@@ -14315,19 +14346,34 @@ pub const Index = struct {
         // complete scan; static fields keep accelerating.
         if (cfg.dynamic_rules_backfill_pending) return null;
         const field_name = fieldNameFromQueryPath(query_field);
+        // Resolve a dynamic field's type only when every rule whose name/path
+        // selector matches it AGREES on the scalar type. Ingest projects the
+        // first selector-matching rule's type, so a single matching rule (or
+        // several that agree) gives query the exact type ingest stored. When
+        // matching rules disagree (overlapping globs with different types, or a
+        // `match_mapping_type` rule whose applicability is value-dependent and
+        // unknowable here), we cannot know which type ingest stored per document,
+        // so we decline resolution and let the query fall back to a complete scan
+        // rather than read a type that may only cover part of the documents.
+        var resolved_type: ?[]const u8 = null;
         for (rules) |rule| {
             if (!dynamicRuleResolvesField(rule, query_field, field_name)) continue;
-            const mask = dynamicRuleRoleMask(rule.type);
-            const matches_class = switch (class) {
-                .group => mask & role_group != 0,
-                .measure => mask & role_measure != 0,
-                .time => mask & role_time != 0,
-                .any => mask != 0,
-            };
-            if (!matches_class) continue;
-            return .{ .name = query_field, .path = query_field, .type = rule.type };
+            if (resolved_type) |t| {
+                if (!std.mem.eql(u8, t, rule.type)) return null; // ambiguous
+            } else {
+                resolved_type = rule.type;
+            }
         }
-        return null;
+        const rule_type = resolved_type orelse return null;
+        const mask = dynamicRuleRoleMask(rule_type);
+        const matches_class = switch (class) {
+            .group => mask & role_group != 0,
+            .measure => mask & role_measure != 0,
+            .time => mask & role_time != 0,
+            .any => mask != 0,
+        };
+        if (!matches_class) return null;
+        return .{ .name = query_field, .path = query_field, .type = rule_type };
     }
 
     pub fn resolveField(self: *const Index, query_field: []const u8, class: FieldClass) ?ResolvedField {
@@ -19779,6 +19825,56 @@ test "algebraic config rejects dynamic rule without a name or path selector" {
     try std.testing.expectError(error.InvalidAlgebraicConfig, Index.open(alloc, "bad",
         \\{"version":1,"table":"events","dynamic_field_rules":[{"name":"x","unmatch":"skip_*","type":"keyword"}]}
     ));
+}
+
+test "algebraic dynamic field resolution agrees with ingest under overlapping rules" {
+    const alloc = std.testing.allocator;
+    var backend = @import("../../mem_backend.zig").Backend.init(alloc, .{});
+    defer backend.close();
+    const runtime_store = try backend.runtimeStore(alloc, .{});
+    var store = try docstore_mod.DocStore.openRuntime(alloc, runtime_store);
+    defer store.close();
+
+    // Two overlapping rules match `score` with DIFFERENT types. Ingest projects
+    // the first matching rule (number); query-time resolution must DECLINE
+    // (ambiguous) rather than resolve to a type that may disagree with what
+    // ingest stored — otherwise aggregates would decode the wrong scalar type.
+    // A non-overlapping field (`region`) still resolves cleanly.
+    const cfg =
+        \\{"version":1,"table":"events","dynamic_field_rules":[
+        \\  {"name":"score_num","match":"score","type":"number"},
+        \\  {"name":"score_str","match":"score","type":"string"},
+        \\  {"name":"region","match":"region","type":"string"}
+        \\]}
+    ;
+    var idx = try Index.open(alloc, "alg_overlap", cfg);
+    defer idx.close();
+
+    // Ambiguous field: no resolution for any class.
+    try std.testing.expect(idx.fieldConfig("score", .group) == null);
+    try std.testing.expect(idx.fieldConfig("score", .measure) == null);
+    try std.testing.expect(idx.resolveField("score", .group) == null);
+    // Unambiguous field still resolves.
+    const region = idx.fieldConfig("region", .group) orelse return error.TestUnexpectedResult;
+    try std.testing.expectEqualStrings("string", region.type);
+
+    // Ingest projects the first matching rule's type (number) for `score`.
+    const docs = [_]derived_types.DerivedDocument{
+        .{ .key = "e1", .action = .upsert, .cleaned_value = "{\"score\":10,\"region\":\"us\"}" },
+    };
+    try idx.applyBatch(&store, .{ .documents = docs[0..] });
+    const fact_key = try idx.docFactKey("e1");
+    defer alloc.free(fact_key);
+    var read_txn = try store.beginReadTxn();
+    const payload = try read_txn.get(fact_key);
+    var facts = try fact_mod.decodeListAlloc(alloc, payload);
+    read_txn.abort();
+    defer facts.deinit(alloc);
+    // The number rule produces a measure fact; a string rule never would, so the
+    // presence of a `score` measure fact confirms ingest stored it number-typed
+    // (the first matching rule), consistent with query declining the ambiguity.
+    try std.testing.expect(factHasField(facts.facts, .measure, "score"));
+    try std.testing.expect(factHasField(facts.facts, .group, "score"));
 }
 
 test "algebraic path profile recomputes max string token count after deleting max row" {

--- a/zig/pkg/antfly/src/storage/db/algebraic/index.zig
+++ b/zig/pkg/antfly/src/storage/db/algebraic/index.zig
@@ -3072,6 +3072,23 @@ pub const Index = struct {
         return .{ .index = self };
     }
 
+    /// Swap the index configuration in place from a new config JSON. Used to
+    /// apply a dynamic-template change to a running index without a reopen:
+    /// the next ingest projects facts using the refreshed dynamic_field_rules.
+    /// Persisted sidecar rows are untouched (lazy backfill); only newly written
+    /// or rewritten documents reflect the new rules until a full rebuild.
+    pub fn reloadConfigJson(self: *Index, config_json: []const u8) !void {
+        var parsed = try std.json.parseFromSlice(Config, self.alloc, config_json, .{ .allocate = .alloc_always });
+        errdefer parsed.deinit();
+        try validateConfig(parsed.value);
+        // Cached adaptive specs are derived from the old config; drop them so
+        // they are recomputed lazily against the new one.
+        self.invalidateAdaptiveReadySpecCache();
+        const old = self.parsed;
+        self.parsed = parsed;
+        old.deinit();
+    }
+
     pub fn attachResourceManager(self: *Index, manager: *resource_manager_mod.ResourceManager) void {
         self.resource_manager = manager;
     }
@@ -19537,6 +19554,50 @@ test "algebraic dynamic templates project typed docfacts without a schema rebuil
     try std.testing.expect(!factHasField(facts2.facts, .group, "user_id"));
     try std.testing.expect(!factHasField(facts2.facts, .group, "metrics.latency"));
     try std.testing.expect(factHasField(facts2.facts, .group, "session_id"));
+}
+
+test "algebraic reloadConfigJson applies new dynamic template rules to live writes" {
+    const alloc = std.testing.allocator;
+    var backend = @import("../../mem_backend.zig").Backend.init(alloc, .{});
+    defer backend.close();
+    const runtime_store = try backend.runtimeStore(alloc, .{});
+    var store = try docstore_mod.DocStore.openRuntime(alloc, runtime_store);
+    defer store.close();
+
+    const cfg_v1 =
+        \\{"version":1,"table":"events","dynamic_field_rules":[{"name":"score","match":"score","type":"string"}]}
+    ;
+    var idx = try Index.open(alloc, "alg_reload", cfg_v1);
+    defer idx.close();
+
+    const doc_v1 = [_]derived_types.DerivedDocument{
+        .{ .key = "e1", .action = .upsert, .cleaned_value = "{\"score\":42}" },
+    };
+    try idx.applyBatch(&store, .{ .documents = doc_v1[0..] });
+
+    // Template-only change: `score` is now numeric (group + measure) instead of
+    // string. Reload the config in place, then write a new document.
+    const cfg_v2 =
+        \\{"version":1,"table":"events","dynamic_field_rules":[{"name":"score","match":"score","type":"number"}]}
+    ;
+    try idx.reloadConfigJson(cfg_v2);
+
+    const doc_v2 = [_]derived_types.DerivedDocument{
+        .{ .key = "e2", .action = .upsert, .cleaned_value = "{\"score\":7}" },
+    };
+    try idx.applyBatch(&store, .{ .documents = doc_v2[0..] });
+
+    const fact_key = try idx.docFactKey("e2");
+    defer alloc.free(fact_key);
+    var read_txn = try store.beginReadTxn();
+    const payload = try read_txn.get(fact_key);
+    var facts = try fact_mod.decodeListAlloc(alloc, payload);
+    read_txn.abort();
+    defer facts.deinit(alloc);
+
+    // The new write uses the refreshed numeric rule => measure fact present.
+    try std.testing.expect(factHasField(facts.facts, .measure, "score"));
+    try std.testing.expect(factHasField(facts.facts, .group, "score"));
 }
 
 test "algebraic path profile recomputes max string token count after deleting max row" {

--- a/zig/pkg/antfly/src/storage/db/algebraic/index.zig
+++ b/zig/pkg/antfly/src/storage/db/algebraic/index.zig
@@ -33,6 +33,7 @@ const backend_erased = @import("../../backend_erased.zig");
 const backend_types = @import("../../backend_types.zig");
 const docstore_mod = @import("../../docstore.zig");
 const internal_keys = @import("../../internal_keys.zig");
+const runtime_schema = @import("../../schema.zig");
 const lsm_backend = @import("../../lsm_backend.zig");
 const lsm_storage_io = @import("../../lsm_backend/storage_io.zig");
 const resource_manager_mod = @import("../../resource_manager.zig");
@@ -218,6 +219,7 @@ pub const Config = struct {
     group_fields: []const FieldConfig = &.{},
     measure_fields: []const FieldConfig = &.{},
     time_fields: []const FieldConfig = &.{},
+    dynamic_field_rules: []const fact_mod.DynamicRule = &.{},
     laws: []const LawConfig = &.{},
     joins: []const JoinConfig = &.{},
     materializations: []const MaterializationConfig = &.{},
@@ -346,6 +348,159 @@ pub fn validateConfig(cfg: Config) !void {
         }
     }
     if (cfg.adaptive.observation_decay_retain_percent > 100) return error.InvalidAlgebraicConfig;
+    for (cfg.dynamic_field_rules) |rule| {
+        if (rule.type.len == 0) return error.InvalidAlgebraicConfig;
+        if (dynamicRuleRoleMask(rule.type) == 0) return error.InvalidAlgebraicConfig;
+        // A rule with no selector at all would match every field; require at
+        // least one selector so a misconfigured template cannot blanket-project.
+        if (rule.match == null and rule.unmatch == null and
+            rule.path_match == null and rule.path_unmatch == null and
+            rule.match_mapping_type == null) return error.InvalidAlgebraicConfig;
+    }
+}
+
+// ============================================================================
+// Dynamic-template docfact projection
+//
+// Templates are evaluated against every observed field at ingest time. A field
+// not already covered by a static spec that matches a rule selector is promoted
+// into typed group/measure/time docfacts, so dynamic-template changes take
+// effect for new writes without a schema version bump or reindex. The bounded-
+// type guard is enforced upstream in schema_capability.zig (only keyword/
+// numeric/boolean/datetime templates become rules); open text stays schemaless.
+// ============================================================================
+
+/// Bitmask of roles a resolved scalar type projects into. Mirrors the static
+/// classification in schema_capability.zig (numeric => group+measure, datetime
+/// => group+time, others => group).
+const role_group: u3 = 0b001;
+const role_measure: u3 = 0b010;
+const role_time: u3 = 0b100;
+
+fn dynamicRuleRoleMask(scalar_type: []const u8) u3 {
+    if (std.mem.eql(u8, scalar_type, "integer") or std.mem.eql(u8, scalar_type, "number")) {
+        return role_group | role_measure;
+    }
+    if (std.mem.eql(u8, scalar_type, "datetime")) return role_group | role_time;
+    if (std.mem.eql(u8, scalar_type, "string") or std.mem.eql(u8, scalar_type, "boolean")) return role_group;
+    return 0;
+}
+
+fn dynamicRuleMatches(rule: fact_mod.DynamicRule, path: []const u8, field_name: []const u8, json_value: std.json.Value) bool {
+    if (rule.match) |pattern| {
+        if (!runtime_schema.globMatch(pattern, field_name)) return false;
+    }
+    if (rule.unmatch) |pattern| {
+        if (runtime_schema.globMatch(pattern, field_name)) return false;
+    }
+    if (rule.path_match) |pattern| {
+        if (!runtime_schema.globMatch(pattern, path)) return false;
+    }
+    if (rule.path_unmatch) |pattern| {
+        if (runtime_schema.globMatch(pattern, path)) return false;
+    }
+    if (rule.match_mapping_type) |expected| {
+        const actual = runtime_schema.matchMappingTypeName(json_value) orelse return false;
+        if (!std.mem.eql(u8, expected, actual)) return false;
+    }
+    return true;
+}
+
+fn staticSpecCoversPath(specs: []const fact_mod.FieldSpec, path: []const u8) bool {
+    for (specs) |spec| {
+        if (std.mem.eql(u8, spec.path, path)) return true;
+    }
+    return false;
+}
+
+/// Project dynamic-template-matched docfacts for a document. The fact `field`
+/// identity is the full dotted path (so nested dynamic fields never collide with
+/// each other or with statically-declared leaf-named fields); for the common
+/// top-level template case the path equals the field name.
+fn projectDynamicDocFactsAlloc(
+    alloc: std.mem.Allocator,
+    rules: []const fact_mod.DynamicRule,
+    static_specs: []const fact_mod.FieldSpec,
+    root: std.json.Value,
+) !fact_mod.FactList {
+    var out = std.ArrayListUnmanaged(fact_mod.Fact).empty;
+    errdefer {
+        for (out.items) |*item| item.deinit(alloc);
+        out.deinit(alloc);
+    }
+    if (rules.len > 0 and root == .object) {
+        try walkDynamicDocFacts(alloc, rules, static_specs, &out, "", root);
+    }
+    return .{ .facts = try out.toOwnedSlice(alloc) };
+}
+
+fn walkDynamicDocFacts(
+    alloc: std.mem.Allocator,
+    rules: []const fact_mod.DynamicRule,
+    static_specs: []const fact_mod.FieldSpec,
+    out: *std.ArrayListUnmanaged(fact_mod.Fact),
+    prefix: []const u8,
+    node: std.json.Value,
+) !void {
+    if (node != .object) return;
+    var it = node.object.iterator();
+    while (it.next()) |entry| {
+        const field_name = entry.key_ptr.*;
+        const child_value = entry.value_ptr.*;
+        const path = if (prefix.len == 0)
+            try alloc.dupe(u8, field_name)
+        else
+            try std.fmt.allocPrint(alloc, "{s}.{s}", .{ prefix, field_name });
+        defer alloc.free(path);
+        switch (child_value) {
+            // Descend into nested objects so path_match selectors can target
+            // dotted paths; arrays stay on the schemaless path-fact path.
+            .object => try walkDynamicDocFacts(alloc, rules, static_specs, out, path, child_value),
+            .array => {},
+            else => try projectDynamicLeaf(alloc, rules, static_specs, out, path, field_name, child_value),
+        }
+    }
+}
+
+fn projectDynamicLeaf(
+    alloc: std.mem.Allocator,
+    rules: []const fact_mod.DynamicRule,
+    static_specs: []const fact_mod.FieldSpec,
+    out: *std.ArrayListUnmanaged(fact_mod.Fact),
+    path: []const u8,
+    field_name: []const u8,
+    json_value: std.json.Value,
+) !void {
+    // Explicit schema fields win over dynamic templates (resolution order in
+    // SCHEMA.md): if a static spec already covers this path, skip it.
+    if (staticSpecCoversPath(static_specs, path)) return;
+
+    for (rules) |rule| {
+        if (!dynamicRuleMatches(rule, path, field_name, json_value)) continue;
+        const mask = dynamicRuleRoleMask(rule.type);
+        var projected = false;
+        if (mask & role_group != 0) projected = (try appendDynamicFact(alloc, out, .group, path, rule.type, json_value)) or projected;
+        if (mask & role_measure != 0) projected = (try appendDynamicFact(alloc, out, .measure, path, rule.type, json_value)) or projected;
+        if (mask & role_time != 0) projected = (try appendDynamicFact(alloc, out, .time, path, rule.type, json_value)) or projected;
+        // First template that yields a usable typed fact wins (Bleve/ES order).
+        if (projected) return;
+    }
+}
+
+fn appendDynamicFact(
+    alloc: std.mem.Allocator,
+    out: *std.ArrayListUnmanaged(fact_mod.Fact),
+    role: fact_mod.Role,
+    field: []const u8,
+    scalar_type: []const u8,
+    json_value: std.json.Value,
+) !bool {
+    const scalar = (try value_mod.scalarFromJsonAlloc(alloc, scalar_type, json_value)) orelse return false;
+    errdefer alloc.free(scalar);
+    const field_copy = try alloc.dupe(u8, field);
+    errdefer alloc.free(field_copy);
+    try out.append(alloc, .{ .role = role, .field = field_copy, .scalar = scalar });
+    return true;
 }
 
 fn validateUniqueFieldNames(fields: []const FieldConfig) !void {
@@ -15072,9 +15227,7 @@ pub const Index = struct {
         defer parsed.deinit();
         if (parsed.value != .object) return false;
 
-        const specs = try self.factSpecsAlloc();
-        defer self.alloc.free(specs);
-        var new_facts = try fact_mod.projectDocumentAlloc(self.alloc, specs, parsed.value);
+        var new_facts = try self.projectAllDocFactsAlloc(parsed.value);
         defer new_facts.deinit(self.alloc);
         const new_fact_payload = try fact_mod.encodeListAlloc(self.alloc, new_facts.facts);
         defer self.alloc.free(new_fact_payload);
@@ -15126,13 +15279,40 @@ pub const Index = struct {
         return true;
     }
 
+    /// Project both the statically-declared docfacts and any dynamic
+    /// template-matched docfacts for a document into a single fact list. This is
+    /// the one place ingest derives typed facts so the fresh-write and coalesced-
+    /// update paths stay byte-for-byte consistent in the stored docfact row.
+    fn projectAllDocFactsAlloc(self: *Index, root: std.json.Value) !fact_mod.FactList {
+        const specs = try self.factSpecsAlloc();
+        defer self.alloc.free(specs);
+        var facts = try fact_mod.projectDocumentAlloc(self.alloc, specs, root);
+        errdefer facts.deinit(self.alloc);
+
+        const rules = self.config().dynamic_field_rules;
+        if (rules.len == 0) return facts;
+
+        var dynamic = try projectDynamicDocFactsAlloc(self.alloc, rules, specs, root);
+        defer dynamic.deinit(self.alloc);
+        if (dynamic.facts.len == 0) return facts;
+
+        const combined = try self.alloc.alloc(fact_mod.Fact, facts.facts.len + dynamic.facts.len);
+        @memcpy(combined[0..facts.facts.len], facts.facts);
+        @memcpy(combined[facts.facts.len..], dynamic.facts);
+        // Element ownership transfers into `combined`; free only the backing
+        // slices and neutralize the sources so their deinits are no-ops.
+        if (facts.facts.len > 0) self.alloc.free(facts.facts);
+        if (dynamic.facts.len > 0) self.alloc.free(dynamic.facts);
+        dynamic.facts = &.{};
+        facts.facts = combined;
+        return facts;
+    }
+
     fn writeDocFacts(self: *Index, txn: anytype, doc_key: []const u8, value: []const u8, maintenance_context: ?*BatchMaintenanceContext) !void {
         var parsed = std.json.parseFromSlice(std.json.Value, self.alloc, value, .{}) catch return;
         defer parsed.deinit();
         if (parsed.value != .object) return;
-        const specs = try self.factSpecsAlloc();
-        defer self.alloc.free(specs);
-        var facts = try fact_mod.projectDocumentAlloc(self.alloc, specs, parsed.value);
+        var facts = try self.projectAllDocFactsAlloc(parsed.value);
         defer facts.deinit(self.alloc);
         const encoded = try fact_mod.encodeListAlloc(self.alloc, facts.facts);
         defer self.alloc.free(encoded);
@@ -19285,6 +19465,78 @@ test "algebraic index stores schemaless path facts and lookup rows" {
         else => return err,
     };
     deleted_txn.abort();
+}
+
+fn factHasField(facts: []const fact_mod.Fact, role: fact_mod.Role, field: []const u8) bool {
+    for (facts) |f| {
+        if (f.role == role and std.mem.eql(u8, f.field, field)) return true;
+    }
+    return false;
+}
+
+test "algebraic dynamic templates project typed docfacts without a schema rebuild" {
+    const alloc = std.testing.allocator;
+    var backend = @import("../../mem_backend.zig").Backend.init(alloc, .{});
+    defer backend.close();
+    const runtime_store = try backend.runtimeStore(alloc, .{});
+    var store = try docstore_mod.DocStore.openRuntime(alloc, runtime_store);
+    defer store.close();
+
+    // Explicit `tenant` group field plus three dynamic-template rules. The
+    // `tenant` rule (number) must lose to the explicit string field; `*_id`
+    // and `metrics.*` promote unknown fields into typed facts at ingest.
+    const cfg =
+        \\{
+        \\  "version": 1,
+        \\  "table": "events",
+        \\  "group_fields": [{"name":"tenant","path":"tenant","type":"string"}],
+        \\  "dynamic_field_rules": [
+        \\    {"name":"explicit_loses","match":"tenant","type":"number"},
+        \\    {"name":"ids","match":"*_id","type":"string"},
+        \\    {"name":"metrics","path_match":"metrics.*","type":"number"}
+        \\  ]
+        \\}
+    ;
+    var idx = try Index.open(alloc, "alg_dyn_templates", cfg);
+    defer idx.close();
+
+    const docs = [_]derived_types.DerivedDocument{
+        .{ .key = "e1", .action = .upsert, .cleaned_value = "{\"tenant\":\"t1\",\"user_id\":\"u42\",\"metrics\":{\"latency\":12}}" },
+    };
+    try idx.applyBatch(&store, .{ .documents = docs[0..] });
+
+    const fact_key = try idx.docFactKey("e1");
+    defer alloc.free(fact_key);
+    var read_txn = try store.beginReadTxn();
+    const payload = try read_txn.get(fact_key);
+    var facts = try fact_mod.decodeListAlloc(alloc, payload);
+    read_txn.abort();
+    defer facts.deinit(alloc);
+
+    // Explicit field wins: tenant is a string group fact, never a number measure.
+    try std.testing.expect(factHasField(facts.facts, .group, "tenant"));
+    try std.testing.expect(!factHasField(facts.facts, .measure, "tenant"));
+    // `user_id` matched `*_id` -> string group fact keyed by its path.
+    try std.testing.expect(factHasField(facts.facts, .group, "user_id"));
+    try std.testing.expect(!factHasField(facts.facts, .measure, "user_id"));
+    // Nested `metrics.latency` matched `metrics.*` -> numeric group + measure.
+    try std.testing.expect(factHasField(facts.facts, .group, "metrics.latency"));
+    try std.testing.expect(factHasField(facts.facts, .measure, "metrics.latency"));
+
+    // Overwriting the document removes stale dynamic facts (symmetric cleanup
+    // through the coalesced update path).
+    const overwrite = [_]derived_types.DerivedDocument{
+        .{ .key = "e1", .action = .upsert, .cleaned_value = "{\"tenant\":\"t1\",\"session_id\":\"s7\"}" },
+    };
+    try idx.applyBatch(&store, .{ .documents = overwrite[0..] });
+    var read_txn2 = try store.beginReadTxn();
+    const payload2 = try read_txn2.get(fact_key);
+    var facts2 = try fact_mod.decodeListAlloc(alloc, payload2);
+    read_txn2.abort();
+    defer facts2.deinit(alloc);
+    try std.testing.expect(!factHasField(facts2.facts, .group, "user_id"));
+    try std.testing.expect(!factHasField(facts2.facts, .group, "metrics.latency"));
+    try std.testing.expect(factHasField(facts2.facts, .group, "session_id"));
 }
 
 test "algebraic path profile recomputes max string token count after deleting max row" {

--- a/zig/pkg/antfly/src/storage/db/algebraic/index.zig
+++ b/zig/pkg/antfly/src/storage/db/algebraic/index.zig
@@ -406,6 +406,32 @@ fn dynamicRuleMatches(rule: fact_mod.DynamicRule, path: []const u8, field_name: 
     return true;
 }
 
+fn fieldNameFromQueryPath(path: []const u8) []const u8 {
+    const idx = std.mem.lastIndexOfScalar(u8, path, '.') orelse return path;
+    return path[idx + 1 ..];
+}
+
+/// Query-time variant of `dynamicRuleMatches` with no runtime value: a rule can
+/// only resolve a concrete query field if it carries a name/path selector
+/// (`match`/`path_match`). Rules gated solely by `match_mapping_type` cannot be
+/// evaluated without a value and so do not resolve query fields.
+fn dynamicRuleResolvesField(rule: fact_mod.DynamicRule, path: []const u8, field_name: []const u8) bool {
+    if (rule.match == null and rule.path_match == null) return false;
+    if (rule.match) |pattern| {
+        if (!runtime_schema.globMatch(pattern, field_name)) return false;
+    }
+    if (rule.unmatch) |pattern| {
+        if (runtime_schema.globMatch(pattern, field_name)) return false;
+    }
+    if (rule.path_match) |pattern| {
+        if (!runtime_schema.globMatch(pattern, path)) return false;
+    }
+    if (rule.path_unmatch) |pattern| {
+        if (runtime_schema.globMatch(pattern, path)) return false;
+    }
+    return true;
+}
+
 fn staticSpecCoversPath(specs: []const fact_mod.FieldSpec, path: []const u8) bool {
     for (specs) |spec| {
         if (std.mem.eql(u8, spec.path, path)) return true;
@@ -14263,6 +14289,29 @@ pub const Index = struct {
                 if (fieldMatchesQuery(field, query_field)) return field;
             }
         }
+        return self.dynamicFieldConfig(query_field, class);
+    }
+
+    /// Resolve a query field that is not statically declared but matches a
+    /// dynamic template, so group/measure/time queries over template-promoted
+    /// fields route to the algebraic sidecar. The synthesized config keys facts
+    /// by the full query path (matching the ingest-time fact identity).
+    fn dynamicFieldConfig(self: *const Index, query_field: []const u8, class: FieldClass) ?FieldConfig {
+        const rules = self.config().dynamic_field_rules;
+        if (rules.len == 0) return null;
+        const field_name = fieldNameFromQueryPath(query_field);
+        for (rules) |rule| {
+            if (!dynamicRuleResolvesField(rule, query_field, field_name)) continue;
+            const mask = dynamicRuleRoleMask(rule.type);
+            const matches_class = switch (class) {
+                .group => mask & role_group != 0,
+                .measure => mask & role_measure != 0,
+                .time => mask & role_time != 0,
+                .any => mask != 0,
+            };
+            if (!matches_class) continue;
+            return .{ .name = query_field, .path = query_field, .type = rule.type };
+        }
         return null;
     }
 
@@ -19598,6 +19647,89 @@ test "algebraic reloadConfigJson applies new dynamic template rules to live writ
     // The new write uses the refreshed numeric rule => measure fact present.
     try std.testing.expect(factHasField(facts.facts, .measure, "score"));
     try std.testing.expect(factHasField(facts.facts, .group, "score"));
+}
+
+test "algebraic dynamic template fields resolve and aggregate at query time" {
+    const alloc = std.testing.allocator;
+    var backend = @import("../../mem_backend.zig").Backend.init(alloc, .{});
+    defer backend.close();
+    const runtime_store = try backend.runtimeStore(alloc, .{});
+    var store = try docstore_mod.DocStore.openRuntime(alloc, runtime_store);
+    defer store.close();
+
+    const cfg =
+        \\{"version":1,"table":"events","dynamic_field_rules":[
+        \\  {"name":"ids","match":"*_id","type":"string"},
+        \\  {"name":"score","match":"score","type":"number"}
+        \\]}
+    ;
+    var idx = try Index.open(alloc, "alg_dyn_query", cfg);
+    defer idx.close();
+
+    // Query-time field resolution now recognizes template-promoted fields so the
+    // planner routes group/measure queries over them to the sidecar.
+    try std.testing.expect(idx.resolveField("user_id", .group) != null);
+    try std.testing.expectEqualStrings("string", idx.fieldConfig("user_id", .group).?.type);
+    try std.testing.expect(idx.resolveField("score", .measure) != null);
+    try std.testing.expectEqualStrings("number", idx.fieldConfig("score", .measure).?.type);
+    // A field matching no template is not algebraic, and a string field is not a
+    // measure (only numeric templates resolve as measures).
+    try std.testing.expect(idx.fieldConfig("unmatched", .group) == null);
+    try std.testing.expect(idx.fieldConfig("user_id", .measure) == null);
+
+    const docs = [_]derived_types.DerivedDocument{
+        .{ .key = "e1", .action = .upsert, .cleaned_value = "{\"user_id\":\"u1\",\"score\":10}" },
+        .{ .key = "e2", .action = .upsert, .cleaned_value = "{\"user_id\":\"u1\",\"score\":20}" },
+        .{ .key = "e3", .action = .upsert, .cleaned_value = "{\"user_id\":\"u2\",\"score\":5}" },
+    };
+    try idx.applyBatch(&store, .{ .documents = docs[0..] });
+
+    // Terms count grouped by the dynamic `user_id` field, executed through the
+    // docfact fold scan the planner routes to once the field resolves.
+    const fold = DocFactBucketFoldRequest{
+        .kind = .terms,
+        .op = .count,
+        .bucket_field = "user_id",
+        .bucket_role = .group,
+    };
+    const metadata = try docFactBucketFoldMetadataAlloc(alloc, fold);
+    defer alloc.free(metadata);
+    const access_paths = [_]ir.PhysicalAccessPath{ir.docFactAccessPath(idx.name)};
+    const steps = [_]ir.TensorProgramStep{
+        .{ .expr = .{
+            .fragment = .slice,
+            .output_dims = &.{ .doc, .field, .scalar },
+            .owner = idx.name,
+            .layout = .docfact_rows,
+        } },
+        .{
+            .expr = .{
+                .fragment = .reduce,
+                .input_dims = &.{ .doc, .field, .scalar },
+                .output_dims = &distributed_bucket_scalar_output_dims,
+                .semantic_id = "by_user",
+                .law_id = .count,
+                .metadata = metadata,
+            },
+            .inputs = &.{.{ .step = 0 }},
+        },
+    };
+    const program = ir.TensorProgram{ .steps = steps[0..], .output = .{ .step = 1 } };
+    const entries = (try idx.scanDocFactBucketFoldEntriesWithTensorProgram(&store, fold, access_paths[0..], program, .{ .step = 1 })) orelse return error.TestUnexpectedResult;
+    defer {
+        for (entries) |*entry| entry.deinit(alloc);
+        alloc.free(entries);
+    }
+
+    try std.testing.expectEqual(@as(usize, 2), entries.len);
+    var u1_count: ?[]const u8 = null;
+    var u2_count: ?[]const u8 = null;
+    for (entries) |entry| {
+        if (std.mem.indexOf(u8, entry.group_key, "u1") != null) u1_count = entry.value;
+        if (std.mem.indexOf(u8, entry.group_key, "u2") != null) u2_count = entry.value;
+    }
+    try std.testing.expectEqualStrings("2", u1_count orelse return error.TestUnexpectedResult);
+    try std.testing.expectEqualStrings("1", u2_count orelse return error.TestUnexpectedResult);
 }
 
 test "algebraic path profile recomputes max string token count after deleting max row" {

--- a/zig/pkg/antfly/src/storage/db/algebraic/schema_capability.zig
+++ b/zig/pkg/antfly/src/storage/db/algebraic/schema_capability.zig
@@ -41,9 +41,34 @@ pub const FieldCapability = struct {
     }
 };
 
+/// A table-level dynamic template compiled into a runtime-adaptive algebraic
+/// rule. Only templates that resolve to a bounded scalar type become rules; the
+/// selectors are carried verbatim and evaluated per-document at ingest time.
+pub const DynamicRuleCapability = struct {
+    name: []u8,
+    match: ?[]u8 = null,
+    unmatch: ?[]u8 = null,
+    path_match: ?[]u8 = null,
+    path_unmatch: ?[]u8 = null,
+    match_mapping_type: ?[]u8 = null,
+    scalar_type: []u8,
+
+    pub fn deinit(self: *DynamicRuleCapability, alloc: Allocator) void {
+        alloc.free(self.name);
+        if (self.match) |v| alloc.free(v);
+        if (self.unmatch) |v| alloc.free(v);
+        if (self.path_match) |v| alloc.free(v);
+        if (self.path_unmatch) |v| alloc.free(v);
+        if (self.match_mapping_type) |v| alloc.free(v);
+        alloc.free(self.scalar_type);
+        self.* = undefined;
+    }
+};
+
 pub const Plan = struct {
     schema_version: u32 = 0,
     fields: []FieldCapability = &.{},
+    dynamic_rules: []DynamicRuleCapability = &.{},
     skipped_dynamic_fields: u32 = 0,
     skipped_complex_fields: u32 = 0,
     skipped_unbounded_fields: u32 = 0,
@@ -51,6 +76,8 @@ pub const Plan = struct {
     pub fn deinit(self: *Plan, alloc: Allocator) void {
         for (self.fields) |*field| field.deinit(alloc);
         if (self.fields.len > 0) alloc.free(self.fields);
+        for (self.dynamic_rules) |*rule| rule.deinit(alloc);
+        if (self.dynamic_rules.len > 0) alloc.free(self.dynamic_rules);
         self.* = undefined;
     }
 };
@@ -71,9 +98,38 @@ pub fn compilePlanAlloc(alloc: Allocator, schema: schema_mod.ParsedTableSchema) 
         for (fields.items) |*field| field.deinit(alloc);
         fields.deinit(alloc);
     }
+    var dynamic_rules = std.ArrayListUnmanaged(DynamicRuleCapability).empty;
+    errdefer {
+        for (dynamic_rules.items) |*rule| rule.deinit(alloc);
+        dynamic_rules.deinit(alloc);
+    }
     var skipped_dynamic_fields: u32 = 0;
     var skipped_complex_fields: u32 = 0;
     var skipped_unbounded_fields: u32 = 0;
+
+    for (schema.dynamic_templates) |tmpl| {
+        // A template needs at least one positive/type selector; one with only
+        // negative (or no) selectors would blanket-match every field, so it is
+        // not safe to promote into bounded algebraic facts.
+        const has_positive_selector = tmpl.match_pattern != null or tmpl.path_match != null or tmpl.match_mapping_type != null;
+        const scalar = boundedScalarForTemplateType(tmpl.field_type orelse "text");
+        if (!has_positive_selector or scalar == null) {
+            // Unbounded/open text templates and overly-broad selectors stay on
+            // the schemaless path-fact path rather than typed docfacts.
+            skipped_dynamic_fields += 1;
+            skipped_unbounded_fields += 1;
+            continue;
+        }
+        try dynamic_rules.append(alloc, .{
+            .name = try alloc.dupe(u8, tmpl.name),
+            .match = try dupeOptional(alloc, tmpl.match_pattern),
+            .unmatch = try dupeOptional(alloc, tmpl.unmatch_pattern),
+            .path_match = try dupeOptional(alloc, tmpl.path_match),
+            .path_unmatch = try dupeOptional(alloc, tmpl.path_unmatch),
+            .match_mapping_type = try dupeOptional(alloc, tmpl.match_mapping_type),
+            .scalar_type = try alloc.dupe(u8, scalar.?),
+        });
+    }
 
     for (schema.document_schemas) |document_schema| {
         if (document_schema.additional_properties_allowed orelse false) {
@@ -101,10 +157,29 @@ pub fn compilePlanAlloc(alloc: Allocator, schema: schema_mod.ParsedTableSchema) 
     return .{
         .schema_version = schema.version,
         .fields = try fields.toOwnedSlice(alloc),
+        .dynamic_rules = try dynamic_rules.toOwnedSlice(alloc),
         .skipped_dynamic_fields = skipped_dynamic_fields,
         .skipped_complex_fields = skipped_complex_fields,
         .skipped_unbounded_fields = skipped_unbounded_fields,
     };
+}
+
+fn dupeOptional(alloc: Allocator, value: ?[]const u8) !?[]u8 {
+    return if (value) |v| try alloc.dupe(u8, v) else null;
+}
+
+/// Map a dynamic-template Antfly field type onto the bounded algebraic scalar it
+/// projects into, or null when the type is unbounded/unsupported (text, html,
+/// search_as_you_type, embedding, geo, blob) and must stay schemaless.
+fn boundedScalarForTemplateType(field_type: []const u8) ?[]const u8 {
+    if (std.mem.eql(u8, field_type, "keyword") or
+        std.mem.eql(u8, field_type, "link") or
+        std.mem.eql(u8, field_type, "string")) return "string";
+    if (std.mem.eql(u8, field_type, "boolean") or std.mem.eql(u8, field_type, "bool")) return "boolean";
+    if (std.mem.eql(u8, field_type, "datetime")) return "datetime";
+    if (std.mem.eql(u8, field_type, "numeric") or std.mem.eql(u8, field_type, "number")) return "number";
+    if (std.mem.eql(u8, field_type, "integer")) return "integer";
+    return null;
 }
 
 pub fn configJsonFromSchemaJsonAlloc(alloc: Allocator, table_name: []const u8, schema_json: []const u8) ![]u8 {
@@ -171,6 +246,11 @@ pub fn configJsonFromPlanAlloc(alloc: Allocator, table_name: []const u8, plan: P
     try out.append(alloc, ':');
     try appendFieldArray(alloc, &out, plan, .time);
 
+    try out.append(alloc, ',');
+    try appendJsonString(alloc, &out, "dynamic_field_rules");
+    try out.append(alloc, ':');
+    try appendDynamicRuleArray(alloc, &out, plan);
+
     try out.appendSlice(alloc, ",");
     try appendJsonString(alloc, &out, "laws");
     try out.appendSlice(alloc, ":[");
@@ -231,6 +311,17 @@ pub fn capabilityFingerprintAlloc(alloc: Allocator, plan: Plan) ![]u8 {
             field.name,
             field.path,
             field.scalar_type,
+        });
+    }
+    for (plan.dynamic_rules) |rule| {
+        try appendFmt(alloc, &canonical, "dyn:{s}:{s}:{s}:{s}:{s}:{s}:{s}|", .{
+            rule.name,
+            rule.scalar_type,
+            rule.match orelse "",
+            rule.unmatch orelse "",
+            rule.path_match orelse "",
+            rule.path_unmatch orelse "",
+            rule.match_mapping_type orelse "",
         });
     }
     try appendFmt(alloc, &canonical, "skip:{d}:{d}:{d}", .{
@@ -300,6 +391,45 @@ fn sameFieldIdentity(lhs: FieldCapability, rhs: FieldCapability) bool {
         std.mem.eql(u8, lhs.document_type, rhs.document_type) and
         std.mem.eql(u8, lhs.name, rhs.name) and
         std.mem.eql(u8, lhs.path, rhs.path);
+}
+
+fn appendDynamicRuleArray(
+    alloc: Allocator,
+    out: *std.ArrayListUnmanaged(u8),
+    plan: Plan,
+) !void {
+    try out.append(alloc, '[');
+    for (plan.dynamic_rules, 0..) |rule, i| {
+        if (i > 0) try out.append(alloc, ',');
+        try out.append(alloc, '{');
+        try appendJsonString(alloc, out, "name");
+        try out.append(alloc, ':');
+        try appendJsonString(alloc, out, rule.name);
+        try appendOptionalJsonField(alloc, out, "match", rule.match);
+        try appendOptionalJsonField(alloc, out, "unmatch", rule.unmatch);
+        try appendOptionalJsonField(alloc, out, "path_match", rule.path_match);
+        try appendOptionalJsonField(alloc, out, "path_unmatch", rule.path_unmatch);
+        try appendOptionalJsonField(alloc, out, "match_mapping_type", rule.match_mapping_type);
+        try out.append(alloc, ',');
+        try appendJsonString(alloc, out, "type");
+        try out.append(alloc, ':');
+        try appendJsonString(alloc, out, rule.scalar_type);
+        try out.append(alloc, '}');
+    }
+    try out.append(alloc, ']');
+}
+
+fn appendOptionalJsonField(
+    alloc: Allocator,
+    out: *std.ArrayListUnmanaged(u8),
+    key: []const u8,
+    value: ?[]const u8,
+) !void {
+    const v = value orelse return;
+    try out.append(alloc, ',');
+    try appendJsonString(alloc, out, key);
+    try out.append(alloc, ':');
+    try appendJsonString(alloc, out, v);
 }
 
 fn appendFieldArray(
@@ -593,6 +723,76 @@ test "schema capability change classification separates additive from rebuild ch
     try std.testing.expectEqual(@as(u32, 1), breaking.changed_type_fields);
     try std.testing.expect(!breaking.compatible_additive);
     try std.testing.expect(breaking.requires_rebuild);
+}
+
+test "schema capability compiles bounded dynamic templates into runtime rules" {
+    const alloc = std.testing.allocator;
+    var parsed = try schema_mod.parseValidatedTableSchema(alloc,
+        \\{"version":9,"default_type":"doc",
+        \\"document_schemas":{"doc":{"schema":{"type":"object","properties":{"title":{"type":"text"}}}}},
+        \\"dynamic_templates":[
+        \\{"name":"ids_as_keyword","match":"*_id","mapping":{"type":"keyword"}},
+        \\{"name":"metrics_as_numeric","path_match":"metrics.*","mapping":{"type":"numeric"}},
+        \\{"name":"events_as_date","match_mapping_type":"date","mapping":{"type":"datetime"}},
+        \\{"name":"bodies_as_text","match":"body_*","mapping":{"type":"text"}},
+        \\{"name":"only_negative","unmatch":"skip_*","mapping":{"type":"keyword"}}
+        \\]}
+    );
+    defer parsed.deinit(alloc);
+
+    var plan = try compilePlanAlloc(alloc, parsed);
+    defer plan.deinit(alloc);
+
+    // keyword + numeric + datetime templates are bounded with positive selectors
+    // => 3 rules. The text template (unbounded) and the negative-only template
+    // (no positive selector) are skipped onto the schemaless path.
+    try std.testing.expectEqual(@as(usize, 3), plan.dynamic_rules.len);
+    try std.testing.expect(plan.skipped_unbounded_fields >= 2);
+
+    const config_json = try configJsonFromPlanAlloc(alloc, "orders", plan);
+    defer alloc.free(config_json);
+    var parsed_config = try std.json.parseFromSlice(index_mod.Config, alloc, config_json, .{ .allocate = .alloc_always });
+    defer parsed_config.deinit();
+    try std.testing.expectEqual(@as(usize, 3), parsed_config.value.dynamic_field_rules.len);
+    // The emitted config must satisfy the index validator (selector present,
+    // bounded scalar type) so the index can open against it.
+    try index_mod.validateConfig(parsed_config.value);
+
+    var found_numeric = false;
+    for (parsed_config.value.dynamic_field_rules) |rule| {
+        if (std.mem.eql(u8, rule.name, "metrics_as_numeric")) {
+            try std.testing.expectEqualStrings("metrics.*", rule.path_match.?);
+            try std.testing.expectEqualStrings("number", rule.type);
+            found_numeric = true;
+        }
+    }
+    try std.testing.expect(found_numeric);
+}
+
+test "schema capability fingerprint reflects dynamic template type change" {
+    const alloc = std.testing.allocator;
+    var keyword_schema = try schema_mod.parseValidatedTableSchema(alloc,
+        \\{"version":1,"default_type":"doc","document_schemas":{"doc":{"schema":{"type":"object","properties":{"title":{"type":"text"}}}}},"dynamic_templates":[{"name":"ext","match":"ext_*","mapping":{"type":"keyword"}}]}
+    );
+    defer keyword_schema.deinit(alloc);
+    var numeric_schema = try schema_mod.parseValidatedTableSchema(alloc,
+        \\{"version":1,"default_type":"doc","document_schemas":{"doc":{"schema":{"type":"object","properties":{"title":{"type":"text"}}}}},"dynamic_templates":[{"name":"ext","match":"ext_*","mapping":{"type":"numeric"}}]}
+    );
+    defer numeric_schema.deinit(alloc);
+
+    var keyword_plan = try compilePlanAlloc(alloc, keyword_schema);
+    defer keyword_plan.deinit(alloc);
+    var numeric_plan = try compilePlanAlloc(alloc, numeric_schema);
+    defer numeric_plan.deinit(alloc);
+
+    const keyword_fp = try capabilityFingerprintAlloc(alloc, keyword_plan);
+    defer alloc.free(keyword_fp);
+    const numeric_fp = try capabilityFingerprintAlloc(alloc, numeric_plan);
+    defer alloc.free(numeric_fp);
+
+    // A template-only type change (same schema version) must still shift the
+    // capability fingerprint so the sidecar detects drift.
+    try std.testing.expect(!std.mem.eql(u8, keyword_fp, numeric_fp));
 }
 
 fn expectCapability(

--- a/zig/pkg/antfly/src/storage/db/algebraic/schema_capability.zig
+++ b/zig/pkg/antfly/src/storage/db/algebraic/schema_capability.zig
@@ -108,14 +108,18 @@ pub fn compilePlanAlloc(alloc: Allocator, schema: schema_mod.ParsedTableSchema) 
     var skipped_unbounded_fields: u32 = 0;
 
     for (schema.dynamic_templates) |tmpl| {
-        // A template needs at least one positive/type selector; one with only
-        // negative (or no) selectors would blanket-match every field, so it is
-        // not safe to promote into bounded algebraic facts.
-        const has_positive_selector = tmpl.match_pattern != null or tmpl.path_match != null or tmpl.match_mapping_type != null;
+        // An algebraic rule needs a name/path selector (`match` / `path_match`).
+        // `match_mapping_type` alone is NOT enough: it can be evaluated at ingest
+        // (a value is present) but never at query time (no value), so a
+        // mapping-type-only rule would project docfacts that no query can ever
+        // resolve. Such templates stay on the schemaless path-fact path so ingest
+        // and query resolution remain symmetric.
+        const has_named_selector = tmpl.match_pattern != null or tmpl.path_match != null;
         const scalar = boundedScalarForTemplateType(tmpl.field_type orelse "text");
-        if (!has_positive_selector or scalar == null) {
-            // Unbounded/open text templates and overly-broad selectors stay on
-            // the schemaless path-fact path rather than typed docfacts.
+        if (!has_named_selector or scalar == null) {
+            // Unbounded/open text templates and selector-less / mapping-type-only
+            // templates stay on the schemaless path-fact path rather than typed
+            // docfacts.
             skipped_dynamic_fields += 1;
             skipped_unbounded_fields += 1;
             continue;
@@ -743,17 +747,21 @@ test "schema capability compiles bounded dynamic templates into runtime rules" {
     var plan = try compilePlanAlloc(alloc, parsed);
     defer plan.deinit(alloc);
 
-    // keyword + numeric + datetime templates are bounded with positive selectors
-    // => 3 rules. The text template (unbounded) and the negative-only template
-    // (no positive selector) are skipped onto the schemaless path.
-    try std.testing.expectEqual(@as(usize, 3), plan.dynamic_rules.len);
-    try std.testing.expect(plan.skipped_unbounded_fields >= 2);
+    // Only templates with a name/path selector AND a bounded type become rules:
+    // ids (keyword/match) and metrics (numeric/path_match) => 2 rules. Skipped:
+    // the date template (match_mapping_type-only — can't resolve at query time),
+    // the text template (unbounded), and the negative-only template.
+    try std.testing.expectEqual(@as(usize, 2), plan.dynamic_rules.len);
+    try std.testing.expect(plan.skipped_unbounded_fields >= 3);
+    for (plan.dynamic_rules) |rule| {
+        try std.testing.expect(!std.mem.eql(u8, rule.name, "events_as_date"));
+    }
 
     const config_json = try configJsonFromPlanAlloc(alloc, "orders", plan);
     defer alloc.free(config_json);
     var parsed_config = try std.json.parseFromSlice(index_mod.Config, alloc, config_json, .{ .allocate = .alloc_always });
     defer parsed_config.deinit();
-    try std.testing.expectEqual(@as(usize, 3), parsed_config.value.dynamic_field_rules.len);
+    try std.testing.expectEqual(@as(usize, 2), parsed_config.value.dynamic_field_rules.len);
     // The emitted config must satisfy the index validator (selector present,
     // bounded scalar type) so the index can open against it.
     try index_mod.validateConfig(parsed_config.value);

--- a/zig/pkg/antfly/src/storage/db/catalog/index_manager.zig
+++ b/zig/pkg/antfly/src/storage/db/catalog/index_manager.zig
@@ -2328,6 +2328,28 @@ pub const IndexManager = struct {
         entry.config.deinit(self.alloc);
     }
 
+    /// Regenerate every algebraic index's schema-derived config from `schema_json`
+    /// and apply it in place. This propagates a dynamic-template change to live
+    /// indexes without a reopen; it is semantically equivalent to what a fresh
+    /// open would produce (lazy backfill — only new/rewritten docs reflect new
+    /// rules). No-op when there are no algebraic indexes or no schema.
+    pub fn reloadAlgebraicSchemaConfigs(self: *IndexManager, schema_json: []const u8) !void {
+        if (schema_json.len == 0) return;
+        for (self.algebraic_indexes.items) |*entry| {
+            const table_name = entry.index.config().table;
+            const new_config_json = try algebraic_mod.schema_capability.configJsonFromSchemaJsonAlloc(self.alloc, table_name, schema_json);
+            defer self.alloc.free(new_config_json);
+            // Skip the swap when the regenerated config is unchanged so periodic
+            // reconciles don't needlessly re-parse and reset the live config.
+            if (std.mem.eql(u8, new_config_json, entry.config.config_json)) continue;
+            const owned = try self.alloc.dupe(u8, new_config_json);
+            errdefer self.alloc.free(owned);
+            try entry.index.reloadConfigJson(new_config_json);
+            self.alloc.free(entry.config.config_json);
+            entry.config.config_json = owned;
+        }
+    }
+
     fn freeAlgebraicIndexEntry(self: *IndexManager, entry: *AlgebraicIndex) void {
         entry.index.close();
         self.destroyIndexApplyMutex(entry.apply_mutex);

--- a/zig/pkg/antfly/src/storage/db/catalog/index_manager.zig
+++ b/zig/pkg/antfly/src/storage/db/catalog/index_manager.zig
@@ -2329,22 +2329,60 @@ pub const IndexManager = struct {
     }
 
     /// Regenerate every algebraic index's schema-derived config from `schema_json`
-    /// and apply it in place. This propagates a dynamic-template change to live
-    /// indexes without a reopen; it is semantically equivalent to what a fresh
-    /// open would produce (lazy backfill — only new/rewritten docs reflect new
-    /// rules). No-op when there are no algebraic indexes or no schema.
+    /// and apply it in place when the schema-derived capability actually changed.
+    /// Carries forward user-tunable runtime knobs, and sets
+    /// dynamic_rules_backfill_pending on a real change so query-time resolution of
+    /// dynamic-template fields is withheld (those aggregations fall back to a
+    /// complete scan instead of reading facts that only cover post-change docs)
+    /// until the index is rebuilt. No-op when there are no algebraic indexes, no
+    /// schema, or the capability fingerprint is unchanged.
     pub fn reloadAlgebraicSchemaConfigs(self: *IndexManager, schema_json: []const u8) !void {
         if (schema_json.len == 0) return;
         for (self.algebraic_indexes.items) |*entry| {
-            const table_name = entry.index.config().table;
-            const new_config_json = try algebraic_mod.schema_capability.configJsonFromSchemaJsonAlloc(self.alloc, table_name, schema_json);
+            const cur = entry.index.config();
+            const new_config_json = try algebraic_mod.schema_capability.configJsonFromSchemaJsonAlloc(self.alloc, cur.table, schema_json);
             defer self.alloc.free(new_config_json);
-            // Skip the swap when the regenerated config is unchanged so periodic
-            // reconciles don't needlessly re-parse and reset the live config.
-            if (std.mem.eql(u8, new_config_json, entry.config.config_json)) continue;
-            const owned = try self.alloc.dupe(u8, new_config_json);
+
+            var new_parsed = try std.json.parseFromSlice(algebraic_mod.index.Config, self.alloc, new_config_json, .{ .allocate = .alloc_always });
+            defer new_parsed.deinit();
+
+            // Skip when the schema-derived capability is unchanged. Compare the
+            // capability fingerprint (which encodes schema_version, fields, and
+            // dynamic-template rules) rather than raw bytes: the live and durable
+            // serializations differ in shape and tunable knobs, so a byte compare
+            // would never short-circuit and every reconcile would churn the
+            // live config.
+            if (cur.capability_fingerprint.len > 0 and
+                std.mem.eql(u8, new_parsed.value.capability_fingerprint, cur.capability_fingerprint)) continue;
+
+            // Carry forward user-tunable runtime knobs (the durable regeneration
+            // in api/tables.zig preserves the same set) so a schema/template
+            // change does not silently reset planner/adaptive tuning in place.
+            new_parsed.value.adaptive = cur.adaptive;
+            new_parsed.value.pathfact_policy = cur.pathfact_policy;
+            new_parsed.value.max_result_buckets = cur.max_result_buckets;
+            new_parsed.value.max_planner_scan_rows = cur.max_planner_scan_rows;
+            new_parsed.value.max_batch_accumulator_entries = cur.max_batch_accumulator_entries;
+            new_parsed.value.min_max_candidate_cache_size = cur.min_max_candidate_cache_size;
+            new_parsed.value.enable_temporal_range_pruning = cur.enable_temporal_range_pruning;
+
+            // The capability changed against an already-open table, so existing
+            // documents have not been re-projected through the new dynamic rules.
+            // Mark dynamic-field resolution as backfill-pending so aggregations
+            // over template-promoted fields fall back to a complete scan (correct
+            // results) instead of reading facts that only cover docs written after
+            // the change. Static fields keep accelerating. The durable
+            // regeneration in api/tables.zig sets the same flag so it survives
+            // reopen. (Table create takes the fingerprint-equality skip above, so
+            // a freshly-built index is never flagged.)
+            new_parsed.value.dynamic_rules_backfill_pending = true;
+
+            const merged_json = try std.json.Stringify.valueAlloc(self.alloc, new_parsed.value, .{ .emit_null_optional_fields = false });
+            defer self.alloc.free(merged_json);
+
+            const owned = try self.alloc.dupe(u8, merged_json);
             errdefer self.alloc.free(owned);
-            try entry.index.reloadConfigJson(new_config_json);
+            try entry.index.reloadConfigJson(merged_json);
             self.alloc.free(entry.config.config_json);
             entry.config.config_json = owned;
         }

--- a/zig/pkg/antfly/src/storage/db/db.zig
+++ b/zig/pkg/antfly/src/storage/db/db.zig
@@ -14699,6 +14699,13 @@ pub const DB = struct {
         return try self.core.getStoreValue(alloc, public_schema_json_key);
     }
 
+    /// Refresh schema-derived algebraic index configs (notably dynamic-template
+    /// rules) in place from the given table schema JSON, so a dynamic-template
+    /// change applies to a running DB without a reopen.
+    pub fn reloadAlgebraicSchemaConfigs(self: *DB, schema_json: []const u8) !void {
+        try self.core.index_manager.reloadAlgebraicSchemaConfigs(schema_json);
+    }
+
     pub fn beginTransaction(self: *DB, timestamp_ns: u64) !transactions_mod.TxnId {
         const txn_id = makeTxnId(self);
         return try self.beginTransactionWithIdAndParticipants(txn_id, timestamp_ns, &.{});

--- a/zig/pkg/antfly/src/storage/schema.zig
+++ b/zig/pkg/antfly/src/storage/schema.zig
@@ -1175,6 +1175,13 @@ fn dynamicTemplateMatchesDeclaredPath(
     return true;
 }
 
+/// Public wrapper exposing the canonical `match_mapping_type` inference so other
+/// indexes (e.g. the algebraic sidecar) evaluate dynamic-template selectors with
+/// identical semantics instead of re-implementing type detection.
+pub fn matchMappingTypeName(value: std.json.Value) ?[]const u8 {
+    return inferDynamicTemplateMatchType(value);
+}
+
 fn inferDynamicTemplateMatchType(value: std.json.Value) ?[]const u8 {
     return switch (value) {
         .string => |text| if (parseRfc3339ToNs(text) != null or isValidDate(text)) "date" else "string",


### PR DESCRIPTION
## What changed

- projects bounded dynamic-template matches into algebraic schema configuration
- keeps ingest and query projection symmetric
- reloads schema-derived configuration and gates pending backfills
- adds a focused dynamic-template test target

## Why

This recovers the independently useful work from closed PR #144 without bundling relational storage, SQL, graph metrics, or HLL changes.

## Impact

Eligible dynamic-template fields participate consistently in typed algebraic projection after schema updates.

## Validation

- `zig build algebraic-dynamic-template-test --summary all` — 14/14 passed, no leaks
- `git diff --check`