### PR TITLE
test(storage): stabilize algebraic repair activation

### DIFF
--- a/zig/pkg/antfly/src/storage/db/db.zig
+++ b/zig/pkg/antfly/src/storage/db/db.zig
@@ -71177,6 +71177,14 @@ test "db managed algebraic admission builds and reopens an isolated generation" 
     const path = tempPath(&path_buf);
     defer cleanupTempDir(path);
 
+    const repair_options = types.ArtifactRepairRunOptions{
+        // This test verifies durable generation construction, activation, and
+        // reopen—not the production reader-pause SLA. A contended CI worker
+        // can exhaust the 250 ms production window, which correctly persists
+        // retry backoff that this synchronous test loop does not wait out.
+        .max_activation_pause_ms = 5_000,
+    };
+
     const cfg = types.IndexConfig{
         .name = "analytics_idx",
         .kind = .algebraic,
@@ -71205,12 +71213,13 @@ test "db managed algebraic admission builds and reopens an isolated generation" 
 
         var repaired = false;
         for (0..16) |_| {
-            const step = try db.advanceIndexRepairIntent(alloc, repair_id, .{});
+            const step = try db.advanceIndexRepairIntent(alloc, repair_id, repair_options);
             if (step.repaired) {
                 repaired = true;
                 break;
             }
             try std.testing.expect(!step.terminal);
+            try std.testing.expectEqual(@as(u64, 0), step.next_retry_at_ms);
         }
         try std.testing.expect(repaired);
         try std.testing.expect(!db.core.index_manager.repairUnavailable(cfg.name));

--- a/zig/pkg/antfly/src/storage/db/db.zig
+++ b/zig/pkg/antfly/src/storage/db/db.zig
@@ -71171,19 +71171,19 @@ test "db managed vector admission durably seeds missing enrichment artifacts" {
     try std.testing.expect(db.core.index_manager.repairUnavailable("semantic_idx"));
 }
 
+// Functional repair tests verify durable construction, activation, and reopen,
+// not the production reader-pause SLA. A contended CI worker can exhaust the
+// 250 ms production window, which correctly persists retry backoff that these
+// synchronous completion loops do not wait out.
+const repair_completion_test_options = types.ArtifactRepairRunOptions{
+    .max_activation_pause_ms = 5_000,
+};
+
 test "db managed algebraic admission builds and reopens an isolated generation" {
     const alloc = std.testing.allocator;
     var path_buf: [256]u8 = undefined;
     const path = tempPath(&path_buf);
     defer cleanupTempDir(path);
-
-    const repair_options = types.ArtifactRepairRunOptions{
-        // This test verifies durable generation construction, activation, and
-        // reopen—not the production reader-pause SLA. A contended CI worker
-        // can exhaust the 250 ms production window, which correctly persists
-        // retry backoff that this synchronous test loop does not wait out.
-        .max_activation_pause_ms = 5_000,
-    };
 
     const cfg = types.IndexConfig{
         .name = "analytics_idx",
@@ -71213,7 +71213,7 @@ test "db managed algebraic admission builds and reopens an isolated generation" 
 
         var repaired = false;
         for (0..16) |_| {
-            const step = try db.advanceIndexRepairIntent(alloc, repair_id, repair_options);
+            const step = try db.advanceIndexRepairIntent(alloc, repair_id, repair_completion_test_options);
             if (step.repaired) {
                 repaired = true;
                 break;
@@ -71280,13 +71280,6 @@ test "db algebraic generation build yields and resumes from its durable source c
         }
     };
     var yield_token: u8 = 0;
-    const resume_options = types.ArtifactRepairRunOptions{
-        // This test covers durable cursor yield/resume, not the production
-        // activation pause SLA. Give contended CI hosts enough headroom so an
-        // activation timeout cannot arm retry backoff between immediate test
-        // attempts and masquerade as a failure to resume the saved cursor.
-        .max_activation_pause_ms = 5_000,
-    };
     var repair_id: u128 = 0;
     {
         var db = try DB.open(alloc, std.mem.span(path), .{
@@ -71303,7 +71296,7 @@ test "db algebraic generation build yields and resumes from its durable source c
             .sync_level = .write,
         });
         repair_id = (try db.admitManagedIndex(cfg)) orelse return error.TestUnexpectedResult;
-        var yield_options = resume_options;
+        var yield_options = repair_completion_test_options;
         yield_options.yield_check = .{ .ptr = &yield_token, .is_requested = Yield.requested };
         const first = try db.advanceIndexRepairIntent(alloc, repair_id, yield_options);
         try std.testing.expect(first.attempted);
@@ -71337,12 +71330,13 @@ test "db algebraic generation build yields and resumes from its durable source c
     try std.testing.expectEqual(repair_id, (try reopened.indexRepairIdForIndex(alloc, cfg.name)).?);
     var repaired = false;
     for (0..16) |_| {
-        const step = try reopened.advanceIndexRepairIntent(alloc, repair_id, resume_options);
+        const step = try reopened.advanceIndexRepairIntent(alloc, repair_id, repair_completion_test_options);
         if (step.repaired) {
             repaired = true;
             break;
         }
         try std.testing.expect(!step.terminal);
+        try std.testing.expectEqual(@as(u64, 0), step.next_retry_at_ms);
     }
     try std.testing.expect(repaired);
     const active = reopened.core.index_manager.algebraicIndex(cfg.name) orelse return error.TestUnexpectedResult;
@@ -71419,12 +71413,13 @@ test "db forced algebraic repair persists an operator generation intent before e
     try std.testing.expectEqual(repair_id, (try reopened.indexRepairIdForIndex(alloc, cfg.name)).?);
     var repaired = false;
     for (0..16) |_| {
-        const step = try reopened.advanceIndexRepairIntent(alloc, repair_id, .{});
+        const step = try reopened.advanceIndexRepairIntent(alloc, repair_id, repair_completion_test_options);
         if (step.repaired) {
             repaired = true;
             break;
         }
         try std.testing.expect(!step.terminal);
+        try std.testing.expectEqual(@as(u64, 0), step.next_retry_at_ms);
     }
     try std.testing.expect(repaired);
     try std.testing.expect((try reopened.indexRepairIdForIndex(alloc, cfg.name)) == null);
@@ -71487,12 +71482,13 @@ test "db algebraic post-commit activation crash recovers through generation repa
         return error.TestUnexpectedResult;
     var repaired = false;
     for (0..16) |_| {
-        const step = try reopened.advanceIndexRepairIntent(alloc, repair_id, .{});
+        const step = try reopened.advanceIndexRepairIntent(alloc, repair_id, repair_completion_test_options);
         if (step.repaired) {
             repaired = true;
             break;
         }
         try std.testing.expect(!step.terminal);
+        try std.testing.expectEqual(@as(u64, 0), step.next_retry_at_ms);
     }
     try std.testing.expect(repaired);
     try std.testing.expect(!reopened.core.index_manager.repairUnavailable(cfg.name));
@@ -71582,12 +71578,13 @@ test "db managed full text admission survives restart without in-place backfill"
 
     var repaired = false;
     for (0..16) |_| {
-        const step = try reopened.advanceIndexRepairIntent(alloc, repair_id, .{});
+        const step = try reopened.advanceIndexRepairIntent(alloc, repair_id, repair_completion_test_options);
         if (step.repaired) {
             repaired = true;
             break;
         }
         try std.testing.expect(!step.terminal);
+        try std.testing.expectEqual(@as(u64, 0), step.next_retry_at_ms);
     }
     try std.testing.expect(repaired);
     try std.testing.expect(!try reopened.hasPendingIndexRepairIntents(alloc));


### PR DESCRIPTION
## Summary

- decouple synchronous algebraic and full-text repair completion tests from the production 250 ms reader-pause SLA
- use one shared test-only activation policy with enough headroom for contended CI workers
- fail immediately and diagnostically if any completion loop unexpectedly schedules retry backoff

## Root cause

These tests synchronously poll durable repair intents, but inherited the production activation pause limit. On a contended runner, a valid repair can miss that bounded activation window and correctly persist `next_retry_at_ms`. The tight test loops do not wait for that production backoff, so every remaining iteration is deferred and the final `repaired` assertion fails.

This change leaves the production 250 ms activation policy and retry behavior unchanged. It only removes the unrelated latency assertion from a test whose purpose is generation construction, activation, and reopen correctness.

## Validation

- `zig build api-table-writes-production-regression-test --summary all` — 83/83 passed
- original failing algebraic test with the CI seed — passed
- four affected algebraic completion tests across 20 concurrent distinct seeds — 80/80 passed
- `zig build db-test --summary all -- --test-filter "db managed full text admission survives restart without in-place backfill"` — 1/1 passed
- affected full-text completion test across 20 concurrent distinct seeds — 20/20 passed
- `git diff --check`
