### PR TITLE
Label controlled release archive downloads

### DIFF
--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -55,6 +55,7 @@ jobs:
             "antfly_${version}_Linux_x86_64.tar.gz"
           do
             curl -fsSL \
+              --max-redirs 0 \
               -H "X-Antfly-Download-Channel: release-automation" \
               -H "X-Antfly-Audience: ci" \
               "${base}/${archive}" \

--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -54,7 +54,11 @@ jobs:
             "antfly_${version}_Linux_arm64.tar.gz" \
             "antfly_${version}_Linux_x86_64.tar.gz"
           do
-            curl -fsSL "${base}/${archive}" -o "dist/release-archives/${archive}"
+            curl -fsSL \
+              -H "X-Antfly-Download-Channel: release-automation" \
+              -H "X-Antfly-Audience: ci" \
+              "${base}/${archive}" \
+              -o "dist/release-archives/${archive}"
           done
 
       - uses: actions/setup-python@v5

--- a/.github/workflows/zig-tests.yml
+++ b/.github/workflows/zig-tests.yml
@@ -30,6 +30,7 @@ jobs:
       model_check: ${{ steps.detect.outputs.model_check }}
       trace_validate: ${{ steps.detect.outputs.trace_validate }}
       backup_s3: ${{ steps.detect.outputs.backup_s3 }}
+      release_tooling: ${{ steps.detect.outputs.release_tooling }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -48,6 +49,7 @@ jobs:
               echo "model_check=true"
               echo "trace_validate=true"
               echo "backup_s3=true"
+              echo "release_tooling=true"
             } >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -60,6 +62,7 @@ jobs:
                 echo "model_check=true"
                 echo "trace_validate=true"
                 echo "backup_s3=false"
+                echo "release_tooling=false"
               } >> "$GITHUB_OUTPUT"
             else
               {
@@ -67,6 +70,7 @@ jobs:
                 echo "model_check=false"
                 echo "trace_validate=false"
                 echo "backup_s3=true"
+                echo "release_tooling=false"
               } >> "$GITHUB_OUTPUT"
             fi
             exit 0
@@ -83,6 +87,7 @@ jobs:
               echo "model_check=true"
               echo "trace_validate=true"
               echo "backup_s3=true"
+              echo "release_tooling=true"
             } >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -155,6 +160,34 @@ jobs:
           else
             echo "trace_validate=true" >> "$GITHUB_OUTPUT"
           fi
+
+          if git diff --quiet "$base" "${{ github.sha }}" -- \
+            scripts/install.sh \
+            scripts/test_install_download_markers.sh \
+            .github/workflows/cli-publish.yml \
+            .github/workflows/zig-tests.yml
+          then
+            echo "release_tooling=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "release_tooling=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  release-tooling:
+    name: release-tooling
+    needs: changes
+    if: needs.changes.outputs.release_tooling == 'true'
+    runs-on: arc-antfly-standard
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Test release download markers
+        run: |
+          scripts/test_install_download_markers.sh
+          sh -n scripts/install.sh
+          bash -n scripts/test_install_download_markers.sh
 
   backup-s3-integration:
     name: backup-s3-integration

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -29,7 +29,8 @@ require() {
 download_archive() {
     case "${ANTFLY_DOWNLOAD_CLASS:-}" in
         employee|ci)
-            curl -A "antfly-installer/1" -H "X-Antfly-Audience: ${ANTFLY_DOWNLOAD_CLASS}" "$@"
+            curl -A "antfly-installer/1" -H "X-Antfly-Audience: ${ANTFLY_DOWNLOAD_CLASS}" \
+                --max-redirs 0 "$@"
             ;;
         ""|external)
             curl -A "antfly-installer/1" "$@"
@@ -225,6 +226,8 @@ Environment:
   unset, external, and invalid values are measured as external traffic. Values
   are caller-asserted and can be omitted or forged. They are not authentication
   credentials and must not be treated as proof of employee or CI identity.
+  Labeled requests reject redirects so their metric headers stay on the
+  versioned releases.antfly.io request.
 
   By default, it installs to:
     - /usr/local/bin (if running as root)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -26,6 +26,21 @@ require() {
     fi
 }
 
+download_archive() {
+    case "${ANTFLY_DOWNLOAD_CLASS:-}" in
+        employee|ci)
+            curl -A "antfly-installer/1" -H "X-Antfly-Audience: ${ANTFLY_DOWNLOAD_CLASS}" "$@"
+            ;;
+        ""|external)
+            curl -A "antfly-installer/1" "$@"
+            ;;
+        *)
+            warning "Ignoring invalid ANTFLY_DOWNLOAD_CLASS; expected external, employee, or ci"
+            curl -A "antfly-installer/1" "$@"
+            ;;
+    esac
+}
+
 # Detect OS and architecture
 detect_platform() {
     OS=$(uname -s | tr '[:upper:]' '[:lower:]')
@@ -88,7 +103,7 @@ EOF
     DOWNLOAD_URL="https://releases.antfly.io/antfly/${TAG}/${ARCHIVE_NAME}"
 
     status "Downloading from $DOWNLOAD_URL..."
-    if ! curl -fsSL "$DOWNLOAD_URL" -o "$TEMP_DIR/$ARCHIVE_NAME"; then
+    if ! download_archive -fsSL "$DOWNLOAD_URL" -o "$TEMP_DIR/$ARCHIVE_NAME"; then
         error "Failed to download Antfly. Please check your internet connection and the version number."
     fi
 
@@ -204,6 +219,10 @@ Options:
 Environment:
   This script will automatically detect your OS and architecture,
   download the appropriate binaries, and install them.
+
+  ANTFLY_DOWNLOAD_CLASS may be external, employee, or ci. Employee and CI
+  archive requests carry a metric label; missing or invalid values are treated
+  as external. The label is not an authentication credential.
 
   By default, it installs to:
     - /usr/local/bin (if running as root)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -220,9 +220,11 @@ Environment:
   This script will automatically detect your OS and architecture,
   download the appropriate binaries, and install them.
 
-  ANTFLY_DOWNLOAD_CLASS may be external, employee, or ci. Employee and CI
-  archive requests carry a metric label; missing or invalid values are treated
-  as external. The label is not an authentication credential.
+  ANTFLY_DOWNLOAD_CLASS supplies a best-effort analytics label for archive
+  requests. Set it to employee for staff downloads or ci for automated jobs;
+  unset, external, and invalid values are measured as external traffic. Values
+  are caller-asserted and can be omitted or forged. They are not authentication
+  credentials and must not be treated as proof of employee or CI identity.
 
   By default, it installs to:
     - /usr/local/bin (if running as root)

--- a/scripts/test_install_download_markers.sh
+++ b/scripts/test_install_download_markers.sh
@@ -77,10 +77,14 @@ employee_arguments="$(printf '%s\n' "$employee_files" | sed -n '1p')"
 assert_line "-A" "$employee_arguments"
 assert_line "antfly-installer/1" "$employee_arguments"
 assert_line "X-Antfly-Audience: employee" "$employee_arguments"
+assert_line "--max-redirs" "$employee_arguments"
+assert_line "0" "$employee_arguments"
 
 ci_files="$(run_case ci)"
 ci_arguments="$(printf '%s\n' "$ci_files" | sed -n '1p')"
 assert_line "X-Antfly-Audience: ci" "$ci_arguments"
+assert_line "--max-redirs" "$ci_arguments"
+assert_line "0" "$ci_arguments"
 
 external_files="$(run_case external)"
 external_arguments="$(printf '%s\n' "$external_files" | sed -n '1p')"
@@ -92,5 +96,17 @@ invalid_arguments="$(printf '%s\n' "$invalid_files" | sed -n '1p')"
 invalid_stderr="$(printf '%s\n' "$invalid_files" | sed -n '2p')"
 assert_no_audience_header "$invalid_arguments"
 grep -Fq "Ignoring invalid ANTFLY_DOWNLOAD_CLASS" "$invalid_stderr"
+
+publish_workflow="$repo_root/.github/workflows/cli-publish.yml"
+for expected in \
+  '--max-redirs 0' \
+  'X-Antfly-Download-Channel: release-automation' \
+  'X-Antfly-Audience: ci'
+do
+  grep -Fq -- "$expected" "$publish_workflow" || {
+    echo "missing release automation marker '$expected' in $publish_workflow" >&2
+    exit 1
+  }
+done
 
 echo "install download marker tests passed"

--- a/scripts/test_install_download_markers.sh
+++ b/scripts/test_install_download_markers.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+test_root="$(mktemp -d)"
+trap 'rm -rf "$test_root"' EXIT
+mkdir -p "$test_root/bin" "$test_root/home"
+
+cat >"$test_root/bin/uname" <<'EOF'
+#!/bin/sh
+case "$1" in
+  -s) printf 'Linux\n' ;;
+  -m) printf 'x86_64\n' ;;
+  *) exit 1 ;;
+esac
+EOF
+
+cat >"$test_root/bin/id" <<'EOF'
+#!/bin/sh
+if [ "${1:-}" = "-u" ]; then
+  printf '1000\n'
+else
+  /usr/bin/id "$@"
+fi
+EOF
+
+cat >"$test_root/bin/tar" <<'EOF'
+#!/bin/sh
+exit 0
+EOF
+
+cat >"$test_root/bin/curl" <<'EOF'
+#!/bin/sh
+printf '%s\n' "$@" >"$CURL_ARGUMENTS_FILE"
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "-o" ]; then
+    shift
+    : >"$1"
+    break
+  fi
+  shift
+done
+EOF
+chmod +x "$test_root/bin/"*
+
+run_case() {
+  local class="$1"
+  local arguments_file="$test_root/curl-${class:-missing}.txt"
+  local stderr_file="$test_root/stderr-${class:-missing}.txt"
+  CURL_ARGUMENTS_FILE="$arguments_file" \
+    ANTFLY_DOWNLOAD_CLASS="$class" \
+    HOME="$test_root/home" \
+    PATH="$test_root/bin:/usr/bin:/bin" \
+    sh "$repo_root/scripts/install.sh" v1.2.3 >/dev/null 2>"$stderr_file"
+  printf '%s\n' "$arguments_file" "$stderr_file"
+}
+
+assert_line() {
+  local expected="$1"
+  local file="$2"
+  grep -Fqx -- "$expected" "$file" || {
+    echo "missing expected curl argument '$expected' in $file" >&2
+    exit 1
+  }
+}
+
+assert_no_audience_header() {
+  local file="$1"
+  if grep -Fq -- "X-Antfly-Audience:" "$file"; then
+    echo "unexpected audience header in $file" >&2
+    exit 1
+  fi
+}
+
+employee_files="$(run_case employee)"
+employee_arguments="$(printf '%s\n' "$employee_files" | sed -n '1p')"
+assert_line "-A" "$employee_arguments"
+assert_line "antfly-installer/1" "$employee_arguments"
+assert_line "X-Antfly-Audience: employee" "$employee_arguments"
+
+ci_files="$(run_case ci)"
+ci_arguments="$(printf '%s\n' "$ci_files" | sed -n '1p')"
+assert_line "X-Antfly-Audience: ci" "$ci_arguments"
+
+external_files="$(run_case external)"
+external_arguments="$(printf '%s\n' "$external_files" | sed -n '1p')"
+assert_line "antfly-installer/1" "$external_arguments"
+assert_no_audience_header "$external_arguments"
+
+invalid_files="$(run_case not-valid)"
+invalid_arguments="$(printf '%s\n' "$invalid_files" | sed -n '1p')"
+invalid_stderr="$(printf '%s\n' "$invalid_files" | sed -n '2p')"
+assert_no_audience_header "$invalid_arguments"
+grep -Fq "Ignoring invalid ANTFLY_DOWNLOAD_CLASS" "$invalid_stderr"
+
+echo "install download marker tests passed"


### PR DESCRIPTION
Implemented by Codex.

Summary:
- send User-Agent antfly-installer/1 on installer archive requests
- accept ANTFLY_DOWNLOAD_CLASS=external, employee, or ci; only employee and ci send the metric-label header
- treat missing or invalid values as external without breaking installs
- label direct CLI packaging downloads as release automation and CI
- reject redirects for labeled installer and release-automation requests so metric headers remain on the versioned release host
- add a hermetic installer and release-workflow marker test

These headers are caller-asserted metric labels only. They can be omitted or forged and must not authorize access or prove employee or CI identity.

Validation:
- installer and release-workflow marker test passes
- sh/bash syntax checks pass
- ShellCheck passes (excluding the installer script's pre-existing POSIX local warning)
- actionlint passes
- a live one-byte versioned archive request returned 206 with Content-Range and zero redirects while redirect rejection was enabled
- git diff --check passes
