### PR TITLE
ci(zig): parallelize unit and recall checks

### DIFF
--- a/.github/workflows/zig-tests.yml
+++ b/.github/workflows/zig-tests.yml
@@ -289,6 +289,8 @@ jobs:
           tools/test_run_bounded_zig_build.py
           tools/test_analyze_zig_import_graph.py
           tools/test_audit_storage_test_shards.py
+          tools/test_run_test_partitions.py
+          tools/test_run_recall_checks.py
 
       - name: Check inference kernel generator
         working-directory: zig/pkg/inference
@@ -560,6 +562,8 @@ jobs:
           tools/test_run_bounded_zig_build.py
           tools/test_analyze_zig_import_graph.py
           tools/test_audit_storage_test_shards.py
+          tools/test_run_test_partitions.py
+          tools/test_run_recall_checks.py
 
       # Keep normal build-step parallelism while bounding aggregate compiler
       # memory to the pod's cgroup budget.
@@ -600,6 +604,7 @@ jobs:
           taskset -c ${{ steps.cpus.outputs.list }}
           python3 tools/run_bounded_zig_build.py --zig zig -- build
           release-scale-test
+          recall-harness-build
           --build-runner ${{ steps.cpus.outputs.build_runner }}
           --maxrss ${{ steps.cpus.outputs.max_rss }}
 
@@ -633,42 +638,14 @@ jobs:
           --build-runner ${{ steps.cpus.outputs.build_runner }}
           --maxrss ${{ steps.cpus.outputs.max_rss }}
 
-      - name: Run Zig recall tests
+      - name: Run Zig recall checks
         working-directory: zig
         run: >-
           taskset -c ${{ steps.cpus.outputs.list }}
           python3 tools/run_bounded_zig_build.py --zig zig -- build
-          recall-test
+          recall-ci-test
           --build-runner ${{ steps.cpus.outputs.build_runner }}
           --maxrss ${{ steps.cpus.outputs.max_rss }}
-
-      - name: Run Zig recall harness sweep
-        working-directory: zig
-        run: |
-          set -euo pipefail
-          datasets=(
-            images-512d-10k.gob
-            random-20d-1k.gob
-            fashionminst-784d-1k.gob
-            fashionminst-784d-10k.gob
-            laionclip-768d-1k.gob
-            laiongemini-1408d-1k.gob
-            laiongemini-512d-10k.gob
-            dbpedia-1536d-1k.gob
-            random-2048d-1k.gob
-            random-4096d-1k.gob
-            wikiarticles-768d-10k.gob
-          )
-          for dataset in "${datasets[@]}"; do
-            echo "::group::recall-harness ${dataset}"
-            taskset -c ${{ steps.cpus.outputs.list }} \
-              python3 tools/run_bounded_zig_build.py --zig zig -- build \
-              recall-harness \
-              --build-runner ${{ steps.cpus.outputs.build_runner }} \
-              --maxrss ${{ steps.cpus.outputs.max_rss }} \
-              -- --dataset-dir testdata/vectorsets --dataset "${dataset}"
-            echo "::endgroup::"
-          done
 
       - name: Run Zig chaos tests
         working-directory: zig

--- a/zig/bench/vectors/recall_harness.zig
+++ b/zig/bench/vectors/recall_harness.zig
@@ -37,6 +37,7 @@ const Config = struct {
     dataset_dir: []const u8,
     suite: Suite = .both,
     dataset_filter: ?[]const u8 = null,
+    metric: ?vec.DistanceMetric = null,
     bulk_build: bool = false,
     centroid_only_routing: bool = false,
     dump_query_index: ?usize = null,
@@ -115,6 +116,8 @@ fn parseArgs(args_in: std.process.Args) !Config {
             cfg.suite = parseSuite(raw) orelse return error.InvalidArgument;
         } else if (std.mem.eql(u8, arg, "--dataset")) {
             cfg.dataset_filter = args.next() orelse return error.InvalidArgument;
+        } else if (std.mem.eql(u8, arg, "--metric")) {
+            cfg.metric = parseMetric(args.next() orelse return error.InvalidArgument) orelse return error.InvalidArgument;
         } else if (std.mem.eql(u8, arg, "--bulk-build")) {
             cfg.bulk_build = true;
         } else if (std.mem.eql(u8, arg, "--centroid-only-routing")) {
@@ -184,34 +187,72 @@ fn runSuite(
             );
             return err;
         };
-        const case_ok = compareMetrics(case, actual);
+        const case_ok = compareMetrics(cfg, case, actual);
         all_ok = all_ok and case_ok;
 
-        std.debug.print(
-            "{s} dataset={s} randomize={any} count={d} topk={d} recall(E={d:.2} IP={d:.2} C={d:.2}) expected(E={d:.2} IP={d:.2} C={d:.2}) {s}\n",
-            .{
-                suite_name,
-                case.dataset,
-                case.randomize,
-                case.count,
-                case.top_k,
-                actual.euclidean,
-                actual.inner_product,
-                actual.cosine,
-                case.expected.euclidean,
-                case.expected.inner_product,
-                case.expected.cosine,
-                if (case_ok) "OK" else "MISMATCH",
-            },
-        );
+        if (cfg.metric) |metric| {
+            std.debug.print(
+                "{s} dataset={s} randomize={any} count={d} topk={d} metric={s} recall={d:.2} expected={d:.2} {s}\n",
+                .{
+                    suite_name,
+                    case.dataset,
+                    case.randomize,
+                    case.count,
+                    case.top_k,
+                    @tagName(metric),
+                    metricValue(actual, metric),
+                    metricValue(case.expected, metric),
+                    if (case_ok) "OK" else "MISMATCH",
+                },
+            );
+        } else {
+            std.debug.print(
+                "{s} dataset={s} randomize={any} count={d} topk={d} recall(E={d:.2} IP={d:.2} C={d:.2}) expected(E={d:.2} IP={d:.2} C={d:.2}) {s}\n",
+                .{
+                    suite_name,
+                    case.dataset,
+                    case.randomize,
+                    case.count,
+                    case.top_k,
+                    actual.euclidean,
+                    actual.inner_product,
+                    actual.cosine,
+                    case.expected.euclidean,
+                    case.expected.inner_product,
+                    case.expected.cosine,
+                    if (case_ok) "OK" else "MISMATCH",
+                },
+            );
+        }
     }
     return all_ok;
 }
 
-fn compareMetrics(case: RecallCase, actual: common.MetricStats) bool {
+fn compareMetrics(cfg: Config, case: RecallCase, actual: common.MetricStats) bool {
+    if (cfg.metric) |metric| {
+        return approxEq(metricValue(actual, metric), metricValue(case.expected, metric), case.tolerance);
+    }
     return approxEq(actual.euclidean, case.expected.euclidean, case.tolerance) and
         approxEq(actual.inner_product, case.expected.inner_product, case.tolerance) and
         approxEq(actual.cosine, case.expected.cosine, case.tolerance);
+}
+
+fn metricValue(stats: common.MetricStats, metric: vec.DistanceMetric) f64 {
+    return switch (metric) {
+        .l2_squared => stats.euclidean,
+        .inner_product => stats.inner_product,
+        .cosine => stats.cosine,
+    };
+}
+
+fn singleMetricStats(metric: vec.DistanceMetric, value: f64) common.MetricStats {
+    var stats: common.MetricStats = .{ .euclidean = 0, .inner_product = 0, .cosine = 0 };
+    switch (metric) {
+        .l2_squared => stats.euclidean = value,
+        .inner_product => stats.inner_product = value,
+        .cosine => stats.cosine = value,
+    }
+    return stats;
 }
 
 fn approxEq(actual: f64, expected: f64, tolerance: f64) bool {
@@ -232,7 +273,6 @@ fn convertedDatasetName(alloc: std.mem.Allocator, gob_name: []const u8) ![]u8 {
 }
 
 fn runQuantizerCase(io: std.Io, alloc: std.mem.Allocator, cfg: Config, dataset_path: []const u8, case: RecallCase) !common.MetricStats {
-    _ = cfg;
     std.debug.print("recall_harness_load_start suite=quantizer dataset={s} path={s}\n", .{ case.dataset, dataset_path });
     var loaded = try common.loadVectorSet(io, alloc, dataset_path);
     defer loaded.deinit(alloc);
@@ -256,6 +296,12 @@ fn runQuantizerCase(io: std.Io, alloc: std.mem.Allocator, cfg: Config, dataset_p
         std.debug.print("recall_harness_randomize_done suite=quantizer dataset={s}\n", .{case.dataset});
     }
 
+    if (cfg.metric) |metric| {
+        return singleMetricStats(
+            metric,
+            100.0 * try calculateQuantizerRecallMetric(alloc, case.dataset, split, case.top_k, metric),
+        );
+    }
     const euclidean = 100.0 * try calculateQuantizerRecallMetric(alloc, case.dataset, split, case.top_k, .l2_squared);
     const inner_product = 100.0 * try calculateQuantizerRecallMetric(alloc, case.dataset, split, case.top_k, .inner_product);
     const cosine = 100.0 * try calculateQuantizerRecallMetric(alloc, case.dataset, split, case.top_k, .cosine);
@@ -381,6 +427,12 @@ fn runHBCCase(io: std.Io, alloc: std.mem.Allocator, cfg: Config, dataset_path: [
         }
     }
 
+    if (cfg.metric) |metric| {
+        return singleMetricStats(
+            metric,
+            100.0 * try calculateHBCRecallMetric(alloc, case.dataset, split, case.top_k, case.randomize, metric, cfg.bulk_build, cfg.centroid_only_routing),
+        );
+    }
     const euclidean = 100.0 * try calculateHBCRecallMetric(alloc, case.dataset, split, case.top_k, case.randomize, .l2_squared, cfg.bulk_build, cfg.centroid_only_routing);
     const inner_product = 100.0 * try calculateHBCRecallMetric(alloc, case.dataset, split, case.top_k, case.randomize, .inner_product, cfg.bulk_build, cfg.centroid_only_routing);
     const cosine = 100.0 * try calculateHBCRecallMetric(alloc, case.dataset, split, case.top_k, case.randomize, .cosine, cfg.bulk_build, cfg.centroid_only_routing);

--- a/zig/build.zig
+++ b/zig/build.zig
@@ -234,6 +234,29 @@ fn addRuntimeSkipTestFilters(run: *std.Build.Step.Run, filters: []const []const 
     }
 }
 
+fn configureUnitStorageTestRun(
+    b: *std.Build,
+    run: *std.Build.Step.Run,
+    runtime_filters: []const []const u8,
+    allow_empty_filter: bool,
+    unit_skip_filters: []const []const u8,
+    root_skip_filters: []const []const u8,
+    extra_skip_filters: []const []const u8,
+    is_ha_shard: bool,
+) void {
+    addRuntimeTestFilters(b, run, runtime_filters);
+    if (allow_empty_filter) run.addArg("--allow-empty-test-filter");
+    addRuntimeSkipTestFilters(run, unit_skip_filters);
+    for (root_skip_filters) |filter| {
+        // `storage.ha` keeps the HA suite out of broad root-module test runs.
+        // Applying it to the dedicated shard would select zero tests.
+        if (is_ha_shard and std.mem.eql(u8, filter, "storage.ha")) continue;
+        run.addArgs(&.{ "--skip-test-filter", filter });
+    }
+    addRuntimeSkipTestFilters(run, extra_skip_filters);
+    addRuntimeSkipTestFilters(run, &release_scale_test_filters);
+}
+
 fn compileFiltersWithAnchors(
     b: *std.Build,
     anchors: []const []const u8,
@@ -3837,20 +3860,7 @@ pub fn build(b: *std.Build) void {
     const lite_cmd_test_step = b.step("lite-cmd-test", "Run command tests owned by Antfly Lite profiles");
     lite_cmd_test_step.dependOn(&run_lite_cmd_tests.step);
 
-    const lib_recall_default_filters = [_][]const u8{
-        "HBC recall",
-    };
-    const lib_recall_tests = b.addTest(.{
-        .root_module = lib_test_mod,
-        .filters = selectTestFilters(b, &lib_recall_default_filters),
-        .test_runner = .{
-            .path = b.path("pkg/antfly/src/test_runner.zig"),
-            .mode = .simple,
-        },
-    });
-    const run_lib_recall_tests = addFilteredTestRunArtifact(b, lib_recall_tests);
     const recall_test_step = b.step("recall-test", "Run HBC vector recall quality tests");
-    recall_test_step.dependOn(&run_lib_recall_tests.step);
 
     const raft_unit_default_filters = [_][]const u8{"raft."};
     const raft_unit_tests = b.addTest(.{
@@ -6788,12 +6798,16 @@ pub fn build(b: *std.Build) void {
     unit_test_step.dependOn(delegated_inference_steps.inference_test);
     unit_test_step.dependOn(delegated_inference_steps.inference_finetune_test);
     unit_test_step.dependOn(lib_standalone_runtime_test_step);
-    unit_test_step.dependOn(ha_test_step);
+    // The aggregate's storage HA shard owns the library tests. Keep only the
+    // command-root coverage that the shard cannot discover; `ha-test` remains
+    // available as the convenient focused target containing both artifacts.
+    unit_test_step.dependOn(&run_ha_cli_tests.step);
     unit_test_step.dependOn(&run_raft_unit_tests.step);
     unit_test_step.dependOn(&run_raft_runtime_tests.step);
     unit_test_step.dependOn(&run_raft_restore_tests.step);
-    unit_test_step.dependOn(&run_raft_ready_continuation_tests.step);
-    unit_test_step.dependOn(&run_raft_transport_tests.step);
+    // The standalone Raft library and Antfly-rooted Raft artifacts already
+    // contain the ready-continuation and transport selections, respectively.
+    // Preserve their focused targets without executing them twice in `unit-test`.
 
     // Progress mode uses one union-filtered root artifact too. Storage and
     // metadata module paths overlap, while raft-transport is a strict subset
@@ -7475,6 +7489,19 @@ pub fn build(b: *std.Build) void {
         5 * 1024 * 1024 * 1024,
         5 * 1024 * 1024 * 1024,
     };
+    // Recent CI timings put these DB categories at 279 seconds and the
+    // complement at 297 seconds. Run the two halves from one compiled DB-core
+    // artifact so the dominant shard gets parallel runtime without duplicating
+    // its expensive semantic analysis and code generation.
+    const unit_storage_db_core_lane_filters = [_][]const u8{
+        "db restore",
+        "db explicit doc-id",
+        "db artifact repair",
+        "db document",
+        "db dense",
+        "db split",
+    };
+    const unit_storage_recall_filters = [_][]const u8{"HBC recall"};
     const unit_storage_sharded_test_step = b.step(
         "unit-storage-test",
         "Run the storage portion of the default unit-test target in bounded codegen shards",
@@ -7490,6 +7517,11 @@ pub fn build(b: *std.Build) void {
             unit_storage_shard_audit.addArgs(&.{ "--filter", shard_filter });
         }
     }
+    unit_storage_shard_audit.addArg("--runtime-partition-source");
+    unit_storage_shard_audit.addFileArg(b.path("pkg/antfly/src/storage/db/db.zig"));
+    for (unit_storage_db_core_lane_filters) |lane_filter| {
+        unit_storage_shard_audit.addArgs(&.{ "--runtime-partition-filter", lane_filter });
+    }
     const unit_storage_shard_audit_step = b.step(
         "unit-storage-test-audit",
         "Verify every test-bearing storage module belongs to a bounded codegen shard",
@@ -7498,16 +7530,28 @@ pub fn build(b: *std.Build) void {
     const storage_runtime_filter_is_default =
         lib_storage_runtime_filters.len == 1 and
         std.mem.eql(u8, lib_storage_runtime_filters[0], "storage.");
-    var unit_storage_tail: ?*std.Build.Step = null;
+    // Keep the largest DB artifact on one lane and serialize the remaining
+    // storage shards on the other. The patched build runner still enforces
+    // every artifact's max_rss claim, while the second lane prevents the DB
+    // runtime from leaving the other CPU cores idle for several minutes.
+    const unit_storage_shard_lanes = [_]usize{ 1, 1, 1, 0, 1, 1, 1 };
+    var unit_storage_tails = [_]?*std.Build.Step{ null, null };
+    var recall_test_artifact: ?*std.Build.Step.Compile = null;
     for (
         unit_storage_shard_filters,
         unit_storage_shard_names,
         unit_storage_shard_max_rss,
-    ) |shard_filters, shard_name, shard_max_rss| {
+        unit_storage_shard_lanes,
+    ) |shard_filters, shard_name, shard_max_rss, lane| {
+        const is_utility_shard = std.mem.eql(u8, shard_name, "storage-utility-tests");
+        const compile_filters = if (is_utility_shard)
+            compileFiltersWithAnchors(b, shard_filters, &unit_storage_recall_filters)
+        else
+            shard_filters;
         const unit_storage_tests = b.addTest(.{
             .name = shard_name,
             .root_module = lib_test_mod,
-            .filters = shard_filters,
+            .filters = compile_filters,
             .test_runner = .{
                 .path = b.path("pkg/antfly/src/test_runner.zig"),
                 .mode = .simple,
@@ -7515,26 +7559,81 @@ pub fn build(b: *std.Build) void {
             .max_rss = shard_max_rss,
         });
         unit_storage_tests.step.dependOn(&unit_storage_shard_audit.step);
-        if (unit_storage_tail) |previous| unit_storage_tests.step.dependOn(previous);
-        const run_unit_storage_tests = b.addRunArtifact(unit_storage_tests);
-        addRuntimeTestFilters(b, run_unit_storage_tests, lib_storage_runtime_filters);
-        if (!storage_runtime_filter_is_default) {
-            run_unit_storage_tests.addArg("--allow-empty-test-filter");
+        const lane_previous = unit_storage_tails[lane];
+        // Keep the reusable recall artifact free of unit-run dependencies so
+        // `zig build recall-test` does not execute the rest of storage first.
+        // Its ordinary unit Run step is still ordered on the lane below.
+        if (!is_utility_shard) {
+            if (lane_previous) |previous| unit_storage_tests.step.dependOn(previous);
         }
-        addRuntimeSkipTestFilters(run_unit_storage_tests, lib_unit_filters);
+        if (is_utility_shard) recall_test_artifact = unit_storage_tests;
         const is_ha_shard = std.mem.eql(u8, shard_name, "storage-ha-tests");
-        for (root_test_skip_filters) |filter| {
-            // `storage.ha` keeps the HA suite out of broad root-module test
-            // runs. Applying that same exclusion to its dedicated shard makes
-            // the shard select zero tests and fail before exercising anything.
-            if (is_ha_shard and std.mem.eql(u8, filter, "storage.ha")) continue;
-            run_unit_storage_tests.addArgs(&.{ "--skip-test-filter", filter });
+        const is_db_core_shard = std.mem.eql(u8, shard_name, "storage-db-core-tests");
+        if (is_db_core_shard and storage_runtime_filter_is_default) {
+            // Zig serializes independent checked Run steps for one artifact.
+            // Use one scheduler-visible step that launches both filtered
+            // processes, preserving one compile while realizing the overlap.
+            const run_db_core_partitioned_tests = b.addSystemCommand(&.{"python3"});
+            run_db_core_partitioned_tests.setName("run test storage-db-core-tests partitioned");
+            run_db_core_partitioned_tests.addFileArg(b.path("tools/run_test_partitions.py"));
+            run_db_core_partitioned_tests.addArg("--executable");
+            run_db_core_partitioned_tests.addArtifactArg(unit_storage_tests);
+            for (unit_storage_db_core_lane_filters) |lane_filter| {
+                run_db_core_partitioned_tests.addArgs(&.{ "--partition-filter", lane_filter });
+            }
+            for (lib_unit_filters) |filter| {
+                run_db_core_partitioned_tests.addArgs(&.{ "--common-skip-filter", filter });
+            }
+            for (root_test_skip_filters) |filter| {
+                run_db_core_partitioned_tests.addArgs(&.{ "--common-skip-filter", filter });
+            }
+            for (release_scale_test_filters) |filter| {
+                run_db_core_partitioned_tests.addArgs(&.{ "--common-skip-filter", filter });
+            }
+            if (b.args) |runtime_args| {
+                if (runtime_args.len != 0) {
+                    run_db_core_partitioned_tests.addArg("--");
+                    run_db_core_partitioned_tests.addArgs(runtime_args);
+                }
+            }
+            run_db_core_partitioned_tests.stdio = .inherit;
+            run_db_core_partitioned_tests.step.max_rss = 12 * 1024 * 1024 * 1024;
+            unit_test_step.dependOn(&run_db_core_partitioned_tests.step);
+            unit_storage_sharded_test_step.dependOn(&run_db_core_partitioned_tests.step);
+            unit_storage_tails[lane] = &run_db_core_partitioned_tests.step;
+            continue;
         }
-        addRuntimeSkipTestFilters(run_unit_storage_tests, &release_scale_test_filters);
+
+        const run_unit_storage_tests = b.addRunArtifact(unit_storage_tests);
+        configureUnitStorageTestRun(
+            b,
+            run_unit_storage_tests,
+            lib_storage_runtime_filters,
+            !storage_runtime_filter_is_default,
+            lib_unit_filters,
+            &root_test_skip_filters,
+            &.{},
+            is_ha_shard,
+        );
+        if (is_utility_shard) {
+            if (lane_previous) |previous| run_unit_storage_tests.step.dependOn(previous);
+        }
         unit_test_step.dependOn(&run_unit_storage_tests.step);
         unit_storage_sharded_test_step.dependOn(&run_unit_storage_tests.step);
-        unit_storage_tail = &run_unit_storage_tests.step;
+        unit_storage_tails[lane] = &run_unit_storage_tests.step;
     }
+
+    // Reuse the storage utility executable instead of compiling another copy
+    // of the broad Antfly root solely for the two corpus recall tests. Its
+    // ordinary unit run selects `storage.` and therefore never executes these
+    // additional compile-time tests.
+    const compiled_recall_tests = recall_test_artifact orelse @panic("storage utility test artifact missing");
+    const run_compiled_recall_tests = addFilteredTestRunArtifactWithRuntimeFilters(
+        b,
+        compiled_recall_tests,
+        &unit_storage_recall_filters,
+    );
+    recall_test_step.dependOn(&run_compiled_recall_tests.step);
 
     // The complete metadata namespace pulls in the simulation harness and a
     // large amount of control-plane code even though the default unit target
@@ -7618,15 +7717,18 @@ pub fn build(b: *std.Build) void {
     const metadata_runtime_filter_is_default =
         lib_metadata_runtime_filters.len == 1 and
         std.mem.eql(u8, lib_metadata_runtime_filters[0], "metadata.");
-    var unit_metadata_compile_tail: ?*std.Build.Step = null;
-    var unit_metadata_aggregate_run_tail: ?*std.Build.Step = null;
-    var unit_metadata_focused_run_tail: ?*std.Build.Step = null;
+    const unit_metadata_shard_lanes = [_]usize{ 0, 1, 0, 1, 0, 1, 0, 1, 0 };
+    var unit_metadata_compile_tails = [_]?*std.Build.Step{ null, null };
+    var unit_metadata_aggregate_run_tails = [_]?*std.Build.Step{ null, null };
+    var unit_metadata_focused_run_tails = [_]?*std.Build.Step{ null, null };
     for (
         unit_metadata_shard_filters,
         unit_metadata_shard_names,
         metadata_unit_test_mods,
         unit_metadata_shard_max_rss,
-    ) |shard_filters, shard_name, test_mod, shard_max_rss| {
+        unit_metadata_shard_lanes,
+    ) |shard_filters, shard_name, test_mod, shard_max_rss, lane| {
+        const is_runtime_exclusive = std.mem.eql(u8, shard_name, "metadata-replication-backfill-tests");
         const unit_metadata_tests = b.addTest(.{
             .name = shard_name,
             .root_module = test_mod,
@@ -7637,8 +7739,8 @@ pub fn build(b: *std.Build) void {
             },
             .max_rss = shard_max_rss,
         });
-        if (unit_metadata_compile_tail) |previous| unit_metadata_tests.step.dependOn(previous);
-        unit_metadata_compile_tail = &unit_metadata_tests.step;
+        if (unit_metadata_compile_tails[lane]) |previous| unit_metadata_tests.step.dependOn(previous);
+        unit_metadata_compile_tails[lane] = &unit_metadata_tests.step;
         const run_unit_metadata_tests = b.addRunArtifact(unit_metadata_tests);
         const runtime_filters = if (metadata_runtime_filter_is_default)
             shard_filters
@@ -7656,11 +7758,19 @@ pub fn build(b: *std.Build) void {
         for (root_test_skip_filters) |filter| {
             run_unit_metadata_tests.addArgs(&.{ "--skip-test-filter", filter });
         }
-        if (unit_metadata_aggregate_run_tail) |previous| {
+        if (is_runtime_exclusive) {
+            for (unit_metadata_aggregate_run_tails) |previous| {
+                if (previous) |previous_step| run_unit_metadata_tests.step.dependOn(previous_step);
+            }
+        } else if (unit_metadata_aggregate_run_tails[lane]) |previous| {
             run_unit_metadata_tests.step.dependOn(previous);
         }
         unit_test_step.dependOn(&run_unit_metadata_tests.step);
-        unit_metadata_aggregate_run_tail = &run_unit_metadata_tests.step;
+        if (is_runtime_exclusive) {
+            unit_metadata_aggregate_run_tails = .{ &run_unit_metadata_tests.step, &run_unit_metadata_tests.step };
+        } else {
+            unit_metadata_aggregate_run_tails[lane] = &run_unit_metadata_tests.step;
+        }
 
         // The standalone metadata step owns its selected metadata tests. Use a
         // separate run policy so a caller filter is not mistaken for the root
@@ -7673,12 +7783,20 @@ pub fn build(b: *std.Build) void {
         for (root_test_skip_filters) |filter| {
             run_focused_metadata_tests.addArgs(&.{ "--skip-test-filter", filter });
         }
-        if (unit_metadata_focused_run_tail) |previous| {
+        if (is_runtime_exclusive) {
+            for (unit_metadata_focused_run_tails) |previous| {
+                if (previous) |previous_step| run_focused_metadata_tests.step.dependOn(previous_step);
+            }
+        } else if (unit_metadata_focused_run_tails[lane]) |previous| {
             run_focused_metadata_tests.step.dependOn(previous);
         }
         unit_metadata_sharded_test_step.dependOn(&run_focused_metadata_tests.step);
         lib_metadata_test_step.dependOn(&run_focused_metadata_tests.step);
-        unit_metadata_focused_run_tail = &run_focused_metadata_tests.step;
+        if (is_runtime_exclusive) {
+            unit_metadata_focused_run_tails = .{ &run_focused_metadata_tests.step, &run_focused_metadata_tests.step };
+        } else {
+            unit_metadata_focused_run_tails[lane] = &run_focused_metadata_tests.step;
+        }
     }
 
     // Default Antfly unit coverage is hermetic: no network fetchers, no
@@ -9456,6 +9574,29 @@ pub fn build(b: *std.Build) void {
     const recall_harness_step = b.step("recall-harness", "Run Zig recall suites against exported vector datasets");
     recall_harness_step.dependOn(&run_recall_harness.step);
 
+    // Allow full CI to compile this ReleaseFast executable alongside the
+    // release-scale regressions, then reuse the cached artifact for the recall
+    // phase instead of paying its compile cost on the recall critical path.
+    const recall_harness_build_step = b.step("recall-harness-build", "Build the recall harness without running it");
+    recall_harness_build_step.dependOn(&recall_harness.step);
+
+    const run_recall_checks = b.addSystemCommand(&.{"python3"});
+    run_recall_checks.setName("run storage and per-metric recall checks concurrently");
+    run_recall_checks.addFileArg(b.path("tools/run_recall_checks.py"));
+    run_recall_checks.addArg("--test-executable");
+    run_recall_checks.addArtifactArg(compiled_recall_tests);
+    run_recall_checks.addArg("--harness-executable");
+    run_recall_checks.addArtifactArg(recall_harness);
+    run_recall_checks.addArg("--dataset-dir");
+    run_recall_checks.addDirectoryArg(b.path("testdata/vectorsets"));
+    run_recall_checks.stdio = .inherit;
+    run_recall_checks.step.max_rss = 12 * 1024 * 1024 * 1024;
+    const recall_ci_test_step = b.step(
+        "recall-ci-test",
+        "Run storage-backed and per-metric recall checks concurrently",
+    );
+    recall_ci_test_step.dependOn(&run_recall_checks.step);
+
     const antfly_main_mod = b.createModule(.{
         .root_source_file = b.path("pkg/antfly/src/main.zig"),
         .target = target,
@@ -9786,18 +9927,11 @@ pub fn build(b: *std.Build) void {
     lite_dev_step.dependOn(&run_capi_tests.step);
     lite_dev_step.dependOn(&run_antfly_embedded_pkg_tests.step);
 
-    const run_recall_harness_default = b.addRunArtifact(recall_harness);
-    run_recall_harness_default.stdio = .inherit;
-    run_recall_harness_default.addArgs(&.{
-        "--dataset-dir",
-        "testdata/vectorsets",
-    });
     dependOnAll(antfly_test_step, &.{
         unit_test_step,
         sim_test_step,
         integration_test_step,
-        recall_test_step,
-        &run_recall_harness_default.step,
+        recall_ci_test_step,
         chaos_test_step,
     });
 

--- a/zig/tools/audit_storage_test_shards.py
+++ b/zig/tools/audit_storage_test_shards.py
@@ -11,6 +11,7 @@ from typing import Iterable, Sequence
 
 
 TEST_DECLARATION = re.compile(r'(?m)^\s*(?:pub\s+)?test(?:\s|")')
+QUOTED_TEST_DECLARATION = re.compile(r'(?m)^\s*(?:pub\s+)?test\s+"([^"]+)"')
 MANIFEST_IMPORT = re.compile(r'(?m)^\s*_\s*=\s*@import\("([^"]+\.zig)"\);\s*$')
 
 
@@ -75,16 +76,55 @@ def audit_manifest(root: Path, manifest: Path, filters: Sequence[str]) -> list[s
     return failures
 
 
+def audit_runtime_partition(source: Path, filters: Sequence[str]) -> list[str]:
+    """Verify a name-filtered lane and its complement both retain tests."""
+    if not source.is_file():
+        return [f"runtime partition source does not exist: {source}"]
+
+    names = QUOTED_TEST_DECLARATION.findall(source.read_text(encoding="utf-8"))
+    failures: list[str] = []
+    for test_filter in filters:
+        # The custom runner applies filters containing a dot to fully-qualified
+        # names. Lane filters deliberately target declared names so module path
+        # changes cannot silently alter the partition.
+        if "." in test_filter:
+            failures.append(
+                f"runtime partition filter must target a declared name: {test_filter}"
+            )
+        elif not any(test_filter in name for name in names):
+            failures.append(f"runtime partition filter matches no tests: {test_filter}")
+
+    selected = [name for name in names if any(test_filter in name for test_filter in filters)]
+    if not selected:
+        failures.append("runtime partition selects no tests")
+    elif len(selected) == len(names):
+        failures.append("runtime partition leaves no tests for its complement")
+    return failures
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--root", type=Path, required=True)
     parser.add_argument("--manifest", type=Path, required=True)
     parser.add_argument("--filter", action="append", default=[])
+    parser.add_argument("--runtime-partition-source", type=Path)
+    parser.add_argument("--runtime-partition-filter", action="append", default=[])
     args = parser.parse_args()
     if not args.filter:
         parser.error("at least one --filter is required")
+    if bool(args.runtime_partition_source) != bool(args.runtime_partition_filter):
+        parser.error(
+            "--runtime-partition-source and --runtime-partition-filter must be used together"
+        )
 
     failures = audit_manifest(args.root, args.manifest, args.filter)
+    if args.runtime_partition_source:
+        failures.extend(
+            audit_runtime_partition(
+                args.runtime_partition_source,
+                args.runtime_partition_filter,
+            )
+        )
     if not failures:
         return 0
     print("storage test shard audit failed:")

--- a/zig/tools/run_recall_checks.py
+++ b/zig/tools/run_recall_checks.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Run storage-backed recall and per-metric harness checks concurrently."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+import threading
+from pathlib import Path
+from typing import Sequence
+
+
+METRICS = ("l2_squared", "inner_product", "cosine")
+
+
+def build_commands(
+    test_executable: Path,
+    harness_executable: Path,
+    dataset_dir: Path,
+) -> tuple[tuple[str, list[str]], ...]:
+    commands: list[tuple[str, list[str]]] = [
+        (
+            "storage-hbc",
+            [str(test_executable), "--test-filter", "HBC recall"],
+        )
+    ]
+    for metric in METRICS:
+        commands.append(
+            (
+                f"harness-{metric}",
+                [
+                    str(harness_executable),
+                    "--dataset-dir",
+                    str(dataset_dir),
+                    "--metric",
+                    metric,
+                ],
+            )
+        )
+    return tuple(commands)
+
+
+def stream_output(label: str, process: subprocess.Popen[str], lock: threading.Lock) -> None:
+    assert process.stdout is not None
+    for line in process.stdout:
+        with lock:
+            sys.stderr.write(f"[{label}] {line}")
+            sys.stderr.flush()
+
+
+def run_checks(commands: Sequence[tuple[str, Sequence[str]]]) -> int:
+    processes: list[tuple[str, subprocess.Popen[str]]] = []
+    try:
+        for label, command in commands:
+            processes.append(
+                (
+                    label,
+                    subprocess.Popen(
+                        command,
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.STDOUT,
+                        text=True,
+                        errors="replace",
+                    ),
+                )
+            )
+    except BaseException:
+        for _, process in processes:
+            process.terminate()
+        for _, process in processes:
+            process.wait()
+        raise
+
+    lock = threading.Lock()
+    readers = [
+        threading.Thread(target=stream_output, args=(label, process, lock), daemon=True)
+        for label, process in processes
+    ]
+    for reader in readers:
+        reader.start()
+
+    return_codes = [process.wait() for _, process in processes]
+    for reader in readers:
+        reader.join()
+    for _, process in processes:
+        assert process.stdout is not None
+        process.stdout.close()
+    for return_code in return_codes:
+        if return_code != 0:
+            return return_code if return_code > 0 else 128 - return_code
+    return 0
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--test-executable", type=Path, required=True)
+    parser.add_argument("--harness-executable", type=Path, required=True)
+    parser.add_argument("--dataset-dir", type=Path, required=True)
+    args = parser.parse_args(argv)
+    return run_checks(
+        build_commands(
+            args.test_executable,
+            args.harness_executable,
+            args.dataset_dir,
+        )
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/zig/tools/run_test_partitions.py
+++ b/zig/tools/run_test_partitions.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Run one compiled Zig test artifact in a filtered lane and its complement."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+import threading
+from pathlib import Path
+from typing import Sequence
+
+
+def build_commands(
+    executable: Path,
+    partition_filters: Sequence[str],
+    common_skip_filters: Sequence[str],
+    runtime_args: Sequence[str],
+) -> tuple[list[str], list[str]]:
+    common = [str(executable)]
+    for test_filter in common_skip_filters:
+        common.extend(("--skip-test-filter", test_filter))
+
+    partition = [str(executable)]
+    for test_filter in partition_filters:
+        partition.extend(("--test-filter", test_filter))
+    partition.extend(common[1:])
+    partition.extend(runtime_args)
+
+    complement = [str(executable), "--test-filter", "storage."]
+    complement.extend(common[1:])
+    for test_filter in partition_filters:
+        complement.extend(("--skip-test-filter", test_filter))
+    complement.extend(runtime_args)
+    return partition, complement
+
+
+def stream_output(label: str, process: subprocess.Popen[str], lock: threading.Lock) -> None:
+    assert process.stdout is not None
+    for line in process.stdout:
+        with lock:
+            sys.stderr.write(f"[{label}] {line}")
+            sys.stderr.flush()
+
+
+def run_partitions(commands: Sequence[tuple[str, Sequence[str]]]) -> int:
+    processes: list[tuple[str, subprocess.Popen[str]]] = []
+    try:
+        for label, command in commands:
+            processes.append(
+                (
+                    label,
+                    subprocess.Popen(
+                        command,
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.STDOUT,
+                        text=True,
+                        errors="replace",
+                    ),
+                )
+            )
+    except BaseException:
+        for _, process in processes:
+            process.terminate()
+        for _, process in processes:
+            process.wait()
+        raise
+
+    lock = threading.Lock()
+    readers = [
+        threading.Thread(target=stream_output, args=(label, process, lock), daemon=True)
+        for label, process in processes
+    ]
+    for reader in readers:
+        reader.start()
+
+    return_codes = [process.wait() for _, process in processes]
+    for reader in readers:
+        reader.join()
+    for _, process in processes:
+        assert process.stdout is not None
+        process.stdout.close()
+    for return_code in return_codes:
+        if return_code != 0:
+            return return_code if return_code > 0 else 128 - return_code
+    return 0
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--executable", type=Path, required=True)
+    parser.add_argument("--partition-filter", action="append", default=[])
+    parser.add_argument("--common-skip-filter", action="append", default=[])
+    args, runtime_args = parser.parse_known_args(argv)
+    if not args.partition_filter:
+        parser.error("at least one --partition-filter is required")
+    if runtime_args[:1] == ["--"]:
+        runtime_args = runtime_args[1:]
+
+    partition, complement = build_commands(
+        args.executable,
+        args.partition_filter,
+        args.common_skip_filter,
+        runtime_args,
+    )
+    return run_partitions(
+        (
+            ("db-core-category", partition),
+            ("db-core-complement", complement),
+        )
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/zig/tools/test_audit_storage_test_shards.py
+++ b/zig/tools/test_audit_storage_test_shards.py
@@ -75,6 +75,53 @@ class StorageTestShardAuditTest(unittest.TestCase):
             self.audit(["storage.db.query."]),
         )
 
+    def test_accepts_runtime_partition_with_a_nonempty_complement(self):
+        source = self.root / "db.zig"
+        self.write(
+            "db.zig",
+            'test "db restore snapshot" {}\n'
+            'test "db dense search" {}\n'
+            'test "db transaction" {}\n',
+        )
+        self.assertEqual(
+            [],
+            audit.audit_runtime_partition(source, ["db restore", "db dense"]),
+        )
+
+    def test_rejects_stale_runtime_partition_filter(self):
+        source = self.root / "db.zig"
+        self.write("db.zig", 'test "db transaction" {}\n')
+        self.assertEqual(
+            [
+                "runtime partition filter matches no tests: db restore",
+                "runtime partition selects no tests",
+            ],
+            audit.audit_runtime_partition(source, ["db restore"]),
+        )
+
+    def test_rejects_runtime_partition_without_a_complement(self):
+        source = self.root / "db.zig"
+        self.write("db.zig", 'test "db restore snapshot" {}\n')
+        self.assertEqual(
+            ["runtime partition leaves no tests for its complement"],
+            audit.audit_runtime_partition(source, ["db restore"]),
+        )
+
+    def test_rejects_qualified_runtime_partition_filter(self):
+        source = self.root / "db.zig"
+        self.write(
+            "db.zig",
+            'test "db restore snapshot" {}\n'
+            'test "db transaction" {}\n',
+        )
+        self.assertEqual(
+            [
+                "runtime partition filter must target a declared name: storage.db",
+                "runtime partition selects no tests",
+            ],
+            audit.audit_runtime_partition(source, ["storage.db"]),
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/zig/tools/test_run_recall_checks.py
+++ b/zig/tools/test_run_recall_checks.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+
+import importlib.util
+import sys
+import time
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).with_name("run_recall_checks.py")
+SPEC = importlib.util.spec_from_file_location("run_recall_checks", SCRIPT)
+assert SPEC and SPEC.loader
+recall = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = recall
+SPEC.loader.exec_module(recall)
+
+
+class RunRecallChecksTest(unittest.TestCase):
+    def test_builds_storage_and_per_metric_commands(self):
+        commands = recall.build_commands(
+            Path("storage-tests"),
+            Path("recall-harness"),
+            Path("vectors"),
+        )
+        self.assertEqual(
+            ("storage-hbc", ["storage-tests", "--test-filter", "HBC recall"]),
+            commands[0],
+        )
+        self.assertEqual(
+            ["harness-l2_squared", "harness-inner_product", "harness-cosine"],
+            [label for label, _ in commands[1:]],
+        )
+        self.assertEqual(
+            [
+                "recall-harness",
+                "--dataset-dir",
+                "vectors",
+                "--metric",
+                "cosine",
+            ],
+            commands[-1][1],
+        )
+
+    def test_runs_all_commands_concurrently(self):
+        command = [sys.executable, "-c", "import time; time.sleep(0.5)"]
+        started = time.monotonic()
+        self.assertEqual(
+            0,
+            recall.run_checks(tuple((str(index), command) for index in range(4))),
+        )
+        self.assertLess(time.monotonic() - started, 0.9)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/zig/tools/test_run_test_partitions.py
+++ b/zig/tools/test_run_test_partitions.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+
+import importlib.util
+import sys
+import time
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).with_name("run_test_partitions.py")
+SPEC = importlib.util.spec_from_file_location("run_test_partitions", SCRIPT)
+assert SPEC and SPEC.loader
+partitions = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = partitions
+SPEC.loader.exec_module(partitions)
+
+
+class RunTestPartitionsTest(unittest.TestCase):
+    def test_builds_disjoint_partition_and_complement_commands(self):
+        partition, complement = partitions.build_commands(
+            Path("test-binary"),
+            ["db restore", "db dense"],
+            ["simulation", "release scale"],
+            ["--seed=123", "--skip-test-filter", "caller skip"],
+        )
+        self.assertEqual(
+            [
+                "test-binary",
+                "--test-filter",
+                "db restore",
+                "--test-filter",
+                "db dense",
+                "--skip-test-filter",
+                "simulation",
+                "--skip-test-filter",
+                "release scale",
+                "--seed=123",
+                "--skip-test-filter",
+                "caller skip",
+            ],
+            partition,
+        )
+        self.assertEqual(
+            [
+                "test-binary",
+                "--test-filter",
+                "storage.",
+                "--skip-test-filter",
+                "simulation",
+                "--skip-test-filter",
+                "release scale",
+                "--skip-test-filter",
+                "db restore",
+                "--skip-test-filter",
+                "db dense",
+                "--seed=123",
+                "--skip-test-filter",
+                "caller skip",
+            ],
+            complement,
+        )
+
+    def test_runs_both_commands_concurrently(self):
+        command = [sys.executable, "-c", "import time; time.sleep(0.5)"]
+        started = time.monotonic()
+        self.assertEqual(
+            0,
+            partitions.run_partitions((("first", command), ("second", command))),
+        )
+        self.assertLess(time.monotonic() - started, 0.85)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- run Zig storage and metadata unit shards across two bounded lanes
- split the large storage DB-core test set into concurrent filtered partitions and audit the partition coverage
- reuse the storage utility compilation for HBC recall checks
- run storage recall and the three recall-harness metrics concurrently
- prebuild the recall harness alongside release-scale regressions
- consolidate the Zig CI workflow around the new bounded targets

## Local validation

- Python orchestration and audit tests: 40 passed
- Zig formatting, workflow YAML parsing, and diff checks passed
- recall-test: 2 passed
- recall-ci-test: passed in 317.50s; harness work completed beneath the storage-recall critical path
- release-scale-test plus recall-harness-build: 4 passed in 523.65s
- bounded storage unit aggregate passed under the detected 30.9 GiB memory limit

## Known existing timing sensitivity

The unchanged metadata backfill test for hosted snapshot/streaming rounds can still exceed its rounds < 64 assertion. It reproduced outside the sandbox after placing that runtime behind an exclusive barrier, so it is not caused by concurrent metadata lane execution.