### PR TITLE
Speed up Zig storage tests and TLA checks

### DIFF
--- a/zig/Makefile
+++ b/zig/Makefile
@@ -126,7 +126,7 @@ tla-check-split: tla-tools
 	  -workers auto -deadlock
 
 tla-check-snap: tla-tools
-	@echo "==> Model checking snapshot transfer spec (safety only, ~90s)..."
+	@echo "==> Model checking snapshot transfer spec (safety only, symmetry reduced)..."
 	source ../scripts/tla-tools.sh && \
 	"$$TLA_JAVA" -XX:+UseParallelGC -cp "$$TLA2TOOLS" tlc2.TLC \
 	  -config specs/tla/AntflySnapshotTransfer-safety.cfg specs/tla/SnapshotTransferMC.tla \

--- a/zig/build.zig
+++ b/zig/build.zig
@@ -7471,24 +7471,7 @@ pub fn build(b: *std.Build) void {
             "storage.wal.",
         },
     };
-    const unit_storage_shard_names = [_][]const u8{
-        "storage-algebraic-tests",
-        "storage-derived-enrichment-tests",
-        "storage-query-catalog-tests",
-        "storage-db-core-tests",
-        "storage-ha-tests",
-        "storage-lsm-lite-tests",
-        "storage-utility-tests",
-    };
-    const unit_storage_shard_max_rss = [_]usize{
-        4 * 1024 * 1024 * 1024,
-        5 * 1024 * 1024 * 1024,
-        5 * 1024 * 1024 * 1024,
-        8 * 1024 * 1024 * 1024,
-        5 * 1024 * 1024 * 1024,
-        5 * 1024 * 1024 * 1024,
-        5 * 1024 * 1024 * 1024,
-    };
+    const unit_storage_db_core_shard_index = 3;
     // Recent CI timings put these DB categories at 279 seconds and the
     // complement at 297 seconds. Run the two halves from one compiled DB-core
     // artifact so the dominant shard gets parallel runtime without duplicating
@@ -7530,25 +7513,142 @@ pub fn build(b: *std.Build) void {
     const storage_runtime_filter_is_default =
         lib_storage_runtime_filters.len == 1 and
         std.mem.eql(u8, lib_storage_runtime_filters[0], "storage.");
-    // Keep the largest DB artifact on one lane and serialize the remaining
-    // storage shards on the other. The patched build runner still enforces
-    // every artifact's max_rss claim, while the second lane prevents the DB
-    // runtime from leaving the other CPU cores idle for several minutes.
-    const unit_storage_shard_lanes = [_]usize{ 1, 1, 1, 0, 1, 1, 1 };
-    var unit_storage_tails = [_]?*std.Build.Step{ null, null };
-    var recall_test_artifact: ?*std.Build.Step.Compile = null;
+    // Preserve three independent compiler processes while removing four
+    // repeated semantic-analysis/code-generation passes through the broad
+    // Antfly test root. DB core remains isolated, the engine artifact owns HA
+    // and LSM/Lite, and the support artifact owns the other four logical
+    // ownership groups plus the reusable recall tests.
+    var unit_storage_support_compile_filters: []const []const u8 = &.{};
+    for ([_]usize{ 0, 1, 2, 6 }) |shard_index| {
+        unit_storage_support_compile_filters = compileFiltersWithAnchors(
+            b,
+            unit_storage_support_compile_filters,
+            unit_storage_shard_filters[shard_index],
+        );
+    }
+    unit_storage_support_compile_filters = compileFiltersWithAnchors(
+        b,
+        unit_storage_support_compile_filters,
+        &unit_storage_recall_filters,
+    );
+    var unit_storage_engine_compile_filters: []const []const u8 = &.{};
+    for ([_]usize{ 4, 5 }) |shard_index| {
+        unit_storage_engine_compile_filters = compileFiltersWithAnchors(
+            b,
+            unit_storage_engine_compile_filters,
+            unit_storage_shard_filters[shard_index],
+        );
+    }
+
+    const unit_storage_support_tests = b.addTest(.{
+        .name = "storage-support-tests",
+        .root_module = lib_test_mod,
+        .filters = unit_storage_support_compile_filters,
+        .test_runner = .{
+            .path = b.path("pkg/antfly/src/test_runner.zig"),
+            .mode = .simple,
+        },
+        .max_rss = 8 * 1024 * 1024 * 1024,
+    });
+    unit_storage_support_tests.step.dependOn(&unit_storage_shard_audit.step);
+    const run_unit_storage_support_tests = b.addRunArtifact(unit_storage_support_tests);
+    configureUnitStorageTestRun(
+        b,
+        run_unit_storage_support_tests,
+        lib_storage_runtime_filters,
+        !storage_runtime_filter_is_default,
+        lib_unit_filters,
+        &root_test_skip_filters,
+        &.{},
+        false,
+    );
+    unit_test_step.dependOn(&run_unit_storage_support_tests.step);
+    unit_storage_sharded_test_step.dependOn(&run_unit_storage_support_tests.step);
+
+    const unit_storage_engine_tests = b.addTest(.{
+        .name = "storage-engine-tests",
+        .root_module = lib_test_mod,
+        .filters = unit_storage_engine_compile_filters,
+        .test_runner = .{
+            .path = b.path("pkg/antfly/src/test_runner.zig"),
+            .mode = .simple,
+        },
+        .max_rss = 8 * 1024 * 1024 * 1024,
+    });
+    unit_storage_engine_tests.step.dependOn(&unit_storage_shard_audit.step);
+    const run_unit_storage_engine_tests = b.addRunArtifact(unit_storage_engine_tests);
+    configureUnitStorageTestRun(
+        b,
+        run_unit_storage_engine_tests,
+        lib_storage_runtime_filters,
+        !storage_runtime_filter_is_default,
+        lib_unit_filters,
+        &root_test_skip_filters,
+        &.{},
+        // This artifact owns HA, so do not apply the broad-root HA skip.
+        true,
+    );
+    // Keep runtime memory bounded to the existing two lanes. This dependency
+    // orders only the Run steps; all three artifacts remain free to compile in
+    // parallel.
+    run_unit_storage_engine_tests.step.dependOn(&run_unit_storage_support_tests.step);
+    unit_test_step.dependOn(&run_unit_storage_engine_tests.step);
+    unit_storage_sharded_test_step.dependOn(&run_unit_storage_engine_tests.step);
+
+    const unit_storage_db_core_tests = b.addTest(.{
+        .name = "storage-db-core-tests",
+        .root_module = lib_test_mod,
+        .filters = unit_storage_shard_filters[unit_storage_db_core_shard_index],
+        .test_runner = .{
+            .path = b.path("pkg/antfly/src/test_runner.zig"),
+            .mode = .simple,
+        },
+        .max_rss = 8 * 1024 * 1024 * 1024,
+    });
+    unit_storage_db_core_tests.step.dependOn(&unit_storage_shard_audit.step);
+    const unit_storage_compile_step = b.step(
+        "unit-storage-compile",
+        "Compile the three storage unit-test artifacts without running them",
+    );
+    unit_storage_compile_step.dependOn(&unit_storage_support_tests.step);
+    unit_storage_compile_step.dependOn(&unit_storage_engine_tests.step);
+    unit_storage_compile_step.dependOn(&unit_storage_db_core_tests.step);
+
+    // Keep an explicit, opt-in equivalence check for future changes to these
+    // groupings. It compiles the former seven-artifact layout and compares the
+    // union of declared named tests with the default three-artifact layout.
+    // Neither the baseline artifacts nor this comparison are dependencies of
+    // unit-test, unit-storage-test, or recall-test.
+    const unit_storage_baseline_names = [_][]const u8{
+        "storage-algebraic-baseline-tests",
+        "storage-derived-enrichment-baseline-tests",
+        "storage-query-catalog-baseline-tests",
+        "storage-db-core-baseline-tests",
+        "storage-ha-baseline-tests",
+        "storage-lsm-lite-baseline-tests",
+        "storage-utility-baseline-tests",
+    };
+    const unit_storage_baseline_max_rss = [_]usize{
+        4 * 1024 * 1024 * 1024,
+        5 * 1024 * 1024 * 1024,
+        5 * 1024 * 1024 * 1024,
+        8 * 1024 * 1024 * 1024,
+        5 * 1024 * 1024 * 1024,
+        5 * 1024 * 1024 * 1024,
+        5 * 1024 * 1024 * 1024,
+    };
+    var unit_storage_baseline_tests: [unit_storage_shard_filters.len]*std.Build.Step.Compile = undefined;
     for (
         unit_storage_shard_filters,
-        unit_storage_shard_names,
-        unit_storage_shard_max_rss,
-        unit_storage_shard_lanes,
-    ) |shard_filters, shard_name, shard_max_rss, lane| {
-        const is_utility_shard = std.mem.eql(u8, shard_name, "storage-utility-tests");
-        const compile_filters = if (is_utility_shard)
+        unit_storage_baseline_names,
+        unit_storage_baseline_max_rss,
+        0..,
+    ) |shard_filters, shard_name, shard_max_rss, shard_index| {
+        const compile_filters = if (shard_index == 6)
             compileFiltersWithAnchors(b, shard_filters, &unit_storage_recall_filters)
         else
             shard_filters;
-        const unit_storage_tests = b.addTest(.{
+        unit_storage_baseline_tests[shard_index] = b.addTest(.{
             .name = shard_name,
             .root_module = lib_test_mod,
             .filters = compile_filters,
@@ -7558,76 +7658,78 @@ pub fn build(b: *std.Build) void {
             },
             .max_rss = shard_max_rss,
         });
-        unit_storage_tests.step.dependOn(&unit_storage_shard_audit.step);
-        const lane_previous = unit_storage_tails[lane];
-        // Keep the reusable recall artifact free of unit-run dependencies so
-        // `zig build recall-test` does not execute the rest of storage first.
-        // Its ordinary unit Run step is still ordered on the lane below.
-        if (!is_utility_shard) {
-            if (lane_previous) |previous| unit_storage_tests.step.dependOn(previous);
-        }
-        if (is_utility_shard) recall_test_artifact = unit_storage_tests;
-        const is_ha_shard = std.mem.eql(u8, shard_name, "storage-ha-tests");
-        const is_db_core_shard = std.mem.eql(u8, shard_name, "storage-db-core-tests");
-        if (is_db_core_shard and storage_runtime_filter_is_default) {
-            // Zig serializes independent checked Run steps for one artifact.
-            // Use one scheduler-visible step that launches both filtered
-            // processes, preserving one compile while realizing the overlap.
-            const run_db_core_partitioned_tests = b.addSystemCommand(&.{"python3"});
-            run_db_core_partitioned_tests.setName("run test storage-db-core-tests partitioned");
-            run_db_core_partitioned_tests.addFileArg(b.path("tools/run_test_partitions.py"));
-            run_db_core_partitioned_tests.addArg("--executable");
-            run_db_core_partitioned_tests.addArtifactArg(unit_storage_tests);
-            for (unit_storage_db_core_lane_filters) |lane_filter| {
-                run_db_core_partitioned_tests.addArgs(&.{ "--partition-filter", lane_filter });
-            }
-            for (lib_unit_filters) |filter| {
-                run_db_core_partitioned_tests.addArgs(&.{ "--common-skip-filter", filter });
-            }
-            for (root_test_skip_filters) |filter| {
-                run_db_core_partitioned_tests.addArgs(&.{ "--common-skip-filter", filter });
-            }
-            for (release_scale_test_filters) |filter| {
-                run_db_core_partitioned_tests.addArgs(&.{ "--common-skip-filter", filter });
-            }
-            if (b.args) |runtime_args| {
-                if (runtime_args.len != 0) {
-                    run_db_core_partitioned_tests.addArg("--");
-                    run_db_core_partitioned_tests.addArgs(runtime_args);
-                }
-            }
-            run_db_core_partitioned_tests.stdio = .inherit;
-            run_db_core_partitioned_tests.step.max_rss = 12 * 1024 * 1024 * 1024;
-            unit_test_step.dependOn(&run_db_core_partitioned_tests.step);
-            unit_storage_sharded_test_step.dependOn(&run_db_core_partitioned_tests.step);
-            unit_storage_tails[lane] = &run_db_core_partitioned_tests.step;
-            continue;
-        }
+        unit_storage_baseline_tests[shard_index].step.dependOn(&unit_storage_shard_audit.step);
+    }
+    const compare_unit_storage_inventory = b.addSystemCommand(&.{"python3"});
+    compare_unit_storage_inventory.setName("compare consolidated storage test inventory");
+    compare_unit_storage_inventory.addFileArg(b.path("tools/compare_test_inventories.py"));
+    compare_unit_storage_inventory.addArg("--baseline");
+    for (unit_storage_baseline_tests) |baseline_tests| {
+        compare_unit_storage_inventory.addArtifactArg(baseline_tests);
+    }
+    compare_unit_storage_inventory.addArg("--candidate");
+    compare_unit_storage_inventory.addArtifactArg(unit_storage_support_tests);
+    compare_unit_storage_inventory.addArtifactArg(unit_storage_engine_tests);
+    compare_unit_storage_inventory.addArtifactArg(unit_storage_db_core_tests);
+    compare_unit_storage_inventory.addArgs(&.{ "--label", "storage consolidation" });
+    const unit_storage_inventory_step = b.step(
+        "unit-storage-test-inventory",
+        "Verify the consolidated artifacts preserve the seven-shard named test inventory",
+    );
+    unit_storage_inventory_step.dependOn(&compare_unit_storage_inventory.step);
 
-        const run_unit_storage_tests = b.addRunArtifact(unit_storage_tests);
+    if (storage_runtime_filter_is_default) {
+        // Zig serializes independent checked Run steps for one artifact. Use
+        // one scheduler-visible step that launches both filtered DB processes,
+        // preserving one compile while realizing the overlap.
+        const run_db_core_partitioned_tests = b.addSystemCommand(&.{"python3"});
+        run_db_core_partitioned_tests.setName("run test storage-db-core-tests partitioned");
+        run_db_core_partitioned_tests.addFileArg(b.path("tools/run_test_partitions.py"));
+        run_db_core_partitioned_tests.addArg("--executable");
+        run_db_core_partitioned_tests.addArtifactArg(unit_storage_db_core_tests);
+        for (unit_storage_db_core_lane_filters) |lane_filter| {
+            run_db_core_partitioned_tests.addArgs(&.{ "--partition-filter", lane_filter });
+        }
+        for (lib_unit_filters) |filter| {
+            run_db_core_partitioned_tests.addArgs(&.{ "--common-skip-filter", filter });
+        }
+        for (root_test_skip_filters) |filter| {
+            run_db_core_partitioned_tests.addArgs(&.{ "--common-skip-filter", filter });
+        }
+        for (release_scale_test_filters) |filter| {
+            run_db_core_partitioned_tests.addArgs(&.{ "--common-skip-filter", filter });
+        }
+        if (b.args) |runtime_args| {
+            if (runtime_args.len != 0) {
+                run_db_core_partitioned_tests.addArg("--");
+                run_db_core_partitioned_tests.addArgs(runtime_args);
+            }
+        }
+        run_db_core_partitioned_tests.stdio = .inherit;
+        run_db_core_partitioned_tests.step.max_rss = 12 * 1024 * 1024 * 1024;
+        unit_test_step.dependOn(&run_db_core_partitioned_tests.step);
+        unit_storage_sharded_test_step.dependOn(&run_db_core_partitioned_tests.step);
+    } else {
+        const run_unit_storage_db_core_tests = b.addRunArtifact(unit_storage_db_core_tests);
         configureUnitStorageTestRun(
             b,
-            run_unit_storage_tests,
+            run_unit_storage_db_core_tests,
             lib_storage_runtime_filters,
-            !storage_runtime_filter_is_default,
+            true,
             lib_unit_filters,
             &root_test_skip_filters,
             &.{},
-            is_ha_shard,
+            false,
         );
-        if (is_utility_shard) {
-            if (lane_previous) |previous| run_unit_storage_tests.step.dependOn(previous);
-        }
-        unit_test_step.dependOn(&run_unit_storage_tests.step);
-        unit_storage_sharded_test_step.dependOn(&run_unit_storage_tests.step);
-        unit_storage_tails[lane] = &run_unit_storage_tests.step;
+        unit_test_step.dependOn(&run_unit_storage_db_core_tests.step);
+        unit_storage_sharded_test_step.dependOn(&run_unit_storage_db_core_tests.step);
     }
 
     // Reuse the storage utility executable instead of compiling another copy
     // of the broad Antfly root solely for the two corpus recall tests. Its
     // ordinary unit run selects `storage.` and therefore never executes these
     // additional compile-time tests.
-    const compiled_recall_tests = recall_test_artifact orelse @panic("storage utility test artifact missing");
+    const compiled_recall_tests = unit_storage_support_tests;
     const run_compiled_recall_tests = addFilteredTestRunArtifactWithRuntimeFilters(
         b,
         compiled_recall_tests,

--- a/zig/pkg/antfly/src/test_runner.zig
+++ b/zig/pkg/antfly/src/test_runner.zig
@@ -36,6 +36,7 @@ pub fn main(init: std.process.Init.Minimal) void {
     var include_filters: std.ArrayList([]const u8) = .empty;
     var exclude_filters: std.ArrayList([]const u8) = .empty;
     var allow_empty_test_filter = false;
+    var list_tests = false;
 
     var i: usize = 1;
     while (i < args.len) : (i += 1) {
@@ -57,6 +58,8 @@ pub fn main(init: std.process.Init.Minimal) void {
             appendFilter(arena, "--skip-test-filter", &exclude_filters, args[i]);
         } else if (std.mem.eql(u8, arg, "--allow-empty-test-filter")) {
             allow_empty_test_filter = true;
+        } else if (std.mem.eql(u8, arg, "--list-tests")) {
+            list_tests = true;
         } else if (std.mem.startsWith(u8, arg, "--cache-dir=")) {
             // Accepted for compatibility with the default test runner.
         } else if (std.mem.eql(u8, arg, "--listen=-")) {
@@ -100,6 +103,15 @@ pub fn main(init: std.process.Init.Minimal) void {
         }
         std.debug.print("test selection matched no runnable tests\n", .{});
         std.process.exit(1);
+    }
+
+    if (list_tests) {
+        for (test_fns) |test_fn| {
+            if (matchesFilter(test_fn.name)) {
+                std.debug.print("TEST\t{s}\n", .{test_fn.name});
+            }
+        }
+        return;
     }
 
     const trace_cleanup = getenvBool("ANTFLY_TEST_CLEANUP_TRACE");

--- a/zig/specs/tla/AntflySnapshotTransfer-safety.cfg
+++ b/zig/specs/tla/AntflySnapshotTransfer-safety.cfg
@@ -26,6 +26,10 @@ CONSTANTS
 
 SPECIFICATION Spec
 
+\* Nodes are model values with symmetric initial state and transitions. TLC
+\* checks one canonical representative for each node-id permutation.
+SYMMETRY MCSymmetry
+
 \* Safety invariants checked at every reachable state
 INVARIANTS
     TypeOK

--- a/zig/specs/tla/SnapshotTransferMC.tla
+++ b/zig/specs/tla/SnapshotTransferMC.tla
@@ -55,4 +55,10 @@ MCNodes      == {n1, n2, n3}
 MCMaxRetries == 3
 MCMaxSnapshots == 3
 
+\* Every node starts identically and the specification only distinguishes a
+\* node through its current state. Canonicalize states that differ solely by a
+\* node-id permutation in the safety model. The safety configuration enables
+\* this operator explicitly; the liveness configuration remains unchanged.
+MCSymmetry == Permutations(MCNodes)
+
 =============================================================================

--- a/zig/tools/compare_test_inventories.py
+++ b/zig/tools/compare_test_inventories.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Compare unions of declared tests from compiled Zig test executables."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+from pathlib import Path
+from typing import Sequence
+
+
+INVENTORY_PREFIX = "TEST\t"
+
+
+def parse_inventory(output: str, *, include_unnamed: bool = False) -> frozenset[str]:
+    names = [
+        line.removeprefix(INVENTORY_PREFIX)
+        for line in output.splitlines()
+        if line.startswith(INVENTORY_PREFIX)
+    ]
+    if not names:
+        raise ValueError("test executable produced no inventory entries")
+    if len(names) != len(set(names)):
+        duplicates = sorted(name for name in set(names) if names.count(name) > 1)
+        raise ValueError(f"test executable produced duplicate inventory entries: {duplicates}")
+    if not include_unnamed:
+        names = [name for name in names if not name.endswith(".test_0")]
+    return frozenset(names)
+
+
+def executable_inventory(executable: Path, *, include_unnamed: bool = False) -> frozenset[str]:
+    completed = subprocess.run(
+        [str(executable), "--list-tests"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        errors="replace",
+        check=False,
+    )
+    if completed.returncode != 0:
+        raise RuntimeError(
+            f"{executable} --list-tests exited with {completed.returncode}:\n"
+            f"{completed.stdout}"
+        )
+    return parse_inventory(completed.stdout, include_unnamed=include_unnamed)
+
+
+def combined_executable_inventory(
+    executables: Sequence[Path], *, include_unnamed: bool = False
+) -> frozenset[str]:
+    combined: set[str] = set()
+    for executable in executables:
+        inventory = executable_inventory(executable, include_unnamed=include_unnamed)
+        overlap = sorted(combined.intersection(inventory))
+        if overlap:
+            raise ValueError(f"test executables contain duplicate inventory entries: {overlap}")
+        combined.update(inventory)
+    return frozenset(combined)
+
+
+def inventory_diff(
+    baseline: frozenset[str],
+    candidate: frozenset[str],
+) -> tuple[list[str], list[str]]:
+    return sorted(baseline - candidate), sorted(candidate - baseline)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--baseline", type=Path, nargs="+", required=True)
+    parser.add_argument("--candidate", type=Path, nargs="+", required=True)
+    parser.add_argument("--label", required=True)
+    parser.add_argument("--include-unnamed", action="store_true")
+    args = parser.parse_args(argv)
+
+    baseline = combined_executable_inventory(
+        args.baseline, include_unnamed=args.include_unnamed
+    )
+    candidate = combined_executable_inventory(
+        args.candidate, include_unnamed=args.include_unnamed
+    )
+    missing, added = inventory_diff(baseline, candidate)
+    if not missing and not added:
+        kind = "all" if args.include_unnamed else "named"
+        print(f"{args.label}: identical {kind} inventory ({len(candidate)} tests)")
+        return 0
+
+    print(f"{args.label}: test inventory mismatch")
+    for name in missing:
+        print(f"  missing: {name}")
+    for name in added:
+        print(f"  added: {name}")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/zig/tools/test_compare_test_inventories.py
+++ b/zig/tools/test_compare_test_inventories.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+SCRIPT = Path(__file__).with_name("compare_test_inventories.py")
+SPEC = importlib.util.spec_from_file_location("compare_test_inventories", SCRIPT)
+assert SPEC and SPEC.loader
+inventories = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = inventories
+SPEC.loader.exec_module(inventories)
+
+
+class CompareTestInventoriesTest(unittest.TestCase):
+    def test_parses_inventory_lines_among_diagnostics(self):
+        self.assertEqual(
+            frozenset({"storage.db.test.one", "storage.db.test.two"}),
+            inventories.parse_inventory(
+                "diagnostic\n"
+                "TEST\tstorage.db.test.one\n"
+                "TEST\tstorage.db.test.two\n"
+            ),
+        )
+
+    def test_rejects_empty_inventory(self):
+        with self.assertRaisesRegex(ValueError, "no inventory entries"):
+            inventories.parse_inventory("diagnostic only\n")
+
+    def test_rejects_duplicate_inventory_names(self):
+        with self.assertRaisesRegex(ValueError, "duplicate inventory entries"):
+            inventories.parse_inventory("TEST\tone\nTEST\tone\n")
+
+    def test_excludes_unnamed_import_aggregation_tests_by_default(self):
+        output = "TEST\troot.test_0\nTEST\tstorage.db.test.named\n"
+        self.assertEqual(
+            frozenset({"storage.db.test.named"}),
+            inventories.parse_inventory(output),
+        )
+        self.assertEqual(
+            frozenset({"root.test_0", "storage.db.test.named"}),
+            inventories.parse_inventory(output, include_unnamed=True),
+        )
+
+    def test_combines_disjoint_executable_inventories(self):
+        with mock.patch.object(
+            inventories,
+            "executable_inventory",
+            side_effect=[frozenset({"one"}), frozenset({"two"})],
+        ):
+            self.assertEqual(
+                frozenset({"one", "two"}),
+                inventories.combined_executable_inventory([Path("a"), Path("b")]),
+            )
+
+    def test_rejects_overlap_between_executables(self):
+        with mock.patch.object(
+            inventories,
+            "executable_inventory",
+            side_effect=[frozenset({"shared"}), frozenset({"shared"})],
+        ):
+            with self.assertRaisesRegex(ValueError, "duplicate inventory entries"):
+                inventories.combined_executable_inventory([Path("a"), Path("b")])
+
+    def test_reports_missing_and_added_names(self):
+        self.assertEqual(
+            (["baseline-only"], ["candidate-only"]),
+            inventories.inventory_diff(
+                frozenset({"shared", "baseline-only"}),
+                frozenset({"shared", "candidate-only"}),
+            ),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- canonicalize symmetric node identities in the snapshot-transfer safety model
- consolidate seven broad-root storage test artifacts into three balanced artifacts while preserving the existing two runtime lanes and DB partitioning
- keep recall checks on the reusable support artifact
- add an opt-in inventory equivalence check that compares the old and new compiled named-test sets

## Performance

On a 14-core local machine:

- snapshot-transfer TLC: 102.4s to 25.4s wall time; generated states 228,587,191 to 38,168,411 and distinct states 27,361,379 to 4,570,385
- cold storage artifact compile: 61.6s to 60.1s wall time and 184.4s to 141.3s CPU time

I also prototyped overlapping model checking with trace generation inside the existing job. It measured 58.3s versus a 57.7s sequential control because contention consumed the overlap, so that path is intentionally not included.

## Verification

- make -C zig tla-check-snap
- complete TLC model and generated trace validation
- zig build unit-storage-test: all 3,093 selected tests passed, with expected skips
- zig build recall-test: 2 passed
- zig build unit-storage-test-inventory: identical 3,268-test named inventory, with no duplicates
- 47 affected Python tooling tests
- zig fmt --check and zig build --help