### PR TITLE
Harden partitioned runtime archive link order

### DIFF
--- a/zig/build.zig
+++ b/zig/build.zig
@@ -50,6 +50,31 @@ const RuntimeLibraryUnit = enum {
     cli,
 };
 
+// Static archives must be presented from consumers to providers. The
+// distributed/application unit calls into both the API kernel and inference
+// unit, while the remote CLI is an executable-facing leaf. Keep this separate
+// from RuntimeLibraryUnit declaration order: declaration order controls build
+// graph construction, not the final link's dependency topology.
+const runtime_library_link_order = [_]RuntimeLibraryUnit{
+    .cli,
+    .distributed,
+    .api_kernel,
+    .inference,
+};
+
+comptime {
+    const unit_count = std.meta.fields(RuntimeLibraryUnit).len;
+    if (runtime_library_link_order.len != unit_count)
+        @compileError("runtime_library_link_order must contain every runtime library unit exactly once");
+    var seen = [_]bool{false} ** unit_count;
+    for (runtime_library_link_order) |unit| {
+        const index = @intFromEnum(unit);
+        if (seen[index])
+            @compileError("runtime_library_link_order contains a duplicate runtime library unit");
+        seen[index] = true;
+    }
+}
+
 const snowball_languages = [_][]const u8{
     "danish",
     "dutch",
@@ -9698,12 +9723,15 @@ pub fn build(b: *std.Build) void {
         if (unit == .distributed) {
             libantfly_link_mod.linkLibrary(role_artifact);
         }
-        antfly_main.root_module.linkLibrary(role_artifact);
         if (strip) {
             var visited = std.AutoHashMap(*std.Build.Module, void).init(b.allocator);
             defer visited.deinit();
             setStripRecursively(role_mod, &visited);
         }
+    }
+
+    for (runtime_library_link_order) |unit| {
+        antfly_main.root_module.linkLibrary(runtime_library_artifacts[@intFromEnum(unit)].?);
     }
 
     if (runtime_artifact_role) |role| {
@@ -9733,15 +9761,15 @@ pub fn build(b: *std.Build) void {
                 role_exe.root_module.linkLibrary(runtime_library_artifacts[@intFromEnum(RuntimeLibraryUnit.distributed)].?);
             },
             .data, .metadata => {
-                role_exe.root_module.linkLibrary(runtime_library_artifacts[@intFromEnum(RuntimeLibraryUnit.api_kernel)].?);
                 role_exe.root_module.linkLibrary(runtime_library_artifacts[@intFromEnum(RuntimeLibraryUnit.distributed)].?);
+                role_exe.root_module.linkLibrary(runtime_library_artifacts[@intFromEnum(RuntimeLibraryUnit.api_kernel)].?);
             },
             .inference => {
                 role_exe.root_module.linkLibrary(runtime_library_artifacts[@intFromEnum(RuntimeLibraryUnit.inference)].?);
             },
             .standalone => {
-                role_exe.root_module.linkLibrary(runtime_library_artifacts[@intFromEnum(RuntimeLibraryUnit.api_kernel)].?);
                 role_exe.root_module.linkLibrary(runtime_library_artifacts[@intFromEnum(RuntimeLibraryUnit.distributed)].?);
+                role_exe.root_module.linkLibrary(runtime_library_artifacts[@intFromEnum(RuntimeLibraryUnit.api_kernel)].?);
                 role_exe.root_module.linkLibrary(runtime_library_artifacts[@intFromEnum(RuntimeLibraryUnit.inference)].?);
             },
         }


### PR DESCRIPTION
## Summary

- link partitioned runtime archives in consumer-before-provider order
- validate at compile time that the explicit link order covers every runtime unit exactly once
- use the same dependency order for focused data, metadata, and standalone artifacts

## Failure analysis

PR #450 exposed two independent failures. The 21 undefined `antfly_api_kernel_*` symbols came from presenting the API provider archive before the distributed consumer archive. This change makes the dependency order explicit without carrying over PR #450’s experimental deeper storage split.

The post-test SIGABRT was caused by HTTP request watchdog workers surviving successful requests. That cleanup is already fixed on `main` by the bounded watchdog cleanup from #484, including a focused regression, so this PR verifies and retains that fix rather than duplicating it.

## Verification

- `zig build lib-httpx-test -- --test-filter "successful H1 requests do not wait for their timeout deadline"`
- `zig build -Doptimize=Debug antfly`
- `zig build -Doptimize=Debug -Druntime-artifact-role=data runtime-artifact`
- `zig build -Doptimize=Debug -Druntime-artifact-role=metadata runtime-artifact`
- `zig build -Doptimize=Debug -Druntime-artifact-role=standalone runtime-artifact`
- `zig build -Dcpu=baseline -Doptimize=ReleaseFast -Dstrip=true antfly`
- `zig fmt build.zig`
- `git diff --check`