### PR TITLE
test(e2e): reuse Antfly processes within safe modules

### DIFF
--- a/zig/e2e/antfly/conftest.py
+++ b/zig/e2e/antfly/conftest.py
@@ -26,6 +26,10 @@ Usage:
 
     # Or start the local unified stateful entrypoint automatically:
     ANTFLY_BIN=./zig-out/bin/antfly uv run --project e2e/antfly pytest e2e/antfly/test_schema_migration.py
+
+Modules marked ``reuse_antfly_process`` share one local process and clean their
+tables after each test. Set ANTFLY_E2E_DISABLE_PROCESS_REUSE=1 to compare or
+debug those modules with the original one-process-per-test isolation.
 """
 
 from __future__ import annotations
@@ -203,6 +207,44 @@ def _start_stateful_server_with_retry(binary: str, port: int) -> PublicAntflySer
             time.sleep(0.5)
     assert last_error is not None
     raise last_error
+
+
+def _uses_reusable_antfly_process(request: pytest.FixtureRequest) -> bool:
+    disabled = os.environ.get("ANTFLY_E2E_DISABLE_PROCESS_REUSE", "").lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+    return not disabled and request.node.get_closest_marker("reuse_antfly_process") is not None
+
+
+class ReusableAntflyRuntime:
+    """A module-owned server shared by explicitly opted-in API tests."""
+
+    def __init__(
+        self,
+        server: PublicAntflyServer | StandaloneAntflyServer | StatefulAntflyServer,
+        *,
+        default_api_root: str,
+    ):
+        self.server = server
+        self.default_api_root = default_api_root
+        self.test_failed = False
+
+
+def _cleanup_created_tables(api: Any, table_names: set[str]) -> list[str]:
+    """Remove resources owned by one test and return any cleanup diagnostics."""
+
+    cleanup_errors: list[str] = []
+    for table_name in reversed(sorted(table_names)):
+        try:
+            response = api.s.delete(f"{api.url}/tables/{quote(table_name, safe='')}", timeout=30)
+            if response.status_code not in (200, 202, 204, 404):
+                cleanup_errors.append(f"{table_name}: HTTP {response.status_code} {response.text[:500]}")
+        except requests.RequestException as err:
+            cleanup_errors.append(f"{table_name}: {err}")
+    return cleanup_errors
 
 
 def ready_index_status(index_info: dict[str, Any], *, require_query_fresh: bool = False) -> dict[str, Any] | None:
@@ -2019,24 +2061,43 @@ def real_clipclap_backup_api(request, clipclap_model_available):
     return request.getfixturevalue("backup_api")
 
 
+@pytest.fixture(scope="module")
+def _reusable_stateful_runtime():
+    binary = resolve_binary_path(os.environ.get("ANTFLY_BIN", str(DEFAULT_ANTFLY_BIN)))
+    if not Path(binary).exists():
+        pytest.skip(f"Public API binary not found: {binary}")
+    server = _start_stateful_server_with_retry(binary, find_free_port())
+    default_api_root = ANTFLY_PUBLIC_API_ROOT if Path(binary).name == "antfly" else ""
+    runtime = ReusableAntflyRuntime(server, default_api_root=default_api_root)
+    yield runtime
+    server.stop(test_failed=runtime.test_failed)
+
+
 @pytest.fixture(scope="function")
 def stateful_api(request: pytest.FixtureRequest):
     base_url = os.environ.get("ANTFLY_STATEFUL_URL")
     server: PublicAntflyServer | StandaloneAntflyServer | StatefulAntflyServer | None = None
+    reusable_runtime: ReusableAntflyRuntime | None = None
     default_root = os.environ.get("ANTFLY_STATEFUL_API_ROOT")
     if not base_url:
-        binary = resolve_binary_path(os.environ.get("ANTFLY_BIN", str(DEFAULT_ANTFLY_BIN)))
-        if not Path(binary).exists():
-            pytest.skip(f"Public API binary not found: {binary}")
-        port = find_free_port()
-        server = _start_stateful_server_with_retry(binary, port)
+        if _uses_reusable_antfly_process(request):
+            reusable_runtime = request.getfixturevalue("_reusable_stateful_runtime")
+            server = reusable_runtime.server
+            binary = server.binary
+            if default_root is None:
+                default_root = reusable_runtime.default_api_root
+        else:
+            binary = resolve_binary_path(os.environ.get("ANTFLY_BIN", str(DEFAULT_ANTFLY_BIN)))
+            if not Path(binary).exists():
+                pytest.skip(f"Public API binary not found: {binary}")
+            server = _start_stateful_server_with_retry(binary, find_free_port())
         base_url = server.url
         if default_root is None and Path(binary).name == "antfly":
             default_root = ANTFLY_PUBLIC_API_ROOT
 
     base = antfly_public_api_url(base_url, root=default_root if default_root is not None else "")
 
-    if not wait_for_server(base, timeout=10):
+    if reusable_runtime is None and not wait_for_server(base, timeout=10):
         pytest.skip(f"Public API at {base} is not reachable")
 
     session = requests.Session()
@@ -2054,6 +2115,7 @@ def stateful_api(request: pytest.FixtureRequest):
             self.url = base_url.rstrip("/")
             self._server = server_ref
             self._request_lock = threading.Lock()
+            self._created_tables: set[str] = set()
 
         def _raise_request_error(self, err: requests.RequestException) -> None:
             raise_request_error_with_logs(err, self._server)
@@ -2208,7 +2270,9 @@ def stateful_api(request: pytest.FixtureRequest):
                     time.sleep(0.1)
                     continue
                 if response.status_code not in (404, 500):
-                    return self._check(response)
+                    created = self._check(response)
+                    self._created_tables.add(table_name)
+                    return created
                 if time.monotonic() >= deadline:
                     return self._check(response)
                 time.sleep(0.1)
@@ -2548,28 +2612,58 @@ def stateful_api(request: pytest.FixtureRequest):
                 return ""
             return self._server.debug_logs().strip()
 
-    yield PublicApi(session, base, server)
+    api = PublicApi(session, base, server)
+    yield api
+    report = getattr(request.node, "rep_call", None)
+    test_failed = bool(report and report.failed)
+    cleanup_errors = _cleanup_created_tables(api, api._created_tables) if reusable_runtime is not None else []
     session.close()
-    if server is not None:
-        report = getattr(request.node, "rep_call", None)
-        server.stop(test_failed=bool(report and report.failed))
+    if reusable_runtime is not None:
+        reusable_runtime.test_failed = reusable_runtime.test_failed or test_failed or bool(cleanup_errors)
+        if cleanup_errors:
+            message = "failed to clean reusable Antfly test tables:\n" + "\n".join(cleanup_errors)
+            if test_failed:
+                print(message)
+            else:
+                raise AssertionError(message)
+    elif server is not None:
+        server.stop(test_failed=test_failed)
 
 
-@pytest.fixture(scope="function")
-def backup_api():
+@pytest.fixture(scope="module")
+def _reusable_backup_runtime():
     binary = resolve_binary_path(os.environ.get("ANTFLY_BIN", str(DEFAULT_ANTFLY_BIN)))
     if not Path(binary).exists():
         pytest.skip(f"Public API binary not found: {binary}")
-
-    port = find_free_port()
     if Path(binary).name == "antfly":
-        server = StandaloneAntflyServer(binary, "127.0.0.1", port)
+        server = StandaloneAntflyServer(binary, "127.0.0.1", find_free_port())
     else:
-        server = PublicAntflyServer(binary, "127.0.0.1", port)
+        server = PublicAntflyServer(binary, "127.0.0.1", find_free_port())
+    default_api_root = ANTFLY_PUBLIC_API_ROOT if Path(binary).name == "antfly" else ""
+    runtime = ReusableAntflyRuntime(server, default_api_root=default_api_root)
+    yield runtime
+    server.stop(test_failed=runtime.test_failed)
+
+
+@pytest.fixture(scope="function")
+def backup_api(request: pytest.FixtureRequest):
+    reusable_runtime: ReusableAntflyRuntime | None = None
+    if _uses_reusable_antfly_process(request):
+        reusable_runtime = request.getfixturevalue("_reusable_backup_runtime")
+        server = reusable_runtime.server
+        binary = server.binary
+    else:
+        binary = resolve_binary_path(os.environ.get("ANTFLY_BIN", str(DEFAULT_ANTFLY_BIN)))
+        if not Path(binary).exists():
+            pytest.skip(f"Public API binary not found: {binary}")
+        if Path(binary).name == "antfly":
+            server = StandaloneAntflyServer(binary, "127.0.0.1", find_free_port())
+        else:
+            server = PublicAntflyServer(binary, "127.0.0.1", find_free_port())
 
     base = antfly_public_api_url(server.url, binary=binary)
 
-    if not wait_for_server(base, timeout=10):
+    if reusable_runtime is None and not wait_for_server(base, timeout=10):
         server.stop()
         pytest.skip(f"Public API at {base} is not reachable")
 
@@ -2588,6 +2682,7 @@ def backup_api():
             self.url = base_url.rstrip("/")
             self._server = server_ref
             self._request_lock = threading.Lock()
+            self._created_tables: set[str] = set()
 
         def _raise_request_error(self, err: requests.RequestException) -> None:
             raise_request_error_with_logs(err, self._server)
@@ -2668,7 +2763,9 @@ def backup_api():
                     time.sleep(0.1)
                     continue
                 if response.status_code not in (404, 500):
-                    return self._check(response)
+                    created = self._check(response)
+                    self._created_tables.add(table_name)
+                    return created
                 if time.monotonic() >= deadline:
                     return self._check(response)
                 time.sleep(0.1)
@@ -2865,9 +2962,22 @@ def backup_api():
             response = self.s.get(f"{self.url}/backups?location={location}&connection={E2E_BACKUP_CONNECTION}", timeout=30)
             return self._check(response)
 
-    yield PublicApi(session, base, server)
+    api = PublicApi(session, base, server)
+    yield api
+    report = getattr(request.node, "rep_call", None)
+    test_failed = bool(report and report.failed)
+    cleanup_errors = _cleanup_created_tables(api, api._created_tables) if reusable_runtime is not None else []
     session.close()
-    server.stop()
+    if reusable_runtime is not None:
+        reusable_runtime.test_failed = reusable_runtime.test_failed or test_failed or bool(cleanup_errors)
+        if cleanup_errors:
+            message = "failed to clean reusable Antfly test tables:\n" + "\n".join(cleanup_errors)
+            if test_failed:
+                print(message)
+            else:
+                raise AssertionError(message)
+    else:
+        server.stop(test_failed=test_failed)
 
 
 @pytest.fixture(scope="function", params=["stateful", "serverless"], ids=["stateful", "serverless"])

--- a/zig/e2e/antfly/conftest.py
+++ b/zig/e2e/antfly/conftest.py
@@ -48,7 +48,7 @@ import time
 from contextlib import ExitStack
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
-from urllib.parse import quote, urlparse
+from urllib.parse import quote, unquote, urlparse
 from typing import Any, Callable
 
 import pytest
@@ -216,7 +216,12 @@ def _uses_reusable_antfly_process(request: pytest.FixtureRequest) -> bool:
         "yes",
         "on",
     }
-    return not disabled and request.node.get_closest_marker("reuse_antfly_process") is not None
+    force_fresh = request.node.get_closest_marker("fresh_antfly_process") is not None
+    return (
+        not disabled
+        and not force_fresh
+        and request.node.get_closest_marker("reuse_antfly_process") is not None
+    )
 
 
 class ReusableAntflyRuntime:
@@ -245,6 +250,13 @@ def _cleanup_created_tables(api: Any, table_names: set[str]) -> list[str]:
         except requests.RequestException as err:
             cleanup_errors.append(f"{table_name}: {err}")
     return cleanup_errors
+
+
+def _created_table_from_path(path: str) -> str | None:
+    parts = path.partition("?")[0].strip("/").split("/")
+    if len(parts) != 2 or parts[0] != "tables" or not parts[1]:
+        return None
+    return unquote(parts[1])
 
 
 def ready_index_status(index_info: dict[str, Any], *, require_query_fresh: bool = False) -> dict[str, Any] | None:
@@ -2230,7 +2242,10 @@ def stateful_api(request: pytest.FixtureRequest):
         def post(self, path: str, payload: dict) -> Any:
             try:
                 with self._request_lock:
-                    return self._check(self.s.post(f"{self.url}{path}", json=payload, timeout=30))
+                    result = self._check(self.s.post(f"{self.url}{path}", json=payload, timeout=30))
+                if table_name := _created_table_from_path(path):
+                    self._created_tables.add(table_name)
+                return result
             except requests.RequestException as err:
                 self._raise_request_error(err)
 
@@ -2723,7 +2738,10 @@ def backup_api(request: pytest.FixtureRequest):
         def post(self, path: str, payload: dict) -> Any:
             try:
                 with self._request_lock:
-                    return self._check(self.s.post(f"{self.url}{path}", json=payload, timeout=30))
+                    result = self._check(self.s.post(f"{self.url}{path}", json=payload, timeout=30))
+                if table_name := _created_table_from_path(path):
+                    self._created_tables.add(table_name)
+                return result
             except requests.RequestException as err:
                 self._raise_request_error(err)
 

--- a/zig/e2e/antfly/pyproject.toml
+++ b/zig/e2e/antfly/pyproject.toml
@@ -13,6 +13,7 @@ testpaths = ["."]
 addopts = "-v --durations=50 --durations-min=1.0"
 markers = [
     "reuse_antfly_process: share one local Antfly process within this test module and clean tables after each test",
+    "fresh_antfly_process: override module-level process reuse for tests that exercise process or storage lifecycle",
     "objectstore_integration: requires real S3 or GCS objectstore credentials and buckets",
     "standalone_integration: requires local antfly standalone plus a live inference generator model",
     "ha_standby: starts local Zig antfly standalone primary/standby processes for HA replication",

--- a/zig/e2e/antfly/pyproject.toml
+++ b/zig/e2e/antfly/pyproject.toml
@@ -10,8 +10,9 @@ dependencies = [
 
 [tool.pytest.ini_options]
 testpaths = ["."]
-addopts = "-v"
+addopts = "-v --durations=50 --durations-min=1.0"
 markers = [
+    "reuse_antfly_process: share one local Antfly process within this test module and clean tables after each test",
     "objectstore_integration: requires real S3 or GCS objectstore credentials and buckets",
     "standalone_integration: requires local antfly standalone plus a live inference generator model",
     "ha_standby: starts local Zig antfly standalone primary/standby processes for HA replication",

--- a/zig/e2e/antfly/test_foreign_sources.py
+++ b/zig/e2e/antfly/test_foreign_sources.py
@@ -24,7 +24,10 @@ import requests
 
 from helpers import query_hits_total_value, wait_until
 
-pytestmark = pytest.mark.postgres_integration
+pytestmark = [
+    pytest.mark.postgres_integration,
+    pytest.mark.reuse_antfly_process,
+]
 
 DEFAULT_PG_DSN = "postgres://localhost:5432/postgres?sslmode=disable"
 PSQL_BIN = os.environ.get("ANTFLY_TEST_PSQL_BIN", "/opt/homebrew/opt/postgresql@18/bin/psql")

--- a/zig/e2e/antfly/test_graph.py
+++ b/zig/e2e/antfly/test_graph.py
@@ -17,9 +17,14 @@
 from __future__ import annotations
 
 import time
+
+import pytest
 import requests
 
 from helpers import json_doc, query_hits_total_value, upsert, wait_until
+
+
+pytestmark = pytest.mark.reuse_antfly_process
 
 
 def _create_index(api, table_name: str, index_name: str, payload: dict) -> dict:

--- a/zig/e2e/antfly/test_index_lifecycle.py
+++ b/zig/e2e/antfly/test_index_lifecycle.py
@@ -28,6 +28,9 @@ from conftest import ready_index_status
 from helpers import json_doc, upsert, wait_until
 
 
+pytestmark = pytest.mark.reuse_antfly_process
+
+
 def _table_name(created: dict) -> str:
     return created.get("name") or created.get("table_name") or ""
 
@@ -344,6 +347,7 @@ def test_stateful_table_accepts_public_full_text_create_index(stateful_api):
     assert detail["config"]["type"] == "full_text"
 
 
+@pytest.mark.fresh_antfly_process
 def test_stateful_managed_algebraic_generation_rebuild_catches_up_and_reopens(stateful_api):
     table_name = f"managed_algebraic_generation_{time.time_ns()}"
     index_name = "analytics_idx"
@@ -1199,6 +1203,7 @@ def test_stateful_managed_embeddings_backfill_recovers_after_rate_limited_enrich
     assert _response_hit_ids(alpha_query)[0] == "doc:a"
 
 
+@pytest.mark.fresh_antfly_process
 def test_stateful_managed_embeddings_backfill_resumes_after_process_restart(
     single_item_enrichment_batches,
     stateful_api,
@@ -1587,6 +1592,7 @@ def test_stateful_managed_embeddings_provider_pacing_is_shared_across_tables(
     assert stats["rate_limited_requests"] <= 1
 
 
+@pytest.mark.fresh_antfly_process
 def test_stateful_managed_embeddings_delete_recreate_recovers_after_corrupt_artifact(
     stateful_api,
     openai_embedder,
@@ -1837,14 +1843,18 @@ def test_table_chunker_full_text_index_routes_template_chunks(table_api, openai_
         if table_api.backend == "serverless":
             assert table_api.publish_table(table_name) is not None
 
-        hits = wait_until(
-            lambda: (
-                current
-                if ((current := query_ids(table_name)) and full_text_enabled)
-                else None
-            ),
-            timeout_s=30.0,
-            interval_s=0.5,
+        # `full_index` is the positive completion barrier for stateful tables;
+        # serverless tables additionally complete publication above. Do not
+        # poll for an absent hit when full text is disabled: that predicate can
+        # never succeed and previously consumed the entire 30-second timeout.
+        hits = (
+            wait_until(
+                lambda: current if (current := query_ids(table_name)) else None,
+                timeout_s=30.0,
+                interval_s=0.5,
+            )
+            if full_text_enabled
+            else None
         )
         return table_name, {"hits": hits or []}
 
@@ -2313,21 +2323,17 @@ def test_serverless_named_embedding_indexes_report_publication_actions(serverles
     )
     assert serverless_api.delete_index(table_name, "semantic_a") == {}
 
-    planned = wait_until(
-        lambda: (
-            current
-            if (
-                (current := serverless_api.table_build_status(table_name)).get("head_republish_recommended") is True
-                and _named_action(current, "vector_index_actions", "semantic_b") == "reuse"
-                and _named_action(current, "sparse_index_actions", "sparse_a") == "reuse"
-                and _named_action(current, "sparse_index_actions", "sparse_b") == "rebuild"
-            )
-            else None
-        ),
-        timeout_s=30.0,
-        interval_s=0.5,
-    )
-    if planned is not None:
+    # The pre-build plan is a transient diagnostic snapshot: the test's
+    # required contract is the post-build action set below. Inspect it when it
+    # is already observable, but do not spend 30 seconds waiting for an
+    # optional intermediate state.
+    planned = serverless_api.table_build_status(table_name)
+    if (
+        planned.get("head_republish_recommended") is True
+        and _named_action(planned, "vector_index_actions", "semantic_b") == "reuse"
+        and _named_action(planned, "sparse_index_actions", "sparse_a") == "reuse"
+        and _named_action(planned, "sparse_index_actions", "sparse_b") == "rebuild"
+    ):
         assert _named_action(planned, "vector_index_actions", "semantic_a") == "drop"
         assert planned["artifact_actions"]["dense_vector"] == "reuse"
         assert planned["artifact_actions"]["sparse_vector"] == "rebuild"

--- a/zig/e2e/antfly/test_query_string.py
+++ b/zig/e2e/antfly/test_query_string.py
@@ -19,9 +19,13 @@ from __future__ import annotations
 import json
 import time
 
+import pytest
 import requests
 
 from helpers import wait_until
+
+
+pytestmark = pytest.mark.reuse_antfly_process
 
 
 def _hit_ids(result: dict, response_index: int = 0) -> list[str]:

--- a/zig/e2e/antfly/test_quickstart.py
+++ b/zig/e2e/antfly/test_quickstart.py
@@ -21,6 +21,10 @@ import requests
 
 from helpers import assert_single_top_hit, json_doc, upsert, wait_until
 
+
+pytestmark = pytest.mark.reuse_antfly_process
+
+
 CLIPCLAP_MODEL = "antflydb/clipclap"
 
 

--- a/zig/e2e/antfly/test_retrieval.py
+++ b/zig/e2e/antfly/test_retrieval.py
@@ -25,6 +25,9 @@ import requests
 from helpers import wait_until
 
 
+pytestmark = pytest.mark.reuse_antfly_process
+
+
 def _parse_sse_events(body: str) -> list[tuple[str, object]]:
     events: list[tuple[str, object]] = []
     for chunk in body.strip().split("\n\n"):

--- a/zig/e2e/antfly/test_sparse.py
+++ b/zig/e2e/antfly/test_sparse.py
@@ -26,6 +26,9 @@ import requests
 from helpers import wait_until
 
 
+pytestmark = pytest.mark.reuse_antfly_process
+
+
 def _create_index(api, table_name: str, index_name: str, payload: dict) -> dict:
     return api.post(f"/tables/{table_name}/indexes/{index_name}", payload)
 

--- a/zig/e2e/antfly/test_transactions.py
+++ b/zig/e2e/antfly/test_transactions.py
@@ -27,6 +27,9 @@ import requests
 from helpers import wait_until
 
 
+pytestmark = pytest.mark.reuse_antfly_process
+
+
 NUM_SHARDS = 4
 
 

--- a/zig/e2e/antfly/test_transforms.py
+++ b/zig/e2e/antfly/test_transforms.py
@@ -26,6 +26,9 @@ from helpers import wait_until
 from helpers import json_doc, upsert
 
 
+pytestmark = pytest.mark.reuse_antfly_process
+
+
 def _raise_thread_errors(errors: list[Exception]) -> None:
     if errors:
         raise AssertionError("\n\n".join(str(err) for err in errors))


### PR DESCRIPTION
## Summary

- add an explicit `reuse_antfly_process` marker for E2E modules that are safe to run against one module-owned local Antfly process
- retain function-scoped HTTP clients and track/delete every table created by each test, including direct `POST /tables/{name}` creation
- add a `fresh_antfly_process` override for restart, pause/resume, corruption, and storage-lifecycle cases inside otherwise reusable modules
- keep unmarked lifecycle, scaling, CDC, auth, and backup/restore tests on the existing fresh-process path
- add `ANTFLY_E2E_DISABLE_PROCESS_REUSE=1` for isolation debugging and apples-to-apples timing comparisons
- remove three unnecessary 30-second index test waits: two impossible negative polls and one optional transient-state poll
- report the 50 slowest E2E phases taking at least one second

## Measured impact

On the same macOS host and Antfly binary:

- `test_transforms.py` stateful cases: 18.83s -> 6.29s (67% faster)
- `test_retrieval.py`: 45.02s -> 14.39s (68% faster)
- `test_foreign_sources.py`: 30.53s -> 4.67s (85% faster)
- `test_index_lifecycle.py`:
  - original behavior: 147.87s
  - poll fixes with reuse disabled: 54.28s
  - poll fixes plus reuse: 32.60s
  - combined reduction: 78%

Nine opted-in modules cover 166 collected cases. Each module still owns a separate Antfly process, and the three process-mutating index cases retain fresh-process isolation.

## Verification

- full index lifecycle module: 35 passed with reuse and 35 passed with reuse disabled
- all three fresh-process index lifecycle overrides passed together
- PostgreSQL foreign-source module: 40 passed with reuse and 40 passed with reuse disabled
- 36 reusable stateful API cases passed together
- 27 retrieval cases passed with reuse and again with reuse disabled
- quickstart, graph, and sparse cohort: 26 passed, 2 real-model cases skipped
- process/port lifecycle regressions: 21 passed
- full Antfly E2E collection: 265 tests collected; test inventory is unchanged
- Python compile checks and `git diff --check`
