### PR TITLE
test(e2e): halve Antfly suite time with module parallelism

### DIFF
--- a/.github/workflows/zig-tests.yml
+++ b/.github/workflows/zig-tests.yml
@@ -990,7 +990,7 @@ jobs:
           ANTFLY_LSM_OPEN_DEBUG: "1"
         run: |
           chmod +x ./zig-out/bin/antfly
-          taskset -c ${{ steps.e2e_cpus.outputs.list }} uv run --project e2e/antfly pytest -q --continue-on-collection-errors e2e/antfly
+          taskset -c ${{ steps.e2e_cpus.outputs.list }} ../scripts/ci/zig-antfly-e2e-pytest.sh e2e/antfly
 
   e2e-full:
     name: e2e-full

--- a/scripts/ci/zig-antfly-e2e-pytest.sh
+++ b/scripts/ci/zig-antfly-e2e-pytest.sh
@@ -17,7 +17,12 @@ set -euo pipefail
 
 script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd "$script_dir/../.." && pwd)"
-workers="${ANTFLY_E2E_WORKERS:-2}"
+default_workers=4
+detected_workers="$(getconf _NPROCESSORS_ONLN 2>/dev/null || true)"
+if [[ "$detected_workers" =~ ^[1-9][0-9]*$ ]] && (( detected_workers < default_workers )); then
+  default_workers="$detected_workers"
+fi
+workers="${ANTFLY_E2E_WORKERS:-$default_workers}"
 
 if [[ ! "$workers" =~ ^(0|[1-9][0-9]*)$ ]]; then
   echo "ANTFLY_E2E_WORKERS must be a non-negative integer; got: $workers" >&2

--- a/scripts/ci/zig-antfly-e2e-pytest.sh
+++ b/scripts/ci/zig-antfly-e2e-pytest.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Copyright 2026 Antfly, Inc.
+#
+# Licensed under the Elastic License 2.0 (ELv2); you may not use this file
+# except in compliance with the Elastic License 2.0. You may obtain a copy of
+# the Elastic License 2.0 at
+#
+#     https://www.antfly.io/licensing/ELv2-license
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the Elastic License 2.0 is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# Elastic License 2.0 for the specific language governing permissions and
+# limitations.
+
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/../.." && pwd)"
+workers="${ANTFLY_E2E_WORKERS:-2}"
+
+if [[ ! "$workers" =~ ^(0|[1-9][0-9]*)$ ]]; then
+  echo "ANTFLY_E2E_WORKERS must be a non-negative integer; got: $workers" >&2
+  exit 2
+fi
+
+cd "$repo_root/zig"
+if (( workers > 1 )); then
+  # Keep every module on one worker so module-scoped Antfly process reuse and
+  # its per-test cleanup remain a single coherent lifecycle.
+  exec uv run --project e2e/antfly pytest -q --continue-on-collection-errors \
+    -n "$workers" --dist=loadscope "$@"
+fi
+
+exec uv run --project e2e/antfly pytest -q --continue-on-collection-errors "$@"

--- a/scripts/ci/zig-e2e-base-linux.sh
+++ b/scripts/ci/zig-e2e-base-linux.sh
@@ -80,7 +80,7 @@ fi
 
 antfly_status=0
 if [[ "$e2e_suite" != "inference" ]]; then
-  UV_PROJECT_ENVIRONMENT="$antfly_venv" uv run --project e2e/antfly pytest -q --continue-on-collection-errors "${antfly_args[@]}" || antfly_status=$?
+  UV_PROJECT_ENVIRONMENT="$antfly_venv" "$script_dir/zig-antfly-e2e-pytest.sh" "${antfly_args[@]}" || antfly_status=$?
 fi
 
 inference_status=0

--- a/zig/README.md
+++ b/zig/README.md
@@ -119,9 +119,9 @@ scripts/ci/zig-antfly-e2e-pytest.sh e2e/antfly
 uv run --project e2e/inference pytest -q e2e/inference
 ```
 
-The Antfly runner uses two pytest workers and keeps each module on one worker
-so module-scoped process reuse remains intact. Set `ANTFLY_E2E_WORKERS=1` for a
-sequential comparison or debugging run.
+The Antfly runner uses up to four pytest workers and keeps each module on one
+worker so module-scoped process reuse remains intact. Set
+`ANTFLY_E2E_WORKERS=1` for a sequential comparison or debugging run.
 
 Some e2e tests start local binaries from `zig-out/bin`; build the relevant
 binary first when running those tests directly:

--- a/zig/README.md
+++ b/zig/README.md
@@ -115,9 +115,13 @@ needed. From the repository root, use `make zig-test` or `make zig-unit-test`.
 The Python e2e suites are split by product:
 
 ```sh
-uv run --project e2e/antfly pytest -q e2e/antfly
+scripts/ci/zig-antfly-e2e-pytest.sh e2e/antfly
 uv run --project e2e/inference pytest -q e2e/inference
 ```
+
+The Antfly runner uses two pytest workers and keeps each module on one worker
+so module-scoped process reuse remains intact. Set `ANTFLY_E2E_WORKERS=1` for a
+sequential comparison or debugging run.
 
 Some e2e tests start local binaries from `zig-out/bin`; build the relevant
 binary first when running those tests directly:

--- a/zig/e2e/antfly/conftest.py
+++ b/zig/e2e/antfly/conftest.py
@@ -54,6 +54,7 @@ from typing import Any, Callable
 import pytest
 import requests
 
+from helpers import start_http_server
 from port_reservations import LoopbackPortReservations, find_free_port
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -1059,8 +1060,7 @@ class InferenceRerankerServer:
                 _ = args
 
         self._server = ThreadingHTTPServer((host, port), Handler)
-        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
-        self._thread.start()
+        self._thread = start_http_server(self._server)
         if not wait_for_listener(self.url):
             raise RuntimeError(f"Inference reranker server failed to start at {self.url}")
 
@@ -1122,8 +1122,7 @@ class InferenceGeneratorServer:
                 _ = args
 
         self._server = ThreadingHTTPServer((host, port), Handler)
-        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
-        self._thread.start()
+        self._thread = start_http_server(self._server)
         if not wait_for_listener(self.url):
             raise RuntimeError(f"Inference generator server failed to start at {self.url}")
 
@@ -1288,8 +1287,7 @@ class PdfOcrE2EServer:
                 _ = args
 
         self._server = ThreadingHTTPServer((host, port), Handler)
-        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
-        self._thread.start()
+        self._thread = start_http_server(self._server)
         if not wait_for_listener(self.base_url):
             raise RuntimeError(f"PDF OCR E2E server failed to start at {self.base_url}")
 
@@ -1378,8 +1376,7 @@ class OpenAiEmbeddingServer:
                 _ = args
 
         self._server = ThreadingHTTPServer((host, port), Handler)
-        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
-        self._thread.start()
+        self._thread = start_http_server(self._server)
         if not wait_for_listener(self.url):
             raise RuntimeError(f"OpenAI embedding server failed to start at {self.url}")
 
@@ -1484,8 +1481,7 @@ class RateLimitedOpenAiEmbeddingServer:
                 _ = args
 
         self._server = ThreadingHTTPServer((host, port), Handler)
-        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
-        self._thread.start()
+        self._thread = start_http_server(self._server)
         if not wait_for_listener(self.url):
             raise RuntimeError(f"Rate-limited OpenAI embedding server failed to start at {self.url}")
 
@@ -1598,8 +1594,7 @@ class PacingSensitiveOpenAiEmbeddingServer:
                 _ = args
 
         self._server = ThreadingHTTPServer((host, port), Handler)
-        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
-        self._thread.start()
+        self._thread = start_http_server(self._server)
         if not wait_for_listener(self.url):
             raise RuntimeError(f"Pacing-sensitive OpenAI embedding server failed to start at {self.url}")
 
@@ -1744,8 +1739,7 @@ class InferenceEmbeddingServer:
                 _ = args
 
         self._server = ThreadingHTTPServer((host, port), Handler)
-        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
-        self._thread.start()
+        self._thread = start_http_server(self._server)
         if not wait_for_listener(self.url):
             raise RuntimeError(f"Inference embedding server failed to start at {self.url}")
 

--- a/zig/e2e/antfly/helpers.py
+++ b/zig/e2e/antfly/helpers.py
@@ -17,10 +17,26 @@
 from __future__ import annotations
 
 import json
+import threading
 import time
+from socketserver import BaseServer
 from typing import Callable
 
 import requests
+
+
+HTTP_SERVER_POLL_INTERVAL_S = 0.02
+
+
+def start_http_server(server: BaseServer) -> threading.Thread:
+    """Start a test HTTP server without Python's 500ms shutdown latency."""
+    thread = threading.Thread(
+        target=server.serve_forever,
+        kwargs={"poll_interval": HTTP_SERVER_POLL_INTERVAL_S},
+        daemon=True,
+    )
+    thread.start()
+    return thread
 
 
 def json_doc(**fields) -> str:

--- a/zig/e2e/antfly/pyproject.toml
+++ b/zig/e2e/antfly/pyproject.toml
@@ -5,6 +5,7 @@ description = "Portable E2E tests for antfly-zig"
 requires-python = ">=3.11"
 dependencies = [
     "pytest>=8.0",
+    "pytest-xdist>=3.8",
     "requests>=2.31",
 ]
 

--- a/zig/e2e/antfly/test_sparse.py
+++ b/zig/e2e/antfly/test_sparse.py
@@ -16,14 +16,13 @@
 
 from __future__ import annotations
 
-import threading
 import time
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 import pytest
 import requests
 
-from helpers import wait_until
+from helpers import start_http_server, wait_until
 
 
 pytestmark = pytest.mark.reuse_antfly_process
@@ -105,8 +104,7 @@ class _TextServer:
         self._server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
         host, port = self._server.server_address
         self.url = f"http://{host}:{port}"
-        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
-        self._thread.start()
+        self._thread = start_http_server(self._server)
 
     def stop(self) -> None:
         self._server.shutdown()

--- a/zig/e2e/antfly/test_transforms.py
+++ b/zig/e2e/antfly/test_transforms.py
@@ -400,8 +400,15 @@ def test_serverless_table_transforms_follow_latest_then_published(serverless_api
     assert published_before["table_name"] == table_name
     assert published_before["view"] == "published"
     published_before_docs = _docs_by_id(published_before)
-    assert "status" not in published_before_docs["doc-a"]
-    assert published_before_docs["doc-a"]["version"] == 1
+    published_before_doc = published_before_docs["doc-a"]
+    # Automatic publication may win the race with this observation. Both the
+    # previous snapshot and the fully transformed snapshot are valid here;
+    # partial transform visibility is not.
+    if "status" in published_before_doc:
+        assert published_before_doc["status"] == "updated"
+        assert published_before_doc["version"] == 3
+    else:
+        assert published_before_doc["version"] == 1
 
     try:
         serverless_api.build_table(table_name)

--- a/zig/e2e/antfly/uv.lock
+++ b/zig/e2e/antfly/uv.lock
@@ -8,12 +8,14 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "pytest" },
+    { name = "pytest-xdist" },
     { name = "requests" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "pytest", specifier = ">=8.0" },
+    { name = "pytest-xdist", specifier = ">=3.8" },
     { name = "requests", specifier = ">=2.31" },
 ]
 
@@ -125,6 +127,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.11"
 source = { registry = "https://pypi.org/simple" }
@@ -183,6 +194,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- run Antfly pytest modules on up to four xdist workers while keeping each module and its reusable process on one worker
- bound the default by detected CPU count and allow immediate sequential fallback with ANTFLY_E2E_WORKERS=1
- reduce Python mock HTTP server shutdown polling from 500ms to 20ms
- make the shared runner the default for base CI, full CI, and documented local runs
- remove a transient publication-order assumption exposed by parallel scheduling

## Measured impact

Using the same local Antfly binary and 200-test comparable base selection:

- sequential: 276.21s
- two workers: 137.62s
- three workers: 104.25s
- four workers: 81.41s

Four workers are approximately 70% faster than sequential and 41% faster than the original two-worker PR default.

The mock-heavy retrieval/quickstart/sparse slice improved from 30.29s to 20.52s from fast server teardown alone, then to 11.45s with two workers.

## Validation

- four workers: 190 passed, 10 skipped in 81.03s pytest time
- three workers: 190 passed, 10 skipped in 103.70s
- two workers: 190 passed, 10 skipped in 137.28s
- 44 passed, 2 skipped in sequential and parallel mock-heavy benchmarks
- Python byte compilation for changed E2E modules
- shell syntax checks for both E2E runner scripts
- sequential and parallel runner collection checks
- git diff --check

The base comparisons exclude test_exact_sort.py because the borrowed benchmark binary predates its current capability metadata expectation; that test failed identically in the sequential baseline.