### PR TITLE
test: add isolation-aware E2E scheduling

### DIFF
--- a/.github/workflows/zig-tests.yml
+++ b/.github/workflows/zig-tests.yml
@@ -830,6 +830,7 @@ jobs:
       ZIG_GLOBAL_CACHE_DIR: /mnt/cache/antfly/zig/zig-global
       UV_CACHE_DIR: /mnt/cache/antfly/zig/uv
       HF_HOME: /mnt/cache/antfly/zig/hf
+      ANTFLY_E2E_DURATION_FILE: /mnt/cache/antfly/zig/e2e-durations/antfly-v1.json
       ANTFLY_CI_TRACE: "1"
     steps:
       - uses: actions/checkout@v6
@@ -851,7 +852,7 @@ jobs:
           global_cache="/mnt/cache/antfly/zig/zig-global"
           echo "ZIG_LOCAL_CACHE_DIR=$local_cache" >> "$GITHUB_ENV"
           echo "ZIG_GLOBAL_CACHE_DIR=$global_cache" >> "$GITHUB_ENV"
-          mkdir -p "$local_cache" "$global_cache" "$UV_CACHE_DIR" "$HF_HOME"
+          mkdir -p "$local_cache" "$global_cache" "$UV_CACHE_DIR" "$HF_HOME" "$(dirname "$ANTFLY_E2E_DURATION_FILE")"
           mkdir -p "/mnt/cache/antfly/zig/home-cache-${{ matrix.suite }}" "/mnt/cache/antfly/zig/home-antfly-${{ matrix.suite }}"
           rm -rf ~/.cache ~/.antfly
           ln -s "/mnt/cache/antfly/zig/home-cache-${{ matrix.suite }}" ~/.cache
@@ -994,6 +995,7 @@ jobs:
     env:
       UV_CACHE_DIR: /mnt/cache/antfly/zig/uv
       HF_HOME: /mnt/cache/antfly/zig/hf
+      ANTFLY_E2E_DURATION_FILE: /mnt/cache/antfly/zig/e2e-durations/antfly-v1.json
     steps:
       - uses: actions/checkout@v6
         with:
@@ -1004,7 +1006,7 @@ jobs:
 
       - name: Prepare ARC test cache dirs
         run: |
-          mkdir -p "$UV_CACHE_DIR" "$HF_HOME"
+          mkdir -p "$UV_CACHE_DIR" "$HF_HOME" "$(dirname "$ANTFLY_E2E_DURATION_FILE")"
           mkdir -p "/mnt/cache/antfly/zig/home-cache-full-${{ matrix.suite }}" "/mnt/cache/antfly/zig/home-antfly-full-${{ matrix.suite }}"
           rm -rf ~/.cache ~/.antfly
           ln -s "/mnt/cache/antfly/zig/home-cache-full-${{ matrix.suite }}" ~/.cache

--- a/scripts/ci/zig-antfly-e2e-pytest.sh
+++ b/scripts/ci/zig-antfly-e2e-pytest.sh
@@ -17,27 +17,31 @@ set -euo pipefail
 
 script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd "$script_dir/../.." && pwd)"
-# Each module worker can run a multi-threaded standalone or serverless Antfly
-# process. Two workers keep the 8-CPU ARC jobs parallel without oversubscribing
-# the servers that exercise multi-shard transactions, scaling, and publication.
-default_workers=2
+# Lightweight checks can use four workers while the scheduler separately caps
+# concurrent Antfly processes and clusters.
+default_workers=4
 detected_workers="$(getconf _NPROCESSORS_ONLN 2>/dev/null || true)"
 if [[ "$detected_workers" =~ ^[1-9][0-9]*$ ]] && (( detected_workers < default_workers )); then
   default_workers="$detected_workers"
 fi
 workers="${ANTFLY_E2E_WORKERS:-$default_workers}"
+process_slots="${ANTFLY_E2E_PROCESS_SLOTS:-2}"
 
 if [[ ! "$workers" =~ ^(0|[1-9][0-9]*)$ ]]; then
   echo "ANTFLY_E2E_WORKERS must be a non-negative integer; got: $workers" >&2
   exit 2
 fi
+if [[ ! "$process_slots" =~ ^[1-9][0-9]*$ ]]; then
+  echo "ANTFLY_E2E_PROCESS_SLOTS must be a positive integer; got: $process_slots" >&2
+  exit 2
+fi
 
 cd "$repo_root/zig"
 if (( workers > 1 )); then
-  # Keep every module on one worker so module-scoped Antfly process reuse and
-  # its per-test cleanup remain a single coherent lifecycle.
+  # Isolation groups preserve shared fixture lifecycles; independent tests are
+  # scheduled longest-first without exceeding the Antfly process budget.
   exec uv run --project e2e/antfly pytest -q --continue-on-collection-errors \
-    -n "$workers" --dist=loadscope "$@"
+    -n "$workers" --dist=loadgroup --e2e-process-slots "$process_slots" "$@"
 fi
 
 exec uv run --project e2e/antfly pytest -q --continue-on-collection-errors "$@"

--- a/zig/README.md
+++ b/zig/README.md
@@ -133,8 +133,9 @@ fixtures. Custom fixtures can place
 `@e2e_resource("antfly_process")` from `e2e_scheduler` immediately below
 `@pytest.fixture`; fixture scope determines its isolation boundary and a
 session-scoped fixture automatically retains a process slot for the worker's
-lifetime. Add `lifetime="session", identity="shared_runtime"` on wrapper fixtures
-that share a longer-lived process. Tests that launch a process directly can use
+lifetime. Inferred session identities are fixture-definition-specific; add
+`lifetime="session", identity="shared_runtime"` on wrapper fixtures that share a
+longer-lived process. Tests that launch a process directly can use
 `@pytest.mark.e2e_resource("antfly_process")`. Tests with unusual sharing
 requirements can use
 `@pytest.mark.e2e_isolation("test")` or `@pytest.mark.e2e_isolation("module")`.

--- a/zig/README.md
+++ b/zig/README.md
@@ -131,9 +131,11 @@ their queued work completes.
 The scheduler infers process ownership and fixture scope for the standard E2E
 fixtures. Custom fixtures can place
 `@e2e_resource("antfly_process")` from `e2e_scheduler` immediately below
-`@pytest.fixture`; add `lifetime="session", identity="fixture_name"` when that
-process survives until worker shutdown. Tests that launch a process directly can
-use `@pytest.mark.e2e_resource("antfly_process")`. Tests with unusual sharing
+`@pytest.fixture`; fixture scope determines its isolation boundary and a
+session-scoped fixture automatically retains a process slot for the worker's
+lifetime. Add `lifetime="session", identity="shared_runtime"` on wrapper fixtures
+that share a longer-lived process. Tests that launch a process directly can use
+`@pytest.mark.e2e_resource("antfly_process")`. Tests with unusual sharing
 requirements can use
 `@pytest.mark.e2e_isolation("test")` or `@pytest.mark.e2e_isolation("module")`.
 

--- a/zig/README.md
+++ b/zig/README.md
@@ -130,7 +130,8 @@ the worker; transient function- and module-scoped fixtures release theirs after
 their queued work completes.
 The scheduler infers process ownership and fixture scope for the standard E2E
 fixtures. Custom fixtures can declare `@pytest.mark.e2e_resource("antfly_process")`,
-and tests with unusual sharing requirements can use
+or add `lifetime="session", identity="fixture_name"` when that process survives
+until worker shutdown. Tests with unusual sharing requirements can use
 `@pytest.mark.e2e_isolation("test")` or `@pytest.mark.e2e_isolation("module")`.
 
 Some e2e tests start local binaries from `zig-out/bin`; build the relevant

--- a/zig/README.md
+++ b/zig/README.md
@@ -119,10 +119,16 @@ scripts/ci/zig-antfly-e2e-pytest.sh e2e/antfly
 uv run --project e2e/inference pytest -q e2e/inference
 ```
 
-The Antfly runner uses up to two pytest workers and keeps each module on one
-worker so module-scoped process reuse remains intact. Set
-`ANTFLY_E2E_WORKERS` to override the resource-safe default for experiments, or
-set it to `1` for a sequential comparison or debugging run.
+The Antfly runner uses up to four pytest workers, schedules historically slow
+independent tests first, and keeps shared fixtures on one worker. Antfly process
+and cluster work has a separate concurrency budget of two. Set
+`ANTFLY_E2E_WORKERS` and `ANTFLY_E2E_PROCESS_SLOTS` to tune those limits, or set
+`ANTFLY_E2E_WORKERS=1` for a sequential debugging run. Test duration history is
+stored under `e2e/antfly/.pytest_cache` locally and in the ARC cache in CI.
+The scheduler infers process ownership and fixture scope for the standard E2E
+fixtures. Custom fixtures can declare `@pytest.mark.e2e_resource("antfly_process")`,
+and tests with unusual sharing requirements can use
+`@pytest.mark.e2e_isolation("test")` or `@pytest.mark.e2e_isolation("module")`.
 
 Some e2e tests start local binaries from `zig-out/bin`; build the relevant
 binary first when running those tests directly:

--- a/zig/README.md
+++ b/zig/README.md
@@ -129,9 +129,12 @@ Session-scoped process fixtures retain their process slot for the lifetime of
 the worker; transient function- and module-scoped fixtures release theirs after
 their queued work completes.
 The scheduler infers process ownership and fixture scope for the standard E2E
-fixtures. Custom fixtures can declare `@pytest.mark.e2e_resource("antfly_process")`,
-or add `lifetime="session", identity="fixture_name"` when that process survives
-until worker shutdown. Tests with unusual sharing requirements can use
+fixtures. Custom fixtures can place
+`@e2e_resource("antfly_process")` from `e2e_scheduler` immediately below
+`@pytest.fixture`; add `lifetime="session", identity="fixture_name"` when that
+process survives until worker shutdown. Tests that launch a process directly can
+use `@pytest.mark.e2e_resource("antfly_process")`. Tests with unusual sharing
+requirements can use
 `@pytest.mark.e2e_isolation("test")` or `@pytest.mark.e2e_isolation("module")`.
 
 Some e2e tests start local binaries from `zig-out/bin`; build the relevant

--- a/zig/README.md
+++ b/zig/README.md
@@ -125,6 +125,9 @@ and cluster work has a separate concurrency budget of two. Set
 `ANTFLY_E2E_WORKERS` and `ANTFLY_E2E_PROCESS_SLOTS` to tune those limits, or set
 `ANTFLY_E2E_WORKERS=1` for a sequential debugging run. Test duration history is
 stored under `e2e/antfly/.pytest_cache` locally and in the ARC cache in CI.
+Session-scoped process fixtures retain their process slot for the lifetime of
+the worker; transient function- and module-scoped fixtures release theirs after
+their queued work completes.
 The scheduler infers process ownership and fixture scope for the standard E2E
 fixtures. Custom fixtures can declare `@pytest.mark.e2e_resource("antfly_process")`,
 and tests with unusual sharing requirements can use

--- a/zig/README.md
+++ b/zig/README.md
@@ -131,9 +131,11 @@ their queued work completes.
 The scheduler infers process ownership and fixture scope for the standard E2E
 fixtures. Custom fixtures can place
 `@e2e_resource("antfly_process")` from `e2e_scheduler` immediately below
-`@pytest.fixture`; fixture scope determines its isolation boundary and a
-session-scoped fixture automatically retains a process slot for the worker's
-lifetime. Inferred session identities are fixture-definition-specific; add
+`@pytest.fixture`; the fixture's effective scope determines its isolation
+boundary, including indirect parametrization scope overrides. Package-scoped
+fixtures stay on one worker for their package, while a session-scoped fixture
+automatically retains a process slot for the worker's lifetime. Inferred
+session identities are fixture-definition-specific; add
 `lifetime="session", identity="shared_runtime"` on wrapper fixtures that share a
 longer-lived process. Tests that launch a process directly can use
 `@pytest.mark.e2e_resource("antfly_process")`. Tests with unusual sharing

--- a/zig/e2e/antfly/conftest.py
+++ b/zig/e2e/antfly/conftest.py
@@ -57,6 +57,8 @@ import requests
 from helpers import create_index_payload, start_http_server
 from port_reservations import LoopbackPortReservations, find_free_port
 
+pytest_plugins = ("e2e_scheduler",)
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_ANTFLY_BIN = REPO_ROOT / "zig-out" / "bin" / "antfly"
 E2E_BACKUP_CONNECTION = "e2e-backups"

--- a/zig/e2e/antfly/e2e_scheduler.py
+++ b/zig/e2e/antfly/e2e_scheduler.py
@@ -145,22 +145,39 @@ def _fixture_scope(item: pytest.Item, fixture_name: str) -> str | None:
 
 def _fixture_resource_declarations(
     item: pytest.Item,
-) -> list[tuple[str, object, object, str, str]]:
+) -> list[tuple[str, object, object, str, str, str]]:
     """Return resource declarations attached to fixtures used by an item."""
     fixture_info = getattr(item, "_fixtureinfo", None)
     if fixture_info is None:
         return []
 
-    declarations: list[tuple[str, object, object, str, str]] = []
+    declarations: list[tuple[str, object, object, str, str, str]] = []
     for fixture_name in item.fixturenames:
         definitions = fixture_info.name2fixturedefs.get(fixture_name)
         if not definitions:
             continue
         definition = definitions[-1]
         function = getattr(definition, "func", None)
+        base_id = str(getattr(definition, "baseid", ""))
+        if not base_id:
+            module = str(getattr(function, "__module__", ""))
+            qualified_name = str(getattr(function, "__qualname__", fixture_name))
+            base_id = f"{module}.{qualified_name}"
+        provenance = f"{base_id}:{fixture_name}"
+        default_identity = (
+            f"{fixture_name}."
+            f"{hashlib.sha1(provenance.encode('utf-8')).hexdigest()[:10]}"
+        )
         for name, lifetime, identity in getattr(function, E2E_RESOURCE_ATTRIBUTE, ()):
             declarations.append(
-                (str(name), lifetime, identity, fixture_name, str(definition.scope))
+                (
+                    str(name),
+                    lifetime,
+                    identity,
+                    fixture_name,
+                    str(definition.scope),
+                    default_identity,
+                )
             )
     return declarations
 
@@ -196,6 +213,7 @@ def scheduling_group(item: pytest.Item) -> str:
             marker.kwargs.get("identity"),
             None,
             None,
+            "",
         )
         for marker in item.iter_markers("e2e_resource")
     ]
@@ -206,6 +224,7 @@ def scheduling_group(item: pytest.Item) -> str:
         identity,
         fixture_name,
         fixture_scope,
+        default_identity,
     ) in resource_declarations:
         if resource_name != "antfly_process":
             continue
@@ -218,7 +237,7 @@ def scheduling_group(item: pytest.Item) -> str:
         if fixture_scope == "session" and lifetime is None:
             lifetime = "session"
         if lifetime == "session" and identity is None and fixture_name is not None:
-            identity = fixture_name
+            identity = default_identity
         if lifetime is None:
             if identity is not None:
                 raise pytest.UsageError(
@@ -249,14 +268,17 @@ def scheduling_group(item: pytest.Item) -> str:
     shared_external = item.get_closest_marker("postgres_integration") is not None
     isolation = item.get_closest_marker("e2e_isolation")
 
-    # A reusable runtime or any module/session fixture must stay on one worker.
-    # Function-scoped process fixtures already provide complete test isolation.
-    shared = reuse_process and not force_fresh
-    shared = shared or any(
+    # Preserve fixture sharing at the narrowest safe boundary. Function-scoped
+    # process fixtures already provide complete test isolation.
+    module_shared = reuse_process and not force_fresh
+    module_shared = module_shared or any(
         scope in {"module", "package", "session"} for scope in process_scopes
     )
-    shared = shared or bool(persistent_processes)
-    shared = shared or shared_external
+    module_shared = module_shared or bool(persistent_processes)
+    module_shared = module_shared or shared_external
+    boundary = (
+        "module" if module_shared else "class" if "class" in process_scopes else "test"
+    )
     explicit_group: str | None = None
     if isolation is not None:
         policy = str(isolation.args[0]) if isolation.args else "module"
@@ -264,11 +286,18 @@ def scheduling_group(item: pytest.Item) -> str:
             raise pytest.UsageError(
                 f"{nodeid}: e2e_isolation must be 'test' or 'module', got {policy!r}"
             )
-        shared = policy == "module"
+        boundary = policy
         if group := isolation.kwargs.get("group"):
             explicit_group = str(group)
-    identity = explicit_group or (module_id if shared else nodeid)
-    kind = "module--" if shared else "test--"
+    if explicit_group is not None:
+        identity = explicit_group
+    elif boundary == "module":
+        identity = module_id
+    elif boundary == "class":
+        identity = nodeid.rsplit("::", 1)[0]
+    else:
+        identity = nodeid
+    kind = f"{boundary}--"
     if persistent_processes:
         identities = "+".join(sorted(persistent_processes))
         transient_process = declared_transient_process or bool(

--- a/zig/e2e/antfly/e2e_scheduler.py
+++ b/zig/e2e/antfly/e2e_scheduler.py
@@ -30,6 +30,7 @@ from xdist.workermanage import WorkerController
 
 DURATION_FILE_VERSION = 1
 PROCESS_GROUP_PREFIX = "antfly-process--"
+PERSISTENT_PROCESS_GROUP_PREFIX = f"{PROCESS_GROUP_PREFIX}persistent--"
 DEFAULT_PROCESS_SECONDS = 5.0
 DEFAULT_LIGHT_SECONDS = 0.05
 
@@ -61,6 +62,15 @@ ANTFLY_PROCESS_FIXTURES = frozenset(
         "stateful_api",
         "stateful_auth_api",
         "table_api",
+    }
+)
+
+# These are the process-owning roots among the session-scoped fixtures above.
+# Depending fixtures such as serverless_api share the same worker reservation.
+PERSISTENT_ANTFLY_PROCESS_FIXTURES = frozenset(
+    {
+        "embedded_standalone_runtime",
+        "serverless_runtime",
     }
 )
 
@@ -99,6 +109,13 @@ def scheduling_group(item: pytest.Item) -> str:
         for fixture_name in ANTFLY_PROCESS_FIXTURES.intersection(item.fixturenames)
         if (scope := _fixture_scope(item, fixture_name)) is not None
     }
+    persistent_processes = sorted(
+        fixture_name
+        for fixture_name in PERSISTENT_ANTFLY_PROCESS_FIXTURES.intersection(
+            item.fixturenames
+        )
+        if _fixture_scope(item, fixture_name) == "session"
+    )
     declared_resources = {
         str(mark.args[0]) for mark in item.iter_markers("e2e_resource") if mark.args
     }
@@ -127,7 +144,10 @@ def scheduling_group(item: pytest.Item) -> str:
             explicit_group = str(group)
     identity = explicit_group or (module_id if shared else nodeid)
     kind = "module--" if shared else "test--"
-    resource = PROCESS_GROUP_PREFIX if process_owned else "light--"
+    if persistent_processes:
+        resource = PERSISTENT_PROCESS_GROUP_PREFIX
+    else:
+        resource = PROCESS_GROUP_PREFIX if process_owned else "light--"
     return _safe_group_name(f"{resource}{kind}", identity)
 
 
@@ -225,10 +245,15 @@ class IsolationAwareScheduling(LoadGroupScheduling):
             Path(config.getoption("e2e_duration_file"))
         )
         self._retiring_nodes: set[WorkerController] = set()
+        self._persistent_process_workers: set[WorkerController] = set()
 
     @staticmethod
     def _scope_uses_process(scope: str) -> bool:
         return scope.startswith(PROCESS_GROUP_PREFIX)
+
+    @staticmethod
+    def _scope_uses_persistent_process(scope: str) -> bool:
+        return scope.startswith(PERSISTENT_PROCESS_GROUP_PREFIX)
 
     @classmethod
     def _workload_uses_process(cls, workload: dict[str, dict[str, bool]]) -> bool:
@@ -241,11 +266,13 @@ class IsolationAwareScheduling(LoadGroupScheduling):
     def _reserved_process_workers(self) -> int:
         # xdist requires each worker to have a second queued item before it can
         # start the first. Reserve capacity per sequential worker queue rather
-        # than per queued work unit: a worker can never run two units at once.
+        # than per queued work unit. A session fixture keeps its worker's
+        # reservation after its own work unit completes.
         return sum(
             1
-            for workload in self.assigned_work.values()
-            if self._workload_uses_process(workload)
+            for node, workload in self.assigned_work.items()
+            if node in self._persistent_process_workers
+            or self._workload_uses_process(workload)
         )
 
     def _scope_duration(self, scope: str, work_unit: dict[str, bool]) -> float:
@@ -257,8 +284,9 @@ class IsolationAwareScheduling(LoadGroupScheduling):
         )
 
     def _next_eligible_scope(self, node: WorkerController) -> str | None:
-        node_has_process_reservation = self._workload_uses_process(
-            self.assigned_work.get(node, {})
+        node_has_process_reservation = (
+            node in self._persistent_process_workers
+            or self._workload_uses_process(self.assigned_work.get(node, {}))
         )
         process_capacity = (
             node_has_process_reservation
@@ -291,6 +319,8 @@ class IsolationAwareScheduling(LoadGroupScheduling):
                 if not complete
             ]
         )
+        if self._scope_uses_persistent_process(scope):
+            self._persistent_process_workers.add(node)
 
     def _reschedule(self, node: WorkerController) -> None:
         if node.shutting_down:
@@ -327,12 +357,17 @@ class IsolationAwareScheduling(LoadGroupScheduling):
             self._reschedule(candidate)
 
     def remove_node(self, node: WorkerController) -> str | None:
-        if node in self._retiring_nodes:
-            self._retiring_nodes.remove(node)
+        workeroutput = getattr(node, "workeroutput", None)
+        exitstatus = workeroutput.get("exitstatus") if workeroutput else None
+        retired_cleanly = node in self._retiring_nodes and exitstatus in {0, 1}
+        self._retiring_nodes.discard(node)
+        self._persistent_process_workers.discard(node)
+
+        if retired_cleanly:
             workload = self.assigned_work.pop(node)
             # Depending on event timing, xdist may stop before its last queued
             # item. Put only genuinely incomplete items back into circulation;
-            # this was an intentional retirement, not a test-process crash.
+            # the worker confirmed a normal exit after intentional retirement.
             for scope, work_unit in workload.items():
                 incomplete = {
                     nodeid: False

--- a/zig/e2e/antfly/e2e_scheduler.py
+++ b/zig/e2e/antfly/e2e_scheduler.py
@@ -18,10 +18,13 @@ from __future__ import annotations
 
 import hashlib
 import json
+import math
 import os
 import re
 import tempfile
+from collections.abc import Callable
 from pathlib import Path
+from typing import TypeVar
 
 import pytest
 from xdist.remote import Producer
@@ -88,6 +91,30 @@ PERSISTENT_PROCESS_PARAMETERS = {
     ("table_api", "serverless"): "serverless_runtime",
 }
 RESOURCE_IDENTITY_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
+E2E_RESOURCE_ATTRIBUTE = "__antfly_e2e_resources__"
+FixtureFunction = TypeVar("FixtureFunction", bound=Callable[..., object])
+
+
+def e2e_resource(
+    name: str,
+    *,
+    lifetime: str | None = None,
+    identity: str | None = None,
+) -> Callable[[FixtureFunction], FixtureFunction]:
+    """Declare a resource; place this immediately below ``@pytest.fixture``."""
+
+    def decorate(function: FixtureFunction) -> FixtureFunction:
+        if getattr(function, "_fixture_function_marker", None) is not None:
+            raise TypeError("@e2e_resource must be placed below @pytest.fixture")
+        declarations = tuple(getattr(function, E2E_RESOURCE_ATTRIBUTE, ()))
+        setattr(
+            function,
+            E2E_RESOURCE_ATTRIBUTE,
+            (*declarations, (name, lifetime, identity)),
+        )
+        return function
+
+    return decorate
 
 
 def normalize_nodeid(nodeid: str) -> str:
@@ -115,6 +142,28 @@ def _fixture_scope(item: pytest.Item, fixture_name: str) -> str | None:
     return str(definitions[-1].scope)
 
 
+def _fixture_resource_declarations(
+    item: pytest.Item,
+) -> list[tuple[str, object, object, str, str]]:
+    """Return resource declarations attached to fixtures used by an item."""
+    fixture_info = getattr(item, "_fixtureinfo", None)
+    if fixture_info is None:
+        return []
+
+    declarations: list[tuple[str, object, object, str, str]] = []
+    for fixture_name in item.fixturenames:
+        definitions = fixture_info.name2fixturedefs.get(fixture_name)
+        if not definitions:
+            continue
+        definition = definitions[-1]
+        function = getattr(definition, "func", None)
+        for name, lifetime, identity in getattr(function, E2E_RESOURCE_ATTRIBUTE, ()):
+            declarations.append(
+                (str(name), lifetime, identity, fixture_name, str(definition.scope))
+            )
+    return declarations
+
+
 def scheduling_group(item: pytest.Item) -> str:
     """Return a stable group encoding process cost and isolation boundary."""
     nodeid = normalize_nodeid(item.nodeid)
@@ -138,29 +187,52 @@ def scheduling_group(item: pytest.Item) -> str:
                 persistent_processes.add(identity)
     declared_process = False
     declared_transient_process = False
-    for resource_marker in item.iter_markers("e2e_resource"):
-        if not resource_marker.args or str(resource_marker.args[0]) != "antfly_process":
+    declared_process_scopes: set[str] = set()
+    resource_declarations = [
+        (
+            str(marker.args[0]) if marker.args else "",
+            marker.kwargs.get("lifetime"),
+            marker.kwargs.get("identity"),
+            None,
+            None,
+        )
+        for marker in item.iter_markers("e2e_resource")
+    ]
+    resource_declarations.extend(_fixture_resource_declarations(item))
+    for (
+        resource_name,
+        lifetime,
+        identity,
+        fixture_name,
+        fixture_scope,
+    ) in resource_declarations:
+        if resource_name != "antfly_process":
             continue
+        declaration_context = (
+            f" (fixture {fixture_name!r})" if fixture_name is not None else ""
+        )
         declared_process = True
-        lifetime = resource_marker.kwargs.get("lifetime")
+        if fixture_scope is not None:
+            declared_process_scopes.add(fixture_scope)
         if lifetime is None:
             declared_transient_process = True
             continue
         if lifetime != "session":
             raise pytest.UsageError(
-                f"{nodeid}: antfly_process lifetime must be 'session', got {lifetime!r}"
+                f"{nodeid}{declaration_context}: antfly_process lifetime must be "
+                f"'session', got {lifetime!r}"
             )
-        identity = resource_marker.kwargs.get("identity")
         if (
             not isinstance(identity, str)
             or not RESOURCE_IDENTITY_RE.fullmatch(identity)
             or "--" in identity
         ):
             raise pytest.UsageError(
-                f"{nodeid}: a session antfly_process requires an identity containing "
-                "only letters, digits, '.', '_' or '-'"
+                f"{nodeid}{declaration_context}: a session antfly_process requires "
+                "an identity containing only letters, digits, '.', '_' or '-'"
             )
         persistent_processes.add(identity)
+    process_scopes.update(declared_process_scopes)
     process_owned = bool(process_scopes) or declared_process
     reuse_process = item.get_closest_marker("reuse_antfly_process") is not None
     force_fresh = item.get_closest_marker("fresh_antfly_process") is not None
@@ -276,6 +348,8 @@ class DurationHistory:
             payload = json.loads(self.path.read_text(encoding="utf-8"))
         except (OSError, ValueError, TypeError):
             return
+        if not isinstance(payload, dict):
+            return
         if payload.get("version") != DURATION_FILE_VERSION:
             return
         tests = payload.get("tests")
@@ -286,12 +360,18 @@ class DurationHistory:
                 continue
             seconds = entry.get("seconds")
             samples = entry.get("samples")
-            if not isinstance(seconds, (int, float)) or seconds < 0:
+            if isinstance(seconds, bool) or not isinstance(seconds, (int, float)):
                 continue
-            if not isinstance(samples, int) or samples < 1:
+            try:
+                normalized_seconds = float(seconds)
+            except (OverflowError, ValueError):
+                continue
+            if not math.isfinite(normalized_seconds) or normalized_seconds < 0:
+                continue
+            if isinstance(samples, bool) or not isinstance(samples, int) or samples < 1:
                 continue
             self.tests[nodeid] = {
-                "seconds": float(seconds),
+                "seconds": normalized_seconds,
                 "samples": samples,
             }
 

--- a/zig/e2e/antfly/e2e_scheduler.py
+++ b/zig/e2e/antfly/e2e_scheduler.py
@@ -650,6 +650,85 @@ class IsolationAwareScheduling(LoadGroupScheduling):
             for candidate in self.nodes
         )
 
+    def _retirement_score(
+        self,
+        candidate: WorkerController,
+    ) -> tuple[float, float, int]:
+        """Prefer retirements that unlock work without discarding useful reuse."""
+        candidate_workload = self.assigned_work[candidate]
+        released_slots = len(self._persistent_processes.get(candidate, ())) + int(
+            self._workload_uses_transient_process(candidate_workload)
+        )
+        reserved_after_retirement = max(
+            0, self._reserved_process_slots() - released_slots
+        )
+        remaining_nodes = [
+            node
+            for node in self.nodes
+            if node is not candidate and not node.shutting_down
+        ]
+        unlocked_duration = 0.0
+        reuse_value = 0.0
+        owned = self._persistent_processes.get(candidate, set())
+        for scope, work_unit in self.workqueue.items():
+            if not any(not complete for complete in work_unit.values()):
+                continue
+            duration = self._scope_duration(scope, work_unit)
+            if any(
+                reserved_after_retirement + self._additional_process_slots(node, scope)
+                <= self.process_slots
+                for node in remaining_nodes
+            ):
+                unlocked_duration += duration
+            requested = self._scope_persistent_processes(scope)
+            if requested:
+                reuse_value += (
+                    duration * len(requested.intersection(owned)) / len(requested)
+                )
+        return unlocked_duration, -reuse_value, released_slots
+
+    def _retire_best_resource_worker(self) -> bool:
+        """Retire one drainable resource worker while preserving a successor."""
+        live_nodes = [node for node in self.nodes if not node.shutting_down]
+        candidates = [
+            node
+            for node in live_nodes
+            if self._pending_of(self.assigned_work[node]) <= 1
+            and (
+                self._persistent_processes.get(node)
+                or self._workload_uses_process(self.assigned_work[node])
+            )
+            and any(successor is not node for successor in live_nodes)
+        ]
+        if not candidates:
+            return False
+        candidate = max(candidates, key=self._retirement_score)
+        self._retiring_nodes.add(candidate)
+        candidate.shutdown()
+        return True
+
+    def _another_worker_will_make_progress(
+        self,
+        node: WorkerController,
+    ) -> bool:
+        """Return whether a future worker event can reopen scheduling capacity."""
+        if any(
+            candidate.shutting_down for candidate in self.nodes if candidate is not node
+        ):
+            return True
+        return any(
+            candidate is not node and self._pending_of(workload) > 1
+            for candidate, workload in self.assigned_work.items()
+        )
+
+    def _another_worker_can_accept_work(self, node: WorkerController) -> bool:
+        return any(
+            candidate is not node
+            and not candidate.shutting_down
+            and self._next_eligible_scope(candidate) is not None
+            for candidate in self.nodes
+        )
+
     def _next_eligible_scope(self, node: WorkerController) -> str | None:
         reserved_process_slots = self._reserved_process_slots()
         for scope, work_unit in self.workqueue.items():
@@ -720,71 +799,41 @@ class IsolationAwareScheduling(LoadGroupScheduling):
             self._assign_work_unit(node)
             return
         # This worker cannot reserve an Antfly process slot and no lightweight
-        # work remains. A shutdown command lets it finish its queued item while
-        # the process-reserved workers drain the remaining queue.
+        # work remains. Preserve a live successor whenever a shutdown is needed
+        # to drain a one-item worker queue or release a persistent reservation.
         pending = self._pending_of(self.assigned_work[node])
         if pending == 0:
             # An idle worker can safely wait for a slot. If it owns a session
             # process that blocks all remaining work, rotate one such worker at
             # a time so teardown releases the lifetime reservation.
-            owns_persistent_process = bool(self._persistent_processes.get(node))
-            persistent_retirement_in_flight = any(
-                self._persistent_processes.get(candidate)
-                for candidate in self._retiring_nodes
-            )
-            other_live_worker = any(
-                candidate is not node and not candidate.shutting_down
-                for candidate in self.nodes
-            )
-            if owns_persistent_process and not persistent_retirement_in_flight:
-                if not other_live_worker:
+            if self._persistent_processes.get(node):
+                if self._another_worker_can_accept_work(
+                    node
+                ) or self._another_worker_will_make_progress(node):
+                    return
+                if not self._retire_best_resource_worker():
                     raise pytest.UsageError(
                         "all remaining work requires a new session process, but no "
                         "worker is available to replace the current session owner; "
                         "increase --e2e-process-slots or run without xdist"
                     )
-                self._retiring_nodes.add(node)
-                node.shutdown()
             return
         if pending == 1:
-            # A lightweight worker with one queued item can wait for a process
-            # slot: assigning it the newly eligible unit will also unblock its
-            # current item. Do not discard every clean successor while a
-            # session owner is draining. If a persistent reservation is the
-            # blocker, start rotating that owner now.
-            if not self._workload_uses_process(
-                self.assigned_work[node]
-            ) and not self._persistent_processes.get(node):
-                transient_release_pending = any(
-                    candidate is not node
-                    and self._workload_uses_transient_process(workload)
-                    for candidate, workload in self.assigned_work.items()
-                )
-                persistent_owners = [
-                    candidate
-                    for candidate in self.nodes
-                    if candidate is not node
-                    and not candidate.shutting_down
-                    and self._persistent_processes.get(candidate)
-                ]
-                owner_can_continue = any(
-                    self._next_eligible_scope(candidate) is not None
-                    for candidate in persistent_owners
-                )
-                if transient_release_pending or owner_can_continue:
-                    return
-                persistent_retirement_in_flight = any(
-                    self._persistent_processes.get(candidate)
-                    for candidate in self._retiring_nodes
-                )
-                if not persistent_retirement_in_flight:
-                    persistent_owner = next(iter(persistent_owners), None)
-                    if persistent_owner is not None:
-                        self._retiring_nodes.add(persistent_owner)
-                        persistent_owner.shutdown()
+            # A one-item worker can wait when another worker will produce an
+            # event or accept queued work. Otherwise rotate the resource worker
+            # that unlocks the most work, while retaining one live successor to
+            # receive the follow-up assignment that unblocks its current item.
+            if self._another_worker_can_accept_work(
+                node
+            ) or self._another_worker_will_make_progress(node):
                 return
-            self._retiring_nodes.add(node)
-            node.shutdown()
+            if self._retire_best_resource_worker():
+                return
+            raise pytest.UsageError(
+                "all remaining work requires another process slot, but no worker "
+                "is available to release or replace the current process owner; "
+                "increase --e2e-process-slots or run without xdist"
+            )
 
     def mark_test_complete(
         self,

--- a/zig/e2e/antfly/e2e_scheduler.py
+++ b/zig/e2e/antfly/e2e_scheduler.py
@@ -29,6 +29,7 @@ from typing import TypeVar
 
 import pytest
 from xdist.remote import Producer
+from xdist.report import report_collection_diff
 from xdist.scheduler.loadgroup import LoadGroupScheduling
 from xdist.workermanage import WorkerController
 
@@ -582,6 +583,29 @@ class IsolationAwareScheduling(LoadGroupScheduling):
             # will execute.
             getattr(self, "_collecting_nodes", set()).discard(node)
             getattr(self, "_starting_replacements", set()).discard(node)
+            return
+
+        # LoadScopeScheduling rejects a late collection that differs from the
+        # established one without registering the worker. It cannot ever
+        # become schedulable, so do not leave it advertised as future progress
+        # or retry rotations indefinitely.
+        getattr(self, "_collecting_nodes", set()).discard(node)
+        getattr(self, "_starting_replacements", set()).discard(node)
+        node.shutdown()
+        worker_id = str(getattr(getattr(node, "gateway", None), "id", "replacement"))
+        reference_node, reference_collection = next(
+            iter(self.registered_collections.items())
+        )
+        collection_diff = report_collection_diff(
+            reference_collection,
+            collection,
+            str(getattr(reference_node.gateway, "id", "established")),
+            worker_id,
+        )
+        raise pytest.UsageError(
+            f"replacement worker {worker_id} collected different tests from the "
+            f"established E2E collection\n{collection_diff}"
+        )
 
     @staticmethod
     def _scope_uses_process(scope: str) -> bool:

--- a/zig/e2e/antfly/e2e_scheduler.py
+++ b/zig/e2e/antfly/e2e_scheduler.py
@@ -1114,6 +1114,13 @@ def pytest_configure(config: pytest.Config) -> None:
     slots = int(config.getoption("e2e_process_slots"))
     if slots < 1:
         raise pytest.UsageError("--e2e-process-slots must be a positive integer")
+    dist = config.getoption("dist", "no")
+    if dist not in {"no", "loadgroup"} and config.getoption("tx", ()):
+        raise pytest.UsageError(
+            "parallel Antfly E2E requires --dist=loadgroup so fixture isolation "
+            "and --e2e-process-slots remain enforced; remove the explicit "
+            f"--dist={dist} override or use scripts/ci/zig-antfly-e2e-pytest.sh"
+        )
     if not hasattr(config, "workerinput"):
         _duration_history = DurationHistory(Path(config.getoption("e2e_duration_file")))
         _duration_report_totals = {}

--- a/zig/e2e/antfly/e2e_scheduler.py
+++ b/zig/e2e/antfly/e2e_scheduler.py
@@ -1050,10 +1050,33 @@ class IsolationAwareScheduling(LoadGroupScheduling):
             self._reschedule_all()
             return None
 
-        crashitem = super().remove_node(node)
+        workload = self.assigned_work.pop(node)
+        if not self._pending_of(workload):
+            return None
+
+        # Preserve xdist's crash-reporting contract while delaying assignment
+        # until every failed scope is back in the queue. Calling the parent
+        # implementation here would immediately reschedule in worker insertion
+        # order, bypassing the resource- and duration-aware global priority.
+        crashitem = next(
+            (
+                nodeid
+                for work_unit in workload.values()
+                for nodeid, complete in work_unit.items()
+                if not complete
+            ),
+            None,
+        )
+        if crashitem is None:
+            raise RuntimeError(
+                "Unable to identify crashitem on a workload with pending items"
+            )
+
+        self.workqueue.update(workload)
         for scope in list(self.workqueue):
             if all(self.workqueue[scope].values()):
                 del self.workqueue[scope]
+        self._reschedule_all()
         return crashitem
 
 

--- a/zig/e2e/antfly/e2e_scheduler.py
+++ b/zig/e2e/antfly/e2e_scheduler.py
@@ -549,7 +549,13 @@ class IsolationAwareScheduling(LoadGroupScheduling):
             Path(config.getoption("e2e_duration_file"))
         )
         self._retiring_nodes: set[WorkerController] = set()
+        self._starting_replacements: set[WorkerController] = set()
+        self._transient_handoffs: set[WorkerController] = set()
         self._persistent_processes: dict[WorkerController, set[str]] = {}
+
+    def add_node(self, node: WorkerController) -> None:
+        super().add_node(node)
+        getattr(self, "_starting_replacements", set()).discard(node)
 
     @staticmethod
     def _scope_uses_process(scope: str) -> bool:
@@ -598,13 +604,23 @@ class IsolationAwareScheduling(LoadGroupScheduling):
             for scope, work_unit in workload.items()
         )
 
+    def _worker_reserved_process_slots(self, node: WorkerController) -> int:
+        transient_slots = int(
+            self._workload_uses_transient_process(self.assigned_work[node])
+        )
+        # A queued persistent-only scope can reuse the lane occupied by the
+        # worker's final transient test: pytest tears down that test's fixture
+        # before setting up the next item. Keep the future persistent capacity
+        # reserved without double-counting the non-overlapping transition.
+        if node in getattr(self, "_transient_handoffs", set()):
+            transient_slots -= 1
+        return len(self._persistent_processes.get(node, ())) + transient_slots
+
     def _reserved_process_slots(self) -> int:
         # A sequential worker needs at most one transient slot, regardless of
         # its runway. Session process identities remain reserved until exit.
         return sum(
-            len(self._persistent_processes.get(node, ()))
-            + int(self._workload_uses_transient_process(workload))
-            for node, workload in self.assigned_work.items()
+            self._worker_reserved_process_slots(node) for node in self.assigned_work
         )
 
     def _additional_process_slots(self, node: WorkerController, scope: str) -> int:
@@ -629,6 +645,27 @@ class IsolationAwareScheduling(LoadGroupScheduling):
             for nodeid, complete in work_unit.items()
             if not complete
         )
+
+    def _transient_handoff_fits(
+        self,
+        node: WorkerController,
+        scope: str,
+        reserved_process_slots: int,
+    ) -> bool:
+        """Allow a final transient test to hand its lane to persistent work."""
+        if (
+            self._pending_of(self.assigned_work[node]) != 1
+            or not self._workload_uses_transient_process(self.assigned_work[node])
+            or self._scope_uses_transient_process(scope)
+        ):
+            return False
+        requested = self._scope_persistent_processes(scope)
+        if not requested:
+            return False
+        additional_persistent = len(
+            requested - self._persistent_processes.get(node, set())
+        )
+        return reserved_process_slots - 1 + additional_persistent <= self.process_slots
 
     def _defer_new_persistent_process(self, node: WorkerController, scope: str) -> bool:
         requested = self._scope_persistent_processes(scope)
@@ -655,10 +692,7 @@ class IsolationAwareScheduling(LoadGroupScheduling):
         candidate: WorkerController,
     ) -> tuple[float, float, int]:
         """Prefer retirements that unlock work without discarding useful reuse."""
-        candidate_workload = self.assigned_work[candidate]
-        released_slots = len(self._persistent_processes.get(candidate, ())) + int(
-            self._workload_uses_transient_process(candidate_workload)
-        )
+        released_slots = self._worker_reserved_process_slots(candidate)
         reserved_after_retirement = max(
             0, self._reserved_process_slots() - released_slots
         )
@@ -687,9 +721,32 @@ class IsolationAwareScheduling(LoadGroupScheduling):
                 )
         return unlocked_duration, -reuse_value, released_slots
 
+    def _replacement_controller(self) -> object | None:
+        config = getattr(self, "config", None)
+        pluginmanager = getattr(config, "pluginmanager", None)
+        if pluginmanager is None:
+            return None
+        controller = pluginmanager.getplugin("dsession")
+        return (
+            controller if callable(getattr(controller, "_clone_node", None)) else None
+        )
+
+    def _start_replacement(self, node: WorkerController) -> bool:
+        """Keep intentional resource rotation from consuming the worker pool."""
+        controller = self._replacement_controller()
+        if controller is None:
+            return False
+        # xdist exposes worker replacement only through DSession. This is the
+        # same path it uses for crashed workers, without charging the crash
+        # restart budget or reporting an intentional teardown as a failure.
+        replacement = controller._clone_node(node)  # type: ignore[attr-defined]
+        self.__dict__.setdefault("_starting_replacements", set()).add(replacement)
+        return True
+
     def _retire_best_resource_worker(self) -> bool:
         """Retire one drainable resource worker while preserving a successor."""
         live_nodes = [node for node in self.nodes if not node.shutting_down]
+        can_replace = self._replacement_controller() is not None
         candidates = [
             node
             for node in live_nodes
@@ -698,11 +755,16 @@ class IsolationAwareScheduling(LoadGroupScheduling):
                 self._persistent_processes.get(node)
                 or self._workload_uses_process(self.assigned_work[node])
             )
-            and any(successor is not node for successor in live_nodes)
+            and (can_replace or any(successor is not node for successor in live_nodes))
         ]
         if not candidates:
             return False
         candidate = max(candidates, key=self._retirement_score)
+        replacement_started = self._start_replacement(candidate)
+        if not replacement_started and not any(
+            successor is not candidate for successor in live_nodes
+        ):
+            return False
         self._retiring_nodes.add(candidate)
         candidate.shutdown()
         return True
@@ -712,6 +774,8 @@ class IsolationAwareScheduling(LoadGroupScheduling):
         node: WorkerController,
     ) -> bool:
         """Return whether a future worker event can reopen scheduling capacity."""
+        if getattr(self, "_starting_replacements", set()):
+            return True
         if any(
             candidate.shutting_down for candidate in self.nodes if candidate is not node
         ):
@@ -747,8 +811,11 @@ class IsolationAwareScheduling(LoadGroupScheduling):
             for scope, work_unit in self.workqueue.items()
             if any(not complete for complete in work_unit.values())
             and not self._defer_new_persistent_process(node, scope)
-            and reserved_process_slots + self._additional_process_slots(node, scope)
-            <= self.process_slots
+            and (
+                reserved_process_slots + self._additional_process_slots(node, scope)
+                <= self.process_slots
+                or self._transient_handoff_fits(node, scope, reserved_process_slots)
+            )
         ]
         if not eligible:
             return None
@@ -768,6 +835,9 @@ class IsolationAwareScheduling(LoadGroupScheduling):
         scope = self._next_eligible_scope(node)
         if scope is None:
             return
+        transient_handoff = self._transient_handoff_fits(
+            node, scope, self._reserved_process_slots()
+        )
         work_unit = self.workqueue.pop(scope)
         self.assigned_work.setdefault(node, {})[scope] = work_unit
         worker_collection = self.registered_collections[node]
@@ -783,6 +853,8 @@ class IsolationAwareScheduling(LoadGroupScheduling):
             self._persistent_processes.setdefault(node, set()).update(
                 persistent_processes
             )
+        if transient_handoff:
+            self.__dict__.setdefault("_transient_handoffs", set()).add(node)
 
     def _reschedule(self, node: WorkerController) -> None:
         if node.shutting_down:
@@ -844,6 +916,8 @@ class IsolationAwareScheduling(LoadGroupScheduling):
         nodeid = self.registered_collections[node][item_index]
         scope = self._split_scope(nodeid)
         self.assigned_work[node][scope][nodeid] = True
+        if not self._workload_uses_transient_process(self.assigned_work[node]):
+            getattr(self, "_transient_handoffs", set()).discard(node)
         # Reconsider every idle worker whenever a resource slot is released.
         for candidate in self.nodes:
             self._reschedule(candidate)
@@ -853,6 +927,8 @@ class IsolationAwareScheduling(LoadGroupScheduling):
         exitstatus = workeroutput.get("exitstatus") if workeroutput else None
         retired_cleanly = node in self._retiring_nodes and exitstatus in {0, 1}
         self._retiring_nodes.discard(node)
+        getattr(self, "_starting_replacements", set()).discard(node)
+        getattr(self, "_transient_handoffs", set()).discard(node)
         self._persistent_processes.pop(node, None)
 
         if retired_cleanly:
@@ -880,6 +956,8 @@ class IsolationAwareScheduling(LoadGroupScheduling):
 
 
 _duration_history: DurationHistory | None = None
+_duration_report_totals: dict[str, float] = {}
+_executed_duration_nodeids: set[str] = set()
 
 
 def pytest_addoption(parser: pytest.Parser) -> None:
@@ -901,12 +979,14 @@ def pytest_addoption(parser: pytest.Parser) -> None:
 
 
 def pytest_configure(config: pytest.Config) -> None:
-    global _duration_history
+    global _duration_history, _duration_report_totals, _executed_duration_nodeids
     slots = int(config.getoption("e2e_process_slots"))
     if slots < 1:
         raise pytest.UsageError("--e2e-process-slots must be a positive integer")
     if not hasattr(config, "workerinput"):
         _duration_history = DurationHistory(Path(config.getoption("e2e_duration_file")))
+        _duration_report_totals = {}
+        _executed_duration_nodeids = set()
 
 
 @pytest.hookimpl(tryfirst=True)
@@ -926,12 +1006,34 @@ def pytest_xdist_make_scheduler(
 
 
 def pytest_runtest_logreport(report: pytest.TestReport) -> None:
+    if _duration_history is None:
+        return
+    nodeid = normalize_nodeid(report.nodeid)
+    duration = max(0.0, float(report.duration))
+    if math.isfinite(duration):
+        _duration_report_totals[nodeid] = (
+            _duration_report_totals.get(nodeid, 0.0) + duration
+        )
+    if report.when == "call" and (
+        not report.skipped or getattr(report, "wasxfail", None) is not None
+    ):
+        _executed_duration_nodeids.add(nodeid)
+
+
+def _flush_duration_reports() -> None:
     if _duration_history is not None:
-        _duration_history.observe(report.nodeid, report.duration)
+        for nodeid in _executed_duration_nodeids:
+            _duration_history.observe(nodeid, _duration_report_totals.get(nodeid, 0.0))
+    _duration_report_totals.clear()
+    _executed_duration_nodeids.clear()
 
 
 def pytest_sessionfinish(session: pytest.Session) -> None:
     if _duration_history is not None:
+        # Setup and teardown are material E2E costs, but only retain their total
+        # when the test reached a real call phase. Environment-dependent skips
+        # and setup failures must not train expensive full-CI tests toward zero.
+        _flush_duration_reports()
         error = _duration_history.save()
         if error is not None:
             terminal_reporter = session.config.pluginmanager.get_plugin(

--- a/zig/e2e/antfly/e2e_scheduler.py
+++ b/zig/e2e/antfly/e2e_scheduler.py
@@ -1052,6 +1052,10 @@ class IsolationAwareScheduling(LoadGroupScheduling):
 
         workload = self.assigned_work.pop(node)
         if not self._pending_of(workload):
+            # Removing the worker may have released persistent process slots.
+            # Let existing ready workers use that capacity immediately instead
+            # of waiting for a replacement to start and finish collection.
+            self._reschedule_all()
             return None
 
         # Preserve xdist's crash-reporting contract while delaying assignment

--- a/zig/e2e/antfly/e2e_scheduler.py
+++ b/zig/e2e/antfly/e2e_scheduler.py
@@ -22,7 +22,7 @@ import math
 import os
 import re
 import tempfile
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from fcntl import LOCK_EX, flock
 from pathlib import Path
 from typing import TypeVar
@@ -562,12 +562,26 @@ class IsolationAwareScheduling(LoadGroupScheduling):
         )
         self._retiring_nodes: set[WorkerController] = set()
         self._starting_replacements: set[WorkerController] = set()
+        self._collecting_nodes: set[WorkerController] = set()
         self._transient_handoffs: set[WorkerController] = set()
         self._persistent_processes: dict[WorkerController, set[str]] = {}
 
     def add_node(self, node: WorkerController) -> None:
         super().add_node(node)
-        getattr(self, "_starting_replacements", set()).discard(node)
+        self.__dict__.setdefault("_collecting_nodes", set()).add(node)
+
+    def add_node_collection(
+        self,
+        node: WorkerController,
+        collection: Sequence[str],
+    ) -> None:
+        super().add_node_collection(node, collection)
+        if node in self.registered_collections:
+            # workerready only means the process connected. Work cannot be
+            # indexed safely until the replacement submits the collection it
+            # will execute.
+            getattr(self, "_collecting_nodes", set()).discard(node)
+            getattr(self, "_starting_replacements", set()).discard(node)
 
     @staticmethod
     def _scope_uses_process(scope: str) -> bool:
@@ -692,6 +706,7 @@ class IsolationAwareScheduling(LoadGroupScheduling):
         return any(
             candidate is not node
             and not candidate.shutting_down
+            and candidate in self.registered_collections
             and not self._persistent_processes.get(candidate)
             and self._pending_of(self.assigned_work[candidate]) == 0
             and reserved_process_slots
@@ -712,7 +727,9 @@ class IsolationAwareScheduling(LoadGroupScheduling):
         remaining_nodes = [
             node
             for node in self.nodes
-            if node is not candidate and not node.shutting_down
+            if node is not candidate
+            and not node.shutting_down
+            and node in self.registered_collections
         ]
         unlocked_duration = 0.0
         reuse_value = 0.0
@@ -789,6 +806,8 @@ class IsolationAwareScheduling(LoadGroupScheduling):
         """Return whether a future worker event can reopen scheduling capacity."""
         if getattr(self, "_starting_replacements", set()):
             return True
+        if getattr(self, "_collecting_nodes", set()):
+            return True
         if any(
             candidate.shutting_down for candidate in self.nodes if candidate is not node
         ):
@@ -802,9 +821,56 @@ class IsolationAwareScheduling(LoadGroupScheduling):
         return any(
             candidate is not node
             and not candidate.shutting_down
+            and candidate in self.registered_collections
             and self._next_eligible_scope(candidate) is not None
             for candidate in self.nodes
         )
+
+    def _reschedule_priority(
+        self,
+        node: WorkerController,
+    ) -> tuple[bool, float, bool, int]:
+        """Rank safe assignments globally without weakening resource reuse."""
+        if (
+            node.shutting_down
+            or node not in self.registered_collections
+            or self._pending_of(self.assigned_work[node]) > 2
+        ):
+            return False, 0.0, False, 0
+        scope = self._next_eligible_scope(node)
+        if scope is None:
+            return False, 0.0, False, 0
+        requested = self._scope_persistent_processes(scope)
+        owned = self._persistent_processes.get(node, set())
+        reuses_reserved_capacity = (
+            bool(requested)
+            and requested.issubset(owned)
+            and self._additional_process_slots(node, scope) == 0
+        )
+        return (
+            reuses_reserved_capacity,
+            self._scope_duration(scope, self.workqueue[scope]),
+            not bool(owned),
+            -self._pending_of(self.assigned_work[node]),
+        )
+
+    def _reschedule_all(self) -> None:
+        """Reconsider ready workers in resource- and duration-aware order."""
+        candidates = sorted(
+            self.nodes,
+            key=self._reschedule_priority,
+            reverse=True,
+        )
+        for candidate in candidates:
+            self._reschedule(candidate)
+
+    def schedule(self) -> None:
+        if self.collection is None:
+            super().schedule()
+            return
+        # Late collections come from replacement workers. Reopen scheduling
+        # with the same global priority used for resource-release events.
+        self._reschedule_all()
 
     def _next_eligible_scope(self, node: WorkerController) -> str | None:
         reserved_process_slots = self._reserved_process_slots()
@@ -870,7 +936,7 @@ class IsolationAwareScheduling(LoadGroupScheduling):
             self.__dict__.setdefault("_transient_handoffs", set()).add(node)
 
     def _reschedule(self, node: WorkerController) -> None:
-        if node.shutting_down:
+        if node.shutting_down or node not in self.registered_collections:
             return
         if not self.workqueue:
             node.shutdown()
@@ -932,8 +998,7 @@ class IsolationAwareScheduling(LoadGroupScheduling):
         if not self._workload_uses_transient_process(self.assigned_work[node]):
             getattr(self, "_transient_handoffs", set()).discard(node)
         # Reconsider every idle worker whenever a resource slot is released.
-        for candidate in self.nodes:
-            self._reschedule(candidate)
+        self._reschedule_all()
 
     def remove_node(self, node: WorkerController) -> str | None:
         workeroutput = getattr(node, "workeroutput", None)
@@ -941,6 +1006,7 @@ class IsolationAwareScheduling(LoadGroupScheduling):
         retired_cleanly = node in self._retiring_nodes and exitstatus in {0, 1}
         self._retiring_nodes.discard(node)
         getattr(self, "_starting_replacements", set()).discard(node)
+        getattr(self, "_collecting_nodes", set()).discard(node)
         getattr(self, "_transient_handoffs", set()).discard(node)
         self._persistent_processes.pop(node, None)
 
@@ -957,8 +1023,7 @@ class IsolationAwareScheduling(LoadGroupScheduling):
                 }
                 if incomplete:
                     self.workqueue.setdefault(scope, {}).update(incomplete)
-            for candidate in list(self.assigned_work):
-                self._reschedule(candidate)
+            self._reschedule_all()
             return None
 
         crashitem = super().remove_node(node)

--- a/zig/e2e/antfly/e2e_scheduler.py
+++ b/zig/e2e/antfly/e2e_scheduler.py
@@ -131,39 +131,63 @@ def _safe_group_name(prefix: str, identity: str) -> str:
     return f"{prefix}{readable}-{digest}"
 
 
-def _fixture_scope(item: pytest.Item, fixture_name: str) -> str | None:
+def _scope_name(scope: object) -> str:
+    """Normalize pytest's Scope enum and test doubles to their public names."""
+    return str(getattr(scope, "value", scope))
+
+
+def _fixture_definition(item: pytest.Item, fixture_name: str) -> object | None:
     fixture_info = getattr(item, "_fixtureinfo", None)
     definitions = (
         fixture_info.name2fixturedefs.get(fixture_name)
         if fixture_info is not None
         else None
     )
-    if not definitions:
+    return definitions[-1] if definitions else None
+
+
+def _effective_fixture_scope(
+    item: pytest.Item,
+    fixture_name: str,
+    definition: object,
+) -> str:
+    """Return the cache scope pytest will actually use for this item."""
+    callspec = getattr(item, "callspec", None)
+    parameter_scopes = getattr(callspec, "_arg2scope", {})
+    if fixture_name in parameter_scopes:
+        return _scope_name(parameter_scopes[fixture_name])
+    return _scope_name(definition.scope)  # type: ignore[attr-defined]
+
+
+def _fixture_scope(item: pytest.Item, fixture_name: str) -> str | None:
+    definition = _fixture_definition(item, fixture_name)
+    if definition is None:
         return None
-    return str(definitions[-1].scope)
+    return _effective_fixture_scope(item, fixture_name, definition)
 
 
 def _fixture_resource_declarations(
     item: pytest.Item,
-) -> list[tuple[str, object, object, str, str, str]]:
+) -> list[tuple[str, object, object, str, str, str, str]]:
     """Return resource declarations attached to fixtures used by an item."""
     fixture_info = getattr(item, "_fixtureinfo", None)
     if fixture_info is None:
         return []
 
-    declarations: list[tuple[str, object, object, str, str, str]] = []
+    declarations: list[tuple[str, object, object, str, str, str, str]] = []
     for fixture_name in item.fixturenames:
         definitions = fixture_info.name2fixturedefs.get(fixture_name)
         if not definitions:
             continue
         definition = definitions[-1]
         function = getattr(definition, "func", None)
-        base_id = str(getattr(definition, "baseid", ""))
-        if not base_id:
+        fixture_base_id = str(getattr(definition, "baseid", ""))
+        provenance_base_id = fixture_base_id
+        if not provenance_base_id:
             module = str(getattr(function, "__module__", ""))
             qualified_name = str(getattr(function, "__qualname__", fixture_name))
-            base_id = f"{module}.{qualified_name}"
-        provenance = f"{base_id}:{fixture_name}"
+            provenance_base_id = f"{module}.{qualified_name}"
+        provenance = f"{provenance_base_id}:{fixture_name}"
         default_identity = (
             f"{fixture_name}."
             f"{hashlib.sha1(provenance.encode('utf-8')).hexdigest()[:10]}"
@@ -175,8 +199,9 @@ def _fixture_resource_declarations(
                     lifetime,
                     identity,
                     fixture_name,
-                    str(definition.scope),
+                    _effective_fixture_scope(item, fixture_name, definition),
                     default_identity,
+                    fixture_base_id,
                 )
             )
     return declarations
@@ -190,6 +215,12 @@ def scheduling_group(item: pytest.Item) -> str:
         scope
         for fixture_name in ANTFLY_PROCESS_FIXTURES.intersection(item.fixturenames)
         if (scope := _fixture_scope(item, fixture_name)) is not None
+    }
+    package_boundaries = {
+        str(getattr(definition, "baseid", "")) or "."
+        for fixture_name in ANTFLY_PROCESS_FIXTURES.intersection(item.fixturenames)
+        if (definition := _fixture_definition(item, fixture_name)) is not None
+        and _effective_fixture_scope(item, fixture_name, definition) == "package"
     }
     persistent_processes = {
         fixture_name
@@ -214,6 +245,7 @@ def scheduling_group(item: pytest.Item) -> str:
             None,
             None,
             "",
+            "",
         )
         for marker in item.iter_markers("e2e_resource")
     ]
@@ -225,6 +257,7 @@ def scheduling_group(item: pytest.Item) -> str:
         fixture_name,
         fixture_scope,
         default_identity,
+        fixture_base_id,
     ) in resource_declarations:
         if resource_name != "antfly_process":
             continue
@@ -234,6 +267,8 @@ def scheduling_group(item: pytest.Item) -> str:
         declared_process = True
         if fixture_scope is not None:
             declared_process_scopes.add(fixture_scope)
+            if fixture_scope == "package":
+                package_boundaries.add(fixture_base_id or ".")
         if fixture_scope == "session" and lifetime is None:
             lifetime = "session"
         if lifetime == "session" and identity is None and fixture_name is not None:
@@ -272,13 +307,21 @@ def scheduling_group(item: pytest.Item) -> str:
     # process fixtures already provide complete test isolation.
     module_shared = reuse_process and not force_fresh
     module_shared = module_shared or any(
-        scope in {"module", "package", "session"} for scope in process_scopes
+        scope in {"module", "session"} for scope in process_scopes
     )
     module_shared = module_shared or bool(persistent_processes)
     module_shared = module_shared or shared_external
-    boundary = (
-        "module" if module_shared else "class" if "class" in process_scopes else "test"
+    class_id = (
+        nodeid.rsplit("::", 1)[0] if getattr(item, "cls", None) is not None else None
     )
+    if package_boundaries:
+        boundary = "package"
+    elif module_shared:
+        boundary = "module"
+    elif "class" in process_scopes and class_id is not None:
+        boundary = "class"
+    else:
+        boundary = "test"
     explicit_group: str | None = None
     if isolation is not None:
         policy = str(isolation.args[0]) if isolation.args else "module"
@@ -293,8 +336,16 @@ def scheduling_group(item: pytest.Item) -> str:
         identity = explicit_group
     elif boundary == "module":
         identity = module_id
+    elif boundary == "package":
+        # The shallowest applicable package owns every nested package fixture
+        # too, so grouping at it preserves all package-scoped lifecycles.
+        identity = min(
+            package_boundaries,
+            key=lambda package: (package.count("/"), len(package), package),
+        )
     elif boundary == "class":
-        identity = nodeid.rsplit("::", 1)[0]
+        assert class_id is not None
+        identity = class_id
     else:
         identity = nodeid
     kind = f"{boundary}--"
@@ -587,11 +638,15 @@ class IsolationAwareScheduling(LoadGroupScheduling):
         # Keep session processes on separate workers when an idle clean worker
         # is available. This preserves parallel execution without changing the
         # slot bound; consolidation onto one worker remains the fallback.
+        reserved_process_slots = self._reserved_process_slots()
         return any(
             candidate is not node
             and not candidate.shutting_down
             and not self._persistent_processes.get(candidate)
             and self._pending_of(self.assigned_work[candidate]) == 0
+            and reserved_process_slots
+            + self._additional_process_slots(candidate, scope)
+            <= self.process_slots
             for candidate in self.nodes
         )
 
@@ -692,6 +747,42 @@ class IsolationAwareScheduling(LoadGroupScheduling):
                 node.shutdown()
             return
         if pending == 1:
+            # A lightweight worker with one queued item can wait for a process
+            # slot: assigning it the newly eligible unit will also unblock its
+            # current item. Do not discard every clean successor while a
+            # session owner is draining. If a persistent reservation is the
+            # blocker, start rotating that owner now.
+            if not self._workload_uses_process(
+                self.assigned_work[node]
+            ) and not self._persistent_processes.get(node):
+                transient_release_pending = any(
+                    candidate is not node
+                    and self._workload_uses_transient_process(workload)
+                    for candidate, workload in self.assigned_work.items()
+                )
+                persistent_owners = [
+                    candidate
+                    for candidate in self.nodes
+                    if candidate is not node
+                    and not candidate.shutting_down
+                    and self._persistent_processes.get(candidate)
+                ]
+                owner_can_continue = any(
+                    self._next_eligible_scope(candidate) is not None
+                    for candidate in persistent_owners
+                )
+                if transient_release_pending or owner_can_continue:
+                    return
+                persistent_retirement_in_flight = any(
+                    self._persistent_processes.get(candidate)
+                    for candidate in self._retiring_nodes
+                )
+                if not persistent_retirement_in_flight:
+                    persistent_owner = next(iter(persistent_owners), None)
+                    if persistent_owner is not None:
+                        self._retiring_nodes.add(persistent_owner)
+                        persistent_owner.shutdown()
+                return
             self._retiring_nodes.add(node)
             node.shutdown()
 

--- a/zig/e2e/antfly/e2e_scheduler.py
+++ b/zig/e2e/antfly/e2e_scheduler.py
@@ -1,0 +1,407 @@
+# Copyright 2026 Antfly, Inc.
+#
+# Licensed under the Elastic License 2.0 (ELv2); you may not use this file
+# except in compliance with the Elastic License 2.0. You may obtain a copy of
+# the Elastic License 2.0 at
+#
+#     https://www.antfly.io/licensing/ELv2-license
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the Elastic License 2.0 is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# Elastic License 2.0 for the specific language governing permissions and
+# limitations.
+
+"""Isolation-aware, duration-weighted scheduling for Antfly E2E tests."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import tempfile
+from pathlib import Path
+
+import pytest
+from xdist.remote import Producer
+from xdist.scheduler.loadgroup import LoadGroupScheduling
+from xdist.workermanage import WorkerController
+
+DURATION_FILE_VERSION = 1
+PROCESS_GROUP_PREFIX = "antfly-process--"
+DEFAULT_PROCESS_SECONDS = 5.0
+DEFAULT_LIGHT_SECONDS = 0.05
+
+# These fixtures own an Antfly process or cluster. Fixture scope determines
+# whether tests can be scheduled independently or must remain on one worker.
+ANTFLY_PROCESS_FIXTURES = frozenset(
+    {
+        "auth_api",
+        "backup_api",
+        "cdc_stateful_api",
+        "cli_server",
+        "compact_scaling_cluster",
+        "_reusable_backup_runtime",
+        "_reusable_stateful_runtime",
+        "embedded_standalone_api",
+        "embedded_standalone_cli",
+        "embedded_standalone_runtime",
+        "extension_server",
+        "ha_cluster",
+        "multi_metadata_backup_cluster",
+        "multi_node_scaling_cluster",
+        "real_clipclap_backup_api",
+        "resolution_cluster",
+        "serverless_api",
+        "serverless_runtime",
+        "split_scaling_cluster",
+        "split_status_cluster",
+        "standalone_lifecycle_server",
+        "stateful_api",
+        "stateful_auth_api",
+        "table_api",
+    }
+)
+
+
+def normalize_nodeid(nodeid: str) -> str:
+    """Remove the suffix pytest-xdist adds for loadgroup scheduling."""
+    if nodeid.rfind("@") > nodeid.rfind("]"):
+        return nodeid.rsplit("@", 1)[0]
+    return nodeid
+
+
+def _safe_group_name(prefix: str, identity: str) -> str:
+    readable = re.sub(r"[^A-Za-z0-9_.-]+", "-", identity).strip("-")[-80:]
+    digest = hashlib.sha1(identity.encode("utf-8")).hexdigest()[:10]
+    return f"{prefix}{readable}-{digest}"
+
+
+def _fixture_scope(item: pytest.Item, fixture_name: str) -> str | None:
+    fixture_info = getattr(item, "_fixtureinfo", None)
+    definitions = (
+        fixture_info.name2fixturedefs.get(fixture_name)
+        if fixture_info is not None
+        else None
+    )
+    if not definitions:
+        return None
+    return str(definitions[-1].scope)
+
+
+def scheduling_group(item: pytest.Item) -> str:
+    """Return a stable group encoding process cost and isolation boundary."""
+    nodeid = normalize_nodeid(item.nodeid)
+    module_id = nodeid.split("::", 1)[0]
+    process_scopes = {
+        scope
+        for fixture_name in ANTFLY_PROCESS_FIXTURES.intersection(item.fixturenames)
+        if (scope := _fixture_scope(item, fixture_name)) is not None
+    }
+    declared_resources = {
+        str(mark.args[0]) for mark in item.iter_markers("e2e_resource") if mark.args
+    }
+    process_owned = bool(process_scopes) or "antfly_process" in declared_resources
+    reuse_process = item.get_closest_marker("reuse_antfly_process") is not None
+    force_fresh = item.get_closest_marker("fresh_antfly_process") is not None
+    shared_external = item.get_closest_marker("postgres_integration") is not None
+    isolation = item.get_closest_marker("e2e_isolation")
+
+    # A reusable runtime or any module/session fixture must stay on one worker.
+    # Function-scoped process fixtures already provide complete test isolation.
+    shared = reuse_process and not force_fresh
+    shared = shared or any(
+        scope in {"module", "package", "session"} for scope in process_scopes
+    )
+    shared = shared or shared_external
+    explicit_group: str | None = None
+    if isolation is not None:
+        policy = str(isolation.args[0]) if isolation.args else "module"
+        if policy not in {"test", "module"}:
+            raise pytest.UsageError(
+                f"{nodeid}: e2e_isolation must be 'test' or 'module', got {policy!r}"
+            )
+        shared = policy == "module"
+        if group := isolation.kwargs.get("group"):
+            explicit_group = str(group)
+    identity = explicit_group or (module_id if shared else nodeid)
+    kind = "module--" if shared else "test--"
+    resource = PROCESS_GROUP_PREFIX if process_owned else "light--"
+    return _safe_group_name(f"{resource}{kind}", identity)
+
+
+class DurationHistory:
+    """Persistent exponentially weighted test duration observations."""
+
+    def __init__(self, path: Path):
+        self.path = path
+        self.tests: dict[str, dict[str, float | int]] = {}
+        self.observed: dict[str, float] = {}
+        self._load()
+
+    def _load(self) -> None:
+        try:
+            payload = json.loads(self.path.read_text(encoding="utf-8"))
+        except (OSError, ValueError, TypeError):
+            return
+        if payload.get("version") != DURATION_FILE_VERSION:
+            return
+        tests = payload.get("tests")
+        if not isinstance(tests, dict):
+            return
+        for nodeid, entry in tests.items():
+            if not isinstance(nodeid, str) or not isinstance(entry, dict):
+                continue
+            seconds = entry.get("seconds")
+            samples = entry.get("samples")
+            if not isinstance(seconds, (int, float)) or seconds < 0:
+                continue
+            if not isinstance(samples, int) or samples < 1:
+                continue
+            self.tests[nodeid] = {
+                "seconds": float(seconds),
+                "samples": samples,
+            }
+
+    def estimate(self, nodeid: str, *, process_owned: bool) -> float:
+        entry = self.tests.get(normalize_nodeid(nodeid))
+        if entry is not None:
+            return float(entry["seconds"])
+        return DEFAULT_PROCESS_SECONDS if process_owned else DEFAULT_LIGHT_SECONDS
+
+    def observe(self, nodeid: str, duration: float) -> None:
+        normalized = normalize_nodeid(nodeid)
+        self.observed[normalized] = self.observed.get(normalized, 0.0) + max(
+            0.0, duration
+        )
+
+    def save(self) -> None:
+        if not self.observed:
+            return
+        for nodeid, observed_seconds in self.observed.items():
+            previous = self.tests.get(nodeid)
+            if previous is None:
+                seconds = observed_seconds
+                samples = 1
+            else:
+                # Favor established CI history while still adapting to real shifts.
+                seconds = 0.7 * float(previous["seconds"]) + 0.3 * observed_seconds
+                samples = int(previous["samples"]) + 1
+            self.tests[nodeid] = {
+                "seconds": round(seconds, 6),
+                "samples": samples,
+            }
+
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "version": DURATION_FILE_VERSION,
+            "tests": dict(sorted(self.tests.items())),
+        }
+        fd, temporary_path = tempfile.mkstemp(
+            prefix=f".{self.path.name}.",
+            dir=self.path.parent,
+            text=True,
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                json.dump(payload, handle, indent=2, sort_keys=True)
+                handle.write("\n")
+            os.replace(temporary_path, self.path)
+        finally:
+            try:
+                os.unlink(temporary_path)
+            except FileNotFoundError:
+                pass
+
+
+class IsolationAwareScheduling(LoadGroupScheduling):
+    """Longest-first loadgroup scheduling with a separate process budget."""
+
+    def __init__(self, config: pytest.Config, log: Producer | None = None):
+        super().__init__(config, log)
+        self.process_slots = int(config.getoption("e2e_process_slots"))
+        self.duration_history = DurationHistory(
+            Path(config.getoption("e2e_duration_file"))
+        )
+        self._retiring_nodes: set[WorkerController] = set()
+
+    @staticmethod
+    def _scope_uses_process(scope: str) -> bool:
+        return scope.startswith(PROCESS_GROUP_PREFIX)
+
+    @classmethod
+    def _workload_uses_process(cls, workload: dict[str, dict[str, bool]]) -> bool:
+        return any(
+            cls._scope_uses_process(scope)
+            and any(not complete for complete in work_unit.values())
+            for scope, work_unit in workload.items()
+        )
+
+    def _reserved_process_workers(self) -> int:
+        # xdist requires each worker to have a second queued item before it can
+        # start the first. Reserve capacity per sequential worker queue rather
+        # than per queued work unit: a worker can never run two units at once.
+        return sum(
+            1
+            for workload in self.assigned_work.values()
+            if self._workload_uses_process(workload)
+        )
+
+    def _scope_duration(self, scope: str, work_unit: dict[str, bool]) -> float:
+        process_owned = self._scope_uses_process(scope)
+        return sum(
+            self.duration_history.estimate(nodeid, process_owned=process_owned)
+            for nodeid, complete in work_unit.items()
+            if not complete
+        )
+
+    def _next_eligible_scope(self, node: WorkerController) -> str | None:
+        node_has_process_reservation = self._workload_uses_process(
+            self.assigned_work.get(node, {})
+        )
+        process_capacity = (
+            node_has_process_reservation
+            or self._reserved_process_workers() < self.process_slots
+        )
+        eligible = [
+            (scope, work_unit)
+            for scope, work_unit in self.workqueue.items()
+            if any(not complete for complete in work_unit.values())
+            and (process_capacity or not self._scope_uses_process(scope))
+        ]
+        if not eligible:
+            return None
+        return max(
+            eligible,
+            key=lambda entry: self._scope_duration(entry[0], entry[1]),
+        )[0]
+
+    def _assign_work_unit(self, node: WorkerController) -> None:
+        scope = self._next_eligible_scope(node)
+        if scope is None:
+            return
+        work_unit = self.workqueue.pop(scope)
+        self.assigned_work.setdefault(node, {})[scope] = work_unit
+        worker_collection = self.registered_collections[node]
+        node.send_runtest_some(
+            [
+                worker_collection.index(nodeid)
+                for nodeid, complete in work_unit.items()
+                if not complete
+            ]
+        )
+
+    def _reschedule(self, node: WorkerController) -> None:
+        if node.shutting_down:
+            return
+        if not self.workqueue:
+            node.shutdown()
+            return
+        # Keep xdist's two-item runway. Workers fetch their next item before
+        # running the current one, so a single queued item without a following
+        # item or shutdown command deadlocks the worker protocol.
+        if self._pending_of(self.assigned_work[node]) > 2:
+            return
+        if self._next_eligible_scope(node) is not None:
+            self._assign_work_unit(node)
+            return
+        # This worker cannot reserve an Antfly process slot and no lightweight
+        # work remains. A shutdown command lets it finish its queued item while
+        # the process-reserved workers drain the remaining queue.
+        if self._pending_of(self.assigned_work[node]) <= 1:
+            self._retiring_nodes.add(node)
+            node.shutdown()
+
+    def mark_test_complete(
+        self,
+        node: WorkerController,
+        item_index: int,
+        duration: float = 0,
+    ) -> None:
+        nodeid = self.registered_collections[node][item_index]
+        scope = self._split_scope(nodeid)
+        self.assigned_work[node][scope][nodeid] = True
+        # Reconsider every idle worker whenever a resource slot is released.
+        for candidate in self.nodes:
+            self._reschedule(candidate)
+
+    def remove_node(self, node: WorkerController) -> str | None:
+        if node in self._retiring_nodes:
+            self._retiring_nodes.remove(node)
+            workload = self.assigned_work.pop(node)
+            # Depending on event timing, xdist may stop before its last queued
+            # item. Put only genuinely incomplete items back into circulation;
+            # this was an intentional retirement, not a test-process crash.
+            for scope, work_unit in workload.items():
+                incomplete = {
+                    nodeid: False
+                    for nodeid, complete in work_unit.items()
+                    if not complete
+                }
+                if incomplete:
+                    self.workqueue.setdefault(scope, {}).update(incomplete)
+            for candidate in list(self.assigned_work):
+                self._reschedule(candidate)
+            return None
+
+        crashitem = super().remove_node(node)
+        for scope in list(self.workqueue):
+            if all(self.workqueue[scope].values()):
+                del self.workqueue[scope]
+        return crashitem
+
+
+_duration_history: DurationHistory | None = None
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    group = parser.getgroup("antfly-e2e-scheduler")
+    group.addoption(
+        "--e2e-process-slots",
+        type=int,
+        default=int(os.environ.get("ANTFLY_E2E_PROCESS_SLOTS", "2")),
+        help="Maximum concurrently scheduled Antfly process or cluster work units.",
+    )
+    group.addoption(
+        "--e2e-duration-file",
+        default=os.environ.get(
+            "ANTFLY_E2E_DURATION_FILE",
+            str(Path(__file__).parent / ".pytest_cache" / "durations-v1.json"),
+        ),
+        help="Persistent JSON file used for duration-weighted scheduling.",
+    )
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    global _duration_history
+    slots = int(config.getoption("e2e_process_slots"))
+    if slots < 1:
+        raise pytest.UsageError("--e2e-process-slots must be a positive integer")
+    if not hasattr(config, "workerinput"):
+        _duration_history = DurationHistory(Path(config.getoption("e2e_duration_file")))
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+    for item in items:
+        item.add_marker(pytest.mark.xdist_group(scheduling_group(item)))
+
+
+def pytest_xdist_make_scheduler(
+    config: pytest.Config,
+    log: Producer,
+) -> IsolationAwareScheduling | None:
+    if config.getvalue("dist") != "loadgroup":
+        return None
+    return IsolationAwareScheduling(config, log)
+
+
+def pytest_runtest_logreport(report: pytest.TestReport) -> None:
+    if _duration_history is not None:
+        _duration_history.observe(report.nodeid, report.duration)
+
+
+def pytest_sessionfinish() -> None:
+    if _duration_history is not None:
+        _duration_history.save()

--- a/zig/e2e/antfly/e2e_scheduler.py
+++ b/zig/e2e/antfly/e2e_scheduler.py
@@ -23,6 +23,7 @@ import os
 import re
 import tempfile
 from collections.abc import Callable
+from fcntl import LOCK_EX, flock
 from pathlib import Path
 from typing import TypeVar
 
@@ -214,7 +215,16 @@ def scheduling_group(item: pytest.Item) -> str:
         declared_process = True
         if fixture_scope is not None:
             declared_process_scopes.add(fixture_scope)
+        if fixture_scope == "session" and lifetime is None:
+            lifetime = "session"
+        if lifetime == "session" and identity is None and fixture_name is not None:
+            identity = fixture_name
         if lifetime is None:
+            if identity is not None:
+                raise pytest.UsageError(
+                    f"{nodeid}{declaration_context}: antfly_process identity requires "
+                    "lifetime='session'"
+                )
             declared_transient_process = True
             continue
         if lifetime != "session":
@@ -387,11 +397,34 @@ class DurationHistory:
             0.0, duration
         )
 
-    def save(self) -> None:
+    def save(self) -> OSError | None:
         if not self.observed:
-            return
+            return None
+
+        try:
+            self._save_locked()
+        except OSError as exc:
+            return exc
+        return None
+
+    def _save_locked(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        lock_path = self.path.with_name(f".{self.path.name}.lock")
+        with lock_path.open("a", encoding="utf-8") as lock_handle:
+            # Multiple PR, base, and full jobs share one ARC history file. Reload
+            # only after acquiring the advisory lock so no observation is lost
+            # to a stale last-writer-wins replacement.
+            flock(lock_handle.fileno(), LOCK_EX)
+            latest = DurationHistory(self.path)
+            merged_tests = dict(self.tests)
+            merged_tests.update(latest.tests)
+            self._merge_observations(merged_tests)
+            self._write(merged_tests)
+            self.tests = merged_tests
+
+    def _merge_observations(self, tests: dict[str, dict[str, float | int]]) -> None:
         for nodeid, observed_seconds in self.observed.items():
-            previous = self.tests.get(nodeid)
+            previous = tests.get(nodeid)
             if previous is None:
                 seconds = observed_seconds
                 samples = 1
@@ -399,15 +432,15 @@ class DurationHistory:
                 # Favor established CI history while still adapting to real shifts.
                 seconds = 0.7 * float(previous["seconds"]) + 0.3 * observed_seconds
                 samples = int(previous["samples"]) + 1
-            self.tests[nodeid] = {
+            tests[nodeid] = {
                 "seconds": round(seconds, 6),
                 "samples": samples,
             }
 
-        self.path.parent.mkdir(parents=True, exist_ok=True)
+    def _write(self, tests: dict[str, dict[str, float | int]]) -> None:
         payload = {
             "version": DURATION_FILE_VERSION,
-            "tests": dict(sorted(self.tests.items())),
+            "tests": dict(sorted(tests.items())),
         }
         fd, temporary_path = tempfile.mkstemp(
             prefix=f".{self.path.name}.",
@@ -422,7 +455,7 @@ class DurationHistory:
         finally:
             try:
                 os.unlink(temporary_path)
-            except FileNotFoundError:
+            except OSError:
                 pass
 
 
@@ -728,6 +761,15 @@ def pytest_runtest_logreport(report: pytest.TestReport) -> None:
         _duration_history.observe(report.nodeid, report.duration)
 
 
-def pytest_sessionfinish() -> None:
+def pytest_sessionfinish(session: pytest.Session) -> None:
     if _duration_history is not None:
-        _duration_history.save()
+        error = _duration_history.save()
+        if error is not None:
+            terminal_reporter = session.config.pluginmanager.get_plugin(
+                "terminalreporter"
+            )
+            if terminal_reporter is not None:
+                terminal_reporter.write_line(
+                    f"warning: could not update E2E duration history at "
+                    f"{_duration_history.path}: {error}"
+                )

--- a/zig/e2e/antfly/e2e_scheduler.py
+++ b/zig/e2e/antfly/e2e_scheduler.py
@@ -31,6 +31,7 @@ from xdist.workermanage import WorkerController
 DURATION_FILE_VERSION = 1
 PROCESS_GROUP_PREFIX = "antfly-process--"
 PERSISTENT_PROCESS_GROUP_PREFIX = f"{PROCESS_GROUP_PREFIX}persistent--"
+MIXED_PROCESS_GROUP_PREFIX = f"{PROCESS_GROUP_PREFIX}mixed--"
 DEFAULT_PROCESS_SECONDS = 5.0
 DEFAULT_LIGHT_SECONDS = 0.05
 
@@ -73,6 +74,20 @@ PERSISTENT_ANTFLY_PROCESS_FIXTURES = frozenset(
         "serverless_runtime",
     }
 )
+TRANSIENT_ANTFLY_PROCESS_FIXTURES = ANTFLY_PROCESS_FIXTURES - {
+    "embedded_standalone_api",
+    "embedded_standalone_cli",
+    "embedded_standalone_runtime",
+    "serverless_api",
+    "serverless_runtime",
+    "table_api",
+}
+# Dynamic fixture dependencies are not present in item.fixturenames. Map the
+# collected parameter values that select a session-lived process explicitly.
+PERSISTENT_PROCESS_PARAMETERS = {
+    ("table_api", "serverless"): "serverless_runtime",
+}
+RESOURCE_IDENTITY_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
 
 
 def normalize_nodeid(nodeid: str) -> str:
@@ -109,17 +124,44 @@ def scheduling_group(item: pytest.Item) -> str:
         for fixture_name in ANTFLY_PROCESS_FIXTURES.intersection(item.fixturenames)
         if (scope := _fixture_scope(item, fixture_name)) is not None
     }
-    persistent_processes = sorted(
+    persistent_processes = {
         fixture_name
         for fixture_name in PERSISTENT_ANTFLY_PROCESS_FIXTURES.intersection(
             item.fixturenames
         )
         if _fixture_scope(item, fixture_name) == "session"
-    )
-    declared_resources = {
-        str(mark.args[0]) for mark in item.iter_markers("e2e_resource") if mark.args
     }
-    process_owned = bool(process_scopes) or "antfly_process" in declared_resources
+    callspec = getattr(item, "callspec", None)
+    if callspec is not None:
+        for (parameter, value), identity in PERSISTENT_PROCESS_PARAMETERS.items():
+            if callspec.params.get(parameter) == value:
+                persistent_processes.add(identity)
+    declared_process = False
+    declared_transient_process = False
+    for resource_marker in item.iter_markers("e2e_resource"):
+        if not resource_marker.args or str(resource_marker.args[0]) != "antfly_process":
+            continue
+        declared_process = True
+        lifetime = resource_marker.kwargs.get("lifetime")
+        if lifetime is None:
+            declared_transient_process = True
+            continue
+        if lifetime != "session":
+            raise pytest.UsageError(
+                f"{nodeid}: antfly_process lifetime must be 'session', got {lifetime!r}"
+            )
+        identity = resource_marker.kwargs.get("identity")
+        if (
+            not isinstance(identity, str)
+            or not RESOURCE_IDENTITY_RE.fullmatch(identity)
+            or "--" in identity
+        ):
+            raise pytest.UsageError(
+                f"{nodeid}: a session antfly_process requires an identity containing "
+                "only letters, digits, '.', '_' or '-'"
+            )
+        persistent_processes.add(identity)
+    process_owned = bool(process_scopes) or declared_process
     reuse_process = item.get_closest_marker("reuse_antfly_process") is not None
     force_fresh = item.get_closest_marker("fresh_antfly_process") is not None
     shared_external = item.get_closest_marker("postgres_integration") is not None
@@ -131,6 +173,7 @@ def scheduling_group(item: pytest.Item) -> str:
     shared = shared or any(
         scope in {"module", "package", "session"} for scope in process_scopes
     )
+    shared = shared or bool(persistent_processes)
     shared = shared or shared_external
     explicit_group: str | None = None
     if isolation is not None:
@@ -145,10 +188,78 @@ def scheduling_group(item: pytest.Item) -> str:
     identity = explicit_group or (module_id if shared else nodeid)
     kind = "module--" if shared else "test--"
     if persistent_processes:
-        resource = PERSISTENT_PROCESS_GROUP_PREFIX
+        identities = "+".join(sorted(persistent_processes))
+        transient_process = declared_transient_process or bool(
+            TRANSIENT_ANTFLY_PROCESS_FIXTURES.intersection(item.fixturenames)
+        )
+        prefix = (
+            MIXED_PROCESS_GROUP_PREFIX
+            if transient_process
+            else PERSISTENT_PROCESS_GROUP_PREFIX
+        )
+        resource = f"{prefix}{identities}--"
     else:
         resource = PROCESS_GROUP_PREFIX if process_owned else "light--"
     return _safe_group_name(f"{resource}{kind}", identity)
+
+
+def _scheduling_group_parts(group: str) -> tuple[frozenset[str], bool, str]:
+    persistent_prefix = next(
+        (
+            prefix
+            for prefix in (
+                PERSISTENT_PROCESS_GROUP_PREFIX,
+                MIXED_PROCESS_GROUP_PREFIX,
+            )
+            if group.startswith(prefix)
+        ),
+        None,
+    )
+    if persistent_prefix is not None:
+        encoded, separator, suffix = group.removeprefix(persistent_prefix).partition(
+            "--"
+        )
+        if not separator or not encoded:
+            raise ValueError(f"invalid persistent scheduling group: {group!r}")
+        return (
+            frozenset(encoded.split("+")),
+            persistent_prefix == MIXED_PROCESS_GROUP_PREFIX,
+            suffix,
+        )
+    if group.startswith(PROCESS_GROUP_PREFIX):
+        return frozenset(), True, group.removeprefix(PROCESS_GROUP_PREFIX)
+    return frozenset(), False, group.removeprefix("light--")
+
+
+def _consolidate_scheduling_groups(groups: list[str]) -> list[str]:
+    """Keep every isolation group together under its strictest resource policy."""
+    policies: dict[str, tuple[set[str], bool]] = {}
+    for group in groups:
+        persistent, transient_process, isolation_suffix = _scheduling_group_parts(group)
+        identities, any_transient_process = policies.setdefault(
+            isolation_suffix, (set(), False)
+        )
+        identities.update(persistent)
+        policies[isolation_suffix] = (
+            identities,
+            any_transient_process or transient_process,
+        )
+
+    consolidated = []
+    for group in groups:
+        _, _, isolation_suffix = _scheduling_group_parts(group)
+        identities, transient_process = policies[isolation_suffix]
+        if identities:
+            prefix = (
+                MIXED_PROCESS_GROUP_PREFIX
+                if transient_process
+                else PERSISTENT_PROCESS_GROUP_PREFIX
+            )
+            resource = f"{prefix}{'+'.join(sorted(identities))}--"
+        else:
+            resource = PROCESS_GROUP_PREFIX if transient_process else "light--"
+        consolidated.append(f"{resource}{isolation_suffix}")
+    return consolidated
 
 
 class DurationHistory:
@@ -245,15 +356,36 @@ class IsolationAwareScheduling(LoadGroupScheduling):
             Path(config.getoption("e2e_duration_file"))
         )
         self._retiring_nodes: set[WorkerController] = set()
-        self._persistent_process_workers: set[WorkerController] = set()
+        self._persistent_processes: dict[WorkerController, set[str]] = {}
 
     @staticmethod
     def _scope_uses_process(scope: str) -> bool:
         return scope.startswith(PROCESS_GROUP_PREFIX)
 
     @staticmethod
-    def _scope_uses_persistent_process(scope: str) -> bool:
-        return scope.startswith(PERSISTENT_PROCESS_GROUP_PREFIX)
+    def _scope_persistent_processes(scope: str) -> frozenset[str]:
+        prefix = next(
+            (
+                candidate
+                for candidate in (
+                    PERSISTENT_PROCESS_GROUP_PREFIX,
+                    MIXED_PROCESS_GROUP_PREFIX,
+                )
+                if scope.startswith(candidate)
+            ),
+            None,
+        )
+        if prefix is None:
+            return frozenset()
+        encoded = scope.removeprefix(prefix).split("--", 1)[0]
+        return frozenset(encoded.split("+")) if encoded else frozenset()
+
+    @staticmethod
+    def _scope_uses_transient_process(scope: str) -> bool:
+        return scope.startswith(MIXED_PROCESS_GROUP_PREFIX) or (
+            scope.startswith(PROCESS_GROUP_PREFIX)
+            and not scope.startswith(PERSISTENT_PROCESS_GROUP_PREFIX)
+        )
 
     @classmethod
     def _workload_uses_process(cls, workload: dict[str, dict[str, bool]]) -> bool:
@@ -263,17 +395,39 @@ class IsolationAwareScheduling(LoadGroupScheduling):
             for scope, work_unit in workload.items()
         )
 
-    def _reserved_process_workers(self) -> int:
-        # xdist requires each worker to have a second queued item before it can
-        # start the first. Reserve capacity per sequential worker queue rather
-        # than per queued work unit. A session fixture keeps its worker's
-        # reservation after its own work unit completes.
-        return sum(
-            1
-            for node, workload in self.assigned_work.items()
-            if node in self._persistent_process_workers
-            or self._workload_uses_process(workload)
+    @classmethod
+    def _workload_uses_transient_process(
+        cls, workload: dict[str, dict[str, bool]]
+    ) -> bool:
+        return any(
+            cls._scope_uses_transient_process(scope)
+            and any(not complete for complete in work_unit.values())
+            for scope, work_unit in workload.items()
         )
+
+    def _reserved_process_slots(self) -> int:
+        # A sequential worker needs at most one transient slot, regardless of
+        # its runway. Session process identities remain reserved until exit.
+        return sum(
+            len(self._persistent_processes.get(node, ()))
+            + int(self._workload_uses_transient_process(workload))
+            for node, workload in self.assigned_work.items()
+        )
+
+    def _additional_process_slots(self, node: WorkerController, scope: str) -> int:
+        persistent_processes = self._scope_persistent_processes(scope)
+        additional = len(
+            persistent_processes - self._persistent_processes.get(node, set())
+        )
+        if not self._scope_uses_process(scope):
+            return additional
+        if self._scope_uses_transient_process(scope):
+            additional += int(
+                not self._workload_uses_transient_process(
+                    self.assigned_work.get(node, {})
+                )
+            )
+        return additional
 
     def _scope_duration(self, scope: str, work_unit: dict[str, bool]) -> float:
         process_owned = self._scope_uses_process(scope)
@@ -283,26 +437,55 @@ class IsolationAwareScheduling(LoadGroupScheduling):
             if not complete
         )
 
+    def _defer_new_persistent_process(self, node: WorkerController, scope: str) -> bool:
+        requested = self._scope_persistent_processes(scope)
+        owned = self._persistent_processes.get(node, set())
+        if not requested or not owned or requested.issubset(owned):
+            return False
+        # Keep session processes on separate workers when an idle clean worker
+        # is available. This preserves parallel execution without changing the
+        # slot bound; consolidation onto one worker remains the fallback.
+        return any(
+            candidate is not node
+            and not candidate.shutting_down
+            and not self._persistent_processes.get(candidate)
+            and self._pending_of(self.assigned_work[candidate]) == 0
+            for candidate in self.nodes
+        )
+
     def _next_eligible_scope(self, node: WorkerController) -> str | None:
-        node_has_process_reservation = (
-            node in self._persistent_process_workers
-            or self._workload_uses_process(self.assigned_work.get(node, {}))
-        )
-        process_capacity = (
-            node_has_process_reservation
-            or self._reserved_process_workers() < self.process_slots
-        )
+        reserved_process_slots = self._reserved_process_slots()
+        for scope, work_unit in self.workqueue.items():
+            if not any(not complete for complete in work_unit.values()):
+                continue
+            minimum_slots = len(self._scope_persistent_processes(scope)) + int(
+                self._scope_uses_transient_process(scope)
+            )
+            if minimum_slots > self.process_slots:
+                raise pytest.UsageError(
+                    f"{scope!r} requires {minimum_slots} Antfly process slots, "
+                    f"but --e2e-process-slots is {self.process_slots}"
+                )
         eligible = [
             (scope, work_unit)
             for scope, work_unit in self.workqueue.items()
             if any(not complete for complete in work_unit.values())
-            and (process_capacity or not self._scope_uses_process(scope))
+            and not self._defer_new_persistent_process(node, scope)
+            and reserved_process_slots + self._additional_process_slots(node, scope)
+            <= self.process_slots
         ]
         if not eligible:
             return None
+        owned_processes = self._persistent_processes.get(node, set())
         return max(
             eligible,
-            key=lambda entry: self._scope_duration(entry[0], entry[1]),
+            key=lambda entry: (
+                bool(self._scope_persistent_processes(entry[0]))
+                and self._scope_persistent_processes(entry[0]).issubset(
+                    owned_processes
+                ),
+                self._scope_duration(entry[0], entry[1]),
+            ),
         )[0]
 
     def _assign_work_unit(self, node: WorkerController) -> None:
@@ -319,8 +502,11 @@ class IsolationAwareScheduling(LoadGroupScheduling):
                 if not complete
             ]
         )
-        if self._scope_uses_persistent_process(scope):
-            self._persistent_process_workers.add(node)
+        persistent_processes = self._scope_persistent_processes(scope)
+        if persistent_processes:
+            self._persistent_processes.setdefault(node, set()).update(
+                persistent_processes
+            )
 
     def _reschedule(self, node: WorkerController) -> None:
         if node.shutting_down:
@@ -339,7 +525,31 @@ class IsolationAwareScheduling(LoadGroupScheduling):
         # This worker cannot reserve an Antfly process slot and no lightweight
         # work remains. A shutdown command lets it finish its queued item while
         # the process-reserved workers drain the remaining queue.
-        if self._pending_of(self.assigned_work[node]) <= 1:
+        pending = self._pending_of(self.assigned_work[node])
+        if pending == 0:
+            # An idle worker can safely wait for a slot. If it owns a session
+            # process that blocks all remaining work, rotate one such worker at
+            # a time so teardown releases the lifetime reservation.
+            owns_persistent_process = bool(self._persistent_processes.get(node))
+            persistent_retirement_in_flight = any(
+                self._persistent_processes.get(candidate)
+                for candidate in self._retiring_nodes
+            )
+            other_live_worker = any(
+                candidate is not node and not candidate.shutting_down
+                for candidate in self.nodes
+            )
+            if owns_persistent_process and not persistent_retirement_in_flight:
+                if not other_live_worker:
+                    raise pytest.UsageError(
+                        "all remaining work requires a new session process, but no "
+                        "worker is available to replace the current session owner; "
+                        "increase --e2e-process-slots or run without xdist"
+                    )
+                self._retiring_nodes.add(node)
+                node.shutdown()
+            return
+        if pending == 1:
             self._retiring_nodes.add(node)
             node.shutdown()
 
@@ -361,7 +571,7 @@ class IsolationAwareScheduling(LoadGroupScheduling):
         exitstatus = workeroutput.get("exitstatus") if workeroutput else None
         retired_cleanly = node in self._retiring_nodes and exitstatus in {0, 1}
         self._retiring_nodes.discard(node)
-        self._persistent_process_workers.discard(node)
+        self._persistent_processes.pop(node, None)
 
         if retired_cleanly:
             workload = self.assigned_work.pop(node)
@@ -419,8 +629,9 @@ def pytest_configure(config: pytest.Config) -> None:
 
 @pytest.hookimpl(tryfirst=True)
 def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
-    for item in items:
-        item.add_marker(pytest.mark.xdist_group(scheduling_group(item)))
+    groups = _consolidate_scheduling_groups([scheduling_group(item) for item in items])
+    for item, group in zip(items, groups, strict=True):
+        item.add_marker(pytest.mark.xdist_group(group))
 
 
 def pytest_xdist_make_scheduler(

--- a/zig/e2e/antfly/e2e_scheduler.py
+++ b/zig/e2e/antfly/e2e_scheduler.py
@@ -305,12 +305,11 @@ def scheduling_group(item: pytest.Item) -> str:
 
     # Preserve fixture sharing at the narrowest safe boundary. Function-scoped
     # process fixtures already provide complete test isolation.
-    module_shared = reuse_process and not force_fresh
-    module_shared = module_shared or any(
-        scope in {"module", "session"} for scope in process_scopes
-    )
+    shared_module_boundary = reuse_process and not force_fresh
+    shared_module_boundary = shared_module_boundary or "module" in process_scopes
+    shared_module_boundary = shared_module_boundary or shared_external
+    module_shared = shared_module_boundary or "session" in process_scopes
     module_shared = module_shared or bool(persistent_processes)
-    module_shared = module_shared or shared_external
     class_id = (
         nodeid.rsplit("::", 1)[0] if getattr(item, "cls", None) is not None else None
     )
@@ -362,7 +361,20 @@ def scheduling_group(item: pytest.Item) -> str:
         resource = f"{prefix}{identities}--"
     else:
         resource = PROCESS_GROUP_PREFIX if process_owned else "light--"
-    return _safe_group_name(f"{resource}{kind}", identity)
+    group_identity = identity
+    if (
+        persistent_processes
+        and isolation is None
+        and not package_boundaries
+        and not shared_module_boundary
+    ):
+        # Automatically inferred module isolation preserves each session
+        # fixture's users without coupling unrelated session processes in the
+        # same module. Explicit isolation groups still consolidate every
+        # resource they name, and a single item requesting multiple identities
+        # continues to reserve all of them together.
+        group_identity = f"{identity}::session={'+'.join(sorted(persistent_processes))}"
+    return _safe_group_name(f"{resource}{kind}", group_identity)
 
 
 def _scheduling_group_parts(group: str) -> tuple[frozenset[str], bool, str]:
@@ -635,6 +647,7 @@ class IsolationAwareScheduling(LoadGroupScheduling):
                 not self._workload_uses_transient_process(
                     self.assigned_work.get(node, {})
                 )
+                or node in getattr(self, "_transient_handoffs", set())
             )
         return additional
 

--- a/zig/e2e/antfly/e2e_scheduler.py
+++ b/zig/e2e/antfly/e2e_scheduler.py
@@ -1094,7 +1094,9 @@ def pytest_addoption(parser: pytest.Parser) -> None:
     group.addoption(
         "--e2e-process-slots",
         type=int,
-        default=int(os.environ.get("ANTFLY_E2E_PROCESS_SLOTS", "2")),
+        # Keep environment defaults as text so pytest's argument parser applies
+        # the same integer conversion and concise usage error as a CLI value.
+        default=os.environ.get("ANTFLY_E2E_PROCESS_SLOTS", "2"),
         help="Maximum concurrently scheduled Antfly process or cluster work units.",
     )
     group.addoption(

--- a/zig/e2e/antfly/pyproject.toml
+++ b/zig/e2e/antfly/pyproject.toml
@@ -13,6 +13,8 @@ dependencies = [
 testpaths = ["."]
 addopts = "-v --durations=50 --durations-min=1.0"
 markers = [
+    "e2e_isolation(policy, group=None): declares test- or module-level scheduling isolation",
+    "e2e_resource(name): declares a capacity-constrained resource such as antfly_process",
     "reuse_antfly_process: share one local Antfly process within this test module and clean tables after each test",
     "fresh_antfly_process: override module-level process reuse for tests that exercise process or storage lifecycle",
     "objectstore_integration: requires real S3 or GCS objectstore credentials and buckets",

--- a/zig/e2e/antfly/pyproject.toml
+++ b/zig/e2e/antfly/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
 
 [tool.pytest.ini_options]
 testpaths = ["."]
-addopts = "-v --durations=50 --durations-min=1.0"
+addopts = "-v --durations=50 --durations-min=1.0 --dist=loadgroup"
 markers = [
     "e2e_isolation(policy, group=None): declares test- or module-level scheduling isolation",
     "e2e_resource(name, lifetime=None, identity=None): declares a capacity-constrained resource such as antfly_process",

--- a/zig/e2e/antfly/pyproject.toml
+++ b/zig/e2e/antfly/pyproject.toml
@@ -14,7 +14,7 @@ testpaths = ["."]
 addopts = "-v --durations=50 --durations-min=1.0"
 markers = [
     "e2e_isolation(policy, group=None): declares test- or module-level scheduling isolation",
-    "e2e_resource(name): declares a capacity-constrained resource such as antfly_process",
+    "e2e_resource(name, lifetime=None, identity=None): declares a capacity-constrained resource such as antfly_process",
     "reuse_antfly_process: share one local Antfly process within this test module and clean tables after each test",
     "fresh_antfly_process: override module-level process reuse for tests that exercise process or storage lifecycle",
     "objectstore_integration: requires real S3 or GCS objectstore credentials and buckets",

--- a/zig/e2e/antfly/test_e2e_scheduler.py
+++ b/zig/e2e/antfly/test_e2e_scheduler.py
@@ -28,6 +28,7 @@ from e2e_scheduler import (
     DurationHistory,
     IsolationAwareScheduling,
     _consolidate_scheduling_groups,
+    e2e_resource,
     normalize_nodeid,
     scheduling_group,
 )
@@ -78,6 +79,31 @@ class FakeWorker:
 
 def mark(name: str, *args: object, **kwargs: object) -> pytest.Mark:
     return pytest.Mark(name, args, kwargs, _ispytest=True)
+
+
+def test_fixture_resource_decorator_rejects_inverted_order() -> None:
+    def fixture_function() -> None:
+        pass
+
+    fixture_definition = pytest.fixture(fixture_function)
+    with pytest.raises(TypeError, match="must be placed below @pytest.fixture"):
+        e2e_resource("antfly_process")(fixture_definition)  # type: ignore[arg-type]
+
+
+@pytest.fixture(scope="session")
+@e2e_resource(
+    "antfly_process",
+    lifetime="session",
+    identity="declared_session_process_fixture",
+)
+def declared_session_process_fixture() -> None:
+    """Exercise resource metadata attached to a real pytest fixture."""
+
+
+@pytest.fixture(scope="module")
+@e2e_resource("antfly_process")
+def declared_module_process_fixture() -> None:
+    """Exercise scope inference for a transient custom process fixture."""
 
 
 def test_normalize_nodeid_only_removes_xdist_group_suffix() -> None:
@@ -148,6 +174,32 @@ def test_declared_session_process_has_stable_identity_and_module_scope() -> None
     )
 
 
+@pytest.mark.e2e_isolation("module", group="declared-session-fixture")
+def test_fixture_resource_declaration_is_applied_to_consuming_test(
+    request: pytest.FixtureRequest,
+    declared_session_process_fixture: None,
+) -> None:
+    del declared_session_process_fixture
+    groups = [mark.args[0] for mark in request.node.iter_markers("xdist_group")]
+
+    assert len(groups) == 1
+    assert str(groups[0]).startswith(
+        f"{PERSISTENT_PROCESS_GROUP_PREFIX}declared_session_process_fixture--module--"
+    )
+
+
+@pytest.mark.e2e_isolation("module", group="declared-module-fixture")
+def test_fixture_resource_declaration_preserves_fixture_scope(
+    request: pytest.FixtureRequest,
+    declared_module_process_fixture: None,
+) -> None:
+    del declared_module_process_fixture
+    groups = [mark.args[0] for mark in request.node.iter_markers("xdist_group")]
+
+    assert len(groups) == 1
+    assert str(groups[0]).startswith(f"{PROCESS_GROUP_PREFIX}module--")
+
+
 def test_dynamic_serverless_table_parameter_has_persistent_identity() -> None:
     item = FakeItem(
         "test_foreign_sources.py::test_query[serverless]",
@@ -205,6 +257,41 @@ def test_duration_history_round_trips_and_smooths_observations(tmp_path: Path) -
         "samples": 2,
         "seconds": 2.6,
     }
+
+
+@pytest.mark.parametrize("payload", [None, [], 1, "valid JSON"])
+def test_duration_history_ignores_non_object_json(
+    tmp_path: Path, payload: object
+) -> None:
+    path = tmp_path / "durations.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    history = DurationHistory(path)
+
+    assert history.tests == {}
+
+
+def test_duration_history_ignores_invalid_numeric_entries(tmp_path: Path) -> None:
+    path = tmp_path / "durations.json"
+    path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "tests": {
+                    "valid": {"seconds": 2.0, "samples": 1},
+                    "boolean-seconds": {"seconds": True, "samples": 1},
+                    "infinite-seconds": {"seconds": float("inf"), "samples": 1},
+                    "overflowing-seconds": {"seconds": 10**1000, "samples": 1},
+                    "boolean-samples": {"seconds": 1.0, "samples": True},
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    history = DurationHistory(path)
+
+    assert history.tests == {"valid": {"seconds": 2.0, "samples": 1}}
 
 
 def test_scheduler_prefers_longest_eligible_work_without_exceeding_process_slots(

--- a/zig/e2e/antfly/test_e2e_scheduler.py
+++ b/zig/e2e/antfly/test_e2e_scheduler.py
@@ -1,0 +1,207 @@
+# Copyright 2026 Antfly, Inc.
+#
+# Licensed under the Elastic License 2.0 (ELv2); you may not use this file
+# except in compliance with the Elastic License 2.0. You may obtain a copy of
+# the Elastic License 2.0 at
+#
+#     https://www.antfly.io/licensing/ELv2-license
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the Elastic License 2.0 is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# Elastic License 2.0 for the specific language governing permissions and
+# limitations.
+
+from __future__ import annotations
+
+import json
+from collections import OrderedDict
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from e2e_scheduler import (
+    PROCESS_GROUP_PREFIX,
+    DurationHistory,
+    IsolationAwareScheduling,
+    normalize_nodeid,
+    scheduling_group,
+)
+
+
+class FakeItem:
+    def __init__(
+        self,
+        nodeid: str,
+        *,
+        fixtures: dict[str, str] | None = None,
+        markers: list[pytest.Mark] | None = None,
+    ):
+        self.nodeid = nodeid
+        fixture_scopes = fixtures or {}
+        self.fixturenames = list(fixture_scopes)
+        self._fixtureinfo = SimpleNamespace(
+            name2fixturedefs={
+                name: [SimpleNamespace(scope=scope)]
+                for name, scope in fixture_scopes.items()
+            }
+        )
+        self._markers = markers or []
+
+    def iter_markers(self, name: str):
+        return (mark for mark in self._markers if mark.name == name)
+
+    def get_closest_marker(self, name: str):
+        return next(self.iter_markers(name), None)
+
+
+def mark(name: str, *args: object, **kwargs: object) -> pytest.Mark:
+    return pytest.Mark(name, args, kwargs, _ispytest=True)
+
+
+def test_normalize_nodeid_only_removes_xdist_group_suffix() -> None:
+    assert normalize_nodeid("test_a.py::test_case@group") == "test_a.py::test_case"
+    assert normalize_nodeid("test_a.py::test_case[user@example.com]") == (
+        "test_a.py::test_case[user@example.com]"
+    )
+
+
+def test_function_scoped_process_fixture_is_independently_schedulable() -> None:
+    item = FakeItem(
+        "test_backup_restore.py::test_cluster_restore_modes",
+        fixtures={"backup_api": "function"},
+    )
+    group = scheduling_group(item)  # type: ignore[arg-type]
+    assert group.startswith(f"{PROCESS_GROUP_PREFIX}test--")
+
+
+def test_reused_or_session_process_fixture_stays_module_grouped() -> None:
+    reused = FakeItem(
+        "test_retrieval.py::test_pipeline",
+        fixtures={"backup_api": "function"},
+        markers=[mark("reuse_antfly_process")],
+    )
+    session_owned = FakeItem(
+        "test_sync_levels.py::test_visibility",
+        fixtures={"serverless_api": "session"},
+    )
+    assert "module--" in scheduling_group(reused)  # type: ignore[arg-type]
+    assert "module--" in scheduling_group(session_owned)  # type: ignore[arg-type]
+
+
+def test_explicit_isolation_and_resource_override_fixture_inference() -> None:
+    item = FakeItem(
+        "test_custom.py::test_cluster",
+        markers=[
+            mark("e2e_isolation", "test"),
+            mark("e2e_resource", "antfly_process"),
+        ],
+    )
+    group = scheduling_group(item)  # type: ignore[arg-type]
+    assert group.startswith(f"{PROCESS_GROUP_PREFIX}test--")
+
+
+def test_duration_history_round_trips_and_smooths_observations(tmp_path: Path) -> None:
+    path = tmp_path / "durations.json"
+    history = DurationHistory(path)
+    history.observe("test_a.py::test_case@group", 2.0)
+    history.save()
+
+    reloaded = DurationHistory(path)
+    assert reloaded.estimate("test_a.py::test_case", process_owned=False) == 2.0
+    reloaded.observe("test_a.py::test_case", 4.0)
+    reloaded.save()
+
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert payload["tests"]["test_a.py::test_case"] == {
+        "samples": 2,
+        "seconds": 2.6,
+    }
+
+
+def test_scheduler_prefers_longest_eligible_work_without_exceeding_process_slots(
+    tmp_path: Path,
+) -> None:
+    scheduler = IsolationAwareScheduling.__new__(IsolationAwareScheduling)
+    scheduler.process_slots = 1
+    scheduler.duration_history = DurationHistory(tmp_path / "durations.json")
+    scheduler.duration_history.tests = {
+        "test_process.py::test_long": {"seconds": 20.0, "samples": 1},
+        "test_light.py::test_short": {"seconds": 1.0, "samples": 1},
+    }
+    scheduler.workqueue = OrderedDict(
+        {
+            f"{PROCESS_GROUP_PREFIX}test--long": {
+                "test_process.py::test_long": False,
+            },
+            "light--test--short": {"test_light.py::test_short": False},
+        }
+    )
+    active_node = object()
+    target_node = object()
+    scheduler.assigned_work = {
+        active_node: {
+            f"{PROCESS_GROUP_PREFIX}test--active": {
+                "test_process.py::test_active": False,
+            }
+        },
+        target_node: {},
+    }
+
+    assert scheduler._next_eligible_scope(target_node) == "light--test--short"
+    scheduler.assigned_work = {target_node: {}}
+    assert (
+        scheduler._next_eligible_scope(target_node)
+        == f"{PROCESS_GROUP_PREFIX}test--long"
+    )
+
+
+def test_scheduler_reserves_process_capacity_per_worker_not_queued_unit(
+    tmp_path: Path,
+) -> None:
+    scheduler = IsolationAwareScheduling.__new__(IsolationAwareScheduling)
+    scheduler.process_slots = 1
+    scheduler.duration_history = DurationHistory(tmp_path / "durations.json")
+    process_scope = f"{PROCESS_GROUP_PREFIX}test--next"
+    scheduler.workqueue = OrderedDict(
+        {process_scope: {"test_process.py::test_next": False}}
+    )
+    reserved_node = object()
+    other_node = object()
+    scheduler.assigned_work = {
+        reserved_node: {
+            f"{PROCESS_GROUP_PREFIX}test--first": {
+                "test_process.py::test_first": False,
+            },
+            f"{PROCESS_GROUP_PREFIX}test--second": {
+                "test_process.py::test_second": False,
+            },
+        },
+        other_node: {},
+    }
+
+    assert scheduler._reserved_process_workers() == 1
+    assert scheduler._next_eligible_scope(reserved_node) == process_scope
+    assert scheduler._next_eligible_scope(other_node) is None
+
+
+def test_intentionally_retired_worker_requeues_only_incomplete_work(
+    tmp_path: Path,
+) -> None:
+    scheduler = IsolationAwareScheduling.__new__(IsolationAwareScheduling)
+    scheduler.process_slots = 1
+    scheduler.duration_history = DurationHistory(tmp_path / "durations.json")
+    retired_node = object()
+    scheduler._retiring_nodes = {retired_node}
+    scheduler.workqueue = OrderedDict()
+    scheduler.assigned_work = {
+        retired_node: {
+            "light--test--finished": {"test_light.py::test_finished": True},
+            "light--test--pending": {"test_light.py::test_pending": False},
+        }
+    }
+
+    assert scheduler.remove_node(retired_node) is None
+    assert scheduler.workqueue == {
+        "light--test--pending": {"test_light.py::test_pending": False}
+    }

--- a/zig/e2e/antfly/test_e2e_scheduler.py
+++ b/zig/e2e/antfly/test_e2e_scheduler.py
@@ -20,7 +20,9 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
+
 from e2e_scheduler import (
+    PERSISTENT_PROCESS_GROUP_PREFIX,
     PROCESS_GROUP_PREFIX,
     DurationHistory,
     IsolationAwareScheduling,
@@ -55,6 +57,16 @@ class FakeItem:
         return next(self.iter_markers(name), None)
 
 
+class FakeWorker:
+    def __init__(self, *, exitstatus: int | None = None):
+        self.sent: list[list[int]] = []
+        if exitstatus is not None:
+            self.workeroutput = {"exitstatus": exitstatus}
+
+    def send_runtest_some(self, indexes: list[int]) -> None:
+        self.sent.append(indexes)
+
+
 def mark(name: str, *args: object, **kwargs: object) -> pytest.Mark:
     return pytest.Mark(name, args, kwargs, _ispytest=True)
 
@@ -83,10 +95,14 @@ def test_reused_or_session_process_fixture_stays_module_grouped() -> None:
     )
     session_owned = FakeItem(
         "test_sync_levels.py::test_visibility",
-        fixtures={"serverless_api": "session"},
+        fixtures={
+            "serverless_api": "session",
+            "serverless_runtime": "session",
+        },
     )
     assert "module--" in scheduling_group(reused)  # type: ignore[arg-type]
-    assert "module--" in scheduling_group(session_owned)  # type: ignore[arg-type]
+    session_group = scheduling_group(session_owned)  # type: ignore[arg-type]
+    assert session_group.startswith(f"{PERSISTENT_PROCESS_GROUP_PREFIX}module--")
 
 
 def test_explicit_isolation_and_resource_override_fixture_inference() -> None:
@@ -125,6 +141,7 @@ def test_scheduler_prefers_longest_eligible_work_without_exceeding_process_slots
     scheduler = IsolationAwareScheduling.__new__(IsolationAwareScheduling)
     scheduler.process_slots = 1
     scheduler.duration_history = DurationHistory(tmp_path / "durations.json")
+    scheduler._persistent_process_workers = set()
     scheduler.duration_history.tests = {
         "test_process.py::test_long": {"seconds": 20.0, "samples": 1},
         "test_light.py::test_short": {"seconds": 1.0, "samples": 1},
@@ -162,6 +179,7 @@ def test_scheduler_reserves_process_capacity_per_worker_not_queued_unit(
     scheduler = IsolationAwareScheduling.__new__(IsolationAwareScheduling)
     scheduler.process_slots = 1
     scheduler.duration_history = DurationHistory(tmp_path / "durations.json")
+    scheduler._persistent_process_workers = set()
     process_scope = f"{PROCESS_GROUP_PREFIX}test--next"
     scheduler.workqueue = OrderedDict(
         {process_scope: {"test_process.py::test_next": False}}
@@ -185,14 +203,92 @@ def test_scheduler_reserves_process_capacity_per_worker_not_queued_unit(
     assert scheduler._next_eligible_scope(other_node) is None
 
 
+def test_session_process_reservation_lasts_for_worker_lifetime(
+    tmp_path: Path,
+) -> None:
+    scheduler = IsolationAwareScheduling.__new__(IsolationAwareScheduling)
+    scheduler.process_slots = 1
+    scheduler.duration_history = DurationHistory(tmp_path / "durations.json")
+    transient_scope = f"{PROCESS_GROUP_PREFIX}test--transient"
+    owner = object()
+    other_node = object()
+    scheduler._persistent_process_workers = {owner}
+    scheduler.assigned_work = {
+        owner: {
+            f"{PERSISTENT_PROCESS_GROUP_PREFIX}module--done": {
+                "test_serverless.py::test_done": True,
+            }
+        },
+        other_node: {},
+    }
+    scheduler.workqueue = OrderedDict(
+        {
+            transient_scope: {"test_process.py::test_transient": False},
+        }
+    )
+
+    assert scheduler._reserved_process_workers() == 1
+    assert scheduler._next_eligible_scope(owner) == transient_scope
+    assert scheduler._next_eligible_scope(other_node) is None
+
+
+def test_assigning_session_process_makes_worker_reservation_sticky(
+    tmp_path: Path,
+) -> None:
+    scheduler = IsolationAwareScheduling.__new__(IsolationAwareScheduling)
+    scheduler.process_slots = 1
+    scheduler.duration_history = DurationHistory(tmp_path / "durations.json")
+    scheduler._persistent_process_workers = set()
+    node = FakeWorker()
+    nodeid = "test_serverless.py::test_session"
+    scope = f"{PERSISTENT_PROCESS_GROUP_PREFIX}module--serverless"
+    scheduler.workqueue = OrderedDict({scope: {nodeid: False}})
+    scheduler.assigned_work = {node: {}}
+    scheduler.registered_collections = {node: [nodeid]}
+
+    scheduler._assign_work_unit(node)
+
+    assert node.sent == [[0]]
+    assert node in scheduler._persistent_process_workers
+    scheduler.assigned_work[node][scope][nodeid] = True
+    assert scheduler._reserved_process_workers() == 1
+
+
+def test_transient_process_capacity_is_released_after_completion(
+    tmp_path: Path,
+) -> None:
+    scheduler = IsolationAwareScheduling.__new__(IsolationAwareScheduling)
+    scheduler.process_slots = 1
+    scheduler.duration_history = DurationHistory(tmp_path / "durations.json")
+    scheduler._persistent_process_workers = set()
+    first_node = object()
+    other_node = object()
+    next_scope = f"{PROCESS_GROUP_PREFIX}test--next"
+    scheduler.assigned_work = {
+        first_node: {
+            f"{PROCESS_GROUP_PREFIX}test--done": {
+                "test_process.py::test_done": True,
+            }
+        },
+        other_node: {},
+    }
+    scheduler.workqueue = OrderedDict(
+        {next_scope: {"test_process.py::test_next": False}}
+    )
+
+    assert scheduler._reserved_process_workers() == 0
+    assert scheduler._next_eligible_scope(other_node) == next_scope
+
+
 def test_intentionally_retired_worker_requeues_only_incomplete_work(
     tmp_path: Path,
 ) -> None:
     scheduler = IsolationAwareScheduling.__new__(IsolationAwareScheduling)
     scheduler.process_slots = 1
     scheduler.duration_history = DurationHistory(tmp_path / "durations.json")
-    retired_node = object()
+    retired_node = FakeWorker(exitstatus=0)
     scheduler._retiring_nodes = {retired_node}
+    scheduler._persistent_process_workers = {retired_node}
     scheduler.workqueue = OrderedDict()
     scheduler.assigned_work = {
         retired_node: {
@@ -205,3 +301,30 @@ def test_intentionally_retired_worker_requeues_only_incomplete_work(
     assert scheduler.workqueue == {
         "light--test--pending": {"test_light.py::test_pending": False}
     }
+    assert retired_node not in scheduler._persistent_process_workers
+
+
+@pytest.mark.parametrize("exitstatus", [None, 2, 3])
+def test_retiring_worker_crash_is_reported_and_requeued(
+    tmp_path: Path,
+    exitstatus: int | None,
+) -> None:
+    scheduler = IsolationAwareScheduling.__new__(IsolationAwareScheduling)
+    scheduler.process_slots = 1
+    scheduler.duration_history = DurationHistory(tmp_path / "durations.json")
+    crashed_node = FakeWorker(exitstatus=exitstatus)
+    scheduler._retiring_nodes = {crashed_node}
+    scheduler._persistent_process_workers = {crashed_node}
+    scheduler.workqueue = OrderedDict()
+    scheduler.assigned_work = {
+        crashed_node: {
+            "light--test--pending": {"test_light.py::test_pending": False},
+        }
+    }
+
+    assert scheduler.remove_node(crashed_node) == "test_light.py::test_pending"
+    assert scheduler.workqueue == {
+        "light--test--pending": {"test_light.py::test_pending": False}
+    }
+    assert crashed_node not in scheduler._retiring_nodes
+    assert crashed_node not in scheduler._persistent_process_workers

--- a/zig/e2e/antfly/test_e2e_scheduler.py
+++ b/zig/e2e/antfly/test_e2e_scheduler.py
@@ -851,6 +851,7 @@ def test_new_session_identity_prefers_idle_clean_worker(tmp_path: Path) -> None:
     )
     scheduler._persistent_processes = {owner: {"serverless_runtime"}}
     scheduler.assigned_work = {owner: {}, clean: {}}
+    scheduler.registered_collections = {owner: [], clean: []}
     scheduler.workqueue = OrderedDict(
         {embedded_scope: {"test_standalone.py::test_next": False}}
     )
@@ -873,6 +874,7 @@ def test_session_owner_adds_identity_when_clean_worker_cannot_fit_scope(
     )
     scheduler._persistent_processes = {owner: {"serverless_runtime"}}
     scheduler.assigned_work = {owner: {}, clean: {}}
+    scheduler.registered_collections = {owner: [], clean: []}
     scheduler.workqueue = OrderedDict(
         {combined_scope: {"test_combined.py::test_next": False}}
     )
@@ -944,6 +946,7 @@ def test_final_transient_test_hands_its_slot_to_persistent_runway(
     persistent_nodeid = f"test_serverless.py::test_next@{persistent_scope}"
     scheduler._retiring_nodes = set()
     scheduler._starting_replacements = set()
+    scheduler._collecting_nodes = set()
     scheduler._transient_handoffs = set()
     scheduler._persistent_processes = {}
     scheduler.assigned_work = {
@@ -1037,6 +1040,7 @@ def test_last_resource_worker_starts_replacement_before_retirement(
     scheduler.assigned_work = {
         owner: {owner_scope: {"test_owner.py::test_current": False}},
     }
+    scheduler.registered_collections = {owner: ["test_owner.py::test_current"]}
     scheduler.workqueue = OrderedDict(
         {queued_scope: {"test_transient.py::test_queued": False}}
     )
@@ -1049,8 +1053,91 @@ def test_last_resource_worker_starts_replacement_before_retirement(
     assert owner.shutting_down
 
     scheduler.add_node(replacement)
-    assert replacement not in scheduler._starting_replacements
+    assert replacement in scheduler._starting_replacements
     assert replacement in scheduler.assigned_work
+
+
+def test_replacement_waits_for_collection_before_accepting_work(
+    tmp_path: Path,
+) -> None:
+    scheduler = IsolationAwareScheduling.__new__(IsolationAwareScheduling)
+    scheduler.process_slots = 1
+    scheduler.duration_history = DurationHistory(tmp_path / "durations.json")
+    original = FakeWorker()
+    replacement = FakeWorker()
+    nodeid = "test_process.py::test_queued"
+    scope = f"{PROCESS_GROUP_PREFIX}test--queued"
+    scheduler.numnodes = 1
+    scheduler.collection = [nodeid]
+    scheduler._retiring_nodes = set()
+    scheduler._starting_replacements = {replacement}
+    scheduler._collecting_nodes = set()
+    scheduler._transient_handoffs = set()
+    scheduler._persistent_processes = {}
+    scheduler.assigned_work = {original: {}}
+    scheduler.registered_collections = {original: [nodeid]}
+    scheduler.workqueue = OrderedDict({scope: {nodeid: False}})
+
+    scheduler.add_node(replacement)
+    scheduler._reschedule(replacement)
+
+    assert replacement.sent == []
+    assert not replacement.shutting_down
+    assert replacement in scheduler._starting_replacements
+    assert list(scheduler.workqueue) == [scope]
+
+    original.shutting_down = True
+    scheduler.add_node_collection(replacement, [nodeid])
+    scheduler.schedule()
+
+    assert replacement not in scheduler._starting_replacements
+    assert replacement.sent == [[0]]
+    assert not scheduler.workqueue
+
+
+def test_global_reschedule_starts_long_persistent_work_on_clean_worker_first(
+    tmp_path: Path,
+) -> None:
+    scheduler = IsolationAwareScheduling.__new__(IsolationAwareScheduling)
+    scheduler.process_slots = 2
+    scheduler.duration_history = DurationHistory(tmp_path / "durations.json")
+    owner = FakeWorker()
+    clean = FakeWorker()
+    owner_nodeid = "test_a.py::test_done"
+    persistent_nodeid = "test_b.py::test_long"
+    transient_nodeid = "test_transient.py::test_short"
+    owner_scope = f"{PERSISTENT_PROCESS_GROUP_PREFIX}runtime_a--module--done"
+    persistent_scope = f"{PERSISTENT_PROCESS_GROUP_PREFIX}runtime_b--module--long"
+    transient_scope = f"{PROCESS_GROUP_PREFIX}test--short"
+    scheduler.duration_history.tests = {
+        persistent_nodeid: {"seconds": 100.0, "samples": 1},
+        transient_nodeid: {"seconds": 1.0, "samples": 1},
+    }
+    scheduler._retiring_nodes = set()
+    scheduler._starting_replacements = set()
+    scheduler._collecting_nodes = set()
+    scheduler._transient_handoffs = set()
+    scheduler._persistent_processes = {owner: {"runtime_a"}}
+    scheduler.assigned_work = {
+        owner: {owner_scope: {owner_nodeid: True}},
+        clean: {},
+    }
+    collection = [owner_nodeid, persistent_nodeid, transient_nodeid]
+    scheduler.registered_collections = {owner: collection, clean: collection}
+    scheduler.workqueue = OrderedDict(
+        {
+            persistent_scope: {persistent_nodeid: False},
+            transient_scope: {transient_nodeid: False},
+        }
+    )
+
+    scheduler._reschedule_all()
+
+    assert owner.sent == []
+    assert clean.sent == [[1]]
+    assert list(scheduler.workqueue) == [transient_scope]
+    assert scheduler._persistent_processes[clean] == {"runtime_b"}
+    assert scheduler._reserved_process_slots() == 2
 
 
 def test_idle_worker_waits_while_session_owner_rotates_to_release_slot(
@@ -1073,7 +1160,10 @@ def test_idle_worker_waits_while_session_owner_rotates_to_release_slot(
         waiter: {},
     }
     scheduler.workqueue = OrderedDict({transient_scope: {waiting_nodeid: False}})
-    scheduler.registered_collections = {waiter: [waiting_nodeid]}
+    scheduler.registered_collections = {
+        owner: ["test_serverless.py::test_done", waiting_nodeid],
+        waiter: [waiting_nodeid],
+    }
 
     scheduler._reschedule(waiter)
     assert not waiter.shutting_down
@@ -1228,6 +1318,7 @@ def test_lightweight_runway_waits_for_transient_slot_release(tmp_path: Path) -> 
             }
         }
     )
+    scheduler.registered_collections = {owner: [], active: [], successor: []}
 
     scheduler._reschedule(successor)
 
@@ -1256,6 +1347,7 @@ def test_lightweight_runway_waits_when_session_owner_can_continue(
     scheduler.workqueue = OrderedDict(
         {matching_scope: {"test_serverless.py::test_next": False}}
     )
+    scheduler.registered_collections = {owner: [], successor: []}
 
     scheduler._reschedule(successor)
 

--- a/zig/e2e/antfly/test_e2e_scheduler.py
+++ b/zig/e2e/antfly/test_e2e_scheduler.py
@@ -1095,6 +1095,43 @@ def test_replacement_waits_for_collection_before_accepting_work(
     assert not scheduler.workqueue
 
 
+def test_replacement_collection_mismatch_fails_fast_and_clears_progress(
+    tmp_path: Path,
+) -> None:
+    scheduler = IsolationAwareScheduling.__new__(IsolationAwareScheduling)
+    scheduler.process_slots = 1
+    scheduler.duration_history = DurationHistory(tmp_path / "durations.json")
+    original = FakeWorker()
+    replacement = FakeWorker()
+    original.gateway = SimpleNamespace(id="gw0")
+    replacement.gateway = SimpleNamespace(id="gw2")
+    original_nodeid = "test_process.py::test_original"
+    replacement_nodeid = "test_process.py::test_replacement"
+    scheduler.numnodes = 1
+    scheduler.collection = [original_nodeid]
+    scheduler.log = lambda message: None
+    scheduler._retiring_nodes = set()
+    scheduler._starting_replacements = {replacement}
+    scheduler._collecting_nodes = set()
+    scheduler._transient_handoffs = set()
+    scheduler._persistent_processes = {}
+    scheduler.assigned_work = {original: {}}
+    scheduler.registered_collections = {original: [original_nodeid]}
+    scheduler.workqueue = OrderedDict()
+
+    scheduler.add_node(replacement)
+    with pytest.raises(
+        pytest.UsageError,
+        match="replacement worker gw2 collected different tests",
+    ):
+        scheduler.add_node_collection(replacement, [replacement_nodeid])
+
+    assert replacement.shutting_down
+    assert replacement not in scheduler.registered_collections
+    assert replacement not in scheduler._starting_replacements
+    assert replacement not in scheduler._collecting_nodes
+
+
 def test_global_reschedule_starts_long_persistent_work_on_clean_worker_first(
     tmp_path: Path,
 ) -> None:

--- a/zig/e2e/antfly/test_e2e_scheduler.py
+++ b/zig/e2e/antfly/test_e2e_scheduler.py
@@ -41,6 +41,8 @@ class FakeItem:
         nodeid: str,
         *,
         fixtures: dict[str, str] | None = None,
+        fixture_baseids: dict[str, str] | None = None,
+        fixture_functions: dict[str, object] | None = None,
         markers: list[pytest.Mark] | None = None,
         params: dict[str, object] | None = None,
     ):
@@ -53,6 +55,10 @@ class FakeItem:
                 for name, scope in fixture_scopes.items()
             }
         )
+        for name, definitions in self._fixtureinfo.name2fixturedefs.items():
+            definition = definitions[-1]
+            definition.baseid = (fixture_baseids or {}).get(name, "")
+            definition.func = (fixture_functions or {}).get(name)
         self._markers = markers or []
         if params is not None:
             self.callspec = SimpleNamespace(params=params)
@@ -103,6 +109,12 @@ def declared_module_process_fixture() -> None:
     """Exercise scope inference for a transient custom process fixture."""
 
 
+@pytest.fixture(scope="class")
+@e2e_resource("antfly_process")
+def declared_class_process_fixture() -> None:
+    """Exercise class-level process isolation without module serialization."""
+
+
 def test_normalize_nodeid_only_removes_xdist_group_suffix() -> None:
     assert normalize_nodeid("test_a.py::test_case@group") == "test_a.py::test_case"
     assert normalize_nodeid("test_a.py::test_case[user@example.com]") == (
@@ -137,6 +149,29 @@ def test_reused_or_session_process_fixture_stays_module_grouped() -> None:
     assert session_group.startswith(
         f"{PERSISTENT_PROCESS_GROUP_PREFIX}serverless_runtime--module--"
     )
+
+
+def test_class_scoped_process_fixture_stays_class_grouped() -> None:
+    first = FakeItem(
+        "test_custom.py::TestProcess::test_first",
+        fixtures={"backup_api": "class"},
+    )
+    second = FakeItem(
+        "test_custom.py::TestProcess::test_second",
+        fixtures={"backup_api": "class"},
+    )
+    unrelated = FakeItem(
+        "test_custom.py::TestOtherProcess::test_first",
+        fixtures={"backup_api": "class"},
+    )
+
+    first_group = scheduling_group(first)  # type: ignore[arg-type]
+    second_group = scheduling_group(second)  # type: ignore[arg-type]
+    unrelated_group = scheduling_group(unrelated)  # type: ignore[arg-type]
+
+    assert first_group.startswith(f"{PROCESS_GROUP_PREFIX}class--")
+    assert first_group == second_group
+    assert first_group != unrelated_group
 
 
 def test_explicit_isolation_and_resource_override_fixture_inference() -> None:
@@ -181,8 +216,9 @@ def test_fixture_resource_declaration_is_applied_to_consuming_test(
 
     assert len(groups) == 1
     assert str(groups[0]).startswith(
-        f"{PERSISTENT_PROCESS_GROUP_PREFIX}declared_session_process_fixture--module--"
+        f"{PERSISTENT_PROCESS_GROUP_PREFIX}declared_session_process_fixture."
     )
+    assert "--module--" in str(groups[0])
 
 
 @pytest.mark.e2e_isolation("module", group="declared-module-fixture")
@@ -195,6 +231,71 @@ def test_fixture_resource_declaration_preserves_fixture_scope(
 
     assert len(groups) == 1
     assert str(groups[0]).startswith(f"{PROCESS_GROUP_PREFIX}module--")
+
+
+class TestFixtureResourceClassScope:
+    def test_first_method_uses_class_group(
+        self,
+        request: pytest.FixtureRequest,
+        declared_class_process_fixture: None,
+    ) -> None:
+        del declared_class_process_fixture
+        groups = [mark.args[0] for mark in request.node.iter_markers("xdist_group")]
+
+        assert len(groups) == 1
+        assert str(groups[0]).startswith(f"{PROCESS_GROUP_PREFIX}class--")
+
+    def test_second_method_uses_same_class_group(
+        self,
+        request: pytest.FixtureRequest,
+        declared_class_process_fixture: None,
+    ) -> None:
+        del declared_class_process_fixture
+        groups = [mark.args[0] for mark in request.node.iter_markers("xdist_group")]
+
+        assert len(groups) == 1
+        assert str(groups[0]).startswith(f"{PROCESS_GROUP_PREFIX}class--")
+
+
+def test_inferred_session_identity_includes_fixture_provenance() -> None:
+    @e2e_resource("antfly_process")
+    def first_runtime() -> None:
+        pass
+
+    @e2e_resource("antfly_process")
+    def second_runtime() -> None:
+        pass
+
+    first = FakeItem(
+        "test_a.py::test_runtime",
+        fixtures={"runtime": "session"},
+        fixture_baseids={"runtime": "test_a.py"},
+        fixture_functions={"runtime": first_runtime},
+    )
+    second = FakeItem(
+        "test_b.py::test_runtime",
+        fixtures={"runtime": "session"},
+        fixture_baseids={"runtime": "test_b.py"},
+        fixture_functions={"runtime": second_runtime},
+    )
+    shared_definition = FakeItem(
+        "test_c.py::test_runtime",
+        fixtures={"runtime": "session"},
+        fixture_baseids={"runtime": "test_a.py"},
+        fixture_functions={"runtime": first_runtime},
+    )
+
+    first_group = scheduling_group(first)  # type: ignore[arg-type]
+    second_group = scheduling_group(second)  # type: ignore[arg-type]
+    shared_group = scheduling_group(shared_definition)  # type: ignore[arg-type]
+    first_identity = first_group.split("--", 4)[2]
+    second_identity = second_group.split("--", 4)[2]
+    shared_identity = shared_group.split("--", 4)[2]
+
+    assert first_group.startswith(f"{PERSISTENT_PROCESS_GROUP_PREFIX}runtime.")
+    assert second_group.startswith(f"{PERSISTENT_PROCESS_GROUP_PREFIX}runtime.")
+    assert first_identity != second_identity
+    assert first_identity == shared_identity
 
 
 def test_dynamic_serverless_table_parameter_has_persistent_identity() -> None:

--- a/zig/e2e/antfly/test_e2e_scheduler.py
+++ b/zig/e2e/antfly/test_e2e_scheduler.py
@@ -15,12 +15,12 @@
 from __future__ import annotations
 
 import json
+import sys
 from collections import OrderedDict
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
-import e2e_scheduler as e2e_scheduler_module
 import pytest
 from e2e_scheduler import (
     MIXED_PROCESS_GROUP_PREFIX,
@@ -342,6 +342,70 @@ def test_declared_session_process_has_stable_identity_and_module_scope() -> None
     )
 
 
+def test_inferred_session_identities_in_one_module_remain_independent() -> None:
+    first = FakeItem(
+        "test_custom.py::test_first",
+        markers=[
+            mark(
+                "e2e_resource",
+                "antfly_process",
+                lifetime="session",
+                identity="runtime_a",
+            )
+        ],
+    )
+    second = FakeItem(
+        "test_custom.py::test_second",
+        markers=[
+            mark(
+                "e2e_resource",
+                "antfly_process",
+                lifetime="session",
+                identity="runtime_b",
+            )
+        ],
+    )
+
+    groups = _consolidate_scheduling_groups(
+        [
+            scheduling_group(first),  # type: ignore[arg-type]
+            scheduling_group(second),  # type: ignore[arg-type]
+        ]
+    )
+
+    assert groups[0] != groups[1]
+    assert groups[0].startswith(f"{PERSISTENT_PROCESS_GROUP_PREFIX}runtime_a--module--")
+    assert groups[1].startswith(f"{PERSISTENT_PROCESS_GROUP_PREFIX}runtime_b--module--")
+
+
+def test_explicit_session_group_consolidates_all_required_identities() -> None:
+    groups = []
+    for nodeid, identity in (
+        ("test_custom.py::test_first", "runtime_a"),
+        ("test_custom.py::test_second", "runtime_b"),
+    ):
+        item = FakeItem(
+            nodeid,
+            markers=[
+                mark("e2e_isolation", "module", group="shared-runtime-tests"),
+                mark(
+                    "e2e_resource",
+                    "antfly_process",
+                    lifetime="session",
+                    identity=identity,
+                ),
+            ],
+        )
+        groups.append(scheduling_group(item))  # type: ignore[arg-type]
+
+    consolidated = _consolidate_scheduling_groups(groups)
+
+    assert consolidated[0] == consolidated[1]
+    assert consolidated[0].startswith(
+        f"{PERSISTENT_PROCESS_GROUP_PREFIX}runtime_a+runtime_b--module--"
+    )
+
+
 @pytest.mark.e2e_isolation("module", group="declared-session-fixture")
 def test_fixture_resource_declaration_is_applied_to_consuming_test(
     request: pytest.FixtureRequest,
@@ -593,6 +657,7 @@ def test_duration_reports_exclude_skips_but_keep_full_executed_protocol(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    e2e_scheduler_module = sys.modules[DurationHistory.__module__]
     history = DurationHistory(tmp_path / "durations.json")
     monkeypatch.setattr(e2e_scheduler_module, "_duration_history", history)
     monkeypatch.setattr(e2e_scheduler_module, "_duration_report_totals", {})
@@ -898,6 +963,47 @@ def test_final_transient_test_hands_its_slot_to_persistent_runway(
     scheduler.mark_test_complete(worker, 0)
 
     assert worker not in scheduler._transient_handoffs
+    assert scheduler._reserved_process_slots() == 1
+
+
+def test_transient_handoff_lane_cannot_be_reused_behind_persistent_work(
+    tmp_path: Path,
+) -> None:
+    scheduler = IsolationAwareScheduling.__new__(IsolationAwareScheduling)
+    scheduler.process_slots = 1
+    scheduler.duration_history = DurationHistory(tmp_path / "durations.json")
+    worker = FakeWorker()
+    current_scope = f"{PROCESS_GROUP_PREFIX}test--current"
+    persistent_scope = (
+        f"{PERSISTENT_PROCESS_GROUP_PREFIX}serverless_runtime--module--next"
+    )
+    later_scope = f"{PROCESS_GROUP_PREFIX}test--later"
+    current_nodeid = "test_transient.py::test_current"
+    persistent_nodeid = "test_serverless.py::test_next"
+    later_nodeid = "test_transient.py::test_later"
+    scheduler._retiring_nodes = set()
+    scheduler._starting_replacements = set()
+    scheduler._transient_handoffs = set()
+    scheduler._persistent_processes = {}
+    scheduler.assigned_work = {
+        worker: {current_scope: {current_nodeid: False}},
+    }
+    scheduler.workqueue = OrderedDict(
+        {
+            persistent_scope: {persistent_nodeid: False},
+            later_scope: {later_nodeid: False},
+        }
+    )
+    scheduler.registered_collections = {
+        worker: [current_nodeid, persistent_nodeid, later_nodeid]
+    }
+
+    scheduler._reschedule(worker)
+    scheduler._reschedule(worker)
+
+    assert worker.sent == [[1]]
+    assert list(scheduler.workqueue) == [later_scope]
+    assert scheduler._additional_process_slots(worker, later_scope) == 1
     assert scheduler._reserved_process_slots() == 1
 
 

--- a/zig/e2e/antfly/test_e2e_scheduler.py
+++ b/zig/e2e/antfly/test_e2e_scheduler.py
@@ -895,6 +895,90 @@ def test_lightweight_runway_preserves_successor_for_session_rotation(
     assert successor.sent == [[1]]
 
 
+def test_process_runway_preserves_last_successor_for_queued_work(
+    tmp_path: Path,
+) -> None:
+    scheduler = IsolationAwareScheduling.__new__(IsolationAwareScheduling)
+    scheduler.process_slots = 2
+    scheduler.duration_history = DurationHistory(tmp_path / "durations.json")
+    first = FakeWorker()
+    second = FakeWorker()
+    first_scope = f"{PROCESS_GROUP_PREFIX}test--first"
+    second_scope = f"{PROCESS_GROUP_PREFIX}test--second"
+    queued_scope = f"{PERSISTENT_PROCESS_GROUP_PREFIX}new_runtime--module--queued"
+    scheduler._retiring_nodes = set()
+    scheduler._persistent_processes = {}
+    scheduler.assigned_work = {
+        first: {first_scope: {"test_process.py::test_first": False}},
+        second: {second_scope: {"test_process.py::test_second": False}},
+    }
+    scheduler.workqueue = OrderedDict(
+        {queued_scope: {"test_process.py::test_queued": False}}
+    )
+    scheduler.registered_collections = {
+        first: ["test_process.py::test_first", "test_process.py::test_queued"],
+        second: ["test_process.py::test_second", "test_process.py::test_queued"],
+    }
+
+    scheduler._reschedule(first)
+    scheduler._reschedule(second)
+
+    retiring = [node for node in (first, second) if node.shutting_down]
+    successors = [node for node in (first, second) if not node.shutting_down]
+    assert len(retiring) == 1
+    assert len(successors) == 1
+    assert scheduler.workqueue
+
+    retired_workload = scheduler.assigned_work[retiring[0]]
+    for work_unit in retired_workload.values():
+        for nodeid in work_unit:
+            work_unit[nodeid] = True
+    scheduler._reschedule(successors[0])
+
+    assert successors[0].sent == [[1]]
+    assert not scheduler.workqueue
+
+
+def test_session_rotation_preserves_owner_needed_by_queued_work(
+    tmp_path: Path,
+) -> None:
+    scheduler = IsolationAwareScheduling.__new__(IsolationAwareScheduling)
+    scheduler.process_slots = 2
+    scheduler.duration_history = DurationHistory(tmp_path / "durations.json")
+    useful_owner = FakeWorker()
+    unrelated_owner = FakeWorker(exitstatus=0)
+    successor = FakeWorker()
+    useful_scope = f"{PERSISTENT_PROCESS_GROUP_PREFIX}runtime_a--module--done"
+    unrelated_scope = f"{PERSISTENT_PROCESS_GROUP_PREFIX}runtime_b--module--done"
+    queued_scope = f"{MIXED_PROCESS_GROUP_PREFIX}runtime_a--module--queued"
+    queued_nodeid = "test_mixed.py::test_queued"
+    scheduler._retiring_nodes = set()
+    scheduler._persistent_processes = {
+        useful_owner: {"runtime_a"},
+        unrelated_owner: {"runtime_b"},
+    }
+    scheduler.assigned_work = {
+        useful_owner: {useful_scope: {"test_a.py::test_done": True}},
+        unrelated_owner: {unrelated_scope: {"test_b.py::test_done": True}},
+        successor: {"light--test--queued": {"test_light.py::test_queued": False}},
+    }
+    scheduler.workqueue = OrderedDict({queued_scope: {queued_nodeid: False}})
+    scheduler.registered_collections = {
+        useful_owner: [queued_nodeid],
+        successor: ["test_light.py::test_queued", queued_nodeid],
+    }
+
+    scheduler._reschedule(useful_owner)
+
+    assert unrelated_owner.shutting_down
+    assert unrelated_owner in scheduler._retiring_nodes
+    assert not useful_owner.shutting_down
+
+    assert scheduler.remove_node(unrelated_owner) is None
+    assert useful_owner.sent == [[0]]
+    assert not scheduler.workqueue
+
+
 def test_lightweight_runway_waits_for_transient_slot_release(tmp_path: Path) -> None:
     scheduler = IsolationAwareScheduling.__new__(IsolationAwareScheduling)
     scheduler.process_slots = 2

--- a/zig/e2e/antfly/test_e2e_scheduler.py
+++ b/zig/e2e/antfly/test_e2e_scheduler.py
@@ -43,6 +43,8 @@ class FakeItem:
         fixtures: dict[str, str] | None = None,
         fixture_baseids: dict[str, str] | None = None,
         fixture_functions: dict[str, object] | None = None,
+        fixture_parameter_scopes: dict[str, str] | None = None,
+        test_class: bool = False,
         markers: list[pytest.Mark] | None = None,
         params: dict[str, object] | None = None,
     ):
@@ -60,8 +62,15 @@ class FakeItem:
             definition.baseid = (fixture_baseids or {}).get(name, "")
             definition.func = (fixture_functions or {}).get(name)
         self._markers = markers or []
-        if params is not None:
-            self.callspec = SimpleNamespace(params=params)
+        self.cls = object() if test_class else None
+        if params is not None or fixture_parameter_scopes:
+            self.callspec = SimpleNamespace(
+                params=params or {},
+                _arg2scope={
+                    name: SimpleNamespace(value=scope)
+                    for name, scope in (fixture_parameter_scopes or {}).items()
+                },
+            )
 
     def iter_markers(self, name: str):
         return (mark for mark in self._markers if mark.name == name)
@@ -115,6 +124,13 @@ def declared_class_process_fixture() -> None:
     """Exercise class-level process isolation without module serialization."""
 
 
+@pytest.fixture(scope="function")
+@e2e_resource("antfly_process")
+def declared_parametrized_process_fixture(request: pytest.FixtureRequest) -> object:
+    """Exercise pytest's per-param effective scope metadata."""
+    return request.param
+
+
 def test_normalize_nodeid_only_removes_xdist_group_suffix() -> None:
     assert normalize_nodeid("test_a.py::test_case@group") == "test_a.py::test_case"
     assert normalize_nodeid("test_a.py::test_case[user@example.com]") == (
@@ -155,14 +171,17 @@ def test_class_scoped_process_fixture_stays_class_grouped() -> None:
     first = FakeItem(
         "test_custom.py::TestProcess::test_first",
         fixtures={"backup_api": "class"},
+        test_class=True,
     )
     second = FakeItem(
         "test_custom.py::TestProcess::test_second",
         fixtures={"backup_api": "class"},
+        test_class=True,
     )
     unrelated = FakeItem(
         "test_custom.py::TestOtherProcess::test_first",
         fixtures={"backup_api": "class"},
+        test_class=True,
     )
 
     first_group = scheduling_group(first)  # type: ignore[arg-type]
@@ -172,6 +191,123 @@ def test_class_scoped_process_fixture_stays_class_grouped() -> None:
     assert first_group.startswith(f"{PROCESS_GROUP_PREFIX}class--")
     assert first_group == second_group
     assert first_group != unrelated_group
+
+
+def test_class_scoped_process_fixture_outside_class_stays_test_grouped() -> None:
+    first = FakeItem(
+        "test_custom.py::test_first",
+        fixtures={"backup_api": "class"},
+    )
+    second = FakeItem(
+        "test_custom.py::test_second",
+        fixtures={"backup_api": "class"},
+    )
+
+    first_group = scheduling_group(first)  # type: ignore[arg-type]
+    second_group = scheduling_group(second)  # type: ignore[arg-type]
+
+    assert first_group.startswith(f"{PROCESS_GROUP_PREFIX}test--")
+    assert first_group != second_group
+
+
+def test_package_scoped_process_fixture_stays_package_grouped() -> None:
+    @e2e_resource("antfly_process")
+    def package_runtime() -> None:
+        pass
+
+    first = FakeItem(
+        "pkg/test_first.py::test_process",
+        fixtures={"runtime": "package"},
+        fixture_baseids={"runtime": "pkg"},
+        fixture_functions={"runtime": package_runtime},
+    )
+    second = FakeItem(
+        "pkg/test_second.py::test_process",
+        fixtures={"runtime": "package"},
+        fixture_baseids={"runtime": "pkg"},
+        fixture_functions={"runtime": package_runtime},
+    )
+    unrelated = FakeItem(
+        "other/test_process.py::test_process",
+        fixtures={"runtime": "package"},
+        fixture_baseids={"runtime": "other"},
+        fixture_functions={"runtime": package_runtime},
+    )
+
+    first_group = scheduling_group(first)  # type: ignore[arg-type]
+    second_group = scheduling_group(second)  # type: ignore[arg-type]
+    unrelated_group = scheduling_group(unrelated)  # type: ignore[arg-type]
+
+    assert first_group.startswith(f"{PROCESS_GROUP_PREFIX}package--")
+    assert first_group == second_group
+    assert first_group != unrelated_group
+
+
+def test_root_package_process_fixtures_share_root_boundary() -> None:
+    @e2e_resource("antfly_process")
+    def first_runtime() -> None:
+        pass
+
+    @e2e_resource("antfly_process")
+    def second_runtime() -> None:
+        pass
+
+    first = FakeItem(
+        "test_first.py::test_process",
+        fixtures={"first_runtime": "package"},
+        fixture_functions={"first_runtime": first_runtime},
+    )
+    second = FakeItem(
+        "test_second.py::test_process",
+        fixtures={"second_runtime": "package"},
+        fixture_functions={"second_runtime": second_runtime},
+    )
+
+    first_group = scheduling_group(first)  # type: ignore[arg-type]
+    second_group = scheduling_group(second)  # type: ignore[arg-type]
+
+    assert first_group.startswith(f"{PROCESS_GROUP_PREFIX}package--")
+    assert first_group == second_group
+
+
+def test_effective_parameter_scope_overrides_fixture_definition_scope() -> None:
+    @e2e_resource("antfly_process")
+    def declared_runtime() -> None:
+        pass
+
+    widened_first = FakeItem(
+        "test_custom.py::test_first[value]",
+        fixtures={"stateful_api": "function"},
+        fixture_parameter_scopes={"stateful_api": "module"},
+    )
+    widened_second = FakeItem(
+        "test_custom.py::test_second[value]",
+        fixtures={"stateful_api": "function"},
+        fixture_parameter_scopes={"stateful_api": "module"},
+    )
+    narrowed = FakeItem(
+        "test_custom.py::test_narrowed[value]",
+        fixtures={"serverless_runtime": "session"},
+        fixture_parameter_scopes={"serverless_runtime": "function"},
+    )
+    narrowed_declaration = FakeItem(
+        "test_custom.py::test_declared_narrowed[value]",
+        fixtures={"runtime": "session"},
+        fixture_functions={"runtime": declared_runtime},
+        fixture_parameter_scopes={"runtime": "function"},
+    )
+
+    first_group = scheduling_group(widened_first)  # type: ignore[arg-type]
+    second_group = scheduling_group(widened_second)  # type: ignore[arg-type]
+    narrowed_group = scheduling_group(narrowed)  # type: ignore[arg-type]
+    narrowed_declaration_group = scheduling_group(  # type: ignore[arg-type]
+        narrowed_declaration
+    )
+
+    assert first_group.startswith(f"{PROCESS_GROUP_PREFIX}module--")
+    assert first_group == second_group
+    assert narrowed_group.startswith(f"{PROCESS_GROUP_PREFIX}test--")
+    assert narrowed_declaration_group.startswith(f"{PROCESS_GROUP_PREFIX}test--")
 
 
 def test_explicit_isolation_and_resource_override_fixture_inference() -> None:
@@ -255,6 +391,34 @@ class TestFixtureResourceClassScope:
 
         assert len(groups) == 1
         assert str(groups[0]).startswith(f"{PROCESS_GROUP_PREFIX}class--")
+
+
+def test_real_class_scoped_fixture_outside_class_uses_test_group(
+    request: pytest.FixtureRequest,
+    declared_class_process_fixture: None,
+) -> None:
+    del declared_class_process_fixture
+    groups = [mark.args[0] for mark in request.node.iter_markers("xdist_group")]
+
+    assert len(groups) == 1
+    assert str(groups[0]).startswith(f"{PROCESS_GROUP_PREFIX}test--")
+
+
+@pytest.mark.parametrize(
+    "declared_parametrized_process_fixture",
+    [None],
+    indirect=True,
+    scope="module",
+)
+def test_real_effective_parameter_scope_is_used(
+    request: pytest.FixtureRequest,
+    declared_parametrized_process_fixture: object,
+) -> None:
+    del declared_parametrized_process_fixture
+    groups = [mark.args[0] for mark in request.node.iter_markers("xdist_group")]
+
+    assert len(groups) == 1
+    assert str(groups[0]).startswith(f"{PROCESS_GROUP_PREFIX}module--")
 
 
 def test_inferred_session_identity_includes_fixture_provenance() -> None:
@@ -595,6 +759,28 @@ def test_new_session_identity_prefers_idle_clean_worker(tmp_path: Path) -> None:
     assert scheduler._next_eligible_scope(clean) == embedded_scope
 
 
+def test_session_owner_adds_identity_when_clean_worker_cannot_fit_scope(
+    tmp_path: Path,
+) -> None:
+    scheduler = IsolationAwareScheduling.__new__(IsolationAwareScheduling)
+    scheduler.process_slots = 2
+    scheduler.duration_history = DurationHistory(tmp_path / "durations.json")
+    owner = FakeWorker()
+    clean = FakeWorker()
+    combined_scope = (
+        f"{PERSISTENT_PROCESS_GROUP_PREFIX}embedded_standalone_runtime+"
+        "serverless_runtime--module--combined"
+    )
+    scheduler._persistent_processes = {owner: {"serverless_runtime"}}
+    scheduler.assigned_work = {owner: {}, clean: {}}
+    scheduler.workqueue = OrderedDict(
+        {combined_scope: {"test_combined.py::test_next": False}}
+    )
+
+    assert scheduler._next_eligible_scope(owner) == combined_scope
+    assert scheduler._next_eligible_scope(clean) is None
+
+
 def test_assigning_session_process_makes_worker_reservation_sticky(
     tmp_path: Path,
 ) -> None:
@@ -673,6 +859,101 @@ def test_idle_worker_waits_while_session_owner_rotates_to_release_slot(
 
     assert scheduler.remove_node(owner) is None
     assert waiter.sent == [[0]]
+
+
+def test_lightweight_runway_preserves_successor_for_session_rotation(
+    tmp_path: Path,
+) -> None:
+    scheduler = IsolationAwareScheduling.__new__(IsolationAwareScheduling)
+    scheduler.process_slots = 1
+    scheduler.duration_history = DurationHistory(tmp_path / "durations.json")
+    owner = FakeWorker(exitstatus=0)
+    successor = FakeWorker()
+    completed_scope = (
+        f"{PERSISTENT_PROCESS_GROUP_PREFIX}serverless_runtime--module--done"
+    )
+    transient_scope = f"{PROCESS_GROUP_PREFIX}test--waiting"
+    waiting_nodeid = "test_process.py::test_waiting"
+    scheduler._retiring_nodes = set()
+    scheduler._persistent_processes = {owner: {"serverless_runtime"}}
+    scheduler.assigned_work = {
+        owner: {completed_scope: {"test_serverless.py::test_done": True}},
+        successor: {"light--test--queued": {"test_light.py::test_queued": False}},
+    }
+    scheduler.workqueue = OrderedDict({transient_scope: {waiting_nodeid: False}})
+    scheduler.registered_collections = {
+        successor: ["test_light.py::test_queued", waiting_nodeid]
+    }
+
+    scheduler._reschedule(successor)
+
+    assert owner.shutting_down
+    assert owner in scheduler._retiring_nodes
+    assert not successor.shutting_down
+
+    assert scheduler.remove_node(owner) is None
+    assert successor.sent == [[1]]
+
+
+def test_lightweight_runway_waits_for_transient_slot_release(tmp_path: Path) -> None:
+    scheduler = IsolationAwareScheduling.__new__(IsolationAwareScheduling)
+    scheduler.process_slots = 2
+    scheduler.duration_history = DurationHistory(tmp_path / "durations.json")
+    owner = FakeWorker()
+    active = FakeWorker()
+    successor = FakeWorker()
+    scheduler._retiring_nodes = set()
+    scheduler._persistent_processes = {owner: {"serverless_runtime"}}
+    scheduler.assigned_work = {
+        owner: {},
+        active: {
+            f"{PROCESS_GROUP_PREFIX}test--active": {
+                "test_process.py::test_active": False
+            }
+        },
+        successor: {"light--test--queued": {"test_light.py::test_queued": False}},
+    }
+    scheduler.workqueue = OrderedDict(
+        {
+            f"{PROCESS_GROUP_PREFIX}test--waiting": {
+                "test_process.py::test_waiting": False
+            }
+        }
+    )
+
+    scheduler._reschedule(successor)
+
+    assert not owner.shutting_down
+    assert not successor.shutting_down
+    assert scheduler._retiring_nodes == set()
+
+
+def test_lightweight_runway_waits_when_session_owner_can_continue(
+    tmp_path: Path,
+) -> None:
+    scheduler = IsolationAwareScheduling.__new__(IsolationAwareScheduling)
+    scheduler.process_slots = 1
+    scheduler.duration_history = DurationHistory(tmp_path / "durations.json")
+    owner = FakeWorker()
+    successor = FakeWorker()
+    matching_scope = (
+        f"{PERSISTENT_PROCESS_GROUP_PREFIX}serverless_runtime--module--next"
+    )
+    scheduler._retiring_nodes = set()
+    scheduler._persistent_processes = {owner: {"serverless_runtime"}}
+    scheduler.assigned_work = {
+        owner: {},
+        successor: {"light--test--queued": {"test_light.py::test_queued": False}},
+    }
+    scheduler.workqueue = OrderedDict(
+        {matching_scope: {"test_serverless.py::test_next": False}}
+    )
+
+    scheduler._reschedule(successor)
+
+    assert not owner.shutting_down
+    assert not successor.shutting_down
+    assert scheduler._retiring_nodes == set()
 
 
 def test_intentionally_retired_worker_requeues_only_incomplete_work(

--- a/zig/e2e/antfly/test_e2e_scheduler.py
+++ b/zig/e2e/antfly/test_e2e_scheduler.py
@@ -121,6 +121,26 @@ def test_process_slot_configuration_rejects_non_positive_values(slots: int) -> N
         pytest_configure(config)  # type: ignore[arg-type]
 
 
+def test_parallel_configuration_rejects_incompatible_distribution_mode() -> None:
+    options = {
+        "e2e_process_slots": 2,
+        "dist": "load",
+        "tx": ["popen", "popen"],
+    }
+    config = SimpleNamespace(
+        getoption=lambda name, default=None: options.get(name, default)
+    )
+
+    with pytest.raises(
+        pytest.UsageError,
+        match=(
+            "parallel Antfly E2E requires --dist=loadgroup so fixture isolation "
+            "and --e2e-process-slots remain enforced"
+        ),
+    ):
+        pytest_configure(config)  # type: ignore[arg-type]
+
+
 def test_fixture_resource_decorator_rejects_inverted_order() -> None:
     def fixture_function() -> None:
         pass

--- a/zig/e2e/antfly/test_e2e_scheduler.py
+++ b/zig/e2e/antfly/test_e2e_scheduler.py
@@ -31,6 +31,8 @@ from e2e_scheduler import (
     _consolidate_scheduling_groups,
     e2e_resource,
     normalize_nodeid,
+    pytest_addoption,
+    pytest_configure,
     scheduling_group,
 )
 
@@ -95,6 +97,28 @@ class FakeWorker:
 
 def mark(name: str, *args: object, **kwargs: object) -> pytest.Mark:
     return pytest.Mark(name, args, kwargs, _ispytest=True)
+
+
+def test_process_slot_environment_default_uses_pytest_integer_parser(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ANTFLY_E2E_PROCESS_SLOTS", "invalid")
+
+    with pytest.raises(pytest.UsageError, match="invalid int value: 'invalid'"):
+        parser = pytest.Parser(_ispytest=True)
+        pytest_addoption(parser)
+        parser.parse([])
+
+
+@pytest.mark.parametrize("slots", [0, -1])
+def test_process_slot_configuration_rejects_non_positive_values(slots: int) -> None:
+    config = SimpleNamespace(getoption=lambda name: slots)
+
+    with pytest.raises(
+        pytest.UsageError,
+        match="--e2e-process-slots must be a positive integer",
+    ):
+        pytest_configure(config)  # type: ignore[arg-type]
 
 
 def test_fixture_resource_decorator_rejects_inverted_order() -> None:

--- a/zig/e2e/antfly/test_e2e_scheduler.py
+++ b/zig/e2e/antfly/test_e2e_scheduler.py
@@ -22,10 +22,12 @@ from types import SimpleNamespace
 import pytest
 
 from e2e_scheduler import (
+    MIXED_PROCESS_GROUP_PREFIX,
     PERSISTENT_PROCESS_GROUP_PREFIX,
     PROCESS_GROUP_PREFIX,
     DurationHistory,
     IsolationAwareScheduling,
+    _consolidate_scheduling_groups,
     normalize_nodeid,
     scheduling_group,
 )
@@ -38,6 +40,7 @@ class FakeItem:
         *,
         fixtures: dict[str, str] | None = None,
         markers: list[pytest.Mark] | None = None,
+        params: dict[str, object] | None = None,
     ):
         self.nodeid = nodeid
         fixture_scopes = fixtures or {}
@@ -49,6 +52,8 @@ class FakeItem:
             }
         )
         self._markers = markers or []
+        if params is not None:
+            self.callspec = SimpleNamespace(params=params)
 
     def iter_markers(self, name: str):
         return (mark for mark in self._markers if mark.name == name)
@@ -60,11 +65,15 @@ class FakeItem:
 class FakeWorker:
     def __init__(self, *, exitstatus: int | None = None):
         self.sent: list[list[int]] = []
+        self.shutting_down = False
         if exitstatus is not None:
             self.workeroutput = {"exitstatus": exitstatus}
 
     def send_runtest_some(self, indexes: list[int]) -> None:
         self.sent.append(indexes)
+
+    def shutdown(self) -> None:
+        self.shutting_down = True
 
 
 def mark(name: str, *args: object, **kwargs: object) -> pytest.Mark:
@@ -102,7 +111,9 @@ def test_reused_or_session_process_fixture_stays_module_grouped() -> None:
     )
     assert "module--" in scheduling_group(reused)  # type: ignore[arg-type]
     session_group = scheduling_group(session_owned)  # type: ignore[arg-type]
-    assert session_group.startswith(f"{PERSISTENT_PROCESS_GROUP_PREFIX}module--")
+    assert session_group.startswith(
+        f"{PERSISTENT_PROCESS_GROUP_PREFIX}serverless_runtime--module--"
+    )
 
 
 def test_explicit_isolation_and_resource_override_fixture_inference() -> None:
@@ -115,6 +126,67 @@ def test_explicit_isolation_and_resource_override_fixture_inference() -> None:
     )
     group = scheduling_group(item)  # type: ignore[arg-type]
     assert group.startswith(f"{PROCESS_GROUP_PREFIX}test--")
+
+
+def test_declared_session_process_has_stable_identity_and_module_scope() -> None:
+    item = FakeItem(
+        "test_custom.py::test_session_server",
+        markers=[
+            mark(
+                "e2e_resource",
+                "antfly_process",
+                lifetime="session",
+                identity="custom_runtime",
+            ),
+        ],
+    )
+
+    group = scheduling_group(item)  # type: ignore[arg-type]
+
+    assert group.startswith(
+        f"{PERSISTENT_PROCESS_GROUP_PREFIX}custom_runtime--module--"
+    )
+
+
+def test_dynamic_serverless_table_parameter_has_persistent_identity() -> None:
+    item = FakeItem(
+        "test_foreign_sources.py::test_query[serverless]",
+        fixtures={"table_api": "function"},
+        params={"table_api": "serverless"},
+    )
+
+    group = scheduling_group(item)  # type: ignore[arg-type]
+
+    assert group.startswith(
+        f"{PERSISTENT_PROCESS_GROUP_PREFIX}serverless_runtime--module--"
+    )
+
+
+def test_shared_group_uses_strictest_resource_policy_for_every_item() -> None:
+    stateful = FakeItem(
+        "test_foreign_sources.py::test_query[stateful]",
+        fixtures={"table_api": "function"},
+        markers=[mark("reuse_antfly_process")],
+        params={"table_api": "stateful"},
+    )
+    serverless = FakeItem(
+        "test_foreign_sources.py::test_query[serverless]",
+        fixtures={"table_api": "function"},
+        markers=[mark("reuse_antfly_process")],
+        params={"table_api": "serverless"},
+    )
+
+    groups = _consolidate_scheduling_groups(
+        [
+            scheduling_group(stateful),  # type: ignore[arg-type]
+            scheduling_group(serverless),  # type: ignore[arg-type]
+        ]
+    )
+
+    assert groups[0] == groups[1]
+    assert groups[0].startswith(
+        f"{MIXED_PROCESS_GROUP_PREFIX}serverless_runtime--module--"
+    )
 
 
 def test_duration_history_round_trips_and_smooths_observations(tmp_path: Path) -> None:
@@ -141,7 +213,7 @@ def test_scheduler_prefers_longest_eligible_work_without_exceeding_process_slots
     scheduler = IsolationAwareScheduling.__new__(IsolationAwareScheduling)
     scheduler.process_slots = 1
     scheduler.duration_history = DurationHistory(tmp_path / "durations.json")
-    scheduler._persistent_process_workers = set()
+    scheduler._persistent_processes = {}
     scheduler.duration_history.tests = {
         "test_process.py::test_long": {"seconds": 20.0, "samples": 1},
         "test_light.py::test_short": {"seconds": 1.0, "samples": 1},
@@ -179,7 +251,7 @@ def test_scheduler_reserves_process_capacity_per_worker_not_queued_unit(
     scheduler = IsolationAwareScheduling.__new__(IsolationAwareScheduling)
     scheduler.process_slots = 1
     scheduler.duration_history = DurationHistory(tmp_path / "durations.json")
-    scheduler._persistent_process_workers = set()
+    scheduler._persistent_processes = {}
     process_scope = f"{PROCESS_GROUP_PREFIX}test--next"
     scheduler.workqueue = OrderedDict(
         {process_scope: {"test_process.py::test_next": False}}
@@ -198,7 +270,7 @@ def test_scheduler_reserves_process_capacity_per_worker_not_queued_unit(
         other_node: {},
     }
 
-    assert scheduler._reserved_process_workers() == 1
+    assert scheduler._reserved_process_slots() == 1
     assert scheduler._next_eligible_scope(reserved_node) == process_scope
     assert scheduler._next_eligible_scope(other_node) is None
 
@@ -210,12 +282,15 @@ def test_session_process_reservation_lasts_for_worker_lifetime(
     scheduler.process_slots = 1
     scheduler.duration_history = DurationHistory(tmp_path / "durations.json")
     transient_scope = f"{PROCESS_GROUP_PREFIX}test--transient"
+    matching_scope = (
+        f"{PERSISTENT_PROCESS_GROUP_PREFIX}serverless_runtime--module--next"
+    )
     owner = object()
     other_node = object()
-    scheduler._persistent_process_workers = {owner}
+    scheduler._persistent_processes = {owner: {"serverless_runtime"}}
     scheduler.assigned_work = {
         owner: {
-            f"{PERSISTENT_PROCESS_GROUP_PREFIX}module--done": {
+            f"{PERSISTENT_PROCESS_GROUP_PREFIX}serverless_runtime--module--done": {
                 "test_serverless.py::test_done": True,
             }
         },
@@ -224,12 +299,82 @@ def test_session_process_reservation_lasts_for_worker_lifetime(
     scheduler.workqueue = OrderedDict(
         {
             transient_scope: {"test_process.py::test_transient": False},
+            matching_scope: {"test_serverless.py::test_next": False},
         }
     )
 
-    assert scheduler._reserved_process_workers() == 1
-    assert scheduler._next_eligible_scope(owner) == transient_scope
+    assert scheduler._reserved_process_slots() == 1
+    assert scheduler._next_eligible_scope(owner) == matching_scope
     assert scheduler._next_eligible_scope(other_node) is None
+
+
+def test_transient_work_needs_an_additional_slot_on_session_owner(
+    tmp_path: Path,
+) -> None:
+    scheduler = IsolationAwareScheduling.__new__(IsolationAwareScheduling)
+    scheduler.process_slots = 2
+    scheduler.duration_history = DurationHistory(tmp_path / "durations.json")
+    owner = object()
+    other_node = object()
+    transient_scope = f"{PROCESS_GROUP_PREFIX}test--transient"
+    scheduler._persistent_processes = {owner: {"serverless_runtime"}}
+    scheduler.assigned_work = {owner: {}, other_node: {}}
+    scheduler.workqueue = OrderedDict(
+        {transient_scope: {"test_process.py::test_transient": False}}
+    )
+
+    assert scheduler._next_eligible_scope(owner) == transient_scope
+    scheduler.assigned_work[owner][transient_scope] = scheduler.workqueue.pop(
+        transient_scope
+    )
+    assert scheduler._reserved_process_slots() == 2
+    scheduler.workqueue = OrderedDict(
+        {
+            f"{PROCESS_GROUP_PREFIX}test--blocked": {
+                "test_process.py::test_blocked": False
+            }
+        }
+    )
+    assert scheduler._next_eligible_scope(other_node) is None
+
+
+def test_mixed_group_reserves_persistent_and_transient_slots(tmp_path: Path) -> None:
+    scheduler = IsolationAwareScheduling.__new__(IsolationAwareScheduling)
+    scheduler.process_slots = 2
+    scheduler.duration_history = DurationHistory(tmp_path / "durations.json")
+    scheduler._persistent_processes = {}
+    node = object()
+    mixed_scope = f"{MIXED_PROCESS_GROUP_PREFIX}serverless_runtime--module--mixed"
+    scheduler.assigned_work = {node: {}}
+    scheduler.workqueue = OrderedDict(
+        {mixed_scope: {"test_mixed.py::test_case": False}}
+    )
+
+    assert scheduler._additional_process_slots(node, mixed_scope) == 2
+    assert scheduler._next_eligible_scope(node) == mixed_scope
+
+    scheduler.process_slots = 1
+    with pytest.raises(pytest.UsageError, match="requires 2 Antfly process slots"):
+        scheduler._next_eligible_scope(node)
+
+
+def test_new_session_identity_prefers_idle_clean_worker(tmp_path: Path) -> None:
+    scheduler = IsolationAwareScheduling.__new__(IsolationAwareScheduling)
+    scheduler.process_slots = 2
+    scheduler.duration_history = DurationHistory(tmp_path / "durations.json")
+    owner = FakeWorker()
+    clean = FakeWorker()
+    embedded_scope = (
+        f"{PERSISTENT_PROCESS_GROUP_PREFIX}embedded_standalone_runtime--module--next"
+    )
+    scheduler._persistent_processes = {owner: {"serverless_runtime"}}
+    scheduler.assigned_work = {owner: {}, clean: {}}
+    scheduler.workqueue = OrderedDict(
+        {embedded_scope: {"test_standalone.py::test_next": False}}
+    )
+
+    assert scheduler._next_eligible_scope(owner) is None
+    assert scheduler._next_eligible_scope(clean) == embedded_scope
 
 
 def test_assigning_session_process_makes_worker_reservation_sticky(
@@ -238,10 +383,10 @@ def test_assigning_session_process_makes_worker_reservation_sticky(
     scheduler = IsolationAwareScheduling.__new__(IsolationAwareScheduling)
     scheduler.process_slots = 1
     scheduler.duration_history = DurationHistory(tmp_path / "durations.json")
-    scheduler._persistent_process_workers = set()
+    scheduler._persistent_processes = {}
     node = FakeWorker()
     nodeid = "test_serverless.py::test_session"
-    scope = f"{PERSISTENT_PROCESS_GROUP_PREFIX}module--serverless"
+    scope = f"{PERSISTENT_PROCESS_GROUP_PREFIX}serverless_runtime--module--serverless"
     scheduler.workqueue = OrderedDict({scope: {nodeid: False}})
     scheduler.assigned_work = {node: {}}
     scheduler.registered_collections = {node: [nodeid]}
@@ -249,9 +394,9 @@ def test_assigning_session_process_makes_worker_reservation_sticky(
     scheduler._assign_work_unit(node)
 
     assert node.sent == [[0]]
-    assert node in scheduler._persistent_process_workers
+    assert scheduler._persistent_processes[node] == {"serverless_runtime"}
     scheduler.assigned_work[node][scope][nodeid] = True
-    assert scheduler._reserved_process_workers() == 1
+    assert scheduler._reserved_process_slots() == 1
 
 
 def test_transient_process_capacity_is_released_after_completion(
@@ -260,7 +405,7 @@ def test_transient_process_capacity_is_released_after_completion(
     scheduler = IsolationAwareScheduling.__new__(IsolationAwareScheduling)
     scheduler.process_slots = 1
     scheduler.duration_history = DurationHistory(tmp_path / "durations.json")
-    scheduler._persistent_process_workers = set()
+    scheduler._persistent_processes = {}
     first_node = object()
     other_node = object()
     next_scope = f"{PROCESS_GROUP_PREFIX}test--next"
@@ -276,8 +421,40 @@ def test_transient_process_capacity_is_released_after_completion(
         {next_scope: {"test_process.py::test_next": False}}
     )
 
-    assert scheduler._reserved_process_workers() == 0
+    assert scheduler._reserved_process_slots() == 0
     assert scheduler._next_eligible_scope(other_node) == next_scope
+
+
+def test_idle_worker_waits_while_session_owner_rotates_to_release_slot(
+    tmp_path: Path,
+) -> None:
+    scheduler = IsolationAwareScheduling.__new__(IsolationAwareScheduling)
+    scheduler.process_slots = 1
+    scheduler.duration_history = DurationHistory(tmp_path / "durations.json")
+    owner = FakeWorker(exitstatus=0)
+    waiter = FakeWorker()
+    completed_scope = (
+        f"{PERSISTENT_PROCESS_GROUP_PREFIX}serverless_runtime--module--done"
+    )
+    transient_scope = f"{PROCESS_GROUP_PREFIX}test--waiting"
+    waiting_nodeid = "test_process.py::test_waiting"
+    scheduler._retiring_nodes = set()
+    scheduler._persistent_processes = {owner: {"serverless_runtime"}}
+    scheduler.assigned_work = {
+        owner: {completed_scope: {"test_serverless.py::test_done": True}},
+        waiter: {},
+    }
+    scheduler.workqueue = OrderedDict({transient_scope: {waiting_nodeid: False}})
+    scheduler.registered_collections = {waiter: [waiting_nodeid]}
+
+    scheduler._reschedule(waiter)
+    assert not waiter.shutting_down
+    scheduler._reschedule(owner)
+    assert owner.shutting_down
+    assert owner in scheduler._retiring_nodes
+
+    assert scheduler.remove_node(owner) is None
+    assert waiter.sent == [[0]]
 
 
 def test_intentionally_retired_worker_requeues_only_incomplete_work(
@@ -288,7 +465,7 @@ def test_intentionally_retired_worker_requeues_only_incomplete_work(
     scheduler.duration_history = DurationHistory(tmp_path / "durations.json")
     retired_node = FakeWorker(exitstatus=0)
     scheduler._retiring_nodes = {retired_node}
-    scheduler._persistent_process_workers = {retired_node}
+    scheduler._persistent_processes = {retired_node: {"serverless_runtime"}}
     scheduler.workqueue = OrderedDict()
     scheduler.assigned_work = {
         retired_node: {
@@ -301,7 +478,7 @@ def test_intentionally_retired_worker_requeues_only_incomplete_work(
     assert scheduler.workqueue == {
         "light--test--pending": {"test_light.py::test_pending": False}
     }
-    assert retired_node not in scheduler._persistent_process_workers
+    assert retired_node not in scheduler._persistent_processes
 
 
 @pytest.mark.parametrize("exitstatus", [None, 2, 3])
@@ -314,7 +491,7 @@ def test_retiring_worker_crash_is_reported_and_requeued(
     scheduler.duration_history = DurationHistory(tmp_path / "durations.json")
     crashed_node = FakeWorker(exitstatus=exitstatus)
     scheduler._retiring_nodes = {crashed_node}
-    scheduler._persistent_process_workers = {crashed_node}
+    scheduler._persistent_processes = {crashed_node: {"serverless_runtime"}}
     scheduler.workqueue = OrderedDict()
     scheduler.assigned_work = {
         crashed_node: {
@@ -327,4 +504,4 @@ def test_retiring_worker_crash_is_reported_and_requeued(
         "light--test--pending": {"test_light.py::test_pending": False}
     }
     assert crashed_node not in scheduler._retiring_nodes
-    assert crashed_node not in scheduler._persistent_process_workers
+    assert crashed_node not in scheduler._persistent_processes

--- a/zig/e2e/antfly/test_e2e_scheduler.py
+++ b/zig/e2e/antfly/test_e2e_scheduler.py
@@ -1498,3 +1498,39 @@ def test_crash_recovery_preserves_global_duration_priority(tmp_path: Path) -> No
     assert list(scheduler.workqueue) == [transient_scope]
     assert scheduler._persistent_processes[clean] == {"runtime_b"}
     assert scheduler._reserved_process_slots() == 2
+
+
+def test_completed_worker_removal_immediately_reuses_released_process_slot(
+    tmp_path: Path,
+) -> None:
+    scheduler = IsolationAwareScheduling.__new__(IsolationAwareScheduling)
+    scheduler.process_slots = 1
+    scheduler.duration_history = DurationHistory(tmp_path / "durations.json")
+    owner = FakeWorker(exitstatus=2)
+    clean = FakeWorker()
+    owner_nodeid = "test_a.py::test_done"
+    queued_nodeid = "test_b.py::test_waiting"
+    owner_scope = f"{PERSISTENT_PROCESS_GROUP_PREFIX}runtime_a--module--done"
+    queued_scope = f"{PERSISTENT_PROCESS_GROUP_PREFIX}runtime_b--module--waiting"
+    collection = [owner_nodeid, queued_nodeid]
+    scheduler._retiring_nodes = set()
+    scheduler._starting_replacements = set()
+    scheduler._collecting_nodes = set()
+    scheduler._transient_handoffs = set()
+    scheduler._persistent_processes = {owner: {"runtime_a"}}
+    scheduler.assigned_work = {
+        owner: {owner_scope: {owner_nodeid: True}},
+        clean: {},
+    }
+    scheduler.registered_collections = {
+        owner: collection,
+        clean: collection,
+    }
+    scheduler.workqueue = OrderedDict({queued_scope: {queued_nodeid: False}})
+
+    assert scheduler.remove_node(owner) is None
+
+    assert clean.sent == [[1]]
+    assert scheduler.workqueue == {}
+    assert scheduler._persistent_processes == {clean: {"runtime_b"}}
+    assert scheduler._reserved_process_slots() == 1

--- a/zig/e2e/antfly/test_e2e_scheduler.py
+++ b/zig/e2e/antfly/test_e2e_scheduler.py
@@ -20,8 +20,8 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import e2e_scheduler as e2e_scheduler_module
 import pytest
-
 from e2e_scheduler import (
     MIXED_PROCESS_GROUP_PREFIX,
     PERSISTENT_PROCESS_GROUP_PREFIX,
@@ -589,6 +589,41 @@ def test_duration_history_merges_observations_from_stale_writers(
     }
 
 
+def test_duration_reports_exclude_skips_but_keep_full_executed_protocol(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    history = DurationHistory(tmp_path / "durations.json")
+    monkeypatch.setattr(e2e_scheduler_module, "_duration_history", history)
+    monkeypatch.setattr(e2e_scheduler_module, "_duration_report_totals", {})
+    monkeypatch.setattr(e2e_scheduler_module, "_executed_duration_nodeids", set())
+
+    for when, duration in (("setup", 2.0), ("call", 0.1), ("teardown", 0.2)):
+        e2e_scheduler_module.pytest_runtest_logreport(
+            SimpleNamespace(
+                nodeid="test_optional.py::test_skipped@group",
+                duration=duration,
+                when=when,
+                skipped=when == "call",
+            )
+        )
+    for when, duration in (("setup", 3.0), ("call", 4.0), ("teardown", 1.0)):
+        e2e_scheduler_module.pytest_runtest_logreport(
+            SimpleNamespace(
+                nodeid="test_real.py::test_executed@group",
+                duration=duration,
+                when=when,
+                skipped=False,
+            )
+        )
+
+    e2e_scheduler_module._flush_duration_reports()
+
+    assert history.observed == {"test_real.py::test_executed": 8.0}
+    assert e2e_scheduler_module._duration_report_totals == {}
+    assert e2e_scheduler_module._executed_duration_nodeids == set()
+
+
 def test_scheduler_prefers_longest_eligible_work_without_exceeding_process_slots(
     tmp_path: Path,
 ) -> None:
@@ -829,6 +864,89 @@ def test_transient_process_capacity_is_released_after_completion(
     assert scheduler._next_eligible_scope(other_node) == next_scope
 
 
+def test_final_transient_test_hands_its_slot_to_persistent_runway(
+    tmp_path: Path,
+) -> None:
+    scheduler = IsolationAwareScheduling.__new__(IsolationAwareScheduling)
+    scheduler.process_slots = 1
+    scheduler.duration_history = DurationHistory(tmp_path / "durations.json")
+    worker = FakeWorker()
+    transient_scope = f"{PROCESS_GROUP_PREFIX}test--transient"
+    persistent_scope = (
+        f"{PERSISTENT_PROCESS_GROUP_PREFIX}serverless_runtime--module--next"
+    )
+    transient_nodeid = f"test_transient.py::test_current@{transient_scope}"
+    persistent_nodeid = f"test_serverless.py::test_next@{persistent_scope}"
+    scheduler._retiring_nodes = set()
+    scheduler._starting_replacements = set()
+    scheduler._transient_handoffs = set()
+    scheduler._persistent_processes = {}
+    scheduler.assigned_work = {
+        worker: {transient_scope: {transient_nodeid: False}},
+    }
+    scheduler.workqueue = OrderedDict({persistent_scope: {persistent_nodeid: False}})
+    scheduler.registered_collections = {worker: [transient_nodeid, persistent_nodeid]}
+
+    scheduler._reschedule(worker)
+
+    assert worker.sent == [[1]]
+    assert not worker.shutting_down
+    assert scheduler._persistent_processes[worker] == {"serverless_runtime"}
+    assert worker in scheduler._transient_handoffs
+    assert scheduler._reserved_process_slots() == 1
+
+    scheduler.mark_test_complete(worker, 0)
+
+    assert worker not in scheduler._transient_handoffs
+    assert scheduler._reserved_process_slots() == 1
+
+
+def test_last_resource_worker_starts_replacement_before_retirement(
+    tmp_path: Path,
+) -> None:
+    scheduler = IsolationAwareScheduling.__new__(IsolationAwareScheduling)
+    scheduler.process_slots = 1
+    scheduler.duration_history = DurationHistory(tmp_path / "durations.json")
+    owner = FakeWorker()
+    replacement = FakeWorker()
+    cloned: list[FakeWorker] = []
+
+    def clone_node(node: FakeWorker) -> FakeWorker:
+        assert node is owner
+        cloned.append(replacement)
+        return replacement
+
+    controller = SimpleNamespace(_clone_node=clone_node)
+    scheduler.config = SimpleNamespace(
+        pluginmanager=SimpleNamespace(
+            getplugin=lambda name: controller if name == "dsession" else None
+        )
+    )
+    owner_scope = f"{PERSISTENT_PROCESS_GROUP_PREFIX}serverless_runtime--module--owner"
+    queued_scope = f"{PROCESS_GROUP_PREFIX}test--queued"
+    scheduler._retiring_nodes = set()
+    scheduler._starting_replacements = set()
+    scheduler._transient_handoffs = set()
+    scheduler._persistent_processes = {owner: {"serverless_runtime"}}
+    scheduler.assigned_work = {
+        owner: {owner_scope: {"test_owner.py::test_current": False}},
+    }
+    scheduler.workqueue = OrderedDict(
+        {queued_scope: {"test_transient.py::test_queued": False}}
+    )
+
+    scheduler._reschedule(owner)
+
+    assert cloned == [replacement]
+    assert replacement in scheduler._starting_replacements
+    assert owner in scheduler._retiring_nodes
+    assert owner.shutting_down
+
+    scheduler.add_node(replacement)
+    assert replacement not in scheduler._starting_replacements
+    assert replacement in scheduler.assigned_work
+
+
 def test_idle_worker_waits_while_session_owner_rotates_to_release_slot(
     tmp_path: Path,
 ) -> None:
@@ -905,7 +1023,7 @@ def test_process_runway_preserves_last_successor_for_queued_work(
     second = FakeWorker()
     first_scope = f"{PROCESS_GROUP_PREFIX}test--first"
     second_scope = f"{PROCESS_GROUP_PREFIX}test--second"
-    queued_scope = f"{PERSISTENT_PROCESS_GROUP_PREFIX}new_runtime--module--queued"
+    queued_scope = f"{MIXED_PROCESS_GROUP_PREFIX}new_runtime--module--queued"
     scheduler._retiring_nodes = set()
     scheduler._persistent_processes = {}
     scheduler.assigned_work = {

--- a/zig/e2e/antfly/test_e2e_scheduler.py
+++ b/zig/e2e/antfly/test_e2e_scheduler.py
@@ -18,6 +18,7 @@ import json
 from collections import OrderedDict
 from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import patch
 
 import pytest
 
@@ -91,13 +92,9 @@ def test_fixture_resource_decorator_rejects_inverted_order() -> None:
 
 
 @pytest.fixture(scope="session")
-@e2e_resource(
-    "antfly_process",
-    lifetime="session",
-    identity="declared_session_process_fixture",
-)
+@e2e_resource("antfly_process")
 def declared_session_process_fixture() -> None:
-    """Exercise resource metadata attached to a real pytest fixture."""
+    """Exercise inferred lifetime metadata on a real session fixture."""
 
 
 @pytest.fixture(scope="module")
@@ -292,6 +289,39 @@ def test_duration_history_ignores_invalid_numeric_entries(tmp_path: Path) -> Non
     history = DurationHistory(path)
 
     assert history.tests == {"valid": {"seconds": 2.0, "samples": 1}}
+
+
+def test_duration_history_save_failure_is_non_fatal(tmp_path: Path) -> None:
+    history = DurationHistory(tmp_path / "durations.json")
+    history.observe("test_a.py::test_case", 1.0)
+
+    with patch("e2e_scheduler.tempfile.mkstemp", side_effect=OSError("cache full")):
+        error = history.save()
+
+    assert isinstance(error, OSError)
+    assert str(error) == "cache full"
+
+
+def test_duration_history_merges_observations_from_stale_writers(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "durations.json"
+    first = DurationHistory(path)
+    second = DurationHistory(path)
+    first.observe("test_a.py::test_shared", 1.0)
+    first.observe("test_a.py::test_first", 2.0)
+    second.observe("test_a.py::test_shared", 3.0)
+    second.observe("test_a.py::test_second", 4.0)
+
+    assert first.save() is None
+    assert second.save() is None
+
+    reloaded = DurationHistory(path)
+    assert reloaded.tests == {
+        "test_a.py::test_first": {"seconds": 2.0, "samples": 1},
+        "test_a.py::test_second": {"seconds": 4.0, "samples": 1},
+        "test_a.py::test_shared": {"seconds": 1.6, "samples": 2},
+    }
 
 
 def test_scheduler_prefers_longest_eligible_work_without_exceeding_process_slots(

--- a/zig/e2e/antfly/test_e2e_scheduler.py
+++ b/zig/e2e/antfly/test_e2e_scheduler.py
@@ -1441,3 +1441,60 @@ def test_retiring_worker_crash_is_reported_and_requeued(
     }
     assert crashed_node not in scheduler._retiring_nodes
     assert crashed_node not in scheduler._persistent_processes
+
+
+def test_crash_recovery_preserves_global_duration_priority(tmp_path: Path) -> None:
+    scheduler = IsolationAwareScheduling.__new__(IsolationAwareScheduling)
+    scheduler.process_slots = 2
+    scheduler.duration_history = DurationHistory(tmp_path / "durations.json")
+    owner = FakeWorker()
+    clean = FakeWorker()
+    crashed = FakeWorker(exitstatus=2)
+    owner_nodeid = "test_a.py::test_done"
+    persistent_nodeid = "test_b.py::test_long"
+    transient_nodeid = "test_transient.py::test_short"
+    crash_nodeid = "test_crash.py::test_retry"
+    owner_scope = f"{PERSISTENT_PROCESS_GROUP_PREFIX}runtime_a--module--done"
+    persistent_scope = f"{PERSISTENT_PROCESS_GROUP_PREFIX}runtime_b--module--long"
+    transient_scope = f"{PROCESS_GROUP_PREFIX}test--short"
+    crash_scope = "light--test--crash"
+    collection = [
+        owner_nodeid,
+        persistent_nodeid,
+        transient_nodeid,
+        crash_nodeid,
+    ]
+    scheduler.duration_history.tests = {
+        persistent_nodeid: {"seconds": 100.0, "samples": 1},
+        transient_nodeid: {"seconds": 1.0, "samples": 1},
+        crash_nodeid: {"seconds": 0.1, "samples": 1},
+    }
+    scheduler._retiring_nodes = set()
+    scheduler._starting_replacements = set()
+    scheduler._collecting_nodes = set()
+    scheduler._transient_handoffs = set()
+    scheduler._persistent_processes = {owner: {"runtime_a"}}
+    scheduler.assigned_work = {
+        owner: {owner_scope: {owner_nodeid: True}},
+        clean: {},
+        crashed: {crash_scope: {crash_nodeid: False}},
+    }
+    scheduler.registered_collections = {
+        owner: collection,
+        clean: collection,
+        crashed: collection,
+    }
+    scheduler.workqueue = OrderedDict(
+        {
+            persistent_scope: {persistent_nodeid: False},
+            transient_scope: {transient_nodeid: False},
+        }
+    )
+
+    assert scheduler.remove_node(crashed) == crash_nodeid
+
+    assert clean.sent == [[1]]
+    assert owner.sent == [[3]]
+    assert list(scheduler.workqueue) == [transient_scope]
+    assert scheduler._persistent_processes[clean] == {"runtime_b"}
+    assert scheduler._reserved_process_slots() == 2

--- a/zig/e2e/antfly/test_extensions.py
+++ b/zig/e2e/antfly/test_extensions.py
@@ -240,6 +240,7 @@ def test_extension_package_routes_match_standalone_and_distributed(extension_ser
     _assert_extension_package_routes(extension_server)
 
 
+@pytest.mark.e2e_resource("antfly_process")
 def test_extension_memoryaf_wasm_runtime_required() -> None:
     if not os.environ.get("ANTFLY_WASMTIME_LIB"):
         pytest.skip("set ANTFLY_WASMTIME_LIB to run the required Wasmtime extension runtime e2e")


### PR DESCRIPTION
## Summary

- persist per-test E2E duration history locally and in the ARC cache, then schedule the longest eligible isolation group first
- infer test/module isolation from Antfly fixture scope and existing reuse/fresh markers, with explicit resource and isolation markers for custom cases
- separate pytest worker count (default 4) from the concurrent Antfly process/cluster budget (default 2)
- preserve xdist fixture lifecycles and safely retire lightweight-only workers when constrained process work remains

## Validation

- focused scheduler unit tests: 8 passed
- CI wrapper smoke with 4 workers: 8 passed
- distributed scheduler and port-reservation regression: 29 passed
- constrained mixed process/light protocol stress: 12 passed
- real Antfly smoke covering shared module runtime plus fresh backup runtime with 1 process slot: 3 passed
- full Antfly E2E collection: 297 tests
- ruff, black, shellcheck, bash syntax, actionlint, and git diff checks