### PR TITLE
Reconstruct PDF whitespace and isolate OCR page failures

### DIFF
--- a/zig/build.zig
+++ b/zig/build.zig
@@ -4510,6 +4510,7 @@ pub fn build(b: *std.Build) void {
             "document-wide OCR resource failure preserves units and marks pending pages",
             "OCR pending metadata construction is allocation-failure safe",
             "generated text provider config is validated while parsing extraction config",
+            "PDF text regions use reconstructed output spans",
             "public enrichment validation rejects invalid execution and producer config",
             "enrichment runtime document extraction manifest uses v2 range and merge shape",
             "enrichment runtime document extraction state parses byte-array keys",

--- a/zig/build.zig
+++ b/zig/build.zig
@@ -4507,6 +4507,7 @@ pub fn build(b: *std.Build) void {
             "retained document collection allocations compose with the hard working-set cap",
             "document replay payloads are admitted before persistent allocation",
             "document extraction generated OCR bypasses unsupported native batch",
+            "document-wide OCR resource failure preserves units and marks pending pages",
             "OCR pending metadata construction is allocation-failure safe",
             "generated text provider config is validated while parsing extraction config",
             "public enrichment validation rejects invalid execution and producer config",

--- a/zig/lib/pdf/src/reader.zig
+++ b/zig/lib/pdf/src/reader.zig
@@ -1802,8 +1802,6 @@ pub const Reader = struct {
         var layout_runs = std.ArrayList(LayoutTextRun).empty;
         defer layout_runs.deinit(self.alloc);
         defer for (layout_runs.items) |*run| run.deinit(self.alloc);
-        var text_parser = TextContentParser.init(self.alloc, &canonical);
-        defer text_parser.deinit();
         var layout_parser = try PositionedTextParser.init(self.alloc, .{ .layout = &layout_runs }, .{}, &.{}, .nonzero);
         defer layout_parser.deinit();
 
@@ -1815,6 +1813,12 @@ pub const Reader = struct {
         for (streams) |*stream| {
             const decoded = try self.readDecodedStreamData(stream);
             defer self.alloc.free(decoded);
+            // Keep the pre-reconstruction extraction contract as the byte
+            // preservation baseline. Real-world PDFs sometimes package
+            // independently generated content streams whose inherited font
+            // state would otherwise decode (and drop) different glyphs.
+            var text_parser = TextContentParser.init(self.alloc, &canonical);
+            defer text_parser.deinit();
             try text_parser.consume(decoded, fonts, forms, 0);
             try layout_parser.consume(decoded, fonts, &.{}, forms);
         }
@@ -2568,8 +2572,6 @@ pub const Reader = struct {
             for (runs.items) |*run| run.deinit(self.alloc);
             runs.deinit(self.alloc);
         }
-        var text_parser = TextContentParser.init(self.alloc, &text);
-        defer text_parser.deinit();
         var run_parser = try PositionedTextParser.init(self.alloc, .{ .render = &runs }, .{}, &.{}, .nonzero);
         defer run_parser.deinit();
 
@@ -2581,6 +2583,11 @@ pub const Reader = struct {
         for (streams) |*stream| {
             const decoded = try self.readDecodedStreamData(stream);
             defer self.alloc.free(decoded);
+            // Runs retain cross-stream graphics/text state for geometry, while
+            // canonical bytes retain the legacy per-stream decoding behavior.
+            // Reconstruction is accepted only when it preserves those bytes.
+            var text_parser = TextContentParser.init(self.alloc, &text);
+            defer text_parser.deinit();
             try text_parser.consume(decoded, fonts, forms, 0);
             try run_parser.consume(decoded, fonts, gstates, forms);
         }
@@ -4190,14 +4197,20 @@ pub const Reader = struct {
     }
 
     fn buildPageFont(self: *const Reader, name: []const u8, font_obj: *const syntax.Object) !PageFont {
+        var owned_name: ?[]u8 = try self.alloc.dupe(u8, name);
+        errdefer if (owned_name) |value| self.alloc.free(value);
+        var decoder: ?FontDecoder = try self.buildFontDecoder(font_obj);
+        errdefer if (decoder) |*value| value.deinit(self.alloc);
         var font = PageFont{
-            .name = try self.alloc.dupe(u8, name),
-            .decoder = try self.buildFontDecoder(font_obj),
+            .name = owned_name.?,
+            .decoder = decoder.?,
             .type3 = null,
             .type1 = null,
             .truetype = null,
             .cff_otf = null,
         };
+        owned_name = null;
+        decoder = null;
         errdefer font.deinit(self.alloc);
         font.type3 = self.buildType3Font(font_obj) catch |err| switch (err) {
             error.OutOfMemory => return err,
@@ -11215,6 +11228,78 @@ test "reader preserves text state across page content streams" {
     try std.testing.expect(second.x > first.x);
     try std.testing.expect(first.font_index != null);
     try std.testing.expectEqual(first.font_index, second.font_index);
+}
+
+test "reader preserves canonical bytes when inherited stream font loses glyphs" {
+    const alloc = std.testing.allocator;
+    const first_content = "q BT /F1 12 Tf\n";
+    const second_content = "(FOURTH EDITION) Tj ET Q\n";
+    // This two-byte font deliberately recognizes only the first two code
+    // pairs. Persisting it into the independently generated second stream
+    // produces "FR"; the legacy per-stream canonical extraction preserves the
+    // complete literal text and therefore rejects that lossy reconstruction.
+    const cmap =
+        "2 beginbfchar\n" ++
+        "<464F> <0046>\n" ++
+        "<5552> <0052>\n" ++
+        "endbfchar\n";
+    const objects = [_][]const u8{
+        "1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n",
+        "2 0 obj\n<< /Type /Pages /Count 1 /Kids [3 0 R] >>\nendobj\n",
+        "3 0 obj\n<< /Type /Page /Parent 2 0 R /Resources << /Font << /F1 6 0 R >> >> /Contents [4 0 R 5 0 R] >>\nendobj\n",
+        try std.fmt.allocPrint(alloc, "4 0 obj\n<< /Length {d} >>\nstream\n{s}endstream\nendobj\n", .{ first_content.len, first_content }),
+        try std.fmt.allocPrint(alloc, "5 0 obj\n<< /Length {d} >>\nstream\n{s}endstream\nendobj\n", .{ second_content.len, second_content }),
+        "6 0 obj\n<< /Type /Font /Subtype /Type0 /ToUnicode 7 0 R >>\nendobj\n",
+        try std.fmt.allocPrint(alloc, "7 0 obj\n<< /Length {d} >>\nstream\n{s}endstream\nendobj\n", .{ cmap.len, cmap }),
+    };
+    defer alloc.free(objects[3]);
+    defer alloc.free(objects[4]);
+    defer alloc.free(objects[6]);
+
+    var prefix = std.ArrayList(u8).empty;
+    defer prefix.deinit(alloc);
+    try prefix.appendSlice(alloc, "%PDF-1.7\n");
+    var offsets: [objects.len]usize = undefined;
+    for (objects, 0..) |object, i| {
+        offsets[i] = prefix.items.len;
+        try prefix.appendSlice(alloc, object);
+    }
+    const xref_offset = prefix.items.len;
+    try prefix.appendSlice(alloc, "xref\n0 8\n0000000000 65535 f \n");
+    for (offsets) |offset| {
+        const line = try std.fmt.allocPrint(alloc, "{d:0>10} 00000 n \n", .{offset});
+        defer alloc.free(line);
+        try prefix.appendSlice(alloc, line);
+    }
+    try prefix.appendSlice(alloc, "trailer\n<< /Size 8 /Root 1 0 R >>\n");
+    const sample = try std.fmt.allocPrint(alloc, "{s}startxref\n{d}\n%%EOF\n", .{ prefix.items, xref_offset });
+    defer alloc.free(sample);
+
+    var reader = try Reader.init(alloc, sample);
+    defer reader.deinit();
+    const plain_text = try reader.extractPageTextAlloc(1);
+    defer alloc.free(plain_text);
+    var analysis = try reader.extractPageTextAnalysisAlloc(1);
+    defer analysis.deinit(alloc);
+
+    try std.testing.expectEqualStrings("FOURTH EDITION", std.mem.trim(u8, plain_text, &std.ascii.whitespace));
+    try std.testing.expectEqualStrings("FOURTH EDITION", std.mem.trim(u8, analysis.text, &std.ascii.whitespace));
+    try std.testing.expectEqual(@as(usize, 1), analysis.runs.len);
+    try std.testing.expectEqualStrings("FR", analysis.runs[0].text);
+    try std.testing.expectEqual(@as(?TextOutputSpan, null), analysis.runs[0].output_span);
+
+    const AllocationRunner = struct {
+        fn run(failing_alloc: Allocator, pdf_bytes: []const u8) !void {
+            var parsed = try Reader.init(failing_alloc, pdf_bytes);
+            defer parsed.deinit();
+
+            const extracted = try parsed.extractPageTextAlloc(1);
+            defer failing_alloc.free(extracted);
+            var extracted_analysis = try parsed.extractPageTextAnalysisAlloc(1);
+            defer extracted_analysis.deinit(failing_alloc);
+        }
+    };
+    try std.testing.checkAllAllocationFailures(alloc, AllocationRunner.run, .{sample});
 }
 
 test "reader plain text ignores unused malformed extended graphics state" {

--- a/zig/lib/pdf/src/reader.zig
+++ b/zig/lib/pdf/src/reader.zig
@@ -186,16 +186,6 @@ const FontDecoder = struct {
                     defer alloc.free(fallback);
                     try out.appendSlice(alloc, fallback);
                 }
-            } else if (rawCodeLooksLikePdfDocText(raw[code_start..i])) {
-                // In malformed content arrays a multibyte font selected by an
-                // earlier stream can remain active for a later stream whose
-                // bytes are ordinary PDF text. An incomplete ToUnicode map
-                // must not silently discard those printable words. Preserve
-                // them through the same PDFDoc fallback used when no font is
-                // selected; mapped multibyte codes still take precedence.
-                const fallback = try text_encoding.pdfDocDecodeAlloc(alloc, raw[code_start..i]);
-                defer alloc.free(fallback);
-                try out.appendSlice(alloc, fallback);
             }
         }
 
@@ -223,15 +213,6 @@ const FontDecoder = struct {
         return @min(self.code_bytes, remaining.len);
     }
 };
-
-fn rawCodeLooksLikePdfDocText(raw: []const u8) bool {
-    var has_alphanumeric = false;
-    for (raw) |byte| {
-        if (!std.ascii.isPrint(byte) and !std.ascii.isWhitespace(byte)) return false;
-        has_alphanumeric = has_alphanumeric or std.ascii.isAlphanumeric(byte);
-    }
-    return has_alphanumeric;
-}
 
 const PageFont = struct {
     name: []u8,
@@ -10802,37 +10783,6 @@ test "reader uses ToUnicode codespacerange for multibyte text extraction" {
     const text = try reader.extractPlainTextAlloc();
     defer alloc.free(text);
     try std.testing.expectEqualStrings("\u{03A9}\n", text);
-}
-
-test "reader preserves unmapped multibyte text with PDFDoc fallback" {
-    const alloc = std.testing.allocator;
-    const entries = [_]ToUnicodeEntry{.{
-        .src = 0x0102,
-        .src_len = 2,
-        .dst = @constCast("\u{03A9}"),
-    }};
-    const ranges = [_]CodeSpaceRange{.{
-        .lo = 0,
-        .hi = 0xffff,
-        .len = 2,
-    }};
-    const decoder = FontDecoder{
-        .code_bytes = 2,
-        .to_unicode = @constCast(&entries),
-        .codespace_ranges = @constCast(&ranges),
-    };
-
-    const mapped = try decoder.decodeAlloc(alloc, &.{ 0x01, 0x02 });
-    defer alloc.free(mapped);
-    try std.testing.expectEqualStrings("\u{03A9}", mapped);
-
-    const fallback = try decoder.decodeAlloc(alloc, "FOURTH EDITION");
-    defer alloc.free(fallback);
-    try std.testing.expectEqualStrings("FOURTH EDITION", fallback);
-
-    const binary = try decoder.decodeAlloc(alloc, &.{ 0x00, 0x03 });
-    defer alloc.free(binary);
-    try std.testing.expectEqualStrings("", binary);
 }
 
 test "reader uses multiline ToUnicode bfrange arrays" {

--- a/zig/lib/pdf/src/reader.zig
+++ b/zig/lib/pdf/src/reader.zig
@@ -186,6 +186,16 @@ const FontDecoder = struct {
                     defer alloc.free(fallback);
                     try out.appendSlice(alloc, fallback);
                 }
+            } else if (rawCodeLooksLikePdfDocText(raw[code_start..i])) {
+                // In malformed content arrays a multibyte font selected by an
+                // earlier stream can remain active for a later stream whose
+                // bytes are ordinary PDF text. An incomplete ToUnicode map
+                // must not silently discard those printable words. Preserve
+                // them through the same PDFDoc fallback used when no font is
+                // selected; mapped multibyte codes still take precedence.
+                const fallback = try text_encoding.pdfDocDecodeAlloc(alloc, raw[code_start..i]);
+                defer alloc.free(fallback);
+                try out.appendSlice(alloc, fallback);
             }
         }
 
@@ -213,6 +223,15 @@ const FontDecoder = struct {
         return @min(self.code_bytes, remaining.len);
     }
 };
+
+fn rawCodeLooksLikePdfDocText(raw: []const u8) bool {
+    var has_alphanumeric = false;
+    for (raw) |byte| {
+        if (!std.ascii.isPrint(byte) and !std.ascii.isWhitespace(byte)) return false;
+        has_alphanumeric = has_alphanumeric or std.ascii.isAlphanumeric(byte);
+    }
+    return has_alphanumeric;
+}
 
 const PageFont = struct {
     name: []u8,
@@ -10770,6 +10789,37 @@ test "reader uses ToUnicode codespacerange for multibyte text extraction" {
     const text = try reader.extractPlainTextAlloc();
     defer alloc.free(text);
     try std.testing.expectEqualStrings("\u{03A9}\n", text);
+}
+
+test "reader preserves unmapped multibyte text with PDFDoc fallback" {
+    const alloc = std.testing.allocator;
+    const entries = [_]ToUnicodeEntry{.{
+        .src = 0x0102,
+        .src_len = 2,
+        .dst = @constCast("\u{03A9}"),
+    }};
+    const ranges = [_]CodeSpaceRange{.{
+        .lo = 0,
+        .hi = 0xffff,
+        .len = 2,
+    }};
+    const decoder = FontDecoder{
+        .code_bytes = 2,
+        .to_unicode = @constCast(&entries),
+        .codespace_ranges = @constCast(&ranges),
+    };
+
+    const mapped = try decoder.decodeAlloc(alloc, &.{ 0x01, 0x02 });
+    defer alloc.free(mapped);
+    try std.testing.expectEqualStrings("\u{03A9}", mapped);
+
+    const fallback = try decoder.decodeAlloc(alloc, "FOURTH EDITION");
+    defer alloc.free(fallback);
+    try std.testing.expectEqualStrings("FOURTH EDITION", fallback);
+
+    const binary = try decoder.decodeAlloc(alloc, &.{ 0x00, 0x03 });
+    defer alloc.free(binary);
+    try std.testing.expectEqualStrings("", binary);
 }
 
 test "reader uses multiline ToUnicode bfrange arrays" {

--- a/zig/lib/pdf/src/reader.zig
+++ b/zig/lib/pdf/src/reader.zig
@@ -1670,22 +1670,10 @@ pub const Reader = struct {
     }
 
     pub fn extractPageTextAlloc(self: *Reader, page_num: usize) ![]u8 {
-        var page = try self.readPageObject(page_num);
-        defer page.deinit(self.alloc);
-
-        const fonts = try self.collectPageFontsAlloc(&page);
-        defer {
-            for (fonts) |*font| font.deinit(self.alloc);
-            self.alloc.free(fonts);
-        }
-        const forms = try self.collectPageFormsAlloc(&page);
-        defer {
-            for (forms) |*form| form.deinit(self.alloc);
-            self.alloc.free(forms);
-        }
-
-        const contents = page.get("Contents") orelse return try self.alloc.dupe(u8, "");
-        return try self.extractContentsTextAlloc(contents, fonts, forms);
+        const analysis = try self.extractPageTextAnalysisAlloc(page_num);
+        for (analysis.runs) |*run| run.deinit(self.alloc);
+        if (analysis.runs.len > 0) self.alloc.free(analysis.runs);
+        return analysis.text;
     }
 
     /// Extracts canonical page text and positioned text runs while sharing the
@@ -2446,8 +2434,17 @@ pub const Reader = struct {
             try extractTextRunsFromContentAppend(self.alloc, &runs, decoded, fonts, gstates, forms);
         }
 
-        const owned_text = try text.toOwnedSlice(self.alloc);
+        var owned_text = try text.toOwnedSlice(self.alloc);
         errdefer self.alloc.free(owned_text);
+        if (runs.items.len > 0) {
+            const reconstructed = try reconstructTextFromRunsAlloc(self.alloc, runs.items);
+            if (sameNonWhitespaceBytes(owned_text, reconstructed)) {
+                self.alloc.free(owned_text);
+                owned_text = reconstructed;
+            } else {
+                self.alloc.free(reconstructed);
+            }
+        }
         const owned_runs = try runs.toOwnedSlice(self.alloc);
         return .{ .text = owned_text, .runs = owned_runs };
     }
@@ -8392,6 +8389,103 @@ fn measureSfntAdvanceAlloc(
     return advance;
 }
 
+fn sameNonWhitespaceBytes(left: []const u8, right: []const u8) bool {
+    var left_index: usize = 0;
+    var right_index: usize = 0;
+    while (true) {
+        while (left_index < left.len and std.ascii.isWhitespace(left[left_index])) left_index += 1;
+        while (right_index < right.len and std.ascii.isWhitespace(right[right_index])) right_index += 1;
+        if (left_index == left.len or right_index == right.len) {
+            while (left_index < left.len and std.ascii.isWhitespace(left[left_index])) left_index += 1;
+            while (right_index < right.len and std.ascii.isWhitespace(right[right_index])) right_index += 1;
+            return left_index == left.len and right_index == right.len;
+        }
+        if (left[left_index] != right[right_index]) return false;
+        left_index += 1;
+        right_index += 1;
+    }
+}
+
+fn textRunAxisLength(run: TextRun) f64 {
+    return @sqrt(run.a * run.a + run.b * run.b);
+}
+
+fn textRunVerticalScale(run: TextRun) f64 {
+    return @sqrt(run.c * run.c + run.d * run.d);
+}
+
+fn textRunsShareLine(previous: TextRun, current: TextRun) bool {
+    const previous_axis = textRunAxisLength(previous);
+    const current_axis = textRunAxisLength(current);
+    if (previous_axis <= 0.000001 or current_axis <= 0.000001) return false;
+    const direction_alignment =
+        (previous.a * current.a + previous.b * current.b) /
+        (previous_axis * current_axis);
+    if (direction_alignment < 0.8) return false;
+
+    const delta_x = current.x - previous.x;
+    const delta_y = current.y - previous.y;
+    const cross_axis_gap = @abs(
+        delta_x * (-previous.b / previous_axis) +
+            delta_y * (previous.a / previous_axis),
+    );
+    const previous_height = @abs(previous.font_size) * textRunVerticalScale(previous);
+    const current_height = @abs(current.font_size) * textRunVerticalScale(current);
+    const line_tolerance = @max(1.0, @max(previous_height, current_height) * 0.45);
+    return cross_axis_gap <= line_tolerance;
+}
+
+fn textRunForwardGap(previous: TextRun, current: TextRun) f64 {
+    const axis = textRunAxisLength(previous);
+    if (axis <= 0.000001) return 0;
+    const previous_end_x = previous.x + previous.a * previous.advance_width;
+    const previous_end_y = previous.y + previous.b * previous.advance_width;
+    return (current.x - previous_end_x) * (previous.a / axis) +
+        (current.y - previous_end_y) * (previous.b / axis);
+}
+
+fn appendLayoutNewline(alloc: Allocator, out: *std.ArrayList(u8)) !void {
+    while (out.items.len > 0 and
+        (out.items[out.items.len - 1] == ' ' or
+            out.items[out.items.len - 1] == '\t' or
+            out.items[out.items.len - 1] == '\r'))
+    {
+        _ = out.pop();
+    }
+    try appendNewline(alloc, out);
+}
+
+fn reconstructTextFromRunsAlloc(alloc: Allocator, runs: []const TextRun) ![]u8 {
+    var out = std.ArrayList(u8).empty;
+    defer out.deinit(alloc);
+    var previous: ?TextRun = null;
+    for (runs) |run| {
+        if (run.text.len == 0) continue;
+        if (previous) |prior| {
+            if (!textRunsShareLine(prior, run)) {
+                try appendLayoutNewline(alloc, &out);
+            } else if (!std.ascii.isWhitespace(out.items[out.items.len - 1]) and
+                !std.ascii.isWhitespace(run.text[0]))
+            {
+                const axis = textRunAxisLength(prior);
+                const font_scale = @abs(prior.font_size) * axis;
+                const gap = textRunForwardGap(prior, run);
+                const word_gap = @max(0.5, font_scale * 0.12);
+                const operator_overlap_tolerance = font_scale * 0.15;
+                if (gap > word_gap or
+                    (prior.paint_order != run.paint_order and gap > -operator_overlap_tolerance))
+                {
+                    try out.append(alloc, ' ');
+                }
+            }
+        }
+        try out.appendSlice(alloc, run.text);
+        previous = run;
+    }
+    try appendNewline(alloc, &out);
+    return try out.toOwnedSlice(alloc);
+}
+
 fn appendNewline(alloc: Allocator, out: *std.ArrayList(u8)) !void {
     if (out.items.len == 0) return;
     if (out.items[out.items.len - 1] == '\n') return;
@@ -10606,6 +10700,22 @@ test "reader caches shared page fonts across text analysis" {
     try std.testing.expectEqualStrings("SECOND PAGE", std.mem.trim(u8, second.text, &std.ascii.whitespace));
 }
 
+test "reader reconstructs spaces and lines from positioned text runs" {
+    const alloc = std.testing.allocator;
+    const runs = [_]TextRun{
+        .{ .text = "Max", .x = 0, .y = 100, .font_size = 10, .advance_width = 15, .paint_order = 0 },
+        .{ .text = "Length", .x = 17, .y = 100, .font_size = 10, .advance_width = 30, .paint_order = 0 },
+        .{ .text = "Avg", .x = 46.5, .y = 100, .font_size = 10, .advance_width = 14, .paint_order = 1 },
+        .{ .text = "Multi-v", .x = 0, .y = 80, .font_size = 10, .advance_width = 30, .paint_order = 2 },
+        .{ .text = "ec", .x = 30.5, .y = 80, .font_size = 10, .advance_width = 8, .paint_order = 2 },
+    };
+    const text = try reconstructTextFromRunsAlloc(alloc, &runs);
+    defer alloc.free(text);
+    try std.testing.expectEqualStrings("Max Length Avg\nMulti-vec\n", text);
+    try std.testing.expect(sameNonWhitespaceBytes("MaxLengthAvg Multi-vec", text));
+    try std.testing.expect(!sameNonWhitespaceBytes("MaxLengthAvg Multi-vector", text));
+}
+
 test "reader extracts positioned text runs from text matrix operators" {
     const alloc = std.testing.allocator;
     const content = "BT\n/F1 12 Tf\n1 0 0 1 72 720 Tm\n(Top) Tj\n0 -24 Td\n(Bottom) Tj\nET\n";
@@ -10642,6 +10752,10 @@ test "reader extracts positioned text runs from text matrix operators" {
 
     var reader = try Reader.init(alloc, sample);
     defer reader.deinit();
+
+    const text = try reader.extractPageTextAlloc(1);
+    defer alloc.free(text);
+    try std.testing.expectEqualStrings("Top\nBottom", std.mem.trim(u8, text, &std.ascii.whitespace));
 
     const runs = try reader.extractPageTextRunsAlloc(1);
     defer {

--- a/zig/lib/pdf/src/reader.zig
+++ b/zig/lib/pdf/src/reader.zig
@@ -364,6 +364,11 @@ const TextExtractionState = struct {
     current_font_index: ?usize = null,
 };
 
+pub const TextOutputSpan = struct {
+    start: usize,
+    end: usize,
+};
+
 pub const TextRun = struct {
     text: []const u8,
     raw_text: ?[]const u8 = null,
@@ -389,6 +394,8 @@ pub const TextRun = struct {
     ascent: f64 = 0,
     descent: f64 = 0,
     paint_order: usize = 0,
+    output_span: ?TextOutputSpan = null,
+
     blend_mode: BlendMode = .normal,
     group_id: ?u32 = null,
     group_parent_id: ?u32 = null,
@@ -405,6 +412,26 @@ pub const TextRun = struct {
         if (self.fill_pattern_name) |name| alloc.free(name);
         if (self.stroke_pattern_name) |name| alloc.free(name);
         if (self.raw_text) |raw| alloc.free(raw);
+        alloc.free(self.text);
+        self.* = undefined;
+    }
+};
+const LayoutTextRun = struct {
+    text: []const u8,
+    x: f64,
+    y: f64,
+    font_size: f64,
+    a: f64 = 1,
+    b: f64 = 0,
+    c: f64 = 0,
+    d: f64 = 1,
+    advance_width: f64 = 0,
+    ascent: f64 = 0,
+    descent: f64 = 0,
+    paint_order: usize = 0,
+    output_span: ?TextOutputSpan = null,
+
+    fn deinit(self: *LayoutTextRun, alloc: Allocator) void {
         alloc.free(self.text);
         self.* = undefined;
     }
@@ -676,11 +703,11 @@ const TextRunStackEntry = struct {
     fill_pattern_name: ?[]const u8,
     stroke_pattern_name: ?[]const u8,
     clip_box: ?PageBox,
-    clip_points: []const [2]f64,
+    clip_points: ?[]const [2]f64,
     clip_fill_rule: FillRule,
 
     fn deinit(self: *TextRunStackEntry, alloc: Allocator) void {
-        alloc.free(self.clip_points);
+        if (self.clip_points) |points| alloc.free(points);
         self.* = undefined;
     }
 };
@@ -869,6 +896,117 @@ const ExponentialTintTransform = struct {
     }
 };
 
+const PositionedTextOutput = union(enum) {
+    layout: *std.ArrayList(LayoutTextRun),
+    render: *std.ArrayList(TextRun),
+
+    fn len(self: PositionedTextOutput) usize {
+        return switch (self) {
+            .layout => |out| out.items.len,
+            .render => |out| out.items.len,
+        };
+    }
+
+    fn isLayout(self: PositionedTextOutput) bool {
+        return self == .layout;
+    }
+};
+
+const PositionedTextParser = struct {
+    alloc: Allocator,
+    output: PositionedTextOutput,
+    operands: std.ArrayList(syntax.Object) = .empty,
+    retained_names: std.ArrayList(syntax.Object) = .empty,
+    state: TextRunState = .{},
+    stack: std.ArrayList(TextRunStackEntry) = .empty,
+    current_path: std.ArrayList([2]f64) = .empty,
+    current_path_closed: bool = false,
+    current_clip_points: std.ArrayList([2]f64) = .empty,
+    current_clip_fill_rule: FillRule = .nonzero,
+    paint_order: usize = 0,
+    next_group_id: u32 = 1,
+
+    fn init(
+        alloc: Allocator,
+        output: PositionedTextOutput,
+        initial_state: TextRunState,
+        initial_clip_points: []const [2]f64,
+        initial_clip_fill_rule: FillRule,
+    ) !PositionedTextParser {
+        var self = PositionedTextParser{
+            .alloc = alloc,
+            .output = output,
+            .state = initial_state,
+            .current_clip_fill_rule = initial_clip_fill_rule,
+        };
+        errdefer self.deinit();
+        try self.current_clip_points.appendSlice(alloc, initial_clip_points);
+        return self;
+    }
+
+    fn deinit(self: *PositionedTextParser) void {
+        clearContentOperands(self.alloc, &self.operands);
+        self.operands.deinit(self.alloc);
+        for (self.retained_names.items) |*name| name.deinit(self.alloc);
+        self.retained_names.deinit(self.alloc);
+        for (self.stack.items) |*entry| entry.deinit(self.alloc);
+        self.stack.deinit(self.alloc);
+        self.current_path.deinit(self.alloc);
+        self.current_clip_points.deinit(self.alloc);
+        self.* = undefined;
+    }
+
+    fn consume(
+        self: *PositionedTextParser,
+        bytes: []const u8,
+        fonts: []const PageFont,
+        gstates: []const PageExtGState,
+        forms: []const PageForm,
+    ) anyerror!void {
+        var scanner = syntax.Scanner.init(self.alloc, bytes);
+        defer scanner.deinit();
+
+        while (true) {
+            var lex = (try readContentLexeme(&scanner)) orelse {
+                clearContentOperands(self.alloc, &self.operands);
+                continue;
+            };
+            defer syntax.Scanner.freeLexeme(self.alloc, &lex);
+
+            if (lex == .eof) break;
+            if (lex == .keyword and !isContentObjectStartKeyword(lex.keyword)) {
+                try applyTextRunOperator(
+                    self.alloc,
+                    self.output,
+                    &self.state,
+                    &self.stack,
+                    &self.current_path,
+                    &self.current_path_closed,
+                    &self.current_clip_points,
+                    &self.current_clip_fill_rule,
+                    fonts,
+                    gstates,
+                    forms,
+                    &self.paint_order,
+                    &self.next_group_id,
+                    lex.keyword,
+                    self.operands.items,
+                );
+                try clearContentOperandsRetainingNames(self.alloc, &self.operands, &self.retained_names);
+                continue;
+            }
+
+            try scanner.unreadLexeme(try cloneLexemeForContent(self.alloc, lex));
+            const maybe_obj = try readContentObject(&scanner);
+            if (maybe_obj) |obj| {
+                try appendOwnedSyntaxObject(self.alloc, &self.operands, obj);
+            } else {
+                clearContentOperands(self.alloc, &self.operands);
+            }
+        }
+    }
+};
+
 fn extractTextRunsFromContentAppend(
     alloc: Allocator,
     out: *std.ArrayList(TextRun),
@@ -877,73 +1015,9 @@ fn extractTextRunsFromContentAppend(
     gstates: []const PageExtGState,
     forms: []const PageForm,
 ) !void {
-    var paint_order: usize = 0;
-    var next_group_id: u32 = 1;
-    return try extractTextRunsFromContentAppendWithState(alloc, out, bytes, fonts, gstates, forms, .{}, &.{}, .nonzero, &paint_order, &next_group_id);
-}
-
-fn extractTextRunsFromContentAppendWithState(
-    alloc: Allocator,
-    out: *std.ArrayList(TextRun),
-    bytes: []const u8,
-    fonts: []const PageFont,
-    gstates: []const PageExtGState,
-    forms: []const PageForm,
-    initial_state: TextRunState,
-    initial_clip_points: []const [2]f64,
-    initial_clip_fill_rule: FillRule,
-    paint_order: *usize,
-    next_group_id: *u32,
-) anyerror!void {
-    var scanner = syntax.Scanner.init(alloc, bytes);
-    defer scanner.deinit();
-
-    var operands = std.ArrayList(syntax.Object).empty;
-    defer {
-        for (operands.items) |*obj| obj.deinit(alloc);
-        operands.deinit(alloc);
-    }
-    var retained_names = std.ArrayList(syntax.Object).empty;
-    defer {
-        for (retained_names.items) |*name| name.deinit(alloc);
-        retained_names.deinit(alloc);
-    }
-
-    var state = initial_state;
-    var stack = std.ArrayList(TextRunStackEntry).empty;
-    defer {
-        for (stack.items) |*entry| entry.deinit(alloc);
-        stack.deinit(alloc);
-    }
-    var current_path = std.ArrayList([2]f64).empty;
-    defer current_path.deinit(alloc);
-    var current_path_closed = false;
-    var current_clip_points = std.ArrayList([2]f64).empty;
-    defer current_clip_points.deinit(alloc);
-    var current_clip_fill_rule: FillRule = initial_clip_fill_rule;
-    try current_clip_points.appendSlice(alloc, initial_clip_points);
-    while (true) {
-        var lex = (try readContentLexeme(&scanner)) orelse {
-            clearContentOperands(alloc, &operands);
-            continue;
-        };
-        defer syntax.Scanner.freeLexeme(alloc, &lex);
-
-        if (lex == .eof) break;
-        if (lex == .keyword and !isContentObjectStartKeyword(lex.keyword)) {
-            try applyTextRunOperator(alloc, out, &state, &stack, &current_path, &current_path_closed, &current_clip_points, &current_clip_fill_rule, fonts, gstates, forms, paint_order, next_group_id, lex.keyword, operands.items);
-            try clearContentOperandsRetainingNames(alloc, &operands, &retained_names);
-            continue;
-        }
-
-        try scanner.unreadLexeme(try cloneLexemeForContent(alloc, lex));
-        const maybe_obj = try readContentObject(&scanner);
-        if (maybe_obj) |obj| {
-            try appendOwnedSyntaxObject(alloc, &operands, obj);
-        } else {
-            clearContentOperands(alloc, &operands);
-        }
-    }
+    var parser = try PositionedTextParser.init(alloc, .{ .render = out }, .{}, &.{}, .nonzero);
+    defer parser.deinit();
+    try parser.consume(bytes, fonts, gstates, forms);
 }
 
 fn extractImageRunsFromContentAppend(
@@ -1708,10 +1782,56 @@ pub const Reader = struct {
     }
 
     pub fn extractPageTextAlloc(self: *Reader, page_num: usize) ![]u8 {
-        const analysis = try self.extractPageTextAnalysisAlloc(page_num);
-        for (analysis.runs) |*run| run.deinit(self.alloc);
-        if (analysis.runs.len > 0) self.alloc.free(analysis.runs);
-        return analysis.text;
+        var page = try self.readPageObject(page_num);
+        defer page.deinit(self.alloc);
+
+        const fonts = try self.collectPageFontsAlloc(&page);
+        defer {
+            for (fonts) |*font| font.deinit(self.alloc);
+            self.alloc.free(fonts);
+        }
+        const forms = try self.collectPageTextFormsAlloc(&page);
+        defer {
+            for (forms) |*form| form.deinit(self.alloc);
+            self.alloc.free(forms);
+        }
+
+        const contents = page.get("Contents") orelse return try self.alloc.dupe(u8, "");
+        var canonical = std.ArrayList(u8).empty;
+        defer canonical.deinit(self.alloc);
+        var layout_runs = std.ArrayList(LayoutTextRun).empty;
+        defer layout_runs.deinit(self.alloc);
+        defer for (layout_runs.items) |*run| run.deinit(self.alloc);
+        var text_parser = TextContentParser.init(self.alloc, &canonical);
+        defer text_parser.deinit();
+        var layout_parser = try PositionedTextParser.init(self.alloc, .{ .layout = &layout_runs }, .{}, &.{}, .nonzero);
+        defer layout_parser.deinit();
+
+        const streams = try self.collectContentStreamsAlloc(contents);
+        defer {
+            for (streams) |*stream| stream.deinit(self.alloc);
+            self.alloc.free(streams);
+        }
+        for (streams) |*stream| {
+            const decoded = try self.readDecodedStreamData(stream);
+            defer self.alloc.free(decoded);
+            try text_parser.consume(decoded, fonts, forms, 0);
+            try layout_parser.consume(decoded, fonts, &.{}, forms);
+        }
+
+        var owned_text = try canonical.toOwnedSlice(self.alloc);
+        errdefer self.alloc.free(owned_text);
+        if (layout_runs.items.len > 0) {
+            const reconstructed = try reconstructTextFromRunsAlloc(self.alloc, layout_runs.items);
+            if (sameNonWhitespaceBytes(owned_text, reconstructed)) {
+                self.alloc.free(owned_text);
+                owned_text = reconstructed;
+            } else {
+                self.alloc.free(reconstructed);
+                clearTextRunOutputSpans(layout_runs.items);
+            }
+        }
+        return owned_text;
     }
 
     /// Extracts canonical page text and positioned text runs while sharing the
@@ -1903,6 +2023,9 @@ pub const Reader = struct {
         errdefer if (!pattern_transferred) for (pattern_out.items) |*run| run.deinit(self.alloc);
         errdefer if (!shape_transferred) for (shape_out.items) |*run| run.deinit(self.alloc);
 
+        var text_parser = try PositionedTextParser.init(self.alloc, .{ .render = &text_out }, .{}, &.{}, .nonzero);
+        defer text_parser.deinit();
+
         if (page.get("Contents")) |contents| {
             const streams = try self.collectContentStreamsAlloc(contents);
             defer {
@@ -1912,7 +2035,7 @@ pub const Reader = struct {
             for (streams) |*stream| {
                 const decoded = try self.readDecodedStreamData(stream);
                 defer self.alloc.free(decoded);
-                try self.extractRenderRunsFromContentAppend(&text_out, &image_out, &shading_out, &pattern_out, &shape_out, decoded, fonts, images, shadings, patterns, gstates, forms);
+                try self.extractRenderRunsFromContentAppend(&text_parser, &image_out, &shading_out, &pattern_out, &shape_out, decoded, fonts, images, shadings, patterns, gstates, forms);
             }
         }
 
@@ -2181,13 +2304,19 @@ pub const Reader = struct {
         var out = std.ArrayList(TextRun).empty;
         defer out.deinit(self.alloc);
         errdefer for (out.items) |*run| run.deinit(self.alloc);
+        var parser = try PositionedTextParser.init(self.alloc, .{ .render = &out }, .{}, &.{}, .nonzero);
+        defer parser.deinit();
 
         const streams = try self.collectContentStreamsAlloc(contents);
         defer {
             for (streams) |*stream| stream.deinit(self.alloc);
             self.alloc.free(streams);
         }
-        for (streams) |*stream| try self.extractSingleContentTextRunsAppend(&out, stream, fonts, gstates, forms);
+        for (streams) |*stream| {
+            const decoded = try self.readDecodedStreamData(stream);
+            defer self.alloc.free(decoded);
+            try parser.consume(decoded, fonts, gstates, forms);
+        }
 
         return try out.toOwnedSlice(self.alloc);
     }
@@ -2254,7 +2383,7 @@ pub const Reader = struct {
 
     fn extractRenderRunsFromContentAppend(
         self: *const Reader,
-        text_out: *std.ArrayList(TextRun),
+        text_parser: *PositionedTextParser,
         image_out: *std.ArrayList(ImageRun),
         shading_out: *std.ArrayList(ShadingRun),
         pattern_out: *std.ArrayList(PatternRun),
@@ -2267,7 +2396,7 @@ pub const Reader = struct {
         gstates: []const PageExtGState,
         forms: []const PageForm,
     ) !void {
-        try extractTextRunsFromContentAppend(self.alloc, text_out, decoded, fonts, gstates, forms);
+        try text_parser.consume(decoded, fonts, gstates, forms);
         const has_do = contentMayContainOperator(decoded, "Do");
         const has_shape_paint = contentMayContainShapePaintOperator(decoded);
         const has_shading_paint = contentMayContainOperator(decoded, "sh");
@@ -2425,24 +2554,6 @@ pub const Reader = struct {
         }
     }
 
-    fn extractContentsTextAlloc(self: *const Reader, contents: *const syntax.Object, fonts: []const PageFont, forms: []const PageForm) ![]u8 {
-        var out = std.ArrayList(u8).empty;
-        defer out.deinit(self.alloc);
-
-        const streams = try self.collectContentStreamsAlloc(contents);
-        defer {
-            for (streams) |*stream| stream.deinit(self.alloc);
-            self.alloc.free(streams);
-        }
-        for (streams) |*stream| {
-            const chunk = try self.extractSingleContentTextAlloc(stream, fonts, forms);
-            defer self.alloc.free(chunk);
-            try out.appendSlice(self.alloc, chunk);
-        }
-
-        return try out.toOwnedSlice(self.alloc);
-    }
-
     fn extractContentsTextAnalysisAlloc(
         self: *const Reader,
         contents: *const syntax.Object,
@@ -2457,6 +2568,10 @@ pub const Reader = struct {
             for (runs.items) |*run| run.deinit(self.alloc);
             runs.deinit(self.alloc);
         }
+        var text_parser = TextContentParser.init(self.alloc, &text);
+        defer text_parser.deinit();
+        var run_parser = try PositionedTextParser.init(self.alloc, .{ .render = &runs }, .{}, &.{}, .nonzero);
+        defer run_parser.deinit();
 
         const streams = try self.collectContentStreamsAlloc(contents);
         defer {
@@ -2466,10 +2581,8 @@ pub const Reader = struct {
         for (streams) |*stream| {
             const decoded = try self.readDecodedStreamData(stream);
             defer self.alloc.free(decoded);
-            const chunk = try extractTextFromContentAlloc(self.alloc, decoded, fonts, forms, 0);
-            defer self.alloc.free(chunk);
-            try text.appendSlice(self.alloc, chunk);
-            try extractTextRunsFromContentAppend(self.alloc, &runs, decoded, fonts, gstates, forms);
+            try text_parser.consume(decoded, fonts, forms, 0);
+            try run_parser.consume(decoded, fonts, gstates, forms);
         }
 
         var owned_text = try text.toOwnedSlice(self.alloc);
@@ -2481,22 +2594,11 @@ pub const Reader = struct {
                 owned_text = reconstructed;
             } else {
                 self.alloc.free(reconstructed);
+                clearTextRunOutputSpans(runs.items);
             }
         }
         const owned_runs = try runs.toOwnedSlice(self.alloc);
         return .{ .text = owned_text, .runs = owned_runs };
-    }
-
-    fn extractSingleContentTextAlloc(self: *const Reader, obj: *const syntax.Object, fonts: []const PageFont, forms: []const PageForm) ![]u8 {
-        const decoded = try self.readDecodedStreamData(obj);
-        defer self.alloc.free(decoded);
-        return try extractTextFromContentAlloc(self.alloc, decoded, fonts, forms, 0);
-    }
-
-    fn extractSingleContentTextRunsAppend(self: *const Reader, out: *std.ArrayList(TextRun), obj: *const syntax.Object, fonts: []const PageFont, gstates: []const PageExtGState, forms: []const PageForm) !void {
-        const decoded = try self.readDecodedStreamData(obj);
-        defer self.alloc.free(decoded);
-        try extractTextRunsFromContentAppend(self.alloc, out, decoded, fonts, gstates, forms);
     }
 
     fn extractSingleContentImageRunsAppend(self: *const Reader, out: *std.ArrayList(ImageRun), obj: *const syntax.Object, images: []const PageImage, gstates: []const PageExtGState, forms: []const PageForm) !void {
@@ -2862,6 +2964,13 @@ pub const Reader = struct {
         if (resources == null) return try self.alloc.alloc(PageForm, 0);
         defer if (resources) |*obj| obj.deinit(self.alloc);
         return try self.collectFormsFromResourcesAlloc(&resources.?, &resources.?, 0);
+    }
+
+    fn collectPageTextFormsAlloc(self: *const Reader, page: *const syntax.Object) ![]PageForm {
+        var resources = try self.findInheritedPageValue(page, "Resources");
+        if (resources == null) return try self.alloc.alloc(PageForm, 0);
+        defer if (resources) |*obj| obj.deinit(self.alloc);
+        return try self.collectTextFormsFromResourcesAlloc(&resources.?, &resources.?, 0);
     }
 
     fn collectFontsFromResourcesAlloc(self: *const Reader, resources: *const syntax.Object) ![]PageFont {
@@ -3241,6 +3350,83 @@ pub const Reader = struct {
                 .forms = forms,
             });
             name = null;
+        }
+        return try out.toOwnedSlice(self.alloc);
+    }
+
+    fn collectTextFormsFromResourcesAlloc(
+        self: *const Reader,
+        resources: *const syntax.Object,
+        fallback_resources: ?*const syntax.Object,
+        depth: u8,
+    ) anyerror![]PageForm {
+        if (depth > 1) return try self.alloc.alloc(PageForm, 0);
+        const xobject_obj = resources.get("XObject") orelse return try self.alloc.alloc(PageForm, 0);
+        var resolved_xobjects = try self.resolveValue(xobject_obj);
+        defer resolved_xobjects.deinit(self.alloc);
+        if (resolved_xobjects != .dict) return try self.alloc.alloc(PageForm, 0);
+
+        var out = std.ArrayList(PageForm).empty;
+        defer out.deinit(self.alloc);
+        errdefer for (out.items) |*form| form.deinit(self.alloc);
+        for (resolved_xobjects.dict) |entry| {
+            var xobj = try self.resolveValue(&entry.value);
+            defer xobj.deinit(self.alloc);
+            if (xobj != .stream) continue;
+            const subtype = xobj.get("Subtype") orelse continue;
+            if (!std.mem.eql(u8, subtype.asName() orelse continue, "Form")) continue;
+
+            var content: ?[]u8 = try self.readDecodedStreamData(&xobj);
+            errdefer if (content) |owned| self.alloc.free(owned);
+            var resolved_form_resources: ?syntax.Object = null;
+            defer if (resolved_form_resources) |*obj| obj.deinit(self.alloc);
+            if (xobj.get("Resources")) |form_resources_obj| {
+                resolved_form_resources = try self.resolveValue(form_resources_obj);
+            } else if (fallback_resources) |fallback| {
+                resolved_form_resources = try fallback.clone(self.alloc);
+            }
+
+            var fonts: ?[]PageFont = if (resolved_form_resources) |*form_resources|
+                try self.collectFontsFromResourcesAlloc(form_resources)
+            else
+                try self.alloc.alloc(PageFont, 0);
+            errdefer if (fonts) |owned| {
+                for (owned) |*font| font.deinit(self.alloc);
+                if (owned.len > 0) self.alloc.free(owned);
+            };
+            var forms: ?[]PageForm = if (resolved_form_resources) |*form_resources|
+                try self.collectTextFormsFromResourcesAlloc(form_resources, fallback_resources orelse form_resources, depth + 1)
+            else
+                try self.alloc.alloc(PageForm, 0);
+            errdefer if (forms) |owned| {
+                for (owned) |*form| form.deinit(self.alloc);
+                if (owned.len > 0) self.alloc.free(owned);
+            };
+            var name: ?[]u8 = try self.alloc.dupe(u8, entry.key);
+            errdefer if (name) |owned| self.alloc.free(owned);
+
+            try out.append(self.alloc, .{
+                .name = name.?,
+                .content = content.?,
+                .matrix = blk: {
+                    const matrix_obj = xobj.get("Matrix") orelse break :blk .{};
+                    if (matrix_obj.* != .array or matrix_obj.array.len < 6) break :blk .{};
+                    break :blk .{
+                        .a = numericObjectValue(&matrix_obj.array[0]) orelse 1,
+                        .b = numericObjectValue(&matrix_obj.array[1]) orelse 0,
+                        .c = numericObjectValue(&matrix_obj.array[2]) orelse 0,
+                        .d = numericObjectValue(&matrix_obj.array[3]) orelse 1,
+                        .e = numericObjectValue(&matrix_obj.array[4]) orelse 0,
+                        .f = numericObjectValue(&matrix_obj.array[5]) orelse 0,
+                    };
+                },
+                .fonts = fonts.?,
+                .forms = forms.?,
+            });
+            name = null;
+            content = null;
+            fonts = null;
+            forms = null;
         }
         return try out.toOwnedSlice(self.alloc);
     }
@@ -6323,6 +6509,67 @@ fn parseHexToUtf8Alloc(alloc: Allocator, hex: []const u8) ![]u8 {
     return try alloc.dupe(u8, buf[0..n]);
 }
 
+const TextContentParser = struct {
+    alloc: Allocator,
+    out: *std.ArrayList(u8),
+    operands: std.ArrayList(syntax.Object) = .empty,
+    state: TextExtractionState = .{},
+
+    fn init(alloc: Allocator, out: *std.ArrayList(u8)) TextContentParser {
+        return .{ .alloc = alloc, .out = out };
+    }
+
+    fn deinit(self: *TextContentParser) void {
+        clearContentOperands(self.alloc, &self.operands);
+        self.operands.deinit(self.alloc);
+        self.* = undefined;
+    }
+
+    fn consume(
+        self: *TextContentParser,
+        bytes: []const u8,
+        fonts: []const PageFont,
+        forms: []const PageForm,
+        form_depth: usize,
+    ) anyerror!void {
+        if (form_depth > 128) return error.InvalidContents;
+        var scanner = syntax.Scanner.init(self.alloc, bytes);
+        defer scanner.deinit();
+
+        while (true) {
+            var lex = (try readContentLexeme(&scanner)) orelse {
+                clearContentOperands(self.alloc, &self.operands);
+                continue;
+            };
+            defer syntax.Scanner.freeLexeme(self.alloc, &lex);
+
+            if (lex == .eof) break;
+            if (lex == .keyword and !isContentObjectStartKeyword(lex.keyword)) {
+                try applyTextOperator(
+                    self.alloc,
+                    self.out,
+                    &self.state,
+                    fonts,
+                    forms,
+                    form_depth,
+                    lex.keyword,
+                    self.operands.items,
+                );
+                clearContentOperands(self.alloc, &self.operands);
+                continue;
+            }
+
+            try scanner.unreadLexeme(try cloneLexemeForContent(self.alloc, lex));
+            const maybe_obj = try readContentObject(&scanner);
+            if (maybe_obj) |obj| {
+                try appendOwnedSyntaxObject(self.alloc, &self.operands, obj);
+            } else {
+                clearContentOperands(self.alloc, &self.operands);
+            }
+        }
+    }
+};
+
 fn extractTextFromContentAlloc(
     alloc: Allocator,
     bytes: []const u8,
@@ -6330,44 +6577,11 @@ fn extractTextFromContentAlloc(
     forms: []const PageForm,
     form_depth: usize,
 ) anyerror![]u8 {
-    if (form_depth > 128) return error.InvalidContents;
-    var scanner = syntax.Scanner.init(alloc, bytes);
-    defer scanner.deinit();
-
-    var operands = std.ArrayList(syntax.Object).empty;
-    defer {
-        for (operands.items) |*obj| obj.deinit(alloc);
-        operands.deinit(alloc);
-    }
-
     var out = std.ArrayList(u8).empty;
     defer out.deinit(alloc);
-    var state = TextExtractionState{};
-
-    while (true) {
-        var lex = (try readContentLexeme(&scanner)) orelse {
-            clearContentOperands(alloc, &operands);
-            continue;
-        };
-        defer syntax.Scanner.freeLexeme(alloc, &lex);
-
-        if (lex == .eof) break;
-        if (lex == .keyword and !isContentObjectStartKeyword(lex.keyword)) {
-            try applyTextOperator(alloc, &out, &state, fonts, forms, form_depth, lex.keyword, operands.items);
-            for (operands.items) |*obj| obj.deinit(alloc);
-            operands.clearRetainingCapacity();
-            continue;
-        }
-
-        try scanner.unreadLexeme(try cloneLexemeForContent(alloc, lex));
-        const maybe_obj = try readContentObject(&scanner);
-        if (maybe_obj) |obj| {
-            try appendOwnedSyntaxObject(alloc, &operands, obj);
-        } else {
-            clearContentOperands(alloc, &operands);
-        }
-    }
-
+    var parser = TextContentParser.init(alloc, &out);
+    defer parser.deinit();
+    try parser.consume(bytes, fonts, forms, form_depth);
     return try out.toOwnedSlice(alloc);
 }
 
@@ -6502,7 +6716,7 @@ fn applyTextOperator(
 
 fn applyTextRunOperator(
     alloc: Allocator,
-    out: *std.ArrayList(TextRun),
+    out: PositionedTextOutput,
     state: *TextRunState,
     stack: *std.ArrayList(TextRunStackEntry),
     current_path: *std.ArrayList([2]f64),
@@ -6524,8 +6738,8 @@ fn applyTextRunOperator(
         paint_order.* += 1;
     }
     if (std.mem.eql(u8, op, "q")) {
-        const clip_points = try alloc.dupe([2]f64, current_clip_points.items);
-        errdefer alloc.free(clip_points);
+        const clip_points = if (out.isLayout()) null else try alloc.dupe([2]f64, current_clip_points.items);
+        errdefer if (clip_points) |points| alloc.free(points);
         try stack.append(alloc, .{
             .matrix = state.matrix,
             .alpha = state.alpha,
@@ -6576,14 +6790,17 @@ fn applyTextRunOperator(
             state.fill_pattern_name = entry.fill_pattern_name;
             state.stroke_pattern_name = entry.stroke_pattern_name;
             state.clip_box = entry.clip_box;
-            current_clip_points.clearRetainingCapacity();
-            try current_clip_points.appendSlice(alloc, entry.clip_points);
-            current_clip_fill_rule.* = entry.clip_fill_rule;
+            if (entry.clip_points) |clip_points| {
+                current_clip_points.clearRetainingCapacity();
+                try current_clip_points.appendSlice(alloc, clip_points);
+                current_clip_fill_rule.* = entry.clip_fill_rule;
+            }
         }
         current_path.clearRetainingCapacity();
         current_path_closed.* = false;
         return;
     }
+    if (std.mem.eql(u8, op, "gs") and out.isLayout()) return;
     if (std.mem.eql(u8, op, "gs") and operands.len >= 1 and operands[operands.len - 1] == .name) {
         if (findExtGState(gstates, operands[operands.len - 1].name)) |gstate| {
             state.alpha = gstate.fill_alpha;
@@ -6606,6 +6823,7 @@ fn applyTextRunOperator(
         }
         return;
     }
+    if (out.isLayout() and isLayoutIgnoredTextOperator(op)) return;
     if (std.mem.eql(u8, op, "m") and operands.len >= 2) {
         current_path.clearRetainingCapacity();
         current_path_closed.* = false;
@@ -6968,7 +7186,7 @@ fn applyTextRunOperator(
         if (operands.len == 0 or operands[operands.len - 1] != .name) return;
         const name = operands[operands.len - 1].name;
         const form = findPageForm(forms, name) orelse return;
-        const start_len = out.items.len;
+        const start_len = out.len();
         var nested_state = buildFormTextState(state.*, form);
         if (form.transparency_group) {
             nested_state.group_parent_id = state.group_id;
@@ -6977,10 +7195,20 @@ fn applyTextRunOperator(
             nested_state.group_knockout = form.group_knockout;
             next_group_id.* += 1;
         }
-        try extractTextRunsFromContentAppendWithState(alloc, out, form.content, form.fonts, form.gstates, form.forms, nested_state, current_clip_points.items, current_clip_fill_rule.*, paint_order, next_group_id);
-        for (out.items[start_len..]) |*run| {
-            run.vectorizable = false;
-            run.font_index = null;
+        const nested_clip = if (out.isLayout()) &.{} else current_clip_points.items;
+        var nested_parser = try PositionedTextParser.init(alloc, out, nested_state, nested_clip, current_clip_fill_rule.*);
+        defer nested_parser.deinit();
+        nested_parser.paint_order = paint_order.*;
+        nested_parser.next_group_id = next_group_id.*;
+        try nested_parser.consume(form.content, form.fonts, form.gstates, form.forms);
+        paint_order.* = nested_parser.paint_order;
+        next_group_id.* = nested_parser.next_group_id;
+        switch (out) {
+            .layout => {},
+            .render => |render_out| for (render_out.items[start_len..]) |*run| {
+                run.vectorizable = false;
+                run.font_index = null;
+            },
         }
         return;
     }
@@ -8193,7 +8421,7 @@ fn appendDecodedString(
 
 fn appendTextRunOperand(
     alloc: Allocator,
-    out: *std.ArrayList(TextRun),
+    out: PositionedTextOutput,
     state: *TextRunState,
     current_clip_points: []const [2]f64,
     current_clip_fill_rule: @FieldType(ShapeRun, "fill_rule"),
@@ -8207,7 +8435,7 @@ fn appendTextRunOperand(
 
 fn appendTextRunDecodedString(
     alloc: Allocator,
-    out: *std.ArrayList(TextRun),
+    out: PositionedTextOutput,
     state: *TextRunState,
     current_clip_points: []const [2]f64,
     current_clip_fill_rule: @FieldType(ShapeRun, "fill_rule"),
@@ -8237,61 +8465,81 @@ fn appendTextRunDecodedString(
         try measureFontAdvanceAlloc(alloc, fonts, font_idx, raw, decoded, state.*)
     else
         estimateDecodedAdvance(decoded, state.*);
-    if (state.render_mode != 3) {
-        const vectorizable = if (state.current_font_index) |font_idx|
-            fonts[font_idx].type3 != null or
-                fonts[font_idx].type1 != null or
-                fonts[font_idx].truetype != null or
-                fonts[font_idx].cff_otf != null
-        else
-            false;
-        const text = try alloc.dupe(u8, decoded);
-        errdefer alloc.free(text);
-        const raw_text = try alloc.dupe(u8, raw);
-        errdefer alloc.free(raw_text);
-        const fill_pattern_name = if (state.fill_pattern_name) |name| try alloc.dupe(u8, name) else null;
-        errdefer if (fill_pattern_name) |name| alloc.free(name);
-        const stroke_pattern_name = if (state.stroke_pattern_name) |name| try alloc.dupe(u8, name) else null;
-        errdefer if (stroke_pattern_name) |name| alloc.free(name);
-        const clip_points = if (current_clip_points.len > 0) try alloc.dupe([2]f64, current_clip_points) else null;
-        errdefer if (clip_points) |clip| alloc.free(clip);
-        try out.append(alloc, .{
-            .text = text,
-            .raw_text = raw_text,
-            .font_index = if (state.current_font_index) |idx| @intCast(idx) else null,
-            .vectorizable = vectorizable,
-            .x = position[0],
-            .y = position[1],
-            .font_size = state.font_size,
-            .a = basis_x[0],
-            .b = basis_x[1],
-            .c = basis_y[0],
-            .d = basis_y[1],
-            .alpha = state.alpha,
-            .stroke_alpha = state.stroke_alpha,
-            .render_mode = state.render_mode,
-            .fill_color = state.fill_color,
-            .stroke_color = state.stroke_color,
-            .stroke_width = state.stroke_width,
-            .horizontal_scale = state.horizontal_scale,
-            .char_spacing = state.char_spacing,
-            .word_spacing = state.word_spacing,
-            .advance_width = advance_width,
-            .ascent = metrics.ascent,
-            .descent = metrics.descent,
-            .paint_order = paint_order,
-            .blend_mode = state.blend_mode,
-            .group_id = state.group_id,
-            .group_parent_id = state.group_parent_id,
-            .group_isolated = state.group_isolated,
-            .group_knockout = state.group_knockout,
-            .fill_pattern_name = fill_pattern_name,
-            .stroke_pattern_name = stroke_pattern_name,
-            .clip_box = state.clip_box,
-            .clip_points = clip_points,
-            .clip_fill_rule = current_clip_fill_rule,
-        });
-    }
+    if (state.render_mode != 3) switch (out) {
+        .layout => |layout_out| {
+            const text = try alloc.dupe(u8, decoded);
+            errdefer alloc.free(text);
+            try layout_out.append(alloc, .{
+                .text = text,
+                .x = position[0],
+                .y = position[1],
+                .font_size = state.font_size,
+                .a = basis_x[0],
+                .b = basis_x[1],
+                .c = basis_y[0],
+                .d = basis_y[1],
+                .advance_width = advance_width,
+                .ascent = metrics.ascent,
+                .descent = metrics.descent,
+                .paint_order = paint_order,
+            });
+        },
+        .render => |render_out| {
+            const vectorizable = if (state.current_font_index) |font_idx|
+                fonts[font_idx].type3 != null or
+                    fonts[font_idx].type1 != null or
+                    fonts[font_idx].truetype != null or
+                    fonts[font_idx].cff_otf != null
+            else
+                false;
+            const text = try alloc.dupe(u8, decoded);
+            errdefer alloc.free(text);
+            const raw_text = try alloc.dupe(u8, raw);
+            errdefer alloc.free(raw_text);
+            const fill_pattern_name = if (state.fill_pattern_name) |name| try alloc.dupe(u8, name) else null;
+            errdefer if (fill_pattern_name) |name| alloc.free(name);
+            const stroke_pattern_name = if (state.stroke_pattern_name) |name| try alloc.dupe(u8, name) else null;
+            errdefer if (stroke_pattern_name) |name| alloc.free(name);
+            const clip_points = if (current_clip_points.len > 0) try alloc.dupe([2]f64, current_clip_points) else null;
+            errdefer if (clip_points) |clip| alloc.free(clip);
+            try render_out.append(alloc, .{
+                .text = text,
+                .raw_text = raw_text,
+                .font_index = if (state.current_font_index) |idx| @intCast(idx) else null,
+                .vectorizable = vectorizable,
+                .x = position[0],
+                .y = position[1],
+                .font_size = state.font_size,
+                .a = basis_x[0],
+                .b = basis_x[1],
+                .c = basis_y[0],
+                .d = basis_y[1],
+                .alpha = state.alpha,
+                .stroke_alpha = state.stroke_alpha,
+                .render_mode = state.render_mode,
+                .fill_color = state.fill_color,
+                .stroke_color = state.stroke_color,
+                .stroke_width = state.stroke_width,
+                .horizontal_scale = state.horizontal_scale,
+                .char_spacing = state.char_spacing,
+                .word_spacing = state.word_spacing,
+                .advance_width = advance_width,
+                .ascent = metrics.ascent,
+                .descent = metrics.descent,
+                .paint_order = paint_order,
+                .blend_mode = state.blend_mode,
+                .group_id = state.group_id,
+                .group_parent_id = state.group_parent_id,
+                .group_isolated = state.group_isolated,
+                .group_knockout = state.group_knockout,
+                .fill_pattern_name = fill_pattern_name,
+                .stroke_pattern_name = stroke_pattern_name,
+                .clip_box = state.clip_box,
+                .clip_points = clip_points,
+                .clip_fill_rule = current_clip_fill_rule,
+            });
+        },
+    };
 
     state.x += advance_width * state.text_a;
     state.y += advance_width * state.text_b;
@@ -8444,15 +8692,15 @@ fn sameNonWhitespaceBytes(left: []const u8, right: []const u8) bool {
     }
 }
 
-fn textRunAxisLength(run: TextRun) f64 {
+fn textRunAxisLength(run: anytype) f64 {
     return @sqrt(run.a * run.a + run.b * run.b);
 }
 
-fn textRunVerticalScale(run: TextRun) f64 {
+fn textRunVerticalScale(run: anytype) f64 {
     return @sqrt(run.c * run.c + run.d * run.d);
 }
 
-fn textRunsShareLine(previous: TextRun, current: TextRun) bool {
+fn textRunsShareLine(previous: anytype, current: anytype) bool {
     const previous_axis = textRunAxisLength(previous);
     const current_axis = textRunAxisLength(current);
     if (previous_axis <= 0.000001 or current_axis <= 0.000001) return false;
@@ -8473,7 +8721,7 @@ fn textRunsShareLine(previous: TextRun, current: TextRun) bool {
     return cross_axis_gap <= line_tolerance;
 }
 
-fn textRunForwardGap(previous: TextRun, current: TextRun) f64 {
+fn textRunForwardGap(previous: anytype, current: anytype) f64 {
     const axis = textRunAxisLength(previous);
     if (axis <= 0.000001) return 0;
     const previous_end_x = previous.x + previous.a * previous.advance_width;
@@ -8482,7 +8730,24 @@ fn textRunForwardGap(previous: TextRun, current: TextRun) f64 {
         (current.y - previous_end_y) * (previous.b / axis);
 }
 
-fn appendLayoutNewline(alloc: Allocator, out: *std.ArrayList(u8)) !void {
+fn clearTextRunOutputSpans(runs: anytype) void {
+    for (runs) |*run| run.output_span = null;
+}
+
+fn clampTextRunOutputSpans(runs: anytype, output_len: usize) void {
+    for (runs) |*run| {
+        const span = run.output_span orelse continue;
+        if (span.end <= output_len) continue;
+        if (span.start >= output_len) {
+            run.output_span = null;
+        } else {
+            run.output_span = .{ .start = span.start, .end = output_len };
+        }
+    }
+}
+
+fn appendLayoutNewline(alloc: Allocator, out: *std.ArrayList(u8), runs: anytype) !void {
+    const original_len = out.items.len;
     while (out.items.len > 0 and
         (out.items[out.items.len - 1] == ' ' or
             out.items[out.items.len - 1] == '\t' or
@@ -8490,6 +8755,7 @@ fn appendLayoutNewline(alloc: Allocator, out: *std.ArrayList(u8)) !void {
     {
         _ = out.pop();
     }
+    if (out.items.len != original_len) clampTextRunOutputSpans(runs, out.items.len);
     try appendNewline(alloc, out);
 }
 
@@ -8501,21 +8767,23 @@ fn endsWithColon(text: []const u8) bool {
     return text.len > 0 and text[text.len - 1] == ':';
 }
 
-fn reconstructTextFromRunsAlloc(alloc: Allocator, runs: []const TextRun) ![]u8 {
+fn reconstructTextFromRunsAlloc(alloc: Allocator, runs: anytype) ![]u8 {
+    clearTextRunOutputSpans(runs);
     var out = std.ArrayList(u8).empty;
     defer out.deinit(alloc);
-    var previous: ?TextRun = null;
-    for (runs) |run| {
+    var previous_index: ?usize = null;
+    for (runs, 0..) |*run, run_index| {
         if (run.text.len == 0) continue;
-        if (previous) |prior| {
-            if (!textRunsShareLine(prior, run)) {
-                try appendLayoutNewline(alloc, &out);
+        if (previous_index) |prior_index| {
+            const prior = runs[prior_index];
+            if (!textRunsShareLine(prior, run.*)) {
+                try appendLayoutNewline(alloc, &out, runs[0..run_index]);
             } else if (!std.ascii.isWhitespace(out.items[out.items.len - 1]) and
                 !std.ascii.isWhitespace(run.text[0]))
             {
                 const axis = textRunAxisLength(prior);
                 const font_scale = @abs(prior.font_size) * axis;
-                const gap = textRunForwardGap(prior, run);
+                const gap = textRunForwardGap(prior, run.*);
                 const word_gap = @max(0.5, font_scale * 0.12);
                 const operator_overlap_tolerance = font_scale * 0.15;
                 const operator_boundary = prior.paint_order != run.paint_order;
@@ -8531,8 +8799,11 @@ fn reconstructTextFromRunsAlloc(alloc: Allocator, runs: []const TextRun) ![]u8 {
                 }
             }
         }
+        const start = out.items.len;
         try out.appendSlice(alloc, run.text);
-        previous = run;
+        const end = out.items.len;
+        if (start < end) run.output_span = .{ .start = start, .end = end };
+        previous_index = run_index;
     }
     try appendNewline(alloc, &out);
     return try out.toOwnedSlice(alloc);
@@ -8562,6 +8833,19 @@ fn isShapePaintOperator(op: []const u8) bool {
         std.mem.eql(u8, op, "s") or std.mem.eql(u8, op, "B") or
         std.mem.eql(u8, op, "B*") or std.mem.eql(u8, op, "b") or
         std.mem.eql(u8, op, "b*");
+}
+
+fn isLayoutIgnoredTextOperator(op: []const u8) bool {
+    if (isShapePaintOperator(op) or std.mem.eql(u8, op, "sh")) return true;
+    const ignored = [_][]const u8{
+        "m",   "l",  "c",   "v", "y", "h", "re", "W",  "W*", "n",
+        "w",   "rg", "RG",  "g", "G", "k", "K",  "cs", "CS", "sc",
+        "scn", "SC", "SCN",
+    };
+    for (ignored) |candidate| {
+        if (std.mem.eql(u8, op, candidate)) return true;
+    }
+    return false;
 }
 
 fn isTextShowOperator(op: []const u8) bool {
@@ -8852,7 +9136,13 @@ fn buildPatternRunAlloc(
     defer tile_text_list.deinit(alloc);
     errdefer for (tile_text_list.items) |*run| run.deinit(alloc);
     const text_state = buildPatternTextState(state);
-    try extractTextRunsFromContentAppendWithState(alloc, &tile_text_list, pattern.content, pattern.fonts, pattern.gstates, pattern.forms, text_state, &.{}, .nonzero, &tile_paint_order, &tile_group_id);
+    var text_parser = try PositionedTextParser.init(alloc, .{ .render = &tile_text_list }, text_state, &.{}, .nonzero);
+    defer text_parser.deinit();
+    text_parser.paint_order = tile_paint_order;
+    text_parser.next_group_id = tile_group_id;
+    try text_parser.consume(pattern.content, pattern.fonts, pattern.gstates, pattern.forms);
+    tile_paint_order = text_parser.paint_order;
+    tile_group_id = text_parser.next_group_id;
 
     var tile_pattern_list = std.ArrayList(PatternRun).empty;
     defer tile_pattern_list.deinit(alloc);
@@ -10775,7 +11065,7 @@ test "reader caches shared page fonts across text analysis" {
 
 test "reader reconstructs spaces and lines from positioned text runs" {
     const alloc = std.testing.allocator;
-    const runs = [_]TextRun{
+    var runs = [_]TextRun{
         .{ .text = "Max", .x = 0, .y = 100, .font_size = 10, .advance_width = 15, .paint_order = 0 },
         .{ .text = "Length", .x = 17, .y = 100, .font_size = 10, .advance_width = 30, .paint_order = 0 },
         .{ .text = "Avg", .x = 46.5, .y = 100, .font_size = 10, .advance_width = 14, .paint_order = 1 },
@@ -10789,9 +11079,23 @@ test "reader reconstructs spaces and lines from positioned text runs" {
     try std.testing.expect(!sameNonWhitespaceBytes("MaxLengthAvg Multi-vector", text));
 }
 
+test "reader clamps reconstructed spans after trimming line whitespace" {
+    const alloc = std.testing.allocator;
+    var runs = [_]TextRun{
+        .{ .text = "Heading ", .x = 0, .y = 100, .font_size = 10, .advance_width = 40, .paint_order = 0 },
+        .{ .text = "Body", .x = 0, .y = 80, .font_size = 10, .advance_width = 20, .paint_order = 1 },
+    };
+    const text = try reconstructTextFromRunsAlloc(alloc, &runs);
+    defer alloc.free(text);
+
+    try std.testing.expectEqualStrings("Heading\nBody\n", text);
+    try std.testing.expectEqual(TextOutputSpan{ .start = 0, .end = 7 }, runs[0].output_span.?);
+    try std.testing.expectEqual(TextOutputSpan{ .start = 8, .end = 12 }, runs[1].output_span.?);
+}
+
 test "reader separates caption punctuation despite overlapping metrics" {
     const alloc = std.testing.allocator;
-    const runs = [_]TextRun{
+    var runs = [_]TextRun{
         .{ .text = "Figure", .x = 0, .y = 100, .font_size = 10, .advance_width = 30, .paint_order = 0 },
         .{ .text = "4:", .x = 32, .y = 100, .font_size = 10, .advance_width = 10, .paint_order = 0 },
         .{ .text = "Statics", .x = 35, .y = 100, .font_size = 10, .advance_width = 35, .paint_order = 1 },
@@ -10855,6 +11159,100 @@ test "reader extracts positioned text runs from text matrix operators" {
     try std.testing.expectApproxEqAbs(@as(f64, 72), runs[0].x, 0.001);
     try std.testing.expectApproxEqAbs(@as(f64, 1), runs[0].a, 0.001);
     try std.testing.expectApproxEqAbs(@as(f64, 0), runs[0].b, 0.001);
+}
+
+test "reader preserves text state across page content streams" {
+    const alloc = std.testing.allocator;
+    const first_content = "q 2 0 0 2 0 0 cm BT /F1 12 Tf 1 0 0 1 72 360 Tm (Hello) Tj\n";
+    const second_content = "(World) Tj ET Q\n";
+    const objects = [_][]const u8{
+        "1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n",
+        "2 0 obj\n<< /Type /Pages /Count 1 /Kids [3 0 R] >>\nendobj\n",
+        "3 0 obj\n<< /Type /Page /Parent 2 0 R /Resources << /Font << /F1 6 0 R >> >> /Contents [4 0 R 5 0 R] >>\nendobj\n",
+        try std.fmt.allocPrint(alloc, "4 0 obj\n<< /Length {d} >>\nstream\n{s}endstream\nendobj\n", .{ first_content.len, first_content }),
+        try std.fmt.allocPrint(alloc, "5 0 obj\n<< /Length {d} >>\nstream\n{s}endstream\nendobj\n", .{ second_content.len, second_content }),
+        "6 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /StandardEncoding >>\nendobj\n",
+    };
+    defer alloc.free(objects[3]);
+    defer alloc.free(objects[4]);
+
+    var prefix = std.ArrayList(u8).empty;
+    defer prefix.deinit(alloc);
+    try prefix.appendSlice(alloc, "%PDF-1.7\n");
+    var offsets: [objects.len]usize = undefined;
+    for (objects, 0..) |object, i| {
+        offsets[i] = prefix.items.len;
+        try prefix.appendSlice(alloc, object);
+    }
+    const xref_offset = prefix.items.len;
+    try prefix.appendSlice(alloc, "xref\n0 7\n0000000000 65535 f \n");
+    for (offsets) |offset| {
+        const line = try std.fmt.allocPrint(alloc, "{d:0>10} 00000 n \n", .{offset});
+        defer alloc.free(line);
+        try prefix.appendSlice(alloc, line);
+    }
+    try prefix.appendSlice(alloc, "trailer\n<< /Size 7 /Root 1 0 R >>\n");
+    const sample = try std.fmt.allocPrint(alloc, "{s}startxref\n{d}\n%%EOF\n", .{ prefix.items, xref_offset });
+    defer alloc.free(sample);
+
+    var reader = try Reader.init(alloc, sample);
+    defer reader.deinit();
+    const plain_text = try reader.extractPageTextAlloc(1);
+    defer alloc.free(plain_text);
+    var analysis = try reader.extractPageTextAnalysisAlloc(1);
+    defer analysis.deinit(alloc);
+
+    try std.testing.expectEqualStrings("Hello World", std.mem.trim(u8, plain_text, &std.ascii.whitespace));
+    try std.testing.expectEqualStrings("Hello World", std.mem.trim(u8, analysis.text, &std.ascii.whitespace));
+    try std.testing.expectEqual(@as(usize, 2), analysis.runs.len);
+    const first = analysis.runs[0];
+    const second = analysis.runs[1];
+    try std.testing.expectApproxEqAbs(first.y, second.y, 0.001);
+    try std.testing.expectApproxEqAbs(first.a, second.a, 0.001);
+    try std.testing.expectApproxEqAbs(first.b, second.b, 0.001);
+    try std.testing.expectApproxEqAbs(first.c, second.c, 0.001);
+    try std.testing.expectApproxEqAbs(first.d, second.d, 0.001);
+    try std.testing.expect(second.x > first.x);
+    try std.testing.expect(first.font_index != null);
+    try std.testing.expectEqual(first.font_index, second.font_index);
+}
+
+test "reader plain text ignores unused malformed extended graphics state" {
+    const alloc = std.testing.allocator;
+    const content = "BT /F1 12 Tf 1 0 0 1 72 720 Tm (Plain) Tj ET\n";
+    const objects = [_][]const u8{
+        "1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n",
+        "2 0 obj\n<< /Type /Pages /Count 1 /Kids [3 0 R] >>\nendobj\n",
+        "3 0 obj\n<< /Type /Page /Parent 2 0 R /Resources << /Font << /F1 5 0 R >> /ExtGState << /Bad 99 0 R >> >> /Contents 4 0 R >>\nendobj\n",
+        try std.fmt.allocPrint(alloc, "4 0 obj\n<< /Length {d} >>\nstream\n{s}endstream\nendobj\n", .{ content.len, content }),
+        "5 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /StandardEncoding >>\nendobj\n",
+    };
+    defer alloc.free(objects[3]);
+
+    var prefix = std.ArrayList(u8).empty;
+    defer prefix.deinit(alloc);
+    try prefix.appendSlice(alloc, "%PDF-1.7\n");
+    var offsets: [objects.len]usize = undefined;
+    for (objects, 0..) |object, i| {
+        offsets[i] = prefix.items.len;
+        try prefix.appendSlice(alloc, object);
+    }
+    const xref_offset = prefix.items.len;
+    try prefix.appendSlice(alloc, "xref\n0 6\n0000000000 65535 f \n");
+    for (offsets) |offset| {
+        const line = try std.fmt.allocPrint(alloc, "{d:0>10} 00000 n \n", .{offset});
+        defer alloc.free(line);
+        try prefix.appendSlice(alloc, line);
+    }
+    try prefix.appendSlice(alloc, "trailer\n<< /Size 6 /Root 1 0 R >>\n");
+    const sample = try std.fmt.allocPrint(alloc, "{s}startxref\n{d}\n%%EOF\n", .{ prefix.items, xref_offset });
+    defer alloc.free(sample);
+
+    var reader = try Reader.init(alloc, sample);
+    defer reader.deinit();
+    const text = try reader.extractPageTextAlloc(1);
+    defer alloc.free(text);
+    try std.testing.expectEqualStrings("Plain", std.mem.trim(u8, text, &std.ascii.whitespace));
 }
 
 test "reader preserves rotated text transform on runs" {
@@ -11469,8 +11867,8 @@ test "PDF render run ownership is allocation-failure safe" {
                 .fill_pattern_name = "fill-pattern",
                 .stroke_pattern_name = "stroke-pattern",
             };
-            try appendTextRunDecodedString(alloc, &text_runs, &text_state, &clip, .nonzero, &.{}, 1, "owned text");
-            try appendTextRunDecodedString(alloc, &text_runs, &text_state, &clip, .nonzero, &.{}, 2, "second run");
+            try appendTextRunDecodedString(alloc, .{ .render = &text_runs }, &text_state, &clip, .nonzero, &.{}, 1, "owned text");
+            try appendTextRunDecodedString(alloc, .{ .render = &text_runs }, &text_state, &clip, .nonzero, &.{}, 2, "second run");
 
             var shape_runs = std.ArrayList(ShapeRun).empty;
             defer {

--- a/zig/lib/pdf/src/reader.zig
+++ b/zig/lib/pdf/src/reader.zig
@@ -1262,12 +1262,18 @@ fn extractShapeRunsFromContentAppendWithState(
 
 const EncryptionContext = struct {
     file_key: [16]u8,
+    file_key_len: u8,
     method: Method,
 
     const Method = enum {
         rc4,
         aesv2,
     };
+};
+
+const ObjectEncryptionKey = struct {
+    bytes: [16]u8,
+    len: u8,
 };
 
 const pdf_password_padding = [_]u8{
@@ -1319,28 +1325,36 @@ fn decryptAesV2Alloc(alloc: Allocator, encrypted: []const u8, key: [16]u8) ![]u8
     return result;
 }
 
-fn decryptRc4Alloc(alloc: Allocator, encrypted: []const u8, key: [16]u8) ![]u8 {
+fn decryptRc4Alloc(alloc: Allocator, encrypted: []const u8, key: ObjectEncryptionKey) ![]u8 {
     const plaintext = try alloc.dupe(u8, encrypted);
-    rc4Crypt(&key, plaintext);
+    rc4Crypt(key.bytes[0..key.len], plaintext);
     return plaintext;
 }
 
-fn objectEncryptionKey(file_key: [16]u8, ptr: syntax.ObjRef, method: EncryptionContext.Method) [16]u8 {
+fn objectEncryptionKey(
+    file_key: [16]u8,
+    file_key_len: usize,
+    ptr: syntax.ObjRef,
+    method: EncryptionContext.Method,
+) ObjectEncryptionKey {
+    std.debug.assert(file_key_len >= 5 and file_key_len <= 16);
     var material: [25]u8 = undefined;
-    @memcpy(material[0..16], &file_key);
-    material[16] = @truncate(ptr.id);
-    material[17] = @truncate(ptr.id >> 8);
-    material[18] = @truncate(ptr.id >> 16);
-    material[19] = @truncate(ptr.gen);
-    material[20] = @truncate(ptr.gen >> 8);
-    const material_len: usize = switch (method) {
-        .rc4 => 21,
-        .aesv2 => blk: {
-            @memcpy(material[21..25], "sAlT");
-            break :blk 25;
-        },
+    @memcpy(material[0..file_key_len], file_key[0..file_key_len]);
+    var material_len = file_key_len;
+    material[material_len] = @truncate(ptr.id);
+    material[material_len + 1] = @truncate(ptr.id >> 8);
+    material[material_len + 2] = @truncate(ptr.id >> 16);
+    material[material_len + 3] = @truncate(ptr.gen);
+    material[material_len + 4] = @truncate(ptr.gen >> 8);
+    material_len += 5;
+    if (method == .aesv2) {
+        @memcpy(material[material_len..][0..4], "sAlT");
+        material_len += 4;
+    }
+    return .{
+        .bytes = std.crypto.hash.Md5.hashResult(material[0..material_len]),
+        .len = @intCast(@min(file_key_len + 5, 16)),
     };
-    return std.crypto.hash.Md5.hashResult(material[0..material_len]);
 }
 
 pub const Reader = struct {
@@ -1485,9 +1499,9 @@ pub const Reader = struct {
 
     fn initializeEncryption(self: *Reader) !void {
         // Support common empty-user-password compatibility encryption used by
-        // public document corpora: V2/R3 RC4 and V4/R4 AESV2, both with
-        // 128-bit file keys. Password-protected documents and newer handlers
-        // remain explicitly unsupported rather than guessing.
+        // public document corpora: V1/R2 and V2/R3 RC4 plus V4/R4 AESV2.
+        // Password-protected documents and newer handlers remain explicitly
+        // unsupported rather than guessing.
         const encrypt_value = self.trailerGet("Encrypt") orelse return;
         var encrypt = try self.resolveValue(encrypt_value);
         defer encrypt.deinit(self.alloc);
@@ -1495,20 +1509,33 @@ pub const Reader = struct {
         if (!std.mem.eql(u8, (encrypt.get("Filter") orelse return error.UnsupportedPdfEncryption).asName() orelse return error.UnsupportedPdfEncryption, "Standard")) return error.UnsupportedPdfEncryption;
         const version = (encrypt.get("V") orelse return error.UnsupportedPdfEncryption).asInteger() orelse return error.UnsupportedPdfEncryption;
         const revision = (encrypt.get("R") orelse return error.UnsupportedPdfEncryption).asInteger() orelse return error.UnsupportedPdfEncryption;
-        if ((encrypt.get("Length") orelse return error.UnsupportedPdfEncryption).asInteger() != 128) return error.UnsupportedPdfEncryption;
-        const method: EncryptionContext.Method = if (version == 2 and revision == 3)
+        const length_bits = if (encrypt.get("Length")) |length|
+            length.asInteger() orelse return error.UnsupportedPdfEncryption
+        else if (version == 1 and revision == 2)
+            40
+        else
+            return error.UnsupportedPdfEncryption;
+        const method: EncryptionContext.Method = if (version == 1 and revision == 2 and length_bits == 40)
             .rc4
-        else if (version == 4 and revision == 4)
+        else if (version == 2 and revision == 3 and length_bits == 128)
+            .rc4
+        else if (version == 4 and revision == 4 and length_bits == 128)
             .aesv2
         else
             return error.UnsupportedPdfEncryption;
+        const file_key_len: usize = @intCast(@divExact(length_bits, 8));
         const owner_key = switch ((encrypt.get("O") orelse return error.UnsupportedPdfEncryption).*) {
             .string => |value| value,
             else => return error.UnsupportedPdfEncryption,
         };
         if (owner_key.len != 32) return error.UnsupportedPdfEncryption;
         const permissions_i = (encrypt.get("P") orelse return error.UnsupportedPdfEncryption).asInteger() orelse return error.UnsupportedPdfEncryption;
-        if (permissions_i < std.math.minInt(i32) or permissions_i > std.math.maxInt(i32)) return error.UnsupportedPdfEncryption;
+        const permission_bits: u32 = if (permissions_i >= std.math.minInt(i32) and permissions_i <= std.math.maxInt(i32))
+            @bitCast(@as(i32, @intCast(permissions_i)))
+        else if (permissions_i >= 0 and permissions_i <= std.math.maxInt(u32))
+            @intCast(permissions_i)
+        else
+            return error.UnsupportedPdfEncryption;
         const id_array = switch ((self.trailerGet("ID") orelse return error.UnsupportedPdfEncryption).*) {
             .array => |value| value,
             else => return error.UnsupportedPdfEncryption,
@@ -1530,7 +1557,7 @@ pub const Reader = struct {
         md5.update(&pdf_password_padding);
         md5.update(owner_key);
         var permissions: [4]u8 = undefined;
-        std.mem.writeInt(u32, &permissions, @bitCast(@as(i32, @intCast(permissions_i))), .little);
+        std.mem.writeInt(u32, &permissions, permission_bits, .little);
         md5.update(&permissions);
         md5.update(file_id);
         if (revision >= 4) {
@@ -1540,36 +1567,47 @@ pub const Reader = struct {
         }
         var digest: [16]u8 = undefined;
         md5.final(&digest);
-        for (0..50) |_| digest = std.crypto.hash.Md5.hashResult(&digest);
+        if (revision >= 3) {
+            for (0..50) |_| digest = std.crypto.hash.Md5.hashResult(digest[0..file_key_len]);
+        }
+        var file_key = [_]u8{0} ** 16;
+        @memcpy(file_key[0..file_key_len], digest[0..file_key_len]);
 
         const user_key = switch ((encrypt.get("U") orelse return error.UnsupportedPdfEncryption).*) {
             .string => |value| value,
             else => return error.UnsupportedPdfEncryption,
         };
-        if (user_key.len < 16) return error.UnsupportedPdfEncryption;
-        var user_md5 = std.crypto.hash.Md5.init(.{});
-        user_md5.update(&pdf_password_padding);
-        user_md5.update(file_id);
-        var user_check: [16]u8 = undefined;
-        user_md5.final(&user_check);
-        rc4Crypt(&digest, &user_check);
-        for (1..20) |round| {
-            var round_key: [16]u8 = undefined;
-            for (&round_key, digest) |*value, key_byte| value.* = key_byte ^ @as(u8, @intCast(round));
-            rc4Crypt(&round_key, &user_check);
+        if (revision == 2) {
+            if (user_key.len < pdf_password_padding.len) return error.UnsupportedPdfEncryption;
+            var user_check = pdf_password_padding;
+            rc4Crypt(file_key[0..file_key_len], &user_check);
+            if (!std.mem.eql(u8, user_key[0..pdf_password_padding.len], &user_check)) return error.UnsupportedPdfEncryption;
+        } else {
+            if (user_key.len < 16) return error.UnsupportedPdfEncryption;
+            var user_md5 = std.crypto.hash.Md5.init(.{});
+            user_md5.update(&pdf_password_padding);
+            user_md5.update(file_id);
+            var user_check: [16]u8 = undefined;
+            user_md5.final(&user_check);
+            rc4Crypt(file_key[0..file_key_len], &user_check);
+            for (1..20) |round| {
+                var round_key: [16]u8 = undefined;
+                for (round_key[0..file_key_len], file_key[0..file_key_len]) |*value, key_byte| value.* = key_byte ^ @as(u8, @intCast(round));
+                rc4Crypt(round_key[0..file_key_len], &user_check);
+            }
+            if (!std.mem.eql(u8, user_key[0..16], &user_check)) return error.UnsupportedPdfEncryption;
         }
-        if (!std.mem.eql(u8, user_key[0..16], &user_check)) return error.UnsupportedPdfEncryption;
-        self.encryption = .{ .file_key = digest, .method = method };
+        self.encryption = .{ .file_key = file_key, .file_key_len = @intCast(file_key_len), .method = method };
     }
 
     fn decryptObject(self: *const Reader, obj: *syntax.Object, ptr: syntax.ObjRef) !void {
         const context = self.encryption orelse return;
-        const key = objectEncryptionKey(context.file_key, ptr, context.method);
+        const key = objectEncryptionKey(context.file_key, context.file_key_len, ptr, context.method);
         switch (obj.*) {
             .string => |encrypted| {
                 const decrypted = switch (context.method) {
                     .rc4 => try decryptRc4Alloc(self.alloc, encrypted, key),
-                    .aesv2 => try decryptAesV2Alloc(self.alloc, encrypted, key),
+                    .aesv2 => try decryptAesV2Alloc(self.alloc, encrypted, key.bytes),
                 };
                 self.alloc.free(encrypted);
                 obj.* = .{ .string = decrypted };
@@ -1584,7 +1622,7 @@ pub const Reader = struct {
                     if (end > self.bytes.len) return error.InvalidObjectOffset;
                     const decrypted = switch (context.method) {
                         .rc4 => try decryptRc4Alloc(self.alloc, self.bytes[stream.data_offset..end], key),
-                        .aesv2 => try decryptAesV2Alloc(self.alloc, self.bytes[stream.data_offset..end], key),
+                        .aesv2 => try decryptAesV2Alloc(self.alloc, self.bytes[stream.data_offset..end], key.bytes),
                     };
                     errdefer self.alloc.free(decrypted);
                     try self.decrypted_streams.put(self.alloc, stream.data_offset, decrypted);
@@ -8455,6 +8493,14 @@ fn appendLayoutNewline(alloc: Allocator, out: *std.ArrayList(u8)) !void {
     try appendNewline(alloc, out);
 }
 
+fn startsWithAsciiUpper(text: []const u8) bool {
+    return text.len > 0 and std.ascii.isUpper(text[0]);
+}
+
+fn endsWithColon(text: []const u8) bool {
+    return text.len > 0 and text[text.len - 1] == ':';
+}
+
 fn reconstructTextFromRunsAlloc(alloc: Allocator, runs: []const TextRun) ![]u8 {
     var out = std.ArrayList(u8).empty;
     defer out.deinit(alloc);
@@ -8472,8 +8518,14 @@ fn reconstructTextFromRunsAlloc(alloc: Allocator, runs: []const TextRun) ![]u8 {
                 const gap = textRunForwardGap(prior, run);
                 const word_gap = @max(0.5, font_scale * 0.12);
                 const operator_overlap_tolerance = font_scale * 0.15;
+                const operator_boundary = prior.paint_order != run.paint_order;
+                const caption_boundary =
+                    prior.paint_order != run.paint_order and
+                    endsWithColon(prior.text) and
+                    startsWithAsciiUpper(run.text);
                 if (gap > word_gap or
-                    (prior.paint_order != run.paint_order and gap > -operator_overlap_tolerance))
+                    caption_boundary or
+                    (operator_boundary and gap > -operator_overlap_tolerance))
                 {
                     try out.append(alloc, ' ');
                 }
@@ -10591,17 +10643,38 @@ test "AESV2 object data decrypts and removes PKCS7 padding" {
 test "RC4 object data decrypts with the unsalted object key" {
     const alloc = std.testing.allocator;
     const file_key = [_]u8{ 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f };
-    const key = objectEncryptionKey(file_key, .{ .id = 42, .gen = 3 }, .rc4);
+    const key = objectEncryptionKey(file_key, file_key.len, .{ .id = 42, .gen = 3 }, .rc4);
     const encrypted = try alloc.dupe(u8, "hello legacy encrypted pdf");
     defer alloc.free(encrypted);
-    rc4Crypt(&key, encrypted);
+    rc4Crypt(key.bytes[0..key.len], encrypted);
 
     const decrypted = try decryptRc4Alloc(alloc, encrypted, key);
     defer alloc.free(decrypted);
     try std.testing.expectEqualStrings("hello legacy encrypted pdf", decrypted);
 
-    const aes_key = objectEncryptionKey(file_key, .{ .id = 42, .gen = 3 }, .aesv2);
-    try std.testing.expect(!std.mem.eql(u8, &key, &aes_key));
+    const short_key = objectEncryptionKey(file_key, 5, .{ .id = 42, .gen = 3 }, .rc4);
+    try std.testing.expectEqual(@as(u8, 10), short_key.len);
+    const aes_key = objectEncryptionKey(file_key, file_key.len, .{ .id = 42, .gen = 3 }, .aesv2);
+    try std.testing.expectEqual(@as(u8, 16), aes_key.len);
+    try std.testing.expect(!std.mem.eql(u8, &key.bytes, &aes_key.bytes));
+}
+
+test "reader extracts empty-password Standard R2 RC4 PDF" {
+    const alloc = std.testing.allocator;
+    const fixture = @embedFile("../testdata/rc4_40_empty_password_fixture.pdf");
+    var reader = Reader.init(alloc, fixture) catch |err| {
+        std.debug.print("RC4-40 reader init failed: {}\n", .{err});
+        return err;
+    };
+    defer reader.deinit();
+    try std.testing.expectEqual(@as(u8, 5), reader.encryption.?.file_key_len);
+    try std.testing.expectEqual(EncryptionContext.Method.rc4, reader.encryption.?.method);
+    const text = reader.extractPageTextAlloc(1) catch |err| {
+        std.debug.print("RC4-40 text extraction failed: {}\n", .{err});
+        return err;
+    };
+    defer alloc.free(text);
+    try std.testing.expectEqualStrings("Hello RC4-40", std.mem.trim(u8, text, &std.ascii.whitespace));
 }
 
 test "stream filter prefix decoding stops before DCT data" {
@@ -10714,6 +10787,18 @@ test "reader reconstructs spaces and lines from positioned text runs" {
     try std.testing.expectEqualStrings("Max Length Avg\nMulti-vec\n", text);
     try std.testing.expect(sameNonWhitespaceBytes("MaxLengthAvg Multi-vec", text));
     try std.testing.expect(!sameNonWhitespaceBytes("MaxLengthAvg Multi-vector", text));
+}
+
+test "reader separates caption punctuation despite overlapping metrics" {
+    const alloc = std.testing.allocator;
+    const runs = [_]TextRun{
+        .{ .text = "Figure", .x = 0, .y = 100, .font_size = 10, .advance_width = 30, .paint_order = 0 },
+        .{ .text = "4:", .x = 32, .y = 100, .font_size = 10, .advance_width = 10, .paint_order = 0 },
+        .{ .text = "Statics", .x = 35, .y = 100, .font_size = 10, .advance_width = 35, .paint_order = 1 },
+    };
+    const text = try reconstructTextFromRunsAlloc(alloc, &runs);
+    defer alloc.free(text);
+    try std.testing.expectEqualStrings("Figure 4: Statics\n", text);
 }
 
 test "reader extracts positioned text runs from text matrix operators" {

--- a/zig/lib/pdf/src/syntax.zig
+++ b/zig/lib/pdf/src/syntax.zig
@@ -243,14 +243,17 @@ pub const Scanner = struct {
                         }
                         if (tok3 == .keyword and std.mem.eql(u8, tok3.keyword, "obj")) {
                             const boxed = try self.alloc.create(Object);
-                            errdefer self.alloc.destroy(boxed);
+                            var boxed_initialized = false;
+                            errdefer {
+                                if (boxed_initialized) boxed.deinit(self.alloc);
+                                self.alloc.destroy(boxed);
+                            }
                             boxed.* = try self.readObject();
+                            boxed_initialized = true;
 
                             var end_tok = try self.readToken();
                             defer end_tok.deinit(self.alloc);
                             if (end_tok != .keyword or !std.mem.eql(u8, end_tok.keyword, "endobj")) {
-                                boxed.deinit(self.alloc);
-                                self.alloc.destroy(boxed);
                                 return error.MissingEndObj;
                             }
 
@@ -344,6 +347,10 @@ pub const Scanner = struct {
 
         const owned = try entries.toOwnedSlice(self.alloc);
         entries = .empty;
+        errdefer {
+            for (owned) |*entry| entry.deinit(self.alloc);
+            self.alloc.free(owned);
+        }
 
         var tok = try self.readToken();
         defer tok.deinit(self.alloc);
@@ -441,7 +448,9 @@ pub const Scanner = struct {
     }
 
     fn unreadToken(self: *Scanner, tok: Token) anyerror!void {
-        try self.unread.append(self.alloc, tok);
+        var owned = tok;
+        errdefer owned.deinit(self.alloc);
+        try self.unread.append(self.alloc, owned);
     }
 
     fn skipSpaceAndComments(self: *Scanner) void {

--- a/zig/lib/pdf/src/syntax.zig
+++ b/zig/lib/pdf/src/syntax.zig
@@ -373,16 +373,12 @@ pub const Scanner = struct {
         const data_offset = self.base_offset + data_start;
         const actual_length = if (streamLength(owned)) |direct_length| blk: {
             if (self.pos + direct_length > self.bytes.len) {
-                for (owned) |*entry| entry.deinit(self.alloc);
-                self.alloc.free(owned);
                 return error.UnexpectedEof;
             }
             self.pos += direct_length;
             break :blk direct_length;
         } else blk: {
             const data_end = findEndStreamDataEnd(self.bytes, self.pos) orelse {
-                for (owned) |*entry| entry.deinit(self.alloc);
-                self.alloc.free(owned);
                 return error.MissingEndStream;
             };
             self.pos = data_end;
@@ -392,8 +388,6 @@ pub const Scanner = struct {
         var end_tok = try self.readToken();
         defer end_tok.deinit(self.alloc);
         if (end_tok != .keyword or !std.mem.eql(u8, end_tok.keyword, "endstream")) {
-            for (owned) |*entry| entry.deinit(self.alloc);
-            self.alloc.free(owned);
             return error.MissingEndStream;
         }
 
@@ -1025,4 +1019,30 @@ test "scanner parses stream object with indirect length" {
     try std.testing.expect(def.obj_def.value.* == .stream);
     try std.testing.expectEqual(@as(usize, 5), def.obj_def.value.stream.data_length);
     try std.testing.expectEqual(expected_offset, def.obj_def.value.stream.data_offset);
+}
+
+test "scanner cleans stream dictionaries on malformed stream endings" {
+    const cases = [_]struct {
+        input: []const u8,
+        expected: anyerror,
+    }{
+        .{
+            .input = "<< /Length 100 >> stream\nx",
+            .expected = error.UnexpectedEof,
+        },
+        .{
+            .input = "<< /Type /Example >> stream\nunterminated",
+            .expected = error.MissingEndStream,
+        },
+        .{
+            .input = "<< /Length 3 >> stream\nabc nope",
+            .expected = error.MissingEndStream,
+        },
+    };
+
+    for (cases) |case| {
+        var scanner = Scanner.init(std.testing.allocator, case.input);
+        defer scanner.deinit();
+        try std.testing.expectError(case.expected, scanner.readObject());
+    }
 }

--- a/zig/lib/pdf/testdata/rc4_40_empty_password_fixture.pdf
+++ b/zig/lib/pdf/testdata/rc4_40_empty_password_fixture.pdf
@@ -1,0 +1,81 @@
+%PDF-1.3
+%‚„œ”
+1 0 obj
+<<
+/Producer <2225e9724c>
+>>
+endobj
+2 0 obj
+<<
+/Type /Pages
+/Count 1
+/Kids [ 4 0 R ]
+>>
+endobj
+3 0 obj
+<<
+/Type /Catalog
+/Pages 2 0 R
+>>
+endobj
+4 0 obj
+<<
+/Type /Page
+/Resources <<
+/Font <<
+/F1 5 0 R
+>>
+>>
+/MediaBox [ 0.0 0.0 612 792 ]
+/Parent 2 0 R
+/Contents 6 0 R
+>>
+endobj
+5 0 obj
+<<
+/Type /Font
+/Subtype /Type1
+/BaseFont /Helvetica
+/Encoding /WinAnsiEncoding
+>>
+endobj
+6 0 obj
+<<
+/Length 43
+>>
+stream
+æ†'@ €Ú}ßh&ÖdÒçPﬂ¸>ú˚ì„ç+uµï0›ÏxY¿IGÆ™Ä
+endstream
+endobj
+7 0 obj
+<<
+/V 1
+/R 2
+/Length 40
+/P 4294967292
+/Filter /Standard
+/O <f6ded8eb9448bf31370439d381eb5fd53a3ada02157f59bb846d85f1a65045cc>
+/U <7a0caf9cc7f8fa74bc80bf4641d8f245c254a8d0500546217174bd09a8f67ad9>
+>>
+endobj
+xref
+0 8
+0000000000 65535 f 
+0000000015 00000 n 
+0000000059 00000 n 
+0000000118 00000 n 
+0000000167 00000 n 
+0000000299 00000 n 
+0000000396 00000 n 
+0000000489 00000 n 
+trailer
+<<
+/Size 8
+/Root 3 0 R
+/Info 1 0 R
+/ID [ <3162666330616231363339666233376635336434363364393234313237656135> <3162666330616231363339666233376635336434363364393234313237656135> ]
+/Encrypt 7 0 R
+>>
+startxref
+703
+%%EOF

--- a/zig/lib/vectorindex/src/spfresh_index.zig
+++ b/zig/lib/vectorindex/src/spfresh_index.zig
@@ -454,6 +454,13 @@ pub fn runAutoPostingMaintenanceTxn(self: anytype, txn: anytype) !void {
     _ = try repairDirtyPostingsTxnWithOptions(self, txn, .{ .max_postings = max_postings });
 }
 
+fn replaceOwnedU64Slice(alloc: std.mem.Allocator, target: *[]u64, replacement: *?[]u64) void {
+    const owned = replacement.* orelse unreachable;
+    if (target.*.len > 0) alloc.free(target.*);
+    target.* = owned;
+    replacement.* = null;
+}
+
 fn mergeUnderfullPostingWithNearestSibling(
     self: anytype,
     txn: anytype,
@@ -487,12 +494,11 @@ fn mergeUnderfullPostingWithNearestSibling(
     try sibling.ensureUnbacked(self.alloc);
 
     const merged_len = sibling.members.len + leaf.members.len;
-    var merged = try self.alloc.alloc(u64, merged_len);
-    errdefer self.alloc.free(merged);
-    @memcpy(merged[0..sibling.members.len], sibling.members);
-    @memcpy(merged[sibling.members.len..], leaf.members);
-    self.alloc.free(sibling.members);
-    sibling.members = merged;
+    var merged: ?[]u64 = try self.alloc.alloc(u64, merged_len);
+    errdefer if (merged) |owned| self.alloc.free(owned);
+    @memcpy(merged.?[0..sibling.members.len], sibling.members);
+    @memcpy(merged.?[sibling.members.len..], leaf.members);
+    replaceOwnedU64Slice(self.alloc, &sibling.members, &merged);
     posting.PostingStore.noteMembersChanged(&sibling);
     try posting.PostingStore.recomputeCentroid(self, txn, &sibling);
     if (self.config.use_quantization) {
@@ -505,16 +511,15 @@ fn mergeUnderfullPostingWithNearestSibling(
 
     for (leaf.members) |mid| try self.putVecLeaf(txn, mid, best_sibling_id);
 
-    var new_children = try self.alloc.alloc(u64, parent.children.len - 1);
-    errdefer self.alloc.free(new_children);
+    var new_children: ?[]u64 = try self.alloc.alloc(u64, parent.children.len - 1);
+    errdefer if (new_children) |owned| self.alloc.free(owned);
     var wi_child: usize = 0;
     for (parent.children) |cid| {
         if (cid == leaf.id) continue;
-        new_children[wi_child] = cid;
+        new_children.?[wi_child] = cid;
         wi_child += 1;
     }
-    self.alloc.free(parent.children);
-    parent.children = new_children;
+    replaceOwnedU64Slice(self.alloc, &parent.children, &new_children);
     try self.recomputeInternalCentroid(txn, &parent);
     try self.saveNodeWithOptionsMode(txn, &parent, save_options, false);
     try self.deleteNode(txn, leaf.id);
@@ -787,6 +792,30 @@ pub fn repairDirtyPostingsTxnWithOptions(
     self.write_profile.posting_maintenance_boundary_reassigned_vectors += result.boundary_reassigned_vectors;
 
     return result;
+}
+
+test "owned slice replacement survives later error cleanup" {
+    const Runner = struct {
+        fn run(alloc: std.mem.Allocator) !void {
+            var node = types.Node{
+                .id = 1,
+                .is_leaf = true,
+                .level = 0,
+                .parent = 0,
+                .centroid = &.{},
+                .children = &.{},
+                .members = try alloc.dupe(u64, &.{ 1, 2 }),
+            };
+            defer node.deinit(alloc);
+
+            var replacement: ?[]u64 = try alloc.dupe(u64, &.{ 3, 4, 5 });
+            errdefer if (replacement) |owned| alloc.free(owned);
+            replaceOwnedU64Slice(alloc, &node.members, &replacement);
+            return error.InjectedFailure;
+        }
+    };
+
+    try std.testing.expectError(error.InjectedFailure, Runner.run(std.testing.allocator));
 }
 
 test "posting backlog stats starts clean" {

--- a/zig/pkg/antfly/src/api/tables.zig
+++ b/zig/pkg/antfly/src/api/tables.zig
@@ -2921,6 +2921,7 @@ fn antflyTypeName(value: runtime_schema_mod.AntflyType) []const u8 {
 }
 
 fn queryNeedsPrimaryTextIndex(req: db_mod.types.SearchRequest) bool {
+    if (req.hierarchy_children != null) return false;
     if (req.full_text != null) return true;
     if (req.filter_query_json.len > 0 or req.exclusion_query_json.len > 0) return true;
     if (req.full_text_queries.len > 0) return false;
@@ -5075,6 +5076,23 @@ test "metadata.query routing selects read schema full text index" {
     try routeQueryRequestToActiveReadIndex(std.testing.allocator, &table, &req);
     try std.testing.expectEqualStrings("full_text_index_v0", req.index_name.?);
     try std.testing.expectEqualStrings("full_text_index_v0", req.primary_text_index_name.?);
+}
+
+test "metadata.query routing leaves hierarchy child traversal index free" {
+    const table: metadata_table_manager.TableRecord = .{
+        .table_id = 7,
+        .name = "docs",
+        .schema_json = "{\"version\":2}",
+        .indexes_json = "{\"full_text_index_v2\":{\"type\":\"full_text\"}}",
+        .placement_role = "data",
+    };
+    var req: db_mod.types.SearchRequest = .{
+        .hierarchy_children = .{ .parent_id = "doc:a" },
+    };
+
+    try routeQueryRequestToActiveReadIndex(std.testing.allocator, &table, &req);
+    try std.testing.expect(req.index_name == null);
+    try std.testing.expect(req.primary_text_index_name == null);
 }
 
 test "metadata.query routing selects current versioned full text index" {

--- a/zig/pkg/antfly/src/storage/db/enrichment/document_extraction.zig
+++ b/zig/pkg/antfly/src/storage/db/enrichment/document_extraction.zig
@@ -64,6 +64,11 @@ const pdf = if (builtin.os.tag == .freestanding or builtin.is_test or build_opti
                 }
             };
 
+            pub const TextOutputSpan = struct {
+                start: usize,
+                end: usize,
+            };
+
             pub const TextRun = struct {
                 text: []const u8,
                 x: f64 = 0,
@@ -76,6 +81,7 @@ const pdf = if (builtin.os.tag == .freestanding or builtin.is_test or build_opti
                 advance_width: f64 = 0,
                 ascent: f64 = 0,
                 descent: f64 = 0,
+                output_span: ?TextOutputSpan = null,
 
                 pub fn deinit(_: *TextRun, _: Allocator) void {}
             };
@@ -93,8 +99,13 @@ const pdf = if (builtin.os.tag == .freestanding or builtin.is_test or build_opti
         };
 
         pub const render = struct {
-            pub fn textRunBounds(_: reader.TextRun) struct { min_x: f64, max_x: f64, min_y: f64, max_y: f64 } {
-                return .{ .min_x = 0, .max_x = 0, .min_y = 0, .max_y = 0 };
+            pub fn textRunBounds(run: reader.TextRun) struct { min_x: f64, max_x: f64, min_y: f64, max_y: f64 } {
+                return .{
+                    .min_x = run.x,
+                    .max_x = run.x + run.advance_width,
+                    .min_y = run.y - run.descent,
+                    .max_y = run.y + run.ascent,
+                };
             }
         };
 
@@ -1696,8 +1707,13 @@ fn extractPdfTextRegionsFromRunsAlloc(
     var search_from: usize = 0;
     for (runs) |run| {
         if (run.text.len == 0) continue;
-        const start = std.mem.indexOfPos(u8, page_text, search_from, run.text) orelse continue;
-        const end = start + run.text.len;
+        const start, const end = if (run.output_span) |span| blk: {
+            if (span.start >= span.end or span.end > page_text.len) continue;
+            break :blk .{ span.start, span.end };
+        } else blk: {
+            const start = std.mem.indexOfPos(u8, page_text, search_from, run.text) orelse continue;
+            break :blk .{ start, start + run.text.len };
+        };
         const span_start = std.math.cast(u32, start) orelse continue;
         const span_end = std.math.cast(u32, end) orelse continue;
         const bounds = pdf.render.textRunBounds(run);
@@ -1708,6 +1724,43 @@ fn extractPdfTextRegionsFromRunsAlloc(
         search_from = end;
     }
     return try regions.toOwnedSlice(alloc);
+}
+
+test "PDF text regions use reconstructed output spans" {
+    const alloc = std.testing.allocator;
+    const runs = [_]pdf.reader.TextRun{
+        .{
+            .text = "Heading ",
+            .x = 10,
+            .y = 20,
+            .font_size = 10,
+            .advance_width = 40,
+            .ascent = 8,
+            .descent = 2,
+            .output_span = .{ .start = 0, .end = 7 },
+        },
+        .{
+            .text = "Body",
+            .x = 15,
+            .y = 5,
+            .font_size = 10,
+            .advance_width = 20,
+            .ascent = 7,
+            .descent = 3,
+            .output_span = .{ .start = 8, .end = 12 },
+        },
+    };
+    const regions = try extractPdfTextRegionsFromRunsAlloc(alloc, &runs, "Heading\nBody\n");
+    defer if (regions.len > 0) alloc.free(regions);
+
+    try std.testing.expectEqual(@as(usize, 2), regions.len);
+    try std.testing.expectEqual([2]u32{ 0, 7 }, regions[0].span);
+    try std.testing.expectEqual([2]u32{ 8, 12 }, regions[1].span);
+    const first_bounds = pdf.render.textRunBounds(runs[0]);
+    const second_bounds = pdf.render.textRunBounds(runs[1]);
+    try std.testing.expectEqual([4]f64{ first_bounds.min_x, first_bounds.min_y, first_bounds.max_x, first_bounds.max_y }, regions[0].bbox);
+    try std.testing.expectEqual([4]f64{ second_bounds.min_x, second_bounds.min_y, second_bounds.max_x, second_bounds.max_y }, regions[1].bbox);
+    try std.testing.expect(!std.mem.eql(f64, &regions[0].bbox, &regions[1].bbox));
 }
 
 fn extractSingleTextUnitAlloc(

--- a/zig/pkg/antfly/src/storage/db/enrichment/document_extraction.zig
+++ b/zig/pkg/antfly/src/storage/db/enrichment/document_extraction.zig
@@ -1704,16 +1704,15 @@ fn extractPdfTextRegionsFromRunsAlloc(
 
     var regions = std.ArrayListUnmanaged(TextRegion).empty;
     defer regions.deinit(alloc);
-    var search_from: usize = 0;
     for (runs) |run| {
         if (run.text.len == 0) continue;
-        const start, const end = if (run.output_span) |span| blk: {
-            if (span.start >= span.end or span.end > page_text.len) continue;
-            break :blk .{ span.start, span.end };
-        } else blk: {
-            const start = std.mem.indexOfPos(u8, page_text, search_from, run.text) orelse continue;
-            break :blk .{ start, start + run.text.len };
-        };
+        // A null span means reconstruction could not align this positioned run
+        // with the canonical page text. Substring matching is unsafe here: a
+        // degraded run can match unrelated text and receive the wrong bounds.
+        const output_span = run.output_span orelse continue;
+        if (output_span.start >= output_span.end or output_span.end > page_text.len) continue;
+        const start = output_span.start;
+        const end = output_span.end;
         const span_start = std.math.cast(u32, start) orelse continue;
         const span_end = std.math.cast(u32, end) orelse continue;
         const bounds = pdf.render.textRunBounds(run);
@@ -1721,7 +1720,6 @@ fn extractPdfTextRegionsFromRunsAlloc(
             .span = .{ span_start, span_end },
             .bbox = .{ bounds.min_x, bounds.min_y, bounds.max_x, bounds.max_y },
         });
-        search_from = end;
     }
     return try regions.toOwnedSlice(alloc);
 }
@@ -1761,6 +1759,23 @@ test "PDF text regions use reconstructed output spans" {
     try std.testing.expectEqual([4]f64{ first_bounds.min_x, first_bounds.min_y, first_bounds.max_x, first_bounds.max_y }, regions[0].bbox);
     try std.testing.expectEqual([4]f64{ second_bounds.min_x, second_bounds.min_y, second_bounds.max_x, second_bounds.max_y }, regions[1].bbox);
     try std.testing.expect(!std.mem.eql(f64, &regions[0].bbox, &regions[1].bbox));
+
+    const unaligned_runs = [_]pdf.reader.TextRun{.{
+        .text = "FR",
+        .x = 100,
+        .y = 200,
+        .font_size = 12,
+        .advance_width = 80,
+        .ascent = 9,
+        .descent = 3,
+        .output_span = null,
+    }};
+
+    // "FR" occurs in the canonical text, but this run has no validated
+    // alignment and must not borrow that unrelated span.
+    const unaligned_regions = try extractPdfTextRegionsFromRunsAlloc(alloc, &unaligned_runs, "FOURTH EDITION FR");
+    defer if (unaligned_regions.len > 0) alloc.free(unaligned_regions);
+    try std.testing.expectEqual(@as(usize, 0), unaligned_regions.len);
 }
 
 fn extractSingleTextUnitAlloc(

--- a/zig/pkg/antfly/src/storage/db/enrichment/enrichment_runtime.zig
+++ b/zig/pkg/antfly/src/storage/db/enrichment/enrichment_runtime.zig
@@ -5336,7 +5336,18 @@ pub fn completeDocumentExtractionGeneratedTextForRequest(
     if (!generated_text_enabled) return;
     const producer = runtime.config.asset_producer orelse return error.MissingAssetProducer;
     const batch_policy = requestGeneratedTextBatchPolicy(alloc, request);
-    try completeRuntimeDocumentExtractionGeneratedTextBatch(runtime, alloc, producer, config, batch_policy, source_url, source_bytes, extraction.route_type, source_content_type, extraction.units, .ocr);
+    completeRuntimeDocumentExtractionGeneratedTextBatch(runtime, alloc, producer, config, batch_policy, source_url, source_bytes, extraction.route_type, source_content_type, extraction.units, .ocr) catch |err| {
+        if (!isDocumentWideOcrFailure(err)) return err;
+        try markPendingGeneratedUnitTextFailures(
+            alloc,
+            extraction.units,
+            "pending_ocr",
+            "ocr_text",
+            .ocr,
+            "render_resource",
+            err,
+        );
+    };
     try completeRuntimeDocumentExtractionGeneratedTextBatch(runtime, alloc, producer, config, batch_policy, source_url, source_bytes, extraction.route_type, source_content_type, extraction.units, .transcript);
 }
 
@@ -5571,7 +5582,7 @@ fn completeRuntimeDocumentExtractionGeneratedTextBatchWithAllocator(
                 const render_started_ns = runtime.config.clock.nowRealtimeNs();
                 const rendered_page = pdf_session.?.renderPagePngAdaptiveAlloc(working_alloc, unit.page_number orelse 1, config.ocr_render_dpi, config.ocr_max_rendered_pixels, config.ocr_max_rendered_dimension) catch |err| {
                     logRuntimeOcrRenderProfile(runtime, source_fingerprint, unit.page_number, config.ocr_render_dpi, null, null, null, null, render_started_ns, @errorName(err));
-                    if (shouldYieldRequestError(runtime, err)) return err;
+                    if (!isOcrPageRenderFailure(err) and shouldYieldRequestError(runtime, err)) return err;
                     try setRuntimeGeneratedUnitFailureStage(alloc, &units[idx], kind, "render");
                     try markRuntimeGeneratedUnitTextFailure(alloc, &units[idx], method, kind, err);
                     continue;
@@ -5972,6 +5983,45 @@ fn applyRuntimeGeneratedUnitText(
     const start = unit.char_start orelse 0;
     unit.char_start = start;
     unit.char_end = std.math.cast(u32, @as(usize, @intCast(start)) + unit.text.len);
+}
+
+fn isDocumentWideOcrFailure(err: anyerror) bool {
+    return switch (err) {
+        error.DocumentExtractionWorkingSetTooLarge,
+        error.PdfDecodeWorkingSetTooLarge,
+        error.DecodedStreamTooLarge,
+        => true,
+        else => false,
+    };
+}
+
+fn isOcrPageRenderFailure(err: anyerror) bool {
+    return switch (err) {
+        error.RenderedPageTooLarge,
+        error.MissingCcittEol,
+        error.JpegDecodeFailed,
+        error.UnsupportedPdfRendering,
+        error.InvalidPageBox,
+        => true,
+        else => false,
+    };
+}
+
+fn markPendingGeneratedUnitTextFailures(
+    alloc: Allocator,
+    units: []document_extraction_mod.Unit,
+    pending_status: []const u8,
+    method: []const u8,
+    kind: RuntimeGeneratedUnitTextKind,
+    stage: []const u8,
+    err: anyerror,
+) !void {
+    for (units) |*unit| {
+        const status = unit.extraction_status orelse continue;
+        if (!std.mem.eql(u8, status, pending_status)) continue;
+        try setRuntimeGeneratedUnitFailureStage(alloc, unit, kind, stage);
+        try markRuntimeGeneratedUnitTextFailure(alloc, unit, method, kind, err);
+    }
 }
 
 fn markRuntimeGeneratedUnitTextFailure(
@@ -13098,6 +13148,64 @@ test "synchronous document extraction OCR batches honor request execution item c
     try std.testing.expectEqualStrings("ocr text 0", units[0].text);
     try std.testing.expectEqualStrings("ocr text 1", units[1].text);
     try std.testing.expectEqualStrings("ocr text 0", units[2].text);
+}
+
+test "document-wide OCR resource failure preserves units and marks pending pages" {
+    const alloc = std.testing.allocator;
+    var units = [_]document_extraction_mod.Unit{
+        .{
+            .unit_id = try alloc.dupe(u8, "page:000001"),
+            .unit_type = try alloc.dupe(u8, "page"),
+            .text = try alloc.dupe(u8, "retained native text"),
+            .method = try alloc.dupe(u8, "pdf_ocr_pending"),
+            .extraction_status = try alloc.dupe(u8, "pending_ocr"),
+            .page_number = 1,
+        },
+        .{
+            .unit_id = try alloc.dupe(u8, "image:000002"),
+            .unit_type = try alloc.dupe(u8, "image"),
+            .text = try alloc.dupe(u8, "pending image"),
+            .method = try alloc.dupe(u8, "pdf_ocr_pending"),
+            .extraction_status = try alloc.dupe(u8, "pending_ocr"),
+            .page_number = 2,
+        },
+        .{
+            .unit_id = try alloc.dupe(u8, "page:000003"),
+            .unit_type = try alloc.dupe(u8, "page"),
+            .text = try alloc.dupe(u8, "already complete"),
+            .method = try alloc.dupe(u8, "pdf_text"),
+            .extraction_status = try alloc.dupe(u8, "completed_embedded_preferred"),
+            .page_number = 3,
+        },
+    };
+    defer for (&units) |*unit| unit.deinit(alloc);
+
+    try markPendingGeneratedUnitTextFailures(
+        alloc,
+        &units,
+        "pending_ocr",
+        "ocr_text",
+        .ocr,
+        "render_resource",
+        error.DocumentExtractionWorkingSetTooLarge,
+    );
+
+    try std.testing.expectEqualStrings("failed_ocr", units[0].extraction_status.?);
+    try std.testing.expectEqualStrings("pdf_text", units[0].method);
+    try std.testing.expectEqualStrings("retained native text", units[0].text);
+    try std.testing.expectEqualStrings("render_resource", units[0].ocr_failure_stage.?);
+    try std.testing.expect(std.mem.indexOf(u8, units[0].extraction_warning.?, "DocumentExtractionWorkingSetTooLarge") != null);
+    try std.testing.expectEqualStrings("failed_ocr", units[1].extraction_status.?);
+    try std.testing.expectEqualStrings("", units[1].text);
+    try std.testing.expectEqualStrings("completed_embedded_preferred", units[2].extraction_status.?);
+    try std.testing.expectEqualStrings("already complete", units[2].text);
+
+    try std.testing.expect(isDocumentWideOcrFailure(error.DocumentExtractionWorkingSetTooLarge));
+    try std.testing.expect(!isDocumentWideOcrFailure(error.OutOfMemory));
+    try std.testing.expect(isOcrPageRenderFailure(error.RenderedPageTooLarge));
+    try std.testing.expect(isOcrPageRenderFailure(error.MissingCcittEol));
+    try std.testing.expect(isOcrPageRenderFailure(error.JpegDecodeFailed));
+    try std.testing.expect(!isOcrPageRenderFailure(error.OutOfMemory));
 }
 
 test "document extraction rejects and records Florence prompt echoes" {

--- a/zig/pkg/antfly/src/storage/db/enrichment/enrichment_runtime.zig
+++ b/zig/pkg/antfly/src/storage/db/enrichment/enrichment_runtime.zig
@@ -5582,7 +5582,7 @@ fn completeRuntimeDocumentExtractionGeneratedTextBatchWithAllocator(
                 const render_started_ns = runtime.config.clock.nowRealtimeNs();
                 const rendered_page = pdf_session.?.renderPagePngAdaptiveAlloc(working_alloc, unit.page_number orelse 1, config.ocr_render_dpi, config.ocr_max_rendered_pixels, config.ocr_max_rendered_dimension) catch |err| {
                     logRuntimeOcrRenderProfile(runtime, source_fingerprint, unit.page_number, config.ocr_render_dpi, null, null, null, null, render_started_ns, @errorName(err));
-                    if (!isOcrPageRenderFailure(err) and shouldYieldRequestError(runtime, err)) return err;
+                    if (!shouldIsolateOcrPageRenderFailure(err)) return err;
                     try setRuntimeGeneratedUnitFailureStage(alloc, &units[idx], kind, "render");
                     try markRuntimeGeneratedUnitTextFailure(alloc, &units[idx], method, kind, err);
                     continue;
@@ -5995,16 +5995,13 @@ fn isDocumentWideOcrFailure(err: anyerror) bool {
     };
 }
 
-fn isOcrPageRenderFailure(err: anyerror) bool {
-    return switch (err) {
-        error.RenderedPageTooLarge,
-        error.MissingCcittEol,
-        error.JpegDecodeFailed,
-        error.UnsupportedPdfRendering,
-        error.InvalidPageBox,
-        => true,
-        else => false,
-    };
+fn shouldIsolateOcrPageRenderFailure(err: anyerror) bool {
+    // Rendering is local to one page and performs no remote I/O, so decoder,
+    // validation, and platform-renderer failures are deterministic for that
+    // page. Keep the allowlist on the errors that must escape instead: worker
+    // control flow and fatal process/runtime failures such as OutOfMemory.
+    return !isEnrichmentControlError(err) and
+        enrichmentErrorDisposition(err) != .fatal_worker;
 }
 
 fn markPendingGeneratedUnitTextFailures(
@@ -13202,10 +13199,15 @@ test "document-wide OCR resource failure preserves units and marks pending pages
 
     try std.testing.expect(isDocumentWideOcrFailure(error.DocumentExtractionWorkingSetTooLarge));
     try std.testing.expect(!isDocumentWideOcrFailure(error.OutOfMemory));
-    try std.testing.expect(isOcrPageRenderFailure(error.RenderedPageTooLarge));
-    try std.testing.expect(isOcrPageRenderFailure(error.MissingCcittEol));
-    try std.testing.expect(isOcrPageRenderFailure(error.JpegDecodeFailed));
-    try std.testing.expect(!isOcrPageRenderFailure(error.OutOfMemory));
+    try std.testing.expect(shouldIsolateOcrPageRenderFailure(error.RenderedPageTooLarge));
+    try std.testing.expect(shouldIsolateOcrPageRenderFailure(error.MissingCcittEol));
+    try std.testing.expect(shouldIsolateOcrPageRenderFailure(error.JpegDecodeFailed));
+    try std.testing.expect(shouldIsolateOcrPageRenderFailure(error.InvalidPageRotation));
+    try std.testing.expect(shouldIsolateOcrPageRenderFailure(error.InvalidFlateStream));
+    try std.testing.expect(shouldIsolateOcrPageRenderFailure(error.MalformedLzw));
+    try std.testing.expect(shouldIsolateOcrPageRenderFailure(error.MalformedPredictorData));
+    try std.testing.expect(!shouldIsolateOcrPageRenderFailure(error.OutOfMemory));
+    try std.testing.expect(!shouldIsolateOcrPageRenderFailure(error.EnrichmentRetryAborted));
 }
 
 test "document extraction rejects and records Florence prompt echoes" {


### PR DESCRIPTION
## Summary

- reconstruct canonical PDF text from positioned text-run geometry when the non-whitespace byte sequence is unchanged
- infer word, line, and caption boundaries without splitting within-operator kerning
- keep `hierarchy.children` navigation free of an injected primary text index
- isolate PDF OCR rendering failures to page units instead of aborting the document merge
- retain native page text when OCR rendering or validation fails
- support empty-user-password Standard V1/R2 40-bit RC4 PDFs

## Why

Many PDFs encode spaces and table columns as positioned text fragments rather than literal space glyphs. The previous canonical extractor concatenated decoded strings and ignored that geometry. Separately, one OCR render/decode failure could abort the full document, producing no units or chunks.

The reconstruction path is guarded: it is used only when its non-whitespace bytes exactly equal the existing canonical extraction. Otherwise Antfly keeps the prior output.

## Diagnostic corpus result

Reran the 114 previously failed OHR PDFs plus the deterministic 60-document success sample: 174 documents and 3,402 expected pages.

| Health measure | Original | Whitespace-only | This PR |
|---|---:|---:|---:|
| Strict failed documents | 114 | 113 | 111 |
| Documents with retrievable chunks | 107 | 107 | 142 |
| Artifact-error documents | 65 | 65 | 0 |
| Represented pages | 2,789 | 2,789 | 3,402 |
| Represented-page rate | 81.98% | 81.98% | 100.00% |
| Strict page success | 77.78% | 76.87% | 88.80% |
| Nonempty retained-text rate | 80.78% | 80.78% | 93.74% |
| Alphanumeric retained-text rate | 80.69% | 80.69% | 93.56% |
| Zero-chunk documents | 67 | 67 | 32 |

OCR-failed page count rises because 613 formerly missing pages now exist and carry explicit page-level failure outcomes. Existing artifact/document health semantics are unchanged.

On the 2,151-question diagnostic subset:

| Metric | Whitespace-only | This PR |
|---|---:|---:|
| Lexical top-1 page recall | 0.3096 | 0.4258 |
| Lexical top-5 page recall | 0.4547 | 0.5895 |
| Lexical top-5 mean LCS | 0.3249 | 0.4241 |
| Hybrid top-1 page recall | 0.2999 | 0.4082 |
| Hybrid top-5 page recall | 0.4928 | 0.6402 |
| Hybrid top-5 mean LCS | 0.3268 | 0.4312 |

## Representative whitespace repair

`academic/2402.03216v4.pdf`, page 8:

- words: 44 → 743 (`pypdf`: 731)
- OHR evidence LCS: 0.0625 → 1.0
- non-whitespace bytes unchanged

## Verification

- `zig build lib-pdf-test -Doptimize=ReleaseFast -j2 --test-timeout 10m` — 215 passed
- `zig build lib-db-enrichment-test -Doptimize=ReleaseFast -j2 --test-timeout 10m` — 97 passed
- direct native extraction of both affected real V1/R2 RC4 PDFs
- cold ingest of representative failure modes
- cold rerun of all 174 diagnostic documents
- exact hierarchy unit/page reconciliation
- no query errors across 2,151 retrieval questions

## Deliberately deferred

- off-page/Form XObject text filtering until transform composition is validated
- orientation detection and handwriting-specific OCR
- semantic chart descriptions or other inferred enrichment; OCR remains transcription-only
