### PR TITLE
fix(metadata): tolerate control-round authority churn

### DIFF
--- a/zig/pkg/antfly/src/metadata/runtime.zig
+++ b/zig/pkg/antfly/src/metadata/runtime.zig
@@ -33,6 +33,10 @@ const metadata_bootstrap_campaign_retry_min_interval_ns: u64 = 500 * std.time.ns
 const trusted_principal_secret_key = "antfly.trusted_principal.secret";
 const trusted_principal_issuer_key = "antfly.trusted_principal.issuer";
 
+fn isExpectedControlRoundError(err: anyerror) bool {
+    return antfly.metadata.authority.isRetryableError(err);
+}
+
 fn metadataRaftRuntimeConfig() raft_engine.runtime.RuntimeConfig {
     return .{
         .max_tick_batch = 32,
@@ -1034,7 +1038,14 @@ pub fn runFromIterator(
             }
         }
         const run_round_start_ns = platform_time.monotonicNs();
-        server.runControlRoundOnly() catch |err| return supervisor.fail("metadata", "control-round", err);
+        server.runControlRoundOnly() catch |err| {
+            // Leadership can change after a control round observes the local
+            // reconcile lease but before one of its proposals is admitted.
+            // Retry authority churn on the next tick instead of terminating a
+            // healthy follower; storage and process failures remain fatal.
+            if (!isExpectedControlRoundError(err))
+                return supervisor.fail("metadata", "control-round", err);
+        };
         const run_round_elapsed_ns = platform_time.monotonicNs() -| run_round_start_ns;
         if (run_round_elapsed_ns > antfly.metadata_service.metadata_run_round_slow_threshold_ns) {
             std.log.warn("metadata runRound slow elapsed_ms={d}", .{@divTrunc(run_round_elapsed_ns, std.time.ns_per_ms)});
@@ -1940,6 +1951,22 @@ test "metadata runtime retries bootstrap campaign only for leaderless voters" {
 
     status.soft.leader_id = null;
     try std.testing.expect(!metadataRaftStatusShouldBootstrapCampaign(status, 4));
+}
+
+test "metadata runtime retries authority loss from control rounds" {
+    const expected_errors = [_]anyerror{
+        error.NotLeader,
+        error.ProposalDropped,
+        error.LeaderTransferInProgress,
+        error.MetadataLinearizableReadTimeout,
+        error.MetadataSnapshotHeadMismatch,
+        error.ReconcileLeaseNotHeld,
+    };
+    for (expected_errors) |err| {
+        try std.testing.expect(isExpectedControlRoundError(err));
+    }
+    try std.testing.expect(!isExpectedControlRoundError(error.OutOfMemory));
+    try std.testing.expect(!isExpectedControlRoundError(error.Corrupted));
 }
 
 test "metadata runtime scales bootstrap campaign retry interval with tick" {


### PR DESCRIPTION
## Summary

- keep a healthy metadata follower alive when a control round loses Raft authority during a concurrent election
- retry only errors in the shared metadata authority retry classification; storage, allocation, corruption, and other unexpected failures remain fatal
- add regression coverage for every retryable authority error plus fail-closed examples

## Investigation

The failing PR #528 job completed 220 tests before `test_autoscaling_adds_data_node_and_assigns_placements` reported that data node 104 did not register on every metadata node. Metadata node 1 was refusing connections.

Its log shows that the process had started and served metadata work, then a WAL commit took about 1.85 seconds. During that interval node 2 won a new election. The next control round on node 1 returned `error.NotLeader`, and the production runtime treated that normal authority transition as a fatal `control-round` startup failure and exited.

PR #528 does not modify the metadata runtime or this scaling test. The same fatal path was present on main, so this is a main-branch timing flake exposed by the PR run.

## Validation

- `zig build lib-metadata-test --summary failures -- "metadata runtime retries authority loss from control rounds"`
- `zig fmt --check zig/pkg/antfly/src/metadata/runtime.zig`
- `git diff --check`
- repository regression loop, patched binary: 10/10 passes for `e2e/antfly/test_scaling.py::test_autoscaling_adds_data_node_and_assigns_placements`
- post-rebase scheduler-aware regression pass: 1/1

The focused scenario also passed 10/10 on unmodified main, consistent with the failure requiring a rare election/WAL timing interleaving; the CI node log provides the reproducing trace.