### PR TITLE
zig: consolidate metadata unit test artifacts

### DIFF
--- a/zig/build.zig
+++ b/zig/build.zig
@@ -2089,7 +2089,7 @@ pub fn build(b: *std.Build) void {
     });
     antfly_imports.configure(b, api_http_runtime_test_mod, true, true);
 
-    const metadata_unit_test_root_paths = [_][]const u8{
+    const metadata_unit_baseline_root_paths = [_][]const u8{
         "pkg/antfly/src/metadata_reconciler_test_root.zig",
         "pkg/antfly/src/metadata_service_http_test_root.zig",
         "pkg/antfly/src/metadata_core_test_root.zig",
@@ -2099,6 +2099,20 @@ pub fn build(b: *std.Build) void {
         "pkg/antfly/src/metadata_table_provisioner_test_root.zig",
         "pkg/antfly/src/metadata_replication_backfill_test_root.zig",
         "pkg/antfly/src/metadata_storage_test_root.zig",
+    };
+    var metadata_unit_baseline_mods: [metadata_unit_baseline_root_paths.len]*std.Build.Module = undefined;
+    for (metadata_unit_baseline_root_paths, &metadata_unit_baseline_mods) |root_path, *test_mod| {
+        test_mod.* = b.createModule(.{
+            .root_source_file = b.path(root_path),
+            .target = target,
+            .optimize = optimize,
+        });
+        antfly_imports.configure(b, test_mod.*, true, true);
+    }
+
+    const metadata_unit_test_root_paths = [_][]const u8{
+        "pkg/antfly/src/metadata_unit_lane_a_test_root.zig",
+        "pkg/antfly/src/metadata_unit_lane_b_test_root.zig",
     };
     var metadata_unit_test_mods: [metadata_unit_test_root_paths.len]*std.Build.Module = undefined;
     for (metadata_unit_test_root_paths, &metadata_unit_test_mods) |root_path, *test_mod| {
@@ -7965,7 +7979,62 @@ pub fn build(b: *std.Build) void {
         "unit-metadata-test",
         "Run the production metadata portion of the default unit-test target in bounded shards",
     );
-    const unit_metadata_shard_names = [_][]const u8{
+    const metadata_runtime_filter_is_default =
+        lib_metadata_runtime_filters.len == 1 and
+        std.mem.eql(u8, lib_metadata_runtime_filters[0], "metadata.");
+    // Preserve the former two compile lanes while compiling each lane's
+    // production metadata ownership groups into one executable. This removes
+    // seven repeated semantic-analysis/code-generation passes without
+    // constructing the public metadata barrel that also owns simulations.
+    const unit_metadata_artifact_shard_indices = [_][]const usize{
+        &.{ 0, 2, 4, 6, 8 },
+        &.{ 1, 3, 5, 7 },
+    };
+    const unit_metadata_artifact_names = [_][]const u8{
+        "metadata-unit-lane-a-tests",
+        "metadata-unit-lane-b-tests",
+    };
+    var unit_metadata_compile_filters: [unit_metadata_artifact_shard_indices.len][]const []const u8 = .{
+        &.{},
+        &.{},
+    };
+    for (unit_metadata_artifact_shard_indices, &unit_metadata_compile_filters) |shard_indices, *compile_filters| {
+        for (shard_indices) |shard_index| {
+            compile_filters.* = compileFiltersWithAnchors(
+                b,
+                compile_filters.*,
+                unit_metadata_shard_filters[shard_index],
+            );
+        }
+    }
+
+    var unit_metadata_tests: [metadata_unit_test_mods.len]*std.Build.Step.Compile = undefined;
+    for (
+        unit_metadata_artifact_names,
+        metadata_unit_test_mods,
+        unit_metadata_compile_filters,
+        &unit_metadata_tests,
+    ) |artifact_name, test_mod, compile_filters, *tests| {
+        tests.* = b.addTest(.{
+            .name = artifact_name,
+            .root_module = test_mod,
+            .filters = compile_filters,
+            .test_runner = .{
+                .path = b.path("pkg/antfly/src/test_runner.zig"),
+                .mode = .simple,
+            },
+            .max_rss = 8 * 1024 * 1024 * 1024,
+        });
+    }
+    const unit_metadata_compile_step = b.step(
+        "unit-metadata-compile",
+        "Compile the two consolidated metadata unit-test artifacts without running them",
+    );
+    for (unit_metadata_tests) |tests| unit_metadata_compile_step.dependOn(&tests.step);
+
+    // Keep the prior nine-artifact layout as an opt-in coverage oracle. It is
+    // deliberately absent from unit-test and unit-metadata-test.
+    const unit_metadata_baseline_names = [_][]const u8{
         "metadata-reconciler-tests",
         "metadata-service-http-tests",
         "metadata-core-tests",
@@ -7976,106 +8045,157 @@ pub fn build(b: *std.Build) void {
         "metadata-replication-backfill-tests",
         "metadata-storage-tests",
     };
-    const unit_metadata_shard_max_rss = [_]usize{
+    const unit_metadata_baseline_max_rss = [_]usize{
         5 * 1024 * 1024 * 1024,
         5 * 1024 * 1024 * 1024,
-        // The core shard now compiles the contextual public router and its
-        // compatibility manifest; Debug codegen peaks around 6.8 GB on
-        // aarch64 macOS.
         7 * 1024 * 1024 * 1024,
         5 * 1024 * 1024 * 1024,
-        // The server shard compiles the public API kernel and listener stack;
-        // Debug codegen currently peaks around 6.4 GB on aarch64 macOS.
         7 * 1024 * 1024 * 1024,
         5 * 1024 * 1024 * 1024,
         5 * 1024 * 1024 * 1024,
         7 * 1024 * 1024 * 1024,
         6 * 1024 * 1024 * 1024,
     };
-    const metadata_runtime_filter_is_default =
-        lib_metadata_runtime_filters.len == 1 and
-        std.mem.eql(u8, lib_metadata_runtime_filters[0], "metadata.");
-    const unit_metadata_shard_lanes = [_]usize{ 0, 1, 0, 1, 0, 1, 0, 1, 0 };
-    var unit_metadata_compile_tails = [_]?*std.Build.Step{ null, null };
-    var unit_metadata_aggregate_run_tails = [_]?*std.Build.Step{ null, null };
-    var unit_metadata_focused_run_tails = [_]?*std.Build.Step{ null, null };
+    const unit_metadata_baseline_lanes = [_]usize{ 0, 1, 0, 1, 0, 1, 0, 1, 0 };
+    var unit_metadata_baseline_compile_tails = [_]?*std.Build.Step{ null, null };
+    var unit_metadata_baseline_tests: [metadata_unit_baseline_mods.len]*std.Build.Step.Compile = undefined;
     for (
         unit_metadata_shard_filters,
-        unit_metadata_shard_names,
-        metadata_unit_test_mods,
-        unit_metadata_shard_max_rss,
-        unit_metadata_shard_lanes,
-    ) |shard_filters, shard_name, test_mod, shard_max_rss, lane| {
-        const is_runtime_exclusive = std.mem.eql(u8, shard_name, "metadata-replication-backfill-tests");
-        const unit_metadata_tests = b.addTest(.{
-            .name = shard_name,
+        unit_metadata_baseline_names,
+        metadata_unit_baseline_mods,
+        unit_metadata_baseline_max_rss,
+        unit_metadata_baseline_lanes,
+        &unit_metadata_baseline_tests,
+    ) |shard_filters, artifact_name, test_mod, max_rss, lane, *tests| {
+        tests.* = b.addTest(.{
+            .name = artifact_name,
             .root_module = test_mod,
             .filters = shard_filters,
             .test_runner = .{
                 .path = b.path("pkg/antfly/src/test_runner.zig"),
                 .mode = .simple,
             },
-            .max_rss = shard_max_rss,
+            .max_rss = max_rss,
         });
-        if (unit_metadata_compile_tails[lane]) |previous| unit_metadata_tests.step.dependOn(previous);
-        unit_metadata_compile_tails[lane] = &unit_metadata_tests.step;
-        const run_unit_metadata_tests = b.addRunArtifact(unit_metadata_tests);
+        if (unit_metadata_baseline_compile_tails[lane]) |previous| {
+            tests.*.step.dependOn(previous);
+        } else {
+            for (unit_metadata_tests) |candidate| tests.*.step.dependOn(&candidate.step);
+        }
+        unit_metadata_baseline_compile_tails[lane] = &tests.*.step;
+    }
+    const compare_unit_metadata_inventory = b.addSystemCommand(&.{"python3"});
+    compare_unit_metadata_inventory.setName("compare consolidated metadata test inventory");
+    compare_unit_metadata_inventory.addFileArg(b.path("tools/compare_test_inventories.py"));
+    compare_unit_metadata_inventory.addArg("--baseline");
+    for (unit_metadata_baseline_tests) |tests| compare_unit_metadata_inventory.addArtifactArg(tests);
+    compare_unit_metadata_inventory.addArg("--candidate");
+    for (unit_metadata_tests) |tests| compare_unit_metadata_inventory.addArtifactArg(tests);
+    compare_unit_metadata_inventory.addArgs(&.{ "--label", "metadata consolidation" });
+    const unit_metadata_inventory_step = b.step(
+        "unit-metadata-test-inventory",
+        "Verify the two consolidated artifacts preserve the nine-shard named test inventory",
+    );
+    unit_metadata_inventory_step.dependOn(&compare_unit_metadata_inventory.step);
+
+    var unit_metadata_lane_a_pre_filters: []const []const u8 = &.{};
+    for ([_]usize{ 0, 2, 4, 6 }) |shard_index| {
+        unit_metadata_lane_a_pre_filters = compileFiltersWithAnchors(
+            b,
+            unit_metadata_lane_a_pre_filters,
+            unit_metadata_shard_filters[shard_index],
+        );
+    }
+    var unit_metadata_lane_b_pre_filters: []const []const u8 = &.{};
+    for ([_]usize{ 1, 3, 5 }) |shard_index| {
+        unit_metadata_lane_b_pre_filters = compileFiltersWithAnchors(
+            b,
+            unit_metadata_lane_b_pre_filters,
+            unit_metadata_shard_filters[shard_index],
+        );
+    }
+    const MetadataRuntimePartition = struct {
+        name: []const u8,
+        artifact_index: usize,
+        filters: []const []const u8,
+        other_filters: []const []const u8,
+    };
+    const unit_metadata_runtime_partitions = [_]MetadataRuntimePartition{
+        .{
+            .name = "metadata-unit-lane-a-pre-tests",
+            .artifact_index = 0,
+            .filters = unit_metadata_lane_a_pre_filters,
+            .other_filters = unit_metadata_shard_filters[8],
+        },
+        .{
+            .name = "metadata-unit-lane-b-pre-tests",
+            .artifact_index = 1,
+            .filters = unit_metadata_lane_b_pre_filters,
+            .other_filters = unit_metadata_shard_filters[7],
+        },
+        .{
+            .name = "metadata-replication-backfill-tests",
+            .artifact_index = 1,
+            .filters = unit_metadata_shard_filters[7],
+            .other_filters = unit_metadata_lane_b_pre_filters,
+        },
+        .{
+            .name = "metadata-storage-tests",
+            .artifact_index = 0,
+            .filters = unit_metadata_shard_filters[8],
+            .other_filters = unit_metadata_lane_a_pre_filters,
+        },
+    };
+    var unit_metadata_aggregate_runs: [unit_metadata_runtime_partitions.len]*std.Build.Step.Run = undefined;
+    var unit_metadata_focused_runs: [unit_metadata_runtime_partitions.len]*std.Build.Step.Run = undefined;
+    for (
+        unit_metadata_runtime_partitions,
+        &unit_metadata_aggregate_runs,
+        &unit_metadata_focused_runs,
+    ) |partition, *aggregate_run, *focused_run| {
         const runtime_filters = if (metadata_runtime_filter_is_default)
-            shard_filters
+            partition.filters
         else
             lib_metadata_runtime_filters;
-        addRuntimeTestFilters(b, run_unit_metadata_tests, runtime_filters);
-        // A focused caller filter generally belongs to only one aggregate
-        // artifact. Permit the other metadata shards to be empty, while
-        // keeping the default CI selection strict so a stale shard filter
-        // cannot silently remove coverage.
-        if (!metadata_runtime_filter_is_default) {
-            run_unit_metadata_tests.addArg("--allow-empty-test-filter");
-        }
-        addRuntimeSkipTestFilters(run_unit_metadata_tests, lib_unit_filters);
+
+        aggregate_run.* = b.addRunArtifact(unit_metadata_tests[partition.artifact_index]);
+        aggregate_run.*.setName(b.fmt("run test {s}", .{partition.name}));
+        addRuntimeTestFilters(b, aggregate_run.*, runtime_filters);
+        addRuntimeSkipTestFilters(aggregate_run.*, lib_unit_filters);
         for (root_test_skip_filters) |filter| {
-            run_unit_metadata_tests.addArgs(&.{ "--skip-test-filter", filter });
+            aggregate_run.*.addArgs(&.{ "--skip-test-filter", filter });
         }
-        if (is_runtime_exclusive) {
-            for (unit_metadata_aggregate_run_tails) |previous| {
-                if (previous) |previous_step| run_unit_metadata_tests.step.dependOn(previous_step);
-            }
-        } else if (unit_metadata_aggregate_run_tails[lane]) |previous| {
-            run_unit_metadata_tests.step.dependOn(previous);
+        if (!metadata_runtime_filter_is_default) {
+            aggregate_run.*.addArg("--allow-empty-test-filter");
+            addRuntimeSkipTestFilters(aggregate_run.*, partition.other_filters);
         }
-        unit_test_step.dependOn(&run_unit_metadata_tests.step);
-        if (is_runtime_exclusive) {
-            unit_metadata_aggregate_run_tails = .{ &run_unit_metadata_tests.step, &run_unit_metadata_tests.step };
-        } else {
-            unit_metadata_aggregate_run_tails[lane] = &run_unit_metadata_tests.step;
-        }
+        unit_test_step.dependOn(&aggregate_run.*.step);
 
         // The standalone metadata step owns its selected metadata tests. Use a
         // separate run policy so a caller filter is not mistaken for the root
         // aggregate's overlap exclusion and skipped everywhere.
-        const run_focused_metadata_tests = b.addRunArtifact(unit_metadata_tests);
-        addRuntimeTestFilters(b, run_focused_metadata_tests, runtime_filters);
+        focused_run.* = b.addRunArtifact(unit_metadata_tests[partition.artifact_index]);
+        focused_run.*.setName(b.fmt("run focused test {s}", .{partition.name}));
+        addRuntimeTestFilters(b, focused_run.*, runtime_filters);
         if (!metadata_runtime_filter_is_default) {
-            run_focused_metadata_tests.addArg("--allow-empty-test-filter");
+            focused_run.*.addArg("--allow-empty-test-filter");
+            addRuntimeSkipTestFilters(focused_run.*, partition.other_filters);
         }
         for (root_test_skip_filters) |filter| {
-            run_focused_metadata_tests.addArgs(&.{ "--skip-test-filter", filter });
+            focused_run.*.addArgs(&.{ "--skip-test-filter", filter });
         }
-        if (is_runtime_exclusive) {
-            for (unit_metadata_focused_run_tails) |previous| {
-                if (previous) |previous_step| run_focused_metadata_tests.step.dependOn(previous_step);
-            }
-        } else if (unit_metadata_focused_run_tails[lane]) |previous| {
-            run_focused_metadata_tests.step.dependOn(previous);
-        }
-        unit_metadata_sharded_test_step.dependOn(&run_focused_metadata_tests.step);
-        lib_metadata_test_step.dependOn(&run_focused_metadata_tests.step);
-        if (is_runtime_exclusive) {
-            unit_metadata_focused_run_tails = .{ &run_focused_metadata_tests.step, &run_focused_metadata_tests.step };
-        } else {
-            unit_metadata_focused_run_tails[lane] = &run_focused_metadata_tests.step;
-        }
+        unit_metadata_sharded_test_step.dependOn(&focused_run.*.step);
+        lib_metadata_test_step.dependOn(&focused_run.*.step);
     }
+
+    // Preserve the existing runtime isolation: ordinary lane work overlaps,
+    // replication backfill runs alone, and metadata storage follows it.
+    unit_metadata_aggregate_runs[2].step.dependOn(&unit_metadata_aggregate_runs[0].step);
+    unit_metadata_aggregate_runs[2].step.dependOn(&unit_metadata_aggregate_runs[1].step);
+    unit_metadata_aggregate_runs[3].step.dependOn(&unit_metadata_aggregate_runs[2].step);
+    unit_metadata_focused_runs[2].step.dependOn(&unit_metadata_focused_runs[0].step);
+    unit_metadata_focused_runs[2].step.dependOn(&unit_metadata_focused_runs[1].step);
+    unit_metadata_focused_runs[3].step.dependOn(&unit_metadata_focused_runs[2].step);
 
     // Default Antfly unit coverage is hermetic: no network fetchers, no
     // benchmarks, and no soak/conformance suites that require external corpora.

--- a/zig/pkg/antfly/src/metadata_unit_lane_a_test_root.zig
+++ b/zig/pkg/antfly/src/metadata_unit_lane_a_test_root.zig
@@ -1,0 +1,29 @@
+// Copyright 2026 Antfly, Inc.
+//
+// Licensed under the Elastic License 2.0 (ELv2); you may not use this file
+// except in compliance with the Elastic License 2.0. You may obtain a copy of
+// the License at https://www.antfly.io/licensing/ELv2-license.
+
+const reconciler = @import("metadata/reconciler.zig");
+const state = @import("metadata/state.zig");
+const runtime = @import("metadata/runtime.zig");
+const authority = @import("metadata/authority.zig");
+const incarnation = @import("metadata/incarnation.zig");
+const reconcile_lease = @import("metadata/reconcile_lease.zig");
+const store_observer = @import("metadata/store_observer.zig");
+const server = @import("metadata/server.zig");
+const table_provisioner = @import("metadata/table_provisioner.zig");
+const storage = @import("metadata/storage/mod.zig");
+
+test {
+    _ = reconciler;
+    _ = state;
+    _ = runtime;
+    _ = authority;
+    _ = incarnation;
+    _ = reconcile_lease;
+    _ = store_observer;
+    _ = server;
+    _ = table_provisioner;
+    _ = storage;
+}

--- a/zig/pkg/antfly/src/metadata_unit_lane_b_test_root.zig
+++ b/zig/pkg/antfly/src/metadata_unit_lane_b_test_root.zig
@@ -1,0 +1,49 @@
+// Copyright 2026 Antfly, Inc.
+//
+// Licensed under the Elastic License 2.0 (ELv2); you may not use this file
+// except in compliance with the Elastic License 2.0. You may obtain a copy of
+// the License at https://www.antfly.io/licensing/ELv2-license.
+
+const service = @import("metadata/service.zig");
+const admin_read_operations = @import("metadata/admin_read_operations.zig");
+const admin_mutation_operations = @import("metadata/admin_mutation_operations.zig");
+const extension_operations = @import("metadata/extension_operations.zig");
+const node_operations = @import("metadata/node_operations.zig");
+const table_operations = @import("metadata/table_operations.zig");
+const http_client = @import("metadata/http_client.zig");
+const http_routes = @import("metadata/http_routes.zig");
+const http_server = @import("metadata/http_server.zig");
+const api = @import("metadata/api.zig");
+const admin = @import("metadata/admin.zig");
+const placement_planner = @import("metadata/placement_planner.zig");
+const control_loop = @import("metadata/control_loop.zig");
+const table_manager = @import("metadata/table_manager.zig");
+const table_workflow = @import("metadata/table_workflow.zig");
+const transition_state = @import("metadata/transition_state.zig");
+const transition_actions = @import("metadata/transition_actions.zig");
+const transition_controller = @import("metadata/transition_controller.zig");
+const transition_driver = @import("metadata/transition_driver.zig");
+const replication_backfill = @import("metadata/replication_backfill.zig");
+
+test {
+    _ = service;
+    _ = admin_read_operations;
+    _ = admin_mutation_operations;
+    _ = extension_operations;
+    _ = node_operations;
+    _ = table_operations;
+    _ = http_client;
+    _ = http_routes;
+    _ = http_server;
+    _ = api;
+    _ = admin;
+    _ = placement_planner;
+    _ = control_loop;
+    _ = table_manager;
+    _ = table_workflow;
+    _ = transition_state;
+    _ = transition_actions;
+    _ = transition_controller;
+    _ = transition_driver;
+    _ = replication_backfill;
+}


### PR DESCRIPTION
## Summary

- consolidate the nine production metadata unit-test compile artifacts into two bounded compile lanes
- preserve the existing runtime isolation contract: ordinary lane work overlaps, replication-backfill runs alone after both lanes, and metadata storage follows it
- retain the former nine artifacts behind an opt-in inventory check so coverage drift is detectable without paying their compile cost in normal `unit-test` runs
- preserve concise focused filtering without running a matching test twice

## Local impact

On a cold local cache on this machine:

- prior metadata layout: about 200s
- consolidated `unit-metadata-compile`: about 108s
- cached full runtime: about 21s

The compile comparison is directional rather than a CI benchmark, but removes seven repeated semantic-analysis/code-generation passes while keeping two bounded parallel lanes.

## Validation

- `zig build unit-metadata-test --summary all`
- `zig build unit-metadata-test-inventory --summary all` — identical named inventory (446 tests)
- `zig build unit-metadata-test --summary all -- metadata.storage.` — exactly 58 storage tests
- `zig fmt --check build.zig pkg/antfly/src/metadata_unit_lane_a_test_root.zig pkg/antfly/src/metadata_unit_lane_b_test_root.zig`
- `git diff --check`
