### PR TITLE
zig: split serverless from storage release unit

### DIFF
--- a/.github/workflows/diagnose-zig-arm64-bad-alloc.yml
+++ b/.github/workflows/diagnose-zig-arm64-bad-alloc.yml
@@ -1,0 +1,132 @@
+name: Diagnose Darwin ARM64 release packaging
+
+# Run this expensive release reproduction from the Actions UI, or before a PR
+# merges by applying the `ci:darwin-release` label. Ordinary PR updates do not
+# schedule the 20 GiB ReleaseFast build.
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [labeled]
+
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  ZIG_VERSION: 0.16.0
+  MACOS_SDK_VERSION: "15.5"
+  MACOS_SDK_SHA256: c15cf0f3f17d714d1aa5a642da8e118db53d79429eb015771ba816aa7c6c1cbd
+
+jobs:
+  darwin-release:
+    name: Darwin ARM64 ReleaseFast archive
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' &&
+       github.event.label.name == 'ci:darwin-release' &&
+       github.event.pull_request.head.repo.full_name == github.repository)
+    runs-on: arc-antfly-publish
+    timeout-minutes: 180
+    steps:
+      - name: Checkout requested revision
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          submodules: true
+
+      - name: Verify x86_64 host
+        run: test "$(uname -m)" = x86_64
+
+      - name: Verify runtime boundaries and bounded runner
+        run: |
+          python3 zig/tools/analyze_zig_import_graph.py --check-runtime-boundary --check-codegen-boundary --check-api-kernel-boundary --json
+          python3 -m unittest zig/tools/test_analyze_zig_import_graph.py
+          python3 -m unittest zig/tools/test_patch_zig_0_16_build_runner_maxrss.py
+          python3 -m unittest zig/tools/test_run_bounded_zig_build.py
+
+      - name: Install Linux build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential clang lld curl xz-utils git perl python3 linux-libc-dev ca-certificates time file
+
+      - name: Install Zig
+        run: |
+          curl --fail --location --retry 3 \
+            "https://ziglang.org/download/${ZIG_VERSION}/zig-x86_64-linux-${ZIG_VERSION}.tar.xz" \
+            -o "$RUNNER_TEMP/zig.tar.xz"
+          mkdir -p "$RUNNER_TEMP/zig"
+          tar -xJf "$RUNNER_TEMP/zig.tar.xz" -C "$RUNNER_TEMP/zig" --strip-components=1
+          echo "$RUNNER_TEMP/zig" >> "$GITHUB_PATH"
+
+      - name: Install pinned macOS cross-compilation SDK
+        run: |
+          sdk_archive="$RUNNER_TEMP/MacOSX${MACOS_SDK_VERSION}.sdk.tar.xz"
+          sdk_stage="$RUNNER_TEMP/macos-sdk"
+          curl --fail --location --retry 3 \
+            "https://github.com/joseluisq/macosx-sdks/releases/download/${MACOS_SDK_VERSION}/MacOSX${MACOS_SDK_VERSION}.sdk.tar.xz" \
+            -o "$sdk_archive"
+          echo "$MACOS_SDK_SHA256  $sdk_archive" | sha256sum --check --strict
+          mkdir -p "$sdk_stage"
+          tar -xJf "$sdk_archive" -C "$sdk_stage"
+
+          sdk_path="$sdk_stage/MacOSX${MACOS_SDK_VERSION}.sdk"
+          test -d "$sdk_path/System/Library/Frameworks/Metal.framework"
+          test -d "$sdk_path/System/Library/Frameworks/MetalPerformanceShaders.framework"
+          test -d "$sdk_path/System/Library/Frameworks/Accelerate.framework"
+          echo "SDK_PATH=$sdk_path" >> "$GITHUB_ENV"
+
+      - name: Build production Darwin ARM64 archive
+        run: |
+          mkdir -p dist/release-archives
+          /usr/bin/time -v -o "$RUNNER_TEMP/darwin-arm64-release.time" \
+            scripts/packaging/build_zig_release_archive.sh \
+            --version 0.0.0-diagnostic \
+            --target aarch64-macos \
+            --optimize ReleaseFast \
+            --archive-name antfly_diagnostic_Darwin_arm64.tar.gz \
+            --out-dir dist/release-archives \
+            --metal true \
+            --system-blas true
+
+      - name: Verify Darwin ARM64 archive
+        run: |
+          archive=dist/release-archives/antfly_diagnostic_Darwin_arm64.tar.gz
+          extract_root="$RUNNER_TEMP/darwin-arm64-archive"
+          mkdir -p "$extract_root"
+          tar -xzf "$archive" -C "$extract_root"
+
+          binary="$extract_root/antfly"
+          library="$extract_root/lib/libantfly.dylib"
+          test -x "$binary"
+          test -f "$library"
+          test -f "$extract_root/include/antfly.h"
+          file "$binary" | tee "$RUNNER_TEMP/darwin-arm64.binary-file"
+          file "$library" | tee "$RUNNER_TEMP/darwin-arm64.capi-file"
+          grep -Eq 'Mach-O 64-bit (arm64|arm64e)' "$RUNNER_TEMP/darwin-arm64.binary-file"
+          grep -Eq 'Mach-O 64-bit (arm64|arm64e)' "$RUNNER_TEMP/darwin-arm64.capi-file"
+          stat -c 'binary_size_bytes=%s' "$binary" | tee "$RUNNER_TEMP/darwin-arm64.binary-size"
+          stat -c 'capi_size_bytes=%s' "$library" | tee "$RUNNER_TEMP/darwin-arm64.capi-size"
+          library_size=$(stat -c '%s' "$library")
+          if [ "$library_size" -ge 20971520 ]; then
+            echo "libantfly.dylib exceeded the 20MiB retained-code budget: $library_size bytes" >&2
+            exit 1
+          fi
+
+      - name: Report compiler memory
+        if: ${{ always() }}
+        run: cat "$RUNNER_TEMP/darwin-arm64-release.time" || true
+
+      - name: Upload diagnostic result
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v6
+        with:
+          name: zig-darwin-arm64-release-fast
+          path: |
+            dist/release-archives/antfly_diagnostic_Darwin_arm64.tar.gz
+            ${{ runner.temp }}/antfly-zig-release-aarch64-macos
+            ${{ runner.temp }}/darwin-arm64-release.time
+            ${{ runner.temp }}/darwin-arm64.binary-file
+            ${{ runner.temp }}/darwin-arm64.binary-size
+            ${{ runner.temp }}/darwin-arm64.capi-file
+            ${{ runner.temp }}/darwin-arm64.capi-size
+          if-no-files-found: warn

--- a/scripts/packaging/build_zig_release_archive.sh
+++ b/scripts/packaging/build_zig_release_archive.sh
@@ -238,9 +238,9 @@ run_zig_build_steps_with_retry() {
 
 (
   cd "$repo_root/zig"
-  # API and the shared PIC application/storage unit occupy the initial bounded
-  # memory group. Inference starts after API, while the short remote CLI unit
-  # starts after application/storage, preserving useful overlap deterministically.
+  # The runtime libraries carry measured max-RSS claims, so the build runner
+  # overlaps only the API, storage, serverless, inference, and CLI units that
+  # fit within its bounded memory group.
   run_zig_build_steps_with_retry archive antfly capi
 )
 

--- a/zig/build.zig
+++ b/zig/build.zig
@@ -45,6 +45,10 @@ const RuntimeArtifactRole = enum {
 const RuntimeLibraryUnit = enum {
     api_kernel,
     distributed,
+    // Serverless/lake execution is a large, independently deployable graph.
+    // Keep it out of the PIC storage kernel so LLVM never has to optimize the
+    // two closures as one ARM64 ReleaseFast compilation unit.
+    serverless,
     inference,
     // Remote/client commands do not own storage or server runtimes.
     cli,
@@ -57,6 +61,7 @@ const RuntimeLibraryUnit = enum {
 // graph construction, not the final link's dependency topology.
 const runtime_library_link_order = [_]RuntimeLibraryUnit{
     .cli,
+    .serverless,
     .distributed,
     .api_kernel,
     .inference,
@@ -10062,19 +10067,24 @@ pub fn build(b: *std.Build) void {
                 // Claims conservatively cover clean production ReleaseFast
                 // peaks measured for both aarch64-linux-musl and explicit
                 // aarch64-macos (including Metal and Accelerate). They are
-                // scheduling reservations, not hard process limits. A 48 GiB
-                // budget can overlap all four units while a smaller cgroup
+                // scheduling reservations, not hard process limits. A larger
+                // budget can overlap more units while a smaller cgroup
                 // automatically schedules only the subset that fits.
                 // aarch64-macOS ReleaseFast codegen reached 9.95 GB with
                 // platform frameworks. Linux ARM64 reached 4.99 GB in the
                 // v0.2.1-rc0 release build, so reserve 6 GiB rather than
                 // forcing the scheduler to discard a completed 4 GiB claim.
                 .api_kernel => @as(usize, if (target.result.os.tag == .macos) 11 else 6) * 1024 * 1024 * 1024,
-                // Clean aarch64-macOS ReleaseFast storage codegen reached
-                // 17.42 GB (16.23 GiB) with the platform frameworks enabled.
-                // Keep the
-                // tighter Linux reservation, where CI remains below 8 GiB.
+                // Before the serverless split, clean aarch64-macOS ReleaseFast
+                // storage codegen reached 17.42 GB (16.23 GiB). Keep the old
+                // conservative reservations until both release runners have
+                // measured the smaller storage-only closure.
                 .distributed => @as(usize, if (target.result.os.tag == .macos) 18 else 8) * 1024 * 1024 * 1024,
+                // This is deliberately a separate non-PIC product unit. The
+                // Its cold aarch64-macOS ReleaseFast build peaks near 2 GiB;
+                // the 10 GiB reservation keeps it serialized with the macOS
+                // storage kernel until both release runners confirm that.
+                .serverless => 10 * 1024 * 1024 * 1024,
                 // The broad aarch64-macOS ReleaseFast inference root now
                 // reaches roughly 13.6 GB after storage/runtime integration.
                 // Reserve enough headroom for mode-dependent IR; the build
@@ -10086,6 +10096,11 @@ pub fn build(b: *std.Build) void {
                 .cli => 3 * 1024 * 1024 * 1024,
             },
         });
+        const runtime_unit_step = b.step(
+            b.fmt("runtime-unit-{s}", .{@tagName(unit)}),
+            b.fmt("Build only the {s} runtime library unit", .{@tagName(unit)}),
+        );
+        runtime_unit_step.dependOn(&role_artifact.step);
         runtime_library_artifacts[@intFromEnum(unit)] = role_artifact;
         if (unit == .distributed) {
             // The executable and C ABI libraries share this one optimized

--- a/zig/pkg/antfly/src/runtime_artifact_lib.zig
+++ b/zig/pkg/antfly/src/runtime_artifact_lib.zig
@@ -43,7 +43,7 @@ const cli_runtime = if (unit_options.unit == .cli) @import("cli_runtime.zig") el
 const ha_runtime = if (unit_options.unit == .distributed) @import("cmd/ha.zig") else struct {};
 const data_runtime = if (unit_options.unit == .distributed) @import("data/runtime.zig") else struct {};
 const metadata_runtime = if (unit_options.unit == .distributed) @import("metadata/runtime.zig") else struct {};
-const serverless_runtime = if (unit_options.unit == .distributed) @import("cmd/serverless.zig") else struct {};
+const serverless_runtime = if (unit_options.unit == .serverless) @import("cmd/serverless.zig") else struct {};
 const inference_runtime = if (unit_options.unit == .inference) @import("inference_runtime/runtime.zig") else struct {};
 // Standalone adds about 35 seconds when co-generated with the server roles but
 // costs 6 minutes and 8 GiB as a separate ARM64 Linux unit. Keep it co-located
@@ -287,10 +287,12 @@ comptime {
             exportInternal(&dataEntry, "antfly_runtime_data");
             exportInternal(&haEntry, "antfly_runtime_ha");
             exportInternal(&metadataEntry, "antfly_runtime_metadata");
-            exportInternal(&serverlessEntry, "antfly_runtime_serverless");
             exportInternal(&standaloneEntry, "antfly_runtime_standalone");
             exportInternal(&restore_staging_exports.create, "antfly_restore_staging_create");
             exportInternal(&restore_staging_exports.destroy, "antfly_restore_staging_destroy");
+        },
+        .serverless => {
+            exportInternal(&serverlessEntry, "antfly_runtime_serverless");
         },
         .inference => {
             exportInternal(&standaloneInferenceGetFunctionTable, "antfly_standalone_inference_get_function_table");


### PR DESCRIPTION
Splits the serverless/lake runtime out of the PIC storage kernel so LLVM optimizes them as separate ARM64 ReleaseFast units. This keeps the existing runtime ABI and final link topology while reducing the size of the formerly failing storage compilation.

Also ports PR #536's label-triggered Darwin ARM64 release workflow. Apply the ci:darwin-release label to run the full production archive reproduction on arc-antfly-publish.

Local validation:
- cold aarch64-macos ReleaseFast storage unit: passed, 3 GiB MaxRSS
- cold aarch64-macos ReleaseFast serverless unit: passed, 2 GiB MaxRSS
- runtime/codegen/API boundary audit: passed
- workflow Python tests: 27 passed
- actionlint and zig fmt: passed