### PR TITLE
fix(release): install Zig for CLI packaging

### DIFF
--- a/.github/workflows/antfly-release.yml
+++ b/.github/workflows/antfly-release.yml
@@ -229,6 +229,15 @@ jobs:
           node-version: 24.x
           registry-url: https://registry.npmjs.org/
 
+      - name: Set up Zig
+        run: |
+          curl --fail --location --retry 3 \
+            "https://ziglang.org/download/${ZIG_VERSION}/zig-x86_64-linux-${ZIG_VERSION}.tar.xz" \
+            -o "$RUNNER_TEMP/zig.tar.xz"
+          mkdir -p "$RUNNER_TEMP/zig"
+          tar -xJf "$RUNNER_TEMP/zig.tar.xz" -C "$RUNNER_TEMP/zig" --strip-components=1
+          echo "$RUNNER_TEMP/zig" >> "$GITHUB_PATH"
+
       - name: Test Antfly C ABI packaging
         run: python scripts/packaging/test_cabi_packaging.py
 

--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -21,6 +21,7 @@ permissions:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  ZIG_VERSION: 0.16.0
 
 jobs:
   package:
@@ -70,6 +71,15 @@ jobs:
         with:
           node-version: 24.x
           registry-url: https://registry.npmjs.org/
+
+      - name: Set up Zig
+        run: |
+          curl --fail --location --retry 3 \
+            "https://ziglang.org/download/${ZIG_VERSION}/zig-x86_64-linux-${ZIG_VERSION}.tar.xz" \
+            -o "$RUNNER_TEMP/zig.tar.xz"
+          mkdir -p "$RUNNER_TEMP/zig"
+          tar -xJf "$RUNNER_TEMP/zig.tar.xz" -C "$RUNNER_TEMP/zig" --strip-components=1
+          echo "$RUNNER_TEMP/zig" >> "$GITHUB_PATH"
 
       - name: Test Antfly C ABI packaging
         run: python scripts/packaging/test_cabi_packaging.py


### PR DESCRIPTION
The v0.2.1-rc0 release built all native archives successfully, then failed in Build CLI package artifacts because scripts/completions.sh now invokes Zig and the packaging job only installed Python and Node.

Install pinned Zig 0.16.0 in both workflows that run the C ABI packaging test and build CLI packages.

Validation:
- actionlint .github/workflows/antfly-release.yml .github/workflows/cli-publish.yml
- python3 scripts/packaging/test_cabi_packaging.py