### PR TITLE
fix(api): own cluster topology response data

### DIFF
--- a/zig/build.zig
+++ b/zig/build.zig
@@ -3436,7 +3436,7 @@ pub fn build(b: *std.Build) void {
     antfly_imports.configure(b, api_cluster_secret_status_test_mod, true, true);
     const api_cluster_secret_status_tests = b.addTest(.{
         .root_module = api_cluster_secret_status_test_mod,
-        .filters = &.{"cluster status carries non-secret"},
+        .filters = &.{ "cluster status carries non-secret", "cluster topology owns snapshot data" },
     });
     const run_api_cluster_secret_status_tests = addFilteredTestRunArtifact(b, api_cluster_secret_status_tests);
     lib_common_secrets_test_step.dependOn(&run_api_cluster_secret_status_tests.step);

--- a/zig/pkg/antfly/src/api/cluster.zig
+++ b/zig/pkg/antfly/src/api/cluster.zig
@@ -19,6 +19,7 @@ const metadata_reconciler = @import("../metadata/reconciler.zig");
 const table_manager = @import("../metadata/table_manager.zig");
 const common_config = @import("../common/config.zig");
 const metadata_openapi = @import("antfly_metadata_openapi");
+const raft_reconciler = @import("../raft/reconciler.zig");
 
 pub const ClusterHealth = enum {
     healthy,
@@ -100,10 +101,22 @@ pub const ClusterDataStatus = struct {
     groups: []const DataGroupStatus = &.{},
 
     pub fn deinit(self: *ClusterDataStatus, alloc: std.mem.Allocator) void {
-        if (self.nodes.len > 0) alloc.free(@constCast(self.nodes));
-        if (self.ranges.len > 0) alloc.free(@constCast(self.ranges));
-        if (self.replicas.len > 0) alloc.free(@constCast(self.replicas));
-        if (self.groups.len > 0) alloc.free(@constCast(self.groups));
+        if (self.nodes.len > 0) {
+            for (@constCast(self.nodes)) |*node| node.deinit(alloc);
+            alloc.free(@constCast(self.nodes));
+        }
+        if (self.ranges.len > 0) {
+            for (@constCast(self.ranges)) |*range| range.deinit(alloc);
+            alloc.free(@constCast(self.ranges));
+        }
+        if (self.replicas.len > 0) {
+            for (@constCast(self.replicas)) |*replica| replica.deinit(alloc);
+            alloc.free(@constCast(self.replicas));
+        }
+        if (self.groups.len > 0) {
+            for (@constCast(self.groups)) |*group| group.deinit(alloc);
+            alloc.free(@constCast(self.groups));
+        }
         self.* = undefined;
     }
 };
@@ -125,6 +138,16 @@ pub const DataNodeStatus = struct {
     read_load: u32 = 0,
     write_load: u32 = 0,
     active_backfills: u32 = 0,
+
+    fn deinit(self: *DataNodeStatus, alloc: std.mem.Allocator) void {
+        alloc.free(self.api_url);
+        alloc.free(self.raft_url);
+        alloc.free(self.role);
+        alloc.free(self.state);
+        alloc.free(self.health_class);
+        alloc.free(self.failure_domain);
+        self.* = undefined;
+    }
 };
 
 pub const DataRangeStatus = struct {
@@ -142,6 +165,14 @@ pub const DataRangeStatus = struct {
     doc_count: u64 = 0,
     disk_bytes: u64 = 0,
     empty: bool = true,
+
+    fn deinit(self: *DataRangeStatus, alloc: std.mem.Allocator) void {
+        alloc.free(self.table_name);
+        alloc.free(self.start_key);
+        if (self.end_key) |end_key| alloc.free(end_key);
+        alloc.free(self.state);
+        self.* = undefined;
+    }
 };
 
 pub const DataReplicaStatus = struct {
@@ -150,6 +181,11 @@ pub const DataReplicaStatus = struct {
     node_id: u64,
     replica_id: u64,
     peer_node_ids: []const u64 = &.{},
+
+    fn deinit(self: *DataReplicaStatus, alloc: std.mem.Allocator) void {
+        alloc.free(self.peer_node_ids);
+        self.* = undefined;
+    }
 };
 
 pub const DataGroupStatus = struct {
@@ -169,6 +205,11 @@ pub const DataGroupStatus = struct {
     doc_count: u64 = 0,
     disk_bytes: u64 = 0,
     empty: bool = true,
+
+    fn deinit(self: *DataGroupStatus, alloc: std.mem.Allocator) void {
+        alloc.free(self.doc_identity_lifecycle);
+        self.* = undefined;
+    }
 };
 
 pub fn fromMetadataStatus(alloc: std.mem.Allocator, status: metadata_api.MetadataStatus) !ClusterStatus {
@@ -262,18 +303,48 @@ pub fn topologyFromStatus(alloc: std.mem.Allocator, status: ClusterStatus) !Clus
 }
 
 pub fn dataFromSnapshot(alloc: std.mem.Allocator, snapshot: *const metadata_api.AdminSnapshot) !ClusterDataStatus {
-    const nodes = try alloc.alloc(DataNodeStatus, snapshot.stores.len);
-    errdefer alloc.free(nodes);
-    for (snapshot.stores, 0..) |store, i| {
+    var data: ClusterDataStatus = .{};
+    errdefer data.deinit(alloc);
+    data.nodes = try cloneNodeStatuses(alloc, snapshot.stores);
+    data.ranges = try cloneRangeStatuses(
+        alloc,
+        snapshot.tables,
+        snapshot.ranges,
+        snapshot.merged_group_statuses,
+    );
+    data.replicas = try cloneReplicaStatuses(alloc, snapshot.placement_intents);
+    data.groups = try cloneGroupStatuses(alloc, snapshot.merged_group_statuses);
+    return data;
+}
+
+fn cloneNodeStatuses(alloc: std.mem.Allocator, stores: []const table_manager.StoreRecord) ![]DataNodeStatus {
+    const nodes = try alloc.alloc(DataNodeStatus, stores.len);
+    var initialized: usize = 0;
+    errdefer {
+        for (nodes[0..initialized]) |*node| node.deinit(alloc);
+        alloc.free(nodes);
+    }
+    for (stores, 0..) |store, i| {
+        const api_url = try alloc.dupe(u8, store.api_url);
+        errdefer alloc.free(api_url);
+        const raft_url = try alloc.dupe(u8, store.raft_url);
+        errdefer alloc.free(raft_url);
+        const role = try alloc.dupe(u8, store.role);
+        errdefer alloc.free(role);
+        const state = try alloc.dupe(u8, if (store.live) store.health_class else "unhealthy");
+        errdefer alloc.free(state);
+        const health_class = try alloc.dupe(u8, store.health_class);
+        errdefer alloc.free(health_class);
+        const failure_domain = try alloc.dupe(u8, store.failure_domain);
         nodes[i] = .{
             .data_id = store.store_id,
             .node_id = store.node_id,
-            .api_url = store.api_url,
-            .raft_url = store.raft_url,
-            .role = store.role,
-            .state = if (store.live) store.health_class else "unhealthy",
-            .health_class = store.health_class,
-            .failure_domain = store.failure_domain,
+            .api_url = api_url,
+            .raft_url = raft_url,
+            .role = role,
+            .state = state,
+            .health_class = health_class,
+            .failure_domain = failure_domain,
             .live = store.live,
             .drain_requested = store.drain_requested,
             .capacity_bytes = store.capacity_bytes,
@@ -283,45 +354,89 @@ pub fn dataFromSnapshot(alloc: std.mem.Allocator, snapshot: *const metadata_api.
             .write_load = store.write_load,
             .active_backfills = store.active_backfills,
         };
+        initialized += 1;
     }
+    return nodes;
+}
 
-    const ranges = try alloc.alloc(DataRangeStatus, snapshot.ranges.len);
-    errdefer alloc.free(ranges);
-    for (snapshot.ranges, 0..) |range, i| {
-        const group = findGroupStatus(snapshot.merged_group_statuses, range.group_id);
+fn cloneRangeStatuses(
+    alloc: std.mem.Allocator,
+    tables: []const table_manager.TableRecord,
+    source_ranges: []const table_manager.RangeRecord,
+    merged_group_statuses: []const metadata_reconciler.MergedGroupStatus,
+) ![]DataRangeStatus {
+    const ranges = try alloc.alloc(DataRangeStatus, source_ranges.len);
+    var initialized: usize = 0;
+    errdefer {
+        for (ranges[0..initialized]) |*range| range.deinit(alloc);
+        alloc.free(ranges);
+    }
+    for (source_ranges, 0..) |range, i| {
+        const group = findGroupStatus(merged_group_statuses, range.group_id);
+        const table_name = try alloc.dupe(u8, tableName(tables, range.table_id));
+        errdefer alloc.free(table_name);
+        const start_key = try alloc.dupe(u8, range.start_key);
+        errdefer alloc.free(start_key);
+        const end_key = if (range.end_key) |value| try alloc.dupe(u8, value) else null;
+        errdefer if (end_key) |value| alloc.free(value);
+        const state = try alloc.dupe(u8, if (group) |status_value| rangeState(status_value) else "unknown");
         ranges[i] = .{
             .group_id = range.group_id,
             .range_id = range.range_id,
             .table_id = range.table_id,
-            .table_name = tableName(snapshot.tables, range.table_id),
-            .start_key = range.start_key,
-            .end_key = range.end_key,
+            .table_name = table_name,
+            .start_key = start_key,
+            .end_key = end_key,
             .doc_identity_shard_id = range.doc_identity_shard_id,
             .doc_identity_range_id = range.doc_identity_range_id,
-            .state = if (group) |status_value| rangeState(status_value) else "unknown",
+            .state = state,
             .leader_data_id = if (group) |status_value| if (status_value.leader_known) status_value.leader_store_id else null else null,
             .voter_count = if (group) |status_value| status_value.voter_count else 0,
             .doc_count = if (group) |status_value| status_value.doc_count else 0,
             .disk_bytes = if (group) |status_value| status_value.disk_bytes else 0,
             .empty = if (group) |status_value| status_value.empty else true,
         };
+        initialized += 1;
     }
+    return ranges;
+}
 
-    const replicas = try alloc.alloc(DataReplicaStatus, snapshot.placement_intents.len);
-    errdefer alloc.free(replicas);
-    for (snapshot.placement_intents, 0..) |intent, i| {
+fn cloneReplicaStatuses(
+    alloc: std.mem.Allocator,
+    placement_intents: []const raft_reconciler.PlacementIntent,
+) ![]DataReplicaStatus {
+    const replicas = try alloc.alloc(DataReplicaStatus, placement_intents.len);
+    var initialized: usize = 0;
+    errdefer {
+        for (replicas[0..initialized]) |*replica| replica.deinit(alloc);
+        alloc.free(replicas);
+    }
+    for (placement_intents, 0..) |intent, i| {
+        const peer_node_ids = try alloc.dupe(u64, intent.peer_node_ids);
         replicas[i] = .{
             .group_id = intent.record.group_id,
             .data_id = intent.store_id,
             .node_id = intent.record.local_node_id,
             .replica_id = intent.record.replica_id,
-            .peer_node_ids = intent.peer_node_ids,
+            .peer_node_ids = peer_node_ids,
         };
+        initialized += 1;
     }
+    return replicas;
+}
 
-    const groups = try alloc.alloc(DataGroupStatus, snapshot.merged_group_statuses.len);
-    errdefer alloc.free(groups);
-    for (snapshot.merged_group_statuses, 0..) |group, i| {
+fn cloneGroupStatuses(
+    alloc: std.mem.Allocator,
+    merged_group_statuses: []const metadata_reconciler.MergedGroupStatus,
+) ![]DataGroupStatus {
+    const groups = try alloc.alloc(DataGroupStatus, merged_group_statuses.len);
+    var initialized: usize = 0;
+    errdefer {
+        for (groups[0..initialized]) |*group| group.deinit(alloc);
+        alloc.free(groups);
+    }
+    for (merged_group_statuses, 0..) |group, i| {
+        const doc_identity_lifecycle = try alloc.dupe(u8, group.doc_identity_lifecycle);
         groups[i] = .{
             .group_id = group.group_id,
             .leader_known = group.leader_known,
@@ -335,19 +450,14 @@ pub fn dataFromSnapshot(alloc: std.mem.Allocator, snapshot: *const metadata_api.
             .replay_caught_up = group.replay_caught_up,
             .cutover_ready = group.cutover_ready,
             .reads_ready_after_cutover = group.reads_ready_after_cutover,
-            .doc_identity_lifecycle = group.doc_identity_lifecycle,
+            .doc_identity_lifecycle = doc_identity_lifecycle,
             .doc_count = group.doc_count,
             .disk_bytes = group.disk_bytes,
             .empty = group.empty,
         };
+        initialized += 1;
     }
-
-    return .{
-        .nodes = nodes,
-        .ranges = ranges,
-        .replicas = replicas,
-        .groups = groups,
-    };
+    return groups;
 }
 
 pub fn applySecretStoreHealth(alloc: std.mem.Allocator, status: *ClusterStatus, health: common_secrets.ReloadHealth) !void {
@@ -536,4 +646,145 @@ test "cluster status carries non-secret runtime config generation and hash" {
     try std.testing.expectEqualStrings("0123456789abcdef000000000000000000000000000000000000000000000000", runtime_config.hash);
     try std.testing.expect(runtime_config.last_reload_failed);
     try std.testing.expect(runtime_config.stale);
+}
+
+test "cluster topology owns snapshot data through serialization" {
+    const alloc = std.testing.allocator;
+    var source_arena = std.heap.ArenaAllocator.init(alloc);
+    var source_arena_live = true;
+    defer if (source_arena_live) source_arena.deinit();
+    const source = source_arena.allocator();
+
+    const tables = try source.alloc(table_manager.TableRecord, 1);
+    tables[0] = .{
+        .table_id = 7,
+        .name = try source.dupe(u8, "docs"),
+    };
+    const ranges = try source.alloc(table_manager.RangeRecord, 1);
+    ranges[0] = .{
+        .group_id = 11,
+        .range_id = 12,
+        .table_id = 7,
+        .start_key = try source.dupe(u8, "doc:a"),
+        .end_key = try source.dupe(u8, "doc:z"),
+    };
+    const stores = try source.alloc(table_manager.StoreRecord, 1);
+    stores[0] = .{
+        .store_id = 3,
+        .node_id = 4,
+        .api_url = try source.dupe(u8, "http://127.0.0.1:8080"),
+        .raft_url = try source.dupe(u8, "http://127.0.0.1:9021"),
+        .role = try source.dupe(u8, "data"),
+        .health_class = try source.dupe(u8, "healthy"),
+        .failure_domain = try source.dupe(u8, "rack-a"),
+    };
+    const placement_intents = try source.alloc(raft_reconciler.PlacementIntent, 1);
+    placement_intents[0] = .{
+        .record = .{ .group_id = 11, .replica_id = 5, .local_node_id = 4 },
+        .store_id = 3,
+        .peer_node_ids = try source.dupe(u64, &.{ 4, 8 }),
+    };
+    const merged_group_statuses = try source.alloc(metadata_reconciler.MergedGroupStatus, 1);
+    merged_group_statuses[0] = .{
+        .group_id = 11,
+        .leader_known = true,
+        .leader_store_id = 3,
+        .voter_count_known = true,
+        .voter_count = 2,
+        .healthy_voter_reports = 2,
+        .doc_identity_lifecycle = try source.dupe(u8, "ready"),
+    };
+    const snapshot: metadata_api.AdminSnapshot = .{
+        .status = .{ .metadata_group_id = 1, .metrics = .{} },
+        .tables = tables,
+        .ranges = ranges,
+        .stores = stores,
+        .placement_intents = placement_intents,
+        .split_transitions = &.{},
+        .merge_transitions = &.{},
+        .merged_group_statuses = merged_group_statuses,
+    };
+
+    var topology = try topologyFromStatusAndSnapshot(
+        alloc,
+        .{ .health = .healthy },
+        &snapshot,
+    );
+    defer topology.deinit(alloc);
+    try std.testing.expect(topology.data.nodes[0].api_url.ptr != stores[0].api_url.ptr);
+    try std.testing.expect(topology.data.ranges[0].table_name.ptr != tables[0].name.ptr);
+    try std.testing.expect(topology.data.ranges[0].start_key.ptr != ranges[0].start_key.ptr);
+    try std.testing.expect(topology.data.replicas[0].peer_node_ids.ptr != placement_intents[0].peer_node_ids.ptr);
+    try std.testing.expect(topology.data.groups[0].doc_identity_lifecycle.ptr != merged_group_statuses[0].doc_identity_lifecycle.ptr);
+
+    source_arena.deinit();
+    source_arena_live = false;
+
+    try std.testing.expectEqualStrings("http://127.0.0.1:8080", topology.data.nodes[0].api_url);
+    try std.testing.expectEqualStrings("http://127.0.0.1:9021", topology.data.nodes[0].raft_url);
+    try std.testing.expectEqualStrings("data", topology.data.nodes[0].role);
+    try std.testing.expectEqualStrings("healthy", topology.data.nodes[0].state);
+    try std.testing.expectEqualStrings("healthy", topology.data.nodes[0].health_class);
+    try std.testing.expectEqualStrings("rack-a", topology.data.nodes[0].failure_domain);
+    try std.testing.expectEqualStrings("docs", topology.data.ranges[0].table_name);
+    try std.testing.expectEqualStrings("doc:a", topology.data.ranges[0].start_key);
+    try std.testing.expectEqualStrings("doc:z", topology.data.ranges[0].end_key.?);
+    try std.testing.expectEqualStrings("healthy", topology.data.ranges[0].state);
+    try std.testing.expectEqualSlices(u64, &.{ 4, 8 }, topology.data.replicas[0].peer_node_ids);
+    try std.testing.expectEqualStrings("ready", topology.data.groups[0].doc_identity_lifecycle);
+
+    const encoded = try std.json.Stringify.valueAlloc(alloc, topology, .{});
+    defer alloc.free(encoded);
+    try std.testing.expect(std.mem.indexOf(u8, encoded, "\"api_url\":\"http://127.0.0.1:8080\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, encoded, "\"role\":\"data\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, encoded, "\"state\":\"healthy\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, encoded, "\"health_class\":\"healthy\"") != null);
+
+    const AllocationRunner = struct {
+        fn run(failing_alloc: std.mem.Allocator) !void {
+            var source_tables = [_]table_manager.TableRecord{.{ .table_id = 7, .name = "docs" }};
+            var source_ranges = [_]table_manager.RangeRecord{.{
+                .group_id = 11,
+                .range_id = 12,
+                .table_id = 7,
+                .start_key = "doc:a",
+                .end_key = "doc:z",
+            }};
+            var source_stores = [_]table_manager.StoreRecord{.{
+                .store_id = 3,
+                .node_id = 4,
+                .api_url = "http://127.0.0.1:8080",
+                .raft_url = "http://127.0.0.1:9021",
+                .role = "data",
+                .health_class = "healthy",
+                .failure_domain = "rack-a",
+            }};
+            var source_placements = [_]raft_reconciler.PlacementIntent{.{
+                .record = .{ .group_id = 11, .replica_id = 5, .local_node_id = 4 },
+                .store_id = 3,
+                .peer_node_ids = &.{ 4, 8 },
+            }};
+            var source_groups = [_]metadata_reconciler.MergedGroupStatus{.{
+                .group_id = 11,
+                .doc_identity_lifecycle = "ready",
+            }};
+            const source_snapshot: metadata_api.AdminSnapshot = .{
+                .status = .{ .metadata_group_id = 1, .metrics = .{} },
+                .tables = &source_tables,
+                .ranges = &source_ranges,
+                .stores = &source_stores,
+                .placement_intents = &source_placements,
+                .split_transitions = &.{},
+                .merge_transitions = &.{},
+                .merged_group_statuses = &source_groups,
+            };
+            var owned = try topologyFromStatusAndSnapshot(
+                failing_alloc,
+                .{ .health = .healthy },
+                &source_snapshot,
+            );
+            defer owned.deinit(failing_alloc);
+        }
+    };
+    try std.testing.checkAllAllocationFailures(alloc, AllocationRunner.run, .{});
 }

--- a/zig/pkg/antfly/src/standalone/runtime.zig
+++ b/zig/pkg/antfly/src/standalone/runtime.zig
@@ -799,6 +799,14 @@ const LocalStandaloneMetadata = struct {
         self.* = undefined;
     }
 
+    fn setApiUrl(self: *LocalStandaloneMetadata, api_url: []const u8) !void {
+        const owned_api_url = try self.alloc.dupe(u8, api_url);
+        lockAtomic(&self.mutex);
+        defer self.mutex.unlock();
+        self.alloc.free(self.api_url);
+        self.api_url = owned_api_url;
+    }
+
     fn catalogSource(self: *LocalStandaloneMetadata) antfly.public_api.table_catalog.CatalogSource {
         return .{
             .ptr = self,
@@ -2333,6 +2341,7 @@ pub fn runFromIterator(
             &handler,
             antfly_node,
             api_server,
+            &local_metadata,
             &unified_api_ready,
             &unified_lifecycle,
             &http_runtime,
@@ -2346,6 +2355,7 @@ pub fn runFromIterator(
             &handler,
             antfly_node,
             api_server,
+            &local_metadata,
             &unified_api_ready,
             &unified_lifecycle,
             &http_runtime,
@@ -2483,11 +2493,12 @@ fn serveUnifiedWithInference(
     handler: *ApiKernelHandler,
     antfly_node: *anyopaque,
     api_server: *ApiHttpServer,
+    local_metadata: *LocalStandaloneMetadata,
     unified_api_ready: *std.atomic.Value(bool),
     lifecycle: *UnifiedServerLifecycle,
     http_runtime: *httpx.HttpRuntime,
 ) void {
-    serveUnifiedInner(true, alloc, io, public_http_config, cors_config, handler, antfly_node, api_server, unified_api_ready, lifecycle, http_runtime) catch |err| {
+    serveUnifiedInner(true, alloc, io, public_http_config, cors_config, handler, antfly_node, api_server, local_metadata, unified_api_ready, lifecycle, http_runtime) catch |err| {
         unified_api_ready.store(false, .release);
         lifecycle.publishFailure(err);
         std.debug.print("unified server error: {}\n", .{err});
@@ -2505,11 +2516,12 @@ fn serveUnifiedWithLinkedInference(
     handler: *ApiKernelHandler,
     inference_handle: *anyopaque,
     api_server: *ApiHttpServer,
+    local_metadata: *LocalStandaloneMetadata,
     unified_api_ready: *std.atomic.Value(bool),
     lifecycle: *UnifiedServerLifecycle,
     http_runtime: *httpx.HttpRuntime,
 ) void {
-    serveUnifiedInner(false, alloc, io, public_http_config, cors_config, handler, inference_handle, api_server, unified_api_ready, lifecycle, http_runtime) catch |err| {
+    serveUnifiedInner(false, alloc, io, public_http_config, cors_config, handler, inference_handle, api_server, local_metadata, unified_api_ready, lifecycle, http_runtime) catch |err| {
         unified_api_ready.store(false, .release);
         lifecycle.publishFailure(err);
         std.debug.print("unified server error: {}\n", .{err});
@@ -2528,6 +2540,7 @@ fn serveUnifiedInner(
     handler: *ApiKernelHandler,
     antfly_node: *anyopaque,
     api_server: *ApiHttpServer,
+    local_metadata: *LocalStandaloneMetadata,
     unified_api_ready: *std.atomic.Value(bool),
     lifecycle: *UnifiedServerLifecycle,
     http_runtime: *httpx.HttpRuntime,
@@ -2601,6 +2614,20 @@ fn serveUnifiedInner(
         listener_task.requestStop();
         listener_task.join() catch {};
     };
+    if (public_http_config.port == 0) {
+        const bound_address = server.boundAddress() orelse return error.PublicListenerAddressUnavailable;
+        const bound_port = switch (bound_address) {
+            .ip4 => |address| address.port,
+            .ip6 => |address| address.port,
+        };
+        const bound_api_url = try std.fmt.allocPrint(
+            alloc,
+            "http://{s}:{d}",
+            .{ public_http_config.host, bound_port },
+        );
+        defer alloc.free(bound_api_url);
+        try local_metadata.setApiUrl(bound_api_url);
+    }
     unified_api_ready.store(true, .release);
     try lifecycle.publishReady();
 
@@ -7476,6 +7503,12 @@ test "standalone metadata advertises a linearizable owned snapshot" {
     try std.testing.expectEqual(@as(u64, 9), snapshot.status.metadata_epoch);
     try std.testing.expectEqual(@as(usize, 1), snapshot.tables.len);
     try std.testing.expectEqualStrings("docs", snapshot.tables[0].name);
+
+    try metadata.setApiUrl("http://127.0.0.1:49152");
+    var rebound_snapshot = (try source.linearizableSnapshot(.{})) orelse return error.TestUnexpectedResult;
+    defer source.freeAdminSnapshot(&rebound_snapshot);
+    try std.testing.expectEqual(@as(usize, 1), rebound_snapshot.stores.len);
+    try std.testing.expectEqualStrings("http://127.0.0.1:49152", rebound_snapshot.stores[0].api_url);
 }
 
 test "standalone metadata rejects corrupt catalog without double-freeing owned paths" {


### PR DESCRIPTION
## Summary

- deep-copy cluster topology strings and replica peer IDs before releasing metadata snapshots
- release nested topology allocations during response cleanup
- advertise the actual bound standalone API port when configured with port 0
- add snapshot-lifetime, JSON-shape, allocation-failure, and rebound URL coverage

## Verification

- zig build antfly
- zig build lib-common-secrets-test
- zig build lib-standalone-runtime-test
- zig build api-http-runtime-test
- live standalone port-0 reproduction returned string-valued topology fields and the actual bound port

Closes #542