### PR TITLE
fix(release): install xz for CLI Zig setup

### DIFF
--- a/.github/workflows/antfly-release.yml
+++ b/.github/workflows/antfly-release.yml
@@ -231,6 +231,8 @@ jobs:
 
       - name: Set up Zig
         run: |
+          sudo apt-get update
+          sudo apt-get install -y xz-utils
           curl --fail --location --retry 3 \
             "https://ziglang.org/download/${ZIG_VERSION}/zig-x86_64-linux-${ZIG_VERSION}.tar.xz" \
             -o "$RUNNER_TEMP/zig.tar.xz"

--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -74,6 +74,8 @@ jobs:
 
       - name: Set up Zig
         run: |
+          sudo apt-get update
+          sudo apt-get install -y xz-utils
           curl --fail --location --retry 3 \
             "https://ziglang.org/download/${ZIG_VERSION}/zig-x86_64-linux-${ZIG_VERSION}.tar.xz" \
             -o "$RUNNER_TEMP/zig.tar.xz"


### PR DESCRIPTION
The replacement v0.2.1-rc0 release downloaded Zig successfully in Build CLI package artifacts, but the minimal ARC runner could not extract the tar.xz because xz was absent.

Install xz-utils before the existing direct pinned Zig download in both CLI packaging workflows.

Validation:
- actionlint .github/workflows/antfly-release.yml .github/workflows/cli-publish.yml
- python3 scripts/packaging/test_cabi_packaging.py