### PR TITLE
test(e2e): isolate transaction runtimes

### DIFF
--- a/zig/e2e/antfly/test_transactions.py
+++ b/zig/e2e/antfly/test_transactions.py
@@ -27,7 +27,10 @@ import requests
 from helpers import wait_until
 
 
-pytestmark = pytest.mark.reuse_antfly_process
+# Transaction commits can return while durable propagation and recovery continue.
+# Keep each test on a fresh runtime so that deferred work cannot cross a fixture
+# cleanup boundary and stall the next table lifecycle operation.
+pytestmark = pytest.mark.fresh_antfly_process
 
 
 NUM_SHARDS = 4


### PR DESCRIPTION
## Summary

- run each transaction E2E test on a fresh Antfly runtime
- keep deferred transaction propagation and recovery from crossing fixture cleanup boundaries
- prevent one delayed transaction teardown from cascading into table-creation timeouts across the module

This addresses the transaction-test cascade in the failed PR #545 E2E job: https://github.com/antflydb/antfly/actions/runs/32748319131/job/97516926899?pr=545

## Validation

- transaction module with 2 workers, 2 process slots, and LSM open debugging: 21 passed
- E2E scheduler unit tests: 62 passed
- full base E2E selection with 4 workers, 2 process slots, and LSM open debugging: 276 passed, 10 skipped
- git diff --check