### PR TITLE
fix(release): publish CLI packages on hosted runners

### DIFF
--- a/.github/workflows/antfly-release.yml
+++ b/.github/workflows/antfly-release.yml
@@ -279,7 +279,7 @@ jobs:
   publish-cli-pypi:
     name: Publish antfly-cli to PyPI
     needs: package-cli-artifacts
-    runs-on: arc-antfly-standard
+    runs-on: ubuntu-latest
     environment:
       name: pypi
       url: https://pypi.org/p/antfly-cli
@@ -297,7 +297,7 @@ jobs:
   publish-cli-npm:
     name: Publish @antfly/cli to npm
     needs: package-cli-artifacts
-    runs-on: arc-antfly-standard
+    runs-on: ubuntu-latest
     environment: npm
     permissions:
       id-token: write


### PR DESCRIPTION
## Summary
- publish the PyPI package from a GitHub-hosted runner so the publishing action can use Docker
- publish the npm package from a GitHub-hosted runner so npm provenance is supported
- leave archive and package construction on ARC runners

## Validation
- `actionlint .github/workflows/antfly-release.yml .github/workflows/cli-publish.yml`
- `git diff --check`