### PR TITLE
Match vector recall to concurrent benchmark lanes

### DIFF
--- a/scripts/run_resource_manager_cache_matrix.sh
+++ b/scripts/run_resource_manager_cache_matrix.sh
@@ -30,7 +30,7 @@ if [[ "$SMOKE" == "1" ]]; then
   ENDPOINT_SIZES="${RESOURCE_CACHE_MATRIX_ENDPOINT_SIZES:-256}"
   MEMORY_BUDGETS_MB="${RESOURCE_CACHE_MATRIX_MEMORY_BUDGETS_MB:-512}"
   DIMS="${RESOURCE_CACHE_MATRIX_DIMS:-32}"
-  QUERIES="${RESOURCE_CACHE_MATRIX_QUERIES:-4}"
+  QUERIES="${RESOURCE_CACHE_MATRIX_QUERIES:-8}"
   REPEATS="${RESOURCE_CACHE_MATRIX_REPEATS:-2}"
   K="${RESOURCE_CACHE_MATRIX_K:-10}"
   BATCH_SIZE="${RESOURCE_CACHE_MATRIX_BATCH_SIZE:-128}"
@@ -69,7 +69,14 @@ MAX_RSS_TO_BUDGET_RATIO="${RESOURCE_CACHE_MATRIX_MAX_RSS_TO_BUDGET_RATIO:-1.25}"
 MAX_SEARCH_HEALTH_LATENCY_MS="${RESOURCE_CACHE_MATRIX_MAX_SEARCH_HEALTH_LATENCY_MS:-20}"
 MIN_SOURCE_RECALL_AT_K="${RESOURCE_CACHE_MATRIX_MIN_SOURCE_RECALL_AT_K:-1.0}"
 MIN_SOURCE_TOP1_RECALL="${RESOURCE_CACHE_MATRIX_MIN_SOURCE_TOP1_RECALL:-0.95}"
-EXACT_RECALL_SAMPLES="${RESOURCE_CACHE_MATRIX_EXACT_RECALL_SAMPLES:-1}"
+if [[ "$SMOKE" == "1" ]]; then
+  EXACT_RECALL_SAMPLES="${RESOURCE_CACHE_MATRIX_EXACT_RECALL_SAMPLES:-8}"
+else
+  # One sample per generated-vector cluster is the minimum production
+  # evidence. Additional samples revisit clusters at distinct corpus strata.
+  EXACT_RECALL_SAMPLES="${RESOURCE_CACHE_MATRIX_EXACT_RECALL_SAMPLES:-8}"
+fi
+EXPECTED_EXACT_RECALL_STRATA="${RESOURCE_CACHE_MATRIX_EXPECTED_EXACT_RECALL_STRATA:-8}"
 MIN_EXACT_RECALL_AT_K="${RESOURCE_CACHE_MATRIX_MIN_EXACT_RECALL_AT_K:-0.90}"
 
 mkdir -p "$OUT"
@@ -95,8 +102,8 @@ fi
   printf 'run_endpoints=%s\nrun_maintenance=%s\n' "$RUN_ENDPOINTS" "$RUN_MAINTENANCE"
   printf 'optimize=%s\n' "$OPTIMIZE"
   printf 'resume=%s\n' "$RESUME"
-  printf 'dims=%s\nqueries=%s\nrepeats=%s\nk=%s\nbatch_size=%s\nsearch_threads=%s\nexact_recall_samples=%s\nmin_exact_recall_at_k=%s\n' \
-    "$DIMS" "$QUERIES" "$REPEATS" "$K" "$BATCH_SIZE" "$SEARCH_THREADS" "$EXACT_RECALL_SAMPLES" "$MIN_EXACT_RECALL_AT_K"
+  printf 'dims=%s\nqueries=%s\nrepeats=%s\nk=%s\nbatch_size=%s\nsearch_threads=%s\nexact_recall_samples=%s\nexpected_exact_recall_strata=%s\nmin_exact_recall_at_k=%s\n' \
+    "$DIMS" "$QUERIES" "$REPEATS" "$K" "$BATCH_SIZE" "$SEARCH_THREADS" "$EXACT_RECALL_SAMPLES" "$EXPECTED_EXACT_RECALL_STRATA" "$MIN_EXACT_RECALL_AT_K"
   git -C "$ROOT" rev-parse HEAD
   git -C "$ROOT" status --short
   uname -a
@@ -151,7 +158,12 @@ run_case() {
   if [[ "$shape" == "dense-filter" ]]; then
     cmd+=(--filter-selectivity-percent "$filter_selectivity")
   fi
-  if [[ "$docs" == "1000000" ]] && [[ "$shape" == "dense" || "$shape" == "dense-filter" ]]; then
+  # Tie recall evidence to the cases used to explain the 50K elbow and the
+  # 1M dense/selectivity comparisons without adding full scans to every
+  # intermediate-scale diagnostic.
+  if [[ "$SMOKE" == "1" && ("$shape" == "dense" || "$shape" == "dense-filter") ]] ||
+    [[ "$docs" == "1000000" && ("$shape" == "dense" || "$shape" == "dense-filter") ]] ||
+    [[ "$docs" == "50000" && "$shape" == "dense-filter" && "$filter_selectivity" == "1" ]]; then
     cmd+=(--exact-recall-samples "$EXACT_RECALL_SAMPLES")
   fi
   if [[ "$shape" == "graph-expand" ]]; then
@@ -275,10 +287,6 @@ if [[ "$ENFORCE_GATES" == "1" ]]; then
       dense_1m_top1_recall="$(summary_value "dense-1000000-m${budget_mb}" source_top1_recall)"
       filtered_1m_recall="$(summary_value "dense-filter-p1-1000000-m${budget_mb}" source_recall_at_k)"
       filtered_1m_top1_recall="$(summary_value "dense-filter-p1-1000000-m${budget_mb}" source_top1_recall)"
-      dense_1m_exact_recall="$(summary_value "dense-1000000-m${budget_mb}" exact_recall_at_k)"
-      filtered_1m_exact_recall="$(summary_value "dense-filter-p1-1000000-m${budget_mb}" exact_recall_at_k)"
-      dense_1m_exact_recall_samples="$(summary_value "dense-1000000-m${budget_mb}" exact_recall_samples)"
-      filtered_1m_exact_recall_samples="$(summary_value "dense-filter-p1-1000000-m${budget_mb}" exact_recall_samples)"
       load_rss_bytes="$(summary_budget_max "$budget_mb" load_rss_peak_bytes)"
       search_rss_bytes="$(summary_budget_max "$budget_mb" search_rss_peak_bytes)"
       hbc_accounted_bytes="$(summary_budget_max "$budget_mb" hbc_accounted_bytes)"
@@ -332,15 +340,27 @@ if [[ "$ENFORCE_GATES" == "1" ]]; then
           "$MIN_SOURCE_RECALL_AT_K" "$MIN_SOURCE_TOP1_RECALL" "$budget_mb" >&2
         FAILURES=$((FAILURES + 1))
       fi
-      if ! gate_float_ge "$dense_1m_exact_recall_samples" "$EXACT_RECALL_SAMPLES" ||
-        ! gate_float_ge "$filtered_1m_exact_recall_samples" "$EXACT_RECALL_SAMPLES" ||
-        ! gate_float_ge "$dense_1m_exact_recall" "$MIN_EXACT_RECALL_AT_K" ||
-        ! gate_float_ge "$filtered_1m_exact_recall" "$MIN_EXACT_RECALL_AT_K"; then
-        printf 'gate failed: exact ground-truth recall dense_at_k=%s filtered_at_k=%s dense_samples=%s filtered_samples=%s minimum_at_k=%s required_samples=%s budget_mb=%s\n' \
-          "$dense_1m_exact_recall" "$filtered_1m_exact_recall" "$dense_1m_exact_recall_samples" "$filtered_1m_exact_recall_samples" \
-          "$MIN_EXACT_RECALL_AT_K" "$EXACT_RECALL_SAMPLES" "$budget_mb" >&2
-        FAILURES=$((FAILURES + 1))
-      fi
+      exact_recall_cases=(
+        "dense-filter-p1-50000-m${budget_mb}"
+        "dense-1000000-m${budget_mb}"
+        "dense-filter-p1-1000000-m${budget_mb}"
+        "dense-filter-p10-1000000-m${budget_mb}"
+      )
+      for exact_recall_case in "${exact_recall_cases[@]}"; do
+        exact_recall="$(summary_value "$exact_recall_case" exact_recall_at_k)"
+        exact_recall_samples="$(summary_value "$exact_recall_case" exact_recall_samples)"
+        exact_recall_strata="$(summary_value "$exact_recall_case" exact_recall_strata)"
+        exact_recall_lane="$(summary_value "$exact_recall_case" exact_recall_lane)"
+        if ! gate_float_ge "$exact_recall_samples" "$EXACT_RECALL_SAMPLES" ||
+          ! gate_float_ge "$exact_recall_strata" "$EXPECTED_EXACT_RECALL_STRATA" ||
+          ! gate_float_ge "$exact_recall" "$MIN_EXACT_RECALL_AT_K" ||
+          [[ "$exact_recall_lane" != "concurrent" ]]; then
+          printf 'gate failed: matched-lane exact ground-truth recall case=%s recall_at_k=%s samples=%s strata=%s lane=%s minimum_at_k=%s required_samples=%s required_strata=%s budget_mb=%s\n' \
+            "$exact_recall_case" "$exact_recall" "$exact_recall_samples" "$exact_recall_strata" "$exact_recall_lane" \
+            "$MIN_EXACT_RECALL_AT_K" "$EXACT_RECALL_SAMPLES" "$EXPECTED_EXACT_RECALL_STRATA" "$budget_mb" >&2
+          FAILURES=$((FAILURES + 1))
+        fi
+      done
       if ! gate_float_le "$load_rss_bytes" "$allowed_rss_bytes"; then
         printf 'gate failed: maximum load rss bytes=%s allowed=%s budget_mb=%s ratio=%s\n' \
           "$load_rss_bytes" "$allowed_rss_bytes" "$budget_mb" "$MAX_RSS_TO_BUDGET_RATIO" >&2

--- a/scripts/run_resource_manager_cache_matrix.sh
+++ b/scripts/run_resource_manager_cache_matrix.sh
@@ -126,6 +126,7 @@ run_case() {
   local budget_mb="$4"
   local filter_selectivity="${5:-10}"
   local case_repeats="${6:-$REPEATS}"
+  local run_exact_recall="${7:-0}"
   if [[ "$RESUME" == "1" ]] && awk -F '\t' -v case_name="$name" '$1 == case_name { found = 1 } END { exit(found ? 0 : 1) }' "$STATUS_FILE"; then
     printf 'skipping-recorded\t%s\n' "$name"
     return 0
@@ -158,12 +159,10 @@ run_case() {
   if [[ "$shape" == "dense-filter" ]]; then
     cmd+=(--filter-selectivity-percent "$filter_selectivity")
   fi
-  # Tie recall evidence to the cases used to explain the 50K elbow and the
-  # 1M dense/selectivity comparisons without adding full scans to every
-  # intermediate-scale diagnostic.
-  if [[ "$SMOKE" == "1" && ("$shape" == "dense" || "$shape" == "dense-filter") ]] ||
-    [[ "$docs" == "1000000" && ("$shape" == "dense" || "$shape" == "dense-filter") ]] ||
-    [[ "$docs" == "50000" && "$shape" == "dense-filter" && "$filter_selectivity" == "1" ]]; then
+  # Exact truth is deliberately opt-in per invocation. Inferring it from the
+  # shape/size also catches maintenance and ad-hoc diagnostic cases, adding
+  # billions of comparisons that neither contribute to nor gate evidence.
+  if [[ "$run_exact_recall" == "1" ]]; then
     cmd+=(--exact-recall-samples "$EXACT_RECALL_SAMPLES")
   fi
   if [[ "$shape" == "graph-expand" ]]; then
@@ -198,9 +197,19 @@ fi
 FAILURES="$(awk -F '\t' '$2 != 0 { count += 1 } END { print count + 0 }' "$STATUS_FILE")"
 for budget_mb in $MEMORY_BUDGETS_MB; do
   for docs in $SCALE_SIZES; do
-    run_case "dense-${docs}-m${budget_mb}" dense "$docs" "$budget_mb" || FAILURES=$((FAILURES + 1))
+    dense_exact_recall=0
+    if [[ "$SMOKE" == "1" || "$docs" == "1000000" ]]; then
+      dense_exact_recall=1
+    fi
+    run_case "dense-${docs}-m${budget_mb}" dense "$docs" "$budget_mb" 10 "$REPEATS" "$dense_exact_recall" || FAILURES=$((FAILURES + 1))
     for filter_selectivity in $FILTER_SELECTIVITIES; do
-      run_case "dense-filter-p${filter_selectivity}-${docs}-m${budget_mb}" dense-filter "$docs" "$budget_mb" "$filter_selectivity" || FAILURES=$((FAILURES + 1))
+      filtered_exact_recall=0
+      if [[ "$SMOKE" == "1" ]] ||
+        [[ "$docs" == "1000000" && ("$filter_selectivity" == "1" || "$filter_selectivity" == "10") ]] ||
+        [[ "$docs" == "50000" && "$filter_selectivity" == "1" ]]; then
+        filtered_exact_recall=1
+      fi
+      run_case "dense-filter-p${filter_selectivity}-${docs}-m${budget_mb}" dense-filter "$docs" "$budget_mb" "$filter_selectivity" "$REPEATS" "$filtered_exact_recall" || FAILURES=$((FAILURES + 1))
     done
   done
   if [[ "$RUN_ENDPOINTS" == "1" ]]; then

--- a/zig/MANAGERS.md
+++ b/zig/MANAGERS.md
@@ -850,7 +850,9 @@ adaptive route. Production runs sample every one of the eight generated-vector
 clusters before revisiting a cluster and record `exact_recall_lane`, sample
 count, and covered strata in each JSON summary. The sample count, required
 strata, and minimum recall remain environment-overridable for longer
-qualification runs.
+qualification runs. Exact truth is enabled explicitly only for those four
+qualification cases (and reduced smoke cases); maintenance soaks and ad-hoc
+scale diagnostics never inherit the full scans from a matching shape or size.
 Run the reduced
 endpoint/integration check before the evidence-producing matrix:
 

--- a/zig/MANAGERS.md
+++ b/zig/MANAGERS.md
@@ -819,6 +819,8 @@ The reproducible production-boundary driver is
 `scripts/run_resource_manager_cache_matrix.sh`. It builds the production
 standalone server and harness in `ReleaseFast` by default, assigns an explicit
 process memory envelope to every child,
+routes process/filesystem operations through `std.Io`, and uses
+`lib/platform` for monotonic time, sleeping, and cooperative thread waits,
 and records commands, environment, per-case logs, status, and JSONL summaries
 under `zig/bench/results/resource-manager-cache-matrix/`. Its default matrix
 covers dense and 1%/10% filtered-dense searches at 50k, 600k, 700k, 800k, and 1M,
@@ -831,18 +833,24 @@ selectivity regresses below 70% of the matched 10% lane, when the maximum
 thread lane fails to exceed one-thread QPS by 25%, when the search health probe
 exceeds 20 ms (invalidating a contaminated-host result), when the exact source
 vector is not returned at k, top-1 source recall falls below 95%, or sampled
-exact ground-truth recall@k falls below 90%, when
+exact ground-truth recall@k falls below 90% in any of the 50k/1%, 1M dense,
+1M/1%, or 1M/10% lanes, when
 the maximum load or search RSS across successful recorded cases exceeds 125%
 of the explicit process envelope, when their maximum HBC-accounted bytes
 exceed that envelope, when the maintenance soak falls below 70% of its
 base lane, or without separately populated cold/warm phases. All thresholds
 remain environment-overridable for an explicitly different resource envelope.
 The release-blocker recall suite, per-lane source-vector canary, and sampled
-exact top-k ground truth run before a result is accepted as evidence. Exact
-ground-truth scans and their validation requests run after every timed QPS,
-latency, cache-residency, and RSS measurement so validation cannot warm or
-otherwise improve the reported performance lane. The sample count and minimum
-recall remain environment-overridable for longer qualification runs.
+exact top-k ground truth run before a result is accepted as evidence. The
+primary concurrent worker retains the selected response hits during the timed
+QPS lane, while exact ground-truth scans run locally afterward. Validation
+therefore observes the routing and cache pressure that produced the reported
+QPS without issuing post-measurement requests that could take a different
+adaptive route. Production runs sample every one of the eight generated-vector
+clusters before revisiting a cluster and record `exact_recall_lane`, sample
+count, and covered strata in each JSON summary. The sample count, required
+strata, and minimum recall remain environment-overridable for longer
+qualification runs.
 Run the reduced
 endpoint/integration check before the evidence-producing matrix:
 

--- a/zig/bench/storage/public_query_guardrail.zig
+++ b/zig/bench/storage/public_query_guardrail.zig
@@ -429,6 +429,7 @@ const QueryBenchStats = struct {
     dense_exact_recall_hits: u64 = 0,
     dense_exact_recall_expected: u64 = 0,
     dense_exact_recall_samples: u64 = 0,
+    dense_exact_recall_strata: u64 = 0,
     response_filter_match_count: u64 = 0,
     response_sort_tuple_count: u64 = 0,
     response_sort_tuple_valid_count: u64 = 0,
@@ -620,6 +621,24 @@ const ConcurrentStats = struct {
     fn avgRequestNs(self: ConcurrentStats) u64 {
         if (self.queries == 0) return 0;
         return self.request_ns / self.queries;
+    }
+};
+
+const ExactRecallCapturedResponse = struct {
+    query_idx: usize,
+    hit_doc_indices: []usize,
+    hit_count: usize = 0,
+};
+
+const ConcurrentStartGate = struct {
+    ready: std.atomic.Value(usize) = std.atomic.Value(usize).init(0),
+    start: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+    aborted: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+
+    fn await(self: *ConcurrentStartGate) bool {
+        _ = self.ready.fetchAdd(1, .acq_rel);
+        while (!self.start.load(.acquire)) platform_time.yieldBriefly();
+        return !self.aborted.load(.acquire);
     }
 };
 
@@ -1055,6 +1074,8 @@ const HttpWorkerContext = struct {
     base_uri: []const u8,
     query_bodies: []const []const u8,
     repeats: usize,
+    start_gate: *ConcurrentStartGate,
+    exact_recall_responses: []ExactRecallCapturedResponse = &.{},
     stats: ConcurrentStats = .{},
     err: ?anyerror = null,
 
@@ -1062,12 +1083,14 @@ const HttpWorkerContext = struct {
         var executor = std_http_executor.StdHttpExecutor.init(self.alloc, .{});
         defer executor.deinit();
         var client = api.ApiHttpClient.init(self.alloc, executor.executor());
+        if (!self.start_gate.await()) return;
         const started = nowNs();
         var local_queries: u64 = 0;
         var local_request_ns: u64 = 0;
         var local_max_request_ns: u64 = 0;
-        for (0..self.repeats) |_| {
-            for (self.query_bodies) |body| {
+        for (0..self.repeats) |repeat_idx| {
+            var exact_recall_cursor: usize = 0;
+            for (self.query_bodies, 0..) |body, query_idx| {
                 const request_started = nowNs();
                 var resp = client.fetchQuery(self.base_uri, table_name, body) catch |err| retry: {
                     if (isRetryableQueryConnectionError(err)) {
@@ -1097,6 +1120,19 @@ const HttpWorkerContext = struct {
                     self.stats.total_ns = elapsedSince(started);
                     return;
                 };
+                if (repeat_idx == 0 and exact_recall_cursor < self.exact_recall_responses.len and
+                    self.exact_recall_responses[exact_recall_cursor].query_idx == query_idx)
+                {
+                    const captured = &self.exact_recall_responses[exact_recall_cursor];
+                    const hits = parsed.value.responses[0].hits.hits orelse &.{};
+                    for (hits) |hit| {
+                        const doc_idx = benchmarkDocIndexFromKey(hit._id) orelse continue;
+                        if (captured.hit_count == captured.hit_doc_indices.len) break;
+                        captured.hit_doc_indices[captured.hit_count] = doc_idx;
+                        captured.hit_count += 1;
+                    }
+                    exact_recall_cursor += 1;
+                }
                 const request_elapsed = elapsedSince(request_started);
                 local_request_ns += request_elapsed;
                 local_max_request_ns = @max(local_max_request_ns, request_elapsed);
@@ -1179,7 +1215,7 @@ pub fn main(init: std.process.Init) !void {
         try runStandaloneBench(alloc, init.io, cwd, cfg, dataset, query_bodies);
     } else {
         switch (cfg.mode) {
-            .handler => try runHandlerBench(alloc, cfg, dataset, queries, query_bodies),
+            .handler => try runHandlerBench(alloc, init.io, cfg, dataset, queries, query_bodies),
             .local => try runLocalBench(alloc, init.io, cfg, dataset, queries, query_bodies),
             .standalone => {
                 const cwd = try std.process.currentPathAlloc(init.io, alloc);
@@ -1192,6 +1228,7 @@ pub fn main(init: std.process.Init) !void {
 
 fn runHandlerBench(
     alloc: std.mem.Allocator,
+    io: std.Io,
     cfg: Config,
     dataset: []const f32,
     queries: []const f32,
@@ -1200,7 +1237,7 @@ fn runHandlerBench(
     _ = queries;
     var path_buf: [256]u8 = undefined;
     const path = tempPath(&path_buf);
-    defer cleanupTempDir(path);
+    defer cleanupTempDir(io, path);
 
     var db = try openAndSeedDb(alloc, path[0..path.len], cfg, dataset);
     defer db.close();
@@ -1380,7 +1417,7 @@ fn runLocalBench(
     _ = queries;
     var path_buf: [256]u8 = undefined;
     const path = tempPath(&path_buf);
-    defer cleanupTempDir(path);
+    defer cleanupTempDir(io, path);
 
     var db = try openAndSeedDb(alloc, path[0..path.len], cfg, dataset);
     defer db.close();
@@ -1466,10 +1503,11 @@ fn runLocalBench(
         try benchConcurrentDirectHandler(alloc, server.executor(), query_bodies, cfg);
     std.debug.print("public-query guardrail stage=http-concurrent\n", .{});
     const concurrent = try benchConcurrentHttpWithPolling(alloc, io, base_uri, query_bodies, health_uri, metrics_uri, null, cfg, null);
+    defer concurrent.deinit(alloc);
 
     try enforceGuardrails(cfg, concurrent.polls);
+    try validateSampledExactDenseRecall(alloc, dataset, concurrent.exact_recall_responses, cfg, &http_stats);
     try maybeRunHttpSearchThreadSweep(alloc, io, base_uri, query_bodies, health_uri, metrics_uri, null, cfg, null);
-    try validateSampledExactDenseRecall(alloc, base_uri, dataset, query_bodies, cfg, &http_stats);
 
     const avg_db_ns = db_stats.avgNs();
     const avg_handler_ns = handler_stats.avgNs();
@@ -1597,6 +1635,12 @@ const ConcurrentRun = struct {
     http: ConcurrentStats,
     polls: PollStats,
     rss_peak_bytes: usize = 0,
+    exact_recall_responses: []ExactRecallCapturedResponse = &.{},
+
+    fn deinit(self: *const ConcurrentRun, alloc: std.mem.Allocator) void {
+        for (self.exact_recall_responses) |captured| alloc.free(captured.hit_doc_indices);
+        alloc.free(self.exact_recall_responses);
+    }
 };
 
 const LoadRun = struct {
@@ -1626,6 +1670,9 @@ fn maybeRunHttpSearchThreadSweep(
         const threads = @min(next_threads, cfg.search_threads);
         var run_cfg = cfg;
         run_cfg.search_threads = threads;
+        // The primary concurrent lane owns matched-recall sampling. A sweep
+        // measures scaling only and must not allocate or overwrite captures.
+        run_cfg.exact_recall_samples = 0;
         const run = try benchConcurrentHttpWithPolling(
             alloc,
             io,
@@ -1637,6 +1684,7 @@ fn maybeRunHttpSearchThreadSweep(
             run_cfg,
             rss_pid,
         );
+        defer run.deinit(alloc);
         try enforceGuardrails(run_cfg, run.polls);
         std.debug.print(
             "public_query_thread_sweep threads={d} qps={d:.2} avg={d:.3}us max={d:.3}us rss_peak_mb={d:.2} health_max_ms={d:.2} metrics_max_ms={d:.2} status_max_ms={d:.2} failures={{health={d},metrics={d},status={d}}}\n",
@@ -2248,6 +2296,11 @@ fn benchConcurrentHttpWithPolling(
     cfg: Config,
     rss_pid: ?std.process.Child.Id,
 ) !ConcurrentRun {
+    const exact_recall_responses = try makeExactRecallCapturedResponses(alloc, cfg);
+    errdefer {
+        for (exact_recall_responses) |captured| alloc.free(captured.hit_doc_indices);
+        alloc.free(exact_recall_responses);
+    }
     var stop = std.atomic.Value(bool).init(false);
     var health_poller = EndpointPollerContext{
         .alloc = alloc,
@@ -2295,15 +2348,32 @@ fn benchConcurrentHttpWithPolling(
     const threads = try alloc.alloc(std.Thread, cfg.search_threads);
     defer alloc.free(threads);
 
+    var start_gate = ConcurrentStartGate{};
+    var spawned_threads: usize = 0;
+    errdefer {
+        // A partial spawn must release and join workers already waiting at
+        // the gate; otherwise an allocation/thread-limit failure leaks them.
+        start_gate.aborted.store(true, .release);
+        start_gate.start.store(true, .release);
+        for (threads[0..spawned_threads]) |thread| thread.join();
+    }
     for (workers, 0..) |*worker, i| {
         worker.* = .{
             .alloc = alloc,
             .base_uri = base_uri,
             .query_bodies = query_bodies,
             .repeats = cfg.repeats,
+            .start_gate = &start_gate,
+            // One worker captures each selected query exactly once while all
+            // workers are active. The response therefore shares the QPS
+            // lane's routing and cache pressure without duplicate ownership.
+            .exact_recall_responses = if (i == 0) exact_recall_responses else &.{},
         };
         threads[i] = try std.Thread.spawn(.{ .stack_size = 512 * 1024 }, HttpWorkerContext.run, .{worker});
+        spawned_threads += 1;
     }
+    while (start_gate.ready.load(.acquire) != cfg.search_threads) platform_time.yieldBriefly();
+    start_gate.start.store(true, .release);
 
     var combined: ConcurrentStats = .{};
     for (threads, workers) |thread, *worker| {
@@ -2335,6 +2405,7 @@ fn benchConcurrentHttpWithPolling(
         .http = combined,
         .polls = polls,
         .rss_peak_bytes = if (rss_poller) |ctx| ctx.peak_rss_bytes else 0,
+        .exact_recall_responses = exact_recall_responses,
     };
 }
 
@@ -2994,6 +3065,73 @@ fn exactDenseRecallCandidateEligible(cfg: Config, source_doc_idx: usize, candida
     return true;
 }
 
+fn exactRecallQueryCluster(query_idx: usize, cfg: Config) usize {
+    return querySourceDocIndex(query_idx, cfg) % 8;
+}
+
+fn makeExactRecallCapturedResponses(alloc: std.mem.Allocator, cfg: Config) ![]ExactRecallCapturedResponse {
+    if (!supportsExactDenseRecall(cfg) or cfg.exact_recall_samples == 0) {
+        return try alloc.alloc(ExactRecallCapturedResponse, 0);
+    }
+
+    const sample_count = @min(cfg.exact_recall_samples, cfg.queries);
+    const query_indices = try alloc.alloc(usize, sample_count);
+    defer alloc.free(query_indices);
+    const selected = try alloc.alloc(bool, cfg.queries);
+    defer alloc.free(selected);
+    @memset(selected, false);
+
+    // Visit every synthetic cluster before taking a second sample from any
+    // cluster. Within each pass, choose the unused query nearest that pass's
+    // midpoint so repeated samples remain spread across the complete corpus.
+    const pass_count = (sample_count + 7) / 8;
+    for (0..sample_count) |sample_idx| {
+        const target_cluster = sample_idx % 8;
+        const pass = sample_idx / 8;
+        const target_query_idx = @min(
+            cfg.queries - 1,
+            ((pass * 2 + 1) * cfg.queries) / (pass_count * 2),
+        );
+        var best_query_idx: ?usize = null;
+        var best_distance: usize = std.math.maxInt(usize);
+        for (0..cfg.queries) |query_idx| {
+            if (selected[query_idx] or exactRecallQueryCluster(query_idx, cfg) != target_cluster) continue;
+            const distance = if (query_idx > target_query_idx) query_idx - target_query_idx else target_query_idx - query_idx;
+            if (distance >= best_distance) continue;
+            best_query_idx = query_idx;
+            best_distance = distance;
+        }
+        // Tiny smoke configurations may not contain every cluster. Preserve
+        // the requested sample count by filling from the nearest unused query.
+        if (best_query_idx == null) {
+            for (0..cfg.queries) |query_idx| {
+                if (selected[query_idx]) continue;
+                const distance = if (query_idx > target_query_idx) query_idx - target_query_idx else target_query_idx - query_idx;
+                if (distance >= best_distance) continue;
+                best_query_idx = query_idx;
+                best_distance = distance;
+            }
+        }
+        const query_idx = best_query_idx orelse return error.InvalidRecallSampleSelection;
+        selected[query_idx] = true;
+        query_indices[sample_idx] = query_idx;
+    }
+    std.mem.sort(usize, query_indices, {}, std.sort.asc(usize));
+
+    const responses = try alloc.alloc(ExactRecallCapturedResponse, sample_count);
+    errdefer alloc.free(responses);
+    var initialized: usize = 0;
+    errdefer for (responses[0..initialized]) |captured| alloc.free(captured.hit_doc_indices);
+    for (responses, query_indices) |*captured, query_idx| {
+        captured.* = .{
+            .query_idx = query_idx,
+            .hit_doc_indices = try alloc.alloc(usize, cfg.k),
+        };
+        initialized += 1;
+    }
+    return responses;
+}
+
 fn calculateExactDenseRecallTruth(
     alloc: std.mem.Allocator,
     dataset: []const f32,
@@ -3036,53 +3174,42 @@ fn calculateExactDenseRecallTruth(
 
 fn validateSampledExactDenseRecall(
     alloc: std.mem.Allocator,
-    base_uri: []const u8,
     dataset: []const f32,
-    query_bodies: []const []const u8,
+    captured_responses: []const ExactRecallCapturedResponse,
     cfg: Config,
     stats: *QueryBenchStats,
 ) !void {
     if (!supportsExactDenseRecall(cfg) or cfg.exact_recall_samples == 0) return;
-    const sample_count = @min(cfg.exact_recall_samples, cfg.queries);
-    var executor = std_http_executor.StdHttpExecutor.init(alloc, .{});
-    defer executor.deinit();
-    var client = api.ApiHttpClient.init(alloc, executor.executor());
+    const expected_samples = @min(cfg.exact_recall_samples, cfg.queries);
+    if (captured_responses.len != expected_samples) return error.InvalidRecallSampleCount;
+    var cluster_mask: u8 = 0;
 
-    for (0..sample_count) |sample_idx| {
-        // Use the midpoint of deterministic query strata instead of sampling
-        // only query zero. This remains reproducible across memory envelopes.
-        const query_idx = @min(
-            cfg.queries - 1,
-            ((sample_idx * 2 + 1) * cfg.queries) / (sample_count * 2),
-        );
+    for (captured_responses) |captured| {
+        const query_idx = captured.query_idx;
         const truth = try calculateExactDenseRecallTruth(alloc, dataset, query_idx, cfg);
         defer alloc.free(truth);
         if (truth.len == 0) return error.InvalidRecallGroundTruth;
-
-        var resp = try client.fetchQuery(base_uri, table_name, query_bodies[query_idx]);
-        defer resp.deinit(alloc);
-        var parsed = try std.json.parseFromSlice(QueryResponseWire, alloc, resp.body, .{ .ignore_unknown_fields = true });
-        defer parsed.deinit();
-        if (parsed.value.responses.len == 0) return error.InvalidQueryResponse;
-        const hits = parsed.value.responses[0].hits.hits orelse return error.InvalidQueryResponse;
+        if (captured.hit_count == 0) return error.InvalidQueryResponse;
 
         var matched: u64 = 0;
         for (truth) |truth_doc_idx| {
-            for (hits) |hit| {
-                const returned_doc_idx = benchmarkDocIndexFromKey(hit._id) orelse continue;
+            for (captured.hit_doc_indices[0..captured.hit_count]) |returned_doc_idx| {
                 if (returned_doc_idx != truth_doc_idx) continue;
                 matched += 1;
                 break;
             }
         }
+        cluster_mask |= @as(u8, 1) << @intCast(exactRecallQueryCluster(query_idx, cfg));
         stats.dense_exact_recall_hits += matched;
         stats.dense_exact_recall_expected += @intCast(truth.len);
         stats.dense_exact_recall_samples += 1;
     }
+    stats.dense_exact_recall_strata = @popCount(cluster_mask);
     std.debug.print(
-        "public_query_exact_recall samples={d} hits={d} expected={d} recall_at_k={d:.6}\n",
+        "public_query_exact_recall lane=concurrent samples={d} strata={d} hits={d} expected={d} recall_at_k={d:.6}\n",
         .{
             stats.dense_exact_recall_samples,
+            stats.dense_exact_recall_strata,
             stats.dense_exact_recall_hits,
             stats.dense_exact_recall_expected,
             rate(stats.dense_exact_recall_hits, stats.dense_exact_recall_expected),
@@ -3117,7 +3244,7 @@ fn runStandaloneBench(
     var completed = false;
     defer {
         if (completed) {
-            cleanupTempDir(root_path);
+            cleanupTempDir(io, root_path);
         } else {
             std.debug.print("public-query guardrail preserved failed standalone root={s}\n", .{root_path});
         }
@@ -3169,15 +3296,16 @@ fn runStandaloneBench(
     try enforceSymbolicResultFillGuardrail(cfg, http_stats);
     std.debug.print("public-query guardrail stage=http-concurrent\n", .{});
     const concurrent = try benchConcurrentHttpWithPolling(alloc, io, base_uri, query_bodies, health_uri, metrics_uri, index_status_uri, cfg, child.id);
+    defer concurrent.deinit(alloc);
+    try validateSampledExactDenseRecall(alloc, dataset, concurrent.exact_recall_responses, cfg, &http_stats);
     try maybeRunHttpSearchThreadSweep(alloc, io, base_uri, query_bodies, health_uri, metrics_uri, index_status_uri, cfg, child.id);
 
     const search_memory = fetchMemoryBreakdown(alloc, base_uri, metrics_uri) catch |err| blk: {
         std.debug.print("public-query guardrail memory_breakdown_err phase=post_search err={s}\n", .{@errorName(err)});
         break :blk MemoryBreakdown{};
     };
-    // Keep exact ground-truth work and validation requests outside every
-    // latency, QPS, cache-residency, and process-RSS measurement above.
-    try validateSampledExactDenseRecall(alloc, base_uri, dataset, query_bodies, cfg, &http_stats);
+    // Exact ground-truth work stays outside the timed lane; the compared hits
+    // were captured from that lane rather than issued as new requests.
 
     const avg_http_ns = http_stats.avgNs();
     const avg_profile_ns = http_stats.avgProfileNs();
@@ -4558,7 +4686,7 @@ fn printPublicQueryGuardrailSummaryJson(
         },
     );
     std.debug.print(
-        ",\"load_health_max_ms\":{d:.3},\"load_metrics_max_ms\":{d:.3},\"load_status_max_ms\":{d:.3},\"search_health_max_ms\":{d:.3},\"search_metrics_max_ms\":{d:.3},\"search_status_max_ms\":{d:.3},\"source_recall_at_k\":{d:.6},\"source_top1_recall\":{d:.6},\"exact_recall_at_k\":{d:.6},\"exact_recall_samples\":{d},\"exact_artifact_cache_hits_avg\":{d:.3},\"exact_artifact_vectors_loaded_avg\":{d:.3},\"rerank_metadata_vectors_loaded_avg\":{d:.3},\"rerank_artifact_cache_hits_avg\":{d:.3},\"rerank_artifact_vectors_loaded_avg\":{d:.3}",
+        ",\"load_health_max_ms\":{d:.3},\"load_metrics_max_ms\":{d:.3},\"load_status_max_ms\":{d:.3},\"search_health_max_ms\":{d:.3},\"search_metrics_max_ms\":{d:.3},\"search_status_max_ms\":{d:.3},\"source_recall_at_k\":{d:.6},\"source_top1_recall\":{d:.6},\"exact_recall_at_k\":{d:.6},\"exact_recall_samples\":{d},\"exact_recall_strata\":{d},\"exact_recall_lane\":\"{s}\",\"exact_artifact_cache_hits_avg\":{d:.3},\"exact_artifact_vectors_loaded_avg\":{d:.3},\"rerank_metadata_vectors_loaded_avg\":{d:.3},\"rerank_artifact_cache_hits_avg\":{d:.3},\"rerank_artifact_vectors_loaded_avg\":{d:.3}",
         .{
             nsToMs(load.polls.health_max_latency_ns),
             nsToMs(load.polls.metrics_max_latency_ns),
@@ -4570,6 +4698,8 @@ fn printPublicQueryGuardrailSummaryJson(
             rate(http_stats.dense_source_top1_count, http_stats.dense_recall_queries),
             rate(http_stats.dense_exact_recall_hits, http_stats.dense_exact_recall_expected),
             http_stats.dense_exact_recall_samples,
+            http_stats.dense_exact_recall_strata,
+            if (http_stats.dense_exact_recall_samples > 0) "concurrent" else "disabled",
             avgPerQuery(profile_stats, profile_stats.profile_exact_artifact_cache_hits),
             avgPerQuery(profile_stats, profile_stats.profile_exact_artifact_vectors_loaded),
             avgPerQuery(profile_stats, profile_stats.profile_rerank_metadata_vectors_loaded),
@@ -4883,10 +5013,8 @@ fn sampleRssBytes(alloc: std.mem.Allocator, io: std.Io, pid: std.process.Child.I
     return rss_kib * 1024;
 }
 
-fn cleanupTempDir(path: [:0]u8) void {
-    var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
-    defer io_impl.deinit();
-    std.Io.Dir.cwd().deleteTree(io_impl.io(), path[0..path.len]) catch {};
+fn cleanupTempDir(io: std.Io, path: [:0]u8) void {
+    std.Io.Dir.cwd().deleteTree(io, path[0..path.len]) catch {};
 }
 
 fn nowNs() u64 {
@@ -4898,15 +5026,7 @@ fn elapsedSince(started: u64) u64 {
 }
 
 fn sleepMs(ms: u64) void {
-    var req = std.posix.timespec{
-        .sec = @intCast(ms / std.time.ms_per_s),
-        .nsec = @intCast((ms % std.time.ms_per_s) * std.time.ns_per_ms),
-    };
-    while (true) switch (std.posix.errno(std.posix.system.nanosleep(&req, &req))) {
-        .SUCCESS => return,
-        .INTR => continue,
-        else => return,
-    };
+    platform_time.sleepNs(ms *| std.time.ns_per_ms);
 }
 
 fn nsToUs(ns: u64) f64 {

--- a/zig/bench/storage/public_query_guardrail.zig
+++ b/zig/bench/storage/public_query_guardrail.zig
@@ -2323,9 +2323,24 @@ fn benchConcurrentHttpWithPolling(
         .poll_interval_ms = cfg.poll_interval_ms,
         .stop = &stop,
     } else null;
-    const health_thread = try std.Thread.spawn(.{ .stack_size = 512 * 1024 }, EndpointPollerContext.run, .{&health_poller});
-    const metrics_thread = try std.Thread.spawn(.{ .stack_size = 512 * 1024 }, EndpointPollerContext.run, .{&metrics_poller});
-    const status_thread: ?std.Thread = blk: {
+    var health_thread: ?std.Thread = null;
+    var metrics_thread: ?std.Thread = null;
+    var status_thread: ?std.Thread = null;
+    var rss_thread: ?std.Thread = null;
+    defer {
+        // Pollers borrow stack-owned contexts, so every exit path must stop
+        // and join each successfully spawned thread before those contexts go
+        // out of scope. joinOptionalThread clears consumed handles and keeps
+        // this cleanup safe after the normal-path joins below.
+        stop.store(true, .release);
+        joinOptionalThread(&health_thread);
+        joinOptionalThread(&metrics_thread);
+        joinOptionalThread(&status_thread);
+        joinOptionalThread(&rss_thread);
+    }
+    health_thread = try std.Thread.spawn(.{ .stack_size = 512 * 1024 }, EndpointPollerContext.run, .{&health_poller});
+    metrics_thread = try std.Thread.spawn(.{ .stack_size = 512 * 1024 }, EndpointPollerContext.run, .{&metrics_poller});
+    status_thread = blk: {
         if (status_poller) |*poller| {
             break :blk try std.Thread.spawn(.{ .stack_size = 512 * 1024 }, EndpointPollerContext.run, .{poller});
         }
@@ -2338,7 +2353,7 @@ fn benchConcurrentHttpWithPolling(
         .poll_interval_ms = cfg.poll_interval_ms,
         .stop = &stop,
     } else null;
-    const rss_thread: ?std.Thread = if (rss_poller != null)
+    rss_thread = if (rss_poller != null)
         try std.Thread.spawn(.{ .stack_size = 512 * 1024 }, RssPollerContext.run, .{&rss_poller.?})
     else
         null;
@@ -2350,12 +2365,13 @@ fn benchConcurrentHttpWithPolling(
 
     var start_gate = ConcurrentStartGate{};
     var spawned_threads: usize = 0;
+    var joined_threads: usize = 0;
     errdefer {
-        // A partial spawn must release and join workers already waiting at
-        // the gate; otherwise an allocation/thread-limit failure leaks them.
+        // Release workers waiting after a partial spawn and join only handles
+        // that have not already been consumed by the normal join loop.
         start_gate.aborted.store(true, .release);
         start_gate.start.store(true, .release);
-        for (threads[0..spawned_threads]) |thread| thread.join();
+        for (threads[joined_threads..spawned_threads]) |thread| thread.join();
     }
     for (workers, 0..) |*worker, i| {
         worker.* = .{
@@ -2376,21 +2392,27 @@ fn benchConcurrentHttpWithPolling(
     start_gate.start.store(true, .release);
 
     var combined: ConcurrentStats = .{};
+    var worker_err: ?anyerror = null;
     for (threads, workers) |thread, *worker| {
         thread.join();
-        if (worker.err) |err| return err;
+        joined_threads += 1;
+        if (worker.err) |err| {
+            if (worker_err == null) worker_err = err;
+            continue;
+        }
         combined.total_ns = @max(combined.total_ns, worker.stats.total_ns);
         combined.request_ns += worker.stats.request_ns;
         combined.max_request_ns = @max(combined.max_request_ns, worker.stats.max_request_ns);
         combined.queries += worker.stats.queries;
         combined.failures += worker.stats.failures;
     }
+    if (worker_err) |err| return err;
 
     stop.store(true, .release);
-    health_thread.join();
-    metrics_thread.join();
-    if (status_thread) |thread| thread.join();
-    if (rss_thread) |thread| thread.join();
+    joinOptionalThread(&health_thread);
+    joinOptionalThread(&metrics_thread);
+    joinOptionalThread(&status_thread);
+    joinOptionalThread(&rss_thread);
     if (health_poller.err) |err| return err;
     if (metrics_poller.err) |err| return err;
     if (status_poller) |ctx| if (ctx.err) |err| return err;
@@ -2407,6 +2429,12 @@ fn benchConcurrentHttpWithPolling(
         .rss_peak_bytes = if (rss_poller) |ctx| ctx.peak_rss_bytes else 0,
         .exact_recall_responses = exact_recall_responses,
     };
+}
+
+fn joinOptionalThread(thread: *?std.Thread) void {
+    const spawned = thread.* orelse return;
+    thread.* = null;
+    spawned.join();
 }
 
 fn accumulateParsedResponse(stats: *QueryBenchStats, parsed: QueryResponseWire, elapsed_ns: u64, raw_body: []const u8, cfg: Config, query_idx: usize) !void {

--- a/zig/pkg/antfly/src/storage/db/catalog/index_manager.zig
+++ b/zig/pkg/antfly/src/storage/db/catalog/index_manager.zig
@@ -25367,6 +25367,7 @@ test "dense index manager accepts external embedding indexes without enrichments
 test "production external scorers use bounded cache-first artifact batches" {
     const alloc = std.testing.allocator;
     const dims: usize = 3;
+    const external_rerank_batch_size: usize = 128;
     const candidate_count = exact_dense_score_batch_size + 17;
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -25406,12 +25407,11 @@ test "production external scorers use bounded cache-first artifact batches" {
     defer alloc.free(vectors);
     const candidate_ids = try alloc.alloc(u64, candidate_count);
     defer alloc.free(candidate_ids);
+    const candidate_id_order = try alloc.alloc(usize, candidate_count);
+    defer alloc.free(candidate_id_order);
     for (writes, 0..) |*write, i| {
         doc_keys[i] = try std.fmt.allocPrint(alloc, "doc:{d:0>6}", .{i});
         const vector = vectors[i * dims ..][0..dims];
-        vector[0] = @floatFromInt(i);
-        vector[1] = @floatFromInt(i % 17);
-        vector[2] = @floatFromInt(i % 31);
         write.* = .{
             .index_name = @constCast("semantic_idx"),
             .doc_key = doc_keys[i],
@@ -25419,7 +25419,28 @@ test "production external scorers use bounded cache-first artifact batches" {
             .artifact_key = null,
         };
         candidate_ids[i] = deterministicDenseVectorId(doc_keys[i]);
+        candidate_id_order[i] = i;
     }
+    std.mem.sort(usize, candidate_id_order, candidate_ids, struct {
+        fn lessThan(ids: []const u64, lhs: usize, rhs: usize) bool {
+            return ids[lhs] < ids[rhs];
+        }
+    }.lessThan);
+    // External batches are sorted by vector id for storage locality. Make the
+    // first complete batch a compact ordered range followed by a continuous
+    // tail. Queries from opposite ends then deterministically cover both
+    // halves of the stop invariant: a safe positive stop and a required
+    // continuation, without relying on hash ordering accidentally correlating
+    // with distance.
+    for (candidate_id_order, 0..) |candidate_idx, rank| {
+        const vector = vectors[candidate_idx * dims ..][0..dims];
+        const base: f32 = @floatFromInt(rank + if (rank < external_rerank_batch_size) @as(usize, 0) else 128);
+        vector[0] = base;
+        vector[1] = @floatFromInt(rank % 17);
+        vector[2] = @floatFromInt(rank % 31);
+    }
+    const far_query_idx = candidate_id_order[candidate_count - 1];
+    const missing_candidate_idx = candidate_id_order[external_rerank_batch_size];
     try manager.applyDenseEmbeddingWritesByNameWithOptions(&store, "semantic_idx", writes, .{ .mode = .bulk_ingest });
 
     const entry = manager.denseIndex("semantic_idx") orelse return error.IndexNotFound;
@@ -25477,7 +25498,7 @@ test "production external scorers use bounded cache-first artifact batches" {
 
     // Missing/corrupt external artifacts are candidate-local failures. They
     // must not fail the whole request (the old scalar fallback did).
-    const missing_artifact_key = try internal_keys.embeddingArtifactKeyForDocumentAlloc(alloc, doc_keys[2], "semantic_idx");
+    const missing_artifact_key = try internal_keys.embeddingArtifactKeyForDocumentAlloc(alloc, doc_keys[missing_candidate_idx], "semantic_idx");
     defer alloc.free(missing_artifact_key);
     try store.delete(missing_artifact_key);
 
@@ -25494,7 +25515,7 @@ test "production external scorers use bounded cache-first artifact batches" {
     defer hbc_mod.setTestGetVectorViewOrScratchHook(null, null);
 
     var outcome = try manager.exactScoreDenseEntryWithRequest(entry, .{
-        .query = vectors[(candidate_count - 1) * dims ..][0..dims],
+        .query = vectors[far_query_idx * dims ..][0..dims],
         .k = 10,
         .filter_ids = candidate_ids,
     });
@@ -25514,7 +25535,7 @@ test "production external scorers use bounded cache-first artifact batches" {
     try std.testing.expect(outcome.profile.workspace_bytes > 0);
     try std.testing.expect(outcome.profile.artifact_read_ns > 0);
     try std.testing.expectEqual(@as(usize, 10), outcome.results.getHits().len);
-    try std.testing.expectEqual(candidate_ids[candidate_count - 1], outcome.results.getHits()[0].vector_id);
+    try std.testing.expectEqual(candidate_ids[far_query_idx], outcome.results.getHits()[0].vector_id);
 
     // Drive the complete production HBC search path with the default boundary
     // policy. An ambiguous distance threshold selects the full >128 candidate
@@ -25523,8 +25544,9 @@ test "production external scorers use bounded cache-first artifact batches" {
     // frontier, so skipping it would be a recall bug.
     for (candidate_ids) |vector_id| entry.index.invalidateVectorCache(vector_id);
     entry.index.abortVectorCacheMutations();
+    const no_stop_query = [_]f32{ 20_000, 0, 0 };
     var boundary_probe = try entry.index.searchProfiledRequest(.{
-        .query = vectors[(candidate_count - 1) * dims ..][0..dims],
+        .query = &no_stop_query,
         .k = 128,
         .search_width = @intCast(candidate_count),
         .load_metadata = false,
@@ -25534,15 +25556,17 @@ test "production external scorers use bounded cache-first artifact batches" {
     try std.testing.expect(boundary_probe.profile.approx_top_count > 0);
     const approximate_top = boundary_probe.profile.approx_top[0];
     try std.testing.expect(approximate_top.error_bound > 0);
-    const ambiguous_distance_over = approximate_top.distance - approximate_top.error_bound / 2;
+    // Equality with the approximate lower bound is ambiguous, while a query
+    // outside the indexed corpus keeps every true top-k distance eligible.
+    const ambiguous_distance_over = approximate_top.lower_bound;
     for (candidate_ids) |vector_id| entry.index.invalidateVectorCache(vector_id);
     entry.index.abortVectorCacheMutations();
 
     var full_profiled = try entry.index.searchProfiledRequest(.{
-        .query = vectors[(candidate_count - 1) * dims ..][0..dims],
+        .query = &no_stop_query,
         .k = 128,
         .search_width = @intCast(candidate_count),
-        // Equality with a retained approximate distance is ambiguous under
+        // Equality with the retained approximate lower bound is ambiguous under
         // the default boundary policy and therefore selects the complete
         // candidate shell before progressive exact batches evaluate the stop.
         .distance_over = ambiguous_distance_over,
@@ -25576,16 +25600,14 @@ test "production external scorers use bounded cache-first artifact batches" {
             return lhs.vector_id < rhs.vector_id;
         }
     };
-    // Size for the complete shell: the fixture currently excludes the
-    // deleted artifact and the query vector by threshold, but correctness of
-    // this oracle must not depend on that threshold calibration.
+    // Size for the complete shell so correctness of this oracle never depends
+    // on how many candidates the calibrated threshold admits.
     const expected_storage = try alloc.alloc(ExpectedHit, candidate_count);
     defer alloc.free(expected_storage);
     var expected_count: usize = 0;
-    const query = vectors[(candidate_count - 1) * dims ..][0..dims];
     for (candidate_ids, 0..) |vector_id, i| {
-        if (i == 2) continue; // Candidate-local artifact deleted above.
-        const distance = vector_mod.distance(query, vectors[i * dims ..][0..dims], .l2_squared);
+        if (i == missing_candidate_idx) continue; // Candidate-local artifact deleted above.
+        const distance = vector_mod.distance(&no_stop_query, vectors[i * dims ..][0..dims], .l2_squared);
         if (distance <= ambiguous_distance_over) continue; // distance_over is strict.
         expected_storage[expected_count] = .{ .vector_id = vector_id, .distance = distance };
         expected_count += 1;
@@ -25593,9 +25615,80 @@ test "production external scorers use bounded cache-first artifact batches" {
     std.mem.sort(ExpectedHit, expected_storage[0..expected_count], {}, ExpectedHit.lessThan);
     const hits = full_profiled.results.getHits();
     try std.testing.expectEqual(@as(usize, 128), hits.len);
-    for (hits, expected_storage[0..hits.len]) |hit, expected| {
+    for (hits, expected_storage[0..hits.len], 0..) |hit, expected, rank| {
+        if (expected.vector_id != hit.vector_id) std.debug.print(
+            "external boundary no-stop mismatch rank={d} expected_id={d} actual_id={d}\n",
+            .{ rank, expected.vector_id, hit.vector_id },
+        );
         try std.testing.expectEqual(expected.vector_id, hit.vector_id);
-        try std.testing.expectApproxEqAbs(expected.distance, hit.distance, 0.0001);
+        try std.testing.expectApproxEqRel(expected.distance, hit.distance, 0.000001);
+    }
+
+    // A separated vector-id-ordered shell must exercise the positive half of
+    // the production stop proof: after one bounded external batch establishes
+    // 128 exact upper bounds, candidates whose approximate lower bounds are
+    // strictly worse can be skipped. Keep the
+    // threshold ambiguity so this still enters through the default boundary
+    // policy rather than forcing rerank_policy=always.
+    for (candidate_ids) |vector_id| entry.index.invalidateVectorCache(vector_id);
+    entry.index.abortVectorCacheMutations();
+    const early_stop_query = [_]f32{ -10_000, 0, 0 };
+    var early_stop_probe = try entry.index.searchProfiledRequest(.{
+        .query = &early_stop_query,
+        .k = 128,
+        .search_width = @intCast(candidate_count),
+        .load_metadata = false,
+        .filter_ids = candidate_ids,
+    });
+    defer early_stop_probe.results.deinit();
+    try std.testing.expect(early_stop_probe.profile.approx_top_count > 0);
+    const early_stop_top = early_stop_probe.profile.approx_top[0];
+    try std.testing.expect(early_stop_top.error_bound > 0);
+    const early_stop_distance_over = early_stop_top.lower_bound;
+    for (candidate_ids) |vector_id| entry.index.invalidateVectorCache(vector_id);
+    entry.index.abortVectorCacheMutations();
+
+    var early_stopped = try entry.index.searchProfiledRequest(.{
+        .query = &early_stop_query,
+        .k = 128,
+        .search_width = @intCast(candidate_count),
+        .distance_over = early_stop_distance_over,
+        .load_metadata = false,
+        .filter_ids = candidate_ids,
+    });
+    defer early_stopped.results.deinit();
+    try std.testing.expect(early_stopped.profile.approx_candidate_count > 128);
+    try std.testing.expect(early_stopped.profile.rerank_candidate_count > 128);
+    try std.testing.expect(early_stopped.profile.full_rerank_due_to_threshold);
+    try std.testing.expect(early_stopped.profile.ambiguous_distance_over_hits > 0);
+    try std.testing.expect(early_stopped.profile.rerank_candidates_skipped_by_bound > 0);
+    try std.testing.expect(early_stopped.profile.rerank_batches > 0);
+    try std.testing.expect(early_stopped.profile.rerank_batches <
+        std.math.divCeil(u64, early_stopped.profile.rerank_candidate_count, 128) catch unreachable);
+    try std.testing.expectEqual(@as(u64, 128), early_stopped.profile.rerank_max_batch_size);
+    try std.testing.expectEqual(
+        early_stopped.profile.rerank_artifact_vectors_loaded,
+        early_stopped.profile.rerank_metadata_vectors_loaded,
+    );
+
+    expected_count = 0;
+    for (candidate_ids, 0..) |vector_id, i| {
+        if (i == missing_candidate_idx) continue;
+        const distance = vector_mod.distance(&early_stop_query, vectors[i * dims ..][0..dims], .l2_squared);
+        if (distance <= early_stop_distance_over) continue;
+        expected_storage[expected_count] = .{ .vector_id = vector_id, .distance = distance };
+        expected_count += 1;
+    }
+    std.mem.sort(ExpectedHit, expected_storage[0..expected_count], {}, ExpectedHit.lessThan);
+    const early_hits = early_stopped.results.getHits();
+    try std.testing.expectEqual(@as(usize, 128), early_hits.len);
+    for (early_hits, expected_storage[0..early_hits.len], 0..) |hit, expected, rank| {
+        if (expected.vector_id != hit.vector_id) std.debug.print(
+            "external boundary early-stop mismatch rank={d} expected_id={d} actual_id={d}\n",
+            .{ rank, expected.vector_id, hit.vector_id },
+        );
+        try std.testing.expectEqual(expected.vector_id, hit.vector_id);
+        try std.testing.expectApproxEqRel(expected.distance, hit.distance, 0.000001);
     }
 }
 

--- a/zig/pkg/antfly/src/storage/db/catalog/index_manager.zig
+++ b/zig/pkg/antfly/src/storage/db/catalog/index_manager.zig
@@ -25392,7 +25392,7 @@ test "production external scorers use bounded cache-first artifact batches" {
     try manager.addAllNoBackfill(&store, &.{.{
         .name = "semantic_idx",
         .kind = .dense_vector,
-        .config_json = "{\"field\":\"embedding\",\"dims\":3,\"metric\":\"l2_squared\",\"embedding_name\":\"semantic_idx\",\"external\":true,\"rerank_policy\":\"always\"}",
+        .config_json = "{\"field\":\"embedding\",\"dims\":3,\"metric\":\"l2_squared\",\"embedding_name\":\"semantic_idx\",\"external\":true}",
     }});
 
     const writes = try alloc.alloc(mapper.DenseEmbeddingWrite, candidate_count);
@@ -25423,7 +25423,8 @@ test "production external scorers use bounded cache-first artifact batches" {
     try manager.applyDenseEmbeddingWritesByNameWithOptions(&store, "semantic_idx", writes, .{ .mode = .bulk_ingest });
 
     const entry = manager.denseIndex("semantic_idx") orelse return error.IndexNotFound;
-    var residency_probe = entry.index.acquireDecodedVectorResidency(candidate_count) orelse return error.TestUnexpectedResult;
+    try std.testing.expectEqual(hbc_mod.HBCConfig.RerankPolicy.boundary, entry.index.config.rerank_policy);
+    var residency_probe = entry.index.acquireDecodedVectorResidency(candidate_count) orelse return error.ResidencyProbeUnavailable;
     residency_probe.deinit();
     try std.testing.expectEqual(@as(u64, candidate_count), entry.index.stats().active_count);
     try std.testing.expectEqual(@as(u64, 0), entry.index.hbcCacheStats().vector.used_bytes);
@@ -25515,49 +25516,87 @@ test "production external scorers use bounded cache-first artifact batches" {
     try std.testing.expectEqual(@as(usize, 10), outcome.results.getHits().len);
     try std.testing.expectEqual(candidate_ids[candidate_count - 1], outcome.results.getHits()[0].vector_id);
 
-    // Drive the complete production HBC search path through more than one
-    // 128-entry external rerank batch. This catches regressions in batching,
-    // output-slot restoration, profile composition, and loader wiring that a
-    // direct two-candidate adapter call cannot observe.
+    // Drive the complete production HBC search path with the default boundary
+    // policy. An ambiguous distance threshold selects the full >128 candidate
+    // set, after which exact sorted batches evaluate the stop proof. This
+    // fixture keeps the second batch's lower bounds overlapping the retained
+    // frontier, so skipping it would be a recall bug.
     for (candidate_ids) |vector_id| entry.index.invalidateVectorCache(vector_id);
     entry.index.abortVectorCacheMutations();
-    var first_sorted_idx: usize = 0;
-    for (candidate_ids, 0..) |vector_id, i| {
-        if (vector_id < candidate_ids[first_sorted_idx]) first_sorted_idx = i;
-    }
-    var preload_lease = entry.index.acquireDecodedVectorResidency(1) orelse return error.TestUnexpectedResult;
-    defer preload_lease.deinit();
-    _ = try entry.index.cacheVectorForResidencyLease(
-        &preload_lease,
-        candidate_ids[first_sorted_idx],
-        vectors[first_sorted_idx * dims ..][0..dims],
-    );
-    var preloaded = entry.index.borrowCachedVector(candidate_ids[first_sorted_idx]) orelse return error.TestUnexpectedResult;
-    preloaded.deinit();
-    var full_profiled = try entry.index.searchProfiledRequest(.{
+    var boundary_probe = try entry.index.searchProfiledRequest(.{
         .query = vectors[(candidate_count - 1) * dims ..][0..dims],
-        .k = candidate_count,
-        .rerank_k = candidate_count,
+        .k = 128,
         .search_width = @intCast(candidate_count),
         .load_metadata = false,
         .filter_ids = candidate_ids,
     });
-    defer full_profiled.results.deinit();
+    defer boundary_probe.results.deinit();
+    try std.testing.expect(boundary_probe.profile.approx_top_count > 0);
+    const approximate_top = boundary_probe.profile.approx_top[0];
+    try std.testing.expect(approximate_top.error_bound > 0);
+    const ambiguous_distance_over = approximate_top.distance - approximate_top.error_bound / 2;
+    for (candidate_ids) |vector_id| entry.index.invalidateVectorCache(vector_id);
+    entry.index.abortVectorCacheMutations();
 
+    var full_profiled = try entry.index.searchProfiledRequest(.{
+        .query = vectors[(candidate_count - 1) * dims ..][0..dims],
+        .k = 128,
+        .search_width = @intCast(candidate_count),
+        // Equality with a retained approximate distance is ambiguous under
+        // the default boundary policy and therefore selects the complete
+        // candidate shell before progressive exact batches evaluate the stop.
+        .distance_over = ambiguous_distance_over,
+        .load_metadata = false,
+        .filter_ids = candidate_ids,
+    });
+    defer full_profiled.results.deinit();
     try std.testing.expect(full_profiled.profile.approx_candidate_count > 128);
     try std.testing.expect(full_profiled.profile.rerank_candidate_count > 128);
-    try std.testing.expect(full_profiled.profile.rerank_batches >= 2);
+    try std.testing.expect(full_profiled.profile.full_rerank_due_to_threshold);
+    try std.testing.expect(full_profiled.profile.ambiguous_distance_over_hits > 0);
+    try std.testing.expect(full_profiled.profile.rerank_batches > 0);
     try std.testing.expectEqual(@as(u64, 128), full_profiled.profile.rerank_max_batch_size);
-    try std.testing.expect(full_profiled.profile.rerank_artifact_cache_hits > 0);
-    try std.testing.expect(full_profiled.profile.rerank_artifact_vectors_loaded > 128);
+    try std.testing.expect(full_profiled.profile.rerank_artifact_vectors_loaded > 0);
     try std.testing.expectEqual(
         full_profiled.profile.rerank_artifact_vectors_loaded,
         full_profiled.profile.rerank_metadata_vectors_loaded,
     );
-    // The approximate result shell retains the candidate-local missing entry
-    // at infinite distance when k spans the entire corpus.
-    try std.testing.expectEqual(candidate_count, full_profiled.results.getHits().len);
-    try std.testing.expectEqual(candidate_ids[candidate_count - 1], full_profiled.results.getHits()[0].vector_id);
+    try std.testing.expectEqual(@as(u64, 0), full_profiled.profile.rerank_candidates_skipped_by_bound);
+    try std.testing.expectEqual(
+        std.math.divCeil(u64, full_profiled.profile.rerank_candidate_count, 128) catch unreachable,
+        full_profiled.profile.rerank_batches,
+    );
+
+    const ExpectedHit = struct {
+        vector_id: u64,
+        distance: f32,
+
+        fn lessThan(_: void, lhs: @This(), rhs: @This()) bool {
+            if (lhs.distance != rhs.distance) return lhs.distance < rhs.distance;
+            return lhs.vector_id < rhs.vector_id;
+        }
+    };
+    // Size for the complete shell: the fixture currently excludes the
+    // deleted artifact and the query vector by threshold, but correctness of
+    // this oracle must not depend on that threshold calibration.
+    const expected_storage = try alloc.alloc(ExpectedHit, candidate_count);
+    defer alloc.free(expected_storage);
+    var expected_count: usize = 0;
+    const query = vectors[(candidate_count - 1) * dims ..][0..dims];
+    for (candidate_ids, 0..) |vector_id, i| {
+        if (i == 2) continue; // Candidate-local artifact deleted above.
+        const distance = vector_mod.distance(query, vectors[i * dims ..][0..dims], .l2_squared);
+        if (distance <= ambiguous_distance_over) continue; // distance_over is strict.
+        expected_storage[expected_count] = .{ .vector_id = vector_id, .distance = distance };
+        expected_count += 1;
+    }
+    std.mem.sort(ExpectedHit, expected_storage[0..expected_count], {}, ExpectedHit.lessThan);
+    const hits = full_profiled.results.getHits();
+    try std.testing.expectEqual(@as(usize, 128), hits.len);
+    for (hits, expected_storage[0..hits.len]) |hit, expected| {
+        try std.testing.expectEqual(expected.vector_id, hit.vector_id);
+        try std.testing.expectApproxEqAbs(expected.distance, hit.distance, 0.0001);
+    }
 }
 
 test "external dense embedding writes persist deterministic vector mappings" {


### PR DESCRIPTION
## Summary

- capture stratified exact-recall samples from the primary concurrent QPS lane instead of issuing sequential validation requests afterward
- require eight generated-vector cluster strata and gate only the 50K/1%, 1M dense, 1M/1%, and 1M/10% production cases; maintenance and ad-hoc diagnostics do not inherit full exact scans
- exercise the production-default external-vector boundary reranker with more than 128 candidates, bounded batches, conservative continuation, a proven positive early stop, profile assertions, and brute-force exact top-k comparison
- make worker and poller ownership single-consumption with unconditional cleanup on every error path
- route benchmark process/filesystem work through std.Io and timing, sleeping, and cooperative waits through lib/platform

## Validation

- `zig build -Doptimize=ReleaseFast release-blocker-regression-test` — 10/10 passed, 0 leaked
- `zig build -Doptimize=ReleaseFast public-query-standalone-guardrail-build`
- production external-vector fixture — 201 rerank candidates, one 128-vector batch, 73 safely skipped candidates, exact top-k preserved
- standalone 1%-filtered smoke — concurrent capture lane, 8/8 strata, recall@10: 1.0
- standalone dense smoke — concurrent capture lane, 8/8 strata (tiny 256-document fixture recall@10: 0.75; production recall gate intentionally disabled for smoke)
- `bash -n scripts/run_resource_manager_cache_matrix.sh`
- `git diff --check`

## Production qualification

The full 50K/1M production matrix is intentionally not run locally as part of this PR. It remains the evidence-producing qualification and must pass all four matched-lane recall gates before publishing final QPS/recall numbers.