### PR TITLE
fix(auth): bind durable destination authority

### DIFF
--- a/go/pkg/sdk/oapi/client.gen.go
+++ b/go/pkg/sdk/oapi/client.gen.go
@@ -5445,6 +5445,21 @@ func (e ListRestoreJobsParamsScope) Valid() bool {
 	}
 }
 
+// Defines values for ReauthorizeTableDestinations200JSONResponseBodyStatus.
+const (
+	ReauthorizeTableDestinations200JSONResponseBodyStatusAuthorized ReauthorizeTableDestinations200JSONResponseBodyStatus = "authorized"
+)
+
+// Valid indicates whether the value is a known member of the ReauthorizeTableDestinations200JSONResponseBodyStatus enum.
+func (e ReauthorizeTableDestinations200JSONResponseBodyStatus) Valid() bool {
+	switch e {
+	case ReauthorizeTableDestinations200JSONResponseBodyStatusAuthorized:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for LookupKeyParamsConsistency.
 const (
 	LookupKeyParamsConsistencyLeaderLease LookupKeyParamsConsistency = "leader_lease"
@@ -18365,6 +18380,9 @@ type ListTablesParams struct {
 	Pattern string `form:"pattern,omitempty" json:"pattern,omitempty,omitzero"`
 }
 
+// ReauthorizeTableDestinations200JSONResponseBodyStatus defines parameters for ReauthorizeTableDestinations.
+type ReauthorizeTableDestinations200JSONResponseBodyStatus string
+
 // LookupKeyParams defines parameters for LookupKey.
 type LookupKeyParams struct {
 	// Fields Comma-separated list of fields to include in the response.
@@ -25276,6 +25294,18 @@ type ClientInterface interface {
 	// Corresponds with POST /db/v1/tables/{tableName}/batch (the `BatchWrite` operationId).
 	BatchWrite(ctx context.Context, tableName string, body BatchWriteJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// ReauthorizeTableDestinations Adopt stored write destinations with the current credential
+	//
+	// Reauthorizes the table's existing CDC routes and graph resolver destinations
+	// using the caller's current permissions. This idempotent operation is intended
+	// for upgrading tables created before durable destination authorization was
+	// introduced, and for explicitly transferring destination ownership after a
+	// credential is rotated. The caller needs admin permission on the source table
+	// and write permission on every eventual destination table.
+	//
+	// Corresponds with POST /db/v1/tables/{tableName}/destination-authorization (the `ReauthorizeTableDestinations` operationId).
+	ReauthorizeTableDestinations(ctx context.Context, tableName string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// ScanKeysWithBody Scan documents in a table within a key range
 	//
 	// Scans keys in a table within an optional key range and returns them as
@@ -28763,6 +28793,28 @@ func (c *Client) BatchWriteWithBody(ctx context.Context, tableName string, conte
 // Corresponds with POST /db/v1/tables/{tableName}/batch (the `BatchWrite` operationId).
 func (c *Client) BatchWrite(ctx context.Context, tableName string, body BatchWriteJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewBatchWriteRequest(c.Server, tableName, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+// ReauthorizeTableDestinations Adopt stored write destinations with the current credential
+//
+// Reauthorizes the table's existing CDC routes and graph resolver destinations
+// using the caller's current permissions. This idempotent operation is intended
+// for upgrading tables created before durable destination authorization was
+// introduced, and for explicitly transferring destination ownership after a
+// credential is rotated. The caller needs admin permission on the source table
+// and write permission on every eventual destination table.
+//
+// Corresponds with POST /db/v1/tables/{tableName}/destination-authorization (the `ReauthorizeTableDestinations` operationId).
+func (c *Client) ReauthorizeTableDestinations(ctx context.Context, tableName string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewReauthorizeTableDestinationsRequest(c.Server, tableName)
 	if err != nil {
 		return nil, err
 	}
@@ -32974,6 +33026,40 @@ func NewBatchWriteRequestWithBody(server string, tableName string, contentType s
 	return req, nil
 }
 
+// NewReauthorizeTableDestinationsRequest constructs an http.Request for the ReauthorizeTableDestinations method
+func NewReauthorizeTableDestinationsRequest(server string, tableName string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "tableName", tableName, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/db/v1/tables/%s/destination-authorization", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewScanKeysRequest calls the generic ScanKeys builder with application/json body
 func NewScanKeysRequest(server string, tableName string, body ScanKeysJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
@@ -36926,6 +37012,20 @@ type ClientWithResponsesInterface interface {
 	// Corresponds with POST /db/v1/tables/{tableName}/batch (the `BatchWrite` operationId).
 	BatchWriteWithResponse(ctx context.Context, tableName string, body BatchWriteJSONRequestBody, reqEditors ...RequestEditorFn) (*BatchWriteResponse, error)
 
+	// ReauthorizeTableDestinationsWithResponse Adopt stored write destinations with the current credential
+	//
+	// Reauthorizes the table's existing CDC routes and graph resolver destinations
+	// using the caller's current permissions. This idempotent operation is intended
+	// for upgrading tables created before durable destination authorization was
+	// introduced, and for explicitly transferring destination ownership after a
+	// credential is rotated. The caller needs admin permission on the source table
+	// and write permission on every eventual destination table.
+	//
+	// Returns a wrapper object for the known response body format(s).
+	//
+	// Corresponds with POST /db/v1/tables/{tableName}/destination-authorization (the `ReauthorizeTableDestinations` operationId).
+	ReauthorizeTableDestinationsWithResponse(ctx context.Context, tableName string, reqEditors ...RequestEditorFn) (*ReauthorizeTableDestinationsResponse, error)
+
 	// ScanKeysWithBodyWithResponse Scan documents in a table within a key range
 	//
 	// Scans keys in a table within an optional key range and returns them as
@@ -40805,6 +40905,8 @@ type RestoreResponse struct {
 	JSON400 *BadRequest
 	// JSON409 the response for an HTTP 409 `application/json` response
 	JSON409 *Conflict
+	// JSON422 the response for an HTTP 422 `application/json` response
+	JSON422 *Error
 	// JSON500 the response for an HTTP 500 `application/json` response
 	JSON500 *InternalServerError
 	// JSON503 the response for an HTTP 503 `application/json` response
@@ -40826,6 +40928,11 @@ func (r RestoreResponse) GetJSON400() *BadRequest {
 // GetJSON409 returns the response for an HTTP 409 `application/json` response
 func (r RestoreResponse) GetJSON409() *Conflict {
 	return r.JSON409
+}
+
+// GetJSON422 returns the response for an HTTP 422 `application/json` response
+func (r RestoreResponse) GetJSON422() *Error {
+	return r.JSON422
 }
 
 // GetJSON500 returns the response for an HTTP 500 `application/json` response
@@ -41410,6 +41517,8 @@ type CreateTableResponse struct {
 	JSON200 *Table
 	// JSON400 the response for an HTTP 400 `application/json` response
 	JSON400 *BadRequest
+	// JSON422 the response for an HTTP 422 `application/json` response
+	JSON422 *Error
 }
 
 // GetJSON200 returns the response for an HTTP 200 `application/json` response
@@ -41420,6 +41529,11 @@ func (r CreateTableResponse) GetJSON200() *Table {
 // GetJSON400 returns the response for an HTTP 400 `application/json` response
 func (r CreateTableResponse) GetJSON400() *BadRequest {
 	return r.JSON400
+}
+
+// GetJSON422 returns the response for an HTTP 422 `application/json` response
+func (r CreateTableResponse) GetJSON422() *Error {
+	return r.JSON422
 }
 
 // GetBody returns the raw response body bytes
@@ -42197,6 +42311,95 @@ func (r BatchWriteResponse) ContentType() string {
 	return ""
 }
 
+type ReauthorizeTableDestinationsResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	// JSON200 the response for an HTTP 200 `application/json` response
+	JSON200 *struct {
+		Status ReauthorizeTableDestinations200JSONResponseBodyStatus `json:"status"`
+		Table  string                                                `json:"table"`
+	}
+	// JSON400 the response for an HTTP 400 `application/json` response
+	JSON400 *BadRequest
+	// JSON403 the response for an HTTP 403 `application/json` response
+	JSON403 *Error
+	// JSON404 the response for an HTTP 404 `application/json` response
+	JSON404 *NotFound
+	// JSON409 the response for an HTTP 409 `application/json` response
+	JSON409 *Conflict
+	// JSON422 the response for an HTTP 422 `application/json` response
+	JSON422 *Error
+	// JSON500 the response for an HTTP 500 `application/json` response
+	JSON500 *InternalServerError
+}
+
+// GetJSON200 returns the response for an HTTP 200 `application/json` response
+func (r ReauthorizeTableDestinationsResponse) GetJSON200() *struct {
+	Status ReauthorizeTableDestinations200JSONResponseBodyStatus `json:"status"`
+	Table  string                                                `json:"table"`
+} {
+	return r.JSON200
+}
+
+// GetJSON400 returns the response for an HTTP 400 `application/json` response
+func (r ReauthorizeTableDestinationsResponse) GetJSON400() *BadRequest {
+	return r.JSON400
+}
+
+// GetJSON403 returns the response for an HTTP 403 `application/json` response
+func (r ReauthorizeTableDestinationsResponse) GetJSON403() *Error {
+	return r.JSON403
+}
+
+// GetJSON404 returns the response for an HTTP 404 `application/json` response
+func (r ReauthorizeTableDestinationsResponse) GetJSON404() *NotFound {
+	return r.JSON404
+}
+
+// GetJSON409 returns the response for an HTTP 409 `application/json` response
+func (r ReauthorizeTableDestinationsResponse) GetJSON409() *Conflict {
+	return r.JSON409
+}
+
+// GetJSON422 returns the response for an HTTP 422 `application/json` response
+func (r ReauthorizeTableDestinationsResponse) GetJSON422() *Error {
+	return r.JSON422
+}
+
+// GetJSON500 returns the response for an HTTP 500 `application/json` response
+func (r ReauthorizeTableDestinationsResponse) GetJSON500() *InternalServerError {
+	return r.JSON500
+}
+
+// GetBody returns the raw response body bytes
+func (r ReauthorizeTableDestinationsResponse) GetBody() []byte {
+	return r.Body
+}
+
+// Status returns HTTPResponse.Status
+func (r ReauthorizeTableDestinationsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ReauthorizeTableDestinationsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r ReauthorizeTableDestinationsResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
 type ScanKeysResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -42704,6 +42907,8 @@ type CreateIndexResponse struct {
 	JSON405 *MethodNotAllowed
 	// JSON409 the response for an HTTP 409 `application/json` response
 	JSON409 *Conflict
+	// JSON422 the response for an HTTP 422 `application/json` response
+	JSON422 *Error
 	// JSON429 the response for an HTTP 429 `application/json` response
 	JSON429 *StorageResourceExhausted
 	// JSON500 the response for an HTTP 500 `application/json` response
@@ -42737,6 +42942,11 @@ func (r CreateIndexResponse) GetJSON405() *MethodNotAllowed {
 // GetJSON409 returns the response for an HTTP 409 `application/json` response
 func (r CreateIndexResponse) GetJSON409() *Conflict {
 	return r.JSON409
+}
+
+// GetJSON422 returns the response for an HTTP 422 `application/json` response
+func (r CreateIndexResponse) GetJSON422() *Error {
+	return r.JSON422
 }
 
 // GetJSON429 returns the response for an HTTP 429 `application/json` response
@@ -43385,6 +43595,8 @@ type RestoreTableResponse struct {
 	JSON400 *BadRequest
 	// JSON409 the response for an HTTP 409 `application/json` response
 	JSON409 *Conflict
+	// JSON422 the response for an HTTP 422 `application/json` response
+	JSON422 *Error
 	// JSON500 the response for an HTTP 500 `application/json` response
 	JSON500 *InternalServerError
 	// JSON503 the response for an HTTP 503 `application/json` response
@@ -43406,6 +43618,11 @@ func (r RestoreTableResponse) GetJSON400() *BadRequest {
 // GetJSON409 returns the response for an HTTP 409 `application/json` response
 func (r RestoreTableResponse) GetJSON409() *Conflict {
 	return r.JSON409
+}
+
+// GetJSON422 returns the response for an HTTP 422 `application/json` response
+func (r RestoreTableResponse) GetJSON422() *Error {
+	return r.JSON422
 }
 
 // GetJSON500 returns the response for an HTTP 500 `application/json` response
@@ -47576,6 +47793,26 @@ func (c *ClientWithResponses) BatchWriteWithResponse(ctx context.Context, tableN
 	return ParseBatchWriteResponse(rsp)
 }
 
+// ReauthorizeTableDestinationsWithResponse Adopt stored write destinations with the current credential
+//
+// Reauthorizes the table's existing CDC routes and graph resolver destinations
+// using the caller's current permissions. This idempotent operation is intended
+// for upgrading tables created before durable destination authorization was
+// introduced, and for explicitly transferring destination ownership after a
+// credential is rotated. The caller needs admin permission on the source table
+// and write permission on every eventual destination table.
+//
+// Returns a wrapper object for the known response body format(s).
+//
+// Corresponds with POST /db/v1/tables/{tableName}/destination-authorization (the `ReauthorizeTableDestinations` operationId).
+func (c *ClientWithResponses) ReauthorizeTableDestinationsWithResponse(ctx context.Context, tableName string, reqEditors ...RequestEditorFn) (*ReauthorizeTableDestinationsResponse, error) {
+	rsp, err := c.ReauthorizeTableDestinations(ctx, tableName, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseReauthorizeTableDestinationsResponse(rsp)
+}
+
 // ScanKeysWithBodyWithResponse Scan documents in a table within a key range
 //
 // Scans keys in a table within an optional key range and returns them as
@@ -51303,6 +51540,13 @@ func ParseRestoreResponse(rsp *http.Response) (*RestoreResponse, error) {
 		}
 		response.JSON409 = &dest
 
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest Error
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest InternalServerError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
@@ -51761,6 +52005,13 @@ func ParseCreateTableResponse(rsp *http.Response) (*CreateTableResponse, error) 
 			return nil, err
 		}
 		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest Error
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
 
 	}
 
@@ -52381,6 +52632,77 @@ func ParseBatchWriteResponse(rsp *http.Response) (*BatchWriteResponse, error) {
 	return response, nil
 }
 
+// ParseReauthorizeTableDestinationsResponse parses an HTTP response from a ReauthorizeTableDestinationsWithResponse call
+func ParseReauthorizeTableDestinationsResponse(rsp *http.Response) (*ReauthorizeTableDestinationsResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ReauthorizeTableDestinationsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest struct {
+			Status ReauthorizeTableDestinations200JSONResponseBodyStatus `json:"status"`
+			Table  string                                                `json:"table"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest Error
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 409:
+		var dest Conflict
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON409 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest Error
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalServerError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
 // ParseScanKeysResponse parses an HTTP response from a ScanKeysWithResponse call
 func ParseScanKeysResponse(rsp *http.Response) (*ScanKeysResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
@@ -52807,6 +53129,13 @@ func ParseCreateIndexResponse(rsp *http.Response) (*CreateIndexResponse, error) 
 			return nil, err
 		}
 		response.JSON409 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest Error
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 429:
 		var dest StorageResourceExhausted
@@ -53354,6 +53683,13 @@ func ParseRestoreTableResponse(rsp *http.Response) (*RestoreTableResponse, error
 			return nil, err
 		}
 		response.JSON409 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest Error
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest InternalServerError
@@ -56238,201 +56574,201 @@ var swaggerSpec = []string{
 	"Y9BXaSEaHekGR/947+gf7xz9gUf+vai4vDlEWDNkQ1vqqec9BxXBwc0eIJIBwh5ZqgKOAFotSVzvKgFz",
 	"0nktNODITthLKEXCXuSa8AVeymUuhRnBKZsvQVKyfMMWLgGhGloLaEySFC9zbaSpuen3p4rL2omCp1YW",
 	"7L7Js3Uu5+yI/DyazbstKlwSXEANf86x7CxE8pKE54VILdb/H3t/u9zGrewL47eCYnZVbC+Skp1k/XeU",
-	"2nWOIttZOrETLclOzt4ZbxGcAUlEQ2AWgJHEuFy1P/0v4Kn18bm6dSVPobuBmSGHL5JFSXb0JbGGM3ht",
-	"9Bu6f829VtrDDenRqf7fgB/rojr5uLvw5ohb19vd/XpDnbGhKfZ4UfSgBrEwqDXSuCl8bP/1x7TF01RY",
+	"2nWOIttZOrEdLclOzt4ZbxGcAUlEQ2AWgJHEuFy1P/0v4Kn18bm6dSVPobuBmSGHL5JFSU70JbGGM3ht",
+	"9Bu6f829VtrDDenRqf7fgB/rojr5uLvw5ohb19vd/XpDnbGhKfZ4UfSgBrEwqDXSuCl8bP/1p7TF01RY",
 	"2yO41qa+GbTI1fO+B/ok6pInEygQRyRfNYkBPN8xKyBd0onL/oxP89YLCPy4dgT67CXPc8uGPD3z/ZOs",
-	"3z86enWIStHpwfGL5y9+enO4/+pkU6nfKhrWLvOioCBKWCEa1jZ6M2rRba79tfQs5PZqE2lfK12Nt5lQ",
-	"4lZpV1Wj6YZan3BHXYFQIeJ2qo2w/fUV5tZx/m2h868/bSdtpwzY/ZWOQ3vxL+74aQ1btRFPNfbbGLDf",
-	"ueMEqbpEF2nXGMe5HkIgxQraDV+uJLFo9tzYMVlPz619EdNrTpOPoYJaQLFeMYJwz0mbOsr5eSMwr9HS",
-	"u2X9q/FpWlNBwjBCpTj6rbtqR6kdguNt39Vrgeo3ptvocqemAuGjoP2gU9J/HWowty2a1xcq+OCsRpSW",
-	"aZMoghTL2IUYgvKDIGpB5lFiurRsgOxv4DcekcYwH/1Lm6hY+HuecLCNVKtzf14BL30BrX+FmuV173qT",
-	"gN1/EApYNReKF8VONblEfdUnRWte4qLG4KeBl4sB7bza2BvRctprBMwzt5aIzFLhhqQLVHIhhmFbw9pi",
-	"EP4LXnvEJryGpNtshbh3LTweytAWnr8ayZ1IVGimN9cEo1InqZ5OtWKariQoe8DpIkYJgAezJtV+Ialm",
-	"2aMRz3PPPezjoGP/3/1QNcX/efLi+OjFcf1Js7KKf/L98f4vL+oP/vPnt/U/Xx3+9OPbo/qT1Uy+28rH",
-	"uu2sFHbV6+EG0yMQwXdaFXsYGn4ulgJk+R8b+w+qztJQtEs+93Iu1VlZLHv/Ffw694kVpgDdtR2ZD36d",
-	"+wQLXSwvprVQeacbFOMln7SoA93OTJfL3v9PXc6pAEEDmP0Et3GVTr6gii8t3XMUzkco/AEEnRrhmBEj",
-	"YYRKRZ8dwb+pVsWFGJJY8YdA4UUb8tyqmkDQWRekzkeoKaELHDApnvfCQNCG7T8/uEHFqHWqrYWTCOVz",
-	"xc6GV0DqGZmJeVCxVcU6Ni4gtG/P6rU6TS1sUFw6w+GOq+BjEYGsLxBwtSqdvLx+0kSOJzmEDH/UQGIz",
-	"dGXOx8JuMoycq3HZCiyGB8PTX3gHA4cCiB+56oUCD731/x2ZL5sZJEKt14LXqrx3fzaaIoHwdFFrX+qs",
-	"bYtIXRovVtlyxH0WAlSvFjR2DV3/vqzyKrOicsxsaFEe1aQGuttX0XnNIT9P5SXQd3nm/5uJOSov2wt6",
-	"85EINsq6CHhSif0ngQIwUAevHq5fgafNENrc2mmnifqVWtOYandjyKnQpYtRBFV09mJ8dggTpG+8OTCV",
-	"eS6tSLXK7HoPRaSQd2t0cVUlByyi6KLp1OKtNyVJmJjPVpP5O7Ru3HgODQinfXaCCgfFjUDRGnGOwH6l",
-	"UQ04vRpXvreStVqd/rVqHT6HH1gm1CyX1rU1evVqgA1B3oaiWEnpIKBlHXK4KSb71yt3SDPjea4vbm5q",
-	"89pB2+xaRX+otbb5DDfRBChrMLza35Z030iotiZ2cHVWKygIHpNKk2f4V3CNVP7Szo0I0U1nsokkgnXG",
-	"F/sbSZc2yvAv9eblSYP2+0tqX9bcd23sofIVNH10VX3buotu44XZgrTaRCK1MkCzWhRtGr+2qIq01jxp",
-	"8fSE25FEJarHnjwRl/zJkz324pIzJUrD851wVVL/ev/oEF9HN4D/Ak3+fibOg2+tKuTJHlnptRhw9ZTF",
-	"Y/wW/QFQf6Gl+CeWx2/U+6TvwBfiPwO/R+0T/HmmS//jf+qyn+ppvUWIoYPNxZqfofypNmejXF9Y/B6d",
-	"Ib4JdHzMt1BbBkxEQF5vQroBtoKE4Vu5ihO2gdouLnnlaInuky75gtDTEX030VfS5qj+VeZZyk225cpi",
-	"F9TNehiT+GabAjXvprmNAsyBWuYrMNecgKvLLy/VdeotR3Xn7fGrBoSvkTfk8V+kejjZ4bG0/rCHkGk4",
-	"C8BdIzWHQ9HTRgrlopBIVKTvVaVx60PwE0an+LVq4/JC9mfY1JIaGSEi/8RvP+7vfiF/FLP9Er1i0q8R",
-	"4tl2QqWljv9RGyq0WrXL4Uu/ld9zK9PQBJCWqJVjptf9KOFlwY0wi2/D4/nXP4DKNdItuBoacpmKcpij",
-	"Zxw0yRi1glciVK6lH/7cPzqkYHhE9y2V5+eDnWy4c/500MVUDXgp/OKf4G9SkWty7gWJP79+RUD9QFiN",
-	"V6Y5ta4yr/FSnGguRyKdpflce/EF6z8CaSYdWLM0hyOc8f7RYQ1Kaq9z/pTnxYQ/JVgYxQvZ2et81d/t",
-	"f0WpObDdON6ddMLdTijOQZkOhW4ru7RYLc1/y2rfVn7Sk+c/Uq2dlOd5ogYL/QyYEXkM0g2I2aT2DbkV",
-	"/pxj/GAEKjnM/LmdcHdQGy8yR2Hd9zqbkXkYbI1acesdyIIKdMbXcezDsMcUHRnhtj402THFGYaYPVi+",
-	"Z7u72xxHAAD+gDXvdsS5UK5nnRF8+hENQzlInN4co2zuchWfyI4pYAEDZijGGgeCGFWwZLYL5WEoEerE",
-	"y/AX5xDaMMKKinOvs0f4bA/wgR57GvjQ7Xy9jUV9YYw2bXM+JOAqU1U1+nr36S0OYL+RruBlDwazYQIn",
-	"Dq4eNwclrSCepEQ8MRzyV7c45GMx1a5ysA9znZ5VdUxqpzu8EbPCqO40jPjrWxwxhOHBqo10qXDJnt7m",
-	"kr0WmeRxPcRlKkRm55cLSoUigOyHbuebWz4HVDaZqp0JfNEP49ndkdZIOG+ycpkjnX+DdN7WR2TMiNPl",
-	"9bIDXvBUuhl++f+7xWn8UMUsB9t1yZ5PxVSbGRuW2ViQwgYIALMohxmw5ZogjAoyvB6lu2fqS0X6SZFD",
-	"xT1x6a1np5md8jwPFWQtIRlGI1abheq1VZ4WqLZffEEJUvjHF+ylf58dhFcf8fyCz2yV+wpm6QkYuBjX",
-	"0sNsyaq6LsS/UZlg//JbS9kF/5F0YDRJxz9+yS2appnAml9QETIM4+effvq/cWQ9dhJmFOeAvWpVMSc5",
-	"lTn37Ml/gJ96rVD3Qsivt629Lj7A+Z9m0uyEir47AxxT/Q4FBlv1KEcUYunpmNaLHUC9JIh2Oa4l2Kc8",
-	"nWDBeCIMLzmfsalUJYQH+c+wtkSMTB5qNwmOF78srl58t1WtKtXZG3Hptq1QQUd3rU3RIKIqtXBU38RS",
-	"1yLDKj7Wjso8nz3oItfTRe6N3LqeqGhwYKCeFq4ZUnnrHBhSxpZz4P1ccsv0KNiPtfRNzDzdT1NRUFVU",
-	"4vzVK1GM2AkvBDkhUCeHEDo+DR/VzLZaiVqhzkWuC9FnL6GiOTdW9FJeYO02YGtdNsi447/Jd/3Y74Cy",
-	"+uH9RFFaI0GVSmWd4BnUGmKZ8N1AMguDm5M+ew6PIPkVy4cji0NXQy9C0iYKspSzAFtSA6jl47ERY8AM",
-	"FYBA0CvkpchJWoYkZ2SuueYZZLGjCpGot8ev2HDmBCu0o4ty8LaTH4A+Bg3jOyZVLpVgVpcmFeD+oaKw",
-	"PHUlFJVEBAQvD9uYarCtXsQd2zZ3hZ7umrvSIJZz12o9YvbbA5d9sPj+BBbfC+IYU2/5dYkNxpRxCwnh",
-	"C/yNAX+zZCzML+6DabgF07Ap7zG8vSZ3H/FKbtck9uMFyY9M/wo+1VonVQ31uhIAQj3IfbwFSRS3JOe/",
-	"tGwwp0aw/aPDbvBzQ6HFhsd6TuNYoQgAIBxoAwMmnZhSZefSYvVzNqgUhETBTReUYYZalxBdU1cb2JW0",
-	"hkRtqDaw9VpDoq6sNrDVWkOiPkJtYDFvJN5wjbRJVGZ00ZNQUxxoAwtugzVMeuDJ8x9tqykH5Bpl7IPK",
-	"0VA5ov/6Qcd40DEedIwHHePe6hgLykFTvcCIyRXOXZhfLzPyXMQ0CMAl8ktpMWx8/zBOq+DG2VDwBSR6",
-	"olKutJIpz8P1egjkwWQcrKEN2c1jJbGYMF7r6nqP3UTBTWXEuW0Wf+9SRuP8U8+TIiJuVoPJrVoGF8mh",
-	"J/DekANjqM0zKiagMnnx3UOJDXXMVYYnowd5Pj2EUwa/Q0ZgDcRBGPc6lRE8G3SbWgJUby5xTQ3L9IXy",
-	"ekOfvRGXrqdVPktUbTipVracCsu0EqzqpFSy1SH7gvZ3O9L7RRzXHUnu+gBWSO368sFVx4Oj4EGIP1wN",
-	"P1wN36ZsJi6E4k4KWwk5252TWnZObDXuAoKvc7nMDg5jupPF+9dcewH86tXrChETUp5+ENMpZ1899la7",
-	"54Ws5kaIxfyX3RaH6MbGjW245jRi/VXnOMDG2Z0B4w7Bv8uiH4AQRHQw4EeDyr51mkH+RYWA3LxCPgkx",
-	"Qf7vE+HYoB4RNMCsgFRICGBeiCp6dHLy4jEugFQpZtbzPFGoZGQid9z2GeTnQ+gU0A6XyjLOBs3oMrjo",
-	"GZCPop+o/ZrsocglBpWxoDdwjeyx357//NOLdwNAeKmhlMVYp0RdGAlX23DzS0isfsH+9ubNUTRPcUFt",
-	"N4IhCBO9JGIqnU0UV2wAU9jD0zdgI+NVnYuJtgITj8DjUuRcKkACxffYVEAOCqZJJirNdVSVcFJ+Prp0",
-	"fkVoOth02KFDVZSOvSTvEyF/LQkQRB8VLhF1bNGtE1YerHKdi0Q9sjPrxLTrdTfTZf5kWceVe1wPF++z",
-	"FpqYjyWjsw0Dfk6aGYlIcs+IupnkF4oqi7C0nJYYmpjPGE+NtpaA+UDie0qCv3N9gRmhT3d32Wv5fbfO",
-	"mgdQj4A6PvWM+tRroBajP//1P/+8gKUfREWwH8NK+/7TVKu0NEYodxoC4+DardBW+qH963/++fSvvldI",
-	"f4jBlsi/+myf/SGMrg3Iq884GJwny6RFBAilFVbHgYXY0OVFinCi2l1e9Npyt1dFYeiUkVRPStSQS2je",
-	"vaHOZtQiAeygP1SQBk9OQORbkPjbcAdGfx+NLli6wOWip9DTutfQsZNzwZ7+FaYPNS/xk+BOxDIIcfe/",
-	"efoM9kEb1tgRHveKXWmXv2McNi9R8dd0xqzAcJg5n+tIKulEHEMqZA5+SyA/WJ3TaPkPEiyeY9GTS6sh",
-	"srHos9c89+c0LKkNSetf7+522cVE5g1gW1P3pnrdxNp48fz106+W+FIPvYnI80ilNSNIp2lpbCQqPJJA",
-	"Wl1mNRTCPBeGzjAxw9DhN7tfRWqCTyjlaFmkSwx4JQXlIYD4IYD4wUp8sBI/LyuxEKZHd2ut7t4YOfRg",
-	"Qj5EF9ds3cDN6waoNz3XeKODabsz5A7zndsN3ONSWUSxL3Ixx+7HCxOwjKO71M5UOjFa6dIy6KGfqIPK",
-	"ziC0//hVyP0Cxy9qIV7bE5ciLR3cbmBJHdA36WNoVmTsx1/ojJjvWKmqWsf+QMGtd4RZg/x9xIhg3CYq",
-	"vgF0bCulhINSxqwc5nU5hfF9fm6Opw5rvxNnhsHE8Lyo6oCB+Gx3FwxXggzQUwGogTzP4VbeQn99dpBL",
-	"kJFQWlwqW3hWAIqff+tL/4PXyvMZA0gIK89FogaBogcgJgbBrJQiz2yXFXlp2YCIZdBlhkMSO9ZjMQJr",
-	"1flBJsqPkttgL8OOCIAS9L332Uvu6NzLVAAadJirHz1UwANNN1GlRTp5dnk5Z9a9aVyaQww5QqbC1tco",
-	"Borfa5XP+uxl6Uqv9/ufoVQLBETCcmOwOSrXi5EWGPAAYZZo7Huy2sOGMFLze9izGhFL9OL0sGe4pfAz",
-	"1bBmVSWH5gWMJ6tEGfE71mXxxgd0zS0bvP3p5O3R0c/Hb148P3399tWbw9c/P99/NYjqdqU1+34a2vd3",
-	"icJ+obG4xkYAJIZUWOJbKJd7U4tAKFYozzDZW9agoc/7okbTYJZfXSyQQ0C8kBV/1gbYTHNPkK8QPA1G",
-	"/WMI7rs+Hse702abbOlTVWpvVUP7vsnJo69xqsFZwRV7+uzfG1zGfm7h8k2VgipizQt0RMlGwVhXLNAz",
-	"7AfhdZVFfYIkYy693Nejmk85XqV3Y9JNlxlB+OZdFh3Y3XBp7P9pBFQRgX/xDJyQKmPOTzE1cijMnK86",
-	"1L2yCAICiUbkpl9wmYvwLqYH/b3kygFGB4CMe8k14eeCDXry3wfMlqORvAx5QZRXhJ3sYxJVzPWJiVDs",
-	"0bCUuetJBXlVR15cczVbPap6zhJ0FqpDUG8/oX6kDTZjwq+LLcWfcH740+mUKmVCHcoBeH8gmE0Ky1Ku",
-	"2JSbM5ZzJ3qAjEbXvUArVV+PBv6N09obgy4bpDofCuMGMNsX4MSUI6Z0mGvd/QlTi7VuaG61S5WVFxyb",
-	"tv8iEBK1X91fz0VTYndey5hyxcdeKaeQgrG0zkDS2WHY3x9eyZ9eHMcvtQH/YM9OtAshGJj6sRB5EXcU",
-	"iZpGdSL+8exE/GPpzMMZoIm/+abLXr7a/6nn//H9/vEbPBOvXv/9BwYH1vdZE3TTWgYgO0bfLHb8i7RS",
-	"qzV98+qEvDE/Hxx32XOtStdlL3MNbKyH5bJ+PjjGhL8QFgJhrdZxldHV0RdfsDfVwQ2Th0p3K8dQO+00",
-	"ECqQ2GW/8vNnv4j0WZf9rfz+xfEbdEFBkz2n4Y5l7iKtdofGK+Rrui3Daw3I7mvTtl5J67Cpzm3oNtjV",
-	"KqWG5kV4Jncei/E9f0iLu0k5f0vDeDMREVK9Ac+CZdCqFDYJNaVdSTi5fOmKhzBzCAJTmf/Jr7RnJrP+",
-	"nDryqu3qua5y+K+WezCIpdMNPfAOujJBZ8kij8vlmVjKyiAa80hePjuBkIGPu5OPzPMmL+R77MkTGP2T",
-	"J3vsyFvPnvMikpuXx9nOhKvMSwwnUG7jNzBV/83zVgZNhU1ifB/TpStKxx7B1X7hbBfsdkvAZdWK+SZf",
-	"e+u557g9Y+ew3iQ+H8Eipxw2C7S8X/6+Ty1Ui+xb+EXakueV/OLKXiD4HlZZ5640PO9FYOXC6GnhCObs",
-	"tdYqM4JPYXroLQIzn0ZTfYY7Em5nVbhWA9oBb0oAhmWjnPsF9NsK3pYgwPwcj0LniTrR06hDkHOKwTrQ",
-	"AGFjMjmCM1gPlYSP7F7YUdgddvDz8XM/h0FS7u5+ldrTVJusd/4M/qRbddoPVnBjQbBWnz/X6S9/3280",
-	"kOn0/B8cvw/PwiLj036/jz/szP8S3se9qI/hHHfr7/vzxMCILqn/nw+O659hyENNG5r7+AAJpdbAwf4R",
-	"1BSoNULx0xUTaCOnBXoJM6PjP/jVU4CbFVCEL6osErnc/xq00NUyEqQGnwtUUajMth9kfxDDYWt3q3QX",
-	"j24xMRqJFPT5LAZF9OCan66OPeega+xCmESFuNjq1rZUEpEWuGO54NaBhxaeFp7ULzTLRJpDeDFyRqxf",
-	"ErtOVOgLw4wZIWWH8oQ1TzW4VGE+GLSAN+v4BOJ2u+jD9cesh3Ykvvjo2Tc4ieGMVTXUqsiL2vpIG6q1",
-	"zMVUXDE6o8/2Y5sTXhRC2Y3ChcELjNWY6VG3Ja6hCmlov1x/3ohxSNTHBjk0IlwSta0gB1aLcUjUFYMc",
-	"3mC1zBAXwsZGX1jGnZ6iMz1RCJY3R+nV1tNSVsNtj5tAmrKJmo+b+I5Nl8dNoHHSGjTBMGYCgAFD0ARO",
-	"B3zOzfw0ikIHoV/lSwOgWpdS5SpXR6JqjuWaswMJahCyBgiDripPDDeCnvLohS5hqSgrElVVyN0/OrR9",
-	"1uLa/F2kzrY5tRd9022GjrcSgW9tPUHe93TXPmQcw3Ir6zCQEn8Idn8IY3gIdn8Idr/FYHfPnBZtW29Y",
-	"7bR72h43bWcvclbc/4se1rJkhRE9I3xDgvoL+m3E4jIiF+dcpQARyqk2HFrZqs0pvQhGhpfgjJitDH5n",
-	"vD0WLMWfp6V1e1j4jiL9qWdHthiB7oaanIDJewxjB/e6E9MCip9CibsTobKW2SE0MUQ0DGimg3iLnQkr",
-	"x4qdCVHYGr6sddyJXFiL+naee/0mpYt9p1laWq/s/OHVIN8XZguMZbroRqgwzDZzJDQ8+QdGW9vD+F1T",
-	"88oDgG6MkKhFVbAYxItz91tuwOG+xs8fwOkPdA7uVW8z6wKw3atr9+V3CjO2eE/giSTeFIAHGEds2T/i",
-	"BUxIrKDm4w99rdQlXi/sl05PeQjTKKAQQL2JeIcja5dQLWEKFNhQDw04Fjz3M/77hVA962a5YG1aXChp",
-	"4rXuEcYxNPGfyMtgjPTnC5AS8PQGK7bnaeRcZLU0U6CUl2CPIHUTAF/VK6w7nIN6SmeMkkBy7FmZiUQN",
-	"cjnciZ8OWMHTMz+Oi4lMJ2zCVZaDYhOIlbRDv6ZALPWlatcTfdPkDtm+qug7u3tlEUexXF2k5Qin6EFn",
-	"vBmd8Y41sM8pAgBpuBLws0q0LyoPpxXv20SPqHHKqmj2MhUCpA3oES0RZHweZYfWvldw46LTKdTNBUle",
-	"s4EB0z2w1X6iYhJ4FZbohdkwQs7LKRjFTsTosN5QcNOIZK/l0XhlACRKA+Ge9KCm8Fi4TK+YOadMoSDL",
-	"c64yLwOW9M9zuEJhplShq/+SY1qLwojCaM9pQkL92EhQfQqOi9JP1FWyiULGR8zNjx4wcJUvIvi0pvK0",
-	"+seWypLXkXxuVapU3d5/+fI8Hqv7KWG8elOP1MUa+A+uigdXxScHrnOb9Pq6zcSIwoUwXf6gy/UgL6DC",
-	"h1/+GG4tMjYT7nP1hYDe0q5iLFViIHhqleoCL2CUEYSm11It5kKzHrXEXgmX9h9/vIHfCPGa6xbCEGnL",
-	"wQTuhpyInlTS0SO8IaheYiOZC7ghP5gDItgsVOytFeyAW2HDHfXfwxdVagsUBQvxpNUdK8wPr417QBGX",
-	"jhVcGhsbMrNlrVAFJ68Vert53tUDd73c8GJiuN8i/y1tYYCArt23X2iT2RAzwZXNY3/hT/pqKNyFECoW",
-	"arStGgp0cxuo7NTV3SsjNIw1yOxIvg5KZj7Yug+27r2ydWu8oY2p14VFFWm6XF5UIayW8TKTGpASaq0v",
-	"BLRCgEhLyKo2FLX6cVFmzfDYpaFmhbxGoBmN2jPMCGhLz6JMBHGcS883c6jUhn7Zqgh+JhxWk6XIr7AC",
-	"vtWXPBVDrc98u/iYPevvxrZfqHEu7aQ30mlpRUYN4KrNfU4BwOFLK/JRz5aFMOcSv4Ql3ocdA7wUCPSA",
-	"P7Em9ESXuTdXwVvx16/Jv571g4Mai3dOubMM07OYVhgv47vcg7jk/V8gYE5Pp0J5RbPHDL9gRwevYeSv",
-	"j76COiSv9g/gz6/3d/b9PylWHaqj+78Gg4E/ZIl6nyjGkg50kHT2WIIV5OTOBe5Bz0k1SzpdfA2oEV97",
-	"e5b/cCz7/X7SSdQHaNE3/KuX/nFfJlK5vRvujX4MfeDvQtWHsSBXqxMF27Ft2Vp1d9fitT6S5RIWabQ6",
-	"5Q8O5Qche8+EbEXIcyLxUTMXI9xNY+3OnalYlUgGKQ2e1zrA5QpJ5BS7ls/q8eciA4iqfkuCrDvAD95a",
-	"qGL6Uae6WYF3Khz3ogO+yzKJkcNH9Xc+dDuqzEG0Il9pqRFcCEMBcNBqLHm/asOP4jdttfD9UmCJ2Pcd",
-	"gWKls9f5XU9UpsUm1XkX6eekAlqLC3zTJ38p8b5VnCrd3nyWxvoTg0A3LLxYFeuFIs61Eru/vfvQbdbt",
-	"xSf1wrq/vfvwrpmM6QJFt9AzlMoe287ebx0g33eN42NL2K712Zilkv8oBQvvs3DtDKqk7wcDGg64HUrF",
-	"KnrsMqMvelgHv0s3CrosvJYLDkcpbL81ScrP9SSM7iPP3Ebnodbh4oHYnJo/I8LCtJrSTeK214jpWOdi",
-	"CTHtvKd/fdipNn89iRl9wfDdSBosk0akwKidw4p5cOlHZEbdxBATDpiD3igCImsnLNrjY33xkgZ2G9QV",
-	"u3uhnJk9EFhFYNW2o4DmqkFzDZKjNey88zKPGz4VSFlLKuFXr+zQrh9xNzkKTzsf3m1Ovjvv4bL2A9Jv",
-	"LtAfvOjAPhdIh01anrVTMlwCFyLFxLlAzhDH7Tvrt/gPfQ/zJLxIwV+3DK4akoFW2oyAr7dPWrVxbE2Z",
-	"vWO6xl2qE0ELYXvTn+M+L6XxlfwSAEy3RGc/CLeeyG5uv+a541WUxweSvSkl8uPp9SZ4cnfBW8oREGwq",
-	"2CNt2JdPvsTh5TmOxj729Cv9qwV3k063g4ZLJ4y16Zbp1jaksmwAt8e2GDbvup2ibKvFIRxEYRpR5Dxd",
-	"wvQRGcUrJV1USboVXFRTh1k8gidLjuD13FrLjcu1dhvlc2OsdsT1xIl6PT7erHVu0wO2nmXUTq0Vbqse",
-	"r5VwBuQiDBjvknxfNDS/oI8/M2ZycgPMpK6ZgX25gZ+H41WEHgFzQKtUKgKPs4BSdxwDrrNpw1BtNxbe",
-	"2ps0EJq+n492sVzfhrgTl8tNBkIt7fSlNkOZZUKxXi24fm6vP0s7PVD8aocPvLLz3v/vJz5dbc48h+dY",
-	"4BF0x3SJhxRfbPeOtlgi/kWGnWb3hi2H04hBrCjFHt+ahglL8rnqlkgejC/xR3av4r5fS4s/CGDa3888",
-	"eW/TZoHRX4nnPhD2Z2g0lcjMgELbaPtqJtFb4svzfqrukkgSrDHoWbQSFziWWCdoDFUC4/Z7a7/g1l5o",
-	"k0GJWqIKhRGgjp9hCmcqMgBOWFKENnL5m79erzpo3Kq3EFQKyMRa1RZ+neXxdOsHvxrZPRJrwdqAAssV",
-	"M9gJlMCm0k65SyfEEr7d/igPtBrlMm0wqJiWAlmm9nMziKgUaHVKr6ak7fBC9s7EbP0ditcC948OmX+Z",
-	"6QtVhf5X7j+Qm+xEpEZQyW0lsBQVgFNmS+7jYMK3dBUHfX2CBs6DQL0BSybSL+p7c8eFaOO2RSsNqqpD",
-	"MHecEHtAcIPZ8XC4UOOicgKQNwjOCMySw3o5S4QsTXKbYha7WCFow4zvVNbiKH+VboL8au1A76vofXwH",
-	"HhAaB9EQYq+FMKGQuASLps2Xtv7jg3lw81KfqLSNk20k+nfen4nZYbbSYXMkzJQrjGzLyHnTZFY0ij47",
-	"KYfW04VyVWowBp8Dg/LnCSpnDAULlSuW+X1qzGqd5ycc1eXOn1uguTCIz93dolbR3A1Jz+7aD3/0VLsq",
-	"7GKB4oNpAh7zmxLxbVd4b4uMhyMS7aGNnEz4pe/uKAx2O7IaOwqdrJDWP4mLag6bS+qbI3rSxF9jOdhW",
-	"UJMwvLLI7pWgVvW1g8KpNa/Zg8vsRpkTEjTa/EV1dq5iDM8FO68PxoqHufqSmTIXlGOKg6nhixAcaPSa",
-	"eSN0WShWFUX90ugpOcfmuNYiVDo0Tdi4sb9gWtRG6TQKYAjXilEOcBNfhTmEBq4U6XAa717nbxnbxhtQ",
-	"jm90vG98z6vGvPL6v94IRGms1z6Oatu/NALublgQjEuNKciiop/Kiqiv2j1iT0wbdqxzUXsS6AL9z5E6",
-	"P8sQvxrtx0j4Gjur5VhscM/F87xhol3lvuuoxhRvw0W3Knvk4U7s4U7M1Cl5+YnYrgtvP8uC/64ppNae",
-	"qv0sq0b6Rm/x0qt+kFp05mrY4RbcDz/LbtULt4FuX42TA/T4Pb//ejj1N3vq97Ns7oitkoQr1Xujc7Gh",
+	"3z86enWIStHpwfGL5y/evD3cf3WyqdRvFQ1rl3lRUBAlrBANaxu9GbXoNtf+WnoWcnu1ibSvla7G20wo",
+	"cau0q6rRdEOtT7ijrkCoEHE71UbY/voKc+s4/7bQ+deftpO2Uwbs/krHob34F3f8tIat2oinGvttDNjv",
+	"3HGCVF2ii7RrjONcDyGQYgXthi9Xklg0e27smKyn59a+iOk1p8nHUEEtoFivGEG456RNHeX8vBGY12jp",
+	"/bL+1fg0rakgYRihUhz91l21o9QOwfG27+q1QPUb0210uVNTgfBR0H7QKem/DjWY2xbN6wsVfHBWI0rL",
+	"tEkUQYpl7EIMQflBELUg8ygxXVo2QPY38BuPSGOYj/6lTVQs/D1PONhGqtW5P6+Al76A1r9CzfK6d71J",
+	"wO4/CAWsmgvFi2KnmlyivuqTojUvcVFj8NPAy8WAdl5t7I1oOe01AuaZW0tEZqlwQ9IFKrkQw7CtYW0x",
+	"CP8Frz1iE15D0m22Qty7Fh4PZWgLz1+N5E4kKjTTm2uCUamTVE+nWjFNVxKUPeB0EaMEwINZk2o/k1Sz",
+	"7NGI57nnHvZx0LH/736omuL/PHlxfPTiuP6kWVnFP/n+eP/nF/UH//nTu/qfrw7f/PjuqP5kNZPvtvKx",
+	"bjsrhV31erjB9AhE8J1WxR6Ghp+LpQBZ/sfG/oOqszQU7ZLPvZxLdVYWy95/Bb/OfWKFKUB3bUfmg1/n",
+	"PsFCF8uLaS1U3ukGxXjJJy3qQLcz0+Wy9/9Tl3MqQNAAZm/gNq7SyRdU8aWle47C+QiFP4CgUyMcM2Ik",
+	"jFCp6LMj+DfVqrgQQxIr/hAovGhDnltVEwg664LU+QQ1JXSBAybF814YCNqw/ecHN6gYtU61tXASoXyu",
+	"2NnwCkg9IzMxDyq2qljHxgWE9u1ZvVanqYUNiktnONxxFXwsIpD1BQKuVqWTl9dPmsjxJIeQ4U8aSGyG",
+	"rsz5WNhNhpFzNS5bgcXwYHj6C+9g4FAA8SNXvVDgobf+vyPzZTODRKj1WvBalffuz0ZTJBCeLmrtS521",
+	"bRGpS+PFKluOuM9CgOrVgsauoevfl1VeZVZUjpkNLcqjmtRAd/sqOq855OepvAT6Ls/8fzMxR+Vle0Fv",
+	"PhLBRlkXAU8qsf8kUAAG6uDVw/Ur8LQZQptbO+00Ub9SaxpT7W4MORW6dDGKoIrOXozPDmGC9I03B6Yy",
+	"z6UVqVaZXe+hiBTyfo0urqrkgEUUXTSdWrz1piQJE/PZajJ/h9aNG8+hAeG0z05Q4aC4EShaI84R2K80",
+	"qgGnV+PK91ayVqvTv1atw+fwA8uEmuXSurZGr14NsCHI21AUKykdBLSsQw43xWT/euUOaWY8z/XFzU1t",
+	"Xjtom12r6A+11jaf4SaaAGUNhlf725LuGwnV1sQOrs5qBQXBY1Jp8gz/Cq6Ryl/auREhuulMNpFEsM74",
+	"Yn8j6dJGGf6l3rw8adB+f0nty5r7ro09VL6Cpo+uqm9bd9FtvDBbkFabSKRWBmhWi6JN49cWVZHWmict",
+	"np5wO5KoRPXYkyfikj95ssdeXHKmRGl4vhOuSupf7x8d4uvoBvBfoMnfz8R58K1VhTzZIyu9FgOunrJ4",
+	"jN+iPwDqL7QU/8Ty+I16n/Qd+EL8Z+D3qH2CP8906X/8T132Uz2ttwgxdLC5WPMzlD/V5myU6wuL36Mz",
+	"xDeBjo/5FmrLgIkIyOtNSDfAVpAwfCtXccI2UNvFJa8cLdF90iVfEHo6ou8m+kraHNW/yDxLucm2XFns",
+	"grpZD2MS32xToObdNLdRgDlQy3wF5poTcHX55aW6Tr3lqO68O37VgPA18oY8/otUDyc7PJbWH/YQMg1n",
+	"AbhrpOZwKHraSKFcFBKJivS9qjRufQh+wugUv1ZtXF7I/gybWlIjI0Tkn/jtx/3dL+SPYrZfoldM+jVC",
+	"PNtOqLTU8T9qQ4VWq3Y5fOm38ntuZRqaANIStXLM9LofJbwsuBFm8W14PP/6R1C5RroFV0NDLlNRDnP0",
+	"jIMmGaNW8EqEyrX0w5/7R4cUDI/ovqXy/Hywkw13zp8OupiqAS+FX/wT/E0qck3OvSDx59evCKgfCKvx",
+	"yjSn1lXmNV6KE83lSKSzNJ9rL75g/UcgzaQDa5bmcIQz3j86rEFJ7XXOn/K8mPCnBAujeCE7e52v+rv9",
+	"ryg1B7Ybx7uTTrjbCcU5KNOh0G1llxarpflvWe3byk968vxHqrWT8jxP1GChnwEzIo9BugExm9S+IbfC",
+	"n3OMH4xAJYeZP7cT7g5q40XmKKz7XmczMg+DrVErbr0DWVCBzvg6jn0Y9piiIyPc1scmO6Y4wxCzB8v3",
+	"bHd3m+MIAMAfsebdjjgXyvWsM4JPP6FhKAeJ05tjlM1druIT2TEFLGDADMVY40AQowqWzHahPAwlQp14",
+	"Gf7iHEIbRlhRce519gif7QE+0GNPAx+7na+3sagvjNGmbc6HBFxlqqpGX+8+vcUB7DfSFbzswWA2TODE",
+	"wdXj5qCkFcSTlIgnhkP+6haHfCym2lUO9mGu07OqjkntdIc3YlYY1Z2GEX99iyOGMDxYtZEuFS7Z09tc",
+	"stcikzyuh7hMhcjs/HJBqVAEkP3Y7Xxzy+eAyiZTtTOBL/phPLs70hoJ501WLnOk82+Qztv6iIwZcbq8",
+	"XnbAC55KN8Mv/3+3OI0fqpjlYLsu2fOpmGozY8MyGwtS2AABYBblMAO2XBOEUUGG16N090x9qUg/KXKo",
+	"uCcuvfXsNLNTnuehgqwlJMNoxGqzUL22ytMC1faLLyhBCv/4gr3077OD8Oojnl/wma1yX8EsPQEDF+Na",
+	"epgtWVXXhfg3KhPsX35nKbvgP5IOjCbp+McvuUXTNBNY8wsqQoZh/PTmzf+NI+uxkzCjOAfsVauKOcmp",
+	"zLlnT/4D/NRrhboXQn69be118QHO/zSTZidU9N0Z4Jjqdygw2KpHOaIQS0/HtF7sAOolQbTLcS3BPuXp",
+	"BAvGE2F4yfmMTaUqITzIf4a1JWJk8lC7SXC8+GVx9eK7rWpVqc7eiku3bYUKOrprbYoGEVWphaP6Npa6",
+	"FhlW8bF2VOb57EEXuZ4ucm/k1vVERYMDA/W0cM2QylvnwJAytpwD7+eSW6ZHwX6spW9i5ul+moqCqqIS",
+	"569eiWLETnghyAmBOjmE0PFp+KhmttVK1Ap1LnJdiD57CRXNubGil/ICa7cBW+uyQcYd/1W+78d+B5TV",
+	"D+8nitIaCapUKusEz6DWEMuE7waSWRjcnPTZc3gEya9YPhxZHLoaehGSNlGQpZwF2JIaQC0fj40YA2ao",
+	"AASCXiEvRU7SMiQ5I3PNNc8gix1ViES9O37FhjMnWKEdXZSDt538APQxaBjfMalyqQSzujSpAPcPFYXl",
+	"qSuhqCQiIHh52MZUg231Iu7Ytrkr9HTX3JUGsZy7VusRs98euOyDxfcnsPheEMeYesuvS2wwpoxbSAhf",
+	"4G8M+JslY2F+cR9Mwy2Yhk15j+HtNbn7iFdyuyaxHy9IfmT6V/Cp1jqpaqjXlQAQ6kHu4y1IorglOf+l",
+	"ZYM5NYLtHx12g58bCi02PNZzGscKRQAA4UAbGDDpxJQqO5cWq5+zQaUgJApuuqAMM9S6hOiautrArqQ1",
+	"JGpDtYGt1xoSdWW1ga3WGhL1CWoDi3kj8YZrpE2iMqOLnoSa4kAbWHAbrGHSA0+e/2hbTTkg1yhjH1SO",
+	"hsoR/dcPOsaDjvGgYzzoGPdWx1hQDprqBUZMrnDuwvx6mZHnIqZBAC6RX0qLYeP7h3FaBTfOhoIvINET",
+	"lXKllUx5Hq7XQyAPJuNgDW3Ibh4ricWE8VpX13vsJgpuKiPObbP4e5cyGuefep4UEXGzGkxu1TK4SA49",
+	"gfeGHBhDbZ5RMQGVyYvvHkpsqGOuMjwZPcjz6SGcMvgdMgJrIA7CuNepjODZoNvUEqB6c4lralimL5TX",
+	"G/rsrbh0Pa3yWaJqw0m1suVUWKaVYFUnpZKtDtkXtL/bkd4v4rjuSHLXB7BCateXD646HhwFD0L84Wr4",
+	"4Wr4NmUzcSEUd1LYSsjZ7pzUsnNiq3EXEHydy2V2cBjTnSzev+baC+BXr15XiJiQ8vSDmE45++qxt9o9",
+	"L2Q1N0Is5r/stjhENzZubMM1pxHrrzrHATbO7gwYdwj+XRb9AIQgooMBPxpU9q3TDPIvKgTk5hXySYgJ",
+	"8n+fCMcG9YigAWYFpEJCAPNCVNGjk5MXj3EBpEoxs57niUIlIxO547bPID8fQqeAdrhUlnE2aEaXwUXP",
+	"gHwU/UTt12QPRS4xqIwFvYFrZI/9+vynNy/eDwDhpYZSFmOdEnVhJFxtw80vIbH6Bfvb27dH0TzFBbXd",
+	"CIYgTPSSiKl0NlFcsQFMYQ9P34CNjFd1LibaCkw8Ao9LkXOpAAkU32NTATkomCaZqDTXUVXCSfn56NL5",
+	"FaHpYNNhhw5VUTr2krxPhPy1JEAQfVS4RNSxRbdOWHmwynUuEvXIzqwT067X3UyX+ZNlHVfucT1cvM9a",
+	"aGI+lozONgz4OWlmJCLJPSPqZpJfKKoswtJyWmJoYj5jPDXaWgLmA4nvKQn+zvUFZoQ+3d1lr+X33Tpr",
+	"HkA9Aur41DPqU6+BWoz+/Nf//PMCln4QFcF+DCvt+09TrdLSGKHcaQiMg2u3Qlvph/av//nn07/6XiH9",
+	"IQZbIv/qs332uzC6NiCvPuNgcJ4skxYRIJRWWB0HFmJDlxcpwolqd3nRa8vdXhWFoVNGUj0pUUMuoXn3",
+	"hjqbUYsEsIP+UEEaPDkBkW9B4m/DHRj9fTS6YOkCl4ueQk/rXkPHTs4Fe/pXmD7UvMRPgjsRyyDE3f/m",
+	"6TPYB21YY0d43Ct2pV3+jnHYvETFX9MZswLDYeZ8riOppBNxDKmQOfgtgfxgdU6j5T9IsHiORU8urYbI",
+	"xqLPXvPcn9OwpDYkrX+9u9tlFxOZN4BtTd2b6nUTa+PF89dPv1riSz30JiLPI5XWjCCdpqWxkajwSAJp",
+	"dZnVUAjzXBg6w8QMQ4ff7H4VqQk+oZSjZZEuMeCVFJSHAOKHAOIHK/HBSvxjWYmFMD26W2t198bIoQcT",
+	"8iG6uGbrBm5eN0C96bnGGx1M250hd5jv3G7gHpfKIop9kYs5dj9emIBlHN2ldqbSidFKl5ZBD/1EHVR2",
+	"BqH9x69C7hc4flEL8dqeuBRp6eB2A0vqgL5JH0OzImM//kxnxHzHSlXVOvYHCm69I8wa5O8jRgTjNlHx",
+	"DaBjWyklHJQyZuUwr8spjO/zc3M8dVj7nTgzDCaG50VVBwzEZ7u7YLgSZICeCkAN5HkOt/IW+uuzg1yC",
+	"jITS4lLZwrMCUPz8W1/6H7xWns8YQEJYeS4SNQgUPQAxMQhmpRR5ZrusyEvLBkQsgy4zHJLYsR6LEVir",
+	"zg8yUX6U3AZ7GXZEAJSg773PXnJH516mAtCgw1z96KECHmi6iSot0smzy8s5s+5t49IcYsgRMhW2vkYx",
+	"UPxeq3zWZy9LV3q93/8MpVogIBKWG4PNUblejLTAgAcIs0Rj35PVHjaEkZrfw57ViFiiF6eHPcMthZ+p",
+	"hjWrKjk0L2A8WSXKiN+wLos3PqBrbtng3ZuTd0dHPx2/ffH89PW7V28PX//0fP/VIKrbldbs+2lo398l",
+	"CvuFxuIaGwGQGFJhiW+hXO5NLQKhWKE8w2RvWYOGPu+LGk2DWX51sUAOAfFCVvxZG2AzzT1BvkLwNBj1",
+	"jyG47/t4HO9Om22ypc9Vqb1VDe37JiePvsapBmcFV+zps39vcBn7RwuXb6oUVBFrXqAjSjYKxrpigZ5h",
+	"PwivqyzqEyQZc+nlvh7VfMrxKr0bk266zAjCN++y6MDuhktj/08joIoI/Itn4IRUGXN+iqmRQ2HmfNWh",
+	"7pVFEBBINCI3/YLLXIR3MT3o7yVXDjA6AGTcS64JPxds0JP/PmC2HI3kZcgLorwi7GQfk6hirk9MhGKP",
+	"hqXMXU8qyKs68uKaq9nqUdVzlqCzUB2CenuD+pE22IwJvy62FH/C+eFPp1OqlAl1KAfg/YFgNiksS7li",
+	"U27OWM6d6AEyGl33Aq1UfT0a+DdOa28MumyQ6nwojBvAbF+AE1OOmNJhrnX3J0wt1rqhudUuVVZecGza",
+	"/otASNR+dX89F02J3XktY8oVH3ulnEIKxtI6A0lnh2F/f3gl37w4jl9qA/7Bnp1oF0IwMPVjIfIi7igS",
+	"NY3qRPzj2Yn4x9KZhzNAE3/7TZe9fLX/puf/8f3+8Vs8E69e//0HBgfW91kTdNNaBiA7Rt8sdvyztFKr",
+	"NX3z6oS8NT8dHHfZc61K12Uvcw1srIflsn46OMaEvxAWAmGt1nGV0dXRF1+wt9XBDZOHSncrx1A77TQQ",
+	"KpDYZb/w82c/i/RZl/2t/P7F8Vt0QUGTPafhjmXuIq12h8Yr5Gu6LcNrDcjua9O2XknrsKnObeg22NUq",
+	"pYbmRXgmdx6L8T1/SIu7STl/S8N4OxERUr0Bz4Jl0KoUNgk1pV1JOLl86YqHMHMIAlOZ/8mvtGcms/6c",
+	"OvKq7eq5rnL4r5Z7MIil0w098A66MkFnySKPy+WZWMrKIBrzSF4+O4GQgU+7k4/M8yYv5HvsyRMY/ZMn",
+	"e+zIW8+e8yKSm5fH2c6Eq8xLDCdQbuM3MFX/zfNWBk2FTWJ8H9OlK0rHHsHVfuFsF+x2S8Bl1Yr5Jl97",
+	"67nnuD1j57DeJD4fwSKnHDYLtLyf/75PLVSL7Fv4WdqS55X84speIPgeVlnnrjQ870Vg5cLoaeEI5uy1",
+	"1iozgk9heugtAjOfRlN9hjsSbmdVuFYD2gFvSgCGZaOc+wX02wreliDA/ByPQueJOtHTqEOQc4rBOtAA",
+	"YWMyOYIzWA+VhI/sXthR2B128NPxcz+HQVLu7n6V2tNUm6x3/gz+pFt12g9WcGNBsFafP9fpz3/fbzSQ",
+	"6fT8Hxy/D8/CIuPTfr+PP+zM/xLex72oj+Ecd+vv+/PEwIguqf+fDo7rn2HIQ00bmvv4AAml1sDB/hHU",
+	"FKg1QvHTFRNoI6cFegkzo+M/+MVTgJsVUIQvqiwSudz/GrTQ1TISpAafC1RRqMy2H2R/EMNha3erdBeP",
+	"bjExGokU9PksBkX04Jqfro4956Br7EKYRIW42OrWtlQSkRa4Y7ng1oGHFp4WntQvNMtEmkN4MXJGrF8S",
+	"u05U6AvDjBkhZYfyhDVPNbhUYT4YtIA36/gE4na76MP1x6yHdiS++OjZNziJ4YxVNdSqyIva+kgbqrXM",
+	"xVRcMTqjz/ZjmxNeFELZjcKFwQuM1ZjpUbclrqEKaWi/XH/eiHFI1KcGOTQiXBK1rSAHVotxSNQVgxze",
+	"YrXMEBfCxkZfWMadnqIzPVEIljdH6dXW01JWw22Pm0Casomaj5v4jk2Xx02gcdIaNMEwZgKAAUPQBE4H",
+	"fM7N/DSKQgehX+VLA6Bal1LlKldHomqO5ZqzAwlqELIGCIOuKk8MN4Ke8uiFLmGpKCsSVVXI3T86tH3W",
+	"4tr8TaTOtjm1F33TbYaOtxKBb209Qd73dNc+ZBzDcivrMJASfwh2fwhjeAh2fwh2v8Vgd8+cFm1bb1jt",
+	"tHvaHjdtZy9yVtz/ix7WsmSFET0jfEOC+gv6bcTiMiIX51ylABHKqTYcWtmqzSm9CEaGl+CMmK0Mfme8",
+	"PRYsxZ+npXV7WPiOIv2pZ0e2GIHuhpqcgMl7DGMH97oT0wKKn0KJuxOhspbZITQxRDQMaKaDeIudCSvH",
+	"ip0JUdgavqx13IlcWIv6dp57/Sali32nWVpar+z87tUg3xdmC4xluuhGqDDMNnMkNDz5B0Zb28P4XVPz",
+	"ygOAboyQqEVVsBjEi3P3W27A4b7Gzx/A6Q90Du5VbzPrArDdq2v35XcKM7Z4T+CJJN4UgAcYR2zZP+IF",
+	"TEisoObjD32t1CVeL+yXTk95CNMooBBAvYl4hyNrl1AtYQoU2FAPDTgWPPcz/vuFUD3rZrlgbVpcKGni",
+	"te4RxjE08Z/Iy2CM9OcLkBLw9AYrtudp5FxktTRToJSXYI8gdRMAX9UrrDucg3pKZ4ySQHLsWZmJRA1y",
+	"OdyJnw5YwdMzP46LiUwnbMJVloNiE4iVtEO/pkAs9aVq1xN90+QO2b6q6Du7e2URR7FcXaTlCKfoQWe8",
+	"GZ3xjjWwP1IEANJwJeBnlWhfVB5OK963iR5R45RV0exlKgRIG9AjWiLI+DzKDq19r+DGRadTqJsLkrxm",
+	"AwOme2Cr/UTFJPAqLNELs2GEnJdTMIqdiNFhvaHgphHJXsuj8coASJQGwj3pQU3hsXCZXjFzTplCQZbn",
+	"XGVeBizpn+dwhcJMqUJX/yXHtBaFEYXRntOEhPqxkaD6FBwXpZ+oq2QThYyPmJsfPWDgKl9E8GlN5Wn1",
+	"jy2VJa8j+dyqVKm6vf/y5Xk8VvdTwnj1ph6pizXwH1wVD66Kzw5c5zbp9XWbiRGFC2G6/E6X60FeQIUP",
+	"v/wx3FpkbCbcH9UXAnpLu4qxVImB4KlVqgu8gFFGEJpeS7WYC8161BJ7JVzaf/zpBn4jxGuuWwhDpC0H",
+	"E7gbciJ6UklHj/CGoHqJjWQu4Ib8YA6IYLNQsXdWsANuhQ131H8PX1SpLVAULMSTVnesMD+8Nu4BRVw6",
+	"VnBpbGzIzJa1QhWcvFbo7eZ5Vw/c9XLDi4nhfov8t7SFAQK6dt9+oU1mQ8wEVzaP/YU/6auhcBdCqFio",
+	"0bZqKNDNbaCyU1d3r4zQMNYgsyP5OiiZ+WDrPti698rWrfGGNqZeFxZVpOlyeVGFsFrGy0xqQEqotb4Q",
+	"0AoBIi0hq9pQ1OqnRZk1w2OXhpoV8hqBZjRqzzAjoC09izIRxHEuPd/MoVIb+mWrIviZcFhNliK/wgr4",
+	"Vl/yVAy1PvPt4mP2rL8b236hxrm0k95Ip6UVGTWAqzb3OQUAhy+tyEc9WxbCnEv8EpZ4H3YM8FIg0AP+",
+	"xJrQE13m3lwFb8Vfvyb/etYPDmos3jnlzjJMz2JaYbyM73IP4pL3f4aAOT2dCuUVzR4z/IIdHbyGkb8+",
+	"+grqkLzaP4A/v97f2ff/pFh1qI7u/xoMBv6QJepDohhLOtBB0tljCVaQkzsXuAc9J9Us6XTxNaBGfO3d",
+	"Wf7Dsez3+0knUR+hRd/wL176x32ZSOX2brg3+jH0gb8LVR/GglytThRsx7Zla9XdXYvX+kiWS1ik0eqU",
+	"PziUH4TsPROyFSHPicRHzVyMcDeNtTt3pmJVIhmkNHhe6wCXKySRU+xaPqvHn4sMIKr6LQmy7gA/eGeh",
+	"iuknnepmBd6pcNyLDvguyyRGDh/V3/nY7agyB9GKfKWlRnAhDAXAQaux5P2qDT+K37TVwvdLgSViP3QE",
+	"ipXOXuc3PVGZFptU512kn5MKaC0u8E2f/KXE+05xqnR781ka608MAt2w8GJVrBeKONdK7P76/mO3WbcX",
+	"n9QL6/76/uP7ZjKmCxTdQs9QKntsO3u/doB83zeOjy1hu9ZnY5ZK/qMULLzPwrUzqJK+HwxoOOB2KBWr",
+	"6LHLjL7oYR38Lt0o6LLwWi44HKWw/dYkKT/XkzC6TzxzG52HWoeLB2Jzav4DERam1ZRuEre9RkzHOhdL",
+	"iGnnA/3r4061+etJzOgLhu9G0mCZNCIFRu0cVsyDSz8iM+omhphwwBz0RhEQWTth0R4f64uXNLDboK7Y",
+	"3QvlzOyBwCoCq7YdBTRXDZprkBytYee9l3nc8KlAylpSCb96ZYd2/Yi7yVF42vn4fnPy3fkAl7UfkX5z",
+	"gf7gRQf2uUA6bNLyrJ2S4RK4ECkmzgVyhjhu31m/xX/oe5gn4UUK/rplcNWQDLTSZgR8vX3Sqo1ja8rs",
+	"HdM17lKdCFoI25v+HPd5KY2v5JcAYLolOvtBuPVEdnP7Nc8dr6I8PpDsTSmRn06vN8GTuwveUo6AYFPB",
+	"HmnDvnzyJQ4vz3E09rGnX+lfLbibdLodNFw6YaxNt0y3tiGVZQO4PbbFsHnf7RRlWy0O4SAK04gi5+kS",
+	"po/IKF4p6aJK0q3gopo6zOIRPFlyBK/n1lpuXK612yifG2O1I64nTtTr8fFmrXObHrD1LKN2aq1wW/V4",
+	"rYQzIBdhwHiX5PuiofkFffwHYyYnN8BM6poZ2Jcb+Hk4XkXoETAHtEqlIvA4Cyh1xzHgOps2DNV2Y+Gd",
+	"vUkDoen7+WQXy/VtiDtxudxkINTSTl9qM5RZJhTr1YLr5/b6D2mnB4pf7fCBV3Y++P+94dPV5sxzeI4F",
+	"HkF3TJd4SPHFdu9oiyXiX2TYaXZv2HI4jRjEilLs8a1pmLAkf1TdEsmD8SX+yO5V3PdrafEHAUz7+5kn",
+	"723aLDD6K/HcB8L+AxpNJTIzoNA22r6aSfSO+PK8n6q7JJIEawx6Fq3EBY4l1gkaQ5XAuP3e2i+4tRfa",
+	"ZFCilqhCYQSo42eYwpmKDIATlhShjVz+5q/Xqw4at+otBJUCMrFWtYVfZ3k83frBr0Z2j8RasDagwHLF",
+	"DHYCJbCptFPu0gmxhG+3P8oDrUa5TBsMKqalQJap/aMZRFQKtDqlV1PSdnghe2ditv4OxWuB+0eHzL/M",
+	"9IWqQv8r9x/ITXYiUiOo5LYSWIoKwCmzJfdxMOFbuoqDvj5DA+dBoN6AJRPpF/W9ueNCtHHbopUGVdUh",
+	"mDtOiD0guMHseDhcqHFROQHIGwRnBGbJYb2cJUKWJrlNMYtdrBC0YcZ3KmtxlL9IN0F+tXag91X0Pr4D",
+	"DwiNg2gIsddCmFBIXIJF0+ZLW//xwTy4ealPVNrGyTYS/TsfzsTsMFvpsDkSZsoVRrZl5LxpMisaRZ+d",
+	"lEPr6UK5KjUYg8+BQfnzBJUzhoKFyhXL/D41ZrXO8xOO6nLnzy3QXBjEH93dolbR3A1Jz+7aD3/0VLsq",
+	"7GKB4oNpAh7zmxLxbVd474qMhyMS7aGNnEz4pe/uKAx2O7IaOwqdrJDWb8RFNYfNJfXNET1p4q+xHGwr",
+	"qEkYXllk90pQq/raQeHUmtfswWV2o8wJCRpt/qI6O1cxhueCndcHY8XDXH3JTJkLyjHFwdTwRQgONHrN",
+	"vBG6LBSriqJ+afSUnGNzXGsRKh2aJmzc2F8wLWqjdBoFMIRrxSgHuImvwhxCA1eKdDiNd6/zt4xt4w0o",
+	"xzc63re+51VjXnn9X28EojTWax9Hte1fGgF3NywIxqXGFGRR0U9lRdRX7R6xJ6YNO9a5qD0JdIH+50id",
+	"f8gQvxrtx0j4Gjur5VhscM/F87xhol3lvuuoxhRvw0W3Knvk4U7s4U7M1Cl5+YnYrgtvP8uC/64ppNae",
+	"qv0sq0b6Vm/x0qt+kFp05mrY4RbcDz/LbtULt4FuX42TA/T4Pb//ejj1N3vq97Ns7oitkoQr1Xujc7Gh",
 	"Yo+x7s2kHzYV06EwdiKLun6/TH/3usummvtxo58Qyeg0aZNL9V29cRSyf3XPCcWhsALPcAkXI5I3yfbI",
-	"xb3Vcv00b/ngaYNk8tmnnASzdu78UbrempQSqSbCSCcybCima1Z5n9Wd3PKA2WM4wTelhc6R/8comw9c",
-	"/gauZ0G5M7TFC+R1KwrdWr6/gkj3s8wPdqs6ne9g31o5VlPfVmtuwhJRwuGze6bdwWjvp153B6Lkc9bh",
-	"4Egtam8tyd4tetvmqd48z1vTvZdEV7RKmk82gfuBUreTN75ItNdPTVwmmDY9AVfJFm/P420/Cutzwz/N",
-	"pPBKR/+zJofj9m4nJ/zqtPSDeEj8/nORZVsC+MY0eVOxJJ9k4vc1zxzVukStdqizWaidupBv3Zob/pAU",
-	"/mdICn/QFbeRi74hX/PKXjb0qh4fw5SA2nvDUuaZMMvhfd9aYRlX7NWr1wC+EmHCqf5zBZ9KQOUSAe+l",
-	"wqupqoB6/ZT1scBdqBab0dmjCjSlFVmF/UJJ7wCSTpTW9zR+6sSlO6Ve43k9xZawMF6/tcBZaYWXwCNt",
-	"AKT2e78EIV4hQqxTKlxcCkBNDxDtasyI6VYfwV7ADnxpGdIL1GUbA4QdM3gzznM/n+P9H1ghC5FL1Yqs",
-	"DnP9HrcGGtiSb6fezx2BvzaHYMu8lUMjQr4n1jtic/M1XYjVQYBdIHlt4qUA0MHtMT1SLu6O69VRVMPa",
-	"eI6Rev0Gq148vnFuCFTjeUxVIWGGh3eeN9V4Irx1Go+bbWON8ayuY4vs+ct9KkjIi8Jonk7wCg2jYCrF",
-	"YS9Rac6NHM3Yv/7//w+zIhepO7XOM78xPjNiJJUg9uUfiEuRlg4AsJ88+VHM2EvhpyXs3pMnVI+/zJ3s",
-	"hVaePNljJ2LKPbvpsu9fP/umy5wRgNbDi0mXBXxWwO2ZzIZGZvX6E0fEkHw7BxMuVeRtkIULFSWF8koi",
-	"bbBvPCw+QKx7yof1tzQMZuBEW8IpP4AlIBpEDHXU2LCESQ9Kk3tGiouQScunQzku4X1s4lhwq5XvCIaI",
-	"1S7QXLROFBZSfxXLSioURhuJi3iCKyXjEg7CQAd77BeROm2YlVPph+lmYWqYSVCVpIQPh9Nn3wz22Msy",
-	"z3uUJQUvw1L5tYeiolKN4e2w8oM9dlIJRCxaSYsM7/kVHeyxQwfUeS5wiRU/l2NMW4Lm8QTIP/DRoyM+",
-	"FocqE5dYXg3WegBbPvCLgyU+7EQWRKnO8HNhrF+UHhsgHQz22IGeDqUSzMZFwt6Oj1+ihWC4OqN1PHnB",
-	"Xpx7lvdmVtQW04niFAhB+AYDPcHGsKEYc8UeWSHYycmLEyeKE3yTZOXjqonC6LER1vo26J8wFKlAoRBF",
-	"o5n4ykI7npNBasbCYEZSSTsRWaOhg/B6o6U059ZGoh3soR7Cmo+JzrG5g8ZPb0IZHfgLJRy2bAIpI1UI",
-	"PsUq90TfQFXppFRn7BHacfjZSOe5viiLQVUjJmP4sFcWVRmbxkcT6TxdqUyey6ysFQpqjBym9jdJ43Na",
-	"56dTnXmKfKN1Hsug+mfEwmpL6F95rTOiP3/oBnvsxTnPS6ql489iavF9/7y+FplWAqg1KElh7/D1+ByU",
-	"oYUPg7FJGawOz85Ies4y9AJRZD1g7Uyoc5HrAuN9h9pN0Nzzhqwn6lQrW04F1uUZgDTzkwCpplPAJa4m",
-	"DI8ft9bFqY92W9dyc0tyJ8pb274guJO4dDviHCrvAmk325x3QnjloXfiNwjYiufl/qM+O6GlPsfNK6d+",
-	"4xLltQpoHYK5Ea3ZTYQ0LNUGZwsaPY0TyyvO+0RaSnYF6kNiMbEIwa0rmfMDiZUF7k6t24LvOMwSqIdV",
-	"tlKNOYVXEAikxoU2VemGPD0ri+WKXJUZjW8GwDV0ynnJVzm98FmfvQA9j0w9+owAByyYlKiPB6nPHuGK",
-	"d5n0YlrYLrMTbrJYZI/HYjD7eU6/4Yd+17xwExmuwB/WYemWfaa06qH5QSMoymHupZqfS5qX1gnTy8W5",
-	"yFkoR45523zk/J6eCzNLVJVPC/OJs7Fehapce7EF4rTIW1M9nUqXKKpPqzIoy2cyW7FvcVmAmNiJwpg6",
-	"SnWpnO2zfTYovOrI80GitGEDtBYGjDvnp0dJ55DS28NPM8nHSlvnpcmwdCzTwoLxQyvAuJ+XdRomUCt3",
-	"GMuys/2wQrisSlfyjDaeuk3U4Ovd3QG8pkvHLowENTeSix/7iKcOXA3f47PD5whFIafTkvyjx6KkMrTs",
-	"8DnWuA0oIRMA+w67l3lLAYcWFz0sweDr3W8HsM654OG2LZaypwGVKp1wNRZZPyi92vCxYK80Momgrvm/",
-	"c6yJB3CCe2zg/9jb2dkpuJvsOE1nByrw7U/5H1qxk6/22MB+tbezMyzTM+F6hL8y977vl9Yi6rvQLRS8",
-	"eZ/TUD7sJOpf//x///XP//nXP/+HvcfPT2X2oRfoNxwhKKTPGHs0vzaPfQv/pBaqyn09m+oi0lp42RJu",
-	"0CzXPLPLyu/gwLeFV4Djxz7uSGrPjWF5pR3awnAS4xHus0PluaILOVTQgte6uSu92j6oVO9EScvAV1Nz",
-	"3HTZxUTmojr6rH7yjSi0cbUTnyj/kzd9QeozfxTHE+oc/THSWZGP2AW3jIo+z93+9hP1s+d+taE1OGaN",
-	"YczTmFcfKhVgdWWY73mV2BohiFZ/EiCEauJ99QdBPKPe9OJKlWtwS1/TsXqrYqWzm/fOEPE0ZWmTy9aE",
-	"OC366ZQrPobKrS1ifHkwzivpj7dWIij8rPBMT4/mRCG1w6SiguVxl3tnYuYlUCYM427uuitwrH70NkTh",
-	"zodeLgivEmDjiUJdAPEHRJh9QCTqMienwjo+LbCGCPnFvU0OPRxxC5zdCzHCWxkocelO09JYbQYVh2/4",
-	"mnxXCguLjkVbQXG/RN/TMq4JDg8yI0zbd0QODjCcsJX+tsVIp1u724TXpzP8YIfDovVoJDtLotXD+Fde",
-	"n65NGv0JLPOBuMRjdyr1wKtuCov4sQo3CRbHC/UIPUEyOZLPknFWrX3cSF/zSzktp5HKIwFJBWcDSGPZ",
-	"WkGZ527DShtxb9DtPd3d7Xam2Db85f+Uiv6MlpVUTozhDveyN9Y9/7Rnz2TR0+Tm64GiKExnb8RzK1om",
-	"cKCVk4o8Bkjv1SQI/Ath/aDozorp4MeN+Uz55Suhxp5ZPX327zCF+Lc/EM7vb2ev89+/7ff+i/f+2O19",
-	"+676Z/+09+7Jvy3YkZtP9t0WRTqea4gkXCHPXwVA6VjeMrDV64m360urrYAGL8zqCtLFpZPlNuKRMFAI",
-	"G15jUllhnO0GVBrk4rFctmU8Ndpa9GkXeRAAXiwwzrwV4I0Sp6cyxa84nHxQ1739VxmyoaWaDPVmBZpd",
-	"XopiK9wrV2heZNKT5bB03o541ism3Ib32aNnRweP++yFBMR+3uwJVCUvnLTxlqVgmSb74a1vgVthnzxB",
-	"2xYmCjF2aOuFUtE0wke4PsRywiqFEthQLgCLf3KpHJcqXCx4PRBu0sbgfKeph7XrsX1cMbopgH1G7I22",
-	"C1S4Gfneb9evUO18O8p81cuVNPmnWxnA8mN/4FeyF+x7T8JxsWoqsj/Qz26wRP6GY0PazEQqLRWvJMfD",
-	"d+xcWjmUuacGbRiYCqksuMLq/+fCQJSRdRJSzcHjd209/ev1n/yk3ctwu3qT2KJvKh6Aq7GyvHj1stc8",
+	"xb3Vcv00b/ngaYNk8odPOQlm7dz5o3S9NSklUk2EkU5k2FBM16zyPqs7ueUBs8dwgm9KC50j/09RNh+4",
+	"/A1cz4JyZ2iLF8jrVhS6tXx/BZHuZ5kf7FZ1Ot/BvrVyrKa+rdbchCWihMNn90y7g9HeT73uDkTJH1mH",
+	"gyO1qL21JHu36G2bp3rzPG9N914SXdEqaT7bBO4HSt1O3vgi0V4/NXGZYNr0BFwlW7w9j7f9KKzPDf88",
+	"k8IrHf3PmhyO27udnPCr09IP4iHx+89Flm0J4BvT5E3FknyWid/XPHNU6xK12qHOZqF26kK+dWtu+ENS",
+	"+J8hKfxBV9xGLvqGfM0re9nQq3p8DFMCau8NS5lnwiyH931nhWVcsVevXgP4SoQJp/rPFXwqAZVLBLyX",
+	"Cq+mqgLq9VPWxwJ3oVpsRmePKtCUVmQV9gslvQNIOlFa39P4qROX7pR6jef1FFvCwnj91gJnpRVeAo+0",
+	"AZDa7/0ShHiFCLFOqXBxKQA1PUC0qzEjplt9BHsBO/ClZUgvUJdtDBB2zODNOM/9fI73f2CFLEQuVSuy",
+	"Osz1e9waaGBLvp16P3cE/tocgi3zVg6NCPmeWO+Izc3XdCFWBwF2geS1iZcCQAe3x/RIubg7rldHUQ1r",
+	"4zlG6vUbrHrx+Ma5IVCN5zFVhYQZHt553lTjifDWaTxuto01xrO6ji2y5y/3qSAhLwqjeTrBKzSMgqkU",
+	"h71EpTk3cjRj//r//z/Milyk7tQ6z/zG+MyIkVSC2Jd/IC5FWjoAwH7y5EcxYy+Fn5awe0+eUD3+Mney",
+	"F1p58mSPnYgp9+ymy75//eybLnNGAFoPLyZdFvBZAbdnMhsamdXrTxwRQ/LtHEy4VJG3QRYuVJQUyiuJ",
+	"tMG+8bD4ALHuKR/W39IwmIETbQmn/ACWgGgQMdRRY8MSJj0oTe4ZKS5CJi2fDuW4hPexiWPBrVa+Ixgi",
+	"VrtAc9E6UVhI/VUsK6lQGG0kLuIJrpSMSzgIAx3ssZ9F6rRhVk6lH6abhalhJkFVkhI+HE6ffTPYYy/L",
+	"PO9RlhS8DEvl1x6Kiko1hrfDyg/22EklELFoJS0yvOdXdLDHDh1Q57nAJVb8XI4xbQmaxxMgf8dHj474",
+	"WByqTFxieTVY6wFs+cAvDpb4sBNZEKU6w8+FsX5RemyAdDDYYwd6OpRKMBsXCXs7Pn6JFoLh6ozW8eQF",
+	"e3HuWd7bWVFbTCeKUyAE4RsM9AQbw4ZizBV7ZIVgJycvTpwoTvBNkpWPqyYKo8dGWOvboH/CUKQChUIU",
+	"jWbiKwvteE4GqRkLgxlJJe1EZI2GDsLrjZbSnFsbiXawh3oIaz4mOsfmDho/vQ1ldOAvlHDYsgmkjFQh",
+	"+BSr3BN9A1Wlk1KdsUdox+FnI53n+qIsBlWNmIzhw15ZVGVsGh9NpPN0pTJ5LrOyViioMXKY2t8kjc9p",
+	"nZ9OdeYp8q3WeSyD6p8RC6stoX/ltc6I/vyhG+yxF+c8L6mWjj+LqcX3/fP6WmRaCaDWoCSFvcPX43NQ",
+	"hhY+DMYmZbA6PDsj6TnL0AtEkfWAtTOhzkWuC4z3HWo3QXPPG7KeqFOtbDkVWJdnANLMTwKkmk4Bl7ia",
+	"MDx+3FoXpz7abV3LzS3JnShvbfuC4E7i0u2Ic6i8C6TdbHPeCeGVh96J3yBgK56X+4/67ISW+hw3r5z6",
+	"jUuU1yqgdQjmRrRmNxHSsFQbnC1o9DROLK847xNpKdkVqA+JxcQiBLeuZM4PJFYWuDu1bgu+4zBLoB5W",
+	"2Uo15hReQSCQGhfaVKUb8vSsLJYrclVmNL4ZANfQKeclX+X0wmd99gL0PDL16DMCHLBgUqI+HqQ+e4Qr",
+	"3mXSi2lhu8xOuMlikT0ei8Hs5zn9hh/6XfPCTWS4Ar9bh6Vb9pnSqofmB42gKIe5l2p+LmleWidMLxfn",
+	"ImehHDnmbfOR83t6LswsUVU+LcwnzsZ6Fapy7cUWiNMib031dCpdoqg+rcqgLJ/JbMW+xWUBYmInCmPq",
+	"KNWlcrbP9tmg8KojzweJ0oYN0FoYMO6cnx4lnUNKbw8/zSQfK22dlybD0rFMCwvGD60A435e1mmYQK3c",
+	"YSzLzvbDCuGyKl3JM9p46jZRg693dwfwmi4duzAS1NxILn7sI546cDV8j88OnyMUhZxOS/KPHouSytCy",
+	"w+dY4zaghEwA7DvsXuYtBRxaXPSwBIOvd78dwDrngofbtljKngZUqnTC1Vhk/aD0asPHgr3SyCSCuub/",
+	"zrEmHsAJ7rGB/2NvZ2en4G6y4zSdHajAtz/lv2vFTr7aYwP71d7OzrBMz4TrEf7K3Pu+X1qLqO9Ct1Dw",
+	"5kNOQ/m4k6h//fP//dc//+df//wf9gE/P5XZx16g33CEoJA+Y+zR/No89i38k1qoKvf1bKqLSGvhZUu4",
+	"QbNc88wuK7+DA98WXgGOH/u4I6k9N4bllXZoC8NJjEe4zw6V54ou5FBBC17r5q70avugUr0TJS0DX03N",
+	"cdNlFxOZi+ros/rJN6LQxtVOfKL8T970BanP/FEcT6hz9MdIZ0U+YhfcMir6PHf720/UT5771YbW4Jg1",
+	"hjFPY159qFSA1ZVhvudVYmuEIFr9SYAQqon31R8E8Yx604srVa7BLX1Nx+qdipXObt47Q8TTlKVNLlsT",
+	"4rTop1Ou+Bgqt7aI8eXBOK+kP95aiaDws8IzPT2aE4XUDpOKCpbHXe6diZmXQJkwjLu5667AsfrR2xCF",
+	"Ox96uSC8SoCNJwp1AcQfEGH2AZGoy5ycCuv4tMAaIuQX9zY59HDELXB2L8QIb2WgxKU7TUtjtRlUHL7h",
+	"a/JdKSwsOhZtBcX9En1Py7gmODzIjDBt3xE5OMBwwlb62xYjnW7tbhNen87wgx0Oi9ajkewsiVYP4195",
+	"fbo2afQNWOYDcYnH7lTqgVfdFBbxYxVuEiyOF+oReoJkciSfJeOsWvu0kb7ml3JaTiOVRwKSCs4GkMay",
+	"tYIyz92GlTbi3qDbe7q72+1MsW34y/8pFf0ZLSupnBjDHe5lb6x7/mnPnsmip8nN1wNFUZjO3ojnVrRM",
+	"4EArJxV5DJDeq0kQ+BfC+kHRnRXTwY8b85nyy1dCjT2zevrs32EK8W9/IJzf385e579/3e/9F+/9vtv7",
+	"9n31z/5p7/2Tf1uwIzef7PstinQ81xBJuEKevwqA0rG8ZWCr1xNv15dWWwENXpjVFaSLSyfLbcQjYaAQ",
+	"NrzGpLLCONsNqDTIxWO5bMt4arS16NMu8iAAvFhgnHkrwBslTk9lil9xOPmgrnv7rzJkQ0s1GerNCjS7",
+	"vBTFVrhXrtC8yKQny2HpvB3xrFdMuA3vs0fPjg4e99kLCYj9vNkTqEpeOGnjLUvBMk32wzvfArfCPnmC",
+	"ti1MFGLs0NYLpaJphI9wfYjlhFUKJbChXAAW/+RSOS5VuFjweiDcpI3B+U5TD2vXY/u4YnRTAPuM2Btt",
+	"F6hwM/K9365foNr5dpT5qpcrafJPtzKA5cf+wK9kL9j3noTjYtVUZH+gn91gifwNx4a0mYlUWipeSY6H",
+	"79i5tHIoc08N2jAwFVJZcIXV/8+FgSgj6ySkmoPH79p6+tfrP3mj3ctwu3qT2KJvKx6Aq7GyvHj1stc8",
 	"4QJlKFJeWsG4F40ZlMvrMqcLnevxjI2ESkV3fgW9qSbAAeVNj0YZwdWrcOI/zIW1tZG8ROusZoTUFgZc",
 	"wUXO5dySrHXHAgqh1iaTijttwLYrVY3Li5E2ftZpk4a+A50YaYOPxBaQ0JYep7rI8cbBMqckiaO1qQXB",
-	"Ep0InrsJK/LSgmOwp3Qmusx4K6ALwXsy5bWKhLXd14Zl3E6GmpuMnUtxYduLgtKItu92eENDa+UGNN84",
+	"Ep0InrsJK/LSgmOwp3Qmusx4K6ALwXsy5bWKhLXd14Zl3E6GmpuMnUtxYduLgtKItu92eEtDa+UGNN84",
 	"/GDdtEVy3zIoKuvVC1LipR/x+fukCkEBzbll3FwRqgyR5ab2C1VO4drRogMlZcEyqllFNjq3BdUFl5Z5",
-	"qmXeOjeJcrogk3xQ+2qwx2So3csKo89lBsAxF2IYDNDqaaJix4c/xwgv0scOnh+Eg4GCDoBbQkSYYGTc",
+	"qmXeOjeJcrogk3xQ+2qwx2So3csKo89lBsAxF2IYDNDqaaJix4c/xQgv0scOnh+Eg4GCDoBbQkSYYGTc",
 	"VN4rGYbcC+VAfTP8XMvMMpvri9gzXEH4lqB8ONn1/4GF1rvoCVichG8fr/ozlsP1pDZMOpuo+WLz7GIi",
 	"jCBThz4Wl4W2sSiM1/T2jw777KBauUSBU3nEZY5uAbgEA30R/WnhCgGddCzpwK1O0vH6rBM8Y3qEfrbg",
 	"t7iYYNo1obuy/fCpHrGkU21v0mFTwRX5LGqGMcJfg4ve826lHcy8Vxg9RJu0iR+7xGdRm+Q6v4WXn7xn",
@@ -56440,434 +56776,442 @@ var swaggerSpec = []string{
 	"t5IOhnrgBNuMVbjF7FzJ1F82VXFZcAVAJfVC/ec8L4XdYwMksQFzOlGwGRhqU9ErvBCoDB3mwa/rp15t",
 	"YO301Q5wn73yxH2hzZmneF24njd7VEaGT2+Uy/HEscLzALxeXL4stEVXW5gTAbmnSccr30kHYLxmBfnU",
 	"mJ1o4+hes2dl5m2bdCLIc0N3Ybg0jaV81XgAaG9kjVlhJM9BQjjtNbBzoRycg1DH2IiREXbC+LTIY1wI",
-	"UU68uxppkwK8queReLjgPiz6GY3INV9BQ9TLysXapguidkxXK/xRLNSlxYOgv5bPoyZk207jtQT/zvvq",
-	"j1OZfdiJzGHnfeTOH5Z7Sw7VuT7DoPGKrVQWp5uYeHsTrwOqHvuJimXNBlXPTwZw9VoHKevHcGzaIrjh",
+	"UU68uxppkwK8queReLjgPiz6GY3INV9BQ9TLysXapguidkxXK/xRLNSlxYOgv5bPoyZk207jtQT/zofq",
+	"j1OZfdyJzGHnQ+TOH5d7Sw7VuT7DoPGKrVQWp5uYeHsTrwOqHvuJimXNBlXPTwZw9VoHKevHcGzaIrjh",
 	"8zIuUQMMINljngkMyIXYEKlfWrY07uQ75PBY2jDuKslSckZyL9hGfngZ5rW0SC9cicMwiYO6l3dOjrUk",
-	"/jR24eP8wnFFHdhUURimvOBkYZNk6Cfl7u5XaZwH/CkGS3KTqiS2lflJqpx6EoQQyk63E6L+4SPD1Vmn",
-	"24FAN/D3O8NTDJq6iK4bDrCa3uBMjRyKzrslQDI3mTmEs2jJHbrZi9qrdH7VuCp4w6tz1TkUSOcXE6Fq",
+	"/jR24dP8wnFFHdhUURimvOBkYZNk6Cfl7u5XaZwH/CkGS3KTqiS2lflJqpx6EoQQyk63E6L+4SPD1Vmn",
+	"24FAN/D3O8NTDJq6iK4bDrCa3uBMjRyKzvslQDI3mTmEs2jJHbrZi9qrdH7VuCp4w6tz1TkUSOcXE6Fq",
 	"WOqkt1SHlO7I+5uETR0u6rotkVPtkU41WtSmterFdfk0wdMvG+o8M/HKCgXvg69k7qBEMZ2JNOeknYfu",
 	"ascIJcSzVT3XFgmvrvHae+Mb3NgSOGCkUO6AFzyFzm9YxCD/AvBtvG7zA+JOelulIqnG5dWG4mZ1cP1x",
-	"qZjAyFFtrDcfadEoLCoE42CEPIbjhLSitzG5hzmBplLVVDf82z9OsaI0hajDrqM7R8SgVXKBV5FqFMT6",
+	"qZjAyFFtrDcfadEoLCoE42CEPIbjhLSidzG5hzmBplLVVDf82z9OsaI0hajDrqM7R8SgVXKBV5FqFMT6",
 	"5Al7RLsPDheVnTpTuknfiFycc+VOvdGIAVGk1/gnj8GBboS3H7twjwUOqy5TWTrusqkxXTblBXb66tXr",
-	"Hre938tsLNr6xR9QAQgNQ+ep6HqacpNRmSthbTcGboS/JmTngH/MzbpsIvKi9rYxInX0B0TTanX6j5J7",
+	"Hre938psLNr6xR9QAQgNQ+ep6HqacpNRmSthbTcGboS/JmTngH/MzbpsIvKi9rYxInX0B0TTanX6j5J7",
 	"Am+RchTjuy0nO4YK30mgTBWl3Mb3arHNVXDbnSYnVYQ7n6cUwcoCy8L8uMf3J1MIyXlbqUInjquM51qJ",
 	"+iIFl9GmsaRocS1lWy8wYccGblS/vguMId7jeYt4wuH+LIB1e5lCeZC4F8B+vviCUg5eYCiERfYwn3kS",
-	"wuv8fiXqfaKYN4Eheqqzx5LOhTyThcgkTzpd/HE+h9K/9z7BFcBvhjqb7fldLp0wSecDfQiRAv6Np7uJ",
-	"+kBhdBBqGNJ+NhsSXEf4CYURhWyc2oDwrZFMw+1gnssxiJ0akVYtUICt//K3pOOky8Wpn8VpTN9JOu/m",
+	"wuv8fiXqQ6KYN4Eheqqzx5LOhTyThcgkTzpd/HE+h9K/9yHBFcBvhjqb7fldLp0wSecjfQiRAv6Np7uJ",
+	"+khhdBBqGNJ+NhsSXEf4CYURhWyc2oDwrZFMw+1gnssxiJ0akVYtUICt//LXpOOky8Wpn8VpTN9JOu/n",
 	"p/Fsbhp/g5SY4G98dHz88vG6qRRGZ2Xq7BUWN+eF0wUbg4ZWLW7rGkzkeOKVFcgj8ZPHr1jYm2ULQMNq",
-	"m309W3ZxcH8pjEzFHhoDz3Z3d9lfpDq1Tqdne+hX+RDb8YyE+vNmQdLpwoLIlP5ZOyQti//0m+big081",
-	"pt6vW3eArakWHedUGDGSl/gC4k/u8XQq9q6wOTx18lzMTVVceq0GhWHrqqGfbI8KwrQcmG/mKO2n5wFt",
-	"YModzPWl10LK/CykhXWZFSqrYglCSh63jD4Gp+7gADlG782sEHv1s7Fz2VOZX75BP1EQuA5pUNPSOs//",
-	"6PMkUYO9EJ5brTCyDb9uLXSZdPYP4aeK5n5LvJEHuxwn/c2HuSYzncKWtW1DbT2TjiudNpLnsJCxvae7",
-	"H5ZF7v6Q6yHP/05+sa0lTFfaSLfTttLN5nBzO3udoVQcBtZiUd1yvvVxbH1prnUzMOBW1RiUgeaKYbR/",
-	"k8J4KpodQOTXieM52p/Pnq3/+K2ywVf+4pKn7kSbzSOcYME+JigXGngjpoU23Mh8ts2w3BDLxNkYTgsL",
-	"buSNNCCMkhYrTDd8IQTuBNTicCOJkVl9dsAVRVyLuQhhzmw5tMJF0wtfeq2zKtHUa4mncnSKF0yDPbY/",
-	"1MYxOWJczZjjZixI0Zorxcoe0bUfZYmeyaLRzsmZLKqEipqqFsZKtzsOPtfnwoAfARI4+RgxZoGGuRMB",
-	"UwcSmarMBNv1jah66FZIW3ETMWUatOPmEOKlZRiGBODQkvJb7EylE6OVLi37XQ+bYDwhdwSzfuCK7nc9",
-	"pOAt31AhjJXgBfKjh5zIqm3/Ku2Syho9JepCmzNhwCsaybXPjrTfztpYsbdamZWQ3ttP1AF3PNdjukdG",
-	"pTxGAM1YOhHpGYZRAiJ32FMFA1faJcqIAgsl4vx8p9y4PjscsRwwpwFDFeOlbQgZgZvSqvGub4YCinim",
-	"Cwgkz2eMKyY8M+hijFEPlYJqExD1IWIjed1HhawgVcWMf8dKZUQOo/QEDintfq/mCQ3ubtNcW8jd2aeV",
-	"4+lEWDagAD2RDepZXFBlI1IZ3XdbuvENQeQ43JiS5ccWb5WgzKdtbBjOC85oKvI87EqiUk1c4Vw0g/4a",
-	"+wfx99wrKX12LKbaCYqNRMCoRFnHx37WkFBbbYmoZXihdw4il/rsqNa4dbqwTImLRPEsgvSrjGWGS2VZ",
-	"deUGew8/QWMmbr694EVBd9yJQpSZHlQNrw5pvzWrF1nf2tB5mMGZmCGMjdPgZclnFJUUK5BCBSK8/g7n",
-	"pM9+FDO6VaT8JR0Tm8nP6U+CkSqVBc9heoG1RhYF7K8fQJls9JZBbxNYGCovSuUkfM/Bvz8JQO3k4T/M",
-	"vFhyQqWzHhZGbI2nfvbNX+fjqT8qTHpriVe0i1dyKD27wXxp6P3/6GF7/nHFMQML5GkqCgfXJrg1MKaQ",
-	"y9cmf3M8oG+PX4UiV4GZt3Hk/urLdUjSnfX2RxStNg9nOB5TMVaN0ACZyDkgNlmRapXZZvMrcgY+wHp8",
-	"FilW/huZim0qcYFS5kLMg7Y1DBmMG3rjiTB2ftfDDeCOPc8Q1vVG0ljXjekvmHeJJngt/coIx6USWZ36",
-	"aKCeNqMgQmm9BB05Hhu75OZ081yWb+ZSWbqrqXLhKvXngv+jFNvMTXm2uyo15Wnv23e/7fa+ffd+t/v0",
-	"2w//1l71rq1XSAbotF3M/qMUJbAYUyqF3DqqG51uhy6oup0UNQKRtV3ALukVBFlrrwGtLgTDvuvearxK",
-	"RVSexFphIaurxjrxXjtZ5n7wDogbaREJ9nr8Yuf973p4KrM16NCkiww94xCjkddO05p+2Wd/BxqMgWOR",
-	"1JicTkUmuRP5LFFgiyGR4quoEHJIAMb0R69tBSV0BoaANEZAdmVtxomq66xBN45KYtrUfZkewr1FBsYb",
-	"CdCp1zgTVdfM0ZmGH5/G63WKQmlTKlHHrqkFt0LwrRFQVMe2riSgP/MaCRI3Lu7Qlq0bINGsqe3UOgpe",
-	"gzcdwoWrVeiFVYDw1yirEG0JMsRnJAIShSaUM7MG9kdPaddD2cYG3+x+NWClcjJHKepN3JjL5buacJso",
-	"2GHKOc7z2XcszSUGJ010mWchuyFG7TIHJgVYNLwKaE4UB3cA40MLhlSbw1S4+0B7xzdBc/eHw/4gWhls",
-	"mNpaIl0fGoYsd2XQVT3Z9duNFYp/b1Uo3lWs34rUCLc6Dx+8ErXIRPwGsK/rUE0UTf4If+7hOo1kLrpM",
-	"qHN2zg3GZGg3edxP1E+eh0d3FrWJcc3sX//zT/SKVH00sHWor2UR5ic0qW1WFIculmka+GtYkVwG0+Yh",
-	"8nWpBkOEuOGhWiDgnfdnYrZBRQuAF4XNiSZLjbIvjER3zwIN9xmgjVS5HQg4EYIQpjoTEOmK1PzN7lf+",
-	"BcxthQhwemGBXJ/DaJFeNiqKQaRFd5L3Pbr6ujx/u+MnmdHIPuwFuqjoDAIEGzs+t6E3fhKQGiKNXlm0",
-	"tJLKmZhRnQKMztGFUFz2eSFPz8TscXsk8JmYrRRHdYnDe3/s9/6LIBX+8m9XKVeAVxFh6QkZ/E4P5FHp",
-	"aqfx5v2W2Dhksd9RFByOYHlNkyC7tFke/3Y1j949E3t/Zg7TPHFXELMoltc5E8H3xvP5RGcy852ciqC6",
-	"tdkuJ0H2bztnmTpakbFMqttDGtPH5CtfVZcjELGKyBZV+zcBZ2yl5MMqGcGLPiT5h3FkQQxiNN1p0nnc",
-	"gKWCh0v8vNjA8juzb7rrU3cWhmbEWFwykqfV4P4bBtJ/cnoOxtxf/m1+oP9dWmFO+0+WjZUE9JLBfrO7",
-	"e/Pu2Y1qFcIOnkSvwLpChfsxE5ao47OANoohMrXDAQ9WHw2q3AcV/Zq2zpxVYXTxJtaZWmdSILptZnRR",
-	"3IzEvzeL7dehpY5Oy0p321nOD8ItWcebk0mNA7GsFkgmHJf5PfDd/hBDscKQ1qzrSkbtKTlca4ddWlYz",
-	"zb+7qYuslRcvrdxcYUYrcUGzA9d/CGog4HGWiZFUkN5Xw35e8E6FMP+3VrADbkOE/4mcxqtdiDIqVa2a",
-	"UsYdb42OVuX0FDMLILy6GXD8phrraJMEgmZjX4UYdaxuBPHPijH/KEB2nxKV1n5kVah/42lrS+EHvxcY",
-	"VI3ZjxS7Xb1QxGzJha8hDj5redxsGPd5rmF86bJH+JIAzEDB7WdidqFNlnTeNT/40J3vHPIObrx/v1cY",
-	"Ub/5SIY6m21pIPN91//8MLdZsRlCdOhJ1eN5Xk/TwJnheGtNx2bpH6HlJNzon1bziETmX/mwmBARiRUJ",
-	"/lRml3NkWrUVY9OxNer/w9LTdL6keswGp+obGmkjT8KP4QizN1hKUZII39LMsalyZ658Jik55PbOZMhG",
-	"udOziSkq9+Bozm33LZzQ7uKGQJLOms5VOR0Ks3nnAA8l05vkEFVeUTOZ6Hp8IhL+ej5BOS+rOEWtMFS1",
-	"RJQXhW80xlx7Bb/0Szt3AkOKOB22POdT3lj/pANoDcT28rw3lUrm07l3SkNvTJwr9nZ24EJ5oq3be/r0",
-	"66++DpytWrMFFvfFF+x7YR07Mjx1MkXNpMeeQ6myoOR41SRFN6vICVtp6qcg6ilr/juo+ETah7jwBj9m",
-	"QPoW7NQbOV6rscJZ9uhp7ysI0vdK0VRwJdV4VJIVRNd8DcOcsu9qOWGNDENo60ArC6n3HDYMg90rPQii",
-	"95GPEzXAyCb1dMC2GA7QBt/UyvTeeOxq1cMd+YDf0EX5EmsDw4mbtiDu89xVMK3rtezEG4dxrIVAb2Dx",
-	"rbKtd0IVkPUeT/iIkO+q8qfheyaUkekEagbW1w2qiyYKPu6yCl++/jpBU/hFhhS/4SwsN2FNSYJoi515",
-	"0jA67xU5VwLAIb9jpcVg/FiDJ75tNCQ3A3QaVH9I1JS7Cv2qqrKBtVAJPT8l6L3Y4rJb+H3q6EU1p62b",
-	"0Yt9Lg0GXNyh2kX9lW8t75N3ibJqWkiwdiKAlO7OVl8RkrLqOO68D//EH6q5rb/6t9XIl5/XysLvUykE",
-	"qlhiRKpVKnOJvvfMQOKK7uVajYXpZcICDkONmowYSyi+CIBogNAjHZRPgZBGp1mmmdXLowIWibnzkdjT",
-	"6yunt5wKCjW4PSjmb9Z/8Fq4ic5+0m4fIveyzyURIAQAqLbje39Pb3dJ1lTLAfP9LEEfqx/tqzGPJeEF",
-	"x3ACIW/sKuc+1PaqsgAbow+JoHPluqaYhtZnB1Dj04tMa0WD/XoBO4PS/oMqVx62MgDbOe3bqQ0QFFmo",
-	"vR437kubqIB2Wym70MySgIYljGQL2D6xA4SF3AZ+/rV4mCFKeGBjt5TPhMuNhYbhtFyLp11PKTCCSoZh",
-	"oNK9YYr13iIm9RyP2AZrXIbJBkUyqbpW5Bk89zvGpQFMXFT91YzGiYa5MFCmNVGEh0T2gNEXUIfrTMwY",
-	"lN3qg7GPta7OxGxQhVxGQGVuMdAeMj2II31p2cC/Sd+gF7bIRUAcplSttFZaqJ+o51WllDABModyLwAo",
-	"1p6S49kAPBVUgctWI4P0ahoalBZEmGGswBQwneqDJWzucioQKBzaTZSn5UKoTCjnLWev+9mUY55Lzs1Y",
-	"4ItVDdLWBGUi4+dkaAXGdszVeFuuifm+yElBI6l5K7aZVrtuECsqHBI5RxaAqXvWAmJ5TL59kAG3IQNo",
-	"Cxif43YBRo0MVUPkvEmhjWuJgV7Ig32QBevuv0OaS2mF6Y14ihiDwE1/10NyBIXxBgdQpR8jVAkkKWWA",
-	"XGmb8NB+0rGeozA9LI2MHSSqMHIqIRkMkBaGMzaoNnGAF+2ERhPzdOtSIFHEz5nVbKItAVFHGZAiSI3n",
-	"1S08mIZhExUAFlKd57xAFkIYJ6iKx6pfBLnjJR523cbHwUu+wMPDvEKi1vZZeb1LGNMdcfPG1FuzxwLj",
-	"8ITk+Ta5ox/Y9i2w7ehGnz/lNcdxfYO2zrghIfkQ85GXxWitPV1b8jl/HGnXUyO3T9X3KkJ4Q+JajCBe",
-	"pLHufRfrC3O8abneUh6gvobSWyFyJBGNoz379DC7DW99+8HeIV3hE9DQPsetXOkgqBfgrrsFwDhGWzqC",
-	"jZU5+EGrFPsFTWgfN/rT5NZgQBL6oBNmKhW/8RqbHzdCOkcPetJt6ElEy/dQUdpBCI0Hdnqv2CkiwxCW",
-	"fLmeXADphteeAd+VNlGBCRFuTrfpUQ2ACpBIG9ATCWEH2PJ3iZpHwwkIJQhE6bCrCvfRm9O+uf2jQ6YI",
-	"taHQBmod1gBPpIrF4EBE1EB/lkPlfJqyoEIz0mZBKPTvWio0gD4jatF3rSQBWzWhao4z4QigNGO8iZkU",
-	"AZj+dOYKruZt8HmC+bsy34aSiAEi8OYicpZxsu8REvfwOSKbyum0dIgVHC7OuYqHgrCQRcYOn0feNPh6",
-	"99tBxDEFMN9w3x6v0wlZeoFtYO/bjM7EHrZYAb6oFQZ736l2vcrtrIG1t6SUrr8Cpy0KVAmRDdzdVDr/",
-	"9Wqrr/4ANhSHfavgntjla0L32qbCSHuymI14ZS7h0sk1mMQo1sOqV/nbBruYP7AunfwaS/9t47y6dLLF",
-	"47pB3ysuJJsrPleG4Sa1hLVDOWiW1a+A2cV37FxaSYUjtTfxjZOpLDhEzhCSurQIm84KoTLY81tlH7U1",
-	"gqKJRc5le2TQ8sqGbyaCcPrpJKTEagIQpPV2I155+V3wcwbQ8izUEAw1jlkK4QRYQRAVP8EuJgIqjIbr",
-	"oR7W7j/mIwdqMqClR325z/ZVDTxely7VU0FA+DFEFKJnZmyYS5VRJEGAJgwYisoBVLrSqicDurcjjHZt",
-	"phBbAHUzNmDDz4Wy4hgcPZ5fFUZYWxqxMSs+8RZGLqyFYoYcqgi+5DKPbXx1U3sJHAVi2MEGikoZ2nRu",
-	"Vqv6qE0mFYc0EMtcVZajgc5CQKHBoInHZGsFO5ACpScohw41DLSF+ogfLSXCetzxvfdSJfIk5cqyMzGD",
-	"kCFeS7qG8uJV5vWZmGGEQCi/GKzbKQQPKXGRSyV6mQCMaCreyx5hMaXHfVaVSIonheM7qD5RgWE/+8Gp",
-	"zAbzlDSSWOcgjiifeb3qd6xzHF/GXKkqMaOMZSsTJR3sGmi4eBnO83xh7rVaKX474OewHrgCrZfLKVc/",
-	"ipndFloVNb/yqniVVd5eQ2mOAlv3sIsBVbB1sm3TPJkkHcg+xeXvdDcrztTsHUo0jLy0YY+wBi9WgyYK",
-	"+tPZu37LI123ns7qTN4Af6qAG9sxf7Q+KwusVLGSjXnthves8C95EgqoMbUkRsxEDShzYVX7iTococzF",
-	"BCcv7eteNG8sVclO7AQLS1ko0UqYDtjJXoAK6CJqU9Lxr/xEFRW4m9hQ4q7PswxK5qTSzfC1X2Wepdxg",
-	"K6dQPtv2n+BvL0KhOvixF3/t1wsBwnD8DHheG0/1hu2e4iZLYbvUhP+qASpUH343YB73YY/bYYawp84V",
-	"nbAcAnOgTJFKZ7HkTg6bjUFEIcJ9YATPMEh+UKWsIcMujPREC997PsGN/INCebhnxgPreC4Gnt3qC89C",
-	"JtohSOBwBo2AMlfrOgCPe+2r5xthr06oEnwr7n81h/biBJ1q8H6ZCSi/8RCxpE9zQWD+UOZsC9D5VyyK",
-	"Pr9jUF0KuGSzcsn/7VEp6V+Esa0VTOgH5vSZULTV3vSIB+otZChKi+C//nj+fHCA+isqkImCrYA8YqdB",
-	"4cZkx+DMnOpMjkLt0H6iks5u0mFSZYD+jafY86xY9Ru8TLivK1TOPxvnp7LYcKcV9JrhjCEU6CcSgPGj",
-	"mMVbpjAHMKNwatcDO71a+MOcaLtKLvGqu7FaPi7RfQP+FDRNvpCbiwpp7o9OgJ3PpAWTvpmTFUolJIqy",
-	"gbEMOwU6hr7BqDJyPIZqro0w62VpwPO3F6/DNNZJ9ODLIKApBrlbnqkjwQ4qIT0raunKQeJrlc/6iRoY",
-	"fuElgI0KgGUaa76ELwDcUqB+iUYGEIINqZ88m0rFCm/lY4EyiOefA2OUlgnl38+WywucSGvxlHAKux3D",
-	"L267dMqyLVqbOx3X/NqZ03/qGAIs3bL+wH867PdImFQo1xMq1ZnI5tmRlyX9O+XBcyEU6wFtA4VDxFOV",
-	"U4Isoz0ePu5gN1G2TCfemqwLpF6ppGOTUN+WiUtnOLgTqN7X0fOXXfa3N69fQdWpLvOsHZI8gbVRPVCv",
-	"CoNTdsJN1uMX3IjvQtR7Jopcz9CAwxcptynmLMF4uOMMfZRQaURfkAxq27X2aiPLOMcDb7/vvH0zvj6q",
-	"+PQDY9+csR+iCrUyaGBaHZUH5n4vo8duRsTc23TkP912LruLoDr10VUQ3ArxqKIMCeJDhJjnKhtae9k6",
-	"LGWetST0xYLS86bZgS5m3YD1oE0X/RzCdNH5kRo59H+QeqANZsBFLYKeewEVRgIROYniec5i/fsrpRZ3",
-	"7iIPbNWl9XE9kXcxh/dBKN1AQu71vfgB/m0VYv8hvXMb2PLQ13Ww5ev4gBX3/fShwDwnqM9t8V75k8IB",
-	"o6nsvId/bASDf0h+9rYQoHkxkInLzxgGXyElBCNzI0JYlnC5ZFVvzmxpnOTFk0t7dW1Q/HuWDikb0/l0",
-	"YL7qvYULrZbe4mm9mYhCTFGuSHBbAK3Qwx0FFuIIMpzk0gPAs+zOgnqvqUldub7/RnFrJ04bPhbHApXs",
-	"F5cTXlr3OWWbZRUDBwSKDdj3SlE6FWYs7mtw2EylE6OV/AOtrjMhCob3zFDmb6ZSjAASl7hr6MrEvbcs",
-	"l2eCnUx0IUezbqKOtHVjI2yXnXwFUYFczZgF2wiiW00wfftsP7eanSl9oRi3e9RqHAyc426i/OMhtwJ+",
-	"AvReA0vOc3oieqmeTr15DQ+gHsj32k2CCYjBftZJhf7FaWkdG4owqOGsQkvxRjijkEEAUxGid8FnDLYP",
-	"QlAOKYJQiQuajkURj50B5naBxi1kWsRZW4T+xphDWt3QANSYdvV2wBVNhUxCkCdLyt3dZ39lhzHs9MmT",
-	"PfaTxh1Cq3ko3IUQCj63fXYS41qt48YlCrURNYMXmPSquBPGlAWarr6/WEfFt+5pg+xdBGKlzbCNZd8/",
-	"OrTsUaAB9qvWB/TTY9pAlvMzwcQlxPIAWVxwIyYa8JKxOJfTYVkgwERf9HKOASsNCHEa5a/7xz8d/vQD",
-	"rgAF8CKUehWn4DfNUmmZc2FyhIzEWCrbT9QJIZzBTS2u4v7RYXB3t1yvKsHNazjJVxWEFPODttsfEhJQ",
-	"akFgnvbAaT7UGUF/H2CDvRcq1QBWDZ91OxC24T/PuXWnMMfsVPrxwaCAoCjtxW/a3i6KSWIdr3jhtG8G",
-	"ihd09r799tv+t996NSe+/qz2+mu/QdXbz+BlkI9VEHGcxVvl+bUR1oa4UBhd8OLcl7F/6G6oFNT2+45w",
-	"4xsjsGXeeo0APzP/9bIaxbegnzzdQHAf8VmuefZG61fcnyH4bgO95q2K3rXXIpP8jRds9yqGsyZAgdkB",
-	"l43SMgjKikHWZeRjRll8FFOHh+b6TiK8KLtWVmO4Y9t+ltLffU/bzCqEDuq1D9ZHSW8UzHx7Z59mEFpv",
-	"OfjwxlyK073JMPxbuG8/AKS2Ewi0BPvi2ZVO/ItLnroTbTZ38cCyfIyBgcRZJa5s09LAPaxVe5g3NOBM",
-	"XuH4I2zMjrS2FPc1G+UV4NgE8EMCusnE0NWdphRLhzPXER5RqKzQUrlEhZgFcQmI4rV7NNutLpPwT7Tk",
-	"IPCuSzdLCIIoPGXQMzcRBtOSmmELbJOoBag0EMIWGB0vNoLys5i57UkacB8oIj7qezRTIyAqOQm0b9nA",
-	"eTnp/iNMBuF5w7rFKQLCBRPKAXoEpL2FLymQexRq8kSsXq4yvIJbFkcYQGC5NIdIS9th1LUufLfXzny5",
-	"RvWSua6X1+ehRYMzBYbTZwz5s70KKfVVtNfXb4jB3T3I7BXwXRsLEJBdERQVTF017gWEEHrpQpuzfqIC",
-	"vivhsEZcVM+ueJqW0zLniLtaKmQ0CPYbQMQIoypRKc9zWwv+D2yUSWWd4JlfpeB60aVlA1Oq2iEZUCos",
-	"jq6C1Q6XXd6e9zwxBD0rAX4PZ2Yw8zDupXitta62h9Da7GQ9JuvulnpuYzT/Rw9rJlxWmoDQgWASedjJ",
-	"G0e7WT+044psQzQAuPUI/owNSwdZHg1AngfuuJHhCBX9lvOJG+GSmyC6tpy/OzsKNXojYMM/I2Qrvxox",
-	"3Kt7ytoO3joaagvh31PE0y2v0upKJI5NtXVLAUdDYA4g4x1ULvWIMx/qHPrRg9lSwwtYDoa3FKP0nvKf",
-	"Cp0tCDdWTLi9YylsxBSAFQjZUJuwyA+S9xp4oluVufcTHPSuOE+I5m1AHXJXq4tE2xDhD9lLcAj5sWQ9",
-	"MDYS9bseVvBBwmBCijP8XBhbrzrJpKqqX3ALd5aoaM0SVfDSvzzlLp2A9710esqdTGkI6BHi9swCvF4K",
-	"dTL0hYLwYzaDxKDKPAsnUnleQIyiVE7mmOlDg+N5VPFtl1nNeKIGEdtyUIGKTgVXFuKTgPtALUzrDF3B",
-	"Xsg8B4U7XuoGaD+umLj0LEi6UHkDI5YB3TRgioawVPrckrWBOf5xqN2wvH5mTig4LdioZdJVC8bzfPZd",
-	"le2qE+XHBgag00FgUGUy4RfDC4cWyMzloKX3VDjcLirp+qHN4ZAiRUpVcxr4k0aiolcHnQUUsprNGcyR",
-	"2rFjcGAq8vgTA5PeuMAwpbrnkUG6tABV7MS0QFQImj6pIMRvwbPXb3Fbx5wcYZPqaqfmpJcqs8Evn/OZ",
-	"jRHziKHsGY6svFrDWaIGAF40aMBUAZAV5CPW6xRRrSBy2iuNoHHUdXBpUTyMrVL8q3kENBQsWAQ6M5wM",
-	"cqn70UAyCqXwT3imL0IdxqlQrsvSIGakY2UREkKDikxzhaHkULH0H6VQqSAZBAh6AIRlLyiCRVKRUouh",
-	"cN+xieC5m8ywEt6loAuHMwmx1aWC6KHBSJtU/AdWPpU23kdQN2rGCm2hIFS1unDnAfk33AVwgvrccU0o",
-	"RbbCxCa46lIZYXUO6UZi6FiAC8pn8cKlckS23bkk6oqponN5Nw0f5lYvMI5Ldfu+ROh0fXW+BsMCvh89",
-	"jQ8Gw8bpPKWq6akLS/oxQgCc+9eL2KCPgRvcSuDGMXYYQjdWjpiqUp+JGVaY8wyLjwTEPTozwzpj/hTD",
-	"rKSNswGvAwDFARtLdYFf+6nXGIDX641UqSx4jvwk4GKTnRH0YmgcUZSouJm3KcQFdBSWDX+vFi5GWaaz",
-	"HgKiVcs15ZevhBp7Onn2zV+7nalU4e+n82Ej3c5lb6x7/mHPc+ReQDbsAd8TprM34rkVlJe+DQYFq3ql",
-	"ELZnN937Ep31eYwBiDtfpRw2kK9eaey+zaz0Ou+5YG+PX8Us15Z2DUWr91fDpwEu06y3P4KtWaDpcjwm",
-	"hDmd514WZ8LLbKmY9WZaZpvNT6WS03Japwu/6WNhPgby6oox/Z9HOiXuZNC/IcQuwvBfk/fWQOLvVPku",
-	"WzgtRpGf4HdbvBClHm45uu0NEckCR8DhsBJmfzfBrPdG50ASCCT/pWU2UEOgd/hhaRpKhem3Ome4hh59",
-	"IkDZtlv1six0h5E/yzXZffS/1SbEbBjo/Yt2aRvlhiyqtmM7QzHGCPslQP/+59pSbotHVD1AjyutnKdb",
-	"7HY5dbxZXHAGrs1r2zf3hqBg7p4BLE7xOiSV5oIrqnnTnuuJL7QzhDkZ2QrRWjo9Gp2q1RC1726VudCc",
-	"VtZqwFeorOKnTjQwG1YWTFwWXprfGEdCrP469bSWvODotQOn088HB+zRz4WTU2mdTKu75HQGGU5G54/r",
-	"4wvZXdqcjXJ98eTJXqKeepOOZzWUbMyYMGJc5twEMOHgSbJdlvLCRXd2ohhjg3nk3Np1C1mGI20QA90I",
-	"niXqWZ8d6GlROsEujHTCslyjG27ILVRvI1xrniGUrk3UV312Ug79GoDJSbUNAg4cpHXFb6xw7BHAzv+F",
-	"neOY7GMYa3CNQbf43lwlGcsKYVAreOwX7E11G1bH1uGISIFDpC6oqsgUC3KQBxIv5wGZm6tZeBcKlVES",
-	"I9641QlJWsaH6MdFeHj29e63LJgdiYrLS4UA0FaClHv/YenYxUSmE6zmHguDwP77YeR5NWQYbDdsAzeC",
-	"iUuRluBCrryj55KzZ0cH0EKVMxkuplBH8rOQhukLFTcB7xhx9Xr4VobQQD0AOp71cB8uiCRtNwY/tJyr",
-	"igpb77OAIG5VaGOXd5S/1jKOzcR4VeZw3gC40Tu1jx8eXSjjEdigrM+dV/O5g9UKbCIrwWcZuEt6VQ/F",
-	"7VW7eTNXyOaC242q13xHnk2JmPY3L9lJwC5gtl9Hmr+v/XUq18SHLmhVi/pg2+ZVr9TJ5zDr3LIO+BwF",
-	"z1WtiAbizT1JrLsZx94WIlbdigW8AfLcATay3HTZ9z9/unQK2Eur6JPmE7jpA02uDfHzC3VztvMCPS5a",
-	"Q2uUvZukyNvVGT/crsG+VrsIZyHqYVvUDK8/qD+pcnjNBbu6PngrvpTg0tgWF6nAFNu5yInjY1FbXUQQ",
-	"uv88BMaNg71743O9dMWRMutH/SBbN0lcG4u5U5EFyvz4Q2EEzzY/Esf+7U/jQPih3ovjEIayCgqaZ3dz",
-	"Hu5MIP0y55mA5GxIbko/lUNY9/XeyFG0/FygQ3OFpgsxVfUVDx99KtZXGO9KdSW8RDFkD2JivfYUgu0a",
-	"2lONOG6SPnfex3+jENF5PuTp2XK6PaY3tkG53fdtIUL1EV41SujeHAS/bCKD4KuHI7A2bk3nOSxVuw2B",
-	"6LI3fCS8XNhcffp03RL31po4eTAjrq3BNC/Nb+RAwAXu5gfiV3j90zAoYKyfwpH4FYMZHg7GtQ/GBZHl",
-	"6vMgLp1QEDbhz4VU1nEvrdfUjKG3XsSPb6l+zHy/m5SRiV+xaq593IFmIKZsfbFawNjQ6qXbea/male2",
-	"1OdYmEh7uFxTG1TrYsVXLV7s6jCm8G9ZT2zbro22Z353AN9Gte3Psu1Zlo5E79yPZb95bj8/vTti9Nfe",
-	"eMgrN7OeKRXFVs6TAn3EOCt4egZMzyKOwRqKWH9gd1KtRnIMcr9svZ/zP5dG3LPTu4X6KmGmnwYhHYs0",
-	"DHgFEznGBOs2LsLC9zDGj6CgTFrIU1mqOj7HFx74f+0mBZdkxc7RG0tEQMzahNJgUo0BdiWrAKSuu5dG",
-	"rwh8x9plnzkf8JNsYwHbPPJzfa64gTO6WCIkqoJqGysMGxAEAgcsJ4kX6uFoN7cIV2TFycYXGGdZYAI3",
-	"u2V6+LtInb2iMfMzffWJ7ttGplTs+rWYDoXZxI6Kn7ApfMNodVttKfqNePFwdvPHETM+lx9HTIb87Hk0",
-	"TvO2ufRm5/8tJeVeQb8PKawfSS1kHKw++XHsR+Ht2zh51FlV6H+DQrgxkDwYPaE6ffvh4/PvN9wYcbar",
-	"Fm4DJ8b88n2Ocm5hsxY35yhsiXA84473a67HGxlDnHVwHS4dgtKOjXSpslYHyiIRxRFfjzh2QsLVznv6",
-	"15Xo5ZcYdXAnZNN+4VqFQtyPu9YrEGDIk6kR4iIRVIVj5HRaugY9UAMryGGaezKY6kzkddY6b44jupqb",
-	"CPbG8EwifA17/YoVRmQyddqwlDue6zEkUQ6oXfp10E/UUXgR0/dyzTORIYbHICl3d79Kp/lpJg38W+zg",
-	"I7+F9ABx3sRloa03BSOOGBU0BGjLQwYTCUNZVtikGsp2CyqPhBEqFVV3q4yf2voY4YwU563YF09vfnxL",
-	"mdD+MqQ12ApIM2WpEXAEeW7ZhTDIsQKuXO1C5ZaGHG5mQi6smAOxuaVhvJkIVirPl7JQ0bIOVWvieZIW",
-	"vBqlXYNtByUWpLMQRyBU5n9CAFiezVo1hmXn1HZq556eLs/nRswzx4eQZl0d9kfOCMGEsmI6zEWXCtdB",
-	"Vc+TX14/Zhqg0jBleZSokeCuNJ4fwRD67DUwnI/gBImKuMVgjPjfsbjJoMHTBhHIPAcjZlRJzUQVNZ6E",
-	"GdfSsDBW2u02JkJntbMtl3+TcdyZp3Z+GGuZV0Bj+fqWzzyyopBk/2jK85E2U08YOpt1w472oEQOm0oL",
-	"2eSPP1GGepOK6PohR7FUqaK1ap+3NIjvgZE4ranm0CPkBOzp7u7uLjP6wj7+s/F4YsxLmDyO9wbCEWBC",
-	"qMOXJu/sdXYgroWUyfcL5ShlesakclW1aKcJqgMUNFym/aNDgGj44gt2gIWXX8mh4UYK6x/TW4XR5zIT",
-	"FnDGe2OhPAcWGTt5/iPV2/ZN/lwItX90GJVgWNQ930yPPXnyg37yZI8NxtJNymE/1dMdDo1nQ/rHzljv",
-	"FGfjHZudDfCTN7NCnMCc4NP/PfdBz9kBe6SK6WN8/WjmJlrBq/RCAU8G7NHR7OgQsDn28xxH7cUdokDy",
-	"USi0XrhmhfWA0e4mRpfjCUt1JhjNPqCjACS+SSfSidSVhudQ3PpciovI7ADglRtptaLahqUVLOVWsHEp",
-	"Mw7gwlYgisVvUy5VBFeBft49mjhX2L0dmndf6p1Mp/YxiEMyrcbCOanGpwFqqdu57GXSFjmf/YRv/IBv",
-	"sJP6Gzq1fNQDZo3AZL91fgUgkJPnPzI70WWesUMYr5fdUyCF30Xq/len2/mbvmCZZocNFNDGyvm3fp14",
-	"zplyxQ7ZSKoMVzFU4P5fnXeLFRFeayUd1KrPAlLITJcm0Gyal9YJ86UloGV4D491RcvwCvsbvBBAWejD",
-	"8FkEO47kbQTPe05OReASGrFPqOAb9DPhJrN7SHEE9OxJbh/KAGSNtyqIGJ7jB5kYG69iQTF37fvBFxtw",
-	"BqWLIx2VKq1/X6palwdGAuI/GyHsgmV8NBIpbDI1BxmO+Cmo3/AZtt27kJmIn9K60cpDAQL/Ga4fSyci",
-	"PYvrtccGP7x4w3ZwKH/AYT0yeircRJTWW8hGpja8RX8OvB5aaOPY1892d33rWP1O2Ap1GrDMAZDTREqa",
-	"xhExO7NOTKncXi4MTFSqkeFYjqE0ol8/ErSIdUC+xVMRKOX13EstByPSOy6HHPnzEHZKBmqcIdFz598F",
-	"9FM5AvnlAt0hbQkLlSUaB6maO5E6LEG1tu2nhbB0sG6/VG1npc/e4M8I2wlvVABOQLGIA8+mZe5kkcdi",
-	"guFEIRIkoPmgWGaZGEmFTCuuP+rus0LA0YHq22FAND6UQE+eQL1VbOrJE5xnWlqnp2HktSixRP06kblg",
-	"Aau3i30TwjtCVMYzbMW58Gx4KJQYSWejAPLShJ3wkXBwel4oC2cGBplqZaUFeOFQtDEuD36NqFl/iIwd",
-	"+oWRauwbeVnmOXsjLh0+ZbCtfv6eLqGCtRe8UEe3KIwujPSb+30uzgWbInw8tf+9cJ6MToQXJr5pP9we",
-	"v+CGtgKIfeqnCZP0r0GRWqqcozJWCAN9QolJ3yaWM6aRw1Bw4rgTKP2Cwwqg42qYVrTttW1iJ2GXa5oB",
-	"TNg6rjJussbb9S2t9hJ2YzAYeA0wUe8TxVjSCUt9Shpf0tlj8JP/EVKzc1F75p/im42H/rGfk3+YdPCK",
-	"LOl06z/7LfB8Q9i5L+Fb6ea6WWwVvZKNVvGVy17QSTzx+5d/SwDxJul0WdI5E7MLbbKk867+4YducwTe",
-	"RLrRAUzcNF/Tp1cf1/QJNyctXcKFDH7bMsIPmw1xs5UJXtc1I23Z9LUbT1RWuok2yyfT/KLxZ+2PDw1q",
-	"41kwCI4a3QPAeOPNuDJSpXmZiZ5UPZ7ngYyQMLuRQuJSUdfwvw+J+gBHCzH7ns8Un8q0xq3Yo0HbiAaP",
-	"QZkZrBnvgPXYzyqfUamJkRR5FmQAFNEeVGs8YI+MSPV0KgCe37O/Gm96vKY7LInRI47q1a/QGU4J4OUe",
-	"jXJxKYO6ZHN9IQw0fDhCKx35msi64bMaF7UxIgLX6ifEEKfIBEA57KH/qo24BsjaFH7UmLafaZSFGYgW",
-	"3xS1H27tM62+9JbGRBjp2GDJ5g/QsCq4Vx18K/v+GIJcpYb2FsdIR5WGOFh2RuM5Yf1+/8OAeD2x9Crs",
-	"HJ9/URsinNxBomAsfij0DYg8PCyW1n7ml3qiL1Cng63Ejeyz10HHQE2BigBEzQPeiuIxyu8TLHjivwEb",
-	"byXTfecpKJR+jvLJ/4bNY5PNgaxvtcnK610MoFWvUw7YI//yYxDJ1eM+fUem7a9+f1CK97jtzXTZ22xi",
-	"fgj43Sm3pzNdnuK2rhlNtz6U02djw6eD5rOv6NncsE9h704LI0bykngLaFIHejqUChWc4zIX4dwMfH94",
-	"QzTw8mcApva0dCUcXHHpVVJ5LtijdKK1FVDBh1tWGDnlBknpMZoU1QPLHmG7XWr0MViUQ7Cth8CCENaF",
-	"G8m9SvtoENa7ywaL6zVAJtTyA/sLi5965qMvqG1dusYY2SNwhvAsszRncDDMn5VY+6tWaAlv78ArkJLG",
-	"3SNy38EhJcpOtHETrrI+e3HpX7Mpz7kB5zpo+QgoCucQ7YGhgONGp4xJmyhszDNBzyUzDaxRF1j2jV5T",
-	"VMrDDxdQXXuAnwqWAh+LRAU3NxuC9R+8SQNtMmFOh7NBf5FPQNsDtPHqdfAaRxvYJfF2mE2E4XFQLlDg",
-	"vLVx/USdCMcG/t+ebwchAVcbtFtdpsqpMDLdUeV0KMwOVXboJmqodS642vH/73quLLyNv+P/seP/ZR2f",
-	"FnBhkkt1FobXD8wNK0JZLMknw61WXC/Cm/2ODTKdnuIfUNIJKvWhhMtnsPScFeUwl6nfGXDGYK2msB5A",
-	"VtPSOqq6AftC8mX2pW2o19BPovwnnkJofcPLkXsyx898GyIVmYDSf+fCRJHoxLTIPccAE0uoigcHlZxO",
-	"XybSHDxm3tjjU/87YCrhfhbcTbp4ZZMo5cV8DpZSMZlZcFDE0cDkhoIKXaY877fZA5TRf8pdwxJYqgUn",
-	"HbS18Ee/reDEqf3eJMwFeeg/IdZKFBYUEVStujiueQth5ZDaulSLKitx9eonPBALlk0UO3NDj8+Xjn6l",
-	"onjibX6o/EUOOcaH+px8L4NqI4ihwwpEUdZFXGEB9QDymT8wjCuez/zmkxwIzIgpAZQnjUhdPmNhqP1E",
-	"7WdQrG3hdDuNvOP/4+1blxs3knRfpaJnNoakCYqSutteOhy7aknd1lq3EWV794wcYpEokrBAFKYKlJru",
-	"6Pl5HuA84nmSE5WXqgIIXdqeOX9sNQHUNSszKy9fZhYsPVzWzp2iBmHdFAiMPBAXjsYDXDMUuoRycDHi",
-	"11QakykT1/8kYOKbYiU3WDovYnB+1J4lBFznmc4jQgfoMLlwQu2mmGfGVmA7dWs3B6zlWQ4xE+B9wDJ6",
-	"WcHD+JatjkZJp+4Cu74pHqRZuW7WqwILlcJC3ebZXM02s1zdQiz+RLiRo7AREzqv6SQqfHpT0Kgh4X09",
-	"mymV2hbejQX2bop3yDXdNpC6HFRosGjg3o5q57ftRNQvOKn66C8VgQ6bQ6hpwmxzSnJ1r3ISenpOtIUS",
-	"EbRM+AqFo0I1VOZicovaNLzsBg72HTyWpIKNtnnQF17J3F+RWQ7uaDw7uDa505AgVnmrQtMXz2gsfTFx",
-	"0mnSFWgSglFRuUANPYCwQAUFJ9dxMmcyiNqNVL+g8Wnj/lXT87wi1R3ULwfXoJDShoHhi37xil8CRrEE",
-	"VG2cBpAOugX0nSrIFEV1DmW+sZnFcAGgKjT32L6IltPRfWiKnIoD6BRVzKc6/f767FRUcgH3E5Ls3Bs8",
-	"q7Xndb8E9a4Esdn5bgNLyjyuGxo6ObJ91wnA3VdqoU3m5jDP8koZO3hU20zI4hdfAoK4hAVZV5o5xKBF",
-	"w/8D2rzvCMcH5CUS8ePV6Q4oQkRFtCQ8bdP1TOMcNS7ohdlFoAfSx1yT56CSWdEhpQxtzvNcS0difhUh",
-	"KsD2HRnPoCrzTBtFoyMlzrV2bdZqBxgI6V5+QEdOpbvOVioaBut78CVre6R3Rl2jqNvhUkfA3ftC3StE",
-	"j8f2PyhtS1k5thI6WCgN7gvXwamssmqdqp1cFwv4S8Cz0FFOpdMcpTCoNc9xobRdSqSLQ9jzj2Kh9MLI",
-	"cpnNBDwLLVG9YCA0oxZkKseBjon5hVGq1VSBoHWN/wTBP8L/RoSNNn8w54CNOtoam62yXBonPpGOaVdy",
-	"PXUNvssKx3fAmB43FbWQreSCzoT73xS/CIcP2AxcLb3Dn8oPbN2pyBsfGXmQpyJnnCtjOIopVpkncOTY",
-	"2rUtqCbi//7v/yMmkQ1h61W8WrhXHdO84epx8bdE9a2fEw3Hr/uffvFmGF/8/D2qgsHaXivzLeDqiR40",
-	"vkVpsJd55Z3s6eStnNz6y86k1xvBYQFnZxCNQe3nNy1/i/EOmbLwLdrKmEOsZOnkMZp5vDymCAmB5hDX",
-	"/MFJFDzgG6R5w2zFuVw5BeNQF/d4eYLH9ctJ2OyIAtjhRQwyWBcb9iQUCnY9n2cfFS/NZSw3wVSKwszt",
-	"MtobwNhmhTbZIguNQigctPADMUkSnGDIecz4M263+/yzDDTHqMp/kTHrCbMSrSgZd5ziQ0alIBDCIz/T",
-	"FrERvUUTFJ29BHQCYZdo3Wt9eZ9e3n/Jy3UJ11HpQokicS0I/DH+DAjvnbKVuDRyVjmpg+ZGsKzSDQYK",
-	"kjS1j0hfw1o1YKxYUWlp1wQayJhawdbBNmtwtmXFYhRxm6ZtUZGbbqqrpZh77QYjr8EwQpaiRBykabt2",
-	"0dQfongCiguAeaIOBapHUymCc+z0JlBuuCw93wNcC2O09j5lxwbmX7rbXVFTz+aev/3pT+IyeAjc6bdZ",
-	"Grsi2+yKxPSW8l6JZbZYKhMuKDNtKy5xEWjVZrau5FETjpXMJfjxvbUaLWbFXyrvGgfzlKRqPSRV21Yd",
-	"+HJMd35U7na4hHpGdYEMk0JRGo2ozu3BcOqjc2FO8TY0bOqlMt7A5w6wpcubsNlveB/1gwJTCe7BEbP/",
-	"6+tT0XHKUnKtk9PsHgsbcWgdrocNA8TaVkGtB/BZqiUchRnM3QLLwLQBkpsiqY7Ca1tTN2ql7ynRESLy",
-	"FsapPoIKqGE92XUBAQFUCOpKziuRQykprxNB2J04jNEI3COPxwCzhps51kKG8AK0OmDUwqSq8lse86TV",
-	"lQ0CAbUKKu1Fxp2bV/HH+Mre66V/+qQPnNr61/vA11aZ2yx9oVMXDGfyUe9S7Bh9gcfye/0gsgoqO9lR",
-	"r+eIOhAFFk8jEvK3+xoR+UDEzAT1hXicFbHyQydjuhGpmst1XqEtv6ZZQTUrkRXWrZUuQMS82yY9sy6s",
-	"uySYjdgfctHhFiJ0nx9TAbi0Rup4ReRz7SRDpqzIViuVZpBVIzpU4Ib6hKEc0QnDNiC6X6WiszscDuP2",
-	"ASs9Wyn0Ri20D2WEoc10YVVh1/5Cf4jhGu4cXCnSwVEv44AtySEdVf0mBQmlSqbuxMdL/cwhwevVE0fk",
-	"67T20NtS60bil5wh6Opff4KatutHDGKPGKyb5wsGfctNPBeaUA8/YL8NKX3xwF4SQHCFnwMh0XGMyIN0",
-	"ajLnl0ZZJzayonb/sCiYyORfiKv3h/v7+/8ucPKiowaLQV9M9oZ7b5LhbjLcvd7dGw2Ho+Hwf6GDLpz/",
-	"UDyerysPWY6RjyKYNb0ZgFnCe1zm4qZwg2bSsmCU/aAj1gHvoYq7P7TuRhuOM/z6ZuV+fCNWWbGuSPjv",
-	"vV66H/dei6VeG/ztazAdfS1SubGQmiPJ5bf79pslKqruL/fSrnhQ6o7H7E7XobSogLo7AiKShrhE2ITm",
-	"Udo+MbvLx05MLm11KyGLzVFF2G6uKspcdhfmQ8x2UvtsMhCURA4+Q88EdIHVGvE9p0VBzBeWTiTxRdUk",
-	"r5XTBd1t61CCsvzCiYG0DIN2Hyuhigr4JY2ct4LG7tk3dX2qF+JKY1T1C3vdH9aW6lQv2jQURNtPqdv9",
-	"IWy/Vzxqqu1SupuGMlCBkzY7BBeO0etKB84RbbiJY/BmnHApOpNRNaHLrLhTG4v37IvObpcKcQJVnms0",
-	"hKTKKpPJnE2whVIpSlDQmUmm2Zks4LN/7A6HiRMpH712vJQFPAddy91KgslgqtMMD8ZZVmQrmbML2au9",
-	"ovOP/aGYbipSUPnTLq4Chiu+B3nIZJEICvu4UxsuLVppDkgOWmfnH6tsZjSd2C5NOkMPuy4ovDGXEOIJ",
-	"zc5kjmaKVZbnQP2xsooj4kq079RS3mfa0JCuWoV+x+NcYSHQRJyC6E/AOu8jK0WnNCj2RLrGlBgsZwmf",
-	"vEmwObEwcqbcKmU6FYpiVaOam5CHKoyiFlLUT1ANSL1y4BUC2xXULezGw1LlK04FwbhqJtZ6CLijwKjQ",
-	"KSYJLhYcb8EkwzHfdEpOzt9fCEw0cJ24RmJdPT5l3+299s3cgnP9Xubf7Q8ttwJ7oNK4gm5QcMBg/N3r",
-	"PRE192bltrWS+S29/93u/v7XNU/TGZQS5aFt3Qh6PXJJwvnTDRckEQGxQRtFu9bvByHQ6AAyxjCZWEvy",
-	"ljaNdbYu8GQOuUZ+zhBEI80dxdN5/dBvNkvtlb6nofMBUlVzZG5Oq7LakFsDxpjn8XkqjXaMHMLuK41c",
-	"5NKo+0yvbb5p2Qn0PNKxWcpiARVmqcfHl6xQD43BYcDcQ5DNklYvVonb1u44jN6omcxn6xxkL97dwh5G",
-	"lk2khtNslVWxqcEdfD27g0ygpdHeY8UaVa+HoXfn15dgH9kUMzFzX1gOHuesAMgI4SbxABAPgkjsrVVk",
-	"OeLWJivEP2rshRrgQ0JZTxDYT57RGtIeBJFfn/r1a64Z+0kxYgDbCko9KESuCdbfWHnThv88l4WO8y2g",
-	"oaezLWCwL8m1ONLiBMQTuJ8x08DH+tN9iKS7ozOeUz0tKWX/rpjJEpNheCFw1pyq8Rdby9SYKTFV1YNS",
-	"hfA2N7ZmgnmlNQ+DpDz6QCKeieYwN0xMwsZhW6o1ZTlhW6yUWSggpv5NMZWzu3W5YxTI/D5bbLL7LF3L",
-	"PJKGPkEDEzMvagH8x/N5NstUUUHcrusWMIKwutJWrA9QhBQWBS6l8GKEEoz8pvAZUxifRMZJmpB3A9yp",
-	"DcWQlTIzthtMQsqKjvfeg7rCoz/KHCuaQhXpCMm6PQkRqkyTGx8SqCjaI8Ydp2Mv48qx6H+/KfaScol1",
-	"ZADcvLN3eejEo670TOcDAc4GnzLv5bYtZWHDqmHmFvsdboqmtQ5KYluRVYChKtJogtsV1rdsH7sDcUYx",
-	"7yGVFVyHyorvTw8j1Ruyd1QOocVxmVwYIFVOj4rnogpRr1Izg/i5qAoeqRoUwoa11A/QfJfn/CsHkfRr",
-	"3eKi1nq4KV4PxGXcusRkajTgSOazKFsqLYyyOr+Pun8zEFdcly/XuvQaETZCHlUf0ANuW1LG47FRthuu",
-	"+XvMzuTLba/nHW+O7Z1rH0BycHniWb9IxK9riuqp+GD4BDZqB+iTkwJZZ0PBANmEmPNH1KcNFhEVlV6o",
-	"aommIifIMZZomoNz6HB7FriKS1mkuUqh3rqJl4jEjmcBrpV/7A1XliVQFAuDh6hqnLteL7q41LRx+gDN",
-	"TnYkEBdCvAmNg7ngkbYb44CofXQ2wL6vQWPgNiMJ+KCNrRLIm+1sTZfuEB/W0siiUn5boy0gcoUVZ9tB",
-	"B5lJVm266LPZWmaRWe4JhFfHqSxo1AOUtVWTCjENIXW33MakRCdo/HXCBV+mnCuahbcFxIqTY2dGoU6D",
-	"R9ZTFVEUGVTWVhnHzuZZrsRX4PVCqYZDA09BQtF0xLoh/BasObxIMTW+W+d35MGxdBKAt+Z5ok1SaKer",
-	"LIRVK1nwnRbUKhBrZyDWOkeOk403xQymOPaaFedeq5I9uLUUbPWRwm2RE+q1mSkr8uxOifFSl9l8078p",
-	"LrWtFsaJ0vE+hDPJAgMM/UrRlwNxkFst7gr9UAhpR9RqXc3r3xTuZycrUBqjCwXSsXP6RSWQ3mJm+Apw",
-	"8XdOFmI/MCeaDtvIaDzTTQiivVObARsH3B4YpZIHuUFNYHRT8O44iqMd7wsMULECIx7T8IAlrKeNKdjk",
-	"wKxM039c2ODd2682TQO2oJQLjvPvhEncKXdi9gZirJz8wd9LSETVdY0mMMd9Hz8JT+xIrEucIRsQtyZD",
-	"77fNqYTo9NdOMpRKVsDOCqeuwSgSUZBmDuGRgYGzZufesm3HjSICiKZ2zjbjv56Cf358fHp8eC164v3V",
-	"xRmHwltxcXV0fCXe/Y/IUnF6cnZyDVgY4uL9+/HxtRhObgohEiD9OHz+6J1bKJqeG/pyMzVZ6r267pur",
-	"dUEWAM56Wuq1yTc7qczyTRd9s9KfGJ8ogwfDyS0YN6Rhy3SVFTuyzHb2hnuvk+HuDk9g8KvVxX9AsOt3",
-	"WerY7t7b3F2Jvtt7Uxt9RPQMMEZJnsZCEV2mE/yG5jZVM73yKasIiYY9owvSj3pfAI84lXcK0+OBpMBu",
-	"BSFDojNx53JnOBzuwpgnfeF/2eNfBoNBF/tHhRjZFlIMnPYHadRSO/mtPgJHw7cv8cJLXWWFgAXpC6sA",
-	"soA0HiCt6YZoDwfuRj012ezOtlBJqvJK3iKz9YTitPdAKbU1bgyRkqY9peCbBOyb64eEZTndcyC6P3yO",
-	"CWiOxN9xNjQrO2N3KnJlLSk7uInWcU8wrlFCfuLEVyV5BR1jxbm7NoKQgw2Tc4XKGyCQZnO8qZp1Seap",
-	"hjIyroySqwgco++OrJFF6jpCOzIaKHEKPx9cnZ+cf8DxViAuKWiwmK0NJNgjW0GqdEuRU2KFcazS3ZRI",
-	"fcFob2QPTrvTRb4J9yh38wIOfoW3L3ASY44aXstgQ+6lyfTaeiMnIcVQnIwjo9HOzk4pq+VOpXfwQ4gQ",
-	"1ADZ4MiM7G6JmNj90c7OdD27UxV84l48WMnfdCHG+65/Gkp8r+TAdqIR2B/sRthClnapfeCi+MFRHNuD",
-	"b4ojiGePLmp0l4T1JMg7ivPgG2e4JKIEy4xYF9nf1yjFYjNAsxLOthUAzvlF443HARceuTqBQnjnjiqe",
-	"jdrd3/rDBOvC3BxA0ZA9Pn/3b1wAMWY1Fm21HqeBbujWHqwMLdaCY7wgeocvaXI1lIR5I6a5T6Bt28GY",
-	"/ZsiiBCAGpBOM6fsOLA9OO0EDsaVmmWlASq8ksWdeL8GR1Pn6uq9v46jOlAL9oYAa4j4HpOIAr86cXm0",
-	"r9tNUcmPmPCrH5SZr3MRjT8rFnA6wKNchx7InDYwmep0M3IMYV0pA5ZAjirGXdDGvXVwfuRY/8WV++/5",
-	"xTW8eOWOeNTURkkzQmyqveHeEEFKlsYpdeGlm1cYSlXCg5tX3kA8Jl3Wz/VcIrhPLovFWoaeaKe29mWE",
-	"lldIvwtquo9Z8LE/DLMBUyCYKlakQeRTk3VT55gjcLw1IjSIWHs8ke+RJHAkuMc3BUWm2UZYGffLwgSn",
-	"1k4uLRkTrrFb19gt6TDosQbK4PDXaHvZ2X3zivuNvkPYBycsJJob8jxbQEQw+zZ53aJ8jFvX/m3h7nO1",
-	"/AuKLiW3Ekz1GLNQ0Wp+heZFhMwm6eHJd+7dUf4gwC/iEoIJKbsDEcYiJvmw1BZYI2QfmwpbjQBi0fLe",
-	"SJ7Bzih4EdfBXeZG4OWHuTCNgE8Jmoe7EL23u7eP4QXwr9dv3t68aowaDvZNcVCWOaDG144vFvs5OD9y",
-	"MhXDZ9sH6Pe0vr9fUerDZlSp2bLQuV5sxFeNk3jz6jNPJng74JKEmRbAqCrIiszYbwfJAjgB+MF7Vv0+",
-	"8sSOMUou2gkOydyabef84jpMtNuYqeKWH5usn2uqSqPABycuriiFawTs7l6l0WwbBhWnxCg2ElGeCHqW",
-	"EV+Qrdx2pj3ZGlncZcWiT0Aw7mecSwSvwCz86uCD6FyhLJd5crBeuPVQqfjgAcy6GC3cEERFyhhnKsRo",
-	"EzM4PT1DBWebAxnuiluC10DHs/5sSSuwUF8ydgrYMfpBO+PxcTfmgCtp7lJ3Rw/9w/nJCid+xSy4a3yY",
-	"begDBH6IFQeBymvix3iwAFSFm+LEM5eK1tLoNdha8MT6EEd8GNDfYBkOc2mtY+k2rJ8VQCcWYwicxsGh",
-	"1e40Jrz+ThkpK/STI79tVQXiZQmx8x5pVHScsPVaU1fEQfwnR/Sc8sDR/sN7MqOxow2qzx4O2+eB9FmZ",
-	"cctKK3jiCY9EyhVDELVZ6hmLCdiBUxYxTw9RjAKIketA/H0NQcmeze4OmsKLA6qDJvKVF9RdDE8D5jFp",
-	"SiIKsG3ImYm3cQ2cpo/0aRSqduQ2dAz3cW3JTWYqczjN7B+K2E0sUb1i4FnXnuuVDrRnyGSPVcVMp8oQ",
-	"hDbeqSAXyhM5ZhJyYEPit9wjQg3c0F3zzFZWoJHOZmuD0Tuy2FIaIiwVSDQlI/cKslnJIZ34eEUeClkd",
-	"K12KNxAu0m1N6m6V8gvM9shlCU5mFu5gfnBv7A6H9JOhydRi+ojQDAXr5blcySgFG2ZFMXaqWMyk3vnr",
-	"gyr2E16ZZDh4+270fvdtnEoeAqZqCZ1bIXJuE/eZdMSlWRewkyRo9bqCCzqRddi4jUhVRSh9uKcLWcLF",
-	"hDABxCorstV6BQZBu9R52o6a1bqgKwipUiJX0hQhId0t1bporN4qK25hBLfA0dyz4eBNWD35kR4vZHlb",
-	"KjOjAMr94WC4tRqJmDTam4zED0qVqKrw9L00g8BYW4n//jeh5+iH9hWnsLW27icjMXbvIXorBrDO1lV2",
-	"r8JaCvURUptrTYPpFk+Quyjw/r0ekH16XLljsQCxdYi4JEv98JiCbCJ2wQAkeO83Zj4RHQor7o4eu2wl",
-	"zDfSPtphxYMCx5pYaVsBNiiGExo7n7hWcgmTHMMUfCMeawHF9oPKFktaZGUD8GC+QZuEzHJ9r8wEoxfC",
-	"3LJ5xAqChMOUdV6qN2wk9po0stxJrBNOODsp0mMh3KQ0ijhHQ6+JdJmbAth3pMuQAGKQuymlAsC9ydDv",
-	"VaTrKWnIkNPr1bJ60IVG+ThBGDnZyEKY9nQE5vBx0NlrdlnRCav2lacHNIQjC2dNrtKikMboB7QuaIyO",
-	"2cd0SGZmECjuyd6CNRubweOKrH/lhKVeV3mmjI0tLbDkT5taGALwWVvL06aQJy+KwQyibGO50OBw9R6I",
-	"vA512VQCaJOfN8s4xRatczVlrtXKQma7CEiW7o2Yj/Vy+wo24ZTKlU4B6KGWtopYZd5e0kyUqR60T83H",
-	"NBwII/G6TtBYfCp7ZGnB1m+Kd2d7bwhCoDlyUs8haXcQMkjBgoAQjRg500SlrKdG0sk5bEQRtYTJ+ih0",
-	"P3AvaOIMGMiNytKP/uFKrW6dPPAIEPWY8wvM9mckKX57IjoM/dkdiZM54IP0GZUXFzSDwmnabFDedNZW",
-	"wfVdG1EpiPzq1t3+1IlbVL5XCZkvtMmq5epxK5XoYKJhMFN1W+1UorNtp+puGapEZ8tQ1d22VInOtqWq",
-	"6zNbcGv/YrfTpMMOc8ojXScAs8U+k7K3DZPhyTXkjUfJ5ONwaIhgD8rS6I/Zyh3Bu6RQ0jieXDgpNYUl",
-	"Ovjh/LzLiIKgAW3py3UCv2/mrQ+279WNDf5emvRBGpXI2UzldH9KM1vByxwnGIUMjU/OjiCdxaxn/pb5",
-	"8Zu3OwdnRyNx8NN/76F796f/Tt7s7qH8INcxshUaZIylmoiDq7OROD++OIePx2fHojOeyZzi4SqTfQzA",
-	"e13hxwomKkc077Lqr+6OVFQcjYi2+nQ9UymT/lzrqjQQoAWIMxCDGPJEz7X4cPljHMuifeC5a+3w8kfi",
-	"L6kqc72JIqFbcuee4Qxhj1pYg39Y4w6Pqd70GD/63VcAmeeJU63zVfR8bejpsqrK0c5O7lS1pbbVaHf3",
-	"9f7rFrW/10Nmf6ZTojH3G4Y0pixeIIWcvemMoNnndDM4uyQj9ENhW7UvnztjOcEWQdUgJ52Buybbb/Eq",
-	"oVVcQZr+ShZrQMKJDy5FxWBNFhl5Y3u9Y44DaJ8OwDPBJP4H8kRCZYcXTCcAN/gp9aMJIRxNbRJHqgBv",
-	"bX1MFK7CLaXZCg8PfIIsCRV0N89KFQF6inPgUDGji3N9beac8xZ2FncdIRlYQOHwRwRdAFHVUx9x/F/j",
-	"i/NLWS3ZK8LpTg3insBPvqwYKRb8+58Ha6vMYOquZwRa6JdqJL6H4K+pdPom/YqsGxO1SqNXZdXYhLC2",
-	"I3FMf9YDh6EJ/sgzXQJT8cs8EhclAyxAUGlhvXb1bQOFAwDGuK9sLvTKbQmmQZOJ7zcY0E+Za3snUrTQ",
-	"BAIepRCSjlAiO3KdZnrHHX9d1xfglsjA2Q3VoEHhbdvaoPStiV8xA92aOM6olMYyihnetfAnXklfQ8aT",
-	"Yo36GiNE8idQhz/CdJEL3MKAa3yX58uwcZxOyVOGS/83r+tc0I9vjHP75w0QF+slI8Q3+cf6+H42GVDv",
-	"GfK+Y98x7fLZEzzRsQ1QIzHOmXa6SRfxpuMm8f4C5hvA9YKT8Tae9Uh8at2LkfjbcLDbF8PBnvvP/i/i",
-	"8wTxFWqkAzY5faeKBG/7Tnl/rpd4QfHB12BcG7zpi5tXr/fcP/YGQ/GZuvRwkhQpDjeISbHO88mXzMd9",
-	"QC1euAMPKfTRt3/DEE+UO6AA/zJBfL9CJ7r8VrgRaAyv5KFgtQFIg8MVoQuY52SXpA+03sNa3KWsP1iI",
-	"oHXNBwZZZ4v+tnYBSoboYCQHlk/rbhP9E5rJ03rJi7QSJvVLXUI9OLTgjsQkNOckCHhDE5hRwnhzq49T",
-	"mdFvUMTJmzOhgs/Js1MpVSGztqkAyJ1f22Q/sSvAzKM3ZZnd3inyn9m7ZDAYxFM54ym0NzMRnd03+2/T",
-	"br/lDZyH6OwPv95re0OmMhkO93wbHtBL60WuxAflluy5iS/wrecnPhy+jgyvUDCHUBVuXq02Cf0UzN0E",
-	"CcYe32SmisrIfDdktses+Ou330S5uzXaRpkZw3qRqQolZkBuO/h5LN6p1OjZ3XOzntJrbaQLIUqDKqtk",
-	"ERFZch9GjsBkfmZK2irZbd31xxtzRPvo0z33dKaXyqgB/q6KRZ7ZZXK/v/UIFinPisVa5u45l70Ja3fi",
-	"MVVuCrrYssI5kz4vzoOZgQqC1iHQQ/ie2q7HhJRgwP8ee9VHdK4fdDKu5EJ1GWgB2wg+IO+UhS2toyNW",
-	"S0XuHNRqo4etvoMnBXJT7v/zr18xqG7Q/35nw3ku72XrRS0OdO71WLukFe1M4MNJ1y+s3VpZQGnzoqUT",
-	"89auRxoLcqjXG3uQb+oLqZtUjl4PRQfEiWLvffojKZcZkOtU3jWewCf7Ey5D4zg0VlIrq+S1du/BX0m1",
-	"NtPwTw0Dpa+QveFX8GeyNxgm81zaZaI+lvAR/r47eOPYU+MXeJPaOiic0lpigstklst1qpL95E1idVGo",
-	"Ktkb7r3eHe7hseSnulxbeDLc2/v3CVe8Ab7C9dqw0cHjDSb3e6OhF1Xn6BCJTm6Hgjv5FEF9LXJsMoQT",
-	"3gHbeeUfPCi7w70vOCk1UfJSYfKcONk6Arjvf7Hbnl7Hy/yFmJmaN/Ajd/OgG9JDDtSYki8N5Yn+TKWZ",
-	"JNCNgNuHLDFac2Ko/TiRWxbC56kISPSFexsrbA9Ol+a9P1lh7D5QkbTq7WuBHvNUdCDm88erky7QlfvX",
-	"CGaz82upFt9O4e0+Kp74D9Q8OZacXi6Ll7/7oKblEy/jMH+8OsXwcNLoEPcXq/oB4O8+/UGBw57OD5yA",
-	"ERiVL37iq+7vbJDuaMHqgVE1bhpttzaGO795dUkR+5dLXekQg+c+9Bg2bQud/fTu4uph+MOHhT44ODg4",
-	"H/+4PP5xcdBQ/BD5kwwYyTuwQF6C7QKICGFnst/QJVtHT5rp4l4B7THQG7kXA8Uj+bWYSv55ovEZwyV3",
-	"WFvLkfj0CVb48+ebm+KQo8nEp08cWQYPjkJ77lnU/OfP/wrLaIsY5Z0RYwhYDykEYNdyRLi9uG7JfdnK",
-	"pX/8q4XKn4t1lqodSmAnFBhIV+edaYFYmUnAtsCMkwhpA7HqyLI6Cgg93LouHFnUWzdqppz0ADShGoiJ",
-	"tOja+1jFdm+cKU188umTR9/8/HkyEieYWY2eEqrLAK/9KSOM8s+fB4PBp0872Rw+OOSgQ5mLXC+yGb+P",
-	"EDrGyA1/4X7BTipU/tCswB+si9wxbh/FyJ/h7zS6e2Ug2dl3Sl//J/Dhz58dl/j06T/v1Mb/DdD1/l+5",
-	"hH+MxKnWJSKcclBdr/duneVVkhXie5WXynAO1e5A9Hp2ZtbT76tV3uuJRFyhJxsJeMdWGwjPW1jCtKyM",
-	"nFUIBUKFeoxeARglkOxkMgl0BL98+uTbF8tqld+S7fTzZ/4A/s8dWy5pjgMg9owBC/TADYl/h8Jo+P1B",
-	"mkISXg5xhphWPAWECJUjQJbolH2RZvd9sdxNlm/7Is/6QlUzzEUSIYSvzGVG08M4Y6MgvTsF0H9fsBMC",
-	"Cno99XdYuGMOIgq5Mpz5wltqH10jR4Qd9XeuLXDzCgFIbl51P38+gD+JMBvvO3oAExskQcPrDCoNNB1/",
-	"Raxi340ZZDcM+4MqfgATTkWGaBTrqHa44wclZbd86o/OBD9fm/w7EDRHspI/Xp34gYfH1TKzA3jndm3y",
-	"lhfQsOJYE5W9AK4EXwx+LRcYtLv1DYhUzmbkbB38qCwe+6iZCLTdCS2eECK+P/x4dYq41ZSVCFSEagfg",
-	"bdfVHtZ6fDTeY5rPYDCYME161UHsRLqDSMTPaur6t80QWI8JuykVR7Fhtp8IKU9tOU5QIYZPE6kmIhHj",
-	"/QQougJQXE6k6hAYG73YXPA7tcFKS7BgASz7kAZ36d0EYd16PVQZAfVaPxS5llA7wSgLzs9ONqdUs26/",
-	"rlL4hfUtXR69tyhNPlbMtTCpHOt9QIqgUUUKQZKSTAX+c8fP3OdXcNxzus2HdlBbOdO/ZXku6S3PFJBG",
-	"qJQ4zNjo3NMHzwylZ2m02yDM1uWd4zLkHGvoVCBkcVTpaqltJR6WWaXyzFb08NJk9072nFwi2wPh7lGs",
-	"xuOr90JWlZzdWSYtHgrCzUI4p42E9O5wePaO3/3++vpSpH7sgEgOtw7GUuP8/4DX+a34TRlfloQihZRM",
-	"HYOmVmHDhdfXtsewN3z9TfmxjyXNiRCYrsZKjUR70e2dmk34T7ygSTLTaHN+DYwbzuW11gUycPinr4d7",
-	"fXFx7kEQr8GYf2EyjM4nYPVzQqnrPsoNQxdQ136AwMGeB7U/FrkqFtXyTJo7Zb7DEgpOCyiq714/92mq",
-	"YA2V+e7m1c1N1cq/YGbvCTsoxIH3evvD5O3w39BzgVELGEJAIg0P23+NL86ZIA+pOho5TwmAd4ShKQ2E",
-	"GaZhQJbBGSJWFqSLOUH+tz/t/zISMutTONcqZ93gWk7Bfk7b4VpfF1kA8vHlHLmXi1rIxOnpmSilsWQx",
-	"FIK8ov5gTeIVn4jOVOu8OwLI7j8xIHmlqaYN1r+IiLQya+XZNW7UBIpodEdgqaQK8cKWcganMpC3/8zv",
-	"20R0MOuoyx5rutZrg1EAtBSoYkIIlZjQXk/4DctnhO+Sel2V62pUU7kwQkqcOP7ECe+V9oFCPsVdYNnV",
-	"kfgvWShxpPHwtm/YFq15hNpIQAL9jSlkC702/hwvsmq5noKkr7QuEtxx+Ju+/qDFiZuTr7zf+rHMyztl",
-	"77JiZ6Hx45viZ28p4bteH31JFLOBxJqB+y71hheIdagQxTIz0bU8s4KBGlU6qNVHOEZJ4VYUpDNHGXCN",
-	"e+7RbexKQfwPewiaAQkIW4/NFQsqpYJaNxU3DYUk/Cn48jtzdDn2UQ7Ph/c8dn19/ObauLX62RKheu++",
-	"N2xAQRhdEnaaR+ubYPocxVwIX76Val2AvCiNKpWTSZM/DyYiw5qzBGLB9W3/PGgJ6hCRdzVsHb0PxVr/",
-	"NvxlgC7xiedpWeSUuIZibawuIGExxoiktMIB1y+gSBG6LWBBGUih9mGgmPHv04TrRVh9/ngt8MuvqM+W",
-	"zYATgEbk/ey/n0r8av3LrRvnulKjOLbDnTwKTsGI+izPEby4Gc4S+wLYo7D/zevgYYss03BQGTyZbUF/",
-	"wPD09dtvWi1L3qD0hyxFv9s0ve2k/EIvz1M9N70RjyTkXAaBg64SMVbVuvxDhv03+2+3iZTKvr2cQmOn",
-	"+Ze4zbcc53/+dHF5fH5wcntweXL7w/H/fG5ditaqJr0e5bYEvfghsyoHNMrvsYSGf2R9jD5mjc02kB/m",
-	"60nQfW2HAqGh5AYZ5R338VbWtqrYcT5Gg+VgRdqVko4fzdc5RbHZqGIzniqLKTsbRuOsHnRiK7hBBmoT",
-	"X/nAs25UgwVuVH2COqSvqMoVMucNdocX2XsrDnO9BtxPCv7AyK97levSCcid0l2RZpu+mLkXo6gSilwj",
-	"otyxM8lgm6SCxcoKwKI0wj0fvGs3RUBDwmecc8yhvNdZKh6WOlchD7CG8xxyN1G3ce0cxGVhxj68+xrS",
-	"M/G1WumYne1i1fVqMhQIuzsQR5hPH8O8bpdJASNCKwb3kyj+tJT/ehx/jkr7VK/8/0TJ15Zy/l9Qvjtu",
-	"4wsLZ+xxWcA4pctpDK3LGwEnRPVFQqbGI3Vqo0SPx0eyzzlisOnuqpPQFYeLXFezZeuo2sEjmFW6j2/h",
-	"48b4onz8XJa1Orr1qmseU6G10u7feL9/eWxuoFq3FfsBWuZQgFCYKuW7nV1P4xLXiHHAlYSyolxXN4WE",
-	"e4GxAqs5v8dyUu7c9XliXHQI/13pEkkpl6UTImhr9knuvrTPEeE//ey6XsqyVIVFhrLRaw+va/CD/+CQ",
-	"dDQ1WP4dYcIxThWgOoUqTDZbujPab+KeEihRhGzCMMOhbs9AfK+M+osbiawQX7tUswoHFjpFGD7RobJB",
-	"zP4K9UBxvQBVRUjTNatM13uKD/irc/VAob6VFseMBX2N0Mc+ULBl5vXpPbYOgfm5iz3WCY8O4NQpLMXl",
-	"xfha7GBa/84n+D/4kHZopXY+wR/w28v0lJreMRgMthnDsR+i3//ajMin5Vek7l3FCWJByPoeMkp3FDAb",
-	"Xg5A3U0U/CiG+xEUfEBVAHR/qleFbgunEiAwvWtjYZS1nuWcNR7UVx3Q71666LR0p1rfCVmJCQBr3uIY",
-	"qM5bWFDuD2oZwJsBl8QYbdAtyuWSD4Bkwn748IjW1Nt6T5CI22+eT+U6sVgpAMoBjBgDvjKbZs2C9zLL",
-	"VRo12l5oqzIZO1nVx1IXTluQOWy8ns+f2M4AyNvYUK4ugW0jUnuYmbvrZYXPxa2WUVkIizC+2VxYvVKw",
-	"CJSS4UsUwLQiEN8WyulMtimgufufJ6gcwoqSFQ4R7/VKVUu1tlzhAFbFqubmrCGxnOrC0FI3sfFjBMT7",
-	"TDaFNTghmI2RKbrXO9SrlS54mmI8U4U0ma55Wf2VG7DsfizkvcxyBA4mw1a04LQNjY0H1muVuc9mitFu",
-	"rbflN+bBVWI7HB8UOFO3Na+WGgKbhDsFt2BxGcXEyEnifJmI6ZTLXwFesuNSA5LhByJCjiYtWwXgXgPJ",
-	"TzaUgx94ciHvla/YIqlFrz8vJQM0I9xKBROvKJMYCm9oU4mJf+fWqFJm5paT6ybCamo05IRilJN7j1wW",
-	"JrtXKSKUDrzX98odHShKAGERbN32ni46jJQcX5mNN5lj1UQylkPQON9X/D0BggjQGcIGbRPudI6A/r7W",
-	"Fant22Hy3s0LgY3I56CsMxRhQoWmH3t9un4Cp1HdkAiiBstZFPfKVtlCRg7FK6JUW+mStmklPwpZuZtl",
-	"1aROIk5UN3zxb6DOGsvt9d7LPHdLyJgPGzpL7yHnNYMjAZwL/FF9D/Ud8BMYqp++d4s7lzlySfjHFv0/",
-	"PMrogbW3GlWfx1Oj1NhKmdUzaGq1N30utlmoW+Q41DbPiFR+mm/DtHq9zKxn9x6zKH+QG8s4aIyPwfw7",
-	"Ckh3QmcdWJSXmL5mCGppWzVZrjUhHhO3bKZmuHun0SWa01mbQSVMTI6OT4+vj58VAnD+rhRq86E+CXY1",
-	"EpMWBa6tkf1BpE+By89uydmEtSWkSTBE9npRFXvWnjsRNkCXFdNaLRTN9Sq5pn7c1U3BMKHI4vFOjitJ",
-	"uEAyVQPRCHXvxCneXTpCTaD+bcU+VNoELMx3yLjP5K/aRNcSPmyQswErZFVl+4ygSew+6OCjl+jQ+LE/",
-	"PPhPHyWLbSbUZkIV5x5JwICwg9WG4g0I8tXDJW8FLn4wsiSMBsJhOU4XEJYGIbjwNKwr1HKHJQUmBYDu",
-	"mS7sMivRjMzYUZWRTggHPLWBOM3uImS7voC2oNKsvSk4xLm1KCvfW0plEqQgqMkUn6FQ4z7MR1zcO51A",
-	"PWzPBBFO0ZPl9Eo3CA/REY0R5slAdRlhtxMKaJESjLwbSaEI1RWBhn0bUAcN18I7KJKlLjmmJImgHePV",
-	"RKBad3uKAvkWYQ7t9d/8bQvebAO10LNM5rf0uGl+5p1/qspstEHu7bjokjLxCF9edfb5YRs1U0WFBba4",
-	"xMPTVTefLc56DFv+hYVZPaeqVWj9o4VV5QyPAahtMqqNcqfqNfK67lhhAAvwQzclp+lhmca4SCsS9HaB",
-	"1q1j2bzuPlWZlRr9wqqsnqjuba1CM+5M/EuvJzpVqAfVRYxCf6eAa0ejFJhXl8iGGpUre7Zg1HZh3ZB7",
-	"PvHFJzlfmGbhxohc+EvGGB8LUlmikcJltNK0vjBMWQWs1ehjP2wgl21qFB3KLs0KAXSDdQ4SccRgWnFr",
-	"lBQGFcg92paolRp9oiSp31fIr/VVIbbrkgppg8Z8fX36/6NO6ZNFSUEU2N/JQTH+9PYF9bF3axz22p1c",
-	"gV9jjRNu4lva+BovoiKmei6yAj5i8EWoreNW8oB+Fe+VSn/nZP4IXw3oeG7vc2krKAjrhgzTixv9Vujc",
-	"Xe2Ig7QVH90qr3qloF5DgbVxf+92VUaBnL6NZPRzNc2bm8Zt+DjEqK1vhVFzo+xSQFULJ7VzAkLUeVrb",
-	"Wd6++H78e4mwzG7d6n0p+bkLMnwHwtpt01PEBy7FPEsRTrZI9UN0/0ZDxosqxHpOwdKxzjECig9Dv7dw",
-	"jEadWarhSrIcQKyh7isyxpoEtXURSkhCvvlmUVlfd9q129ntwkpBq1Q7yyiIUa2rAC+qNQuthKIWX14w",
-	"tq5wxbVquZBGKBm7JekfLxtLKviXl4yF7eOCjs1Ne7yG7OOVYhEUyuPxPFUVFsnWbQ4oKd32ArCe9Nqr",
-	"wEa1iLHESp3o2qrBqiYx/6qnLE5v3aX7tqry7/a/tCgsTgcLwu7ufR0qwn7z71sFYd+83t/zyu0ZWXZB",
-	"M1RpUwsHYXsNAKLxQU+FzdxppUpgUzVzW0m5FW7fHDvnGXq+ghRUuKHf29rQvdW5WaE2vkw+Wpi2ea9J",
-	"xCGWRAFjA5xHK1KjsRwKGg5R+aEawF45OvZ6rw9pg/QUVJfR+EBN4RG/zGUh5GwGhdMWVMwoKnS0BSXW",
-	"UqIWLDfRqNjIwya87QqxB3nu75wzvQL6X8nCG/keK0H7VE+PFKP1thzVvjRPlJG99NftrcqscGeJtVp3",
-	"dckqK/RDAdtLEfpUOCddcI3XUL+WAl/adFnRAcwUPozhG8qKO9dgClBeJx9FKwpVQOOh2aWbtBc3sX5L",
-	"hYDgNSapRqXcQ1m4wayAopGVFK2U+0TpXcyYIDo+v74EIvNg1tEVur3+LlmltiKinEZLic0xLmhNlbcv",
-	"jqLwJHhbs0M8GlLhbQgQcuCDvUilZJ31uc/jkIdHFM5m+zJ3BHGL/tc/1P7u8vFwEHd38LFd9UtTPQQh",
-	"LHdsC9F5Nsu2NgQiapzIrS3xoOYX9Gw31ws2VvwMcRdQZy1bLGOOGxU0pO+Av6SgqsSkLrK5b5mLmkkx",
-	"1VWVq0LN7ugeiy4Yu9QGqo82ijYT3l62Uom75Gd8mWHIZ9TgrU9jDoyUJvKTMu4YNU1HU1I3fJwIxlQE",
-	"/ElolEcTQywD5zOKgpcRVaEmkBJxDMb+FtMHITo3RbDB8PYYqhh2/una0ASr+Hxt6Oehim89kkHkeSDi",
-	"Q4DhbNbm3XLbts5TceK2pA5XTGZ3wEVwDaOrGiw/7sVDWVDFaabxYBGjUpvezNSKVHwRF/bCIp+VxrCg",
-	"sIo/WmVaVg5+fmmTjktleG8ODV/6H1uajx6+tBN3TXIKeG3Dqa+DMvtBbVr6cR+5Jy/txOgHkok+rY3Q",
-	"t0NnV/oB7wct/V3pB7o8vLjLQ2mnWSGMpiCvhdHrUqwcJRnHieKOc9XaZ65aehtniwKMTraSOYLCQgEk",
-	"OasslSv1NQAH0bbJ2Z2jyLZN40cthcqxGNr4r6cJJmFTtwqysH2+3FzNNrNcRd2d8Hutp5fb8DC29tXn",
-	"X9yLlVx8cOvkDu8nTwUwl1f9V5VcwKkmkV3nES0l5bfLy7XAoG+xGzhx3PW6WkYd06GqHQFPo4F+4hZO",
-	"CuI6oZn4cbQCoZtor8I6/vL5l8//LwAA//8=",
+	"m309W3ZxcH8pjEzFHhoDz3Z3d9lfpDq1Tqdne+hX+Rjb8YyE+vNmQdLpwoLIlP5ZOyQti//0m+big081",
+	"pt6vW3eArakWHedUGDGSl/gC4k/u8XQq9q6wOTx18lzMTVVceq0GhWHrqqGfbI8KwrQcmG/mKO3N84A2",
+	"MOUO5vrSayFlfhbSwrrMCpVVsQQhJY9bRh+DU3dwgByj93ZWiL362di57KnML9+gnygIXIc0qGlpned/",
+	"9HmSqMFeCM+tVhjZhl+3FrpMOvuH8FNFc78m3siDXY6T/ubjXJOZTmHL2rahtp5Jx5VOG8lzWMjY3tPd",
+	"j8sid3/I9ZDnfye/2NYSpittpNtpW+lmc7i5nb3OUCoOA2uxqG453/o4tr4017oZGHCragzKQHPFMNq/",
+	"SWE8Fc0OIPLrxPEc7c9nz9Z//E7Z4Ct/cclTd6LN5hFOsGCfEpQLDbwV00IbbmQ+22ZYbohl4mwMp4UF",
+	"N/JGGhBGSYsVphu+EAJ3AmpxuJHEyKw+O+CKIq7FXIQwZ7YcWuGi6YUvvdZZlWjqtcRTOTrFC6bBHtsf",
+	"auOYHDGuZsxxMxakaM2VYmWP6NqPskTPZNFo5+RMFlVCRU1VC2Ol2x0Hn+tzYcCPAAmcfIwYs0DD3ImA",
+	"qQOJTFVmgu36RlQ9dCukrbiJmDIN2nFzCPHSMgxDAnBoSfktdqbSidFKl5b9podNMJ6QO4JZP3BF95se",
+	"UvCWb6gQxkrwAvnRQ05k1bZ/lXZJZY2eEnWhzZkw4BWN5NpnR9pvZ22s2FutzEpI7+0n6oA7nusx3SOj",
+	"Uh4jgGYsnYj0DMMoAZE77KmCgSvtEmVEgYUScX6+U25cnx2OWA6Y04ChivHSNoSMwE1p1XjXN0MBRTzT",
+	"BQSS5zPGFROeGXQxxqiHSkG1CYj6ELGRvO6jQlaQqmLGv2OlMiKHUXoCh5R2v1fzhAZ3t2muLeTu7NPK",
+	"8XQiLBtQgJ7IBvUsLqiyEamM7rst3fiGIHIcbkzJ8mOLt0pQ5tM2NgznBWc0FXkediVRqSaucC6aQX+N",
+	"/YP4e+6VlD47FlPtBMVGImBUoqzjYz9rSKittkTUMrzQOweRS312VGvcOl1YpsRFongWQfpVxjLDpbKs",
+	"unKDvYefoDETN99e8KKgO+5EIcpMD6qGV4e035rVi6xvbeg8zOBMzBDGxmnwsuQzikqKFUihAhFef4dz",
+	"0mc/ihndKlL+ko6JzeTn9CfBSJXKgucwvcBaI4sC9tcPoEw2esugtwksDJUXpXISvufg358EoHby8B9m",
+	"Xiw5odJZDwsjtsZTP/vmr/Px1J8UJr21xCvaxSs5lJ7dYL409P5/9LA9/7jimIEF8jQVhYNrE9waGFPI",
+	"5WuTvzke0HfHr0KRq8DM2zhyf/XlOiTpznr7I4pWm4czHI+pGKtGaIBM5BwQm6xItcpss/kVOQMfYT1u",
+	"I8WK9MEtA/LULzdJJvgegUmF/cjAP00B2CiTuFLasSFlMeHxl9Yf14wipGHdbiNTzH8jU7FNXTQQ/Fyk",
+	"fFAahyERc9WlgmcslAxUrVJPaeep6zmt9MHzAwqO5MWkue7BnQ5T8fJ5/+iw57l3826p31nUgnd+08MN",
+	"4KE9jxXW9UbSWNeN6UKYp4oui1q6mhGeSERWP620Iv4sR8GN2s0SNOnIZuySm+bNc3++mUv96a4+xQtX",
+	"zz8V/B+l2GYuz7PdVak8T3vfvv91t/ft+w+73afffvy39iqBbb1C8kSn7SL7H6UogSWbUimUblE963Q7",
+	"dKHX7aSoQYms7cJ6Sa8g+Ft7Deh+IXj4ffdW43sqovIk1gqjWV3N1on32slF94NJQZxNiwi9QnBNnV/s",
+	"fPhND09ltgZNm3S3oWccYjTy2nxa08f77O9AgzHQLpIak9OpyCR3Ip8lCmxXJFJ8FRVoDgnTmC7qtdOg",
+	"tM/AcJLGCMhGrc04UXUdP9gSUalOm7YC00O458nA2CWFY+qFX6Lqlgw6H/Hj0xiOQFE7bUo42iQ1NepW",
+	"CL41Yozq/taVKvT/XiOh5MblKtr+dYMtmoG1nVpHwWvwuUN4dbUKvbAKEC4cZRWiU0FG/YxEQKLQ5HRm",
+	"1sBK8ZK7h7KNDb7Z/WrASuVkjlI0n9Vy33xXE24TBTtMOdp5PvuOpbnEYK6JLvMsZIPEKGfmwAQDC5BX",
+	"AeCJ4uA+YXxowfBsczALdx9o7/gmaO7+cNgfRCuDDVNbS6TrQ+mQ5a4MUqsnB3+7sULx760KxfuK9VuR",
+	"GuFW4xaAF6cWyYnfAFZ4HdqKou8f4c89XKeRzEWXCXXOzrnBGBbtJo/7iXrjeXh0/1GbGAfO/vU//0Qv",
+	"UtVHA4uI+loWkX9Ck9pmBXboYpmmgb+GFcllMAUfIoWXajBEiBseqgUC3vlwJmYbVAABOFbYnGiy1Cj7",
+	"wkh0jy3QcJ8BOkuVC4MAHSFoY6ozAZHBSM3f7H7lX8BcYIiYpxcWyPU5jBbpZaMiIkRadId736PRr8vz",
+	"tzt+khmNbM1eoIuKziCgsrHjcxt64ycBqSHS6JVFSyupnIkZ1XXAaCZdCMVlnxfy9EzMHrdHTp+J2Upx",
+	"VJc4vPf7fu+/CILiL/92lfIOeHUTlp6Q1O/0QB6VrnYab97Pi41D1v8dRQ3iCJbXgAmyS5vl8YJX84De",
+	"M7H3Z+YwzRN3BTGLYnmdMxF8bzyfTwwnM9/JqQiqW5vtchJk/7ZzvKmjFRnepLo9pH19Sn73VXU5Al2r",
+	"iGxRtX8bcNlWSj6sKhLc9UOSfxh3F8QgRh+eJp3HDRgveLjEz4sNLL9j/Ka7PtVpYWhGjMUlI3laDe6/",
+	"YSD9J6fnYMz95d/mB/rfpRXmtP9k2VhJQC8Z7De7uzfvnt2otiPs4En0Cqwr7LgfM4eJOv4QUFAxpKh2",
+	"OODB6qNBlQ6hAmLT1pmzKowu3sa6XOtMCkQDzowuipuR+Pdmsf06tNQdalnpbjvL+UG4Jet4czKpcSCW",
+	"1U7JhOMyvwe+2x9i6FoY0pp1XcmoPSWHMICwS8tqzPl3N3WRtfLipZWuK4xtJS5oduD6D0EgBNTOMjGS",
+	"CtIha1jZC96pkBbxzgp2wG3IiDiR03iHDFFZpapVn8q4463R5KqcnmImBoSjNwO031ZjHW2ScNFs7KsQ",
+	"04/VoCBeXDHmHwWI81Oi0tqPrEqNaDxtbSn84PcCg9AxW5Ri3asXiphduvA15A1kLY+bDeM+zzWML8Ur",
+	"eACyoGSAMzG70CZLOu+bH3zszncOeRo33r/fK8xA2HwkQ53NtjSQ+b7rf36c26zYDCFg9KTq8Tyvp7Xg",
+	"zHC8taZjs/SP0HISbvRPq3lEIvOvfFxMIInEigR/KrPLOTKt2oqx/Nga9f9x6Wk6X1JtZ4NT9Q2NtJFX",
+	"4sdwhNkuLKWoUoS7aeYkVblGVz6TlExze2cyZO/c6dnElJ57cDTntvsWTmh3cUMgqWlN56qcDoXZvHOA",
+	"05LpTXKIKg+rmXx1PT4RCX89n6AcoVWcolZIq1oiyiPDNxpjrr2CX/qlnTuBIaWeDlue8ylvrH/SAXQL",
+	"Ynt53ptKJfPp3DuloTcmzhV7OztwoTzR1u09ffr1V18Hzlat2QKL++IL9r2wjh0ZnjqZombSY8+htFtQ",
+	"crxqkqKbVeSERTX1UxD1FD//HVTIIu1DXHiDHzNGfQt26o0cr9VY4Sx79LT3FSQ1eKVoKriSajwqyQqi",
+	"a76GYU7ZirUcukZGJrR1oJUFqAIOG4bJAZUeBNkOyMeJGmBkk3r6ZFsMB2iDb2tljW881rfq4Y58wG/p",
+	"onyJtYHh101bEPd57iqY1vW6nuHbCHV93hbNunEg641jc9bi2tebpXcRPLroadgJNWTW+3/hI8JNrIrn",
+	"hu+ZUEamE6g4WaciqE2bKPi4y6rqBPXXCdjEkxwkiA5ngfgIqUwSwF/szJOV0XmvyLkSAC36HSstpnLE",
+	"Ck7xbaMhNR6A96B2SKKm3FXYaVWNFqykS7UXUgJujC0ui0nYp45eVHPaulNhsc+loZGLO1QLW7jyHe59",
+	"8rVRTlYLCdaOHpDS3XkuVgTorDqOOx/CP/GHam7rAyFsNfLl57Xyd/SpkAbVuzEi1SqVucSbiMxA2pPu",
+	"5VqNhellwgKKR42ajBhLKN0JjAnwnaSD4jsQ4Ok0yzSzenmMxCIxdz4RuXx93f2WU0GBF7cH5P3N+g9e",
+	"CzfR2Rvt9iGOMfuj5F+EcAjVdnzv7+ntLsm5azlgvp8l2HX1o3015rEk2OIYTiBkHV7l3IfKcFUOaWP0",
+	"IY14rtjbFJMY++wAKsR6kWmtaLBfL2BnzD8cVEgLsJUBFtFp305tgKDWQ+X+uHFf2kQFrORK9YdmloR3",
+	"LGEkW0CGih0gqOg2qi9ci4cZooQHNnZLaWS43FimGk7LtXja9ZQCI6jgHIZt3RumWO8tIprP8YhtsMZl",
+	"iH5QYpVqs0WewXO/Y1waQFRG1V/NaJzophAGTMVEEZoW2QNGX0AVN29tQdG2Prg+sFLamZgNqgDUCMfN",
+	"LaYdQN4LcaQvLRv4N+kb9EkXuQh41ZS4ltYKU/UT9byqsxMmQOZQ7gUAZR4QtAIbgN+G6rfZamSQnE9D",
+	"g8KUCFKN9bsCIlh9sITsXk4FwsxDu4nytFwI5e3XfIa6n/UWuBcUOTdjgS9WFWxb09uJjJ+ToRUY2zFX",
+	"4205aub7IpcNjaTmu9lmUva6Qayoj0nkHFkAJjJaC3j3MXX7QQbchgygLWB8jtsFED4yVA2R8yZlWq4l",
+	"BnohK/hBFqyLBghJP6UVpjfiKSJUAjf9TQ/JERTGGxxAlX6MQDeQspUB7qltgov7ScdqoML0sLA2dpCo",
+	"wsiphNQ4wOkYztig2sQBhh0QllHMWq5LgUQRP2dWs4m2BGMeZUCKEEeeV7fwYBqGTVSA50h1nvMCWQgh",
+	"5KAqHmvGEWCTl3jYdRsfhzuDBR4e5hXS1rbPyutdwpjuiJs3pt6aSxcYhyckz7fJOf/Atm+BbUd//fwp",
+	"rzmO6xu0dcYN6dmHmJ29LGJt7enaks/500i7nii6faq+V/HSGxLXYjz1Io1177tYX5jjTcv1luIS9TWU",
+	"cIs2kohN0p6Le5jdhre+/WDvkK7wGWhof8StXOkgqJdvr7sFwDhGWzpC1ZU5+EErwIEFTWgfN/rz5NZg",
+	"QBJ2pRNmKhW/8QqtnzZCOkcPetJt6ElEy/dQUdpBQJEHdnqv2Cni5FAlgnI9uQDuD689A74rbaICEyIU",
+	"oW7ToxrgJSCtOGBvEt4QsOXvEjWPDRTwWhDG1GFXFWqoN6d9c/tHh0wRhkWhDVTKrMG/SBVLCYKIqEEg",
+	"LQcO+jxlQYXtpM2CUOjftVRowMRGDKfvWkkCtmpCtUBnwhG8bcZ4E0EqwlH96cwVXM3b4POErnhlvg0F",
+	"NQMy481F5CzjZN8jeObhc8TFldNp6RBpOlyccxUPBSFpi4wdPo+8afD17reDiIILUNDhvj1epxMu+QLb",
+	"wN63GauKPVwpTPVqN9hFrazch06161Wmaw3qvyXBdv0VOG1RoEqIbODupsANrleZf/UHsKE47Do07NY1",
+	"RezyNWGdbVNhpD1ZzM28Mpdw6eQaTGIUq6nVa0Rug13MH1iXTn6JhSO3cV5dOtnicd2g7xUXks0Vnyvi",
+	"cZNawtqhHICmxjKqcVfB+ovv2Lm0ksqOam/iGydTWXCInCEcfmkRdJ8VQmWw57fKPmprBCU3i5zL9sig",
+	"5XUx304EVXmgk5ASqwmwmNbbjXjl5XfBzxkg77NQgTJUyGYphBNg/UlU/AS7mAioTxuuh3pjo8uCHfOR",
+	"AzUZsPajvtxn+6pWekCXLtVTQWUUYogoRM/M2DCXKqNIggDUGBAlCcNaadWTARveEcK/NlOILYDUgw3Y",
+	"8HOhrDgGR4/nV4UR1pZmc3jrE29h5MJaKIXJoQblSy7z2MZXN7WXwFEghh1soKiUoU3nZrWaodpkUnFI",
+	"irHMVUVdGlg1BJsaDJp4TLZW7gUpUHqCcuhQw0BbqK75yVKilhTRa+BbX0NyXEy0FQEeqZFtQVE1Q4FV",
+	"OgBi+faT2Y9FxIyx9TDJSpk8eH4Q0h2qvBEjrM79Wa5PKVFV7GfK8xzKUgejqSpOG1MwqgNX8XhpsWJH",
+	"JrJEQdp7MTY8q9UVCdlGRHQt8PNNUHJ2wW2ipHIYf5XhXbhvWlx6TiVdPos1PQzC/ldN6QtFVVeoREmi",
+	"alk/0jKj/bHN8PYeZ82UEJllPJtKVS/KSyFQFPJFsfGxpsfcmwIEBxQ4LnneGBNaDK1RT3EzQSd8Xtuc",
+	"T3UINBXvCuAp4HlX0EMtUN5dgvtuLcpQUXWFCk7tv99AX3++auOryhN0xq4reG8BBewAiSfn6ZkNM/E6",
+	"RYNqKIhkjhi2Z1vceq2JT0vAu0e+j31PcYHz4wlvzAkSJOtupWoy14f52Qmy/I5jtpbKm5OUK8vOxAzC",
+	"XXkNPsX/qSoMlTMxw+i2UHg6eGanEPiqxEUulehlAqo9iIxB+chHWEbycZ9VxSGjlsfxHWQl0Ceqg4NT",
+	"mQ3mtaCRxApPcUT5jBVG/4ZFUOLLmPVcJRWWsWB3oqQD5gwSEQO5eJ4vzL1WJc5vB/wc1gNXoDUwKuXq",
+	"RzGz28KdpOZXhjmtEiDt1SPnKLB1D7sYDAxbJ9s2zZNJ0gEcCVz+TnezspTN3qE41QjYySPrjOBTCCOk",
+	"QqSP/3S+Wr/lka5bT2d1Jj9Btw4dVBDM7eh9Wp+VBdboWsnGvGXOe1b4lzwJBfy3GhwBYkoEvNiwqv1E",
+	"HY7QXsTkXK8a1m+ARmWeV4m67ARLalooTk/oTNjJXgD96aLUTjr+lTdUS4q7iQ3Fffs8y6BYYCrdDF/7",
+	"ReZZyg22cppOSnVm+0/wtxehRC/82Iu/9uslkGE4fgY8r42nesN2T3GTpbBdasJ/1YAHrA+/G6oX9GGP",
+	"2wEDsafOFS8QOQSVQoFGlc5iscEcNhtV6JCdNTCCZ5jgNajSrZFhF0Z6ooXvPZ/gXuXDMFTumfHAOp6L",
+	"gWe3+sKzkIl2CPc7nEEj4IiodR1KiFg+Ej3fCHt18gbZbmsFn2oO7WWGOtXg/TKTitx4iFUhTnNBZXmg",
+	"wOsWiuDwLJMowI5qGjzK77W69THW1QQu2azZ9n97+4g08LMwtrV2G/3AnD4TirZa2tqBegfZ9dIijL8/",
+	"nj8dHKAlhs6PRMFWACKI0+AswkT9oDFNdSZHoWp6P1FJZzfpMKkyqOOBp9jzrEwL9AyBUYv7usJd8mfj",
+	"/McEW+sti6DXDGcMQb0/k+DBH8UsRkiEOYALEKd2Pdjyq4XuzYm2q+BgrIrrqGFJEN03gMxB0+QLuBKo",
+	"kOb+6IQCMpm04I5u5hOHokeJIiQLuIQMQfqhb3AIGjkeQx37RorQMgiL+Zv312Ea6yR68MMTZCSDvGPP",
+	"1JFgB5WQnhU1qI0g8bXKZ/1EDQy/8BLARgXAMo3V28IXAFMtUL9EIwMIwUbXzLwDB3LR5mCVpWVC+fez",
+	"5fICJ9JaBi2cwm7H8IvbLoK2bIvW4n7ENb826sefOv4Ni7CtP/CfD/s9EiYVyvWESnUmsnl25GVJ/055",
+	"8Fz433po+kDhEK1b5UMiy2jP5Yo72E2ULdOJtybrAqlXKunYJFT2Z+LSGQ7uBCoRevT8ZZf97e3rV1A/",
+	"sss8aweAAmBtVAndq8JwoTjhJuvxC27EdyFjKxNFrmdowOGLlJcb821hPNxxhvdrUDNMX5AMatu19rph",
+	"yzjHA2+/77x9M74+qvj0A2PfnLEfogq1MuBtWh2VB+Z+LyOfb0bE3FsojT/ddi67izhU5zyXWXQVBLdC",
+	"PKooQ4L4ECFfp0Ly0F62DkuZZy3J6MG7tWCaHehi1g04Rdp00c8hTBedH6mRQ/8HqQfa4I111CLouRdQ",
+	"YSQQTZoonufMopuyPW58KSxG5y5ymFcFXB3XQSgW8ScehNINgElc34sfgFxX1d45pHduo0oM9HWdKjF1",
+	"pN+K+37+MJaeE9TnthgT9VlhWNJUdj7APzYqaHNIfva28NV5MZCJyz9wQRuFlBCMzI0IYRlYwJJVvTmz",
+	"pXGSF08u7dW1y9vcs1R+2ZjO5wNRWe8tXGi19BZP681EwyO8RkWC24Jahx7uKCgeR5DhJJceAJ5ld5aQ",
+	"ck1N6n5Gm/2wPJr1KkFnG8WHnzht+FgcCzQIXlxOeGndHymrO6uEDSA9rRc1KyHrV23ODWHVT4UZi/sa",
+	"KjdT6cRoJX9HG/RMiILhrTuUL56pFOOhxCXSBTp2kbosy+WZYCcTXcjRrJuoI23d2AjbZSdfQXw/VzNm",
+	"wVKEPBUTHAF9tp9bzc6UvlCM2z1qNQ4G1rWbKP94yK2AnwCH38Cm8pyeiF6qp1PhbV//AOqcfa/dJBjE",
+	"GLZfRbJOSwunjQY1nFW4Z2di1mcU/A+waEL0LviMwfZBQM4h5QIocUHTsajwYGdQS6RAUx9yJuOsLZY0",
+	"wewBWt3QAB9aiPGr2gHHPBVoC+kaLCl3d5/9lR3GePYnT/bYG407hD6EoXAXQij43PbZScxQsY4blyjU",
+	"zdQMXmByBEHwxpQFGvK+v1gfzrfuaYOsf4RUp82wjWXfPzq07FGgAfaL1gf002PaQJbzM8HEJUQ2AVlc",
+	"cCMmGiofYLy902FZINxGX/RyjuE7jdIoNMpf9o/fHL75AVeAUnGwREwVteE3jeJf9bkwOYI/Y2SZ7Sfq",
+	"hLBK4d4aV3H/6DA4/1sum5Xg5jWc5KuqBRQBhZbs7xJSSWshcZ724AphqDMqaXKADfZeqFRDWgJ81u1A",
+	"EIv/POfWncIcs1PpxweDAoKiOHq/aXu7qDQQ63jFC6d9M1CUqbP37bff9r/91it98fVntddf+w2q3n4G",
+	"L4N4q9KB4izeKS8RjLA2RMnC6IJP676M/WN3Q2Fe2+87qofTGIEt89ZLFfiZ+a+hBMDdaGtPN1ANjvgs",
+	"1zx7q/Ur7s8QfLeBlvdORV/ja5FJ/va+ReDXBSgwO+CyUVoGQVkxyLqMfMwoH58iDPHQXN9lhteG18In",
+	"CDeO2883/rvvaZv4ANBBdWq7G8SMbxTafXtnn2YQWm85+PDGXLLyvcEK+FuIPjgAzNUTCDutrK2NT/yL",
+	"S566E202d3jBsnyKCYPEWaWgbtOWwT2s1W2aN2XgTF7h+CMA3I60thT3NTfnFSDShYRKgqzLxNDVXcgU",
+	"WYgz1xHoWKis0FK5RIUIDnEJtUFqt4q2W12t4Z9oK0IYYpfu2RDOWHjKoGduIgzmejaDONgmMRxQMygE",
+	"cTA6XmwEZfURg8WTNCA4UX5A1PdopkZAjHYSaN+ygfNy0v1HmAwC7Yd1i1MErComlAMcKEhgD19SWPso",
+	"1BqMqPtcZXghuSyqMsC5c2kOkZa2w6hrXfhur50HdI06ZHNdL687SIsGZwoMpz8weN/2ap3VV9FeX78h",
+	"Bnf3cPFXQGpvLEDAaEd4czB11bgXsL7opQttzvqJCkjthKgeEc49u+JpWk7LnCOCeqmQ0SBsf4ADJbTJ",
+	"RKU8z20tFSKwUSaVdYJnfpWC60WXlg1MqWqHZECgFji6qkBGuPrz9rzniSEEXAnwezgzg5mHcS9FXq91",
+	"tT2s9WYn69HVd7fUcxuj+T96WDPhstIEfAOEhcrDTt44bt36oR1XZBtiI8CtR0CmbFg6yHlpQOs9cMeN",
+	"DEeoVLycT9wIl9wEm73l/N3ZUajRG0EU/xnB1/nViOFe3drWdvDWcc1bCP+eYpdveZVW1xRzbKqtWwod",
+	"HsKUAOP2oHKpx4oxoWKxHz2YLTX0hOWwtkvRxu8p/6lwVoNwY8WE2zuWwkZMAWaCMIq1CYv8IHmvgQy+",
+	"VZl7P2G+74rzhNjmBmgxd7UKh7QNEciYvQSHkB9L1gNjI1G/6WEFBCgMpuc4w8+FsXVsMSZVVceKW7iz",
+	"JJSmRBW89C9PuUsn4H0vnZ5yJ1MaAnqEuD2zAJSbQsUrwOhiTrMZpElV5lk4kcrzAmIUpXIyx7wnGhzP",
+	"o4pvu8xqxhM1iCjVgwoefCq4shCtBdwHqlpbZ+gK9kLmOSjc8VI3gPRyFaHGQg0tjN8GnPKADh6CdOlz",
+	"S9YGIh7EoXbD8vqZOaHgtGCjlklXLRjP89l3Ve6vTiCYBQxAp4PAoBqjwi8GwJctgl8vhx+/p8LhdvHF",
+	"1w9tDlEcKVKqmtPAnzQSFb06fDzgidZszmCO1I4dgwNTkcefGGL8xgWGKdU9jwzSpYWiA05MC8TIoOmT",
+	"CkL8Fjx7/Ra3dcxQEjaprnZqTnqpMhv88jmf2Zg/gNUQPMORlVdrOEvUAKCcBg3QLoD1guzMesVBqvpH",
+	"TnulEf6Vug4uLYqHsRXgQTWPgA2DpQdBZ4aTQS51PxpIzSFAgwnP9EWoqDwVynVZGsSMdKwsQnpsUJFp",
+	"rjCUHGqP/6MUKhUkgwALF2DB7AVFsEgqN24x2O47NhE8d5MZ1rS9FHThcCYh0rxUED00GGmTiv/AGubS",
+	"xvsI6kbNWKEtlHasVhfuPCAbibsA1VCfO64JJQxX1S2o8ESpKKYuw9udAJ6Uz+KFS+WIbLtzSdQVE2fn",
+	"spAaPsytXmAcl+r2fYnQ6fo6uw2GBXw/ehofDIaNk5tKVdNTF5b0U4QAOPevF7FBHwM3uJXAjWPsMIRu",
+	"rBzxCQ7zTMywVqxnWHwkIO7RmRkC7AIK7QgvJcJswOsAsHnAxlJdiCwwzRoD8Hq9kSqVBc+Rn4QKF2Rn",
+	"BL0YGkdMKUL19TaFuICOwrLh79XCxSjLdNZDeLglKMh/7XamUoW/n86HjXQ7l72x7vmHPc+RewHnsQd8",
+	"T5jO3ojnVlCW/jYYFKzqlULYnt1070t01ucxBiDufJWA2cABe6XTCI09r5J7nfdcsHfHr2LOb0u7huLh",
+	"+6vB5AClatbbH8HWLNB0OR4T3p7OcwRx9jJbKma9mZbZZvNTqeS0nNbpwm/6WJhPAQC7jxkOXgXAMikV",
+	"EGrWhrELusStAO3ep9RYpMNgPUCAYCwHtFRyrMxaCGfn4PlBDTB9G8kLNXDuO7VRyhaBhMH2J/jdFu+N",
+	"qYdbDgJ8S9S4cNpwOKyE2d9NzO+9Uc2QBMLZ+tIyG6hhM3DrCghydaJ5rVzGicAKA1t1Ri10hwFSyxX+",
+	"fXRT1ibEbBjo/QsKahvlhlp0bcd2hmKMiQhLKhv5n2tLuS0eUfUAPa40Bp9usdvl1PF2ccEZeICvbQbe",
+	"G4KCuXsGsDjF65BUmguuqMhfe4IwvtDOEOZkZCuub+n0aHSqVuMav79V5kJzWlmcCl+hOtKfO9HAbFhZ",
+	"MHFZeGl+YxwJixPVqae1xhdH5yb45n46OGCPfiqcnErrZFpduaczSAQzOn9cH19IgtPmbJTriydP9hL1",
+	"1Fu+PKtBq2NiiRHjMucmIFAHh5vtspQXLnr9E8UYG8zDLddupciAhoI2PJ0ABnainvXZgZ4WpRNYe8Ky",
+	"XKO3csgtlKslMHSeIf6yTdRXfXZSDv0aoM6P6xHAA2O9igDKzB5BrYK/sHMck30MYw0eRCx5Ae/Nlc6z",
+	"rBAGtYLHfsHeVpeGdUAmjjAmOETqgsqoTbECGTlqMYYB4Ny5moV3oTIr5XrixWSdkKRlfIjubqwpwL7e",
+	"/ZYF6yxRcXnJaEKTEnAa/IelYxcTmU7Ai1JVQoP998PI82rIMNhu2AZuBBOXIi3B0145kc8lZ8+ODqCF",
+	"KrU03N+hjuRnIQ3TFypuAl7F4ur18K0M8aR6gI496+E+XBBJ2m6MEWk5VxUVtl77AUHcqtDGLu8oza9l",
+	"HJuJ8aqu87wBcKNXj58+vFAdCY7ABnUM77x84R2sVmATWQmu3cBd0qtWWr298n5v5yr3XXC7Ubm+78gB",
+	"LLEQws1LdhKwC0D/15HmH2p/nco1YbQLWtWiPti2edUrdfI5zDq3rAM+R8FzVSuiAZN0T/IPb6ZA8RYC",
+	"e92KBbwB8twBNrLcdNn3P3++dAqAXavok+YTuOkDTa6NhPQLdXO28wI9LlpDa5S9m6TI29UZP96uwb5W",
+	"uwhnIephW9QMrz+oP6lyeM0Fu7o+eCu+lODS2BYXqRA427nIieNjUVtdBFq6/zwExo2DvXvjc710xZEy",
+	"60f9IFs3ye8bi7lTkQXK/PRDYQTPNj8Sx/7tz+NA+KHei+MQhrIKP5xnd3Me7kwg/TznmYAcdsgBSz+X",
+	"Q1j39d7IUbT8XKBDc4WmC6Fn9RUPH30u1lcY70p1JbwUCug/iIm12lOISWxoTzXiuEn63PkQ/41CROf5",
+	"kKdny+n2mN7YBuV2P7SFCNVHeNUooXtzEPyyiQyivB6OwNoAOZ3nsFTtNgTC/N7wkfByYXP16fN1S9xb",
+	"a+LkwYy4tgbTvDS/kQMBF7ibH4hf4PXPw6CAsX4OR+IXDGZ4OBjXPhgXRJarz4O4dEJB2IQ/F1JZx720",
+	"XlNoiN56ET++paJD8/1uUnsofsWquWKg91wgpmx9sVrA2NDqpdv5oOYKnrYUdVmYSHu4XFMbVOtixVfm",
+	"K4SuDiPSwZb1xLbt2mh75ncHYIBU2/4s255lWVv0zv1Y9pvn9vPTuyNGf+2Nh/R7M+uZUlFs5Twp0EeM",
+	"s4KnZ8D0LMI9rKGI9Qd2J9VqJMcg98vW+zn/c2nEPTu9WyjKE2b6eRDSsUjDgFcwkWPMQ2/jIix8T0lA",
+	"16agTFrIU1mqOj7HFx74f+0mBZdkxc7RG0tEQExuhXpyUo0BnSarcLauu5dGrwh8x4J3f3A+4CfZxgK2",
+	"eeTn+lxxA2d0sURIVFX4NlYYNiAIxFdYThIv1MPRbm4RrsiKk40vMM6ywARudsv08DeROntFY+Yn+uoz",
+	"3beNTKnY9WsxHQqziR0VP2FT+IbR6rbaUvQb8eLh7OaPI2Z8Lj+OmAz5h+fROM3b5tKbnf93lJR7Bf0+",
+	"pLB+IrWQcbD65MexH4W3b+PkUWevuZIjclStrZ4cA8mD0TOlr9sPH59/v+HGiLNdtXAbODHml++PKOcW",
+	"Nmtxc47ClgjHM+54v+Z6vBmgiTDrpYgTYQhKOzbSpcpaHSiLRBRHfD3i2AkJVzsf6F9XopefY9TBnZBN",
+	"+4VrFQpxP+5ar0CAIU+mRoiLRFDV15HTaeka9EANrCCHae7JYKozkddZ67w5jiB0biLYW8MziSg/7PUr",
+	"VhiRydRpw1LueK7HkEQ5oHbp10E/UUfhRUzfyzXPRIZgIYOk3N39Kp3mp5k08G+xg4/8FtIDhMMTl4W2",
+	"3hSMcGtU9xEQQA8ZTCQMZVn9l2oo263CPRJGqFRU3a0yfmrrY4QzUpy3Yl88vfnxLWVC+8sA6WArIM20",
+	"Bmpj2YUwyLEC/F7tQuWWhhxuZkIurJhDy7mlYbydCFYqz5eyUPizjuhr4nmSFrwapV0DAQiVKKSzEEcg",
+	"VOZ/Qpxcns1aNYZl59R2aueeni7P50ZoOMeHkGZdHfZHzgjBhLJiOsxFl+r7QfHTk59fP2YaEOUwZXmU",
+	"qJHgrjSeH8EQ+uw1MJxP4ASJivDOYIz437EGzKDB0wYR7z0HI2ZUSc1EFTWehBnX0rAwVtrtNiZCZ7Wz",
+	"LZd/k3Hcmad2fhhrmVdAY/n6ls88sqKQZP9oyvORNlNPGDqbdcOO9qCSEJtKC9nkjz9ThnqTiuj6IUex",
+	"VKmitaKotzSI74GROK2pNNMj5ATs6e7u7i4z+sI+/rPxeGLMS5g8jvcGwhFgQqjDlybv7HV2IK6FlMkP",
+	"C1U7ZXrGpHJVUW2nCaoDFDRcpv2jQ4Bo+OILdoD1qV/JoeFGCusf01uF0ecyExbg2HtjoTwHFhk7ef4j",
+	"lSX3Tf5UCLV/dBiVYFjUPd9Mjz158oN+8mSPDcbSTcphP9XTHYScy4b0j52x3inOxjs2OxvgJ29nhTiB",
+	"OcGn/3vug56zA/ZIFdPH+PrRzE20glfphQKeDNijo9nRIWBz7Oc5jtqLOwTL5KNQj75wzUL0AcreTYwu",
+	"xxOW6kwwmn1AR4HKASadSCdSVxqeQw3wcykuIrMDHFxupNWKSkCWVrCUW8HGpcw4YDBbgSgWv065VBFc",
+	"Bfp5/2jiXGH3dmjefal3Mp3axyAOybQaC+ekGp8GqKVu57KXSVvkfPYG3/gB32An9Td0avmoB8wagcl+",
+	"7fwCQCAnz39kdqLLPGOHMF4vu6dACr+J1P2vTrfzN33BMs0OG2CpjZXzb/0y8Zwz5YodspFUGa5iKFT+",
+	"vzrvFwtHvNZKOijpnwWkkJkuTaDZNC+tE+ZLS3jU8B4e64qW4RX2N3ghgLLQh+GziAkdydsInvecnIrA",
+	"JTRin1BdPOhnwk1m95DiCA/bk9w+VEvIGm9VEDE8xw8yMTZexYKa99r3gy824AxKF0c6KlVa/75UtS4P",
+	"jITCCGyEsAuW8dFIpLDJ1BxkOOKnoH7DZ9h270JmIn5K60YrD3Ua/Ge4fiydiPQsrtceG/zw4i3bwaH8",
+	"Dof1yOipcBNRWm8hG5na8Bb9OfB6aKGNY18/2931rWORQGErcG6AfAfcUhMpaRpHxOzMOjGlqoS5MDBR",
+	"qUaGY9WK0oh+/UjQItYB+RZPRaCU13MvtRyMSO+4HHLkz0PYKRmocYZEz51/F0Bi5Qjklwt0h7QlLBTg",
+	"aBykau5E6rAE1dq2nxbC0gFATc/AWs5Kn73FnxEfFN6oAJyAYhEun03L3MkijzUXw4lCJEhA80GxzDIx",
+	"kgqZVlx/1N1nhYCjA0XKw4BofCiBnjyBsrTY1JMnOM+0tE5Pw8hrUWKJ+mUic8ECpHEX+yYgfISojGfY",
+	"inPh2fBQKDGSzkYB5KUJO+Ej4eD0vFAWzgwMMtXKSgsozKG2ZVwe/BpRs34XGTv0CyPV2Dfyssxz9lZc",
+	"OnzKYFv9/D1dQqFvL3ih3HBRGF0Y6Tf3+1ycCzZFlH1q/3vhPBmdCC9MfNN+uD1+wQ1tBRD71E8TJulf",
+	"g1q+VGBIZawQBvqESpy+Taz6TCOHoeDEcSdQ+gWHFUDH1TCtaNtr28ROwi7XNAOYsHVcZdxkjbfrW1rt",
+	"JezGYDDwGmCiPiSKsaQTlvqUNL6ks8fgJ/8jpGbnovbMP8U3Gw/9Yz8n/zDp4BVZ0unWf/Zb4PmGsHNf",
+	"wrfSzXWz2Cp6JRut4isRQBeI37/8awKIN0mny5LOmZhdaJMlnff1Dz92myPwJtKNDmDipvmaPr36uKZP",
+	"uDlp6RIuZPDblhF+3GyIm61M8LquGWnLpq/deKKy0k20WT6Z5heNP2t/fGxQG8+CQXDU6B5w2BtvxpWR",
+	"Ks3LTPSk6vE8D2SEhNmNFBKXirqG/31M1Ec4WojZ93ym+FSmNW7FHg3aRjR4DMrMYM14B6zHflL5jCpy",
+	"jKTIsyADoNb4oFrjAXtkRKqnUwFVDDz7q/Gmx2u6w8ohPeKoXv0KneGUAF7u0SgXlzKoSzbXF8JAw4cj",
+	"tNKRr4msGz6rcVEbIyJwrd4g1DpFJgDKYQ/9V23ENUDWpvCjxrT9TKMszEC0+Kao/XBrn2n1pbc0JsJI",
+	"xwZLNn+AhlXBvergW9n3xxDkKjW0tzhGOqo0xMGyMxrPCev3+x8HxOuJpVdh5/j8i9oQ4eQOEgVj8UOh",
+	"b0Dk4WGxtPYzv9QTfYE6HWwlbmSfvQ46BmoKVCshah7wVhSPUX6fYF0Y/w3YeCuZ7ntPQaFCdpRP/jds",
+	"HptsDmR9q01WXu9iAK16nXLAHvmXH4NIrh736TsybX/x+4NSvMdtb6bL3mYT80PA7065PZ3p8hS3dc1o",
+	"uvWhnD4bGz4dNJ99Rc/mhn0Ke3daGDGSl8RbQJM60NMhIcCz4zIX4dwMfH94QzTw8mcApva0dCUcXHHp",
+	"VVJ5LtijdKK1FVDoiFtWGDnlBknpMZoU1QPLHmG7XWr0MViUQ7Cth8CCENaFG8m9SvtoENa7ywaL6zVA",
+	"JtTyA/sLi5965qMvqG1dusYY2SNwhvAsszRncDDMn5VYIq1Wjwpv78ArkJLG3SNy38EhJcpOtHETrrI+",
+	"e3HpX7Mpz7kB5zpo+QgoCucQ7YGhgONGp4xJmyhszDNBzyUzDaxRF1gdj15TVPHEDxdQXXuAnwqWAh+L",
+	"RAU3NxuC9R+8SQNtMmFOh7NBf5FPQNsDtPHq5QIbRxvYJfF2mE2E4XFQVVHgvLVx/USdCMcG/t+ebwch",
+	"AVcbtFtdpsqpMDLdUeX/x9u3NzduY/l+FVTPbI2kiLJsd3eySqV23ba7441fYznJ7h2lLEiEJcYUwQEo",
+	"u5Wunj/vB7gf8X6SWzgPAKToRycz95/ELZJ4HpwXzjm/1UyZHQLA6E+Kmda5ksWO+3/fcWXlbPwd98eO",
+	"+8tWclXChUmeFXc8vAEzNwTOsohcmPGtll8vqjf7rZimen6D/wDkKwA0RAmXb2DppSjXszybu50BZwxC",
+	"WvF6AFmt1rYicBLYF5Ivm7/YmnoN/UwK94mjEFpfftlzT1HJO9eGmqtUAULivTJeJFZqVeaOY4CJpYrA",
+	"g1klp9OXqnkOHjNn7MmVew41lXA/S1kt+3hlMykKJ+ZzsJTK5caCg8KPBiY3U4QHOpf5oM0eoIz+G1nV",
+	"LIFHteDJK7S18KHbVnDiRM/rhLklD90nxFqJwlgRQdWqj+NqWghPDqmty2JbZSWuHh7hgdiybLzYaQzd",
+	"//7o6J9UFMfO5geANHLICTnT9+R7mYaNIIYOK+BFWR/rCivAA8g37sAIWch84zaf5AAzI1EooLzMqHmV",
+	"bwQPdTApDlLAtNs63ZVG3pFZ8PQw+p87RQ3CmhRYGHkgLhyNh3LNgAcKqHlxxa+ZNCZTJoZJpcLEk2Il",
+	"N4gwGDE4P2rPEkJd57nOI0KH0mFy4YTapLjNjK3Ad+rW7hZqLc9ziJmA2wdEG8wKHsa37HU0Sjp1F9j1",
+	"pHiQZuW6Wa8KxHOFhbrJs1s138xzdQOx+FPhRo7CRkzpvKbTCB92UtCoIeF9PZ8rldoW3o04hJPiHXJN",
+	"tw2kLgcVGjwauLej2vltOxF1AydVH71REeiwOYSaJsw+pyRX9yonoadvibZQIoKWCV+hcFSohspcTG9Q",
+	"m4aX3cDBv4PHklSw0TYP+kKTzP0VueXARuPZgdnkTkOCtcpbFZq+eEZj6Yupk07TrkCXEIyKUBU19ADC",
+	"AhUUnFzHyZzpIGo3Uv2CxqeN+1dNz/OKVHdQNw6uQSGlDQPHF/3iFb8EnGIJqNo4DSAdvBbQd6ogVxTB",
+	"Qcp8YzOL4QJAVejusX0RLaej+9AUXSoOoFNUMZ/q9Pvrs1NRyQXYJyTZuTd4VmvP634J6l0J1mZn2waW",
+	"lHlcNzR0cmT7rhMod1+phTaZm8NtllfK2MGj2mZCHr/YCAjiEhZkXWnmEIMWDf8PaPO+IxwfkJdIxI9X",
+	"pzugCBEV0ZLwtE3XM41z1LigF2YXgR5IH3NNnoNKZkWHlDL0Od/mWjoS86sIUQG278h4DuDVc20UjY6U",
+	"ONfatVmrHWAgpHv5AR05le46W6loGKzvwZes7ZHeGXWNom6HoY6Au/eFuldYPR7b/6C0LSXghoUOFkrD",
+	"9YXr4FRWWbVO1U6uiwX8JeBZ6CgnhDlHKVzUmue4UNouJdLFIez5R7FQGiC3srmAZ6ElglUGQjNqQa5y",
+	"HOiYmF8YpVrNFAha1/hPEPwj/G9E2OjzB3cO+KijrbHZKsulceIT6Zh2Jdcz1+C7rHB8B5zpcVNRC9lK",
+	"LuhMuP/N8Itw+IDNgGnpL/wJfmDLpqLb+MjJgzwVOeOtMoajmGKVeQpHjr1d24JqKv7v//4/Yhr5ELZe",
+	"RdPCveqY5oRB9uJviepbPycajl/3P/3i3TAeI/49qoLB215DQxdgeuINGltRGvxlXnknfzrdVk5vvLEz",
+	"7fVGcFjgsjOIxqD285uWv8V4h0xZ+BZ9ZcwhVrJ08hjdPF4eU4SEQHeIa/7gJAoe8A3SvGG24lyunIJx",
+	"qIt7NJ7gcd04CZsdUQBfeBGDDN7Fhj8JhYJd395mHxUvzWUsN8FVisLM7TL6G8DZZoU22SILjUIoHLTw",
+	"AzFJEpzgyHnM+TNu9/v8sxw0x6jKf5Ez6wm3Eq0oOXec4kNOpSAQwiM/0xaxEb1FExSdvQR0AmGX6N1r",
+	"fXmfXt5/yct1CddR6UKJInEtCPwx/gwI752ylbg0cl45qYPuRvCskgUDgCRN7SPS1xCrBpwVK0Lgdk2g",
+	"g4ypFXwd7LOGy7asWIwibtP0LSq6ppvpailuvXaDkdfgGCFPUSIO0rRdu2jqD1E8AcUFwDxRhwLVo6kU",
+	"wTl2ehMoN4zez3aAa2GM3t6n/NjA/Etn3RU19ezW87c//UlchhsCd/ptlsZXkW1+RWJ6S3mvxDJbLJUJ",
+	"Bspc24ohLgKt2szWlTxqwrGSWwn3+N5bjR6z4i+VvxoH95QktB6Sqm2rDnw5pjs/KmcdLgHPqC6QYVIo",
+	"SqMR1bk9OE59dC7MKd6Ghk+9VMY7+NwBtmS8CZv9hvaoHxS4SnAPjpj9X1+fio5TlpJrnZxm9whsxKF1",
+	"uB42DBCxrYJaD8VnCXI5CjO4dQssA9OGktwUSXUUXtuaulErfU+JjhCRtzCA5koAagi7uy4gIICAoK7k",
+	"bSVygJLyOhHCkx7G1QjcI1+PAWYNljlCRkN4AXodMGphWlX5DY952nqVDQIBtQqC9iLnzuRV/DG+svd6",
+	"6Z8+eQdObf3r78DXVpmbLH3hpS44zuSjt0vxxegLbiy/1w8iqwDZyY56PUfUgSgQPI1IyFv3NSLygYiZ",
+	"CeoL8TgrYuWHTsZsI1J1K9d5hb78mmYFaFYiK6xbK12AiHm3TXpmXVhnJJiN2B8yNnMLEbrPjwkALq2R",
+	"OpqIfK6dZMiUFdlqpdIMsmpEhwBuqE8YyhGdMGwDovtVKjq7w+Ewbh9qpWcrhbdRC+1DGWFoc11YVdi1",
+	"N+gPMVzDnYMrRTo46mUcsCU5pKOqW1KQUKpk6k58vNTPHBI0r544Il+ntYfel1p3Er/kDEFX//oT1PRd",
+	"P+IQe8Rh3TxfMOgbbuK50IR6+AHf25DSFw/sJQEEV/g5EBIdx4g8SKcmd35plHViIytq9odFwUQu/0Jc",
+	"vT/c39//d4GTFx01WAz6Yro33HuTDHeT4e717t5oOBwNh/8LL+jC+Q8Y+2yuPGQ5Rj6K4Nb0bgBmCe9x",
+	"mYtJ4QbNpGXBKftBR6wD3kMVd39onUUbjjP8+mblfnwjVlmxrkj4771euh/3XoulXhv87WtwHX0tUrmx",
+	"kJoj6cpv9+03S1RU3V/upV3xoNQdj9mdrkNpUQF1NgJWJA1xibAJzaO0fWJ2l4+dmFza6kZCFpujirDd",
+	"jCrKXHYX5kPMdlr7bDoQlEQOd4aeCegC0RrxPadFQcwXQieS+CI0yWvldEFnbR1KUJZfODGQlmHQ7mMl",
+	"VFEBv6SR81bQ2D37pq5P9UJcaYyqfmGv+8PaUp3qRZuGgtX2U+p2fwjb7xWPmmq7lM7SUAYQOGmzQ3Dh",
+	"GG9d6cA5og2WOAZvxgmXojMdVVMyZsWd2li0sy86u10C4gSqPNfoCEmVVSaTObtgC6VSlKCgM5NMs3NZ",
+	"wGf/2B0OEydSPnrteCkLeA66lrNKgstgptMMD8ZZVmQrmfMVsld7Recf+0Mx21SkoPKnXVwFDFd8D/KQ",
+	"ySIRFPZxpzYMLVppDkgOWmfnH6tsbjSd2C5NOsMbdl1QeGMuIcQTmp3LHN0UqyzPgfpjZRVHxEi079RS",
+	"3mfa0JCuWoV+x9e5QiDQRJyC6E/AO+8jK0WnNCj2RLrGlBiEs4RP3iTYnFgYOVdulTKdCkWxqhHmJuSh",
+	"CqOohRT1E1QDUq8ceIXAdgV1C7vxsFT5ilNBMK6aibUeAu4oMAI6xSTBxYLjLZhkOOabTsnJ+fsLgYkG",
+	"rhPXSKyrx6fsu73XvpkbuFy/l/l3+0PLrcAeqDRG0A0KDjiMv3u9J6Lm3qzctlYyv6H3v9vd3/+6dtN0",
+	"BlCiPLQti6DXoytJOH+6cQVJREBs0EbRrnX7IAQaHUDGGCYTa0m3pU1nna0LPJlDrpGfMwTRSHNH8XRe",
+	"P/SbzVJ7pe9p6HyAVNUcmZvTqqw2dK0BY8zz+DyVRjtGDmH3lUYucmnUfabXNt+07ATePNKxWcpiAQiz",
+	"1OPjS1aoh8bgMGDuIchmSasXq8Rta3ccRm/UXObzdQ6yF223sIeRZxOp4TRbZVXsanAHX8/vIBNoabS/",
+	"sWKNqtfD0Lvz60vwj2yKuZi7LywHj3NWAGSEcJN4AIgHQST21iqyHHFrkxXiHzX2Qg3wIaGsJwjsp5vR",
+	"WqU9CCK/PvXr11wzvifFiAFsKyj1oBC5Jlh/Y+VNG/7zXBY6zreAhp7OtoDBviTX4kiLExBPcP2MmQY+",
+	"1p/sIZLujs54TvW0pJTvd8VclpgMwwuBs+ZUjb/YWqbGXImZqh6UKoT3ubE3E9wrrXkYJOXxDiTimegO",
+	"c8PEJGwctiWsKcsJ22KlzEIBMfUnxUzO79bljlEg8/vsscnus3Qt80ga+gQNTMy8qAXwH9/eZvNMFRXE",
+	"7bpuoUYQoittxfoARUhhUeBSCi9GKMHIJ4XPmML4JHJO0oT8NcCd2lAMWSkzY7vBJaSs6Pjbe1BXePRH",
+	"mWNFM0CRjipZtychAso0XeNDAhVFe8R1x+nYyxg5Fu/fJ8VeUi4RRwaKm3f2Lg+deNSVnut8IOCywafM",
+	"e7ltS1nYsGqYucX3DpOi6a0DSGwrsgpqqIo0muA2wvqW72N3IM4o5j2kssLVobLi+9PDSPWG7B2VQ2hx",
+	"DJMLAyTk9Ag8F1WIOkrNHOLnIhQ8UjUohA2x1A/QfZfn/CsHkfRr3eKi1nqYFK8H4jJuXWIyNTpwJPNZ",
+	"lC2VFkZZnd9H3b8ZiCvG5cu1Lr1GhI3QjaoP6IFrW1LG47FRthuu+XvMzmTjttfzF2+O7Z1rH0BycHni",
+	"Wb9IxK9riuqp+GD4BDZqB+iTkwJZZ0PBANmEmPNH1KcNgoiKSi9UtURXkRPkGEs0y+Fy6HB7FriKS1mk",
+	"uUoBb93ES0Rix7MA18o/9oYryxIoioXBQ1Q1zl2vFxkuNW2cPkC3kx0JrAsh3oTGwV3wSNuNcUDUPl42",
+	"wL6vQWPgNiMJ+KCNrRLIm+1sTZdsiA9raWRRKb+t0RYQucKKs++gg8wkqzZdvLPZWmaRWe4JhFfHqSzo",
+	"1IMqa6smFWIaQuqs3MakRCdo/HXChbtMeatoFt4XECtOjp0ZhToNHllPVURR5FBZW2UcO7vNciW+glsv",
+	"lGo4NLgpSCiajlg3hN+CN4cXKabGd+v8jm5wLJ0E4K15nmiTFNrpKgth1UoWbNOCWgVi7QzEWufIcbLx",
+	"ppjDFMdes+Lca1XyDW4tBVt9pHBb5IR6bebKijy7U2K81GV2u+lPikttq4VxonS8D+FMssAAQ79S9OVA",
+	"HORWi7tCPxRC2hG1Wlfz+pPC/exkBUpjvEKBdOycflEJpLeYOb4CXPydk4XYD8yJpsM+MhrPbBOCaO/U",
+	"ZsDOAbcHRqnkQW5QExhNCt4dR3G0432BASpWYMRjGh6whPW0MQOfHLiVafqPCxu0vf1q0zRgC0q54Dj/",
+	"TpjEnXInZm8gxsrJH/y9hERUXddoAnPc9/GT8MSOxLrEGbIDcWsy9H7bnEqITn/tJEOpZAXsrHDqGowi",
+	"EQVp5hAeGRg4a3buLdt23CgigGhq52wz/usp3M+Pj0+PD69FT7y/ujjjUHgrLq6Ojq/Eu/8RWSpOT85O",
+	"rqEWhrh4/358fC2G00khRAKkH4fPH71zC0XTc0NfbmYmS/2trvvmal2QB4CznpZ6bfLNTiqzfNPFu1np",
+	"T4xPlMGD4eQWjBvSsGW6yoodWWY7e8O918lwd4cnMPjV6uI/INj1uyx1bHfvbe5Mou/23tRGHxE9Fxij",
+	"JE9jAUSX6QS/obnN1FyvfMoqlkTDnvEK0o96XwCPOJV3CtPjgaTAbwUhQ6IzdedyZzgc7sKYp33hf9nj",
+	"XwaDQRf7R4UY2RZSDJz2B2nUUjv5rT4CR8O3L9Hgpa6yQsCC9IVVULKANB4grdmGaA8H7kY9M9n8zrZQ",
+	"SarySt4gs/WE4rT3QCm1NW4MkZKmPaXgm1TYN9cPCctysnMguj98jglojsTfcTY0KztjdypyZS0pO7iJ",
+	"1nFPcK5RQn7ixFcleQUdY8W5uzaCkIMNk7cKlTeoQJrdoqVq1iW5pxrKyLgySq6i4hh9d2SNLFLXEfqR",
+	"0UGJU/j54Or85PwDjrcCcUlBg8V8bSDBHtkKUqVbipwSK4xjlc5SIvUFo72RPTjtThf5JthRzvICDn6F",
+	"1hdcEmOOGpplsCH30mR6bb2TkyrFUJyMI6PRzs5OKavlTqV38EOIENRQssGRGfndEjG1+6Odndl6fqcq",
+	"+MS9eLCSv+lCjPdd/zSU2K7kwHaiEdgf7EbYQpZ2qX3govjBURz7gyfFEcSzR4Ya2ZKwnlTyjuI82OIM",
+	"RiJKsMyIdZH9fY1SLHYDNJFwtr0AcM4vGm88XnDhEdMJFMI7d1TxbNRsf+sPE6wLc3Moiobs8Xnbv2EA",
+	"YsxqLNpqPc4C3ZDVHrwMLd6CYzQQ/YUvaXK1Kgm3jZjmPhVt2w7G7E+KIEKg1IB0mjllx4HvwWkncDCu",
+	"1DwrDVDhlSzuxPs1XDR1rq7ee3Mc1YFasDcEWEPE95hEFNyrE5dH/7rdFJX8iAm/+kGZ23UuovFnxQJO",
+	"B9wo10sPZE4bmM50uhk5hrCulAFPIEcV4y5o4946OD9yrP/iyv33/OIaXrxyRzxqaqOkGWFtqr3h3hCL",
+	"lCyNU+rCS5NXGEpVwoPJK+8gHpMu6+d6LrG4Ty6LxVqGnmintvZlhJ5XSL8LarqPWfCxP1xmA6ZAZapY",
+	"kQaRT03WXZ1jjsDx3ojQINba44l8jySBI8E9nhQUmWYbYWXcLwsTnFo7ubRkTLjGblxjN6TD4I01UAaH",
+	"v0bby5fdk1fcb/Qdln1wwkKiuyHPswVEBPPdJq9blI9x49q/KZw9V8u/oOhSulaCqR5jFip6za/QvYgl",
+	"s0l6ePK99ddR/iDAL+ISggkpuwMrjEVM8mGpLbBGyD42FbYaFYhFz3sjeQY7o+BFXAdnzI3glh/mwjQC",
+	"d0rQPNhC9N7u3j6GF8C/Xr95O3nVGDUc7ElxUJY5VI2vHV8E+zk4P3IyFcNn2wfo97S+v19R6sNmVKn5",
+	"stC5XmzEV42TOHn1mScTbjvASMJMC2BUFWRFZnxvB8kCOAH4wd+s+n3kiR1jlFy0ExySuTXbzvnFdZho",
+	"tzFTxS0/Nlk/11SVRsEdnLi4ohSuEbC7e5VGs204VJwSo9hJRHkieLOM9QXZy23n2pOtkcVdViz6VAjG",
+	"/YxzicorMAu/OvggOlcoy2WeHKwXbj1UKj74AmZdjBZuCKIi5RpnKsRoEzM4PT1DBWebAxnuiluC10DH",
+	"s/5sSSsQqC8ZOwXsGO9BO+PxcTfmgCtp7lJno4f+4fxkhRO/Yh6ua3yYbegDBH6IFQeBymvix3iwgKoK",
+	"k+LEM5eK1tLoNfha8MT6EEd8GKq/wTIc5tJax9JtWD8rgE4sxhA4jYNDq91pTHj9nTJSVnhPjvy2VRWI",
+	"lyXEzvtKo6LjhK3XmroiDuI/OaLnlAeO/h/ekzmNHX1Qfb7hsH0eSJ+VGbestIInnvBIpFxxCaI2Tz3X",
+	"YgJ24JRFzNPDKkahiJHrQPx9DUHJns3uDprCiwOqgybylRfUXQxPA+YxbUoiCrBtyJmp93ENnKaP9GkU",
+	"qnZ0begY7uPakpvMTOZwmvl+KGI3sUT1ioFnXXuuVzrQniGTP1YVc50qQyW00aaCXChP5JhJyIENid9y",
+	"XxFq4Ibumme2sgKNdD5fG4zekcWW0hDVUoFEU3JyryCblS6kEx+vyEMhr2OlS/EGwkW6rUndrVJ+gdke",
+	"uSzhkpmFO7gf3Bu7wyH9ZGgytZg+IjRDwXp5LlcySsGGWVGMnSoWc6l3/vqgiv2EVyYZDt6+G73ffRun",
+	"koeAqVpC51aInNvEfSYdcWnWBewkCVq9rsBAJ7IOG7cRqaqoSh/u6UKWYJhQTQCxyopstV6BQ9AudZ62",
+	"V81qXdAVhFQpkStpipCQ7pZqXTRWb5UVNzCCG+Bo7tlw8CasnvxIjxeyvCmVmVMA5f5wMNxajURMG+1N",
+	"R+IHpUpUVXj6XppBYKytxH//m9C3eA/tEaewtbbupyMxdu9h9VYMYJ2vq+xehbUU6iOkNteaBtctniBn",
+	"KPD+vR6Qf3pcuWOxALF1iHVJlvrhMQXZROyCC5Cg3W/M7VR0KKy4O3rM2EqYb6R99MOKBwUXa2KlbQW1",
+	"QTGc0NjbqWsllzDJMUzBN+JrLaDYflDZYkmLrGwoPJhv0Cchs1zfKzPF6IUwt+w2YgVBwmHKOi/VG3YS",
+	"e00aWe401gmnnJ0U6bEQblIaRZyjoddEusykAPYd6TIkgLjI3YxSAcBuMvR7Fel6Shpy5PR6tawevEKj",
+	"fJwgjJxsZCFMezoCd/g46Ow1v6zohFX7ytMDOsKRhbMmV2lRSGP0A3oXNEbH7GM6JDMzCBT3ZG/Bm43N",
+	"4HFF1r9ywlKvqzxTxsaeFljyp10tXALwWV/L066QJw3F4AZRtrFc6HC4eg9EXi912VQCaJOfd8s4xRa9",
+	"czVlrtXLQm67qJAs2Y2Yj/Vy/wo24ZTKlU6h0EMtbRVrlXl/STNRpnrQPjUf03AgjMTrOkFj8anskacF",
+	"W58U78723lAJgebIST2HpN1ByCAFDwKWaMTImWZVynpqJJ2cw0YUUUuYrI9C9wP3gibOgIHcqCz96B+u",
+	"1OrGyQNfAaIec36B2f5cSYrfnooOl/7sjsTJLdQH6XNVXlzQDIDTtNmgvOmsrQLzXRtRKYj86tav/akT",
+	"t6hsVwmZL7TJquXqcS+V6GCiYXBTdVv9VKKz7afqbjmqRGfLUdXd9lSJzranquszW3Br/2K306TDDnPK",
+	"I5kTULPFPpOyt10mw5NryBuPksnH4dAQwR6UpdEfs5U7gndJoaRxPLlwUmoGS3Tww/l5lysKgga0pS/X",
+	"Cfy+mbc+2LarGxv8vTTpgzQqkfO5ysl+SjNbwcscJxiFDI1Pzo4gncWs597K/PjN252Ds6OROPjpv/fw",
+	"even/07e7O6h/KCrY2QrNMi4lmoiDq7ORuL8+OIcPh6fHYvOeC5zioerTPYxFN7rCj9WcFE5onmXVX91",
+	"NlJRcTQi+urT9VylTPq3WlelgQAtqDgDMYghT/Rciw+XP8axLNoHnrvWDi9/JP6SqjLXmygSuiV37hnO",
+	"EPaohTX4hzXu8JjqTY/xo99tAsg8T5xqna+i52tDT5dVVY52dnKnqi21rUa7u6/3X7eo/b0eMvsznRKN",
+	"ud8wpDFl8QIp5HybzhU0+5xuBmeXZIR+KGyr9uVzZywn2GJRNchJ58Jd0+23eJXQK64gTX8lizVUwokP",
+	"LkXFICaLjG5je71jjgNonw6UZ4JJ/A/kiQRkhxdMJxRu8FPqRxPCcjS1SRypAm5r62OicBVuKc1WeHjg",
+	"E2RJqKC7eVaqCKWnOAcOFTMynOtrc8s5b2FncdexJAMLKBz+iEoXQFT1zEcc/9f44vxSVku+FeF0pwZx",
+	"T+EnDytGigX//ufB2iozmDnzjIoW+qUaie8h+Gsmnb5JvyLrxkSt0uhVWTU2IaztSBzTn/XAYWiCP/JM",
+	"l4qp+GUeiYuSCyxAUGlhvXb1baMKBxQY476yW6FXbkswDZpcfL/BgH7KXNs7kaKFLhC4UQoh6VhKZEeu",
+	"00zvuOOv6/oCWIlcOLuhGjQovG1bG5S+NfErZqBbE8cZldJYrmKGthb+xCvpMWQ8KdaorzFCJH8q6vBH",
+	"mC5ygRsYcI3v8ny5bBynU/KUwej/5nWdC/rxjXFu/7wB4mK9ZIT4Jv9YH9/PJgPqPUPed+w7pl0+e4In",
+	"OrYBaiTGOdNON+ki3nTcJN5fqPkG5XrhkvEmnvVIfGrdi5H423Cw2xfDwZ77z/4v4vMU6yvUSAd8cvpO",
+	"FQla+055f66XeEHxwdfgXBu86YvJq9d77h97g6H4TF36cpIUKQ4WxLRY5/n0S+bjPqAWL9yBhxT66Nu/",
+	"YYgnyh1QgH+ZYn2/Qie6/Fa4EWgMr+ShINoApMHhipAB5jnZJekDrXZYy3Up6w8WImhd84FB1tmit9Yu",
+	"QMkQHYzkQPi07jbRP6GZPK2XvEgrYVK/1CXgwaEHdySmoTknQeA2NIEZJVxvbvVxJjP6DUCcvDsTEHxO",
+	"np1KqQqZtU0Fitz5tU32E7uCmnn0piyzmztF92f2LhkMBvFUzngK7c1MRWf3zf7btNtveQPnITr7w6/3",
+	"2t6QqUyGwz3fhi/opfUiV+KDckv23MQX+NbzEx8OX0eOVwDMoaoKk1erTUI/BXc3lQTjG99krorKyHw3",
+	"ZLbHrPjrt99Eubs12kaZGZf1IlcVSsxQue3g57F4p1Kj53fPzXpGr7WRLoQoDaqskkVEZMl9GDkWJvMz",
+	"U9JWyW7rrj/emCPaR5/uuadzvVRGDfB3VSzyzC6T+/2tR7BIeVYs1jJ3zxn2Jqzdia+pMinIsGWFcy59",
+	"XpwvZgYqCHqHQA9hO7VdjwkpwVD/e+xVH9G5ftDJuJIL1eVCC9hGuAPyl7KwpfXqiNVS0XUOarXRw9a7",
+	"gycFclPu//PNr7iobtD/fmfDeS7vZauhFgc693qsXdKKdqbw4bTrF9ZurSxUafOipRPz1q6vNBbkUK83",
+	"9kW+qS+kblI5ej0UHRAnir336Y+kXGZArjN513gCn+xPGYbGcWhEUiur5LV278FfSbU2s/BPDQOlr5C9",
+	"4VfwZ7I3GCa3ubTLRH0s4SP8fXfwxrGnxi/wJrV1UDiltcQEl+k8l+tUJfvJm8TqolBVsjfce7073MNj",
+	"yU91ubbwZLi39+9TRrwBvsJ4bdjo4PEGk/u90dCLqnO8EIlOboeCO/kUAb4WXWxyCSe0Adt55R88KLvD",
+	"vS84KTVR8lJh8pw42ToCuO9/sds3vY6XeYOYmZp38CN380U3pC85UGNKHhrKE/2ZSjNJRTdC3T5kidGa",
+	"E0Ptx4ncshA+T0VAoi/YbaywPThdmvf+ZIWx+0BF0qq3rwXemKeiAzGfP16ddIGu3L9GMJudX0u1+HYG",
+	"b/dR8cR/oObJseT0clm8/N0HNSufeBmH+ePVKYaHk0aHdX8R1Q8K/u7THxQ47On8wAkYgVH54ic2dX9n",
+	"g2SjBa8HRtW4abRZbVzufPLqkiL2L5e60iEGz33oa9i0LXT207uLq4fhDx8W+uDg4OB8/OPy+MfFQUPx",
+	"w8qf5MBI3oEH8hJ8F0BEWHYm+w2vZOvVk+a6uFdAe1zoja4XA8Uj+bW4Sv55ovEZxyV3WFvLkfj0CVb4",
+	"8+fJpDjkaDLx6RNHlsGDo9CeexY1//nzv8Iz2iJGeWfEGALWQwoB+LUcEW4vrltyD1u59I9/tYD8uVhn",
+	"qdqhBHaqAgPp6rwzLSVW5hJqW2DGSVRpA2vVkWd1FCr0cOu6cGRRb92ouXLSA6oJ1YqYSItXex+r2O+N",
+	"M6WJTz998tU3P3+ejsQJZlbjTQnhMsBrf8qoRvnnz4PB4NOnnewWPjjkoEOZi1wvsjm/jyV0jJEb/sL9",
+	"gp1UqPyhW4E/WBe5Y9w+ipE/w99pdPfKQLKz75S+/k/gw58/Oy7x6dN/3qmN/xtK1/t/5RL+MRKnWpdY",
+	"4ZSD6nq9d+ssr5KsEN+rvFSGc6h2B6LXs3Oznn1frfJeTyTiCm+ykYB3bLWB8LyFpZqWlZHzCkuBEFCP",
+	"0SsoRgkkO51OAx3BL58++fbFslrlN+Q7/fyZP4D/c8eWIc1xAMSeMWCBHrgh8e8AjIbfH6QpJOHlEGeI",
+	"acUzqBChciyQJTplX6TZfV8sd5Pl277Is75Q1RxzkUQI4StzmdH0MM7YKEjvTqHovwfshICCXk/9HRbu",
+	"mIOIQq4MZ77wltpH18gRYUf9nbEFJq+wAMnkVffz5wP4kwiz8b6jB3CxQRI0vM5FpYGm46+IVey7MYPs",
+	"hmF/UMUP4MKpyBGNYh3VDnf8AFJ260790Zng52uTfweC5khW8serEz/w8LhaZnYA79ysTd7yAjpWHGsi",
+	"2AvgSvDF4NdygUG7W9+ASOVsRs7WwY/K4rGPmolA253Q4gkhYvvhx6tTrFtNWYlARah2QL3tutrDWo+P",
+	"xntM8xkMBlOmSa86iJ1IdxCJ+FnNXP+2GQLra8JuSsVRbJjtJ0LKU1uOEyDE8Gki1UQkYryfAEVXUBSX",
+	"E6k6VIyNXmwu+J3aINISLFgoln1Ig7v01wRh3Xo9VBmh6rV+KHItATvBKAuXn53sllLNuv26SuEX1rd0",
+	"efTeojT5WDHXwqRyxPuAFEGjihSCJCW5Cvznjp+5z6/guOdkzYd2UFs5079leS7pLc8UkEYIShxmbHTu",
+	"6YNnhtKzNNptEGbr8s4xDDnHGjoVCFkcIV0tta3EwzKrVJ7Zih5emuzeyZ6TS2R7INx9Favx+Oq9kFUl",
+	"53eWSYuHguVmIZzTRkJ6dzg8e8fvfn99fSlSP3aoSA5WB9dS4/z/UK/zW/GbMh6WhCKFlEwdg6ZWYcOF",
+	"19e2x7A3fP1N+bGPkOZECExXY6VGoh10e6fmE/4TL2iSzDX6nF8D44Zzea11gQwc/unxcK8vLs59EcRr",
+	"cOZfmAyj86mw+jlVqes+yg1DF4BrP8DCwZ4HtT8WuSoW1fJMmjtlvkMIBacFFNV3r5/7NFWwhsp8N3k1",
+	"mVSt/Atm9p5qB4U48F5vf5i8Hf4b3lxg1AKGEJBIw8P2X+OLcybIQ0JHo8tTKsA7wtCURoUZpmGoLIMz",
+	"xFpZkC7mBPnf/rT/y0jIrE/hXKucdYNrOQP/OW2Ha31dZKGQj4dz5F4uaiETp6dnopTGksdQCLoV9Qdr",
+	"Gq/4VHRmWufdEZTs/hMXJK80Ydog/kVEpJVZK8+ucaOmAKLRHYGnkhDihS3lHE5lIG//md+3qehg1lGX",
+	"b6zJrNcGowBoKVDFhBAqMaW9nvIbls8I25J6XZXralRTuTBCSpw4/sQJ75X2gUI+xV0g7OpI/JcslDjS",
+	"eHjbN2yL1nyF2khAAv2NKWQLb238OV5k1XI9A0lfaV0kuOPwN339QYsTNyePvN/6sczLO2XvsmJnofHj",
+	"SfGz95SwrdfHuySK2UBizeD6LvWOF4h1qLCKZWYiszyzggs1qnRQw0c4RknhVhSkM0cZMMY99+g2dqUg",
+	"/odvCJoBCVi2HpsrFgSlglo3gZsGIAl/Cr7cZo6MYx/l8Hx4z2Pm6+OWa8Nq9bMlQvW3+96xAYAwuqTa",
+	"ab5a3xTT5yjmQnj4VsK6AHlRGlUqJ5Omfx5MRYaYs1TEgvFt/zxoCeoQ0e1q2Dp6H8Ba/zb8ZYBX4lPP",
+	"07LoUuIawNpYXUDC4hojktIKB4xfQJEiZC0goAykUPswUMz492nCdRBWnz9eC/zyK+qzZTPgBKAR+Xv2",
+	"308lfrX+5d6Nc12pURzb4U4eBadgRH2W51i8uBnOEt8F8I3C/jevww1b5JmGg8rFk9kX9AccT1+//abV",
+	"s+QdSn/IU/S7XdPbl5RfeMvzVM/N24hHEnIug8DBqxIxVtW6/EOO/Tf7b7eJlGDfXk6h8aX5l1ybb12c",
+	"//nTxeXx+cHJzcHlyc0Px//zuXUpWlFNej3KbQl68UNmVQ7VKL9HCA3/yPoYfcwam28gP8zjSZC9tkOB",
+	"0AC5QU55x328l7UNFTvOx2iwHESkXSnp+NHtOqcoNhshNuOpspiys+FqnNWDTmwFFmSgNvGVDzzrRhgs",
+	"YFH1qdQhfUUoV8icN9gdGrL3Vhzmeg11Pyn4AyO/7lWuSycgd0pnIs03fTF3L0ZRJRS5RkS5Y+eSi22S",
+	"ChYrK1AWpRHu+eCvdlMsaEj1GW855lDe6ywVD0udq5AHWKvzHHI3Ubdx7RzEsDBjH959DemZ+FoNOmZn",
+	"G6y6jiZDgbC7A3GE+fRxmddtmBRwIrTW4H6yij8t5b++jj9HpX2qI/8/AfnaAuf/BfDdcRtfCJyxx7CA",
+	"cUqX0xhalzcqnBDhi4RMjUdwaqNEj8dHss85YrDpztRJyMRhkOtqvmwdVXvxCGaV7uMb+LgxvigfP5dl",
+	"DUe3jrrmayq0Iu3+jff7l8fmBqp1G9gP0DKHAgRgqpRtO7uexRDXWOOAkYSyolxXk0KCXWCsQDTn9wgn",
+	"5c5dnyfGoEP470qXSEq5LJ0QQV+zT3L30D5HVP/pZ9f1UpalKiwylI1e+/K6Bj/4Dw5JR1eD5d+xTDjG",
+	"qUKpTqEKk82X7oz2m3VPqShRVNmEywwH3J6B+F4Z9Rc3Ellhfe1SzSscWOgUy/CJDsEGMfsr1APF9UKp",
+	"Kqo0XfPKdP1N8QF/da4eKNS30uKYa0FfY+ljHyjYMvP69B5bh8D8nGGPOOHRAZw5haW4vBhfix1M69/5",
+	"BP+HO6QdWqmdT/AH/PYyPaWmdwwGg23GcOyH6Pe/NiO60/IrUr9dxQkiIGR9D7lKdxQwG14OhbqbVfCj",
+	"GO5HquBDVQWo7k94VXht4VQCLEzv2lgYZa1nOWeNB/VVh+p3L110WrpTre+ErMQUCmve4BgI5y0sKPcH",
+	"WAbwZqhLYow2eC3KcMkHQDJhP3x4RGvqbb0nSMTtN8+ncp1YRAoAOIAR14CvzKaJWfBeZrlKo0bbgbYq",
+	"k/Elq/pY6sJpCzKHjde3t09sZyjI29hQRpfAtrFSe5iZs/WywufiVssIFsJiGd/sVli9UrAIlJLhIQpg",
+	"WlER3xbK6Uy3KaC5+5+nqBzCipIXDive65WqlmptGeEAVsWq5uasIbGccGFoqZu18eMKiPeZbApruIRg",
+	"Nkau6F7vUK9WuuBpivFcFdJkunbL6k1uqGX3YyHvZZZj4WBybEULTtvQ2HhgvVaZ+2yuuNqt9b78xjwY",
+	"JbbD8UGBM3Vb82qpIfBJuFNwAx6XUUyMnCTOxkRMpwx/BfWSHZcakAw/EFHlaNKyVSjcayD5yQY4+IEn",
+	"F7q98ogtklr0+vNScoFmLLdSwcQryiQG4A1tKjH179wYVcrM3HBy3VRYTY2GnFCMcnLv0ZWFye5VihVK",
+	"B/7W98odHQAlgLAI9m77my46jJQcX5mNd5kjaiI5yyFonO0VbydAEAFehrBD2wSbzhHQ39e6IrV9O0ze",
+	"X/NCYCPyOYB1BhAmVGj68a1P10/gNMINiUrUIJxFca9slS1kdKF4RZRqK13SNq3kRyErZ1lWTeok4kR1",
+	"w4N/A3XWWG6v917muVtCrvmwobP0HnJeMzgSwLngPqrvS32H+glcqp++d4t7K3PkkvCPLfp/eJTRA2tv",
+	"dao+X0+NUmMrZVbPVFOrvelzsc1C3SDHobZ5RqTy03wbrtXrZWY9u/c1i/IHubFcB43rYzD/jgLSndBZ",
+	"BxblJabHDEEtbQuT5VpTxWPils3UDGd3Gl2iO521GVTCxPTo+PT4+vhZIQDn70qhNh/wSbCrkZi2KHBt",
+	"jewPIn0KrvzslpxNWFtCmgRHZK8Xodiz9tyJagN0WTGtYaFoxqtkTP24q0nBZUKRxaNNjitJdYFkqgai",
+	"EereiVO8u3SEmoX6txX7gLQJtTDfIeM+k79qE5klfNggZwNWyKrK9rmCJrH7oIOPXqJD48f+8OA/fZQs",
+	"tplQmwkhzj2SgAFhB6sNxRtQyVdfLnkrcPGDkSXVaKA6LMfpAsLSIAQXnoZ1BSx3WFJgUlDQPdOFXWYl",
+	"upG5dlRlpBPCoZ7aQJxmd1Flu76AtgBp1k4KDnFuBWVlu6VUJkEKAkym+AwFjPswH3Fx73QC9bA9E6xw",
+	"ijdZTq90g/AlOqIxwjy5UF1GtdupCmiRUhl5N5JCUVVXLDTs2wAcNFwLf0GRLHXJMSVJVNoxXk0sVOus",
+	"pyiQbxHm0I7/5q0teLOtqIWeZzK/ocdN9zPv/FMos9EGubdj0CVl4hG+HHX2+WEbNVdFhQBbDPHwNOrm",
+	"s+Csx7DlXwjM6jlVDaH1jwKryjkeA1DbZISNcqfqGHldd6wwgAX4oZuS0/QQpjEGaUWC3gZo3TqWTXP3",
+	"KWRWavQLUVk9Ud3bGkIz7kz8S68nOlXAg+pijUJvU4DZ0YAC8+oS+VAjuLJnAaO2gXVD7vnUg09yvjDN",
+	"wo0RufCXjDE+FqSyRCMFY7TStL4wTFmFWqvRx37YQC7b1Cg6lF2aFQLoBnEOEnHExbTi1igpDBDIfbUt",
+	"UYMafQKS1O8r5Nd6VIhtXFIhbdCYr69P/3/glD4JSgqiwP5ODorxpzcvwMferXHYa3dyBX6NGCfcxLe0",
+	"8TVeRCCm+lZkBXzExRcBW8et5AH9Kt4rlf7OyfwRvhqq47m9z6WtABDWDRmmFzf6rdC5M+2Ig7SBj27B",
+	"q14pwGsoEBv3925XZRTI6ZtIRj+Had7cNG7DxyFGbX0rjLo1yi4FoFo4qZ1TIUSdp7Wd5e2L7ePfS4Rl",
+	"duNW70vJzxnI8B0Ia7dNTxEfXCnmWYrlZItUP0T2NzoyXoQQ6zkFS8c6xwhVfLj0ewvHaODMEoYryXIo",
+	"Yg24r8gYaxLU1kUoVRLyzTdBZT3utGu3s9uFlYJWCTvLKIhRrasAL8KahVYCqMWXA8bWFa4Yq5aBNAJk",
+	"7Jakfxw2llTwL4eMhe1jQMfmpj2OIfs4UiwWhfL1eJ5ChUWydZsDSkq3HQDWk147CmyERYwQK3Wia0OD",
+	"VU1i/lXPWJzeOKP7pqry7/a/FBQWp4OAsLt7XwdE2G/+fQsQ9s3r/T2v3J6RZxc0Q5U2tXAQttdQQDQ+",
+	"6KmwmTuthAQ2U3O3lZRb4fbNsXOeoecrSEGFG/q9rQ3de52bCLWxMfkoMG3TrknEIUKigLMBzqMVqdEI",
+	"h4KOQ1R+CAPYK0fHXu/1IW2QnoLqMjofqCk84pe5LISczwE4bUFgRhHQ0VYpsRaIWvDcRKNiJw+78LYR",
+	"Yg/y3Nucc70C+l/Jwjv5HoOgfaqnR8BovS9HtS/NEzCyl97c3kJmBZsl1mqd6ZJVVuiHAraXIvQJOCdd",
+	"MMZrwK+lwJc2XVZ0oGYKH8bwDWXFnWtwBSivk4+iFQUU0Hhodukm7cVNrN8SEBC8xiTVQMo9lIUbzAoo",
+	"GllJ0Uq5T0DvYsYE0fH59SUQmS9mHZnQ7fi75JXaiohyGi0lNsd1QWuqvH1xFIUnwZuaH+LRkArvQ4CQ",
+	"Ax/sRSol66zPfR6HPDyicDbbl7kjiBu8f/1D7e8uHw8HcbaDj+2qG031EISw3LEvROfZPNvaEIiocSK3",
+	"tsSD2r2gZ7u5XrCz4meIuwCctWyxjDluBGhI3wF/SUFViUldZLe+ZQY1k2KmqypXhZrfkR2LVzB2qQ2g",
+	"jzZAm6neXrZSiTPyMzZmuOQzavDWpzEHRkoT+UkZd4yarqMZqRs+TgRjKkL9SWiURxOXWAbOZxQFL2NV",
+	"hZpASsQxOPtbXB9U0bkpgg2Gt8elimHnn8aGprKKz2NDP1+q+MZXMohuHoj4sMBwNm+73XLbts5TceK2",
+	"pF6umNzuUBfBNYxX1eD5cS8eyoIQp5nGg0eMoDa9m6m1UvFFDOyFIJ+VxrCgsIo/WmVaVg5+fmmTjktl",
+	"aDeHhi/9jy3NRw9f2okzk5wCXttw6uugzH5Qm5Z+3EfuyUs7MfqBZKJPa6Pq26GzK/2A9kFLf1f6gYyH",
+	"F3d5KO0sK4TRFOS1MHpdipWjJOM4Udxxrlr7zFVLb+NsUYDTyVYyx6KwAIAk55UluFKPATiItk3O7xxF",
+	"tm0aP2oBKkcwtPFfTxNMwqZuFWRh+3y5WzXfzHMVdXfC77WeXm7Dl7G1rz7/4l6s5OKDWyd3eD95KoC5",
+	"vOq/quQCTjWJ7DqPaIGU34aXaymDvsVu4MRx1+tqGXVMh6p2BDyNBvqJWzgpiOuEZuLH0QqEbqK9Cuv4",
+	"y+dfPv+/AAAA//8=",
 }
 
 // decodeSpec returns the embedded OpenAPI spec as raw JSON bytes,

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3087,6 +3087,7 @@ paths:
 
         direct-path generation.
       operationId: restore
+      x-antfly-credential-note: Durable CDC and graph destinations require Basic or API-key authentication.
       parameters:
         - name: Idempotency-Key
           in: header
@@ -3126,6 +3127,13 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '409':
           $ref: '#/components/responses/Conflict'
+        '422':
+          description: The selected backup contains durable destinations that cannot be bound to this
+            credential type
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
         '503':
           $ref: '#/components/responses/ServiceUnavailable'
         '500':
@@ -3821,6 +3829,7 @@ paths:
       tags:
         - table_management
       operationId: createTable
+      x-antfly-credential-note: Durable CDC and graph destinations require Basic or API-key authentication.
       requestBody:
         required: true
         content:
@@ -3836,6 +3845,12 @@ paths:
                 $ref: '#/components/schemas/Table'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '422':
+          description: Durable destinations cannot be bound to this credential type
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
       security:
         - BasicAuth: []
         - ApiKeyAuth: []
@@ -4136,6 +4151,7 @@ paths:
       tags:
         - data_operations
       operationId: restoreTable
+      x-antfly-credential-note: Durable CDC and graph destinations require Basic or API-key authentication.
       parameters:
         - name: Idempotency-Key
           in: header
@@ -4174,8 +4190,82 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '409':
           $ref: '#/components/responses/Conflict'
+        '422':
+          description: The backup contains durable destinations that cannot be bound to this credential
+            type
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
         '503':
           $ref: '#/components/responses/ServiceUnavailable'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+      security:
+        - BasicAuth: []
+        - ApiKeyAuth: []
+        - BearerAuth: []
+  /db/v1/tables/{tableName}/destination-authorization:
+    parameters:
+      - name: tableName
+        in: path
+        required: true
+        description: Name of the table whose stored destinations should be adopted
+        schema:
+          type: string
+          maxLength: 255
+    post:
+      summary: Adopt stored write destinations with the current credential
+      description: >
+        Reauthorizes the table's existing CDC routes and graph resolver destinations
+
+        using the caller's current permissions. This idempotent operation is intended
+
+        for upgrading tables created before durable destination authorization was
+
+        introduced, and for explicitly transferring destination ownership after a
+
+        credential is rotated. The caller needs admin permission on the source table
+
+        and write permission on every eventual destination table.
+      tags:
+        - table_management
+      operationId: reauthorizeTableDestinations
+      responses:
+        '200':
+          description: Destination authorization was durably adopted
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - table
+                  - status
+                properties:
+                  table:
+                    type: string
+                  status:
+                    type: string
+                    enum:
+                      - authorized
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          description: Caller lacks authority on the source or a destination table
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '422':
+          description: Durable destinations cannot be bound to this credential type
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
         '500':
           $ref: '#/components/responses/InternalServerError'
       security:
@@ -5264,6 +5354,7 @@ paths:
       tags:
         - index_management
       operationId: createIndex
+      x-antfly-credential-note: Graph resolver destinations require Basic or API-key authentication.
       requestBody:
         required: true
         content:
@@ -5285,6 +5376,12 @@ paths:
           $ref: '#/components/responses/MethodNotAllowed'
         '409':
           $ref: '#/components/responses/Conflict'
+        '422':
+          description: Graph resolver destinations cannot be bound to this credential type
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
         '429':
           $ref: '#/components/responses/StorageResourceExhausted'
         '503':

--- a/py/packages/sdk/src/antfly/client_generated/api/cluster_management/restore.py
+++ b/py/packages/sdk/src/antfly/client_generated/api/cluster_management/restore.py
@@ -49,6 +49,11 @@ def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Res
 
         return response_409
 
+    if response.status_code == 422:
+        response_422 = Error.from_dict(response.json())
+
+        return response_422
+
     if response.status_code == 500:
         response_500 = Error.from_dict(response.json())
 

--- a/py/packages/sdk/src/antfly/client_generated/api/data_operations/restore_table.py
+++ b/py/packages/sdk/src/antfly/client_generated/api/data_operations/restore_table.py
@@ -53,6 +53,11 @@ def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Res
 
         return response_409
 
+    if response.status_code == 422:
+        response_422 = Error.from_dict(response.json())
+
+        return response_422
+
     if response.status_code == 500:
         response_500 = Error.from_dict(response.json())
 

--- a/py/packages/sdk/src/antfly/client_generated/api/index_management/create_index.py
+++ b/py/packages/sdk/src/antfly/client_generated/api/index_management/create_index.py
@@ -123,6 +123,11 @@ def _parse_response(
 
         return response_409
 
+    if response.status_code == 422:
+        response_422 = Error.from_dict(response.json())
+
+        return response_422
+
     if response.status_code == 429:
         response_429 = StorageResourceExhaustedError.from_dict(response.json())
 

--- a/py/packages/sdk/src/antfly/client_generated/api/table_management/create_table.py
+++ b/py/packages/sdk/src/antfly/client_generated/api/table_management/create_table.py
@@ -45,6 +45,11 @@ def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Res
 
         return response_400
 
+    if response.status_code == 422:
+        response_422 = Error.from_dict(response.json())
+
+        return response_422
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:

--- a/py/packages/sdk/src/antfly/client_generated/api/table_management/reauthorize_table_destinations.py
+++ b/py/packages/sdk/src/antfly/client_generated/api/table_management/reauthorize_table_destinations.py
@@ -1,0 +1,214 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.error import Error
+from ...models.reauthorize_table_destinations_response_200 import ReauthorizeTableDestinationsResponse200
+from ...types import Response
+
+
+def _get_kwargs(
+    table_name: str,
+) -> dict[str, Any]:
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/db/v1/tables/{table_name}/destination-authorization".format(
+            table_name=quote(str(table_name), safe=""),
+        ),
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Error | ReauthorizeTableDestinationsResponse200 | None:
+    if response.status_code == 200:
+        response_200 = ReauthorizeTableDestinationsResponse200.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 400:
+        response_400 = Error.from_dict(response.json())
+
+        return response_400
+
+    if response.status_code == 403:
+        response_403 = Error.from_dict(response.json())
+
+        return response_403
+
+    if response.status_code == 404:
+        response_404 = Error.from_dict(response.json())
+
+        return response_404
+
+    if response.status_code == 409:
+        response_409 = Error.from_dict(response.json())
+
+        return response_409
+
+    if response.status_code == 422:
+        response_422 = Error.from_dict(response.json())
+
+        return response_422
+
+    if response.status_code == 500:
+        response_500 = Error.from_dict(response.json())
+
+        return response_500
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[Error | ReauthorizeTableDestinationsResponse200]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    table_name: str,
+    *,
+    client: AuthenticatedClient,
+) -> Response[Error | ReauthorizeTableDestinationsResponse200]:
+    """Adopt stored write destinations with the current credential
+
+     Reauthorizes the table's existing CDC routes and graph resolver destinations
+    using the caller's current permissions. This idempotent operation is intended
+    for upgrading tables created before durable destination authorization was
+    introduced, and for explicitly transferring destination ownership after a
+    credential is rotated. The caller needs admin permission on the source table
+    and write permission on every eventual destination table.
+
+    Args:
+        table_name (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Error | ReauthorizeTableDestinationsResponse200]
+    """
+
+    kwargs = _get_kwargs(
+        table_name=table_name,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    table_name: str,
+    *,
+    client: AuthenticatedClient,
+) -> Error | ReauthorizeTableDestinationsResponse200 | None:
+    """Adopt stored write destinations with the current credential
+
+     Reauthorizes the table's existing CDC routes and graph resolver destinations
+    using the caller's current permissions. This idempotent operation is intended
+    for upgrading tables created before durable destination authorization was
+    introduced, and for explicitly transferring destination ownership after a
+    credential is rotated. The caller needs admin permission on the source table
+    and write permission on every eventual destination table.
+
+    Args:
+        table_name (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Error | ReauthorizeTableDestinationsResponse200
+    """
+
+    return sync_detailed(
+        table_name=table_name,
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    table_name: str,
+    *,
+    client: AuthenticatedClient,
+) -> Response[Error | ReauthorizeTableDestinationsResponse200]:
+    """Adopt stored write destinations with the current credential
+
+     Reauthorizes the table's existing CDC routes and graph resolver destinations
+    using the caller's current permissions. This idempotent operation is intended
+    for upgrading tables created before durable destination authorization was
+    introduced, and for explicitly transferring destination ownership after a
+    credential is rotated. The caller needs admin permission on the source table
+    and write permission on every eventual destination table.
+
+    Args:
+        table_name (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Error | ReauthorizeTableDestinationsResponse200]
+    """
+
+    kwargs = _get_kwargs(
+        table_name=table_name,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    table_name: str,
+    *,
+    client: AuthenticatedClient,
+) -> Error | ReauthorizeTableDestinationsResponse200 | None:
+    """Adopt stored write destinations with the current credential
+
+     Reauthorizes the table's existing CDC routes and graph resolver destinations
+    using the caller's current permissions. This idempotent operation is intended
+    for upgrading tables created before durable destination authorization was
+    introduced, and for explicitly transferring destination ownership after a
+    credential is rotated. The caller needs admin permission on the source table
+    and write permission on every eventual destination table.
+
+    Args:
+        table_name (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Error | ReauthorizeTableDestinationsResponse200
+    """
+
+    return (
+        await asyncio_detailed(
+            table_name=table_name,
+            client=client,
+        )
+    ).parsed

--- a/py/packages/sdk/src/antfly/client_generated/models/__init__.py
+++ b/py/packages/sdk/src/antfly/client_generated/models/__init__.py
@@ -659,6 +659,8 @@ from .query_strategy import QueryStrategy
 from .query_string_query import QueryStringQuery
 from .query_temporarily_unavailable_error import QueryTemporarilyUnavailableError
 from .query_temporarily_unavailable_error_code import QueryTemporarilyUnavailableErrorCode
+from .reauthorize_table_destinations_response_200 import ReauthorizeTableDestinationsResponse200
+from .reauthorize_table_destinations_response_200_status import ReauthorizeTableDestinationsResponse200Status
 from .regexp_query import RegexpQuery
 from .repair_issue_list_request import RepairIssueListRequest
 from .repair_run_request import RepairRunRequest
@@ -1482,6 +1484,8 @@ __all__ = (
     "QueryStringQuery",
     "QueryTemporarilyUnavailableError",
     "QueryTemporarilyUnavailableErrorCode",
+    "ReauthorizeTableDestinationsResponse200",
+    "ReauthorizeTableDestinationsResponse200Status",
     "RegexpQuery",
     "RepairIssueListRequest",
     "RepairRunRequest",

--- a/py/packages/sdk/src/antfly/client_generated/models/reauthorize_table_destinations_response_200.py
+++ b/py/packages/sdk/src/antfly/client_generated/models/reauthorize_table_destinations_response_200.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..models.reauthorize_table_destinations_response_200_status import ReauthorizeTableDestinationsResponse200Status
+
+T = TypeVar("T", bound="ReauthorizeTableDestinationsResponse200")
+
+
+@_attrs_define
+class ReauthorizeTableDestinationsResponse200:
+    """
+    Attributes:
+        table (str):
+        status (ReauthorizeTableDestinationsResponse200Status):
+    """
+
+    table: str
+    status: ReauthorizeTableDestinationsResponse200Status
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        table = self.table
+
+        status = self.status.value
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "table": table,
+                "status": status,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        table = d.pop("table")
+
+        status = ReauthorizeTableDestinationsResponse200Status(d.pop("status"))
+
+        reauthorize_table_destinations_response_200 = cls(
+            table=table,
+            status=status,
+        )
+
+        reauthorize_table_destinations_response_200.additional_properties = d
+        return reauthorize_table_destinations_response_200
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/py/packages/sdk/src/antfly/client_generated/models/reauthorize_table_destinations_response_200_status.py
+++ b/py/packages/sdk/src/antfly/client_generated/models/reauthorize_table_destinations_response_200_status.py
@@ -1,0 +1,8 @@
+from enum import Enum
+
+
+class ReauthorizeTableDestinationsResponse200Status(str, Enum):
+    AUTHORIZED = "authorized"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/specs/openapi/antfly/metadata.yaml
+++ b/specs/openapi/antfly/metadata.yaml
@@ -9477,6 +9477,7 @@ paths:
         admission and drains current readers and writers before swapping the
         direct-path generation.
       operationId: restore
+      x-antfly-credential-note: Durable CDC and graph destinations require Basic or API-key authentication.
       parameters:
         - name: Idempotency-Key
           in: header
@@ -9511,6 +9512,12 @@ paths:
           $ref: "#/components/responses/BadRequest"
         "409":
           $ref: "#/components/responses/Conflict"
+        "422":
+          description: The selected backup contains durable destinations that cannot be bound to this credential type
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
         "503":
           $ref: "#/components/responses/ServiceUnavailable"
         "500":
@@ -10047,6 +10054,7 @@ paths:
       tags:
         - table_management
       operationId: createTable
+      x-antfly-credential-note: Durable CDC and graph destinations require Basic or API-key authentication.
       requestBody:
         required: true
         content:
@@ -10062,6 +10070,12 @@ paths:
                 $ref: "#/components/schemas/Table"
         "400":
           $ref: "#/components/responses/BadRequest"
+        "422":
+          description: Durable destinations cannot be bound to this credential type
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
     delete:
       summary: Drop a table
       tags:
@@ -10317,6 +10331,7 @@ paths:
       tags:
         - data_operations
       operationId: restoreTable
+      x-antfly-credential-note: Durable CDC and graph destinations require Basic or API-key authentication.
       parameters:
         - name: Idempotency-Key
           in: header
@@ -10351,8 +10366,72 @@ paths:
           $ref: "#/components/responses/BadRequest"
         "409":
           $ref: "#/components/responses/Conflict"
+        "422":
+          description: The backup contains durable destinations that cannot be bound to this credential type
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
         "503":
           $ref: "#/components/responses/ServiceUnavailable"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+  /tables/{tableName}/destination-authorization:
+    parameters:
+      - name: tableName
+        in: path
+        required: true
+        description: Name of the table whose stored destinations should be adopted
+        schema:
+          type: string
+          maxLength: 255
+    post:
+      summary: Adopt stored write destinations with the current credential
+      description: |
+        Reauthorizes the table's existing CDC routes and graph resolver destinations
+        using the caller's current permissions. This idempotent operation is intended
+        for upgrading tables created before durable destination authorization was
+        introduced, and for explicitly transferring destination ownership after a
+        credential is rotated. The caller needs admin permission on the source table
+        and write permission on every eventual destination table.
+      tags:
+        - table_management
+      operationId: reauthorizeTableDestinations
+      responses:
+        "200":
+          description: Destination authorization was durably adopted
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - table
+                  - status
+                properties:
+                  table:
+                    type: string
+                  status:
+                    type: string
+                    enum:
+                      - authorized
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          description: Caller lacks authority on the source or a destination table
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
+        "422":
+          description: Durable destinations cannot be bound to this credential type
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
         "500":
           $ref: "#/components/responses/InternalServerError"
   /tables/{tableName}/schema:
@@ -11280,6 +11359,7 @@ paths:
       tags:
         - index_management
       operationId: createIndex
+      x-antfly-credential-note: Graph resolver destinations require Basic or API-key authentication.
       requestBody:
         required: true
         content:
@@ -11301,6 +11381,12 @@ paths:
           $ref: "#/components/responses/MethodNotAllowed"
         "409":
           $ref: "#/components/responses/Conflict"
+        "422":
+          description: Graph resolver destinations cannot be bound to this credential type
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
         "429":
           $ref: "#/components/responses/StorageResourceExhausted"
         "503":

--- a/ts/packages/sdk/src/public-api.d.ts
+++ b/ts/packages/sdk/src/public-api.d.ts
@@ -1012,6 +1012,34 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/db/v1/tables/{tableName}/destination-authorization": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Name of the table whose stored destinations should be adopted */
+                tableName: string;
+            };
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Adopt stored write destinations with the current credential
+         * @description Reauthorizes the table's existing CDC routes and graph resolver destinations
+         *     using the caller's current permissions. This idempotent operation is intended
+         *     for upgrading tables created before durable destination authorization was
+         *     introduced, and for explicitly transferring destination ownership after a
+         *     credential is rotated. The caller needs admin permission on the source table
+         *     and write permission on every eventual destination table.
+         */
+        post: operations["reauthorizeTableDestinations"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/db/v1/tables/{tableName}/schema": {
         parameters: {
             query?: never;
@@ -14857,6 +14885,15 @@ export interface operations {
             };
             400: components["responses"]["BadRequest"];
             409: components["responses"]["Conflict"];
+            /** @description The selected backup contains durable destinations that cannot be bound to this credential type */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             500: components["responses"]["InternalServerError"];
             503: components["responses"]["ServiceUnavailable"];
         };
@@ -15229,6 +15266,15 @@ export interface operations {
                 };
             };
             400: components["responses"]["BadRequest"];
+            /** @description Durable destinations cannot be bound to this credential type */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
         };
     };
     dropTable: {
@@ -15452,8 +15498,66 @@ export interface operations {
             };
             400: components["responses"]["BadRequest"];
             409: components["responses"]["Conflict"];
+            /** @description The backup contains durable destinations that cannot be bound to this credential type */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             500: components["responses"]["InternalServerError"];
             503: components["responses"]["ServiceUnavailable"];
+        };
+    };
+    reauthorizeTableDestinations: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Name of the table whose stored destinations should be adopted */
+                tableName: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Destination authorization was durably adopted */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        table: string;
+                        /** @enum {string} */
+                        status: "authorized";
+                    };
+                };
+            };
+            400: components["responses"]["BadRequest"];
+            /** @description Caller lacks authority on the source or a destination table */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            404: components["responses"]["NotFound"];
+            409: components["responses"]["Conflict"];
+            /** @description Durable destinations cannot be bound to this credential type */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            500: components["responses"]["InternalServerError"];
         };
     };
     updateSchema: {
@@ -16230,6 +16334,15 @@ export interface operations {
             404: components["responses"]["NotFound"];
             405: components["responses"]["MethodNotAllowed"];
             409: components["responses"]["Conflict"];
+            /** @description Graph resolver destinations cannot be bound to this credential type */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             429: components["responses"]["StorageResourceExhausted"];
             500: components["responses"]["InternalServerError"];
             503: components["responses"]["ServiceUnavailable"];

--- a/zig/build.zig
+++ b/zig/build.zig
@@ -2954,6 +2954,7 @@ pub fn build(b: *std.Build) void {
     const api_restore_jobs_tests = b.addTest(.{
         .root_module = api_restore_jobs_test_mod,
         .filters = &.{
+            "failed destination authorization refresh reuses the idempotent restore job",
             "delayed replicated restore refresh cannot regress a running job",
             "restore job store is idempotent and fenced",
             "restore idempotency keys are scoped by principal and resource",
@@ -5345,6 +5346,15 @@ pub fn build(b: *std.Build) void {
         "query builder runtime preflight injects mandatory row filter",
         "MCP document sampling pushes mandatory row filters into storage scans",
         "usermgr api key permission intersection narrows owner and key wildcards",
+        "stored destination admission requires write permission on every eventual sink",
+        "stored destination envelopes cannot be forged and validate on resume",
+        "stored destination grants bind credential source and live permissions",
+        "legacy restore jobs resume only when backed-up definitions are sink free",
+        "failed destination authorization refresh reuses the idempotent restore job",
+        "destination authorization adoption requires source table admin",
+        "legacy stored destinations can be adopted idempotently",
+        "api http server cluster restore",
+        "cluster restore repository errors preserve operational failure semantics",
     };
     const authorization_sink_tests = b.addTest(.{
         .root_module = lib_test_mod,

--- a/zig/e2e/antfly/test_backup_restore.py
+++ b/zig/e2e/antfly/test_backup_restore.py
@@ -1395,9 +1395,11 @@ def test_restore_missing_backup_returns_bad_request(backup_api):
                 "connection": BACKUP_CONNECTION,
             },
         )
-        table_job = _wait_for_terminal_restore_job(backup_api, table_restore)
-        assert table_job["phase"] == "failed"
-        assert table_job["error"] == "TableAlreadyExists"
+        # Table restore must inspect the manifest before it can authorize every
+        # stored destination. A missing manifest is therefore rejected at
+        # admission and never consumes a durable job slot.
+        assert table_restore.status_code == 400
+        assert table_restore.json() == {"error": "invalid backup manifest"}
 
         cluster_restore = backup_api._request(
             "POST",

--- a/zig/pkg/antfly/src/api/cluster_api_http.zig
+++ b/zig/pkg/antfly/src/api/cluster_api_http.zig
@@ -49,6 +49,7 @@ pub const ClusterApi = struct {
         BackupRepositoryBusy,
         BackupManifestTooLarge,
         BackupIntegrityFailure,
+        RestoreDestinationReauthorizationRequired,
         TableAlreadyExists,
         MethodNotAllowed,
         Cancelled,
@@ -81,6 +82,7 @@ pub const ClusterApi = struct {
             req: backups_api.ClusterRestoreRequest,
             location: *backups_api.BackupLocation,
             restore_mode: []const u8,
+            request: operation.RequestContext,
         ) ExecuteRestoreError!RestoreExecution,
     };
 
@@ -110,8 +112,9 @@ pub const ClusterApi = struct {
         req: backups_api.ClusterRestoreRequest,
         location: *backups_api.BackupLocation,
         restore_mode: []const u8,
+        request: operation.RequestContext,
     ) ExecuteRestoreError!RestoreExecution {
-        return try self.vtable.execute_cluster_restore(self.ptr, alloc, req, location, restore_mode);
+        return try self.vtable.execute_cluster_restore(self.ptr, alloc, req, location, restore_mode, request);
     }
 };
 
@@ -220,6 +223,7 @@ pub fn handleClusterRestore(
     secret_store: ?*common_secrets.FileStore,
     node_config: ?*const common_config.Config,
     io: ?std.Io,
+    request: operation.RequestContext,
 ) !OwnedResponse {
     var req = backups_api.parseClusterRestoreRequest(alloc, body) catch {
         return .{ .status = 400, .body = try alloc.dupe(u8, "invalid restore request") };
@@ -247,12 +251,13 @@ pub fn handleClusterRestore(
         return .{ .status = 400, .body = try alloc.dupe(u8, "invalid restore request") };
     };
 
-    const result = api.executeClusterRestore(alloc, req, &location, restore_mode) catch |err| switch (err) {
+    const result = api.executeClusterRestore(alloc, req, &location, restore_mode, request) catch |err| switch (err) {
         error.NotLeader => return err,
         error.InvalidRequest => return .{ .status = 400, .body = try alloc.dupe(u8, "invalid restore request") },
         error.BackupRepositoryBusy => return .{ .status = 409, .body = try alloc.dupe(u8, "backup repository is busy; retry later") },
         error.BackupManifestTooLarge => return .{ .status = 400, .body = try alloc.dupe(u8, backups_api.manifest_too_large_message) },
         error.BackupIntegrityFailure => return .{ .status = 422, .body = try alloc.dupe(u8, backups_api.integrity_failure_message) },
+        error.RestoreDestinationReauthorizationRequired => return .{ .status = 409, .body = try alloc.dupe(u8, "restore destination authorization is missing or revoked; resubmit with a currently authorized credential") },
         error.TableAlreadyExists => return .{ .status = 400, .body = try alloc.dupe(u8, "table already exists") },
         error.MethodNotAllowed => return .{ .status = 405, .body = try alloc.dupe(u8, "method not allowed") },
         error.Cancelled => return .{ .status = 409, .body = try alloc.dupe(u8, "restore cancelled") },
@@ -290,6 +295,7 @@ test "cluster backup APIs require named connections" {
         null,
         null,
         null,
+        .{},
     );
     defer restore.deinit(std.testing.allocator);
     try std.testing.expectEqual(@as(u16, 400), restore.status);

--- a/zig/pkg/antfly/src/api/http_routes.zig
+++ b/zig/pkg/antfly/src/api/http_routes.zig
@@ -87,6 +87,7 @@ pub const Routes = struct {
     pub const merge_suffix = "/merge";
     pub const backup_suffix = "/backup";
     pub const restore_suffix = "/restore";
+    pub const destination_authorization_suffix = "/destination-authorization";
     pub const query_suffix = "/query";
     pub const query_preflight_suffix = "/query-preflight";
     pub const text_stats_suffix = "/text-stats";
@@ -506,6 +507,14 @@ pub const Routes = struct {
     pub fn matchTablePath(path: []const u8) ?TablePath {
         if (!std.mem.startsWith(u8, path, tables_prefix)) return null;
         const table_name = path[tables_prefix.len..];
+        if (table_name.len == 0 or std.mem.indexOfScalar(u8, table_name, '/') != null) return null;
+        return .{ .table_name = table_name };
+    }
+
+    pub fn matchTableDestinationAuthorization(path: []const u8) ?TablePath {
+        if (!std.mem.startsWith(u8, path, tables_prefix)) return null;
+        if (!std.mem.endsWith(u8, path, destination_authorization_suffix)) return null;
+        const table_name = path[tables_prefix.len .. path.len - destination_authorization_suffix.len];
         if (table_name.len == 0 or std.mem.indexOfScalar(u8, table_name, '/') != null) return null;
         return .{ .table_name = table_name };
     }

--- a/zig/pkg/antfly/src/api/http_server.zig
+++ b/zig/pkg/antfly/src/api/http_server.zig
@@ -33,6 +33,7 @@ const public_table_http = @import("public_table_http.zig");
 const linear_merge_api = @import("linear_merge.zig");
 const cluster = @import("cluster.zig");
 const indexes_api = @import("indexes.zig");
+const stored_destination_authorization = @import("stored_destination_authorization.zig");
 const coverage_policy = @import("coverage_policy.zig");
 const table_contract = @import("table_contract.zig");
 const metadata_admin = @import("../metadata/admin.zig");
@@ -7167,10 +7168,6 @@ pub const ApiHttpServer = struct {
         }
     };
 
-    fn restoreOwnedTable(self: *ApiHttpServer, table_name: []const u8, backup_location: *backups_api.BackupLocation, source_location: []const u8, backup_id: []const u8) !OwnedRestoreOutcome {
-        return try self.restoreOwnedTableWithLifecycle(table_name, backup_location, source_location, backup_id, backup_id, false, false, null);
-    }
-
     /// Admit the exact requested artifact immediately before metadata
     /// publication. Native manifests already carry integrity metadata and are
     /// streamed once for verification. The Go portable envelope predates
@@ -7290,6 +7287,129 @@ pub const ApiHttpServer = struct {
         );
     }
 
+    fn restoreDestinationPrincipal(
+        alloc: std.mem.Allocator,
+        replication_sources_json: []const u8,
+        indexes_json: []const u8,
+        fingerprint: []const u8,
+        principal: []const u8,
+    ) ![]const u8 {
+        const legacy = fingerprint.len == 0 and principal.len == 0;
+        if (legacy) {
+            if (try stored_destination_authorization.configurationHasDestinations(
+                alloc,
+                replication_sources_json,
+                indexes_json,
+            )) return error.RestoreDestinationReauthorizationRequired;
+            // No eventual write exists, so resuming with catalog ownership does
+            // not manufacture authority. This preserves pre-upgrade sink-free
+            // jobs without weakening the destination boundary.
+            return stored_destination_authorization.catalog_service_principal;
+        }
+        if (fingerprint.len == 0 or principal.len == 0)
+            return error.StoredDestinationAuthorizationInvalid;
+        if (!stored_destination_authorization.destinationConfigFingerprintMatches(
+            replication_sources_json,
+            indexes_json,
+            fingerprint,
+        )) return error.StoredDestinationAuthorizationInvalid;
+        return principal;
+    }
+
+    fn authorizeClusterRestoreManifestDestinations(
+        self: *ApiHttpServer,
+        alloc: std.mem.Allocator,
+        location: *backups_api.BackupLocation,
+        backup_id: []const u8,
+        artifact_backup_id: []const u8,
+        principal: []const u8,
+    ) !void {
+        var manifest = try backups_api.readManifestFromLocationWithArtifactBackupId(
+            alloc,
+            location,
+            backup_id,
+            artifact_backup_id,
+        );
+        defer manifest.deinit(alloc);
+        const fingerprint = try stored_destination_authorization.destinationConfigFingerprintAlloc(
+            alloc,
+            manifest.replication_sources_json,
+            manifest.indexes_json,
+        );
+        defer alloc.free(fingerprint);
+        const effective_principal = try restoreDestinationPrincipal(
+            alloc,
+            manifest.replication_sources_json,
+            manifest.indexes_json,
+            if (principal.len > 0) fingerprint else "",
+            principal,
+        );
+        const authorizer: stored_destination_authorization.Authorizer = .{
+            .manager = self.cfg.user_manager,
+            .auth_enabled = self.cfg.auth_enabled,
+        };
+        const sealed_replication_sources = try stored_destination_authorization.sealReplicationSourcesJsonForPrincipalAlloc(
+            alloc,
+            manifest.replication_sources_json,
+            manifest.table_name,
+            effective_principal,
+            authorizer,
+        );
+        defer alloc.free(sealed_replication_sources);
+        const sealed_indexes = try stored_destination_authorization.sealIndexesJsonForPrincipalAlloc(
+            alloc,
+            manifest.indexes_json,
+            manifest.table_name,
+            effective_principal,
+            authorizer,
+        );
+        defer alloc.free(sealed_indexes);
+        try stored_destination_authorization.authorizeReplicationSourcesJson(
+            alloc,
+            sealed_replication_sources,
+            manifest.table_name,
+            authorizer,
+        );
+        try stored_destination_authorization.authorizeIndexesJson(
+            alloc,
+            sealed_indexes,
+            manifest.table_name,
+            authorizer,
+        );
+    }
+
+    test "legacy restore jobs resume only when backed-up definitions are sink free" {
+        const alloc = std.testing.allocator;
+        try std.testing.expectEqualStrings(
+            stored_destination_authorization.catalog_service_principal,
+            try restoreDestinationPrincipal(alloc, "[]", "{}", "", ""),
+        );
+        try std.testing.expectError(
+            error.RestoreDestinationReauthorizationRequired,
+            restoreDestinationPrincipal(
+                alloc,
+                "[{\"type\":\"postgres\",\"routes\":[{\"target_table\":\"protected\"}]}]",
+                "{}",
+                "",
+                "",
+            ),
+        );
+        try std.testing.expectError(
+            error.RestoreDestinationReauthorizationRequired,
+            restoreDestinationPrincipal(
+                alloc,
+                "[]",
+                "{\"graph\":{\"resolvers\":[{\"table\":\"protected\"}]}}",
+                "",
+                "",
+            ),
+        );
+        try std.testing.expectError(
+            error.StoredDestinationAuthorizationInvalid,
+            restoreDestinationPrincipal(alloc, "[]", "{}", "fingerprint-only", ""),
+        );
+    }
+
     fn restoreOwnedTableWithLifecycle(
         self: *ApiHttpServer,
         table_name: []const u8,
@@ -7300,6 +7420,8 @@ pub const ApiHttpServer = struct {
         restore_lifecycle_already_active: bool,
         replace_existing: bool,
         verification_cache: ?*backups_api.ArtifactVerificationCache,
+        destination_authorization_fingerprint: []const u8,
+        destination_authorization_principal: []const u8,
     ) !OwnedRestoreOutcome {
         var manifest = backups_api.readManifestFromLocationWithArtifactBackupId(
             self.alloc,
@@ -7319,6 +7441,47 @@ pub const ApiHttpServer = struct {
         if (!std.mem.eql(u8, manifest.table_name, table_name)) return error.InvalidBackupRequest;
         if (manifest.read_schema_json.len > 0) return error.UnsupportedBackupMigrationState;
         try backups_api.validateRestorableManifestLayout(&manifest);
+        const effective_destination_principal = try restoreDestinationPrincipal(
+            self.alloc,
+            manifest.replication_sources_json,
+            manifest.indexes_json,
+            destination_authorization_fingerprint,
+            destination_authorization_principal,
+        );
+        const destination_authorizer: stored_destination_authorization.Authorizer = .{
+            .manager = self.cfg.user_manager,
+            .auth_enabled = self.cfg.auth_enabled,
+        };
+        const sealed_replication_sources_json = try stored_destination_authorization.sealReplicationSourcesJsonForPrincipalAlloc(
+            self.alloc,
+            manifest.replication_sources_json,
+            table_name,
+            effective_destination_principal,
+            destination_authorizer,
+        );
+        self.alloc.free(manifest.replication_sources_json);
+        manifest.replication_sources_json = sealed_replication_sources_json;
+        const sealed_indexes_json = try stored_destination_authorization.sealIndexesJsonForPrincipalAlloc(
+            self.alloc,
+            manifest.indexes_json,
+            table_name,
+            effective_destination_principal,
+            destination_authorizer,
+        );
+        self.alloc.free(manifest.indexes_json);
+        manifest.indexes_json = sealed_indexes_json;
+        try stored_destination_authorization.authorizeReplicationSourcesJson(
+            self.alloc,
+            manifest.replication_sources_json,
+            table_name,
+            destination_authorizer,
+        );
+        try stored_destination_authorization.authorizeIndexesJson(
+            self.alloc,
+            manifest.indexes_json,
+            table_name,
+            destination_authorizer,
+        );
         const target_exists = try self.tableExists(table_name);
         if (replace_existing and !target_exists) return error.TableNotFound;
 
@@ -7586,8 +7749,21 @@ pub const ApiHttpServer = struct {
         backup_location: *backups_api.BackupLocation,
         source_location: []const u8,
         backup_id: []const u8,
+        destination_authorization_fingerprint: []const u8,
+        destination_authorization_principal: []const u8,
     ) !OwnedRestoreOutcome {
-        return try self.restoreOwnedTableWithRetryAndLifecycle(table_name, backup_location, source_location, backup_id, backup_id, false, false, null);
+        return try self.restoreOwnedTableWithRetryAndLifecycle(
+            table_name,
+            backup_location,
+            source_location,
+            backup_id,
+            backup_id,
+            false,
+            false,
+            null,
+            destination_authorization_fingerprint,
+            destination_authorization_principal,
+        );
     }
 
     fn restoreOwnedTableWithRetryAndLifecycle(
@@ -7600,10 +7776,12 @@ pub const ApiHttpServer = struct {
         restore_lifecycle_already_active: bool,
         replace_existing: bool,
         verification_cache: ?*backups_api.ArtifactVerificationCache,
+        destination_authorization_fingerprint: []const u8,
+        destination_authorization_principal: []const u8,
     ) !OwnedRestoreOutcome {
         var attempt: usize = 0;
         while (attempt < 3) : (attempt += 1) {
-            const outcome = self.restoreOwnedTableWithLifecycle(table_name, backup_location, source_location, backup_id, artifact_backup_id, restore_lifecycle_already_active, replace_existing, verification_cache) catch |err| switch (err) {
+            const outcome = self.restoreOwnedTableWithLifecycle(table_name, backup_location, source_location, backup_id, artifact_backup_id, restore_lifecycle_already_active, replace_existing, verification_cache, destination_authorization_fingerprint, destination_authorization_principal) catch |err| switch (err) {
                 error.TableVisibilityTimeout => {
                     if (attempt + 1 >= 3) return err;
                     if (!replace_existing and (self.tableExists(table_name) catch false)) {
@@ -9351,6 +9529,50 @@ pub const ApiHttpServer = struct {
             };
             if (!std.mem.eql(u8, manifest.table_name, table_name))
                 return error.InvalidBackupRequest;
+            const effective_destination_principal = restoreDestinationPrincipal(
+                self.alloc,
+                manifest.replication_sources_json,
+                manifest.indexes_json,
+                request.destination_authorization_fingerprint,
+                request.destination_authorization_principal,
+            ) catch |err| switch (err) {
+                error.RestoreDestinationReauthorizationRequired => return error.RestoreDestinationReauthorizationRequired,
+                else => return error.InvalidBackupRequest,
+            };
+            const destination_authorizer: stored_destination_authorization.Authorizer = .{
+                .manager = self.cfg.user_manager,
+                .auth_enabled = self.cfg.auth_enabled,
+            };
+            const sealed_replication_sources_json = stored_destination_authorization.sealReplicationSourcesJsonForPrincipalAlloc(
+                self.alloc,
+                manifest.replication_sources_json,
+                table_name,
+                effective_destination_principal,
+                destination_authorizer,
+            ) catch return error.InvalidBackupRequest;
+            self.alloc.free(manifest.replication_sources_json);
+            manifest.replication_sources_json = sealed_replication_sources_json;
+            const sealed_indexes_json = stored_destination_authorization.sealIndexesJsonForPrincipalAlloc(
+                self.alloc,
+                manifest.indexes_json,
+                table_name,
+                effective_destination_principal,
+                destination_authorizer,
+            ) catch return error.InvalidBackupRequest;
+            self.alloc.free(manifest.indexes_json);
+            manifest.indexes_json = sealed_indexes_json;
+            stored_destination_authorization.authorizeReplicationSourcesJson(
+                self.alloc,
+                manifest.replication_sources_json,
+                table_name,
+                destination_authorizer,
+            ) catch return error.InvalidBackupRequest;
+            stored_destination_authorization.authorizeIndexesJson(
+                self.alloc,
+                manifest.indexes_json,
+                table_name,
+                destination_authorizer,
+            ) catch return error.InvalidBackupRequest;
 
             if (self.restoreMetadataTableWithRetry(self.alloc, table_name, location_uri, connection, backup_id, &manifest) catch |err| switch (err) {
                 error.NotLeader, error.ProposalDropped, error.LeaderTransferInProgress => return error.NotLeader,
@@ -9368,13 +9590,22 @@ pub const ApiHttpServer = struct {
             }
         }
 
-        const outcome = self.restoreOwnedTableWithRetry(table_name, location, location_uri, backup_id) catch |err| switch (err) {
+        const outcome = self.restoreOwnedTableWithRetry(
+            table_name,
+            location,
+            location_uri,
+            backup_id,
+            request.destination_authorization_fingerprint,
+            request.destination_authorization_principal,
+        ) catch |err| switch (err) {
             error.NotLeader, error.ProposalDropped, error.LeaderTransferInProgress => return error.NotLeader,
             error.UnsupportedOperation => return error.MethodNotAllowed,
             error.InvalidBackupRequest => {
                 if (self.tableExists(table_name) catch |table_exists_err| return metadataAccessFailure(table_exists_err)) return error.TableAlreadyExists;
                 return error.InvalidBackupRequest;
             },
+            error.StoredDestinationAuthorizationInvalid => return error.InvalidBackupRequest,
+            error.RestoreDestinationReauthorizationRequired => return error.RestoreDestinationReauthorizationRequired,
             else => {
                 if (metadata_authority.isRetryableError(err)) return error.NotLeader;
                 return mapExecuteRestoreError(err);
@@ -9387,6 +9618,7 @@ pub const ApiHttpServer = struct {
         if (backups_api.isArtifactIntegrityError(err)) return error.BackupIntegrityFailure;
         if (metadata_authority.isRetryableError(err)) return error.NotLeader;
         return switch (err) {
+            error.RestoreDestinationReauthorizationRequired => error.RestoreDestinationReauthorizationRequired,
             error.TableAlreadyExists => error.TableAlreadyExists,
             error.UnsupportedBackupMigrationState => error.UnsupportedBackupMigrationState,
             error.UnsupportedMultiRangeTable => error.UnsupportedMultiRangeTable,
@@ -9395,6 +9627,7 @@ pub const ApiHttpServer = struct {
             error.RestoreDurabilityConfirmed => error.RestoreDurabilityConfirmed,
             error.BackupManifestTooLarge => error.BackupManifestTooLarge,
             error.InvalidBackupRequest => error.InvalidBackupRequest,
+            error.StoredDestinationAuthorizationInvalid => error.InvalidBackupRequest,
             else => error.InternalFailure,
         };
     }
@@ -9869,6 +10102,20 @@ pub const ApiHttpServer = struct {
             },
         };
 
+        const destination_principal = if (request.destination_authorization_principal.len > 0)
+            request.destination_authorization_principal
+        else
+            stored_destination_authorization.catalog_service_principal;
+        const authorized_index_json = stored_destination_authorization.sealIndexJsonForPrincipalAlloc(
+            alloc,
+            normalized_index_json,
+            table_name,
+            destination_principal,
+            .{ .manager = self.cfg.user_manager, .auth_enabled = self.cfg.auth_enabled },
+        ) catch
+            return error.InvalidIndexRequest;
+        defer alloc.free(authorized_index_json);
+
         // Reserve the response before consensus. Nothing after the irreversible
         // mutation boundary should fail solely because response memory could
         // not be allocated.
@@ -9878,7 +10125,7 @@ pub const ApiHttpServer = struct {
         // Materialize catalog-owned fields once. The same exact config is sent
         // through consensus and used as the projection expectation, making the
         // operation idempotent across retries and leadership changes.
-        const expected_indexes_json = indexes_api.addIndexToTableIndexesJson(alloc, table_before.indexes_json, index_name, normalized_index_json) catch |err| switch (err) {
+        const expected_indexes_json = indexes_api.addIndexToTableIndexesJson(alloc, table_before.indexes_json, index_name, authorized_index_json) catch |err| switch (err) {
             error.InvalidTableIndexMetadata, error.InvalidCreateIndexRequest => return error.InvalidIndexRequest,
             else => return error.InternalFailure,
         };
@@ -10689,10 +10936,22 @@ pub const ApiHttpServer = struct {
         req: backups_api.ClusterRestoreRequest,
         location: *backups_api.BackupLocation,
         restore_mode: []const u8,
+        request: api_operation.RequestContext,
     ) cluster_api_http.ClusterApi.ExecuteRestoreError!cluster_api_http.ClusterApi.RestoreExecution {
         return .{
             .status = 200,
-            .body = try executePublicClusterRestoreWithCancellation(ptr, alloc, req, location, restore_mode, null, null, &.{}, &.{}),
+            .body = try executePublicClusterRestoreWithCancellation(
+                ptr,
+                alloc,
+                req,
+                location,
+                restore_mode,
+                request.destination_authorization_principal,
+                null,
+                null,
+                &.{},
+                &.{},
+            ),
         };
     }
 
@@ -10722,6 +10981,7 @@ pub const ApiHttpServer = struct {
         req: backups_api.ClusterRestoreRequest,
         location: *backups_api.BackupLocation,
         restore_mode: []const u8,
+        destination_authorization_principal: []const u8,
         cancellation: ?RestoreCancellation,
         active_table_index: ?u16,
         durability_pending_table_ranges: []const restore_jobs.TableIndexRange,
@@ -10835,6 +11095,18 @@ pub const ApiHttpServer = struct {
             // because it now exists; wait for the already-published replica
             // restore intent to drain instead.
             if (restore_jobs.containsTableIndex(published_table_ranges, @intCast(i))) {
+                self.authorizeClusterRestoreManifestDestinations(
+                    op_alloc,
+                    location,
+                    table_backup_id,
+                    artifact_backup_id,
+                    destination_authorization_principal,
+                ) catch |err| switch (err) {
+                    error.RestoreDestinationReauthorizationRequired,
+                    error.StoredDestinationAuthorizationRevoked,
+                    => return error.RestoreDestinationReauthorizationRequired,
+                    else => return error.InvalidRequest,
+                };
                 if (!self.cfg.deployment_mode.isStandalone()) {
                     self.waitForDistributedRestoreCompletion(table_name, req.location, table_backup_id, artifact_backup_id, cancellation) catch |err| switch (err) {
                         error.NotLeader => return error.NotLeader,
@@ -10921,6 +11193,63 @@ pub const ApiHttpServer = struct {
                     }
                 };
 
+                const destination_authorization_fingerprint = stored_destination_authorization.destinationConfigFingerprintAlloc(
+                    op_alloc,
+                    table_manifest.replication_sources_json,
+                    table_manifest.indexes_json,
+                ) catch return error.InternalFailure;
+                defer op_alloc.free(destination_authorization_fingerprint);
+                const effective_destination_principal = restoreDestinationPrincipal(
+                    op_alloc,
+                    table_manifest.replication_sources_json,
+                    table_manifest.indexes_json,
+                    if (destination_authorization_principal.len > 0) destination_authorization_fingerprint else "",
+                    destination_authorization_principal,
+                ) catch |err| switch (err) {
+                    error.RestoreDestinationReauthorizationRequired => return error.RestoreDestinationReauthorizationRequired,
+                    else => return error.InvalidRequest,
+                };
+                const sealed_replication_sources_json = stored_destination_authorization.sealReplicationSourcesJsonForPrincipalAlloc(
+                    op_alloc,
+                    table_manifest.replication_sources_json,
+                    table_name,
+                    effective_destination_principal,
+                    .{ .manager = self.cfg.user_manager, .auth_enabled = self.cfg.auth_enabled },
+                ) catch return error.InvalidRequest;
+                op_alloc.free(table_manifest.replication_sources_json);
+                table_manifest.replication_sources_json = sealed_replication_sources_json;
+                const sealed_indexes_json = stored_destination_authorization.sealIndexesJsonForPrincipalAlloc(
+                    op_alloc,
+                    table_manifest.indexes_json,
+                    table_name,
+                    effective_destination_principal,
+                    .{ .manager = self.cfg.user_manager, .auth_enabled = self.cfg.auth_enabled },
+                ) catch return error.InvalidRequest;
+                op_alloc.free(table_manifest.indexes_json);
+                table_manifest.indexes_json = sealed_indexes_json;
+                const destination_authorizer: stored_destination_authorization.Authorizer = .{
+                    .manager = self.cfg.user_manager,
+                    .auth_enabled = self.cfg.auth_enabled,
+                };
+                stored_destination_authorization.authorizeReplicationSourcesJson(
+                    op_alloc,
+                    table_manifest.replication_sources_json,
+                    table_name,
+                    destination_authorizer,
+                ) catch |err| switch (err) {
+                    error.StoredDestinationAuthorizationRevoked => return error.RestoreDestinationReauthorizationRequired,
+                    else => return error.InvalidRequest,
+                };
+                stored_destination_authorization.authorizeIndexesJson(
+                    op_alloc,
+                    table_manifest.indexes_json,
+                    table_name,
+                    destination_authorizer,
+                ) catch |err| switch (err) {
+                    error.StoredDestinationAuthorizationRevoked => return error.RestoreDestinationReauthorizationRequired,
+                    else => return error.InvalidRequest,
+                };
+
                 const restored_via_metadata = self.restoreMetadataTableWithRetry(
                     alloc,
                     table_name,
@@ -10977,8 +11306,38 @@ pub const ApiHttpServer = struct {
             }
 
             const replace_existing = is_overwrite and (self.tableExists(table_name) catch |err| return metadataAccessFailure(err));
-            const outcome = self.restoreOwnedTableWithRetryAndLifecycle(table_name, location, req.location, table_backup_id, artifact_backup_id, false, replace_existing, &verification_cache) catch |err| {
+            var authorized_manifest = backups_api.readManifestFromLocationWithArtifactBackupId(
+                op_alloc,
+                location,
+                table_backup_id,
+                artifact_backup_id,
+            ) catch return error.InvalidRequest;
+            defer authorized_manifest.deinit(op_alloc);
+            const destination_authorization_fingerprint = stored_destination_authorization.destinationConfigFingerprintAlloc(
+                op_alloc,
+                authorized_manifest.replication_sources_json,
+                authorized_manifest.indexes_json,
+            ) catch return error.InternalFailure;
+            defer op_alloc.free(destination_authorization_fingerprint);
+            const outcome = self.restoreOwnedTableWithRetryAndLifecycle(
+                table_name,
+                location,
+                req.location,
+                table_backup_id,
+                artifact_backup_id,
+                false,
+                replace_existing,
+                &verification_cache,
+                if (destination_authorization_principal.len > 0)
+                    destination_authorization_fingerprint
+                else
+                    "",
+                destination_authorization_principal,
+            ) catch |err| {
                 if (metadata_authority.isRetryableError(err)) return error.NotLeader;
+                if (err == error.RestoreDestinationReauthorizationRequired or
+                    err == error.StoredDestinationAuthorizationRevoked)
+                    return error.RestoreDestinationReauthorizationRequired;
                 std.log.err("cluster restore failed phase=materialization class={s}", .{@errorName(err)});
                 statuses[i].@"error" = switch (err) {
                     error.UnsupportedOperation => "method not allowed",
@@ -11175,7 +11534,7 @@ pub const ApiHttpServer = struct {
                     try tables_api.buildTableListWithStorageStatuses(arena_impl.allocator(), &snapshot, null, storage_statuses),
                 );
             },
-            .create_table => |request| return try self.executeMcpCreateTable(request.table_name, request.body),
+            .create_table => |request| return try self.executeMcpCreateTable(request.table_name, request.body, authenticated_identity),
             .drop_table => |request| return try self.executeMcpDropTable(request.table_name),
             .describe_table => |request| {
                 const body = (try self.maybeEncodeTableStatus(request.table_name)) orelse
@@ -11188,7 +11547,26 @@ pub const ApiHttpServer = struct {
                 return try contextualResponseFromPublicTable(self.alloc, response);
             },
             .create_index => |request| {
-                var response = try public_table_http.handleTableCreateIndex(self.alloc, request.table_name, request.index_name, request.body, self.tableApi(.{}));
+                const allowed = graphResolverDestinationsAllowedForIdentity(
+                    self.alloc,
+                    authenticated_identity,
+                    request.body,
+                    true,
+                ) catch |err| {
+                    if (err == error.StoredDestinationCredentialUnsupported)
+                        return try contextualJsonErrorResponse(self.alloc, 422, "durable destinations require Basic or API-key authentication");
+                    return try contextual_operations.textAlloc(self.alloc, 400, "invalid graph resolver destination configuration");
+                };
+                if (!allowed) return try contextualJsonErrorResponse(self.alloc, 403, "forbidden");
+                var response = try public_table_http.handleTableCreateIndex(
+                    self.alloc,
+                    request.table_name,
+                    request.index_name,
+                    request.body,
+                    self.tableApi(.{
+                        .destination_authorization_principal = storedDestinationPrincipal(authenticated_identity),
+                    }),
+                );
                 defer response.deinit(self.alloc);
                 return try contextualResponseFromPublicTable(self.alloc, response);
             },
@@ -11228,7 +11606,7 @@ pub const ApiHttpServer = struct {
                     request.table_name,
                     request.body,
                     null,
-                    if (authenticated_identity) |identity| identity.username else null,
+                    authenticated_identity,
                 );
                 defer response.deinit(self.alloc);
                 return try cloneContextualResponse(self.alloc, response);
@@ -11241,7 +11619,12 @@ pub const ApiHttpServer = struct {
         }
     }
 
-    fn executeMcpCreateTable(self: *ApiHttpServer, table_name: []const u8, body: []const u8) !contextual_operations.OwnedResponse {
+    fn executeMcpCreateTable(
+        self: *ApiHttpServer,
+        table_name: []const u8,
+        body: []const u8,
+        authenticated_identity: ?AuthenticatedIdentity,
+    ) !contextual_operations.OwnedResponse {
         var request = table_contract.parseCreateTableRequest(self.alloc, body) catch |err|
             return try contextual_operations.textAlloc(self.alloc, 400, table_contract.createTableRequestErrorMessage(err, body));
         defer request.deinit(self.alloc);
@@ -11266,6 +11649,51 @@ pub const ApiHttpServer = struct {
         request.indexes_json = normalized_indexes_json;
         tables_api.validatePublicAlgebraicIndexesJson(self.alloc, request.indexes_json orelse tables_api.default_indexes_json) catch
             return try contextual_operations.textAlloc(self.alloc, 400, "unsupported table index configuration");
+
+        const destinations_allowed = (replicationDestinationsAllowedForIdentity(
+            self.alloc,
+            authenticated_identity,
+            request.replication_sources_json orelse "[]",
+        ) catch |err| {
+            if (err == error.StoredDestinationCredentialUnsupported)
+                return try contextualJsonErrorResponse(self.alloc, 422, "durable destinations require Basic or API-key authentication");
+            return try contextual_operations.textAlloc(self.alloc, 400, "invalid replication destination configuration");
+        }) and
+            (graphResolverDestinationsAllowedForIdentity(
+                self.alloc,
+                authenticated_identity,
+                request.indexes_json orelse tables_api.default_indexes_json,
+                false,
+            ) catch |err| {
+                if (err == error.StoredDestinationCredentialUnsupported)
+                    return try contextualJsonErrorResponse(self.alloc, 422, "durable destinations require Basic or API-key authentication");
+                return try contextual_operations.textAlloc(self.alloc, 400, "invalid graph resolver destination configuration");
+            });
+        if (!destinations_allowed) return try contextualJsonErrorResponse(self.alloc, 403, "forbidden");
+
+        const destination_principal = storedDestinationPrincipal(authenticated_identity);
+        const destination_authorizer: stored_destination_authorization.Authorizer = .{
+            .manager = self.cfg.user_manager,
+            .auth_enabled = self.cfg.auth_enabled,
+        };
+        const sealed_replication_sources_json = try stored_destination_authorization.sealReplicationSourcesJsonForPrincipalAlloc(
+            self.alloc,
+            request.replication_sources_json orelse "[]",
+            table_name,
+            destination_principal,
+            destination_authorizer,
+        );
+        if (request.replication_sources_json) |old| self.alloc.free(old);
+        request.replication_sources_json = sealed_replication_sources_json;
+        const sealed_indexes_json = try stored_destination_authorization.sealIndexesJsonForPrincipalAlloc(
+            self.alloc,
+            request.indexes_json orelse tables_api.default_indexes_json,
+            table_name,
+            destination_principal,
+            destination_authorizer,
+        );
+        if (request.indexes_json) |old| self.alloc.free(old);
+        request.indexes_json = sealed_indexes_json;
 
         self.source.createTable(self.alloc, table_name, request) catch |err| return switch (err) {
             error.TableAlreadyExists => try contextual_operations.textAlloc(self.alloc, 409, "table already exists"),
@@ -12278,12 +12706,108 @@ pub const ApiHttpServer = struct {
         return try publicOperationJsonResponse(self.alloc, 202, updated);
     }
 
+    pub fn handlePublicReauthorizeTableDestinations(
+        self: *ApiHttpServer,
+        table_name: []const u8,
+        authenticated_identity: ?AuthenticatedIdentity,
+    ) !contextual_operations.OwnedResponse {
+        const current = (self.loadOwnedTableRecord(self.alloc, table_name) catch |err| {
+            if (metadata_authority.isRetryableError(err))
+                return try contextualRetryableJsonErrorResponse(self.alloc, 503, "metadata leader unavailable");
+            return err;
+        }) orelse return try contextualJsonErrorResponse(self.alloc, 404, "not found");
+        defer metadata_table_manager.freeTable(self.alloc, current);
+
+        const destinations_allowed = (replicationDestinationsAllowedForIdentity(
+            self.alloc,
+            authenticated_identity,
+            current.replication_sources_json,
+        ) catch |err| {
+            if (err == error.StoredDestinationCredentialUnsupported)
+                return try contextualJsonErrorResponse(self.alloc, 422, "durable destinations require Basic or API-key authentication");
+            return try contextualJsonErrorResponse(self.alloc, 400, "invalid replication destination configuration");
+        }) and
+            (graphResolverDestinationsAllowedForIdentity(
+                self.alloc,
+                authenticated_identity,
+                current.indexes_json,
+                false,
+            ) catch |err| {
+                if (err == error.StoredDestinationCredentialUnsupported)
+                    return try contextualJsonErrorResponse(self.alloc, 422, "durable destinations require Basic or API-key authentication");
+                return try contextualJsonErrorResponse(self.alloc, 400, "invalid graph resolver destination configuration");
+            });
+        if (!destinations_allowed)
+            return try contextualJsonErrorResponse(self.alloc, 403, "forbidden");
+
+        const principal = storedDestinationPrincipal(authenticated_identity);
+        const destination_authorizer: stored_destination_authorization.Authorizer = .{
+            .manager = self.cfg.user_manager,
+            .auth_enabled = self.cfg.auth_enabled,
+        };
+        const sealed_replication_sources = stored_destination_authorization.sealReplicationSourcesJsonForPrincipalAlloc(
+            self.alloc,
+            current.replication_sources_json,
+            table_name,
+            principal,
+            destination_authorizer,
+        ) catch return try contextualJsonErrorResponse(self.alloc, 400, "invalid replication destination configuration");
+        defer self.alloc.free(sealed_replication_sources);
+        const sealed_indexes = stored_destination_authorization.sealIndexesJsonForPrincipalAlloc(
+            self.alloc,
+            current.indexes_json,
+            table_name,
+            principal,
+            destination_authorizer,
+        ) catch return try contextualJsonErrorResponse(self.alloc, 400, "invalid graph resolver destination configuration");
+        defer self.alloc.free(sealed_indexes);
+
+        if (!std.mem.eql(u8, current.replication_sources_json, sealed_replication_sources) or
+            !std.mem.eql(u8, current.indexes_json, sealed_indexes))
+        {
+            var replacement = try metadata_table_manager.cloneTable(self.alloc, current);
+            defer metadata_table_manager.freeTable(self.alloc, replacement);
+            const replacement_replication_sources = try self.alloc.dupe(u8, sealed_replication_sources);
+            self.alloc.free(replacement.replication_sources_json);
+            replacement.replication_sources_json = replacement_replication_sources;
+            const replacement_indexes = try self.alloc.dupe(u8, sealed_indexes);
+            self.alloc.free(replacement.indexes_json);
+            replacement.indexes_json = replacement_indexes;
+            self.source.replaceTableDefinition(current, replacement) catch |err| switch (err) {
+                error.TableNotFound => return try contextualJsonErrorResponse(self.alloc, 404, "not found"),
+                error.TableGenerationChanged, error.TableTransitionActive => return try contextualJsonErrorResponse(self.alloc, 409, "table definition changed; retry authorization"),
+                error.ExtensionOwnedObject, error.UnsupportedOperation => return try contextualJsonErrorResponse(self.alloc, 405, "method not allowed"),
+                else => {
+                    if (metadata_authority.isRetryableError(err))
+                        return try contextualRetryableJsonErrorResponse(self.alloc, 503, "metadata leader unavailable");
+                    return err;
+                },
+            };
+            self.waitForMetadataProjection(table_name, null, sealed_indexes) catch |err| {
+                if (metadata_authority.isRetryableError(err) or err == error.TableVisibilityTimeout)
+                    return try contextualRetryableJsonErrorResponse(self.alloc, 503, "destination authorization projection is pending");
+                return err;
+            };
+            if (self.table_writes) |writes| {
+                _ = writes.requestTableStructuralReconcile(self.alloc, table_name) catch |err| {
+                    std.log.warn("destination authorization reconcile deferred table={s} class={s}", .{ table_name, @errorName(err) });
+                };
+            }
+        }
+
+        const body = try std.json.Stringify.valueAlloc(self.alloc, .{
+            .table = table_name,
+            .status = "authorized",
+        }, .{});
+        return contextual_operations.json(body, false);
+    }
+
     pub fn handlePublicTableRestore(
         self: *ApiHttpServer,
         table_name: []const u8,
         body: []const u8,
         idempotency_key: ?[]const u8,
-        principal: ?[]const u8,
+        authenticated_identity: ?AuthenticatedIdentity,
     ) !contextual_operations.OwnedResponse {
         const parsed = backups_api.parseRestoreRequest(self.alloc, body) catch return try contextualJsonErrorResponse(self.alloc, 400, "invalid restore request");
         defer parsed.deinit();
@@ -12296,9 +12820,47 @@ pub const ApiHttpServer = struct {
             .required_capability = "restore.read",
             .io = self.sharedApiIo(),
         }) catch |err| return try contextualJsonErrorResponse(self.alloc, 400, backups_api.backupLocationErrorMessage(err) orelse "invalid restore location");
-        location.deinit(self.alloc);
+        defer location.deinit(self.alloc);
         self.ensureAsyncRestoreWorker() catch |err| return try restoreJobStartErrorResponse(self.alloc, err);
-        const idempotency_namespace = try restoreIdempotencyNamespaceAlloc(self.alloc, principal, .table, table_name);
+        var manifest = backups_api.readManifestFromLocationWithArtifactBackupId(
+            self.alloc,
+            &location,
+            parsed.value.backup_id,
+            parsed.value.backup_id,
+        ) catch return try contextualJsonErrorResponse(self.alloc, 400, "invalid backup manifest");
+        defer manifest.deinit(self.alloc);
+        const destinations_allowed = (replicationDestinationsAllowedForIdentity(
+            self.alloc,
+            authenticated_identity,
+            manifest.replication_sources_json,
+        ) catch |err| {
+            if (err == error.StoredDestinationCredentialUnsupported)
+                return try contextualJsonErrorResponse(self.alloc, 422, "durable destinations require Basic or API-key authentication");
+            return try contextualJsonErrorResponse(self.alloc, 400, "invalid replication destination configuration");
+        }) and
+            (graphResolverDestinationsAllowedForIdentity(
+                self.alloc,
+                authenticated_identity,
+                manifest.indexes_json,
+                false,
+            ) catch |err| {
+                if (err == error.StoredDestinationCredentialUnsupported)
+                    return try contextualJsonErrorResponse(self.alloc, 422, "durable destinations require Basic or API-key authentication");
+                return try contextualJsonErrorResponse(self.alloc, 400, "invalid graph resolver destination configuration");
+            });
+        if (!destinations_allowed) return try contextualJsonErrorResponse(self.alloc, 403, "forbidden");
+        const destination_authorization_fingerprint = try stored_destination_authorization.destinationConfigFingerprintAlloc(
+            self.alloc,
+            manifest.replication_sources_json,
+            manifest.indexes_json,
+        );
+        defer self.alloc.free(destination_authorization_fingerprint);
+        const idempotency_namespace = try restoreIdempotencyNamespaceAlloc(
+            self.alloc,
+            transactionPrincipal(authenticated_identity),
+            .table,
+            table_name,
+        );
         defer self.alloc.free(idempotency_namespace);
         const encoded = self.restore_job_store.start(self.alloc, .{
             .scope = .table,
@@ -12308,6 +12870,8 @@ pub const ApiHttpServer = struct {
             .connection = connection,
             .idempotency_namespace = idempotency_namespace,
             .idempotency_key = idempotency_key,
+            .destination_authorization_fingerprint = destination_authorization_fingerprint,
+            .destination_authorization_principal = storedDestinationPrincipal(authenticated_identity),
         }) catch |err| return try restoreJobStartErrorResponse(self.alloc, err);
         defer self.alloc.free(encoded);
         var state = try std.json.parseFromSlice(restore_jobs.JobState, self.alloc, encoded, .{ .ignore_unknown_fields = true });
@@ -12321,7 +12885,7 @@ pub const ApiHttpServer = struct {
         self: *ApiHttpServer,
         body: []const u8,
         idempotency_key: ?[]const u8,
-        principal: ?[]const u8,
+        authenticated_identity: ?AuthenticatedIdentity,
     ) !contextual_operations.OwnedResponse {
         var req = backups_api.parseClusterRestoreRequest(self.alloc, body) catch return try contextualJsonErrorResponse(self.alloc, 400, "invalid restore request");
         defer backups_api.freeClusterRestoreRequest(self.alloc, &req);
@@ -12334,9 +12898,66 @@ pub const ApiHttpServer = struct {
             .required_capability = "restore.read",
             .io = self.sharedApiIo(),
         }) catch |err| return try contextualJsonErrorResponse(self.alloc, 400, backups_api.backupLocationErrorMessage(err) orelse "invalid restore location");
-        location.deinit(self.alloc);
+        defer location.deinit(self.alloc);
+
+        if (authenticated_identity) |identity| {
+            const credential_supported = std.mem.startsWith(u8, identity.credential_principal, "basic:") or
+                std.mem.startsWith(u8, identity.credential_principal, "api-key:");
+            if (!credential_supported) {
+                const restore_io = self.sharedApiIo() orelse
+                    return try contextualJsonErrorResponse(self.alloc, 503, "restore service unavailable");
+                var verification_cache: backups_api.ArtifactVerificationCache = .{};
+                defer verification_cache.deinit(self.alloc);
+                var cluster_manifest = backups_api.readClusterManifestForRestoreAdmissionWithCache(
+                    self.alloc,
+                    restore_io,
+                    &location,
+                    req.backup_id,
+                    &verification_cache,
+                ) catch |err| return try contextualJsonErrorResponse(
+                    self.alloc,
+                    if (err == error.BackupManifestTooLarge) 413 else 400,
+                    if (err == error.BackupManifestTooLarge) backups_api.manifest_too_large_message else "invalid cluster backup manifest",
+                );
+                defer cluster_manifest.deinit(self.alloc);
+                var owned_table_names: ?[][]u8 = null;
+                defer if (owned_table_names) |names| freeOwnedTableNames(self.alloc, names);
+                const selected_tables: []const []const u8 = if (req.table_names) |names|
+                    names
+                else blk: {
+                    const names = tableNamesFromClusterManifestAlloc(self.alloc, &cluster_manifest) catch
+                        return try contextualJsonErrorResponse(self.alloc, 500, "unable to inspect cluster backup");
+                    owned_table_names = names;
+                    break :blk names;
+                };
+                if (selected_tables.len > restore_jobs.max_cluster_tables_per_job)
+                    return try contextualJsonErrorResponse(self.alloc, 400, "too many tables requested");
+                for (selected_tables) |table_name| {
+                    const cluster_table = backups_api.findClusterTable(&cluster_manifest, table_name) orelse
+                        return try contextualJsonErrorResponse(self.alloc, 400, "backup does not include a requested table");
+                    const artifact_backup_id = cluster_table.artifact_backup_id orelse cluster_table.table_backup_id;
+                    self.authorizeClusterRestoreManifestDestinations(
+                        self.alloc,
+                        &location,
+                        cluster_table.table_backup_id,
+                        artifact_backup_id,
+                        identity.credential_principal,
+                    ) catch |err| switch (err) {
+                        error.StoredDestinationCredentialUnsupported => return try contextualJsonErrorResponse(self.alloc, 422, "durable destinations require Basic or API-key authentication"),
+                        error.StoredDestinationAuthorizationRevoked => return try contextualJsonErrorResponse(self.alloc, 403, "destination authorization is missing or revoked"),
+                        error.RestoreDestinationReauthorizationRequired => return try contextualJsonErrorResponse(self.alloc, 409, "restore destination authorization must be refreshed"),
+                        else => return try contextualJsonErrorResponse(self.alloc, 400, "invalid table backup manifest"),
+                    };
+                }
+            }
+        }
         self.ensureAsyncRestoreWorker() catch |err| return try restoreJobStartErrorResponse(self.alloc, err);
-        const idempotency_namespace = try restoreIdempotencyNamespaceAlloc(self.alloc, principal, .cluster, null);
+        const idempotency_namespace = try restoreIdempotencyNamespaceAlloc(
+            self.alloc,
+            transactionPrincipal(authenticated_identity),
+            .cluster,
+            null,
+        );
         defer self.alloc.free(idempotency_namespace);
         const encoded = self.restore_job_store.start(self.alloc, .{
             .scope = .cluster,
@@ -12347,6 +12968,7 @@ pub const ApiHttpServer = struct {
             .table_names = req.table_names,
             .idempotency_namespace = idempotency_namespace,
             .idempotency_key = idempotency_key,
+            .destination_authorization_principal = storedDestinationPrincipal(authenticated_identity),
         }) catch |err| return try restoreJobStartErrorResponse(self.alloc, err);
         defer self.alloc.free(encoded);
         var state = try std.json.parseFromSlice(restore_jobs.JobState, self.alloc, encoded, .{ .ignore_unknown_fields = true });
@@ -12562,7 +13184,10 @@ pub const ApiHttpServer = struct {
                         state.location,
                         state.connection,
                         &location,
-                        .{},
+                        .{
+                            .destination_authorization_fingerprint = state.destination_authorization_fingerprint,
+                            .destination_authorization_principal = state.destination_authorization_principal,
+                        },
                     ) catch |err| switch (err) {
                         // The local owned-table path reports durable completion as
                         // a sentinel because the public callback otherwise has no
@@ -12632,7 +13257,7 @@ pub const ApiHttpServer = struct {
                 .connection = state.connection,
                 .table_names = state.table_names,
                 .restore_mode = state.restore_mode,
-            }, &location, state.restore_mode, .{ .job_id = state.job_id, .attempt_id = state.attempt_id }, state.active_table_index, state.durability_pending_table_ranges orelse &.{}, state.published_table_ranges orelse &.{}) catch |err| {
+            }, &location, state.restore_mode, state.destination_authorization_principal, .{ .job_id = state.job_id, .attempt_id = state.attempt_id }, state.active_table_index, state.durability_pending_table_ranges orelse &.{}, state.published_table_ranges orelse &.{}) catch |err| {
                 if (err == error.BackupRepositoryBusy) {
                     const retry_delay_ns = restoreRepositoryRetryDelayNs(
                         state.job_id,
@@ -14805,6 +15430,7 @@ pub fn requiredPermissionForRequest(alloc: std.mem.Allocator, method: http_commo
         .POST, .PUT, .DELETE => null,
     };
     if (routes.Routes.matchTableLookup(path)) |lookup| return try tablePermission(alloc, lookup.table_name, .read);
+    if (routes.Routes.matchTableDestinationAuthorization(path)) |adoption| return try tablePermission(alloc, adoption.table_name, .admin);
     if (routes.Routes.matchTableQuery(path)) |query| return try tablePermission(alloc, query.table_name, .read);
     if (routes.Routes.matchTableScan(path)) |scan| return try tablePermission(alloc, scan.table_name, .read);
     if (routes.Routes.matchTableDocumentArtifacts(path)) |artifact| return try tablePermission(alloc, artifact.table_name, switch (method) {
@@ -14897,6 +15523,130 @@ pub fn requiredPermissionForRequest(alloc: std.mem.Allocator, method: http_commo
     return null;
 }
 
+test "destination authorization adoption requires source table admin" {
+    const required = (try requiredPermissionForRequest(
+        std.testing.allocator,
+        .POST,
+        "/tables/source%20table/destination-authorization",
+    )).?;
+    defer required.deinit(std.testing.allocator);
+    try std.testing.expectEqual(usermgr.ResourceType.table, required.resource_type);
+    try std.testing.expectEqualStrings("source table", required.resource);
+    try std.testing.expectEqual(usermgr.PermissionType.admin, required.permission_type);
+    const get_required = (try requiredPermissionForRequest(
+        std.testing.allocator,
+        .GET,
+        "/tables/source/destination-authorization",
+    )).?;
+    defer get_required.deinit(std.testing.allocator);
+}
+
+test "legacy stored destinations can be adopted idempotently" {
+    const alloc = std.testing.allocator;
+    const FakeSource = struct {
+        alloc: std.mem.Allocator,
+        table: metadata_table_manager.TableRecord = .{
+            .table_id = 1,
+            .name = "source",
+            .indexes_json = "{\"graph\":{\"resolvers\":[{\"table\":\"protected\"}]}}",
+            .replication_sources_json = "[{\"type\":\"snapshot\",\"routes\":[{\"target_table\":\"protected\"}]}]",
+        },
+        owned_indexes: ?[]u8 = null,
+        owned_replication_sources: ?[]u8 = null,
+        replace_count: usize = 0,
+
+        fn deinit(self: *@This()) void {
+            if (self.owned_indexes) |value| self.alloc.free(value);
+            if (self.owned_replication_sources) |value| self.alloc.free(value);
+        }
+
+        fn iface(self: *@This()) StatusSource {
+            return .{ .ptr = self, .vtable = &.{
+                .status = status,
+                .admin_snapshot = adminSnapshot,
+                .free_admin_snapshot = freeAdminSnapshot,
+                .replace_table_definition = replaceTableDefinition,
+                .wait_table_projection = waitTableProjection,
+            } };
+        }
+
+        fn status(_: *anyopaque) !metadata_api.MetadataStatus {
+            return .{ .metadata_group_id = 1, .metrics = .{} };
+        }
+
+        fn adminSnapshot(ptr: *anyopaque) !metadata_api.AdminSnapshot {
+            const self: *@This() = @ptrCast(@alignCast(ptr));
+            return .{
+                .status = .{ .metadata_group_id = 1, .metrics = .{} },
+                .tables = @as([*]metadata_table_manager.TableRecord, @ptrCast(&self.table))[0..1],
+                .ranges = @constCast((&[_]metadata_table_manager.RangeRecord{})[0..]),
+                .stores = @constCast((&[_]metadata_table_manager.StoreRecord{})[0..]),
+                .placement_intents = @constCast((&[_]raft_reconciler.PlacementIntent{})[0..]),
+                .split_transitions = @constCast((&[_]metadata_transition_state.SplitTransitionRecord{})[0..]),
+                .merge_transitions = @constCast((&[_]metadata_transition_state.MergeTransitionRecord{})[0..]),
+            };
+        }
+
+        fn freeAdminSnapshot(_: *anyopaque, _: *metadata_api.AdminSnapshot) void {}
+
+        fn replaceTableDefinition(
+            ptr: *anyopaque,
+            expected: metadata_table_manager.TableRecord,
+            replacement: metadata_table_manager.TableRecord,
+        ) !void {
+            const self: *@This() = @ptrCast(@alignCast(ptr));
+            if (!metadata_table_manager.tableDefinitionsEqual(self.table, expected))
+                return error.TableGenerationChanged;
+            const indexes = try self.alloc.dupe(u8, replacement.indexes_json);
+            errdefer self.alloc.free(indexes);
+            const replication_sources = try self.alloc.dupe(u8, replacement.replication_sources_json);
+            if (self.owned_indexes) |value| self.alloc.free(value);
+            if (self.owned_replication_sources) |value| self.alloc.free(value);
+            self.owned_indexes = indexes;
+            self.owned_replication_sources = replication_sources;
+            self.table.indexes_json = indexes;
+            self.table.replication_sources_json = replication_sources;
+            self.replace_count += 1;
+        }
+
+        fn waitTableProjection(_: *anyopaque, _: []const u8, _: ?[]const u8, _: ?[]const u8) !void {}
+    };
+
+    var source = FakeSource{ .alloc = alloc };
+    defer source.deinit();
+    var server = ApiHttpServer.init(alloc, .{}, source.iface(), null, null);
+    defer server.deinit();
+
+    var first = try executeHttpxTestRequest(&server, .{
+        .method = .POST,
+        .uri = "/tables/source/destination-authorization",
+    });
+    defer first.deinit(alloc);
+    try std.testing.expectEqual(@as(u16, 200), first.status);
+    try std.testing.expectEqual(@as(usize, 1), source.replace_count);
+    const authorizer: stored_destination_authorization.Authorizer = .{ .auth_enabled = false };
+    try stored_destination_authorization.authorizeReplicationSourcesJson(
+        alloc,
+        source.table.replication_sources_json,
+        "source",
+        authorizer,
+    );
+    try stored_destination_authorization.authorizeIndexesJson(
+        alloc,
+        source.table.indexes_json,
+        "source",
+        authorizer,
+    );
+
+    var second = try executeHttpxTestRequest(&server, .{
+        .method = .POST,
+        .uri = "/tables/source/destination-authorization",
+    });
+    defer second.deinit(alloc);
+    try std.testing.expectEqual(@as(u16, 200), second.status);
+    try std.testing.expectEqual(@as(usize, 1), source.replace_count);
+}
+
 test "inference connection invocation requires inference write permission" {
     const required = (try requiredPermissionForRequest(
         std.testing.allocator,
@@ -14967,6 +15717,15 @@ pub fn transactionPrincipal(authenticated_identity: ?AuthenticatedIdentity) ?[]c
     return identity.credential_principal;
 }
 
+pub fn storedDestinationPrincipal(authenticated_identity: ?AuthenticatedIdentity) []const u8 {
+    const identity = authenticated_identity orelse
+        return stored_destination_authorization.auth_disabled_principal;
+    return if (identity.credential_principal.len > 0)
+        identity.credential_principal
+    else
+        identity.username;
+}
+
 fn transactionTablePermissionAllowed(
     authenticated_identity: ?AuthenticatedIdentity,
     table_name: []const u8,
@@ -14974,6 +15733,83 @@ fn transactionTablePermissionAllowed(
 ) bool {
     const identity = authenticated_identity orelse return true;
     return permissionsAllow(identity.permissions, .table, table_name, permission_type);
+}
+
+fn storedDestinationAllowedForIdentity(
+    authenticated_identity: ?AuthenticatedIdentity,
+    table_name: []const u8,
+) !bool {
+    const identity = authenticated_identity orelse return true;
+    if (!std.mem.startsWith(u8, identity.credential_principal, "basic:") and
+        !std.mem.startsWith(u8, identity.credential_principal, "api-key:"))
+        return error.StoredDestinationCredentialUnsupported;
+    return permissionsAllow(identity.permissions, .table, table_name, .write);
+}
+
+fn replicationDestinationsAllowedForIdentity(
+    alloc: std.mem.Allocator,
+    authenticated_identity: ?AuthenticatedIdentity,
+    replication_sources_json: []const u8,
+) !bool {
+    var parsed = try std.json.parseFromSlice(std.json.Value, alloc, replication_sources_json, .{});
+    defer parsed.deinit();
+    if (parsed.value != .array) return error.InvalidCreateTableRequest;
+    for (parsed.value.array.items) |source| {
+        if (source != .object) return error.InvalidCreateTableRequest;
+        const routes_value = source.object.get("routes") orelse continue;
+        if (routes_value == .null) continue;
+        if (routes_value != .array) return error.InvalidCreateTableRequest;
+        for (routes_value.array.items) |route| {
+            if (route != .object) return error.InvalidCreateTableRequest;
+            const target = route.object.get("target_table") orelse return error.InvalidCreateTableRequest;
+            if (target != .string or target.string.len == 0) return error.InvalidCreateTableRequest;
+            if (!(try storedDestinationAllowedForIdentity(authenticated_identity, target.string))) return false;
+        }
+    }
+    return true;
+}
+
+fn graphResolverDestinationsAllowedForIdentity(
+    alloc: std.mem.Allocator,
+    authenticated_identity: ?AuthenticatedIdentity,
+    indexes_json: []const u8,
+    single_index: bool,
+) !bool {
+    var parsed = try std.json.parseFromSlice(std.json.Value, alloc, indexes_json, .{});
+    defer parsed.deinit();
+    if (single_index) return try graphResolverValueDestinationsAllowed(authenticated_identity, parsed.value);
+    if (parsed.value != .object) return error.InvalidCreateTableRequest;
+    return try graphResolverValueDestinationsAllowed(authenticated_identity, parsed.value);
+}
+
+fn graphResolverValueDestinationsAllowed(
+    authenticated_identity: ?AuthenticatedIdentity,
+    value: std.json.Value,
+) !bool {
+    switch (value) {
+        .object => |object| {
+            if (object.get("resolvers")) |resolvers| {
+                if (resolvers != .array) return error.InvalidCreateTableRequest;
+                for (resolvers.array.items) |resolver| {
+                    if (resolver == .string) continue;
+                    if (resolver != .object) return error.InvalidCreateTableRequest;
+                    const table = resolver.object.get("table") orelse continue;
+                    if (table != .string or table.string.len == 0) return error.InvalidCreateTableRequest;
+                    if (!(try storedDestinationAllowedForIdentity(authenticated_identity, table.string))) return false;
+                }
+            }
+            var it = object.iterator();
+            while (it.next()) |entry| {
+                if (std.mem.eql(u8, entry.key_ptr.*, "resolvers")) continue;
+                if (!(try graphResolverValueDestinationsAllowed(authenticated_identity, entry.value_ptr.*))) return false;
+            }
+        },
+        .array => |array| for (array.items) |item| {
+            if (!(try graphResolverValueDestinationsAllowed(authenticated_identity, item))) return false;
+        },
+        else => {},
+    }
+    return true;
 }
 
 test "document artifact routes declare read and admin permissions" {
@@ -21775,6 +22611,60 @@ fn bindTestAuthManager(alloc: std.mem.Allocator, auth: *TestAuthManager) !void {
         alloc,
         auth.store.iface(),
         try usermgr.initDefaultEnforcer(alloc, auth.policy_store.iface()),
+    );
+}
+
+test "stored destination grants bind credential source and live permissions" {
+    const alloc = std.testing.allocator;
+    var auth = try initTestAuthManager(alloc);
+    try bindTestAuthManager(alloc, &auth);
+    defer auth.manager.deinit();
+    defer auth.policy_store.deinit();
+    defer auth.store.deinit();
+
+    var permission = try usermgr.Permission.initOwned(alloc, .table, "protected", .write);
+    defer permission.deinit(alloc);
+    var user = try auth.manager.createUser("alice", "initial-password", &.{permission});
+    defer user.deinit(alloc);
+
+    const authorizer: stored_destination_authorization.Authorizer = .{
+        .manager = &auth.manager,
+        .auth_enabled = true,
+    };
+    const raw =
+        \\[{"type":"postgres","routes":[{"target_table":"protected"}]}]
+    ;
+    const sealed = try stored_destination_authorization.sealReplicationSourcesJsonForPrincipalAlloc(
+        alloc,
+        raw,
+        "source",
+        "basic:alice",
+        authorizer,
+    );
+    defer alloc.free(sealed);
+    try stored_destination_authorization.authorizeReplicationSourcesJson(alloc, sealed, "source", authorizer);
+    try std.testing.expectError(
+        error.StoredDestinationAuthorizationInvalid,
+        stored_destination_authorization.authorizeReplicationSourcesJson(alloc, sealed, "other-source", authorizer),
+    );
+
+    try auth.manager.updatePassword("alice", "rotated-password");
+    try std.testing.expectError(
+        error.StoredDestinationAuthorizationInvalid,
+        stored_destination_authorization.authorizeReplicationSourcesJson(alloc, sealed, "source", authorizer),
+    );
+    const resealed = try stored_destination_authorization.sealReplicationSourcesJsonForPrincipalAlloc(
+        alloc,
+        raw,
+        "source",
+        "basic:alice",
+        authorizer,
+    );
+    defer alloc.free(resealed);
+    try auth.manager.removePermissionFromUser("alice", "protected", .table);
+    try std.testing.expectError(
+        error.StoredDestinationAuthorizationRevoked,
+        stored_destination_authorization.authorizeReplicationSourcesJson(alloc, resealed, "source", authorizer),
     );
 }
 
@@ -34871,7 +35761,7 @@ test "api http server rejects restore before persistence without an asynchronous
         "docs",
         "{\"backup_id\":\"snap1\",\"location\":\"file:///tmp/backups\",\"connection\":\"test-backups\"}",
         "restore-without-worker",
-        "admin",
+        null,
     );
     defer response.deinit(std.testing.allocator);
     try std.testing.expectEqual(@as(u16, 503), response.status);
@@ -34890,7 +35780,7 @@ test "api http server rejects restore before persistence without an asynchronous
         "docs",
         "{\"backup_id\":\"snap1\",\"location\":\"file:///tmp/backups\",\"connection\":\"test-backups\"}",
         "restore-without-store",
-        "admin",
+        null,
     );
     defer storeless_response.deinit(std.testing.allocator);
     try std.testing.expectEqual(@as(u16, 503), storeless_response.status);

--- a/zig/pkg/antfly/src/api/http_server.zig
+++ b/zig/pkg/antfly/src/api/http_server.zig
@@ -31948,7 +31948,7 @@ test "api http server serves table create and drop" {
             try std.testing.expectEqualStrings("docs table", req.description.?);
             try std.testing.expect(req.schema_json == null);
             try std.testing.expect(try indexes_api.equivalentIndexConfigJson(std.testing.allocator, tables_api.default_indexes_json, req.indexes_json.?));
-            try std.testing.expect(req.replication_sources_json == null);
+            try std.testing.expectEqualStrings("[]", req.replication_sources_json.?);
             self.created = true;
             self.replaceIndexesJson(inner_alloc, try inner_alloc.dupe(u8, req.indexes_json.?), true);
         }

--- a/zig/pkg/antfly/src/api/httpx_handler.zig
+++ b/zig/pkg/antfly/src/api/httpx_handler.zig
@@ -53,6 +53,7 @@ const backups_api = @import("backups.zig");
 const batch_api = @import("batch.zig");
 const restore_jobs = @import("restore_jobs.zig");
 const public_table_http = @import("public_table_http.zig");
+const stored_destination_authorization = @import("stored_destination_authorization.zig");
 const tables_api = @import("tables.zig");
 const table_contract = @import("table_contract.zig");
 const table_reads = if (builtin.is_test) @import("table_reads.zig") else @import("table_read_source.zig");
@@ -110,6 +111,90 @@ fn isNdjsonContentType(content_type: ?[]const u8) bool {
     const value = content_type orelse return false;
     const media_type = std.mem.trim(u8, if (std.mem.indexOfScalar(u8, value, ';')) |idx| value[0..idx] else value, " \t");
     return std.ascii.eqlIgnoreCase(media_type, "application/x-ndjson");
+}
+
+fn storedDestinationAllowed(identity: ?AuthenticatedIdentity, table_name: []const u8) !bool {
+    const authenticated = identity orelse return true;
+    if (!std.mem.startsWith(u8, authenticated.credential_principal, "basic:") and
+        !std.mem.startsWith(u8, authenticated.credential_principal, "api-key:"))
+        return error.StoredDestinationCredentialUnsupported;
+    return http_server_mod.permissionsAllow(authenticated.permissions, .table, table_name, .write);
+}
+
+fn replicationDestinationsAllowed(
+    alloc: std.mem.Allocator,
+    identity: ?AuthenticatedIdentity,
+    replication_sources_json: []const u8,
+) !bool {
+    var parsed = try std.json.parseFromSlice(std.json.Value, alloc, replication_sources_json, .{});
+    defer parsed.deinit();
+    const sources = switch (parsed.value) {
+        .array => |array| array.items,
+        else => return error.InvalidCreateTableRequest,
+    };
+    for (sources) |source| {
+        if (source != .object) return error.InvalidCreateTableRequest;
+        const routes_value = source.object.get("routes") orelse continue;
+        if (routes_value == .null) continue;
+        const configured_routes = switch (routes_value) {
+            .array => |array| array.items,
+            else => return error.InvalidCreateTableRequest,
+        };
+        for (configured_routes) |configured_route| {
+            if (configured_route != .object) return error.InvalidCreateTableRequest;
+            const target_value = configured_route.object.get("target_table") orelse return error.InvalidCreateTableRequest;
+            const target_table = switch (target_value) {
+                .string => |value| value,
+                else => return error.InvalidCreateTableRequest,
+            };
+            if (target_table.len == 0) return error.InvalidCreateTableRequest;
+            if (!(try storedDestinationAllowed(identity, target_table))) return false;
+        }
+    }
+    return true;
+}
+
+fn graphResolverDestinationsAllowedInConfig(
+    identity: ?AuthenticatedIdentity,
+    config: std.json.Value,
+) !bool {
+    switch (config) {
+        .object => |object| {
+            if (object.get("resolvers")) |resolvers_value| {
+                if (resolvers_value != .array) return error.InvalidCreateTableRequest;
+                for (resolvers_value.array.items) |resolver| {
+                    if (resolver == .string) continue;
+                    if (resolver != .object) return error.InvalidCreateTableRequest;
+                    const table_value = resolver.object.get("table") orelse continue;
+                    if (table_value != .string or table_value.string.len == 0) return error.InvalidCreateTableRequest;
+                    if (!(try storedDestinationAllowed(identity, table_value.string))) return false;
+                }
+            }
+            var it = object.iterator();
+            while (it.next()) |entry| {
+                if (std.mem.eql(u8, entry.key_ptr.*, "resolvers")) continue;
+                if (!(try graphResolverDestinationsAllowedInConfig(identity, entry.value_ptr.*))) return false;
+            }
+        },
+        .array => |array| for (array.items) |item| {
+            if (!(try graphResolverDestinationsAllowedInConfig(identity, item))) return false;
+        },
+        else => {},
+    }
+    return true;
+}
+
+fn graphResolverDestinationsAllowed(
+    alloc: std.mem.Allocator,
+    identity: ?AuthenticatedIdentity,
+    indexes_json: []const u8,
+    single_index: bool,
+) !bool {
+    var parsed = try std.json.parseFromSlice(std.json.Value, alloc, indexes_json, .{});
+    defer parsed.deinit();
+    if (single_index) return try graphResolverDestinationsAllowedInConfig(identity, parsed.value);
+    if (parsed.value != .object) return error.InvalidCreateTableRequest;
+    return try graphResolverDestinationsAllowedInConfig(identity, parsed.value);
 }
 
 pub const RequestAdmission = http_server_mod.RequestAdmission;
@@ -789,6 +874,7 @@ pub const AntflyApiHandler = struct {
                 .kind = .user,
                 .subject = authenticated.username,
             } else null,
+            .destination_authorization_principal = http_server_mod.storedDestinationPrincipal(identity),
         };
     }
 
@@ -3405,7 +3491,7 @@ pub const AntflyApiHandler = struct {
         var resp = try self.api_server.handlePublicClusterRestore(
             body_data,
             ctx.header("idempotency-key"),
-            if (authenticated_identity) |identity| identity.username else null,
+            authenticated_identity,
         );
         return respondOwnedContextualResponse(ctx, &resp, self.api_server.alloc);
     }
@@ -3883,6 +3969,50 @@ pub const AntflyApiHandler = struct {
             _ = ctx.status(400);
             return ctx.text("unsupported table index configuration");
         };
+        const destinations_allowed = (replicationDestinationsAllowed(
+            alloc,
+            authenticated_identity,
+            create_req.replication_sources_json orelse "[]",
+        ) catch |err| {
+            if (err == error.StoredDestinationCredentialUnsupported)
+                return jsonErrorResponse(ctx, 422, "durable destinations require Basic or API-key authentication");
+            _ = ctx.status(400);
+            return ctx.text("invalid replication destination configuration");
+        }) and (graphResolverDestinationsAllowed(
+            alloc,
+            authenticated_identity,
+            create_req.indexes_json orelse tables_api.default_indexes_json,
+            false,
+        ) catch |err| {
+            if (err == error.StoredDestinationCredentialUnsupported)
+                return jsonErrorResponse(ctx, 422, "durable destinations require Basic or API-key authentication");
+            _ = ctx.status(400);
+            return ctx.text("invalid graph resolver destination configuration");
+        });
+        if (!destinations_allowed) return jsonErrorResponse(ctx, 403, "forbidden");
+        const destination_principal = http_server_mod.storedDestinationPrincipal(authenticated_identity);
+        const destination_authorizer: stored_destination_authorization.Authorizer = .{
+            .manager = self.api_server.cfg.user_manager,
+            .auth_enabled = self.api_server.cfg.auth_enabled,
+        };
+        const sealed_replication_sources_json = try stored_destination_authorization.sealReplicationSourcesJsonForPrincipalAlloc(
+            alloc,
+            create_req.replication_sources_json orelse "[]",
+            decoded_table_name,
+            destination_principal,
+            destination_authorizer,
+        );
+        if (create_req.replication_sources_json) |old| alloc.free(old);
+        create_req.replication_sources_json = sealed_replication_sources_json;
+        const sealed_indexes_json = try stored_destination_authorization.sealIndexesJsonForPrincipalAlloc(
+            alloc,
+            create_req.indexes_json orelse tables_api.default_indexes_json,
+            decoded_table_name,
+            destination_principal,
+            destination_authorizer,
+        );
+        if (create_req.indexes_json) |old| alloc.free(old);
+        create_req.indexes_json = sealed_indexes_json;
         std.log.info("public create table begin table={s}", .{decoded_table_name});
         const metadata_create_start_ns = platform_time.monotonicNs();
         var metadata_create_attempts: usize = 0;
@@ -4194,7 +4324,21 @@ pub const AntflyApiHandler = struct {
             decoded_table_name,
             body_data,
             ctx.header("idempotency-key"),
-            if (authenticated_identity) |identity| identity.username else null,
+            authenticated_identity,
+        );
+        return respondOwnedContextualResponse(ctx, &resp, self.api_server.alloc);
+    }
+
+    pub fn reauthorizeTableDestinations(self: *AntflyApiHandler, ctx: *httpx.Context, table_name: []const u8) !httpx.Response {
+        var authenticated_identity: ?AuthenticatedIdentity = null;
+        defer if (authenticated_identity) |*identity| identity.deinit(self.api_server.alloc);
+        if (try self.authorizeRequest(ctx, &authenticated_identity)) |resp| return resp;
+        const decoded_table_name = (try decodePathParamOrBadRequest(ctx, table_name)) orelse
+            return ctx.text("invalid path parameter");
+        defer ctx.allocator.free(decoded_table_name);
+        var resp = try self.api_server.handlePublicReauthorizeTableDestinations(
+            decoded_table_name,
+            authenticated_identity,
         );
         return respondOwnedContextualResponse(ctx, &resp, self.api_server.alloc);
     }
@@ -4704,6 +4848,18 @@ pub const AntflyApiHandler = struct {
         const decoded_index_name = (try decodePathParamOrBadRequest(ctx, index_name)) orelse return ctx.text("invalid path parameter");
         defer ctx.allocator.free(decoded_index_name);
         const body_data = (try ctx.body()) orelse "";
+        const destinations_allowed = graphResolverDestinationsAllowed(
+            ctx.allocator,
+            authenticated_identity,
+            body_data,
+            true,
+        ) catch |err| {
+            if (err == error.StoredDestinationCredentialUnsupported)
+                return jsonErrorResponse(ctx, 422, "durable destinations require Basic or API-key authentication");
+            _ = ctx.status(400);
+            return ctx.text("invalid graph resolver destination configuration");
+        };
+        if (!destinations_allowed) return jsonErrorResponse(ctx, 403, "forbidden");
         var resp = try public_table_http.handleTableCreateIndex(ctx.allocator, decoded_table_name, decoded_index_name, body_data, self.api_server.tableApi(operationContext(ctx, authenticated_identity)));
         return respondOwnedApiResponse(ctx, &resp);
     }
@@ -7810,6 +7966,46 @@ test "httpx global query table name comes from request body" {
     defer parsed_table.deinit();
 
     try std.testing.expectEqualStrings("files", parsed_table.table_name);
+}
+
+test "stored destination admission requires write permission on every eventual sink" {
+    const alloc = std.testing.allocator;
+    var decoy_permission = [_]usermgr.Permission{
+        try usermgr.Permission.initOwned(alloc, .table, "decoy", .admin),
+    };
+    defer decoy_permission[0].deinit(alloc);
+    const decoy_identity = AuthenticatedIdentity{
+        .username = @constCast("attacker"),
+        .credential_principal = @constCast("basic:attacker"),
+        .permissions = &decoy_permission,
+    };
+
+    const cdc_config =
+        \\[{"type":"postgres","dsn":"postgres://db","postgres_table":"events","routes":[{"target_table":"protected","where":{"term":{"tier":"gold"}}}]}]
+    ;
+    try std.testing.expect(!(try replicationDestinationsAllowed(alloc, decoy_identity, cdc_config)));
+
+    const graph_config =
+        \\{"type":"graph","resolvers":[{"name":"entities","table":"protected","source_artifact":"relations_v1","resolution_artifact":"resolution_v1"}]}
+    ;
+    try std.testing.expect(!(try graphResolverDestinationsAllowed(alloc, decoy_identity, graph_config, true)));
+    const table_indexes_config =
+        \\{"relations_graph":{"type":"graph"},"resolvers":[{"name":"entities","table":"protected","source_artifact":"relations_v1","resolution_artifact":"resolution_v1"}]}
+    ;
+    try std.testing.expect(!(try graphResolverDestinationsAllowed(alloc, decoy_identity, table_indexes_config, false)));
+
+    var sink_permission = [_]usermgr.Permission{
+        try usermgr.Permission.initOwned(alloc, .table, "protected", .write),
+    };
+    defer sink_permission[0].deinit(alloc);
+    const sink_identity = AuthenticatedIdentity{
+        .username = @constCast("operator"),
+        .credential_principal = @constCast("basic:operator"),
+        .permissions = &sink_permission,
+    };
+    try std.testing.expect(try replicationDestinationsAllowed(alloc, sink_identity, cdc_config));
+    try std.testing.expect(try graphResolverDestinationsAllowed(alloc, sink_identity, graph_config, true));
+    try std.testing.expect(try graphResolverDestinationsAllowed(alloc, sink_identity, table_indexes_config, false));
 }
 
 test "httpx query endpoints accept ndjson multiquery bodies" {

--- a/zig/pkg/antfly/src/api/operation.zig
+++ b/zig/pkg/antfly/src/api/operation.zig
@@ -71,6 +71,12 @@ pub const RequestContext = struct {
     request_id: []const u8 = "",
     principal: ?Principal = null,
     admission: ?*AdmissionReservation = null,
+    /// Durable hash of an externally sourced table definition that was
+    /// authorized before asynchronous restore admission.
+    destination_authorization_fingerprint: []const u8 = "",
+    /// Credential identity that authorized durable background destinations.
+    /// Workers re-resolve this principal against the live user/key store.
+    destination_authorization_principal: []const u8 = "",
 
     pub fn ensureActive(self: RequestContext) ApiError!void {
         if (self.cancellation.isCancelled()) return error.Canceled;

--- a/zig/pkg/antfly/src/api/public_table_http.zig
+++ b/zig/pkg/antfly/src/api/public_table_http.zig
@@ -181,6 +181,7 @@ pub const TableApi = struct {
         RestoreDurabilityPending,
         RestoreDurabilityConfirmed,
         BackupIntegrityFailure,
+        RestoreDestinationReauthorizationRequired,
         InvalidBackupRequest,
         InternalFailure,
     };
@@ -1200,6 +1201,10 @@ pub fn handleTableRestore(
         error.RestoreDurabilityPending => return .{ .status = 202, .body = try backups_api.encodeRestoreDurabilityPending(alloc), .json = true },
         error.RestoreDurabilityConfirmed => return .{ .status = 200, .body = try backups_api.encodeRestoreDurabilityConfirmed(alloc), .json = true },
         error.BackupIntegrityFailure => return .{ .status = 422, .body = try alloc.dupe(u8, backups_api.integrity_failure_message) },
+        error.RestoreDestinationReauthorizationRequired => return .{
+            .status = 409,
+            .body = try alloc.dupe(u8, "restore was queued before destination authorization was recorded; resubmit it to reauthorize CDC and graph destinations"),
+        },
         error.InvalidBackupRequest => return .{ .status = 400, .body = try alloc.dupe(u8, "invalid restore request") },
         error.InternalFailure => return .{ .status = 500, .body = try alloc.dupe(u8, "restore failed") },
     };

--- a/zig/pkg/antfly/src/api/request_admission_policy.zig
+++ b/zig/pkg/antfly/src/api/request_admission_policy.zig
@@ -93,6 +93,7 @@ pub const public_operation_policies = [_]PublicOperationPolicy{
     .{ .operation_id = "cancelTableRepairJob", .class = .none },
     .{ .operation_id = "runTableRepair", .class = .none },
     .{ .operation_id = "restoreTable", .class = .none },
+    .{ .operation_id = "reauthorizeTableDestinations", .class = .none },
     .{ .operation_id = "updateSchema", .class = .none },
     .{ .operation_id = "listTransactionSessions", .class = .none },
     .{ .operation_id = "beginTransaction", .class = .none },

--- a/zig/pkg/antfly/src/api/restore_jobs.zig
+++ b/zig/pkg/antfly/src/api/restore_jobs.zig
@@ -71,6 +71,8 @@ pub const JobState = struct {
     idempotency_key: []const u8,
     idempotency_explicit: bool = false,
     request_fingerprint: []const u8,
+    destination_authorization_fingerprint: []const u8 = "",
+    destination_authorization_principal: []const u8 = "",
     result_json: ?[]const u8 = null,
     last_error: ?[]const u8 = null,
     created_at_ms: u64,
@@ -88,6 +90,8 @@ pub const StartRequest = struct {
     table_names: ?[]const []const u8 = null,
     idempotency_namespace: []const u8,
     idempotency_key: ?[]const u8 = null,
+    destination_authorization_fingerprint: []const u8 = "",
+    destination_authorization_principal: []const u8 = "",
 };
 
 pub const ListBatch = struct {
@@ -458,6 +462,8 @@ pub const Store = struct {
                         .idempotency_key = parsed.value.idempotency_key,
                         .idempotency_explicit = parsed.value.idempotency_explicit,
                         .request_fingerprint = parsed.value.request_fingerprint,
+                        .destination_authorization_fingerprint = parsed.value.destination_authorization_fingerprint,
+                        .destination_authorization_principal = parsed.value.destination_authorization_principal,
                         .last_error = "resuming_after_restart",
                         .created_at_ms = parsed.value.created_at_ms,
                         .updated_at_ms = nowMillis(),
@@ -718,6 +724,8 @@ pub const Store = struct {
                 .idempotency_key = parsed.value.idempotency_key,
                 .idempotency_explicit = parsed.value.idempotency_explicit,
                 .request_fingerprint = parsed.value.request_fingerprint,
+                .destination_authorization_fingerprint = parsed.value.destination_authorization_fingerprint,
+                .destination_authorization_principal = parsed.value.destination_authorization_principal,
                 .last_error = "resuming_after_restart",
                 .created_at_ms = parsed.value.created_at_ms,
                 .updated_at_ms = nowMillis(),
@@ -784,7 +792,60 @@ pub const Store = struct {
                 const encoded = self.jobs.get(job_id) orelse return error.CorruptRestoreJobStore;
                 var parsed = try std.json.parseFromSlice(JobState, alloc, encoded, .{ .ignore_unknown_fields = true });
                 defer parsed.deinit();
-                if (!std.mem.eql(u8, parsed.value.request_fingerprint, fingerprint)) return error.IdempotencyConflict;
+                const same_request = std.mem.eql(u8, parsed.value.request_fingerprint, fingerprint);
+                const reauthorize = destinationReauthorizationMatches(parsed.value, req);
+                if (!same_request and !reauthorize) return error.IdempotencyConflict;
+                if (reauthorize) {
+                    // A destination authorization failure is guaranteed to
+                    // occur before the next publication boundary. Re-admission
+                    // with the same explicit key is an authorization refresh,
+                    // not a different operation: preserve both job identity
+                    // and durable cluster progress while atomically returning
+                    // the attempt to the FIFO.
+                    self.compactPendingFullyLocked();
+                    try self.pending.ensureUnusedCapacity(self.alloc, 1);
+                    const dispatch_sequence = try self.allocateDispatchSequenceLocked();
+                    const now = nowMillis();
+                    const reauthorized = try encode(alloc, .{
+                        .format_version = restore_job_format_version,
+                        .job_id = parsed.value.job_id,
+                        .enqueue_sequence = parsed.value.enqueue_sequence,
+                        .dispatch_sequence = dispatch_sequence,
+                        .not_before_ms = now,
+                        .attempt_id = parsed.value.attempt_id,
+                        .scope = parsed.value.scope,
+                        .table_name = parsed.value.table_name,
+                        .backup_id = parsed.value.backup_id,
+                        .location = parsed.value.location,
+                        .connection = parsed.value.connection,
+                        .restore_mode = parsed.value.restore_mode,
+                        .table_names = parsed.value.table_names,
+                        .active_table_index = parsed.value.active_table_index,
+                        .durability_pending_table_ranges = parsed.value.durability_pending_table_ranges,
+                        .published_table_ranges = parsed.value.published_table_ranges,
+                        .completed_table_ranges = parsed.value.completed_table_ranges,
+                        .phase = .queued,
+                        .idempotency_namespace = parsed.value.idempotency_namespace,
+                        .idempotency_key = parsed.value.idempotency_key,
+                        .idempotency_explicit = true,
+                        .request_fingerprint = fingerprint,
+                        .destination_authorization_fingerprint = req.destination_authorization_fingerprint,
+                        .destination_authorization_principal = req.destination_authorization_principal,
+                        .created_at_ms = parsed.value.created_at_ms,
+                        .updated_at_ms = now,
+                        .expires_at_ms = std.math.maxInt(i64),
+                    });
+                    errdefer alloc.free(reauthorized);
+                    if (reauthorized.len > max_initial_restore_job_bytes)
+                        return error.RestoreJobRecordTooLarge;
+                    try self.storeLocked(job_id, reauthorized);
+                    try self.insertPendingSortedLocked(.{
+                        .job_id = job_id,
+                        .dispatch_sequence = dispatch_sequence,
+                        .not_before_ms = now,
+                    });
+                    return reauthorized;
+                }
                 return try alloc.dupe(u8, encoded);
             }
         }
@@ -824,6 +885,8 @@ pub const Store = struct {
             .idempotency_key = idempotency_key,
             .idempotency_explicit = explicit_idempotency_key != null,
             .request_fingerprint = fingerprint,
+            .destination_authorization_fingerprint = req.destination_authorization_fingerprint,
+            .destination_authorization_principal = req.destination_authorization_principal,
             .created_at_ms = now,
             .updated_at_ms = now,
             .expires_at_ms = std.math.maxInt(i64),
@@ -1364,6 +1427,8 @@ pub const Store = struct {
             .idempotency_key = current.idempotency_key,
             .idempotency_explicit = current.idempotency_explicit,
             .request_fingerprint = current.request_fingerprint,
+            .destination_authorization_fingerprint = current.destination_authorization_fingerprint,
+            .destination_authorization_principal = current.destination_authorization_principal,
             .result_json = update.result_json orelse current.result_json,
             .last_error = update.last_error,
             .created_at_ms = current.created_at_ms,
@@ -1626,6 +1691,8 @@ fn validateStartRequest(req: StartRequest) !void {
         req.location.len == 0 or req.location.len > max_restore_string_bytes or
         req.connection.len == 0 or req.connection.len > max_restore_string_bytes or
         req.idempotency_namespace.len == 0 or req.idempotency_namespace.len > 256 or
+        req.destination_authorization_fingerprint.len > 64 or
+        req.destination_authorization_principal.len > 256 or
         (req.table_name != null and req.table_name.?.len > max_restore_string_bytes))
         return error.RestoreJobRecordTooLarge;
     switch (req.scope) {
@@ -1898,12 +1965,57 @@ fn requestFingerprintAlloc(alloc: std.mem.Allocator, req: StartRequest) ![]u8 {
         .connection = req.connection,
         .restore_mode = req.restore_mode,
         .table_names = req.table_names,
+        .destination_authorization_fingerprint = req.destination_authorization_fingerprint,
+        .destination_authorization_principal = req.destination_authorization_principal,
     }, .{});
     defer alloc.free(canonical);
     var digest: [std.crypto.hash.sha2.Sha256.digest_length]u8 = undefined;
     std.crypto.hash.sha2.Sha256.hash(canonical, &digest, .{});
     const hex = std.fmt.bytesToHex(digest, .lower);
     return try alloc.dupe(u8, &hex);
+}
+
+fn optionalBytesEqual(lhs: ?[]const u8, rhs: ?[]const u8) bool {
+    if (lhs == null or rhs == null) return lhs == null and rhs == null;
+    return std.mem.eql(u8, lhs.?, rhs.?);
+}
+
+fn optionalStringListEqual(lhs: ?[]const []const u8, rhs: ?[]const []const u8) bool {
+    if (lhs == null or rhs == null) return lhs == null and rhs == null;
+    if (lhs.?.len != rhs.?.len) return false;
+    for (lhs.?, rhs.?) |left, right| {
+        if (!std.mem.eql(u8, left, right)) return false;
+    }
+    return true;
+}
+
+fn destinationReauthorizationMatches(current: JobState, req: StartRequest) bool {
+    const authorization_failure = current.last_error != null and
+        (std.mem.eql(u8, current.last_error.?, "RestoreDestinationReauthorizationRequired") or
+            std.mem.eql(u8, current.last_error.?, "StoredDestinationAuthorizationRevoked"));
+    const legacy_authorization = current.destination_authorization_fingerprint.len == 0 and
+        current.destination_authorization_principal.len == 0;
+    const same_authorization = std.mem.eql(
+        u8,
+        current.destination_authorization_fingerprint,
+        req.destination_authorization_fingerprint,
+    ) and std.mem.eql(
+        u8,
+        current.destination_authorization_principal,
+        req.destination_authorization_principal,
+    );
+    return current.phase == .failed and
+        authorization_failure and
+        req.destination_authorization_principal.len > 0 and
+        (req.scope == .cluster or req.destination_authorization_fingerprint.len > 0) and
+        (legacy_authorization or same_authorization) and
+        current.scope == req.scope and
+        optionalBytesEqual(current.table_name, req.table_name) and
+        std.mem.eql(u8, current.backup_id, req.backup_id) and
+        std.mem.eql(u8, current.location, req.location) and
+        std.mem.eql(u8, current.connection, req.connection) and
+        std.mem.eql(u8, current.restore_mode, req.restore_mode) and
+        optionalStringListEqual(current.table_names, req.table_names);
 }
 
 fn idempotencyMapKeyAlloc(alloc: std.mem.Allocator, namespace: []const u8, key: []const u8) ![]u8 {
@@ -2010,6 +2122,78 @@ const TestReplicatedPersistence = struct {
     }
 };
 
+test "failed destination authorization refresh reuses the idempotent restore job" {
+    const alloc = std.testing.allocator;
+    var persistence = TestReplicatedPersistence.init(alloc);
+    defer persistence.deinit();
+    var store = Store.initWithIo(alloc, std.testing.io);
+    defer store.deinit();
+    try store.attachReplicated(persistence.persistence());
+
+    const legacy_request: StartRequest = .{
+        .scope = .table,
+        .table_name = "source",
+        .backup_id = "daily",
+        .location = "s3://archive/daily",
+        .connection = "archive-reader",
+        .idempotency_namespace = "basic:operator:table:source",
+        .idempotency_key = "restore-7",
+    };
+    const queued = try store.start(alloc, legacy_request);
+    defer alloc.free(queued);
+    var queued_state = try std.json.parseFromSlice(JobState, alloc, queued, .{});
+    defer queued_state.deinit();
+    const running = (try store.begin(alloc, queued_state.value.job_id)).?;
+    defer alloc.free(running);
+    var running_state = try std.json.parseFromSlice(JobState, alloc, running, .{});
+    defer running_state.deinit();
+    const failed = try store.fail(
+        alloc,
+        running_state.value,
+        "RestoreDestinationReauthorizationRequired",
+    );
+    defer alloc.free(failed);
+
+    const fingerprint = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+    const adopted_request: StartRequest = .{
+        .scope = .table,
+        .table_name = "source",
+        .backup_id = "daily",
+        .location = "s3://archive/daily",
+        .connection = "archive-reader",
+        .idempotency_namespace = "basic:operator:table:source",
+        .idempotency_key = "restore-7",
+        .destination_authorization_fingerprint = fingerprint,
+        .destination_authorization_principal = "basic:operator",
+    };
+    const reauthorized = try store.start(alloc, adopted_request);
+    defer alloc.free(reauthorized);
+    var reauthorized_state = try std.json.parseFromSlice(JobState, alloc, reauthorized, .{});
+    defer reauthorized_state.deinit();
+    try std.testing.expectEqual(queued_state.value.job_id, reauthorized_state.value.job_id);
+    try std.testing.expectEqual(Phase.queued, reauthorized_state.value.phase);
+    try std.testing.expectEqualStrings(fingerprint, reauthorized_state.value.destination_authorization_fingerprint);
+    try std.testing.expectEqualStrings("basic:operator", reauthorized_state.value.destination_authorization_principal);
+    try std.testing.expect(reauthorized_state.value.last_error == null);
+
+    const rerunning = (try store.begin(alloc, queued_state.value.job_id)).?;
+    defer alloc.free(rerunning);
+    var rerunning_state = try std.json.parseFromSlice(JobState, alloc, rerunning, .{});
+    defer rerunning_state.deinit();
+    const revoked = try store.fail(alloc, rerunning_state.value, "StoredDestinationAuthorizationRevoked");
+    defer alloc.free(revoked);
+    const refreshed = try store.start(alloc, adopted_request);
+    defer alloc.free(refreshed);
+    var refreshed_state = try std.json.parseFromSlice(JobState, alloc, refreshed, .{});
+    defer refreshed_state.deinit();
+    try std.testing.expectEqual(Phase.queued, refreshed_state.value.phase);
+    try std.testing.expectEqual(reauthorized_state.value.job_id, refreshed_state.value.job_id);
+
+    var changed = adopted_request;
+    changed.backup_id = "different";
+    try std.testing.expectError(error.IdempotencyConflict, store.start(alloc, changed));
+}
+
 test "delayed replicated restore refresh cannot regress a running job" {
     var persistence = TestReplicatedPersistence.init(std.testing.allocator);
     defer persistence.deinit();
@@ -2091,6 +2275,7 @@ test "restore job store is idempotent and fenced" {
         .connection = "archive-reader",
         .idempotency_namespace = "principal:admin:cluster",
         .idempotency_key = "restore-daily",
+        .destination_authorization_fingerprint = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
     };
     const first = try store.start(std.testing.allocator, req);
     defer std.testing.allocator.free(first);
@@ -2099,14 +2284,17 @@ test "restore job store is idempotent and fenced" {
     try std.testing.expectEqualStrings(first, second);
     var parsed = try std.json.parseFromSlice(JobState, std.testing.allocator, first, .{});
     defer parsed.deinit();
+    try std.testing.expectEqualStrings(req.destination_authorization_fingerprint, parsed.value.destination_authorization_fingerprint);
     const running = (try store.begin(std.testing.allocator, parsed.value.job_id)).?;
     defer std.testing.allocator.free(running);
     var parsed_running = try std.json.parseFromSlice(JobState, std.testing.allocator, running, .{});
     defer parsed_running.deinit();
+    try std.testing.expectEqualStrings(req.destination_authorization_fingerprint, parsed_running.value.destination_authorization_fingerprint);
     const done = try store.finish(std.testing.allocator, parsed_running.value, "{\"status\":\"completed\"}");
     defer std.testing.allocator.free(done);
     var parsed_done = try std.json.parseFromSlice(JobState, std.testing.allocator, done, .{});
     defer parsed_done.deinit();
+    try std.testing.expectEqualStrings(req.destination_authorization_fingerprint, parsed_done.value.destination_authorization_fingerprint);
     try std.testing.expectEqual(Phase.succeeded, parsed_done.value.phase);
 }
 

--- a/zig/pkg/antfly/src/api/stored_destination_authorization.zig
+++ b/zig/pkg/antfly/src/api/stored_destination_authorization.zig
@@ -1,0 +1,654 @@
+// Copyright 2026 Antfly, Inc.
+//
+// Licensed under the Elastic License 2.0 (ELv2); you may not use this file
+// except in compliance with the Elastic License 2.0. You may obtain a copy of
+// the Elastic License at https://www.antfly.io/licensing/ELv2-license
+
+//! Durable authorization envelopes for catalog-stored write destinations.
+//!
+//! Admission code first checks the caller's live permissions, then seals the
+//! normalized catalog JSON with the exact destination set. Background workers
+//! validate that server-authored set whenever work starts or resumes. Public
+//! admission always overwrites this reserved field, so a client cannot mint a
+//! grant by including it in its request.
+
+const std = @import("std");
+const usermgr = @import("../usermgr/mod.zig");
+
+pub const grant_field = "_antfly_destination_authorization_v1";
+pub const catalog_service_principal = "service:catalog";
+pub const auth_disabled_principal = "service:auth-disabled";
+const auth_disabled_signature = "auth-disabled";
+const grant_domain = "antfly.destination-authorization.v1";
+
+pub const Authorizer = struct {
+    manager: ?*const usermgr.UserManager = null,
+    auth_enabled: bool = false,
+
+    fn signatureAlloc(
+        self: Authorizer,
+        alloc: std.mem.Allocator,
+        principal: []const u8,
+        payload: []const u8,
+    ) ![]u8 {
+        if (std.mem.eql(u8, principal, auth_disabled_principal)) {
+            if (!self.auth_enabled) return try alloc.dupe(u8, auth_disabled_signature);
+            return error.StoredDestinationAuthorizationRevoked;
+        }
+        if (std.mem.eql(u8, principal, catalog_service_principal))
+            return error.StoredDestinationCredentialUnsupported;
+        if (!std.mem.startsWith(u8, principal, "basic:") and
+            !std.mem.startsWith(u8, principal, "api-key:"))
+            return error.StoredDestinationCredentialUnsupported;
+        const manager = self.manager orelse return error.StoredDestinationAuthorizationRevoked;
+        const mac = manager.destinationGrantMac(principal, payload) catch |err| switch (err) {
+            error.InvalidDestinationGrantPrincipal => return error.StoredDestinationCredentialUnsupported,
+            else => return error.StoredDestinationAuthorizationRevoked,
+        };
+        const hex = std.fmt.bytesToHex(mac, .lower);
+        return try alloc.dupe(u8, &hex);
+    }
+
+    pub fn authorize(
+        self: Authorizer,
+        alloc: std.mem.Allocator,
+        principal: []const u8,
+        destinations: []const []const u8,
+        payload: []const u8,
+        signature: []const u8,
+    ) !void {
+        const expected = try self.signatureAlloc(alloc, principal, payload);
+        defer alloc.free(expected);
+        if (!constantTimeEql(expected, signature))
+            return error.StoredDestinationAuthorizationInvalid;
+        if (std.mem.eql(u8, principal, auth_disabled_principal)) return;
+        const manager = self.manager orelse return error.StoredDestinationAuthorizationRevoked;
+        const permissions = if (std.mem.startsWith(u8, principal, "basic:"))
+            manager.getPermissionsForUser(principal["basic:".len..]) catch |err| switch (err) {
+                error.OutOfMemory => return err,
+                else => return error.StoredDestinationAuthorizationRevoked,
+            }
+        else if (std.mem.startsWith(u8, principal, "api-key:"))
+            manager.effectiveApiKeyPermissions(principal["api-key:".len..]) catch |err| switch (err) {
+                error.OutOfMemory => return err,
+                else => return error.StoredDestinationAuthorizationRevoked,
+            }
+        else
+            return error.StoredDestinationAuthorizationRevoked;
+        defer {
+            for (permissions) |*permission| permission.deinit(manager.alloc);
+            manager.alloc.free(permissions);
+        }
+        for (destinations) |destination| {
+            if (!permissionsAllowWrite(permissions, destination))
+                return error.StoredDestinationAuthorizationRevoked;
+        }
+    }
+};
+
+fn constantTimeEql(left: []const u8, right: []const u8) bool {
+    if (left.len != right.len) return false;
+    var diff: u8 = 0;
+    for (left, right) |a, b| diff |= a ^ b;
+    return diff == 0;
+}
+
+fn permissionsAllowWrite(permissions: []const usermgr.Permission, table_name: []const u8) bool {
+    for (permissions) |permission| {
+        const type_match = permission.resource_type == .@"*" or permission.resource_type == .table;
+        const resource_match = std.mem.eql(u8, permission.resource, "*") or
+            std.mem.eql(u8, permission.resource, table_name);
+        if (type_match and resource_match and (permission.type == .write or permission.type == .admin))
+            return true;
+    }
+    return false;
+}
+
+pub fn destinationConfigFingerprintAlloc(
+    alloc: std.mem.Allocator,
+    replication_sources_json: []const u8,
+    indexes_json: []const u8,
+) ![]u8 {
+    var hasher = std.crypto.hash.sha2.Sha256.init(.{});
+    var length_bytes: [8]u8 = undefined;
+    std.mem.writeInt(u64, &length_bytes, @intCast(replication_sources_json.len), .little);
+    hasher.update(&length_bytes);
+    hasher.update(replication_sources_json);
+    std.mem.writeInt(u64, &length_bytes, @intCast(indexes_json.len), .little);
+    hasher.update(&length_bytes);
+    hasher.update(indexes_json);
+    var digest: [std.crypto.hash.sha2.Sha256.digest_length]u8 = undefined;
+    hasher.final(&digest);
+    const hex = std.fmt.bytesToHex(digest, .lower);
+    return try alloc.dupe(u8, &hex);
+}
+
+pub fn destinationConfigFingerprintMatches(
+    replication_sources_json: []const u8,
+    indexes_json: []const u8,
+    expected: []const u8,
+) bool {
+    if (expected.len != std.crypto.hash.sha2.Sha256.digest_length * 2) return false;
+    var hasher = std.crypto.hash.sha2.Sha256.init(.{});
+    var length_bytes: [8]u8 = undefined;
+    std.mem.writeInt(u64, &length_bytes, @intCast(replication_sources_json.len), .little);
+    hasher.update(&length_bytes);
+    hasher.update(replication_sources_json);
+    std.mem.writeInt(u64, &length_bytes, @intCast(indexes_json.len), .little);
+    hasher.update(&length_bytes);
+    hasher.update(indexes_json);
+    var digest: [std.crypto.hash.sha2.Sha256.digest_length]u8 = undefined;
+    hasher.final(&digest);
+    const hex = std.fmt.bytesToHex(digest, .lower);
+    return std.mem.eql(u8, &hex, expected);
+}
+
+/// Legacy restore jobs predate durable destination grants. They may resume
+/// automatically only when the backed-up definition cannot write to another
+/// table. This parser is intentionally shared with sealing so schema drift
+/// fails closed instead of silently classifying a new sink form as harmless.
+pub fn configurationHasDestinations(
+    alloc: std.mem.Allocator,
+    replication_sources_json: []const u8,
+    indexes_json: []const u8,
+) !bool {
+    var parsed_sources = try std.json.parseFromSlice(std.json.Value, alloc, replication_sources_json, .{});
+    defer parsed_sources.deinit();
+    if (parsed_sources.value != .array) return error.InvalidStoredDestinationConfig;
+    for (parsed_sources.value.array.items) |source| {
+        if (source != .object) return error.InvalidStoredDestinationConfig;
+        var destinations = std.ArrayListUnmanaged([]const u8).empty;
+        collectRouteDestinations(alloc, source, &destinations) catch |err| {
+            destinations.deinit(alloc);
+            return err;
+        };
+        const has_destinations = destinations.items.len > 0;
+        destinations.deinit(alloc);
+        if (has_destinations) return true;
+    }
+
+    var parsed_indexes = try std.json.parseFromSlice(std.json.Value, alloc, indexes_json, .{});
+    defer parsed_indexes.deinit();
+    if (parsed_indexes.value != .object) return error.InvalidStoredDestinationConfig;
+    return try valueHasResolverDestination(parsed_indexes.value);
+}
+
+fn valueHasResolverDestination(value: std.json.Value) !bool {
+    switch (value) {
+        .object => |object| {
+            if (object.get("resolvers")) |resolvers| {
+                if (resolvers != .array) return error.InvalidStoredDestinationConfig;
+                for (resolvers.array.items) |resolver| {
+                    if (resolver == .string) continue;
+                    if (resolver != .object) return error.InvalidStoredDestinationConfig;
+                    const table = resolver.object.get("table") orelse
+                        return error.InvalidStoredDestinationConfig;
+                    if (table != .string or table.string.len == 0)
+                        return error.InvalidStoredDestinationConfig;
+                    return true;
+                }
+            }
+            var it = object.iterator();
+            while (it.next()) |entry| {
+                if (std.mem.eql(u8, entry.key_ptr.*, "resolvers")) continue;
+                if (try valueHasResolverDestination(entry.value_ptr.*)) return true;
+            }
+        },
+        .array => |array| for (array.items) |item| {
+            if (try valueHasResolverDestination(item)) return true;
+        },
+        else => {},
+    }
+    return false;
+}
+
+pub fn sealReplicationSourcesJsonForPrincipalAlloc(
+    alloc: std.mem.Allocator,
+    json: []const u8,
+    source_table: []const u8,
+    principal: []const u8,
+    authorizer: ?Authorizer,
+) ![]u8 {
+    if (principal.len == 0) return error.InvalidStoredDestinationConfig;
+    var parsed = try std.json.parseFromSlice(std.json.Value, alloc, json, .{});
+    defer parsed.deinit();
+    if (parsed.value != .array) return error.InvalidStoredDestinationConfig;
+
+    var out = std.ArrayListUnmanaged(u8).empty;
+    defer out.deinit(alloc);
+    try out.append(alloc, '[');
+    for (parsed.value.array.items, 0..) |source, index| {
+        if (index > 0) try out.append(alloc, ',');
+        if (source != .object) return error.InvalidStoredDestinationConfig;
+        var destinations = std.ArrayListUnmanaged([]const u8).empty;
+        defer destinations.deinit(alloc);
+        try collectRouteDestinations(alloc, source, &destinations);
+        try appendSealedObject(alloc, &out, source.object, source_table, destinations.items, principal, authorizer);
+    }
+    try out.append(alloc, ']');
+    return try out.toOwnedSlice(alloc);
+}
+
+pub fn sealIndexesJsonForPrincipalAlloc(
+    alloc: std.mem.Allocator,
+    json: []const u8,
+    source_table: []const u8,
+    principal: []const u8,
+    authorizer: ?Authorizer,
+) ![]u8 {
+    if (principal.len == 0) return error.InvalidStoredDestinationConfig;
+    var parsed = try std.json.parseFromSlice(std.json.Value, alloc, json, .{});
+    defer parsed.deinit();
+    if (parsed.value != .object) return error.InvalidStoredDestinationConfig;
+
+    var out = std.ArrayListUnmanaged(u8).empty;
+    defer out.deinit(alloc);
+    try appendValueSealingResolvers(alloc, &out, parsed.value, source_table, principal, authorizer);
+    return try out.toOwnedSlice(alloc);
+}
+
+pub fn sealIndexJsonForPrincipalAlloc(
+    alloc: std.mem.Allocator,
+    json: []const u8,
+    source_table: []const u8,
+    principal: []const u8,
+    authorizer: ?Authorizer,
+) ![]u8 {
+    if (principal.len == 0) return error.InvalidStoredDestinationConfig;
+    var parsed = try std.json.parseFromSlice(std.json.Value, alloc, json, .{});
+    defer parsed.deinit();
+    if (parsed.value != .object) return error.InvalidStoredDestinationConfig;
+    var out = std.ArrayListUnmanaged(u8).empty;
+    defer out.deinit(alloc);
+    try appendValueSealingResolvers(alloc, &out, parsed.value, source_table, principal, authorizer);
+    return try out.toOwnedSlice(alloc);
+}
+
+pub fn validateReplicationSourceValue(alloc: std.mem.Allocator, source: std.json.Value) !void {
+    return try authorizeReplicationSourceValue(alloc, source, "", null);
+}
+
+pub fn authorizeReplicationSourcesJson(
+    alloc: std.mem.Allocator,
+    json: []const u8,
+    source_table: []const u8,
+    authorizer: ?Authorizer,
+) !void {
+    var parsed = try std.json.parseFromSlice(std.json.Value, alloc, json, .{});
+    defer parsed.deinit();
+    if (parsed.value != .array) return error.InvalidStoredDestinationConfig;
+    for (parsed.value.array.items) |source|
+        try authorizeReplicationSourceValue(alloc, source, source_table, authorizer);
+}
+
+pub fn authorizeReplicationSourceValue(
+    alloc: std.mem.Allocator,
+    source: std.json.Value,
+    source_table: []const u8,
+    authorizer: ?Authorizer,
+) !void {
+    if (source != .object) return error.InvalidStoredDestinationConfig;
+    var destinations = std.ArrayListUnmanaged([]const u8).empty;
+    defer destinations.deinit(alloc);
+    try collectRouteDestinations(alloc, source, &destinations);
+    const grant = try validateGrant(source.object, destinations.items);
+    if (authorizer) |live| {
+        const payload = try grantSigningPayloadAlloc(
+            alloc,
+            source_table,
+            grant.principal,
+            destinations.items,
+            source.object,
+        );
+        defer alloc.free(payload);
+        try live.authorize(alloc, grant.principal, destinations.items, payload, grant.signature);
+    }
+}
+
+pub fn validateIndexesJson(alloc: std.mem.Allocator, json: []const u8) !void {
+    return try authorizeIndexesJson(alloc, json, "", null);
+}
+
+pub fn authorizeIndexesJson(
+    alloc: std.mem.Allocator,
+    json: []const u8,
+    source_table: []const u8,
+    authorizer: ?Authorizer,
+) !void {
+    var parsed = try std.json.parseFromSlice(std.json.Value, alloc, json, .{});
+    defer parsed.deinit();
+    if (parsed.value != .object) return error.InvalidStoredDestinationConfig;
+    try validateResolverGrants(alloc, parsed.value, source_table, authorizer);
+}
+
+fn validateResolverGrants(
+    alloc: std.mem.Allocator,
+    value: std.json.Value,
+    source_table: []const u8,
+    authorizer: ?Authorizer,
+) !void {
+    switch (value) {
+        .object => |object| {
+            if (object.get("resolvers")) |resolvers| {
+                if (resolvers != .array) return error.InvalidStoredDestinationConfig;
+                for (resolvers.array.items) |resolver| {
+                    if (resolver == .string) continue;
+                    if (resolver != .object) return error.InvalidStoredDestinationConfig;
+                    const table = resolver.object.get("table") orelse return error.InvalidStoredDestinationConfig;
+                    if (table != .string or table.string.len == 0) return error.InvalidStoredDestinationConfig;
+                    const destinations = &.{table.string};
+                    const grant = try validateGrant(resolver.object, destinations);
+                    if (authorizer) |live| {
+                        const payload = try grantSigningPayloadAlloc(
+                            alloc,
+                            source_table,
+                            grant.principal,
+                            destinations,
+                            resolver.object,
+                        );
+                        defer alloc.free(payload);
+                        try live.authorize(alloc, grant.principal, destinations, payload, grant.signature);
+                    }
+                }
+            }
+            var it = object.iterator();
+            while (it.next()) |entry| {
+                if (std.mem.eql(u8, entry.key_ptr.*, "resolvers") or
+                    std.mem.eql(u8, entry.key_ptr.*, grant_field)) continue;
+                try validateResolverGrants(alloc, entry.value_ptr.*, source_table, authorizer);
+            }
+        },
+        .array => |array| for (array.items) |item| try validateResolverGrants(alloc, item, source_table, authorizer),
+        else => {},
+    }
+}
+
+const ValidatedGrant = struct {
+    principal: []const u8,
+    signature: []const u8,
+};
+
+fn validateGrant(object: std.json.ObjectMap, destinations: []const []const u8) !ValidatedGrant {
+    if (destinations.len == 0) return .{ .principal = catalog_service_principal, .signature = "" };
+    const grant = object.get(grant_field) orelse return error.StoredDestinationAuthorizationMissing;
+    if (grant != .object) return error.StoredDestinationAuthorizationInvalid;
+    const principal_value = grant.object.get("principal") orelse return error.StoredDestinationAuthorizationInvalid;
+    if (principal_value != .string or principal_value.string.len == 0)
+        return error.StoredDestinationAuthorizationInvalid;
+    const signature_value = grant.object.get("signature") orelse return error.StoredDestinationAuthorizationInvalid;
+    if (signature_value != .string or signature_value.string.len == 0 or signature_value.string.len > 128)
+        return error.StoredDestinationAuthorizationInvalid;
+    const granted_destinations = grant.object.get("destinations") orelse return error.StoredDestinationAuthorizationInvalid;
+    if (granted_destinations != .array or granted_destinations.array.items.len != destinations.len)
+        return error.StoredDestinationAuthorizationInvalid;
+    for (granted_destinations.array.items) |item| if (item != .string)
+        return error.StoredDestinationAuthorizationInvalid;
+    for (destinations) |destination| {
+        var found = false;
+        for (granted_destinations.array.items) |item| {
+            if (item == .string and std.mem.eql(u8, item.string, destination)) {
+                found = true;
+                break;
+            }
+        }
+        if (!found) return error.StoredDestinationAuthorizationInvalid;
+    }
+    return .{ .principal = principal_value.string, .signature = signature_value.string };
+}
+
+fn collectRouteDestinations(
+    alloc: std.mem.Allocator,
+    source: std.json.Value,
+    out: *std.ArrayListUnmanaged([]const u8),
+) !void {
+    const routes = source.object.get("routes") orelse return;
+    if (routes == .null) return;
+    if (routes != .array) return error.InvalidStoredDestinationConfig;
+    for (routes.array.items) |route| {
+        if (route != .object) return error.InvalidStoredDestinationConfig;
+        const target = route.object.get("target_table") orelse return error.InvalidStoredDestinationConfig;
+        if (target != .string or target.string.len == 0) return error.InvalidStoredDestinationConfig;
+        try appendUnique(alloc, out, target.string);
+    }
+}
+
+fn appendValueSealingResolvers(
+    alloc: std.mem.Allocator,
+    out: *std.ArrayListUnmanaged(u8),
+    value: std.json.Value,
+    source_table: []const u8,
+    principal: []const u8,
+    authorizer: ?Authorizer,
+) !void {
+    switch (value) {
+        .object => |object| {
+            try out.append(alloc, '{');
+            var first = true;
+            var it = object.iterator();
+            while (it.next()) |entry| {
+                if (std.mem.eql(u8, entry.key_ptr.*, grant_field)) continue;
+                if (!first) try out.append(alloc, ',');
+                first = false;
+                try appendJsonValue(alloc, out, .{ .string = entry.key_ptr.* });
+                try out.append(alloc, ':');
+                if (std.mem.eql(u8, entry.key_ptr.*, "resolvers")) {
+                    const resolvers = entry.value_ptr.*;
+                    if (resolvers != .array) return error.InvalidStoredDestinationConfig;
+                    try out.append(alloc, '[');
+                    for (resolvers.array.items, 0..) |resolver, index| {
+                        if (index > 0) try out.append(alloc, ',');
+                        if (resolver == .string) {
+                            try appendJsonValue(alloc, out, resolver);
+                            continue;
+                        }
+                        if (resolver != .object) return error.InvalidStoredDestinationConfig;
+                        const table = resolver.object.get("table") orelse return error.InvalidStoredDestinationConfig;
+                        if (table != .string or table.string.len == 0) return error.InvalidStoredDestinationConfig;
+                        try appendSealedObject(
+                            alloc,
+                            out,
+                            resolver.object,
+                            source_table,
+                            &.{table.string},
+                            principal,
+                            authorizer,
+                        );
+                    }
+                    try out.append(alloc, ']');
+                } else {
+                    try appendValueSealingResolvers(alloc, out, entry.value_ptr.*, source_table, principal, authorizer);
+                }
+            }
+            try out.append(alloc, '}');
+        },
+        .array => |array| {
+            try out.append(alloc, '[');
+            for (array.items, 0..) |item, index| {
+                if (index > 0) try out.append(alloc, ',');
+                try appendValueSealingResolvers(alloc, out, item, source_table, principal, authorizer);
+            }
+            try out.append(alloc, ']');
+        },
+        else => try appendJsonValue(alloc, out, value),
+    }
+}
+
+fn appendUnique(
+    alloc: std.mem.Allocator,
+    out: *std.ArrayListUnmanaged([]const u8),
+    value: []const u8,
+) !void {
+    for (out.items) |existing| if (std.mem.eql(u8, existing, value)) return;
+    try out.append(alloc, value);
+}
+
+fn appendSealedObject(
+    alloc: std.mem.Allocator,
+    out: *std.ArrayListUnmanaged(u8),
+    object: std.json.ObjectMap,
+    source_table: []const u8,
+    destinations: []const []const u8,
+    principal: []const u8,
+    authorizer: ?Authorizer,
+) !void {
+    try out.append(alloc, '{');
+    var first = true;
+    var it = object.iterator();
+    while (it.next()) |entry| {
+        if (std.mem.eql(u8, entry.key_ptr.*, grant_field)) continue;
+        if (!first) try out.append(alloc, ',');
+        first = false;
+        try appendJsonValue(alloc, out, .{ .string = entry.key_ptr.* });
+        try out.append(alloc, ':');
+        try appendJsonValue(alloc, out, entry.value_ptr.*);
+    }
+    if (destinations.len > 0) {
+        const live = authorizer orelse return error.StoredDestinationAuthorizationUnavailable;
+        const payload = try grantSigningPayloadAlloc(alloc, source_table, principal, destinations, object);
+        defer alloc.free(payload);
+        const signature = try live.signatureAlloc(alloc, principal, payload);
+        defer alloc.free(signature);
+        if (!first) try out.append(alloc, ',');
+        try appendJsonValue(alloc, out, .{ .string = grant_field });
+        try out.appendSlice(alloc, ":{\"principal\":");
+        try appendJsonValue(alloc, out, .{ .string = principal });
+        try out.appendSlice(alloc, ",\"signature\":");
+        try appendJsonValue(alloc, out, .{ .string = signature });
+        try out.appendSlice(alloc, ",\"destinations\":[");
+        for (destinations, 0..) |destination, index| {
+            if (index > 0) try out.append(alloc, ',');
+            try appendJsonValue(alloc, out, .{ .string = destination });
+        }
+        try out.appendSlice(alloc, "]}");
+    }
+    try out.append(alloc, '}');
+}
+
+fn grantSigningPayloadAlloc(
+    alloc: std.mem.Allocator,
+    source_table: []const u8,
+    principal: []const u8,
+    destinations: []const []const u8,
+    object: std.json.ObjectMap,
+) ![]u8 {
+    var out = std.ArrayListUnmanaged(u8).empty;
+    errdefer out.deinit(alloc);
+    try out.appendSlice(alloc, "{\"domain\":");
+    try appendJsonValue(alloc, &out, .{ .string = grant_domain });
+    try out.appendSlice(alloc, ",\"source_table\":");
+    try appendJsonValue(alloc, &out, .{ .string = source_table });
+    try out.appendSlice(alloc, ",\"principal\":");
+    try appendJsonValue(alloc, &out, .{ .string = principal });
+    try out.appendSlice(alloc, ",\"destinations\":[");
+    for (destinations, 0..) |destination, index| {
+        if (index > 0) try out.append(alloc, ',');
+        try appendJsonValue(alloc, &out, .{ .string = destination });
+    }
+    try out.appendSlice(alloc, "],\"configuration\":{");
+    var first = true;
+    var it = object.iterator();
+    while (it.next()) |entry| {
+        if (std.mem.eql(u8, entry.key_ptr.*, grant_field)) continue;
+        if (!first) try out.append(alloc, ',');
+        first = false;
+        try appendJsonValue(alloc, &out, .{ .string = entry.key_ptr.* });
+        try out.append(alloc, ':');
+        try appendJsonValue(alloc, &out, entry.value_ptr.*);
+    }
+    try out.appendSlice(alloc, "}}");
+    return try out.toOwnedSlice(alloc);
+}
+
+fn appendJsonValue(alloc: std.mem.Allocator, out: *std.ArrayListUnmanaged(u8), value: std.json.Value) !void {
+    const encoded = try std.fmt.allocPrint(alloc, "{f}", .{std.json.fmt(value, .{})});
+    defer alloc.free(encoded);
+    try out.appendSlice(alloc, encoded);
+}
+
+test "stored destination envelopes cannot be forged and validate on resume" {
+    const alloc = std.testing.allocator;
+    const disabled_authorizer: Authorizer = .{ .auth_enabled = false };
+    const raw =
+        \\[{"type":"postgres","routes":[{"target_table":"protected"}],"_antfly_destination_authorization_v1":["decoy"]}]
+    ;
+    const sealed = try sealReplicationSourcesJsonForPrincipalAlloc(
+        alloc,
+        raw,
+        "source",
+        auth_disabled_principal,
+        disabled_authorizer,
+    );
+    defer alloc.free(sealed);
+    try std.testing.expect(std.mem.indexOf(u8, sealed, "protected") != null);
+    try std.testing.expect(std.mem.indexOf(u8, sealed, auth_disabled_principal) != null);
+    try std.testing.expect(std.mem.indexOf(u8, sealed, "decoy") == null);
+    var parsed = try std.json.parseFromSlice(std.json.Value, alloc, sealed, .{});
+    defer parsed.deinit();
+    try authorizeReplicationSourceValue(alloc, parsed.value.array.items[0], "source", disabled_authorizer);
+    try std.testing.expectError(error.StoredDestinationAuthorizationMissing, blk: {
+        var unsealed = try std.json.parseFromSlice(std.json.Value, alloc, raw, .{});
+        defer unsealed.deinit();
+        _ = unsealed.value.array.items[0].object.swapRemove(grant_field);
+        break :blk validateReplicationSourceValue(alloc, unsealed.value.array.items[0]);
+    });
+
+    const raw_indexes =
+        \\{"graph":{"type":"graph"},"resolvers":[{"name":"entity","table":"protected","_antfly_destination_authorization_v1":["decoy"]}]}
+    ;
+    const sealed_indexes = try sealIndexesJsonForPrincipalAlloc(
+        alloc,
+        raw_indexes,
+        "source",
+        auth_disabled_principal,
+        disabled_authorizer,
+    );
+    defer alloc.free(sealed_indexes);
+    try validateIndexesJson(alloc, sealed_indexes);
+    try std.testing.expect(std.mem.indexOf(u8, sealed_indexes, "protected") != null);
+    try std.testing.expect(std.mem.indexOf(u8, sealed_indexes, "decoy") == null);
+    try std.testing.expectError(error.StoredDestinationAuthorizationInvalid, validateIndexesJson(
+        alloc,
+        "{\"graph\":{\"type\":\"graph\"},\"resolvers\":[{\"table\":\"protected\",\"_antfly_destination_authorization_v1\":[\"decoy\"]}]}",
+    ));
+
+    try std.testing.expectError(
+        error.StoredDestinationCredentialUnsupported,
+        sealReplicationSourcesJsonForPrincipalAlloc(
+            alloc,
+            raw,
+            "source",
+            "trusted:issuer:user",
+            .{ .auth_enabled = true },
+        ),
+    );
+    const unauthenticated_sealed = try sealReplicationSourcesJsonForPrincipalAlloc(
+        alloc,
+        raw,
+        "source",
+        auth_disabled_principal,
+        disabled_authorizer,
+    );
+    defer alloc.free(unauthenticated_sealed);
+    try authorizeReplicationSourcesJson(alloc, unauthenticated_sealed, "source", disabled_authorizer);
+    try std.testing.expectError(
+        error.StoredDestinationAuthorizationRevoked,
+        authorizeReplicationSourcesJson(alloc, unauthenticated_sealed, "source", .{ .auth_enabled = true }),
+    );
+    // With authentication disabled, every caller already has universal table
+    // authority; the fixed marker is accepted only while that mode remains
+    // active and is rejected immediately if authentication is enabled.
+    try authorizeReplicationSourcesJson(alloc, unauthenticated_sealed, "different-source", disabled_authorizer);
+
+    const forged =
+        \\[{"type":"postgres","routes":[{"target_table":"protected"}],"_antfly_destination_authorization_v1":{"principal":"service:catalog","signature":"forged","destinations":["protected"]}}]
+    ;
+    try std.testing.expectError(
+        error.StoredDestinationCredentialUnsupported,
+        authorizeReplicationSourcesJson(alloc, forged, "source", .{ .auth_enabled = true }),
+    );
+
+    const fingerprint = try destinationConfigFingerprintAlloc(alloc, raw, raw_indexes);
+    defer alloc.free(fingerprint);
+    try std.testing.expect(destinationConfigFingerprintMatches(raw, raw_indexes, fingerprint));
+    try std.testing.expect(!destinationConfigFingerprintMatches(raw, "{}", fingerprint));
+}

--- a/zig/pkg/antfly/src/api/table_writes.zig
+++ b/zig/pkg/antfly/src/api/table_writes.zig
@@ -59,6 +59,7 @@ const coverage_policy_mod = @import("coverage_policy.zig");
 const query_api = @import("query.zig");
 const public_table_http = @import("public_table_http.zig");
 const runtime_status = @import("runtime_status.zig");
+const stored_destination_authorization = @import("stored_destination_authorization.zig");
 
 fn publishRuntimeStatusGroupForTest(
     cache: *runtime_status.TableRuntimeSnapshotCache,
@@ -5474,6 +5475,7 @@ pub const ProvisionedTableWriteSource = struct {
     antfly_provider: ?managed_embedder.AntflyProvider = null,
     inference_api_url: ?[]const u8 = null,
     secret_store: ?*common_secrets.FileStore = null,
+    destination_authorizer: ?stored_destination_authorization.Authorizer = null,
     restore_open_options: backups_api.OpenOptions = .{},
     remote_content: ?*const scraping.RemoteContentConfig = null,
     resolution_candidate_source: ?db_mod.CandidateSource = null,
@@ -5847,6 +5849,14 @@ pub const ProvisionedTableWriteSource = struct {
         self.restore_open_options.secret_store = secret_store;
         if (self.write_cache) |cache| cache.secret_store = secret_store;
         if (self.startup_write_cache) |cache| cache.secret_store = secret_store;
+        return self;
+    }
+
+    pub fn withDestinationAuthorization(
+        self: *ProvisionedTableWriteSource,
+        authorizer: ?stored_destination_authorization.Authorizer,
+    ) *ProvisionedTableWriteSource {
+        self.destination_authorizer = authorizer;
         return self;
     }
 
@@ -8307,6 +8317,8 @@ pub const ProvisionedTableWriteSource = struct {
             const effective_ha_mirror = haMirrorForManagedDbOpenMode(mode, self.ha_async_mirror);
             var effective_open_options = managed_open_options;
             effective_open_options.drain_resolver_backfill = false;
+            effective_open_options.source_table = table_name;
+            effective_open_options.destination_authorizer = self.destination_authorizer;
             effective_open_options.inference_api_url = self.inference_api_url;
             effective_open_options.ha_write_gate = self.ha_write_gate;
             effective_open_options.ha_async_effect_mirror = effective_ha_mirror;
@@ -8960,6 +8972,7 @@ pub const ProvisionedTableWriteSource = struct {
             .{
                 .backend_runtime = backend_runtime,
                 .restore_open_options = self.restore_open_options,
+                .destination_authorizer = self.destination_authorizer,
             },
         );
 
@@ -12007,7 +12020,11 @@ pub const ProvisionedTableWriteSource = struct {
                 alloc,
                 cached.db,
                 indexes_json,
-                .{ .drain_resolver_backfill = false },
+                .{
+                    .drain_resolver_backfill = false,
+                    .source_table = table_name,
+                    .destination_authorizer = self.destination_authorizer,
+                },
             );
             try self.repairRestoredDbRuntimeStateBlocking(alloc, cached.db, group_id, 0);
 
@@ -12733,6 +12750,8 @@ pub const ProvisionedTableWriteSource = struct {
                 else
                     try metadata_table_provisioner.reconcileDbIndexesWithOptions(alloc, cached.db, indexes_json, .{
                         .drain_resolver_backfill = false,
+                        .source_table = table_name,
+                        .destination_authorizer = self.destination_authorizer,
                     });
                 if (reconcile_summary.indexes_pending != 0) {
                     _ = try cached.db.advanceGeneratedArtifactCleanupPage(metadata.target_index_name);
@@ -12923,6 +12942,8 @@ pub const ProvisionedTableWriteSource = struct {
             else
                 try metadata_table_provisioner.reconcileDbIndexesWithOptions(alloc, &db, indexes_json, .{
                     .drain_resolver_backfill = false,
+                    .source_table = table_name,
+                    .destination_authorizer = self.destination_authorizer,
                 });
             if (reconcile_summary.indexes_pending != 0) {
                 _ = try db.advanceGeneratedArtifactCleanupPage(metadata.target_index_name);
@@ -13516,6 +13537,8 @@ pub const ProvisionedTableWriteSource = struct {
                     );
                     _ = try metadata_table_provisioner.reconcileDbIndexesWithOptions(alloc, cached.db, indexes_json, .{
                         .drain_resolver_backfill = false,
+                        .source_table = table_name,
+                        .destination_authorizer = self.destination_authorizer,
                     });
                     cached_groups.appendAssumeCapacity(cached);
                 }
@@ -13616,6 +13639,8 @@ pub const ProvisionedTableWriteSource = struct {
             // names that already exist on reopen).
             _ = try metadata_table_provisioner.ensureResolversWithOptions(alloc, &opened.?, indexes_json, .{
                 .drain_backfill = false,
+                .source_table = table_name,
+                .destination_authorizer = self.destination_authorizer,
             });
             if (seed_create_table_writer) {
                 try self.write_cache.?.seedCreatedDbLocked(&opened, group_id, lsm_root_generation, table_name, indexes_json, schema_json);
@@ -16775,6 +16800,7 @@ pub const HostedProvisionedTableWriteSource = struct {
     group_visible_root_generation: ?table_reads.GroupVisibleRootGenerationSource = null,
     secret_store: ?*common_secrets.FileStore = null,
     remote_content: ?*const scraping.RemoteContentConfig = null,
+    destination_authorizer: ?stored_destination_authorization.Authorizer = null,
     foreground_derived_progress: bool = false,
 
     pub fn init(
@@ -16818,6 +16844,14 @@ pub const HostedProvisionedTableWriteSource = struct {
         if (hostedManagedDbCacheForRootIfPresent(self.replica_root_dir)) |cache| {
             cache.write_cache.inference_api_url = inference_api_url;
         }
+        return self;
+    }
+
+    pub fn withDestinationAuthorization(
+        self: *HostedProvisionedTableWriteSource,
+        authorizer: ?stored_destination_authorization.Authorizer,
+    ) *HostedProvisionedTableWriteSource {
+        self.destination_authorizer = authorizer;
         return self;
     }
 
@@ -17037,6 +17071,8 @@ pub const HostedProvisionedTableWriteSource = struct {
                 identity_namespace,
                 .{
                     .drain_resolver_backfill = false,
+                    .source_table = table_name,
+                    .destination_authorizer = self.destination_authorizer,
                     .inference_api_url = cache.write_cache.inference_api_url,
                     .ha_write_gate = cache.write_cache.ha_write_gate,
                     .ha_async_effect_mirror = effective_ha_mirror,
@@ -20799,6 +20835,8 @@ fn openManagedDbWithIndexesJsonAndCacheModeWithRuntimeAndLocalAntflyAndIdentity(
 
 const ManagedDbOpenOptions = struct {
     drain_resolver_backfill: bool = true,
+    source_table: []const u8 = "",
+    destination_authorizer: ?stored_destination_authorization.Authorizer = null,
     /// HA replay must reconcile catalog-driven indexes while the node remains a
     /// read-only standby. Perform that structural reconciliation in an isolated
     /// workerless open, then reopen with the live HA gate before publishing the
@@ -21287,6 +21325,8 @@ fn openManagedDbWithIndexesJsonAndCacheModeWithRuntimeAndLocalAntflyAndIdentityW
     else
         try metadata_table_provisioner.reconcileDbIndexesWithOptions(alloc, &db, indexes_json, .{
             .drain_resolver_backfill = options.drain_resolver_backfill,
+            .source_table = options.source_table,
+            .destination_authorizer = options.destination_authorizer,
         });
     if (summary.indexManagerCatalogChanged() or options.reconcile_for_replicated_apply) {
         // First-open provisioning can mutate the live index manager. Reopen so

--- a/zig/pkg/antfly/src/data/runtime.zig
+++ b/zig/pkg/antfly/src/data/runtime.zig
@@ -4934,6 +4934,10 @@ pub const DataServer = struct {
         _ = self.read_source.withIo(&self.query_io_impl.?);
         _ = self.read_source.withSecretStore(api_server_cfg.secret_store);
         _ = self.write_source.withSecretStore(api_server_cfg.secret_store);
+        _ = self.write_source.withDestinationAuthorization(.{
+            .manager = api_server_cfg.user_manager,
+            .auth_enabled = api_server_cfg.auth_enabled,
+        });
         const restore_io = if (self.backend_runtime) |runtime|
             if (runtime.apiIoImpl()) |io_impl| io_impl.io() else null
         else
@@ -4956,6 +4960,10 @@ pub const DataServer = struct {
         if (self.data_raft_apply) |apply_sm| {
             apply_sm.attachProvisionedStorage(&self.provisioned_storage);
             _ = apply_sm.write_source.withSecretStore(api_server_cfg.secret_store);
+            _ = apply_sm.write_source.withDestinationAuthorization(.{
+                .manager = api_server_cfg.user_manager,
+                .auth_enabled = api_server_cfg.auth_enabled,
+            });
             _ = apply_sm.write_source.withRestoreAccess(api_server_cfg.node_config, restore_io);
             _ = apply_sm.write_source.withRemoteContent(api_server_cfg.remote_content);
             _ = try apply_sm.write_source.withHAWriteGate(ha_write_gate);

--- a/zig/pkg/antfly/src/metadata/replication_backfill.zig
+++ b/zig/pkg/antfly/src/metadata/replication_backfill.zig
@@ -13,6 +13,7 @@
 // limitations.
 
 const std = @import("std");
+const stored_destination_authorization = @import("../api/stored_destination_authorization.zig");
 const platform_time = @import("antfly_platform").time;
 const foreign_mod = @import("../foreign/mod.zig");
 const table_writes_api = @import("../api/table_writes.zig");
@@ -79,6 +80,9 @@ fn classifyReplicationError(err: anyerror) []const u8 {
         error.UnknownColumn,
         error.InvalidQueryRequest,
         error.UnsupportedReplicationStreaming,
+        error.StoredDestinationAuthorizationMissing,
+        error.StoredDestinationAuthorizationInvalid,
+        error.StoredDestinationAuthorizationRevoked,
         => "terminal",
         else => "retryable",
     };
@@ -101,6 +105,7 @@ pub const SnapshotBackfillRunner = struct {
     prepared_snapshot_timeout_ns: u64 = default_prepared_snapshot_timeout_ns,
     quantum_deadline_ns: ?u64 = null,
     work_permit: ?WorkPermit = null,
+    destination_authorizer: ?stored_destination_authorization.Authorizer = null,
 
     fn checkpointWork(self: *SnapshotBackfillRunner) !void {
         if (self.work_permit) |permit| try permit.checkpoint();
@@ -197,7 +202,7 @@ pub const SnapshotBackfillRunner = struct {
             &progress_cutover_provider_identity,
         ) catch |err| {
             self.checkpointWork() catch return err;
-            var parsed = parseReplicationSourceConfig(self.alloc, table.name, table.replication_sources_json, source_ordinal) catch return err;
+            var parsed = parseReplicationSourceConfig(self.alloc, table.name, table.replication_sources_json, source_ordinal, self.destination_authorizer) catch return err;
             defer parsed.deinit(self.alloc);
 
             callUpsertStatus(status_sink, .{
@@ -261,7 +266,7 @@ pub const SnapshotBackfillRunner = struct {
         progress_cutover_provider_identity: *foreign_mod.ExactCutoverIntent.ProviderIdentity,
     ) !BackfillSummary {
         try self.checkpointWork();
-        var parsed = try parseReplicationSourceConfig(self.alloc, table.name, table.replication_sources_json, source_ordinal);
+        var parsed = try parseReplicationSourceConfig(self.alloc, table.name, table.replication_sources_json, source_ordinal, self.destination_authorizer);
         defer parsed.deinit(self.alloc);
 
         var resolved_dsn = try secrets.resolveReferenceWithGenerationOwned(self.alloc, self.secret_store, parsed.dsn);
@@ -1205,6 +1210,7 @@ pub const StreamingReplicationRunner = struct {
     secret_store: ?*secrets.FileStore = null,
     batch_size: usize = 256,
     work_permit: ?WorkPermit = null,
+    destination_authorizer: ?stored_destination_authorization.Authorizer = null,
 
     fn checkpointWork(self: *StreamingReplicationRunner) !void {
         if (self.work_permit) |permit| try permit.checkpoint();
@@ -1230,7 +1236,7 @@ pub const StreamingReplicationRunner = struct {
 
         return self.runTableSourceInner(status_sink, table, source_ordinal, snapshot_offset, cutover_mode, resume_checkpoint, existing_status, &progress_checkpoint) catch |err| {
             self.checkpointWork() catch return err;
-            var parsed = parseReplicationSourceConfig(self.alloc, table.name, table.replication_sources_json, source_ordinal) catch return err;
+            var parsed = parseReplicationSourceConfig(self.alloc, table.name, table.replication_sources_json, source_ordinal, self.destination_authorizer) catch return err;
             defer parsed.deinit(self.alloc);
             const prior_failures = if (existing_status) |status|
                 if (std.mem.eql(u8, status.phase, "streaming_failed")) status.consecutive_failures else 0
@@ -1314,7 +1320,7 @@ pub const StreamingReplicationRunner = struct {
         progress_checkpoint: *std.ArrayListUnmanaged(u8),
     ) !StreamSummary {
         try self.checkpointWork();
-        var parsed = try parseReplicationSourceConfig(self.alloc, table.name, table.replication_sources_json, source_ordinal);
+        var parsed = try parseReplicationSourceConfig(self.alloc, table.name, table.replication_sources_json, source_ordinal, self.destination_authorizer);
         defer parsed.deinit(self.alloc);
 
         var resolved_dsn = try secrets.resolveReferenceWithGenerationOwned(self.alloc, self.secret_store, parsed.dsn);
@@ -1684,6 +1690,7 @@ fn parseReplicationSourceConfig(
     table_name: []const u8,
     replication_sources_json: []const u8,
     source_ordinal: u32,
+    destination_authorizer: ?stored_destination_authorization.Authorizer,
 ) !ParsedReplicationSourceConfig {
     var parsed = try std.json.parseFromSlice(std.json.Value, alloc, replication_sources_json, .{});
     defer parsed.deinit();
@@ -1693,6 +1700,12 @@ fn parseReplicationSourceConfig(
 
     const source = parsed.value.array.items[source_ordinal];
     if (source != .object) return error.InvalidReplicationSourceConfig;
+    try stored_destination_authorization.authorizeReplicationSourceValue(
+        alloc,
+        source,
+        table_name,
+        destination_authorizer,
+    );
 
     const type_name = try parseRequiredStringFieldAlloc(alloc, source, "type");
     errdefer alloc.free(type_name);
@@ -4193,6 +4206,7 @@ test "metadata replication backfill routes matching snapshot rows to target tabl
         \\  "dsn":"postgres://db",
         \\  "postgres_table":"users",
         \\  "key_template":"id",
+        \\  "_antfly_destination_authorization_v1":{"principal":"service:auth-disabled","signature":"auth-disabled","destinations":["premium_users","free_users"]},
         \\  "routes":[
         \\    {
         \\      "target_table":"premium_users",
@@ -4233,6 +4247,7 @@ test "metadata replication source parser derives slot and publication names like
         "docs",
         "[{\"type\":\"postgres\",\"dsn\":\"postgres://db\",\"postgres_table\":\"Users-Prod\",\"key_template\":\"id\"}]",
         0,
+        null,
     );
     defer parsed.deinit(alloc);
 
@@ -4250,6 +4265,7 @@ test "metadata replication source parser preserves explicit slot and publication
         "docs",
         "[{\"type\":\"postgres\",\"dsn\":\"postgres://db\",\"postgres_table\":\"users\",\"slot_name\":\"custom_slot\",\"publication_name\":\"custom_pub\",\"on_delete\":[{\"op\":\"$unset\",\"path\":\"name\"}]}]",
         0,
+        null,
     );
     defer parsed.deinit(alloc);
 
@@ -4266,6 +4282,7 @@ test "metadata exact cutover config ownership survives credential rotation" {
         "docs",
         "[{\"type\":\"postgres\",\"dsn\":\"postgres://alice:old-secret@db/app\",\"postgres_table\":\"users\",\"slot_name\":\"custom_slot\",\"publication_name\":\"custom_pub\"}]",
         0,
+        null,
     );
     defer before.deinit(alloc);
     var after = try parseReplicationSourceConfig(
@@ -4273,6 +4290,7 @@ test "metadata exact cutover config ownership survives credential rotation" {
         "docs",
         "[{\"type\":\"postgres\",\"dsn\":\"postgres://alice:new-secret@db/app\",\"postgres_table\":\"users\",\"slot_name\":\"custom_slot\",\"publication_name\":\"custom_pub\"}]",
         0,
+        null,
     );
     defer after.deinit(alloc);
 
@@ -4289,6 +4307,7 @@ test "metadata replication source parser accepts null optional fields" {
         "docs",
         "[{\"type\":\"postgres\",\"dsn\":\"postgres://db\",\"postgres_table\":\"users\",\"key_template\":null,\"slot_name\":null,\"publication_name\":null,\"on_update\":null,\"on_delete\":null,\"publication_filter\":null,\"routes\":null}]",
         0,
+        null,
     );
     defer parsed.deinit(alloc);
 
@@ -4312,6 +4331,7 @@ test "metadata replication source parser detects delete document op" {
         "docs",
         "[{\"type\":\"postgres\",\"dsn\":\"postgres://db\",\"postgres_table\":\"users\",\"on_delete\":[{\"op\":\"$delete_document\"}]}]",
         0,
+        null,
     );
     defer parsed.deinit(alloc);
 
@@ -5411,6 +5431,7 @@ test "metadata replication stream routes matching rows to target tables" {
         \\  "postgres_table":"users",
         \\  "key_template":"id",
         \\  "on_update":[{"op":"$set","path":"ignored","value":"true"}],
+        \\  "_antfly_destination_authorization_v1":{"principal":"service:auth-disabled","signature":"auth-disabled","destinations":["premium_users","free_users"]},
         \\  "routes":[
         \\    {
         \\      "target_table":"premium_users",

--- a/zig/pkg/antfly/src/metadata/server.zig
+++ b/zig/pkg/antfly/src/metadata/server.zig
@@ -74,7 +74,12 @@ pub const MetadataServer = struct {
     ) !MetadataServer {
         const svc = try alloc.create(service.MetadataHttpService);
         errdefer alloc.destroy(svc);
-        svc.* = try service.MetadataHttpService.init(alloc, cfg.http, deps.http, cfg.service);
+        var service_cfg = cfg.service;
+        service_cfg.destination_authorizer = .{
+            .manager = cfg.api_server_cfg.user_manager,
+            .auth_enabled = cfg.api_server_cfg.auth_enabled,
+        };
+        svc.* = try service.MetadataHttpService.init(alloc, cfg.http, deps.http, service_cfg);
         errdefer svc.deinit();
 
         var owned_hosted_shard_ops: ?*raft_hosted_shard_ops.HostedShardOperationAdapter = null;
@@ -180,6 +185,10 @@ pub const MetadataServer = struct {
             _ = public_write_source.withInferenceAPIURL(if (cfg.api_server_cfg.node_config) |node_config| node_config.inference.api_url else null);
             _ = public_write_source.withSecretStore(cfg.api_server_cfg.secret_store);
             _ = public_write_source.withRemoteContent(cfg.api_server_cfg.remote_content);
+            _ = public_write_source.withDestinationAuthorization(.{
+                .manager = cfg.api_server_cfg.user_manager,
+                .auth_enabled = cfg.api_server_cfg.auth_enabled,
+            });
             owned_public_write_source = public_write_source;
 
             var api_server_cfg = cfg.api_server_cfg;

--- a/zig/pkg/antfly/src/metadata/service.zig
+++ b/zig/pkg/antfly/src/metadata/service.zig
@@ -49,6 +49,7 @@ const api_table_catalog = @import("../api/table_catalog.zig");
 const api_operation = @import("../api/operation.zig");
 const api_table_router = @import("../api/table_router.zig");
 const api_table_writes = @import("../api/table_writes.zig");
+const stored_destination_authorization = @import("../api/stored_destination_authorization.zig");
 const db_mod = @import("../storage/db/mod.zig");
 const backend_runtime_mod = @import("../storage/background_runtime.zig");
 const backfill_state_mod = @import("../storage/db/backfill_state.zig");
@@ -489,6 +490,7 @@ pub const MetadataServiceConfig = struct {
     observe_local_replica_root: bool = true,
     backend_runtime: ?*backend_runtime_mod.BackendRuntime = null,
     secret_store: ?*common_secrets.FileStore = null,
+    destination_authorizer: ?stored_destination_authorization.Authorizer = null,
     reallocation_protocol_peers: []const ReallocationProtocolPeer = &.{},
 };
 
@@ -1766,6 +1768,7 @@ pub const MetadataService = struct {
     cdc_backfill_registry: foreign_mod.Registry = .{},
     cdc_next_round_at_ms: u64 = 0,
     secret_store: ?*common_secrets.FileStore = null,
+    destination_authorizer: ?stored_destination_authorization.Authorizer = null,
     json_response_calls: std.atomic.Value(u64) = .init(0),
     json_response_bytes_total: std.atomic.Value(u64) = .init(0),
     json_response_peak_bytes: std.atomic.Value(u64) = .init(0),
@@ -1820,6 +1823,7 @@ pub const MetadataService = struct {
             .lifecycle_signal = LifecycleSignal.init(alloc),
             .backend_runtime = cfg.backend_runtime,
             .secret_store = cfg.secret_store,
+            .destination_authorizer = cfg.destination_authorizer,
             .linearizable_read_tracker = read_tracker,
             .raft = try raft_service.ManagedHostService.init(alloc, host_cfg, host_deps, cfg.raft, deps.raft),
         };
@@ -3238,6 +3242,7 @@ pub const MetadataService = struct {
             ranges,
             .{
                 .backend_runtime = try self.ensureBackendRuntime(),
+                .destination_authorizer = self.destination_authorizer,
             },
         );
         try self.refreshLocalRestoreProgress(group_ids, tables, ranges);
@@ -3467,6 +3472,7 @@ pub const MetadataService = struct {
         );
         write_source.backend_runtime = runtime;
         _ = write_source.withSecretStore(self.secret_store);
+        _ = write_source.withDestinationAuthorization(self.destination_authorizer);
         var coordinator = metadata_replication_backfill.SnapshotBackfillCoordinator{
             .alloc = self.alloc,
             .runner = .{
@@ -3476,6 +3482,7 @@ pub const MetadataService = struct {
                 .write_source = write_source.source(),
                 .secret_store = self.secret_store,
                 .work_permit = cdcWorkPermit(self),
+                .destination_authorizer = self.destination_authorizer,
             },
         };
         const summary = coordinator.runRound(self) catch |err| {
@@ -3504,6 +3511,7 @@ pub const MetadataService = struct {
                 .write_source = write_source.source(),
                 .secret_store = self.secret_store,
                 .work_permit = cdcWorkPermit(self),
+                .destination_authorizer = self.destination_authorizer,
             },
         };
         const stream_summary = streaming.runRound(self) catch |err| {
@@ -3607,6 +3615,7 @@ pub const MetadataHttpService = struct {
     cdc_backfill_registry: foreign_mod.Registry = .{},
     cdc_next_round_at_ms: u64 = 0,
     secret_store: ?*common_secrets.FileStore = null,
+    destination_authorizer: ?stored_destination_authorization.Authorizer = null,
     backend_runtime_mutex: std.Io.Mutex = .init,
     backend_runtime: ?*backend_runtime_mod.BackendRuntime = null,
     owned_backend_runtime: ?backend_runtime_mod.BackendRuntimeHandle = null,
@@ -3666,6 +3675,7 @@ pub const MetadataHttpService = struct {
             .backend_runtime = backend_runtime,
             .owned_backend_runtime = owned_backend_runtime,
             .secret_store = cfg.secret_store,
+            .destination_authorizer = cfg.destination_authorizer,
             .linearizable_read_tracker = read_tracker,
             .raft = try raft_service.ManagedHttpHostService.init(alloc, host_cfg, http_deps, cfg.raft, deps.raft),
         };
@@ -6063,6 +6073,7 @@ pub const MetadataHttpService = struct {
             inputs.ranges,
             .{
                 .backend_runtime = try self.ensureBackendRuntime(),
+                .destination_authorizer = self.destination_authorizer,
             },
         );
         try self.refreshLocalRestoreProgress(group_ids, inputs.tables, inputs.ranges, inputs.restore_progresses);
@@ -6311,6 +6322,7 @@ pub const MetadataHttpService = struct {
         );
         _ = hosted_write_source.withBackendRuntime(runtime);
         _ = hosted_write_source.withSecretStore(self.secret_store);
+        _ = hosted_write_source.withDestinationAuthorization(self.destination_authorizer);
         const write_source = self.cdc_write_source_override orelse hosted_write_source.source();
         var coordinator = metadata_replication_backfill.SnapshotBackfillCoordinator{
             .alloc = self.alloc,
@@ -6321,6 +6333,7 @@ pub const MetadataHttpService = struct {
                 .write_source = write_source,
                 .secret_store = self.secret_store,
                 .work_permit = cdcWorkPermit(self),
+                .destination_authorizer = self.destination_authorizer,
             },
         };
         const summary = coordinator.runRound(self) catch |err| {
@@ -6352,6 +6365,7 @@ pub const MetadataHttpService = struct {
                 .write_source = write_source,
                 .secret_store = self.secret_store,
                 .work_permit = cdcWorkPermit(self),
+                .destination_authorizer = self.destination_authorizer,
             },
         };
         const stream_summary = streaming.runRound(self) catch |err| {

--- a/zig/pkg/antfly/src/metadata/table_provisioner.zig
+++ b/zig/pkg/antfly/src/metadata/table_provisioner.zig
@@ -13,6 +13,7 @@
 // limitations.
 
 const std = @import("std");
+const stored_destination_authorization = @import("../api/stored_destination_authorization.zig");
 const backups_api = @import("../api/backups.zig");
 const common_config = @import("../common/config.zig");
 const fs_paths = @import("../common/fs_paths.zig");
@@ -75,6 +76,7 @@ pub const ReconcileReplicaRootOptions = struct {
     backend_runtime: ?*backend_runtime_mod.BackendRuntime = null,
     shard_db_adapter: ?shard_db_adapter_mod.ShardDbAdapter = null,
     restore_open_options: backups_api.OpenOptions = .{},
+    destination_authorizer: ?stored_destination_authorization.Authorizer = null,
 };
 
 fn provisioningDbOpenOptions() db_mod.OpenOptions {
@@ -236,7 +238,10 @@ pub fn reconcileReplicaRootWithOptions(
         var db = try db_mod.DB.open(alloc, path, open_options);
         defer db.close();
         summary.dbs_opened += 1;
-        const index_summary = try reconcileDbIndexes(alloc, &db, table.indexes_json);
+        const index_summary = try reconcileDbIndexesWithOptions(alloc, &db, table.indexes_json, .{
+            .source_table = table.name,
+            .destination_authorizer = options.destination_authorizer,
+        });
         summary.merge(index_summary);
     }
     return summary;
@@ -259,6 +264,8 @@ pub fn reconcileDbIndexes(
 
 pub const ReconcileDbIndexOptions = struct {
     drain_resolver_backfill: bool = true,
+    source_table: []const u8 = "",
+    destination_authorizer: ?stored_destination_authorization.Authorizer = null,
 };
 
 fn dbIndexReconciliationCanMutate(db: *const db_mod.DB) bool {
@@ -289,6 +296,8 @@ pub fn reconcileDbIndexesWithOptions(
     const enrichment_summary = try ensureEnrichments(db, desired_enrichments.items);
     const resolver_summary = try ensureResolversWithOptions(alloc, db, indexes_json, .{
         .drain_backfill = options.drain_resolver_backfill,
+        .source_table = options.source_table,
+        .destination_authorizer = options.destination_authorizer,
     });
     const missing_indexes_removed = try removeMissingIndexes(alloc, db, indexes_json);
     const index_summary = try ensureIndexes(alloc, db, indexes_json);
@@ -1291,6 +1300,8 @@ pub fn ensureResolvers(alloc: std.mem.Allocator, db: *db_mod.DB, indexes_json: [
 
 pub const EnsureResolverOptions = struct {
     drain_backfill: bool = true,
+    source_table: []const u8 = "",
+    destination_authorizer: ?stored_destination_authorization.Authorizer = null,
 };
 
 pub fn ensureResolversWithOptions(
@@ -1299,6 +1310,12 @@ pub fn ensureResolversWithOptions(
     indexes_json: []const u8,
     options: EnsureResolverOptions,
 ) !ResolverReconcileSummary {
+    try stored_destination_authorization.authorizeIndexesJson(
+        alloc,
+        indexes_json,
+        options.source_table,
+        options.destination_authorizer,
+    );
     var parsed = try std.json.parseFromSlice(std.json.Value, alloc, indexes_json, .{});
     defer parsed.deinit();
 
@@ -2200,7 +2217,7 @@ test "table provisioner registers a resolver declared in the table index config"
         \\    "artifact":{"name":"relations_v1","kind":"asset","source":{"type":"field","value":"relations"},"content_type":"application/json"}},
         \\  "resolvers":[
         \\    {"name":"kg","table":"entities","source_artifact":"relations_v1","resolution_artifact":"resolution_v1",
-        \\     "key_template":"{{ lower _entity.label }}/{{ slug _entity.text }}","candidate_search":"prefix","config_generation":1}
+        \\     "key_template":"{{ lower _entity.label }}/{{ slug _entity.text }}","candidate_search":"prefix","config_generation":1,"_antfly_destination_authorization_v1":{"principal":"service:auth-disabled","signature":"auth-disabled","destinations":["entities"]}}
         \\  ]
         \\}
     ;
@@ -2257,7 +2274,7 @@ test "table provisioner registers a resolver declared in the table index config"
         \\    "artifact":{"name":"relations_v1","kind":"asset","source":{"type":"field","value":"relations"},"content_type":"application/json"}},
         \\  "resolvers":[
         \\    {"name":"kg","table":"entities","source_artifact":"relations_v1","resolution_artifact":"resolution_v1",
-        \\     "key_template":"{{ lower _entity.label }}/{{ slug _entity.text }}","candidate_search":"prefix","config_generation":2}
+        \\     "key_template":"{{ lower _entity.label }}/{{ slug _entity.text }}","candidate_search":"prefix","config_generation":2,"_antfly_destination_authorization_v1":{"principal":"service:auth-disabled","signature":"auth-disabled","destinations":["entities"]}}
         \\  ]
         \\}
     ;
@@ -2377,7 +2394,7 @@ test "table provisioner can admit resolver backfill without draining corpus work
         \\    "artifact":{"name":"relations_v1","kind":"asset","source":{"type":"field","value":"relations"},"content_type":"application/json"}},
         \\  "resolvers":[
         \\    {"name":"kg","table":"entities","source_artifact":"relations_v1","resolution_artifact":"resolution_v1",
-        \\     "key_template":"{{ lower _entity.label }}/{{ slug _entity.text }}","candidate_search":"prefix","config_generation":1}
+        \\     "key_template":"{{ lower _entity.label }}/{{ slug _entity.text }}","candidate_search":"prefix","config_generation":1,"_antfly_destination_authorization_v1":{"principal":"service:auth-disabled","signature":"auth-disabled","destinations":["entities"]}}
         \\  ]
         \\}
     ;

--- a/zig/pkg/antfly/src/openapi/generated/antfly_client_openapi/client.zig
+++ b/zig/pkg/antfly/src/openapi/generated/antfly_client_openapi/client.zig
@@ -1115,6 +1115,17 @@ pub const Client = struct {
         return ApiResponse(types.BatchResponse).fromResponse(self.allocator, &resp);
     }
 
+    /// Adopt stored write destinations with the current credential
+    /// POST /db/v1/tables/{tableName}/destination-authorization
+    pub fn reauthorizeTableDestinations(self: *@This(), table_name: []const u8) !ApiResponse(std.json.Value) {
+        const encoded_table_name = try httpx.PercentEncoding.encode(self.allocator, table_name);
+        defer self.allocator.free(encoded_table_name);
+        const url = try std.fmt.allocPrint(self.allocator, "{s}/db/v1/tables/{s}/destination-authorization", .{ self.base_url, encoded_table_name });
+        defer self.allocator.free(url);
+        var resp = try self.http.post(url, .{ .headers = self.authHeaders() });
+        return ApiResponse(std.json.Value).fromResponse(self.allocator, &resp);
+    }
+
     /// Scan documents in a table within a key range
     /// POST /db/v1/tables/{tableName}/documents
     pub fn scanKeys(self: *@This(), table_name: []const u8, body: ?types.ScanKeysRequest) !RawResponse {

--- a/zig/pkg/antfly/src/openapi/generated/antfly_metadata_openapi/server.zig
+++ b/zig/pkg/antfly/src/openapi/generated/antfly_metadata_openapi/server.zig
@@ -246,6 +246,12 @@ pub fn parseBatchWriteBody(allocator: std.mem.Allocator, body: []const u8) !std.
     return std.json.parseFromSlice(types.BatchRequest, allocator, body, .{ .ignore_unknown_fields = true });
 }
 
+/// Adopt stored write destinations with the current credential
+pub const ReauthorizeTableDestinationsPathParams = struct {
+    /// Name of the table whose stored destinations should be adopted
+    table_name: []const u8,
+};
+
 /// Scan documents in a table within a key range
 pub const ScanKeysPathParams = struct {
     /// Name of the table
@@ -575,6 +581,7 @@ pub const routes = [_]Route{
     .{ .method = "POST", .path = "/tables/{tableName}/artifacts/{artifactName}/reprocess-jobs/{jobId}/cancel", .operation_id = "cancelDocumentArtifactReprocessJob", .request_body = .none, .streaming_response = false },
     .{ .method = "POST", .path = "/tables/{tableName}/backup", .operation_id = "backupTable", .request_body = .buffered, .streaming_response = false },
     .{ .method = "POST", .path = "/tables/{tableName}/batch", .operation_id = "batchWrite", .request_body = .buffered, .streaming_response = false },
+    .{ .method = "POST", .path = "/tables/{tableName}/destination-authorization", .operation_id = "reauthorizeTableDestinations", .request_body = .none, .streaming_response = false },
     .{ .method = "POST", .path = "/tables/{tableName}/documents", .operation_id = "scanKeys", .request_body = .buffered, .streaming_response = true },
     .{ .method = "GET", .path = "/tables/{tableName}/documents/{key}", .operation_id = "lookupKey", .request_body = .none, .streaming_response = false },
     .{ .method = "GET", .path = "/tables/{tableName}/documents/{key}/artifacts", .operation_id = "listDocumentArtifactManifests", .request_body = .none, .streaming_response = false },
@@ -652,6 +659,7 @@ pub fn ServerRouter(comptime Impl: type) type {
         if (!@hasDecl(Impl, "cancelDocumentArtifactReprocessJob")) @compileError("ServerRouter: Impl missing required method 'cancelDocumentArtifactReprocessJob'");
         if (!@hasDecl(Impl, "backupTable")) @compileError("ServerRouter: Impl missing required method 'backupTable'");
         if (!@hasDecl(Impl, "batchWrite")) @compileError("ServerRouter: Impl missing required method 'batchWrite'");
+        if (!@hasDecl(Impl, "reauthorizeTableDestinations")) @compileError("ServerRouter: Impl missing required method 'reauthorizeTableDestinations'");
         if (!@hasDecl(Impl, "scanKeys")) @compileError("ServerRouter: Impl missing required method 'scanKeys'");
         if (!@hasDecl(Impl, "lookupKey")) @compileError("ServerRouter: Impl missing required method 'lookupKey'");
         if (!@hasDecl(Impl, "listDocumentArtifactManifests")) @compileError("ServerRouter: Impl missing required method 'listDocumentArtifactManifests'");
@@ -727,6 +735,7 @@ pub fn ServerRouter(comptime Impl: type) type {
             try server.post("/tables/:tableName/artifacts/:artifactName/reprocess-jobs/:jobId/cancel", httpx.Handler.bind(self.impl, cancelDocumentArtifactReprocessJob));
             try server.post("/tables/:tableName/backup", httpx.Handler.bind(self.impl, backupTable));
             try server.post("/tables/:tableName/batch", httpx.Handler.bind(self.impl, batchWrite));
+            try server.post("/tables/:tableName/destination-authorization", httpx.Handler.bind(self.impl, reauthorizeTableDestinations));
             try server.post("/tables/:tableName/documents", httpx.Handler.bind(self.impl, scanKeys));
             try server.get("/tables/:tableName/documents/:key", httpx.Handler.bind(self.impl, lookupKey));
             try server.get("/tables/:tableName/documents/:key/artifacts", httpx.Handler.bind(self.impl, listDocumentArtifactManifests));
@@ -1001,6 +1010,13 @@ pub fn ServerRouter(comptime Impl: type) type {
         fn batchWrite(impl: *Impl, ctx: *httpx.Context) anyerror!httpx.Response {
             const table_name = ctx.param("tableName") orelse return ctx.status(400).json(.{ .@"error" = "missing_path_param", .message = "Missing path parameter: tableName" });
             return impl.batchWrite(ctx, table_name);
+        }
+
+        /// Adopt stored write destinations with the current credential
+        /// POST /tables/{tableName}/destination-authorization
+        fn reauthorizeTableDestinations(impl: *Impl, ctx: *httpx.Context) anyerror!httpx.Response {
+            const table_name = ctx.param("tableName") orelse return ctx.status(400).json(.{ .@"error" = "missing_path_param", .message = "Missing path parameter: tableName" });
+            return impl.reauthorizeTableDestinations(ctx, table_name);
         }
 
         /// Scan documents in a table within a key range
@@ -1285,6 +1301,7 @@ pub fn ServerRouter(comptime Impl: type) type {
 //   fn cancelDocumentArtifactReprocessJob(self: *Impl, ctx: *httpx.Context, table_name: []const u8, artifact_name: []const u8, job_id: []const u8) !httpx.Response
 //   fn backupTable(self: *Impl, ctx: *httpx.Context, table_name: []const u8) !httpx.Response
 //   fn batchWrite(self: *Impl, ctx: *httpx.Context, table_name: []const u8) !httpx.Response
+//   fn reauthorizeTableDestinations(self: *Impl, ctx: *httpx.Context, table_name: []const u8) !httpx.Response
 //   fn scanKeys(self: *Impl, ctx: *httpx.Context, table_name: []const u8) !httpx.Response
 //   fn lookupKey(self: *Impl, ctx: *httpx.Context, table_name: []const u8, key: []const u8, params: LookupKeyParams) !httpx.Response
 //   fn listDocumentArtifactManifests(self: *Impl, ctx: *httpx.Context, table_name: []const u8, key: []const u8, params: ListDocumentArtifactManifestsParams) !httpx.Response

--- a/zig/pkg/antfly/src/openapi/generated/antfly_public_openapi/server.zig
+++ b/zig/pkg/antfly/src/openapi/generated/antfly_public_openapi/server.zig
@@ -432,6 +432,12 @@ pub fn parseBatchWriteBody(allocator: std.mem.Allocator, body: []const u8) !std.
     return std.json.parseFromSlice(types.BatchRequest, allocator, body, .{ .ignore_unknown_fields = true });
 }
 
+/// Adopt stored write destinations with the current credential
+pub const ReauthorizeTableDestinationsPathParams = struct {
+    /// Name of the table whose stored destinations should be adopted
+    table_name: []const u8,
+};
+
 /// Scan documents in a table within a key range
 pub const ScanKeysPathParams = struct {
     /// Name of the table
@@ -785,6 +791,7 @@ pub const routes = [_]Route{
     .{ .method = "POST", .path = "/tables/{tableName}/artifacts/{artifactName}/reprocess-jobs/{jobId}/cancel", .operation_id = "cancelDocumentArtifactReprocessJob", .request_body = .none, .streaming_response = false },
     .{ .method = "POST", .path = "/tables/{tableName}/backup", .operation_id = "backupTable", .request_body = .buffered, .streaming_response = false },
     .{ .method = "POST", .path = "/tables/{tableName}/batch", .operation_id = "batchWrite", .request_body = .buffered, .streaming_response = false },
+    .{ .method = "POST", .path = "/tables/{tableName}/destination-authorization", .operation_id = "reauthorizeTableDestinations", .request_body = .none, .streaming_response = false },
     .{ .method = "POST", .path = "/tables/{tableName}/documents", .operation_id = "scanKeys", .request_body = .buffered, .streaming_response = true },
     .{ .method = "GET", .path = "/tables/{tableName}/documents/{key}", .operation_id = "lookupKey", .request_body = .none, .streaming_response = false },
     .{ .method = "GET", .path = "/tables/{tableName}/documents/{key}/artifacts", .operation_id = "listDocumentArtifactManifests", .request_body = .none, .streaming_response = false },
@@ -877,6 +884,7 @@ pub const routes = [_]Route{
 //   fn cancelDocumentArtifactReprocessJob(self: *Impl, ctx: *httpx.Context, table_name: []const u8, artifact_name: []const u8, job_id: []const u8) !httpx.Response
 //   fn backupTable(self: *Impl, ctx: *httpx.Context, table_name: []const u8) !httpx.Response
 //   fn batchWrite(self: *Impl, ctx: *httpx.Context, table_name: []const u8) !httpx.Response
+//   fn reauthorizeTableDestinations(self: *Impl, ctx: *httpx.Context, table_name: []const u8) !httpx.Response
 //   fn scanKeys(self: *Impl, ctx: *httpx.Context, table_name: []const u8) !httpx.Response
 //   fn lookupKey(self: *Impl, ctx: *httpx.Context, table_name: []const u8, key: []const u8, params: LookupKeyParams) !httpx.Response
 //   fn listDocumentArtifactManifests(self: *Impl, ctx: *httpx.Context, table_name: []const u8, key: []const u8, params: ListDocumentArtifactManifestsParams) !httpx.Response

--- a/zig/pkg/antfly/src/usermgr/user_manager.zig
+++ b/zig/pkg/antfly/src/usermgr/user_manager.zig
@@ -1099,6 +1099,9 @@ pub const UserManager = struct {
     }
 
     pub fn validateApiKey(self: *const UserManager, key_id: []const u8, key_secret: []const u8) !ValidatedApiKey {
+        const mutable: *UserManager = @constCast(self);
+        lockMutationMutex(&mutable.mutation_mutex);
+        defer mutable.mutation_mutex.unlock();
         const record = self.api_keys.get(key_id) orelse return error.ApiKeyNotFound;
         const secret_size = std.base64.url_safe_no_pad.Decoder.calcSizeForSlice(key_secret) catch {
             return error.ApiKeyInvalid;
@@ -1119,22 +1122,79 @@ pub const UserManager = struct {
             for (owner_row_filter) |*entry| entry.deinit(self.alloc);
             self.alloc.free(owner_row_filter);
         }
+        const effective_permissions = try self.effectiveApiKeyPermissionsUnlocked(key_id);
+        errdefer {
+            for (effective_permissions) |*permission| permission.deinit(self.alloc);
+            self.alloc.free(effective_permissions);
+        }
+
+        return .{
+            .username = try self.alloc.dupe(u8, record.key.username),
+            .permissions = effective_permissions,
+            .row_filter = try combineLayeredRowFilters(self.alloc, owner_row_filter, record.key.row_filter),
+            .metadata_json = try self.alloc.dupe(u8, self.user_metadata.get(record.key.username) orelse "{}"),
+            .roles = try self.getRolesForUser(record.key.username),
+        };
+    }
+
+    /// Resolve the current authority of an existing API-key identity without
+    /// requiring its bearer secret. Durable background grants use this only
+    /// after admission has authenticated the secret and bound the key id into
+    /// catalog metadata. Deletion, expiry, and owner revocation all fail
+    /// closed on the next worker authorization check.
+    pub fn effectiveApiKeyPermissions(self: *const UserManager, key_id: []const u8) ![]Permission {
+        const mutable: *UserManager = @constCast(self);
+        lockMutationMutex(&mutable.mutation_mutex);
+        defer mutable.mutation_mutex.unlock();
+        return try self.effectiveApiKeyPermissionsUnlocked(key_id);
+    }
+
+    fn effectiveApiKeyPermissionsUnlocked(self: *const UserManager, key_id: []const u8) ![]Permission {
+        const record = self.api_keys.get(key_id) orelse return error.ApiKeyNotFound;
+        if (record.key.expires_at_ns) |expires_at_ns| {
+            if (nowNs() > expires_at_ns) return error.ApiKeyExpired;
+        }
         const owner_permissions = try self.getPermissionsForUser(record.key.username);
         defer {
             for (owner_permissions) |*permission| permission.deinit(self.alloc);
             self.alloc.free(owner_permissions);
         }
+        return if (record.key.permissions.len > 0)
+            try intersectPermissions(self.alloc, record.key.permissions, owner_permissions)
+        else
+            try clonePermissions(self.alloc, owner_permissions);
+    }
 
-        return .{
-            .username = try self.alloc.dupe(u8, record.key.username),
-            .permissions = if (record.key.permissions.len > 0)
-                try intersectPermissions(self.alloc, record.key.permissions, owner_permissions)
-            else
-                try clonePermissions(self.alloc, owner_permissions),
-            .row_filter = try combineLayeredRowFilters(self.alloc, owner_row_filter, record.key.row_filter),
-            .metadata_json = try self.alloc.dupe(u8, self.user_metadata.get(record.key.username) orelse "{}"),
-            .roles = try self.getRolesForUser(record.key.username),
-        };
+    /// Produce a server-only authenticator for durable authorization records.
+    /// The key material is the persisted verifier for the credential, never
+    /// the bearer secret itself. Password rotation, API-key deletion, and key
+    /// rotation therefore invalidate old records without introducing another
+    /// operator-managed cluster secret.
+    pub fn destinationGrantMac(
+        self: *const UserManager,
+        principal: []const u8,
+        payload: []const u8,
+    ) ![std.crypto.auth.hmac.sha2.HmacSha256.mac_length]u8 {
+        const mutable: *UserManager = @constCast(self);
+        lockMutationMutex(&mutable.mutation_mutex);
+        defer mutable.mutation_mutex.unlock();
+        const key = if (std.mem.startsWith(u8, principal, "basic:")) blk: {
+            const username = principal["basic:".len..];
+            if (username.len == 0) return error.InvalidDestinationGrantPrincipal;
+            break :blk self.users.get(username) orelse return error.UserNotFound;
+        } else if (std.mem.startsWith(u8, principal, "api-key:")) blk: {
+            const key_id = principal["api-key:".len..];
+            if (key_id.len == 0) return error.InvalidDestinationGrantPrincipal;
+            const record = self.api_keys.get(key_id) orelse return error.ApiKeyNotFound;
+            if (record.key.expires_at_ns) |expires_at_ns| {
+                if (nowNs() > expires_at_ns) return error.ApiKeyExpired;
+            }
+            break :blk record.secret_hash;
+        } else return error.InvalidDestinationGrantPrincipal;
+
+        var mac: [std.crypto.auth.hmac.sha2.HmacSha256.mac_length]u8 = undefined;
+        std.crypto.auth.hmac.sha2.HmacSha256.create(&mac, payload, key);
+        return mac;
     }
 
     pub fn listApiKeys(self: *const UserManager, username: []const u8) ![]ApiKey {


### PR DESCRIPTION
## Summary

- authorize CDC, graph, and restore destinations at admission and again whenever durable work starts or resumes
- seal each grant with a credential-derived HMAC over its source table, principal, exact normalized configuration, and destinations
- invalidate grants on password/key rotation, key expiry/deletion, or live permission revocation without another operator-managed secret
- fail closed for legacy unbound configurations while providing an explicit authorized adoption endpoint
- wire enforcement into metadata and data-node workers, and return explicit 422 responses for unsupported trusted-principal sink configurations
- update OpenAPI plus generated Go, Python, TypeScript, and Zig SDKs

## Stack

This is PR 2 of 3 and is stacked on #554. Its base should be changed to main after #554 merges. The final PR contains internal RPC authentication and operator rollout support.

## Validation

- make generate
- zig build authorization-audit -fincremental --summary all
- focused authorization sink tests: 16/16
- broader authorization tests: 56/56
- exploit oracle: 11/11
- leak checks clean
- OpenAPI generated check passes; the aggregate local generated check reaches Snowball and requires the worktree submodule checkout