### PR TITLE
Fix artifact full-text merge scaling past 1M chunks

### DIFF
--- a/.github/workflows/zig-scale-tests.yml
+++ b/.github/workflows/zig-scale-tests.yml
@@ -8,7 +8,9 @@ on:
     - cron: "30 9 * * *"
   workflow_dispatch:
   pull_request:
-    types: [labeled]
+    # A label opts the PR into this gate until it is removed. Re-run for every
+    # new head, and use the unlabeled event to cancel an in-flight scale run.
+    types: [labeled, unlabeled, synchronize, reopened]
 
 permissions:
   contents: read
@@ -29,7 +31,7 @@ jobs:
       github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' &&
-       github.event.label.name == 'ci:scale-tests' &&
+       contains(github.event.pull_request.labels.*.name, 'ci:scale-tests') &&
        github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: arc-antfly-heavy
     timeout-minutes: 60

--- a/.github/workflows/zig-scale-tests.yml
+++ b/.github/workflows/zig-scale-tests.yml
@@ -1,0 +1,75 @@
+name: Zig Scale Tests
+
+# Keep corpus-scale correctness gates isolated from required E2E latency and
+# resource accounting. Run them continuously on the default branch, manually,
+# or before merging a same-repository PR by applying `ci:scale-tests`.
+on:
+  schedule:
+    - cron: "30 9 * * *"
+  workflow_dispatch:
+  pull_request:
+    types: [labeled]
+
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  ZIG_LOCAL_CACHE_DIR: ${{ github.workspace }}/zig/.zig-cache-scale
+  ZIG_GLOBAL_CACHE_DIR: ${{ github.workspace }}/zig/.zig-global-cache-scale
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  artifact-full-text:
+    name: Artifact full-text / >1M chunks
+    if: >-
+      github.event_name == 'schedule' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' &&
+       github.event.label.name == 'ci:scale-tests' &&
+       github.event.pull_request.head.repo.full_name == github.repository)
+    runs-on: arc-antfly-heavy
+    timeout-minutes: 60
+    env:
+      ANTFLY_CI_ZIG_OPTIMIZE: ReleaseSafe
+      ANTFLY_CI_ZIG_STRIP: "true"
+      ANTFLY_ARTIFACT_FULL_TEXT_SCALE: "1"
+      ANTFLY_BIN: ./zig-out/bin/antfly
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          submodules: true
+
+      - name: Install build tools
+        run: sudo apt-get update && sudo apt-get install -y build-essential pkg-config ca-certificates git curl xz-utils
+
+      - name: Set up Zig
+        uses: mlugg/setup-zig@v2
+        with:
+          version: 0.16.0
+          use-cache: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+
+      - name: Compute CPU bound
+        id: cpus
+        run: |
+          jobs=$(nproc)
+          if [ "$jobs" -gt 8 ]; then jobs=8; fi
+          echo "list=0-$((jobs - 1))" >> "$GITHUB_OUTPUT"
+
+      - name: Build E2E executable
+        run: scripts/ci/zig-build-e2e-binaries.sh
+
+      - name: Run artifact full-text scale gate
+        working-directory: zig
+        run: |
+          chmod +x ./zig-out/bin/antfly
+          taskset -c ${{ steps.cpus.outputs.list }} \
+            uv run --project e2e/antfly pytest -q \
+            e2e/antfly/test_artifacts.py::test_artifact_full_text_scale_exceeds_one_million_chunks_on_three_shards

--- a/zig/e2e/antfly/README.md
+++ b/zig/e2e/antfly/README.md
@@ -152,6 +152,26 @@ export GOOGLE_CLOUD_PROJECT=my-project
 
 When these envs are absent, the remote backup tests skip cleanly.
 
+## Artifact Full-Text Scale Qualification
+
+`test_artifacts.py` includes an opt-in qualification that generates more than
+one million artifact-backed full-text chunks. It verifies that child ranges
+remain co-resident with their parents and that parents spanning a three-shard
+table produce indexed chunks on every shard. Its deliberately skewed parent
+distribution also drives one shard past the former 746k ceiling. The dedicated
+`Zig Scale Tests` workflow runs this gate daily, through manual dispatch, or on
+a same-repository pull request when the `ci:scale-tests` label is applied. It
+runs separately from the required and full E2E shards.
+
+Run it locally from `zig/` with:
+
+```bash
+ANTFLY_ARTIFACT_FULL_TEXT_SCALE=1 \
+  uv run --project e2e/antfly pytest \
+  e2e/antfly/test_artifacts.py::test_artifact_full_text_scale_exceeds_one_million_chunks_on_three_shards \
+  -q
+```
+
 ## Main Gaps
 
 Compared with `../antfly/e2e`, the biggest missing areas are:

--- a/zig/e2e/antfly/pyproject.toml
+++ b/zig/e2e/antfly/pyproject.toml
@@ -23,4 +23,5 @@ markers = [
     "real_model: requires local or downloadable model weights",
     "postgres_integration: requires a local PostgreSQL instance",
     "slow: marks tests that are too long-running for required E2E base CI",
+    "scale: marks corpus-scale correctness gates run by dedicated scale CI",
 ]

--- a/zig/e2e/antfly/test_artifacts.py
+++ b/zig/e2e/antfly/test_artifacts.py
@@ -18,9 +18,13 @@ from __future__ import annotations
 
 import base64
 import json
+import os
 import time
 from pathlib import Path
 from urllib.parse import quote
+
+import pytest
+import requests
 
 from helpers import assert_created_index, wait_until
 
@@ -90,6 +94,38 @@ def _document_units_index_config() -> dict:
         },
         "artifact": artifact,
         "edge_types": [{"name": "mentions"}],
+    }
+
+
+def _artifact_full_text_indexes(*, chunk_size: int) -> dict[str, dict]:
+    units = _document_units_index_config()
+    return {
+        "document_units": units,
+        "document_text": {
+            "type": "full_text",
+            "field": "text",
+            "artifact_name": "document_chunks_v1",
+            "enrichments": [
+                {
+                    "name": DOCUMENT_UNITS_ARTIFACT,
+                    "kind": "asset",
+                    "field": "url",
+                    "content_type": "application/json",
+                    "producer_json": json.dumps(
+                        units["artifact"]["producer_json"], separators=(",", ":")
+                    ),
+                },
+                {
+                    "name": "document_chunks_v1",
+                    "kind": "chunk",
+                    "field": "text",
+                    "source_artifact_name": DOCUMENT_UNITS_ARTIFACT,
+                    "chunk_size": chunk_size,
+                    "chunk_overlap": 0,
+                    "full_text_index": True,
+                },
+            ],
+        },
     }
 
 
@@ -655,6 +691,233 @@ def test_pdf_auto_ocr_only_renders_pages_without_usable_embedded_text_e2e(
     reader_stats = pdf_ocr_e2e_server.stats()
     assert reader_stats["png_requests"] == 1, reader_stats
     assert reader_stats["jpeg_requests"] == 0, reader_stats
+
+
+def test_artifact_full_text_chunks_remain_with_parents_across_three_shards(
+    stateful_api,
+):
+    """Parent range routing, not the shared ``af1:chunk`` display prefix, owns chunks."""
+
+    table_name = f"artifact_full_text_three_shards_{time.time_ns()}"
+    created = stateful_api.create_table(
+        table_name,
+        num_shards=3,
+        indexes=_artifact_full_text_indexes(chunk_size=16),
+    )
+    assert created.get("name") == table_name or created.get("table_name") == table_name
+
+    # Three-shard tables start with lexical ranges. These parent keys
+    # deliberately land below, between, and above the two initial boundaries.
+    # Their generated artifact keys must stay in the selected parent group.
+    parent_markers = {
+        "0/parent-left": "leftartifactmarker",
+        "8/parent-middle": "middleartifactmarker",
+        "z/parent-right": "rightartifactmarker",
+    }
+    inserts = {}
+    for parent_key, marker in parent_markers.items():
+        source = ((marker + " common ") * 96).encode()
+        inserts[parent_key] = {
+            "filename": f"{marker}.txt",
+            "mime_type": "text/plain",
+            "version": "1",
+            "url": "data:text/plain;base64," + base64.b64encode(source).decode(),
+        }
+
+    written = stateful_api.batch_write(
+        table_name,
+        inserts=inserts,
+        sync_level="full_index",
+    )
+    assert written["inserted"] == len(inserts)
+
+    manifests = {}
+    for parent_key in parent_markers:
+        manifest = wait_until(
+            lambda parent_key=parent_key: (
+                current
+                if (
+                    (current := _manifest_ready(stateful_api, table_name, parent_key))
+                    is not None
+                    and current.get("chunk_count", 0) > 1
+                )
+                else None
+            ),
+            timeout_s=90.0,
+            interval_s=0.5,
+        )
+        assert manifest is not None
+        assert manifest["child_ranges"]
+        assert all(
+            child_range.get("placement") == "parent"
+            for child_range in manifest["child_ranges"]
+        )
+        manifests[parent_key] = manifest
+
+    def distributed_index_status() -> dict | None:
+        detail = stateful_api.get_index(table_name, "document_text")
+        shards = detail.get("shard_status", {})
+        counts = [
+            int(status.get("total_indexed", 0))
+            for status in shards.values()
+        ]
+        if len(counts) != 3 or not all(count > 0 for count in counts):
+            return None
+        return detail
+
+    detail = wait_until(
+        distributed_index_status,
+        timeout_s=90.0,
+        interval_s=0.5,
+    )
+    assert detail is not None, json.dumps(
+        stateful_api.get_index(table_name, "document_text"),
+        indent=2,
+        sort_keys=True,
+    )
+
+    result = stateful_api.query_table(
+        table_name,
+        {
+            "full_text_search": {"field": "text", "match": "common"},
+            "limit": 10,
+        },
+    )
+    assert set(parent_markers).issubset(_query_hit_ids(result)), {
+        "manifests": manifests,
+        "result": result,
+    }
+
+
+@pytest.mark.slow
+@pytest.mark.scale
+def test_artifact_full_text_scale_exceeds_one_million_chunks_on_three_shards(
+    stateful_api,
+):
+    """Opt-in live qualification for the artifact-specific merge/backpressure path."""
+
+    if os.environ.get("ANTFLY_ARTIFACT_FULL_TEXT_SCALE") != "1":
+        pytest.skip("set ANTFLY_ARTIFACT_FULL_TEXT_SCALE=1 to run the >1M chunk gate")
+
+    target_chunks = 1_000_001
+    table_name = f"artifact_full_text_scale_{time.time_ns()}"
+    created = stateful_api.create_table(
+        table_name,
+        num_shards=3,
+        indexes=_artifact_full_text_indexes(chunk_size=8),
+    )
+    assert created.get("name") == table_name or created.get("table_name") == table_name
+
+    # Keep each source close to the reported PG-19 reproduction's ~829 chunks
+    # per book. Giant inline sources are not representative: the source field
+    # remains part of each derived indexing input until segment publication.
+    source = ("artifactscaletoken " * 340).encode()
+    source_url = "data:text/plain;base64," + base64.b64encode(source).decode()
+    lane_prefixes = ("0/", "8/", "z/")
+    hot_shard_floor = 750_000
+    generated_chunks = 0
+    parent_number = 0
+    sample_manifests: dict[str, dict] = {}
+
+    # Keep source requests bounded and wait for each batch's generated chunks,
+    # matching the live PG-19 reproduction instead of measuring accepted rows.
+    # Five of every six parents deliberately share one range, so this gate
+    # crosses the old ~746k per-shard ceiling while still exercising all three
+    # shards. Submit one source at a time so merge backpressure throttles the
+    # producer instead of accumulating a multi-thousand-chunk HTTP burst.
+    while generated_chunks < target_chunks:
+        batch_slot = parent_number % 6
+        cycle = parent_number // 6
+        prefix = (
+            lane_prefixes[0]
+            if batch_slot < 5
+            else lane_prefixes[1 + cycle % 2]
+        )
+        parent_key = f"{prefix}scale-{parent_number:08d}"
+
+        def ready_parent() -> dict | None:
+            manifest = _manifest_ready(stateful_api, table_name, parent_key)
+            if manifest is None or manifest.get("chunk_count", 0) == 0:
+                return None
+            return manifest
+
+        manifest = None
+        for attempt in range(3):
+            try:
+                inserted = stateful_api.batch_write_with_timeout(
+                    table_name,
+                    inserts={
+                        parent_key: {
+                            "filename": f"scale-{parent_number:08d}.txt",
+                            "mime_type": "text/plain",
+                            "version": "1",
+                            "url": source_url,
+                        }
+                    },
+                    sync_level="write",
+                    timeout_s=300.0,
+                )
+                assert inserted["inserted"] == 1
+                break
+            except requests.RequestException:
+                # The write may commit before a busy shard can return its HTTP
+                # response. Confirm the deterministic parent before retrying;
+                # a dead or permanently stalled server still exhausts this
+                # strict attempt bound and fails the qualification.
+                manifest = wait_until(
+                    ready_parent,
+                    timeout_s=30.0,
+                    interval_s=1.0,
+                )
+                if manifest is not None:
+                    break
+                if attempt == 2:
+                    raise
+
+        if manifest is None:
+            manifest = wait_until(
+                ready_parent,
+                timeout_s=300.0,
+                interval_s=1.0,
+            )
+        assert manifest is not None
+        generated_chunks += manifest["chunk_count"]
+        sample_manifests.setdefault(prefix, manifest)
+        parent_number += 1
+
+    assert generated_chunks >= target_chunks
+    assert set(sample_manifests) == set(lane_prefixes)
+    assert all(
+        child_range.get("placement") == "parent"
+        for manifest in sample_manifests.values()
+        for child_range in manifest["child_ranges"]
+    )
+
+    def million_chunks_visible_on_every_shard() -> dict | None:
+        detail = stateful_api.get_index(table_name, "document_text")
+        shards = detail.get("shard_status", {})
+        counts = [
+            int(status.get("total_indexed", 0))
+            for status in shards.values()
+        ]
+        if len(counts) != 3 or not all(count > 0 for count in counts):
+            return None
+        if sum(counts) < target_chunks:
+            return None
+        if max(counts) < hot_shard_floor:
+            return None
+        return detail
+
+    detail = wait_until(
+        million_chunks_visible_on_every_shard,
+        timeout_s=600.0,
+        interval_s=2.0,
+    )
+    assert detail is not None, json.dumps(
+        stateful_api.get_index(table_name, "document_text"),
+        indent=2,
+        sort_keys=True,
+    )
 
 
 def test_artifact_backed_embedding_table_provisions_atomically(

--- a/zig/e2e/antfly/test_artifacts.py
+++ b/zig/e2e/antfly/test_artifacts.py
@@ -29,6 +29,7 @@ import requests
 from helpers import assert_created_index, wait_until
 
 DOCUMENT_UNITS_ARTIFACT = "document_units_v1"
+DEFAULT_FULL_TEXT_INDEX = "full_text_index_v0"
 
 
 def _document_artifact_path(table_name: str, doc_key: str, artifact_name: str) -> str:
@@ -97,38 +98,6 @@ def _document_units_index_config() -> dict:
     }
 
 
-def _artifact_full_text_indexes(*, chunk_size: int) -> dict[str, dict]:
-    units = _document_units_index_config()
-    return {
-        "document_units": units,
-        "document_text": {
-            "type": "full_text",
-            "field": "text",
-            "artifact_name": "document_chunks_v1",
-            "enrichments": [
-                {
-                    "name": DOCUMENT_UNITS_ARTIFACT,
-                    "kind": "asset",
-                    "field": "url",
-                    "content_type": "application/json",
-                    "producer_json": json.dumps(
-                        units["artifact"]["producer_json"], separators=(",", ":")
-                    ),
-                },
-                {
-                    "name": "document_chunks_v1",
-                    "kind": "chunk",
-                    "field": "text",
-                    "source_artifact_name": DOCUMENT_UNITS_ARTIFACT,
-                    "chunk_size": chunk_size,
-                    "chunk_overlap": 0,
-                    "full_text_index": True,
-                },
-            ],
-        },
-    }
-
-
 def _manifest_ready(api, table_name: str, doc_key: str) -> dict | None:
     try:
         manifest = api.get(
@@ -156,6 +125,74 @@ def _table_has_artifact_enrichment(
         if enrichment.get("name") == artifact_name and enrichment.get("kind") == kind:
             return table
     return None
+
+
+def _provision_artifact_full_text(api, table_name: str, *, chunk_size: int) -> dict:
+    """Use the public enrichment UX to provision exactly one default text index."""
+
+    asset_enrichment = _document_units_asset_enrichment()
+    asset_enrichment["producer_json"] = json.dumps(
+        asset_enrichment["producer_json"], separators=(",", ":")
+    )
+    assert (
+        api.put(
+            f"{_table_artifact_path(table_name, DOCUMENT_UNITS_ARTIFACT)}/enrichment",
+            asset_enrichment,
+        )
+        == {}
+    )
+    assert (
+        wait_until(
+            lambda: _table_has_artifact_enrichment(
+                api, table_name, DOCUMENT_UNITS_ARTIFACT, "asset"
+            ),
+            timeout_s=30.0,
+            interval_s=0.25,
+        )
+        is not None
+    )
+
+    assert (
+        api.put(
+            f"{_table_artifact_path(table_name, 'document_chunks_v1')}/enrichment",
+            {
+                "kind": "chunk",
+                "source_artifact_name": DOCUMENT_UNITS_ARTIFACT,
+                "field": "text",
+                "chunk_size": chunk_size,
+                "chunk_overlap": 0,
+                "full_text_index": True,
+            },
+        )
+        == {}
+    )
+    assert (
+        wait_until(
+            lambda: _table_has_artifact_enrichment(
+                api, table_name, "document_chunks_v1", "chunk"
+            ),
+            timeout_s=30.0,
+            interval_s=0.25,
+        )
+        is not None
+    )
+
+    def default_index_ready() -> dict | None:
+        try:
+            current = api.get_index(table_name, DEFAULT_FULL_TEXT_INDEX)
+        except Exception:
+            return None
+        if current.get("config", {}).get("type") != "full_text":
+            return None
+        return current
+
+    detail = wait_until(
+        default_index_ready,
+        timeout_s=30.0,
+        interval_s=0.25,
+    )
+    assert detail is not None
+    return detail
 
 
 def test_document_artifact_manifest_and_reprocess_job_e2e(stateful_api):
@@ -702,9 +739,9 @@ def test_artifact_full_text_chunks_remain_with_parents_across_three_shards(
     created = stateful_api.create_table(
         table_name,
         num_shards=3,
-        indexes=_artifact_full_text_indexes(chunk_size=16),
     )
     assert created.get("name") == table_name or created.get("table_name") == table_name
+    _provision_artifact_full_text(stateful_api, table_name, chunk_size=16)
 
     # Three-shard tables start with lexical ranges. These parent keys
     # deliberately land below, between, and above the two initial boundaries.
@@ -755,7 +792,7 @@ def test_artifact_full_text_chunks_remain_with_parents_across_three_shards(
         manifests[parent_key] = manifest
 
     def distributed_index_status() -> dict | None:
-        detail = stateful_api.get_index(table_name, "document_text")
+        detail = stateful_api.get_index(table_name, DEFAULT_FULL_TEXT_INDEX)
         shards = detail.get("shard_status", {})
         counts = [
             int(status.get("total_indexed", 0))
@@ -771,7 +808,7 @@ def test_artifact_full_text_chunks_remain_with_parents_across_three_shards(
         interval_s=0.5,
     )
     assert detail is not None, json.dumps(
-        stateful_api.get_index(table_name, "document_text"),
+        stateful_api.get_index(table_name, DEFAULT_FULL_TEXT_INDEX),
         indent=2,
         sort_keys=True,
     )
@@ -804,9 +841,9 @@ def test_artifact_full_text_scale_exceeds_one_million_chunks_on_three_shards(
     created = stateful_api.create_table(
         table_name,
         num_shards=3,
-        indexes=_artifact_full_text_indexes(chunk_size=8),
     )
     assert created.get("name") == table_name or created.get("table_name") == table_name
+    _provision_artifact_full_text(stateful_api, table_name, chunk_size=8)
 
     # Keep each source close to the reported PG-19 reproduction's ~829 chunks
     # per book. Giant inline sources are not representative: the source field
@@ -894,7 +931,7 @@ def test_artifact_full_text_scale_exceeds_one_million_chunks_on_three_shards(
     )
 
     def million_chunks_visible_on_every_shard() -> dict | None:
-        detail = stateful_api.get_index(table_name, "document_text")
+        detail = stateful_api.get_index(table_name, DEFAULT_FULL_TEXT_INDEX)
         shards = detail.get("shard_status", {})
         counts = [
             int(status.get("total_indexed", 0))
@@ -914,7 +951,7 @@ def test_artifact_full_text_scale_exceeds_one_million_chunks_on_three_shards(
         interval_s=2.0,
     )
     assert detail is not None, json.dumps(
-        stateful_api.get_index(table_name, "document_text"),
+        stateful_api.get_index(table_name, DEFAULT_FULL_TEXT_INDEX),
         indent=2,
         sort_keys=True,
     )

--- a/zig/lib/vellum/src/mod.zig
+++ b/zig/lib/vellum/src/mod.zig
@@ -1135,6 +1135,7 @@ pub const FSTIterator = struct {
             .aut_states_stack = .empty,
             .next_start = .empty,
         };
+        errdefer it.deinit();
         try it.pointTo(start_inclusive);
         return it;
     }

--- a/zig/lib/vellum/src/mod.zig
+++ b/zig/lib/vellum/src/mod.zig
@@ -424,6 +424,7 @@ pub const Builder = struct {
             .last = .empty,
             .out = .empty,
         };
+        errdefer b.deinit();
 
         // Write header
         try b.out.appendSlice(alloc, &std.mem.toBytes(std.mem.nativeToLittle(u64, version_v1)));

--- a/zig/lib/vellum/src/mod.zig
+++ b/zig/lib/vellum/src/mod.zig
@@ -546,13 +546,13 @@ pub const Builder = struct {
         while (i_state + 1 < self.stack.items.len) {
             var unfinished = self.stack.items[self.stack.items.len - 1];
             self.stack.items.len -= 1;
+            defer unfinished.node.deinit(self.alloc);
             if (addr == none_addr) {
                 // popEmpty - don't call lastCompiled
             } else {
                 try unfinished.lastCompiled(self.alloc, addr);
             }
             addr = try self.compile(&unfinished.node);
-            unfinished.node.deinit(self.alloc);
         }
         try self.stack.items[self.stack.items.len - 1].lastCompiled(self.alloc, addr);
     }
@@ -1472,6 +1472,25 @@ test "registry rollover sweep frees stale nodes" {
         try std.testing.expect((try fst.get("xx")).found);
         try std.testing.expect(!(try fst.get("aa")).found);
     }
+}
+
+test "builder releases every partial allocation" {
+    const alloc = std.testing.allocator;
+
+    const Runner = struct {
+        fn run(failing_alloc: Allocator) !void {
+            var builder = try Builder.init(failing_alloc, .{ .registry_table_size = 4 });
+            defer builder.deinit();
+
+            try builder.insert("alpha", 10);
+            try builder.insert("beta", 20);
+
+            const data = try builder.finish();
+            defer failing_alloc.free(data);
+        }
+    };
+
+    try std.testing.checkAllAllocationFailures(alloc, Runner.run, .{});
 }
 
 test "builder.reset reuses one Builder for multiple FSTs" {

--- a/zig/pkg/antfly/src/section/inverted.zig
+++ b/zig/pkg/antfly/src/section/inverted.zig
@@ -4904,10 +4904,16 @@ pub fn writeMergedInvertedSectionSlotsWithDeletes(
     }
 
     var term_iters = try alloc.alloc(TermIterator, sections.len);
+    const term_iter_present = alloc.alloc(bool, sections.len) catch |err| {
+        alloc.free(term_iters);
+        return err;
+    };
+    @memset(term_iter_present, false);
     defer {
         for (term_iters, 0..) |*iter, i| {
-            if (reader_present[i]) iter.deinit();
+            if (term_iter_present[i]) iter.deinit();
         }
+        alloc.free(term_iter_present);
         alloc.free(term_iters);
     }
 
@@ -4918,6 +4924,7 @@ pub fn writeMergedInvertedSectionSlotsWithDeletes(
     for (readers, 0..) |*reader, seg_idx| {
         if (!reader_present[seg_idx]) continue;
         term_iters[seg_idx] = try reader.termIterator();
+        term_iter_present[seg_idx] = true;
         current_entries[seg_idx] = try nextTermIteratorEntry(term_iters, seg_idx);
     }
 
@@ -5010,10 +5017,16 @@ pub fn writeMergedInvertedSectionSlotsWithDocMaps(
     }
 
     var term_iters = try alloc.alloc(TermIterator, sections.len);
+    const term_iter_present = alloc.alloc(bool, sections.len) catch |err| {
+        alloc.free(term_iters);
+        return err;
+    };
+    @memset(term_iter_present, false);
     defer {
         for (term_iters, 0..) |*iter, i| {
-            if (reader_present[i]) iter.deinit();
+            if (term_iter_present[i]) iter.deinit();
         }
+        alloc.free(term_iter_present);
         alloc.free(term_iters);
     }
 
@@ -5024,6 +5037,7 @@ pub fn writeMergedInvertedSectionSlotsWithDocMaps(
     for (readers, 0..) |*reader, seg_idx| {
         if (!reader_present[seg_idx]) continue;
         term_iters[seg_idx] = try reader.termIterator();
+        term_iter_present[seg_idx] = true;
         current_entries[seg_idx] = try nextTermIteratorEntry(term_iters, seg_idx);
     }
 
@@ -6227,6 +6241,36 @@ test "merge with inverted doc_count less than segment doc_count" {
     // "root-b" should be remapped from doc 0 in seg2 to doc 4 in merged
     const root_b = reader.lookup("root-b") orelse return error.TestExpectedEqual;
     try std.testing.expectEqual(@as(u32, 1), root_b.docFreq());
+}
+
+test "merged inverted section cleans up partially initialized term iterators" {
+    const alloc = std.testing.allocator;
+
+    var first_builder = InvertedIndexBuilder.init(alloc, .{});
+    defer first_builder.deinit();
+    try first_builder.addDocument(0, &.{.{ .term = "alpha", .freq = 1, .norm = 1 }});
+    const first = try first_builder.build();
+    defer alloc.free(first);
+
+    var second_builder = InvertedIndexBuilder.init(alloc, .{});
+    defer second_builder.deinit();
+    try second_builder.addDocument(0, &.{.{ .term = "beta", .freq = 1, .norm = 1 }});
+    const second = try second_builder.build();
+    defer alloc.free(second);
+
+    const Runner = struct {
+        fn run(failing_alloc: Allocator, first_section: []const u8, second_section: []const u8) !void {
+            const merged = try mergeInvertedSectionSlotsWithDeletes(
+                failing_alloc,
+                &.{ first_section, second_section },
+                &.{ 1, 1 },
+                null,
+                .{},
+            );
+            defer failing_alloc.free(merged);
+        }
+    };
+    try std.testing.checkAllAllocationFailures(alloc, Runner.run, .{ first, second });
 }
 
 test "sparse field postings beyond first chunk survive merge" {

--- a/zig/pkg/antfly/src/storage/db/catalog/index_manager.zig
+++ b/zig/pkg/antfly/src/storage/db/catalog/index_manager.zig
@@ -11600,10 +11600,6 @@ pub const IndexManager = struct {
                 .peak_task_alloc_bytes = @intCast(alloc_stats.peak_bytes),
             };
             errdefer result.deinit(alloc);
-            result.buildPublicationLookup(task_alloc) catch |err| {
-                if (tracking.limit_exceeded or task.deletion_state.budget.denied()) return error.ResourceBudgetExceeded;
-                return err;
-            };
             result.peak_task_alloc_bytes = @intCast(alloc_stats.peak_bytes);
             return result;
         } else |err| switch (err) {
@@ -11645,10 +11641,6 @@ pub const IndexManager = struct {
             .peak_task_alloc_bytes = @intCast(alloc_stats.peak_bytes),
         };
         errdefer result.deinit(alloc);
-        result.buildPublicationLookup(task_alloc) catch |err| {
-            if (tracking.limit_exceeded or task.deletion_state.budget.denied()) return error.ResourceBudgetExceeded;
-            return err;
-        };
         result.peak_task_alloc_bytes = @intCast(alloc_stats.peak_bytes);
         return result;
     }
@@ -12126,15 +12118,15 @@ pub const IndexManager = struct {
         const layout = seg.layoutStats(false);
 
         // Merge working memory is driven by doc renumbering, the largest term
-        // accumulator, compact dictionary/value builders, and the publication
-        // identity table. File-backed output streams separately; heap-backed
-        // output adds its serialized source-sized envelope at the caller.
-        // Keep generous capacity/headroom factors here and enforce the
-        // reservation with the bounded task allocator.
-        // Include the fixed-capacity publication identity table. Ordinal-backed
-        // documents use 32 bytes at the table's <= 50% load factor; retain more
-        // headroom for the less common string-identity fallback.
-        const per_doc_bytes: u64 = if (layout.index_sort_bytes > 0) 224 else 160;
+        // accumulator, and compact dictionary/value builders. File-backed
+        // output streams separately; heap-backed output adds its serialized
+        // source-sized envelope at the caller. The publication identity table
+        // is no longer part of the normal reservation: append-only publication
+        // does not build it, while a rare concurrent-delete publication may
+        // fail its lazy allocation and safely retry the merge. Charging that
+        // O(live documents) table here recreated a hard admission ceiling even
+        // after its eager allocation was removed from execution.
+        const per_doc_bytes: u64 = if (layout.index_sort_bytes > 0) 128 else 64;
         var bytes = try std.math.mul(u64, seg.reader.doc_count, per_doc_bytes);
         bytes = try std.math.add(u64, bytes, try std.math.mul(u64, layout.inverted_term_dict_bytes, 3));
         bytes = try std.math.add(u64, bytes, try std.math.mul(u64, layout.inverted_bloom_bytes, 3));
@@ -12164,7 +12156,7 @@ pub const IndexManager = struct {
     fn textMergePublicationDeletes(
         entry: *TextIndex,
         task: *const TextMergeTask,
-        result: *const TextMergeResult,
+        result: *TextMergeResult,
         deletion_deltas: []const TextMergeDeletionDelta,
     ) !TextMergePublicationDeletes {
         if (deletion_deltas.len != task.source.len) return error.InvalidDeletionSnapshot;
@@ -12177,6 +12169,28 @@ pub const IndexManager = struct {
                 if (maybe_deleted.*) |*deleted| deleted.deinit();
             }
             publication_alloc.free(output_deleted);
+        }
+
+        // Append-only ingestion is the dominant full-text merge workload. Do
+        // not build an O(live documents) identity table unless a delete raced
+        // the unlocked merge build and publication actually needs to transfer
+        // that tombstone into the replacement. At artifact scale the eager
+        // table could exhaust the bounded merge allocator, permanently defer
+        // later merges, and leave producers retrying merge backpressure.
+        var has_deletion_deltas = false;
+        for (deletion_deltas) |delta| {
+            if (delta.count == 0) continue;
+            has_deletion_deltas = true;
+            break;
+        }
+        if (has_deletion_deltas) {
+            var lookup_alloc_stats = PhaseAllocStats{};
+            var lookup_tracking = PhaseTrackingAllocator.init(publication_alloc, &lookup_alloc_stats);
+            try result.buildPublicationLookup(lookup_tracking.allocator());
+            result.peak_task_alloc_bytes = @max(
+                result.peak_task_alloc_bytes,
+                @as(u64, @intCast(lookup_alloc_stats.peak_bytes)),
+            );
         }
 
         const snap = entry.persistent.acquireSnapshot();
@@ -26486,6 +26500,8 @@ test "text merge task carries concurrent deletes into publication" {
 
     var result = try IndexManager.executeTextMergeTask(alloc, &task);
     defer result.deinit(alloc);
+    try std.testing.expectEqual(@as(usize, 0), result.output_ordinals.len);
+    try std.testing.expectEqual(@as(usize, 0), result.output_ids.len);
     var merged_docs: u32 = 0;
     for (result.prepared_segments) |*prepared| {
         var reader = try segment_mod.SegmentReader.init(alloc, prepared.data.bytes());
@@ -26503,6 +26519,7 @@ test "text merge task carries concurrent deletes into publication" {
     try std.testing.expectEqual(frozen_live_docs, merged_docs);
     const applied = try manager.finishTextMergeTask(&task, &result);
     try std.testing.expect(applied);
+    try std.testing.expect(result.output_ordinals.len + result.output_ids.len > 0);
     const merge_stats = manager.textMergeStats();
     try std.testing.expectEqual(@as(u64, 0), merge_stats.in_flight_merges);
     try std.testing.expectEqual(@as(u64, 0), merge_stats.in_flight_segments);
@@ -26977,8 +26994,13 @@ test "text merge task records input and output bytes" {
 
     var result = try IndexManager.executeTextMergeTask(alloc, &task);
     defer result.deinit(alloc);
+    // Append-only merges do not pay for a document-sized publication lookup.
+    try std.testing.expectEqual(@as(usize, 0), result.output_ordinals.len);
+    try std.testing.expectEqual(@as(usize, 0), result.output_ids.len);
     const expected_output = IndexManager.textMergeResultOutputStats(&result);
     try std.testing.expect(try manager.finishTextMergeTask(&task, &result));
+    try std.testing.expectEqual(@as(usize, 0), result.output_ordinals.len);
+    try std.testing.expectEqual(@as(usize, 0), result.output_ids.len);
 
     const stats = manager.textMergeStats();
     try std.testing.expectEqual(@as(u64, 1), stats.completed_merges);

--- a/zig/pkg/antfly/src/storage/db/catalog/index_manager.zig
+++ b/zig/pkg/antfly/src/storage/db/catalog/index_manager.zig
@@ -366,7 +366,13 @@ const PhaseTrackingAllocator = struct {
 const TextMergeBudgetAllocator = struct {
     backing: Allocator,
     reservation: ?resource_manager_mod.Reservation,
+    /// All bytes competing inside the reservation, including persistent
+    /// publication work temporarily charged through `chargeExternal`.
     live_bytes: std.atomic.Value(usize) = .init(0),
+    /// Task-owned allocations only. Keep this separate from `live_bytes` so
+    /// operational peak telemetry is not inflated by estimated external work.
+    task_live_bytes: std.atomic.Value(usize) = .init(0),
+    peak_task_live_bytes: std.atomic.Value(usize) = .init(0),
     budget_denied: std.atomic.Value(bool) = .init(false),
 
     fn init(backing: Allocator, reservation: ?resource_manager_mod.Reservation) TextMergeBudgetAllocator {
@@ -377,6 +383,8 @@ const TextMergeBudgetAllocator = struct {
     }
 
     fn deinit(self: *TextMergeBudgetAllocator) void {
+        std.debug.assert(self.live_bytes.load(.acquire) == 0);
+        std.debug.assert(self.task_live_bytes.load(.acquire) == 0);
         if (self.reservation) |*reservation| reservation.release();
         self.* = undefined;
     }
@@ -397,16 +405,18 @@ const TextMergeBudgetAllocator = struct {
         return self.budget_denied.load(.acquire);
     }
 
-    /// Task-owned and externally charged bytes which are live inside the
-    /// admitted merge reservation.
+    /// Task-owned and externally charged bytes live inside the admitted merge
+    /// reservation. This is the enforcement ledger, not task telemetry.
     fn liveBytes(self: *const TextMergeBudgetAllocator) usize {
         return self.live_bytes.load(.acquire);
     }
 
-    fn liveBytesExcludingExternal(self: *const TextMergeBudgetAllocator, external_bytes: usize) usize {
-        const live_bytes = self.liveBytes();
-        std.debug.assert(live_bytes >= external_bytes);
-        return live_bytes - external_bytes;
+    fn taskLiveBytes(self: *const TextMergeBudgetAllocator) usize {
+        return self.task_live_bytes.load(.acquire);
+    }
+
+    fn peakTaskLiveBytes(self: *const TextMergeBudgetAllocator) usize {
+        return self.peak_task_live_bytes.load(.acquire);
     }
 
     /// Account allocations which must be owned by the persistent index's
@@ -420,7 +430,7 @@ const TextMergeBudgetAllocator = struct {
     }
 
     fn releaseExternal(self: *TextMergeBudgetAllocator, bytes: usize) void {
-        self.releaseBytes(bytes);
+        self.releaseReservedBytes(bytes);
     }
 
     fn reserveGrowth(self: *TextMergeBudgetAllocator, bytes: usize) bool {
@@ -439,49 +449,73 @@ const TextMergeBudgetAllocator = struct {
         }
     }
 
-    fn releaseBytes(self: *TextMergeBudgetAllocator, bytes: usize) void {
+    fn releaseReservedBytes(self: *TextMergeBudgetAllocator, bytes: usize) void {
         if (bytes == 0) return;
         const previous = self.live_bytes.fetchSub(bytes, .acq_rel);
         std.debug.assert(previous >= bytes);
     }
 
+    fn noteTaskGrowth(self: *TextMergeBudgetAllocator, bytes: usize) void {
+        if (bytes == 0) return;
+        const previous = self.task_live_bytes.fetchAdd(bytes, .acq_rel);
+        const current = previous + bytes;
+        var peak = self.peak_task_live_bytes.load(.acquire);
+        while (current > peak) {
+            peak = self.peak_task_live_bytes.cmpxchgWeak(peak, current, .acq_rel, .acquire) orelse return;
+        }
+    }
+
+    fn reserveTaskGrowth(self: *TextMergeBudgetAllocator, bytes: usize) bool {
+        if (!self.reserveGrowth(bytes)) return false;
+        self.noteTaskGrowth(bytes);
+        return true;
+    }
+
+    fn releaseTaskBytes(self: *TextMergeBudgetAllocator, bytes: usize) void {
+        if (bytes == 0) return;
+        const previous = self.task_live_bytes.fetchSub(bytes, .acq_rel);
+        std.debug.assert(previous >= bytes);
+        self.releaseReservedBytes(bytes);
+    }
+
     fn alloc(ctx: *anyopaque, len: usize, alignment: std.mem.Alignment, ret_addr: usize) ?[*]u8 {
         const self: *TextMergeBudgetAllocator = @ptrCast(@alignCast(ctx));
-        if (!self.reserveGrowth(len)) return null;
-        return self.backing.rawAlloc(len, alignment, ret_addr) orelse {
-            self.releaseBytes(len);
+        if (!self.reserveTaskGrowth(len)) return null;
+        const ptr = self.backing.rawAlloc(len, alignment, ret_addr) orelse {
+            self.releaseTaskBytes(len);
             return null;
         };
+        return ptr;
     }
 
     fn resize(ctx: *anyopaque, memory: []u8, alignment: std.mem.Alignment, new_len: usize, ret_addr: usize) bool {
         const self: *TextMergeBudgetAllocator = @ptrCast(@alignCast(ctx));
         const growth = new_len -| memory.len;
-        if (growth > 0 and !self.reserveGrowth(growth)) return false;
+        if (growth > 0 and !self.reserveTaskGrowth(growth)) return false;
         if (!self.backing.rawResize(memory, alignment, new_len, ret_addr)) {
-            if (growth > 0) self.releaseBytes(growth);
+            if (growth > 0) self.releaseTaskBytes(growth);
             return false;
         }
-        if (new_len < memory.len) self.releaseBytes(memory.len - new_len);
+        if (new_len < memory.len) self.releaseTaskBytes(memory.len - new_len);
         return true;
     }
 
     fn remap(ctx: *anyopaque, memory: []u8, alignment: std.mem.Alignment, new_len: usize, ret_addr: usize) ?[*]u8 {
         const self: *TextMergeBudgetAllocator = @ptrCast(@alignCast(ctx));
         const growth = new_len -| memory.len;
-        if (growth > 0 and !self.reserveGrowth(growth)) return null;
+        if (growth > 0 and !self.reserveTaskGrowth(growth)) return null;
         const ptr = self.backing.rawRemap(memory, alignment, new_len, ret_addr) orelse {
-            if (growth > 0) self.releaseBytes(growth);
+            if (growth > 0) self.releaseTaskBytes(growth);
             return null;
         };
-        if (new_len < memory.len) self.releaseBytes(memory.len - new_len);
+        if (new_len < memory.len) self.releaseTaskBytes(memory.len - new_len);
         return ptr;
     }
 
     fn free(ctx: *anyopaque, memory: []u8, alignment: std.mem.Alignment, ret_addr: usize) void {
         const self: *TextMergeBudgetAllocator = @ptrCast(@alignCast(ctx));
         self.backing.rawFree(memory, alignment, ret_addr);
-        self.releaseBytes(memory.len);
+        self.releaseTaskBytes(memory.len);
     }
 };
 
@@ -522,13 +556,23 @@ test "text merge task allocator tracks live and external bytes without reservati
     const task_bytes = try alloc.alloc(u8, 128);
     defer alloc.free(task_bytes);
     try std.testing.expectEqual(@as(usize, 128), budget.liveBytes());
+    try std.testing.expectEqual(@as(usize, 128), budget.taskLiveBytes());
+    try std.testing.expectEqual(@as(usize, 128), budget.peakTaskLiveBytes());
 
     const external_charge = try budget.chargeExternal(64);
     try std.testing.expectEqual(@as(usize, 192), budget.liveBytes());
-    try std.testing.expectEqual(@as(usize, 128), budget.liveBytesExcludingExternal(external_charge));
+    try std.testing.expectEqual(@as(usize, 128), budget.taskLiveBytes());
+    try std.testing.expectEqual(@as(usize, 128), budget.peakTaskLiveBytes());
 
     budget.releaseExternal(external_charge);
     try std.testing.expectEqual(@as(usize, 128), budget.liveBytes());
+
+    const transient = try alloc.alloc(u8, 256);
+    try std.testing.expectEqual(@as(usize, 384), budget.taskLiveBytes());
+    try std.testing.expectEqual(@as(usize, 384), budget.peakTaskLiveBytes());
+    alloc.free(transient);
+    try std.testing.expectEqual(@as(usize, 128), budget.taskLiveBytes());
+    try std.testing.expectEqual(@as(usize, 384), budget.peakTaskLiveBytes());
 }
 
 pub const TextMemoryAttributionStats = struct {
@@ -1528,18 +1572,17 @@ pub const IndexManager = struct {
         prepared_owner: ?*persistent_mod.PersistentIndex = null,
         output_ordinals: []OrdinalSlot = &.{},
         output_ids: []IdSlot = &.{},
-        /// Stable allocator behind the build-scoped tracking wrapper. Result
-        /// storage must be released before the owning merge task is destroyed.
+        publication_lookup_built: bool = false,
+        /// Stable task allocator. Result storage must be released before the
+        /// owning merge task is destroyed.
         owned_alloc: ?Allocator = null,
         elapsed_ns: u64 = 0,
-        /// Peak bytes allocated through the merge task allocator. File-backed
-        /// and heap-backed builders both run through this allocator.
+        /// Exact high-water mark of task-owned bytes from task creation through
+        /// publication. Persistent publication charges are excluded.
         peak_task_alloc_bytes: u64 = 0,
 
-        // Lookup storage is allocated through the task's tracking wrapper.
-        // That wrapper delegates raw allocations unchanged to the backing
-        // allocator, so detached result ownership is released through `alloc`
-        // in deinit after the stack-scoped tracker has recorded its peak.
+        // Lookup storage uses the stable task allocator because it survives
+        // the off-lock preparation phase until atomic publication.
         fn buildPublicationLookup(self: *TextMergeResult, alloc: Allocator) !void {
             const output_count = if (self.prepared_segments.len > 0) self.prepared_segments.len else self.segments.len;
             var ordinal_count: usize = 0;
@@ -1593,6 +1636,7 @@ pub const IndexManager = struct {
             }
             self.output_ordinals = ordinals;
             self.output_ids = ids;
+            self.publication_lookup_built = true;
         }
 
         fn outputForOrdinal(self: *const TextMergeResult, identity: u32) ?OutputLocation {
@@ -9061,7 +9105,17 @@ pub const IndexManager = struct {
                 else => return err,
             };
             defer result.deinit(self.alloc);
-            _ = try self.finishTextMergeTask(&task, &result);
+            while (true) {
+                _ = self.finishTextMergeTask(&task, &result) catch |err| {
+                    if (err != error.TextMergePublicationLookupRequired) return err;
+                    // This synchronous scheduler does not acquire the runtime's
+                    // database-wide apply lock. Prepare outside IndexManager's
+                    // short per-index publication critical section and retry.
+                    try prepareTextMergeTaskPublicationLookup(&task, &result);
+                    continue;
+                };
+                break;
+            }
             completed += 1;
         }
         return completed;
@@ -11602,11 +11656,9 @@ pub const IndexManager = struct {
         const started_ns = platform_time.monotonicNs();
         defer task.discardSourceCleanPages();
         logTextMergeTaskMemory("before", task, 0);
-        var alloc_stats = PhaseAllocStats{};
-        var tracking = PhaseTrackingAllocator.init(task.mergeAllocator(), &alloc_stats);
-        const task_alloc = tracking.allocator();
+        const task_alloc = task.mergeAllocator();
         const deleted_docs = task_alloc.alloc(?roaring.RoaringBitmap, task.source.len) catch |err| {
-            if (tracking.limit_exceeded or task.deletion_state.budget.denied()) return error.ResourceBudgetExceeded;
+            if (task.deletion_state.budget.denied()) return error.ResourceBudgetExceeded;
             return err;
         };
         defer task_alloc.free(deleted_docs);
@@ -11629,19 +11681,19 @@ pub const IndexManager = struct {
                 .prepared_owner = task.persistent,
                 .owned_alloc = task.mergeAllocator(),
                 .elapsed_ns = platform_time.monotonicNs() -| started_ns,
-                .peak_task_alloc_bytes = @intCast(alloc_stats.peak_bytes),
+                .peak_task_alloc_bytes = @intCast(task.deletion_state.budget.peakTaskLiveBytes()),
             };
             errdefer result.deinit(alloc);
-            result.peak_task_alloc_bytes = @intCast(alloc_stats.peak_bytes);
             return result;
         } else |err| switch (err) {
             error.EmptySegment => return .{
                 .segments = &.{},
                 .elapsed_ns = platform_time.monotonicNs() -| started_ns,
+                .peak_task_alloc_bytes = @intCast(task.deletion_state.budget.peakTaskLiveBytes()),
             },
             error.Unsupported => {},
             else => {
-                if (tracking.limit_exceeded or task.deletion_state.budget.denied()) return error.ResourceBudgetExceeded;
+                if (task.deletion_state.budget.denied()) return error.ResourceBudgetExceeded;
                 if (builtin.os.tag != .freestanding) {
                     std.log.err("scheduled text merge file-backed build failed index={s}: {s}", .{ task.index_name, @errorName(err) });
                 }
@@ -11649,14 +11701,14 @@ pub const IndexManager = struct {
             },
         }
 
-        const merged = merger_mod.mergeSegmentsBounded(tracking.allocator(), task.snapshot, task.merge_indices, .{
+        const merged = merger_mod.mergeSegmentsBounded(task_alloc, task.snapshot, task.merge_indices, .{
             .target_segment_bytes = @intCast(activeTextMergePolicy().max_segment_size),
             .deleted_docs = deleted_docs,
         }) catch |err| {
-            if (tracking.limit_exceeded or task.deletion_state.budget.denied()) return error.ResourceBudgetExceeded;
+            if (task.deletion_state.budget.denied()) return error.ResourceBudgetExceeded;
             if (err == error.EmptySegment) return .{
                 .elapsed_ns = platform_time.monotonicNs() -| started_ns,
-                .peak_task_alloc_bytes = @intCast(alloc_stats.peak_bytes),
+                .peak_task_alloc_bytes = @intCast(task.deletion_state.budget.peakTaskLiveBytes()),
             };
             if (builtin.os.tag != .freestanding) {
                 std.log.err("scheduled text merge failed index={s}: {s}", .{ task.index_name, @errorName(err) });
@@ -11670,11 +11722,25 @@ pub const IndexManager = struct {
             .segments = merged,
             .owned_alloc = task.mergeAllocator(),
             .elapsed_ns = platform_time.monotonicNs() -| started_ns,
-            .peak_task_alloc_bytes = @intCast(alloc_stats.peak_bytes),
+            .peak_task_alloc_bytes = @intCast(task.deletion_state.budget.peakTaskLiveBytes()),
         };
         errdefer result.deinit(alloc);
-        result.peak_task_alloc_bytes = @intCast(alloc_stats.peak_bytes);
         return result;
+    }
+
+    /// Build the document-identity lookup required to reconcile deletions
+    /// which commit after the merge snapshot. The runtime calls this only
+    /// after publication reports that a lookup is necessary, and crucially
+    /// does so without holding the database-wide apply lock.
+    pub fn prepareTextMergeTaskPublicationLookup(task: *const TextMergeTask, result: *TextMergeResult) !void {
+        if (result.publication_lookup_built) return;
+        result.buildPublicationLookup(task.mergeAllocator()) catch |err| {
+            return task.deletion_state.allocationError(err);
+        };
+        result.peak_task_alloc_bytes = @max(
+            result.peak_task_alloc_bytes,
+            @as(u64, @intCast(task.deletion_state.budget.peakTaskLiveBytes())),
+        );
     }
 
     fn logTextMergeTaskMemory(label: []const u8, task: *const TextMergeTask, output_bytes: u64) void {
@@ -11699,7 +11765,8 @@ pub const IndexManager = struct {
     }
 
     pub fn finishTextMergeTask(self: *IndexManager, task: *const TextMergeTask, result: *TextMergeResult) !bool {
-        defer self.completeTextMergeTaskTracking(task);
+        var retire_task = true;
+        defer if (retire_task) self.completeTextMergeTaskTracking(task);
 
         const entry = self.textIndexEntry(task.index_name) orelse return false;
         if (!self.text_merge_scheduler.taskInFlight(task.index_name, task.source, task.deletion_state)) {
@@ -11730,12 +11797,25 @@ pub const IndexManager = struct {
         }
         var merge_delta_locked = true;
         defer if (merge_delta_locked) entry.merge_delta_mutex.unlock();
+        var has_deletion_deltas = false;
+        for (task.deletion_state.deltas) |delta| {
+            if (delta.count == 0) continue;
+            has_deletion_deltas = true;
+            break;
+        }
+        if (has_deletion_deltas and !result.publication_lookup_built) {
+            // Do not scan the entire merge output while the caller holds the
+            // database-wide apply lock. Preserve task registration so the
+            // runtime can prepare the lookup off-lock and retry publication.
+            retire_task = false;
+            return error.TextMergePublicationLookupRequired;
+        }
         const publication_external_bytes = estimateTextMergePublicationExternalBytes(entry, task, result) catch |err| {
             return task.deletion_state.allocationError(err);
         };
         const publication_external_charge = try task.deletion_state.budget.chargeExternal(publication_external_bytes);
         defer task.deletion_state.budget.releaseExternal(publication_external_charge);
-        var publication_deletes = textMergePublicationDeletes(entry, task, result, publication_external_charge, task.deletion_state.deltas) catch |err| {
+        var publication_deletes = textMergePublicationDeletes(entry, task, result, task.deletion_state.deltas) catch |err| {
             return task.deletion_state.allocationError(err);
         };
         defer publication_deletes.deinit(task.mergeAllocator());
@@ -12000,9 +12080,9 @@ pub const IndexManager = struct {
             // oversized exception would account the estimate without actually
             // bounding the live working set.
             .strict => try manager.reserve(.text_merge_buffers, reservation_bytes),
-            // Scheduled tasks execute through PhaseTrackingAllocator. Permit
-            // one task up to 2x the normal hard limit: ResourceManager keeps it
-            // exclusive and the task allocator enforces the same live cap.
+            // Permit one scheduled task up to 2x the normal hard limit:
+            // ResourceManager keeps it exclusive and the task's shared budget
+            // allocator enforces the same live cap through publication.
             .bounded_task => try manager.reserveBoundedOversizedSingle(.text_merge_buffers, reservation_bytes, 2),
         };
     }
@@ -12189,7 +12269,6 @@ pub const IndexManager = struct {
         entry: *TextIndex,
         task: *const TextMergeTask,
         result: *TextMergeResult,
-        publication_external_charge: usize,
         deletion_deltas: []const TextMergeDeletionDelta,
     ) !TextMergePublicationDeletes {
         if (deletion_deltas.len != task.source.len) return error.InvalidDeletionSnapshot;
@@ -12204,34 +12283,13 @@ pub const IndexManager = struct {
             publication_alloc.free(output_deleted);
         }
 
-        // Append-only ingestion is the dominant full-text merge workload. Do
-        // not build an O(live documents) identity table unless a delete raced
-        // the unlocked merge build and publication actually needs to transfer
-        // that tombstone into the replacement. At artifact scale the eager
-        // table could exhaust the bounded merge allocator, permanently defer
-        // later merges, and leave producers retrying merge backpressure.
-        var has_deletion_deltas = false;
+        // Publication requested the O(live documents) lookup only when a
+        // delete raced the unlocked build, and the runtime prepared it without
+        // holding the database-wide apply lock.
         for (deletion_deltas) |delta| {
             if (delta.count == 0) continue;
-            has_deletion_deltas = true;
+            std.debug.assert(result.publication_lookup_built);
             break;
-        }
-        if (has_deletion_deltas) {
-            // The merge output and task state remain live while publication
-            // constructs this lazy identity lookup. Seed the phase after the
-            // output bitmap array is allocated, excluding only the persistent
-            // publication envelope charged to this same budget.
-            const publication_task_live_bytes = task.deletion_state.budget.liveBytesExcludingExternal(publication_external_charge);
-            var lookup_alloc_stats = PhaseAllocStats{
-                .current_bytes = publication_task_live_bytes,
-                .peak_bytes = publication_task_live_bytes,
-            };
-            var lookup_tracking = PhaseTrackingAllocator.init(publication_alloc, &lookup_alloc_stats);
-            try result.buildPublicationLookup(lookup_tracking.allocator());
-            result.peak_task_alloc_bytes = @max(
-                result.peak_task_alloc_bytes,
-                @as(u64, @intCast(lookup_alloc_stats.peak_bytes)),
-            );
         }
 
         const snap = entry.persistent.acquireSnapshot();
@@ -12266,13 +12324,12 @@ pub const IndexManager = struct {
             }
         }
 
-        // Roaring bitmaps retain the stable task allocator rather than the
-        // stack-scoped phase wrapper. Sample the exact task ledger after they
-        // are built so their live bytes overlap the retained identity lookup
-        // in the completed-merge peak, while excluding persistent publication.
+        // The shared allocator high-water mark includes task creation, merge
+        // build, the off-lock lookup, and publication bitmaps while excluding
+        // persistent publication charges by construction.
         result.peak_task_alloc_bytes = @max(
             result.peak_task_alloc_bytes,
-            @as(u64, @intCast(task.deletion_state.budget.liveBytesExcludingExternal(publication_external_charge))),
+            @as(u64, @intCast(task.deletion_state.budget.peakTaskLiveBytes())),
         );
 
         return .{
@@ -26594,6 +26651,19 @@ test "text merge task carries concurrent deletes into publication" {
     defer task.mergeAllocator().free(telemetry_probe);
     const publication_task_live_bytes = task.deletion_state.budget.liveBytes();
     try std.testing.expect(publication_task_live_bytes > build_peak);
+    // Publication must never perform the document-sized scan while its caller
+    // holds the database apply lock. It preserves the in-flight task and asks
+    // the runtime to prepare the lookup off-lock instead.
+    try std.testing.expectError(
+        error.TextMergePublicationLookupRequired,
+        manager.finishTextMergeTask(&task, &result),
+    );
+    try std.testing.expectEqual(@as(usize, 0), result.output_ordinals.len);
+    try std.testing.expectEqual(@as(usize, 0), result.output_ids.len);
+    try std.testing.expectEqual(@as(u64, 1), manager.textMergeStats().in_flight_merges);
+
+    try IndexManager.prepareTextMergeTaskPublicationLookup(&task, &result);
+    try std.testing.expect(result.publication_lookup_built);
     const applied = try manager.finishTextMergeTask(&task, &result);
     try std.testing.expect(applied);
     try std.testing.expect(result.output_ordinals.len + result.output_ids.len > 0);

--- a/zig/pkg/antfly/src/storage/db/catalog/index_manager.zig
+++ b/zig/pkg/antfly/src/storage/db/catalog/index_manager.zig
@@ -397,11 +397,16 @@ const TextMergeBudgetAllocator = struct {
         return self.budget_denied.load(.acquire);
     }
 
-    /// Task-owned bytes which are live inside the admitted merge reservation.
-    /// Capture this before charging persistent publication work when reporting
-    /// the task allocator's overlapping publication peak.
+    /// Task-owned and externally charged bytes which are live inside the
+    /// admitted merge reservation.
     fn liveBytes(self: *const TextMergeBudgetAllocator) usize {
         return self.live_bytes.load(.acquire);
+    }
+
+    fn liveBytesExcludingExternal(self: *const TextMergeBudgetAllocator, external_bytes: usize) usize {
+        const live_bytes = self.liveBytes();
+        std.debug.assert(live_bytes >= external_bytes);
+        return live_bytes - external_bytes;
     }
 
     /// Account allocations which must be owned by the persistent index's
@@ -419,8 +424,11 @@ const TextMergeBudgetAllocator = struct {
     }
 
     fn reserveGrowth(self: *TextMergeBudgetAllocator, bytes: usize) bool {
-        if (bytes == 0 or self.reservation == null) return true;
-        const limit = std.math.cast(usize, self.reservation.?.bytes) orelse std.math.maxInt(usize);
+        if (bytes == 0) return true;
+        const limit = if (self.reservation) |reservation|
+            std.math.cast(usize, reservation.bytes) orelse std.math.maxInt(usize)
+        else
+            std.math.maxInt(usize);
         var live = self.live_bytes.load(.acquire);
         while (true) {
             if (bytes > limit -| live) {
@@ -432,7 +440,7 @@ const TextMergeBudgetAllocator = struct {
     }
 
     fn releaseBytes(self: *TextMergeBudgetAllocator, bytes: usize) void {
-        if (bytes == 0 or self.reservation == null) return;
+        if (bytes == 0) return;
         const previous = self.live_bytes.fetchSub(bytes, .acq_rel);
         std.debug.assert(previous >= bytes);
     }
@@ -504,6 +512,23 @@ test "text merge bounded task allocator enforces live reservation" {
     alloc.free(second);
     try std.testing.expectEqual(@as(usize, 40), stats.current_bytes);
     try std.testing.expectEqual(@as(usize, 64), stats.peak_bytes);
+}
+
+test "text merge task allocator tracks live and external bytes without reservation" {
+    var budget = TextMergeBudgetAllocator.init(std.testing.allocator, null);
+    defer budget.deinit();
+    const alloc = budget.allocator();
+
+    const task_bytes = try alloc.alloc(u8, 128);
+    defer alloc.free(task_bytes);
+    try std.testing.expectEqual(@as(usize, 128), budget.liveBytes());
+
+    const external_charge = try budget.chargeExternal(64);
+    try std.testing.expectEqual(@as(usize, 192), budget.liveBytes());
+    try std.testing.expectEqual(@as(usize, 128), budget.liveBytesExcludingExternal(external_charge));
+
+    budget.releaseExternal(external_charge);
+    try std.testing.expectEqual(@as(usize, 128), budget.liveBytes());
 }
 
 pub const TextMemoryAttributionStats = struct {
@@ -11705,13 +11730,12 @@ pub const IndexManager = struct {
         }
         var merge_delta_locked = true;
         defer if (merge_delta_locked) entry.merge_delta_mutex.unlock();
-        const publication_task_live_bytes = task.deletion_state.budget.liveBytes();
         const publication_external_bytes = estimateTextMergePublicationExternalBytes(entry, task, result) catch |err| {
             return task.deletion_state.allocationError(err);
         };
         const publication_external_charge = try task.deletion_state.budget.chargeExternal(publication_external_bytes);
         defer task.deletion_state.budget.releaseExternal(publication_external_charge);
-        var publication_deletes = textMergePublicationDeletes(entry, task, result, publication_task_live_bytes, task.deletion_state.deltas) catch |err| {
+        var publication_deletes = textMergePublicationDeletes(entry, task, result, publication_external_charge, task.deletion_state.deltas) catch |err| {
             return task.deletion_state.allocationError(err);
         };
         defer publication_deletes.deinit(task.mergeAllocator());
@@ -12165,7 +12189,7 @@ pub const IndexManager = struct {
         entry: *TextIndex,
         task: *const TextMergeTask,
         result: *TextMergeResult,
-        publication_task_live_bytes: usize,
+        publication_external_charge: usize,
         deletion_deltas: []const TextMergeDeletionDelta,
     ) !TextMergePublicationDeletes {
         if (deletion_deltas.len != task.source.len) return error.InvalidDeletionSnapshot;
@@ -12194,9 +12218,10 @@ pub const IndexManager = struct {
         }
         if (has_deletion_deltas) {
             // The merge output and task state remain live while publication
-            // constructs this lazy identity lookup. Seed the phase with that
-            // live baseline so telemetry reports the real overlapping peak,
-            // not merely the larger of two incorrectly disjoint phases.
+            // constructs this lazy identity lookup. Seed the phase after the
+            // output bitmap array is allocated, excluding only the persistent
+            // publication envelope charged to this same budget.
+            const publication_task_live_bytes = task.deletion_state.budget.liveBytesExcludingExternal(publication_external_charge);
             var lookup_alloc_stats = PhaseAllocStats{
                 .current_bytes = publication_task_live_bytes,
                 .peak_bytes = publication_task_live_bytes,
@@ -12240,6 +12265,15 @@ pub const IndexManager = struct {
                 try output_deleted[output_idx].?.add(output.doc);
             }
         }
+
+        // Roaring bitmaps retain the stable task allocator rather than the
+        // stack-scoped phase wrapper. Sample the exact task ledger after they
+        // are built so their live bytes overlap the retained identity lookup
+        // in the completed-merge peak, while excluding persistent publication.
+        result.peak_task_alloc_bytes = @max(
+            result.peak_task_alloc_bytes,
+            @as(u64, @intCast(task.deletion_state.budget.liveBytesExcludingExternal(publication_external_charge))),
+        );
 
         return .{
             .source_current = true,

--- a/zig/pkg/antfly/src/storage/db/catalog/index_manager.zig
+++ b/zig/pkg/antfly/src/storage/db/catalog/index_manager.zig
@@ -397,6 +397,13 @@ const TextMergeBudgetAllocator = struct {
         return self.budget_denied.load(.acquire);
     }
 
+    /// Task-owned bytes which are live inside the admitted merge reservation.
+    /// Capture this before charging persistent publication work when reporting
+    /// the task allocator's overlapping publication peak.
+    fn liveBytes(self: *const TextMergeBudgetAllocator) usize {
+        return self.live_bytes.load(.acquire);
+    }
+
     /// Account allocations which must be owned by the persistent index's
     /// allocator (and therefore cannot safely retain this task-local allocator
     /// after publication). The charge remains live across the external work so
@@ -11698,12 +11705,13 @@ pub const IndexManager = struct {
         }
         var merge_delta_locked = true;
         defer if (merge_delta_locked) entry.merge_delta_mutex.unlock();
+        const publication_task_live_bytes = task.deletion_state.budget.liveBytes();
         const publication_external_bytes = estimateTextMergePublicationExternalBytes(entry, task, result) catch |err| {
             return task.deletion_state.allocationError(err);
         };
         const publication_external_charge = try task.deletion_state.budget.chargeExternal(publication_external_bytes);
         defer task.deletion_state.budget.releaseExternal(publication_external_charge);
-        var publication_deletes = textMergePublicationDeletes(entry, task, result, task.deletion_state.deltas) catch |err| {
+        var publication_deletes = textMergePublicationDeletes(entry, task, result, publication_task_live_bytes, task.deletion_state.deltas) catch |err| {
             return task.deletion_state.allocationError(err);
         };
         defer publication_deletes.deinit(task.mergeAllocator());
@@ -12157,6 +12165,7 @@ pub const IndexManager = struct {
         entry: *TextIndex,
         task: *const TextMergeTask,
         result: *TextMergeResult,
+        publication_task_live_bytes: usize,
         deletion_deltas: []const TextMergeDeletionDelta,
     ) !TextMergePublicationDeletes {
         if (deletion_deltas.len != task.source.len) return error.InvalidDeletionSnapshot;
@@ -12184,7 +12193,14 @@ pub const IndexManager = struct {
             break;
         }
         if (has_deletion_deltas) {
-            var lookup_alloc_stats = PhaseAllocStats{};
+            // The merge output and task state remain live while publication
+            // constructs this lazy identity lookup. Seed the phase with that
+            // live baseline so telemetry reports the real overlapping peak,
+            // not merely the larger of two incorrectly disjoint phases.
+            var lookup_alloc_stats = PhaseAllocStats{
+                .current_bytes = publication_task_live_bytes,
+                .peak_bytes = publication_task_live_bytes,
+            };
             var lookup_tracking = PhaseTrackingAllocator.init(publication_alloc, &lookup_alloc_stats);
             try result.buildPublicationLookup(lookup_tracking.allocator());
             result.peak_task_alloc_bytes = @max(
@@ -26414,6 +26430,21 @@ test "text merge task carries concurrent deletes into publication" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 
+    var budgets = resource_manager_mod.Options.defaultBudgets();
+    budgets[@intFromEnum(resource_manager_mod.Slice.text_merge_buffers)] = .{
+        .soft_limit_bytes = 64 * 1024 * 1024,
+        .hard_limit_bytes = 64 * 1024 * 1024,
+    };
+    var policies = resource_manager_mod.Options.defaultPolicies();
+    policies[@intFromEnum(resource_manager_mod.Slice.text_merge_buffers)] = .{
+        .soft_action = .report,
+        .hard_action = .report,
+    };
+    var resource_manager = resource_manager_mod.ResourceManager.init(.{
+        .budgets = budgets,
+        .policies = policies,
+    });
+
     var path_buf: [std.fs.max_path_bytes]u8 = undefined;
     const path = try std.fmt.bufPrint(&path_buf, ".zig-cache/tmp/{s}", .{tmp.sub_path});
     const path_z = try alloc.dupeZ(u8, path);
@@ -26422,7 +26453,9 @@ test "text merge task carries concurrent deletes into publication" {
     var store = try docstore_mod.DocStore.open(alloc, path_z, .{});
     defer store.close();
 
-    var manager = try IndexManager.init(alloc, path);
+    var manager = try IndexManager.initWithOptions(alloc, path, .{
+        .resource_manager = &resource_manager,
+    });
     defer manager.deinit();
     manager.updateRange(.{ .start = "", .end = "" });
 
@@ -26517,9 +26550,20 @@ test "text merge task carries concurrent deletes into publication" {
     // the later tombstone into the replacement rather than reject the useful
     // merge and retry forever under sustained mutation.
     try std.testing.expectEqual(frozen_live_docs, merged_docs);
+    // Keep a known task-local allocation live across publication. The peak
+    // must include this existing working set plus the lazy identity lookup,
+    // rather than treating build and publication as disjoint phases.
+    const build_peak = result.peak_task_alloc_bytes;
+    const telemetry_probe_len = std.math.cast(usize, build_peak +| 4096) orelse
+        return error.TestUnexpectedResult;
+    const telemetry_probe = try task.mergeAllocator().alloc(u8, telemetry_probe_len);
+    defer task.mergeAllocator().free(telemetry_probe);
+    const publication_task_live_bytes = task.deletion_state.budget.liveBytes();
+    try std.testing.expect(publication_task_live_bytes > build_peak);
     const applied = try manager.finishTextMergeTask(&task, &result);
     try std.testing.expect(applied);
     try std.testing.expect(result.output_ordinals.len + result.output_ids.len > 0);
+    try std.testing.expect(result.peak_task_alloc_bytes >= publication_task_live_bytes);
     const merge_stats = manager.textMergeStats();
     try std.testing.expectEqual(@as(u64, 0), merge_stats.in_flight_merges);
     try std.testing.expectEqual(@as(u64, 0), merge_stats.in_flight_segments);

--- a/zig/pkg/antfly/src/storage/db/db.zig
+++ b/zig/pkg/antfly/src/storage/db/db.zig
@@ -80578,6 +80578,8 @@ test "db text merge descriptor admission failures retry without quarantine" {
     defer runtime.deinit();
     defer text_merge_runtime_mod.test_execute_admission_failures_remaining.store(0, .release);
     defer text_merge_runtime_mod.test_finish_admission_failures_remaining.store(0, .release);
+    defer text_merge_runtime_mod.test_finish_lookup_required_remaining.store(0, .release);
+    defer text_merge_runtime_mod.test_lookup_prepare_apply_lock_released.store(false, .release);
 
     text_merge_runtime_mod.test_execute_admission_failures_remaining.store(1, .release);
     try std.testing.expect(!try runtime.runOnce());
@@ -80588,6 +80590,18 @@ test "db text merge descriptor admission failures retry without quarantine" {
 
     text_merge_runtime_mod.test_finish_admission_failures_remaining.store(1, .release);
     try std.testing.expect(!try runtime.runOnce());
+    stats = runtime.stats();
+    try std.testing.expectEqual(@as(u64, 0), stats.failed_merges);
+    try std.testing.expectEqual(@as(u64, 0), stats.quarantined_merges);
+    try std.testing.expectEqual(@as(u64, 0), stats.in_flight_merges);
+
+    // A lookup-required publication keeps the same task registered, prepares
+    // its identity map outside the runtime apply lock, and retries immediately
+    // rather than counting a failure or quarantine.
+    text_merge_runtime_mod.test_lookup_prepare_apply_lock_released.store(false, .release);
+    text_merge_runtime_mod.test_finish_lookup_required_remaining.store(1, .release);
+    try std.testing.expect(try runtime.runOnce());
+    try std.testing.expect(text_merge_runtime_mod.test_lookup_prepare_apply_lock_released.load(.acquire));
     stats = runtime.stats();
     try std.testing.expectEqual(@as(u64, 0), stats.failed_merges);
     try std.testing.expectEqual(@as(u64, 0), stats.quarantined_merges);

--- a/zig/pkg/antfly/src/storage/db/maintenance/text_merge_runtime.zig
+++ b/zig/pkg/antfly/src/storage/db/maintenance/text_merge_runtime.zig
@@ -55,6 +55,8 @@ pub var test_stop_entered: std.atomic.Value(bool) = .init(false);
 pub var test_start_failures_remaining: std.atomic.Value(u32) = .init(0);
 pub var test_execute_admission_failures_remaining: std.atomic.Value(u32) = .init(0);
 pub var test_finish_admission_failures_remaining: std.atomic.Value(u32) = .init(0);
+pub var test_finish_lookup_required_remaining: std.atomic.Value(u32) = .init(0);
+pub var test_lookup_prepare_apply_lock_released: std.atomic.Value(bool) = .init(false);
 pub var test_wait_for_fd_admission: std.atomic.Value(bool) = .init(false);
 pub var test_fd_admission_entered: std.atomic.Value(bool) = .init(false);
 pub var test_fd_admission_canceled: std.atomic.Value(bool) = .init(false);
@@ -416,30 +418,64 @@ pub const TextMergeRuntime = if (builtin.os.tag == .freestanding) struct {
         };
         defer result.deinit(work_alloc);
 
-        lockApplyExclusive(self.apply_mutex);
-        const finish_fd_epoch = self.native_storage_pool.admissionEpoch();
-        _ = finishTextMergeTaskForRuntime(self.index_manager, &task, &result) catch |err| {
-            if (err == error.Canceled) {
-                self.index_manager.cancelTextMergeTask(&task);
+        while (true) {
+            lockApplyExclusive(self.apply_mutex);
+            const finish_fd_epoch = self.native_storage_pool.admissionEpoch();
+            _ = finishTextMergeTaskForRuntime(self.index_manager, &task, &result) catch |err| {
+                if (err == error.TextMergePublicationLookupRequired) {
+                    // A post-snapshot deletion needs an output identity map.
+                    // Release the database-wide apply lock before the O(n)
+                    // scan, then retry the short validate-and-publish phase.
+                    self.apply_mutex.unlockExclusive();
+                    if (builtin.is_test) {
+                        const lock_released = self.apply_mutex.tryLockExclusive();
+                        test_lookup_prepare_apply_lock_released.store(lock_released, .release);
+                        if (lock_released) self.apply_mutex.unlockExclusive();
+                    }
+                    index_manager_mod.IndexManager.prepareTextMergeTaskPublicationLookup(&task, &result) catch |prepare_err| {
+                        lockApplyExclusive(self.apply_mutex);
+                        if (prepare_err == error.Canceled) {
+                            self.index_manager.cancelTextMergeTask(&task);
+                            self.apply_mutex.unlockExclusive();
+                            self.signalProducerAdmissionChanged();
+                            return prepare_err;
+                        }
+                        if (isRecoverableMergeAdmissionError(prepare_err)) {
+                            self.index_manager.cancelTextMergeTask(&task);
+                            self.deferForFdAdmissionError(prepare_err, finish_fd_epoch);
+                            self.apply_mutex.unlockExclusive();
+                            self.signalProducerAdmissionChanged();
+                            return false;
+                        }
+                        self.index_manager.noteTextMergeFailure(&task, prepare_err);
+                        self.apply_mutex.unlockExclusive();
+                        self.signalProducerAdmissionChanged();
+                        return prepare_err;
+                    };
+                    continue;
+                }
+                if (err == error.Canceled) {
+                    self.index_manager.cancelTextMergeTask(&task);
+                    self.apply_mutex.unlockExclusive();
+                    self.signalProducerAdmissionChanged();
+                    return err;
+                }
+                if (isRecoverableMergeAdmissionError(err)) {
+                    self.index_manager.cancelTextMergeTask(&task);
+                    self.deferForFdAdmissionError(err, finish_fd_epoch);
+                    self.apply_mutex.unlockExclusive();
+                    self.signalProducerAdmissionChanged();
+                    return false;
+                }
+                self.index_manager.noteTextMergeFailure(&task, err);
                 self.apply_mutex.unlockExclusive();
                 self.signalProducerAdmissionChanged();
                 return err;
-            }
-            if (isRecoverableMergeAdmissionError(err)) {
-                self.index_manager.cancelTextMergeTask(&task);
-                self.deferForFdAdmissionError(err, finish_fd_epoch);
-                self.apply_mutex.unlockExclusive();
-                self.signalProducerAdmissionChanged();
-                return false;
-            }
-            self.index_manager.noteTextMergeFailure(&task, err);
+            };
             self.apply_mutex.unlockExclusive();
             self.signalProducerAdmissionChanged();
-            return err;
-        };
-        self.apply_mutex.unlockExclusive();
-        self.signalProducerAdmissionChanged();
-        return true;
+            return true;
+        }
     }
 
     pub fn applyBackpressure(self: *TextMergeRuntime) BackpressureOutcome {
@@ -978,6 +1014,9 @@ fn finishTextMergeTaskForRuntime(
     task: *const index_manager_mod.IndexManager.TextMergeTask,
     result: *index_manager_mod.IndexManager.TextMergeResult,
 ) !bool {
+    if (builtin.is_test and consumeTestFailure(&test_finish_lookup_required_remaining)) {
+        return error.TextMergePublicationLookupRequired;
+    }
     if (builtin.is_test and consumeTestFailure(&test_finish_admission_failures_remaining)) {
         return error.PersistentDescriptorAdmissionExhausted;
     }


### PR DESCRIPTION
## Summary

- keep generated artifact children routed by their internal parent-prefixed keys and verify parent co-residency across three shards
- avoid the O(live documents) publication identity lookup for append-only text merges, building it lazily only when a concurrent deletion must be transferred
- remove the unused lookup from normal merge admission estimates so one hot shard can continue merging past the prior ~746k ceiling
- make partially initialized inverted-term iterator cleanup allocation-safe
- isolate the >1M correctness gate in dedicated `ci:scale-tests` CI

## Problem

A three-shard artifact-backed full-text table could stop making progress around 746k indexed chunks on one shard and repeatedly return `TextMergeBackpressureTimeout`. The shared public `af1:chunk:...` prefix was not the routing key: generated child ranges were already co-resident with their parent. The scale ceiling came from eagerly allocating and reserving an O(live documents) publication identity table for every append-only merge. Once that exceeded the bounded text-merge budget, later merges could not gain admission.

The recent 1M VectorDBBench qualification exercises top-level dense/vector writes, not the document extraction -> chunk artifact -> full-text merge path.

## Design

Artifact children remain co-resident with their parent. Parents that span lexical shard ranges distribute their children across those shards; a deliberately skewed parent distribution in the scale gate also drives one shard beyond 750k chunks. Public artifact IDs remain presentation identities rather than routing keys.

## CI

The fast three-shard placement regression stays in normal CI. The >1M gate is marked `scale` and runs in a dedicated single-process workflow:

- daily schedule
- manual dispatch
- same-repository PRs when `ci:scale-tests` is applied

## Validation

- artifact scale E2E: 1,000,304 chunks distributed `833,856 / 83,224 / 83,224`; passed in 25:11 locally
- fast three-shard artifact placement/search E2E passed
- focused merge, publication, reservation, and allocation-failure Zig tests passed
- full Antfly binary build passed
- workflow YAML parsing and `git diff --check` passed