### PR TITLE
inference: require configured execution backend

### DIFF
--- a/zig/pkg/inference/src/backends/backends.zig
+++ b/zig/pkg/inference/src/backends/backends.zig
@@ -360,8 +360,17 @@ pub const SessionManager = struct {
     /// different valid required backend makes the fast path ineligible.
     pub fn allowsDirectBackend(self: *const SessionManager, backend: BackendType) !bool {
         if (self.required_backend_invalid) return error.InvalidRequiredBackend;
+        if (self.required_backend) |required| {
+            if (!required.supportsDirectSessionLoad()) return error.RequiredBackendUnavailable;
+        }
+        return self.allowsBackend(backend);
+    }
+
+    /// Whether a backend-specific execution path is compatible with the
+    /// process-level required backend, including compiled artifact runtimes.
+    pub fn allowsBackend(self: *const SessionManager, backend: BackendType) !bool {
+        if (self.required_backend_invalid) return error.InvalidRequiredBackend;
         const required = self.required_backend orelse return true;
-        if (!required.supportsDirectSessionLoad()) return error.RequiredBackendUnavailable;
         return required == backend;
     }
 
@@ -636,6 +645,8 @@ test "required backend gates backend-specific fast paths" {
     manager.required_backend_invalid = false;
     try std.testing.expect(try manager.allowsDirectBackend(.cuda));
     try std.testing.expect(!try manager.allowsDirectBackend(.onnx));
+    try std.testing.expect(try manager.allowsBackend(.cuda));
+    try std.testing.expect(!try manager.allowsBackend(.onnx));
 
     manager.required_backend = null;
     try std.testing.expect(try manager.allowsDirectBackend(.onnx));

--- a/zig/pkg/inference/src/backends/backends.zig
+++ b/zig/pkg/inference/src/backends/backends.zig
@@ -348,6 +348,10 @@ pub const SessionManager = struct {
         required_buf: *[1]BackendType,
     ) ![]const BackendType {
         if (self.required_backend_invalid) return error.InvalidRequiredBackend;
+        if (self.required_backend) |backend| {
+            if (!backend.supportsDirectSessionLoad())
+                return error.RequiredBackendUnavailable;
+        }
         return enforceRequiredBackend(self.required_backend, fallback_backends, required_buf);
     }
 

--- a/zig/pkg/inference/src/backends/backends.zig
+++ b/zig/pkg/inference/src/backends/backends.zig
@@ -120,10 +120,17 @@ test "backend runtime classifies external ONNX CUDA as GPU hosted" {
 
 const backend_order_capacity = std.meta.fields(BackendType).len;
 
+const RequiredBackendConfig = struct {
+    backend: ?BackendType = null,
+    invalid: bool = false,
+};
+
 /// SessionManager selects the best available backend and creates sessions.
 pub const SessionManager = struct {
     allocator: std.mem.Allocator,
     preferred_backends: []const BackendType,
+    required_backend: ?BackendType,
+    required_backend_invalid: bool,
     graph_runtime_strategy: ?graph_runtime_mod.Strategy = null,
     kernel_jit: kernel_jit_mod.Config = .{},
     kernel_jit_load_context: kernel_jit_mod.LoadContext = .dynamic,
@@ -140,16 +147,22 @@ pub const SessionManager = struct {
     io: ?std.Io = null,
 
     pub fn init(allocator: std.mem.Allocator) SessionManager {
+        const required = requiredBackendFromEnv();
         return .{
             .allocator = allocator,
             .preferred_backends = configuredPreferredBackends(),
+            .required_backend = required.backend,
+            .required_backend_invalid = required.invalid,
         };
     }
 
     pub fn initWithIo(allocator: std.mem.Allocator, io: std.Io) SessionManager {
+        const required = requiredBackendFromEnv();
         return .{
             .allocator = allocator,
             .preferred_backends = configuredPreferredBackends(),
+            .required_backend = required.backend,
+            .required_backend_invalid = required.invalid,
             .io = io,
         };
     }
@@ -174,14 +187,21 @@ pub const SessionManager = struct {
         model_path: []const u8,
         shared_backend_ctx: ?*imported_onnx_session.SharedBackendContext,
     ) !Session {
+        if (self.required_backend_invalid) return error.InvalidRequiredBackend;
         var manifest = manifest_mod.loadFromDir(self.allocator, model_path) catch null;
         defer if (manifest) |*m| m.deinit();
         var effective_buf: [backend_order_capacity]BackendType = undefined;
-        const effective_backends = effectiveBackendOrder(
+        const fallback_backends = effectiveBackendOrder(
             self.allocator,
             &effective_buf,
             self.preferred_backends,
             if (manifest) |m| m else null,
+        );
+        var required_buf: [1]BackendType = undefined;
+        const effective_backends = enforceRequiredBackend(
+            self.required_backend,
+            fallback_backends,
+            &required_buf,
         );
 
         // Every backend below logs its failure and moves on, so without this the caller
@@ -315,6 +335,7 @@ pub const SessionManager = struct {
             std.log.info("selected backend {s} for {s}", .{ @tagName(backend), model_path });
             return session;
         }
+        if (self.required_backend != null) return error.RequiredBackendUnavailable;
         if (self.kernel_jit.qualified_profile_path != null or self.kernel_jit.profile_capture_only) return error.KernelJitProfileRequiresMetalBackend;
         if (self.kernel_jit.mode.failClosed()) return error.KernelJitRequiredBackendUnavailable;
         // NoBackendAvailable only when no backend produced a real error.
@@ -345,6 +366,10 @@ pub const SessionManager = struct {
     }
 
     pub fn bestAvailable(self: *const SessionManager) ?BackendType {
+        if (self.required_backend_invalid) return null;
+        if (self.required_backend) |backend| {
+            return if (backend.available() and backend.supportsDirectSessionLoad()) backend else null;
+        }
         if (self.kernel_jit.mode.failClosed()) return self.bestKernelJitBackend();
         for (self.preferred_backends) |backend| {
             if (backend.available() and backend.supportsDirectSessionLoad()) return backend;
@@ -353,6 +378,11 @@ pub const SessionManager = struct {
     }
 
     pub fn bestKernelJitBackend(self: *const SessionManager) ?BackendType {
+        if (self.required_backend_invalid) return null;
+        if (self.required_backend) |backend| {
+            return if (backend.supportsKernelJitSession() and backend.available() and
+                backend.supportsDirectSessionLoad()) backend else null;
+        }
         for (self.preferred_backends) |backend| {
             if (backend.supportsKernelJitSession() and backend.available() and
                 backend.supportsDirectSessionLoad()) return backend;
@@ -500,14 +530,87 @@ fn preferredBackendOverride() ?BackendType {
     const value = std.c.getenv("ANTFLY_INFERENCE_PREFERRED_BACKEND") orelse
         std.c.getenv("TERMITE_PREFERRED_BACKEND") orelse
         return null;
-    const slice = std.mem.span(value);
-    if (std.ascii.eqlIgnoreCase(slice, "auto")) return null;
-    if (std.ascii.eqlIgnoreCase(slice, "onnx")) return .onnx;
-    if (std.ascii.eqlIgnoreCase(slice, "metal")) return .metal;
-    if (std.ascii.eqlIgnoreCase(slice, "pjrt")) return .pjrt;
-    if (std.ascii.eqlIgnoreCase(slice, "cuda")) return .cuda;
-    if (std.ascii.eqlIgnoreCase(slice, "native")) return .native;
+    const backend = parseBackendName(std.mem.span(value), true) orelse return null;
+    return if (backend == .wasm) null else backend;
+}
+
+fn requiredBackendFromEnv() RequiredBackendConfig {
+    if (build_options.enable_wasm or !build_options.link_libc) return .{};
+    const value = std.c.getenv("ANTFLY_INFERENCE_REQUIRED_BACKEND") orelse return .{};
+    return requiredBackendConfigForValue(std.mem.span(value));
+}
+
+fn requiredBackendConfigForValue(value: []const u8) RequiredBackendConfig {
+    return if (parseBackendName(value, false)) |backend|
+        .{ .backend = backend }
+    else
+        .{ .invalid = true };
+}
+
+fn parseBackendName(value: []const u8, allow_auto: bool) ?BackendType {
+    if (allow_auto and std.ascii.eqlIgnoreCase(value, "auto")) return null;
+    if (std.ascii.eqlIgnoreCase(value, "onnx")) return .onnx;
+    if (std.ascii.eqlIgnoreCase(value, "metal")) return .metal;
+    if (std.ascii.eqlIgnoreCase(value, "pjrt")) return .pjrt;
+    if (std.ascii.eqlIgnoreCase(value, "cuda")) return .cuda;
+    if (std.ascii.eqlIgnoreCase(value, "native")) return .native;
+    if (std.ascii.eqlIgnoreCase(value, "wasm")) return .wasm;
     return null;
+}
+
+fn enforceRequiredBackend(
+    required_backend: ?BackendType,
+    fallback_backends: []const BackendType,
+    required_buf: *[1]BackendType,
+) []const BackendType {
+    const backend = required_backend orelse return fallback_backends;
+    required_buf[0] = backend;
+    return required_buf;
+}
+
+test "required backend parser rejects auto and invalid values" {
+    try std.testing.expectEqual(BackendType.cuda, requiredBackendConfigForValue("cuda").backend.?);
+    try std.testing.expectEqual(BackendType.pjrt, requiredBackendConfigForValue("pjrt").backend.?);
+    try std.testing.expectEqual(BackendType.wasm, requiredBackendConfigForValue("wasm").backend.?);
+    try std.testing.expect(requiredBackendConfigForValue("auto").invalid);
+    try std.testing.expect(requiredBackendConfigForValue("bogus").invalid);
+}
+
+test "session manager reads required backend policy from environment" {
+    const expected = requiredBackendFromEnv();
+    const manager = SessionManager.init(std.testing.allocator);
+    try std.testing.expectEqual(expected.backend, manager.required_backend);
+    try std.testing.expectEqual(expected.invalid, manager.required_backend_invalid);
+}
+
+test "required backend replaces every fallback candidate" {
+    var required_buf: [1]BackendType = undefined;
+    const fallback = [_]BackendType{ .native, .onnx, .metal };
+    try std.testing.expectEqualSlices(
+        BackendType,
+        &.{.cuda},
+        enforceRequiredBackend(.cuda, &fallback, &required_buf),
+    );
+    try std.testing.expectEqualSlices(
+        BackendType,
+        &fallback,
+        enforceRequiredBackend(null, &fallback, &required_buf),
+    );
+}
+
+test "invalid required backend fails before model loading" {
+    var manager = SessionManager.init(std.testing.allocator);
+    manager.required_backend = null;
+    manager.required_backend_invalid = true;
+    try std.testing.expectError(error.InvalidRequiredBackend, manager.loadModel("/nonexistent/model"));
+}
+
+test "unavailable required backend does not fall back" {
+    var manager = SessionManager.init(std.testing.allocator);
+    manager.required_backend = .pjrt;
+    manager.required_backend_invalid = false;
+    manager.preferred_backends = &.{.native};
+    try std.testing.expectError(error.RequiredBackendUnavailable, manager.loadModel("/nonexistent/model"));
 }
 
 fn gpuEagerDenseMaxBytes() u64 {

--- a/zig/pkg/inference/src/backends/backends.zig
+++ b/zig/pkg/inference/src/backends/backends.zig
@@ -333,11 +333,11 @@ pub const SessionManager = struct {
             std.log.info("selected backend {s} for {s}", .{ @tagName(backend), model_path });
             return session;
         }
-        if (self.required_backend != null) return error.RequiredBackendUnavailable;
+        if (self.required_backend != null) return backendLoadFailure(self.required_backend, first_err);
         if (self.kernel_jit.qualified_profile_path != null or self.kernel_jit.profile_capture_only) return error.KernelJitProfileRequiresMetalBackend;
         if (self.kernel_jit.mode.failClosed()) return error.KernelJitRequiredBackendUnavailable;
         // NoBackendAvailable only when no backend produced a real error.
-        return first_err orelse error.NoBackendAvailable;
+        return backendLoadFailure(null, first_err);
     }
 
     /// Apply the process-level fail-closed backend policy before callers make
@@ -353,6 +353,16 @@ pub const SessionManager = struct {
                 return error.RequiredBackendUnavailable;
         }
         return enforceRequiredBackend(self.required_backend, fallback_backends, required_buf);
+    }
+
+    /// Whether a backend-specific fast path may bypass normal session loading.
+    /// Invalid or unsupported required policies still fail closed, while a
+    /// different valid required backend makes the fast path ineligible.
+    pub fn allowsDirectBackend(self: *const SessionManager, backend: BackendType) !bool {
+        if (self.required_backend_invalid) return error.InvalidRequiredBackend;
+        const required = self.required_backend orelse return true;
+        if (!required.supportsDirectSessionLoad()) return error.RequiredBackendUnavailable;
+        return required == backend;
     }
 
     fn createImportedOnnxSession(
@@ -581,6 +591,11 @@ fn enforceRequiredBackend(
     return required_buf;
 }
 
+fn backendLoadFailure(required_backend: ?BackendType, first_err: ?anyerror) anyerror {
+    if (required_backend != null) return first_err orelse error.RequiredBackendUnavailable;
+    return first_err orelse error.NoBackendAvailable;
+}
+
 test "required backend parser rejects auto and invalid values" {
     try std.testing.expectEqual(BackendType.cuda, requiredBackendConfigForValue("cuda").backend.?);
     try std.testing.expectEqual(BackendType.pjrt, requiredBackendConfigForValue("pjrt").backend.?);
@@ -615,6 +630,20 @@ test "required backend replaces every fallback candidate" {
     );
 }
 
+test "required backend gates backend-specific fast paths" {
+    var manager = SessionManager.init(std.testing.allocator);
+    manager.required_backend = .cuda;
+    manager.required_backend_invalid = false;
+    try std.testing.expect(try manager.allowsDirectBackend(.cuda));
+    try std.testing.expect(!try manager.allowsDirectBackend(.onnx));
+
+    manager.required_backend = null;
+    try std.testing.expect(try manager.allowsDirectBackend(.onnx));
+
+    manager.required_backend_invalid = true;
+    try std.testing.expectError(error.InvalidRequiredBackend, manager.allowsDirectBackend(.onnx));
+}
+
 test "invalid required backend fails before model loading" {
     var manager = SessionManager.init(std.testing.allocator);
     manager.required_backend = null;
@@ -628,6 +657,17 @@ test "unavailable required backend does not fall back" {
     manager.required_backend_invalid = false;
     manager.preferred_backends = &.{.native};
     try std.testing.expectError(error.RequiredBackendUnavailable, manager.loadModel("/nonexistent/model"));
+}
+
+test "failing required backend preserves its load error" {
+    try std.testing.expectEqual(
+        error.NoTensorStoreFound,
+        backendLoadFailure(.native, error.NoTensorStoreFound),
+    );
+    try std.testing.expectEqual(
+        error.RequiredBackendUnavailable,
+        backendLoadFailure(.cuda, null),
+    );
 }
 
 fn gpuEagerDenseMaxBytes() u64 {

--- a/zig/pkg/inference/src/backends/backends.zig
+++ b/zig/pkg/inference/src/backends/backends.zig
@@ -129,8 +129,8 @@ const RequiredBackendConfig = struct {
 pub const SessionManager = struct {
     allocator: std.mem.Allocator,
     preferred_backends: []const BackendType,
-    required_backend: ?BackendType,
-    required_backend_invalid: bool,
+    required_backend: ?BackendType = null,
+    required_backend_invalid: bool = false,
     graph_runtime_strategy: ?graph_runtime_mod.Strategy = null,
     kernel_jit: kernel_jit_mod.Config = .{},
     kernel_jit_load_context: kernel_jit_mod.LoadContext = .dynamic,
@@ -187,7 +187,6 @@ pub const SessionManager = struct {
         model_path: []const u8,
         shared_backend_ctx: ?*imported_onnx_session.SharedBackendContext,
     ) !Session {
-        if (self.required_backend_invalid) return error.InvalidRequiredBackend;
         var manifest = manifest_mod.loadFromDir(self.allocator, model_path) catch null;
         defer if (manifest) |*m| m.deinit();
         var effective_buf: [backend_order_capacity]BackendType = undefined;
@@ -198,8 +197,7 @@ pub const SessionManager = struct {
             if (manifest) |m| m else null,
         );
         var required_buf: [1]BackendType = undefined;
-        const effective_backends = enforceRequiredBackend(
-            self.required_backend,
+        const effective_backends = try self.requiredBackendCandidates(
             fallback_backends,
             &required_buf,
         );
@@ -340,6 +338,17 @@ pub const SessionManager = struct {
         if (self.kernel_jit.mode.failClosed()) return error.KernelJitRequiredBackendUnavailable;
         // NoBackendAvailable only when no backend produced a real error.
         return first_err orelse error.NoBackendAvailable;
+    }
+
+    /// Apply the process-level fail-closed backend policy before callers make
+    /// backend-specific artifact, compatibility, or resource-admission choices.
+    pub fn requiredBackendCandidates(
+        self: *const SessionManager,
+        fallback_backends: []const BackendType,
+        required_buf: *[1]BackendType,
+    ) ![]const BackendType {
+        if (self.required_backend_invalid) return error.InvalidRequiredBackend;
+        return enforceRequiredBackend(self.required_backend, fallback_backends, required_buf);
     }
 
     fn createImportedOnnxSession(
@@ -584,17 +593,21 @@ test "session manager reads required backend policy from environment" {
 }
 
 test "required backend replaces every fallback candidate" {
+    var manager = SessionManager.init(std.testing.allocator);
+    manager.required_backend = .cuda;
+    manager.required_backend_invalid = false;
     var required_buf: [1]BackendType = undefined;
     const fallback = [_]BackendType{ .native, .onnx, .metal };
     try std.testing.expectEqualSlices(
         BackendType,
         &.{.cuda},
-        enforceRequiredBackend(.cuda, &fallback, &required_buf),
+        try manager.requiredBackendCandidates(&fallback, &required_buf),
     );
+    manager.required_backend = null;
     try std.testing.expectEqualSlices(
         BackendType,
         &fallback,
-        enforceRequiredBackend(null, &fallback, &required_buf),
+        try manager.requiredBackendCandidates(&fallback, &required_buf),
     );
 }
 

--- a/zig/pkg/inference/src/backends/backends.zig
+++ b/zig/pkg/inference/src/backends/backends.zig
@@ -178,6 +178,18 @@ pub const SessionManager = struct {
         return copy;
     }
 
+    /// Validate the process-level required backend before a server publishes
+    /// readiness or an artifact path begins execution. Required backends must
+    /// be compiled into this binary and support the direct session-loading
+    /// contract used by the inference runtime. PJRT is intentionally rejected
+    /// until the runtime has a consistent compiled-only loading path.
+    pub fn validateRequiredBackendPolicy(self: *const SessionManager) !void {
+        if (self.required_backend_invalid) return error.InvalidRequiredBackend;
+        const backend = self.required_backend orelse return;
+        if (!backend.available() or !backend.supportsDirectSessionLoad())
+            return error.RequiredBackendUnavailable;
+    }
+
     pub fn loadModel(self: *SessionManager, model_path: []const u8) !Session {
         return self.loadModelWithImportedOnnxContext(model_path, null);
     }
@@ -653,6 +665,36 @@ test "required backend gates backend-specific fast paths" {
 
     manager.required_backend_invalid = true;
     try std.testing.expectError(error.InvalidRequiredBackend, manager.allowsDirectBackend(.onnx));
+}
+
+test "required backend policy rejects unavailable and compiled-only backends" {
+    var manager = SessionManager.init(std.testing.allocator);
+    manager.required_backend = null;
+    manager.required_backend_invalid = false;
+    try manager.validateRequiredBackendPolicy();
+
+    manager.required_backend_invalid = true;
+    try std.testing.expectError(
+        error.InvalidRequiredBackend,
+        manager.validateRequiredBackendPolicy(),
+    );
+
+    manager.required_backend_invalid = false;
+    manager.required_backend = .pjrt;
+    try std.testing.expectError(
+        error.RequiredBackendUnavailable,
+        manager.validateRequiredBackendPolicy(),
+    );
+
+    manager.required_backend = .native;
+    if (BackendType.native.available()) {
+        try manager.validateRequiredBackendPolicy();
+    } else {
+        try std.testing.expectError(
+            error.RequiredBackendUnavailable,
+            manager.validateRequiredBackendPolicy(),
+        );
+    }
 }
 
 test "invalid required backend fails before model loading" {

--- a/zig/pkg/inference/src/cli/compare_generate.zig
+++ b/zig/pkg/inference/src/cli/compare_generate.zig
@@ -420,6 +420,7 @@ pub fn main(allocator: std.mem.Allocator, io: std.Io, args: []const []const u8) 
     const opts = try parseArgs(args);
 
     var session_manager = backends.SessionManager.init(allocator);
+    try session_manager.validateRequiredBackendPolicy();
     configureBackendPreference(&session_manager, opts.backend);
 
     var model_manager = model_manager_mod.ModelManager.init(allocator, session_manager);
@@ -467,6 +468,7 @@ pub fn main(allocator: std.mem.Allocator, io: std.Io, args: []const []const u8) 
         } else if (!c_file.fileExistsInDir(allocator, opts.reference_model_dir, "genai_config.json") and
             onnx_decoder_only_vlm.isSupportedModelDir(allocator, opts.reference_model_dir))
         {
+            try validateDirectOnnxPolicy(&session_manager);
             const stage_override = platform.env.getenv("TERMITE_COMPARE_NATIVE_VISION_STAGE");
             if (opts.image_features_only and stage_override != null) {
                 const native_image_features = try collectNativeVisionStageFeatures(
@@ -713,6 +715,7 @@ pub fn main(allocator: std.mem.Allocator, io: std.Io, args: []const []const u8) 
     } else if (!c_file.fileExistsInDir(allocator, opts.reference_model_dir, "genai_config.json") and
         onnx_decoder_only_vlm.isSupportedModelDir(allocator, opts.reference_model_dir))
     {
+        try validateDirectOnnxPolicy(&session_manager);
         var onnx_pipeline = try onnx_decoder_only_vlm.Pipeline.load(allocator, opts.reference_model_dir);
         defer onnx_pipeline.deinit();
         const onnx_prompt = try alignOnnxPromptForCompare(
@@ -743,6 +746,7 @@ pub fn main(allocator: std.mem.Allocator, io: std.Io, args: []const []const u8) 
         return;
     } else if (try ortgenai.prepareGenerativeModelPackage(allocator, opts.reference_model_dir)) |onnx_model_dir| {
         defer allocator.free(onnx_model_dir);
+        try validateDirectOnnxPolicy(&session_manager);
         const onnx_prompt = try allocator.dupe(u8, native.prompt);
         defer allocator.free(onnx_prompt);
         print("native_prompt == onnx_prompt: {}\n", .{true});
@@ -3754,6 +3758,43 @@ fn configureBackendPreference(session_manager: *backends.SessionManager, choice:
         .cuda => &.{ .cuda, .native },
         .metal => &.{ .metal, .onnx, .native },
     };
+}
+
+fn validateDirectOnnxPolicy(session_manager: *const backends.SessionManager) !void {
+    try session_manager.validateRequiredBackendPolicy();
+    if (!try session_manager.allowsDirectBackend(.onnx))
+        return error.RequiredBackendUnavailable;
+}
+
+test "compare direct ONNX routes honor the required backend" {
+    var session_manager = backends.SessionManager.init(std.testing.allocator);
+    session_manager.required_backend_invalid = false;
+
+    session_manager.required_backend = null;
+    try validateDirectOnnxPolicy(&session_manager);
+
+    session_manager.required_backend = .cuda;
+    try std.testing.expectError(
+        error.RequiredBackendUnavailable,
+        validateDirectOnnxPolicy(&session_manager),
+    );
+
+    session_manager.required_backend = .onnx;
+    if (build_options.enable_onnx) {
+        try validateDirectOnnxPolicy(&session_manager);
+    } else {
+        try std.testing.expectError(
+            error.RequiredBackendUnavailable,
+            validateDirectOnnxPolicy(&session_manager),
+        );
+    }
+
+    session_manager.required_backend = null;
+    session_manager.required_backend_invalid = true;
+    try std.testing.expectError(
+        error.InvalidRequiredBackend,
+        validateDirectOnnxPolicy(&session_manager),
+    );
 }
 
 fn printUsage() void {

--- a/zig/pkg/inference/src/inference.zig
+++ b/zig/pkg/inference/src/inference.zig
@@ -56,6 +56,7 @@ pub const quantize = @import("quantize/root.zig");
 pub const client = if (build_options.skip_openapi) struct {} else @import("inference_client");
 pub const linalg = @import("inference_linalg");
 pub const native_generate = @import("native_generate.zig");
+pub const native_backend_choice = @import("native_backend_choice.zig");
 pub const native_chat = @import("native_chat.zig");
 pub const native_compile = @import("native_compile.zig");
 pub const native_export = @import("native_export.zig");
@@ -126,6 +127,7 @@ test {
     _ = client;
     _ = scraping;
     _ = native_generate;
+    _ = native_backend_choice;
     _ = native_chat;
     _ = native_compile;
     _ = native_export;

--- a/zig/pkg/inference/src/native_backend_choice.zig
+++ b/zig/pkg/inference/src/native_backend_choice.zig
@@ -106,6 +106,7 @@ pub fn validateRequiredCompiledBackend(
     session_manager: *const backends.SessionManager,
     compiled_backend: ?ops.BackendKind,
 ) !void {
+    try session_manager.validateRequiredBackendPolicy();
     const backend = switch (compiled_backend orelse return) {
         .native => backends.BackendType.native,
         .metal => backends.BackendType.metal,
@@ -120,6 +121,12 @@ pub fn validateRequiredCompiledBackend(
         },
     };
     if (!try session_manager.allowsBackend(backend)) return error.RequiredBackendUnavailable;
+}
+
+pub fn compiledArtifactBackend(name: []const u8) !ops.BackendKind {
+    if (std.mem.eql(u8, name, "onnx")) return .onnx;
+    if (std.mem.eql(u8, name, "xla")) return .pjrt;
+    return error.UnsupportedCompileBackend;
 }
 
 pub fn forcesGraphMode(choice: Choice) bool {
@@ -171,17 +178,20 @@ test "compiledPartitionBackend maps explicit compiled backends" {
 
 test "required backend gates compiled backend execution" {
     var manager = backends.SessionManager.init(std.testing.allocator);
-    manager.required_backend = .cuda;
+    manager.required_backend = .native;
     manager.required_backend_invalid = false;
     try validateRequiredCompiledBackend(&manager, null);
-    try validateRequiredCompiledBackend(&manager, .cuda);
+    try validateRequiredCompiledBackend(&manager, .native);
     try std.testing.expectError(
         error.RequiredBackendUnavailable,
         validateRequiredCompiledBackend(&manager, .onnx),
     );
 
     manager.required_backend = .pjrt;
-    try validateRequiredCompiledBackend(&manager, .pjrt);
+    try std.testing.expectError(
+        error.RequiredBackendUnavailable,
+        validateRequiredCompiledBackend(&manager, .pjrt),
+    );
 
     manager.required_backend = null;
     manager.required_backend_invalid = true;
@@ -192,6 +202,20 @@ test "required backend gates compiled backend execution" {
     try std.testing.expectError(
         error.InvalidRequiredBackend,
         validateRequiredCompiledBackend(&manager, .graph),
+    );
+}
+
+test "compiled artifact backend names share required policy validation" {
+    try std.testing.expectEqual(ops.BackendKind.onnx, try compiledArtifactBackend("onnx"));
+    try std.testing.expectEqual(ops.BackendKind.pjrt, try compiledArtifactBackend("xla"));
+    try std.testing.expectError(error.UnsupportedCompileBackend, compiledArtifactBackend("cuda"));
+
+    var manager = backends.SessionManager.init(std.testing.allocator);
+    manager.required_backend = .native;
+    manager.required_backend_invalid = false;
+    try std.testing.expectError(
+        error.RequiredBackendUnavailable,
+        validateRequiredCompiledBackend(&manager, try compiledArtifactBackend("onnx")),
     );
 }
 

--- a/zig/pkg/inference/src/native_backend_choice.zig
+++ b/zig/pkg/inference/src/native_backend_choice.zig
@@ -102,6 +102,26 @@ pub fn compiledPartitionBackendForMode(choice: Choice, compiled_mode_requested: 
     return compiledPartitionBackend(choice);
 }
 
+pub fn validateRequiredCompiledBackend(
+    session_manager: *const backends.SessionManager,
+    compiled_backend: ?ops.BackendKind,
+) !void {
+    const backend = switch (compiled_backend orelse return) {
+        .native => backends.BackendType.native,
+        .metal => backends.BackendType.metal,
+        .onnx => backends.BackendType.onnx,
+        .pjrt => backends.BackendType.pjrt,
+        .cuda => backends.BackendType.cuda,
+        .wasm, .webgpu => backends.BackendType.wasm,
+        .graph => {
+            if (session_manager.required_backend_invalid) return error.InvalidRequiredBackend;
+            if (session_manager.required_backend != null) return error.RequiredBackendUnavailable;
+            return;
+        },
+    };
+    if (!try session_manager.allowsBackend(backend)) return error.RequiredBackendUnavailable;
+}
+
 pub fn forcesGraphMode(choice: Choice) bool {
     return compiledPartitionBackend(choice) != null;
 }
@@ -147,6 +167,32 @@ test "compiledPartitionBackend maps explicit compiled backends" {
         try std.testing.expectEqual(@as(?ops.BackendKind, null), compiledPartitionBackendForMode(.webgpu, true));
     }
     try std.testing.expectEqual(@as(?ops.BackendKind, null), compiledPartitionBackendForMode(.webgpu, false));
+}
+
+test "required backend gates compiled backend execution" {
+    var manager = backends.SessionManager.init(std.testing.allocator);
+    manager.required_backend = .cuda;
+    manager.required_backend_invalid = false;
+    try validateRequiredCompiledBackend(&manager, null);
+    try validateRequiredCompiledBackend(&manager, .cuda);
+    try std.testing.expectError(
+        error.RequiredBackendUnavailable,
+        validateRequiredCompiledBackend(&manager, .onnx),
+    );
+
+    manager.required_backend = .pjrt;
+    try validateRequiredCompiledBackend(&manager, .pjrt);
+
+    manager.required_backend = null;
+    manager.required_backend_invalid = true;
+    try std.testing.expectError(
+        error.InvalidRequiredBackend,
+        validateRequiredCompiledBackend(&manager, .onnx),
+    );
+    try std.testing.expectError(
+        error.InvalidRequiredBackend,
+        validateRequiredCompiledBackend(&manager, .graph),
+    );
 }
 
 test "explicit session preferences never silently fall back" {

--- a/zig/pkg/inference/src/native_generate.zig
+++ b/zig/pkg/inference/src/native_generate.zig
@@ -410,6 +410,14 @@ pub fn main(allocator: std.mem.Allocator, io: std.Io, args: []const []const u8) 
     session_manager.kernel_jit = jit_config;
     session_manager.kernel_jit_load_context = .startup_preload;
 
+    try native_backend_choice.validateRequiredCompiledBackend(
+        &session_manager,
+        if (artifact_backend) |backend|
+            if (std.mem.eql(u8, backend, "onnx")) .onnx else .pjrt
+        else
+            null,
+    );
+
     const allow_direct_onnx = (opts.backend == .auto or opts.backend == .onnx) and
         try session_manager.allowsDirectBackend(.onnx);
     if (allow_direct_onnx and !jit_config.mode.compiles() and opts.kernel_jit_profile_out == null and effective_draft_model == null and build_options.enable_onnx and
@@ -680,6 +688,7 @@ pub fn main(allocator: std.mem.Allocator, io: std.Io, args: []const []const u8) 
         }
         break :blk @as(?ops.BackendKind, null);
     };
+    try native_backend_choice.validateRequiredCompiledBackend(&session_manager, explicit_partition_backend);
     const compiled_attachment_target: graph_mod.compiled_backend.AttachmentTarget = opts.compiled_target orelse blk: {
         if (compiled_mode_requested and explicit_partition_backend == .metal) break :blk .whole_model;
         break :blk .partitioned;

--- a/zig/pkg/inference/src/native_generate.zig
+++ b/zig/pkg/inference/src/native_generate.zig
@@ -405,7 +405,13 @@ pub fn main(allocator: std.mem.Allocator, io: std.Io, args: []const []const u8) 
     defer if (resolved_artifact_dir) |path| allocator.free(path);
     const route_onnx_whole_model_graph = opts.backend == .onnx and opts.compiled_target == .whole_model;
 
-    const allow_direct_onnx = opts.backend == .auto or opts.backend == .onnx;
+    var session_manager = backends.SessionManager.initWithIo(allocator, io);
+    configureBackendPreference(&session_manager, if (route_onnx_whole_model_graph) .native else opts.backend);
+    session_manager.kernel_jit = jit_config;
+    session_manager.kernel_jit_load_context = .startup_preload;
+
+    const allow_direct_onnx = (opts.backend == .auto or opts.backend == .onnx) and
+        try session_manager.allowsDirectBackend(.onnx);
     if (allow_direct_onnx and !jit_config.mode.compiles() and opts.kernel_jit_profile_out == null and effective_draft_model == null and build_options.enable_onnx and
         !route_onnx_whole_model_graph and
         !c_file.fileExistsInDir(allocator, opts.model_dir, "genai_config.json") and
@@ -501,11 +507,6 @@ pub fn main(allocator: std.mem.Allocator, io: std.Io, args: []const []const u8) 
         }
         return;
     }
-
-    var session_manager = backends.SessionManager.initWithIo(allocator, io);
-    configureBackendPreference(&session_manager, if (route_onnx_whole_model_graph) .native else opts.backend);
-    session_manager.kernel_jit = jit_config;
-    session_manager.kernel_jit_load_context = .startup_preload;
 
     var model_manager = model_manager_mod.ModelManager.init(allocator, session_manager);
     defer model_manager.deinit();

--- a/zig/pkg/inference/src/native_run_artifact.zig
+++ b/zig/pkg/inference/src/native_run_artifact.zig
@@ -336,9 +336,13 @@ pub fn validateArtifact(
     io: std.Io,
     artifact_or_manifest_path: []const u8,
 ) !ValidationResult {
+    const session_manager = backends.SessionManager.init(allocator);
+    try session_manager.validateRequiredBackendPolicy();
+
     if (compiled_artifact.isPackageManifestPath(artifact_or_manifest_path)) {
         var parsed = try compiled_artifact.readPackageManifest(allocator, io, artifact_or_manifest_path);
         defer parsed.deinit();
+        try validateArtifactBackendPolicy(&session_manager, parsed.value.backend);
         var prefill_count: usize = 0;
         var decode_count: usize = 0;
         for (parsed.value.artifacts) |entry| {
@@ -377,6 +381,7 @@ pub fn validateArtifact(
     var parsed = try compiled_artifact.readManifest(allocator, io, manifest_path);
     defer parsed.deinit();
     const manifest = parsed.value;
+    try validateArtifactBackendPolicy(&session_manager, manifest.backend);
 
     if (std.mem.eql(u8, manifest.backend, "onnx")) {
         if (!build_options.enable_onnx) return error.BackendUnavailable;

--- a/zig/pkg/inference/src/native_run_artifact.zig
+++ b/zig/pkg/inference/src/native_run_artifact.zig
@@ -337,12 +337,23 @@ pub fn validateArtifact(
     artifact_or_manifest_path: []const u8,
 ) !ValidationResult {
     const session_manager = backends.SessionManager.init(allocator);
-    try session_manager.validateRequiredBackendPolicy();
+    return validateArtifactWithSessionManager(
+        allocator,
+        io,
+        artifact_or_manifest_path,
+        &session_manager,
+    );
+}
 
+fn validateArtifactWithSessionManager(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    artifact_or_manifest_path: []const u8,
+    session_manager: *const backends.SessionManager,
+) !ValidationResult {
     if (compiled_artifact.isPackageManifestPath(artifact_or_manifest_path)) {
         var parsed = try compiled_artifact.readPackageManifest(allocator, io, artifact_or_manifest_path);
         defer parsed.deinit();
-        try validateArtifactBackendPolicy(&session_manager, parsed.value.backend);
         var prefill_count: usize = 0;
         var decode_count: usize = 0;
         for (parsed.value.artifacts) |entry| {
@@ -381,9 +392,9 @@ pub fn validateArtifact(
     var parsed = try compiled_artifact.readManifest(allocator, io, manifest_path);
     defer parsed.deinit();
     const manifest = parsed.value;
-    try validateArtifactBackendPolicy(&session_manager, manifest.backend);
 
     if (std.mem.eql(u8, manifest.backend, "onnx")) {
+        try validateArtifactBackendPolicy(session_manager, manifest.backend);
         if (!build_options.enable_onnx) return error.BackendUnavailable;
         var session = try backends.onnx.createSession(allocator, manifest.artifact_path);
         defer session.close();
@@ -2989,6 +3000,47 @@ test "parseArgs accepts validate without prompt" {
     try std.testing.expect(opts.validate);
 }
 
+test "validateArtifact keeps XLA metadata inspection outside execution policy" {
+    if (!build_options.enable_pjrt) return error.SkipZigTest;
+
+    const allocator = std.testing.allocator;
+    const io = std.testing.io;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const base_dir = try std.fs.path.join(allocator, &.{ ".zig-cache", "tmp", tmp.sub_path[0..] });
+    defer allocator.free(base_dir);
+    const artifact_path = try std.fs.path.join(allocator, &.{ base_dir, "model.hlo" });
+    defer allocator.free(artifact_path);
+    const manifest_path = try std.fs.path.join(allocator, &.{ base_dir, "model.hlo.inference.json" });
+    defer allocator.free(manifest_path);
+
+    try std.Io.Dir.cwd().writeFile(io, .{ .sub_path = artifact_path, .data = "hlo" });
+    try compiled_artifact.writeManifest(allocator, io, manifest_path, .{
+        .backend = "xla",
+        .kind = "stablehlo",
+        .model_dir = "/tmp/model",
+        .artifact_path = artifact_path,
+        .prompt_tokens = 1,
+        .seq_len = 1,
+        .query_seq_len = 1,
+        .attention_mode = "causal",
+        .raw_prompt = true,
+        .chat_template_applied = false,
+    });
+
+    var session_manager = backends.SessionManager.init(allocator);
+    session_manager.required_backend_invalid = true;
+    var validation = try validateArtifactWithSessionManager(
+        allocator,
+        io,
+        manifest_path,
+        &session_manager,
+    );
+    defer validation.deinit(allocator);
+    try std.testing.expectEqualStrings("xla", validation.backend);
+}
+
 test "validateArtifact summarizes package manifests" {
     const allocator = std.testing.allocator;
     const io = std.testing.io;
@@ -3077,7 +3129,14 @@ test "validateArtifact summarizes package manifests" {
         },
     });
 
-    var validation = try validateArtifact(allocator, io, package_path);
+    var session_manager = backends.SessionManager.init(allocator);
+    session_manager.required_backend_invalid = true;
+    var validation = try validateArtifactWithSessionManager(
+        allocator,
+        io,
+        package_path,
+        &session_manager,
+    );
     defer validation.deinit(allocator);
     try std.testing.expect(validation.is_package);
     try std.testing.expectEqualStrings("xla", validation.backend);

--- a/zig/pkg/inference/src/native_run_artifact.zig
+++ b/zig/pkg/inference/src/native_run_artifact.zig
@@ -935,6 +935,9 @@ fn runParsedArtifactPrompt(
     no_chat_template: bool,
     raw_prompt: bool,
 ) !RunResult {
+    const session_manager = backends.SessionManager.init(allocator);
+    try validateArtifactBackendPolicy(&session_manager, artifact.backend);
+
     var model_manifest = try manifest_mod.loadFromDir(allocator, artifact.model_dir);
     defer {
         if (pjrtExecDebugEnabled() and std.mem.eql(u8, artifact.backend, "xla")) std.log.info("PJRT run-artifact model manifest deinit begin", .{});
@@ -989,6 +992,27 @@ fn runParsedArtifactPrompt(
         graph_input_ids,
         compare_host,
     );
+}
+
+fn validateArtifactBackendPolicy(
+    session_manager: *const backends.SessionManager,
+    artifact_backend_name: []const u8,
+) !void {
+    const artifact_backend = try native_backend_choice.compiledArtifactBackend(artifact_backend_name);
+    try native_backend_choice.validateRequiredCompiledBackend(session_manager, artifact_backend);
+}
+
+test "run-artifact rejects a compiled backend outside the required policy" {
+    var session_manager = backends.SessionManager.init(std.testing.allocator);
+    session_manager.required_backend = .native;
+    session_manager.required_backend_invalid = false;
+    try std.testing.expectError(
+        error.RequiredBackendUnavailable,
+        validateArtifactBackendPolicy(&session_manager, "onnx"),
+    );
+
+    session_manager.required_backend = null;
+    try validateArtifactBackendPolicy(&session_manager, "onnx");
 }
 
 fn runPreparedArtifactPrompt(

--- a/zig/pkg/inference/src/native_smoke.zig
+++ b/zig/pkg/inference/src/native_smoke.zig
@@ -80,6 +80,7 @@ pub fn main(allocator: std.mem.Allocator, io: std.Io, args: []const []const u8) 
 
     var session_manager = backends.SessionManager.initWithIo(allocator, io);
     configureBackendPreference(&session_manager, opts.backend);
+    try validateSmokeBackendPolicy(&session_manager, opts.backend);
 
     var model_manager = model_manager_mod.ModelManager.init(allocator, session_manager);
     defer model_manager.deinit();
@@ -294,6 +295,29 @@ pub fn main(allocator: std.mem.Allocator, io: std.Io, args: []const []const u8) 
 
     print("finish_reason={s} tokens={d}\n", .{ result.finish_reason, result.tokens_used });
     print("{s}\n", .{result.text});
+}
+
+fn validateSmokeBackendPolicy(
+    session_manager: *const backends.SessionManager,
+    choice: BackendChoice,
+) !void {
+    try native_backend_choice.validateRequiredCompiledBackend(
+        session_manager,
+        native_backend_choice.compiledPartitionBackend(choice),
+    );
+}
+
+test "smoke rejects a compiled backend outside the required policy" {
+    var session_manager = backends.SessionManager.init(std.testing.allocator);
+    session_manager.required_backend = .native;
+    session_manager.required_backend_invalid = false;
+    try std.testing.expectError(
+        error.RequiredBackendUnavailable,
+        validateSmokeBackendPolicy(&session_manager, .onnx),
+    );
+
+    session_manager.required_backend = null;
+    try validateSmokeBackendPolicy(&session_manager, .onnx);
 }
 
 fn parseArgs(args: []const []const u8) !Options {

--- a/zig/pkg/inference/src/readers/reader.zig
+++ b/zig/pkg/inference/src/readers/reader.zig
@@ -244,14 +244,16 @@ pub const LoadedReader = union(enum) {
 
         const parser_kind = try detectParserKind(allocator, model_path);
         if (parser_kind == .moondream) {
-            if (onnx_decoder_only_vlm.isSupportedModelDir(allocator, model_path)) {
-                return .{ .vlm = try VlmLoadedReader.loadFromDir(allocator, model_path) };
-            }
-            if (build_options.enable_onnx) {
-                if (GenAiLoadedReader.loadFromDir(allocator, model_path)) |reader| {
-                    return .{ .genai = reader };
-                } else |err| {
-                    std.log.warn("ortgenai moondream reader load failed for {s}: {s}", .{ model_path, @errorName(err) });
+            if (try session_manager.allowsDirectBackend(.onnx)) {
+                if (onnx_decoder_only_vlm.isSupportedModelDir(allocator, model_path)) {
+                    return .{ .vlm = try VlmLoadedReader.loadFromDir(allocator, model_path) };
+                }
+                if (build_options.enable_onnx) {
+                    if (GenAiLoadedReader.loadFromDir(allocator, model_path)) |reader| {
+                        return .{ .genai = reader };
+                    } else |err| {
+                        std.log.warn("ortgenai moondream reader load failed for {s}: {s}", .{ model_path, @errorName(err) });
+                    }
                 }
             }
         }

--- a/zig/pkg/inference/src/server/model_manager.zig
+++ b/zig/pkg/inference/src/server/model_manager.zig
@@ -4772,6 +4772,11 @@ pub const ModelManager = struct {
         component_paths: []const []const u8,
         contract: ComponentContract,
     ) !ComponentLoader {
+        var required_backend_scratch: [1]backends.BackendType = undefined;
+        const effective_backends = try self.session_manager.requiredBackendCandidates(
+            preferred_backends,
+            &required_backend_scratch,
+        );
         var loader = ComponentLoader{ .manager = self };
         for (component_paths) |path| try loader.addComponentPath(path);
         if (loader.component_path_count == 0) return error.IncompleteModelBundle;
@@ -4781,7 +4786,7 @@ pub const ModelManager = struct {
             const key = componentPlanKey(
                 model_dir,
                 &man,
-                preferred_backends,
+                effective_backends,
                 component_paths,
                 policy,
                 contract,
@@ -4803,13 +4808,13 @@ pub const ModelManager = struct {
             try validateComponentNativeArtifacts(
                 self.allocator,
                 component_paths,
-                preferred_backends,
+                effective_backends,
                 &inspection,
             );
             try validateComponentImportedGraphs(
                 self.allocator,
                 component_paths,
-                preferred_backends,
+                effective_backends,
                 &inspection,
             );
             const signature_after = try componentDependencySignature(
@@ -4823,7 +4828,7 @@ pub const ModelManager = struct {
             )) return error.ModelArtifactsChanging;
             const validated = try policyAllowedComponentBackendsFromInspection(
                 &loader.allowed_backends,
-                preferred_backends,
+                effective_backends,
                 policy,
                 &inspection,
             );
@@ -4834,7 +4839,7 @@ pub const ModelManager = struct {
                 inspection.dependencies.items,
             ) catch {};
             break :blk validated;
-        } else preferred_backends;
+        } else effective_backends;
         for (allowed) |backend| {
             if (!backend.supportsDirectSessionLoad()) continue;
             if (loader.allowed_backend_count == loader.allowed_backends.len) break;
@@ -8355,6 +8360,20 @@ test "component compatibility validates explicit split ONNX graphs" {
         .multistage_ocr,
     );
     try std.testing.expectEqual(@as(usize, 1), manager.component_plan_cache.count());
+
+    var required_session_manager = backends.SessionManager.init(allocator);
+    required_session_manager.required_backend = .cuda;
+    required_session_manager.required_backend_invalid = false;
+    var required_manager = ModelManager.init(allocator, required_session_manager);
+    defer required_manager.deinit();
+    const required_loader = try required_manager.componentLoaderForPathsWithContract(
+        root,
+        &.{.native},
+        &.{ encoder, decoder },
+        .multistage_ocr,
+    );
+    try std.testing.expectEqual(@as(usize, 1), required_loader.allowed_backend_count);
+    try std.testing.expectEqual(backends.BackendType.cuda, required_loader.allowed_backends[0]);
 
     try dir.dir.writeFile(std.testing.io, .{
         .sub_path = "encoder_model.onnx",

--- a/zig/pkg/inference/src/server/model_manager.zig
+++ b/zig/pkg/inference/src/server/model_manager.zig
@@ -4882,6 +4882,11 @@ pub const ModelManager = struct {
         shared_backend_ctx: ?*backends.imported_onnx_session.SharedBackendContext,
         source_session_manager: *const backends.SessionManager,
     ) !ManagedSession {
+        var required_backend_scratch: [1]backends.BackendType = undefined;
+        const effective_backends = try source_session_manager.requiredBackendCandidates(
+            preferred_backends,
+            &required_backend_scratch,
+        );
         var first_err: ?anyerror = null;
         var artifact_estimate = if (self.admission_enabled)
             try ComponentArtifactEstimate.init(self.allocator, model_path)
@@ -4889,7 +4894,7 @@ pub const ModelManager = struct {
             ComponentArtifactEstimate.disabled;
         defer artifact_estimate.deinit();
 
-        for (preferred_backends) |backend| {
+        for (effective_backends) |backend| {
             if (!backend.supportsDirectSessionLoad()) continue;
             if (shared_backend_ctx) |shared| {
                 if (shared.backendType() != backend) continue;
@@ -5741,13 +5746,18 @@ pub const ModelManager = struct {
         preferred_backends: []const backends.BackendType,
         cache_default_alias: bool,
     ) !ModelHandle {
-        const flight_key = try self.loadFlightKey(model_dir, preferred_backends, cache_default_alias);
+        var required_backend_scratch: [1]backends.BackendType = undefined;
+        const effective_backends = try self.session_manager.requiredBackendCandidates(
+            preferred_backends,
+            &required_backend_scratch,
+        );
+        const flight_key = try self.loadFlightKey(model_dir, effective_backends, cache_default_alias);
         defer self.allocator.free(flight_key);
 
         self.lockLoadedModels();
         const cached = self.lookupLoadedModelLocked(
             model_dir,
-            preferred_backends,
+            effective_backends,
             cache_default_alias,
         ) catch |err| {
             self.unlockLoadedModels();
@@ -5794,7 +5804,7 @@ pub const ModelManager = struct {
         // runtime for its complete construction.
         var session_manager = sessionManagerForPreferredBackends(
             self.allocator,
-            preferred_backends,
+            effective_backends,
             &self.session_manager,
         );
         self.unlockLoadedModels();
@@ -6972,8 +6982,13 @@ fn loadSessionForPreferredBackends(
     man: manifest_mod.ModelManifest,
     source_session_manager: *const backends.SessionManager,
 ) !LoadedSessionPlan {
+    var required_backend_scratch: [1]backends.BackendType = undefined;
+    const policy_backends = try source_session_manager.requiredBackendCandidates(
+        preferred_backends,
+        &required_backend_scratch,
+    );
     var effective_scratch: [7]backends.BackendType = undefined;
-    const effective_backends = effectiveLoadBackends(&effective_scratch, preferred_backends, man);
+    const effective_backends = effectiveLoadBackends(&effective_scratch, policy_backends, man);
     // Keep the first real failure. Reporting a blanket NoModelFileFound hides the
     // actionable cause: a GGUF whose tensors could not be resolved fails with
     // MissingRequiredWeights, and callers were being told the file did not exist.
@@ -7727,6 +7742,28 @@ test "effectiveLoadBackends preserves explicit onnx-only classifier preference" 
 
     const effective = effectiveLoadBackends(&scratch, &preferred, classifier);
     try std.testing.expectEqualSlices(backends.BackendType, &preferred, effective);
+}
+
+test "required backend is applied before model manager backend planning" {
+    const allocator = std.testing.allocator;
+    var source = backends.SessionManager.init(allocator);
+    source.preferred_backends = &.{ .native, .onnx };
+    source.required_backend = .cuda;
+    source.required_backend_invalid = false;
+
+    var required_scratch: [1]backends.BackendType = undefined;
+    const policy_backends = try source.requiredBackendCandidates(
+        source.preferred_backends,
+        &required_scratch,
+    );
+
+    var load_scratch: [7]backends.BackendType = undefined;
+    var classifier = manifest_mod.ModelManifest{ .allocator = allocator, .model_type = .classifier };
+    defer classifier.deinit();
+    classifier.safetensors_path = try allocator.dupe(u8, "model.safetensors");
+
+    const effective = effectiveLoadBackends(&load_scratch, policy_backends, classifier);
+    try std.testing.expectEqualSlices(backends.BackendType, &.{.cuda}, effective);
 }
 
 test "isManifestPotentiallyLoadableInCurrentBuild accepts onnx-only models when onnx model support is enabled" {

--- a/zig/pkg/inference/src/server/model_manager.zig
+++ b/zig/pkg/inference/src/server/model_manager.zig
@@ -6467,6 +6467,8 @@ fn sessionManagerForPreferredBackends(
     return .{
         .allocator = allocator,
         .preferred_backends = preferred_backends,
+        .required_backend = source.required_backend,
+        .required_backend_invalid = source.required_backend_invalid,
         .graph_runtime_strategy = source.graph_runtime_strategy,
         .kernel_jit = source.kernel_jit,
         .kernel_jit_load_context = source.kernel_jit_load_context,

--- a/zig/pkg/inference/src/server/model_manager.zig
+++ b/zig/pkg/inference/src/server/model_manager.zig
@@ -7771,6 +7771,28 @@ test "required backend is applied before model manager backend planning" {
     try std.testing.expectEqualSlices(backends.BackendType, &.{.cuda}, effective);
 }
 
+test "model manager rejects an unavailable required backend before artifact selection" {
+    const allocator = std.testing.allocator;
+    var session_manager = backends.SessionManager.init(allocator);
+    session_manager.required_backend = .pjrt;
+    session_manager.required_backend_invalid = false;
+    var manager = ModelManager.init(allocator, session_manager);
+    defer manager.deinit();
+
+    try std.testing.expectError(
+        error.RequiredBackendUnavailable,
+        manager.acquireFromDir("/nonexistent/required-backend-model"),
+    );
+    try std.testing.expectError(
+        error.RequiredBackendUnavailable,
+        manager.componentLoaderForPaths(
+            "/nonexistent/required-backend-model",
+            &.{.native},
+            &.{"/nonexistent/component"},
+        ),
+    );
+}
+
 test "isManifestPotentiallyLoadableInCurrentBuild accepts onnx-only models when onnx model support is enabled" {
     const allocator = std.testing.allocator;
 

--- a/zig/pkg/inference/src/server/server.zig
+++ b/zig/pkg/inference/src/server/server.zig
@@ -6356,6 +6356,10 @@ pub const Node = struct {
             .metal
         else
             backend_selection.compiled_partition_backend;
+        native_backend_choice.validateRequiredCompiledBackend(
+            &self.session_manager,
+            effective_compiled_partition_backend,
+        ) catch |err| return modelLoadFailureResponse(ctx, err);
         const effective_compiled_attachment_target: graph_mod.compiled_backend.AttachmentTarget = if (auto_metal_whole_model)
             .whole_model
         else

--- a/zig/pkg/inference/src/server/server.zig
+++ b/zig/pkg/inference/src/server/server.zig
@@ -2596,6 +2596,35 @@ fn classifyExtractionResolutionFailure(err: anyerror) ExtractionResolutionFailur
     };
 }
 
+fn compatibilityBackendsForSessionManager(
+    session_manager: *const backends_mod.SessionManager,
+    required_scratch: *[1]backends_mod.BackendType,
+) ![]const backends_mod.BackendType {
+    return session_manager.requiredBackendCandidates(
+        session_manager.preferred_backends,
+        required_scratch,
+    );
+}
+
+test "compatibility backend candidates honor required policy" {
+    var session_manager = backends_mod.SessionManager.init(std.testing.allocator);
+    session_manager.preferred_backends = &.{ .native, .cuda };
+    session_manager.required_backend = .cuda;
+    session_manager.required_backend_invalid = false;
+    var required_scratch: [1]backends_mod.BackendType = undefined;
+    try std.testing.expectEqualSlices(
+        backends_mod.BackendType,
+        &.{.cuda},
+        try compatibilityBackendsForSessionManager(&session_manager, &required_scratch),
+    );
+
+    session_manager.required_backend = .pjrt;
+    try std.testing.expectError(
+        error.RequiredBackendUnavailable,
+        compatibilityBackendsForSessionManager(&session_manager, &required_scratch),
+    );
+}
+
 pub const Node = struct {
     config: NodeConfig,
     allocator: std.mem.Allocator,
@@ -2872,6 +2901,11 @@ pub const Node = struct {
         allocator: std.mem.Allocator,
         model_path: []const u8,
     ) !CompatibilitySummary {
+        var required_backend_scratch: [1]backends_mod.BackendType = undefined;
+        const compatibility_backends = try compatibilityBackendsForSessionManager(
+            &self.session_manager,
+            &required_backend_scratch,
+        );
         var io_impl: ?std.Io.Threaded = null;
         defer if (io_impl) |*threaded| threaded.deinit();
         const io = self.session_manager.io orelse blk: {
@@ -2930,7 +2964,7 @@ pub const Node = struct {
                 allocator,
                 model_path,
                 &man,
-                self.session_manager.preferred_backends,
+                compatibility_backends,
             );
 
             var verification_manifest = try manifest_mod.loadListingFromDir(

--- a/zig/pkg/inference/src/server/server.zig
+++ b/zig/pkg/inference/src/server/server.zig
@@ -6019,7 +6019,10 @@ pub const Node = struct {
             self.config.allow_unknown_models,
         )) |response|
             return response;
-        const allow_onnx = effective_draft_model_name == null and
+        const required_policy_allows_onnx = self.session_manager.allowsDirectBackend(.onnx) catch |err|
+            return modelLoadFailureResponse(ctx, err);
+        const allow_onnx = required_policy_allows_onnx and
+            effective_draft_model_name == null and
             !backend_selection.graph_mode_requested and
             (body.backend == null or backend_selection.native_choice == .onnx);
 

--- a/zig/pkg/inference/src/server/server.zig
+++ b/zig/pkg/inference/src/server/server.zig
@@ -2742,6 +2742,7 @@ pub const Node = struct {
         try config.kernel_jit.validate();
         try config.prompt_cache.validate();
         var session_manager = backends_mod.SessionManager.init(allocator);
+        try session_manager.validateRequiredBackendPolicy();
         session_manager.kernel_jit = config.kernel_jit;
         try graph_mod.kernel_jit.validateMetalProfileBackend(
             backends_mod.BackendType.metal.available(),
@@ -10944,7 +10945,11 @@ pub const Node = struct {
 
     fn readyzHandler(self: *Node, ctx: *httpx.Context) anyerror!httpx.Response {
         const snapshot = self.readiness_inventory.load();
-        const is_ready = snapshot.initialized and snapshot.counts.total() > 0;
+        const required_backend_ready = blk: {
+            self.session_manager.validateRequiredBackendPolicy() catch break :blk false;
+            break :blk true;
+        };
+        const is_ready = required_backend_ready and snapshot.initialized and snapshot.counts.total() > 0;
         const status_text = if (is_ready) "ready" else "not_ready";
         const status_code: u16 = if (is_ready) 200 else 503;
         return ctx.status(status_code).json(.{
@@ -15260,6 +15265,19 @@ test "readyz serves only the published inventory snapshot" {
         try std.testing.expect(std.mem.indexOf(u8, response.body.?, "\"status\":\"ready\"") != null);
         try std.testing.expect(std.mem.indexOf(u8, response.body.?, "\"generators\":2") != null);
         try std.testing.expect(std.mem.indexOf(u8, response.body.?, "\"embedders\":1") != null);
+    }
+
+    node.session_manager.required_backend_invalid = true;
+    {
+        var request = try httpx.Request.init(allocator, .GET, "/readyz");
+        defer request.deinit();
+        var ctx = httpx.Context.init(allocator, std.testing.io, &request);
+        defer ctx.deinit();
+
+        var response = try node.readyzHandler(&ctx);
+        defer response.deinit();
+        try std.testing.expectEqual(@as(u16, 503), response.status.code);
+        try std.testing.expect(std.mem.indexOf(u8, response.body.?, "\"status\":\"not_ready\"") != null);
     }
 }
 


### PR DESCRIPTION
## Summary

- add `ANTFLY_INFERENCE_REQUIRED_BACKEND` as a fail-closed runtime policy distinct from backend preference
- restrict model loading, direct ONNX paths, and compiled/artifact selection to the required backend when configured
- reject invalid values, distinguish an unavailable backend from a backend-specific load failure, and preserve the policy across server/model-manager copies
- keep existing automatic fallback behavior unchanged when no required backend is configured

## Motivation

GPU-hosted inference must not silently fall back to CPU when CUDA is unavailable. This allows production deployments to require CUDA while preserving the existing preferred-backend and test-harness behavior.

## Out of scope

- provisioning GPU infrastructure
- publishing or selecting a production container image
- choosing the production model bundle
- proving execution on a real CUDA device

## Validation

- focused required-backend suite: 9 selected, 9 passed
- full `zig build inference-test`: 3,156 selected; 3,138 passed; 18 skipped
- `git diff --check`
