### PR TITLE
Fix full CI status and simulation failures

### DIFF
--- a/zig/pkg/antfly/src/api/table_writes.zig
+++ b/zig/pkg/antfly/src/api/table_writes.zig
@@ -22282,8 +22282,12 @@ fn overlayRuntimeStatusReplayTargetFromDb(
     status: *runtime_status.LocalTableRuntimeStatus,
     db: *db_mod.DB,
 ) void {
-    const async_stats = db.snapshotAsyncIndexingStats();
-    status.stats.async_indexing = async_stats;
+    // Cold/query-only recovery has no producer runtime of its own. If a live
+    // writer is resident, overlay its lock-free lifecycle snapshot together
+    // with replay watermarks so a just-recovered status cannot transiently
+    // report a ready managed index with `enrichment_runtime.enabled=false`.
+    db.overlayRuntimeStatusRuntimeBestEffort(&status.stats);
+    const async_stats = status.stats.async_indexing;
     for (status.stats.indexes) |*item| {
         const prior_backfill_active = item.backfill_active;
         const prior_backfill_progress = item.backfill_progress;

--- a/zig/pkg/antfly/src/metadata/sim_harness.zig
+++ b/zig/pkg/antfly/src/metadata/sim_harness.zig
@@ -66,8 +66,10 @@ const casbin = @import("antfly_casbin");
 
 const LeanSimAllocator = std.heap.DebugAllocator(.{ .stack_trace_frames = 0 });
 // Public API simulations can open DBs and hosted indexes from the listener
-// request thread; keep enough stack for that Linux CI path.
-const lean_sim_thread_stack_size = 4 * 1024 * 1024;
+// request thread. Debug x86_64 index construction exceeds the partitioned
+// runtime's 4 MiB floor, so match the production HTTP request stack instead
+// of intermittently entering the guard page while opening query-only DBs.
+const lean_sim_thread_stack_size = 8 * 1024 * 1024;
 fn leanSimHttpAllocator() std.mem.Allocator {
     return std.heap.smp_allocator;
 }

--- a/zig/pkg/antfly/src/storage/db/db.zig
+++ b/zig/pkg/antfly/src/storage/db/db.zig
@@ -21383,6 +21383,14 @@ pub const DB = struct {
         else
             fallback;
         const desired = self.async_context.enrichment_desired_running.load(.acquire);
+        // `desired` is the lock-free source of truth for whether this DB owns
+        // an enrichment producer. A retained query-only snapshot may have
+        // `enabled=false`, and lifecycle contention prevents us from replacing
+        // it with runtime.stats(). Never let that observation gap turn a live
+        // or restarting producer into a disabled one: public readiness treats
+        // enabled + retrying as transient debt and remains fail-closed until a
+        // later poll can observe the worker directly.
+        if (desired) enrichment_status.enabled = true;
         const started = if (lifecycle_locked)
             if (self.async_context.enrichment_runtime) |runtime| runtime.isStarted() else false
         else
@@ -46641,7 +46649,6 @@ test "db enrichment status does not wait for lifecycle mutation" {
 
     lockAtomicWithBackoff(&db.async_context.enrichment_lifecycle_mutex);
     const fallback = types.EnrichmentStats{
-        .enabled = true,
         .target_sequence = 41,
         .applied_sequence = 37,
     };

--- a/zig/pkg/antfly/src/storage/db/db.zig
+++ b/zig/pkg/antfly/src/storage/db/db.zig
@@ -20854,10 +20854,16 @@ pub const DB = struct {
             item.index_repair_phase,
             item.index_repair_wait_reason,
         );
-        // Keep status available when the optional bounded proof cannot be
+        // Keep status available when either optional bounded proof cannot be
         // read; query admission independently retries it and remains closed.
-        item.index_repair_active_generation_serviceable =
-            self.managedAdmissionGenerationIsQueryable(alloc, intent) catch false;
+        // A complete active generation makes managed-admission repair debt
+        // redundant even before its scheduler quantum removes the intent.
+        // Preserve degradation for merely queryable progressive generations:
+        // their physical artifact count can still be advancing.
+        const active_generation_complete =
+            self.managedAdmissionGenerationIsServiceable(alloc, intent) catch false;
+        item.index_repair_active_generation_serviceable = active_generation_complete or
+            (self.managedAdmissionGenerationIsQueryable(alloc, intent) catch false);
         switch (intent.trigger) {
             .incomplete_bulk_publish,
             .root_generation_rebuild,
@@ -20881,6 +20887,7 @@ pub const DB = struct {
                     intent.phase == .terminal;
             },
         }
+        if (active_generation_complete) item.repair_degraded = false;
     }
 
     fn durableGenerationBuildActive(item: *const types.DBIndexStats) bool {
@@ -21391,7 +21398,10 @@ pub const DB = struct {
         return enrichment_status;
     }
 
-    fn overlayRuntimeStatusRuntimeOnly(self: *DB, runtime_stats: *types.DBStats) void {
+    /// Refresh lock-free worker diagnostics on a retained status snapshot.
+    /// Callers that only need runtime lifecycle facts can use this without
+    /// contending on the index apply lock or replacing durable coverage data.
+    pub fn overlayRuntimeStatusRuntimeBestEffort(self: *DB, runtime_stats: *types.DBStats) void {
         runtime_stats.async_indexing = self.snapshotAsyncIndexingStats();
         runtime_stats.enrichment = self.enrichmentStatsWithSupervisorState(runtime_stats.enrichment);
         runtime_stats.resolution = self.resolutionStageStats();
@@ -21610,12 +21620,12 @@ pub const DB = struct {
     }
 
     pub fn overlayRuntimeStatusBestEffort(self: *DB, stats_alloc: Allocator, runtime_stats: *types.DBStats) void {
-        self.overlayRuntimeStatusRuntimeOnly(runtime_stats);
+        self.overlayRuntimeStatusRuntimeBestEffort(runtime_stats);
         self.overlayRuntimeStatusIndexesAssumeApplyLockHeld(stats_alloc, runtime_stats);
     }
 
     pub fn overlayRuntimeStatusConsistent(self: *DB, stats_alloc: Allocator, runtime_stats: *types.DBStats) !void {
-        self.overlayRuntimeStatusRuntimeOnly(runtime_stats);
+        self.overlayRuntimeStatusRuntimeBestEffort(runtime_stats);
         lockApplyShared(self);
         defer self.core.unlockApplyShared();
         try self.overlayRuntimeStatusIndexesLocked(stats_alloc, runtime_stats);
@@ -46643,6 +46653,27 @@ test "db enrichment status does not wait for lifecycle mutation" {
     try std.testing.expectEqual(@as(u64, 37), status.applied_sequence);
     try std.testing.expect(status.retrying);
     try std.testing.expect(!status.worker_failed);
+}
+
+test "db runtime-only status overlay preserves a resident enrichment worker" {
+    const alloc = std.testing.allocator;
+    var deterministic = embedder_mod.DeterministicDenseEmbedder{};
+    var path_buf: [256]u8 = undefined;
+    const path = tempPath(&path_buf);
+    defer cleanupTempDir(path);
+
+    var db = try DB.open(alloc, std.mem.span(path), .{
+        .enrichment = .{ .dense_embedder = deterministic.interface() },
+    });
+    defer db.close();
+
+    // Model a durable/query-only recovery snapshot. A resident writer overlay
+    // must replace its absent producer diagnostics immediately rather than
+    // waiting for the periodic full status refresh.
+    var recovered: types.DBStats = .{};
+    db.overlayRuntimeStatusRuntimeBestEffort(&recovered);
+    try std.testing.expect(recovered.enrichment.enabled);
+    try std.testing.expect(recovered.enrichment.worker_started);
 }
 
 test "db ttl cleanup enabled requires backend runtime io" {
@@ -74097,6 +74128,15 @@ test "db progressive managed admission serves a checkpointed partial generation"
     });
     try std.testing.expect(try db.managedAdmissionGenerationIsQueryable(alloc, repair.intent));
     try std.testing.expect(!try db.managedAdmissionGenerationIsServiceable(alloc, repair.intent));
+    const partial_stats = try db.stats(alloc);
+    defer types.freeDBStats(alloc, partial_stats);
+    var saw_partial_repair_degraded = false;
+    for (partial_stats.indexes) |index_stats| {
+        if (!std.mem.eql(u8, index_stats.name, cfg.name)) continue;
+        try std.testing.expect(index_stats.index_repair_active_generation_serviceable);
+        saw_partial_repair_degraded = index_stats.repair_degraded;
+    }
+    try std.testing.expect(saw_partial_repair_degraded);
     try db.failIfIndexQuarantined(cfg.name);
 
     var partial = try db.search(alloc, .{
@@ -74264,11 +74304,14 @@ test "db completed partial managed admission serves and retires redundant repair
     const runtime_stats = try db.stats(alloc);
     defer types.freeDBStats(alloc, runtime_stats);
     var saw_serviceable_generation = false;
+    var saw_redundant_repair_degraded = true;
     for (runtime_stats.indexes) |index_stats| {
         if (!std.mem.eql(u8, index_stats.name, cfg.name)) continue;
         saw_serviceable_generation = index_stats.index_repair_active_generation_serviceable;
+        saw_redundant_repair_degraded = index_stats.repair_degraded;
     }
     try std.testing.expect(saw_serviceable_generation);
+    try std.testing.expect(!saw_redundant_repair_degraded);
 
     // Query admission may prove the pinned active generation independently of
     // the background scheduler, while the next scheduler quantum durably


### PR DESCRIPTION
## Summary

- match metadata simulation request stacks to the production HTTP stack size, preventing the x86 Debug query-only DB open from entering the guard page
- overlay resident writer lifecycle diagnostics onto cold recovered status snapshots so ready managed indexes do not transiently report enrichment disabled
- clear redundant managed-admission repair degradation only after the existing complete-generation proof verifies coverage, replay, exact artifact cardinality, and HBC structural quietness
- add regressions for resident enrichment status and partial-versus-complete managed generation repair state

## CI failures addressed

- https://github.com/antflydb/antfly/actions/runs/32915494211/job/98029550753
- https://github.com/antflydb/antfly/actions/runs/32915494211/job/98034438025

## Verification

- zig build antfly
- zig build integration-test --seed 0x6e5abc5: both metadata groups and 183/183 integration tests passed
- zig build db-enrichment-test: 147/147 passed
- focused progressive and completed managed-admission boundary tests: 2/2 passed
- test_public_managed_semantic_full_index_pipeline: passed
- git diff --check

## Slow E2E note

The 500-document gate was exercised several times. The production boundary regressions pass and directly cover the completed-but-degraded status from CI. The final local end-to-end attempt timed out earlier in startup catch-up while an unrelated long-running 1M-vector benchmark was consuming the host; its final status had zero second-index coverage and did not reproduce the completed-but-degraded CI state.