### PR TITLE
fix(operator): advertise stable data pod routes

### DIFF
--- a/go/pkg/operator/controllers/antfly/antflycluster_controller.go
+++ b/go/pkg/operator/controllers/antfly/antflycluster_controller.go
@@ -4516,11 +4516,19 @@ ID=$((ORDINAL + 1))
 exec /antfly data --node-id $ID --store-id $ID --config /config/config.json \
   --api-host ${POD_IP} \
   --api-port %d \
+  --api-advertise-url http://${HOSTNAME}.%s-data.%s.svc.cluster.local:%d \
   --raft-host ${POD_IP} \
   --raft-port %d \
+  --raft-advertise-url http://${HOSTNAME}.%s-data.%s.svc.cluster.local:%d \
   --health-port %d%s
 								`,
 								cluster.Spec.DataNodes.API.Port,
+								cluster.Name,
+								cluster.Namespace,
+								cluster.Spec.DataNodes.API.Port,
+								cluster.Spec.DataNodes.Raft.Port,
+								cluster.Name,
+								cluster.Namespace,
 								cluster.Spec.DataNodes.Raft.Port,
 								cluster.Spec.DataNodes.Health.Port,
 								secretStoreArg(cluster.Spec.SecretStore),
@@ -11848,16 +11856,16 @@ func haSeedArtifactPVCStorage(name string, pvc *antflyv1.HASeedArtifactPVCSpec, 
 		return nil, nil
 	}
 	return []corev1.VolumeMount{{
-			Name:      name,
-			MountPath: pvc.MountPath,
+		Name:      name,
+		MountPath: pvc.MountPath,
+		ReadOnly:  readOnly,
+	}}, []corev1.Volume{{
+		Name: name,
+		VolumeSource: corev1.VolumeSource{PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+			ClaimName: pvc.ClaimName,
 			ReadOnly:  readOnly,
-		}}, []corev1.Volume{{
-			Name: name,
-			VolumeSource: corev1.VolumeSource{PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-				ClaimName: pvc.ClaimName,
-				ReadOnly:  readOnly,
-			}},
-		}}
+		}},
+	}}
 }
 
 func haSeedArtifactForAction(cluster *antflyv1.AntflyCluster, action antflyv1.HAPlannedActionStatus) *antflyv1.HASeedArtifactSpec {

--- a/go/pkg/operator/controllers/antfly/antflycluster_controller_test.go
+++ b/go/pkg/operator/controllers/antfly/antflycluster_controller_test.go
@@ -14782,6 +14782,45 @@ func TestReconcileSplitStatefulSetsMountSecretStore(t *testing.T) {
 	}
 }
 
+func TestDataStatefulSetAdvertisesStablePodDNS(t *testing.T) {
+	g := NewWithT(t)
+
+	s := runtime.NewScheme()
+	g.Expect(antflyv1.AddToScheme(s)).To(Succeed())
+	g.Expect(appsv1.AddToScheme(s)).To(Succeed())
+	g.Expect(corev1.AddToScheme(s)).To(Succeed())
+
+	cluster := &antflyv1.AntflyCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "stable-routes", Namespace: "antfly-system"},
+		Spec: antflyv1.AntflyClusterSpec{
+			Image: "antfly:latest",
+			DataNodes: antflyv1.DataNodesSpec{
+				Replicas: 3,
+				API:      antflyv1.APISpec{Port: 12380},
+				Raft:     antflyv1.APISpec{Port: 9021},
+				Health:   antflyv1.APISpec{Port: 4200},
+			},
+			Storage: antflyv1.StorageSpec{StorageClass: "standard", DataStorage: "1Gi"},
+			Config:  "{}",
+		},
+	}
+	client := newHAControllerTestClient(t, s, cluster)
+	reconciler := &AntflyClusterReconciler{Client: client, Scheme: s}
+
+	g.Expect(reconciler.reconcileDataStatefulSet(context.Background(), &envFromCache{}, cluster)).To(Succeed())
+
+	sts := &appsv1.StatefulSet{}
+	g.Expect(client.Get(context.Background(), types.NamespacedName{
+		Name: cluster.Name + "-data", Namespace: cluster.Namespace,
+	}, sts)).To(Succeed())
+	g.Expect(sts.Spec.ServiceName).To(Equal("stable-routes-data"))
+	args := sts.Spec.Template.Spec.Containers[0].Args[0]
+	g.Expect(args).To(ContainSubstring("--api-host ${POD_IP}"))
+	g.Expect(args).To(ContainSubstring("--raft-host ${POD_IP}"))
+	g.Expect(args).To(ContainSubstring("--api-advertise-url http://${HOSTNAME}.stable-routes-data.antfly-system.svc.cluster.local:12380"))
+	g.Expect(args).To(ContainSubstring("--raft-advertise-url http://${HOSTNAME}.stable-routes-data.antfly-system.svc.cluster.local:9021"))
+}
+
 func TestUpdateStatus_Standalone(t *testing.T) {
 	g := NewWithT(t)
 


### PR DESCRIPTION
## Summary

- keep data API and Raft listeners bound to the Pod IP
- advertise stable StatefulSet pod DNS names through the headless service
- cover the generated API and Raft routes with a regression test

## Context

Extracted from #561 so the operator routing prerequisite can be reviewed and landed independently. The contributor's original authorship is retained.

After this lands, the corresponding operator routing commit can be dropped from #561.

## Validation

- `go test ./controllers/antfly`
