### PR TITLE
fix(cli): make restore polling resilient to transient responses

### DIFF
--- a/zig/pkg/antfly-client/src/client.zig
+++ b/zig/pkg/antfly-client/src/client.zig
@@ -417,12 +417,18 @@ pub const AntflyClient = struct {
     }
 
     pub fn getRestoreJob(self: *AntflyClient, job_id: []const u8) !openapi.ApiResponse(openapi.types.RestoreJob) {
-        var resp = try self.inner.getRestoreJob(job_id);
+        var resp = try self.getRestoreJobResponse(job_id);
         if (resp.status_code >= 300) {
             defer resp.deinit();
             return self.apiErrorFromResponse(&resp);
         }
         return resp;
+    }
+
+    /// Returns the restore status response without converting non-success
+    /// statuses so callers can honor the endpoint's retry contract.
+    pub fn getRestoreJobResponse(self: *AntflyClient, job_id: []const u8) !openapi.ApiResponse(openapi.types.RestoreJob) {
+        return self.inner.getRestoreJob(job_id);
     }
 
     pub fn cancelRestoreJob(self: *AntflyClient, job_id: []const u8) !openapi.ApiResponse(openapi.types.RestoreJob) {

--- a/zig/pkg/antfly/src/cmd/cli/backup.zig
+++ b/zig/pkg/antfly/src/cmd/cli/backup.zig
@@ -23,11 +23,12 @@ const portable_backup = antfly.portable_backup;
 
 const default_restore_wait_timeout_ms: u64 = 30 * 60 * 1000;
 const restore_poll_interval_ms: u64 = 1000;
+const restore_poll_ambiguous_grace_polls: u64 = 5;
 const max_restore_tables: usize = 256;
 const default_backup_list_limit: usize = 100;
 const max_backup_list_limit: usize = 1000;
 
-const RestorePollDisposition = enum { use_data, retry, invalid };
+const RestorePollDisposition = enum { retry, invalid };
 
 const BackupArgs = struct {
     help: bool = false,
@@ -255,22 +256,21 @@ pub fn waitForRestoreJob(
 ) !antfly_client.openapi.ApiResponse(antfly_client.types.RestoreJob) {
     const started_ns = platform_time.monotonicNs();
     const timeout_ns = std.math.mul(u64, timeout_ms, std.time.ns_per_ms) catch std.math.maxInt(u64);
+    var poll_index: u64 = 0;
     while (true) {
-        var response = try client.getRestoreJob(job_id);
+        var response = try client.getRestoreJobResponse(job_id);
         if (response.data) |*data| {
             if (isTerminalRestorePhase(data.value.phase)) return response;
-        } else if (classifyRestorePollResponse(response.status_code, false) == .invalid) {
+        } else if (classifyRestorePollResponse(response.status_code, poll_index) == .invalid) {
             cli.expectHttpSuccess(response);
             response.deinit();
             return error.InvalidRestoreResponse;
         } else {
-            // A distributed metadata follower can legitimately lag the
-            // replicated restore catalog for a short period. The endpoint's
-            // 503 contract is explicitly retryable; keep the canonical CLI
-            // usable behind a non-sticky load balancer instead of turning
-            // normal Raft propagation into a terminal restore failure.
+            // Followers can lag the replicated catalog, and load balancers or
+            // upstreams can fail transiently while the restore remains live.
         }
         response.deinit();
+        poll_index +|= 1;
         const elapsed_ns = platform_time.monotonicNs() -| started_ns;
         if (elapsed_ns >= timeout_ns) return error.RestoreWaitTimeout;
         const poll_ns = restore_poll_interval_ms * std.time.ns_per_ms;
@@ -279,9 +279,12 @@ pub fn waitForRestoreJob(
     }
 }
 
-fn classifyRestorePollResponse(status_code: u16, has_data: bool) RestorePollDisposition {
-    if (has_data) return .use_data;
-    return if (status_code == 503) .retry else .invalid;
+fn classifyRestorePollResponse(status_code: u16, poll_index: u64) RestorePollDisposition {
+    return switch (status_code) {
+        408, 429, 502, 503, 504 => .retry,
+        404, 500 => if (poll_index < restore_poll_ambiguous_grace_polls) .retry else .invalid,
+        else => .invalid,
+    };
 }
 
 pub fn isTerminalRestorePhase(phase: []const u8) bool {
@@ -768,11 +771,37 @@ test "restore cli validation rejects unsupported input extension" {
     try std.testing.expectError(error.InvalidRestoreInputPath, validateRestoreArgs(opts));
 }
 
-test "restore polling response classification retries only service unavailable" {
-    try std.testing.expectEqual(RestorePollDisposition.use_data, classifyRestorePollResponse(200, true));
-    try std.testing.expectEqual(RestorePollDisposition.retry, classifyRestorePollResponse(503, false));
-    try std.testing.expectEqual(RestorePollDisposition.invalid, classifyRestorePollResponse(404, false));
-    try std.testing.expectEqual(RestorePollDisposition.invalid, classifyRestorePollResponse(500, false));
+test "restore polling response classification retries transient statuses" {
+    var raw_status: u32 = 0;
+    while (raw_status <= std.math.maxInt(u16)) : (raw_status += 1) {
+        const status: u16 = @intCast(raw_status);
+        const initial_expected: RestorePollDisposition = switch (status) {
+            404, 408, 429, 500, 502, 503, 504 => .retry,
+            else => .invalid,
+        };
+        const after_grace_expected: RestorePollDisposition = switch (status) {
+            408, 429, 502, 503, 504 => .retry,
+            else => .invalid,
+        };
+        try std.testing.expectEqual(initial_expected, classifyRestorePollResponse(status, 0));
+        try std.testing.expectEqual(after_grace_expected, classifyRestorePollResponse(status, restore_poll_ambiguous_grace_polls));
+    }
+}
+
+test "restore polling response classification bounds ambiguous status grace" {
+    for ([_]u16{ 404, 500 }) |status| {
+        try std.testing.expectEqual(.retry, classifyRestorePollResponse(status, restore_poll_ambiguous_grace_polls - 1));
+        try std.testing.expectEqual(.invalid, classifyRestorePollResponse(status, restore_poll_ambiguous_grace_polls));
+        try std.testing.expectEqual(.invalid, classifyRestorePollResponse(status, std.math.maxInt(u64)));
+    }
+    for ([_]u16{ 408, 429, 502, 503, 504 }) |status| {
+        try std.testing.expectEqual(.retry, classifyRestorePollResponse(status, restore_poll_ambiguous_grace_polls));
+        try std.testing.expectEqual(.retry, classifyRestorePollResponse(status, std.math.maxInt(u64)));
+    }
+    for ([_]u16{ 400, 401, 403 }) |status| {
+        try std.testing.expectEqual(.invalid, classifyRestorePollResponse(status, 0));
+        try std.testing.expectEqual(.invalid, classifyRestorePollResponse(status, std.math.maxInt(u64)));
+    }
 }
 
 test "restore cli parser rejects unknown arguments" {

--- a/zig/pkg/antfly/src/cmd/cli/backup.zig
+++ b/zig/pkg/antfly/src/cmd/cli/backup.zig
@@ -23,12 +23,42 @@ const portable_backup = antfly.portable_backup;
 
 const default_restore_wait_timeout_ms: u64 = 30 * 60 * 1000;
 const restore_poll_interval_ms: u64 = 1000;
-const restore_poll_ambiguous_grace_polls: u64 = 5;
+const restore_poll_ambiguous_grace_polls: u8 = 5;
 const max_restore_tables: usize = 256;
 const default_backup_list_limit: usize = 100;
 const max_backup_list_limit: usize = 1000;
 
-const RestorePollDisposition = enum { retry, invalid };
+const RestorePollDisposition = enum { use_data, retry, invalid };
+
+const RestorePollState = struct {
+    consecutive_ambiguous_polls: u8 = 0,
+
+    fn observe(self: *RestorePollState, status_code: u16, has_data: bool) RestorePollDisposition {
+        if (has_data) {
+            self.consecutive_ambiguous_polls = 0;
+            return .use_data;
+        }
+
+        return switch (status_code) {
+            // Explicitly transient responses reset the bounded ambiguity
+            // streak. The overall restore timeout still bounds retries.
+            408, 429, 502, 503, 504 => blk: {
+                self.consecutive_ambiguous_polls = 0;
+                break :blk .retry;
+            },
+            // A follower can briefly lack a newly committed job, and an
+            // upstream can emit a short 500 burst. Bound only consecutive
+            // ambiguous observations so a late blip does not terminate an
+            // otherwise healthy long-running restore.
+            404, 500 => blk: {
+                if (self.consecutive_ambiguous_polls >= restore_poll_ambiguous_grace_polls) break :blk .invalid;
+                self.consecutive_ambiguous_polls += 1;
+                break :blk .retry;
+            },
+            else => .invalid,
+        };
+    }
+};
 
 const BackupArgs = struct {
     help: bool = false,
@@ -256,12 +286,14 @@ pub fn waitForRestoreJob(
 ) !antfly_client.openapi.ApiResponse(antfly_client.types.RestoreJob) {
     const started_ns = platform_time.monotonicNs();
     const timeout_ns = std.math.mul(u64, timeout_ms, std.time.ns_per_ms) catch std.math.maxInt(u64);
-    var poll_index: u64 = 0;
+    var poll_state = RestorePollState{};
     while (true) {
         var response = try client.getRestoreJobResponse(job_id);
+        const disposition = poll_state.observe(response.status_code, response.data != null);
         if (response.data) |*data| {
+            std.debug.assert(disposition == .use_data);
             if (isTerminalRestorePhase(data.value.phase)) return response;
-        } else if (classifyRestorePollResponse(response.status_code, poll_index) == .invalid) {
+        } else if (disposition == .invalid) {
             cli.expectHttpSuccess(response);
             response.deinit();
             return error.InvalidRestoreResponse;
@@ -270,21 +302,12 @@ pub fn waitForRestoreJob(
             // upstreams can fail transiently while the restore remains live.
         }
         response.deinit();
-        poll_index +|= 1;
         const elapsed_ns = platform_time.monotonicNs() -| started_ns;
         if (elapsed_ns >= timeout_ns) return error.RestoreWaitTimeout;
         const poll_ns = restore_poll_interval_ms * std.time.ns_per_ms;
         const delay_ns = @min(poll_ns, timeout_ns - elapsed_ns);
         io.sleep(std.Io.Duration.fromNanoseconds(@intCast(delay_ns)), .awake) catch return error.RestoreWaitInterrupted;
     }
-}
-
-fn classifyRestorePollResponse(status_code: u16, poll_index: u64) RestorePollDisposition {
-    return switch (status_code) {
-        408, 429, 502, 503, 504 => .retry,
-        404, 500 => if (poll_index < restore_poll_ambiguous_grace_polls) .retry else .invalid,
-        else => .invalid,
-    };
 }
 
 pub fn isTerminalRestorePhase(phase: []const u8) bool {
@@ -775,33 +798,47 @@ test "restore polling response classification retries transient statuses" {
     var raw_status: u32 = 0;
     while (raw_status <= std.math.maxInt(u16)) : (raw_status += 1) {
         const status: u16 = @intCast(raw_status);
+        var state = RestorePollState{};
         const initial_expected: RestorePollDisposition = switch (status) {
             404, 408, 429, 500, 502, 503, 504 => .retry,
             else => .invalid,
         };
-        const after_grace_expected: RestorePollDisposition = switch (status) {
-            408, 429, 502, 503, 504 => .retry,
-            else => .invalid,
-        };
-        try std.testing.expectEqual(initial_expected, classifyRestorePollResponse(status, 0));
-        try std.testing.expectEqual(after_grace_expected, classifyRestorePollResponse(status, restore_poll_ambiguous_grace_polls));
+        try std.testing.expectEqual(initial_expected, state.observe(status, false));
+    }
+
+    var success_state = RestorePollState{ .consecutive_ambiguous_polls = restore_poll_ambiguous_grace_polls };
+    try std.testing.expectEqual(.use_data, success_state.observe(200, true));
+    try std.testing.expectEqual(@as(u8, 0), success_state.consecutive_ambiguous_polls);
+    try std.testing.expectEqual(.invalid, success_state.observe(200, false));
+}
+
+test "restore polling response classification bounds consecutive ambiguity" {
+    for ([_]u16{ 404, 500 }) |status| {
+        var state = RestorePollState{};
+        for (0..restore_poll_ambiguous_grace_polls) |_| {
+            try std.testing.expectEqual(.retry, state.observe(status, false));
+        }
+        try std.testing.expectEqual(.invalid, state.observe(status, false));
     }
 }
 
-test "restore polling response classification bounds ambiguous status grace" {
-    for ([_]u16{ 404, 500 }) |status| {
-        try std.testing.expectEqual(.retry, classifyRestorePollResponse(status, restore_poll_ambiguous_grace_polls - 1));
-        try std.testing.expectEqual(.invalid, classifyRestorePollResponse(status, restore_poll_ambiguous_grace_polls));
-        try std.testing.expectEqual(.invalid, classifyRestorePollResponse(status, std.math.maxInt(u64)));
+test "restore polling response classification resets ambiguity after recovery" {
+    var state = RestorePollState{};
+    for (0..restore_poll_ambiguous_grace_polls) |_| {
+        try std.testing.expectEqual(.retry, state.observe(404, false));
     }
-    for ([_]u16{ 408, 429, 502, 503, 504 }) |status| {
-        try std.testing.expectEqual(.retry, classifyRestorePollResponse(status, restore_poll_ambiguous_grace_polls));
-        try std.testing.expectEqual(.retry, classifyRestorePollResponse(status, std.math.maxInt(u64)));
+
+    // A long-running restore can produce many healthy observations before a
+    // follower or upstream briefly becomes ambiguous again.
+    try std.testing.expectEqual(.use_data, state.observe(200, true));
+    for (0..32) |_| try std.testing.expectEqual(.use_data, state.observe(200, true));
+    for (0..restore_poll_ambiguous_grace_polls) |_| {
+        try std.testing.expectEqual(.retry, state.observe(500, false));
     }
-    for ([_]u16{ 400, 401, 403 }) |status| {
-        try std.testing.expectEqual(.invalid, classifyRestorePollResponse(status, 0));
-        try std.testing.expectEqual(.invalid, classifyRestorePollResponse(status, std.math.maxInt(u64)));
-    }
+
+    // Explicitly transient statuses also break an ambiguous streak.
+    try std.testing.expectEqual(.retry, state.observe(503, false));
+    try std.testing.expectEqual(.retry, state.observe(404, false));
 }
 
 test "restore cli parser rejects unknown arguments" {


### PR DESCRIPTION
## Summary

- classify restore polling responses before the generated client turns non-2xx statuses into generic errors
- retry 408, 429, 502, 503, and 504 responses until the overall timeout
- tolerate only a bounded run of consecutive ambiguous 404/500 responses
- reset the ambiguity grace period after a valid response or an explicitly transient response
- add regression coverage for classification, late failures, recovery, and grace-period reset behavior

## Context

Extracted and hardened from #561 so restore polling resilience can be reviewed separately from the distributed state-machine changes.

The consecutive-failure accounting is important: counting total polls would make a healthy long-running restore fail immediately on a late transient response. After this lands, the corresponding restore polling changes can be dropped from #561.

## Validation

- `zig build cmd-test -fincremental --summary all -- --test-filter 'restore polling response classification'` (88/88 passed, no leaks)
