### PR TITLE
fix(inference): preserve preload registry variants

### DIFF
--- a/zig/build.zig
+++ b/zig/build.zig
@@ -3417,6 +3417,21 @@ pub fn build(b: *std.Build) void {
     const lib_common_config_test_step = b.step("lib-common-config-test", "Run common/config tests");
     lib_common_config_test_step.dependOn(&run_lib_common_config_tests.step);
 
+    const lib_preload_model_spec_tests = b.addTest(.{
+        .root_module = lib_test_mod,
+        .filters = &.{
+            "preload model spec parser categorizes registry variants and backends",
+            "inference runtime preload parser preserves registry variants and explicit backends",
+        },
+        .test_runner = .{
+            .path = b.path("pkg/antfly/src/test_runner.zig"),
+            .mode = .simple,
+        },
+    });
+    const run_lib_preload_model_spec_tests = addFilteredTestRunArtifact(b, lib_preload_model_spec_tests);
+    const lib_preload_model_spec_test_step = b.step("lib-preload-model-spec-test", "Run preload model CLI parser tests");
+    lib_preload_model_spec_test_step.dependOn(&run_lib_preload_model_spec_tests.step);
+
     const lib_common_secrets_tests = b.addTest(.{
         .root_module = lib_test_mod,
         .filters = &.{ "file secret store", "remote content runtime" },
@@ -6957,6 +6972,7 @@ pub fn build(b: *std.Build) void {
             "parse cli accepts secret store path",
             "parse cli accepts ARD identity flags",
             "parse cli accepts canonical host port and models dir flags",
+            "parse cli preserves registry variants and recognizes explicit preload backends",
             "parse cli accepts HA primary runtime flags",
             "parse cli accepts HA primary sync policy flags",
             "parse cli accepts HA standby runtime flags",
@@ -7045,6 +7061,7 @@ pub fn build(b: *std.Build) void {
     unit_test_step.dependOn(&run_lib_reranking_runtime_tests.step);
     unit_test_step.dependOn(&run_lib_common_tests.step);
     unit_test_step.dependOn(&run_lib_common_config_tests.step);
+    unit_test_step.dependOn(&run_lib_preload_model_spec_tests.step);
     unit_test_step.dependOn(&run_lib_common_secrets_tests.step);
     unit_test_step.dependOn(&run_httpx_transport_regression_tests.step);
     unit_test_step.dependOn(&run_api_http_runtime_tests.step);

--- a/zig/pkg/antfly/src/common/preload_model_spec.zig
+++ b/zig/pkg/antfly/src/common/preload_model_spec.zig
@@ -1,0 +1,64 @@
+// Copyright 2026 Antfly, Inc.
+//
+// Licensed under the Elastic License 2.0 (ELv2); you may not use this file
+// except in compliance with the Elastic License 2.0. You may obtain a copy of
+// the License at https://www.antfly.io/licensing/ELv2-license
+
+const std = @import("std");
+
+pub const Spec = struct {
+    kind: []const u8,
+    name: []const u8,
+    backend: ?[]const u8,
+};
+
+fn isBackend(value: []const u8) bool {
+    return std.mem.eql(u8, value, "native") or
+        std.mem.eql(u8, value, "onnx") or
+        std.mem.eql(u8, value, "metal") or
+        std.mem.eql(u8, value, "cuda") or
+        std.mem.eql(u8, value, "xla") or
+        std.mem.eql(u8, value, "pjrt") or
+        std.mem.eql(u8, value, "wasm") or
+        std.mem.eql(u8, value, "webgpu");
+}
+
+pub fn parse(value: []const u8) !Spec {
+    const separator = std.mem.indexOfScalar(u8, value, ':') orelse return error.InvalidArguments;
+    const kind = value[0..separator];
+    if (kind.len == 0) return error.InvalidArguments;
+
+    var name = value[separator + 1 ..];
+    var backend: ?[]const u8 = null;
+    if (std.mem.indexOfScalar(u8, name, ':')) |backend_separator| {
+        const candidate = name[0..backend_separator];
+        if (isBackend(candidate)) {
+            backend = candidate;
+            name = name[backend_separator + 1 ..];
+        }
+    }
+    if (name.len == 0) return error.InvalidArguments;
+    return .{ .kind = kind, .name = name, .backend = backend };
+}
+
+test "preload model spec parser categorizes registry variants and backends" {
+    const variant = try parse("embedder:BAAI/bge-small-en-v1.5:i8");
+    try std.testing.expectEqualStrings("embedder", variant.kind);
+    try std.testing.expectEqualStrings("BAAI/bge-small-en-v1.5:i8", variant.name);
+    try std.testing.expectEqual(null, variant.backend);
+
+    const multi_component_variant = try parse("generator:owner/model:gguf:Q4_K_M");
+    try std.testing.expectEqualStrings("owner/model:gguf:Q4_K_M", multi_component_variant.name);
+    try std.testing.expectEqual(null, multi_component_variant.backend);
+
+    for ([_][]const u8{ "native", "onnx", "metal", "cuda", "xla", "pjrt", "wasm", "webgpu" }) |backend| {
+        var buffer: [96]u8 = undefined;
+        const value = try std.fmt.bufPrint(&buffer, "embedder:{s}:owner/model:i8", .{backend});
+        const spec = try parse(value);
+        try std.testing.expectEqualStrings(backend, spec.backend.?);
+        try std.testing.expectEqualStrings("owner/model:i8", spec.name);
+    }
+
+    try std.testing.expectError(error.InvalidArguments, parse("embedder:"));
+    try std.testing.expectError(error.InvalidArguments, parse("embedder:metal:"));
+}

--- a/zig/pkg/antfly/src/inference_runtime/runtime.zig
+++ b/zig/pkg/antfly/src/inference_runtime/runtime.zig
@@ -16,6 +16,7 @@ const std = @import("std");
 const build_options = @import("build_options");
 const platform = @import("antfly_platform");
 const common_config = @import("../common/config.zig");
+const preload_model_spec = @import("../common/preload_model_spec.zig");
 const process_memory_budget = @import("../common/process_memory_budget.zig");
 const runtime_lifecycle = @import("../common/runtime_lifecycle.zig");
 const inference = @import("inference_server");
@@ -174,20 +175,11 @@ fn parsePreloadModelKind(value: []const u8) ?inference.server.WarmModelKind {
 }
 
 fn parsePreloadModelFlag(value: []const u8) !inference.server.WarmModel {
-    const separator = std.mem.indexOfScalar(u8, value, ':') orelse return error.InvalidArguments;
-    const kind_name = value[0..separator];
-    var model_name = value[separator + 1 ..];
-    var backend: ?inference.backends.BackendType = null;
-    if (std.mem.indexOfScalar(u8, model_name, ':')) |backend_separator| {
-        const backend_name = model_name[0..backend_separator];
-        backend = parseBackendType(backend_name) orelse return error.InvalidArguments;
-        model_name = model_name[backend_separator + 1 ..];
-    }
-    if (model_name.len == 0) return error.InvalidArguments;
+    const spec = try preload_model_spec.parse(value);
     return .{
-        .kind = parsePreloadModelKind(kind_name) orelse return error.InvalidArguments,
-        .name = model_name,
-        .backend = backend,
+        .kind = parsePreloadModelKind(spec.kind) orelse return error.InvalidArguments,
+        .name = spec.name,
+        .backend = if (spec.backend) |backend| parseBackendType(backend) orelse return error.InvalidArguments else null,
         .format = null,
         .quantization = null,
     };
@@ -883,6 +875,33 @@ test "inference runtime module compiles" {
     _ = run;
     _ = runFromIterator;
     _ = spawnServerProcess;
+}
+
+test "inference runtime preload parser preserves registry variants and explicit backends" {
+    const variant = try parsePreloadModelFlag("embedder:BAAI/bge-small-en-v1.5:i8");
+    try std.testing.expectEqual(.embedder, variant.kind);
+    try std.testing.expectEqualStrings("BAAI/bge-small-en-v1.5:i8", variant.name);
+    try std.testing.expectEqual(null, variant.backend);
+
+    const multi_component_variant = try parsePreloadModelFlag("generator:owner/model:gguf:Q4_K_M");
+    try std.testing.expectEqualStrings("owner/model:gguf:Q4_K_M", multi_component_variant.name);
+    try std.testing.expectEqual(null, multi_component_variant.backend);
+
+    const explicit_backend = try parsePreloadModelFlag("generator:metal:owner/model:Q4_K_M");
+    try std.testing.expectEqual(.generator, explicit_backend.kind);
+    try std.testing.expectEqualStrings("owner/model:Q4_K_M", explicit_backend.name);
+    try std.testing.expectEqual(.metal, explicit_backend.backend.?);
+
+    for ([_][]const u8{ "native", "onnx", "metal", "cuda", "xla", "pjrt", "wasm", "webgpu" }) |backend| {
+        var buffer: [96]u8 = undefined;
+        const value = try std.fmt.bufPrint(&buffer, "embedder:{s}:owner/model:i8", .{backend});
+        const spec = try preload_model_spec.parse(value);
+        try std.testing.expectEqualStrings(backend, spec.backend.?);
+        try std.testing.expectEqualStrings("owner/model:i8", spec.name);
+    }
+
+    try std.testing.expectError(error.InvalidArguments, preload_model_spec.parse("embedder:"));
+    try std.testing.expectError(error.InvalidArguments, preload_model_spec.parse("embedder:metal:"));
 }
 
 test "inference runtime preserves effective process envelope provenance" {

--- a/zig/pkg/antfly/src/standalone/runtime.zig
+++ b/zig/pkg/antfly/src/standalone/runtime.zig
@@ -22,6 +22,7 @@ const group_ids = @import("../common/group_ids.zig");
 const threaded_io_limits = @import("../common/threaded_io_limits.zig");
 const fs_paths = @import("../common/fs_paths.zig");
 const process_memory_budget = @import("../common/process_memory_budget.zig");
+const preload_model_spec = @import("../common/preload_model_spec.zig");
 const platform_time = @import("antfly_platform").time;
 const platform = @import("antfly_platform");
 const inference_bridge = @import("inference_bridge.zig");
@@ -3425,33 +3426,12 @@ fn validPreloadModelKind(value: []const u8) bool {
         std.mem.eql(u8, value, "extractor");
 }
 
-fn validInferenceBackend(value: []const u8) bool {
-    return std.mem.eql(u8, value, "native") or
-        std.mem.eql(u8, value, "onnx") or
-        std.mem.eql(u8, value, "metal") or
-        std.mem.eql(u8, value, "cuda") or
-        std.mem.eql(u8, value, "xla") or
-        std.mem.eql(u8, value, "pjrt") or
-        std.mem.eql(u8, value, "wasm") or
-        std.mem.eql(u8, value, "webgpu");
-}
-
 fn parsePreloadModelFlag(value: []const u8) !inference_bridge.WarmModel {
-    const separator = std.mem.indexOfScalar(u8, value, ':') orelse return error.InvalidArguments;
-    const kind_name = value[0..separator];
-    var model_name = value[separator + 1 ..];
-    var backend: ?[]const u8 = null;
-    if (std.mem.indexOfScalar(u8, model_name, ':')) |backend_separator| {
-        const backend_name = model_name[0..backend_separator];
-        if (!validInferenceBackend(backend_name)) return error.InvalidArguments;
-        backend = backend_name;
-        model_name = model_name[backend_separator + 1 ..];
-    }
-    if (model_name.len == 0) return error.InvalidArguments;
+    const spec = try preload_model_spec.parse(value);
     return .{
-        .kind = inference_bridge.String.init(if (validPreloadModelKind(kind_name)) kind_name else return error.InvalidArguments),
-        .name = inference_bridge.String.init(model_name),
-        .backend = inference_bridge.OptionalString.init(backend),
+        .kind = inference_bridge.String.init(if (validPreloadModelKind(spec.kind)) spec.kind else return error.InvalidArguments),
+        .name = inference_bridge.String.init(spec.name),
+        .backend = inference_bridge.OptionalString.init(spec.backend),
     };
 }
 
@@ -6089,6 +6069,24 @@ test "parse cli accepts canonical host port and models dir flags" {
     try std.testing.expectEqualStrings("gemma-e2b", cfg.inference_preload_models.items[0].name.slice());
     try std.testing.expectEqualStrings("metal", cfg.inference_preload_models.items[0].backend.slice().?);
     try std.testing.expectEqualStrings("/tmp/antfly-data", cfg.data_dir.?);
+}
+
+test "parse cli preserves registry variants and recognizes explicit preload backends" {
+    var argv = [_][*:0]const u8{
+        "--preload-model",
+        "embedder:owner/model:i8",
+        "--preload-model",
+        "generator:metal:owner/model:Q4_K_M",
+    };
+    var iter = std.process.Args.Iterator.init(.{ .vector = argv[0..] });
+    var cfg = try parseCli(std.testing.allocator, &iter);
+    defer cfg.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), cfg.inference_preload_models.items.len);
+    try std.testing.expectEqualStrings("owner/model:i8", cfg.inference_preload_models.items[0].name.slice());
+    try std.testing.expect(cfg.inference_preload_models.items[0].backend.slice() == null);
+    try std.testing.expectEqualStrings("owner/model:Q4_K_M", cfg.inference_preload_models.items[1].name.slice());
+    try std.testing.expectEqualStrings("metal", cfg.inference_preload_models.items[1].backend.slice().?);
 }
 
 test "parse cli accepts HA primary runtime flags" {

--- a/zig/pkg/inference/src/main.zig
+++ b/zig/pkg/inference/src/main.zig
@@ -174,8 +174,10 @@ fn parsePreloadModelFlag(value: []const u8) !inference.server.WarmModel {
     var backend: ?inference.backends.BackendType = null;
     if (std.mem.indexOfScalar(u8, model_name, ':')) |backend_separator| {
         const backend_name = model_name[0..backend_separator];
-        backend = parseBackendType(backend_name) orelse return error.InvalidArguments;
-        model_name = model_name[backend_separator + 1 ..];
+        if (parseBackendType(backend_name)) |parsed_backend| {
+            backend = parsed_backend;
+            model_name = model_name[backend_separator + 1 ..];
+        }
     }
     if (model_name.len == 0) return error.InvalidArguments;
     return .{
@@ -185,6 +187,21 @@ fn parsePreloadModelFlag(value: []const u8) !inference.server.WarmModel {
         .format = null,
         .quantization = null,
     };
+}
+
+test "preload model parser preserves registry variants and recognizes explicit backends" {
+    const variant = try parsePreloadModelFlag("embedder:owner/model:i8");
+    try std.testing.expectEqual(inference.server.WarmModelKind.embedder, variant.kind);
+    try std.testing.expectEqualStrings("owner/model:i8", variant.name);
+    try std.testing.expect(variant.backend == null);
+
+    const multi_component_variant = try parsePreloadModelFlag("generator:owner/model:gguf:Q4_K_M");
+    try std.testing.expectEqualStrings("owner/model:gguf:Q4_K_M", multi_component_variant.name);
+    try std.testing.expect(multi_component_variant.backend == null);
+
+    const backend = try parsePreloadModelFlag("generator:metal:owner/model:i8");
+    try std.testing.expectEqualStrings("owner/model:i8", backend.name);
+    try std.testing.expectEqual(inference.backends.BackendType.metal, backend.backend.?);
 }
 
 fn parseAdmissionLimit(value: []const u8) !usize {


### PR DESCRIPTION
## Summary

- centralize preload model spec parsing for the main and standalone inference runtimes
- preserve registry variants such as `owner/model:i8` and `owner/model:gguf:Q4_K_M`
- treat a prefix as a backend only when it names a supported backend explicitly
- add coverage for variant-preserving and explicit-backend forms in both runtimes

## Context

Extracted from #561 so this CLI parsing fix can land independently of eager-preload orchestration. The contributor's original authorship is retained.

After this lands, the corresponding parser changes can be dropped from #561.

## Validation

- `zig build lib-preload-model-spec-test -fincremental --summary all` (2/2 passed)
- `zig build lib-standalone-runtime-test -fincremental --summary all -- --test-filter 'parse cli preserves registry variants and recognizes explicit preload backends'` (64/64 passed)
- from `zig/pkg/inference`: `zig build test-cli -fincremental --summary all -- --test-filter 'preload model parser preserves registry variants and recognizes explicit backends'` (1/1 passed)
