### PR TITLE
fix(operator): support custom Kubernetes cluster domains

### DIFF
--- a/go/pkg/operator/cmd/antfly-operator/main.go
+++ b/go/pkg/operator/cmd/antfly-operator/main.go
@@ -55,6 +55,7 @@ func main() {
 	var skipCRDInstall bool
 	var enableInferenceControllers bool
 	var inferenceAntflyImage string
+	var clusterDomain string
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
@@ -66,14 +67,21 @@ func main() {
 		"Enable InferencePool and InferenceProxy controllers and AntflyCluster.spec.inference management. CRD installation remains unconditional unless --skip-crd-install is set.")
 	flag.StringVar(&inferenceAntflyImage, "inference-antfly-image", defaultInferenceImage,
 		"Default Zig Antfly image for InferencePool pods. The image must provide the /antfly inference runtime contract.")
+	flag.StringVar(&clusterDomain, "cluster-domain", controllers.DefaultClusterDomain,
+		"Kubernetes DNS cluster domain used for internal Service and StatefulSet pod addresses.")
 	opts := zap.Options{
 		Development: false,
 		TimeEncoder: zapcore.RFC3339TimeEncoder,
 	}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
-
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+
+	clusterDomain, err := controllers.NormalizeClusterDomain(clusterDomain)
+	if err != nil {
+		setupLog.Error(err, "invalid operator configuration", "option", "cluster-domain")
+		os.Exit(2)
+	}
 
 	mgrOpts := ctrl.Options{
 		Scheme:                 scheme,
@@ -106,6 +114,7 @@ func main() {
 	setupLog.Info("operator configuration",
 		"enableInferenceControllers", enableInferenceControllers,
 		"inferenceAntflyImage", inferenceAntflyImage,
+		"clusterDomain", clusterDomain,
 		"skipCRDInstall", skipCRDInstall,
 		"webhooksEnabled", webhooksEnabled(),
 	)
@@ -122,24 +131,27 @@ func main() {
 		Recorder:              mgr.GetEventRecorder("antfly-operator"),
 		ManageInferencePools:  enableInferenceControllers,
 		DefaultInferenceImage: inferenceAntflyImage,
+		ClusterDomain:         clusterDomain,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "AntflyCluster")
 		os.Exit(1)
 	}
 
 	if err = (&controllers.AntflyBackupReconciler{
-		Client:   mgr.GetClient(),
-		Scheme:   mgr.GetScheme(),
-		Recorder: mgr.GetEventRecorder("antfly-backup"),
+		Client:        mgr.GetClient(),
+		Scheme:        mgr.GetScheme(),
+		Recorder:      mgr.GetEventRecorder("antfly-backup"),
+		ClusterDomain: clusterDomain,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "AntflyBackup")
 		os.Exit(1)
 	}
 
 	if err = (&controllers.AntflyRestoreReconciler{
-		Client:   mgr.GetClient(),
-		Scheme:   mgr.GetScheme(),
-		Recorder: mgr.GetEventRecorder("antfly-restore"),
+		Client:        mgr.GetClient(),
+		Scheme:        mgr.GetScheme(),
+		Recorder:      mgr.GetEventRecorder("antfly-restore"),
+		ClusterDomain: clusterDomain,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "AntflyRestore")
 		os.Exit(1)

--- a/go/pkg/operator/controllers/antfly/antflybackup_controller.go
+++ b/go/pkg/operator/controllers/antfly/antflybackup_controller.go
@@ -29,8 +29,9 @@ import (
 // AntflyBackupReconciler reconciles an AntflyBackup object
 type AntflyBackupReconciler struct {
 	client.Client
-	Scheme   *runtime.Scheme
-	Recorder events.EventRecorder
+	Scheme        *runtime.Scheme
+	Recorder      events.EventRecorder
+	ClusterDomain string
 }
 
 //+kubebuilder:rbac:groups=antfly.io,resources=antflybackups,verbs=get;list;watch;create;update;patch;delete
@@ -164,8 +165,7 @@ func (r *AntflyBackupReconciler) buildCronJobSpec(backup *antflyv1.AntflyBackup,
 	}
 
 	// Build the cluster API URL using the public-api service
-	clusterURL := fmt.Sprintf("http://%s-public-api.%s.svc.cluster.local",
-		cluster.Name, clusterNamespace)
+	clusterURL := "http://" + serviceDNSName(cluster.Name+"-public-api", clusterNamespace, r.ClusterDomain)
 
 	// Build shell command. All user-controlled values are shell-quoted to
 	// prevent injection. backup.Name is additionally safe because Kubernetes
@@ -506,6 +506,9 @@ func (r *AntflyBackupReconciler) setCondition(backup *antflyv1.AntflyBackup, con
 
 // SetupWithManager sets up the controller with the Manager
 func (r *AntflyBackupReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	if err := normalizeClusterDomainField(&r.ClusterDomain); err != nil {
+		return fmt.Errorf("configure AntflyBackup controller: %w", err)
+	}
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&antflyv1.AntflyBackup{}).
 		Owns(&batchv1.CronJob{}).

--- a/go/pkg/operator/controllers/antfly/antflybackup_controller_test.go
+++ b/go/pkg/operator/controllers/antfly/antflybackup_controller_test.go
@@ -260,7 +260,7 @@ func backupJob(name, namespace, backupName string, conditionType batchv1.JobCond
 }
 
 func TestBuildCronJobSpec_CommandStructure(t *testing.T) {
-	r := &AntflyBackupReconciler{}
+	r := &AntflyBackupReconciler{ClusterDomain: "corp.internal"}
 	backup := &antflyv1.AntflyBackup{
 		ObjectMeta: metav1.ObjectMeta{Name: "my-backup", Namespace: "default"},
 		Spec: antflyv1.AntflyBackupSpec{
@@ -292,7 +292,7 @@ func TestBuildCronJobSpec_CommandStructure(t *testing.T) {
 		t.Errorf("command should not use stale --url flag: %s", cmd)
 	}
 
-	if got := envValue(container.Env, "ANTFLY_URL"); got != "http://my-cluster-public-api.default.svc.cluster.local" {
+	if got := envValue(container.Env, "ANTFLY_URL"); got != "http://my-cluster-public-api.default.svc.corp.internal" {
 		t.Errorf("ANTFLY_URL = %q, want cluster public API URL", got)
 	}
 

--- a/go/pkg/operator/controllers/antfly/antflycluster_controller.go
+++ b/go/pkg/operator/controllers/antfly/antflycluster_controller.go
@@ -69,6 +69,7 @@ type AntflyClusterReconciler struct {
 	Recorder              events.EventRecorder
 	ManageInferencePools  bool
 	DefaultInferenceImage string
+	ClusterDomain         string
 	Now                   func() time.Time
 	// MonotonicNow is a test hook for process-local HA watchdog barriers. In
 	// production it is nil and time.Now retains its monotonic clock reading.
@@ -1957,8 +1958,9 @@ func (r *AntflyClusterReconciler) fetchMetadataRuntimeTopology(ctx context.Conte
 	// steady-state monitoring must not clone the projected catalog.
 	paths := [...]string{metadataRuntimeTopologyPath, metadataRuntimeStatusPath}
 	for pathIndex, requestPath := range paths {
-		url := fmt.Sprintf("http://%s-metadata-%d.%s-metadata.%s.svc.cluster.local:%d%s",
-			cluster.Name, ordinal, cluster.Name, cluster.Namespace, cluster.Spec.MetadataNodes.MetadataAPI.Port, requestPath)
+		podName := fmt.Sprintf("%s-metadata-%d", cluster.Name, ordinal)
+		host := statefulPodDNSName(podName, cluster.Name+"-metadata", cluster.Namespace, r.ClusterDomain)
+		url := fmt.Sprintf("http://%s:%d%s", host, cluster.Spec.MetadataNodes.MetadataAPI.Port, requestPath)
 		req, err := http.NewRequestWithContext(probeCtx, http.MethodGet, url, nil)
 		if err != nil {
 			return nil, fmt.Errorf("create metadata topology request: %w", err)
@@ -3157,7 +3159,7 @@ func managedInferencePoolName(cluster *antflyv1.AntflyCluster, managed antflyv1.
 	return fmt.Sprintf("%s-inference-%d", cluster.Name, index)
 }
 
-func configuredInferenceAPIURL(cluster *antflyv1.AntflyCluster) string {
+func (r *AntflyClusterReconciler) configuredInferenceAPIURL(cluster *antflyv1.AntflyCluster) string {
 	if cluster.Spec.Inference == nil {
 		return ""
 	}
@@ -3167,7 +3169,7 @@ func configuredInferenceAPIURL(cluster *antflyv1.AntflyCluster) string {
 		for i, managed := range inference.ManagedPools {
 			name := managedInferencePoolName(cluster, managed, len(inference.ManagedPools), i)
 			if strings.TrimSpace(name) != "" {
-				return fmt.Sprintf("http://%s.%s.svc.cluster.local:%d", name, cluster.Namespace, defaultManagedInferenceAPIPort)
+				return fmt.Sprintf("http://%s:%d", serviceDNSName(name, cluster.Namespace, r.ClusterDomain), defaultManagedInferenceAPIPort)
 			}
 		}
 	case antflyv1.AntflyInferenceModeSharedRef:
@@ -3399,8 +3401,9 @@ func (r *AntflyClusterReconciler) generateDistributedConfig(cluster *antflyv1.An
 
 	orchestrationURLs := make(map[string]string, metadataReplicas)
 	for i := uint64(1); i <= uint64(max(metadataReplicas, 0)); i++ { //nolint:gosec // G115: metadataReplicas is a small positive Kubernetes replica count
-		url := fmt.Sprintf("http://%s-metadata-%d.%s-metadata.%s.svc.cluster.local:%d",
-			cluster.Name, i-1, cluster.Name, cluster.Namespace, cluster.Spec.MetadataNodes.MetadataAPI.Port)
+		podName := fmt.Sprintf("%s-metadata-%d", cluster.Name, i-1)
+		host := statefulPodDNSName(podName, cluster.Name+"-metadata", cluster.Namespace, r.ClusterDomain)
+		url := fmt.Sprintf("http://%s:%d", host, cluster.Spec.MetadataNodes.MetadataAPI.Port)
 		s := strconv.FormatUint(i, 16)
 		orchestrationURLs[s] = url
 	}
@@ -3440,7 +3443,7 @@ func (r *AntflyClusterReconciler) generateDistributedConfig(cluster *antflyv1.An
 		},
 	}
 	completeConfig["storage"] = storageConfig
-	if apiURL := configuredInferenceAPIURL(cluster); apiURL != "" {
+	if apiURL := r.configuredInferenceAPIURL(cluster); apiURL != "" {
 		ensureInferenceAPIURL(completeConfig, apiURL)
 	}
 
@@ -3486,7 +3489,7 @@ func (r *AntflyClusterReconciler) generateStandaloneConfig(cluster *antflyv1.Ant
 	}
 
 	orchestrationURLs := map[string]string{
-		strconv.FormatInt(int64(standalone.NodeID), 16): fmt.Sprintf("http://%s.%s.svc.cluster.local:%d", standaloneStatefulSetName(cluster), cluster.Namespace, standalone.MetadataAPI.Port),
+		strconv.FormatInt(int64(standalone.NodeID), 16): fmt.Sprintf("http://%s:%d", serviceDNSName(standaloneStatefulSetName(cluster), cluster.Namespace, r.ClusterDomain), standalone.MetadataAPI.Port),
 	}
 
 	completeConfig := map[string]any{
@@ -4379,12 +4382,14 @@ func (r *AntflyClusterReconciler) buildMetadataClusterConfig(cluster *antflyv1.A
 		if i > 1 {
 			config.WriteString(", ")
 		}
+		podName := fmt.Sprintf("%s-metadata-%d", cluster.Name, i-1)
+		host := statefulPodDNSName(podName, cluster.Name+"-metadata", cluster.Namespace, r.ClusterDomain)
 		fmt.Fprintf(
 			&config,
-			`"%d": {"raft_url":"http://%s-metadata-%d.%s-metadata.%s.svc.cluster.local:%d","orchestration_url":"http://%s-metadata-%d.%s-metadata.%s.svc.cluster.local:%d"}`,
+			`"%d": {"raft_url":"http://%s:%d","orchestration_url":"http://%s:%d"}`,
 			i,
-			cluster.Name, i-1, cluster.Name, cluster.Namespace, cluster.Spec.MetadataNodes.MetadataRaft.Port,
-			cluster.Name, i-1, cluster.Name, cluster.Namespace, cluster.Spec.MetadataNodes.MetadataAPI.Port,
+			host, cluster.Spec.MetadataNodes.MetadataRaft.Port,
+			host, cluster.Spec.MetadataNodes.MetadataAPI.Port,
 		)
 	}
 	config.WriteString(" }")
@@ -4393,6 +4398,7 @@ func (r *AntflyClusterReconciler) buildMetadataClusterConfig(cluster *antflyv1.A
 
 func (r *AntflyClusterReconciler) reconcileDataStatefulSet(ctx context.Context, cache *envFromCache, cluster *antflyv1.AntflyCluster) error {
 	replicas := effectiveDataNodeReplicas(cluster)
+	dataAdvertiseHost := "${HOSTNAME}." + serviceDNSName(cluster.Name+"-data", cluster.Namespace, r.ClusterDomain)
 
 	storageSize := "1Gi"
 	if cluster.Spec.Storage.DataStorage != "" {
@@ -4516,19 +4522,17 @@ ID=$((ORDINAL + 1))
 exec /antfly data --node-id $ID --store-id $ID --config /config/config.json \
   --api-host ${POD_IP} \
   --api-port %d \
-  --api-advertise-url http://${HOSTNAME}.%s-data.%s.svc.cluster.local:%d \
+  --api-advertise-url http://%s:%d \
   --raft-host ${POD_IP} \
   --raft-port %d \
-  --raft-advertise-url http://${HOSTNAME}.%s-data.%s.svc.cluster.local:%d \
+  --raft-advertise-url http://%s:%d \
   --health-port %d%s
 								`,
 								cluster.Spec.DataNodes.API.Port,
-								cluster.Name,
-								cluster.Namespace,
+								dataAdvertiseHost,
 								cluster.Spec.DataNodes.API.Port,
 								cluster.Spec.DataNodes.Raft.Port,
-								cluster.Name,
-								cluster.Namespace,
+								dataAdvertiseHost,
 								cluster.Spec.DataNodes.Raft.Port,
 								cluster.Spec.DataNodes.Health.Port,
 								secretStoreArg(cluster.Spec.SecretStore),
@@ -13221,6 +13225,9 @@ func hasAnyPrefix(name string, prefixes []string) bool {
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *AntflyClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	if err := normalizeClusterDomainField(&r.ClusterDomain); err != nil {
+		return fmt.Errorf("configure AntflyCluster controller: %w", err)
+	}
 	if err := ctrl.NewControllerManagedBy(mgr).
 		Named("antflycluster-ha-lease-renewal").
 		WithOptions(controller.Options{MaxConcurrentReconciles: 16}).

--- a/go/pkg/operator/controllers/antfly/antflycluster_controller_test.go
+++ b/go/pkg/operator/controllers/antfly/antflycluster_controller_test.go
@@ -14805,7 +14805,7 @@ func TestDataStatefulSetAdvertisesStablePodDNS(t *testing.T) {
 		},
 	}
 	client := newHAControllerTestClient(t, s, cluster)
-	reconciler := &AntflyClusterReconciler{Client: client, Scheme: s}
+	reconciler := &AntflyClusterReconciler{Client: client, Scheme: s, ClusterDomain: "corp.internal"}
 
 	g.Expect(reconciler.reconcileDataStatefulSet(context.Background(), &envFromCache{}, cluster)).To(Succeed())
 
@@ -14817,8 +14817,8 @@ func TestDataStatefulSetAdvertisesStablePodDNS(t *testing.T) {
 	args := sts.Spec.Template.Spec.Containers[0].Args[0]
 	g.Expect(args).To(ContainSubstring("--api-host ${POD_IP}"))
 	g.Expect(args).To(ContainSubstring("--raft-host ${POD_IP}"))
-	g.Expect(args).To(ContainSubstring("--api-advertise-url http://${HOSTNAME}.stable-routes-data.antfly-system.svc.cluster.local:12380"))
-	g.Expect(args).To(ContainSubstring("--raft-advertise-url http://${HOSTNAME}.stable-routes-data.antfly-system.svc.cluster.local:9021"))
+	g.Expect(args).To(ContainSubstring("--api-advertise-url http://${HOSTNAME}.stable-routes-data.antfly-system.svc.corp.internal:12380"))
+	g.Expect(args).To(ContainSubstring("--raft-advertise-url http://${HOSTNAME}.stable-routes-data.antfly-system.svc.corp.internal:9021"))
 }
 
 func TestUpdateStatus_Standalone(t *testing.T) {

--- a/go/pkg/operator/controllers/antfly/antflyrestore_controller.go
+++ b/go/pkg/operator/controllers/antfly/antflyrestore_controller.go
@@ -24,8 +24,9 @@ import (
 // AntflyRestoreReconciler reconciles an AntflyRestore object
 type AntflyRestoreReconciler struct {
 	client.Client
-	Scheme   *runtime.Scheme
-	Recorder events.EventRecorder
+	Scheme        *runtime.Scheme
+	Recorder      events.EventRecorder
+	ClusterDomain string
 }
 
 //+kubebuilder:rbac:groups=antfly.io,resources=antflyrestores,verbs=get;list;watch;create;update;patch;delete
@@ -174,8 +175,7 @@ func (r *AntflyRestoreReconciler) buildRestoreJob(restore *antflyv1.AntflyRestor
 	}
 
 	// Build the cluster API URL using the public-api service
-	clusterURL := fmt.Sprintf("http://%s-public-api.%s.svc.cluster.local",
-		cluster.Name, clusterNamespace)
+	clusterURL := "http://" + serviceDNSName(cluster.Name+"-public-api", clusterNamespace, r.ClusterDomain)
 
 	// Build CLI arguments
 	args := []string{
@@ -374,6 +374,9 @@ func (r *AntflyRestoreReconciler) setCondition(restore *antflyv1.AntflyRestore, 
 
 // SetupWithManager sets up the controller with the Manager
 func (r *AntflyRestoreReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	if err := normalizeClusterDomainField(&r.ClusterDomain); err != nil {
+		return fmt.Errorf("configure AntflyRestore controller: %w", err)
+	}
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&antflyv1.AntflyRestore{}).
 		Owns(&batchv1.Job{}).

--- a/go/pkg/operator/controllers/antfly/antflyrestore_controller_test.go
+++ b/go/pkg/operator/controllers/antfly/antflyrestore_controller_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestBuildRestoreJob_StandaloneStillUsesPublicAPIService(t *testing.T) {
-	r := &AntflyRestoreReconciler{}
+	r := &AntflyRestoreReconciler{ClusterDomain: "corp.internal"}
 	restore := &antflyv1.AntflyRestore{
 		ObjectMeta: metav1.ObjectMeta{Name: "standalone-restore", Namespace: "default"},
 		Spec: antflyv1.AntflyRestoreSpec{
@@ -63,7 +63,7 @@ func TestBuildRestoreJob_StandaloneStillUsesPublicAPIService(t *testing.T) {
 	if !foundConnection {
 		t.Fatalf("expected named restore connection in args: %#v", args)
 	}
-	if got := envValue(container.Env, "ANTFLY_URL"); got != "http://standalone-cluster-public-api.default.svc.cluster.local" {
+	if got := envValue(container.Env, "ANTFLY_URL"); got != "http://standalone-cluster-public-api.default.svc.corp.internal" {
 		t.Fatalf("expected restore URL to continue using public-api service in standalone mode, got: %q", got)
 	}
 }

--- a/go/pkg/operator/controllers/antfly/cluster_dns.go
+++ b/go/pkg/operator/controllers/antfly/cluster_dns.go
@@ -1,0 +1,52 @@
+package controllers
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/validation"
+)
+
+const DefaultClusterDomain = "cluster.local"
+
+// NormalizeClusterDomain validates the DNS suffix used for Kubernetes Service
+// and StatefulSet pod addresses. A trailing root dot is accepted for operator
+// ergonomics but omitted from generated URLs.
+func NormalizeClusterDomain(raw string) (string, error) {
+	domain := strings.TrimSpace(raw)
+	if domain == "" {
+		return DefaultClusterDomain, nil
+	}
+	domain = strings.TrimSuffix(domain, ".")
+	if domain == "" {
+		return "", fmt.Errorf("cluster domain must contain at least one DNS label")
+	}
+	if problems := validation.IsDNS1123Subdomain(domain); len(problems) > 0 {
+		return "", fmt.Errorf("invalid cluster domain %q: %s", raw, strings.Join(problems, "; "))
+	}
+	return domain, nil
+}
+
+func clusterDomainOrDefault(domain string) string {
+	if domain == "" {
+		return DefaultClusterDomain
+	}
+	return domain
+}
+
+func normalizeClusterDomainField(domain *string) error {
+	normalized, err := NormalizeClusterDomain(*domain)
+	if err != nil {
+		return err
+	}
+	*domain = normalized
+	return nil
+}
+
+func serviceDNSName(service, namespace, clusterDomain string) string {
+	return fmt.Sprintf("%s.%s.svc.%s", service, namespace, clusterDomainOrDefault(clusterDomain))
+}
+
+func statefulPodDNSName(pod, service, namespace, clusterDomain string) string {
+	return pod + "." + serviceDNSName(service, namespace, clusterDomain)
+}

--- a/go/pkg/operator/controllers/antfly/cluster_dns_test.go
+++ b/go/pkg/operator/controllers/antfly/cluster_dns_test.go
@@ -1,0 +1,61 @@
+package controllers
+
+import "testing"
+
+func TestNormalizeClusterDomain(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{name: "empty uses Kubernetes default", want: DefaultClusterDomain},
+		{name: "trims whitespace and root dot", input: "  corp.internal.  ", want: "corp.internal"},
+		{name: "rejects empty root", input: ".", wantErr: true},
+		{name: "rejects multiple root dots", input: "corp.internal..", wantErr: true},
+		{name: "rejects uppercase", input: "Corp.internal", wantErr: true},
+		{name: "rejects invalid label", input: "corp_internal", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NormalizeClusterDomain(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("NormalizeClusterDomain(%q) succeeded, want error", tt.input)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("NormalizeClusterDomain(%q): %v", tt.input, err)
+			}
+			if got != tt.want {
+				t.Fatalf("NormalizeClusterDomain(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestInternalDNSNames(t *testing.T) {
+	if got, want := serviceDNSName("antfly-public-api", "database", "corp.internal"), "antfly-public-api.database.svc.corp.internal"; got != want {
+		t.Fatalf("serviceDNSName() = %q, want %q", got, want)
+	}
+	if got, want := statefulPodDNSName("antfly-data-2", "antfly-data", "database", "corp.internal"), "antfly-data-2.antfly-data.database.svc.corp.internal"; got != want {
+		t.Fatalf("statefulPodDNSName() = %q, want %q", got, want)
+	}
+}
+
+func TestNormalizeClusterDomainField(t *testing.T) {
+	domain := " corp.internal. "
+	if err := normalizeClusterDomainField(&domain); err != nil {
+		t.Fatalf("normalizeClusterDomainField(): %v", err)
+	}
+	if domain != "corp.internal" {
+		t.Fatalf("normalized domain = %q, want corp.internal", domain)
+	}
+
+	invalid := "invalid_domain"
+	if err := normalizeClusterDomainField(&invalid); err == nil {
+		t.Fatal("normalizeClusterDomainField() succeeded for invalid domain")
+	}
+}

--- a/go/pkg/operator/docs/getting-started/installation.md
+++ b/go/pkg/operator/docs/getting-started/installation.md
@@ -36,6 +36,12 @@ mirrored or available to your cluster, add `--inference-antfly-image=<image>` to
 the deployment args. The image must provide the `/antfly inference` runtime
 contract.
 
+The operator generates fully qualified internal Service and StatefulSet pod
+addresses using Kubernetes' default `cluster.local` DNS domain. On clusters
+configured with a different domain, add `--cluster-domain=<domain>` to the
+operator deployment args. The value must be a valid DNS subdomain; a trailing
+root dot is accepted and removed.
+
 For TPU-backed `InferencePool` resources, the controller downloads the
 checksum-pinned PJRT `libtpu.so` plugin into an ephemeral volume before starting
 the inference container. TPU pods therefore need outbound HTTPS access to


### PR DESCRIPTION
Follow-up to merged PR #566.

Summary

- add a validated --cluster-domain operator option with cluster.local as the backwards-compatible default
- use the configured domain for metadata, data, standalone, managed-inference, backup, and restore internal endpoints
- normalize once at controller setup and reuse the stored value during reconciliation
- document custom-domain deployment configuration and add default/custom/invalid-domain regression coverage

Validation

- go test ./... from go/pkg/operator
- git diff --check