### PR TITLE
zig: shard HBC vector-cache reads and bound admission

### DIFF
--- a/zig/build.zig
+++ b/zig/build.zig
@@ -6582,6 +6582,26 @@ pub fn build(b: *std.Build) void {
     const lib_storage_test_step = b.step("lib-storage-test", "Run root-module storage tests only");
     lib_storage_test_step.dependOn(&run_lib_storage_tests.step);
 
+    const hbc_cache_contention_tests = b.addTest(.{
+        .name = "hbc-cache-contention-experiment-tests",
+        .root_module = lib_test_mod,
+        .filters = &.{
+            "hbc shared",
+            "resource manager derives elastic HBC cache-class policy from pressure",
+        },
+        .test_runner = .{
+            .path = b.path("pkg/antfly/src/test_runner.zig"),
+            .mode = .simple,
+        },
+        .max_rss = 8 * 1024 * 1024 * 1024,
+    });
+    const run_hbc_cache_contention_tests = b.addRunArtifact(hbc_cache_contention_tests);
+    const hbc_cache_contention_step = b.step(
+        "hbc-cache-contention-experiment",
+        "Run the focused shared HBC cache concurrency experiment",
+    );
+    hbc_cache_contention_step.dependOn(&run_hbc_cache_contention_tests.step);
+
     const ha_tests = b.addTest(.{
         .root_module = lib_test_mod,
         .filters = &.{"storage.ha"},

--- a/zig/pkg/antfly/src/storage/hbc_adapter.zig
+++ b/zig/pkg/antfly/src/storage/hbc_adapter.zig
@@ -608,6 +608,11 @@ const HbcSharedAdmission = struct {
     overcommitted: bool = false,
 };
 
+const HbcVectorLookupStats = struct {
+    hits: u64 = 0,
+    misses: u64 = 0,
+};
+
 fn sharedVectorFillStripe(namespace: u64, vector_id: u64) usize {
     var value = namespace ^ std.math.rotl(u64, vector_id, 29);
     value ^= value >> 33;
@@ -779,9 +784,183 @@ fn noteHbcKindEviction(stats: *HbcCacheStats, kind: HbcCacheKind) void {
     hbcKindStats(stats, kind).evictions += 1;
 }
 
+/// Read-optimized ownership fence for the process-wide HBC cache maps.
+///
+/// `ApplyRwLock` intentionally provides a writer-preferring service fence for
+/// apply/runtime coordination, but its shared path takes two mutexes and
+/// updates several global telemetry atomics. A vector query can perform
+/// hundreds of cache lookups, so that design turns read-only hits into one
+/// process-wide serialization point. Cache readers need only stabilize the
+/// maps long enough to retain an entry; entry lifetime is then ref-counted.
+///
+/// This lock therefore uses one atomic word for ownership and a writer-intent
+/// counter to bound writer starvation. The read hot path performs one CAS on
+/// acquire and one subtraction on release, with no telemetry writes. Writers
+/// retain exclusive map/invalidation semantics.
+const CacheRwLock = struct {
+    const vector_read_stripe_count = 64;
+    const writer_bit: usize = @as(usize, 1) << (@bitSizeOf(usize) - 1);
+    const reader_mask: usize = writer_bit - 1;
+
+    state: std.atomic.Value(usize) = .init(0),
+    writers_waiting: std.atomic.Value(u32) = .init(0),
+    vector_fence_pending: std.atomic.Value(bool) = .init(false),
+    // Vector lookups dominate the shared-cache hot path. Key-striped reader
+    // ownership lets independent lookups proceed without modifying the same
+    // global reader-count word. Structural writers fence every stripe before
+    // mutating the authoritative hash map.
+    vector_read_stripes: [vector_read_stripe_count]std.atomic.Mutex = .{.unlocked} ** vector_read_stripe_count,
+    exclusive_lock_calls: AtomicU64 = .init(0),
+    exclusive_contended_calls: AtomicU64 = .init(0),
+    exclusive_wait_ns: AtomicU64 = .init(0),
+    exclusive_max_wait_ns: AtomicU64 = .init(0),
+
+    fn backoff(attempts: usize) void {
+        if (builtin.os.tag == .freestanding or builtin.single_threaded or attempts < 64) {
+            std.atomic.spinLoopHint();
+        } else {
+            std.Thread.yield() catch {};
+        }
+    }
+
+    fn lockShared(self: *@This()) void {
+        var attempts: usize = 0;
+        while (true) : (attempts += 1) {
+            if (self.writers_waiting.load(.acquire) != 0) {
+                backoff(attempts);
+                continue;
+            }
+            const observed = self.state.load(.monotonic);
+            std.debug.assert(observed & reader_mask != reader_mask);
+            if (observed & writer_bit != 0 or
+                self.state.cmpxchgWeak(observed, observed + 1, .acquire, .monotonic) != null)
+            {
+                backoff(attempts);
+                continue;
+            }
+            return;
+        }
+    }
+
+    fn tryLockShared(self: *@This()) bool {
+        if (self.writers_waiting.load(.acquire) != 0) return false;
+        const observed = self.state.load(.monotonic);
+        if (observed & writer_bit != 0 or observed & reader_mask == reader_mask) return false;
+        return self.state.cmpxchgStrong(observed, observed + 1, .acquire, .monotonic) == null;
+    }
+
+    fn unlockShared(self: *@This()) void {
+        const previous = self.state.fetchSub(1, .release);
+        std.debug.assert(previous & writer_bit == 0 and previous & reader_mask != 0);
+    }
+
+    fn vectorReadStripe(namespace: u64, vector_id: u64) usize {
+        return sharedVectorFillStripe(namespace, vector_id) & (vector_read_stripe_count - 1);
+    }
+
+    fn lockVectorShared(self: *@This(), namespace: u64, vector_id: u64) usize {
+        const stripe = vectorReadStripe(namespace, vector_id);
+        var attempts: usize = 0;
+        while (true) : (attempts += 1) {
+            // Once a structural writer publishes intent, stop admitting new
+            // striped readers so it can fence the finite set already active.
+            if (!self.vector_fence_pending.load(.acquire) and
+                self.vector_read_stripes[stripe].tryLock()) break;
+            backoff(attempts);
+        }
+        return stripe;
+    }
+
+    fn unlockVectorShared(self: *@This(), stripe: usize) void {
+        self.vector_read_stripes[stripe].unlock();
+    }
+
+    fn lockVectorStripes(self: *@This()) void {
+        for (&self.vector_read_stripes) |*stripe| {
+            var attempts: usize = 0;
+            while (!stripe.tryLock()) : (attempts += 1) backoff(attempts);
+        }
+    }
+
+    fn tryLockVectorStripes(self: *@This()) ?usize {
+        for (&self.vector_read_stripes, 0..) |*stripe, index| {
+            if (!stripe.tryLock()) return index;
+        }
+        return vector_read_stripe_count;
+    }
+
+    fn unlockVectorStripes(self: *@This(), count: usize) void {
+        var remaining = count;
+        while (remaining != 0) {
+            remaining -= 1;
+            self.vector_read_stripes[remaining].unlock();
+        }
+    }
+
+    fn tryLockExclusive(self: *@This()) bool {
+        _ = self.exclusive_lock_calls.fetchAdd(1, .monotonic);
+        if (self.state.cmpxchgStrong(0, writer_bit, .acquire, .monotonic) != null) return false;
+        self.vector_fence_pending.store(true, .release);
+        const locked = self.tryLockVectorStripes() orelse unreachable;
+        if (locked != vector_read_stripe_count) {
+            self.unlockVectorStripes(locked);
+            self.vector_fence_pending.store(false, .release);
+            self.state.store(0, .release);
+            return false;
+        }
+        self.vector_fence_pending.store(false, .release);
+        return true;
+    }
+
+    fn lockExclusive(self: *@This()) void {
+        const started_ns = nowNs();
+        _ = self.exclusive_lock_calls.fetchAdd(1, .monotonic);
+        _ = self.writers_waiting.fetchAdd(1, .acq_rel);
+        defer _ = self.writers_waiting.fetchSub(1, .release);
+
+        var attempts: usize = 0;
+        while (self.state.cmpxchgWeak(0, writer_bit, .acquire, .monotonic) != null) : (attempts += 1) {
+            backoff(attempts);
+        }
+        if (attempts != 0) {
+            const waited_ns = elapsedSince(started_ns);
+            _ = self.exclusive_contended_calls.fetchAdd(1, .monotonic);
+            _ = self.exclusive_wait_ns.fetchAdd(waited_ns, .monotonic);
+            var maximum = self.exclusive_max_wait_ns.load(.monotonic);
+            while (waited_ns > maximum) {
+                maximum = self.exclusive_max_wait_ns.cmpxchgWeak(maximum, waited_ns, .monotonic, .monotonic) orelse break;
+            }
+        }
+        self.vector_fence_pending.store(true, .release);
+        self.lockVectorStripes();
+        self.vector_fence_pending.store(false, .release);
+    }
+
+    fn unlockExclusive(self: *@This()) void {
+        self.unlockVectorStripes(vector_read_stripe_count);
+        const previous = self.state.swap(0, .release);
+        std.debug.assert(previous == writer_bit);
+    }
+
+    fn snapshot(self: *const @This()) apply_rw_lock_mod.ApplyRwLock.Stats {
+        return .{
+            // Deliberately zero: exact shared telemetry would reintroduce a
+            // globally written cache line on every vector hit.
+            .shared_lock_calls = 0,
+            .shared_contended_calls = 0,
+            .shared_wait_ns = 0,
+            .shared_max_wait_ns = 0,
+            .exclusive_lock_calls = self.exclusive_lock_calls.load(.monotonic),
+            .exclusive_contended_calls = self.exclusive_contended_calls.load(.monotonic),
+            .exclusive_wait_ns = self.exclusive_wait_ns.load(.monotonic),
+            .exclusive_max_wait_ns = self.exclusive_max_wait_ns.load(.monotonic),
+        };
+    }
+};
+
 pub const Cache = struct {
     alloc: Allocator,
-    mutex: apply_rw_lock_mod.ApplyRwLock = .{},
+    mutex: CacheRwLock = .{},
     resource_manager: ?*resource_manager_mod.ResourceManager = null,
     reclaimer_identity: u64 = 0,
     physical_accounting: HbcPhysicalAccounting = .{},
@@ -814,6 +993,10 @@ pub const Cache = struct {
     vector_slots: std.AutoHashMapUnmanaged(HbcSharedCacheKey, usize) = .empty,
     vector_clock: std.ArrayListUnmanaged(HbcSharedClockEntry) = .empty,
     vector_hand: usize = 0,
+    // Lookup counters follow the same ownership stripes as vector reads. This
+    // avoids recreating one globally written cache line solely for telemetry.
+    vector_lookup_stats: [CacheRwLock.vector_read_stripe_count]std.AutoHashMapUnmanaged(u64, HbcVectorLookupStats) =
+        .{std.AutoHashMapUnmanaged(u64, HbcVectorLookupStats).empty} ** CacheRwLock.vector_read_stripe_count,
     metadata_cache: std.AutoHashMapUnmanaged(HbcSharedCacheKey, *MetadataCacheEntry) = .empty,
     metadata_slots: std.AutoHashMapUnmanaged(HbcSharedCacheKey, usize) = .empty,
     metadata_clock: std.ArrayListUnmanaged(HbcSharedClockEntry) = .empty,
@@ -846,6 +1029,7 @@ pub const Cache = struct {
         self.vector_cache.deinit(self.alloc);
         self.vector_slots.deinit(self.alloc);
         self.vector_clock.deinit(self.alloc);
+        for (&self.vector_lookup_stats) |*stats| stats.deinit(self.alloc);
         self.metadata_cache.deinit(self.alloc);
         self.metadata_slots.deinit(self.alloc);
         self.metadata_clock.deinit(self.alloc);
@@ -1064,6 +1248,17 @@ pub const Cache = struct {
             snapshotHbcCacheStats(stored)
         else
             HbcCacheStats{};
+        // Shared vector-cache lookups are tracked per read stripe. Structural
+        // map changes require exclusive ownership, so the global shared lock
+        // stabilizes these maps while their counters are loaded atomically.
+        stats.vector.hits = 0;
+        stats.vector.misses = 0;
+        for (&self.vector_lookup_stats) |*lookup_stats| {
+            if (lookup_stats.getPtr(namespace)) |stored| {
+                stats.vector.hits +|= @atomicLoad(u64, &stored.hits, .monotonic);
+                stats.vector.misses +|= @atomicLoad(u64, &stored.misses, .monotonic);
+            }
+        }
         stats.pinned_bytes = self.namespace_pinned_accounting.current(namespace);
         stats.accounted_bytes = stats.total_bytes +| stats.pinned_bytes;
         return stats;
@@ -1084,6 +1279,20 @@ pub const Cache = struct {
                 _ = @atomicRmw(u64, &counters.misses, .Add, 1, .monotonic);
             }
         }
+    }
+
+    fn noteVectorLookupStriped(self: *Cache, stripe: usize, namespace: u64, hit: bool) void {
+        const stats = self.vector_lookup_stats[stripe].getPtr(namespace) orelse return;
+        if (hit) {
+            _ = @atomicRmw(u64, &stats.hits, .Add, 1, .monotonic);
+        } else {
+            _ = @atomicRmw(u64, &stats.misses, .Add, 1, .monotonic);
+        }
+    }
+
+    fn ensureVectorLookupStatsLocked(self: *Cache, stripe: usize, namespace: u64) !void {
+        const entry = try self.vector_lookup_stats[stripe].getOrPut(self.alloc, namespace);
+        if (!entry.found_existing) entry.value_ptr.* = .{};
     }
 
     pub fn invalidateNamespace(self: *Cache, namespace: u64) void {
@@ -1270,17 +1479,17 @@ pub const Cache = struct {
     }
 
     pub fn borrowVector(self: *Cache, namespace: u64, vector_id: u64) ?BorrowedVectorLease {
-        self.mutex.lockShared();
+        const read_stripe = self.mutex.lockVectorShared(namespace, vector_id);
         const key: HbcSharedCacheKey = .{ .namespace = namespace, .id = vector_id };
         if (self.vector_cache.get(key)) |entry| {
-            self.noteLookupLocked(.vector, namespace, true);
+            self.noteVectorLookupStriped(read_stripe, namespace, true);
             self.touchSlot(&self.vector_clock, self.vector_slots.get(key));
             retainVectorCacheEntry(entry);
-            self.mutex.unlockShared();
+            self.mutex.unlockVectorShared(read_stripe);
             return .{ .retained = .{ .alloc = self.alloc, .entry = entry } };
         }
-        self.noteLookupLocked(.vector, namespace, false);
-        self.mutex.unlockShared();
+        self.noteVectorLookupStriped(read_stripe, namespace, false);
+        self.mutex.unlockVectorShared(read_stripe);
         return null;
     }
 
@@ -1432,15 +1641,15 @@ pub const Cache = struct {
         defer self.vector_fill_mutexes[fill_stripe].unlock();
 
         const key: HbcSharedCacheKey = .{ .namespace = namespace, .id = vector_id };
-        self.mutex.lockShared();
+        const read_stripe = self.mutex.lockVectorShared(namespace, vector_id);
         if (self.vector_cache.get(key)) |existing| {
             if (std.mem.eql(f32, existing.vector, vector_data)) {
                 self.touchSlot(&self.vector_clock, self.vector_slots.get(key));
-                self.mutex.unlockShared();
+                self.mutex.unlockVectorShared(read_stripe);
                 return vector_data;
             }
         }
-        self.mutex.unlockShared();
+        self.mutex.unlockVectorShared(read_stripe);
 
         const copied = try self.alloc.dupe(f32, vector_data);
         const entry = self.alloc.create(VectorCacheEntry) catch |err| {
@@ -1479,6 +1688,7 @@ pub const Cache = struct {
             return vector_data;
         };
         errdefer self.rollbackAdmissionLocked(admission);
+        try self.ensureVectorLookupStatsLocked(CacheRwLock.vectorReadStripe(namespace, vector_id), namespace);
         try self.recordClockSlot(&self.vector_clock, &self.vector_slots, key);
         errdefer removeSlot(&self.vector_clock, &self.vector_slots, key);
         try self.vector_cache.put(self.alloc, key, entry);
@@ -1973,6 +2183,7 @@ pub const Cache = struct {
             const removed = self.namespace_paths.fetchRemove(namespace) orelse return;
             self.alloc.free(removed.value.path);
         }
+        for (&self.vector_lookup_stats) |*lookup_stats| _ = lookup_stats.remove(namespace);
         _ = self.namespace_stats.remove(namespace);
     }
 
@@ -11482,6 +11693,167 @@ test "hbc shared vector publication coalesces concurrent duplicate fills" {
     var borrowed = cache.borrowVector(namespace, 42).?;
     defer borrowed.deinit();
     try std.testing.expectEqualSlices(f32, &.{ 1.0, 2.0, 3.0, 4.0 }, borrowed.view());
+}
+
+test "hbc shared cache contention experiment" {
+    const Experiment = struct {
+        const Mode = enum { hot, hot_no_touch, miss, insert, insert_sampled, bypass_copy };
+        const dims = 768;
+
+        const Context = struct {
+            cache: *Cache,
+            namespace: u64,
+            mode: Mode,
+            thread_index: usize,
+            operations: usize,
+            hot_keys: usize,
+            id_base: u64,
+            vector: *const [dims]f32,
+            start: *std.atomic.Value(bool),
+            failed: *std.atomic.Value(bool),
+        };
+
+        fn borrowVectorNoTouch(cache: *Cache, namespace: u64, vector_id: u64) ?BorrowedVectorLease {
+            const read_stripe = cache.mutex.lockVectorShared(namespace, vector_id);
+            const key: HbcSharedCacheKey = .{ .namespace = namespace, .id = vector_id };
+            if (cache.vector_cache.get(key)) |entry| {
+                retainVectorCacheEntry(entry);
+                cache.mutex.unlockVectorShared(read_stripe);
+                return .{ .retained = .{ .alloc = cache.alloc, .entry = entry } };
+            }
+            cache.mutex.unlockVectorShared(read_stripe);
+            return null;
+        }
+
+        fn runWorker(ctx: Context) void {
+            while (!ctx.start.load(.acquire)) std.atomic.spinLoopHint();
+            for (0..ctx.operations) |operation| {
+                switch (ctx.mode) {
+                    .hot, .hot_no_touch => {
+                        const id = 1 + ((operation *% 11400714819323198485 +% ctx.thread_index *% 2654435761) % ctx.hot_keys);
+                        var lease = if (ctx.mode == .hot)
+                            ctx.cache.borrowVector(ctx.namespace, id)
+                        else
+                            borrowVectorNoTouch(ctx.cache, ctx.namespace, id);
+                        if (lease) |*borrowed| {
+                            std.mem.doNotOptimizeAway(borrowed.view()[0]);
+                            borrowed.deinit();
+                        } else {
+                            ctx.failed.store(true, .release);
+                            return;
+                        }
+                    },
+                    .miss => {
+                        const id = ctx.id_base + ctx.thread_index * ctx.operations + operation;
+                        if (ctx.cache.borrowVector(ctx.namespace, id)) |borrowed_value| {
+                            var borrowed = borrowed_value;
+                            borrowed.deinit();
+                            ctx.failed.store(true, .release);
+                            return;
+                        }
+                    },
+                    .insert, .insert_sampled => {
+                        const id = ctx.id_base + ctx.thread_index * ctx.operations + operation;
+                        if (ctx.mode == .insert_sampled and
+                            (ctx.thread_index * ctx.operations + operation) % 8 != 0)
+                        {
+                            std.mem.doNotOptimizeAway(ctx.vector[operation % dims]);
+                            continue;
+                        }
+                        _ = ctx.cache.cacheVector(ctx.namespace, id, ctx.vector) catch {
+                            ctx.failed.store(true, .release);
+                            return;
+                        };
+                    },
+                    .bypass_copy => {
+                        const copy = ctx.cache.alloc.dupe(f32, ctx.vector) catch {
+                            ctx.failed.store(true, .release);
+                            return;
+                        };
+                        std.mem.doNotOptimizeAway(copy[operation % dims]);
+                        ctx.cache.alloc.free(copy);
+                    },
+                }
+            }
+        }
+
+        fn subtract(after: u64, before: u64) u64 {
+            return after -| before;
+        }
+
+        fn runMode(
+            cache: *Cache,
+            namespace: u64,
+            mode: Mode,
+            thread_count: usize,
+            operations: usize,
+            hot_keys: usize,
+            id_base: u64,
+            vector: *const [dims]f32,
+        ) !void {
+            var start = std.atomic.Value(bool).init(false);
+            var failed = std.atomic.Value(bool).init(false);
+            var threads: [30]std.Thread = undefined;
+            const before = cache.mutex.snapshot();
+            const started_ns = nowNs();
+            for (threads[0..thread_count], 0..) |*thread, thread_index| {
+                thread.* = try std.Thread.spawn(.{}, runWorker, .{Context{
+                    .cache = cache,
+                    .namespace = namespace,
+                    .mode = mode,
+                    .thread_index = thread_index,
+                    .operations = operations,
+                    .hot_keys = hot_keys,
+                    .id_base = id_base,
+                    .vector = vector,
+                    .start = &start,
+                    .failed = &failed,
+                }});
+            }
+            start.store(true, .release);
+            for (threads[0..thread_count]) |*thread| thread.join();
+            const elapsed_ns = @max(@as(u64, 1), elapsedSince(started_ns));
+            const after = cache.mutex.snapshot();
+            const total_operations = thread_count * operations;
+            const ops_per_second = @as(f64, @floatFromInt(total_operations)) * 1_000_000_000.0 /
+                @as(f64, @floatFromInt(elapsed_ns));
+            std.debug.print(
+                "hbc_cache_contention mode={s} threads={d} operations={d} elapsed_ms={d:.3} ops_per_second={d:.2} shared_calls={d} shared_contended={d} shared_wait_ms={d:.3} exclusive_calls={d} exclusive_contended={d} exclusive_wait_ms={d:.3}\n",
+                .{
+                    @tagName(mode),
+                    thread_count,
+                    total_operations,
+                    @as(f64, @floatFromInt(elapsed_ns)) / 1_000_000.0,
+                    ops_per_second,
+                    subtract(after.shared_lock_calls, before.shared_lock_calls),
+                    subtract(after.shared_contended_calls, before.shared_contended_calls),
+                    @as(f64, @floatFromInt(subtract(after.shared_wait_ns, before.shared_wait_ns))) / 1_000_000.0,
+                    subtract(after.exclusive_lock_calls, before.exclusive_lock_calls),
+                    subtract(after.exclusive_contended_calls, before.exclusive_contended_calls),
+                    @as(f64, @floatFromInt(subtract(after.exclusive_wait_ns, before.exclusive_wait_ns))) / 1_000_000.0,
+                },
+            );
+            try std.testing.expect(!failed.load(.acquire));
+        }
+    };
+
+    var cache = Cache.init(std.heap.page_allocator);
+    defer cache.deinit();
+    const namespace = hbcCacheNamespace("/tmp/hbc-cache-contention-experiment");
+    var vector: [Experiment.dims]f32 = undefined;
+    for (&vector, 0..) |*value, i| value.* = @floatFromInt(i);
+    const hot_keys = 4096;
+    for (0..hot_keys) |key| _ = try cache.cacheVector(namespace, key + 1, &vector);
+
+    for ([_]usize{ 1, 2, 4, 8, 16, 30 }) |thread_count| {
+        const id_base = @as(u64, thread_count) * 1_000_000;
+        try Experiment.runMode(&cache, namespace, .hot, thread_count, 100_000, hot_keys, id_base, &vector);
+        try Experiment.runMode(&cache, namespace, .hot_no_touch, thread_count, 100_000, hot_keys, id_base, &vector);
+        try Experiment.runMode(&cache, namespace, .miss, thread_count, 100_000, hot_keys, 1_000_000_000 + id_base, &vector);
+        try Experiment.runMode(&cache, namespace, .insert, thread_count, 2_000, hot_keys, 2_000_000_000 + id_base, &vector);
+        try Experiment.runMode(&cache, namespace, .insert_sampled, thread_count, 2_000, hot_keys, 3_000_000_000 + id_base, &vector);
+        try Experiment.runMode(&cache, namespace, .bypass_copy, thread_count, 2_000, hot_keys, id_base, &vector);
+    }
 }
 
 test "hbc stable cache namespace canonicalizes equivalent path spellings" {

--- a/zig/pkg/antfly/src/storage/hbc_adapter.zig
+++ b/zig/pkg/antfly/src/storage/hbc_adapter.zig
@@ -1290,9 +1290,24 @@ pub const Cache = struct {
         }
     }
 
-    fn ensureVectorLookupStatsLocked(self: *Cache, stripe: usize, namespace: u64) !void {
-        const entry = try self.vector_lookup_stats[stripe].getOrPut(self.alloc, namespace);
-        if (!entry.found_existing) entry.value_ptr.* = .{};
+    fn ensureVectorLookupStatsLocked(self: *Cache, namespace: u64) !void {
+        // Stripe entries are installed and removed as one namespace-wide set,
+        // so stripe zero is the allocation-free fast-path sentinel after the
+        // first registration or successful vector admission.
+        if (self.vector_lookup_stats[0].contains(namespace)) return;
+        var created: [CacheRwLock.vector_read_stripe_count]bool =
+            .{false} ** CacheRwLock.vector_read_stripe_count;
+        errdefer for (&self.vector_lookup_stats, 0..) |*lookup_stats, stripe| {
+            if (created[stripe]) std.debug.assert(lookup_stats.remove(namespace));
+        };
+
+        for (&self.vector_lookup_stats, 0..) |*lookup_stats, stripe| {
+            const entry = try lookup_stats.getOrPut(self.alloc, namespace);
+            if (!entry.found_existing) {
+                entry.value_ptr.* = .{};
+                created[stripe] = true;
+            }
+        }
     }
 
     pub fn invalidateNamespace(self: *Cache, namespace: u64) void {
@@ -1324,9 +1339,14 @@ pub const Cache = struct {
             return false;
         };
         if (!stats_entry.found_existing) stats_entry.value_ptr.* = .{};
+        self.ensureVectorLookupStatsLocked(namespace) catch {
+            if (!stats_entry.found_existing) _ = self.namespace_stats.remove(namespace);
+            self.alloc.free(stable_path);
+            return false;
+        };
 
         const entry = self.namespace_paths.getOrPut(self.alloc, namespace) catch {
-            if (!stats_entry.found_existing) _ = self.namespace_stats.remove(namespace);
+            if (!stats_entry.found_existing) self.removeNamespaceStateIfUnusedLocked(namespace);
             self.alloc.free(stable_path);
             return false;
         };
@@ -1688,7 +1708,7 @@ pub const Cache = struct {
             return vector_data;
         };
         errdefer self.rollbackAdmissionLocked(admission);
-        try self.ensureVectorLookupStatsLocked(CacheRwLock.vectorReadStripe(namespace, vector_id), namespace);
+        try self.ensureVectorLookupStatsLocked(namespace);
         try self.recordClockSlot(&self.vector_clock, &self.vector_slots, key);
         errdefer removeSlot(&self.vector_clock, &self.vector_slots, key);
         try self.vector_cache.put(self.alloc, key, entry);
@@ -11695,6 +11715,26 @@ test "hbc shared vector publication coalesces concurrent duplicate fills" {
     try std.testing.expectEqualSlices(f32, &.{ 1.0, 2.0, 3.0, 4.0 }, borrowed.view());
 }
 
+test "hbc shared vector lookup stats preserve compulsory and cross-stripe misses" {
+    var cache = Cache.init(std.testing.allocator);
+    defer cache.deinit();
+
+    const registered_path = "/tmp/hbc-vector-lookup-stats";
+    const registered_namespace = hbcCacheNamespace(registered_path);
+    try std.testing.expect(cache.registerNamespacePath(registered_namespace, registered_path));
+    try std.testing.expect(cache.borrowVector(registered_namespace, 42) == null);
+    try std.testing.expectEqual(@as(u64, 1), cache.namespaceStats(registered_namespace).vector.misses);
+
+    const direct_namespace = hbcCacheNamespace("/tmp/hbc-vector-lookup-stats-direct");
+    const cached_id: u64 = 1;
+    _ = try cache.cacheVector(direct_namespace, cached_id, &.{ 1.0, 2.0, 3.0, 4.0 });
+    const cached_stripe = CacheRwLock.vectorReadStripe(direct_namespace, cached_id);
+    var missing_id: u64 = cached_id + 1;
+    while (CacheRwLock.vectorReadStripe(direct_namespace, missing_id) == cached_stripe) missing_id += 1;
+    try std.testing.expect(cache.borrowVector(direct_namespace, missing_id) == null);
+    try std.testing.expectEqual(@as(u64, 1), cache.namespaceStats(direct_namespace).vector.misses);
+}
+
 test "hbc shared cache contention experiment" {
     const Experiment = struct {
         const Mode = enum { hot, hot_no_touch, miss, insert, insert_sampled, bypass_copy };
@@ -12148,6 +12188,9 @@ test "hbc shared cache bounds namespace state across path churn" {
 
     try std.testing.expectEqual(@as(usize, 0), cache.namespace_paths.count());
     try std.testing.expectEqual(@as(usize, 0), cache.namespace_stats.count());
+    for (&cache.vector_lookup_stats) |*lookup_stats| {
+        try std.testing.expectEqual(@as(usize, 0), lookup_stats.count());
+    }
 }
 
 test "hbc cache reports byte usage to resource manager" {

--- a/zig/pkg/antfly/src/storage/hbc_adapter.zig
+++ b/zig/pkg/antfly/src/storage/hbc_adapter.zig
@@ -875,11 +875,16 @@ const CacheRwLock = struct {
         self.vector_read_stripes[stripe].unlock();
     }
 
-    fn lockVectorStripes(self: *@This()) void {
+    fn lockVectorStripes(self: *@This()) bool {
+        var contended = false;
         for (&self.vector_read_stripes) |*stripe| {
             var attempts: usize = 0;
-            while (!stripe.tryLock()) : (attempts += 1) backoff(attempts);
+            while (!stripe.tryLock()) : (attempts += 1) {
+                contended = true;
+                backoff(attempts);
+            }
         }
+        return contended;
     }
 
     fn tryLockVectorStripes(self: *@This()) ?usize {
@@ -922,7 +927,10 @@ const CacheRwLock = struct {
         while (self.state.cmpxchgWeak(0, writer_bit, .acquire, .monotonic) != null) : (attempts += 1) {
             backoff(attempts);
         }
-        if (attempts != 0) {
+        self.vector_fence_pending.store(true, .release);
+        const stripes_contended = self.lockVectorStripes();
+        self.vector_fence_pending.store(false, .release);
+        if (attempts != 0 or stripes_contended) {
             const waited_ns = elapsedSince(started_ns);
             _ = self.exclusive_contended_calls.fetchAdd(1, .monotonic);
             _ = self.exclusive_wait_ns.fetchAdd(waited_ns, .monotonic);
@@ -931,9 +939,6 @@ const CacheRwLock = struct {
                 maximum = self.exclusive_max_wait_ns.cmpxchgWeak(maximum, waited_ns, .monotonic, .monotonic) orelse break;
             }
         }
-        self.vector_fence_pending.store(true, .release);
-        self.lockVectorStripes();
-        self.vector_fence_pending.store(false, .release);
     }
 
     fn unlockExclusive(self: *@This()) void {
@@ -11733,6 +11738,34 @@ test "hbc shared vector lookup stats preserve compulsory and cross-stripe misses
     while (CacheRwLock.vectorReadStripe(direct_namespace, missing_id) == cached_stripe) missing_id += 1;
     try std.testing.expect(cache.borrowVector(direct_namespace, missing_id) == null);
     try std.testing.expectEqual(@as(u64, 1), cache.namespaceStats(direct_namespace).vector.misses);
+}
+
+test "hbc shared cache lock reports striped reader wait" {
+    const Writer = struct {
+        fn run(lock: *CacheRwLock, acquired: *std.atomic.Value(bool)) void {
+            lock.lockExclusive();
+            acquired.store(true, .release);
+            lock.unlockExclusive();
+        }
+    };
+
+    var lock: CacheRwLock = .{};
+    const read_stripe = lock.lockVectorShared(1, 1);
+    var writer_acquired = std.atomic.Value(bool).init(false);
+    var writer = try std.Thread.spawn(.{}, Writer.run, .{ &lock, &writer_acquired });
+    while (!lock.vector_fence_pending.load(.acquire)) std.atomic.spinLoopHint();
+    var io_impl = std.Io.Threaded.init(std.testing.allocator, .{});
+    defer io_impl.deinit();
+    try io_impl.io().sleep(std.Io.Duration.fromMilliseconds(10), .awake);
+    lock.unlockVectorShared(read_stripe);
+    writer.join();
+
+    try std.testing.expect(writer_acquired.load(.acquire));
+    const stats = lock.snapshot();
+    try std.testing.expectEqual(@as(u64, 1), stats.exclusive_lock_calls);
+    try std.testing.expectEqual(@as(u64, 1), stats.exclusive_contended_calls);
+    try std.testing.expect(stats.exclusive_wait_ns > 0);
+    try std.testing.expect(stats.exclusive_max_wait_ns > 0);
 }
 
 test "hbc shared cache contention experiment" {

--- a/zig/pkg/antfly/src/storage/resource_manager.zig
+++ b/zig/pkg/antfly/src/storage/resource_manager.zig
@@ -2292,8 +2292,13 @@ pub const ResourceManager = struct {
             .quantized_protected_bytes = target_bytes / 4,
             .metadata_protected_bytes = target_bytes / 32,
             .concurrent_vector_admission_stride = switch (pressure) {
-                .normal => 1,
-                .soft => 8,
+                // A cold concurrent query can discover hundreds of unique
+                // vectors. Admitting every miss serializes those workers on
+                // the shared cache publication lock before pressure has had a
+                // chance to react. Keep a doorkeeper active from the first
+                // overlapping fill; stronger pressure samples more sparsely.
+                .normal => 8,
+                .soft => 16,
                 .hard => 0,
             },
         };
@@ -3284,12 +3289,12 @@ test "resource manager derives elastic HBC cache-class policy from pressure" {
     try std.testing.expectEqual(@as(u64, 200), policy.protectedBytes(.quantized));
     try std.testing.expectEqual(@as(u64, 25), policy.protectedBytes(.metadata));
     try std.testing.expectEqual(@as(u64, 0), policy.protectedBytes(.vector));
-    try std.testing.expectEqual(@as(u32, 1), policy.concurrent_vector_admission_stride);
+    try std.testing.expectEqual(@as(u32, 8), policy.concurrent_vector_admission_stride);
 
     var observed: u64 = 0;
     manager.observeUsage(.hbc_node_metadata_cache, &observed, 900);
     policy = manager.hbcCachePolicy();
-    try std.testing.expectEqual(@as(u32, 8), policy.concurrent_vector_admission_stride);
+    try std.testing.expectEqual(@as(u32, 16), policy.concurrent_vector_admission_stride);
 
     manager.observeUsage(.hbc_node_metadata_cache, &observed, 1001);
     policy = manager.hbcCachePolicy();


### PR DESCRIPTION
## Summary

- Replace the HBC shared-cache vector read path with a cache-specific atomic fence and 64 key-hashed read stripes.
- Shard exact vector lookup telemetry while preserving coherent global structural mutation, invalidation, accounting, and eviction.
- Bound decoded-vector admission under normal and soft concurrent pressure.
- Add a focused 768-dimensional contention experiment and regression build step.

## Why

In the VectorDBBench concurrency-30 workload, each query touches and reranks hundreds of vectors. The rc1 path routed every hit and miss through shared ApplyRwLock reader bookkeeping, while cold publications serialized on one global writer. That combination inflated the decoded-vector demand working set while throughput flattened.

## Validation

- zig build hbc-cache-contention-experiment -Doptimize=ReleaseFast: 25/25 tests pass with zero leaks.
- zig build -Doptimize=ReleaseFast antfly succeeds.
- Controlled 30-thread hot lookups improved from about 2.17-2.83M/s on rc1 to 4.19-6.75M/s with this change.
- Sampled concurrent fill improved about 6.9-7.5x relative to admit-all fill.
- In the 50k production harness, exact recall@100 remained 0.63, vector cache memory fell from 42.86 MB to 22.02 MB, and the 16-to-30-thread scaling shape changed from -2.2% to +9.1%.

## Benchmark caveat

The fixed end-to-end production run shared the host with concurrent Zig builds: load time was 155s versus 85s and health endpoint latency was roughly 3-4x worse. Its absolute QPS result is therefore not a valid before/after comparison. The causal performance evidence comes from the controlled contention experiment; the production run is used only for recall, memory, and concurrency-scaling signals.

Dashboard context: https://circus.antfly.io/v0.2.1-rc1/