### PR TITLE
Support quantized Mixedbread ONNX rerankers

### DIFF
--- a/zig/lib/ml/src/graph/node.zig
+++ b/zig/lib/ml/src/graph/node.zig
@@ -136,6 +136,11 @@ pub const ArgReduceAttrs = struct {
 
 pub const ReshapeAttrs = struct {
     new_shape: Shape,
+    /// ONNX Reshape may compute its target from request-dependent shape
+    /// arithmetic. In that case input 1 carries the exact target dimensions
+    /// and the static new_shape is only an import/planning approximation.
+    runtime_shape: bool = false,
+    allow_zero: bool = false,
 };
 
 pub const TransposeAttrs = struct {
@@ -178,6 +183,7 @@ pub const TakeRowsAttrs = struct {
 
 pub const GatherAttrs = struct {
     axis: u8 = 0,
+    elements: bool = false,
 };
 
 pub const ScatterAddAttrs = struct {

--- a/zig/lib/ml/src/graph/passes/const_fold.zig
+++ b/zig/lib/ml/src/graph/passes/const_fold.zig
@@ -318,6 +318,7 @@ fn evalNode(
 
         // ── Reshape (data unchanged) ───────────────────────────
         .reshape => {
+            if (n.op.reshape.runtime_shape) return null;
             if (in0_data.len != num_elements) return null;
             return try allocator.dupe(f32, in0_data);
         },
@@ -628,6 +629,7 @@ fn foldGather(
     const out_shape = n.output_shape;
     if (table_shape.dtype != out_shape.dtype) return null;
     const attrs = n.op.gather;
+    if (attrs.elements) return null;
     const axis = attrs.axis;
     const rank = table_shape.rank();
     if (axis >= rank) return null;

--- a/zig/lib/ml/src/graph/passes/fuse.zig
+++ b/zig/lib/ml/src/graph/passes/fuse.zig
@@ -333,6 +333,7 @@ pub fn fuse(allocator: std.mem.Allocator, graph: *const Graph) !FuseResult {
 
             // ── reshape(x, same_shape) -> x ───────────────────────
             .reshape => |attrs| {
+                if (attrs.runtime_shape) continue;
                 if (in0 == null_node) continue;
                 const input_shape = work.node(in0).output_shape;
                 if (shapesEqual(input_shape, attrs.new_shape)) {
@@ -1964,10 +1965,12 @@ fn fuseChainReshape(allocator: std.mem.Allocator, work: *Graph, reachable: []con
             .reshape => |a| a,
             else => continue,
         };
+        if (outer_attrs.runtime_shape) continue;
         const inner_id = outer.inputs[0];
         if (inner_id == null_node or inner_id >= count) continue;
         const inner = work.node(inner_id);
         if (std.meta.activeTag(inner.op) != .reshape) continue;
+        if (inner.op.reshape.runtime_shape) continue;
 
         const new_id = try work.addNode(.{
             .op = .{ .reshape = .{ .new_shape = outer_attrs.new_shape } },

--- a/zig/lib/onnx/src/export.zig
+++ b/zig/lib/onnx/src/export.zig
@@ -1906,7 +1906,8 @@ fn convertOpToNode(
     // Determine if this op needs an extra shape input appended to its
     // ONNX input list. For Reshape / Expand the target shape lives in the
     // termite node's attributes; ONNX expects it as a second tensor input.
-    const shape_attr: ?Shape = switch (n.op) {
+    const existing_shape_input = n.num_inputs >= 2;
+    const shape_attr: ?Shape = if (existing_shape_input) null else switch (n.op) {
         .reshape => |a| a.new_shape,
         .broadcast_in_dim => |a| a.target_shape,
         else => null,
@@ -2155,7 +2156,7 @@ fn mapOp(alloc: Allocator, graph: *const Graph, n: *const Node) !OpMapping {
         .concat_prim => |a| try intAttrOp(alloc, "Concat", "axis", a.axis),
         .range => simpleOp("Range"),
         .shape_of => |a| try shapeOfOp(alloc, a),
-        .gather => |a| try intAttrOp(alloc, "Gather", "axis", a.axis),
+        .gather => |a| try intAttrOp(alloc, if (a.elements) "GatherElements" else "Gather", "axis", a.axis),
         .scatter_add => simpleOp("ScatterElements"),
 
         // Contraction

--- a/zig/lib/onnx/src/ops.zig
+++ b/zig/lib/onnx/src/ops.zig
@@ -208,6 +208,8 @@ pub fn convertNodeWithScope(
         .CumSum => convertCumSum(builder, node, inputs),
         .DequantizeLinear => convertDequantizeLinear(builder, node, inputs),
         .QuantizeLinear => convertQuantizeLinear(builder, node, inputs),
+        .DynamicQuantizeLinear => convertDynamicQuantizeLinear(builder, inputs, extra_outputs),
+        .MatMulInteger => convertMatMulInteger(builder, node, inputs),
         .AveragePool => convertAveragePool(builder, node, inputs),
         .MaxPool => convertMaxPool(builder, node, inputs),
         .GlobalAveragePool => convertGlobalAveragePool(builder, inputs),
@@ -332,6 +334,8 @@ const OpType = enum {
     CumSum,
     DequantizeLinear,
     QuantizeLinear,
+    DynamicQuantizeLinear,
+    MatMulInteger,
     AveragePool,
     MaxPool,
     GlobalAveragePool,
@@ -440,6 +444,8 @@ const OpType = enum {
             .{ "CumSum", .CumSum },
             .{ "DequantizeLinear", .DequantizeLinear },
             .{ "QuantizeLinear", .QuantizeLinear },
+            .{ "DynamicQuantizeLinear", .DynamicQuantizeLinear },
+            .{ "MatMulInteger", .MatMulInteger },
             .{ "AveragePool", .AveragePool },
             .{ "MaxPool", .MaxPool },
             .{ "GlobalAveragePool", .GlobalAveragePool },
@@ -880,6 +886,7 @@ fn materializeConstantValues(builder: *Builder, node_id: NodeId, buf: []f32) ?[]
             return buf[0..total];
         },
         .gather => |g_attrs| {
+            if (g_attrs.elements) return null;
             // Gather(data, indices) along axis — materialize both, extract elements
             const gather_inputs = n.getInputs();
             if (gather_inputs.len < 2) return null;
@@ -931,6 +938,39 @@ fn nodeDependsOnRuntimeValue(builder: *Builder, node_id: NodeId, depth: usize) b
             break :blk false;
         },
     };
+}
+
+fn nodeHasRuntimeDependentShape(builder: *Builder, node_id: NodeId, depth: usize) bool {
+    if (node_id == null_node) return false;
+    // Conservatively preserve Shape as a runtime operation when a dynamic
+    // shape transform may be hidden behind otherwise-concrete import-time
+    // inference. This prevents Shape(Reshape(x, runtime_target)) from
+    // capturing the representative import dimensions.
+    if (depth >= 64) return true;
+
+    const n = builder.graph.node(node_id);
+    for (0..n.output_shape.rank()) |axis| {
+        if (n.output_shape.dim(@intCast(axis)) < 0) return true;
+    }
+
+    switch (n.op) {
+        .constant, .parameter, .fused_from_float32 => return false,
+        .reshape => |attrs| {
+            if (attrs.runtime_shape) return true;
+        },
+        .broadcast_in_dim => {
+            if (n.num_inputs > 1 and nodeDependsOnRuntimeValue(builder, n.inputs[1], 0)) return true;
+        },
+        .slice => |attrs| {
+            if (attrs.runtime_starts or attrs.runtime_limits) return true;
+        },
+        else => {},
+    }
+
+    for (n.getInputs()) |input| {
+        if (nodeHasRuntimeDependentShape(builder, input, depth + 1)) return true;
+    }
+    return false;
 }
 
 fn foldSymbolicShapeArithmetic(op: OpCode, a: f32, b: f32) ?f32 {
@@ -1092,6 +1132,11 @@ fn convertReshape(allocator: std.mem.Allocator, builder: *Builder, node: *const 
         if (inserted_axis) |axis| {
             for (0..rank) |target_i| {
                 if (target_i == axis or dims[target_i] >= 0) continue;
+                // Splitting the final input dimension produces two final
+                // target dimensions. Do not copy the unsplit input width into
+                // the inferred trailing target; the division below resolves
+                // it from the explicit split factor instead.
+                if (axis == input_rank - 1 and target_i == rank - 1) continue;
                 const input_i = if (target_i < axis) target_i else target_i - 1;
                 dims[target_i] = input_shape.dim(@intCast(input_i));
             }
@@ -1278,7 +1323,19 @@ fn convertReshape(allocator: std.mem.Allocator, builder: *Builder, node: *const 
         .rank_ = rank,
     };
 
-    return builder.reshape(inputs[0], new_shape);
+    const result = try builder.reshape(inputs[0], new_shape);
+    const target_node = builder.graph.node(inputs[1]);
+    const runtime_shape = std.meta.activeTag(target_node.op) != .constant;
+    if (runtime_shape or allow_zero) {
+        const reshape_node = builder.graph.nodeMut(result);
+        reshape_node.op.reshape.runtime_shape = runtime_shape;
+        reshape_node.op.reshape.allow_zero = allow_zero;
+        if (runtime_shape) {
+            reshape_node.inputs[1] = inputs[1];
+            reshape_node.num_inputs = 2;
+        }
+    }
+    return result;
 }
 
 fn convertTranspose(builder: *Builder, node: *const NodeProto, input: NodeId) ConvertError!NodeId {
@@ -2095,8 +2152,11 @@ fn convertExpand(builder: *Builder, inputs: []const NodeId) ConvertError!NodeId 
             .num_axes = @min(in_rank, out_rank),
         } },
         .output_shape = out_shape,
-        .inputs = .{ src, null_node, null_node, null_node },
-        .num_inputs = 1,
+        // Keep the ONNX shape input live. Static dimensions remain embedded
+        // in target_shape, while the interpreter can use the tensor's values
+        // when shape arithmetic resolves symbolic dimensions at runtime.
+        .inputs = .{ src, inputs[1], null_node, null_node },
+        .num_inputs = 2,
     });
 }
 
@@ -2285,7 +2345,7 @@ fn convertShape(builder: *Builder, node: *const NodeProto, input: NodeId) Conver
         if (dim < 0) has_dynamic = true;
         dims_f32[i] = @floatFromInt(dim);
     }
-    if (has_dynamic) {
+    if (has_dynamic or nodeHasRuntimeDependentShape(builder, input, 0)) {
         return builder.graph.addNode(.{
             .op = .{ .shape_of = .{
                 .start = @intCast(start),
@@ -3273,7 +3333,7 @@ fn convertGatherElements(builder: *Builder, node: *const NodeProto, inputs: []co
 
     // GatherElements output shape = indices shape
     return builder.graph.addNode(.{
-        .op = .{ .gather = .{ .axis = axis } },
+        .op = .{ .gather = .{ .axis = axis, .elements = true } },
         .output_shape = Shape{ .dtype = data_shape.dtype, .dims = indices_shape.dims, .rank_ = indices_shape.rank_ },
         .inputs = .{ inputs[0], inputs[1], null_node, null_node },
         .num_inputs = 2,
@@ -3419,11 +3479,6 @@ fn convertQuantizeLinear(builder: *Builder, node: *const NodeProto, inputs: []co
     // y = x / scale
     var result = try builder.div(x, scale);
 
-    // Round to nearest (half to even is ONNX default, we approximate with floor(x + 0.5))
-    const half = try builder.scalarConst(x_shape.dtype, 0.5);
-    result = try builder.add(result, half);
-    result = try convertFloor(builder, result);
-
     // Add zero_point if provided
     if (inputs.len >= 3 and inputs[2] != null_node) {
         var zp = inputs[2];
@@ -3436,25 +3491,147 @@ fn convertQuantizeLinear(builder: *Builder, node: *const NodeProto, inputs: []co
         result = try builder.add(result, zp);
     }
 
-    // Clamp to output type range
+    // Clamp to the output type range before rounding. Values outside the
+    // range saturate to the same endpoint whether clipping happens before or
+    // after rounding, and clipping first keeps parity detection numerically
+    // well-behaved for large out-of-range values.
     const qmin: f32 = switch (out_dtype) {
         .u8 => 0.0,
+        .i8 => -128.0,
+        .i16 => -32768.0,
         .i32 => -2147483648.0,
         else => 0.0,
     };
     const qmax: f32 = switch (out_dtype) {
         .u8 => 255.0,
+        .i8 => 127.0,
+        .i16 => 32767.0,
         .i32 => 2147483647.0,
         else => 255.0,
     };
-    const min_node = try builder.scalarConst(x_shape.dtype, qmin);
-    const max_node = try builder.scalarConst(x_shape.dtype, qmax);
-    // clamp: max(min, min(x, max))
-    const clamped_hi = try selectOp(builder, try cmpLessThan(builder, result, max_node), result, max_node);
-    const clamped = try selectOp(builder, try cmpLessThan(builder, min_node, clamped_hi), clamped_hi, min_node);
+    result = try roundToNearestEvenClamped(builder, result, qmin, qmax);
 
     // Cast to output dtype
-    return castDType(builder, clamped, out_dtype);
+    return castDType(builder, result, out_dtype);
+}
+
+/// ONNX Round uses round-to-nearest, ties-to-even. The graph IR does not have
+/// a native round primitive, so decompose it from Floor, comparisons, and
+/// selection. `value` is clipped first because all current users are
+/// quantizers with a finite integer output range.
+fn roundToNearestEvenClamped(builder: *Builder, value: NodeId, min_value: f32, max_value: f32) ConvertError!NodeId {
+    const dtype = builder.graph.node(value).output_shape.dtype;
+    const min_node = try builder.scalarConst(dtype, min_value);
+    const max_node = try builder.scalarConst(dtype, max_value);
+    const below_min = try broadcastBinaryOp(builder, .less_than, value, min_node);
+    const clipped_min = try selectOp(builder, below_min, min_node, value);
+    const above_max = try broadcastBinaryOp(builder, .less_than, max_node, clipped_min);
+    const clipped = try selectOp(builder, above_max, max_node, clipped_min);
+
+    const floored = try convertFloor(builder, clipped);
+    const fraction = try builder.sub(clipped, floored);
+    const half = try builder.scalarConst(dtype, 0.5);
+    const one = try builder.scalarConst(dtype, 1.0);
+    const zero = try builder.scalarConst(dtype, 0.0);
+
+    const below_half = try broadcastBinaryOp(builder, .less_than, fraction, half);
+    const above_half = try broadcastBinaryOp(builder, .less_than, half, fraction);
+
+    // For an exact tie, round up only when floor(value) is odd. Values have
+    // already been clipped to the quantized range, so floor(value) is a small
+    // integer and this parity calculation is exact in f32.
+    const two = try builder.scalarConst(dtype, 2.0);
+    const half_floor = try convertFloor(builder, try builder.div(floored, two));
+    const even_floor = try builder.mul(half_floor, two);
+    const floor_is_odd = try broadcastBinaryOp(builder, .less_than, even_floor, floored);
+    const tie_increment = try selectOp(builder, floor_is_odd, one, zero);
+    const at_or_above_half_increment = try selectOp(builder, above_half, one, tie_increment);
+    const increment = try selectOp(builder, below_half, zero, at_or_above_half_increment);
+    return builder.add(floored, increment);
+}
+
+/// DynamicQuantizeLinear computes one uint8 scale and zero point across the
+/// full activation tensor, then quantizes the activation with ONNX's
+/// round-to-nearest-even rule. Its three outputs are `(y, scale, zero_point)`.
+fn convertDynamicQuantizeLinear(builder: *Builder, inputs: []const NodeId, extra_outputs: ?[]NodeId) ConvertError!NodeId {
+    if (inputs.len < 1 or inputs[0] == null_node) return error.MissingInput;
+    const x = inputs[0];
+    const x_shape = builder.graph.node(x).output_shape;
+    if (x_shape.dtype != .f32) return error.UnsupportedDType;
+
+    var axes: [8]u8 = undefined;
+    for (0..x_shape.rank()) |axis| axes[axis] = @intCast(axis);
+
+    const x_max_kept = try builder.reduceMax(x, axes[0..x_shape.rank()]);
+    const x_min_kept = try builder.neg(try builder.reduceMax(try builder.neg(x), axes[0..x_shape.rank()]));
+    const scalar_shape = Shape.scalar(.f32);
+    const x_max = try builder.reshape(x_max_kept, scalar_shape);
+    const x_min = try builder.reshape(x_min_kept, scalar_shape);
+
+    const zero = try builder.scalarConst(.f32, 0.0);
+    const one = try builder.scalarConst(.f32, 1.0);
+    const qmax = try builder.scalarConst(.f32, 255.0);
+    const min_adjusted = try selectOp(builder, try cmpLessThan(builder, x_min, zero), x_min, zero);
+    const max_adjusted = try selectOp(builder, try cmpLessThan(builder, zero, x_max), x_max, zero);
+    const value_range = try builder.sub(max_adjusted, min_adjusted);
+    const computed_scale = try builder.div(value_range, qmax);
+    // ORT defines the all-zero tensor case as scale=1, zero_point=0.
+    const has_range = try cmpLessThan(builder, zero, value_range);
+    const scale = try selectOp(builder, has_range, computed_scale, one);
+
+    const initial_zero_point = try builder.neg(try builder.div(min_adjusted, scale));
+    const rounded_zero_point = try roundToNearestEvenClamped(builder, initial_zero_point, 0.0, 255.0);
+    const zero_point = try castDType(builder, rounded_zero_point, .u8);
+
+    var quantized = try broadcastBinaryOp(builder, .div, x, scale);
+    quantized = try broadcastBinaryOp(builder, .add, quantized, try castDType(builder, zero_point, .f32));
+    quantized = try roundToNearestEvenClamped(builder, quantized, 0.0, 255.0);
+    quantized = try castDType(builder, quantized, .u8);
+
+    if (extra_outputs) |outputs| {
+        if (outputs.len >= 1) outputs[0] = scale;
+        if (outputs.len >= 2) outputs[1] = zero_point;
+    }
+    return quantized;
+}
+
+/// MatMulInteger computes `(A - a_zero_point) @ (B - b_zero_point)` and
+/// produces i32 values. The native interpreter stores numeric buffers as f32,
+/// but its dot primitive accumulates in f64 before materializing f32; this
+/// matches this reranker's immediate MatMulInteger -> Cast(float) path.
+///
+/// For a 2-D RHS with a per-column zero point, expand the algebra instead of
+/// broadcasting and materializing a centered copy of the full weight matrix:
+///
+///   A' @ (B - b_zp) = A' @ B - reduce_sum(A', K) * b_zp
+fn convertMatMulInteger(builder: *Builder, node: *const NodeProto, inputs: []const NodeId) ConvertError!NodeId {
+    if (inputs.len < 2 or inputs[0] == null_node or inputs[1] == null_node) return error.MissingInput;
+
+    var a = try castDType(builder, inputs[0], .f32);
+    const b = try castDType(builder, inputs[1], .f32);
+    if (inputs.len >= 3 and inputs[2] != null_node) {
+        const a_zero_point = try castDType(builder, inputs[2], .f32);
+        a = try broadcastBinaryOp(builder, .sub, a, a_zero_point);
+    }
+
+    var result = try convertMatMul(builder, node, a, b);
+    if (inputs.len >= 4 and inputs[3] != null_node) {
+        const b_zero_point = try castDType(builder, inputs[3], .f32);
+        const b_shape = builder.graph.node(b).output_shape;
+        const b_zp_shape = builder.graph.node(b_zero_point).output_shape;
+        if (b_shape.rank() == 2 and b_zp_shape.rank() <= 1) {
+            const a_shape = builder.graph.node(a).output_shape;
+            if (a_shape.rank() == 0) return error.ShapeMismatch;
+            const row_sums = try builder.reduceSum(a, &.{a_shape.rank() - 1});
+            const correction = try broadcastBinaryOp(builder, .mul, row_sums, b_zero_point);
+            result = try broadcastBinaryOp(builder, .sub, result, correction);
+        } else {
+            const centered_b = try broadcastBinaryOp(builder, .sub, b, b_zero_point);
+            result = try convertMatMul(builder, node, a, centered_b);
+        }
+    }
+
+    return castDType(builder, result, .i32);
 }
 
 /// Reshape a 1D per-axis tensor to broadcast along a specific axis of the target shape.
@@ -5383,6 +5560,29 @@ test "convertNode Shape materializes dims" {
     try std.testing.expectEqual(@as(i64, 3), out_shape.dim(0));
 }
 
+test "convertNode Shape stays runtime after runtime-targeted Reshape" {
+    const allocator = std.testing.allocator;
+    var g = Graph.init(allocator);
+    defer g.deinit();
+    var b = Builder.init(&g);
+
+    const x = try b.parameter("input", Shape.init(.f32, &.{ 1, 512, 768 }));
+    const dim0 = try b.scalarConst(.f32, 12.0);
+    const dim1 = try b.scalarConst(.f32, 512.0);
+    const dim2 = try b.scalarConst(.f32, 64.0);
+    const concat_node = NodeProto{ .op_type = "Concat" };
+    const target = try convertNode(allocator, &b, &concat_node, &.{ dim0, dim1, dim2 }, null);
+
+    const reshape_node = NodeProto{ .op_type = "Reshape" };
+    const reshaped = try convertNode(allocator, &b, &reshape_node, &.{ x, target }, null);
+    try std.testing.expect(g.node(reshaped).op.reshape.runtime_shape);
+    try std.testing.expectEqual(@as(i64, 12), g.node(reshaped).output_shape.dim(0));
+
+    const shape_node = NodeProto{ .op_type = "Shape" };
+    const result = try convertNode(allocator, &b, &shape_node, &.{reshaped}, null);
+    try std.testing.expectEqual(.shape_of, std.meta.activeTag(g.node(result).op));
+}
+
 test "convertNode LayerNormalization emits fused" {
     const allocator = std.testing.allocator;
     var g = Graph.init(allocator);
@@ -5478,6 +5678,9 @@ test "OpType.fromString Phase 3 ops" {
     try std.testing.expect(OpType.fromString("GatherElements") != null);
     try std.testing.expect(OpType.fromString("CumSum") != null);
     try std.testing.expect(OpType.fromString("DequantizeLinear") != null);
+    try std.testing.expect(OpType.fromString("QuantizeLinear") != null);
+    try std.testing.expect(OpType.fromString("DynamicQuantizeLinear") != null);
+    try std.testing.expect(OpType.fromString("MatMulInteger") != null);
     try std.testing.expect(OpType.fromString("AveragePool") != null);
     try std.testing.expect(OpType.fromString("MaxPool") != null);
     try std.testing.expect(OpType.fromString("GlobalAveragePool") != null);
@@ -5839,6 +6042,47 @@ test "convertNode QuantizeLinear with zero_point" {
     try std.testing.expectEqual(DType.u8, g.node(result).output_shape.dtype);
 }
 
+test "convertNode DynamicQuantizeLinear exposes quantized scale and zero point outputs" {
+    const allocator = std.testing.allocator;
+    var g = Graph.init(allocator);
+    defer g.deinit();
+    var b = Builder.init(&g);
+
+    const x = try b.parameter("x", Shape.init(.f32, &.{ 2, 4 }));
+    var outputs = [_]NodeId{ null_node, null_node };
+    var output_names = [_][]const u8{ "y", "y_scale", "y_zero_point" };
+    const node = NodeProto{ .op_type = "DynamicQuantizeLinear", .outputs = &output_names };
+    const quantized = try convertNode(allocator, &b, &node, &.{x}, &outputs);
+
+    try std.testing.expectEqual(DType.u8, g.node(quantized).output_shape.dtype);
+    try std.testing.expectEqualSlices(i64, &.{ 2, 4 }, g.node(quantized).output_shape.dims[0..2]);
+    try std.testing.expect(outputs[0] != null_node);
+    try std.testing.expectEqual(DType.f32, g.node(outputs[0]).output_shape.dtype);
+    try std.testing.expectEqual(@as(u8, 0), g.node(outputs[0]).output_shape.rank());
+    try std.testing.expect(outputs[1] != null_node);
+    try std.testing.expectEqual(DType.u8, g.node(outputs[1]).output_shape.dtype);
+    try std.testing.expectEqual(@as(u8, 0), g.node(outputs[1]).output_shape.rank());
+}
+
+test "convertNode MatMulInteger lowers per-column weight zero point without centering weight" {
+    const allocator = std.testing.allocator;
+    var g = Graph.init(allocator);
+    defer g.deinit();
+    var b = Builder.init(&g);
+
+    const a = try b.parameter("a", Shape.init(.u8, &.{ 2, 3 }));
+    const weight = try b.parameter("weight", Shape.init(.i8, &.{ 3, 4 }));
+    const a_zero_point = try b.parameter("a_zero_point", Shape.scalar(.u8));
+    const weight_zero_point = try b.parameter("weight_zero_point", Shape.init(.i8, &.{4}));
+    const node = NodeProto{ .op_type = "MatMulInteger" };
+    const result = try convertNode(allocator, &b, &node, &.{ a, weight, a_zero_point, weight_zero_point }, null);
+
+    try std.testing.expectEqual(DType.i32, g.node(result).output_shape.dtype);
+    try std.testing.expectEqualSlices(i64, &.{ 2, 4 }, g.node(result).output_shape.dims[0..2]);
+    try std.testing.expectEqual(@as(usize, 1), countOpTag(&g, .dot_general));
+    try std.testing.expectEqual(@as(usize, 1), countOpTag(&g, .reduce_sum));
+}
+
 test "convertNode DequantizeLinear block quantization" {
     const allocator = std.testing.allocator;
     var g = Graph.init(allocator);
@@ -6192,6 +6436,9 @@ test "convertNode Reshape preserves symbolic copied dim in ambiguous target" {
     try std.testing.expectEqual(@as(u8, 2), out_shape.rank());
     try std.testing.expectEqual(@as(i64, 1), out_shape.dim(0));
     try std.testing.expectEqual(@as(i64, -1), out_shape.dim(1));
+    try std.testing.expect(g.node(result).op.reshape.runtime_shape);
+    try std.testing.expectEqual(@as(u8, 2), g.node(result).num_inputs);
+    try std.testing.expectEqual(target, g.node(result).inputs[1]);
 }
 
 test "convertNode Reshape keeps fully symbolic ambiguous target dynamic" {
@@ -6321,6 +6568,29 @@ test "convertNode Expand" {
     const out_shape = g.node(result).output_shape;
     try std.testing.expectEqual(@as(i64, 3), out_shape.dim(0));
     try std.testing.expectEqual(@as(i64, 4), out_shape.dim(1));
+    try std.testing.expectEqual(@as(u8, 2), g.node(result).num_inputs);
+    try std.testing.expectEqual(target, g.node(result).inputs[1]);
+}
+
+test "convertNode GatherElements preserves elementwise semantics" {
+    const allocator = std.testing.allocator;
+    var g = Graph.init(allocator);
+    defer g.deinit();
+    var b = Builder.init(&g);
+
+    const data = try b.parameter("data", Shape.init(.f32, &.{ 2, 3, 4 }));
+    const indices = try b.parameter("indices", Shape.init(.i64, &.{ 2, 3, 2 }));
+    var attrs = [_]AttributeProto{
+        .{ .name = "axis", .i = 2 },
+    };
+    const node = NodeProto{ .op_type = "GatherElements", .attributes = &attrs };
+    const result = try convertNode(allocator, &b, &node, &.{ data, indices }, null);
+
+    const gather = g.node(result);
+    try std.testing.expect(gather.op.gather.elements);
+    try std.testing.expectEqual(@as(u8, 2), gather.op.gather.axis);
+    try std.testing.expectEqual(@as(u8, 3), gather.output_shape.rank());
+    try std.testing.expectEqual(@as(i64, 2), gather.output_shape.dim(2));
 }
 
 // ── Coverage Tests: Reductions ──────────────────────────────────────
@@ -6559,6 +6829,20 @@ test "convertNode Reshape still infers inserted split axis for attention heads" 
     try std.testing.expectEqual(@as(i64, 77), out_shape.dim(1));
     try std.testing.expectEqual(@as(i64, 8), out_shape.dim(2));
     try std.testing.expectEqual(@as(i64, 64), out_shape.dim(3));
+}
+
+test "convertNode Reshape infers trailing head dimension from explicit head count" {
+    const allocator = std.testing.allocator;
+    var g = Graph.init(allocator);
+    defer g.deinit();
+    var b = Builder.init(&g);
+
+    const x = try b.parameter("attn_hidden", Shape.init(.f32, &.{ 1, 512, 768 }));
+    const target = try b.tensorConst(&.{ 1.0, 512.0, 12.0, -1.0 }, Shape.init(.i64, &.{4}));
+    const node = NodeProto{ .op_type = "Reshape", .name = "split_heads_trailing" };
+    const result = try convertNode(allocator, &b, &node, &.{ x, target }, null);
+    const out_shape = g.node(result).output_shape;
+    try std.testing.expectEqualSlices(i64, &.{ 1, 512, 12, 64 }, out_shape.dims[0..out_shape.rank()]);
 }
 
 test "convertNode Reshape infers split axis when target has two symbolic dims" {

--- a/zig/lib/onnx/src/tensor.zig
+++ b/zig/lib/onnx/src/tensor.zig
@@ -45,6 +45,9 @@ pub fn onnxDTypeToTermite(dt: DataType) !DType {
         .float32 => .f32,
         .float16 => .f16,
         .bfloat16 => .bf16,
+        .float64 => .f64,
+        .int8 => .i8,
+        .int16 => .i16,
         .int32 => .i32,
         .int64 => .i64,
         .uint8 => .u8,
@@ -282,6 +285,17 @@ fn extractRawDataAsF32(allocator: std.mem.Allocator, raw: []const u8, dt: DataTy
                 result[i] = @floatFromInt(v);
             }
         },
+        .int8 => {
+            if (raw.len < count) return error.InsufficientData;
+            for (0..count) |i| result[i] = @floatFromInt(@as(i8, @bitCast(raw[i])));
+        },
+        .int16 => {
+            if (raw.len < count * 2) return error.InsufficientData;
+            for (0..count) |i| {
+                const v = std.mem.readInt(i16, raw[i * 2 ..][0..2], .little);
+                result[i] = @floatFromInt(v);
+            }
+        },
         .int64 => {
             if (raw.len < count * 8) return error.InsufficientData;
             for (0..count) |i| {
@@ -394,8 +408,25 @@ test "onnxDTypeToTermite" {
     try std.testing.expectEqual(DType.f32, try onnxDTypeToTermite(.float32));
     try std.testing.expectEqual(DType.f16, try onnxDTypeToTermite(.float16));
     try std.testing.expectEqual(DType.bf16, try onnxDTypeToTermite(.bfloat16));
+    try std.testing.expectEqual(DType.f64, try onnxDTypeToTermite(.float64));
+    try std.testing.expectEqual(DType.i8, try onnxDTypeToTermite(.int8));
+    try std.testing.expectEqual(DType.i16, try onnxDTypeToTermite(.int16));
     try std.testing.expectEqual(DType.i32, try onnxDTypeToTermite(.int32));
     try std.testing.expectEqual(DType.i64, try onnxDTypeToTermite(.int64));
+}
+
+test "extractFloat32 from raw_data int8" {
+    const allocator = std.testing.allocator;
+    const values = [_]i8{ -128, -3, 0, 7, 127 };
+    var dims = [_]i64{values.len};
+    const tensor = TensorProto{
+        .dims = &dims,
+        .data_type = .int8,
+        .raw_data = std.mem.sliceAsBytes(&values),
+    };
+    const result = try extractFloat32(allocator, &tensor);
+    defer allocator.free(result);
+    try std.testing.expectEqualSlices(f32, &.{ -128.0, -3.0, 0.0, 7.0, 127.0 }, result);
 }
 
 test "numElements" {

--- a/zig/pkg/inference/src/backends/imported_onnx_session.zig
+++ b/zig/pkg/inference/src/backends/imported_onnx_session.zig
@@ -1962,6 +1962,138 @@ test "imported onnx session runs simple add model" {
     }
 }
 
+test "imported onnx session matches dynamic quantized integer matmul semantics" {
+    const allocator = std.testing.allocator;
+    const proto = onnx_graph.proto;
+
+    var matrix_dims = [_]proto.TensorShapeProto.Dimension{
+        .{ .dim_value = 2 },
+        .{ .dim_value = 2 },
+    };
+    var input_infos = [_]proto.ValueInfoProto{
+        .{
+            .name = "x",
+            .type_proto = .{ .tensor_type = .{
+                .elem_type = .float32,
+                .shape = .{ .dims = &matrix_dims },
+            } },
+        },
+    };
+    var output_infos = [_]proto.ValueInfoProto{
+        .{
+            .name = "q",
+            .type_proto = .{ .tensor_type = .{
+                .elem_type = .uint8,
+                .shape = .{ .dims = &matrix_dims },
+            } },
+        },
+        .{
+            .name = "scale",
+            .type_proto = .{ .tensor_type = .{
+                .elem_type = .float32,
+                .shape = .{ .dims = &.{} },
+            } },
+        },
+        .{
+            .name = "zp",
+            .type_proto = .{ .tensor_type = .{
+                .elem_type = .uint8,
+                .shape = .{ .dims = &.{} },
+            } },
+        },
+        .{
+            .name = "out",
+            .type_proto = .{ .tensor_type = .{
+                .elem_type = .float32,
+                .shape = .{ .dims = &matrix_dims },
+            } },
+        },
+    };
+
+    const weight_values = [_]i8{ 1, -2, 3, 4 };
+    const weight_zero_points = [_]i8{ 0, 0 };
+    var weight_dims = [_]i64{ 2, 2 };
+    var zero_point_dims = [_]i64{2};
+    var initializers = [_]proto.TensorProto{
+        .{
+            .name = "w",
+            .dims = &weight_dims,
+            .data_type = .int8,
+            .raw_data = std.mem.sliceAsBytes(&weight_values),
+        },
+        .{
+            .name = "wzp",
+            .dims = &zero_point_dims,
+            .data_type = .int8,
+            .raw_data = std.mem.sliceAsBytes(&weight_zero_points),
+        },
+    };
+
+    var dql_inputs = [_][]const u8{"x"};
+    var dql_outputs = [_][]const u8{ "q", "scale", "zp" };
+    var mm_inputs = [_][]const u8{ "q", "w", "zp", "wzp" };
+    var mm_outputs = [_][]const u8{"mm"};
+    var cast_inputs = [_][]const u8{"mm"};
+    var cast_outputs = [_][]const u8{"out"};
+    var cast_attrs = [_]proto.AttributeProto{
+        .{ .name = "to", .i = @intFromEnum(proto.DataType.float32), .attr_type = .int },
+    };
+    var nodes = [_]proto.NodeProto{
+        .{ .op_type = "DynamicQuantizeLinear", .inputs = &dql_inputs, .outputs = &dql_outputs },
+        .{ .op_type = "MatMulInteger", .inputs = &mm_inputs, .outputs = &mm_outputs },
+        .{ .op_type = "Cast", .inputs = &cast_inputs, .outputs = &cast_outputs, .attributes = &cast_attrs },
+    };
+    var opsets = [_]proto.OpsetImport{.{ .domain = "", .version = 12 }};
+    const graph_proto = proto.GraphProto{
+        .name = "dynamic_quantized_matmul",
+        .nodes = &nodes,
+        .initializers = &initializers,
+        .inputs = &input_infos,
+        .outputs = &output_infos,
+    };
+    const model = proto.ModelProto{
+        .ir_version = 7,
+        .opset_import = &opsets,
+        .graph = graph_proto,
+    };
+    const model_bytes = try onnx_graph.serializeModel(allocator, &model);
+    defer allocator.free(model_bytes);
+
+    var dir = std.testing.tmpDir(.{});
+    defer dir.cleanup();
+    try dir.dir.writeFile(std.testing.io, .{ .sub_path = "model.onnx", .data = model_bytes });
+    const path = try std.fs.path.join(allocator, &.{ ".zig-cache", "tmp", dir.sub_path[0..], "model.onnx" });
+    defer allocator.free(path);
+
+    var session = try createSessionWithOptions(allocator, path, .native, .{
+        .graph_runtime_strategy = .partitioned,
+    });
+    defer session.close();
+
+    const input = [_]f32{ -2.0, -1.0, 0.0, 1.0 };
+    var input_tensor = try Tensor.initFloat32(allocator, "x", &.{ 2, 2 }, &input);
+    defer input_tensor.deinit();
+
+    var outputs = try session.run(&.{input_tensor}, allocator);
+    defer {
+        for (outputs) |*tensor| tensor.deinit();
+        allocator.free(outputs);
+    }
+
+    try std.testing.expectEqual(@as(usize, 4), outputs.len);
+    // Native graph execution stores intermediate integer tensors in numeric
+    // f32 buffers; the graph-declared u8/i32 dtypes still drive rounding and
+    // downstream conversion semantics.
+    try std.testing.expectEqual(DType.f32, outputs[0].dtype);
+    try std.testing.expectEqualSlices(f32, &.{ 0.0, 85.0, 170.0, 255.0 }, outputs[0].asFloat32());
+    try std.testing.expectEqual(DType.f32, outputs[1].dtype);
+    try std.testing.expectApproxEqAbs(@as(f32, 0.011764706), outputs[1].asFloat32()[0], 1e-8);
+    try std.testing.expectEqual(DType.f32, outputs[2].dtype);
+    try std.testing.expectEqual(@as(f32, 170.0), outputs[2].asFloat32()[0]);
+    try std.testing.expectEqual(DType.f32, outputs[3].dtype);
+    try std.testing.expectEqualSlices(f32, &.{ -425.0, 0.0, 255.0, 340.0 }, outputs[3].asFloat32());
+}
+
 test "ONNX artifact inspection includes and validates external tensor files" {
     const allocator = std.testing.allocator;
 

--- a/zig/pkg/inference/src/bench/reranker_e2e.zig
+++ b/zig/pkg/inference/src/bench/reranker_e2e.zig
@@ -104,7 +104,10 @@ pub fn main(init: std.process.Init) !void {
     }
 
     if (opts.format == .text and model.session.backend() != .onnx) {
-        var debug_backend = try session_factory.getComputeBackend(model.session, allocator);
+        var debug_backend = session_factory.getComputeBackend(model.session, allocator) catch |err| switch (err) {
+            error.NotArchSession => return,
+            else => return err,
+        };
         defer debug_backend.deinit();
         const provider_stats = debug_backend.debugTimingSnapshot().provider;
         print(

--- a/zig/pkg/inference/src/graph/compiled_onnx.zig
+++ b/zig/pkg/inference/src/graph/compiled_onnx.zig
@@ -49,7 +49,7 @@ fn shapeIsConcretePositive(shape: @import("ml").graph.Shape) bool {
 
 fn reshapeHasCompileSafeShape(op: ml.graph.OpCode) bool {
     return switch (op) {
-        .reshape => |attrs| shapeIsConcretePositive(attrs.new_shape),
+        .reshape => |attrs| !attrs.runtime_shape and shapeIsConcretePositive(attrs.new_shape),
         else => true,
     };
 }

--- a/zig/pkg/inference/src/graph/compiled_pjrt.zig
+++ b/zig/pkg/inference/src/graph/compiled_pjrt.zig
@@ -133,7 +133,7 @@ fn shapeIsConcretePositive(shape: @import("ml").graph.Shape) bool {
 
 fn reshapeHasCompileSafeShape(op: OpCode) bool {
     return switch (op) {
-        .reshape => |attrs| shapeIsConcretePositive(attrs.new_shape),
+        .reshape => |attrs| !attrs.runtime_shape and shapeIsConcretePositive(attrs.new_shape),
         else => true,
     };
 }

--- a/zig/pkg/inference/src/graph/interpreter.zig
+++ b/zig/pkg/inference/src/graph/interpreter.zig
@@ -1156,10 +1156,19 @@ fn cloneTensorForShape(
     shape: Shape,
 ) !CT {
     var dims: [8]i32 = undefined;
-    const rank = shape.rank();
+    const runtime_shape: ?[]i64 = cb.tensorShape(tensor, allocator) catch null;
+    defer if (runtime_shape) |actual| allocator.free(actual);
+
+    // Dynamic imported graphs retain their exported/static dimensions in the
+    // graph Shape while the backend tensor carries the dimensions for this
+    // request. An alias-safety clone must preserve that runtime shape; using
+    // the declaration can either reject a symbolic dimension or manufacture a
+    // larger element count than the tensor actually contains.
+    const rank = if (runtime_shape) |actual| actual.len else shape.rank();
     if (rank > dims.len) return error.UnsupportedShape;
     for (0..rank) |axis| {
-        dims[axis] = std.math.cast(i32, shape.dim(@intCast(axis))) orelse return error.UnsupportedShape;
+        const dim = if (runtime_shape) |actual| actual[axis] else shape.dim(@intCast(axis));
+        dims[axis] = std.math.cast(i32, dim) orelse return error.UnsupportedShape;
     }
 
     if (try cb.cloneTensorShape(tensor, dims[0..rank])) |cloned| return cloned;
@@ -1493,6 +1502,45 @@ fn ensureDeclaredShape(cb: *const ComputeBackend, val: CT, declared: Shape) ?CT 
     return cb.primReshape(val, dims[0..rank]) catch null;
 }
 
+fn resolveRuntimeBroadcastShape(lhs: []const i64, rhs: []const i64, out: *[8]i64) ?[]const i64 {
+    const rank = @max(lhs.len, rhs.len);
+    if (rank > out.len) return null;
+
+    for (0..rank) |axis| {
+        const lhs_axis = axis + lhs.len;
+        const rhs_axis = axis + rhs.len;
+        const lhs_dim: i64 = if (lhs_axis >= rank) lhs[lhs_axis - rank] else 1;
+        const rhs_dim: i64 = if (rhs_axis >= rank) rhs[rhs_axis - rank] else 1;
+        if (lhs_dim <= 0 or rhs_dim <= 0) return null;
+        if (lhs_dim == rhs_dim) {
+            out[axis] = lhs_dim;
+        } else if (lhs_dim == 1) {
+            out[axis] = rhs_dim;
+        } else if (rhs_dim == 1) {
+            out[axis] = lhs_dim;
+        } else {
+            return null;
+        }
+    }
+    return out[0..rank];
+}
+
+fn runtimeBroadcastOperand(
+    cb: *const ComputeBackend,
+    value: CT,
+    actual_shape: []const i64,
+    target_shape: []const i64,
+) !?CT {
+    if (std.mem.eql(i64, actual_shape, target_shape)) return null;
+    if (actual_shape.len > target_shape.len or target_shape.len > ml.graph.shape.max_rank)
+        return error.ShapeMismatch;
+
+    var axes: [ml.graph.shape.max_rank]u8 = undefined;
+    const offset = target_shape.len - actual_shape.len;
+    for (0..actual_shape.len) |axis| axes[axis] = @intCast(offset + axis);
+    return try cb.primBroadcastInDim(value, target_shape, axes[0..actual_shape.len], actual_shape);
+}
+
 fn executeGeluBackwardFallback(
     allocator: std.mem.Allocator,
     output_shape: Shape,
@@ -1658,6 +1706,51 @@ fn resolveSingleInferredDim(dims: []i64, input_numel: usize) bool {
     return known_product == input_numel;
 }
 
+fn resolveOnnxRuntimeReshapeDims(
+    shape_values: []const f32,
+    actual_input_shape: []const i64,
+    allow_zero: bool,
+    out: *[8]i64,
+) ![]const i64 {
+    if (shape_values.len == 0 or shape_values.len > out.len) return error.InvalidTensorShape;
+    const input_numel = safeElementCountFromDims(actual_input_shape) orelse return error.InvalidTensorShape;
+
+    var inferred_axis: ?usize = null;
+    var known_product: usize = 1;
+    for (shape_values, 0..) |value, axis| {
+        const rounded = @round(value);
+        if (!std.math.isFinite(rounded) or @abs(value - rounded) > 1e-3 or
+            rounded < @as(f32, @floatFromInt(std.math.minInt(i32))) or
+            rounded > @as(f32, @floatFromInt(std.math.maxInt(i32))))
+        {
+            return error.InvalidTensorShape;
+        }
+        var dim: i64 = @intFromFloat(rounded);
+        if (dim == 0 and !allow_zero) {
+            if (axis >= actual_input_shape.len or actual_input_shape[axis] <= 0) return error.InvalidTensorShape;
+            dim = actual_input_shape[axis];
+        }
+        if (dim < -1) return error.InvalidTensorShape;
+        if (dim == -1) {
+            if (inferred_axis != null) return error.InvalidTensorShape;
+            inferred_axis = axis;
+        } else if (dim == 0) {
+            known_product = 0;
+        } else {
+            known_product = std.math.mul(usize, known_product, @intCast(dim)) catch return error.InvalidTensorShape;
+        }
+        out[axis] = dim;
+    }
+
+    if (inferred_axis) |axis| {
+        if (known_product == 0 or input_numel % known_product != 0) return error.ShapeMismatch;
+        out[axis] = @intCast(input_numel / known_product);
+    } else if (known_product != input_numel) {
+        return error.ShapeMismatch;
+    }
+    return out[0..shape_values.len];
+}
+
 fn resolveRuntimeReshapeDims(actual: []const i64, declared: Shape, target: Shape, out: *[8]i64) ?[]const i64 {
     const rank = target.rank();
     if (rank < 1 or rank > out.len or actual.len == 0) return null;
@@ -1671,6 +1764,18 @@ fn resolveRuntimeReshapeDims(actual: []const i64, declared: Shape, target: Shape
         } else {
             out[i] = dim;
         }
+    }
+
+    // Unsqueeze is represented by the graph IR as a reshape. When its input
+    // contains dynamic dimensions, the converted target can contain multiple
+    // -1 placeholders (for example [-1, -1] -> [1, 1, -1, -1]). Recover the
+    // request dimensions by matching the declared input axes from the right;
+    // any unmatched target axes must be inserted singleton dimensions.
+    if (resolveRuntimeSingletonInsertion(actual, declared, target, input_numel, out)) |resolved| {
+        return resolved;
+    }
+    if (resolveRuntimeSingletonRemoval(actual, declared, target, input_numel, out)) |resolved| {
+        return resolved;
     }
 
     const declared_batch = if (declared.rank() > 0) declared.dim(0) else -1;
@@ -1728,6 +1833,87 @@ fn resolveRuntimeReshapeDims(actual: []const i64, declared: Shape, target: Shape
         return out[0..rank];
     }
     return null;
+}
+
+fn resolveRuntimeSingletonInsertion(
+    actual: []const i64,
+    declared: Shape,
+    target: Shape,
+    input_numel: usize,
+    out: *[8]i64,
+) ?[]const i64 {
+    const target_rank = target.rank();
+    const declared_rank = declared.rank();
+    if (actual.len != declared_rank or target_rank <= declared_rank or target_rank > out.len) return null;
+
+    for (0..target_rank) |axis| out[axis] = target.dim(@intCast(axis));
+
+    var target_pos = target_rank;
+    var declared_pos = declared_rank;
+    while (declared_pos > 0) {
+        declared_pos -= 1;
+        const declared_dim = declared.dim(@intCast(declared_pos));
+        var matched = false;
+        while (target_pos > 0) {
+            target_pos -= 1;
+            const target_dim = target.dim(@intCast(target_pos));
+            if (target_dim == declared_dim) {
+                if (actual[declared_pos] <= 0) return null;
+                out[target_pos] = actual[declared_pos];
+                matched = true;
+                break;
+            }
+            if (target_dim != 1) return null;
+            out[target_pos] = 1;
+        }
+        if (!matched) return null;
+    }
+    while (target_pos > 0) {
+        target_pos -= 1;
+        if (target.dim(@intCast(target_pos)) != 1) return null;
+        out[target_pos] = 1;
+    }
+
+    if (safeElementCountFromDims(out[0..target_rank]) != input_numel) return null;
+    return out[0..target_rank];
+}
+
+fn resolveRuntimeSingletonRemoval(
+    actual: []const i64,
+    declared: Shape,
+    target: Shape,
+    input_numel: usize,
+    out: *[8]i64,
+) ?[]const i64 {
+    const target_rank = target.rank();
+    const declared_rank = declared.rank();
+    if (actual.len != declared_rank or target_rank >= declared_rank or target_rank > out.len) return null;
+
+    var target_pos = target_rank;
+    var declared_pos = declared_rank;
+    while (target_pos > 0) {
+        target_pos -= 1;
+        const target_dim = target.dim(@intCast(target_pos));
+        var matched = false;
+        while (declared_pos > 0) {
+            declared_pos -= 1;
+            const declared_dim = declared.dim(@intCast(declared_pos));
+            if (target_dim == declared_dim) {
+                if (actual[declared_pos] <= 0) return null;
+                out[target_pos] = actual[declared_pos];
+                matched = true;
+                break;
+            }
+            if (declared_dim != 1 or actual[declared_pos] != 1) return null;
+        }
+        if (!matched) return null;
+    }
+    while (declared_pos > 0) {
+        declared_pos -= 1;
+        if (declared.dim(@intCast(declared_pos)) != 1 or actual[declared_pos] != 1) return null;
+    }
+    if (safeElementCountFromDims(out[0..target_rank]) != input_numel) return null;
+    return out[0..target_rank];
 }
 
 fn resolveRuntimeCollapsedResizeDims(actual: []const i64, target: Shape, input_numel: usize, out: *[8]i64) ?[]const i64 {
@@ -2806,9 +2992,27 @@ pub fn executeNode(
                 if (a_reshaped) |r| cb.free(r);
                 if (b_reshaped) |r| cb.free(r);
             }
-            const a_ct = a_reshaped orelse a_val;
-            const b_ct = b_reshaped orelse b_val;
-            if (n.op == .add and state.isLastUseBy(ins[0], node_id) and !isNonDonatedRuntimeInput(state.options, ins[0])) {
+            const a_declared_ct = a_reshaped orelse a_val;
+            const b_declared_ct = b_reshaped orelse b_val;
+            const a_actual = cb.tensorShape(a_declared_ct, std.heap.page_allocator) catch null;
+            defer if (a_actual) |shape| std.heap.page_allocator.free(shape);
+            const b_actual = cb.tensorShape(b_declared_ct, std.heap.page_allocator) catch null;
+            defer if (b_actual) |shape| std.heap.page_allocator.free(shape);
+            var a_broadcast: ?CT = null;
+            defer if (a_broadcast) |value| cb.free(value);
+            var b_broadcast: ?CT = null;
+            defer if (b_broadcast) |value| cb.free(value);
+            if (a_actual != null and b_actual != null and !std.mem.eql(i64, a_actual.?, b_actual.?)) {
+                var target_buf: [ml.graph.shape.max_rank]i64 = undefined;
+                const target = resolveRuntimeBroadcastShape(a_actual.?, b_actual.?, &target_buf) orelse
+                    return error.ShapeMismatch;
+                a_broadcast = try runtimeBroadcastOperand(cb, a_declared_ct, a_actual.?, target);
+                b_broadcast = try runtimeBroadcastOperand(cb, b_declared_ct, b_actual.?, target);
+            }
+            const a_ct = a_broadcast orelse a_declared_ct;
+            const b_ct = b_broadcast orelse b_declared_ct;
+            const can_donate = a_broadcast == null and b_broadcast == null;
+            if (can_donate and n.op == .add and state.isLastUseBy(ins[0], node_id) and !isNonDonatedRuntimeInput(state.options, ins[0])) {
                 if (cb.addConsumeLeft(a_ct, b_ct) catch |err| switch (err) {
                     error.ShapeMismatch, error.UnsupportedShape, error.UnsupportedPrimitiveOp => null,
                     else => return err,
@@ -2818,7 +3022,7 @@ pub fn executeNode(
                     return consumed;
                 }
             }
-            if (n.op == .add and state.isLastUseBy(ins[1], node_id) and !isNonDonatedRuntimeInput(state.options, ins[1])) {
+            if (can_donate and n.op == .add and state.isLastUseBy(ins[1], node_id) and !isNonDonatedRuntimeInput(state.options, ins[1])) {
                 if (cb.addConsumeRight(a_ct, b_ct) catch |err| switch (err) {
                     error.ShapeMismatch, error.UnsupportedShape, error.UnsupportedPrimitiveOp => null,
                     else => return err,
@@ -2828,7 +3032,7 @@ pub fn executeNode(
                     return consumed;
                 }
             }
-            if (n.op == .mul and state.isLastUseBy(ins[0], node_id) and !isNonDonatedRuntimeInput(state.options, ins[0])) {
+            if (can_donate and n.op == .mul and state.isLastUseBy(ins[0], node_id) and !isNonDonatedRuntimeInput(state.options, ins[0])) {
                 if (cb.multiplyConsumeLeft(a_ct, b_ct) catch |err| switch (err) {
                     error.ShapeMismatch, error.UnsupportedShape, error.UnsupportedPrimitiveOp => null,
                     else => return err,
@@ -2838,7 +3042,7 @@ pub fn executeNode(
                     return consumed;
                 }
             }
-            if (n.op == .mul and state.isLastUseBy(ins[1], node_id) and !isNonDonatedRuntimeInput(state.options, ins[1])) {
+            if (can_donate and n.op == .mul and state.isLastUseBy(ins[1], node_id) and !isNonDonatedRuntimeInput(state.options, ins[1])) {
                 if (cb.multiplyConsumeRight(a_ct, b_ct) catch |err| switch (err) {
                     error.ShapeMismatch, error.UnsupportedShape, error.UnsupportedPrimitiveOp => null,
                     else => return err,
@@ -2848,7 +3052,7 @@ pub fn executeNode(
                     return consumed;
                 }
             }
-            if (n.op == .sub and state.isLastUseBy(ins[0], node_id) and !isNonDonatedRuntimeInput(state.options, ins[0])) {
+            if (can_donate and n.op == .sub and state.isLastUseBy(ins[0], node_id) and !isNonDonatedRuntimeInput(state.options, ins[0])) {
                 if (cb.subtractConsumeLeft(a_ct, b_ct) catch |err| switch (err) {
                     error.ShapeMismatch, error.UnsupportedShape, error.UnsupportedPrimitiveOp => null,
                     else => return err,
@@ -2858,7 +3062,7 @@ pub fn executeNode(
                     return consumed;
                 }
             }
-            if (n.op == .div and state.isLastUseBy(ins[0], node_id) and !isNonDonatedRuntimeInput(state.options, ins[0])) {
+            if (can_donate and n.op == .div and state.isLastUseBy(ins[0], node_id) and !isNonDonatedRuntimeInput(state.options, ins[0])) {
                 if (cb.divideConsumeLeft(a_ct, b_ct) catch |err| switch (err) {
                     error.ShapeMismatch, error.UnsupportedShape, error.UnsupportedPrimitiveOp => null,
                     else => return err,
@@ -2868,7 +3072,7 @@ pub fn executeNode(
                     return consumed;
                 }
             }
-            if (n.op == .less_than and state.isLastUseBy(ins[0], node_id) and !isNonDonatedRuntimeInput(state.options, ins[0])) {
+            if (can_donate and n.op == .less_than and state.isLastUseBy(ins[0], node_id) and !isNonDonatedRuntimeInput(state.options, ins[0])) {
                 if (cb.lessThanConsumeLeft(a_ct, b_ct) catch |err| switch (err) {
                     error.ShapeMismatch, error.UnsupportedShape, error.UnsupportedPrimitiveOp => null,
                     else => return err,
@@ -3036,11 +3240,22 @@ pub fn executeNode(
             const rank = attrs.new_shape.rank();
             var dims: [8]i64 = undefined;
             for (0..rank) |d| dims[d] = attrs.new_shape.dim(@intCast(d));
-            var reshaped_input = ensureDeclaredShape(cb, V.get(ins[0]), graph.node(ins[0]).output_shape);
+            var reshaped_input = if (attrs.runtime_shape)
+                null
+            else
+                ensureDeclaredShape(cb, V.get(ins[0]), graph.node(ins[0]).output_shape);
             defer if (reshaped_input) |v| cb.free(v);
             const input_value = reshaped_input orelse V.get(ins[0]);
             var resolved_dims: [8]i64 = undefined;
             const runtime_dims = blk: {
+                if (attrs.runtime_shape) {
+                    if (ins.len < 2 or ins[1] == null_node) return error.MissingRuntimeInput;
+                    const actual = try cb.tensorShape(input_value, std.heap.page_allocator);
+                    defer std.heap.page_allocator.free(actual);
+                    const shape_values = try cb.toFloat32(V.get(ins[1]), std.heap.page_allocator);
+                    defer std.heap.page_allocator.free(shape_values);
+                    break :blk try resolveOnnxRuntimeReshapeDims(shape_values, actual, attrs.allow_zero, &resolved_dims);
+                }
                 const actual = cb.tensorShape(input_value, std.heap.page_allocator) catch break :blk dims[0..rank];
                 defer std.heap.page_allocator.free(actual);
                 const input_numel = safeElementCountFromDims(actual) orelse break :blk dims[0..rank];
@@ -3120,9 +3335,46 @@ pub fn executeNode(
         .broadcast_in_dim => |attrs| {
             var sbuf: [8]i64 = undefined;
             const in_shape = fillShapeDims(graph, ins[0], &sbuf);
-            const rank = attrs.target_shape.rank();
+            var rank = @as(usize, attrs.target_shape.rank());
             var target_dims: [8]i64 = undefined;
             for (0..rank) |d| target_dims[d] = attrs.target_shape.dim(@intCast(d));
+
+            // ONNX Expand accepts its target as a tensor. The importer embeds
+            // any statically materializable values in target_shape and keeps
+            // the original shape input as input 1 for dynamic shape graphs.
+            if (ins.len > 1 and ins[1] != null_node) {
+                const shape_values = try cb.toFloat32(V.get(ins[1]), std.heap.page_allocator);
+                defer std.heap.page_allocator.free(shape_values);
+                if (shape_values.len > 0 and shape_values.len <= target_dims.len) {
+                    rank = shape_values.len;
+                    const actual_input_shape = cb.tensorShape(V.get(ins[0]), std.heap.page_allocator) catch null;
+                    defer if (actual_input_shape) |actual| std.heap.page_allocator.free(actual);
+                    const effective_input_shape = actual_input_shape orelse in_shape;
+                    for (0..rank) |d| {
+                        const rounded = @round(shape_values[d]);
+                        if (!std.math.isFinite(rounded) or @abs(shape_values[d] - rounded) > 1e-3)
+                            return error.InvalidTensorShape;
+                        var target_dim: i64 = @intFromFloat(rounded);
+                        const aligned_input_axis = if (d + effective_input_shape.len >= rank)
+                            d + effective_input_shape.len - rank
+                        else
+                            effective_input_shape.len;
+                        const input_dim: i64 = if (aligned_input_axis < effective_input_shape.len)
+                            effective_input_shape[aligned_input_axis]
+                        else
+                            1;
+                        if (target_dim <= 0) {
+                            const declared = if (d < attrs.target_shape.rank()) attrs.target_shape.dim(@intCast(d)) else -1;
+                            target_dim = if (declared > 0) declared else if (input_dim > 0) input_dim else 1;
+                        } else if (target_dim == 1 and input_dim > 1) {
+                            target_dim = input_dim;
+                        } else if (input_dim > 1 and target_dim != input_dim) {
+                            return error.ShapeMismatch;
+                        }
+                        target_dims[d] = target_dim;
+                    }
+                }
+            }
             const reshaped = ensureDeclaredShape(cb, V.get(ins[0]), graph.node(ins[0]).output_shape);
             defer if (reshaped) |r| cb.free(r);
             const result = try cb.primBroadcastInDim(
@@ -3311,6 +3563,23 @@ pub fn executeNode(
         .gather => |attrs| {
             var sbuf: [8]i64 = undefined;
             const in_shape = runtimeOrDeclaredShape(state, graph, ins[0], &sbuf);
+            var indices_buf: [8]i64 = undefined;
+            const indices_shape = runtimeOrDeclaredShape(state, graph, ins[1], &indices_buf);
+            if (attrs.elements) {
+                const actual_in_shape = cb.tensorShape(V.get(ins[0]), std.heap.page_allocator) catch null;
+                defer if (actual_in_shape) |shape| std.heap.page_allocator.free(shape);
+                const actual_indices_shape = cb.tensorShape(V.get(ins[1]), std.heap.page_allocator) catch null;
+                defer if (actual_indices_shape) |shape| std.heap.page_allocator.free(shape);
+                return executeGatherElements(
+                    std.heap.page_allocator,
+                    cb,
+                    V.get(ins[0]),
+                    V.get(ins[1]),
+                    actual_in_shape orelse in_shape,
+                    actual_indices_shape orelse indices_shape,
+                    attrs.axis,
+                );
+            }
             if (attrs.axis == 0) gather_add_bias: {
                 const input_node = graph.node(ins[0]);
                 if (input_node.op != .add) break :gather_add_bias;
@@ -3609,6 +3878,80 @@ pub fn executeNode(
             return error.UnsupportedPrimitiveOp;
         },
     };
+}
+
+fn executeGatherElements(
+    allocator: std.mem.Allocator,
+    cb: *const ComputeBackend,
+    input: CT,
+    indices: CT,
+    input_shape: []const i64,
+    indices_shape: []const i64,
+    axis: u8,
+) !CT {
+    const rank = input_shape.len;
+    if (rank == 0 or rank > 8 or indices_shape.len != rank or axis >= rank)
+        return error.InvalidTensorShape;
+
+    const input_count = safeElementCountFromDims(input_shape) orelse return error.InvalidTensorShape;
+    const output_count = safeElementCountFromDims(indices_shape) orelse return error.InvalidTensorShape;
+    const input_data = try cb.toFloat32(input, allocator);
+    defer allocator.free(input_data);
+    const index_data = try cb.toFloat32(indices, allocator);
+    defer allocator.free(index_data);
+    if (input_data.len != input_count or index_data.len != output_count)
+        return error.InvalidTensorShape;
+
+    var input_strides: [8]usize = undefined;
+    var output_strides: [8]usize = undefined;
+    var stride: usize = 1;
+    var rev = rank;
+    while (rev > 0) {
+        rev -= 1;
+        input_strides[rev] = stride;
+        stride = std.math.mul(usize, stride, @intCast(input_shape[rev])) catch
+            return error.InvalidTensorShape;
+    }
+    stride = 1;
+    rev = rank;
+    while (rev > 0) {
+        rev -= 1;
+        output_strides[rev] = stride;
+        stride = std.math.mul(usize, stride, @intCast(indices_shape[rev])) catch
+            return error.InvalidTensorShape;
+    }
+
+    const output = try allocator.alloc(f32, output_count);
+    defer allocator.free(output);
+    for (0..output_count) |flat_output| {
+        var remaining = flat_output;
+        var input_offset: usize = 0;
+        for (0..rank) |d| {
+            const coord = remaining / output_strides[d];
+            remaining %= output_strides[d];
+            if (d == axis) {
+                const raw_index = index_data[flat_output];
+                const rounded = @round(raw_index);
+                if (!std.math.isFinite(rounded) or @abs(raw_index - rounded) > 1e-3)
+                    return error.InvalidTensorIndex;
+                var gather_index: i64 = @intFromFloat(rounded);
+                if (gather_index < 0) gather_index += input_shape[d];
+                if (gather_index < 0 or gather_index >= input_shape[d])
+                    return error.IndexOutOfBounds;
+                input_offset += @as(usize, @intCast(gather_index)) * input_strides[d];
+            } else {
+                if (coord >= input_shape[d]) return error.InvalidTensorShape;
+                input_offset += coord * input_strides[d];
+            }
+        }
+        output[flat_output] = input_data[input_offset];
+    }
+
+    var dims: [8]i32 = undefined;
+    for (indices_shape, 0..) |dim, d| {
+        dims[d] = std.math.cast(i32, dim) orelse return error.InvalidTensorShape;
+    }
+    return cb.fromFloat32Shape(output, dims[0..rank]);
 }
 
 // ── Tests ──────────────────────────────────────────────────────────────
@@ -4469,6 +4812,62 @@ test "shouldReshapeToDeclaredShape preserves concrete runtime batch" {
     ));
 }
 
+test "runtime shape tensors preserve distinct ONNX reshape layouts" {
+    const allocator = std.testing.allocator;
+
+    var g = Graph.init(allocator);
+    defer g.deinit();
+    var builder = ml.graph.Builder.init(&g);
+
+    const x = try builder.parameter("x", Shape.init(.f32, &.{16}));
+    const row_target = try builder.parameter("row_target", Shape.init(.i64, &.{3}));
+    const column_target = try builder.parameter("column_target", Shape.init(.i64, &.{3}));
+    const attrs = ml.graph.node.ReshapeAttrs{
+        .new_shape = Shape.init(.f32, &.{ 1, -1, -1 }),
+        .runtime_shape = true,
+    };
+    const row = try g.addNode(.{
+        .op = .{ .reshape = attrs },
+        .output_shape = attrs.new_shape,
+        .inputs = .{ x, row_target, null_node, null_node },
+        .num_inputs = 2,
+    });
+    const column = try g.addNode(.{
+        .op = .{ .reshape = attrs },
+        .output_shape = attrs.new_shape,
+        .inputs = .{ x, column_target, null_node, null_node },
+        .num_inputs = 2,
+    });
+    try g.markOutput(row);
+    try g.markOutput(column);
+
+    var ws = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
+    var compute = NativeCompute.init(allocator, &ws, null);
+    var cb_val = compute.computeBackend();
+
+    const x_ct = try cb_val.fromFloat32Shape(&.{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 }, &.{16});
+    defer cb_val.free(x_ct);
+    const row_target_ct = try cb_val.fromFloat32Shape(&.{ 1, 1, 16 }, &.{3});
+    defer cb_val.free(row_target_ct);
+    const column_target_ct = try cb_val.fromFloat32Shape(&.{ 1, 16, 1 }, &.{3});
+    defer cb_val.free(column_target_ct);
+    const rt_inputs = [_]RuntimeInput{
+        .{ .node_id = x, .value = x_ct },
+        .{ .node_id = row_target, .value = row_target_ct },
+        .{ .node_id = column_target, .value = column_target_ct },
+    };
+
+    var result = try execute(allocator, &g, &cb_val, .{ .runtime_inputs = &rt_inputs });
+    defer result.deinit(&cb_val);
+
+    const row_shape = try cb_val.tensorShape(result.outputs[0], allocator);
+    defer allocator.free(row_shape);
+    const column_shape = try cb_val.tensorShape(result.outputs[1], allocator);
+    defer allocator.free(column_shape);
+    try std.testing.expectEqualSlices(i64, &.{ 1, 1, 16 }, row_shape);
+    try std.testing.expectEqualSlices(i64, &.{ 1, 16, 1 }, column_shape);
+}
+
 test "resolveRuntimeReshapeDims preserves runtime batch for exported singleton reshape" {
     var out: [8]i64 = undefined;
     const resolved = resolveRuntimeReshapeDims(
@@ -4479,6 +4878,30 @@ test "resolveRuntimeReshapeDims preserves runtime batch for exported singleton r
     ) orelse return error.TestUnexpectedResult;
 
     try std.testing.expectEqualSlices(i64, &.{ 2, 6, 2, 2 }, resolved);
+}
+
+test "resolveRuntimeReshapeDims restores dynamic axes around inserted singleton dimensions" {
+    var out: [8]i64 = undefined;
+    const resolved = resolveRuntimeReshapeDims(
+        &.{ 19, 1 },
+        Shape.init(.i64, &.{ -1, -1 }),
+        Shape.init(.i64, &.{ 1, 1, -1, -1 }),
+        &out,
+    ) orelse return error.TestUnexpectedResult;
+
+    try std.testing.expectEqualSlices(i64, &.{ 1, 1, 19, 1 }, resolved);
+}
+
+test "resolveRuntimeReshapeDims preserves dynamic axes while removing singleton dimensions" {
+    var out: [8]i64 = undefined;
+    const resolved = resolveRuntimeReshapeDims(
+        &.{ 1, 1, 19, 19 },
+        Shape.init(.i64, &.{ 1, 1, -1, -1 }),
+        Shape.init(.i64, &.{ 1, -1, -1 }),
+        &out,
+    ) orelse return error.TestUnexpectedResult;
+
+    try std.testing.expectEqualSlices(i64, &.{ 1, 19, 19 }, resolved);
 }
 
 test "resolveRuntimeReshapeDims expands concrete singleton batch reshape" {
@@ -5267,6 +5690,46 @@ test "execute clones aliased passthrough outputs that outlive their input branch
     try std.testing.expectApproxEqAbs(@as(f32, -0.5 + @exp(@as(f32, -0.5))), actual[1], 1e-4);
 }
 
+test "execute preserves runtime shape when cloning an aliased dynamic tensor" {
+    const allocator = std.testing.allocator;
+
+    var g = Graph.init(allocator);
+    defer g.deinit();
+    var builder = ml.graph.Builder.init(&g);
+
+    const x = try builder.parameter("x", Shape.init(.f32, &.{ -1, 3 }));
+    const y = try builder.convertDtype(x, .f32);
+    const z = try builder.expOp(x);
+    const out = try builder.add(y, z);
+    try g.markOutput(out);
+
+    var ws = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
+    var compute = NativeCompute.init(allocator, &ws, null);
+    var cb_val = compute.computeBackend();
+
+    const input = [_]f32{ 1.5, -0.5, 2.0, -1.0, 0.0, 0.5 };
+    const x_ct = try cb_val.fromFloat32Shape(&input, &.{ 2, 3 });
+    const rt_inputs = [_]RuntimeInput{
+        .{ .node_id = x, .value = x_ct },
+    };
+
+    var result = try execute(allocator, &g, &cb_val, .{
+        .runtime_inputs = &rt_inputs,
+    });
+    defer result.deinit(&cb_val);
+    defer cb_val.free(x_ct);
+
+    const actual_shape = try cb_val.tensorShape(result.outputs[0], allocator);
+    defer allocator.free(actual_shape);
+    try std.testing.expectEqualSlices(i64, &.{ 2, 3 }, actual_shape);
+
+    const actual = try cb_val.toFloat32(result.outputs[0], allocator);
+    defer allocator.free(actual);
+    for (input, actual) |value, got| {
+        try std.testing.expectApproxEqAbs(value + @exp(value), got, 1e-4);
+    }
+}
+
 test "execution result deinit frees duplicate output handles once" {
     const allocator = std.testing.allocator;
 
@@ -5691,6 +6154,46 @@ test "runtime shape drives symbolic argmax" {
     try std.testing.expectEqualSlices(f32, &.{ 3, 0, 2, 0, 1, 2 }, actual);
 }
 
+test "runtime binary broadcasting expands complementary symbolic axes" {
+    const allocator = std.testing.allocator;
+
+    var g = Graph.init(allocator);
+    defer g.deinit();
+    var builder = ml.graph.Builder.init(&g);
+
+    const lhs = try builder.parameter("lhs", Shape.init(.f32, &.{ -1, 1 }));
+    const rhs = try builder.parameter("rhs", Shape.init(.f32, &.{ 1, -1 }));
+    const out = try builder.sub(lhs, rhs);
+    try g.markOutput(out);
+
+    var ws = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
+    var compute = NativeCompute.init(allocator, &ws, null);
+    var cb_val = compute.computeBackend();
+
+    const lhs_ct = try cb_val.fromFloat32Shape(&.{ 0, 1, 2 }, &.{ 3, 1 });
+    defer cb_val.free(lhs_ct);
+    const rhs_ct = try cb_val.fromFloat32Shape(&.{ 0, 10, 20, 30 }, &.{ 1, 4 });
+    defer cb_val.free(rhs_ct);
+    const rt_inputs = [_]RuntimeInput{
+        .{ .node_id = lhs, .value = lhs_ct },
+        .{ .node_id = rhs, .value = rhs_ct },
+    };
+
+    var result = try execute(allocator, &g, &cb_val, .{ .runtime_inputs = &rt_inputs });
+    defer result.deinit(&cb_val);
+
+    const actual_shape = try cb_val.tensorShape(result.outputs[0], allocator);
+    defer allocator.free(actual_shape);
+    try std.testing.expectEqualSlices(i64, &.{ 3, 4 }, actual_shape);
+    const actual = try cb_val.toFloat32(result.outputs[0], allocator);
+    defer allocator.free(actual);
+    try std.testing.expectEqualSlices(f32, &.{
+        0, -10, -20, -30,
+        1, -9,  -19, -29,
+        2, -8,  -18, -28,
+    }, actual);
+}
+
 test "runtime shape drives symbolic broadcast_in_dim" {
     const allocator = std.testing.allocator;
 
@@ -5743,6 +6246,168 @@ test "runtime shape drives symbolic broadcast_in_dim" {
         4, 5, 6,
         4, 5, 6,
     }, actual);
+}
+
+test "runtime shape tensor drives dynamic broadcast_in_dim" {
+    const allocator = std.testing.allocator;
+
+    var g = Graph.init(allocator);
+    defer g.deinit();
+    var builder = ml.graph.Builder.init(&g);
+
+    const x = try builder.parameter("x", Shape.init(.f32, &.{ 1, 1, -1 }));
+    const target = try builder.parameter("target", Shape.init(.i64, &.{3}));
+    var attrs = ml.graph.node.BroadcastAttrs{ .target_shape = Shape.init(.f32, &.{ -1, -1, -1 }) };
+    attrs.broadcast_axes = .{ 0, 1, 2, 0, 0, 0, 0, 0 };
+    attrs.num_axes = 3;
+    const out = try g.addNode(.{
+        .op = .{ .broadcast_in_dim = attrs },
+        .output_shape = attrs.target_shape,
+        .inputs = .{ x, target, null_node, null_node },
+        .num_inputs = 2,
+    });
+    try g.markOutput(out);
+
+    var ws = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
+    var compute = NativeCompute.init(allocator, &ws, null);
+    var cb_val = compute.computeBackend();
+
+    const x_ct = try cb_val.fromFloat32Shape(&.{ 1, 2, 3 }, &.{ 1, 1, 3 });
+    defer cb_val.free(x_ct);
+    const target_ct = try cb_val.fromFloat32Shape(&.{ 2, 4, 3 }, &.{3});
+    defer cb_val.free(target_ct);
+    const rt_inputs = [_]RuntimeInput{
+        .{ .node_id = x, .value = x_ct },
+        .{ .node_id = target, .value = target_ct },
+    };
+
+    var result = try execute(allocator, &g, &cb_val, .{ .runtime_inputs = &rt_inputs });
+    defer result.deinit(&cb_val);
+
+    const actual_shape = try cb_val.tensorShape(result.outputs[0], allocator);
+    defer allocator.free(actual_shape);
+    try std.testing.expectEqualSlices(i64, &.{ 2, 4, 3 }, actual_shape);
+    const actual = try cb_val.toFloat32(result.outputs[0], allocator);
+    defer allocator.free(actual);
+    try std.testing.expectEqual(@as(usize, 24), actual.len);
+    for (0..8) |row| {
+        try std.testing.expectEqualSlices(f32, &.{ 1, 2, 3 }, actual[row * 3 ..][0..3]);
+    }
+}
+
+test "native interpreter executes GatherElements along the selected axis" {
+    const allocator = std.testing.allocator;
+
+    var g = Graph.init(allocator);
+    defer g.deinit();
+    var builder = ml.graph.Builder.init(&g);
+
+    const data = try builder.parameter("data", Shape.init(.f32, &.{ -1, -1, 5 }));
+    const indices = try builder.parameter("indices", Shape.init(.i64, &.{ -1, -1, -1 }));
+    const out = try g.addNode(.{
+        .op = .{ .gather = .{ .axis = 2, .elements = true } },
+        .output_shape = Shape.init(.f32, &.{ -1, -1, -1 }),
+        .inputs = .{ data, indices, null_node, null_node },
+        .num_inputs = 2,
+    });
+    try g.markOutput(out);
+
+    var ws = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
+    var compute = NativeCompute.init(allocator, &ws, null);
+    var cb_val = compute.computeBackend();
+
+    const data_values = [_]f32{
+        10, 11, 12, 13, 14,
+        20, 21, 22, 23, 24,
+        30, 31, 32, 33, 34,
+        40, 41, 42, 43, 44,
+    };
+    const index_values = [_]f32{
+        4, 0,  2,
+        1, 3,  0,
+        2, 2,  4,
+        0, -1, 1,
+    };
+    const data_ct = try cb_val.fromFloat32Shape(&data_values, &.{ 2, 2, 5 });
+    defer cb_val.free(data_ct);
+    const indices_ct = try cb_val.fromFloat32Shape(&index_values, &.{ 2, 2, 3 });
+    defer cb_val.free(indices_ct);
+    const rt_inputs = [_]RuntimeInput{
+        .{ .node_id = data, .value = data_ct },
+        .{ .node_id = indices, .value = indices_ct },
+    };
+
+    var result = try execute(allocator, &g, &cb_val, .{ .runtime_inputs = &rt_inputs });
+    defer result.deinit(&cb_val);
+    const actual_shape = try cb_val.tensorShape(result.outputs[0], allocator);
+    defer allocator.free(actual_shape);
+    try std.testing.expectEqualSlices(i64, &.{ 2, 2, 3 }, actual_shape);
+    const actual = try cb_val.toFloat32(result.outputs[0], allocator);
+    defer allocator.free(actual);
+    try std.testing.expectEqualSlices(f32, &.{ 14, 10, 12, 21, 23, 20, 32, 32, 34, 40, 44, 41 }, actual);
+}
+
+test "native GatherElements uses concrete shape of a dynamic broadcast result" {
+    const allocator = std.testing.allocator;
+
+    var g = Graph.init(allocator);
+    defer g.deinit();
+    var builder = ml.graph.Builder.init(&g);
+
+    const data = try builder.parameter("data", Shape.init(.f32, &.{ -1, -1, 5 }));
+    const indices_seed = try builder.parameter("indices_seed", Shape.init(.i64, &.{ 1, -1, -1 }));
+    const target = try builder.parameter("target", Shape.init(.i64, &.{3}));
+    var broadcast_attrs = ml.graph.node.BroadcastAttrs{ .target_shape = Shape.init(.i64, &.{ -1, -1, -1 }) };
+    broadcast_attrs.broadcast_axes = .{ 0, 1, 2, 0, 0, 0, 0, 0 };
+    broadcast_attrs.num_axes = 3;
+    const indices = try g.addNode(.{
+        .op = .{ .broadcast_in_dim = broadcast_attrs },
+        .output_shape = broadcast_attrs.target_shape,
+        .inputs = .{ indices_seed, target, null_node, null_node },
+        .num_inputs = 2,
+    });
+    const out = try g.addNode(.{
+        .op = .{ .gather = .{ .axis = 2, .elements = true } },
+        .output_shape = Shape.init(.f32, &.{ -1, -1, -1 }),
+        .inputs = .{ data, indices, null_node, null_node },
+        .num_inputs = 2,
+    });
+    try g.markOutput(out);
+
+    var ws = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
+    var compute = NativeCompute.init(allocator, &ws, null);
+    var cb_val = compute.computeBackend();
+
+    const data_values = [_]f32{
+        10, 11, 12, 13, 14,
+        20, 21, 22, 23, 24,
+        30, 31, 32, 33, 34,
+        40, 41, 42, 43, 44,
+    };
+    const index_values = [_]f32{
+        4, 0, 2,
+        1, 3, 0,
+    };
+    const data_ct = try cb_val.fromFloat32Shape(&data_values, &.{ 2, 2, 5 });
+    defer cb_val.free(data_ct);
+    const indices_ct = try cb_val.fromFloat32Shape(&index_values, &.{ 1, 2, 3 });
+    defer cb_val.free(indices_ct);
+    const target_ct = try cb_val.fromFloat32Shape(&.{ 2, 2, 3 }, &.{3});
+    defer cb_val.free(target_ct);
+    const rt_inputs = [_]RuntimeInput{
+        .{ .node_id = data, .value = data_ct },
+        .{ .node_id = indices_seed, .value = indices_ct },
+        .{ .node_id = target, .value = target_ct },
+    };
+
+    var result = try execute(allocator, &g, &cb_val, .{ .runtime_inputs = &rt_inputs });
+    defer result.deinit(&cb_val);
+    const actual_shape = try cb_val.tensorShape(result.outputs[0], allocator);
+    defer allocator.free(actual_shape);
+    try std.testing.expectEqualSlices(i64, &.{ 2, 2, 3 }, actual_shape);
+    const actual = try cb_val.toFloat32(result.outputs[0], allocator);
+    defer allocator.free(actual);
+    try std.testing.expectEqualSlices(f32, &.{ 14, 10, 12, 21, 23, 20, 34, 30, 32, 41, 43, 40 }, actual);
 }
 
 test "runtime shape drives dynamic integer resize broadcast values" {

--- a/zig/pkg/inference/src/graph/metal_capabilities.zig
+++ b/zig/pkg/inference/src/graph/metal_capabilities.zig
@@ -382,6 +382,11 @@ fn metalTransposeHasResidentShape(query: CapabilityQuery) bool {
 }
 
 fn metalReshapeHasResidentShape(query: CapabilityQuery) bool {
+    const attrs = switch (query.op) {
+        .reshape => |attrs| attrs,
+        else => return false,
+    };
+    if (attrs.runtime_shape) return false;
     const input_shape = nodeInputShape(query, 0) orelse return false;
     const output_shape = query.graph.node(query.node_id).output_shape;
     return input_shape.dtype == output_shape.dtype and
@@ -524,6 +529,7 @@ fn metalGatherHasResidentShape(query: CapabilityQuery) bool {
         .gather => |attrs| attrs,
         else => return false,
     };
+    if (attrs.elements) return false;
     if (attrs.axis != 0) return false;
     const input_shape = nodeInputShape(query, 0) orelse return false;
     const indices_shape = nodeInputShape(query, 1) orelse return false;

--- a/zig/pkg/inference/src/graph/native_partition_executor.zig
+++ b/zig/pkg/inference/src/graph/native_partition_executor.zig
@@ -480,6 +480,7 @@ fn executeNativePlannedNode(
             );
         },
         .reshape => |attrs| blk: {
+            if (attrs.runtime_shape) return null;
             const rank = attrs.new_shape.rank();
             var dims: [8]i64 = undefined;
             for (0..rank) |d| dims[d] = attrs.new_shape.dim(@intCast(d));

--- a/zig/pkg/inference/src/graph/pjrt_compiler.zig
+++ b/zig/pkg/inference/src/graph/pjrt_compiler.zig
@@ -1396,7 +1396,7 @@ pub fn compileGradientGraph(
 
             // Shape ops
             .reshape => |attrs| {
-                if (!hloShapeIsConcretePositive(attrs.new_shape)) return error.UnsupportedShape;
+                if (attrs.runtime_shape or !hloShapeIsConcretePositive(attrs.new_shape)) return error.UnsupportedShape;
                 node_map[nid] = try b.reshape(
                     try getHloId(node_map, ins[0]),
                     hlo.Shape.init(graphDTypeToHlo(attrs.new_shape.dtype), attrs.new_shape.dims[0..attrs.new_shape.rank()]),

--- a/zig/pkg/inference/src/graph/webgpu_capabilities.zig
+++ b/zig/pkg/inference/src/graph/webgpu_capabilities.zig
@@ -283,6 +283,7 @@ fn webGpuNodeHasSupportedShape(query: CapabilityQuery) bool {
     const node = query.graph.node(query.node_id);
     if (node.output_shape.numElements() == null and node.output_shape.maxElements() == null) return false;
     return switch (query.op) {
+        .reshape => |attrs| !attrs.runtime_shape,
         .fused_linear_no_bias, .fused_linear_no_bias_pair => |attrs| webGpuLinearAttrsHaveSupportedShape(attrs),
         .fused_layer_norm, .fused_rms_norm => |attrs| blk: {
             if (attrs.dim == 0) break :blk false;

--- a/zig/pkg/inference/src/ops/native_compute.zig
+++ b/zig/pkg/inference/src/ops/native_compute.zig
@@ -1760,7 +1760,19 @@ fn resolveDotOperandShapeFromPeer(
 
         if (dim <= 0) {
             if (indexOfAxis(batch_dims, axis)) |batch_index| {
-                if (batch_index < peer_batch_dims.len) {
+                // Generic dynamic ONNX dimensions (-1, and occasionally 0
+                // from incomplete shape inference) must retain a concrete
+                // runtime batch extent when one is already attached to the
+                // tensor. The peer may intentionally have a smaller repeated
+                // batch (for example one set of weights per attention head),
+                // so copying its extent would fold batch rows into the free
+                // dimension while preserving only the total element count.
+                if (declared_dim >= -1) {
+                    if (stored_shape) |shape| {
+                        if (i < shape.len and shape[i] > 0) dim = shape[i];
+                    }
+                }
+                if (dim <= 0 and batch_index < peer_batch_dims.len) {
                     const peer_axis = peer_batch_dims[batch_index];
                     if (peer_axis < peer_shape.len and peer_shape[peer_axis] > 0) {
                         dim = peer_shape[peer_axis];
@@ -38017,7 +38029,7 @@ fn primDotGeneralOp(ctx: *anyopaque, lhs: CT, rhs: CT, lhs_shape: []const i64, r
         if (!symbolic_batch_dims and lhs_has_batch and lhs_batch_shape.len > 0) computeStrides(lhs_batch_shape, lhs_batch_strides[0..lhs_batch_shape.len]);
         var rhs_batch_strides: [8]usize = undefined;
         if (!symbolic_batch_dims and rhs_has_batch and rhs_batch_shape.len > 0) computeStrides(rhs_batch_shape, rhs_batch_strides[0..rhs_batch_shape.len]);
-        if (symbolic_batch_dims or flattened_batch_broadcast or lhs_free_axis == null or rhs_free_axis == null or lhs_buf2.source_tensor != null or rhs_buf2.source_tensor != null) {
+        if (symbolic_batch_dims or lhs_free_axis == null or rhs_free_axis == null) {
             for (0..batch_size) |b| {
                 const lhs_batch_index = if (symbolic_batch_dims or flattened_batch_broadcast)
                     if (lhs_batch_elems == 1) 0 else b % lhs_batch_elems
@@ -38043,7 +38055,16 @@ fn primDotGeneralOp(ctx: *anyopaque, lhs: CT, rhs: CT, lhs_shape: []const i64, r
             const rhs_strides = logicalStridesOrContiguous(rhs, rhs_effective_shape, rhs_stride_scratch[0..rhs_effective_shape.len]);
 
             for (0..batch_size) |b| {
-                const lhs_batch_offset = if (lhs_has_batch and out_batch_shape.len > 0)
+                const lhs_batch_offset = if (lhs_has_batch and flattened_batch_broadcast)
+                    broadcastTensorOffsetForOutputBatch(
+                        if (lhs_batch_elems == 1) 0 else b % lhs_batch_elems,
+                        lhs_batch_shape,
+                        lhs_batch_strides[0..lhs_batch_shape.len],
+                        lhs_batch_shape,
+                        lhs_batch,
+                        lhs_strides,
+                    )
+                else if (lhs_has_batch and out_batch_shape.len > 0)
                     broadcastTensorOffsetForOutputBatch(
                         b,
                         out_batch_shape,
@@ -38054,7 +38075,16 @@ fn primDotGeneralOp(ctx: *anyopaque, lhs: CT, rhs: CT, lhs_shape: []const i64, r
                     )
                 else
                     0;
-                const rhs_batch_offset = if (rhs_has_batch and out_batch_shape.len > 0)
+                const rhs_batch_offset = if (rhs_has_batch and flattened_batch_broadcast)
+                    broadcastTensorOffsetForOutputBatch(
+                        if (rhs_batch_elems == 1) 0 else b % rhs_batch_elems,
+                        rhs_batch_shape,
+                        rhs_batch_strides[0..rhs_batch_shape.len],
+                        rhs_batch_shape,
+                        rhs_batch,
+                        rhs_strides,
+                    )
+                else if (rhs_has_batch and out_batch_shape.len > 0)
                     broadcastTensorOffsetForOutputBatch(
                         b,
                         out_batch_shape,
@@ -48045,6 +48075,64 @@ test "dot_general resolves rhs symbolic batch and free dims from lhs peer" {
 
     try std.testing.expectEqualSlices(i64, &.{ 2, 3, 4, 6 }, tensorStoredShape(out_ct).?);
     try std.testing.expectEqual(@as(usize, 2 * 3 * 4 * 6), getData(out_ct).len);
+}
+
+test "dot_general keeps concrete flattened batch extent with repeated per-head rhs" {
+    const allocator = std.testing.allocator;
+    var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
+    var compute = NativeCompute.init(allocator, &weight_store, null);
+
+    const lhs_data = try allocator.alloc(f32, 4 * 3 * 2);
+    defer allocator.free(lhs_data);
+    @memset(lhs_data, 1.0);
+
+    const rhs_data = try allocator.alloc(f32, 2 * 5 * 2);
+    defer allocator.free(rhs_data);
+    for (0..2) |batch| {
+        for (0..5) |column| {
+            for (0..2) |contracting| {
+                rhs_data[(batch * 5 + column) * 2 + contracting] = @floatFromInt(batch * 100 + column * 10 + contracting + 1);
+            }
+        }
+    }
+
+    const lhs_ct = try compute.makeBuf(lhs_data, false);
+    defer freeTensor(&compute, lhs_ct);
+    const lhs_shaped = try compute.withLogicalShape(lhs_ct, &.{ 4, 3, 2 });
+
+    const rhs_ct = try compute.makeBuf(rhs_data, false);
+    defer freeTensor(&compute, rhs_ct);
+    const rhs_shaped = try compute.withLogicalShape(rhs_ct, &.{ 2, 5, 2 });
+    const rhs_transposed = try primTransposeOp(&compute, rhs_shaped, &.{ 0, 2, 1 }, &.{ 2, 5, 2 });
+    defer freeTensor(&compute, rhs_transposed);
+
+    const out_ct = try primDotGeneralOp(
+        &compute,
+        lhs_shaped,
+        rhs_transposed,
+        &.{ -1, -1, -1 },
+        &.{ 0, 0, 0 },
+        &.{2},
+        &.{1},
+        &.{0},
+        &.{0},
+    );
+    defer freeTensor(&compute, out_ct);
+
+    try std.testing.expectEqualSlices(i64, &.{ 4, 3, 5 }, tensorStoredShape(out_ct).?);
+    try std.testing.expectEqual(@as(usize, 4 * 3 * 5), getData(out_ct).len);
+    const expected_rows = [_][5]f32{
+        .{ 3, 23, 43, 63, 83 },
+        .{ 203, 223, 243, 263, 283 },
+        .{ 3, 23, 43, 63, 83 },
+        .{ 203, 223, 243, 263, 283 },
+    };
+    for (0..4) |batch| {
+        for (0..3) |row| {
+            const offset = (batch * 3 + row) * 5;
+            try std.testing.expectEqualSlices(f32, &expected_rows[batch], getData(out_ct)[offset..][0..5]);
+        }
+    }
 }
 
 test "dot_general handles batched rhs free-before-contract layout" {


### PR DESCRIPTION
[codex 5.6 sol] 

  ## Summary

  - Add native ONNX support for `DynamicQuantizeLinear` and `MatMulInteger`.
  - Preserve concrete runtime shapes through dynamic reshape, expand, broadcast, and `GatherElements`.
  - Fix repeated per-head batched matmul to respect runtime batch extents and transposed tensor
  strides.
  - Keep the documented i8 Mixedbread reranker working without falling back to the much larger f32
  artifact.

  ## Validation

  - `zig build lib-onnx-test`: 231 passed, 4 skipped
  - `zig build inference-test`: 3,210 passed, 20 skipped
  - ReleaseFast `/ai/v1/rerank`: HTTP 200
  - Native i8 scores: relevant `0.94104`, irrelevant `0.003462`
  - ONNX Runtime reference: relevant `0.93523`, irrelevant `0.003853`