### PR TITLE
round2 of reranker fixes: preserve dynamic shapes in native graph partitions

### DIFF
--- a/zig/pkg/inference/src/graph/interpreter.zig
+++ b/zig/pkg/inference/src/graph/interpreter.zig
@@ -1254,6 +1254,84 @@ fn computeRuntimeShapeCaptureSet(allocator: std.mem.Allocator, graph: *const Gra
     return capture;
 }
 
+/// Request-scoped concrete shapes shared by partition executors. Imported
+/// graphs can retain symbolic dimensions in their declarations after the
+/// backend has resolved them for a particular request; interpreter fallbacks
+/// inside a partition need the same provenance as whole-graph interpretation.
+pub const RuntimeShapeTracker = struct {
+    allocator: std.mem.Allocator,
+    capture: []const bool = &.{},
+    owned_capture: ?[]bool = null,
+    shapes: ?[]?[]i64 = null,
+
+    pub fn init(
+        allocator: std.mem.Allocator,
+        graph: *const Graph,
+        cached_analysis: ?CachedAnalysis,
+    ) !RuntimeShapeTracker {
+        var tracker = RuntimeShapeTracker{ .allocator = allocator };
+        errdefer tracker.deinit();
+
+        if (cached_analysis) |analysis| {
+            tracker.capture = analysis.runtime_shape_capture;
+        } else {
+            const capture = try computeRuntimeShapeCaptureSet(allocator, graph);
+            tracker.capture = capture;
+            tracker.owned_capture = capture;
+        }
+
+        if (shapeCaptureSetHasAny(tracker.capture) and graphNeedsRuntimeShapeTracking(graph)) {
+            const shapes = try allocator.alloc(?[]i64, graph.nodeCount());
+            @memset(shapes, null);
+            tracker.shapes = shapes;
+        }
+        return tracker;
+    }
+
+    pub fn deinit(self: *RuntimeShapeTracker) void {
+        if (self.shapes) |shapes| {
+            for (shapes) |maybe_shape| {
+                if (maybe_shape) |shape| self.allocator.free(shape);
+            }
+            self.allocator.free(shapes);
+            self.shapes = null;
+        }
+        if (self.owned_capture) |capture| {
+            self.allocator.free(capture);
+            self.owned_capture = null;
+        }
+        self.capture = &.{};
+    }
+
+    pub fn runtimeShapes(self: *const RuntimeShapeTracker) ?[]const ?[]const i64 {
+        return self.shapes;
+    }
+
+    pub fn record(
+        self: *RuntimeShapeTracker,
+        cb: *const ComputeBackend,
+        node_id: NodeId,
+        value: CT,
+    ) !void {
+        try recordRuntimeShape(self.allocator, cb, self.shapes, self.capture, node_id, value);
+    }
+};
+
+fn graphNeedsRuntimeShapeTracking(graph: *const Graph) bool {
+    for (0..graph.nodeCount()) |index| {
+        const node = graph.node(@intCast(index));
+        for (0..node.output_shape.rank()) |axis| {
+            if (node.output_shape.dim(@intCast(axis)) < 0) return true;
+        }
+        switch (node.op) {
+            .reshape => |attrs| if (attrs.runtime_shape) return true,
+            .broadcast_in_dim => if (node.num_inputs > 1) return true,
+            else => {},
+        }
+    }
+    return false;
+}
+
 /// Convert a flat MoeRouteSelection (rows * top_k entries) into a grouped
 /// format sorted by expert. Mirrors the grouping in gpt.zig's
 /// runGroupedExpertBatchTensor.

--- a/zig/pkg/inference/src/graph/multi_executor.zig
+++ b/zig/pkg/inference/src/graph/multi_executor.zig
@@ -241,6 +241,16 @@ pub fn executeMultiDevice(
     const last_use = if (options.cached_analysis) |ca| ca.last_use else try interpreter.computeLastUse(allocator, graph, reachable);
     defer if (!have_cache) allocator.free(last_use);
 
+    var runtime_shape_tracker = try interpreter.RuntimeShapeTracker.init(allocator, graph, options.cached_analysis);
+    defer runtime_shape_tracker.deinit();
+    if (options.runtime_inputs) |inputs| {
+        const runtime_backend = (mesh.device(0) orelse return error.DeviceNotFound).backend;
+        for (inputs) |ri| {
+            if (ri.node_id >= count) continue;
+            try runtime_shape_tracker.record(runtime_backend, ri.node_id, ri.value);
+        }
+    }
+
     var owned_graph_buffer_plan: ?buffer_plan_mod.BufferPlan = null;
     defer if (owned_graph_buffer_plan) |*buffer_plan| buffer_plan.deinit();
     const graph_buffer_plan = if (options.cached_buffer_plan) |buffer_plan|
@@ -335,6 +345,7 @@ pub fn executeMultiDevice(
             .attention_layer = &attention_layer,
             .pair_second = &pair_second,
             .embedding_ids = options.embedding_ids,
+            .runtime_shape_tracker = &runtime_shape_tracker,
         };
 
         if (part.executor) |exec| {
@@ -360,6 +371,7 @@ pub fn executeMultiDevice(
                 .options = options,
                 .last_use = last_use,
                 .pair_second = pair_second,
+                .runtime_shapes = runtime_shape_tracker.runtimeShapes(),
             };
 
             // Execute each node in this partition.
@@ -379,6 +391,7 @@ pub fn executeMultiDevice(
                         values[i] = rt_val;
                     }
                     value_device[i] = dev_id;
+                    try runtime_shape_tracker.record(cb, node_id, values[i].?);
                     if (collect_stats and part.backend == .cuda) exec_stats.planned_operator_dispatches += 1;
                     continue;
                 }
@@ -395,6 +408,7 @@ pub fn executeMultiDevice(
                     }
                 }
                 value_device[i] = dev_id;
+                try runtime_shape_tracker.record(cb, node_id, values[i].?);
                 try interpreter.cloneOutputIfAliasedInputWouldBeFreed(
                     allocator,
                     graph,

--- a/zig/pkg/inference/src/graph/native_partition_executor.zig
+++ b/zig/pkg/inference/src/graph/native_partition_executor.zig
@@ -140,6 +140,7 @@ pub const NativePartitionExecutor = struct {
             .options = options,
             .last_use = last_use,
             .pair_second = if (exec_ctx.pair_second) |pair| pair.* else null,
+            .runtime_shapes = if (exec_ctx.runtime_shape_tracker) |tracker| tracker.runtimeShapes() else null,
         };
         defer exec_state.freeMoeState();
 
@@ -162,6 +163,9 @@ pub const NativePartitionExecutor = struct {
                     values[i] = rt_val;
                 }
                 value_device[i] = device_id;
+                if (exec_ctx.runtime_shape_tracker) |tracker| {
+                    try tracker.record(cb, node_id, values[i].?);
+                }
                 continue;
             }
 
@@ -184,6 +188,9 @@ pub const NativePartitionExecutor = struct {
                 if (exec_ctx.stats) |stats| stats.interpreter_fallbacks += 1;
             }
             value_device[i] = device_id;
+            if (exec_ctx.runtime_shape_tracker) |tracker| {
+                try tracker.record(cb, node_id, values[i].?);
+            }
 
             try interpreter.cloneOutputIfAliasedInputWouldBeFreed(
                 allocator,
@@ -243,6 +250,11 @@ fn executeNativePlannedNode(
     if (cb.kind() != .native) return null;
     const n = graph.node(node_id);
     const inputs = n.getInputs();
+    // Planned native kernels currently derive several operand layouts from
+    // graph declarations. When any participating shape is symbolic, route the
+    // node through executeNode, which resolves those layouts from the shared
+    // request shape tracker. Static graphs keep the planned fast path.
+    if (exec_state.runtime_shapes != null and nodeTouchesSymbolicShape(graph, node_id)) return null;
     return switch (n.op) {
         .parameter => blk: {
             const name = graph.parameterName(n);
@@ -480,7 +492,10 @@ fn executeNativePlannedNode(
             );
         },
         .reshape => |attrs| blk: {
-            if (attrs.runtime_shape) return null;
+            // Imported dynamic graphs may encode a request-dependent reshape
+            // with static-looking symbolic attributes. Let executeNode resolve
+            // those dimensions from the shared request shape provenance.
+            if (attrs.runtime_shape or exec_state.runtime_shapes != null) return null;
             const rank = attrs.new_shape.rank();
             var dims: [8]i64 = undefined;
             for (0..rank) |d| dims[d] = attrs.new_shape.dim(@intCast(d));
@@ -494,6 +509,9 @@ fn executeNativePlannedNode(
             break :blk try cb.primTranspose(valueAt(values, inputs[0]), perm, input_shape);
         },
         .broadcast_in_dim => |attrs| blk: {
+            // ONNX Expand carries its target as a second runtime input. The
+            // planned path only understands the declared target attributes.
+            if (n.num_inputs > 1) return null;
             var input_shape_buf: [8]i64 = undefined;
             const input_shape = fillShapeDims(graph, inputs[0], &input_shape_buf);
             const rank = attrs.target_shape.rank();
@@ -614,6 +632,23 @@ fn executeNativePlannedNode(
         },
         else => null,
     };
+}
+
+fn nodeTouchesSymbolicShape(graph: *const Graph, node_id: NodeId) bool {
+    const node = graph.node(node_id);
+    if (shapeHasSymbolicDim(node.output_shape)) return true;
+    for (node.getInputs()) |input_id| {
+        if (input_id == null_node or input_id >= graph.nodeCount()) continue;
+        if (shapeHasSymbolicDim(graph.node(input_id).output_shape)) return true;
+    }
+    return false;
+}
+
+fn shapeHasSymbolicDim(shape: ml.graph.Shape) bool {
+    for (0..shape.rank()) |axis| {
+        if (shape.dim(@intCast(axis)) < 0) return true;
+    }
+    return false;
 }
 
 fn fillShapeDims(graph: *const Graph, node_id: NodeId, buf: *[8]i64) []const i64 {

--- a/zig/pkg/inference/src/graph/partition.zig
+++ b/zig/pkg/inference/src/graph/partition.zig
@@ -235,6 +235,7 @@ pub const PartitionExecutor = struct {
         attention_layer: ?*usize = null,
         pair_second: ?*?CT = null,
         embedding_ids: ?[]const i64 = null,
+        runtime_shape_tracker: ?*interpreter.RuntimeShapeTracker = null,
     };
 
     pub const VTable = struct {

--- a/zig/pkg/inference/src/graph/runtime.zig
+++ b/zig/pkg/inference/src/graph/runtime.zig
@@ -910,3 +910,79 @@ test "native graph runtime attaches native partition executors" {
         try std.testing.expect(part.executor != null);
     }
 }
+
+test "native partitioned runtimes restore request dimensions after flattened projection" {
+    const allocator = std.testing.allocator;
+    var graph = Graph.init(allocator);
+    defer graph.deinit();
+    var builder = Builder.init(&graph);
+
+    // Mirrors the dynamic sequence-classifier topology used by imported ONNX
+    // rerankers: [batch, sequence, hidden] is flattened for a projection and
+    // then restored from symbolic graph dimensions.
+    const x = try builder.parameter("x", Shape.init(.f32, &.{ -1, -1, 4 }));
+    const weight = try builder.parameter("weight", Shape.init(.f32, &.{ 4, 5 }));
+    const flat = try builder.reshape(x, Shape.init(.f32, &.{ -1, 4 }));
+    const projected = try builder.matmul(flat, weight);
+    const restored = try builder.reshape(projected, Shape.init(.f32, &.{ -1, -1, 5 }));
+    try graph.markOutput(restored);
+
+    var weight_store = WeightStore{
+        .allocator = allocator,
+        .resident_weights = .{},
+        .lazy_weights = .{},
+    };
+    defer {
+        native_mod.deinitPrefetchQueue(&weight_store);
+        weight_store.resident_weights.deinit(allocator);
+        weight_store.lazy_weights.deinit(allocator);
+    }
+    var compute = NativeCompute.init(allocator, &weight_store, null);
+    var cb = compute.computeBackend();
+
+    const x_data = [_]f32{
+        1,  2,  3,  4,
+        5,  6,  7,  8,
+        9,  10, 11, 12,
+        13, 14, 15, 16,
+        17, 18, 19, 20,
+        21, 22, 23, 24,
+    };
+    const weight_data = [_]f32{
+        1, 0, 0, 0, 1,
+        0, 1, 0, 0, 1,
+        0, 0, 1, 0, 1,
+        0, 0, 0, 1, 1,
+    };
+    const x_value = try cb.fromFloat32Shape(&x_data, &.{ 2, 3, 4 });
+    defer cb.free(x_value);
+    const weight_value = try cb.fromFloat32Shape(&weight_data, &.{ 4, 5 });
+    defer cb.free(weight_value);
+    const runtime_inputs = [_]interpreter.RuntimeInput{
+        .{ .node_id = x, .value = x_value },
+        .{ .node_id = weight, .value = weight_value },
+    };
+    var analysis = try interpreter.CachedAnalysis.compute(allocator, &graph);
+    defer analysis.deinit(allocator);
+
+    for ([_]Strategy{ .partitioned, .compiled_preferred }) |strategy| {
+        var runtime = try Runtime.init(allocator, &graph, &cb, strategy);
+        defer runtime.deinit();
+
+        var result = try runtime.execute(allocator, &graph, .{
+            .runtime_inputs = &runtime_inputs,
+            .cached_analysis = analysis,
+        });
+        defer result.deinit(&runtime);
+
+        const actual_shape = try cb.tensorShape(result.outputs[0], allocator);
+        defer allocator.free(actual_shape);
+        try std.testing.expectEqualSlices(i64, &.{ 2, 3, 5 }, actual_shape);
+
+        const actual = try cb.toFloat32(result.outputs[0], allocator);
+        defer allocator.free(actual);
+        try std.testing.expectEqual(@as(usize, 30), actual.len);
+        try std.testing.expectEqualSlices(f32, &.{ 1, 2, 3, 4, 10 }, actual[0..5]);
+        try std.testing.expectEqualSlices(f32, &.{ 21, 22, 23, 24, 90 }, actual[25..30]);
+    }
+}


### PR DESCRIPTION
[codex 5.6 sol] 

  ## Summary

  - Track concrete request shapes across partitioned graph execution.
  - Route symbolic native nodes through shape-aware interpreter execution.
  - Fix InvalidTensorShape for the mixedbread i8 reranker under partitioned and compiled-preferred
    runtimes.

  - Add regression coverage for restoring dimensions after flattened projections.

  ## Validation

  - Full inference suite: 3,211 passed, 20 skipped.
  - CLI suite: 10 passed.
  - Mixedbread i8 checksum matches interpreter in all runtime modes: 0.944502.
  - Formatting and diff checks pass.