### PR TITLE
Avoid Raft runtime lock for catalog routing

### DIFF
--- a/zig/pkg/antfly/src/api/table_catalog.zig
+++ b/zig/pkg/antfly/src/api/table_catalog.zig
@@ -106,6 +106,8 @@ pub const CatalogSource = struct {
             .vtable = &.{
                 .admin_snapshot = metadataServiceAdminSnapshot,
                 .free_admin_snapshot = metadataServiceFreeAdminSnapshot,
+                .routing_snapshot = metadataServiceRoutingSnapshot,
+                .free_routing_snapshot = metadataServiceFreeRoutingSnapshot,
                 .requires_linearizable_publication_fence = true,
                 .validate_publication = metadataServiceValidatePublication,
                 .validate_table_publication = metadataServiceValidateTablePublication,
@@ -698,6 +700,16 @@ fn metadataServiceFreeAdminSnapshot(ptr: *anyopaque, snapshot: *metadata_api.Adm
     svc.freeAdminSnapshot(snapshot);
 }
 
+fn metadataServiceRoutingSnapshot(ptr: *anyopaque, deadline_ns: ?u64) !metadata_api.CatalogRoutingSnapshot {
+    const svc: *metadata_service.MetadataService = @ptrCast(@alignCast(ptr));
+    return try svc.catalogRoutingSnapshot(deadline_ns);
+}
+
+fn metadataServiceFreeRoutingSnapshot(ptr: *anyopaque, snapshot: *metadata_api.CatalogRoutingSnapshot) void {
+    const svc: *metadata_service.MetadataService = @ptrCast(@alignCast(ptr));
+    svc.freeCatalogRoutingSnapshot(snapshot);
+}
+
 fn metadataServiceValidatePublication(ptr: *anyopaque, contract: metadata_api.CatalogPublicationContract) !bool {
     const svc: *metadata_service.MetadataService = @ptrCast(@alignCast(ptr));
     return try svc.validatePublication(contract);
@@ -780,6 +792,13 @@ fn rangeOverlapsSpan(range: metadata_table_manager.RangeRecord, from_key: []cons
         if (end_key.len > 0 and from_key.len > 0 and std.mem.order(u8, end_key, from_key) != .gt) return false;
     }
     return true;
+}
+
+test "metadata service catalog source uses compact routing snapshots" {
+    var svc: metadata_service.MetadataService = undefined;
+    const source = CatalogSource.fromMetadataService(&svc);
+    try std.testing.expect(source.vtable.routing_snapshot != null);
+    try std.testing.expect(source.vtable.free_routing_snapshot != null);
 }
 
 test "transaction topology fence rejects active split transitions" {

--- a/zig/pkg/antfly/src/api/table_catalog.zig
+++ b/zig/pkg/antfly/src/api/table_catalog.zig
@@ -34,6 +34,11 @@ pub const CatalogSource = struct {
         /// valid until the matching `free_admin_snapshot` call returns.
         admin_snapshot: *const fn (ptr: *anyopaque) anyerror!metadata_api.AdminSnapshot,
         free_admin_snapshot: *const fn (ptr: *anyopaque, snapshot: *metadata_api.AdminSnapshot) void,
+        /// Optional compact path for pure table/range routing. These callbacks
+        /// must be provided as a pair; sources without them fall back to the
+        /// full admin snapshot for compatibility.
+        routing_snapshot: ?*const fn (ptr: *anyopaque, deadline_ns: ?u64) anyerror!metadata_api.CatalogRoutingSnapshot = null,
+        free_routing_snapshot: ?*const fn (ptr: *anyopaque, snapshot: *metadata_api.CatalogRoutingSnapshot) void = null,
         /// Production sources must fail closed when either linearizable
         /// publication validator is unavailable.
         requires_linearizable_publication_fence: bool = false,
@@ -48,6 +53,41 @@ pub const CatalogSource = struct {
 
     pub fn freeAdminSnapshot(self: CatalogSource, snapshot: *metadata_api.AdminSnapshot) void {
         self.vtable.free_admin_snapshot(self.ptr, snapshot);
+    }
+
+    const RoutingSnapshot = union(enum) {
+        compact: metadata_api.CatalogRoutingSnapshot,
+        admin: metadata_api.AdminSnapshot,
+
+        fn tables(self: *const @This()) []const metadata_table_manager.TableRecord {
+            return switch (self.*) {
+                .compact => |snapshot| snapshot.tables,
+                .admin => |snapshot| snapshot.tables,
+            };
+        }
+
+        fn ranges(self: *const @This()) []const metadata_table_manager.RangeRecord {
+            return switch (self.*) {
+                .compact => |snapshot| snapshot.ranges,
+                .admin => |snapshot| snapshot.ranges,
+            };
+        }
+    };
+
+    fn routingSnapshot(self: CatalogSource, deadline_ns: ?u64) !RoutingSnapshot {
+        if (self.vtable.routing_snapshot) |capture| {
+            std.debug.assert(self.vtable.free_routing_snapshot != null);
+            return .{ .compact = try capture(self.ptr, deadline_ns) };
+        }
+        return .{ .admin = try self.adminSnapshot() };
+    }
+
+    fn freeRoutingSnapshot(self: CatalogSource, snapshot: *RoutingSnapshot) void {
+        switch (snapshot.*) {
+            .compact => |*compact| self.vtable.free_routing_snapshot.?(self.ptr, compact),
+            .admin => |*admin| self.freeAdminSnapshot(admin),
+        }
+        snapshot.* = undefined;
     }
 
     pub fn validatePublication(self: CatalogSource, contract: metadata_api.CatalogPublicationContract) !bool {
@@ -79,6 +119,8 @@ pub const CatalogSource = struct {
             .vtable = &.{
                 .admin_snapshot = metadataHttpServiceAdminSnapshot,
                 .free_admin_snapshot = metadataHttpServiceFreeAdminSnapshot,
+                .routing_snapshot = metadataHttpServiceRoutingSnapshot,
+                .free_routing_snapshot = metadataHttpServiceFreeRoutingSnapshot,
                 .requires_linearizable_publication_fence = true,
                 .validate_publication = metadataHttpServiceValidatePublication,
                 .validate_table_publication = metadataHttpServiceValidateTablePublication,
@@ -518,6 +560,35 @@ pub fn resolveGroupForKeyPinned(
     return try resolveGroupForKey(alloc, catalog, table_name, key);
 }
 
+fn findTableByName(
+    tables: []const metadata_table_manager.TableRecord,
+    table_name: []const u8,
+) ?*const metadata_table_manager.TableRecord {
+    for (tables) |*table| {
+        if (std.mem.eql(u8, table.name, table_name)) return table;
+    }
+    return null;
+}
+
+fn listTableRanges(
+    alloc: std.mem.Allocator,
+    catalog_ranges: []const metadata_table_manager.RangeRecord,
+    table_id: u64,
+) ![]const *const metadata_table_manager.RangeRecord {
+    var count: usize = 0;
+    for (catalog_ranges) |range| {
+        if (range.table_id == table_id) count += 1;
+    }
+    const ranges = try alloc.alloc(*const metadata_table_manager.RangeRecord, count);
+    var index: usize = 0;
+    for (catalog_ranges) |*range| {
+        if (range.table_id != table_id) continue;
+        ranges[index] = range;
+        index += 1;
+    }
+    return ranges;
+}
+
 pub fn resolveGroupsForSpan(
     alloc: std.mem.Allocator,
     catalog: CatalogSource,
@@ -525,10 +596,21 @@ pub fn resolveGroupsForSpan(
     from_key: []const u8,
     to_key: []const u8,
 ) ![]u64 {
-    var snapshot = try catalog.adminSnapshot();
-    defer catalog.freeAdminSnapshot(&snapshot);
-    const table = tables_api.findTableByName(&snapshot, table_name) orelse return try alloc.alloc(u64, 0);
-    const ranges = try metadata_admin.listTableRanges(alloc, &snapshot, table.table_id);
+    return try resolveGroupsForSpanWithDeadline(alloc, catalog, table_name, from_key, to_key, null);
+}
+
+fn resolveGroupsForSpanWithDeadline(
+    alloc: std.mem.Allocator,
+    catalog: CatalogSource,
+    table_name: []const u8,
+    from_key: []const u8,
+    to_key: []const u8,
+    deadline_ns: ?u64,
+) ![]u64 {
+    var snapshot = try catalog.routingSnapshot(deadline_ns);
+    defer catalog.freeRoutingSnapshot(&snapshot);
+    const table = findTableByName(snapshot.tables(), table_name) orelse return try alloc.alloc(u64, 0);
+    const ranges = try listTableRanges(alloc, snapshot.ranges(), table.table_id);
     defer metadata_admin.freeRangeRefs(alloc, ranges);
 
     sortRangeRefs(ranges);
@@ -586,10 +668,21 @@ pub fn resolveGroupsForSpanEventually(
     poll_interval_ms: u64,
 ) ![]u64 {
     const start_ns = platform_time.monotonicNs();
+    const deadline_ns = start_ns +| timeout_ns;
     while (true) {
-        const groups = try resolveGroupsForSpan(alloc, catalog, table_name, from_key, to_key);
+        const groups = resolveGroupsForSpanWithDeadline(
+            alloc,
+            catalog,
+            table_name,
+            from_key,
+            to_key,
+            deadline_ns,
+        ) catch |err| switch (err) {
+            error.CatalogRoutingSnapshotTimeout => return try alloc.alloc(u64, 0),
+            else => return err,
+        };
         if (groups.len != 0) return groups;
-        if (platform_time.monotonicNs() -| start_ns >= timeout_ns) return groups;
+        if (platform_time.monotonicNs() >= deadline_ns) return groups;
         alloc.free(groups);
         platform_clock.Clock.real().sleepMs(poll_interval_ms);
     }
@@ -623,6 +716,16 @@ fn metadataHttpServiceAdminSnapshot(ptr: *anyopaque) !metadata_api.AdminSnapshot
 fn metadataHttpServiceFreeAdminSnapshot(ptr: *anyopaque, snapshot: *metadata_api.AdminSnapshot) void {
     const svc: *metadata_service.MetadataHttpService = @ptrCast(@alignCast(ptr));
     svc.freeAdminSnapshot(snapshot);
+}
+
+fn metadataHttpServiceRoutingSnapshot(ptr: *anyopaque, deadline_ns: ?u64) !metadata_api.CatalogRoutingSnapshot {
+    const svc: *metadata_service.MetadataHttpService = @ptrCast(@alignCast(ptr));
+    return try svc.catalogRoutingSnapshot(deadline_ns);
+}
+
+fn metadataHttpServiceFreeRoutingSnapshot(ptr: *anyopaque, snapshot: *metadata_api.CatalogRoutingSnapshot) void {
+    const svc: *metadata_service.MetadataHttpService = @ptrCast(@alignCast(ptr));
+    svc.freeCatalogRoutingSnapshot(snapshot);
 }
 
 fn metadataHttpServiceValidatePublication(ptr: *anyopaque, contract: metadata_api.CatalogPublicationContract) !bool {
@@ -841,6 +944,97 @@ test "catalog source resolves groups by key and span" {
     try std.testing.expectEqual(@as(usize, 2), groups.len);
     try std.testing.expectEqual(@as(u64, 7001), groups[0]);
     try std.testing.expectEqual(@as(u64, 7002), groups[1]);
+}
+
+test "span routing uses compact catalog snapshot when available" {
+    const TestState = struct {
+        freed: bool = false,
+    };
+    const FakeCatalog = struct {
+        const tables = [_]metadata_table_manager.TableRecord{
+            .{ .table_id = 7, .name = "docs", .placement_role = "data" },
+        };
+        const ranges = [_]metadata_table_manager.RangeRecord{
+            .{ .group_id = 7001, .table_id = 7, .start_key = "", .end_key = null },
+        };
+
+        fn iface(state: *TestState) CatalogSource {
+            return .{
+                .ptr = state,
+                .vtable = &.{
+                    .admin_snapshot = adminSnapshot,
+                    .free_admin_snapshot = freeAdminSnapshot,
+                    .routing_snapshot = routingSnapshot,
+                    .free_routing_snapshot = freeRoutingSnapshot,
+                },
+            };
+        }
+
+        fn adminSnapshot(_: *anyopaque) !metadata_api.AdminSnapshot {
+            return error.AdminSnapshotUsedForRouting;
+        }
+
+        fn freeAdminSnapshot(_: *anyopaque, _: *metadata_api.AdminSnapshot) void {}
+
+        fn routingSnapshot(_: *anyopaque, _: ?u64) !metadata_api.CatalogRoutingSnapshot {
+            return .{
+                .tables = @constCast(tables[0..]),
+                .ranges = @constCast(ranges[0..]),
+            };
+        }
+
+        fn freeRoutingSnapshot(ptr: *anyopaque, _: *metadata_api.CatalogRoutingSnapshot) void {
+            const state: *TestState = @ptrCast(@alignCast(ptr));
+            state.freed = true;
+        }
+    };
+
+    var state = TestState{};
+    const groups = try resolveGroupsForSpan(std.testing.allocator, FakeCatalog.iface(&state), "docs", "", "");
+    defer std.testing.allocator.free(groups);
+    try std.testing.expectEqualSlices(u64, &.{7001}, groups);
+    try std.testing.expect(state.freed);
+}
+
+test "eventual span routing treats snapshot deadline as an empty projection" {
+    const FakeCatalog = struct {
+        fn iface() CatalogSource {
+            return .{
+                .ptr = undefined,
+                .vtable = &.{
+                    .admin_snapshot = adminSnapshot,
+                    .free_admin_snapshot = freeAdminSnapshot,
+                    .routing_snapshot = routingSnapshot,
+                    .free_routing_snapshot = freeRoutingSnapshot,
+                },
+            };
+        }
+
+        fn adminSnapshot(_: *anyopaque) !metadata_api.AdminSnapshot {
+            return error.AdminSnapshotUsedForRouting;
+        }
+
+        fn freeAdminSnapshot(_: *anyopaque, _: *metadata_api.AdminSnapshot) void {}
+
+        fn routingSnapshot(_: *anyopaque, deadline_ns: ?u64) !metadata_api.CatalogRoutingSnapshot {
+            try std.testing.expect(deadline_ns != null);
+            return error.CatalogRoutingSnapshotTimeout;
+        }
+
+        fn freeRoutingSnapshot(_: *anyopaque, _: *metadata_api.CatalogRoutingSnapshot) void {}
+    };
+
+    const groups = try resolveGroupsForSpanEventually(
+        std.testing.allocator,
+        FakeCatalog.iface(),
+        "docs",
+        "",
+        "",
+        std.time.ns_per_s,
+        1,
+    );
+    defer std.testing.allocator.free(groups);
+    try std.testing.expectEqual(@as(usize, 0), groups.len);
 }
 
 test "catalog doc identity readiness checks table range health" {

--- a/zig/pkg/antfly/src/metadata/api.zig
+++ b/zig/pkg/antfly/src/metadata/api.zig
@@ -205,6 +205,14 @@ pub const AdminSnapshot = struct {
     merged_group_statuses: []metadata_reconciler.MergedGroupStatus = &.{},
 };
 
+/// Atomic projected catalog view used only for table-to-group routing. Keep
+/// identity and operational status out of this type so it cannot accidentally
+/// be used as a publication fence or an admin snapshot.
+pub const CatalogRoutingSnapshot = struct {
+    tables: []table_manager.TableRecord,
+    ranges: []table_manager.RangeRecord,
+};
+
 /// Compact catalog values consumed while staging one data-Raft generation.
 /// Metadata replicas compare this after a linearizable read so the network and
 /// allocation cost is independent of the cluster-wide catalog size.

--- a/zig/pkg/antfly/src/metadata/service.zig
+++ b/zig/pkg/antfly/src/metadata/service.zig
@@ -3034,9 +3034,9 @@ pub const MetadataService = struct {
             return &(self.catalog_validation_cache.snapshot orelse unreachable);
         }
 
-        // The apply store captures the two projected lists under its apply
-        // mutex. The listener epoch stabilizes cache publication and
-        // invalidation without requiring the outer Raft runtime lock.
+        // The apply store captures both projected lists from one point-in-time
+        // storage transaction. The listener epoch stabilizes cache publication
+        // and invalidation without either apply or outer Raft runtime locks.
         var attempts: usize = 0;
         while (attempts < 4) : (attempts += 1) {
             const before = self.catalog_epoch.load(.acquire);
@@ -5942,10 +5942,10 @@ pub const MetadataHttpService = struct {
         return snapshot;
     }
 
-    /// The apply store captures one committed table/range pair under its apply
-    /// mutex, and this catalog mutex publishes that immutable pair. The
-    /// listener epoch stabilizes cache publication and invalidation without
-    /// requiring the outer Raft runtime lock.
+    /// The apply store captures one committed table/range pair from a
+    /// point-in-time storage transaction, and this catalog mutex publishes that
+    /// immutable pair. The listener epoch stabilizes cache publication and
+    /// invalidation without either apply or outer Raft runtime locks.
     fn catalogValidationSnapshotLocked(self: *MetadataHttpService) !*const CatalogValidationSnapshot {
         return try self.catalogValidationSnapshotLockedUntil(null);
     }

--- a/zig/pkg/antfly/src/metadata/service.zig
+++ b/zig/pkg/antfly/src/metadata/service.zig
@@ -1545,6 +1545,32 @@ fn cloneProjectedRangesOwned(
     return out;
 }
 
+fn cloneCatalogRoutingSnapshot(
+    service: anytype,
+    deadline_ns: ?u64,
+) !metadata_api.CatalogRoutingSnapshot {
+    if (!lockMutexUntil(&service.catalog_validation_mutex, deadline_ns))
+        return error.CatalogRoutingSnapshotTimeout;
+    defer service.catalog_validation_mutex.unlock(std.Options.debug_io);
+
+    const catalog = try service.catalogValidationSnapshotLockedUntil(deadline_ns);
+    const tables = try cloneProjectedTablesOwned(service.alloc, catalog.tables);
+    errdefer service.freeProjectedTables(service.alloc, tables);
+    return .{
+        .tables = tables,
+        .ranges = try cloneProjectedRangesOwned(service.alloc, catalog.ranges),
+    };
+}
+
+fn freeCatalogRoutingSnapshotOwned(
+    service: anytype,
+    snapshot: *metadata_api.CatalogRoutingSnapshot,
+) void {
+    service.freeProjectedTables(service.alloc, snapshot.tables);
+    service.freeProjectedRanges(service.alloc, snapshot.ranges);
+    snapshot.* = undefined;
+}
+
 fn cloneProjectedStoresOwned(
     alloc: std.mem.Allocator,
     records: []const metadata_table_manager.StoreRecord,
@@ -2980,6 +3006,16 @@ pub const MetadataService = struct {
         return try metadata_api.captureSnapshot(self.alloc, self);
     }
 
+    /// Capture only the atomically paired table/range projection used for
+    /// routing, without computing the full administrative status projection.
+    pub fn catalogRoutingSnapshot(self: *MetadataService, deadline_ns: ?u64) !metadata_api.CatalogRoutingSnapshot {
+        return try cloneCatalogRoutingSnapshot(self, deadline_ns);
+    }
+
+    pub fn freeCatalogRoutingSnapshot(self: *MetadataService, snapshot: *metadata_api.CatalogRoutingSnapshot) void {
+        freeCatalogRoutingSnapshotOwned(self, snapshot);
+    }
+
     pub fn adminSnapshotFence(self: *MetadataService) !AdminSnapshotFence {
         const raft = serviceGroupRaftObservation(self, self.metadata_group_id);
         return .{
@@ -3014,11 +3050,14 @@ pub const MetadataService = struct {
         return snapshot.index.matchesTablePublication(contract, self.metadata_group_id, incarnation, snapshot.tables);
     }
 
-    fn captureCatalogValidationSnapshot(self: *MetadataService) !CatalogValidationSnapshot {
+    fn captureCatalogValidationSnapshot(
+        self: *MetadataService,
+        deadline_ns: ?u64,
+    ) !CatalogValidationSnapshot {
         const store = self.projectedStore() orelse return error.MissingMetadataStore;
         var snapshot: CatalogValidationSnapshot = .{};
         errdefer snapshot.deinit(self.alloc);
-        const projected = try store.captureCatalogProjection(self.alloc, self.metadata_group_id, null);
+        const projected = try store.captureCatalogProjection(self.alloc, self.metadata_group_id, deadline_ns);
         snapshot.tables = projected.tables;
         snapshot.ranges = projected.ranges;
         snapshot.index = try metadata_api.CatalogProjectionIndex.init(self.alloc, snapshot.tables, snapshot.ranges);
@@ -3026,6 +3065,13 @@ pub const MetadataService = struct {
     }
 
     fn catalogValidationSnapshotLocked(self: *MetadataService) !*const CatalogValidationSnapshot {
+        return try self.catalogValidationSnapshotLockedUntil(null);
+    }
+
+    fn catalogValidationSnapshotLockedUntil(
+        self: *MetadataService,
+        deadline_ns: ?u64,
+    ) !*const CatalogValidationSnapshot {
         try self.ensureLifecycleListenerRegistered();
         const current_epoch = self.catalog_epoch.load(.acquire);
         if (self.catalog_validation_cache.snapshot != null and
@@ -3039,10 +3085,16 @@ pub const MetadataService = struct {
         // and invalidation without either apply or outer Raft runtime locks.
         var attempts: usize = 0;
         while (attempts < 4) : (attempts += 1) {
+            if (deadline_ns) |deadline| {
+                if (platform_time.monotonicNs() >= deadline) return error.CatalogRoutingSnapshotTimeout;
+            }
             const before = self.catalog_epoch.load(.acquire);
-            var fresh = try self.captureCatalogValidationSnapshot();
+            var fresh = try self.captureCatalogValidationSnapshot(deadline_ns);
             errdefer fresh.deinit(self.alloc);
             const after = self.catalog_epoch.load(.acquire);
+            if (deadline_ns) |deadline| {
+                if (platform_time.monotonicNs() >= deadline) return error.CatalogRoutingSnapshotTimeout;
+            }
             if (before != after) {
                 fresh.deinit(self.alloc);
                 continue;
@@ -5749,21 +5801,11 @@ pub const MetadataHttpService = struct {
     /// routing. In particular, this avoids computing detailed operator status
     /// and reconciliation planning on the public request path.
     pub fn catalogRoutingSnapshot(self: *MetadataHttpService, deadline_ns: ?u64) !metadata_api.CatalogRoutingSnapshot {
-        if (!lockMutexUntil(&self.catalog_validation_mutex, deadline_ns)) return error.CatalogRoutingSnapshotTimeout;
-        defer self.catalog_validation_mutex.unlock(std.Options.debug_io);
-        const catalog = try self.catalogValidationSnapshotLockedUntil(deadline_ns);
-        const tables = try cloneProjectedTablesOwned(self.alloc, catalog.tables);
-        errdefer self.freeProjectedTables(self.alloc, tables);
-        return .{
-            .tables = tables,
-            .ranges = try cloneProjectedRangesOwned(self.alloc, catalog.ranges),
-        };
+        return try cloneCatalogRoutingSnapshot(self, deadline_ns);
     }
 
     pub fn freeCatalogRoutingSnapshot(self: *MetadataHttpService, snapshot: *metadata_api.CatalogRoutingSnapshot) void {
-        self.freeProjectedTables(self.alloc, snapshot.tables);
-        self.freeProjectedRanges(self.alloc, snapshot.ranges);
-        snapshot.* = undefined;
+        freeCatalogRoutingSnapshotOwned(self, snapshot);
     }
 
     pub fn adminSnapshotFence(self: *MetadataHttpService) !AdminSnapshotFence {
@@ -13671,6 +13713,20 @@ test "metadata service admin snapshot captures projected topology and status" {
     try std.testing.expectEqualStrings("lsn:0/16B6A50", snapshot.replication_source_statuses[0].prepared_checkpoint);
     try std.testing.expectEqualStrings("lsn:0/16B6B10", snapshot.replication_source_statuses[0].stream_checkpoint);
     try std.testing.expectEqual(@as(usize, 1), snapshot.status.repair_placement_groups);
+
+    var routing = try svc.catalogRoutingSnapshot(null);
+    defer svc.freeCatalogRoutingSnapshot(&routing);
+    try std.testing.expectEqual(@as(usize, 1), routing.tables.len);
+    try std.testing.expectEqual(@as(usize, 1), routing.ranges.len);
+    try std.testing.expectEqual(@as(u64, 89), routing.tables[0].table_id);
+    try std.testing.expectEqual(@as(u64, 8901), routing.ranges[0].group_id);
+
+    svc.catalog_validation_mutex.lockUncancelable(std.Options.debug_io);
+    defer svc.catalog_validation_mutex.unlock(std.Options.debug_io);
+    try std.testing.expectError(
+        error.CatalogRoutingSnapshotTimeout,
+        svc.catalogRoutingSnapshot(platform_time.monotonicNs() + std.time.ns_per_ms),
+    );
 }
 
 test "metadata service committed metadata changes request lifecycle reconcile hook" {

--- a/zig/pkg/antfly/src/metadata/service.zig
+++ b/zig/pkg/antfly/src/metadata/service.zig
@@ -1319,6 +1319,18 @@ const CatalogValidationSnapshotCache = struct {
     }
 };
 
+fn lockMutexUntil(mutex: *std.Io.Mutex, deadline_ns: ?u64) bool {
+    const deadline = deadline_ns orelse {
+        mutex.lockUncancelable(std.Options.debug_io);
+        return true;
+    };
+    while (!mutex.tryLock()) {
+        if (platform_time.monotonicNs() >= deadline) return false;
+        platform_clock.Clock.real().sleepMs(1);
+    }
+    return true;
+}
+
 const ProjectedCoreSnapshotCache = struct {
     core_epoch: u64 = 0,
     placement_epoch: u64 = 0,
@@ -3006,8 +3018,9 @@ pub const MetadataService = struct {
         const store = self.projectedStore() orelse return error.MissingMetadataStore;
         var snapshot: CatalogValidationSnapshot = .{};
         errdefer snapshot.deinit(self.alloc);
-        snapshot.tables = try store.listTables(self.alloc, self.metadata_group_id);
-        snapshot.ranges = try store.listRanges(self.alloc, self.metadata_group_id);
+        const projected = try store.captureCatalogProjection(self.alloc, self.metadata_group_id, null);
+        snapshot.tables = projected.tables;
+        snapshot.ranges = projected.ranges;
         snapshot.index = try metadata_api.CatalogProjectionIndex.init(self.alloc, snapshot.tables, snapshot.ranges);
         return snapshot;
     }
@@ -3021,9 +3034,9 @@ pub const MetadataService = struct {
             return &(self.catalog_validation_cache.snapshot orelse unreachable);
         }
 
-        // MetadataService does not own the HTTP runtime lock. Stabilize the
-        // two projected lists against the listener epoch instead, so a table
-        // and its ranges can never come from different applied revisions.
+        // The apply store captures the two projected lists under its apply
+        // mutex. The listener epoch stabilizes cache publication and
+        // invalidation without requiring the outer Raft runtime lock.
         var attempts: usize = 0;
         while (attempts < 4) : (attempts += 1) {
             const before = self.catalog_epoch.load(.acquire);
@@ -5732,6 +5745,27 @@ pub const MetadataHttpService = struct {
         return try self.buildAdminSnapshot(true);
     }
 
+    /// Capture only the atomically paired table/range projection used for
+    /// routing. In particular, this avoids computing detailed operator status
+    /// and reconciliation planning on the public request path.
+    pub fn catalogRoutingSnapshot(self: *MetadataHttpService, deadline_ns: ?u64) !metadata_api.CatalogRoutingSnapshot {
+        if (!lockMutexUntil(&self.catalog_validation_mutex, deadline_ns)) return error.CatalogRoutingSnapshotTimeout;
+        defer self.catalog_validation_mutex.unlock(std.Options.debug_io);
+        const catalog = try self.catalogValidationSnapshotLockedUntil(deadline_ns);
+        const tables = try cloneProjectedTablesOwned(self.alloc, catalog.tables);
+        errdefer self.freeProjectedTables(self.alloc, tables);
+        return .{
+            .tables = tables,
+            .ranges = try cloneProjectedRangesOwned(self.alloc, catalog.ranges),
+        };
+    }
+
+    pub fn freeCatalogRoutingSnapshot(self: *MetadataHttpService, snapshot: *metadata_api.CatalogRoutingSnapshot) void {
+        self.freeProjectedTables(self.alloc, snapshot.tables);
+        self.freeProjectedRanges(self.alloc, snapshot.ranges);
+        snapshot.* = undefined;
+    }
+
     pub fn adminSnapshotFence(self: *MetadataHttpService) !AdminSnapshotFence {
         const raft = serviceGroupRaftObservation(self, self.metadata_group_id);
         return .{
@@ -5894,28 +5928,61 @@ pub const MetadataHttpService = struct {
         return snapshot.index.matchesTablePublication(contract, self.metadata_group_id, incarnation, snapshot.tables);
     }
 
-    /// Called with both the catalog-validation mutex and the Raft runtime lock
-    /// held. Only catalog records are cloned, and non-catalog projection
-    /// traffic cannot invalidate this cache.
+    fn captureCatalogValidationSnapshot(
+        self: *MetadataHttpService,
+        deadline_ns: ?u64,
+    ) !CatalogValidationSnapshot {
+        const store = self.projectedStore() orelse return error.MissingMetadataStore;
+        var snapshot: CatalogValidationSnapshot = .{};
+        errdefer snapshot.deinit(self.alloc);
+        const projected = try store.captureCatalogProjection(self.alloc, self.metadata_group_id, deadline_ns);
+        snapshot.tables = projected.tables;
+        snapshot.ranges = projected.ranges;
+        snapshot.index = try metadata_api.CatalogProjectionIndex.init(self.alloc, snapshot.tables, snapshot.ranges);
+        return snapshot;
+    }
+
+    /// The apply store captures one committed table/range pair under its apply
+    /// mutex, and this catalog mutex publishes that immutable pair. The
+    /// listener epoch stabilizes cache publication and invalidation without
+    /// requiring the outer Raft runtime lock.
     fn catalogValidationSnapshotLocked(self: *MetadataHttpService) !*const CatalogValidationSnapshot {
+        return try self.catalogValidationSnapshotLockedUntil(null);
+    }
+
+    fn catalogValidationSnapshotLockedUntil(
+        self: *MetadataHttpService,
+        deadline_ns: ?u64,
+    ) !*const CatalogValidationSnapshot {
         try self.ensureLifecycleListenerRegistered();
         const current_epoch = self.catalog_epoch.load(.acquire);
-        if (self.catalog_validation_cache.snapshot == null or
-            self.catalog_validation_cache.catalog_epoch != current_epoch)
+        if (self.catalog_validation_cache.snapshot != null and
+            self.catalog_validation_cache.catalog_epoch == current_epoch)
         {
-            const store = self.projectedStore() orelse return error.MissingMetadataStore;
-            var fresh: CatalogValidationSnapshot = .{};
-            errdefer fresh.deinit(self.alloc);
-            fresh.tables = try store.listTables(self.alloc, self.metadata_group_id);
-            fresh.ranges = try store.listRanges(self.alloc, self.metadata_group_id);
-            fresh.index = try metadata_api.CatalogProjectionIndex.init(self.alloc, fresh.tables, fresh.ranges);
-            if (self.catalog_validation_cache.snapshot) |*snapshot| snapshot.deinit(self.alloc);
-            self.catalog_validation_cache = .{
-                .catalog_epoch = current_epoch,
-                .snapshot = fresh,
-            };
+            return &(self.catalog_validation_cache.snapshot orelse unreachable);
         }
-        return &(self.catalog_validation_cache.snapshot orelse unreachable);
+
+        var attempts: usize = 0;
+        while (attempts < 4) : (attempts += 1) {
+            if (deadline_ns) |deadline| {
+                if (platform_time.monotonicNs() >= deadline) return error.CatalogRoutingSnapshotTimeout;
+            }
+            const before = self.catalog_epoch.load(.acquire);
+            var fresh = try self.captureCatalogValidationSnapshot(deadline_ns);
+            errdefer fresh.deinit(self.alloc);
+            const after = self.catalog_epoch.load(.acquire);
+            if (deadline_ns) |deadline| {
+                if (platform_time.monotonicNs() >= deadline) return error.CatalogRoutingSnapshotTimeout;
+            }
+            if (before != after) {
+                fresh.deinit(self.alloc);
+                continue;
+            }
+            if (self.catalog_validation_cache.snapshot) |*snapshot| snapshot.deinit(self.alloc);
+            self.catalog_validation_cache = .{ .catalog_epoch = after, .snapshot = fresh };
+            return &(self.catalog_validation_cache.snapshot orelse unreachable);
+        }
+        return error.CatalogProjectionUnstable;
     }
 
     pub fn freeAdminSnapshot(self: *MetadataHttpService, snapshot: *metadata_api.AdminSnapshot) void {
@@ -6061,8 +6128,6 @@ pub const MetadataHttpService = struct {
     }
 
     pub fn listProjectedTables(self: *MetadataHttpService, alloc: std.mem.Allocator) ![]metadata_table_manager.TableRecord {
-        self.lockRuntime();
-        defer self.unlockRuntime();
         self.catalog_validation_mutex.lockUncancelable(std.Options.debug_io);
         defer self.catalog_validation_mutex.unlock(std.Options.debug_io);
         const snapshot = try self.catalogValidationSnapshotLocked();
@@ -6181,8 +6246,6 @@ pub const MetadataHttpService = struct {
     }
 
     pub fn listProjectedRanges(self: *MetadataHttpService, alloc: std.mem.Allocator) ![]metadata_table_manager.RangeRecord {
-        self.lockRuntime();
-        defer self.unlockRuntime();
         self.catalog_validation_mutex.lockUncancelable(std.Options.debug_io);
         defer self.catalog_validation_mutex.unlock(std.Options.debug_io);
         const snapshot = try self.catalogValidationSnapshotLocked();
@@ -14016,6 +14079,29 @@ test "metadata http service catalog cache is independent from volatile projectio
     defer svc.freeProjectedTables(std.testing.allocator, before);
     try std.testing.expectEqual(@as(usize, 0), before.len);
     try std.testing.expectEqual(true, svc.lifecycle_listener_registered);
+
+    // Routing reads the independently published catalog projection and must
+    // not depend on the Raft runtime lock being available.
+    {
+        svc.lockRuntime();
+        defer svc.unlockRuntime();
+        var routing = try svc.catalogRoutingSnapshot(null);
+        defer svc.freeCatalogRoutingSnapshot(&routing);
+        try std.testing.expectEqual(@as(usize, 0), routing.tables.len);
+        try std.testing.expectEqual(@as(usize, 0), routing.ranges.len);
+    }
+
+    // A contended publication mutex observes the caller's routing deadline
+    // instead of extending the outer eventual-resolution timeout forever.
+    {
+        svc.catalog_validation_mutex.lockUncancelable(std.Options.debug_io);
+        defer svc.catalog_validation_mutex.unlock(std.Options.debug_io);
+        try std.testing.expectError(
+            error.CatalogRoutingSnapshotTimeout,
+            svc.catalogRoutingSnapshot(platform_time.monotonicNs() + std.time.ns_per_ms),
+        );
+    }
+
     const leader_status = svc.raft.host.http_host.host.raftStatus(2900) orelse return error.MissingRaftStatus;
     try std.testing.expect(leader_status.hard.current_term > 0);
     const receipt = try svc.proposeTransitionCommandWithReceiptInTerm(.{

--- a/zig/pkg/antfly/src/metadata/storage/raft_apply_store.zig
+++ b/zig/pkg/antfly/src/metadata/storage/raft_apply_store.zig
@@ -31,7 +31,6 @@ const raft_reconciler = @import("../../raft/reconciler.zig");
 const raft_storage_mod = @import("../../raft/storage/mod.zig");
 const wal_replica_state_mod = @import("../../raft/storage/wal_replica_state.zig");
 const raft_state_machine = @import("../../raft/state_machine/mod.zig");
-const platform_clock = @import("antfly_platform").clock;
 const platform_time = @import("antfly_platform").time;
 
 pub const AppliedMetadataBatch = struct {
@@ -1582,16 +1581,21 @@ pub const RaftApplyStore = struct {
     }
 
     pub fn listTables(self: *RaftApplyStore, alloc: std.mem.Allocator, group_id: u64) ![]metadata.TableRecord {
+        var txn = try self.store.beginReadTxn();
+        defer txn.abort();
+        return try self.listTablesTxn(alloc, &txn, group_id);
+    }
+
+    fn listTablesTxn(
+        _: *RaftApplyStore,
+        alloc: std.mem.Allocator,
+        txn: *docstore.DocStore.Txn,
+        group_id: u64,
+    ) ![]metadata.TableRecord {
         var prefix_buf: [128]u8 = undefined;
         const prefix = try tablePrefixForGroup(&prefix_buf, group_id);
-        const kvs = try self.store.scanPrefix(alloc, prefix);
-        defer {
-            for (kvs) |kv| {
-                alloc.free(kv.key);
-                alloc.free(kv.value);
-            }
-            alloc.free(kvs);
-        }
+        const kvs = try docstore.DocStore.scanPrefixTxn(alloc, txn, prefix);
+        defer freeKvs(alloc, kvs);
         const out = try alloc.alloc(metadata.TableRecord, kvs.len);
         var filled: usize = 0;
         errdefer {
@@ -1607,30 +1611,33 @@ pub const RaftApplyStore = struct {
         return out;
     }
 
-    /// Capture the table and range namespaces from one committed apply-store
-    /// revision without acquiring the outer Raft runtime lock.
+    /// Capture the table and range namespaces from one committed storage
+    /// revision without acquiring either the apply or outer Raft runtime lock.
     pub fn captureCatalogProjection(
         self: *RaftApplyStore,
         alloc: std.mem.Allocator,
         group_id: u64,
         deadline_ns: ?u64,
     ) !CatalogProjectionSnapshot {
-        const io = self.io_impl.io();
         if (deadline_ns) |deadline| {
-            while (!self.apply_mutex.tryLock()) {
-                if (platform_time.monotonicNs() >= deadline) return error.CatalogRoutingSnapshotTimeout;
-                platform_clock.Clock.real().sleepMs(1);
-            }
-        } else {
-            self.apply_mutex.lockUncancelable(io);
+            if (platform_time.monotonicNs() >= deadline) return error.CatalogRoutingSnapshotTimeout;
         }
-        defer self.apply_mutex.unlock(io);
+        var txn = try self.store.beginReadTxn();
+        defer txn.abort();
 
-        const tables = try self.listTables(alloc, group_id);
+        const tables = try self.listTablesTxn(alloc, &txn, group_id);
         errdefer self.freeTables(alloc, tables);
+        if (deadline_ns) |deadline| {
+            if (platform_time.monotonicNs() >= deadline) return error.CatalogRoutingSnapshotTimeout;
+        }
+        const ranges = try self.listRangesTxn(alloc, &txn, group_id);
+        errdefer self.freeRanges(alloc, ranges);
+        if (deadline_ns) |deadline| {
+            if (platform_time.monotonicNs() >= deadline) return error.CatalogRoutingSnapshotTimeout;
+        }
         return .{
             .tables = tables,
-            .ranges = try self.listRanges(alloc, group_id),
+            .ranges = ranges,
         };
     }
 
@@ -1898,22 +1905,31 @@ pub const RaftApplyStore = struct {
     }
 
     pub fn listRanges(self: *RaftApplyStore, alloc: std.mem.Allocator, group_id: u64) ![]metadata.RangeRecord {
+        var txn = try self.store.beginReadTxn();
+        defer txn.abort();
+        return try self.listRangesTxn(alloc, &txn, group_id);
+    }
+
+    fn listRangesTxn(
+        _: *RaftApplyStore,
+        alloc: std.mem.Allocator,
+        txn: *docstore.DocStore.Txn,
+        group_id: u64,
+    ) ![]metadata.RangeRecord {
         var prefix_buf: [128]u8 = undefined;
         const prefix = try rangePrefixForGroup(&prefix_buf, group_id);
-        const kvs = try self.store.scanPrefix(alloc, prefix);
-        defer {
-            for (kvs) |kv| {
-                alloc.free(kv.key);
-                alloc.free(kv.value);
-            }
-            alloc.free(kvs);
-        }
+        const kvs = try docstore.DocStore.scanPrefixTxn(alloc, txn, prefix);
+        defer freeKvs(alloc, kvs);
         const out = try alloc.alloc(metadata.RangeRecord, kvs.len);
+        var filled: usize = 0;
         errdefer {
-            for (out[0..kvs.len]) |record| metadata_table_manager.freeRange(alloc, record);
+            for (out[0..filled]) |record| metadata_table_manager.freeRange(alloc, record);
             alloc.free(out);
         }
-        for (kvs, 0..) |kv, i| out[i] = try decodeRangeRecord(alloc, kv.value);
+        for (kvs, 0..) |kv, i| {
+            out[i] = try decodeRangeRecord(alloc, kv.value);
+            filled = i + 1;
+        }
         return out;
     }
 
@@ -8381,7 +8397,7 @@ test "metadata raft apply store publishes listeners only after commit" {
     try std.testing.expectEqual(@as(usize, 0), tables.len);
 }
 
-test "metadata raft apply store catalog projection honors apply deadline" {
+test "metadata raft apply store catalog projection uses storage snapshot independently from apply mutex" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 
@@ -8391,25 +8407,92 @@ test "metadata raft apply store catalog projection honors apply deadline" {
     var store = try RaftApplyStore.init(std.testing.allocator, .{ .root_dir = root });
     defer store.deinit();
 
+    const table = try encodeTransitionCommand(std.testing.allocator, .{
+        .upsert_table = testTransitionTableRecord(),
+    });
+    defer std.testing.allocator.free(table);
+    const range = try encodeTransitionCommand(std.testing.allocator, .{
+        .upsert_range = testTransitionRangeRecord(
+            101,
+            test_transition_table_contract.source_identity,
+            "",
+            null,
+        ),
+    });
+    defer std.testing.allocator.free(range);
+    const entries = try raft_state_machine.encodeCommittedEntries(std.testing.allocator, &.{
+        .{ .term = 1, .index = 1, .entry_type = .normal, .data = table },
+        .{ .term = 1, .index = 2, .entry_type = .normal, .data = range },
+    });
+    defer std.testing.allocator.free(entries);
+    var outcome = try store.applyCommittedBatch(41, 2, entries);
+    defer outcome.deinit();
+
+    // Keep one storage snapshot open across a later apply and prove the two
+    // namespace scans cannot straddle that commit.
+    {
+        var txn = try store.store.beginReadTxn();
+        defer txn.abort();
+        const before_tables = try store.listTablesTxn(std.testing.allocator, &txn, 41);
+        defer store.freeTables(std.testing.allocator, before_tables);
+
+        var updated_table = testTransitionTableRecord();
+        updated_table.schema_json = "{\"title\":{\"type\":\"text\"}}";
+        const table_update = try encodeTransitionCommand(std.testing.allocator, .{
+            .upsert_table = updated_table,
+        });
+        defer std.testing.allocator.free(table_update);
+        const range_update = try encodeTransitionCommand(std.testing.allocator, .{
+            .upsert_range = testTransitionRangeRecord(
+                101,
+                test_transition_table_contract.source_identity,
+                "m",
+                null,
+            ),
+        });
+        defer std.testing.allocator.free(range_update);
+        const update_entries = try raft_state_machine.encodeCommittedEntries(std.testing.allocator, &.{
+            .{ .term = 1, .index = 3, .entry_type = .normal, .data = table_update },
+            .{ .term = 1, .index = 4, .entry_type = .normal, .data = range_update },
+        });
+        defer std.testing.allocator.free(update_entries);
+        var update_outcome = try store.applyCommittedBatch(41, 4, update_entries);
+        defer update_outcome.deinit();
+
+        const before_ranges = try store.listRangesTxn(std.testing.allocator, &txn, 41);
+        defer store.freeRanges(std.testing.allocator, before_ranges);
+        try std.testing.expectEqual(@as(usize, 1), before_tables.len);
+        try std.testing.expectEqual(@as(usize, 1), before_ranges.len);
+        try std.testing.expectEqualStrings(test_transition_table_contract.schema_json, before_tables[0].schema_json);
+        try std.testing.expectEqualStrings("", before_ranges[0].start_key);
+    }
+
+    try std.testing.expectError(
+        error.CatalogRoutingSnapshotTimeout,
+        store.captureCatalogProjection(
+            std.testing.allocator,
+            41,
+            platform_time.monotonicNs() -| 1,
+        ),
+    );
+
     const io = store.io_impl.io();
     store.apply_mutex.lockUncancelable(io);
     {
         defer store.apply_mutex.unlock(io);
-        try std.testing.expectError(
-            error.CatalogRoutingSnapshotTimeout,
-            store.captureCatalogProjection(
-                std.testing.allocator,
-                41,
-                platform_time.monotonicNs() + std.time.ns_per_ms,
-            ),
+        const snapshot = try store.captureCatalogProjection(
+            std.testing.allocator,
+            41,
+            platform_time.monotonicNs() + std.time.ns_per_s,
         );
+        defer store.freeTables(std.testing.allocator, snapshot.tables);
+        defer store.freeRanges(std.testing.allocator, snapshot.ranges);
+        try std.testing.expectEqual(@as(usize, 1), snapshot.tables.len);
+        try std.testing.expectEqual(@as(usize, 1), snapshot.ranges.len);
+        try std.testing.expectEqual(snapshot.tables[0].table_id, snapshot.ranges[0].table_id);
+        try std.testing.expectEqualStrings("{\"title\":{\"type\":\"text\"}}", snapshot.tables[0].schema_json);
+        try std.testing.expectEqualStrings("m", snapshot.ranges[0].start_key);
     }
-
-    const snapshot = try store.captureCatalogProjection(std.testing.allocator, 41, null);
-    defer store.freeTables(std.testing.allocator, snapshot.tables);
-    defer store.freeRanges(std.testing.allocator, snapshot.ranges);
-    try std.testing.expectEqual(@as(usize, 0), snapshot.tables.len);
-    try std.testing.expectEqual(@as(usize, 0), snapshot.ranges.len);
 }
 
 test "metadata raft apply store resolves stale store drain intent at apply time" {

--- a/zig/pkg/antfly/src/metadata/storage/raft_apply_store.zig
+++ b/zig/pkg/antfly/src/metadata/storage/raft_apply_store.zig
@@ -31,10 +31,17 @@ const raft_reconciler = @import("../../raft/reconciler.zig");
 const raft_storage_mod = @import("../../raft/storage/mod.zig");
 const wal_replica_state_mod = @import("../../raft/storage/wal_replica_state.zig");
 const raft_state_machine = @import("../../raft/state_machine/mod.zig");
+const platform_clock = @import("antfly_platform").clock;
+const platform_time = @import("antfly_platform").time;
 
 pub const AppliedMetadataBatch = struct {
     commit_index: u64,
     entries_bytes: []const u8,
+};
+
+pub const CatalogProjectionSnapshot = struct {
+    tables: []metadata.TableRecord,
+    ranges: []metadata.RangeRecord,
 };
 
 pub const ExtensionMemberKey = struct {
@@ -1598,6 +1605,33 @@ pub const RaftApplyStore = struct {
             filled = i + 1;
         }
         return out;
+    }
+
+    /// Capture the table and range namespaces from one committed apply-store
+    /// revision without acquiring the outer Raft runtime lock.
+    pub fn captureCatalogProjection(
+        self: *RaftApplyStore,
+        alloc: std.mem.Allocator,
+        group_id: u64,
+        deadline_ns: ?u64,
+    ) !CatalogProjectionSnapshot {
+        const io = self.io_impl.io();
+        if (deadline_ns) |deadline| {
+            while (!self.apply_mutex.tryLock()) {
+                if (platform_time.monotonicNs() >= deadline) return error.CatalogRoutingSnapshotTimeout;
+                platform_clock.Clock.real().sleepMs(1);
+            }
+        } else {
+            self.apply_mutex.lockUncancelable(io);
+        }
+        defer self.apply_mutex.unlock(io);
+
+        const tables = try self.listTables(alloc, group_id);
+        errdefer self.freeTables(alloc, tables);
+        return .{
+            .tables = tables,
+            .ranges = try self.listRanges(alloc, group_id),
+        };
     }
 
     pub fn freeTables(_: *RaftApplyStore, alloc: std.mem.Allocator, records: []metadata.TableRecord) void {
@@ -8345,6 +8379,37 @@ test "metadata raft apply store publishes listeners only after commit" {
     const tables = try store.listTables(std.testing.allocator, 41);
     defer store.freeTables(std.testing.allocator, tables);
     try std.testing.expectEqual(@as(usize, 0), tables.len);
+}
+
+test "metadata raft apply store catalog projection honors apply deadline" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const root = try std.fmt.allocPrint(std.testing.allocator, ".zig-cache/tmp/{s}/metadata-catalog-projection-deadline", .{tmp.sub_path});
+    defer std.testing.allocator.free(root);
+
+    var store = try RaftApplyStore.init(std.testing.allocator, .{ .root_dir = root });
+    defer store.deinit();
+
+    const io = store.io_impl.io();
+    store.apply_mutex.lockUncancelable(io);
+    {
+        defer store.apply_mutex.unlock(io);
+        try std.testing.expectError(
+            error.CatalogRoutingSnapshotTimeout,
+            store.captureCatalogProjection(
+                std.testing.allocator,
+                41,
+                platform_time.monotonicNs() + std.time.ns_per_ms,
+            ),
+        );
+    }
+
+    const snapshot = try store.captureCatalogProjection(std.testing.allocator, 41, null);
+    defer store.freeTables(std.testing.allocator, snapshot.tables);
+    defer store.freeRanges(std.testing.allocator, snapshot.ranges);
+    try std.testing.expectEqual(@as(usize, 0), snapshot.tables.len);
+    try std.testing.expectEqual(@as(usize, 0), snapshot.ranges.len);
 }
 
 test "metadata raft apply store resolves stale store drain intent at apply time" {


### PR DESCRIPTION
## Summary

- add a typed routing-only catalog projection for table/range lookups
- capture tables and ranges atomically from one point-in-time storage transaction without taking the apply or outer Raft runtime locks
- share the compact, deadline-aware snapshot path across MetadataHttpService and MetadataService catalog sources
- cache the immutable projection with epoch invalidation and propagate routing deadlines through cache publication and storage capture
- keep full status/incarnation snapshots for admin and publication-fence consumers

This addresses the low-FD autograph stall observed in https://github.com/antflydb/antfly/actions/runs/33266166009/job/99144023573?pr=595, where routing blocked while building an unbounded full admin snapshot.

## Validation

- python3 tools/run_bounded_zig_build.py --zig zig -- build antfly -fincremental
- focused compact-route, constructor wiring, cache/runtime-independence, storage snapshot isolation, apply-mutex independence, and deadline tests passed with no leaks
- exact autograph low-FD regression loop at 256 FDs on the final implementation: 20/20 passed
- git diff --check