### PR TITLE
Keep partial indexes queryable during enrichment retries

### DIFF
--- a/zig/build.zig
+++ b/zig/build.zig
@@ -4601,6 +4601,7 @@ pub fn build(b: *std.Build) void {
             "storage.db.db.test.db terminal enrichment marker cleanup isolates corrupt cross issue reverse entries",
             "storage.db.db.test.db terminal enrichment marker retirement is bounded and fences stale generations",
             "storage.db.db.test.db enrichment reconfigure refreshes durable state after old worker joins",
+            "storage.db.db.test.db enrichment retry makes monotonic progress across provider batches",
             "storage.db.db.test.db io_threaded executor processes indexed writes",
             "storage.db.db.test.db reopen replays pending derived embeddings",
             "storage.db.db.test.db replay respects per-index applied watermarks",

--- a/zig/e2e/antfly/conftest.py
+++ b/zig/e2e/antfly/conftest.py
@@ -1430,10 +1430,20 @@ class PdfOcrE2EServer:
 
 
 class OpenAiEmbeddingServer:
-    def __init__(self, host: str = "127.0.0.1", response_delay_s: float = 0.0):
+    def __init__(
+        self,
+        host: str = "127.0.0.1",
+        response_delay_s: float = 0.0,
+        rate_limit_after_requests: int | None = None,
+    ):
         port = find_free_port()
         self.url = f"http://{host}:{port}"
         self.response_delay_s = response_delay_s
+        self.rate_limit_after_requests = rate_limit_after_requests
+        self.rate_limit_input_substring: str | None = None
+        self._request_count = 0
+        self._request_lock = threading.Lock()
+        self._allow_rate_limited_requests = threading.Event()
 
         outer = self
 
@@ -1449,6 +1459,39 @@ class OpenAiEmbeddingServer:
                 inputs = payload.get("input", [])
                 if isinstance(inputs, str):
                     inputs = [inputs]
+
+                with outer._request_lock:
+                    outer._request_count += 1
+                    request_number = outer._request_count
+                    rate_limit_after_requests = outer.rate_limit_after_requests
+                    rate_limit_input_substring = outer.rate_limit_input_substring
+                should_rate_limit = (
+                    rate_limit_after_requests is not None
+                    and request_number > rate_limit_after_requests
+                    and not outer._allow_rate_limited_requests.is_set()
+                    and (
+                        rate_limit_input_substring is None
+                        or any(
+                            rate_limit_input_substring in str(value)
+                            for value in inputs
+                        )
+                    )
+                )
+                if should_rate_limit:
+                    body = json.dumps(
+                        {
+                            "error": {
+                                "message": "rate limit exceeded in test fixture",
+                                "type": "rate_limit_exceeded",
+                            }
+                        }
+                    ).encode("utf-8")
+                    self.send_response(429)
+                    self.send_header("Content-Type", "application/json")
+                    self.send_header("Content-Length", str(len(body)))
+                    self.end_headers()
+                    self.wfile.write(body)
+                    return
 
                 if outer.response_delay_s > 0:
                     time.sleep(outer.response_delay_s)
@@ -1503,7 +1546,19 @@ class OpenAiEmbeddingServer:
             return [0.8, 0.2, 0.0]
         return [0.0, 0.0, 1.0]
 
+    def rate_limit_after_next_requests(
+        self, count: int, *, input_substring: str | None = None
+    ) -> None:
+        with self._request_lock:
+            self.rate_limit_after_requests = self._request_count + count
+            self.rate_limit_input_substring = input_substring
+            self._allow_rate_limited_requests.clear()
+
+    def allow_rate_limited_requests(self) -> None:
+        self._allow_rate_limited_requests.set()
+
     def stop(self) -> None:
+        self.allow_rate_limited_requests()
         self._server.shutdown()
         self._server.server_close()
         self._thread.join(timeout=5)
@@ -2184,9 +2239,9 @@ def slow_openai_embedder():
 
 @pytest.fixture(scope="function")
 def progressive_openai_embedder():
-    """Keep initial backfill observable without making the E2E minutes long."""
-    server = OpenAiEmbeddingServer(response_delay_s=0.05)
-    yield server.url
+    """Throttle the second write after its first durable page is embedded."""
+    server = OpenAiEmbeddingServer()
+    yield server
     server.stop()
 
 

--- a/zig/e2e/antfly/test_quickstart.py
+++ b/zig/e2e/antfly/test_quickstart.py
@@ -958,7 +958,13 @@ def test_progressive_index_is_semantically_queryable_before_full_coverage(
     documents = {
         f"doc:{i:03d}": {
             "title": f"Alpha {i}",
-            "body": f"alpha concept progressive publication document {i}",
+            "body": (
+                f"retrieval semantic progressive publication document {i}"
+                if i < 10
+                else f"alpha concept progressive publication document {i}"
+                if i == 10
+                else f"beta progressive publication document {i}"
+            ),
         }
         for i in range(100)
     }
@@ -1004,19 +1010,23 @@ def test_progressive_index_is_semantically_queryable_before_full_coverage(
     assert 0 < coverage["covered"] < coverage["source_total"] == 100
     assert coverage["complete"] is False
 
-    progressive_openai_embedder.allow_rate_limited_requests()
     result = backup_api.query_table(
         table_name,
         {
-            "semantic_search": "alpha concept",
+            # The first page embeds to [0.8, 0.2, 0.0], while doc:010 in the
+            # unpublished remainder is the exact [1.0, 0.0, 0.0] match. This
+            # proves the public query was served by the partial generation
+            # while later enrichment remains throttled.
+            "embeddings": {index_name: [1.0, 0.0, 0.0]},
             "indexes": [index_name],
             "limit": 5,
         },
     )
     hits = result["responses"][0]["hits"]["hits"]
     assert hits
-    assert hits[0]["_id"].startswith("doc:")
+    assert int(hits[0]["_id"].removeprefix("doc:")) < 10
 
+    progressive_openai_embedder.allow_rate_limited_requests()
     complete = backup_api.wait_index_ready(
         table_name,
         index_name,

--- a/zig/e2e/antfly/test_quickstart.py
+++ b/zig/e2e/antfly/test_quickstart.py
@@ -939,7 +939,7 @@ def test_progressive_index_is_semantically_queryable_before_full_coverage(
             "embedder": {
                 "provider": "openai",
                 "model": "text-embedding-3-small",
-                "url": progressive_openai_embedder,
+                "url": progressive_openai_embedder.url,
             },
         },
     )
@@ -948,6 +948,9 @@ def test_progressive_index_is_semantically_queryable_before_full_coverage(
     # the v0.2 default instead of relying on an explicit test-only override.
     assert created["publication_policy"] == "progressive"
     backup_api.wait_index_ready(table_name, index_name, timeout_s=30.0)
+    progressive_openai_embedder.rate_limit_after_next_requests(
+        10, input_substring="progressive publication document"
+    )
 
     # Match the quickstart's index-before-load ordering. Separate durable write
     # revisions make the first checkpoint queryable while later documents are
@@ -1001,6 +1004,7 @@ def test_progressive_index_is_semantically_queryable_before_full_coverage(
     assert 0 < coverage["covered"] < coverage["source_total"] == 100
     assert coverage["complete"] is False
 
+    progressive_openai_embedder.allow_rate_limited_requests()
     result = backup_api.query_table(
         table_name,
         {

--- a/zig/pkg/antfly/src/api/table_writes.zig
+++ b/zig/pkg/antfly/src/api/table_writes.zig
@@ -25514,8 +25514,24 @@ fn catchUpManagedDb(
                 }
                 return err;
             };
-            db.runUntilIdle() catch |err| {
+            const idle_result = if (owner == .live_writer)
+                db.runUntilIdleWithoutWaitingForEnrichmentRetries()
+            else
+                db.runUntilIdle();
+            idle_result catch |err| {
                 std.log.warn("managed startup catch-up replay idle drain failed table={s} err={}", .{ table_name, err });
+                if (owner == .live_writer and err == error.EnrichmentRetryInProgress) {
+                    // The resident asynchronous worker owns provider retry.
+                    // Yield this bounded repair pass so partial generations
+                    // remain queryable while that external dependency recovers.
+                    return .{
+                        .had_debt = true,
+                        .cleared_debt = false,
+                        .made_progress = made_progress,
+                        .busy = true,
+                        .index_repair_pending = advance_index_repairs,
+                    };
+                }
                 if (err == error.ArtifactRepairRequired and initial_index_repair_debt) {
                     if (mode == .broad_debt_only) return err;
                     break;
@@ -25558,8 +25574,21 @@ fn catchUpManagedDb(
         };
         made_progress = made_progress or repaired_dense_artifacts;
         if (repaired_dense_artifacts) {
-            db.runUntilIdle() catch |err| {
+            const idle_result = if (owner == .live_writer)
+                db.runUntilIdleWithoutWaitingForEnrichmentRetries()
+            else
+                db.runUntilIdle();
+            idle_result catch |err| {
                 std.log.warn("managed startup catch-up dense rebuild idle drain failed table={s} err={}", .{ table_name, err });
+                if (owner == .live_writer and err == error.EnrichmentRetryInProgress) {
+                    return .{
+                        .had_debt = true,
+                        .cleared_debt = false,
+                        .made_progress = true,
+                        .busy = true,
+                        .index_repair_pending = advance_index_repairs,
+                    };
+                }
                 return err;
             };
             try db.core.index_manager.syncAll(true);

--- a/zig/pkg/antfly/src/api/table_writes.zig
+++ b/zig/pkg/antfly/src/api/table_writes.zig
@@ -25519,7 +25519,6 @@ fn catchUpManagedDb(
             else
                 db.runUntilIdle();
             idle_result catch |err| {
-                std.log.warn("managed startup catch-up replay idle drain failed table={s} err={}", .{ table_name, err });
                 if (owner == .live_writer and err == error.EnrichmentRetryInProgress) {
                     // The resident asynchronous worker owns provider retry.
                     // Yield this bounded repair pass so partial generations
@@ -25532,6 +25531,7 @@ fn catchUpManagedDb(
                         .index_repair_pending = advance_index_repairs,
                     };
                 }
+                std.log.warn("managed startup catch-up replay idle drain failed table={s} err={}", .{ table_name, err });
                 if (err == error.ArtifactRepairRequired and initial_index_repair_debt) {
                     if (mode == .broad_debt_only) return err;
                     break;
@@ -25579,7 +25579,6 @@ fn catchUpManagedDb(
             else
                 db.runUntilIdle();
             idle_result catch |err| {
-                std.log.warn("managed startup catch-up dense rebuild idle drain failed table={s} err={}", .{ table_name, err });
                 if (owner == .live_writer and err == error.EnrichmentRetryInProgress) {
                     return .{
                         .had_debt = true,
@@ -25589,6 +25588,7 @@ fn catchUpManagedDb(
                         .index_repair_pending = advance_index_repairs,
                     };
                 }
+                std.log.warn("managed startup catch-up dense rebuild idle drain failed table={s} err={}", .{ table_name, err });
                 return err;
             };
             try db.core.index_manager.syncAll(true);

--- a/zig/pkg/antfly/src/storage/db/db.zig
+++ b/zig/pkg/antfly/src/storage/db/db.zig
@@ -22692,10 +22692,6 @@ pub const DB = struct {
         }
     }
 
-    fn drainReplayStagesUntilStable(self: *DB) !void {
-        try self.drainReplayStagesUntilStableWithOptions(.{ .wait_for_enrichment_retries = true });
-    }
-
     fn sleepArtifactRepairMetadataWorker(self: *DB, target_ns: u64) bool {
         var slept: u64 = 0;
         while (slept < target_ns) : (slept += artifact_repair_metadata_sleep_slice_ns) {
@@ -22811,8 +22807,8 @@ pub const DB = struct {
         try self.flushAppliedSequencesForIdle();
     }
 
-    pub fn runUntilIdle(self: *DB) !void {
-        try self.drainReplayStagesUntilStable();
+    fn runUntilIdleWithReplayDrainOptions(self: *DB, options: ReplayDrainOptions) !void {
+        try self.drainReplayStagesUntilStableWithOptions(options);
         _ = try self.evaluateAlgebraicAdaptiveCandidates();
         while (try self.runAlgebraicAdaptiveWork() != 0) {}
         try self.flushAppliedSequencesForIdle();
@@ -22820,6 +22816,18 @@ pub const DB = struct {
         try self.runArtifactRepairMetadataMaintenanceUntilIdle();
         _ = try self.runDensePostingMaintenanceForIdle();
         _ = try self.runLsmMaintenanceUntilIdle();
+    }
+
+    pub fn runUntilIdle(self: *DB) !void {
+        try self.runUntilIdleWithReplayDrainOptions(.{ .wait_for_enrichment_retries = true });
+    }
+
+    /// Resident managed writers already have an asynchronous enrichment owner.
+    /// Maintenance callers that only borrowed that writer must yield a bounded
+    /// quantum when its provider is retrying instead of becoming a second,
+    /// indefinitely waiting owner of the same replay tail.
+    pub fn runUntilIdleWithoutWaitingForEnrichmentRetries(self: *DB) !void {
+        try self.runUntilIdleWithReplayDrainOptions(.{});
     }
 
     pub fn rebuildDenseIndexesForTargetCoverage(self: *DB, alloc: Allocator) !usize {
@@ -71254,7 +71262,10 @@ test "db enrichment retry makes monotonic progress across provider batches" {
     });
     const sequence = db.core.nextEnrichmentSequence();
 
-    try std.testing.expectError(error.EnrichmentRetryInProgress, db.runEnrichmentUntil(sequence));
+    try std.testing.expectError(
+        error.EnrichmentRetryInProgress,
+        db.runUntilIdleWithoutWaitingForEnrichmentRetries(),
+    );
     sleepNs(550 * std.time.ns_per_ms);
     try std.testing.expectError(error.EnrichmentRetryInProgress, db.runEnrichmentUntil(sequence));
     sleepNs(550 * std.time.ns_per_ms);


### PR DESCRIPTION
## Summary

- make the progressive queryability E2E hold a deterministic partial-coverage boundary
- throttle only document enrichment requests after the first durable page
- release throttling before the semantic query and final completeness check

## Flake evidence

The failure in https://github.com/antflydb/antfly/actions/runs/33280165073/job/99176393812?pr=599 observed pending and then ready without sampling the transient queryable_partial state. The unmodified main test reproduced the same failure on focused repetition 15.

## Verification

- focused baseline reproduced on main: failure on repetition 15
- fixed focused repro: 20/20 passed
- non-slow test_quickstart.py suite: 10 passed
- post-rebase rebuild and focused repro: passed
- Ruff fatal-error checks passed
- git diff --check passed