### PR TITLE
ci: use glibc-linked Zig for release builds

### DIFF
--- a/.github/workflows/antfly-container.yml
+++ b/.github/workflows/antfly-container.yml
@@ -33,6 +33,9 @@ env:
   CLOUD_BUILD_WORKER_POOL: projects/antfly-image-artifacts/locations/us-central1/workerPools/antfly-container-builders
   ZIG_ARTIFACT_BUCKET: antfly-image-artifacts-zig-build-artifacts
   ZIG_VERSION: 0.16.0
+  # Keep the glibc-linked host compiler reproducible while continuing to emit
+  # static musl release artifacts for both architectures.
+  NIXPKGS_REV: c5c4a43b0e8056328ec4529f735cabdb8f1942bb
 
 jobs:
   build-artifact:
@@ -90,14 +93,21 @@ jobs:
       - name: Install build dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential clang lld curl xz-utils git perl python3 linux-libc-dev ca-certificates
+          sudo apt-get install -y build-essential clang lld curl xz-utils git perl python3 linux-libc-dev ca-certificates file
 
-      - name: Install Zig
+      - name: Install Nix
+        uses: cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24 # v31
+        with:
+          nix_path: nixpkgs=https://github.com/NixOS/nixpkgs/archive/${{ env.NIXPKGS_REV }}.tar.gz
+
+      - name: Install glibc-linked Zig
         run: |
-          curl -L "https://ziglang.org/download/${ZIG_VERSION}/zig-${{ matrix.zig_arch }}-linux-${ZIG_VERSION}.tar.xz" -o "$RUNNER_TEMP/zig.tar.xz"
-          mkdir -p "$RUNNER_TEMP/zig"
-          tar -xJf "$RUNNER_TEMP/zig.tar.xz" -C "$RUNNER_TEMP/zig" --strip-components=1
-          echo "$RUNNER_TEMP/zig" >> "$GITHUB_PATH"
+          zig_path="$(nix-build '<nixpkgs>' -A zig_0_16 --no-out-link)"
+          test "$("$zig_path/bin/zig" version)" = "$ZIG_VERSION"
+          compiler_description="$(file "$zig_path/bin/zig")"
+          echo "$compiler_description"
+          grep -q 'dynamically linked' <<<"$compiler_description"
+          echo "$zig_path/bin" >> "$GITHUB_PATH"
 
       - name: Build runtime artifact
         run: |

--- a/.github/workflows/antfly-release.yml
+++ b/.github/workflows/antfly-release.yml
@@ -11,6 +11,9 @@ permissions:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   ZIG_VERSION: 0.16.0
+  # Keep the glibc-linked host compiler reproducible. The release targets are
+  # still the musl and Darwin targets selected by the matrix below.
+  NIXPKGS_REV: c5c4a43b0e8056328ec4529f735cabdb8f1942bb
   MACOS_SDK_VERSION: "15.5"
   MACOS_SDK_SHA256: c15cf0f3f17d714d1aa5a642da8e118db53d79429eb015771ba816aa7c6c1cbd
 
@@ -75,17 +78,23 @@ jobs:
         if: ${{ matrix.os == 'linux' }}
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential clang lld curl xz-utils git perl python3 linux-libc-dev ca-certificates
+          sudo apt-get install -y build-essential clang lld curl xz-utils git perl python3 linux-libc-dev ca-certificates file
 
-      - name: Install Zig (Linux)
+      - name: Install Nix
+        if: ${{ matrix.os == 'linux' }}
+        uses: cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24 # v31
+        with:
+          nix_path: nixpkgs=https://github.com/NixOS/nixpkgs/archive/${{ env.NIXPKGS_REV }}.tar.gz
+
+      - name: Install glibc-linked Zig (Linux)
         if: ${{ matrix.os == 'linux' }}
         run: |
-          curl --fail --location --retry 3 \
-            "https://ziglang.org/download/${ZIG_VERSION}/zig-${{ matrix.zig_arch }}-linux-${ZIG_VERSION}.tar.xz" \
-            -o "$RUNNER_TEMP/zig.tar.xz"
-          mkdir -p "$RUNNER_TEMP/zig"
-          tar -xJf "$RUNNER_TEMP/zig.tar.xz" -C "$RUNNER_TEMP/zig" --strip-components=1
-          echo "$RUNNER_TEMP/zig" >> "$GITHUB_PATH"
+          zig_path="$(nix-build '<nixpkgs>' -A zig_0_16 --no-out-link)"
+          test "$("$zig_path/bin/zig" version)" = "$ZIG_VERSION"
+          compiler_description="$(file "$zig_path/bin/zig")"
+          echo "$compiler_description"
+          grep -q 'dynamically linked' <<<"$compiler_description"
+          echo "$zig_path/bin" >> "$GITHUB_PATH"
 
       - name: Install pinned macOS cross-compilation SDK
         if: ${{ matrix.macos_sdk == 'true' }}

--- a/.github/workflows/diagnose-zig-arm64-bad-alloc.yml
+++ b/.github/workflows/diagnose-zig-arm64-bad-alloc.yml
@@ -14,6 +14,7 @@ permissions:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   ZIG_VERSION: 0.16.0
+  NIXPKGS_REV: c5c4a43b0e8056328ec4529f735cabdb8f1942bb
   MACOS_SDK_VERSION: "15.5"
   MACOS_SDK_SHA256: c15cf0f3f17d714d1aa5a642da8e118db53d79429eb015771ba816aa7c6c1cbd
 
@@ -49,14 +50,19 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y build-essential clang lld curl xz-utils git perl python3 linux-libc-dev ca-certificates time file
 
-      - name: Install Zig
+      - name: Install Nix
+        uses: cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24 # v31
+        with:
+          nix_path: nixpkgs=https://github.com/NixOS/nixpkgs/archive/${{ env.NIXPKGS_REV }}.tar.gz
+
+      - name: Install glibc-linked Zig
         run: |
-          curl --fail --location --retry 3 \
-            "https://ziglang.org/download/${ZIG_VERSION}/zig-x86_64-linux-${ZIG_VERSION}.tar.xz" \
-            -o "$RUNNER_TEMP/zig.tar.xz"
-          mkdir -p "$RUNNER_TEMP/zig"
-          tar -xJf "$RUNNER_TEMP/zig.tar.xz" -C "$RUNNER_TEMP/zig" --strip-components=1
-          echo "$RUNNER_TEMP/zig" >> "$GITHUB_PATH"
+          zig_path="$(nix-build '<nixpkgs>' -A zig_0_16 --no-out-link)"
+          test "$("$zig_path/bin/zig" version)" = "$ZIG_VERSION"
+          compiler_description="$(file "$zig_path/bin/zig")"
+          echo "$compiler_description"
+          grep -q 'dynamically linked' <<<"$compiler_description"
+          echo "$zig_path/bin" >> "$GITHUB_PATH"
 
       - name: Install pinned macOS cross-compilation SDK
         run: |


### PR DESCRIPTION
## Summary

- install Zig 0.16.0 from a pinned Nixpkgs revision for tagged release archives
- apply the same host-compiler change to container runtime artifact builds
- verify both the Zig version and that the selected compiler is dynamically linked
- keep all release targets and `ReleaseFast` settings unchanged

## Why

The official Linux Zig tarball is statically linked and the `antfly-storage-kernel` build reaches Linux `vm.max_map_count=65530` before it reaches the 32 GiB runner memory limit. The terminal LLVM allocation failure was a 152 KiB `mmap`, while cgroup OOM counters remained zero.

The glibc-linked Zig control completed the exact ARM64-musl ReleaseFast build with a peak of 155 VMAs, 7.63 GiB compiler RSS, and 13.14 GiB total pod usage. Since main cross-compiles all tagged release targets on Linux, the host-compiler change covers the Linux and Darwin release archives without changing their target ABI.

Tracking issue: #604

## Validation

- `actionlint .github/workflows/antfly-release.yml .github/workflows/antfly-container.yml`
- `git diff --check`
- successful exact storage-kernel probe: https://github.com/antflydb/antfly/actions/runs/33332235847

The Nix installer action and Nixpkgs revision are SHA-pinned, and the workflow rejects a compiler whose version is not exactly 0.16.0 or whose executable is not dynamically linked.