### PR TITLE
fix(data): retry incomplete split provisioning snapshots

### DIFF
--- a/zig/build.zig
+++ b/zig/build.zig
@@ -4603,6 +4603,7 @@ pub fn build(b: *std.Build) void {
         "remote metadata source bounds unsupported linearizable snapshot probes",
         "remote metadata source shares backend runtime io across a bounded executor pool",
         "data runtime treats metadata leadership churn as retryable bootstrap failure",
+        "data runtime retries incomplete split provisioning projections",
         "data runtime metadata bootstrap retry delay is bounded and jittered",
         "data runtime heartbeat cache cannot regress to an older full report",
         "idle cached runtime status stays fresh only for the published root generation",

--- a/zig/pkg/antfly/src/data/runtime.zig
+++ b/zig/pkg/antfly/src/data/runtime.zig
@@ -3879,6 +3879,11 @@ fn isRetryableMetadataBootstrapError(err: anyerror) bool {
         // control-plane backoff preserves that exclusion without terminating
         // the data process and permanently removing a destination voter.
         error.TransitionDestinationProvisioningBusy,
+        // Placement and split-transition projections are multi-row. A data
+        // node can briefly observe its destination placement before the
+        // provisioning range becomes visible in the same snapshot. Fail
+        // closed for that round, then retry from a fresh metadata snapshot.
+        error.MissingProvisioningRange,
         // Placement projection is multi-row. A store can observe its local
         // row before every row needed to prove the incumbent voter set is
         // visible. Refusing to bootstrap from that partial set is required,
@@ -3931,6 +3936,10 @@ test "data runtime treats metadata leadership churn as retryable bootstrap failu
     try std.testing.expect(isRetryableMetadataBootstrapError(error.TransitionDestinationProvisioningBusy));
     try std.testing.expect(!isRetryableMetadataBootstrapError(error.InvalidArguments));
     try std.testing.expect(!isRetryableMetadataBootstrapError(error.MetadataIncarnationMismatch));
+}
+
+test "data runtime retries incomplete split provisioning projections" {
+    try std.testing.expect(isRetryableMetadataBootstrapError(error.MissingProvisioningRange));
 }
 
 test "replicated transition action lanes fail fast without serializing unrelated groups" {


### PR DESCRIPTION
## Summary

- treat a transient MissingProvisioningRange metadata projection gap as a retryable data-node bootstrap condition
- preserve fail-closed split destination admission while retrying from a fresh snapshot with the existing bounded backoff
- register a focused regression in the data-runtime test shard

## Root cause

The autoscaling failure in PR #607 also reproduced on its origin/main base. Under mixed load, a data node observed its placement row before the matching split-provisioning range row, returned MissingProvisioningRange, and terminated. Metadata retained its last healthy status, so the active reallocation barrier waited indefinitely for that dead voter and the added node never received a placement.

Original failing job: https://github.com/antflydb/antfly/actions/runs/33426670378/job/99612881480?pr=607
Same test on the exact main/base SHA: https://github.com/antflydb/antfly/actions/runs/33356882462/job/99385297304

## Verification

- lib-data-runtime-test: 129 passed, 0 failed
- exact autoscaling regression loop before fix: 1 failure in 60 mixed-load runs; preserved data-102 log ended with MissingProvisioningRange
- exact autoscaling regression loop after fix: 60/60 passed with 3 workers x 20 repetitions
- zig fmt and git diff --check pass