### PR TITLE
test: account for expected error logs

### DIFF
--- a/zig/pkg/antfly/src/api/restore_jobs.zig
+++ b/zig/pkg/antfly/src/api/restore_jobs.zig
@@ -2383,6 +2383,8 @@ test "failed destination authorization refresh reuses the idempotent restore job
 }
 
 test "replicated restore persistence maps private callback errors to stable unavailability" {
+    @import("../test_error_logs.zig").expectErrorLogs(2);
+
     var persistence = TestReplicatedPersistence.init(std.testing.allocator);
     defer persistence.deinit();
     const replicated = persistence.persistence();
@@ -2816,6 +2818,8 @@ test "replicated restore mutations are rejected after leadership term changes" {
 }
 
 test "restore dispatch recovery retains worker ownership when begin fails" {
+    @import("../test_error_logs.zig").expectErrorLogs(1);
+
     var persistence = TestReplicatedPersistence.init(std.testing.allocator);
     defer persistence.deinit();
     var store = Store.initWithIo(std.testing.allocator, std.testing.io);

--- a/zig/pkg/antfly/src/test_error_logs.zig
+++ b/zig/pkg/antfly/src/test_error_logs.zig
@@ -1,0 +1,22 @@
+// Copyright 2026 Antfly, Inc.
+//
+// Licensed under the Elastic License 2.0 (ELv2); you may not use this file
+// except in compliance with the Elastic License 2.0. You may obtain a copy of
+// the Elastic License 2.0 at
+//
+//     https://www.antfly.io/licensing/ELv2-license
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+extern fn antfly_test_expect_error_logs(count: usize) callconv(.c) void;
+
+/// Declares the exact number of error-level logs that the current test expects.
+/// Multiple calls are additive. The custom test runner resets and verifies this
+/// count at every test boundary.
+pub fn expectErrorLogs(count: usize) void {
+    if (count == 0) @panic("expected error log count must be greater than zero");
+    antfly_test_expect_error_logs(count);
+}

--- a/zig/pkg/antfly/src/test_runner.zig
+++ b/zig/pkg/antfly/src/test_runner.zig
@@ -20,7 +20,8 @@ pub const std_options: std.Options = .{
     .logFn = log,
 };
 
-var log_err_count: usize = 0;
+var log_err_count: std.atomic.Value(usize) = .init(0);
+var expected_error_log_count: std.atomic.Value(usize) = .init(0);
 var test_filters: []const []const u8 = &.{};
 var skip_test_filters: []const []const u8 = &.{};
 
@@ -76,6 +77,7 @@ pub fn main(init: std.process.Init.Minimal) void {
     var skip_count: usize = 0;
     var fail_count: usize = 0;
     var leak_count: usize = 0;
+    var matched_error_log_count: usize = 0;
     var total_count: usize = 0;
     const matched_filter_counts = arena.alloc(usize, test_filters.len) catch
         @panic("out of memory while allocating test filter counters");
@@ -115,6 +117,7 @@ pub fn main(init: std.process.Init.Minimal) void {
     }
 
     const trace_cleanup = getenvBool("ANTFLY_TEST_CLEANUP_TRACE");
+    const fail_on_error_logs = getenvBool("ANTFLY_TEST_FAIL_ON_ERROR_LOGS");
     var current_count: usize = 0;
     for (test_fns) |test_fn| {
         if (!matchesFilter(test_fn.name)) continue;
@@ -130,17 +133,17 @@ pub fn main(init: std.process.Init.Minimal) void {
         });
         testing.environ = init.environ;
         testing.log_level = .warn;
+        expected_error_log_count.store(0, .release);
+        const error_logs_before = log_err_count.load(.acquire);
 
-        if (test_fn.func()) |_| {
-            ok_count += 1;
-            std.debug.print("OK\n", .{});
-        } else |err| switch (err) {
+        const Outcome = enum { passed, skipped, failed };
+        var outcome: Outcome = .passed;
+        if (test_fn.func()) |_| {} else |err| switch (err) {
             error.SkipZigTest => {
-                skip_count += 1;
-                std.debug.print("SKIP\n", .{});
+                outcome = .skipped;
             },
             else => {
-                fail_count += 1;
+                outcome = .failed;
                 // Logs emitted by a test can split the leading test name from
                 // its result. Repeat it on failure so CI attribution survives
                 // interleaved diagnostics and truncated log windows.
@@ -158,19 +161,59 @@ pub fn main(init: std.process.Init.Minimal) void {
             leak_count += 1;
         }
         if (trace_cleanup) std.debug.print("CLEANUP done {s}\n", .{test_fn.name});
+
+        const error_logs_after = log_err_count.load(.acquire);
+        const actual_error_logs = error_logs_after -| error_logs_before;
+        const expected_error_logs = expected_error_log_count.swap(0, .acq_rel);
+        const declared_expectation_mismatch =
+            expected_error_logs != 0 and actual_error_logs != expected_error_logs;
+        const strict_unexpected_error_logs =
+            fail_on_error_logs and expected_error_logs == 0 and actual_error_logs != 0;
+        if (declared_expectation_mismatch or strict_unexpected_error_logs) {
+            fail_count += 1;
+            std.debug.print(
+                "FAIL (expected {d} error logs, observed {d}) {s}\n",
+                .{ expected_error_logs, actual_error_logs, test_fn.name },
+            );
+        } else {
+            if (actual_error_logs == expected_error_logs) {
+                matched_error_log_count +|= actual_error_logs;
+            }
+            switch (outcome) {
+                .passed => {
+                    ok_count += 1;
+                    std.debug.print("OK\n", .{});
+                },
+                .skipped => {
+                    skip_count += 1;
+                    std.debug.print("SKIP\n", .{});
+                },
+                .failed => fail_count += 1,
+            }
+        }
     }
 
     std.debug.print(
         "{d} passed; {d} skipped; {d} failed; {d} leaked.\n",
         .{ ok_count, skip_count, fail_count, leak_count },
     );
-    const fail_on_error_logs = getenvBool("ANTFLY_TEST_FAIL_ON_ERROR_LOGS");
-    if (log_err_count != 0) {
-        std.debug.print("{d} errors were logged.\n", .{log_err_count});
+    const total_error_log_count = log_err_count.load(.acquire);
+    const unexpected_error_log_count = total_error_log_count -| matched_error_log_count;
+    if (total_error_log_count != 0) {
+        std.debug.print(
+            "{d} errors were logged ({d} expected, {d} unexpected).\n",
+            .{ total_error_log_count, matched_error_log_count, unexpected_error_log_count },
+        );
     }
-    if (fail_count != 0 or leak_count != 0 or (fail_on_error_logs and log_err_count != 0)) {
+    if (fail_count != 0 or leak_count != 0 or
+        (fail_on_error_logs and unexpected_error_log_count != 0))
+    {
         std.process.exit(1);
     }
+}
+
+pub export fn antfly_test_expect_error_logs(count: usize) callconv(.c) void {
+    _ = expected_error_log_count.fetchAdd(count, .monotonic);
 }
 
 fn matchesFilter(name: []const u8) bool {
@@ -244,7 +287,7 @@ pub fn log(
 ) void {
     @disableInstrumentation();
     if (@intFromEnum(message_level) <= @intFromEnum(std.log.Level.err)) {
-        log_err_count +|= 1;
+        _ = log_err_count.fetchAdd(1, .monotonic);
     }
     std.debug.print("[{s}] ({s}): ", .{
         @tagName(message_level),


### PR DESCRIPTION
## Summary

- add exact, per-test expected error-log accounting to the Antfly Zig test runner
- keep unexpected error logs fatal when `ANTFLY_TEST_FAIL_ON_ERROR_LOGS=1`
- preserve the existing non-strict behavior for targets that explicitly disable the error-log gate
- mark only the two restore persistence tests that intentionally exercise production error logging
- count error logs atomically so worker-thread logs are safe to observe

## Why

The restore tests correctly exercise private persistence callback failures, and the production path correctly logs those failures at error level. The strict x86 runner treated all three intentional logs as unexpected after all 22 restore tests had passed. A target-wide exemption would also hide unrelated errors, so this adds a narrow expectation that must match exactly.

Fixes #614.

## Testing

- `ANTFLY_TEST_FAIL_ON_ERROR_LOGS=1 zig build lib-api-restore-jobs-test`
  - 22 passed, 0 failed
  - 3 errors logged: 3 expected, 0 unexpected
- runner contract probes verified exact expectations pass, missing expected logs fail, strict unexpected logs fail, and non-strict unexpected logs retain their prior behavior
