### PR TITLE
fix(inference): gate POSIX file advice on Linux

### DIFF
--- a/zig/pkg/inference/src/util/c_file.zig
+++ b/zig/pkg/inference/src/util/c_file.zig
@@ -24,6 +24,12 @@ const build_options = @import("build_options");
 
 pub const link_libc = build_options.link_libc;
 
+/// `posix_fadvise` is a Linux API despite its name; Darwin does not export the
+/// symbol. Keep capability selection in one compile-time constant so advisory
+/// I/O paths cannot accidentally leave an unresolved reference on another
+/// libc platform.
+pub const supports_posix_file_advice = build_options.link_libc and builtin.os.tag == .linux;
+
 pub const c = if (build_options.link_libc) PosixC else struct {};
 
 const PosixC = struct {
@@ -179,8 +185,7 @@ pub const MmapRegion = struct {
     /// advisory Linux optimization and deliberately cannot fail allocation or
     /// inference when a kernel/filesystem declines either hint.
     pub fn discardFileRange(self: *MmapRegion, offset: usize, len: usize) void {
-        if (!comptime build_options.link_libc) return;
-        if (comptime builtin.os.tag != .linux) return;
+        if (comptime !supports_posix_file_advice) return;
         if (offset >= self.data.len or len == 0) return;
 
         const clamped_len = @min(len, self.data.len - offset);
@@ -210,11 +215,11 @@ pub const MmapRegion = struct {
         // envelope even though the evicted model owns no live memory. Both
         // hints are best effort and affect only clean file-backed pages:
         // anonymous, dirty, writeback, and still-shared pages remain charged.
-        if (self.discard_on_deinit and comptime build_options.link_libc and builtin.os.tag == .linux) {
+        if (self.discard_on_deinit and comptime supports_posix_file_advice) {
             advise(self.data.ptr, mapped_len, .dont_need);
         }
         std.posix.munmap(self.data);
-        if (self.discard_on_deinit and comptime build_options.link_libc and builtin.os.tag == .linux) {
+        if (self.discard_on_deinit and comptime supports_posix_file_advice) {
             _ = c.posix_fadvise(
                 fd,
                 0,
@@ -437,8 +442,7 @@ fn readRegionFromFd(fd: std.posix.fd_t, buf: []u8, offset: u64) !void {
 pub const FileAdvice = enum { normal, sequential, random, will_need, dont_need, no_reuse };
 
 pub fn adviseFileRange(allocator: std.mem.Allocator, path: []const u8, offset: u64, len: usize, advice: FileAdvice) void {
-    if (!comptime build_options.link_libc) return;
-    if (comptime builtin.os.tag != .linux) return;
+    if (comptime !supports_posix_file_advice) return;
     const path_z = allocator.dupeZ(u8, path) catch return;
     defer allocator.free(path_z);
     const fd = openReadOnlyZ(path_z) catch return;
@@ -468,8 +472,7 @@ pub fn prefetchFile(
     path: []const u8,
     requested_workers: u8,
 ) !FilePrefetchResult {
-    if (!comptime build_options.link_libc or builtin.os.tag != .linux)
-        return error.UnsupportedPlatform;
+    if (comptime !supports_posix_file_advice) return error.UnsupportedPlatform;
     const workers: usize = std.math.clamp(@as(usize, requested_workers), 1, 8);
     const path_z = try allocator.dupeZ(u8, path);
     defer allocator.free(path_z);
@@ -782,8 +785,7 @@ test "mmapTempCopy maps unlinked temp data" {
 }
 
 test "prefetchFile reads every byte with bounded workers" {
-    if (!comptime build_options.link_libc or builtin.os.tag != .linux)
-        return error.SkipZigTest;
+    if (comptime !supports_posix_file_advice) return error.SkipZigTest;
     const allocator = std.testing.allocator;
     const path = try std.fmt.allocPrint(
         allocator,


### PR DESCRIPTION
## Summary

- centralize the compile-time capability check for Linux `posix_fadvise`
- compile Linux-only file-advice calls out of Darwin and no-libc builds
- use the same capability guard for range discard, mmap teardown, file advice, prefetch, and the Linux-only prefetch test

## Regression source

PR #592 (`aefb21865`) added `prefetchFile` and changed the mmap teardown checks to combine runtime state with the platform guard. On Darwin, that left a reference to `posix_fadvise`, which libc does not export. The Linux cache-advice behavior is unchanged.

## Testing

- focused Darwin probe before the fix: link failure, `undefined symbol: _posix_fadvise`
- identical probe after the fix: 6 passed, 1 Linux-only test skipped
- `zig build runtime-unit-inference`
- `zig fmt zig/pkg/inference/src/util/c_file.zig`
- `git diff --check`
