### PR TITLE
Preserve artifact indexes during embedding publication

### DIFF
--- a/zig/e2e/antfly/test_artifacts.py
+++ b/zig/e2e/antfly/test_artifacts.py
@@ -1216,6 +1216,192 @@ def test_artifact_backed_embedding_table_provisions_atomically(
     )
 
 
+def test_adding_artifact_embedding_index_preserves_populated_full_text_across_restarts(
+    stateful_api, openai_embedder
+):
+    """A vector backfill must not publish chunk deletes to a sibling text index."""
+
+    table_name = f"artifact_embedding_add_preserves_text_{time.time_ns()}"
+    doc_key = "existing-artifact-document"
+    canary = "artifactcollapsecanary"
+
+    stateful_api.create_table(table_name, num_shards=1)
+    stateful_api.create_index(
+        table_name,
+        "document_text",
+        {
+            "name": "document_text",
+            "type": "full_text",
+            "field": "text",
+            "artifact_name": "document_chunks_v1",
+            "enrichments": [
+                {
+                    "name": DOCUMENT_UNITS_ARTIFACT,
+                    "kind": "asset",
+                    "field": "url",
+                    "content_type": "application/json",
+                    "producer_json": json.dumps(
+                        {
+                            "type": "document_extraction",
+                            "config": {"ocr": {"enabled": False}},
+                        },
+                        separators=(",", ":"),
+                    ),
+                },
+                {
+                    "name": "document_chunks_v1",
+                    "kind": "chunk",
+                    "source_artifact_name": DOCUMENT_UNITS_ARTIFACT,
+                    "field": "text",
+                    "chunk_size": 512,
+                    "chunk_overlap": 0,
+                    "full_text_index": True,
+                },
+            ],
+        },
+    )
+
+    source = f"A stable document containing {canary}.".encode()
+    merged = stateful_api.batch_write(
+        table_name,
+        inserts={
+            doc_key: {
+                "filename": "canary.txt",
+                "mime_type": "text/plain",
+                "version": "1",
+                "url": "data:text/plain;base64,"
+                + base64.b64encode(source).decode(),
+            }
+        },
+        sync_level="full_index",
+    )
+    assert merged["inserted"] == 1
+
+    def text_projection_intact() -> dict | None:
+        detail = stateful_api.get_index(table_name, "document_text")
+        result = stateful_api.query_table(
+            table_name,
+            {
+                "full_text_index": "document_text",
+                "full_text_search": {"field": "text", "match": canary},
+                "limit": 5,
+            },
+        )
+        if detail.get("status", {}).get("doc_count") != 1:
+            return None
+        if doc_key not in _query_hit_ids(result):
+            return None
+        return {"detail": detail, "result": result}
+
+    before_restart = wait_until(
+        text_projection_intact,
+        timeout_s=60.0,
+        interval_s=0.25,
+    )
+    assert before_restart is not None
+    text_incarnation = before_restart["detail"]["status"]["readiness"]["incarnation"]
+
+    stateful_api.restart_server()
+    baseline_restart = wait_until(
+        text_projection_intact,
+        timeout_s=60.0,
+        interval_s=0.25,
+    )
+    assert baseline_restart is not None
+    assert (
+        baseline_restart["detail"]["status"]["readiness"]["incarnation"]
+        == text_incarnation
+    )
+
+    stateful_api.create_index(
+        table_name,
+        "document_vectors",
+        {
+            "name": "document_vectors",
+            "type": "embeddings",
+            "field": "embedding",
+            "dimension": 3,
+            "distance_metric": "cosine",
+            "embedding_name": "document_chunk_dense_v1",
+            "source_artifact_name": "document_chunks_v1",
+            "embedder": {
+                "provider": "openai",
+                "model": "text-embedding-3-small",
+                "url": openai_embedder,
+            },
+            "enrichments": [
+                {
+                    "name": "document_chunk_dense_v1",
+                    "kind": "embedding",
+                    "field": "text",
+                    "source_artifact_name": "document_chunks_v1",
+                    "expected_dims": 3,
+                }
+            ],
+        },
+    )
+    vector_ready = wait_until(
+        lambda: (
+            detail
+            if (detail := stateful_api.get_index(table_name, "document_vectors"))
+            .get("status", {})
+            .get("readiness", {})
+            .get("queryable")
+            is True
+            and detail["status"].get("doc_count") == 1
+            else None
+        ),
+        timeout_s=120.0,
+        interval_s=0.5,
+    )
+    assert vector_ready is not None, json.dumps(
+        stateful_api.get_index(table_name, "document_vectors"),
+        indent=2,
+        sort_keys=True,
+    )
+    assert (
+        wait_until(
+            lambda: (
+                result
+                if doc_key
+                in _query_hit_ids(
+                    result := stateful_api.query_table(
+                        table_name,
+                        {
+                            "semantic_search": canary,
+                            "indexes": ["document_vectors"],
+                            "limit": 5,
+                        },
+                    )
+                )
+                else None
+            ),
+            timeout_s=60.0,
+            interval_s=0.5,
+        )
+        is not None
+    )
+
+    after_embedding_add = text_projection_intact()
+    assert after_embedding_add is not None
+    assert (
+        after_embedding_add["detail"]["status"]["readiness"]["incarnation"]
+        == text_incarnation
+    )
+
+    stateful_api.restart_server()
+    after_final_restart = wait_until(
+        text_projection_intact,
+        timeout_s=60.0,
+        interval_s=0.25,
+    )
+    assert after_final_restart is not None
+    assert (
+        after_final_restart["detail"]["status"]["readiness"]["incarnation"]
+        == text_incarnation
+    )
+
+
 def test_embedding_producer_registry_rejects_orphans_and_owner_mismatches(
     stateful_api, openai_embedder
 ):

--- a/zig/pkg/antfly/src/storage/db/catalog/index_manager.zig
+++ b/zig/pkg/antfly/src/storage/db/catalog/index_manager.zig
@@ -10808,6 +10808,25 @@ pub const IndexManager = struct {
         return .projection_changed;
     }
 
+    /// Return whether `key` belongs to the source projection captured by
+    /// `context`. The caller must hold the catalog shared lock, normally
+    /// through a ManagedIndexApplyGuard. Replay delete lanes are shared by
+    /// all derived index kinds, so an artifact-backed text index must filter
+    /// them by the same source predicate used for indexing writes.
+    pub fn textPublicationContextConsumesKeyAssumeCatalogLocked(
+        self: *IndexManager,
+        index_name: []const u8,
+        context: TextPublicationContext,
+        key: []const u8,
+    ) !bool {
+        const entry = self.textIndexEntry(index_name) orelse return error.IndexNotFound;
+        if (entry.instance_id != context.instance_id) return error.IndexNotFound;
+        entry.lockAnalysisShared();
+        defer entry.unlockAnalysisShared();
+        if (entry.projection_revision != context.projection_revision) return error.IndexNotFound;
+        return try textIndexShouldConsumeDoc(self, entry, key);
+    }
+
     /// Plan the natural segment fan-out before producer admission. Projection
     /// is repeated during publication, but tokenization and segment construction
     /// still happen only once. Using the same source and segment splitters as

--- a/zig/pkg/antfly/src/storage/db/db.zig
+++ b/zig/pkg/antfly/src/storage/db/db.zig
@@ -44528,13 +44528,6 @@ fn applyDerivedBatchToIndexContextProfiled(ctx: *const AsyncContext, batch: deri
         };
         var publication_context = try ctx.index_manager.acquireTextPublicationContext(ctx.alloc, index_ref.name);
         defer publication_context.deinit();
-        const delete_keys = try collectTextReplayDeleteKeys(
-            ctx.alloc,
-            batch,
-            index_ref.name,
-            publication_context.chunk_backed,
-        );
-        defer if (delete_keys.len > 0) ctx.alloc.free(delete_keys);
         var collected = try collectTextDocumentWritesForIndex(
             ctx.alloc,
             ctx.store,
@@ -44591,10 +44584,21 @@ fn applyDerivedBatchToIndexContextProfiled(ctx: *const AsyncContext, batch: deri
                 if (before_apply == .projection_changed) {
                     replan_suffix = true;
                 } else {
+                    const delete_keys = if (applied_first_chunk)
+                        &.{}
+                    else
+                        try collectTextReplayDeleteKeys(
+                            ctx.alloc,
+                            ctx.index_manager,
+                            batch,
+                            index_ref.name,
+                            publication_context,
+                        );
+                    defer if (delete_keys.len > 0) ctx.alloc.free(delete_keys);
                     try ctx.index_manager.applyTextBatchByNameWithOptions(
                         ctx.store,
                         index_ref.name,
-                        if (applied_first_chunk) &.{} else delete_keys,
+                        delete_keys,
                         write_chunk,
                         text_replay_options,
                     );
@@ -44652,7 +44656,21 @@ fn applyDerivedBatchToIndexContextProfiled(ctx: *const AsyncContext, batch: deri
             try ctx.index_manager.validateDenseEmbeddingArtifactsByName(ctx.store, index_ref.name, dense_embeddings.writes);
 
             const dense_delete_start_ns = monotonicTimeNs();
+            const targeted_delete_keys = try collectTargetedDocumentDeleteKeys(
+                ctx.alloc,
+                batch.documents,
+                .dense_vector,
+                index_ref.name,
+            );
+            defer if (targeted_delete_keys.len > 0) ctx.alloc.free(targeted_delete_keys);
+            // A dense upsert is a replacement only inside the index named by
+            // the embedding write. Deriving the delete after per-index
+            // filtering keeps that intent out of the batch-wide delete lane.
+            const replacement_keys = try collectDenseEmbeddingReplacementKeys(ctx.alloc, dense_embeddings.writes);
+            defer if (replacement_keys.len > 0) ctx.alloc.free(replacement_keys);
             try ctx.index_manager.deleteDenseBatchByNameWithOptions(ctx.store, index_ref.name, batch.deleted_keys, batch_options);
+            try ctx.index_manager.deleteDenseBatchByNameWithOptions(ctx.store, index_ref.name, targeted_delete_keys, batch_options);
+            try ctx.index_manager.deleteDenseBatchByNameWithOptions(ctx.store, index_ref.name, replacement_keys, batch_options);
             const chunk_backed = if (ctx.index_manager.denseIndex(index_ref.name)) |entry|
                 entry.chunk_name != null
             else
@@ -44731,7 +44749,15 @@ fn applyDerivedBatchToIndexContextProfiled(ctx: *const AsyncContext, batch: deri
             try ctx.index_manager.validateSparseEmbeddingArtifactsByName(ctx.store, index_ref.name, sparse_embeddings.writes);
 
             const sparse_delete_start_ns = if (emit_sparse_write_profile) monotonicTimeNs() else 0;
+            const targeted_delete_keys = try collectTargetedDocumentDeleteKeys(
+                ctx.alloc,
+                batch.documents,
+                .sparse_vector,
+                index_ref.name,
+            );
+            defer if (targeted_delete_keys.len > 0) ctx.alloc.free(targeted_delete_keys);
             try ctx.index_manager.deleteSparseBatchByNameWithOptions(index_ref.name, batch.deleted_keys, batch_options);
+            try ctx.index_manager.deleteSparseBatchByNameWithOptions(index_ref.name, targeted_delete_keys, batch_options);
             try ctx.index_manager.deleteSparseBatchByNameWithOptions(index_ref.name, batch.overwritten_doc_keys, batch_options);
             try deleteDerivedCoverageForDocKeys(ctx.alloc, ctx.store, ctx.index_manager, index_ref.name, batch.deleted_keys);
             try deleteDerivedCoverageForDocKeys(ctx.alloc, ctx.store, ctx.index_manager, index_ref.name, batch.overwritten_doc_keys);
@@ -44890,15 +44916,25 @@ fn managedIndexBatchApplicability(
     index_ref: index_manager_mod.ManagedIndexRef,
 ) ManagedIndexBatchApplicability {
     switch (index_ref.kind) {
-        .full_text, .algebraic => {
+        .full_text => {
             if (batch.deleted_keys.len > 0 or batch.overwritten_doc_keys.len > 0) return .relevant;
             for (batch.documents) |doc| {
-                if (doc.action == .upsert) return .relevant;
+                if (doc.action == .upsert or documentTargetsManagedIndex(doc, .full_text, index_ref.name)) return .relevant;
+            }
+            return .irrelevant;
+        },
+        .algebraic => {
+            if (batch.deleted_keys.len > 0 or batch.overwritten_doc_keys.len > 0) return .relevant;
+            for (batch.documents) |doc| {
+                if (doc.action == .upsert or documentTargetsManagedIndex(doc, .algebraic, index_ref.name)) return .relevant;
             }
             return .irrelevant;
         },
         .dense_vector => {
             if (batch.deleted_keys.len > 0 or batch.overwritten_doc_keys.len > 0) return .relevant;
+            for (batch.documents) |doc| {
+                if (documentTargetsManagedIndex(doc, .dense_vector, index_ref.name)) return .relevant;
+            }
             const uses_artifact_members = index_manager.denseIndexUsesArtifactMembers(index_ref.name);
             if (!uses_artifact_members) {
                 for (batch.documents) |doc| {
@@ -44916,6 +44952,9 @@ fn managedIndexBatchApplicability(
         },
         .sparse_vector => {
             if (batch.deleted_keys.len > 0 or batch.overwritten_doc_keys.len > 0) return .relevant;
+            for (batch.documents) |doc| {
+                if (documentTargetsManagedIndex(doc, .sparse_vector, index_ref.name)) return .relevant;
+            }
             const uses_artifact_members = index_manager.sparseIndexUsesArtifactMembers(index_ref.name);
             if (!uses_artifact_members) {
                 for (batch.documents) |doc| {
@@ -45010,6 +45049,10 @@ fn batchAdvancesManagedIndexApplyState(
     switch (index_ref.kind) {
         .dense_vector, .sparse_vector => {
             if (batch.deleted_keys.len > 0 or batch.overwritten_doc_keys.len > 0) return true;
+            const target_kind: derived_types.DerivedTarget = if (index_ref.kind == .dense_vector) .dense_vector else .sparse_vector;
+            for (batch.documents) |doc| {
+                if (doc.action == .delete and documentTargetsManagedIndex(doc, target_kind, index_ref.name)) return true;
+            }
             const artifact_backed_dense = if (index_ref.kind == .dense_vector)
                 if (index_manager.denseIndex(index_ref.name)) |entry| denseIndexIsArtifactBacked(entry) else false
             else
@@ -45603,19 +45646,26 @@ fn appendUniqueBorrowedKeyWithSet(
 
 fn collectTextReplayDeleteKeys(
     alloc: Allocator,
+    index_manager: *index_manager_mod.IndexManager,
     batch: derived_types.DerivedBatch,
     index_name: []const u8,
-    chunk_backed: bool,
+    publication_context: index_manager_mod.TextPublicationContext,
 ) ![]const []const u8 {
     var keys = std.ArrayListUnmanaged([]const u8).empty;
     errdefer keys.deinit(alloc);
     var seen = std.StringHashMapUnmanaged(void).empty;
     defer seen.deinit(alloc);
 
-    for (batch.deleted_keys) |key| try appendUniqueBorrowedKeyWithSet(alloc, &keys, &seen, key);
-    for (batch.overwritten_doc_keys) |key| try appendUniqueBorrowedKeyWithSet(alloc, &keys, &seen, key);
+    for (batch.deleted_keys) |key| {
+        if (!try index_manager.textPublicationContextConsumesKeyAssumeCatalogLocked(index_name, publication_context, key)) continue;
+        try appendUniqueBorrowedKeyWithSet(alloc, &keys, &seen, key);
+    }
+    for (batch.overwritten_doc_keys) |key| {
+        if (!try index_manager.textPublicationContextConsumesKeyAssumeCatalogLocked(index_name, publication_context, key)) continue;
+        try appendUniqueBorrowedKeyWithSet(alloc, &keys, &seen, key);
+    }
     for (batch.documents) |doc| {
-        if (doc.action == .delete and !documentTargetsTextIndex(doc, index_name, chunk_backed)) continue;
+        if (!documentTargetsTextIndex(doc, index_name, publication_context.chunk_backed)) continue;
         try appendUniqueBorrowedKeyWithSet(alloc, &keys, &seen, doc.key);
     }
 
@@ -45837,6 +45887,52 @@ fn documentTargetsTextIndex(doc: derived_types.DerivedDocument, index_name: []co
         if (!is_chunk_index and std.mem.eql(u8, target.index_name, "*")) return true;
     }
     return false;
+}
+
+fn documentTargetsManagedIndex(
+    doc: derived_types.DerivedDocument,
+    kind: derived_types.DerivedTarget,
+    index_name: []const u8,
+) bool {
+    for (doc.targets) |target| {
+        if (target.kind != kind) continue;
+        if (std.mem.eql(u8, target.index_name, index_name)) return true;
+    }
+    return false;
+}
+
+fn collectTargetedDocumentDeleteKeys(
+    alloc: Allocator,
+    documents: []const derived_types.DerivedDocument,
+    kind: derived_types.DerivedTarget,
+    index_name: []const u8,
+) ![]const []const u8 {
+    var keys = std.ArrayListUnmanaged([]const u8).empty;
+    errdefer keys.deinit(alloc);
+    var seen = std.StringHashMapUnmanaged(void).empty;
+    defer seen.deinit(alloc);
+
+    for (documents) |doc| {
+        if (doc.action != .delete) continue;
+        if (!documentTargetsManagedIndex(doc, kind, index_name)) continue;
+        try appendUniqueBorrowedKeyWithSet(alloc, &keys, &seen, doc.key);
+    }
+    return try keys.toOwnedSlice(alloc);
+}
+
+fn collectDenseEmbeddingReplacementKeys(
+    alloc: Allocator,
+    embeddings: []const mapper.DenseEmbeddingWrite,
+) ![]const []const u8 {
+    var keys = std.ArrayListUnmanaged([]const u8).empty;
+    errdefer keys.deinit(alloc);
+    var seen = std.StringHashMapUnmanaged(void).empty;
+    defer seen.deinit(alloc);
+
+    for (embeddings) |embedding| {
+        try appendUniqueBorrowedKeyWithSet(alloc, &keys, &seen, embedding.doc_key);
+    }
+    return try keys.toOwnedSlice(alloc);
 }
 
 fn collectDenseEmbeddingWrites(alloc: Allocator, embeddings: []const derived_types.DerivedDenseEmbeddingWrite, index_name: []const u8) ![]mapper.DenseEmbeddingWrite {
@@ -72358,6 +72454,96 @@ test "db preflight classifies canonical artifact full-text sources consistently"
     var publication = try db.core.index_manager.acquireTextPublicationContext(alloc, "artifact_text");
     defer publication.deinit();
     try std.testing.expect(publication.chunk_backed);
+}
+
+test "artifact text replay deletes only keys owned by its source projection" {
+    const alloc = std.testing.allocator;
+
+    var path_buf: [256]u8 = undefined;
+    const path = tempPath(&path_buf);
+    defer cleanupTempDir(path);
+
+    var db = try DB.open(alloc, std.mem.span(path), .{});
+    defer db.close();
+
+    try db.addEnrichment(.{
+        .name = "body_chunks_v1",
+        .kind = .chunk,
+        .field = "body",
+        .chunk_size = 64,
+    });
+    try db.addEnrichment(.{
+        .name = "notes_chunks_v1",
+        .kind = .chunk,
+        .field = "notes",
+        .chunk_size = 64,
+    });
+    try db.addIndex(.{
+        .name = "body_text",
+        .kind = .full_text,
+        .config_json = "{\"sources\":[{\"artifact\":\"body_chunks_v1\"}]}",
+    });
+
+    const body_key = try internal_keys.chunkArtifactKeyAlloc(alloc, "doc-a", "body_chunks_v1", 0);
+    defer alloc.free(body_key);
+    const notes_key = try internal_keys.chunkArtifactKeyAlloc(alloc, "doc-a", "notes_chunks_v1", 0);
+    defer alloc.free(notes_key);
+
+    const body_target = [_]derived_types.DerivedTargetRef{.{
+        .kind = .full_text,
+        .index_name = "body_text",
+    }};
+    const other_target = [_]derived_types.DerivedTargetRef{.{
+        .kind = .full_text,
+        .index_name = "notes_text",
+    }};
+    const replay_deletes = [_][]const u8{ body_key, notes_key, "doc-a" };
+    const replay_overwrites = [_][]const u8{ notes_key, "doc-b" };
+    const replay_documents = [_]derived_types.DerivedDocument{
+        .{ .key = body_key, .action = .upsert, .targets = &body_target },
+        .{ .key = notes_key, .action = .upsert, .targets = &other_target },
+    };
+
+    var publication = try db.core.index_manager.acquireTextPublicationContext(alloc, "body_text");
+    defer publication.deinit();
+    var apply_guard = try db.core.index_manager.lockManagedIndexApply(.{
+        .name = "body_text",
+        .kind = .full_text,
+    });
+    defer apply_guard.unlock();
+    const keys = try collectTextReplayDeleteKeys(
+        alloc,
+        db.core.index_manager,
+        .{
+            .deleted_keys = &replay_deletes,
+            .overwritten_doc_keys = &replay_overwrites,
+            .documents = &replay_documents,
+        },
+        "body_text",
+        publication,
+    );
+    defer alloc.free(keys);
+
+    try std.testing.expectEqual(@as(usize, 1), keys.len);
+    try std.testing.expectEqualStrings(body_key, keys[0]);
+
+    const dense_delete_target = [_]derived_types.DerivedTargetRef{.{
+        .kind = .dense_vector,
+        .index_name = "document_vectors",
+    }};
+    const targeted_delete = [_]derived_types.DerivedDocument{.{
+        .key = body_key,
+        .action = .delete,
+        .targets = &dense_delete_target,
+    }};
+    var record = try change_journal_mod.recordFromDerivedBatch(alloc, .{
+        .documents = &targeted_delete,
+    }, 7);
+    defer change_journal_mod.deinitRecord(alloc, &record);
+    try std.testing.expectEqual(@as(usize, 1), record.deleted_doc_keys.len);
+    try std.testing.expectEqualStrings(body_key, record.deleted_doc_keys[0]);
+    try std.testing.expect(journalRecordHasHint(record, .dense_vector));
+    try std.testing.expect(!journalRecordHasHint(record, .full_text));
 }
 
 test "db preflightSearchRequest validates live lane bindings" {

--- a/zig/pkg/antfly/src/storage/db/db.zig
+++ b/zig/pkg/antfly/src/storage/db/db.zig
@@ -78306,13 +78306,25 @@ test "collectDocumentWrites skips missing out-of-range replay docs" {
 test "text replay delete keys include upserted derived document keys" {
     const alloc = std.testing.allocator;
 
+    var path_buf: [256]u8 = undefined;
+    const path = tempPath(&path_buf);
+    defer cleanupTempDir(path);
+
+    var db = try DB.open(alloc, std.mem.span(path), .{});
+    defer db.close();
+    try db.addIndex(.{
+        .name = "selected_text",
+        .kind = .full_text,
+        .config_json = "{}",
+    });
+
     const selected_target = [_]derived_types.DerivedTargetRef{.{ .kind = .full_text, .index_name = "selected_text" }};
     const other_target = [_]derived_types.DerivedTargetRef{.{ .kind = .full_text, .index_name = "other_text" }};
     const docs = [_]derived_types.DerivedDocument{
-        .{ .key = "chunk:1", .action = .upsert, .cleaned_value = "{\"text\":\"new\"}" },
+        .{ .key = "chunk:1", .action = .upsert, .cleaned_value = "{\"text\":\"new\"}", .targets = &selected_target },
         .{ .key = "deleted:2", .action = .delete, .targets = &selected_target },
         .{ .key = "ignored", .action = .delete, .targets = &other_target },
-        .{ .key = "chunk:1", .action = .upsert, .cleaned_value = "{\"text\":\"newer\"}" },
+        .{ .key = "chunk:1", .action = .upsert, .cleaned_value = "{\"text\":\"newer\"}", .targets = &selected_target },
     };
     const deleted = [_][]const u8{"deleted:1"};
     const overwritten = [_][]const u8{ "chunk:1", "overwritten:1" };
@@ -78322,7 +78334,20 @@ test "text replay delete keys include upserted derived document keys" {
         .overwritten_doc_keys = &overwritten,
     };
 
-    const keys = try collectTextReplayDeleteKeys(alloc, batch, "selected_text", true);
+    var publication = try db.core.index_manager.acquireTextPublicationContext(alloc, "selected_text");
+    defer publication.deinit();
+    var apply_guard = try db.core.index_manager.lockManagedIndexApply(.{
+        .name = "selected_text",
+        .kind = .full_text,
+    });
+    defer apply_guard.unlock();
+    const keys = try collectTextReplayDeleteKeys(
+        alloc,
+        db.core.index_manager,
+        batch,
+        "selected_text",
+        publication,
+    );
     defer alloc.free(keys);
 
     try std.testing.expectEqual(@as(usize, 4), keys.len);

--- a/zig/pkg/antfly/src/storage/db/db.zig
+++ b/zig/pkg/antfly/src/storage/db/db.zig
@@ -44656,20 +44656,19 @@ fn applyDerivedBatchToIndexContextProfiled(ctx: *const AsyncContext, batch: deri
             try ctx.index_manager.validateDenseEmbeddingArtifactsByName(ctx.store, index_ref.name, dense_embeddings.writes);
 
             const dense_delete_start_ns = monotonicTimeNs();
-            const targeted_delete_keys = try collectTargetedDocumentDeleteKeys(
+            const replay_delete_keys = try collectVectorReplayDeleteKeys(
                 ctx.alloc,
-                batch.documents,
-                .dense_vector,
-                index_ref.name,
+                ctx.index_manager,
+                index_ref,
+                batch.deleted_keys,
             );
-            defer if (targeted_delete_keys.len > 0) ctx.alloc.free(targeted_delete_keys);
+            defer freeOwnedKeySlice(ctx.alloc, replay_delete_keys);
             // A dense upsert is a replacement only inside the index named by
             // the embedding write. Deriving the delete after per-index
             // filtering keeps that intent out of the batch-wide delete lane.
             const replacement_keys = try collectDenseEmbeddingReplacementKeys(ctx.alloc, dense_embeddings.writes);
             defer if (replacement_keys.len > 0) ctx.alloc.free(replacement_keys);
-            try ctx.index_manager.deleteDenseBatchByNameWithOptions(ctx.store, index_ref.name, batch.deleted_keys, batch_options);
-            try ctx.index_manager.deleteDenseBatchByNameWithOptions(ctx.store, index_ref.name, targeted_delete_keys, batch_options);
+            try ctx.index_manager.deleteDenseBatchByNameWithOptions(ctx.store, index_ref.name, replay_delete_keys, batch_options);
             try ctx.index_manager.deleteDenseBatchByNameWithOptions(ctx.store, index_ref.name, replacement_keys, batch_options);
             const chunk_backed = if (ctx.index_manager.denseIndex(index_ref.name)) |entry|
                 entry.chunk_name != null
@@ -44749,15 +44748,14 @@ fn applyDerivedBatchToIndexContextProfiled(ctx: *const AsyncContext, batch: deri
             try ctx.index_manager.validateSparseEmbeddingArtifactsByName(ctx.store, index_ref.name, sparse_embeddings.writes);
 
             const sparse_delete_start_ns = if (emit_sparse_write_profile) monotonicTimeNs() else 0;
-            const targeted_delete_keys = try collectTargetedDocumentDeleteKeys(
+            const replay_delete_keys = try collectVectorReplayDeleteKeys(
                 ctx.alloc,
-                batch.documents,
-                .sparse_vector,
-                index_ref.name,
+                ctx.index_manager,
+                index_ref,
+                batch.deleted_keys,
             );
-            defer if (targeted_delete_keys.len > 0) ctx.alloc.free(targeted_delete_keys);
-            try ctx.index_manager.deleteSparseBatchByNameWithOptions(index_ref.name, batch.deleted_keys, batch_options);
-            try ctx.index_manager.deleteSparseBatchByNameWithOptions(index_ref.name, targeted_delete_keys, batch_options);
+            defer freeOwnedKeySlice(ctx.alloc, replay_delete_keys);
+            try ctx.index_manager.deleteSparseBatchByNameWithOptions(index_ref.name, replay_delete_keys, batch_options);
             try ctx.index_manager.deleteSparseBatchByNameWithOptions(index_ref.name, batch.overwritten_doc_keys, batch_options);
             try deleteDerivedCoverageForDocKeys(ctx.alloc, ctx.store, ctx.index_manager, index_ref.name, batch.deleted_keys);
             try deleteDerivedCoverageForDocKeys(ctx.alloc, ctx.store, ctx.index_manager, index_ref.name, batch.overwritten_doc_keys);
@@ -44916,25 +44914,15 @@ fn managedIndexBatchApplicability(
     index_ref: index_manager_mod.ManagedIndexRef,
 ) ManagedIndexBatchApplicability {
     switch (index_ref.kind) {
-        .full_text => {
+        .full_text, .algebraic => {
             if (batch.deleted_keys.len > 0 or batch.overwritten_doc_keys.len > 0) return .relevant;
             for (batch.documents) |doc| {
-                if (doc.action == .upsert or documentTargetsManagedIndex(doc, .full_text, index_ref.name)) return .relevant;
-            }
-            return .irrelevant;
-        },
-        .algebraic => {
-            if (batch.deleted_keys.len > 0 or batch.overwritten_doc_keys.len > 0) return .relevant;
-            for (batch.documents) |doc| {
-                if (doc.action == .upsert or documentTargetsManagedIndex(doc, .algebraic, index_ref.name)) return .relevant;
+                if (doc.action == .upsert) return .relevant;
             }
             return .irrelevant;
         },
         .dense_vector => {
             if (batch.deleted_keys.len > 0 or batch.overwritten_doc_keys.len > 0) return .relevant;
-            for (batch.documents) |doc| {
-                if (documentTargetsManagedIndex(doc, .dense_vector, index_ref.name)) return .relevant;
-            }
             const uses_artifact_members = index_manager.denseIndexUsesArtifactMembers(index_ref.name);
             if (!uses_artifact_members) {
                 for (batch.documents) |doc| {
@@ -44952,9 +44940,6 @@ fn managedIndexBatchApplicability(
         },
         .sparse_vector => {
             if (batch.deleted_keys.len > 0 or batch.overwritten_doc_keys.len > 0) return .relevant;
-            for (batch.documents) |doc| {
-                if (documentTargetsManagedIndex(doc, .sparse_vector, index_ref.name)) return .relevant;
-            }
             const uses_artifact_members = index_manager.sparseIndexUsesArtifactMembers(index_ref.name);
             if (!uses_artifact_members) {
                 for (batch.documents) |doc| {
@@ -45049,10 +45034,6 @@ fn batchAdvancesManagedIndexApplyState(
     switch (index_ref.kind) {
         .dense_vector, .sparse_vector => {
             if (batch.deleted_keys.len > 0 or batch.overwritten_doc_keys.len > 0) return true;
-            const target_kind: derived_types.DerivedTarget = if (index_ref.kind == .dense_vector) .dense_vector else .sparse_vector;
-            for (batch.documents) |doc| {
-                if (doc.action == .delete and documentTargetsManagedIndex(doc, target_kind, index_ref.name)) return true;
-            }
             const artifact_backed_dense = if (index_ref.kind == .dense_vector)
                 if (index_manager.denseIndex(index_ref.name)) |entry| denseIndexIsArtifactBacked(entry) else false
             else
@@ -45889,33 +45870,34 @@ fn documentTargetsTextIndex(doc: derived_types.DerivedDocument, index_name: []co
     return false;
 }
 
-fn documentTargetsManagedIndex(
-    doc: derived_types.DerivedDocument,
-    kind: derived_types.DerivedTarget,
-    index_name: []const u8,
-) bool {
-    for (doc.targets) |target| {
-        if (target.kind != kind) continue;
-        if (std.mem.eql(u8, target.index_name, index_name)) return true;
-    }
-    return false;
-}
-
-fn collectTargetedDocumentDeleteKeys(
+fn collectVectorReplayDeleteKeys(
     alloc: Allocator,
-    documents: []const derived_types.DerivedDocument,
-    kind: derived_types.DerivedTarget,
-    index_name: []const u8,
-) ![]const []const u8 {
-    var keys = std.ArrayListUnmanaged([]const u8).empty;
-    errdefer keys.deinit(alloc);
+    index_manager: *index_manager_mod.IndexManager,
+    index_ref: index_manager_mod.ManagedIndexRef,
+    deleted_keys: []const []const u8,
+) ![][]u8 {
+    std.debug.assert(index_ref.kind == .dense_vector or index_ref.kind == .sparse_vector);
+    var keys = std.ArrayListUnmanaged([]u8).empty;
+    errdefer {
+        for (keys.items) |key| alloc.free(key);
+        keys.deinit(alloc);
+    }
     var seen = std.StringHashMapUnmanaged(void).empty;
     defer seen.deinit(alloc);
 
-    for (documents) |doc| {
-        if (doc.action != .delete) continue;
-        if (!documentTargetsManagedIndex(doc, kind, index_name)) continue;
-        try appendUniqueBorrowedKeyWithSet(alloc, &keys, &seen, doc.key);
+    for (deleted_keys) |key| {
+        if (!internal_keys.isEmbeddingArtifactKey(key) and !internal_keys.isDerivedEmbeddingArtifactKey(key)) {
+            try appendUniqueOwnedKeyIndexed(alloc, &keys, &seen, key);
+            continue;
+        }
+
+        var identity = artifact_ids.decodeEmbeddingArtifactIdentityAlloc(alloc, key) catch |err| switch (err) {
+            error.InvalidInternalUserKey => continue,
+            else => return err,
+        } orelse continue;
+        defer identity.deinit(alloc);
+        if (!managedIndexConsumesEmbeddingName(index_manager, index_ref, identity.embedding_name)) continue;
+        try appendUniqueOwnedKeyIndexed(alloc, &keys, &seen, identity.doc_key);
     }
     return try keys.toOwnedSlice(alloc);
 }
@@ -72526,24 +72508,53 @@ test "artifact text replay deletes only keys owned by its source projection" {
 
     try std.testing.expectEqual(@as(usize, 1), keys.len);
     try std.testing.expectEqualStrings(body_key, keys[0]);
+}
 
-    const dense_delete_target = [_]derived_types.DerivedTargetRef{.{
+test "embedding artifact replay deletes only the consuming vector projection" {
+    const alloc = std.testing.allocator;
+
+    var path_buf: [256]u8 = undefined;
+    const path = tempPath(&path_buf);
+    defer cleanupTempDir(path);
+
+    var db = try DB.open(alloc, std.mem.span(path), .{});
+    defer db.close();
+
+    try db.addIndex(.{
+        .name = "dense_a",
         .kind = .dense_vector,
-        .index_name = "document_vectors",
-    }};
-    const targeted_delete = [_]derived_types.DerivedDocument{.{
-        .key = body_key,
-        .action = .delete,
-        .targets = &dense_delete_target,
-    }};
-    var record = try change_journal_mod.recordFromDerivedBatch(alloc, .{
-        .documents = &targeted_delete,
-    }, 7);
-    defer change_journal_mod.deinitRecord(alloc, &record);
-    try std.testing.expectEqual(@as(usize, 1), record.deleted_doc_keys.len);
-    try std.testing.expectEqualStrings(body_key, record.deleted_doc_keys[0]);
-    try std.testing.expect(journalRecordHasHint(record, .dense_vector));
-    try std.testing.expect(!journalRecordHasHint(record, .full_text));
+        .config_json = "{\"field\":\"embedding\",\"dims\":3,\"generator\":{\"kind\":\"dense_embedding\",\"source_field\":\"body\",\"chunk_name\":\"shared_chunks_v1\",\"chunk_size\":64,\"embedding_name\":\"embedding_a\"}}",
+    });
+    try db.addIndex(.{
+        .name = "dense_b",
+        .kind = .dense_vector,
+        .config_json = "{\"field\":\"embedding\",\"dims\":3,\"generator\":{\"kind\":\"dense_embedding\",\"source_field\":\"body\",\"chunk_name\":\"shared_chunks_v1\",\"chunk_size\":64,\"embedding_name\":\"embedding_b\"}}",
+    });
+
+    const chunk_key = try internal_keys.chunkArtifactKeyAlloc(alloc, "doc-a", "shared_chunks_v1", 0);
+    defer alloc.free(chunk_key);
+    const embedding_a_key = try internal_keys.derivedEmbeddingArtifactKeyAlloc(alloc, chunk_key, "embedding_a");
+    defer alloc.free(embedding_a_key);
+    const deleted_keys = [_][]const u8{embedding_a_key};
+
+    const dense_a_deletes = try collectVectorReplayDeleteKeys(
+        alloc,
+        db.core.index_manager,
+        .{ .name = "dense_a", .kind = .dense_vector },
+        &deleted_keys,
+    );
+    defer freeOwnedKeySlice(alloc, dense_a_deletes);
+    try std.testing.expectEqual(@as(usize, 1), dense_a_deletes.len);
+    try std.testing.expectEqualStrings(chunk_key, dense_a_deletes[0]);
+
+    const dense_b_deletes = try collectVectorReplayDeleteKeys(
+        alloc,
+        db.core.index_manager,
+        .{ .name = "dense_b", .kind = .dense_vector },
+        &deleted_keys,
+    );
+    defer freeOwnedKeySlice(alloc, dense_b_deletes);
+    try std.testing.expectEqual(@as(usize, 0), dense_b_deletes.len);
 }
 
 test "db preflightSearchRequest validates live lane bindings" {

--- a/zig/pkg/antfly/src/storage/db/derived/change_journal.zig
+++ b/zig/pkg/antfly/src/storage/db/derived/change_journal.zig
@@ -199,7 +199,6 @@ pub fn recordFromDerivedBatch(alloc: Allocator, batch: derived_types.DerivedBatc
 
     for (batch.documents) |doc| {
         if (doc.action == .upsert) try appendUniqueString(alloc, &changed_doc_keys, doc.key);
-        if (doc.action == .delete) try appendUniqueString(alloc, &deleted_doc_keys, doc.key);
         if (doc.action == .upsert) {
             try appendUniqueHintAlloc(alloc, &target_hints, .dense_vector);
             try appendUniqueHintAlloc(alloc, &target_hints, .sparse_vector);

--- a/zig/pkg/antfly/src/storage/db/derived/change_journal.zig
+++ b/zig/pkg/antfly/src/storage/db/derived/change_journal.zig
@@ -199,6 +199,7 @@ pub fn recordFromDerivedBatch(alloc: Allocator, batch: derived_types.DerivedBatc
 
     for (batch.documents) |doc| {
         if (doc.action == .upsert) try appendUniqueString(alloc, &changed_doc_keys, doc.key);
+        if (doc.action == .delete) try appendUniqueString(alloc, &deleted_doc_keys, doc.key);
         if (doc.action == .upsert) {
             try appendUniqueHintAlloc(alloc, &target_hints, .dense_vector);
             try appendUniqueHintAlloc(alloc, &target_hints, .sparse_vector);

--- a/zig/pkg/antfly/src/storage/db/enrichment/enrichment_runtime.zig
+++ b/zig/pkg/antfly/src/storage/db/enrichment/enrichment_runtime.zig
@@ -1897,11 +1897,9 @@ fn requestUsesMaterializedChunkArtifact(
 }
 
 const StaleEmbeddingDeletes = struct {
-    vector_keys: [][]u8 = &.{},
     artifact_delete_keys: [][]u8 = &.{},
 
     fn deinit(self: *@This(), alloc: Allocator) void {
-        freeKeyList(alloc, self.vector_keys);
         freeKeyList(alloc, self.artifact_delete_keys);
         self.* = .{};
     }
@@ -9025,10 +9023,6 @@ fn processMaterializedChunkDenseRequest(
 
     for (existing_embedding_keys.items) |embedding_key| {
         if (try derivedEmbeddingBelongsToDesiredChunkSet(runtime.alloc, embedding_key, &desired_chunk_keys)) continue;
-        if (try internal_keys.derivedEmbeddingBaseKeyAlloc(runtime.alloc, embedding_key)) |base_key| {
-            defer runtime.alloc.free(base_key);
-            try appendTargetedDeleteDocumentToWindow(runtime, window, base_key, .dense_vector, consumer_indexes);
-        }
         try appendUniqueDupeKey(runtime.alloc, &window.artifact_delete_keys, embedding_key);
         try flushGeneratedReplayWindowIfNeeded(runtime, window, max_window_items);
     }
@@ -9245,10 +9239,6 @@ fn processMaterializedChunkSparseRequest(
 
     for (existing_embedding_keys.items) |embedding_key| {
         if (try derivedEmbeddingBelongsToDesiredChunkSet(runtime.alloc, embedding_key, &desired_chunk_keys)) continue;
-        if (try internal_keys.derivedEmbeddingBaseKeyAlloc(runtime.alloc, embedding_key)) |base_key| {
-            defer runtime.alloc.free(base_key);
-            try appendTargetedDeleteDocumentToWindow(runtime, window, base_key, .sparse_vector, consumer_indexes);
-        }
         try appendUniqueDupeKey(runtime.alloc, &window.artifact_delete_keys, embedding_key);
         try flushGeneratedReplayWindowIfNeeded(runtime, window, max_window_items);
     }
@@ -9489,7 +9479,7 @@ fn processChunkedDenseWindow(
             const request_stale = try deleteStaleChunkEmbeddingArtifacts(runtime, request.doc_key, chunk_artifact_name, embedding_artifact_name, source_set.desired_chunk_keys);
             var stale_deletes = request_stale;
             errdefer stale_deletes.deinit(runtime.alloc);
-            try mergeOwnedStaleEmbeddingDeletesIntoWindow(runtime, window, &stale_deletes, .dense_vector, consumer_indexes);
+            try mergeOwnedStaleEmbeddingDeletesIntoWindow(runtime, window, &stale_deletes);
             try flushGeneratedReplayWindowIfNeeded(runtime, window, max_window_items);
             if (source_set.sources.len == 0) {
                 try markDerivedCoverageSkipped(runtime, window, request, consumer_indexes);
@@ -9679,37 +9669,20 @@ fn appendFullTextDeleteDocumentToWindow(
     key: []const u8,
     text_indexes: []const []const u8,
 ) !void {
-    return try appendTargetedDeleteDocumentToWindow(runtime, window, key, .full_text, text_indexes);
-}
-
-fn appendTargetedDeleteDocumentToWindow(
-    runtime: *EnrichmentRuntime,
-    window: *GeneratedReplayWindow,
-    key: []const u8,
-    kind: derived_types.DerivedTarget,
-    indexes: []const []const u8,
-) !void {
-    // Targeted document mutations survive journal encoding as a delete on
-    // only the named index-kind replay lanes. `deleted_keys` is intentionally
-    // reserved for source deletions that must fan out to every projection.
-    if (indexes.len == 0) return;
-    const targets = try runtime.alloc.alloc(derived_types.DerivedTargetRef, indexes.len);
-    var initialized_targets: usize = 0;
+    if (text_indexes.len == 0) return;
+    const targets = try runtime.alloc.alloc(derived_types.DerivedTargetRef, text_indexes.len);
     errdefer {
-        for (targets[0..initialized_targets]) |target| runtime.alloc.free(@constCast(target.index_name));
+        for (targets) |target| runtime.alloc.free(@constCast(target.index_name));
         runtime.alloc.free(targets);
     }
-    for (indexes, 0..) |index_name, i| {
+    for (text_indexes, 0..) |index_name, i| {
         targets[i] = .{
-            .kind = kind,
+            .kind = .full_text,
             .index_name = try runtime.alloc.dupe(u8, index_name),
         };
-        initialized_targets += 1;
     }
-    const owned_key = try runtime.alloc.dupe(u8, key);
-    errdefer runtime.alloc.free(owned_key);
     try window.documents.append(runtime.alloc, .{
-        .key = owned_key,
+        .key = try runtime.alloc.dupe(u8, key),
         .action = .delete,
         .targets = targets,
     });
@@ -9789,16 +9762,8 @@ fn mergeOwnedStaleEmbeddingDeletesIntoWindow(
     runtime: *EnrichmentRuntime,
     window: *GeneratedReplayWindow,
     stale: *StaleEmbeddingDeletes,
-    kind: derived_types.DerivedTarget,
-    consumer_indexes: []const []const u8,
 ) !void {
     errdefer stale.deinit(runtime.alloc);
-    for (stale.vector_keys) |key| {
-        try appendTargetedDeleteDocumentToWindow(runtime, window, key, kind, consumer_indexes);
-    }
-    for (stale.vector_keys) |key| runtime.alloc.free(key);
-    runtime.alloc.free(stale.vector_keys);
-    stale.vector_keys = &.{};
     try mergeOwnedArtifactDeleteKeysIntoWindow(runtime, window, stale.artifact_delete_keys);
     stale.artifact_delete_keys = &.{};
 }
@@ -9982,7 +9947,7 @@ fn processDenseEmbedding(
         errdefer stale_deletes.deinit(runtime.alloc);
         if (source_set.sources.len == 0) {
             try markDerivedCoverageSkipped(runtime, window, request, consumer_indexes);
-            try mergeOwnedStaleEmbeddingDeletesIntoWindow(runtime, window, &stale_deletes, .dense_vector, consumer_indexes);
+            try mergeOwnedStaleEmbeddingDeletesIntoWindow(runtime, window, &stale_deletes);
             return;
         }
 
@@ -9994,7 +9959,7 @@ fn processDenseEmbedding(
 
         if (chunk_embeddings.len == 0) {
             try markDerivedCoverageSkipped(runtime, window, request, consumer_indexes);
-            try mergeOwnedStaleEmbeddingDeletesIntoWindow(runtime, window, &stale_deletes, .dense_vector, consumer_indexes);
+            try mergeOwnedStaleEmbeddingDeletesIntoWindow(runtime, window, &stale_deletes);
             return;
         }
 
@@ -10005,7 +9970,7 @@ fn processDenseEmbedding(
             for (expanded) |embedding| freeDerivedDenseEmbedding(runtime.alloc, embedding);
             if (expanded.len > 0) runtime.alloc.free(expanded);
         }
-        try mergeOwnedStaleEmbeddingDeletesIntoWindow(runtime, window, &stale_deletes, .dense_vector, consumer_indexes);
+        try mergeOwnedStaleEmbeddingDeletesIntoWindow(runtime, window, &stale_deletes);
         try appendOwnedDenseEmbeddingsToWindow(runtime, window, &expanded);
         return;
     }
@@ -10123,7 +10088,7 @@ fn processSparseEmbedding(
         errdefer stale_deletes.deinit(runtime.alloc);
         if (source_set.sources.len == 0) {
             try markDerivedCoverageSkipped(runtime, window, request, consumer_indexes);
-            try mergeOwnedStaleEmbeddingDeletesIntoWindow(runtime, window, &stale_deletes, .sparse_vector, consumer_indexes);
+            try mergeOwnedStaleEmbeddingDeletesIntoWindow(runtime, window, &stale_deletes);
             return;
         }
 
@@ -10135,7 +10100,7 @@ fn processSparseEmbedding(
 
         if (chunk_embeddings.len == 0) {
             try markDerivedCoverageSkipped(runtime, window, request, consumer_indexes);
-            try mergeOwnedStaleEmbeddingDeletesIntoWindow(runtime, window, &stale_deletes, .sparse_vector, consumer_indexes);
+            try mergeOwnedStaleEmbeddingDeletesIntoWindow(runtime, window, &stale_deletes);
             return;
         }
 
@@ -10145,7 +10110,7 @@ fn processSparseEmbedding(
             for (expanded) |embedding| freeDerivedSparseEmbedding(runtime.alloc, embedding);
             if (expanded.len > 0) runtime.alloc.free(expanded);
         }
-        try mergeOwnedStaleEmbeddingDeletesIntoWindow(runtime, window, &stale_deletes, .sparse_vector, consumer_indexes);
+        try mergeOwnedStaleEmbeddingDeletesIntoWindow(runtime, window, &stale_deletes);
         try appendOwnedSparseEmbeddingsToWindow(runtime, window, &expanded);
         return;
     }
@@ -12246,8 +12211,6 @@ fn deleteStaleChunkEmbeddingArtifacts(
     defer backend_scan.freeResults(runtime.alloc, existing);
     if (existing.len == 0) return .{};
 
-    var stale_vector_keys = std.ArrayListUnmanaged([]u8).empty;
-    errdefer freeKeyList(runtime.alloc, stale_vector_keys.items);
     var artifact_delete_keys = std.ArrayListUnmanaged([]u8).empty;
     errdefer freeKeyList(runtime.alloc, artifact_delete_keys.items);
 
@@ -12255,13 +12218,9 @@ fn deleteStaleChunkEmbeddingArtifacts(
         if (!internal_keys.isDerivedEmbeddingArtifactKey(entry.key)) continue;
         if (!internal_keys.matchesDerivedEmbeddingArtifactName(entry.key, embedding_artifact_name)) continue;
         if (derivedEmbeddingBelongsToDesiredChunk(entry.key, desired_chunk_keys)) continue;
-        if (try internal_keys.derivedEmbeddingBaseKeyAlloc(runtime.alloc, entry.key)) |base_key| {
-            try appendUniqueOwnedKey(runtime.alloc, &stale_vector_keys, base_key);
-        }
         try appendUniqueDupeKey(runtime.alloc, &artifact_delete_keys, entry.key);
     }
     return .{
-        .vector_keys = try stale_vector_keys.toOwnedSlice(runtime.alloc),
         .artifact_delete_keys = try artifact_delete_keys.toOwnedSlice(runtime.alloc),
     };
 }

--- a/zig/pkg/antfly/src/storage/db/enrichment/enrichment_runtime.zig
+++ b/zig/pkg/antfly/src/storage/db/enrichment/enrichment_runtime.zig
@@ -8792,7 +8792,6 @@ fn flushChunkedDenseItems(
     }
 
     for (batch_items, vectors, 0..) |item, vector, idx| {
-        try appendUniqueDupeKey(runtime.alloc, &window.deleted_keys, item.chunk_key);
         try writeEmbeddingArtifact(runtime, .{
             .base_key = item.chunk_key,
             .parent_doc_key = item.parent_doc_key,
@@ -9027,7 +9026,8 @@ fn processMaterializedChunkDenseRequest(
     for (existing_embedding_keys.items) |embedding_key| {
         if (try derivedEmbeddingBelongsToDesiredChunkSet(runtime.alloc, embedding_key, &desired_chunk_keys)) continue;
         if (try internal_keys.derivedEmbeddingBaseKeyAlloc(runtime.alloc, embedding_key)) |base_key| {
-            try appendUniqueOwnedKey(runtime.alloc, &window.deleted_keys, base_key);
+            defer runtime.alloc.free(base_key);
+            try appendTargetedDeleteDocumentToWindow(runtime, window, base_key, .dense_vector, consumer_indexes);
         }
         try appendUniqueDupeKey(runtime.alloc, &window.artifact_delete_keys, embedding_key);
         try flushGeneratedReplayWindowIfNeeded(runtime, window, max_window_items);
@@ -9246,7 +9246,8 @@ fn processMaterializedChunkSparseRequest(
     for (existing_embedding_keys.items) |embedding_key| {
         if (try derivedEmbeddingBelongsToDesiredChunkSet(runtime.alloc, embedding_key, &desired_chunk_keys)) continue;
         if (try internal_keys.derivedEmbeddingBaseKeyAlloc(runtime.alloc, embedding_key)) |base_key| {
-            try appendUniqueOwnedKey(runtime.alloc, &window.deleted_keys, base_key);
+            defer runtime.alloc.free(base_key);
+            try appendTargetedDeleteDocumentToWindow(runtime, window, base_key, .sparse_vector, consumer_indexes);
         }
         try appendUniqueDupeKey(runtime.alloc, &window.artifact_delete_keys, embedding_key);
         try flushGeneratedReplayWindowIfNeeded(runtime, window, max_window_items);
@@ -9488,7 +9489,7 @@ fn processChunkedDenseWindow(
             const request_stale = try deleteStaleChunkEmbeddingArtifacts(runtime, request.doc_key, chunk_artifact_name, embedding_artifact_name, source_set.desired_chunk_keys);
             var stale_deletes = request_stale;
             errdefer stale_deletes.deinit(runtime.alloc);
-            try mergeOwnedStaleEmbeddingDeletesIntoWindow(runtime, window, &stale_deletes);
+            try mergeOwnedStaleEmbeddingDeletesIntoWindow(runtime, window, &stale_deletes, .dense_vector, consumer_indexes);
             try flushGeneratedReplayWindowIfNeeded(runtime, window, max_window_items);
             if (source_set.sources.len == 0) {
                 try markDerivedCoverageSkipped(runtime, window, request, consumer_indexes);
@@ -9678,20 +9679,37 @@ fn appendFullTextDeleteDocumentToWindow(
     key: []const u8,
     text_indexes: []const []const u8,
 ) !void {
-    if (text_indexes.len == 0) return;
-    const targets = try runtime.alloc.alloc(derived_types.DerivedTargetRef, text_indexes.len);
+    return try appendTargetedDeleteDocumentToWindow(runtime, window, key, .full_text, text_indexes);
+}
+
+fn appendTargetedDeleteDocumentToWindow(
+    runtime: *EnrichmentRuntime,
+    window: *GeneratedReplayWindow,
+    key: []const u8,
+    kind: derived_types.DerivedTarget,
+    indexes: []const []const u8,
+) !void {
+    // Targeted document mutations survive journal encoding as a delete on
+    // only the named index-kind replay lanes. `deleted_keys` is intentionally
+    // reserved for source deletions that must fan out to every projection.
+    if (indexes.len == 0) return;
+    const targets = try runtime.alloc.alloc(derived_types.DerivedTargetRef, indexes.len);
+    var initialized_targets: usize = 0;
     errdefer {
-        for (targets) |target| runtime.alloc.free(@constCast(target.index_name));
+        for (targets[0..initialized_targets]) |target| runtime.alloc.free(@constCast(target.index_name));
         runtime.alloc.free(targets);
     }
-    for (text_indexes, 0..) |index_name, i| {
+    for (indexes, 0..) |index_name, i| {
         targets[i] = .{
-            .kind = .full_text,
+            .kind = kind,
             .index_name = try runtime.alloc.dupe(u8, index_name),
         };
+        initialized_targets += 1;
     }
+    const owned_key = try runtime.alloc.dupe(u8, key);
+    errdefer runtime.alloc.free(owned_key);
     try window.documents.append(runtime.alloc, .{
-        .key = try runtime.alloc.dupe(u8, key),
+        .key = owned_key,
         .action = .delete,
         .targets = targets,
     });
@@ -9771,9 +9789,15 @@ fn mergeOwnedStaleEmbeddingDeletesIntoWindow(
     runtime: *EnrichmentRuntime,
     window: *GeneratedReplayWindow,
     stale: *StaleEmbeddingDeletes,
+    kind: derived_types.DerivedTarget,
+    consumer_indexes: []const []const u8,
 ) !void {
     errdefer stale.deinit(runtime.alloc);
-    try mergeOwnedDeletedKeysIntoWindow(runtime, window, stale.vector_keys);
+    for (stale.vector_keys) |key| {
+        try appendTargetedDeleteDocumentToWindow(runtime, window, key, kind, consumer_indexes);
+    }
+    for (stale.vector_keys) |key| runtime.alloc.free(key);
+    runtime.alloc.free(stale.vector_keys);
     stale.vector_keys = &.{};
     try mergeOwnedArtifactDeleteKeysIntoWindow(runtime, window, stale.artifact_delete_keys);
     stale.artifact_delete_keys = &.{};
@@ -9958,7 +9982,7 @@ fn processDenseEmbedding(
         errdefer stale_deletes.deinit(runtime.alloc);
         if (source_set.sources.len == 0) {
             try markDerivedCoverageSkipped(runtime, window, request, consumer_indexes);
-            try mergeOwnedStaleEmbeddingDeletesIntoWindow(runtime, window, &stale_deletes);
+            try mergeOwnedStaleEmbeddingDeletesIntoWindow(runtime, window, &stale_deletes, .dense_vector, consumer_indexes);
             return;
         }
 
@@ -9970,13 +9994,10 @@ fn processDenseEmbedding(
 
         if (chunk_embeddings.len == 0) {
             try markDerivedCoverageSkipped(runtime, window, request, consumer_indexes);
-            try mergeOwnedStaleEmbeddingDeletesIntoWindow(runtime, window, &stale_deletes);
+            try mergeOwnedStaleEmbeddingDeletesIntoWindow(runtime, window, &stale_deletes, .dense_vector, consumer_indexes);
             return;
         }
 
-        for (chunk_embeddings) |embedding| {
-            if (embedding.vector.len > 0) try appendUniqueDupeKey(runtime.alloc, &window.deleted_keys, embedding.doc_key);
-        }
         try writeChunkEmbeddingArtifacts(runtime, request.doc_key, request.source_field, request.producer_json, embedding_artifact_name, chunk_embeddings);
         try queueDerivedCoverageProduced(runtime, window, request, consumer_indexes);
         var expanded = try expandDenseEmbeddingsForConsumers(runtime, chunk_embeddings, consumer_indexes);
@@ -9984,7 +10005,7 @@ fn processDenseEmbedding(
             for (expanded) |embedding| freeDerivedDenseEmbedding(runtime.alloc, embedding);
             if (expanded.len > 0) runtime.alloc.free(expanded);
         }
-        try mergeOwnedStaleEmbeddingDeletesIntoWindow(runtime, window, &stale_deletes);
+        try mergeOwnedStaleEmbeddingDeletesIntoWindow(runtime, window, &stale_deletes, .dense_vector, consumer_indexes);
         try appendOwnedDenseEmbeddingsToWindow(runtime, window, &expanded);
         return;
     }
@@ -10102,7 +10123,7 @@ fn processSparseEmbedding(
         errdefer stale_deletes.deinit(runtime.alloc);
         if (source_set.sources.len == 0) {
             try markDerivedCoverageSkipped(runtime, window, request, consumer_indexes);
-            try mergeOwnedStaleEmbeddingDeletesIntoWindow(runtime, window, &stale_deletes);
+            try mergeOwnedStaleEmbeddingDeletesIntoWindow(runtime, window, &stale_deletes, .sparse_vector, consumer_indexes);
             return;
         }
 
@@ -10114,7 +10135,7 @@ fn processSparseEmbedding(
 
         if (chunk_embeddings.len == 0) {
             try markDerivedCoverageSkipped(runtime, window, request, consumer_indexes);
-            try mergeOwnedStaleEmbeddingDeletesIntoWindow(runtime, window, &stale_deletes);
+            try mergeOwnedStaleEmbeddingDeletesIntoWindow(runtime, window, &stale_deletes, .sparse_vector, consumer_indexes);
             return;
         }
 
@@ -10124,7 +10145,7 @@ fn processSparseEmbedding(
             for (expanded) |embedding| freeDerivedSparseEmbedding(runtime.alloc, embedding);
             if (expanded.len > 0) runtime.alloc.free(expanded);
         }
-        try mergeOwnedStaleEmbeddingDeletesIntoWindow(runtime, window, &stale_deletes);
+        try mergeOwnedStaleEmbeddingDeletesIntoWindow(runtime, window, &stale_deletes, .sparse_vector, consumer_indexes);
         try appendOwnedSparseEmbeddingsToWindow(runtime, window, &expanded);
         return;
     }


### PR DESCRIPTION
## Summary

- scope full-text deletes to indexes that consume the affected artifact source
- scope dense and sparse vector replacement deletes to their target indexes instead of broadcasting chunk keys to every derived index
- retain complete embedding artifact identities in durable delete records and translate them only inside vector indexes that consume that embedding
- add a restart-persistent end-to-end regression covering an existing artifact-backed full-text index followed by an artifact-backed embedding index
- add a two-vector routing regression proving an embedding-A artifact delete cannot delete the same chunk from embedding B

## Root cause

Embedding publication placed chunk keys in the batch-wide deleted-key lane. Every derived index worker consumes that lane, so adding the vector projection caused the existing full-text projection over the same chunk artifact to tombstone its documents. Stale embedding cleanup now journals the complete artifact key; vector replay decodes its embedding owner and maps it to the base document key only after confirming that the current index consumes that embedding.

## Validation

- exact standalone reproducer against the pre-fix binary
- new artifact full-text plus embedding restart end-to-end test
- existing atomic artifact index creation end-to-end test
- focused dense, sparse, reopened-index, and full-text routing unit tests
- focused two-vector embedding-delete ownership test
- zig build antfly
- git diff --check
