### PR TITLE
Retry Autograph table creation only after proven non-admission

### DIFF
--- a/zig/build.zig
+++ b/zig/build.zig
@@ -4092,6 +4092,7 @@ pub fn build(b: *std.Build) void {
         "api http server create table with local writes waits for projected presence without lifecycle",
         "api http server rejects oversized table definitions before parsing across public and MCP",
         "api http server reports exhausted table mutation authority consistently",
+        "api http server marks every proven table mutation pre-admission failure",
         "api http server retries only pre-admission public table drop failures",
         "ambiguous mutation response is explicitly non-retryable",
         "routed table mutation preserves hop budget for provably unsent request",

--- a/zig/e2e/antfly/test_resolution.py
+++ b/zig/e2e/antfly/test_resolution.py
@@ -64,6 +64,16 @@ def _new_e2e_deadline() -> "_Deadline":
     return _Deadline(AUTOGRAPH_E2E_TIMEOUT_S)
 
 
+def _retry_after_delay_s(response: requests.Response) -> float:
+    """Read the same-service Retry-After delta, falling back fail-safe."""
+    raw_delay = response.headers.get("Retry-After", "").strip()
+    try:
+        delay_s = int(raw_delay, 10)
+    except ValueError:
+        return POLL_INTERVAL_S
+    return delay_s if delay_s >= 0 else POLL_INTERVAL_S
+
+
 DOCUMENTS_INDEXES = {
     # Materializes each document's `relations` field into the `relations_v1`
     # extraction asset the resolver consumes (no LLM needed). The resolver is
@@ -203,7 +213,7 @@ class _Api:
             last_not_admitted_response = (
                 f"HTTP {response.status_code}: {response.text[:512]}"
             )
-            deadline.sleep()
+            deadline.sleep(_retry_after_delay_s(response))
 
     def insert(
         self,
@@ -400,10 +410,11 @@ class _Deadline:
             )
         return min(max_timeout_s, remaining)
 
-    def sleep(self) -> None:
+    def sleep(self, delay_s: float = POLL_INTERVAL_S) -> None:
         remaining = self.remaining()
-        if remaining > 0.0:
-            time.sleep(min(POLL_INTERVAL_S, remaining))
+        bounded_delay_s = min(max(0.0, delay_s), remaining)
+        if bounded_delay_s > 0.0:
+            time.sleep(bounded_delay_s)
 
 
 def _test_response(
@@ -423,6 +434,39 @@ def _test_response(
     return response
 
 
+@pytest.mark.parametrize(
+    ("retry_after", "expected_delay_s"),
+    [
+        (None, POLL_INTERVAL_S),
+        ("invalid", POLL_INTERVAL_S),
+        ("-1", POLL_INTERVAL_S),
+        ("0", 0.0),
+        ("2", 2.0),
+    ],
+)
+def test_retry_after_delay_uses_valid_delta_seconds_or_poll_fallback(
+    retry_after: str | None,
+    expected_delay_s: float,
+):
+    headers = {"Retry-After": retry_after} if retry_after is not None else None
+    response = _test_response("http://data-a/db/v1/tables/documents", 503, headers=headers)
+
+    assert _retry_after_delay_s(response) == expected_delay_s
+
+
+def test_deadline_sleep_clamps_retry_after_to_remaining_time(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    deadline = _Deadline(10.0)
+    sleep_delays: list[float] = []
+    monkeypatch.setattr(deadline, "remaining", lambda: 0.25)
+    monkeypatch.setattr(time, "sleep", sleep_delays.append)
+
+    deadline.sleep(2.0)
+
+    assert sleep_delays == [0.25]
+
+
 def test_create_table_retries_explicit_non_admission_within_deadline(
     monkeypatch: pytest.MonkeyPatch,
 ):
@@ -436,13 +480,17 @@ def test_create_table_retries_explicit_non_admission_within_deadline(
             _test_response(
                 url,
                 503,
-                headers=METADATA_MUTATION_NOT_ADMITTED_RESPONSE_HEADERS,
+                headers={
+                    **METADATA_MUTATION_NOT_ADMITTED_RESPONSE_HEADERS,
+                    "Retry-After": "1",
+                },
                 body=b"metadata leader unavailable",
             ),
             _test_response(url, 200, body=b"{}"),
         ]
     )
     post_calls = 0
+    sleep_delays: list[float] = []
 
     def post(*_: Any, **__: Any) -> requests.Response:
         nonlocal post_calls
@@ -451,10 +499,11 @@ def test_create_table_retries_explicit_non_admission_within_deadline(
 
     deadline = _Deadline(10.0)
     monkeypatch.setattr(api.s, "post", post)
-    monkeypatch.setattr(deadline, "sleep", lambda: None)
+    monkeypatch.setattr(deadline, "sleep", sleep_delays.append)
 
     assert api.create_table("documents", deadline=deadline) == {}
     assert post_calls == 2
+    assert sleep_delays == [1.0]
 
 
 @pytest.mark.parametrize(

--- a/zig/e2e/antfly/test_resolution.py
+++ b/zig/e2e/antfly/test_resolution.py
@@ -38,12 +38,15 @@ from urllib.parse import quote
 
 import pytest
 import requests
-
 from conftest import (
     DEFAULT_ANTFLY_BIN,
     resolve_binary_path,
 )
-from test_scaling import MultiNodeScalingCluster
+from test_scaling import (
+    METADATA_MUTATION_NOT_ADMITTED_HEADER,
+    METADATA_MUTATION_NOT_ADMITTED_VALUE,
+    MultiNodeScalingCluster,
+)
 
 AUTOGRAPH_E2E_TIMEOUT_S = 115.0
 AUTOGRAPH_CLUSTER_STARTUP_TIMEOUT_S = 115.0
@@ -52,6 +55,9 @@ POLL_INTERVAL_S = 0.5
 POLL_REQUEST_TIMEOUT_S = 5.0
 WRITE_REQUEST_TIMEOUT_FLOOR_S = 5.0
 WRITE_OUTCOME_RECONCILE_TIMEOUT_S = 5.0
+METADATA_MUTATION_NOT_ADMITTED_RESPONSE_HEADERS = {
+    METADATA_MUTATION_NOT_ADMITTED_HEADER: METADATA_MUTATION_NOT_ADMITTED_VALUE
+}
 
 
 def _new_e2e_deadline() -> "_Deadline":
@@ -150,18 +156,54 @@ class _Api:
         if indexes is not None:
             payload["indexes"] = indexes
         max_timeout = 90.0 if indexes is not None or num_shards > 1 else 30.0
-        timeout = deadline.request_timeout(max_timeout) if deadline is not None else max_timeout
-        try:
-            response = self.s.post(f"{self.url}/tables/{name}", json=payload, timeout=timeout)
-        except requests.RequestException as exc:
-            stacks = self._server.native_stack_dumps()
-            index_names = sorted(indexes.keys()) if indexes is not None else []
-            raise AssertionError(
-                f"create table timed out/failed table={name!r} shards={num_shards} "
-                f"indexes={index_names!r}: {exc!r}\n[native stacks]\n{stacks}"
-                f"\n[logs]\n{self._server.debug_logs()}"
-            ) from exc
-        return self._check(response)
+        last_not_admitted_response: str | None = None
+        while True:
+            try:
+                timeout = (
+                    deadline.request_timeout(max_timeout)
+                    if deadline is not None
+                    else max_timeout
+                )
+            except AssertionError as exc:
+                stacks = self._server.native_stack_dumps()
+                index_names = sorted(indexes.keys()) if indexes is not None else []
+                raise AssertionError(
+                    f"create table exhausted its {deadline.timeout_s:.1f}s deadline "
+                    f"table={name!r} shards={num_shards} indexes={index_names!r} "
+                    f"last_not_admitted_response={last_not_admitted_response!r}"
+                    f"\n[native stacks]\n{stacks}"
+                    f"\n[metadata snapshot]\n{self._server.metadata_snapshot_diagnostic()}"
+                    f"\n[logs]\n{self._server.debug_logs()}"
+                ) from exc
+            try:
+                response = self.s.post(
+                    f"{self.url}/tables/{name}", json=payload, timeout=timeout
+                )
+            except requests.RequestException as exc:
+                # A transport failure does not prove whether the DDL reached
+                # Raft, so never replay it automatically.
+                stacks = self._server.native_stack_dumps()
+                index_names = sorted(indexes.keys()) if indexes is not None else []
+                raise AssertionError(
+                    f"create table timed out/failed table={name!r} shards={num_shards} "
+                    f"indexes={index_names!r}: {exc!r}\n[native stacks]\n{stacks}"
+                    f"\n[logs]\n{self._server.debug_logs()}"
+                ) from exc
+
+            mutation_not_admitted = (
+                response.status_code == 503
+                and response.headers.get(METADATA_MUTATION_NOT_ADMITTED_HEADER, "")
+                .strip()
+                .lower()
+                == METADATA_MUTATION_NOT_ADMITTED_VALUE
+            )
+            if deadline is None or not mutation_not_admitted:
+                return self._check(response)
+
+            last_not_admitted_response = (
+                f"HTTP {response.status_code}: {response.text[:512]}"
+            )
+            deadline.sleep()
 
     def insert(
         self,
@@ -362,6 +404,101 @@ class _Deadline:
         remaining = self.remaining()
         if remaining > 0.0:
             time.sleep(min(POLL_INTERVAL_S, remaining))
+
+
+def _test_response(
+    url: str,
+    status: int,
+    *,
+    headers: dict[str, str] | None = None,
+    body: bytes = b"",
+) -> requests.Response:
+    response = requests.Response()
+    response.status_code = status
+    response.headers.update(headers or {})
+    response._content = body
+    response.url = url
+    response.reason = "test response"
+    response.request = requests.Request("POST", url).prepare()
+    return response
+
+
+def test_create_table_retries_explicit_non_admission_within_deadline(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    class _Server:
+        pass
+
+    api = _Api("http://data-a/db/v1", _Server())
+    url = "http://data-a/db/v1/tables/documents"
+    responses = iter(
+        [
+            _test_response(
+                url,
+                503,
+                headers=METADATA_MUTATION_NOT_ADMITTED_RESPONSE_HEADERS,
+                body=b"metadata leader unavailable",
+            ),
+            _test_response(url, 200, body=b"{}"),
+        ]
+    )
+    post_calls = 0
+
+    def post(*_: Any, **__: Any) -> requests.Response:
+        nonlocal post_calls
+        post_calls += 1
+        return next(responses)
+
+    deadline = _Deadline(10.0)
+    monkeypatch.setattr(api.s, "post", post)
+    monkeypatch.setattr(deadline, "sleep", lambda: None)
+
+    assert api.create_table("documents", deadline=deadline) == {}
+    assert post_calls == 2
+
+
+@pytest.mark.parametrize(
+    ("status", "headers", "with_deadline"),
+    [
+        (503, {"X-Antfly-Metadata-Not-Leader": "true"}, True),
+        (
+            409,
+            METADATA_MUTATION_NOT_ADMITTED_RESPONSE_HEADERS,
+            True,
+        ),
+        (
+            503,
+            METADATA_MUTATION_NOT_ADMITTED_RESPONSE_HEADERS,
+            False,
+        ),
+    ],
+)
+def test_create_table_never_retries_without_safe_bounded_non_admission_contract(
+    monkeypatch: pytest.MonkeyPatch,
+    status: int,
+    headers: dict[str, str],
+    with_deadline: bool,
+):
+    class _Server:
+        @staticmethod
+        def debug_logs() -> str:
+            return "test logs"
+
+    api = _Api("http://data-a/db/v1", _Server())
+    url = "http://data-a/db/v1/tables/documents"
+    post_calls = 0
+
+    def post(*_: Any, **__: Any) -> requests.Response:
+        nonlocal post_calls
+        post_calls += 1
+        return _test_response(url, status, headers=headers, body=b"mutation failed")
+
+    monkeypatch.setattr(api.s, "post", post)
+    deadline = _Deadline(10.0) if with_deadline else None
+
+    with pytest.raises(requests.HTTPError):
+        api.create_table("documents", deadline=deadline)
+    assert post_calls == 1
 
 
 def test_insert_reconciles_unknown_upsert_before_retry(monkeypatch: pytest.MonkeyPatch):

--- a/zig/pkg/antfly/src/api/http_server.zig
+++ b/zig/pkg/antfly/src/api/http_server.zig
@@ -36191,14 +36191,14 @@ test "api http server reports exhausted table mutation authority consistently" {
         .body = "{}",
     });
     defer public_create.deinit(alloc);
-    try expectPublicMetadataNotLeaderResponse(public_create);
+    try expectPublicMetadataMutationNotAdmittedResponse(public_create);
 
     var public_drop = try executeHttpxTestRequest(&server, .{
         .method = .DELETE,
         .uri = "/tables/docs",
     });
     defer public_drop.deinit(alloc);
-    try expectPublicMetadataNotLeaderResponse(public_drop);
+    try expectPublicMetadataMutationNotAdmittedResponse(public_drop);
 
     var mcp_create = try server.executeMcpCreateTable("docs", "{}", null);
     defer mcp_create.deinit(alloc);
@@ -38980,6 +38980,15 @@ fn expectPublicMetadataNotLeaderResponse(resp: http_common.HttpResponse) !void {
     try std.testing.expect(metadata_not_leader);
 }
 
+fn expectPublicMetadataMutationNotAdmittedResponse(resp: http_common.HttpResponse) !void {
+    try expectPublicMetadataNotLeaderResponse(resp);
+    try std.testing.expectEqualStrings(
+        http_common.metadata_mutation_not_admitted_value,
+        resp.header(http_common.metadata_mutation_not_admitted_header) orelse
+            return error.MissingMutationNotAdmittedHeader,
+    );
+}
+
 fn expectPublicMetadataMutationOutcomeUnknownResponse(resp: http_common.HttpResponse) !void {
     try std.testing.expectEqual(@as(u16, 409), resp.status);
     try std.testing.expectEqualStrings(
@@ -39135,7 +39144,7 @@ test "api http server returns retryable not leader when metadata proposal is dro
     });
     defer resp.deinit(alloc);
 
-    try expectPublicMetadataNotLeaderResponse(resp);
+    try expectPublicMetadataMutationNotAdmittedResponse(resp);
     try std.testing.expectEqual(@as(usize, 3), source.create_calls);
 }
 

--- a/zig/pkg/antfly/src/api/http_server.zig
+++ b/zig/pkg/antfly/src/api/http_server.zig
@@ -36213,6 +36213,68 @@ test "api http server reports exhausted table mutation authority consistently" {
     try std.testing.expectEqual(@as(usize, 3), source.drop_calls);
 }
 
+test "api http server marks every proven table mutation pre-admission failure" {
+    const alloc = std.testing.allocator;
+    const FakeSource = struct {
+        mutation_error: anyerror,
+
+        fn iface(self: *@This()) StatusSource {
+            return .{ .ptr = self, .vtable = &.{
+                .status = status,
+                .create_table = createTable,
+                .drop_table_exact = dropTableExact,
+            } };
+        }
+
+        fn status(_: *anyopaque) !metadata_api.MetadataStatus {
+            return .{ .metadata_group_id = 1, .metrics = .{}, .projected_stores = 1 };
+        }
+
+        fn createTable(ptr: *anyopaque, _: std.mem.Allocator, _: []const u8, _: tables_api.CreateTableRequest) !void {
+            const self: *@This() = @ptrCast(@alignCast(ptr));
+            return self.mutation_error;
+        }
+
+        fn dropTableExact(
+            ptr: *anyopaque,
+            _: std.mem.Allocator,
+            _: []const u8,
+        ) !metadata_table_topology_mutations.DropResult {
+            const self: *@This() = @ptrCast(@alignCast(ptr));
+            return self.mutation_error;
+        }
+    };
+
+    for ([_]anyerror{
+        error.TableTopologyProtocolUpgradeRequired,
+        error.RaftMutationDeadlineExceeded,
+    }) |mutation_error| {
+        const expected_body = switch (mutation_error) {
+            error.TableTopologyProtocolUpgradeRequired => "metadata cluster upgrade in progress; retry later",
+            error.RaftMutationDeadlineExceeded => "metadata mutation deadline exceeded before admission; retry later",
+            else => unreachable,
+        };
+        var source = FakeSource{ .mutation_error = mutation_error };
+        var server = ApiHttpServer.init(alloc, .{}, source.iface(), null, null);
+
+        var create_response = try executeHttpxTestRequest(&server, .{
+            .method = .POST,
+            .uri = "/tables/docs",
+            .content_type = "application/json",
+            .body = "{}",
+        });
+        defer create_response.deinit(alloc);
+        try expectPublicMetadataMutationNotAdmittedTextResponse(create_response, expected_body);
+
+        var drop_response = try executeHttpxTestRequest(&server, .{
+            .method = .DELETE,
+            .uri = "/tables/docs",
+        });
+        defer drop_response.deinit(alloc);
+        try expectPublicMetadataMutationNotAdmittedTextResponse(drop_response, expected_body);
+    }
+}
+
 test "api http server retries only pre-admission public table drop failures" {
     const alloc = std.testing.allocator;
     const FailureMode = enum {
@@ -38982,11 +39044,25 @@ fn expectPublicMetadataNotLeaderResponse(resp: http_common.HttpResponse) !void {
 
 fn expectPublicMetadataMutationNotAdmittedResponse(resp: http_common.HttpResponse) !void {
     try expectPublicMetadataNotLeaderResponse(resp);
+    try expectPublicMetadataMutationNotAdmittedMarker(resp);
+}
+
+fn expectPublicMetadataMutationNotAdmittedMarker(resp: http_common.HttpResponse) !void {
     try std.testing.expectEqualStrings(
         http_common.metadata_mutation_not_admitted_value,
         resp.header(http_common.metadata_mutation_not_admitted_header) orelse
             return error.MissingMutationNotAdmittedHeader,
     );
+}
+
+fn expectPublicMetadataMutationNotAdmittedTextResponse(resp: http_common.HttpResponse, expected_body: []const u8) !void {
+    try std.testing.expectEqual(@as(u16, 503), resp.status);
+    try std.testing.expectEqualStrings(expected_body, resp.body);
+    try std.testing.expectEqualStrings(
+        "1",
+        resp.header("Retry-After") orelse return error.MissingRetryAfterHeader,
+    );
+    try expectPublicMetadataMutationNotAdmittedMarker(resp);
 }
 
 fn expectPublicMetadataMutationOutcomeUnknownResponse(resp: http_common.HttpResponse) !void {
@@ -39002,6 +39078,7 @@ fn expectPublicMetadataMutationOutcomeUnknownResponse(resp: http_common.HttpResp
     );
     try std.testing.expect(resp.header("Retry-After") == null);
     try std.testing.expect(resp.header(http_common.metadata_not_leader_header) == null);
+    try std.testing.expect(resp.header(http_common.metadata_mutation_not_admitted_header) == null);
 }
 
 fn expectPublicMetadataCapabilityUnavailableResponse(resp: http_common.HttpResponse) !void {

--- a/zig/pkg/antfly/src/api/httpx_handler.zig
+++ b/zig/pkg/antfly/src/api/httpx_handler.zig
@@ -501,7 +501,7 @@ pub const AntflyApiHandler = struct {
         return ctx.response.build();
     }
 
-    fn metadataMutationNotAdmittedResponse(ctx: *httpx.Context) !httpx.Response {
+    fn markMetadataMutationNotAdmitted(ctx: *httpx.Context) !void {
         // This is stronger than the metadata routing hint: callers may replay
         // a mutation only when the authority layer proved that no proposal was
         // admitted. Keep this marker off ambiguous and read-only failures.
@@ -509,7 +509,18 @@ pub const AntflyApiHandler = struct {
             http_common.metadata_mutation_not_admitted_header,
             http_common.metadata_mutation_not_admitted_value,
         );
+    }
+
+    fn metadataMutationNotAdmittedResponse(ctx: *httpx.Context) !httpx.Response {
+        try markMetadataMutationNotAdmitted(ctx);
         return metadataNotLeaderResponse(ctx);
+    }
+
+    fn metadataMutationNotAdmittedTextResponse(ctx: *httpx.Context, message: []const u8) !httpx.Response {
+        try markMetadataMutationNotAdmitted(ctx);
+        try ctx.setHeader("Retry-After", "1");
+        _ = ctx.status(503);
+        return ctx.text(message);
     }
 
     fn metadataMutationOutcomeUnknownResponse(ctx: *httpx.Context) !httpx.Response {
@@ -4575,14 +4586,10 @@ pub const AntflyApiHandler = struct {
                     return ctx.text("table topology changed; retry with the current table state");
                 },
                 error.TableTopologyProtocolUpgradeRequired => {
-                    try ctx.setHeader("Retry-After", "1");
-                    _ = ctx.status(503);
-                    return ctx.text("metadata cluster upgrade in progress; retry later");
+                    return metadataMutationNotAdmittedTextResponse(ctx, "metadata cluster upgrade in progress; retry later");
                 },
                 error.RaftMutationDeadlineExceeded => {
-                    try ctx.setHeader("Retry-After", "1");
-                    _ = ctx.status(503);
-                    return ctx.text("metadata mutation deadline exceeded before admission; retry later");
+                    return metadataMutationNotAdmittedTextResponse(ctx, "metadata mutation deadline exceeded before admission; retry later");
                 },
                 error.MetadataMutationOutcomeUnknown => {
                     return metadataMutationOutcomeUnknownResponse(ctx);
@@ -4706,14 +4713,10 @@ pub const AntflyApiHandler = struct {
                     return ctx.text("table topology changed or is extension-owned");
                 },
                 error.TableTopologyProtocolUpgradeRequired => {
-                    try ctx.setHeader("Retry-After", "1");
-                    _ = ctx.status(503);
-                    return ctx.text("metadata cluster upgrade in progress; retry later");
+                    return metadataMutationNotAdmittedTextResponse(ctx, "metadata cluster upgrade in progress; retry later");
                 },
                 error.RaftMutationDeadlineExceeded => {
-                    try ctx.setHeader("Retry-After", "1");
-                    _ = ctx.status(503);
-                    return ctx.text("metadata mutation deadline exceeded before admission; retry later");
+                    return metadataMutationNotAdmittedTextResponse(ctx, "metadata mutation deadline exceeded before admission; retry later");
                 },
                 error.MetadataMutationOutcomeUnknown => {
                     return metadataMutationOutcomeUnknownResponse(ctx);

--- a/zig/pkg/antfly/src/api/httpx_handler.zig
+++ b/zig/pkg/antfly/src/api/httpx_handler.zig
@@ -501,6 +501,17 @@ pub const AntflyApiHandler = struct {
         return ctx.response.build();
     }
 
+    fn metadataMutationNotAdmittedResponse(ctx: *httpx.Context) !httpx.Response {
+        // This is stronger than the metadata routing hint: callers may replay
+        // a mutation only when the authority layer proved that no proposal was
+        // admitted. Keep this marker off ambiguous and read-only failures.
+        try ctx.setHeader(
+            http_common.metadata_mutation_not_admitted_header,
+            http_common.metadata_mutation_not_admitted_value,
+        );
+        return metadataNotLeaderResponse(ctx);
+    }
+
     fn metadataMutationOutcomeUnknownResponse(ctx: *httpx.Context) !httpx.Response {
         try ctx.setHeader(
             metadata_http_routes.Routes.raft_mutation_outcome_header,
@@ -4592,7 +4603,7 @@ pub const AntflyApiHandler = struct {
                             sleepNs(self.api_server.metadataMutationRetryPollNs());
                             continue;
                         }
-                        return metadataNotLeaderResponse(ctx);
+                        return metadataMutationNotAdmittedResponse(ctx);
                     }
                     if (metadata_authority.isRetryableError(err))
                         return metadataMutationOutcomeUnknownResponse(ctx);
@@ -4714,7 +4725,7 @@ pub const AntflyApiHandler = struct {
                             sleepNs(self.api_server.metadataMutationRetryPollNs());
                             continue;
                         }
-                        return metadataNotLeaderResponse(ctx);
+                        return metadataMutationNotAdmittedResponse(ctx);
                     }
                     if (err == error.UnexpectedHttpStatus or metadata_authority.isRetryableError(err))
                         return metadataMutationOutcomeUnknownResponse(ctx);


### PR DESCRIPTION
## Summary

- expose the strong metadata-mutation-not-admitted response header for every public table create/drop failure proven to occur before Raft admission
- centralize the text response contract for topology-upgrade rejection and routing-deadline exhaustion
- retry Autograph E2E table creation only for an explicit 503 non-admission proof and only within the caller deadline
- honor valid Retry-After delta-seconds and clamp sleeps to the remaining deadline, with a safe polling fallback for missing or malformed guidance
- keep weak not-leader hints, ambiguous 409 outcomes, transport failures, and unbounded callers single-submit
- add focused production response-contract and E2E helper regressions, including an assertion that ambiguous outcomes never carry replay proof

This is the durable follow-up to #622 and the intermittent low-FD failure in Actions run 33674028566, job 100403253238.

## Validation

- zig build api-http-runtime-test (70 passed)
- focused test_resolution pytest selection (11 passed)
- Ruff import and undefined-name checks
- git diff --check