### PR TITLE
Fix simulation import and artifact readiness race

### DIFF
--- a/zig/build.zig
+++ b/zig/build.zig
@@ -7925,6 +7925,7 @@ pub fn build(b: *std.Build) void {
     index_manager_test_mod.addImport("antfly_matcher", matcher_mod);
     index_manager_test_mod.addImport("antfly_resolver", resolver_mod);
     index_manager_test_mod.addImport("antfly_chunking", chunking_mod);
+    index_manager_test_mod.addImport("antfly-json", json_mod);
     index_manager_test_mod.addImport("antfly_regex", regex_mod);
     index_manager_test_mod.addImport("antfly_reader_config", reader_config_mod);
     index_manager_test_mod.addImport("structlog", structlog_mod);

--- a/zig/e2e/antfly/test_artifacts.py
+++ b/zig/e2e/antfly/test_artifacts.py
@@ -1125,23 +1125,28 @@ def test_artifact_backed_embedding_table_provisions_atomically(
         )
         is not None
     )
+
+    def ready_embedding_status():
+        current = stateful_api.get_index(table_name, "document_vectors")
+        status = current.get("status", {})
+        index_coverage = status.get("coverage", {})
+        enrichment_runtime = status.get("enrichment_runtime", {})
+        if (
+            index_coverage.get("source_total") == 2
+            and index_coverage.get("produced") == 2
+            and index_coverage.get("covered") == 2
+            and index_coverage.get("observation_complete") is True
+            and index_coverage.get("complete") is True
+            and index_coverage.get("healthy") is True
+            and enrichment_runtime.get("enabled") is True
+            and enrichment_runtime.get("worker_started") is True
+            and enrichment_runtime.get("embed_batches_completed", 0) > 0
+        ):
+            return current
+        return None
+
     coverage = wait_until(
-        lambda: (
-            status
-            if (
-                (status := stateful_api.get_index(table_name, "document_vectors"))
-                .get("status", {})
-                .get("coverage", {})
-                .get("source_total")
-                == 2
-                and status["status"]["coverage"].get("produced") == 2
-                and status["status"]["coverage"].get("covered") == 2
-                and status["status"]["coverage"].get("observation_complete") is True
-                and status["status"]["coverage"].get("complete") is True
-                and status["status"]["coverage"].get("healthy") is True
-            )
-            else None
-        ),
+        ready_embedding_status,
         timeout_s=60.0,
         interval_s=0.5,
     )


### PR DESCRIPTION
## Summary

- add the missing `antfly-json` import to the standalone index-manager test module used by `storage-vopr-test`
- wait for coverage and enrichment worker telemetry in the same E2E status snapshot
- preserve the worker lifecycle assertion instead of weakening the artifact producer test

## CI failures

- https://github.com/antflydb/antfly/actions/runs/33688640033/job/100464558301
- https://github.com/antflydb/antfly/actions/runs/33688640033/job/100473848237

## Validation

- `zig build storage-vopr-test`
- CI-equivalent ReleaseSafe Antfly binary build
- focused `test_artifact_backed_embedding_table_provisions_atomically` passed 12 local runs, including 10 consecutive timing-stress repetitions
- `zig fmt --check build.zig`
- `python3 -m py_compile e2e/antfly/test_artifacts.py`
- `git diff --check`