### PR TITLE
fix: validate Zig release build path

### DIFF
--- a/scripts/release/build-contract.json
+++ b/scripts/release/build-contract.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "required_source_paths": [
-    "build.zig",
+    "zig/build.zig",
     "scripts/install.sh",
     "scripts/packaging/build_zig_release_archive.sh",
     "scripts/packaging/package_cli_release.py",

--- a/scripts/release/test_release_promotion.py
+++ b/scripts/release/test_release_promotion.py
@@ -32,6 +32,23 @@ def load_module(name: str, filename: str):
 
 
 class ReleasePromotionTests(unittest.TestCase):
+    def test_declared_source_contract_paths_exist_in_repository(self) -> None:
+        contract = load_module(
+            "validate_source_contract_paths_test", "validate_source_contract.py"
+        )
+        repo_root = RELEASE_DIR.parents[1]
+        document = json.loads((RELEASE_DIR / "build-contract.json").read_text())
+
+        self.assertEqual(
+            set(document["required_source_paths"]), contract.REQUIRED_PATHS
+        )
+        missing = [
+            path
+            for path in document["required_source_paths"]
+            if not (repo_root / path).is_file()
+        ]
+        self.assertEqual(missing, [])
+
     def test_source_commit_must_declare_a_supported_build_contract(self) -> None:
         contract = load_module(
             "validate_source_contract_test", "validate_source_contract.py"

--- a/scripts/release/validate_source_contract.py
+++ b/scripts/release/validate_source_contract.py
@@ -12,7 +12,7 @@ from pathlib import Path, PurePosixPath
 CONTRACT_PATH = "scripts/release/build-contract.json"
 SUPPORTED_SCHEMA = 1
 REQUIRED_PATHS = {
-    "build.zig",
+    "zig/build.zig",
     "scripts/install.sh",
     "scripts/packaging/build_zig_release_archive.sh",
     "scripts/packaging/package_cli_release.py",


### PR DESCRIPTION
## Summary
- require the actual zig/build.zig source path in the release build contract
- add a regression test that every declared source-contract path exists

## Validation
- scripts/release/test.sh
- python3 scripts/release/validate_source_contract.py --commit 9d819bbe4d34ce3eb2ca47d635795f620e4c503a
- uvx black --check scripts/release/validate_source_contract.py scripts/release/test_release_promotion.py