### PR TITLE
release: add trusted maintenance line policy

### DIFF
--- a/.github/workflows/antfly-artifact-build.yml
+++ b/.github/workflows/antfly-artifact-build.yml
@@ -86,12 +86,16 @@ jobs:
           [[ "$SOURCE_REF_HEAD" =~ ^[0-9a-f]{40}$ ]]
           if [ "$RELEASE_CHANNEL" = nightly ]; then
             resolved="$(python scripts/release/release_lines.py nightly)"
+            test "$RELEASE_LINE" = "$(jq -r .release_line <<<"$resolved")"
+            test "$SOURCE_REF" = "$(jq -r .source_ref <<<"$resolved")"
           else
-            resolved="$(python scripts/release/release_lines.py resolve --tag "$RELEASE_TAG")"
+            python scripts/release/release_lines.py verify-provenance \
+              --tag "$RELEASE_TAG" \
+              --release-line "$RELEASE_LINE" \
+              --source-ref "$SOURCE_REF" \
+              --allow-closed >/dev/null
             test "$SOURCE_COMMIT" = "$SOURCE_REF_HEAD"
           fi
-          test "$RELEASE_LINE" = "$(jq -r .release_line <<<"$resolved")"
-          test "$SOURCE_REF" = "$(jq -r .source_ref <<<"$resolved")"
           git fetch --no-tags origin "$SOURCE_REF"
           current_source_head="$(git rev-parse FETCH_HEAD)"
           git merge-base --is-ancestor "$SOURCE_REF_HEAD" "$current_source_head"

--- a/.github/workflows/antfly-artifact-build.yml
+++ b/.github/workflows/antfly-artifact-build.yml
@@ -8,7 +8,19 @@ on:
         required: true
         type: string
       source_commit:
-        description: "Exact default-branch commit to build"
+        description: "Exact trusted release-line commit to build"
+        required: true
+        type: string
+      release_line:
+        description: "Tag-derived release line, or nightly"
+        required: true
+        type: string
+      source_ref:
+        description: "Controller-selected protected source branch"
+        required: true
+        type: string
+      source_ref_head:
+        description: "Immutable source branch head observed when requested"
         required: true
         type: string
       channel:
@@ -60,15 +72,30 @@ jobs:
       - name: Load pinned toolchain policy
         id: toolchain
         uses: ./.github/actions/load-toolchain-policy
-      - name: Require compatible immutable default-branch source
+      - name: Require compatible immutable release-line source
         env:
+          RELEASE_TAG: ${{ inputs.tag_name }}
+          RELEASE_CHANNEL: ${{ inputs.channel }}
           SOURCE_COMMIT: ${{ inputs.source_commit }}
-          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          RELEASE_LINE: ${{ inputs.release_line }}
+          SOURCE_REF: ${{ inputs.source_ref }}
+          SOURCE_REF_HEAD: ${{ inputs.source_ref_head }}
         run: |
           set -euo pipefail
           [[ "$SOURCE_COMMIT" =~ ^[0-9a-f]{40}$ ]]
-          git fetch --no-tags origin "$DEFAULT_BRANCH"
-          git merge-base --is-ancestor "$SOURCE_COMMIT" "origin/$DEFAULT_BRANCH"
+          [[ "$SOURCE_REF_HEAD" =~ ^[0-9a-f]{40}$ ]]
+          if [ "$RELEASE_CHANNEL" = nightly ]; then
+            resolved="$(python scripts/release/release_lines.py nightly)"
+          else
+            resolved="$(python scripts/release/release_lines.py resolve --tag "$RELEASE_TAG")"
+            test "$SOURCE_COMMIT" = "$SOURCE_REF_HEAD"
+          fi
+          test "$RELEASE_LINE" = "$(jq -r .release_line <<<"$resolved")"
+          test "$SOURCE_REF" = "$(jq -r .source_ref <<<"$resolved")"
+          git fetch --no-tags origin "$SOURCE_REF"
+          current_source_head="$(git rev-parse FETCH_HEAD)"
+          git merge-base --is-ancestor "$SOURCE_REF_HEAD" "$current_source_head"
+          git merge-base --is-ancestor "$SOURCE_COMMIT" "$SOURCE_REF_HEAD"
           python scripts/release/validate_source_contract.py --commit "$SOURCE_COMMIT"
       - name: Validate release channel
         id: channel
@@ -224,6 +251,9 @@ jobs:
         env:
           RELEASE_TAG: ${{ inputs.tag_name }}
           SOURCE_COMMIT: ${{ inputs.source_commit }}
+          RELEASE_LINE: ${{ inputs.release_line }}
+          SOURCE_REF: ${{ inputs.source_ref }}
+          SOURCE_REF_HEAD: ${{ inputs.source_ref_head }}
           BUILD_CONTROLLER_COMMIT: ${{ needs.release-plan.outputs.build_controller_commit }}
           RELEASE_CHANNEL: ${{ needs.release-plan.outputs.channel }}
         run: |
@@ -232,6 +262,9 @@ jobs:
             --tag "$RELEASE_TAG" \
             --channel "$RELEASE_CHANNEL" \
             --source-commit "$SOURCE_COMMIT" \
+            --release-line "$RELEASE_LINE" \
+            --source-ref "$SOURCE_REF" \
+            --source-ref-head "$SOURCE_REF_HEAD" \
             --build-controller-commit "$BUILD_CONTROLLER_COMMIT" \
             > dist/release-request/release-request.json
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/antfly-operator-go.yml
+++ b/.github/workflows/antfly-operator-go.yml
@@ -16,7 +16,7 @@ on:
       - '.github/actions/load-toolchain-policy/action.yml'
       - '.github/workflows/antfly-operator-go.yml'
   pull_request:
-    branches: ["main"]
+    branches: ["main", "v*.x"]
     paths:
       - 'go/pkg/operator/**'
       - 'go/pkg/sdk/admin/**'

--- a/.github/workflows/antfly-proxy-go.yml
+++ b/.github/workflows/antfly-proxy-go.yml
@@ -11,7 +11,7 @@ on:
       - ".github/actions/load-toolchain-policy/action.yml"
       - ".github/workflows/antfly-proxy-go.yml"
   pull_request:
-    branches: ["main"]
+    branches: ["main", "v*.x"]
     paths:
       - "go/pkg/proxy/**"
       - "scripts/ci/toolchain-policy.json"

--- a/.github/workflows/antfly-release-build-controller.yml
+++ b/.github/workflows/antfly-release-build-controller.yml
@@ -23,6 +23,9 @@ jobs:
     outputs:
       tag: ${{ steps.request.outputs.tag }}
       source_commit: ${{ steps.request.outputs.source_commit }}
+      release_line: ${{ steps.request.outputs.release_line }}
+      source_ref: ${{ steps.request.outputs.source_ref }}
+      source_ref_head: ${{ steps.request.outputs.source_ref_head }}
       channel: ${{ steps.request.outputs.channel }}
       build_controller_commit: ${{ steps.request.outputs.build_controller_commit }}
     steps:
@@ -48,26 +51,45 @@ jobs:
         run: |
           set -euo pipefail
           request=dist/build-request/build-request.json
-          test "$(jq -r .schema_version "$request")" = 1
+          request_schema="$(jq -r .schema_version "$request")"
           request_kind="$(jq -r .request_kind "$request")"
           tag="$(jq -r .tag "$request")"
           source_commit="$(jq -r .source_commit "$request")"
           channel="$(jq -r .channel "$request")"
           [[ "$tag" =~ ^v[0-9]+(\.[0-9]+){2}(-[0-9A-Za-z.-]+)?$ ]]
           case "$TRIGGER_WORKFLOW:$TRIGGER_EVENT:$request_kind" in
-            "Release request:push:tag")
+            "Release request:workflow_dispatch:tag")
+              test "$request_schema" = 2
+              test "$TRIGGER_HEAD_BRANCH" = "$DEFAULT_BRANCH"
               test "$channel" = auto
-              test "$source_commit" = "$TRIGGER_HEAD_SHA"
+              git merge-base --is-ancestor "$TRIGGER_HEAD_SHA" "origin/$DEFAULT_BRANCH"
+              release_line="$(jq -r .release_line "$request")"
+              source_ref="$(jq -r .source_ref "$request")"
+              source_ref_head="$(jq -r .source_ref_head "$request")"
+              resolved="$(python scripts/release/release_lines.py resolve --tag "$tag")"
+              test "$release_line" = "$(jq -r .release_line <<<"$resolved")"
+              test "$source_ref" = "$(jq -r .source_ref <<<"$resolved")"
+              test "$source_commit" = "$source_ref_head"
+              git fetch --no-tags origin "$source_ref"
+              current_source_head="$(git rev-parse FETCH_HEAD)"
+              git merge-base --is-ancestor "$source_ref_head" "$current_source_head"
               git fetch --force origin "refs/tags/$tag:refs/tags/$tag"
               test "$(git rev-parse "$tag^{commit}")" = "$source_commit"
               ;;
             "Nightly request:workflow_dispatch:nightly")
+              test "$request_schema" = 1
               test "$TRIGGER_HEAD_BRANCH" = "$DEFAULT_BRANCH"
               test "$channel" = nightly
               test "$tag" = "v0.0.0-dev.${TRIGGER_RUN_ID}"
+              resolved="$(python scripts/release/release_lines.py nightly)"
+              release_line="$(jq -r .release_line <<<"$resolved")"
+              source_ref="$(jq -r .source_ref <<<"$resolved")"
+              git fetch --no-tags origin "$source_ref"
+              source_ref_head="$(git rev-parse FETCH_HEAD)"
               if [ -z "$source_commit" ]; then
                 source_commit="$TRIGGER_HEAD_SHA"
               fi
+              git merge-base --is-ancestor "$source_commit" "$source_ref_head"
               ;;
             *)
               echo "untrusted release build trigger" >&2
@@ -75,13 +97,16 @@ jobs:
               ;;
           esac
           [[ "$source_commit" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$source_ref_head" =~ ^[0-9a-f]{40}$ ]]
           git cat-file -e "$source_commit^{commit}"
-          git merge-base --is-ancestor "$source_commit" "origin/$DEFAULT_BRANCH"
           build_controller_commit="$(git rev-parse HEAD)"
           test "$build_controller_commit" = "$GITHUB_SHA"
           {
             echo "tag=$tag"
             echo "source_commit=$source_commit"
+            echo "release_line=$release_line"
+            echo "source_ref=$source_ref"
+            echo "source_ref_head=$source_ref_head"
             echo "channel=$channel"
             echo "build_controller_commit=$build_controller_commit"
           } >> "$GITHUB_OUTPUT"
@@ -94,5 +119,8 @@ jobs:
     with:
       tag_name: ${{ needs.resolve.outputs.tag }}
       source_commit: ${{ needs.resolve.outputs.source_commit }}
+      release_line: ${{ needs.resolve.outputs.release_line }}
+      source_ref: ${{ needs.resolve.outputs.source_ref }}
+      source_ref_head: ${{ needs.resolve.outputs.source_ref_head }}
       channel: ${{ needs.resolve.outputs.channel }}
       build_controller_commit: ${{ needs.resolve.outputs.build_controller_commit }}

--- a/.github/workflows/antfly-release-build-controller.yml
+++ b/.github/workflows/antfly-release-build-controller.yml
@@ -66,9 +66,11 @@ jobs:
               release_line="$(jq -r .release_line "$request")"
               source_ref="$(jq -r .source_ref "$request")"
               source_ref_head="$(jq -r .source_ref_head "$request")"
-              resolved="$(python scripts/release/release_lines.py resolve --tag "$tag")"
-              test "$release_line" = "$(jq -r .release_line <<<"$resolved")"
-              test "$source_ref" = "$(jq -r .source_ref <<<"$resolved")"
+              python scripts/release/release_lines.py verify-provenance \
+                --tag "$tag" \
+                --release-line "$release_line" \
+                --source-ref "$source_ref" \
+                --allow-closed >/dev/null
               test "$source_commit" = "$source_ref_head"
               git fetch --no-tags origin "$source_ref"
               current_source_head="$(git rev-parse FETCH_HEAD)"

--- a/.github/workflows/antfly-release-build.yml
+++ b/.github/workflows/antfly-release-build.yml
@@ -1,32 +1,114 @@
 name: Release request
 
-# Tag code has read-only access and emits only an untrusted identity request.
-# The release-build controller validates it from the default branch.
+# This main-owned workflow is the only supported release-tag creator. It
+# resolves the version line from controller policy, snapshots the protected
+# source branch tip, uploads that immutable request, and creates the tag last.
 on:
-  push:
-    tags:
-      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Canonical release tag, for example v0.2.1-rc.4"
+        required: true
+        type: string
 
 permissions:
   contents: read
 
+concurrency:
+  group: release-cut-${{ inputs.tag }}
+  cancel-in-progress: false
+
 jobs:
   request:
+    name: Cut protected release tag
+    if: ${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
     runs-on: ubuntu-latest
+    environment: release-cut
+    permissions:
+      actions: read
+      contents: write
     steps:
-      - name: Write untrusted tag request
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+      - name: Verify the protected release-cut environment contract
         env:
-          RELEASE_TAG: ${{ github.ref_name }}
-          SOURCE_COMMIT: ${{ github.sha }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python scripts/release/github_environment.py check \
+            --repository "$GITHUB_REPOSITORY" \
+            --environment release-cut
+          python scripts/release/github_rulesets.py check \
+            --repository "$GITHUB_REPOSITORY"
+      - name: Resolve trusted release source
+        id: source
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+          test "$GITHUB_REF" = "refs/heads/$DEFAULT_BRANCH"
+          git fetch --no-tags origin "refs/heads/$DEFAULT_BRANCH"
+          git merge-base --is-ancestor "$GITHUB_SHA" FETCH_HEAD
+          python scripts/release/release_channels.py resolve \
+            --tag "$RELEASE_TAG" --channel auto >/dev/null
+          resolved="$(python scripts/release/release_lines.py resolve \
+            --tag "$RELEASE_TAG" --github-output "$GITHUB_OUTPUT")"
+          source_ref="$(jq -r .source_ref <<<"$resolved")"
+          git fetch --no-tags origin "$source_ref"
+          source_ref_head="$(git rev-parse FETCH_HEAD)"
+          if test -n "$(git ls-remote --refs origin "refs/tags/$RELEASE_TAG")"; then
+            git fetch --force origin "refs/tags/$RELEASE_TAG:refs/tags/$RELEASE_TAG"
+            test "$(git cat-file -t "refs/tags/$RELEASE_TAG")" = tag
+            test "$(git rev-parse "$RELEASE_TAG^{commit}")" = "$source_ref_head"
+            tag_exists=true
+          else
+            tag_exists=false
+          fi
+          {
+            echo "source_ref_head=$source_ref_head"
+            echo "source_commit=$source_ref_head"
+            echo "tag_exists=$tag_exists"
+          } >> "$GITHUB_OUTPUT"
+      - name: Write immutable release request
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+          RELEASE_LINE: ${{ steps.source.outputs.release_line }}
+          SOURCE_REF: ${{ steps.source.outputs.source_ref }}
+          SOURCE_REF_HEAD: ${{ steps.source.outputs.source_ref_head }}
+          SOURCE_COMMIT: ${{ steps.source.outputs.source_commit }}
         run: |
           mkdir -p dist/build-request
           jq -n \
             --arg tag "$RELEASE_TAG" \
+            --arg release_line "$RELEASE_LINE" \
+            --arg source_ref "$SOURCE_REF" \
+            --arg source_ref_head "$SOURCE_REF_HEAD" \
             --arg source_commit "$SOURCE_COMMIT" \
-            '{schema_version: 1, request_kind: "tag", tag: $tag, source_commit: $source_commit, channel: "auto"}' \
+            '{schema_version: 2, request_kind: "tag", tag: $tag,
+              release_line: $release_line, source_ref: $source_ref,
+              source_ref_head: $source_ref_head, source_commit: $source_commit,
+              channel: "auto"}' \
             > dist/build-request/build-request.json
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: antfly-build-request
           path: dist/build-request/build-request.json
           if-no-files-found: error
+      - name: Create immutable annotated release tag
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+          SOURCE_COMMIT: ${{ steps.source.outputs.source_commit }}
+          TAG_EXISTS: ${{ steps.source.outputs.tag_exists }}
+        run: |
+          set -euo pipefail
+          if [ "$TAG_EXISTS" = true ]; then
+            echo "annotated tag already records the selected branch tip"
+            exit 0
+          fi
+          test "$TAG_EXISTS" = false
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git tag -a "$RELEASE_TAG" -m "$RELEASE_TAG" "$SOURCE_COMMIT"
+          git push origin "refs/tags/$RELEASE_TAG:refs/tags/$RELEASE_TAG"

--- a/.github/workflows/antfly-release-build.yml
+++ b/.github/workflows/antfly-release-build.yml
@@ -50,7 +50,7 @@ jobs:
           set -euo pipefail
           test "$GITHUB_REF" = "refs/heads/$DEFAULT_BRANCH"
           git fetch --no-tags origin "refs/heads/$DEFAULT_BRANCH"
-          git merge-base --is-ancestor "$GITHUB_SHA" FETCH_HEAD
+          test "$GITHUB_SHA" = "$(git rev-parse FETCH_HEAD)"
           python scripts/release/release_channels.py resolve \
             --tag "$RELEASE_TAG" --channel auto >/dev/null
           resolved="$(python scripts/release/release_lines.py resolve \
@@ -99,10 +99,20 @@ jobs:
       - name: Create immutable annotated release tag
         env:
           RELEASE_TAG: ${{ inputs.tag }}
+          SOURCE_REF: ${{ steps.source.outputs.source_ref }}
           SOURCE_COMMIT: ${{ steps.source.outputs.source_commit }}
           TAG_EXISTS: ${{ steps.source.outputs.tag_exists }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
           set -euo pipefail
+          # Abort a dispatch that became stale after approval or while its
+          # request artifact was being written. For a new tag, include the
+          # observed protected branch tips in one atomic push so a newer remote
+          # tip seen during push negotiation also rejects the tag creation.
+          git fetch --no-tags origin "refs/heads/$DEFAULT_BRANCH"
+          test "$GITHUB_SHA" = "$(git rev-parse FETCH_HEAD)"
+          git fetch --no-tags origin "$SOURCE_REF"
+          test "$SOURCE_COMMIT" = "$(git rev-parse FETCH_HEAD)"
           if [ "$TAG_EXISTS" = true ]; then
             echo "annotated tag already records the selected branch tip"
             exit 0
@@ -111,4 +121,12 @@ jobs:
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
           git tag -a "$RELEASE_TAG" -m "$RELEASE_TAG" "$SOURCE_COMMIT"
-          git push origin "refs/tags/$RELEASE_TAG:refs/tags/$RELEASE_TAG"
+          protected_refs=(
+            "$GITHUB_SHA:refs/heads/$DEFAULT_BRANCH"
+          )
+          if [ "$SOURCE_REF" != "refs/heads/$DEFAULT_BRANCH" ]; then
+            protected_refs+=("$SOURCE_COMMIT:$SOURCE_REF")
+          fi
+          git push --atomic origin \
+            "${protected_refs[@]}" \
+            "refs/tags/$RELEASE_TAG:refs/tags/$RELEASE_TAG"

--- a/.github/workflows/antfly-release-gc.yml
+++ b/.github/workflows/antfly-release-gc.yml
@@ -42,9 +42,11 @@ jobs:
       - name: Verify the protected release environment contract
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: >-
-          python scripts/release/github_environment.py check
-          --repository "$GITHUB_REPOSITORY"
+        run: |
+          python scripts/release/github_environment.py check \
+            --repository "$GITHUB_REPOSITORY"
+          python scripts/release/github_rulesets.py check \
+            --repository "$GITHUB_REPOSITORY"
       - name: Install hash-locked object storage client
         run: |
           python -m pip install --require-hashes -r scripts/release/requirements.lock

--- a/.github/workflows/antfly-release.yml
+++ b/.github/workflows/antfly-release.yml
@@ -44,6 +44,9 @@ jobs:
       python_version: ${{ steps.registry-identity.outputs.python_version }}
       container_tag: ${{ steps.registry-identity.outputs.container_tag }}
       commit: ${{ steps.identity.outputs.commit }}
+      release_line: ${{ steps.identity.outputs.release_line }}
+      source_ref: ${{ steps.identity.outputs.source_ref }}
+      source_ref_head: ${{ steps.identity.outputs.source_ref_head }}
       build_controller_commit: ${{ steps.identity.outputs.build_controller_commit }}
       promotion_controller_commit: ${{ steps.identity.outputs.promotion_controller_commit }}
       allow_legacy: ${{ steps.identity.outputs.allow_legacy }}
@@ -125,11 +128,21 @@ jobs:
           promotion_controller_commit="$(git rev-parse HEAD)"
           if [ "$EVENT_NAME" = workflow_run ]; then
             request=dist/release-request/release-request.json
-            test "$(jq -r .schema_version "$request")" = 4
+            provenance_schema="$(jq -r .schema_version "$request")"
+            test "$provenance_schema" = 4 || test "$provenance_schema" = 5
             raw="$(jq -r .tag "$request")"
             commit="$(jq -r .source_commit "$request")"
             build_controller_commit="$(jq -r .build_controller_commit "$request")"
             requested_channel="$(jq -r .channel "$request")"
+            if [ "$provenance_schema" = 5 ]; then
+              release_line="$(jq -r .release_line "$request")"
+              source_ref="$(jq -r .source_ref "$request")"
+              source_ref_head="$(jq -r .source_ref_head "$request")"
+            else
+              release_line=""
+              source_ref=""
+              source_ref_head=""
+            fi
             allow_legacy=false
             test "$BUILD_EVENT" = workflow_run
           else
@@ -138,6 +151,10 @@ jobs:
             expected_ledger="${RECOVERY_LEDGER_SHA256,,}"
             test -n "$expected_ledger"
             build_controller_commit=""
+            provenance_schema=""
+            release_line=""
+            source_ref=""
+            source_ref_head=""
             allow_legacy=true
           fi
           if ! [[ "$raw" =~ ^v?[0-9]+(\.[0-9]+){1,2}([-+][0-9A-Za-z.-]+)?$ ]]; then
@@ -166,17 +183,26 @@ jobs:
             echo "version=$version"
             echo "tag=$tag"
             echo "commit=$commit"
+            echo "provenance_schema=$provenance_schema"
+            echo "release_line=$release_line"
+            echo "source_ref=$source_ref"
+            echo "source_ref_head=$source_ref_head"
             echo "build_controller_commit=$build_controller_commit"
             echo "promotion_controller_commit=$promotion_controller_commit"
             echo "allow_legacy=$allow_legacy"
             echo "expected_ledger=$expected_ledger"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Require the tag and commit to be immutable default-branch history
+      - name: Require immutable controller and release-source history
         env:
+          EVENT_NAME: ${{ github.event_name }}
           RELEASE_TAG: ${{ steps.identity.outputs.tag }}
           RELEASE_COMMIT: ${{ steps.identity.outputs.commit }}
           RELEASE_CHANNEL: ${{ steps.identity.outputs.channel }}
+          PROVENANCE_SCHEMA: ${{ steps.identity.outputs.provenance_schema }}
+          RELEASE_LINE: ${{ steps.identity.outputs.release_line }}
+          SOURCE_REF: ${{ steps.identity.outputs.source_ref }}
+          SOURCE_REF_HEAD: ${{ steps.identity.outputs.source_ref_head }}
           BUILD_CONTROLLER_COMMIT: ${{ steps.identity.outputs.build_controller_commit }}
           PROMOTION_CONTROLLER_COMMIT: ${{ steps.identity.outputs.promotion_controller_commit }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
@@ -188,13 +214,30 @@ jobs:
           else
             git cat-file -e "$RELEASE_COMMIT^{commit}"
           fi
-          git merge-base --is-ancestor "$RELEASE_COMMIT" "origin/$DEFAULT_BRANCH"
           test "$(git rev-parse HEAD)" = "$PROMOTION_CONTROLLER_COMMIT"
           git merge-base --is-ancestor "$PROMOTION_CONTROLLER_COMMIT" "origin/$DEFAULT_BRANCH"
           if [ -n "$BUILD_CONTROLLER_COMMIT" ]; then
             [[ "$BUILD_CONTROLLER_COMMIT" =~ ^[0-9a-f]{40}$ ]]
             git cat-file -e "$BUILD_CONTROLLER_COMMIT^{commit}"
             git merge-base --is-ancestor "$BUILD_CONTROLLER_COMMIT" "origin/$DEFAULT_BRANCH"
+          fi
+          if [ "$EVENT_NAME" = workflow_run ]; then
+            if [ "$PROVENANCE_SCHEMA" = 5 ]; then
+              if [ "$RELEASE_CHANNEL" = nightly ]; then
+                resolved="$(python scripts/release/release_lines.py nightly)"
+              else
+                resolved="$(python scripts/release/release_lines.py resolve --tag "$RELEASE_TAG" --allow-closed)"
+                test "$RELEASE_COMMIT" = "$SOURCE_REF_HEAD"
+              fi
+              test "$RELEASE_LINE" = "$(jq -r .release_line <<<"$resolved")"
+              test "$SOURCE_REF" = "$(jq -r .source_ref <<<"$resolved")"
+              git fetch --no-tags origin "$SOURCE_REF"
+              current_source_head="$(git rev-parse FETCH_HEAD)"
+              git merge-base --is-ancestor "$SOURCE_REF_HEAD" "$current_source_head"
+              git merge-base --is-ancestor "$RELEASE_COMMIT" "$SOURCE_REF_HEAD"
+            else
+              git merge-base --is-ancestor "$RELEASE_COMMIT" "origin/$DEFAULT_BRANCH"
+            fi
           fi
 
       - name: Install hash-locked object storage client
@@ -335,6 +378,21 @@ jobs:
             --commit "$RELEASE_COMMIT" \
             --ledger-sha256 "$actual"
           echo "sha256=$actual" >> "$GITHUB_OUTPUT"
+
+      - name: Verify recovered legacy source ancestry
+        if: ${{ github.event_name == 'repository_dispatch' }}
+        env:
+          RELEASE_COMMIT: ${{ steps.identity.outputs.commit }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+          schema="$(jq -r .schema_version dist/release-payload/artifacts.json)"
+          if [ "$schema" -le 4 ]; then
+            git cat-file -e "$RELEASE_COMMIT^{commit}"
+            git merge-base --is-ancestor "$RELEASE_COMMIT" "origin/$DEFAULT_BRANCH"
+          else
+            test "$schema" = 5
+          fi
 
       - name: Repair the GitHub release mirror from verified bytes
         if: ${{ github.event_name == 'repository_dispatch' && steps.identity.outputs.github_release != 'none' && steps.recovery.outputs.source == 'object-storage' }}
@@ -627,10 +685,12 @@ jobs:
       - name: Verify the protected release environment contract
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: >-
-          python scripts/release/github_environment.py check
-          --repository "$GITHUB_REPOSITORY"
-          --environment release-promotion
+        run: |
+          python scripts/release/github_environment.py check \
+            --repository "$GITHUB_REPOSITORY" \
+            --environment release-promotion
+          python scripts/release/github_rulesets.py check \
+            --repository "$GITHUB_REPOSITORY"
       - name: Install hash-locked object storage client
         run: |
           python -m pip install --require-hashes -r scripts/release/requirements.lock

--- a/.github/workflows/antfly-release.yml
+++ b/.github/workflows/antfly-release.yml
@@ -225,12 +225,16 @@ jobs:
             if [ "$PROVENANCE_SCHEMA" = 5 ]; then
               if [ "$RELEASE_CHANNEL" = nightly ]; then
                 resolved="$(python scripts/release/release_lines.py nightly)"
+                test "$RELEASE_LINE" = "$(jq -r .release_line <<<"$resolved")"
+                test "$SOURCE_REF" = "$(jq -r .source_ref <<<"$resolved")"
               else
-                resolved="$(python scripts/release/release_lines.py resolve --tag "$RELEASE_TAG" --allow-closed)"
+                python scripts/release/release_lines.py verify-provenance \
+                  --tag "$RELEASE_TAG" \
+                  --release-line "$RELEASE_LINE" \
+                  --source-ref "$SOURCE_REF" \
+                  --allow-closed >/dev/null
                 test "$RELEASE_COMMIT" = "$SOURCE_REF_HEAD"
               fi
-              test "$RELEASE_LINE" = "$(jq -r .release_line <<<"$resolved")"
-              test "$SOURCE_REF" = "$(jq -r .source_ref <<<"$resolved")"
               git fetch --no-tags origin "$SOURCE_REF"
               current_source_head="$(git rev-parse FETCH_HEAD)"
               git merge-base --is-ancestor "$SOURCE_REF_HEAD" "$current_source_head"

--- a/.github/workflows/sdks-ci.yml
+++ b/.github/workflows/sdks-ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    branches: [main, "v*.x"]
   merge_group:
     types: [checks_requested]
   workflow_dispatch:

--- a/.github/workflows/zig-tests.yml
+++ b/.github/workflows/zig-tests.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: ["main"]
   pull_request:
-    branches: ["main"]
+    branches: ["main", "v*.x"]
   merge_group:
     types: [checks_requested]
   schedule:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -64,7 +64,8 @@ credentials; those refs provide only versioned source objects.
    is loaded through `workflow_run` from the default branch. It re-derives the
    source branch from current controller policy and requires the tag, source
    commit, and recorded branch head to agree. Direct tag pushes do not trigger
-   a release.
+   a release. If `main` or the selected source branch moves after approval, the
+   request fails before tag creation and must be dispatched again.
 2. The build controller pins its exact commit and calls
    `.github/workflows/antfly-artifact-build.yml`, the sole reusable artifact
    builder, from that same commit. The requested source commit supplies only
@@ -365,6 +366,12 @@ The tag's major/minor version selects its source through
 cannot cut new releases. Recovery may continue to resolve a closed line so an
 already sealed ledger does not become unusable.
 
+Each line records one current `source_ref` for new cuts and an append-only
+`trusted_source_refs` provenance list. When ownership moves from `main` to a
+maintenance branch, change `source_ref` and add the maintenance ref without
+removing `main`; retained ledgers and already approved requests remain valid
+against the branch that originally supplied their source.
+
 ## Maintenance Release Lines
 
 Before `main` advances to the next minor line, synchronize the maintenance
@@ -382,7 +389,10 @@ branch one final time and merge the release-policy support into it. After
 Adding a future line is a reviewed controller-policy change. When a line is no
 longer supported, retain its mapping but change its status to `closed`; deleting
 the mapping would also disable provenance validation for retained releases. A
-line's source ref is immutable after its first schema-v5 release.
+line's trusted source refs are append-only after its first schema-v5 release.
+Before `main` advances beyond a supported line, create and synchronize the
+matching `v<major>.<minor>.x` branch, change that line's current `source_ref`,
+and retain both refs in `trusted_source_refs`.
 
 Run a snapshot for the current default-branch head with
 `gh workflow run antfly-nightly.yml`. To reproduce a snapshot from a specific

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -49,17 +49,22 @@ SDK and enables Metal and Accelerate.
 
 ## Pipeline Ownership
 
-Release is split into an untrusted request plane, a default-branch artifact
-plane, and a default-branch promotion plane. Code loaded from a tag or manually
-selected workflow ref never controls a builder or receives publication
-credentials.
+Release is split into an approved request plane, a default-branch artifact
+plane, and a default-branch promotion plane. Code loaded from a tag or a
+maintenance branch never controls a workflow or receives publication
+credentials; those refs provide only versioned source objects.
 
 1. `.github/workflows/antfly-release-build.yml` and
-   `.github/workflows/antfly-nightly.yml` emit only an untrusted JSON request.
-   They never call a builder. `.github/workflows/antfly-release-build-controller.yml`
-   is loaded through `workflow_run` from the default branch. It requires tag
-   requests to match the pushed tag and commit, and nightly requests to have
-   been dispatched on the default branch.
+   `.github/workflows/antfly-nightly.yml` are dispatched on `main` and emit an
+   immutable JSON request. A version release passes the protected `release-cut`
+   environment, derives its source branch from the tag and
+   `scripts/release/release-lines.json`, snapshots that branch's exact tip,
+   uploads the request, and creates the annotated tag last. It never accepts a
+   caller-supplied source branch. `.github/workflows/antfly-release-build-controller.yml`
+   is loaded through `workflow_run` from the default branch. It re-derives the
+   source branch from current controller policy and requires the tag, source
+   commit, and recorded branch head to agree. Direct tag pushes do not trigger
+   a release.
 2. The build controller pins its exact commit and calls
    `.github/workflows/antfly-artifact-build.yml`, the sole reusable artifact
    builder, from that same commit. The requested source commit supplies only
@@ -70,22 +75,25 @@ credentials.
    calls `.github/workflows/cli-package.yml`, extracts `install.sh` and
    `openapi.yaml` directly from the selected Git commit, and uploads the native
    archives, CLI snapshot, commit-bound source snapshot, and
-   canonical `ReleaseSpec` (source commit, build-controller commit, channel,
-   build contract, and all registry versions) as an Actions artifact. The
+   canonical schema-v5 `ReleaseSpec` (release line, source ref, validated source
+   head, source commit, build-controller commit, channel, build contract, and
+   all registry versions) as an Actions artifact. The
    workflow graph, nested reusable workflows, and controller-owned scripts all
    share that recorded build-controller identity.
 3. Completion of the build controller triggers
    `.github/workflows/antfly-release.yml` through `workflow_run`. GitHub loads
    this privileged promotion workflow from the default branch. It checks the
-   channel identity and source commit, combines the build outputs into one
-   schema-versioned artifact ledger, verifies it, attests
+   channel identity and recorded release-line provenance, combines the build
+   outputs into one schema-versioned artifact ledger, verifies it, attests
    every payload file, and stores the exact bytes under immutable,
    content-addressed object-storage keys. Stable and next additionally stage
    those bytes on a draft GitHub Release; nightly deliberately does not create
    a GitHub Release.
-4. The promotion controller separates the complete payload into
-   ledger, runtime, and CLI scopes, and verifies source ancestry, attestations,
-   exact scope membership, and every digest.
+4. The promotion controller separates the complete payload into ledger,
+   runtime, and CLI scopes, and verifies controller ancestry, the recorded
+   source branch and head, attestations, exact scope membership, and every
+   digest. Schema-v4 payloads remain recoverable with their historical
+   default-branch ancestry rule; new builds always emit schema v5.
 5. Policy-selected package registries, the Homebrew formula, and the single
    multi-architecture container image consume those verified scopes. Stable
    and RC releases publish npm and PyPI packages; nightly builds verify the same
@@ -200,10 +208,11 @@ verified bytes and removes unledgered assets before publishing the release.
 Nightly uses R2 as its only policy-selected source.
 
 The deployment environments follow the versioned contract in
-`scripts/release/github-environments.json`. `release-promotion` accepts only the
-default `main` branch and protects release preflight plus retention approval;
+`scripts/release/github-environments.json`. `release-cut` and
+`release-promotion` accept only `main`; the former protects tag creation and the
+latter protects release preflight plus retention approval.
 `container-publish` accepts only the legacy release and operator tag patterns.
-Both copy the required-reviewer set from the `npm` environment and prevent
+All three copy the required-reviewer set from the `npm` environment and prevent
 self-review. Release preflight and retention planning audit the live GitHub
 configuration before any mutable or destructive operation. An administrator
 applies intentional contract changes with:
@@ -212,6 +221,22 @@ applies intentional contract changes with:
 python3 scripts/release/github_environment.py apply \
   --repository antflydb/antfly
 ```
+
+Repository ref protections follow
+`scripts/release/github-rulesets.json`. The branch ruleset covers `main` and
+`v*.x`, requires a reviewed PR and GitHub Actions-owned `sdks-ci`, `zig-base`,
+and `e2e-base` checks, and prohibits branch deletion and force-pushes. The tag
+ruleset prohibits updating or deleting `v*` tags. Apply and verify it with:
+
+```bash
+python3 scripts/release/github_rulesets.py apply \
+  --repository antflydb/antfly
+```
+
+The apply commands require repository-administration permission and must run
+after the contract change has merged. Maintenance PRs are included in the CI
+workflow branch filters so protected `v*.x` branches receive the same required
+checks.
 
 `.github/workflows/antfly-container.yml` has only a `workflow_call` entry point.
 It accepts only the default-branch promotion controller's normal `workflow_run`
@@ -327,6 +352,38 @@ represented by every publication target (notably container tags). Historical
 spellings such as `rc2`, `pre.2`, and `preview2` can be read from existing
 journals during recovery, but cannot create a new release candidate.
 
+Cut a stable or prerelease tag through the protected default-branch workflow;
+do not create or move it with `git tag`:
+
+```bash
+gh workflow run antfly-release-build.yml --ref main -f tag=v0.2.1-rc.4
+```
+
+The tag's major/minor version selects its source through
+`scripts/release/release-lines.json`. The initial policy maps `0.2` to
+`refs/heads/v0.2.x` and `0.3` to `refs/heads/main`. Unknown and closed lines
+cannot cut new releases. Recovery may continue to resolve a closed line so an
+already sealed ledger does not become unusable.
+
+## Maintenance Release Lines
+
+Before `main` advances to the next minor line, synchronize the maintenance
+branch one final time and merge the release-policy support into it. After
+`main` becomes `0.3`, `v0.2.x` owns all `0.2` source releases:
+
+1. Land the fix on `main` unless it is intentionally maintenance-only.
+2. Open a backport PR containing only the applicable commits against
+   `v0.2.x`; never merge the `0.3`-era `main` history into it.
+3. Wait for the protected maintenance-branch checks and review.
+4. Dispatch the release workflow from `main` with the next canonical
+   `v0.2.1-rc.N` tag. The controller tags the exact `v0.2.x` tip recorded in
+   provenance.
+
+Adding a future line is a reviewed controller-policy change. When a line is no
+longer supported, retain its mapping but change its status to `closed`; deleting
+the mapping would also disable provenance validation for retained releases. A
+line's source ref is immutable after its first schema-v5 release.
+
 Run a snapshot for the current default-branch head with
 `gh workflow run antfly-nightly.yml`. To reproduce a snapshot from a specific
 default-branch commit, add `-f source_commit=<40-character-commit>`.
@@ -387,9 +444,9 @@ new plan and approval. Fresh journal and alias ETags protect the actual sweep.
 Registry cleanup removes only container digests with no retained or channel
 references. Per-ledger container identity records have an independent
 lifecycle: every expired record is removed after registry validation even when
-its image digest is shared with a retained release. Conversely, a schema-v4
-release missing its immutable container record is retained for repair rather
-than partially collected. R2 payloads and identity records are deleted only
+its image digest is shared with a retained release. Conversely, a schema-v4 or
+schema-v5 release missing its immutable container record is retained for repair
+rather than partially collected. R2 payloads and identity records are deleted only
 after registry cleanup succeeds. The GC never deletes stable releases, shared
 content-addressed objects, or npm/PyPI versions. Immutable completion receipts
 remain as compact audit history after payload deletion. Existing `termite/`

--- a/scripts/packaging/test_cabi_packaging.py
+++ b/scripts/packaging/test_cabi_packaging.py
@@ -205,12 +205,22 @@ class CAbiPackagingTests(unittest.TestCase):
             'test "$TRIGGER_HEAD_BRANCH" = "$DEFAULT_BRANCH"', build_controller_workflow
         )
         self.assertIn("build_controller_commit:", artifact_build_workflow)
-        self.assertIn('tags:\n      - "v*"', release_build_workflow)
+        self.assertIn("workflow_dispatch:", release_build_workflow)
+        self.assertNotIn('tags:\n      - "v*"', release_build_workflow)
+        self.assertIn("environment: release-cut", release_build_workflow)
+        self.assertIn(
+            "python scripts/release/release_lines.py resolve", release_build_workflow
+        )
+        self.assertIn(
+            "python scripts/release/github_rulesets.py check", release_build_workflow
+        )
+        self.assertIn('git tag -a "$RELEASE_TAG"', release_build_workflow)
         self.assertIn("permissions:\n  contents: read", release_build_workflow)
-        self.assertNotIn("contents: write", release_build_workflow)
+        self.assertIn("contents: write", release_build_workflow)
         self.assertNotIn("id-token: write", release_build_workflow)
-        self.assertNotIn("environment:", release_build_workflow)
         self.assertNotIn("publish_objectstorage.py", release_build_workflow)
+        for field in ("release_line:", "source_ref:", "source_ref_head:"):
+            self.assertIn(field, artifact_build_workflow)
         self.assertIn("permissions:\n  contents: read", artifact_build_workflow)
         self.assertNotIn("contents: write", artifact_build_workflow)
         self.assertNotIn("id-token: write", artifact_build_workflow)
@@ -223,6 +233,7 @@ class CAbiPackagingTests(unittest.TestCase):
         self.assertIn("repository_dispatch:", release_workflow)
         self.assertIn("promote-cli-release", release_workflow)
         self.assertIn("promote-release-channel", release_workflow)
+        self.assertIn("github_rulesets.py check", release_workflow)
         self.assertIn("release_channels.py resolve", artifact_build_workflow)
         self.assertIn("release_platforms.py github-matrix", artifact_build_workflow)
         self.assertIn("verify_release_ledger.py", release_workflow)
@@ -402,6 +413,7 @@ class CAbiPackagingTests(unittest.TestCase):
         self.assertNotIn("environment: container-publish", release_gc_workflow)
         self.assertEqual(release_gc_workflow.count("environment: release-promotion"), 1)
         self.assertIn("github_environment.py check", release_gc_workflow)
+        self.assertIn("github_rulesets.py check", release_gc_workflow)
         self.assertIn(
             'test "$GITHUB_REF" = "refs/heads/$DEFAULT_BRANCH"',
             release_gc_workflow,
@@ -413,7 +425,10 @@ class CAbiPackagingTests(unittest.TestCase):
             release_gc_workflow.index("group: antfly-release-storage"),
         )
         environments = environment_policy["environments"]
-        self.assertEqual(set(environments), {"container-publish", "release-promotion"})
+        self.assertEqual(
+            set(environments),
+            {"container-publish", "release-cut", "release-promotion"},
+        )
         container_refs = {
             (policy["name"], policy["type"])
             for policy in environments["container-publish"]["branch_policies"]
@@ -422,10 +437,15 @@ class CAbiPackagingTests(unittest.TestCase):
             (policy["name"], policy["type"])
             for policy in environments["release-promotion"]["branch_policies"]
         }
+        release_cut_refs = {
+            (policy["name"], policy["type"])
+            for policy in environments["release-cut"]["branch_policies"]
+        }
         self.assertNotIn(("main", "branch"), container_refs)
         self.assertTrue(container_refs)
         self.assertTrue(all(policy_type == "tag" for _, policy_type in container_refs))
         self.assertEqual(release_refs, {("main", "branch")})
+        self.assertEqual(release_cut_refs, {("main", "branch")})
         sdk_npm_workflow = (
             REPO_ROOT / ".github" / "workflows" / "ts-npm-publish.yml"
         ).read_text()

--- a/scripts/release/build_release_payload.py
+++ b/scripts/release/build_release_payload.py
@@ -135,9 +135,31 @@ def verify_release_spec(path: Path, tag: str, commit: str) -> dict[str, object]:
     channel = document.get("channel")
     if not isinstance(build_controller_commit, str) or not isinstance(channel, str):
         raise SystemExit("release spec does not match the release identity")
-    expected = build_release_spec(
-        tag, channel, commit, build_controller_commit
-    ).document()
+    schema_version = document.get("schema_version")
+    if schema_version == 4:
+        expected = build_release_spec(
+            tag, channel, commit, build_controller_commit
+        ).document()
+    elif schema_version == 5:
+        release_line = document.get("release_line")
+        source_ref = document.get("source_ref")
+        source_ref_head = document.get("source_ref_head")
+        if not all(
+            isinstance(value, str)
+            for value in (release_line, source_ref, source_ref_head)
+        ):
+            raise SystemExit("release spec does not match the release identity")
+        expected = build_release_spec(
+            tag,
+            channel,
+            commit,
+            build_controller_commit,
+            release_line=release_line,
+            source_ref=source_ref,
+            source_ref_head=source_ref_head,
+        ).document()
+    else:
+        raise SystemExit("release spec uses an unsupported schema")
     if document != expected:
         raise SystemExit("release spec does not match the release identity")
     return document
@@ -266,6 +288,14 @@ def main() -> int:
         "registry_versions": registry_versions,
         "artifacts": artifacts,
     }
+    if release_spec["schema_version"] == 5:
+        metadata.update(
+            {
+                "release_line": release_spec["release_line"],
+                "source_ref": release_spec["source_ref"],
+                "source_ref_head": release_spec["source_ref_head"],
+            }
+        )
 
     metadata_path = out_dir / "metadata.json"
     artifacts_path = out_dir / "artifacts.json"
@@ -282,22 +312,27 @@ def main() -> int:
             "sha256": sha256(metadata_path),
         },
     ]
-    artifacts_path.write_text(
-        json.dumps(
+    ledger = {
+        "tag": tag,
+        "version": version,
+        "commit": args.commit,
+        "build_controller_commit": release_spec["build_controller_commit"],
+        "promotion_controller_commit": args.promotion_controller_commit,
+        "schema_version": release_spec["schema_version"],
+        "generated_at": release_generated_at,
+        "registry_versions": registry_versions,
+        "artifacts": ledger_artifacts,
+    }
+    if release_spec["schema_version"] == 5:
+        ledger.update(
             {
-                "tag": tag,
-                "version": version,
-                "commit": args.commit,
-                "build_controller_commit": release_spec["build_controller_commit"],
-                "promotion_controller_commit": args.promotion_controller_commit,
-                "schema_version": 4,
-                "generated_at": release_generated_at,
-                "registry_versions": registry_versions,
-                "artifacts": ledger_artifacts,
-            },
-            indent=2,
+                "release_line": release_spec["release_line"],
+                "source_ref": release_spec["source_ref"],
+                "source_ref_head": release_spec["source_ref_head"],
+            }
         )
-        + "\n",
+    artifacts_path.write_text(
+        json.dumps(ledger, indent=2) + "\n",
         encoding="utf-8",
     )
 

--- a/scripts/release/download_objectstorage.py
+++ b/scripts/release/download_objectstorage.py
@@ -113,7 +113,7 @@ class LocalReader:
 
 def payload_names(ledger_bytes: bytes) -> list[str]:
     ledger = json.loads(ledger_bytes)
-    if ledger.get("schema_version") not in {1, 2, 3, 4}:
+    if ledger.get("schema_version") not in {1, 2, 3, 4, 5}:
         raise SystemExit("unsupported release ledger schema")
     entries = ledger.get("artifacts")
     if not isinstance(entries, list) or not entries:

--- a/scripts/release/github-environments.json
+++ b/scripts/release/github-environments.json
@@ -1,6 +1,18 @@
 {
   "schema_version": 1,
   "environments": {
+    "release-cut": {
+      "reviewers_from": "npm",
+      "prevent_self_review": true,
+      "wait_timer": 0,
+      "deployment_branch_policy": {
+        "protected_branches": false,
+        "custom_branch_policies": true
+      },
+      "branch_policies": [
+        {"name": "main", "type": "branch"}
+      ]
+    },
     "container-publish": {
       "reviewers_from": "npm",
       "prevent_self_review": true,

--- a/scripts/release/github-rulesets.json
+++ b/scripts/release/github-rulesets.json
@@ -1,0 +1,58 @@
+{
+  "schema_version": 1,
+  "rulesets": {
+    "antfly-release-policy-branches": {
+      "target": "branch",
+      "enforcement": "active",
+      "bypass_actors": [],
+      "conditions": {
+        "ref_name": {
+          "include": ["refs/heads/main", "refs/heads/v*.x"],
+          "exclude": []
+        }
+      },
+      "rules": [
+        {"type": "deletion"},
+        {"type": "non_fast_forward"},
+        {
+          "type": "pull_request",
+          "parameters": {
+            "allowed_merge_methods": ["merge", "squash", "rebase"],
+            "dismiss_stale_reviews_on_push": true,
+            "require_code_owner_review": false,
+            "require_last_push_approval": true,
+            "required_approving_review_count": 1,
+            "required_review_thread_resolution": true
+          }
+        },
+        {
+          "type": "required_status_checks",
+          "parameters": {
+            "do_not_enforce_on_create": true,
+            "required_status_checks": [
+              {"context": "sdks-ci", "integration_id": 15368},
+              {"context": "zig-base", "integration_id": 15368},
+              {"context": "e2e-base", "integration_id": 15368}
+            ],
+            "strict_required_status_checks_policy": true
+          }
+        }
+      ]
+    },
+    "antfly-release-policy-tags": {
+      "target": "tag",
+      "enforcement": "active",
+      "bypass_actors": [],
+      "conditions": {
+        "ref_name": {
+          "include": ["refs/tags/v*"],
+          "exclude": []
+        }
+      },
+      "rules": [
+        {"type": "deletion"},
+        {"type": "update", "parameters": {"update_allows_fetch_and_merge": false}}
+      ]
+    }
+  }
+}

--- a/scripts/release/github_rulesets.py
+++ b/scripts/release/github_rulesets.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""Check or apply Antfly's versioned GitHub repository rulesets."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+from github_environment import GitHubAPI
+
+CONTRACT_PATH = Path(__file__).with_name("github-rulesets.json")
+RULESET_FIELDS = {
+    "target",
+    "enforcement",
+    "bypass_actors",
+    "conditions",
+    "rules",
+}
+
+
+def load_contract(path: Path = CONTRACT_PATH) -> dict[str, Any]:
+    try:
+        document = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise SystemExit(f"cannot load GitHub ruleset contract: {path}") from exc
+    rulesets = document.get("rulesets") if isinstance(document, dict) else None
+    if (
+        not isinstance(document, dict)
+        or set(document) != {"schema_version", "rulesets"}
+        or document.get("schema_version") != 1
+        or not isinstance(rulesets, dict)
+        or not rulesets
+    ):
+        raise SystemExit("unsupported GitHub ruleset contract")
+    for name, ruleset in rulesets.items():
+        if (
+            not isinstance(name, str)
+            or not name.startswith("antfly-release-policy-")
+            or not isinstance(ruleset, dict)
+            or set(ruleset) != RULESET_FIELDS
+            or ruleset.get("target") not in {"branch", "tag"}
+            or ruleset.get("enforcement") != "active"
+            or ruleset.get("bypass_actors") != []
+            or not isinstance(ruleset.get("conditions"), dict)
+            or not isinstance(ruleset.get("rules"), list)
+            or not ruleset["rules"]
+        ):
+            raise SystemExit(f"invalid GitHub ruleset contract for {name}")
+    return document
+
+
+def ruleset_payload(name: str, desired: dict[str, Any]) -> dict[str, Any]:
+    return {"name": name, **desired}
+
+
+def managed_rulesets(api: GitHubAPI, repository: str) -> dict[str, dict[str, Any]]:
+    summaries = api.request(
+        "GET", f"repos/{repository}/rulesets?includes_parents=false&per_page=100"
+    )
+    if not isinstance(summaries, list):
+        raise SystemExit("GitHub returned malformed repository rulesets")
+    result: dict[str, dict[str, Any]] = {}
+    for summary in summaries:
+        name = summary.get("name") if isinstance(summary, dict) else None
+        ruleset_id = summary.get("id") if isinstance(summary, dict) else None
+        if not isinstance(name, str) or not isinstance(ruleset_id, int):
+            raise SystemExit("GitHub returned a malformed repository ruleset")
+        if not name.startswith("antfly-release-policy-"):
+            continue
+        if name in result:
+            raise SystemExit(f"GitHub returned duplicate managed ruleset {name}")
+        current = api.request("GET", f"repos/{repository}/rulesets/{ruleset_id}")
+        if not isinstance(current, dict):
+            raise SystemExit(f"GitHub returned malformed ruleset {name}")
+        result[name] = current
+    return result
+
+
+def normalized_ruleset(document: dict[str, Any]) -> dict[str, Any]:
+    normalized = {
+        field: json.loads(json.dumps(document.get(field)))
+        for field in sorted(RULESET_FIELDS)
+    }
+    # GitHub omits an empty bypass list for tokens without repository-rules
+    # write access. Empty and omitted are equivalent for this no-bypass policy.
+    normalized["bypass_actors"] = sorted(
+        normalized["bypass_actors"] or [],
+        key=lambda actor: (
+            actor.get("actor_type", ""),
+            actor.get("actor_id") or -1,
+            actor.get("bypass_mode", ""),
+        ),
+    )
+    ref_name = normalized["conditions"]["ref_name"]
+    ref_name["include"] = sorted(ref_name["include"])
+    ref_name["exclude"] = sorted(ref_name["exclude"])
+    for rule in normalized["rules"]:
+        parameters = rule.get("parameters", {})
+        if "allowed_merge_methods" in parameters:
+            parameters["allowed_merge_methods"] = sorted(
+                parameters["allowed_merge_methods"]
+            )
+        if "required_status_checks" in parameters:
+            parameters["required_status_checks"] = sorted(
+                parameters["required_status_checks"],
+                key=lambda check: (check["context"], check.get("integration_id", -1)),
+            )
+    normalized["rules"] = sorted(normalized["rules"], key=lambda rule: rule["type"])
+    return normalized
+
+
+def ruleset_findings(
+    desired: dict[str, dict[str, Any]], current: dict[str, dict[str, Any]]
+) -> list[str]:
+    findings: list[str] = []
+    for name in sorted(desired.keys() - current.keys()):
+        findings.append(f"missing ruleset: {name}")
+    for name in sorted(current.keys() - desired.keys()):
+        findings.append(f"unexpected managed ruleset: {name}")
+    for name in sorted(desired.keys() & current.keys()):
+        if normalized_ruleset(current[name]) != normalized_ruleset(desired[name]):
+            findings.append(f"ruleset differs from contract: {name}")
+    return findings
+
+
+def apply_rulesets(
+    api: GitHubAPI,
+    repository: str,
+    desired: dict[str, dict[str, Any]],
+    current: dict[str, dict[str, Any]],
+) -> None:
+    for name, ruleset in desired.items():
+        payload = ruleset_payload(name, ruleset)
+        existing = current.get(name)
+        if existing is None:
+            api.request("POST", f"repos/{repository}/rulesets", payload)
+            continue
+        ruleset_id = existing.get("id")
+        if not isinstance(ruleset_id, int):
+            raise SystemExit(f"GitHub ruleset {name} has no numeric id")
+        if normalized_ruleset(existing) != normalized_ruleset(ruleset):
+            api.request("PUT", f"repos/{repository}/rulesets/{ruleset_id}", payload)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("check", "apply"))
+    parser.add_argument("--repository", default=os.environ.get("GITHUB_REPOSITORY", ""))
+    parser.add_argument("--contract", type=Path, default=CONTRACT_PATH)
+    args = parser.parse_args()
+    if not args.repository or "/" not in args.repository:
+        parser.error("--repository OWNER/REPO is required")
+
+    desired = load_contract(args.contract)["rulesets"]
+    api = GitHubAPI()
+    current = managed_rulesets(api, args.repository)
+    if args.command == "apply":
+        apply_rulesets(api, args.repository, desired, current)
+        current = managed_rulesets(api, args.repository)
+    findings = ruleset_findings(desired, current)
+    if findings:
+        raise SystemExit(
+            "GitHub repository rulesets do not match their contract:\n  "
+            + "\n  ".join(findings)
+            + "\nrun github_rulesets.py apply with an administrator token"
+        )
+    print(f"verified {len(desired)} GitHub repository ruleset(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release/release-lines.json
+++ b/scripts/release/release-lines.json
@@ -1,12 +1,14 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "lines": {
     "0.2": {
       "source_ref": "refs/heads/v0.2.x",
+      "trusted_source_refs": ["refs/heads/v0.2.x"],
       "status": "active"
     },
     "0.3": {
       "source_ref": "refs/heads/main",
+      "trusted_source_refs": ["refs/heads/main"],
       "status": "active"
     }
   },

--- a/scripts/release/release-lines.json
+++ b/scripts/release/release-lines.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 1,
+  "lines": {
+    "0.2": {
+      "source_ref": "refs/heads/v0.2.x",
+      "status": "active"
+    },
+    "0.3": {
+      "source_ref": "refs/heads/main",
+      "status": "active"
+    }
+  },
+  "nightly_source_ref": "refs/heads/main"
+}

--- a/scripts/release/release_channels.py
+++ b/scripts/release/release_channels.py
@@ -55,9 +55,12 @@ class ReleaseSpec:
     npm_version: str
     python_version: str
     container_tag: str
+    release_line: str | None = None
+    source_ref: str | None = None
+    source_ref_head: str | None = None
 
     def document(self) -> dict[str, object]:
-        return {
+        document: dict[str, object] = {
             "schema_version": 4,
             "tag": self.tag,
             "version": self.tag.removeprefix("v"),
@@ -71,6 +74,23 @@ class ReleaseSpec:
                 "container": self.container_tag,
             },
         }
+        source_provenance = (
+            self.release_line,
+            self.source_ref,
+            self.source_ref_head,
+        )
+        if any(value is not None for value in source_provenance):
+            if not all(value is not None for value in source_provenance):
+                raise SystemExit("release spec has incomplete source provenance")
+            document.update(
+                {
+                    "schema_version": 5,
+                    "release_line": self.release_line,
+                    "source_ref": self.source_ref,
+                    "source_ref_head": self.source_ref_head,
+                }
+            )
+        return document
 
 
 def parse_version(tag: str) -> tuple[tuple[int, int, int], tuple[str, ...] | None]:
@@ -154,6 +174,9 @@ def build_release_spec(
     policy: dict[str, Any] | None = None,
     *,
     allow_legacy: bool = False,
+    release_line: str | None = None,
+    source_ref: str | None = None,
+    source_ref_head: str | None = None,
 ) -> ReleaseSpec:
     for name, commit in (
         ("source", source_commit),
@@ -161,6 +184,18 @@ def build_release_spec(
     ):
         if not re.fullmatch(r"[0-9a-f]{40}", commit):
             raise SystemExit(f"invalid {name} commit: {commit}")
+    source_provenance = (release_line, source_ref, source_ref_head)
+    if any(value is not None for value in source_provenance):
+        if not all(value is not None for value in source_provenance):
+            raise SystemExit("release spec has incomplete source provenance")
+        if release_line != "nightly" and not re.fullmatch(
+            r"(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)", str(release_line)
+        ):
+            raise SystemExit(f"invalid release line: {release_line}")
+        if not re.fullmatch(r"refs/heads/[A-Za-z0-9._/-]+", str(source_ref)):
+            raise SystemExit(f"invalid release source ref: {source_ref}")
+        if not re.fullmatch(r"[0-9a-f]{40}", str(source_ref_head)):
+            raise SystemExit(f"invalid release source ref head: {source_ref_head}")
     channel_name, _ = resolve_channel(
         tag, requested_channel, policy, allow_legacy=allow_legacy
     )
@@ -173,6 +208,9 @@ def build_release_spec(
         npm_version=registry["npm_version"],
         python_version=registry["python_version"],
         container_tag=registry["container_tag"],
+        release_line=release_line,
+        source_ref=source_ref,
+        source_ref_head=source_ref_head,
     )
 
 
@@ -457,6 +495,9 @@ def main() -> int:
     parser.add_argument("--github-output", type=Path)
     parser.add_argument("--source-commit")
     parser.add_argument("--build-controller-commit")
+    parser.add_argument("--release-line")
+    parser.add_argument("--source-ref")
+    parser.add_argument("--source-ref-head")
     parser.add_argument("--allow-legacy", action="store_true")
     args = parser.parse_args()
 
@@ -469,6 +510,10 @@ def main() -> int:
     if args.command == "spec":
         if not args.source_commit or not args.build_controller_commit:
             parser.error("spec requires --source-commit and --build-controller-commit")
+        if not args.release_line or not args.source_ref or not args.source_ref_head:
+            parser.error(
+                "spec requires --release-line, --source-ref, and --source-ref-head"
+            )
         spec = build_release_spec(
             args.tag,
             args.channel,
@@ -476,6 +521,9 @@ def main() -> int:
             args.build_controller_commit,
             policy,
             allow_legacy=args.allow_legacy,
+            release_line=args.release_line,
+            source_ref=args.source_ref,
+            source_ref_head=args.source_ref_head,
         )
         print(json.dumps(spec.document(), indent=2, sort_keys=True))
         return 0

--- a/scripts/release/release_gc.py
+++ b/scripts/release/release_gc.py
@@ -34,7 +34,7 @@ RELEASE_ROOT = "antfly/"
 CONTENT_ROOT = "antfly/artifacts/sha256/"
 CONTAINER_IDENTITY_ROOT = "antfly/container-identities/"
 LEDGER_NAME = "artifacts.json"
-SUPPORTED_LEDGER_SCHEMAS = {1, 2, 3, 4}
+SUPPORTED_LEDGER_SCHEMAS = {1, 2, 3, 4, 5}
 SHA256 = re.compile(r"[0-9a-f]{64}")
 
 
@@ -388,7 +388,7 @@ def plan_gc(
                 retained[tag] = "newest-nightly-count"
             elif release.published_at >= nightly_cutoff:
                 retained[tag] = "nightly-age-window"
-            elif release.schema_version == 4 and tag not in container_records:
+            elif release.schema_version in {4, 5} and tag not in container_records:
                 retained[tag] = "missing-container-identity"
             else:
                 expired[tag] = "nightly-retention-expired"
@@ -398,7 +398,7 @@ def plan_gc(
                 retained[tag] = "awaiting-matching-stable"
             elif now < matching_stable_completed_at + prerelease_grace:
                 retained[tag] = "matching-stable-grace-window"
-            elif release.schema_version == 4 and tag not in container_records:
+            elif release.schema_version in {4, 5} and tag not in container_records:
                 retained[tag] = "missing-container-identity"
             else:
                 expired[tag] = "prerelease-grace-expired"

--- a/scripts/release/release_lines.py
+++ b/scripts/release/release_lines.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Resolve version tags to controller-owned release source branches."""
 
 from __future__ import annotations
@@ -26,6 +25,7 @@ LINE_STATUSES = {"active", "closed"}
 class ReleaseLine:
     name: str
     source_ref: str
+    trusted_source_refs: tuple[str, ...]
     status: str
 
     def outputs(self) -> dict[str, str]:
@@ -52,7 +52,7 @@ def validate_policy(policy: dict[str, Any]) -> None:
         "nightly_source_ref",
     }:
         raise SystemExit("release-line policy has an invalid top-level contract")
-    if policy["schema_version"] != 1:
+    if policy["schema_version"] != 2:
         raise SystemExit("unsupported release-line policy schema")
     if policy["nightly_source_ref"] != DEFAULT_BRANCH_REF:
         raise SystemExit("nightly releases must use refs/heads/main")
@@ -64,25 +64,36 @@ def validate_policy(policy: dict[str, Any]) -> None:
             raise SystemExit(f"invalid release line: {name!r}")
         if not isinstance(document, dict) or set(document) != {
             "source_ref",
+            "trusted_source_refs",
             "status",
         }:
             raise SystemExit(f"release line {name} has an invalid contract")
         source_ref = document["source_ref"]
+        trusted_source_refs = document["trusted_source_refs"]
         status = document["status"]
         if status not in LINE_STATUSES:
             raise SystemExit(f"release line {name} has an invalid status")
-        maintenance = (
-            MAINTENANCE_REF_PATTERN.fullmatch(source_ref)
-            if isinstance(source_ref, str)
-            else None
-        )
-        if source_ref != DEFAULT_BRANCH_REF and (
-            maintenance is None
-            or f"{maintenance.group(1)}.{maintenance.group(2)}" != name
+        if (
+            not isinstance(trusted_source_refs, list)
+            or not trusted_source_refs
+            or any(not isinstance(ref, str) for ref in trusted_source_refs)
+            or len(set(trusted_source_refs)) != len(trusted_source_refs)
+            or source_ref not in trusted_source_refs
         ):
             raise SystemExit(
-                f"release line {name} must use refs/heads/main or refs/heads/v{name}.x"
+                f"release line {name} must define unique trusted source refs "
+                "including its current source ref"
             )
+        for trusted_source_ref in trusted_source_refs:
+            maintenance = MAINTENANCE_REF_PATTERN.fullmatch(trusted_source_ref)
+            if trusted_source_ref != DEFAULT_BRANCH_REF and (
+                maintenance is None
+                or f"{maintenance.group(1)}.{maintenance.group(2)}" != name
+            ):
+                raise SystemExit(
+                    f"release line {name} must use refs/heads/main or "
+                    f"refs/heads/v{name}.x"
+                )
 
 
 def line_name_for_tag(tag: str) -> str:
@@ -106,12 +117,33 @@ def resolve_tag(
     status = str(document["status"])
     if status != "active" and not allow_closed:
         raise SystemExit(f"release line {name} is closed")
-    return ReleaseLine(name, str(document["source_ref"]), status)
+    return ReleaseLine(
+        name,
+        str(document["source_ref"]),
+        tuple(str(ref) for ref in document["trusted_source_refs"]),
+        status,
+    )
+
+
+def validate_provenance(
+    tag: str,
+    release_line: str,
+    source_ref: str,
+    policy: dict[str, Any] | None = None,
+    *,
+    allow_closed: bool = False,
+) -> ReleaseLine:
+    """Validate recorded provenance without changing the source for new cuts."""
+    expected = resolve_tag(tag, policy, allow_closed=allow_closed)
+    if release_line != expected.name or source_ref not in expected.trusted_source_refs:
+        raise SystemExit("invalid release-line provenance")
+    return expected
 
 
 def nightly_line(policy: dict[str, Any] | None = None) -> ReleaseLine:
     policy = policy or load_policy()
-    return ReleaseLine("nightly", str(policy["nightly_source_ref"]), "active")
+    source_ref = str(policy["nightly_source_ref"])
+    return ReleaseLine("nightly", source_ref, (source_ref,), "active")
 
 
 def write_outputs(outputs: dict[str, str], output_path: Path | None) -> None:
@@ -125,8 +157,12 @@ def write_outputs(outputs: dict[str, str], output_path: Path | None) -> None:
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("command", choices=("validate", "resolve", "nightly"))
+    parser.add_argument(
+        "command", choices=("validate", "resolve", "verify-provenance", "nightly")
+    )
     parser.add_argument("--tag")
+    parser.add_argument("--release-line")
+    parser.add_argument("--source-ref")
     parser.add_argument("--allow-closed", action="store_true")
     parser.add_argument("--github-output", type=Path)
     args = parser.parse_args()
@@ -135,10 +171,23 @@ def main() -> int:
     if args.command == "validate":
         print(f"validated {len(policy['lines'])} release lines")
         return 0
-    if args.command == "resolve":
+    if args.command in {"resolve", "verify-provenance"}:
         if not args.tag:
-            parser.error("resolve requires --tag")
-        line = resolve_tag(args.tag, policy, allow_closed=args.allow_closed)
+            parser.error(f"{args.command} requires --tag")
+        if args.command == "verify-provenance":
+            if not args.release_line or not args.source_ref:
+                parser.error(
+                    "verify-provenance requires --release-line and --source-ref"
+                )
+            line = validate_provenance(
+                args.tag,
+                args.release_line,
+                args.source_ref,
+                policy,
+                allow_closed=args.allow_closed,
+            )
+        else:
+            line = resolve_tag(args.tag, policy, allow_closed=args.allow_closed)
     else:
         line = nightly_line(policy)
     outputs = line.outputs()

--- a/scripts/release/release_lines.py
+++ b/scripts/release/release_lines.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Resolve version tags to controller-owned release source branches."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from release_channels import NIGHTLY_PATTERN, is_canonical_tag, parse_version
+
+POLICY_PATH = Path(__file__).with_name("release-lines.json")
+LINE_PATTERN = re.compile(r"^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$")
+MAINTENANCE_REF_PATTERN = re.compile(
+    r"^refs/heads/v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.x$"
+)
+DEFAULT_BRANCH_REF = "refs/heads/main"
+LINE_STATUSES = {"active", "closed"}
+
+
+@dataclass(frozen=True)
+class ReleaseLine:
+    name: str
+    source_ref: str
+    status: str
+
+    def outputs(self) -> dict[str, str]:
+        return {
+            "release_line": self.name,
+            "source_ref": self.source_ref,
+            "line_status": self.status,
+        }
+
+
+def load_policy(path: Path = POLICY_PATH) -> dict[str, Any]:
+    try:
+        policy = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise SystemExit(f"invalid release-line policy: {path}") from exc
+    validate_policy(policy)
+    return policy
+
+
+def validate_policy(policy: dict[str, Any]) -> None:
+    if not isinstance(policy, dict) or set(policy) != {
+        "schema_version",
+        "lines",
+        "nightly_source_ref",
+    }:
+        raise SystemExit("release-line policy has an invalid top-level contract")
+    if policy["schema_version"] != 1:
+        raise SystemExit("unsupported release-line policy schema")
+    if policy["nightly_source_ref"] != DEFAULT_BRANCH_REF:
+        raise SystemExit("nightly releases must use refs/heads/main")
+    lines = policy["lines"]
+    if not isinstance(lines, dict) or not lines:
+        raise SystemExit("release-line policy defines no release lines")
+    for name, document in lines.items():
+        if not isinstance(name, str) or not LINE_PATTERN.fullmatch(name):
+            raise SystemExit(f"invalid release line: {name!r}")
+        if not isinstance(document, dict) or set(document) != {
+            "source_ref",
+            "status",
+        }:
+            raise SystemExit(f"release line {name} has an invalid contract")
+        source_ref = document["source_ref"]
+        status = document["status"]
+        if status not in LINE_STATUSES:
+            raise SystemExit(f"release line {name} has an invalid status")
+        maintenance = (
+            MAINTENANCE_REF_PATTERN.fullmatch(source_ref)
+            if isinstance(source_ref, str)
+            else None
+        )
+        if source_ref != DEFAULT_BRANCH_REF and (
+            maintenance is None
+            or f"{maintenance.group(1)}.{maintenance.group(2)}" != name
+        ):
+            raise SystemExit(
+                f"release line {name} must use refs/heads/main or refs/heads/v{name}.x"
+            )
+
+
+def line_name_for_tag(tag: str) -> str:
+    if not is_canonical_tag(tag) or NIGHTLY_PATTERN.fullmatch(tag):
+        raise SystemExit(f"release line requires a canonical non-nightly tag: {tag}")
+    core, _ = parse_version(tag)
+    return f"{core[0]}.{core[1]}"
+
+
+def resolve_tag(
+    tag: str,
+    policy: dict[str, Any] | None = None,
+    *,
+    allow_closed: bool = False,
+) -> ReleaseLine:
+    policy = policy or load_policy()
+    name = line_name_for_tag(tag)
+    document = policy["lines"].get(name)
+    if not isinstance(document, dict):
+        raise SystemExit(f"no trusted release line is configured for {tag}")
+    status = str(document["status"])
+    if status != "active" and not allow_closed:
+        raise SystemExit(f"release line {name} is closed")
+    return ReleaseLine(name, str(document["source_ref"]), status)
+
+
+def nightly_line(policy: dict[str, Any] | None = None) -> ReleaseLine:
+    policy = policy or load_policy()
+    return ReleaseLine("nightly", str(policy["nightly_source_ref"]), "active")
+
+
+def write_outputs(outputs: dict[str, str], output_path: Path | None) -> None:
+    if output_path is None and os.environ.get("GITHUB_OUTPUT"):
+        output_path = Path(os.environ["GITHUB_OUTPUT"])
+    if output_path:
+        with output_path.open("a", encoding="utf-8") as output:
+            for key, value in outputs.items():
+                output.write(f"{key}={value}\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("validate", "resolve", "nightly"))
+    parser.add_argument("--tag")
+    parser.add_argument("--allow-closed", action="store_true")
+    parser.add_argument("--github-output", type=Path)
+    args = parser.parse_args()
+
+    policy = load_policy()
+    if args.command == "validate":
+        print(f"validated {len(policy['lines'])} release lines")
+        return 0
+    if args.command == "resolve":
+        if not args.tag:
+            parser.error("resolve requires --tag")
+        line = resolve_tag(args.tag, policy, allow_closed=args.allow_closed)
+    else:
+        line = nightly_line(policy)
+    outputs = line.outputs()
+    write_outputs(outputs, args.github_output)
+    print(json.dumps(outputs, sort_keys=True, separators=(",", ":")))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release/test_github_rulesets.py
+++ b/scripts/release/test_github_rulesets.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Tests for the versioned GitHub repository-ruleset contract."""
+
+from __future__ import annotations
+
+import copy
+import tempfile
+import unittest
+from pathlib import Path
+
+from github_rulesets import load_contract, normalized_ruleset, ruleset_findings
+
+
+class GitHubRulesetContractTests(unittest.TestCase):
+    def test_contract_protects_release_branches_and_version_tags(self) -> None:
+        rulesets = load_contract()["rulesets"]
+        branches = rulesets["antfly-release-policy-branches"]
+        tags = rulesets["antfly-release-policy-tags"]
+
+        self.assertEqual(
+            branches["conditions"]["ref_name"]["include"],
+            ["refs/heads/main", "refs/heads/v*.x"],
+        )
+        self.assertEqual(
+            {rule["type"] for rule in branches["rules"]},
+            {"deletion", "non_fast_forward", "pull_request", "required_status_checks"},
+        )
+        self.assertEqual(tags["conditions"]["ref_name"]["include"], ["refs/tags/v*"])
+        self.assertEqual(
+            {rule["type"] for rule in tags["rules"]}, {"deletion", "update"}
+        )
+
+    def test_findings_detect_missing_unexpected_and_drifted_rulesets(self) -> None:
+        desired = load_contract()["rulesets"]
+        names = sorted(desired)
+        current = {
+            names[0]: {"id": 1, "name": names[0], **copy.deepcopy(desired[names[0]])},
+            "antfly-release-policy-obsolete": {"id": 2},
+        }
+        current[names[0]]["enforcement"] = "disabled"
+
+        self.assertEqual(
+            ruleset_findings(desired, current),
+            [
+                f"missing ruleset: {names[1]}",
+                "unexpected managed ruleset: antfly-release-policy-obsolete",
+                f"ruleset differs from contract: {names[0]}",
+            ],
+        )
+
+    def test_normalization_ignores_api_response_metadata(self) -> None:
+        desired = load_contract()["rulesets"]["antfly-release-policy-tags"]
+        current = {"id": 42, "name": "ignored", **copy.deepcopy(desired)}
+        self.assertEqual(normalized_ruleset(current), normalized_ruleset(desired))
+
+    def test_contract_loader_rejects_non_object_document(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            path = Path(raw) / "rulesets.json"
+            path.write_text("[]\n", encoding="utf-8")
+            with self.assertRaisesRegex(SystemExit, "unsupported GitHub ruleset"):
+                load_contract(path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/release/test_release_lines.py
+++ b/scripts/release/test_release_lines.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Tests for controller-owned release-line policy."""
+
+from __future__ import annotations
+
+import copy
+import unittest
+
+import release_lines
+
+
+class ReleaseLinePolicyTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.policy = release_lines.load_policy()
+
+    def test_active_lines_resolve_from_canonical_tags(self) -> None:
+        line = release_lines.resolve_tag("v0.2.1-rc.4", self.policy)
+        self.assertEqual((line.name, line.source_ref), ("0.2", "refs/heads/v0.2.x"))
+        line = release_lines.resolve_tag("v0.3.0", self.policy)
+        self.assertEqual((line.name, line.source_ref), ("0.3", "refs/heads/main"))
+
+    def test_tag_cannot_select_a_different_release_line(self) -> None:
+        with self.assertRaisesRegex(SystemExit, "no trusted release line"):
+            release_lines.resolve_tag("v0.4.0-rc.1", self.policy)
+
+    def test_noncanonical_and_nightly_tags_cannot_select_release_lines(self) -> None:
+        for tag in ("v0.2.1-rc4", "v0.0.0-dev.12"):
+            with self.subTest(tag=tag), self.assertRaisesRegex(
+                SystemExit, "canonical non-nightly"
+            ):
+                release_lines.resolve_tag(tag, self.policy)
+
+    def test_closed_line_is_recovery_only(self) -> None:
+        policy = copy.deepcopy(self.policy)
+        policy["lines"]["0.2"]["status"] = "closed"
+        release_lines.validate_policy(policy)
+        with self.assertRaisesRegex(SystemExit, "closed"):
+            release_lines.resolve_tag("v0.2.1", policy)
+        self.assertEqual(
+            release_lines.resolve_tag("v0.2.1", policy, allow_closed=True).source_ref,
+            "refs/heads/v0.2.x",
+        )
+
+    def test_policy_rejects_arbitrary_or_cross_line_source_refs(self) -> None:
+        for source_ref in (
+            "refs/heads/feature/release",
+            "refs/heads/v0.3.x",
+            "refs/tags/v0.2.1",
+            "main",
+        ):
+            policy = copy.deepcopy(self.policy)
+            policy["lines"]["0.2"]["source_ref"] = source_ref
+            with self.subTest(source_ref=source_ref), self.assertRaises(SystemExit):
+                release_lines.validate_policy(policy)
+
+    def test_nightly_is_always_main(self) -> None:
+        self.assertEqual(
+            release_lines.nightly_line(self.policy).source_ref,
+            "refs/heads/main",
+        )
+        policy = copy.deepcopy(self.policy)
+        policy["nightly_source_ref"] = "refs/heads/v0.2.x"
+        with self.assertRaisesRegex(SystemExit, "nightly"):
+            release_lines.validate_policy(policy)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/release/test_release_lines.py
+++ b/scripts/release/test_release_lines.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Tests for controller-owned release-line policy."""
 
 from __future__ import annotations
@@ -16,6 +15,7 @@ class ReleaseLinePolicyTests(unittest.TestCase):
     def test_active_lines_resolve_from_canonical_tags(self) -> None:
         line = release_lines.resolve_tag("v0.2.1-rc.4", self.policy)
         self.assertEqual((line.name, line.source_ref), ("0.2", "refs/heads/v0.2.x"))
+        self.assertEqual(line.trusted_source_refs, ("refs/heads/v0.2.x",))
         line = release_lines.resolve_tag("v0.3.0", self.policy)
         self.assertEqual((line.name, line.source_ref), ("0.3", "refs/heads/main"))
 
@@ -25,8 +25,9 @@ class ReleaseLinePolicyTests(unittest.TestCase):
 
     def test_noncanonical_and_nightly_tags_cannot_select_release_lines(self) -> None:
         for tag in ("v0.2.1-rc4", "v0.0.0-dev.12"):
-            with self.subTest(tag=tag), self.assertRaisesRegex(
-                SystemExit, "canonical non-nightly"
+            with (
+                self.subTest(tag=tag),
+                self.assertRaisesRegex(SystemExit, "canonical non-nightly"),
             ):
                 release_lines.resolve_tag(tag, self.policy)
 
@@ -40,6 +41,37 @@ class ReleaseLinePolicyTests(unittest.TestCase):
             release_lines.resolve_tag("v0.2.1", policy, allow_closed=True).source_ref,
             "refs/heads/v0.2.x",
         )
+        release_lines.validate_provenance(
+            "v0.2.1",
+            "0.2",
+            "refs/heads/v0.2.x",
+            policy,
+            allow_closed=True,
+        )
+
+    def test_source_handoff_preserves_historical_provenance(self) -> None:
+        policy = copy.deepcopy(self.policy)
+        policy["lines"]["0.3"]["source_ref"] = "refs/heads/v0.3.x"
+        policy["lines"]["0.3"]["trusted_source_refs"].append("refs/heads/v0.3.x")
+        release_lines.validate_policy(policy)
+
+        current = release_lines.resolve_tag("v0.3.1", policy)
+        self.assertEqual(current.source_ref, "refs/heads/v0.3.x")
+        release_lines.validate_provenance("v0.3.0", "0.3", "refs/heads/main", policy)
+        release_lines.validate_provenance("v0.3.1", "0.3", "refs/heads/v0.3.x", policy)
+
+    def test_provenance_rejects_wrong_line_or_untrusted_source(self) -> None:
+        for line, source_ref in (
+            ("0.2", "refs/heads/main"),
+            ("0.3", "refs/heads/v0.2.x"),
+        ):
+            with (
+                self.subTest(line=line, source_ref=source_ref),
+                self.assertRaisesRegex(SystemExit, "invalid release-line provenance"),
+            ):
+                release_lines.validate_provenance(
+                    "v0.3.0", line, source_ref, self.policy
+                )
 
     def test_policy_rejects_arbitrary_or_cross_line_source_refs(self) -> None:
         for source_ref in (
@@ -51,6 +83,22 @@ class ReleaseLinePolicyTests(unittest.TestCase):
             policy = copy.deepcopy(self.policy)
             policy["lines"]["0.2"]["source_ref"] = source_ref
             with self.subTest(source_ref=source_ref), self.assertRaises(SystemExit):
+                release_lines.validate_policy(policy)
+
+    def test_policy_rejects_invalid_or_incomplete_trusted_source_history(self) -> None:
+        for trusted_source_refs in (
+            [],
+            ["refs/heads/main"],
+            ["refs/heads/v0.2.x", "refs/heads/v0.2.x"],
+            ["refs/heads/v0.2.x", "refs/heads/v0.3.x"],
+            ["refs/heads/v0.2.x", "refs/heads/feature"],
+        ):
+            policy = copy.deepcopy(self.policy)
+            policy["lines"]["0.2"]["trusted_source_refs"] = trusted_source_refs
+            with (
+                self.subTest(trusted_source_refs=trusted_source_refs),
+                self.assertRaises(SystemExit),
+            ):
                 release_lines.validate_policy(policy)
 
     def test_nightly_is_always_main(self) -> None:

--- a/scripts/release/test_release_promotion.py
+++ b/scripts/release/test_release_promotion.py
@@ -100,6 +100,91 @@ class ReleasePromotionTests(unittest.TestCase):
                 (output / "install.sh").read_bytes(), objects["scripts/install.sh"]
             )
 
+    def test_release_spec_records_trusted_release_line_provenance(self) -> None:
+        channels = load_module(
+            "release_channels_provenance_test", "release_channels.py"
+        )
+        document = channels.build_release_spec(
+            "v0.2.1-rc.4",
+            "auto",
+            COMMIT,
+            "f" * 40,
+            release_line="0.2",
+            source_ref="refs/heads/v0.2.x",
+            source_ref_head=COMMIT,
+        ).document()
+
+        self.assertEqual(document["schema_version"], 5)
+        self.assertEqual(document["release_line"], "0.2")
+        self.assertEqual(document["source_ref"], "refs/heads/v0.2.x")
+        self.assertEqual(document["source_ref_head"], COMMIT)
+
+    def test_schema_five_ledger_enforces_controller_release_line(self) -> None:
+        verifier = load_module(
+            "verify_release_ledger_provenance_test", "verify_release_ledger.py"
+        )
+        with tempfile.TemporaryDirectory() as raw_tmp:
+            root = Path(raw_tmp)
+            artifact = root / "antfly.tar.gz"
+            artifact.write_bytes(b"release")
+            ledger_path = root / "artifacts.json"
+            ledger = {
+                "schema_version": 5,
+                "tag": "v0.2.1-rc.4",
+                "commit": COMMIT,
+                "release_line": "0.2",
+                "source_ref": "refs/heads/v0.2.x",
+                "source_ref_head": COMMIT,
+                "build_controller_commit": "e" * 40,
+                "promotion_controller_commit": "f" * 40,
+                "artifacts": [
+                    {
+                        "name": artifact.name,
+                        "size": artifact.stat().st_size,
+                        "sha256": verifier.sha256(artifact),
+                        "scope": "runtime",
+                    }
+                ],
+            }
+            ledger_path.write_text(json.dumps(ledger))
+            verifier.verify_payload(
+                ledger_path,
+                root,
+                "v0.2.1-rc.4",
+                COMMIT,
+                verifier.sha256(ledger_path),
+                None,
+            )
+
+            ledger["source_ref"] = "refs/heads/main"
+            ledger_path.write_text(json.dumps(ledger))
+            with self.assertRaisesRegex(SystemExit, "release-line provenance"):
+                verifier.verify_payload(
+                    ledger_path,
+                    root,
+                    "v0.2.1-rc.4",
+                    COMMIT,
+                    verifier.sha256(ledger_path),
+                    None,
+                )
+
+    def test_schema_four_release_spec_remains_compatible(self) -> None:
+        channels = load_module("release_channels_v4_compat_test", "release_channels.py")
+        payload = load_module(
+            "build_release_payload_v4_compat_test", "build_release_payload.py"
+        )
+        with tempfile.TemporaryDirectory() as raw_tmp:
+            path = Path(raw_tmp) / "release-request.json"
+            document = channels.build_release_spec(
+                "v1.2.3", "stable", COMMIT, "f" * 40
+            ).document()
+            path.write_text(json.dumps(document))
+
+            self.assertEqual(document["schema_version"], 4)
+            self.assertEqual(
+                payload.verify_release_spec(path, "v1.2.3", COMMIT), document
+            )
+
     def test_release_channel_policy_resolves_all_supported_channels(self) -> None:
         channels = load_module("release_channels_test", "release_channels.py")
         policy = channels.load_policy()
@@ -1216,16 +1301,16 @@ class ReleasePromotionTests(unittest.TestCase):
             archives.mkdir()
             extras.mkdir()
             source.mkdir()
-            (archives / "antfly_1.2.3_Linux_x86_64_gnu.tar.gz").write_bytes(b"native")
-            (extras / "antfly-cli-1.2.3.tgz").write_bytes(b"npm")
+            (archives / "antfly_0.2.1_Linux_x86_64_gnu.tar.gz").write_bytes(b"native")
+            (extras / "antfly-cli-0.2.1.tgz").write_bytes(b"npm")
             (extras / "cli-snapshot.json").write_text(
                 json.dumps(
                     {
-                        "version": "1.2.3",
+                        "version": "0.2.1",
                         "commit": COMMIT,
                         "registry_versions": {
-                            "npm": "1.2.3",
-                            "python": "1.2.3",
+                            "npm": "0.2.1",
+                            "python": "0.2.1",
                         },
                     }
                 )
@@ -1259,17 +1344,20 @@ class ReleasePromotionTests(unittest.TestCase):
             release_spec.write_text(
                 json.dumps(
                     {
-                        "schema_version": 4,
-                        "tag": "v1.2.3",
-                        "version": "1.2.3",
+                        "schema_version": 5,
+                        "tag": "v0.2.1",
+                        "version": "0.2.1",
                         "channel": "stable",
                         "source_commit": COMMIT,
+                        "release_line": "0.2",
+                        "source_ref": "refs/heads/v0.2.x",
+                        "source_ref_head": COMMIT,
                         "build_controller_commit": "f" * 40,
                         "build_contract_schema": 1,
                         "registry_versions": {
-                            "npm": "1.2.3",
-                            "python": "1.2.3",
-                            "container": "v1.2.3",
+                            "npm": "0.2.1",
+                            "python": "0.2.1",
+                            "container": "v0.2.1",
                         },
                     }
                 )
@@ -1277,7 +1365,7 @@ class ReleasePromotionTests(unittest.TestCase):
             argv = [
                 "build_release_payload.py",
                 "--tag",
-                "v1.2.3",
+                "v0.2.1",
                 "--commit",
                 COMMIT,
                 "--archive-dir",
@@ -1299,13 +1387,16 @@ class ReleasePromotionTests(unittest.TestCase):
             ):
                 self.assertEqual(payload.main(), 0)
             ledger = json.loads((output / "artifacts.json").read_text())
-            self.assertEqual(ledger["schema_version"], 4)
+            self.assertEqual(ledger["schema_version"], 5)
+            self.assertEqual(ledger["release_line"], "0.2")
+            self.assertEqual(ledger["source_ref"], "refs/heads/v0.2.x")
+            self.assertEqual(ledger["source_ref_head"], COMMIT)
             self.assertEqual(ledger["build_controller_commit"], "f" * 40)
             self.assertEqual(ledger["promotion_controller_commit"], "e" * 40)
             self.assertEqual(ledger["generated_at"], "1970-01-01T00:00:00Z")
             self.assertEqual(
                 ledger["registry_versions"],
-                {"npm": "1.2.3", "python": "1.2.3", "container": "v1.2.3"},
+                {"npm": "0.2.1", "python": "0.2.1", "container": "v0.2.1"},
             )
             kinds = {artifact["kind"] for artifact in ledger["artifacts"]}
             self.assertIn("runtime-archive", kinds)
@@ -1321,7 +1412,7 @@ class ReleasePromotionTests(unittest.TestCase):
             )
             promotion = root / "promotion"
             promotion.mkdir()
-            promoted_package = promotion / "antfly-cli-1.2.3.tgz"
+            promoted_package = promotion / "antfly-cli-0.2.1.tgz"
             promoted_package.write_bytes((output / promoted_package.name).read_bytes())
             promoted_manifest = promotion / "cli-snapshot.json"
             promoted_manifest.write_bytes(
@@ -1336,7 +1427,7 @@ class ReleasePromotionTests(unittest.TestCase):
                 "--scope",
                 "cli",
                 "--tag",
-                "v1.2.3",
+                "v0.2.1",
                 "--commit",
                 COMMIT,
                 "--ledger-sha256",

--- a/scripts/release/test_release_promotion.py
+++ b/scripts/release/test_release_promotion.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import copy
 import hashlib
 import importlib.util
 import io
@@ -167,6 +168,51 @@ class ReleasePromotionTests(unittest.TestCase):
                     verifier.sha256(ledger_path),
                     None,
                 )
+
+    def test_schema_five_ledger_survives_release_line_handoff(self) -> None:
+        verifier = load_module(
+            "verify_release_ledger_handoff_test", "verify_release_ledger.py"
+        )
+        release_lines = load_module("release_lines_handoff_test", "release_lines.py")
+        policy = copy.deepcopy(release_lines.load_policy())
+        policy["lines"]["0.3"]["source_ref"] = "refs/heads/v0.3.x"
+        policy["lines"]["0.3"]["trusted_source_refs"].append("refs/heads/v0.3.x")
+        release_lines.validate_policy(policy)
+
+        with tempfile.TemporaryDirectory() as raw_tmp:
+            root = Path(raw_tmp)
+            artifact = root / "antfly.tar.gz"
+            artifact.write_bytes(b"release")
+            ledger_path = root / "artifacts.json"
+            ledger = {
+                "schema_version": 5,
+                "tag": "v0.3.0",
+                "commit": COMMIT,
+                "release_line": "0.3",
+                "source_ref": "refs/heads/main",
+                "source_ref_head": COMMIT,
+                "build_controller_commit": "e" * 40,
+                "promotion_controller_commit": "f" * 40,
+                "artifacts": [
+                    {
+                        "name": artifact.name,
+                        "size": artifact.stat().st_size,
+                        "sha256": verifier.sha256(artifact),
+                        "scope": "runtime",
+                    }
+                ],
+            }
+            ledger_path.write_text(json.dumps(ledger))
+
+            verifier.verify_payload(
+                ledger_path,
+                root,
+                "v0.3.0",
+                COMMIT,
+                verifier.sha256(ledger_path),
+                None,
+                policy,
+            )
 
     def test_schema_four_release_spec_remains_compatible(self) -> None:
         channels = load_module("release_channels_v4_compat_test", "release_channels.py")

--- a/scripts/release/verify_release_ledger.py
+++ b/scripts/release/verify_release_ledger.py
@@ -10,7 +10,7 @@ import re
 from pathlib import Path
 
 from release_channels import NIGHTLY_PATTERN
-from release_lines import nightly_line, resolve_tag
+from release_lines import nightly_line, validate_provenance
 
 
 def inferred_scope(entry: dict[str, object]) -> str:
@@ -40,6 +40,7 @@ def verify_payload(
     commit: str,
     ledger_sha256: str,
     scope: str | None = None,
+    release_line_policy: dict[str, object] | None = None,
 ) -> str:
     expected_ledger_digest = ledger_sha256.lower()
     if not re.fullmatch(r"[0-9a-f]{64}", expected_ledger_digest):
@@ -74,9 +75,13 @@ def verify_payload(
             if release_line != expected.name or source_ref != expected.source_ref:
                 raise SystemExit("release ledger has invalid nightly source provenance")
         else:
-            expected = resolve_tag(tag, allow_closed=True)
-            if release_line != expected.name or source_ref != expected.source_ref:
-                raise SystemExit("release ledger has invalid release-line provenance")
+            validate_provenance(
+                tag,
+                release_line,
+                source_ref,
+                release_line_policy,
+                allow_closed=True,
+            )
             if source_ref_head != commit:
                 raise SystemExit(
                     "release ledger source head differs from release commit"

--- a/scripts/release/verify_release_ledger.py
+++ b/scripts/release/verify_release_ledger.py
@@ -9,6 +9,9 @@ import json
 import re
 from pathlib import Path
 
+from release_channels import NIGHTLY_PATTERN
+from release_lines import nightly_line, resolve_tag
+
 
 def inferred_scope(entry: dict[str, object]) -> str:
     scope = entry.get("scope")
@@ -50,14 +53,34 @@ def verify_payload(
 
     ledger = json.loads(ledger_path.read_text(encoding="utf-8"))
     schema_version = ledger.get("schema_version")
-    if schema_version not in {1, 2, 3, 4}:
+    if schema_version not in {1, 2, 3, 4, 5}:
         raise SystemExit("unsupported release ledger schema")
     if ledger.get("tag") != tag or ledger.get("commit") != commit:
         raise SystemExit("release ledger does not match the requested tag and commit")
-    if schema_version == 4:
+    if schema_version in {4, 5}:
         for field in ("build_controller_commit", "promotion_controller_commit"):
             if not re.fullmatch(r"[0-9a-f]{40}", str(ledger.get(field, ""))):
                 raise SystemExit(f"release ledger has an invalid {field}")
+    if schema_version == 5:
+        release_line = ledger.get("release_line")
+        source_ref = ledger.get("source_ref")
+        source_ref_head = ledger.get("source_ref_head")
+        if not isinstance(release_line, str) or not isinstance(source_ref, str):
+            raise SystemExit("release ledger has invalid source provenance")
+        if not re.fullmatch(r"[0-9a-f]{40}", str(source_ref_head)):
+            raise SystemExit("release ledger has invalid source provenance")
+        if NIGHTLY_PATTERN.fullmatch(tag):
+            expected = nightly_line()
+            if release_line != expected.name or source_ref != expected.source_ref:
+                raise SystemExit("release ledger has invalid nightly source provenance")
+        else:
+            expected = resolve_tag(tag, allow_closed=True)
+            if release_line != expected.name or source_ref != expected.source_ref:
+                raise SystemExit("release ledger has invalid release-line provenance")
+            if source_ref_head != commit:
+                raise SystemExit(
+                    "release ledger source head differs from release commit"
+                )
 
     entries: dict[str, dict[str, object]] = {}
     ledger_artifacts = ledger.get("artifacts")
@@ -74,7 +97,7 @@ def verify_payload(
             or name in entries
         ):
             raise SystemExit("release ledger contains an invalid or duplicate artifact")
-        if schema_version in {2, 3, 4} and entry.get("scope") not in {
+        if schema_version in {2, 3, 4, 5} and entry.get("scope") not in {
             "runtime",
             "cli",
             "support",


### PR DESCRIPTION
## Summary

- add a controller-owned release-line map (`0.2 -> v0.2.x`, `0.3 -> main`) and derive source refs exclusively from canonical tags
- replace direct tag-triggered builds with an approved main-owned release-cut workflow that snapshots the selected branch tip, writes an immutable request, and creates the annotated tag last
- carry release line, source ref, and validated ref head through schema-v5 build/promotion provenance while retaining schema-v4 recovery compatibility
- codify main/v*.x branch protection and immutable v* tag rulesets, audit them at privileged release/GC entry points, and enable CI on maintenance PRs
- document the backport-only maintenance lifecycle once main advances to 0.3

## Verification

- `scripts/release/test.sh` (10 packaging tests, 111 release tests)
- `actionlint` on all changed workflows
- `scripts/release/validate_workflow_actions.py`
- `git diff --check`

## Rollout after merge

1. Synchronize this final pre-0.3 main state into `v0.2.x`, so the maintenance branch has the CI trigger/support contract.
2. Apply `scripts/release/github_environment.py` to create the protected `release-cut` environment.
3. Apply `scripts/release/github_rulesets.py` to protect `main`, `v*.x`, and `v*` tags.
4. Cut subsequent releases with `gh workflow run antfly-release-build.yml --ref main -f tag=v0.2.1-rc.N`.

The live ruleset audit currently reports both managed rulesets as missing; this is intentional until the introducing PR and final maintenance-branch synchronization are merged.