### PR TITLE
Bound Raft replication pipelines before runtime quarantine

### DIFF
--- a/zig/pkg/antfly/src/data/runtime.zig
+++ b/zig/pkg/antfly/src/data/runtime.zig
@@ -392,6 +392,9 @@ const internal_service_issuer_key = "antfly.internal_service.issuer";
 const internal_service_rollout_mode_key = "antfly.internal_service.rollout_mode";
 const data_raft_max_snapshot_transfer_bytes: usize = 1 << 30;
 const data_raft_max_regular_ready_bytes: usize = 64 * 1024 * 1024;
+// Bound each follower independently; the runtime Ready ceiling remains a
+// last-resort invariant rather than ordinary replication flow control.
+const data_raft_max_inflight_bytes_per_peer: usize = data_raft_max_regular_ready_bytes;
 const data_raft_max_single_ready_bytes: usize =
     data_raft_max_snapshot_transfer_bytes + data_raft_max_regular_ready_bytes;
 
@@ -1182,6 +1185,7 @@ const DataDescriptorFactory = struct {
                     .check_quorum = true,
                     .step_down_on_removal = true,
                     .max_size_per_msg = data_raft_max_regular_ready_bytes,
+                    .max_inflight_bytes = data_raft_max_inflight_bytes_per_peer,
                     .max_committed_size_per_ready = data_raft_max_regular_ready_bytes,
                     .random_seed = antfly.raft.stableRandomSeed(record.group_id, record.local_node_id),
                 },
@@ -1226,6 +1230,7 @@ test "data descriptor factory separates bootstrap voters from transport peers" {
     try std.testing.expectEqualSlices(u64, &.{ 1, 2, 3, 4 }, desc.group.raft_config.peers);
     try std.testing.expectEqualSlices(u64, &.{ 1, 2, 3 }, desc.initial_voters.?);
     try std.testing.expectEqual(data_raft_max_regular_ready_bytes, desc.group.raft_config.max_size_per_msg);
+    try std.testing.expectEqual(data_raft_max_inflight_bytes_per_peer, desc.group.raft_config.max_inflight_bytes);
     try std.testing.expectEqual(data_raft_max_regular_ready_bytes, desc.group.raft_config.max_committed_size_per_ready);
 }
 

--- a/zig/pkg/antfly/src/metadata/runtime.zig
+++ b/zig/pkg/antfly/src/metadata/runtime.zig
@@ -44,6 +44,9 @@ fn isExpectedControlRoundError(err: anyerror) bool {
 
 const metadata_raft_max_snapshot_transfer_bytes: usize = 1 << 30;
 const metadata_raft_max_regular_ready_bytes: usize = 64 * 1024 * 1024;
+// Bound each follower's append pipeline so ordinary replication cannot build
+// an aggregate Ready large enough to trip the runtime's last-resort ceiling.
+const metadata_raft_max_inflight_bytes_per_peer: usize = metadata_raft_max_regular_ready_bytes;
 const metadata_raft_max_single_ready_bytes: usize =
     metadata_raft_max_snapshot_transfer_bytes + metadata_raft_max_regular_ready_bytes;
 
@@ -147,6 +150,7 @@ const Factory = struct {
                     .check_quorum = true,
                     .step_down_on_removal = true,
                     .max_size_per_msg = metadata_raft_max_regular_ready_bytes,
+                    .max_inflight_bytes = metadata_raft_max_inflight_bytes_per_peer,
                     .max_committed_size_per_ready = metadata_raft_max_regular_ready_bytes,
                     .random_seed = antfly.raft.stableRandomSeed(record.group_id, record.local_node_id),
                 },
@@ -2024,6 +2028,31 @@ test "metadata runtime enables bounded raft storage compaction for multi-node gr
     try std.testing.expectEqual(@as(u64, metadata_raft_retained_entries), runtime_cfg.applied_log_retained_entries);
     try std.testing.expectEqual(@as(u64, metadata_raft_compaction_min_interval_entries), runtime_cfg.applied_log_compaction_min_interval_entries);
     try std.testing.expect(!runtime_cfg.applied_log_compaction_single_node_only);
+}
+
+test "metadata descriptor bounds each peer replication pipeline" {
+    var store = raft_engine.core.MemoryStorage.init(std.testing.allocator);
+    defer store.deinit();
+    var factory = Factory{
+        .alloc = std.testing.allocator,
+        .store = &store,
+        .metadata_group_id = group_ids.main_metadata_group_id,
+        .metadata_peer_node_ids = try std.testing.allocator.dupe(u64, &.{ 1, 2, 3 }),
+    };
+    defer factory.deinit();
+
+    var desc = try factory.iface().buildDescriptor(.{
+        .group_id = group_ids.main_metadata_group_id,
+        .replica_id = 1,
+        .local_node_id = 1,
+    });
+    defer factory.iface().freeDescriptor(std.testing.allocator, &desc);
+
+    try std.testing.expectEqual(
+        metadata_raft_max_inflight_bytes_per_peer,
+        desc.group.raft_config.max_inflight_bytes,
+    );
+    try std.testing.expect(desc.group.raft_config.max_inflight_bytes != std.math.maxInt(usize));
 }
 
 test "metadata runtime chooses one preferred bootstrap campaigner" {


### PR DESCRIPTION
## Summary

- bound metadata and data Raft append pipelines by bytes per follower
- retain the existing hard outbound Ready ceiling as a last-resort invariant
- cover both descriptor factories so the bounded policy cannot silently regress

## Context

CI job 100911630047 intermittently quarantined the main metadata group after one Ready grew to 1,140,903,564 bytes, just beyond the deliberate 1,140,850,688-byte ceiling. Raft descriptors configured message and committed-entry batch limits but left max_inflight_bytes at its normalized unlimited default. Under a lagging or loaded peer, overlapping append batches could therefore accumulate until the runtime correctly failed closed.

This change applies producer-side flow control instead of weakening the runtime ceiling. Snapshot transfer and the one-oversized-entry liveness behavior remain unchanged.

## Validation

- zig build lib-metadata-test -- --test-filter "metadata descriptor bounds each peer replication pipeline"
- zig build lib-data-runtime-test -- --test-filter "data descriptor factory separates bootstrap voters from transport peers"
- zig build antfly -j2 --summary failures
- exact 3x3 public metadata backup/restore E2E: 11/11 local passes, including a 10-iteration regression soak
