### PR TITLE
test: drain managed writers before source teardown

### DIFF
--- a/zig/pkg/antfly/src/api/table_writes.zig
+++ b/zig/pkg/antfly/src/api/table_writes.zig
@@ -37254,12 +37254,19 @@ test "failed full index enrichment does not make resident reads unavailable" {
 
     var backend_runtime = try db_mod.background_runtime.BackendRuntimeHandle.init(alloc, .{ .backend = .io_threaded });
     defer backend_runtime.deinit();
-    var write_cache = ProvisionedTableWriteCache.init(alloc);
-    defer write_cache.deinit();
-
     var source = ProvisionedTableWriteSource.init(path, FakeCatalog.iface());
     defer source.deinit();
     source.backend_runtime = backend_runtime.ptr();
+
+    var write_cache = ProvisionedTableWriteCache.init(alloc);
+    defer {
+        // Stop source-owned admission first, then close the DBs that may still
+        // hold copied visibility callbacks while their callback target is
+        // alive. `source.deinit` runs after this block and may safely poison
+        // the borrowed callback target.
+        source.quiesce();
+        write_cache.deinit();
+    }
     source.write_cache = &write_cache;
 
     _ = try source.source().batch(alloc, "stable", .{


### PR DESCRIPTION
Summary:
- quiesce the provisioned write source before closing its attached write cache
- close cached DB workers while their copied visibility callback target is still alive
- let source deinit poison the callback target only after cache teardown completes

This fixes the x86_64 data-runtime shard crash from Actions run 33842323303, where the failed full-index enrichment test aborted in runtime-status mutex acquisition after a late enrichment callback.

Validation:
- focused test passed 10 consecutive runs with loopback networking enabled
- complete lib-data-runtime-test shard passed: 144 passed, 0 failed