### PR TITLE
release: validate controller-owned source lines

### DIFF
--- a/.github/workflows/antfly-artifact-build.yml
+++ b/.github/workflows/antfly-artifact-build.yml
@@ -8,7 +8,19 @@ on:
         required: true
         type: string
       source_commit:
-        description: "Exact default-branch commit to build"
+        description: "Exact trusted release-line commit to build"
+        required: true
+        type: string
+      release_line:
+        description: "Tag-derived release line, or nightly"
+        required: true
+        type: string
+      source_ref:
+        description: "Controller-selected protected source branch"
+        required: true
+        type: string
+      source_ref_head:
+        description: "Immutable source branch head observed by the controller"
         required: true
         type: string
       channel:
@@ -60,15 +72,33 @@ jobs:
       - name: Load pinned toolchain policy
         id: toolchain
         uses: ./.github/actions/load-toolchain-policy
-      - name: Require compatible immutable default-branch source
+      - name: Require compatible immutable release-line source
         env:
+          RELEASE_TAG: ${{ inputs.tag_name }}
+          RELEASE_CHANNEL: ${{ inputs.channel }}
           SOURCE_COMMIT: ${{ inputs.source_commit }}
-          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          RELEASE_LINE: ${{ inputs.release_line }}
+          SOURCE_REF: ${{ inputs.source_ref }}
+          SOURCE_REF_HEAD: ${{ inputs.source_ref_head }}
         run: |
           set -euo pipefail
           [[ "$SOURCE_COMMIT" =~ ^[0-9a-f]{40}$ ]]
-          git fetch --no-tags origin "$DEFAULT_BRANCH"
-          git merge-base --is-ancestor "$SOURCE_COMMIT" "origin/$DEFAULT_BRANCH"
+          [[ "$SOURCE_REF_HEAD" =~ ^[0-9a-f]{40}$ ]]
+          if [ "$RELEASE_CHANNEL" = nightly ]; then
+            resolved="$(python scripts/release/release_lines.py nightly)"
+            test "$RELEASE_LINE" = "$(jq -r .release_line <<<"$resolved")"
+            test "$SOURCE_REF" = "$(jq -r .source_ref <<<"$resolved")"
+          else
+            python scripts/release/release_lines.py verify-provenance \
+              --tag "$RELEASE_TAG" \
+              --release-line "$RELEASE_LINE" \
+              --source-ref "$SOURCE_REF" >/dev/null
+            test "$SOURCE_COMMIT" = "$SOURCE_REF_HEAD"
+          fi
+          git fetch --no-tags origin "$SOURCE_REF"
+          current_source_head="$(git rev-parse FETCH_HEAD)"
+          git merge-base --is-ancestor "$SOURCE_REF_HEAD" "$current_source_head"
+          git merge-base --is-ancestor "$SOURCE_COMMIT" "$SOURCE_REF_HEAD"
           python scripts/release/validate_source_contract.py --commit "$SOURCE_COMMIT"
       - name: Validate release channel
         id: channel
@@ -224,6 +254,9 @@ jobs:
         env:
           RELEASE_TAG: ${{ inputs.tag_name }}
           SOURCE_COMMIT: ${{ inputs.source_commit }}
+          RELEASE_LINE: ${{ inputs.release_line }}
+          SOURCE_REF: ${{ inputs.source_ref }}
+          SOURCE_REF_HEAD: ${{ inputs.source_ref_head }}
           BUILD_CONTROLLER_COMMIT: ${{ needs.release-plan.outputs.build_controller_commit }}
           RELEASE_CHANNEL: ${{ needs.release-plan.outputs.channel }}
         run: |
@@ -232,6 +265,9 @@ jobs:
             --tag "$RELEASE_TAG" \
             --channel "$RELEASE_CHANNEL" \
             --source-commit "$SOURCE_COMMIT" \
+            --release-line "$RELEASE_LINE" \
+            --source-ref "$SOURCE_REF" \
+            --source-ref-head "$SOURCE_REF_HEAD" \
             --build-controller-commit "$BUILD_CONTROLLER_COMMIT" \
             > dist/release-request/release-request.json
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/antfly-artifact-build.yml
+++ b/.github/workflows/antfly-artifact-build.yml
@@ -93,7 +93,6 @@ jobs:
               --tag "$RELEASE_TAG" \
               --release-line "$RELEASE_LINE" \
               --source-ref "$SOURCE_REF" >/dev/null
-            test "$SOURCE_COMMIT" = "$SOURCE_REF_HEAD"
           fi
           git fetch --no-tags origin "$SOURCE_REF"
           current_source_head="$(git rev-parse FETCH_HEAD)"

--- a/.github/workflows/antfly-release-build-controller.yml
+++ b/.github/workflows/antfly-release-build-controller.yml
@@ -57,6 +57,24 @@ jobs:
           source_commit="$(jq -r .source_commit "$request")"
           channel="$(jq -r .channel "$request")"
           [[ "$tag" =~ ^v[0-9]+(\.[0-9]+){2}(-[0-9A-Za-z.-]+)?$ ]]
+          build_controller_commit="$(git rev-parse HEAD)"
+          test "$build_controller_commit" = "$GITHUB_SHA"
+          git fetch --no-tags origin "refs/heads/$DEFAULT_BRANCH"
+          current_default_head="$(git rev-parse FETCH_HEAD)"
+          policy_paths=(
+            .github/workflows/antfly-release-build-controller.yml
+            scripts/release/release-lines.json
+            scripts/release/release_lines.py
+            scripts/release/release_channels.py
+          )
+          for path in "${policy_paths[@]}"; do
+            controller_blob="$(git rev-parse "$build_controller_commit:$path")"
+            current_blob="$(git rev-parse "$current_default_head:$path")"
+            if [ "$controller_blob" != "$current_blob" ]; then
+              echo "release-line policy changed after this controller was queued: $path" >&2
+              exit 2
+            fi
+          done
           case "$TRIGGER_WORKFLOW:$TRIGGER_EVENT:$request_kind" in
             "Release request:push:tag")
               test "$channel" = auto
@@ -64,9 +82,12 @@ jobs:
               resolved="$(python scripts/release/release_lines.py resolve --tag "$tag")"
               release_line="$(jq -r .release_line <<<"$resolved")"
               source_ref="$(jq -r .source_ref <<<"$resolved")"
-              git fetch --no-tags origin "$source_ref"
-              source_ref_head="$(git rev-parse FETCH_HEAD)"
-              test "$source_commit" = "$source_ref_head"
+              if [ "$source_ref" = "refs/heads/$DEFAULT_BRANCH" ]; then
+                source_ref_head="$current_default_head"
+              else
+                git fetch --no-tags origin "$source_ref"
+                source_ref_head="$(git rev-parse FETCH_HEAD)"
+              fi
               git fetch --force origin "refs/tags/$tag:refs/tags/$tag"
               test "$(git rev-parse "$tag^{commit}")" = "$source_commit"
               ;;
@@ -77,12 +98,15 @@ jobs:
               resolved="$(python scripts/release/release_lines.py nightly)"
               release_line="$(jq -r .release_line <<<"$resolved")"
               source_ref="$(jq -r .source_ref <<<"$resolved")"
-              git fetch --no-tags origin "$source_ref"
-              source_ref_head="$(git rev-parse FETCH_HEAD)"
+              if [ "$source_ref" = "refs/heads/$DEFAULT_BRANCH" ]; then
+                source_ref_head="$current_default_head"
+              else
+                git fetch --no-tags origin "$source_ref"
+                source_ref_head="$(git rev-parse FETCH_HEAD)"
+              fi
               if [ -z "$source_commit" ]; then
                 source_commit="$TRIGGER_HEAD_SHA"
               fi
-              git merge-base --is-ancestor "$source_commit" "$source_ref_head"
               ;;
             *)
               echo "untrusted release build trigger" >&2
@@ -92,8 +116,7 @@ jobs:
           [[ "$source_commit" =~ ^[0-9a-f]{40}$ ]]
           [[ "$source_ref_head" =~ ^[0-9a-f]{40}$ ]]
           git cat-file -e "$source_commit^{commit}"
-          build_controller_commit="$(git rev-parse HEAD)"
-          test "$build_controller_commit" = "$GITHUB_SHA"
+          git merge-base --is-ancestor "$source_commit" "$source_ref_head"
           {
             echo "tag=$tag"
             echo "source_commit=$source_commit"

--- a/.github/workflows/antfly-release-build-controller.yml
+++ b/.github/workflows/antfly-release-build-controller.yml
@@ -23,6 +23,9 @@ jobs:
     outputs:
       tag: ${{ steps.request.outputs.tag }}
       source_commit: ${{ steps.request.outputs.source_commit }}
+      release_line: ${{ steps.request.outputs.release_line }}
+      source_ref: ${{ steps.request.outputs.source_ref }}
+      source_ref_head: ${{ steps.request.outputs.source_ref_head }}
       channel: ${{ steps.request.outputs.channel }}
       build_controller_commit: ${{ steps.request.outputs.build_controller_commit }}
     steps:
@@ -58,6 +61,12 @@ jobs:
             "Release request:push:tag")
               test "$channel" = auto
               test "$source_commit" = "$TRIGGER_HEAD_SHA"
+              resolved="$(python scripts/release/release_lines.py resolve --tag "$tag")"
+              release_line="$(jq -r .release_line <<<"$resolved")"
+              source_ref="$(jq -r .source_ref <<<"$resolved")"
+              git fetch --no-tags origin "$source_ref"
+              source_ref_head="$(git rev-parse FETCH_HEAD)"
+              test "$source_commit" = "$source_ref_head"
               git fetch --force origin "refs/tags/$tag:refs/tags/$tag"
               test "$(git rev-parse "$tag^{commit}")" = "$source_commit"
               ;;
@@ -65,9 +74,15 @@ jobs:
               test "$TRIGGER_HEAD_BRANCH" = "$DEFAULT_BRANCH"
               test "$channel" = nightly
               test "$tag" = "v0.0.0-dev.${TRIGGER_RUN_ID}"
+              resolved="$(python scripts/release/release_lines.py nightly)"
+              release_line="$(jq -r .release_line <<<"$resolved")"
+              source_ref="$(jq -r .source_ref <<<"$resolved")"
+              git fetch --no-tags origin "$source_ref"
+              source_ref_head="$(git rev-parse FETCH_HEAD)"
               if [ -z "$source_commit" ]; then
                 source_commit="$TRIGGER_HEAD_SHA"
               fi
+              git merge-base --is-ancestor "$source_commit" "$source_ref_head"
               ;;
             *)
               echo "untrusted release build trigger" >&2
@@ -75,13 +90,16 @@ jobs:
               ;;
           esac
           [[ "$source_commit" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$source_ref_head" =~ ^[0-9a-f]{40}$ ]]
           git cat-file -e "$source_commit^{commit}"
-          git merge-base --is-ancestor "$source_commit" "origin/$DEFAULT_BRANCH"
           build_controller_commit="$(git rev-parse HEAD)"
           test "$build_controller_commit" = "$GITHUB_SHA"
           {
             echo "tag=$tag"
             echo "source_commit=$source_commit"
+            echo "release_line=$release_line"
+            echo "source_ref=$source_ref"
+            echo "source_ref_head=$source_ref_head"
             echo "channel=$channel"
             echo "build_controller_commit=$build_controller_commit"
           } >> "$GITHUB_OUTPUT"
@@ -94,5 +112,8 @@ jobs:
     with:
       tag_name: ${{ needs.resolve.outputs.tag }}
       source_commit: ${{ needs.resolve.outputs.source_commit }}
+      release_line: ${{ needs.resolve.outputs.release_line }}
+      source_ref: ${{ needs.resolve.outputs.source_ref }}
+      source_ref_head: ${{ needs.resolve.outputs.source_ref_head }}
       channel: ${{ needs.resolve.outputs.channel }}
       build_controller_commit: ${{ needs.resolve.outputs.build_controller_commit }}

--- a/.github/workflows/antfly-release.yml
+++ b/.github/workflows/antfly-release.yml
@@ -44,6 +44,9 @@ jobs:
       python_version: ${{ steps.registry-identity.outputs.python_version }}
       container_tag: ${{ steps.registry-identity.outputs.container_tag }}
       commit: ${{ steps.identity.outputs.commit }}
+      release_line: ${{ steps.identity.outputs.release_line }}
+      source_ref: ${{ steps.identity.outputs.source_ref }}
+      source_ref_head: ${{ steps.identity.outputs.source_ref_head }}
       build_controller_commit: ${{ steps.identity.outputs.build_controller_commit }}
       promotion_controller_commit: ${{ steps.identity.outputs.promotion_controller_commit }}
       allow_legacy: ${{ steps.identity.outputs.allow_legacy }}
@@ -125,11 +128,21 @@ jobs:
           promotion_controller_commit="$(git rev-parse HEAD)"
           if [ "$EVENT_NAME" = workflow_run ]; then
             request=dist/release-request/release-request.json
-            test "$(jq -r .schema_version "$request")" = 4
+            provenance_schema="$(jq -r .schema_version "$request")"
+            test "$provenance_schema" = 4 || test "$provenance_schema" = 5
             raw="$(jq -r .tag "$request")"
             commit="$(jq -r .source_commit "$request")"
             build_controller_commit="$(jq -r .build_controller_commit "$request")"
             requested_channel="$(jq -r .channel "$request")"
+            if [ "$provenance_schema" = 5 ]; then
+              release_line="$(jq -r .release_line "$request")"
+              source_ref="$(jq -r .source_ref "$request")"
+              source_ref_head="$(jq -r .source_ref_head "$request")"
+            else
+              release_line=""
+              source_ref=""
+              source_ref_head=""
+            fi
             allow_legacy=false
             test "$BUILD_EVENT" = workflow_run
           else
@@ -138,6 +151,10 @@ jobs:
             expected_ledger="${RECOVERY_LEDGER_SHA256,,}"
             test -n "$expected_ledger"
             build_controller_commit=""
+            provenance_schema=""
+            release_line=""
+            source_ref=""
+            source_ref_head=""
             allow_legacy=true
           fi
           if ! [[ "$raw" =~ ^v?[0-9]+(\.[0-9]+){1,2}([-+][0-9A-Za-z.-]+)?$ ]]; then
@@ -166,17 +183,26 @@ jobs:
             echo "version=$version"
             echo "tag=$tag"
             echo "commit=$commit"
+            echo "provenance_schema=$provenance_schema"
+            echo "release_line=$release_line"
+            echo "source_ref=$source_ref"
+            echo "source_ref_head=$source_ref_head"
             echo "build_controller_commit=$build_controller_commit"
             echo "promotion_controller_commit=$promotion_controller_commit"
             echo "allow_legacy=$allow_legacy"
             echo "expected_ledger=$expected_ledger"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Require the tag and commit to be immutable default-branch history
+      - name: Require immutable controller and release-source history
         env:
+          EVENT_NAME: ${{ github.event_name }}
           RELEASE_TAG: ${{ steps.identity.outputs.tag }}
           RELEASE_COMMIT: ${{ steps.identity.outputs.commit }}
           RELEASE_CHANNEL: ${{ steps.identity.outputs.channel }}
+          PROVENANCE_SCHEMA: ${{ steps.identity.outputs.provenance_schema }}
+          RELEASE_LINE: ${{ steps.identity.outputs.release_line }}
+          SOURCE_REF: ${{ steps.identity.outputs.source_ref }}
+          SOURCE_REF_HEAD: ${{ steps.identity.outputs.source_ref_head }}
           BUILD_CONTROLLER_COMMIT: ${{ steps.identity.outputs.build_controller_commit }}
           PROMOTION_CONTROLLER_COMMIT: ${{ steps.identity.outputs.promotion_controller_commit }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
@@ -188,13 +214,34 @@ jobs:
           else
             git cat-file -e "$RELEASE_COMMIT^{commit}"
           fi
-          git merge-base --is-ancestor "$RELEASE_COMMIT" "origin/$DEFAULT_BRANCH"
           test "$(git rev-parse HEAD)" = "$PROMOTION_CONTROLLER_COMMIT"
           git merge-base --is-ancestor "$PROMOTION_CONTROLLER_COMMIT" "origin/$DEFAULT_BRANCH"
           if [ -n "$BUILD_CONTROLLER_COMMIT" ]; then
             [[ "$BUILD_CONTROLLER_COMMIT" =~ ^[0-9a-f]{40}$ ]]
             git cat-file -e "$BUILD_CONTROLLER_COMMIT^{commit}"
             git merge-base --is-ancestor "$BUILD_CONTROLLER_COMMIT" "origin/$DEFAULT_BRANCH"
+          fi
+          if [ "$EVENT_NAME" = workflow_run ]; then
+            if [ "$PROVENANCE_SCHEMA" = 5 ]; then
+              if [ "$RELEASE_CHANNEL" = nightly ]; then
+                resolved="$(python scripts/release/release_lines.py nightly)"
+                test "$RELEASE_LINE" = "$(jq -r .release_line <<<"$resolved")"
+                test "$SOURCE_REF" = "$(jq -r .source_ref <<<"$resolved")"
+              else
+                python scripts/release/release_lines.py verify-provenance \
+                  --tag "$RELEASE_TAG" \
+                  --release-line "$RELEASE_LINE" \
+                  --source-ref "$SOURCE_REF" \
+                  --allow-closed >/dev/null
+                test "$RELEASE_COMMIT" = "$SOURCE_REF_HEAD"
+              fi
+              git fetch --no-tags origin "$SOURCE_REF"
+              current_source_head="$(git rev-parse FETCH_HEAD)"
+              git merge-base --is-ancestor "$SOURCE_REF_HEAD" "$current_source_head"
+              git merge-base --is-ancestor "$RELEASE_COMMIT" "$SOURCE_REF_HEAD"
+            else
+              git merge-base --is-ancestor "$RELEASE_COMMIT" "origin/$DEFAULT_BRANCH"
+            fi
           fi
 
       - name: Install hash-locked object storage client
@@ -335,6 +382,43 @@ jobs:
             --commit "$RELEASE_COMMIT" \
             --ledger-sha256 "$actual"
           echo "sha256=$actual" >> "$GITHUB_OUTPUT"
+
+      - name: Verify recovered release-source history
+        if: ${{ github.event_name == 'repository_dispatch' }}
+        env:
+          RELEASE_TAG: ${{ steps.identity.outputs.tag }}
+          RELEASE_COMMIT: ${{ steps.identity.outputs.commit }}
+          RELEASE_CHANNEL: ${{ steps.identity.outputs.channel }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+          ledger=dist/release-payload/artifacts.json
+          schema="$(jq -r .schema_version "$ledger")"
+          if [ "$schema" -le 4 ]; then
+            git cat-file -e "$RELEASE_COMMIT^{commit}"
+            git merge-base --is-ancestor "$RELEASE_COMMIT" "origin/$DEFAULT_BRANCH"
+          else
+            test "$schema" = 5
+            release_line="$(jq -er .release_line "$ledger")"
+            source_ref="$(jq -er .source_ref "$ledger")"
+            source_ref_head="$(jq -er .source_ref_head "$ledger")"
+            if [ "$RELEASE_CHANNEL" = nightly ]; then
+              resolved="$(python scripts/release/release_lines.py nightly)"
+              test "$release_line" = "$(jq -r .release_line <<<"$resolved")"
+              test "$source_ref" = "$(jq -r .source_ref <<<"$resolved")"
+            else
+              python scripts/release/release_lines.py verify-provenance \
+                --tag "$RELEASE_TAG" \
+                --release-line "$release_line" \
+                --source-ref "$source_ref" \
+                --allow-closed >/dev/null
+              test "$RELEASE_COMMIT" = "$source_ref_head"
+            fi
+            git fetch --no-tags origin "$source_ref"
+            current_source_head="$(git rev-parse FETCH_HEAD)"
+            git merge-base --is-ancestor "$source_ref_head" "$current_source_head"
+            git merge-base --is-ancestor "$RELEASE_COMMIT" "$source_ref_head"
+          fi
 
       - name: Repair the GitHub release mirror from verified bytes
         if: ${{ github.event_name == 'repository_dispatch' && steps.identity.outputs.github_release != 'none' && steps.recovery.outputs.source == 'object-storage' }}

--- a/.github/workflows/antfly-release.yml
+++ b/.github/workflows/antfly-release.yml
@@ -233,7 +233,6 @@ jobs:
                   --release-line "$RELEASE_LINE" \
                   --source-ref "$SOURCE_REF" \
                   --allow-closed >/dev/null
-                test "$RELEASE_COMMIT" = "$SOURCE_REF_HEAD"
               fi
               git fetch --no-tags origin "$SOURCE_REF"
               current_source_head="$(git rev-parse FETCH_HEAD)"
@@ -412,7 +411,6 @@ jobs:
                 --release-line "$release_line" \
                 --source-ref "$source_ref" \
                 --allow-closed >/dev/null
-              test "$RELEASE_COMMIT" = "$source_ref_head"
             fi
             git fetch --no-tags origin "$source_ref"
             current_source_head="$(git rev-parse FETCH_HEAD)"

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -58,8 +58,9 @@ credentials.
    `.github/workflows/antfly-nightly.yml` emit only an untrusted JSON request.
    They never call a builder. `.github/workflows/antfly-release-build-controller.yml`
    is loaded through `workflow_run` from the default branch. It requires tag
-   requests to match the pushed tag and commit, and nightly requests to have
-   been dispatched on the default branch.
+   requests to match the pushed tag and commit and to point at the exact tip of
+   the controller-selected release branch. Nightly requests must have been
+   dispatched on the default branch.
 2. The build controller pins its exact commit and calls
    `.github/workflows/antfly-artifact-build.yml`, the sole reusable artifact
    builder, from that same commit. The requested source commit supplies only
@@ -70,8 +71,9 @@ credentials.
    calls `.github/workflows/cli-package.yml`, extracts `install.sh` and
    `openapi.yaml` directly from the selected Git commit, and uploads the native
    archives, CLI snapshot, commit-bound source snapshot, and
-   canonical `ReleaseSpec` (source commit, build-controller commit, channel,
-   build contract, and all registry versions) as an Actions artifact. The
+   canonical `ReleaseSpec` (source commit, trusted source branch and observed
+   branch head, build-controller commit, channel, build contract, and all
+   registry versions) as an Actions artifact. The
    workflow graph, nested reusable workflows, and controller-owned scripts all
    share that recorded build-controller identity.
 3. Completion of the build controller triggers
@@ -327,6 +329,38 @@ represented by every publication target (notably container tags). Historical
 spellings such as `rc2`, `pre.2`, and `preview2` can be read from existing
 journals during recovery, but cannot create a new release candidate.
 
+## Release Lines
+
+`scripts/release/release-lines.json` is the default-branch controller's map
+from a tag's `X.Y` version line to its trusted source branch. It currently maps
+`0.2` to `main`; no maintenance-branch rollout is active yet. Release tags are
+still created and pushed manually, and a new non-nightly tag is accepted only
+when its commit is the selected branch's exact tip when the controller validates
+the request. The request cannot nominate its own source branch.
+
+The selected branch and observed branch head are recorded in schema-v5 release
+provenance and carried through artifact build, promotion, ledger verification,
+and recovery. Each line also retains an explicit history of trusted source
+branches. This allows an older release built from `main` to remain verifiable
+after ownership of that line moves to its maintenance branch, without allowing
+a new tag to select a historical branch.
+
+When `main` begins 0.3 development:
+
+1. Ensure `v0.2.x` points at the intended final shared 0.2 commit.
+2. In a reviewed change on `main`, change the `0.2` `source_ref` to
+   `refs/heads/v0.2.x`, append that ref to `trusted_source_refs` without removing
+   `refs/heads/main`, and add an active `0.3` line sourced from
+   `refs/heads/main`.
+3. Backport later 0.2 fixes through PRs into `v0.2.x`, and create canonical
+   `v0.2.*` tags only from its exact tip. Do not merge 0.3-era `main` back into
+   the maintenance branch.
+
+Privileged build and promotion policy always remains on `main`; only versioned
+release source comes from the mapped maintenance branch. Repository branch/tag
+protection is an independent administrative control and is not enforced by
+this file.
+
 Run a snapshot for the current default-branch head with
 `gh workflow run antfly-nightly.yml`. To reproduce a snapshot from a specific
 default-branch commit, add `-f source_commit=<40-character-commit>`.
@@ -387,9 +421,10 @@ new plan and approval. Fresh journal and alias ETags protect the actual sweep.
 Registry cleanup removes only container digests with no retained or channel
 references. Per-ledger container identity records have an independent
 lifecycle: every expired record is removed after registry validation even when
-its image digest is shared with a retained release. Conversely, a schema-v4
-release missing its immutable container record is retained for repair rather
-than partially collected. R2 payloads and identity records are deleted only
+its image digest is shared with a retained release. Conversely, a release using
+the controller-provenance ledger schemas (v4 or v5) but missing its immutable
+container record is retained for repair rather than partially collected. R2
+payloads and identity records are deleted only
 after registry cleanup succeeds. The GC never deletes stable releases, shared
 content-addressed objects, or npm/PyPI versions. Immutable completion receipts
 remain as compact audit history after payload deletion. Existing `termite/`

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -58,9 +58,11 @@ credentials.
    `.github/workflows/antfly-nightly.yml` emit only an untrusted JSON request.
    They never call a builder. `.github/workflows/antfly-release-build-controller.yml`
    is loaded through `workflow_run` from the default branch. It requires tag
-   requests to match the pushed tag and commit and to point at the exact tip of
-   the controller-selected release branch. Nightly requests must have been
-   dispatched on the default branch.
+   requests to match the pushed tag and commit and to belong to the
+   controller-selected release branch. Nightly requests must have been
+   dispatched on the default branch. Before resolving either request, the
+   controller also requires its release-line policy bundle to match one atomic
+   snapshot of the current default branch.
 2. The build controller pins its exact commit and calls
    `.github/workflows/antfly-artifact-build.yml`, the sole reusable artifact
    builder, from that same commit. The requested source commit supplies only
@@ -334,9 +336,10 @@ journals during recovery, but cannot create a new release candidate.
 `scripts/release/release-lines.json` is the default-branch controller's map
 from a tag's `X.Y` version line to its trusted source branch. It currently maps
 `0.2` to `main`; no maintenance-branch rollout is active yet. Release tags are
-still created and pushed manually, and a new non-nightly tag is accepted only
-when its commit is the selected branch's exact tip when the controller validates
-the request. The request cannot nominate its own source branch.
+still created and pushed manually. A non-nightly tag is accepted when its
+commit belongs to the selected branch when the controller validates it. This
+keeps a tag request replayable after the branch advances. The request cannot
+nominate its own source branch.
 
 The selected branch and observed branch head are recorded in schema-v5 release
 provenance and carried through artifact build, promotion, ledger verification,
@@ -353,8 +356,8 @@ When `main` begins 0.3 development:
    `refs/heads/main`, and add an active `0.3` line sourced from
    `refs/heads/main`.
 3. Backport later 0.2 fixes through PRs into `v0.2.x`, and create canonical
-   `v0.2.*` tags only from its exact tip. Do not merge 0.3-era `main` back into
-   the maintenance branch.
+   `v0.2.*` tags only from commits in that branch. Do not merge 0.3-era `main`
+   back into the maintenance branch.
 
 Privileged build and promotion policy always remains on `main`; only versioned
 release source comes from the mapped maintenance branch. Repository branch/tag

--- a/scripts/packaging/test_cabi_packaging.py
+++ b/scripts/packaging/test_cabi_packaging.py
@@ -211,6 +211,17 @@ class CAbiPackagingTests(unittest.TestCase):
         self.assertNotIn("id-token: write", release_build_workflow)
         self.assertNotIn("environment:", release_build_workflow)
         self.assertNotIn("publish_objectstorage.py", release_build_workflow)
+        for field in ("release_line:", "source_ref:", "source_ref_head:"):
+            self.assertIn(field, artifact_build_workflow)
+            self.assertIn(field, build_controller_workflow)
+        self.assertIn(
+            "python scripts/release/release_lines.py resolve",
+            build_controller_workflow,
+        )
+        self.assertIn(
+            'test "$source_commit" = "$source_ref_head"',
+            build_controller_workflow,
+        )
         self.assertIn("permissions:\n  contents: read", artifact_build_workflow)
         self.assertNotIn("contents: write", artifact_build_workflow)
         self.assertNotIn("id-token: write", artifact_build_workflow)

--- a/scripts/packaging/test_cabi_packaging.py
+++ b/scripts/packaging/test_cabi_packaging.py
@@ -219,7 +219,15 @@ class CAbiPackagingTests(unittest.TestCase):
             build_controller_workflow,
         )
         self.assertIn(
+            'git merge-base --is-ancestor "$source_commit" "$source_ref_head"',
+            build_controller_workflow,
+        )
+        self.assertNotIn(
             'test "$source_commit" = "$source_ref_head"',
+            build_controller_workflow,
+        )
+        self.assertIn(
+            "release-line policy changed after this controller was queued",
             build_controller_workflow,
         )
         self.assertIn("permissions:\n  contents: read", artifact_build_workflow)

--- a/scripts/release/build_release_payload.py
+++ b/scripts/release/build_release_payload.py
@@ -135,9 +135,31 @@ def verify_release_spec(path: Path, tag: str, commit: str) -> dict[str, object]:
     channel = document.get("channel")
     if not isinstance(build_controller_commit, str) or not isinstance(channel, str):
         raise SystemExit("release spec does not match the release identity")
-    expected = build_release_spec(
-        tag, channel, commit, build_controller_commit
-    ).document()
+    schema_version = document.get("schema_version")
+    if schema_version == 4:
+        expected = build_release_spec(
+            tag, channel, commit, build_controller_commit
+        ).document()
+    elif schema_version == 5:
+        release_line = document.get("release_line")
+        source_ref = document.get("source_ref")
+        source_ref_head = document.get("source_ref_head")
+        if not all(
+            isinstance(value, str)
+            for value in (release_line, source_ref, source_ref_head)
+        ):
+            raise SystemExit("release spec does not match the release identity")
+        expected = build_release_spec(
+            tag,
+            channel,
+            commit,
+            build_controller_commit,
+            release_line=release_line,
+            source_ref=source_ref,
+            source_ref_head=source_ref_head,
+        ).document()
+    else:
+        raise SystemExit("release spec uses an unsupported schema")
     if document != expected:
         raise SystemExit("release spec does not match the release identity")
     return document
@@ -266,6 +288,14 @@ def main() -> int:
         "registry_versions": registry_versions,
         "artifacts": artifacts,
     }
+    if release_spec["schema_version"] == 5:
+        metadata.update(
+            {
+                "release_line": release_spec["release_line"],
+                "source_ref": release_spec["source_ref"],
+                "source_ref_head": release_spec["source_ref_head"],
+            }
+        )
 
     metadata_path = out_dir / "metadata.json"
     artifacts_path = out_dir / "artifacts.json"
@@ -282,22 +312,27 @@ def main() -> int:
             "sha256": sha256(metadata_path),
         },
     ]
-    artifacts_path.write_text(
-        json.dumps(
+    ledger = {
+        "tag": tag,
+        "version": version,
+        "commit": args.commit,
+        "build_controller_commit": release_spec["build_controller_commit"],
+        "promotion_controller_commit": args.promotion_controller_commit,
+        "schema_version": release_spec["schema_version"],
+        "generated_at": release_generated_at,
+        "registry_versions": registry_versions,
+        "artifacts": ledger_artifacts,
+    }
+    if release_spec["schema_version"] == 5:
+        ledger.update(
             {
-                "tag": tag,
-                "version": version,
-                "commit": args.commit,
-                "build_controller_commit": release_spec["build_controller_commit"],
-                "promotion_controller_commit": args.promotion_controller_commit,
-                "schema_version": 4,
-                "generated_at": release_generated_at,
-                "registry_versions": registry_versions,
-                "artifacts": ledger_artifacts,
-            },
-            indent=2,
+                "release_line": release_spec["release_line"],
+                "source_ref": release_spec["source_ref"],
+                "source_ref_head": release_spec["source_ref_head"],
+            }
         )
-        + "\n",
+    artifacts_path.write_text(
+        json.dumps(ledger, indent=2) + "\n",
         encoding="utf-8",
     )
 

--- a/scripts/release/download_objectstorage.py
+++ b/scripts/release/download_objectstorage.py
@@ -113,7 +113,7 @@ class LocalReader:
 
 def payload_names(ledger_bytes: bytes) -> list[str]:
     ledger = json.loads(ledger_bytes)
-    if ledger.get("schema_version") not in {1, 2, 3, 4}:
+    if ledger.get("schema_version") not in {1, 2, 3, 4, 5}:
         raise SystemExit("unsupported release ledger schema")
     entries = ledger.get("artifacts")
     if not isinstance(entries, list) or not entries:

--- a/scripts/release/release-lines.json
+++ b/scripts/release/release-lines.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": 2,
+  "lines": {
+    "0.2": {
+      "source_ref": "refs/heads/main",
+      "trusted_source_refs": ["refs/heads/main"],
+      "status": "active"
+    }
+  },
+  "nightly_source_ref": "refs/heads/main"
+}

--- a/scripts/release/release_channels.py
+++ b/scripts/release/release_channels.py
@@ -55,9 +55,12 @@ class ReleaseSpec:
     npm_version: str
     python_version: str
     container_tag: str
+    release_line: str | None = None
+    source_ref: str | None = None
+    source_ref_head: str | None = None
 
     def document(self) -> dict[str, object]:
-        return {
+        document: dict[str, object] = {
             "schema_version": 4,
             "tag": self.tag,
             "version": self.tag.removeprefix("v"),
@@ -71,6 +74,23 @@ class ReleaseSpec:
                 "container": self.container_tag,
             },
         }
+        source_provenance = (
+            self.release_line,
+            self.source_ref,
+            self.source_ref_head,
+        )
+        if any(value is not None for value in source_provenance):
+            if not all(value is not None for value in source_provenance):
+                raise SystemExit("release spec has incomplete source provenance")
+            document.update(
+                {
+                    "schema_version": 5,
+                    "release_line": self.release_line,
+                    "source_ref": self.source_ref,
+                    "source_ref_head": self.source_ref_head,
+                }
+            )
+        return document
 
 
 def parse_version(tag: str) -> tuple[tuple[int, int, int], tuple[str, ...] | None]:
@@ -154,6 +174,9 @@ def build_release_spec(
     policy: dict[str, Any] | None = None,
     *,
     allow_legacy: bool = False,
+    release_line: str | None = None,
+    source_ref: str | None = None,
+    source_ref_head: str | None = None,
 ) -> ReleaseSpec:
     for name, commit in (
         ("source", source_commit),
@@ -161,6 +184,18 @@ def build_release_spec(
     ):
         if not re.fullmatch(r"[0-9a-f]{40}", commit):
             raise SystemExit(f"invalid {name} commit: {commit}")
+    source_provenance = (release_line, source_ref, source_ref_head)
+    if any(value is not None for value in source_provenance):
+        if not all(value is not None for value in source_provenance):
+            raise SystemExit("release spec has incomplete source provenance")
+        if release_line != "nightly" and not re.fullmatch(
+            r"(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)", str(release_line)
+        ):
+            raise SystemExit(f"invalid release line: {release_line}")
+        if not re.fullmatch(r"refs/heads/[A-Za-z0-9._/-]+", str(source_ref)):
+            raise SystemExit(f"invalid release source ref: {source_ref}")
+        if not re.fullmatch(r"[0-9a-f]{40}", str(source_ref_head)):
+            raise SystemExit(f"invalid release source ref head: {source_ref_head}")
     channel_name, _ = resolve_channel(
         tag, requested_channel, policy, allow_legacy=allow_legacy
     )
@@ -173,6 +208,9 @@ def build_release_spec(
         npm_version=registry["npm_version"],
         python_version=registry["python_version"],
         container_tag=registry["container_tag"],
+        release_line=release_line,
+        source_ref=source_ref,
+        source_ref_head=source_ref_head,
     )
 
 
@@ -457,6 +495,9 @@ def main() -> int:
     parser.add_argument("--github-output", type=Path)
     parser.add_argument("--source-commit")
     parser.add_argument("--build-controller-commit")
+    parser.add_argument("--release-line")
+    parser.add_argument("--source-ref")
+    parser.add_argument("--source-ref-head")
     parser.add_argument("--allow-legacy", action="store_true")
     args = parser.parse_args()
 
@@ -469,6 +510,10 @@ def main() -> int:
     if args.command == "spec":
         if not args.source_commit or not args.build_controller_commit:
             parser.error("spec requires --source-commit and --build-controller-commit")
+        if not args.release_line or not args.source_ref or not args.source_ref_head:
+            parser.error(
+                "spec requires --release-line, --source-ref, and --source-ref-head"
+            )
         spec = build_release_spec(
             args.tag,
             args.channel,
@@ -476,6 +521,9 @@ def main() -> int:
             args.build_controller_commit,
             policy,
             allow_legacy=args.allow_legacy,
+            release_line=args.release_line,
+            source_ref=args.source_ref,
+            source_ref_head=args.source_ref_head,
         )
         print(json.dumps(spec.document(), indent=2, sort_keys=True))
         return 0

--- a/scripts/release/release_gc.py
+++ b/scripts/release/release_gc.py
@@ -34,7 +34,7 @@ RELEASE_ROOT = "antfly/"
 CONTENT_ROOT = "antfly/artifacts/sha256/"
 CONTAINER_IDENTITY_ROOT = "antfly/container-identities/"
 LEDGER_NAME = "artifacts.json"
-SUPPORTED_LEDGER_SCHEMAS = {1, 2, 3, 4}
+SUPPORTED_LEDGER_SCHEMAS = {1, 2, 3, 4, 5}
 SHA256 = re.compile(r"[0-9a-f]{64}")
 
 
@@ -388,7 +388,7 @@ def plan_gc(
                 retained[tag] = "newest-nightly-count"
             elif release.published_at >= nightly_cutoff:
                 retained[tag] = "nightly-age-window"
-            elif release.schema_version == 4 and tag not in container_records:
+            elif release.schema_version in {4, 5} and tag not in container_records:
                 retained[tag] = "missing-container-identity"
             else:
                 expired[tag] = "nightly-retention-expired"
@@ -398,7 +398,7 @@ def plan_gc(
                 retained[tag] = "awaiting-matching-stable"
             elif now < matching_stable_completed_at + prerelease_grace:
                 retained[tag] = "matching-stable-grace-window"
-            elif release.schema_version == 4 and tag not in container_records:
+            elif release.schema_version in {4, 5} and tag not in container_records:
                 retained[tag] = "missing-container-identity"
             else:
                 expired[tag] = "prerelease-grace-expired"

--- a/scripts/release/release_lines.py
+++ b/scripts/release/release_lines.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""Resolve version tags to controller-owned release source branches."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from release_channels import NIGHTLY_PATTERN, is_canonical_tag, parse_version
+
+POLICY_PATH = Path(__file__).with_name("release-lines.json")
+LINE_PATTERN = re.compile(r"^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$")
+MAINTENANCE_REF_PATTERN = re.compile(
+    r"^refs/heads/v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.x$"
+)
+DEFAULT_BRANCH_REF = "refs/heads/main"
+LINE_STATUSES = {"active", "closed"}
+
+
+@dataclass(frozen=True)
+class ReleaseLine:
+    name: str
+    source_ref: str
+    trusted_source_refs: tuple[str, ...]
+    status: str
+
+    def outputs(self) -> dict[str, str]:
+        return {
+            "release_line": self.name,
+            "source_ref": self.source_ref,
+            "line_status": self.status,
+        }
+
+
+def load_policy(path: Path = POLICY_PATH) -> dict[str, Any]:
+    try:
+        policy = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise SystemExit(f"invalid release-line policy: {path}") from exc
+    validate_policy(policy)
+    return policy
+
+
+def validate_policy(policy: dict[str, Any]) -> None:
+    if not isinstance(policy, dict) or set(policy) != {
+        "schema_version",
+        "lines",
+        "nightly_source_ref",
+    }:
+        raise SystemExit("release-line policy has an invalid top-level contract")
+    if policy["schema_version"] != 2:
+        raise SystemExit("unsupported release-line policy schema")
+    if policy["nightly_source_ref"] != DEFAULT_BRANCH_REF:
+        raise SystemExit("nightly releases must use refs/heads/main")
+    lines = policy["lines"]
+    if not isinstance(lines, dict) or not lines:
+        raise SystemExit("release-line policy defines no release lines")
+    for name, document in lines.items():
+        if not isinstance(name, str) or not LINE_PATTERN.fullmatch(name):
+            raise SystemExit(f"invalid release line: {name!r}")
+        if not isinstance(document, dict) or set(document) != {
+            "source_ref",
+            "trusted_source_refs",
+            "status",
+        }:
+            raise SystemExit(f"release line {name} has an invalid contract")
+        source_ref = document["source_ref"]
+        trusted_source_refs = document["trusted_source_refs"]
+        status = document["status"]
+        if status not in LINE_STATUSES:
+            raise SystemExit(f"release line {name} has an invalid status")
+        if (
+            not isinstance(trusted_source_refs, list)
+            or not trusted_source_refs
+            or any(not isinstance(ref, str) for ref in trusted_source_refs)
+            or len(set(trusted_source_refs)) != len(trusted_source_refs)
+            or source_ref not in trusted_source_refs
+        ):
+            raise SystemExit(
+                f"release line {name} must define unique trusted source refs "
+                "including its current source ref"
+            )
+        for trusted_source_ref in trusted_source_refs:
+            maintenance = MAINTENANCE_REF_PATTERN.fullmatch(trusted_source_ref)
+            if trusted_source_ref != DEFAULT_BRANCH_REF and (
+                maintenance is None
+                or f"{maintenance.group(1)}.{maintenance.group(2)}" != name
+            ):
+                raise SystemExit(
+                    f"release line {name} must use refs/heads/main or "
+                    f"refs/heads/v{name}.x"
+                )
+
+
+def line_name_for_tag(tag: str) -> str:
+    if not is_canonical_tag(tag) or NIGHTLY_PATTERN.fullmatch(tag):
+        raise SystemExit(f"release line requires a canonical non-nightly tag: {tag}")
+    core, _ = parse_version(tag)
+    return f"{core[0]}.{core[1]}"
+
+
+def resolve_tag(
+    tag: str,
+    policy: dict[str, Any] | None = None,
+    *,
+    allow_closed: bool = False,
+) -> ReleaseLine:
+    policy = policy or load_policy()
+    name = line_name_for_tag(tag)
+    document = policy["lines"].get(name)
+    if not isinstance(document, dict):
+        raise SystemExit(f"no trusted release line is configured for {tag}")
+    status = str(document["status"])
+    if status != "active" and not allow_closed:
+        raise SystemExit(f"release line {name} is closed")
+    return ReleaseLine(
+        name,
+        str(document["source_ref"]),
+        tuple(str(ref) for ref in document["trusted_source_refs"]),
+        status,
+    )
+
+
+def validate_provenance(
+    tag: str,
+    release_line: str,
+    source_ref: str,
+    policy: dict[str, Any] | None = None,
+    *,
+    allow_closed: bool = False,
+) -> ReleaseLine:
+    """Validate recorded provenance without changing the source for new cuts."""
+    expected = resolve_tag(tag, policy, allow_closed=allow_closed)
+    if release_line != expected.name or source_ref not in expected.trusted_source_refs:
+        raise SystemExit("invalid release-line provenance")
+    return expected
+
+
+def nightly_line(policy: dict[str, Any] | None = None) -> ReleaseLine:
+    policy = policy or load_policy()
+    source_ref = str(policy["nightly_source_ref"])
+    return ReleaseLine("nightly", source_ref, (source_ref,), "active")
+
+
+def write_outputs(outputs: dict[str, str], output_path: Path | None) -> None:
+    if output_path is None and os.environ.get("GITHUB_OUTPUT"):
+        output_path = Path(os.environ["GITHUB_OUTPUT"])
+    if output_path:
+        with output_path.open("a", encoding="utf-8") as output:
+            for key, value in outputs.items():
+                output.write(f"{key}={value}\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "command", choices=("validate", "resolve", "verify-provenance", "nightly")
+    )
+    parser.add_argument("--tag")
+    parser.add_argument("--release-line")
+    parser.add_argument("--source-ref")
+    parser.add_argument("--allow-closed", action="store_true")
+    parser.add_argument("--github-output", type=Path)
+    args = parser.parse_args()
+
+    policy = load_policy()
+    if args.command == "validate":
+        print(f"validated {len(policy['lines'])} release lines")
+        return 0
+    if args.command in {"resolve", "verify-provenance"}:
+        if not args.tag:
+            parser.error(f"{args.command} requires --tag")
+        if args.command == "verify-provenance":
+            if not args.release_line or not args.source_ref:
+                parser.error(
+                    "verify-provenance requires --release-line and --source-ref"
+                )
+            line = validate_provenance(
+                args.tag,
+                args.release_line,
+                args.source_ref,
+                policy,
+                allow_closed=args.allow_closed,
+            )
+        else:
+            line = resolve_tag(args.tag, policy, allow_closed=args.allow_closed)
+    else:
+        line = nightly_line(policy)
+    outputs = line.outputs()
+    write_outputs(outputs, args.github_output)
+    print(json.dumps(outputs, sort_keys=True, separators=(",", ":")))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release/test_release_lines.py
+++ b/scripts/release/test_release_lines.py
@@ -1,0 +1,113 @@
+"""Tests for controller-owned release-line policy."""
+
+from __future__ import annotations
+
+import copy
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import release_lines
+
+
+class ReleaseLinePolicyTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.policy = release_lines.load_policy()
+
+    def test_active_line_resolves_from_canonical_tags(self) -> None:
+        line = release_lines.resolve_tag("v0.2.1-rc.4", self.policy)
+        self.assertEqual((line.name, line.source_ref), ("0.2", "refs/heads/main"))
+        self.assertEqual(line.trusted_source_refs, ("refs/heads/main",))
+
+    def test_tag_cannot_select_a_different_release_line(self) -> None:
+        with self.assertRaisesRegex(SystemExit, "no trusted release line"):
+            release_lines.resolve_tag("v0.3.0-rc.1", self.policy)
+
+    def test_noncanonical_and_nightly_tags_cannot_select_release_lines(self) -> None:
+        for tag in ("v0.2.1-rc4", "v0.0.0-dev.12"):
+            with (
+                self.subTest(tag=tag),
+                self.assertRaisesRegex(SystemExit, "canonical non-nightly"),
+            ):
+                release_lines.resolve_tag(tag, self.policy)
+
+    def test_closed_line_is_recovery_only(self) -> None:
+        policy = copy.deepcopy(self.policy)
+        policy["lines"]["0.2"]["status"] = "closed"
+        release_lines.validate_policy(policy)
+        with self.assertRaisesRegex(SystemExit, "closed"):
+            release_lines.resolve_tag("v0.2.1", policy)
+        release_lines.validate_provenance(
+            "v0.2.1",
+            "0.2",
+            "refs/heads/main",
+            policy,
+            allow_closed=True,
+        )
+
+    def test_source_handoff_preserves_historical_provenance(self) -> None:
+        policy = copy.deepcopy(self.policy)
+        policy["lines"]["0.2"]["source_ref"] = "refs/heads/v0.2.x"
+        policy["lines"]["0.2"]["trusted_source_refs"].append("refs/heads/v0.2.x")
+        release_lines.validate_policy(policy)
+
+        current = release_lines.resolve_tag("v0.2.2", policy)
+        self.assertEqual(current.source_ref, "refs/heads/v0.2.x")
+        release_lines.validate_provenance("v0.2.1", "0.2", "refs/heads/main", policy)
+        release_lines.validate_provenance("v0.2.2", "0.2", "refs/heads/v0.2.x", policy)
+
+    def test_provenance_rejects_wrong_line_or_untrusted_source(self) -> None:
+        for line, source_ref in (
+            ("0.3", "refs/heads/main"),
+            ("0.2", "refs/heads/v0.2.x"),
+        ):
+            with (
+                self.subTest(line=line, source_ref=source_ref),
+                self.assertRaisesRegex(SystemExit, "invalid release-line provenance"),
+            ):
+                release_lines.validate_provenance(
+                    "v0.2.1", line, source_ref, self.policy
+                )
+
+    def test_policy_rejects_arbitrary_or_cross_line_source_refs(self) -> None:
+        for source_ref in (
+            "refs/heads/feature/release",
+            "refs/heads/v0.3.x",
+            "refs/tags/v0.2.1",
+            "main",
+        ):
+            policy = copy.deepcopy(self.policy)
+            policy["lines"]["0.2"]["source_ref"] = source_ref
+            with self.subTest(source_ref=source_ref), self.assertRaises(SystemExit):
+                release_lines.validate_policy(policy)
+
+    def test_policy_rejects_invalid_or_incomplete_trusted_source_history(self) -> None:
+        for trusted_source_refs in (
+            [],
+            ["refs/heads/v0.2.x"],
+            ["refs/heads/main", "refs/heads/main"],
+            ["refs/heads/main", "refs/heads/v0.3.x"],
+            ["refs/heads/main", "refs/heads/feature"],
+        ):
+            policy = copy.deepcopy(self.policy)
+            policy["lines"]["0.2"]["trusted_source_refs"] = trusted_source_refs
+            with (
+                self.subTest(trusted_source_refs=trusted_source_refs),
+                self.assertRaises(SystemExit),
+            ):
+                release_lines.validate_policy(policy)
+
+    def test_nightly_is_always_main(self) -> None:
+        self.assertEqual(
+            release_lines.nightly_line(self.policy).source_ref,
+            "refs/heads/main",
+        )
+        policy = copy.deepcopy(self.policy)
+        policy["nightly_source_ref"] = "refs/heads/v0.2.x"
+        with self.assertRaisesRegex(SystemExit, "nightly"):
+            release_lines.validate_policy(policy)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/release/test_release_promotion.py
+++ b/scripts/release/test_release_promotion.py
@@ -18,6 +18,7 @@ from unittest import mock
 
 RELEASE_DIR = Path(__file__).resolve().parent
 COMMIT = "0123456789abcdef0123456789abcdef01234567"
+SOURCE_HEAD = "1" * 40
 sys.path.insert(0, str(RELEASE_DIR))
 
 
@@ -112,13 +113,13 @@ class ReleasePromotionTests(unittest.TestCase):
             "f" * 40,
             release_line="0.2",
             source_ref="refs/heads/main",
-            source_ref_head=COMMIT,
+            source_ref_head=SOURCE_HEAD,
         ).document()
 
         self.assertEqual(document["schema_version"], 5)
         self.assertEqual(document["release_line"], "0.2")
         self.assertEqual(document["source_ref"], "refs/heads/main")
-        self.assertEqual(document["source_ref_head"], COMMIT)
+        self.assertEqual(document["source_ref_head"], SOURCE_HEAD)
 
     def test_schema_five_ledger_enforces_controller_release_line(self) -> None:
         verifier = load_module(
@@ -135,7 +136,7 @@ class ReleasePromotionTests(unittest.TestCase):
                 "commit": COMMIT,
                 "release_line": "0.2",
                 "source_ref": "refs/heads/main",
-                "source_ref_head": COMMIT,
+                "source_ref_head": SOURCE_HEAD,
                 "build_controller_commit": "e" * 40,
                 "promotion_controller_commit": "f" * 40,
                 "artifacts": [
@@ -190,7 +191,7 @@ class ReleasePromotionTests(unittest.TestCase):
                 "commit": COMMIT,
                 "release_line": "0.2",
                 "source_ref": "refs/heads/main",
-                "source_ref_head": COMMIT,
+                "source_ref_head": SOURCE_HEAD,
                 "build_controller_commit": "e" * 40,
                 "promotion_controller_commit": "f" * 40,
                 "artifacts": [
@@ -1397,7 +1398,7 @@ class ReleasePromotionTests(unittest.TestCase):
                         "source_commit": COMMIT,
                         "release_line": "0.2",
                         "source_ref": "refs/heads/main",
-                        "source_ref_head": COMMIT,
+                        "source_ref_head": SOURCE_HEAD,
                         "build_controller_commit": "f" * 40,
                         "build_contract_schema": 1,
                         "registry_versions": {
@@ -1436,7 +1437,7 @@ class ReleasePromotionTests(unittest.TestCase):
             self.assertEqual(ledger["schema_version"], 5)
             self.assertEqual(ledger["release_line"], "0.2")
             self.assertEqual(ledger["source_ref"], "refs/heads/main")
-            self.assertEqual(ledger["source_ref_head"], COMMIT)
+            self.assertEqual(ledger["source_ref_head"], SOURCE_HEAD)
             self.assertEqual(ledger["build_controller_commit"], "f" * 40)
             self.assertEqual(ledger["promotion_controller_commit"], "e" * 40)
             self.assertEqual(ledger["generated_at"], "1970-01-01T00:00:00Z")

--- a/scripts/release/test_release_promotion.py
+++ b/scripts/release/test_release_promotion.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import copy
 import hashlib
 import importlib.util
 import io
@@ -98,6 +99,136 @@ class ReleasePromotionTests(unittest.TestCase):
             )
             self.assertEqual(
                 (output / "install.sh").read_bytes(), objects["scripts/install.sh"]
+            )
+
+    def test_release_spec_records_trusted_release_line_provenance(self) -> None:
+        channels = load_module(
+            "release_channels_provenance_test", "release_channels.py"
+        )
+        document = channels.build_release_spec(
+            "v0.2.1-rc.4",
+            "auto",
+            COMMIT,
+            "f" * 40,
+            release_line="0.2",
+            source_ref="refs/heads/main",
+            source_ref_head=COMMIT,
+        ).document()
+
+        self.assertEqual(document["schema_version"], 5)
+        self.assertEqual(document["release_line"], "0.2")
+        self.assertEqual(document["source_ref"], "refs/heads/main")
+        self.assertEqual(document["source_ref_head"], COMMIT)
+
+    def test_schema_five_ledger_enforces_controller_release_line(self) -> None:
+        verifier = load_module(
+            "verify_release_ledger_provenance_test", "verify_release_ledger.py"
+        )
+        with tempfile.TemporaryDirectory() as raw_tmp:
+            root = Path(raw_tmp)
+            artifact = root / "antfly.tar.gz"
+            artifact.write_bytes(b"release")
+            ledger_path = root / "artifacts.json"
+            ledger = {
+                "schema_version": 5,
+                "tag": "v0.2.1-rc.4",
+                "commit": COMMIT,
+                "release_line": "0.2",
+                "source_ref": "refs/heads/main",
+                "source_ref_head": COMMIT,
+                "build_controller_commit": "e" * 40,
+                "promotion_controller_commit": "f" * 40,
+                "artifacts": [
+                    {
+                        "name": artifact.name,
+                        "size": artifact.stat().st_size,
+                        "sha256": verifier.sha256(artifact),
+                        "scope": "runtime",
+                    }
+                ],
+            }
+            ledger_path.write_text(json.dumps(ledger))
+            verifier.verify_payload(
+                ledger_path,
+                root,
+                "v0.2.1-rc.4",
+                COMMIT,
+                verifier.sha256(ledger_path),
+                None,
+            )
+
+            ledger["source_ref"] = "refs/heads/v0.2.x"
+            ledger_path.write_text(json.dumps(ledger))
+            with self.assertRaisesRegex(SystemExit, "release-line provenance"):
+                verifier.verify_payload(
+                    ledger_path,
+                    root,
+                    "v0.2.1-rc.4",
+                    COMMIT,
+                    verifier.sha256(ledger_path),
+                    None,
+                )
+
+    def test_schema_five_ledger_survives_release_line_handoff(self) -> None:
+        verifier = load_module(
+            "verify_release_ledger_handoff_test", "verify_release_ledger.py"
+        )
+        release_lines = load_module("release_lines_handoff_test", "release_lines.py")
+        policy = copy.deepcopy(release_lines.load_policy())
+        policy["lines"]["0.2"]["source_ref"] = "refs/heads/v0.2.x"
+        policy["lines"]["0.2"]["trusted_source_refs"].append("refs/heads/v0.2.x")
+        release_lines.validate_policy(policy)
+
+        with tempfile.TemporaryDirectory() as raw_tmp:
+            root = Path(raw_tmp)
+            artifact = root / "antfly.tar.gz"
+            artifact.write_bytes(b"release")
+            ledger_path = root / "artifacts.json"
+            ledger = {
+                "schema_version": 5,
+                "tag": "v0.2.1",
+                "commit": COMMIT,
+                "release_line": "0.2",
+                "source_ref": "refs/heads/main",
+                "source_ref_head": COMMIT,
+                "build_controller_commit": "e" * 40,
+                "promotion_controller_commit": "f" * 40,
+                "artifacts": [
+                    {
+                        "name": artifact.name,
+                        "size": artifact.stat().st_size,
+                        "sha256": verifier.sha256(artifact),
+                        "scope": "runtime",
+                    }
+                ],
+            }
+            ledger_path.write_text(json.dumps(ledger))
+
+            verifier.verify_payload(
+                ledger_path,
+                root,
+                "v0.2.1",
+                COMMIT,
+                verifier.sha256(ledger_path),
+                None,
+                policy,
+            )
+
+    def test_schema_four_release_spec_remains_compatible(self) -> None:
+        channels = load_module("release_channels_v4_compat_test", "release_channels.py")
+        payload = load_module(
+            "build_release_payload_v4_compat_test", "build_release_payload.py"
+        )
+        with tempfile.TemporaryDirectory() as raw_tmp:
+            path = Path(raw_tmp) / "release-request.json"
+            document = channels.build_release_spec(
+                "v1.2.3", "stable", COMMIT, "f" * 40
+            ).document()
+            path.write_text(json.dumps(document))
+
+            self.assertEqual(document["schema_version"], 4)
+            self.assertEqual(
+                payload.verify_release_spec(path, "v1.2.3", COMMIT), document
             )
 
     def test_release_channel_policy_resolves_all_supported_channels(self) -> None:
@@ -1216,16 +1347,16 @@ class ReleasePromotionTests(unittest.TestCase):
             archives.mkdir()
             extras.mkdir()
             source.mkdir()
-            (archives / "antfly_1.2.3_Linux_x86_64_gnu.tar.gz").write_bytes(b"native")
-            (extras / "antfly-cli-1.2.3.tgz").write_bytes(b"npm")
+            (archives / "antfly_0.2.1_Linux_x86_64_gnu.tar.gz").write_bytes(b"native")
+            (extras / "antfly-cli-0.2.1.tgz").write_bytes(b"npm")
             (extras / "cli-snapshot.json").write_text(
                 json.dumps(
                     {
-                        "version": "1.2.3",
+                        "version": "0.2.1",
                         "commit": COMMIT,
                         "registry_versions": {
-                            "npm": "1.2.3",
-                            "python": "1.2.3",
+                            "npm": "0.2.1",
+                            "python": "0.2.1",
                         },
                     }
                 )
@@ -1259,17 +1390,20 @@ class ReleasePromotionTests(unittest.TestCase):
             release_spec.write_text(
                 json.dumps(
                     {
-                        "schema_version": 4,
-                        "tag": "v1.2.3",
-                        "version": "1.2.3",
+                        "schema_version": 5,
+                        "tag": "v0.2.1",
+                        "version": "0.2.1",
                         "channel": "stable",
                         "source_commit": COMMIT,
+                        "release_line": "0.2",
+                        "source_ref": "refs/heads/main",
+                        "source_ref_head": COMMIT,
                         "build_controller_commit": "f" * 40,
                         "build_contract_schema": 1,
                         "registry_versions": {
-                            "npm": "1.2.3",
-                            "python": "1.2.3",
-                            "container": "v1.2.3",
+                            "npm": "0.2.1",
+                            "python": "0.2.1",
+                            "container": "v0.2.1",
                         },
                     }
                 )
@@ -1277,7 +1411,7 @@ class ReleasePromotionTests(unittest.TestCase):
             argv = [
                 "build_release_payload.py",
                 "--tag",
-                "v1.2.3",
+                "v0.2.1",
                 "--commit",
                 COMMIT,
                 "--archive-dir",
@@ -1299,13 +1433,16 @@ class ReleasePromotionTests(unittest.TestCase):
             ):
                 self.assertEqual(payload.main(), 0)
             ledger = json.loads((output / "artifacts.json").read_text())
-            self.assertEqual(ledger["schema_version"], 4)
+            self.assertEqual(ledger["schema_version"], 5)
+            self.assertEqual(ledger["release_line"], "0.2")
+            self.assertEqual(ledger["source_ref"], "refs/heads/main")
+            self.assertEqual(ledger["source_ref_head"], COMMIT)
             self.assertEqual(ledger["build_controller_commit"], "f" * 40)
             self.assertEqual(ledger["promotion_controller_commit"], "e" * 40)
             self.assertEqual(ledger["generated_at"], "1970-01-01T00:00:00Z")
             self.assertEqual(
                 ledger["registry_versions"],
-                {"npm": "1.2.3", "python": "1.2.3", "container": "v1.2.3"},
+                {"npm": "0.2.1", "python": "0.2.1", "container": "v0.2.1"},
             )
             kinds = {artifact["kind"] for artifact in ledger["artifacts"]}
             self.assertIn("runtime-archive", kinds)
@@ -1321,7 +1458,7 @@ class ReleasePromotionTests(unittest.TestCase):
             )
             promotion = root / "promotion"
             promotion.mkdir()
-            promoted_package = promotion / "antfly-cli-1.2.3.tgz"
+            promoted_package = promotion / "antfly-cli-0.2.1.tgz"
             promoted_package.write_bytes((output / promoted_package.name).read_bytes())
             promoted_manifest = promotion / "cli-snapshot.json"
             promoted_manifest.write_bytes(
@@ -1336,7 +1473,7 @@ class ReleasePromotionTests(unittest.TestCase):
                 "--scope",
                 "cli",
                 "--tag",
-                "v1.2.3",
+                "v0.2.1",
                 "--commit",
                 COMMIT,
                 "--ledger-sha256",

--- a/scripts/release/verify_release_ledger.py
+++ b/scripts/release/verify_release_ledger.py
@@ -82,10 +82,6 @@ def verify_payload(
                 release_line_policy,
                 allow_closed=True,
             )
-            if source_ref_head != commit:
-                raise SystemExit(
-                    "release ledger source head differs from release commit"
-                )
 
     entries: dict[str, dict[str, object]] = {}
     ledger_artifacts = ledger.get("artifacts")

--- a/scripts/release/verify_release_ledger.py
+++ b/scripts/release/verify_release_ledger.py
@@ -9,6 +9,9 @@ import json
 import re
 from pathlib import Path
 
+from release_channels import NIGHTLY_PATTERN
+from release_lines import nightly_line, validate_provenance
+
 
 def inferred_scope(entry: dict[str, object]) -> str:
     scope = entry.get("scope")
@@ -37,6 +40,7 @@ def verify_payload(
     commit: str,
     ledger_sha256: str,
     scope: str | None = None,
+    release_line_policy: dict[str, object] | None = None,
 ) -> str:
     expected_ledger_digest = ledger_sha256.lower()
     if not re.fullmatch(r"[0-9a-f]{64}", expected_ledger_digest):
@@ -50,14 +54,38 @@ def verify_payload(
 
     ledger = json.loads(ledger_path.read_text(encoding="utf-8"))
     schema_version = ledger.get("schema_version")
-    if schema_version not in {1, 2, 3, 4}:
+    if schema_version not in {1, 2, 3, 4, 5}:
         raise SystemExit("unsupported release ledger schema")
     if ledger.get("tag") != tag or ledger.get("commit") != commit:
         raise SystemExit("release ledger does not match the requested tag and commit")
-    if schema_version == 4:
+    if schema_version in {4, 5}:
         for field in ("build_controller_commit", "promotion_controller_commit"):
             if not re.fullmatch(r"[0-9a-f]{40}", str(ledger.get(field, ""))):
                 raise SystemExit(f"release ledger has an invalid {field}")
+    if schema_version == 5:
+        release_line = ledger.get("release_line")
+        source_ref = ledger.get("source_ref")
+        source_ref_head = ledger.get("source_ref_head")
+        if not isinstance(release_line, str) or not isinstance(source_ref, str):
+            raise SystemExit("release ledger has invalid source provenance")
+        if not re.fullmatch(r"[0-9a-f]{40}", str(source_ref_head)):
+            raise SystemExit("release ledger has invalid source provenance")
+        if NIGHTLY_PATTERN.fullmatch(tag):
+            expected = nightly_line()
+            if release_line != expected.name or source_ref != expected.source_ref:
+                raise SystemExit("release ledger has invalid nightly source provenance")
+        else:
+            validate_provenance(
+                tag,
+                release_line,
+                source_ref,
+                release_line_policy,
+                allow_closed=True,
+            )
+            if source_ref_head != commit:
+                raise SystemExit(
+                    "release ledger source head differs from release commit"
+                )
 
     entries: dict[str, dict[str, object]] = {}
     ledger_artifacts = ledger.get("artifacts")
@@ -74,7 +102,7 @@ def verify_payload(
             or name in entries
         ):
             raise SystemExit("release ledger contains an invalid or duplicate artifact")
-        if schema_version in {2, 3, 4} and entry.get("scope") not in {
+        if schema_version in {2, 3, 4, 5} and entry.get("scope") not in {
             "runtime",
             "cli",
             "support",


### PR DESCRIPTION
Implements the smaller release-line design discussed after #636 without restoring the release-cut workflow or repository settings from #639.

## What changes

- keeps release tags manual and keeps the tag request workflow read-only
- adds a main-owned release-line map with only `0.2 -> main` active today
- derives the trusted source branch from the tag version in the privileged `workflow_run` controller
- requires a non-nightly tag commit to belong to the selected branch, preserving delayed validation and reruns
- fences queued controllers against one current-main snapshot of the release-line policy bundle
- records release line, source ref, and observed ref head in schema-v5 build provenance and ledgers
- validates that provenance through build, promotion, recovery, and retention
- preserves schema-v4 compatibility and historical trusted refs across a future `main -> v0.N.x` handoff
- documents the future 0.3 / v0.2.x transition procedure

## Deliberately not included

- no release-cut environment
- no workflow-created tags
- no required status checks, rulesets, or branch-protection rollout
- no current switch to `v0.2.x`

## Validation

- `scripts/ci/check.sh release`
- `actionlint`
- Ruff and Black checks on changed Python files
- `git diff --check`