### PR TITLE
test(inference): exercise HTTP cancellation and worker recovery end to end

### DIFF
--- a/zig/build.zig
+++ b/zig/build.zig
@@ -188,6 +188,7 @@ const inference_delegated_steps = [_][]const u8{
     "bench-gliner2-native",
     "gliner2-entity-training-readiness",
     "test-finetune",
+    "test-cancellation-e2e",
     "test",
     "wasm",
 };

--- a/zig/pkg/inference/build.zig
+++ b/zig/pkg/inference/build.zig
@@ -1741,6 +1741,26 @@ pub fn build(b: *std.Build) void {
         quant_kernel_local_check_step.dependOn(&run_quant_kernel_cuda_microbench_tests.step);
     }
     const test_step = b.step("test", "Run unit tests");
+    const cancellation_e2e_step = b.step("test-cancellation-e2e", "Run HTTP inference cancellation and worker recovery E2E tests");
+    if (targetRunsOnBuildHost(b, target) and (target.result.os.tag == .linux or target.result.os.tag == .macos)) {
+        const fixture = b.addExecutable(.{
+            .name = "inference-cancellation-fixture",
+            .root_module = b.createModule(.{
+                .root_source_file = b.path("tests/cancellation_fixture.zig"),
+                .target = target,
+                .optimize = optimize,
+            }),
+        });
+        fixture.root_module.addImport("inference", runtime_graph.inference_mod);
+        fixture.root_module.addImport("httpx", httpx_mod);
+        fixture.root_module.addImport("antfly_platform", platform_mod);
+        fixture.root_module.link_libc = true;
+        const integration = b.addSystemCommand(&.{"python3"});
+        integration.addFileArg(b.path("tests/test_cancellation_e2e.py"));
+        integration.addArtifactArg(fixture);
+        cancellation_e2e_step.dependOn(&integration.step);
+        if (selected_test_filters.len == 0) test_step.dependOn(cancellation_e2e_step);
+    }
     test_step.dependOn(&quant_kernel_codegen_test_check.step);
     test_step.dependOn(&cuda_artifact_source_policy_check.step);
     test_step.dependOn(&run_quant_kernel_metal_runtime_check_tests.step);

--- a/zig/pkg/inference/tests/README.md
+++ b/zig/pkg/inference/tests/README.md
@@ -1,0 +1,32 @@
+# Inference cancellation E2E
+
+Run from `zig/` with `zig build inference-test-cancellation-e2e`, or from
+`zig/pkg/inference/` with `zig build test-cancellation-e2e`. The unfiltered
+`inference-test` / package `test` aggregate also runs this suite on native Linux
+and macOS. It needs Python 3, but no downloaded model, GPU, or Python packages.
+
+The fixture runs production HTTP routes, tokenization, request/weighted/run
+admission, execution control, the hard-cancellation watchdog, and the process
+supervisor. Only the model session is synthetic. Its control routes exist only
+in this test executable, which is not installed or linked into the server.
+
+Each test first verifies a successful embedding, arms a blocking model call,
+waits until the real HTTP request owns admission and scratch memory, and then
+aborts its TCP client with a reset (RST):
+
+- A cooperative session must observe cancellation, unwind its permits, and
+  continue serving in the same worker.
+- An uninterruptible session never checks cancellation or requests a restart;
+  the production watchdog must terminate it and the supervisor must replace it.
+
+Both paths must return to baseline resource accounting and serve the same
+embedding successfully afterward. All network waits are bounded, and cleanup
+terminates the fixture process group even on failure.
+
+An orderly TCP half-close (FIN) is not cancellation: an HTTP/1 client may still
+be waiting to read the response. The tests deliberately use RST to establish
+response abandonment, matching the production transport contract.
+
+This covers transport-abort propagation through model execution. It does not
+exercise real GPU drivers, cold model loading, or application-deadline wiring;
+those need separate coverage.

--- a/zig/pkg/inference/tests/cancellation_fixture.zig
+++ b/zig/pkg/inference/tests/cancellation_fixture.zig
@@ -1,0 +1,157 @@
+// Copyright 2026 Antfly, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Test-only executable. The HTTP routes, model handles, tokenizer, admission,
+//! execution control, watchdog and process supervisor are production code.
+//! Only the Session vtable is synthetic; no fault hooks ship in the server.
+const std = @import("std");
+const inference = @import("inference");
+const httpx = @import("httpx");
+const platform = @import("antfly_platform");
+const Session = inference.backends.Session;
+const Tensor = inference.backends.Tensor;
+const TensorInfo = inference.backends.TensorInfo;
+const Control = inference.InferenceExecutionControl;
+
+const Fixture = struct {
+    node: *inference.server.Node,
+    hard: bool,
+    block_next: std.atomic.Value(bool) = .init(false),
+    active: std.atomic.Value(usize) = .init(0),
+    cancelled: std.atomic.Value(usize) = .init(0),
+    entered: std.atomic.Value(usize) = .init(0),
+
+    fn state(self: *@This(), ctx: *httpx.Context) !httpx.Response {
+        const memory = self.node.model_manager.resource_domain.?.admission.snapshot();
+        return ctx.json(.{
+            .pid = std.posix.system.getpid(),
+            .active = self.active.load(.acquire),
+            .entered = self.entered.load(.acquire),
+            .cancelled = self.cancelled.load(.acquire),
+            .requests = self.node.inference_admission.inFlightRequests(),
+            .units = self.node.inference_admission.inFlightUnits(),
+            .scratch = memory.host_scratch_bytes,
+        });
+    }
+
+    fn arm(self: *@This(), ctx: *httpx.Context) !httpx.Response {
+        self.block_next.store(true, .release);
+        return ctx.json(.{ .armed = true });
+    }
+
+    fn run(_: *anyopaque, _: []const Tensor, _: std.mem.Allocator) ![]Tensor {
+        return error.UncontrolledFixtureExecution;
+    }
+
+    fn runWithControl(raw: *anyopaque, inputs: []const Tensor, alloc: std.mem.Allocator, control: Control) ![]Tensor {
+        const self: *@This() = @ptrCast(@alignCast(raw));
+        _ = self.active.fetchAdd(1, .acq_rel);
+        defer _ = self.active.fetchSub(1, .acq_rel);
+        _ = self.entered.fetchAdd(1, .acq_rel);
+        if (self.block_next.swap(false, .acq_rel)) {
+            if (self.hard) {
+                // An actual uninterruptible call: no checks, sleeps, or direct
+                // restart request. Only the production watchdog can stop it.
+                while (true) std.atomic.spinLoopHint();
+            }
+            while (true) {
+                control.check() catch |err| {
+                    _ = self.cancelled.fetchAdd(1, .acq_rel);
+                    return err;
+                };
+                try control.io.?.sleep(.fromMilliseconds(1), .awake);
+            }
+        }
+        try control.check();
+        const batch = inputs[0].shape[0];
+        const sequence = inputs[0].shape[1];
+        const values = try alloc.alloc(f32, @intCast(batch * sequence * 4));
+        defer alloc.free(values);
+        @memset(values, 1);
+        const outputs = try alloc.alloc(Tensor, 1);
+        errdefer alloc.free(outputs);
+        outputs[0] = try Tensor.initFloat32(alloc, "last_hidden_state", &.{ batch, sequence, 4 }, values);
+        return outputs;
+    }
+
+    fn inputInfo(_: *anyopaque) []const TensorInfo {
+        return &.{
+            .{ .name = "input_ids", .dtype = .i64, .shape = &.{ -1, -1 } },
+            .{ .name = "attention_mask", .dtype = .i64, .shape = &.{ -1, -1 } },
+        };
+    }
+    fn outputInfo(_: *anyopaque) []const TensorInfo {
+        return &.{.{ .name = "last_hidden_state", .dtype = .f32, .shape = &.{ -1, -1, 4 } }};
+    }
+    fn backend(_: *anyopaque) inference.backends.BackendType {
+        return .native;
+    }
+    fn interruption(raw: *anyopaque) inference.execution_control.Interruption {
+        const self: *@This() = @ptrCast(@alignCast(raw));
+        return if (self.hard) .process_required else .cooperative;
+    }
+    fn close(_: *anyopaque) void {}
+    const vtable = Session.VTable{
+        .run = run,
+        .runWithControl = runWithControl,
+        .inputInfo = inputInfo,
+        .outputInfo = outputInfo,
+        .backend = backend,
+        .interruption = interruption,
+        .close = close,
+    };
+};
+
+pub fn main(init: std.process.Init) !void {
+    var lifetime = platform.inference_process_supervisor.WorkerLifetime{};
+    defer lifetime.deinit(init.io);
+    if (try platform.inference_process_supervisor.runIfNeeded(init, 1, &lifetime)) return;
+    const alloc = init.gpa;
+    const model_dir = init.environ_map.get("FIXTURE_MODEL_DIR") orelse return error.MissingModelDir;
+    const port = try std.fmt.parseInt(u16, init.environ_map.get("FIXTURE_PORT") orelse return error.MissingPort, 10);
+    var node = try inference.server.Node.init(alloc, .{
+        .models_dir = std.fs.path.dirname(model_dir) orelse return error.MissingModelsRoot,
+        .allow_unknown_models = true,
+        .process_termination_available = true,
+        .max_concurrent_requests = 1,
+    });
+    defer node.deinit();
+    try node.attachIo(init.io);
+    try node.model_manager.ensureResourceOwnerReady();
+    var fixture = Fixture{ .node = &node, .hard = std.mem.eql(u8, init.environ_map.get("FIXTURE_MODE") orelse "", "hard") };
+
+    const ModelPtr = @typeInfo(@TypeOf(node.model_manager.loaded.get(model_dir))).optional.child;
+    const model = try alloc.create(std.meta.Child(ModelPtr));
+    model.* = .{
+        .allocator = alloc,
+        .model_dir = try alloc.dupe(u8, model_dir),
+        .manifest = try inference.models.manifest.loadFromDir(alloc, model_dir),
+        .hf_tok = try inference.hf_tokenizer.HfTokenizer.loadFromBytes(alloc,
+            \\{"version":"1.0","model":{"type":"BPE","vocab":{"a":0,"b":1},"merges":[]}}
+        ),
+        .sp_tok = null,
+        .session = .{
+            .ptr = &fixture,
+            .vtable = &Fixture.vtable,
+            .run_admission = .{
+                .controller = &node.model_manager.resource_domain.?.admission,
+                .backend_class = .cpu,
+                .limits = .{},
+                .static_workspace_bytes = 4096,
+            },
+        },
+        .session_manager = &node.session_manager,
+        .model_manager = &node.model_manager,
+        .prompt_prefix_cache = inference.runtime.kv.prompt_cache.PromptPrefixCache.init(alloc),
+        .native_generation_graph_cache = inference.graph.cache.GraphCache.init(alloc),
+        .pinned = true,
+    };
+    try node.model_manager.loaded.put(alloc, try alloc.dupe(u8, model_dir), model);
+
+    var server = httpx.Server.initWithConfig(alloc, init.io, node.httpServerConfig("127.0.0.1", port));
+    defer server.deinit();
+    try node.registerHttpRoutes(&server);
+    try server.get("/_fixture/state", httpx.Handler.bind(&fixture, Fixture.state));
+    try server.post("/_fixture/arm", httpx.Handler.bind(&fixture, Fixture.arm));
+    try server.listen();
+}

--- a/zig/pkg/inference/tests/test_cancellation_e2e.py
+++ b/zig/pkg/inference/tests/test_cancellation_e2e.py
@@ -161,20 +161,24 @@ class CancellationE2E(unittest.TestCase):
             self.assertIn(".exited = 86", log)
         else:
             recovered = self.wait_state(
-                lambda s: s["cancelled"] == 1
-                and s["active"] == 0
-                and s["requests"] == 0
-                and s["units"] == 0
+                lambda s: (
+                    s["cancelled"] == 1
+                    and s["active"] == 0
+                    and s["requests"] == 0
+                    and s["units"] == 0
+                )
             )
             self.assertEqual(recovered["pid"], initial["pid"])
         self.assertEqual(recovered["scratch"], baseline["scratch"])
         self.assertIsNone(self.proc.poll(), "supervisor must survive cancellation")
         self.assertEqual(self.embed(), expected)
         completed = self.wait_state(
-            lambda s: s["active"] == 0
-            and s["requests"] == 0
-            and s["units"] == 0
-            and s["scratch"] == baseline["scratch"]
+            lambda s: (
+                s["active"] == 0
+                and s["requests"] == 0
+                and s["units"] == 0
+                and s["scratch"] == baseline["scratch"]
+            )
         )
         self.assertEqual(completed["pid"], recovered["pid"])
         self.assertEqual(completed["entered"], 1 if mode == "hard" else 3)

--- a/zig/pkg/inference/tests/test_cancellation_e2e.py
+++ b/zig/pkg/inference/tests/test_cancellation_e2e.py
@@ -1,0 +1,190 @@
+# Copyright 2026 Antfly, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Real HTTP cancellation against production inference routes and supervision.
+
+Only model computation is synthetic, so these tests need no GPU or downloads.
+Every wait is bounded; cleanup owns the complete fixture process group.
+"""
+
+import http.client
+import json
+import os
+import signal
+import socket
+import struct
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+FIXTURE = os.path.abspath(sys.argv.pop(1))
+
+
+class CancellationE2E(unittest.TestCase):
+    def start(self, mode):
+        temp = tempfile.TemporaryDirectory(prefix="inference-cancellation-")
+        self.addCleanup(temp.cleanup)
+        model = Path(temp.name).resolve() / "fixture-model"
+        model.mkdir()
+        (model / "config.json").write_text(
+            json.dumps(
+                {
+                    "model_type": "bert",
+                    "hidden_size": 4,
+                    "num_hidden_layers": 1,
+                    "num_attention_heads": 1,
+                    "intermediate_size": 8,
+                    "vocab_size": 2,
+                    "max_position_embeddings": 16,
+                }
+            )
+        )
+        # A minimal safetensors artifact lets the normal compatibility
+        # gate discover a native bundle. Computation uses the resident fixture.
+        header = json.dumps(
+            {"fixture": {"dtype": "F32", "shape": [1], "data_offsets": [0, 4]}}
+        ).encode()
+        header += b" " * (-len(header) % 8)
+        (model / "model.safetensors").write_bytes(
+            len(header).to_bytes(8, "little") + header + b"\0" * 4
+        )
+        with socket.socket() as reservation:
+            reservation.bind(("127.0.0.1", 0))
+            self.port = reservation.getsockname()[1]
+        self.model = model.name
+        env = {
+            k: v for k, v in os.environ.items() if not k.startswith("ANTFLY_INFERENCE_")
+        }
+        env.update(
+            FIXTURE_MODEL_DIR=str(model), FIXTURE_PORT=str(self.port), FIXTURE_MODE=mode
+        )
+        # addCleanup closes the log after terminating the process group.
+        self.log = tempfile.TemporaryFile(mode="w+b")  # noqa: SIM115
+        self.addCleanup(self.log.close)
+        self.proc = subprocess.Popen(
+            [FIXTURE, "run"],
+            env=env,
+            stdout=self.log,
+            stderr=self.log,
+            start_new_session=True,
+        )
+        self.addCleanup(self.stop)
+        return self.wait_state(lambda state: True)
+
+    def stop(self):
+        try:
+            os.killpg(self.proc.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        self.proc.wait(timeout=5)
+
+    def request(self, method, path, body=None):
+        conn = http.client.HTTPConnection("127.0.0.1", self.port, timeout=1)
+        try:
+            conn.request(
+                method,
+                path,
+                json.dumps(body) if body is not None else None,
+                {"Content-Type": "application/json"},
+            )
+            response = conn.getresponse()
+            return response.status, json.loads(response.read())
+        finally:
+            conn.close()
+
+    def wait_state(self, predicate, timeout=10):
+        deadline = time.monotonic() + timeout
+        last = None
+        while time.monotonic() < deadline:
+            if self.proc.poll() is not None:
+                break
+            try:
+                status, last = self.request("GET", "/_fixture/state")
+                if status == 200 and predicate(last):
+                    return last
+            except (OSError, http.client.HTTPException, ValueError):
+                pass
+            time.sleep(0.025)
+        self.fail(f"state condition timed out; last={last}; log={self.read_log()}")
+
+    def read_log(self):
+        # Do not move the file offset shared with the worker's stderr.
+        size = os.fstat(self.log.fileno()).st_size
+        return os.pread(self.log.fileno(), 12000, max(0, size - 12000)).decode(
+            errors="replace"
+        )
+
+    def embed(self):
+        status, result = self.request(
+            "POST", "/ai/v1/embed", {"model": self.model, "input": ["ab"]}
+        )
+        self.assertEqual(status, 200, result)
+        return result
+
+    def exercise(self, mode):
+        initial = self.start(mode)
+        expected = self.embed()
+        baseline = self.wait_state(
+            lambda s: s["requests"] == 0 and s["units"] == 0 and s["active"] == 0
+        )
+        self.assertEqual(baseline["entered"], 1)
+        self.assertEqual(self.request("POST", "/_fixture/arm")[0], 200)
+        client = socket.create_connection(("127.0.0.1", self.port), timeout=2)
+        self.addCleanup(client.close)
+        body = json.dumps({"model": self.model, "input": ["ab"]}).encode()
+        client.sendall(
+            b"POST /ai/v1/embed HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/json\r\nContent-Length: "
+            + str(len(body)).encode()
+            + b"\r\n\r\n"
+            + body
+        )
+        running = self.wait_state(lambda s: s["active"] == 1)
+        self.assertEqual(running["pid"], initial["pid"])
+        self.assertEqual(running["entered"], 2)
+        self.assertEqual(running["requests"], 1)
+        self.assertGreater(running["units"], 0)
+        self.assertGreater(running["scratch"], baseline["scratch"])
+        # Abort with RST, not FIN: an orderly TCP half-close is legal while
+        # waiting for the response and intentionally does not cancel HTTP/1.
+        # Never set a cancellation token or invoke the watchdog directly.
+        client.setsockopt(socket.SOL_SOCKET, socket.SO_LINGER, struct.pack("ii", 1, 0))
+        client.close()
+        if mode == "hard":
+            recovered = self.wait_state(lambda s: s["pid"] != initial["pid"])
+            with self.assertRaises(ProcessLookupError):
+                os.kill(initial["pid"], 0)
+            # A native crash also restarts a worker; it must not make this pass.
+            log = self.read_log()
+            self.assertIn("terminating supervised worker err=Cancelled", log)
+            self.assertIn(".exited = 86", log)
+        else:
+            recovered = self.wait_state(
+                lambda s: s["cancelled"] == 1
+                and s["active"] == 0
+                and s["requests"] == 0
+                and s["units"] == 0
+            )
+            self.assertEqual(recovered["pid"], initial["pid"])
+        self.assertEqual(recovered["scratch"], baseline["scratch"])
+        self.assertIsNone(self.proc.poll(), "supervisor must survive cancellation")
+        self.assertEqual(self.embed(), expected)
+        completed = self.wait_state(
+            lambda s: s["active"] == 0
+            and s["requests"] == 0
+            and s["units"] == 0
+            and s["scratch"] == baseline["scratch"]
+        )
+        self.assertEqual(completed["pid"], recovered["pid"])
+        self.assertEqual(completed["entered"], 1 if mode == "hard" else 3)
+
+    def test_disconnect_unwinds_cooperative_inference(self):
+        self.exercise("cooperative")
+
+    def test_disconnect_replaces_uninterruptible_worker(self):
+        self.exercise("hard")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Follow-up to merged #644, on a fresh branch from current main.

- Add real HTTP/1 transport-abort E2E tests through production inference embedding routes, tokenization, admission accounting, execution control, watchdog, and supervisor.
- Verify cooperative cancellation releases permits and scratch memory without replacing the worker.
- Verify an uninterruptible backend is terminated by the real watchdog with the reserved restart exit code, then replaced by the supervisor. A generic crash cannot satisfy the test.
- Verify subsequent embedding requests execute successfully and all request, weighted, and scratch accounting returns to baseline.
- Wire the suite into the default unfiltered inference test aggregate on native Linux/macOS, with a focused inference-test-cancellation-e2e root target.

Only the model session is synthetic. The fixture is test-only, is not installed, and needs no GPU, downloaded model, or third-party Python packages. No production server behavior changes.

## Transport contract and scope
The client aborts using TCP RST. Orderly FIN is deliberately not treated as HTTP/1 cancellation because the client may still be waiting for its response. This suite covers transport-abort propagation during model execution, not real GPU drivers, cold model loading, HTTP/2 resets, or application-deadline wiring.

## Validation
- Full inference package test aggregate: passed; 3,394 library tests passed, 22 skipped; 13 CLI tests passed; new E2E pair passed.
- New E2E pair repeated five times: 10/10 passed.
- Root build help confirms the delegated target.
- Zig formatting, Black, Ruff, and git diff checks passed.
- Self-reviewed before pushing; current origin/main is included.

Local validation was on macOS arm64; Linux execution is covered by the existing CI inference aggregate.