### PR TITLE
preserve BGE-M3 enrichment batching and benchmark timing

### DIFF
--- a/zig/pkg/antfly/src/storage/db/enrichment/asset_producer.zig
+++ b/zig/pkg/antfly/src/storage/db/enrichment/asset_producer.zig
@@ -158,6 +158,11 @@ pub const Producer = struct {
         try context.check();
         const out = if (self.vtable.produce_batch_with_context) |produce_batch|
             try produce_batch(self.ptr, alloc, requests, context)
+        else if (self.vtable.produce_batch) |produce_batch|
+            // Preserve the native-batch contract advertised by canProduceBatch.
+            // Legacy callbacks cannot observe the context internally, but
+            // remain fenced by the checks before and after this call.
+            try produce_batch(self.ptr, alloc, requests)
         else blk: {
             const items = try alloc.alloc([]u8, requests.len);
             errdefer {
@@ -258,4 +263,65 @@ test "asset producer forwards request context to cancellable implementations" {
     defer std.testing.allocator.free(output);
     try std.testing.expectEqualStrings("controlled", output);
     try std.testing.expectEqual(@as(usize, 1), probe.context_calls);
+}
+
+test "asset producer preserves legacy native batch under request context" {
+    const Probe = struct {
+        batch_calls: usize = 0,
+        cancel_after_batch: ?*std.atomic.Value(bool) = null,
+
+        fn single(_: *anyopaque, _: Allocator, _: Request) anyerror![]u8 {
+            return error.SingleCallbackInvoked;
+        }
+
+        fn batch(raw: *anyopaque, alloc: Allocator, requests: []const Request) anyerror![][]u8 {
+            const self: *@This() = @ptrCast(@alignCast(raw));
+            self.batch_calls += 1;
+            const out = try alloc.alloc([]u8, requests.len);
+            for (out) |*item| item.* = "";
+            errdefer {
+                for (out) |item| if (item.len > 0) alloc.free(item);
+                alloc.free(out);
+            }
+            for (out, requests) |*item, request| item.* = try alloc.dupe(u8, request.source_text);
+            if (self.cancel_after_batch) |cancelled| cancelled.store(true, .release);
+            return out;
+        }
+    };
+
+    const requests = [_]Request{
+        .{ .producer_type = .copy, .config_json = "", .source_text = "one" },
+        .{ .producer_type = .copy, .config_json = "", .source_text = "two" },
+    };
+    var probe = Probe{};
+    const producer = Producer{
+        .ptr = &probe,
+        .vtable = &.{ .produce = Probe.single, .produce_batch = Probe.batch },
+    };
+    try std.testing.expect(try producer.canProduceBatch(std.testing.allocator, &requests));
+    const output = try producer.produceBatchWithContext(
+        std.testing.allocator,
+        &requests,
+        .{ .io = std.testing.io, .deadline_ns = null },
+    );
+    defer {
+        for (output) |item| std.testing.allocator.free(item);
+        std.testing.allocator.free(output);
+    }
+    try std.testing.expectEqual(@as(usize, 1), probe.batch_calls);
+    try std.testing.expectEqualStrings("one", output[0]);
+    try std.testing.expectEqualStrings("two", output[1]);
+
+    var cancelled = std.atomic.Value(bool).init(false);
+    probe.cancel_after_batch = &cancelled;
+    try std.testing.expectError(error.Cancelled, producer.produceBatchWithContext(
+        std.testing.allocator,
+        &requests,
+        .{
+            .io = std.testing.io,
+            .deadline_ns = null,
+            .cancellation = @import("../../../common/cancellation.zig").CancellationToken.fromAtomic(&cancelled),
+        },
+    ));
+    try std.testing.expectEqual(@as(usize, 2), probe.batch_calls);
 }

--- a/zig/pkg/inference/build.zig
+++ b/zig/pkg/inference/build.zig
@@ -1683,6 +1683,16 @@ pub fn build(b: *std.Build) void {
     cli_tests.root_module.addImport("antfly_platform", platform_mod);
     cli_tests.root_module.link_libc = link_libc;
 
+    const bge_m3_e2e_bench_tests = b.addTest(.{
+        .root_module = bge_m3_e2e_bench_exe.root_module,
+    });
+    const run_bge_m3_e2e_bench_tests = b.addRunArtifact(bge_m3_e2e_bench_tests);
+    const bge_m3_e2e_bench_test_step = b.step(
+        "test-bge-m3-e2e-benchmark",
+        "Run BGE-M3 benchmark contract tests",
+    );
+    bge_m3_e2e_bench_test_step.dependOn(&run_bge_m3_e2e_bench_tests.step);
+
     const run_cli_tests = b.addRunArtifact(cli_tests);
     for (selected_test_filters) |filter| {
         run_cli_tests.addArgs(&.{ "--test-filter", filter });
@@ -1766,9 +1776,10 @@ pub fn build(b: *std.Build) void {
     test_step.dependOn(&run_quant_kernel_metal_runtime_check_tests.step);
     test_step.dependOn(&run_tests.step);
     // A focused server/library filter need not match an executable-root test.
-    // The default aggregate still owns the complete CLI suite.
+    // The default aggregate still owns the complete executable-root suites.
     if (selected_test_filters.len == 0) {
         test_step.dependOn(&run_cli_tests.step);
+        test_step.dependOn(&run_bge_m3_e2e_bench_tests.step);
     }
     const install_tests = b.addInstallArtifact(tests, .{
         .dest_sub_path = "antfly-inference-tests",

--- a/zig/pkg/inference/src/bench/bge_m3_e2e.zig
+++ b/zig/pkg/inference/src/bench/bge_m3_e2e.zig
@@ -94,18 +94,41 @@ const PhaseCapture = struct {
     tokenizing_ns: u64 = 0,
     preparing_ns: u64 = 0,
     executing_ns: u64 = 0,
+    serializing_ns: u64 = 0,
+    active_phase: ?inference.execution_control.Phase = null,
+    last_transition_ns: u64 = 0,
+
+    fn begin(self: *@This(), started_ns: u64) void {
+        self.active_phase = .loading_model;
+        self.last_transition_ns = started_ns;
+    }
+
+    fn account(self: *@This(), phase: inference.execution_control.Phase, elapsed_ns: u64) void {
+        const slot = switch (phase) {
+            .queued, .loading_model, .loading_weights => &self.loading_ns,
+            .preparing_weights => &self.preparing_ns,
+            .tokenizing => &self.tokenizing_ns,
+            .executing => &self.executing_ns,
+            .serializing, .publishing => &self.serializing_ns,
+        };
+        slot.* +|= elapsed_ns;
+    }
+
+    fn transition(self: *@This(), next_phase: inference.execution_control.Phase, now_ns: u64) void {
+        if (self.active_phase) |phase| self.account(phase, now_ns -| self.last_transition_ns);
+        self.active_phase = next_phase;
+        self.last_transition_ns = now_ns;
+    }
 
     fn update(raw: ?*anyopaque, progress: inference.execution_control.Progress) void {
         const self: *@This() = @ptrCast(@alignCast(raw.?));
-        const now = nowNs();
-        const slot = switch (progress.phase) {
-            .loading_model => &self.loading_ns,
-            .tokenizing => &self.tokenizing_ns,
-            .preparing_weights => &self.preparing_ns,
-            .executing => &self.executing_ns,
-            else => return,
-        };
-        if (slot.* == 0) slot.* = now;
+        self.transition(progress.phase, nowNs());
+    }
+
+    fn finish(self: *@This(), finished_ns: u64) void {
+        if (self.active_phase) |phase| self.account(phase, finished_ns -| self.last_transition_ns);
+        self.active_phase = null;
+        self.last_transition_ns = finished_ns;
     }
 };
 
@@ -168,6 +191,7 @@ pub fn main(init: std.process.Init) !void {
         .progress = .{ .ptr = &cold_capture, .update_fn = PhaseCapture.update },
     };
     const load_started_ns = nowNs();
+    cold_capture.begin(load_started_ns);
     const managed_text = try managedBenchmarkText(allocator, fixture.source_text);
     defer allocator.free(managed_text);
     const managed_texts = try allocator.alloc([]const u8, opts.batch);
@@ -183,6 +207,7 @@ pub fn main(init: std.process.Init) !void {
         return err;
     };
     const cold_forward_done_ns = nowNs();
+    cold_capture.finish(cold_forward_done_ns);
     const cold_json = try std.json.Stringify.valueAlloc(allocator, cold_embeddings, .{});
     const cold_done_ns = nowNs();
     allocator.free(cold_json);
@@ -193,6 +218,7 @@ pub fn main(init: std.process.Init) !void {
     var warm_capture = PhaseCapture{};
     const warm_control = inference.InferenceExecutionControl{ .progress = .{ .ptr = &warm_capture, .update_fn = PhaseCapture.update } };
     const warm_started_ns = nowNs();
+    warm_capture.begin(warm_started_ns);
     const warm_embeddings = try node.embedDenseTextsFromPathWithExecutionControl(
         allocator,
         warm_control,
@@ -200,6 +226,7 @@ pub fn main(init: std.process.Init) !void {
         managed_texts,
     );
     const warm_forward_done_ns = nowNs();
+    warm_capture.finish(warm_forward_done_ns);
     const warm_json = try std.json.Stringify.valueAlloc(allocator, warm_embeddings, .{});
     const warm_done_ns = nowNs();
     allocator.free(warm_json);
@@ -441,31 +468,33 @@ fn managedBenchmarkText(allocator: std.mem.Allocator, source: []const u8) ![]u8 
 }
 
 fn managedTiming(capture: PhaseCapture, started: u64, forward_done: u64, done: u64) ManagedTiming {
-    const tokenizing = if (capture.tokenizing_ns != 0) capture.tokenizing_ns else forward_done;
-    const preparing = if (capture.preparing_ns != 0) capture.preparing_ns else tokenizing;
-    const executing = if (capture.executing_ns != 0) capture.executing_ns else preparing;
     return .{
         .total_ns = done -| started,
-        .model_load_ns = tokenizing -| started,
-        .tokenization_ns = preparing -| tokenizing,
-        .weight_prep_ns = executing -| preparing,
-        .forward_ns = forward_done -| executing,
-        .serialization_ns = done -| forward_done,
+        .model_load_ns = capture.loading_ns,
+        .tokenization_ns = capture.tokenizing_ns,
+        .weight_prep_ns = capture.preparing_ns,
+        .forward_ns = capture.executing_ns,
+        .serialization_ns = capture.serializing_ns +| (done -| forward_done),
     };
 }
 
 fn validateManagedTiming(timing: ManagedTiming) !void {
     const attributed = timing.model_load_ns +| timing.tokenization_ns +| timing.weight_prep_ns +| timing.forward_ns +| timing.serialization_ns;
-    if (attributed > timing.total_ns) return error.InvalidPhaseTiming;
+    if (attributed != timing.total_ns) return error.InvalidPhaseTiming;
 }
 
-test "managed BGE timing partitions ordered request phases" {
-    const timing = managedTiming(.{
-        .loading_ns = 10,
-        .tokenizing_ns = 30,
-        .preparing_ns = 50,
-        .executing_ns = 80,
-    }, 10, 130, 150);
+test "managed BGE timing accumulates repeated and reordered request phases" {
+    var capture = PhaseCapture{};
+    capture.begin(10);
+    capture.transition(.preparing_weights, 30);
+    capture.transition(.tokenizing, 50);
+    capture.transition(.preparing_weights, 60);
+    capture.transition(.tokenizing, 70);
+    capture.transition(.executing, 80);
+    capture.transition(.serializing, 130);
+    capture.finish(140);
+
+    const timing = managedTiming(capture, 10, 140, 150);
     try std.testing.expectEqual(@as(u64, 20), timing.model_load_ns);
     try std.testing.expectEqual(@as(u64, 20), timing.tokenization_ns);
     try std.testing.expectEqual(@as(u64, 30), timing.weight_prep_ns);
@@ -475,11 +504,19 @@ test "managed BGE timing partitions ordered request phases" {
     try validateManagedTiming(timing);
 }
 
-test "managed BGE timing rejects overlapping phase attribution" {
+test "managed BGE timing rejects incomplete or overlapping phase attribution" {
     try std.testing.expectError(error.InvalidPhaseTiming, validateManagedTiming(.{
         .total_ns = 10,
         .model_load_ns = 10,
         .tokenization_ns = 10,
+        .weight_prep_ns = 0,
+        .forward_ns = 0,
+        .serialization_ns = 0,
+    }));
+    try std.testing.expectError(error.InvalidPhaseTiming, validateManagedTiming(.{
+        .total_ns = 10,
+        .model_load_ns = 5,
+        .tokenization_ns = 0,
         .weight_prep_ns = 0,
         .forward_ns = 0,
         .serialization_ns = 0,


### PR DESCRIPTION
## Summary

This change preserves native asset-producer batching under request execution control and makes the BGE-M3 benchmark's phase measurements accurate and testable.

## Changes

- Preserve a declared legacy native batch callback when a request context is present, instead of silently degrading to per-item execution.
- Keep cancellation and deadline checks before and after legacy batch execution, and release returned outputs if the request is cancelled after the callback.
- Replace BGE-M3's first-timestamp phase calculation with interval-based accounting that supports repeated or reordered progress phases without overlap.
- Require measured phase durations to reconcile exactly with total managed-request time.
- Add a focused BGE-M3 benchmark contract-test target and include it in the unfiltered inference test aggregate.

## Validation

- `zig fmt --check`: passed.
- Diff/whitespace validation: passed.
- Asset-producer focused suite: 10/10 passed with no leaks.
- Asset-producer x86_64 Linux compile check: passed.
- BGE-M3 benchmark contract tests: passed.
- ReleaseFast Metal benchmark entry-point smoke test: passed.

## Real-model smoke metrics

BGE-M3 F32 on Metal, single-sample validation of the equivalent pre-rebase patch:

- Managed warm request, batch 1 / 195 tokens: **223.2 ms**
- Direct request, batch 1 / 16 tokens: **33.9 ms**
- Direct GPU frame: **13.8 ms**
- Measured swap growth: **0 bytes**

