### PR TITLE
Fix Metal inference and remove model qualification allowlists

### DIFF
--- a/zig/pkg/antfly/src/inference_runtime/runtime.zig
+++ b/zig/pkg/antfly/src/inference_runtime/runtime.zig
@@ -99,7 +99,7 @@ pub const SpawnedServer = struct {
 const EmbeddedServerConfig = struct {
     api_url: []const u8,
     models_dir: ?[]const u8 = null,
-    allow_unknown_models: bool = false,
+    allow_unknown_models: bool = true,
     ml_dir: ?[]const u8 = null,
     content_security: ?common_config.Config.ContentSecurityConfig = null,
     s3_credentials: ?common_config.Config.S3CredentialsConfig = null,
@@ -321,7 +321,7 @@ fn runServer(alloc: std.mem.Allocator, io: std.Io, args: *std.process.Args.Itera
     var kernel_jit_max_cache_bytes_mb_override: ?usize = null;
     var kernel_jit_preload_budget_ms_override: ?u64 = null;
     var allow_insecure_public_bind = false;
-    var allow_unknown_models = false;
+    var allow_unknown_models = true;
     var preload_models = std.ArrayListUnmanaged(inference.server.WarmModel).empty;
     defer preload_models.deinit(alloc);
 
@@ -877,7 +877,7 @@ fn printUsage() void {
         \\  --kernel-jit-max-cache-mb <n> Persistent JIT cache limit; 0 disables persistence
         \\  --kernel-jit-preload-budget-ms <n> Per-session best-effort startup JIT budget
         \\  --preload-model <kind:name|kind:backend:name>  Preload and warm a configured model before serving
-        \\  --allow-unknown-models  Permit artifacts whose compatibility cannot be proven; known incompatible models remain blocked
+        \\  --allow-unknown-models  Accepted for compatibility; unknown architectures are attempted by default
         \\
         \\Pull options:
         \\  --token <token>  HuggingFace API token (or set HF_TOKEN env var)

--- a/zig/pkg/antfly/src/runtime_error_abi.zig
+++ b/zig/pkg/antfly/src/runtime_error_abi.zig
@@ -346,6 +346,7 @@ pub const Detail = enum(c_int) {
     unsupported_generator_provider,
     generate_request_failed,
     generation_rate_limit,
+    unsupported_tensor_type,
 };
 
 pub const Status = extern struct {
@@ -442,6 +443,7 @@ pub fn statusFromError(err: anyerror) Status {
         error.MethodNotAllowed => status(.unsupported, .method_not_allowed),
         error.Unsupported => status(.unsupported, .unsupported),
         error.UnsupportedOperation => status(.unsupported, .unsupported_operation),
+        error.UnsupportedTensorType => status(.unsupported, .unsupported_tensor_type),
         error.UnsupportedTransformOperation => status(.invalid_argument, .unsupported_transform_operation),
         error.InvalidGraphEdges => status(.invalid_argument, .invalid_graph_edges),
         error.InvalidTableIndexMetadata => status(.invalid_argument, .invalid_table_index_metadata),
@@ -777,6 +779,7 @@ fn detailErrorName(comptime detail: Detail) []const u8 {
         .method_not_allowed => "MethodNotAllowed",
         .unsupported => "Unsupported",
         .unsupported_operation => "UnsupportedOperation",
+        .unsupported_tensor_type => "UnsupportedTensorType",
         .unsupported_query_request => "UnsupportedQueryRequest",
         .unsupported_filter_query_request => "UnsupportedFilterQueryRequest",
         .unsupported_exclusion_query_request => "UnsupportedExclusionQueryRequest",

--- a/zig/pkg/inference/MODEL_COMPATIBILITY.md
+++ b/zig/pkg/inference/MODEL_COMPATIBILITY.md
@@ -1,0 +1,32 @@
+# Model loading and download integrity
+
+Antfly is a generic inference engine. Pull models using Hugging Face repository
+references, with an optional format, quantization, or revision:
+
+```sh
+antfly inference pull Qwen/Qwen3-Embedding-0.6B-GGUF
+antfly inference pull Qwen/Qwen3-Embedding-0.6B:safetensors
+```
+
+Pull does not accept short model aliases. Explicit pinned bundle variants remain
+available for reproducing qualification runs, but they are not required to serve
+a model. Local chat shortcuts are separate from the pull interface.
+
+Serving checks the selected artifact route: required files and tensors, tensor
+formats, graph validity, model role, and backend support. An unrecognized
+architecture is attempted by default; the loader reports unsupported operations
+or architectures when it cannot construct a session. Known invalid or unsafe
+runtime paths remain rejected. Qualification catalogs and exact model receipts
+are not serving allowlists.
+
+Managed download receipts record which files belong to a completed transaction.
+They prevent partially downloaded or mixed bundles from being published as
+ready. Expected hashes detect corruption or substitution relative to a trusted
+reference; immutable revisions also make debugging and benchmarks reproducible.
+A receipt is neither a model certification nor proof of numerical quality,
+performance, or compatibility with every backend. Local, unmanaged models can
+be loaded without a receipt and undergo the same artifact checks.
+
+Qualification reports describe evidence for particular artifacts, hardware,
+and runtime versions. They do not prevent other models or quantizations from
+using an implemented runtime.

--- a/zig/pkg/inference/QWEN3VL_SUPPORT.md
+++ b/zig/pkg/inference/QWEN3VL_SUPPORT.md
@@ -1,37 +1,29 @@
 # Qwen3-VL inference support
 
-This document is the operational contract for Qwen3-VL generation and
-Qwen3-VL-Reranker inference in Antfly. The implementation is deliberately
-fail-closed: code and artifact recognition may land before a model/backend
-pair is enabled, but an unqualified bundle cannot be made runnable with
-`--allow-unknown-models`.
+This document records Qwen3-VL generation and reranking qualification evidence.
+The historical promotion restrictions below describe the releases in which the
+reports were collected; they are not the current serving admission policy.
 
-The production promotion is intentionally narrow. Only these managed receipt
-identities are runnable, and only through Metal:
+Current admission validates the selected artifact, tensors, serving role, and
+backend. A catalog entry or exact qualification receipt is not required. The
+split decoder/projector runtime currently requires Metal; integrated safetensors
+generation also supports CUDA. See [model compatibility](MODEL_COMPATIBILITY.md).
 
-| Serving role | Exact managed source | Quantization | Status |
-| --- | --- | --- | --- |
-| Generation | `Qwen/Qwen3-VL-2B-Instruct-GGUF:q4-k-m-bundle-v1` | Q4_K_M decoder + Q8_0 projector | Promoted |
-| Reranking | `Qwen/Qwen3-VL-Reranker-2B-GGUF:q8-0-q8-0-bundle-v1` | Q8_0 decoder + Q8_0 projector + F16 score head | Promoted |
-
-The 4B and 8B generation bundles, BF16 reranker oracle, Q4 reranker, other
-quantizations, unmanaged copies, changed receipts, and non-Metal backends
-remain blocked. This is an exact-artifact promotion, not family-wide enablement.
+## Historical qualification evidence
 
 ## Pinned artifacts
 
-`antfly inference pull` recognizes the following source aliases. Each alias
+Explicit pinned bundle references select the following fixtures. Each reference
 resolves to immutable Hub revisions, verifies exact sizes and SHA-256 digests,
 stages the complete bundle beside the live model directory, and publishes it
-with a single managed receipt only after every artifact is valid. A pull alias
-is not, by itself, a serving promotion.
+with a single managed receipt only after every artifact is valid. A pinned pull is not, by itself, evidence of runtime qualification.
 
-| Alias | Decoder or model | Vision projector | Approximate installed size |
+| Reference | Decoder or model | Vision projector | Approximate installed size |
 | --- | --- | --- | ---: |
-| `qwen3-vl-2b` | Official `Qwen3VL-2B-Instruct-Q4_K_M.gguf` | Official Q8_0 mmproj | 1.46 GiB |
-| `qwen3-vl-4b` | Official `Qwen3VL-4B-Instruct-Q4_K_M.gguf` | Official Q8_0 mmproj | 2.76 GiB |
-| `qwen3-vl-8b` | Official `Qwen3VL-8B-Instruct-Q4_K_M.gguf` | Official Q8_0 mmproj | 5.39 GiB |
-| `qwen3-vl-reranker-2b` | Official BF16 `model.safetensors` conversion/parity oracle; not serveable | Embedded in the checkpoint | 3.97 GiB |
+| `Qwen/Qwen3-VL-2B-Instruct-GGUF:q4-k-m-bundle-v1` | Official `Qwen3VL-2B-Instruct-Q4_K_M.gguf` | Official Q8_0 mmproj | 1.46 GiB |
+| `Qwen/Qwen3-VL-4B-Instruct-GGUF:q4-k-m-bundle-v1` | Official `Qwen3VL-4B-Instruct-Q4_K_M.gguf` | Official Q8_0 mmproj | 2.76 GiB |
+| `Qwen/Qwen3-VL-8B-Instruct-GGUF:q4-k-m-bundle-v1` | Official `Qwen3VL-8B-Instruct-Q4_K_M.gguf` | Official Q8_0 mmproj | 5.39 GiB |
+| `Qwen/Qwen3-VL-Reranker-2B:bf16-safetensors-bundle-v1` | Official BF16 `model.safetensors` conversion/parity oracle; not serveable | Embedded in the checkpoint | 3.97 GiB |
 
 The reranker serving artifact is produced from that pinned BF16 source with
 `convert_qwen3vl_reranker.py`: Q8_0 decoder, Q8_0 projector, and an F16
@@ -62,8 +54,8 @@ unpinned community conversion.
 Examples:
 
 ```sh
-antfly inference pull qwen3-vl-2b
-antfly inference pull qwen3-vl-reranker-2b  # BF16 conversion/parity oracle
+antfly inference pull Qwen/Qwen3-VL-2B-Instruct-GGUF:q4-k-m-bundle-v1
+antfly inference pull Qwen/Qwen3-VL-Reranker-2B:bf16-safetensors-bundle-v1  # BF16 conversion/parity oracle
 ```
 
 The source catalog, including revisions, exact filenames, sizes, and SHA-256

--- a/zig/pkg/inference/scripts/qwen3_embedding/README.md
+++ b/zig/pkg/inference/scripts/qwen3_embedding/README.md
@@ -65,10 +65,11 @@ antfly inference pull hf:Qwen/Qwen3-Embedding-0.6B-GGUF:f16-bundle-v1   # GGUF F
 antfly inference pull hf:Qwen/Qwen3-Embedding-0.6B:bf16-safetensors-bundle-v1  # safetensors
 ```
 
-The Q8_0 bundle is qualified on Metal, CUDA, and native CPU. The F16 GGUF is
-admitted on Metal, while the BF16 safetensors bundle is admitted on Metal and
-CUDA; each variant still requires its exact managed receipt and live artifact
-hashes.
+These pinned references reproduce the qualification fixtures. Normal pulls can
+use `Qwen/Qwen3-Embedding-0.6B-GGUF` or
+`Qwen/Qwen3-Embedding-0.6B:safetensors`. Serving validates the artifact and
+backend contract, without requiring a catalog identity or qualification receipt.
+See [model compatibility](../../MODEL_COMPATIBILITY.md).
 
 Then run the gate against the running server:
 

--- a/zig/pkg/inference/src/hard_cancellation_watchdog.zig
+++ b/zig/pkg/inference/src/hard_cancellation_watchdog.zig
@@ -1,0 +1,126 @@
+// Copyright 2026 Antfly, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const std = @import("std");
+const platform = @import("antfly_platform");
+const execution_control_mod = @import("execution_control.zig");
+fn spinLock(mutex: *std.atomic.Mutex) void {
+    while (!mutex.tryLock()) std.atomic.spinLoopHint();
+}
+
+/// Watches only calls which declared that cooperative or native termination is
+/// insufficient. Expiry is process-fatal by design: the supervisor owns the
+/// replacement generation, while continuing in this address space could reuse
+/// buffers still retained by a wedged driver.
+pub const HardCancellationWatchdog = struct {
+    const Entry = struct {
+        token: u64,
+        control: execution_control_mod.MonitorControl,
+    };
+
+    allocator: std.mem.Allocator,
+    mutex: std.atomic.Mutex = .unlocked,
+    entries: std.ArrayListUnmanaged(Entry) = .empty,
+    next_token: u64 = 1,
+    stopping: std.atomic.Value(bool) = .init(false),
+    io: ?std.Io = null,
+    group: std.Io.Group = .init,
+
+    pub fn create(allocator: std.mem.Allocator) !*HardCancellationWatchdog {
+        const self = try allocator.create(HardCancellationWatchdog);
+        errdefer allocator.destroy(self);
+        self.* = .{ .allocator = allocator };
+        return self;
+    }
+
+    pub fn start(self: *HardCancellationWatchdog, io: std.Io) !void {
+        if (self.io != null) return;
+        self.io = io;
+        errdefer self.io = null;
+        try self.group.concurrent(io, run, .{ self, io });
+    }
+
+    pub fn destroy(self: *HardCancellationWatchdog) void {
+        self.stopping.store(true, .release);
+        if (self.io) |io| {
+            self.group.cancel(io);
+            self.group.await(io) catch {};
+        }
+        spinLock(&self.mutex);
+        std.debug.assert(self.entries.items.len == 0);
+        self.entries.deinit(self.allocator);
+        self.mutex.unlock();
+        const allocator = self.allocator;
+        self.* = undefined;
+        allocator.destroy(self);
+    }
+
+    pub fn boundary(self: *HardCancellationWatchdog) execution_control_mod.HardCancellationBoundary {
+        return .{
+            .ptr = self,
+            .arm_fn = armOpaque,
+            .disarm_fn = disarmOpaque,
+        };
+    }
+
+    fn armOpaque(raw: *anyopaque, control: execution_control_mod.MonitorControl) !u64 {
+        const self: *HardCancellationWatchdog = @ptrCast(@alignCast(raw));
+        try control.check();
+        spinLock(&self.mutex);
+        defer self.mutex.unlock();
+        if (self.stopping.load(.acquire)) return error.InferenceWorkerShuttingDown;
+        if (self.io == null) return error.HardCancellationWatchdogNotStarted;
+        const token = self.next_token;
+        self.next_token +%= 1;
+        if (self.next_token == 0) self.next_token = 1;
+        try self.entries.append(self.allocator, .{ .token = token, .control = control });
+        return token;
+    }
+
+    fn disarmOpaque(raw: *anyopaque, token: u64) void {
+        const self: *HardCancellationWatchdog = @ptrCast(@alignCast(raw));
+        spinLock(&self.mutex);
+        defer self.mutex.unlock();
+        for (self.entries.items, 0..) |entry, index| {
+            if (entry.token != token) continue;
+            _ = self.entries.swapRemove(index);
+            return;
+        }
+        // A missing token is an ownership violation. Do not silently leave a
+        // borrowed request pointer in the monitor.
+        @panic("hard cancellation watchdog token was not armed");
+    }
+
+    fn run(self: *HardCancellationWatchdog, io: std.Io) std.Io.Cancelable!void {
+        while (!self.stopping.load(.acquire)) {
+            var fatal: ?anyerror = null;
+            spinLock(&self.mutex);
+            for (self.entries.items) |entry| {
+                entry.control.check() catch |err| {
+                    fatal = err;
+                    break;
+                };
+            }
+            self.mutex.unlock();
+            if (fatal) |err| {
+                std.log.err(
+                    "uninterruptible inference request expired; terminating supervised worker err={s}",
+                    .{@errorName(err)},
+                );
+                platform.inference_process_supervisor.restartWorker();
+            }
+            try io.sleep(std.Io.Duration.fromMilliseconds(10), .awake);
+        }
+    }
+};

--- a/zig/pkg/inference/src/main.zig
+++ b/zig/pkg/inference/src/main.zig
@@ -388,7 +388,7 @@ const run_usage_options =
     \\  --kernel-jit-mode <mode>             off, shadow, on, or required
     \\  --preload-model <spec>               Warm a model at startup; repeatable
     \\  --allow-insecure-public-bind         Permit a non-loopback listener without built-in auth/TLS
-    \\  --allow-unknown-models               Allow models absent from the registry
+    \\  --allow-unknown-models               Accepted for compatibility; unknown architectures are attempted by default
     \\  -h, --help                           Show this help and exit
     \\
 ;
@@ -466,7 +466,7 @@ fn runServer(allocator: std.mem.Allocator, io: std.Io, args: []const []const u8)
     var budget_overrides_mib = inference.runtime.tier.memory.BudgetOverridesMib{};
     var kernel_jit_mode_override: ?inference.graph.kernel_jit.Mode = null;
     var allow_insecure_public_bind = false;
-    var allow_unknown_models = false;
+    var allow_unknown_models = true;
     var models_overridden = false;
     var ml_overridden = false;
     var preload_models = std.ArrayListUnmanaged(inference.server.WarmModel).empty;
@@ -824,7 +824,7 @@ fn printUsage(usage_name: []const u8) void {
         \\  --scratch-budget-mb <n> Process-wide inference scratch-memory admission override (MiB)
         \\  --kernel-jit-mode <off|shadow|on|required> JIT startup-preloaded Metal/CUDA models
         \\  --preload-model <kind:name|kind:backend:name> Preload and warm a configured model before serving
-        \\  --allow-unknown-models Permit artifacts whose compatibility cannot be proven; known incompatible models remain blocked
+        \\  --allow-unknown-models Accepted for compatibility; unknown architectures are attempted by default
         \\
         \\Pull options:
         \\  --token <token>   HuggingFace API token (or set HF_TOKEN env var)

--- a/zig/pkg/inference/src/models/compatibility.zig
+++ b/zig/pkg/inference/src/models/compatibility.zig
@@ -16,17 +16,14 @@
 //!
 //! This is intentionally not an artifact certification system. Compatibility is derived
 //! from the artifact contract and the runtime paths compiled into this build. Unknown
-//! contracts require an explicit server opt-in. Known unsafe or invalid contracts remain
-//! blocked even when that opt-in is set.
+//! contracts are attempted by default. Known unsafe or invalid contracts remain
+//! blocked; repository names, published receipts, and qualification lists are not admission policy.
 
 const std = @import("std");
 const manifest_mod = @import("manifest.zig");
 const c_file = @import("../util/c_file.zig");
 const gguf_format = @import("../gguf/format.zig");
 const gguf_writer = @import("../gguf/writer.zig");
-const managed_receipt = @import("../registry/managed_receipt.zig");
-const qwen3vl_catalog = @import("../registry/qwen3vl_catalog.zig");
-const qwen3_embedding_catalog = @import("../registry/qwen3_embedding_catalog.zig");
 
 pub const Level = enum {
     compatible,
@@ -62,28 +59,13 @@ pub const Assessment = struct {
 };
 
 pub const Policy = struct {
-    allow_unknown: bool = false,
-};
-
-pub const Qwen3VlPromotion = enum {
-    none,
-    generation_2b_q4_k_m,
-    reranker_2b_q8_0,
-};
-
-pub const Qwen3EmbeddingPromotion = enum {
-    none,
-    q8_0,
-    f16,
-    bf16_safetensors,
+    allow_unknown: bool = true,
 };
 
 pub const Inspection = struct {
     architecture: []u8,
     expert_count: u32 = 0,
     qualified_gemma4_a4b: bool = false,
-    qwen3vl_promotion: Qwen3VlPromotion = .none,
-    qwen3_embedding_promotion: Qwen3EmbeddingPromotion = .none,
     artifact_inspected: bool = true,
 
     pub fn deinit(self: *Inspection, allocator: std.mem.Allocator) void {
@@ -104,16 +86,7 @@ pub fn inspectAlloc(
     };
     errdefer result.deinit(allocator);
 
-    if (!man.usesGgufWeights()) {
-        result.qwen3_embedding_promotion = inspectQwen3EmbeddingSafetensorsPromotion(
-            allocator,
-            man,
-        ) catch |err| switch (err) {
-            error.OutOfMemory => return err,
-            else => .none,
-        };
-        return result;
-    }
+    if (!man.usesGgufWeights()) return result;
     const gguf_path = man.gguf_path.?;
     result.artifact_inspected = false;
     var region = c_file.MmapRegion.init(allocator, gguf_path) catch
@@ -124,352 +97,8 @@ pub fn inspectAlloc(
     region.preserveFileCacheOnDeinit();
     const metadata = gguf_format.readSupportMetadata(region.data) catch return result;
     result.artifact_inspected = true;
-    result.qwen3vl_promotion = inspectQwen3VlPromotion(
-        allocator,
-        man,
-        metadata,
-    ) catch |err| switch (err) {
-        error.OutOfMemory => return err,
-        else => .none,
-    };
-    result.qwen3_embedding_promotion = inspectQwen3EmbeddingPromotion(
-        allocator,
-        man,
-        metadata,
-    ) catch |err| switch (err) {
-        error.OutOfMemory => return err,
-        else => .none,
-    };
     try applyArtifactMetadata(allocator, &result, metadata);
     return result;
-}
-
-fn qwen3VlGeometryIsQualified(metadata: gguf_format.SupportMetadata) bool {
-    const architecture = metadata.architecture orelse return false;
-    return (std.mem.eql(u8, architecture, "qwen3vl") or
-        std.mem.eql(u8, architecture, "qwen3_vl")) and
-        metadata.block_count == 28 and
-        metadata.embedding_length == 2048 and
-        metadata.expert_count == 0;
-}
-
-fn receiptSourceMatches(
-    receipt: managed_receipt.DownloadReceipt,
-    owner: []const u8,
-    name: []const u8,
-    variant: []const u8,
-) bool {
-    const source = receipt.source orelse return false;
-    return std.mem.eql(u8, source.owner, owner) and
-        std.mem.eql(u8, source.name, name) and
-        std.mem.eql(u8, source.variant, variant);
-}
-
-fn receiptArtifactMatches(
-    receipt: managed_receipt.DownloadReceipt,
-    path: []const u8,
-    size: u64,
-    expected_sha256: ?[]const u8,
-) bool {
-    for (receipt.artifacts) |artifact| {
-        if (!std.mem.eql(u8, artifact.path, path)) continue;
-        if (artifact.size != size) return false;
-        if (expected_sha256) |expected| {
-            const actual = artifact.sha256 orelse return false;
-            return std.mem.eql(u8, actual, expected);
-        }
-        return artifact.sha256 == null;
-    }
-    return false;
-}
-
-fn generationReceiptMatches(
-    man: *const manifest_mod.ModelManifest,
-    receipt: managed_receipt.DownloadReceipt,
-) bool {
-    if (!std.mem.eql(u8, man.inference_bundle_family, manifest_mod.qwen3_vl_gguf_bundle_family) or
-        receipt.version != 2 or receipt.artifacts.len != 10)
-    {
-        return false;
-    }
-    const source = receipt.source orelse return false;
-    const bundle = qwen3vl_catalog.findGenerationBundleForHubRef(
-        source.owner,
-        source.name,
-        source.variant,
-    ) orelse return false;
-    if (bundle.size != .vl_2b) return false;
-    const decoder_path = man.gguf_path orelse return false;
-    const projector_path = man.gguf_projector_path orelse return false;
-    if (!std.mem.eql(u8, std.fs.path.basename(decoder_path), bundle.decoder.path) or
-        !std.mem.eql(u8, std.fs.path.basename(projector_path), bundle.projector.path))
-    {
-        return false;
-    }
-    for (bundle.artifacts()) |artifact| {
-        if (!receiptArtifactMatches(receipt, artifact.path, artifact.size, artifact.sha256))
-            return false;
-    }
-    for (qwen3vl_catalog.promoted_generation_2b_metadata_artifacts) |artifact| {
-        // These bytes are generated inside the managed pull transaction, so
-        // legacy receipts intentionally have no declared digest. The exact
-        // content gate below re-hashes them against the catalog identity.
-        if (!receiptArtifactMatches(receipt, artifact.path, artifact.size, null))
-            return false;
-    }
-    return true;
-}
-
-fn rerankerReceiptMatches(
-    man: *const manifest_mod.ModelManifest,
-    receipt: managed_receipt.DownloadReceipt,
-) bool {
-    if (!man.isQwen3VlRerankerGgufBundle() or
-        receipt.version != 2 or
-        receipt.artifacts.len != qwen3vl_catalog.promoted_reranker_artifacts.len or
-        !receiptSourceMatches(
-            receipt,
-            qwen3vl_catalog.promoted_reranker_owner,
-            qwen3vl_catalog.promoted_reranker_name,
-            qwen3vl_catalog.promoted_reranker_variant,
-        ))
-    {
-        return false;
-    }
-    const decoder_path = man.gguf_path orelse return false;
-    const projector_path = man.gguf_projector_path orelse return false;
-    if (!std.mem.eql(
-        u8,
-        std.fs.path.basename(decoder_path),
-        qwen3vl_catalog.promoted_reranker_decoder.path,
-    ) or !std.mem.eql(
-        u8,
-        std.fs.path.basename(projector_path),
-        qwen3vl_catalog.promoted_reranker_projector.path,
-    )) return false;
-    for (qwen3vl_catalog.promoted_reranker_artifacts) |artifact| {
-        if (!receiptArtifactMatches(receipt, artifact.path, artifact.size, artifact.sha256))
-            return false;
-    }
-    return true;
-}
-
-fn qwen3VlPromotionFromReceipt(
-    man: *const manifest_mod.ModelManifest,
-    metadata: gguf_format.SupportMetadata,
-    receipt: managed_receipt.DownloadReceipt,
-) Qwen3VlPromotion {
-    if (!qwen3VlGeometryIsQualified(metadata)) return .none;
-    if (generationReceiptMatches(man, receipt)) return .generation_2b_q4_k_m;
-    if (rerankerReceiptMatches(man, receipt)) return .reranker_2b_q8_0;
-    return .none;
-}
-
-fn validatedArtifactContentMatches(
-    receipt: *const managed_receipt.ValidatedReceipt,
-    path: []const u8,
-    expected_sha256: []const u8,
-) bool {
-    const artifact = receipt.find(path) orelse return false;
-    managed_receipt.verifyValidatedArtifactSha256(
-        std.Options.debug_io,
-        artifact,
-        expected_sha256,
-    ) catch return false;
-    return true;
-}
-
-/// The declaration check above protects the source and receipt schema.  This
-/// separate content gate proves that every artifact selected for a promoted
-/// runtime is still the exact byte sequence that was qualified.
-fn qwen3VlPromotionContentMatches(
-    receipt: *const managed_receipt.ValidatedReceipt,
-    promotion: Qwen3VlPromotion,
-) bool {
-    switch (promotion) {
-        .none => return false,
-        .generation_2b_q4_k_m => {
-            const bundle = &qwen3vl_catalog.generation_bundles[0];
-            for (bundle.artifacts()) |artifact| {
-                if (!validatedArtifactContentMatches(receipt, artifact.path, artifact.sha256))
-                    return false;
-            }
-            for (qwen3vl_catalog.promoted_generation_2b_metadata_artifacts) |artifact| {
-                if (!validatedArtifactContentMatches(receipt, artifact.path, artifact.sha256))
-                    return false;
-            }
-            return true;
-        },
-        .reranker_2b_q8_0 => {
-            for (qwen3vl_catalog.promoted_reranker_artifacts) |artifact| {
-                if (!validatedArtifactContentMatches(receipt, artifact.path, artifact.sha256))
-                    return false;
-            }
-            return true;
-        },
-    }
-}
-
-fn inspectQwen3VlPromotion(
-    allocator: std.mem.Allocator,
-    man: *const manifest_mod.ModelManifest,
-    metadata: gguf_format.SupportMetadata,
-) !Qwen3VlPromotion {
-    if (!man.isQwen3VlGgufBundle()) return .none;
-    const gguf_path = man.gguf_path orelse return .none;
-    const model_dir = std.fs.path.dirname(gguf_path) orelse return .none;
-    var receipt = (try managed_receipt.loadValidated(
-        allocator,
-        std.Options.debug_io,
-        model_dir,
-    )) orelse return .none;
-    defer receipt.deinit();
-    const promotion = qwen3VlPromotionFromReceipt(man, metadata, receipt.parsed.value);
-    if (!qwen3VlPromotionContentMatches(&receipt, promotion)) return .none;
-    return promotion;
-}
-
-fn qwen3EmbeddingGeometryIsQualified(metadata: gguf_format.SupportMetadata) bool {
-    const architecture = metadata.architecture orelse return false;
-    return std.mem.eql(u8, architecture, "qwen3") and
-        metadata.block_count == 28 and
-        metadata.embedding_length == 1024 and
-        metadata.expert_count == 0;
-}
-
-fn qwen3EmbeddingPromotionFromReceipt(
-    man: *const manifest_mod.ModelManifest,
-    metadata: gguf_format.SupportMetadata,
-    receipt: managed_receipt.DownloadReceipt,
-) Qwen3EmbeddingPromotion {
-    if (!qwen3EmbeddingGeometryIsQualified(metadata) or
-        man.model_type != .embedder or
-        man.embedding_style != .qwen3_embedding or
-        !man.isLastTokenDecoderEmbedder() or
-        receipt.version != 2)
-    {
-        return .none;
-    }
-    const source = receipt.source orelse return .none;
-    const bundle = qwen3_embedding_catalog.findBundleForHubRef(
-        source.owner,
-        source.name,
-        source.variant,
-    ) orelse return .none;
-    if (bundle.generated_model_manifest == null or
-        receipt.artifacts.len != bundle.artifacts().len + 1)
-    {
-        return .none;
-    }
-    const gguf_path = man.gguf_path orelse return .none;
-    if (!std.mem.eql(u8, std.fs.path.basename(gguf_path), bundle.artifacts()[0].path))
-        return .none;
-    for (bundle.artifacts()) |artifact| {
-        if (!receiptArtifactMatches(receipt, artifact.path, artifact.size, artifact.sha256))
-            return .none;
-    }
-    if (!receiptArtifactMatches(
-        receipt,
-        "model_manifest.json",
-        qwen3_embedding_catalog.gguf_bundle_model_manifest.len,
-        qwen3_embedding_catalog.gguf_bundle_model_manifest_sha256,
-    )) return .none;
-    if (std.mem.eql(u8, bundle.variant, qwen3_embedding_catalog.q8_0_bundle_variant)) return .q8_0;
-    if (std.mem.eql(u8, bundle.variant, qwen3_embedding_catalog.f16_bundle_variant)) return .f16;
-    return .none;
-}
-
-fn qwen3EmbeddingPromotionContentMatches(
-    receipt: *const managed_receipt.ValidatedReceipt,
-    promotion: Qwen3EmbeddingPromotion,
-) bool {
-    const bundle = switch (promotion) {
-        .none => return false,
-        .q8_0 => &qwen3_embedding_catalog.bundles[0],
-        .f16 => &qwen3_embedding_catalog.bundles[1],
-        .bf16_safetensors => &qwen3_embedding_catalog.bundles[2],
-    };
-    for (bundle.artifacts()) |artifact| {
-        if (!validatedArtifactContentMatches(receipt, artifact.path, artifact.sha256))
-            return false;
-    }
-    return promotion == .bf16_safetensors or validatedArtifactContentMatches(
-        receipt,
-        "model_manifest.json",
-        qwen3_embedding_catalog.gguf_bundle_model_manifest_sha256,
-    );
-}
-
-fn inspectQwen3EmbeddingPromotion(
-    allocator: std.mem.Allocator,
-    man: *const manifest_mod.ModelManifest,
-    metadata: gguf_format.SupportMetadata,
-) !Qwen3EmbeddingPromotion {
-    if (man.embedding_style != .qwen3_embedding or !man.usesGgufWeights()) return .none;
-    const gguf_path = man.gguf_path orelse return .none;
-    const model_dir = std.fs.path.dirname(gguf_path) orelse return .none;
-    var receipt = (try managed_receipt.loadValidated(
-        allocator,
-        std.Options.debug_io,
-        model_dir,
-    )) orelse return .none;
-    defer receipt.deinit();
-    const promotion = qwen3EmbeddingPromotionFromReceipt(man, metadata, receipt.parsed.value);
-    if (!qwen3EmbeddingPromotionContentMatches(&receipt, promotion)) return .none;
-    return promotion;
-}
-
-fn qwen3EmbeddingSafetensorsPromotionFromReceipt(
-    man: *const manifest_mod.ModelManifest,
-    receipt: managed_receipt.DownloadReceipt,
-) Qwen3EmbeddingPromotion {
-    if (man.model_type != .embedder or
-        man.embedding_style != .qwen3_embedding or
-        man.pooling != .last or
-        !man.normalize or
-        !man.embedding_profile.isResolved() or
-        !std.mem.eql(u8, man.config_model_arch, "qwen3") or
-        man.hidden_size != 1024 or
-        man.num_hidden_layers != 28 or
-        receipt.version != 2)
-    {
-        return .none;
-    }
-    const bundle = &qwen3_embedding_catalog.bundles[2];
-    const source = receipt.source orelse return .none;
-    const receipt_bundle = qwen3_embedding_catalog.findBundleForHubRef(
-        source.owner,
-        source.name,
-        source.variant,
-    ) orelse return .none;
-    if (receipt_bundle != bundle or receipt.artifacts.len != bundle.artifacts().len) {
-        return .none;
-    }
-    const safetensors_path = man.safetensors_path orelse return .none;
-    if (!std.mem.eql(u8, std.fs.path.basename(safetensors_path), bundle.artifacts()[0].path))
-        return .none;
-    for (bundle.artifacts()) |artifact| {
-        if (!receiptArtifactMatches(receipt, artifact.path, artifact.size, artifact.sha256))
-            return .none;
-    }
-    return .bf16_safetensors;
-}
-
-fn inspectQwen3EmbeddingSafetensorsPromotion(
-    allocator: std.mem.Allocator,
-    man: *const manifest_mod.ModelManifest,
-) !Qwen3EmbeddingPromotion {
-    if (man.embedding_style != .qwen3_embedding or man.safetensors_path == null) return .none;
-    const model_dir = std.fs.path.dirname(man.safetensors_path.?) orelse return .none;
-    var receipt = (try managed_receipt.loadValidated(
-        allocator,
-        std.Options.debug_io,
-        model_dir,
-    )) orelse return .none;
-    defer receipt.deinit();
-    const promotion = qwen3EmbeddingSafetensorsPromotionFromReceipt(man, receipt.parsed.value);
-    if (!qwen3EmbeddingPromotionContentMatches(&receipt, promotion)) return .none;
-    return promotion;
 }
 
 test "compatibility inspection ignores an unselected colocated GGUF" {
@@ -520,7 +149,7 @@ pub fn assessInspection(
         return makeUnknown(
             inspection.architecture,
             .artifact_unreadable,
-            "GGUF compatibility metadata could not be inspected; start the server with --allow-unknown-models to opt in",
+            "GGUF compatibility metadata could not be inspected",
         );
     }
     return assessWithRuntimeFacts(
@@ -528,8 +157,6 @@ pub fn assessInspection(
         inspection.architecture,
         inspection.expert_count,
         inspection.qualified_gemma4_a4b,
-        inspection.qwen3vl_promotion,
-        inspection.qwen3_embedding_promotion,
     );
 }
 
@@ -538,7 +165,7 @@ fn assessWithFacts(
     architecture: []const u8,
     expert_count: u32,
 ) Assessment {
-    return assessWithRuntimeFacts(man, architecture, expert_count, false, .none, .none);
+    return assessWithRuntimeFacts(man, architecture, expert_count, false);
 }
 
 fn assessWithRuntimeFacts(
@@ -546,8 +173,6 @@ fn assessWithRuntimeFacts(
     architecture: []const u8,
     expert_count: u32,
     qualified_gemma4_a4b: bool,
-    qwen3vl_promotion: Qwen3VlPromotion,
-    qwen3_embedding_promotion: Qwen3EmbeddingPromotion,
 ) Assessment {
     if (man.hasIncompleteGlinerBundle() or
         man.hasIncompleteColqwenBundle() or
@@ -579,37 +204,13 @@ fn assessWithRuntimeFacts(
                 "Qwen3-VL BF16 safetensors bundle does not match the declared generation role",
             );
         }
-        return switch (qwen3vl_promotion) {
-            .generation_2b_q4_k_m => if (man.model_type == .generator and
-                std.mem.eql(u8, man.inference_bundle_family, manifest_mod.qwen3_vl_gguf_bundle_family))
-                makeCompatible(
-                    architecture,
-                    "qualified Qwen3-VL 2B Q4_K_M decoder and Q8_0 projector bundle",
-                )
-            else
-                makeIncompatible(
-                    architecture,
-                    .unsupported_backend,
-                    "Qwen3-VL promotion receipt does not match the declared serving role",
-                ),
-            .reranker_2b_q8_0 => if (man.model_type == .reranker and
-                man.isQwen3VlRerankerGgufBundle())
-                makeCompatible(
-                    architecture,
-                    "qualified Qwen3-VL Reranker 2B Q8_0 bundle with F16 score head",
-                )
-            else
-                makeIncompatible(
-                    architecture,
-                    .unsupported_backend,
-                    "Qwen3-VL promotion receipt does not match the declared serving role",
-                ),
-            .none => makeIncompatible(
-                architecture,
-                .unsupported_backend,
-                "Qwen3-VL requires an exact production-qualified managed receipt; unqualified sizes, quantizations, and safetensors oracle bundles remain blocked",
-            ),
-        };
+        if (stringIn(architecture, &.{ "qwen3vl", "qwen3_vl" }) and
+            ((man.model_type == .generator and std.mem.eql(u8, man.inference_bundle_family, manifest_mod.qwen3_vl_gguf_bundle_family)) or
+                (man.model_type == .reranker and man.isQwen3VlRerankerGgufBundle())))
+        {
+            return makeCompatible(architecture, "Qwen3-VL decoder/projector runtime");
+        }
+        return makeIncompatible(architecture, .unsupported_backend, "the Qwen3-VL artifact route does not implement the declared serving role");
     }
 
     if (man.model_type == .generator)
@@ -669,21 +270,12 @@ fn assessWithRuntimeFacts(
             else => {
                 // Qwen3-Embedding checkpoints resolve to the qwen3 decoder
                 // arch (unknown to the encoder list below) but serve through
-                // the qualified resident last-token embedding runtime.
+                // the resident last-token embedding runtime.
                 if (std.mem.eql(u8, architecture, "qwen3") and
                     man.embedding_style == .qwen3_embedding and
                     man.isLastTokenDecoderEmbedder())
                 {
-                    return switch (qwen3_embedding_promotion) {
-                        .q8_0 => makeCompatible(architecture, "qualified Qwen3-Embedding 0.6B Q8_0 managed bundle"),
-                        .f16 => makeCompatible(architecture, "qualified Qwen3-Embedding 0.6B F16 managed bundle"),
-                        .bf16_safetensors => makeCompatible(architecture, "qualified Qwen3-Embedding 0.6B BF16 safetensors managed bundle"),
-                        .none => makeIncompatible(
-                            architecture,
-                            .unsupported_backend,
-                            "Qwen3-Embedding requires an exact production-qualified managed receipt and live artifact hashes",
-                        ),
-                    };
+                    return makeCompatible(architecture, "Qwen3 last-token embedding runtime");
                 }
             },
         },
@@ -719,7 +311,7 @@ fn assessWithRuntimeFacts(
     return makeUnknown(
         architecture,
         .unknown_architecture,
-        "unrecognized model architecture; start the server with --allow-unknown-models to opt in",
+        "unrecognized model architecture; the selected backend will validate it at load time",
     );
 }
 
@@ -837,7 +429,7 @@ fn assessGenerator(
     return makeUnknown(
         architecture,
         .unknown_architecture,
-        "unrecognized generator architecture; start the server with --allow-unknown-models to opt in",
+        "unrecognized generator architecture; the selected backend will validate it at load time",
     );
 }
 
@@ -885,17 +477,16 @@ pub fn makeIncompatible(architecture: []const u8, code: Code, message: []const u
     return .{ .level = .incompatible, .code = code, .message = message, .architecture = architecture };
 }
 
-test "qwen3-embedding style requires an exact managed promotion" {
+test "qwen3 embedding accepts the executable contract without a catalog receipt" {
     var man = manifest_mod.ModelManifest{ .allocator = std.testing.allocator };
     man.model_type = .embedder;
     man.pooling = .last;
     man.embedding_style = .qwen3_embedding;
     const result = assess(&man, "qwen3");
-    try std.testing.expectEqual(Level.incompatible, result.level);
+    try std.testing.expectEqual(Level.compatible, result.level);
 
     var promoted = Inspection{
         .architecture = try std.testing.allocator.dupe(u8, "qwen3"),
-        .qwen3_embedding_promotion = .q8_0,
     };
     defer promoted.deinit(std.testing.allocator);
     try std.testing.expectEqual(Level.compatible, assessInspection(&man, promoted).level);
@@ -914,107 +505,13 @@ test "qwen3-embedding style requires an exact managed promotion" {
     try std.testing.expectEqual(Level.unknown, bare_result.level);
 }
 
-test "qwen3-embedding promotion receipt pins source variant and every artifact" {
-    const bundle = &qwen3_embedding_catalog.bundles[0];
-    var artifacts: [bundle.artifact_list.len + 1]managed_receipt.ArtifactReceipt = undefined;
-    for (bundle.artifacts(), 0..) |artifact, i| artifacts[i] = .{
-        .path = artifact.path,
-        .size = artifact.size,
-        .sha256 = artifact.sha256,
-    };
-    artifacts[bundle.artifact_list.len] = .{
-        .path = "model_manifest.json",
-        .size = qwen3_embedding_catalog.gguf_bundle_model_manifest.len,
-        .sha256 = qwen3_embedding_catalog.gguf_bundle_model_manifest_sha256,
-    };
-    const slash = std.mem.indexOfScalar(u8, bundle.source_repo, '/').?;
-    var receipt = managed_receipt.DownloadReceipt{
-        .version = 2,
-        .source = .{
-            .owner = bundle.source_repo[0..slash],
-            .name = bundle.source_repo[slash + 1 ..],
-            .variant = bundle.variant,
-        },
-        .artifacts = &artifacts,
-    };
-    var man = manifest_mod.ModelManifest{
-        .allocator = std.testing.allocator,
-        .model_type = .embedder,
-        .pooling = .last,
-        .embedding_style = .qwen3_embedding,
-        .gguf_path = bundle.artifacts()[0].path,
-    };
-    const metadata = gguf_format.SupportMetadata{
-        .architecture = "qwen3",
-        .block_count = 28,
-        .embedding_length = 1024,
-    };
-    try std.testing.expectEqual(.q8_0, qwen3EmbeddingPromotionFromReceipt(&man, metadata, receipt));
-    artifacts[0].sha256 = "0000000000000000000000000000000000000000000000000000000000000000";
-    try std.testing.expectEqual(.none, qwen3EmbeddingPromotionFromReceipt(&man, metadata, receipt));
-    artifacts[0].sha256 = bundle.artifacts()[0].sha256;
-    receipt.source.?.variant = qwen3_embedding_catalog.f16_bundle_variant;
-    try std.testing.expectEqual(.none, qwen3EmbeddingPromotionFromReceipt(&man, metadata, receipt));
-}
-
-test "qwen3-embedding safetensors promotion pins the complete BF16 bundle" {
-    const bundle = &qwen3_embedding_catalog.bundles[2];
-    var artifacts: [bundle.artifact_list.len]managed_receipt.ArtifactReceipt = undefined;
-    for (bundle.artifacts(), 0..) |artifact, i| artifacts[i] = .{
-        .path = artifact.path,
-        .size = artifact.size,
-        .sha256 = artifact.sha256,
-    };
-    const slash = std.mem.indexOfScalar(u8, bundle.source_repo, '/').?;
-    var receipt = managed_receipt.DownloadReceipt{
-        .version = 2,
-        .source = .{
-            .owner = bundle.source_repo[0..slash],
-            .name = bundle.source_repo[slash + 1 ..],
-            .variant = bundle.variant,
-        },
-        .artifacts = &artifacts,
-    };
-    var man = manifest_mod.ModelManifest{
-        .allocator = std.testing.allocator,
-        .model_type = .embedder,
-        .pooling = .last,
-        .normalize = true,
-        .embedding_style = .qwen3_embedding,
-        .embedding_profile = .{
-            .task_contract = .profiled,
-            .query = .{ .declared = true },
-            .document = .{ .declared = true },
-        },
-        .config_model_arch = "qwen3",
-        .hidden_size = 1024,
-        .num_hidden_layers = 28,
-        .safetensors_path = bundle.artifacts()[0].path,
-    };
-    try std.testing.expectEqual(
-        .bf16_safetensors,
-        qwen3EmbeddingSafetensorsPromotionFromReceipt(&man, receipt),
-    );
-    artifacts[1].size -= 1;
-    try std.testing.expectEqual(
-        .none,
-        qwen3EmbeddingSafetensorsPromotionFromReceipt(&man, receipt),
-    );
-    artifacts[1].size += 1;
-    receipt.source.?.variant = qwen3_embedding_catalog.q8_0_bundle_variant;
-    try std.testing.expectEqual(
-        .none,
-        qwen3EmbeddingSafetensorsPromotionFromReceipt(&man, receipt),
-    );
-}
-
-test "unknown generators are unknown and require opt in" {
+test "unknown architectures are attempted by default with optional strict policy" {
     var man = manifest_mod.ModelManifest{ .allocator = std.testing.allocator };
     man.model_type = .generator;
     const result = assess(&man, "brand_new_decoder");
     try std.testing.expectEqual(Level.unknown, result.level);
     try std.testing.expect(!result.allowed(false));
-    try std.testing.expect(result.allowed(true));
+    try std.testing.expect(result.allowed((Policy{}).allow_unknown));
 }
 
 test "known unsafe generators cannot be enabled by unknown opt in" {
@@ -1275,7 +772,7 @@ test "known Qwen hybrid variants and NomicBERT stay classified" {
     try std.testing.expectEqual(Level.compatible, assess(&embedder, "nomic_bert").level);
 }
 
-test "Qwen3-VL bundles fail closed before runtime qualification" {
+test "Qwen3-VL admission checks required artifacts and implemented serving roles" {
     const allocator = std.testing.allocator;
     var manifest = manifest_mod.ModelManifest{
         .allocator = allocator,
@@ -1296,8 +793,8 @@ test "Qwen3-VL bundles fail closed before runtime qualification" {
     manifest.tokenizer_config_path = try allocator.dupe(u8, "tokenizer_config.json");
     manifest.preprocessor_config_path = try allocator.dupe(u8, "preprocessor_config.json");
     assessment = assess(&manifest, "qwen3vl");
-    try std.testing.expectEqual(Code.unsupported_backend, assessment.code);
-    try std.testing.expect(!assessment.allowed(true));
+    try std.testing.expectEqual(Level.compatible, assessment.level);
+    try std.testing.expect(assessment.allowed(true));
 
     var reranker = manifest_mod.ModelManifest{
         .allocator = allocator,
@@ -1314,116 +811,6 @@ test "Qwen3-VL bundles fail closed before runtime qualification" {
     assessment = assess(&reranker, "qwen3_vl");
     try std.testing.expectEqual(Code.unsupported_backend, assessment.code);
     try std.testing.expect(!assessment.allowed(true));
-}
-
-test "Qwen3-VL promotion accepts only exact 2B generation and calibrated Q8 reranker receipts" {
-    const generation_bundle = &qwen3vl_catalog.generation_bundles[0];
-    const generation_catalog = generation_bundle.artifacts();
-    var generation_artifacts: [10]managed_receipt.ArtifactReceipt = undefined;
-    for (generation_catalog, 0..) |artifact, index| {
-        generation_artifacts[index] = .{
-            .path = artifact.path,
-            .size = artifact.size,
-            .sha256 = artifact.sha256,
-        };
-    }
-    for (qwen3vl_catalog.promoted_generation_2b_metadata_artifacts, 8..) |artifact, index| {
-        generation_artifacts[index] = .{
-            .path = artifact.path,
-            .size = artifact.size,
-        };
-    }
-    const generation_receipt = managed_receipt.DownloadReceipt{
-        .version = 2,
-        .source = .{
-            .owner = "Qwen",
-            .name = "Qwen3-VL-2B-Instruct-GGUF",
-            .variant = qwen3vl_catalog.generation_bundle_variant,
-        },
-        .artifacts = &generation_artifacts,
-    };
-    var generation_manifest = manifest_mod.ModelManifest{
-        .allocator = std.testing.allocator,
-        .model_type = .generator,
-        .model_type_origin = .bundle,
-        .inference_bundle_family = manifest_mod.qwen3_vl_gguf_bundle_family,
-        .gguf_path = "Qwen3VL-2B-Instruct-Q4_K_M.gguf",
-        .gguf_projector_path = "mmproj-Qwen3VL-2B-Instruct-Q8_0.gguf",
-        .config_path = "config.json",
-        .tokenizer_json_path = "tokenizer.json",
-        .tokenizer_config_path = "tokenizer_config.json",
-        .preprocessor_config_path = "preprocessor_config.json",
-    };
-    const metadata = gguf_format.SupportMetadata{
-        .architecture = "qwen3vl",
-        .block_count = 28,
-        .embedding_length = 2048,
-    };
-    try std.testing.expectEqual(
-        Qwen3VlPromotion.generation_2b_q4_k_m,
-        qwen3VlPromotionFromReceipt(&generation_manifest, metadata, generation_receipt),
-    );
-
-    var promoted_inspection = Inspection{
-        .architecture = try std.testing.allocator.dupe(u8, "qwen3vl"),
-        .qwen3vl_promotion = .generation_2b_q4_k_m,
-    };
-    defer promoted_inspection.deinit(std.testing.allocator);
-    try std.testing.expectEqual(
-        Level.compatible,
-        assessInspection(&generation_manifest, promoted_inspection).level,
-    );
-
-    generation_artifacts[0].sha256 = "0000000000000000000000000000000000000000000000000000000000000000";
-    try std.testing.expectEqual(
-        Qwen3VlPromotion.none,
-        qwen3VlPromotionFromReceipt(&generation_manifest, metadata, generation_receipt),
-    );
-    generation_artifacts[0].sha256 = generation_catalog[0].sha256;
-    generation_manifest.gguf_path = "substituted.gguf";
-    try std.testing.expectEqual(
-        Qwen3VlPromotion.none,
-        qwen3VlPromotionFromReceipt(&generation_manifest, metadata, generation_receipt),
-    );
-
-    var reranker_artifacts: [qwen3vl_catalog.promoted_reranker_artifacts.len]managed_receipt.ArtifactReceipt = undefined;
-    for (qwen3vl_catalog.promoted_reranker_artifacts, 0..) |artifact, index| {
-        reranker_artifacts[index] = .{
-            .path = artifact.path,
-            .size = artifact.size,
-            .sha256 = artifact.sha256,
-        };
-    }
-    var reranker_receipt = managed_receipt.DownloadReceipt{
-        .version = 2,
-        .source = .{
-            .owner = qwen3vl_catalog.promoted_reranker_owner,
-            .name = qwen3vl_catalog.promoted_reranker_name,
-            .variant = qwen3vl_catalog.promoted_reranker_variant,
-        },
-        .artifacts = &reranker_artifacts,
-    };
-    var reranker_manifest = manifest_mod.ModelManifest{
-        .allocator = std.testing.allocator,
-        .model_type = .reranker,
-        .model_type_origin = .bundle,
-        .inference_bundle_family = manifest_mod.qwen3_vl_reranker_gguf_bundle_family,
-        .gguf_path = "Qwen3-VL-Reranker-2B-Q8_0.gguf",
-        .gguf_projector_path = "mmproj-Qwen3-VL-Reranker-2B-Q8_0.gguf",
-        .config_path = "config.json",
-        .tokenizer_json_path = "tokenizer.json",
-        .tokenizer_config_path = "tokenizer_config.json",
-        .preprocessor_config_path = "preprocessor_config.json",
-    };
-    try std.testing.expectEqual(
-        Qwen3VlPromotion.reranker_2b_q8_0,
-        qwen3VlPromotionFromReceipt(&reranker_manifest, metadata, reranker_receipt),
-    );
-    reranker_receipt.source.?.variant = "q4-k-m-ranking-only";
-    try std.testing.expectEqual(
-        Qwen3VlPromotion.none,
-        qwen3VlPromotionFromReceipt(&reranker_manifest, metadata, reranker_receipt),
-    );
 }
 
 test "known unsafe local site models stay blocked even with unknown opt in" {

--- a/zig/pkg/inference/src/ops/metal_compute.zig
+++ b/zig/pkg/inference/src/ops/metal_compute.zig
@@ -732,6 +732,10 @@ pub const MetalCompute = if (build_options.enable_metal) struct {
         native_dense_dtype: ?tensor_mod.DType = null,
         native_dense_bytes_owned: bool = false,
         native_dense_mmap_source_bytes: ?[]const u8 = null,
+        /// Owned f32 peer for consumers that cannot use native dense bytes.
+        /// Host aliases retain its data independently of the original bytes
+        /// and lazy-weight pin. Never copied into aliases; freed by freeOp.
+        native_dense_host_cache: ?CT = null,
     };
 
     const LazyMultiply = struct {
@@ -2207,11 +2211,9 @@ pub const MetalCompute = if (build_options.enable_metal) struct {
             refcount.* = 1;
             break :blk refcount;
         } else null;
+        errdefer if (shared_data_refcount) |refcount| allocator.destroy(refcount);
         const logical_shape = try allocator.alloc(i64, shape.len);
-        errdefer {
-            allocator.free(logical_shape);
-            if (shared_data_refcount) |refcount| allocator.destroy(refcount);
-        }
+        errdefer allocator.free(logical_shape);
         for (shape, 0..) |dim, i| logical_shape[i] = dim;
         buf.* = .{
             .data = data,
@@ -2293,6 +2295,29 @@ pub const MetalCompute = if (build_options.enable_metal) struct {
         return scratch[0..resolved_shape.len];
     }
 
+    /// Materialize native dense storage once, without changing its dtype or
+    /// bytes. All host views share the peer's refcounted f32 backing, so they
+    /// remain valid after the native tensor (including owned concat bytes or
+    /// a pinned mmap weight) is released.
+    fn hostAliasSource(buf: *Buf) !*Buf {
+        if (buf.native_dense_bytes == null or buf.native_dense_dtype == null or buf.data.len != 0) return buf;
+        if (buf.native_dense_host_cache) |cache| return toBuf(cache);
+        const shape = buf.logical_shape orelse return error.InvalidTensorShape;
+        const shape_i32 = try buf.allocator.alloc(i32, shape.len);
+        defer buf.allocator.free(shape_i32);
+        for (shape, 0..) |dim, i| shape_i32[i] = std.math.cast(i32, dim) orelse return error.InvalidTensorShape;
+        const values = try convertNativeDenseBytesToOwnedF32(
+            buf.allocator,
+            buf.native_dense_bytes.?,
+            buf.native_dense_dtype.?,
+            try shapeNumel(shape),
+        );
+        errdefer buf.allocator.free(values);
+        const cache = try denseBuf(buf.allocator, values, true, shape_i32);
+        buf.native_dense_host_cache = cache;
+        return toBuf(cache);
+    }
+
     fn makeViewAlias(
         self: *MetalCompute,
         input: CT,
@@ -2300,7 +2325,7 @@ pub const MetalCompute = if (build_options.enable_metal) struct {
         strides: []const usize,
         base_offset: usize,
     ) !CT {
-        const source = toBuf(input);
+        const source = try hostAliasSource(toBuf(input));
         // A pending lazy_multiply has no concrete `data` to alias — copying the
         // empty slice and dropping the deferred product orphans the buffer
         // (data.len=0, lazy_multiply lost). Reject so the caller materializes
@@ -2341,7 +2366,7 @@ pub const MetalCompute = if (build_options.enable_metal) struct {
         input: CT,
         shape: []const i64,
     ) !CT {
-        const source = toBuf(input);
+        const source = try hostAliasSource(toBuf(input));
         if (source.metal_tensor != null or source.quantized_storage != null or source.owned_quantized_storage != null or source.lazy_entry != null) {
             return error.UnsupportedTensorType;
         }
@@ -2379,7 +2404,7 @@ pub const MetalCompute = if (build_options.enable_metal) struct {
         shape: []const i64,
         index_map: []const usize,
     ) !CT {
-        const source = toBuf(input);
+        const source = try hostAliasSource(toBuf(input));
         if (source.metal_tensor != null or source.quantized_storage != null or source.owned_quantized_storage != null or source.lazy_entry != null) {
             return error.UnsupportedTensorType;
         }
@@ -2417,7 +2442,7 @@ pub const MetalCompute = if (build_options.enable_metal) struct {
         shape: []const i64,
         owned_index_map: []usize,
     ) !CT {
-        const source = toBuf(input);
+        const source = try hostAliasSource(toBuf(input));
         if (source.metal_tensor != null or source.quantized_storage != null or source.owned_quantized_storage != null or source.lazy_entry != null) {
             return error.UnsupportedTensorType;
         }
@@ -2455,7 +2480,7 @@ pub const MetalCompute = if (build_options.enable_metal) struct {
         input: CT,
         shape: []const i64,
     ) !CT {
-        const source = toBuf(input);
+        const source = try hostAliasSource(toBuf(input));
         const source_index_map = source.view_index_map orelse return error.InvalidTensorShape;
         if (source.metal_tensor != null or source.quantized_storage != null or source.owned_quantized_storage != null or source.lazy_entry != null) {
             return error.UnsupportedTensorType;
@@ -2670,7 +2695,7 @@ pub const MetalCompute = if (build_options.enable_metal) struct {
         // materialization is forbidden here.
         if (hasHostView(buf)) return materializedViewSlice(buf);
         if (buf.native_dense_bytes != null and buf.native_dense_dtype != null and buf.data.len == 0) {
-            return error.UnsupportedTensorType;
+            return (try hostAliasSource(buf)).data;
         }
         return buf.data;
     }
@@ -4513,14 +4538,7 @@ pub const MetalCompute = if (build_options.enable_metal) struct {
             var dims: [metal_tensor_mod.max_dims]i32 = undefined;
             if (shape.len > dims.len) return error.UnsupportedShape;
             for (shape, 0..) |dim, i| dims[i] = std.math.cast(i32, dim) orelse return error.InvalidTensorShape;
-            const values = try convertNativeDenseBytesToOwnedF32(
-                std.heap.c_allocator,
-                buf.native_dense_bytes.?,
-                buf.native_dense_dtype.?,
-                try shapeNumel(shape),
-            );
-            errdefer std.heap.c_allocator.free(values);
-            return MetalTensor.owned(values, dims[0..shape.len]);
+            return MetalTensor.ownedCloneFrom(try hostSliceForBuf(buf), dims[0..shape.len]);
         }
         if (buf.lazy_multiply) |*lazy| {
             var lhs = try lazy.lhs.retainedCopy();
@@ -6320,12 +6338,12 @@ pub const MetalCompute = if (build_options.enable_metal) struct {
     }
 
     fn freeOp(ctx: *anyopaque, tensor: CT) void {
-        _ = ctx;
         const buf = toBuf(tensor);
         if (buf.lazy_entry) |entry| {
             if (entry.pin_count > 0) entry.pin_count -= 1;
         }
         releaseOwnedHostData(buf);
+        if (buf.native_dense_host_cache) |cache| freeOp(ctx, cache);
         if (buf.logical_shape) |shape| buf.allocator.free(shape);
         if (buf.view_strides) |strides| buf.allocator.free(strides);
         if (buf.logical_view_strides) |strides| buf.allocator.free(strides);
@@ -6403,13 +6421,7 @@ pub const MetalCompute = if (build_options.enable_metal) struct {
         if (buf.runtime_quantized_storage) |storage| return try self.dequantizeStorageToFloat32(tensor, storage, allocator);
         if (buf.owned_quantized_storage) |storage| return try self.dequantizeStorageToFloat32(tensor, storage, allocator);
         if (buf.native_dense_bytes != null and buf.native_dense_dtype != null and buf.data.len == 0) {
-            const expected_count = if (buf.logical_shape) |shape| try shapeNumel(shape) else 0;
-            return convertNativeDenseBytesToOwnedF32(
-                allocator,
-                buf.native_dense_bytes.?,
-                buf.native_dense_dtype.?,
-                expected_count,
-            );
+            return allocator.dupe(f32, try hostSliceForBuf(buf));
         }
         // A pending lazy multiply has no concrete storage (`data` is the
         // empty placeholder); reading it through the generic host path
@@ -7107,17 +7119,6 @@ pub const MetalCompute = if (build_options.enable_metal) struct {
         }
         if (buf.owned_quantized_storage) |storage| {
             const host = try self.dequantizeStorageToFloat32(ct, storage, self.allocator);
-            defer self.allocator.free(host);
-            return native_ctx.cb.fromFloat32Shape(host, shape_i32);
-        }
-        if (buf.native_dense_bytes != null and buf.native_dense_dtype != null and buf.data.len == 0) {
-            const expected_count = try shapeNumel(shape_i64);
-            const host = try convertNativeDenseBytesToOwnedF32(
-                self.allocator,
-                buf.native_dense_bytes.?,
-                buf.native_dense_dtype.?,
-                expected_count,
-            );
             defer self.allocator.free(host);
             return native_ctx.cb.fromFloat32Shape(host, shape_i32);
         }
@@ -31258,6 +31259,135 @@ test "metal_compute: add uploads equal-size host peer instead of downloading dev
     try std.testing.expectEqualSlices(f32, &.{ 11, 22, 33, 44, 55, 66 }, out_data);
 }
 
+fn testNativeDenseTensor(allocator: std.mem.Allocator, bytes: []const u8, dtype: tensor_mod.DType, shape: []const i32, owned: bool) !CT {
+    const backing = if (owned) try allocator.dupe(u8, bytes) else bytes;
+    errdefer if (owned) allocator.free(backing);
+    const tensor = try MetalCompute.denseBuf(allocator, &.{}, false, shape);
+    const buf = MetalCompute.toBuf(tensor);
+    buf.native_dense_bytes = backing;
+    buf.native_dense_dtype = dtype;
+    buf.native_dense_bytes_owned = owned;
+    return tensor;
+}
+
+test "metal_compute: native dense reshape preserves values after source release" {
+    if (!build_options.enable_metal) return error.SkipZigTest;
+    if (!@import("../backends/metal_runtime.zig").metalDeviceAvailable()) return error.SkipZigTest;
+    const allocator = std.testing.allocator;
+    var weights = testMetalWeightStoreInit(allocator);
+    defer weights.lazy_weights.deinit(allocator);
+    var compute = try MetalCompute.init(allocator, &weights, null);
+    defer compute.deinit();
+    var cb = compute.computeBackend();
+    inline for (.{ tensor_mod.DType.f16, tensor_mod.DType.bf16 }) |dtype| {
+        const encoded = if (dtype == .f16)
+            [_]u16{ 0x4900, 0x4d00, 0x4f80 }
+        else
+            [_]u16{ 0x4120, 0x41a0, 0x41f0 };
+        for ([_]bool{ false, true }) |owned| {
+            var source: ?CT = try testNativeDenseTensor(allocator, std.mem.asBytes(&encoded), dtype, &.{ 1, 3 }, owned);
+            defer if (source) |tensor| cb.free(tensor);
+            const flat = try cb.primReshape(source.?, &.{3});
+            defer cb.free(flat);
+            const sibling = try cb.primReshape(source.?, &.{ 3, 1 });
+            defer cb.free(sibling);
+            const source_buf = MetalCompute.toBuf(source.?);
+            try std.testing.expectEqual(@as(usize, 0), source_buf.data.len);
+            try std.testing.expectEqual(dtype, source_buf.native_dense_dtype.?);
+            try std.testing.expectEqualSlices(u8, std.mem.asBytes(&encoded), source_buf.native_dense_bytes.?);
+            try std.testing.expectEqual(MetalCompute.toBuf(flat).data.ptr, MetalCompute.toBuf(sibling).data.ptr);
+            cb.free(source.?);
+            source = null;
+            const values = try cb.toFloat32(flat, allocator);
+            defer allocator.free(values);
+            try std.testing.expectEqualSlices(f32, &.{ 10, 20, 30 }, values);
+            const sibling_values = try cb.toFloat32(sibling, allocator);
+            defer allocator.free(sibling_values);
+            try std.testing.expectEqualSlices(f32, values, sibling_values);
+        }
+    }
+}
+
+test "metal_compute: native dense views compose across host and device consumers" {
+    if (!build_options.enable_metal) return error.SkipZigTest;
+    if (!@import("../backends/metal_runtime.zig").metalDeviceAvailable()) return error.SkipZigTest;
+    const allocator = std.testing.allocator;
+    var weights = testMetalWeightStoreInit(allocator);
+    defer weights.lazy_weights.deinit(allocator);
+    var compute = try MetalCompute.init(allocator, &weights, null);
+    defer compute.deinit();
+    var cb = compute.computeBackend();
+    inline for (.{ tensor_mod.DType.f16, tensor_mod.DType.bf16 }) |dtype| {
+        const encoded = if (dtype == .f16)
+            [_]u16{ 0x3c00, 0x4000, 0x4200, 0x4400, 0x4500, 0x4600 }
+        else
+            [_]u16{ 0x3f80, 0x4000, 0x4040, 0x4080, 0x40a0, 0x40c0 };
+        for ([_]bool{ false, true }) |owned| {
+            // Start with native bytes, then exercise a strided alias, an
+            // index-map reshape, slicing and broadcast before device upload.
+            const reshaped = blk: {
+                const source = try testNativeDenseTensor(allocator, std.mem.asBytes(&encoded), dtype, &.{ 2, 3 }, owned);
+                defer cb.free(source);
+                const transposed = try cb.primTranspose(source, &.{ 1, 0 }, &.{ 2, 3 });
+                defer cb.free(transposed);
+                break :blk try cb.primReshape(transposed, &.{ 2, 3 });
+            };
+            defer cb.free(reshaped);
+            const expected = [_]f32{ 1, 4, 2, 5, 3, 6 };
+            const values = try cb.toFloat32(reshaped, allocator);
+            defer allocator.free(values);
+            try std.testing.expectEqualSlices(f32, &expected, values);
+            const sliced = try cb.sliceLastDim(reshaped, 1, 3);
+            defer cb.free(sliced);
+            const broadcast = try cb.primBroadcastInDim(sliced, &.{ 2, 2, 2 }, &.{ 1, 2 }, &.{ 2, 2 });
+            defer cb.free(broadcast);
+            const device = try compute.ctFromOwnedMetalTensor(try compute.ownedDeviceMetalTensorFromCt(broadcast));
+            defer cb.free(device);
+            const output = try cb.add(device, device);
+            defer cb.free(output);
+            try std.testing.expect(MetalCompute.debugHasDeviceTensor(&cb, output));
+            const doubled = try cb.toFloat32(output, allocator);
+            defer allocator.free(doubled);
+            try std.testing.expectEqualSlices(f32, &.{ 8, 4, 6, 12, 8, 4, 6, 12 }, doubled);
+            const mixed = try cb.add(device, broadcast);
+            defer cb.free(mixed);
+            const mixed_values = try cb.toFloat32(mixed, allocator);
+            defer allocator.free(mixed_values);
+            try std.testing.expectEqualSlices(f32, doubled, mixed_values);
+            // Host reads and device uploads must not change a shared view.
+            const again = try cb.toFloat32(reshaped, allocator);
+            defer allocator.free(again);
+            try std.testing.expectEqualSlices(f32, &expected, again);
+        }
+        const source = try testNativeDenseTensor(allocator, std.mem.asBytes(&encoded), dtype, &.{ 2, 3 }, false);
+        defer cb.free(source);
+        const direct_slice = try cb.sliceLastDim(source, 1, 3);
+        defer cb.free(direct_slice);
+        const slice_values = try cb.toFloat32(direct_slice, allocator);
+        defer allocator.free(slice_values);
+        try std.testing.expectEqualSlices(f32, &.{ 2, 3, 5, 6 }, slice_values);
+        const direct_broadcast = try cb.primBroadcastInDim(source, &.{ 2, 2, 3 }, &.{ 1, 2 }, &.{ 2, 3 });
+        defer cb.free(direct_broadcast);
+        const broadcast_values = try cb.toFloat32(direct_broadcast, allocator);
+        defer allocator.free(broadcast_values);
+        try std.testing.expectEqualSlices(f32, &.{ 1, 2, 3, 4, 5, 6, 1, 2, 3, 4, 5, 6 }, broadcast_values);
+    }
+}
+
+fn testNativeDenseMaterializationAllocationFailures(allocator: std.mem.Allocator) !void {
+    const bytes = [_]u8{ 0x80, 0x3f, 0x00, 0x40 };
+    const source = try testNativeDenseTensor(allocator, &bytes, .bf16, &.{2}, false);
+    var fake_ctx: u8 align(@alignOf(MetalCompute)) = 0;
+    defer MetalCompute.freeOp(&fake_ctx, source);
+    const values = try MetalCompute.hostSliceForBuf(MetalCompute.toBuf(source));
+    try std.testing.expectEqualSlices(f32, &.{ 1, 2 }, values);
+}
+
+test "metal_compute: native dense materialization cleans up allocation failures" {
+    if (!build_options.enable_metal) return error.SkipZigTest;
+    try std.testing.checkAllAllocationFailures(std.testing.allocator, testNativeDenseMaterializationAllocationFailures, .{});
+}
+
 test "metal_compute: add native dense logits bias keeps single and batched rows resident" {
     if (!build_options.enable_metal) return error.SkipZigTest;
     if (!@import("../backends/metal_runtime.zig").metalDeviceAvailable()) return error.SkipZigTest;
@@ -31283,6 +31413,7 @@ test "metal_compute: add native dense logits bias keeps single and batched rows 
             .native_dense_dtype = dtype,
         };
         const bias: CT = @ptrCast(&bias_buf);
+        defer if (bias_buf.native_dense_host_cache) |cache| cb.free(cache);
         for ([_]usize{ 1, 2 }) |rows| {
             const input = try cb.fromFloat32Shape((&[_]f32{ 1, 2, 3, 4, 5, 6 })[0 .. rows * 3], &.{ @intCast(rows), 3 });
             defer cb.free(input);
@@ -34919,6 +35050,7 @@ test "metal_compute: toFloat32 materializes zero-copy bf16 weights" {
         .native_dense_dtype = .bf16,
     };
     var fake_ctx: u8 align(@alignOf(MetalCompute)) = 0;
+    defer if (buf.native_dense_host_cache) |cache| MetalCompute.freeOp(&fake_ctx, cache);
 
     const values = try MetalCompute.toFloat32Op(&fake_ctx, @ptrCast(&buf), std.testing.allocator);
     defer std.testing.allocator.free(values);

--- a/zig/pkg/inference/src/ops/metal_compute.zig
+++ b/zig/pkg/inference/src/ops/metal_compute.zig
@@ -2742,7 +2742,7 @@ pub const MetalCompute = if (build_options.enable_metal) struct {
     }
 
     fn bufElemCount(buf: *const Buf) usize {
-        if (hasHostView(buf)) {
+        if (hasHostView(buf) or (buf.native_dense_bytes != null and buf.native_dense_dtype != null)) {
             if (buf.logical_shape) |shape| {
                 if (safeShapeNumel(shape)) |numel| return numel;
             }
@@ -4506,7 +4506,21 @@ pub const MetalCompute = if (build_options.enable_metal) struct {
             return error.UnsupportedTensorType;
         }
         if (buf.native_dense_bytes != null and buf.native_dense_dtype != null and buf.data.len == 0) {
-            return error.UnsupportedTensorType;
+            // Dense f16/bf16 weights also reach elementwise consumers (for
+            // example Florence's [1, vocab] final logits bias). Keep their
+            // original storage intact while materializing an owned f32 peer.
+            const shape = buf.logical_shape orelse return error.InvalidTensorShape;
+            var dims: [metal_tensor_mod.max_dims]i32 = undefined;
+            if (shape.len > dims.len) return error.UnsupportedShape;
+            for (shape, 0..) |dim, i| dims[i] = std.math.cast(i32, dim) orelse return error.InvalidTensorShape;
+            const values = try convertNativeDenseBytesToOwnedF32(
+                std.heap.c_allocator,
+                buf.native_dense_bytes.?,
+                buf.native_dense_dtype.?,
+                try shapeNumel(shape),
+            );
+            errdefer std.heap.c_allocator.free(values);
+            return MetalTensor.owned(values, dims[0..shape.len]);
         }
         if (buf.lazy_multiply) |*lazy| {
             var lhs = try lazy.lhs.retainedCopy();
@@ -20988,6 +21002,11 @@ pub const MetalCompute = if (build_options.enable_metal) struct {
             }
             return addOp(ctx, materialized_a orelse a, materialized_b orelse b);
         }
+        if ((a_buf.native_dense_bytes != null and a_buf.data.len == 0) or
+            (b_buf.native_dense_bytes != null and b_buf.data.len == 0))
+        {
+            return self.hostFallbackBinary(a, b, null, null, .add);
+        }
         const a_data = try hostSliceForBuf(a_buf);
         const b_data = try hostSliceForBuf(b_buf);
         if (!canFlatElementwise(a_buf.logical_shape, b_buf.logical_shape, a_data.len, b_data.len)) {
@@ -31237,6 +31256,49 @@ test "metal_compute: add uploads equal-size host peer instead of downloading dev
     const out_data = try metal_cb.toFloat32(out, allocator);
     defer allocator.free(out_data);
     try std.testing.expectEqualSlices(f32, &.{ 11, 22, 33, 44, 55, 66 }, out_data);
+}
+
+test "metal_compute: add native dense logits bias keeps single and batched rows resident" {
+    if (!build_options.enable_metal) return error.SkipZigTest;
+    if (!@import("../backends/metal_runtime.zig").metalDeviceAvailable()) return error.SkipZigTest;
+    const allocator = std.testing.allocator;
+    var weights = testMetalWeightStoreInit(allocator);
+    defer weights.lazy_weights.deinit(allocator);
+    var compute = try MetalCompute.init(allocator, &weights, null);
+    defer compute.deinit();
+    var cb = compute.computeBackend();
+    const expected = [_]f32{ 11, 22, 33, 14, 25, 36 };
+    inline for (.{ tensor_mod.DType.f16, tensor_mod.DType.bf16 }) |dtype| {
+        const encoded = if (dtype == .f16)
+            [_]u16{ 0x4900, 0x4d00, 0x4f80 }
+        else
+            [_]u16{ 0x4120, 0x41a0, 0x41f0 };
+        var shape = [_]i64{ 1, 3 };
+        var bias_buf = MetalCompute.Buf{
+            .data = &.{},
+            .allocator = allocator,
+            .owned = false,
+            .logical_shape = &shape,
+            .native_dense_bytes = std.mem.asBytes(&encoded),
+            .native_dense_dtype = dtype,
+        };
+        const bias: CT = @ptrCast(&bias_buf);
+        for ([_]usize{ 1, 2 }) |rows| {
+            const input = try cb.fromFloat32Shape((&[_]f32{ 1, 2, 3, 4, 5, 6 })[0 .. rows * 3], &.{ @intCast(rows), 3 });
+            defer cb.free(input);
+            const device = try compute.ctFromOwnedMetalTensor(try compute.ownedDeviceMetalTensorFromCt(input));
+            defer cb.free(device);
+            const output = try cb.add(device, bias);
+            defer cb.free(output);
+            try std.testing.expect(MetalCompute.debugHasDeviceTensor(&cb, output));
+            const values = try cb.toFloat32(output, allocator);
+            defer allocator.free(values);
+            try std.testing.expectEqualSlices(f32, expected[0 .. rows * 3], values);
+            // Reading the bias must not replace its native representation.
+            try std.testing.expectEqual(@as(usize, 0), bias_buf.data.len);
+            try std.testing.expectEqual(dtype, bias_buf.native_dense_dtype.?);
+        }
+    }
 }
 
 test "metal_compute: add keeps row-wise rhs broadcast resident" {

--- a/zig/pkg/inference/src/registry/download.zig
+++ b/zig/pkg/inference/src/registry/download.zig
@@ -1772,8 +1772,8 @@ pub fn downloadPinnedQwen3VlRerankerBundle(
 /// the official GGUF weight artifact with tokenizer sidecars from the
 /// original safetensors repository (the GGUF repo ships weights only) and
 /// write a generated model_manifest.json declaring the last-token embedder
-/// contract. The safetensors bundle carries its own sentence-transformers
-/// detection sidecars and needs no synthetic manifest.
+/// contract. Safetensors bundles retain their sentence-transformers sidecars
+/// and receive the same pinned executable query/document profile.
 pub fn downloadPinnedQwen3EmbeddingBundle(
     allocator: std.mem.Allocator,
     io: std.Io,

--- a/zig/pkg/inference/src/registry/qwen3_embedding_catalog.zig
+++ b/zig/pkg/inference/src/registry/qwen3_embedding_catalog.zig
@@ -174,9 +174,10 @@ pub const bundles = [_]EmbeddingBundle{
         .id = "qwen3-embedding-0.6b-bf16-safetensors",
         .variant = safetensors_bundle_variant,
         .source_repo = safetensors_repo,
-        // Sentence-transformers sidecars (modules.json + 1_Pooling +
-        // prompts) drive detection; no synthetic manifest required.
-        .generated_model_manifest = null,
+        // The executable query/document profile is part of every managed
+        // embedding bundle, including safetensors. Pull must not replace it
+        // with generic task-only metadata before writing the final receipt.
+        .generated_model_manifest = gguf_bundle_model_manifest,
         .artifact_list = &safetensors_artifacts,
     },
 };
@@ -238,7 +239,7 @@ test "Qwen3-Embedding artifact catalog is immutable and internally consistent" {
     try std.testing.expectEqualStrings("Qwen3-Embedding-0.6B-f16.gguf", f16_bundle.artifact_list[0].path);
 
     const st = findBundleForHubRef("Qwen", "Qwen3-Embedding-0.6B", safetensors_bundle_variant).?;
-    try std.testing.expect(st.generated_model_manifest == null);
+    try std.testing.expectEqualStrings(gguf_bundle_model_manifest, st.generated_model_manifest.?);
     try std.testing.expectEqual(@as(usize, 7), st.artifact_list.len);
 
     try std.testing.expect(findBundleForHubRef("Qwen", "Qwen3-Embedding-0.6B", q8_0_bundle_variant) == null);

--- a/zig/pkg/inference/src/registry/registry.zig
+++ b/zig/pkg/inference/src/registry/registry.zig
@@ -148,6 +148,30 @@ test "friendly alias refs parse as explicit model refs" {
     }
 }
 
+/// Pull accepts the public HuggingFace owner/model[:variant] syntax. Local
+/// command aliases must not silently select a different repository or bundle.
+fn parsePullModelRef(value: []const u8) !ModelRef {
+    const ref = try ModelRef.parse(value);
+    // This repository's main branch has no safetensors; retain the canonical
+    // pull repair without accepting a short-name alias.
+    if (std.ascii.eqlIgnoreCase(ref.owner, "BAAI") and
+        std.ascii.eqlIgnoreCase(ref.name, "bge-m3") and
+        std.mem.eql(u8, ref.variant, "auto"))
+        return ModelRef.parse(bge_m3_pinned_ref);
+    return ref;
+}
+
+test "pull uses canonical repository refs without short-name bundle aliases" {
+    const gguf = try parsePullModelRef("Qwen/Qwen3-Embedding-0.6B-GGUF");
+    try std.testing.expectEqualStrings("Qwen", gguf.owner);
+    try std.testing.expectEqualStrings("Qwen3-Embedding-0.6B-GGUF", gguf.name);
+    try std.testing.expectEqualStrings("auto", gguf.variant);
+    const safetensors = try parsePullModelRef("hf:Qwen/Qwen3-Embedding-0.6B:safetensors");
+    try std.testing.expectEqualStrings("safetensors", safetensors.variant);
+    try std.testing.expectError(error.InvalidModelRef, parsePullModelRef("qwen3-embedding-0.6b-safetensors"));
+    try std.testing.expectError(error.InvalidModelRef, parsePullModelRef("gemma4-e2b"));
+}
+
 fn parseModelRefOrAlias(value: []const u8) !ModelRef {
     return ModelRef.parse(resolveFriendlyRef(value) orelse value);
 }
@@ -494,8 +518,7 @@ pub const ModelRegistry = struct {
         capabilities_csv: ?[]const u8,
         projector_selection: download.ProjectorSelection,
     ) !void {
-        const resolved_ref = resolveFriendlyRef(ref_str) orelse ref_str;
-        const ref = try ModelRef.parse(resolved_ref);
+        const ref = try parsePullModelRef(ref_str);
         const resolved_models_dir = try resolveModelsDirForWriteAlloc(self.allocator, io, self.models_dir);
         defer self.allocator.free(resolved_models_dir);
 
@@ -2022,4 +2045,37 @@ test "resolveVariant retains legacy suffix resolution" {
     const expected = try std.fs.path.join(allocator, &.{ models_dir, "owner", "model-q4_0" });
     defer allocator.free(expected);
     try std.testing.expectEqualStrings(expected, resolved);
+}
+
+test "pull preserves the pinned Qwen3 BF16 executable profile through manifest finalization" {
+    const alloc = std.testing.allocator;
+    const io = std.testing.io;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const model_dir = try std.fs.path.join(alloc, &.{ ".zig-cache", "tmp", tmp.sub_path[0..], "staging" });
+    defer alloc.free(model_dir);
+    try download.beginManagedDownload(alloc, io, model_dir);
+    const config_path = try std.fs.path.join(alloc, &.{ model_dir, "model.safetensors" });
+    defer alloc.free(config_path);
+    try Dir.cwd().writeFile(io, .{ .sub_path = config_path, .data = "payload" });
+    const plan_path = try std.fs.path.join(alloc, &.{ model_dir, download.managed_download_plan_filename });
+    defer alloc.free(plan_path);
+    try Dir.cwd().writeFile(io, .{
+        .sub_path = plan_path,
+        .data = "{\"version\":2,\"source\":{\"owner\":\"Qwen\",\"name\":\"Qwen3-Embedding-0.6B\",\"variant\":\"bf16-safetensors-bundle-v1\"},\"artifacts\":[{\"path\":\"model.safetensors\",\"size\":7}]}",
+    });
+    const manifest = qwen3_embedding_catalog.bundles[2].generated_model_manifest.?;
+    try download.writeManagedArtifactAndUpdatePlan(alloc, io, model_dir, "model_manifest.json", manifest);
+    var registry = ModelRegistry.init(alloc, model_dir);
+    try registry.writePulledModelManifest(io, model_dir, null, null);
+    var plan = try managed_receipt.loadValidatedPlan(alloc, io, model_dir);
+    defer plan.deinit();
+    const artifact = plan.find("model_manifest.json").?;
+    try std.testing.expectEqual(manifest.len, artifact.size);
+    try std.testing.expectEqualStrings(qwen3_embedding_catalog.gguf_bundle_model_manifest_sha256, artifact.sha256.?);
+    var loaded = try manifest_mod.loadFromManagedPlanDir(alloc, model_dir);
+    defer loaded.deinit();
+    try std.testing.expectEqual(manifest_mod.ModelType.embedder, loaded.model_type);
+    try std.testing.expect(loaded.embedding_profile.isResolved());
+    try std.testing.expectEqual(manifest_mod.PoolingStrategy.last, loaded.pooling);
 }

--- a/zig/pkg/inference/src/server/model_manager.zig
+++ b/zig/pkg/inference/src/server/model_manager.zig
@@ -10619,7 +10619,34 @@ test "ModelManager loads split gliner bundle and exposes runtime pipeline" {
     try std.testing.expectError(error.MissingSpecialTokenIds, pipeline.recognizeBatch(&.{"hello"}, &.{"person"}));
 }
 
-test "ModelManager serving policy fails closed before loading generator weights" {
+test "ModelManager strict serving policy rejects unknown generator architectures" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.writeFile(std.testing.io, .{
+        .sub_path = "model_manifest.json",
+        .data = "{\"type\":\"generator\"}",
+    });
+    try tmp.dir.writeFile(std.testing.io, .{
+        .sub_path = "config.json",
+        .data = "{\"model_type\":\"brand_new_decoder\"}",
+    });
+
+    const dir_path = try std.fs.path.join(allocator, &.{ ".zig-cache", "tmp", tmp.sub_path[0..] });
+    defer allocator.free(dir_path);
+
+    var manager = ModelManager.init(allocator, .{
+        .allocator = allocator,
+        .preferred_backends = &.{.native},
+    });
+    defer manager.deinit();
+    manager.configureServingPolicy(.{ .allow_unknown = false });
+
+    try std.testing.expectError(error.UnknownModelCompatibility, manager.loadFromDir(dir_path));
+}
+
+test "ModelManager default serving policy still rejects a generator without a loadable artifact" {
     const allocator = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -10643,37 +10670,10 @@ test "ModelManager serving policy fails closed before loading generator weights"
     defer manager.deinit();
     manager.configureServingPolicy(.{});
 
-    try std.testing.expectError(error.UnknownModelCompatibility, manager.loadFromDir(dir_path));
-}
-
-test "unknown opt in still rejects a generator without a loadable artifact" {
-    const allocator = std.testing.allocator;
-    var tmp = std.testing.tmpDir(.{});
-    defer tmp.cleanup();
-
-    try tmp.dir.writeFile(std.testing.io, .{
-        .sub_path = "model_manifest.json",
-        .data = "{\"type\":\"generator\"}",
-    });
-    try tmp.dir.writeFile(std.testing.io, .{
-        .sub_path = "config.json",
-        .data = "{\"model_type\":\"brand_new_decoder\"}",
-    });
-
-    const dir_path = try std.fs.path.join(allocator, &.{ ".zig-cache", "tmp", tmp.sub_path[0..] });
-    defer allocator.free(dir_path);
-
-    var manager = ModelManager.init(allocator, .{
-        .allocator = allocator,
-        .preferred_backends = &.{.native},
-    });
-    defer manager.deinit();
-    manager.configureServingPolicy(.{ .allow_unknown = true });
-
     try std.testing.expectError(error.IncompatibleModel, manager.loadFromDir(dir_path));
 }
 
-test "unknown opt in does not enable a known incompatible generator" {
+test "ModelManager default serving policy does not enable a known incompatible generator" {
     const allocator = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -10695,7 +10695,7 @@ test "unknown opt in does not enable a known incompatible generator" {
         .preferred_backends = &.{.native},
     });
     defer manager.deinit();
-    manager.configureServingPolicy(.{ .allow_unknown = true });
+    manager.configureServingPolicy(.{});
 
     try std.testing.expectError(error.IncompatibleModel, manager.loadFromDir(dir_path));
 }

--- a/zig/pkg/inference/src/server/model_manager.zig
+++ b/zig/pkg/inference/src/server/model_manager.zig
@@ -20,6 +20,7 @@
 const std = @import("std");
 const execution_control_mod = @import("../execution_control.zig");
 const InferenceExecutionControl = execution_control_mod.InferenceExecutionControl;
+const HardCancellationWatchdog = @import("../hard_cancellation_watchdog.zig").HardCancellationWatchdog;
 const builtin = @import("builtin");
 const build_options = @import("build_options");
 const platform = @import("antfly_platform");
@@ -544,7 +545,7 @@ pub fn compatibilitySummaryForBackend(
         return .{
             .level = .incompatible,
             .code = .unsupported_backend,
-            .message = "production-qualified Qwen3-VL bundles require Metal, except the integrated BF16 generation bundle which also supports CUDA",
+            .message = "the split Qwen3-VL decoder/projector route requires Metal; the integrated safetensors generation route also supports CUDA",
         };
     }
     if (man.embedding_style == .qwen3_embedding and
@@ -554,7 +555,7 @@ pub fn compatibilitySummaryForBackend(
         return .{
             .level = .incompatible,
             .code = .unsupported_backend,
-            .message = "production-qualified Qwen3-Embedding GGUF bundles require Metal, native CPU, or CUDA",
+            .message = "Qwen3 GGUF embedding requires Metal, native CPU, or CUDA",
         };
     }
 
@@ -567,21 +568,6 @@ pub fn compatibilitySummaryForBackend(
     defer inspection.deinit(allocator);
     const assessment = model_compatibility.assessInspection(&candidate_manifest, inspection);
     if (assessment.level == .incompatible) return summaryFromAssessment(assessment);
-    if (!qwen3VlPromotionSupportsBackend(inspection.qwen3vl_promotion, backend)) {
-        return .{
-            .level = .incompatible,
-            .code = .unsupported_backend,
-            .message = "production-qualified Qwen3-VL bundles require the Metal backend",
-        };
-    }
-    if (!qwen3EmbeddingPromotionSupportsBackend(inspection.qwen3_embedding_promotion, backend)) {
-        return .{
-            .level = .incompatible,
-            .code = .unsupported_backend,
-            .message = "this production-qualified Qwen3-Embedding variant is not qualified on the selected backend",
-        };
-    }
-
     var projector_decoder = ProjectorDecoderContract{
         .family = projectorDecoderFamilyForArchitecture(man.config_model_arch),
         .hidden_size = man.hidden_size,
@@ -716,36 +702,6 @@ test "Qwen3 embedding production backends include native CPU and CUDA" {
     try std.testing.expect(qwen3EmbeddingSupportsBackend(.metal));
     try std.testing.expect(qwen3EmbeddingSupportsBackend(.native));
     try std.testing.expect(qwen3EmbeddingSupportsBackend(.cuda));
-}
-
-fn qwen3EmbeddingPromotionSupportsBackend(
-    promotion: model_compatibility.Qwen3EmbeddingPromotion,
-    backend: backends.BackendType,
-) bool {
-    return switch (promotion) {
-        .none => true,
-        .q8_0 => backend == .metal or backend == .native or backend == .cuda,
-        .f16 => backend == .metal,
-        .bf16_safetensors => backend == .metal or backend == .cuda,
-    };
-}
-
-test "Qwen3 embedding promotion backend qualification is variant-specific" {
-    try std.testing.expect(qwen3EmbeddingPromotionSupportsBackend(.q8_0, .native));
-    try std.testing.expect(qwen3EmbeddingPromotionSupportsBackend(.q8_0, .metal));
-    try std.testing.expect(qwen3EmbeddingPromotionSupportsBackend(.q8_0, .cuda));
-    try std.testing.expect(!qwen3EmbeddingPromotionSupportsBackend(.f16, .native));
-    try std.testing.expect(qwen3EmbeddingPromotionSupportsBackend(.f16, .metal));
-    try std.testing.expect(!qwen3EmbeddingPromotionSupportsBackend(.bf16_safetensors, .native));
-    try std.testing.expect(qwen3EmbeddingPromotionSupportsBackend(.bf16_safetensors, .metal));
-    try std.testing.expect(qwen3EmbeddingPromotionSupportsBackend(.bf16_safetensors, .cuda));
-}
-
-fn qwen3VlPromotionSupportsBackend(
-    promotion: model_compatibility.Qwen3VlPromotion,
-    backend: backends.BackendType,
-) bool {
-    return promotion == .none or backend == .metal;
 }
 
 /// Aggregate candidate compatibility as an OR: a model bundle is usable when
@@ -3838,6 +3794,7 @@ pub const ModelManager = struct {
     /// Lazily allocated at a stable address for offline/direct callers. Never
     /// borrow a request's Io: shared loads and resident sessions outlive it.
     owned_load_runtime: ?*std.Io.Threaded = null,
+    owned_load_watchdog: ?*HardCancellationWatchdog = null,
     in_flight_loads: std.StringHashMapUnmanaged(*LoadFlight) = .empty,
     whisper_assets: std.AutoHashMapUnmanaged(ComponentPlanKey, *WhisperCompositeAssets) = .empty,
     in_flight_whisper_assets: std.AutoHashMapUnmanaged(ComponentPlanKey, *WhisperAssetsLoadFlight) = .empty,
@@ -5603,6 +5560,7 @@ pub const ModelManager = struct {
             owned.deinit();
             self.allocator.destroy(owned);
         };
+        defer if (self.owned_load_watchdog) |watchdog| watchdog.destroy();
         if (self.load_io) |io| self.load_group.cancel(io);
         if (self.eviction_io) |io| self.eviction_group.cancel(io);
         std.debug.assert(self.in_flight_loads.count() == 0);
@@ -6444,6 +6402,17 @@ pub const ModelManager = struct {
         return io;
     }
 
+    fn offlineLoadBoundaryLocked(self: *ModelManager, io: std.Io) !?execution_control_mod.HardCancellationBoundary {
+        if (!self.session_manager.process_isolation_available) return null;
+        if (self.owned_load_watchdog == null) {
+            const watchdog = try HardCancellationWatchdog.create(self.allocator);
+            errdefer watchdog.destroy();
+            try watchdog.start(io);
+            self.owned_load_watchdog = watchdog;
+        }
+        return self.owned_load_watchdog.?.boundary();
+    }
+
     fn loadFromDirCoordinated(
         self: *ModelManager,
         model_dir: []const u8,
@@ -6496,13 +6465,20 @@ pub const ModelManager = struct {
             self.unlockLoadedModels();
             return err;
         };
+        // Offline CLI loads also run in a cancellable manager-owned task.
+        // Their process is disposable, but the task still needs a real monitor
+        // for a driver call that cannot observe its final waiter's cancellation.
+        const hard_cancellation = if (control) |active| active.hard_cancellation else self.offlineLoadBoundaryLocked(coordination_io) catch |err| {
+            self.unlockLoadedModels();
+            return err;
+        };
         const flight = self.allocator.create(LoadFlight) catch |err| {
             self.unlockLoadedModels();
             return err;
         };
         flight.* = .{
             .io = coordination_io,
-            .hard_cancellation = if (control) |active| active.hard_cancellation else null,
+            .hard_cancellation = hard_cancellation,
         };
         const owned_flight_key = self.allocator.dupe(u8, flight_key) catch |err| {
             self.allocator.destroy(flight);
@@ -9612,23 +9588,6 @@ test "safetensors compatibility rejects a missing referenced shard" {
     try std.testing.expectEqual(model_compatibility.Code.artifact_unreadable, summary.code);
 }
 
-test "production-qualified Qwen3-VL promotions are Metal only" {
-    try std.testing.expect(qwen3VlPromotionSupportsBackend(.none, .native));
-    try std.testing.expect(qwen3VlPromotionSupportsBackend(.none, .onnx));
-    try std.testing.expect(qwen3VlPromotionSupportsBackend(.none, .metal));
-    try std.testing.expect(qwen3VlPromotionSupportsBackend(.none, .cuda));
-
-    inline for (.{
-        model_compatibility.Qwen3VlPromotion.generation_2b_q4_k_m,
-        model_compatibility.Qwen3VlPromotion.reranker_2b_q8_0,
-    }) |promotion| {
-        try std.testing.expect(!qwen3VlPromotionSupportsBackend(promotion, .native));
-        try std.testing.expect(!qwen3VlPromotionSupportsBackend(promotion, .onnx));
-        try std.testing.expect(qwen3VlPromotionSupportsBackend(promotion, .metal));
-        try std.testing.expect(!qwen3VlPromotionSupportsBackend(promotion, .cuda));
-    }
-}
-
 test "native compatibility rejects a missing lazy GGUF companion" {
     const allocator = std.testing.allocator;
     var dir = std.testing.tmpDir(.{});
@@ -11480,4 +11439,20 @@ fn appendTestMetadataF32Array(allocator: std.mem.Allocator, data: *std.ArrayList
     try appendTestLe(u32, allocator, data, @intFromEnum(gguf_format.MetadataValueType.f32));
     try appendTestLe(u64, allocator, data, values.len);
     for (values) |value| try appendTestLe(u32, allocator, data, @bitCast(value));
+}
+
+test "offline load runtime supplies a real hard cancellation boundary only for disposable processes" {
+    const alloc = std.testing.allocator;
+    var manager = ModelManager.init(alloc, .{ .allocator = alloc, .preferred_backends = &.{.metal}, .process_isolation_available = false });
+    defer manager.deinit();
+    try std.testing.expect(try manager.offlineLoadBoundaryLocked(std.testing.io) == null);
+    try std.testing.expect(manager.owned_load_watchdog == null);
+    manager.session_manager.process_isolation_available = true;
+    const boundary = (try manager.offlineLoadBoundaryLocked(std.testing.io)).?;
+    const again = (try manager.offlineLoadBoundaryLocked(std.testing.io)).?;
+    try std.testing.expectEqual(boundary.ptr, again.ptr);
+    const control = InferenceExecutionControl{ .hard_cancellation = boundary };
+    var guard = try control.enterUninterruptible(.process_required);
+    guard.deinit();
+    try std.testing.expectEqual(@as(usize, 0), manager.owned_load_watchdog.?.entries.items.len);
 }

--- a/zig/pkg/inference/src/server/server.zig
+++ b/zig/pkg/inference/src/server/server.zig
@@ -1092,111 +1092,7 @@ fn rawGenerateChatTemplateKwargsAreValid(
     return true;
 }
 
-/// Watches only calls which declared that cooperative or native termination is
-/// insufficient. Expiry is process-fatal by design: the supervisor owns the
-/// replacement generation, while continuing in this address space could reuse
-/// buffers still retained by a wedged driver.
-const HardCancellationWatchdog = struct {
-    const Entry = struct {
-        token: u64,
-        control: execution_control_mod.MonitorControl,
-    };
-
-    allocator: std.mem.Allocator,
-    mutex: std.atomic.Mutex = .unlocked,
-    entries: std.ArrayListUnmanaged(Entry) = .empty,
-    next_token: u64 = 1,
-    stopping: std.atomic.Value(bool) = .init(false),
-    io: ?std.Io = null,
-    group: std.Io.Group = .init,
-
-    fn create(allocator: std.mem.Allocator) !*HardCancellationWatchdog {
-        const self = try allocator.create(HardCancellationWatchdog);
-        errdefer allocator.destroy(self);
-        self.* = .{ .allocator = allocator };
-        return self;
-    }
-
-    fn start(self: *HardCancellationWatchdog, io: std.Io) !void {
-        if (self.io != null) return;
-        self.io = io;
-        errdefer self.io = null;
-        try self.group.concurrent(io, run, .{ self, io });
-    }
-
-    fn destroy(self: *HardCancellationWatchdog) void {
-        self.stopping.store(true, .release);
-        if (self.io) |io| {
-            self.group.cancel(io);
-            self.group.await(io) catch {};
-        }
-        spinLock(&self.mutex);
-        std.debug.assert(self.entries.items.len == 0);
-        self.entries.deinit(self.allocator);
-        self.mutex.unlock();
-        const allocator = self.allocator;
-        self.* = undefined;
-        allocator.destroy(self);
-    }
-
-    fn boundary(self: *HardCancellationWatchdog) execution_control_mod.HardCancellationBoundary {
-        return .{
-            .ptr = self,
-            .arm_fn = armOpaque,
-            .disarm_fn = disarmOpaque,
-        };
-    }
-
-    fn armOpaque(raw: *anyopaque, control: execution_control_mod.MonitorControl) !u64 {
-        const self: *HardCancellationWatchdog = @ptrCast(@alignCast(raw));
-        try control.check();
-        spinLock(&self.mutex);
-        defer self.mutex.unlock();
-        if (self.stopping.load(.acquire)) return error.InferenceWorkerShuttingDown;
-        if (self.io == null) return error.HardCancellationWatchdogNotStarted;
-        const token = self.next_token;
-        self.next_token +%= 1;
-        if (self.next_token == 0) self.next_token = 1;
-        try self.entries.append(self.allocator, .{ .token = token, .control = control });
-        return token;
-    }
-
-    fn disarmOpaque(raw: *anyopaque, token: u64) void {
-        const self: *HardCancellationWatchdog = @ptrCast(@alignCast(raw));
-        spinLock(&self.mutex);
-        defer self.mutex.unlock();
-        for (self.entries.items, 0..) |entry, index| {
-            if (entry.token != token) continue;
-            _ = self.entries.swapRemove(index);
-            return;
-        }
-        // A missing token is an ownership violation. Do not silently leave a
-        // borrowed request pointer in the monitor.
-        @panic("hard cancellation watchdog token was not armed");
-    }
-
-    fn run(self: *HardCancellationWatchdog, io: std.Io) std.Io.Cancelable!void {
-        while (!self.stopping.load(.acquire)) {
-            var fatal: ?anyerror = null;
-            spinLock(&self.mutex);
-            for (self.entries.items) |entry| {
-                entry.control.check() catch |err| {
-                    fatal = err;
-                    break;
-                };
-            }
-            self.mutex.unlock();
-            if (fatal) |err| {
-                std.log.err(
-                    "uninterruptible inference request expired; terminating supervised worker err={s}",
-                    .{@errorName(err)},
-                );
-                platform.inference_process_supervisor.restartWorker();
-            }
-            try io.sleep(std.Io.Duration.fromMilliseconds(10), .awake);
-        }
-    }
-};
+const HardCancellationWatchdog = @import("../hard_cancellation_watchdog.zig").HardCancellationWatchdog;
 
 pub const NodeConfig = struct {
     models_dir: []const u8 = "./models",
@@ -1236,7 +1132,7 @@ pub const NodeConfig = struct {
     allow_insecure_public_bind: bool = false,
     /// Permit artifacts whose compatibility cannot be proven by this build.
     /// Known incompatible or unsafe artifacts remain blocked.
-    allow_unknown_models: bool = false,
+    allow_unknown_models: bool = true,
     /// True only when this Node owns its whole process and may terminate it to
     /// interrupt a wedged driver. Production sets this in a supervised worker;
     /// disposable CLI tools may opt in directly. Embedded database nodes must


### PR DESCRIPTION
Restore Metal CLI loading and Florence OCR, and make serving admission depend on the executable artifact contract rather than exact model qualification receipts. On rc.4, an otherwise valid Qwen3 download could be rejected, CLI Metal loads returned `ProcessIsolationRequired`, and Florence's Metal decoder rejected its f16 final logits bias.

- Give offline coordinated loads a real process cancellation watchdog; preserve embedded-process isolation restrictions.
- Share an owned f32 materialization of native f16/bf16 storage across host views, host fallback, and Metal upload. Preserve native bytes and let aliases outlive their source. Preserve `UnsupportedTensorType` across the runtime boundary.
- Remove Qwen receipt/hash/variant serving allowlists. Attempt unknown architectures by default while retaining artifact, tensor, graph, backend, and known unsafe-runtime checks.
- Require canonical `owner/model[:variant]` pull references and preserve the executable embedding profile in pinned BF16 downloads. Keep download integrity and atomic publication independent of qualification.
- Document the distinction between download integrity, runtime compatibility, and benchmark qualification.

Validation: 36 focused admission/pull/Metal tests, 7 stable runtime ABI tests, and 162 database enrichment tests pass. A real Florence fixture reads `HELLO` on Metal after failing with `UnsupportedTensorType` on official rc.4. The repaired CLI embeds with Metal; canonical `Qwen/Qwen3-Embedding-0.6B-GGUF` pull succeeds. The final debug standalone server ingests a loopback URL-backed, image-only 16-page PDF with 16 successful OCR pages, zero OCR failures, 16 chunks, and a successful full-text query. Both canonical GGUF and BF16 Qwen3 models return 1024-dimensional embeddings on Metal (BF16 checked with a 16 GiB process budget).

The materialized-chunk ownership fix is already on the base branch via #653. The retained nyx corpus was not available locally; these checks do not constitute a full OHR rerun or Qwen latency qualification.

The native-dense view regression is covered by 24 passing focused tests on Metal: f16/bf16 reshape after source release, borrowed and owned backing, composed transpose/reshape/slice/broadcast, host/device numerical agreement, and allocation-failure cleanup. The real Florence Metal OCR fixture also passes after this change. The standalone PDF and Qwen smoke tests above used commit `8a4b2d8`; the final shared tensor change was validated with these focused tests and the OCR fixture.
