### PR TITLE
Share accelerated Zig checksums and enforce usage in CI

### DIFF
--- a/.github/workflows/zig-tests.yml
+++ b/.github/workflows/zig-tests.yml
@@ -338,7 +338,9 @@ jobs:
 
       - name: Test baseline checksum runtime dispatch
         working-directory: zig
-        run: zig build lib-hash-test -Dcpu=baseline -Doptimize=ReleaseSafe
+        run: |
+          zig test lib/hash/src/mod.zig -O Debug -mcpu=baseline -fno-llvm
+          zig build lib-hash-test -Dcpu=baseline -Doptimize=ReleaseSafe
 
       - name: Check generated sources
         run: make zig-generated-check

--- a/.github/workflows/zig-tests.yml
+++ b/.github/workflows/zig-tests.yml
@@ -113,6 +113,8 @@ jobs:
             ':(glob)zig/**' \
             ':(exclude,glob)zig/pkg/antfly/antfarm/**' \
             ':(glob)scripts/ci/zig-*.sh' \
+            scripts/ci/check_zig_checksum_usage.py \
+            scripts/ci/test_check_zig_checksum_usage.py \
             scripts/ci/toolchain-policy.json \
             .github/actions/load-toolchain-policy/action.yml \
             scripts/test-backup-s3-integration.sh \
@@ -255,7 +257,7 @@ jobs:
         run: |
           set -euo pipefail
           sudo apt-get update
-          sudo apt-get install -y ca-certificates curl xz-utils
+          sudo apt-get install -y ca-certificates curl xz-utils python3 make
           curl -fsSL \
             "https://ziglang.org/download/${ZIG_VERSION}/zig-aarch64-linux-${ZIG_VERSION}.tar.xz" \
             -o "$RUNNER_TEMP/zig.tar.xz"
@@ -278,6 +280,14 @@ jobs:
           zig test -O ReleaseFast zig/pkg/antfly/src/encoding/streamvbyte.zig
           zig test zig/pkg/antfly/src/encoding/chunked_coder.zig
           zig test -O ReleaseFast zig/pkg/antfly/src/encoding/chunked_coder.zig
+
+      - name: Check shared checksum usage
+        run: make zig-checksums-check
+
+      - name: Test baseline ARM64 checksum runtime dispatch
+        run: |
+          zig test zig/lib/hash/src/mod.zig -O ReleaseSafe -mcpu=baseline
+          zig test zig/lib/hash/src/mod.zig -O ReleaseSafe -mcpu=baseline -lc
 
   zig-base-tests:
     name: zig-base / x86_64
@@ -322,6 +332,13 @@ jobs:
 
       - name: Verify Zig version
         run: zig version
+
+      - name: Check shared checksum usage
+        run: make zig-checksums-check
+
+      - name: Test baseline checksum runtime dispatch
+        working-directory: zig
+        run: zig build lib-hash-test -Dcpu=baseline -Doptimize=ReleaseSafe
 
       - name: Check generated sources
         run: make zig-generated-check

--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ help:
 # ====================================================================================
 
 .PHONY: build build-docs generate graph-identifier-generate graph-identifier-check fmt fmt-check repository-check lint license-headers license-check update-deps tidy tidy-check install-git-hooks build-antfarm build-antfarm-main release-scripting-test
-.PHONY: zig-build zig-test zig-unit-test zig-generate zig-openapi-generate zig-generated-check zig-openapi-check zig-snowball-check zig-license-headers zig-license-check zig-tla-check
+.PHONY: zig-build zig-test zig-unit-test zig-generate zig-openapi-generate zig-generated-check zig-openapi-check zig-snowball-check zig-license-headers zig-license-check zig-tla-check zig-checksums-check
 
 build-antfarm: build-antfarm-main
 
@@ -132,6 +132,10 @@ zig-generate:
 
 zig-openapi-generate:
 	$(ZIG_MAKE) openapi-generate
+
+zig-checksums-check:
+	python3 -m unittest discover -s scripts/ci -p test_check_zig_checksum_usage.py
+	python3 scripts/ci/check_zig_checksum_usage.py
 
 zig-generated-check: graph-identifier-check
 	$(ZIG_MAKE) generated-check

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -30,3 +30,37 @@ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
 CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
+
+
+## Chromium CRC32 folding implementation
+
+`zig/lib/hash/src/x86_crc32.zig` adapts the PCLMUL folding implementation
+from Chromium `third_party/zlib/crc32_simd.c`.
+
+Copyright 2017 The Chromium Authors
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google LLC nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/scripts/ci/check_zig_checksum_usage.py
+++ b/scripts/ci/check_zig_checksum_usage.py
@@ -1,0 +1,342 @@
+# Copyright 2026 Antfly, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Keep first-party checksum callers on antfly_hash, retaining std test oracles.
+
+This is a lexical policy check, not Zig type checking. It recognizes ordinary
+aliases of std/hash/crc and literal @field access, skips comments and strings,
+and exempts test blocks and the shared checksum implementation itself. New
+checksum algorithms with different polynomials are outside this policy.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+TOKEN = re.compile(
+    r"(?P<skip>\s+|//[^\n]*|\\\\[^\n]*)"
+    r'|(?P<quoted_identifier>@"(?:\\.|[^"\\])*")'
+    r'|(?P<string>"(?:\\.|[^"\\])*")'
+    r"|(?P<char>'(?:\\.|[^'\\])*')"
+    r"|(?P<identifier>@?[A-Za-z_][A-Za-z_0-9]*)"
+    r"|(?P<number>0[xX][0-9a-fA-F_]+|[0-9][0-9_]*)"
+    r"|(?P<punct>.)"
+)
+REPLACEMENTS = {
+    "std.hash.Crc32": "Crc32",
+    "std.hash.crc.Crc32": "Crc32",
+    "std.hash.crc.Crc32IsoHdlc": "Crc32",
+    "std.hash.crc.Crc32Iscsi": "Crc32c",
+    "std.hash.crc.Crc64Nvme": "Crc64Nvme",
+    "std.hash.Adler32": "Adler32",
+}
+POLYNOMIALS = {
+    0x04C11DB7: "Crc32",
+    0x1EDC6F41: "Crc32c",
+    0xAD93D23594C93659: "Crc64Nvme",
+}
+SKIP_DIRS = {"zig-out", "node_modules", "__pycache__"}
+
+
+@dataclass(frozen=True)
+class Token:
+    kind: str
+    value: str
+    offset: int
+
+
+def tokens(source: str) -> list[Token]:
+    result = []
+    for match in TOKEN.finditer(source):
+        kind = match.lastgroup
+        if kind == "skip":
+            continue
+        value = match.group()
+        if kind == "quoted_identifier":
+            value = value[2:-1]
+        result.append(Token(kind, value, match.start()))
+    return result
+
+
+def expression(ts: list[Token], start: int, aliases: dict[str, str]) -> tuple[str, int]:
+    """Resolve a std import/alias and its field chain, without evaluating Zig."""
+    if start >= len(ts):
+        return "", start
+    value = ts[start].value
+    end = start + 1
+    if value == "@import" and [t.value for t in ts[start + 1 : start + 4]] == [
+        "(",
+        '"std"',
+        ")",
+    ]:
+        path, end = "std", start + 4
+    elif value == "@field" and start + 1 < len(ts) and ts[start + 1].value == "(":
+        path, end = expression(ts, start + 2, aliases)
+        if (
+            not path
+            or end + 2 >= len(ts)
+            or ts[end].value != ","
+            or ts[end + 1].kind != "string"
+            or ts[end + 2].value != ")"
+        ):
+            return "", start + 1
+        path += "." + ts[end + 1].value[1:-1]
+        end += 3
+    elif ts[start].kind in {"identifier", "quoted_identifier"}:
+        path = aliases.get(value, "")
+    else:
+        return "", end
+    if not path:
+        return "", end
+    while (
+        end + 1 < len(ts)
+        and ts[end].value == "."
+        and ts[end + 1].kind in {"identifier", "quoted_identifier"}
+    ):
+        path += "." + ts[end + 1].value
+        end += 2
+    return path, end
+
+
+def generic_replacement(ts: list[Token], start: int) -> str | None:
+    if start + 2 >= len(ts) or ts[start].value != "(":
+        return None
+    width = ts[start + 1].value
+    if width not in {"u32", "u64"} or ts[start + 2].value != ",":
+        return None
+    fields = {}
+    depth = 0
+    for index in range(start, len(ts)):
+        token = ts[index]
+        if token.kind == "punct":
+            if token.value == "(":
+                depth += 1
+            elif token.value == ")":
+                depth -= 1
+                if depth == 0:
+                    break
+        if index + 3 < len(ts) and token.value == "." and ts[index + 2].value == "=":
+            value = ts[index + 3]
+            # Only recognize literal complete values, not computed expressions.
+            if index + 4 >= len(ts) or ts[index + 4].value not in {",", "}"}:
+                continue
+            if value.kind == "number":
+                number = value.value.replace("_", "")
+                fields[ts[index + 1].value] = int(
+                    number, 16 if number.lower().startswith("0x") else 10
+                )
+            elif value.value in {"true", "false"}:
+                fields[ts[index + 1].value] = value.value == "true"
+    # The polynomial alone does not identify a CRC. Preserve variants such as
+    # CRC32/MPEG-2, which share IEEE's polynomial but use different parameters.
+    mask = (1 << int(width[1:])) - 1
+    if (
+        fields.get("initial") == mask
+        and fields.get("xor_output") == mask
+        and fields.get("reflect_input") is True
+        and fields.get("reflect_output") is True
+    ):
+        replacement = POLYNOMIALS.get(fields.get("polynomial"))
+        if replacement and (width == "u64") == (replacement == "Crc64Nvme"):
+            return replacement
+    return None
+
+
+def delimiter_pairs(ts: list[Token]) -> dict[int, int]:
+    pairs = {}
+    stack = []
+    for index, token in enumerate(ts):
+        if token.kind != "punct":
+            continue
+        if token.value in {"(", "[", "{"}:
+            stack.append(index)
+        elif token.value in {")", "]", "}"} and stack:
+            opening = stack.pop()
+            pairs[opening] = index
+            pairs[index] = opening
+    return pairs
+
+
+def declaration(
+    ts: list[Token], index: int, pairs: dict[int, int]
+) -> tuple[str, int] | None:
+    """Find an initializer, including declarations with explicit type annotations."""
+    if (
+        ts[index].kind != "identifier"
+        or ts[index].value not in {"const", "var"}
+        or index + 2 >= len(ts)
+        or ts[index + 1].kind not in {"identifier", "quoted_identifier"}
+    ):
+        return None
+    cursor = index + 2
+    if ts[cursor].value == ":":
+        cursor += 1
+        while cursor < len(ts) and ts[cursor].value not in {"=", ";", "}"}:
+            cursor = pairs[cursor] + 1 if pairs.get(cursor, -1) > cursor else cursor + 1
+    if cursor < len(ts) and ts[cursor].value == "=":
+        return ts[index + 1].value, cursor + 1
+    return None
+
+
+def container_body(ts: list[Token], opening: int, pairs: dict[int, int]) -> bool:
+    previous = opening - 1
+    if previous >= 0 and ts[previous].value == ")":
+        previous = pairs.get(previous, previous) - 1
+    return (
+        previous >= 0
+        and ts[previous].kind == "identifier"
+        and ts[previous].value in {"struct", "union", "enum", "opaque"}
+    )
+
+
+def container_aliases(
+    ts: list[Token],
+    start: int,
+    end: int,
+    inherited: dict[str, str],
+    pairs: dict[int, int],
+) -> dict[str, str]:
+    """Resolve container declarations before scanning uses; locals stay sequential."""
+    declarations = {}
+    index = start
+    while index < end:
+        if binding := declaration(ts, index, pairs):
+            name, initializer = binding
+            declarations[name] = initializer
+        # Do not collect declarations from nested containers, functions or tests.
+        index = pairs[index] + 1 if pairs.get(index, -1) > index else index + 1
+    aliases = inherited.copy()
+    for name in declarations:
+        aliases.pop(name, None)
+    # An alias may depend on another declared later, including multiple hops.
+    # The bound also makes invalid cyclic declarations terminate predictably.
+    for _ in range(len(declarations)):
+        changed = False
+        for name, initializer in declarations.items():
+            path, _ = expression(ts, initializer, aliases)
+            if aliases.get(name, "") != path:
+                if path:
+                    aliases[name] = path
+                else:
+                    aliases.pop(name, None)
+                changed = True
+        if not changed:
+            break
+    return aliases
+
+
+def violations(source: str) -> list[tuple[int, str, str]]:
+    # Every supported checksum reference (including the generic Crc factory)
+    # contains one of these names. Avoid tokenizing unrelated generated files.
+    if "Crc" not in source and "Adler32" not in source:
+        return []
+    ts = tokens(source)
+    pairs = delimiter_pairs(ts)
+    scopes = [container_aliases(ts, 0, len(ts), {}, pairs)]
+    found = []
+    index = 0
+    while index < len(ts):
+        token = ts[index]
+        # test "name" { ... } and unnamed test { ... }, including nested braces.
+        if token.kind == "identifier" and token.value == "test":
+            body = index + 1
+            if body < len(ts) and ts[body].kind == "string":
+                body += 1
+            if body < len(ts) and ts[body].value == "{":
+                depth = 1
+                index = body + 1
+                while index < len(ts) and depth:
+                    if ts[index].kind == "punct":
+                        depth += (ts[index].value == "{") - (ts[index].value == "}")
+                    index += 1
+                continue
+        if token.kind == "punct" and token.value == "{":
+            aliases = scopes[-1].copy()
+            if container_body(ts, index, pairs):
+                aliases = container_aliases(
+                    ts, index + 1, pairs.get(index, len(ts)), aliases, pairs
+                )
+            scopes.append(aliases)
+        elif token.kind == "punct" and token.value == "}" and len(scopes) > 1:
+            scopes.pop()
+        # Resolve namespace aliases; clear aliases shadowed by unrelated locals.
+        if binding := declaration(ts, index, pairs):
+            name, initializer = binding
+            path, _ = expression(ts, initializer, scopes[-1])
+            if path:
+                scopes[-1][name] = path
+            else:
+                scopes[-1].pop(name, None)
+            # Check the annotation and initializer, not the newly declared name.
+            index += 2
+            continue
+        path, end = expression(ts, index, scopes[-1])
+        replacement = next(
+            (
+                new
+                for old, new in REPLACEMENTS.items()
+                if path == old or path.startswith(old + ".")
+            ),
+            None,
+        )
+        if path == "std.hash.crc.Crc":
+            replacement = generic_replacement(ts, end)
+        if replacement:
+            found.append((source.count("\n", 0, token.offset) + 1, path, replacement))
+        index = max(index + 1, end)
+    return found
+
+
+def check(root: Path) -> list[str]:
+    errors = []
+    for path in sorted((root / "zig").rglob("*.zig")):
+        relative = path.relative_to(root)
+        if any(part.startswith(".") or part in SKIP_DIRS for part in relative.parts):
+            continue
+        # This module owns the kernels and their standard-library oracles.
+        if relative.parts[:3] == ("zig", "lib", "hash"):
+            continue
+        for line, original, replacement in violations(path.read_text()):
+            errors.append(
+                f'{relative}:{line}: use @import("antfly_hash").{replacement} instead of {original}'
+            )
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--root", type=Path, default=Path(__file__).resolve().parents[2]
+    )
+    args = parser.parse_args()
+    if not (args.root / "zig").is_dir():
+        parser.error(f"missing Zig tree: {args.root / 'zig'}")
+    errors = check(args.root)
+    if errors:
+        print("\n".join(errors), file=sys.stderr)
+        print(
+            "Keep std checksum oracles inside test blocks or zig/lib/hash.",
+            file=sys.stderr,
+        )
+        return 1
+    print("Zig checksum usage: all production callers use antfly_hash")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/test_check_zig_checksum_usage.py
+++ b/scripts/ci/test_check_zig_checksum_usage.py
@@ -1,0 +1,205 @@
+# Copyright 2026 Antfly, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from check_zig_checksum_usage import check, violations
+
+
+class ChecksumUsageTests(unittest.TestCase):
+    def test_direct_and_namespace_aliases_are_rejected(self):
+        for expression in (
+            "std.hash.Crc32.hash(data)",
+            "std.hash.crc.Crc32IsoHdlc.hash(data)",
+            "std.hash.crc.Crc32Iscsi.hash(data)",
+            "std.hash.crc.Crc64Nvme.hash(data)",
+            "std.hash.Adler32.hash(data)",
+            '@import("std").hash.Crc32.hash(data)',
+            '@field(std.hash, "Crc32").hash(data)',
+            'std.@"hash".@"Crc32".hash(data)',
+        ):
+            with self.subTest(expression=expression):
+                self.assertTrue(
+                    violations('const std = @import("std");\n' + expression)
+                )
+        self.assertTrue(
+            violations(
+                'const s = @import("std"); const h = s.hash; const c = h.crc; c.Crc32Iscsi.hash(data);'
+            )
+        )
+
+    def test_generic_nvme_and_ieee_are_rejected_but_other_crcs_are_allowed(self):
+        for width, polynomial, mask in (
+            ("u64", "0xad93_d235_94c9_3659", "0xffff_ffff_ffff_ffff"),
+            ("u32", "0x04c11db7", "0xffff_ffff"),
+            ("u32", "0x1edc6f41", "0xffff_ffff"),
+        ):
+            source = (
+                'const s = @import("std"); const C = s.hash.crc.Crc; C('
+                + width
+                + ", .{ .polynomial = "
+                + polynomial
+                + ", .initial = "
+                + mask
+                + ", .xor_output = "
+                + mask
+                + ", .reflect_input = true, .reflect_output = true"
+                + " });"
+            )
+            self.assertEqual(len(violations(source)), 1)
+            self.assertFalse(
+                violations(
+                    source.replace(".reflect_input = true", ".reflect_input = false")
+                )
+            )
+            self.assertFalse(
+                violations(source.replace(".xor_output = " + mask, ".xor_output = 0"))
+            )
+        self.assertFalse(
+            violations(
+                'const s = @import("std"); s.hash.crc.Crc(u16, .{ .polynomial = 0x8005 });'
+            )
+        )
+
+    def test_comments_strings_and_nested_test_blocks_are_ignored(self):
+        self.assertFalse(
+            violations(r"""
+const std = @import("std");
+// std.hash.Crc32.hash(bytes)
+const text = "std.hash.Crc32 }";
+const multiline =
+    \\std.hash.Adler32.hash(bytes) }
+;
+test "oracle" {
+    const nested = struct { fn check() void { _ = std.hash.Crc32.hash("}"); } };
+    _ = nested;
+}
+test { _ = std.hash.Adler32.hash("{"); }
+""")
+        )
+        found = violations(
+            'const std = @import("std");\ntest { _ = std.hash.Crc32.hash("}"); }\nconst bad = std.hash.Crc32.hash(data);'
+        )
+        self.assertEqual(len(found), 1)
+        self.assertEqual(found[0][0], 3)
+
+    def test_unrelated_hashes_and_shared_api_are_allowed(self):
+        self.assertFalse(
+            violations(
+                'const std = @import("std"); std.hash.Wyhash.hash(0, data); std.hash.XxHash64.hash(0, data); std.crypto.hash.sha2.Sha256.hash(data, &out, .{}); @import("antfly_hash").Crc32.hash(data);'
+            )
+        )
+
+    def test_alias_scope_does_not_leak(self):
+        source = 'const s = @import("std"); fn a() void { const h = s.hash; _ = h.Wyhash; } fn b() void { const h = unrelated; _ = h.Crc32; }'
+        self.assertFalse(violations(source))
+
+    def test_forward_container_declarations_are_resolved(self):
+        sources = (
+            'pub fn checksum(data: []const u8) u32 { return std.hash.Crc32.hash(data); }\nconst std = @import("std");',
+            'pub fn checksum(data: []const u8) u32 { return h.Crc32.hash(data); }\nconst h = s.hash; const s = @import("std");',
+            'const S = struct { pub fn checksum(data: []const u8) u32 { return h.Crc32.hash(data); }\nconst h = s.hash; }; const s = @import("std");',
+            'const S = union(enum) { value: u32, pub fn checksum(data: []const u8) u32 { return h.Crc32.hash(data); }\nconst h = s.hash; }; const s = @import("std");',
+        )
+        for source in sources:
+            with self.subTest(source=source):
+                found = violations(source)
+                self.assertEqual(len(found), 1)
+                self.assertEqual(found[0][2], "Crc32")
+
+    def test_explicitly_typed_namespace_aliases_are_resolved(self):
+        for source in (
+            'const s: type = @import("std"); const h: type = s.hash; h.Adler32.hash(data);',
+            'pub fn checksum(data: []const u8) u32 { return h.Crc32.hash(data); } const h: type = std.hash; const std = @import("std");',
+            'const s = @import("std"); fn checksum(data: []const u8) u32 { const h: type = s.hash; return h.crc.Crc32Iscsi.hash(data); }',
+        ):
+            with self.subTest(source=source):
+                self.assertEqual(len(violations(source)), 1)
+
+    def test_precollection_preserves_scope_and_test_exemptions(self):
+        self.assertFalse(
+            violations("""
+const s = @import("std");
+const h = unrelated;
+fn checksum() void { _ = h.Crc32; }
+fn local() void { const h2: type = s.hash; _ = h2.Wyhash; }
+fn sibling() void { _ = h2.Crc32; }
+test "oracle" { const h: type = s.hash; _ = h.Crc32.hash("data"); }
+const S = struct { const h: type = s.hash; };
+""")
+        )
+        self.assertFalse(violations("const a = b; const b = a;"))
+
+    def test_checksum_types_in_annotations_are_still_rejected(self):
+        source = 'const std = @import("std"); var crc: std.hash.Crc32 = .{};'
+        self.assertEqual(len(violations(source)), 1)
+
+    def test_cli_rejects_the_review_reproducer(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "zig").mkdir()
+            (
+                root / "zig/caller.zig"
+            ).write_text("""pub fn checksum(data: []const u8) u32 { return h.Crc32.hash(data); }
+const std = @import("std");
+const h: type = std.hash;
+test "oracle" { _ = std.hash.Crc32.hash("123456789"); }
+""")
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(Path(__file__).with_name("check_zig_checksum_usage.py")),
+                    "--root",
+                    str(root),
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("zig/caller.zig:1:", result.stderr)
+            self.assertNotIn("zig/caller.zig:4:", result.stderr)
+
+    def test_quoted_test_identifier_does_not_hide_production_code(self):
+        source = 'const std = @import("std"); const @"test" = struct { const crc = std.hash.Crc32; };'
+        self.assertTrue(violations(source))
+
+    def test_cli_scans_production_and_exempts_only_the_checksum_implementation(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "zig/lib/hash").mkdir(parents=True)
+            source = 'const std = @import("std"); const Crc32 = std.hash.Crc32;'
+            (root / "zig/lib/hash/oracle.zig").write_text(source)
+            self.assertFalse(check(root))
+            (root / "zig/caller.zig").write_text(source)
+            command = [
+                sys.executable,
+                str(Path(__file__).with_name("check_zig_checksum_usage.py")),
+                "--root",
+                str(root),
+            ]
+            result = subprocess.run(
+                command, capture_output=True, text=True, check=False
+            )
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("zig/caller.zig:1:", result.stderr)
+            self.assertIn('@import("antfly_hash").Crc32', result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/zig/build.zig
+++ b/zig/build.zig
@@ -758,6 +758,7 @@ const AntflyRootImports = struct {
     bloom: *std.Build.Module,
     vector: *std.Build.Module,
     vectorindex: *std.Build.Module,
+    hash: *std.Build.Module,
     matcher: *std.Build.Module,
     resolver: *std.Build.Module,
     casbin: *std.Build.Module,
@@ -829,6 +830,7 @@ const AntflyRootImports = struct {
         .{ .name = "bloom", .field = "bloom" },
         .{ .name = "antfly_vector", .field = "vector" },
         .{ .name = "antfly_vectorindex", .field = "vectorindex" },
+        .{ .name = "antfly_hash", .field = "hash" },
         .{ .name = "antfly_matcher", .field = "matcher" },
         .{ .name = "antfly_resolver", .field = "resolver" },
         .{ .name = "antfly_casbin", .field = "casbin" },
@@ -1717,6 +1719,23 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
     wasm_vector_mod.addImport("protobuf", protobuf_mod);
+    const hash_mod = b.createModule(.{
+        .root_source_file = b.path("lib/hash/src/mod.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    const wasm_hash_mod = b.createModule(.{
+        .root_source_file = b.path("lib/hash/src/mod.zig"),
+        .target = wasm_target,
+        .optimize = optimize,
+    });
+    // Standalone benchmark roots force ReleaseFast even when the root build
+    // defaults to Debug. Keep their checksum dependency equally optimized.
+    const hash_bench_mod = if (optimize == .ReleaseFast) hash_mod else b.createModule(.{
+        .root_source_file = b.path("lib/hash/src/mod.zig"),
+        .target = target,
+        .optimize = .ReleaseFast,
+    });
     const vectorindex_mod = b.createModule(.{
         .root_source_file = b.path("lib/vectorindex/src/mod.zig"),
         .target = target,
@@ -1749,6 +1768,7 @@ pub fn build(b: *std.Build) void {
     });
     storage_mod.addImport("bloom", bloom_mod);
     storage_mod.addImport("antfly_platform", platform_mod);
+    storage_mod.addImport("antfly_hash", hash_mod);
     const usermgr_mod = b.createModule(.{
         .root_source_file = b.path("pkg/antfly/src/usermgr/mod.zig"),
         .target = target,
@@ -1873,6 +1893,7 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
     });
+    image_mod.addImport("antfly_hash", hash_mod);
     const pdf_mod = b.createModule(.{
         .root_source_file = b.path("lib/pdf/src/mod.zig"),
         .target = target,
@@ -1901,6 +1922,7 @@ pub fn build(b: *std.Build) void {
         .target = wasm_target,
         .optimize = optimize,
     });
+    wasm_image_mod.addImport("antfly_hash", wasm_hash_mod);
     const wasm_pdf_mod = b.createModule(.{
         .root_source_file = b.path("lib/pdf/src/mod.zig"),
         .target = wasm_target,
@@ -1997,6 +2019,7 @@ pub fn build(b: *std.Build) void {
             .regex = regex_mod,
             .jsonschema = jsonschema_mod,
             .image = image_mod,
+            .hash = hash_mod,
             .prometheus = prometheus_mod,
             .structlog = structlog_mod,
             .jinja = inference_jinja_mod,
@@ -2118,6 +2141,7 @@ pub fn build(b: *std.Build) void {
         .bloom = bloom_mod,
         .vector = vector_mod,
         .vectorindex = vectorindex_mod,
+        .hash = hash_mod,
         .matcher = matcher_mod,
         .resolver = resolver_mod,
         .casbin = casbin_mod,
@@ -2299,6 +2323,7 @@ pub fn build(b: *std.Build) void {
         bloom_mod,
         vector_mod,
         vectorindex_mod,
+        hash_mod,
         vellum_mod,
         regex_mod,
         image_mod,
@@ -2384,6 +2409,7 @@ pub fn build(b: *std.Build) void {
         wasm_bloom_mod,
         wasm_vector_mod,
         wasm_vectorindex_mod,
+        wasm_hash_mod,
         vellum_mod,
         regex_mod,
         wasm_image_mod,
@@ -2946,6 +2972,7 @@ pub fn build(b: *std.Build) void {
     });
     common_http_test_mod.addImport("raft_engine", raft_engine_mod);
     common_http_test_mod.addImport("antfly_platform", platform_mod);
+    common_http_test_mod.addImport("antfly_hash", hash_mod);
     common_http_test_mod.addImport("httpx", httpx_mod);
     const common_http_tests = b.addTest(.{
         .root_module = common_http_test_mod,
@@ -3126,6 +3153,14 @@ pub fn build(b: *std.Build) void {
     const lib_embeddings_test_step = b.step("lib-embeddings-test", "Run standalone lib/embeddings tests");
     lib_embeddings_test_step.dependOn(&run_lib_embeddings_tests.step);
 
+    const lib_hash_tests = b.addTest(.{
+        .root_module = hash_mod,
+        .filters = b.args orelse &.{},
+    });
+    const run_lib_hash_tests = b.addRunArtifact(lib_hash_tests);
+    const lib_hash_test_step = b.step("lib-hash-test", "Run standalone lib/hash tests");
+    lib_hash_test_step.dependOn(&run_lib_hash_tests.step);
+
     const lib_vectorindex_tests = b.addTest(.{
         .root_module = vectorindex_mod,
     });
@@ -3172,6 +3207,18 @@ pub fn build(b: *std.Build) void {
         .root_module = image_test_mod,
     });
     const run_lib_image_tests = b.addRunArtifact(lib_image_tests);
+    // A named image dependency does not discover its internal PNG tests.
+    // Compile PNG as a test root to verify its checksum/container integration.
+    const png_test_mod = b.createModule(.{
+        .root_source_file = b.path("lib/image/src/png.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    png_test_mod.addImport("antfly_hash", hash_mod);
+    const png_tests = b.addTest(.{ .root_module = png_test_mod });
+    const run_png_tests = b.addRunArtifact(png_tests);
+    b.step("lib-image-png-test", "Run PNG codec and checksum compatibility tests").dependOn(&run_png_tests.step);
+
     const jpeg2000_decode_test_mod = b.createModule(.{
         .root_source_file = b.path("lib/image/src/jpeg2000/decode.zig"),
         .target = target,
@@ -3188,6 +3235,7 @@ pub fn build(b: *std.Build) void {
     jpeg2000_decode_test_step.dependOn(&run_jpeg2000_decode_tests.step);
     const lib_image_test_step = b.step("lib-image-test", "Run shared image tests");
     lib_image_test_step.dependOn(&run_lib_image_tests.step);
+    lib_image_test_step.dependOn(&run_png_tests.step);
     lib_image_test_step.dependOn(&run_jpeg2000_decode_tests.step);
 
     const pdf_test_mod = b.createModule(.{
@@ -3220,6 +3268,7 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = .ReleaseFast,
     });
+    lib_image_bench_mod.addImport("antfly_hash", hash_bench_mod);
     lib_image_bench_mod.addOptions("build_options", lib_image_bench_build_options);
     if (lib_image_spng_paths) |spng_paths| {
         lib_image_bench_mod.addIncludePath(.{ .cwd_relative = spng_paths.include_dir });
@@ -3254,6 +3303,7 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = .ReleaseFast,
     });
+    pdf_bench_image_mod.addImport("antfly_hash", hash_bench_mod);
     const pdf_bench_font_mod = b.createModule(.{
         .root_source_file = b.path("lib/font/src/mod.zig"),
         .target = target,
@@ -3320,6 +3370,7 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
     });
+    lib_image_conformance_test_mod.addImport("antfly_hash", hash_mod);
     const lib_image_conformance_tests = b.addTest(.{
         .root_module = lib_image_conformance_test_mod,
         .filters = &.{"conformance corpus"},
@@ -3335,6 +3386,7 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
     });
+    lib_image_corpus_mod.addImport("antfly_hash", hash_mod);
     lib_image_corpus_mod.addOptions("build_options", lib_image_corpus_build_options);
     if (lib_image_spng_paths) |spng_paths| {
         lib_image_corpus_mod.addIncludePath(.{ .cwd_relative = spng_paths.include_dir });
@@ -7927,6 +7979,7 @@ pub fn build(b: *std.Build) void {
     unit_test_step.dependOn(&run_lib_generating_tests.step);
     unit_test_step.dependOn(&run_lib_embeddings_tests.step);
     unit_test_step.dependOn(&run_lib_vectorindex_tests.step);
+    unit_test_step.dependOn(&run_lib_hash_tests.step);
     unit_test_step.dependOn(&run_vector_cancellation_tests.step);
     unit_test_step.dependOn(&run_lib_chunking_tests.step);
     unit_test_step.dependOn(&run_lib_generating_runtime_tests.step);
@@ -7967,6 +8020,7 @@ pub fn build(b: *std.Build) void {
     unit_test_step.dependOn(&run_lib_mcp_tests.step);
     unit_test_step.dependOn(&run_lib_a2a_tests.step);
     unit_test_step.dependOn(&run_lib_image_tests.step);
+    unit_test_step.dependOn(&run_png_tests.step);
     unit_test_step.dependOn(&run_jpeg2000_decode_tests.step);
     unit_test_step.dependOn(&run_lib_pdf_tests.step);
     unit_test_step.dependOn(&run_lib_scraping_tests.step);
@@ -8024,7 +8078,7 @@ pub fn build(b: *std.Build) void {
     const lmdb_test_step = b.step("lmdb-test", "Run Zig LMDB port unit tests");
     lmdb_test_step.dependOn(&run_lmdb_unit_tests.step);
 
-    const storage_lmdb_test_mod = makeLmdbModule(b, "pkg/antfly/src/storage/lmdb.zig", target, optimize, build_options, lmdb_engine_mod, platform_mod);
+    const storage_lmdb_test_mod = makeLmdbModule(b, "pkg/antfly/src/storage/lmdb.zig", target, optimize, build_options, lmdb_engine_mod, platform_mod, hash_mod);
     const storage_lmdb_unit_tests = b.addTest(.{
         .root_module = storage_lmdb_test_mod,
     });
@@ -8055,7 +8109,7 @@ pub fn build(b: *std.Build) void {
 
     const storage_lmdb_soak_build_options = makeLmdbBuildOptions(b, lmdb_backend, lmdb_evented_async_io, true);
     const storage_lmdb_soak_engine_mod = makeLmdbEngineModule(b, target, optimize, true, storage_lmdb_soak_build_options);
-    const storage_lmdb_soak_test_mod = makeLmdbModule(b, "pkg/antfly/src/storage/lmdb.zig", target, optimize, storage_lmdb_soak_build_options, storage_lmdb_soak_engine_mod, platform_mod);
+    const storage_lmdb_soak_test_mod = makeLmdbModule(b, "pkg/antfly/src/storage/lmdb.zig", target, optimize, storage_lmdb_soak_build_options, storage_lmdb_soak_engine_mod, platform_mod, hash_mod);
     const storage_lmdb_soak_tests = b.addTest(.{
         .root_module = storage_lmdb_soak_test_mod,
         .filters = &.{"LMDB sim soak stays green"},
@@ -8064,7 +8118,7 @@ pub fn build(b: *std.Build) void {
     const storage_lmdb_soak_step = b.step("lmdb-sim-soak", "Run only the LMDB simulation soak test");
     storage_lmdb_soak_step.dependOn(&run_storage_lmdb_soak_tests.step);
 
-    const docstore_test_mod = makeLmdbModule(b, "pkg/antfly/src/docstore_test_root.zig", target, optimize, build_options, lmdb_engine_mod, platform_mod);
+    const docstore_test_mod = makeLmdbModule(b, "pkg/antfly/src/docstore_test_root.zig", target, optimize, build_options, lmdb_engine_mod, platform_mod, hash_mod);
     docstore_test_mod.addImport("bloom", bloom_mod);
     const docstore_unit_tests = b.addTest(.{
         .root_module = docstore_test_mod,
@@ -8074,7 +8128,7 @@ pub fn build(b: *std.Build) void {
     const docstore_test_step = b.step("docstore-test", "Run storage/docstore unit tests");
     docstore_test_step.dependOn(&run_docstore_unit_tests.step);
 
-    const shard_test_mod = makeLmdbModule(b, "pkg/antfly/src/shard_test_root.zig", target, optimize, build_options, lmdb_engine_mod, platform_mod);
+    const shard_test_mod = makeLmdbModule(b, "pkg/antfly/src/shard_test_root.zig", target, optimize, build_options, lmdb_engine_mod, platform_mod, hash_mod);
     shard_test_mod.addImport("bloom", bloom_mod);
     const shard_unit_tests = b.addTest(.{
         .root_module = shard_test_mod,
@@ -8084,7 +8138,7 @@ pub fn build(b: *std.Build) void {
     const shard_test_step = b.step("shard-test", "Run storage/shard unit tests");
     shard_test_step.dependOn(&run_shard_unit_tests.step);
 
-    const wal_test_mod = makeLmdbModule(b, "pkg/antfly/src/wal_test_root.zig", target, optimize, build_options, lmdb_engine_mod, platform_mod);
+    const wal_test_mod = makeLmdbModule(b, "pkg/antfly/src/wal_test_root.zig", target, optimize, build_options, lmdb_engine_mod, platform_mod, hash_mod);
     wal_test_mod.addImport("bloom", bloom_mod);
     wal_test_mod.addImport("structlog", structlog_mod);
     const wal_unit_tests = b.addTest(.{
@@ -8136,7 +8190,7 @@ pub fn build(b: *std.Build) void {
 
     const wal_soak_build_options = makeLmdbBuildOptions(b, lmdb_backend, lmdb_evented_async_io, true);
     const wal_soak_engine_mod = makeLmdbEngineModule(b, target, optimize, true, wal_soak_build_options);
-    const wal_soak_test_mod = makeLmdbModule(b, "pkg/antfly/src/wal_test_root.zig", target, optimize, wal_soak_build_options, wal_soak_engine_mod, platform_mod);
+    const wal_soak_test_mod = makeLmdbModule(b, "pkg/antfly/src/wal_test_root.zig", target, optimize, wal_soak_build_options, wal_soak_engine_mod, platform_mod, hash_mod);
     wal_soak_test_mod.addImport("bloom", bloom_mod);
     const wal_soak_tests = b.addTest(.{
         .root_module = wal_soak_test_mod,
@@ -8151,7 +8205,7 @@ pub fn build(b: *std.Build) void {
     storage_sim_soak_step.dependOn(&run_wal_soak_tests.step);
     soak_test_step.dependOn(storage_sim_soak_step);
 
-    const persistent_test_mod = makeLmdbModule(b, "pkg/antfly/src/persistent_test_root.zig", target, optimize, build_options, lmdb_engine_mod, platform_mod);
+    const persistent_test_mod = makeLmdbModule(b, "pkg/antfly/src/persistent_test_root.zig", target, optimize, build_options, lmdb_engine_mod, platform_mod, hash_mod);
     persistent_test_mod.addImport("bloom", bloom_mod);
     persistent_test_mod.addImport("antfly_vellum", vellum_mod);
     persistent_test_mod.addImport("antfly_regex", regex_mod);
@@ -8213,7 +8267,7 @@ pub fn build(b: *std.Build) void {
 
     const persistent_soak_build_options = makeLmdbBuildOptions(b, lmdb_backend, lmdb_evented_async_io, true);
     const persistent_soak_engine_mod = makeLmdbEngineModule(b, target, optimize, true, persistent_soak_build_options);
-    const persistent_soak_test_mod = makeLmdbModule(b, "pkg/antfly/src/persistent_test_root.zig", target, optimize, persistent_soak_build_options, persistent_soak_engine_mod, platform_mod);
+    const persistent_soak_test_mod = makeLmdbModule(b, "pkg/antfly/src/persistent_test_root.zig", target, optimize, persistent_soak_build_options, persistent_soak_engine_mod, platform_mod, hash_mod);
     persistent_soak_test_mod.addImport("bloom", bloom_mod);
     persistent_soak_test_mod.addImport("antfly_vellum", vellum_mod);
     persistent_soak_test_mod.addImport("antfly_regex", regex_mod);
@@ -8230,7 +8284,7 @@ pub fn build(b: *std.Build) void {
 
     storage_sim_soak_step.dependOn(&run_persistent_soak_tests.step);
 
-    const index_manager_test_mod = makeLmdbModule(b, "pkg/antfly/src/index_manager_test_root.zig", target, optimize, build_options, lmdb_engine_mod, platform_mod);
+    const index_manager_test_mod = makeLmdbModule(b, "pkg/antfly/src/index_manager_test_root.zig", target, optimize, build_options, lmdb_engine_mod, platform_mod, hash_mod);
     addSnowballModule(b, index_manager_test_mod);
     index_manager_test_mod.addImport("bloom", bloom_mod);
     index_manager_test_mod.addImport("antfly_vellum", vellum_mod);
@@ -8291,7 +8345,7 @@ pub fn build(b: *std.Build) void {
     const index_manager_vopr_step = b.step("index-manager-vopr-test", "Run index manager modeled-storage VOPR smoke tests");
     index_manager_vopr_step.dependOn(&run_index_manager_vopr_tests.step);
 
-    const db_test_mod = makeLmdbModule(b, "pkg/antfly/src/db_test_root.zig", target, optimize, build_options, lmdb_engine_mod, platform_mod);
+    const db_test_mod = makeLmdbModule(b, "pkg/antfly/src/db_test_root.zig", target, optimize, build_options, lmdb_engine_mod, platform_mod, hash_mod);
     const transcribing_db_test_stub_mod = b.createModule(.{
         .root_source_file = b.path("pkg/antfly/src/testing/transcribing_stub.zig"),
         .target = target,
@@ -8553,7 +8607,7 @@ pub fn build(b: *std.Build) void {
     const db_split_replay_step = b.step("db-split-replay-fixtures", "Run only the DB split replay fixture tests");
     db_split_replay_step.dependOn(&run_db_split_replay_tests.step);
 
-    const sparse_test_mod = makeLmdbModule(b, "pkg/antfly/src/sparse_test_root.zig", target, optimize, build_options, lmdb_engine_mod, platform_mod);
+    const sparse_test_mod = makeLmdbModule(b, "pkg/antfly/src/sparse_test_root.zig", target, optimize, build_options, lmdb_engine_mod, platform_mod, hash_mod);
     sparse_test_mod.addImport("bloom", bloom_mod);
     const sparse_unit_tests = b.addTest(.{
         .root_module = sparse_test_mod,
@@ -8566,7 +8620,7 @@ pub fn build(b: *std.Build) void {
     const sparse_test_step = b.step("sparse-test", "Run sparse index unit tests");
     sparse_test_step.dependOn(&run_sparse_unit_tests.step);
 
-    const derived_log_test_mod = makeLmdbModule(b, "pkg/antfly/src/derived_log_test_root.zig", target, optimize, build_options, lmdb_engine_mod, platform_mod);
+    const derived_log_test_mod = makeLmdbModule(b, "pkg/antfly/src/derived_log_test_root.zig", target, optimize, build_options, lmdb_engine_mod, platform_mod, hash_mod);
     derived_log_test_mod.addImport("bloom", bloom_mod);
     const derived_log_unit_tests = b.addTest(.{
         .root_module = derived_log_test_mod,
@@ -9230,7 +9284,7 @@ pub fn build(b: *std.Build) void {
     const lmdb_bench_engine_options_c = makeLmdbBuildOptions(b, .c, false, false);
     const lmdb_bench_build_options_c = makeRootBuildOptions(b, .c, false, false, false, true, false, lite_local_inference_runtime, true, antfly_version);
     const lmdb_bench_engine_mod_c = makeLmdbEngineModule(b, target, .ReleaseFast, true, lmdb_bench_engine_options_c);
-    const lmdb_bench_wrapper_mod_c = makeLmdbModule(b, "pkg/antfly/src/storage/lmdb.zig", target, .ReleaseFast, lmdb_bench_build_options_c, lmdb_bench_engine_mod_c, platform_mod);
+    const lmdb_bench_wrapper_mod_c = makeLmdbModule(b, "pkg/antfly/src/storage/lmdb.zig", target, .ReleaseFast, lmdb_bench_build_options_c, lmdb_bench_engine_mod_c, platform_mod, hash_bench_mod);
     const lmdb_bench_mod_c = b.createModule(.{
         .root_source_file = b.path("bench/storage/lmdb_bench.zig"),
         .target = target,
@@ -9247,7 +9301,7 @@ pub fn build(b: *std.Build) void {
     const lmdb_bench_engine_options_zig = makeLmdbBuildOptions(b, .zig, lmdb_evented_async_io, false);
     const lmdb_bench_build_options_zig = makeRootBuildOptions(b, .zig, lmdb_evented_async_io, false, false, true, false, lite_local_inference_runtime, true, antfly_version);
     const lmdb_bench_engine_mod_zig = makeLmdbEngineModule(b, target, .ReleaseFast, true, lmdb_bench_engine_options_zig);
-    const lmdb_bench_wrapper_mod_zig = makeLmdbModule(b, "pkg/antfly/src/storage/lmdb.zig", target, .ReleaseFast, lmdb_bench_build_options_zig, lmdb_bench_engine_mod_zig, platform_mod);
+    const lmdb_bench_wrapper_mod_zig = makeLmdbModule(b, "pkg/antfly/src/storage/lmdb.zig", target, .ReleaseFast, lmdb_bench_build_options_zig, lmdb_bench_engine_mod_zig, platform_mod, hash_bench_mod);
     const lmdb_bench_mod_zig = b.createModule(.{
         .root_source_file = b.path("bench/storage/lmdb_bench.zig"),
         .target = target,
@@ -9305,7 +9359,7 @@ pub fn build(b: *std.Build) void {
     const split_bench_engine_options = makeLmdbBuildOptions(b, lmdb_backend, lmdb_evented_async_io, false);
     const split_bench_build_options = makeRootBuildOptions(b, lmdb_backend, lmdb_evented_async_io, false, false, true, false, lite_local_inference_runtime, true, antfly_version);
     const split_bench_engine_mod = makeLmdbEngineModule(b, target, .ReleaseFast, true, split_bench_engine_options);
-    const split_bench_root_mod = makeLmdbModule(b, antfly_benches_build.split_bench_root, target, .ReleaseFast, split_bench_build_options, split_bench_engine_mod, platform_mod);
+    const split_bench_root_mod = makeLmdbModule(b, antfly_benches_build.split_bench_root, target, .ReleaseFast, split_bench_build_options, split_bench_engine_mod, platform_mod, hash_bench_mod);
     const split_bench_mod = b.createModule(.{
         .root_source_file = b.path("bench/storage/split_bench.zig"),
         .target = target,
@@ -9502,6 +9556,7 @@ pub fn build(b: *std.Build) void {
     });
     lsm_write_bench_root_mod.addImport("bloom", bloom_mod);
     lsm_write_bench_root_mod.addImport("antfly_platform", platform_mod);
+    lsm_write_bench_root_mod.addImport("antfly_hash", hash_bench_mod);
     lsm_write_bench_mod.addImport("antfly_zig", lsm_write_bench_root_mod);
     const lsm_write_bench = b.addExecutable(.{
         .name = "lsm_write_bench",
@@ -9563,6 +9618,7 @@ pub fn build(b: *std.Build) void {
     text_segment_bench_root_mod.addImport("bloom", bloom_mod);
     text_segment_bench_root_mod.addImport("antfly_vellum", vellum_mod);
     text_segment_bench_root_mod.addImport("antfly_platform", platform_mod);
+    text_segment_bench_root_mod.addImport("antfly_hash", hash_bench_mod);
     text_segment_write_bench_mod.addImport("antfly_text_bench", text_segment_bench_root_mod);
     const text_segment_write_bench = b.addExecutable(.{
         .name = "text_segment_write_bench",
@@ -9631,7 +9687,7 @@ pub fn build(b: *std.Build) void {
     const wal_bench_engine_options = makeLmdbBuildOptions(b, lmdb_backend, lmdb_evented_async_io, false);
     const wal_bench_build_options = makeRootBuildOptions(b, lmdb_backend, lmdb_evented_async_io, false, false, true, false, lite_local_inference_runtime, true, antfly_version);
     const wal_bench_engine_mod = makeLmdbEngineModule(b, target, .ReleaseFast, true, wal_bench_engine_options);
-    const wal_bench_wal_mod = makeLmdbModule(b, antfly_benches_build.wal_bench_root, target, .ReleaseFast, wal_bench_build_options, wal_bench_engine_mod, platform_mod);
+    const wal_bench_wal_mod = makeLmdbModule(b, antfly_benches_build.wal_bench_root, target, .ReleaseFast, wal_bench_build_options, wal_bench_engine_mod, platform_mod, hash_bench_mod);
     const wal_bench_mod = b.createModule(.{
         .root_source_file = b.path("bench/storage/wal_bench.zig"),
         .target = target,
@@ -9731,6 +9787,7 @@ pub fn build(b: *std.Build) void {
     derived_log_bench_root_mod.addImport("lmdb_engine", derived_log_bench_engine_mod);
     derived_log_bench_root_mod.addImport("bloom", bloom_mod);
     derived_log_bench_root_mod.addImport("antfly_platform", platform_mod);
+    derived_log_bench_root_mod.addImport("antfly_hash", hash_bench_mod);
     derived_log_bench_root_mod.link_libc = true;
     const derived_log_bench_mod = b.createModule(.{
         .root_source_file = b.path("bench/storage/derived_log_bench.zig"),
@@ -9891,6 +9948,7 @@ pub fn build(b: *std.Build) void {
     quickstart_bench_root_mod.addImport("antfly_vellum", vellum_mod);
     quickstart_bench_root_mod.addImport("bloom", bloom_mod);
     quickstart_bench_root_mod.addImport("antfly_platform", platform_mod);
+    quickstart_bench_root_mod.addImport("antfly_hash", hash_bench_mod);
     addSnowballModule(b, quickstart_bench_root_mod);
 
     const quickstart_bench_mod = b.createModule(.{
@@ -10330,6 +10388,7 @@ pub fn build(b: *std.Build) void {
     hbc_isolate_root_mod.addImport("antfly_vector", vector_mod);
     hbc_isolate_root_mod.addImport("antfly_vectorindex", vectorindex_mod);
     hbc_isolate_root_mod.addImport("antfly_platform", platform_mod);
+    hbc_isolate_root_mod.addImport("antfly_hash", hash_bench_mod);
     hbc_isolate_mod.addImport("antfly_hbc_isolate_root", hbc_isolate_root_mod);
 
     const hbc_isolate = b.addExecutable(.{
@@ -10405,6 +10464,7 @@ pub fn build(b: *std.Build) void {
     replay_bench_root_mod.addImport("antfly_reranking", reranking_mod);
     replay_bench_root_mod.addImport("antfly_scraping", scraping_mod);
     replay_bench_root_mod.addImport("antfly_platform", platform_mod);
+    replay_bench_root_mod.addImport("antfly_hash", hash_bench_mod);
     addSnowballModule(b, replay_bench_root_mod);
     replay_bench_mod.addImport("antfly-zig", replay_bench_root_mod);
 
@@ -10544,6 +10604,7 @@ pub fn build(b: *std.Build) void {
     algebraic_bench_root_mod.addImport("antfly_vellum", vellum_mod);
     algebraic_bench_root_mod.addImport("antfly_regex", regex_mod);
     algebraic_bench_root_mod.addImport("antfly_platform", platform_mod);
+    algebraic_bench_root_mod.addImport("antfly_hash", hash_bench_mod);
     algebraic_bench_root_mod.addImport("antfly_reranking", reranking_mod);
     algebraic_bench_root_mod.addImport("antfly_resolver", resolver_mod);
     algebraic_bench_root_mod.addImport("antfly_reader_config", reader_config_mod);
@@ -10802,6 +10863,7 @@ pub fn build(b: *std.Build) void {
     });
     provisioned_dense_ingest_guardrail_mod.addImport("antfly-zig", lib_mod);
     provisioned_dense_ingest_guardrail_mod.addImport("antfly_platform", platform_mod);
+    provisioned_dense_ingest_guardrail_mod.addImport("antfly_hash", hash_mod);
 
     const provisioned_dense_ingest_guardrail = b.addExecutable(.{
         .name = "provisioned_dense_ingest_guardrail",
@@ -11106,6 +11168,7 @@ pub fn build(b: *std.Build) void {
     antfly_main_mod.addImport("antfly-client", antfly_client_pkg_mod);
     antfly_main_mod.addImport("structlog", structlog_mod);
     antfly_main_mod.addImport("antfly_platform", platform_mod);
+    antfly_main_mod.addImport("antfly_hash", hash_mod);
     antfly_main_mod.addOptions("build_options", production_build_options);
     addMacosSdkPaths(b, antfly_main_mod, target);
 
@@ -11326,6 +11389,7 @@ pub fn build(b: *std.Build) void {
     lite_main_mod.addOptions("build_options", build_options);
     lite_main_mod.addImport("structlog", structlog_mod);
     lite_main_mod.addImport("antfly_platform", platform_mod);
+    lite_main_mod.addImport("antfly_hash", hash_mod);
     const lite_main = b.addExecutable(.{
         .name = "antfly-lite",
         .root_module = lite_main_mod,

--- a/zig/build.zig.zon
+++ b/zig/build.zig.zon
@@ -35,6 +35,7 @@
         "e2e/inference",
         "lib/audio",
         "lib/chunker",
+        "lib/hash",
         "lib/httpx",
         "lib/jinja",
         "lib/json",

--- a/zig/lib/chunker/src/png.zig
+++ b/zig/lib/chunker/src/png.zig
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 const std = @import("std");
+const Crc32 = @import("antfly_hash").Crc32;
+const Adler32 = @import("antfly_hash").Adler32;
 
 pub fn encodeRgba(alloc: std.mem.Allocator, width: u32, height: u32, rgba: []const u8) ![]u8 {
     const expected = @as(usize, width) * @as(usize, height) * 4;
@@ -75,7 +77,7 @@ fn encodeZlibNoCompression(alloc: std.mem.Allocator, payload: []const u8) ![]u8 
     }
 
     var checksum: [4]u8 = undefined;
-    std.mem.writeInt(u32, &checksum, std.hash.Adler32.hash(payload), .big);
+    std.mem.writeInt(u32, &checksum, Adler32.hash(payload), .big);
     try out.appendSlice(alloc, &checksum);
 
     return try out.toOwnedSlice(alloc);
@@ -94,7 +96,7 @@ fn appendChunk(alloc: std.mem.Allocator, out: *std.ArrayListUnmanaged(u8), name:
     @memcpy(crc_buf[name.len..], data);
 
     var crc: [4]u8 = undefined;
-    std.mem.writeInt(u32, &crc, std.hash.Crc32.hash(crc_buf), .big);
+    std.mem.writeInt(u32, &crc, Crc32.hash(crc_buf), .big);
     try out.appendSlice(alloc, &crc);
 }
 

--- a/zig/lib/hash/LICENSE.chromium
+++ b/zig/lib/hash/LICENSE.chromium
@@ -1,0 +1,27 @@
+// Copyright 2017 The Chromium Authors
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//    * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//    * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//    * Neither the name of Google LLC nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/zig/lib/hash/README.md
+++ b/zig/lib/hash/README.md
@@ -1,0 +1,87 @@
+# Shared checksums
+
+Import `antfly_hash`. `Crc32`, `Crc32c`, `Crc64Nvme`, and `Adler32` expose
+`init()`, `update(bytes)`, `final()`, and `hash(bytes)`. Updates accept arbitrary
+alignment and empty slices; `final()` leaves the state usable for more updates.
+The checksums preserve the standard-library values and existing on-disk/wire
+formats. They are not cryptographic hashes.
+
+| API | Accelerated implementation | Portable implementation |
+| --- | --- | --- |
+| `Crc32` (IEEE) | ARM64 CRC; x86-64 PCLMUL folding for buffers >=64 bytes | Slicing-by-eight |
+| `Crc32c` (Castagnoli) | ARM64 CRC32C; x86-64 SSE4.2 CRC instructions | Slicing-by-eight |
+| `Crc64Nvme` | — | Slicing-by-eight |
+| `Adler32` | Zig vectors, extracted from the image encoder | Compiler-lowered vectors and scalar tails |
+
+CPU features guaranteed by the compilation target bypass runtime discovery.
+Baseline Linux ARM64 builds read HWCAP through libc or Zig's startup auxiliary
+vector; macOS ARM64 supports CRC on every supported machine. Hosted x86-64
+builds use CPUID. The cache is atomic and allocation-free; optional instructions
+are isolated in non-inlined kernels. PCLMUL requires SSE2 but not AVX, SSE4.1,
+or SSE4.2. SSE4.2's CRC instruction is used only for Castagnoli, never IEEE.
+Other platforms retain target guarantees or portable code. Freestanding builds
+only use target-guaranteed features; the C backend uses portable code. A libc-free
+Linux library without startup-provided auxv also stays portable.
+
+CRC tables occupy 8 KiB per 32-bit polynomial and 16 KiB for CRC64/NVME.
+Compile-time hashing always uses the portable path. CRC64/NVME currently has no
+hardware kernel; slicing-by-eight improves on Zig's byte-at-a-time generic CRC.
+
+Production callers include storage, WAL, Raft state, backup/HA formats, Lite,
+lake object verification, and both PNG encoders. Image PNG encoding writes the
+zlib wrapper around raw deflate so its Adler32 trailer also uses this module;
+a compatibility test checks byte-for-byte equality with the standard wrapper.
+Wyhash, xxHash, SHA, BLAKE3, and CRCs with other parameters keep their existing
+implementations.
+
+## Validation
+
+From the repository root, `make zig-checksums-check` tests and runs the CI
+usage guard. It rejects ordinary direct/aliased std checksum calls in production
+Zig code, including forward container declarations and explicitly typed
+namespace aliases, allowing test blocks and this implementation's reference oracles.
+This is a lexical policy check, not a Zig type checker: computed reflection or
+cross-file namespace reexports are not resolved. CI runs it and executes native
+baseline checksum tests on both x86-64 and Linux ARM64, including libc and
+libc-free ARM64 startup paths.
+
+From `zig/`:
+
+```sh
+zig build lib-hash-test lib-image-png-test -Doptimize=Debug
+zig build lib-hash-test -Dcpu=baseline -Doptimize=ReleaseSafe
+zig build lib-hash-test -Doptimize=ReleaseFast -- throughput
+```
+
+Hash and PNG tests also run with `unit-test`. Correctness checks cover known
+vectors, portable versus dispatched kernels, unaligned buffers, folding/tail
+boundaries, incremental updates, Adler reduction limits, and concurrent CPU
+cache initialization. The throughput benchmark compares all four algorithms
+against std at 64 B, 4 KiB, and 1 MiB, checking identical result sums.
+
+Local Apple M4 / Zig 0.16.0 ReleaseFast results (median of three samples,
+32 MiB hashed per sample, 1 MiB buffers):
+
+| Checksum | std time | Shared time | Kernel speedup |
+| --- | --- | --- | --- |
+| CRC32 | 65.2 ms | 3.22 ms | 20.2× |
+| CRC32C | 64.0 ms | 3.23 ms | 19.8× |
+| CRC64/NVME | 64.7 ms | 14.1 ms | 4.6× |
+| Adler32 | 9.12 ms | 2.73 ms | 3.3× |
+
+These measure checksum throughput, not end-to-end storage or query performance.
+The x86-64 baseline kernels were also executed under Rosetta for correctness;
+use native x86 hardware for representative x86 performance measurements.
+
+Cross-target compile checks (not runtime validation):
+
+```sh
+zig test lib/hash/src/mod.zig -O ReleaseSafe -target x86_64-linux-musl -mcpu=baseline -fno-emit-bin
+zig test lib/hash/src/mod.zig -O ReleaseSafe -target aarch64-linux-musl -mcpu=baseline -fno-emit-bin
+zig test lib/hash/src/mod.zig -O ReleaseSafe -target aarch64-linux-musl -mcpu=baseline -lc -fno-emit-bin
+zig test lib/hash/src/mod.zig -O ReleaseSafe -target wasm32-wasi -fno-emit-bin
+```
+
+The x86 IEEE folding algorithm and constants are adapted from Chromium zlib's
+[`crc32_simd.c`](https://chromium.googlesource.com/chromium/src/+/main/third_party/zlib/crc32_simd.c). Its BSD notice is retained in `LICENSE.chromium` and the root
+`THIRD_PARTY_NOTICES.md` shipped with releases.

--- a/zig/lib/hash/README.md
+++ b/zig/lib/hash/README.md
@@ -20,7 +20,9 @@ builds use CPUID. The cache is atomic and allocation-free; optional instructions
 are isolated in non-inlined kernels. PCLMUL requires SSE2 but not AVX, SSE4.1,
 or SSE4.2. SSE4.2's CRC instruction is used only for Castagnoli, never IEEE.
 Other platforms retain target guarantees or portable code. Freestanding builds
-only use target-guaranteed features; the C backend uses portable code. A libc-free
+only use target-guaranteed features; the C backend uses portable code. Zig 0.16's
+non-LLVM x86 backend cannot encode the CRC instructions, so it also uses portable
+CRC32/CRC32C kernels; LLVM release builds retain hardware acceleration. A libc-free
 Linux library without startup-provided auxv also stays portable.
 
 CRC tables occupy 8 KiB per 32-bit polynomial and 16 KiB for CRC64/NVME.
@@ -52,6 +54,9 @@ zig build lib-hash-test lib-image-png-test -Doptimize=Debug
 zig build lib-hash-test -Dcpu=baseline -Doptimize=ReleaseSafe
 zig build lib-hash-test -Doptimize=ReleaseFast -- throughput
 ```
+
+On Linux x86-64, CI also runs `zig test lib/hash/src/mod.zig -O Debug
+-mcpu=baseline -fno-llvm` to exercise the non-LLVM backend's portable kernels.
 
 Hash and PNG tests also run with `unit-test`. Correctness checks cover known
 vectors, portable versus dispatched kernels, unaligned buffers, folding/tail

--- a/zig/lib/hash/src/adler32.zig
+++ b/zig/lib/hash/src/adler32.zig
@@ -1,0 +1,101 @@
+// Copyright 2026 Antfly, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Shared vectorized Adler32, originally in lib/image's PNG encoder.
+const std = @import("std");
+
+pub const Adler32 = struct {
+    state: u32 = 1,
+
+    pub fn init() Adler32 {
+        return .{};
+    }
+    pub fn update(self: *Adler32, bytes: []const u8) void {
+        self.state = updateState(self.state, bytes);
+    }
+    pub fn final(self: Adler32) u32 {
+        return self.state;
+    }
+    pub fn hash(bytes: []const u8) u32 {
+        var adler = init();
+        adler.update(bytes);
+        return adler.final();
+    }
+};
+
+fn updateState(state: u32, bytes: []const u8) u32 {
+    const base = 65521;
+    const nmax = 5552;
+    const weights: @Vector(16, u32) = .{ 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1 };
+
+    var s1 = state & 0xffff;
+    var s2 = state >> 16;
+    var index: usize = 0;
+
+    while (index < bytes.len) {
+        const end = @min(index + nmax, bytes.len);
+        while (index + 16 <= end) : (index += 16) {
+            const byte_vec: @Vector(16, u8) = bytes[index..][0..16].*;
+            const lanes: @Vector(16, u32) = @intCast(byte_vec);
+            const sum = @reduce(.Add, lanes);
+            const weighted_sum = @reduce(.Add, lanes * weights);
+            s2 += 16 * s1 + weighted_sum;
+            s1 += sum;
+        }
+        while (index < end) : (index += 1) {
+            s1 += bytes[index];
+            s2 += s1;
+        }
+        s1 %= base;
+        s2 %= base;
+    }
+
+    return s1 | (s2 << 16);
+}
+
+test "Adler32 vector lanes tails and reduction bounds match standard" {
+    try std.testing.expectEqual(@as(u32, 0x091e01de), Adler32.hash("123456789"));
+    try std.testing.expectEqual(@as(u32, 1), Adler32.hash(""));
+    try std.testing.expectEqual(@as(u32, 0x091e01de), comptime Adler32.hash("123456789"));
+    var bytes: [65536 + 32]u8 = undefined;
+    var random = std.Random.DefaultPrng.init(0xad1e32);
+    random.random().bytes(&bytes);
+    for (0..32) |offset| {
+        for (0..65) |len| try check(bytes[offset..][0..len]);
+        for ([_]usize{ 255, 256, 1023, 1024, 5551, 5552, 5553, 11103, 11104, 11105, 65536 }) |len| {
+            try check(bytes[offset..][0..len]);
+        }
+    }
+    // All-ones input maximizes both sums and exposes reduction overflow.
+    @memset(&bytes, 0xff);
+    try check(&bytes);
+    var adler = Adler32.init();
+    var oracle: std.hash.Adler32 = .{};
+    for (0..64) |_| {
+        adler.update(&bytes);
+        oracle.update(&bytes);
+    }
+    try std.testing.expectEqual(oracle.adler, adler.final());
+}
+
+fn check(data: []const u8) !void {
+    const expected = std.hash.Adler32.hash(data);
+    try std.testing.expectEqual(expected, Adler32.hash(data));
+    var adler = Adler32.init();
+    const split = data.len / 3;
+    adler.update(data[0..split]);
+    adler.update("");
+    adler.update(data[split..]);
+    try std.testing.expectEqual(expected, adler.final());
+}

--- a/zig/lib/hash/src/arm_crc.zig
+++ b/zig/lib/hash/src/arm_crc.zig
@@ -1,0 +1,53 @@
+// Copyright 2026 Antfly, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const std = @import("std");
+
+/// Call only after compile-time or runtime detection of ARM CRC support.
+/// The directive enables assembly of the guarded instructions in a baseline
+/// build; it does not let the compiler emit CRC elsewhere in that build.
+pub noinline fn update(comptime castagnoli: bool, initial: u32, bytes: []const u8) u32 {
+    var crc = initial;
+    var remaining = bytes;
+    while (remaining.len >= 8) {
+        crc = instruction(castagnoli, u64, crc, std.mem.readInt(u64, remaining[0..8], .little));
+        remaining = remaining[8..];
+    }
+    if (remaining.len >= 4) {
+        crc = instruction(castagnoli, u32, crc, std.mem.readInt(u32, remaining[0..4], .little));
+        remaining = remaining[4..];
+    }
+    if (remaining.len >= 2) {
+        crc = instruction(castagnoli, u16, crc, std.mem.readInt(u16, remaining[0..2], .little));
+        remaining = remaining[2..];
+    }
+    if (remaining.len != 0) crc = instruction(castagnoli, u8, crc, remaining[0]);
+    return crc;
+}
+
+inline fn instruction(comptime castagnoli: bool, comptime T: type, crc: u32, value: T) u32 {
+    const mnemonic = "crc32" ++ (if (castagnoli) "c" else "") ++ switch (T) {
+        u64 => "x",
+        u32 => "w",
+        u16 => "h",
+        u8 => "b",
+        else => unreachable,
+    };
+    const operand = if (T == u64) "%[value]" else "%[value:w]";
+    return asm (".arch_extension crc\n" ++ mnemonic ++ " %[out:w], %[crc:w], " ++ operand
+        : [out] "=r" (-> u32),
+        : [crc] "r" (crc),
+          [value] "r" (value),
+    );
+}

--- a/zig/lib/hash/src/benchmark.zig
+++ b/zig/lib/hash/src/benchmark.zig
@@ -1,0 +1,57 @@
+// Copyright 2026 Antfly, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const crc32 = @import("crc32.zig");
+const crc64 = @import("crc64.zig");
+const adler = @import("adler32.zig");
+
+test "checksum throughput microbenchmark" {
+    if (builtin.mode != .ReleaseFast) return error.SkipZigTest;
+    const bytes = try std.testing.allocator.alloc(u8, 1024 * 1024);
+    defer std.testing.allocator.free(bytes);
+    var random = std.Random.DefaultPrng.init(0x593);
+    random.random().bytes(bytes);
+    std.debug.print("checksum kernels crc32={s} crc32c={s} cpu={s}\n", .{
+        @tagName(crc32.Crc32.implementation()), @tagName(crc32.Crc32c.implementation()), builtin.cpu.model.name,
+    });
+    inline for (.{
+        .{ "crc32", std.hash.Crc32, crc32.Crc32 },
+        .{ "crc32c", std.hash.crc.Crc32Iscsi, crc32.Crc32c },
+        .{ "crc64nvme", crc64.Oracle, crc64.Crc64Nvme },
+        .{ "adler32", std.hash.Adler32, adler.Adler32 },
+    }) |case| {
+        for ([_]usize{ 64, 4096, 1024 * 1024 }) |size| {
+            for (0..3) |round| {
+                var sums: [2]u64 = undefined;
+                inline for (.{ case[1], case[2] }, 0..) |Impl, impl_index| {
+                    const count = 32 * 1024 * 1024 / size;
+                    var sum: u64 = 0;
+                    const started = std.Io.Clock.awake.now(std.testing.io).nanoseconds;
+                    for (0..count) |iteration| {
+                        bytes[0] = @truncate(iteration + round);
+                        sum +%= Impl.hash(bytes[0..size]);
+                    }
+                    const elapsed = std.Io.Clock.awake.now(std.testing.io).nanoseconds - started;
+                    sums[impl_index] = sum;
+                    std.debug.print("checksum={s} impl={s} size={} bytes={} elapsed_ns={} sum={}\n", .{
+                        case[0], if (impl_index == 0) "std" else "antfly", size, size * count, elapsed, sum,
+                    });
+                }
+                try std.testing.expectEqual(sums[0], sums[1]);
+            }
+        }
+    }
+}

--- a/zig/lib/hash/src/cpu.zig
+++ b/zig/lib/hash/src/cpu.zig
@@ -1,0 +1,159 @@
+// Copyright 2026 Antfly, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Only these feature bits are cached, so concurrent first calls may safely
+//! repeat detection. No allocation, lock, initialization order, or libc is
+//! required. Hosted x86-64 platforms preserve the baseline SSE2 register state;
+//! these kernels do not use AVX and therefore need no XGETBV check.
+const std = @import("std");
+const builtin = @import("builtin");
+
+pub const Features = packed struct(u8) {
+    arm_crc: bool = false,
+    x86_crc: bool = false,
+    pclmul: bool = false,
+    _reserved: u4 = 0,
+    initialized: bool = true,
+};
+
+var cached = std.atomic.Value(u8).init(0);
+
+pub fn features() Features {
+    if (comptime builtin.cpu.arch != .aarch64 and builtin.cpu.arch != .x86_64) return .{};
+    if (comptime builtin.zig_backend == .stage2_c) return .{};
+    if (comptime builtin.os.tag == .freestanding) return guaranteed();
+    return featuresCached(&cached);
+}
+
+fn featuresCached(cache: *std.atomic.Value(u8)) Features {
+    const value = cache.load(.monotonic);
+    if (value != 0) return @bitCast(value);
+    const detected = detect();
+    cache.store(@bitCast(detected), .monotonic);
+    return detected;
+}
+
+pub fn guaranteed() Features {
+    if (comptime builtin.zig_backend == .stage2_c) return .{};
+    return switch (builtin.cpu.arch) {
+        .aarch64 => .{ .arm_crc = builtin.cpu.has(.aarch64, .crc) },
+        .x86_64 => .{
+            .x86_crc = builtin.cpu.has(.x86, .crc32),
+            .pclmul = builtin.cpu.has(.x86, .pclmul),
+        },
+        else => .{},
+    };
+}
+
+fn detect() Features {
+    if (comptime builtin.zig_backend == .stage2_c or builtin.os.tag == .freestanding) return guaranteed();
+    var result = guaranteed();
+    switch (builtin.cpu.arch) {
+        .aarch64 => switch (builtin.os.tag) {
+            .linux => result.arm_crc = result.arm_crc or fromArmHwcap(linuxHwcap()).arm_crc,
+            // Every supported Apple Silicon macOS machine has ARM CRC, even
+            // when the caller deliberately compiles with -mcpu=generic.
+            .macos => result.arm_crc = true,
+            else => {}, // Unsupported OS discovery retains the safe baseline.
+        },
+        .x86_64 => {
+            var eax: u32 = undefined;
+            var ebx: u32 = undefined;
+            var ecx: u32 = undefined;
+            var edx: u32 = undefined;
+            asm volatile ("cpuid"
+                : [_] "={eax}" (eax),
+                  [_] "={ebx}" (ebx),
+                  [_] "={ecx}" (ecx),
+                  [_] "={edx}" (edx),
+                : [_] "{eax}" (@as(u32, 1)),
+                  [_] "{ecx}" (@as(u32, 0)),
+            );
+            const native = fromX86Leaf1(ecx, edx);
+            result.x86_crc = result.x86_crc or native.x86_crc;
+            result.pclmul = result.pclmul or native.pclmul;
+        },
+        else => {},
+    }
+    return result;
+}
+
+fn linuxHwcap() usize {
+    // libc owns auxv initialization for C-hosted executables and shared libs.
+    // Zig owns it for libc-free executables. A libc-free library without a
+    // startup-provided auxv simply stays portable.
+    if (builtin.link_libc) return std.c.getauxval(std.elf.AT_HWCAP);
+    const auxv = std.os.linux.elf_aux_maybe orelse return 0;
+    var index: usize = 0;
+    while (auxv[index].a_type != std.elf.AT_NULL) : (index += 1) {
+        if (auxv[index].a_type == std.elf.AT_HWCAP) return auxv[index].a_un.a_val;
+    }
+    return 0;
+}
+
+fn fromArmHwcap(hwcap: usize) Features {
+    return .{ .arm_crc = hwcap & (1 << 7) != 0 }; // Linux AArch64 HWCAP_CRC32.
+}
+
+fn fromX86Leaf1(ecx: u32, edx: u32) Features {
+    return .{
+        .x86_crc = ecx & (1 << 20) != 0, // SSE4.2 CRC32C (not IEEE CRC32).
+        .pclmul = ecx & (1 << 1) != 0 and edx & (1 << 26) != 0,
+    };
+}
+
+test "CPU feature decoding requires the exact optional instruction bits" {
+    try std.testing.expect(!fromArmHwcap(0).arm_crc);
+    try std.testing.expect(fromArmHwcap(1 << 7).arm_crc);
+    try std.testing.expect(!fromX86Leaf1(0, 0).x86_crc);
+    try std.testing.expect(fromX86Leaf1(1 << 20, 0).x86_crc);
+    try std.testing.expect(!fromX86Leaf1(1 << 20, 1 << 26).pclmul);
+    try std.testing.expect(!fromX86Leaf1(1 << 1, 0).pclmul);
+    try std.testing.expect(fromX86Leaf1(1 << 1, 1 << 26).pclmul);
+    try std.testing.expectEqual(features(), features());
+}
+
+test "CPU feature cache is safe during concurrent first use" {
+    if (builtin.single_threaded) return error.SkipZigTest;
+    const Worker = struct {
+        cache: *std.atomic.Value(u8),
+        start: *std.atomic.Value(bool),
+        observed: Features = .{},
+
+        fn run(self: *@This()) void {
+            while (!self.start.load(.acquire)) std.atomic.spinLoopHint();
+            self.observed = featuresCached(self.cache);
+        }
+    };
+    var cache = std.atomic.Value(u8).init(0);
+    var start = std.atomic.Value(bool).init(false);
+    var workers: [8]Worker = undefined;
+    var threads: [8]std.Thread = undefined;
+    var started: usize = 0;
+    errdefer {
+        start.store(true, .release);
+        for (threads[0..started]) |thread| thread.join();
+    }
+    for (&workers, &threads) |*worker, *thread| {
+        worker.* = .{ .cache = &cache, .start = &start };
+        thread.* = try std.Thread.spawn(.{}, Worker.run, .{worker});
+        started += 1;
+    }
+    start.store(true, .release);
+    for (threads) |thread| thread.join();
+    started = 0;
+    const expected = detect();
+    for (workers) |worker| try std.testing.expectEqual(expected, worker.observed);
+    try std.testing.expectEqual(expected, featuresCached(&cache));
+}

--- a/zig/lib/hash/src/crc32.zig
+++ b/zig/lib/hash/src/crc32.zig
@@ -23,6 +23,11 @@ const arm = @import("arm_crc.zig");
 const x86_ieee = @import("x86_crc32.zig");
 const x86_castagnoli = @import("x86_crc32c.zig");
 
+// Zig 0.16's non-LLVM x86 backend cannot encode either PCLMULQDQ or
+// CRC32 r64,r64. Keep those kernels out of semantic analysis in Debug builds
+// using that backend; LLVM release builds retain hardware acceleration.
+const asm_kernels_supported = builtin.zig_backend != .stage2_c and builtin.zig_backend != .stage2_x86_64;
+
 pub const Crc32 = Crc(false);
 pub const Crc32c = Crc(true);
 pub const Implementation = enum { slicing_by_eight, arm_crc, x86_pclmul, x86_crc };
@@ -46,7 +51,7 @@ fn Crc(comptime castagnoli: bool) type {
         }
 
         fn select(features: cpu.Features) Implementation {
-            if (comptime builtin.zig_backend == .stage2_c) return .slicing_by_eight;
+            if (comptime !asm_kernels_supported) return .slicing_by_eight;
             return switch (builtin.cpu.arch) {
                 .aarch64 => if (features.arm_crc) .arm_crc else .slicing_by_eight,
                 .x86_64 => if (castagnoli)
@@ -63,7 +68,7 @@ fn Crc(comptime castagnoli: bool) type {
                 self.updatePortable(bytes);
                 return;
             }
-            if (comptime builtin.zig_backend != .stage2_c) {
+            if (comptime asm_kernels_supported) {
                 if (comptime builtin.cpu.arch == .aarch64) {
                     if (implementation() == .arm_crc) {
                         self.crc = arm.update(castagnoli, self.crc, bytes);

--- a/zig/lib/hash/src/crc32.zig
+++ b/zig/lib/hash/src/crc32.zig
@@ -1,0 +1,172 @@
+// Copyright 2026 Antfly, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! IEEE CRC32 and CRC32C with std-compatible streaming and wire semantics.
+//! Compilation-target guarantees bypass discovery. Baseline builds discover
+//! optional instructions once, and unsupported platforms remain portable.
+const std = @import("std");
+const builtin = @import("builtin");
+const cpu = @import("cpu.zig");
+const portable = @import("portable_crc.zig");
+const arm = @import("arm_crc.zig");
+const x86_ieee = @import("x86_crc32.zig");
+const x86_castagnoli = @import("x86_crc32c.zig");
+
+pub const Crc32 = Crc(false);
+pub const Crc32c = Crc(true);
+pub const Implementation = enum { slicing_by_eight, arm_crc, x86_pclmul, x86_crc };
+
+fn Crc(comptime castagnoli: bool) type {
+    return struct {
+        const Self = @This();
+        const polynomial: u32 = if (castagnoli) 0x82f63b78 else 0xedb88320;
+        crc: u32 = 0xffffffff,
+
+        pub fn init() Self {
+            return .{};
+        }
+
+        /// Available bulk kernel. Short IEEE buffers use the portable path
+        /// even when PCLMUL is available, avoiding folding setup overhead.
+        pub fn implementation() Implementation {
+            const baseline = comptime select(cpu.guaranteed());
+            if (comptime baseline != .slicing_by_eight) return baseline;
+            return select(cpu.features());
+        }
+
+        fn select(features: cpu.Features) Implementation {
+            if (comptime builtin.zig_backend == .stage2_c) return .slicing_by_eight;
+            return switch (builtin.cpu.arch) {
+                .aarch64 => if (features.arm_crc) .arm_crc else .slicing_by_eight,
+                .x86_64 => if (castagnoli)
+                    (if (features.x86_crc) .x86_crc else .slicing_by_eight)
+                else
+                    (if (features.pclmul) .x86_pclmul else .slicing_by_eight),
+                else => .slicing_by_eight,
+            };
+        }
+
+        pub fn update(self: *Self, bytes: []const u8) void {
+            if (bytes.len == 0) return;
+            if (@inComptime()) {
+                self.updatePortable(bytes);
+                return;
+            }
+            if (comptime builtin.zig_backend != .stage2_c) {
+                if (comptime builtin.cpu.arch == .aarch64) {
+                    if (implementation() == .arm_crc) {
+                        self.crc = arm.update(castagnoli, self.crc, bytes);
+                        return;
+                    }
+                } else if (comptime builtin.cpu.arch == .x86_64) {
+                    if (comptime castagnoli) {
+                        if (implementation() == .x86_crc) {
+                            self.crc = x86_castagnoli.update(self.crc, bytes);
+                            return;
+                        }
+                    } else if (bytes.len >= 64 and implementation() == .x86_pclmul) {
+                        const folded_len = bytes.len & ~@as(usize, 15);
+                        self.crc = x86_ieee.update(self.crc, bytes[0..folded_len]);
+                        self.updatePortable(bytes[folded_len..]);
+                        return;
+                    }
+                }
+            }
+            self.updatePortable(bytes);
+        }
+
+        fn updatePortable(self: *Self, bytes: []const u8) void {
+            self.crc = portable.update(u32, polynomial, self.crc, bytes);
+        }
+
+        pub fn final(self: Self) u32 {
+            return self.crc ^ 0xffffffff;
+        }
+
+        pub fn hash(bytes: []const u8) u32 {
+            var crc = init();
+            crc.update(bytes);
+            return crc.final();
+        }
+    };
+}
+
+test "CRC32 and CRC32C preserve known vectors and comptime hashing" {
+    try std.testing.expectEqual(@as(u32, 0xcbf43926), Crc32.hash("123456789"));
+    try std.testing.expectEqual(@as(u32, 0xe3069283), Crc32c.hash("123456789"));
+    try std.testing.expectEqual(@as(u32, 0xcbf43926), comptime Crc32.hash("123456789"));
+    try std.testing.expectEqual(@as(u32, 0xe3069283), comptime Crc32c.hash("123456789"));
+    try std.testing.expectEqual(@as(u32, 0), Crc32.hash(""));
+    try std.testing.expectEqual(@as(u32, 0), Crc32c.hash(""));
+    // SSE4.2 alone must never select IEEE acceleration.
+    try std.testing.expectEqual(Implementation.slicing_by_eight, Crc32.select(.{ .x86_crc = true }));
+    try std.testing.expectEqual(Implementation.slicing_by_eight, Crc32.select(.{}));
+    try std.testing.expectEqual(Implementation.slicing_by_eight, Crc32c.select(.{}));
+}
+
+test "CRC dispatch selects the available bulk kernels" {
+    const available = cpu.features();
+    try std.testing.expectEqual(Crc32.select(available), Crc32.implementation());
+    try std.testing.expectEqual(Crc32c.select(available), Crc32c.implementation());
+    std.debug.print("CRC dispatch target={s} crc32={s} crc32c={s}\n", .{
+        builtin.cpu.model.name, @tagName(Crc32.implementation()), @tagName(Crc32c.implementation()),
+    });
+}
+
+test "CRC32 kernels agree across unaligned buffers tails and incremental updates" {
+    var bytes: [65536 + 32]u8 = undefined;
+    var random = std.Random.DefaultPrng.init(0x593c32);
+    random.random().bytes(&bytes);
+    inline for (.{ false, true }) |castagnoli| {
+        const Impl = Crc(castagnoli);
+        const Oracle = if (castagnoli) std.hash.crc.Crc32Iscsi else std.hash.Crc32;
+        for (0..32) |offset| {
+            for (0..513) |len| try check(Impl, Oracle, bytes[offset..][0..len]);
+            for ([_]usize{ 1023, 1024, 1031, 4095, 4096, 16383, 16384, 65535, 65536 }) |len| {
+                try check(Impl, Oracle, bytes[offset..][0..len]);
+            }
+        }
+        for (0..256) |split| {
+            const data = bytes[1..1028];
+            var crc = Impl.init();
+            crc.update(data[0..split]);
+            crc.update(data[split..]);
+            try std.testing.expectEqual(Oracle.hash(data), crc.final());
+        }
+    }
+}
+
+fn check(comptime Impl: type, comptime Oracle: type, data: []const u8) !void {
+    const expected = Oracle.hash(data);
+    try std.testing.expectEqual(expected, Impl.hash(data));
+    var fast = Impl.init();
+    var slow = Impl.init();
+    const split = data.len / 3;
+    fast.update(data[0..split]);
+    fast.update(&.{});
+    fast.update(data[split..]);
+    slow.updatePortable(data[0..split]);
+    slow.updatePortable(&.{});
+    slow.updatePortable(data[split..]);
+    try std.testing.expectEqual(expected, fast.final());
+    try std.testing.expectEqual(expected, slow.final());
+    // final is non-mutating and both states remain usable after it.
+    fast.update("suffix");
+    slow.updatePortable("suffix");
+    var oracle = Oracle.init();
+    oracle.update(data);
+    oracle.update("suffix");
+    try std.testing.expectEqual(oracle.final(), fast.final());
+    try std.testing.expectEqual(oracle.final(), slow.final());
+}

--- a/zig/lib/hash/src/crc64.zig
+++ b/zig/lib/hash/src/crc64.zig
@@ -1,0 +1,72 @@
+// Copyright 2026 Antfly, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const std = @import("std");
+const portable = @import("portable_crc.zig");
+
+/// CRC-64/NVME, not CRC-64/ECMA or CRC-64/XZ. Its reflected polynomial is
+/// 0x9a6c9329ac4bc9b5. Raw state and final XOR are both all ones.
+pub const Crc64Nvme = struct {
+    crc: u64 = 0xffffffffffffffff,
+
+    pub fn init() Crc64Nvme {
+        return .{};
+    }
+
+    pub fn update(self: *Crc64Nvme, bytes: []const u8) void {
+        self.crc = portable.update(u64, 0x9a6c9329ac4bc9b5, self.crc, bytes);
+    }
+
+    pub fn final(self: Crc64Nvme) u64 {
+        return self.crc ^ 0xffffffffffffffff;
+    }
+
+    pub fn hash(bytes: []const u8) u64 {
+        var crc = init();
+        crc.update(bytes);
+        return crc.final();
+    }
+};
+
+pub const Oracle = std.hash.crc.Crc(u64, .{
+    .polynomial = 0xad93d23594c93659,
+    .initial = 0xffffffffffffffff,
+    .reflect_input = true,
+    .reflect_output = true,
+    .xor_output = 0xffffffffffffffff,
+});
+
+test "CRC64 NVME matches standard across alignment and incremental boundaries" {
+    try std.testing.expectEqual(@as(u64, 0xae8b14860a799888), Crc64Nvme.hash("123456789"));
+    try std.testing.expectEqual(@as(u64, 0), Crc64Nvme.hash(""));
+    try std.testing.expectEqual(@as(u64, 0xae8b14860a799888), comptime Crc64Nvme.hash("123456789"));
+    var bytes: [65536 + 32]u8 = undefined;
+    var random = std.Random.DefaultPrng.init(0x64_593c32);
+    random.random().bytes(&bytes);
+    for (0..32) |offset| {
+        for (0..513) |len| try check(bytes[offset..][0..len]);
+        for ([_]usize{ 1023, 1024, 4095, 4096, 65535, 65536 }) |len| try check(bytes[offset..][0..len]);
+    }
+}
+
+fn check(data: []const u8) !void {
+    const expected = Oracle.hash(data);
+    try std.testing.expectEqual(expected, Crc64Nvme.hash(data));
+    var crc = Crc64Nvme.init();
+    const split = data.len / 3;
+    crc.update(data[0..split]);
+    crc.update("");
+    crc.update(data[split..]);
+    try std.testing.expectEqual(expected, crc.final());
+}

--- a/zig/lib/hash/src/mod.zig
+++ b/zig/lib/hash/src/mod.zig
@@ -1,0 +1,27 @@
+// Copyright 2026 Antfly, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Allocation-free checksums with std-compatible wire semantics.
+pub const Crc32 = @import("crc32.zig").Crc32;
+pub const Crc32c = @import("crc32.zig").Crc32c;
+pub const Crc64Nvme = @import("crc64.zig").Crc64Nvme;
+pub const Adler32 = @import("adler32.zig").Adler32;
+
+test {
+    _ = @import("cpu.zig");
+    _ = @import("crc32.zig");
+    _ = @import("crc64.zig");
+    _ = @import("adler32.zig");
+    _ = @import("benchmark.zig");
+}

--- a/zig/lib/hash/src/portable_crc.zig
+++ b/zig/lib/hash/src/portable_crc.zig
@@ -1,0 +1,48 @@
+// Copyright 2026 Antfly, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const std = @import("std");
+
+/// Reflected CRC update with raw (uncomplemented) state. Eight tables allow
+/// independent lookups for each byte of a word, with no alignment requirement.
+pub fn update(comptime T: type, comptime polynomial: T, initial: T, bytes: []const u8) T {
+    const tables = comptime slicingTables(T, polynomial);
+    var crc = initial;
+    var remaining = bytes;
+    while (remaining.len >= 8) {
+        const word = std.mem.readInt(u64, remaining[0..8], .little) ^ @as(u64, crc);
+        crc = 0;
+        inline for (0..8) |i| crc ^= tables[7 - i][@as(u8, @truncate(word >> (8 * i)))];
+        remaining = remaining[8..];
+    }
+    for (remaining) |byte| crc = tables[0][@as(u8, @truncate(crc ^ byte))] ^ (crc >> 8);
+    return crc;
+}
+
+fn slicingTables(comptime T: type, comptime polynomial: T) [8][256]T {
+    @setEvalBranchQuota(30000);
+    var tables: [8][256]T = undefined;
+    for (0..256) |i| {
+        var crc: T = @intCast(i);
+        for (0..8) |_| crc = if (crc & 1 != 0) (crc >> 1) ^ polynomial else crc >> 1;
+        tables[0][i] = crc;
+    }
+    for (1..8) |table_index| {
+        for (0..256) |i| {
+            const previous = tables[table_index - 1][i];
+            tables[table_index][i] = (previous >> 8) ^ tables[0][@as(u8, @truncate(previous))];
+        }
+    }
+    return tables;
+}

--- a/zig/lib/hash/src/x86_crc32.zig
+++ b/zig/lib/hash/src/x86_crc32.zig
@@ -1,0 +1,74 @@
+// Copyright 2026 Antfly, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Copyright 2017 The Chromium Authors
+// SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
+// See ../LICENSE.chromium for the upstream license.
+//
+// The folding/reduction algorithm and constants are adapted from Chromium's
+// third_party/zlib/crc32_simd.c (crc32_sse42_simd_), based on Intel's
+// "Fast CRC Computation for Generic Polynomials Using PCLMULQDQ Instruction".
+// This port needs only baseline SSE2 plus PCLMUL, not SSE4.1/4.2 or AVX.
+const std = @import("std");
+const V = @Vector(2, u64);
+const fold512: V = .{ 0x0154442bd4, 0x01c6e41596 };
+const fold128: V = .{ 0x01751997d0, 0x00ccaa009e };
+const fold96: V = .{ 0x0163cd6124, 0 };
+const polynomial: V = .{ 0x01db710641, 0x01f7011641 };
+const low32: V = .{ 0xffffffff, 0xffffffff };
+
+/// Raw IEEE state update for at least 64 bytes, in multiples of 16.
+/// The caller handles short buffers/tails and checks CPU support.
+pub noinline fn update(initial: u32, bytes: []const u8) u32 {
+    std.debug.assert(bytes.len >= 64 and bytes.len % 16 == 0);
+    var lanes = [4]V{ load(bytes[0..16]), load(bytes[16..32]), load(bytes[32..48]), load(bytes[48..64]) };
+    lanes[0] ^= V{ initial, 0 };
+    var remaining = bytes[64..];
+    while (remaining.len >= 64) {
+        inline for (0..4) |i| lanes[i] = fold(lanes[i], fold512) ^ load(remaining[i * 16 ..][0..16]);
+        remaining = remaining[64..];
+    }
+    var state = lanes[0];
+    inline for (1..4) |i| state = fold(state, fold128) ^ lanes[i];
+    while (remaining.len >= 16) {
+        state = fold(state, fold128) ^ load(remaining[0..16]);
+        remaining = remaining[16..];
+    }
+    // Reduce 128 -> 96 -> 64 bits, then Barrett-reduce to the raw CRC32.
+    state = shiftRight(state, 64) ^ clmul(0x10, state, fold128);
+    state = shiftRight(state, 32) ^ clmul(0x00, state & low32, fold96);
+    var quotient = clmul(0x10, state & low32, polynomial) & low32;
+    quotient = clmul(0x00, quotient, polynomial);
+    return @truncate(@as(u128, @bitCast(state ^ quotient)) >> 32);
+}
+
+inline fn load(bytes: *const [16]u8) V {
+    return @bitCast(bytes.*);
+}
+
+inline fn shiftRight(value: V, comptime bits: u7) V {
+    return @bitCast(@as(u128, @bitCast(value)) >> bits);
+}
+
+inline fn fold(value: V, factors: V) V {
+    return clmul(0x00, value, factors) ^ clmul(0x11, value, factors);
+}
+
+inline fn clmul(comptime selector: u8, lhs: V, rhs: V) V {
+    return asm (std.fmt.comptimePrint("pclmulqdq ${d}, %[rhs], %[out]", .{selector})
+        : [out] "=x" (-> V),
+        : [_] "0" (lhs),
+          [rhs] "x" (rhs),
+    );
+}

--- a/zig/lib/hash/src/x86_crc32c.zig
+++ b/zig/lib/hash/src/x86_crc32c.zig
@@ -1,0 +1,39 @@
+// Copyright 2026 Antfly, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const std = @import("std");
+
+/// SSE4.2's CRC32 instruction computes Castagnoli, not IEEE. Only called after
+/// CPUID or compilation-target validation; all memory reads stay in the slice.
+pub noinline fn update(initial: u32, bytes: []const u8) u32 {
+    var crc: u64 = initial;
+    var remaining = bytes;
+    while (remaining.len >= 8) {
+        crc = asm ("crc32q %[value], %[crc]"
+            : [crc] "=r" (-> u64),
+            : [_] "0" (crc),
+              [value] "r" (std.mem.readInt(u64, remaining[0..8], .little)),
+        );
+        remaining = remaining[8..];
+    }
+    var tail: u32 = @truncate(crc);
+    for (remaining) |byte| {
+        tail = asm ("crc32b %[value], %[crc]"
+            : [crc] "=r" (-> u32),
+            : [_] "0" (tail),
+              [value] "r" (byte),
+        );
+    }
+    return tail;
+}

--- a/zig/lib/image/src/png.zig
+++ b/zig/lib/image/src/png.zig
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 const std = @import("std");
-const builtin = @import("builtin");
+const Crc32 = @import("antfly_hash").Crc32;
+const Adler32 = @import("antfly_hash").Adler32;
 const test_support = @import("test_support.zig");
 
 const Allocator = std.mem.Allocator;
@@ -60,27 +61,35 @@ pub fn encodeRgbaWithCancellation(alloc: Allocator, width: u32, height: u32, rgb
     var compressed = try std.Io.Writer.Allocating.initCapacity(alloc, 16 * 1024);
     defer compressed.deinit();
     {
+        try compressed.writer.writeAll(std.compress.flate.Container.zlib.header());
+        var adler = Adler32.init();
         var history: [std.compress.flate.max_window_len]u8 = undefined;
         var compressor = try std.compress.flate.Compress.init(
             &compressed.writer,
             history[0..],
-            .zlib,
+            .raw,
             .default,
         );
         for (0..height) |row| {
             try compressor.writer.writeByte(0);
+            adler.update(&.{0});
             const offset = row * row_bytes;
             const row_data = rgba[offset..][0..row_bytes];
             var chunk_offset: usize = 0;
             while (chunk_offset < row_data.len) {
                 try cancellation.check();
                 const chunk_end = chunk_offset + @min(row_data.len - chunk_offset, cancellation_work_bytes);
-                try compressor.writer.writeAll(row_data[chunk_offset..chunk_end]);
+                const chunk = row_data[chunk_offset..chunk_end];
+                try compressor.writer.writeAll(chunk);
+                adler.update(chunk);
                 chunk_offset = chunk_end;
             }
         }
         try cancellation.check();
         try compressor.finish();
+        var trailer: [4]u8 = undefined;
+        std.mem.writeInt(u32, &trailer, adler.final(), .big);
+        try compressed.writer.writeAll(&trailer);
     }
     try cancellation.check();
     const zlib = compressed.writer.buffered();
@@ -110,18 +119,19 @@ pub fn encodeRgbaWithCancellation(alloc: Allocator, width: u32, height: u32, rgb
     const idat_type_start = cursor;
     @memcpy(out[cursor .. cursor + 4], "IDAT");
     cursor += 4;
-    var idat_crc = crc32FastUpdate(crc32FastInit(), out[idat_type_start..cursor]);
+    var idat_crc = Crc32.init();
+    idat_crc.update(out[idat_type_start..cursor]);
     var zlib_offset: usize = 0;
     while (zlib_offset < zlib.len) {
         try cancellation.check();
         const chunk_end = zlib_offset + @min(zlib.len - zlib_offset, cancellation_work_bytes);
         const chunk = zlib[zlib_offset..chunk_end];
         @memcpy(out[cursor .. cursor + chunk.len], chunk);
-        idat_crc = crc32FastUpdate(idat_crc, chunk);
+        idat_crc.update(chunk);
         cursor += chunk.len;
         zlib_offset = chunk_end;
     }
-    writeU32be(out[cursor .. cursor + 4], crc32FastFinal(idat_crc));
+    writeU32be(out[cursor .. cursor + 4], idat_crc.final());
     cursor += 4;
 
     try cancellation.check();
@@ -153,180 +163,10 @@ fn writeU32be(dest: []u8, value: u32) void {
 }
 
 fn chunkCrc(name: []const u8, data: []const u8) u32 {
-    var crc = crc32FastInit();
-    crc = crc32FastUpdate(crc, name);
-    crc = crc32FastUpdate(crc, data);
-    return crc32FastFinal(crc);
-}
-
-fn crc32Fast(bytes: []const u8) u32 {
-    return crc32FastFinal(crc32FastUpdate(crc32FastInit(), bytes));
-}
-
-fn crc32FastInit() u32 {
-    return 0xffffffff;
-}
-
-fn crc32FastFinal(crc: u32) u32 {
-    return crc ^ 0xffffffff;
-}
-
-fn crc32FastUpdate(initial_crc: u32, bytes: []const u8) u32 {
-    if (comptime builtin.cpu.arch == .aarch64 and std.Target.aarch64.featureSetHas(builtin.cpu.features, .crc)) {
-        return crc32Arm64Update(initial_crc, bytes);
-    }
-
-    const tables = comptime crc32SlicingTables();
-    var crc = initial_crc;
-    var index: usize = 0;
-
-    while (index + 8 <= bytes.len) : (index += 8) {
-        crc ^= readU32le(bytes[index .. index + 4]);
-        const next = readU32le(bytes[index + 4 .. index + 8]);
-        crc =
-            tables[7][@as(u8, @truncate(crc))] ^
-            tables[6][@as(u8, @truncate(crc >> 8))] ^
-            tables[5][@as(u8, @truncate(crc >> 16))] ^
-            tables[4][@as(u8, @truncate(crc >> 24))] ^
-            tables[3][@as(u8, @truncate(next))] ^
-            tables[2][@as(u8, @truncate(next >> 8))] ^
-            tables[1][@as(u8, @truncate(next >> 16))] ^
-            tables[0][@as(u8, @truncate(next >> 24))];
-    }
-
-    while (index < bytes.len) : (index += 1) {
-        crc = tables[0][@as(u8, @truncate(crc ^ bytes[index]))] ^ (crc >> 8);
-    }
-    return crc;
-}
-
-fn crc32SlicingTables() [8][256]u32 {
-    @setEvalBranchQuota(30000);
-    const polynomial: u32 = 0xedb88320;
-    var tables: [8][256]u32 = undefined;
-    for (0..256) |i| {
-        var crc: u32 = @intCast(i);
-        for (0..8) |_| {
-            crc = if ((crc & 1) != 0) (crc >> 1) ^ polynomial else crc >> 1;
-        }
-        tables[0][i] = crc;
-    }
-    for (1..8) |table_index| {
-        for (0..256) |i| {
-            const previous = tables[table_index - 1][i];
-            tables[table_index][i] = (previous >> 8) ^ tables[0][@as(u8, @truncate(previous))];
-        }
-    }
-    return tables;
-}
-
-fn readU32le(bytes: []const u8) u32 {
-    return @as(u32, bytes[0]) |
-        (@as(u32, bytes[1]) << 8) |
-        (@as(u32, bytes[2]) << 16) |
-        (@as(u32, bytes[3]) << 24);
-}
-
-fn readU16le(bytes: []const u8) u16 {
-    return @as(u16, bytes[0]) |
-        (@as(u16, bytes[1]) << 8);
-}
-
-fn readU64le(bytes: []const u8) u64 {
-    return @as(u64, bytes[0]) |
-        (@as(u64, bytes[1]) << 8) |
-        (@as(u64, bytes[2]) << 16) |
-        (@as(u64, bytes[3]) << 24) |
-        (@as(u64, bytes[4]) << 32) |
-        (@as(u64, bytes[5]) << 40) |
-        (@as(u64, bytes[6]) << 48) |
-        (@as(u64, bytes[7]) << 56);
-}
-
-fn crc32Arm64Update(initial_crc: u32, bytes: []const u8) u32 {
-    var crc = initial_crc;
-    var index: usize = 0;
-    while (index + 8 <= bytes.len) : (index += 8) {
-        crc = crc32Arm64U64(crc, readU64le(bytes[index .. index + 8]));
-    }
-    if (index + 4 <= bytes.len) {
-        crc = crc32Arm64U32(crc, readU32le(bytes[index .. index + 4]));
-        index += 4;
-    }
-    if (index + 2 <= bytes.len) {
-        crc = crc32Arm64U16(crc, readU16le(bytes[index .. index + 2]));
-        index += 2;
-    }
-    if (index < bytes.len) {
-        crc = crc32Arm64U8(crc, bytes[index]);
-    }
-    return crc;
-}
-
-fn crc32Arm64U64(crc: u32, value: u64) u32 {
-    return asm ("crc32x %[out:w], %[crc:w], %[value]"
-        : [out] "=r" (-> u32),
-        : [crc] "r" (crc),
-          [value] "r" (value),
-    );
-}
-
-fn crc32Arm64U32(crc: u32, value: u32) u32 {
-    return asm ("crc32w %[out:w], %[crc:w], %[value:w]"
-        : [out] "=r" (-> u32),
-        : [crc] "r" (crc),
-          [value] "r" (value),
-    );
-}
-
-fn crc32Arm64U16(crc: u32, value: u16) u32 {
-    return asm ("crc32h %[out:w], %[crc:w], %[value:w]"
-        : [out] "=r" (-> u32),
-        : [crc] "r" (crc),
-          [value] "r" (value),
-    );
-}
-
-fn crc32Arm64U8(crc: u32, value: u8) u32 {
-    return asm ("crc32b %[out:w], %[crc:w], %[value:w]"
-        : [out] "=r" (-> u32),
-        : [crc] "r" (crc),
-          [value] "r" (value),
-    );
-}
-
-fn adler32FastInit() u32 {
-    return 1;
-}
-
-fn adler32FastUpdate(state: u32, bytes: []const u8) u32 {
-    const base = 65521;
-    const nmax = 5552;
-    const weights: @Vector(16, u32) = .{ 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1 };
-
-    var s1 = state & 0xffff;
-    var s2 = state >> 16;
-    var index: usize = 0;
-
-    while (index < bytes.len) {
-        const end = @min(index + nmax, bytes.len);
-        while (index + 16 <= end) : (index += 16) {
-            const byte_vec: @Vector(16, u8) = bytes[index..][0..16].*;
-            const lanes: @Vector(16, u32) = @intCast(byte_vec);
-            const sum = @reduce(.Add, lanes);
-            const weighted_sum = @reduce(.Add, lanes * weights);
-            s2 += 16 * s1 + weighted_sum;
-            s1 += sum;
-        }
-        while (index < end) : (index += 1) {
-            s1 += bytes[index];
-            s2 += s1;
-        }
-        s1 %= base;
-        s2 %= base;
-    }
-
-    return s1 | (s2 << 16);
+    var crc = Crc32.init();
+    crc.update(name);
+    crc.update(data);
+    return crc.final();
 }
 
 pub fn decodeRgba(alloc: Allocator, png_bytes: []const u8) !DecodedImage {
@@ -901,27 +741,59 @@ test "encode rgba compresses repetitive pages" {
     try std.testing.expectEqualSlices(u8, rgba, decoded.rgba);
 }
 
+test "PNG shared Adler32 preserves the standard zlib container bytes" {
+    const alloc = std.testing.allocator;
+    const width = 16385; // Each row crosses the cancellation/chunk boundary.
+    const height = 2;
+    const rgba = try alloc.alloc(u8, width * height * 4);
+    defer alloc.free(rgba);
+    var random = std.Random.DefaultPrng.init(0xad1e32);
+    random.random().bytes(rgba);
+    const encoded = try encodeRgba(alloc, width, height, rgba);
+    defer alloc.free(encoded);
+
+    var reference = try std.Io.Writer.Allocating.initCapacity(alloc, 16 * 1024);
+    defer reference.deinit();
+    var history: [std.compress.flate.max_window_len]u8 = undefined;
+    var compressor = try std.compress.flate.Compress.init(&reference.writer, &history, .zlib, .default);
+    for (0..height) |row| {
+        try compressor.writer.writeByte(0);
+        const pixels = rgba[row * width * 4 ..][0 .. width * 4];
+        var offset: usize = 0;
+        while (offset < pixels.len) {
+            const end = offset + @min(pixels.len - offset, cancellation_work_bytes);
+            try compressor.writer.writeAll(pixels[offset..end]);
+            offset = end;
+        }
+    }
+    try compressor.finish();
+    const idat_offset = 8 + chunkTotalLen(13);
+    const idat_len = std.mem.readInt(u32, encoded[idat_offset..][0..4], .big);
+    try std.testing.expectEqualStrings("IDAT", encoded[idat_offset + 4 ..][0..4]);
+    try std.testing.expectEqualSlices(u8, reference.writer.buffered(), encoded[idat_offset + 8 ..][0..idat_len]);
+}
+
 test "png crc32 fast path matches std crc32" {
     const bytes = "IHDRabcdefghijklmnopqrstuvwxyz0123456789";
-    try std.testing.expectEqual(std.hash.Crc32.hash(bytes), crc32Fast(bytes));
-    var crc = crc32FastInit();
-    crc = crc32FastUpdate(crc, bytes[0..4]);
-    crc = crc32FastUpdate(crc, bytes[4..]);
-    try std.testing.expectEqual(std.hash.Crc32.hash(bytes), crc32FastFinal(crc));
+    try std.testing.expectEqual(std.hash.Crc32.hash(bytes), Crc32.hash(bytes));
+    var crc = Crc32.init();
+    crc.update(bytes[0..4]);
+    crc.update(bytes[4..]);
+    try std.testing.expectEqual(std.hash.Crc32.hash(bytes), crc.final());
 }
 
 test "png adler32 fast path matches std adler32" {
     const bytes = "abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789";
-    try std.testing.expectEqual(std.hash.Adler32.hash(bytes), adler32FastUpdate(adler32FastInit(), bytes));
+    try std.testing.expectEqual(std.hash.Adler32.hash(bytes), Adler32.hash(bytes));
 
-    var chunked = adler32FastInit();
-    chunked = adler32FastUpdate(chunked, bytes[0..7]);
-    chunked = adler32FastUpdate(chunked, bytes[7..31]);
-    chunked = adler32FastUpdate(chunked, bytes[31..]);
-    try std.testing.expectEqual(std.hash.Adler32.hash(bytes), chunked);
+    var chunked = Adler32.init();
+    chunked.update(bytes[0..7]);
+    chunked.update(bytes[7..31]);
+    chunked.update(bytes[31..]);
+    try std.testing.expectEqual(std.hash.Adler32.hash(bytes), chunked.final());
 
     const long = [_]u8{0xf3} ** 7000;
-    try std.testing.expectEqual(std.hash.Adler32.hash(&long), adler32FastUpdate(adler32FastInit(), &long));
+    try std.testing.expectEqual(std.hash.Adler32.hash(&long), Adler32.hash(&long));
 }
 
 test "decode rgba matches manifest-backed red fixture" {

--- a/zig/pkg/antfly/build/embedded.zig
+++ b/zig/pkg/antfly/build/embedded.zig
@@ -32,6 +32,7 @@ pub fn configureModule(
     bloom_mod: *std.Build.Module,
     vector_mod: *std.Build.Module,
     vectorindex_mod: *std.Build.Module,
+    hash_mod: *std.Build.Module,
     vellum_mod: *std.Build.Module,
     regex_mod: *std.Build.Module,
     image_mod: *std.Build.Module,
@@ -55,6 +56,7 @@ pub fn configureModule(
     mod.addImport("bloom", bloom_mod);
     mod.addImport("antfly_vector", vector_mod);
     mod.addImport("antfly_vectorindex", vectorindex_mod);
+    mod.addImport("antfly_hash", hash_mod);
     mod.addImport("antfly_vellum", vellum_mod);
     mod.addImport("antfly_regex", regex_mod);
     mod.addImport("antfly_image", image_mod);

--- a/zig/pkg/antfly/build/storage.zig
+++ b/zig/pkg/antfly/build/storage.zig
@@ -116,6 +116,7 @@ pub fn makeLmdbModule(
     build_options: *std.Build.Step.Options,
     lmdb_engine_mod: *std.Build.Module,
     platform_mod: *std.Build.Module,
+    hash_mod: *std.Build.Module,
 ) *std.Build.Module {
     const mod = b.createModule(.{
         .root_source_file = b.path(root_path),
@@ -125,6 +126,7 @@ pub fn makeLmdbModule(
     mod.addOptions("build_options", build_options);
     mod.addImport("lmdb_engine", lmdb_engine_mod);
     mod.addImport("antfly_platform", platform_mod);
+    mod.addImport("antfly_hash", hash_mod);
     mod.addCSourceFiles(.{
         .files = &.{ "lib/lmdb/mdb.c", "lib/lmdb/midl.c" },
         .flags = &lmdb_c_flags,

--- a/zig/pkg/antfly/src/raft/storage/replica_state.zig
+++ b/zig/pkg/antfly/src/raft/storage/replica_state.zig
@@ -13,6 +13,7 @@
 // limitations.
 
 const std = @import("std");
+const Crc32 = @import("antfly_hash").Crc32;
 const fs_paths = @import("../../common/fs_paths.zig");
 const threaded_io_limits = @import("../../common/threaded_io_limits.zig");
 const raft_engine = @import("raft_engine");
@@ -308,7 +309,7 @@ pub const PersistentReplicaState = struct {
             raw[raw.len - state_checksum_len ..][0..state_checksum_len],
             .little,
         );
-        if (std.hash.Crc32.hash(body) != expected_checksum) return error.InvalidReplicaState;
+        if (Crc32.hash(body) != expected_checksum) return error.InvalidReplicaState;
 
         var cursor: usize = 0;
         if (try readInt(u32, body, &cursor) != magic) return error.InvalidReplicaState;
@@ -380,7 +381,7 @@ pub const PersistentReplicaState = struct {
         if (buffer.items.len > max_state_body_bytes)
             return error.ReplicaStateTooLarge;
         var checksum: [state_checksum_len]u8 = undefined;
-        std.mem.writeInt(u32, &checksum, std.hash.Crc32.hash(buffer.items), .little);
+        std.mem.writeInt(u32, &checksum, Crc32.hash(buffer.items), .little);
         try buffer.appendSlice(self.alloc, &checksum);
 
         const path = try self.statePath();
@@ -656,7 +657,7 @@ test "persistent replica state rejects corrupt unchecked and structurally invali
     std.mem.writeInt(
         u32,
         unchecked[unchecked.len - state_checksum_len ..][0..state_checksum_len],
-        std.hash.Crc32.hash(unchecked[0 .. unchecked.len - state_checksum_len]),
+        Crc32.hash(unchecked[0 .. unchecked.len - state_checksum_len]),
         .little,
     );
     try std.Io.Dir.cwd().writeFile(std.testing.io, .{ .sub_path = state_path, .data = unchecked });
@@ -678,7 +679,7 @@ test "persistent replica state rejects corrupt unchecked and structurally invali
     try PersistentReplicaState.appendInt(u64, alloc, &invalid, 0);
     try PersistentReplicaState.appendInt(u64, alloc, &invalid, 0);
     try PersistentReplicaState.appendInt(u32, alloc, &invalid, std.math.maxInt(u32));
-    try PersistentReplicaState.appendInt(u32, alloc, &invalid, std.hash.Crc32.hash(invalid.items));
+    try PersistentReplicaState.appendInt(u32, alloc, &invalid, Crc32.hash(invalid.items));
     try std.Io.Dir.cwd().writeFile(std.testing.io, .{ .sub_path = state_path, .data = invalid.items });
     try std.testing.expectError(
         error.InvalidReplicaState,

--- a/zig/pkg/antfly/src/raft/storage/wal_replica_state.zig
+++ b/zig/pkg/antfly/src/raft/storage/wal_replica_state.zig
@@ -13,6 +13,7 @@
 // limitations.
 
 const std = @import("std");
+const Crc32 = @import("antfly_hash").Crc32;
 const fs_paths = @import("../../common/fs_paths.zig");
 const threaded_io_limits = @import("../../common/threaded_io_limits.zig");
 const raft_engine = @import("raft_engine");
@@ -646,7 +647,7 @@ pub const WalReplicaState = struct {
         std.mem.writeInt(u32, payload[0..4], applied_watermark_magic, .little);
         std.mem.writeInt(u32, payload[4..8], applied_watermark_version, .little);
         std.mem.writeInt(u64, payload[8..16], self.applied_index, .little);
-        std.mem.writeInt(u32, payload[16..20], std.hash.Crc32.hash(payload[0..16]), .little);
+        std.mem.writeInt(u32, payload[16..20], Crc32.hash(payload[0..16]), .little);
         try writeFileAtomically(self.io_impl.io(), self.applied_watermark_path, &payload);
         self.durable_applied_index = self.applied_index;
         self.stats.applied_watermark_persist_ns += elapsedSince(started_ns);
@@ -678,7 +679,7 @@ pub const WalReplicaState = struct {
         if (file_magic != applied_watermark_magic) return error.InvalidReplicaState;
         const file_version = std.mem.readInt(u32, payload[4..8], .little);
         if (file_version != applied_watermark_version) return error.UnsupportedReplicaStateVersion;
-        if (std.mem.readInt(u32, payload[16..20], .little) != std.hash.Crc32.hash(payload[0..16]))
+        if (std.mem.readInt(u32, payload[16..20], .little) != Crc32.hash(payload[0..16]))
             return error.InvalidReplicaState;
         const watermark = std.mem.readInt(u64, payload[8..16], .little);
         if (watermark > self.applied_index) self.applied_index = watermark;

--- a/zig/pkg/antfly/src/segment.zig
+++ b/zig/pkg/antfly/src/segment.zig
@@ -31,6 +31,7 @@
 //! Compatible with zapx v16/v17 section-based architecture.
 
 const std = @import("std");
+const Crc32 = @import("antfly_hash").Crc32;
 const Allocator = std.mem.Allocator;
 const byte_copy = @import("common/byte_copy.zig");
 const platform_time = @import("antfly_platform").time;
@@ -356,7 +357,7 @@ pub const SegmentWriter = struct {
                 section.offset = sink.len();
                 try sink.appendSlice(section.data);
                 section.length = section.data.len;
-                section.checksum = std.hash.Crc32.hash(section.data);
+                section.checksum = Crc32.hash(section.data);
                 self.alloc.free(section.data);
                 section.data = &.{};
             }
@@ -483,7 +484,7 @@ pub const SegmentWriter = struct {
             try sink.appendSlice(compressed);
             try sink.writeAt(
                 block_checksums_start + @as(usize, block_idx) * 4,
-                &@as([4]u8, @bitCast(std.mem.nativeToLittle(u32, std.hash.Crc32.hash(compressed)))),
+                &@as([4]u8, @bitCast(std.mem.nativeToLittle(u32, Crc32.hash(compressed)))),
             );
 
             const block_end_offset: u64 = @intCast(sink.len() - data_start);
@@ -655,9 +656,9 @@ pub const SegmentReader = struct {
         if (index_offset > footer_start) return error.InvalidSegment;
         if (stored_start > index_offset or stored_len > index_offset - stored_start) return error.InvalidSegment;
         if (stored_metadata_len > stored_len) return error.InvalidSegment;
-        const expected_metadata_crc = std.hash.Crc32.hash(data[index_offset .. end - 8]);
+        const expected_metadata_crc = Crc32.hash(data[index_offset .. end - 8]);
         if (metadata_crc != expected_metadata_crc) return error.CrcMismatch;
-        if (std.hash.Crc32.hash(data[stored_start..][0..stored_metadata_len]) != stored_metadata_crc) return error.CrcMismatch;
+        if (Crc32.hash(data[stored_start..][0..stored_metadata_len]) != stored_metadata_crc) return error.CrcMismatch;
 
         if (stored_metadata_len < 5) return error.InvalidSegment;
         const stored_mode = data[stored_start];
@@ -806,7 +807,7 @@ pub const SegmentReader = struct {
                             integrity_invalid => return error.CrcMismatch,
                             else => {},
                         }
-                        if (std.hash.Crc32.hash(bytes) != section.checksum) {
+                        if (Crc32.hash(bytes) != section.checksum) {
                             validation.store(integrity_invalid, .release);
                             return error.CrcMismatch;
                         }
@@ -833,7 +834,7 @@ pub const SegmentReader = struct {
             integrity_invalid => return error.CrcMismatch,
             else => {},
         }
-        if (std.hash.Crc32.hash(bytes) != expected) {
+        if (Crc32.hash(bytes) != expected) {
             validation.store(integrity_invalid, .release);
             return error.CrcMismatch;
         }
@@ -1193,13 +1194,13 @@ pub const MemorySegmentSink = struct {
     fn crc32Prefix(ptr: *anyopaque, len_prefix: usize) !u32 {
         const self: *MemorySegmentSink = @ptrCast(@alignCast(ptr));
         if (len_prefix > self.out.items.len) return error.InvalidSegment;
-        return std.hash.Crc32.hash(self.out.items[0..len_prefix]);
+        return Crc32.hash(self.out.items[0..len_prefix]);
     }
 
     fn crc32Range(ptr: *anyopaque, offset: usize, range_len: usize) !u32 {
         const self: *MemorySegmentSink = @ptrCast(@alignCast(ptr));
         if (offset > self.out.items.len or range_len > self.out.items.len - offset) return error.InvalidSegment;
-        return std.hash.Crc32.hash(self.out.items[offset..][0..range_len]);
+        return Crc32.hash(self.out.items[offset..][0..range_len]);
     }
 };
 
@@ -1924,7 +1925,7 @@ fn flushMergedStoredBlock(
     try sink.appendSlice(compressed);
     try sink.writeAt(
         block_checksums_start + @as(usize, block_idx) * 4,
-        &@as([4]u8, @bitCast(std.mem.nativeToLittle(u32, std.hash.Crc32.hash(compressed)))),
+        &@as([4]u8, @bitCast(std.mem.nativeToLittle(u32, Crc32.hash(compressed)))),
     );
     const block_end_offset: u64 = @intCast(sink.len() - data_start);
     try sink.writeAt(block_offsets_start + @as(usize, block_idx) * 8, &@as([8]u8, @bitCast(std.mem.nativeToLittle(u64, block_end_offset))));
@@ -2007,7 +2008,7 @@ fn appendBuiltSection(
         .section_type = section_type,
         .offset = offset,
         .length = data.len,
-        .checksum = std.hash.Crc32.hash(data),
+        .checksum = Crc32.hash(data),
     });
 }
 
@@ -2947,13 +2948,13 @@ test "segment readers fail closed on checksummed malformed document offsets" {
     std.mem.writeInt(
         u32,
         malformed[end - 16 ..][0..4],
-        std.hash.Crc32.hash(malformed[stored_start..][0..stored_metadata_len]),
+        Crc32.hash(malformed[stored_start..][0..stored_metadata_len]),
         .big,
     );
     std.mem.writeInt(
         u32,
         malformed[end - 8 ..][0..4],
-        std.hash.Crc32.hash(malformed[sections_index_offset .. end - 8]),
+        Crc32.hash(malformed[sections_index_offset .. end - 8]),
         .big,
     );
 

--- a/zig/pkg/antfly/src/serverless/external_source/iceberg_avro.zig
+++ b/zig/pkg/antfly/src/serverless/external_source/iceberg_avro.zig
@@ -21,6 +21,7 @@
 //! manifest files without inventing a JSON-only test format.
 
 const std = @import("std");
+const Crc32 = @import("antfly_hash").Crc32;
 const Allocator = std.mem.Allocator;
 const snappy = @import("../../encoding/snappy.zig");
 
@@ -439,7 +440,7 @@ fn decodeBlockAlloc(
             const expected_crc = std.mem.readInt(u32, encoded_block[checksum_start..][0..4], .big);
             const decoded = try snappy.decode(alloc, compressed);
             errdefer alloc.free(decoded);
-            if (std.hash.Crc32.hash(decoded) != expected_crc) return error.AvroBlockChecksumMismatch;
+            if (Crc32.hash(decoded) != expected_crc) return error.AvroBlockChecksumMismatch;
             break :blk .{ .bytes = decoded, .owned = decoded };
         },
         .zstandard => blk: {
@@ -1484,7 +1485,7 @@ fn encodeFixtureBlockAlloc(
         const encoded = try alloc.alloc(u8, compressed.len + 4);
         errdefer alloc.free(encoded);
         @memcpy(encoded[0..compressed.len], compressed);
-        std.mem.writeInt(u32, encoded[compressed.len..][0..4], std.hash.Crc32.hash(block), .big);
+        std.mem.writeInt(u32, encoded[compressed.len..][0..4], Crc32.hash(block), .big);
         return .{ .bytes = encoded, .owned = encoded };
     }
     if (std.mem.eql(u8, codec, "zstandard")) {

--- a/zig/pkg/antfly/src/serverless/query/lake_object_reader.zig
+++ b/zig/pkg/antfly/src/serverless/query/lake_object_reader.zig
@@ -15,6 +15,9 @@
 //! Object-storage backed range reader for lake scans.
 
 const std = @import("std");
+const Crc32 = @import("antfly_hash").Crc32;
+const Crc32c = @import("antfly_hash").Crc32c;
+const Crc64Nvme = @import("antfly_hash").Crc64Nvme;
 const lake_range_io = @import("lake_range_io.zig");
 const lake_parquet_rowgroup = @import("lake_parquet_rowgroup.zig");
 const object_storage = @import("../../storage/object_storage.zig");
@@ -135,22 +138,15 @@ fn validatePlannedObjectChecksum(
     switch (checksum.algorithm) {
         .crc32_base64 => {
             var digest: [4]u8 = undefined;
-            std.mem.writeInt(u32, &digest, std.hash.crc.Crc32.hash(body), .big);
+            std.mem.writeInt(u32, &digest, Crc32.hash(body), .big);
             try validateBase64Digest(checksum.value, &digest);
         },
         .crc32c_base64 => {
             var digest: [4]u8 = undefined;
-            std.mem.writeInt(u32, &digest, std.hash.crc.Crc32Iscsi.hash(body), .big);
+            std.mem.writeInt(u32, &digest, Crc32c.hash(body), .big);
             try validateBase64Digest(checksum.value, &digest);
         },
         .crc64nvme_base64 => {
-            const Crc64Nvme = std.hash.crc.Crc(u64, .{
-                .polynomial = 0xad93d23594c93659,
-                .initial = 0xffffffffffffffff,
-                .reflect_input = true,
-                .reflect_output = true,
-                .xor_output = 0xffffffffffffffff,
-            });
             var digest: [8]u8 = undefined;
             std.mem.writeInt(u64, &digest, Crc64Nvme.hash(body), .big);
             try validateBase64Digest(checksum.value, &digest);
@@ -494,18 +490,29 @@ test "lake object storage range reader validates full object checksums" {
     var mismatched_reader = ObjectStorageRangeReader.init(mismatched.client());
     try std.testing.expectError(error.PreconditionFailed, mismatched_reader.parquetReader().readPlannedAlloc(alloc, full_read));
 
-    var crc32c_digest: [4]u8 = undefined;
-    std.mem.writeInt(u32, &crc32c_digest, std.hash.crc.Crc32Iscsi.hash("0123456789"), .big);
-    var crc32c_encoded: [std.base64.standard.Encoder.calcSize(crc32c_digest.len)]u8 = undefined;
-    _ = std.base64.standard.Encoder.encode(&crc32c_encoded, &crc32c_digest);
-    var gcs_crc32c = ChecksumObjectStorage{ .checksum = .{
-        .algorithm = .crc32c_base64,
-        .value = &crc32c_encoded,
-    } };
-    var gcs_crc32c_reader = ObjectStorageRangeReader.init(gcs_crc32c.client());
-    const gcs_bytes = try gcs_crc32c_reader.parquetReader().readPlannedAlloc(alloc, full_read);
-    defer alloc.free(gcs_bytes);
-    try std.testing.expectEqualStrings("0123456789", gcs_bytes);
+    // Fixed, independently generated checksums for the full body "0123456789".
+    // This tests provider byte order/base64 framing as well as all three CRC variants.
+    const crc_cases = [_]struct { algorithm: object_storage.ObjectChecksumAlgorithm, value: []const u8 }{
+        .{ .algorithm = .crc32_base64, .value = "poTHxg==" },
+        .{ .algorithm = .crc32c_base64, .value = "KAwGng==" },
+        .{ .algorithm = .crc64nvme_base64, .value = "Ffmx7kz9nB0=" },
+    };
+    for (crc_cases) |case| {
+        var provider = ChecksumObjectStorage{ .checksum = .{
+            .algorithm = case.algorithm,
+            .value = case.value,
+        } };
+        var reader = ObjectStorageRangeReader.init(provider.client());
+        const checked = try reader.parquetReader().readPlannedAlloc(alloc, full_read);
+        defer alloc.free(checked);
+        try std.testing.expectEqualStrings("0123456789", checked);
+        provider.checksum.?.value = if (case.algorithm == .crc64nvme_base64) "AAAAAAAAAAA=" else "AAAAAA==";
+        try std.testing.expectError(error.PreconditionFailed, reader.parquetReader().readPlannedAlloc(alloc, full_read));
+        // An object-wide CRC cannot validate a range of that object.
+        const partial = try reader.parquetReader().readPlannedAlloc(alloc, partial_read);
+        defer alloc.free(partial);
+        try std.testing.expectEqualStrings("2345", partial);
+    }
 
     var composite = ChecksumObjectStorage{ .checksum = .{
         .algorithm = .sha256_base64,

--- a/zig/pkg/antfly/src/storage/backup_bundle.zig
+++ b/zig/pkg/antfly/src/storage/backup_bundle.zig
@@ -11,6 +11,7 @@
 //! in backup_repository.zig and address complete manifests by SHA-256.
 
 const std = @import("std");
+const Crc32 = @import("antfly_hash").Crc32;
 
 pub const manifest_schema_version: u32 = 1;
 pub const afb_reader_version: u32 = 2;
@@ -375,14 +376,14 @@ pub fn encodeTrailer(trailer: Trailer) [trailer_size]u8 {
     @memcpy(out[0..trailer_magic.len], &trailer_magic);
     std.mem.writeInt(u64, out[8..16], trailer.footer_offset, .little);
     std.mem.writeInt(u64, out[16..24], trailer.footer_payload_size, .little);
-    std.mem.writeInt(u32, out[28..32], std.hash.Crc32.hash(out[0..28]), .little);
+    std.mem.writeInt(u32, out[28..32], Crc32.hash(out[0..28]), .little);
     return out;
 }
 
 pub fn decodeTrailer(encoded: *const [trailer_size]u8, bundle_size: u64) !Trailer {
     if (bundle_size < trailer_size) return error.InvalidBundleFooter;
     if (!std.mem.eql(u8, encoded[0..trailer_magic.len], &trailer_magic) or
-        std.mem.readInt(u32, encoded[28..32], .little) != std.hash.Crc32.hash(encoded[0..28]))
+        std.mem.readInt(u32, encoded[28..32], .little) != Crc32.hash(encoded[0..28]))
         return error.InvalidBundleFooter;
     const trailer: Trailer = .{
         .footer_offset = std.mem.readInt(u64, encoded[8..16], .little),

--- a/zig/pkg/antfly/src/storage/backup_codec.zig
+++ b/zig/pkg/antfly/src/storage/backup_codec.zig
@@ -14,7 +14,7 @@
 
 const std = @import("std");
 const Allocator = std.mem.Allocator;
-const Crc32 = std.hash.Crc32;
+const Crc32 = @import("antfly_hash").Crc32;
 const ArrayList = std.ArrayList;
 
 /// AFB file magic bytes: "ANTFLYB\n"

--- a/zig/pkg/antfly/src/storage/db/backfill_state.zig
+++ b/zig/pkg/antfly/src/storage/db/backfill_state.zig
@@ -13,6 +13,7 @@
 // limitations.
 
 const std = @import("std");
+const Crc32 = @import("antfly_hash").Crc32;
 const builtin = @import("builtin");
 const Allocator = std.mem.Allocator;
 const fs_paths = @import("../../common/fs_paths.zig");
@@ -459,7 +460,7 @@ fn encodeState(alloc: Allocator, owner_generation: ?u64, complete: bool, key: []
     pos += rebuild_state_key_length_bytes;
     @memcpy(encoded[pos .. pos + key.len], key);
     pos += key.len;
-    std.mem.writeInt(u32, encoded[pos..][0..rebuild_state_checksum_bytes], std.hash.Crc32.hash(encoded[0..pos]), .little);
+    std.mem.writeInt(u32, encoded[pos..][0..rebuild_state_checksum_bytes], Crc32.hash(encoded[0..pos]), .little);
     return encoded;
 }
 
@@ -501,7 +502,7 @@ fn decodeState(alloc: Allocator, encoded: []const u8) !DecodedCursor {
 
     const checksum_offset = encoded.len - rebuild_state_checksum_bytes;
     const stored_checksum = std.mem.readInt(u32, encoded[checksum_offset..][0..rebuild_state_checksum_bytes], .little);
-    if (stored_checksum != std.hash.Crc32.hash(encoded[0..checksum_offset])) {
+    if (stored_checksum != Crc32.hash(encoded[0..checksum_offset])) {
         return error.InvalidRebuildState;
     }
     const complete = flags & rebuild_state_flag_complete != 0;

--- a/zig/pkg/antfly/src/storage/db/derived/apply_state.zig
+++ b/zig/pkg/antfly/src/storage/db/derived/apply_state.zig
@@ -13,6 +13,7 @@
 // limitations.
 
 const std = @import("std");
+const Crc32 = @import("antfly_hash").Crc32;
 const platform_sync = @import("antfly_platform").sync;
 const builtin = @import("builtin");
 const Allocator = std.mem.Allocator;
@@ -594,7 +595,7 @@ fn decodeCheckpoint(alloc: Allocator, raw: []const u8) !CheckpointMap {
         raw[raw.len - checkpoint_checksum_len ..][0..checkpoint_checksum_len],
         .little,
     );
-    if (std.hash.Crc32.hash(body) != stored_checksum) return error.InvalidDerivedApplyState;
+    if (Crc32.hash(body) != stored_checksum) return error.InvalidDerivedApplyState;
     if (!std.mem.eql(u8, body[0..checkpoint_magic.len], checkpoint_magic)) return error.InvalidDerivedApplyState;
     var pos: usize = checkpoint_magic.len;
     const format_version = try readCheckpointInt(body, &pos, u32);
@@ -688,7 +689,7 @@ fn encodeCheckpoint(alloc: Allocator, checkpoint: *const CheckpointMap) ![]u8 {
         try appendCheckpointInt(alloc, &out, u64, value.published_count orelse 0);
         try out.appendSlice(alloc, name);
     }
-    try appendCheckpointInt(alloc, &out, u32, std.hash.Crc32.hash(out.items));
+    try appendCheckpointInt(alloc, &out, u32, Crc32.hash(out.items));
     if (out.items.len > checkpoint_max_bytes) return error.InvalidDerivedApplyState;
     return try out.toOwnedSlice(alloc);
 }
@@ -951,7 +952,7 @@ test "projection checkpoint reads v2 without inventing a publication certificate
     try appendCheckpointInt(alloc, &encoded, u64, 9);
     try appendCheckpointInt(alloc, &encoded, u64, 0x1234);
     try encoded.appendSlice(alloc, name);
-    try appendCheckpointInt(alloc, &encoded, u32, std.hash.Crc32.hash(encoded.items));
+    try appendCheckpointInt(alloc, &encoded, u32, Crc32.hash(encoded.items));
 
     var checkpoint = try decodeCheckpoint(alloc, encoded.items);
     defer checkpoint.deinit(alloc);

--- a/zig/pkg/antfly/src/storage/db/derived/index_generation_manifest.zig
+++ b/zig/pkg/antfly/src/storage/db/derived/index_generation_manifest.zig
@@ -9,6 +9,7 @@
 //! fsync+rename manifest exists. A directory alone is never publication proof.
 
 const std = @import("std");
+const Crc32 = @import("antfly_hash").Crc32;
 const fs_paths = @import("../../../common/fs_paths.zig");
 
 const Allocator = std.mem.Allocator;
@@ -150,7 +151,7 @@ fn encode(alloc: Allocator, generation_id: u128, index_name: []const u8, config_
     try appendInt(alloc, &out, u64, sequence);
     try appendInt(alloc, &out, u32, @intCast(index_name.len));
     try out.appendSlice(alloc, index_name);
-    try appendInt(alloc, &out, u32, std.hash.Crc32.hash(out.items));
+    try appendInt(alloc, &out, u32, Crc32.hash(out.items));
     return try out.toOwnedSlice(alloc);
 }
 
@@ -159,7 +160,7 @@ fn decode(alloc: Allocator, raw: []const u8) !Manifest {
         return error.InvalidIndexGenerationManifest;
     }
     const payload_end = raw.len - 4;
-    if (std.hash.Crc32.hash(raw[0..payload_end]) != std.mem.readInt(u32, raw[payload_end..][0..4], .little)) {
+    if (Crc32.hash(raw[0..payload_end]) != std.mem.readInt(u32, raw[payload_end..][0..4], .little)) {
         return error.InvalidIndexGenerationManifest;
     }
     var pos: usize = magic.len;

--- a/zig/pkg/antfly/src/storage/db/derived/index_repair_state.zig
+++ b/zig/pkg/antfly/src/storage/db/derived/index_repair_state.zig
@@ -13,6 +13,7 @@
 //! never observe one without the other.
 
 const std = @import("std");
+const Crc32 = @import("antfly_hash").Crc32;
 const Allocator = std.mem.Allocator;
 const fs_paths = @import("../../../common/fs_paths.zig");
 const platform_sync = @import("antfly_platform").sync;
@@ -834,7 +835,7 @@ fn encode(alloc: Allocator, state: *const State) ![]u8 {
             try appendInt(alloc, &out, u64, pin.retain_after_sequence);
         }
     }
-    try appendInt(alloc, &out, u32, std.hash.Crc32.hash(out.items));
+    try appendInt(alloc, &out, u32, Crc32.hash(out.items));
     if (out.items.len > max_file_bytes) return error.IndexRepairStateTooLarge;
     return try out.toOwnedSlice(alloc);
 }
@@ -843,7 +844,7 @@ fn decode(alloc: Allocator, raw: []const u8) !State {
     if (raw.len < magic.len + 4 + 4 or !std.mem.eql(u8, raw[0..magic.len], magic)) return error.InvalidIndexRepairState;
     const payload_end = raw.len - 4;
     const expected_crc = std.mem.readInt(u32, raw[payload_end..][0..4], .little);
-    if (std.hash.Crc32.hash(raw[0..payload_end]) != expected_crc) return error.InvalidIndexRepairState;
+    if (Crc32.hash(raw[0..payload_end]) != expected_crc) return error.InvalidIndexRepairState;
     var pos: usize = magic.len;
     const decoded_format_version = try readInt(raw[0..payload_end], &pos, u32);
     if (decoded_format_version < 1 or decoded_format_version > format_version) return error.InvalidIndexRepairState;

--- a/zig/pkg/antfly/src/storage/db/enrichment/document_extraction.zig
+++ b/zig/pkg/antfly/src/storage/db/enrichment/document_extraction.zig
@@ -13,6 +13,7 @@
 // limitations.
 
 const std = @import("std");
+const Crc32 = @import("antfly_hash").Crc32;
 const builtin = @import("builtin");
 const build_options = @import("build_options");
 const platform_time = @import("antfly_platform").time;
@@ -3324,7 +3325,7 @@ fn buildStoredZipAlloc(alloc: Allocator, entries: []const TestZipEntry) ![]u8 {
 
     for (entries) |entry| {
         const offset = out.items.len;
-        const crc = std.hash.crc.Crc32.hash(entry.data);
+        const crc = Crc32.hash(entry.data);
         try appendZipLe32(alloc, &out, 0x04034b50);
         try appendZipLe16(alloc, &out, 20);
         try appendZipLe16(alloc, &out, 0);

--- a/zig/pkg/antfly/src/storage/db/enrichment/enrichment_state.zig
+++ b/zig/pkg/antfly/src/storage/db/enrichment/enrichment_state.zig
@@ -13,6 +13,7 @@
 // limitations.
 
 const std = @import("std");
+const Crc32 = @import("antfly_hash").Crc32;
 const Allocator = std.mem.Allocator;
 const backend_erased = @import("../../backend_erased.zig");
 const docstore_mod = @import("../../docstore.zig");
@@ -172,7 +173,7 @@ fn encodeReplayCursor(alloc: Allocator, cursor: ReplayCursor) ![]u8 {
     writeCheckpointInt(raw, &pos, u32, @intCast(cursor.doc_key.len));
     @memcpy(raw[pos .. pos + cursor.doc_key.len], cursor.doc_key);
     pos += cursor.doc_key.len;
-    writeCheckpointInt(raw, &pos, u32, std.hash.Crc32.hash(raw[0..body_len]));
+    writeCheckpointInt(raw, &pos, u32, Crc32.hash(raw[0..body_len]));
     return raw;
 }
 
@@ -182,7 +183,7 @@ fn decodeReplayCursor(alloc: Allocator, raw: []const u8) !ReplayCursor {
         return error.InvalidEnrichmentState;
     const body_len = raw.len - 4;
     const expected_crc = std.mem.readInt(u32, raw[body_len..][0..4], .little);
-    if (std.hash.Crc32.hash(raw[0..body_len]) != expected_crc) return error.InvalidEnrichmentState;
+    if (Crc32.hash(raw[0..body_len]) != expected_crc) return error.InvalidEnrichmentState;
     var pos: usize = replay_cursor_magic.len;
     if (readCheckpointInt(raw, &pos, u32) != replay_cursor_format_version)
         return error.InvalidEnrichmentState;

--- a/zig/pkg/antfly/src/storage/db/root_identity.zig
+++ b/zig/pkg/antfly/src/storage/db/root_identity.zig
@@ -10,6 +10,7 @@
 //! atomically published; ordinary opens only load the path-owned identity.
 
 const std = @import("std");
+const Crc32 = @import("antfly_hash").Crc32;
 const Allocator = std.mem.Allocator;
 const fs_paths = @import("../../common/fs_paths.zig");
 const platform_time = @import("antfly_platform").time;
@@ -134,7 +135,7 @@ fn encode(state: State) [encoded_len]u8 {
     pos += @sizeOf(u32);
     std.mem.writeInt(u128, raw[pos..][0..@sizeOf(u128)], state.incarnation, .little);
     pos += @sizeOf(u128);
-    std.mem.writeInt(u32, raw[pos..][0..@sizeOf(u32)], std.hash.Crc32.hash(raw[0..pos]), .little);
+    std.mem.writeInt(u32, raw[pos..][0..@sizeOf(u32)], Crc32.hash(raw[0..pos]), .little);
     return raw;
 }
 
@@ -142,7 +143,7 @@ fn decode(raw: []const u8) !State {
     if (raw.len != encoded_len or !std.mem.eql(u8, raw[0..magic.len], magic)) return error.InvalidRootIdentityState;
     const payload_end = raw.len - @sizeOf(u32);
     const expected_crc = std.mem.readInt(u32, raw[payload_end..][0..@sizeOf(u32)], .little);
-    if (std.hash.Crc32.hash(raw[0..payload_end]) != expected_crc) return error.InvalidRootIdentityState;
+    if (Crc32.hash(raw[0..payload_end]) != expected_crc) return error.InvalidRootIdentityState;
     var pos: usize = magic.len;
     const version = std.mem.readInt(u32, raw[pos..][0..@sizeOf(u32)], .little);
     pos += @sizeOf(u32);

--- a/zig/pkg/antfly/src/storage/ha/backup_manifest.zig
+++ b/zig/pkg/antfly/src/storage/ha/backup_manifest.zig
@@ -20,7 +20,7 @@
 
 const std = @import("std");
 const Allocator = std.mem.Allocator;
-const Crc32 = std.hash.Crc32;
+const Crc32 = @import("antfly_hash").Crc32;
 const standby_mod = @import("standby.zig");
 
 pub const magic = [8]u8{ 'A', 'F', 'H', 'A', 'B', 'K', 'P', '\n' };

--- a/zig/pkg/antfly/src/storage/ha/fencing.zig
+++ b/zig/pkg/antfly/src/storage/ha/fencing.zig
@@ -23,7 +23,7 @@
 
 const std = @import("std");
 const Allocator = std.mem.Allocator;
-const Crc32 = std.hash.Crc32;
+const Crc32 = @import("antfly_hash").Crc32;
 const replication_record = @import("replication_record.zig");
 const standby_mod = @import("standby.zig");
 const validation = @import("validation.zig");

--- a/zig/pkg/antfly/src/storage/ha/replication_record.zig
+++ b/zig/pkg/antfly/src/storage/ha/replication_record.zig
@@ -21,7 +21,7 @@
 
 const std = @import("std");
 const Allocator = std.mem.Allocator;
-const Crc32 = std.hash.Crc32;
+const Crc32 = @import("antfly_hash").Crc32;
 
 pub const magic = [8]u8{ 'A', 'F', 'H', 'A', 'W', 'A', 'L', '\n' };
 pub const format_version: u16 = 1;

--- a/zig/pkg/antfly/src/storage/ha/seed_artifact.zig
+++ b/zig/pkg/antfly/src/storage/ha/seed_artifact.zig
@@ -12,6 +12,7 @@
 //! or Job restarts: an existing object is accepted only when its bytes match.
 
 const std = @import("std");
+const Crc32 = @import("antfly_hash").Crc32;
 const Allocator = std.mem.Allocator;
 const Sha256 = std.crypto.hash.sha2.Sha256;
 const fs_paths = @import("../../common/fs_paths.zig");
@@ -385,7 +386,7 @@ fn publishWithOptions(alloc: Allocator, store: Store, request: PublishRequest, o
         defer source.close(io);
         var reader = source.reader(io, &.{});
         var file_sha = Sha256.init(.{});
-        var file_crc = std.hash.Crc32.init();
+        var file_crc = Crc32.init();
         var streamed_bytes: u64 = 0;
         var chunk_receipts = std.ArrayListUnmanaged(ChunkReceipt).empty;
         errdefer {
@@ -1153,7 +1154,7 @@ fn checksumRemoteArtifactFile(
     limits: Limits,
 ) !RestoredFile {
     var sha = Sha256.init(.{});
-    var crc = std.hash.Crc32.init();
+    var crc = Crc32.init();
     var read_bytes: u64 = 0;
     switch (receipt_version) {
         legacy_format_version => {
@@ -1210,7 +1211,7 @@ fn checksumRemoteArtifactFile(
 
 fn absorbVerifiedBytes(
     sha: *Sha256,
-    crc: *std.hash.Crc32,
+    crc: *Crc32,
     read_bytes: *u64,
     body: []const u8,
     expected_size: u64,
@@ -1230,7 +1231,7 @@ fn checksumLocalFile(io: std.Io, path: []const u8, max_bytes: usize) !RestoredFi
     var reader = file.reader(io, &.{});
     var buffer: [64 * 1024]u8 = undefined;
     var sha = Sha256.init(.{});
-    var crc = std.hash.Crc32.init();
+    var crc = Crc32.init();
     var size: u64 = 0;
     while (true) {
         const read = try reader.interface.readSliceShort(&buffer);
@@ -1265,7 +1266,7 @@ fn restoreArtifactFile(
     errdefer std.Io.Dir.cwd().deleteFile(io, temp) catch {};
 
     var sha = Sha256.init(.{});
-    var crc = std.hash.Crc32.init();
+    var crc = Crc32.init();
     var written: u64 = 0;
     {
         var file = try std.Io.Dir.cwd().createFile(io, temp, .{ .truncate = true });
@@ -1335,7 +1336,7 @@ fn restoreArtifactFile(
 fn appendRestoredBytes(
     writer: *std.Io.Writer,
     sha: *Sha256,
-    crc: *std.hash.Crc32,
+    crc: *Crc32,
     written: *u64,
     body: []const u8,
     expected_size: u64,

--- a/zig/pkg/antfly/src/storage/ha/seed_capture.zig
+++ b/zig/pkg/antfly/src/storage/ha/seed_capture.zig
@@ -27,7 +27,7 @@
 
 const std = @import("std");
 const Allocator = std.mem.Allocator;
-const Crc32 = std.hash.Crc32;
+const Crc32 = @import("antfly_hash").Crc32;
 const Sha256 = std.crypto.hash.sha2.Sha256;
 const fs_paths = @import("../../common/fs_paths.zig");
 const backup_manifest = @import("backup_manifest.zig");

--- a/zig/pkg/antfly/src/storage/ha/slot_store.zig
+++ b/zig/pkg/antfly/src/storage/ha/slot_store.zig
@@ -23,7 +23,7 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const Allocator = std.mem.Allocator;
-const Crc32 = std.hash.Crc32;
+const Crc32 = @import("antfly_hash").Crc32;
 const wal_mod = @import("../wal.zig");
 
 const magic = [8]u8{ 'A', 'F', 'H', 'A', 'S', 'L', 'T', '\n' };

--- a/zig/pkg/antfly/src/storage/ha/standby.zig
+++ b/zig/pkg/antfly/src/storage/ha/standby.zig
@@ -21,7 +21,7 @@
 
 const std = @import("std");
 const Allocator = std.mem.Allocator;
-const Crc32 = std.hash.Crc32;
+const Crc32 = @import("antfly_hash").Crc32;
 const replication_log = @import("replication_log.zig");
 const replication_record = @import("replication_record.zig");
 const wal_mod = @import("../wal.zig");

--- a/zig/pkg/antfly/src/storage/lite/bridge.zig
+++ b/zig/pkg/antfly/src/storage/lite/bridge.zig
@@ -20,6 +20,7 @@
 //! remains for storage-engine development and conformance tests.
 
 const std = @import("std");
+const Crc32 = @import("antfly_hash").Crc32;
 const builtin = @import("builtin");
 const byte_copy = @import("../../common/byte_copy.zig");
 const fs_paths = @import("../../common/fs_paths.zig");
@@ -360,7 +361,7 @@ fn parseRecord(raw: []const u8, offset: usize) !ParsedRecord {
     if (encoded_len > raw.len - offset) return error.TruncatedTail;
     const end = offset + encoded_len;
 
-    var crc = std.hash.Crc32.init();
+    var crc = Crc32.init();
     crc.update(header[0..record_header_no_crc_size]);
     crc.update(raw[offset + record_header_size .. end]);
     if (crc.final() != expected_crc) return error.ChecksumMismatch;
@@ -414,7 +415,7 @@ fn appendEncodedRecord(
     @memcpy(record[record_header_size + path.len ..][0..aux.len], aux);
     @memcpy(record[record_header_size + path.len + aux.len ..][0..value.len], value);
 
-    var crc = std.hash.Crc32.init();
+    var crc = Crc32.init();
     crc.update(record[0..record_header_no_crc_size]);
     crc.update(record[record_header_size..]);
     std.mem.writeInt(u32, record[21..25], crc.final(), .little);
@@ -798,13 +799,13 @@ const ContainerAtomicWriteSink = struct {
     fn crc32Prefix(ptr: *anyopaque, len_prefix: usize) !u32 {
         const self: *ContainerAtomicWriteSink = @ptrCast(@alignCast(ptr));
         if (len_prefix > self.out.items.len) return error.InvalidAtomicWriteOffset;
-        return std.hash.Crc32.hash(self.out.items[0..len_prefix]);
+        return Crc32.hash(self.out.items[0..len_prefix]);
     }
 
     fn crc32Range(ptr: *anyopaque, offset: usize, range_len: usize) !u32 {
         const self: *ContainerAtomicWriteSink = @ptrCast(@alignCast(ptr));
         if (offset > self.out.items.len or range_len > self.out.items.len - offset) return error.InvalidAtomicWriteOffset;
-        return std.hash.Crc32.hash(self.out.items[offset..][0..range_len]);
+        return Crc32.hash(self.out.items[offset..][0..range_len]);
     }
 
     fn finish(ptr: *anyopaque) !void {
@@ -991,7 +992,7 @@ test "aflite container storage supports rename delete tree and atomic writer" {
     var writer = try storage.beginAtomicWrite(alloc, "/root/sub/c");
     try writer.appendSlice("hello _____");
     try writer.writeAt(6, "world");
-    try std.testing.expectEqual(std.hash.Crc32.hash("hello world"), try writer.crc32Prefix(writer.len()));
+    try std.testing.expectEqual(Crc32.hash("hello world"), try writer.crc32Prefix(writer.len()));
     try writer.finish();
 
     const atomic = try storage.readFileAlloc(alloc, "/root/sub/c", 64);

--- a/zig/pkg/antfly/src/storage/lite/index_storage.zig
+++ b/zig/pkg/antfly/src/storage/lite/index_storage.zig
@@ -21,6 +21,7 @@
 //! native catalog-page layout; this adapter is not a user-visible file format.
 
 const std = @import("std");
+const Crc32 = @import("antfly_hash").Crc32;
 const platform_sync = @import("antfly_platform").sync;
 const byte_copy = @import("../../common/byte_copy.zig");
 const docstore = @import("docstore.zig");
@@ -327,13 +328,13 @@ const NativeAtomicWriteSink = struct {
     fn crc32Prefix(ptr: *anyopaque, len_prefix: usize) !u32 {
         const self: *NativeAtomicWriteSink = @ptrCast(@alignCast(ptr));
         if (len_prefix > self.out.items.len) return error.InvalidAtomicWriteOffset;
-        return std.hash.Crc32.hash(self.out.items[0..len_prefix]);
+        return Crc32.hash(self.out.items[0..len_prefix]);
     }
 
     fn crc32Range(ptr: *anyopaque, offset: usize, range_len: usize) !u32 {
         const self: *NativeAtomicWriteSink = @ptrCast(@alignCast(ptr));
         if (offset > self.out.items.len or range_len > self.out.items.len - offset) return error.InvalidAtomicWriteOffset;
-        return std.hash.Crc32.hash(self.out.items[offset..][0..range_len]);
+        return Crc32.hash(self.out.items[offset..][0..range_len]);
     }
 
     fn finish(ptr: *anyopaque) !void {
@@ -373,7 +374,7 @@ test "lite native index storage persists logical files across reopen" {
         var writer = try storage.beginAtomicWrite(allocator, "/indexes/ft/b.tbl");
         try writer.appendSlice("abc_____");
         try writer.writeAt(3, "def");
-        try std.testing.expectEqual(std.hash.Crc32.hash("abcdef__"), try writer.crc32Prefix(writer.len()));
+        try std.testing.expectEqual(Crc32.hash("abcdef__"), try writer.crc32Prefix(writer.len()));
         try writer.finish();
 
         const checkpoint = docs.file.activeCheckpoint();

--- a/zig/pkg/antfly/src/storage/lite/native.zig
+++ b/zig/pkg/antfly/src/storage/lite/native.zig
@@ -18,6 +18,7 @@
 //! layout plus the first native page stores used by the Lite backend.
 
 const std = @import("std");
+const Crc32 = @import("antfly_hash").Crc32;
 const antfly_platform = @import("antfly_platform");
 const platform_sync = antfly_platform.sync;
 const fs_paths = @import("../../common/fs_paths.zig");
@@ -4279,7 +4280,7 @@ fn encodePage(out: []u8, kind: PageKind, payload: []const u8) void {
     std.mem.writeInt(u32, out[8..12], @intCast(payload.len), .little);
     @memcpy(out[page_header_size..][0..payload.len], payload);
 
-    var crc = std.hash.Crc32.init();
+    var crc = Crc32.init();
     crc.update(out[0..page_crc_offset]);
     crc.update(out[page_header_size..][0..payload.len]);
     std.mem.writeInt(u32, out[page_crc_offset..][0..4], crc.final(), .little);
@@ -4303,7 +4304,7 @@ fn decodePagePayloadAlloc(allocator: Allocator, raw: []const u8, expected_kind: 
     const payload_len = std.mem.readInt(u32, raw[8..12], .little);
     if (payload_len > raw.len - page_header_size) return error.InvalidNativePageLength;
 
-    var crc = std.hash.Crc32.init();
+    var crc = Crc32.init();
     crc.update(raw[0..page_crc_offset]);
     crc.update(raw[page_header_size..][0..payload_len]);
     const expected_crc = std.mem.readInt(u32, raw[page_crc_offset..][0..4], .little);
@@ -4631,7 +4632,7 @@ fn readHeaderExactAt(file: std.Io.File, io: std.Io, out: *[header_size]u8) !void
 }
 
 fn headerChecksum(raw: []const u8) u32 {
-    var crc = std.hash.Crc32.init();
+    var crc = Crc32.init();
     crc.update(raw[0..active_checkpoint_offset]);
     crc.update(raw[active_checkpoint_offset + 1 .. checkpoint_slots_offset]);
     crc.update(raw[checkpoint_slots_end..header_checksum_offset]);
@@ -4639,7 +4640,7 @@ fn headerChecksum(raw: []const u8) u32 {
 }
 
 fn checkpointSlotChecksum(raw: []const u8) u32 {
-    var crc = std.hash.Crc32.init();
+    var crc = Crc32.init();
     crc.update(raw[0..checkpoint_slot_payload_size]);
     return crc.final();
 }

--- a/zig/pkg/antfly/src/storage/lsm/manifest.zig
+++ b/zig/pkg/antfly/src/storage/lsm/manifest.zig
@@ -13,6 +13,7 @@
 // limitations.
 
 const std = @import("std");
+const Crc32 = @import("antfly_hash").Crc32;
 const lsm_table_file = @import("table_file.zig");
 
 pub const magic = "ALSMMAN1";
@@ -152,7 +153,7 @@ pub fn encodeAlloc(allocator: std.mem.Allocator, manifest: Manifest) ![]u8 {
         try appendU32(allocator, &bytes, @intCast(obsolete.path.len));
         try bytes.appendSlice(allocator, obsolete.path);
     }
-    try appendU32(allocator, &bytes, std.hash.Crc32.hash(bytes.items));
+    try appendU32(allocator, &bytes, Crc32.hash(bytes.items));
 
     return try bytes.toOwnedSlice(allocator);
 }
@@ -305,7 +306,7 @@ fn verifiedBody(raw: []const u8) ![]const u8 {
     if (raw.len < checksum_len) return error.InvalidManifest;
     const body = raw[0 .. raw.len - checksum_len];
     const expected = std.mem.readInt(u32, raw[raw.len - checksum_len ..][0..checksum_len], .little);
-    if (std.hash.Crc32.hash(body) != expected) return error.InvalidManifest;
+    if (Crc32.hash(body) != expected) return error.InvalidManifest;
     return body;
 }
 

--- a/zig/pkg/antfly/src/storage/lsm/table_file.zig
+++ b/zig/pkg/antfly/src/storage/lsm/table_file.zig
@@ -13,6 +13,7 @@
 // limitations.
 
 const std = @import("std");
+const Crc32 = @import("antfly_hash").Crc32;
 const bloom = @import("bloom");
 const byte_copy = @import("../../common/byte_copy.zig");
 const snappy = @import("../../encoding/snappy.zig");
@@ -800,7 +801,7 @@ const memory_table_sink_vtable = TableSink.VTable{
 
 const ChecksummedTableSink = struct {
     parent: *TableSink,
-    crc: std.hash.Crc32 = .init(),
+    crc: Crc32 = .init(),
 
     fn sink(self: *ChecksummedTableSink) TableSink {
         return .{
@@ -1505,7 +1506,7 @@ pub const StreamingEncoder = struct {
             .physical_relative_offset = physical_relative_offset,
             .physical_len = try checkedU32(encoded_payload.payload.len),
             .compression = encoded_payload.compression,
-            .checksum = std.hash.Crc32.hash(encoded_payload.payload),
+            .checksum = Crc32.hash(encoded_payload.payload),
             .first_entry_index = try checkedU32(self.block_first_entry_index),
             .entry_count = try checkedU32(self.block_entry_count),
             .smallest_namespace_name = smallest_namespace_name,
@@ -1662,7 +1663,7 @@ fn flushEncodedBlock(
         .physical_relative_offset = physical_relative_offset,
         .physical_len = try checkedU32(encoded_payload.payload.len),
         .compression = encoded_payload.compression,
-        .checksum = std.hash.Crc32.hash(encoded_payload.payload),
+        .checksum = Crc32.hash(encoded_payload.payload),
         .first_entry_index = try checkedU32(block_first_entry_index),
         .entry_count = try checkedU32(block_entry_count),
         .smallest_namespace_name = block_smallest_namespace_name,
@@ -2216,7 +2217,7 @@ pub fn decodeWindowFromRawAlloc(
 }
 
 pub fn validateBlockPayload(payload: []const u8, expected_checksum: u32) !void {
-    if (std.hash.Crc32.hash(payload) != expected_checksum) return error.TableBlockChecksumMismatch;
+    if (Crc32.hash(payload) != expected_checksum) return error.TableBlockChecksumMismatch;
 }
 
 fn validateRawBlockChecksums(raw: []const u8, index: *const TableIndex) !void {
@@ -2295,7 +2296,7 @@ pub fn decodeFooterBytes(raw: []const u8) !Footer {
     if (raw.len != footer_len) return error.InvalidTableFile;
     if (!hasFooterMagic(raw)) return error.InvalidTableFile;
     const stored_footer_checksum = std.mem.readInt(u32, raw[44..48], .little);
-    if (std.hash.Crc32.hash(raw[0..44]) != stored_footer_checksum) return error.InvalidTableFile;
+    if (Crc32.hash(raw[0..44]) != stored_footer_checksum) return error.InvalidTableFile;
 
     var cursor: usize = footer_magic.len;
     if (try readU32(raw, &cursor) != version) return error.UnsupportedVersion;
@@ -2324,7 +2325,7 @@ pub fn decodeIndexFromFooterAlloc(
     metadata: []const u8,
 ) !TableIndex {
     if (metadata.len != footer.metadata_len) return error.InvalidTableFile;
-    if (std.hash.Crc32.hash(metadata) != footer.metadata_checksum) return error.InvalidTableFile;
+    if (Crc32.hash(metadata) != footer.metadata_checksum) return error.InvalidTableFile;
     return try decodeFooterMetadataAlloc(
         allocator,
         metadata,
@@ -2342,7 +2343,7 @@ pub fn decodeSequentialIndexFromFooterAlloc(
     metadata: []const u8,
 ) !SequentialTableIndex {
     if (metadata.len != footer.metadata_len) return error.InvalidTableFile;
-    if (std.hash.Crc32.hash(metadata) != footer.metadata_checksum) return error.InvalidTableFile;
+    if (Crc32.hash(metadata) != footer.metadata_checksum) return error.InvalidTableFile;
     var cursor: usize = 0;
 
     // Entry offsets and all lookup accelerators are deliberately skipped.
@@ -2615,7 +2616,7 @@ fn appendFooter(
     std.mem.writeInt(u32, raw[32..36], try checkedU32(entry_count), .little);
     std.mem.writeInt(u32, raw[36..40], try checkedU32(entry_data_len), .little);
     std.mem.writeInt(u32, raw[40..44], metadata_checksum, .little);
-    std.mem.writeInt(u32, raw[44..48], std.hash.Crc32.hash(raw[0..44]), .little);
+    std.mem.writeInt(u32, raw[44..48], Crc32.hash(raw[0..44]), .little);
     try sink.appendSlice(&raw);
 }
 
@@ -2667,7 +2668,7 @@ fn decodeVersionedIndexAlloc(
     if (footer.metadata_offset > footer_offset or footer.metadata_len != footer_offset - footer.metadata_offset)
         return error.InvalidTableFile;
     const metadata = raw[footer.metadata_offset..footer_offset];
-    if (std.hash.Crc32.hash(metadata) != footer.metadata_checksum) return error.InvalidTableFile;
+    if (Crc32.hash(metadata) != footer.metadata_checksum) return error.InvalidTableFile;
     var index = try decodeFooterMetadataAlloc(
         allocator,
         metadata,
@@ -3157,7 +3158,7 @@ test "table file rejects forged footer entry count before allocating offsets" {
 
     const footer_bytes = encoded[encoded.len - footer_len ..];
     std.mem.writeInt(u32, footer_bytes[32..36], std.math.maxInt(u32), .little);
-    std.mem.writeInt(u32, footer_bytes[44..48], std.hash.Crc32.hash(footer_bytes[0..44]), .little);
+    std.mem.writeInt(u32, footer_bytes[44..48], Crc32.hash(footer_bytes[0..44]), .little);
     const footer = try decodeFooterBytes(footer_bytes);
     const metadata = encoded[footer.metadata_offset .. footer.metadata_offset + footer.metadata_len];
 

--- a/zig/pkg/antfly/src/storage/lsm_backend/repository.zig
+++ b/zig/pkg/antfly/src/storage/lsm_backend/repository.zig
@@ -13,6 +13,7 @@
 // limitations.
 
 const std = @import("std");
+const Crc32 = @import("antfly_hash").Crc32;
 const Allocator = std.mem.Allocator;
 const bloom = @import("bloom");
 const byte_copy = @import("../../common/byte_copy.zig");
@@ -1289,7 +1290,7 @@ test "repository rejects forged run metadata length before allocating" {
     const footer_offset = encoded.len - lsm_table_file.footer_len;
     const footer = encoded[footer_offset..];
     std.mem.writeInt(u64, footer[24..32], max_run_file_read_bytes, .little);
-    std.mem.writeInt(u32, footer[44..48], std.hash.Crc32.hash(footer[0..44]), .little);
+    std.mem.writeInt(u32, footer[44..48], Crc32.hash(footer[0..44]), .little);
 
     const path = "/repository-forged-run-metadata/run.tbl";
     try storage.storage().writeFileAbsolute(path, encoded);

--- a/zig/pkg/antfly/src/storage/lsm_backend/storage_io.zig
+++ b/zig/pkg/antfly/src/storage/lsm_backend/storage_io.zig
@@ -13,6 +13,7 @@
 // limitations.
 
 const std = @import("std");
+const Crc32 = @import("antfly_hash").Crc32;
 const platform_sync = @import("antfly_platform").sync;
 const builtin = @import("builtin");
 const platform = @import("antfly_platform");
@@ -711,13 +712,13 @@ const BufferedAtomicWriteSink = struct {
     fn crc32Prefix(ptr: *anyopaque, len_prefix: usize) !u32 {
         const self: *BufferedAtomicWriteSink = @ptrCast(@alignCast(ptr));
         if (len_prefix > self.out.items.len) return error.InvalidAtomicWriteOffset;
-        return std.hash.Crc32.hash(self.out.items[0..len_prefix]);
+        return Crc32.hash(self.out.items[0..len_prefix]);
     }
 
     fn crc32Range(ptr: *anyopaque, offset: usize, range_len: usize) !u32 {
         const self: *BufferedAtomicWriteSink = @ptrCast(@alignCast(ptr));
         if (offset > self.out.items.len or range_len > self.out.items.len - offset) return error.InvalidAtomicWriteOffset;
-        return std.hash.Crc32.hash(self.out.items[offset..][0..range_len]);
+        return Crc32.hash(self.out.items[offset..][0..range_len]);
     }
 
     fn finish(ptr: *anyopaque) !void {
@@ -2771,13 +2772,13 @@ const NativeBufferedAtomicWriteSink = struct {
     fn crc32Prefix(ptr: *anyopaque, len_prefix: usize) !u32 {
         const self: *NativeBufferedAtomicWriteSink = @ptrCast(@alignCast(ptr));
         if (len_prefix > self.out.items.len) return error.InvalidAtomicWriteOffset;
-        return std.hash.Crc32.hash(self.out.items[0..len_prefix]);
+        return Crc32.hash(self.out.items[0..len_prefix]);
     }
 
     fn crc32Range(ptr: *anyopaque, offset: usize, range_len: usize) !u32 {
         const self: *NativeBufferedAtomicWriteSink = @ptrCast(@alignCast(ptr));
         if (offset > self.out.items.len or range_len > self.out.items.len - offset) return error.InvalidAtomicWriteOffset;
-        return std.hash.Crc32.hash(self.out.items[offset..][0..range_len]);
+        return Crc32.hash(self.out.items[offset..][0..range_len]);
     }
 
     fn finish(ptr: *anyopaque) !void {
@@ -2918,7 +2919,7 @@ const NativeAtomicWriteSink = struct {
         const self: *NativeAtomicWriteSink = @ptrCast(@alignCast(ptr));
         if (range_offset > self.bytes_written or range_len > self.bytes_written - range_offset) return error.InvalidAtomicWriteOffset;
 
-        var crc = std.hash.Crc32.init();
+        var crc = Crc32.init();
         var offset: usize = 0;
         var buf: [64 * 1024]u8 = undefined;
         while (offset < range_len) {
@@ -3448,7 +3449,7 @@ test "native atomic write sink supports patching and crc before finish" {
 
     try writer.appendSlice("hello _____");
     try writer.writeAt(6, "world");
-    try std.testing.expectEqual(std.hash.Crc32.hash("hello world"), try writer.crc32Prefix(writer.len()));
+    try std.testing.expectEqual(Crc32.hash("hello world"), try writer.crc32Prefix(writer.len()));
 
     active = false;
     try writer.finish();
@@ -4246,7 +4247,7 @@ test "native buffered atomic write sink retains invalidation state past storage 
 
     try writer.appendSlice("buffered _____");
     try writer.writeAt(9, "lease");
-    try std.testing.expectEqual(std.hash.Crc32.hash("buffered lease"), try writer.crc32Prefix(writer.len()));
+    try std.testing.expectEqual(Crc32.hash("buffered lease"), try writer.crc32Prefix(writer.len()));
     native.deinit();
 
     active = false;

--- a/zig/pkg/antfly/src/storage/lsm_backend/wal.zig
+++ b/zig/pkg/antfly/src/storage/lsm_backend/wal.zig
@@ -13,6 +13,7 @@
 // limitations.
 
 const std = @import("std");
+const Crc32 = @import("antfly_hash").Crc32;
 const builtin = @import("builtin");
 const platform = @import("antfly_platform");
 const Allocator = std.mem.Allocator;
@@ -228,7 +229,7 @@ pub fn appendStateWithOptionsResult(
     std.mem.writeInt(u16, record[4..6], record_version, .little);
     std.mem.writeInt(u16, record[6..8], record_header_len, .little);
     std.mem.writeInt(u32, record[8..12], @intCast(payload.len), .little);
-    std.mem.writeInt(u32, record[12..16], std.hash.Crc32.hash(payload), .little);
+    std.mem.writeInt(u32, record[12..16], Crc32.hash(payload), .little);
 
     const wal_dir = try walDirPathAlloc(allocator, root_dir);
     defer allocator.free(wal_dir);
@@ -551,7 +552,7 @@ pub fn appendReplay(
     std.mem.writeInt(u16, record[6..8], replay_record_header_len, .little);
     std.mem.writeInt(u64, record[8..16], sequence, .little);
     std.mem.writeInt(u32, record[16..20], @intCast(payload.len), .little);
-    std.mem.writeInt(u32, record[20..24], std.hash.Crc32.hash(payload), .little);
+    std.mem.writeInt(u32, record[20..24], Crc32.hash(payload), .little);
     @memcpy(record[replay_record_header_len..], payload);
 
     const wal_dir = try walDirPathAlloc(allocator, root_dir);
@@ -1013,7 +1014,7 @@ fn consumeCompleteReplayRecords(
 
         if (sequence >= from_sequence) {
             const payload = pending.items[pos + replay_record_header_len .. pos + total_len];
-            if (std.hash.Crc32.hash(payload) != expected_crc) {
+            if (Crc32.hash(payload) != expected_crc) {
                 logCorruptWalDetail("replay_crc", 0, pos, pending.items.len, "replay CRC mismatch");
                 return error.CorruptLsmWal;
             }
@@ -1075,7 +1076,7 @@ fn consumeReplayRecordsFromMixedWal(
             if (pending.items.len - pos < total_len) break;
             if (sequence >= from_sequence) {
                 const payload = pending.items[pos + replay_record_header_len .. pos + total_len];
-                if (std.hash.Crc32.hash(payload) != expected_crc) {
+                if (Crc32.hash(payload) != expected_crc) {
                     logCorruptWalDetail("mixed_replay_crc", 0, pos, pending.items.len, "mixed WAL replay CRC mismatch");
                     return error.CorruptLsmWal;
                 }
@@ -1206,7 +1207,7 @@ fn consumeCompleteRecords(
             if (pending.items.len - pos < total_len) break;
 
             const payload = pending.items[pos + record_header_len .. pos + total_len];
-            if (std.hash.Crc32.hash(payload) != expected_crc) {
+            if (Crc32.hash(payload) != expected_crc) {
                 logCorruptWalDetail("record_crc", segment, pos, pending.items.len, "state record CRC mismatch");
                 return error.CorruptLsmWal;
             }
@@ -1244,7 +1245,7 @@ fn consumeCompleteRecords(
             const total_len = replay_record_header_len + payload_len;
             if (pending.items.len - pos < total_len) break;
             const payload = pending.items[pos + replay_record_header_len .. pos + total_len];
-            if (std.hash.Crc32.hash(payload) != expected_crc) {
+            if (Crc32.hash(payload) != expected_crc) {
                 logCorruptWalDetail("replay_record_crc", segment, pos, pending.items.len, "replay record CRC mismatch");
                 return error.CorruptLsmWal;
             }
@@ -1360,7 +1361,7 @@ fn encodeControl(out: []u8, kind: ControlKind, payload: []const u8) void {
     std.mem.writeInt(
         u32,
         out[out.len - control_checksum_len ..][0..control_checksum_len],
-        std.hash.Crc32.hash(out[0 .. out.len - control_checksum_len]),
+        Crc32.hash(out[0 .. out.len - control_checksum_len]),
         .little,
     );
 }
@@ -1376,7 +1377,7 @@ fn decodeControl(raw: []const u8, kind: ControlKind, payload_len: usize) ![]cons
         raw[raw.len - control_checksum_len ..][0..control_checksum_len],
         .little,
     );
-    if (std.hash.Crc32.hash(raw[0 .. raw.len - control_checksum_len]) != expected_checksum)
+    if (Crc32.hash(raw[0 .. raw.len - control_checksum_len]) != expected_checksum)
         return error.CorruptLsmWalIndex;
     return raw[control_header_len .. control_header_len + payload_len];
 }

--- a/zig/pkg/antfly/src/storage/portable_wal.zig
+++ b/zig/pkg/antfly/src/storage/portable_wal.zig
@@ -13,6 +13,7 @@
 // limitations.
 
 const std = @import("std");
+const Crc32 = @import("antfly_hash").Crc32;
 const platform_sync = @import("antfly_platform").sync;
 const Allocator = std.mem.Allocator;
 const lsm_backend = @import("lsm_backend/mod.zig");
@@ -317,7 +318,7 @@ const EntryIterator = struct {
         const stored_crc = std.mem.readInt(u32, self.bytes[self.pos..][0..4], .little);
         self.pos += 4;
 
-        var crc = std.hash.Crc32.init();
+        var crc = Crc32.init();
         crc.update(std.mem.asBytes(&data_len_u32));
         crc.update(data);
         if (crc.final() != stored_crc) return error.CorruptWal;
@@ -336,7 +337,7 @@ fn appendEncodedEntry(alloc: Allocator, bytes: *std.ArrayListUnmanaged(u8), lsn:
     bytes.appendSliceAssumeCapacity(std.mem.asBytes(&data_len_u32));
     bytes.appendSliceAssumeCapacity(data);
 
-    var crc = std.hash.Crc32.init();
+    var crc = Crc32.init();
     crc.update(std.mem.asBytes(&data_len_u32));
     crc.update(data);
     const stored_crc = crc.final();

--- a/zig/pkg/antfly/src/storage/wal.zig
+++ b/zig/pkg/antfly/src/storage/wal.zig
@@ -24,6 +24,7 @@
 //! CRC covers data_len + data bytes.
 
 const std = @import("std");
+const Crc32 = @import("antfly_hash").Crc32;
 const builtin = @import("builtin");
 const build_options = @import("build_options");
 const Allocator = std.mem.Allocator;
@@ -1434,7 +1435,7 @@ fn decodeWalValue(value: []const u8) error{CorruptWal}![]const u8 {
     const data = value[4..data_end];
     const stored_crc = std.mem.readInt(u32, value[data_end..][0..4], .little);
 
-    var crc = std.hash.Crc32.init();
+    var crc = Crc32.init();
     crc.update(value[0..4]);
     crc.update(data);
     if (crc.final() != stored_crc) return error.CorruptWal;
@@ -1449,7 +1450,7 @@ fn encodeEntryValue(dst: []u8, data_len: u32, data: []const u8, checksum: u32) v
 }
 
 fn checksumForEntry(data_len: u32, data: []const u8) u32 {
-    var crc = std.hash.Crc32.init();
+    var crc = Crc32.init();
     crc.update(&std.mem.toBytes(std.mem.nativeToLittle(u32, data_len)));
     crc.update(data);
     return crc.final();

--- a/zig/pkg/inference/build.zig
+++ b/zig/pkg/inference/build.zig
@@ -2316,6 +2316,7 @@ pub fn build(b: *std.Build) void {
     chunker_tests.root_module.addImport("inference_audio", inference_audio_mod);
     chunker_tests.root_module.addImport("inference_fixed_tokenizer_data", inference_fixed_tokenizer_data_mod);
     chunker_tests.root_module.addImport("antfly_image", antfly_image_mod);
+    chunker_tests.root_module.addImport("antfly_hash", inference_chunker_mod.import_table.get("antfly_hash").?);
     chunker_tests.root_module.link_libc = true;
     const run_chunker_tests = b.addRunArtifact(chunker_tests);
     const chunker_test_step = b.step("test-chunker", "Run chunker tests");
@@ -2393,6 +2394,12 @@ pub fn build(b: *std.Build) void {
             .optimize = .ReleaseSafe,
             .single_threaded = true,
         });
+        const wasm_hash_mod = b.createModule(.{
+            .root_source_file = b.path(b.fmt("{s}/lib/hash/src/mod.zig", .{shared_lib_root})),
+            .target = wasm_target,
+            .optimize = .ReleaseSafe,
+        });
+        wasm_image_mod.addImport("antfly_hash", wasm_hash_mod);
         const wasm_platform_mod = b.dependency("antfly_platform", .{
             .target = wasm_target,
             .optimize = .ReleaseSafe,

--- a/zig/pkg/inference/build/runtime.zig
+++ b/zig/pkg/inference/build/runtime.zig
@@ -59,6 +59,7 @@ pub const SharedModules = struct {
     regex: ?*std.Build.Module = null,
     jsonschema: ?*std.Build.Module = null,
     image: ?*std.Build.Module = null,
+    hash: ?*std.Build.Module = null,
     prometheus: ?*std.Build.Module = null,
     structlog: ?*std.Build.Module = null,
     jinja: ?*std.Build.Module = null,
@@ -174,7 +175,9 @@ pub fn create(config: Config) Graph {
         mod.addImport("antfly_regex", regex_mod);
         break :blk mod;
     };
+    const hash_mod = shared.hash orelse createSharedModule(config, "lib/hash/src/mod.zig");
     const image_mod = shared.image orelse createSharedModule(config, "lib/image/src/mod.zig");
+    if (shared.image == null) image_mod.addImport("antfly_hash", hash_mod);
     const prometheus_mod = shared.prometheus orelse createOptionalSharedModule(config, "lib/prometheus/src/root.zig", "src/compat/prometheus.zig");
     const structlog_mod = shared.structlog orelse createOptionalSharedModule(config, "lib/structlog/src/root.zig", "src/compat/structlog.zig");
     const jinja_mod = shared.jinja orelse b.dependency("jinja", .{
@@ -286,6 +289,7 @@ pub fn create(config: Config) Graph {
     inference_chunker_mod.addImport("inference_hf_tokenizer", inference_hf_tokenizer_mod);
     inference_chunker_mod.addImport("inference_fixed_tokenizer_data", inference_fixed_tokenizer_data_mod);
     inference_chunker_mod.addImport("antfly_image", image_mod);
+    inference_chunker_mod.addImport("antfly_hash", hash_mod);
 
     const inference_mod = b.createModule(.{
         .root_source_file = b.path(pathJoin(b, paths.inference_root, "src/inference.zig")),


### PR DESCRIPTION
Production Zig checksum callers currently use byte-at-a-time standard CRC implementations or duplicate PNG helpers. Move storage, WAL, Raft, backup/HA, Lite, lake-reader, and PNG callers onto `antfly_hash`, preserving existing checksum values and wire formats.

- Add cached runtime CPU dispatch for baseline builds, ARM64 CRC32/CRC32C instructions, x86 PCLMUL IEEE CRC32 folding, and x86 SSE4.2 CRC32C, with portable fallbacks. Zig 0.16's non-LLVM x86 backend uses portable CRC32/CRC32C because its instruction encoder rejects these kernels; LLVM release builds retain hardware acceleration. CI explicitly tests both backends.
- Add slicing-by-eight CRC64/NVME and share the vectorized Adler32 implementation between PNG encoders. Verify the image encoder's zlib output against the standard wrapper byte for byte.
- Enforce shared checksum usage with `make zig-checksums-check` and native ARM64/x86 baseline CI tests. The lexical guard permits standard-library test oracles and unrelated hashes, handles forward container declarations and typed namespace aliases, and includes regressions for the review findings.
- Retain Chromium's PCLMUL attribution and BSD notice in release notices.

Release packaging continues to use `-Dcpu=baseline` with `ReleaseFast`; runtime dispatch enables optional instructions on capable hosts without raising the binary's minimum CPU requirements.

Local Apple M4, Zig 0.16.0 ReleaseFast kernel benchmarks at 1 MiB measured approximately 20.2x CRC32, 19.8x CRC32C, 4.6x CRC64/NVME, and 3.3x Adler32 speedups against std. These are checksum throughput measurements, not end-to-end application speedups. Methodology and commands are in `zig/lib/hash/README.md`.

Validation:

- Full baseline ReleaseSafe Antfly CLI build: all 27 build steps succeeded.
- Focused storage, WAL, HA, Raft storage, Lite, lake-reader, chunker, hash, and PNG suites passed.
- Native ARM checksum tests and x86 baseline kernel tests under Rosetta passed; Rosetta results are not native x86 performance measurements.
- Linux ARM64/x86, WASI, freestanding WASM, and C-backend compile checks passed. Native Linux runtime dispatch is covered by the added CI jobs.
- All 12 CI guard tests, repository checksum scan, Ruff checks, and diff whitespace checks passed.

Existing validation limitations: full-application WASM has the same failures on the base revision, and the repository-wide license check has pre-existing header failures. Newly added files comply with the license-header check.
