### PR TITLE
Fix Zig CI repair and E2E readiness flakes

### DIFF
--- a/zig/e2e/FLAKES.md
+++ b/zig/e2e/FLAKES.md
@@ -1,0 +1,113 @@
+# Zig E2E flakes
+
+Track intermittent failures with their original evidence, the contract being
+tested, and repeated validation. A passing soak reduces uncertainty; it does not
+establish the cause of a failure that was not reproduced locally. Keep resolved
+entries so later failures can be compared with the original signature.
+
+## Known cases
+
+| Test | CI evidence | Fix commit | Status |
+| --- | --- | --- | --- |
+| `test_retrieval.py::test_retrieval_agent_streaming_fallback_progress` | [PR #657, run 34176604388, job 101914807099](https://github.com/antflydb/antfly/actions/runs/34176604388/job/101914807099?pr=657), head [`bc8f8a20d`](https://github.com/antflydb/antfly/commit/bc8f8a20d34534969decc90813fbcb8f390164f1) | [`47106c1fd`](https://github.com/antflydb/antfly/commit/47106c1fd09e9be5f1e3333363fd77d007813632) | Teardown recovery fixed; original reset cause unknown; 30/30 soak runs passed. |
+| `test_backup_restore.py::test_three_by_three_cluster_backup_restore_through_metadata_public_api` | [PR #658, run 34177703845, job 101916669107](https://github.com/antflydb/antfly/actions/runs/34177703845/job/101916669107?pr=658), head [`96bee1e80`](https://github.com/antflydb/antfly/commit/96bee1e80cf115c2dc636ed065a0378d8cfb27f3) | [`1bf7230cc`](https://github.com/antflydb/antfly/commit/1bf7230cc74c37ba4263964719542c210ff9473d) | Write-admission handling fixed; 30/30 soak runs passed. |
+| `test_cli.py::test_cli_inline_create_load_wait_query_image_and_rag_pipeline` | [PR #658, run 34177703845, job 101916669107](https://github.com/antflydb/antfly/actions/runs/34177703845/job/101916669107?pr=658), head [`96bee1e80`](https://github.com/antflydb/antfly/commit/96bee1e80cf115c2dc636ed065a0378d8cfb27f3) | [`1bf7230cc`](https://github.com/antflydb/antfly/commit/1bf7230cc74c37ba4263964719542c210ff9473d) | Readiness assertion fixed; 30/30 soak runs passed. |
+
+### Retrieval streaming teardown
+
+The retrieval assertions passed, then the reusable fixture's DELETE failed with
+`ConnectionResetError(104, 'Connection reset by peer')`. The old cleanup made one
+attempt and discarded the server diagnostics. The CI artifact contained only the
+executable, so it cannot establish whether that reset was a transport failure or
+a server failure.
+
+Cleanup now retries an idempotent DELETE at most three times within its existing
+30-second request budget. A retry may return 404 when the original DELETE
+succeeded but its response was lost. Process-exit checks run before and after
+requests; exited servers and HTTP errors still fail. Exhausted transport errors
+include bounded server logs and process status. Recovered transport failures are
+printed in the soak log rather than silently discarded.
+
+Deterministic harness tests cover resets, successful deletion before response
+loss, deadline/attempt exhaustion, HTTP errors, and server crashes. The original
+CI reset has not been reproduced naturally in the local soak.
+
+### Three-by-three backup seeding
+
+The first document batch returned HTTP 503 with `write unavailable`, after the
+test observed three healthy voters and a known leader for each shard. That
+metadata observation does not hold a lease on the current data leader or routing
+catalog. The public write API explicitly distinguishes this pre-commit
+unavailability from ambiguous and post-commit outcomes.
+
+The fixture now seeds documents through a bounded admission loop that retries
+only the exact `503 write unavailable` response. Transport failures, other HTTP
+errors, ambiguous transactions, and pending durability acknowledgements remain
+failures. The original assertions still verify every seeded document, all three
+shard payloads in the backup, and restored documents through every data node.
+
+Harness regressions cover eventual admission, retry classification, deadline
+diagnostics, and process exit. The specific CI rejection has not been
+reproduced naturally in the local soak.
+
+### CLI image readiness
+
+`index wait --until searchable-artifacts=1` succeeded, but the following source
+coverage assertion saw `covered == 0`. Query-visible vectors and the asynchronous
+source census have independent publication points. The searchable-artifact wait
+contract checks queryability and visible vectors, not source coverage.
+
+The test now checks the matching milestone at each stage: at least one queryable
+vector after the searchable-artifact wait, then exact source outcomes after
+complete readiness. The later assertions still require one covered source, two
+skipped sources, zero failures, and a successful image query. No wait deadline
+was increased and no source-coverage assertion was removed from final completion.
+
+The specific premature assertion did not fail naturally in the local soak.
+
+## Related unit failure
+
+The same main-based branch also fixes
+`db repair issue list exposes algebraic generation debt as repairable` from
+[run 34177703845, job 101910688344](https://github.com/antflydb/antfly/actions/runs/34177703845/job/101910688344?pr=658)
+in [`d9e095ed9`](https://github.com/antflydb/antfly/commit/d9e095ed9a96dd764ff3967b18bf812a08579b86).
+A temporary 300 ms activation hook reproduced the exact `indexes_rebuilt`
+assertion on main. The functional test now uses the existing 5-second completion
+budget; the 250 ms production policy is unchanged. The injected case passed
+before removing the temporary hook. Twenty subsequent repetitions of the repair
+test and the production deadline test passed (40 test executions), using
+`zig/tools/run_bounded_zig_build.py` while the E2E soak ran.
+
+## Soak record
+
+2026-09-07 (America/Los_Angeles): fixes are based on `origin/main`
+[`43fda0ba4`](https://github.com/antflydb/antfly/commit/43fda0ba4684163a3ee563f18fd4ad61849003cf).
+Local validation ran on macOS ARM64; the cited CI jobs ran on Linux x86_64.
+The native ReleaseSafe `antfly` build passed all 27 build steps. The fixed E2E
+tests are committed at [`1bf7230cc`](https://github.com/antflydb/antfly/commit/1bf7230cc74c37ba4263964719542c210ff9473d).
+
+- Initial mixed-load check using the existing PR #658 executable: three workers,
+  three repetitions of each case, **27/27 passed**. This included the teardown
+  recovery change; the backup and CLI tests were still unchanged.
+- Fixed main-based checkout: three workers, ten repetitions of each case,
+  **90/90 passed** (30 per case), with no recovered cleanup transport errors.
+- Fast harness, scheduler, and metadata leader-discovery regressions:
+  **101 passed**.
+
+From the repository root, after building `zig/zig-out/bin/antfly`:
+
+```sh
+SKIP_BUILD=1 \
+ANTFLY_E2E_ENV_LOADED=1 \
+ANTFLY_E2E_REGRESSION_WORKERS=3 \
+ANTFLY_E2E_REGRESSION_REPEATS=10 \
+ANTFLY_E2E_PRESERVE_FAILURE_LIMIT=2 \
+scripts/ci/zig-e2e-regression-loop.sh \
+  e2e/antfly/test_backup_restore.py::test_three_by_three_cluster_backup_restore_through_metadata_public_api \
+  e2e/antfly/test_cli.py::test_cli_inline_create_load_wait_query_image_and_rag_pipeline \
+  e2e/antfly/test_retrieval.py::test_retrieval_agent_streaming_fallback_progress
+```
+
+The script preserves failed worker logs and the first two failed runtime roots
+per worker with this configuration. Record the tested commit, worker/repetition
+counts, failing node IDs, and preserved diagnostics when adding a new result.

--- a/zig/e2e/antfly/README.md
+++ b/zig/e2e/antfly/README.md
@@ -2,6 +2,9 @@
 
 This directory holds portable end-to-end tests for Antfly Zig.
 
+See [FLAKES.md](../FLAKES.md) for intermittent failures, CI evidence, fix commits,
+and regression-soak commands and results.
+
 Use product-area names for test files. Do not use migration labels like `*_parity.py`.
 
 ## Current Coverage

--- a/zig/e2e/antfly/conftest.py
+++ b/zig/e2e/antfly/conftest.py
@@ -319,6 +319,9 @@ def _delete_created_table(api: Any, table_name: str) -> None:
             remaining = deadline - time.monotonic()
             if attempt == 2 or remaining <= 0.1:
                 raise_request_error_with_logs(err, api._server)
+            print(
+                f"retrying table cleanup for {table_name}: {type(err).__name__}: {err}"
+            )
             time.sleep(0.1)
             continue
         except requests.RequestException as err:

--- a/zig/e2e/antfly/conftest.py
+++ b/zig/e2e/antfly/conftest.py
@@ -295,16 +295,44 @@ def _cleanup_created_tables(api: Any, table_names: set[str]) -> list[str]:
     cleanup_errors: list[str] = []
     for table_name in reversed(sorted(table_names)):
         try:
-            response = api.s.delete(
-                f"{api.url}/tables/{quote(table_name, safe='')}", timeout=30
-            )
-            if response.status_code not in (200, 202, 204, 404):
-                cleanup_errors.append(
-                    f"{table_name}: HTTP {response.status_code} {response.text[:500]}"
-                )
-        except requests.RequestException as err:
+            _delete_created_table(api, table_name)
+        except (requests.RequestException, RuntimeError) as err:
             cleanup_errors.append(f"{table_name}: {err}")
     return cleanup_errors
+
+
+def _delete_created_table(api: Any, table_name: str) -> None:
+    # DELETE is idempotent: a lost response may mean the table is already gone.
+    # Retry transport failures within one cleanup deadline, but never hide an
+    # exited server or a real HTTP error behind a later successful request.
+    deadline = time.monotonic() + 30
+    for attempt in range(3):
+        raise_if_server_process_exited(api._server)
+        try:
+            with api._request_lock:
+                response = api.s.delete(
+                    f"{api.url}/tables/{quote(table_name, safe='')}",
+                    timeout=max(0.001, deadline - time.monotonic()),
+                )
+        except (requests.ConnectionError, requests.Timeout) as err:
+            raise_if_server_process_exited(api._server)
+            remaining = deadline - time.monotonic()
+            if attempt == 2 or remaining <= 0.1:
+                raise_request_error_with_logs(err, api._server)
+            time.sleep(0.1)
+            continue
+        except requests.RequestException as err:
+            raise_request_error_with_logs(err, api._server)
+        raise_if_server_process_exited(api._server)
+        if response.status_code not in (200, 202, 204, 404):
+            raise_request_error_with_logs(
+                requests.HTTPError(
+                    f"HTTP {response.status_code} {response.text[:500]}",
+                    response=response,
+                ),
+                api._server,
+            )
+        return
 
 
 def _created_table_from_path(path: str) -> str | None:

--- a/zig/e2e/antfly/test_backup_restore.py
+++ b/zig/e2e/antfly/test_backup_restore.py
@@ -285,6 +285,40 @@ def _check_response(response: requests.Response) -> dict:
     return payload
 
 
+def _seed_cluster_docs_when_writable(
+    cluster, session: requests.Session, table_name: str, docs: dict, *, timeout_s=30.0
+) -> dict:
+    # Replication status is an observation, not a lease on the data leader or
+    # its routing catalog. Seed through the write API's admission contract.
+    # Only this explicit pre-commit response permits a fresh batch attempt;
+    # transport failures and ambiguous/post-commit outcomes must remain errors.
+    deadline = time.monotonic() + timeout_s
+    last_response: requests.Response | None = None
+
+    def attempt() -> dict | None:
+        nonlocal last_response
+        cluster.assert_processes_alive()
+        last_response = session.post(
+            f"{cluster.data_api_urls[0]}/tables/{table_name}/batch",
+            json={"inserts": docs, "sync_level": "write"},
+            timeout=max(0.001, deadline - time.monotonic()),
+        )
+        if (
+            last_response.status_code == 503
+            and last_response.text.strip() == "write unavailable"
+        ):
+            return None
+        return _check_response(last_response)
+
+    batch = wait_until(attempt, timeout_s=timeout_s, interval_s=0.1)
+    assert batch is not None, (
+        f"table {table_name} did not become writable; "
+        f"last_response={last_response.text if last_response is not None else None}\n"
+        f"{cluster.debug_logs()}"
+    )
+    return batch
+
+
 def _is_metadata_not_leader_response(response: requests.Response) -> bool:
     return response.headers.get("X-Antfly-Metadata-Not-Leader", "").lower() == "true"
 
@@ -1426,13 +1460,7 @@ def test_three_by_three_cluster_backup_restore_through_metadata_public_api(
             "content": "high range backup and restore coverage",
         },
     }
-    batch = _check_response(
-        session.post(
-            f"{data_api_url}/tables/{table_name}/batch",
-            json={"inserts": source_docs, "sync_level": "write"},
-            timeout=30,
-        )
-    )
+    batch = _seed_cluster_docs_when_writable(cluster, session, table_name, source_docs)
     assert batch["inserted"] == len(source_docs)
     assert wait_until(
         lambda: (

--- a/zig/e2e/antfly/test_cli.py
+++ b/zig/e2e/antfly/test_cli.py
@@ -612,7 +612,9 @@ def test_cli_inline_create_load_wait_query_image_and_rag_pipeline(
         image_coverage = image_status["status"]["source_coverage"]
         assert image_coverage["policy"] == "partial"
         assert image_coverage["total"] == 3
-        assert image_coverage["covered"] >= 1
+        # The query-visible vector count and asynchronous source census have
+        # independent publication points. searchable-artifacts only promises
+        # the former; check exact source outcomes after complete readiness below.
         assert image_coverage["failed"] == 0
         assert image_status["status"]["readiness"]["queryable"] is True
         assert image_status["status"]["searchable_vectors"] >= 1

--- a/zig/e2e/antfly/test_standalone_harness.py
+++ b/zig/e2e/antfly/test_standalone_harness.py
@@ -16,6 +16,7 @@
 
 import pytest
 import requests
+import threading
 from types import SimpleNamespace
 
 import conftest as e2e_conftest
@@ -205,6 +206,93 @@ def _http_error(status: int, body: bytes, **headers: str) -> requests.HTTPError:
     response._content = body
     response.headers.update(headers)
     return requests.HTTPError(response=response)
+
+
+def _cleanup_api(monkeypatch, outcomes, *, exit_status=None):
+    calls = []
+    pending = iter(outcomes)
+
+    def delete(url, **kwargs):
+        calls.append((url, kwargs))
+        outcome = next(pending)
+        if isinstance(outcome, Exception):
+            raise outcome
+        return _http_error(outcome, b"delete response").response
+
+    monkeypatch.setattr(e2e_conftest.time, "sleep", lambda _: None)
+    server = SimpleNamespace(
+        proc=SimpleNamespace(poll=lambda: exit_status),
+        debug_logs=lambda: "cleanup server diagnostics",
+    )
+    return (
+        SimpleNamespace(
+            s=SimpleNamespace(delete=delete),
+            url="http://localhost/api/v1",
+            _server=server,
+            _request_lock=threading.Lock(),
+        ),
+        calls,
+    )
+
+
+@pytest.mark.parametrize("status", [200, 202, 204, 404])
+def test_table_cleanup_retries_reset_including_already_deleted(monkeypatch, status):
+    api, calls = _cleanup_api(
+        monkeypatch, [requests.ConnectionError("connection reset"), status]
+    )
+    assert e2e_conftest._cleanup_created_tables(api, {"table/a"}) == []
+    assert len(calls) == 2
+    assert all(url.endswith("/tables/table%2Fa") for url, _ in calls)
+
+
+def test_table_cleanup_stops_retrying_and_keeps_diagnostics(monkeypatch):
+    api, calls = _cleanup_api(
+        monkeypatch, [requests.ConnectionError("connection reset")] * 3 + [204]
+    )
+    errors = e2e_conftest._cleanup_created_tables(api, {"z_table", "a_table"})
+    assert len(errors) == 1
+    assert "z_table: connection reset" in errors[0]
+    assert "cleanup server diagnostics" in errors[0]
+    assert "proc: None" in errors[0]
+    assert len(calls) == 4  # Other owned tables still get cleaned up.
+
+
+def test_table_cleanup_preserves_http_failures_without_retry(monkeypatch):
+    api, calls = _cleanup_api(monkeypatch, [500])
+    errors = e2e_conftest._cleanup_created_tables(api, {"table"})
+    assert len(errors) == 1
+    assert "HTTP 500 delete response" in errors[0]
+    assert len(calls) == 1
+
+
+def test_table_cleanup_rejects_exited_server_before_request(monkeypatch):
+    api, calls = _cleanup_api(monkeypatch, [204], exit_status=-11)
+    errors = e2e_conftest._cleanup_created_tables(api, {"table"})
+    assert len(errors) == 1
+    assert "proc: -11" in errors[0]
+    assert "cleanup server diagnostics" in errors[0]
+    assert calls == []
+
+
+@pytest.mark.parametrize("outcome", [requests.ConnectionError("connection reset"), 204])
+def test_table_cleanup_does_not_hide_server_crash(monkeypatch, outcome):
+    api, calls = _cleanup_api(monkeypatch, [outcome, 204])
+    api._server.proc.poll = lambda: -11 if calls else None
+    errors = e2e_conftest._cleanup_created_tables(api, {"table"})
+    assert len(errors) == 1
+    assert "proc: -11" in errors[0]
+    assert len(calls) == 1
+
+
+def test_table_cleanup_does_not_retry_after_deadline(monkeypatch):
+    api, calls = _cleanup_api(monkeypatch, [requests.Timeout("delete timed out"), 204])
+    clock = iter([0.0, 0.0, 30.0])
+    monkeypatch.setattr(e2e_conftest.time, "monotonic", lambda: next(clock))
+    errors = e2e_conftest._cleanup_created_tables(api, {"table"})
+    assert len(errors) == 1
+    assert "delete timed out" in errors[0]
+    assert len(calls) == 1
+    assert calls[0][1]["timeout"] == 30
 
 
 def test_wait_until_retries_structured_retryable_service_unavailable():

--- a/zig/e2e/antfly/test_standalone_harness.py
+++ b/zig/e2e/antfly/test_standalone_harness.py
@@ -21,6 +21,7 @@ from types import SimpleNamespace
 
 import conftest as e2e_conftest
 import helpers
+import test_backup_restore as backups
 import test_standalone as standalone
 
 
@@ -293,6 +294,95 @@ def test_table_cleanup_does_not_retry_after_deadline(monkeypatch):
     assert "delete timed out" in errors[0]
     assert len(calls) == 1
     assert calls[0][1]["timeout"] == 30
+
+
+def _seed_cluster(monkeypatch, outcomes):
+    calls = []
+    pending = iter(outcomes)
+    clock = [0.0]
+    monkeypatch.setattr(backups.time, "monotonic", lambda: clock[0])
+    monkeypatch.setattr(
+        backups.time, "sleep", lambda delay: clock.__setitem__(0, clock[0] + delay)
+    )
+
+    def post(url, **kwargs):
+        calls.append(kwargs)
+        outcome = next(pending)
+        if isinstance(outcome, Exception):
+            raise outcome
+        status, body = outcome
+        response = requests.Response()
+        response.status_code = status
+        response._content = body
+        response.url = url
+        response.request = requests.Request("POST", url).prepare()
+        return response
+
+    return (
+        SimpleNamespace(
+            data_api_urls=["http://localhost/db/v1"],
+            assert_processes_alive=lambda: None,
+            debug_logs=lambda: "cluster write diagnostics",
+        ),
+        SimpleNamespace(post=post),
+        calls,
+    )
+
+
+def test_cluster_seed_waits_for_precommit_write_admission(monkeypatch):
+    cluster, session, calls = _seed_cluster(
+        monkeypatch, [(503, b"write unavailable"), (200, b'{"inserted":1}')]
+    )
+    docs = {"doc:a": {"title": "a"}}
+    assert backups._seed_cluster_docs_when_writable(cluster, session, "docs", docs) == {
+        "inserted": 1
+    }
+    assert len(calls) == 2
+    assert all(
+        call["json"] == {"inserts": docs, "sync_level": "write"} for call in calls
+    )
+
+
+@pytest.mark.parametrize(
+    "outcome",
+    [
+        (503, b"write committed locally; standby durability acknowledgment pending"),
+        (409, b"transaction outcome unknown"),
+        (500, b"internal failure"),
+        (400, b"invalid batch request"),
+        requests.ConnectionError("response lost"),
+    ],
+)
+def test_cluster_seed_preserves_non_admission_failures(monkeypatch, outcome):
+    cluster, session, calls = _seed_cluster(monkeypatch, [outcome])
+    with pytest.raises((AssertionError, requests.ConnectionError)):
+        backups._seed_cluster_docs_when_writable(cluster, session, "docs", {})
+    assert len(calls) == 1
+
+
+def test_cluster_seed_deadline_retains_cluster_diagnostics(monkeypatch):
+    cluster, session, calls = _seed_cluster(
+        monkeypatch, [(503, b"write unavailable")] * 3
+    )
+    with pytest.raises(AssertionError, match="cluster write diagnostics"):
+        backups._seed_cluster_docs_when_writable(
+            cluster, session, "docs", {}, timeout_s=0.25
+        )
+    assert len(calls) == 3
+    assert calls[-1]["timeout"] < calls[0]["timeout"]
+
+
+def test_cluster_seed_stops_when_server_exits(monkeypatch):
+    cluster, session, calls = _seed_cluster(monkeypatch, [(503, b"write unavailable")])
+
+    def assert_alive():
+        if calls:
+            raise RuntimeError("data server exited")
+
+    cluster.assert_processes_alive = assert_alive
+    with pytest.raises(RuntimeError, match="data server exited"):
+        backups._seed_cluster_docs_when_writable(cluster, session, "docs", {})
+    assert len(calls) == 1
 
 
 def test_wait_until_retries_structured_retryable_service_unavailable():

--- a/zig/pkg/antfly/src/storage/db/db.zig
+++ b/zig/pkg/antfly/src/storage/db/db.zig
@@ -69688,12 +69688,13 @@ test "db repair issue list exposes algebraic generation debt as repairable" {
     try std.testing.expectEqualStrings("", page.issues[0].unsupported_reason);
     try std.testing.expectEqualStrings("index_repair_required", page.issues[0].last_error);
 
-    var repair = try db.repairArtifactIssuesWithRequest(alloc, .{
+    // This checks repairability and completion, not the production pause SLA.
+    var repair = try db.repairArtifactIssuesWithRequestOptions(alloc, .{
         .target = .index,
         .artifact_kind = .algebraic,
         .index_name = "alg_v1",
         .limit = 1,
-    });
+    }, repair_completion_test_options);
     defer repair.deinit(alloc);
     try std.testing.expectEqual(@as(u64, 1), repair.scanned);
     try std.testing.expectEqual(@as(u64, 0), repair.unsupported);


### PR DESCRIPTION
Fix CI test assumptions present on main in algebraic repair completion, 3×3 backup seeding, and CLI image readiness. Also make reusable table cleanup tolerate a lost DELETE response while preserving server-crash diagnostics.

- Give the functional algebraic repairability test the existing completion budget. The production activation deadline remains 250 ms.
- Retry cluster seeding only after the explicit pre-commit `503 write unavailable` response. Transport failures, ambiguous outcomes, and pending durability acknowledgements still fail.
- Check query-visible vectors after `searchable-artifacts=1`; keep exact source-census assertions at complete readiness.
- Bound DELETE retries, detect exited servers, and report recovered transport failures and exhausted-request diagnostics.
- Start `zig/e2e/FLAKES.md` with the CI runs, failing heads, fix commits, and soak commands/results.

Evidence: [unit failure](https://github.com/antflydb/antfly/actions/runs/34177703845/job/101910688344?pr=658), [backup and CLI failures](https://github.com/antflydb/antfly/actions/runs/34177703845/job/101916669107?pr=658), [retrieval teardown failure](https://github.com/antflydb/antfly/actions/runs/34176604388/job/101914807099?pr=657). An injected 300 ms activation pause reproduced the exact unit assertion on main and passed with the test-budget fix. The natural E2E failures did not recur locally; the original reset's cause remains unknown because CI retained no server logs.

Validation: 101 fast Python checks; five focused Zig tests; 20 repetitions of the repair and production-deadline tests (40 passing executions); native ReleaseSafe Antfly build (27/27 steps). E2E validation runs on macOS ARM64: 27 initial mixed-load executions using the existing PR executable passed; the fixed main-based soak passed 90/90 executions (three workers × ten repetitions × three cases), with no recovered cleanup transport errors.
