### PR TITLE
fix(inference): write embedding CLI results to stdout

### DIFF
--- a/zig/e2e/inference/test_embed.py
+++ b/zig/e2e/inference/test_embed.py
@@ -267,6 +267,7 @@ def test_clipclap_image_embedding_golden_contract(tmp_path):
                 str(model_dir),
                 "--backend",
                 "native",
+                "--print-timing",
                 "--image",
                 str(image_path),
             ],
@@ -275,13 +276,11 @@ def test_clipclap_image_embedding_golden_contract(tmp_path):
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
         )
-        combined = [*result.stdout.splitlines(), *result.stderr.splitlines()]
-        response_line = next(
-            line
-            for line in reversed(combined)
-            if line.startswith("{") and '"embeddings"' in line
-        )
-        return json.loads(response_line)["embeddings"][0]
+        # stdout is a single machine-readable result; diagnostics stay on stderr.
+        response = json.loads(result.stdout)
+        assert "timing_ms:" in result.stderr
+        assert '"embeddings":' not in result.stderr
+        return response["embeddings"][0]
 
     first = run_embedding()
     second = run_embedding()

--- a/zig/pkg/inference/src/native_embed.zig
+++ b/zig/pkg/inference/src/native_embed.zig
@@ -75,6 +75,9 @@ pub fn main(allocator: std.mem.Allocator, io: std.Io, args: []const []const u8) 
         return error.InvalidArguments;
     }
 
+    var stdout_buffer: [4096]u8 = undefined;
+    var stdout = std.Io.File.stdout().writer(io, &stdout_buffer);
+
     const started_at = std.Io.Timestamp.now(io, .awake);
     try ensureRequestedMetalHostedBackendAvailable(opts.backend);
 
@@ -113,6 +116,7 @@ pub fn main(allocator: std.mem.Allocator, io: std.Io, args: []const []const u8) 
 
         try writeSparseResultJson(
             allocator,
+            &stdout.interface,
             opts.model_dir,
             opts.order.items,
             sparse_embeddings,
@@ -190,6 +194,7 @@ pub fn main(allocator: std.mem.Allocator, io: std.Io, args: []const []const u8) 
 
     try writeResultJson(
         allocator,
+        &stdout.interface,
         opts.model_dir,
         opts.order.items,
         text_embeddings,
@@ -322,6 +327,7 @@ fn durationMillis(from: std.Io.Timestamp, to: std.Io.Timestamp) u64 {
 
 fn writeResultJson(
     allocator: std.mem.Allocator,
+    writer: *std.Io.Writer,
     model_name: []const u8,
     order: []const InputRef,
     text_embeddings: [][]f32,
@@ -355,11 +361,13 @@ fn writeResultJson(
     }
     try buf.appendSlice(allocator, "]}\n");
 
-    print("{s}", .{buf.items});
+    try writer.writeAll(buf.items);
+    try writer.flush();
 }
 
 fn writeSparseResultJson(
     allocator: std.mem.Allocator,
+    writer: *std.Io.Writer,
     model_name: []const u8,
     order: []const InputRef,
     text_embeddings: []const sparse_embedding_mod.SparseVector,
@@ -382,7 +390,8 @@ fn writeSparseResultJson(
     }
     try buf.appendSlice(allocator, "]}\n");
 
-    print("{s}", .{buf.items});
+    try writer.writeAll(buf.items);
+    try writer.flush();
 }
 
 fn appendEmbeddingJson(buf: *std.ArrayListUnmanaged(u8), allocator: std.mem.Allocator, emb: []const f32) !void {
@@ -553,4 +562,64 @@ test "appendSparseEmbeddingJson writes cli sparse embedding shape" {
         "{\"indices\":[2,17,42],\"values\":[0.25,1.5,3]}",
         buf.items,
     );
+}
+
+test "embed result writer preserves multimodal order and escaped model name" {
+    var output = std.Io.Writer.Allocating.init(std.testing.allocator);
+    defer output.deinit();
+    var text = [_]f32{ 1, 2 };
+    var image = [_]f32{ 3, 4 };
+    var audio = [_]f32{ 5, 6 };
+    var texts = [_][]f32{&text};
+    var images = [_][]f32{&image};
+    var audios = [_][]f32{&audio};
+    try writeResultJson(std.testing.allocator, &output.writer, "model\"name", &.{
+        .{ .modality = .audio, .index = 0 },
+        .{ .modality = .text, .index = 0 },
+        .{ .modality = .image, .index = 0 },
+        .{ .modality = .text, .index = 0 },
+    }, &texts, &images, &audios);
+    try std.testing.expectEqualStrings(
+        "{\"model\":\"model\\\"name\",\"modalities\":[\"audio\",\"text\",\"image\",\"text\"],\"embeddings\":[[5,6],[1,2],[3,4],[1,2]]}\n",
+        output.written(),
+    );
+}
+
+test "embed sparse result writer preserves input order" {
+    var output = std.Io.Writer.Allocating.init(std.testing.allocator);
+    defer output.deinit();
+    var indices = [_]u32{ 2, 17 };
+    var values = [_]f32{ 0.25, 1.5 };
+    const embeddings = [_]sparse_embedding_mod.SparseVector{
+        .{ .indices = indices[0..1], .values = values[0..1] },
+        .{ .indices = indices[1..], .values = values[1..] },
+    };
+    try writeSparseResultJson(std.testing.allocator, &output.writer, "model", &.{
+        .{ .modality = .text, .index = 1 },
+        .{ .modality = .text, .index = 0 },
+    }, &embeddings);
+    try std.testing.expectEqualStrings(
+        "{\"model\":\"model\",\"modalities\":[\"text\",\"text\"],\"embeddings\":[{\"indices\":[17],\"values\":[1.5]},{\"indices\":[2],\"values\":[0.25]}]}\n",
+        output.written(),
+    );
+}
+
+test "embed result writers propagate output failures" {
+    var output = std.Io.Writer.fixed(&.{});
+    try std.testing.expectError(error.WriteFailed, writeResultJson(
+        std.testing.allocator,
+        &output,
+        "model",
+        &.{},
+        &.{},
+        &.{},
+        &.{},
+    ));
+    try std.testing.expectError(error.WriteFailed, writeSparseResultJson(
+        std.testing.allocator,
+        &output,
+        "model",
+        &.{},
+        &.{},
+    ));
 }


### PR DESCRIPTION
## Summary

- Send dense, multimodal, and sparse `antfly inference embed` result JSON to stdout through a fallible, explicitly flushed writer. Keep diagnostics and `--print-timing` on stderr.
- Cover multimodal ordering, model-name escaping, sparse ordering, and output failures with unit tests.
- Tighten the real ClipClap CLI golden test to parse stdout only and require timing diagnostics on stderr. Previously it silently accepted result JSON on stderr.

No quickstart changes or performance kernel changes are included.

## Validation

- `zig build test -j1 -- native_embed` from `zig/pkg/inference`: 6 passed.
- Standalone inference Debug build and `zig build -Doptimize=ReleaseFast -Dmetal=true -j1`: passed.
- `test_clipclap_image_embedding_golden_contract`: passed against both new Debug and ReleaseFast inference executables (temporary argv adapter maps the harness's `antfly inference` prefix to the standalone inference executable). The same tightened test fails against the previous binary because stdout is empty.
- `zig fmt --check src/native_embed.zig` and `git diff --check`: passed.

## Requested Qwen Metal timing investigation

Tested current source based on main `43fda0ba4684163a3ee563f18fd4ad61849003cf`, ReleaseFast, Apple M4 Max / 36 GiB, pinned `hf:Qwen/Qwen3-Embedding-0.6B-GGUF:q8-0-bundle-v1`. Model SHA-256: `06507c7b42688469c4e7298b0a1e16deff06caf291cf0a5b278c308249c3e439`.

The reported 65-token versus 520-token latency inversion did **not** reproduce on this Q8 bundle. This does not rule it out for different weights, hardware, inputs, or execution routes. Other builds and inference jobs were active on this shared host; these are operational measurements, not isolated performance qualification.

### Resident encoder (batch 1, 3 warmups + 20 measured calls per cell)

Existing `bench-qwen3-embedding-e2e` uses exact synthetic tokens and excludes model load and tokenization. Every measured call used Metal resident execution with zero fallbacks and padding ratio 1.000.

| Tokens | Mean latency |
| --- | --- |
| 63 | 35.20 ms |
| 64 | 35.78 ms |
| 65 | 33.01 ms (separate repeats: 33.83 and 34.96 ms) |
| 66 | 33.31 ms |
| 128 | 28.96 ms |
| 129 | 37.62 ms |
| 511 | 89.91 ms |
| 512 | 81.00 ms |
| 513 | 91.88 ms |
| 520 | 92.47 ms (repeat: 92.79 ms) |

Reproduce a cell from `zig/pkg/inference`:

```sh
zig build bench-qwen3-embedding-e2e -Dmetal=true -Doptimize=ReleaseFast -j1 -- \
  --model-dir <downloaded-q8-bundle-directory> --backend metal \
  --batch 1 --seq-len 65 --warmup 3 --iters 20
```

There are smaller shape-boundary effects. The Q8 dispatch code selects a different route at 65 rows and splits full 64-row tiles from remainder rows. An exploratory run with the existing `TERMITE_METAL_DISABLE_Q8_0_SG_M64=1` switch still showed the 128-to-129 jump (30.71 to 37.42 ms), so switching that route is not a demonstrated fix. No causal claim about the original slowdown or kernel optimization is made here.

### HTTP serving path

An isolated ReleaseFast inference process served alternating 65-/520-token requests, reversing order each iteration, with unique text per request, batch 1, 3 warmups and 20 measured requests per length. Actual model token lengths include trailing EOS; response usage reports 64/519 input tokens. Opt-in embedding traces verified all 46 requests: successful Metal execution, exactly 65/520 active tokens, and padded tokens equal active tokens. All vectors were finite, normalized, and 1024-dimensional.

| Actual model tokens | Mean | p50 | p95 |
| --- | --- | --- | --- |
| 65 | 70.99 ms | 70.46 ms | 72.85 ms |
| 520 | 132.13 ms | 132.15 ms | 132.85 ms |

The HTTP probe includes request handling, tokenization, serialization, and opt-in trace overhead, unlike the resident-encoder benchmark. The probe server has been stopped. Raw benchmark logs, replayable inputs/traces, and the HTTP probe script are retained locally; investigation notes are not added to repository docs.
