### PR TITLE
fix(e2e): bound cleanup and account for provider retry backoff

### DIFF
--- a/zig/e2e/FLAKES.md
+++ b/zig/e2e/FLAKES.md
@@ -94,9 +94,10 @@ default policy allows six worker attempts, each with six provider attempts:
 The assertion now has a named, finite 90-second allowance for that policy. It
 still requires a terminal source failure, repeated provider calls, a healthy
 shared worker and text index, and later successful image work. The test reports
-elapsed retry time and provider-request count. The CLI fixture also passes test
-failure status into server teardown so the regression script can retain failed
-runtime roots and logs.
+elapsed retry time and provider-request count. The CLI fixture stops the server
+during teardown and defers the directory cleanup decision until the completed
+teardown report, so the regression script can retain failed runtime roots and
+logs, including failures in the module's last fixture teardown.
 
 The unchanged 30-second test failed in all three workers against the existing
 PR #659 executable, reproducing the CI signature. This demonstrates a test budget
@@ -167,6 +168,11 @@ counts, failing node IDs, and preserved diagnostics when adding a new result.
   after the fix). Both used the existing PR #659 executable from
   `.worktrees/std-io-migration-audit/zig/zig-out/bin/antfly`, exercising real
   retry sleeps. The 105 fast regressions also passed with this change.
+- Review correction [`d058ddb2f`](https://github.com/antflydb/antfly/commit/d058ddb2ff4e478f1b539774cf3938a3d711cf9d):
+  **113 fast regressions passed**, including eight real-pytest lifecycle cases
+  covering setup, call, final teardown, earlier-test failures, preservation
+  settings, successful cleanup, and directory cleanup errors. These tests use
+  the real CLI fixture and server shutdown method without launching a server.
 
 Both soaks used `scripts/ci/zig-e2e-regression-loop.sh` with `SKIP_BUILD=1`,
 `ANTFLY_BIN` set to the executable above, and the corresponding test node ID.

--- a/zig/e2e/FLAKES.md
+++ b/zig/e2e/FLAKES.md
@@ -12,6 +12,7 @@ entries so later failures can be compared with the original signature.
 | `test_retrieval.py::test_retrieval_agent_streaming_fallback_progress` | [PR #657, run 34176604388, job 101914807099](https://github.com/antflydb/antfly/actions/runs/34176604388/job/101914807099?pr=657), head [`bc8f8a20d`](https://github.com/antflydb/antfly/commit/bc8f8a20d34534969decc90813fbcb8f390164f1) | [`47106c1fd`](https://github.com/antflydb/antfly/commit/47106c1fd09e9be5f1e3333363fd77d007813632) | Teardown recovery fixed; original reset cause unknown; 30/30 soak runs passed. |
 | `test_backup_restore.py::test_three_by_three_cluster_backup_restore_through_metadata_public_api` | [PR #658, run 34177703845, job 101916669107](https://github.com/antflydb/antfly/actions/runs/34177703845/job/101916669107?pr=658), head [`96bee1e80`](https://github.com/antflydb/antfly/commit/96bee1e80cf115c2dc636ed065a0378d8cfb27f3) | [`1bf7230cc`](https://github.com/antflydb/antfly/commit/1bf7230cc74c37ba4263964719542c210ff9473d) | Write-admission handling fixed; 30/30 soak runs passed. |
 | `test_cli.py::test_cli_inline_create_load_wait_query_image_and_rag_pipeline` | [PR #658, run 34177703845, job 101916669107](https://github.com/antflydb/antfly/actions/runs/34177703845/job/101916669107?pr=658), head [`96bee1e80`](https://github.com/antflydb/antfly/commit/96bee1e80cf115c2dc636ed065a0378d8cfb27f3) | [`1bf7230cc`](https://github.com/antflydb/antfly/commit/1bf7230cc74c37ba4263964719542c210ff9473d) | Readiness assertion fixed; 30/30 soak runs passed. |
+| Same CLI pipeline, retry-exhaustion phase (`settled_failure is not None`) | [PR #659, run 34182855053, job 101932868141](https://github.com/antflydb/antfly/actions/runs/34182855053/job/101932868141), head [`51ec7a551`](https://github.com/antflydb/antfly/commit/51ec7a551aa3ac5713eb243155a9e2c9d8cfa0ac) | [`19b988108`](https://github.com/antflydb/antfly/commit/19b9881080af1dbc805f9ad5bda096b62bf063b1) | Reproduced in 3/3 concurrent runs with real retry sleeps; corrected-budget soak passed 9/9. |
 
 ### Retrieval streaming teardown
 
@@ -31,6 +32,13 @@ printed in the soak log rather than silently discarded.
 Deterministic harness tests cover resets, successful deletion before response
 loss, deadline/attempt exhaustion, HTTP errors, and server crashes. The original
 CI reset has not been reproduced naturally in the local soak.
+
+The review of #660 also found that lock contention could escape this cleanup
+deadline. Follow-up [`5e05d2314`](https://github.com/antflydb/antfly/commit/5e05d2314a6555a73f5dfa20766f5587b42d6f6e)
+bounds lock acquisition by the remaining time and rechecks the deadline before
+DELETE. Regression cases cover lock timeout, late acquisition, and retry-sleep
+overshoot, including lock release on failure. A further 30/30 retrieval teardown
+soak runs passed with the existing main-based executable.
 
 ### Three-by-three backup seeding
 
@@ -64,6 +72,39 @@ skipped sources, zero failures, and a successful image query. No wait deadline
 was increased and no source-coverage assertion was removed from final completion.
 
 The specific premature assertion did not fail naturally in the local soak.
+
+### CLI provider retry exhaustion with real backoff
+
+This is a different phase of the CLI pipeline; #660 did not fix it. The test
+keeps returning HTTP 503 for the ClipClap provider and expects the request to
+exhaust its budget, become a per-source failure, and leave the shared enrichment
+worker and sibling text index healthy. CI still reported one pending source,
+zero failed sources, eight retryable errors, and a live retrying worker when the
+30-second assertion expired.
+
+PR #659 restores real sleeps in `enrichment_runtime.zig`. Previously, the
+`@hasDecl(std.Thread, "sleep")` guard skipped inline sleeps with Zig 0.16. The
+default policy allows six worker attempts, each with six provider attempts:
+
+- Inline delays per worker attempt: 0.25 + 0.5 + 1 + 2 + 4 = 7.75 seconds.
+- Five worker backoffs: 0.5 + 1 + 2 + 4 + 8 = 15.5 seconds.
+- Total scheduled delay before exhaustion: 6 × 7.75 + 15.5 = **62 seconds**,
+  before HTTP, storage, or scheduler overhead.
+
+The assertion now has a named, finite 90-second allowance for that policy. It
+still requires a terminal source failure, repeated provider calls, a healthy
+shared worker and text index, and later successful image work. The test reports
+elapsed retry time and provider-request count. The CLI fixture also passes test
+failure status into server teardown so the regression script can retain failed
+runtime roots and logs.
+
+The unchanged 30-second test failed in all three workers against the existing
+PR #659 executable, reproducing the CI signature. This demonstrates a test budget
+that was incompatible with the real retry schedule, not a need to remove
+production backoff or weaken per-source failure isolation.
+
+With the fix, all nine runs passed against that same executable. Each exhausted
+36 provider requests in 62.63–63.21 seconds, matching the scheduled backoff.
 
 ## Related unit failure
 
@@ -111,3 +152,22 @@ scripts/ci/zig-e2e-regression-loop.sh \
 The script preserves failed worker logs and the first two failed runtime roots
 per worker with this configuration. Record the tested commit, worker/repetition
 counts, failing node IDs, and preserved diagnostics when adding a new result.
+
+### Follow-up validation after #660
+
+2026-09-07 (America/Los_Angeles), macOS ARM64, based on #660's squash merge
+[`3ce736ee6`](https://github.com/antflydb/antfly/commit/3ce736ee67a547e196423480ed6a079576a93582):
+
+- Cleanup deadline fix [`5e05d2314`](https://github.com/antflydb/antfly/commit/5e05d2314a6555a73f5dfa20766f5587b42d6f6e):
+  **105 fast regressions passed**; the retrieval case passed **30/30**
+  (three workers × ten repetitions) using the existing main-based executable
+  from `.worktrees/fix-ci-repair-retrieval/zig/zig-out/bin/antfly`.
+- CLI retry budget fix [`19b988108`](https://github.com/antflydb/antfly/commit/19b9881080af1dbc805f9ad5bda096b62bf063b1):
+  **3/3 failed before**, **9/9 passed after** (three workers × three repetitions
+  after the fix). Both used the existing PR #659 executable from
+  `.worktrees/std-io-migration-audit/zig/zig-out/bin/antfly`, exercising real
+  retry sleeps. The 105 fast regressions also passed with this change.
+
+Both soaks used `scripts/ci/zig-e2e-regression-loop.sh` with `SKIP_BUILD=1`,
+`ANTFLY_BIN` set to the executable above, and the corresponding test node ID.
+These are local macOS results; Linux CI remains the cross-platform check.

--- a/zig/e2e/antfly/conftest.py
+++ b/zig/e2e/antfly/conftest.py
@@ -309,11 +309,29 @@ def _delete_created_table(api: Any, table_name: str) -> None:
     for attempt in range(3):
         raise_if_server_process_exited(api._server)
         try:
-            with api._request_lock:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise requests.Timeout(
+                    "table cleanup deadline expired before request lock"
+                )
+            if not api._request_lock.acquire(timeout=remaining):
+                raise requests.Timeout(
+                    "table cleanup timed out waiting for request lock"
+                )
+            try:
+                # Lock acquisition may consume the deadline, including when
+                # the waiter is descheduled just as the lock becomes available.
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise requests.Timeout(
+                        "table cleanup deadline expired before DELETE"
+                    )
                 response = api.s.delete(
                     f"{api.url}/tables/{quote(table_name, safe='')}",
-                    timeout=max(0.001, deadline - time.monotonic()),
+                    timeout=remaining,
                 )
+            finally:
+                api._request_lock.release()
         except (requests.ConnectionError, requests.Timeout) as err:
             raise_if_server_process_exited(api._server)
             remaining = deadline - time.monotonic()

--- a/zig/e2e/antfly/conftest.py
+++ b/zig/e2e/antfly/conftest.py
@@ -140,11 +140,50 @@ def maybe_preserve_tempdir(
     return True
 
 
+_DEFERRED_MODULE_TEMPDIRS = pytest.StashKey[list[tempfile.TemporaryDirectory[str]]]()
+
+
+def defer_module_tempdir_cleanup(
+    module: pytest.Module, tempdir: tempfile.TemporaryDirectory[str]
+) -> None:
+    # Keep ownership until the report for the module's last teardown is ready.
+    module.stash.setdefault(_DEFERRED_MODULE_TEMPDIRS, []).append(tempdir)
+
+
 @pytest.hookimpl(hookwrapper=True)
 def pytest_runtest_makereport(item: pytest.Item, call: pytest.CallInfo[object]):
     outcome = yield
     report = outcome.get_result()
     setattr(item, f"rep_{report.when}", report)
+    module = item.getparent(pytest.Module)
+    if report.when != "teardown" or module is None:
+        return
+    pending = module.stash.get(_DEFERRED_MODULE_TEMPDIRS, [])
+    if not pending:
+        return
+    del module.stash[_DEFERRED_MODULE_TEMPDIRS]
+    failed = any(
+        phase_report is not None and phase_report.failed
+        for module_item in item.session.items
+        if module_item.getparent(pytest.Module) is module
+        for phase in ("setup", "call", "teardown")
+        for phase_report in (getattr(module_item, f"rep_{phase}", None),)
+    )
+    for tempdir in pending:
+        if not maybe_preserve_tempdir(tempdir, failed=failed):
+            try:
+                tempdir.cleanup()
+            except OSError as err:
+                # Cleanup now runs after fixture teardown; attach errors to its
+                # report rather than turning them into a pytest internal error.
+                diagnostic = f"E2E directory cleanup failed for {tempdir.name}: {err}"
+                report.longrepr = (
+                    f"{report.longrepr}\n{diagnostic}"
+                    if report.longrepr is not None
+                    else diagnostic
+                )
+                report.outcome = "failed"
+                failed = True
 
 
 def default_antfly_api_root(binary: str) -> str:
@@ -1306,11 +1345,13 @@ class StandaloneAntflyServer:
     def resume(self) -> None:
         self._start_process(truncate_logs=False)
 
-    def stop(self, *, test_failed: bool = False) -> None:
+    def stop(self, *, test_failed: bool = False, cleanup_root: bool = True) -> None:
         self._stop_process()
         self.port_reservations.close()
         self.log_file.close()
-        if not maybe_preserve_tempdir(self.tempdir, failed=test_failed):
+        if cleanup_root and not maybe_preserve_tempdir(
+            self.tempdir, failed=test_failed
+        ):
             self.tempdir.cleanup()
 
 

--- a/zig/e2e/antfly/test_cli.py
+++ b/zig/e2e/antfly/test_cli.py
@@ -36,6 +36,7 @@ from conftest import (
     InferenceGeneratorServer,
     InferenceRerankerServer,
     StandaloneAntflyServer,
+    defer_module_tempdir_cleanup,
     resolve_binary_path,
 )
 from helpers import wait_until
@@ -125,14 +126,10 @@ def cli_server(cli_inference_servers, request):
     server = StandaloneAntflyServer(binary, "127.0.0.1", port)
     server.cli_inference_urls = cli_inference_servers
     yield server
-    test_failed = any(
-        report is not None and report.failed
-        for item in request.session.items
-        if item.getparent(pytest.Module) is request.node
-        for phase in ("setup", "call", "teardown")
-        for report in (getattr(item, f"rep_{phase}", None),)
-    )
-    server.stop(test_failed=test_failed)
+    # Stop processes now, but wait for the final teardown report before deciding
+    # whether this module's runtime directory should be retained for diagnostics.
+    defer_module_tempdir_cleanup(request.node, server.tempdir)
+    server.stop(cleanup_root=False)
 
 
 @pytest.fixture(scope="module")

--- a/zig/e2e/antfly/test_cli.py
+++ b/zig/e2e/antfly/test_cli.py
@@ -42,6 +42,14 @@ from helpers import wait_until
 from port_reservations import find_free_port
 
 
+# enrichment_runtime.zig permits six worker attempts, each containing six
+# provider attempts. Inline sleeps total 7.75s per worker attempt; the five
+# worker backoffs total 15.5s. Exhaustion therefore needs 62s of scheduled
+# backoff alone, plus HTTP/storage work and scheduling. Keep this finite
+# allowance aligned with that policy instead of relying on no-op retry sleeps.
+TRANSIENT_EMBEDDING_SETTLE_TIMEOUT_S = 90.0
+
+
 class TinyImageServer:
     """Local HTTP origin used to exercise remoteMedia's real transport path."""
 
@@ -108,7 +116,7 @@ def cli_media_server():
 
 
 @pytest.fixture(scope="module")
-def cli_server(cli_inference_servers):
+def cli_server(cli_inference_servers, request):
     binary = resolve_binary_path(os.environ.get("ANTFLY_BIN", str(DEFAULT_ANTFLY_BIN)))
     if not Path(binary).exists():
         pytest.skip(f"antfly binary not found: {binary}")
@@ -117,7 +125,14 @@ def cli_server(cli_inference_servers):
     server = StandaloneAntflyServer(binary, "127.0.0.1", port)
     server.cli_inference_urls = cli_inference_servers
     yield server
-    server.stop()
+    test_failed = any(
+        report is not None and report.failed
+        for item in request.session.items
+        if item.getparent(pytest.Module) is request.node
+        for phase in ("setup", "call", "teardown")
+        for report in (getattr(item, f"rep_{phase}", None),)
+    )
+    server.stop(test_failed=test_failed)
 
 
 @pytest.fixture(scope="module")
@@ -724,12 +739,23 @@ def test_cli_inline_create_load_wait_query_image_and_rag_pipeline(
                 return status
             return None
 
+        retry_started = time.monotonic()
         settled_failure = wait_until(
-            isolated_failure_is_settled, timeout_s=30.0, interval_s=0.05
+            isolated_failure_is_settled,
+            timeout_s=TRANSIENT_EMBEDDING_SETTLE_TIMEOUT_S,
+            interval_s=0.05,
         )
-        assert settled_failure is not None, cli(
-            "index", "get", "--table", table, "--index", "thumbnail"
-        ).stdout
+        retry_elapsed = time.monotonic() - retry_started
+        retry_requests = embedder_server.transient_embedding_requests
+        assert settled_failure is not None, (
+            f"ClipClap failure did not settle after {retry_elapsed:.2f}s; "
+            f"provider_requests={retry_requests}\n"
+            + cli("index", "get", "--table", table, "--index", "thumbnail").stdout
+        )
+        print(
+            f"ClipClap retries settled after {retry_elapsed:.2f}s "
+            f"({retry_requests} provider requests)"
+        )
         embedder_server.release_transient_embedding_failures()
         assert embedder_server.transient_embedding_requests > 1
         assert settled_failure["enrichment_runtime"]["worker_failed"] is False

--- a/zig/e2e/antfly/test_standalone_harness.py
+++ b/zig/e2e/antfly/test_standalone_harness.py
@@ -287,13 +287,78 @@ def test_table_cleanup_does_not_hide_server_crash(monkeypatch, outcome):
 
 def test_table_cleanup_does_not_retry_after_deadline(monkeypatch):
     api, calls = _cleanup_api(monkeypatch, [requests.Timeout("delete timed out"), 204])
-    clock = iter([0.0, 0.0, 30.0])
-    monkeypatch.setattr(e2e_conftest.time, "monotonic", lambda: next(clock))
+    clock = [0.0]
+    monkeypatch.setattr(e2e_conftest.time, "monotonic", lambda: clock[0])
+    delete = api.s.delete
+
+    def timed_out_delete(*args, **kwargs):
+        clock[0] = 30.0
+        return delete(*args, **kwargs)
+
+    api.s.delete = timed_out_delete
     errors = e2e_conftest._cleanup_created_tables(api, {"table"})
     assert len(errors) == 1
     assert "delete timed out" in errors[0]
     assert len(calls) == 1
     assert calls[0][1]["timeout"] == 30
+    assert not api._request_lock.locked()
+
+
+def test_table_cleanup_does_not_retry_when_sleep_passes_deadline(monkeypatch):
+    api, calls = _cleanup_api(monkeypatch, [requests.ConnectionError("reset"), 204])
+    clock = [0.0]
+    monkeypatch.setattr(e2e_conftest.time, "monotonic", lambda: clock[0])
+    monkeypatch.setattr(
+        e2e_conftest.time, "sleep", lambda _: clock.__setitem__(0, 31.0)
+    )
+    errors = e2e_conftest._cleanup_created_tables(api, {"table"})
+    assert len(errors) == 1
+    assert "deadline expired" in errors[0]
+    assert len(calls) == 1
+    assert not api._request_lock.locked()
+
+
+@pytest.mark.parametrize(
+    "delay, acquired, request_timeout",
+    [(30.0, False, None), (31.0, True, None), (29.0, True, 1.0)],
+)
+def test_table_cleanup_bounds_lock_wait_and_rechecks_deadline(
+    monkeypatch, delay, acquired, request_timeout
+):
+    api, calls = _cleanup_api(monkeypatch, [204])
+    clock = [0.0]
+    monkeypatch.setattr(e2e_conftest.time, "monotonic", lambda: clock[0])
+
+    class ContendedLock:
+        releases = 0
+
+        def acquire(self, *, timeout=-1):
+            assert timeout == 30.0, "cleanup must bound the lock wait"
+            clock[0] += delay
+            return acquired
+
+        def release(self):
+            self.releases += 1
+
+        def __enter__(self):
+            self.acquire()
+
+        def __exit__(self, *args):
+            self.release()
+
+    lock = ContendedLock()
+    api._request_lock = lock
+    errors = e2e_conftest._cleanup_created_tables(api, {"table"})
+    assert lock.releases == int(acquired)
+    if request_timeout is None:
+        assert calls == []
+        assert len(errors) == 1
+        assert "cleanup server diagnostics" in errors[0]
+        assert "request lock" in errors[0] or "deadline" in errors[0]
+    else:
+        assert errors == []
+        assert len(calls) == 1
+        assert calls[0][1]["timeout"] == request_timeout
 
 
 def _seed_cluster(monkeypatch, outcomes):

--- a/zig/e2e/antfly/test_standalone_harness.py
+++ b/zig/e2e/antfly/test_standalone_harness.py
@@ -16,6 +16,10 @@
 
 import pytest
 import requests
+import os
+from pathlib import Path
+import subprocess
+import sys
 import threading
 from types import SimpleNamespace
 
@@ -23,6 +27,119 @@ import conftest as e2e_conftest
 import helpers
 import test_backup_restore as backups
 import test_standalone as standalone
+
+
+@pytest.mark.parametrize(
+    "failure_phase, preservation, retained",
+    [
+        ("none", "failure", False),
+        ("setup", "failure", True),
+        ("call", "failure", True),
+        ("teardown", "failure", True),
+        ("earlier_call", "failure", True),
+        ("teardown", "never", False),
+        ("none", "always", True),
+        ("cleanup", "never", False),
+    ],
+)
+def test_cli_runtime_preservation_uses_completed_module_reports(
+    tmp_path, failure_phase, preservation, retained
+):
+    # Run real pytest finalizers and the real CLI fixture: a mocked report cannot
+    # expose the ordering between module shutdown and the last teardown report.
+    probe = tmp_path / "test_cli_preservation.py"
+    probe.write_text("""
+import os
+from pathlib import Path
+import sys
+import tempfile
+from types import SimpleNamespace
+
+import pytest
+import conftest as harness
+import test_cli as cli_tests
+
+cli_server = cli_tests.cli_server
+phase = os.environ["PROBE_FAILURE_PHASE"]
+
+@pytest.fixture(scope="module")
+def cli_inference_servers():
+    def server_factory(*args):
+        server = object.__new__(harness.StandaloneAntflyServer)
+        server.tempdir = tempfile.TemporaryDirectory(dir=Path(__file__).parent)
+        root = Path(server.tempdir.name)
+        Path("runtime-path").write_text(str(root))
+        server.log_file = (root / "server.log").open("w")
+        server.log_file.write("retained diagnostics")
+        server.proc = None
+        server.port_reservations = SimpleNamespace(close=lambda: None)
+        server._stop_process = lambda: Path("process-stopped").touch()
+        if phase == "cleanup":
+            def cleanup_error():
+                raise OSError("injected cleanup failure")
+            server.tempdir.cleanup = cleanup_error
+        return server
+
+    with pytest.MonkeyPatch.context() as patch:
+        patch.setenv("ANTFLY_BIN", sys.executable)
+        patch.setattr(cli_tests, "find_free_port", lambda: 0)
+        patch.setattr(cli_tests, "StandaloneAntflyServer", server_factory)
+        yield {}
+        # This dependency finalizes after cli_server has stopped its process.
+        assert Path("process-stopped").exists()
+        assert Path(Path("runtime-path").read_text()).exists()
+        if phase == "teardown":
+            raise RuntimeError("injected teardown failure")
+
+@pytest.fixture
+def setup_probe(cli_server):
+    if phase == "setup":
+        raise RuntimeError("injected setup failure")
+
+def test_first(cli_server):
+    assert phase != "earlier_call", "injected earlier call failure"
+
+def test_last(cli_server, setup_probe):
+    assert phase != "call", "injected call failure"
+""")
+    env = os.environ.copy()
+    env.update(
+        PYTHONPATH=str(Path(e2e_conftest.__file__).parent),
+        PYTEST_DISABLE_PLUGIN_AUTOLOAD="1",
+        PROBE_FAILURE_PHASE=failure_phase,
+        ANTFLY_E2E_PRESERVE_ROOT="1" if preservation == "always" else "0",
+        ANTFLY_E2E_PRESERVE_ROOT_ON_FAILURE=("1" if preservation == "failure" else "0"),
+    )
+    env.pop("PYTEST_ADDOPTS", None)
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "-p",
+            "xdist.plugin",
+            "-p",
+            "conftest",
+            "--confcutdir",
+            str(tmp_path),
+            "-q",
+            str(probe),
+        ],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    output = result.stdout + result.stderr
+    assert "INTERNALERROR" not in output, output
+    assert result.returncode == (0 if failure_phase == "none" else 1), output
+    if failure_phase != "none":
+        assert "injected" in output, output
+    root = Path((tmp_path / "runtime-path").read_text())
+    assert root.exists() is retained, output
+    if retained:
+        assert (root / "server.log").read_text() == "retained diagnostics"
 
 
 @pytest.mark.parametrize("total", [10 * 1024**3, 1024**4])


### PR DESCRIPTION
Table cleanup could wait indefinitely for the shared request lock, then send DELETE after its 30-second deadline had expired. Bound lock acquisition by the remaining deadline and recheck before sending the request. This addresses the review follow-up from merged #660.

The CLI pipeline failure in [PR #659's E2E job](https://github.com/antflydb/antfly/actions/runs/34182855053/job/101932868141) occurs later than the readiness failure fixed by #660. Restoring real retry sleeps requires 62 seconds of scheduled backoff before provider retry exhaustion; the test allowed only 30 seconds. Give that assertion a documented 90-second budget, retain the source-failure and worker-isolation assertions, and report elapsed time and provider request count. Stop CLI processes during fixture teardown and defer the directory cleanup decision until the completed teardown report, so soak diagnostics survive failures in the module's last teardown too. Production retry policy is unchanged.

Record the CI signature, root cause, fix commits, and reproduction/soak evidence in `zig/e2e/FLAKES.md`.

Validation on macOS ARM64 using the repository regression-loop script:

- CLI case against the existing PR #659 executable with real retry sleeps: **3/3 failed before; 9/9 passed after**, with three concurrent workers. Exhaustion took **62.63–63.21 seconds and 36 provider requests** in each passing run.
- Retrieval cleanup: **30/30 passed**, three workers × ten repetitions, using the existing main-based executable from the #660 worktree.
- **113 fast harness, scheduler, and metadata quorum checks passed**, including lock timeout, late acquisition, retry-sleep overshoot, and release-on-error cases. Eight real-pytest lifecycle cases cover setup, call, final teardown, earlier-test failures, preservation settings, successful cleanup, and directory cleanup errors.
- `git diff --check` passed. Linux CI provides cross-platform validation; local soaks reused existing native executables because these changes affect only the Python harness and documentation.
