### PR TITLE
fix(inference): bound weight lifetimes and reclaim Metal request contexts

### DIFF
--- a/zig/pkg/inference/src/architectures/bert.zig
+++ b/zig/pkg/inference/src/architectures/bert.zig
@@ -949,6 +949,7 @@ const EmbeddingLayerNormResidentProbe = struct {
     const vtable = blk: {
         var vt = native_compute_mod.vtable_impl;
         vt.getWeight = getWeight;
+        vt.acquireWeight = getWeight;
         vt.decoderRuntimeApplyLayerNorm = applyLayerNorm;
         break :blk vt;
     };

--- a/zig/pkg/inference/src/architectures/clip.zig
+++ b/zig/pkg/inference/src/architectures/clip.zig
@@ -537,6 +537,7 @@ test "native clip vision patch weight direct path matches explicit 2d reshape" {
         weight_store.lazy_weights.deinit(allocator);
     }
     var compute = native_compute.NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
     var cb = compute.computeBackend();
 
     const batch = 2;

--- a/zig/pkg/inference/src/architectures/gemma4_projector.zig
+++ b/zig/pkg/inference/src/architectures/gemma4_projector.zig
@@ -1860,6 +1860,7 @@ test "gemma4 12b real mmproj optional projector smoke" {
     var weight_store = native_compute.WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     defer native_compute.deinitPrefetchQueue(&weight_store);
     var compute = native_compute.NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
     var cb = compute.computeBackend();
 
     if (image_path) |path| {

--- a/zig/pkg/inference/src/architectures/gpt.zig
+++ b/zig/pkg/inference/src/architectures/gpt.zig
@@ -5043,7 +5043,7 @@ test "deepseek v4 compressed attention dispatches resident backend request and f
     var store = native_compute_mod.WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     defer deinitDeepSeekV4TestWeightStore(allocator, &store);
     var compute = native_compute_mod.NativeCompute.init(allocator, &store, null);
-    defer compute.weight_reservations.deinit(allocator);
+    defer compute.deinit();
     var cb = ComputeBackend{ .ptr = &compute, .vtable = &DeepSeekV4DeviceFastPathTestBackend.vtable };
 
     try putDeepSeekV4TestWeight(allocator, &store, "model.layers.0.self_attn.compressor.kv_proj.weight", &.{ 2, 2 }, &.{
@@ -11561,7 +11561,7 @@ test "uniform batched RoPE restarts positions for each item" {
     var store = native_compute_mod.WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     defer deinitDeepSeekV4TestWeightStore(allocator, &store);
     var compute = native_compute_mod.NativeCompute.init(allocator, &store, null);
-    defer compute.weight_reservations.deinit(allocator);
+    defer compute.deinit();
     var cb = ComputeBackend{ .ptr = &compute, .vtable = &native_compute_mod.vtable_impl };
 
     const first_values = [_]f32{ 1.0, 0.0, 0.0, 1.0 };
@@ -11597,7 +11597,7 @@ test "Gemma 4 router independently RMS-normalizes and hidden-scales its source" 
     var store = native_compute_mod.WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     defer deinitDeepSeekV4TestWeightStore(allocator, &store);
     var compute = native_compute_mod.NativeCompute.init(allocator, &store, null);
-    defer compute.weight_reservations.deinit(allocator);
+    defer compute.deinit();
     var cb = ComputeBackend{ .ptr = &compute, .vtable = &native_compute_mod.vtable_impl };
 
     try putDeepSeekV4TestWeight(
@@ -11636,7 +11636,7 @@ test "Qwen3-VL attention requires and consumes explicit M-RoPE positions" {
     var store = native_compute_mod.WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     defer deinitDeepSeekV4TestWeightStore(allocator, &store);
     var compute = native_compute_mod.NativeCompute.init(allocator, &store, null);
-    defer compute.weight_reservations.deinit(allocator);
+    defer compute.deinit();
     var cb = ComputeBackend{ .ptr = &compute, .vtable = &native_compute_mod.vtable_impl };
 
     const q = try cb.fromFloat32Shape(&.{ 1, 0, 0, 0, 1, 0, 1, 0, 0, 0, 1, 0 }, &.{ 2, 6 });
@@ -11699,7 +11699,7 @@ test "Qwen3-VL DeepStack adds features only to visual rows" {
     var store = native_compute_mod.WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     defer deinitDeepSeekV4TestWeightStore(allocator, &store);
     var compute = native_compute_mod.NativeCompute.init(allocator, &store, null);
-    defer compute.weight_reservations.deinit(allocator);
+    defer compute.deinit();
     var cb = ComputeBackend{ .ptr = &compute, .vtable = &native_compute_mod.vtable_impl };
     const hidden = try cb.fromFloat32Shape(&.{ 1, 2, 10, 20, 100, 200 }, &.{ 3, 2 });
     defer cb.free(hidden);
@@ -11814,7 +11814,7 @@ test "Qwen3-VL reranker prefers converted two-row classifier head" {
     var store = native_compute_mod.WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     defer deinitDeepSeekV4TestWeightStore(allocator, &store);
     var compute = native_compute_mod.NativeCompute.init(allocator, &store, null);
-    defer compute.weight_reservations.deinit(allocator);
+    defer compute.deinit();
     var cb = ComputeBackend{ .ptr = &compute, .vtable = &native_compute_mod.vtable_impl };
 
     try putDeepSeekV4TestWeight(

--- a/zig/pkg/inference/src/architectures/modern_bert.zig
+++ b/zig/pkg/inference/src/architectures/modern_bert.zig
@@ -1290,6 +1290,7 @@ test "HuggingFace ModernBERT fused checkpoint omits layer zero attention norm an
     var store = native_compute.WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     defer deinitTestWeightStore(allocator, &store);
     var compute = native_compute.NativeCompute.init(allocator, &store, null);
+    defer compute.deinit();
     var cb = compute.computeBackend();
 
     // This is the exact public checkpoint structure in miniature: bare

--- a/zig/pkg/inference/src/architectures/qwen3vl_projector.zig
+++ b/zig/pkg/inference/src/architectures/qwen3vl_projector.zig
@@ -1887,7 +1887,7 @@ test "Qwen3-VL projector cancellation unwinds live vision intermediates with cac
     var store = native_compute.WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     defer native_compute.deinitPrefetchQueue(&store);
     var compute = native_compute.NativeCompute.init(allocator, &store, null);
-    defer compute.weight_reservations.deinit(allocator);
+    defer compute.deinit();
     var cb = ComputeBackend{ .ptr = &compute, .vtable = &native_compute.vtable_impl };
     // The first layer norm really executes. Cancellation at its following
     // projection must release that intermediate even when weights are cached.
@@ -1946,7 +1946,7 @@ test "Qwen3-VL prompt preparation keeps M-RoPE mask and DeepStack aligned" {
     errdefer tensor.deinit();
     try store.resident_weights.put(allocator, name, weight_source.LoadedWeight{ .tensor = tensor });
     var compute = native_compute.NativeCompute.init(allocator, &store, null);
-    defer compute.weight_reservations.deinit(allocator);
+    defer compute.deinit();
     var cb = ComputeBackend{ .ptr = &compute, .vtable = &native_compute.vtable_impl };
     var projected = ProjectedImages{
         .allocator = allocator,

--- a/zig/pkg/inference/src/architectures/session_factory.zig
+++ b/zig/pkg/inference/src/architectures/session_factory.zig
@@ -4946,7 +4946,7 @@ fn makeMetalHostedComputeBackend(
             self.metal_jit_scope,
             self.kernel_jit_load_context,
         );
-    return compute.computeBackend();
+    return compute.ownedComputeBackend();
 }
 
 fn initGpuHostedPrefetch(self: *ArchSession) !void {

--- a/zig/pkg/inference/src/bench/clipclap_native.zig
+++ b/zig/pkg/inference/src/bench/clipclap_native.zig
@@ -1030,6 +1030,7 @@ fn runConcreteScenario(
             switch (cfg.backend) {
                 .native => {
                     var compute = if (cfg.io) |io| NativeCompute.initWithIo(allocator, &weight_store, null, io) else NativeCompute.init(allocator, &weight_store, null);
+                    defer compute.deinit();
                     const cb = compute.computeBackend();
                     const result = try benchClipText(allocator, &cb, clip_cfg, inputs, cfg, variant);
                     if (cfg.format == .text) printQuantCacheStats(&weight_store);
@@ -1052,6 +1053,7 @@ fn runConcreteScenario(
             switch (cfg.backend) {
                 .native => {
                     var compute = if (cfg.io) |io| NativeCompute.initWithIo(allocator, &weight_store, null, io) else NativeCompute.init(allocator, &weight_store, null);
+                    defer compute.deinit();
                     const cb = compute.computeBackend();
                     const result = try benchClipVision(allocator, &cb, clip_cfg, pixels, cfg, variant);
                     if (cfg.format == .text) printQuantCacheStats(&weight_store);
@@ -1078,6 +1080,7 @@ fn runConcreteScenario(
             switch (cfg.backend) {
                 .native => {
                     var compute = if (cfg.io) |io| NativeCompute.initWithIo(allocator, &weight_store, null, io) else NativeCompute.init(allocator, &weight_store, null);
+                    defer compute.deinit();
                     const cb = compute.computeBackend();
                     const result = try benchClapText(allocator, &cb, clap_cfg, inputs, cfg, variant);
                     if (cfg.format == .text) printQuantCacheStats(&weight_store);
@@ -1106,6 +1109,7 @@ fn runConcreteScenario(
             switch (cfg.backend) {
                 .native => {
                     var compute = if (cfg.io) |io| NativeCompute.initWithIo(allocator, &weight_store, null, io) else NativeCompute.init(allocator, &weight_store, null);
+                    defer compute.deinit();
                     const cb = compute.computeBackend();
                     const result = try benchClapAudio(allocator, &cb, clap_audio_cfg, audio_features, is_longer, cfg, variant);
                     if (cfg.format == .text) printQuantCacheStats(&weight_store);

--- a/zig/pkg/inference/src/bench/gliner2_native.zig
+++ b/zig/pkg/inference/src/bench/gliner2_native.zig
@@ -815,6 +815,7 @@ pub fn main(init: std.process.Init) !void {
     switch (cfg.backend) {
         .native => {
             var compute = NativeCompute.init(allocator, &weight_store, null);
+            defer compute.deinit();
             const cb = compute.computeBackend();
             try runBenchmark(allocator, &cb, cfg, inputs, &weight_store);
         },

--- a/zig/pkg/inference/src/bench/training.zig
+++ b/zig/pkg/inference/src/bench/training.zig
@@ -237,6 +237,7 @@ fn runGraphVariant(
         ws.lazy_weights.deinit(allocator);
     }
     var compute = NativeCompute.init(allocator, &ws, null);
+    defer compute.deinit();
     var cb = compute.computeBackend();
 
     var loop = training_loop_mod.TrainingLoop.init(allocator, .{

--- a/zig/pkg/inference/src/finetune/colqwen2.zig
+++ b/zig/pkg/inference/src/finetune/colqwen2.zig
@@ -1075,6 +1075,7 @@ pub fn trainLoRABundleOneStep(
         .lazy_weights = .{},
     };
     var compute = native_compute.NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
     var cb = compute.computeBackend();
     var optimizer_state = optimizers.OptimizerState.init(allocator);
     defer optimizer_state.deinit();

--- a/zig/pkg/inference/src/finetune/eval/eval_fused_chunker.zig
+++ b/zig/pkg/inference/src/finetune/eval/eval_fused_chunker.zig
@@ -366,6 +366,7 @@ pub fn main(init: std.process.Init) !void {
     };
 
     var native_backend = native_compute.NativeCompute.init(allocator, &weight_store, null);
+    defer native_backend.deinit();
     const cb: ComputeBackend = native_backend.computeBackend();
 
     print("backend: native\n", .{});

--- a/zig/pkg/inference/src/finetune/gemma4.zig
+++ b/zig/pkg/inference/src/finetune/gemma4.zig
@@ -1552,6 +1552,7 @@ pub fn prepareMultimodalInputsFromChatData(
     defer dummy_ws.resident_weights.deinit(allocator);
     defer dummy_ws.lazy_weights.deinit(allocator);
     var native_engine = native_compute.NativeCompute.init(allocator, &dummy_ws, null);
+    defer native_engine.deinit();
     const projector_cb = native_engine.computeBackend();
     var media_token_cache = PrepareMediaTokenCache{};
     defer media_token_cache.deinit(allocator);

--- a/zig/pkg/inference/src/finetune/gliner2_real_autodiff.zig
+++ b/zig/pkg/inference/src/finetune/gliner2_real_autodiff.zig
@@ -3513,6 +3513,7 @@ test "count-embed schema projection is invariant to span negative masking" {
         .lazy_weights = .{},
     };
     var compute = native_compute.NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
     const cb = compute.computeBackend();
 
     var owned = std.ArrayListUnmanaged(CT).empty;
@@ -3646,6 +3647,7 @@ test "span_start count-embed schema projection ignores the structure BCE mask" {
         .lazy_weights = .{},
     };
     var compute = native_compute.NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
     const cb = compute.computeBackend();
 
     var owned = std.ArrayListUnmanaged(CT).empty;

--- a/zig/pkg/inference/src/finetune/graph_bridge.zig
+++ b/zig/pkg/inference/src/finetune/graph_bridge.zig
@@ -973,6 +973,7 @@ test "graph bridge linear classifier one step updates head" {
     const native_compute = @import("../ops/native_compute.zig");
     var ws = native_compute.WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = native_compute.NativeCompute.init(allocator, &ws, null);
+    defer compute.deinit();
     var cb = compute.computeBackend();
 
     var graph_bundle = try LinearClassifierGraph.init(allocator, 4, 3, 2);
@@ -1020,6 +1021,7 @@ test "graph bridge mlp classifier one step updates head" {
     const native_compute = @import("../ops/native_compute.zig");
     var ws = native_compute.WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = native_compute.NativeCompute.init(allocator, &ws, null);
+    defer compute.deinit();
     var cb = compute.computeBackend();
 
     var graph_bundle = try MlpClassifierGraph.init(allocator, 4, 3, 5, 2);
@@ -1076,6 +1078,7 @@ test "graph bridge lora linear one step updates adapters" {
     const native_compute = @import("../ops/native_compute.zig");
     var ws = native_compute.WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = native_compute.NativeCompute.init(allocator, &ws, null);
+    defer compute.deinit();
     var cb = compute.computeBackend();
 
     var graph_bundle = try LoRALinearGraph.init(allocator, 3, 4, 4, 2, 4.0);

--- a/zig/pkg/inference/src/finetune/layoutlmv3.zig
+++ b/zig/pkg/inference/src/finetune/layoutlmv3.zig
@@ -883,6 +883,7 @@ pub fn trainLoRABundleOneStep(
     const b_before = l2Norm(layer.adapter_b);
     var graph_weight_store = native_compute.WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var graph_compute = native_compute.NativeCompute.init(allocator, &graph_weight_store, null);
+    defer graph_compute.deinit();
     const graph_cb = graph_compute.computeBackend();
     var graph_optimizer_state = optimizers.OptimizerState.init(allocator);
     defer graph_optimizer_state.deinit();
@@ -2625,6 +2626,7 @@ fn trainSequenceEpoch(
     // Use provided backend, or fall back to internal native compute.
     var native_weight_store = native_compute.WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var fallback_native = native_compute.NativeCompute.init(allocator, &native_weight_store, null);
+    defer fallback_native.deinit();
     var native_cb = fallback_native.computeBackend();
     const graph_cb: *const ComputeBackend = provided_cb orelse &native_cb;
     var graph_optimizer_state = optimizers.OptimizerState.init(allocator);
@@ -2777,6 +2779,7 @@ fn trainTokenEpoch(
     // Use provided backend, or fall back to internal native compute.
     var native_weight_store = native_compute.WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var fallback_native = native_compute.NativeCompute.init(allocator, &native_weight_store, null);
+    defer fallback_native.deinit();
     var native_cb = fallback_native.computeBackend();
     const graph_cb: *const ComputeBackend = provided_cb orelse &native_cb;
     var graph_optimizer_state = optimizers.OptimizerState.init(allocator);

--- a/zig/pkg/inference/src/finetune/qwen2_real_autodiff.zig
+++ b/zig/pkg/inference/src/finetune/qwen2_real_autodiff.zig
@@ -109,6 +109,14 @@ pub const LoadedBackend = struct {
     }
 
     pub fn deinit(self: *LoadedBackend) void {
+        // Retire cached handles while their borrowed model storage is live.
+        switch (self.kind) {
+            .native => if (self.native_engine) |engine| {
+                engine.data = &self.native_ws.?;
+                var cb = engine.computeBackend();
+                cb.deinit();
+            },
+        }
         if (self.native_ws) |*ws| {
             native_compute.deinitPrefetchQueue(ws);
             var it = ws.resident_weights.iterator();
@@ -121,13 +129,6 @@ pub const LoadedBackend = struct {
         }
         if (self.safetensors_source) |src| src.weightSource().deinit();
         if (self.sharded_safetensors_source) |src| src.weightSource().deinit();
-        switch (self.kind) {
-            .native => if (self.native_engine) |engine| {
-                engine.data = &self.native_ws.?;
-                var cb = engine.computeBackend();
-                cb.deinit();
-            },
-        }
         self.* = undefined;
     }
 };

--- a/zig/pkg/inference/src/finetune/test/test_bert_e2e.zig
+++ b/zig/pkg/inference/src/finetune/test/test_bert_e2e.zig
@@ -197,6 +197,7 @@ test "BERT e2e: loss decreases over training steps" {
 
     // 2. Create compute backend.
     var native = NativeCompute.init(allocator, &weight_store, null);
+    defer native.deinit();
     var cb = native.computeBackend();
 
     // 3. Create the RealAutodiffTrainer with LoRA targeting query + value.

--- a/zig/pkg/inference/src/finetune/test/test_deberta_e2e.zig
+++ b/zig/pkg/inference/src/finetune/test/test_deberta_e2e.zig
@@ -331,6 +331,7 @@ test "DeBERTa e2e: loss decreases over training steps" {
 
     // 2. Create compute backend.
     var native = NativeCompute.init(allocator, &weight_store, null);
+    defer native.deinit();
     var cb = native.computeBackend();
 
     // 3. Create the RealAutodiffTrainer with LoRA targeting query_proj + value_proj.

--- a/zig/pkg/inference/src/finetune/test/test_fused_chunker_e2e.zig
+++ b/zig/pkg/inference/src/finetune/test/test_fused_chunker_e2e.zig
@@ -207,6 +207,7 @@ test "Fused chunker e2e: loss decreases over training steps" {
 
     // 2. Create compute backend.
     var native = NativeCompute.init(allocator, &weight_store, null);
+    defer native.deinit();
     var cb = native.computeBackend();
 
     // 3. Create the RealAutodiffTrainer with LoRA targeting query_proj + value_proj.

--- a/zig/pkg/inference/src/finetune/test/test_gliner2_backend_grad_parity.zig
+++ b/zig/pkg/inference/src/finetune/test/test_gliner2_backend_grad_parity.zig
@@ -858,6 +858,7 @@ fn runBackendGradParity(
         var store = try NativeStore.init(allocator, specs);
         defer store.deinit();
         var compute = NativeCompute.init(allocator, &store.store, null);
+        defer compute.deinit();
         var cb = compute.computeBackend();
         break :blk try runOneStep(allocator, &cb, config, batch.inputs());
     };
@@ -1060,6 +1061,7 @@ fn runCudaGradParity(
         var store = try NativeStore.init(allocator, specs);
         defer store.deinit();
         var compute = NativeCompute.init(allocator, &store.store, null);
+        defer compute.deinit();
         var cb = compute.computeBackend();
         const started_ns = monotonicNowNs();
         const run = try runOneStep(allocator, &cb, config, batch.inputs());
@@ -1236,6 +1238,7 @@ test "GLiNER2 CUDA packed DeBERTa attention forward and VJP match native" {
     var native_store = try NativeStore.init(allocator, &.{});
     defer native_store.deinit();
     var native_compute_instance = NativeCompute.init(allocator, &native_store.store, null);
+    defer native_compute_instance.deinit();
     var native_cb = native_compute_instance.computeBackend();
     const token_shape = [_]i32{ @intCast(batch * seq_len), @intCast(hidden) };
     const rel_shape = [_]i32{ @intCast(2 * seq_len - 1), @intCast(hidden) };

--- a/zig/pkg/inference/src/finetune/test/test_gliner2_e2e.zig
+++ b/zig/pkg/inference/src/finetune/test/test_gliner2_e2e.zig
@@ -213,6 +213,7 @@ test "GLiNER2 e2e: loss decreases over training steps" {
 
     // 2. Create compute backend.
     var native = NativeCompute.init(allocator, &weight_store, null);
+    defer native.deinit();
     var cb = native.computeBackend();
 
     // 3. Create the RealAutodiffTrainer with LoRA targeting query_proj + value_proj.
@@ -359,6 +360,7 @@ test "GLiNER2 inference: fixed text produces deterministic token logits" {
     try populateGliner2Weights(allocator, &weight_store, rng);
 
     var native = NativeCompute.init(allocator, &weight_store, null);
+    defer native.deinit();
     var cb = native.computeBackend();
 
     const lora_targets = [_][]const u8{ "query_proj", "value_proj" };

--- a/zig/pkg/inference/src/finetune/test/test_gliner2_real_training.zig
+++ b/zig/pkg/inference/src/finetune/test/test_gliner2_real_training.zig
@@ -606,6 +606,7 @@ test "GLiNER2 real training: loss decreases on actual model weights" {
     // 2. Create compute backend
     // ----------------------------------------------------------------
     var native = NativeCompute.init(allocator, &weight_store, null);
+    defer native.deinit();
     var cb = native.computeBackend();
 
     // ----------------------------------------------------------------
@@ -936,6 +937,7 @@ test "GLiNER2 real training: gliner2_total_loss produces nonzero finite loss and
     }
 
     var native = NativeCompute.init(allocator, &weight_store, null);
+    defer native.deinit();
     var cb = native.computeBackend();
 
     // ── Upstream-format records + entity vocab + HF tokenizer ─────────────

--- a/zig/pkg/inference/src/finetune/test/test_layoutlmv3_e2e.zig
+++ b/zig/pkg/inference/src/finetune/test/test_layoutlmv3_e2e.zig
@@ -217,6 +217,7 @@ test "LayoutLMv3 e2e: loss decreases over training steps" {
 
     // 2. Create compute backend.
     var native = NativeCompute.init(allocator, &weight_store, null);
+    defer native.deinit();
     var cb = native.computeBackend();
 
     // 3. Create the RealAutodiffTrainer with LoRA targeting query + value.

--- a/zig/pkg/inference/src/finetune/test/test_qwen2_e2e.zig
+++ b/zig/pkg/inference/src/finetune/test/test_qwen2_e2e.zig
@@ -329,6 +329,7 @@ test "Qwen2 e2e: loss decreases over training steps" {
 
     // 2. Create compute backend.
     var native = NativeCompute.init(allocator, &weight_store, null);
+    defer native.deinit();
     var cb = native.computeBackend();
 
     // 3. Create the RealAutodiffTrainer with LoRA targeting q_proj + v_proj.

--- a/zig/pkg/inference/src/finetune/tools/eval_gliner2_autodiff_adapter.zig
+++ b/zig/pkg/inference/src/finetune/tools/eval_gliner2_autodiff_adapter.zig
@@ -693,6 +693,7 @@ pub const NativeEvalSession = struct {
             self.allocator.destroy(graph);
         }
         self.full_task_graphs.deinit(self.allocator);
+        self.native_backend.deinit();
         self.adapter_reader.deinit();
         self.tokenizer.deinit(self.allocator);
         deinitNativeWeightStore(self.allocator, &self.weight_store, &self.owned_weight_names);
@@ -1661,6 +1662,7 @@ fn evalSavedAdapter(allocator: std.mem.Allocator, owned_opts: OwnedOptions) !Eva
         .auto => {},
     };
     defer switch (selected_backend) {
+        .native => native_backend.deinit(),
         .metal => if (comptime build_options.enable_metal) metal_backend.deinit(),
         else => {},
     };

--- a/zig/pkg/inference/src/finetune/train/train_fused_chunker.zig
+++ b/zig/pkg/inference/src/finetune/train/train_fused_chunker.zig
@@ -475,6 +475,7 @@ fn run(allocator: std.mem.Allocator, opts: Options) !void {
     // Declare both backends at outer scope so their addresses are stable for
     // the ComputeBackend vtable pointer that FusedTrainer holds.
     var native_backend = native_compute.NativeCompute.init(allocator, &weight_store, null);
+    defer native_backend.deinit();
     const cb: ComputeBackend = native_backend.computeBackend();
 
     print("backend: native\n", .{});

--- a/zig/pkg/inference/src/finetune/train/train_gliner2_autodiff.zig
+++ b/zig/pkg/inference/src/finetune/train/train_gliner2_autodiff.zig
@@ -795,6 +795,7 @@ fn runTraining(allocator: std.mem.Allocator, opts: Options) !void {
         else => {},
     };
     defer switch (selected_backend) {
+        .native => native_backend.deinit(),
         .metal => if (comptime build_options.enable_metal) metal_backend.deinit(),
         .cuda => if (comptime build_options.enable_cuda) cuda_backend.deinit(),
         else => {},

--- a/zig/pkg/inference/src/finetune/train/train_reranker_autodiff.zig
+++ b/zig/pkg/inference/src/finetune/train/train_reranker_autodiff.zig
@@ -255,6 +255,7 @@ fn runTraining(allocator: std.mem.Allocator, opts: Options) !void {
     }
 
     var native_backend = native_compute.NativeCompute.init(allocator, &weight_store, null);
+    defer native_backend.deinit();
     const cb = native_backend.computeBackend();
 
     // ------------------------------------------------------------------

--- a/zig/pkg/inference/src/graph/collective_ops.zig
+++ b/zig/pkg/inference/src/graph/collective_ops.zig
@@ -142,7 +142,9 @@ test "allReduceSum sums across two devices" {
     var ws_a = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var ws_b = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute_a = NativeCompute.init(allocator, &ws_a, null);
+    defer compute_a.deinit();
     var compute_b = NativeCompute.init(allocator, &ws_b, null);
+    defer compute_b.deinit();
     const cb_a = compute_a.computeBackend();
     const cb_b = compute_b.computeBackend();
 
@@ -180,7 +182,9 @@ test "allGather concatenates across two devices" {
     var ws_a = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var ws_b = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute_a = NativeCompute.init(allocator, &ws_a, null);
+    defer compute_a.deinit();
     var compute_b = NativeCompute.init(allocator, &ws_b, null);
+    defer compute_b.deinit();
     const cb_a = compute_a.computeBackend();
     const cb_b = compute_b.computeBackend();
 

--- a/zig/pkg/inference/src/graph/distributed_training.zig
+++ b/zig/pkg/inference/src/graph/distributed_training.zig
@@ -261,7 +261,9 @@ test "2-device gradient averaging" {
     var ws_a = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var ws_b = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute_a = NativeCompute.init(allocator, &ws_a, null);
+    defer compute_a.deinit();
     var compute_b = NativeCompute.init(allocator, &ws_b, null);
+    defer compute_b.deinit();
     var cb_a = compute_a.computeBackend();
     var cb_b = compute_b.computeBackend();
 
@@ -318,7 +320,9 @@ test "distributed loss decreases" {
     var ws_a = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var ws_b = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute_a = NativeCompute.init(allocator, &ws_a, null);
+    defer compute_a.deinit();
     var compute_b = NativeCompute.init(allocator, &ws_b, null);
+    defer compute_b.deinit();
     var cb_a = compute_a.computeBackend();
     var cb_b = compute_b.computeBackend();
 

--- a/zig/pkg/inference/src/graph/interpreter.zig
+++ b/zig/pkg/inference/src/graph/interpreter.zig
@@ -855,6 +855,20 @@ pub fn execute(
     //    the cached weight handle for future executions. Detect this by
     //    comparing output CT pointers against runtime input CTs.
     const outputs = try allocator.alloc(CT, graph.outputs.items.len);
+    errdefer allocator.free(outputs);
+    var output_count: usize = 0;
+    errdefer for (outputs[0..output_count]) |output| {
+        // The values cleanup owns ordinary outputs; only detached runtime-input
+        // copies need separate cleanup if assembling later outputs fails.
+        var in_values = false;
+        for (values) |value| {
+            if (value == output) {
+                in_values = true;
+                break;
+            }
+        }
+        if (!in_values) cb.free(output);
+    };
     for (graph.outputs.items, 0..) |out_id, idx| {
         const ct = values[out_id] orelse return error.MissingRuntimeInput;
         // Check if this output CT pointer aliases any non-donated runtime input.
@@ -876,10 +890,11 @@ pub fn execute(
         } else {
             outputs[idx] = ct;
         }
+        output_count += 1;
     }
 
-    // 7. Free remaining parameter handles. getWeight() allocates a new
-    //    handle each call (e.g. native buffer); the underlying weight data is
+    // 7. Free remaining parameter handles. acquireWeight() returns a distinct
+    //    caller-owned handle each call; the underlying weight data may be
     //    borrowed, but the handle itself must be freed. Skip outputs
     //    (caller owns them) and runtime inputs (caller owns them).
     //
@@ -952,6 +967,14 @@ pub fn captureNodeValues(
     const values = try allocator.alloc(?CT, count);
     defer allocator.free(values);
     @memset(values, null);
+    // Captures are detached copies. All graph-owned values, including unused
+    // parameter handles and outputs, must be released on success and failure.
+    defer for (0..values.len) |i| {
+        const ct = values[i] orelse continue;
+        if (isBorrowedRuntimeValue(options, ct)) continue;
+        nullCtAliases(values, ct);
+        cb.free(ct);
+    };
 
     const shape_capture = if (options.cached_analysis) |ca| ca.runtime_shape_capture else try computeRuntimeShapeCaptureSet(allocator, graph);
     defer if (!have_cache) allocator.free(shape_capture);
@@ -1037,8 +1060,8 @@ pub fn captureNodeValues(
                             continue;
                         }
                     }
+                    nullCtAliases(values, ct);
                     cb.free(ct);
-                    values[input_id] = null;
                 }
             }
         }
@@ -2312,7 +2335,7 @@ pub fn executeNode(
         .parameter => |attrs| {
             const name = graph.parameterName(n);
             _ = attrs;
-            return cb.getWeight(name);
+            return cb.acquireWeight(name);
         },
 
         .constant => |attrs| {
@@ -4592,6 +4615,7 @@ const TestCompute = struct {
         .deinitBackend = &deinitBackend,
         .freeTensor = &freeTensor,
         .getWeight = &getWeight,
+        .acquireWeight = &getWeight,
         .prefetchWeightHint = &prefetchHint,
         .drainPrefetchBudget = &drainPrefetch,
         .embeddingLookup = &embeddingLookupOp,
@@ -5704,6 +5728,73 @@ test "native interpreter does not donate a reshape view before a future sibling 
     const original_data = try cb_val.toFloat32(x_ct, allocator);
     defer allocator.free(original_data);
     try std.testing.expectEqualSlices(f32, &.{ 1, 2, 3, 4 }, original_data);
+}
+
+fn testDuplicateWeightParameters(allocator: std.mem.Allocator, capture: bool) !void {
+    if (comptime !build_options.enable_native) return error.SkipZigTest;
+    var graph = Graph.init(allocator);
+    defer graph.deinit();
+    var builder = ml.graph.Builder.init(&graph);
+    const first = try builder.parameter("shared", Shape.init(.f32, &.{2}));
+    const second = try builder.parameter("shared", Shape.init(.f32, &.{2}));
+    const activated = try builder.relu(first);
+    try graph.markOutput(activated);
+    try graph.markOutput(second);
+    // Repeated output nodes own one handle, unlike repeated acquisitions.
+    try graph.markOutput(second);
+    var data = [_]f32{ 1, -2 };
+    var shape = [_]i64{2};
+    var store = WeightStore{ .allocator = allocator, .resident_weights = .empty, .lazy_weights = .empty };
+    defer store.resident_weights.deinit(allocator);
+    try store.resident_weights.put(allocator, "shared", .{ .tensor = .{
+        .data = std.mem.sliceAsBytes(&data),
+        .shape = &shape,
+        .dtype = .f32,
+        .name = "shared",
+        .allocator = allocator,
+        .owns_data = false,
+        .owns_shape = false,
+    } });
+    var budget = @import("../runtime/tier/memory.zig").RunBudget.init(.{ .host_limit_bytes = 64 });
+    const compute = try allocator.create(NativeCompute);
+    compute.* = NativeCompute.init(allocator, &store, &budget);
+    defer store.prefetch.deinit();
+    const cb = compute.computeBackend();
+    defer cb.deinit();
+    // Graph acquisition must neither reuse nor release a borrowed eager handle.
+    const borrowed = try cb.getWeight("shared");
+    defer cb.free(borrowed);
+    if (capture) {
+        var result = try captureNodeValues(allocator, &graph, &cb, .{}, &.{ activated, second });
+        defer result.deinit(&cb);
+        const actual = try cb.toFloat32(result.values[1], allocator);
+        defer allocator.free(actual);
+        try std.testing.expectEqualSlices(f32, &data, actual);
+    } else {
+        var result = try execute(allocator, &graph, &cb, .{});
+        defer result.deinit(&cb);
+        try std.testing.expect(result.outputs[1] != borrowed);
+        try std.testing.expectEqual(result.outputs[1], result.outputs[2]);
+        const actual = try cb.toFloat32(result.outputs[1], allocator);
+        defer allocator.free(actual);
+        try std.testing.expectEqualSlices(f32, &data, actual);
+    }
+    try std.testing.expectEqual(@as(usize, 1), compute.weight_handles.count());
+    const actual = try cb.toFloat32(borrowed, allocator);
+    defer allocator.free(actual);
+    try std.testing.expectEqualSlices(f32, &data, actual);
+    try std.testing.expectEqual(@as(usize, 8), budget.host_weight_bytes);
+}
+
+test "native graph duplicate weight parameters preserve live siblings and borrowed handles" {
+    try testDuplicateWeightParameters(std.testing.allocator, false);
+    try testDuplicateWeightParameters(std.testing.allocator, true);
+}
+
+test "native graph weight acquisition unwinds allocation failures" {
+    if (comptime !build_options.enable_native) return error.SkipZigTest;
+    try std.testing.checkAllAllocationFailures(std.testing.allocator, testDuplicateWeightParameters, .{false});
+    try std.testing.checkAllAllocationFailures(std.testing.allocator, testDuplicateWeightParameters, .{true});
 }
 
 test "execute lowered graph through native backend" {

--- a/zig/pkg/inference/src/graph/interpreter.zig
+++ b/zig/pkg/inference/src/graph/interpreter.zig
@@ -4986,6 +4986,7 @@ test "runtime shape tensors preserve distinct ONNX reshape layouts" {
 
     var ws = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &ws, null);
+    defer compute.deinit();
     var cb_val = compute.computeBackend();
 
     const x_ct = try cb_val.fromFloat32Shape(&.{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 }, &.{16});
@@ -5710,6 +5711,7 @@ test "native interpreter does not donate a reshape view before a future sibling 
 
     var ws = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &ws, null);
+    defer compute.deinit();
     var cb_val = compute.computeBackend();
 
     const x_ct = try cb_val.fromFloat32Shape(&.{ 1, 2, 3, 4 }, &.{4});
@@ -5820,6 +5822,7 @@ test "execute lowered graph through native backend" {
     // Set up native backend (empty WeightStore — we inject params via runtime_inputs).
     var ws = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &ws, null);
+    defer compute.deinit();
     var cb_val = compute.computeBackend();
 
     // Create parameter CTs.
@@ -5875,6 +5878,7 @@ test "primitive elementwise ops execute through native" {
     // All primitive ops — set up native backend, inject x via runtime_inputs.
     var ws = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &ws, null);
+    defer compute.deinit();
     var cb_val = compute.computeBackend();
 
     const x_ct = try cb_val.fromFloat32(&.{ 3.0, 4.0 });
@@ -5913,6 +5917,7 @@ test "execute clones aliased passthrough outputs that outlive their input branch
 
     var ws = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &ws, null);
+    defer compute.deinit();
     var cb_val = compute.computeBackend();
 
     const x_ct = try cb_val.fromFloat32(&.{ 1.5, -0.5 });
@@ -5949,6 +5954,7 @@ test "execute preserves runtime shape when cloning an aliased dynamic tensor" {
 
     var ws = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &ws, null);
+    defer compute.deinit();
     var cb_val = compute.computeBackend();
 
     const input = [_]f32{ 1.5, -0.5, 2.0, -1.0, 0.0, 0.5 };
@@ -5988,6 +5994,7 @@ test "execution result deinit frees duplicate output handles once" {
 
     var ws = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &ws, null);
+    defer compute.deinit();
     var cb_val = compute.computeBackend();
 
     const x_ct = try cb_val.fromFloat32(&.{ 1.0, 2.0 });
@@ -6024,6 +6031,7 @@ test "reshape uses declared input shape before symbolic transpose" {
 
     var ws = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &ws, null);
+    defer compute.deinit();
     var cb_val = compute.computeBackend();
 
     var input: [2 * 3 * 8]f32 = undefined;
@@ -6061,6 +6069,7 @@ test "reshape preserves runtime batch for exported singleton target" {
 
     var ws = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &ws, null);
+    defer compute.deinit();
     var cb_val = compute.computeBackend();
 
     var input: [2 * 6 * 4]f32 = undefined;
@@ -6098,6 +6107,7 @@ test "runtime shape drives symbolic reduce" {
 
     var ws = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &ws, null);
+    defer compute.deinit();
     var cb_val = compute.computeBackend();
 
     var input: [2 * 4 * 3]f32 = undefined;
@@ -6146,6 +6156,7 @@ test "runtime shape drives symbolic slice" {
 
     var ws = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &ws, null);
+    defer compute.deinit();
     var cb_val = compute.computeBackend();
 
     var input: [2 * 4 * 3]f32 = undefined;
@@ -6216,6 +6227,7 @@ test "runtime shape expression bounds a slice of a static tensor" {
 
     var ws = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &ws, null);
+    defer compute.deinit();
     var cb_val = compute.computeBackend();
 
     const ids: [3 * 4]f32 = @splat(0);
@@ -6250,6 +6262,7 @@ test "runtime shape drives symbolic concat" {
 
     var ws = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &ws, null);
+    defer compute.deinit();
     var cb_val = compute.computeBackend();
 
     var a_input: [2 * 2 * 3]f32 = undefined;
@@ -6306,6 +6319,7 @@ test "runtime shape drives symbolic batched dot_general" {
 
     var ws = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &ws, null);
+    defer compute.deinit();
     var cb_val = compute.computeBackend();
 
     const a_input = [_]f32{
@@ -6365,6 +6379,7 @@ test "runtime shape drives symbolic argmax" {
 
     var ws = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &ws, null);
+    defer compute.deinit();
     var cb_val = compute.computeBackend();
 
     const input = [_]f32{
@@ -6412,6 +6427,7 @@ test "runtime binary broadcasting expands complementary symbolic axes" {
 
     var ws = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &ws, null);
+    defer compute.deinit();
     var cb_val = compute.computeBackend();
 
     const lhs_ct = try cb_val.fromFloat32Shape(&.{ 0, 1, 2 }, &.{ 3, 1 });
@@ -6459,6 +6475,7 @@ test "runtime shape drives symbolic broadcast_in_dim" {
 
     var ws = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &ws, null);
+    defer compute.deinit();
     var cb_val = compute.computeBackend();
 
     const input = [_]f32{ 1, 2, 3, 4, 5, 6 };
@@ -6514,6 +6531,7 @@ test "runtime shape tensor drives dynamic broadcast_in_dim" {
 
     var ws = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &ws, null);
+    defer compute.deinit();
     var cb_val = compute.computeBackend();
 
     const x_ct = try cb_val.fromFloat32Shape(&.{ 1, 2, 3 }, &.{ 1, 1, 3 });
@@ -6558,6 +6576,7 @@ test "native interpreter executes GatherElements along the selected axis" {
 
     var ws = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &ws, null);
+    defer compute.deinit();
     var cb_val = compute.computeBackend();
 
     const data_values = [_]f32{
@@ -6620,6 +6639,7 @@ test "native GatherElements uses concrete shape of a dynamic broadcast result" {
 
     var ws = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &ws, null);
+    defer compute.deinit();
     var cb_val = compute.computeBackend();
 
     const data_values = [_]f32{
@@ -6678,6 +6698,7 @@ test "runtime shape drives dynamic integer resize broadcast values" {
 
     var ws = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &ws, null);
+    defer compute.deinit();
     var cb_val = compute.computeBackend();
 
     const input = [_]f32{
@@ -6725,6 +6746,7 @@ test "runtime shape drives symbolic scatter_add" {
 
     var ws = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &ws, null);
+    defer compute.deinit();
     var cb_val = compute.computeBackend();
 
     const dest_ct = try cb_val.fromFloat32Shape(&.{ 10, 20, 30, 40, 50, 60 }, &.{ 3, 2 });
@@ -6777,6 +6799,7 @@ test "reshape restores batched flattened projection shape before gather" {
 
     var ws = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &ws, null);
+    defer compute.deinit();
     var cb_val = compute.computeBackend();
 
     var input: [2 * 4 * 6]f32 = undefined;

--- a/zig/pkg/inference/src/graph/metal_partition_executor.zig
+++ b/zig/pkg/inference/src/graph/metal_partition_executor.zig
@@ -16833,6 +16833,7 @@ test "metal partition executor consumes buffer plan and evaluates partition" {
     var weight_store = native_compute.WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     defer deinitEmptyNativeWeightStore(&weight_store, allocator);
     var compute = native_compute.NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
     var cb = compute.computeBackend();
 
     const count: usize = @intCast(g.nodeCount());
@@ -16902,6 +16903,7 @@ test "metal partition executor command path handles add softmax and reshape" {
     var weight_store = native_compute.WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     defer deinitEmptyNativeWeightStore(&weight_store, allocator);
     var compute = native_compute.NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
     var cb = compute.computeBackend();
 
     const count: usize = @intCast(g.nodeCount());
@@ -16981,6 +16983,7 @@ test "metal partition executor command path handles linear and norms" {
     var weight_store = native_compute.WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     defer deinitEmptyNativeWeightStore(&weight_store, allocator);
     var compute = native_compute.NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
     var cb = compute.computeBackend();
 
     const count: usize = @intCast(g.nodeCount());
@@ -17203,6 +17206,7 @@ test "metal partition executor eager multi op chain matches host" {
     var native_weight_store = native_compute.WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     defer deinitEmptyNativeWeightStore(&native_weight_store, allocator);
     var native_compute_impl = native_compute.NativeCompute.init(allocator, &native_weight_store, null);
+    defer native_compute_impl.deinit();
     var native_cb = native_compute_impl.computeBackend();
     var mesh = try device_mesh_mod.DeviceMesh.init(allocator, &.{
         .{ .id = 0, .backend = &native_cb, .kind = .native },
@@ -17322,6 +17326,7 @@ test "metal partition executor fuses sibling no-bias linears into one pair comma
     var weight_store = native_compute.WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     defer deinitEmptyNativeWeightStore(&weight_store, allocator);
     var compute = native_compute.NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
     var cb = compute.computeBackend();
 
     const count: usize = @intCast(g.nodeCount());
@@ -19386,6 +19391,7 @@ test "metal partition executor owned runtime region plan reuses cached plan" {
     var weight_store = native_compute.WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     defer deinitEmptyNativeWeightStore(&weight_store, allocator);
     var compute = native_compute.NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
     var cb = compute.computeBackend();
     var exec = MetalPartitionExecutor.initBorrowed(allocator, &g, &cb);
     exec.owned = true;
@@ -19990,6 +19996,7 @@ test "metal partition executor resident primitive chain stays device backed" {
     var native_weight_store = native_compute.WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     defer deinitEmptyNativeWeightStore(&native_weight_store, allocator);
     var native_compute_impl = native_compute.NativeCompute.init(allocator, &native_weight_store, null);
+    defer native_compute_impl.deinit();
     var native_cb = native_compute_impl.computeBackend();
     var mesh = try device_mesh_mod.DeviceMesh.init(allocator, &.{
         .{ .id = 0, .backend = &native_cb, .kind = .native },
@@ -20088,6 +20095,7 @@ test "metal partition executor resident concat prim stays device backed" {
     var native_weight_store = native_compute.WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     defer deinitEmptyNativeWeightStore(&native_weight_store, allocator);
     var native_compute_impl = native_compute.NativeCompute.init(allocator, &native_weight_store, null);
+    defer native_compute_impl.deinit();
     var native_cb = native_compute_impl.computeBackend();
     var mesh = try device_mesh_mod.DeviceMesh.init(allocator, &.{
         .{ .id = 0, .backend = &native_cb, .kind = .native },
@@ -20550,6 +20558,7 @@ test "metal partition executor resident last-dim reductions stay device backed" 
     var native_weight_store = native_compute.WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     defer deinitEmptyNativeWeightStore(&native_weight_store, allocator);
     var native_compute_impl = native_compute.NativeCompute.init(allocator, &native_weight_store, null);
+    defer native_compute_impl.deinit();
     var native_cb = native_compute_impl.computeBackend();
     var mesh = try device_mesh_mod.DeviceMesh.init(allocator, &.{
         .{ .id = 0, .backend = &native_cb, .kind = .native },
@@ -22146,6 +22155,7 @@ test "metal partition executor owned lifecycle deinitializes cleanly" {
     var weight_store = native_compute.WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     defer deinitEmptyNativeWeightStore(&weight_store, allocator);
     var compute = native_compute.NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
     var cb = compute.computeBackend();
 
     const exec = try MetalPartitionExecutor.create(allocator, &g, &cb);

--- a/zig/pkg/inference/src/graph/metal_partition_executor.zig
+++ b/zig/pkg/inference/src/graph/metal_partition_executor.zig
@@ -8360,7 +8360,9 @@ fn valueForOrMaterializeParameter(
     if (index >= values.len or index >= value_device.len) return null;
     const node = graph.node(node_id);
     if (node.op != .parameter) return null;
-    const materialized = try cb.getWeight(graph.parameterName(node));
+    // Value slots own independent handles: alias-deduplicating graph cleanup
+    // must not collapse separate references to the same named weight.
+    const materialized = try cb.acquireWeight(graph.parameterName(node));
     values[index] = materialized;
     value_device[index] = device_id;
     return materialized;
@@ -16308,9 +16310,7 @@ fn materializePartitionParameters(
         if (rt_map.contains(node_id)) continue;
         const node = graph.node(node_id);
         if (node.op != .parameter) continue;
-        const materialized = try cb.getWeight(graph.parameterName(node));
-        values[i] = materialized;
-        value_device[i] = device_id;
+        const materialized = (try valueForOrMaterializeParameter(graph, cb, values, value_device, device_id, node_id)) orelse return error.MissingValue;
         if (stats) |s| {
             s.descriptor_materializations += 1;
             if (isMetalResidentOrQuantizedDescriptor(cb, materialized)) {
@@ -16321,6 +16321,100 @@ fn materializePartitionParameters(
                 s.host_materialized_parameter_outputs += 1;
                 if (traceMetalHostOutputsEnabled()) traceMetalHostOutput(graph, node_id, "parameter_materialization_host_output");
             }
+        }
+    }
+}
+
+fn testCompiledParameterWeightOwnership(allocator: std.mem.Allocator, lazy: bool, on_demand: bool) !void {
+    const native = @import("../ops/native_compute.zig");
+    const memory = @import("../runtime/tier/memory.zig");
+    var graph = Graph.init(allocator);
+    defer graph.deinit();
+    var builder = ml.graph.Builder.init(&graph);
+    const first = try builder.parameter("shared", Shape.init(.f32, &.{2}));
+    const second = try builder.parameter("shared", Shape.init(.f32, &.{2}));
+    const sum = try builder.add(first, second);
+    try graph.markOutput(sum);
+
+    var data = [_]f32{ 1, -2 };
+    var shape = [_]i64{2};
+    const weight: weight_source_mod.LoadedWeight = .{ .tensor = .{
+        .data = std.mem.sliceAsBytes(&data),
+        .shape = &shape,
+        .dtype = .f32,
+        .name = "shared",
+        .allocator = allocator,
+        .owns_data = false,
+        .owns_shape = false,
+    } };
+    var store = native.WeightStore{ .allocator = allocator, .resident_weights = .empty, .lazy_weights = .empty };
+    defer store.resident_weights.deinit(allocator);
+    defer store.lazy_weights.deinit(allocator);
+    if (lazy) {
+        try store.lazy_weights.put(allocator, "shared", .{
+            .tensor_ref = .{ .name = "shared" },
+            .loaded = weight,
+            .loaded_bytes = std.mem.sliceAsBytes(&data).len,
+        });
+    } else {
+        try store.resident_weights.put(allocator, "shared", weight);
+    }
+    var budget = memory.RunBudget.init(.{ .host_limit_bytes = 64 });
+    var compute = native.NativeCompute.init(allocator, &store, &budget);
+    defer native.deinitPrefetchQueue(&store);
+    defer compute.deinit();
+    const cb = compute.computeBackend();
+    var borrowed: ?CT = try cb.getWeight("shared");
+    defer if (borrowed) |ct| cb.free(ct);
+    var values = [_]?CT{ null, null, null };
+    defer for (values) |value| {
+        if (value) |ct| cb.free(ct);
+    };
+    var devices = [_]DeviceId{ 0, 0, 0 };
+    const reachable = [_]bool{ true, true, true };
+    const last_use = [_]u32{ sum, sum, std.math.maxInt(u32) };
+    // Re-visiting a materialized node must not acquire another reference.
+    for (0..2) |_| {
+        if (on_demand) {
+            _ = try valueForOrMaterializeParameter(&graph, &cb, &values, &devices, 0, first);
+            _ = try valueForOrMaterializeParameter(&graph, &cb, &values, &devices, 0, second);
+        } else {
+            try materializePartitionParameters(&graph, &cb, &values, &devices, &.{ first, second, sum }, &reachable, 0, .empty, null);
+        }
+    }
+    try std.testing.expect(values[first] != values[second]);
+    try std.testing.expect(values[first] != borrowed and values[second] != borrowed);
+    if (lazy) try std.testing.expectEqual(@as(usize, 3), store.lazy_weights.get("shared").?.pin_count);
+
+    // Both parameters die at the same consumer. The compiled executor's
+    // pointer-deduplicating cleanup must release both acquisitions.
+    const freed = try freeExpiredInputs(allocator, &graph, &cb, &values, &devices, sum, 0, &last_use, null, .empty, .empty, .{});
+    try std.testing.expectEqual(@as(usize, 2), freed.count);
+    try std.testing.expect(values[first] == null and values[second] == null);
+    const actual = try cb.toFloat32(borrowed.?, allocator);
+    defer allocator.free(actual);
+    try std.testing.expectEqualSlices(f32, &data, actual);
+    try std.testing.expectEqual(@as(usize, 8), budget.host_weight_bytes);
+    if (lazy) try std.testing.expectEqual(@as(usize, 1), store.lazy_weights.get("shared").?.pin_count);
+    cb.free(borrowed.?);
+    borrowed = null;
+    try std.testing.expectEqual(@as(usize, 0), budget.host_weight_bytes);
+    try std.testing.expectEqual(@as(usize, 0), compute.weight_handles.count());
+    if (lazy) try std.testing.expectEqual(@as(usize, 0), store.lazy_weights.get("shared").?.pin_count);
+}
+
+test "compiled parameter acquisitions release reservations and lazy pins independently" {
+    inline for (.{ false, true }) |lazy| {
+        inline for (.{ false, true }) |on_demand| {
+            try testCompiledParameterWeightOwnership(std.testing.allocator, lazy, on_demand);
+        }
+    }
+}
+
+test "compiled parameter acquisitions unwind allocation failures" {
+    inline for (.{ false, true }) |lazy| {
+        inline for (.{ false, true }) |on_demand| {
+            try std.testing.checkAllAllocationFailures(std.testing.allocator, testCompiledParameterWeightOwnership, .{ lazy, on_demand });
         }
     }
 }

--- a/zig/pkg/inference/src/graph/multi_executor.zig
+++ b/zig/pkg/inference/src/graph/multi_executor.zig
@@ -768,6 +768,7 @@ test "graph backend partition executes through native partition executor path" {
     var weight_store = native_compute.WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     defer deinitEmptyNativeWeightStore(&weight_store, allocator);
     var compute = native_compute.NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
     var cb = compute.computeBackend();
     var mesh = try DeviceMesh.init(allocator, &.{.{ .id = 0, .backend = &cb, .kind = .native }});
     defer mesh.deinit();
@@ -814,11 +815,13 @@ test "native partition executor transfers borrowed runtime input across devices"
     var weight_store_a = native_compute.WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     defer deinitEmptyNativeWeightStore(&weight_store_a, allocator);
     var compute_a = native_compute.NativeCompute.init(allocator, &weight_store_a, null);
+    defer compute_a.deinit();
     var cb_a = compute_a.computeBackend();
 
     var weight_store_b = native_compute.WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     defer deinitEmptyNativeWeightStore(&weight_store_b, allocator);
     var compute_b = native_compute.NativeCompute.init(allocator, &weight_store_b, null);
+    defer compute_b.deinit();
     var cb_b = compute_b.computeBackend();
 
     var mesh = try DeviceMesh.init(allocator, &.{
@@ -878,6 +881,7 @@ test "multi-executor keeps metal partition outputs resident until final readback
     var native_weight_store = native_compute.WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     defer deinitEmptyNativeWeightStore(&native_weight_store, allocator);
     var native_compute_impl = native_compute.NativeCompute.init(allocator, &native_weight_store, null);
+    defer native_compute_impl.deinit();
     var native_cb = native_compute_impl.computeBackend();
 
     var metal_weight_store = initEmptyMetalWeightStore(allocator);
@@ -946,6 +950,7 @@ test "multi-executor metal graph outputs survive plan-slot reuse across executio
     var native_weight_store = native_compute.WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     defer deinitEmptyNativeWeightStore(&native_weight_store, allocator);
     var native_compute_impl = native_compute.NativeCompute.init(allocator, &native_weight_store, null);
+    defer native_compute_impl.deinit();
     var native_cb = native_compute_impl.computeBackend();
 
     var metal_weight_store = initEmptyMetalWeightStore(allocator);

--- a/zig/pkg/inference/src/graph/native_partition_executor.zig
+++ b/zig/pkg/inference/src/graph/native_partition_executor.zig
@@ -938,6 +938,7 @@ test "native partition executor evaluates a partition through backend ops" {
     var weight_store = native_compute.WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     defer deinitEmptyNativeWeightStore(&weight_store, allocator);
     var compute = native_compute.NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
     var cb = compute.computeBackend();
 
     const count: usize = @intCast(g.nodeCount());
@@ -994,6 +995,7 @@ test "native partition executor executes linear through native cblas path" {
     var weight_store = native_compute.WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     defer deinitEmptyNativeWeightStore(&weight_store, allocator);
     var compute = native_compute.NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
     var cb = compute.computeBackend();
 
     const count: usize = @intCast(g.nodeCount());
@@ -1048,6 +1050,7 @@ test "native partition executor owned lifecycle deinitializes cleanly" {
     var weight_store = native_compute.WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     defer deinitEmptyNativeWeightStore(&weight_store, allocator);
     var compute = native_compute.NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
     var cb = compute.computeBackend();
 
     const exec = try NativePartitionExecutor.create(allocator, &g, &cb);

--- a/zig/pkg/inference/src/graph/pjrt_test.zig
+++ b/zig/pkg/inference/src/graph/pjrt_test.zig
@@ -192,6 +192,7 @@ test "pjrt_compiler: linear partition compiles to valid HLO" {
     defer cleanupWeights(allocator, &weight_setup.ws, weight_setup.tensors);
 
     var compute = NativeCompute.init(allocator, &weight_setup.ws, null);
+    defer compute.deinit();
     const cb = compute.computeBackend();
 
     // Partition: everything goes to PJRT
@@ -266,6 +267,7 @@ test "pjrt_executor: linear layer end-to-end" {
     defer cleanupWeights(allocator, &weight_setup.ws, weight_setup.tensors);
 
     var compute = NativeCompute.init(allocator, &weight_setup.ws, null);
+    defer compute.deinit();
     const cb = compute.computeBackend();
 
     // Partition
@@ -375,6 +377,7 @@ test "pjrt_executor: embedding lookup uses runtime embedding ids" {
     defer cleanupWeights(allocator, &weight_setup.ws, weight_setup.tensors);
 
     var compute = NativeCompute.init(allocator, &weight_setup.ws, null);
+    defer compute.deinit();
     const cb = compute.computeBackend();
 
     const supportsEmbedding = struct {
@@ -523,6 +526,7 @@ test "pjrt_model_runtime: decode uses single token id" {
     defer cleanupWeights(allocator, &weight_setup.ws, weight_setup.tensors);
 
     var compute = NativeCompute.init(allocator, &weight_setup.ws, null);
+    defer compute.deinit();
     const cb = compute.computeBackend();
 
     const supportsEmbedding = struct {
@@ -598,6 +602,7 @@ test "pjrt_executor: gelu activation end-to-end" {
     var ws = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
 
     var compute = NativeCompute.init(allocator, &ws, null);
+    defer compute.deinit();
     const cb = compute.computeBackend();
 
     // Partition
@@ -699,6 +704,7 @@ test "pjrt_executor: linear + rms_norm + gelu pipeline" {
     defer cleanupWeights(allocator, &weight_setup.ws, weight_setup.tensors);
 
     var compute = NativeCompute.init(allocator, &weight_setup.ws, null);
+    defer compute.deinit();
     const cb = compute.computeBackend();
 
     const caps = [_]Capability{
@@ -843,6 +849,7 @@ test "pjrt_executor: element-wise add end-to-end" {
 
     var ws = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &ws, null);
+    defer compute.deinit();
     const cb = compute.computeBackend();
 
     const caps = [_]Capability{

--- a/zig/pkg/inference/src/graph/runtime.zig
+++ b/zig/pkg/inference/src/graph/runtime.zig
@@ -899,6 +899,7 @@ test "native graph runtime attaches native partition executors" {
         weight_store.lazy_weights.deinit(allocator);
     }
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
     var cb = compute.computeBackend();
 
     var runtime = try Runtime.init(allocator, &graph, &cb, .partitioned);
@@ -938,6 +939,7 @@ test "native partitioned runtimes restore request dimensions after flattened pro
         weight_store.lazy_weights.deinit(allocator);
     }
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
     var cb = compute.computeBackend();
 
     const x_data = [_]f32{

--- a/zig/pkg/inference/src/graph/tracing_compute.zig
+++ b/zig/pkg/inference/src/graph/tracing_compute.zig
@@ -191,6 +191,7 @@ pub const TracingCompute = struct {
         .deinitBackend = &deinitBackend,
         .freeTensor = &freeTensor,
         .getWeight = &getWeight,
+        .acquireWeight = &getWeight,
         .prefetchWeightHint = &prefetchWeightHint,
         .drainPrefetchBudget = &drainPrefetchBudget,
         .embeddingLookup = &embeddingLookup,

--- a/zig/pkg/inference/src/graph/training.zig
+++ b/zig/pkg/inference/src/graph/training.zig
@@ -2585,6 +2585,7 @@ test "trainStep computes loss and gradients for linear model" {
     // Set up native backend with empty WeightStore.
     var ws = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &ws, null);
+    defer compute.deinit();
     var cb_val = compute.computeBackend();
 
     // Create parameter CTs.
@@ -2637,6 +2638,7 @@ test "CompiledTrainSession can retain gradient tensors without host extraction" 
 
     var ws = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &ws, null);
+    defer compute.deinit();
     var cb_val = compute.computeBackend();
 
     const x_ct = try cb_val.fromFloat32Shape(&.{ 1, 2, 3, 4, 5, 6, 7, 8 }, &.{ 2, 4 });
@@ -2684,6 +2686,7 @@ test "trainStep on linear-gelu chain" {
     // Set up native backend.
     var ws = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &ws, null);
+    defer compute.deinit();
     var cb_val = compute.computeBackend();
 
     // Create parameter CTs with small positive values.
@@ -2734,6 +2737,7 @@ test "trainStep emits checkpoint summary when enabled" {
 
     var ws = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &ws, null);
+    defer compute.deinit();
     var cb_val = compute.computeBackend();
 
     const x_ct = try cb_val.fromFloat32(&.{ 1, 1, 1, 1, 1, 1, 1, 1 });

--- a/zig/pkg/inference/src/graph/training_loop.zig
+++ b/zig/pkg/inference/src/graph/training_loop.zig
@@ -703,6 +703,7 @@ test "TrainingLoop loss decreases" {
     // Set up native backend.
     var bws = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &bws, null);
+    defer compute.deinit();
     var cb_val = compute.computeBackend();
 
     // Initialize training loop.
@@ -818,6 +819,7 @@ test "training loop exposes checkpoint summary and timing metrics" {
 
     var bws = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &bws, null);
+    defer compute.deinit();
     var cb_val = compute.computeBackend();
 
     var loop = TrainingLoop.init(allocator, .{

--- a/zig/pkg/inference/src/graph/webgpu_partition_executor.zig
+++ b/zig/pkg/inference/src/graph/webgpu_partition_executor.zig
@@ -929,6 +929,7 @@ test "webgpu partition executor delegates through partition executor path" {
         weight_store.lazy_weights.deinit(allocator);
     }
     var compute = native_compute.NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
     var cb = compute.computeBackend();
 
     const count: usize = @intCast(g.nodeCount());
@@ -1008,6 +1009,7 @@ test "webgpu partition executor direct softmax reduction commands" {
         weight_store.lazy_weights.deinit(allocator);
     }
     var compute = native_compute.NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
     var cb = compute.computeBackend();
 
     const count: usize = @intCast(g.nodeCount());
@@ -1096,6 +1098,7 @@ test "webgpu partition executor direct mask select commands" {
         weight_store.lazy_weights.deinit(allocator);
     }
     var compute = native_compute.NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
     var cb = compute.computeBackend();
 
     const count: usize = @intCast(g.nodeCount());
@@ -1184,6 +1187,7 @@ test "webgpu partition executor direct view movement commands" {
         weight_store.lazy_weights.deinit(allocator);
     }
     var compute = native_compute.NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
     var cb = compute.computeBackend();
 
     const count: usize = @intCast(g.nodeCount());
@@ -1270,6 +1274,7 @@ test "webgpu partition executor direct transformer dense commands" {
         weight_store.lazy_weights.deinit(allocator);
     }
     var compute = native_compute.NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
     var cb = compute.computeBackend();
 
     const x_data = [_]f32{ 0.5, -1.0, 2.0, 3.0, -2.0, 0.25, 1.5, -0.75 };
@@ -1441,6 +1446,7 @@ test "webgpu partition executor direct planned grouped transformer commands" {
         weight_store.lazy_weights.deinit(allocator);
     }
     var compute = native_compute.NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
     var cb = compute.computeBackend();
 
     const x_data = try allocator.alloc(f32, rows * hidden);
@@ -1586,6 +1592,7 @@ test "webgpu partition executor direct planned pair projection commands" {
         weight_store.lazy_weights.deinit(allocator);
     }
     var compute = native_compute.NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
     var cb = compute.computeBackend();
 
     const x_data = try allocator.alloc(f32, rows * hidden);
@@ -1734,6 +1741,7 @@ test "webgpu partition executor resident transformer block parity with planned q
         weight_store.lazy_weights.deinit(allocator);
     }
     var compute = native_compute.NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
     var cb = compute.computeBackend();
 
     const x_data = try allocator.alloc(f32, rows * hidden);

--- a/zig/pkg/inference/src/ops/cuda/cuda_compute.zig
+++ b/zig/pkg/inference/src/ops/cuda/cuda_compute.zig
@@ -8834,6 +8834,56 @@ fn getWeight(ctx: *anyopaque, name: []const u8) anyerror!CT {
     };
 }
 
+fn acquireWeight(ctx: *anyopaque, name: []const u8) anyerror!CT {
+    const self: *CudaCompute = @ptrCast(@alignCast(ctx));
+    const weight = tensorFromCt(try getWeight(ctx, name));
+    const handle = try self.allocator.create(CudaTensor);
+    errdefer self.allocator.destroy(handle);
+    handle.* = borrowedSlotTensor(weight);
+    // The resident/streaming store owns device storage. The graph owns only
+    // this handle and its shape, never the store's tensor metadata.
+    handle.shape = try self.allocator.dupe(i64, weight.shape);
+    handle.owns_shape = true;
+    handle.owned_by_tensor = true;
+    return @ptrCast(handle);
+}
+
+fn testAcquiredWeightHandle(allocator: std.mem.Allocator) !void {
+    // No driver is needed: acquired handles may free their metadata, but must
+    // never attempt to free the resident model's device allocations.
+    var self: CudaCompute = undefined;
+    self.allocator = allocator;
+    self.a4b_runtime = null;
+    self.resident_weights = .empty;
+    defer self.resident_weights.deinit(allocator);
+    self.lazy_device_epochs = .empty;
+    var shape = [_]i64{ 2, 2 };
+    try self.resident_weights.put(allocator, "weight", .{
+        .buffer = .{ .ptr = 0x1234, .len = 16 },
+        .dtype = .f32,
+        .shape = &shape,
+        .elem_count = 4,
+        .owned_by_tensor = false,
+    });
+    const borrowed = try getWeight(&self, "weight");
+    const first = try acquireWeight(&self, "weight");
+    defer freeTensor(&self, first);
+    const second = try acquireWeight(&self, "weight");
+    defer freeTensor(&self, second);
+    try std.testing.expect(first != second and first != borrowed and second != borrowed);
+    const handle = tensorFromCt(second);
+    try std.testing.expect(!handle.owns_buffer and !handle.owns_tc_quant and !handle.owns_bf16_mirror and !handle.owns_training_upload_host);
+    try std.testing.expect(handle.owns_shape and handle.owned_by_tensor);
+    try std.testing.expect(handle.shape.ptr != shape[0..].ptr);
+    try std.testing.expectEqualSlices(i64, &shape, handle.shape);
+    try std.testing.expectEqual(@as(driver_mod.CUdeviceptr, 0x1234), handle.buffer.ptr);
+}
+
+test "CUDA acquired weight handles have independent metadata and borrowed storage" {
+    try testAcquiredWeightHandle(std.testing.allocator);
+    try std.testing.checkAllAllocationFailures(std.testing.allocator, testAcquiredWeightHandle, .{});
+}
+
 fn prefetchWeightHint(ctx: *anyopaque, name: []const u8, hint: u32) void {
     const self: *CudaCompute = @ptrCast(@alignCast(ctx));
     if (self.resident_weights.contains(name)) return;
@@ -22443,6 +22493,7 @@ const vtable = ops.ComputeBackend.VTable{
     .convertDType = &convertDTypeOp,
     .provisionKvDeviceWriteHook = &provisionKvDeviceWriteHook,
     .getWeight = &getWeight,
+    .acquireWeight = &acquireWeight,
     .prefetchWeightHint = &prefetchWeightHint,
     .drainPrefetchBudget = &drainPrefetchBudget,
     .debugProfileCheckpoint = &debugProfileCheckpoint,

--- a/zig/pkg/inference/src/ops/metal_compute.zig
+++ b/zig/pkg/inference/src/ops/metal_compute.zig
@@ -28969,6 +28969,7 @@ test "metal_compute: paged decode attention matches native on f32 cache" {
     defer native_ws.resident_weights.deinit(allocator);
     defer native_ws.lazy_weights.deinit(allocator);
     var native_compute = native_compute_mod.NativeCompute.init(allocator, &native_ws, null);
+    defer native_compute.deinit();
     var native_cb = native_compute.computeBackend();
 
     var prior_k: [prior_tokens * hidden_kv]f32 = undefined;
@@ -29111,6 +29112,7 @@ test "metal_compute: mixed paged attention batch matches native" {
     defer native_ws.resident_weights.deinit(allocator);
     defer native_ws.lazy_weights.deinit(allocator);
     var native_compute = native_compute_mod.NativeCompute.init(allocator, &native_ws, null);
+    defer native_compute.deinit();
     var native_cb = native_compute.computeBackend();
 
     var decode_prior_k: [decode_prior_tokens * hidden_kv]f32 = undefined;
@@ -29299,6 +29301,7 @@ test "metal_compute: paged decode attention matches native on storage runtime f3
     defer native_ws.resident_weights.deinit(allocator);
     defer native_ws.lazy_weights.deinit(allocator);
     var native_compute = native_compute_mod.NativeCompute.init(allocator, &native_ws, null);
+    defer native_compute.deinit();
     var native_cb = native_compute.computeBackend();
 
     var prior_k: [prior_tokens * hidden_kv]f32 = undefined;
@@ -29628,6 +29631,7 @@ test "metal_compute: paged decode attention matches native on metal device f32 c
     defer native_ws.resident_weights.deinit(allocator);
     defer native_ws.lazy_weights.deinit(allocator);
     var native_compute = native_compute_mod.NativeCompute.init(allocator, &native_ws, null);
+    defer native_compute.deinit();
     var native_cb = native_compute.computeBackend();
 
     var prior_k: [prior_tokens * hidden_kv]f32 = undefined;
@@ -29802,6 +29806,7 @@ test "metal_compute: paged decode attention matches native on Gemma qLen1 f32 ca
     defer native_ws.resident_weights.deinit(allocator);
     defer native_ws.lazy_weights.deinit(allocator);
     var native_compute = native_compute_mod.NativeCompute.init(allocator, &native_ws, null);
+    defer native_compute.deinit();
     var native_cb = native_compute.computeBackend();
 
     const prior_k = try allocator.alloc(f32, prior_tokens * hidden_kv);
@@ -29971,6 +29976,7 @@ test "metal_compute: dense causal attention without kv cache matches native" {
     defer native_ws.resident_weights.deinit(allocator);
     defer native_ws.lazy_weights.deinit(allocator);
     var native_compute = native_compute_mod.NativeCompute.init(allocator, &native_ws, null);
+    defer native_compute.deinit();
     var native_cb = native_compute.computeBackend();
 
     var q_data: [q_len * hidden_q]f32 = undefined;
@@ -30123,6 +30129,7 @@ test "metal_compute: shared-kv prefill ignores placeholder kv when skip_kv_write
     defer native_ws.resident_weights.deinit(allocator);
     defer native_ws.lazy_weights.deinit(allocator);
     var native_compute = native_compute_mod.NativeCompute.init(allocator, &native_ws, null);
+    defer native_compute.deinit();
     var native_cb = native_compute.computeBackend();
 
     var donor_k: [seq_len * hidden_kv]f32 = undefined;
@@ -30285,6 +30292,7 @@ test "metal_compute: shared-kv prefill reuses manager gathered span when skip_kv
     defer native_ws.resident_weights.deinit(allocator);
     defer native_ws.lazy_weights.deinit(allocator);
     var native_compute = native_compute_mod.NativeCompute.init(allocator, &native_ws, null);
+    defer native_compute.deinit();
     var native_cb = native_compute.computeBackend();
 
     var donor_k: [seq_len * hidden_kv]f32 = undefined;
@@ -33731,6 +33739,7 @@ test "metal_compute: disentangled relative attention backward matches native at 
     defer native_ws.resident_weights.deinit(allocator);
     defer native_ws.lazy_weights.deinit(allocator);
     var native_compute = native_compute_mod.NativeCompute.init(allocator, &native_ws, null);
+    defer native_compute.deinit();
     var native_cb = native_compute.computeBackend();
 
     const native_q = try native_cb.fromFloat32Shape(q_data, &token_shape);
@@ -33843,6 +33852,7 @@ fn expectStableDebertaForward(allocator: std.mem.Allocator) !void {
     defer native_ws.resident_weights.deinit(allocator);
     defer native_ws.lazy_weights.deinit(allocator);
     var native_compute = native_compute_mod.NativeCompute.init(allocator, &native_ws, null);
+    defer native_compute.deinit();
     var native_cb = native_compute.computeBackend();
 
     const native_q = try native_cb.fromFloat32Shape(q_data, &token_shape);
@@ -33976,6 +33986,7 @@ test "metal_compute: compact DeBERTa relative rows match expanded native attenti
     defer native_ws.resident_weights.deinit(allocator);
     defer native_ws.lazy_weights.deinit(allocator);
     var native_compute = native_compute_mod.NativeCompute.init(allocator, &native_ws, null);
+    defer native_compute.deinit();
     var native_cb = native_compute.computeBackend();
     const native_q = try native_cb.fromFloat32Shape(q_data, &token_shape);
     defer native_cb.free(native_q);
@@ -34084,6 +34095,7 @@ test "metal_compute: threadgroup scaled dot product attention is stable at multi
     defer native_ws.resident_weights.deinit(allocator);
     defer native_ws.lazy_weights.deinit(allocator);
     var native_compute = native_compute_mod.NativeCompute.init(allocator, &native_ws, null);
+    defer native_compute.deinit();
     var native_cb = native_compute.computeBackend();
 
     const native_q = try native_cb.fromFloat32Shape(q_data, &token_shape);
@@ -34129,6 +34141,7 @@ const audit_repeats = 20;
 const AuditNative = struct {
     ws: native_compute_mod.WeightStore,
     compute: native_compute_mod.NativeCompute,
+    compute_initialized: bool = false,
 
     fn init(allocator: std.mem.Allocator) AuditNative {
         return .{
@@ -34138,11 +34151,14 @@ const AuditNative = struct {
     }
 
     fn backend(self: *AuditNative, allocator: std.mem.Allocator) ops.ComputeBackend {
+        std.debug.assert(!self.compute_initialized);
         self.compute = native_compute_mod.NativeCompute.init(allocator, &self.ws, null);
+        self.compute_initialized = true;
         return self.compute.computeBackend();
     }
 
     fn deinit(self: *AuditNative, allocator: std.mem.Allocator) void {
+        if (self.compute_initialized) self.compute.deinit();
         self.ws.resident_weights.deinit(allocator);
         self.ws.lazy_weights.deinit(allocator);
     }

--- a/zig/pkg/inference/src/ops/metal_compute.zig
+++ b/zig/pkg/inference/src/ops/metal_compute.zig
@@ -727,6 +727,8 @@ pub const MetalCompute = if (build_options.enable_metal) struct {
         metal_tensor: ?MetalTensor = null,
         lazy_multiply: ?LazyMultiply = null,
         lazy_entry: ?*gpu_hosted_store_mod.LazyWeightEntry = null,
+        // Source metadata is useful even when the dense cache owns the pin.
+        owns_lazy_pin: bool = false,
         quantized_storage: ?*const QuantizedStorage = null,
         runtime_quantized_storage: ?*const QuantizedStorage = null,
         owned_quantized_storage: ?*QuantizedStorage = null,
@@ -3547,6 +3549,7 @@ pub const MetalCompute = if (build_options.enable_metal) struct {
             .shared_data_refcount = shared_data_refcount,
             .logical_shape = logical_shape,
             .lazy_entry = lazy_entry,
+            .owns_lazy_pin = lazy_entry != null,
             .quantized_storage = quantized_storage,
             .runtime_quantized_storage = runtime_quantized_storage,
             .native_dense_bytes = null,
@@ -3598,8 +3601,9 @@ pub const MetalCompute = if (build_options.enable_metal) struct {
         const shape = try self.allocator.dupe(i64, cached.logical_shape);
         errdefer self.allocator.free(shape);
         // The dense cache owns the source pin and native bytes, not each view.
-        const tensor = try self.makeWeightBuf(cached.data, false, shape, null, null, cached.runtime_quantized_storage);
+        const tensor = try self.makeWeightBuf(cached.data, false, shape, cached.lazy_entry, null, cached.runtime_quantized_storage);
         const buf = toBuf(tensor);
+        buf.owns_lazy_pin = false;
         buf.native_dense_bytes = cached.native_dense_bytes;
         buf.native_dense_dtype = cached.native_dense_dtype;
         buf.native_dense_mmap_source_bytes = cached.native_dense_mmap_source_bytes;
@@ -6366,7 +6370,8 @@ pub const MetalCompute = if (build_options.enable_metal) struct {
             self.allocator.free(name);
             buf.weight_handle_name = null;
         }
-        if (buf.lazy_entry) |entry| {
+        if (buf.owns_lazy_pin) {
+            const entry = buf.lazy_entry.?;
             const self: *MetalCompute = @ptrCast(@alignCast(ctx));
             self.data.prefetch.lock();
             defer self.data.prefetch.unlock();
@@ -21249,6 +21254,14 @@ pub const MetalCompute = if (build_options.enable_metal) struct {
     }
 
     fn getWeightOp(ctx: *anyopaque, name: []const u8) anyerror!CT {
+        return lookupWeight(ctx, name, true);
+    }
+
+    fn acquireWeightOp(ctx: *anyopaque, name: []const u8) anyerror!CT {
+        return lookupWeight(ctx, name, false);
+    }
+
+    fn lookupWeight(ctx: *anyopaque, name: []const u8, shared: bool) anyerror!CT {
         const self: *MetalCompute = @ptrCast(@alignCast(ctx));
 
         var name_buf: [1024]u8 = undefined;
@@ -21265,6 +21278,8 @@ pub const MetalCompute = if (build_options.enable_metal) struct {
             break :blk name_buf[0..written.len :0];
         };
         const full_name = name_z[0..name_z.len];
+
+        if (!shared) return self.loadWeight(name, full_name);
 
         if (self.weight_handles.get(full_name)) |tensor| {
             toBuf(tensor).weight_handle_refs += 1;
@@ -28380,6 +28395,7 @@ pub const MetalCompute = if (build_options.enable_metal) struct {
         vt.reserveGraphPlanSlots = reserveGraphPlanSlotsOp;
         vt.freeTensor = freeOp;
         vt.getWeight = getWeightOp;
+        vt.acquireWeight = acquireWeightOp;
         vt.prefetchWeightHint = prefetchWeightHintOp;
         vt.drainPrefetchBudget = drainPrefetchBudgetOp;
         vt.fromFloat32 = fromFloat32Op;
@@ -35162,6 +35178,12 @@ fn testMetalWeightHandleLifetime(allocator: std.mem.Allocator, quantized: bool) 
     var compute = MetalCompute{ .allocator = allocator, .data = &store, .provider_impl = undefined };
     defer compute.deinitWeightCaches();
     const first = try MetalCompute.getWeightOp(&compute, "weight");
+    {
+        const acquired = try MetalCompute.acquireWeightOp(&compute, "weight");
+        defer MetalCompute.freeOp(&compute, acquired);
+        try std.testing.expect(first != acquired);
+        try std.testing.expectEqual(@as(usize, if (quantized) 2 else 1), entry.pin_count);
+    }
     const alias = if (!quantized) try compute.aliasHostBufferWithShape(first, &.{4}) else null;
     defer if (alias) |view| MetalCompute.freeOp(&compute, view);
     var peer: ?CT = null;
@@ -35202,6 +35224,7 @@ test "metal_compute: weight handle lifetime bounds materializations and lazy pin
 }
 
 test "metal_compute: weight handle lifetime unwinds allocation failures" {
+    if (comptime !build_options.enable_metal) return error.SkipZigTest;
     try std.testing.checkAllAllocationFailures(std.testing.allocator, testMetalWeightHandleLifetime, .{false});
     try std.testing.checkAllAllocationFailures(std.testing.allocator, testMetalWeightHandleLifetime, .{true});
 }
@@ -35231,6 +35254,54 @@ test "metal_compute: dense cache owns native bytes independently of weight handl
     const values = try MetalCompute.toFloat32Op(&compute, second, allocator);
     defer allocator.free(values);
     try std.testing.expectEqualSlices(f32, &.{ 1, -2.5 }, values);
+}
+
+test "metal_compute: acquired dense weights preserve host fallback and cache pin ownership" {
+    if (!build_options.enable_metal) return error.SkipZigTest;
+    const allocator = std.testing.allocator;
+    var bytes = [_]u8{ 0x80, 0x3f, 0, 0, 0, 0, 0x80, 0x3f };
+    var shape = [_]i64{ 2, 2 };
+    var store = testMetalWeightStoreInit(allocator);
+    store.prefetch = gpu_hosted_store_mod.PrefetchQueue.init(allocator, &store, gpu_hosted_store_mod.simplePrefetchProcess);
+    defer store.prefetch.deinit();
+    defer store.lazy_weights.deinit(allocator);
+    try store.lazy_weights.put(allocator, "weight", .{
+        .tensor_ref = .{ .name = "weight" },
+        .host_loaded = .{ .tensor = .{
+            .data = &bytes,
+            .shape = &shape,
+            .dtype = .bf16,
+            .name = "weight",
+            .allocator = allocator,
+            .owns_data = false,
+            .owns_shape = false,
+        } },
+    });
+    var provider: MetalCompute.ProviderImpl = undefined;
+    provider.raw_decode_runtime = null;
+    var compute = MetalCompute{ .allocator = allocator, .data = &store, .provider_impl = &provider };
+    defer compute.deinitWeightCaches();
+    const cb = compute.computeBackend();
+    const first = try cb.getWeight("weight");
+    const second = try cb.acquireWeight("weight");
+    defer cb.free(second);
+    const third = try cb.acquireWeight("weight");
+    defer cb.free(third);
+    try std.testing.expect(first != second and second != third and first != third);
+    const entry = store.lazy_weights.getPtr("weight").?;
+    try std.testing.expectEqual(@as(usize, 1), entry.pin_count);
+    try std.testing.expectEqual(entry, MetalCompute.toBuf(second).lazy_entry.?);
+    try std.testing.expect(!MetalCompute.toBuf(second).owns_lazy_pin);
+    try std.testing.expectEqual(MetalCompute.toBuf(first).native_dense_bytes.?.ptr, MetalCompute.toBuf(second).native_dense_bytes.?.ptr);
+    cb.free(first);
+    try std.testing.expectEqual(@as(usize, 1), entry.pin_count);
+    const input = try cb.fromFloat32(&.{ 3, 4 });
+    defer cb.free(input);
+    const output = try MetalCompute.linearNoBiasOpWithPlannedDispatch(&compute, input, second, 1, 2, 2, null);
+    defer cb.free(output);
+    const actual = try cb.toFloat32(output, allocator);
+    defer allocator.free(actual);
+    try std.testing.expectEqualSlices(f32, &.{ 3, 4 }, actual);
 }
 
 test "metal_compute: toFloat32 materializes zero-copy bf16 weights" {

--- a/zig/pkg/inference/src/ops/metal_compute.zig
+++ b/zig/pkg/inference/src/ops/metal_compute.zig
@@ -707,6 +707,8 @@ pub const MetalCompute = if (build_options.enable_metal) struct {
         data: []f32,
         allocator: std.mem.Allocator,
         owned: bool,
+        weight_handle_name: ?[]const u8 = null,
+        weight_handle_refs: usize = 0,
         shared_data_refcount: ?*usize = null,
         logical_shape: ?[]i64 = null,
         view_strides: ?[]usize = null,
@@ -1058,6 +1060,9 @@ pub const MetalCompute = if (build_options.enable_metal) struct {
     deepseek_v4_device_cache: std.AutoHashMapUnmanaged(DeepSeekV4CacheKey, DeepSeekV4DeviceLayerCache) = .empty,
     backend_kv_write_serial: u64 = 0,
     dense_weight_cache: std.StringHashMapUnmanaged(CachedDenseWeight) = .empty,
+    // One live handle (including its host materialization) per named weight.
+    // Early releases retire the handle; remaining borrowers end at deinit.
+    weight_handles: std.StringHashMapUnmanaged(CT) = .empty,
     layer_output_scale_device_cache: std.AutoHashMapUnmanaged(usize, MetalTensor) = .empty,
     unit_rms_weight_device_cache: std.AutoHashMapUnmanaged(usize, MetalTensor) = .empty,
     adjusted_norm_weight_device_cache: std.AutoHashMapUnmanaged(AdjustedNormWeightKey, MetalTensor) = .empty,
@@ -3560,10 +3565,14 @@ pub const MetalCompute = if (build_options.enable_metal) struct {
         native_dense: ?NativeDenseBytes,
         native_dense_dtype: ?tensor_mod.DType,
     ) !*const CachedDenseWeight {
-        const gop = try self.dense_weight_cache.getOrPut(self.allocator, full_name);
+        try self.dense_weight_cache.ensureUnusedCapacity(self.allocator, 1);
+        const owned_name = try self.allocator.dupe(u8, full_name);
+        const gop = self.dense_weight_cache.getOrPutAssumeCapacity(owned_name);
         if (!gop.found_existing) {
-            gop.key_ptr.* = try self.allocator.dupe(u8, full_name);
-            errdefer self.allocator.free(gop.key_ptr.*);
+            // All production insertions hold the weight-store residency lock.
+            // Cached native bytes/runtime storage must remain pinned even when
+            // the last caller releases its lightweight handle early.
+            if (lazy_entry) |entry| entry.pin_count += 1;
             gop.value_ptr.* = .{
                 .data = data,
                 .logical_shape = logical_shape,
@@ -3575,6 +3584,7 @@ pub const MetalCompute = if (build_options.enable_metal) struct {
                 .native_dense_mmap_source_bytes = if (native_dense) |native_info| native_info.mmap_source_bytes else null,
             };
         } else {
+            self.allocator.free(owned_name);
             if (data.len != 0) self.allocator.free(data);
             self.allocator.free(logical_shape);
             if (native_dense) |native_info| {
@@ -3587,11 +3597,11 @@ pub const MetalCompute = if (build_options.enable_metal) struct {
     fn cachedDenseWeightBuf(self: *MetalCompute, cached: *const CachedDenseWeight) !CT {
         const shape = try self.allocator.dupe(i64, cached.logical_shape);
         errdefer self.allocator.free(shape);
-        const tensor = try self.makeWeightBuf(cached.data, false, shape, cached.lazy_entry, null, cached.runtime_quantized_storage);
+        // The dense cache owns the source pin and native bytes, not each view.
+        const tensor = try self.makeWeightBuf(cached.data, false, shape, null, null, cached.runtime_quantized_storage);
         const buf = toBuf(tensor);
         buf.native_dense_bytes = cached.native_dense_bytes;
         buf.native_dense_dtype = cached.native_dense_dtype;
-        buf.native_dense_bytes_owned = cached.native_dense_bytes_owned;
         buf.native_dense_mmap_source_bytes = cached.native_dense_mmap_source_bytes;
         return tensor;
     }
@@ -4312,12 +4322,7 @@ pub const MetalCompute = if (build_options.enable_metal) struct {
         var v4_it = self.deepseek_v4_device_cache.iterator();
         while (v4_it.next()) |entry| entry.value_ptr.deinit();
         self.deepseek_v4_device_cache.deinit(self.allocator);
-        var it = self.dense_weight_cache.iterator();
-        while (it.next()) |entry| {
-            self.allocator.free(entry.key_ptr.*);
-            entry.value_ptr.deinit(self.allocator);
-        }
-        self.dense_weight_cache.deinit(self.allocator);
+        self.deinitWeightCaches();
         var scale_it = self.layer_output_scale_device_cache.iterator();
         while (scale_it.next()) |entry| entry.value_ptr.deinit();
         self.layer_output_scale_device_cache.deinit(self.allocator);
@@ -4471,6 +4476,13 @@ pub const MetalCompute = if (build_options.enable_metal) struct {
         self.deinit();
     }
 
+    fn destroyBackendOp(ctx: *anyopaque) void {
+        const self: *MetalCompute = @ptrCast(@alignCast(ctx));
+        const allocator = self.allocator;
+        self.deinit();
+        allocator.destroy(self);
+    }
+
     fn getIoOp(ctx: *anyopaque) ?std.Io {
         const self: *MetalCompute = @ptrCast(@alignCast(ctx));
         return self.io;
@@ -4520,6 +4532,12 @@ pub const MetalCompute = if (build_options.enable_metal) struct {
 
     pub fn computeBackend(self: *MetalCompute) ops.ComputeBackend {
         return .{ .ptr = self, .vtable = &vtable_impl };
+    }
+
+    /// Transfer an allocator-created context to the backend handle. Stack or
+    /// externally owned contexts must use computeBackend instead.
+    pub fn ownedComputeBackend(self: *MetalCompute) ops.ComputeBackend {
+        return .{ .ptr = self, .vtable = &owned_vtable_impl };
     }
 
     fn ownedMetalTensorFromCt(self: *MetalCompute, tensor: CT) !MetalTensor {
@@ -6339,8 +6357,21 @@ pub const MetalCompute = if (build_options.enable_metal) struct {
 
     fn freeOp(ctx: *anyopaque, tensor: CT) void {
         const buf = toBuf(tensor);
+        if (buf.weight_handle_name) |name| {
+            const self: *MetalCompute = @ptrCast(@alignCast(ctx));
+            std.debug.assert(buf.weight_handle_refs > 0);
+            buf.weight_handle_refs -= 1;
+            if (buf.weight_handle_refs != 0) return;
+            std.debug.assert(self.weight_handles.remove(name));
+            self.allocator.free(name);
+            buf.weight_handle_name = null;
+        }
         if (buf.lazy_entry) |entry| {
-            if (entry.pin_count > 0) entry.pin_count -= 1;
+            const self: *MetalCompute = @ptrCast(@alignCast(ctx));
+            self.data.prefetch.lock();
+            defer self.data.prefetch.unlock();
+            std.debug.assert(entry.pin_count > 0);
+            entry.pin_count -= 1;
         }
         releaseOwnedHostData(buf);
         if (buf.native_dense_host_cache) |cache| freeOp(ctx, cache);
@@ -7349,6 +7380,7 @@ pub const MetalCompute = if (build_options.enable_metal) struct {
         comptime op_kind: HostBinaryOp,
     ) !?CT {
         const primary_buf = toBuf(primary);
+        if (primary_buf.weight_handle_name != null) return null;
         const secondary_buf = toBuf(secondary);
         if (primary_buf.quantized_storage != null or secondary_buf.quantized_storage != null) {
             return error.UnsupportedTensorType;
@@ -21192,6 +21224,30 @@ pub const MetalCompute = if (build_options.enable_metal) struct {
         return self.unaryLikeInput(input_buf, output);
     }
 
+    fn deinitWeightCaches(self: *MetalCompute) void {
+        var it = self.weight_handles.iterator();
+        while (it.next()) |entry| {
+            toBuf(entry.value_ptr.*).weight_handle_name = null;
+            freeOp(self, entry.value_ptr.*);
+            self.allocator.free(entry.key_ptr.*);
+        }
+        self.weight_handles.deinit(self.allocator);
+        self.weight_handles = .empty;
+        var dense_it = self.dense_weight_cache.iterator();
+        while (dense_it.next()) |entry| {
+            self.allocator.free(entry.key_ptr.*);
+            if (entry.value_ptr.lazy_entry) |lazy| {
+                self.data.prefetch.lock();
+                defer self.data.prefetch.unlock();
+                std.debug.assert(lazy.pin_count > 0);
+                lazy.pin_count -= 1;
+            }
+            entry.value_ptr.deinit(self.allocator);
+        }
+        self.dense_weight_cache.deinit(self.allocator);
+        self.dense_weight_cache = .empty;
+    }
+
     fn getWeightOp(ctx: *anyopaque, name: []const u8) anyerror!CT {
         const self: *MetalCompute = @ptrCast(@alignCast(ctx));
 
@@ -21210,6 +21266,23 @@ pub const MetalCompute = if (build_options.enable_metal) struct {
         };
         const full_name = name_z[0..name_z.len];
 
+        if (self.weight_handles.get(full_name)) |tensor| {
+            toBuf(tensor).weight_handle_refs += 1;
+            return tensor;
+        }
+        // Reserve bookkeeping before loading/pinning a weight. Failed lookups
+        // never leave a partially initialized cache entry or orphaned handle.
+        try self.weight_handles.ensureUnusedCapacity(self.allocator, 1);
+        const owned_name = try self.allocator.dupe(u8, full_name);
+        errdefer self.allocator.free(owned_name);
+        const tensor = try self.loadWeight(name, full_name);
+        toBuf(tensor).weight_handle_name = owned_name;
+        toBuf(tensor).weight_handle_refs = 1;
+        self.weight_handles.putAssumeCapacityNoClobber(owned_name, tensor);
+        return tensor;
+    }
+
+    fn loadWeight(self: *MetalCompute, name: []const u8, full_name: []const u8) !CT {
         if (self.dense_weight_cache.get(full_name)) |*cached| {
             return self.cachedDenseWeightBuf(cached);
         }
@@ -21245,17 +21318,19 @@ pub const MetalCompute = if (build_options.enable_metal) struct {
 
             if (!false and preferHostLoadedWeightsDebug()) {
                 if (entry.host_loaded) |*loaded| {
-                    const host = try convertTensorToOwnedF32(self.allocator, &loaded.tensor);
-                    errdefer self.allocator.free(host);
-                    const shape = try self.logicalShapeFromTensor(&loaded.tensor);
-                    errdefer self.allocator.free(shape);
-                    const runtime_storage = if (entry.quantized_storage) |*storage| storage else null;
-                    const native_dense = try self.nativeDenseLinearBytesForRuntime(full_name, &loaded.tensor);
-                    errdefer if (native_dense) |native_info| {
-                        if (native_info.owned) self.allocator.free(native_info.bytes);
+                    const cached = blk: {
+                        const host = try convertTensorToOwnedF32(self.allocator, &loaded.tensor);
+                        errdefer self.allocator.free(host);
+                        const shape = try self.logicalShapeFromTensor(&loaded.tensor);
+                        errdefer self.allocator.free(shape);
+                        const runtime_storage = if (entry.quantized_storage) |*storage| storage else null;
+                        const native_dense = try self.nativeDenseLinearBytesForRuntime(full_name, &loaded.tensor);
+                        errdefer if (native_dense) |native_info| {
+                            if (native_info.owned) self.allocator.free(native_info.bytes);
+                        };
+                        const native_dense_dtype = if (native_dense) |native_info| native_info.dtype else null;
+                        break :blk try self.getOrInsertCachedDenseWeight(full_name, host, shape, entry, runtime_storage, native_dense, native_dense_dtype);
                     };
-                    const native_dense_dtype = if (native_dense) |native_info| native_info.dtype else null;
-                    const cached = try self.getOrInsertCachedDenseWeight(full_name, host, shape, entry, runtime_storage, native_dense, native_dense_dtype);
                     return self.cachedDenseWeightBuf(cached);
                 }
             }
@@ -21275,6 +21350,7 @@ pub const MetalCompute = if (build_options.enable_metal) struct {
                         }
                     }
                     entry.pin_count += 1;
+                    errdefer entry.pin_count -= 1;
                     const shape = try self.allocator.dupe(i64, storage.shape);
                     errdefer self.allocator.free(shape);
                     return self.makeWeightBuf(&.{}, false, shape, entry, storage, null);
@@ -21282,20 +21358,22 @@ pub const MetalCompute = if (build_options.enable_metal) struct {
             }
 
             if (entry.host_loaded) |*loaded| {
-                const shape = try self.logicalShapeFromTensor(&loaded.tensor);
-                errdefer self.allocator.free(shape);
-                const runtime_storage = if (entry.quantized_storage) |*storage| storage else null;
-                const native_dense = try self.nativeDenseLinearBytesForRuntime(full_name, &loaded.tensor);
-                errdefer if (native_dense) |native_info| {
-                    if (native_info.owned) self.allocator.free(native_info.bytes);
+                const cached = blk: {
+                    const shape = try self.logicalShapeFromTensor(&loaded.tensor);
+                    errdefer self.allocator.free(shape);
+                    const runtime_storage = if (entry.quantized_storage) |*storage| storage else null;
+                    const native_dense = try self.nativeDenseLinearBytesForRuntime(full_name, &loaded.tensor);
+                    errdefer if (native_dense) |native_info| {
+                        if (native_info.owned) self.allocator.free(native_info.bytes);
+                    };
+                    const native_dense_dtype = if (native_dense) |native_info| native_info.dtype else null;
+                    const host = if (native_dense != null)
+                        @as([]f32, &.{})
+                    else
+                        try convertTensorToOwnedF32(self.allocator, &loaded.tensor);
+                    errdefer if (native_dense == null) self.allocator.free(host);
+                    break :blk try self.getOrInsertCachedDenseWeight(full_name, host, shape, entry, runtime_storage, native_dense, native_dense_dtype);
                 };
-                const native_dense_dtype = if (native_dense) |native_info| native_info.dtype else null;
-                const host = if (native_dense != null)
-                    @as([]f32, &.{})
-                else
-                    try convertTensorToOwnedF32(self.allocator, &loaded.tensor);
-                errdefer if (native_dense == null) self.allocator.free(host);
-                const cached = try self.getOrInsertCachedDenseWeight(full_name, host, shape, entry, runtime_storage, native_dense, native_dense_dtype);
                 return self.cachedDenseWeightBuf(cached);
             }
         }
@@ -28287,6 +28365,12 @@ pub const MetalCompute = if (build_options.enable_metal) struct {
         return self.ctFromOwnedMetalTensor(tensor);
     }
 
+    const owned_vtable_impl = blk: {
+        var vt = vtable_impl;
+        vt.deinitBackend = destroyBackendOp;
+        break :blk vt;
+    };
+
     const vtable_impl = blk: {
         var vt = native_compute_mod.vtable_impl;
         vt.backendKind = backendKindOp;
@@ -28706,6 +28790,22 @@ fn testMetalWeightStoreInit(allocator: std.mem.Allocator) WeightStore {
         .prefix = "",
         .lazy_weights = .empty,
     };
+}
+
+test "metal_compute: owned backend handle destroys its request context" {
+    if (!build_options.enable_metal) return error.SkipZigTest;
+    const allocator = std.testing.allocator;
+    var store = testMetalWeightStoreInit(allocator);
+    defer {
+        deinitSharedNativeProvider(&store);
+        store.lazy_weights.deinit(allocator);
+    }
+    for (0..3) |_| {
+        const compute = try allocator.create(MetalCompute);
+        errdefer allocator.destroy(compute);
+        compute.* = try MetalCompute.init(allocator, &store, null);
+        compute.ownedComputeBackend().deinit();
+    }
 }
 
 test "metal_compute: native provider is shared across backend lifetimes" {
@@ -35028,6 +35128,109 @@ test "metal_compute: dynamic rms norm slot key distinguishes native dense buffer
     try std.testing.expectEqual(@intFromPtr(bytes_a[0..].ptr), key_a.weight_buf);
     try std.testing.expectEqual(@intFromPtr(bytes_b[0..].ptr), key_b.weight_buf);
     try std.testing.expect(key_a.weight_buf != key_b.weight_buf);
+}
+
+fn testMetalWeightHandleLifetime(allocator: std.mem.Allocator, quantized: bool) !void {
+    if (!build_options.enable_metal) return error.SkipZigTest;
+    var bytes = [_]u8{ 0x80, 0x3f, 0x20, 0xc0, 0x00, 0x3f, 0x40, 0x40 };
+    var shape = [_]i64{ 2, 2 };
+    var store = testMetalWeightStoreInit(allocator);
+    store.prefetch = gpu_hosted_store_mod.PrefetchQueue.init(allocator, &store, gpu_hosted_store_mod.simplePrefetchProcess);
+    defer store.prefetch.deinit();
+    defer store.lazy_weights.deinit(allocator);
+    try store.lazy_weights.put(allocator, "weight", .{
+        .tensor_ref = .{ .name = "weight" },
+        .quantized_storage = if (quantized) .{
+            .tensor_type = .{ .known = .Q4_0 },
+            .raw_bytes = &bytes,
+            .shape = &shape,
+            .raw_owned = false,
+            .allocator = allocator,
+        } else null,
+        .host_loaded = if (quantized) null else .{ .tensor = .{
+            .data = &bytes,
+            .shape = &shape,
+            .dtype = .bf16,
+            .name = "weight",
+            .allocator = allocator,
+            .owns_data = false,
+            .owns_shape = false,
+        } },
+    });
+    const entry = store.lazy_weights.getPtr("weight").?;
+    // Exercise the ownership path without a GPU, model download, or provider.
+    var compute = MetalCompute{ .allocator = allocator, .data = &store, .provider_impl = undefined };
+    defer compute.deinitWeightCaches();
+    const first = try MetalCompute.getWeightOp(&compute, "weight");
+    const alias = if (!quantized) try compute.aliasHostBufferWithShape(first, &.{4}) else null;
+    defer if (alias) |view| MetalCompute.freeOp(&compute, view);
+    var peer: ?CT = null;
+    if (!quantized) {
+        const values = try MetalCompute.toFloat32Op(&compute, first, allocator);
+        defer allocator.free(values);
+        try std.testing.expectEqualSlices(f32, &.{ 1, -2.5, 0.5, 3 }, values);
+        peer = MetalCompute.toBuf(first).native_dense_host_cache;
+        try std.testing.expect(peer != null);
+    }
+    for (0..1000) |_| {
+        const again = try MetalCompute.getWeightOp(&compute, "weight");
+        try std.testing.expectEqual(first, again);
+        try std.testing.expectEqual(peer, MetalCompute.toBuf(again).native_dense_host_cache);
+    }
+    try std.testing.expectEqual(@as(usize, 1), compute.weight_handles.count());
+    try std.testing.expectEqual(@as(usize, 1), entry.pin_count);
+    try std.testing.expectEqual(@as(?CT, null), try compute.binaryConsumeIntoPreferred(first, first, .add));
+    for (0..1000) |_| MetalCompute.freeOp(&compute, first);
+    try std.testing.expectEqual(@as(usize, 1), compute.weight_handles.count());
+    MetalCompute.freeOp(&compute, first);
+    try std.testing.expectEqual(@as(usize, 0), compute.weight_handles.count());
+    try std.testing.expectEqual(@as(usize, if (quantized) 0 else 1), entry.pin_count);
+    _ = try MetalCompute.getWeightOp(&compute, "weight");
+    _ = try MetalCompute.getWeightOp(&compute, "weight");
+    compute.deinitWeightCaches();
+    try std.testing.expectEqual(@as(usize, 0), entry.pin_count);
+    if (alias) |view| {
+        const values = try MetalCompute.toFloat32Op(&compute, view, allocator);
+        defer allocator.free(values);
+        try std.testing.expectEqualSlices(f32, &.{ 1, -2.5, 0.5, 3 }, values);
+    }
+}
+
+test "metal_compute: weight handle lifetime bounds materializations and lazy pins" {
+    try testMetalWeightHandleLifetime(std.testing.allocator, false);
+    try testMetalWeightHandleLifetime(std.testing.allocator, true);
+}
+
+test "metal_compute: weight handle lifetime unwinds allocation failures" {
+    try std.testing.checkAllAllocationFailures(std.testing.allocator, testMetalWeightHandleLifetime, .{false});
+    try std.testing.checkAllAllocationFailures(std.testing.allocator, testMetalWeightHandleLifetime, .{true});
+}
+
+test "metal_compute: dense cache owns native bytes independently of weight handles" {
+    if (!build_options.enable_metal) return error.SkipZigTest;
+    const allocator = std.testing.allocator;
+    var store = testMetalWeightStoreInit(allocator);
+    var compute = MetalCompute{ .allocator = allocator, .data = &store, .provider_impl = undefined };
+    defer compute.deinitWeightCaches();
+    const cached = blk: {
+        const bytes = try allocator.dupe(u8, &.{ 0x80, 0x3f, 0x20, 0xc0 });
+        errdefer allocator.free(bytes);
+        const shape = try allocator.dupe(i64, &.{ 1, 2 });
+        errdefer allocator.free(shape);
+        break :blk try compute.getOrInsertCachedDenseWeight("weight", &.{}, shape, null, null, .{
+            .bytes = bytes,
+            .dtype = .bf16,
+            .owned = true,
+        }, .bf16);
+    };
+    const first = try MetalCompute.getWeightOp(&compute, "weight");
+    MetalCompute.freeOp(&compute, first);
+    // Releasing a view must not free the cache's bytes or a second view.
+    try std.testing.expectEqualSlices(u8, &.{ 0x80, 0x3f, 0x20, 0xc0 }, cached.native_dense_bytes.?);
+    const second = try MetalCompute.getWeightOp(&compute, "weight");
+    const values = try MetalCompute.toFloat32Op(&compute, second, allocator);
+    defer allocator.free(values);
+    try std.testing.expectEqualSlices(f32, &.{ 1, -2.5 }, values);
 }
 
 test "metal_compute: toFloat32 materializes zero-copy bf16 weights" {

--- a/zig/pkg/inference/src/ops/native_compute.zig
+++ b/zig/pkg/inference/src/ops/native_compute.zig
@@ -3938,6 +3938,20 @@ pub const NativeCompute = struct {
         return .{ .allocator = allocator, .data = data, .run_budget = run_budget, .io = io };
     }
 
+    /// Release context-owned handles and reservations without destroying self.
+    /// Stack/embedded owners must call this after releasing caller-owned tensors
+    /// and before tearing down the borrowed weight store or run budget.
+    pub fn deinit(self: *NativeCompute) void {
+        deinitWeightHandles(self);
+        var it = self.weight_reservations.iterator();
+        while (it.next()) |entry| {
+            if (self.run_budget) |budget| budget.release(entry.value_ptr.reservation);
+            self.allocator.free(entry.key_ptr.*);
+        }
+        self.weight_reservations.deinit(self.allocator);
+        self.weight_reservations = .empty;
+    }
+
     // Dispatchers select the canonical Io API when this backend was constructed
     // with one; otherwise fall through to the *Sync escape hatch.  Cancellation
     // mid-matmul leaves C in a partial state -- caller's `errdefer` paths must
@@ -3995,6 +4009,8 @@ pub const NativeCompute = struct {
         native.sgemmTransBF16WeightsSync(m, n, k, alpha, a, b, beta, c_out);
     }
 
+    /// Backend deinit also destroys self and requires an allocator-created
+    /// context. Stack/embedded owners instead call NativeCompute.deinit.
     pub fn computeBackend(self: *NativeCompute) ComputeBackend {
         return .{ .ptr = self, .vtable = &vtable_impl };
     }
@@ -4514,18 +4530,7 @@ fn backendKind(_: *anyopaque) BackendKind {
 
 fn deinitBackend(ctx: *anyopaque) void {
     const self: *NativeCompute = @ptrCast(@alignCast(ctx));
-    deinitWeightHandles(self);
-    if (self.run_budget) |run_budget| {
-        var it = self.weight_reservations.iterator();
-        while (it.next()) |entry| {
-            run_budget.release(entry.value_ptr.reservation);
-            self.allocator.free(entry.key_ptr.*);
-        }
-    } else {
-        var it = self.weight_reservations.iterator();
-        while (it.next()) |entry| self.allocator.free(entry.key_ptr.*);
-    }
-    self.weight_reservations.deinit(self.allocator);
+    self.deinit();
     self.allocator.destroy(self);
 }
 
@@ -4741,7 +4746,7 @@ test "native weight handles reserve and release run budget capacity" {
     };
     var budget = run_memory.RunBudget.init(.{ .host_limit_bytes = 96 });
     var compute = NativeCompute.init(allocator, &store, &budget);
-    defer compute.weight_reservations.deinit(allocator);
+    defer compute.deinit();
 
     try std.testing.expect((try acquireWeightReservation(&compute, "weight", 64)) != null);
     try std.testing.expect((try acquireWeightReservation(&compute, "weight", 64)) != null);
@@ -40907,6 +40912,7 @@ test "ComputeBackend linearTriple matches three biased linears" {
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
     const cb = compute.computeBackend();
 
     var input_data = [_]f32{
@@ -40976,6 +40982,7 @@ test "quantized linearTriple propagates token-major shape into sdpa" {
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
     defer deinitPrefetchQueue(&weight_store);
+    defer compute.deinit();
     const cb = compute.computeBackend();
 
     const input_data = try allocator.alloc(f32, rows * in_dim);
@@ -41056,6 +41063,7 @@ test "ComputeBackend linearPair matches two biased linears" {
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
     const cb = compute.computeBackend();
 
     var input_data = [_]f32{
@@ -42010,6 +42018,7 @@ test "native mulMatId supports ggml expert-last dense layout" {
         .lazy_weights = .{},
     };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
     var cb = compute.computeBackend();
 
     const input_ct = try fromFloat32ShapeOp(&compute, &.{ 1.0, 2.0, 3.0, 4.0 }, &.{ 2, 2 });
@@ -42055,6 +42064,7 @@ test "native mulMatId keeps ggml expert-last q8_0 layout quantized" {
         .lazy_weights = .{},
     };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
     var cb = compute.computeBackend();
 
     var input_data: [64]f32 = [_]f32{1.0} ** 64;
@@ -44321,6 +44331,7 @@ fn expectNativeQuantDispatchBucket(
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
     defer deinitPrefetchQueue(&weight_store);
+    defer compute.deinit();
     const dispatched = try allocator.alloc(f32, rows * out_dim);
     defer allocator.free(dispatched);
     @memset(dispatched, 0.0);
@@ -44413,6 +44424,7 @@ test "q4 q5 unmeasured recognizer shapes use cached dense dequant sgemm" {
         var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
         defer deinitPrefetchQueue(&weight_store);
         var compute = NativeCompute.init(allocator, &weight_store, null);
+        defer compute.deinit();
 
         const output = try allocator.alloc(f32, rows * out_dim);
         defer allocator.free(output);
@@ -44493,6 +44505,7 @@ test "q4 q5 gliner encoder shapes use cached dense dequant sgemm" {
         var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
         defer deinitPrefetchQueue(&weight_store);
         var compute = NativeCompute.init(allocator, &weight_store, null);
+        defer compute.deinit();
 
         const output = try allocator.alloc(f32, rows * out_dim);
         defer allocator.free(output);
@@ -44549,6 +44562,7 @@ test "native linearNoBiasWithPlan routes quantized storage through planned op" {
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
     defer deinitPrefetchQueue(&weight_store);
+    defer compute.deinit();
     var cb = compute.computeBackend();
     try std.testing.expect(vtable_impl.linearNoBiasPlanned != null);
 
@@ -44983,6 +44997,7 @@ test "dequant sgemm cache denial falls back without transient scratch by default
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
 
     setQuantizedDequantSgemmOverrideForBench(true);
     setQuantizedDequantSgemmScratchOverrideForBench(false);
@@ -45561,6 +45576,7 @@ test "flash attention matches reference SDPA for long context" {
         .lazy_weights = .{},
     };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
     const flash_output = try flashCausalAttentionHost(
         allocator,
         Q,
@@ -45684,6 +45700,7 @@ test "gqa causal attention matches naive reference" {
         .lazy_weights = .{},
     };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
     const flash_ct = try gqaAttentionSlices(&compute, Q, K, V, null, null, 0, null, seq_len, batch, seq_len, seq_len, 0, 0, num_heads, num_kv_heads, head_dim);
     defer freeTensor(&compute, flash_ct);
     const flash_output = getData(flash_ct);
@@ -45803,6 +45820,7 @@ fn testCompressedKeyPagedAttention(dtype: runtime.kv.pool.KvDType) !void {
         .lazy_weights = .{},
     };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
 
     const attention: AttentionContext = .{
         .mode = .paged_decode,
@@ -45937,6 +45955,7 @@ test "linearNoBias source tensor chunked matches dense f16 weight" {
         .lazy_weights = .{},
     };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
 
     const input_ct = try compute.makeBuf(input[0..], false);
     defer freeTensor(&compute, input_ct);
@@ -45979,6 +45998,7 @@ test "embeddingLookup dequantizes quantized GGUF rows" {
         .lazy_weights = .{},
     };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
     const cb = compute.computeBackend();
 
     const weight_ct = try compute.makeBufWithEntry(empty_f32[0..], false, "token_embd.weight", null, &storage, null);
@@ -46031,7 +46051,27 @@ test "embeddingLookup dequantizes quantized GGUF rows" {
     }
 }
 
-fn testWeightHandleLifetime(allocator: std.mem.Allocator, lazy: bool) !void {
+test "native stack teardown releases empty lookup caches and outstanding reservations" {
+    const allocator = std.testing.allocator;
+    var store = WeightStore{ .allocator = allocator, .resident_weights = .empty, .lazy_weights = .empty };
+    defer store.prefetch.deinit();
+    var budget = run_memory.RunBudget.init(.{ .host_limit_bytes = 96 });
+    var compute = NativeCompute.init(allocator, &store, &budget);
+    defer compute.deinit();
+    try std.testing.expectError(error.MissingWeight, compute.computeBackend().getWeight("missing"));
+    try std.testing.expect(compute.weight_handles.capacity() > 0);
+    _ = try acquireWeightReservation(&compute, "reserved", 64);
+    try std.testing.expectEqual(@as(usize, 64), budget.host_weight_bytes);
+
+    compute.deinit();
+    try std.testing.expectEqual(@as(usize, 0), compute.weight_handles.capacity());
+    try std.testing.expectEqual(@as(usize, 0), compute.weight_reservations.capacity());
+    try std.testing.expectEqual(@as(usize, 0), budget.host_weight_bytes);
+    // The context teardown leaves the shared model store's lifetime to its owner.
+    try std.testing.expect(store.prefetch_initialized);
+}
+
+fn testWeightHandleLifetime(allocator: std.mem.Allocator, lazy: bool, stack_owned: bool) !void {
     var bytes = [_]u8{ 0x80, 0x3f, 0x20, 0xc0, 0x00, 0x3f, 0x40, 0x40 };
     var shape = [_]i64{ 2, 2 };
     const weight = LoadedWeight{ .tensor = .{
@@ -46057,10 +46097,11 @@ fn testWeightHandleLifetime(allocator: std.mem.Allocator, lazy: bool) !void {
     }
     var budget = run_memory.RunBudget.init(.{ .host_limit_bytes = 64 });
     {
-        const compute = try allocator.create(NativeCompute);
+        var stack_compute: NativeCompute = undefined;
+        const compute = if (stack_owned) &stack_compute else try allocator.create(NativeCompute);
         compute.* = NativeCompute.init(allocator, &store, &budget);
         defer store.prefetch.deinit();
-        defer deinitBackend(compute);
+        defer if (stack_owned) compute.deinit() else deinitBackend(compute);
         const first = try getWeight(compute, "weight");
         {
             const owned = try acquireWeight(compute, "weight");
@@ -46102,13 +46143,17 @@ fn testWeightHandleLifetime(allocator: std.mem.Allocator, lazy: bool) !void {
 }
 
 test "native weight handle lifetime is bounded and releases reservations and lazy pins" {
-    try testWeightHandleLifetime(std.testing.allocator, false);
-    try testWeightHandleLifetime(std.testing.allocator, true);
+    inline for (.{ false, true }) |stack_owned| {
+        try testWeightHandleLifetime(std.testing.allocator, false, stack_owned);
+        try testWeightHandleLifetime(std.testing.allocator, true, stack_owned);
+    }
 }
 
 test "native weight handle lifetime unwinds allocation failures" {
-    try std.testing.checkAllAllocationFailures(std.testing.allocator, testWeightHandleLifetime, .{false});
-    try std.testing.checkAllAllocationFailures(std.testing.allocator, testWeightHandleLifetime, .{true});
+    inline for (.{ false, true }) |stack_owned| {
+        try std.testing.checkAllAllocationFailures(std.testing.allocator, testWeightHandleLifetime, .{ false, stack_owned });
+        try std.testing.checkAllAllocationFailures(std.testing.allocator, testWeightHandleLifetime, .{ true, stack_owned });
+    }
 }
 
 test "getWeight preserves resident dense tensor shape metadata" {
@@ -46154,8 +46199,7 @@ test "getWeight preserves resident dense tensor shape metadata" {
     };
     var run_budget = run_memory.RunBudget.init(.{ .host_limit_bytes = 1024 });
     var compute = NativeCompute.init(allocator, &weight_store, &run_budget);
-    defer compute.weight_reservations.deinit(allocator);
-    defer deinitWeightHandles(&compute);
+    defer compute.deinit();
     const cb = compute.computeBackend();
 
     const weight = try cb.getWeight(name);
@@ -46222,6 +46266,7 @@ test "whereSelect handles equal-length operands" {
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
 
     var c = [_]f32{ 1.0, 0.0, 1.0, 0.0 };
     var t = [_]f32{ 10.0, 20.0, 30.0, 40.0 };
@@ -46247,6 +46292,7 @@ test "whereSelect resolves concrete imported bert mask against flat sequence ope
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
 
     const elem_count = 3 * 512;
     const cond_data = try allocator.alloc(f32, elem_count);
@@ -46288,6 +46334,7 @@ test "whereSelect rejects concrete same-numel transpose mismatch" {
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
 
     var cond_data = [_]f32{ 1, 0, 1, 0, 1, 0 };
     var true_data = [_]f32{ 10, 20, 30, 40, 50, 60 };
@@ -46314,6 +46361,7 @@ test "whereSelect rejects symbolic same-numel transpose mismatch" {
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
 
     var cond_data = [_]f32{ 1, 0, 1, 0, 1, 0 };
     var true_data = [_]f32{ 10, 20, 30, 40, 50, 60 };
@@ -46346,6 +46394,7 @@ test "whereSelect broadcasts scalar on_true and on_false" {
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
 
     var c = [_]f32{ 1.0, 0.0, 1.0 };
     var t = [_]f32{99.0}; // scalar
@@ -46370,6 +46419,7 @@ test "whereSelect broadcasts condition across leading dimension" {
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
 
     var c = [_]f32{ 1.0, 0.0, 0.0, 1.0 };
     var t = [_]f32{ 10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0 };
@@ -46408,6 +46458,7 @@ test "whereSelect resolves symbolic condition dims from broadcast context" {
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
 
     const elem_count = 1 * 8 * 4 * 4;
     const cond_data = try allocator.alloc(f32, elem_count);
@@ -46453,6 +46504,7 @@ test "whereSelect reads broadcast view condition without materializing it first"
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
 
     const cond_owned = try allocator.dupe(f32, &.{ 1.0, 0.0, 1.0 });
     const true_owned = try allocator.dupe(f32, &.{ 10.0, 20.0, 30.0, 40.0, 50.0, 60.0 });
@@ -46483,6 +46535,7 @@ test "addConsumeLeft reads broadcast view rhs without materializing it first" {
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
 
     const lhs_owned = try allocator.dupe(f32, &.{ 1, 2, 3, 4, 5, 6 });
     const rhs_owned = try allocator.dupe(f32, &.{ 10, 20, 30 });
@@ -46508,6 +46561,7 @@ test "addConsumeLeft handles repeated suffix broadcast blocks without stepping e
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
 
     const lhs_owned = try allocator.alloc(f32, 2 * 3 * 4);
     for (0..lhs_owned.len) |i| lhs_owned[i] = @floatFromInt(i);
@@ -46544,6 +46598,7 @@ test "multiply reads repeated suffix broadcast blocks without stepping every ele
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
 
     const lhs_owned = try allocator.alloc(f32, 2 * 3 * 4);
     for (0..lhs_owned.len) |i| lhs_owned[i] = @floatFromInt(i + 1);
@@ -46579,6 +46634,7 @@ test "lessThan reads repeated suffix broadcast blocks without stepping every ele
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
 
     const lhs_owned = try allocator.alloc(f32, 2 * 3 * 4);
     for (0..lhs_owned.len) |i| lhs_owned[i] = @floatFromInt(i);
@@ -46632,6 +46688,7 @@ test "transpose resolves clip text attention shape" {
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
 
     const elem_count = 8 * 77 * 64;
     const input_data = try allocator.alloc(f32, elem_count);
@@ -46661,6 +46718,7 @@ test "transpose resolves zero metadata shape from view strides" {
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
 
     const batch = 2;
     const seq = 3;
@@ -46697,6 +46755,7 @@ test "materialize view resolves symbolic logical shape" {
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
 
     const elem_count = 8 * 77 * 64;
     const input_data = try allocator.alloc(f32, elem_count);
@@ -46724,6 +46783,7 @@ test "whereSelect preserves inferred attention cube shape" {
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
 
     const elem_count = 3 * 8 * 3 * 3;
     const cond_data = try allocator.alloc(f32, elem_count);
@@ -46769,6 +46829,7 @@ test "whereSelect handles repeated suffix broadcast blocks without stepping ever
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
 
     const cond_owned = try allocator.dupe(f32, &.{
         1, 0, 1, 0,
@@ -46808,6 +46869,7 @@ test "whereSelectConsumeTrue handles repeated suffix broadcast condition blocks"
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
 
     const cond_owned = try allocator.dupe(f32, &.{
         1, 0, 1, 0,
@@ -46852,6 +46914,7 @@ test "whereSelect handles repeated suffix blocks for condition and false branch 
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
 
     const cond_owned = try allocator.dupe(f32, &.{
         1, 0, 1, 0,
@@ -46897,6 +46960,7 @@ test "add preserves symbolic broadcasted logical shape from the larger operand" 
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
 
     const elem_count = 1 * 8 * 4 * 4;
     const lhs_data = try allocator.alloc(f32, elem_count);
@@ -46927,6 +46991,7 @@ test "reshape preserves symbolic target shape when dims remain unresolved" {
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
 
     var data = [_]f32{0.0} ** (76 * 8 * 76 * 64);
     const in_ct = try compute.makeBuf(data[0..], false);
@@ -46957,6 +47022,7 @@ test "reshape resolves symbolic source dims using data len" {
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
 
     var data = [_]f32{0.0} ** (77 * 512);
     const raw = try compute.makeBuf(data[0..], false);
@@ -46989,6 +47055,7 @@ test "reshape aliases owned backing storage" {
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
 
     const owned = try allocator.dupe(f32, &.{ 1, 2, 3, 4, 5, 6 });
     const in_ct = try compute.makeBuf(owned, true);
@@ -47008,6 +47075,7 @@ test "broadcast_in_dim aliases reshape-only dense buffer" {
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
 
     const owned = try allocator.dupe(f32, &.{ 1, 2, 3, 4, 5, 6 });
     const in_ct = try compute.makeBuf(owned, true);
@@ -47026,6 +47094,7 @@ test "transpose aliases singleton-axis shuffles" {
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
 
     const owned = try allocator.dupe(f32, &.{ 1, 2, 3, 4, 5, 6 });
     const in_ct = try compute.makeBuf(owned, true);
@@ -47044,6 +47113,7 @@ test "transpose creates lazy dense view for non-singleton permutation" {
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
 
     const owned = try allocator.dupe(f32, &.{ 1, 2, 3, 4, 5, 6 });
     const in_ct = try compute.makeBuf(owned, true);
@@ -47063,6 +47133,7 @@ test "broadcast_in_dim creates lazy dense view for repeated expansion" {
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
 
     const owned = try allocator.dupe(f32, &.{ 1, 2, 3 });
     const in_ct = try compute.makeBuf(owned, true);
@@ -47082,6 +47153,7 @@ test "broadcast_in_dim resolves zero target dims from mapped input axes" {
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
 
     const owned = try allocator.dupe(f32, &.{ 1, 2, 3, 4, 5, 6 });
     const in_ct = try compute.makeBuf(owned, true);
@@ -47099,6 +47171,7 @@ test "broadcast_in_dim materializes tiled mapped dimensions" {
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
 
     const owned = try allocator.dupe(f32, &.{ 1, 2, 3, 4 });
     const in_ct = try compute.makeBuf(owned, true);
@@ -47122,6 +47195,7 @@ test "scatterAdd uses indices_shape for output rows" {
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
 
     // input [2, 3], indices [2] pointing to rows 0 and 1, output shape [3] (3 output rows)
     var in_data = [_]f32{ 1, 2, 3, 4, 5, 6 };
@@ -47149,6 +47223,7 @@ test "scatterAdd rejects out-of-bounds indices" {
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
 
     var in_data = [_]f32{ 1, 2, 3 };
     var idx_data = [_]f32{5.0}; // points to row 5, but output only has 2 rows
@@ -47167,6 +47242,7 @@ test "softmax produces correct row-wise probabilities" {
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
 
     // 2 rows of 3 elements each, last_dim_size = 3
     var data = [_]f32{ 1.0, 2.0, 3.0, 1.0, 2.0, 3.0 };
@@ -47189,6 +47265,7 @@ test "softmax resolves dynamic last dimension from logical shape" {
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
 
     var data = [_]f32{ 1.0, 2.0, 3.0, 1.0, 2.0, 3.0 };
     const raw_ct = try compute.makeBuf(data[0..], false);
@@ -47209,6 +47286,7 @@ test "softmaxConsume reuses uniquely owned dense buffer" {
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
 
     const owned = try allocator.dupe(f32, &.{ 1.0, 2.0, 3.0, 0.5, 1.5, 2.5 });
     const in_ct = try compute.makeBuf(owned, true);
@@ -47225,6 +47303,7 @@ test "addConsumeLeft reuses uniquely owned lhs buffer with broadcast" {
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
 
     const lhs_owned = try allocator.dupe(f32, &.{ 1, 2, 3, 4, 5, 6 });
     var rhs_data = [_]f32{ 0.5, -1.0, 2.0 };
@@ -47242,6 +47321,7 @@ test "multiplyConsumeLeft reuses uniquely owned lhs buffer with broadcast" {
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
 
     const lhs_owned = try allocator.dupe(f32, &.{ 1, 2, 3, 4, 5, 6 });
     var rhs_data = [_]f32{ 2.0, -1.0, 0.5 };
@@ -47259,6 +47339,7 @@ test "addConsumeRight reuses uniquely owned rhs buffer with broadcast" {
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
 
     var lhs_data = [_]f32{ 0.5, -1.0, 2.0 };
     const rhs_owned = try allocator.dupe(f32, &.{ 1, 2, 3, 4, 5, 6 });
@@ -47276,6 +47357,7 @@ test "multiplyConsumeRight reuses uniquely owned rhs buffer with broadcast" {
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
 
     var lhs_data = [_]f32{ 2.0, -1.0, 0.5 };
     const rhs_owned = try allocator.dupe(f32, &.{ 1, 2, 3, 4, 5, 6 });
@@ -47293,6 +47375,7 @@ test "subtractConsumeLeft reuses uniquely owned lhs buffer with broadcast" {
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
 
     const lhs_owned = try allocator.dupe(f32, &.{ 1, 2, 3, 4, 5, 6 });
     var rhs_data = [_]f32{ 0.5, -1.0, 2.0 };
@@ -47310,6 +47393,7 @@ test "divideConsumeLeft reuses uniquely owned lhs buffer with broadcast" {
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
 
     const lhs_owned = try allocator.dupe(f32, &.{ 1, 2, 3, 4, 5, 6 });
     var rhs_data = [_]f32{ 2.0, -1.0, 0.5 };
@@ -47327,6 +47411,7 @@ test "lessThanConsumeLeft reuses uniquely owned lhs buffer with broadcast" {
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
 
     const lhs_owned = try allocator.dupe(f32, &.{ 1, 2, 3, 4, 5, 6 });
     var rhs_data = [_]f32{ 3.0, 2.0, 4.0 };
@@ -47344,6 +47429,7 @@ test "whereSelectConsumeTrue reuses uniquely owned true branch with exact output
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
 
     var cond_data = [_]f32{ 1.0, 0.0, 1.0, 0.0 };
     const true_owned = try allocator.dupe(f32, &.{ 10.0, 20.0, 30.0, 40.0 });
@@ -47364,6 +47450,7 @@ test "whereSelectConsumeFalse reuses uniquely owned false branch with exact outp
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
 
     var cond_data = [_]f32{ 1.0, 0.0, 1.0, 0.0 };
     var true_data = [_]f32{10.0};
@@ -47384,6 +47471,7 @@ test "whereSelectConsumeTrue reuses reshaped true branch alias on last-use path"
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
 
     var cond_data = [_]f32{ 1.0, 0.0, 1.0, 0.0, 0.0, 1.0 };
     const true_owned = try allocator.dupe(f32, &.{ 10.0, 20.0, 30.0, 40.0, 50.0, 60.0 });
@@ -47409,6 +47497,7 @@ test "whereSelectConsumeFalse reuses reshaped false branch alias on last-use pat
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
 
     var cond_data = [_]f32{ 1.0, 0.0, 1.0, 0.0, 0.0, 1.0 };
     var true_data = [_]f32{10.0};
@@ -47434,6 +47523,7 @@ test "unaryConsume reuses uniquely owned dense buffer for relu" {
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
 
     const owned = try allocator.dupe(f32, &.{ -1.0, 2.0, -3.0, 4.0 });
     const in_ct = try compute.makeBuf(owned, true);
@@ -47448,6 +47538,7 @@ test "unaryConsume reuses uniquely owned dense buffer for exp" {
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
 
     const owned = try allocator.dupe(f32, &.{ 0.0, 1.0, -1.0 });
     const in_ct = try compute.makeBuf(owned, true);
@@ -47464,6 +47555,7 @@ test "layerNormConsumeInput reuses uniquely owned dense buffer" {
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
 
     const input_owned = try allocator.dupe(f32, &.{ 1.0, 2.0, 3.0, 4.0 });
     var gamma_data = [_]f32{ 1.0, 1.0, 1.0, 1.0 };
@@ -47488,6 +47580,7 @@ test "rmsNormConsumeInput reuses uniquely owned dense buffer" {
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
 
     const input_owned = try allocator.dupe(f32, &.{ 1.0, 2.0, 3.0, 4.0 });
     var weight_data = [_]f32{ 1.0, 1.0, 1.0, 1.0 };
@@ -47509,6 +47602,7 @@ test "sdpaOp respects flattened batch-head layout" {
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
 
     const batch: usize = 2;
     const seq_len: usize = 3;
@@ -47624,6 +47718,7 @@ test "sdpaOp preserves 4d logical shape from query input" {
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
 
     const batch: usize = 1;
     const seq_len: usize = 3;
@@ -47922,6 +48017,7 @@ test "sdpa token-major 2d layout matches head-major reference" {
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
     const cb = ComputeBackend{ .ptr = &compute, .vtable = &vtable_impl };
 
     // seq 40 exercises the flash path, seq 8 the legacy materialized path.
@@ -47977,6 +48073,7 @@ test "sdpa rejects mixed token-major and head-major layouts" {
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
 
     var data = [_]f32{0} ** 8;
     const q_ct = try compute.withLogicalShape(try compute.makeBuf(&data, false), &.{ 2, 4 });
@@ -47996,6 +48093,7 @@ test "ComputeBackend masked BCE with logits forward and backward" {
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
     const cb = ComputeBackend{ .ptr = &compute, .vtable = &vtable_impl };
 
     var logits_data = [_]f32{ -2.0, 0.0, 3.0, 1.0 };
@@ -48068,6 +48166,7 @@ test "ComputeBackend scaledDotProductAttention call site exercises flash layout"
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
     const cb = ComputeBackend{ .ptr = &compute, .vtable = &vtable_impl };
 
     const batch: usize = 2;
@@ -48118,6 +48217,7 @@ test "Qwen3-VL vision attention portable fallback treats an empty mask as unmask
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
     const cb = ComputeBackend{ .ptr = &compute, .vtable = &vtable_impl };
 
     var q_data = [_]f32{ 0.0, 0.0 };
@@ -48139,6 +48239,7 @@ test "ComputeBackend causalSelfAttention call site matches naive reference" {
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
     const cb = ComputeBackend{ .ptr = &compute, .vtable = &vtable_impl };
 
     const batch: usize = 1;
@@ -48179,6 +48280,7 @@ test "ComputeBackend crossAttention call site matches masked reference" {
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
     const cb = ComputeBackend{ .ptr = &compute, .vtable = &vtable_impl };
 
     const batch: usize = 2;
@@ -48221,6 +48323,7 @@ test "dot_general flattens lhs suffix for shared rhs source tensor" {
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
 
     const lhs_len = 3 * 8 * 64;
     const rhs_k = 8 * 64;
@@ -48282,6 +48385,7 @@ test "dot_general handles rank1 outer product without contracting axes" {
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
 
     var lhs_data = [_]f32{ 1, 2, 3 };
     var rhs_data = [_]f32{ 10, 20, 30, 40 };
@@ -48309,6 +48413,7 @@ test "dot_general handles rank2 lhs transpose view without materializing input f
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
 
     const lhs_owned = try allocator.dupe(f32, &.{ 1, 2, 3, 4, 5, 6 });
     var rhs_data = [_]f32{
@@ -48343,6 +48448,7 @@ test "dot_general handles flattened lhs transpose view for shared rhs linear" {
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
 
     const lhs_len = 2 * 3 * 4;
     const rhs_k = 4;
@@ -48397,6 +48503,7 @@ test "dot_general resolves symbolic batched output from peer dimensions" {
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
 
     const lhs_data = try allocator.alloc(f32, 2 * 3 * 4);
     defer allocator.free(lhs_data);
@@ -48427,6 +48534,7 @@ test "dot_general resolves rhs symbolic batch and free dims from lhs peer" {
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
 
     const lhs_data = try allocator.alloc(f32, 2 * 3 * 4 * 5);
     defer allocator.free(lhs_data);
@@ -48455,6 +48563,7 @@ test "dot_general keeps concrete flattened batch extent with repeated per-head r
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
 
     const lhs_data = try allocator.alloc(f32, 4 * 3 * 2);
     defer allocator.free(lhs_data);
@@ -48513,6 +48622,7 @@ test "dot_general handles batched rhs free-before-contract layout" {
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
 
     const batch = 1;
     const heads = 2;
@@ -48581,6 +48691,7 @@ test "dot_general handles clip vision attention score shape" {
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
 
     const batch = 1;
     const heads = 12;
@@ -48626,6 +48737,7 @@ test "dot_general preserves declared symbolic batch factorization" {
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
 
     const lhs_data = try allocator.alloc(f32, 64 * 4 * 64 * 32);
     defer allocator.free(lhs_data);
@@ -48664,6 +48776,7 @@ test "dot_general preserves partially resolved symbolic output shape" {
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
 
     const lhs_data = try allocator.alloc(f32, 2 * 3 * 4);
     defer allocator.free(lhs_data);
@@ -48701,6 +48814,7 @@ test "slice aliases full-range symbolic tensors" {
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
     var cb = compute.computeBackend();
 
     const raw = try allocator.dupe(f32, &.{ 1, 2, 3, 4, 5, 6 });
@@ -48725,6 +48839,7 @@ test "native conv ops preserve runtime logical shape" {
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
     const cb = compute.computeBackend();
 
     var conv1_input = [_]f32{
@@ -48770,6 +48885,7 @@ test "native rejects mismatched shaped buffers before conv2d" {
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
     const cb = compute.computeBackend();
 
     try std.testing.expectError(error.InvalidShape, cb.fromFloat32Shape(&.{1}, &.{2}));
@@ -48794,6 +48910,7 @@ test "argmax reduces axis with keepdims" {
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
 
     const raw = try allocator.dupe(f32, &.{
         1, 5, 3, 4,
@@ -48816,6 +48933,7 @@ test "argmax drops reduced axis when keepdims is false" {
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
 
     const raw = try allocator.dupe(f32, &.{
         1, 3, 2,
@@ -48838,6 +48956,7 @@ test "gather supports scalar index on nonzero axis" {
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
 
     const data = try allocator.dupe(f32, &.{
         1,  2,
@@ -48871,6 +48990,7 @@ test "gather preserves multi-dimensional index shape for 2d tables" {
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
 
     const data = try allocator.dupe(f32, &.{
         1, 2,
@@ -48904,6 +49024,7 @@ test "gather supports arbitrary axis with singleton index tensor" {
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
 
     const data = try allocator.dupe(f32, &.{
         1,  2,  3,  4,
@@ -48942,6 +49063,7 @@ test "gather_nd infers symbolic 2d source shape from coordinate indices" {
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
 
     const data = try allocator.dupe(f32, &.{
         1, 2, 3,
@@ -48969,6 +49091,7 @@ test "concat broadcasts symbolic view tensors across non-axis dims" {
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
 
     const a_raw = try allocator.dupe(f32, &.{ 10, 20 });
     defer allocator.free(a_raw);
@@ -49000,6 +49123,7 @@ test "concat expands stale concrete axis shape from runtime length" {
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
 
     const a_raw = try allocator.dupe(f32, &.{ 1, 2, 3 });
     defer allocator.free(a_raw);
@@ -49024,6 +49148,7 @@ test "transpose materializes source-backed tensors" {
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
 
     const tensor = try tensor_mod.Tensor.initFloat32(allocator, "weight", &.{ 2, 3 }, &.{
         1, 2, 3,
@@ -49048,6 +49173,7 @@ test "exportTensorData rejects source tensors with inconsistent byte length" {
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
     var cb = compute.computeBackend();
 
     const tensor = tensor_mod.Tensor{
@@ -49070,6 +49196,7 @@ test "exportTensorData allows zero-sized source tensors" {
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
     var cb = compute.computeBackend();
 
     const tensor = tensor_mod.Tensor{
@@ -49184,6 +49311,7 @@ test "toFloat32Op returns valid empty temporary tensor data" {
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
 
     const empty = try allocator.alloc(f32, 0);
     const ct = try compute.makeBuf(empty, true);
@@ -49198,6 +49326,7 @@ test "reduce mean materializes source-backed tensors" {
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
 
     const tensor = try tensor_mod.Tensor.initFloat32(allocator, "weight", &.{ 2, 3 }, &.{
         1, 2, 3,
@@ -49218,6 +49347,7 @@ test "gather source-backed 2d table with unshaped vector indices" {
     const allocator = std.testing.allocator;
     var weight_store = WeightStore{ .allocator = allocator, .resident_weights = .{}, .lazy_weights = .{} };
     var compute = NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
 
     const tensor = try tensor_mod.Tensor.initFloat32(allocator, "embedding", &.{ 4, 2 }, &.{
         1, 2,

--- a/zig/pkg/inference/src/ops/native_compute.zig
+++ b/zig/pkg/inference/src/ops/native_compute.zig
@@ -4397,6 +4397,7 @@ pub const vtable_impl = ComputeBackend.VTable{
     .freeTensor = &freeTensor,
     .getIo = &getIo,
     .getWeight = &getWeight,
+    .acquireWeight = &acquireWeight,
     .prefetchWeightHint = &prefetchWeightHint,
     .drainPrefetchBudget = &drainPrefetchBudget,
     .embeddingLookup = &embeddingLookup,
@@ -4783,6 +4784,13 @@ fn getWeight(ctx: *anyopaque, name: []const u8) anyerror!CT {
     toBuf(tensor).weight_handle_refs = 1;
     self.weight_handles.putAssumeCapacityNoClobber(owned_name, tensor);
     return tensor;
+}
+
+fn acquireWeight(ctx: *anyopaque, name: []const u8) anyerror!CT {
+    const self: *NativeCompute = @ptrCast(@alignCast(ctx));
+    const stable_name = self.data.resident_weights.getKey(name) orelse
+        self.data.lazy_weights.getKey(name) orelse name;
+    return loadWeight(self, stable_name);
 }
 
 fn loadWeight(self: *NativeCompute, name: []const u8) !CT {
@@ -34701,7 +34709,8 @@ fn reluOp(ctx: *anyopaque, input: CT) anyerror!CT {
     const self: *NativeCompute = @ptrCast(@alignCast(ctx));
     const output = try self.allocator.dupe(f32, getData(input));
     activations_mod.relu(output);
-    const result = try self.makeBuf(output, true);
+    const result = try self.makeOwnedBuf(output);
+    errdefer freeTensor(ctx, result);
     return propagateLogicalShapeLike(self, result, input);
 }
 
@@ -46053,6 +46062,17 @@ fn testWeightHandleLifetime(allocator: std.mem.Allocator, lazy: bool) !void {
         defer store.prefetch.deinit();
         defer deinitBackend(compute);
         const first = try getWeight(compute, "weight");
+        {
+            const owned = try acquireWeight(compute, "weight");
+            defer freeTensor(compute, owned);
+            const other = try acquireWeight(compute, "weight");
+            defer freeTensor(compute, other);
+            try std.testing.expect(first != owned and owned != other and first != other);
+            try std.testing.expectEqualSlices(f32, getData(first), getData(owned));
+            if (lazy) try std.testing.expectEqual(@as(usize, 3), store.lazy_weights.get("weight").?.pin_count);
+            try std.testing.expectEqual(@as(usize, 3), compute.weight_reservations.get("weight").?.count);
+            try std.testing.expectEqual(@as(?CT, null), try unaryConsumeOp(compute, .relu, owned));
+        }
         const alias = if (!lazy) try aliasDenseBufWithShape(compute, first, &.{4}) else null;
         defer if (alias) |view| freeTensor(compute, view);
         for (0..1000) |_| try std.testing.expectEqual(first, try getWeight(compute, "weight"));

--- a/zig/pkg/inference/src/ops/native_compute.zig
+++ b/zig/pkg/inference/src/ops/native_compute.zig
@@ -791,6 +791,8 @@ const Buf = struct {
     data: []f32,
     allocator: std.mem.Allocator,
     owned: bool,
+    weight_handle_name: ?[]const u8 = null,
+    weight_handle_refs: usize = 0,
     shared_data_refcount: ?*usize = null,
     logical_shape: ?[]i64 = null,
     logical_shape_inline: bool = false,
@@ -947,6 +949,9 @@ fn getData(ct: CT) []f32 {
 
 fn ownedDenseBufWithMaxSharedRefs(ct: CT, max_shared_refs: usize) ?*Buf {
     const buf = toBuf(ct);
+    // Named weights and their views remain immutable even if the dense
+    // conversion itself is allocator-owned and has only one host reference.
+    if (buf.name.len != 0) return null;
     if (!buf.owned or buf.shared_data_refcount == null) return null;
     if (buf.shared_data_refcount.?.* == 0 or buf.shared_data_refcount.?.* > max_shared_refs) return null;
     if (buf.view_strides != null) return null;
@@ -966,9 +971,10 @@ fn aliasDenseBufWithShape(self: *NativeCompute, input: CT, shape: []const i64) !
 
     if (source.owned and source.shared_data_refcount != null) {
         source.shared_data_refcount.?.* += 1;
+        errdefer source.shared_data_refcount.?.* -= 1;
 
         const alias = try self.allocator.create(Buf);
-        errdefer source.shared_data_refcount.?.* -= 1;
+        errdefer self.allocator.destroy(alias);
         alias.* = .{
             .data = source.data,
             .allocator = self.allocator,
@@ -990,6 +996,7 @@ fn aliasDenseBufWithShape(self: *NativeCompute, input: CT, shape: []const i64) !
     }
 
     const alias = try self.allocator.create(Buf);
+    errdefer self.allocator.destroy(alias);
     alias.* = .{
         .data = source.data,
         .allocator = self.allocator,
@@ -3908,6 +3915,7 @@ pub const NativeCompute = struct {
     data: *WeightStore,
     run_budget: ?*run_memory.RunBudget = null,
     weight_reservations: std.StringHashMapUnmanaged(ReservationState) = .empty,
+    weight_handles: std.StringHashMapUnmanaged(CT) = .empty,
     /// Optional Io for parallel GEMM dispatch.  When non-null, sgemm calls
     /// route through linalg's Io-aware variants and parallel work is
     /// scheduled on the runtime's thread pool.  When null, sgemm uses the
@@ -4064,6 +4072,7 @@ pub const NativeCompute = struct {
         source_tensor: ?*const tensor_mod.Tensor,
     ) !CT {
         const b = try self.allocator.create(Buf);
+        errdefer self.allocator.destroy(b);
         var shared_data_refcount: ?*usize = null;
         errdefer if (shared_data_refcount) |refcount| self.allocator.destroy(refcount);
         if (owned) {
@@ -4504,6 +4513,7 @@ fn backendKind(_: *anyopaque) BackendKind {
 
 fn deinitBackend(ctx: *anyopaque) void {
     const self: *NativeCompute = @ptrCast(@alignCast(ctx));
+    deinitWeightHandles(self);
     if (self.run_budget) |run_budget| {
         var it = self.weight_reservations.iterator();
         while (it.next()) |entry| {
@@ -4521,6 +4531,15 @@ fn deinitBackend(ctx: *anyopaque) void {
 fn freeTensor(ctx: *anyopaque, tensor: CT) void {
     const self: *NativeCompute = @ptrCast(@alignCast(ctx));
     const b = toBuf(tensor);
+    const handle_name = b.weight_handle_name;
+    if (handle_name) |name| {
+        std.debug.assert(b.weight_handle_refs > 0);
+        b.weight_handle_refs -= 1;
+        if (b.weight_handle_refs != 0) return;
+        std.debug.assert(self.weight_handles.remove(name));
+        b.weight_handle_name = null;
+    }
+    defer if (handle_name) |name| self.allocator.free(name);
     if (b.lazy_entry) |entry| {
         if (entry.guard) |guard| {
             while (!guard.tryLock()) {
@@ -4735,8 +4754,38 @@ test "native weight handles reserve and release run budget capacity" {
     try std.testing.expectEqual(@as(usize, 0), compute.weight_reservations.count());
 }
 
+fn deinitWeightHandles(self: *NativeCompute) void {
+    var it = self.weight_handles.iterator();
+    while (it.next()) |entry| {
+        toBuf(entry.value_ptr.*).weight_handle_name = null;
+        freeTensor(self, entry.value_ptr.*);
+        self.allocator.free(entry.key_ptr.*);
+    }
+    self.weight_handles.deinit(self.allocator);
+    self.weight_handles = .empty;
+}
+
 fn getWeight(ctx: *anyopaque, name: []const u8) anyerror!CT {
     const self: *NativeCompute = @ptrCast(@alignCast(ctx));
+    if (self.weight_handles.get(name)) |tensor| {
+        toBuf(tensor).weight_handle_refs += 1;
+        return tensor;
+    }
+    try self.weight_handles.ensureUnusedCapacity(self.allocator, 1);
+    const owned_name = try self.allocator.dupe(u8, name);
+    errdefer self.allocator.free(owned_name);
+    // Views copy Buf.name without retaining the handle. Use the model-store
+    // key, whose lifetime also covers views after an early handle release.
+    const stable_name = self.data.resident_weights.getKey(name) orelse
+        self.data.lazy_weights.getKey(name) orelse name;
+    const tensor = try loadWeight(self, stable_name);
+    toBuf(tensor).weight_handle_name = owned_name;
+    toBuf(tensor).weight_handle_refs = 1;
+    self.weight_handles.putAssumeCapacityNoClobber(owned_name, tensor);
+    return tensor;
+}
+
+fn loadWeight(self: *NativeCompute, name: []const u8) !CT {
     if (self.data.resident_weights.getPtr(name)) |w| {
         if (w.quantized_storage) |*storage| {
             try ensurePreparedKBlock(self, storage, null);
@@ -45973,6 +46022,75 @@ test "embeddingLookup dequantizes quantized GGUF rows" {
     }
 }
 
+fn testWeightHandleLifetime(allocator: std.mem.Allocator, lazy: bool) !void {
+    var bytes = [_]u8{ 0x80, 0x3f, 0x20, 0xc0, 0x00, 0x3f, 0x40, 0x40 };
+    var shape = [_]i64{ 2, 2 };
+    const weight = LoadedWeight{ .tensor = .{
+        .data = &bytes,
+        .shape = &shape,
+        .dtype = .bf16,
+        .name = "weight",
+        .allocator = allocator,
+        .owns_data = false,
+        .owns_shape = false,
+    } };
+    var store = WeightStore{ .allocator = allocator, .resident_weights = .empty, .lazy_weights = .empty };
+    defer store.resident_weights.deinit(allocator);
+    defer store.lazy_weights.deinit(allocator);
+    if (lazy) {
+        try store.lazy_weights.put(allocator, "weight", .{
+            .tensor_ref = .{ .name = "weight" },
+            .loaded = weight,
+            .loaded_bytes = bytes.len,
+        });
+    } else {
+        try store.resident_weights.put(allocator, "weight", weight);
+    }
+    var budget = run_memory.RunBudget.init(.{ .host_limit_bytes = 64 });
+    {
+        const compute = try allocator.create(NativeCompute);
+        compute.* = NativeCompute.init(allocator, &store, &budget);
+        defer store.prefetch.deinit();
+        defer deinitBackend(compute);
+        const first = try getWeight(compute, "weight");
+        const alias = if (!lazy) try aliasDenseBufWithShape(compute, first, &.{4}) else null;
+        defer if (alias) |view| freeTensor(compute, view);
+        for (0..1000) |_| try std.testing.expectEqual(first, try getWeight(compute, "weight"));
+        try std.testing.expectEqual(@as(usize, 1), compute.weight_handles.count());
+        try std.testing.expectEqual(@as(usize, 1), compute.weight_reservations.count());
+        if (lazy) try std.testing.expectEqual(@as(usize, 1), store.lazy_weights.get("weight").?.pin_count);
+        try std.testing.expectEqualSlices(f32, &.{ 1, -2.5, 0.5, 3 }, getData(first));
+        try std.testing.expectEqual(@as(?CT, null), try unaryConsumeOp(compute, .relu, first));
+        // Releasing one caller must not invalidate the other borrowers.
+        for (0..1000) |_| freeTensor(compute, first);
+        try std.testing.expectEqualSlices(f32, &.{ 1, -2.5, 0.5, 3 }, getData(first));
+        freeTensor(compute, first);
+        if (alias) |view| {
+            try std.testing.expectEqualSlices(f32, &.{ 1, -2.5, 0.5, 3 }, getData(view));
+            try std.testing.expectEqualStrings("weight", toBuf(view).name);
+            try std.testing.expectEqual(@as(?CT, null), try unaryConsumeOp(compute, .relu, view));
+        }
+        try std.testing.expectEqual(@as(usize, 0), compute.weight_handles.count());
+        try std.testing.expectEqual(@as(usize, 0), budget.host_weight_bytes);
+        if (lazy) try std.testing.expectEqual(@as(usize, 0), store.lazy_weights.get("weight").?.pin_count);
+        // Florence-style callers leave their lookups to backend teardown.
+        _ = try getWeight(compute, "weight");
+        _ = try getWeight(compute, "weight");
+    }
+    try std.testing.expectEqual(@as(usize, 0), budget.host_weight_bytes);
+    if (lazy) try std.testing.expectEqual(@as(usize, 0), store.lazy_weights.get("weight").?.pin_count);
+}
+
+test "native weight handle lifetime is bounded and releases reservations and lazy pins" {
+    try testWeightHandleLifetime(std.testing.allocator, false);
+    try testWeightHandleLifetime(std.testing.allocator, true);
+}
+
+test "native weight handle lifetime unwinds allocation failures" {
+    try std.testing.checkAllAllocationFailures(std.testing.allocator, testWeightHandleLifetime, .{false});
+    try std.testing.checkAllAllocationFailures(std.testing.allocator, testWeightHandleLifetime, .{true});
+}
+
 test "getWeight preserves resident dense tensor shape metadata" {
     const allocator = std.testing.allocator;
 
@@ -46017,6 +46135,7 @@ test "getWeight preserves resident dense tensor shape metadata" {
     var run_budget = run_memory.RunBudget.init(.{ .host_limit_bytes = 1024 });
     var compute = NativeCompute.init(allocator, &weight_store, &run_budget);
     defer compute.weight_reservations.deinit(allocator);
+    defer deinitWeightHandles(&compute);
     const cb = compute.computeBackend();
 
     const weight = try cb.getWeight(name);

--- a/zig/pkg/inference/src/ops/ops.zig
+++ b/zig/pkg/inference/src/ops/ops.zig
@@ -1511,6 +1511,11 @@ pub const ComputeBackend = struct {
         /// but must not consume/mutate the weight or use that reference afterward.
         /// CUDA may retain resident handles until backend teardown regardless.
         getWeight: *const fn (ctx: *anyopaque, name: []const u8) anyerror!CT,
+        /// Acquire a distinct, caller-owned handle to an immutable weight.
+        /// Unlike getWeight, handle identity is never shared with another live
+        /// acquisition. Free exactly once; the backend must outlive the handle.
+        /// Storage may still be borrowed from the model or backend cache.
+        acquireWeight: *const fn (ctx: *anyopaque, name: []const u8) anyerror!CT,
         prefetchWeightHint: *const fn (ctx: *anyopaque, name: []const u8, hint: u32) void,
         drainPrefetchBudget: *const fn (ctx: *anyopaque, max_items: usize) void,
         debugProfileCheckpoint: ?*const fn (ctx: *anyopaque, label: []const u8, layer: usize) void = null,
@@ -2714,6 +2719,11 @@ pub const ComputeBackend = struct {
     pub fn getWeight(self: *const ComputeBackend, name: []const u8) !CT {
         try self.checkExecutionControl();
         return self.vtable.getWeight(self.ptr, name);
+    }
+
+    pub fn acquireWeight(self: *const ComputeBackend, name: []const u8) !CT {
+        try self.checkExecutionControl();
+        return self.vtable.acquireWeight(self.ptr, name);
     }
 
     pub fn prefetchWeight(self: *const ComputeBackend, name: []const u8) void {

--- a/zig/pkg/inference/src/ops/ops.zig
+++ b/zig/pkg/inference/src/ops/ops.zig
@@ -1505,7 +1505,11 @@ pub const ComputeBackend = struct {
         debugCudaGraphCaptureEnd: ?*const fn (ctx: *anyopaque, replay: bool) anyerror!void = null,
         debugCudaDeviceWarmup: ?*const fn (ctx: *anyopaque, bytes: usize, iterations: usize) anyerror!bool = null,
 
-        /// Look up a named weight tensor. Returned tensor is borrowed (do NOT free).
+        /// Look up an immutable, backend-owned weight tensor. Repeated lookups
+        /// share a handle; unreleased handles are reclaimed at backend teardown.
+        /// A caller may release its lookup early with free (once per lookup),
+        /// but must not consume/mutate the weight or use that reference afterward.
+        /// CUDA may retain resident handles until backend teardown regardless.
         getWeight: *const fn (ctx: *anyopaque, name: []const u8) anyerror!CT,
         prefetchWeightHint: *const fn (ctx: *anyopaque, name: []const u8, hint: u32) void,
         drainPrefetchBudget: *const fn (ctx: *anyopaque, max_items: usize) void,

--- a/zig/pkg/inference/src/ops/wasm_compute.zig
+++ b/zig/pkg/inference/src/ops/wasm_compute.zig
@@ -137,6 +137,9 @@ const WEBGPU_ATTN_MAX_SEQ: usize = 512;
 const WEBGPU_CACHED_ATTN_MAX_KV: usize = 2048;
 
 const WasmBuf = struct {
+    // An acquired weight has independent handle identity but resolves to the
+    // model-owned buffer, including its GPU residency and host materialization.
+    weight_source: ?*WasmBuf = null,
     data: []f32,
     len: usize, // logical element count
     owned: bool,
@@ -543,7 +546,8 @@ fn quantFormatFromTensorType(tensor_type: tensor_types.TensorType) ?quant_matmul
 }
 
 fn toBuf(ct: CT) *WasmBuf {
-    return @ptrCast(@alignCast(ct));
+    const buf: *WasmBuf = @ptrCast(@alignCast(ct));
+    return buf.weight_source orelse buf;
 }
 
 fn fromBuf(buf: *WasmBuf) CT {
@@ -967,9 +971,27 @@ pub const WasmCompute = struct {
         return fromBuf(buf);
     }
 
+    fn acquireWeightOp(ctx: *anyopaque, name: []const u8) anyerror!CT {
+        const self: *WasmCompute = @ptrCast(@alignCast(ctx));
+        const source = toBuf(try getWeightOp(ctx, name));
+        const handle = try self.allocator.create(WasmBuf);
+        handle.* = .{
+            .data = &.{},
+            .len = source.len,
+            .owned = false,
+            .allocator = self.allocator,
+            .weight_source = source,
+        };
+        return fromBuf(handle);
+    }
+
     fn freeTensorOp(ctx: *anyopaque, tensor: CT) void {
         _ = ctx;
-        const buf = toBuf(tensor);
+        const buf: *WasmBuf = @ptrCast(@alignCast(tensor));
+        if (buf.weight_source != null) {
+            buf.allocator.destroy(buf);
+            return;
+        }
         // Don't free weight tensors (not owned)
         if (buf.owned) {
             buf.deinit();
@@ -1860,12 +1882,13 @@ pub const WasmCompute = struct {
         _ = request.dim;
         return switch (request.kind) {
             .gelu, .gelu_new => try geluOp(ctx, request.input),
+            .gelu_exact => try geluExactOp(ctx, request.input),
             .silu => try siluOp(ctx, request.input),
             .relu => try reluOp(ctx, request.input),
             .quick_gelu => try quickGeluOp(ctx, request.input),
             .relu_squared => blk: {
                 const relu = try reluOp(ctx, request.input);
-                errdefer freeTensorOp(ctx, relu);
+                defer freeTensorOp(ctx, relu);
                 break :blk try multiplyOp(ctx, relu, relu);
             },
         };
@@ -4993,6 +5016,7 @@ pub const WasmCompute = struct {
         .freeTensor = freeTensorOp,
         .reserveGraphPlanSlots = reserveGraphPlanSlotsOp,
         .getWeight = getWeightOp,
+        .acquireWeight = acquireWeightOp,
         .prefetchWeightHint = noopPrefetch,
         .drainPrefetchBudget = noopDrain,
         .embeddingLookup = embeddingLookupOp,
@@ -5111,10 +5135,30 @@ test {
     _ = @import("wasm_e2e_test.zig");
 }
 
+test "wasm_compute: acquired weights preserve independent identity and shared residency" {
+    const allocator = std.testing.allocator;
+    var compute = WasmCompute.init(allocator);
+    const cb = compute.computeBackend();
+    defer cb.deinit();
+    var data = [_]f32{ 1, -2 };
+    compute.registerWeight("weight", &data);
+    const borrowed = try cb.getWeight("weight");
+    const first = try cb.acquireWeight("weight");
+    const second = try cb.acquireWeight("weight");
+    defer cb.free(second);
+    try std.testing.expect(first != second and first != borrowed and second != borrowed);
+    try std.testing.expectEqual(toBuf(borrowed), toBuf(second));
+    cb.free(first);
+    cb.free(borrowed);
+    const values = try cb.toFloat32(second, allocator);
+    defer allocator.free(values);
+    try std.testing.expectEqualSlices(f32, &data, values);
+}
+
 test "wasm compute graph plan reservation reports unavailable without webgpu" {
     const allocator = std.testing.allocator;
     var compute = WasmCompute.init(allocator);
-    defer compute.deinitBackendOp(&compute);
+    defer WasmCompute.deinitBackendOp(&compute);
     var cb = compute.computeBackend();
 
     const reserved = try cb.reserveGraphPlanSlots(&.{.{ .slot = 0, .bytes = 4096 }});
@@ -5169,7 +5213,7 @@ test "wasm_compute: runAttention includes attention sink probability mass" {
 test "wasm_compute: cached attention includes attention sink probability mass" {
     const allocator = std.testing.allocator;
     var compute = WasmCompute.init(allocator);
-    defer compute.deinitBackendOp(&compute);
+    defer WasmCompute.deinitBackendOp(&compute);
 
     var q_data = [_]f32{0.0};
     var k_data = [_]f32{ 0.0, 0.0, 0.0 };

--- a/zig/pkg/inference/src/pipelines/embedding.zig
+++ b/zig/pkg/inference/src/pipelines/embedding.zig
@@ -2717,6 +2717,7 @@ test "resident masked mean pooling uses backend primitives" {
         native_mod.deinitPrefetchQueue(&weight_store);
     }
     var compute = native_mod.NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
     var cb = compute.computeBackend();
 
     const values = [_]f32{
@@ -2758,6 +2759,7 @@ test "resident text pooling handles flattened batch sequence hidden states" {
         native_mod.deinitPrefetchQueue(&weight_store);
     }
     var compute = native_mod.NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
     var cb = compute.computeBackend();
 
     const values = [_]f32{
@@ -2937,6 +2939,7 @@ test "resident projected input selection supports 3d cls pooling" {
         native_mod.deinitPrefetchQueue(&weight_store);
     }
     var compute = native_mod.NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
     var cb = compute.computeBackend();
 
     const values = [_]f32{
@@ -2991,6 +2994,7 @@ test "resident 2d embedding extraction normalizes before host readback" {
         native_mod.deinitPrefetchQueue(&weight_store);
     }
     var compute = native_mod.NativeCompute.init(allocator, &weight_store, null);
+    defer compute.deinit();
     var cb = compute.computeBackend();
 
     const values = [_]f32{ 3.0, 4.0, 0.0, 0.0 };


### PR DESCRIPTION
## Summary

Fix two confirmed inference ownership leaks behind sustained Florence OCR memory growth, without increasing process budgets or relaxing live-memory admission.

- Intern one live weight handle per name in Native and Metal. Repeated decoder lookups reuse the same handle/materialization; backend teardown reclaims outstanding borrowers.
- Separate caller-owned graph parameter acquisition (`acquireWeight`) from shared eager lookups (`getWeight`). Independent parameter nodes receive distinct handles in Native, Metal, CUDA, and WASM; graph liveness cannot invalidate a still-live sibling. Release graph capture/output state on error, and cover allocation-failure cleanup.
- Preserve early release for existing graph/architecture callers: each lookup can be released once, and the last release retires its handle. Native run-budget reservations and lazy pins remain balanced. CUDA's existing resident, borrowed handles are unchanged.
- Make Metal dense-cache ownership explicit: views do not own cached native bytes; cached backing storage retains its source pin until cache teardown. Unwind allocation failures without orphaned pins, partial map entries, or double frees.
- Retain Metal dense source metadata for CPU fallback independently of pin ownership. Guard Metal-only allocation-failure tests at compile time so Metal-disabled/Linux builds compile.
- Keep named weights immutable on consume paths, retain valid names for Native views, and fix allocation-failure cleanup for handle/view construction.
- Add an explicitly owning Metal backend handle for the session factory. The previous factory allocated a roughly 320 KiB context per read, but the vtable only deinitialized its contents. Stack/external owners, including imported ONNX sessions, keep their existing ownership contract.

## Validation

Based on latest fetched `origin/main` (`74739739f2317ffe11b96f89db97366ce0a853ec`).

- Debug: `zig build test -Dcuda=true -j1 -- 'ops.native_compute' 'ops.metal_compute' 'graph.interpreter' 'graph.tracing_compute' 'architectures.florence' 'pipelines.reading' 'CUDA acquired weight'` from `zig/pkg/inference`: **427 passed, zero skipped** with Metal device access. CUDA coverage here is a driver-free ownership regression, not a CUDA device qualification.
- Metal-disabled Debug: `zig build test -Dmetal=false -j1 -- 'weight handle lifetime' 'graph weight acquisition'`: **3 selected, 3 passed**, including exhaustive allocation failures.
- New tests cover repeated lookups, interleaved releases, dense materialization reuse, surviving views, teardown, reservations, lazy pins, exhaustive allocation failures, cached-byte ownership, and owned Metal contexts.
- ReleaseFast + Metal CLI build passed; formatting and `git diff --check` passed.
- Real Florence model, actual rendered AES PDF page, Metal, 128-token OCR: one warmup plus ten completed measured reads on each of main and the original fix, repeated after `f4e62c965`. All iterations consistent; **byte-identical OCR text and matching decoder telemetry** between builds. This is an output check, not a controlled throughput benchmark.
- Repeated-read heap probe with `MallocStackLogging`, using the same model/page/options. Three live malloc snapshots approximately 10/30/50 seconds into each process:

| Build | First sample | Second sample | Third sample |
| --- | ---: | ---: | ---: |
| main | 315 MiB | 858 MiB | 1,505 MiB |
| original fix (`127c92696`) | 89 MiB | 91 MiB | 72 MiB |
| review fixes (`f4e62c965`) | 93 MiB | 91 MiB | 73 MiB |

The original 212,992-byte bias materialization accumulated 4,749 live copies in the baseline; the fix retains at most one for the active weight handle in the sampled decoding phases. The per-read heap context remains one live allocation instead of accumulating across reads.

Original fixed ReleaseFast binary SHA-256: `0fea2bf2d1e03bbdee4adb29319d033eb7a93ba46cd0ca1b64ba07ba96a7fa0d`. Review-fix binary: `d56f2e7b94343f00f1e3917bbd9198065c1a8c487340309a0a4127719890e7c5`.

## Qualification limits

This isolates and fixes the demonstrated Antfly-owned leaks; it does **not** qualify full-PDF or uninterrupted full-corpus OHR ingestion. The heap snapshots sample different phases, not synchronized idle checkpoints. Smaller AGX Metal-driver context allocations still grow during the probe (about 1.2 to 5.8 MB); their remaining retention has not been attributed or fixed here. Do not interpret these results as proof of zero long-run process growth or a completed native-PDF benchmark. No admission-policy or memory-budget workaround is included.

Raw models, benchmark inputs, heap profiles, and operational investigation notes remain outside the repository. Only implementation and regression tests are committed.
