### PR TITLE
fix: bound chunk overlap and preserve generation capacity errors

### DIFF
--- a/zig/lib/chunker/src/fixed_text.zig
+++ b/zig/lib/chunker/src/fixed_text.zig
@@ -55,7 +55,7 @@ pub fn chunkText(alloc: Allocator, text: []const u8, cfg: types.FixedTextConfig)
     for (sections) |section| {
         const section_tokens = try countTokens(alloc, tokenizer, section.text);
         // Count the actual source span, including separators between sections.
-        const candidate_tokens = if (current.items.len > 0)
+        var candidate_tokens = if (current.items.len > 0)
             try countTokens(alloc, tokenizer, text[current.items[0].start .. section.start + section.text.len])
         else
             section_tokens;
@@ -67,22 +67,22 @@ pub fn chunkText(alloc: Allocator, text: []const u8, cfg: types.FixedTextConfig)
 
             previous_text = chunks.items[chunks.items.len - 1].text.?;
             current.clearRetainingCapacity();
-            current_tokens = 0;
+            candidate_tokens = section_tokens;
 
             if (overlap_tokens > 0 and previous_text.len > 0) {
                 // A full-size next section leaves no room for overlap.
                 const overlap_budget = @min(overlap_tokens, target_tokens -| section_tokens);
                 const overlap_start = try computeOverlapStart(alloc, tokenizer, previous_text, overlap_budget);
                 const overlap_text = previous_text[overlap_start..];
-                if (overlap_text.len > 0 and
-                    try countTokens(alloc, tokenizer, text[previous_start + overlap_start .. section.start + section.text.len]) <= target_tokens)
-                {
-                    try current.append(alloc, .{
-                        .text = overlap_text,
-                        .start = previous_start + overlap_start,
-                        .tokens = try countTokens(alloc, tokenizer, overlap_text),
-                    });
-                    current_tokens = current.items[0].tokens;
+                if (overlap_text.len > 0) {
+                    const overlap_candidate_tokens = try countTokens(alloc, tokenizer, text[previous_start + overlap_start .. section.start + section.text.len]);
+                    if (overlap_candidate_tokens <= target_tokens) {
+                        try current.append(alloc, .{
+                            .text = overlap_text,
+                            .start = previous_start + overlap_start,
+                        });
+                        candidate_tokens = overlap_candidate_tokens;
+                    }
                 }
             }
         }
@@ -92,7 +92,7 @@ pub fn chunkText(alloc: Allocator, text: []const u8, cfg: types.FixedTextConfig)
             .start = section.start,
             .tokens = section_tokens,
         });
-        current_tokens = try countTokens(alloc, tokenizer, text[current.items[0].start .. section.start + section.text.len]);
+        current_tokens = candidate_tokens;
     }
 
     if (current.items.len > 0 and chunks.items.len < max_chunks) {

--- a/zig/lib/chunker/src/fixed_text.zig
+++ b/zig/lib/chunker/src/fixed_text.zig
@@ -54,7 +54,12 @@ pub fn chunkText(alloc: Allocator, text: []const u8, cfg: types.FixedTextConfig)
 
     for (sections) |section| {
         const section_tokens = try countTokens(alloc, tokenizer, section.text);
-        if (current_tokens > 0 and current_tokens + section_tokens > target_tokens) {
+        // Count the actual source span, including separators between sections.
+        const candidate_tokens = if (current.items.len > 0)
+            try countTokens(alloc, tokenizer, text[current.items[0].start .. section.start + section.text.len])
+        else
+            section_tokens;
+        if (current_tokens > 0 and candidate_tokens > target_tokens) {
             try chunks.append(alloc, buildChunk(text, current.items, chunk_id));
             previous_start = current.items[0].start;
             chunk_id += 1;
@@ -65,9 +70,13 @@ pub fn chunkText(alloc: Allocator, text: []const u8, cfg: types.FixedTextConfig)
             current_tokens = 0;
 
             if (overlap_tokens > 0 and previous_text.len > 0) {
-                const overlap_start = computeOverlapStart(alloc, tokenizer, previous_text, overlap_tokens);
+                // A full-size next section leaves no room for overlap.
+                const overlap_budget = @min(overlap_tokens, target_tokens -| section_tokens);
+                const overlap_start = try computeOverlapStart(alloc, tokenizer, previous_text, overlap_budget);
                 const overlap_text = previous_text[overlap_start..];
-                if (overlap_text.len > 0) {
+                if (overlap_text.len > 0 and
+                    try countTokens(alloc, tokenizer, text[previous_start + overlap_start .. section.start + section.text.len]) <= target_tokens)
+                {
                     try current.append(alloc, .{
                         .text = overlap_text,
                         .start = previous_start + overlap_start,
@@ -83,7 +92,7 @@ pub fn chunkText(alloc: Allocator, text: []const u8, cfg: types.FixedTextConfig)
             .start = section.start,
             .tokens = section_tokens,
         });
-        current_tokens += section_tokens;
+        current_tokens = try countTokens(alloc, tokenizer, text[current.items[0].start .. section.start + section.text.len]);
     }
 
     if (current.items.len > 0 and chunks.items.len < max_chunks) {
@@ -303,13 +312,23 @@ fn countTokens(alloc: Allocator, tokenizer: *HfTokenizer, text: []const u8) !usi
     return ids.len;
 }
 
-fn computeOverlapStart(alloc: Allocator, tokenizer: *HfTokenizer, text: []const u8, overlap_tokens: usize) usize {
-    const ids = tokenizer.tokenizer().encode(alloc, text) catch return 0;
-    defer alloc.free(ids);
-    if (ids.len <= overlap_tokens) return 0;
-    const overlap_text = tokenizer.tokenizer().decode(alloc, ids[ids.len - overlap_tokens ..]) catch return 0;
-    defer alloc.free(overlap_text);
-    return std.mem.lastIndexOf(u8, text, overlap_text) orelse 0;
+fn computeOverlapStart(alloc: Allocator, tokenizer: *HfTokenizer, text: []const u8, overlap_tokens: usize) !usize {
+    if (overlap_tokens == 0) return text.len;
+    // Decoded tokens are normalized text, not a searchable source substring.
+    // If offsets are unavailable, omit overlap rather than retaining a prefix.
+    var encoded = (try tokenizer.encodeWithOffsets(alloc, text)) orelse return text.len;
+    defer encoded.deinit(alloc);
+    if (encoded.ids.items.len != encoded.offsets.items.len) return text.len;
+    const first = encoded.ids.items.len -| overlap_tokens;
+    for (encoded.offsets.items[first..]) |offset| {
+        const start: usize = offset[0];
+        if (start >= text.len or start > offset[1] or offset[1] > text.len) return text.len;
+        if (previousUtf8Boundary(text, start) != start) continue;
+        // Starting inside a word can change its tokenization. Only keep a
+        // suffix that fits the overlap budget when encoded independently.
+        if (try countTokens(alloc, tokenizer, text[start..]) <= overlap_tokens) return start;
+    }
+    return text.len;
 }
 
 test "fixed text chunker splits by token target" {
@@ -350,4 +369,50 @@ test "decoded token window fallback clamps to source bounds" {
     const end = fallbackWindowEnd("abc", 1, 1, 2);
     try std.testing.expect(end <= 3);
     try std.testing.expect(end > 1);
+}
+
+test "fixed text overlap preserves source offsets despite normalization" {
+    const alloc = std.testing.allocator;
+    var tokenizer = try HfTokenizer.loadFromBytes(alloc, tokenizer_json);
+    defer tokenizer.deinitSelf();
+    const text = "alpha beta gamma HELLO, WORLD!";
+    const start = try computeOverlapStart(alloc, tokenizer, text, 4);
+    try std.testing.expectEqualStrings("HELLO, WORLD!", text[start..]);
+    try std.testing.expectEqual(text.len, try computeOverlapStart(alloc, tokenizer, text, 0));
+    try std.testing.expectEqual(@as(usize, 0), try computeOverlapStart(alloc, tokenizer, text, 100));
+}
+
+test "fixed text overlap advances bounded chunks through mixed source text" {
+    const alloc = std.testing.allocator;
+    var tokenizer = try HfTokenizer.loadFromBytes(alloc, tokenizer_json);
+    defer tokenizer.deinitSelf();
+    const paragraph = "Korean HISTORY: Major Events (1950–1953), Seoul! Café, 日本語. Repeated WORDS; punctuation changes.\n\n";
+    const text = paragraph ** 80;
+    const chunks = try chunkText(alloc, text, .{ .target_tokens = 200, .overlap_tokens = 25, .max_chunks = 200 });
+    defer alloc.free(chunks);
+    try std.testing.expect(chunks.len > 1 and chunks.len < 200);
+    for (chunks, 0..) |chunk, i| {
+        const start = chunk.start_char.?;
+        const end = chunk.end_char.?;
+        try std.testing.expectEqualStrings(text[start..end], chunk.text.?);
+        try std.testing.expect(std.unicode.utf8ValidateSlice(chunk.text.?));
+        try std.testing.expect(try countTokens(alloc, tokenizer, chunk.text.?) <= 200);
+        if (i > 0) {
+            try std.testing.expect(start > chunks[i - 1].start_char.?);
+            try std.testing.expect(end > chunks[i - 1].end_char.?);
+        }
+    }
+    try std.testing.expect(chunks[chunks.len - 1].end_char.? >= std.mem.trimEnd(u8, text, "\n").len);
+}
+
+test "fixed text overlap leaves room for full sections and counts separators" {
+    const alloc = std.testing.allocator;
+    var tokenizer = try HfTokenizer.loadFromBytes(alloc, tokenizer_json);
+    defer tokenizer.deinitSelf();
+    for ([_][]const u8{ "alpha beta gamma delta\n\nepsilon zeta eta theta", "alpha,beta,gamma,delta,epsilon,zeta,eta,theta" }) |text| {
+        const chunks = try chunkText(alloc, text, .{ .target_tokens = 4, .overlap_tokens = 2, .separator = "," });
+        defer alloc.free(chunks);
+        for (chunks) |chunk| try std.testing.expect(try countTokens(alloc, tokenizer, chunk.text.?) <= 4);
+        try std.testing.expectEqual(text.len, chunks[chunks.len - 1].end_char.?);
+    }
 }

--- a/zig/pkg/antfly/src/api/http_server.zig
+++ b/zig/pkg/antfly/src/api/http_server.zig
@@ -6408,6 +6408,7 @@ pub const ApiHttpServer = struct {
             error.AgentContextLimitExceeded => try contextual_operations.jsonErrorAlloc(self.alloc, 413, "query planning context limit exceeded"),
             error.UnsupportedAgentToolProvider, error.UnsupportedQueryBuilderGeneration => try contextual_operations.jsonErrorAlloc(self.alloc, 400, "query planning requires a tool-capable generator"),
             error.GenerateRequestFailed => try contextual_operations.jsonErrorAlloc(self.alloc, 502, "query generation failed"),
+            error.GenerationCapacityUnavailable => try contextualRetryableTextResponse(self.alloc, 503, "inference capacity temporarily unavailable"),
             error.EmptyResponse => try contextual_operations.jsonErrorAlloc(self.alloc, 502, "generator returned no answer or tool calls"),
             error.DocIdentityNamespaceMismatch => try contextual_operations.jsonErrorAlloc(self.alloc, 503, "doc identity unavailable"),
             error.QueryEmbeddingInputTooLarge => try contextual_operations.jsonErrorAlloc(self.alloc, 413, "query embedding input too large"),

--- a/zig/pkg/antfly/src/api/httpx_handler.zig
+++ b/zig/pkg/antfly/src/api/httpx_handler.zig
@@ -4807,6 +4807,10 @@ pub const AntflyApiHandler = struct {
                 error.UnsupportedAgentToolProvider => return jsonErrorResponse(ctx, 400, "agent tools require an Antfly or OpenAI tool-capable generator"),
                 error.GenerateRequestFailed, error.EmptyResponse => return jsonErrorResponse(ctx, 502, "agent generation failed"),
                 error.RateLimit => return jsonErrorResponse(ctx, 429, "agent generation rate limited"),
+                error.GenerationCapacityUnavailable => {
+                    try ctx.setHeader("Retry-After", "1");
+                    return ctx.status(503).json(.{ .@"error" = "GenerationCapacityUnavailable", .retryable = true, .reason = "inference_capacity" });
+                },
                 error.TableNotFound => {
                     _ = ctx.status(404);
                     return ctx.text("not found");

--- a/zig/pkg/antfly/src/api/retrieval_agent.zig
+++ b/zig/pkg/antfly/src/api/retrieval_agent.zig
@@ -588,12 +588,20 @@ fn failAgentResult(
     kind: enum { retrieval, generation },
 ) !EncodedResponse {
     if (format == .json) return err;
+    if (err == error.GenerationCapacityUnavailable) {
+        const payload = .{ .@"error" = "GenerationCapacityUnavailable", .retryable = true, .reason = "inference_capacity" };
+        try live.emitValue("error", payload);
+        return .{
+            .content_type = "text/event-stream",
+            .body = if (live.sink != null) try alloc.dupe(u8, "") else try encodeSseError(alloc, payload),
+        };
+    }
     // Generation callbacks may originate in a separately compiled runtime.
     const name = if (kind == .generation) "GenerationFailed" else @errorName(err);
     try live.emitValue("error", .{ .@"error" = name });
     return .{
         .content_type = "text/event-stream",
-        .body = if (live.sink != null) try alloc.dupe(u8, "") else try encodeSseError(alloc, name),
+        .body = if (live.sink != null) try alloc.dupe(u8, "") else try encodeSseError(alloc, .{ .@"error" = name }),
     };
 }
 
@@ -5884,11 +5892,11 @@ fn stepProgressPhase(
 
 fn encodeSseError(
     alloc: std.mem.Allocator,
-    message: []const u8,
+    payload: anytype,
 ) ![]u8 {
     var out = std.ArrayListUnmanaged(u8).empty;
     defer out.deinit(alloc);
-    try appendSseEventValue(alloc, &out, "error", .{ .@"error" = message });
+    try appendSseEventValue(alloc, &out, "error", payload);
     return try out.toOwnedSlice(alloc);
 }
 
@@ -9774,6 +9782,66 @@ test "retrieval agent sse uses a stable generation failure name" {
         "{\"error\":\"GenerationFailed\"}",
         firstSseEventData(events, "error").?,
     );
+}
+
+test "retrieval agent sse preserves retryable inference capacity" {
+    const FakeRunner = struct {
+        fn iface() QueryRunner {
+            return .{
+                .ptr = undefined,
+                .vtable = &.{ .run_query = runQuery },
+            };
+        }
+
+        fn runQuery(_: *anyopaque, alloc: std.mem.Allocator, _: []const u8, _: []const u8) !query_api.QueryResponse {
+            return .{
+                .json = try alloc.dupe(u8,
+                    \\{"responses":[{"status":200,"took":1,"hits":{"hits":[{"_id":"doc:a","_score":1.0,"_source":{"content":"alpha body"}}]}}]}
+                ),
+            };
+        }
+    };
+
+    const FailingGeneration = struct {
+        fn iface() GenerationRunner {
+            return .{
+                .ptr = undefined,
+                .vtable = &.{ .execute_chain = executeChain },
+            };
+        }
+
+        fn executeChain(_: *anyopaque, _: std.mem.Allocator, _: []const generating.ChainLink, _: []const generating.ChatMessage) !generating.GenerateResult {
+            return error.GenerationCapacityUnavailable;
+        }
+    };
+
+    const body =
+        \\{"query":"find alpha","stream":true,"generator":{"provider":"antfly","model":"local-generator"},"steps":{"generation":{"enabled":true}},"queries":[{"table":"docs","full_text_search":{"query":"body:alpha"},"limit":5}]}
+    ;
+    const encoded = try execute(std.testing.allocator, FakeRunner.iface(), FailingGeneration.iface(), body);
+    defer std.testing.allocator.free(encoded.body);
+    const events = try parseSseEventsAlloc(std.testing.allocator, encoded.body);
+    defer std.testing.allocator.free(events);
+
+    try std.testing.expectEqualStrings("text/event-stream", encoded.content_type);
+    try std.testing.expectEqual(@as(usize, 0), countSseEvents(events, "done"));
+    try std.testing.expectEqualStrings(
+        "{\"error\":\"GenerationCapacityUnavailable\",\"retryable\":true,\"reason\":\"inference_capacity\"}",
+        firstSseEventData(events, "error").?,
+    );
+
+    var transcript = SseTranscript{};
+    defer transcript.bytes.deinit(std.testing.allocator);
+    const streamed = try executeWithEventSink(std.testing.allocator, FakeRunner.iface(), FailingGeneration.iface(), body, .{
+        .ptr = &transcript,
+        .emit_json_fn = SseTranscript.emit,
+    });
+    defer std.testing.allocator.free(streamed.body);
+    try std.testing.expectEqual(@as(usize, 0), streamed.body.len);
+    const live_events = try parseSseEventsAlloc(std.testing.allocator, transcript.bytes.items);
+    defer std.testing.allocator.free(live_events);
+    try std.testing.expectEqual(@as(usize, 0), countSseEvents(live_events, "done"));
+    try std.testing.expectEqualStrings(firstSseEventData(events, "error").?, firstSseEventData(live_events, "error").?);
 }
 
 test "retrieval agent sse emits followup events" {

--- a/zig/pkg/antfly/src/inference/local.zig
+++ b/zig/pkg/antfly/src/inference/local.zig
@@ -402,7 +402,7 @@ pub const Provider = struct {
                 null,
         });
         defer resp.deinit();
-        if (!resp.ok()) return if (resp.status.code == 429) error.RateLimit else error.GenerateRequestFailed;
+        if (!resp.ok()) return inference.localGenerationStatusError(alloc, resp.status.code, resp.body);
         const body = resp.body orelse return error.EmptyResponse;
         return parseGenerationResponse(alloc, body, self.tools_json, self.tool_choice_json);
     }
@@ -630,6 +630,39 @@ test "antfly embed parts preserves binary base64 until request serialization" {
         return error.TestUnexpectedResult;
     }
     try std.testing.expectEqual(@as(usize, 3), result_dim);
+}
+
+test "generating backend local HTTP preserves retryable capacity" {
+    const alloc = std.testing.allocator;
+    var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
+    defer io_impl.deinit();
+    const io = io_impl.io();
+    var server = try httpx.TestServer.start(alloc, io, &.{.{ .method = .POST, .path = "/generate", .respond = .{
+        .status = 503,
+        .body = "{\"error\":\"MODEL_RESOURCE_BUSY\",\"retryable\":true,\"reason\":\"inference_capacity\",\"retry_after_ms\":1000}",
+    } }});
+    defer server.deinit();
+    var result_error: anyerror = error.TestUnexpectedResult;
+    var group = std.Io.Group.init;
+    defer group.cancel(io);
+    const Call = struct {
+        fn run(a: std.mem.Allocator, test_io: std.Io, url: []const u8, result: *anyerror) std.Io.Cancelable!void {
+            var client = httpx.Client.initWithConfig(a, test_io, .{ .keep_alive = false, .retry_policy = .{ .max_retries = 0 } });
+            defer client.deinit();
+            var provider = Provider.init(a, &client, url);
+            defer provider.deinit();
+            var generator = provider.generator();
+            var response = generator.generate(a, "gemma", &.{.{ .role = .user, .content = .{ .text = "Hello" } }}) catch |err| {
+                result.* = err;
+                return;
+            };
+            response.deinit();
+        }
+    };
+    try group.concurrent(io, Call.run, .{ alloc, io, server.baseUrl(), &result_error });
+    try server.handleOne();
+    try group.await(io);
+    try std.testing.expectEqual(error.GenerationCapacityUnavailable, result_error);
 }
 
 test "antfly generate round trip" {

--- a/zig/pkg/antfly/src/inference/types.zig
+++ b/zig/pkg/antfly/src/inference/types.zig
@@ -51,6 +51,37 @@ pub const GenerateMessagesRequest = struct {
     options: GenerationOptions = .{},
 };
 
+/// Preserve explicit, transient inference admission failures across both the
+/// HTTP provider and the in-process generation bridge. Permanent budget/model
+/// failures and unstructured 503s must not masquerade as capacity retries.
+pub fn localGenerationStatusError(alloc: std.mem.Allocator, status: u16, body: ?[]const u8) anyerror {
+    if (status == 429) return error.RateLimit;
+    if (status == 504) return error.Timeout;
+    if (status == 503) {
+        const Failure = struct { @"error": []const u8 = "", retryable: bool = false };
+        if (body) |bytes| {
+            var parsed = std.json.parseFromSlice(Failure, alloc, bytes, .{ .ignore_unknown_fields = true }) catch
+                return error.GenerateRequestFailed;
+            defer parsed.deinit();
+            if (parsed.value.retryable and std.mem.eql(u8, parsed.value.@"error", "MODEL_RESOURCE_BUSY"))
+                return error.GenerationCapacityUnavailable;
+        }
+    }
+    return error.GenerateRequestFailed;
+}
+
+test "local generation bridge preserves retryable capacity without retrying permanent failures" {
+    const alloc = std.testing.allocator;
+    const busy = "{\"error\":\"MODEL_RESOURCE_BUSY\",\"retryable\":true,\"reason\":\"inference_capacity\",\"retry_after_ms\":1000}";
+    try std.testing.expectEqual(error.GenerationCapacityUnavailable, localGenerationStatusError(alloc, 503, busy));
+    try std.testing.expectEqual(error.GenerateRequestFailed, localGenerationStatusError(alloc, 500, busy));
+    for ([_]?[]const u8{ null, "unavailable", "{}", "{\"error\":\"MODEL_RESOURCE_BUSY\",\"retryable\":false}", "{\"error\":\"MODEL_RESOURCE_LIMIT\",\"retryable\":false}", "{\"error\":\"MODEL_NOT_FOUND\",\"retryable\":true}" }) |body| {
+        try std.testing.expectEqual(error.GenerateRequestFailed, localGenerationStatusError(alloc, 503, body));
+    }
+    try std.testing.expectEqual(error.RateLimit, localGenerationStatusError(alloc, 429, null));
+    try std.testing.expectEqual(error.Timeout, localGenerationStatusError(alloc, 504, null));
+}
+
 test "local generation budgets preserve explicit limits and reject overflow" {
     try std.testing.expectEqual(@as(i32, 128), (try GenerationOptions.fromMaxTokens(128)).max_tokens);
     try std.testing.expectEqual(@as(i32, 256), (GenerationOptions{}).max_tokens);

--- a/zig/pkg/antfly/src/runtime_error_abi.zig
+++ b/zig/pkg/antfly/src/runtime_error_abi.zig
@@ -347,6 +347,7 @@ pub const Detail = enum(c_int) {
     generate_request_failed,
     generation_rate_limit,
     unsupported_tensor_type,
+    generation_capacity_unavailable,
 };
 
 pub const Status = extern struct {
@@ -533,6 +534,7 @@ pub fn statusFromError(err: anyerror) Status {
         error.IncompatibleModel => status(.invalid_argument, .incompatible_model),
         error.UnsupportedGeneratorProvider => status(.unsupported, .unsupported_generator_provider),
         error.GenerateRequestFailed => status(.unavailable, .generate_request_failed),
+        error.GenerationCapacityUnavailable => status(.retryable, .generation_capacity_unavailable),
         error.RateLimit => status(.retryable, .generation_rate_limit),
         error.InvalidRateLimitPolicy => status(.invalid_argument, .invalid_rate_limit_policy),
         error.ConflictingRateLimitPolicy => status(.conflict, .conflicting_rate_limit_policy),
@@ -1004,6 +1006,7 @@ fn detailErrorName(comptime detail: Detail) []const u8 {
         .incompatible_model => "IncompatibleModel",
         .unsupported_generator_provider => "UnsupportedGeneratorProvider",
         .generate_request_failed => "GenerateRequestFailed",
+        .generation_capacity_unavailable => "GenerationCapacityUnavailable",
         .generation_rate_limit => "RateLimit",
         .invalid_rate_limit_policy => "InvalidRateLimitPolicy",
         .conflicting_rate_limit_policy => "ConflictingRateLimitPolicy",
@@ -1110,4 +1113,10 @@ test "provider quota errors retain stable boundary details" {
     try std.testing.expectEqual(error.ProviderQuotaRegistryFull, errorFromStatus(statusFromError(error.ProviderQuotaRegistryFull)));
     try std.testing.expectEqual(error.UnsupportedMediaTokenBudget, errorFromStatus(statusFromError(error.UnsupportedMediaTokenBudget)));
     try std.testing.expectEqual(error.UnsupportedLocalRateLimit, errorFromStatus(statusFromError(error.UnsupportedLocalRateLimit)));
+}
+
+test "generation capacity retains retryability across the runtime boundary" {
+    const result = statusFromError(error.GenerationCapacityUnavailable);
+    try std.testing.expectEqual(@intFromEnum(Code.retryable), result.code);
+    try std.testing.expectEqual(error.GenerationCapacityUnavailable, errorFromStatus(result));
 }

--- a/zig/pkg/antfly/src/standalone/runtime.zig
+++ b/zig/pkg/antfly/src/standalone/runtime.zig
@@ -5542,11 +5542,7 @@ fn inferenceProviderGenerateJson(
     });
     if (request) |context| try context.check();
     if (!response.valid()) return error.RuntimeBoundaryFailure;
-    if (response.status >= 300) return switch (response.status) {
-        429 => error.RateLimit,
-        504 => error.Timeout,
-        else => error.GenerateRequestFailed,
-    };
+    if (response.status >= 300) return antfly.inference.types.localGenerationStatusError(alloc, response.status, response.body.slice());
     return alloc.dupe(u8, response.body.slice());
 }
 


### PR DESCRIPTION
Fixed-text overlap searched normalized decoded tokens in the original source. When case or punctuation differed, a failed match retained the entire previous chunk, producing growing embedding inputs and scratch contention during local RAG.

Use tokenizer byte offsets for overlap, validate the independently tokenized suffix, and count assembled source spans including separators. Reduce or omit overlap when the next section needs the room. Reuse validated candidate token counts on both the normal and overlap paths to avoid duplicate tokenization. Tokenizer errors propagate instead of retaining a prefix.

Preserve explicit retryable `MODEL_RESOURCE_BUSY` HTTP 503 responses as `GenerationCapacityUnavailable` through both the local HTTP provider and in-process JSON generation bridge. Carry the error through the stable runtime ABI, return retryable RAG SSE/JSON failures, and return HTTP 503 with retry guidance for query planning. Permanent or malformed provider failures retain their existing generic failure behavior.

Validation:
- 13 chunker tests pass; all three new regressions fail against the original implementation.
- 36 generation/provider tests, 11 retrieval SSE tests, 8 runtime error ABI tests, and 95 standalone runtime tests pass.
- Live and buffered SSE capacity failures preserve retryability and emit no terminal `done` event.
- Formatting and `git diff --check` pass.
- Full ReleaseFast + Metal production build was interrupted before completion and has no passing result yet.

The retained quickstart dataset/model directory from the report is not available on this machine, so the complete real-model quickstart has not been replayed. Existing materialized chunks are not migrated by this change.
