### PR TITLE
ci: install GitHub CLI on release runners

### DIFF
--- a/.github/actions/setup-github-cli/action.yml
+++ b/.github/actions/setup-github-cli/action.yml
@@ -1,0 +1,41 @@
+name: Set up GitHub CLI
+description: Install the pinned GitHub CLI on Linux ARC runners
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        GH_CLI_VERSION: 2.100.0
+        GH_CLI_AMD64_SHA256: e4d4bb4498e8d007abe545b6568926793ace1b6447da598294a610018cb164be
+        GH_CLI_ARM64_SHA256: ea4e7a581a32ccad6cc7923cb1576ac5859ba4b9a16ab22eb8f8a96e78e2e961
+      run: |
+        set -euo pipefail
+        case "$RUNNER_ARCH" in
+          X64)
+            archive_arch=amd64
+            archive_sha256="$GH_CLI_AMD64_SHA256"
+            ;;
+          ARM64)
+            archive_arch=arm64
+            archive_sha256="$GH_CLI_ARM64_SHA256"
+            ;;
+          *)
+            echo "unsupported runner architecture: $RUNNER_ARCH" >&2
+            exit 2
+            ;;
+        esac
+
+        archive="gh_${GH_CLI_VERSION}_linux_${archive_arch}.tar.gz"
+        install_dir="$RUNNER_TEMP/gh-${GH_CLI_VERSION}-${archive_arch}"
+        curl --fail --location --retry 3 \
+          --output "$RUNNER_TEMP/$archive" \
+          "https://github.com/cli/cli/releases/download/v${GH_CLI_VERSION}/${archive}"
+        echo "$archive_sha256  $RUNNER_TEMP/$archive" | sha256sum --check --status
+        mkdir -p "$install_dir"
+        tar -xzf "$RUNNER_TEMP/$archive" \
+          --strip-components=2 \
+          -C "$install_dir" \
+          "gh_${GH_CLI_VERSION}_linux_${archive_arch}/bin/gh"
+        echo "$install_dir" >> "$GITHUB_PATH"
+        "$install_dir/gh" version

--- a/.github/workflows/antfly-release-gc.yml
+++ b/.github/workflows/antfly-release-gc.yml
@@ -29,6 +29,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: ./.github/actions/setup-github-cli
       - name: Load pinned toolchain policy
         id: toolchain
         uses: ./.github/actions/load-toolchain-policy
@@ -94,6 +95,7 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: ./.github/actions/setup-github-cli
       - name: Load pinned toolchain policy
         id: toolchain
         uses: ./.github/actions/load-toolchain-policy

--- a/.github/workflows/antfly-release.yml
+++ b/.github/workflows/antfly-release.yml
@@ -67,6 +67,8 @@ jobs:
           ref: ${{ github.sha }}
           fetch-depth: 0
 
+      - uses: ./.github/actions/setup-github-cli
+
       - name: Load pinned toolchain policy
         id: toolchain
         uses: ./.github/actions/load-toolchain-policy
@@ -700,6 +702,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ needs.prepare-release-promotion.outputs.promotion_controller_commit }}
+      - uses: ./.github/actions/setup-github-cli
       - name: Load pinned toolchain policy
         id: toolchain
         uses: ./.github/actions/load-toolchain-policy
@@ -1098,6 +1101,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ needs.prepare-release-promotion.outputs.promotion_controller_commit }}
+      - uses: ./.github/actions/setup-github-cli
       - name: Publish the verified GitHub release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/packaging/test_cabi_packaging.py
+++ b/scripts/packaging/test_cabi_packaging.py
@@ -32,6 +32,16 @@ def load_module(name: str, path: Path):
     return module
 
 
+def workflow_job(document: str, name: str) -> str:
+    document = document[document.index("\njobs:\n") + 1 :]
+    marker = f"  {name}:\n"
+    start = document.index(marker)
+    remainder = document[start + len(marker) :]
+    next_job = re.search(r"(?m)^  [a-z][a-z0-9-]*:\n", remainder)
+    end = start + len(marker) + (next_job.start() if next_job else len(remainder))
+    return document[start:end]
+
+
 package_cli_release = load_module(
     "package_cli_release_for_cabi_test",
     PACKAGING_DIR / "package_cli_release.py",
@@ -120,6 +130,9 @@ class CAbiPackagingTests(unittest.TestCase):
         ).read_text()
         release_workflow = (
             REPO_ROOT / ".github" / "workflows" / "antfly-release.yml"
+        ).read_text()
+        github_cli_action = (
+            REPO_ROOT / ".github" / "actions" / "setup-github-cli" / "action.yml"
         ).read_text()
         container_workflow = (
             REPO_ROOT / ".github" / "workflows" / "antfly-container.yml"
@@ -255,6 +268,30 @@ class CAbiPackagingTests(unittest.TestCase):
         self.assertEqual(release_workflow.count("environment: release-promotion"), 1)
         self.assertIn("github_environment.py check", release_workflow)
         self.assertIn("--environment release-promotion", release_workflow)
+        self.assertEqual(
+            release_workflow.count("uses: ./.github/actions/setup-github-cli"), 3
+        )
+        self.assertEqual(
+            release_gc_workflow.count("uses: ./.github/actions/setup-github-cli"),
+            2,
+        )
+        for job_name in (
+            "prepare-release-promotion",
+            "preflight-release-channel",
+            "publish-github-release",
+        ):
+            self.assertIn(
+                "uses: ./.github/actions/setup-github-cli",
+                workflow_job(release_workflow, job_name),
+            )
+        for job_name in ("plan", "apply"):
+            self.assertIn(
+                "uses: ./.github/actions/setup-github-cli",
+                workflow_job(release_gc_workflow, job_name),
+            )
+        self.assertIn("GH_CLI_VERSION: 2.100.0", github_cli_action)
+        self.assertIn("sha256sum --check --status", github_cli_action)
+        self.assertIn('case "$RUNNER_ARCH" in', github_cli_action)
         self.assertIn("--content-addressed-prefix", release_workflow)
         self.assertEqual(release_workflow.count("--exact-prefix"), 2)
         self.assertIn("--signer-workflow", release_workflow)


### PR DESCRIPTION
## Summary

- install GitHub CLI 2.100.0 on Linux ARC runners without root access
- verify the official archive checksum for both x86_64 and arm64
- set up the CLI in every release-promotion and retention job that invokes it
- add regression coverage for the required job placements and pinned installer

## Context

[PR #620](https://github.com/antflydb/antfly/pull/620) expanded the release system to use GitHub CLI, beginning with [commit d34f7bc](https://github.com/antflydb/antfly/commit/d34f7bc202818ad5b657e70c3fd51381a303e754). Follow-on commits added [attestation verification](https://github.com/antflydb/antfly/commit/2fb338276edde6b8cd329c0f878dfbdb77249b17), [tag lookup and release publication](https://github.com/antflydb/antfly/commit/94e8f3b80197bc1470873cf68c4ea82204c8a270), and the [environment-contract checker](https://github.com/antflydb/antfly/commit/929442ce40149fd462d0f260652a519265adc686).

The ARC runner image does not currently provide the CLI, so release promotion stops before container publication. This change makes the dependency explicit and reproducible in the workflows that require it. It does not change runtime or inference behavior.

## Validation

- `./scripts/ci/check.sh release`
- `./scripts/format.sh --check python`
- `git diff --check`

Generated with Codex.
