### PR TITLE
test: isolate Zig filesystem fixtures and clean sibling locks

### DIFF
--- a/zig/build.zig
+++ b/zig/build.zig
@@ -2339,6 +2339,10 @@ pub fn build(b: *std.Build) void {
     });
     @call(.auto, configureEmbeddedModule, .{ b, embedded_support_mod } ++ embedded_deps ++ .{addSnowballModule});
     embedded_support_mod.addImport("antfly_scraping", scraping_mod);
+    embedded_support_mod.addImport("antfly_resolver", resolver_mod);
+    embedded_support_mod.addImport("antfly_matcher", matcher_mod);
+    embedded_support_mod.addImport("antfly_reader_config", reader_config_mod);
+    embedded_support_mod.addImport("antfly_transcribing", transcribing_mod);
 
     const embedded_mod = b.createModule(.{
         .root_source_file = b.path("pkg/antfly/src/embedded/root.zig"),
@@ -3674,6 +3678,18 @@ pub fn build(b: *std.Build) void {
     const run_embedded_tests = addFilteredTestRunArtifact(b, embedded_tests);
     const embedded_test_step = b.step("embedded-test", "Run embedded API tests");
     embedded_test_step.dependOn(&run_embedded_tests.step);
+    // Imported module roots do not collect their own tests through the package
+    // surface test, so run the API fixtures in their owning module as well.
+    const embedded_api_tests = b.addTest(.{
+        .root_module = embedded_api_mod,
+        .filters = &.{
+            "embedded api round-trips batch lookup scan and search over memory-backed durable lsm",
+            "embedded api hosted profile drains derived indexing without native runtimes",
+            "embedded api hosted profile persists text index across reopen over storage",
+        },
+    });
+    const run_embedded_api_tests = addFilteredTestRunArtifact(b, embedded_api_tests);
+    embedded_test_step.dependOn(&run_embedded_api_tests.step);
 
     const antfly_embedded_pkg_tests = b.addTest(.{
         .root_module = antfly_embedded_pkg_mod,

--- a/zig/lib/raft/src/runtime/local_snapshot_transport.zig
+++ b/zig/lib/raft/src/runtime/local_snapshot_transport.zig
@@ -215,7 +215,10 @@ test "local snapshot transport sends and fetches snapshot bytes" {
         }
     };
 
-    const root_dir = "/tmp/antflydb-raft-local-snapshot-transport";
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const root_dir = try std.fmt.allocPrint(std.testing.allocator, ".zig-cache/tmp/{s}/snapshots", .{tmp.sub_path});
+    defer std.testing.allocator.free(root_dir);
     var transport = try LocalSnapshotTransport.init(std.testing.allocator, root_dir);
     defer transport.deinit();
     const snapshot_bytes = try std.testing.allocator.dupe(u8, "snap-bytes");

--- a/zig/lib/raft/src/runtime/runtime_test.zig
+++ b/zig/lib/raft/src/runtime/runtime_test.zig
@@ -1802,7 +1802,10 @@ test "multi raft fetches snapshot through snapshot transport and steps it into t
 
     var transport_recorder = TransportRecorder{ .alloc = std.testing.allocator };
 
-    const root_dir = "/tmp/antflydb-raft-runtime-fetch-snapshot";
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const root_dir = try std.fmt.allocPrint(std.testing.allocator, ".zig-cache/tmp/{s}/snapshots", .{tmp.sub_path});
+    defer std.testing.allocator.free(root_dir);
     var snapshot_transport = try runtime.LocalSnapshotTransport.init(std.testing.allocator, root_dir);
     defer snapshot_transport.deinit();
 
@@ -1929,7 +1932,10 @@ test "multi raft ensureReplica can fetch snapshot bootstrap" {
     var store = core.MemoryStorage.init(std.testing.allocator);
     defer store.deinit();
 
-    const root_dir = "/tmp/antflydb-raft-runtime-ensure-fetch-snapshot";
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const root_dir = try std.fmt.allocPrint(std.testing.allocator, ".zig-cache/tmp/{s}/snapshots", .{tmp.sub_path});
+    defer std.testing.allocator.free(root_dir);
     var snapshot_transport = try runtime.LocalSnapshotTransport.init(std.testing.allocator, root_dir);
     defer snapshot_transport.deinit();
 
@@ -2001,7 +2007,10 @@ test "multi raft rejects snapshot bootstrap above aggregate ownership budget" {
     var store = core.MemoryStorage.init(std.testing.allocator);
     defer store.deinit();
 
-    const root_dir = "/tmp/antflydb-raft-runtime-reject-fetch-snapshot";
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const root_dir = try std.fmt.allocPrint(std.testing.allocator, ".zig-cache/tmp/{s}/snapshots", .{tmp.sub_path});
+    defer std.testing.allocator.free(root_dir);
     var snapshot_transport = try runtime.LocalSnapshotTransport.init(std.testing.allocator, root_dir);
     defer snapshot_transport.deinit();
     var voters = [_]core.types.NodeId{ 1, 2 };
@@ -2113,7 +2122,10 @@ test "multi raft limit backpressure denies oversized snapshot ready" {
     defer storage_recorder.deinit();
     try storage_recorder.registerStore(134, &store);
 
-    const root_dir = "/tmp/antflydb-raft-runtime-limit-backpressure";
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const root_dir = try std.fmt.allocPrint(std.testing.allocator, ".zig-cache/tmp/{s}/snapshots", .{tmp.sub_path});
+    defer std.testing.allocator.free(root_dir);
     var snapshot_transport = try runtime.LocalSnapshotTransport.init(std.testing.allocator, root_dir);
     defer snapshot_transport.deinit();
 
@@ -3015,7 +3027,10 @@ test "runtime control plane restore_replicas can rejoin via snapshot bootstrap" 
     defer factory.deinit();
     try factory.registerStore(142, &store);
 
-    const root_dir = "/tmp/antflydb-raft-runtime-catalog-rejoin";
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const root_dir = try std.fmt.allocPrint(std.testing.allocator, ".zig-cache/tmp/{s}/snapshots", .{tmp.sub_path});
+    defer std.testing.allocator.free(root_dir);
     var snapshot_transport = try runtime.LocalSnapshotTransport.init(std.testing.allocator, root_dir);
     defer snapshot_transport.deinit();
 

--- a/zig/pkg/antfly/src/api/http_client.zig
+++ b/zig/pkg/antfly/src/api/http_client.zig
@@ -13,6 +13,7 @@
 // limitations.
 
 const std = @import("std");
+const TestDirectory = @import("../common/test_directory.zig").TestDirectory;
 const platform_time = @import("antfly_platform").time;
 const ant_json = @import("antfly-json");
 const cluster = @import("cluster.zig");
@@ -5022,7 +5023,9 @@ test "api http client round-trips public transaction commit route" {
     const table_writes = @import("table_writes.zig");
 
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-http-client-txn";
+    var path_tmp = try TestDirectory.init("antfly-api-http-client-txn");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
     std.Io.Dir.cwd().deleteTree(io_impl.io(), path) catch {};
@@ -5119,7 +5122,9 @@ test "api http client round-trips long-lived public transaction session routes" 
     const raft_mod = @import("../raft/mod.zig");
 
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-http-client-session-txn";
+    var path_tmp = try TestDirectory.init("antfly-api-http-client-session-txn");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
     std.Io.Dir.cwd().deleteTree(io_impl.io(), path) catch {};

--- a/zig/pkg/antfly/src/api/http_server.zig
+++ b/zig/pkg/antfly/src/api/http_server.zig
@@ -13,6 +13,7 @@
 // limitations.
 
 const std = @import("std");
+const TestDirectory = @import("../common/test_directory.zig").TestDirectory;
 const ant_json = @import("antfly-json");
 const kernel_abi = @import("kernel_abi.zig");
 const builtin = @import("builtin");
@@ -28484,7 +28485,9 @@ test "api http server serves table lookup with version header" {
         title: []const u8,
     };
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-http-lookup";
+    var path_tmp = try TestDirectory.init("antfly-api-http-lookup");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
     std.Io.Dir.cwd().deleteTree(io_impl.io(), path) catch {};
@@ -28636,7 +28639,9 @@ test "api http server decodes percent-encoded lookup keys" {
         title: []const u8,
     };
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-http-lookup-encoded";
+    var path_tmp = try TestDirectory.init("antfly-api-http-lookup-encoded");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
     std.Io.Dir.cwd().deleteTree(io_impl.io(), path) catch {};
@@ -28705,7 +28710,9 @@ test "api http server decodes percent-encoded lookup keys" {
 
 test "api http server serves document lookup through mcp tool" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-http-mcp-get-document";
+    var path_tmp = try TestDirectory.init("antfly-api-http-mcp-get-document");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
     std.Io.Dir.cwd().deleteTree(io_impl.io(), path) catch {};
@@ -28830,7 +28837,9 @@ test "api http server serves document lookup through mcp tool" {
 
 test "api http server serves fielded full-text search through mcp tools" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-http-mcp-fielded-search";
+    var path_tmp = try TestDirectory.init("antfly-api-http-mcp-fielded-search");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
     std.Io.Dir.cwd().deleteTree(io_impl.io(), path) catch {};
@@ -29382,7 +29391,9 @@ test "api http server serves table scan as ndjson" {
         title: []const u8,
     };
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-http-scan";
+    var path_tmp = try TestDirectory.init("antfly-api-http-scan");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
     std.Io.Dir.cwd().deleteTree(io_impl.io(), path) catch {};
@@ -29466,7 +29477,9 @@ test "api http server serves table scan as ndjson" {
 
 test "api http server serves table query response envelope" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-http-query";
+    var path_tmp = try TestDirectory.init("antfly-api-http-query");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
     std.Io.Dir.cwd().deleteTree(io_impl.io(), path) catch {};
@@ -29530,7 +29543,9 @@ test "api http server serves table query response envelope" {
 
 test "api http server executes public Query filter roots and compositions" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-http-sdk-filter-roots";
+    var path_tmp = try TestDirectory.init("antfly-api-http-sdk-filter-roots");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
     std.Io.Dir.cwd().deleteTree(io_impl.io(), path) catch {};
@@ -29684,7 +29699,9 @@ test "api http server executes public Query filter roots and compositions" {
 
 test "api http server serves table query with SearchAF-shaped terms aggregations" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-http-searchaf-aggregations";
+    var path_tmp = try TestDirectory.init("antfly-api-http-searchaf-aggregations");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
     std.Io.Dir.cwd().deleteTree(io_impl.io(), path) catch {};
@@ -29760,7 +29777,9 @@ test "api http server serves table query with SearchAF-shaped terms aggregations
 
 test "api http server serves retrieval agent response envelope" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-http-retrieval";
+    var path_tmp = try TestDirectory.init("antfly-api-http-retrieval");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
     std.Io.Dir.cwd().deleteTree(io_impl.io(), path) catch {};
@@ -30030,7 +30049,9 @@ test "api http server maps retrieval agent doc identity mismatch to unavailable"
 
 test "api http server serves retrieval agent event stream" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-http-retrieval-stream";
+    var path_tmp = try TestDirectory.init("antfly-api-http-retrieval-stream");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
     std.Io.Dir.cwd().deleteTree(io_impl.io(), path) catch {};
@@ -31109,7 +31130,9 @@ test "api http server serves table batch writes" {
     const StoredTitle = struct {
         title: []const u8,
     };
-    const path = "/tmp/antfly-api-http-batch";
+    var path_tmp = try TestDirectory.init("antfly-api-http-batch");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
     std.Io.Dir.cwd().deleteTree(io_impl.io(), path) catch {};
@@ -31359,7 +31382,9 @@ test "api http server serves table batch transforms" {
         priority: i64,
         version: i64,
     };
-    const path = "/tmp/antfly-api-http-batch-transform";
+    var path_tmp = try TestDirectory.init("antfly-api-http-batch-transform");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
     std.Io.Dir.cwd().deleteTree(io_impl.io(), path) catch {};
@@ -32280,7 +32305,9 @@ test "api http server surfaces structured torn-state conflicts when txn record i
 test "api http server serves long-lived public transaction session routes" {
     const SessionCommitResponse = transactions_api.SessionCommitResponse;
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-http-session-txn";
+    var path_tmp = try TestDirectory.init("antfly-api-http-session-txn");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
     std.Io.Dir.cwd().deleteTree(io_impl.io(), path) catch {};
@@ -32785,8 +32812,12 @@ test "api http server reloads durable transaction sessions after restart" {
     const StoredTitle = struct {
         title: []const u8,
     };
-    const path = "/tmp/antfly-api-http-session-restart";
-    const session_path = "/tmp/antfly-api-http-session-restart-sessions";
+    var path_tmp = try TestDirectory.init("antfly-api-http-session-restart");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
+    var session_path_tmp = try TestDirectory.init("antfly-api-http-session-restart-sessions");
+    defer session_path_tmp.cleanup();
+    const session_path = session_path_tmp.path();
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
     std.Io.Dir.cwd().deleteTree(io_impl.io(), path) catch {};
@@ -33017,7 +33048,9 @@ test "api http server retries stable terminal commits without replaying writes" 
 
 test "api session maintenance recovers crash window after durable 2pc commit" {
     const alloc = std.testing.allocator;
-    const session_path = "/tmp/antfly-api-http-session-post-commit-recovery";
+    var session_path_tmp = try TestDirectory.init("antfly-api-http-session-post-commit-recovery");
+    defer session_path_tmp.cleanup();
+    const session_path = session_path_tmp.path();
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
     std.Io.Dir.cwd().deleteTree(io_impl.io(), session_path) catch {};
@@ -33121,8 +33154,12 @@ test "api session maintenance recovers crash window after durable 2pc commit" {
 
 test "api http server enforces configured savepoint limits and exposes remaining capacity" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-http-session-savepoint-limit";
-    const session_path = "/tmp/antfly-api-http-session-savepoint-limit-sessions";
+    var path_tmp = try TestDirectory.init("antfly-api-http-session-savepoint-limit");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
+    var session_path_tmp = try TestDirectory.init("antfly-api-http-session-savepoint-limit-sessions");
+    defer session_path_tmp.cleanup();
+    const session_path = session_path_tmp.path();
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
     std.Io.Dir.cwd().deleteTree(io_impl.io(), path) catch {};
@@ -33228,7 +33265,9 @@ test "api http server enforces configured savepoint limits and exposes remaining
 
 test "api http server enforces session adoption timeout when configured" {
     const alloc = std.testing.allocator;
-    const session_path = "/tmp/antfly-api-http-session-adopt-timeout";
+    var session_path_tmp = try TestDirectory.init("antfly-api-http-session-adopt-timeout");
+    defer session_path_tmp.cleanup();
+    const session_path = session_path_tmp.path();
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
     std.Io.Dir.cwd().deleteTree(io_impl.io(), session_path) catch {};
@@ -33324,7 +33363,9 @@ test "api http server enforces session adoption timeout when configured" {
 
 test "api http server keeps session maintenance off public request paths" {
     const alloc = std.testing.allocator;
-    const session_path = "/tmp/antfly-api-http-session-renew-cadence";
+    var session_path_tmp = try TestDirectory.init("antfly-api-http-session-renew-cadence");
+    defer session_path_tmp.cleanup();
+    const session_path = session_path_tmp.path();
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
     std.Io.Dir.cwd().deleteTree(io_impl.io(), session_path) catch {};
@@ -33418,7 +33459,9 @@ test "api http server keeps session maintenance off public request paths" {
 
 test "api http server can renew owned session leases via explicit maintenance hook" {
     const alloc = std.testing.allocator;
-    const session_path = "/tmp/antfly-api-http-session-renew-maintenance";
+    var session_path_tmp = try TestDirectory.init("antfly-api-http-session-renew-maintenance");
+    defer session_path_tmp.cleanup();
+    const session_path = session_path_tmp.path();
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
     std.Io.Dir.cwd().deleteTree(io_impl.io(), session_path) catch {};
@@ -33529,7 +33572,9 @@ test "api http server can renew owned session leases via explicit maintenance ho
 
 test "api http server keeps session maintenance off internal request paths" {
     const alloc = std.testing.allocator;
-    const session_path = "/tmp/antfly-api-http-session-renew-internal-route";
+    var session_path_tmp = try TestDirectory.init("antfly-api-http-session-renew-internal-route");
+    defer session_path_tmp.cleanup();
+    const session_path = session_path_tmp.path();
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
     std.Io.Dir.cwd().deleteTree(io_impl.io(), session_path) catch {};
@@ -34040,7 +34085,9 @@ test "api http server serves internal group transaction routes" {
     const StoredTitle = struct {
         title: []const u8,
     };
-    const path = "/tmp/antfly-api-http-txn";
+    var path_tmp = try TestDirectory.init("antfly-api-http-txn");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
     std.Io.Dir.cwd().deleteTree(io_impl.io(), path) catch {};
@@ -34584,7 +34631,9 @@ test "api http server index status falls back when the metadata cache is cold" {
 
 test "api http server reports table storage empty from read visibility" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-http-table-storage-empty";
+    var path_tmp = try TestDirectory.init("antfly-api-http-table-storage-empty");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
     std.Io.Dir.cwd().deleteTree(io_impl.io(), path) catch {};
@@ -34943,7 +34992,9 @@ test "api http server serves local index runtime status" {
             local: ?Stats = null,
         },
     };
-    const path = "/tmp/antfly-api-http-index-status";
+    var path_tmp = try TestDirectory.init("antfly-api-http-index-status");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
     std.Io.Dir.cwd().deleteTree(io_impl.io(), path) catch {};
@@ -36178,7 +36229,9 @@ test "api http server serves provisioned index runtime backfill status across sh
             local: ?Stats = null,
         },
     };
-    const path = "/tmp/antfly-api-http-provisioned-index-status";
+    var path_tmp = try TestDirectory.init("antfly-api-http-provisioned-index-status");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
     std.Io.Dir.cwd().deleteTree(io_impl.io(), path) catch {};

--- a/zig/pkg/antfly/src/api/table_reads.zig
+++ b/zig/pkg/antfly/src/api/table_reads.zig
@@ -13,6 +13,7 @@
 // limitations.
 
 const std = @import("std");
+const TestDirectory = @import("../common/test_directory.zig").TestDirectory;
 const builtin = @import("builtin");
 const ant_json = @import("antfly-json");
 const indexes_openapi = @import("antfly_indexes_openapi");
@@ -6940,7 +6941,9 @@ test "distributed unit group hydration rejects a cross-revision unit payload" {
 
 test "hosted distributed grouped hierarchy expands the globally selected shard page" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-hosted-distributed-grouped-hierarchy";
+    var path_tmp = try TestDirectory.init("antfly-api-hosted-distributed-grouped-hierarchy");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
     std.Io.Dir.cwd().deleteTree(io_impl.io(), path) catch {};
@@ -20691,7 +20694,9 @@ fn civilFromDays(days_since_epoch: i64) CivilDate {
 
 test "bound table read source uses feature db reads and returns version" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-table-reads";
+    var path_tmp = try TestDirectory.init("antfly-api-table-reads");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -20720,7 +20725,9 @@ test "bound table read source uses feature db reads and returns version" {
 
 test "bound table read source scans keys as ndjson" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-table-scan";
+    var path_tmp = try TestDirectory.init("antfly-api-table-scan");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -20758,7 +20765,9 @@ test "bound table read source scans keys as ndjson" {
 
 test "bound table read source formats query responses" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-table-query";
+    var path_tmp = try TestDirectory.init("antfly-api-table-query");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -20789,7 +20798,9 @@ test "bound table read source formats query responses" {
 
 test "bound table read source preflights query requests" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-table-preflight";
+    var path_tmp = try TestDirectory.init("antfly-api-table-preflight");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -20899,7 +20910,9 @@ test "merge runtime preflight summary preserves structured filter exact counts o
 
 test "bound table read source reranks hits after materialization" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-table-rerank";
+    var path_tmp = try TestDirectory.init("antfly-api-table-rerank");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -20989,7 +21002,9 @@ test "bound table read source reranks hits after materialization" {
 
 test "provisioned table read source routes lookup and scan across ranges" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-provisioned-reads";
+    var path_tmp = try TestDirectory.init("antfly-api-provisioned-reads");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -21221,7 +21236,9 @@ test "fanout planner uses io cap and request shape" {
 
 test "provisioned table read source merges query results across ranges" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-provisioned-query";
+    var path_tmp = try TestDirectory.init("antfly-api-provisioned-query");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -21328,7 +21345,9 @@ test "provisioned table read source merges query results across ranges" {
 
 test "provisioned table read source serves dense queries for explicit external embeddings" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-provisioned-query-dense";
+    var path_tmp = try TestDirectory.init("antfly-api-provisioned-query-dense");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -21439,7 +21458,9 @@ test "provisioned table read source serves dense queries for explicit external e
 
 test "provisioned local query execution returns stamped identity request" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-provisioned-query-stamped-identity";
+    var path_tmp = try TestDirectory.init("antfly-api-provisioned-query-stamped-identity");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -21896,7 +21917,9 @@ test "provisioned reads reject a group removed from the table topology" {
 
 test "provisioned local query reuses resident generation without readonly open" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-provisioned-query-resident-db";
+    var path_tmp = try TestDirectory.init("antfly-api-provisioned-query-resident-db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -22372,7 +22395,9 @@ test "provisioned table read source managed runtime config carries inference url
 
 test "provisioned table read source serves public dense query requests with read_index" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-provisioned-query-dense-public";
+    var path_tmp = try TestDirectory.init("antfly-api-provisioned-query-dense-public");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -22452,7 +22477,9 @@ test "provisioned table read source serves public dense query requests with read
 
 test "provisioned table read source serves profiled public dense query requests with read_index" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-provisioned-query-dense-public-profiled";
+    var path_tmp = try TestDirectory.init("antfly-api-provisioned-query-dense-public-profiled");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -22536,7 +22563,9 @@ test "provisioned table read source serves profiled public dense query requests 
 
 test "provisioned table read source serves public dense query requests without explicit indexes" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-provisioned-query-dense-public-implicit-index";
+    var path_tmp = try TestDirectory.init("antfly-api-provisioned-query-dense-public-implicit-index");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -22616,7 +22645,9 @@ test "provisioned table read source serves public dense query requests without e
 
 test "provisioned table read source serves benchmark-shaped packed dense query with full-text present" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-provisioned-query-dense-benchmark-shaped";
+    var path_tmp = try TestDirectory.init("antfly-api-provisioned-query-dense-benchmark-shaped");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -22703,7 +22734,9 @@ test "provisioned table read source serves benchmark-shaped packed dense query w
 
 test "provisioned table read source preflights every local group" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-provisioned-preflight-multigroup";
+    var path_tmp = try TestDirectory.init("antfly-api-provisioned-preflight-multigroup");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -22786,7 +22819,9 @@ test "provisioned table read source preflights every local group" {
 
 test "provisioned local runtime statuses reconcile empty managed embeddings indexes" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-provisioned-runtime-status-managed";
+    var path_tmp = try TestDirectory.init("antfly-api-provisioned-runtime-status-managed");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -22876,7 +22911,9 @@ test "provisioned local runtime statuses reconcile empty managed embeddings inde
 
 test "provisioned query db installs asset producer from indexes_json and replays assets" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-provisioned-asset-enrichment";
+    var path_tmp = try TestDirectory.init("antfly-api-provisioned-asset-enrichment");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -23015,7 +23052,9 @@ test "provisioned query db installs asset producer from indexes_json and replays
 
 test "provisioned table read source runtime status stays cache-only without shared snapshot" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-provisioned-read-runtime-cache";
+    var path_tmp = try TestDirectory.init("antfly-api-provisioned-read-runtime-cache");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -23159,7 +23198,9 @@ test "provisioned table read source runtime status falls back to shared snapshot
 
 test "provisioned table read source runtime status prefers shared snapshot cache" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-provisioned-read-runtime-prefers-snapshot";
+    var path_tmp = try TestDirectory.init("antfly-api-provisioned-read-runtime-prefers-snapshot");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -25816,7 +25857,9 @@ test "explicit text stats requests carry resolved doc filters and apply exact pr
 
 test "explicit text stats requests reject stale identity generation" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-text-stats-stale-identity-generation";
+    var path_tmp = try TestDirectory.init("antfly-api-text-stats-stale-identity-generation");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -26001,7 +26044,9 @@ test "identity-only distributed unit groups consume envelopes without routed rea
 
 test "aggregation context rejects non-current identity generation" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-aggregation-context-identity-generation";
+    var path_tmp = try TestDirectory.init("antfly-api-aggregation-context-identity-generation");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -26125,8 +26170,9 @@ test "aggregation full-result rerun can reuse snapped result identity generation
 
 test "provisioned distributed aggregations collect path terms nested cardinality" {
     const alloc = std.testing.allocator;
-    const path = try std.fmt.allocPrint(alloc, "/tmp/antfly-api-provisioned-algebraic-path-terms-cardinality-{d}", .{platform_time.monotonicNs()});
-    defer alloc.free(path);
+    var path_tmp = try TestDirectory.init("algebraic-path-terms-cardinality");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -26442,7 +26488,9 @@ test "algebraic partial request accepts expression cache proofs without named ma
 
 test "algebraic partial request fails closed when lifecycle is stale" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-algebraic-partials-stale-lifecycle";
+    var path_tmp = try TestDirectory.init("antfly-api-algebraic-partials-stale-lifecycle");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -26493,7 +26541,9 @@ test "algebraic partial request fails closed when lifecycle is stale" {
 
 test "algebraic partial request accepts current identity generation and rejects stale" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-algebraic-partials-stale-identity-generation";
+    var path_tmp = try TestDirectory.init("antfly-api-algebraic-partials-stale-identity-generation");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -26548,7 +26598,9 @@ test "algebraic partial request accepts current identity generation and rejects 
 
 test "algebraic partial request uses HLL at the current identity generation" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-algebraic-partials-current-generation-hll";
+    var path_tmp = try TestDirectory.init("antfly-api-algebraic-partials-current-generation-hll");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -27719,7 +27771,9 @@ test "distributed significant terms candidates use configured analyzers and boun
 
 test "hosted textStatsGroupLocal serves only the local group" {
     const test_alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-hosted-local-text-stats";
+    var path_tmp = try TestDirectory.init("antfly-api-hosted-local-text-stats");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -27862,7 +27916,9 @@ test "hosted textStatsGroupLocal serves only the local group" {
 
 test "hosted table read source preflights query locally" {
     const test_alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-hosted-local-preflight";
+    var path_tmp = try TestDirectory.init("antfly-api-hosted-local-preflight");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -27992,7 +28048,9 @@ test "hosted table read source preflights query locally" {
 
 test "hosted table read source preflights every local group" {
     const test_alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-hosted-local-preflight-multigroup";
+    var path_tmp = try TestDirectory.init("antfly-api-hosted-local-preflight-multigroup");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -28132,7 +28190,9 @@ test "hosted table read source preflights every local group" {
 
 test "hosted table read source preflights mixed local and remote groups" {
     const test_alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-hosted-preflight-mixed";
+    var path_tmp = try TestDirectory.init("antfly-api-hosted-preflight-mixed");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -28670,7 +28730,9 @@ test "conjunctive graph match requires coordination for a single source group" {
 
 test "hosted cross-range graph query expands explicit local start keys" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-hosted-cross-range-graph-explicit";
+    var path_tmp = try TestDirectory.init("antfly-api-hosted-cross-range-graph-explicit");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -28912,7 +28974,9 @@ test "hosted cross-range graph query expands explicit local start keys" {
 
 test "provisioned read cache keys entries by lsm root generation" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-provisioned-read-cache-generation";
+    var path_tmp = try TestDirectory.init("antfly-api-provisioned-read-cache-generation");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -28983,7 +29047,9 @@ test "provisioned read cache keys entries by lsm root generation" {
 
 test "provisioned read cache keys entries by identity namespace" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-provisioned-read-cache-identity-namespace";
+    var path_tmp = try TestDirectory.init("antfly-api-provisioned-read-cache-identity-namespace");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -29064,7 +29130,9 @@ test "provisioned read cache keys entries by identity namespace" {
 
 test "provisioned read cache invalidates repeated ownership moves with pinned leases" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-provisioned-read-cache-ownership-moves";
+    var path_tmp = try TestDirectory.init("antfly-api-provisioned-read-cache-ownership-moves");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -29162,7 +29230,9 @@ test "provisioned read cache invalidates repeated ownership moves with pinned le
 
 test "graph edge local read rejects stale identity generation" {
     const alloc = std.testing.allocator;
-    const root = "/tmp/antfly-api-graph-edge-stale-identity-generation";
+    var root_tmp = try TestDirectory.init("antfly-api-graph-edge-stale-identity-generation");
+    defer root_tmp.cleanup();
+    const root = root_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -29247,7 +29317,9 @@ test "graph edge local read rejects stale identity generation" {
 
 test "graph edge local read rejects stale identity namespace" {
     const alloc = std.testing.allocator;
-    const root = "/tmp/antfly-api-graph-edge-stale-identity-namespace";
+    var root_tmp = try TestDirectory.init("antfly-api-graph-edge-stale-identity-namespace");
+    defer root_tmp.cleanup();
+    const root = root_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -29349,7 +29421,9 @@ test "graph edge local read rejects stale identity namespace" {
 
 test "provisioned lookup db opens with identity namespace" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-provisioned-lookup-identity-namespace";
+    var path_tmp = try TestDirectory.init("antfly-api-provisioned-lookup-identity-namespace");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -29369,7 +29443,9 @@ test "provisioned lookup db opens with identity namespace" {
 
 test "provisioned warm status db opens with identity namespace" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-provisioned-warm-status-identity-namespace";
+    var path_tmp = try TestDirectory.init("antfly-api-provisioned-warm-status-identity-namespace");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -29389,8 +29465,12 @@ test "provisioned warm status db opens with identity namespace" {
 
 test "provisioned direct read db opens reject stale identity namespace" {
     const alloc = std.testing.allocator;
-    const lookup_path = "/tmp/antfly-api-provisioned-lookup-stale-identity-namespace";
-    const status_path = "/tmp/antfly-api-provisioned-status-stale-identity-namespace";
+    var lookup_path_tmp = try TestDirectory.init("antfly-api-provisioned-lookup-stale-identity-namespace");
+    defer lookup_path_tmp.cleanup();
+    const lookup_path = lookup_path_tmp.path();
+    var status_path_tmp = try TestDirectory.init("antfly-api-provisioned-status-stale-identity-namespace");
+    defer status_path_tmp.cleanup();
+    const status_path = status_path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -29445,7 +29525,9 @@ test "provisioned direct read db opens reject stale identity namespace" {
 
 test "provisioned query runtime db opens with catalog identity namespace" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-provisioned-query-runtime-identity-namespace";
+    var path_tmp = try TestDirectory.init("antfly-api-provisioned-query-runtime-identity-namespace");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -29509,7 +29591,9 @@ test "provisioned query runtime db opens with catalog identity namespace" {
 
 test "provisioned query runtime db rejects stale identity namespace" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-provisioned-query-runtime-stale-identity-namespace";
+    var path_tmp = try TestDirectory.init("antfly-api-provisioned-query-runtime-stale-identity-namespace");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -29586,7 +29670,9 @@ test "provisioned query runtime db rejects stale identity namespace" {
 
 test "provisioned primary lookup lease fails on identity namespace mismatch" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-provisioned-primary-lookup-identity-mismatch";
+    var path_tmp = try TestDirectory.init("antfly-api-provisioned-primary-lookup-identity-mismatch");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -29716,7 +29802,9 @@ test "provisioned read cache clear preserves in-flight pending opens and bumps e
 
 test "provisioned read cache invalidate removes entries without dropping pending opens" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-provisioned-read-cache-invalidate";
+    var path_tmp = try TestDirectory.init("antfly-api-provisioned-read-cache-invalidate");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -29791,7 +29879,9 @@ test "provisioned read cache invalidate removes entries without dropping pending
 
 test "provisioned read cache retires invalidated entries until the last lease is released" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-provisioned-read-cache-no-retire";
+    var path_tmp = try TestDirectory.init("antfly-api-provisioned-read-cache-no-retire");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -29872,7 +29962,9 @@ test "provisioned read cache retires invalidated entries until the last lease is
 
 test "provisioned read cache exclusive access drains active read leases" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-provisioned-read-cache-exclusive-drain";
+    var path_tmp = try TestDirectory.init("antfly-api-provisioned-read-cache-exclusive-drain");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -29980,7 +30072,9 @@ test "provisioned read cache exclusive access drains active read leases" {
 
 test "provisioned read cache group exclusive drains only the published group" {
     const alloc = std.testing.allocator;
-    const root = "/tmp/antfly-api-provisioned-read-cache-group-exclusive";
+    var root_tmp = try TestDirectory.init("antfly-api-provisioned-read-cache-group-exclusive");
+    defer root_tmp.cleanup();
+    const root = root_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -30078,7 +30172,9 @@ test "provisioned read cache group exclusive drains only the published group" {
 test "provisioned read cache retirement is allocation-free after entry installation" {
     var failing = std.testing.FailingAllocator.init(std.testing.allocator, .{});
     const alloc = failing.allocator();
-    const path = "/tmp/antfly-api-provisioned-read-cache-retire-oom";
+    var path_tmp = try TestDirectory.init("antfly-api-provisioned-read-cache-retire-oom");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();

--- a/zig/pkg/antfly/src/api/table_writes.zig
+++ b/zig/pkg/antfly/src/api/table_writes.zig
@@ -14,6 +14,7 @@
 
 const builtin = @import("builtin");
 const std = @import("std");
+const TestDirectory = @import("../common/test_directory.zig").TestDirectory;
 const platform = @import("antfly_platform");
 const platform_sync = @import("antfly_platform").sync;
 const metadata_openapi = @import("antfly_metadata_openapi");
@@ -26176,7 +26177,9 @@ test "provisioned stateless batch retries definite aborts to the production boun
 
 test "provisioned single-group commit batch uses atomic shard fast path" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-provisioned-single-group-commit-fast-path";
+    var path_tmp = try TestDirectory.init("antfly-api-provisioned-single-group-commit-fast-path");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -26209,7 +26212,9 @@ test "provisioned single-group commit batch uses atomic shard fast path" {
 
 test "provisioned single-group commit preserves transaction graph transform contract" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-provisioned-single-group-graph-transform";
+    var path_tmp = try TestDirectory.init("antfly-api-provisioned-single-group-graph-transform");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -26272,7 +26277,9 @@ test "provisioned single-group commit preserves transaction graph transform cont
 
 test "provisioned predicate-only batch validates matching and stale versions" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-provisioned-predicate-only-batch";
+    var path_tmp = try TestDirectory.init("antfly-api-provisioned-predicate-only-batch");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -26309,7 +26316,9 @@ test "provisioned predicate-only batch validates matching and stale versions" {
 
 test "resident writer repair state distinguishes clean and metadata-pending writers" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-resident-writer-repair-state";
+    var path_tmp = try TestDirectory.init("antfly-api-resident-writer-repair-state");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -32531,7 +32540,9 @@ fn encodeRemoteDocumentArtifactChildRangeApplyBatch(
 
 test "bound table write source applies batch writes" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-table-batch";
+    var path_tmp = try TestDirectory.init("antfly-api-table-batch");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -32737,7 +32748,9 @@ test "bound table sources inspect and reprocess document artifact manifests" {
 
 test "bound table write source resolves internal group transactions into visible documents" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-table-txn-group-local";
+    var path_tmp = try TestDirectory.init("antfly-api-table-txn-group-local");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -32846,7 +32859,9 @@ test "bound single-group batch reports prepared intent conflicts" {
 
 test "bound table write source provisions default full text index on create" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-table-create";
+    var path_tmp = try TestDirectory.init("antfly-api-table-create");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -33404,7 +33419,9 @@ test "provisioned table write source rejects stale doc identity namespace before
 
 test "bound table write source rejects invalid batch writes against persisted schema" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-table-batch-schema";
+    var path_tmp = try TestDirectory.init("antfly-api-table-batch-schema");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -33432,7 +33449,9 @@ test "bound table write source rejects invalid batch writes against persisted sc
 
 test "bound table write source enforces nested required fields and array items" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-table-nested-schema";
+    var path_tmp = try TestDirectory.init("antfly-api-table-nested-schema");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -33472,7 +33491,9 @@ test "bound table write source enforces nested required fields and array items" 
 
 test "bound table write source enforces enums numeric bounds and anyOf" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-table-enum-bounds-schema";
+    var path_tmp = try TestDirectory.init("antfly-api-table-enum-bounds-schema");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -33511,7 +33532,9 @@ test "bound table write source enforces enums numeric bounds and anyOf" {
 
 test "bound table write source enforces oneOf allOf pattern and item cardinality" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-table-pattern-compose-schema";
+    var path_tmp = try TestDirectory.init("antfly-api-table-pattern-compose-schema");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -33556,7 +33579,9 @@ test "bound table write source enforces oneOf allOf pattern and item cardinality
 
 test "bound table write source enforces string length and object cardinality" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-table-length-cardinality-schema";
+    var path_tmp = try TestDirectory.init("antfly-api-table-length-cardinality-schema");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -33768,8 +33793,12 @@ test "bound table write source backs up and restores a portable local table" {
 
 test "provisioned table write source backs up and restores a local table" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-provisioned-table-backup-restore";
-    const backup_root = "/tmp/antfly-api-provisioned-table-backup-restore-out";
+    var path_tmp = try TestDirectory.init("antfly-api-provisioned-table-backup-restore");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
+    var backup_root_tmp = try TestDirectory.init("antfly-api-provisioned-table-backup-restore-out");
+    defer backup_root_tmp.cleanup();
+    const backup_root = backup_root_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -34316,9 +34345,15 @@ test "provisioned restore repair worker retries transient step failures to compl
 
 test "provisioned table write source backs up a portable local table" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-provisioned-table-portable-backup";
-    const backup_root = "/tmp/antfly-api-provisioned-table-portable-backup-out";
-    const restore_path = "/tmp/antfly-api-provisioned-table-portable-backup-restore";
+    var path_tmp = try TestDirectory.init("antfly-api-provisioned-table-portable-backup");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
+    var backup_root_tmp = try TestDirectory.init("antfly-api-provisioned-table-portable-backup-out");
+    defer backup_root_tmp.cleanup();
+    const backup_root = backup_root_tmp.path();
+    var restore_path_tmp = try TestDirectory.init("antfly-api-provisioned-table-portable-backup-restore");
+    defer restore_path_tmp.cleanup();
+    const restore_path = restore_path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -34409,8 +34444,12 @@ test "provisioned table write source backs up a portable local table" {
 
 test "provisioned table restore rejects mismatched doc identity namespace" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-provisioned-table-backup-restore-docid-mismatch";
-    const backup_root = "/tmp/antfly-api-provisioned-table-backup-restore-docid-mismatch-out";
+    var path_tmp = try TestDirectory.init("antfly-api-provisioned-table-backup-restore-docid-mismatch");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
+    var backup_root_tmp = try TestDirectory.init("antfly-api-provisioned-table-backup-restore-docid-mismatch-out");
+    defer backup_root_tmp.cleanup();
+    const backup_root = backup_root_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -34520,8 +34559,12 @@ test "provisioned table restore rejects mismatched doc identity namespace" {
 
 test "provisioned table write source backs up and restores full_text writes from the write cache" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-provisioned-write-cache-backup-restore";
-    const backup_root = "/tmp/antfly-api-provisioned-write-cache-backup-restore-out";
+    var path_tmp = try TestDirectory.init("antfly-api-provisioned-write-cache-backup-restore");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
+    var backup_root_tmp = try TestDirectory.init("antfly-api-provisioned-write-cache-backup-restore-out");
+    defer backup_root_tmp.cleanup();
+    const backup_root = backup_root_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -35368,7 +35411,9 @@ test "startup cache clear retires dirty identity without a serving owner" {
 
 test "provisioned read preparation invalidates readers without closing dirty writer cache" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-provisioned-write-cache-read-prep";
+    var path_tmp = try TestDirectory.init("antfly-api-provisioned-write-cache-read-prep");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -35512,7 +35557,9 @@ test "auto bulk best-effort finish does not spin when writer cache lock is busy"
 
 test "auto bulk max-window request waits for idle finish" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-provisioned-auto-bulk-roll-without-next-write";
+    var path_tmp = try TestDirectory.init("antfly-api-provisioned-auto-bulk-roll-without-next-write");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -36128,7 +36175,9 @@ test "managed visibility publish hook updates runtime status cache from live wri
 
 test "provisioned read preparation does not block on same-table batch after early dirty publication" {
     const alloc = std.testing.allocator;
-    const replica_root_dir = "/tmp/antfly-api-provisioned-read-prep-active-batch";
+    var replica_root_dir_tmp = try TestDirectory.init("antfly-api-provisioned-read-prep-active-batch");
+    defer replica_root_dir_tmp.cleanup();
+    const replica_root_dir = replica_root_dir_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -36286,7 +36335,9 @@ test "provisioned read preparation does not block on same-table batch after earl
 
 test "provisioned txn commit reuses cached writer state" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-provisioned-txn-resolve-invalidates-write-cache";
+    var path_tmp = try TestDirectory.init("antfly-api-provisioned-txn-resolve-invalidates-write-cache");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -36375,7 +36426,9 @@ test "provisioned txn commit reuses cached writer state" {
 
 test "bound table write source enforces root conditionals not and unique items" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-table-conditional-unique-schema";
+    var path_tmp = try TestDirectory.init("antfly-api-table-conditional-unique-schema");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -36420,7 +36473,9 @@ test "bound table write source enforces root conditionals not and unique items" 
 
 test "bound table write source enforces property names and dependent required" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-table-property-names-schema";
+    var path_tmp = try TestDirectory.init("antfly-api-table-property-names-schema");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -36456,7 +36511,9 @@ test "bound table write source enforces property names and dependent required" {
 
 test "bound table write source enforces dependent schemas" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-table-dependent-schemas";
+    var path_tmp = try TestDirectory.init("antfly-api-table-dependent-schemas");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -36495,7 +36552,9 @@ test "bound table write source enforces dependent schemas" {
 
 test "bound table write source enforces additional properties" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-table-additional-properties";
+    var path_tmp = try TestDirectory.init("antfly-api-table-additional-properties");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -36531,7 +36590,9 @@ test "bound table write source enforces additional properties" {
 
 test "bound table write source enforces contains semantics" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-table-contains";
+    var path_tmp = try TestDirectory.init("antfly-api-table-contains");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -36570,7 +36631,9 @@ test "bound table write source enforces contains semantics" {
 
 test "bound table write source enforces prefix items and pattern properties" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-table-prefix-pattern";
+    var path_tmp = try TestDirectory.init("antfly-api-table-prefix-pattern");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -36612,7 +36675,9 @@ test "bound table write source enforces prefix items and pattern properties" {
 
 test "bound table write source enforces exclusive numeric bounds and multipleOf" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-table-exclusive-multiple";
+    var path_tmp = try TestDirectory.init("antfly-api-table-exclusive-multiple");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -36651,7 +36716,9 @@ test "bound table write source enforces exclusive numeric bounds and multipleOf"
 
 test "bound table write source enforces nullable and type-array fields" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-table-nullable-types";
+    var path_tmp = try TestDirectory.init("antfly-api-table-nullable-types");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -36687,7 +36754,9 @@ test "bound table write source enforces nullable and type-array fields" {
 
 test "bound table write source enforces local defs and refs" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-table-defs-refs";
+    var path_tmp = try TestDirectory.init("antfly-api-table-defs-refs");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -36723,7 +36792,9 @@ test "bound table write source enforces local defs and refs" {
 
 test "bound table write source enforces ref siblings and nested local defs" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-table-ref-siblings-local-defs";
+    var path_tmp = try TestDirectory.init("antfly-api-table-ref-siblings-local-defs");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -36762,7 +36833,9 @@ test "bound table write source enforces ref siblings and nested local defs" {
 
 test "bound table write source enforces recursive root refs" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-table-recursive-root-refs";
+    var path_tmp = try TestDirectory.init("antfly-api-table-recursive-root-refs");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -36798,7 +36871,9 @@ test "bound table write source enforces recursive root refs" {
 
 test "bound table write source enforces format and additionalItems" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-table-format-additional-items";
+    var path_tmp = try TestDirectory.init("antfly-api-table-format-additional-items");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -36843,7 +36918,9 @@ test "bound table write source enforces format and additionalItems" {
 
 test "bound table write source enforces broader string formats" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-table-broader-formats";
+    var path_tmp = try TestDirectory.init("antfly-api-table-broader-formats");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -36891,7 +36968,9 @@ test "bound table write source enforces broader string formats" {
 
 test "bound table write source enforces unevaluated properties and items" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-table-unevaluated";
+    var path_tmp = try TestDirectory.init("antfly-api-table-unevaluated");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -36930,7 +37009,9 @@ test "bound table write source enforces unevaluated properties and items" {
 
 test "bound table write source enforces composed unevaluated coverage" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-table-unevaluated-composed";
+    var path_tmp = try TestDirectory.init("antfly-api-table-unevaluated-composed");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -36972,7 +37053,9 @@ test "bound table write source enforces composed unevaluated coverage" {
 
 test "bound table write source enforces root unevaluated properties" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-table-root-unevaluated";
+    var path_tmp = try TestDirectory.init("antfly-api-table-root-unevaluated");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -37005,7 +37088,9 @@ test "bound table write source enforces root unevaluated properties" {
 
 test "bound table write source enforces conditional and dependency unevaluated coverage" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-table-conditional-unevaluated";
+    var path_tmp = try TestDirectory.init("antfly-api-table-conditional-unevaluated");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -37047,7 +37132,9 @@ test "bound table write source enforces conditional and dependency unevaluated c
 
 test "bound table write source enforces anyOf and oneOf branch evaluation coverage" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-table-branch-unevaluated";
+    var path_tmp = try TestDirectory.init("antfly-api-table-branch-unevaluated");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -37092,7 +37179,9 @@ test "bound table write source enforces anyOf and oneOf branch evaluation covera
 
 test "bound table write source enforces anyOf and oneOf array evaluation coverage" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-table-array-branch-unevaluated";
+    var path_tmp = try TestDirectory.init("antfly-api-table-array-branch-unevaluated");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -37137,7 +37226,9 @@ test "bound table write source enforces anyOf and oneOf array evaluation coverag
 
 test "bound table write source enforces composed contains-driven array evaluation coverage" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-table-array-contains-unevaluated";
+    var path_tmp = try TestDirectory.init("antfly-api-table-array-contains-unevaluated");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -37182,7 +37273,9 @@ test "bound table write source enforces composed contains-driven array evaluatio
 
 test "bound table write source enforces composed pattern and additional properties evaluation coverage" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-table-pattern-additional-unevaluated";
+    var path_tmp = try TestDirectory.init("antfly-api-table-pattern-additional-unevaluated");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -37227,7 +37320,9 @@ test "bound table write source enforces composed pattern and additional properti
 
 test "bound table write source enforces composed ref closure evaluation coverage" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-table-ref-pattern-additional";
+    var path_tmp = try TestDirectory.init("antfly-api-table-ref-pattern-additional");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -37266,7 +37361,9 @@ test "bound table write source enforces composed ref closure evaluation coverage
 
 test "bound table write source enforces nullable composed refs" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-table-nullable-composed-refs";
+    var path_tmp = try TestDirectory.init("antfly-api-table-nullable-composed-refs");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -37302,7 +37399,9 @@ test "bound table write source enforces nullable composed refs" {
 
 test "bound table write source enforces recursive ref closure semantics" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-table-recursive-closure";
+    var path_tmp = try TestDirectory.init("antfly-api-table-recursive-closure");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -37341,7 +37440,9 @@ test "bound table write source enforces recursive ref closure semantics" {
 
 test "bound table write source enforces escaped ref tokens and direct fragment refs" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-table-ref-escaped-hash";
+    var path_tmp = try TestDirectory.init("antfly-api-table-ref-escaped-hash");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -37380,7 +37481,9 @@ test "bound table write source enforces escaped ref tokens and direct fragment r
 
 test "bound table write source enforces legacy dependencies keyword" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-table-legacy-dependencies";
+    var path_tmp = try TestDirectory.init("antfly-api-table-legacy-dependencies");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -37419,7 +37522,9 @@ test "bound table write source enforces legacy dependencies keyword" {
 
 test "bound table write source rejects invalid commit writes against persisted schema" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-table-commit-schema";
+    var path_tmp = try TestDirectory.init("antfly-api-table-commit-schema");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -37446,7 +37551,9 @@ test "bound table write source rejects invalid commit writes against persisted s
 
 test "bound table write source rejects invalid commit transforms against persisted schema" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-table-commit-transform-schema";
+    var path_tmp = try TestDirectory.init("antfly-api-table-commit-transform-schema");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -37519,7 +37626,9 @@ test "bound table write source aborts graph transform transaction on validation 
 
 test "bound table write source rejects invalid txn prepare writes against persisted schema" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-table-prepare-schema";
+    var path_tmp = try TestDirectory.init("antfly-api-table-prepare-schema");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -37547,7 +37656,9 @@ test "bound table write source rejects invalid txn prepare writes against persis
 
 test "bound table write source rejects invalid txn prepare transforms against persisted schema" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-table-prepare-transform-schema";
+    var path_tmp = try TestDirectory.init("antfly-api-table-prepare-transform-schema");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -37583,7 +37694,9 @@ test "bound table write source rejects invalid txn prepare transforms against pe
 
 test "bound table write source rejects invalid batch transforms against persisted schema" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-table-batch-transform-schema";
+    var path_tmp = try TestDirectory.init("antfly-api-table-batch-transform-schema");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -37617,7 +37730,9 @@ test "bound table write source rejects invalid batch transforms against persiste
 
 test "bound table write source validates transforms against same-batch writes" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-table-batch-transform-same-request-schema";
+    var path_tmp = try TestDirectory.init("antfly-api-table-batch-transform-same-request-schema");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -37657,7 +37772,9 @@ test "bound table write source validates transforms against same-batch writes" {
 
 test "bound table write source validates non-upsert transforms against same-batch deletes" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-table-batch-transform-delete-no-upsert-schema";
+    var path_tmp = try TestDirectory.init("antfly-api-table-batch-transform-delete-no-upsert-schema");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -37696,7 +37813,9 @@ test "bound table write source validates non-upsert transforms against same-batc
 
 test "bound table write source rejects upsert transforms against same-batch deletes" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-table-batch-transform-delete-upsert-schema";
+    var path_tmp = try TestDirectory.init("antfly-api-table-batch-transform-delete-upsert-schema");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -37732,7 +37851,9 @@ test "bound table write source rejects upsert transforms against same-batch dele
 
 test "bound table write source derives ttl timestamps from ttl_field values" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-table-ttl-field-schema";
+    var path_tmp = try TestDirectory.init("antfly-api-table-ttl-field-schema");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -37773,7 +37894,9 @@ test "bound table write source derives ttl timestamps from ttl_field values" {
 
 test "provisioned table write source routes batch writes across ranges" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-provisioned-batch";
+    var path_tmp = try TestDirectory.init("antfly-api-provisioned-batch");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -38059,7 +38182,9 @@ const ProvisionedWriteCoalesceFairnessProbe = struct {
 
 test "provisioned table write source coalesces same-group waiters" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-provisioned-batch-coalesce-waiters";
+    var path_tmp = try TestDirectory.init("antfly-api-provisioned-batch-coalesce-waiters");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -38115,7 +38240,9 @@ test "provisioned table write source coalesces same-group waiters" {
 
 test "provisioned table write coalescer hands off after owner completes" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-provisioned-batch-coalesce-fairness";
+    var path_tmp = try TestDirectory.init("antfly-api-provisioned-batch-coalesce-fairness");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -38171,7 +38298,9 @@ test "provisioned table write coalescer hands off after owner completes" {
 
 test "provisioned table write source preserves same-key delete then write across coalesced waiters" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-provisioned-batch-coalesce-delete-write-order";
+    var path_tmp = try TestDirectory.init("antfly-api-provisioned-batch-coalesce-delete-write-order");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -38223,7 +38352,9 @@ test "provisioned table write source preserves same-key delete then write across
 
 test "provisioned table write coalescer isolates invalid waiter on same-key overlap" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-provisioned-batch-coalesce-overlap-isolation";
+    var path_tmp = try TestDirectory.init("antfly-api-provisioned-batch-coalesce-overlap-isolation");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -38277,7 +38408,9 @@ test "provisioned table write coalescer isolates invalid waiter on same-key over
 
 test "provisioned table write coalescer isolates failed waiters" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-provisioned-batch-coalesce-failure-isolation";
+    var path_tmp = try TestDirectory.init("antfly-api-provisioned-batch-coalesce-failure-isolation");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -38329,7 +38462,9 @@ test "provisioned table write coalescer isolates failed waiters" {
 
 test "provisioned table write source rejects writes that violate enforced document schemas" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-provisioned-batch-schema";
+    var path_tmp = try TestDirectory.init("antfly-api-provisioned-batch-schema");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -38378,7 +38513,9 @@ test "provisioned table write source rejects writes that violate enforced docume
 
 test "provisioned table write source drains managed dense enrichment before close" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-provisioned-managed-dense-drain";
+    var path_tmp = try TestDirectory.init("antfly-api-provisioned-managed-dense-drain");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     const FakeEmbeddingProvider = struct {
         fn executor() http_common.RequestExecutor {
@@ -38510,7 +38647,9 @@ test "provisioned table write source drains managed dense enrichment before clos
 
 test "structural reconcile reconfigures retained writer before managed dense writes" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-provisioned-managed-dense-write-cache";
+    var path_tmp = try TestDirectory.init("antfly-api-provisioned-managed-dense-write-cache");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     const FakeEmbeddingProvider = struct {
         var request_count: std.atomic.Value(u32) = .init(0);
@@ -39061,7 +39200,9 @@ test "provisioned managed replay tails converge and publish without later traffi
 
 test "failed full index enrichment does not make resident reads unavailable" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-provisioned-managed-dense-write-cache-failed-close";
+    var path_tmp = try TestDirectory.init("antfly-api-provisioned-managed-dense-write-cache-failed-close");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     const FakeEmbeddingProvider = struct {
         var request_count: std.atomic.Value(u32) = .init(0);
@@ -39280,7 +39421,9 @@ test "failed full index enrichment does not make resident reads unavailable" {
 
 test "provisioned table write source invalidates cached query db after managed dense replay becomes visible" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-provisioned-managed-dense-query-visibility";
+    var path_tmp = try TestDirectory.init("antfly-api-provisioned-managed-dense-query-visibility");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     const FakeEmbeddingProvider = struct {
         request_count: std.atomic.Value(u32) = .init(0),
@@ -39503,7 +39646,9 @@ test "provisioned table write source invalidates cached query db after managed d
 
 test "provisioned table write source persists chunk artifacts when chunker enables full text indexing" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-provisioned-managed-chunk-full-text";
+    var path_tmp = try TestDirectory.init("antfly-api-provisioned-managed-chunk-full-text");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     const FakeEmbeddingProvider = struct {
         fn executor() http_common.RequestExecutor {
@@ -40872,7 +41017,9 @@ test "raft batch aggregation makes failures after an accepted group non-retryabl
 
 test "provisioned table write source runtime status prefers shared snapshot cache" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-provisioned-write-runtime-prefers-snapshot";
+    var path_tmp = try TestDirectory.init("antfly-api-provisioned-write-runtime-prefers-snapshot");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -54580,7 +54727,9 @@ test "provisioned table write source drop index does not hold local db mutex dur
 
 test "provisioned table write source create table provisions local indexes and schema" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-provisioned-create-schema";
+    var path_tmp = try TestDirectory.init("antfly-api-provisioned-create-schema");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
     const schema_json =
         "{\"default_type\":\"doc\",\"enforce_types\":true,\"document_schemas\":{\"doc\":{\"schema\":{\"type\":\"object\",\"properties\":{\"title\":{\"type\":\"text\"}}}}}}";
 
@@ -55349,8 +55498,12 @@ test "cached runtime status is independent of writer lock and target observation
 
 test "provisioned table write source restore table does not hold local db mutex during restore work" {
     const alloc = std.testing.allocator;
-    const path = "/tmp/antfly-api-provisioned-table-restore-mutex";
-    const backup_root = "/tmp/antfly-api-provisioned-table-restore-mutex-out";
+    var path_tmp = try TestDirectory.init("antfly-api-provisioned-table-restore-mutex");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path();
+    var backup_root_tmp = try TestDirectory.init("antfly-api-provisioned-table-restore-mutex-out");
+    defer backup_root_tmp.cleanup();
+    const backup_root = backup_root_tmp.path();
 
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -55423,11 +55576,12 @@ test "provisioned table write source restore table does not hold local db mutex 
     const Worker = struct {
         source: *ProvisionedTableWriteSource,
         manifest: *const backups_api.TableBackupManifest,
+        backup_root: []const u8,
         err: ?anyerror = null,
 
         fn run(self: *@This()) void {
             _ = self.source.source().restoreTable(std.heap.page_allocator, "docs", .{
-                .backup_root = backup_root,
+                .backup_root = self.backup_root,
                 .manifest = self.manifest,
                 .artifact_backup_id = self.manifest.backup_id,
                 .source_location = "file:///provisioned-restore-preparation-test",
@@ -55476,6 +55630,7 @@ test "provisioned table write source restore table does not hold local db mutex 
     var worker = Worker{
         .source = &source,
         .manifest = &manifest,
+        .backup_root = backup_root,
     };
     const thread = try std.Thread.spawn(.{}, Worker.run, .{&worker});
 

--- a/zig/pkg/antfly/src/capi/db.zig
+++ b/zig/pkg/antfly/src/capi/db.zig
@@ -14,6 +14,7 @@
 
 const std = @import("std");
 const antfly = @import("antfly_storage_root");
+const TestDirectory = antfly.testing.TestDirectory;
 const vector_mod = @import("antfly_vector").vector;
 const capi = @import("types.zig");
 const search_wire = @import("search_wire.zig");
@@ -44,21 +45,12 @@ fn monotonicNowNs() u64 {
     return antfly.platform_time.monotonicNs();
 }
 
-var temp_test_path_nonce: u64 = 0;
-
-fn tempTestPath(alloc: Allocator, label: []const u8) ![:0]u8 {
-    const nonce = @atomicRmw(u64, &temp_test_path_nonce, .Add, 1, .monotonic);
-    const path = try std.fmt.allocPrint(alloc, "/tmp/antfly-{s}-{d}-{d}", .{
-        label,
-        antfly.platform_time.monotonicNs(),
-        nonce,
-    });
-    defer alloc.free(path);
-    return try alloc.dupeZ(u8, path);
+fn tempTestPath(alloc: Allocator, root: []const u8, label: []const u8) ![:0]u8 {
+    return try std.fmt.allocPrintSentinel(alloc, "{s}-{s}", .{ root, label }, 0);
 }
 
-fn tempTestAflitePath(alloc: Allocator, label: []const u8) ![:0]u8 {
-    const base = try tempTestPath(alloc, label);
+fn tempTestAflitePath(alloc: Allocator, root: []const u8, label: []const u8) ![:0]u8 {
+    const base = try tempTestPath(alloc, root, label);
     defer alloc.free(base);
     const path = try std.fmt.allocPrint(alloc, "{s}.aflite", .{base});
     defer alloc.free(path);
@@ -6607,8 +6599,10 @@ pub export fn antfly_db_snapshot(
 }
 
 test "capi transaction lifecycle" {
+    var test_tmp = try TestDirectory.init("capi");
+    defer test_tmp.cleanup();
     const alloc = std.testing.allocator;
-    const path = try tempTestPath(alloc, "capi-test");
+    const path = try tempTestPath(alloc, test_tmp.path(), "capi-test");
     defer alloc.free(path);
     var handle_ptr: ?*anyopaque = null;
     cleanupTestDir(path);
@@ -6651,8 +6645,10 @@ test "capi transaction lifecycle" {
 }
 
 test "capi batch and lookup json" {
+    var test_tmp = try TestDirectory.init("capi");
+    defer test_tmp.cleanup();
     const alloc = std.testing.allocator;
-    const path = try tempTestPath(alloc, "capi-batch-test");
+    const path = try tempTestPath(alloc, test_tmp.path(), "capi-batch-test");
     defer alloc.free(path);
     var handle_ptr: ?*anyopaque = null;
     cleanupTestDir(path);
@@ -6702,46 +6698,48 @@ test "capi batch and lookup json" {
 }
 
 test "capi lite opens exports imports checks and vacuums aflite" {
+    var test_tmp = try TestDirectory.init("capi");
+    defer test_tmp.cleanup();
     const alloc = std.testing.allocator;
-    const plain_path = try tempTestPath(alloc, "capi-lite-plain");
+    const plain_path = try tempTestPath(alloc, test_tmp.path(), "capi-lite-plain");
     defer alloc.free(plain_path);
-    const invalid_lite_path = try tempTestPath(alloc, "capi-lite-invalid");
+    const invalid_lite_path = try tempTestPath(alloc, test_tmp.path(), "capi-lite-invalid");
     defer alloc.free(invalid_lite_path);
-    const missing_readonly_path = try tempTestAflitePath(alloc, "capi-lite-missing-readonly");
+    const missing_readonly_path = try tempTestAflitePath(alloc, test_tmp.path(), "capi-lite-missing-readonly");
     defer alloc.free(missing_readonly_path);
-    const missing_status_path = try tempTestAflitePath(alloc, "capi-lite-missing-status");
+    const missing_status_path = try tempTestAflitePath(alloc, test_tmp.path(), "capi-lite-missing-status");
     defer alloc.free(missing_status_path);
-    const short_lite_path = try tempTestAflitePath(alloc, "capi-lite-short");
+    const short_lite_path = try tempTestAflitePath(alloc, test_tmp.path(), "capi-lite-short");
     defer alloc.free(short_lite_path);
-    const src_path = try tempTestAflitePath(alloc, "capi-lite-src");
+    const src_path = try tempTestAflitePath(alloc, test_tmp.path(), "capi-lite-src");
     defer alloc.free(src_path);
-    const remote_inference_path = try tempTestAflitePath(alloc, "capi-lite-remote-inference");
+    const remote_inference_path = try tempTestAflitePath(alloc, test_tmp.path(), "capi-lite-remote-inference");
     defer alloc.free(remote_inference_path);
-    const local_inference_path = try tempTestAflitePath(alloc, "capi-lite-local-inference");
+    const local_inference_path = try tempTestAflitePath(alloc, test_tmp.path(), "capi-lite-local-inference");
     defer alloc.free(local_inference_path);
-    const dst_path = try tempTestAflitePath(alloc, "capi-lite-dst");
+    const dst_path = try tempTestAflitePath(alloc, test_tmp.path(), "capi-lite-dst");
     defer alloc.free(dst_path);
-    const bad_dst_path = try tempTestAflitePath(alloc, "capi-lite-bad-dst");
+    const bad_dst_path = try tempTestAflitePath(alloc, test_tmp.path(), "capi-lite-bad-dst");
     defer alloc.free(bad_dst_path);
-    const schema_dst_path = try tempTestAflitePath(alloc, "capi-lite-schema-dst");
+    const schema_dst_path = try tempTestAflitePath(alloc, test_tmp.path(), "capi-lite-schema-dst");
     defer alloc.free(schema_dst_path);
-    const snapshot_path = try tempTestAflitePath(alloc, "capi-lite-snapshot");
+    const snapshot_path = try tempTestAflitePath(alloc, test_tmp.path(), "capi-lite-snapshot");
     defer alloc.free(snapshot_path);
-    const snapshot_file_path = try tempTestAflitePath(alloc, "capi-lite-snapshot-file");
+    const snapshot_file_path = try tempTestAflitePath(alloc, test_tmp.path(), "capi-lite-snapshot-file");
     defer alloc.free(snapshot_file_path);
-    const pinned_snapshot_path = try tempTestAflitePath(alloc, "capi-lite-pinned-snapshot");
+    const pinned_snapshot_path = try tempTestAflitePath(alloc, test_tmp.path(), "capi-lite-pinned-snapshot");
     defer alloc.free(pinned_snapshot_path);
-    const restore_path = try tempTestAflitePath(alloc, "capi-lite-restore");
+    const restore_path = try tempTestAflitePath(alloc, test_tmp.path(), "capi-lite-restore");
     defer alloc.free(restore_path);
-    const restore_alias_path = try tempTestAflitePath(alloc, "capi-lite-restore-alias");
+    const restore_alias_path = try tempTestAflitePath(alloc, test_tmp.path(), "capi-lite-restore-alias");
     defer alloc.free(restore_alias_path);
-    const locked_restore_path = try tempTestAflitePath(alloc, "capi-lite-restore-locked");
+    const locked_restore_path = try tempTestAflitePath(alloc, test_tmp.path(), "capi-lite-restore-locked");
     defer alloc.free(locked_restore_path);
-    const restore_malformed_path = try tempTestAflitePath(alloc, "capi-lite-restore-malformed");
+    const restore_malformed_path = try tempTestAflitePath(alloc, test_tmp.path(), "capi-lite-restore-malformed");
     defer alloc.free(restore_malformed_path);
-    const invalid_snapshot_path = try tempTestPath(alloc, "capi-lite-snapshot-invalid");
+    const invalid_snapshot_path = try tempTestPath(alloc, test_tmp.path(), "capi-lite-snapshot-invalid");
     defer alloc.free(invalid_snapshot_path);
-    const invalid_snapshot_file_path = try tempTestPath(alloc, "capi-lite-snapshot-file-invalid");
+    const invalid_snapshot_file_path = try tempTestPath(alloc, test_tmp.path(), "capi-lite-snapshot-file-invalid");
     defer alloc.free(invalid_snapshot_file_path);
     cleanupTestDir(plain_path);
     cleanupTestFile(invalid_lite_path);
@@ -7519,8 +7517,10 @@ test "capi lite opens exports imports checks and vacuums aflite" {
 }
 
 test "capi lite exposes hosted and status-only profiles" {
+    var test_tmp = try TestDirectory.init("capi");
+    defer test_tmp.cleanup();
     const alloc = std.testing.allocator;
-    const path = try tempTestAflitePath(alloc, "capi-lite-profiles");
+    const path = try tempTestAflitePath(alloc, test_tmp.path(), "capi-lite-profiles");
     defer alloc.free(path);
     cleanupTestFile(path);
     defer cleanupTestFile(path);
@@ -7599,8 +7599,10 @@ test "capi lite exposes hosted and status-only profiles" {
 }
 
 test "capi lite open options validate and configure ttl cleanup" {
+    var test_tmp = try TestDirectory.init("capi");
+    defer test_tmp.cleanup();
     const alloc = std.testing.allocator;
-    const path = try tempTestAflitePath(alloc, "capi-lite-open-options");
+    const path = try tempTestAflitePath(alloc, test_tmp.path(), "capi-lite-open-options");
     defer alloc.free(path);
     cleanupTestFile(path);
     defer cleanupTestFile(path);
@@ -7683,7 +7685,7 @@ test "capi lite open options validate and configure ttl cleanup" {
     default_handle = null;
     cleanupTestFile(path);
 
-    const dir_path = try tempTestPath(alloc, "capi-generic-directory-open");
+    const dir_path = try tempTestPath(alloc, test_tmp.path(), "capi-generic-directory-open");
     defer alloc.free(dir_path);
     cleanupTestDir(dir_path);
     defer cleanupTestDir(dir_path);
@@ -7790,8 +7792,10 @@ test "capi lite open options validate and configure ttl cleanup" {
 }
 
 test "capi execute graph queries honors identity read generation" {
+    var test_tmp = try TestDirectory.init("capi");
+    defer test_tmp.cleanup();
     const alloc = std.testing.allocator;
-    const path = try tempTestPath(alloc, "capi-execute-graph-generation");
+    const path = try tempTestPath(alloc, test_tmp.path(), "capi-execute-graph-generation");
     defer alloc.free(path);
     var handle_ptr: ?*anyopaque = null;
     cleanupTestDir(path);
@@ -7854,8 +7858,10 @@ test "capi execute graph queries honors identity read generation" {
 }
 
 test "capi search rejects stale identity generation before readable lease hook" {
+    var test_tmp = try TestDirectory.init("capi");
+    defer test_tmp.cleanup();
     const alloc = std.testing.allocator;
-    const path = try tempTestPath(alloc, "capi-stale-generation-before-lease");
+    const path = try tempTestPath(alloc, test_tmp.path(), "capi-stale-generation-before-lease");
     defer alloc.free(path);
 
     cleanupTestDir(path);
@@ -7926,8 +7932,10 @@ test "capi search rejects stale identity generation before readable lease hook" 
 }
 
 test "capi search json returns stamped identity generation" {
+    var test_tmp = try TestDirectory.init("capi");
+    defer test_tmp.cleanup();
     const alloc = std.testing.allocator;
-    const path = try tempTestPath(alloc, "capi-search-generation-response");
+    const path = try tempTestPath(alloc, test_tmp.path(), "capi-search-generation-response");
     defer alloc.free(path);
 
     cleanupTestDir(path);
@@ -8015,8 +8023,10 @@ test "capi search json returns stamped identity generation" {
 }
 
 test "capi aggregate hits rejects stale identity generation before aggregation materialization" {
+    var test_tmp = try TestDirectory.init("capi");
+    defer test_tmp.cleanup();
     const alloc = std.testing.allocator;
-    const path = try tempTestPath(alloc, "capi-aggregate-stale-generation");
+    const path = try tempTestPath(alloc, test_tmp.path(), "capi-aggregate-stale-generation");
     defer alloc.free(path);
 
     cleanupTestDir(path);
@@ -8074,8 +8084,10 @@ test "capi aggregate hits rejects stale identity generation before aggregation m
 }
 
 test "capi request paths trigger readable lease hook" {
+    var test_tmp = try TestDirectory.init("capi");
+    defer test_tmp.cleanup();
     const alloc = std.testing.allocator;
-    const path = try tempTestPath(alloc, "capi-readable-lease");
+    const path = try tempTestPath(alloc, test_tmp.path(), "capi-readable-lease");
     defer alloc.free(path);
 
     cleanupTestDir(path);
@@ -8264,8 +8276,10 @@ test "capi request paths trigger readable lease hook" {
 }
 
 test "capi artifact decode and lookup json" {
+    var test_tmp = try TestDirectory.init("capi");
+    defer test_tmp.cleanup();
     const alloc = std.testing.allocator;
-    const path = try tempTestPath(alloc, "capi-artifact-test");
+    const path = try tempTestPath(alloc, test_tmp.path(), "capi-artifact-test");
     defer alloc.free(path);
     var handle_ptr: ?*anyopaque = null;
     cleanupTestDir(path);
@@ -8331,8 +8345,10 @@ test "capi artifact decode and lookup json" {
 }
 
 test "capi dense search profile breakdown" {
+    var test_tmp = try TestDirectory.init("capi");
+    defer test_tmp.cleanup();
     const alloc = std.testing.allocator;
-    const path = try tempTestPath(alloc, "capi-dense-profile");
+    const path = try tempTestPath(alloc, test_tmp.path(), "capi-dense-profile");
     defer alloc.free(path);
 
     cleanupTestDir(path);

--- a/zig/pkg/antfly/src/capi_root.zig
+++ b/zig/pkg/antfly/src/capi_root.zig
@@ -33,3 +33,4 @@ pub const public_api = @import("api/mod.zig");
 pub const raft = @import("raft/mod.zig");
 pub const transactions = @import("storage/transactions.zig");
 pub const traversal = @import("graph/traversal.zig");
+pub const testing = @import("common/test_directory.zig");

--- a/zig/pkg/antfly/src/common/test_directory.zig
+++ b/zig/pkg/antfly/src/common/test_directory.zig
@@ -1,0 +1,66 @@
+// Copyright 2026 Antfly, Inc.
+//
+// Licensed under the Elastic License 2.0 (ELv2); you may not use this file
+// except in compliance with the Elastic License 2.0. You may obtain a copy of
+// the Elastic License 2.0 at
+//
+//     https://www.antfly.io/licensing/ELv2-license
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the Elastic License 2.0 is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// Elastic License 2.0 for the specific language governing permissions and
+// limitations.
+
+const std = @import("std");
+
+/// Owns a temporary parent around a database/file path. Locks, staging roots,
+/// and other siblings of path() are removed along with the fixture.
+pub const TestDirectory = struct {
+    tmp: std.testing.TmpDir,
+    path_buffer: [std.fs.max_path_bytes]u8,
+    path_len: usize,
+
+    pub fn init(comptime name: []const u8) !TestDirectory {
+        comptime std.debug.assert(name.len > 0 and std.mem.indexOfAny(u8, name, "/\\") == null and
+            !std.mem.eql(u8, name, ".") and !std.mem.eql(u8, name, ".."));
+        var result: TestDirectory = .{
+            .tmp = std.testing.tmpDir(.{}),
+            .path_buffer = undefined,
+            .path_len = undefined,
+        };
+        errdefer result.tmp.cleanup();
+        const root_len = try result.tmp.dir.realPath(std.testing.io, &result.path_buffer);
+        const suffix = try std.fmt.bufPrintZ(result.path_buffer[root_len..], "/{s}", .{name});
+        result.path_len = root_len + suffix.len;
+        return result;
+    }
+
+    pub fn path(self: *const TestDirectory) [:0]const u8 {
+        return self.path_buffer[0..self.path_len :0];
+    }
+
+    pub fn cleanup(self: *TestDirectory) void {
+        self.tmp.cleanup();
+        self.* = undefined;
+    }
+};
+
+test "test directory isolates identical child names and removes sibling files" {
+    var first = try TestDirectory.init("db");
+    var first_active = true;
+    defer if (first_active) first.cleanup();
+    var second = try TestDirectory.init("db");
+    defer second.cleanup();
+    try std.testing.expect(!std.mem.eql(u8, first.path(), second.path()));
+
+    try std.Io.Dir.cwd().createDirPath(std.testing.io, first.path());
+    const lock_path = try std.fmt.allocPrint(std.testing.allocator, "{s}.lock", .{first.path()});
+    defer std.testing.allocator.free(lock_path);
+    const file = try std.Io.Dir.cwd().createFile(std.testing.io, lock_path, .{});
+    file.close(std.testing.io);
+    first.cleanup();
+    first_active = false;
+    try std.testing.expectError(error.FileNotFound, std.Io.Dir.cwd().access(std.testing.io, lock_path, .{}));
+    try second.tmp.dir.access(std.testing.io, ".", .{});
+}

--- a/zig/pkg/antfly/src/embedded/api.zig
+++ b/zig/pkg/antfly/src/embedded/api.zig
@@ -459,7 +459,7 @@ test "embedded api round-trips batch lookup scan and search over memory-backed d
     defer tmp.cleanup();
 
     var path_buf: [std.fs.max_path_bytes]u8 = undefined;
-    const path = try std.fmt.bufPrint(&path_buf, ".zig-cache/tmp/{s}", .{tmp.sub_path});
+    const path = try std.fmt.bufPrint(&path_buf, ".zig-cache/tmp/{s}/db", .{tmp.sub_path});
 
     var memory_storage = lsm_backend.MemoryStorage.init(alloc);
     defer memory_storage.deinit();
@@ -560,7 +560,7 @@ test "embedded api hosted profile drains derived indexing without native runtime
     defer tmp.cleanup();
 
     var path_buf: [std.fs.max_path_bytes]u8 = undefined;
-    const path = try std.fmt.bufPrint(&path_buf, ".zig-cache/tmp/{s}", .{tmp.sub_path});
+    const path = try std.fmt.bufPrint(&path_buf, ".zig-cache/tmp/{s}/db", .{tmp.sub_path});
 
     var memory_storage = lsm_backend.MemoryStorage.init(alloc);
     defer memory_storage.deinit();
@@ -632,7 +632,7 @@ test "embedded api hosted profile persists text index across reopen over storage
     defer tmp.cleanup();
 
     var path_buf: [std.fs.max_path_bytes]u8 = undefined;
-    const path = try std.fmt.bufPrint(&path_buf, ".zig-cache/tmp/{s}", .{tmp.sub_path});
+    const path = try std.fmt.bufPrint(&path_buf, ".zig-cache/tmp/{s}/db", .{tmp.sub_path});
 
     var memory_storage = lsm_backend.MemoryStorage.init(alloc);
     defer memory_storage.deinit();

--- a/zig/pkg/antfly/src/embedded/db.zig
+++ b/zig/pkg/antfly/src/embedded/db.zig
@@ -172,7 +172,7 @@ pub const DB = struct {
 
     pub fn liteStatus(self: *DB, alloc: Allocator) !LiteStatus {
         const backend = if (self.owned_lite_backend) |*lite_backend| lite_backend else return error.NotLiteDatabase;
-        var status = try backend.fullStatus(alloc, &self.inner, self.profile);
+        var status = try backend.fullStatus(alloc, self.inner, self.profile);
         status.inference = self.lite_inference_status orelse status.inference;
         status.capabilities = support.lite.backend.capabilitiesForProfileWithInferenceStatus(self.profile, status.inference);
         return status;

--- a/zig/pkg/antfly/src/storage/db/db.zig
+++ b/zig/pkg/antfly/src/storage/db/db.zig
@@ -13,6 +13,7 @@
 // limitations.
 
 const std = @import("std");
+const TestDirectory = @import("../../common/test_directory.zig").TestDirectory;
 const ant_json = @import("antfly-json");
 const vector_mod = @import("antfly_vector").vector;
 const platform_sync = @import("antfly_platform").sync;
@@ -340,8 +341,9 @@ test "document extraction inline source size uses remote content limit" {
 test "document extraction templated inline source size is rejected before persistence" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     const security = scraping.ContentSecurityConfig{ .max_download_size_bytes = 4 };
@@ -3041,7 +3043,6 @@ fn logSparseWriteProfileDelta(index_name: []const u8, delta: sparse_mod.WritePro
     );
 }
 
-var temp_path_nonce: u64 = 0;
 var split_replay_artifact_nonce: u64 = 0;
 var repair_shadow_nonce = AtomicU64.init(0);
 
@@ -3686,8 +3687,9 @@ test "multi-source sparse replay retains each artifact member" {
 
 test "stale multi-source vector replay writes are source fenced" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -6462,8 +6464,9 @@ pub const DB = struct {
 
     test "db lsm maintenance reclaims due index obsolete paths before primary compaction" {
         const alloc = std.testing.allocator;
-        var path_buf: [256]u8 = undefined;
-        const path = tempPath(&path_buf);
+        var path_tmp = try TestDirectory.init("db");
+        defer path_tmp.cleanup();
+        const path = path_tmp.path().ptr;
         defer cleanupTempDir(path);
 
         var db = try DB.open(alloc, std.mem.span(path), .{
@@ -6556,8 +6559,9 @@ pub const DB = struct {
 
     test "db primary lsm maintenance step does not reclaim index obsolete paths" {
         const alloc = std.testing.allocator;
-        var path_buf: [256]u8 = undefined;
-        const path = tempPath(&path_buf);
+        var path_tmp = try TestDirectory.init("db");
+        defer path_tmp.cleanup();
+        const path = path_tmp.path().ptr;
         defer cleanupTempDir(path);
 
         var db = try DB.open(alloc, std.mem.span(path), .{
@@ -14425,8 +14429,9 @@ pub const DB = struct {
 
     test "rollback action required atomically retires activation certification" {
         const alloc = std.testing.allocator;
-        var path_buf: [256]u8 = undefined;
-        const path = tempPath(&path_buf);
+        var path_tmp = try TestDirectory.init("db");
+        defer path_tmp.cleanup();
+        const path = path_tmp.path().ptr;
         defer cleanupTempDir(path);
 
         var db = try DB.open(alloc, std.mem.span(path), .{
@@ -43028,8 +43033,9 @@ test "async context dense catch-up session finish is idempotent when already clo
 test "dense target advance is not blocked by local catch-up session" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -43066,8 +43072,9 @@ test "dense target advance is not blocked by local catch-up session" {
 test "dense target advance is blocked while external bulk session is active" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -43261,8 +43268,9 @@ fn publishResolutionHandoffContextWithSink(
 test "db resolution handoff completion publishes fanout in one metadata batch" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -43319,14 +43327,17 @@ test "storage.ha resolution handoff fence rejects completion after durable HA re
     if (builtin.single_threaded or builtin.os.tag == .freestanding) return error.SkipZigTest;
 
     const alloc = std.heap.c_allocator;
-    var db_path_buf: [256]u8 = undefined;
-    const db_path = tempPath(&db_path_buf);
+    var db_path_tmp = try TestDirectory.init("db");
+    defer db_path_tmp.cleanup();
+    const db_path = db_path_tmp.path().ptr;
     defer cleanupTempDir(db_path);
-    var ha_log_path_buf: [256]u8 = undefined;
-    const ha_log_path = tempPath(&ha_log_path_buf);
+    var ha_log_path_tmp = try TestDirectory.init("db");
+    defer ha_log_path_tmp.cleanup();
+    const ha_log_path = ha_log_path_tmp.path().ptr;
     defer cleanupTempDir(ha_log_path);
-    var ha_slots_path_buf: [256]u8 = undefined;
-    const ha_slots_path = tempPath(&ha_slots_path_buf);
+    var ha_slots_path_tmp = try TestDirectory.init("db");
+    defer ha_slots_path_tmp.cleanup();
+    const ha_slots_path = ha_slots_path_tmp.path().ptr;
     defer cleanupTempDir(ha_slots_path);
 
     var primary = try ha_primary_mod.Primary.open(alloc, ha_log_path, ha_slots_path, .{
@@ -53904,15 +53915,6 @@ fn allocStressDenseDocJson(alloc: Allocator, dims: usize, doc_index: usize) ![]u
     return owned;
 }
 
-fn tempPath(buf: []u8) [*:0]const u8 {
-    const base = "/tmp/antfly-db-test-";
-    const ts = monotonicTimeNs();
-    const pid: u32 = @intCast(std.posix.system.getpid());
-    const nonce = @atomicRmw(u64, &temp_path_nonce, .Add, 1, .monotonic);
-    const path = std.fmt.bufPrint(buf, "{s}{d}-{d}-{d}\x00", .{ base, pid, ts, nonce }) catch unreachable;
-    return @ptrCast(path.ptr);
-}
-
 fn denseTestVectorId(doc_key: []const u8) u64 {
     const id = std.hash.XxHash64.hash(0, doc_key);
     return if (id == 0) 1 else id;
@@ -54220,8 +54222,9 @@ fn putSparseEmbeddingArtifactForTest(
 test "db vector indexes combine direct document and chunk-backed artifact sources" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -55268,10 +55271,12 @@ fn reportReducedDbSplitSchedule(
         case_label: []const u8,
 
         pub fn replay(self: @This(), candidate: []const DbSplitSimAction) !void {
-            var source_path_buf: [256]u8 = undefined;
-            var dest_path_buf: [256]u8 = undefined;
-            const source_path = tempPath(&source_path_buf);
-            const dest_path = tempPath(&dest_path_buf);
+            var source_path_tmp = try TestDirectory.init("db");
+            defer source_path_tmp.cleanup();
+            var dest_path_tmp = try TestDirectory.init("db");
+            defer dest_path_tmp.cleanup();
+            const source_path = source_path_tmp.path().ptr;
+            const dest_path = dest_path_tmp.path().ptr;
             defer cleanupTempDir(source_path);
             defer cleanupTempDir(dest_path);
             const actual = try replayDbSplitActionsAtPaths(self.alloc, source_path, dest_path, candidate);
@@ -55358,6 +55363,21 @@ fn dbSplitModeledOpenOptions(modeled_device: *storage_sim.ModeledDevice) OpenOpt
     };
 }
 
+fn prepareModeledDbSplitRoot(modeled_device: *storage_sim.ModeledDevice, path: []const u8) !void {
+    try ensureDirPath(path);
+    // The fixture's parent already exists outside the simulated database
+    // lifecycle. Represent all of its ancestors as durable before DB.open,
+    // just as the model previously did implicitly for the top-level /tmp.
+    const storage = modeled_device.storage();
+    var parent = std.fs.path.dirname(path) orelse return;
+    try storage.createDirPath(parent);
+    while (std.fs.path.dirname(parent)) |ancestor| {
+        try storage.syncParentAbsolute(parent);
+        if (std.mem.eql(u8, parent, ancestor)) break;
+        parent = ancestor;
+    }
+}
+
 fn runDbSplitReplayCase(
     alloc: Allocator,
     case_label: []const u8,
@@ -55367,10 +55387,12 @@ fn runDbSplitReplayCase(
     const actions = try buildDbSplitReplayActions(alloc, seed, steps);
     defer alloc.free(actions);
 
-    var source_path_buf: [256]u8 = undefined;
-    var dest_path_buf: [256]u8 = undefined;
-    const source_path = tempPath(&source_path_buf);
-    const dest_path = tempPath(&dest_path_buf);
+    var source_path_tmp = try TestDirectory.init("db");
+    defer source_path_tmp.cleanup();
+    var dest_path_tmp = try TestDirectory.init("db");
+    defer dest_path_tmp.cleanup();
+    const source_path = source_path_tmp.path().ptr;
+    const dest_path = dest_path_tmp.path().ptr;
     defer cleanupTempDir(source_path);
     defer cleanupTempDir(dest_path);
 
@@ -55397,14 +55419,16 @@ fn runModeledDbSplitReplayCase(
     defer modeled_device.deinit();
     const open_options = dbSplitModeledOpenOptions(&modeled_device);
 
-    var source_path_buf: [256]u8 = undefined;
-    var dest_path_buf: [256]u8 = undefined;
-    const source_path = tempPath(&source_path_buf);
-    const dest_path = tempPath(&dest_path_buf);
+    var source_path_tmp = try TestDirectory.init("db");
+    defer source_path_tmp.cleanup();
+    var dest_path_tmp = try TestDirectory.init("db");
+    defer dest_path_tmp.cleanup();
+    const source_path = source_path_tmp.path().ptr;
+    const dest_path = dest_path_tmp.path().ptr;
     defer cleanupTempDir(source_path);
     defer cleanupTempDir(dest_path);
-    try ensureDirPath(std.mem.span(source_path));
-    try ensureDirPath(std.mem.span(dest_path));
+    try prepareModeledDbSplitRoot(&modeled_device, std.mem.span(source_path));
+    try prepareModeledDbSplitRoot(&modeled_device, std.mem.span(dest_path));
 
     const actual = try replayDbSplitActionsAtPathsWithOptions(
         alloc,
@@ -55465,10 +55489,12 @@ fn runDbSplitReplayFixtures(alloc: Allocator) !void {
         defer fixture.deinit(alloc);
 
         const fixture_name = fixture.case_label orelse fixture.label orelse fixture_rel_path;
-        var source_path_buf: [256]u8 = undefined;
-        var dest_path_buf: [256]u8 = undefined;
-        const source_path = tempPath(&source_path_buf);
-        const dest_path = tempPath(&dest_path_buf);
+        var source_path_tmp = try TestDirectory.init("db");
+        defer source_path_tmp.cleanup();
+        var dest_path_tmp = try TestDirectory.init("db");
+        defer dest_path_tmp.cleanup();
+        const source_path = source_path_tmp.path().ptr;
+        const dest_path = dest_path_tmp.path().ptr;
         defer cleanupTempDir(source_path);
         defer cleanupTempDir(dest_path);
 
@@ -55517,14 +55543,16 @@ fn runModeledDbSplitReplayFixtures(alloc: Allocator) !void {
         defer modeled_device.deinit();
         const open_options = dbSplitModeledOpenOptions(&modeled_device);
 
-        var source_path_buf: [256]u8 = undefined;
-        var dest_path_buf: [256]u8 = undefined;
-        const source_path = tempPath(&source_path_buf);
-        const dest_path = tempPath(&dest_path_buf);
+        var source_path_tmp = try TestDirectory.init("db");
+        defer source_path_tmp.cleanup();
+        var dest_path_tmp = try TestDirectory.init("db");
+        defer dest_path_tmp.cleanup();
+        const source_path = source_path_tmp.path().ptr;
+        const dest_path = dest_path_tmp.path().ptr;
         defer cleanupTempDir(source_path);
         defer cleanupTempDir(dest_path);
-        try ensureDirPath(std.mem.span(source_path));
-        try ensureDirPath(std.mem.span(dest_path));
+        try prepareModeledDbSplitRoot(&modeled_device, std.mem.span(source_path));
+        try prepareModeledDbSplitRoot(&modeled_device, std.mem.span(dest_path));
 
         const actual = try replayDbSplitActionsAtPathsWithOptions(
             alloc,
@@ -55575,10 +55603,12 @@ test "db split sim reopen-heavy workload stays green" {
 test "db split full keeps subsequent left-side source writes searchable" {
     const alloc = std.testing.allocator;
 
-    var source_path_buf: [256]u8 = undefined;
-    var dest_path_buf: [256]u8 = undefined;
-    const source_path = tempPath(&source_path_buf);
-    const dest_path = tempPath(&dest_path_buf);
+    var source_path_tmp = try TestDirectory.init("db");
+    defer source_path_tmp.cleanup();
+    var dest_path_tmp = try TestDirectory.init("db");
+    defer dest_path_tmp.cleanup();
+    const source_path = source_path_tmp.path().ptr;
+    const dest_path = dest_path_tmp.path().ptr;
     defer cleanupTempDir(source_path);
     defer cleanupTempDir(dest_path);
 
@@ -55628,8 +55658,9 @@ test "db split modeled sim workloads stay green" {
 test "db batch get match_all search and index registry" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -55672,8 +55703,9 @@ test "db batch get match_all search and index registry" {
 test "db match_all consumes resolved ordinal filter" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -55721,8 +55753,9 @@ test "db stats report engine-owned algebraic adaptive observation status" {
     const alloc = std.testing.allocator;
     const algebraic_ir = @import("algebraic/ir.zig");
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     const cfg =
@@ -55841,8 +55874,9 @@ test "db evaluates policy-gated algebraic adaptive candidates" {
     const alloc = std.testing.allocator;
     const algebraic_ir = @import("algebraic/ir.zig");
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{ .start_index_workers = false });
@@ -55954,12 +55988,14 @@ test "db open borrows shared backend runtime" {
     });
     defer runtime.deinit();
 
-    var first_path_buf: [256]u8 = undefined;
-    const first_path = tempPath(&first_path_buf);
+    var first_path_tmp = try TestDirectory.init("db");
+    defer first_path_tmp.cleanup();
+    const first_path = first_path_tmp.path().ptr;
     defer cleanupTempDir(first_path);
 
-    var second_path_buf: [256]u8 = undefined;
-    const second_path = tempPath(&second_path_buf);
+    var second_path_tmp = try TestDirectory.init("db");
+    defer second_path_tmp.cleanup();
+    const second_path = second_path_tmp.path().ptr;
     defer cleanupTempDir(second_path);
 
     var first = try DB.open(alloc, std.mem.span(first_path), .{
@@ -55998,8 +56034,9 @@ test "db close retires runtime owners for memory primary backend" {
     });
     defer runtime.deinit();
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -56034,8 +56071,9 @@ test "db close retires runtime owners for memory primary backend" {
 
 test "db inherits the resource manager capacity source" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     const CapacityContext = struct {
@@ -56088,8 +56126,9 @@ test "db open downgrades borrowed manual backend runtime to manual executor" {
     });
     defer runtime.deinit();
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -56104,8 +56143,9 @@ test "db open downgrades borrowed manual backend runtime to manual executor" {
 test "db open owns filesystem io for its manual backend runtime" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -56133,8 +56173,9 @@ test "db open rejects borrowed manual runtime without filesystem authority" {
     });
     defer runtime.deinit();
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     try std.testing.expectError(error.BackendRuntimeIoUnavailable, DB.open(alloc, std.mem.span(path), .{
@@ -56152,8 +56193,9 @@ test "db text merge enabled requires backend runtime io" {
     });
     defer runtime.deinit();
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     try std.testing.expectError(error.MissingBackendRuntimeIo, DB.open(alloc, std.mem.span(path), .{
@@ -56173,8 +56215,9 @@ test "db enrichment enabled requires backend runtime io" {
     defer runtime.deinit();
 
     var deterministic = embedder_mod.DeterministicDenseEmbedder{};
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     try std.testing.expectError(error.MissingBackendRuntimeIo, DB.open(alloc, std.mem.span(path), .{
@@ -56188,8 +56231,9 @@ test "db enrichment reconfigure preserves active runtime when replacement cannot
     const alloc = std.testing.allocator;
 
     var deterministic = embedder_mod.DeterministicDenseEmbedder{};
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -56213,8 +56257,9 @@ test "db enrichment reconfigure preserves active runtime when replacement cannot
 
 test "db enrichment reconfigure inherits resident execution and security capabilities" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var remote_content = scraping.RemoteContentConfig{
@@ -56238,8 +56283,9 @@ test "db enrichment reconfigure inherits resident execution and security capabil
 
 test "db enrichment reconfigure refreshes durable state after old worker joins" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var original_embedder = embedder_mod.DeterministicDenseEmbedder{};
@@ -56317,8 +56363,9 @@ test "db enrichment reconfigure refreshes durable state after old worker joins" 
 test "db enrichment restart supervisor recovers transient start failures" {
     const alloc = std.testing.allocator;
     var deterministic = embedder_mod.DeterministicDenseEmbedder{};
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -56350,8 +56397,9 @@ test "db enrichment restart supervisor recovers transient start failures" {
 test "db enrichment status does not wait for lifecycle mutation" {
     const alloc = std.testing.allocator;
     var deterministic = embedder_mod.DeterministicDenseEmbedder{};
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -56377,8 +56425,9 @@ test "db enrichment status does not wait for lifecycle mutation" {
 test "db runtime-only status overlay preserves a resident enrichment worker" {
     const alloc = std.testing.allocator;
     var deterministic = embedder_mod.DeterministicDenseEmbedder{};
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -56474,8 +56523,9 @@ test "db runtime-only status overlay preserves a resident enrichment worker" {
 
 test "runtime status best effort overlay cannot clear readiness under apply contention" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -56514,8 +56564,9 @@ test "db ttl cleanup enabled requires backend runtime io" {
     });
     defer runtime.deinit();
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     try std.testing.expectError(error.MissingBackendRuntimeIo, DB.open(alloc, std.mem.span(path), .{
@@ -56538,8 +56589,9 @@ test "db transaction recovery enabled requires backend runtime io" {
     });
     defer runtime.deinit();
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var resolver_ctx: u8 = 0;
@@ -56557,8 +56609,9 @@ test "db transaction recovery enabled requires backend runtime io" {
 test "db default primary backend survives reopen" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     {
@@ -56591,8 +56644,9 @@ test "db default primary backend survives reopen" {
 test "db basic batch/get works with memory primary backend" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -56616,8 +56670,9 @@ test "db basic batch/get works with memory primary backend" {
 test "db batch treats reserved namespace bytes as user document ids" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -56659,8 +56714,9 @@ test "db batch treats reserved namespace bytes as user document ids" {
 test "db batch and scan round trip adversarial document ids" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -56737,8 +56793,9 @@ test "db batch and scan round trip adversarial document ids" {
 test "db resolved doc-set projection honors identity read generation" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -56850,8 +56907,9 @@ test "db resolved doc-set projection honors identity read generation" {
 test "db persists configured doc identity namespace for batch writes" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     const namespace = doc_identity.Namespace{ .table_id = 7, .shard_id = 11, .range_id = 13 };
@@ -56898,8 +56956,9 @@ test "db persists configured doc identity namespace for batch writes" {
 test "db preferred identity namespace seeds new stores but preserves existing namespace" {
     const alloc = std.testing.allocator;
 
-    var managed_path_buf: [256]u8 = undefined;
-    const managed_path = tempPath(&managed_path_buf);
+    var managed_path_tmp = try TestDirectory.init("db");
+    defer managed_path_tmp.cleanup();
+    const managed_path = managed_path_tmp.path().ptr;
     defer cleanupTempDir(managed_path);
 
     const managed_namespace = doc_identity.Namespace{ .table_id = 7, .shard_id = 7001, .range_id = 7001 };
@@ -56926,8 +56985,9 @@ test "db preferred identity namespace seeds new stores but preserves existing na
         try std.testing.expect(reopened.core.identity_namespace.eql(managed_namespace));
     }
 
-    var legacy_path_buf: [256]u8 = undefined;
-    const legacy_path = tempPath(&legacy_path_buf);
+    var legacy_path_tmp = try TestDirectory.init("db");
+    defer legacy_path_tmp.cleanup();
+    const legacy_path = legacy_path_tmp.path().ptr;
     defer cleanupTempDir(legacy_path);
 
     {
@@ -56954,8 +57014,9 @@ test "db preferred identity namespace seeds new stores but preserves existing na
 test "db can reassign identity namespace for rebuild" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     const old_namespace = doc_identity.Namespace{ .table_id = 8, .shard_id = 801, .range_id = 8001 };
@@ -57030,8 +57091,9 @@ test "db can reassign identity namespace for rebuild" {
 test "db strict namespace reopen recovers after identity reassignment repair" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     const old_namespace = doc_identity.Namespace{ .table_id = 38, .shard_id = 3801, .range_id = 38001 };
@@ -57093,8 +57155,9 @@ test "db strict namespace reopen recovers after identity reassignment repair" {
 test "db identity namespace reassignment refreshes transaction recovery hook context" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     const old_namespace = doc_identity.Namespace{ .table_id = 28, .shard_id = 2801, .range_id = 28001 };
@@ -57138,8 +57201,9 @@ test "db identity namespace reassignment refreshes transaction recovery hook con
 test "db identity namespace reassignment is unavailable on status-only handles" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     const old_namespace = doc_identity.Namespace{ .table_id = 18, .shard_id = 1801, .range_id = 18001 };
@@ -57183,8 +57247,9 @@ test "db identity namespace reassignment is unavailable on status-only handles" 
 test "db stats expose document identity coverage and tombstones" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -57279,8 +57344,9 @@ test "db operational stats prefer the maintained live identity summary" {
     try std.testing.expectEqual(@as(u64, 0), stats.min_deleted_generation);
     try std.testing.expectEqual(@as(u64, 0), stats.max_deleted_generation);
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
     var db = try DB.open(std.testing.allocator, std.mem.span(path), .{
         .primary_backend = .{ .mem = .{} },
@@ -57299,8 +57365,9 @@ test "db operational stats prefer the maintained live identity summary" {
 test "db stats flag document identity ordinal capacity exhaustion" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -57327,8 +57394,9 @@ test "db stats flag document identity ordinal capacity exhaustion" {
 test "db allocates final document ordinal then rejects new documents" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -57376,8 +57444,9 @@ test "db allocates final document ordinal then rejects new documents" {
 test "document extraction template prompt failure is rejected before persistence" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -57471,8 +57540,9 @@ test "db embeddings index remoteMedia accepts bmp via shared image decode" {
     });
     defer template_remote.setHostRenderer(null);
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var image_embedder = ImageDecodingPartsEmbedder{};
@@ -57518,8 +57588,9 @@ test "db embeddings index remoteMedia accepts webp via shared image decode" {
     });
     defer template_remote.setHostRenderer(null);
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var image_embedder = ImageDecodingPartsEmbedder{};
@@ -57569,8 +57640,9 @@ test "db embeddings index remoteMedia accepts webp via shared image decode" {
 test "db allocates final document ordinal with all index families present" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -57653,8 +57725,9 @@ test "db allocates final document ordinal with all index families present" {
 test "db rejects new document writes at ordinal exhaustion for every sync level" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -57700,8 +57773,9 @@ test "db rejects new document writes at ordinal exhaustion for every sync level"
 test "db search requests default to current identity generation snapshot" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -57749,8 +57823,9 @@ test "db search requests default to current identity generation snapshot" {
 test "db caches identity visibility summary after local writes" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -57774,8 +57849,9 @@ test "db caches identity visibility summary after local writes" {
 test "db lsm primary compaction preserves doc identity ordinals" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     const primary_backend: PrimaryBackend = .{ .lsm = .{ .flush_threshold = 1 } };
@@ -57844,8 +57920,9 @@ test "db lsm primary compaction preserves doc identity ordinals" {
 test "db validates internal resolved doc filter wire namespace and generation" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     const namespace = doc_identity.Namespace{ .table_id = 1, .shard_id = 2, .range_id = 3 };
@@ -57900,8 +57977,9 @@ test "db validates internal resolved doc filter wire namespace and generation" {
 test "db explicit doc-id filter resolution honors identity generation" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -57967,8 +58045,9 @@ test "db explicit doc-id filter resolution honors identity generation" {
 test "db doc set planning stats record ordinal bitmap promotion" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -58013,8 +58092,9 @@ test "db doc set planning stats record ordinal bitmap promotion" {
 
 test "db sparse index uses identity ordinals as physical doc nums for primary docs" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -58081,8 +58161,9 @@ test "db sparse index uses identity ordinals as physical doc nums for primary do
 
 test "db sparse hits resolve doc ordinals through identity not sparse doc nums" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -58130,8 +58211,9 @@ test "db sparse hits resolve doc ordinals through identity not sparse doc nums" 
 
 test "db index catalog barrier disables published dense fast path" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -58150,8 +58232,9 @@ test "db index catalog barrier disables published dense fast path" {
 
 test "db index catalog barrier and apply acquisition honor activation deadline" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -58172,8 +58255,9 @@ test "db index catalog barrier and apply acquisition honor activation deadline" 
 
 test "db published dense admission cannot overflow into catalog closure" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -58213,8 +58297,9 @@ test "db dense fast path registers before catalog lookup during index deletion" 
             }
         }
     };
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     // Keep this fixture limited to the catalog-admission race under test.
@@ -58331,8 +58416,9 @@ test "db dense fast path registers before catalog lookup during index deletion" 
 
 test "db dense index stores stable vector ids with ordinal filter mappings" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -58421,8 +58507,9 @@ test "db dense index stores stable vector ids with ordinal filter mappings" {
 
 test "db resolved doc filter normalizes doc keys before composing native ids" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -58469,8 +58556,9 @@ test "db resolved doc filter normalizes doc keys before composing native ids" {
 
 test "db vector full text filters project through doc identity ordinals" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -58566,8 +58654,9 @@ test "db default dynamic schema vector term filters project through doc identity
     const alloc = std.testing.allocator;
     const table_schema_api = @import("../../schema/mod.zig");
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -58675,8 +58764,9 @@ test "db dense default dynamic 0.2 percent numeric filter exact scores bounded c
     const alloc = std.testing.allocator;
     const table_schema_api = @import("../../schema/mod.zig");
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -58836,8 +58926,9 @@ test "db exact sort resolves explicit keyword metadata filters natively" {
     const alloc = std.testing.allocator;
     const table_schema_api = @import("../../schema/mod.zig");
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -58926,8 +59017,9 @@ test "db exact sort resolves mapped numeric metadata filters from typed doc valu
     const alloc = std.testing.allocator;
     const table_schema_api = @import("../../schema/mod.zig");
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -59009,8 +59101,9 @@ test "db exact sort resolves mapped date metadata filters from typed doc values"
     const alloc = std.testing.allocator;
     const table_schema_api = @import("../../schema/mod.zig");
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -59092,8 +59185,9 @@ test "db exact sort resolves mapped boolean metadata filters from typed doc valu
     const alloc = std.testing.allocator;
     const table_schema_api = @import("../../schema/mod.zig");
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -59152,8 +59246,9 @@ test "db exact sort resolves mapped geo metadata filters from typed doc values" 
     const alloc = std.testing.allocator;
     const table_schema_api = @import("../../schema/mod.zig");
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -59234,8 +59329,9 @@ test "db exact sort resolves mapped geo metadata filters from typed doc values" 
 
 test "db non chunked search paths apply broad live doc filter" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -59333,8 +59429,9 @@ test "db non chunked search paths apply broad live doc filter" {
 test "db status_only open reads index catalog without loading index state" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     {
@@ -59464,8 +59561,9 @@ test "db status_only open reads index catalog without loading index state" {
 test "db dense and sparse vector searches apply stored symbolic filters before final paging" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -59527,8 +59625,9 @@ test "db dense and sparse vector searches apply stored symbolic filters before f
 test "db dense stored symbolic filter candidate window covers offset pagination" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -59582,8 +59681,9 @@ test "db dense stored symbolic filter candidate window covers offset pagination"
 test "db dense algebraic doc facts feed native dense and sparse symbolic filters" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -60312,8 +60412,9 @@ test "db dense algebraic doc facts feed native dense and sparse symbolic filters
 test "db vector symbolic filters fail closed when algebraic lifecycle is stale" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -60394,8 +60495,9 @@ test "db vector symbolic filters fail closed when algebraic lifecycle is stale" 
 test "db basic batch/get works with in-memory lsm primary backend" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -60423,8 +60525,9 @@ test "db in-memory primary backends keep derived log off disk" {
         .{ .mem = .{} },
         .{ .lsm_memory = .{} },
     }) |primary_backend| {
-        var path_buf: [256]u8 = undefined;
-        const path = tempPath(&path_buf);
+        var path_tmp = try TestDirectory.init("db");
+        defer path_tmp.cleanup();
+        const path = path_tmp.path().ptr;
         defer cleanupTempDir(path);
 
         {
@@ -60449,8 +60552,9 @@ test "db in-memory primary backends keep derived log off disk" {
 test "db can override change journal backend to lmdb" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     {
@@ -60476,8 +60580,9 @@ test "db can override change journal backend to lmdb" {
 test "db basic batch/get survives reopen with durable lsm primary backend" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     {
@@ -60510,8 +60615,9 @@ test "db basic batch/get survives reopen with durable lsm primary backend" {
 test "db lsm match-all query sees same latest value as point lookup" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -60560,8 +60666,9 @@ test "db lsm match-all query sees same latest value as point lookup" {
 test "db enrichment status changes notify query visibility hook" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var deterministic = embedder_mod.DeterministicDenseEmbedder{};
@@ -60607,8 +60714,9 @@ test "db enrichment status changes notify query visibility hook" {
 test "db source commit publishes exact target observation sequence" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -60686,8 +60794,9 @@ test "db source commit publishes exact target observation sequence" {
 test "db generated downstream indexes are exact convergence targets at source commit" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -60841,8 +60950,9 @@ test "db generated downstream indexes are exact convergence targets at source co
 
 test "db generated downstream indexes are exact convergence targets at source commit including implicit chunk deletion" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
     var db = try DB.open(alloc, std.mem.span(path), .{
         .start_index_workers = false,
@@ -60880,8 +60990,9 @@ test "db generated downstream indexes are exact convergence targets at source co
 test "db full-text index and search survive reopen with durable lsm primary backend" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     {
@@ -60937,8 +61048,9 @@ test "db full-text index and search survive reopen with durable lsm primary back
 test "db algebraic bulk ingest survives reopen with durable lsm primary backend" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     const cfg =
@@ -61018,8 +61130,9 @@ test "db algebraic bulk ingest survives reopen with durable lsm primary backend"
 test "db batch appends only thin replay stream records" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -61042,8 +61155,9 @@ test "db batch appends only thin replay stream records" {
 test "db batch writes thin change journal record" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -61074,8 +61188,9 @@ test "db batch writes thin change journal record" {
 test "db batch delete replay record wakes managed index workers" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -61121,8 +61236,9 @@ test "db batch delete replay record wakes managed index workers" {
 test "db batch uses change journal as the replay authority" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -61159,8 +61275,9 @@ fn journalRecordHasHint(record: change_journal_mod.Record, hint: change_journal_
 test "db pending work stats track replay stream sequence" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -61185,8 +61302,9 @@ test "db pending work stats track replay stream sequence" {
 test "db open preserves existing change journal records" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     {
@@ -61218,8 +61336,9 @@ test "db open preserves existing change journal records" {
 test "db lsm primary reopens explicit dense replay stream state" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     {
@@ -61271,8 +61390,9 @@ test "db lsm primary reopens explicit dense replay stream state" {
 test "db lsm generated chunked enrichment publishes replay stream state" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var deterministic = embedder_mod.DeterministicDenseEmbedder{};
@@ -61353,8 +61473,9 @@ test "db lsm generated chunked enrichment publishes replay stream state" {
 test "db direct graph writes record graph artifacts in the replay stream instead of graph payload replay" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -61390,8 +61511,9 @@ test "db direct graph writes record graph artifacts in the replay stream instead
 test "db _edges writes record graph artifacts in the replay stream instead of graph payload replay" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -61449,8 +61571,9 @@ const FixedVectorEmbedder = struct {
 test "db starts resolver replay workers only while resolver catalog is configured" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -61512,8 +61635,9 @@ test "db starts resolver replay workers only while resolver catalog is configure
 test "db backfills a mention name embedding so ann/cosine resolution links end-to-end" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var embedder = FixedVectorEmbedder{};
@@ -61593,8 +61717,9 @@ test "db backfills a mention name embedding so ann/cosine resolution links end-t
 test "db runUntilIdle catches resolution up to the committed tail after a missed notification" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -61663,8 +61788,9 @@ test "db runUntilIdle catches resolution up to the committed tail after a missed
 test "db re-resolves the corpus when upsertResolver bumps the config generation" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -61730,8 +61856,9 @@ test "db re-resolves the corpus when upsertResolver bumps the config generation"
 test "db re-resolves existing corpus when upsertResolver inserts a new resolver" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -61796,8 +61923,9 @@ test "db re-resolves existing corpus when upsertResolver inserts a new resolver"
 test "db drains pending resolver backfill when retrying a no-op upsertResolver" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -61860,8 +61988,9 @@ test "db drains pending resolver backfill when retrying a no-op upsertResolver" 
 test "db refuses resolver removal while resolution or promotion replay is pending" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -61957,8 +62086,9 @@ const FakePromotionSink = struct {
 test "db promotes resolved entities into entity-document upserts end-to-end" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var sink = FakePromotionSink{ .alloc = alloc };
@@ -62024,8 +62154,9 @@ test "db promotes resolved entities into entity-document upserts end-to-end" {
 test "db graph index materializes relation asset artifacts into graph edge artifacts" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -62070,8 +62201,9 @@ test "db graph index materializes relation asset artifacts into graph edge artif
 test "db graph index materializes unit-derived chunk artifacts into graph edge artifacts" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -62125,8 +62257,9 @@ test "db graph index materializes unit-derived chunk artifacts into graph edge a
 test "db direct generated chunks feed multi-source text and graph indexes" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -62208,8 +62341,9 @@ test "db direct generated chunks feed multi-source text and graph indexes" {
 test "db multi-source full text unions chunk and textual asset streams across deletion and reopen" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     {
@@ -62397,8 +62531,9 @@ test "db multi-source full text unions chunk and textual asset streams across de
 test "db graph replay blocks resolution artifact without resolver contract" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{ .start_index_workers = false });
@@ -62473,8 +62608,9 @@ test "db graph replay blocks resolution artifact without resolver contract" {
 test "db graph replay ignores resolution artifacts bound to another source contract" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{ .start_index_workers = false });
@@ -62532,8 +62668,9 @@ test "db graph replay ignores resolution artifacts bound to another source contr
 test "db materializes doc->entity mention edges as provenance and clears them on delete" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -62651,8 +62788,9 @@ test "db materializes doc->entity mention edges as provenance and clears them on
 test "db resolver removal retires resolution artifacts and mention graph state" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var sink = FakePromotionSink{ .alloc = alloc };
@@ -62791,8 +62929,9 @@ test "db resolver removal retires resolution artifacts and mention graph state" 
 test "db does not materialize review-band resolution as canonical mention edges" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     // Keep production workers enabled: this is the regression for the original
@@ -62884,8 +63023,9 @@ test "db does not materialize review-band resolution as canonical mention edges"
 test "db mention edge weight is fused from extractor trust and mention confidence" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -62975,8 +63115,9 @@ test "db mention edge weight is fused from extractor trust and mention confidenc
 test "db rewriteEntityEdges repoints provenance edges to a merge survivor" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -63041,8 +63182,9 @@ test "db rewriteEntityEdges repoints provenance edges to a merge survivor" {
 test "db graph hydration rejects table-qualified entity nodes in local snapshots" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -63178,8 +63320,9 @@ test "db graph hydration rejects table-qualified entity nodes in local snapshots
 test "db graph relation artifact materializer uses mapping templates" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -63269,8 +63412,9 @@ test "graph artifact parser enforces its independent raw item safety limit" {
 test "db graph visible edge limit applies after identity deduplication" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -63309,8 +63453,9 @@ test "db graph visible edge limit applies after identity deduplication" {
 test "db graph relation artifact materializer resolves entity refs and artifact template values" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -63355,8 +63500,9 @@ test "db graph relation artifact materializer resolves entity refs and artifact 
 test "db graph relation artifact materializer replaces stale document edges" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -63401,8 +63547,9 @@ test "db graph relation artifact materializer replaces stale document edges" {
 test "db multi-source graph precedence falls back after winner deletion and reopen" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     {
@@ -63503,11 +63650,13 @@ test "db multi-source graph precedence falls back after winner deletion and reop
 test "db portable restore rebuilds multi-source graph contender provenance" {
     const alloc = std.testing.allocator;
 
-    var source_buf: [256]u8 = undefined;
-    const source_path = tempPath(&source_buf);
+    var source_tmp = try TestDirectory.init("db");
+    defer source_tmp.cleanup();
+    const source_path = source_tmp.path().ptr;
     defer cleanupTempDir(source_path);
-    var restore_buf: [256]u8 = undefined;
-    const restore_path = tempPath(&restore_buf);
+    var restore_tmp = try TestDirectory.init("db");
+    defer restore_tmp.cleanup();
+    const restore_path = restore_tmp.path().ptr;
     defer cleanupTempDir(restore_path);
 
     const primary_backend: PrimaryBackend = .{ .lsm = .{ .flush_threshold = 1 } };
@@ -63612,8 +63761,9 @@ test "db portable restore rebuilds multi-source graph contender provenance" {
 
 test "db graph config rejects cross-document materialized source ownership" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -63630,8 +63780,9 @@ test "db graph config rejects cross-document materialized source ownership" {
 test "db graph relation artifact materializer deletes edges when asset source disappears" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -63680,8 +63831,9 @@ test "db graph relation artifact materializer deletes edges when asset source di
 test "db graph artifact source lifecycle reuses and protects asset enrichments" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -63731,8 +63883,9 @@ test "db graph artifact source lifecycle reuses and protects asset enrichments" 
 
 test "db query repair gate revalidates stale debt" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{ .start_index_workers = false });
@@ -63753,8 +63906,9 @@ test "db query repair gate revalidates stale debt" {
 
 test "db vector status revalidates stale repair admission without a query" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{ .start_index_workers = false });
@@ -63829,8 +63983,9 @@ test "db vector status revalidates stale repair admission without a query" {
 test "db resolver catalog persists across reopen" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     {
@@ -63896,8 +64051,9 @@ test "db resolver catalog persists across reopen" {
 test "db graph artifact source reuses user enrichment and rejects incompatible shorthand" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -63935,8 +64091,9 @@ test "db graph artifact source reuses user enrichment and rejects incompatible s
 test "db graph source artifact deletion clears materialized graph edges" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -63985,8 +64142,9 @@ test "db graph source artifact deletion clears materialized graph edges" {
 test "db graph artifact edges are visible to graph search queries" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -64038,8 +64196,9 @@ test "db graph artifact edges are visible to graph search queries" {
 test "db graph artifact external node targets return ids without document hydration" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -64134,8 +64293,9 @@ test "db graph artifact external node targets return ids without document hydrat
 test "db async asset producer graph source materializes through replay" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var fake = TestAssetProducer{};
@@ -64180,8 +64340,9 @@ test "db async asset producer graph source materializes through replay" {
 test "db async asset producer mention edges come from resolution artifacts" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var fake = TestAssetProducer{
@@ -64274,8 +64435,9 @@ test "db async asset producer mention edges come from resolution artifacts" {
 test "db graph artifact source replay catches up after reopen" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     {
@@ -64326,8 +64488,9 @@ test "db graph artifact source replay catches up after reopen" {
 test "db graph edge artifact replay catches up after reopen" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     {
@@ -64395,8 +64558,9 @@ test "db graph edge artifact replay catches up after reopen" {
 test "db query_readonly opens empty declared graph index" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     {
@@ -64430,8 +64594,9 @@ test "db query_readonly opens empty declared graph index" {
 test "db batch marks generated enrichment replay for generator-enabled dense index" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -64469,8 +64634,9 @@ test "db batch marks generated enrichment replay for generator-enabled dense ind
 test "db full_index precomputes generated enrichments into the committed batch" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var deterministic_dense = embedder_mod.DeterministicDenseEmbedder{};
@@ -64539,8 +64705,9 @@ test "db full_index precomputes generated enrichments into the committed batch" 
 test "db full_text sync level does not wait for dense hbc visibility" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -64581,8 +64748,9 @@ test "db full_text sync level does not wait for dense hbc visibility" {
 test "db enrichments precomputes generated enrichments into the committed batch" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var deterministic_dense = embedder_mod.DeterministicDenseEmbedder{};
@@ -64642,8 +64810,9 @@ test "db enrichments precomputes generated enrichments into the committed batch"
 test "db replicated apply decouples client enrichment sync from raft apply execution" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var deterministic_dense = embedder_mod.DeterministicDenseEmbedder{};
@@ -64687,8 +64856,9 @@ test "db replicated apply decouples client enrichment sync from raft apply execu
 test "db enrichments precomputed watermark advances across replay entries without enrichment debt" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var deterministic_dense = embedder_mod.DeterministicDenseEmbedder{};
@@ -64729,8 +64899,9 @@ test "db enrichments precomputed watermark advances across replay entries withou
 test "db derived target advance does not skip unseen matching replay records" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{ .start_index_workers = false });
@@ -64848,8 +65019,9 @@ fn jsonTestNumber(value: std.json.Value) f64 {
 test "db asset producer enrichments execute fake providers and skip unchanged state" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var fake = TestAssetProducer{};
@@ -65028,8 +65200,9 @@ test "db asset producer enrichments batch compatible generated assets" {
         }
     };
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var fake = BatchProducer{};
@@ -65112,8 +65285,9 @@ test "db asset producer sync precompute fails closed on permanent item failure" 
         }
     };
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var fake = FallbackProducer{};
@@ -65304,8 +65478,9 @@ test "db document unit payload marks scanned pdf pages as pending OCR" {
 test "db document extraction asset materializes unit artifacts from data url" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var fake = TestAssetProducer{};
@@ -65786,8 +65961,9 @@ test "db canonical hierarchy traversal rejects typed retrieval controls" {
 test "db hierarchy navigation seeks only the descriptor blocks needed by the page" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -65890,8 +66066,9 @@ test "db hierarchy navigation seeks only the descriptor blocks needed by the pag
 test "db hierarchy cursor binds every unit artifact revision under its source" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var fake = TestAssetProducer{};
@@ -65979,8 +66156,9 @@ test "db hierarchy cursor binds every unit artifact revision under its source" {
 test "db async document extraction accounts resource manager working set" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var resource_manager = resource_manager_mod.ResourceManager.init(.{});
@@ -66024,8 +66202,9 @@ test "db async document extraction accounts resource manager working set" {
 test "db async document extraction deletes artifacts with corrupt previous extraction state" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -66114,8 +66293,9 @@ test "db async document extraction deletes artifacts with corrupt previous extra
 test "db document extraction routes mixed files using source metadata fields" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -66158,8 +66338,9 @@ test "db document extraction routes mixed files using source metadata fields" {
 test "db document extraction stores docx section units" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -66205,8 +66386,9 @@ test "db document extraction stores docx section units" {
 test "db document extraction stores zip archive entry units" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -66253,8 +66435,9 @@ test "db document extraction stores zip archive entry units" {
 test "db document extraction stores image pending OCR unit" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -66304,8 +66487,9 @@ test "db document extraction stores image pending OCR unit" {
 test "db document extraction completes image OCR with reader producer" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var fake = TestAssetProducer{};
@@ -66356,8 +66540,9 @@ test "db document extraction attempts forced OCR for a scanned PDF" {
 
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var fake = TestAssetProducer{ .reader_output = "scanned PDF transcription with enough text to remain selected" };
@@ -66424,8 +66609,9 @@ test "db document extraction attempts forced OCR for a scanned PDF" {
 test "db async document extraction reuses generated OCR text across streaming passes" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var fake = TestAssetProducer{};
@@ -66470,8 +66656,9 @@ test "db async document extraction reuses generated OCR text across streaming pa
 test "db document extraction stores structured OCR confidence and coordinates" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var fake = TestAssetProducer{
@@ -66526,8 +66713,9 @@ test "db document extraction stores structured OCR confidence and coordinates" {
 test "db document extraction completes audio transcription with transcriber producer" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var fake = TestAssetProducer{
@@ -66582,8 +66770,9 @@ test "db document extraction completes audio transcription with transcriber prod
 test "db document extraction stores rfc822 email units" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -66636,8 +66825,9 @@ test "db document extraction stores rfc822 email units" {
 test "db document extraction stores multipart rfc822 text parts" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -66689,8 +66879,9 @@ test "db document extraction stores multipart rfc822 text parts" {
 test "db document extraction stores unsupported file manifest without searchable units" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -66817,8 +67008,9 @@ test "db document extraction manifest classifies unit fingerprint keeps" {
 test "db document extraction skips stable unit local rewrites without text consumers" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var counting = CountingDenseEmbedder{};
@@ -66891,8 +67083,9 @@ test "db document extraction skips stable unit local rewrites without text consu
 test "db applies document artifact child range batch without source row write" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -66936,8 +67129,9 @@ test "db applies document artifact child range batch without source row write" {
 test "db document artifact child range batch atomically tracks dense artifact counters" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -67013,8 +67207,9 @@ test "db document artifact child range batch atomically tracks dense artifact co
 test "db dispatches generated document child range artifacts to remote owner" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -67267,8 +67462,9 @@ test "generated enrichment preparation helpers release partial allocations" {
 test "db retries remote document child range dispatch from durable outbox" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -67378,8 +67574,9 @@ test "db retries remote document child range dispatch from durable outbox" {
 test "db document extraction manifest inspection and reprocess API" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var counting = CountingDenseEmbedder{};
@@ -67557,8 +67754,9 @@ test "db document extraction manifest inspection and reprocess API" {
 test "db generic artifact repair queue reprocesses document asset artifacts" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -67641,8 +67839,9 @@ test "db generic artifact repair queue reprocesses document asset artifacts" {
 test "db generic artifact repair queue regenerates set-valued chunk artifacts" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -67693,8 +67892,9 @@ test "db generic artifact repair queue regenerates set-valued chunk artifacts" {
 test "db repair completion cannot clear debt behind terminal coverage" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -67791,8 +67991,9 @@ test "db repair completion cannot clear debt behind terminal coverage" {
 test "db successful embedding publication retires covered provider failure debt" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -67843,8 +68044,9 @@ test "db successful embedding publication retires covered provider failure debt"
 test "db shared repair completion reprocesses consumer with terminal coverage" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var deterministic = embedder_mod.DeterministicDenseEmbedder{};
@@ -67916,8 +68118,9 @@ test "db shared repair completion reprocesses consumer with terminal coverage" {
 test "db artifact repair summary is persisted for status-only reopen" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     {
@@ -67961,8 +68164,9 @@ test "db artifact repair summary is persisted for status-only reopen" {
 test "db artifact repair summary rebuild is bounded and exact until ready" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     const seeded_count: usize = 1030;
@@ -68043,8 +68247,9 @@ test "db artifact repair summary rebuild is bounded and exact until ready" {
 test "db artifact repair summary rebuild invalidates partial counters on mutation" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     const seeded_count: usize = 1030;
@@ -68160,8 +68365,9 @@ test "db artifact repair summary rebuild invalidates partial counters on mutatio
 test "db artifact repair summary durably scopes debt to configured source" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     {
@@ -68218,8 +68424,9 @@ test "db artifact repair summary durably scopes debt to configured source" {
 
 test "db artifact repair v1 ready marker forces source-summary rebuild" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -68242,8 +68449,9 @@ test "db artifact repair v1 ready marker forces source-summary rebuild" {
 test "db artifact repair dirty marker drains shadow summaries in bounded pages" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -68313,8 +68521,9 @@ test "db artifact repair dirty marker drains shadow summaries in bounded pages" 
 test "db artifact repair summary store writer invalidates partial rebuild" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     const seeded_count: usize = 1030;
@@ -68435,8 +68644,9 @@ test "db artifact repair summary store writer invalidates partial rebuild" {
 test "db artifact repair metadata maintenance drains summary rebuild without restart" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     const seeded_count: usize = 2050;
@@ -68494,8 +68704,9 @@ test "db artifact repair metadata maintenance drains summary rebuild without res
 test "db artifact repair list cursor pages durable repair debt" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -68543,8 +68754,9 @@ test "db artifact repair list cursor pages durable repair debt" {
 test "db artifact repair queue keeps distinct unit artifacts for same document and name" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -68594,8 +68806,9 @@ test "db artifact repair queue keeps distinct unit artifacts for same document a
 test "db artifact repair fallback issue ids do not collide on delimiter-bearing fields" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -68633,8 +68846,9 @@ test "db artifact repair fallback issue ids do not collide on delimiter-bearing 
 test "db artifact repair kind filter uses selective index after reopen" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     {
@@ -68691,8 +68905,9 @@ test "db artifact repair kind filter uses selective index after reopen" {
 test "db artifact repair kind fallback scan is bounded when kind index is rebuilding" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -68764,8 +68979,9 @@ test "db artifact repair kind fallback scan is bounded when kind index is rebuil
 test "db artifact repair reports unsupported artifact kinds without clearing debt" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -68806,8 +69022,9 @@ test "db artifact repair reports unsupported artifact kinds without clearing deb
 test "db index repair requires explicit index and force for healthy rebuild" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -68851,8 +69068,9 @@ test "db index repair requires explicit index and force for healthy rebuild" {
 test "db managed operator repair persists intent without running reconstruction inline" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -68890,8 +69108,9 @@ test "db managed operator repair persists intent without running reconstruction 
 test "index repair advance lease covers cancellation and deletion" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -69005,8 +69224,9 @@ test "index repair advance lease covers cancellation and deletion" {
 test "db index repair targets one graph index per selected config" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -69076,8 +69296,9 @@ test "db index repair targets one graph index per selected config" {
 test "db index repair resets sparse index before rebuilding from artifacts" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -69139,8 +69360,9 @@ test "db index repair resets sparse index before rebuilding from artifacts" {
 test "db index repair rebuilds full text index from stored documents" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -69216,8 +69438,9 @@ test "db index repair rebuilds full text index from stored documents" {
 
 test "db index repair replacement loads named artifact producer dependencies" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
     var db = try DB.open(alloc, std.mem.span(path), .{
         .start_index_workers = false,
@@ -69281,8 +69504,9 @@ test "db index repair replacement loads named artifact producer dependencies" {
 test "db index repair shadow swap survives reopen" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     const text_cfg: types.IndexConfig = .{
@@ -69365,8 +69589,9 @@ test "db index repair shadow swap survives reopen" {
 test "db index repair shadow roots are allocated uniquely" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     const first = try createUniqueRepairShadowBase(alloc, std.mem.span(path));
@@ -69391,8 +69616,9 @@ test "db index repair shadow roots are allocated uniquely" {
 test "db index repair shadow swap preserves post snapshot mutations" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     const text_cfg: types.IndexConfig = .{
@@ -69501,8 +69727,9 @@ test "db index repair shadow swap preserves post snapshot mutations" {
 test "db artifact repair issue list reports recorded graph issue" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -69546,8 +69773,9 @@ test "db artifact repair issue list reports recorded graph issue" {
 test "db artifact repair reports remaining debt when source is missing" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -69594,8 +69822,9 @@ test "db artifact repair reports remaining debt when source is missing" {
 test "db graph generation repair preserves corrupt artifact debt after rebuild" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -69646,8 +69875,9 @@ test "db graph generation repair preserves corrupt artifact debt after rebuild" 
 test "db repair issue list exposes algebraic generation debt as repairable" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -69714,8 +69944,9 @@ test "db repair issue list exposes algebraic generation debt as repairable" {
 test "db index repair serializes duplicate repairs for one index" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -69745,8 +69976,9 @@ test "db index repair serializes duplicate repairs for one index" {
 test "db index repair recovers quarantined index load before rebuild" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     {
@@ -69785,8 +70017,9 @@ test "db index repair recovers quarantined index load before rebuild" {
 test "db index repair rebuilds full text after quarantined root recreation" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
     const path_slice = std.mem.span(path);
 
@@ -69857,8 +70090,9 @@ test "db index repair rebuilds full text after quarantined root recreation" {
 test "db index repair streams graph artifact rebuild in batches" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -69936,8 +70170,9 @@ test "db index repair streams graph artifact rebuild in batches" {
 test "db artifact repair records corrupt graph edge artifacts during replay" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var appended_sequence: u64 = 0;
@@ -69996,8 +70231,9 @@ test "db artifact repair records corrupt graph edge artifacts during replay" {
 test "db artifact repair records corrupt graph source asset artifacts during replay" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var appended_sequence: u64 = 0;
@@ -70095,8 +70331,9 @@ test "db document extraction unit ranges split by text bytes" {
 test "db document extraction failure preserves last-known-good children and recovers" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -70183,8 +70420,9 @@ test "db document extraction failure preserves last-known-good children and reco
 test "db document extraction skips stable unit local rewrites while replaying full text from stored artifacts" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var counting = CountingDenseEmbedder{};
@@ -70394,8 +70632,9 @@ fn testMaterializedEmbeddingWriteGrowth(comptime mode: enum { dense, derived_den
     const is_sparse = mode == .sparse;
     const embedding_name = if (is_sparse) "document_sparse" else "document_dense";
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var deterministic_dense = embedder_mod.DeterministicDenseEmbedder{};
@@ -70551,8 +70790,9 @@ fn testMaterializedEmbeddingWriteGrowth(comptime mode: enum { dense, derived_den
 test "db document extraction chunks units through source artifact enrichment" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var deterministic_dense = embedder_mod.DeterministicDenseEmbedder{};
@@ -70961,8 +71201,9 @@ test "db document extraction state round-trips binary chunk keys beyond one byte
 test "db document extraction changed version updates large chunked source document" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -71048,8 +71289,9 @@ test "db document extraction changed version updates large chunked source docume
 test "db document extraction update recovers corrupt previous extraction state" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -71121,8 +71363,9 @@ test "db document extraction update recovers corrupt previous extraction state" 
 test "db extractEnrichments exposes cleaned writes and special fields" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -71159,8 +71402,9 @@ test "db extractEnrichments exposes cleaned writes and special fields" {
 test "db extractEnrichments rejects unsupported legacy summaries field" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -71177,8 +71421,9 @@ test "db extractEnrichments rejects unsupported legacy summaries field" {
 test "db computeEnrichments synchronously builds chunk and embedding outputs" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var deterministic = embedder_mod.DeterministicDenseEmbedder{};
@@ -71237,8 +71482,9 @@ test "db computeEnrichments synchronously builds chunk and embedding outputs" {
 test "db leased enrichment worker generates dense embeddings" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var deterministic = embedder_mod.DeterministicDenseEmbedder{};
@@ -71297,8 +71543,9 @@ test "db leased enrichment worker generates dense embeddings" {
 test "db leased enrichment worker backs off while a stale owner holds the lease" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var deterministic = embedder_mod.DeterministicDenseEmbedder{};
@@ -71350,8 +71597,9 @@ test "db leased enrichment worker backs off while a stale owner holds the lease"
 test "db leased enrichment worker generates dense embeddings with durable lsm primary backend" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var deterministic = embedder_mod.DeterministicDenseEmbedder{};
@@ -71414,8 +71662,9 @@ test "db leased enrichment worker generates dense embeddings with durable lsm pr
 test "db managed dense enrichment remains searchable after transient rate limits" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     // Admit the first request, then force the worker through the real
@@ -71498,8 +71747,9 @@ test "db managed dense enrichment remains searchable after transient rate limits
 test "db retryable chunked producer does not block independent dense publication" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var gated = SelectiveGateDenseEmbedder{
@@ -71578,8 +71828,9 @@ test "db retryable chunked producer does not block independent dense publication
 test "db retryable asset producer batches do not block independent dense publication" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var gated_asset = GateAssetProducer{};
@@ -71668,8 +71919,9 @@ test "db retryable asset producer batches do not block independent dense publica
 test "db managed dense enrichment retries temporary model capacity without terminal coverage" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var gated = GateDenseEmbedder{
@@ -71751,8 +72003,9 @@ test "db managed dense enrichment retries temporary model capacity without termi
 test "db managed sparse enrichment retries temporary model capacity without terminal coverage" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var gated = GateSparseEmbedder{};
@@ -71830,8 +72083,9 @@ test "db managed sparse enrichment retries temporary model capacity without term
 test "db chunked dense enrichment retries temporary model capacity without terminal coverage" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var gated = GateDenseEmbedder{
@@ -71904,8 +72158,9 @@ test "db chunked dense enrichment retries temporary model capacity without termi
 test "db managed dense delete quiesces rate-limited enrichment and recreates cleanly" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var gated = GateDenseEmbedder{};
@@ -72064,8 +72319,9 @@ test "retired repair cleanup propagates allocation failures from durable metadat
 test "retired repair cleanup resumes marker retirement and removes corrupt sidecars after reopen" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     const issue: types.ArtifactRepairIssue = .{
@@ -72159,8 +72415,9 @@ test "retired repair cleanup resumes marker retirement and removes corrupt sidec
 test "db dense checkpoint persistence serializes with index apply" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -72216,8 +72473,9 @@ test "db dense checkpoint persistence serializes with index apply" {
 test "db open quarantines dense index with unsupported artifact version" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     const dense_cfg: types.IndexConfig = .{
@@ -72361,8 +72619,9 @@ fn corruptNonEmptyFilesUnderDir(alloc: Allocator, root_path: []const u8) !usize 
 test "db drops quarantined dense index after persisted index directory corruption" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
     const path_slice = std.mem.span(path);
 
@@ -72418,8 +72677,9 @@ test "db drops quarantined dense index after persisted index directory corruptio
 test "db quarantined index self-heals via retryQuarantinedIndexLoads" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     {
@@ -72557,8 +72817,9 @@ test "db quarantined index self-heals via retryQuarantinedIndexLoads" {
 test "db targeted quarantine retry does not open unrelated failed indexes" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     {
@@ -72591,8 +72852,9 @@ test "db targeted quarantine retry does not open unrelated failed indexes" {
 test "db read-only open propagates transient index load errors instead of quarantining" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     {
@@ -72633,8 +72895,9 @@ test "db read-only open propagates transient index load errors instead of quaran
 test "db managed dense enrichment delete recreate recovers after corrupt artifact" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var counting = CountingDenseEmbedder{};
@@ -72703,8 +72966,9 @@ test "db managed dense enrichment delete recreate recovers after corrupt artifac
 test "db managed dense enrichment delete recreate recovers after corrupt artifact across reopen" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var counting = CountingDenseEmbedder{};
@@ -72777,8 +73041,9 @@ test "db managed dense enrichment delete recreate recovers after corrupt artifac
 test "db dense repair reprocesses corrupt managed source before rebuilding" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var counting = CountingDenseEmbedder{};
@@ -72870,8 +73135,9 @@ test "db dense repair reprocesses corrupt managed source before rebuilding" {
 test "db dense enrichment skips unchanged source hash" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var counting = CountingDenseEmbedder{};
@@ -72928,8 +73194,9 @@ test "db dense enrichment skips unchanged source hash" {
 test "db dense enrichment republishes unchanged source hash from cached artifact after index reset" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var counting = CountingDenseEmbedder{};
@@ -72985,8 +73252,9 @@ test "db dense enrichment republishes unchanged source hash from cached artifact
 test "db chunked dense enrichment skips unchanged chunks and deletes stale chunk artifacts" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var counting = CountingDenseEmbedder{};
@@ -73074,8 +73342,9 @@ test "db chunked dense enrichment skips unchanged chunks and deletes stale chunk
 test "db chunked dense enrichment replays cached artifacts after dense reset without re-embedding" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var counting = CountingDenseEmbedder{};
@@ -73134,8 +73403,9 @@ test "db chunked dense enrichment replays cached artifacts after dense reset wit
 test "db recreated managed dense index converges replay and irrelevant resolver stages" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var counting = CountingDenseEmbedder{};
@@ -73186,8 +73456,9 @@ test "db recreated managed dense index converges replay and irrelevant resolver 
 test "db reopened chunked dense HBC deletes stale vectors through artifact loader" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var counting = CountingDenseEmbedder{};
@@ -73244,8 +73515,9 @@ test "db reopened chunked dense HBC deletes stale vectors through artifact loade
 test "db chunked generated dense and sparse embeddings search as parent results" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var deterministic_dense = embedder_mod.DeterministicDenseEmbedder{};
@@ -73364,8 +73636,9 @@ test "db chunked generated dense and sparse embeddings search as parent results"
 test "db sparse enrichment skips unchanged source hash" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var counting = CountingSparseEmbedder{};
@@ -73423,8 +73696,9 @@ test "db sparse enrichment skips unchanged source hash" {
 test "db chunked sparse enrichment skips unchanged chunks and deletes stale sparse artifacts" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var counting = CountingSparseEmbedder{};
@@ -73507,8 +73781,9 @@ test "db chunked sparse enrichment skips unchanged chunks and deletes stale spar
 test "db runUntilIdle drains enrichment and derived indexing" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var deterministic = embedder_mod.DeterministicDenseEmbedder{};
@@ -73560,8 +73835,9 @@ test "db runUntilIdle drains enrichment and derived indexing" {
 test "db write sync trailing dense no-op batches drain stale delete replay at idle" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var deterministic = embedder_mod.DeterministicDenseEmbedder{};
@@ -73681,8 +73957,9 @@ test "db write sync trailing dense no-op batches drain stale delete replay at id
 test "db generated enrichment empty backfill advances enrichment checkpoint" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var deterministic = embedder_mod.DeterministicDenseEmbedder{};
@@ -73708,8 +73985,9 @@ test "db generated enrichment empty backfill advances enrichment checkpoint" {
 test "db generated enrichment backfill drains stored docs beyond first replay chunk" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var deterministic = embedder_mod.DeterministicDenseEmbedder{};
@@ -73764,8 +74042,9 @@ test "db generated enrichment backfill drains stored docs beyond first replay ch
 test "db runUntilIdle drains lazy dense posting maintenance" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -73817,8 +74096,9 @@ test "db runUntilIdle drains lazy dense posting maintenance" {
 test "db leased enrichment worker materializes chunk artifacts" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var deterministic = embedder_mod.DeterministicDenseEmbedder{};
@@ -73876,8 +74156,9 @@ test "db leased enrichment worker materializes chunk artifacts" {
 test "db leased enrichment worker keeps chunk storage ephemeral when store_chunks is false" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var counting = CountingDenseEmbedder{};
@@ -73955,8 +74236,9 @@ test "db leased enrichment worker keeps chunk storage ephemeral when store_chunk
 test "db leased enrichment worker persists chunk storage when full text consumes chunked text" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var deterministic = embedder_mod.DeterministicDenseEmbedder{};
@@ -74005,8 +74287,9 @@ test "db leased enrichment worker persists chunk storage when full text consumes
 test "db deferred generated coverage remains pending until the enrichment worker decides an outcome" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
     const config_json =
         "{\"field\":\"embedding\",\"dims\":3,\"coverage_policy\":\"partial\",\"generator\":{\"kind\":\"dense_embedding\",\"source_field\":\"image_url\",\"source_template\":\"{{#if image_url}}{{image_url}}{{/if}}\"}}";
@@ -74069,8 +74352,9 @@ test "db deferred generated coverage remains pending until the enrichment worker
 test "db generated enrichment replay cannot infer terminal skip from an omitted partial artifact" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{ .start_index_workers = false });
@@ -74117,8 +74401,9 @@ test "db generated enrichment replay cannot infer terminal skip from an omitted 
 test "db managed conditional embeddings persist exact mixed corpus coverage across reopen" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
     const config_json =
         "{\"field\":\"embedding\",\"dims\":3,\"generator\":{\"kind\":\"dense_embedding\",\"source_field\":\"image_url\",\"source_template\":\"{{#if image_url}}{{image_url}}{{/if}}\"}}";
@@ -74191,8 +74476,9 @@ test "db managed conditional embeddings persist exact mixed corpus coverage acro
 test "db leased enrichment worker persists chunk storage when chunker enables full text indexing" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var deterministic = embedder_mod.DeterministicDenseEmbedder{};
@@ -74236,8 +74522,9 @@ test "db leased enrichment worker persists chunk storage when chunker enables fu
 test "db default full text index searches template chunk text when chunker full text indexing is enabled" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var deterministic = embedder_mod.DeterministicDenseEmbedder{};
@@ -74282,8 +74569,9 @@ test "db default full text index searches template chunk text when chunker full 
 test "db full_text sync level does not precompute template chunk full text routing" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var deterministic = embedder_mod.DeterministicDenseEmbedder{};
@@ -74356,8 +74644,9 @@ test "cloneManagedSyncTargetsAll duplicates names independently" {
 test "collectManagedSyncTargets includes graph index for graph artifact journal changes" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -74392,8 +74681,9 @@ test "collectManagedSyncTargets includes graph index for graph artifact journal 
 test "visibility targets include graph replay blocked by a missing dependency" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -74424,8 +74714,9 @@ test "visibility targets include graph replay blocked by a missing dependency" {
 test "db full_index supports dense parent search for template chunked embeddings" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var deterministic = embedder_mod.DeterministicDenseEmbedder{};
@@ -74467,8 +74758,9 @@ test "db full_index supports dense parent search for template chunked embeddings
 test "db full_index supports dense parent search when chunk artifacts are ephemeral" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var deterministic = embedder_mod.DeterministicDenseEmbedder{};
@@ -74539,8 +74831,9 @@ test "db full_index supports dense parent search when chunk artifacts are epheme
 test "db reopened full_index supports dense parent search when chunk artifacts are ephemeral" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var deterministic = embedder_mod.DeterministicDenseEmbedder{};
@@ -74587,8 +74880,9 @@ test "db reopened full_index supports dense parent search when chunk artifacts a
 test "db leased enrichment worker materializes chunk artifacts with durable lsm primary backend" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var deterministic = embedder_mod.DeterministicDenseEmbedder{};
@@ -74647,8 +74941,9 @@ test "db leased enrichment worker materializes chunk artifacts with durable lsm 
 test "db shared embedding enrichment feeds multiple dense indexes" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var deterministic = embedder_mod.DeterministicDenseEmbedder{};
@@ -74711,8 +75006,9 @@ test "db shared embedding enrichment feeds multiple dense indexes" {
 test "db shared enrichment failure parks repair debt for every consumer" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var gated = GateDenseEmbedder{};
@@ -74812,8 +75108,9 @@ test "db upstream asset failure dominates downstream coverage in one replay sequ
         }
     };
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var failing = FailingProducer{};
@@ -74900,8 +75197,9 @@ test "db foreign inference provider failure releases enrichment waiter as termin
         }
     };
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var failing = ForeignFailingProducer{};
@@ -75002,8 +75300,9 @@ test "db foreign inference provider failure releases enrichment waiter as termin
 
 test "db terminal enrichment sequence index survives coalescing and retires with repair debt" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var deterministic = embedder_mod.DeterministicDenseEmbedder{};
@@ -75106,8 +75405,9 @@ test "db terminal enrichment sequence index survives coalescing and retires with
 
 test "db terminal enrichment marker cleanup isolates corrupt cross issue reverse entries" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var deterministic = embedder_mod.DeterministicDenseEmbedder{};
@@ -75194,8 +75494,9 @@ test "db terminal enrichment marker cleanup isolates corrupt cross issue reverse
 
 test "db terminal enrichment marker retirement is bounded and fences stale generations" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var deterministic = embedder_mod.DeterministicDenseEmbedder{};
@@ -75275,8 +75576,9 @@ test "db terminal enrichment marker retirement is bounded and fences stale gener
 
 test "db terminal enrichment markers do not resurrect across rollback recreation" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var deterministic = embedder_mod.DeterministicDenseEmbedder{};
@@ -75341,8 +75643,9 @@ test "db terminal enrichment markers do not resurrect across rollback recreation
 test "db enrichment retry makes monotonic progress across provider batches" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var gated = GateDenseEmbedder{};
@@ -75394,8 +75697,9 @@ test "db enrichment retry makes monotonic progress across provider batches" {
 test "db shared enrichment repair regenerates one physical artifact once" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var gated = GateDenseEmbedder{};
@@ -75472,8 +75776,9 @@ test "db shared enrichment repair regenerates one physical artifact once" {
 test "db chunked enrichment failure repair completes from request coverage" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var gated = GateDenseEmbedder{};
@@ -75531,8 +75836,9 @@ test "db chunked enrichment failure repair completes from request coverage" {
 
 test "db asset repair reports a missing source document precisely" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{ .start_optional_runtime_workers = false });
@@ -75585,8 +75891,9 @@ test "db asset repair reports a missing source document precisely" {
 
 test "db enrichment repair never clears a newer failure revision" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{ .start_optional_runtime_workers = false });
@@ -75660,8 +75967,9 @@ test "db enrichment repair never clears a newer failure revision" {
 test "db shared embedding enrichment feeds multiple dense indexes with durable lsm primary backend" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var deterministic = embedder_mod.DeterministicDenseEmbedder{};
@@ -75725,8 +76033,9 @@ test "db shared embedding enrichment feeds multiple dense indexes with durable l
 test "db addEnrichment supports explicit shared definitions" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var validating = ValidatingChunkDenseEmbedder{};
@@ -75811,8 +76120,9 @@ test "db addEnrichment supports explicit shared definitions" {
 test "db index inspection lists graph indexes" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -75837,8 +76147,9 @@ test "db index inspection lists graph indexes" {
 test "db preflight classifies canonical artifact full-text sources consistently" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -75873,8 +76184,9 @@ test "db preflight classifies canonical artifact full-text sources consistently"
 test "artifact text replay deletes only keys owned by its source projection" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -75944,8 +76256,9 @@ test "artifact text replay deletes only keys owned by its source projection" {
 
 test "db chunk retirement removes dense and sparse members from generated and artifact projections" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
     var dense = embedder_mod.DeterministicDenseEmbedder{};
     var sparse = embedder_mod.DeterministicSparseEmbedder{};
@@ -75998,8 +76311,9 @@ test "db chunk retirement removes dense and sparse members from generated and ar
 
 test "db chunk deletion replay targets only matching vector sources" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
     var db = try DB.open(alloc, std.mem.span(path), .{});
     defer db.close();
@@ -76091,8 +76405,9 @@ test "db chunk deletion replay targets only matching vector sources" {
 test "embedding artifact replay deletes only the consuming vector projection" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -76138,8 +76453,9 @@ test "embedding artifact replay deletes only the consuming vector projection" {
 test "db preflightSearchRequest validates live lane bindings" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -76441,8 +76757,9 @@ test "db preflightSearchRequest validates live lane bindings" {
 test "db preflightSearchRequest surfaces structured filter probe counts when count is budget limited" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -76496,8 +76813,9 @@ test "db preflightSearchRequest surfaces structured filter probe counts when cou
 test "db graph methods expose edges, neighbors, and shortest path" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -76581,8 +76899,9 @@ test "db graph methods expose edges, neighbors, and shortest path" {
 test "db graph algebraic shortest path applies exact min-hop edge weight filters" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -76626,8 +76945,9 @@ test "db graph algebraic shortest path applies exact min-hop edge weight filters
 test "db deleteEnrichment rejects referenced definitions" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -76652,8 +76972,9 @@ test "db deleteEnrichment rejects referenced definitions" {
 test "db deleteEnrichment rejects asset referenced by chunk enrichment" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -76679,8 +77000,9 @@ test "db deleteEnrichment rejects asset referenced by chunk enrichment" {
 test "db upsertEnrichment rejects replacing referenced asset with chunk" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -76716,8 +77038,9 @@ test "db upsertEnrichment rejects replacing referenced asset with chunk" {
 test "db upsertEnrichment rejects replacing referenced chunk with asset" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -76752,8 +77075,9 @@ test "db upsertEnrichment rejects replacing referenced chunk with asset" {
 test "db upsertEnrichment rejects replacing indexed chunk with asset" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -76786,8 +77110,9 @@ test "db upsertEnrichment rejects replacing indexed chunk with asset" {
 test "db addEnrichment rejects duplicate names across enrichment kinds" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -76810,8 +77135,9 @@ test "db addEnrichment rejects duplicate names across enrichment kinds" {
 test "db addEnrichment allows unrelated definitions after field sparse index" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -76833,8 +77159,9 @@ test "db addEnrichment allows unrelated definitions after field sparse index" {
 test "db enrichment artifact consumer resolution includes graph and default full text indexes" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -76876,8 +77203,9 @@ test "db enrichment artifact consumer resolution includes graph and default full
 test "db asset enrichment full_text_index feeds default full text index after full_index sync" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -76946,8 +77274,9 @@ test "db asset enrichment full_text_index feeds default full text index after fu
 test "db dense index can reference existing whole-doc embedding enrichment" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var deterministic = embedder_mod.DeterministicDenseEmbedder{};
@@ -76995,8 +77324,9 @@ test "db dense index can reference existing whole-doc embedding enrichment" {
 test "db dense index can reference existing chunk embedding enrichment" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var deterministic = embedder_mod.DeterministicDenseEmbedder{};
@@ -77055,8 +77385,9 @@ test "db dense index can reference existing chunk embedding enrichment" {
 test "db persists shorthand chunk enrichment catalog across reopen" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     {
@@ -77113,8 +77444,9 @@ test "db persists shorthand chunk enrichment catalog across reopen" {
 test "db persists shorthand chunk enrichment catalog across reopen with durable lsm primary backend" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     const primary_backend: PrimaryBackend = .{ .lsm = db_config.primary_lsm_options_default };
@@ -77177,8 +77509,9 @@ test "db persists shorthand chunk enrichment catalog across reopen with durable 
 test "db listEnrichments returns explicit definitions across reopen" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     {
@@ -77216,8 +77549,9 @@ test "db listEnrichments returns explicit definitions across reopen" {
 test "db listEnrichments returns explicit definitions across reopen with durable lsm primary backend" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     const primary_backend: PrimaryBackend = .{ .lsm = db_config.primary_lsm_options_default };
@@ -77261,8 +77595,9 @@ test "db listEnrichments returns explicit definitions across reopen with durable
 test "db full-text chunk consumer returns parent and chunk modes" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var deterministic = embedder_mod.DeterministicDenseEmbedder{};
@@ -77333,8 +77668,9 @@ test "db full-text chunk consumer returns parent and chunk modes" {
 test "db full-text chunk consumer filters expired parents under ttl" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var deterministic = embedder_mod.DeterministicDenseEmbedder{};
@@ -77404,8 +77740,9 @@ test "db full-text chunk consumer filters expired parents under ttl" {
 test "db full-text ttl filters before pagination and count-only totals" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -77456,8 +77793,9 @@ test "db full-text ttl filters before pagination and count-only totals" {
 test "db composed full-text ttl filters resolved text filters before pagination" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -77506,8 +77844,9 @@ test "db composed full-text ttl filters resolved text filters before pagination"
 test "db full-text ttl uses lower-bound totals for non-exhaustive visible pages" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -77546,8 +77885,9 @@ test "db full-text ttl uses lower-bound totals for non-exhaustive visible pages"
 test "db ttl broad live filter preserves all-doc sentinel" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -77579,8 +77919,9 @@ test "db ttl broad live filter preserves all-doc sentinel" {
 test "db public artifact lookup strips private hierarchy metadata without changing internal records" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -77665,8 +78006,9 @@ test "canonical grouped match requests isolate nested pagination and work" {
 test "db full-text chunk parent paging applies after grouping" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var deterministic = embedder_mod.DeterministicDenseEmbedder{};
@@ -77733,8 +78075,9 @@ test "db full-text chunk parent paging applies after grouping" {
 test "db dense chunk consumer supports parent and parent_with_chunks modes" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var deterministic = embedder_mod.DeterministicDenseEmbedder{};
@@ -77896,8 +78239,9 @@ test "db dense chunk consumer supports parent and parent_with_chunks modes" {
 test "db dense chunk consumer supports parent and parent_with_chunks modes with durable lsm primary backend" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var deterministic = embedder_mod.DeterministicDenseEmbedder{};
@@ -77975,8 +78319,9 @@ test "db dense chunk consumer supports parent and parent_with_chunks modes with 
 test "db dense parent paging fetches enough chunk hits before grouping" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var deterministic = embedder_mod.DeterministicDenseEmbedder{};
@@ -78032,8 +78377,9 @@ test "db dense parent paging fetches enough chunk hits before grouping" {
 test "db batch persists per-index applied sequence watermark" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -78075,8 +78421,9 @@ test "db batch persists per-index applied sequence watermark" {
 test "db managed projection checkpoints persist status and config identity" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     const configs = [_]types.IndexConfig{
@@ -78145,8 +78492,9 @@ test "db managed projection checkpoints persist status and config identity" {
 test "db batch truncates replay logs after managed indexes catch up" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -78184,8 +78532,9 @@ test "db batch truncates replay logs after managed indexes catch up" {
 test "db async replay truncation retains durable enrichment debt" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -78232,8 +78581,9 @@ test "db async replay truncation retains durable enrichment debt" {
 test "db restart after provider failure resumes enrichment from retained async replay" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var first_applied_sequence: u64 = 0;
@@ -78343,8 +78693,9 @@ test "db restart after provider failure resumes enrichment from retained async r
 test "db async replay truncation retains journal behind generated enrichment" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var gated = GateDenseEmbedder{};
@@ -78407,8 +78758,9 @@ test "db async replay truncation retains journal behind generated enrichment" {
 test "db io_threaded executor processes indexed writes" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -78449,8 +78801,9 @@ test "db io_threaded executor stress applies explicit dense embeddings on lsm ba
     const progress_interval = @max(batch_size, stressEnvUsize("ANTFLY_STRESS_DENSE_PROGRESS", batch_size * 8));
     const dense_backend = stressDenseBackend();
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -78539,8 +78892,9 @@ test "db io_threaded executor stress applies explicit dense embeddings on lsm ba
 test "db reopen replays pending derived embeddings from durable log" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var appended_sequence: u64 = 0;
@@ -78604,14 +78958,17 @@ test "db reopen replays pending derived embeddings from durable log" {
 test "storage.ha db mirrors appended derived replay records into HA stream" {
     const alloc = std.testing.allocator;
 
-    var db_path_buf: [256]u8 = undefined;
-    const db_path = tempPath(&db_path_buf);
+    var db_path_tmp = try TestDirectory.init("db");
+    defer db_path_tmp.cleanup();
+    const db_path = db_path_tmp.path().ptr;
     defer cleanupTempDir(db_path);
-    var ha_log_path_buf: [256]u8 = undefined;
-    const ha_log_path = tempPath(&ha_log_path_buf);
+    var ha_log_path_tmp = try TestDirectory.init("db");
+    defer ha_log_path_tmp.cleanup();
+    const ha_log_path = ha_log_path_tmp.path().ptr;
     defer cleanupTempDir(ha_log_path);
-    var ha_slots_path_buf: [256]u8 = undefined;
-    const ha_slots_path = tempPath(&ha_slots_path_buf);
+    var ha_slots_path_tmp = try TestDirectory.init("db");
+    defer ha_slots_path_tmp.cleanup();
+    const ha_slots_path = ha_slots_path_tmp.path().ptr;
     defer cleanupTempDir(ha_slots_path);
 
     var primary = try ha_primary_mod.Primary.open(alloc, ha_log_path, ha_slots_path, .{
@@ -78665,14 +79022,17 @@ test "storage.ha db mirrors appended derived replay records into HA stream" {
 test "storage.ha db waits for remote apply before completing derived enrichment" {
     const alloc = std.testing.allocator;
 
-    var db_path_buf: [256]u8 = undefined;
-    const db_path = tempPath(&db_path_buf);
+    var db_path_tmp = try TestDirectory.init("db");
+    defer db_path_tmp.cleanup();
+    const db_path = db_path_tmp.path().ptr;
     defer cleanupTempDir(db_path);
-    var ha_log_path_buf: [256]u8 = undefined;
-    const ha_log_path = tempPath(&ha_log_path_buf);
+    var ha_log_path_tmp = try TestDirectory.init("db");
+    defer ha_log_path_tmp.cleanup();
+    const ha_log_path = ha_log_path_tmp.path().ptr;
     defer cleanupTempDir(ha_log_path);
-    var ha_slots_path_buf: [256]u8 = undefined;
-    const ha_slots_path = tempPath(&ha_slots_path_buf);
+    var ha_slots_path_tmp = try TestDirectory.init("db");
+    defer ha_slots_path_tmp.cleanup();
+    const ha_slots_path = ha_slots_path_tmp.path().ptr;
     defer cleanupTempDir(ha_slots_path);
 
     var primary = try ha_primary_mod.Primary.open(alloc, ha_log_path, ha_slots_path, .{
@@ -78743,23 +79103,29 @@ test "storage.ha db waits for remote apply before completing derived enrichment"
 test "storage.ha db mirrors committed batch mutations into HA stream for standby apply" {
     const alloc = std.testing.allocator;
 
-    var primary_db_path_buf: [256]u8 = undefined;
-    const primary_db_path = tempPath(&primary_db_path_buf);
+    var primary_db_path_tmp = try TestDirectory.init("db");
+    defer primary_db_path_tmp.cleanup();
+    const primary_db_path = primary_db_path_tmp.path().ptr;
     defer cleanupTempDir(primary_db_path);
-    var standby_db_path_buf: [256]u8 = undefined;
-    const standby_db_path = tempPath(&standby_db_path_buf);
+    var standby_db_path_tmp = try TestDirectory.init("db");
+    defer standby_db_path_tmp.cleanup();
+    const standby_db_path = standby_db_path_tmp.path().ptr;
     defer cleanupTempDir(standby_db_path);
-    var ha_log_path_buf: [256]u8 = undefined;
-    const ha_log_path = tempPath(&ha_log_path_buf);
+    var ha_log_path_tmp = try TestDirectory.init("db");
+    defer ha_log_path_tmp.cleanup();
+    const ha_log_path = ha_log_path_tmp.path().ptr;
     defer cleanupTempDir(ha_log_path);
-    var ha_slots_path_buf: [256]u8 = undefined;
-    const ha_slots_path = tempPath(&ha_slots_path_buf);
+    var ha_slots_path_tmp = try TestDirectory.init("db");
+    defer ha_slots_path_tmp.cleanup();
+    const ha_slots_path = ha_slots_path_tmp.path().ptr;
     defer cleanupTempDir(ha_slots_path);
-    var standby_log_path_buf: [256]u8 = undefined;
-    const standby_log_path = tempPath(&standby_log_path_buf);
+    var standby_log_path_tmp = try TestDirectory.init("db");
+    defer standby_log_path_tmp.cleanup();
+    const standby_log_path = standby_log_path_tmp.path().ptr;
     defer cleanupTempDir(standby_log_path);
-    var standby_progress_path_buf: [256]u8 = undefined;
-    const standby_progress_path = tempPath(&standby_progress_path_buf);
+    var standby_progress_path_tmp = try TestDirectory.init("db");
+    defer standby_progress_path_tmp.cleanup();
+    const standby_progress_path = standby_progress_path_tmp.path().ptr;
     defer cleanupTempDir(standby_progress_path);
 
     var primary = try ha_primary_mod.Primary.open(alloc, ha_log_path, ha_slots_path, .{
@@ -78845,14 +79211,17 @@ test "storage.ha seed capture barrier prevents local commit without matching wal
 
     const alloc = std.heap.c_allocator;
 
-    var db_path_buf: [256]u8 = undefined;
-    const db_path = tempPath(&db_path_buf);
+    var db_path_tmp = try TestDirectory.init("db");
+    defer db_path_tmp.cleanup();
+    const db_path = db_path_tmp.path().ptr;
     defer cleanupTempDir(db_path);
-    var ha_log_path_buf: [256]u8 = undefined;
-    const ha_log_path = tempPath(&ha_log_path_buf);
+    var ha_log_path_tmp = try TestDirectory.init("db");
+    defer ha_log_path_tmp.cleanup();
+    const ha_log_path = ha_log_path_tmp.path().ptr;
     defer cleanupTempDir(ha_log_path);
-    var ha_slots_path_buf: [256]u8 = undefined;
-    const ha_slots_path = tempPath(&ha_slots_path_buf);
+    var ha_slots_path_tmp = try TestDirectory.init("db");
+    defer ha_slots_path_tmp.cleanup();
+    const ha_slots_path = ha_slots_path_tmp.path().ptr;
     defer cleanupTempDir(ha_slots_path);
 
     var primary = try ha_primary_mod.Primary.open(alloc, ha_log_path, ha_slots_path, .{
@@ -78910,8 +79279,9 @@ test "storage.ha seed snapshot predrains enrichment before exclusive capture" {
     if (builtin.single_threaded or builtin.os.tag == .freestanding) return error.SkipZigTest;
 
     const alloc = std.testing.allocator;
-    var db_path_buf: [256]u8 = undefined;
-    const db_path = tempPath(&db_path_buf);
+    var db_path_tmp = try TestDirectory.init("db");
+    defer db_path_tmp.cleanup();
+    const db_path = db_path_tmp.path().ptr;
     defer cleanupTempDir(db_path);
     defer {
         var snapshots_buf: [512]u8 = undefined;
@@ -78919,11 +79289,13 @@ test "storage.ha seed snapshot predrains enrichment before exclusive capture" {
             std.Io.Dir.cwd().deleteTree(std.testing.io, snapshots) catch {};
         } else |_| {}
     }
-    var ha_log_path_buf: [256]u8 = undefined;
-    const ha_log_path = tempPath(&ha_log_path_buf);
+    var ha_log_path_tmp = try TestDirectory.init("db");
+    defer ha_log_path_tmp.cleanup();
+    const ha_log_path = ha_log_path_tmp.path().ptr;
     defer cleanupTempDir(ha_log_path);
-    var ha_slots_path_buf: [256]u8 = undefined;
-    const ha_slots_path = tempPath(&ha_slots_path_buf);
+    var ha_slots_path_tmp = try TestDirectory.init("db");
+    defer ha_slots_path_tmp.cleanup();
+    const ha_slots_path = ha_slots_path_tmp.path().ptr;
     defer cleanupTempDir(ha_slots_path);
 
     var primary = try ha_primary_mod.Primary.open(alloc, ha_log_path, ha_slots_path, .{
@@ -79004,14 +79376,17 @@ test "storage.ha fence cannot strand a local commit beyond the HA tail" {
     if (builtin.single_threaded or builtin.os.tag == .freestanding) return error.SkipZigTest;
 
     const alloc = std.heap.c_allocator;
-    var db_path_buf: [256]u8 = undefined;
-    const db_path = tempPath(&db_path_buf);
+    var db_path_tmp = try TestDirectory.init("db");
+    defer db_path_tmp.cleanup();
+    const db_path = db_path_tmp.path().ptr;
     defer cleanupTempDir(db_path);
-    var ha_log_path_buf: [256]u8 = undefined;
-    const ha_log_path = tempPath(&ha_log_path_buf);
+    var ha_log_path_tmp = try TestDirectory.init("db");
+    defer ha_log_path_tmp.cleanup();
+    const ha_log_path = ha_log_path_tmp.path().ptr;
     defer cleanupTempDir(ha_log_path);
-    var ha_slots_path_buf: [256]u8 = undefined;
-    const ha_slots_path = tempPath(&ha_slots_path_buf);
+    var ha_slots_path_tmp = try TestDirectory.init("db");
+    defer ha_slots_path_tmp.cleanup();
+    const ha_slots_path = ha_slots_path_tmp.path().ptr;
     defer cleanupTempDir(ha_slots_path);
 
     var primary = try ha_primary_mod.Primary.open(alloc, ha_log_path, ha_slots_path, .{
@@ -79077,14 +79452,17 @@ test "storage.ha schema json mutation does not reacquire shared barrier behind q
     if (builtin.single_threaded or builtin.os.tag == .freestanding) return error.SkipZigTest;
 
     const alloc = std.testing.allocator;
-    var db_path_buf: [256]u8 = undefined;
-    const db_path = tempPath(&db_path_buf);
+    var db_path_tmp = try TestDirectory.init("db");
+    defer db_path_tmp.cleanup();
+    const db_path = db_path_tmp.path().ptr;
     defer cleanupTempDir(db_path);
-    var ha_log_path_buf: [256]u8 = undefined;
-    const ha_log_path = tempPath(&ha_log_path_buf);
+    var ha_log_path_tmp = try TestDirectory.init("db");
+    defer ha_log_path_tmp.cleanup();
+    const ha_log_path = ha_log_path_tmp.path().ptr;
     defer cleanupTempDir(ha_log_path);
-    var ha_slots_path_buf: [256]u8 = undefined;
-    const ha_slots_path = tempPath(&ha_slots_path_buf);
+    var ha_slots_path_tmp = try TestDirectory.init("db");
+    defer ha_slots_path_tmp.cleanup();
+    const ha_slots_path = ha_slots_path_tmp.path().ptr;
     defer cleanupTempDir(ha_slots_path);
 
     var primary = try ha_primary_mod.Primary.open(alloc, ha_log_path, ha_slots_path, .{
@@ -79162,14 +79540,17 @@ test "storage.ha schema json mutation does not reacquire shared barrier behind q
 test "storage.ha db evaluates sync commit gate for mirrored batch mutations" {
     const alloc = std.testing.allocator;
 
-    var db_path_buf: [256]u8 = undefined;
-    const db_path = tempPath(&db_path_buf);
+    var db_path_tmp = try TestDirectory.init("db");
+    defer db_path_tmp.cleanup();
+    const db_path = db_path_tmp.path().ptr;
     defer cleanupTempDir(db_path);
-    var ha_log_path_buf: [256]u8 = undefined;
-    const ha_log_path = tempPath(&ha_log_path_buf);
+    var ha_log_path_tmp = try TestDirectory.init("db");
+    defer ha_log_path_tmp.cleanup();
+    const ha_log_path = ha_log_path_tmp.path().ptr;
     defer cleanupTempDir(ha_log_path);
-    var ha_slots_path_buf: [256]u8 = undefined;
-    const ha_slots_path = tempPath(&ha_slots_path_buf);
+    var ha_slots_path_tmp = try TestDirectory.init("db");
+    defer ha_slots_path_tmp.cleanup();
+    const ha_slots_path = ha_slots_path_tmp.path().ptr;
     defer cleanupTempDir(ha_slots_path);
 
     var primary = try ha_primary_mod.Primary.open(alloc, ha_log_path, ha_slots_path, .{
@@ -79221,14 +79602,17 @@ test "storage.ha db evaluates sync commit gate for mirrored batch mutations" {
 test "storage.ha db block sync policy waits for standby acknowledgement" {
     const alloc = std.testing.allocator;
 
-    var db_path_buf: [256]u8 = undefined;
-    const db_path = tempPath(&db_path_buf);
+    var db_path_tmp = try TestDirectory.init("db");
+    defer db_path_tmp.cleanup();
+    const db_path = db_path_tmp.path().ptr;
     defer cleanupTempDir(db_path);
-    var ha_log_path_buf: [256]u8 = undefined;
-    const ha_log_path = tempPath(&ha_log_path_buf);
+    var ha_log_path_tmp = try TestDirectory.init("db");
+    defer ha_log_path_tmp.cleanup();
+    const ha_log_path = ha_log_path_tmp.path().ptr;
     defer cleanupTempDir(ha_log_path);
-    var ha_slots_path_buf: [256]u8 = undefined;
-    const ha_slots_path = tempPath(&ha_slots_path_buf);
+    var ha_slots_path_tmp = try TestDirectory.init("db");
+    defer ha_slots_path_tmp.cleanup();
+    const ha_slots_path = ha_slots_path_tmp.path().ptr;
     defer cleanupTempDir(ha_slots_path);
 
     var primary = try ha_primary_mod.Primary.open(alloc, ha_log_path, ha_slots_path, .{
@@ -79294,23 +79678,29 @@ test "storage.ha db block sync policy waits for standby acknowledgement" {
 test "storage.ha db session sync wait satisfies remote apply through standby DB apply" {
     const alloc = std.testing.allocator;
 
-    var primary_db_path_buf: [256]u8 = undefined;
-    const primary_db_path = tempPath(&primary_db_path_buf);
+    var primary_db_path_tmp = try TestDirectory.init("db");
+    defer primary_db_path_tmp.cleanup();
+    const primary_db_path = primary_db_path_tmp.path().ptr;
     defer cleanupTempDir(primary_db_path);
-    var standby_db_path_buf: [256]u8 = undefined;
-    const standby_db_path = tempPath(&standby_db_path_buf);
+    var standby_db_path_tmp = try TestDirectory.init("db");
+    defer standby_db_path_tmp.cleanup();
+    const standby_db_path = standby_db_path_tmp.path().ptr;
     defer cleanupTempDir(standby_db_path);
-    var ha_log_path_buf: [256]u8 = undefined;
-    const ha_log_path = tempPath(&ha_log_path_buf);
+    var ha_log_path_tmp = try TestDirectory.init("db");
+    defer ha_log_path_tmp.cleanup();
+    const ha_log_path = ha_log_path_tmp.path().ptr;
     defer cleanupTempDir(ha_log_path);
-    var ha_slots_path_buf: [256]u8 = undefined;
-    const ha_slots_path = tempPath(&ha_slots_path_buf);
+    var ha_slots_path_tmp = try TestDirectory.init("db");
+    defer ha_slots_path_tmp.cleanup();
+    const ha_slots_path = ha_slots_path_tmp.path().ptr;
     defer cleanupTempDir(ha_slots_path);
-    var standby_log_path_buf: [256]u8 = undefined;
-    const standby_log_path = tempPath(&standby_log_path_buf);
+    var standby_log_path_tmp = try TestDirectory.init("db");
+    defer standby_log_path_tmp.cleanup();
+    const standby_log_path = standby_log_path_tmp.path().ptr;
     defer cleanupTempDir(standby_log_path);
-    var standby_progress_path_buf: [256]u8 = undefined;
-    const standby_progress_path = tempPath(&standby_progress_path_buf);
+    var standby_progress_path_tmp = try TestDirectory.init("db");
+    defer standby_progress_path_tmp.cleanup();
+    const standby_progress_path = standby_progress_path_tmp.path().ptr;
     defer cleanupTempDir(standby_progress_path);
 
     const identity = ha_standby_mod.Identity{
@@ -79389,23 +79779,29 @@ test "storage.ha db session sync wait satisfies remote apply through standby DB 
 test "storage.ha db allows progress but rejects acknowledgement when fenced during remote apply wait" {
     const alloc = std.testing.allocator;
 
-    var primary_db_path_buf: [256]u8 = undefined;
-    const primary_db_path = tempPath(&primary_db_path_buf);
+    var primary_db_path_tmp = try TestDirectory.init("db");
+    defer primary_db_path_tmp.cleanup();
+    const primary_db_path = primary_db_path_tmp.path().ptr;
     defer cleanupTempDir(primary_db_path);
-    var standby_db_path_buf: [256]u8 = undefined;
-    const standby_db_path = tempPath(&standby_db_path_buf);
+    var standby_db_path_tmp = try TestDirectory.init("db");
+    defer standby_db_path_tmp.cleanup();
+    const standby_db_path = standby_db_path_tmp.path().ptr;
     defer cleanupTempDir(standby_db_path);
-    var ha_log_path_buf: [256]u8 = undefined;
-    const ha_log_path = tempPath(&ha_log_path_buf);
+    var ha_log_path_tmp = try TestDirectory.init("db");
+    defer ha_log_path_tmp.cleanup();
+    const ha_log_path = ha_log_path_tmp.path().ptr;
     defer cleanupTempDir(ha_log_path);
-    var ha_slots_path_buf: [256]u8 = undefined;
-    const ha_slots_path = tempPath(&ha_slots_path_buf);
+    var ha_slots_path_tmp = try TestDirectory.init("db");
+    defer ha_slots_path_tmp.cleanup();
+    const ha_slots_path = ha_slots_path_tmp.path().ptr;
     defer cleanupTempDir(ha_slots_path);
-    var standby_log_path_buf: [256]u8 = undefined;
-    const standby_log_path = tempPath(&standby_log_path_buf);
+    var standby_log_path_tmp = try TestDirectory.init("db");
+    defer standby_log_path_tmp.cleanup();
+    const standby_log_path = standby_log_path_tmp.path().ptr;
     defer cleanupTempDir(standby_log_path);
-    var standby_progress_path_buf: [256]u8 = undefined;
-    const standby_progress_path = tempPath(&standby_progress_path_buf);
+    var standby_progress_path_tmp = try TestDirectory.init("db");
+    defer standby_progress_path_tmp.cleanup();
+    const standby_progress_path = standby_progress_path_tmp.path().ptr;
     defer cleanupTempDir(standby_progress_path);
 
     const identity = ha_standby_mod.Identity{
@@ -79522,20 +79918,25 @@ test "storage.ha db allows progress but rejects acknowledgement when fenced duri
 test "storage.ha db session sync wait remote write acknowledges durable receive despite apply failure" {
     const alloc = std.testing.allocator;
 
-    var primary_db_path_buf: [256]u8 = undefined;
-    const primary_db_path = tempPath(&primary_db_path_buf);
+    var primary_db_path_tmp = try TestDirectory.init("db");
+    defer primary_db_path_tmp.cleanup();
+    const primary_db_path = primary_db_path_tmp.path().ptr;
     defer cleanupTempDir(primary_db_path);
-    var ha_log_path_buf: [256]u8 = undefined;
-    const ha_log_path = tempPath(&ha_log_path_buf);
+    var ha_log_path_tmp = try TestDirectory.init("db");
+    defer ha_log_path_tmp.cleanup();
+    const ha_log_path = ha_log_path_tmp.path().ptr;
     defer cleanupTempDir(ha_log_path);
-    var ha_slots_path_buf: [256]u8 = undefined;
-    const ha_slots_path = tempPath(&ha_slots_path_buf);
+    var ha_slots_path_tmp = try TestDirectory.init("db");
+    defer ha_slots_path_tmp.cleanup();
+    const ha_slots_path = ha_slots_path_tmp.path().ptr;
     defer cleanupTempDir(ha_slots_path);
-    var standby_log_path_buf: [256]u8 = undefined;
-    const standby_log_path = tempPath(&standby_log_path_buf);
+    var standby_log_path_tmp = try TestDirectory.init("db");
+    defer standby_log_path_tmp.cleanup();
+    const standby_log_path = standby_log_path_tmp.path().ptr;
     defer cleanupTempDir(standby_log_path);
-    var standby_progress_path_buf: [256]u8 = undefined;
-    const standby_progress_path = tempPath(&standby_progress_path_buf);
+    var standby_progress_path_tmp = try TestDirectory.init("db");
+    defer standby_progress_path_tmp.cleanup();
+    const standby_progress_path = standby_progress_path_tmp.path().ptr;
     defer cleanupTempDir(standby_progress_path);
 
     const identity = ha_standby_mod.Identity{
@@ -79619,14 +80020,17 @@ test "storage.ha db session sync wait remote write acknowledges durable receive 
 test "storage.ha db primary progress sync wait observes reported remote apply ack" {
     const alloc = std.testing.allocator;
 
-    var db_path_buf: [256]u8 = undefined;
-    const db_path = tempPath(&db_path_buf);
+    var db_path_tmp = try TestDirectory.init("db");
+    defer db_path_tmp.cleanup();
+    const db_path = db_path_tmp.path().ptr;
     defer cleanupTempDir(db_path);
-    var ha_log_path_buf: [256]u8 = undefined;
-    const ha_log_path = tempPath(&ha_log_path_buf);
+    var ha_log_path_tmp = try TestDirectory.init("db");
+    defer ha_log_path_tmp.cleanup();
+    const ha_log_path = ha_log_path_tmp.path().ptr;
     defer cleanupTempDir(ha_log_path);
-    var ha_slots_path_buf: [256]u8 = undefined;
-    const ha_slots_path = tempPath(&ha_slots_path_buf);
+    var ha_slots_path_tmp = try TestDirectory.init("db");
+    defer ha_slots_path_tmp.cleanup();
+    const ha_slots_path = ha_slots_path_tmp.path().ptr;
     defer cleanupTempDir(ha_slots_path);
 
     var primary = try ha_primary_mod.Primary.open(alloc, ha_log_path, ha_slots_path, .{
@@ -79700,11 +80104,13 @@ test "storage.ha db primary progress sync wait observes reported remote apply ac
 test "storage.ha primary progress sync wait fast fails without enough eligible candidates" {
     const alloc = std.testing.allocator;
 
-    var ha_log_path_buf: [256]u8 = undefined;
-    const ha_log_path = tempPath(&ha_log_path_buf);
+    var ha_log_path_tmp = try TestDirectory.init("db");
+    defer ha_log_path_tmp.cleanup();
+    const ha_log_path = ha_log_path_tmp.path().ptr;
     defer cleanupTempDir(ha_log_path);
-    var ha_slots_path_buf: [256]u8 = undefined;
-    const ha_slots_path = tempPath(&ha_slots_path_buf);
+    var ha_slots_path_tmp = try TestDirectory.init("db");
+    defer ha_slots_path_tmp.cleanup();
+    const ha_slots_path = ha_slots_path_tmp.path().ptr;
     defer cleanupTempDir(ha_slots_path);
 
     var primary = try ha_primary_mod.Primary.open(alloc, ha_log_path, ha_slots_path, .{
@@ -79748,14 +80154,17 @@ test "storage.ha primary progress sync wait fast fails without enough eligible c
 test "storage.ha db primary progress sync wait returns would block without reported ack" {
     const alloc = std.testing.allocator;
 
-    var db_path_buf: [256]u8 = undefined;
-    const db_path = tempPath(&db_path_buf);
+    var db_path_tmp = try TestDirectory.init("db");
+    defer db_path_tmp.cleanup();
+    const db_path = db_path_tmp.path().ptr;
     defer cleanupTempDir(db_path);
-    var ha_log_path_buf: [256]u8 = undefined;
-    const ha_log_path = tempPath(&ha_log_path_buf);
+    var ha_log_path_tmp = try TestDirectory.init("db");
+    defer ha_log_path_tmp.cleanup();
+    const ha_log_path = ha_log_path_tmp.path().ptr;
     defer cleanupTempDir(ha_log_path);
-    var ha_slots_path_buf: [256]u8 = undefined;
-    const ha_slots_path = tempPath(&ha_slots_path_buf);
+    var ha_slots_path_tmp = try TestDirectory.init("db");
+    defer ha_slots_path_tmp.cleanup();
+    const ha_slots_path = ha_slots_path_tmp.path().ptr;
     defer cleanupTempDir(ha_slots_path);
 
     var primary = try ha_primary_mod.Primary.open(alloc, ha_log_path, ha_slots_path, .{
@@ -79807,14 +80216,17 @@ test "storage.ha db primary progress sync wait returns would block without repor
 test "storage.ha pending acknowledgement preserves batch and replay tail order" {
     const alloc = std.testing.allocator;
 
-    var db_path_buf: [256]u8 = undefined;
-    const db_path = tempPath(&db_path_buf);
+    var db_path_tmp = try TestDirectory.init("db");
+    defer db_path_tmp.cleanup();
+    const db_path = db_path_tmp.path().ptr;
     defer cleanupTempDir(db_path);
-    var ha_log_path_buf: [256]u8 = undefined;
-    const ha_log_path = tempPath(&ha_log_path_buf);
+    var ha_log_path_tmp = try TestDirectory.init("db");
+    defer ha_log_path_tmp.cleanup();
+    const ha_log_path = ha_log_path_tmp.path().ptr;
     defer cleanupTempDir(ha_log_path);
-    var ha_slots_path_buf: [256]u8 = undefined;
-    const ha_slots_path = tempPath(&ha_slots_path_buf);
+    var ha_slots_path_tmp = try TestDirectory.init("db");
+    defer ha_slots_path_tmp.cleanup();
+    const ha_slots_path = ha_slots_path_tmp.path().ptr;
     defer cleanupTempDir(ha_slots_path);
 
     var primary = try ha_primary_mod.Primary.open(alloc, ha_log_path, ha_slots_path, .{
@@ -79874,14 +80286,17 @@ test "storage.ha pending acknowledgement preserves batch and replay tail order" 
 
 test "db transaction HA retry drains durable mirror outbox" {
     const alloc = std.testing.allocator;
-    var db_path_buf: [256]u8 = undefined;
-    const db_path = tempPath(&db_path_buf);
+    var db_path_tmp = try TestDirectory.init("db");
+    defer db_path_tmp.cleanup();
+    const db_path = db_path_tmp.path().ptr;
     defer cleanupTempDir(db_path);
-    var ha_log_path_buf: [256]u8 = undefined;
-    const ha_log_path = tempPath(&ha_log_path_buf);
+    var ha_log_path_tmp = try TestDirectory.init("db");
+    defer ha_log_path_tmp.cleanup();
+    const ha_log_path = ha_log_path_tmp.path().ptr;
     defer cleanupTempDir(ha_log_path);
-    var ha_slots_path_buf: [256]u8 = undefined;
-    const ha_slots_path = tempPath(&ha_slots_path_buf);
+    var ha_slots_path_tmp = try TestDirectory.init("db");
+    defer ha_slots_path_tmp.cleanup();
+    const ha_slots_path = ha_slots_path_tmp.path().ptr;
     defer cleanupTempDir(ha_slots_path);
 
     var primary = try ha_primary_mod.Primary.open(alloc, ha_log_path, ha_slots_path, .{
@@ -79943,14 +80358,17 @@ test "db transaction HA retry drains durable mirror outbox" {
 test "storage.ha db primary progress sync wait survives primary restart before ack" {
     const alloc = std.testing.allocator;
 
-    var db_path_buf: [256]u8 = undefined;
-    const db_path = tempPath(&db_path_buf);
+    var db_path_tmp = try TestDirectory.init("db");
+    defer db_path_tmp.cleanup();
+    const db_path = db_path_tmp.path().ptr;
     defer cleanupTempDir(db_path);
-    var ha_log_path_buf: [256]u8 = undefined;
-    const ha_log_path = tempPath(&ha_log_path_buf);
+    var ha_log_path_tmp = try TestDirectory.init("db");
+    defer ha_log_path_tmp.cleanup();
+    const ha_log_path = ha_log_path_tmp.path().ptr;
     defer cleanupTempDir(ha_log_path);
-    var ha_slots_path_buf: [256]u8 = undefined;
-    const ha_slots_path = tempPath(&ha_slots_path_buf);
+    var ha_slots_path_tmp = try TestDirectory.init("db");
+    defer ha_slots_path_tmp.cleanup();
+    const ha_slots_path = ha_slots_path_tmp.path().ptr;
     defer cleanupTempDir(ha_slots_path);
 
     const identity = ha_primary_mod.Identity{
@@ -80028,14 +80446,17 @@ test "storage.ha db primary progress sync wait survives primary restart before a
 test "storage.ha db block sync policy surfaces wait provider errors" {
     const alloc = std.testing.allocator;
 
-    var db_path_buf: [256]u8 = undefined;
-    const db_path = tempPath(&db_path_buf);
+    var db_path_tmp = try TestDirectory.init("db");
+    defer db_path_tmp.cleanup();
+    const db_path = db_path_tmp.path().ptr;
     defer cleanupTempDir(db_path);
-    var ha_log_path_buf: [256]u8 = undefined;
-    const ha_log_path = tempPath(&ha_log_path_buf);
+    var ha_log_path_tmp = try TestDirectory.init("db");
+    defer ha_log_path_tmp.cleanup();
+    const ha_log_path = ha_log_path_tmp.path().ptr;
     defer cleanupTempDir(ha_log_path);
-    var ha_slots_path_buf: [256]u8 = undefined;
-    const ha_slots_path = tempPath(&ha_slots_path_buf);
+    var ha_slots_path_tmp = try TestDirectory.init("db");
+    defer ha_slots_path_tmp.cleanup();
+    const ha_slots_path = ha_slots_path_tmp.path().ptr;
     defer cleanupTempDir(ha_slots_path);
 
     var primary = try ha_primary_mod.Primary.open(alloc, ha_log_path, ha_slots_path, .{
@@ -80095,14 +80516,17 @@ test "storage.ha db block sync policy surfaces wait provider errors" {
 test "storage.ha db fail-closed sync policy rejects before local batch commit" {
     const alloc = std.testing.allocator;
 
-    var db_path_buf: [256]u8 = undefined;
-    const db_path = tempPath(&db_path_buf);
+    var db_path_tmp = try TestDirectory.init("db");
+    defer db_path_tmp.cleanup();
+    const db_path = db_path_tmp.path().ptr;
     defer cleanupTempDir(db_path);
-    var ha_log_path_buf: [256]u8 = undefined;
-    const ha_log_path = tempPath(&ha_log_path_buf);
+    var ha_log_path_tmp = try TestDirectory.init("db");
+    defer ha_log_path_tmp.cleanup();
+    const ha_log_path = ha_log_path_tmp.path().ptr;
     defer cleanupTempDir(ha_log_path);
-    var ha_slots_path_buf: [256]u8 = undefined;
-    const ha_slots_path = tempPath(&ha_slots_path_buf);
+    var ha_slots_path_tmp = try TestDirectory.init("db");
+    defer ha_slots_path_tmp.cleanup();
+    const ha_slots_path = ha_slots_path_tmp.path().ptr;
     defer cleanupTempDir(ha_slots_path);
 
     var primary = try ha_primary_mod.Primary.open(alloc, ha_log_path, ha_slots_path, .{
@@ -80149,23 +80573,29 @@ test "storage.ha db fail-closed sync policy rejects before local batch commit" {
 test "storage.ha db mirrors and applies schema metadata mutation records" {
     const alloc = std.testing.allocator;
 
-    var primary_db_path_buf: [256]u8 = undefined;
-    const primary_db_path = tempPath(&primary_db_path_buf);
+    var primary_db_path_tmp = try TestDirectory.init("db");
+    defer primary_db_path_tmp.cleanup();
+    const primary_db_path = primary_db_path_tmp.path().ptr;
     defer cleanupTempDir(primary_db_path);
-    var standby_db_path_buf: [256]u8 = undefined;
-    const standby_db_path = tempPath(&standby_db_path_buf);
+    var standby_db_path_tmp = try TestDirectory.init("db");
+    defer standby_db_path_tmp.cleanup();
+    const standby_db_path = standby_db_path_tmp.path().ptr;
     defer cleanupTempDir(standby_db_path);
-    var ha_log_path_buf: [256]u8 = undefined;
-    const ha_log_path = tempPath(&ha_log_path_buf);
+    var ha_log_path_tmp = try TestDirectory.init("db");
+    defer ha_log_path_tmp.cleanup();
+    const ha_log_path = ha_log_path_tmp.path().ptr;
     defer cleanupTempDir(ha_log_path);
-    var ha_slots_path_buf: [256]u8 = undefined;
-    const ha_slots_path = tempPath(&ha_slots_path_buf);
+    var ha_slots_path_tmp = try TestDirectory.init("db");
+    defer ha_slots_path_tmp.cleanup();
+    const ha_slots_path = ha_slots_path_tmp.path().ptr;
     defer cleanupTempDir(ha_slots_path);
-    var standby_log_path_buf: [256]u8 = undefined;
-    const standby_log_path = tempPath(&standby_log_path_buf);
+    var standby_log_path_tmp = try TestDirectory.init("db");
+    defer standby_log_path_tmp.cleanup();
+    const standby_log_path = standby_log_path_tmp.path().ptr;
     defer cleanupTempDir(standby_log_path);
-    var standby_progress_path_buf: [256]u8 = undefined;
-    const standby_progress_path = tempPath(&standby_progress_path_buf);
+    var standby_progress_path_tmp = try TestDirectory.init("db");
+    defer standby_progress_path_tmp.cleanup();
+    const standby_progress_path = standby_progress_path_tmp.path().ptr;
     defer cleanupTempDir(standby_progress_path);
 
     const identity = ha_standby_mod.Identity{
@@ -80238,20 +80668,25 @@ test "storage.ha db mirrors and applies schema metadata mutation records" {
 test "storage.ha db applies batch mutation records through replication session callback" {
     const alloc = std.testing.allocator;
 
-    var standby_db_path_buf: [256]u8 = undefined;
-    const standby_db_path = tempPath(&standby_db_path_buf);
+    var standby_db_path_tmp = try TestDirectory.init("db");
+    defer standby_db_path_tmp.cleanup();
+    const standby_db_path = standby_db_path_tmp.path().ptr;
     defer cleanupTempDir(standby_db_path);
-    var primary_log_path_buf: [256]u8 = undefined;
-    const primary_log_path = tempPath(&primary_log_path_buf);
+    var primary_log_path_tmp = try TestDirectory.init("db");
+    defer primary_log_path_tmp.cleanup();
+    const primary_log_path = primary_log_path_tmp.path().ptr;
     defer cleanupTempDir(primary_log_path);
-    var primary_slots_path_buf: [256]u8 = undefined;
-    const primary_slots_path = tempPath(&primary_slots_path_buf);
+    var primary_slots_path_tmp = try TestDirectory.init("db");
+    defer primary_slots_path_tmp.cleanup();
+    const primary_slots_path = primary_slots_path_tmp.path().ptr;
     defer cleanupTempDir(primary_slots_path);
-    var standby_log_path_buf: [256]u8 = undefined;
-    const standby_log_path = tempPath(&standby_log_path_buf);
+    var standby_log_path_tmp = try TestDirectory.init("db");
+    defer standby_log_path_tmp.cleanup();
+    const standby_log_path = standby_log_path_tmp.path().ptr;
     defer cleanupTempDir(standby_log_path);
-    var standby_progress_path_buf: [256]u8 = undefined;
-    const standby_progress_path = tempPath(&standby_progress_path_buf);
+    var standby_progress_path_tmp = try TestDirectory.init("db");
+    defer standby_progress_path_tmp.cleanup();
+    const standby_progress_path = standby_progress_path_tmp.path().ptr;
     defer cleanupTempDir(standby_progress_path);
 
     const identity = ha_standby_mod.Identity{
@@ -80345,14 +80780,17 @@ test "storage.ha db applies batch mutation records through replication session c
 test "storage.ha db persists applied replication marker across reopen" {
     const alloc = std.testing.allocator;
 
-    var db_path_buf: [256]u8 = undefined;
-    const db_path = tempPath(&db_path_buf);
+    var db_path_tmp = try TestDirectory.init("db");
+    defer db_path_tmp.cleanup();
+    const db_path = db_path_tmp.path().ptr;
     defer cleanupTempDir(db_path);
-    var primary_log_path_buf: [256]u8 = undefined;
-    const primary_log_path = tempPath(&primary_log_path_buf);
+    var primary_log_path_tmp = try TestDirectory.init("db");
+    defer primary_log_path_tmp.cleanup();
+    const primary_log_path = primary_log_path_tmp.path().ptr;
     defer cleanupTempDir(primary_log_path);
-    var primary_slots_path_buf: [256]u8 = undefined;
-    const primary_slots_path = tempPath(&primary_slots_path_buf);
+    var primary_slots_path_tmp = try TestDirectory.init("db");
+    defer primary_slots_path_tmp.cleanup();
+    const primary_slots_path = primary_slots_path_tmp.path().ptr;
     defer cleanupTempDir(primary_slots_path);
 
     const identity = ha_standby_mod.Identity{
@@ -80397,8 +80835,9 @@ test "storage.ha db persists applied replication marker across reopen" {
 test "storage.ha db applies timeline switch as durable replication boundary" {
     const alloc = std.testing.allocator;
 
-    var db_path_buf: [256]u8 = undefined;
-    const db_path = tempPath(&db_path_buf);
+    var db_path_tmp = try TestDirectory.init("db");
+    defer db_path_tmp.cleanup();
+    const db_path = db_path_tmp.path().ptr;
     defer cleanupTempDir(db_path);
 
     const switch_record = ha_replication_record_mod.RecordView{
@@ -80433,14 +80872,17 @@ test "storage.ha db applies timeline switch as durable replication boundary" {
 test "storage.ha db write gate rejects client writes on standby but allows replicated apply" {
     const alloc = std.testing.allocator;
 
-    var db_path_buf: [256]u8 = undefined;
-    const db_path = tempPath(&db_path_buf);
+    var db_path_tmp = try TestDirectory.init("db");
+    defer db_path_tmp.cleanup();
+    const db_path = db_path_tmp.path().ptr;
     defer cleanupTempDir(db_path);
-    var standby_log_path_buf: [256]u8 = undefined;
-    const standby_log_path = tempPath(&standby_log_path_buf);
+    var standby_log_path_tmp = try TestDirectory.init("db");
+    defer standby_log_path_tmp.cleanup();
+    const standby_log_path = standby_log_path_tmp.path().ptr;
     defer cleanupTempDir(standby_log_path);
-    var standby_progress_path_buf: [256]u8 = undefined;
-    const standby_progress_path = tempPath(&standby_progress_path_buf);
+    var standby_progress_path_tmp = try TestDirectory.init("db");
+    defer standby_progress_path_tmp.cleanup();
+    const standby_progress_path = standby_progress_path_tmp.path().ptr;
     defer cleanupTempDir(standby_progress_path);
 
     var standby = try ha_standby_mod.Standby.open(alloc, standby_log_path, standby_progress_path, .{
@@ -80492,17 +80934,21 @@ test "storage.ha db write gate rejects client writes on standby but allows repli
 test "storage.ha db write gate rejects fenced former primary writes" {
     const alloc = std.testing.allocator;
 
-    var db_path_buf: [256]u8 = undefined;
-    const db_path = tempPath(&db_path_buf);
+    var db_path_tmp = try TestDirectory.init("db");
+    defer db_path_tmp.cleanup();
+    const db_path = db_path_tmp.path().ptr;
     defer cleanupTempDir(db_path);
-    var primary_log_path_buf: [256]u8 = undefined;
-    const primary_log_path = tempPath(&primary_log_path_buf);
+    var primary_log_path_tmp = try TestDirectory.init("db");
+    defer primary_log_path_tmp.cleanup();
+    const primary_log_path = primary_log_path_tmp.path().ptr;
     defer cleanupTempDir(primary_log_path);
-    var primary_slots_path_buf: [256]u8 = undefined;
-    const primary_slots_path = tempPath(&primary_slots_path_buf);
+    var primary_slots_path_tmp = try TestDirectory.init("db");
+    defer primary_slots_path_tmp.cleanup();
+    const primary_slots_path = primary_slots_path_tmp.path().ptr;
     defer cleanupTempDir(primary_slots_path);
-    var fence_path_buf: [256]u8 = undefined;
-    const fence_path = tempPath(&fence_path_buf);
+    var fence_path_tmp = try TestDirectory.init("db");
+    defer fence_path_tmp.cleanup();
+    const fence_path = fence_path_tmp.path().ptr;
     defer cleanupTempDir(fence_path);
 
     const identity = ha_primary_mod.Identity{
@@ -80558,14 +81004,17 @@ test "storage.ha db write gate rejects fenced former primary writes" {
 test "storage.ha db standby role suppresses mutating background runtimes" {
     const alloc = std.testing.allocator;
 
-    var db_path_buf: [256]u8 = undefined;
-    const db_path = tempPath(&db_path_buf);
+    var db_path_tmp = try TestDirectory.init("db");
+    defer db_path_tmp.cleanup();
+    const db_path = db_path_tmp.path().ptr;
     defer cleanupTempDir(db_path);
-    var standby_log_path_buf: [256]u8 = undefined;
-    const standby_log_path = tempPath(&standby_log_path_buf);
+    var standby_log_path_tmp = try TestDirectory.init("db");
+    defer standby_log_path_tmp.cleanup();
+    const standby_log_path = standby_log_path_tmp.path().ptr;
     defer cleanupTempDir(standby_log_path);
-    var standby_progress_path_buf: [256]u8 = undefined;
-    const standby_progress_path = tempPath(&standby_progress_path_buf);
+    var standby_progress_path_tmp = try TestDirectory.init("db");
+    defer standby_progress_path_tmp.cleanup();
+    const standby_progress_path = standby_progress_path_tmp.path().ptr;
     defer cleanupTempDir(standby_progress_path);
 
     var standby = try ha_standby_mod.Standby.open(alloc, standby_log_path, standby_progress_path, .{
@@ -80603,8 +81052,9 @@ test "storage.ha db standby role suppresses mutating background runtimes" {
 test "db reopen replays pending derived embeddings with durable lsm primary backend" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var appended_sequence: u64 = 0;
@@ -80672,8 +81122,9 @@ test "db reopen replays pending derived embeddings with durable lsm primary back
 test "db reopen preserves applied watermark above retained replay floor" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     {
@@ -80709,8 +81160,9 @@ test "db reopen preserves applied watermark above retained replay floor" {
 test "db query_readonly open skips pending derived replay on reopen" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var appended_sequence: u64 = 0;
@@ -80833,8 +81285,9 @@ test "db query_readonly open skips pending derived replay on reopen" {
 test "db query_readonly lsm primary opens physical backend read-only" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     {
@@ -80875,8 +81328,9 @@ test "db query_readonly lsm primary opens physical backend read-only" {
 test "db read-only open modes can share lsm root with live writer" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var writer = try DB.open(alloc, std.mem.span(path), .{
@@ -80918,8 +81372,9 @@ test "db read-only open modes can share lsm root with live writer" {
 test "db read-only open modes reject catalog mutations before side effects" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     {
@@ -80988,8 +81443,9 @@ test "db read-only open modes reject catalog mutations before side effects" {
 test "db query_readonly lmdb primary does not create missing database" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var readonly = DB.open(alloc, std.mem.span(path), .{
@@ -81008,8 +81464,9 @@ test "db query_readonly lmdb primary does not create missing database" {
 test "db query_readonly lmdb primary rejects writes after readonly open" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     {
@@ -81048,8 +81505,9 @@ test "db query_readonly lmdb primary rejects writes after readonly open" {
 test "db writer_no_replay open defers pending derived replay until runUntilIdle" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var appended_sequence: u64 = 0;
@@ -81149,8 +81607,9 @@ test "db writer_no_replay open defers pending derived replay until runUntilIdle"
 test "db catch-up advances vacuous derived replay target gap" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     const target_sequence: u64 = 7;
@@ -81204,8 +81663,9 @@ test "db catch-up advances vacuous derived replay target gap" {
 test "db stats report projection checkpoint replay tail per index hint" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     const dense_target_sequence: u64 = 7;
@@ -81291,8 +81751,9 @@ test "db stats report projection checkpoint replay tail per index hint" {
 test "db catch-up hands dense coverage debt to resumable maintenance" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     const target_sequence: u64 = 7;
@@ -81386,8 +81847,9 @@ test "db catch-up hands dense coverage debt to resumable maintenance" {
 
 test "idle generated coverage gap becomes durable paged recovery debt" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -81448,8 +81910,9 @@ test "idle generated coverage gap becomes durable paged recovery debt" {
 test "db catch-up defers artifact dense target advance without durable counter" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     const target_sequence: u64 = 7;
@@ -81505,8 +81968,9 @@ test "db catch-up defers artifact dense target advance without durable counter" 
 
 test "db asynchronous dense replay lag is not classified as repair debt" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -81549,8 +82013,9 @@ test "db asynchronous dense replay lag is not classified as repair debt" {
 
 test "db source artifact debt does not synthesize index generation repair debt" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -81599,8 +82064,9 @@ test "db source artifact debt does not synthesize index generation repair debt" 
 test "dense replay progress target matches replay debt target" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var appended_sequence: u64 = 0;
@@ -81686,8 +82152,9 @@ test "dense replay progress target matches replay debt target" {
 test "db writer_no_replay starts workers without resuming pending derived replay" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var appended_sequence: u64 = 0;
@@ -81774,8 +82241,9 @@ test "db writer_no_replay starts workers without resuming pending derived replay
 test "db writer open resumes generated enrichment replay from journal" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     {
@@ -81850,8 +82318,9 @@ test "db writer open resumes generated enrichment replay from journal" {
 test "enrichment worker bounds retries against a durable foreign lease" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     const lease_ttl_ms: u64 = 5_000;
@@ -81963,8 +82432,9 @@ test "collectDocumentWrites skips missing out-of-range replay docs" {
 test "text replay delete keys include upserted derived document keys" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -82017,8 +82487,9 @@ test "text replay delete keys include upserted derived document keys" {
 test "db replay respects per-index applied watermarks" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var appended_sequence: u64 = 0;
@@ -82090,8 +82561,9 @@ test "db replay respects per-index applied watermarks" {
 test "db replay applies dense embeddings from artifact payloads" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     {
@@ -82146,8 +82618,9 @@ test "db replay applies dense embeddings from artifact payloads" {
 test "db replay blocks dense embedding writes when artifact payload is missing" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var appended_sequence: u64 = 0;
@@ -82223,8 +82696,9 @@ test "db replay blocks dense embedding writes when artifact payload is missing" 
 test "db replay skips a missing dense artifact after its source document was deleted" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var appended_sequence: u64 = 0;
@@ -82265,8 +82739,9 @@ test "db replay skips a missing dense artifact after its source document was del
 test "db replay blocks and preserves corrupt dense embedding artifacts" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var appended_sequence: u64 = 0;
@@ -82394,8 +82869,9 @@ test "db replay blocks and preserves corrupt dense embedding artifacts" {
 test "db repeated replay preserves nonblocking dense artifact repair intent" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     {
@@ -82455,8 +82931,9 @@ test "db repeated replay preserves nonblocking dense artifact repair intent" {
 test "db replay records wrong-dimension dense embedding artifact as repair debt" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var appended_sequence: u64 = 0;
@@ -82519,8 +82996,9 @@ test "db replay records wrong-dimension dense embedding artifact as repair debt"
 test "db repair queue reprocesses corrupt generated dense embedding artifacts" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var deterministic = embedder_mod.DeterministicDenseEmbedder{};
@@ -82600,8 +83078,9 @@ test "db repair queue reprocesses corrupt generated dense embedding artifacts" {
 test "db repair queue reprocesses corrupt chunk generated dense embedding artifacts from parent document" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var deterministic = embedder_mod.DeterministicDenseEmbedder{};
@@ -82686,8 +83165,9 @@ test "db repair queue reprocesses corrupt chunk generated dense embedding artifa
 test "db replay applies sparse embeddings from artifact payloads" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     {
@@ -82734,8 +83214,9 @@ test "db replay applies sparse embeddings from artifact payloads" {
 test "db replay skips a missing sparse artifact after its source document was deleted" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var appended_sequence: u64 = 0;
@@ -82778,8 +83259,9 @@ test "db replay skips a missing sparse artifact after its source document was de
 test "db replay blocks and preserves corrupt sparse embedding artifacts" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var appended_sequence: u64 = 0;
@@ -83144,8 +83626,9 @@ test "db thin replay omits derived work for an unchanged source write" {
 test "db full-text index backfill and search routing" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -83203,8 +83686,9 @@ test "db full-text index backfill and search routing" {
 test "db full-text backfill resumes after interrupted reopen" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     {
@@ -83284,8 +83768,9 @@ test "db full-text backfill resumes after interrupted reopen" {
 test "db full-text backfill retires segment fanout at durable batch boundaries" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     {
@@ -83338,8 +83823,9 @@ test "db full-text backfill retires segment fanout at durable batch boundaries" 
 test "db sparse backfill restarts safely from a legacy cursor after interrupted reopen" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     {
@@ -83516,8 +84002,9 @@ const ConcurrentWriteProbe = struct {
 test "db dense vector index routes knn search" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -83555,8 +84042,9 @@ test "db dense vector index routes knn search" {
 test "db dense vector index routes knn search with durable lsm primary backend" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -83596,8 +84084,9 @@ test "db dense vector index routes knn search with durable lsm primary backend" 
 test "db full text conjunction query" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -83637,8 +84126,9 @@ test "db full text conjunction query" {
 test "db full text conjunction query with incremental full_index batches" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -83683,8 +84173,9 @@ test "db full text conjunction query with incremental full_index batches" {
 test "db full text count_only applies stored filters" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -83720,8 +84211,9 @@ test "db full text count_only applies stored filters" {
 test "db full text match_all applies stored filters" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -83759,8 +84251,9 @@ test "db full text match_all applies stored filters" {
 test "db full_index delete waits for full text visibility" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -83807,8 +84300,9 @@ test "db full_index delete waits for full text visibility" {
 test "db stats uses full text visible count when available" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -83852,8 +84346,9 @@ test "db stats uses full text visible count when available" {
 test "db schemaless full text indexes strings into _all for bare text search" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -83895,8 +84390,9 @@ test "db schemaless full text indexes strings into _all for bare text search" {
 test "db stats does not scan primary docs when full text count is available" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -83934,8 +84430,9 @@ test "db stats does not scan primary docs when full text count is available" {
 test "db sparse vector index routes knn search" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -83976,8 +84473,9 @@ test "db sparse vector index routes knn search" {
 test "db sparse vector index routes knn search with durable lsm primary backend" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -84016,8 +84514,9 @@ test "db sparse vector index routes knn search with durable lsm primary backend"
 test "db graph index routes neighbor queries and doc deletes clean edges" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -84083,8 +84582,9 @@ test "db graph index routes neighbor queries and doc deletes clean edges" {
 test "db direct graph writes persist graph artifacts and deletes remove them" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -84136,8 +84636,9 @@ test "db direct graph writes persist graph artifacts and deletes remove them" {
 test "db delete artifact cleanup isolates binary document id prefixes" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     const first_doc = "doc\x00a";
@@ -84180,8 +84681,9 @@ test "db delete artifact cleanup isolates binary document id prefixes" {
 test "db graph index routes neighbor queries and doc deletes clean edges with durable lsm primary backend" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -84249,8 +84751,9 @@ test "db graph index routes neighbor queries and doc deletes clean edges with du
 test "db document _edges reconcile graph state and preserve base document" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -84327,8 +84830,9 @@ test "db document _edges reconcile graph state and preserve base document" {
 test "db document _edges reconcile graph state and preserve base document with durable lsm primary backend" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -84407,8 +84911,9 @@ test "db document _edges reconcile graph state and preserve base document with d
 test "db document _embeddings update vector index and strip stored special fields" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -84473,8 +84978,9 @@ test "db document _embeddings update vector index and strip stored special field
 test "db dense and sparse field-backed vector indexes strip vector fields and persist embedding artifacts" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -84631,8 +85137,9 @@ test "db dense and sparse field-backed vector indexes strip vector fields and pe
 
 test "db external dense coverage tracks exact writes deletes and reopen" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     const ExpectCoverage = struct {
@@ -84686,8 +85193,9 @@ test "db external dense coverage tracks exact writes deletes and reopen" {
 
 test "db coverage status reports partial counter tuples without scanning markers" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -84790,8 +85298,9 @@ test "runtime status never regresses below durable projection checkpoint" {
 
 test "runtime status overlay hydrates cached derived coverage identity" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     const config_json = "{\"field\":\"embedding\",\"dims\":3,\"external\":true}";
@@ -84824,8 +85333,9 @@ test "runtime status overlay hydrates cached derived coverage identity" {
 test "db document _embeddings update vector index and strip stored special fields with durable lsm primary backend" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -84892,8 +85402,9 @@ test "db document _embeddings update vector index and strip stored special field
 test "db full_index persists explicit dense embeddings across reopen" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var iter: usize = 0;
@@ -84951,8 +85462,9 @@ test "db full_index persists explicit dense embeddings across reopen" {
 test "db rebuildDenseIndexesFromStoredEmbeddingArtifactsIfNeeded repairs external dense doc gaps on reopen" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     {
@@ -85058,8 +85570,9 @@ test "db rebuildDenseIndexesFromStoredEmbeddingArtifactsIfNeeded repairs externa
 
 test "db dense artifact surplus uses quarantined generation replacement" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -85195,8 +85708,9 @@ test "db dense artifact surplus uses quarantined generation replacement" {
 
 test "db dense shadow activation rejects surplus candidate coverage" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -85312,8 +85826,9 @@ test "db repair activation admission is time and sequence bounded" {
 
 test "db automatic dense repair bootstraps missing coverage metadata" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     {
@@ -85382,8 +85897,9 @@ test "db automatic dense repair bootstraps missing coverage metadata" {
 
 test "db quarantined dense bootstrap tracks concurrent insert update and delete" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
     const cfg: types.IndexConfig = .{
         .name = "dense_idx",
@@ -85492,8 +86008,9 @@ test "db quarantined dense bootstrap tracks concurrent insert update and delete"
 
 test "db corrupt repair checkpoint preserves primary availability and fails indexes closed" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
     var repair_checkpoint_path: []u8 = undefined;
 
@@ -85550,8 +86067,9 @@ test "db corrupt repair checkpoint preserves primary availability and fails inde
 test "db index repair rebuilds dense index quarantined by incomplete bulk publish" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     {
@@ -85743,8 +86261,9 @@ test "db index repair rebuilds dense index quarantined by incomplete bulk publis
 
 test "quarantine binding reconciliation serializes with terminal transition" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     {
@@ -85855,8 +86374,9 @@ test "quarantine binding reconciliation serializes with terminal transition" {
 
 test "db restart reconciles activated dense repair without rebuilding" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     {
@@ -86039,8 +86559,9 @@ test "db restart reconciles activated dense repair without rebuilding" {
 
 test "db root generation rollover preserves activated repair debt fail closed" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var old_repair_id: u128 = 0;
@@ -86150,8 +86671,9 @@ test "db root generation rollover preserves activated repair debt fail closed" {
 
 test "db durable root incarnation follows the physical root rather than visibility generations" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var first_incarnation: u128 = 0;
@@ -86239,8 +86761,9 @@ test "db durable root incarnation follows the physical root rather than visibili
 
 test "db restart reconciles an activated graph repair without rebuilding" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var repair_id: u128 = 0;
@@ -86304,8 +86827,9 @@ test "db restart reconciles an activated graph repair without rebuilding" {
 
 test "db paused dense repair resumes its durable candidate after restart" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     {
@@ -86420,8 +86944,9 @@ test "db paused dense repair resumes its durable candidate after restart" {
 
 test "db dense repair durably yields and resumes a reopenable building candidate" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
     test_dense_repair_rebuild_batch_size = 1;
     defer test_dense_repair_rebuild_batch_size = null;
@@ -86600,8 +87125,9 @@ test "db dense repair durably yields and resumes a reopenable building candidate
 
 test "db managed vector admission captures writes while durable repair is pending" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     const cfg = types.IndexConfig{
@@ -86648,8 +87174,9 @@ test "db managed vector admission captures writes while durable repair is pendin
 
 test "db managed full text admission replays transitive artifact producers" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var deterministic = embedder_mod.DeterministicDenseEmbedder{};
@@ -86743,8 +87270,9 @@ test "db managed full text admission replays transitive artifact producers" {
 
 test "db managed vector admission discovers artifacts committed before resident activation" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     const cfg = types.IndexConfig{
@@ -86812,8 +87340,9 @@ test "db managed vector admission discovers artifacts committed before resident 
 
 test "db managed vector admission durably seeds missing enrichment artifacts" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     const document_count: usize = 129;
@@ -86948,8 +87477,9 @@ fn drainManagedAdmissionSourceReplayForTest(db: *DB, alloc: Allocator, repair_id
 
 test "db managed repair scheduler defers canonical worker until shadow activation" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var deterministic = embedder_mod.DeterministicDenseEmbedder{};
@@ -87048,8 +87578,9 @@ test "index repair inspection window is bounded and rotates fairly" {
 
 test "resident index repair scheduler skips deferred prefixes with bounded fair quanta" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -87272,8 +87803,9 @@ test "resident index repair progress waits are revision scoped and event driven"
 
 test "index repair intent string replacement is allocation failure safe" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -87352,8 +87884,9 @@ test "index repair intent string replacement is allocation failure safe" {
 
 test "repair admission revisions stay fail closed and reject delayed publishers" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -87461,8 +87994,9 @@ test "repair admission revisions stay fail closed and reject delayed publishers"
 
 test "db progressive managed admission serves a checkpointed partial generation" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     // Keep exactly one published vector available while the rest of the
@@ -87993,8 +88527,9 @@ test "db progressive managed admission serves a checkpointed partial generation"
 
 test "db progressive managed sparse admission serves a checkpointed partial generation" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var deterministic = embedder_mod.DeterministicSparseEmbedder{};
@@ -88096,8 +88631,9 @@ test "db coverage recovery admits a published generation after its admission mar
 
 fn testManagedGenerationRepairAdmission(mode: enum { quarantine, shadow_handoff, replay_handoff, late_completion, coverage_recovery }) !void {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var deterministic = embedder_mod.DeterministicDenseEmbedder{};
@@ -88215,8 +88751,9 @@ fn testManagedGenerationRepairAdmission(mode: enum { quarantine, shadow_handoff,
 
 test "db empty managed index does not invent generated coverage recovery debt" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
     var deterministic = embedder_mod.DeterministicDenseEmbedder{};
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -88252,8 +88789,9 @@ test "db empty managed index does not invent generated coverage recovery debt" {
 
 test "db completed partial managed admission serves and retires redundant repair" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var deterministic = embedder_mod.DeterministicDenseEmbedder{};
@@ -88319,8 +88857,9 @@ test "db completed partial managed admission serves and retires redundant repair
 
 test "db completed chunked managed admission uses physical artifact count" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var counting = CountingDenseEmbedder{};
@@ -88411,8 +88950,9 @@ test "db completed chunked managed admission uses physical artifact count" {
 
 test "db managed algebraic admission builds and reopens requires generation marker" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     const cfg = types.IndexConfig{
@@ -88459,8 +88999,9 @@ const repair_completion_test_options = types.ArtifactRepairRunOptions{
 
 test "db managed algebraic admission builds and reopens an isolated generation" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     const cfg = types.IndexConfig{
@@ -88545,8 +89086,9 @@ test "db managed algebraic admission builds and reopens an isolated generation" 
 
 test "db algebraic generation build yields and resumes from its durable source cursor" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     const cfg = types.IndexConfig{
@@ -88646,8 +89188,9 @@ test "db algebraic generation build yields and resumes from its durable source c
 
 test "db forced algebraic repair persists an operator generation intent before execution" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
     const cfg = types.IndexConfig{
         .name = "analytics_idx",
@@ -88711,8 +89254,9 @@ test "db forced algebraic repair persists an operator generation intent before e
 
 test "db algebraic post-commit activation crash recovers through generation repair" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     const cfg = types.IndexConfig{
@@ -88786,8 +89330,9 @@ test "db algebraic post-commit activation crash recovers through generation repa
 
 test "db managed full text admission survives restart without in-place backfill" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     const cfg = types.IndexConfig{
@@ -88894,8 +89439,9 @@ test "db managed full text admission survives restart without in-place backfill"
 
 test "db named repair advances managed full text admission without force" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -88938,8 +89484,9 @@ test "db named repair advances managed full text admission without force" {
 
 test "db managed full text admission avoids debt for an empty source" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -88961,8 +89508,9 @@ test "db managed full text admission avoids debt for an empty source" {
 
 test "db ordinary index admission remains fail closed after post-commit activation failure" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -89001,8 +89549,9 @@ test "db ordinary index admission remains fail closed after post-commit activati
 
 test "db managed admission ignores stale zero identity cache" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -89029,8 +89578,9 @@ test "db managed admission ignores stale zero identity cache" {
 
 test "db managed index deletion commits catalog absence with marker removal" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
     const index_name = "full_text_index_v1";
 
@@ -89074,8 +89624,9 @@ test "db managed index deletion commits catalog absence with marker removal" {
 
 test "db managed index deletion remains successful after post-commit cleanup failure" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
     const index_name = "full_text_index_v1";
 
@@ -89133,8 +89684,9 @@ test "db managed index deletion remains successful after post-commit cleanup fai
 
 test "db generated artifact cleanup retries beyond the transient burst" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
     const cfg: types.IndexConfig = .{
         .name = "full_text_index_v1",
@@ -89175,8 +89727,9 @@ test "db generated artifact cleanup retries beyond the transient burst" {
 
 test "db generated artifact finalization releases page arbitration and preserves admission fence" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
     const first: types.IndexConfig = .{
         .name = "a_full_text",
@@ -89243,8 +89796,9 @@ test "db generated artifact finalization releases page arbitration and preserves
 
 test "db managed admission drain preserves a generation requested during the pass" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -89278,8 +89832,9 @@ test "db managed admission drain preserves a generation requested during the pas
 
 test "db managed admission materialization serializes with index deletion" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
     const index_name = "full_text_index_v1";
 
@@ -89392,8 +89947,9 @@ test "db managed admission materialization serializes with index deletion" {
 
 test "db managed admission materialization never infers debt from replay lag" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -89414,8 +89970,9 @@ test "db managed admission materialization never infers debt from replay lag" {
 
 test "db managed visibility hook rehydrates exact durable initial build debt once" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
     const index_name = "full_text_index_v1";
 
@@ -89502,8 +90059,9 @@ test "db managed visibility hook rehydrates exact durable initial build debt onc
 
 test "db completed managed admission emits an initial build clear edge" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -89557,8 +90115,9 @@ test "db completed managed admission emits an initial build clear edge" {
 
 test "db managed admission rejects regressed identity evidence" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -89596,8 +90155,9 @@ test "db managed admission rejects regressed identity evidence" {
 
 test "db managed admission reconciliation retains same-name catalog mismatches" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -89633,8 +90193,9 @@ test "db managed admission reconciliation retains same-name catalog mismatches" 
 
 test "db dense repair defers before candidate creation when node admission is exhausted" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     {
@@ -89718,8 +90279,9 @@ test "db dense repair defers before candidate creation when node admission is ex
 
 test "db dense repair uses resource manager capacity admission before building" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -89775,8 +90337,9 @@ test "db dense repair uses resource manager capacity admission before building" 
 
 test "db dense replay failure upgrades a preflight validation intent" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -89819,8 +90382,9 @@ test "db dense replay failure upgrades a preflight validation intent" {
 
 test "db dense replay missing artifact remains a normal managed admission dependency" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -89850,8 +90414,9 @@ test "db dense replay missing artifact remains a normal managed admission depend
 
 test "db durable repair classification emits exact admission and action edges" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -89951,8 +90516,9 @@ test "db durable repair classification emits exact admission and action edges" {
 
 test "db forced generation repair completion is crash idempotent before api acknowledgement" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -89996,8 +90562,9 @@ test "db forced generation repair completion is crash idempotent before api ackn
 
 test "db incomplete HBC snapshot persists generation repair before maintenance" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var repair_id: u128 = 0;
@@ -90048,8 +90615,9 @@ test "db incomplete HBC snapshot persists generation repair before maintenance" 
 
 test "db forced repair attaches to automatic generation intent idempotently" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -90125,8 +90693,9 @@ test "db forced repair attaches to automatic generation intent idempotently" {
 
 test "db forced repair preserves missing-counter fail-closed classification" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -90175,11 +90744,13 @@ test "db forced repair preserves missing-counter fail-closed classification" {
 
 test "db repair capacity converts materialized shadow bytes into consumed reservation" {
     const alloc = std.testing.allocator;
-    var db_path_buf: [256]u8 = undefined;
-    const db_path = tempPath(&db_path_buf);
+    var db_path_tmp = try TestDirectory.init("db");
+    defer db_path_tmp.cleanup();
+    const db_path = db_path_tmp.path().ptr;
     defer cleanupTempDir(db_path);
-    var candidate_path_buf: [256]u8 = undefined;
-    const candidate_path = tempPath(&candidate_path_buf);
+    var candidate_path_tmp = try TestDirectory.init("db");
+    defer candidate_path_tmp.cleanup();
+    const candidate_path = candidate_path_tmp.path().ptr;
     defer cleanupTempDir(candidate_path);
     try ensureDirPath(std.mem.span(candidate_path));
 
@@ -90235,8 +90806,9 @@ test "db repair capacity converts materialized shadow bytes into consumed reserv
 
 test "db repair replay pin applies hard-pressure write backpressure" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var budgets = resource_manager_mod.Options.defaultBudgets();
@@ -90268,8 +90840,9 @@ test "db repair replay pin applies hard-pressure write backpressure" {
 
 test "db removing one repair pin preserves pressure gate for another index" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -90356,8 +90929,9 @@ test "db removing one repair pin preserves pressure gate for another index" {
 
 test "db healthy dense generation remains searchable until replacement activation" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -90458,8 +91032,9 @@ test "db healthy dense generation remains searchable until replacement activatio
 
 test "db forced dense repair stays fail closed until background health proof" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -90519,8 +91094,9 @@ test "db forced dense repair stays fail closed until background health proof" {
 
 test "db forced dense repair keeps structurally invalid generation fail closed" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -90583,8 +91159,9 @@ test "db forced dense repair keeps structurally invalid generation fail closed" 
 
 test "db restart automatically resumes pinned explicit dense generation rebuild" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     {
@@ -90676,8 +91253,9 @@ test "db restart automatically resumes pinned explicit dense generation rebuild"
 
 test "db restart clears stale dense generation intent after clean checkpoint" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var repair_id: u128 = 0;
@@ -90867,8 +91445,9 @@ fn interruptDenseRepairAfterActivation(
 
 test "db missing activation certification rolls back to serviceable dense predecessor" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -90919,8 +91498,9 @@ test "db missing activation certification rolls back to serviceable dense predec
 
 test "db missing activation certification exposes predecessor action required" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -91020,8 +91600,9 @@ test "db missing activation certification exposes predecessor action required" {
 
 test "db failed activated dense generation rolls back to retained predecessor" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var repair_id: u128 = 0;
@@ -91215,8 +91796,9 @@ test "db failed activated dense generation rolls back to retained predecessor" {
 test "db dense artifact rebuild preserves stable vector ids distinct from ordinals" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     {
@@ -91284,8 +91866,9 @@ test "db dense artifact rebuild preserves stable vector ids distinct from ordina
 test "db dense artifact rebuild trusts clean projection checkpoint without artifact recount" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     {
@@ -91365,8 +91948,9 @@ test "db dense artifact rebuild trusts clean projection checkpoint without artif
 test "db dense projection checkpoint prefers hbc metadata over corrupt sidecar" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     const dense_cfg: types.IndexConfig = .{
@@ -91430,8 +92014,9 @@ test "db dense projection checkpoint prefers hbc metadata over corrupt sidecar" 
 test "db dense artifact coverage finalizes a completed rebuilding checkpoint" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -91472,8 +92057,9 @@ test "db dense artifact coverage finalizes a completed rebuilding checkpoint" {
 test "db last dense catch-up lease finalizes every covered rebuilding generation" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -91534,8 +92120,9 @@ test "db last dense catch-up lease finalizes every covered rebuilding generation
 test "db artifact dense target prefers current incarnation outcomes over stale name counter" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var counting = CountingDenseEmbedder{};
@@ -91583,8 +92170,9 @@ test "db artifact dense target prefers current incarnation outcomes over stale n
 test "db dense finalization owner drains requests queued during publication" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -91636,8 +92224,9 @@ test "db dense finalization owner drains requests queued during publication" {
 test "db last external dense bulk lease finalizes covered rebuilding generations" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -91684,8 +92273,9 @@ test "db last external dense bulk lease finalizes covered rebuilding generations
 test "db empty inline dense generation finalizes without scanning primary documents" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -91715,8 +92305,9 @@ test "db empty inline dense generation finalizes without scanning primary docume
 test "db inline dense generation remains rebuilding until outcomes cover the live corpus" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -91807,8 +92398,9 @@ test "db inline dense generation remains rebuilding until outcomes cover the liv
 test "db inline dense coverage counters rebase with range ownership" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -91848,8 +92440,9 @@ test "db inline dense coverage counters rebase with range ownership" {
 test "db runtime status overlay refreshes identity totals with coverage counters" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -91901,8 +92494,9 @@ test "db runtime status overlay refreshes identity totals with coverage counters
 test "db external dense ingest finalizes an exactly covered rebuilding checkpoint" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -91936,8 +92530,9 @@ test "db external dense ingest finalizes an exactly covered rebuilding checkpoin
 test "db corrupt projection sidecar degrades non-dense checkpoint and quarantines writes" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     const text_cfg: types.IndexConfig = .{
@@ -92016,8 +92611,9 @@ test "db corrupt projection sidecar degrades non-dense checkpoint and quarantine
 test "db dense artifact rebuild rejects clean checkpoint for stale config identity" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     {
@@ -92081,8 +92677,9 @@ test "db dense artifact rebuild rejects clean checkpoint for stale config identi
 test "db dense artifact rebuild checks artifact counters before clean checkpoint skip" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     const dense_cfg: types.IndexConfig = .{
@@ -92142,8 +92739,9 @@ test "db dense artifact rebuild checks artifact counters before clean checkpoint
 
 test "db dense artifact planner does not let stale status override authoritative counter" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -92190,8 +92788,9 @@ test "db dense artifact planner does not let stale status override authoritative
 test "db dense artifact rebuild bootstraps missing counter metadata" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     const dense_cfg: types.IndexConfig = .{
@@ -92288,8 +92887,9 @@ test "db dense artifact rebuild bootstraps missing counter metadata" {
 test "db dense artifact counter bootstrap combines snapshot with concurrent write delta" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -92357,8 +92957,9 @@ test "db dense artifact counter bootstrap combines snapshot with concurrent writ
 
 test "db dense artifact counter bootstrap restarts from a fresh snapshot" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
     const cfg: types.IndexConfig = .{
         .name = "dense_idx",
@@ -92425,8 +93026,9 @@ test "db dense artifact counter bootstrap restarts from a fresh snapshot" {
 
 test "db dense artifact counter bootstrap fences stale concurrent attempt" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -92470,8 +93072,9 @@ test "db dense artifact counter bootstrap fences stale concurrent attempt" {
 
 test "db malformed quarantined dense config does not block healthy artifact counters" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -92558,8 +93161,9 @@ test "db dense counter bootstrap admission respects soft background budget" {
 test "db dense artifact rebuild uses durable artifact counters instead of recount" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     {
@@ -92609,8 +93213,9 @@ test "db dense artifact rebuild uses durable artifact counters instead of recoun
 test "db dense artifact counters include derived chunk embedding artifacts" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -92665,8 +93270,9 @@ test "db dense artifact counters include derived chunk embedding artifacts" {
 test "db dense artifact rebuild force-resets corrupt external dense structure" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     {
@@ -92750,8 +93356,9 @@ test "db dense artifact rebuild resumes from persisted state" {
     const alloc = std.testing.allocator;
     const doc_count: usize = 8;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     {
@@ -92984,8 +93591,9 @@ test "db dense artifact rebuild resume keys are owned by plan allocator" {
     const db_alloc = std.heap.page_allocator;
     const doc_count: usize = 3;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     {
@@ -93045,8 +93653,9 @@ test "db dense artifact rebuild progress counts source artifacts across multiple
     const doc_count: usize = 3;
     const shared_cfg = "{\"field\":\"embedding\",\"dims\":3,\"metric\":\"l2_squared\",\"external\":true,\"embedding_name\":\"shared_dense_v1\"}";
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     {
@@ -93140,8 +93749,9 @@ test "db dense artifact rebuild keeps resume keys owned by caller allocator" {
     const alloc = std.testing.allocator;
     const rebuild_alloc = std.heap.page_allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     {
@@ -93189,8 +93799,9 @@ test "db dense artifact rebuild keeps resume keys owned by caller allocator" {
 test "db chunk-backed dense artifact rebuild stays pending until all chunk artifacts are rebuilt" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var deterministic = embedder_mod.DeterministicDenseEmbedder{};
@@ -93312,8 +93923,9 @@ test "db dense artifact rebuild does not let resumed targets skip fresh targets"
     const doc_count: usize = 4;
     const shared_cfg = "{\"field\":\"embedding\",\"dims\":3,\"metric\":\"l2_squared\",\"external\":true,\"embedding_name\":\"shared_dense_v1\"}";
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     {
@@ -93439,8 +94051,9 @@ test "db dense artifact rebuild does not let resumed targets skip fresh targets"
 test "db dense artifact rebuild ignores stale wrong-dimension artifacts when counting progress" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     {
@@ -93514,8 +94127,9 @@ test "db dense artifact rebuild ignores stale wrong-dimension artifacts when cou
 test "db dense artifact rebuild clears stale persisted state when no valid artifacts remain" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     {
@@ -93571,8 +94185,9 @@ test "db dense artifact rebuild clears stale persisted state when no valid artif
 test "db dense artifact rebuild waits for replay debt instead of raw doc count alone" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var appended_sequence: u64 = 0;
@@ -93649,8 +94264,9 @@ test "db dense artifact rebuild waits for replay debt instead of raw doc count a
 test "db search supports graph result_ref from full-text hits" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -93708,8 +94324,9 @@ test "db search supports graph result_ref from full-text hits" {
 test "db search supports graph result_ref from dense hits without public id handoff" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -93768,8 +94385,9 @@ test "db search supports graph result_ref from dense hits without public id hand
 test "db search rejects unbounded graph result_ref when base result is paged" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -93816,8 +94434,9 @@ test "db search rejects unbounded graph result_ref when base result is paged" {
 test "db search supports graph-only named queries" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -93867,8 +94486,9 @@ test "db search supports graph-only named queries" {
 test "db unfiltered graph search retains algebraic execution" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -93922,8 +94542,9 @@ test "db unfiltered graph search retains algebraic execution" {
 test "db graph search filters result nodes and hidden traversal intermediates" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -94181,8 +94802,9 @@ test "db graph search filters result nodes and hidden traversal intermediates" {
 test "db graph shortest path searches through admitted alternatives" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -94239,8 +94861,9 @@ test "db graph shortest path searches through admitted alternatives" {
 test "db named graph input sets carry resolved doc sets" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -94321,8 +94944,9 @@ test "db named graph input sets carry resolved doc sets" {
 test "db search supports fused graph selectors for single-lane full-text searches" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -94377,8 +95001,9 @@ test "db search supports fused graph selectors for single-lane full-text searche
 test "db search fuses full_text and dense named searches before graph expansion" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -94459,8 +95084,9 @@ test "db search fuses full_text and dense named searches before graph expansion"
 test "db search marks a truncated fused candidate union as a lower bound" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -94522,8 +95148,9 @@ test "db search marks a truncated fused candidate union as a lower bound" {
 test "db hybrid search does not hard-filter dense leg with scoring full_text" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -94588,8 +95215,9 @@ test "db hybrid search does not hard-filter dense leg with scoring full_text" {
 test "db search fuses full_text and dense named searches before graph expansion with durable lsm primary backend" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -94667,8 +95295,9 @@ test "db search fuses full_text and dense named searches before graph expansion 
 test "db search supports named full_text queries fused with dense and sparse before graph expansion" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -94767,8 +95396,9 @@ test "db search supports named full_text queries fused with dense and sparse bef
 test "db search supports named full_text queries fused with dense and sparse before graph expansion with durable lsm primary backend" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -94869,8 +95499,9 @@ test "db search supports named full_text queries fused with dense and sparse bef
 test "db search sorts graph queries by dependency and resolves prior graph results" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -94927,8 +95558,9 @@ test "db search sorts graph queries by dependency and resolves prior graph resul
 test "db search expand_strategy union and intersection apply graph hits to top level results" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -95087,8 +95719,9 @@ test "db graph intersection preserves artifact refs" {
 test "db graph index reloads on reopen for neighbor queries" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     {
@@ -95140,8 +95773,9 @@ test "db graph index reloads on reopen for neighbor queries" {
 test "db graph index reloads on reopen for neighbor queries with durable lsm primary backend" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     const primary_backend: PrimaryBackend = .{ .lsm = .{ .flush_threshold = 1 } };
@@ -95199,8 +95833,9 @@ test "db graph index reloads on reopen for neighbor queries with durable lsm pri
 test "db graph reverse rebuild resumes after interrupted reopen" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     {
@@ -95304,8 +95939,9 @@ test "db graph reverse rebuild resumes after interrupted reopen" {
 test "db reopens persisted index catalog and text index" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     {
@@ -95349,8 +95985,9 @@ test "db reopens persisted index catalog and text index" {
 test "db delete index persists across reopen" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     {
@@ -95388,8 +96025,9 @@ test "db delete index persists across reopen" {
 
 test "db delete full text index drains active merge before closing generation" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -95502,8 +96140,9 @@ test "db delete full text index drains active merge before closing generation" {
 
 test "db structural mutation autonomously retries transient maintenance restart failures" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -95548,8 +96187,9 @@ test "db post-delete filter reader does not deadlock behind queued cleanup write
     if (builtin.single_threaded or builtin.os.tag == .freestanding) return error.SkipZigTest;
     const alloc = std.testing.allocator;
     const doc_count: u32 = 40;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     {
@@ -95674,8 +96314,9 @@ test "db post-delete filter reader does not deadlock behind queued cleanup write
 test "db delete index persists across reopen with durable lsm primary backend" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     const primary_backend: PrimaryBackend = .{ .lsm = .{ .flush_threshold = 1 } };
@@ -95720,8 +96361,9 @@ test "db delete index persists across reopen with durable lsm primary backend" {
 test "db indexed delete removes hits across reopen" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     {
@@ -95776,8 +96418,9 @@ test "db indexed delete removes hits across reopen" {
 test "db indexed delete removes hits across reopen with durable lsm primary backend" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     const primary_backend: PrimaryBackend = .{ .lsm = .{ .flush_threshold = 1 } };
@@ -95838,8 +96481,9 @@ test "db indexed delete removes hits across reopen with durable lsm primary back
 test "db indexed overwrite replaces old hits across reopen" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     {
@@ -95909,8 +96553,9 @@ test "db indexed overwrite replaces old hits across reopen" {
 test "db indexed overwrite replaces old hits across reopen with durable lsm primary backend" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     const primary_backend: PrimaryBackend = .{ .lsm = .{ .flush_threshold = 1 } };
@@ -95986,8 +96631,9 @@ test "db indexed overwrite replaces old hits across reopen with durable lsm prim
 test "db runUntilIdle drains scheduled text merges after repeated writes" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -96036,8 +96682,9 @@ test "db runUntilIdle drains scheduled text merges after repeated writes" {
 test "db text merge descriptor admission failures retry without quarantine" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -96123,8 +96770,9 @@ test "db text merge shutdown cancels a worker blocked on descriptor admission" {
     if (builtin.single_threaded) return error.SkipZigTest;
 
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{ .start_index_workers = false });
@@ -96210,8 +96858,9 @@ test "db close stops text admission before joining derived publishers" {
     if (builtin.single_threaded) return error.SkipZigTest;
 
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -96262,8 +96911,9 @@ test "db close stops text admission before joining derived publishers" {
 test "db text merge backpressure drains sustained segment debt to low watermark" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     // Build the backlog without an automatic merge worker so the admission
@@ -96785,8 +97435,9 @@ test "db text merge backpressure drains sustained segment debt to low watermark"
 test "db text merge producer admission isolates quarantined dimensions" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -96900,8 +97551,9 @@ test "db text merge producer admission isolates quarantined dimensions" {
 test "db text kernel admits natural segments below hard segment limit" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -96938,8 +97590,9 @@ test "db text kernel admits natural segments below hard segment limit" {
 test "db derived text replay admits natural segments below hard segment limit" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -96985,8 +97638,9 @@ test "db derived text replay admits natural segments below hard segment limit" {
 test "db runUntilIdle drains scheduled text merges without index workers" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -97031,8 +97685,9 @@ test "db runUntilIdle drains scheduled text merges without index workers" {
 test "db full_text sync does not require draining scheduled text merges" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -97074,8 +97729,9 @@ test "db full_text sync does not require draining scheduled text merges" {
 test "db force compacts text index to searchable merge tier" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -97127,8 +97783,9 @@ test "db force compacts text index to searchable merge tier" {
 test "db text kernel search matches projected search without stored bodies" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{ .start_index_workers = false });
@@ -97201,8 +97858,9 @@ test "db text kernel search matches projected search without stored bodies" {
 test "db text compaction preserves index sort acceleration" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -97391,8 +98049,9 @@ test "db text compaction preserves index sort acceleration" {
 test "db index sort schema change requires a new text index generation" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -97503,8 +98162,9 @@ test "db index sort schema change requires a new text index generation" {
 test "db text compaction preserves ordinal filters across reopen" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     const expected_ordinal: doc_set.DocOrdinal = 9;
@@ -97615,8 +98275,9 @@ test "db provisioning schema is persisted before configured full text indexes op
     const alloc = std.testing.allocator;
     const table_schema_api = @import("../../schema/mod.zig");
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     // Persist the target-generation catalog entry while the shard still has
@@ -97701,8 +98362,9 @@ test "db best effort force compact leaves text merge debt under pressure" {
     resource_manager.observeUsage(.text_merge_buffers, &tracked_usage, 2);
     defer resource_manager.observeUsage(.text_merge_buffers, &tracked_usage, 0);
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -97790,8 +98452,9 @@ test "db runUntilIdle defers full text merge pressure without failing" {
         .policies = policies,
     });
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -97834,8 +98497,9 @@ test "db runUntilIdle defers full text merge pressure without failing" {
 test "db phrase query survives text compaction deletes and reopen" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     {
@@ -97920,8 +98584,9 @@ test "db phrase query survives text compaction deletes and reopen" {
 test "db prefix wildcard and regexp queries use text dictionary filters" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -97972,8 +98637,9 @@ test "db search_as_you_type schema emits Elasticsearch-style field variants" {
     const alloc = std.testing.allocator;
     const table_schema_api = @import("../../schema/mod.zig");
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -98180,8 +98846,9 @@ test "db one real delete keeps filtered full text on complement path across rest
     const alloc = std.testing.allocator;
     const table_schema_api = @import("../../schema/mod.zig");
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     const schema_json =
@@ -98316,8 +98983,9 @@ test "db production ingest preserves high-frequency keyword recall across clean 
     const alloc = std.testing.allocator;
     const table_schema_api = @import("../../schema/mod.zig");
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     const schema_json =
@@ -98394,8 +99062,9 @@ test "db versioned full text indexes reload matching schema mappings after reope
     const alloc = std.testing.allocator;
     const table_schema_api = @import("../../schema/mod.zig");
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     const schema_v0_json =
@@ -98524,8 +99193,9 @@ test "db additionalProperties true nested text fields survive reopen" {
     const alloc = std.testing.allocator;
     const table_schema_api = @import("../../schema/mod.zig");
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     const schema_json =
@@ -98605,8 +99275,9 @@ test "db explicit field analyzer override drives match queries" {
     const alloc = std.testing.allocator;
     const table_schema_api = @import("../../schema/mod.zig");
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     const schema_json =
@@ -98667,8 +99338,9 @@ test "db dynamic template match_mapping_type analyzer survives reopen" {
     const alloc = std.testing.allocator;
     const table_schema_api = @import("../../schema/mod.zig");
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     const schema_json =
@@ -98753,8 +99425,9 @@ test "db dynamic template precedence beats open additionalProperties fallback" {
     const alloc = std.testing.allocator;
     const table_schema_api = @import("../../schema/mod.zig");
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     const schema_json =
@@ -98817,8 +99490,9 @@ test "db patternProperties text fields survive reopen" {
     const alloc = std.testing.allocator;
     const table_schema_api = @import("../../schema/mod.zig");
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     const schema_json =
@@ -98910,8 +99584,9 @@ test "db root additionalProperties true text fields survive reopen" {
     const alloc = std.testing.allocator;
     const table_schema_api = @import("../../schema/mod.zig");
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     const schema_json =
@@ -98985,8 +99660,9 @@ test "db schema-driven text query matrix covers explicit dynamic template and fa
     const alloc = std.testing.allocator;
     const table_schema_api = @import("../../schema/mod.zig");
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     const schema_json =
@@ -99136,8 +99812,9 @@ test "db schema-driven text query matrix covers explicit dynamic template and fa
 test "db no-schema path recursively infers nested text and typed fields" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     const jan2 = (try parsePatternRfc3339ToNs("2026-01-02T00:00:00Z")).?;
@@ -99226,8 +99903,9 @@ test "db schema-present infer_types opt-in recursively infers nested fields afte
     const alloc = std.testing.allocator;
     const table_schema_api = @import("../../schema/mod.zig");
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     const jan2 = (try parsePatternRfc3339ToNs("2026-01-02T00:00:00Z")).?;
@@ -99343,8 +100021,9 @@ test "db schema-present infer_types opt-in recursively infers nested fields afte
 test "db typed and dictionary queries survive compaction delete and reopen" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     {
@@ -99536,8 +100215,9 @@ test "db typed and dictionary queries survive compaction delete and reopen" {
 test "db mixed-type stored fields survive text compaction and reopen" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     {
@@ -99603,8 +100283,9 @@ test "db mixed-type stored fields survive text compaction and reopen" {
 test "db lookup projects nested document fields" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -99637,8 +100318,9 @@ test "db lookup projects nested document fields" {
 test "db lookup returns full stored json by default" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -99658,8 +100340,9 @@ test "db lookup returns full stored json by default" {
 test "db search projects stored fields for hydrated hits" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -99701,8 +100384,9 @@ test "db search projects stored fields for hydrated hits" {
 test "db lookup includes chunk artifacts when _chunks is requested" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -99746,8 +100430,9 @@ test "db lookup includes chunk artifacts when _chunks is requested" {
 test "db lookup includes unified artifact projection when _artifacts is requested" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -99845,8 +100530,9 @@ test "db lookup includes unified artifact projection when _artifacts is requeste
 test "db search includes chunk artifacts on hydrated hits when _chunks is requested" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -99887,8 +100573,9 @@ test "db search includes chunk artifacts on hydrated hits when _chunks is reques
 test "db scan includes chunk artifacts when _chunks is requested" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -99920,8 +100607,9 @@ test "db scan includes chunk artifacts when _chunks is requested" {
 test "db lookup does not load chunks for nested _chunks projection without explicit include-all selector" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -99949,8 +100637,9 @@ test "db lookup does not load chunks for nested _chunks projection without expli
 test "db lookup loads chunks for _chunks.* selector and allows nested projection" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -99981,8 +100670,9 @@ test "db lookup loads chunks for _chunks.* selector and allows nested projection
 test "db lookup includes embedding artifacts when _embeddings is requested" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -100015,8 +100705,9 @@ test "db lookup includes embedding artifacts when _embeddings is requested" {
 test "db search includes embedding artifacts on hydrated hits when _embeddings is requested" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -100057,8 +100748,9 @@ test "db search includes embedding artifacts on hydrated hits when _embeddings i
 test "db scan includes embedding artifacts when _embeddings is requested" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -100089,8 +100781,9 @@ test "db scan includes embedding artifacts when _embeddings is requested" {
 test "db lookup does not load embeddings for nested _embeddings projection without explicit include-all selector" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -100118,8 +100811,9 @@ test "db lookup does not load embeddings for nested _embeddings projection witho
 test "db lookup loads embeddings for _embeddings.* selector and allows nested projection" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -100198,8 +100892,9 @@ test "db field selection plan only enables chunk special field for explicit incl
 test "db writes and reads timestamp metadata" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -100235,8 +100930,9 @@ test "db writes and reads timestamp metadata" {
 test "db identical rewrite refreshes timestamp metadata" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -100276,8 +100972,9 @@ test "db lookup hides expired documents when ttl schema is configured" {
     const alloc = std.testing.allocator;
     const ttl_duration_ns: u64 = 60 * std.time.ns_per_s;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -100309,8 +101006,9 @@ test "db search filters expired documents when ttl schema is configured" {
     const alloc = std.testing.allocator;
     const ttl_duration_ns: u64 = 60 * std.time.ns_per_s;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -100364,8 +101062,9 @@ test "db dense broad visibility filtering does not bypass ttl" {
     const alloc = std.testing.allocator;
     const ttl_duration_ns: u64 = 60 * std.time.ns_per_s;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -100418,8 +101117,9 @@ test "db ttl falls back to write timestamp when ttl field is missing" {
     const alloc = std.testing.allocator;
     const ttl_duration_ns: u64 = 60 * std.time.ns_per_s;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -100474,8 +101174,9 @@ test "db ttl falls back to write timestamp when ttl field is missing" {
 test "db ttl cleanup reclaims expired documents through normal delete semantics" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     const ttl_cfg: ttl_runtime_mod.Config = .{
@@ -100568,8 +101269,9 @@ test "db ttl delete callback atomically removes dense artifacts and updates repa
     const alloc = std.testing.allocator;
     const ttl_duration_ns: u64 = std.time.ns_per_s;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -100635,8 +101337,9 @@ test "db ttl delete callback atomically removes dense artifacts and updates repa
 test "db stats expose ttl cleanup activity" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     const ttl_cfg: ttl_runtime_mod.Config = .{
@@ -100677,8 +101380,9 @@ test "db stats expose ttl cleanup activity" {
 test "db ttl cleanup can run under lease ownership" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     const ttl_cfg: ttl_runtime_mod.Config = .{
@@ -100722,8 +101426,9 @@ test "db ttl cleanup can run under lease ownership" {
 test "db ttl cleanup can run under lease ownership with durable lsm primary backend" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     const primary_backend: PrimaryBackend = .{ .lsm = .{ .flush_threshold = 1 } };
@@ -100770,8 +101475,9 @@ test "db ttl cleanup can run under lease ownership with durable lsm primary back
 test "db ttl cleanup can run with manual clock" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var clock = platform_clock.ManualClock{
@@ -100816,8 +101522,9 @@ test "db ttl cleanup can run with manual clock" {
 test "db ttl cleanup background worker starts and deletes with manual clock" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var clock = platform_clock.ManualClock{
@@ -100884,8 +101591,9 @@ const TxnResolverRecorder = struct {
 test "db exposes local transaction lifecycle" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -100946,8 +101654,9 @@ test "db exposes local transaction lifecycle" {
 test "db transaction intent writes reject new documents at ordinal exhaustion" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -100992,8 +101701,9 @@ test "db transaction intent writes reject new documents at ordinal exhaustion" {
 test "db transaction-created identity rows remain visible after reopen" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     {
@@ -101032,8 +101742,9 @@ test "db transaction-created identity rows remain visible after reopen" {
 test "db batch resolves transforms against pending same-batch writes" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -101071,8 +101782,9 @@ test "db batch resolves transforms against pending same-batch writes" {
 test "db graph push and pull transforms update projected edges across restart" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     {
@@ -101179,8 +101891,9 @@ test "db graph push and pull transforms update projected edges across restart" {
 
 test "db graph transforms fail closed for replacement operations" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -101218,8 +101931,9 @@ test "db graph transforms fail closed for replacement operations" {
 test "db batch keeps delete when same-batch transform targets deleted key" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -101249,8 +101963,9 @@ test "db batch keeps delete when same-batch transform targets deleted key" {
 test "db transaction abort leaves no visible document" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -101269,8 +101984,9 @@ test "db transaction abort leaves no visible document" {
 test "db transaction resolves transforms against pending same-transaction writes" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -101307,8 +102023,9 @@ test "db transaction resolves transforms against pending same-transaction writes
 
 test "db transaction intents fence ordinary batch transforms" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -101339,8 +102056,9 @@ test "db transaction intents fence ordinary batch transforms" {
 test "db bulk ingest write commits document writes before finish" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -101368,8 +102086,9 @@ test "db bulk ingest write commits document writes before finish" {
 test "db bulk ingest primary lsm writes use direct sorted ingest batch mode" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -101406,8 +102125,9 @@ test "db bulk ingest primary lsm writes use direct sorted ingest batch mode" {
 test "db bulk ingest resolves transforms across direct write batches" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -101452,8 +102172,9 @@ test "db bulk ingest resolves transforms across direct write batches" {
 test "db bulk ingest applies pure-doc work at requested sync level" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -101499,8 +102220,9 @@ test "db bulk ingest applies pure-doc work at requested sync level" {
 test "db bulk ingest keeps direct writes visible before timestamped batch" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -101537,8 +102259,9 @@ test "db bulk ingest keeps direct writes visible before timestamped batch" {
 test "db bulk ingest keeps direct writes visible before predicate batch" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -101585,8 +102308,9 @@ test "db bulk ingest keeps direct writes visible before predicate batch" {
 test "db bulk ingest keeps direct writes visible before graph batch" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -101626,8 +102350,9 @@ test "db bulk ingest keeps direct writes visible before graph batch" {
 test "db query_readonly reopen during active bulk ingest serves empty dense search instead of index-not-found" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var writer = try DB.open(alloc, std.mem.span(path), .{});
@@ -101671,8 +102396,9 @@ test "db query_readonly reopen during active bulk ingest serves empty dense sear
 
 test "db table bulk abort does not quarantine the active dense index" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     {
@@ -101701,8 +102427,9 @@ test "db table bulk abort does not quarantine the active dense index" {
 
 test "db standalone resource manager governs dense cache and storage" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -101726,8 +102453,9 @@ test "db standalone resource manager governs dense cache and storage" {
 
 test "db fallback resource manager does not bind caller owned lsm cache" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var cache = lsm_backend_mod.Cache.init(alloc, lsm_backend_mod.DefaultCacheSizeBytes);
@@ -101829,8 +102557,9 @@ test "db dense streaming replay qualification survives full ingest and reopen" {
     const max_working_set_bytes = readEnvU64("ANTFLY_DENSE_STREAMING_QUALIFICATION_MAX_WORKING_SET_BYTES", 2 * 1024 * 1024 * 1024);
     var peak_rss_bytes: u64 = 0;
     var peak_working_set_bytes: u64 = 0;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     const started_ns = monotonicTimeNs();
@@ -101961,8 +102690,9 @@ test "db dense streaming replay qualification survives full ingest and reopen" {
 test "db query_readonly reopen does not backfill pending external dense artifacts" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     {
@@ -102005,8 +102735,9 @@ test "db query_readonly reopen does not backfill pending external dense artifact
 test "db primary auto bulk leaves dense replay active while session is open" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -102041,8 +102772,9 @@ test "db primary auto bulk leaves dense replay active while session is open" {
 test "db dense auto bulk finish wakes weak-sync replay and publishes visibility after catch-up" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -102166,8 +102898,9 @@ test "db dense auto bulk finish wakes weak-sync replay and publishes visibility 
 test "db dense auto bulk finish wakes current replay target if deferred wake is absent" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -102205,8 +102938,9 @@ test "db dense auto bulk finish wakes current replay target if deferred wake is 
 test "db dense auto bulk replays packed external embedding strings" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -102241,8 +102975,9 @@ test "db dense auto bulk replays packed external embedding strings" {
 test "db bulk ingest keeps full text merge maintenance live" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -102299,8 +103034,9 @@ test "db bulk ingest keeps full text merge maintenance live" {
 test "db bulk ingest finish publishes primary store before streaming dense catch up" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -102349,8 +103085,9 @@ test "db bulk ingest finish publishes primary store before streaming dense catch
 test "db transaction write request enforces version predicates" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -102381,8 +103118,9 @@ test "db transaction write request enforces version predicates" {
 test "db transaction write request detects concurrent intent conflicts" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -102403,8 +103141,9 @@ test "db transaction write request detects concurrent intent conflicts" {
 test "db committed transaction exposes commit timestamp for later predicates" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -102445,8 +103184,9 @@ test "db committed transaction exposes commit timestamp for later predicates" {
 test "db aborted transaction preserves prior committed state and version" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -102484,8 +103224,9 @@ test "db aborted transaction preserves prior committed state and version" {
 test "db explicit resolveTransactionIntents applies participant-style commit version" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -102509,8 +103250,9 @@ test "db explicit resolveTransactionIntents applies participant-style commit ver
 
 test "db replicated transaction commits each raft receipt atomically" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{ .start_index_workers = false });
@@ -102588,8 +103330,9 @@ test "db replicated transaction commits each raft receipt atomically" {
 
 test "db raced replicated transaction completion persists receipt and participant acknowledgement" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{ .start_index_workers = false });
@@ -102648,8 +103391,9 @@ test "db raced replicated transaction completion persists receipt and participan
 
 test "db transaction repeated committed resolve cannot overwrite a newer write" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{ .start_index_workers = false });
@@ -102675,8 +103419,9 @@ test "db transaction repeated committed resolve cannot overwrite a newer write" 
 
 test "db transaction committed transform appends derived replay from final value" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{ .start_index_workers = false });
@@ -102710,8 +103455,9 @@ test "db transaction committed transform appends derived replay from final value
 
 test "db transaction committed transform reaches full text visibility" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -102743,8 +103489,9 @@ test "db transaction committed transform reaches full text visibility" {
 
 test "db transaction idempotent resolve honors stronger sync level" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -102771,8 +103518,9 @@ test "db transaction idempotent resolve honors stronger sync level" {
 test "db recoverTransactions auto-aborts stale pending intents" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -102795,8 +103543,9 @@ test "db recoverTransactions auto-aborts stale pending intents" {
 test "db participant recovery preserves finalized transaction until all participants resolve" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -102831,8 +103580,9 @@ test "db participant recovery preserves finalized transaction until all particip
 test "db participant recovery callbacks run outside the apply lock" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -102874,8 +103624,9 @@ test "db participant recovery callbacks run outside the apply lock" {
 test "db transaction recovery runtime resolves participants and unblocks cleanup" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var recorder = TxnResolverRecorder{};
@@ -102953,8 +103704,9 @@ test "db transaction recovery runtime resolves participants and unblocks cleanup
 test "db transaction recovery runtime rebuilds all derived effects for committed orphaned intents" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     const txn_id = blk: {
@@ -103037,8 +103789,9 @@ test "db transaction recovery runtime rebuilds all derived effects for committed
 test "db batch enforces optimistic version predicates" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -103070,8 +103823,9 @@ test "db batch enforces optimistic version predicates" {
 test "db persists byte range across reopen" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     {
@@ -103106,8 +103860,9 @@ test "db persists byte range across reopen" {
 test "db split state and split deltas are exposed through public api" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -103162,8 +103917,9 @@ test "db split state and split deltas are exposed through public api" {
 test "db split finalization marks split-off document child ranges remote" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -103259,8 +104015,9 @@ test "db split finalization marks split-off document child ranges remote" {
 test "db shadow index manager backfills split-off range and ignores parent-range live writes after split" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -103311,12 +104068,14 @@ test "db shadow index manager backfills split-off range and ignores parent-range
 test "db split prepare and finalize produce destination shard and trim parent range" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
-    var dest_buf: [256]u8 = undefined;
-    const dest = tempPath(&dest_buf);
+    var dest_tmp = try TestDirectory.init("db");
+    defer dest_tmp.cleanup();
+    const dest = dest_tmp.path().ptr;
     defer cleanupTempDir(dest);
 
     const identity_namespace = doc_identity.Namespace{ .table_id = 71, .shard_id = 101, .range_id = 1001 };
@@ -103498,11 +104257,13 @@ test "db split prepare and finalize produce destination shard and trim parent ra
 test "db split preserves multi-source graph fallback ownership on destination" {
     const alloc = std.testing.allocator;
 
-    var parent_buf: [256]u8 = undefined;
-    const parent_path = tempPath(&parent_buf);
+    var parent_tmp = try TestDirectory.init("db");
+    defer parent_tmp.cleanup();
+    const parent_path = parent_tmp.path().ptr;
     defer cleanupTempDir(parent_path);
-    var child_buf: [256]u8 = undefined;
-    const child_path = tempPath(&child_buf);
+    var child_tmp = try TestDirectory.init("db");
+    defer child_tmp.cleanup();
+    const child_path = child_tmp.path().ptr;
     defer cleanupTempDir(child_path);
 
     var parent = try DB.open(alloc, std.mem.span(parent_path), .{});
@@ -103566,12 +104327,14 @@ test "db split preserves multi-source graph fallback ownership on destination" {
 test "db split prepare and finalize work with durable lsm primary backend" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
-    var dest_buf: [256]u8 = undefined;
-    const dest = tempPath(&dest_buf);
+    var dest_tmp = try TestDirectory.init("db");
+    defer dest_tmp.cleanup();
+    const dest = dest_tmp.path().ptr;
     defer cleanupTempDir(dest);
 
     const primary_backend: PrimaryBackend = .{ .lsm = .{ .flush_threshold = 1 } };
@@ -103648,12 +104411,14 @@ test "db split prepare and finalize work with durable lsm primary backend" {
 test "db split prepare survives reopen and finalizes with durable lsm primary backend" {
     const alloc = std.testing.allocator;
 
-    var parent_buf: [256]u8 = undefined;
-    const parent_path = tempPath(&parent_buf);
+    var parent_tmp = try TestDirectory.init("db");
+    defer parent_tmp.cleanup();
+    const parent_path = parent_tmp.path().ptr;
     defer cleanupTempDir(parent_path);
 
-    var child_buf: [256]u8 = undefined;
-    const child_path = tempPath(&child_buf);
+    var child_tmp = try TestDirectory.init("db");
+    defer child_tmp.cleanup();
+    const child_path = child_tmp.path().ptr;
     defer cleanupTempDir(child_path);
 
     const primary_backend: PrimaryBackend = .{ .lsm = .{ .flush_threshold = 1 } };
@@ -103706,12 +104471,14 @@ test "db split prepare survives reopen and finalizes with durable lsm primary ba
 test "db split prepare survives reopen and finalizes text sparse and graph indexes with durable lsm primary backend" {
     const alloc = std.testing.allocator;
 
-    var parent_buf: [256]u8 = undefined;
-    const parent_path = tempPath(&parent_buf);
+    var parent_tmp = try TestDirectory.init("db");
+    defer parent_tmp.cleanup();
+    const parent_path = parent_tmp.path().ptr;
     defer cleanupTempDir(parent_path);
 
-    var child_buf: [256]u8 = undefined;
-    const child_path = tempPath(&child_buf);
+    var child_tmp = try TestDirectory.init("db");
+    defer child_tmp.cleanup();
+    const child_path = child_tmp.path().ptr;
     defer cleanupTempDir(child_path);
 
     const primary_backend: PrimaryBackend = .{ .lsm = db_config.primary_lsm_options_default };
@@ -103851,12 +104618,14 @@ test "db split prepare survives reopen and finalizes text sparse and graph index
 test "db split cutover fences enrichment to the owning range" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
-    var dest_buf: [256]u8 = undefined;
-    const dest = tempPath(&dest_buf);
+    var dest_tmp = try TestDirectory.init("db");
+    defer dest_tmp.cleanup();
+    const dest = dest_tmp.path().ptr;
     defer cleanupTempDir(dest);
 
     var deterministic_parent = embedder_mod.DeterministicDenseEmbedder{};
@@ -103942,8 +104711,9 @@ test "db split cutover fences enrichment to the owning range" {
 
 test "db raft snapshot replacement preserves overlapping incoming documents" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -103969,8 +104739,9 @@ test "db raft snapshot replacement preserves overlapping incoming documents" {
 
 test "db staged raft snapshot chunks atomically replace the live generation" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     {
@@ -104025,8 +104796,9 @@ test "db staged raft snapshot chunks atomically replace the live generation" {
 
 test "db split bootstrap replacement preserves overlapping incoming documents" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -104064,8 +104836,9 @@ test "db split bootstrap replacement preserves overlapping incoming documents" {
 
 test "db split bootstrap retries preserve reserved data and exact sequence" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -104113,8 +104886,9 @@ test "db split bootstrap retries preserve reserved data and exact sequence" {
 test "db replicated split bootstrap requires and preserves begin barrier" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     const identity_namespace: DocIdentityNamespace = .{
@@ -104215,12 +104989,14 @@ test "db replicated split bootstrap requires and preserves begin barrier" {
 test "db split cutover fences enrichment to the owning range with durable lsm primary backend" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
-    var dest_buf: [256]u8 = undefined;
-    const dest = tempPath(&dest_buf);
+    var dest_tmp = try TestDirectory.init("db");
+    defer dest_tmp.cleanup();
+    const dest = dest_tmp.path().ptr;
     defer cleanupTempDir(dest);
 
     const primary_backend: PrimaryBackend = .{ .lsm = db_config.primary_lsm_options_default };
@@ -104311,12 +105087,14 @@ test "db split cutover fences enrichment to the owning range with durable lsm pr
 test "db merge-style cutover fences enrichment to the merged receiver range" {
     const alloc = std.testing.allocator;
 
-    var receiver_buf: [256]u8 = undefined;
-    const receiver_path = tempPath(&receiver_buf);
+    var receiver_tmp = try TestDirectory.init("db");
+    defer receiver_tmp.cleanup();
+    const receiver_path = receiver_tmp.path().ptr;
     defer cleanupTempDir(receiver_path);
 
-    var donor_buf: [256]u8 = undefined;
-    const donor_path = tempPath(&donor_buf);
+    var donor_tmp = try TestDirectory.init("db");
+    defer donor_tmp.cleanup();
+    const donor_path = donor_tmp.path().ptr;
     defer cleanupTempDir(donor_path);
 
     var deterministic_receiver = embedder_mod.DeterministicDenseEmbedder{};
@@ -104405,12 +105183,14 @@ test "db merge-style cutover fences enrichment to the merged receiver range" {
 test "db merge-style cutover fences enrichment to the merged receiver range with durable lsm primary backend" {
     const alloc = std.testing.allocator;
 
-    var receiver_buf: [256]u8 = undefined;
-    const receiver_path = tempPath(&receiver_buf);
+    var receiver_tmp = try TestDirectory.init("db");
+    defer receiver_tmp.cleanup();
+    const receiver_path = receiver_tmp.path().ptr;
     defer cleanupTempDir(receiver_path);
 
-    var donor_buf: [256]u8 = undefined;
-    const donor_path = tempPath(&donor_buf);
+    var donor_tmp = try TestDirectory.init("db");
+    defer donor_tmp.cleanup();
+    const donor_path = donor_tmp.path().ptr;
     defer cleanupTempDir(donor_path);
 
     const primary_backend: PrimaryBackend = .{ .lsm = .{ .flush_threshold = 1 } };
@@ -104503,12 +105283,14 @@ test "db merge-style cutover fences enrichment to the merged receiver range with
 test "db merge-style cutover routes text sparse and graph indexes to the merged receiver range with durable lsm primary backend" {
     const alloc = std.testing.allocator;
 
-    var receiver_buf: [256]u8 = undefined;
-    const receiver_path = tempPath(&receiver_buf);
+    var receiver_tmp = try TestDirectory.init("db");
+    defer receiver_tmp.cleanup();
+    const receiver_path = receiver_tmp.path().ptr;
     defer cleanupTempDir(receiver_path);
 
-    var donor_buf: [256]u8 = undefined;
-    const donor_path = tempPath(&donor_buf);
+    var donor_tmp = try TestDirectory.init("db");
+    defer donor_tmp.cleanup();
+    const donor_path = donor_tmp.path().ptr;
     defer cleanupTempDir(donor_path);
 
     const primary_backend: PrimaryBackend = .{ .lsm = .{ .flush_threshold = 1 } };
@@ -104618,12 +105400,14 @@ test "db merge-style cutover routes text sparse and graph indexes to the merged 
 test "db split cutover preserves enrichment resume and fencing across reopen" {
     const alloc = std.testing.allocator;
 
-    var parent_buf: [256]u8 = undefined;
-    const parent_path = tempPath(&parent_buf);
+    var parent_tmp = try TestDirectory.init("db");
+    defer parent_tmp.cleanup();
+    const parent_path = parent_tmp.path().ptr;
     defer cleanupTempDir(parent_path);
 
-    var child_buf: [256]u8 = undefined;
-    const child_path = tempPath(&child_buf);
+    var child_tmp = try TestDirectory.init("db");
+    defer child_tmp.cleanup();
+    const child_path = child_tmp.path().ptr;
     defer cleanupTempDir(child_path);
 
     {
@@ -104746,12 +105530,14 @@ test "db split cutover preserves enrichment resume and fencing across reopen" {
 test "db split cutover preserves enrichment resume and fencing across reopen with durable lsm primary backend" {
     const alloc = std.testing.allocator;
 
-    var parent_buf: [256]u8 = undefined;
-    const parent_path = tempPath(&parent_buf);
+    var parent_tmp = try TestDirectory.init("db");
+    defer parent_tmp.cleanup();
+    const parent_path = parent_tmp.path().ptr;
     defer cleanupTempDir(parent_path);
 
-    var child_buf: [256]u8 = undefined;
-    const child_path = tempPath(&child_buf);
+    var child_tmp = try TestDirectory.init("db");
+    defer child_tmp.cleanup();
+    const child_path = child_tmp.path().ptr;
     defer cleanupTempDir(child_path);
 
     const primary_backend: PrimaryBackend = .{ .lsm = db_config.primary_lsm_options_default };
@@ -104882,12 +105668,14 @@ test "db split cutover preserves enrichment resume and fencing across reopen wit
 test "db merge-style cutover preserves enrichment resume and fencing across reopen" {
     const alloc = std.testing.allocator;
 
-    var receiver_buf: [256]u8 = undefined;
-    const receiver_path = tempPath(&receiver_buf);
+    var receiver_tmp = try TestDirectory.init("db");
+    defer receiver_tmp.cleanup();
+    const receiver_path = receiver_tmp.path().ptr;
     defer cleanupTempDir(receiver_path);
 
-    var donor_buf: [256]u8 = undefined;
-    const donor_path = tempPath(&donor_buf);
+    var donor_tmp = try TestDirectory.init("db");
+    defer donor_tmp.cleanup();
+    const donor_path = donor_tmp.path().ptr;
     defer cleanupTempDir(donor_path);
 
     {
@@ -105013,12 +105801,14 @@ test "db merge-style cutover preserves enrichment resume and fencing across reop
 test "db merge-style cutover preserves enrichment resume and fencing across reopen with durable lsm primary backend" {
     const alloc = std.testing.allocator;
 
-    var receiver_buf: [256]u8 = undefined;
-    const receiver_path = tempPath(&receiver_buf);
+    var receiver_tmp = try TestDirectory.init("db");
+    defer receiver_tmp.cleanup();
+    const receiver_path = receiver_tmp.path().ptr;
     defer cleanupTempDir(receiver_path);
 
-    var donor_buf: [256]u8 = undefined;
-    const donor_path = tempPath(&donor_buf);
+    var donor_tmp = try TestDirectory.init("db");
+    defer donor_tmp.cleanup();
+    const donor_path = donor_tmp.path().ptr;
     defer cleanupTempDir(donor_path);
 
     const primary_backend: PrimaryBackend = .{ .lsm = db_config.primary_lsm_options_default };
@@ -105152,12 +105942,14 @@ test "db merge-style cutover preserves enrichment resume and fencing across reop
 test "db merge-style cutover preserves text sparse and graph indexes across reopen with durable lsm primary backend" {
     const alloc = std.testing.allocator;
 
-    var receiver_buf: [256]u8 = undefined;
-    const receiver_path = tempPath(&receiver_buf);
+    var receiver_tmp = try TestDirectory.init("db");
+    defer receiver_tmp.cleanup();
+    const receiver_path = receiver_tmp.path().ptr;
     defer cleanupTempDir(receiver_path);
 
-    var donor_buf: [256]u8 = undefined;
-    const donor_path = tempPath(&donor_buf);
+    var donor_tmp = try TestDirectory.init("db");
+    defer donor_tmp.cleanup();
+    const donor_path = donor_tmp.path().ptr;
     defer cleanupTempDir(donor_path);
 
     const primary_backend: PrimaryBackend = .{ .lsm = db_config.primary_lsm_options_default };
@@ -105341,8 +106133,9 @@ test "db dense lsm cache profile benchmark" {
     if (!profileBenchTestsEnabled()) return error.SkipZigTest;
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var lsm_cache = lsm_backend_mod.Cache.init(alloc, 64 * 1024 * 1024);
@@ -105620,8 +106413,9 @@ test "db batch load profile benchmark" {
     if (!profileBenchTestsEnabled()) return error.SkipZigTest;
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -105777,8 +106571,9 @@ test "db hbc posting lazy versus eager profile benchmark" {
     };
 
     for (modes) |mode| {
-        var path_buf: [256]u8 = undefined;
-        const path = tempPath(&path_buf);
+        var path_tmp = try TestDirectory.init("db");
+        defer path_tmp.cleanup();
+        const path = path_tmp.path().ptr;
         defer cleanupTempDir(path);
 
         var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -105875,8 +106670,9 @@ test "native restore deletes projections only for explicit physical corruption" 
 test "db native snapshot exports self-contained generation" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var runtime = try background_runtime_mod.BackendRuntimeHandle.init(alloc, .{
@@ -105939,8 +106735,9 @@ test "db native snapshot rejects projections without immutable checkpoints" {
     @import("../../test_error_logs.zig").expectErrorLogs(1);
 
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
     defer {
         var snapshots_buf: [512]u8 = undefined;
@@ -105974,8 +106771,9 @@ test "db native snapshot rejects storage without atomic host generation publicat
     @import("../../test_error_logs.zig").expectErrorLogs(1);
 
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var memory_storage = lsm_backend_mod.MemoryStorage.init(alloc);
@@ -105994,8 +106792,9 @@ test "db native snapshot rejects storage without atomic host generation publicat
 
 test "db native snapshot rejects an external physical root before creating artifacts" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = std.mem.span(tempPath(&path_buf));
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = std.mem.span(path_tmp.path().ptr);
     defer cleanupTempDir(path);
 
     var backend = mem_backend_mod.Backend.init(alloc, .{});
@@ -106024,11 +106823,13 @@ test "db native snapshot rejects an external physical root before creating artif
 
 test "native restore backend configuration is resolved exactly once" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = std.mem.span(tempPath(&path_buf));
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = std.mem.span(path_tmp.path().ptr);
     defer cleanupTempDir(path);
-    var candidate_path_buf: [256]u8 = undefined;
-    const candidate_path = std.mem.span(tempPath(&candidate_path_buf));
+    var candidate_path_tmp = try TestDirectory.init("db");
+    defer candidate_path_tmp.cleanup();
+    const candidate_path = std.mem.span(candidate_path_tmp.path().ptr);
     defer cleanupTempDir(candidate_path);
 
     const ConfiguratorContext = struct {
@@ -106094,8 +106895,9 @@ test "native restore backend configuration is resolved exactly once" {
 
 test "native restore filesystem publication rejects non-publishable storage capabilities" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = std.mem.span(tempPath(&path_buf));
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = std.mem.span(path_tmp.path().ptr);
     defer cleanupTempDir(path);
 
     var memory_storage = lsm_backend_mod.MemoryStorage.init(alloc);
@@ -106132,8 +106934,9 @@ test "native restore filesystem publication rejects non-publishable storage capa
 
 test "db native snapshot admission bounds capture under concurrent writes" {
     const alloc = std.heap.page_allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
     defer {
         var snapshots_buf: [512]u8 = undefined;
@@ -106324,8 +107127,9 @@ test "db native snapshot admission bounds capture under concurrent writes" {
 test "db snapshot exports logical store only for durable lsm primary backend" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -106364,11 +107168,13 @@ test "db snapshot exports logical store only for durable lsm primary backend" {
 
 test "db native deferred restore preserves generated dense generation without embedder" {
     const alloc = std.testing.allocator;
-    var source_buf: [256]u8 = undefined;
-    const source_path = tempPath(&source_buf);
+    var source_tmp = try TestDirectory.init("db");
+    defer source_tmp.cleanup();
+    const source_path = source_tmp.path().ptr;
     defer cleanupTempDir(source_path);
-    var restore_buf: [256]u8 = undefined;
-    const restore_path = tempPath(&restore_buf);
+    var restore_tmp = try TestDirectory.init("db");
+    defer restore_tmp.cleanup();
+    const restore_path = restore_tmp.path().ptr;
     defer cleanupTempDir(restore_path);
     const primary_backend: PrimaryBackend = .{ .lsm = .{ .flush_threshold = 1 } };
 
@@ -106492,11 +107298,13 @@ test "db native restore rejects a primary revision outside the manifest generati
     @import("../../test_error_logs.zig").expectErrorLogs(1);
 
     const alloc = std.testing.allocator;
-    var source_buf: [256]u8 = undefined;
-    const source_path = tempPath(&source_buf);
+    var source_tmp = try TestDirectory.init("db");
+    defer source_tmp.cleanup();
+    const source_path = source_tmp.path().ptr;
     defer cleanupTempDir(source_path);
-    var restore_buf: [256]u8 = undefined;
-    const restore_path = tempPath(&restore_buf);
+    var restore_tmp = try TestDirectory.init("db");
+    defer restore_tmp.cleanup();
+    const restore_path = restore_tmp.path().ptr;
     defer cleanupTempDir(restore_path);
     const primary_backend: PrimaryBackend = .{ .lsm = .{ .flush_threshold = 1 } };
 
@@ -106558,11 +107366,13 @@ test "db native restore rejects a primary revision outside the manifest generati
 
 test "db native restore preserves primary generation and repairs only a missing projection" {
     const alloc = std.testing.allocator;
-    var source_buf: [256]u8 = undefined;
-    const source_path = tempPath(&source_buf);
+    var source_tmp = try TestDirectory.init("db");
+    defer source_tmp.cleanup();
+    const source_path = source_tmp.path().ptr;
     defer cleanupTempDir(source_path);
-    var restore_buf: [256]u8 = undefined;
-    const restore_path = tempPath(&restore_buf);
+    var restore_tmp = try TestDirectory.init("db");
+    defer restore_tmp.cleanup();
+    const restore_path = restore_tmp.path().ptr;
     defer cleanupTempDir(restore_path);
     const primary_backend: PrimaryBackend = .{ .lsm = .{ .flush_threshold = 1 } };
 
@@ -106702,12 +107512,14 @@ test "db native restore preserves primary generation and repairs only a missing 
 test "db restore snapshot recreates logical store for durable lsm primary backend" {
     const alloc = std.testing.allocator;
 
-    var src_buf: [256]u8 = undefined;
-    const src_path = tempPath(&src_buf);
+    var src_tmp = try TestDirectory.init("db");
+    defer src_tmp.cleanup();
+    const src_path = src_tmp.path().ptr;
     defer cleanupTempDir(src_path);
 
-    var restore_buf: [256]u8 = undefined;
-    const restore_path = tempPath(&restore_buf);
+    var restore_tmp = try TestDirectory.init("db");
+    defer restore_tmp.cleanup();
+    const restore_path = restore_tmp.path().ptr;
     defer cleanupTempDir(restore_path);
 
     const primary_backend: PrimaryBackend = .{ .lsm = .{ .flush_threshold = 1 } };
@@ -106763,11 +107575,13 @@ test "db restore snapshot recreates logical store for durable lsm primary backen
 
 test "logical snapshot descriptor is strict while descriptorless compatibility remains readable" {
     const alloc = std.testing.allocator;
-    var src_buf: [256]u8 = undefined;
-    const src_path = tempPath(&src_buf);
+    var src_tmp = try TestDirectory.init("db");
+    defer src_tmp.cleanup();
+    const src_path = src_tmp.path().ptr;
     defer cleanupTempDir(src_path);
-    var restore_buf: [256]u8 = undefined;
-    const restore_path = tempPath(&restore_buf);
+    var restore_tmp = try TestDirectory.init("db");
+    defer restore_tmp.cleanup();
+    const restore_path = restore_tmp.path().ptr;
     defer cleanupTempDir(restore_path);
     const primary_backend: PrimaryBackend = .{ .lsm = .{ .flush_threshold = 1 } };
 
@@ -106824,8 +107638,9 @@ test "db restore snapshot repeatedly validates run-backed doc identity metadata"
     // diagnostics only poison and guard allocations that cross this boundary.
     const alloc = platform.allocator.processAllocator(std.testing.allocator);
 
-    var src_buf: [256]u8 = undefined;
-    const src_path = tempPath(&src_buf);
+    var src_tmp = try TestDirectory.init("db");
+    defer src_tmp.cleanup();
+    const src_path = src_tmp.path().ptr;
     defer cleanupTempDir(src_path);
 
     const primary_backend: PrimaryBackend = .{ .lsm = .{ .flush_threshold = 1 } };
@@ -106868,8 +107683,9 @@ test "db restore snapshot repeatedly validates run-backed doc identity metadata"
     }
 
     for (0..32) |i| {
-        var restore_buf: [256]u8 = undefined;
-        const restore_path = tempPath(&restore_buf);
+        var restore_tmp = try TestDirectory.init("db");
+        defer restore_tmp.cleanup();
+        const restore_path = restore_tmp.path().ptr;
         defer cleanupTempDir(restore_path);
 
         var transition = try generation_lifecycle.beginProcessExclusive(std.mem.span(restore_path));
@@ -106917,12 +107733,14 @@ test "db restore snapshot repeatedly validates run-backed doc identity metadata"
 test "db restore snapshot rejects invalid doc identity metadata" {
     const alloc = std.testing.allocator;
 
-    var src_buf: [256]u8 = undefined;
-    const src_path = tempPath(&src_buf);
+    var src_tmp = try TestDirectory.init("db");
+    defer src_tmp.cleanup();
+    const src_path = src_tmp.path().ptr;
     defer cleanupTempDir(src_path);
 
-    var restore_buf: [256]u8 = undefined;
-    const restore_path = tempPath(&restore_buf);
+    var restore_tmp = try TestDirectory.init("db");
+    defer restore_tmp.cleanup();
+    const restore_path = restore_tmp.path().ptr;
     defer cleanupTempDir(restore_path);
 
     const primary_backend: PrimaryBackend = .{ .lsm = .{ .flush_threshold = 1 } };
@@ -106967,12 +107785,14 @@ test "db restore snapshot rejects invalid doc identity metadata" {
 test "db deferred restore rejects strict doc identity namespace mismatch" {
     const alloc = std.testing.allocator;
 
-    var src_buf: [256]u8 = undefined;
-    const src_path = tempPath(&src_buf);
+    var src_tmp = try TestDirectory.init("db");
+    defer src_tmp.cleanup();
+    const src_path = src_tmp.path().ptr;
     defer cleanupTempDir(src_path);
 
-    var restore_buf: [256]u8 = undefined;
-    const restore_path = tempPath(&restore_buf);
+    var restore_tmp = try TestDirectory.init("db");
+    defer restore_tmp.cleanup();
+    const restore_path = restore_tmp.path().ptr;
     defer cleanupTempDir(restore_path);
 
     const primary_backend: PrimaryBackend = .{ .lsm = .{ .flush_threshold = 1 } };
@@ -107038,12 +107858,14 @@ test "db deferred restore rejects strict doc identity namespace mismatch" {
 test "db restore snapshot recreates text sparse and graph indexes for durable lsm primary backend" {
     const alloc = std.testing.allocator;
 
-    var src_buf: [256]u8 = undefined;
-    const src_path = tempPath(&src_buf);
+    var src_tmp = try TestDirectory.init("db");
+    defer src_tmp.cleanup();
+    const src_path = src_tmp.path().ptr;
     defer cleanupTempDir(src_path);
 
-    var restore_buf: [256]u8 = undefined;
-    const restore_path = tempPath(&restore_buf);
+    var restore_tmp = try TestDirectory.init("db");
+    defer restore_tmp.cleanup();
+    const restore_path = restore_tmp.path().ptr;
     defer cleanupTempDir(restore_path);
 
     const primary_backend: PrimaryBackend = .{ .lsm = .{ .flush_threshold = 1 } };
@@ -107135,12 +107957,14 @@ test "db restore snapshot recreates text sparse and graph indexes for durable ls
 test "db restore snapshot replays managed chunked dense embeddings for durable lsm primary backend" {
     const alloc = std.testing.allocator;
 
-    var src_buf: [256]u8 = undefined;
-    const src_path = tempPath(&src_buf);
+    var src_tmp = try TestDirectory.init("db");
+    defer src_tmp.cleanup();
+    const src_path = src_tmp.path().ptr;
     defer cleanupTempDir(src_path);
 
-    var restore_buf: [256]u8 = undefined;
-    const restore_path = tempPath(&restore_buf);
+    var restore_tmp = try TestDirectory.init("db");
+    defer restore_tmp.cleanup();
+    const restore_path = restore_tmp.path().ptr;
     defer cleanupTempDir(restore_path);
 
     const primary_backend: PrimaryBackend = .{ .lsm = .{ .flush_threshold = 1 } };
@@ -107234,8 +108058,9 @@ test "db restore snapshot replays managed chunked dense embeddings for durable l
 
 test "db restore dense artifact completion publishes counter bootstrap as a bounded quantum" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -107289,8 +108114,9 @@ test "db restore dense artifact completion publishes counter bootstrap as a boun
 
 test "db restore dense artifact completion keeps every intent when one proof is pending" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -107347,8 +108173,9 @@ test "db restore dense artifact completion keeps every intent when one proof is 
 
 test "db restore dense rebuild rediscovery is pending rather than progress" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -107406,8 +108233,9 @@ test "db restore dense rebuild rediscovery is pending rather than progress" {
 
 test "db restore dense rebuild publishes mixed progress before worker wait" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{
@@ -107466,12 +108294,14 @@ test "db restore dense rebuild publishes mixed progress before worker wait" {
 test "db explicit restore runtime repair repairs managed chunked dense embeddings once for restored shard" {
     const alloc = std.testing.allocator;
 
-    var src_buf: [256]u8 = undefined;
-    const src_path = tempPath(&src_buf);
+    var src_tmp = try TestDirectory.init("db");
+    defer src_tmp.cleanup();
+    const src_path = src_tmp.path().ptr;
     defer cleanupTempDir(src_path);
 
-    var restore_buf: [256]u8 = undefined;
-    const restore_path = tempPath(&restore_buf);
+    var restore_tmp = try TestDirectory.init("db");
+    defer restore_tmp.cleanup();
+    const restore_path = restore_tmp.path().ptr;
     defer cleanupTempDir(restore_path);
 
     const primary_backend: PrimaryBackend = .{ .lsm = .{ .flush_threshold = 1 } };
@@ -107635,12 +108465,14 @@ test "db explicit restore runtime repair repairs managed chunked dense embedding
 test "db restore repair does not complete before regenerated chunk embeddings are query visible" {
     const alloc = std.testing.allocator;
 
-    var src_buf: [256]u8 = undefined;
-    const src_path = tempPath(&src_buf);
+    var src_tmp = try TestDirectory.init("db");
+    defer src_tmp.cleanup();
+    const src_path = src_tmp.path().ptr;
     defer cleanupTempDir(src_path);
 
-    var restore_buf: [256]u8 = undefined;
-    const restore_path = tempPath(&restore_buf);
+    var restore_tmp = try TestDirectory.init("db");
+    defer restore_tmp.cleanup();
+    const restore_path = restore_tmp.path().ptr;
     defer cleanupTempDir(restore_path);
 
     const primary_backend: PrimaryBackend = .{ .lsm = .{ .flush_threshold = 1 } };
@@ -107773,12 +108605,14 @@ test "db restore repair does not complete before regenerated chunk embeddings ar
 test "db incomplete deferred restore import recovers before runtime repair" {
     const alloc = std.testing.allocator;
 
-    var src_buf: [256]u8 = undefined;
-    const src_path = tempPath(&src_buf);
+    var src_tmp = try TestDirectory.init("db");
+    defer src_tmp.cleanup();
+    const src_path = src_tmp.path().ptr;
     defer cleanupTempDir(src_path);
 
-    var restore_buf: [256]u8 = undefined;
-    const restore_path = tempPath(&restore_buf);
+    var restore_tmp = try TestDirectory.init("db");
+    defer restore_tmp.cleanup();
+    const restore_path = restore_tmp.path().ptr;
     defer cleanupTempDir(restore_path);
 
     const primary_backend: PrimaryBackend = .{ .lsm = .{ .flush_threshold = 1 } };
@@ -107840,8 +108674,9 @@ test "db incomplete deferred restore import recovers before runtime repair" {
 
 test "db restore state uses strict structured content identity markers" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
     const location = "file:///tmp/backups?note=line\nphase=complete";
     const artifact_sha256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
@@ -107910,8 +108745,9 @@ test "db graph ownership restore cursor resumes one artifact index exactly" {
 
 test "db graph ownership restore materializes large artifacts in published segments" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{ .start_index_workers = false });
@@ -108040,8 +108876,9 @@ test "db graph ownership restore materializes large artifacts in published segme
 
 test "db restore graph ownership replay persists a bounded page cursor" {
     const alloc = std.testing.allocator;
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{ .start_index_workers = false });
@@ -108111,8 +108948,9 @@ test "db restore graph ownership replay persists a bounded page cursor" {
 test "db rebuild dense indexes preserves corrupt stored embedding artifacts" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -108155,8 +108993,9 @@ test "db dense artifact rebuild write cleanup tolerates artifact-backed empty ve
 test "db rw lock allows search and scan while shared read lock is held" {
     const alloc = std.heap.c_allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -108200,8 +109039,9 @@ test "db rw lock allows search and scan while shared read lock is held" {
 test "db rw lock keeps batch writes blocked behind shared read lock" {
     const alloc = std.heap.c_allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -108247,8 +109087,9 @@ test "db rw lock keeps batch writes blocked behind shared read lock" {
 test "db scan returns hashes and projected documents" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -108280,8 +109121,9 @@ test "db scan returns hashes and projected documents" {
 test "db scan applies structured filter before limit" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -108310,8 +109152,9 @@ test "db scan applies structured filter before limit" {
 test "db updateRange constrains index backfill" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     var db = try DB.open(alloc, std.mem.span(path), .{});
@@ -108342,8 +109185,9 @@ test "db updateRange constrains index backfill" {
 test "db range cardinality remains exact across mutations and reopen" {
     const alloc = std.testing.allocator;
 
-    var path_buf: [256]u8 = undefined;
-    const path = tempPath(&path_buf);
+    var path_tmp = try TestDirectory.init("db");
+    defer path_tmp.cleanup();
+    const path = path_tmp.path().ptr;
     defer cleanupTempDir(path);
 
     {

--- a/zig/pkg/antfly/src/storage/db/generation_lifecycle.zig
+++ b/zig/pkg/antfly/src/storage/db/generation_lifecycle.zig
@@ -1918,17 +1918,27 @@ pub fn hasPublishedGenerationRead(path: []const u8) !bool {
 
 test "generation lifecycle serializes the same root and validates capability target" {
     const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    // Keep roots inside the fixture so cleanup also removes their sibling locks.
+    const path = try std.fmt.allocPrint(alloc, ".zig-cache/tmp/{s}/table-a", .{tmp.sub_path});
+    defer alloc.free(path);
+    const path_alias = try std.fmt.allocPrint(alloc, ".zig-cache/tmp/{s}/../{s}/table-a", .{ tmp.sub_path, tmp.sub_path });
+    defer alloc.free(path_alias);
+    const other_path = try std.fmt.allocPrint(alloc, ".zig-cache/tmp/{s}/table-b", .{tmp.sub_path});
+    defer alloc.free(other_path);
+
     var manager = Manager.init(alloc);
     defer manager.deinit();
 
-    var first = try manager.beginExclusive("/tmp/table-a");
+    var first = try manager.beginExclusive(path);
     defer first.deinit();
-    try first.validate("/tmp/table-a");
-    try std.testing.expectError(error.InvalidGenerationTransition, first.validate("/tmp/table-b"));
-    try std.testing.expectError(error.GenerationTransitionActive, manager.beginExclusive("/tmp/table-a"));
-    try std.testing.expectError(error.GenerationTransitionActive, manager.beginExclusive("/tmp/../tmp/table-a"));
+    try first.validate(path);
+    try std.testing.expectError(error.InvalidGenerationTransition, first.validate(other_path));
+    try std.testing.expectError(error.GenerationTransitionActive, manager.beginExclusive(path));
+    try std.testing.expectError(error.GenerationTransitionActive, manager.beginExclusive(path_alias));
 
-    var other = try manager.beginExclusive("/tmp/table-b");
+    var other = try manager.beginExclusive(other_path);
     other.deinit();
 }
 
@@ -1988,27 +1998,38 @@ test "generation lifecycle returns cross-manager filesystem lock contention" {
 
 test "generation lifecycle retains shared readers until the final owner closes" {
     const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const path = try std.fmt.allocPrint(alloc, ".zig-cache/tmp/{s}/table-readers", .{tmp.sub_path});
+    defer alloc.free(path);
+    const path_alias = try std.fmt.allocPrint(alloc, ".zig-cache/tmp/{s}/../{s}/table-readers", .{ tmp.sub_path, tmp.sub_path });
+    defer alloc.free(path_alias);
+
     var manager = Manager.init(alloc);
     defer manager.deinit();
 
-    var first = try manager.beginRead("/tmp/table-readers");
-    var second = try manager.beginRead("/tmp/../tmp/table-readers");
+    var first = try manager.beginRead(path);
+    var second = try manager.beginRead(path_alias);
     try std.testing.expectEqual(@as(usize, 1), manager.path_states.count());
     const state = manager.path_states.get(first.path_key) orelse return error.TestUnexpectedResult;
     try std.testing.expectEqual(@as(usize, 2), state.readers);
-    try std.testing.expectError(error.GenerationTransitionActive, manager.beginExclusive("/tmp/table-readers"));
+    try std.testing.expectError(error.GenerationTransitionActive, manager.beginExclusive(path));
 
     first.deinit();
-    try std.testing.expectError(error.GenerationTransitionActive, manager.beginExclusive("/tmp/table-readers"));
+    try std.testing.expectError(error.GenerationTransitionActive, manager.beginExclusive(path));
     second.deinit();
     try std.testing.expectEqual(@as(usize, 0), manager.path_states.count());
 
-    var transition = try manager.beginExclusive("/tmp/table-readers");
+    var transition = try manager.beginExclusive(path);
     transition.deinit();
 }
 
 test "serving reconciliation serializes with exclusive generation transition" {
-    const path = "/tmp/antfly-generation-reconciliation-serialization";
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const path = try std.fmt.allocPrint(alloc, ".zig-cache/tmp/{s}/reconciliation-serialization", .{tmp.sub_path});
+    defer alloc.free(path);
     var reconciliation = (try process_manager.beginReconciliation(path)) orelse return error.TestUnexpectedResult;
     defer reconciliation.deinit();
 
@@ -2046,17 +2067,23 @@ test "reconciliation cache canonicalizes aliases for transition invalidation" {
 
 test "reconciliation cache expires when the final reader drains" {
     const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const path = try std.fmt.allocPrint(alloc, ".zig-cache/tmp/{s}/reconciliation-reader-cache", .{tmp.sub_path});
+    defer alloc.free(path);
+    const canonical_path = try canonicalPathAlloc(alloc, path);
+    defer alloc.free(canonical_path);
+
     var manager = Manager.init(alloc);
     defer manager.deinit();
 
-    const path = "/tmp/antfly-generation-reconciliation-reader-cache";
     var reconciliation = (try manager.beginReconciliation(path)) orelse return error.TestUnexpectedResult;
     try manager.promoteReconciliationToRead(path, reconciliation.id, true);
     reconciliation.active = false;
     try std.testing.expect(manager.reconciled_paths.contains(reconciliation.path_key));
 
     manager.finishRead(path, reconciliation.id);
-    try std.testing.expect(!manager.reconciled_paths.contains(path));
+    try std.testing.expect(!manager.reconciled_paths.contains(canonical_path));
     try std.testing.expect((try manager.beginReadIfReconciled(path)) == null);
 }
 

--- a/zig/pkg/antfly/src/storage/lsm_backend/storage_io.zig
+++ b/zig/pkg/antfly/src/storage/lsm_backend/storage_io.zig
@@ -13,6 +13,7 @@
 // limitations.
 
 const std = @import("std");
+const TestDirectory = @import("../../common/test_directory.zig").TestDirectory;
 const Crc32 = @import("antfly_hash").Crc32;
 const platform_sync = @import("antfly_platform").sync;
 const builtin = @import("builtin");
@@ -3433,11 +3434,14 @@ test "storage range read future fallback waits and cancels" {
 test "native atomic write sink supports patching and crc before finish" {
     if (!supports_native_storage) return error.SkipZigTest;
 
+    var test_tmp = try TestDirectory.init("storage");
+    defer test_tmp.cleanup();
+
     var native = try NativeStorage.init(std.testing.allocator, .threaded);
     defer native.deinit();
 
-    var path_buf: [256]u8 = undefined;
-    const path = try std.fmt.bufPrint(&path_buf, "/tmp/antfly-storage-atomic-{d}", .{atomic_write_nonce.fetchAdd(1, .monotonic)});
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const path = try std.fmt.bufPrint(&path_buf, "{s}-antfly-storage-atomic-{d}", .{ test_tmp.path(), atomic_write_nonce.fetchAdd(1, .monotonic) });
     defer native.storage().deleteFileAbsolute(path) catch {};
 
     var writer = try native.storage().beginAtomicWrite(std.testing.allocator, path);
@@ -3476,6 +3480,9 @@ test "native storage retained runtime has a finite worker ceiling" {
 test "native fd cache retries an open that straddles a mutation fence" {
     if (!supports_posix_fd_cache or builtin.single_threaded) return error.SkipZigTest;
 
+    var test_tmp = try TestDirectory.init("storage");
+    defer test_tmp.cleanup();
+
     var pool = NativeStoragePool.initWithCapacityForTest(std.testing.allocator, 4);
     defer pool.deinit();
     var native = try NativeStorage.initWithPool(std.testing.allocator, .threaded, &pool);
@@ -3485,8 +3492,8 @@ test "native fd cache retries an open that straddles a mutation fence" {
     defer io_impl.deinit();
     const io = io_impl.io();
 
-    var path_buf: [256]u8 = undefined;
-    const path = try std.fmt.bufPrint(&path_buf, "/tmp/antfly-storage-invalidation-race-{d}", .{atomic_write_nonce.fetchAdd(1, .monotonic)});
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const path = try std.fmt.bufPrint(&path_buf, "{s}-antfly-storage-invalidation-race-{d}", .{ test_tmp.path(), atomic_write_nonce.fetchAdd(1, .monotonic) });
     defer native.storage().deleteFileAbsolute(path) catch {};
     try native.storage().writeFileAbsolute(path, "old");
 
@@ -3547,14 +3554,17 @@ test "native fd cache retries an open that straddles a mutation fence" {
 test "native fd cache invalidates a deleted tree spelled with trailing separators" {
     if (!supports_posix_fd_cache) return error.SkipZigTest;
 
+    var test_tmp = try TestDirectory.init("storage");
+    defer test_tmp.cleanup();
+
     var pool = NativeStoragePool.initWithCapacityForTest(std.testing.allocator, 8);
     defer pool.deinit();
     var native = try NativeStorage.initWithPool(std.testing.allocator, .threaded, &pool);
     defer native.deinit();
 
     const nonce = atomic_write_nonce.fetchAdd(1, .monotonic);
-    var root_buf: [256]u8 = undefined;
-    const root = try std.fmt.bufPrint(&root_buf, "/tmp/antfly-storage-tree-invalidation-{d}", .{nonce});
+    var root_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root = try std.fmt.bufPrint(&root_buf, "{s}-antfly-storage-tree-invalidation-{d}", .{ test_tmp.path(), nonce });
     defer native.storage().deleteTree(root) catch {};
     try native.storage().createDirPath(root);
 
@@ -3588,13 +3598,16 @@ test "path containment handles root and trailing separators" {
 test "native atomic write finish retains admission through parent sync" {
     if (!supports_posix_fd_cache) return error.SkipZigTest;
 
+    var test_tmp = try TestDirectory.init("storage");
+    defer test_tmp.cleanup();
+
     var pool = NativeStoragePool.initWithCapacityForTest(std.testing.allocator, 4);
     defer pool.deinit();
     var native = try NativeStorage.initWithPool(std.testing.allocator, .threaded, &pool);
     defer native.deinit();
 
-    var path_buf: [256]u8 = undefined;
-    const path = try std.fmt.bufPrint(&path_buf, "/tmp/antfly-storage-atomic-admission-handoff-{d}", .{atomic_write_nonce.fetchAdd(1, .monotonic)});
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const path = try std.fmt.bufPrint(&path_buf, "{s}-antfly-storage-atomic-admission-handoff-{d}", .{ test_tmp.path(), atomic_write_nonce.fetchAdd(1, .monotonic) });
     defer native.storage().deleteFileAbsolute(path) catch {};
 
     var writer = try native.storage().beginAtomicWrite(std.testing.allocator, path);
@@ -3623,13 +3636,16 @@ test "native atomic write finish retains admission through parent sync" {
 
 test "native atomic write sink cleans temporary file when content sync fails" {
     if (!supports_native_storage) return error.SkipZigTest;
+
+    var test_tmp = try TestDirectory.init("storage");
+    defer test_tmp.cleanup();
     if (builtin.os.tag == .windows or builtin.os.tag == .wasi or builtin.os.tag == .freestanding) return error.SkipZigTest;
 
     var native = try NativeStorage.init(std.testing.allocator, .threaded);
     defer native.deinit();
 
-    var path_buf: [256]u8 = undefined;
-    const path = try std.fmt.bufPrint(&path_buf, "/tmp/antfly-storage-atomic-sync-failure-{d}", .{atomic_write_nonce.fetchAdd(1, .monotonic)});
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const path = try std.fmt.bufPrint(&path_buf, "{s}-antfly-storage-atomic-sync-failure-{d}", .{ test_tmp.path(), atomic_write_nonce.fetchAdd(1, .monotonic) });
     defer native.storage().deleteFileAbsolute(path) catch {};
 
     var writer = try native.storage().beginAtomicWrite(std.testing.allocator, path);
@@ -3679,6 +3695,9 @@ test "buffered atomic write sink supports overlapping writes and appends" {
 test "native fd cache evicts to per-store budget" {
     if (!supports_posix_fd_cache) return error.SkipZigTest;
 
+    var test_tmp = try TestDirectory.init("storage");
+    defer test_tmp.cleanup();
+
     var pool = NativeStoragePool.initWithCapacityForTest(std.testing.allocator, fallback_cached_native_fds);
     defer pool.deinit();
     var native = try NativeStorage.initWithPool(std.testing.allocator, .threaded, &pool);
@@ -3686,8 +3705,8 @@ test "native fd cache evicts to per-store budget" {
 
     const base_nonce = atomic_write_nonce.fetchAdd(1, .monotonic);
     for (0..fallback_cached_native_fds + 8) |i| {
-        var path_buf: [256]u8 = undefined;
-        const path = try std.fmt.bufPrint(&path_buf, "/tmp/antfly-storage-fd-cache-{d}-{d}", .{ base_nonce, i });
+        var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+        const path = try std.fmt.bufPrint(&path_buf, "{s}-antfly-storage-fd-cache-{d}-{d}", .{ test_tmp.path(), base_nonce, i });
         try native.storage().writeFileAbsolute(path, "x");
         defer native.storage().deleteFileAbsolute(path) catch {};
 
@@ -3732,6 +3751,9 @@ test "backend runtime native fd pools share one process admission domain" {
 test "transient native writes wait before opening at descriptor capacity" {
     if (!supports_posix_fd_cache or builtin.single_threaded) return error.SkipZigTest;
 
+    var test_tmp = try TestDirectory.init("storage");
+    defer test_tmp.cleanup();
+
     var pool = NativeStoragePool.initWithCapacityForTest(std.testing.allocator, 2);
     defer pool.deinit();
     var native = try NativeStorage.initWithPool(std.testing.allocator, .threaded, &pool);
@@ -3741,8 +3763,8 @@ test "transient native writes wait before opening at descriptor capacity" {
     const io = io_impl.io();
 
     const nonce = atomic_write_nonce.fetchAdd(1, .monotonic);
-    var path_buf: [256]u8 = undefined;
-    const path = try std.fmt.bufPrint(&path_buf, "/tmp/antfly-storage-transient-admission-{d}", .{nonce});
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const path = try std.fmt.bufPrint(&path_buf, "{s}-antfly-storage-transient-admission-{d}", .{ test_tmp.path(), nonce });
     defer native.storage().deleteFileAbsolute(path) catch {};
 
     var occupying_permit = try native.acquireFdPermit();
@@ -3790,6 +3812,9 @@ test "transient native writes wait before opening at descriptor capacity" {
 test "persistent path locks use reserved headroom under transient saturation" {
     if (!supports_posix_fd_cache) return error.SkipZigTest;
 
+    var test_tmp = try TestDirectory.init("storage");
+    defer test_tmp.cleanup();
+
     var pool = NativeStoragePool.initWithCapacityForTest(std.testing.allocator, 8);
     defer pool.deinit();
     var io_impl = std.Io.Threaded.init(std.testing.allocator, .{});
@@ -3801,8 +3826,8 @@ test "persistent path locks use reserved headroom under transient saturation" {
     defer pool.fd_cache.releaseDescriptors(io, held_descriptors);
 
     const nonce = atomic_write_nonce.fetchAdd(1, .monotonic);
-    var path_buf: [256]u8 = undefined;
-    const path = try std.fmt.bufPrint(&path_buf, "/tmp/antfly-storage-path-lock-admission-{d}", .{nonce});
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const path = try std.fmt.bufPrint(&path_buf, "{s}-antfly-storage-path-lock-admission-{d}", .{ test_tmp.path(), nonce });
     defer deleteFilePathPosix(path) catch {};
 
     var lock_file = try openNativePathLockFileWithCache(
@@ -3821,6 +3846,9 @@ test "persistent path locks use reserved headroom under transient saturation" {
 test "persistent path lock exhaustion fails without waiting" {
     if (!supports_posix_fd_cache) return error.SkipZigTest;
 
+    var test_tmp = try TestDirectory.init("storage");
+    defer test_tmp.cleanup();
+
     var pool = NativeStoragePool.initWithCapacityForTest(std.testing.allocator, 2);
     defer pool.deinit();
     var io_impl = std.Io.Threaded.init(std.testing.allocator, .{});
@@ -3830,8 +3858,8 @@ test "persistent path lock exhaustion fails without waiting" {
     defer pool.fd_cache.releasePersistentDescriptors(io, 2);
 
     const nonce = atomic_write_nonce.fetchAdd(1, .monotonic);
-    var path_buf: [256]u8 = undefined;
-    const path = try std.fmt.bufPrint(&path_buf, "/tmp/antfly-storage-path-lock-exhaustion-{d}", .{nonce});
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const path = try std.fmt.bufPrint(&path_buf, "{s}-antfly-storage-path-lock-exhaustion-{d}", .{ test_tmp.path(), nonce });
     defer deleteFilePathPosix(path) catch {};
 
     try std.testing.expectError(
@@ -3873,14 +3901,17 @@ test "transient admission fails fast when only persistent descriptors prevent pr
 test "persistent path locks honor an explicitly configured pool" {
     if (!supports_posix_fd_cache) return error.SkipZigTest;
 
+    var test_tmp = try TestDirectory.init("storage");
+    defer test_tmp.cleanup();
+
     var pool = NativeStoragePool.initWithCapacityForTest(std.testing.allocator, 2);
     defer pool.deinit();
     const nonce = atomic_write_nonce.fetchAdd(1, .monotonic);
-    var first_buf: [256]u8 = undefined;
-    const first_path = try std.fmt.bufPrint(&first_buf, "/tmp/antfly-storage-configured-lock-pool-{d}-first", .{nonce});
+    var first_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const first_path = try std.fmt.bufPrint(&first_buf, "{s}-antfly-storage-configured-lock-pool-{d}-first", .{ test_tmp.path(), nonce });
     defer deleteFilePathPosix(first_path) catch {};
-    var second_buf: [256]u8 = undefined;
-    const second_path = try std.fmt.bufPrint(&second_buf, "/tmp/antfly-storage-configured-lock-pool-{d}-second", .{nonce});
+    var second_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const second_path = try std.fmt.bufPrint(&second_buf, "{s}-antfly-storage-configured-lock-pool-{d}-second", .{ test_tmp.path(), nonce });
     defer deleteFilePathPosix(second_path) catch {};
 
     var first = try openNativePathLockFileWithPool(
@@ -3933,6 +3964,9 @@ test "persistent locks consume reserved headroom without stranding transient cap
 test "shared native fd cache blocks before opening more than 64 files across stores" {
     if (!supports_posix_fd_cache or builtin.single_threaded) return error.SkipZigTest;
 
+    var test_tmp = try TestDirectory.init("storage");
+    defer test_tmp.cleanup();
+
     const capacity = 64;
     const worker_count = capacity + 8;
     const store_count = 3;
@@ -3951,10 +3985,10 @@ test "shared native fd cache blocks before opening more than 64 files across sto
     }
 
     const nonce = atomic_write_nonce.fetchAdd(1, .monotonic);
-    var paths: [worker_count][256]u8 = undefined;
+    var paths: [worker_count][std.fs.max_path_bytes]u8 = undefined;
     var path_lens: [worker_count]usize = undefined;
     for (0..worker_count) |i| {
-        const path = try std.fmt.bufPrint(&paths[i], "/tmp/antfly-storage-shared-fd-cache-{d}-{d}", .{ nonce, i });
+        const path = try std.fmt.bufPrint(&paths[i], "{s}-antfly-storage-shared-fd-cache-{d}-{d}", .{ test_tmp.path(), nonce, i });
         path_lens[i] = path.len;
         try stores[i % store_count].storage().writeFileAbsolute(path, "x");
     }
@@ -4132,6 +4166,9 @@ test "weighted native fd admission preserves FIFO progress" {
 test "shared native fd admission wait is cancellation aware" {
     if (!supports_posix_fd_cache or builtin.single_threaded) return error.SkipZigTest;
 
+    var test_tmp = try TestDirectory.init("storage");
+    defer test_tmp.cleanup();
+
     var pool = NativeStoragePool.initWithCapacityForTest(std.testing.allocator, 2);
     defer pool.deinit();
     var native = try NativeStorage.initWithPool(std.testing.allocator, .threaded, &pool);
@@ -4140,8 +4177,8 @@ test "shared native fd admission wait is cancellation aware" {
     defer io_impl.deinit();
     const io = io_impl.io();
     const nonce = atomic_write_nonce.fetchAdd(1, .monotonic);
-    var second_path_buf: [256]u8 = undefined;
-    const second_path = try std.fmt.bufPrint(&second_path_buf, "/tmp/antfly-storage-fd-cancel-{d}-waiting", .{nonce});
+    var second_path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const second_path = try std.fmt.bufPrint(&second_path_buf, "{s}-antfly-storage-fd-cancel-{d}-waiting", .{ test_tmp.path(), nonce });
     try native.storage().writeFileAbsolute(second_path, "b");
     defer native.storage().deleteFileAbsolute(second_path) catch {};
 
@@ -4190,8 +4227,11 @@ test "native storage state is reclaimed after owner deinit" {
 test "native storage lease owns state past owner deinit" {
     if (!supports_native_storage) return error.SkipZigTest;
 
-    var path_buf: [256]u8 = undefined;
-    const path = try std.fmt.bufPrint(&path_buf, "/tmp/antfly-storage-owned-lease-{d}", .{atomic_write_nonce.fetchAdd(1, .monotonic)});
+    var test_tmp = try TestDirectory.init("storage");
+    defer test_tmp.cleanup();
+
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const path = try std.fmt.bufPrint(&path_buf, "{s}-antfly-storage-owned-lease-{d}", .{ test_tmp.path(), atomic_write_nonce.fetchAdd(1, .monotonic) });
 
     var native = try NativeStorage.init(std.testing.allocator, .threaded);
     var lease = try native.acquireLease();
@@ -4208,10 +4248,13 @@ test "native storage lease owns state past owner deinit" {
 
 test "native atomic write sink retains invalidation state past storage deinit" {
     if (!supports_native_storage) return error.SkipZigTest;
+
+    var test_tmp = try TestDirectory.init("storage");
+    defer test_tmp.cleanup();
     if (builtin.os.tag == .windows or builtin.os.tag == .wasi or builtin.os.tag == .freestanding) return error.SkipZigTest;
 
-    var path_buf: [256]u8 = undefined;
-    const path = try std.fmt.bufPrint(&path_buf, "/tmp/antfly-storage-atomic-lease-{d}", .{atomic_write_nonce.fetchAdd(1, .monotonic)});
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const path = try std.fmt.bufPrint(&path_buf, "{s}-antfly-storage-atomic-lease-{d}", .{ test_tmp.path(), atomic_write_nonce.fetchAdd(1, .monotonic) });
 
     var native = try NativeStorage.init(std.testing.allocator, .threaded);
     var writer = try native.storage().beginAtomicWrite(std.testing.allocator, path);
@@ -4235,10 +4278,13 @@ test "native atomic write sink retains invalidation state past storage deinit" {
 
 test "native buffered atomic write sink retains invalidation state past storage deinit" {
     if (!supports_native_storage) return error.SkipZigTest;
+
+    var test_tmp = try TestDirectory.init("storage");
+    defer test_tmp.cleanup();
     if (builtin.os.tag == .windows or builtin.os.tag == .wasi or builtin.os.tag == .freestanding) return error.SkipZigTest;
 
-    var path_buf: [256]u8 = undefined;
-    const path = try std.fmt.bufPrint(&path_buf, "/tmp/antfly-storage-buffered-atomic-lease-{d}", .{atomic_write_nonce.fetchAdd(1, .monotonic)});
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const path = try std.fmt.bufPrint(&path_buf, "{s}-antfly-storage-buffered-atomic-lease-{d}", .{ test_tmp.path(), atomic_write_nonce.fetchAdd(1, .monotonic) });
 
     var native = try NativeStorage.init(std.testing.allocator, .threaded);
     var writer = try NativeBufferedAtomicWriteSink.create(std.testing.allocator, path, native.state);


### PR DESCRIPTION
Zig tests left generation and Lite lock files behind because cleanup removed only the database directory or `.aflite` file. Fixed `/tmp` names also let concurrent test runs share or delete each other's fixtures. Raft snapshot tests left their directories behind entirely.

Use owned `std.testing.tmpDir` parents, with database/file paths nested inside so cleanup includes sibling locks and staging artifacts:

- Add a test-only `TestDirectory` helper exposing an absolute, null-terminated child path. Migrate 838 DB fixture allocations, the concrete HTTP/table-read/table-write fixtures, C API fixtures, and native storage-I/O fixtures.
- Move the remaining generation-lifecycle fixtures and six Raft snapshot fixtures into Zig temporary directories. Nest the three embedded API database roots below their existing temporary directories.
- Establish fixture-parent durability explicitly in the modeled DB crash tests; their old `/tmp` parent was implicitly durable.
- Collect the three embedded API fixtures in `embedded-test`. Supply missing module dependencies and correct the stale pointer argument in `liteStatus` needed to compile these previously uncollected tests.

Validation:

- Full DB selection: **794 passed, 6 skipped, 0 failed, 0 allocator leaks**.
- Native storage-I/O selection: **27 passed**.
- Default C API plus embedded targets: **15 passed**, including the three embedded API fixtures.
- Targeted Raft snapshot tests: **6 passed**; temporary-directory isolation/sibling-cleanup regression: **1 passed**.
- Original generation-lifecycle change: **27 passed**.
- Formatting and `git diff --check` passed.

The 143 affected API fixture tests yielded **122 passes, 19 failures, and 2 crashes**. Every failure and crash was reproduced on the original PR revision (`c3be3e370`) in a separate worktree, including the same 18 failures and chunking assertion in the main batch, plus the restore writer conflict and create-table crash in separate runs. An extended C API readable-lease-hook check also aborts on both revisions. These pre-existing failures are outside the temporary-fixture cleanup; the default C API target passes.
