### PR TITLE
fix: preserve metadata Raft cadence and backup create admission

### DIFF
--- a/zig/e2e/FLAKES.md
+++ b/zig/e2e/FLAKES.md
@@ -13,6 +13,7 @@ entries so later failures can be compared with the original signature.
 | `test_backup_restore.py::test_three_by_three_cluster_backup_restore_through_metadata_public_api` | [PR #658, run 34177703845, job 101916669107](https://github.com/antflydb/antfly/actions/runs/34177703845/job/101916669107?pr=658), head [`96bee1e80`](https://github.com/antflydb/antfly/commit/96bee1e80cf115c2dc636ed065a0378d8cfb27f3) | [`1bf7230cc`](https://github.com/antflydb/antfly/commit/1bf7230cc74c37ba4263964719542c210ff9473d) | Write-admission handling fixed; 30/30 soak runs passed. |
 | `test_cli.py::test_cli_inline_create_load_wait_query_image_and_rag_pipeline` | [PR #658, run 34177703845, job 101916669107](https://github.com/antflydb/antfly/actions/runs/34177703845/job/101916669107?pr=658), head [`96bee1e80`](https://github.com/antflydb/antfly/commit/96bee1e80cf115c2dc636ed065a0378d8cfb27f3) | [`1bf7230cc`](https://github.com/antflydb/antfly/commit/1bf7230cc74c37ba4263964719542c210ff9473d) | Readiness assertion fixed; 30/30 soak runs passed. |
 | Same CLI pipeline, retry-exhaustion phase (`settled_failure is not None`) | [PR #659, run 34182855053, job 101932868141](https://github.com/antflydb/antfly/actions/runs/34182855053/job/101932868141), head [`51ec7a551`](https://github.com/antflydb/antfly/commit/51ec7a551aa3ac5713eb243155a9e2c9d8cfa0ac) | [`19b988108`](https://github.com/antflydb/antfly/commit/19b9881080af1dbc805f9ad5bda096b62bf063b1) | Reproduced in 3/3 concurrent runs with real retry sleeps; corrected-budget soak passed 9/9. |
+| Same three-by-three backup test, initial table create | [PR #664, run 34263167199, job 102199089027](https://github.com/antflydb/antfly/actions/runs/34263167199/job/102199089027?pr=664), merge `d6108b73b85a8e77dfcb740d5518279b2a51d826` | This change | Read waiter clock and pre-admission handling fixed; 100/100 Debug soak runs passed. |
 
 ### Retrieval streaming teardown
 
@@ -57,6 +58,61 @@ shard payloads in the backup, and restored documents through every data node.
 Harness regressions cover eventual admission, retry classification, deadline
 diagnostics, and process exit. The specific CI rejection has not been
 reproduced naturally in the local soak.
+
+### Three-by-three backup table creation: unknown outcome
+
+The #664 recurrence failed earlier than the seeding case above: the initial
+`POST /db/v1/tables/metadata_leader_backup_<unique suffix>` returned HTTP 409,
+`table mutation outcome is unknown; observe table state before retrying`.
+The job reported 352 passed, five skipped, and this one failure. Its failure
+log did not contain the cluster diagnostics needed to locate the failure.
+The test now attaches all six server log tails when that initial create fails.
+
+Investigation found that `MetadataHttpService.ensureLinearizableReadWithContext`
+ran a **ticking** Raft round on each iteration of its 1 ms polling loop. The
+runtime also has a dedicated cadence driver. Read traffic could therefore
+advance elections, heartbeats, and virtual time independently of elapsed time.
+A captured stack showed a routing read executing this path; the accompanying
+runtime diagnostics reported virtual time well ahead of elapsed time.
+
+The fix uses the existing progress-only Raft operations in
+that read loop, including pending-update synchronization. The dedicated ticker
+continues to own election and heartbeat time. ReadIndex requests, quorum
+requirements, request deadlines, and the E2E create-success assertion remain
+unchanged. Unknown outcomes remain non-retryable; this fix does not turn a 409
+into success or replay a possibly committed mutation.
+
+The local investigation also exposed socket pressure under three concurrent
+six-node clusters: `AddressUnavailable` in data control rounds and Python
+`EADDRNOTAVAIL`, with 45,747 TCP sockets in `TIME_WAIT`. Changing the fixture's
+5 ms ticks to the runtime's 100 ms defaults did not solve the issue: that probe
+reproduced the create 409 near the forwarding deadline. No cadence override
+change is included in the fix.
+
+A deterministic regression starts without a leader and gives a read waiter a
+50 ms deadline. Before the fix, that waiter advanced virtual time from zero to
+3,800 ms. With the fix, it times out without advancing time or electing itself.
+The test then advances the dedicated cadence driver, verifies leader election,
+and completes a ReadIndex request without any further virtual-time advance.
+This proves the clock ownership bug; the original CI log alone cannot establish
+which internal timeout produced its 409.
+
+The first Debug soak then exposed a distinct initial-create failure:
+`503 metadata_leader_unavailable`. The server's
+`metadataMutationNotAdmittedResponse` marks this response with
+`X-Antfly-Metadata-Mutation-Not-Admitted: true`, a stronger guarantee than a
+leader-routing hint. Even a quorum-backed leader observation cannot reserve
+mutation authority for a subsequent request. The fixture now honors this
+pre-admission contract within the original 30-second create budget, using a
+one-second backoff and the remaining budget for each request.
+
+Retry requires HTTP 503, that explicit non-admission marker, the exact
+`metadata_leader_unavailable` code, and `retryable: true`. A contradictory
+unknown/committed outcome marker forbids retry. Transport errors, unmarked
+503s, ambiguous 409s, and process exits still fail. The create must return a
+successful response, and every replication, backup payload, and restore
+assertion remains. Recovered admission attempts are printed in the soak log;
+failures retain the last status, headers, body, and all server log tails.
 
 ### CLI image readiness
 
@@ -177,3 +233,64 @@ counts, failing node IDs, and preserved diagnostics when adding a new result.
 Both soaks used `scripts/ci/zig-e2e-regression-loop.sh` with `SKIP_BUILD=1`,
 `ANTFLY_BIN` set to the executable above, and the corresponding test node ID.
 These are local macOS results; Linux CI remains the cross-platform check.
+
+### Follow-up validation for #664
+
+2026-09-08 (America/Los_Angeles), macOS ARM64, based on `origin/main`
+[`fea3e6611`](https://github.com/antflydb/antfly/commit/fea3e66111a3f39f8cc95a8c71e31d6e30f2dc5f),
+in `.worktrees/fix-metadata-backup-create-flake`:
+
+- The native **Debug** build passed. Executable SHA-256:
+  `65576850a6cbb3d934c8d158138a39dfa7d16f3cab79d80d7c5e0dcadf03611f`.
+- **75 metadata service tests passed** in Debug, with zero leaks, including
+  the read waiter clock regression. **114 Python harness, scheduler, and
+  leader-discovery checks passed**.
+- Original 5 ms fixture cadence, three workers × ten repetitions:
+  **29/30 passed**. No unknown-outcome 409 recurred. Worker 2, iteration 2
+  failed at initial create with the explicit pre-admission JSON response
+  `503 metadata_leader_unavailable` for
+  `metadata_leader_backup_1788900153771408000` through data node 4.
+  This exposed the admission handling gap addressed next; this initial result
+  is not a clean soak.
+- A temporary probe removed only the fixture's `--raft-tick-ms` and
+  `--control-tick-ms` overrides, retaining the original test assertions.
+  At the runtime's 100 ms defaults, **9/9 passed** (three workers × three
+  repetitions). Before the fix, this probe failed 9/9 with five initial-create
+  unknown-outcome 409s. That earlier executable was ReleaseSafe, so the E2E
+  comparison also changes optimization mode; the deterministic clock
+  regression supplies the isolated evidence for the production bug.
+- With the admission helper, **132 fast checks passed**, including 18 new
+  cases covering safe admission retry, successful 200/202 responses, deadline
+  exhaustion, backoff overshoot, process exit, and refusal to replay unmarked,
+  malformed, conflicting, transport-failed, or ambiguous outcomes.
+- Final original-cadence Debug soak with the admission helper:
+  **100/100 passed**, four workers × 25 repetitions. No initial-create retries
+  occurred in this batch; the deterministic harness cases exercise the
+  recovered 503 path. The executable is unchanged from the initial Debug soak.
+
+Build and correctness commands, from `zig/`:
+
+```sh
+python3 tools/run_bounded_zig_build.py --zig zig -- build antfly -Doptimize=Debug -fincremental
+python3 tools/run_bounded_zig_build.py --zig zig -- build lib-metadata-test -Doptimize=Debug -- metadata.service.
+```
+
+Final original-cadence soak, from the worktree root (the initial 30-run batch
+used three workers and ten repetitions):
+
+```sh
+SKIP_BUILD=1 ANTFLY_E2E_ENV_LOADED=1 \
+ANTFLY_E2E_REGRESSION_WORKERS=4 ANTFLY_E2E_REGRESSION_REPEATS=25 \
+ANTFLY_E2E_PRESERVE_FAILURE_LIMIT=2 \
+scripts/ci/zig-e2e-regression-loop.sh \
+  e2e/antfly/test_backup_restore.py::test_three_by_three_cluster_backup_restore_through_metadata_public_api
+```
+
+Local logs, the temporary comparison sources, and the failed six-node runtime
+root are retained under the worktree's ignored
+`.benchmark-results/metadata-backup-flake/` directory. In particular,
+`soak-debug.log` records all 30 original-cadence outcomes and
+`soak-debug-runtime-cadence.log` records the nine comparison outcomes.
+`soak-debug-100.log` records all 100 final passing executions.
+The probe sources are not part of test collection. Linux CI validation remains
+outstanding.

--- a/zig/e2e/antfly/test_backup_restore.py
+++ b/zig/e2e/antfly/test_backup_restore.py
@@ -285,6 +285,68 @@ def _check_response(response: requests.Response) -> dict:
     return payload
 
 
+def _create_cluster_table_when_admitted(
+    cluster,
+    session: requests.Session,
+    table_name: str,
+    definition: dict,
+    *,
+    timeout_s=30.0,
+) -> dict:
+    # Leader observations do not reserve mutation authority. Replay only an
+    # explicit pre-admission rejection; an unknown outcome may have committed.
+    deadline = time.monotonic() + timeout_s
+    attempts = 0
+    last_response: requests.Response | None = None
+    try:
+        while True:
+            cluster.assert_processes_alive()
+            remaining = deadline - time.monotonic()
+            assert remaining > 0, "table create admission deadline exceeded"
+            attempts += 1
+            last_response = session.post(
+                f"{cluster.data_api_urls[0]}/tables/{table_name}",
+                json=definition,
+                timeout=remaining,
+            )
+            cluster.assert_processes_alive()
+            retryable = False
+            if (
+                last_response.status_code == 503
+                and last_response.headers.get(
+                    "X-Antfly-Metadata-Mutation-Not-Admitted", ""
+                ).lower()
+                == "true"
+                and last_response.headers.get("X-Antfly-Raft-Mutation-Outcome")
+                in (None, "not-proposed-v1")
+            ):
+                try:
+                    payload = last_response.json()
+                except ValueError:
+                    payload = None
+                retryable = (
+                    isinstance(payload, dict)
+                    and payload.get("code") == "metadata_leader_unavailable"
+                    and payload.get("retryable") is True
+                )
+            if not retryable:
+                result = _check_response(last_response)
+                if attempts > 1:
+                    print(f"backup table create admitted after {attempts} attempts")
+                return result
+            # This response advertises Retry-After: 1. Keep backoff and every
+            # subsequent request within the original create request budget.
+            time.sleep(min(1.0, max(0.0, deadline - time.monotonic())))
+    except (AssertionError, requests.RequestException) as exc:
+        raise AssertionError(
+            f"backup table create failed after {attempts} attempts: {exc}; "
+            f"last_status={last_response.status_code if last_response is not None else None}; "
+            f"last_headers={dict(last_response.headers) if last_response is not None else None}; "
+            f"last_response={last_response.text if last_response is not None else None}\n"
+            f"{cluster.debug_logs()}"
+        ) from exc
+
+
 def _seed_cluster_docs_when_writable(
     cluster, session: requests.Session, table_name: str, docs: dict, *, timeout_s=30.0
 ) -> dict:
@@ -1432,12 +1494,11 @@ def test_three_by_three_cluster_backup_restore_through_metadata_public_api(
     session.headers["Connection"] = "close"
 
     data_api_url = cluster.data_api_urls[0]
-    _check_response(
-        session.post(
-            f"{data_api_url}/tables/{table_name}",
-            json={"num_shards": 3, "description": "3x3 backup and restore docs"},
-            timeout=30,
-        )
+    _create_cluster_table_when_admitted(
+        cluster,
+        session,
+        table_name,
+        {"num_shards": 3, "description": "3x3 backup and restore docs"},
     )
 
     assert wait_until(

--- a/zig/e2e/antfly/test_standalone_harness.py
+++ b/zig/e2e/antfly/test_standalone_harness.py
@@ -492,12 +492,14 @@ def _seed_cluster(monkeypatch, outcomes):
         outcome = next(pending)
         if isinstance(outcome, Exception):
             raise outcome
-        status, body = outcome
+        status, body, *headers = outcome
         response = requests.Response()
         response.status_code = status
         response._content = body
         response.url = url
         response.request = requests.Request("POST", url).prepare()
+        if headers:
+            response.headers.update(headers[0])
         return response
 
     return (
@@ -509,6 +511,123 @@ def _seed_cluster(monkeypatch, outcomes):
         SimpleNamespace(post=post),
         calls,
     )
+
+
+def _create_not_admitted():
+    return (
+        503,
+        b'{"code":"metadata_leader_unavailable","retryable":true}',
+        {"X-Antfly-Metadata-Mutation-Not-Admitted": "true", "Retry-After": "1"},
+    )
+
+
+@pytest.mark.parametrize("success_status", [200, 202])
+def test_cluster_create_retries_only_proven_non_admission(
+    monkeypatch, capsys, success_status
+):
+    cluster, session, calls = _seed_cluster(
+        monkeypatch, [_create_not_admitted(), (success_status, b"{}")]
+    )
+    definition = {"num_shards": 3, "description": "backup"}
+    assert (
+        backups._create_cluster_table_when_admitted(
+            cluster, session, "docs", definition
+        )
+        == {}
+    )
+    assert [call["json"] for call in calls] == [definition, definition]
+    assert [call["timeout"] for call in calls] == [30.0, 29.0]
+    assert "admitted after 2 attempts" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize(
+    "outcome",
+    [
+        (
+            409,
+            b"table mutation outcome is unknown; observe table state before retrying",
+        ),
+        (409, b"table already exists"),
+        (503, _create_not_admitted()[1]),
+        (503, _create_not_admitted()[1], {"X-Antfly-Metadata-Not-Leader": "true"}),
+        (
+            503,
+            _create_not_admitted()[1],
+            {"X-Antfly-Metadata-Mutation-Not-Admitted": "false"},
+        ),
+        (
+            503,
+            _create_not_admitted()[1],
+            {
+                **_create_not_admitted()[2],
+                "X-Antfly-Raft-Mutation-Outcome": "unknown-v1",
+            },
+        ),
+        (
+            503,
+            _create_not_admitted()[1],
+            {
+                **_create_not_admitted()[2],
+                "X-Antfly-Raft-Mutation-Outcome": "committed-v1",
+            },
+        ),
+        (
+            503,
+            b'{"code":"metadata_leader_unavailable","retryable":false}',
+            _create_not_admitted()[2],
+        ),
+        (
+            503,
+            b'{"code":"different_error","retryable":true}',
+            _create_not_admitted()[2],
+        ),
+        (503, b"malformed response", _create_not_admitted()[2]),
+        (500, b"internal failure"),
+        requests.ConnectionError("response lost"),
+        requests.Timeout("request timed out"),
+    ],
+)
+def test_cluster_create_does_not_replay_uncertain_outcomes(monkeypatch, outcome):
+    cluster, session, calls = _seed_cluster(monkeypatch, [outcome])
+    with pytest.raises(AssertionError, match="cluster write diagnostics"):
+        backups._create_cluster_table_when_admitted(cluster, session, "docs", {})
+    assert len(calls) == 1
+
+
+def test_cluster_create_deadline_bounds_requests_and_retains_rejection(monkeypatch):
+    cluster, session, calls = _seed_cluster(monkeypatch, [_create_not_admitted()] * 3)
+    with pytest.raises(AssertionError, match="admission deadline exceeded") as exc:
+        backups._create_cluster_table_when_admitted(
+            cluster, session, "docs", {}, timeout_s=2.5
+        )
+    assert [call["timeout"] for call in calls] == [2.5, 1.5, 0.5]
+    assert "last_status=503" in str(exc.value)
+    assert "cluster write diagnostics" in str(exc.value)
+
+
+def test_cluster_create_does_not_send_after_backoff_overshoots_deadline(monkeypatch):
+    cluster, session, calls = _seed_cluster(monkeypatch, [_create_not_admitted()])
+    monkeypatch.setattr(
+        backups.time,
+        "sleep",
+        lambda _: monkeypatch.setattr(backups.time, "monotonic", lambda: 31.0),
+    )
+    with pytest.raises(AssertionError, match="admission deadline exceeded"):
+        backups._create_cluster_table_when_admitted(cluster, session, "docs", {})
+    assert len(calls) == 1
+
+
+def test_cluster_create_stops_when_server_exits(monkeypatch):
+    cluster, session, calls = _seed_cluster(monkeypatch, [_create_not_admitted()])
+
+    def assert_alive():
+        if calls:
+            raise RuntimeError("data server exited")
+
+    cluster.assert_processes_alive = assert_alive
+    with pytest.raises(RuntimeError, match="data server exited"):
+        backups._create_cluster_table_when_admitted(cluster, session, "docs", {})
+    assert len(calls) == 1
 
 
 def test_cluster_seed_waits_for_precommit_write_admission(monkeypatch):

--- a/zig/pkg/antfly/src/metadata/service.zig
+++ b/zig/pkg/antfly/src/metadata/service.zig
@@ -8655,10 +8655,13 @@ pub const MetadataHttpService = struct {
             self.lockRuntime();
             {
                 defer self.unlockRuntime();
+                // The cadence driver owns election and heartbeat time. A
+                // read waiter may drain inbound/Ready work, but ticking here
+                // makes the Raft clock run faster with concurrent read load.
                 if (self.raft.pending_updates.items.len > 0) {
-                    _ = try self.raft.syncPendingRaftOnly();
+                    _ = try self.raft.syncPendingRaftProgressOnly();
                 } else {
-                    try self.raft.runRaftRoundOnly();
+                    try self.raft.runRaftProgressOnly();
                 }
                 raft_diagnostics_snapshot = self.raftDiagnosticsSnapshotLocked();
                 latest_raft_diagnostics_snapshot = raft_diagnostics_snapshot;
@@ -18283,7 +18286,7 @@ test "metadata http service catalog cache is independent from volatile projectio
     try std.testing.expectError(error.ServiceClosing, svc.ensureLifecycleListenerRegistered());
 }
 
-test "metadata http service linearizable read waits for leader discovery" {
+test "metadata http service linearizable reads leave elections to the cadence driver" {
     const Factory = struct {
         alloc: std.mem.Allocator,
         store: *raft_engine.core.MemoryStorage,
@@ -18371,7 +18374,20 @@ test "metadata http service linearizable read waits for leader discovery" {
     });
 
     try std.testing.expect(!svc.raft.host.http_host.host.isLocalLeader(2910));
+    const before_discovery = svc.raft.host.http_host.host.runtime_host.virtualTimeMs();
+    try std.testing.expectError(error.DeadlineExceeded, svc.ensureLinearizableReadWithContext(.{
+        .deadline_ns = platform_time.monotonicNs() + 50 * std.time.ns_per_ms,
+    }));
+    try std.testing.expectEqual(before_discovery, svc.raft.host.http_host.host.runtime_host.virtualTimeMs());
+    try std.testing.expect(!svc.raft.host.http_host.host.isLocalLeader(2910));
+
+    // Only the cadence owner advances elections. Once it discovers a leader,
+    // the read waiter must still drain ReadIndex work without another tick.
+    for (0..20) |_| try svc.runRaftRoundOnly();
+    try std.testing.expect(svc.raft.host.http_host.host.isLocalLeader(2910));
+    const before_read = svc.raft.host.http_host.host.runtime_host.virtualTimeMs();
     try svc.ensureLinearizableRead();
+    try std.testing.expectEqual(before_read, svc.raft.host.http_host.host.runtime_host.virtualTimeMs());
     try std.testing.expect(svc.raft.host.http_host.host.isLocalLeader(2910));
     try std.testing.expect(svc.metrics().read_lease_requests > 0);
 }


### PR DESCRIPTION
The 3×3 backup test in [PR #664's CI run](https://github.com/antflydb/antfly/actions/runs/34263167199/job/102199089027?pr=664) failed during initial table creation with an ambiguous HTTP 409. Metadata HTTP read waiters were advancing Raft elections and heartbeats on every 1 ms poll despite a dedicated cadence driver. Use progress-only rounds, including pending-update synchronization, so read traffic cannot accelerate Raft time.

The clock regression reproduced 3,800 ms of virtual-time advancement during a 50 ms read deadline before the fix. It now verifies that waiting cannot elect a leader or advance time, while ReadIndex still completes after the cadence driver elects a leader.

An initial Debug soak passed 29/30 and exposed a separate explicit pre-admission 503. The backup fixture now retries only marked `metadata_leader_unavailable` rejections within its original 30-second budget. Ambiguous outcomes, transport failures, unmarked 503s, and conflicting outcome markers still fail. Replication, backup payload, and restore assertions are preserved. Failures include response and cluster diagnostics; investigation and reproduction commands are recorded in `zig/e2e/FLAKES.md`.

Validation on macOS ARM64:

- Native Debug build and 75 metadata service tests passed, with zero leaks.
- 132 fast harness, scheduler, and leader-discovery checks passed, including 18 admission cases.
- **100/100 Debug backup soak executions passed**, using `scripts/ci/zig-e2e-regression-loop.sh` with four workers × 25 repetitions and the original 5 ms fixture cadence. No initial-create retries occurred in this final batch; deterministic tests cover the 503 recovery path.
- Runtime-default cadence comparison passed 9/9. Earlier comparison failures used ReleaseSafe, so the isolated clock regression provides the causal evidence.
- `git diff --check` and Zig formatting passed.

The original CI log lacked server diagnostics, so it cannot establish which internal timeout produced its 409. Linux CI remains the cross-platform validation.
