### PR TITLE
test(metadata): respect durable backfill retry lifecycle

### DIFF
--- a/zig/pkg/antfly/src/metadata/table_provisioner.zig
+++ b/zig/pkg/antfly/src/metadata/table_provisioner.zig
@@ -1946,11 +1946,20 @@ test "target index reconciliation retires orphaned inline enrichments after dele
 }
 
 test "table provisioner durably enqueues existing corpus full text backfill" {
-    const path = "/tmp/antfly-metadata-table-provisioner-full-text-backfill";
+    try testProvisionedFullTextBackfill(false);
+}
+
+test "table provisioner full text backfill resumes after durable activation deferral" {
+    try testProvisionedFullTextBackfill(true);
+}
+
+fn testProvisionedFullTextBackfill(inject_activation_deferral: bool) !void {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const path = try std.fmt.allocPrint(std.testing.allocator, ".zig-cache/tmp/{s}/backfill", .{tmp.sub_path});
+    defer std.testing.allocator.free(path);
     var io_impl = std.Io.Threaded.init(std.testing.allocator, .{});
     defer io_impl.deinit();
-    std.Io.Dir.cwd().deleteTree(io_impl.io(), path) catch {};
-    defer std.Io.Dir.cwd().deleteTree(io_impl.io(), path) catch {};
 
     var db = try db_mod.DB.open(std.testing.allocator, path, .{
         .start_index_workers = false,
@@ -1988,16 +1997,95 @@ test "table provisioner durably enqueues existing corpus full text backfill" {
     try std.testing.expectEqual(@as(usize, 1), repeated_state.entries.items.len);
     try std.testing.expectEqual(repair_id, repeated_state.entries.items[0].intent.repair_id);
 
+    const Deferral = struct {
+        fired: bool = false,
+
+        fn afterSnapshot(_: *anyopaque, _: *db_mod.DB, _: []const u8, _: u64) !void {}
+
+        fn afterPhase(ptr: *anyopaque, _: *db_mod.DB, _: u128, phase: @import("../storage/db/derived/index_repair_state.zig").Phase) !void {
+            const self: *@This() = @ptrCast(@alignCast(ptr));
+            if (phase == .activating and !self.fired) {
+                self.fired = true;
+                // The production activation deadline returns this same error.
+                // Inject it once without depending on machine speed or sleeps.
+                return error.ShadowIndexCatchUpIncomplete;
+            }
+        }
+    };
+    var deferral = Deferral{};
+    if (inject_activation_deferral) db.shadow_index_repair_hook = .{
+        .ptr = &deferral,
+        .after_snapshot_build = Deferral.afterSnapshot,
+        .after_phase_persisted = Deferral.afterPhase,
+    };
+    defer db.shadow_index_repair_hook = null;
+
+    // This is a functional durability test, not the production 250 ms reader
+    // pause SLA. Match the storage repair tests' activation headroom, but still
+    // honor any persisted retry instead of spending a fixed number of spins.
+    const platform = @import("antfly_platform");
+    const deadline_ns = platform.time.monotonicNs() + 90 * std.time.ns_per_s;
     var repaired = false;
-    for (0..16) |_| {
-        const step = try db.advanceIndexRepairIntent(std.testing.allocator, repair_id, .{});
+    var observed_retry = false;
+    defer if (!repaired) {
+        var state = db.loadIndexRepairState(std.testing.allocator) catch null;
+        if (state) |*snapshot| {
+            defer snapshot.deinit(std.testing.allocator);
+            for (snapshot.entries.items) |entry| {
+                if (entry.intent.repair_id != repair_id) continue;
+                std.debug.print("backfill repair did not complete: phase={s} source_replay={s} attempts={d} next_retry_at_ms={d} last_error={?s}\n", .{
+                    @tagName(entry.intent.phase),  @tagName(entry.intent.source_replay_state), entry.intent.attempt_count,
+                    entry.intent.next_retry_at_ms, entry.intent.last_error,
+                });
+            }
+        }
+    };
+    while (platform.time.monotonicNs() < deadline_ns) {
+        const step = try db.advanceIndexRepairIntent(std.testing.allocator, repair_id, .{
+            .max_activation_pause_ms = 5_000,
+        });
         if (step.repaired) {
             repaired = true;
             break;
         }
         try std.testing.expect(!step.terminal);
+        const now_ms = platform.clock.Clock.real().nowRealtimeMs();
+        const retry_delay_ms = step.next_retry_at_ms -| now_ms;
+        if (retry_delay_ms != 0) {
+            observed_retry = true;
+            var pending_state = try db.loadIndexRepairState(std.testing.allocator);
+            defer pending_state.deinit(std.testing.allocator);
+            try std.testing.expectEqual(@as(usize, 1), pending_state.entries.items.len);
+            const pending = pending_state.entries.items[0];
+            try std.testing.expectEqual(repair_id, pending.intent.repair_id);
+            try std.testing.expectEqual(step.next_retry_at_ms, pending.intent.next_retry_at_ms);
+            // A retry must retain the admitted generation and its checkpoint.
+            if (deferral.fired) {
+                try std.testing.expect(pending.intent.candidate_relative_path != null);
+                try std.testing.expect(pending.intent.last_error != null);
+                try std.testing.expectEqualStrings("repair_attempt_incomplete", pending.intent.last_error.?);
+                // Advancing before the retry time must neither attempt work
+                // nor lose the persisted retry schedule.
+                const early = try db.advanceIndexRepairIntent(std.testing.allocator, repair_id, .{});
+                try std.testing.expect(early.deferred);
+                try std.testing.expect(!early.attempted);
+                try std.testing.expectEqual(step.next_retry_at_ms, early.next_retry_at_ms);
+            }
+        }
+        // Recheck realtime periodically because the durable retry timestamp is
+        // realtime, while the test's overall bound must remain monotonic.
+        while (true) {
+            const remaining_ms = (deadline_ns -| platform.time.monotonicNs()) / std.time.ns_per_ms;
+            if (remaining_ms == 0) break;
+            const retry_ms = step.next_retry_at_ms -| platform.clock.Clock.real().nowRealtimeMs();
+            const wait_ms = @min(remaining_ms, if (retry_ms != 0) @min(retry_ms, 1_000) else @as(u64, 10));
+            try io_impl.io().sleep(std.Io.Duration.fromMilliseconds(@intCast(wait_ms)), .awake);
+            if (platform.clock.Clock.real().nowRealtimeMs() >= step.next_retry_at_ms) break;
+        }
     }
     try std.testing.expect(repaired);
+    try std.testing.expectEqual(inject_activation_deferral, deferral.fired);
+    if (inject_activation_deferral) try std.testing.expect(observed_retry);
     try std.testing.expect(!try db.hasPendingIndexRepairIntents(std.testing.allocator));
 
     const complete = try reconcileDbIndexesWithOptions(std.testing.allocator, &db, indexes_json, .{});


### PR DESCRIPTION
## Summary

Fix the metadata full-text backfill test's completion contract in a separate follow-up to #663. Production activation deadlines, retry policy, and storage behavior are unchanged.

- Replace 16 immediate advancement calls with a bounded, monotonic-deadline wait that honors durable `next_retry_at_ms` timestamps and fails immediately on terminal state.
- Use the same 5-second functional-test activation headroom as the storage repair tests; the production default remains 250 ms.
- Add a deterministic activation-deferral regression using the existing repair phase hook. Verify that the repair identity, candidate checkpoint, and retry schedule survive deferral; premature advancement does not attempt work; and the repair eventually completes without a duplicate reconciliation intent.
- Isolate fixtures with unique temporary directories and print durable repair state when completion fails.

## Why

The [CI failure on #663](https://github.com/antflydb/antfly/actions/runs/34271051458/job/102213354047) exhausted the test's immediate-call loop. A normal activation deferral can persist a first retry approximately 30 seconds in the future, which those calls cannot wait out. The historical log did not include the durable intent state, so it does not conclusively identify that run's precise cause; the new regression reproduces the lifecycle that the old completion loop cannot handle.

The injected case exercises the real production backoff rather than shortening it or bypassing admission. It adds approximately 30 seconds to this test shard.

## Validation

- Debug table-provisioner shard: **45 passed, 0 failed, 0 leaked**, including normal backfill and injected durable activation deferral. Compiled `metadata_table_provisioner_test_root.zig` directly with build-derived module arguments and the `metadata.table_provisioner.` test filter.
- Repeated both backfill tests against that Debug artifact: **2 passed, 0 failed, 0 leaked**.
- `zig fmt --check pkg/antfly/src/metadata/table_provisioner.zig` and `git diff --check` passed.
- The full consolidated metadata suite was not completed locally: an earlier attempt exceeded its declared 8 GiB compiler-memory limit on this machine. The focused shard above avoids compiling the unrelated consolidated lane.
