### PR TITLE
ci: provision envsubst for cosign installer

### DIFF
--- a/.github/workflows/antfly-operator-container.yml
+++ b/.github/workflows/antfly-operator-container.yml
@@ -92,6 +92,13 @@ jobs:
               "ghcr.io/antflydb/antfly-operator:${tag}"
           done
 
+      - name: Install envsubst for cosign installer
+        run: |
+          if ! command -v envsubst >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y --no-install-recommends gettext-base
+          fi
+
       - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Sign container images with annotations (keyless)

--- a/.github/workflows/antfly-release.yml
+++ b/.github/workflows/antfly-release.yml
@@ -1014,6 +1014,12 @@ jobs:
           token_format: access_token
       - name: Install crane
         uses: imjasonh/setup-crane@feee3b6bb0d4c68370f256a4502498c9227e5c6b # v0.7
+      - name: Install envsubst for cosign installer
+        run: |
+          if ! command -v envsubst >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y --no-install-recommends gettext-base
+          fi
       - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
       - name: Commit digest-pinned container version and channel aliases
         env:

--- a/scripts/release/test_workflow_actions.py
+++ b/scripts/release/test_workflow_actions.py
@@ -117,6 +117,19 @@ class WorkflowActionPolicyTests(unittest.TestCase):
             )
             self.assertEqual(validate(root), [root / "ordinary-ci.yml"])
 
+    def test_cosign_workflows_provision_envsubst_before_installer(self) -> None:
+        workflow_dir = Path(__file__).resolve().parents[2] / ".github" / "workflows"
+        for name in ("antfly-operator-container.yml", "antfly-release.yml"):
+            with self.subTest(workflow=name):
+                workflow = (workflow_dir / name).read_text(encoding="utf-8")
+                provision = workflow.index("Install envsubst for cosign installer")
+                installer = workflow.index("uses: sigstore/cosign-installer@")
+                self.assertLess(provision, installer)
+                self.assertIn(
+                    "sudo apt-get install -y --no-install-recommends gettext-base",
+                    workflow[provision:installer],
+                )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- provision `envsubst` on stock ARC publish runners before invoking the cosign installer
- cover both the Antfly runtime promotion and operator container publication workflows
- add regression coverage for the runner-tool contract

## Why

Dependabot PR [#631](https://github.com/antflydb/antfly/pull/631), merged in [`b0b2fb800`](https://github.com/antflydb/antfly/commit/b0b2fb800), upgraded `sigstore/cosign-installer` to v4.1.2. That action now invokes `envsubst`, which is not included in the stock `ghcr.io/actions/actions-runner` image used by `arc-antfly-publish`.

Operator RC.9 built and mirrored successfully, then failed before signing in [the publication run](https://github.com/antflydb/antfly/actions/runs/33892329527). The runtime RC.5 recovery [uses the same cosign installer](https://github.com/antflydb/antfly/actions/runs/34286607793).

This keeps the stock runner image and installs the small `gettext-base` package only when `envsubst` is absent.

## Validation

- `python3 scripts/release/test_workflow_actions.py`
- `python3 scripts/release/validate_workflow_actions.py`
- `actionlint`
- `git diff --check`