### PR TITLE
release: hand off 0.2 to v0.2.x and open 0.3 on main

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -334,8 +334,9 @@ journals during recovery, but cannot create a new release candidate.
 ## Release Lines
 
 `scripts/release/release-lines.json` is the default-branch controller's map
-from a tag's `X.Y` version line to its trusted source branch. It currently maps
-`0.2` to `main`; no maintenance-branch rollout is active yet. Release tags are
+from a tag's `X.Y` version line to its trusted source branch. It maps `0.2` to
+`v0.2.x` and `0.3` to `main`. The branches share the `v0.2.1` release commit,
+`e5261e9e2937d03943b518974bf8063351ad1449`. Release tags are
 still created and pushed manually. A non-nightly tag is accepted when its
 commit belongs to the selected branch when the controller validates it. This
 keeps a tag request replayable after the branch advances. The request cannot
@@ -348,16 +349,22 @@ branches. This allows an older release built from `main` to remain verifiable
 after ownership of that line moves to its maintenance branch, without allowing
 a new tag to select a historical branch.
 
-When `main` begins 0.3 development:
+For the active release lines:
 
-1. Ensure `v0.2.x` points at the intended final shared 0.2 commit.
-2. In a reviewed change on `main`, change the `0.2` `source_ref` to
-   `refs/heads/v0.2.x`, append that ref to `trusted_source_refs` without removing
-   `refs/heads/main`, and add an active `0.3` line sourced from
-   `refs/heads/main`.
-3. Backport later 0.2 fixes through PRs into `v0.2.x`, and create canonical
-   `v0.2.*` tags only from commits in that branch. Do not merge 0.3-era `main`
-   back into the maintenance branch.
+- Backport later 0.2 fixes through PRs into `v0.2.x`, and create canonical
+  `v0.2.*` tags only from commits in that branch. Do not merge 0.3-era `main`
+  back into the maintenance branch.
+- Develop 0.3 on `main` and create canonical `v0.3.*` tags from its commits.
+- Keep both `refs/heads/main` and `refs/heads/v0.2.x` in the 0.2 line's
+  `trusted_source_refs` so releases built before the handoff remain verifiable.
+
+When `main` begins a later minor line, first create that outgoing line's
+maintenance branch at its intended final shared commit. Then, in a reviewed
+change on `main`, move the outgoing line's `source_ref` to its maintenance
+branch, append that ref to `trusted_source_refs` without removing historical
+refs, and add the new active line sourced from `refs/heads/main`. Every minor
+line needs an explicit map entry; future lines do not inherit ownership
+automatically.
 
 Privileged build and promotion policy always remains on `main`; only versioned
 release source comes from the mapped maintenance branch. Repository branch/tag

--- a/scripts/release/release-lines.json
+++ b/scripts/release/release-lines.json
@@ -2,6 +2,11 @@
   "schema_version": 2,
   "lines": {
     "0.2": {
+      "source_ref": "refs/heads/v0.2.x",
+      "trusted_source_refs": ["refs/heads/main", "refs/heads/v0.2.x"],
+      "status": "active"
+    },
+    "0.3": {
       "source_ref": "refs/heads/main",
       "trusted_source_refs": ["refs/heads/main"],
       "status": "active"

--- a/scripts/release/test_release_lines.py
+++ b/scripts/release/test_release_lines.py
@@ -16,13 +16,27 @@ class ReleaseLinePolicyTests(unittest.TestCase):
         self.policy = release_lines.load_policy()
 
     def test_active_line_resolves_from_canonical_tags(self) -> None:
-        line = release_lines.resolve_tag("v0.2.1-rc.4", self.policy)
-        self.assertEqual((line.name, line.source_ref), ("0.2", "refs/heads/main"))
-        self.assertEqual(line.trusted_source_refs, ("refs/heads/main",))
+        for tag in ("v0.2.2", "v0.2.2-rc.1"):
+            with self.subTest(tag=tag):
+                line = release_lines.resolve_tag(tag, self.policy)
+                self.assertEqual(
+                    (line.name, line.source_ref), ("0.2", "refs/heads/v0.2.x")
+                )
+                self.assertEqual(
+                    line.trusted_source_refs,
+                    ("refs/heads/main", "refs/heads/v0.2.x"),
+                )
+        for tag in ("v0.3.0", "v0.3.0-rc.1"):
+            with self.subTest(tag=tag):
+                line = release_lines.resolve_tag(tag, self.policy)
+                self.assertEqual(
+                    (line.name, line.source_ref), ("0.3", "refs/heads/main")
+                )
+                self.assertEqual(line.trusted_source_refs, ("refs/heads/main",))
 
     def test_tag_cannot_select_a_different_release_line(self) -> None:
         with self.assertRaisesRegex(SystemExit, "no trusted release line"):
-            release_lines.resolve_tag("v0.3.0-rc.1", self.policy)
+            release_lines.resolve_tag("v0.4.0-rc.1", self.policy)
 
     def test_noncanonical_and_nightly_tags_cannot_select_release_lines(self) -> None:
         for tag in ("v0.2.1-rc4", "v0.0.0-dev.12"):
@@ -47,20 +61,19 @@ class ReleaseLinePolicyTests(unittest.TestCase):
         )
 
     def test_source_handoff_preserves_historical_provenance(self) -> None:
-        policy = copy.deepcopy(self.policy)
-        policy["lines"]["0.2"]["source_ref"] = "refs/heads/v0.2.x"
-        policy["lines"]["0.2"]["trusted_source_refs"].append("refs/heads/v0.2.x")
-        release_lines.validate_policy(policy)
-
-        current = release_lines.resolve_tag("v0.2.2", policy)
+        current = release_lines.resolve_tag("v0.2.2", self.policy)
         self.assertEqual(current.source_ref, "refs/heads/v0.2.x")
-        release_lines.validate_provenance("v0.2.1", "0.2", "refs/heads/main", policy)
-        release_lines.validate_provenance("v0.2.2", "0.2", "refs/heads/v0.2.x", policy)
+        release_lines.validate_provenance(
+            "v0.2.1", "0.2", "refs/heads/main", self.policy
+        )
+        release_lines.validate_provenance(
+            "v0.2.2", "0.2", "refs/heads/v0.2.x", self.policy
+        )
 
     def test_provenance_rejects_wrong_line_or_untrusted_source(self) -> None:
         for line, source_ref in (
             ("0.3", "refs/heads/main"),
-            ("0.2", "refs/heads/v0.2.x"),
+            ("0.2", "refs/heads/v0.3.x"),
         ):
             with (
                 self.subTest(line=line, source_ref=source_ref),
@@ -85,8 +98,8 @@ class ReleaseLinePolicyTests(unittest.TestCase):
     def test_policy_rejects_invalid_or_incomplete_trusted_source_history(self) -> None:
         for trusted_source_refs in (
             [],
-            ["refs/heads/v0.2.x"],
-            ["refs/heads/main", "refs/heads/main"],
+            ["refs/heads/main"],
+            ["refs/heads/v0.2.x", "refs/heads/v0.2.x"],
             ["refs/heads/main", "refs/heads/v0.3.x"],
             ["refs/heads/main", "refs/heads/feature"],
         ):

--- a/scripts/release/test_release_promotion.py
+++ b/scripts/release/test_release_promotion.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import copy
 import hashlib
 import importlib.util
 import io
@@ -158,7 +157,7 @@ class ReleasePromotionTests(unittest.TestCase):
                 None,
             )
 
-            ledger["source_ref"] = "refs/heads/v0.2.x"
+            ledger["source_ref"] = "refs/heads/v0.3.x"
             ledger_path.write_text(json.dumps(ledger))
             with self.assertRaisesRegex(SystemExit, "release-line provenance"):
                 verifier.verify_payload(
@@ -175,10 +174,7 @@ class ReleasePromotionTests(unittest.TestCase):
             "verify_release_ledger_handoff_test", "verify_release_ledger.py"
         )
         release_lines = load_module("release_lines_handoff_test", "release_lines.py")
-        policy = copy.deepcopy(release_lines.load_policy())
-        policy["lines"]["0.2"]["source_ref"] = "refs/heads/v0.2.x"
-        policy["lines"]["0.2"]["trusted_source_refs"].append("refs/heads/v0.2.x")
-        release_lines.validate_policy(policy)
+        policy = release_lines.load_policy()
 
         with tempfile.TemporaryDirectory() as raw_tmp:
             root = Path(raw_tmp)


### PR DESCRIPTION
After the v0.2.1 release at `e5261e9e2937d03943b518974bf8063351ad1449`, route new 0.2 release tags to `v0.2.x` and open the 0.3 release line on `main`. Keep both source refs trusted for 0.2 so existing releases built from `main` remain verifiable and recoverable.

Update the release documentation and policy tests for the active branch ownership, explicit future minor-line entries, and historical ledger compatibility. Privileged release controllers continue to run from `main`.

`v0.2.x` has fast-forwarded to the release commit. The [v0.2.1 build](https://github.com/antflydb/antfly/actions/runs/34295528997) has passed controller validation and is building its platform archives. Historical source trust allows its promotion to continue after this handoff.

Validation: `scripts/ci/check.sh release` (122 Python tests plus installer and workflow checks), Ruff lint, and `git diff --check`. Formatting: `make fmt`.

Implements the handoff described in #641.
