### PR TITLE
ci: provision Python for Homebrew release preparation (v0.2.x)

### DIFF
--- a/.github/workflows/antfly-release.yml
+++ b/.github/workflows/antfly-release.yml
@@ -649,6 +649,12 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ needs.prepare-release-promotion.outputs.promotion_controller_commit }}
+      - name: Load pinned toolchain policy
+        id: toolchain
+        uses: ./.github/actions/load-toolchain-policy
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: ${{ steps.toolchain.outputs.python_build }}
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: antfly-release-runtime-archives


### PR DESCRIPTION
The v0.2.1 promotion failed while preparing the Homebrew formula because the ARC runner did not have `python` on PATH. Load the repository toolchain policy and install its pinned Python version before running the packaging checks and formula renderer.

Validation: the full `scripts/release/test.sh` suite passed (122 Python tests plus installer and workflow checks); toolchain policy validation, actionlint, and `git diff --check` passed.

The failed promotion already sealed the v0.2.1 artifacts. Recover that exact release after this controller fix reaches main; moving its tag would invalidate the sealed source identity.
