### PR TITLE
test: fix quickstart restart fixture and HA replication startup race

### DIFF
--- a/zig/e2e/FLAKES.md
+++ b/zig/e2e/FLAKES.md
@@ -14,6 +14,83 @@ entries so later failures can be compared with the original signature.
 | `test_cli.py::test_cli_inline_create_load_wait_query_image_and_rag_pipeline` | [PR #658, run 34177703845, job 101916669107](https://github.com/antflydb/antfly/actions/runs/34177703845/job/101916669107?pr=658), head [`96bee1e80`](https://github.com/antflydb/antfly/commit/96bee1e80cf115c2dc636ed065a0378d8cfb27f3) | [`1bf7230cc`](https://github.com/antflydb/antfly/commit/1bf7230cc74c37ba4263964719542c210ff9473d) | Readiness assertion fixed; 30/30 soak runs passed. |
 | Same CLI pipeline, retry-exhaustion phase (`settled_failure is not None`) | [PR #659, run 34182855053, job 101932868141](https://github.com/antflydb/antfly/actions/runs/34182855053/job/101932868141), head [`51ec7a551`](https://github.com/antflydb/antfly/commit/51ec7a551aa3ac5713eb243155a9e2c9d8cfa0ac) | [`19b988108`](https://github.com/antflydb/antfly/commit/19b9881080af1dbc805f9ad5bda096b62bf063b1) | Reproduced in 3/3 concurrent runs with real retry sleeps; corrected-budget soak passed 9/9. |
 | Same three-by-three backup test, initial table create | [PR #664, run 34263167199, job 102199089027](https://github.com/antflydb/antfly/actions/runs/34263167199/job/102199089027?pr=664), merge `d6108b73b85a8e77dfcb740d5518279b2a51d826` | This change | Read waiter clock and pre-admission handling fixed; 100/100 Debug soak runs passed. |
+| `test_quickstart.py::test_public_quickstart_query_string_boolean_controls` | [PR #657, run 34296218257, job 102299245250](https://github.com/antflydb/antfly/actions/runs/34296218257/job/102299245250?pr=657), head `292e5ec9c` | This change | Deterministic fixture mismatch reproduced 9/9; fresh stateful restart fixture passed 30/30 final soak runs. |
+| `test_standby.py::test_standby_streams_public_writes_restarts_and_rejects_writes` | Same #657 job | This change | Live replication startup wait passed 30/30 ordinary and 30/30 delayed-fetch runs. Delayed first fetch reproduces the pending-durability 503 without the wait; original CI delay was not observed locally. |
+
+### Quickstart restart fixture and HA replication startup (#657)
+
+The job reported 376 passed, five skipped, and two failures. The quickstart
+Boolean-query assertions passed, then accessing `backup_api.supports_restart`
+raised `AttributeError`: that fixture does not expose a restart lifecycle.
+The test now uses the existing `stateful_api` restart contract and requests a
+fresh process. All query assertions still run before and after the local
+restart, without restarting a module-shared runtime.
+
+The HA case failed at the first document write after the bootstrapped standby
+restarted with continuous replication enabled. The primary returned HTTP 503,
+`write committed locally; standby durability acknowledgment pending`. That is
+a post-commit outcome and must not be retried as an unadmitted write.
+
+The fixture waited for `/readyz`, but that endpoint does not promise a completed
+upstream replication round. Bootstrap and restart also restore `received_lsn`
+and `applied_lsn` before the background replication loop connects. The test now
+waits for a successful live round (`last_success_ns`), no current replication
+error, and the expected applied LSN before issuing synchronous writes after
+either restart. A successful round includes the upstream status acknowledgement.
+The wait uses the existing 20-second observation budget, caps each read request
+by its remaining time, fails on process exit, and reports the last snapshot
+plus both nodes' logs. Write success, applied data, remote durability, restart
+recovery, and rejection of standby writes remain required. Production policy
+and the two-second synchronous acknowledgement budget are unchanged.
+
+The new `test_standby_replication_startup.py` regression forwards authenticated
+HA requests through a local proxy that delays only the first replication fetch
+by three seconds. Disabling only the live-round requirement reproduces the
+exact pending-durability 503; enabling it passes the complete original HA case.
+Fast harness tests distinguish restored progress from a live round, retain
+applied-LSN requirements, reject unsuccessful replication, bound requests, and
+fail immediately on process exit.
+
+This establishes the missing startup precondition. The original Linux CI log
+contained only primary logs, so it cannot establish what delayed that standby's
+first acknowledgement. All 69 unmodified local HA repetitions passed. A passing
+soak or injected startup delay does not prove the original CI stall's internal
+cause. HA fixture failures now emit both nodes' logs for future comparison.
+
+Validation on 2026-09-08 (America/Los_Angeles), macOS ARM64, based on merged
+`origin/main` commit `50e923cb5`, using one unchanged native Debug executable:
+
+- Native build: 27/27 steps passed. Executable SHA-256:
+  `051121877ef7fe6c5230c00138cc9f0b1b990ffac68a6a4c8a93387bfa0e26e9`.
+- Baseline mixed soak: three workers × three repetitions; quickstart failed
+  9/9 with `AttributeError`, while HA passed 9/9. Additional HA baseline:
+  six workers × ten repetitions, 60/60 passed.
+- Corrected proxy comparison: one failure with the live-round check disabled,
+  one pass with it enabled, using the same executable and three-second delay.
+- 133 fast harness and scheduler checks passed.
+- Final mixed soak: **90/90 passed**, three workers × ten repetitions of each
+  of the two original cases and the delayed-fetch regression (30 per case).
+- `make fmt`, Ruff checks on the three HA test files, and `git diff --check`
+  passed. The quickstart file has an unrelated pre-existing broad-exception
+  lint finding outside this change.
+
+The final mixed soak uses the repository regression loop from the worktree root:
+
+```sh
+SKIP_BUILD=1 ANTFLY_E2E_ENV_LOADED=1 \
+ANTFLY_E2E_REGRESSION_WORKERS=3 ANTFLY_E2E_REGRESSION_REPEATS=10 \
+ANTFLY_E2E_PRESERVE_FAILURE_LIMIT=2 \
+scripts/ci/zig-e2e-regression-loop.sh \
+  e2e/antfly/test_quickstart.py::test_public_quickstart_query_string_boolean_controls \
+  e2e/antfly/test_standby.py::test_standby_streams_public_writes_restarts_and_rejects_writes \
+  e2e/antfly/test_standby_replication_startup.py::test_standby_waits_for_delayed_first_replication
+```
+
+Local evidence is retained in `/private/tmp/antfly-pr657-*.log`, including
+`baseline-soak`, `ha-baseline-soak`, `delayed-before-corrected`,
+`delayed-fixed-proxy`, and `fixed-soak`. The initial proxy prototype omitted
+the GET identity handshake and its failed runs are excluded from the comparison.
+Linux CI remains the cross-platform validation.
 
 ### Retrieval streaming teardown
 

--- a/zig/e2e/antfly/test_quickstart.py
+++ b/zig/e2e/antfly/test_quickstart.py
@@ -283,10 +283,11 @@ def test_public_quickstart_default_field_searches_dynamic_strings(
     ]
 
 
-def test_public_quickstart_query_string_boolean_controls(backup_api):
+@pytest.mark.fresh_antfly_process
+def test_public_quickstart_query_string_boolean_controls(stateful_api):
     table = f"quickstart_boolean_{time.time_ns()}"
-    backup_api.create_table(table, num_shards=1)
-    backup_api.batch_write(
+    stateful_api.create_table(table, num_shards=1)
+    stateful_api.batch_write(
         table,
         inserts={
             "both": {"body": "alpha beta"},
@@ -320,7 +321,7 @@ def test_public_quickstart_query_string_boolean_controls(backup_api):
 
     def assert_controls():
         for query, expected in cases:
-            result = backup_api.query_table(
+            result = stateful_api.query_table(
                 table, {"full_text_search": query, "limit": 10}
             )
             hits = result["responses"][0]["hits"]["hits"]
@@ -328,8 +329,8 @@ def test_public_quickstart_query_string_boolean_controls(backup_api):
             assert len(hits) == len(expected), query
 
     assert_controls()
-    if backup_api.supports_restart:
-        backup_api.restart_server()
+    if stateful_api.supports_restart:
+        stateful_api.restart_server()
         assert_controls()
 
 

--- a/zig/e2e/antfly/test_standby.py
+++ b/zig/e2e/antfly/test_standby.py
@@ -264,13 +264,15 @@ class HAStandaloneNode:
             )
             raise
 
-    def admin_get_response(self, path: str, **params: Any) -> requests.Response:
+    def admin_get_response(
+        self, path: str, *, request_timeout_s: float = 10.0, **params: Any
+    ) -> requests.Response:
         return self._request(
             "GET",
             f"{self.url}{HA_ADMIN_ROOT}{path}",
             params=params,
             headers=self.admin_headers(),
-            timeout=10,
+            timeout=request_timeout_s,
         )
 
     def admin_post_response(
@@ -577,29 +579,59 @@ def ha_cluster(request: pytest.FixtureRequest) -> HACluster:
         yield cluster
     finally:
         report = getattr(request.node, "rep_call", None)
-        cluster.close(test_failed=bool(report and report.failed))
+        test_failed = bool(report and report.failed)
+        if test_failed:
+            print(cluster.debug_logs())
+        cluster.close(test_failed=test_failed)
 
 
 def _wait_for_standby_applied(
-    cluster: HACluster, lsn: int, *, timeout_s: float = 20.0
+    cluster: HACluster,
+    lsn: int,
+    *,
+    timeout_s: float = 20.0,
+    require_live_replication: bool = False,
 ) -> dict[str, Any]:
     deadline = time.monotonic() + timeout_s
     last_snapshot: dict[str, Any] | None = None
     last_error: Exception | None = None
     while time.monotonic() < deadline:
+        proc = cluster.standby.proc
+        if proc is None or proc.poll() is not None:
+            raise AssertionError(
+                f"standby exited while waiting for LSN {lsn}\n{cluster.debug_logs()}"
+            )
         try:
-            status = cluster.standby.admin_get("/standby/status", upstream_lsn=lsn)
+            response = cluster.standby.admin_get_response(
+                "/standby/status",
+                upstream_lsn=lsn,
+                request_timeout_s=max(0.001, min(10.0, deadline - time.monotonic())),
+            )
+            status = cluster.standby._check(response)
         except requests.RequestException as err:
             last_error = err
             time.sleep(0.25)
             continue
         snapshot = status["snapshot"]
         last_snapshot = snapshot
-        if snapshot["received_lsn"] >= lsn and snapshot["applied_lsn"] >= lsn:
+        # Bootstrap/restart restores durable LSNs before the background pull
+        # loop has contacted the primary. A successful round includes the
+        # upstream status acknowledgement; /readyz and restored progress alone
+        # cannot establish that synchronous replication is running.
+        replication_ready = not require_live_replication or (
+            (snapshot.get("last_success_ns") or 0) > 0
+            and snapshot.get("last_error") is None
+        )
+        if (
+            snapshot["received_lsn"] >= lsn
+            and snapshot["applied_lsn"] >= lsn
+            and replication_ready
+        ):
             return snapshot
         time.sleep(0.25)
     raise AssertionError(
-        f"standby did not apply through LSN {lsn}; last={last_snapshot}; last_error={last_error}\n"
+        f"standby did not apply through LSN {lsn}; require_live_replication={require_live_replication}; "
+        f"last={last_snapshot}; last_error={last_error}\n"
         f"{cluster.debug_logs()}"
     )
 
@@ -1015,6 +1047,9 @@ def test_standby_streams_public_writes_restarts_and_rejects_writes(
     )
 
     ha_cluster.standby.restart()
+    _wait_for_standby_applied(
+        ha_cluster, seed["backup_lsn"], require_live_replication=True
+    )
 
     ha_cluster.primary.batch_write(table_name, {"doc:first": {"title": "first"}})
     first_lsn = _primary_lsn(ha_cluster)
@@ -1056,7 +1091,9 @@ def test_standby_streams_public_writes_restarts_and_rejects_writes(
     assert write_check["decision"]["action"] == "reject_read_only_standby"
 
     ha_cluster.standby.restart()
-    restarted_snapshot = _wait_for_standby_applied(ha_cluster, first_lsn)
+    restarted_snapshot = _wait_for_standby_applied(
+        ha_cluster, first_lsn, require_live_replication=True
+    )
     assert restarted_snapshot["received_lsn"] >= first_lsn
     assert restarted_snapshot["applied_lsn"] >= first_lsn
     restarted_doc = _wait_for_standby_lookup(ha_cluster, table_name, "doc:first")

--- a/zig/e2e/antfly/test_standby_harness.py
+++ b/zig/e2e/antfly/test_standby_harness.py
@@ -1,0 +1,106 @@
+# Copyright 2026 Antfly, Inc.
+#
+# Licensed under the Elastic License 2.0 (ELv2); you may not use this file
+# except in compliance with the Elastic License 2.0. You may obtain a copy of
+# the Elastic License 2.0 at
+#
+#     https://www.antfly.io/licensing/ELv2-license
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the Elastic License 2.0 is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the Elastic License 2.0 for the specific language governing permissions
+# and limitations.
+
+"""Fast checks for HA restart readiness and bounded failure diagnostics."""
+
+from types import SimpleNamespace
+
+import pytest
+import test_standby as standby_tests
+
+
+@pytest.fixture
+def readiness_cluster(monkeypatch):
+    clock = [0.0]
+    monkeypatch.setattr(standby_tests.time, "monotonic", lambda: clock[0])
+    monkeypatch.setattr(
+        standby_tests.time,
+        "sleep",
+        lambda duration: clock.__setitem__(0, clock[0] + duration),
+    )
+    snapshots = []
+    timeouts = []
+
+    def read_status(path, *, upstream_lsn, request_timeout_s):
+        assert path == "/standby/status"
+        assert upstream_lsn == 10
+        timeouts.append(request_timeout_s)
+        snapshot = snapshots.pop(0) if len(snapshots) > 1 else snapshots[0]
+        return {"snapshot": snapshot}
+
+    cluster = SimpleNamespace(
+        standby=SimpleNamespace(
+            proc=SimpleNamespace(poll=lambda: None),
+            admin_get_response=read_status,
+            _check=lambda response: response,
+        ),
+        debug_logs=lambda: "primary and standby diagnostics",
+    )
+    return cluster, snapshots, timeouts
+
+
+def snapshot(*, applied_lsn=10, last_success_ns=None, last_error=None):
+    return {
+        "received_lsn": 10,
+        "applied_lsn": applied_lsn,
+        "last_success_ns": last_success_ns,
+        "last_error": last_error,
+    }
+
+
+@pytest.mark.parametrize(
+    "require_live_replication, expected_calls", [(False, 1), (True, 3)]
+)
+def test_restored_progress_requires_a_live_round_before_sync_writes(
+    readiness_cluster, require_live_replication, expected_calls
+):
+    cluster, snapshots, timeouts = readiness_cluster
+    snapshots.extend(
+        [
+            snapshot(),
+            snapshot(applied_lsn=9, last_success_ns=1),
+            snapshot(last_success_ns=2),
+        ]
+    )
+    result = standby_tests._wait_for_standby_applied(
+        cluster, 10, require_live_replication=require_live_replication
+    )
+    assert result["applied_lsn"] == 10
+    assert len(timeouts) == expected_calls
+
+
+@pytest.mark.parametrize(
+    "last_success_ns, last_error", [(None, None), (0, None), (1, "ConnectionRefused")]
+)
+def test_startup_wait_times_out_with_bounded_requests_and_diagnostics(
+    readiness_cluster, last_success_ns, last_error
+):
+    cluster, snapshots, timeouts = readiness_cluster
+    snapshots.append(snapshot(last_success_ns=last_success_ns, last_error=last_error))
+    with pytest.raises(AssertionError, match="require_live_replication=True") as failed:
+        standby_tests._wait_for_standby_applied(
+            cluster, 10, timeout_s=0.5, require_live_replication=True
+        )
+    assert timeouts == [0.5, 0.25]
+    assert "primary and standby diagnostics" in str(failed.value)
+
+
+def test_startup_wait_fails_immediately_when_standby_exits(readiness_cluster):
+    cluster, _, timeouts = readiness_cluster
+    cluster.standby.proc.poll = lambda: 1
+    with pytest.raises(AssertionError, match="standby exited"):
+        standby_tests._wait_for_standby_applied(
+            cluster, 10, require_live_replication=True
+        )
+    assert timeouts == []

--- a/zig/e2e/antfly/test_standby_replication_startup.py
+++ b/zig/e2e/antfly/test_standby_replication_startup.py
@@ -1,0 +1,85 @@
+# Copyright 2026 Antfly, Inc.
+#
+# Licensed under the Elastic License 2.0 (ELv2); you may not use this file
+# except in compliance with the Elastic License 2.0. You may obtain a copy of
+# the Elastic License 2.0 at
+#
+#     https://www.antfly.io/licensing/ELv2-license
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the Elastic License 2.0 is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the Elastic License 2.0 for the specific language governing permissions
+# and limitations.
+
+"""Replication startup must complete before expecting synchronous write success."""
+
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import pytest
+import requests
+import test_standby as standby_tests
+
+ha_cluster = standby_tests.ha_cluster
+pytestmark = pytest.mark.ha_standby
+
+
+def test_standby_waits_for_delayed_first_replication(ha_cluster):
+    upstream = ha_cluster.primary.url
+    delayed = threading.Event()
+
+    class Proxy(BaseHTTPRequestHandler):
+        def forward(self):
+            body = self.rfile.read(int(self.headers.get("Content-Length", "0")))
+            if (
+                self.path == "/internal/v1/ha/replication/start"
+                and not delayed.is_set()
+            ):
+                delayed.set()
+                # Longer than the runtime's two-second synchronous ACK budget.
+                # HTTP readiness and restored checkpoint LSNs are already
+                # available while this first upstream exchange is pending.
+                time.sleep(3.0)
+            response = requests.request(
+                self.command,
+                upstream + self.path,
+                data=body,
+                headers={
+                    "Content-Type": self.headers.get(
+                        "Content-Type", "application/json"
+                    ),
+                    "Authorization": self.headers.get("Authorization", ""),
+                    "Connection": "close",
+                },
+                timeout=10,
+            )
+            self.send_response(response.status_code)
+            self.send_header(
+                "Content-Type", response.headers.get("Content-Type", "application/json")
+            )
+            self.send_header("Content-Length", str(len(response.content)))
+            self.send_header("Connection", "close")
+            self.end_headers()
+            self.wfile.write(response.content)
+
+        do_GET = forward
+        do_POST = forward
+
+        def log_message(self, *args):
+            pass
+
+    proxy = ThreadingHTTPServer(("127.0.0.1", 0), Proxy)
+    thread = threading.Thread(target=proxy.serve_forever, daemon=True)
+    thread.start()
+    ha_cluster.standby.upstream_url = f"http://127.0.0.1:{proxy.server_port}"
+    try:
+        standby_tests.test_standby_streams_public_writes_restarts_and_rejects_writes(
+            ha_cluster
+        )
+    finally:
+        proxy.shutdown()
+        proxy.server_close()
+        thread.join()
+    assert delayed.is_set()


### PR DESCRIPTION
The quickstart Boolean-query test used a backup fixture that has no restart API, while the HA streaming test issued its first synchronous write after HTTP readiness but before confirming live replication. This fixes both test contracts from [the failed #657 job](https://github.com/antflydb/antfly/actions/runs/34296218257/job/102299245250?pr=657).

- Use the existing stateful restart fixture and a fresh process for the quickstart case, retaining its query assertions before and after restart.
- After each HA restart, require a successful upstream replication round, no current replication error, and the expected applied LSN before issuing synchronous writes. Restored checkpoint LSNs alone cannot establish live replication. Requests use the remaining observation budget, process exits fail promptly, and failures include both nodes' logs.
- Add a deterministic E2E regression that delays the first authenticated replication fetch by three seconds, plus fast readiness and deadline tests. The pending-durability response remains a failure and is never retried; production synchronization policy is unchanged.
- Record reproduction evidence, commands, and limitations in `zig/e2e/FLAKES.md`.

Based on `origin/main` at `50e923cb5`, the merge of #657. The quickstart failure reproduced in 9/9 baseline runs. The original HA timing did not recur in 69 ordinary baseline repetitions; disabling only the live-round startup requirement with the delayed-fetch proxy reproduced the exact committed-locally/pending-ACK 503. The corrected requirement passed against the same native Debug executable. The original CI log lacks standby diagnostics, so the internal cause of that particular delay remains unproven.

Validation on macOS ARM64:

- Native Debug build: 27/27 steps passed.
- Final concurrent soak: **90/90 passed** (three workers × ten repetitions × three cases).
- **133** fast harness and scheduler checks passed.
- `make fmt`, Ruff on the three HA test files, and `git diff --check` passed. An unrelated pre-existing broad-exception lint finding remains in the quickstart file.

Linux CI remains the cross-platform check.
