### PR TITLE
ci: provision Nix Zig for Homebrew packaging checks

### DIFF
--- a/.github/workflows/antfly-release.yml
+++ b/.github/workflows/antfly-release.yml
@@ -655,6 +655,29 @@ jobs:
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ steps.toolchain.outputs.python_build }}
+      - name: Install Nix prerequisites
+        run: |
+          sudo_cmd=""
+          if command -v sudo >/dev/null 2>&1; then
+            sudo_cmd="sudo"
+          fi
+          $sudo_cmd apt-get update
+          $sudo_cmd apt-get install --yes --no-install-recommends ca-certificates curl xz-utils file
+      - name: Install Nix
+        uses: cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24 # v31
+        with:
+          nix_path: nixpkgs=https://github.com/NixOS/nixpkgs/archive/${{ steps.toolchain.outputs.zig_nixpkgs_revision }}.tar.gz
+      - name: Install glibc-linked Zig
+        env:
+          ZIG_VERSION: ${{ steps.toolchain.outputs.zig_version }}
+          ZIG_NIX_ATTRIBUTE: ${{ steps.toolchain.outputs.zig_nix_attribute }}
+        run: |
+          zig_path="$(nix-build '<nixpkgs>' -A "$ZIG_NIX_ATTRIBUTE" --no-out-link)"
+          test "$("$zig_path/bin/zig" version)" = "$ZIG_VERSION"
+          compiler_description="$(file "$zig_path/bin/zig")"
+          echo "$compiler_description"
+          grep -q 'dynamically linked' <<<"$compiler_description"
+          echo "$zig_path/bin" >> "$GITHUB_PATH"
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: antfly-release-runtime-archives

--- a/scripts/packaging/test_cabi_packaging.py
+++ b/scripts/packaging/test_cabi_packaging.py
@@ -105,6 +105,22 @@ class CompletionPackagingTests(unittest.TestCase):
 
 
 class CAbiPackagingTests(unittest.TestCase):
+    def test_homebrew_job_provisions_packaging_toolchains(self) -> None:
+        workflow = (
+            REPO_ROOT / ".github" / "workflows" / "antfly-release.yml"
+        ).read_text()
+        job = workflow_job(workflow, "prepare-zig-homebrew")
+        bootstrap = job.split("      - name: Render formula", 1)[0]
+        self.assertIn("uses: actions/setup-python@", bootstrap)
+        self.assertIn("steps.toolchain.outputs.python_build", bootstrap)
+        self.assertIn("uses: cachix/install-nix-action@", bootstrap)
+        self.assertIn("steps.toolchain.outputs.zig_nixpkgs_revision", bootstrap)
+        self.assertIn("steps.toolchain.outputs.zig_nix_attribute", bootstrap)
+        self.assertIn("steps.toolchain.outputs.zig_version", bootstrap)
+        self.assertIn('nix-build \'<nixpkgs>\' -A "$ZIG_NIX_ATTRIBUTE"', bootstrap)
+        self.assertIn('echo "$zig_path/bin" >> "$GITHUB_PATH"', bootstrap)
+        self.assertIn("grep -q 'dynamically linked'", bootstrap)
+
     def test_linux_abi_release_contract_stays_consistent(self) -> None:
         installer = (REPO_ROOT / "scripts" / "install.sh").read_text()
         minimum_match = re.search(


### PR DESCRIPTION
Homebrew release preparation runs packaging tests that compile shell completions. Recovery of v0.2.1 exposed that the ARC job had no Zig compiler after Python setup was fixed.

Install Zig using the same pinned Nix revision, package attribute, version check, and dynamic-linkage check as the Linux release build. Provision Nix prerequisites and add a regression check requiring both Python and Nix-provided Zig before formula preparation.

Validation: full release tooling suite (123 Python tests plus installer and workflow checks), toolchain policy validation, actionlint, and git diff checks passed. Nix installation will be validated by release recovery on the Linux ARC runner.

Recovery will reuse the existing sealed v0.2.1 artifacts and unchanged tag.
