### PR TITLE
fix: wait for npm dist-tag propagation after publish

### DIFF
--- a/scripts/packaging/publish_npm_package.sh
+++ b/scripts/packaging/publish_npm_package.sh
@@ -41,9 +41,20 @@ if [ -n "$published_integrity" ]; then
 fi
 
 npm publish "$tarball" --access public --provenance --tag "$dist_tag"
-published_tag="$(python3 scripts/release/registryctl.py npm-tag \
-  --package "$package_name" --tag "$dist_tag")"
-if [ "$published_tag" != "$version" ]; then
-  echo "npm publish completed but dist-tag ${dist_tag} does not point to v${version}" >&2
-  exit 1
-fi
+# A successful publish can precede the registry's read-side dist-tag update.
+# Retry only that observation; never republish or mutate a tag to repair it.
+attempt=1
+while [ "$attempt" -le 30 ]; do
+  published_tag="$(python3 scripts/release/registryctl.py npm-tag \
+    --package "$package_name" --tag "$dist_tag")"
+  if [ "$published_tag" = "$version" ]; then
+    exit 0
+  fi
+  if [ "$attempt" -lt 30 ]; then
+    echo "waiting for npm dist-tag ${dist_tag} to expose ${package_name}@${version} (attempt ${attempt}/30)" >&2
+    sleep 10
+  fi
+  attempt=$((attempt + 1))
+done
+echo "npm publish completed but dist-tag ${dist_tag} does not point to ${version} after 30 checks" >&2
+exit 1

--- a/scripts/packaging/test_cabi_packaging.py
+++ b/scripts/packaging/test_cabi_packaging.py
@@ -622,7 +622,10 @@ class CAbiPackagingTests(unittest.TestCase):
                 "#!/bin/sh\n"
                 'case "$*" in\n'
                 "  *npm-integrity*) printf '%s\\n' \"${FAKE_NPM_INTEGRITY:-}\" ;;\n"
-                "  *npm-tag*) printf '%s\\n' \"${FAKE_NPM_TAG:-}\" ;;\n"
+                "  *npm-tag*)\n"
+                '    if [ -n "${FAKE_NPM_TAG_FILE:-}" ]; then\n'
+                '      cat "$FAKE_NPM_TAG_FILE"\n'
+                "    else printf '%s\\n' \"${FAKE_NPM_TAG:-}\"; fi ;;\n"
                 "  *) exit 2 ;;\n"
                 "esac\n"
             )
@@ -672,6 +675,36 @@ class CAbiPackagingTests(unittest.TestCase):
             env["FAKE_NPM_TAG"] = "1.2.3"
             subprocess.run(command, check=True, env=env, capture_output=True, text=True)
             self.assertIn("publish", log.read_text())
+
+            # Model a successful publish whose tag is initially stale, then
+            # becomes visible on the next read. No real waits or registry writes.
+            tag_file = root / "tag"
+            tag_file.write_text("1.2.2\n")
+            env["FAKE_NPM_TAG_FILE"] = str(tag_file)
+            sleep = fake_bin / "sleep"
+            sleep.write_text(
+                '#!/bin/sh\nprintf "1.2.3\\n" > "$FAKE_NPM_TAG_FILE"\n'
+            )
+            sleep.chmod(0o755)
+            log.write_text("")
+            propagated = subprocess.run(
+                command, check=True, env=env, capture_output=True, text=True
+            )
+            self.assertIn("waiting for npm dist-tag", propagated.stderr)
+            self.assertEqual(len(log.read_text().splitlines()), 1)
+
+            # A tag that never converges still fails after a bounded wait and
+            # never triggers another publish or an unauthorized dist-tag repair.
+            tag_file.write_text("1.2.2\n")
+            sleep.write_text("#!/bin/sh\nexit 0\n")
+            log.write_text("")
+            stale = subprocess.run(
+                command, env=env, capture_output=True, text=True, check=False
+            )
+            self.assertNotEqual(stale.returncode, 0)
+            self.assertIn("after 30 checks", stale.stderr)
+            self.assertEqual(stale.stderr.count("waiting for npm dist-tag"), 29)
+            self.assertEqual(len(log.read_text().splitlines()), 1)
 
     def test_python_and_npm_packages_preserve_cabi_artifacts(self) -> None:
         with tempfile.TemporaryDirectory() as raw:


### PR DESCRIPTION
The v0.2.1 recovery successfully published @antfly/cli-darwin-arm64, then failed because the immediate registry read did not yet expose its latest tag. The tag subsequently resolved to 0.2.1 without a repair.

Retry the post-publish tag read up to 30 times, ten seconds apart. Publish only once; preserve immediate failures for existing content/tag drift and registry lookup errors. A tag that never converges still fails.

Validation: the full release tooling suite passed, including simulated delayed visibility and permanent tag drift. The tests verify there is only one publish and that retries stop at the limit. Shell syntax and git diff checks passed.
