### PR TITLE
release: prepare SDKs for v0.2.0

### DIFF
--- a/py/packages/sdk/pyproject.toml
+++ b/py/packages/sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "antfly-sdk"
-version = "0.0.2-dev2"
+version = "0.2.0"
 description = "Python SDK for Antfly distributed key-value store and search engine"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/py/packages/sdk/src/antfly/__init__.py
+++ b/py/packages/sdk/src/antfly/__init__.py
@@ -68,7 +68,7 @@ from .index_config import (
     validate_create_index_request_relationships,
 )
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 
 __all__ = [
     "AntflyClient",

--- a/py/packages/sdk/uv.lock
+++ b/py/packages/sdk/uv.lock
@@ -22,7 +22,7 @@ wheels = [
 
 [[package]]
 name = "antfly-sdk"
-version = "0.0.2.dev2"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },

--- a/scripts/packaging/test_cabi_packaging.py
+++ b/scripts/packaging/test_cabi_packaging.py
@@ -117,7 +117,7 @@ class CAbiPackagingTests(unittest.TestCase):
         self.assertIn("steps.toolchain.outputs.zig_nixpkgs_revision", bootstrap)
         self.assertIn("steps.toolchain.outputs.zig_nix_attribute", bootstrap)
         self.assertIn("steps.toolchain.outputs.zig_version", bootstrap)
-        self.assertIn('nix-build \'<nixpkgs>\' -A "$ZIG_NIX_ATTRIBUTE"', bootstrap)
+        self.assertIn("nix-build '<nixpkgs>' -A \"$ZIG_NIX_ATTRIBUTE\"", bootstrap)
         self.assertIn('echo "$zig_path/bin" >> "$GITHUB_PATH"', bootstrap)
         self.assertIn("grep -q 'dynamically linked'", bootstrap)
 
@@ -682,9 +682,7 @@ class CAbiPackagingTests(unittest.TestCase):
             tag_file.write_text("1.2.2\n")
             env["FAKE_NPM_TAG_FILE"] = str(tag_file)
             sleep = fake_bin / "sleep"
-            sleep.write_text(
-                '#!/bin/sh\nprintf "1.2.3\\n" > "$FAKE_NPM_TAG_FILE"\n'
-            )
+            sleep.write_text('#!/bin/sh\nprintf "1.2.3\\n" > "$FAKE_NPM_TAG_FILE"\n')
             sleep.chmod(0o755)
             log.write_text("")
             propagated = subprocess.run(

--- a/ts/packages/sdk/package.json
+++ b/ts/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antfly/sdk",
-  "version": "0.0.14",
+  "version": "0.2.0",
   "description": "TypeScript SDK for Antfly API",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
Prepare the Python and TypeScript SDK packages for 0.2.0 so their versions match the Antfly 0.2 series. Align Python package metadata, its lockfile, and the runtime version; update @antfly/sdk metadata. Correct formatting in the packaging regression tests that was failing main CI.

After merge, publish py/antfly/sdk/v0.2.0, ts/antfly/sdk/v0.2.0, and go/pkg/sdk/v0.2.0 at the merge commit. Go's module path is unchanged and its version is supplied by the module tag.

Validation: Python's 130 tests, lint, type checks, wheel and source builds; TypeScript's prepublish checks (typecheck, lint, build, 279 tests passed and one skipped); Go tests, vet, and race tests. Rebuilt Python 0.2.0 distributions and verified package/runtime version agreement. Toolchain policy, publishing workflow actionlint, and git diff checks passed.
