### PR TITLE
test(scraping): consume HTTP fixture requests before replying

### DIFF
--- a/zig/lib/scraping/src/mod.zig
+++ b/zig/lib/scraping/src/mod.zig
@@ -1895,6 +1895,16 @@ const TestHttpResponseServer = struct {
 
         var write_buffer: [1024]u8 = undefined;
         var writer = stream.writer(self.io, &write_buffer);
+        // Consume the GET request before closing the connection. Closing with
+        // unread request bytes can reset TCP and truncate the response at the
+        // client, making the decoding and size-limit checks scheduling-dependent.
+        var read_buffer: [4096]u8 = undefined;
+        var reader = stream.reader(self.io, &read_buffer);
+        var http = std.http.Server.init(&reader.interface, &writer.interface);
+        _ = http.receiveHead() catch |err| {
+            self.failure = err;
+            return;
+        };
         writer.interface.writeAll(
             "HTTP/1.1 200 OK\r\n" ++
                 "Content-Type: text/plain; charset=utf-8\r\n" ++


### PR DESCRIPTION
The scraping HTTP test server closed accepted sockets without consuming the request headers. Unread request bytes can turn that close into a TCP reset, intermittently producing `RecvFailed` instead of the response or expected size-limit error.

Read the request head before writing the fixture response. This changes only the test server.

Validation: the existing 36-test scraping suite passed 50 consecutive direct executions (1,800 test executions).

First PR in the Zig build organization stack; the following PRs depend on this fixture fix.
