### PR TITLE
fix: validate Homebrew installs and reserve macOS dylib header space

### DIFF
--- a/.github/workflows/antfly-artifact-build.yml
+++ b/.github/workflows/antfly-artifact-build.yml
@@ -203,6 +203,32 @@ jobs:
           path: dist/release-archives/*.tar.gz
           if-no-files-found: error
 
+  test-macos-homebrew:
+    name: Test Apple Silicon Homebrew install and upgrade
+    needs:
+      - release-plan
+      - build-zig-runtime-archives
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.release-plan.outputs.build_controller_commit }}
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: antfly-zig-*
+          merge-multiple: true
+          path: dist/release-archives
+      - name: Test formula against the built archives
+        env:
+          RELEASE_TAG: ${{ inputs.tag_name }}
+        run: |
+          version="${RELEASE_TAG#v}"
+          python3 scripts/packaging/render_homebrew_antfly_formula.py \
+            --version "$version" --tag "$RELEASE_TAG" \
+            --archive-dir dist/release-archives --out dist/antfly.rb
+          bash scripts/packaging/test_homebrew_install.sh \
+            dist/antfly.rb dist/release-archives "$version"
+
   package-cli-artifacts:
     name: Build immutable CLI package snapshot
     needs:
@@ -244,6 +270,7 @@ jobs:
       - build-zig-runtime-archives
       - package-cli-artifacts
       - package-release-source
+      - test-macos-homebrew
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/scripts/packaging/render_homebrew_antfly_formula.py
+++ b/scripts/packaging/render_homebrew_antfly_formula.py
@@ -68,6 +68,9 @@ def main() -> int:
 class Antfly < Formula
   desc "Native Zig AntflyDB runtime"
   homepage "https://docs.antfly.io"
+  version "{args.version}"
+  # Recover from older formulae that inferred version 64 from arm64 archives.
+  version_scheme 1
   license "Elastic-2.0"
 
   if OS.mac?
@@ -111,6 +114,19 @@ class Antfly < Formula
 
   test do
     system "#{{bin}}/antfly", "--help"
+    (testpath/"smoke.c").write <<~C
+      #include <antfly.h>
+      int main(void) {{
+        if (antfly_abi_version() != 1) return 1;
+        void *db = NULL;
+        if (antfly_lite_create("smoke.aflite", &db) != ANTFLY_OK) return 2;
+        antfly_db_close(db);
+        return 0;
+      }}
+    C
+    system ENV.cc, "smoke.c", "-I#{{include}}", "-L#{{lib}}", "-lantfly",
+           "-Wl,-rpath,#{{lib}}", "-o", "smoke"
+    system "./smoke"
   end
 
   def caveats

--- a/scripts/packaging/test_cabi_packaging.py
+++ b/scripts/packaging/test_cabi_packaging.py
@@ -105,6 +105,17 @@ class CompletionPackagingTests(unittest.TestCase):
 
 
 class CAbiPackagingTests(unittest.TestCase):
+    def test_release_requires_native_homebrew_validation(self) -> None:
+        workflow = (
+            REPO_ROOT / ".github" / "workflows" / "antfly-artifact-build.yml"
+        ).read_text()
+        job = workflow_job(workflow, "test-macos-homebrew")
+        self.assertIn("runs-on: macos-15", job)
+        self.assertIn("scripts/packaging/test_homebrew_install.sh", job)
+        self.assertIn(
+            "- test-macos-homebrew", workflow_job(workflow, "release-request")
+        )
+
     def test_homebrew_job_provisions_packaging_toolchains(self) -> None:
         workflow = (
             REPO_ROOT / ".github" / "workflows" / "antfly-release.yml"
@@ -803,6 +814,9 @@ class CAbiPackagingTests(unittest.TestCase):
             )
 
             rendered = formula.read_text()
+            self.assertIn('version "1.2.3"', rendered)
+            self.assertIn("version_scheme 1", rendered)
+            self.assertIn('system "./smoke"', rendered)
             self.assertIn("antfly_1.2.3_Darwin_arm64.tar.gz", rendered)
             self.assertIn("antfly_1.2.3_Linux_arm64_gnu.tar.gz", rendered)
             self.assertIn("antfly_1.2.3_Linux_x86_64_gnu.tar.gz", rendered)

--- a/scripts/packaging/test_homebrew_install.sh
+++ b/scripts/packaging/test_homebrew_install.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Exercise native relocation, C embedding, and migration from the old version 64.
+# Run on a disposable Apple Silicon runner or with an isolated Homebrew prefix.
+set -euo pipefail
+
+formula_source=${1:?usage: test_homebrew_install.sh FORMULA ARCHIVE_DIR VERSION}
+archive_dir=${2:?missing archive directory}
+version=${3:?missing version}
+test "$(uname -s)" = Darwin
+test "$(uname -m)" = arm64
+export HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_ANALYTICS=1
+export HOMEBREW_NO_INSTALL_CLEANUP=1 HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1
+if brew list --formula --versions antfly >/dev/null 2>&1; then
+  echo "Refusing to replace an existing Antfly installation; use an isolated Homebrew prefix" >&2
+  exit 1
+fi
+
+tap=antfly-ci/packaging-test
+brew tap-new "$tap"
+formula="$(brew --repository "$tap")/Formula/antfly.rb"
+python3 - "$formula_source" "$archive_dir" "$formula" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+source, archives, destination = map(Path, sys.argv[1:])
+text = re.sub(
+    r'https://releases\.antfly\.io/antfly/[^/]+/([^"\n]+)',
+    lambda match: (archives.resolve() / match[1]).as_uri(),
+    source.read_text(),
+)
+destination.write_text(text)
+PY
+cp "$formula" "$formula.fixed"
+package="$tap/antfly"
+if brew command trust >/dev/null 2>&1; then
+  brew trust "$tap"
+fi
+installed_version() {
+  basename "$(cd "$(brew --prefix "$package")" && pwd -P)"
+}
+
+# A clean installation must exit successfully and load the installed dylib.
+brew install --formula "$package"
+test "$(installed_version)" = "$version"
+brew test "$package"
+brew uninstall --formula "$package"
+
+# Reproduce the old keg metadata with the same payload, then exercise upgrade.
+python3 - "$formula" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+text = re.sub(r'^  version ".*"$', '  version "64"', path.read_text(), flags=re.M)
+text = text.replace('  version_scheme 1\n', '')
+path.write_text(text)
+PY
+brew install --formula "$package"
+test "$(installed_version)" = 64
+cp "$formula.fixed" "$formula"
+brew upgrade --formula "$package"
+test "$(installed_version)" = "$version"
+brew test "$package"
+echo "Homebrew clean install, C embedding, and 64 -> $version upgrade passed"

--- a/zig/build.zig
+++ b/zig/build.zig
@@ -2700,6 +2700,10 @@ pub fn build(b: *std.Build) void {
         .max_rss = 2 * 1024 * 1024 * 1024,
     });
     libantfly.link_gc_sections = true;
+    // Homebrew rewrites the dylib ID to its absolute opt/lib path on install.
+    if (target.result.os.tag == .macos) {
+        libantfly.headerpad_max_install_names = true;
+    }
     const install_libantfly = b.addInstallArtifact(libantfly, .{});
     const install_capi_header = b.addInstallFileWithDir(
         b.path("pkg/antfly/include/antfly.h"),


### PR DESCRIPTION
Homebrew inferred Antfly's version as `64` and could not relocate the v0.2.1 macOS dylib because its Mach-O header had no room for the absolute install name.

Reserve macOS dylib header space with Zig's `headerpad_max_install_names`. Generate an explicit formula version and `version_scheme 1` so affected version-64 installations can upgrade. Extend `brew test` to compile a C consumer that creates and closes an Antfly Lite database.

Require an Apple Silicon Homebrew job before recording the release request. It tests clean installation, C embedding, and upgrade from a version-64 keg using the actual built archive. The test uses a disposable tap and refuses to replace an existing Antfly installation.

Validation: release tooling suite (12 packaging tests and 112 release tests), Zig formatting, Python formatting, shell syntax, and native Apple Silicon release archive build. The rebuilt dylib accepts the Homebrew install name that fails on v0.2.1. No existing release archive or tag is replaced; the corrected artifacts will ship as v0.2.2.
