### PR TITLE
test(pdf): add layered model and document qualification

### DIFF
--- a/.github/workflows/zig-tests.yml
+++ b/.github/workflows/zig-tests.yml
@@ -121,6 +121,7 @@ jobs:
             scripts/run_db_query_matrix.py \
             scripts/test_run_db_query_matrix.py \
             scripts/test_conformance_fixtures.py \
+            ':(glob)scripts/bench/pdf/**' \
             Makefile \
             .github/workflows/zig-tests.yml \
             .github/workflows/antfly-container.yml
@@ -364,6 +365,7 @@ jobs:
         run: |
           python3 -m unittest discover -s scripts -p test_run_db_query_matrix.py
           python3 -m unittest discover -s scripts -p test_conformance_fixtures.py
+          python3 -m unittest discover -s scripts/bench/pdf -p 'test_*.py'
 
       - name: Check inference kernel generator
         working-directory: zig/pkg/inference
@@ -659,6 +661,7 @@ jobs:
         run: |
           python3 -m unittest discover -s scripts -p test_run_db_query_matrix.py
           python3 -m unittest discover -s scripts -p test_conformance_fixtures.py
+          python3 -m unittest discover -s scripts/bench/pdf -p 'test_*.py'
 
       # Keep normal build-step parallelism while bounding aggregate compiler
       # memory to the pod's cgroup budget.

--- a/scripts/bench/pdf/QUALIFICATION.md
+++ b/scripts/bench/pdf/QUALIFICATION.md
@@ -84,6 +84,9 @@ the existing output signatures. It requires:
 - Each identical consumer must match the primary's text hashes, page geometry,
   artifact counts and published-vector count, not merely match itself across runs.
 - Trial byte ranges in the original server log bind events to each indexing run.
+  Checkpoints stop at the last complete record in a fixed EOF snapshot, using
+  bounded reads; a concurrent partial log write is not mistaken for a boundary.
+  Partial records remain in the log for subsequent coverage validation.
   Corpus page ranges and indexed manifest fingerprints define the expected set;
   both physical renders and admission windows must cover it exactly once. Missing,
   overlapping, out-of-range or out-of-trial evidence fails closed. Older benchmark

--- a/scripts/bench/pdf/QUALIFICATION.md
+++ b/scripts/bench/pdf/QUALIFICATION.md
@@ -50,6 +50,9 @@ to at most 16 requests; HTTP timeouts apply to every request. The report explici
 states that this does not prove native fusion. Family-specific scheduler/backend
 evidence is still required for that claim.
 
+Both serial batch and concurrent responses also use the family's existing unit
+norm tolerance. Cosine parity alone cannot detect scaled, unnormalized vectors.
+
 Example for an already-running Qwen3 endpoint:
 
 ```sh
@@ -78,6 +81,13 @@ the existing output signatures. It requires:
   selection evidence from the existing harness.
 - Forced OCR and exactly one physical render per source/page/trial for two
   compatible consumers, including terminal partial windows.
+- Each identical consumer must match the primary's text hashes, page geometry,
+  artifact counts and published-vector count, not merely match itself across runs.
+- Trial byte ranges in the original server log bind events to each indexing run.
+  Corpus page ranges and indexed manifest fingerprints define the expected set;
+  both physical renders and admission windows must cover it exactly once. Missing,
+  overlapping, out-of-range or out-of-trial evidence fails closed. Older benchmark
+  results without trial boundaries cannot qualify this gate.
 - Both `full_index` and `write` paths at two distinct renderer caps (256/128 MiB
   by default), identical content hashes, page geometry and published-vector counts.
 - Successful windows with tracked bytes within the requested cap and actual

--- a/scripts/bench/pdf/QUALIFICATION.md
+++ b/scripts/bench/pdf/QUALIFICATION.md
@@ -1,0 +1,167 @@
+# Layered document qualification
+
+Extend existing gates; do not replace their validators. `qualify.py` executes a
+trusted JSON plan and aggregates **only its declared gate scopes**. A green
+contract plan is not evidence of model accuracy, native fusion or GPU performance.
+Even three represented layers do not prove that the same model/deployment was
+tested at every layer. Review the exact scopes and deployment evidence.
+
+## Contract lane
+
+Python 3.11+ and the usual Zig/Go build dependencies are required:
+
+```sh
+python3 scripts/bench/pdf/qualify.py \
+  --plan scripts/bench/pdf/execution.plan.json \
+  --output /tmp/pdf-contract-evidence-001
+```
+
+The checked-in plan reuses existing targets for task capabilities, result
+cardinality, credentials, cancellation, admission, linked/worker media transport,
+distributed proxy routing, PDF rendering and precommit/replay recovery. Targets
+run sequentially in Debug with one compiler job each. This bounds runner-level
+concurrency; the tests still exercise their own concurrent execution. These
+tests intentionally use model-free providers. Their success cannot qualify
+serving-time GLiNER2 fusion, Gemma generation, or any other real model.
+
+## Model lanes
+
+Use the family script's exact fixtures, backend selection, precision and thresholds.
+The runner checks the script's versioned report schema and boolean verdict, plus
+its process exit status. It does **not** recompute numerical acceptance.
+
+| Existing owner | Native evidence binding | Scope caveat |
+| --- | --- | --- |
+| `qwen3_embedding/qualify_qwen3_embedding_{metal,cuda}.py` | `schema`, `pass` | Oracle, MRL, retrieval, batch parity; now concurrent request isolation too. Endpoint execution is not proof of device-side fusion. |
+| `gemma4/benchmark_gemma4_cuda_batching.py` | `antfly.gemma4.cuda_batching.v1`, `passed` | Existing exact-response, scheduler activity, throughput and p95 gates remain unchanged. |
+| `qwen3vl/qualify_qwen3vl_reranker_metal.py` | `antfly.qwen3vl.reranker_metal_qualification.v1`, `pass` | Retains multimodal score/preprocessing oracles; not universal reranker batching certification. |
+| `gliner2/qualify_gliner2_cuda_hardware.py` | `contract=gliner2_cuda_hardware_qualification_lane/v1`, `pass` | CUDA training/gradient checks do not qualify serving-time extraction/NER fusion. |
+| `florence2/verify_florence2_cuda_perf.sh` | Explicit legacy exit-code envelope + full log | Keeps backend/resident-KV/token/timing checks, not an OCR semantic oracle. |
+| `clipclap/verify_clipclap_cuda.sh` | Explicit legacy exit-code envelope + full log | Native/CUDA text-vector parity only; image/audio/PDF coverage remains separate. |
+
+Family paths above are relative to `zig/pkg/inference/scripts/`. Existing
+precision-specific tolerances are unchanged. Qwen's additional test uses the
+existing `batch_gates` cosine threshold against isolated outputs (and the existing
+MRL reduction), not a new universal tolerance. It overlaps independently prompted
+query/document requests at full/reduced dimensions, reverses arrival order, and
+checks exact response-index coverage. Defaults are two rounds, four concurrent
+requests; long-context oracles remain in the serial gate. Concurrency is bounded
+to at most 16 requests; HTTP timeouts apply to every request. The report explicitly
+states that this does not prove native fusion. Family-specific scheduler/backend
+evidence is still required for that claim.
+
+Example for an already-running Qwen3 endpoint:
+
+```sh
+python3 scripts/bench/pdf/qualify.py \
+  --plan scripts/bench/pdf/qwen3-metal.plan.json \
+  --output /tmp/qwen-metal-evidence-001 \
+  --var binary=/path/to/frozen/antfly --var models=/path/to/frozen/models \
+  --var oracle=/path/to/oracle.json --var base_url=http://127.0.0.1:8080 \
+  --var model=Qwen/Qwen3-Embedding-0.6B-GGUF --var tier=q8_0
+```
+
+Binary/model hashes are **local artifact inventory**, not attestation that a remote
+URL served those artifacts or selected that backend. Retain server startup/model
+selection logs, remote build/model digests, backend/precision configuration and
+topology with the native report before promoting a hardware result. Do not infer
+distributed qualification from a loopback run, or CUDA execution from a script's
+name. Remote services are user-owned: the runner neither starts nor stops them.
+
+## Document lanes
+
+Prepare the existing Circus corpus and frozen binaries/models as in [README.md](README.md).
+`document.plan.json` runs `qualify_documents.py`, which reuses `benchmark.py` and
+the existing output signatures. It requires:
+
+- All requested trials to finish indexing, both consumer outputs, and backend
+  selection evidence from the existing harness.
+- Forced OCR and exactly one physical render per source/page/trial for two
+  compatible consumers, including terminal partial windows.
+- Both `full_index` and `write` paths at two distinct renderer caps (256/128 MiB
+  by default), identical content hashes, page geometry and published-vector counts.
+- Successful windows with tracked bytes within the requested cap and actual
+  parallelism bounded by requested parallelism. A serial admitted window is valid;
+  requested workers alone never prove concurrent rendering.
+
+```sh
+python3 scripts/bench/pdf/qualify.py \
+  --plan scripts/bench/pdf/document.plan.json \
+  --output /tmp/pdf-document-evidence-001 \
+  --var binary=/path/to/frozen/antfly --var revision=FULL_BINARY_SOURCE_SHA \
+  --var models=/tmp/pdf-assets/models --var work_dir=/tmp/pdf-assets \
+  --var circus_dir=/path/to/antfly-circus --var name=document-001
+```
+
+This lane intentionally profiles and computes **no speedup**. Tracked render-window
+admission is not RSS/GPU peak memory, and low-cap success is not deterministic
+allocator-failure injection (covered in the contract lane). Structural parity is
+not OCR accuracy. The current benchmark pins Florence/BGE and confirms Metal;
+Gemma, ClipClap, extractor and reranker PDF hardware lanes remain unqualified.
+The existing `pdf-model-qualification-test` separately probes real remote reader,
+generator and embedder contracts, but only checks structural outputs.
+
+For completed-indexing performance, retain the existing alternating-order
+`compare.py` and same-binary `render_matrix.py` experiments separately, without
+profiling. Their reports now have schemas `antfly.pdf.comparison.v1` and
+`antfly.pdf.render_matrix.v1`; the native verdict field is `timing_comparable`.
+That verdict establishes comparability, **not that a speedup occurred**. Preserve
+first-process and warm-trial timing distributions and failures. Never compare
+ratios between different sync levels or memory caps.
+
+`performance.plan.json` runs that existing paired gate. Bind `main_binary`,
+`main_revision`, `pr_binary`, `pr_revision`, `models`, `work_dir`, `circus_dir`
+and a fresh `name` with `--var`. `compare.py` and `render_matrix.py` accept
+`--output` to place native evidence inside the runner's fresh gate directory
+while leaving shared corpus/model assets in `--work-dir`.
+
+A valid pressure-driven rematerialization can fail the strict one-render reuse
+gate without being a correctness defect. Keep its failure and pressure evidence;
+do not remove memory limits or force retention merely to pass the reuse check.
+
+## Plan and evidence contract
+
+Plans are executable configuration: review them like shell scripts. Commands are
+argv arrays, not shell strings. `${repo}`, `${run}`, `${python}` and explicit
+`--var NAME=VALUE` substitutions do not invoke a shell. Pass credentials through
+the existing environment, not command arguments/variables retained in reports.
+
+Each gate declares `id`, `layer` (`model`, `execution`, `document`), `kind`
+(`contract`, `hardware`, `performance`), `scope`, `command`, optional `cwd`, and
+positive `timeout_seconds`. Hardware/performance gates must name `artifacts`
+from the plan's path inventory. Files/directories are hashed before and after
+the run. Do not change weights while qualifying; large model trees are deliberately
+hashed twice. Build flags/driver/runtime/backend details remain in native evidence.
+
+JSON gates declare `report.path`, `report.schema`, `report.pass_field` and optional
+`report.schema_field` (for GLiNER's `contract`). Reports must be newly created
+inside `${run}`; stale, missing, unversioned, malformed or non-boolean verdicts
+fail closed. Legacy shell/compiled gates must opt into `legacy_exit_code: true`;
+the runner retains their entire log and a versioned exit-code envelope, without
+fabricating native JSON or additional acceptance criteria.
+
+Every output directory is new. The runner retains the plan, Git revision/dirty
+diff and untracked-source fingerprints, host identity, commands, logs, native
+report hashes, gate verdicts and artifact inventory. A changed source/artifact
+snapshot disqualifies the aggregate. Run from a frozen checkout and put output
+outside the checkout. Subprocess timeout/interruption terminates only the owned
+process group; failed attempts retain a non-passing summary. Other gates continue
+after a failed gate. Native evidence files remain alongside the summary.
+
+`--only execution` can select one layer of a combined plan without requiring
+unselected model assets; omitted gates remain `not_run`, so that partial run never
+passes the whole plan. A contract-only plan can pass its own scope, but missing
+layers remain visible. Combine reviewed gate entries in a plan when they target
+the same exact deployment; do not treat three unrelated green lanes as universal
+qualification. `limitations` must accompany published results.
+
+## Remaining hardware qualification
+
+This follow-up supplies orchestration and gates, not hardware measurements.
+Next run the pinned family artifacts, then qualify true cross-request extraction,
+all ClipClap modalities, reranking and chunking with their own result contracts;
+add backend-native fusion counters where absent. Run the same model contracts
+through independent inference nodes with cancellation/admission recovery and
+retain deployment identity. Extend document semantic oracles and accelerator/RSS
+measurements before claiming those properties. No placeholder or skipped gate is
+evidence of qualification.

--- a/scripts/bench/pdf/README.md
+++ b/scripts/bench/pdf/README.md
@@ -1,5 +1,8 @@
 # Remote-PDF ingestion comparison
 
+For the reuse-first model/execution/document qualification runner, contract plan,
+and profiled precommit/replay memory-cap gate, see [QUALIFICATION.md](QUALIFICATION.md).
+
 Internal engineering benchmark using the OHR-Bench corpus and adapter from
 `antflydb/antfly-circus`. The harness serves unchanged PDF bytes over loopback
 HTTP; **Antfly** fetches, parses, OCRs, chunks, embeds, and indexes them. `pypdf`

--- a/scripts/bench/pdf/benchmark.py
+++ b/scripts/bench/pdf/benchmark.py
@@ -335,6 +335,9 @@ def run_created(args, out):
         )
         startup_seconds = time.perf_counter() - process_started
         for trial in range(args.trials):
+            # Byte offsets bind diagnostic events to this trial without writing
+            # markers into the server-owned log or changing the timed interval.
+            profile_start = (out / "antfly.log").stat().st_size
             table_started = time.perf_counter()
             table = f"pdf_bench_{trial}"
             table_url = f"{url}/db/v1/tables/{table}"
@@ -538,6 +541,12 @@ def run_created(args, out):
             )
             result = dict(
                 trial=trial,
+                profile_log={
+                    "start_byte": profile_start,
+                    "end_byte": (out / "antfly.log").stat().st_size,
+                }
+                if args.read_profile
+                else None,
                 seconds=elapsed,
                 acknowledgement_seconds=ack_seconds,
                 startup_seconds=startup_seconds,

--- a/scripts/bench/pdf/benchmark.py
+++ b/scripts/bench/pdf/benchmark.py
@@ -23,6 +23,28 @@ def save(path, value):
     path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n")
 
 
+def completed_log_offset(path):
+    """Checkpoint the last complete record at a fixed, append-only log EOF.
+
+    A logger may flush one line in several writes. Never wait for it or include
+    a partial record; it remains available to a later checkpoint/validation.
+    Scan backwards in bounded blocks rather than loading the entire server log.
+    """
+    with path.open("rb") as stream:
+        end = stream.seek(0, os.SEEK_END)
+        while end:
+            start = max(0, end - 8192)
+            stream.seek(start)
+            block = stream.read(end - start)
+            if len(block) != end - start:
+                raise ValueError("server log was truncated during checkpoint")
+            newline = block.rfind(b"\n")
+            if newline >= 0:
+                return start + newline + 1
+            end = start
+    return 0
+
+
 def prepare():
     archive_digest = sha256(ROOT / "pdfs.zip")
     if archive_digest != ARCHIVE_SHA256:
@@ -335,9 +357,11 @@ def run_created(args, out):
         )
         startup_seconds = time.perf_counter() - process_started
         for trial in range(args.trials):
-            # Byte offsets bind diagnostic events to this trial without writing
-            # markers into the server-owned log or changing the timed interval.
-            profile_start = (out / "antfly.log").stat().st_size
+            # Checkpoint complete records without writing markers into the
+            # server-owned log or changing the timed interval.
+            profile_start = (
+                completed_log_offset(out / "antfly.log") if args.read_profile else None
+            )
             table_started = time.perf_counter()
             table = f"pdf_bench_{trial}"
             table_url = f"{url}/db/v1/tables/{table}"
@@ -543,7 +567,7 @@ def run_created(args, out):
                 trial=trial,
                 profile_log={
                     "start_byte": profile_start,
-                    "end_byte": (out / "antfly.log").stat().st_size,
+                    "end_byte": completed_log_offset(out / "antfly.log"),
                 }
                 if args.read_profile
                 else None,

--- a/scripts/bench/pdf/compare.py
+++ b/scripts/bench/pdf/compare.py
@@ -132,7 +132,12 @@ def comparable_pair(before, after, trials):
 
 
 def summarize(pairs, trials):
-    report = {"pairs": [], "timing_comparable": True, "timings": None}
+    report = {
+        "schema": "antfly.pdf.comparison.v1",
+        "pairs": [],
+        "timing_comparable": True,
+        "timings": None,
+    }
     for pair in pairs:
         errors = comparable_pair(pair["main"], pair["pr"], trials)
         for subject in ("main", "pr"):
@@ -270,6 +275,11 @@ def run_subject(args, out, index, subject):
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--work-dir", type=Path, required=True)
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Fresh evidence directory; defaults to WORK_DIR/NAME",
+    )
     parser.add_argument("--circus-dir", type=Path, required=True)
     for subject in ("main", "pr"):
         parser.add_argument(f"--{subject}-binary", type=Path, required=True)
@@ -306,7 +316,7 @@ def main():
         getattr(args, f"{subject}_binary").resolve(strict=True)
     args.work_dir = args.work_dir.resolve(strict=True)
     args.circus_dir = args.circus_dir.resolve(strict=True)
-    out = args.work_dir / args.name
+    out = args.output if args.output is not None else args.work_dir / args.name
     out.mkdir()  # Never overwrite an existing experiment.
     save(
         out / "experiment.json",

--- a/scripts/bench/pdf/document.plan.json
+++ b/scripts/bench/pdf/document.plan.json
@@ -1,0 +1,52 @@
+{
+  "schema": "antfly.pdf.qualification_plan.v1",
+  "artifacts": {
+    "binary": "${binary}",
+    "models": "${models}",
+    "corpus": "${work_dir}/corpus.json"
+  },
+  "limitations": [
+    "The existing document harness currently pins Florence/BGE and Metal; this is not a universal PDF model gate.",
+    "Model directory must match WORK_DIR/models used by the existing harness.",
+    "Profiled reuse/admission diagnostics are separate from unprofiled completed-indexing performance."
+  ],
+  "gates": [
+    {
+      "id": "pdf-reuse-pressure",
+      "layer": "document",
+      "kind": "hardware",
+      "scope": "Real remote-PDF completed indexing, exact retained content/page/vector parity, physical render reuse and tracked admission at two memory caps across precommit/replay.",
+      "artifacts": [
+        "binary",
+        "models",
+        "corpus"
+      ],
+      "command": [
+        "${python}",
+        "${repo}/scripts/bench/pdf/qualify_documents.py",
+        "--binary",
+        "${binary}",
+        "--revision",
+        "${revision}",
+        "--work-dir",
+        "${work_dir}",
+        "--circus-dir",
+        "${circus_dir}",
+        "--name",
+        "${name}-reuse",
+        "--output",
+        "${run}/document",
+        "--suite",
+        "text",
+        "--trials",
+        "2"
+      ],
+      "report": {
+        "path": "${run}/document/summary.json",
+        "schema": "antfly.pdf.document_qualification.v1",
+        "pass_field": "pass"
+      },
+      "timeout_seconds": 3600
+    }
+  ]
+}

--- a/scripts/bench/pdf/execution.plan.json
+++ b/scripts/bench/pdf/execution.plan.json
@@ -1,0 +1,114 @@
+{
+  "schema": "antfly.pdf.qualification_plan.v1",
+  "limitations": [
+    "Contract-only lane: fake providers do not qualify real models, native fusion, accelerator memory or hardware performance."
+  ],
+  "gates": [
+    {
+      "id": "inference-scheduler-contracts",
+      "layer": "execution",
+      "kind": "contract",
+      "scope": "Existing hermetic inference scheduler, task pipeline and backend contract tests; not real-model fused execution evidence.",
+      "cwd": "${repo}/zig/pkg/inference",
+      "command": ["zig", "build", "test", "-Doptimize=Debug", "-Dmetal=false", "-Dcuda=false", "-j1"],
+      "legacy_exit_code": true,
+      "timeout_seconds": 1800
+    },
+    {
+      "id": "invocation-contracts",
+      "layer": "execution",
+      "kind": "contract",
+      "scope": "Task-specific capability, per-item identity, admission, cancellation and borrowed-media contracts using fake providers.",
+      "cwd": "${repo}/zig",
+      "command": [
+        "zig",
+        "build",
+        "antfly-generating-test",
+        "-Doptimize=Debug",
+        "-j1"
+      ],
+      "legacy_exit_code": true,
+      "timeout_seconds": 1800
+    },
+    {
+      "id": "worker-transport",
+      "layer": "execution",
+      "kind": "contract",
+      "scope": "Linked and worker-process ABI ownership, cancellation, capacity and borrowed payload isolation; no model correctness claim.",
+      "cwd": "${repo}/zig",
+      "command": [
+        "zig",
+        "build",
+        "antfly-standalone-runtime-test",
+        "-Doptimize=Debug",
+        "-j1"
+      ],
+      "legacy_exit_code": true,
+      "timeout_seconds": 1800
+    },
+    {
+      "id": "embedding-contracts",
+      "layer": "execution",
+      "kind": "contract",
+      "scope": "Provider request boundaries, task roles, credentials, batching cardinality and cancellation; fake provider results.",
+      "cwd": "${repo}/zig",
+      "command": [
+        "zig",
+        "build",
+        "antfly-inference-managed-embedder-test",
+        "-Doptimize=Debug",
+        "-j1"
+      ],
+      "legacy_exit_code": true,
+      "timeout_seconds": 1800
+    },
+    {
+      "id": "pdf-renderer",
+      "layer": "document",
+      "kind": "contract",
+      "scope": "Native PDF parsing/rendering, bounded row decoding and production coordinator with a model-free reader.",
+      "cwd": "${repo}/zig",
+      "command": [
+        "zig",
+        "build",
+        "lib-pdf-test",
+        "-Doptimize=Debug",
+        "-j1"
+      ],
+      "legacy_exit_code": true,
+      "timeout_seconds": 1800
+    },
+    {
+      "id": "document-replay",
+      "layer": "document",
+      "kind": "contract",
+      "scope": "Precommit/replay publication, shared windows, provenance and admission recovery under deterministic test pressure.",
+      "cwd": "${repo}/zig",
+      "command": [
+        "zig",
+        "build",
+        "antfly-storage-db-enrichment-test",
+        "-Doptimize=Debug",
+        "-j1"
+      ],
+      "legacy_exit_code": true,
+      "timeout_seconds": 1800
+    },
+    {
+      "id": "distributed-routing",
+      "layer": "execution",
+      "kind": "contract",
+      "scope": "Inference route discovery, advertised capabilities and proxy routing contracts; not a real multinode model run.",
+      "cwd": "${repo}/go/pkg/proxy",
+      "command": [
+        "env",
+        "GOWORK=off",
+        "go",
+        "test",
+        "./inference"
+      ],
+      "legacy_exit_code": true,
+      "timeout_seconds": 300
+    }
+  ]
+}

--- a/scripts/bench/pdf/performance.plan.json
+++ b/scripts/bench/pdf/performance.plan.json
@@ -1,0 +1,74 @@
+{
+  "schema": "antfly.pdf.qualification_plan.v1",
+  "artifacts": {
+    "main_binary": "${main_binary}",
+    "pr_binary": "${pr_binary}",
+    "models": "${models}",
+    "corpus": "${work_dir}/corpus.json"
+  },
+  "limitations": [
+    "A passing native comparison establishes timing comparability, not that the candidate is faster.",
+    "The existing benchmark pins Florence/BGE and requires Metal evidence.",
+    "Keep the same sync level, cap, corpus, model files, compiler/build configuration and host; review cold/warm distributions separately."
+  ],
+  "gates": [
+    {
+      "id": "pdf-completed-indexing",
+      "layer": "document",
+      "kind": "performance",
+      "scope": "Existing unprofiled alternating-order, equal-output completed-indexing comparison; native report retains first-process and warm-process distributions.",
+      "artifacts": [
+        "main_binary",
+        "pr_binary",
+        "models",
+        "corpus"
+      ],
+      "command": [
+        "${python}",
+        "${repo}/scripts/bench/pdf/compare.py",
+        "--work-dir",
+        "${work_dir}",
+        "--circus-dir",
+        "${circus_dir}",
+        "--main-binary",
+        "${main_binary}",
+        "--main-revision",
+        "${main_revision}",
+        "--pr-binary",
+        "${pr_binary}",
+        "--pr-revision",
+        "${pr_revision}",
+        "--output",
+        "${run}/comparison",
+        "--name",
+        "${name}-performance",
+        "--suite",
+        "text",
+        "--mode",
+        "always",
+        "--consumers",
+        "2",
+        "--sync-level",
+        "full_index",
+        "--reader-batch-size",
+        "4",
+        "--render-workers",
+        "4",
+        "--render-prefetch",
+        "1",
+        "--render-memory-bytes",
+        "268435456",
+        "--pairs",
+        "2",
+        "--trials",
+        "3"
+      ],
+      "report": {
+        "path": "${run}/comparison/summary.json",
+        "schema": "antfly.pdf.comparison.v1",
+        "pass_field": "timing_comparable"
+      },
+      "timeout_seconds": 7200
+    }
+  ]
+}

--- a/scripts/bench/pdf/qualify.py
+++ b/scripts/bench/pdf/qualify.py
@@ -1,0 +1,438 @@
+"""Run existing qualification gates and retain scoped, versioned evidence.
+
+Plans are trusted executable configuration, not downloaded evidence. The runner
+never reimplements model validators or promotes contract tests into hardware proof.
+"""
+
+import argparse
+import hashlib
+import json
+import math
+import os
+import platform
+import re
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+PLAN_SCHEMA = "antfly.pdf.qualification_plan.v1"
+REPORT_SCHEMA = "antfly.pdf.qualification_run.v1"
+GATE_SCHEMA = "antfly.pdf.qualification_gate.v1"
+LAYERS = ("model", "execution", "document")
+KINDS = ("contract", "hardware", "performance")
+
+
+def read_json(path):
+    def reject(value):
+        raise ValueError(f"non-finite JSON number: {value}")
+
+    return json.loads(path.read_text(), parse_constant=reject)
+
+
+def save(path, payload):
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_text(
+        json.dumps(payload, indent=2, sort_keys=True, allow_nan=False) + "\n"
+    )
+    temporary.replace(path)
+
+
+def sha256(path):
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def expand(value, variables):
+    def replace(match):
+        name = match[1]
+        if name not in variables:
+            raise ValueError(f"missing variable: {name}")
+        return variables[name]
+
+    return re.sub(r"\$\{([a-zA-Z_][a-zA-Z_0-9]*)\}", replace, value)
+
+
+def validate_plan(plan):
+    if (
+        not isinstance(plan, dict)
+        or plan.get("schema") != PLAN_SCHEMA
+        or not isinstance(plan.get("gates"), list)
+        or not plan["gates"]
+    ):
+        raise ValueError("expected a versioned plan with nonempty gates")
+    seen = set()
+    artifacts = plan.get("artifacts", {})
+    if not isinstance(artifacts, dict) or any(
+        not isinstance(value, str) for value in artifacts.values()
+    ):
+        raise ValueError("artifacts must map names to paths")
+    for gate in plan["gates"]:
+        if not isinstance(gate, dict):
+            raise TypeError("gates must be objects")
+        identity = gate.get("id", "")
+        if (
+            not isinstance(identity, str)
+            or not re.fullmatch(r"[a-z0-9][a-z0-9_-]*", identity)
+            or identity in seen
+        ):
+            raise ValueError("gate IDs must be unique safe directory names")
+        seen.add(identity)
+        if not isinstance(gate.get("cwd", "${repo}"), str):
+            raise TypeError(f"{identity}: cwd must be a path string")
+        if gate.get("layer") not in LAYERS or gate.get("kind") not in KINDS:
+            raise ValueError(f"{identity}: missing layer or evidence kind")
+        if not isinstance(gate.get("scope"), str) or not gate["scope"].strip():
+            raise ValueError(f"{identity}: an explicit, bounded scope is required")
+        required = gate.get("artifacts", [])
+        if not isinstance(required, list) or any(
+            not isinstance(key, str) or key not in artifacts for key in required
+        ):
+            raise ValueError(f"{identity}: unknown artifact binding")
+        if gate["kind"] != "contract" and not required:
+            raise ValueError(
+                f"{identity}: hardware/performance gates require artifact bindings"
+            )
+        command = gate.get("command")
+        if (
+            not isinstance(command, list)
+            or not command
+            or any(not isinstance(arg, str) or not arg for arg in command)
+        ):
+            raise ValueError(f"{identity}: command must be a nonempty argv array")
+        timeout = gate.get("timeout_seconds", 1800)
+        if (
+            type(timeout) not in (int, float)
+            or not math.isfinite(timeout)
+            or timeout <= 0
+        ):
+            raise ValueError(f"{identity}: invalid timeout")
+        result = gate.get("report")
+        if result is not None:
+            if not isinstance(result, dict) or not all(
+                isinstance(result.get(key), str) and result[key]
+                for key in ("path", "schema", "pass_field")
+            ):
+                raise ValueError(
+                    f"{identity}: report needs path, schema and pass_field"
+                )
+        # Legacy shell/compiled gates publish a versioned exit-code envelope;
+        # opting in explicitly prevents accidentally dropping a JSON verdict.
+        elif gate.get("legacy_exit_code") is not True:
+            raise ValueError(
+                f"{identity}: report or explicit legacy_exit_code required"
+            )
+
+
+def snapshot(paths):
+    result = {}
+    for label, value in sorted(paths.items()):
+        path = Path(value).resolve(strict=True)
+        files = sorted(path.rglob("*")) if path.is_dir() else [path]
+        entries = []
+        for file in files:
+            if file.is_symlink() and file.is_dir():
+                raise ValueError(
+                    f"artifact directory symlink must be bound explicitly: {file}"
+                )
+            if file.is_file():
+                entries.append(
+                    {
+                        "path": (
+                            str(file.relative_to(path)) if path.is_dir() else file.name
+                        ),
+                        "bytes": file.stat().st_size,
+                        "sha256": sha256(file),
+                    }
+                )
+        if not entries:
+            raise ValueError(f"artifact {label} is empty")
+        result[label] = {"path": str(path), "files": entries}
+    return result
+
+
+def source_state(repo):
+    def git(*args):
+        return subprocess.check_output(
+            ["git", "-C", str(repo), *args], text=True
+        ).strip()
+
+    untracked = (
+        subprocess.check_output(
+            ["git", "-C", str(repo), "ls-files", "--others", "--exclude-standard", "-z"]
+        )
+        .decode()
+        .split("\0")
+    )
+    return {
+        "revision": git("rev-parse", "HEAD"),
+        "status": git("status", "--porcelain", "--untracked-files=normal"),
+        "untracked_sha256": {
+            name: sha256(repo / name)
+            for name in untracked
+            if name and (repo / name).is_file()
+        },
+        "diff_sha256": hashlib.sha256(
+            subprocess.check_output(
+                ["git", "-C", str(repo), "diff", "HEAD", "--binary"]
+            )
+        ).hexdigest(),
+    }
+
+
+def run_command(command, cwd, log_path, timeout):
+    if os.name != "posix":
+        raise ValueError("qualification process-group cleanup requires POSIX")
+    started = time.monotonic()
+    with log_path.open("wb") as log:
+        child = subprocess.Popen(
+            command,
+            cwd=cwd,
+            stdout=log,
+            stderr=subprocess.STDOUT,
+            start_new_session=True,
+        )
+        timed_out = False
+        try:
+            try:
+                code = child.wait(timeout=timeout)
+            except subprocess.TimeoutExpired:
+                timed_out = True
+                code = None
+        finally:
+            # Only this invocation's process group; never kill by executable name.
+            try:
+                os.killpg(child.pid, signal.SIGTERM)
+            except ProcessLookupError:
+                pass
+            try:
+                child.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                pass
+            try:
+                os.killpg(child.pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+            child.wait()
+    return {
+        "returncode": code,
+        "timed_out": timed_out,
+        "seconds": time.monotonic() - started,
+    }
+
+
+def run_gate(gate, repo, folder, variables):
+    folder = folder.resolve()
+    folder.mkdir()
+    values = {
+        **variables,
+        "repo": str(repo),
+        "run": str(folder),
+        "python": sys.executable,
+    }
+    result = {
+        "schema": GATE_SCHEMA,
+        "id": gate["id"],
+        "layer": gate["layer"],
+        "kind": gate["kind"],
+        "scope": gate["scope"],
+        "pass": False,
+    }
+    try:
+        command = [expand(arg, values) for arg in gate["command"]]
+        cwd = Path(expand(gate.get("cwd", "${repo}"), values)).resolve(strict=True)
+        result["command"] = command
+        result["cwd"] = str(cwd)
+        spec = gate.get("report")
+        report_path = None
+        if spec:
+            report_path = Path(expand(spec["path"], values)).resolve()
+            if not report_path.is_relative_to(folder) or report_path.exists():
+                raise ValueError(
+                    "gate reports must be fresh files inside their run directory"
+                )
+        result.update(
+            run_command(
+                command, cwd, folder / "command.log", gate.get("timeout_seconds", 1800)
+            )
+        )
+        result["pass"] = result["returncode"] == 0 and not result["timed_out"]
+        if report_path:
+            if (
+                not report_path.resolve().is_relative_to(folder)
+                or report_path.is_symlink()
+            ):
+                raise ValueError("native report escaped its fresh run directory")
+            payload = read_json(report_path)
+            result["report"] = {
+                "path": str(report_path.relative_to(folder)),
+                "sha256": sha256(report_path),
+            }
+            if (
+                not isinstance(payload, dict)
+                or payload.get(spec.get("schema_field", "schema")) != spec["schema"]
+            ):
+                raise ValueError("unexpected native report schema")
+            verdict = payload.get(spec["pass_field"])
+            if type(verdict) is not bool:
+                raise ValueError("native report verdict must be a boolean")
+            result["pass"] = result["pass"] and verdict
+        else:
+            result["legacy_exit_code"] = True
+    except KeyboardInterrupt:
+        result.update({"pass": False, "interrupted": True})
+        save(folder / "gate.json", result)
+        raise
+    except (OSError, ValueError, subprocess.SubprocessError) as exc:
+        result.update({"pass": False, "error": str(exc)})
+    save(folder / "gate.json", result)
+    return result
+
+
+def run_plan(plan, repo, out, variables, only=None):
+    validate_plan(plan)
+    out = out.resolve()
+    repo = repo.resolve(strict=True)
+    # A fresh directory forbids stale successful reports from previous attempts.
+    out.mkdir(parents=True, exist_ok=False)
+    save(out / "plan.json", plan)
+    before = source_state(repo)
+    report = {
+        "schema": REPORT_SCHEMA,
+        "pass": False,
+        "complete": False,
+        "source": before,
+        "host": {"platform": platform.platform(), "machine": platform.machine()},
+        "gates": [],
+        "limitations": plan.get("limitations", []),
+        "claim": "Only the listed gate scopes; not universal model, hardware or PDF qualification.",
+    }
+    save(out / "summary.json", report)
+    try:
+        required = {
+            key
+            for gate in plan["gates"]
+            if only is None or gate["layer"] == only
+            for key in gate.get("artifacts", [])
+        }
+        paths = {
+            key: expand(plan["artifacts"][key], {**variables, "repo": str(repo)})
+            for key in required
+        }
+        report["artifacts"] = snapshot(paths)
+        for gate in plan["gates"]:
+            if only is not None and gate["layer"] != only:
+                report["gates"].append(
+                    {
+                        "id": gate["id"],
+                        "layer": gate["layer"],
+                        "kind": gate["kind"],
+                        "scope": gate["scope"],
+                        "pass": False,
+                        "not_run": True,
+                    }
+                )
+            else:
+                print(
+                    f"Qualifying {gate['id']} ({gate['layer']}/{gate['kind']})",
+                    flush=True,
+                )
+                report["gates"].append(
+                    run_gate(gate, repo, out / gate["id"], variables)
+                )
+            save(out / "summary.json", report)
+        report["artifacts_unchanged"] = report["artifacts"] == snapshot(paths)
+        report["source_unchanged"] = before == source_state(repo)
+        report["complete"] = not any(row.get("not_run") for row in report["gates"])
+        report["layers"] = {
+            layer: {
+                "selected": sum(
+                    row["layer"] == layer and not row.get("not_run")
+                    for row in report["gates"]
+                ),
+                "pass": any(row["layer"] == layer for row in report["gates"])
+                and all(
+                    row["pass"] for row in report["gates"] if row["layer"] == layer
+                ),
+            }
+            for layer in LAYERS
+        }
+        report["pass"] = (
+            report["complete"]
+            and all(row["pass"] for row in report["gates"])
+            and report["artifacts_unchanged"]
+            and report["source_unchanged"]
+        )
+        report["all_layers_represented"] = all(
+            row["selected"] > 0 for row in report["layers"].values()
+        )
+    except KeyboardInterrupt:
+        report["interrupted"] = True
+        raise
+    except (OSError, ValueError, subprocess.SubprocessError) as exc:
+        report["error"] = str(exc)
+    finally:
+        save(out / "summary.json", report)
+    return report
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--plan", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument(
+        "--repo", type=Path, default=Path(__file__).resolve().parents[3]
+    )
+    parser.add_argument("--var", action="append", default=[], metavar="NAME=VALUE")
+    parser.add_argument(
+        "--only", choices=LAYERS, help="Run one layer; omitted gates remain unqualified"
+    )
+    args = parser.parse_args(argv)
+    variables = {}
+    for item in args.var:
+        key, separator, value = item.partition("=")
+        if (
+            not separator
+            or not re.fullmatch(r"[A-Za-z_][A-Za-z_0-9]*", key)
+            or key in ("repo", "run", "python")
+            or key in variables
+        ):
+            parser.error(
+                "variables must be unique NAME=VALUE pairs; repo/run/python are reserved"
+            )
+        variables[key] = value
+
+    def interrupt(signum, _frame):
+        raise KeyboardInterrupt(signum)
+
+    # Batch launchers may inherit SIGINT=SIG_IGN. Establish explicit handlers so
+    # both Ctrl-C and orchestrator SIGTERM unwind the owned process-group lease.
+    previous = {
+        signum: signal.signal(signum, interrupt)
+        for signum in (signal.SIGINT, signal.SIGTERM)
+    }
+    try:
+        report = run_plan(
+            read_json(args.plan), args.repo, args.output, variables, args.only
+        )
+    except (OSError, ValueError, TypeError, subprocess.SubprocessError) as exc:
+        parser.exit(2, f"qualification: {exc}\n")
+    except KeyboardInterrupt as exc:
+        signum = (
+            exc.args[0] if exc.args and isinstance(exc.args[0], int) else signal.SIGINT
+        )
+        parser.exit(
+            128 + signum, "qualification interrupted; non-passing evidence retained\n"
+        )
+    finally:
+        for signum, handler in previous.items():
+            signal.signal(signum, handler)
+    return 0 if report["pass"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/bench/pdf/qualify_documents.py
+++ b/scripts/bench/pdf/qualify_documents.py
@@ -1,0 +1,229 @@
+"""Qualify profiled two-consumer PDF reuse across precommit/replay and memory caps.
+
+Reuses the real remote-PDF harness's structural/content signatures. These are
+diagnostics, never throughput ratios or an OCR accuracy oracle.
+"""
+
+import argparse
+import re
+from collections import Counter
+from pathlib import Path
+from types import SimpleNamespace
+
+from compare import output_signature, run_subject, save
+from render_matrix import render_observations
+
+SCHEMA = "antfly.pdf.document_qualification.v1"
+
+
+def evaluate_run(run, log, trials, memory_bytes):
+    errors = []
+    results = run.get("results", [])
+    if (
+        run.get("returncode") != 0
+        or len(results) != trials
+        or not all(row.get("passed") is True for row in results)
+    ):
+        errors.append("incomplete or failed indexing")
+    if not run.get("metal_confirmed"):
+        errors.append("existing harness did not confirm model backend selection")
+    provenance = run.get("provenance", {})
+    if (
+        provenance.get("mode") != "always"
+        or provenance.get("consumers") != 2
+        or provenance.get("read_profile") is not True
+        or provenance.get("render_memory_bytes") != memory_bytes
+    ):
+        errors.append("missing forced-OCR/two-consumer/profile/memory controls")
+    signatures = []
+    for row in results:
+        try:
+            signature = output_signature(row)
+            if (
+                len(signature["consumer_results"]) != 1
+                or not signature["unit_text_sha256"]
+                or not signature["unit_render_geometry"]
+            ):
+                raise ValueError("missing two-consumer content/page evidence")
+            signatures.append(signature)
+        except (KeyError, TypeError, ValueError) as exc:
+            errors.append(str(exc))
+    observations = render_observations(log)
+    renders = [row for row in observations if row["phase"] == "pdf_render"]
+    windows = [row for row in observations if row["phase"] == "pdf_render_window"]
+    identities = Counter()
+    try:
+        for row in renders:
+            source = row["source_fingerprint"]
+            page = int(row["page"])
+            if (
+                not source
+                or source == "null"
+                or page < 1
+                or row.get("failure") != "null"
+            ):
+                raise ValueError("failed/unattributed physical render")
+            identities[(source, page)] += 1
+        expected = sum(row["pages"] for row in results)
+        if (
+            expected <= 0
+            or len(renders) != expected
+            or any(count != trials for count in identities.values())
+        ):
+            errors.append(
+                "physical renders do not cover each source/page exactly once per trial"
+            )
+        if not windows:
+            errors.append("missing render-window admission evidence")
+        for row in windows:
+            peak = int(row["peak_bytes"])
+            active = int(row["peak_parallelism"])
+            requested = int(row["requested_parallelism"])
+            if (
+                row.get("failure") != "null"
+                or not 0 < peak <= memory_bytes
+                or not 1 <= active <= requested
+            ):
+                errors.append(
+                    "failed window or invalid tracked memory/parallelism bounds"
+                )
+    except (KeyError, TypeError, ValueError) as exc:
+        errors.append(f"invalid profile evidence: {exc}")
+    return {
+        "pass": not errors,
+        "errors": errors,
+        "signatures": signatures,
+        "physical_renders": len(renders),
+        "windows": windows,
+    }
+
+
+def summarize(runs, trials):
+    checks = []
+    reference = None
+    identity = None
+    for entry in runs:
+        run = entry["run"]
+        result = evaluate_run(run, entry["log"], trials, entry["memory_bytes"])
+        result.update(
+            sync_level=entry["sync_level"], memory_bytes=entry["memory_bytes"]
+        )
+        if run.get("provenance", {}).get("sync_level") != entry["sync_level"]:
+            result["errors"].append("sync-level provenance mismatch")
+        current_identity = {
+            key: run.get(key) for key in ("models", "table_config", "server_config")
+        }
+        current_identity["provenance"] = {
+            key: run.get("provenance", {}).get(key)
+            for key in (
+                "binary_sha256",
+                "revision",
+                "selected",
+                "circus_revision",
+                "suite",
+                "reader_batch_size",
+                "render_workers",
+                "render_prefetch",
+            )
+        }
+        if any(value is None for value in current_identity.values()) or any(
+            value is None for value in current_identity["provenance"].values()
+        ):
+            result["errors"].append("missing pinned artifact/configuration identity")
+        if identity is None:
+            identity = current_identity
+        elif current_identity != identity:
+            result["errors"].append("binary/model/corpus/configuration drift")
+        for signature in result.pop("signatures"):
+            if reference is None:
+                reference = signature
+            elif reference != signature:
+                result["errors"].append(
+                    "content/page/vector signature differs across paths or memory caps"
+                )
+        result["pass"] = not result["errors"]
+        checks.append(result)
+    controls = [(entry["sync_level"], entry["memory_bytes"]) for entry in runs]
+    caps = {cap for _, cap in controls}
+    complete = (
+        len(caps) >= 2
+        and len(controls) == len(set(controls))
+        and set(controls)
+        == {(sync, cap) for sync in ("full_index", "write") for cap in caps}
+    )
+    return {
+        "schema": SCHEMA,
+        "pass": complete and all(check["pass"] for check in checks),
+        "complete": complete,
+        "checks": checks,
+        "limitations": [
+            "Profiled: no throughput claim.",
+            "Tracked window admission is not peak RSS or GPU residency.",
+            "Structural/text parity is not OCR semantic accuracy.",
+            "Current PDF benchmark pins Florence/BGE and verifies Metal; other task/backend document lanes remain unqualified.",
+        ],
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    for name in ("work-dir", "circus-dir", "binary", "output"):
+        parser.add_argument("--" + name, type=Path, required=True)
+    parser.add_argument("--revision", required=True)
+    parser.add_argument("--name", required=True)
+    parser.add_argument(
+        "--suite",
+        choices=("text", "small", "throughput", "qualification"),
+        default="text",
+    )
+    parser.add_argument(
+        "--memory-bytes", type=int, nargs="+", default=[268435456, 134217728]
+    )
+    parser.add_argument("--trials", type=int, default=2)
+    parser.add_argument("--timeout", type=int, default=300)
+    parser.add_argument("--port", type=int, default=29700)
+    args = parser.parse_args()
+    if not re.fullmatch(r"[a-zA-Z0-9][a-zA-Z0-9_.-]*", args.name) or not re.fullmatch(
+        r"[0-9a-f]{40}", args.revision
+    ):
+        parser.error("name must be a safe directory name and revision a full SHA")
+    if (
+        min(args.memory_bytes + [args.trials, args.timeout]) <= 0
+        or len(set(args.memory_bytes)) < 2
+        or len(set(args.memory_bytes)) != len(args.memory_bytes)
+    ):
+        parser.error("require positive controls and at least two distinct memory caps")
+    args.output.mkdir(parents=True, exist_ok=False)
+    runs = []
+    for sync in ("full_index", "write"):
+        for cap in args.memory_bytes:
+            current = SimpleNamespace(
+                **vars(args),
+                pr_binary=args.binary,
+                pr_revision=args.revision,
+                sync_level=sync,
+                render_memory_bytes=cap,
+                mode="always",
+                consumers=2,
+                reader_batch_size=4,
+                render_workers=4,
+                render_prefetch=1,
+                read_profile=True,
+            )
+            run = run_subject(current, args.output, len(runs), "pr")
+            log_path = args.work_dir / run["name"] / "antfly.log"
+            runs.append(
+                {
+                    "sync_level": sync,
+                    "memory_bytes": cap,
+                    "run": run,
+                    "log": log_path.read_text() if log_path.exists() else "",
+                }
+            )
+            save(args.output / f"run-{len(runs):02d}.json", runs[-1])
+            save(args.output / "summary.json", summarize(runs, args.trials))
+    return 0 if summarize(runs, args.trials)["pass"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/bench/pdf/qualify_documents.py
+++ b/scripts/bench/pdf/qualify_documents.py
@@ -16,6 +16,86 @@ from render_matrix import render_observations
 SCHEMA = "antfly.pdf.document_qualification.v1"
 
 
+def expected_pages(result, selected):
+    """Bind corpus page ranges to the fingerprints published by indexing."""
+    manifests = result["manifests"]
+    sources = {row["path"]: row["pages"] for row in selected}
+    if (
+        not sources
+        or len(sources) != len(selected)
+        or any(
+            set(mapping) != set(sources)
+            for mapping in (
+                manifests,
+                result["unit_render_geometry"],
+                result["unit_text_sha256"],
+            )
+        )
+    ):
+        raise ValueError("manifest sources do not match the selected corpus")
+    expected = Counter()
+    fingerprints = set()
+    for path, pages in sources.items():
+        fingerprint = manifests[path]["source_fingerprint"]
+        if (
+            not isinstance(fingerprint, str)
+            or not fingerprint
+            or fingerprint == "null"
+            or fingerprint in fingerprints
+            or type(pages) is not int
+            or pages <= 0
+        ):
+            raise ValueError("missing/ambiguous source identity or invalid page count")
+        fingerprints.add(fingerprint)
+        geometry = result["unit_render_geometry"][path]
+        actual_pages = [item["page_number"] for item in geometry.values()]
+        if (
+            any(type(page) is not int for page in actual_pages)
+            or sorted(actual_pages) != list(range(1, pages + 1))
+            or set(geometry) != set(result["unit_text_sha256"][path])
+        ):
+            raise ValueError("retained units do not cover the corpus page range")
+        expected.update((fingerprint, page) for page in range(1, pages + 1))
+    if result["pages"] != sum(sources.values()):
+        raise ValueError("result page count differs from corpus")
+    return expected
+
+
+def verify_trial_profile(observations, expected, memory_bytes, workers):
+    """Require exact render and admission coverage, including partial windows."""
+    renders = Counter()
+    windows = Counter()
+    for row in observations:
+        phase = row["phase"]
+        if phase not in ("pdf_render", "pdf_render_window"):
+            continue
+        source = row["source_fingerprint"]
+        if row.get("failure") != "null":
+            raise ValueError("failed physical render/window")
+        if phase == "pdf_render":
+            renders[(source, int(row["page"]))] += 1
+            continue
+        first, last, count = (
+            int(row[key]) for key in ("first_page", "last_page", "pages")
+        )
+        if not 0 < count == last - first + 1 <= len(expected):
+            raise ValueError("invalid render-window page range")
+        windows.update((source, page) for page in range(first, last + 1))
+        peak = int(row["peak_bytes"])
+        active = int(row["peak_parallelism"])
+        requested = int(row["requested_parallelism"])
+        if not 0 < peak <= memory_bytes or not 1 <= active <= requested <= workers:
+            raise ValueError("invalid tracked memory/parallelism bounds")
+    if renders != expected:
+        raise ValueError(
+            "physical renders do not cover expected source/pages once in this trial"
+        )
+    if windows != expected:
+        raise ValueError(
+            "render windows do not cover expected source/pages once in this trial"
+        )
+
+
 def evaluate_run(run, log, trials, memory_bytes):
     errors = []
     results = run.get("results", [])
@@ -45,48 +125,56 @@ def evaluate_run(run, log, trials, memory_bytes):
                 or not signature["unit_render_geometry"]
             ):
                 raise ValueError("missing two-consumer content/page evidence")
+            consumer = signature["consumer_results"][0]
+            for primary, secondary in (
+                ("unit_text_sha256", "unit_text_sha256"),
+                ("unit_render_geometry", "unit_render_geometry"),
+                ("documents", "manifest_counts"),
+                ("vectors", "searchable_vectors"),
+            ):
+                if signature[primary] != consumer[secondary]:
+                    raise ValueError(f"identical consumers differ: {primary}")
             signatures.append(signature)
         except (KeyError, TypeError, ValueError) as exc:
             errors.append(str(exc))
-    observations = render_observations(log)
+    # Keep byte offsets exact (including CRLF/non-ASCII log content).
+    raw_log = log.encode("utf-8") if isinstance(log, str) else log
+    observations = render_observations(raw_log.decode("utf-8"))
     renders = [row for row in observations if row["phase"] == "pdf_render"]
     windows = [row for row in observations if row["phase"] == "pdf_render_window"]
-    identities = Counter()
     try:
-        for row in renders:
-            source = row["source_fingerprint"]
-            page = int(row["page"])
+        workers = provenance["render_workers"]
+        if type(workers) is not int or workers <= 0:
+            raise ValueError("missing renderer worker bound")
+        cursor = 0
+        excluded = []
+        for trial, row in enumerate(results):
+            bounds = row["profile_log"]
+            start, end = bounds["start_byte"], bounds["end_byte"]
             if (
-                not source
-                or source == "null"
-                or page < 1
-                or row.get("failure") != "null"
+                row["trial"] != trial
+                or type(start) is not int
+                or type(end) is not int
+                or not cursor <= start < end <= len(raw_log)
+                or (start > 0 and raw_log[start - 1 : start] != b"\n")
+                or raw_log[end - 1 : end] != b"\n"
             ):
-                raise ValueError("failed/unattributed physical render")
-            identities[(source, page)] += 1
-        expected = sum(row["pages"] for row in results)
-        if (
-            expected <= 0
-            or len(renders) != expected
-            or any(count != trials for count in identities.values())
-        ):
-            errors.append(
-                "physical renders do not cover each source/page exactly once per trial"
+                raise ValueError("missing/invalid per-trial log boundaries")
+            excluded.append(raw_log[cursor:start])
+            cursor = end
+            verify_trial_profile(
+                render_observations(raw_log[start:end].decode("utf-8")),
+                expected_pages(row, provenance["selected"]),
+                memory_bytes,
+                workers,
             )
-        if not windows:
-            errors.append("missing render-window admission evidence")
-        for row in windows:
-            peak = int(row["peak_bytes"])
-            active = int(row["peak_parallelism"])
-            requested = int(row["requested_parallelism"])
-            if (
-                row.get("failure") != "null"
-                or not 0 < peak <= memory_bytes
-                or not 1 <= active <= requested
-            ):
-                errors.append(
-                    "failed window or invalid tracked memory/parallelism bounds"
-                )
+        excluded.append(raw_log[cursor:])
+        if any(
+            row["phase"] in ("pdf_render", "pdf_render_window")
+            for part in excluded
+            for row in render_observations(part.decode("utf-8"))
+        ):
+            raise ValueError("render evidence exists outside indexed trial boundaries")
     except (KeyError, TypeError, ValueError) as exc:
         errors.append(f"invalid profile evidence: {exc}")
     return {
@@ -217,7 +305,9 @@ def main():
                     "sync_level": sync,
                     "memory_bytes": cap,
                     "run": run,
-                    "log": log_path.read_text() if log_path.exists() else "",
+                    "log": log_path.read_bytes().decode("utf-8")
+                    if log_path.exists()
+                    else "",
                 }
             )
             save(args.output / f"run-{len(runs):02d}.json", runs[-1])

--- a/scripts/bench/pdf/qwen3-metal.plan.json
+++ b/scripts/bench/pdf/qwen3-metal.plan.json
@@ -1,0 +1,50 @@
+{
+  "schema": "antfly.pdf.qualification_plan.v1",
+  "artifacts": {
+    "binary": "${binary}",
+    "models": "${models}",
+    "oracle": "${oracle}"
+  },
+  "limitations": [
+    "Local artifact hashes are inventory, not attestation of a remote serving process. Retain deployment/backend evidence separately.",
+    "Qwen's existing oracle gates and added request isolation do not prove physical native fusion.",
+    "This plan qualifies only the Qwen embedding gate; no PDF or other model family coverage is implied."
+  ],
+  "gates": [
+    {
+      "id": "qwen3-metal",
+      "layer": "model",
+      "kind": "hardware",
+      "scope": "Existing Qwen3 Metal-lane precision/oracle/retrieval/MRL/batch gates plus bounded cross-request role and dimension isolation.",
+      "artifacts": [
+        "binary",
+        "models",
+        "oracle"
+      ],
+      "command": [
+        "${python}",
+        "${repo}/zig/pkg/inference/scripts/qwen3_embedding/qualify_qwen3_embedding_metal.py",
+        "--oracle",
+        "${oracle}",
+        "--base-url",
+        "${base_url}",
+        "--model",
+        "${model}",
+        "--tier",
+        "${tier}",
+        "--concurrency",
+        "4",
+        "--concurrent-rounds",
+        "2",
+        "--report",
+        "${run}/native.json"
+      ],
+      "report": {
+        "path": "${run}/native.json",
+        "schema": "antfly.qwen3_embedding.metal_qualification.v1",
+        "pass_field": "pass"
+      },
+      "timeout_seconds": 3600
+    }
+  ]
+}

--- a/scripts/bench/pdf/render_matrix.py
+++ b/scripts/bench/pdf/render_matrix.py
@@ -39,6 +39,11 @@ def render_observations(log):
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--work-dir", type=Path, required=True)
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Fresh evidence directory; defaults to WORK_DIR/NAME",
+    )
     parser.add_argument("--circus-dir", type=Path, required=True)
     parser.add_argument("--binary", type=Path, required=True)
     parser.add_argument("--revision", required=True)
@@ -69,7 +74,7 @@ def main():
     args.work_dir = args.work_dir.resolve(strict=True)
     args.circus_dir = args.circus_dir.resolve(strict=True)
     args.binary = args.binary.resolve(strict=True)
-    out = args.work_dir / args.name
+    out = args.output if args.output is not None else args.work_dir / args.name
     out.mkdir()
     save(
         out / "experiment.json",
@@ -97,7 +102,12 @@ def main():
             log = (args.work_dir / current[label]["name"] / "antfly.log").read_text()
             current[label]["render_observations"] = render_observations(log)
             save(out / f"round-{round_index:02d}.json", current)
-    report = {"baseline": "w1-p1", "profiled": args.profile, "configurations": {}}
+    report = {
+        "schema": "antfly.pdf.render_matrix.v1",
+        "baseline": "w1-p1",
+        "profiled": args.profile,
+        "configurations": {},
+    }
     for workers, prefetch in settings:
         label = f"w{workers}-p{prefetch}"
         pairs = [ablation_pair(r["w1-p1"], r[label]) for r in rounds]

--- a/scripts/bench/pdf/test_benchmark.py
+++ b/scripts/bench/pdf/test_benchmark.py
@@ -1,4 +1,5 @@
 import copy
+import io
 import json
 import tempfile
 import unittest
@@ -7,7 +8,54 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 import benchmark
-from benchmark import artifact_errors, coverage_ready, unit_text_hashes
+from benchmark import (
+    artifact_errors,
+    completed_log_offset,
+    coverage_ready,
+    unit_text_hashes,
+)
+
+
+class LogCheckpointTests(unittest.TestCase):
+    def test_checkpoint_retains_partial_records_for_later_reads(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "server.log"
+            for complete, partial in (
+                (b"", b""),
+                (b"", b"partial"),
+                (b"complete\n", b""),
+                ("diagnostic café\r\n".encode(), b"partial \xc3"),
+                (b"complete\n", b"x" * 20000),
+            ):
+                with self.subTest(size=len(partial)):
+                    path.write_bytes(complete + partial)
+                    self.assertEqual(len(complete), completed_log_offset(path))
+                    with path.open("ab") as stream:
+                        stream.write(b"finished\n")
+                    self.assertEqual(path.stat().st_size, completed_log_offset(path))
+
+    def test_checkpoint_does_not_chase_concurrent_appends_or_read_unboundedly(self):
+        class AppendingLog(io.BytesIO):
+            max_read = 0
+
+            def read(self, size=-1):
+                self.max_read = max(self.max_read, size)
+                self.assert_bounded(size)
+                position = self.tell()
+                self.seek(0, 2)
+                self.write(b"later complete record\n")
+                self.seek(position)
+                return super().read(size)
+
+            @staticmethod
+            def assert_bounded(size):
+                if not 0 < size <= 8192:
+                    raise AssertionError(f"unbounded read: {size}")
+
+        log = AppendingLog(b"complete\n" + b"x" * 20000)
+        with patch.object(Path, "open", return_value=log):
+            self.assertEqual(len(b"complete\n"), completed_log_offset(Path("unused")))
+        self.assertEqual(8192, log.max_read)
 
 
 class CompletionTests(unittest.TestCase):

--- a/scripts/bench/pdf/test_compare.py
+++ b/scripts/bench/pdf/test_compare.py
@@ -87,9 +87,11 @@ class OutputDirectoryTests(unittest.TestCase):
                 "--pr-revision",
                 "b" * 40,
             ]
-            with patch("sys.argv", argv), patch.object(
-                compare, "run_subject", side_effect=[run(), run()]
-            ), patch("builtins.print"):
+            with (
+                patch("sys.argv", argv),
+                patch.object(compare, "run_subject", side_effect=[run(), run()]),
+                patch("builtins.print"),
+            ):
                 self.assertEqual(0, compare.main())
             summary = json.loads((output / "summary.json").read_text())
             self.assertEqual("antfly.pdf.comparison.v1", summary["schema"])

--- a/scripts/bench/pdf/test_compare.py
+++ b/scripts/bench/pdf/test_compare.py
@@ -1,6 +1,11 @@
 import copy
+import json
+import tempfile
 import unittest
+from pathlib import Path
+from unittest.mock import patch
 
+import compare
 from compare import comparable_pair, summarize
 
 
@@ -53,6 +58,44 @@ def run(seconds=(10, 8, 6)):
             for i in range(len(seconds))
         ],
     }
+
+
+class OutputDirectoryTests(unittest.TestCase):
+    def test_comparison_writes_versioned_report_in_fresh_evidence_directory(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            output = root / "evidence"
+            binary = Path(__file__)
+            argv = [
+                "compare.py",
+                "--work-dir",
+                str(root),
+                "--circus-dir",
+                str(root),
+                "--output",
+                str(output),
+                "--name",
+                "test",
+                "--pairs",
+                "1",
+                "--main-binary",
+                str(binary),
+                "--main-revision",
+                "a" * 40,
+                "--pr-binary",
+                str(binary),
+                "--pr-revision",
+                "b" * 40,
+            ]
+            with patch("sys.argv", argv), patch.object(
+                compare, "run_subject", side_effect=[run(), run()]
+            ), patch("builtins.print"):
+                self.assertEqual(0, compare.main())
+            summary = json.loads((output / "summary.json").read_text())
+            self.assertEqual("antfly.pdf.comparison.v1", summary["schema"])
+            self.assertTrue(summary["timing_comparable"])
+            with patch("sys.argv", argv), self.assertRaises(FileExistsError):
+                compare.main()
 
 
 class CompareTests(unittest.TestCase):

--- a/scripts/bench/pdf/test_qualify.py
+++ b/scripts/bench/pdf/test_qualify.py
@@ -1,0 +1,272 @@
+"""Exercise evidence lifecycle, not model/hardware acceptance thresholds."""
+
+import copy
+import json
+import os
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import qualify
+
+
+def gate():
+    return {
+        "id": "example",
+        "layer": "execution",
+        "kind": "contract",
+        "scope": "test fixture",
+        "command": [
+            sys.executable,
+            "-c",
+            'from pathlib import Path; Path(r\'${run}/native.json\').write_text(\'{"schema":"fixture.v1","pass":true}\')',
+        ],
+        "report": {
+            "path": "${run}/native.json",
+            "schema": "fixture.v1",
+            "pass_field": "pass",
+        },
+    }
+
+
+class QualificationRunnerTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+
+    def run_gate(self, spec=None):
+        return qualify.run_gate(spec or gate(), self.root, self.root / "run", {})
+
+    def test_preserves_native_report_and_verdict(self):
+        result = self.run_gate()
+        self.assertTrue(result["pass"])
+        self.assertEqual(
+            qualify.sha256(self.root / "run/native.json"), result["report"]["sha256"]
+        )
+        self.assertTrue((self.root / "run/command.log").exists())
+
+    def test_native_failure_missing_schema_and_truthy_nonboolean_fail(self):
+        for payload in (
+            {"schema": "fixture.v1", "pass": False},
+            {"pass": True},
+            {"schema": "wrong", "pass": True},
+            {"schema": "fixture.v1", "pass": "true"},
+        ):
+            with self.subTest(payload=payload), tempfile.TemporaryDirectory(
+                dir=self.root
+            ) as folder:
+                spec = gate()
+                spec["command"][-1] = (
+                    "from pathlib import Path; Path(r'${run}/native.json').write_text("
+                    + repr(json.dumps(payload))
+                    + ")"
+                )
+                result = qualify.run_gate(spec, self.root, Path(folder) / "gate", {})
+                self.assertFalse(result["pass"])
+
+    def test_success_report_cannot_override_nonzero_exit(self):
+        spec = gate()
+        spec["command"][-1] += "; raise SystemExit(3)"
+        result = self.run_gate(spec)
+        self.assertEqual(3, result["returncode"])
+        self.assertFalse(result["pass"])
+
+    def test_reports_outside_fresh_directory_are_rejected_before_launch(self):
+        path = self.root / "stale.json"
+        path.write_text('{"schema":"fixture.v1","pass":true}')
+        spec = gate()
+        spec["report"]["path"] = str(path)
+        result = self.run_gate(spec)
+        self.assertFalse(result["pass"])
+        self.assertNotIn("returncode", result)
+
+    def test_missing_report_or_executable_fails_and_is_retained(self):
+        for command in (
+            [sys.executable, "-c", "pass"],
+            ["/nonexistent/qualification-binary"],
+        ):
+            with self.subTest(command=command), tempfile.TemporaryDirectory(
+                dir=self.root
+            ) as folder:
+                spec = gate()
+                spec["command"] = command
+                result = qualify.run_gate(spec, self.root, Path(folder) / "gate", {})
+                self.assertFalse(result["pass"])
+                self.assertTrue((Path(folder) / "gate/gate.json").exists())
+
+    def test_command_cannot_redirect_native_report_to_stale_evidence(self):
+        stale = self.root / "stale.json"
+        stale.write_text('{"schema":"fixture.v1","pass":true}')
+        spec = gate()
+        spec["command"][
+            -1
+        ] = f"from pathlib import Path; Path(r'${{run}}/native.json').symlink_to({str(stale)!r})"
+        result = self.run_gate(spec)
+        self.assertFalse(result["pass"])
+
+    @patch.object(qualify, "source_state", return_value={"revision": "fixture"})
+    def test_failed_gate_does_not_drop_later_evidence(self, _state):
+        failing = gate()
+        failing["command"] = [sys.executable, "-c", "raise SystemExit(1)"]
+        succeeding = gate()
+        succeeding["id"] = "later"
+        result = qualify.run_plan(
+            {"schema": qualify.PLAN_SCHEMA, "gates": [failing, succeeding]},
+            self.root,
+            self.root / "evidence",
+            {},
+        )
+        self.assertTrue(result["complete"])
+        self.assertFalse(result["pass"])
+        self.assertTrue(result["gates"][1]["pass"])
+
+    def test_checked_in_plans_validate(self):
+        for path in Path(__file__).parent.glob("*.plan.json"):
+            with self.subTest(path=path):
+                qualify.validate_plan(qualify.read_json(path))
+
+    def test_timeout_is_a_failed_result(self):
+        spec = gate()
+        spec["command"] = [sys.executable, "-c", "import time; time.sleep(60)"]
+        spec["timeout_seconds"] = 0.05
+        result = self.run_gate(spec)
+        self.assertTrue(result["timed_out"])
+        self.assertFalse(result["pass"])
+
+    def test_cli_interrupts_clean_up_owned_children_and_retain_failure(self):
+        repo = Path(__file__).resolve().parents[3]
+        for signum in (signal.SIGINT, signal.SIGTERM):
+            with self.subTest(signum=signum), tempfile.TemporaryDirectory(
+                dir=self.root
+            ) as temp:
+                folder = Path(temp)
+                spec = gate()
+                spec["command"] = [
+                    sys.executable,
+                    "-c",
+                    "import os,time; from pathlib import Path; marker = Path(r'${run}/ready.tmp'); marker.write_text(str(os.getpid())); marker.rename(marker.with_name('ready')); time.sleep(60)",
+                ]
+                plan = folder / "plan.json"
+                plan.write_text(
+                    json.dumps({"schema": qualify.PLAN_SCHEMA, "gates": [spec]})
+                )
+                output = folder / "evidence"
+                # Reproduce a batch launcher inheriting SIGINT=SIG_IGN, without
+                # preexec_fn hooks that are unsafe in multithreaded processes.
+                command = [
+                    sys.executable,
+                    "-c",
+                    "import os,signal,sys; signal.signal(signal.SIGINT, signal.SIG_IGN); os.execv(sys.executable, sys.argv[1:])",
+                    sys.executable,
+                    str(Path(qualify.__file__).resolve()),
+                    "--repo",
+                    str(repo),
+                    "--plan",
+                    str(plan),
+                    "--output",
+                    str(output),
+                ]
+                process = subprocess.Popen(
+                    command, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+                )
+                try:
+                    ready = output / "example/ready"
+                    deadline = time.monotonic() + 10
+                    while (
+                        not ready.exists()
+                        and process.poll() is None
+                        and time.monotonic() < deadline
+                    ):
+                        time.sleep(0.01)
+                    self.assertTrue(ready.exists())
+                    child_pid = int(ready.read_text())
+                    process.send_signal(signum)
+                    self.assertEqual(128 + signum, process.wait(timeout=10))
+                    with self.assertRaises(ProcessLookupError):
+                        os.kill(child_pid, 0)
+                    summary = json.loads((output / "summary.json").read_text())
+                    self.assertFalse(summary["pass"])
+                    self.assertTrue(summary["interrupted"])
+                    self.assertTrue(
+                        json.loads((output / "example/gate.json").read_text())[
+                            "interrupted"
+                        ]
+                    )
+                finally:
+                    if process.poll() is None:
+                        process.terminate()
+                        process.wait(timeout=10)
+
+    def test_plan_validation_fails_closed(self):
+        plan = {"schema": qualify.PLAN_SCHEMA, "gates": [gate()]}
+        qualify.validate_plan(plan)
+        invalid = []
+        duplicate = copy.deepcopy(plan)
+        duplicate["gates"].append(gate())
+        invalid.append(duplicate)
+        for field, value in (
+            ("id", "../escape"),
+            ("scope", ""),
+            ("kind", "hardware"),
+            ("timeout_seconds", float("nan")),
+            ("command", "echo yes"),
+        ):
+            bad = copy.deepcopy(plan)
+            bad["gates"][0][field] = value
+            invalid.append(bad)
+        for bad in invalid:
+            with self.subTest(plan=bad), self.assertRaises(ValueError):
+                qualify.validate_plan(bad)
+
+    @patch.object(qualify, "source_state", return_value={"revision": "fixture"})
+    def test_subset_does_not_require_unselected_models_or_pass_whole_plan(self, _state):
+        model = gate()
+        model.update(id="model", layer="model", kind="hardware", artifacts=["weights"])
+        plan = {
+            "schema": qualify.PLAN_SCHEMA,
+            "artifacts": {"weights": "${unavailable_model}"},
+            "gates": [gate(), model],
+        }
+        result = qualify.run_plan(
+            plan, self.root, self.root / "evidence", {}, only="execution"
+        )
+        self.assertTrue(result["layers"]["execution"]["pass"])
+        self.assertFalse(result["pass"])
+        self.assertFalse(result["complete"])
+        self.assertTrue(result["gates"][1]["not_run"])
+
+    @patch.object(qualify, "source_state", return_value={"revision": "fixture"})
+    def test_artifact_drift_disqualifies_successful_native_gate(self, _state):
+        artifact = self.root / "binary"
+        artifact.write_text("before")
+        spec = gate()
+        spec["artifacts"] = ["binary"]
+        spec["command"][-1] += f"; Path({str(artifact)!r}).write_text('after')"
+        plan = {
+            "schema": qualify.PLAN_SCHEMA,
+            "artifacts": {"binary": str(artifact)},
+            "gates": [spec],
+        }
+        result = qualify.run_plan(plan, self.root, self.root / "evidence", {})
+        self.assertTrue(result["gates"][0]["pass"])
+        self.assertFalse(result["artifacts_unchanged"])
+        self.assertFalse(result["pass"])
+
+    @patch.object(qualify, "source_state", return_value={"revision": "fixture"})
+    def test_successful_contract_plan_does_not_claim_all_layers(self, _state):
+        plan = {"schema": qualify.PLAN_SCHEMA, "gates": [gate()]}
+        result = qualify.run_plan(plan, self.root, self.root / "evidence", {})
+        self.assertTrue(result["pass"])
+        self.assertFalse(result["all_layers_represented"])
+        with self.assertRaises(FileExistsError):
+            qualify.run_plan(plan, self.root, self.root / "evidence", {})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/bench/pdf/test_qualify.py
+++ b/scripts/bench/pdf/test_qualify.py
@@ -58,9 +58,10 @@ class QualificationRunnerTests(unittest.TestCase):
             {"schema": "wrong", "pass": True},
             {"schema": "fixture.v1", "pass": "true"},
         ):
-            with self.subTest(payload=payload), tempfile.TemporaryDirectory(
-                dir=self.root
-            ) as folder:
+            with (
+                self.subTest(payload=payload),
+                tempfile.TemporaryDirectory(dir=self.root) as folder,
+            ):
                 spec = gate()
                 spec["command"][-1] = (
                     "from pathlib import Path; Path(r'${run}/native.json').write_text("
@@ -91,9 +92,10 @@ class QualificationRunnerTests(unittest.TestCase):
             [sys.executable, "-c", "pass"],
             ["/nonexistent/qualification-binary"],
         ):
-            with self.subTest(command=command), tempfile.TemporaryDirectory(
-                dir=self.root
-            ) as folder:
+            with (
+                self.subTest(command=command),
+                tempfile.TemporaryDirectory(dir=self.root) as folder,
+            ):
                 spec = gate()
                 spec["command"] = command
                 result = qualify.run_gate(spec, self.root, Path(folder) / "gate", {})
@@ -104,9 +106,9 @@ class QualificationRunnerTests(unittest.TestCase):
         stale = self.root / "stale.json"
         stale.write_text('{"schema":"fixture.v1","pass":true}')
         spec = gate()
-        spec["command"][
-            -1
-        ] = f"from pathlib import Path; Path(r'${{run}}/native.json').symlink_to({str(stale)!r})"
+        spec["command"][-1] = (
+            f"from pathlib import Path; Path(r'${{run}}/native.json').symlink_to({str(stale)!r})"
+        )
         result = self.run_gate(spec)
         self.assertFalse(result["pass"])
 
@@ -142,9 +144,10 @@ class QualificationRunnerTests(unittest.TestCase):
     def test_cli_interrupts_clean_up_owned_children_and_retain_failure(self):
         repo = Path(__file__).resolve().parents[3]
         for signum in (signal.SIGINT, signal.SIGTERM):
-            with self.subTest(signum=signum), tempfile.TemporaryDirectory(
-                dir=self.root
-            ) as temp:
+            with (
+                self.subTest(signum=signum),
+                tempfile.TemporaryDirectory(dir=self.root) as temp,
+            ):
                 folder = Path(temp)
                 spec = gate()
                 spec["command"] = [

--- a/scripts/bench/pdf/test_qualify_documents.py
+++ b/scripts/bench/pdf/test_qualify_documents.py
@@ -1,7 +1,10 @@
 import copy
+import tempfile
 import unittest
 from collections import Counter
+from pathlib import Path
 
+from benchmark import completed_log_offset
 from qualify_documents import evaluate_run, summarize, verify_trial_profile
 from render_matrix import render_observations
 from test_compare import run
@@ -55,6 +58,32 @@ def attach_profile(entry, logs):
 
 
 class DocumentQualificationTests(unittest.TestCase):
+    def test_checkpoints_during_split_background_writes_preserve_qualification(self):
+        entry = sample()
+        block = entry["log"][
+            : entry["run"]["results"][0]["profile_log"]["end_byte"]
+        ].encode()
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "server.log"
+            with path.open("wb", buffering=0) as writer:
+                for row in entry["run"]["results"]:
+                    writer.write(b"background caf\xc3")  # split UTF-8, not a record
+                    start = completed_log_offset(path)
+                    writer.write(b"\xa9\r\n" + block + b"next background message")
+                    end = completed_log_offset(path)
+                    row["profile_log"] = {"start_byte": start, "end_byte": end}
+                    writer.write(b" completed\n")
+            entry["log"] = path.read_bytes()
+        result = evaluate_run(entry["run"], entry["log"], 3, entry["memory_bytes"])
+        self.assertTrue(result["pass"], result)
+        # A render begun after the final checkpoint is still outside its trial;
+        # normalizing offsets must not suppress it once the record completes.
+        self.assertFalse(
+            evaluate_run(entry["run"], entry["log"] + block, 3, entry["memory_bytes"])[
+                "pass"
+            ]
+        )
+
     def assert_profile_fails(self, entry):
         result = evaluate_run(entry["run"], entry["log"], 3, entry["memory_bytes"])
         self.assertFalse(result["pass"], result)

--- a/scripts/bench/pdf/test_qualify_documents.py
+++ b/scripts/bench/pdf/test_qualify_documents.py
@@ -1,0 +1,103 @@
+import copy
+import unittest
+
+from qualify_documents import evaluate_run, summarize
+from test_compare import run
+
+
+def sample(sync="full_index", cap=268435456):
+    value = run()
+    value["provenance"].update(
+        sync_level=sync,
+        consumers=2,
+        read_profile=True,
+        render_memory_bytes=cap,
+        render_workers=4,
+        render_prefetch=1,
+        reader_batch_size=4,
+    )
+    for row in value["results"]:
+        row["consumer_results"] = [
+            {
+                "unit_text_sha256": row["unit_text_sha256"],
+                "unit_render_geometry": row["unit_render_geometry"],
+                "searchable_vectors": 1,
+                "manifest_counts": row["manifests"],
+            }
+        ]
+    log = "\n".join(
+        [
+            "read-profile phase=pdf_render source_fingerprint=source page=1 failure=null",
+            "read-profile phase=pdf_render_window peak_bytes=100 requested_parallelism=4 peak_parallelism=1 failure=null",
+        ]
+        * 3
+    )
+    return {"sync_level": sync, "memory_bytes": cap, "run": value, "log": log}
+
+
+class DocumentQualificationTests(unittest.TestCase):
+    def test_requires_both_paths_at_each_memory_cap(self):
+        runs = [
+            sample(sync, cap)
+            for sync in ("full_index", "write")
+            for cap in (134217728, 268435456)
+        ]
+        self.assertTrue(summarize(runs, 3)["pass"])
+        self.assertFalse(summarize(runs[:-1], 3)["pass"])
+        self.assertFalse(summarize(runs + runs[:1], 3)["pass"])
+
+    def test_render_reuse_requires_physical_page_evidence(self):
+        entry = sample()
+        for log in (
+            "",
+            entry["log"] + entry["log"],
+            entry["log"].replace("failure=null", "failure=OutOfMemory"),
+            entry["log"].replace("peak_bytes=100", "peak_bytes=999999999"),
+            entry["log"].replace("peak_parallelism=1", "peak_parallelism=5"),
+            entry["log"].replace("page=1", "page=null"),
+        ):
+            with self.subTest(log=log):
+                self.assertFalse(
+                    evaluate_run(entry["run"], log, 3, entry["memory_bytes"])["pass"]
+                )
+
+    def test_page_counts_alone_do_not_hide_identity_multiplicity(self):
+        entry = sample()
+        log = entry["log"].replace(
+            "source_fingerprint=source", "source_fingerprint=other", 1
+        )
+        self.assertFalse(
+            evaluate_run(entry["run"], log, 3, entry["memory_bytes"])["pass"]
+        )
+
+    def test_output_or_binary_drift_is_not_a_qualified_pressure_fallback(self):
+        runs = [
+            sample(sync, cap)
+            for sync in ("full_index", "write")
+            for cap in (134217728, 268435456)
+        ]
+        changed = copy.deepcopy(runs)
+        changed[-1]["run"]["results"][0]["unit_text_sha256"] = {
+            "wrong": {"page:000001": "different"}
+        }
+        self.assertFalse(summarize(changed, 3)["pass"])
+        changed = copy.deepcopy(runs)
+        changed[-1]["run"]["provenance"]["binary_sha256"] = "different"
+        self.assertFalse(summarize(changed, 3)["pass"])
+
+    def test_missing_consumer_and_incomplete_indexing_fail(self):
+        for mutation in ("consumer", "indexing"):
+            entry = sample()
+            if mutation == "consumer":
+                entry["run"]["results"][0]["consumer_results"] = []
+            else:
+                entry["run"]["results"][0]["passed"] = False
+            self.assertFalse(
+                evaluate_run(entry["run"], entry["log"], 3, entry["memory_bytes"])[
+                    "pass"
+                ]
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/bench/pdf/test_qualify_documents.py
+++ b/scripts/bench/pdf/test_qualify_documents.py
@@ -1,12 +1,15 @@
 import copy
 import unittest
+from collections import Counter
 
-from qualify_documents import evaluate_run, summarize
+from qualify_documents import evaluate_run, summarize, verify_trial_profile
+from render_matrix import render_observations
 from test_compare import run
 
 
 def sample(sync="full_index", cap=268435456):
     value = run()
+    value["provenance"]["selected"][0]["pages"] = 1
     value["provenance"].update(
         sync_level=sync,
         consumers=2,
@@ -17,25 +20,163 @@ def sample(sync="full_index", cap=268435456):
         reader_batch_size=4,
     )
     for row in value["results"]:
+        row["unit_render_geometry"]["scan.pdf"]["page:000001"]["page_number"] = 1
         row["consumer_results"] = [
             {
-                "unit_text_sha256": row["unit_text_sha256"],
-                "unit_render_geometry": row["unit_render_geometry"],
+                "unit_text_sha256": copy.deepcopy(row["unit_text_sha256"]),
+                "unit_render_geometry": copy.deepcopy(row["unit_render_geometry"]),
                 "searchable_vectors": 1,
-                "manifest_counts": row["manifests"],
+                "manifest_counts": copy.deepcopy(row["manifests"]),
             }
         ]
-    log = "\n".join(
-        [
-            "read-profile phase=pdf_render source_fingerprint=source page=1 failure=null",
-            "read-profile phase=pdf_render_window peak_bytes=100 requested_parallelism=4 peak_parallelism=1 failure=null",
-        ]
-        * 3
+        row["manifests"]["scan.pdf"]["source_fingerprint"] = "source"
+    log = (
+        "\n".join(
+            [
+                "read-profile phase=pdf_render source_fingerprint=source page=1 failure=null",
+                "read-profile phase=pdf_render_window source_fingerprint=source first_page=1 last_page=1 pages=1 peak_bytes=100 requested_parallelism=4 peak_parallelism=1 failure=null",
+            ]
+        )
+        + "\n"
     )
-    return {"sync_level": sync, "memory_bytes": cap, "run": value, "log": log}
+    entry = {"sync_level": sync, "memory_bytes": cap, "run": value}
+    attach_profile(entry, [log] * 3)
+    return entry
+
+
+def attach_profile(entry, logs):
+    offset = 0
+    for trial, (row, log) in enumerate(zip(entry["run"]["results"], logs, strict=True)):
+        row["trial"] = trial
+        size = len(log.encode("utf-8"))
+        row["profile_log"] = {"start_byte": offset, "end_byte": offset + size}
+        offset += size
+    entry["log"] = "".join(logs)
 
 
 class DocumentQualificationTests(unittest.TestCase):
+    def assert_profile_fails(self, entry):
+        result = evaluate_run(entry["run"], entry["log"], 3, entry["memory_bytes"])
+        self.assertFalse(result["pass"], result)
+
+    def test_consistently_wrong_secondary_output_fails(self):
+        for field, bad in (
+            ("unit_text_sha256", {"scan.pdf": {"page:000001": "wrong"}}),
+            (
+                "unit_render_geometry",
+                {"scan.pdf": {"page:000001": {"page_number": 999}}},
+            ),
+            (
+                "manifest_counts",
+                {
+                    "scan.pdf": dict(
+                        run()["results"][0]["manifests"]["scan.pdf"], chunk_count=2
+                    )
+                },
+            ),
+            ("searchable_vectors", 2),
+        ):
+            with self.subTest(field=field):
+                runs = [
+                    sample(sync, cap)
+                    for sync in ("full_index", "write")
+                    for cap in (134217728, 268435456)
+                ]
+                for entry in runs:
+                    for row in entry["run"]["results"]:
+                        row["consumer_results"][0][field] = copy.deepcopy(bad)
+                self.assertFalse(summarize(runs, 3)["pass"])
+
+    def test_profiles_require_expected_sources_pages_and_every_window(self):
+        entry = sample()
+        block = entry["log"][: entry["run"]["results"][0]["profile_log"]["end_byte"]]
+        for bad in (
+            block.replace("page=1", "page=999"),
+            block.replace("source_fingerprint=source", "source_fingerprint=unknown"),
+            block.splitlines()[0] + "\n",  # no admission window
+            block.replace("last_page=1", "last_page=2"),
+            block.replace("pages=1", "pages=2"),
+            block.replace("requested_parallelism=4", "requested_parallelism=8"),
+            block + block.splitlines()[1] + "\n",  # overlapping window
+        ):
+            with self.subTest(log=bad):
+                changed = copy.deepcopy(entry)
+                attach_profile(changed, [bad] * 3)
+                self.assert_profile_fails(changed)
+
+    def test_aggregate_counts_cannot_hide_cross_trial_duplicates(self):
+        entry = sample()
+        block = entry["log"][: entry["run"]["results"][0]["profile_log"]["end_byte"]]
+        attach_profile(entry, [block * 2, "no rendering in this trial\n", block])
+        self.assert_profile_fails(entry)
+
+    def test_page_expectations_require_corpus_and_manifest_evidence(self):
+        for mutation in ("fingerprint", "corpus", "geometry", "extra_source"):
+            with self.subTest(mutation=mutation):
+                entry = sample()
+                row = entry["run"]["results"][0]
+                if mutation == "fingerprint":
+                    row["manifests"]["scan.pdf"].pop("source_fingerprint")
+                elif mutation == "corpus":
+                    entry["run"]["provenance"]["selected"][0]["pages"] = 2
+                elif mutation == "geometry":
+                    row["unit_render_geometry"]["scan.pdf"]["page:000001"][
+                        "page_number"
+                    ] = 999
+                else:
+                    row["unit_render_geometry"]["unknown.pdf"] = {
+                        "page:000001": {"page_number": 1}
+                    }
+                # Preserve consumer parity so only provenance validation fails.
+                row["consumer_results"][0]["unit_render_geometry"] = copy.deepcopy(
+                    row["unit_render_geometry"]
+                )
+                self.assert_profile_fails(entry)
+
+    def test_trial_boundaries_are_complete_disjoint_and_byte_based(self):
+        entry = sample()
+        block = entry["log"][: entry["run"]["results"][0]["profile_log"]["end_byte"]]
+        attach_profile(
+            entry,
+            [
+                ("diagnostic café\r\n" + block).replace(
+                    "failure=null\n", "failure=null\r\n"
+                )
+            ]
+            * 3,
+        )
+        self.assertTrue(
+            evaluate_run(entry["run"], entry["log"], 3, entry["memory_bytes"])["pass"]
+        )
+        for mutation in ("missing", "overlap", "extra"):
+            changed = copy.deepcopy(entry)
+            if mutation == "missing":
+                changed["run"]["results"][0].pop("profile_log")
+            elif mutation == "overlap":
+                changed["run"]["results"][1]["profile_log"]["start_byte"] = 0
+            else:
+                changed["log"] += block
+            self.assert_profile_fails(changed)
+
+    def test_terminal_partial_windows_cover_multiple_sources(self):
+        lines = []
+        expected = Counter()
+        for source, pages in (("a", 5), ("b", 2)):
+            for page in range(1, pages + 1):
+                expected[(source, page)] += 1
+                lines.append(
+                    f"read-profile phase=pdf_render source_fingerprint={source} page={page} failure=null"
+                )
+            for first in range(1, pages + 1, 4):
+                last = min(first + 3, pages)
+                lines.append(
+                    f"read-profile phase=pdf_render_window source_fingerprint={source} first_page={first} last_page={last} pages={last - first + 1} peak_bytes=100 requested_parallelism=4 peak_parallelism=1 failure=null"
+                )
+        observations = render_observations("\n".join(lines))
+        verify_trial_profile(observations, expected, 1000, 4)
+        with self.assertRaises(ValueError):
+            verify_trial_profile(observations[:-1], expected, 1000, 4)
+
     def test_requires_both_paths_at_each_memory_cap(self):
         runs = [
             sample(sync, cap)

--- a/zig/PDF.md
+++ b/zig/PDF.md
@@ -4489,6 +4489,34 @@ provenance.
 
 ### Real-model qualification
 
+The follow-up qualification workflow extends existing family gates; it does not
+replace their fixtures, precision/backend requirements or numerical tolerances.
+See [`scripts/bench/pdf/QUALIFICATION.md`](../scripts/bench/pdf/QUALIFICATION.md).
+
+- Model layer: native versioned family reports remain authoritative. Qwen3's
+  Metal/CUDA gates additionally overlap independently prompted query/document
+  requests at mixed dimensions using existing parity/MRL validators. Gemma's
+  batching summary is versioned without changing its scheduler/performance gates.
+- Execution layer: a checked-in contract plan reuses capability, cancellation,
+  admission, per-item identity, linked/worker transport and distributed proxy
+  tests. Fake providers qualify these contracts, not real-model native fusion.
+- Document layer: a profiled two-consumer gate reuses the real PDF benchmark and
+  output signatures, requires both precommit/replay at two memory caps, and checks
+  physical render multiplicity and tracked window bounds. Unprofiled paired
+  completed-indexing performance remains a separate experiment.
+
+The thin runner retains exact gate scopes, native verdicts, command logs, versioned
+report hashes, source and local artifact fingerprints. Missing/skipped evidence,
+schema mismatch, failed processes and source/artifact drift cannot produce a
+passing full-plan result. Local hashes do not attest a remote deployment, and
+represented layers do not imply matching model/deployment coverage.
+
+These scripts and their hermetic tests are not evidence that the exact artifacts
+passed on hardware. The current document benchmark still pins Florence/BGE on
+Metal; generator, multimodal embedder, extractor, reranker and chunker document
+hardware lanes, semantic PDF oracles and accelerator/RSS measurements require
+separate qualification. GLiNER training parity does not qualify serving fusion.
+
 The non-hermetic release gate renders the same two-page fixture and sends its
 pages through actual remote Antfly reader, generator, and embedder contracts:
 

--- a/zig/pkg/inference/scripts/gemma4/benchmark_gemma4_cuda_batching.py
+++ b/zig/pkg/inference/scripts/gemma4/benchmark_gemma4_cuda_batching.py
@@ -692,6 +692,7 @@ def main() -> None:
     results = {dtype: benchmark_dtype(args, dtype) for dtype in args.cache_dtypes}
     passed = all(result["acceptance"]["passed"] for result in results.values())
     matrix_summary = {
+        "schema": "antfly.gemma4.cuda_batching.v1",
         "config": {
             "model": str(args.model.resolve()),
             "tokens": args.tokens,

--- a/zig/pkg/inference/scripts/qwen3_embedding/qualify_qwen3_embedding_common.py
+++ b/zig/pkg/inference/scripts/qwen3_embedding/qualify_qwen3_embedding_common.py
@@ -75,6 +75,15 @@ def gate(name: str, case: str, passed: bool, detail: str) -> dict[str, Any]:
     return {"gate": name, "case": case, "pass": bool(passed), "detail": detail}
 
 
+def unit_norm_gate(case_id: str, norm: float, name: str) -> dict[str, Any]:
+    return gate(
+        name,
+        case_id,
+        math.isfinite(norm) and abs(norm - 1.0) <= NORM_ABS_TOLERANCE,
+        f"|v|={norm:.6f} tol={NORM_ABS_TOLERANCE}",
+    )
+
+
 def load_oracle(path: Path) -> dict[str, Any]:
     try:
         payload = json.loads(path.read_text(encoding="utf-8"))
@@ -236,14 +245,7 @@ def case_gates(
     if not rows[0]["pass"]:
         return rows
     norm = l2_norm(server_vector)
-    rows.append(
-        gate(
-            "unit_norm",
-            case_id,
-            math.isfinite(norm) and abs(norm - 1.0) <= NORM_ABS_TOLERANCE,
-            f"|v|={norm:.6f} tol={NORM_ABS_TOLERANCE}",
-        )
-    )
+    rows.append(unit_norm_gate(case_id, norm, "unit_norm"))
     if norm <= 0.0:
         rows.append(
             gate("oracle_cosine", case_id, False, "server vector has zero norm")
@@ -278,14 +280,7 @@ def mrl_gates(
     if not rows[0]["pass"]:
         return rows
     norm = l2_norm(server_reduced)
-    rows.append(
-        gate(
-            "mrl_unit_norm",
-            case_id,
-            math.isfinite(norm) and abs(norm - 1.0) <= NORM_ABS_TOLERANCE,
-            f"|v|={norm:.6f} tol={NORM_ABS_TOLERANCE}",
-        )
-    )
+    rows.append(unit_norm_gate(case_id, norm, "mrl_unit_norm"))
     if norm <= 0.0:
         rows.append(
             gate(
@@ -323,6 +318,10 @@ def batch_gates(
                 f"width {len(batch_vector)} != {len(single_vector)}",
             )
         ]
+    norm = l2_norm(batch_vector)
+    norm_row = unit_norm_gate(case_id, norm, "batch_unit_norm")
+    if not math.isfinite(norm) or norm <= 0.0:
+        return [norm_row]
     value = cosine(batch_vector, single_vector)
     return [
         gate(
@@ -330,7 +329,8 @@ def batch_gates(
             case_id,
             value >= BATCH_MIN_COSINE,
             f"cosine={value:.6f} min={BATCH_MIN_COSINE}",
-        )
+        ),
+        norm_row,
     ]
 
 
@@ -456,7 +456,11 @@ def concurrent_request_gates(args, cases, single_vectors, default_instruction):
                 for (case_id, body, expected), actual in zip(window, vectors):
                     for row in batch_gates(case_id, expected, actual):
                         row.update(
-                            gate="cross_request_vs_single",
+                            gate=(
+                                "cross_request_unit_norm"
+                                if row["gate"] == "batch_unit_norm"
+                                else "cross_request_vs_single"
+                            ),
                             round=round_index,
                             dimensions=body.get("dimensions", len(expected)),
                         )

--- a/zig/pkg/inference/scripts/qwen3_embedding/qualify_qwen3_embedding_common.py
+++ b/zig/pkg/inference/scripts/qwen3_embedding/qualify_qwen3_embedding_common.py
@@ -24,18 +24,21 @@ from __future__ import annotations
 import argparse
 import json
 import math
-from pathlib import Path
 import sys
-from typing import Any
+import threading
 import urllib.error
 import urllib.request
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import Any
 
 from transformers_embedding_oracle import (
     SCHEMA as ORACLE_SCHEMA,
+)
+from transformers_embedding_oracle import (
     cosine,
     truncate_and_renormalize,
 )
-
 
 SCHEMA = "antfly.qwen3_embedding.qualification.v1"
 EMBEDDINGS_PATH = "/ai/v1/embeddings"
@@ -197,12 +200,14 @@ def post_embeddings(
             f"expected {expected} embeddings, got "
             f"{len(data) if isinstance(data, list) else 'none'}"
         )
-    rows = sorted(
-        enumerate(data),
-        key=lambda item: (
-            item[1].get("index", item[0]) if isinstance(item[1], dict) else item[0]
-        ),
-    )
+    indexes = [item.get("index") if isinstance(item, dict) else None for item in data]
+    if any(type(index) is not int for index in indexes) or sorted(indexes) != list(
+        range(expected)
+    ):
+        raise QualificationError(
+            "embedding indexes must cover each request item exactly once"
+        )
+    rows = sorted(enumerate(data), key=lambda item: item[1]["index"])
     vectors: list[list[float]] = []
     for position, item in rows:
         embedding = item.get("embedding") if isinstance(item, dict) else None
@@ -404,6 +409,66 @@ def case_input(case: dict[str, Any]) -> str:
     return served_text if isinstance(served_text, str) else case["text"]
 
 
+def concurrent_request_gates(args, cases, single_vectors, default_instruction):
+    """Reuse family parity gates under overlapping, differently configured requests.
+
+    This proves response isolation, not physical fusion. Scheduler/backend evidence
+    remains a separate execution gate. Long-context fixtures stay in the serial
+    family gate so concurrency does not multiply their memory requirements.
+    """
+    case_ids = [
+        item
+        for pair in zip(RETRIEVAL_QUERY_CASES, RETRIEVAL_DOCUMENT_CASES)
+        for item in pair
+    ]
+    requests = []
+    for offset in (0, 1):
+        for index, case_id in enumerate(case_ids):
+            dimensions = None if (index + offset) % 2 == 0 else CHECK_DIMENSIONS
+            case = cases[case_id]
+            body = embedding_request_body(
+                args.model,
+                case_input(case),
+                case["role"],
+                case["instruction"],
+                default_instruction,
+                dimensions=dimensions,
+            )
+            expected = single_vectors[case_id]
+            if dimensions is not None:
+                expected = truncate_and_renormalize(expected, dimensions)
+            requests.append((case_id, body, expected))
+    rows = []
+    concurrency = getattr(args, "concurrency", 4)
+    rounds = getattr(args, "concurrent_rounds", 2)
+    with ThreadPoolExecutor(max_workers=concurrency) as pool:
+        for round_index in range(rounds):
+            ordered = requests if round_index % 2 == 0 else list(reversed(requests))
+            for start in range(0, len(ordered), concurrency):
+                window = ordered[start : start + concurrency]
+                barrier = threading.Barrier(len(window), timeout=args.timeout)
+
+                def invoke(item, start_barrier=barrier):
+                    start_barrier.wait()
+                    return post_embeddings(args.base_url, item[1], args.timeout)[0]
+
+                vectors = list(pool.map(invoke, window))
+                for (case_id, body, expected), actual in zip(window, vectors):
+                    for row in batch_gates(case_id, expected, actual):
+                        row.update(
+                            gate="cross_request_vs_single",
+                            round=round_index,
+                            dimensions=body.get("dimensions", len(expected)),
+                        )
+                        rows.append(row)
+    return rows
+
+
+def add_concurrency_arguments(parser):
+    parser.add_argument("--concurrency", type=int, choices=(2, 4, 8, 16), default=4)
+    parser.add_argument("--concurrent-rounds", type=int, choices=range(1, 9), default=2)
+
+
 def run_qualification(
     args: argparse.Namespace,
     *,
@@ -463,6 +528,7 @@ def run_qualification(
     batch_vectors = post_embeddings(args.base_url, batch_body, args.timeout)
     for case_id, batch_vector in zip(document_ids, batch_vectors):
         rows.extend(batch_gates(case_id, server_full[case_id], batch_vector))
+    rows.extend(concurrent_request_gates(args, cases, server_full, default_instruction))
 
     oracle_vectors = {
         case_id: cases[case_id]["embeddings"]["1024"] for case_id in cases
@@ -486,6 +552,11 @@ def run_qualification(
         "model": args.model,
         "tier": args.tier,
         "min_cosine": min_cosine,
+        "cross_request": {
+            "concurrency": getattr(args, "concurrency", 4),
+            "rounds": getattr(args, "concurrent_rounds", 2),
+            "native_fusion_proven": False,
+        },
         "gates": rows,
         "pass": all(row["pass"] for row in rows),
     }

--- a/zig/pkg/inference/scripts/qwen3_embedding/qualify_qwen3_embedding_cuda.py
+++ b/zig/pkg/inference/scripts/qwen3_embedding/qualify_qwen3_embedding_cuda.py
@@ -75,6 +75,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument("--model", default="qwen3-embedding-0.6b")
     parser.add_argument("--timeout", type=float, default=120.0)
     parser.add_argument("--report", type=Path)
+    common.add_concurrency_arguments(parser)
     args = parser.parse_args(argv)
     if args.timeout <= 0:
         parser.error("--timeout must be positive")

--- a/zig/pkg/inference/scripts/qwen3_embedding/qualify_qwen3_embedding_metal.py
+++ b/zig/pkg/inference/scripts/qwen3_embedding/qualify_qwen3_embedding_metal.py
@@ -47,6 +47,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument("--tier", choices=sorted(TIER_MIN_COSINE), required=True)
     parser.add_argument("--timeout", type=float, default=120.0)
     parser.add_argument("--report", type=Path)
+    common.add_concurrency_arguments(parser)
     args = parser.parse_args(argv)
     if args.timeout <= 0:
         parser.error("--timeout must be positive")

--- a/zig/pkg/inference/scripts/qwen3_embedding/test_qualify_qwen3_embedding_concurrency.py
+++ b/zig/pkg/inference/scripts/qwen3_embedding/test_qualify_qwen3_embedding_concurrency.py
@@ -1,0 +1,117 @@
+"""Contract tests of the qualifier, not evidence of real model qualification."""
+
+import io
+import json
+import sys
+import threading
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import qualify_qwen3_embedding_common as common
+from test_qualify_qwen3_embedding_metal import make_oracle_payload
+
+
+class ConcurrentQualificationTests(unittest.TestCase):
+    def setUp(self):
+        payload = make_oracle_payload()
+        self.cases = common.validate_oracle(payload)
+        self.vectors = {
+            key: case["embeddings"]["1024"] for key, case in self.cases.items()
+        }
+        self.by_text = {
+            common.case_input(case): key for key, case in self.cases.items()
+        }
+        self.args = SimpleNamespace(
+            model="model",
+            base_url="http://unused",
+            timeout=5,
+            concurrency=4,
+            concurrent_rounds=2,
+        )
+        self.instruction = payload["contract"]["default_instruction"]
+
+    def response(self, body):
+        vector = self.vectors[self.by_text[body["input"]]]
+        return [
+            (
+                common.truncate_and_renormalize(vector, body["dimensions"])
+                if "dimensions" in body
+                else vector
+            )
+        ]
+
+    def test_bounded_requests_overlap_and_preserve_roles_dimensions_and_order(self):
+        barrier = threading.Barrier(4, timeout=5)
+        lock = threading.Lock()
+        windows = []
+        current = []
+
+        def post(_url, body, _timeout):
+            with lock:
+                current.append(body)
+                if len(current) == 4:
+                    windows.append(list(current))
+                    current.clear()
+            barrier.wait()
+            return self.response(body)
+
+        with patch.object(common, "post_embeddings", side_effect=post):
+            rows = common.concurrent_request_gates(
+                self.args, self.cases, self.vectors, self.instruction
+            )
+        self.assertEqual(32, len(rows))
+        self.assertTrue(all(row["pass"] for row in rows))
+        for window in windows:
+            self.assertEqual(
+                {None, "RETRIEVAL_QUERY"}, {body.get("task_type") for body in window}
+            )
+            self.assertEqual({None, 256}, {body.get("dimensions") for body in window})
+
+    def test_cross_request_leakage_and_dimension_leakage_fail_existing_tolerance(self):
+        for bad in ([1.0] + [0.0] * 1023, [1.0]):
+            with self.subTest(width=len(bad)), patch.object(
+                common, "post_embeddings", return_value=[bad]
+            ):
+                rows = common.concurrent_request_gates(
+                    self.args, self.cases, self.vectors, self.instruction
+                )
+                self.assertTrue(any(not row["pass"] for row in rows))
+
+    def test_request_failure_is_not_dropped(self):
+        with patch.object(
+            common, "post_embeddings", side_effect=common.QualificationError("failed")
+        ), self.assertRaises(common.QualificationError):
+            common.concurrent_request_gates(
+                self.args, self.cases, self.vectors, self.instruction
+            )
+
+    def test_http_item_indexes_are_a_permutation_not_just_the_right_count(self):
+        for indexes in ((0, 0), (1, 2), (False, 1), (None, 1)):
+            body = {"data": [{"index": index, "embedding": [1.0]} for index in indexes]}
+            with self.subTest(indexes=indexes), patch.object(
+                common.urllib.request,
+                "urlopen",
+                return_value=io.BytesIO(json.dumps(body).encode()),
+            ), self.assertRaises(common.QualificationError):
+                common.post_embeddings("http://unused", {"input": ["a", "b"]}, 5)
+
+    def test_http_reorders_unique_item_indexes(self):
+        body = {
+            "data": [{"index": 1, "embedding": [2.0]}, {"index": 0, "embedding": [1.0]}]
+        }
+        with patch.object(
+            common.urllib.request,
+            "urlopen",
+            return_value=io.BytesIO(json.dumps(body).encode()),
+        ):
+            self.assertEqual(
+                [[1.0], [2.0]],
+                common.post_embeddings("http://unused", {"input": ["a", "b"]}, 5),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/zig/pkg/inference/scripts/qwen3_embedding/test_qualify_qwen3_embedding_concurrency.py
+++ b/zig/pkg/inference/scripts/qwen3_embedding/test_qualify_qwen3_embedding_concurrency.py
@@ -62,7 +62,7 @@ class ConcurrentQualificationTests(unittest.TestCase):
             rows = common.concurrent_request_gates(
                 self.args, self.cases, self.vectors, self.instruction
             )
-        self.assertEqual(32, len(rows))
+        self.assertEqual(64, len(rows))
         self.assertTrue(all(row["pass"] for row in rows))
         for window in windows:
             self.assertEqual(
@@ -72,8 +72,9 @@ class ConcurrentQualificationTests(unittest.TestCase):
 
     def test_cross_request_leakage_and_dimension_leakage_fail_existing_tolerance(self):
         for bad in ([1.0] + [0.0] * 1023, [1.0]):
-            with self.subTest(width=len(bad)), patch.object(
-                common, "post_embeddings", return_value=[bad]
+            with (
+                self.subTest(width=len(bad)),
+                patch.object(common, "post_embeddings", return_value=[bad]),
             ):
                 rows = common.concurrent_request_gates(
                     self.args, self.cases, self.vectors, self.instruction
@@ -81,21 +82,49 @@ class ConcurrentQualificationTests(unittest.TestCase):
                 self.assertTrue(any(not row["pass"] for row in rows))
 
     def test_request_failure_is_not_dropped(self):
-        with patch.object(
-            common, "post_embeddings", side_effect=common.QualificationError("failed")
-        ), self.assertRaises(common.QualificationError):
+        with (
+            patch.object(
+                common,
+                "post_embeddings",
+                side_effect=common.QualificationError("failed"),
+            ),
+            self.assertRaises(common.QualificationError),
+        ):
             common.concurrent_request_gates(
                 self.args, self.cases, self.vectors, self.instruction
             )
 
+    def test_concurrent_normalization_uses_existing_family_tolerance(self):
+        for scale, passes in ((7.0, False), (0.5, False), (1.0005, True)):
+
+            def post(_url, body, _timeout):
+                return [[value * scale for value in self.response(body)[0]]]
+
+            with (
+                self.subTest(scale=scale),
+                patch.object(common, "post_embeddings", side_effect=post),
+            ):
+                rows = common.concurrent_request_gates(
+                    self.args, self.cases, self.vectors, self.instruction
+                )
+                norms = [
+                    row for row in rows if row["gate"] == "cross_request_unit_norm"
+                ]
+                self.assertEqual(32, len(norms))
+                self.assertEqual(passes, all(row["pass"] for row in norms))
+
     def test_http_item_indexes_are_a_permutation_not_just_the_right_count(self):
         for indexes in ((0, 0), (1, 2), (False, 1), (None, 1)):
             body = {"data": [{"index": index, "embedding": [1.0]} for index in indexes]}
-            with self.subTest(indexes=indexes), patch.object(
-                common.urllib.request,
-                "urlopen",
-                return_value=io.BytesIO(json.dumps(body).encode()),
-            ), self.assertRaises(common.QualificationError):
+            with (
+                self.subTest(indexes=indexes),
+                patch.object(
+                    common.urllib.request,
+                    "urlopen",
+                    return_value=io.BytesIO(json.dumps(body).encode()),
+                ),
+                self.assertRaises(common.QualificationError),
+            ):
                 common.post_embeddings("http://unused", {"input": ["a", "b"]}, 5)
 
     def test_http_reorders_unique_item_indexes(self):

--- a/zig/pkg/inference/scripts/qwen3_embedding/test_qualify_qwen3_embedding_metal.py
+++ b/zig/pkg/inference/scripts/qwen3_embedding/test_qualify_qwen3_embedding_metal.py
@@ -252,7 +252,21 @@ class BatchGateTests(unittest.TestCase):
     def test_equal_batch_and_single_vectors_pass(self) -> None:
         vector = basis_vector(1024, 9)
         rows = qualify.batch_gates("case", vector, list(vector))
-        self.assertTrue(rows[0]["pass"])
+        self.assertTrue(all(row["pass"] for row in rows))
+
+    def test_batch_vectors_must_obey_the_family_normalization_contract(self) -> None:
+        vector = basis_vector(1024, 9)
+        for scale in (0.0, 7.0, 1e200):
+            with self.subTest(scale=scale):
+                rows = qualify.batch_gates(
+                    "case", vector, [value * scale for value in vector]
+                )
+                self.assertTrue(
+                    any(
+                        row["gate"] == "batch_unit_norm" and not row["pass"]
+                        for row in rows
+                    )
+                )
 
     def test_divergent_batch_vector_fails(self) -> None:
         rows = qualify.batch_gates(


### PR DESCRIPTION
## Summary

Follow-up to #629, based on the merged main branch.

- Add a scoped evidence runner that executes existing gates, preserves versioned native reports, checks fresh evidence and artifact/source drift, and cleans up owned subprocess groups on timeout or interruption.
- Extend the existing Qwen3 Metal/CUDA qualifiers with bounded concurrent query/document requests, mixed dimensions, reversed arrival order and strict response-index coverage. Reuse existing numerical tolerances and explicitly distinguish response isolation from native fusion.
- Add a PDF document gate for two-consumer physical render reuse, completed indexing and content/page/vector-count parity across precommit/replay and two memory caps. Profiled diagnostics do not produce speedup claims.
- Version existing Gemma batching and PDF comparison reports; provide contract, model, document and performance plans. Keep native family validators authoritative.
- Document scope boundaries and remaining hardware work in PDF.md and the PDF benchmark guide; run harness regressions in CI.

## Verification

- All seven gates in execution.plan.json passed: inference scheduler, invocation, worker transport, embedding, native PDF, document replay and Go routing contracts.
- 40 PDF/orchestrator tests, 41 Qwen qualification tests and 11 existing Gemma batching tests passed on Python 3.12.
- Formatting, lint and git diff checks passed.

## Qualification boundaries

Real-model hardware, remote-deployment attestation and performance plans were not run. These tool and contract tests do not establish native fusion, OCR semantic accuracy, accelerator/RSS limits or distributed real-model safety. The current PDF benchmark still pins Florence/BGE with Metal verification; other model/task document hardware lanes remain unqualified. Existing GLiNER training qualification is not serving-time batching evidence.