### PR TITLE
test: use functional activation budget for dense rollback

### DIFF
--- a/zig/pkg/antfly/src/storage/db/db.zig
+++ b/zig/pkg/antfly/src/storage/db/db.zig
@@ -93075,14 +93075,18 @@ test "db failed activated dense generation rolls back to retained predecessor" {
         // Activate one healthy shadow first so the fault below proves that a
         // later failed generation can roll back to a non-canonical predecessor
         // pointer, not only to the original canonical root.
-        var first_generation = try db.repairArtifactIssuesWithRequest(alloc, .{
+        // Use the functional test budget for every activation so scheduling
+        // delays do not prevent the intended crash checkpoint from being hit.
+        var first_generation = try db.repairArtifactIssuesWithRequestOptions(alloc, .{
             .target = .index,
             .artifact_kind = .embedding,
             .index_name = "dense_idx",
             .limit = 1,
             .force = true,
-        });
-        first_generation.deinit(alloc);
+        }, repair_completion_test_options);
+        defer first_generation.deinit(alloc);
+        try std.testing.expectEqual(@as(u64, 1), first_generation.indexes_rebuilt);
+        try std.testing.expect(!first_generation.debt_remaining);
         const first_generation_pointer = (try db.core.index_manager.captureActiveIndexRootPointer("dense_idx")) orelse
             return error.TestUnexpectedResult;
         defer alloc.free(first_generation_pointer);
@@ -93099,13 +93103,13 @@ test "db failed activated dense generation rolls back to retained predecessor" {
             .after_snapshot_build = CrashHook.afterSnapshot,
             .after_pointer_activation = CrashHook.afterActivation,
         };
-        try std.testing.expectError(error.TestCrashBeforeReplacementValidation, db.repairArtifactIssuesWithRequest(alloc, .{
+        try std.testing.expectError(error.TestCrashBeforeReplacementValidation, db.repairArtifactIssuesWithRequestOptions(alloc, .{
             .target = .index,
             .artifact_kind = .embedding,
             .index_name = "dense_idx",
             .limit = 1,
             .force = true,
-        }));
+        }, repair_completion_test_options));
         db.shadow_index_repair_hook = null;
         repair_id = (try db.indexRepairIdForIndex(alloc, "dense_idx")) orelse return error.TestUnexpectedResult;
         var interrupted = try db.loadIndexRepairEntryById(alloc, repair_id);
@@ -93235,7 +93239,7 @@ test "db failed activated dense generation rolls back to retained predecessor" {
     try std.testing.expectEqual(@as(u32, 1), previous.total_hits);
     try std.testing.expectEqualStrings("doc:a", previous.hits[0].id);
 
-    const rebuilt = try reopened.advanceIndexRepairIntent(alloc, repair_id, .{});
+    const rebuilt = try reopened.advanceIndexRepairIntent(alloc, repair_id, repair_completion_test_options);
     try std.testing.expect(rebuilt.attempted);
     try std.testing.expect(rebuilt.repaired);
     try std.testing.expect(!try reopened.hasPendingIndexRepairIntents(alloc));


### PR DESCRIPTION
The dense-generation rollback test can exhaust the 250 ms production activation budget on a contended CI worker before reaching its injected post-activation crash. The repair then returns a failed result instead of `TestCrashBeforeReplacementValidation`, producing the failure seen in [PR #694's x86_64 Zig job](https://github.com/antflydb/antfly/actions/runs/34423487352/job/102704099568).

Use the existing five-second functional-test repair options for the initial predecessor build, the crash-injected replacement, and the final recovery rebuild. Assert that the predecessor completed successfully before testing rollback. Production activation limits and the crash, rollback, and search assertions are preserved.

Validation:

- Injecting a temporary 350 ms pause after persisting the activating phase reproduced the CI failure with the original test. The same pause passed after the fix; the temporary hook was removed.
- `zig build dense-index-lifecycle-regression-test -j4`: all 68 tests across the four test executables passed with no leaks.
- `zig fmt --check` and `git diff --check` passed.

This is an independent fix from `origin/main`; both routing-watch tests in PR #694 passed in the failing CI run.
