### PR TITLE
fix(inference): omit absent optional embedding request fields

### DIFF
--- a/zig/build.zig
+++ b/zig/build.zig
@@ -3565,7 +3565,7 @@ pub fn build(b: *std.Build) void {
 
     const lib_managed_embedder_tests = b.addTest(.{
         .root_module = antfly_test_mod,
-        .filters = &.{ "managed embedder", "antfly numeric", "antfly provider preserves explicit distributed admission denial", "legacy numeric" },
+        .filters = &.{ "managed embedder", "antfly embed request", "antfly embed round trip", "antfly sparse embed round trip", "antfly numeric", "antfly provider preserves explicit distributed admission denial", "legacy numeric" },
     });
     const run_lib_managed_embedder_tests = addFilteredTestRunArtifact(b, lib_managed_embedder_tests);
     const lib_managed_embedder_test_step = b.step("antfly-inference-managed-embedder-test", "Run managed embedder contract and provider tests");
@@ -3921,6 +3921,9 @@ pub fn build(b: *std.Build) void {
         "attachment transport separates wire and peak resident representations",
         "bounded invocation allocator",
         "inline data URI parser validates canonical metadata",
+        "antfly embed request",
+        "antfly embed round trip",
+        "antfly sparse embed round trip",
         "antfly embed parts uses the framed attachment transport",
         "antfly embed parts request sizing is exact for escaped strings",
         "antfly dense JSON response cleanup is allocation-failure safe",

--- a/zig/e2e/antfly/conftest.py
+++ b/zig/e2e/antfly/conftest.py
@@ -2189,6 +2189,12 @@ class InferenceEmbeddingServer:
                     f"{INFERENCE_PUBLIC_API_ROOT}/embed",
                     f"{INFERENCE_PUBLIC_API_ROOT}/embeddings",
                 ):
+                    # Match the inference API's optional, non-nullable strings.
+                    # Permissive fixtures previously hid invalid database requests.
+                    for field in ("task_type", "instruction"):
+                        if field in payload and not isinstance(payload[field], str):
+                            self.send_error(400, f"{field} must be a string")
+                            return
                     model = payload.get("model", "")
                     is_dimension_probe = (
                         "antfly embedding dimension probe"

--- a/zig/e2e/antfly/test_sparse.py
+++ b/zig/e2e/antfly/test_sparse.py
@@ -587,6 +587,24 @@ def test_semantic_query_embedding_template_supports_remote_text(
 def test_managed_sparse_hybrid_query_with_antfly_embeddings(
     backup_api, inference_embedder, inference_reranker
 ):
+    # Direct inference preflight must succeed with omitted optional fields.
+    # Index creation, enrichment, and semantic search below must then exercise
+    # the database's own request serializer against the same strict endpoint.
+    for model in ("antfly-embed-v1", "antfly-sparse-v1"):
+        payload = {"model": model, "input": ["alpha body"]}
+        preflight = requests.post(
+            f"{inference_embedder}/embed", json=payload, timeout=5
+        )
+        assert preflight.status_code == 200, preflight.text
+        assert len(preflight.json()["data"]) == 1
+        for field in ("task_type", "instruction"):
+            invalid = requests.post(
+                f"{inference_embedder}/embed",
+                json={**payload, field: None},
+                timeout=5,
+            )
+            assert invalid.status_code == 400, invalid.text
+
     table_name = f"sparse_hybrid_managed_{time.time_ns()}"
     created = backup_api.create_table(table_name, num_shards=1)
     assert created["name"] == table_name

--- a/zig/pkg/antfly/src/inference/local.zig
+++ b/zig/pkg/antfly/src/inference/local.zig
@@ -527,7 +527,7 @@ pub const Provider = struct {
         var input_array = std.json.Array.init(alloc);
         defer input_array.deinit();
         for (inputs) |input| try input_array.append(.{ .string = input });
-        const json_body = try httpx.json.Json.stringify(self.allocator, EmbedWireRequest{
+        const json_body = try httpx.json.Json.stringifyRequest(self.allocator, EmbedWireRequest{
             .model = model,
             .input = .{ .array = input_array },
         });
@@ -658,7 +658,7 @@ pub const Provider = struct {
         task_type: ?[]const u8,
         instruction: ?[]const u8,
     ) !inference.EmbedResult {
-        const json_body = try httpx.json.Json.stringify(alloc, EmbedWireRequest{
+        const json_body = try httpx.json.Json.stringifyRequest(alloc, EmbedWireRequest{
             .model = model,
             .input = input,
             .task_type = task_type,
@@ -957,13 +957,13 @@ test "antfly provider composes authorization and capability lease headers" {
     try std.testing.expectEqualStrings("X-Antfly-Capability-Revision", headers[3][0]);
 }
 
-test "antfly embed request omits nullable generated fields" {
+test "antfly embed request omits absent optional fields" {
     const alloc = std.testing.allocator;
     var input = std.json.Array.init(alloc);
     defer input.deinit();
     try input.append(.{ .string = "hello" });
 
-    const body = try httpx.json.Json.stringify(alloc, EmbedWireRequest{
+    const body = try httpx.json.Json.stringifyRequest(alloc, EmbedWireRequest{
         .model = "antflydb/clipclap",
         .input = .{ .array = input },
     });
@@ -971,6 +971,8 @@ test "antfly embed request omits nullable generated fields" {
 
     try std.testing.expect(std.mem.indexOf(u8, body, "\"encoding_format\":\"float\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, body, "\"dimensions\"") == null);
+    try std.testing.expect(std.mem.indexOf(u8, body, "\"task_type\"") == null);
+    try std.testing.expect(std.mem.indexOf(u8, body, "\"instruction\"") == null);
     try std.testing.expect(std.mem.indexOf(u8, body, "null") == null);
 }
 
@@ -1020,7 +1022,7 @@ test "antfly embed request carries retrieval task and instruction" {
     defer input.deinit();
     try input.append(.{ .string = "history of Korea" });
 
-    const body = try httpx.json.Json.stringify(alloc, EmbedWireRequest{
+    const body = try httpx.json.Json.stringifyRequest(alloc, EmbedWireRequest{
         .model = "nomic-ai/nomic-embed-text-v1.5",
         .input = .{ .array = input },
         .task_type = "RETRIEVAL_QUERY",
@@ -1241,8 +1243,21 @@ test "antfly sparse embed round trip" {
     defer io_impl.deinit();
     const io = io_impl.io();
 
+    const Assert = struct {
+        fn request(req: httpx.testing_mod.RequestInfo) !void {
+            var parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, req.body, .{});
+            defer parsed.deinit();
+            const obj = parsed.value.object;
+            try std.testing.expectEqualStrings("sparse-model", obj.get("model").?.string);
+            try std.testing.expectEqualStrings("alpha body", obj.get("input").?.array.items[0].string);
+            try std.testing.expectEqualStrings("float", obj.get("encoding_format").?.string);
+            try std.testing.expect(!obj.contains("task_type"));
+            try std.testing.expect(!obj.contains("instruction"));
+        }
+    };
+
     var ts = try httpx.TestServer.start(alloc, io, &.{
-        .{ .method = .POST, .path = "/embed", .respond = .{
+        .{ .method = .POST, .path = "/embed", .assert_request = Assert.request, .respond = .{
             .content_type = "application/json",
             .body =
             \\{"object":"list","data":[{"object":"embedding","index":0,"embedding":{"indices":[7,42],"values":[1.5,0.5]}}],"model":"sparse-model","usage":{"prompt_tokens":1,"total_tokens":1}}
@@ -1415,6 +1430,16 @@ fn testRerankScoresResponse(binary_response: bool) !void {
 }
 
 test "antfly embed round trip (binary)" {
+    try testDenseEmbedRequest(null, null);
+}
+
+test "antfly embed round trip preserves supplied task and instruction" {
+    try testDenseEmbedRequest("RETRIEVAL_DOCUMENT", null);
+    try testDenseEmbedRequest("RETRIEVAL_QUERY", "");
+    try testDenseEmbedRequest("RETRIEVAL_QUERY", "retrieve relevant encyclopedia passages");
+}
+
+fn testDenseEmbedRequest(comptime task_type: ?[]const u8, comptime instruction: ?[]const u8) !void {
     const alloc = std.testing.allocator;
     var io_impl = std.Io.Threaded.init(std.heap.page_allocator, .{});
     defer io_impl.deinit();
@@ -1430,8 +1455,29 @@ test "antfly embed round trip (binary)" {
     bin_buf[20..24].* = @bitCast(@as(f32, 1.5));
     bin_buf[24..28].* = @bitCast(@as(f32, 2.5));
 
+    const Assert = struct {
+        fn request(req: httpx.testing_mod.RequestInfo) !void {
+            var parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, req.body, .{});
+            defer parsed.deinit();
+            const obj = parsed.value.object;
+            try std.testing.expectEqualStrings("bge-small", obj.get("model").?.string);
+            try std.testing.expectEqualStrings("test input", obj.get("input").?.array.items[0].string);
+            try std.testing.expectEqualStrings("float", obj.get("encoding_format").?.string);
+            if (task_type) |value| {
+                try std.testing.expectEqualStrings(value, obj.get("task_type").?.string);
+            } else {
+                try std.testing.expect(!obj.contains("task_type"));
+            }
+            if (instruction) |value| {
+                try std.testing.expectEqualStrings(value, obj.get("instruction").?.string);
+            } else {
+                try std.testing.expect(!obj.contains("instruction"));
+            }
+        }
+    };
+
     var ts = try httpx.TestServer.start(alloc, io, &.{
-        .{ .method = .POST, .path = "/embed", .respond = .{
+        .{ .method = .POST, .path = "/embed", .assert_request = Assert.request, .respond = .{
             .body = &bin_buf,
             .content_type = "application/octet-stream",
         } },
@@ -1453,7 +1499,10 @@ test "antfly embed round trip (binary)" {
             defer provider.deinit();
 
             var emb = provider.embedder();
-            var result = emb.embed(a, "bge-small", &.{"test input"}) catch return;
+            var result = (if (task_type != null or instruction != null)
+                provider.embedWithTask(a, "bge-small", &.{"test input"}, task_type, instruction)
+            else
+                emb.embed(a, "bge-small", &.{"test input"})) catch return;
             defer result.deinit();
 
             ok_out.* = true;


### PR DESCRIPTION
Antfly's dense and sparse HTTP embedding clients serialize absent `instruction` and `task_type` fields as JSON null. The inference API accepts optional strings and rejects explicit null, so valid database embedding configurations can fail even when a direct inference preflight succeeds.

Use `Json.stringifyRequest` at both outbound embedding call sites to omit absent fields while preserving supplied strings, including empty instructions. Add HTTP request assertions for dense and sparse calls, cover document tasks without instructions and query tasks with empty/nonempty instructions, and include the previously excluded omission test and round-trip tests in the managed-embedder and default root test filters.

Validation: the regression assertions fail before the serializer fix. Afterward, `zig build antfly-inference-managed-embedder-test -Doptimize=Debug` passes all 73 tests with no skips or leaks; `zig fmt --check` and `git diff --check` pass. HTTP validation uses local test servers, without model downloads or a Colony deployment.

Also prepared for backport to `v0.2.x`; the bug is present in published v0.2.1.


E2E coverage now enforces the same optional-string contract in `InferenceEmbeddingServer`. The existing managed dense/sparse hybrid test first checks that direct preflight succeeds with omitted fields and rejects explicit null, then creates database indexes, enriches documents, waits for readiness, and executes semantic/hybrid search against that strict HTTP fixture. This exercises the database integration without model downloads.

Built this branch with `zig build antfly -Doptimize=Debug -j2`. The focused regression passed, and `uv run --project e2e/antfly pytest -q e2e/antfly/test_sparse.py` passed all 9 e2e tests. Black formatting and diff checks passed.
