### PR TITLE
fix(inference): backport model configuration fixes to v0.2.x

### DIFF
--- a/.github/workflows/antfly-operator-go.yml
+++ b/.github/workflows/antfly-operator-go.yml
@@ -5,7 +5,7 @@ name: Antfly Operator Tests
 
 on:
   push:
-    branches: ["main"]
+    branches: ["main", "v0.2.x"]
     paths:
       - 'go/pkg/operator/**'
       - 'go/pkg/sdk/admin/**'
@@ -16,7 +16,7 @@ on:
       - '.github/actions/load-toolchain-policy/action.yml'
       - '.github/workflows/antfly-operator-go.yml'
   pull_request:
-    branches: ["main"]
+    branches: ["main", "v0.2.x"]
     paths:
       - 'go/pkg/operator/**'
       - 'go/pkg/sdk/admin/**'
@@ -41,6 +41,7 @@ env:
 jobs:
   test:
     runs-on: arc-antfly-standard
+    timeout-minutes: 30
     defaults:
       run:
         working-directory: go/pkg/operator
@@ -77,6 +78,27 @@ jobs:
 
       - name: Run tests
         run: make test
+
+      # This is a required step, not an env-gated unit test: execute the
+      # reconciler's generated command against the supported release on CPU.
+      # Update the version AND checksum when advancing the runtime baseline.
+      - name: Test generated inference command against released runtime
+        env:
+          RUNTIME_VERSION: '0.2.1'
+          RUNTIME_SHA256: '2378190c86966626e5a6a101918f66f0f175c8f7482a85415fc446a2a09427d7'
+        run: |
+          set -euo pipefail
+          test "$(uname -m)" = x86_64
+          runtime_dir="$(mktemp -d)"
+          archive="antfly_${RUNTIME_VERSION}_Linux_x86_64_gnu.tar.gz"
+          curl --fail --location --retry 3 --max-time 180 \
+            "https://github.com/antflydb/antfly/releases/download/v${RUNTIME_VERSION}/${archive}" \
+            --output "${runtime_dir}/${archive}"
+          printf '%s  %s\n' "$RUNTIME_SHA256" "${runtime_dir}/${archive}" | sha256sum --check --strict
+          tar -xzf "${runtime_dir}/${archive}" -C "$runtime_dir"
+          ANTFLY_RUNTIME_BIN="${runtime_dir}/antfly" GOWORK=off go test \
+            -tags runtimeintegration ./controllers/inference \
+            -run '^TestInferenceRuntimeContract$' -count=1 -v -timeout=20m
 
       - name: Run lint
         run: make lint

--- a/.github/workflows/zig-tests.yml
+++ b/.github/workflows/zig-tests.yml
@@ -2,9 +2,9 @@ name: Zig Tests
 
 on:
   push:
-    branches: ["main"]
+    branches: ["main", "v0.2.x"]
   pull_request:
-    branches: ["main"]
+    branches: ["main", "v0.2.x"]
   merge_group:
     types: [checks_requested]
   schedule:
@@ -132,6 +132,11 @@ jobs:
             ':(exclude,glob)zig/pkg/antfly/antfarm/**' \
             ':(glob)scripts/ci/zig-*.sh' \
             scripts/ci/toolchain-policy.json \
+            ':(glob)go/pkg/operator/**' \
+            ':(glob)go/pkg/sdk/admin/**' \
+            go/pkg/sdk/go.mod \
+            go/pkg/sdk/go.sum \
+            ':(glob)specs/openapi/**' \
             .github/actions/load-toolchain-policy/action.yml \
             scripts/test-backup-s3-integration.sh \
             Makefile \
@@ -916,11 +921,44 @@ jobs:
       - name: Install E2E executable
         run: tar -xzf "${RUNNER_TEMP}/antfly-e2e-base/antfly-e2e-base.tar.gz" -C zig
 
+      - name: Set up Go for operator runtime contract
+        if: matrix.suite == 'inference'
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: ${{ steps.toolchain.outputs.go_version }}
+          cache: false
+
+      # Execute the SAME reconciler-generated contract as the operator job's
+      # pinned v0.2.1 baseline, now against this PR's newly built runtime.
+      - name: Test generated inference command against candidate runtime
+        if: matrix.suite == 'inference'
+        working-directory: go/pkg/operator
+        env:
+          ANTFLY_RUNTIME_BIN: ${{ github.workspace }}/zig/zig-out/bin/antfly
+          GOWORK: 'off'
+          GOEXPERIMENT: simd
+        run: >-
+          taskset -c ${{ steps.e2e_cpus.outputs.list }} go test
+          -tags runtimeintegration ./controllers/inference
+          -run '^TestInferenceRuntimeContract$' -count=1 -v -timeout=20m
+
       - name: Run base E2E
         env:
           SKIP_BUILD: "1"
           ANTFLY_E2E_SUITE: ${{ matrix.suite }}
         run: taskset -c ${{ steps.e2e_cpus.outputs.list }} scripts/ci/zig-e2e-base-linux.sh
+
+      - name: Run inference config contract with a real CPU model
+        if: matrix.suite == 'inference'
+        working-directory: zig
+        env:
+          ANTFLY_BIN: ./zig-out/bin/antfly
+          ANTFLY_INFERENCE_MODELS_DIR: ${{ runner.temp }}/inference-config-models
+          ANTFLY_INFERENCE_DOWNLOAD: "1"
+          UV_PROJECT_ENVIRONMENT: /tmp/antfly-ci-venv/inference
+        run: >-
+          taskset -c ${{ steps.e2e_cpus.outputs.list }} uv run --project e2e/inference pytest -q
+          e2e/inference/test_run_config.py
 
       - name: Run low-FD HTTP worker ratchet regression
         if: matrix.suite == 'antfly'

--- a/docs/guides/inference.mdx
+++ b/docs/guides/inference.mdx
@@ -27,6 +27,69 @@ optimized ONNX and native GGUF execution without external API dependencies.
 - **Local Generation** - Text, image, and audio prompts with supported GGUF models
 - **Privacy** - Data never leaves your infrastructure
 
+## Configuring a Separate Inference Process
+
+`antfly inference run --config inference.json` reads admission settings and the
+model settings `models_dir`, `ml_dir`, `max_loaded_models`, and `preload`:
+
+```json
+{
+  "inference": {
+    "models_dir": "/models",
+    "ml_dir": "/ml",
+    "max_loaded_models": 3,
+    "preload": [
+      {"kind": "embedder", "name": "BAAI/bge-small-en-v1.5", "backend": "native"}
+    ]
+  }
+}
+```
+
+Pull the referenced models into that directory before starting the process.
+The operator's flat config spelling (those four fields at the top level) is
+also accepted. If both spellings exist, the nested `inference` value wins for
+each field, including an explicit empty `preload` list. No `api_url` is required
+to start the server; configure the listener with `--host` and `--port`.
+
+Explicit CLI options override config regardless of argument order. Supplying
+one or more `--preload-model` flags replaces the config preload list rather than
+appending to it. For an exact match of kind, model reference (including artifact
+variant), and backend, config-only `residency_mode` and `memory_budget_mb`
+policies are retained; unrelated config models are not loaded. Duplicate config
+entries matching the same CLI selection are rejected as ambiguous.
+A model-count limit of zero disables that limit. When paths are
+absent from both CLI and config, the usual environment/home defaults apply.
+Preload entries retain their backend, artifact format/quantization, and optional
+residency/memory-budget choices.
+An unqualified preload name with `format`/`quantization` is expanded to an
+explicit artifact reference (for example, `owner/model:gguf:Q4_K`) before
+resolution. Conflicts between preferences and already-qualified references are
+rejected rather than silently selecting another installed artifact.
+
+This config support is for the next runtime release; v0.2.1 requires explicit
+model CLI flags. The operator continues passing those flags so its fix can be
+released independently of the runtime update.
+For that compatibility, the operator resolves nested model overrides into the
+flat config spelling before emitting JSON or CLI arguments. It writes default
+model kinds (`generator` when omitted in `spec.config.preload`) and normalized
+artifact references into both outputs. Remaining non-model nested settings are
+preserved with the client URL field required by the legacy schema; admission
+settings and flat per-model policies remain intact.
+Config-only per-model policies require the new runtime; releasing the operator
+does not add those capabilities to v0.2.1.
+
+For operator-generated eager preloads (the default loading strategy), specify a
+recognized task such as `tasks: [embed]` or `tasks: [generate]` on each model.
+The v0.2.1 warm CLI needs a model kind; an omitted or unrecognized task hint
+does not imply a generator. The operator reports a configuration validation
+failure before creating or updating the workload when that kind is ambiguous.
+Alternatively, supply `spec.config.preload` with an explicit `kind`, or use
+lazy/bounded loading to discover the model task at request time. Per-model
+eager strategy overrides have the same requirement.
+
+Empty or null optional `backend`, `format`, and `quantization` fields in operator
+preload configuration are treated as unspecified in both JSON and CLI output.
+
 ## Model Management
 
 ### List Available Models

--- a/go/pkg/operator/api/inference/v1alpha1/inferencepool_types.go
+++ b/go/pkg/operator/api/inference/v1alpha1/inferencepool_types.go
@@ -187,6 +187,8 @@ type ModelSpec struct {
 
 	// Tasks declares the model tasks to write into the pulled model manifest.
 	// For example: ["embed"].
+	// Generated eager preloads require a recognized task. If omitted, use lazy
+	// or bounded loading, or supply spec.config.preload with an explicit kind.
 	// +optional
 	Tasks []string `json:"tasks,omitempty"`
 

--- a/go/pkg/operator/controllers/inference/inferencepool_args_test.go
+++ b/go/pkg/operator/controllers/inference/inferencepool_args_test.go
@@ -1,0 +1,326 @@
+// Copyright 2026 Antfly, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/events"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	api "github.com/antflydb/antfly/go/pkg/operator/api/inference/v1alpha1"
+)
+
+func TestInferenceStatefulSetModelArguments(t *testing.T) {
+	for _, strategy := range []api.LoadingStrategy{"", api.LoadingStrategyEager, api.LoadingStrategyLazy, api.LoadingStrategyBounded} {
+		t.Run(string(strategy), func(t *testing.T) {
+			g := NewWithT(t)
+			scheme := newInferenceUnitTestScheme(g)
+			maxLoaded := 3
+			pool := &api.InferencePool{
+				ObjectMeta: metav1.ObjectMeta{Name: "models", Namespace: "default", UID: "pool-uid"},
+				Spec: api.InferencePoolSpec{Models: api.ModelConfig{
+					LoadingStrategy: strategy, MaxLoadedModels: &maxLoaded,
+					Preload: []api.ModelSpec{
+						{Name: "hf:owner/embed:gguf:Q4_K", Tasks: []string{"embed"}},
+						{Name: "owner/extract:gguf:Q4_K", Tasks: []string{"extract"}, Strategy: api.LoadingStrategyEager},
+						{Name: "owner/lazy:i8", Tasks: []string{"embed"}, Strategy: api.LoadingStrategyLazy},
+					},
+				}},
+			}
+			client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pool).Build()
+			r := &InferencePoolReconciler{Client: client, Scheme: scheme, AntflyImage: "antfly:v0.2.1"}
+			ctx := context.Background()
+			g.Expect(r.reconcileStatefulSet(ctx, pool)).To(Succeed())
+			sts := &appsv1.StatefulSet{}
+			key := types.NamespacedName{Name: pool.Name, Namespace: pool.Namespace}
+			g.Expect(client.Get(ctx, key, sts)).To(Succeed())
+			want := []string{"inference", "run", "--host", "0.0.0.0", "--port", "8080", "--config", "/config/config.json", "--allow-insecure-public-bind", "--models-dir", "/models", "--max-loaded-models", "3"}
+			if strategy == "" || strategy == api.LoadingStrategyEager {
+				want = append(want, "--preload-model", "embedder:owner/embed:gguf:Q4_K")
+			}
+			want = append(want, "--preload-model", "extractor:owner/extract:gguf:Q4_K")
+			g.Expect(sts.Spec.Template.Spec.Containers[0].Args).To(Equal(want))
+			// All models are downloaded, even when only the eager subset is warmed.
+			g.Expect(sts.Spec.Template.Spec.InitContainers).To(HaveLen(3))
+			for _, c := range sts.Spec.Template.Spec.InitContainers {
+				g.Expect(c.Args[3:5]).To(Equal([]string{"--models-dir", "/models"}))
+			}
+
+			// A config override must affect the pullers, server and shared mount,
+			// and must change the template hash so existing pools roll forward.
+			oldHash := sts.Spec.Template.Annotations["inference.antfly.io/template-hash"]
+			pool.Spec.Config = `{"models_dir":"/custom-models","max_loaded_models":2,"preload":[{"kind":"embedder","backend":"cuda","name":"owner/embed","format":"gguf","quantization":"Q4_K"}]}`
+			g.Expect(r.reconcileStatefulSet(ctx, pool)).To(Succeed())
+			g.Expect(client.Get(ctx, key, sts)).To(Succeed())
+			g.Expect(sts.Spec.Template.Annotations["inference.antfly.io/template-hash"]).NotTo(Equal(oldHash))
+			g.Expect(sts.Spec.Template.Spec.Containers[0].Args).To(Equal([]string{
+				"inference", "run", "--host", "0.0.0.0", "--port", "8080", "--config", "/config/config.json", "--allow-insecure-public-bind",
+				"--models-dir", "/custom-models", "--max-loaded-models", "2", "--preload-model", "embedder:cuda:owner/embed:gguf:Q4_K",
+			}))
+			g.Expect(sts.Spec.Template.Spec.Containers[0].VolumeMounts).To(ContainElement(corev1.VolumeMount{Name: "models", MountPath: "/custom-models"}))
+			for _, c := range sts.Spec.Template.Spec.InitContainers {
+				g.Expect(c.Args[3:5]).To(Equal([]string{"--models-dir", "/custom-models"}))
+				g.Expect(c.VolumeMounts).To(ContainElement(corev1.VolumeMount{Name: "models", MountPath: "/custom-models"}))
+			}
+		})
+	}
+}
+
+func TestInferenceModelArgsValidation(t *testing.T) {
+	for _, config := range []string{
+		`{"models_dir":123}`, `{"models_dir":"relative"}`, `{"models_dir":"/"}`, `{"models_dir":"/config/models"}`,
+		`{"models_dir":"/models","ml_dir":""}`, `{"models_dir":"/models","ml_dir":"relative"}`,
+		`{"models_dir":"/models","max_loaded_models":-1}`, `{"models_dir":"/models","max_loaded_models":1.5}`,
+		`{"models_dir":"/models","preload":[{"kind":"bogus","name":"owner/model"}]}`,
+		`{"models_dir":"/models","preload":[{"backend":"bogus","name":"owner/model"}]}`,
+		`{"models_dir":"/models","preload":[{}]}`,
+		`{"models_dir":"/models","preload":[{"name":"owner/model:gguf:Q4_K","format":"onnx"}]}`,
+	} {
+		t.Run(config, func(t *testing.T) {
+			_, _, err := inferenceModelArgs(config)
+			if err == nil {
+				t.Fatal("expected invalid model configuration to fail")
+			}
+		})
+	}
+}
+
+func TestInferenceEagerPreloadRequiresTaskOrOverride(t *testing.T) {
+	for _, strategy := range []api.LoadingStrategy{"", api.LoadingStrategyEager, api.LoadingStrategyLazy, api.LoadingStrategyBounded} {
+		for _, tasks := range [][]string{nil, {"unknown-task"}} {
+			t.Run(fmt.Sprintf("strategy=%s/tasks=%v", strategy, tasks), func(t *testing.T) {
+				g := NewWithT(t)
+				pool := &api.InferencePool{Spec: api.InferencePoolSpec{Models: api.ModelConfig{
+					LoadingStrategy: strategy,
+					Preload:         []api.ModelSpec{{Name: "BAAI/bge-small-en-v1.5", Tasks: tasks}},
+				}}}
+				r := &InferencePoolReconciler{}
+				_, err := r.generateCompleteConfig(pool)
+				if strategy == "" || strategy == api.LoadingStrategyEager {
+					g.Expect(err).To(MatchError(ContainSubstring("eager loading requires a recognized task")))
+				} else {
+					g.Expect(err).NotTo(HaveOccurred())
+				}
+				// A per-model eager override also needs a kind, even in a lazy pool.
+				pool.Spec.Models.Preload[0].Strategy = api.LoadingStrategyEager
+				_, err = r.generateCompleteConfig(pool)
+				g.Expect(err).To(HaveOccurred())
+				for _, config := range []string{
+					`{"preload":[{"kind":"embedder","name":"BAAI/bge-small-en-v1.5"}]}`,
+					`{"inference":{"preload":[{"kind":"embedder","name":"BAAI/bge-small-en-v1.5"}]}}`,
+					`{"preload":[]}`,
+				} {
+					pool.Spec.Config = config
+					_, err = r.generateCompleteConfig(pool)
+					g.Expect(err).NotTo(HaveOccurred())
+				}
+			})
+		}
+	}
+}
+
+func TestInferenceAmbiguousEagerConfigReportsValidationFailure(t *testing.T) {
+	g := NewWithT(t)
+	scheme := newInferenceUnitTestScheme(g)
+	g.Expect(policyv1.AddToScheme(scheme)).To(Succeed())
+	pool := &api.InferencePool{
+		ObjectMeta: metav1.ObjectMeta{Name: "ambiguous", Namespace: "default", UID: "pool-uid", Generation: 1},
+		Spec: api.InferencePoolSpec{
+			Models:   api.ModelConfig{Preload: []api.ModelSpec{{Name: "BAAI/bge-small-en-v1.5"}}},
+			Replicas: api.ReplicaConfig{Min: 1, Max: 1},
+		},
+		// An operator upgrade must revalidate previously accepted generations.
+		Status: api.InferencePoolStatus{ObservedGeneration: 1, Phase: api.InferencePoolPhaseRunning},
+	}
+	client := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(pool).WithObjects(pool).Build()
+	r := &InferencePoolReconciler{Client: client, Scheme: scheme, Recorder: events.NewFakeRecorder(10)}
+	ctx := context.Background()
+	key := types.NamespacedName{Name: pool.Name, Namespace: pool.Namespace}
+	result, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: key})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result.RequeueAfter).To(BeNumerically(">", 0))
+	g.Expect(client.Get(ctx, key, pool)).To(Succeed())
+	condition := meta.FindStatusCondition(pool.Status.Conditions, api.TypeConfigurationValid)
+	g.Expect(condition).NotTo(BeNil())
+	g.Expect(condition.Status).To(Equal(metav1.ConditionFalse))
+	g.Expect(condition.Message).To(ContainSubstring("eager loading requires a recognized task"))
+	g.Expect(errors.IsNotFound(client.Get(ctx, key, &appsv1.StatefulSet{}))).To(BeTrue())
+	g.Expect(errors.IsNotFound(client.Get(ctx, types.NamespacedName{Name: pool.Name + "-config", Namespace: pool.Namespace}, &corev1.ConfigMap{}))).To(BeTrue())
+
+	// Correcting the hint clears the validation failure and creates the workload.
+	pool.Spec.Models.Preload[0].Tasks = []string{"embed"}
+	pool.Generation++
+	g.Expect(client.Update(ctx, pool)).To(Succeed())
+	_, err = r.Reconcile(ctx, ctrl.Request{NamespacedName: key})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(client.Get(ctx, key, pool)).To(Succeed())
+	g.Expect(meta.IsStatusConditionTrue(pool.Status.Conditions, api.TypeConfigurationValid)).To(BeTrue())
+	g.Expect(client.Get(ctx, key, &appsv1.StatefulSet{})).To(Succeed())
+}
+
+func TestInferenceResolvedConfigLegacyCompatibility(t *testing.T) {
+	for _, input := range []string{
+		`{"inference":{"preload":[]}}`,
+		`{"inference":{"preload":[{"name":"hf:owner/model","format":"gguf","quantization":"Q4_K","residency_mode":"streamed","memory_budget_mb":4096}]}}`,
+		`{"preload":[{"name":"hf:owner/model","format":"gguf","quantization":"Q4_K","residency_mode":"streamed","memory_budget_mb":4096}]}`,
+	} {
+		t.Run(input, func(t *testing.T) {
+			g := NewWithT(t)
+			pool := &api.InferencePool{Spec: api.InferencePoolSpec{Config: input}}
+			raw, err := (&InferencePoolReconciler{}).generateCompleteConfig(pool)
+			g.Expect(err).NotTo(HaveOccurred())
+			var resolved map[string]any
+			g.Expect(json.Unmarshal([]byte(raw), &resolved)).To(Succeed())
+			g.Expect(resolved).NotTo(HaveKey("inference"))
+			preload := resolved["preload"].([]any)
+			if len(preload) > 0 {
+				model := preload[0].(map[string]any)
+				g.Expect(model["kind"]).To(Equal("generator"))
+				g.Expect(model["name"]).To(Equal("owner/model:gguf:Q4_K"))
+				g.Expect(model["residency_mode"]).To(Equal("streamed"))
+				g.Expect(model["memory_budget_mb"]).To(Equal(float64(4096)))
+			}
+		})
+	}
+}
+
+func TestInferenceResolvedConfigPreservesNonModelSettings(t *testing.T) {
+	g := NewWithT(t)
+	pool := &api.InferencePool{Spec: api.InferencePoolSpec{Config: `{"inference":{"keep_alive_ms":42,"ml_dir":"/traditional-models","preload":[]},"admission":{"inference":{"max_concurrent_requests":3}}}`}}
+	raw, err := (&InferencePoolReconciler{}).generateCompleteConfig(pool)
+	g.Expect(err).NotTo(HaveOccurred())
+	var resolved map[string]any
+	g.Expect(json.Unmarshal([]byte(raw), &resolved)).To(Succeed())
+	g.Expect(resolved["inference"]).To(Equal(map[string]any{"api_url": "", "keep_alive_ms": float64(42)}))
+	g.Expect(resolved["admission"]).To(Equal(map[string]any{"inference": map[string]any{"max_concurrent_requests": float64(3)}}))
+	_, args, err := inferenceModelArgs(raw)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(args).To(Equal([]string{"--models-dir", "/models", "--ml-dir", "/traditional-models"}))
+	for _, invalid := range []string{`{"preload":null}`, `{"preload":[null]}`, `{"preload":[{"name":123}]}`} {
+		pool.Spec.Config = invalid
+		_, err := (&InferencePoolReconciler{}).generateCompleteConfig(pool)
+		g.Expect(err).To(HaveOccurred(), invalid)
+	}
+}
+
+func TestInferenceResolvedConfigOptionalIdentityDefaults(t *testing.T) {
+	for _, nested := range []bool{false, true} {
+		for _, empty := range []string{`""`, `null`} {
+			t.Run(fmt.Sprintf("nested=%t/empty=%s", nested, empty), func(t *testing.T) {
+				g := NewWithT(t)
+				config := fmt.Sprintf(`{"preload":[{"kind":"embedder","name":"hf:owner/model","backend":%s,"format":%s,"quantization":%s,"residency_mode":"auto","memory_budget_mb":0}]}`, empty, empty, empty)
+				if nested {
+					config = `{"inference":` + config + `}`
+				}
+				pool := &api.InferencePool{Spec: api.InferencePoolSpec{Config: config}}
+				raw, err := (&InferencePoolReconciler{}).generateCompleteConfig(pool)
+				g.Expect(err).NotTo(HaveOccurred())
+				var resolved struct {
+					Preload []map[string]any `json:"preload"`
+				}
+				g.Expect(json.Unmarshal([]byte(raw), &resolved)).To(Succeed())
+				g.Expect(resolved.Preload).To(Equal([]map[string]any{{
+					"kind": "embedder", "name": "owner/model", "residency_mode": "auto", "memory_budget_mb": float64(0),
+				}}))
+				_, args, err := inferenceModelArgs(raw)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(args).To(Equal([]string{"--models-dir", "/models", "--preload-model", "embedder:owner/model"}))
+			})
+		}
+	}
+}
+
+func TestInferenceNestedConfigOverridesGeneratedModelSettings(t *testing.T) {
+	for _, preload := range []string{`[]`, `[{"kind":"generator","name":"owner/custom","backend":"cuda","format":"gguf","quantization":"Q4_K","residency_mode":"streamed","memory_budget_mb":4096}]`} {
+		t.Run(preload, func(t *testing.T) {
+			g := NewWithT(t)
+			scheme := newInferenceUnitTestScheme(g)
+			pool := &api.InferencePool{
+				ObjectMeta: metav1.ObjectMeta{Name: "nested", Namespace: "default", UID: "nested-uid"},
+				Spec: api.InferencePoolSpec{
+					Models: api.ModelConfig{Preload: []api.ModelSpec{{Name: "owner/generated", Tasks: []string{"embed"}}}},
+					Config: `{"models_dir":"/flat","max_loaded_models":9,"inference":{"models_dir":"/custom-models","max_loaded_models":0,"preload":` + preload + `}}`,
+				},
+			}
+			client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pool).Build()
+			r := &InferencePoolReconciler{Client: client, Scheme: scheme}
+			ctx := context.Background()
+			g.Expect(r.reconcileConfigMap(ctx, pool)).To(Succeed())
+			g.Expect(r.reconcileStatefulSet(ctx, pool)).To(Succeed())
+			sts := &appsv1.StatefulSet{}
+			g.Expect(client.Get(ctx, types.NamespacedName{Name: pool.Name, Namespace: pool.Namespace}, sts)).To(Succeed())
+			want := []string{"inference", "run", "--host", "0.0.0.0", "--port", "8080", "--config", "/config/config.json", "--allow-insecure-public-bind", "--models-dir", "/custom-models", "--max-loaded-models", "0"}
+			if preload != "[]" {
+				want = append(want, "--preload-model", "generator:cuda:owner/custom:gguf:Q4_K")
+			}
+			g.Expect(sts.Spec.Template.Spec.Containers[0].Args).To(Equal(want))
+			g.Expect(sts.Spec.Template.Spec.Containers[0].VolumeMounts).To(ContainElement(corev1.VolumeMount{Name: "models", MountPath: "/custom-models"}))
+			for _, c := range sts.Spec.Template.Spec.InitContainers {
+				g.Expect(c.Args[3:5]).To(Equal([]string{"--models-dir", "/custom-models"}))
+				g.Expect(c.VolumeMounts).To(ContainElement(corev1.VolumeMount{Name: "models", MountPath: "/custom-models"}))
+			}
+			cm := &corev1.ConfigMap{}
+			g.Expect(client.Get(ctx, types.NamespacedName{Name: pool.Name + "-config", Namespace: pool.Namespace}, cm)).To(Succeed())
+			if preload != "[]" {
+				g.Expect(cm.Data["config.json"]).To(ContainSubstring(`"residency_mode": "streamed"`))
+				g.Expect(cm.Data["config.json"]).To(ContainSubstring(`"memory_budget_mb": 4096`))
+			}
+		})
+	}
+}
+
+func TestInferenceModelArgsEagerCapacityAndEmptyOverride(t *testing.T) {
+	g := NewWithT(t)
+	pool := &api.InferencePool{}
+	for i := range 11 {
+		pool.Spec.Models.Preload = append(pool.Spec.Models.Preload, api.ModelSpec{Name: fmt.Sprintf("owner/model-%d:i8", i), Tasks: []string{"embed"}})
+	}
+	raw, err := (&InferencePoolReconciler{}).generateCompleteConfig(pool)
+	g.Expect(err).NotTo(HaveOccurred())
+	_, args, err := inferenceModelArgs(raw)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(args[:4]).To(Equal([]string{"--models-dir", "/models", "--max-loaded-models", "11"}))
+	g.Expect(args).To(HaveLen(26))
+	pool.Spec.Config = `{"preload":[],"max_loaded_models":0}`
+	raw, err = (&InferencePoolReconciler{}).generateCompleteConfig(pool)
+	g.Expect(err).NotTo(HaveOccurred())
+	_, args, err = inferenceModelArgs(raw)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(args).To(Equal([]string{"--models-dir", "/models", "--max-loaded-models", "0"}))
+	pool.Spec.Config = `{"inference":{"preload":[]}}`
+	raw, err = (&InferencePoolReconciler{}).generateCompleteConfig(pool)
+	g.Expect(err).NotTo(HaveOccurred())
+	_, args, err = inferenceModelArgs(raw)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(args).To(Equal([]string{"--models-dir", "/models"}))
+	for _, config := range []string{`null`, `{"inference":null}`, `{"inference":[]}`} {
+		pool.Spec.Config = config
+		_, err = (&InferencePoolReconciler{}).generateCompleteConfig(pool)
+		g.Expect(err).To(HaveOccurred())
+	}
+}

--- a/go/pkg/operator/controllers/inference/inferencepool_config_test.go
+++ b/go/pkg/operator/controllers/inference/inferencepool_config_test.go
@@ -304,7 +304,8 @@ func TestZigWarmModelKindUsesRegistryTaskPrecedence(t *testing.T) {
 	g := NewWithT(t)
 	g.Expect(zigWarmModelKind([]string{"embed"})).To(Equal("embedder"))
 	g.Expect(zigWarmModelKind([]string{"generate", "rerank"})).To(Equal("reranker"))
-	g.Expect(zigWarmModelKind(nil)).To(Equal("generator"))
+	g.Expect(zigWarmModelKind(nil)).To(BeEmpty())
+	g.Expect(zigWarmModelKind([]string{"unknown-task"})).To(BeEmpty())
 }
 
 func TestInferenceWarmModelNamePreservesVariant(t *testing.T) {

--- a/go/pkg/operator/controllers/inference/inferencepool_controller.go
+++ b/go/pkg/operator/controllers/inference/inferencepool_controller.go
@@ -23,6 +23,7 @@ import (
 	stderrors "errors"
 	"fmt"
 	"maps"
+	"path"
 	"reflect"
 	"slices"
 	"strconv"
@@ -119,11 +120,13 @@ func (r *InferencePoolReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	originalConditions := slices.Clone(pool.Status.Conditions)
 
 	// 0. Validate configuration (fallback when webhook is disabled)
-	// Generation guard: skip if spec unchanged since last successful validation.
+	// Revalidate on upgrades too: a previously accepted generation can violate
+	// the runtime contract. Avoid refreshing successful conditions unnecessarily.
+	validationErr := r.validatePool(pool)
 	needsValidation := pool.Status.ObservedGeneration != pool.Generation ||
-		pool.Status.Phase == antflyaiv1alpha1.InferencePoolPhaseDegraded
+		pool.Status.Phase == antflyaiv1alpha1.InferencePoolPhaseDegraded || validationErr != nil
 	if needsValidation {
-		if err := r.validatePool(pool); err != nil {
+		if err := validationErr; err != nil {
 			logger.Error(err, "InferencePool validation failed")
 			meta.SetStatusCondition(&pool.Status.Conditions, metav1.Condition{
 				Type:    antflyaiv1alpha1.TypeConfigurationValid,
@@ -313,6 +316,33 @@ func (r *InferencePoolReconciler) generateCompleteConfig(pool *antflyaiv1alpha1.
 			return "", fmt.Errorf("failed to parse spec.config: %w", err)
 		}
 	}
+	if config == nil {
+		return "", fmt.Errorf("spec.config must be an object")
+	}
+	// Match the standalone runtime's nested-over-flat precedence before
+	// generating defaults, CLI arguments, puller paths, or volume mounts.
+	if raw, exists := config["inference"]; exists {
+		nested, ok := raw.(map[string]any)
+		if !ok {
+			return "", fmt.Errorf("spec.config.inference must be an object")
+		}
+		for _, key := range []string{"models_dir", "ml_dir", "max_loaded_models", "preload"} {
+			if value, exists := nested[key]; exists {
+				config[key] = value
+				delete(nested, key)
+			}
+		}
+		// v0.2.1 validates the nested inference schema even when CLI flags
+		// supply all model options. Keep model policies only in the flat
+		// standalone spelling: the legacy parser ignores them there, while
+		// the new runtime reads them. Preserve unrelated nested settings.
+		if len(nested) == 0 {
+			delete(config, "inference")
+		} else if _, exists := nested["api_url"]; !exists {
+			// The shared legacy schema requires this client-only field.
+			nested["api_url"] = ""
+		}
+	}
 
 	loadingStrategy := pool.Spec.Models.LoadingStrategy
 	if loadingStrategy == "" {
@@ -324,14 +354,22 @@ func (r *InferencePoolReconciler) generateCompleteConfig(pool *antflyaiv1alpha1.
 	// Accelerator selection is configured independently through
 	// ANTFLY_INFERENCE_PREFERRED_BACKEND.
 	preload := make([]map[string]any, 0, len(pool.Spec.Models.Preload))
-	for _, model := range pool.Spec.Models.Preload {
+	_, preloadOverridden := config["preload"]
+	for i, model := range pool.Spec.Models.Preload {
+		if preloadOverridden {
+			break
+		}
 		modelStrategy := effectiveInferenceLoadingStrategy(model.Strategy, loadingStrategy)
 		if modelStrategy != antflyaiv1alpha1.LoadingStrategyEager {
 			continue
 		}
 
+		kind := zigWarmModelKind(model.Tasks)
+		if kind == "" {
+			return "", fmt.Errorf("spec.models.preload[%d] (%q): eager loading requires a recognized task; set tasks (for example [\"embed\"]), provide spec.config.preload with an explicit kind, or use strategy lazy for automatic discovery", i, model.Name)
+		}
 		entry := map[string]any{
-			"kind": zigWarmModelKind(model.Tasks),
+			"kind": kind,
 			"name": inferenceWarmModelName(model.Name),
 		}
 		if format, quantization, ok := inferenceArtifactSelection(model.Name); ok {
@@ -349,6 +387,9 @@ func (r *InferencePoolReconciler) generateCompleteConfig(pool *antflyaiv1alpha1.
 	}
 	if _, exists := config["models_dir"]; !exists {
 		config["models_dir"] = "/models"
+	}
+	if err := normalizeInferencePreloadConfig(config); err != nil {
+		return "", err
 	}
 
 	// Translate Kubernetes durations to the Zig runtime's millisecond setting.
@@ -371,11 +412,15 @@ func (r *InferencePoolReconciler) generateCompleteConfig(pool *antflyaiv1alpha1.
 		}
 	}
 	if _, exists := config["max_loaded_models"]; !exists {
+		preloadCount := len(preload)
+		if explicit, ok := config["preload"].([]map[string]any); ok {
+			preloadCount = len(explicit)
+		}
 		if pool.Spec.Models.MaxLoadedModels != nil {
 			config["max_loaded_models"] = *pool.Spec.Models.MaxLoadedModels
-		} else if len(preload) > 10 {
+		} else if preloadCount > 10 {
 			// Ensure eager startup can retain every requested model.
-			config["max_loaded_models"] = len(preload)
+			config["max_loaded_models"] = preloadCount
 		}
 	}
 
@@ -386,6 +431,145 @@ func (r *InferencePoolReconciler) generateCompleteConfig(pool *antflyaiv1alpha1.
 	}
 
 	return string(configJSON), nil
+}
+
+type inferencePreloadIdentity struct {
+	Kind         string `json:"kind"`
+	Name         string `json:"name"`
+	Backend      string `json:"backend"`
+	Format       string `json:"format"`
+	Quantization string `json:"quantization"`
+}
+
+// Persist defaults and canonical references before either output is generated.
+// Retain policy/extension fields instead of round-tripping through a lossy DTO.
+func normalizeInferencePreloadConfig(config map[string]any) error {
+	raw, exists := config["preload"]
+	if !exists {
+		return nil
+	}
+	data, err := json.Marshal(raw)
+	if err != nil {
+		return err
+	}
+	var entries []map[string]any
+	if err := json.Unmarshal(data, &entries); err != nil {
+		return fmt.Errorf("invalid inference preload config: %w", err)
+	}
+	if entries == nil {
+		return fmt.Errorf("preload must be an array")
+	}
+	for i, entry := range entries {
+		data, err := json.Marshal(entry)
+		if err != nil {
+			return err
+		}
+		var model inferencePreloadIdentity
+		if err := json.Unmarshal(data, &model); err != nil {
+			return fmt.Errorf("preload[%d]: %w", i, err)
+		}
+		if err := normalizeInferencePreloadIdentity(&model, i); err != nil {
+			return err
+		}
+		entry["kind"], entry["name"] = model.Kind, model.Name
+		// JSON null/empty strings decode as an unspecified CLI option. Emit
+		// that same absence for the runtime's stricter optional-field parser.
+		for key, value := range map[string]string{
+			"backend": model.Backend, "format": model.Format, "quantization": model.Quantization,
+		} {
+			if value == "" {
+				delete(entry, key)
+			} else {
+				entry[key] = value
+			}
+		}
+	}
+	config["preload"] = entries
+	return nil
+}
+
+// inferenceModelArgs translates the merged model settings to the released CLI
+// contract. New runtimes also read --config, retaining policies for matching
+// CLI preload identities; old runtimes still require these model flags.
+func inferenceModelArgs(configJSON string) (string, []string, error) {
+	var config struct {
+		ModelsDir       string                     `json:"models_dir"`
+		MLDir           *string                    `json:"ml_dir"`
+		MaxLoadedModels *int                       `json:"max_loaded_models"`
+		Preload         []inferencePreloadIdentity `json:"preload"`
+	}
+	if err := json.Unmarshal([]byte(configJSON), &config); err != nil {
+		return "", nil, fmt.Errorf("invalid inference model config: %w", err)
+	}
+	if !path.IsAbs(config.ModelsDir) || path.Clean(config.ModelsDir) != config.ModelsDir ||
+		config.ModelsDir == "/" || config.ModelsDir == "/config" || strings.HasPrefix(config.ModelsDir, "/config/") {
+		return "", nil, fmt.Errorf("models_dir must be a clean absolute path outside /config")
+	}
+	args := []string{"--models-dir", config.ModelsDir}
+	if config.MLDir != nil {
+		if !path.IsAbs(*config.MLDir) || path.Clean(*config.MLDir) != *config.MLDir ||
+			*config.MLDir == "/" || *config.MLDir == "/config" || strings.HasPrefix(*config.MLDir, "/config/") {
+			return "", nil, fmt.Errorf("ml_dir must be a clean absolute path outside /config")
+		}
+		args = append(args, "--ml-dir", *config.MLDir)
+	}
+	if config.MaxLoadedModels != nil {
+		if *config.MaxLoadedModels < 0 {
+			return "", nil, fmt.Errorf("max_loaded_models must not be negative")
+		}
+		args = append(args, "--max-loaded-models", strconv.Itoa(*config.MaxLoadedModels))
+	}
+	for i, model := range config.Preload {
+		if err := normalizeInferencePreloadIdentity(&model, i); err != nil {
+			return "", nil, err
+		}
+		value := model.Kind + ":"
+		if model.Backend != "" {
+			value += model.Backend + ":"
+		}
+		args = append(args, "--preload-model", value+model.Name)
+	}
+	return config.ModelsDir, args, nil
+}
+
+func normalizeInferencePreloadIdentity(model *inferencePreloadIdentity, i int) error {
+	if model.Kind == "" {
+		model.Kind = "generator"
+	}
+	switch model.Kind {
+	case "embedder", "extractor", "reranker", "classifier", "generator", "reader", "transcriber", "rewriter", "chunker":
+	default:
+		return fmt.Errorf("preload[%d]: unsupported kind %q", i, model.Kind)
+	}
+	switch model.Backend {
+	case "", "native", "onnx", "metal", "cuda", "xla", "pjrt", "wasm", "webgpu":
+	default:
+		return fmt.Errorf("preload[%d]: unsupported backend %q", i, model.Backend)
+	}
+	name := inferenceWarmModelName(model.Name)
+	if name == "" {
+		return fmt.Errorf("preload[%d]: name is required", i)
+	}
+	// Artifact choices must identify the same model in JSON and CLI output.
+	if model.Format != "" || model.Quantization != "" {
+		format, quantization, selected := inferenceArtifactSelection(name)
+		if selected {
+			if (model.Format != "" && model.Format != format) ||
+				(model.Quantization != "" && model.Quantization != quantization) {
+				return fmt.Errorf("preload[%d]: artifact selection conflicts with name", i)
+			}
+		} else {
+			if strings.Contains(name, ":") || model.Format == "" {
+				return fmt.Errorf("preload[%d]: artifact selection requires an unqualified name and format", i)
+			}
+			name += ":" + model.Format
+			if model.Quantization != "" {
+				name += ":" + model.Quantization
+			}
+		}
+	}
+	model.Name = name
+	return nil
 }
 
 func inferenceKeepAliveMillis(pool *antflyaiv1alpha1.InferencePool) (uint64, error) {
@@ -438,8 +622,9 @@ func zigWarmModelKind(tasks []string) string {
 			}
 		}
 	}
-	// Preserve the Zig CLI's historical default for untyped model refs.
-	return "generator"
+	// A missing hint does not establish that the model is a generator. The
+	// released warm CLI requires a kind, so eager callers must reject ambiguity.
+	return ""
 }
 
 func inferenceWarmModelName(modelRef string) string {
@@ -474,6 +659,18 @@ func inferenceArtifactSelection(modelRef string) (format, quantization string, o
 }
 
 func (r *InferencePoolReconciler) reconcileStatefulSet(ctx context.Context, pool *antflyaiv1alpha1.InferencePool) error {
+	// The standalone inference CLI reads admission settings from --config, but
+	// model discovery and warming are CLI-only in v0.2.1. Use the same merged
+	// configuration for the pullers, volume mounts, and server arguments.
+	configJSON, err := r.generateCompleteConfig(pool)
+	if err != nil {
+		return err
+	}
+	modelsDir, modelArgs, err := inferenceModelArgs(configJSON)
+	if err != nil {
+		return err
+	}
+
 	var activationLease *coordinationv1.Lease
 	if pool.Spec.ScaleToZero != nil && pool.Spec.ScaleToZero.Enabled {
 		activationLease = &coordinationv1.Lease{}
@@ -513,7 +710,7 @@ func (r *InferencePoolReconciler) reconcileStatefulSet(ctx context.Context, pool
 		})
 	}
 	for i, model := range preloadModels {
-		args := []string{"inference", "pull", model.Name, "--models-dir", "/models"}
+		args := []string{"inference", "pull", model.Name, "--models-dir", modelsDir}
 		if len(model.Tasks) > 0 {
 			args = append(args, "--tasks", strings.Join(model.Tasks, ","))
 		}
@@ -526,7 +723,7 @@ func (r *InferencePoolReconciler) reconcileStatefulSet(ctx context.Context, pool
 			Command: []string{"/antfly"},
 			Args:    args,
 			VolumeMounts: []corev1.VolumeMount{
-				{Name: "models", MountPath: "/models"},
+				{Name: "models", MountPath: modelsDir},
 			},
 			EnvFrom: []corev1.EnvFromSource{
 				{ConfigMapRef: &corev1.ConfigMapEnvSource{
@@ -543,9 +740,10 @@ func (r *InferencePoolReconciler) reconcileStatefulSet(ctx context.Context, pool
 		"--config", "/config/config.json",
 		"--allow-insecure-public-bind",
 	}
+	inferenceArgs = append(inferenceArgs, modelArgs...)
 
 	inferenceVolumeMounts := []corev1.VolumeMount{
-		{Name: "models", MountPath: "/models"},
+		{Name: "models", MountPath: modelsDir},
 		{Name: "config", MountPath: "/config", ReadOnly: true},
 	}
 	volumes := []corev1.Volume{
@@ -1693,7 +1891,15 @@ func (r *InferencePoolReconciler) addProbes(sts *appsv1.StatefulSet, pool *antfl
 // Note: immutability checks require the old object and are only enforced by the
 // admission webhook.
 func (r *InferencePoolReconciler) validatePool(pool *antflyaiv1alpha1.InferencePool) error {
-	return pool.ValidateInferencePool()
+	if err := pool.ValidateInferencePool(); err != nil {
+		return err
+	}
+	config, err := r.generateCompleteConfig(pool)
+	if err != nil {
+		return err
+	}
+	_, _, err = inferenceModelArgs(config)
+	return err
 }
 
 // applySchedulingConstraints applies user-specified scheduling constraints to the pod template.

--- a/go/pkg/operator/controllers/inference/inferencepool_controller_test.go
+++ b/go/pkg/operator/controllers/inference/inferencepool_controller_test.go
@@ -140,6 +140,8 @@ var _ = Describe("InferencePool Controller", func() {
 				"--port", "8080",
 				"--config", "/config/config.json",
 				"--allow-insecure-public-bind",
+				"--models-dir", "/models",
+				"--preload-model", "embedder:BAAI/bge-small-en-v1.5:i8",
 			}))
 			Expect(createdSts.Spec.Template.Spec.InitContainers).To(HaveLen(2))
 			Expect(createdSts.Spec.Template.Spec.InitContainers[0].Name).To(Equal("pjrt-plugin"))
@@ -191,7 +193,7 @@ var _ = Describe("InferencePool Controller", func() {
 					WorkloadType: antflyaiv1alpha1.WorkloadTypeGeneral,
 					Models: antflyaiv1alpha1.ModelConfig{
 						Preload: []antflyaiv1alpha1.ModelSpec{
-							{Name: "test-model"},
+							{Name: "test-model", Tasks: []string{"generate"}},
 						},
 						LoadingStrategy: antflyaiv1alpha1.LoadingStrategyEager,
 					},
@@ -248,7 +250,7 @@ var _ = Describe("InferencePool Controller", func() {
 				Spec: antflyaiv1alpha1.InferencePoolSpec{
 					WorkloadType: antflyaiv1alpha1.WorkloadTypeGeneral,
 					Models: antflyaiv1alpha1.ModelConfig{
-						Preload:         []antflyaiv1alpha1.ModelSpec{{Name: "test-model"}},
+						Preload:         []antflyaiv1alpha1.ModelSpec{{Name: "test-model", Tasks: []string{"generate"}}},
 						LoadingStrategy: antflyaiv1alpha1.LoadingStrategyEager,
 					},
 					Replicas: antflyaiv1alpha1.ReplicaConfig{
@@ -303,7 +305,7 @@ var _ = Describe("InferencePool Controller", func() {
 				Spec: antflyaiv1alpha1.InferencePoolSpec{
 					WorkloadType: antflyaiv1alpha1.WorkloadTypeGeneral,
 					Models: antflyaiv1alpha1.ModelConfig{
-						Preload:         []antflyaiv1alpha1.ModelSpec{{Name: "test-model"}},
+						Preload:         []antflyaiv1alpha1.ModelSpec{{Name: "test-model", Tasks: []string{"generate"}}},
 						LoadingStrategy: antflyaiv1alpha1.LoadingStrategyEager,
 					},
 					Replicas: antflyaiv1alpha1.ReplicaConfig{
@@ -361,7 +363,7 @@ var _ = Describe("InferencePool Controller", func() {
 					Models: antflyaiv1alpha1.ModelConfig{
 						Preload: []antflyaiv1alpha1.ModelSpec{
 							{
-								Name: "bge-small-en-v1.5:quantized",
+								Name: "bge-small-en-v1.5:quantized", Tasks: []string{"embed"},
 							},
 						},
 						LoadingStrategy: antflyaiv1alpha1.LoadingStrategyEager,
@@ -405,7 +407,7 @@ var _ = Describe("InferencePool Controller", func() {
 					Image:        "my-registry/antfly:zig-v1.0.0",
 					Models: antflyaiv1alpha1.ModelConfig{
 						Preload: []antflyaiv1alpha1.ModelSpec{
-							{Name: "test-model"},
+							{Name: "test-model", Tasks: []string{"generate"}},
 						},
 						LoadingStrategy: antflyaiv1alpha1.LoadingStrategyEager,
 					},
@@ -447,8 +449,8 @@ var _ = Describe("InferencePool Controller", func() {
 					WorkloadType: antflyaiv1alpha1.WorkloadTypeGeneral,
 					Models: antflyaiv1alpha1.ModelConfig{
 						Preload: []antflyaiv1alpha1.ModelSpec{
-							{Name: "model-a:i8"},
-							{Name: "model-b"},
+							{Name: "model-a:i8", Tasks: []string{"generate"}},
+							{Name: "model-b", Tasks: []string{"generate"}},
 							{Name: "model-c:i8", Strategy: antflyaiv1alpha1.LoadingStrategyLazy},
 						},
 						LoadingStrategy: antflyaiv1alpha1.LoadingStrategyEager,
@@ -472,11 +474,11 @@ var _ = Describe("InferencePool Controller", func() {
 			Expect(createdSts.Spec.Template.Spec.InitContainers).To(HaveLen(3))
 			Expect(createdSts.Spec.Template.Spec.InitContainers[0].Command).To(Equal([]string{"/antfly"}))
 			Expect(createdSts.Spec.Template.Spec.InitContainers[0].Args).To(Equal([]string{
-				"inference", "pull", "model-a:i8", "--models-dir", "/models",
+				"inference", "pull", "model-a:i8", "--models-dir", "/models", "--tasks", "generate",
 			}))
 			Expect(createdSts.Spec.Template.Spec.InitContainers[1].Command).To(Equal([]string{"/antfly"}))
 			Expect(createdSts.Spec.Template.Spec.InitContainers[1].Args).To(Equal([]string{
-				"inference", "pull", "model-b", "--models-dir", "/models",
+				"inference", "pull", "model-b", "--models-dir", "/models", "--tasks", "generate",
 			}))
 			Expect(createdSts.Spec.Template.Spec.InitContainers[2].Command).To(Equal([]string{"/antfly"}))
 			Expect(createdSts.Spec.Template.Spec.InitContainers[2].Args).To(Equal([]string{
@@ -488,6 +490,9 @@ var _ = Describe("InferencePool Controller", func() {
 				"--port", "8080",
 				"--config", "/config/config.json",
 				"--allow-insecure-public-bind",
+				"--models-dir", "/models",
+				"--preload-model", "generator:model-a:i8",
+				"--preload-model", "generator:model-b",
 			}))
 
 			Expect(k8sClient.Delete(ctx, pool)).Should(Succeed())

--- a/go/pkg/operator/controllers/inference/inferencepool_hpa_test.go
+++ b/go/pkg/operator/controllers/inference/inferencepool_hpa_test.go
@@ -167,7 +167,7 @@ func TestReconcileStatefulSetFollowsScaleToZeroActivation(t *testing.T) {
 			UID:       types.UID("cold-pool"),
 		},
 		Spec: antflyaiv1alpha1.InferencePoolSpec{
-			Models:      antflyaiv1alpha1.ModelConfig{Preload: []antflyaiv1alpha1.ModelSpec{{Name: "test-model"}}},
+			Models:      antflyaiv1alpha1.ModelConfig{Preload: []antflyaiv1alpha1.ModelSpec{{Name: "test-model", Tasks: []string{"generate"}}}},
 			Replicas:    antflyaiv1alpha1.ReplicaConfig{Min: 0, Max: 1},
 			ScaleToZero: &antflyaiv1alpha1.ScaleToZeroConfig{Enabled: true, IdleTimeout: &idle},
 		},
@@ -225,7 +225,7 @@ func baseAutoscaledInferencePool() *antflyaiv1alpha1.InferencePool {
 		Spec: antflyaiv1alpha1.InferencePoolSpec{
 			WorkloadType: antflyaiv1alpha1.WorkloadTypeGeneral,
 			Models: antflyaiv1alpha1.ModelConfig{
-				Preload:         []antflyaiv1alpha1.ModelSpec{{Name: "test-model"}},
+				Preload:         []antflyaiv1alpha1.ModelSpec{{Name: "test-model", Tasks: []string{"generate"}}},
 				LoadingStrategy: antflyaiv1alpha1.LoadingStrategyEager,
 			},
 			Replicas: antflyaiv1alpha1.ReplicaConfig{

--- a/go/pkg/operator/controllers/inference/inferencepool_labels_test.go
+++ b/go/pkg/operator/controllers/inference/inferencepool_labels_test.go
@@ -74,7 +74,7 @@ func TestInferencePoolPodTemplateLabelsUpdateWhenPoolLabelsChange(t *testing.T) 
 		Spec: antflyaiv1alpha1.InferencePoolSpec{
 			WorkloadType: antflyaiv1alpha1.WorkloadTypeGeneral,
 			Models: antflyaiv1alpha1.ModelConfig{
-				Preload:         []antflyaiv1alpha1.ModelSpec{{Name: "test-model"}},
+				Preload:         []antflyaiv1alpha1.ModelSpec{{Name: "test-model", Tasks: []string{"generate"}}},
 				LoadingStrategy: antflyaiv1alpha1.LoadingStrategyEager,
 			},
 			Replicas: antflyaiv1alpha1.ReplicaConfig{

--- a/go/pkg/operator/controllers/inference/inferencepool_runtime_test.go
+++ b/go/pkg/operator/controllers/inference/inferencepool_runtime_test.go
@@ -1,0 +1,277 @@
+//go:build runtimeintegration && (linux || darwin)
+
+package controllers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	api "github.com/antflydb/antfly/go/pkg/operator/api/inference/v1alpha1"
+)
+
+// This deliberately executes the reconciler's output, not a separately written
+// inference command. Only filesystem mounts and the listen address are mapped
+// to an isolated local sandbox. No model flags may be added by this harness.
+func TestInferenceRuntimeContract(t *testing.T) {
+	binary := os.Getenv("ANTFLY_RUNTIME_BIN")
+	if !filepath.IsAbs(binary) {
+		t.Fatal("runtimeintegration requires ANTFLY_RUNTIME_BIN pointing to a real released or newly built runtime")
+	}
+	root := t.TempDir()
+	modelDir := filepath.Join(root, "models")
+	const model = "BAAI/bge-small-en-v1.5"
+	const generator = "shibatch/tiny1m"
+	const generatorRef = generator + ":gguf:Q4_K_M"
+	downloaded := map[string]bool{}
+	for _, scenario := range []string{"lazy", "eager", "eager-explicit-kind", "empty-identity-options", "null-identity-options", "nested-empty", "nested-other-settings", "nested-tagged", "nested-tagged-with-api-url", "omitted-kind", "nested-omitted-kind", "missing-directory-negative-control"} {
+		t.Run(scenario, func(t *testing.T) {
+			g := NewWithT(t)
+			ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
+			defer cancel()
+			scheme := newInferenceUnitTestScheme(g)
+			pool := &api.InferencePool{
+				ObjectMeta: metav1.ObjectMeta{Name: "runtime-smoke", Namespace: "default", UID: "smoke"},
+				Spec: api.InferencePoolSpec{
+					Hardware: api.HardwareConfig{InferenceBackend: api.InferenceRuntimeBackendCPU},
+					Models:   api.ModelConfig{LoadingStrategy: api.LoadingStrategyLazy, Preload: []api.ModelSpec{{Name: model, Tasks: []string{"embed"}, Capabilities: []string{"text"}}}},
+				},
+			}
+			if scenario == "eager" {
+				pool.Spec.Models.LoadingStrategy = api.LoadingStrategyEager
+			}
+			if scenario == "lazy" || scenario == "eager-explicit-kind" {
+				// Let the puller discover the model task from its metadata. Eager
+				// warming needs an explicit kind when task hints are absent.
+				pool.Spec.Models.Preload[0].Tasks = nil
+				if scenario == "eager-explicit-kind" {
+					pool.Spec.Models.LoadingStrategy = api.LoadingStrategyEager
+					pool.Spec.Config = fmt.Sprintf(`{"preload":[{"kind":"embedder","name":%q}]}`, model)
+				}
+			}
+			if strings.HasSuffix(scenario, "-identity-options") {
+				empty := `""`
+				if scenario == "null-identity-options" {
+					empty = `null`
+				}
+				pool.Spec.Config = fmt.Sprintf(`{"inference":{"preload":[{"kind":"embedder","name":%q,"backend":%s,"format":%s,"quantization":%s}]}}`, model, empty, empty, empty)
+			}
+			warmGenerator := strings.Contains(scenario, "tagged") || strings.Contains(scenario, "omitted-kind")
+			if strings.HasPrefix(scenario, "nested-") || warmGenerator {
+				// Nested overrides must win over flat settings, but the emitted
+				// JSON must remain parseable by v0.2.1's shared config schema.
+				settings := map[string]any{"models_dir": "/nested-models", "max_loaded_models": 0, "preload": []any{}}
+				if scenario == "nested-other-settings" {
+					settings["keep_alive_ms"] = 42
+					settings["ml_dir"] = "/traditional-models"
+				}
+				if warmGenerator {
+					entry := map[string]any{
+						"name": "hf:" + generator, "format": "gguf", "quantization": "Q4_K_M",
+						// Non-default residency budgets are GPU/A4B-only in the
+						// runtime; explicit wire defaults remain CPU-compatible.
+						"residency_mode": "auto", "memory_budget_mb": 0,
+					}
+					if !strings.Contains(scenario, "omitted-kind") {
+						entry["kind"] = "generator"
+					}
+					settings["preload"] = []any{entry}
+					pool.Spec.Models.Preload = append(pool.Spec.Models.Preload, api.ModelSpec{Name: "hf:" + generatorRef, Tasks: []string{"generate"}})
+				}
+				if scenario == "nested-tagged-with-api-url" {
+					settings["api_url"] = ""
+				}
+				config := map[string]any{"admission": map[string]any{"inference": map[string]any{"max_concurrent_requests": 3}}}
+				if strings.HasPrefix(scenario, "nested-") {
+					config["models_dir"], config["inference"] = "/wrong-flat-models", settings
+				} else {
+					for key, value := range settings {
+						config[key] = value
+					}
+				}
+				raw, err := json.Marshal(config)
+				g.Expect(err).NotTo(HaveOccurred())
+				pool.Spec.Config = string(raw)
+			}
+			client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pool).Build()
+			r := &InferencePoolReconciler{Client: client, Scheme: scheme}
+			g.Expect(r.reconcileConfigMap(ctx, pool)).To(Succeed())
+			g.Expect(r.reconcileStatefulSet(ctx, pool)).To(Succeed())
+			cm := &corev1.ConfigMap{}
+			g.Expect(client.Get(ctx, types.NamespacedName{Name: pool.Name + "-config", Namespace: pool.Namespace}, cm)).To(Succeed())
+			sts := &appsv1.StatefulSet{}
+			g.Expect(client.Get(ctx, types.NamespacedName{Name: pool.Name, Namespace: pool.Namespace}, sts)).To(Succeed())
+
+			work := t.TempDir()
+			g.Expect(os.MkdirAll(modelDir, 0755)).To(Succeed())
+			configPath := filepath.Join(work, "config.json")
+			var config map[string]any
+			g.Expect(json.Unmarshal([]byte(cm.Data["config.json"]), &config)).To(Succeed())
+			var mountPath string
+			// Resolve the model mount by name; container mount ordering is not a contract.
+			for _, mount := range sts.Spec.Template.Spec.Containers[0].VolumeMounts {
+				if mount.Name == "models" {
+					mountPath = mount.MountPath
+				}
+			}
+			g.Expect(mountPath).NotTo(BeEmpty())
+			g.Expect(config["models_dir"]).To(Equal(mountPath))
+			config["models_dir"] = modelDir
+			if scenario == "nested-other-settings" {
+				g.Expect(config["ml_dir"]).To(Equal("/traditional-models"))
+				config["ml_dir"] = filepath.Join(work, "ml")
+			}
+			if scenario == "missing-directory-negative-control" {
+				// New runtimes also read this path from config. Remove both
+				// sources so the control remains valid across runtime releases.
+				delete(config, "models_dir")
+			}
+			configJSON, err := json.Marshal(config)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(os.WriteFile(configPath, configJSON, 0600)).To(Succeed())
+			env := []string{"PATH=" + os.Getenv("PATH"), "HOME=" + work, "TMPDIR=" + work, "XDG_CACHE_HOME=" + work}
+			for key, value := range cm.Data {
+				if key != "config.json" {
+					env = append(env, key+"="+value)
+				}
+			}
+			// Keep host credentials and cached models out of the child process.
+			mapArgs := func(args []string) []string {
+				mapped := append([]string(nil), args...)
+				for i, arg := range mapped {
+					switch arg {
+					case mountPath:
+						mapped[i] = modelDir
+					case "/config/config.json":
+						mapped[i] = configPath
+					case "/traditional-models":
+						mapped[i] = filepath.Join(work, "ml")
+					}
+				}
+				return mapped
+			}
+			for _, init := range sts.Spec.Template.Spec.InitContainers {
+				if !downloaded[init.Args[2]] {
+					cmd := exec.CommandContext(ctx, binary, mapArgs(init.Args)...)
+					cmd.Env = env
+					out, err := cmd.CombinedOutput()
+					if err != nil {
+						t.Fatalf("operator model pull failed: %v\n%s", err, out)
+					}
+					downloaded[init.Args[2]] = true
+				}
+			}
+			listener, err := net.Listen("tcp", "127.0.0.1:0")
+			g.Expect(err).NotTo(HaveOccurred())
+			port := fmt.Sprint(listener.Addr().(*net.TCPAddr).Port)
+			g.Expect(listener.Close()).To(Succeed())
+			args := mapArgs(sts.Spec.Template.Spec.Containers[0].Args)
+			for i := 0; i < len(args)-1; i++ {
+				switch args[i] {
+				case "--host":
+					args[i+1] = "127.0.0.1"
+				case "--port":
+					args[i+1] = port
+				}
+			}
+			if scenario == "missing-directory-negative-control" {
+				for i := 0; i < len(args)-1; i++ {
+					if args[i] == "--models-dir" {
+						args = append(args[:i], args[i+2:]...)
+						break
+					}
+				}
+			}
+			logPath := filepath.Join(work, "runtime.log")
+			log, err := os.Create(logPath)
+			g.Expect(err).NotTo(HaveOccurred())
+			cmd := exec.CommandContext(ctx, binary, args...)
+			// Kill the isolated process group, including any runtime worker, on
+			// timeout or cleanup. Never leave an inference process behind in CI.
+			cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+			cmd.Cancel = func() error { return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL) }
+			cmd.Env, cmd.Stdout, cmd.Stderr = env, log, log
+			g.Expect(cmd.Start()).To(Succeed())
+			defer func() {
+				cancel()
+				_ = cmd.Wait()
+				_ = log.Close()
+				if t.Failed() {
+					out, _ := os.ReadFile(logPath)
+					t.Logf("runtime output:\n%s", out)
+				}
+			}()
+			healthClient := &http.Client{Timeout: 2 * time.Second}
+			// Lazy loading does its cold model initialization inside the first
+			// request. Give it the same budget as eager readiness, not a health
+			// probe's deadline: released native CPU builds can take >20s in CI.
+			inferenceClient := &http.Client{Timeout: 90 * time.Second}
+			url := "http://127.0.0.1:" + port
+			status := func(path string) int {
+				resp, err := healthClient.Get(url + path)
+				if err != nil {
+					return 0
+				}
+				defer resp.Body.Close()
+				return resp.StatusCode
+			}
+			g.Eventually(func() int { return status("/healthz") }, 90*time.Second, 250*time.Millisecond).Should(Equal(200))
+			if scenario == "missing-directory-negative-control" {
+				g.Consistently(func() int { return status("/readyz") }, 3*time.Second, 250*time.Millisecond).Should(Equal(503))
+				return
+			}
+			g.Eventually(func() int { return status("/readyz") }, 90*time.Second, 250*time.Millisecond).Should(Equal(200))
+			if scenario == "eager" || scenario == "eager-explicit-kind" || strings.HasSuffix(scenario, "-identity-options") {
+				out, err := os.ReadFile(logPath)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(string(out)).To(ContainSubstring("warmed inference embedder model=" + model))
+			}
+			if warmGenerator {
+				out, err := os.ReadFile(logPath)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(string(out)).To(ContainSubstring("warmed inference generator model=" + generatorRef))
+			}
+			body := bytes.NewBufferString(`{"model":"` + model + `","input":"operator runtime contract smoke test"}`)
+			resp, err := inferenceClient.Post(url+"/ai/v1/embed", "application/json", body)
+			g.Expect(err).NotTo(HaveOccurred())
+			defer resp.Body.Close()
+			data, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(resp.StatusCode).To(Equal(200), string(data))
+			var result struct {
+				Data []struct {
+					Embedding []float64 `json:"embedding"`
+				} `json:"data"`
+			}
+			g.Expect(json.Unmarshal(data, &result)).To(Succeed())
+			g.Expect(result.Data).To(HaveLen(1))
+			g.Expect(result.Data[0].Embedding).To(HaveLen(384))
+			var norm float64
+			for _, value := range result.Data[0].Embedding {
+				g.Expect(math.IsNaN(value) || math.IsInf(value, 0)).To(BeFalse())
+				norm += value * value
+			}
+			g.Expect(norm).To(BeNumerically(">", 0))
+			g.Expect(strings.Join(env, "\n")).To(ContainSubstring("ANTFLY_INFERENCE_REQUIRED_BACKEND=native"))
+		})
+	}
+}

--- a/go/pkg/operator/controllers/inference/inferenceproxy_controller_test.go
+++ b/go/pkg/operator/controllers/inference/inferenceproxy_controller_test.go
@@ -44,7 +44,7 @@ var _ = Describe("InferenceProxy Controller", func() {
 					WorkloadType: antflyaiv1alpha1.WorkloadTypeGeneral,
 					Models: antflyaiv1alpha1.ModelConfig{
 						Preload: []antflyaiv1alpha1.ModelSpec{
-							{Name: "bge-small-en-v1.5"},
+							{Name: "bge-small-en-v1.5", Tasks: []string{"embed"}},
 						},
 						LoadingStrategy: antflyaiv1alpha1.LoadingStrategyEager,
 					},
@@ -151,7 +151,7 @@ var _ = Describe("InferenceProxy Controller", func() {
 				Spec: antflyaiv1alpha1.InferencePoolSpec{
 					WorkloadType: antflyaiv1alpha1.WorkloadTypeGeneral,
 					Models: antflyaiv1alpha1.ModelConfig{
-						Preload:         []antflyaiv1alpha1.ModelSpec{{Name: "model-1"}},
+						Preload:         []antflyaiv1alpha1.ModelSpec{{Name: "model-1", Tasks: []string{"generate"}}},
 						LoadingStrategy: antflyaiv1alpha1.LoadingStrategyEager,
 					},
 					Replicas: antflyaiv1alpha1.ReplicaConfig{Min: 1, Max: 3},
@@ -168,7 +168,7 @@ var _ = Describe("InferenceProxy Controller", func() {
 				Spec: antflyaiv1alpha1.InferencePoolSpec{
 					WorkloadType: antflyaiv1alpha1.WorkloadTypeBurst,
 					Models: antflyaiv1alpha1.ModelConfig{
-						Preload:         []antflyaiv1alpha1.ModelSpec{{Name: "model-1"}},
+						Preload:         []antflyaiv1alpha1.ModelSpec{{Name: "model-1", Tasks: []string{"generate"}}},
 						LoadingStrategy: antflyaiv1alpha1.LoadingStrategyEager,
 					},
 					Replicas: antflyaiv1alpha1.ReplicaConfig{Min: 1, Max: 10},
@@ -235,7 +235,7 @@ var _ = Describe("InferenceProxy Controller", func() {
 				Spec: antflyaiv1alpha1.InferencePoolSpec{
 					WorkloadType: antflyaiv1alpha1.WorkloadTypeGeneral,
 					Models: antflyaiv1alpha1.ModelConfig{
-						Preload:         []antflyaiv1alpha1.ModelSpec{{Name: "bge-small-en-v1.5"}},
+						Preload:         []antflyaiv1alpha1.ModelSpec{{Name: "bge-small-en-v1.5", Tasks: []string{"embed"}}},
 						LoadingStrategy: antflyaiv1alpha1.LoadingStrategyEager,
 					},
 					Replicas: antflyaiv1alpha1.ReplicaConfig{Min: 1, Max: 3},
@@ -298,7 +298,7 @@ var _ = Describe("InferenceProxy Controller", func() {
 				Spec: antflyaiv1alpha1.InferencePoolSpec{
 					WorkloadType: antflyaiv1alpha1.WorkloadTypeGeneral,
 					Models: antflyaiv1alpha1.ModelConfig{
-						Preload:         []antflyaiv1alpha1.ModelSpec{{Name: "model-1"}},
+						Preload:         []antflyaiv1alpha1.ModelSpec{{Name: "model-1", Tasks: []string{"generate"}}},
 						LoadingStrategy: antflyaiv1alpha1.LoadingStrategyEager,
 					},
 					Replicas: antflyaiv1alpha1.ReplicaConfig{Min: 1, Max: 3},
@@ -315,7 +315,7 @@ var _ = Describe("InferenceProxy Controller", func() {
 				Spec: antflyaiv1alpha1.InferencePoolSpec{
 					WorkloadType: antflyaiv1alpha1.WorkloadTypeBurst,
 					Models: antflyaiv1alpha1.ModelConfig{
-						Preload:         []antflyaiv1alpha1.ModelSpec{{Name: "model-1"}},
+						Preload:         []antflyaiv1alpha1.ModelSpec{{Name: "model-1", Tasks: []string{"generate"}}},
 						LoadingStrategy: antflyaiv1alpha1.LoadingStrategyEager,
 					},
 					Replicas: antflyaiv1alpha1.ReplicaConfig{Min: 0, Max: 10},

--- a/go/pkg/operator/docs/DEVELOPMENT.md
+++ b/go/pkg/operator/docs/DEVELOPMENT.md
@@ -37,6 +37,54 @@ make run
 
 ## 🔄 Development Workflow
 
+### Inference runtime contract smoke test
+
+Operator CI runs the generated model-puller and inference-server arguments
+against the checksum-pinned Antfly v0.2.1 Linux GNU release, using the native CPU
+backend, a small public BGE embedding model, and a tiny GGUF generator
+(`shibatch/tiny1m:gguf:Q4_K_M`). It requires eager and lazy
+readiness plus a finite, nonzero 384-dimensional embedding, verifies eager
+warming before the first request, and checks that removing the model-directory
+flag and config field reproduces an unready server. It needs neither Kubernetes
+nor GPUs.
+
+The same reconciler-generated contract runs against the PR's candidate binary
+in `zig-tests.yml`. Both binaries exercise nested overrides (including empty
+preloads and zero model limits), tagged GGUF preloads with and without a nested
+`api_url`, and omitted `kind`/backend defaults. Generator warming is asserted
+before serving an embedding request. Missing downloads/binaries fail the test.
+The CPU fixture uses policy-neutral `residency_mode: auto` and
+`memory_budget_mb: 0`; non-default GPU/A4B policies retain focused config tests
+and require separate GPU execution validation.
+The contract also checks omitted task hints with lazy discovery and an explicit
+eager preload kind, plus empty/null optional identity fields. Unit tests verify
+that ambiguous eager task hints report a validation failure before workload
+creation, including on an operator upgrade with an unchanged pool generation,
+and that correcting the hint allows reconciliation to recover.
+
+To run locally on Linux or macOS, supply an absolute path to a verified released
+or newly built Antfly binary:
+
+```bash
+ANTFLY_RUNTIME_BIN=/absolute/path/to/antfly GOWORK=off go test \
+  -tags runtimeintegration ./controllers/inference \
+  -run '^TestInferenceRuntimeContract$' -count=1 -v -timeout=20m
+```
+
+This explicit integration target fails if its binary is absent or its model
+cannot be downloaded; ordinary offline unit tests do not run it. Downloads and
+runtime state use isolated temporary directories, and server process groups are
+terminated on completion or timeout. When advancing the supported runtime,
+update both the release version and SHA256 in `antfly-operator-go.yml` and run
+this same target against the candidate binary. This test does not exercise
+container packaging, real Kubernetes scheduling, or GPU execution; retain those
+rollout checks separately.
+
+Runtime PR CI also runs `zig/e2e/inference/test_run_config.py` against the newly
+built binary: config-only flat/nested startup, eager warming and embeddings,
+and CLI precedence in either argument order. This covers the config handoff
+independently of the operator's compatibility flags.
+
 ### Quick Development Cycle
 
 ```bash

--- a/zig/build.zig
+++ b/zig/build.zig
@@ -3636,6 +3636,7 @@ pub fn build(b: *std.Build) void {
         .filters = &.{
             "preload model spec parser categorizes registry variants and backends",
             "inference runtime preload parser preserves registry variants and explicit backends",
+            "inference run config",
             "inference list accepts models directory before or after flags",
         },
         .test_runner = .{

--- a/zig/e2e/inference/test_run_config.py
+++ b/zig/e2e/inference/test_run_config.py
@@ -1,0 +1,122 @@
+"""Execute config-only inference and CLI precedence against the candidate binary."""
+
+import json
+import math
+import os
+import signal
+import socket
+import subprocess
+import time
+
+import pytest
+import requests
+
+from .models import ensure_model_by_name, inference_command, models_dir
+
+pytestmark = pytest.mark.model_integration
+MODEL = "BAAI/bge-small-en-v1.5"
+
+
+@pytest.fixture(scope="module")
+def run_config_models():
+    assert ensure_model_by_name(MODEL, "embedders") is not None
+    return models_dir().resolve()
+
+
+@pytest.mark.parametrize("layout", ["flat", "nested", "cli-before", "cli-after"])
+def test_run_config_model_settings(tmp_path, run_config_models, layout):
+    settings = {
+        "models_dir": str(run_config_models),
+        "ml_dir": str(tmp_path / "ml"),
+        "max_loaded_models": 0,
+        "preload": [{"kind": "embedder", "name": MODEL, "backend": "native"}],
+    }
+    model_flags = []
+    if layout.startswith("cli-"):
+        # A bad config model/path must not be loaded in addition to CLI models.
+        settings["models_dir"] = str(tmp_path / "wrong-models")
+        settings["preload"] = [{"kind": "embedder", "name": "missing/config-model"}]
+        settings["max_loaded_models"] = 1
+        model_flags = [
+            "--models-dir",
+            str(run_config_models),
+            "--max-loaded-models",
+            "0",
+            "--preload-model",
+            f"embedder:native:{MODEL}",
+        ]
+    config = {"inference": settings} if layout != "flat" else settings
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps(config))
+    with socket.socket() as listener:
+        listener.bind(("127.0.0.1", 0))
+        port = listener.getsockname()[1]
+    config_flags = ["--config", str(config_path)]
+    command = [*inference_command(), "run", "--host", "127.0.0.1", "--port", str(port)]
+    command += (
+        model_flags + config_flags
+        if layout == "cli-before"
+        else config_flags + model_flags
+    )
+    # Do not inherit credentials or model-path defaults that could hide a
+    # missing config handoff. Retain only executable/library lookup settings.
+    env = {
+        key: os.environ[key]
+        for key in ("PATH", "LD_LIBRARY_PATH", "DYLD_LIBRARY_PATH")
+        if key in os.environ
+    }
+    env.update(
+        {
+            "HOME": str(tmp_path),
+            "XDG_CACHE_HOME": str(tmp_path),
+            "ANTFLY_INFERENCE_PREFERRED_BACKEND": "native",
+            "ANTFLY_INFERENCE_REQUIRED_BACKEND": "native",
+        }
+    )
+    log_path = tmp_path / "runtime.log"
+    with log_path.open("w") as output:
+        process = subprocess.Popen(
+            command,
+            env=env,
+            stdout=output,
+            stderr=subprocess.STDOUT,
+            start_new_session=True,
+        )
+        try:
+            base = f"http://127.0.0.1:{port}"
+            deadline = time.monotonic() + 90
+            while time.monotonic() < deadline:
+                assert process.poll() is None, log_path.read_text()
+                try:
+                    response = requests.get(base + "/readyz", timeout=1)
+                    ready = response.status_code == 200
+                    response.close()
+                    if ready:
+                        break
+                except requests.RequestException:
+                    pass
+                time.sleep(0.1)
+            else:
+                pytest.fail(
+                    "config-only inference never became ready:\n" + log_path.read_text()
+                )
+            # Check warming before the first inference request can load a model.
+            assert f"warmed inference embedder model={MODEL}" in log_path.read_text()
+            with requests.post(
+                base + "/ai/v1/embed",
+                json={"model": MODEL, "input": "runtime config contract"},
+                timeout=30,
+            ) as response:
+                assert response.status_code == 200, (
+                    response.text + "\n" + log_path.read_text()
+                )
+                embedding = response.json()["data"][0]["embedding"]
+                assert len(embedding) == 384
+                assert all(math.isfinite(value) for value in embedding)
+                assert sum(value * value for value in embedding) > 0
+        finally:
+            try:
+                os.killpg(process.pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+            process.wait(timeout=10)

--- a/zig/pkg/antfly/src/common/config.zig
+++ b/zig/pkg/antfly/src/common/config.zig
@@ -2069,7 +2069,8 @@ fn promptCacheFromOpenApi(
         .ttl_ms = ttl_ms,
     };
 }
-fn parseInferencePreloadModels(
+// Shared by unified configuration and the standalone inference CLI loader.
+pub fn parseInferencePreloadModels(
     alloc: std.mem.Allocator,
     raw_inference: ?std.json.Value,
 ) ![]Config.InferenceConfig.WarmModelConfig {
@@ -2093,20 +2094,21 @@ fn parseInferencePreloadModels(
             .object => |entry| entry,
             else => return error.InvalidConfig,
         };
-        out[i] = .{
-            .kind = try requiredStringFieldDup(alloc, model_object, "kind"),
-            .name = try requiredStringFieldDup(alloc, model_object, "name"),
-            .backend = try optionalStringFieldDup(alloc, model_object, "backend"),
-            .format = try optionalStringFieldDup(alloc, model_object, "format"),
-            .quantization = try optionalStringFieldDup(alloc, model_object, "quantization"),
-            .residency_mode = try optionalEnumField(
-                Config.InferenceConfig.WarmModelConfig.ResidencyMode,
-                model_object,
-                "residency_mode",
-            ),
-            .memory_budget_mb = try optionalU32Field(model_object, "memory_budget_mb"),
-        };
+        // Include the partially parsed entry in error cleanup as soon as any
+        // owned fields can be allocated (e.g. a missing name after kind).
+        out[i] = .{ .kind = &.{}, .name = &.{} };
         filled = i + 1;
+        out[i].kind = try requiredStringFieldDup(alloc, model_object, "kind");
+        out[i].name = try requiredStringFieldDup(alloc, model_object, "name");
+        out[i].backend = try optionalStringFieldDup(alloc, model_object, "backend");
+        out[i].format = try optionalStringFieldDup(alloc, model_object, "format");
+        out[i].quantization = try optionalStringFieldDup(alloc, model_object, "quantization");
+        out[i].residency_mode = try optionalEnumField(
+            Config.InferenceConfig.WarmModelConfig.ResidencyMode,
+            model_object,
+            "residency_mode",
+        );
+        out[i].memory_budget_mb = try optionalU32Field(model_object, "memory_budget_mb");
     }
     return out;
 }

--- a/zig/pkg/antfly/src/inference_runtime/runtime.zig
+++ b/zig/pkg/antfly/src/inference_runtime/runtime.zig
@@ -291,6 +291,166 @@ fn resolveRunMaxConcurrentRequests(cli: ?u32, cfg: ?*const common_config.Config)
         common_config.default_inference_max_concurrent_requests);
 }
 
+// Standalone inference historically receives flat model settings from the
+// operator. Normalize those into the canonical inference object before using
+// the shared parser; explicit nested settings take precedence field by field.
+fn parseRunConfig(alloc: std.mem.Allocator, raw: []const u8) !common_config.Config {
+    var arena = std.heap.ArenaAllocator.init(alloc);
+    defer arena.deinit();
+    const scratch = arena.allocator();
+    var parsed = try std.json.parseFromSlice(std.json.Value, scratch, raw, .{});
+    defer parsed.deinit();
+    if (parsed.value != .object) return error.InvalidConfig;
+    var root = &parsed.value.object;
+    var model_config = if (root.get("inference")) |value| switch (value) {
+        .object => value.object,
+        else => return error.InvalidConfig,
+    } else std.json.ObjectMap{};
+    for ([_][]const u8{ "models_dir", "ml_dir", "max_loaded_models", "preload" }) |key| {
+        if (!model_config.contains(key)) {
+            if (root.get(key)) |value| try model_config.put(scratch, key, value);
+        }
+    }
+    // The shared schema requires a client API URL, which is not needed when
+    // starting this local server. Model artifact tags also have a wider CLI
+    // vocabulary than the shared schema enum (e.g. Q4_K_M). Reuse the raw
+    // preload parser so those tags retain their exact spelling.
+    const preload_value = model_config.fetchSwapRemove("preload");
+    if (root.contains("inference") or model_config.count() > 0 or preload_value != null) {
+        if (!model_config.contains("api_url")) try model_config.put(scratch, "api_url", .{ .string = "" });
+        try root.put(scratch, "inference", .{ .object = model_config });
+    }
+    const normalized = try std.json.Stringify.valueAlloc(scratch, parsed.value, .{});
+    var config = try common_config.Config.parseFromSlice(alloc, normalized);
+    errdefer config.deinit();
+    if (preload_value) |entry| {
+        var preload_object = std.json.ObjectMap{};
+        try preload_object.put(scratch, "preload", entry.value);
+        config.inference.preload = try common_config.parseInferencePreloadModels(alloc, .{ .object = preload_object });
+    }
+    for (config.inference.preload) |*model| try normalizeRunPreloadName(alloc, model);
+    return config;
+}
+
+fn stripHuggingFacePrefix(name: []const u8) []const u8 {
+    return if (std.mem.startsWith(u8, name, "hf:")) name[3..] else name;
+}
+
+// Warming resolves by name, so config artifact preferences must be part of the
+// same reference used by the CLI and registry. Config retains ownership.
+fn normalizeRunPreloadName(alloc: std.mem.Allocator, model: *common_config.Config.InferenceConfig.WarmModelConfig) !void {
+    const name = stripHuggingFacePrefix(model.name);
+    if (model.format != null or model.quantization != null) {
+        if (std.mem.indexOfScalar(u8, name, ':')) |separator| {
+            var selection = std.mem.splitScalar(u8, name[separator + 1 ..], ':');
+            const format = selection.next().?;
+            const quantization = selection.next();
+            if (selection.next() != null) return error.InvalidConfig;
+            if (!validRunArtifactFormat(format)) return error.InvalidConfig;
+            if (model.format) |expected| {
+                if (!std.mem.eql(u8, format, expected)) return error.InvalidConfig;
+            }
+            if (model.quantization) |expected| {
+                if (expected.len == 0 or !std.mem.eql(u8, quantization orelse "", expected)) return error.InvalidConfig;
+            }
+        } else {
+            const format = model.format orelse return error.InvalidConfig;
+            if (!validRunArtifactFormat(format) or name.len == 0) return error.InvalidConfig;
+            const qualified = if (model.quantization) |quantization| blk: {
+                if (quantization.len == 0 or std.mem.indexOfScalar(u8, quantization, ':') != null) return error.InvalidConfig;
+                break :blk try std.fmt.allocPrint(alloc, "{s}:{s}:{s}", .{ name, format, quantization });
+            } else try std.fmt.allocPrint(alloc, "{s}:{s}", .{ name, format });
+            alloc.free(model.name);
+            model.name = qualified;
+            return;
+        }
+    }
+    if (name.len != model.name.len) {
+        const normalized = try alloc.dupe(u8, name);
+        alloc.free(model.name);
+        model.name = normalized;
+    }
+}
+
+fn validRunArtifactFormat(format: []const u8) bool {
+    inline for (.{ "gguf", "onnx", "safetensors", "hybrid" }) |supported| {
+        if (std.mem.eql(u8, format, supported)) return true;
+    }
+    return false;
+}
+
+fn runConfiguredWarmModel(model: common_config.Config.InferenceConfig.WarmModelConfig) !inference.server.WarmModel {
+    if (model.name.len == 0) return error.InvalidConfig;
+    return .{
+        .kind = parsePreloadModelKind(model.kind) orelse return error.InvalidArguments,
+        .name = model.name,
+        .backend = try parseOptionalBackendType(model.backend),
+        .format = model.format,
+        .quantization = model.quantization,
+        .residency_mode = if (model.residency_mode) |mode| switch (mode) {
+            .auto => .auto,
+            .resident => .resident,
+            .streamed => .streamed,
+        } else null,
+        .memory_budget_mb = model.memory_budget_mb,
+    };
+}
+
+const RunModelOverrides = struct {
+    models_dir: ?[]const u8 = null,
+    ml_dir: ?[]const u8 = null,
+    max_loaded_models: ?usize = null,
+    preload: []const inference.server.WarmModel = &.{},
+};
+
+const RunModelSettings = struct {
+    models_dir: ?[]const u8,
+    ml_dir: ?[]const u8,
+    max_loaded_models: usize,
+    // Owns the slice only; model strings borrow config/CLI storage.
+    preload: []inference.server.WarmModel,
+};
+
+fn resolveRunModelSettings(alloc: std.mem.Allocator, config: ?*const common_config.Config, cli: RunModelOverrides) !RunModelSettings {
+    const cfg: common_config.Config.InferenceConfig = if (config) |value| value.inference else .{};
+    const max_loaded_models = cli.max_loaded_models orelse if (cfg.max_loaded_models) |limit|
+        std.math.cast(usize, limit) orelse return error.InvalidInferenceModelCacheConfig
+    else
+        10;
+    const models_dir = cli.models_dir orelse cfg.models_dir;
+    const ml_dir = cli.ml_dir orelse cfg.ml_dir;
+    for ([_]?[]const u8{ models_dir, ml_dir }) |maybe_path| {
+        if (maybe_path) |path| {
+            if (path.len == 0 or std.mem.indexOfScalar(u8, path, 0) != null) return error.InvalidConfig;
+        }
+    }
+    const preload = try alloc.alloc(inference.server.WarmModel, if (cli.preload.len > 0) cli.preload.len else cfg.preload.len);
+    errdefer alloc.free(preload);
+    if (cli.preload.len > 0) {
+        @memcpy(preload, cli.preload);
+        // CLI selects the list; it cannot express per-model memory policies.
+        // Preserve those only for an identical kind/reference/backend from
+        // config, never from an unrelated model or another artifact variant.
+        for (preload) |*warm| {
+            var matched = false;
+            for (cfg.preload) |model| {
+                if (!std.mem.eql(u8, model.name, stripHuggingFacePrefix(warm.name))) continue;
+                const configured = try runConfiguredWarmModel(model);
+                if (configured.kind != warm.kind or configured.backend != warm.backend) continue;
+                if (matched) return error.AmbiguousPreloadModelConfig;
+                matched = true;
+                warm.residency_mode = warm.residency_mode orelse configured.residency_mode;
+                warm.memory_budget_mb = warm.memory_budget_mb orelse configured.memory_budget_mb;
+            }
+        }
+    } else {
+        for (cfg.preload, preload) |model, *warm| {
+            warm.* = try runConfiguredWarmModel(model);
+        }
+    }
+    return .{ .models_dir = models_dir, .ml_dir = ml_dir, .max_loaded_models = max_loaded_models, .preload = preload };
+}
+
 fn runServer(alloc: std.mem.Allocator, io: std.Io, args: *std.process.Args.Iterator) !void {
     // Help is side-effect free and wins over every run option, even if it
     // follows an otherwise invalid value. Probe a copy so normal parsing can
@@ -309,9 +469,7 @@ fn runServer(alloc: std.mem.Allocator, io: std.Io, args: *std.process.Args.Itera
 
     var host: []const u8 = "127.0.0.1";
     var port: u16 = 8090;
-    var models_dir: []const u8 = defaultModelsDir(alloc);
-    var ml_dir: []const u8 = defaultMlDir(alloc);
-    var max_loaded_models: usize = 10;
+    var model_overrides = RunModelOverrides{};
     var config_path: ?[]const u8 = null;
     var max_concurrent_requests_override: ?u32 = null;
     var process_memory_budget_mb_override: ?usize = null;
@@ -334,11 +492,11 @@ fn runServer(alloc: std.mem.Allocator, io: std.Io, args: *std.process.Args.Itera
         } else if (std.mem.eql(u8, arg, "--port")) {
             if (args.next()) |p| port = std.fmt.parseInt(u16, p, 10) catch 8090;
         } else if (std.mem.eql(u8, arg, "--models-dir")) {
-            models_dir = args.next() orelse models_dir;
+            model_overrides.models_dir = args.next() orelse return error.InvalidArguments;
         } else if (std.mem.eql(u8, arg, "--ml-dir")) {
-            ml_dir = args.next() orelse ml_dir;
+            model_overrides.ml_dir = args.next() orelse return error.InvalidArguments;
         } else if (std.mem.eql(u8, arg, "--max-loaded-models")) {
-            max_loaded_models = try std.fmt.parseInt(
+            model_overrides.max_loaded_models = try std.fmt.parseInt(
                 usize,
                 args.next() orelse return error.InvalidArguments,
                 10,
@@ -392,11 +550,17 @@ fn runServer(alloc: std.mem.Allocator, io: std.Io, args: *std.process.Args.Itera
         }
     }
 
-    var loaded_config: ?common_config.Config = if (config_path) |path|
-        try common_config.loadFromPath(alloc, path)
-    else
-        null;
+    var loaded_config: ?common_config.Config = if (config_path) |path| blk: {
+        const raw = try std.Io.Dir.cwd().readFileAlloc(io, path, alloc, .limited(16 * 1024 * 1024));
+        defer alloc.free(raw);
+        break :blk try parseRunConfig(alloc, raw);
+    } else null;
     defer if (loaded_config) |*config| config.deinit();
+    model_overrides.preload = preload_models.items;
+    const model_settings = try resolveRunModelSettings(alloc, if (loaded_config) |*config| config else null, model_overrides);
+    defer alloc.free(model_settings.preload);
+    const models_dir = model_settings.models_dir orelse defaultModelsDir(alloc);
+    const ml_dir = model_settings.ml_dir orelse defaultMlDir(alloc);
     const max_concurrent_requests = resolveRunMaxConcurrentRequests(
         max_concurrent_requests_override,
         if (loaded_config) |*config| config else null,
@@ -436,14 +600,14 @@ fn runServer(alloc: std.mem.Allocator, io: std.Io, args: *std.process.Args.Itera
     var node = try inference.server.Node.init(alloc, .{
         .models_dir = models_dir,
         .ml_dir = ml_dir,
-        .max_loaded_models = max_loaded_models,
+        .max_loaded_models = model_settings.max_loaded_models,
         .max_concurrent_requests = max_concurrent_requests,
         .generation_budget_overrides = budgetOverridesFromMb(budget_overrides_mb),
         .process_memory_limit_bytes = process_memory_resolution.limit_bytes,
         .process_memory_limit_provenance = inferenceProcessMemoryLimitProvenance(
             process_memory_resolution.effective_source,
         ),
-        .preload = preload_models.items,
+        .preload = model_settings.preload,
         .kernel_jit = kernel_jit,
         .allow_insecure_public_bind = allow_insecure_public_bind,
         .allow_unknown_models = allow_unknown_models,
@@ -863,7 +1027,7 @@ fn printUsage() void {
         \\  --models-dir <dir> AI models directory (default: ~/.antfly/inference/models)
         \\  --ml-dir <dir>     Traditional ML directory (default: ~/.antfly/inference/ml)
         \\  --max-loaded-models <n> Maximum resident models; 0 disables the count limit (default: 10)
-        \\  --config <path>     Load admission settings from an Antfly config file
+        \\  --config <path>     Load admission and inference model settings (CLI flags override config)
         \\  --max-concurrent-requests <n> Override admission.inference.max_concurrent_requests; 0 disables it
         \\  --process-memory-budget-mb <n> Whole-process host-memory envelope; 0 selects cgroup/host detection
         \\  --inference-process-memory-budget-mb <n> Compatibility alias for --process-memory-budget-mb
@@ -897,6 +1061,151 @@ test "inference runtime module compiles" {
     _ = run;
     _ = runFromIterator;
     _ = spawnServerProcess;
+}
+
+test "inference run config resolves flat operator and canonical model settings" {
+    const alloc = std.testing.allocator;
+    for ([_][]const u8{
+        \\{"models_dir":"/models","ml_dir":"/ml","max_loaded_models":0,"preload":[{"kind":"embedder","name":"owner/model:gguf:Q4_K","backend":"native","format":"gguf","quantization":"Q4_K"}]}
+        ,
+        \\{"inference":{"models_dir":"/models","ml_dir":"/ml","max_loaded_models":0,"preload":[{"kind":"embedder","name":"owner/model:gguf:Q4_K","backend":"native","format":"gguf","quantization":"Q4_K"}]}}
+        ,
+    }) |raw| {
+        var config = try parseRunConfig(alloc, raw);
+        defer config.deinit();
+        const settings = try resolveRunModelSettings(alloc, &config, .{});
+        defer alloc.free(settings.preload);
+        try std.testing.expectEqualStrings("/models", settings.models_dir.?);
+        try std.testing.expectEqualStrings("/ml", settings.ml_dir.?);
+        try std.testing.expectEqual(@as(usize, 0), settings.max_loaded_models);
+        try std.testing.expectEqual(@as(usize, 1), settings.preload.len);
+        try std.testing.expectEqual(.embedder, settings.preload[0].kind);
+        try std.testing.expectEqualStrings("owner/model:gguf:Q4_K", settings.preload[0].name);
+        try std.testing.expectEqual(.native, settings.preload[0].backend.?);
+        try std.testing.expectEqualStrings("gguf", settings.preload[0].format.?);
+        try std.testing.expectEqualStrings("Q4_K", settings.preload[0].quantization.?);
+    }
+}
+
+test "inference run config CLI overrides nested config which overrides flat fields" {
+    const alloc = std.testing.allocator;
+    var config = try parseRunConfig(alloc,
+        \\{"models_dir":"/flat","ml_dir":"/flat-ml","max_loaded_models":8,"preload":[{"kind":"embedder","name":"flat/model"}],"inference":{"models_dir":"/nested","max_loaded_models":3,"preload":[]},"admission":{"inference":{"max_concurrent_requests":7}}}
+    );
+    defer config.deinit();
+    const nested = try resolveRunModelSettings(alloc, &config, .{});
+    defer alloc.free(nested.preload);
+    try std.testing.expectEqualStrings("/nested", nested.models_dir.?);
+    try std.testing.expectEqualStrings("/flat-ml", nested.ml_dir.?);
+    try std.testing.expectEqual(@as(usize, 3), nested.max_loaded_models);
+    try std.testing.expectEqual(@as(usize, 0), nested.preload.len);
+    try std.testing.expectEqual(@as(u32, 7), resolveRunMaxConcurrentRequests(null, &config));
+    const cli = try resolveRunModelSettings(alloc, &config, .{
+        .models_dir = "/cli",
+        .ml_dir = "/cli-ml",
+        .max_loaded_models = 0,
+        .preload = &.{try parsePreloadModelFlag("embedder:native:cli/model:i8")},
+    });
+    defer alloc.free(cli.preload);
+    try std.testing.expectEqualStrings("/cli", cli.models_dir.?);
+    try std.testing.expectEqualStrings("/cli-ml", cli.ml_dir.?);
+    try std.testing.expectEqual(@as(usize, 0), cli.max_loaded_models);
+    try std.testing.expectEqual(@as(usize, 1), cli.preload.len);
+    try std.testing.expectEqualStrings("cli/model:i8", cli.preload[0].name);
+}
+
+test "inference run config selects explicit artifacts and rejects conflicting references" {
+    const alloc = std.testing.allocator;
+    var config = try parseRunConfig(alloc,
+        \\{"inference":{"preload":[{"kind":"generator","name":"hf:owner/model","format":"gguf","quantization":"Q4_K"}]}}
+    );
+    defer config.deinit();
+    const settings = try resolveRunModelSettings(alloc, &config, .{});
+    defer alloc.free(settings.preload);
+    try std.testing.expectEqualStrings("owner/model:gguf:Q4_K", settings.preload[0].name);
+    for ([_][]const u8{
+        \\{"preload":[{"kind":"generator","name":"owner/model:gguf:Q8_0","format":"gguf","quantization":"Q4_K"}]}
+        ,
+        \\{"preload":[{"kind":"generator","name":"owner/model","quantization":"Q4_K"}]}
+        ,
+        \\{"preload":[{"kind":"generator","name":"owner/model:i8","format":"gguf"}]}
+        ,
+    }) |raw| {
+        try std.testing.expectError(error.InvalidConfig, parseRunConfig(alloc, raw));
+    }
+}
+
+test "inference run config retains policies only for matching CLI preload identities" {
+    const alloc = std.testing.allocator;
+    var config = try parseRunConfig(alloc,
+        \\{"preload":[{"kind":"generator","name":"hf:owner/model","backend":"cuda","format":"gguf","quantization":"Q4_K","residency_mode":"streamed","memory_budget_mb":4096},{"kind":"embedder","name":"config/only"}]}
+    );
+    defer config.deinit();
+    const settings = try resolveRunModelSettings(alloc, &config, .{ .preload = &.{
+        try parsePreloadModelFlag("generator:cuda:owner/model:gguf:Q4_K"),
+        try parsePreloadModelFlag("generator:cuda:owner/model:gguf:Q8_0"),
+        try parsePreloadModelFlag("generator:native:owner/model:gguf:Q4_K"),
+        try parsePreloadModelFlag("embedder:cuda:owner/model:gguf:Q4_K"),
+    } });
+    defer alloc.free(settings.preload);
+    try std.testing.expectEqual(@as(usize, 4), settings.preload.len);
+    try std.testing.expect(settings.preload[0].residency_mode != null);
+    try std.testing.expect(settings.preload[0].memory_budget_mb != null);
+    try std.testing.expectEqual(.streamed, settings.preload[0].residency_mode.?);
+    try std.testing.expectEqual(@as(u32, 4096), settings.preload[0].memory_budget_mb.?);
+    const request = settings.preload[0].a4bRequest().?;
+    try std.testing.expectEqual(.streamed, request.residency_mode);
+    try std.testing.expectEqual(@as(u32, 4096), request.memory_budget_mb);
+    for (settings.preload[1..]) |model| {
+        try std.testing.expectEqual(null, model.residency_mode);
+        try std.testing.expectEqual(null, model.memory_budget_mb);
+    }
+}
+
+test "inference run config rejects ambiguous CLI policy matches" {
+    const alloc = std.testing.allocator;
+    var config = try parseRunConfig(alloc,
+        \\{"preload":[{"kind":"generator","name":"owner/model","backend":"cuda","memory_budget_mb":4096},{"kind":"generator","name":"owner/model","backend":"cuda","memory_budget_mb":8192}]}
+    );
+    defer config.deinit();
+    try std.testing.expectError(error.AmbiguousPreloadModelConfig, resolveRunModelSettings(alloc, &config, .{
+        .preload = &.{try parsePreloadModelFlag("generator:cuda:owner/model")},
+    }));
+}
+
+test "inference run config defaults and invalid model policies" {
+    const alloc = std.testing.allocator;
+    const defaults = try resolveRunModelSettings(alloc, null, .{});
+    defer alloc.free(defaults.preload);
+    try std.testing.expectEqual(null, defaults.models_dir);
+    try std.testing.expectEqual(null, defaults.ml_dir);
+    try std.testing.expectEqual(@as(usize, 10), defaults.max_loaded_models);
+    try std.testing.expectEqual(@as(usize, 0), defaults.preload.len);
+    var empty_config = try parseRunConfig(alloc, "{\"inference\":{}}");
+    defer empty_config.deinit();
+    const empty_settings = try resolveRunModelSettings(alloc, &empty_config, .{});
+    defer alloc.free(empty_settings.preload);
+    try std.testing.expectEqual(@as(usize, 10), empty_settings.max_loaded_models);
+    try std.testing.expectError(error.InvalidConfig, parseRunConfig(alloc,
+        \\{"preload":[{"kind":"embedder"}]}
+    ));
+    for ([_][]const u8{
+        \\{"max_loaded_models":-1}
+        ,
+        \\{"models_dir":""}
+        ,
+        \\{"preload":[{"kind":"bogus","name":"owner/model"}]}
+        ,
+        \\{"preload":[{"kind":"embedder","name":"owner/model","backend":"bogus"}]}
+        ,
+    }) |raw| {
+        var config = parseRunConfig(alloc, raw) catch continue;
+        defer config.deinit();
+        if (resolveRunModelSettings(alloc, &config, .{})) |settings| {
+            alloc.free(settings.preload);
+            return error.ExpectedInvalidModelConfig;
+        } else |_| {}
+    }
 }
 
 test "inference runtime preload parser preserves registry variants and explicit backends" {


### PR DESCRIPTION
Codex (GPT-6):

Backport https://github.com/antflydb/antfly/pull/689 to `v0.2.x` for the upcoming patch release. The runtime now honors model directories, limits, and preloads from flat or nested inference config, with explicit CLI options taking precedence. The operator emits consistent legacy-compatible config and CLI flags, preserves model policies, and rejects ambiguous eager model kinds before updating workloads.

Cherry-picked `0df116253877f5ecef8a712183d9ce14d091fa44` with source provenance. The only backport adaptations are placing the new configuration section into the existing v0.2.x guide and enabling the two affected CI workflows for v0.2.x pushes and pull requests.

Validation at `0ee4dc84db829e1058cf184e5580a728d57d4923`:

- Full operator tests with Kubernetes 1.35 envtest, `go build ./...`, and `make lint` pass (zero lint issues).
- Focused Zig common-config and preload/runtime-config tests pass: 53 tests, no skips or leaks.
- Workflow actionlint, Zig formatting, and diff whitespace checks pass.
- Fresh v0.2.x CPU inference artifact builds with `-Donnx=false -Dmetal=false -Doptimize=ReleaseFast`. All 12 operator-generated runtime contract scenarios pass (34 seconds), including real embedding/generator warming and the missing-directory negative control. All four config-only startup/CLI-precedence E2E cases pass. The focused artifact was invoked through a local adapter that removes the top-level `inference` prefix; hosted CI tests the complete Antfly binary.
- Patch comparison confirms identical additions/deletions in all 14 code/test/development-doc files; only the guide placement and two workflow branch filters were adapted.

Hosted operator and Zig CI are still running. Local validation used native CPU inference on macOS; GPU/container behavior is not independently validated here.

This PR does not cut a release or deploy services.
