### PR TITLE
ci(zig): move expensive cache checks into the full suite

### DIFF
--- a/.github/workflows/zig-tests.yml
+++ b/.github/workflows/zig-tests.yml
@@ -390,9 +390,9 @@ jobs:
         working-directory: zig
         run: zig build antfly-storage-bench -Doptimize=Debug
 
-      # The unit gate compiles registered finetune commands once in its normal
-      # cache. These checks inspect coverage and run bounded dependency probes.
-      - name: Test bounded-build tooling
+      # Keep inexpensive tooling checks beside the normal unit gate. The
+      # isolated compilation/cache matrix runs in zig-full / build-cache.
+      - name: Test build tooling
         working-directory: zig
         run: >-
           python3 -m unittest
@@ -404,7 +404,6 @@ jobs:
           tools/test_run_recall_checks.py
           tools/test_test_runner.py
           tools/test_sync_generated.py
-          tools/test_runtime_cache.py
 
       - name: Test benchmark orchestration and fixture setup
         run: |
@@ -693,9 +692,9 @@ jobs:
       - name: Check generated sources
         run: make zig-generated-check
 
-      # The unit gate compiles registered finetune commands once in its normal
-      # cache. These checks inspect coverage and run bounded dependency probes.
-      - name: Test bounded-build tooling
+      # Keep inexpensive tooling checks beside the normal unit gate. The
+      # isolated compilation/cache matrix runs in zig-full / build-cache.
+      - name: Test build tooling
         working-directory: zig
         run: >-
           python3 -m unittest
@@ -707,7 +706,6 @@ jobs:
           tools/test_run_recall_checks.py
           tools/test_test_runner.py
           tools/test_sync_generated.py
-          tools/test_runtime_cache.py
 
       - name: Test benchmark orchestration and fixture setup
         run: |
@@ -806,6 +804,46 @@ jobs:
           --build-runner ${{ steps.cpus.outputs.build_runner }}
           --maxrss ${{ steps.cpus.outputs.max_rss }}
 
+  zig-build-cache-tests:
+    name: zig-full / build-cache
+    needs: changes
+    if: github.event_name == 'merge_group' || (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && inputs.validation_scope == 'all') || github.event.schedule == '0 8 * * *'
+    runs-on: arc-antfly-heavy
+    timeout-minutes: 60
+    env:
+      ZIG_LOCAL_CACHE_DIR: /mnt/cache/antfly/zig/${{ github.job }}/${{ github.run_id }}-${{ github.run_attempt }}/zig-local
+      ZIG_GLOBAL_CACHE_DIR: /mnt/cache/antfly/zig/zig-global
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          submodules: true
+
+      - name: Load pinned toolchain policy
+        id: toolchain
+        uses: ./.github/actions/load-toolchain-policy
+
+      - name: Install build tools
+        run: sudo apt-get update && sudo apt-get install -y build-essential pkg-config ca-certificates git curl xz-utils
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+
+      - name: Set up Zig
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2
+        with:
+          version: ${{ steps.toolchain.outputs.zig_version }}
+          use-cache: false
+
+      - name: Prepare ARC Zig cache dirs
+        run: mkdir -p "$ZIG_LOCAL_CACHE_DIR" "$ZIG_GLOBAL_CACHE_DIR"
+
+      # Each test owns its temporary source overlay and local cache. Keep
+      # those isolated; only the normal global dependency cache is shared.
+      # Verbose output identifies the individual checks in the CI log.
+      - name: Test runtime compilation and cache contracts
+        working-directory: zig
+        run: python3 -u -m unittest -v tools/test_runtime_cache.py
+
   zig-base:
     name: zig-base
     needs: [changes, zig-base-tests, arm64-codec]
@@ -833,7 +871,7 @@ jobs:
 
   zig-full:
     name: zig-full
-    needs: [changes, zig-full-tests, arm64-codec]
+    needs: [changes, zig-full-tests, zig-build-cache-tests, arm64-codec]
     if: |
       always() &&
       (
@@ -848,11 +886,13 @@ jobs:
         env:
           CHANGES_RESULT: ${{ needs.changes.result }}
           X86_64_RESULT: ${{ needs.zig-full-tests.result }}
+          BUILD_CACHE_RESULT: ${{ needs.zig-build-cache-tests.result }}
           ARM64_CODEC_RESULT: ${{ needs.arm64-codec.result }}
         run: |
           set -euo pipefail
           test "$CHANGES_RESULT" = "success"
           test "$X86_64_RESULT" = "success"
+          test "$BUILD_CACHE_RESULT" = "success"
           test "$ARM64_CODEC_RESULT" = "success"
 
   e2e-base-build:


### PR DESCRIPTION
The x86_64 PR job spent 24m46s in its combined build-tooling step before starting the main unit gate. That step mixed 46 lightweight checks with 22 integration tests that repeatedly compile isolated cache fixtures.

Keep the lightweight checks in both base and full unit jobs. Run the unchanged compilation/cache matrix in a separate `zig-full / build-cache` job alongside the full unit job, with the same full-validation event selection: main pushes, merge queues, nightly, and full manual dispatch. Require its success in the `zig-full` aggregate. Ordinary PRs no longer run this matrix; build-tooling changes can request full manual validation on their branch before merge. Verbose unittest output identifies individual cache checks, and each test retains its isolated source overlay and local cache.

Validation: all 46 lightweight tooling checks passed locally in 2.273 seconds; the existing Zig validation-scope test, actionlint, and `git diff --check` passed. The expensive matrix itself is unchanged and was not rerun locally for this scheduling-only change. The earlier CI total is a baseline, not a measured savings result for the new workflow.
