### PR TITLE
fix(container): discover GKE-mounted CUDA driver libraries

### DIFF
--- a/scripts/release/test_runtime_container.py
+++ b/scripts/release/test_runtime_container.py
@@ -1,0 +1,78 @@
+"""GPU driver discovery contract for the standard runtime image, without a GPU."""
+
+import os
+from pathlib import Path
+import shlex
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def runtime_library_paths():
+    # The last ENV assignment is the effective runtime-stage value.
+    assignments = [
+        shlex.split(line)[1].split("=", 1)[1]
+        for line in (ROOT / "zig/Dockerfile.runtime").read_text().splitlines()
+        if line.startswith("ENV LD_LIBRARY_PATH=")
+    ]
+    return assignments[-1].split(":")
+
+
+class RuntimeContainerTests(unittest.TestCase):
+    def test_driver_and_bundled_library_paths(self):
+        paths = runtime_library_paths()
+        self.assertIn("/usr/local/nvidia/lib64", paths)
+        self.assertIn("/usr/local/nvidia/lib", paths)
+        self.assertIn("/usr/local/lib", paths)
+        self.assertTrue(all(path.startswith("/") for path in paths))
+
+    @unittest.skipUnless(
+        sys.platform == "linux" and shutil.which("cc"), "needs Linux cc"
+    )
+    def test_dlopen_finds_driver_in_injected_mount(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            driver_dir = root / "usr/local/nvidia/lib64"
+            driver_dir.mkdir(parents=True)
+            subprocess.run(
+                [
+                    "cc",
+                    "-shared",
+                    "-fPIC",
+                    "-x",
+                    "c",
+                    "-",
+                    "-o",
+                    str(driver_dir / "libcuda.so.1"),
+                ],
+                input="int antfly_test_driver(void) { return 42; }\n",
+                text=True,
+                check=True,
+                capture_output=True,
+            )
+            env = os.environ.copy()
+            # Map container absolute paths into an isolated fixture root. Do not
+            # modify the host or require an NVIDIA driver/GPU on the CI runner.
+            env["LD_LIBRARY_PATH"] = ":".join(
+                str(root / path.lstrip("/")) for path in runtime_library_paths()
+            )
+            subprocess.run(
+                [
+                    sys.executable,
+                    "-c",
+                    "import ctypes; assert ctypes.CDLL('libcuda.so.1').antfly_test_driver() == 42",
+                ],
+                env=env,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/zig/Dockerfile.runtime
+++ b/zig/Dockerfile.runtime
@@ -37,7 +37,9 @@ COPY share/antfly /usr/share/antfly
 COPY --from=wasmtime /opt/wasmtime/lib/libwasmtime.so /usr/local/lib/libwasmtime.so
 
 ENV ANTFLY_WASMTIME_LIB=/usr/local/lib/libwasmtime.so
-ENV LD_LIBRARY_PATH=/usr/local/lib
+# GKE mounts the host CUDA driver here; keep Wasmtime's bundled library path.
+# These directories can be absent on CPU-only nodes without affecting startup.
+ENV LD_LIBRARY_PATH=/usr/local/nvidia/lib64:/usr/local/nvidia/lib:/usr/local/lib
 ENV ANTFLY_EXTENSION_PACKAGE_STORE=/tmp/antflydb/extensions
 
 # Exercise the target architecture's glibc loader during the image build.


### PR DESCRIPTION
Authored by Codex (GPT-5) on Boris's behalf.

## Summary

- Add `/usr/local/nvidia/lib64` and `/usr/local/nvidia/lib` to the standard runtime image's `LD_LIBRARY_PATH`, preserving `/usr/local/lib` for Wasmtime.
- Keep one CPU/GPU-capable image; no bundled CUDA toolkit, driver installation, operator change, or CPU-fallback change.
- Add a GPU-free Linux regression test to the existing release-test discovery suite. It compiles a fixture `libcuda.so.1` under a simulated driver mount and resolves it by library name using the Dockerfile's configured search path.

## Evidence

A GKE L4 smoke test with Antfly v0.2.1 successfully activated the GPU pool but returned `MODEL_LOAD_FAILED: CudaUnavailable`. The container had `/dev/nvidia0` and `/usr/local/nvidia/lib64/libcuda.so.1`, while `LD_LIBRARY_PATH` contained only `/usr/local/lib`. The runtime opens `libcuda.so.1` by name.

All mounted driver dependencies resolved. A read-only `nvidia-smi` query with a process-local NVIDIA library path succeeded and identified the L4. This narrows the failure to driver-library discovery, not missing GPU hardware or a need for a separate GPU image.

## Validation

- Local Linux container: both regression tests passed, including real `dlopen` of the fixture library; no GPU required.
- macOS: path contract passed; Linux-only test skipped as intended.
- Python formatting and `git diff --check` passed.
- Actual GLiNER2 CUDA execution with the fixed image remains a post-release validation step.

## Release plan

Use an RC, provisionally `v0.2.2-rc.1`, rather than a stable release. The release pipeline consumes this Dockerfile from its trusted main-branch controller, so this change must land on main before building the RC from the supported v0.2.x source line. No release tag is created by this PR.

Cold-start edge timeouts and readiness checks for lazy model loading are separate issues; this PR is limited to the confirmed driver search-path failure.
