### PR TITLE
fix(container): backport GKE CUDA library discovery to v0.2.x

### DIFF
--- a/scripts/release/test_runtime_container.py
+++ b/scripts/release/test_runtime_container.py
@@ -1,0 +1,78 @@
+"""GPU driver discovery contract for the standard runtime image, without a GPU."""
+
+import os
+from pathlib import Path
+import shlex
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def runtime_library_paths():
+    # The last ENV assignment is the effective runtime-stage value.
+    assignments = [
+        shlex.split(line)[1].split("=", 1)[1]
+        for line in (ROOT / "zig/Dockerfile.runtime").read_text().splitlines()
+        if line.startswith("ENV LD_LIBRARY_PATH=")
+    ]
+    return assignments[-1].split(":")
+
+
+class RuntimeContainerTests(unittest.TestCase):
+    def test_driver_and_bundled_library_paths(self):
+        paths = runtime_library_paths()
+        self.assertIn("/usr/local/nvidia/lib64", paths)
+        self.assertIn("/usr/local/nvidia/lib", paths)
+        self.assertIn("/usr/local/lib", paths)
+        self.assertTrue(all(path.startswith("/") for path in paths))
+
+    @unittest.skipUnless(
+        sys.platform == "linux" and shutil.which("cc"), "needs Linux cc"
+    )
+    def test_dlopen_finds_driver_in_injected_mount(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            driver_dir = root / "usr/local/nvidia/lib64"
+            driver_dir.mkdir(parents=True)
+            subprocess.run(
+                [
+                    "cc",
+                    "-shared",
+                    "-fPIC",
+                    "-x",
+                    "c",
+                    "-",
+                    "-o",
+                    str(driver_dir / "libcuda.so.1"),
+                ],
+                input="int antfly_test_driver(void) { return 42; }\n",
+                text=True,
+                check=True,
+                capture_output=True,
+            )
+            env = os.environ.copy()
+            # Map container absolute paths into an isolated fixture root. Do not
+            # modify the host or require an NVIDIA driver/GPU on the CI runner.
+            env["LD_LIBRARY_PATH"] = ":".join(
+                str(root / path.lstrip("/")) for path in runtime_library_paths()
+            )
+            subprocess.run(
+                [
+                    sys.executable,
+                    "-c",
+                    "import ctypes; assert ctypes.CDLL('libcuda.so.1').antfly_test_driver() == 42",
+                ],
+                env=env,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/zig/Dockerfile.runtime
+++ b/zig/Dockerfile.runtime
@@ -37,7 +37,9 @@ COPY share/antfly /usr/share/antfly
 COPY --from=wasmtime /opt/wasmtime/lib/libwasmtime.so /usr/local/lib/libwasmtime.so
 
 ENV ANTFLY_WASMTIME_LIB=/usr/local/lib/libwasmtime.so
-ENV LD_LIBRARY_PATH=/usr/local/lib
+# GKE mounts the host CUDA driver here; keep Wasmtime's bundled library path.
+# These directories can be absent on CPU-only nodes without affecting startup.
+ENV LD_LIBRARY_PATH=/usr/local/nvidia/lib64:/usr/local/nvidia/lib:/usr/local/lib
 ENV ANTFLY_EXTENSION_PACKAGE_STORE=/tmp/antflydb/extensions
 
 # Exercise the target architecture's glibc loader during the image build.


### PR DESCRIPTION
Authored by Codex (GPT-5) on Boris's behalf.

## Summary

Exact backport of https://github.com/antflydb/antfly/pull/707 to `v0.2.x`, cherry-picked with provenance from https://github.com/antflydb/antfly/commit/2bd96e33e1c7e12c98b376dd317537601868251d.

- Add GKE's NVIDIA driver directories to the standard runtime container's `LD_LIBRARY_PATH`, preserving the bundled Wasmtime path.
- Include the GPU-free library-discovery regression tests.
- No unrelated main-branch changes, runtime code changes, operator changes, or release-workflow changes.

## Validation

- Clean cherry-pick; both changed files are identical to the merged #707 versions.
- Linux container: both regression tests passed, including dynamic loading of a fixture `libcuda.so.1` from the simulated driver mount.
- macOS: path contract passed; Linux loader test skipped as intended.
- `git diff --check` passed.
- Prior hardware validation of #707's Dockerfile with verified v0.2.1 GNU artifacts passed on a real GKE L4: `cuda-info --smoke`, CUDA-required GLiNER2 extraction, HTTP 200, and expected person/organization/location entities. No library-path override was used. That validates the packaging change, not a newly built maintenance-branch RC.

## Release boundary

Intended for the next v0.2.x RC, provisionally `v0.2.2-rc.1`; this PR does not tag, publish, or deploy it. The final RC artifact still needs qualification.

The separately identified container-publication ancestry check remains outside this backport: the current main-branch publisher checks source ancestry against main even though the release-line policy selects v0.2.x. This backport does not claim to resolve that workflow issue.
