### PR TITLE
vector store: metadata-only inventory scans and payload store micro-benchmark

### DIFF
--- a/scripts/compare_vdbbench_arms.py
+++ b/scripts/compare_vdbbench_arms.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Summarize run_vdbbench_qualification.sh arms side by side.
+
+usage: compare_vdbbench_arms.py RUN_ROOT [RUN_ROOT ...]
+Reads phases.jsonl, qualification-summary.json, disk-after-restart.json and the
+table status snapshots so paired arms can be compared without opening each file.
+"""
+import json, sys
+from pathlib import Path
+
+def phases(root):
+    rows=[json.loads(l) for l in (root/"phases.jsonl").read_text().splitlines() if l.strip()]
+    t={r["phase"]:r["monotonic_ns"] for r in rows}
+    d=lambda a,b:(t[b]-t[a])/1e9 if a in t and b in t else None
+    return {
+        "live_load_query_s": d("live_load_and_query_start","live_load_and_query_end"),
+        "mixed_s": d("mixed_profile_start","mixed_profile_end"),
+        "churn_s": d("source_churn_begin","source_churn_end"),
+        "enrich_s": d("source_enrichment_begin","source_enrichment_end"),
+        "shutdown_s": d("restart_begin","shutdown_complete"),
+        "restart_listen_s": d("shutdown_complete","restart_ready"),
+        "restart_index_ready_s": d("restart_ready","restart_index_ready"),
+        "cold_query_s": d("restart_index_ready","reopened_cold_query_end"),
+        "warm_query_s": d("reopened_cold_query_end","reopened_warm_query_end"),
+    }
+
+def summary(root):
+    s=json.loads((root/"qualification-summary.json").read_text())
+    out={}
+    for run in s.get("runs",[]):
+        label=run.get("label") or run.get("db_label") or "?"
+        key="live" if "cold" not in label and "warm" not in label else ("cold" if "cold" in label else "warm")
+        out[f"{key}_ready_s"]=run.get("ready_seconds")
+        out[f"{key}_max_qps"]=run.get("max_qps")
+        out[f"{key}_recall"]=run.get("recall")
+        out[f"{key}_p99_ms"]=(run.get("serial_latency_ms") or {}).get("p99")
+    m=s.get("public_mixed_profiles",{}).get("public-mixed-profile",{})
+    out["mixed_query_qps"]=m.get("query_qps"); out["mixed_query_p99_ms"]=(m.get("query_latency") or {}).get("p99_ms")
+    out["mixed_write_rows_s"]=m.get("write_rows_per_second"); out["mixed_write_p99_ms"]=(m.get("write_latency") or {}).get("p99_ms")
+    q=s.get("public_query_profiles",{}).get("public-query-profile",{})
+    out["profile_p50_ms"]=q.get("p50_ms"); out["profile_p99_ms"]=q.get("p99_ms")
+    out["rss_live_peak_mib"]=s["rss_profiles"]["rss-live"]["peak_rss_bytes"]/2**20
+    out["rss_restart_peak_mib"]=s["rss_profiles"]["rss-restart"]["peak_rss_bytes"]/2**20
+    return out
+
+def disk(root):
+    try:
+        d=json.loads((root/"disk-after-restart.json").read_text())
+        return {"disk_after_restart_mib": sum(g.get("allocated_bytes",0) for g in d.get("groups",{}).values())/2**20}
+    except Exception: return {}
+
+def status_counters(root):
+    out={}
+    import re
+    for name,tag in (("table-after-restart.json","after_restart"),("table-before-restart.json","before_restart")):
+        try:
+            text=(root/name).read_text()
+            for key in ("inventory_update_ns","preparation_ns","checkpoint_ns","durable_append_ns"):
+                m=re.search('"%s":(\d+)'%key,text)
+                if m: out[f"src_{key.replace('_ns','')}_{tag}_ms"]=int(m.group(1))/1e6
+            for key in ("heap_bytes","immutable_block_bytes","source_segments"):
+                m=re.search('"%s":(\d+)'%key,text)
+                if m: out[f"src_{key}_{tag}"]=int(m.group(1))/(2**20 if key.endswith("bytes") else 1)
+        except Exception: pass
+    for name in ("source-churn.json","source-enrichment.json"):
+        try:
+            d=json.loads((root/name).read_text()); out[name.split(".")[0]+"_qualified"]=d.get("qualified")
+        except Exception: pass
+    return out
+
+rows={}
+for arg in sys.argv[1:]:
+    root=Path(arg); r={}
+    r.update(phases(root)); r.update(summary(root)); r.update(disk(root)); r.update(status_counters(root))
+    rows[root.name]=r
+keys=[k for k in rows[next(iter(rows))].keys()]
+print("metric".ljust(26)+"".join(n.rjust(16) for n in rows))
+for k in keys:
+    line=k.ljust(26)
+    for n in rows:
+        v=rows[n].get(k)
+        line+=(f"{v:16.3f}" if isinstance(v,(int,float)) and not isinstance(v,bool) else str(v).rjust(16))
+    print(line)

--- a/scripts/footprint_sampler_linux.py
+++ b/scripts/footprint_sampler_linux.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Linux stand-in for antfly-circus footprint_sampler.py (which needs vm_stat).
+
+Implements the argument subset run_vdbbench_qualification.sh uses:
+  --capture-wired-baseline PATH
+  --pid-file PATH --wired-baseline-file PATH --out PATH --timeline PATH --interval S
+
+Process-tree footprint is taken from /proc/<pid>/status: VmRSS as the current
+footprint and VmHWM as the ledger peak. Wired growth is reported as 0.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+
+def read_status(pid: int) -> dict[str, int] | None:
+    try:
+        text = Path(f"/proc/{pid}/status").read_text(encoding="utf-8")
+    except OSError:
+        return None
+    out: dict[str, int] = {}
+    for line in text.splitlines():
+        if line.startswith(("VmRSS:", "VmHWM:", "PPid:")):
+            key, value = line.split(":", 1)
+            out[key] = int(value.strip().split()[0])
+    return out
+
+
+def process_tree(root: int) -> list[int]:
+    children: dict[int, list[int]] = {}
+    for entry in os.listdir("/proc"):
+        if not entry.isdigit():
+            continue
+        status = read_status(int(entry))
+        if status is None:
+            continue
+        children.setdefault(status.get("PPid", 0), []).append(int(entry))
+    tree = [root]
+    stack = [root]
+    while stack:
+        for child in children.get(stack.pop(), []):
+            tree.append(child)
+            stack.append(child)
+    return tree
+
+
+def atomic_write(path: Path, value: object) -> None:
+    tmp = path.with_name(path.name + ".tmp")
+    tmp.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(tmp, path)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--pid-file", type=Path)
+    parser.add_argument("--wired-baseline-file", type=Path)
+    parser.add_argument("--capture-wired-baseline", type=Path)
+    parser.add_argument("--out", type=Path)
+    parser.add_argument("--timeline", type=Path)
+    parser.add_argument("--interval", type=float, default=0.3)
+    args = parser.parse_args()
+
+    if args.capture_wired_baseline:
+        atomic_write(args.capture_wired_baseline, {"wired_bytes": 0, "captured_at": time.time()})
+        return 0
+    if not (args.pid_file and args.out):
+        parser.error("--pid-file and --out are required for sampling")
+
+    root_pid = int(args.pid_file.read_text().strip())
+    state: dict[str, object] = {
+        "kind": "native_process_tree",
+        "schema_version": 3,
+        "metric": "native_process_tree_memory_views",
+        "platform": "linux_proc_status",
+        "started": time.time(),
+        "samples": 0,
+        "failed_samples": 0,
+        "baseline_source": "linux_no_wired",
+        "peak_rss_bytes": 0,
+        "process_tree_footprint_peak_bytes": 0,
+        "wired_growth_peak_bytes": 0,
+        "conservative_host_impact_peak_bytes": 0,
+        "processes_seen": [],
+        "footprint_fallback_samples": 0,
+        "native_ledger_interval_seconds": 0.0,
+        "valid_footprint_samples": 0,
+        "footprint_fallback_peak_rss_bytes": 0,
+    }
+    seen: dict[int, dict[str, object]] = {}
+    timeline = args.timeline.open("a", encoding="utf-8") if args.timeline else None
+    try:
+        while True:
+            tree = process_tree(root_pid)
+            rss = 0
+            hwm = 0
+            complete = True
+            for pid in tree:
+                status = read_status(pid)
+                if status is None:
+                    complete = False
+                    continue
+                rss += status.get("VmRSS", 0) * 1024
+                hwm += status.get("VmHWM", 0) * 1024
+                seen[pid] = {"pid": pid, "ppid": status.get("PPid", 0), "command": Path(f"/proc/{pid}/comm").read_text().strip() if Path(f"/proc/{pid}/comm").exists() else ""}
+            if not tree or rss == 0:
+                state["failed_samples"] = int(state["failed_samples"]) + 1
+            else:
+                point = {
+                    "monotonic": time.monotonic(),
+                    "wall_time": time.time(),
+                    "rss_bytes": rss,
+                    "process_tree_footprint_bytes": rss,
+                    "process_tree_footprint_ledger_peak_bytes": hwm,
+                    "conservative_host_impact_bytes": hwm,
+                    "wired_growth_bytes": 0,
+                    "footprint_complete": complete,
+                    "pids": tree,
+                }
+                state["samples"] = int(state["samples"]) + 1
+                state["peak_rss_bytes"] = max(int(state["peak_rss_bytes"]), rss)
+                state["process_tree_footprint_peak_bytes"] = max(int(state["process_tree_footprint_peak_bytes"]), hwm)
+                state["conservative_host_impact_peak_bytes"] = max(int(state["conservative_host_impact_peak_bytes"]), hwm)
+                state["valid_footprint_samples"] = int(state["valid_footprint_samples"]) + 1
+                state["processes_seen"] = [seen[p] for p in sorted(seen)]
+                if timeline:
+                    timeline.write(json.dumps(point, sort_keys=True) + "\n")
+                    timeline.flush()
+            atomic_write(args.out, state)
+            time.sleep(args.interval)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        if timeline:
+            timeline.close()
+    return 0 if int(state["samples"]) > 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/zig/VECTOR_STORE.md
+++ b/zig/VECTOR_STORE.md
@@ -12,6 +12,16 @@ Existing planes remain readable without an eager rewrite. This does not change
 the table-level source-ownership setting or exact-score requirements. Frozen
 comparison catalogs and archive locations are in `benchmark-baselines/README.md`.
 
+## Micro-profile of store costs (2026-09-10)
+
+[VECTOR_STORE_PERF_PROFILE.md](VECTOR_STORE_PERF_PROFILE.md) attributes the
+store's write, read, disk, and memory costs with the isolated
+`vector_payload_bench` harness (`zig build vector-payload-bench`). It records
+the SHA-256 digest as the dominant read-path CPU cost, synchronous WAL and
+delta-chain checkpoints as the largest writer stalls, bootstrap write
+amplification of about 3.6x, and the cold-reopen inventory scan, which now
+reads only identity metadata instead of every payload byte.
+
 ## Sparse fallback and bounded planning follow-up
 
 Sparse batching now applies only when no denser reclaimable segment was selected.

--- a/zig/VECTOR_STORE_PERF_PROFILE.md
+++ b/zig/VECTOR_STORE_PERF_PROFILE.md
@@ -1,0 +1,243 @@
+# Vector store micro-profile: write, read, disk, and memory costs
+
+Date: 2026-09-10. Scope: the table-owned source payload store
+(`storage/vector_payload_store.zig` over `storage/vector_block_store.zig`)
+measured in isolation with the new `vector_payload_bench` harness, not the
+end-to-end VectorDBBench arms recorded in [VECTOR_STORE.md](VECTOR_STORE.md).
+The goal is attribution: which code paths cost what, so the next
+qualification rounds target the largest costs first.
+
+## Harness
+
+```bash
+cd zig
+zig build vector-payload-bench -Doptimize=ReleaseFast              # baseline x86-64
+zig build vector-payload-bench -Doptimize=ReleaseFast -Dcpu=native --prefix zig-out-native
+./zig-out/bin/vector_payload_bench --vectors 50000 --dims 768 --batch 64 --reads 20000 --drop-caches --root /tmp/vps
+./zig-out/bin/vector_payload_bench --vectors 50000 --dims 768 --reopen-only --drop-caches --root /tmp/vps   # after a --keep run
+```
+
+The harness drives the same surface the DB uses: `Session.put` and
+`prepareCommit` per batch of 64 (durable sync append, as `Txn.commit` does),
+`Session.get` resolves, `Store.checkpoint`, updates, and reopen. It runs on
+native on-disk storage and reports the store's own `Stats`, a counting
+allocator for the store heap, RSS, and file sizes. Phases: ingest, hot reads,
+explicit checkpoint (bootstrap base), cold/warm reads, 10% updates, per-read
+component costs, rerank-style batch reads (`locateHashed` +
+`readExactIntoBatch`/`readProjectionsIntoBatch`), and cold reopen.
+
+Host: 4 vCPU Xeon 2.1 GHz (AVX-512, SHA-NI), 15 GiB, ext4 on virtio.
+Raw fsync of a 196 KiB append: p50 0.83 ms, p99 3.7 ms. Zig 0.16.0,
+ReleaseFast, float32 payloads, 768 dims unless stated. Absolute numbers are
+host-specific; the ratios and attributions are the result.
+
+## Headline attribution
+
+| Cost center | Evidence | Share |
+| --- | --- | --- |
+| SHA-256 digest (`Reference.forArtifact`) | callgrind, baseline build, 3K vectors + 9K reads | 86% of all instructions; 65% inside `resolve`, 21% inside `Session.put` |
+| fsync per prepare batch | `durable_append_ns` | 36-45% of preparation time at 50K-200K |
+| Synchronous WAL checkpoint under the store lock | `checkpoint_ns`, `prepare_max_us` | 31% of ingest time at 50K, 60% at 1M; one 33.4 s stall at 1M |
+| Cold reopen inventory scan | `inventory_update_ns`, RSS delta | 92-96% of reopen time; faults the whole corpus into RSS (fixed here) |
+| Everything else in the store (WAL AVL view, block writer, CRC32, compaction merge) | callgrind | < 3% each |
+
+## 1. SHA-256 dominates artifact reads and a large share of writes
+
+`resolveFrom` recomputes the full artifact digest on every read and compares it
+to the reference; `Session.put` computes it once per write. The lookup key is
+already the digest, the block index and WAL frames are CRC32-protected, and
+`Reference.decode` validates the envelope, so the recompute only guards the
+key-binding check (`VectorReferenceIdentityMismatch` when a reference is read
+under a different artifact key) and write-path bugs.
+
+Per-operation cost, warm page cache:
+
+| Build | Dims | Digest | Locate (metadata) | Full resolve p50 | Rerank exact read (no digest) |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| baseline x86-64 | 768 | 12.5 µs | 0.8 µs | 15.3 µs | 1.8-4 µs |
+| `-Dcpu=native` (SHA-NI) | 768 | 3.4 µs | 0.8 µs | 5.1-5.7 µs | 1.7-4 µs |
+| baseline x86-64 | 3072 | 45.8 µs | 0.2 µs | 45.0 µs | 4.6-5.9 µs |
+| `-Dcpu=native` (SHA-NI) | 3072 | 10.7 µs | 0.3 µs | 17.2 µs | 4.5-5.6 µs |
+
+Ingest at 50K: 17.0K vectors/s baseline versus 25.7K vectors/s native, with
+`put_digest` falling from 626 ms to 157 ms. The 1M qualification workload uses
+3072-dim payloads, where a baseline binary spends about 46 µs of CPU per exact
+artifact read on the digest alone.
+
+The container and artifact builds pass `-Dtarget=x86_64-linux-musl` without
+`-Dcpu`, so shipped binaries compile for baseline x86-64 (no SHA-NI, no AVX2);
+the compile line shows `-mcpu baseline`. `std.crypto` selects SHA-NI only at
+compile time.
+
+Options, in order of payoff for the least risk:
+
+1. Add a runtime-dispatched SHA-256 kernel (SHA-NI on x86, SHA2 on aarch64)
+   the way `lib/hash` already dispatches CRC32 at runtime. This alone makes
+   digests 3.7-4.3x cheaper on hosts that have the instructions, with no
+   format change.
+2. Stop hashing the payload on every resolve. Keep the key binding by
+   verifying a short key tag carried in the reference (or by hashing only the
+   key and the CRC-verified payload checksum), and move full digest
+   recomputation to an explicit scrub boundary. Reads then cost the
+   metadata lookup plus the CRC32 the block reader already performs.
+3. Ship x86-64-v3 (or v4) builds where the supported fleet allows it.
+
+## 2. Cold reopen read and checksummed every payload byte (fixed in this branch)
+
+`inventoryRetainedPayloads`, the incremental `Inventory.sync`,
+`Directory.update`/`removeRetired`, GC planning `SegmentStats`, copy-set
+construction, and the ANN mark scan all used `Reader.entryAt`, which validates
+the payload CRC and therefore faults every vector page. Inventory only needs
+identities, which `Reader.sourceIdentityAt` returns from the index and key
+regions that reader admission has already validated. Payload CRCs remain
+enforced at the read, exact-verification, and GC copy boundaries, which are
+the places that consume payload bytes.
+
+Cold reopen (`--drop-caches`, native build):
+
+| Scale | Before: reopen / inventory / RSS delta | After: reopen / inventory / RSS delta |
+| --- | --- | --- |
+| 50K (146 MiB) | 1.47-1.71 s / 1.36-1.58 s / +171 MiB | 0.12-0.13 s / 8 ms / +26 MiB |
+| 200K (586 MiB) | 6.2-7.1 s / 6.0-6.7 s / +609-670 MiB | 0.29-0.31 s / 26 ms / +26 MiB |
+| 1M (2.9 GiB, 2,944 segments) | 38.7-45.3 s / 37.1-43.7 s / +3.1 GiB | 1.86 s / 0.20 s / +191 MiB |
+
+After the change, the remaining 1.65 s of the 1M reopen is opening and
+validating 2,944 cold segment files (index and key regions, about 120 bytes
+per vector) plus WAL recovery; the settled 128-segment layout after base
+compaction opens faster. The old scan also pre-warmed the page cache, so post-reopen reads looked fast
+(5 µs) only because the inventory had just paged in the corpus. After the
+change, reads after a cold reopen are honestly cold (45-50 µs at 50K) until
+touched, and RSS grows with demand rather than by corpus size. Both store
+suites pass (`vector-payload-test` 48/48, `vector-block-store-test` 33/33).
+
+## 3. WAL checkpoint and delta-chain compaction run under the writer lock
+
+`prepareBatch` calls `checkpointLocked` when the WAL reaches the admission
+bound (64 MiB in the harness; `min(64 MiB, slice/8)` = 48 MiB when managed).
+The WAL-to-delta rewrite of 48-64 MiB takes 0.36-0.6 s, during which every
+preparation waits, and with it every primary commit in the batch path:
+
+| Scale | Ingest wall | Checkpoint time inside ingest | Max prepare stall | Vectors/s |
+| ---: | ---: | ---: | ---: | ---: |
+| 50K | 1.95 s | 0.69 s (2 checkpoints) | 364 ms | 25.7K |
+| 200K | 9.2-9.9 s | 3.6-3.9 s (9) | 430-530 ms | 20-22K |
+| 1M | 91.9 s | 55.7 s (47) | 33,371 ms | 10.9K |
+
+At 1M the bootstrap chain reached `max_bootstrap_delta_generations` (24), and
+the next checkpoint rewrote all 24 deltas plus the WAL into one generation
+under the lock: 1.57 GiB rewritten, one 33 s stall, and ingest throughput
+halved relative to 200K. The stall grows with corpus size. The harness does
+not hold the outer DB lock, so this is a candidate mechanism for the
+mixed-workload p99 and readiness tails in the qualification arms rather than
+a confirmed one; the `preparation_ns`, `checkpoint_ns`, and
+`outer_db_batch_lock_wait_ns` counters in a VectorDBBench arm would confirm it.
+
+Recommendation:
+
+- Stage checkpoint output outside the store lock. The WAL view is a
+  persistent, immutable structure, and `stageDeltasToBaseWithShardCount` plus
+  `commitPrepared` already stage on a retained snapshot and install under a
+  brief lock; the WAL-to-delta path should use the same shape.
+- Trigger checkpoints from the background maintenance turn
+  (`runArtifactRepairMetadataMaintenancePass`) at a soft watermark (for
+  example half the admission bound) so the foreground only stalls at the
+  hard bound.
+- Replace the all-at-once delta-chain rewrite with tiered merging (merge the
+  oldest K generations) so no single step is proportional to the corpus.
+
+## 4. Bootstrap write amplification is about 3.6x
+
+Every ingested byte is written three times before the base exists: WAL,
+WAL-to-delta checkpoint, and base compaction, plus the delta-chain rewrite at
+1M.
+
+| Scale | Payload | WAL | Checkpoints during ingest | Base compaction | Total written | Amplification |
+| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 50K | 146 MiB | 151 MiB | 129 MiB | 175 MiB | 455 MiB | 3.1x |
+| 1M | 2,930 MiB | 3,083 MiB | 4,579 MiB (incl. 1,570 MiB chain rewrite) | 3,057 MiB | 10,719 MiB | 3.6x |
+
+Base compaction alone took 53 s at 1M (about 58 MB/s in + out) and 11 s at
+200K. The per-prepare fsync (15.6K fsyncs at 1M, 22 s total) is inherent to
+prepare-before-primary-commit; group commit exists but is gated by the outer
+DB lock as recorded in VECTOR_STORE.md. Each vector is also copied about four
+times on the write path (session arena, `appendUpsert` scratch, frame
+buffer, WAL view chunk), which callgrind puts under 2%.
+
+Larger ideas, not measured: seal WAL generations (the extent machinery
+exists) and build the base directly from sealed WALs at the stable tip,
+skipping the WAL-to-delta rewrite during bootstrap; or raise the WAL
+admission bound only while the base is empty.
+
+## 5. The newest vectors are the slowest to read
+
+Checkpoint and compaction outputs are written with `cold_sequential` intent,
+which issues `fadvise(DONTNEED)` after the durability sync. The freshly
+published generation is therefore never in the page cache, and the WAL-resident
+copy is gone, so the first read of any recently checkpointed vector is a disk
+read:
+
+| Read path | Warm | Cold (fresh delta or evicted base) |
+| --- | ---: | ---: |
+| `Session.get` p50 | 5-7 µs | 46-92 µs |
+| Rerank exact, serial, per vector | 1.8-2.8 µs | 22-40 µs |
+| Rerank exact, 8-wide `std.Io` batch, per vector | 1.7-2.0 µs | 9.7-17 µs |
+
+The eviction is deliberate for large compactions (bounded RSS), but for the
+WAL-to-delta path the output is small (one admission bound) and is exactly the
+data ANN completion and updates read next. Keeping the newest generation
+cached (skip `DONTNEED` for that path, or re-touch its key/index regions)
+removes a disk read per fresh-vector access. The concurrent read batch already
+recovers 2.3x on cold reads; it is worth confirming that the ANN rerank path
+always passes an `Io` so it gets that overlap.
+
+## 6. Memory
+
+The store's own heap is small: peak 70-74 MiB at every scale, which is the
+resident WAL view (one copy of committed WAL bytes, `Chunk.copy`, plus about
+130 bytes of AVL node per record) up to the admission bound. RSS beyond that is
+mapped block residency, which grows with whatever touches payload pages. The
+inventory scan was the largest such toucher (+3.1 GiB at 1M on reopen) and is
+addressed above. Note that the harness's own dataset is resident too; the
+`rss_ex_dataset_mib` field subtracts it.
+
+Production uses glibc malloc (`platform.allocator.processAllocator`) and only
+the inference server calls `malloc_trim`. In this harness, `smaps` showed no
+heap retention beyond the dataset and the store's live allocations, so the
+RSS-versus-physical-footprint divergence in the qualification reports is not
+explained here; sampling `/proc/<pid>/smaps` during a VectorDBBench arm would
+separate file-backed residency from heap in that setting.
+
+## 7. Smaller observations
+
+- `prepareBatch` probes each incoming digest with `Opened.get`, which reads and
+  CRC-checks the payload when the digest already exists; `locateHashed`
+  provides the dims needed by the retry and rescue paths without touching
+  payload bytes.
+- The managed open path selects float16 source encoding (`preferredEncoding`).
+  For the source store that doubles checkpoint CPU (1.80 s versus 0.91 s at
+  50K), slows exact reads about 20%, and does not shrink immutable bytes
+  (132.9 versus 129.0 MiB) because residuals keep exactness. The benefit is
+  halved projection I/O for rerank; that trade should be confirmed for the
+  source store specifically rather than inherited from the ANN store default.
+- A 15 MiB table still publishes 128 shard files per generation (258 files
+  after the bootstrap base, about 2.5 ms per file). `SegmentSizing` already
+  supports adaptive shard counts behind an environment variable.
+- The persistent AVL WAL view allocates about log2(n) nodes per insert (about
+  1,000 allocations per 64-vector batch under the lock). Callgrind puts this at
+  2.5% plus 1.9% for releases; it is not a bottleneck today but would be the
+  next CPU item once the digest cost is gone.
+
+## Suggested order
+
+1. Land the metadata-only inventory change (this branch) and re-run the 50K
+   and 1M readiness/restart gates; expect restart to stop scaling with corpus
+   bytes.
+2. Runtime-dispatched SHA-256, then decide whether reads should recompute the
+   digest at all.
+3. Unlocked, background-triggered WAL checkpoints with tiered delta merging;
+   re-measure mixed p99 and fixed-count churn, which are the metrics the
+   qualification ledger shows regressing.
+4. Keep the newest generation cached after WAL checkpoints; re-measure the
+   first-window query p99.
+5. Revisit bootstrap write amplification only after 3, since the checkpoint
+   restructuring changes where those bytes are produced.

--- a/zig/VECTOR_STORE_PERF_PROFILE.md
+++ b/zig/VECTOR_STORE_PERF_PROFILE.md
@@ -110,6 +110,41 @@ change, reads after a cold reopen are honestly cold (45-50 µs at 50K) until
 touched, and RSS grows with demand rather than by corpus size. Both store
 suites pass (`vector-payload-test` 48/48, `vector-block-store-test` 33/33).
 
+### VectorDBBench 50K qualification A/B (2026-09-12)
+
+Three alternating pairs of `scripts/run_vdbbench_qualification.sh` arms
+(Performance1536D50K, `vector_store` tables, native HBC, float32 blocks,
+batch 100, 4 load workers, query concurrency 1/10/20/30 for 30 s, 30 s mixed,
+1,000-query profile, 4 GiB process budget) on the same 4 vCPU host, ordered
+candidate/control, control/candidate, control/candidate. Control is the
+parent commit's store code; candidate is this branch. All six arms qualified.
+The macOS-only footprint sampler was replaced by
+`scripts/footprint_sampler_linux.py`; `scripts/compare_vdbbench_arms.py`
+produced the table.
+
+| Metric (median, range over 3 arms) | Control | Candidate |
+| --- | ---: | ---: |
+| Source inventory after restart (table status `inventory_update_ns`) | 3.97 s (3.84-4.40) | 6.7 ms (6.5-6.9) |
+| Restart to index ready | 2.17 s (2.16-2.18) | 2.16 s (2.16-2.17) |
+| Live ready seconds | 52.0 (50.8-54.3) | 53.2 (43.8-54.3) |
+| Live max QPS | 305 (299-323) | 316 (286-320) |
+| Live recall | 0.985 | 0.986 |
+| Mixed query QPS / p99 | 96.6 / 269 ms | 93.7 / 268 ms |
+| Mixed write rows/s / p99 | 341 / 3.57 s | 345 / 2.91 s |
+| Fixed churn / enrichment time | 30.8 s / 23.4 s | 30.7 s / 23.1 s |
+| Peak RSS live / after restart | 2,428 / 590 MiB | 2,483 / 591 MiB |
+| Disk after restart | 388 MiB | 393 MiB |
+
+The only repeatable difference is the inventory: about 600x less work after
+every restart, in all three pairs. Restart-to-ready is unchanged because the
+DB open profile (0.28-0.30 s in both arms) does not include the source store;
+its inventory runs off the readiness path and previously competed with the
+first post-restart queries. Every other metric moves in both directions
+within pair noise on this host. Three of the six reopened query passes (two
+control, one candidate) hit an unrelated 80-120 ms p99 stall during the cold
+and warm serial passes; it does not correlate with the binary, so those
+passes are reported by range rather than compared.
+
 ## 3. WAL checkpoint and delta-chain compaction run under the writer lock
 
 `prepareBatch` calls `checkpointLocked` when the WAL reaches the admission

--- a/zig/build.zig
+++ b/zig/build.zig
@@ -9842,6 +9842,18 @@ pub fn build(b: *std.Build) void {
     vector_payload_test_step.dependOn(&run_vector_payload_tests.step);
     unit_test_step.dependOn(&run_vector_payload_tests.step);
 
+    const vector_payload_bench_mod = makeLmdbModule(b, "pkg/antfly/src/vector_payload_bench_root.zig", target, optimize, build_options, lmdb_engine_mod, platform_mod, hash_mod);
+    vector_payload_bench_mod.addImport("bloom", bloom_mod);
+    vector_payload_bench_mod.addImport("antfly_vectorindex", vectorindex_mod);
+    vector_payload_bench_mod.addImport("antfly-json", json_mod);
+    vector_payload_bench_mod.addImport("structlog", structlog_mod);
+    const vector_payload_bench = b.addExecutable(.{
+        .name = "vector_payload_bench",
+        .root_module = vector_payload_bench_mod,
+    });
+    const vector_payload_bench_step = b.step("vector-payload-bench", "Build and install the source vector payload store micro-benchmark");
+    vector_payload_bench_step.dependOn(&b.addInstallArtifact(vector_payload_bench, .{}).step);
+
     const native_vector_store_test_mod = makeLmdbModule(b, "pkg/antfly/src/native_vector_store_test_root.zig", target, optimize, build_options, lmdb_engine_mod, platform_mod, hash_mod);
     native_vector_store_test_mod.addImport("bloom", bloom_mod);
     native_vector_store_test_mod.addImport("antfly_vectorindex", vectorindex_mod);

--- a/zig/pkg/antfly/src/storage/source_location_directory.zig
+++ b/zig/pkg/antfly/src/storage/source_location_directory.zig
@@ -50,8 +50,8 @@ pub const Directory = struct {
         for (opened.readers) |reader| {
             if (reader.generation <= self.generation) continue;
             for (0..reader.count) |i| {
-                const row = try reader.entryAt(i);
-                if (row.key.len != 32 or row.value != .vector) continue;
+                const row = reader.sourceIdentityAt(i);
+                if (row.key.len != 32 or !row.vector) continue;
                 try self.entries.put(row.key[0..32].*, .{ .generation = reader.generation, .shard = reader.shard_id });
                 self.dirty_entries += 1;
             }
@@ -73,7 +73,7 @@ pub const Directory = struct {
             }
             if (retained) continue;
             for (0..reader.count) |i| {
-                const row = try reader.entryAt(i);
+                const row = reader.sourceIdentityAt(i);
                 if (row.key.len != 32) continue;
                 const location = self.entries.get(row.key[0..32].*) orelse continue;
                 if (location.generation == reader.generation and location.shard == reader.shard_id) {

--- a/zig/pkg/antfly/src/storage/vector_payload_store.zig
+++ b/zig/pkg/antfly/src/storage/vector_payload_store.zig
@@ -244,9 +244,9 @@ pub const Store = struct {
                 for (previous.?.readers) |reader| {
                     if (next_segments.contains(id(reader))) continue;
                     for (0..reader.count) |i| {
-                        const row = try reader.entryAt(i);
+                        const row = reader.sourceIdentityAt(i);
                         rows.* += 1;
-                        if (row.value != .vector or row.key.len != 32) return error.InvalidVectorReference;
+                        if (!row.vector or row.key.len != 32) return error.InvalidVectorReference;
                         try self.remove(row.key[0..32].*);
                     }
                 }
@@ -254,10 +254,10 @@ pub const Store = struct {
             for (next.readers) |reader| {
                 if (self.segments.contains(id(reader))) continue;
                 for (0..reader.count) |i| {
-                    const row = try reader.entryAt(i);
+                    const row = reader.sourceIdentityAt(i);
                     rows.* += 1;
-                    if (row.value != .vector or row.key.len != 32) return error.InvalidVectorReference;
-                    try self.add(alloc, row.key[0..32].*, row.value.vector.dims);
+                    if (!row.vector or row.key.len != 32) return error.InvalidVectorReference;
+                    try self.add(alloc, row.key[0..32].*, row.dims);
                 }
             }
             if (!use_delta) {
@@ -623,7 +623,7 @@ pub const Store = struct {
                 while (marking.ann_row < reader.count) : (marking.ann_row += 1) {
                     if (markBudgetExpired(started, budget_ns, limit, progress)) return;
                     progress.rows += 1;
-                    const row = try reader.entryAt(marking.ann_row);
+                    const row = reader.sourceIdentityAt(marking.ann_row);
                     try markAnnKey(marking, row.key, progress);
                 }
                 marking.ann_row = 0;
@@ -1041,10 +1041,14 @@ pub const Store = struct {
         if (@TypeOf(unique) == *LiveSet) {
             if (self.bitmap_marking) try unique.enableBitmapsMode(opened, self.bitmap_locator);
         }
+        // Inventory counts identities. Reader admission has already validated
+        // the immutable index and every key; payload checksums are verified
+        // at the read, verification, and copy boundaries that touch payload
+        // bytes, so this scan must not fault in or hash the vector planes.
         for (opened.readers) |reader| for (0..reader.count) |i| {
-            const entry = try reader.entryAt(i);
+            const entry = reader.sourceIdentityAt(i);
             self.stats.inventory_rows_scanned += 1;
-            if (entry.value == .vector) try FullInventory.put(unique, entry.key, entry.value.vector.dims);
+            if (entry.vector) try FullInventory.put(unique, entry.key, entry.dims);
         };
         for (opened.wal.records.items) |record| {
             if (record.kind == .upsert) try FullInventory.put(unique, record.key, record.dims);
@@ -1797,9 +1801,9 @@ pub const Store = struct {
         live_rows: u64 = 0,
 
         fn add(self: *@This(), reader: anytype, index: usize, live: *const LiveSet) !void {
-            const row = try reader.entryAt(index);
-            if (row.value != .vector or row.key.len != 32) return;
-            const bytes = @as(u64, row.value.vector.dims) * 4;
+            const row = reader.sourceIdentityAt(index);
+            if (!row.vector or row.key.len != 32) return;
+            const bytes = @as(u64, row.dims) * 4;
             self.total += bytes;
             if (!live.contains(row.key[0..32].*)) self.dead += bytes else self.live_rows += 1;
         }
@@ -1976,7 +1980,7 @@ pub const Store = struct {
             for (selected_indices.items) |index| {
                 const reader = self.opened.readers[index];
                 for (0..reader.count) |i| {
-                    const row = try reader.entryAt(i);
+                    const row = reader.sourceIdentityAt(i);
                     if (row.key.len != 32) continue;
                     if (live.get(row.key[0..32].*)) |dims| try copy_live.put(row.key[0..32].*, dims);
                 }

--- a/zig/pkg/antfly/src/vector_payload_bench_root.zig
+++ b/zig/pkg/antfly/src/vector_payload_bench_root.zig
@@ -1,0 +1,740 @@
+// Copyright 2026 Antfly, Inc.
+// Licensed under the Elastic License 2.0 (ELv2).
+
+//! Micro-benchmark for the table-owned source vector payload store.
+//!
+//! Exercises the same public surface the DB uses (Session.put / prepareCommit /
+//! get, Store.checkpoint) against native on-disk storage so the write, read,
+//! disk, and memory costs of the store itself can be attributed without the
+//! surrounding primary LSM, ANN indexes, or HTTP layers.
+//!
+//!   zig build vector-payload-bench -Doptimize=ReleaseFast
+//!   ./zig-out/bin/vector_payload_bench --vectors 50000 --dims 768 --batch 64 --root /tmp/vps
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const payload_store = @import("storage/vector_payload_store.zig");
+const payload = @import("storage/artifact_payload.zig");
+const codec = @import("storage/db/enrichment/artifact_codec.zig");
+const keys = @import("storage/internal_keys.zig");
+const lsm = @import("storage/lsm_backend/mod.zig");
+const time = @import("antfly_platform").time;
+
+const Config = struct {
+    vectors: usize = 20_000,
+    dims: usize = 768,
+    batch: usize = 64,
+    reads: usize = 20_000,
+    update_fraction_percent: usize = 10,
+    root: []const u8 = "/tmp/vector_payload_bench",
+    seed: u64 = 42,
+    managed: bool = false,
+    keep: bool = false,
+    skip_checkpoint: bool = false,
+    drop_caches: bool = false,
+    rerank_batch: usize = 100,
+    rerank_batches: usize = 200,
+    /// Open an existing root written by a prior --keep run, skipping ingest.
+    reopen_only: bool = false,
+};
+
+/// Bytes the benchmark itself keeps resident (keys, artifacts, references) so
+/// process RSS can be reported net of the workload dataset.
+var dataset_bytes: u64 = 0;
+
+const vector_block = @import("antfly_vectorindex").vector_block;
+
+fn dropCaches() bool {
+    const fd = std.c.open("/proc/sys/vm/drop_caches", .{ .ACCMODE = .WRONLY }, @as(c_uint, 0));
+    if (fd < 0) return false;
+    defer _ = std.c.close(fd);
+    return std.c.write(fd, "3", 1) == 1;
+}
+
+/// Counts live and peak bytes handed out to the store so resident metadata
+/// (WAL view chunks, AVL nodes, reader arrays) can be attributed separately
+/// from process RSS, which also includes mmap'd immutable blocks.
+const CountingAllocator = struct {
+    backing: Allocator,
+    live: std.atomic.Value(usize) = .init(0),
+    peak: std.atomic.Value(usize) = .init(0),
+    allocs: std.atomic.Value(u64) = .init(0),
+    frees: std.atomic.Value(u64) = .init(0),
+    mutex: std.atomic.Mutex = .unlocked,
+
+    fn allocator(self: *CountingAllocator) Allocator {
+        return .{ .ptr = self, .vtable = &vtable };
+    }
+
+    const vtable: Allocator.VTable = .{
+        .alloc = alloc,
+        .resize = resize,
+        .remap = remap,
+        .free = free,
+    };
+
+    fn account(self: *CountingAllocator, delta: isize) void {
+        const prev = self.live.load(.monotonic);
+        const next: usize = if (delta >= 0) prev + @as(usize, @intCast(delta)) else prev - @as(usize, @intCast(-delta));
+        self.live.store(next, .monotonic);
+        if (next > self.peak.load(.monotonic)) self.peak.store(next, .monotonic);
+    }
+
+    fn alloc(ctx: *anyopaque, len: usize, alignment: std.mem.Alignment, ret_addr: usize) ?[*]u8 {
+        const self: *CountingAllocator = @ptrCast(@alignCast(ctx));
+        while (!self.mutex.tryLock()) std.Thread.yield() catch {};
+        defer self.mutex.unlock();
+        const result = self.backing.rawAlloc(len, alignment, ret_addr) orelse return null;
+        self.account(@intCast(len));
+        _ = self.allocs.fetchAdd(1, .monotonic);
+        return result;
+    }
+    fn resize(ctx: *anyopaque, memory: []u8, alignment: std.mem.Alignment, new_len: usize, ret_addr: usize) bool {
+        const self: *CountingAllocator = @ptrCast(@alignCast(ctx));
+        while (!self.mutex.tryLock()) std.Thread.yield() catch {};
+        defer self.mutex.unlock();
+        if (!self.backing.rawResize(memory, alignment, new_len, ret_addr)) return false;
+        self.account(@as(isize, @intCast(new_len)) - @as(isize, @intCast(memory.len)));
+        return true;
+    }
+    fn remap(ctx: *anyopaque, memory: []u8, alignment: std.mem.Alignment, new_len: usize, ret_addr: usize) ?[*]u8 {
+        const self: *CountingAllocator = @ptrCast(@alignCast(ctx));
+        while (!self.mutex.tryLock()) std.Thread.yield() catch {};
+        defer self.mutex.unlock();
+        const result = self.backing.rawRemap(memory, alignment, new_len, ret_addr) orelse return null;
+        self.account(@as(isize, @intCast(new_len)) - @as(isize, @intCast(memory.len)));
+        return result;
+    }
+    fn free(ctx: *anyopaque, memory: []u8, alignment: std.mem.Alignment, ret_addr: usize) void {
+        const self: *CountingAllocator = @ptrCast(@alignCast(ctx));
+        while (!self.mutex.tryLock()) std.Thread.yield() catch {};
+        defer self.mutex.unlock();
+        self.backing.rawFree(memory, alignment, ret_addr);
+        self.account(-@as(isize, @intCast(memory.len)));
+        _ = self.frees.fetchAdd(1, .monotonic);
+    }
+};
+
+const Rss = struct {
+    rss_kb: u64 = 0,
+    hwm_kb: u64 = 0,
+
+    fn read() Rss {
+        var result: Rss = .{};
+        const fd = std.c.open("/proc/self/status", .{ .ACCMODE = .RDONLY }, @as(c_uint, 0));
+        if (fd < 0) return result;
+        defer _ = std.c.close(fd);
+        var buf: [16384]u8 = undefined;
+        var len: usize = 0;
+        while (len < buf.len) {
+            const rc = std.c.read(fd, buf[len..].ptr, buf.len - len);
+            if (rc <= 0) break;
+            len += @intCast(rc);
+        }
+        var lines = std.mem.splitScalar(u8, buf[0..len], '\n');
+        while (lines.next()) |line| {
+            if (std.mem.startsWith(u8, line, "VmRSS:")) result.rss_kb = parseKb(line);
+            if (std.mem.startsWith(u8, line, "VmHWM:")) result.hwm_kb = parseKb(line);
+        }
+        return result;
+    }
+
+    fn parseKb(line: []const u8) u64 {
+        var it = std.mem.tokenizeAny(u8, line, " \t");
+        _ = it.next();
+        const value = it.next() orelse return 0;
+        return std.fmt.parseInt(u64, value, 10) catch 0;
+    }
+};
+
+const Timing = struct {
+    samples: std.ArrayListUnmanaged(u64) = .empty,
+
+    fn add(self: *Timing, alloc: Allocator, ns: u64) !void {
+        try self.samples.append(alloc, ns);
+    }
+    fn percentile(self: *Timing, p: f64) u64 {
+        if (self.samples.items.len == 0) return 0;
+        std.mem.sortUnstable(u64, self.samples.items, {}, std.sort.asc(u64));
+        const idx: usize = @intFromFloat(@as(f64, @floatFromInt(self.samples.items.len - 1)) * p);
+        return self.samples.items[idx];
+    }
+    fn total(self: *Timing) u64 {
+        var sum: u64 = 0;
+        for (self.samples.items) |s| sum += s;
+        return sum;
+    }
+};
+
+fn ms(ns: u64) f64 {
+    return @as(f64, @floatFromInt(ns)) / 1e6;
+}
+fn us(ns: u64) f64 {
+    return @as(f64, @floatFromInt(ns)) / 1e3;
+}
+fn mib(bytes: u64) f64 {
+    return @as(f64, @floatFromInt(bytes)) / (1024.0 * 1024.0);
+}
+
+fn diskBytes(storage: lsm.Storage, alloc: Allocator, root: []const u8) !u64 {
+    const names = try storage.listFileNamesAlloc(alloc, root);
+    defer {
+        for (names) |name| alloc.free(name);
+        alloc.free(names);
+    }
+    var total: u64 = 0;
+    for (names) |name| {
+        const path = try std.fs.path.join(alloc, &.{ root, name });
+        defer alloc.free(path);
+        total += storage.fileSize(path) catch 0;
+    }
+    return total;
+}
+
+fn fileCount(storage: lsm.Storage, alloc: Allocator, root: []const u8) !usize {
+    const names = try storage.listFileNamesAlloc(alloc, root);
+    defer {
+        for (names) |name| alloc.free(name);
+        alloc.free(names);
+    }
+    return names.len;
+}
+
+fn printStats(out: *std.Io.Writer, label: []const u8, s: payload.Stats) !void {
+    try out.print(
+        "[{s}] prepare_batches={d} prepared_payloads={d} preparation_ms={d:.1} durable_append_ms={d:.1} lock_wait_ms={d:.1} wal_written_mib={d:.2} active_wal_mib={d:.2} checkpoint_ms={d:.1} ckpt_read_mib={d:.2} ckpt_written_mib={d:.2} immutable_mib={d:.2} segments={d} shards={d} resolved={d} loc_cache_hits={d} loc_cache_misses={d} dir_entries={d} dir_written_mib={d:.2}\n",
+        .{
+            label,
+            s.prepare_batches,
+            s.prepared_payloads,
+            ms(s.preparation_ns),
+            ms(s.durable_append_ns),
+            ms(s.prepare_lock_wait_ns),
+            mib(s.wal_bytes_written),
+            mib(s.active_wal_bytes),
+            ms(s.checkpoint_ns),
+            mib(s.checkpoint_bytes_read),
+            mib(s.checkpoint_bytes_written),
+            mib(s.immutable_block_bytes),
+            s.source_segments,
+            s.source_shards,
+            s.resolved_payloads,
+            s.location_cache_hits,
+            s.location_cache_misses,
+            s.directory_entries,
+            mib(s.directory_bytes_written),
+        },
+    );
+}
+
+fn printMem(out: *std.Io.Writer, label: []const u8, counting: *CountingAllocator) !void {
+    const rss = Rss.read();
+    try out.print(
+        "[{s}] store_heap_live_mib={d:.2} store_heap_peak_mib={d:.2} allocs={d} frees={d} rss_mib={d:.1} hwm_mib={d:.1} rss_ex_dataset_mib={d:.1}\n",
+        .{
+            label,
+            mib(counting.live.load(.monotonic)),
+            mib(counting.peak.load(.monotonic)),
+            counting.allocs.load(.monotonic),
+            counting.frees.load(.monotonic),
+            @as(f64, @floatFromInt(rss.rss_kb)) / 1024.0,
+            @as(f64, @floatFromInt(rss.hwm_kb)) / 1024.0,
+            @as(f64, @floatFromInt(rss.rss_kb)) / 1024.0 - mib(dataset_bytes),
+        },
+    );
+}
+
+fn fillVector(random: std.Random, out: []f32) void {
+    for (out) |*v| v.* = random.float(f32) * 2.0 - 1.0;
+}
+
+pub fn main(init: std.process.Init) !void {
+    var args = try std.process.Args.Iterator.initAllocator(init.minimal.args, init.gpa);
+    defer args.deinit();
+    _ = args.skip();
+    var cfg: Config = .{};
+    while (args.next()) |arg| {
+        if (std.mem.eql(u8, arg, "--vectors")) {
+            cfg.vectors = try std.fmt.parseInt(usize, args.next() orelse return error.InvalidArgument, 10);
+        } else if (std.mem.eql(u8, arg, "--dims")) {
+            cfg.dims = try std.fmt.parseInt(usize, args.next() orelse return error.InvalidArgument, 10);
+        } else if (std.mem.eql(u8, arg, "--batch")) {
+            cfg.batch = try std.fmt.parseInt(usize, args.next() orelse return error.InvalidArgument, 10);
+        } else if (std.mem.eql(u8, arg, "--reads")) {
+            cfg.reads = try std.fmt.parseInt(usize, args.next() orelse return error.InvalidArgument, 10);
+        } else if (std.mem.eql(u8, arg, "--update-percent")) {
+            cfg.update_fraction_percent = try std.fmt.parseInt(usize, args.next() orelse return error.InvalidArgument, 10);
+        } else if (std.mem.eql(u8, arg, "--seed")) {
+            cfg.seed = try std.fmt.parseInt(u64, args.next() orelse return error.InvalidArgument, 10);
+        } else if (std.mem.eql(u8, arg, "--root")) {
+            cfg.root = args.next() orelse return error.InvalidArgument;
+        } else if (std.mem.eql(u8, arg, "--managed")) {
+            cfg.managed = true;
+        } else if (std.mem.eql(u8, arg, "--keep")) {
+            cfg.keep = true;
+        } else if (std.mem.eql(u8, arg, "--skip-checkpoint")) {
+            cfg.skip_checkpoint = true;
+        } else if (std.mem.eql(u8, arg, "--drop-caches")) {
+            cfg.drop_caches = true;
+        } else if (std.mem.eql(u8, arg, "--reopen-only")) {
+            cfg.reopen_only = true;
+            cfg.keep = true;
+        } else if (std.mem.eql(u8, arg, "--rerank-batch")) {
+            cfg.rerank_batch = try std.fmt.parseInt(usize, args.next() orelse return error.InvalidArgument, 10);
+        } else if (std.mem.eql(u8, arg, "--rerank-batches")) {
+            cfg.rerank_batches = try std.fmt.parseInt(usize, args.next() orelse return error.InvalidArgument, 10);
+        } else {
+            std.debug.print("unknown argument {s}\n", .{arg});
+            return error.InvalidArgument;
+        }
+    }
+
+    const alloc = std.heap.c_allocator;
+    var counting: CountingAllocator = .{ .backing = alloc };
+    const store_alloc = counting.allocator();
+
+    var stdout_buffer: [8192]u8 = undefined;
+    var stdout_writer = std.Io.File.stdout().writer(init.io, &stdout_buffer);
+    const out = &stdout_writer.interface;
+    defer stdout_writer.flush() catch {};
+
+    var native = try lsm.NativeStorage.init(alloc, .threaded);
+    defer native.deinit();
+    var threaded = std.Io.Threaded.init(alloc, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+    const storage = native.storage();
+    if (!cfg.reopen_only) {
+        storage.deleteTree(cfg.root) catch {};
+        try storage.createDirPath(cfg.root);
+    }
+    defer if (!cfg.keep) storage.deleteTree(cfg.root) catch {};
+
+    try out.print("vector_payload_bench vectors={d} dims={d} batch={d} reads={d} update_percent={d} managed={} root={s}\n", .{ cfg.vectors, cfg.dims, cfg.batch, cfg.reads, cfg.update_fraction_percent, cfg.managed, cfg.root });
+    try stdout_writer.flush();
+
+    // Dataset: keys as the DB would generate them, random float32 artifacts.
+    var rng = std.Random.DefaultPrng.init(cfg.seed);
+    const random = rng.random();
+    const doc_keys = try alloc.alloc([]u8, cfg.vectors);
+    defer {
+        for (doc_keys) |k| alloc.free(k);
+        alloc.free(doc_keys);
+    }
+    const artifacts = try alloc.alloc([]u8, cfg.vectors);
+    defer {
+        for (artifacts) |a| alloc.free(a);
+        alloc.free(artifacts);
+    }
+    const references = try alloc.alloc([payload.reference_len]u8, cfg.vectors);
+    defer alloc.free(references);
+    {
+        const scratch = try alloc.alloc(f32, cfg.dims);
+        defer alloc.free(scratch);
+        for (0..cfg.vectors) |i| {
+            var doc_buf: [64]u8 = undefined;
+            const doc = try std.fmt.bufPrint(&doc_buf, "doc-{d:0>8}", .{i});
+            doc_keys[i] = try keys.embeddingArtifactKeyForDocumentAlloc(alloc, doc, "embedding");
+            fillVector(random, scratch);
+            artifacts[i] = try codec.encodeDenseEmbeddingAlloc(alloc, @intCast(i + 1), scratch);
+            dataset_bytes += doc_keys[i].len + artifacts[i].len + payload.reference_len;
+        }
+    }
+    try out.print("dataset_mib={d:.2}\n", .{mib(dataset_bytes)});
+
+    var manager: ?*@import("storage/resource_manager.zig").ResourceManager = null;
+    var manager_storage: @import("storage/resource_manager.zig").ResourceManager = undefined;
+    if (cfg.managed) {
+        manager_storage = @import("storage/resource_manager.zig").ResourceManager.init(.{});
+        manager = &manager_storage;
+    }
+    defer if (manager) |m| m.deinit(alloc);
+
+    if (cfg.reopen_only) {
+        // The same seed regenerates the same artifacts, so references can be
+        // recomputed without the original ingest run's output.
+        for (0..cfg.vectors) |i| references[i] = (try payload.Reference.forArtifact(doc_keys[i], artifacts[i])).encode();
+        if (cfg.drop_caches) {
+            if (!dropCaches()) try out.print("[reopen] drop_caches unavailable\n", .{});
+        }
+        const rss_before = Rss.read();
+        const reopen_started = time.monotonicNs();
+        var reopened = if (cfg.managed)
+            try payload_store.Store.openManaged(store_alloc, manager, storage, cfg.root, false)
+        else
+            try payload_store.Store.open(store_alloc, storage, cfg.root, false);
+        defer reopened.deinit();
+        const reopen_ns = time.monotonicNs() -| reopen_started;
+        const rss_after = Rss.read();
+        const reopen_stats = reopened.statsSnapshot();
+        try out.print("[reopen] drop_caches={} wall_ms={d:.1} inventory_ms={d:.1} inventory_rows={d} retained_payloads={d} segments={d} rss_delta_mib={d:.1}\n", .{
+            cfg.drop_caches,
+            ms(reopen_ns),
+            ms(reopen_stats.inventory_update_ns),
+            reopen_stats.inventory_rows_scanned,
+            reopen_stats.retained_payloads,
+            reopen_stats.source_segments,
+            (@as(f64, @floatFromInt(rss_after.rss_kb)) - @as(f64, @floatFromInt(rss_before.rss_kb))) / 1024.0,
+        });
+        try printMem(out, "reopen", &counting);
+        try stdout_writer.flush();
+        try benchReads(out, alloc, &reopened, doc_keys, references, cfg, "read_after_reopen", random);
+        try benchRerank(out, alloc, &reopened, references, cfg, "rerank_after_reopen", random, io);
+        try stdout_writer.flush();
+        return;
+    }
+
+    var source = if (cfg.managed)
+        try payload_store.Store.openManaged(store_alloc, manager, storage, cfg.root, false)
+    else
+        try payload_store.Store.open(store_alloc, storage, cfg.root, false);
+    var source_open = true;
+    defer if (source_open) source.deinit();
+    try out.print("encoding={s} wal_admission_mib={d:.1}\n", .{ @tagName(source.opened.payloadEncoding() orelse .float32), mib(source.wal_admission_bytes) });
+
+    // ---------------------------------------------------------------- ingest
+    var digest_ns: u64 = 0;
+    var batch_timing: Timing = .{};
+    defer batch_timing.samples.deinit(alloc);
+    const ingest_started = time.monotonicNs();
+    {
+        var pos: usize = 0;
+        while (pos < cfg.vectors) {
+            const end = @min(cfg.vectors, pos + cfg.batch);
+            const session = try payload.Session.create(alloc, source.interface());
+            const put_started = time.monotonicNs();
+            for (pos..end) |i| {
+                const ref = try session.put(doc_keys[i], artifacts[i]);
+                references[i] = ref[0..payload.reference_len].*;
+            }
+            digest_ns += time.monotonicNs() -| put_started;
+            const prepare_started = time.monotonicNs();
+            try session.prepareCommit();
+            try batch_timing.add(alloc, time.monotonicNs() -| prepare_started);
+            session.committed = true;
+            session.release();
+            pos = end;
+        }
+    }
+    const ingest_ns = time.monotonicNs() -| ingest_started;
+    const ingest_stats = source.statsSnapshot();
+    const payload_bytes: u64 = @as(u64, cfg.vectors) * @as(u64, cfg.dims) * 4;
+    try out.print(
+        "[ingest] wall_ms={d:.1} vectors_per_s={d:.0} payload_mib={d:.2} put_digest_ms={d:.1} prepare_p50_us={d:.1} prepare_p99_us={d:.1} prepare_max_us={d:.1} prepare_sum_ms={d:.1}\n",
+        .{
+            ms(ingest_ns),
+            @as(f64, @floatFromInt(cfg.vectors)) / (@as(f64, @floatFromInt(ingest_ns)) / 1e9),
+            mib(payload_bytes),
+            ms(digest_ns),
+            us(batch_timing.percentile(0.5)),
+            us(batch_timing.percentile(0.99)),
+            us(batch_timing.percentile(1.0)),
+            ms(batch_timing.total()),
+        },
+    );
+    try printStats(out, "ingest", ingest_stats);
+    try printMem(out, "ingest", &counting);
+    try out.print("[ingest] disk_mib={d:.2} files={d} disk_amplification={d:.2}\n", .{ mib(try diskBytes(storage, alloc, cfg.root)), try fileCount(storage, alloc, cfg.root), @as(f64, @floatFromInt(try diskBytes(storage, alloc, cfg.root))) / @as(f64, @floatFromInt(payload_bytes)) });
+    try stdout_writer.flush();
+
+    // --------------------------------------------------- reads before checkpoint
+    try benchReads(out, alloc, &source, doc_keys, references, cfg, "read_hot", random);
+    try stdout_writer.flush();
+
+    // ------------------------------------------------------------ checkpoint
+    if (!cfg.skip_checkpoint) {
+        const before = source.statsSnapshot();
+        const rss_before = Rss.read();
+        const ckpt_started = time.monotonicNs();
+        try source.checkpoint();
+        const ckpt_ns = time.monotonicNs() -| ckpt_started;
+        const after = source.statsSnapshot();
+        const rss_after = Rss.read();
+        try out.print("[checkpoint] wall_ms={d:.1} stat_checkpoint_ms={d:.1} read_mib={d:.2} written_mib={d:.2} segments={d} active_wal_mib={d:.2} rss_delta_mib={d:.1}\n", .{
+            ms(ckpt_ns),
+            ms(after.checkpoint_ns -| before.checkpoint_ns),
+            mib(after.checkpoint_bytes_read -| before.checkpoint_bytes_read),
+            mib(after.checkpoint_bytes_written -| before.checkpoint_bytes_written),
+            after.source_segments,
+            mib(after.active_wal_bytes),
+            (@as(f64, @floatFromInt(rss_after.rss_kb)) - @as(f64, @floatFromInt(rss_before.rss_kb))) / 1024.0,
+        });
+        try printMem(out, "checkpoint", &counting);
+        try out.print("[checkpoint] disk_mib={d:.2} files={d}\n", .{ mib(try diskBytes(storage, alloc, cfg.root)), try fileCount(storage, alloc, cfg.root) });
+        try stdout_writer.flush();
+
+        try benchReads(out, alloc, &source, doc_keys, references, cfg, "read_cold_blocks", random);
+        try benchReads(out, alloc, &source, doc_keys, references, cfg, "read_warm_blocks", random);
+        try stdout_writer.flush();
+    }
+
+    // ------------------------------------------------------------- updates
+    if (cfg.update_fraction_percent > 0) {
+        const updates = cfg.vectors * cfg.update_fraction_percent / 100;
+        const scratch = try alloc.alloc(f32, cfg.dims);
+        defer alloc.free(scratch);
+        var update_timing: Timing = .{};
+        defer update_timing.samples.deinit(alloc);
+        const before = source.statsSnapshot();
+        const started = time.monotonicNs();
+        var done: usize = 0;
+        while (done < updates) {
+            const end = @min(updates, done + cfg.batch);
+            const session = try payload.Session.create(alloc, source.interface());
+            for (done..end) |_| {
+                const i = random.uintLessThan(usize, cfg.vectors);
+                fillVector(random, scratch);
+                const artifact = try codec.encodeDenseEmbeddingAlloc(alloc, @intCast(i + 1000), scratch);
+                defer alloc.free(artifact);
+                const ref = try session.put(doc_keys[i], artifact);
+                references[i] = ref[0..payload.reference_len].*;
+                alloc.free(artifacts[i]);
+                artifacts[i] = try alloc.dupe(u8, artifact);
+            }
+            const prepare_started = time.monotonicNs();
+            try session.prepareCommit();
+            try update_timing.add(alloc, time.monotonicNs() -| prepare_started);
+            session.committed = true;
+            session.release();
+            done = end;
+        }
+        const elapsed = time.monotonicNs() -| started;
+        const after = source.statsSnapshot();
+        try out.print("[update] count={d} wall_ms={d:.1} vectors_per_s={d:.0} prepare_p50_us={d:.1} prepare_p99_us={d:.1} wal_written_mib={d:.2} checkpoint_ms={d:.1} ckpt_written_mib={d:.2} segments={d}\n", .{
+            updates,
+            ms(elapsed),
+            @as(f64, @floatFromInt(updates)) / (@as(f64, @floatFromInt(elapsed)) / 1e9),
+            us(update_timing.percentile(0.5)),
+            us(update_timing.percentile(0.99)),
+            mib(after.wal_bytes_written -| before.wal_bytes_written),
+            ms(after.checkpoint_ns -| before.checkpoint_ns),
+            mib(after.checkpoint_bytes_written -| before.checkpoint_bytes_written),
+            after.source_segments,
+        });
+        try printMem(out, "update", &counting);
+        try out.print("[update] disk_mib={d:.2} files={d}\n", .{ mib(try diskBytes(storage, alloc, cfg.root)), try fileCount(storage, alloc, cfg.root) });
+        try stdout_writer.flush();
+        try benchReads(out, alloc, &source, doc_keys, references, cfg, "read_after_update", random);
+    }
+
+    try benchComponents(out, alloc, &source, doc_keys, artifacts, references, cfg, random);
+    try benchRerank(out, alloc, &source, references, cfg, "rerank_warm", random, io);
+    try stdout_writer.flush();
+
+    const final = source.statsSnapshot();
+    try printStats(out, "final", final);
+    try printMem(out, "final", &counting);
+    try stdout_writer.flush();
+
+    // ------------------------------------------------------------- reopen
+    source.deinit();
+    source_open = false;
+    if (cfg.drop_caches) {
+        if (!dropCaches()) try out.print("[reopen] drop_caches unavailable\n", .{});
+    }
+    counting.peak.store(counting.live.load(.monotonic), .monotonic);
+    const rss_before = Rss.read();
+    const reopen_started = time.monotonicNs();
+    var reopened = if (cfg.managed)
+        try payload_store.Store.openManaged(store_alloc, manager, storage, cfg.root, false)
+    else
+        try payload_store.Store.open(store_alloc, storage, cfg.root, false);
+    const reopen_ns = time.monotonicNs() -| reopen_started;
+    const rss_after = Rss.read();
+    const reopen_stats = reopened.statsSnapshot();
+    try out.print("[reopen] drop_caches={} wall_ms={d:.1} inventory_ms={d:.1} inventory_rows={d} retained_payloads={d} segments={d} rss_delta_mib={d:.1}\n", .{
+        cfg.drop_caches,
+        ms(reopen_ns),
+        ms(reopen_stats.inventory_update_ns),
+        reopen_stats.inventory_rows_scanned,
+        reopen_stats.retained_payloads,
+        reopen_stats.source_segments,
+        (@as(f64, @floatFromInt(rss_after.rss_kb)) - @as(f64, @floatFromInt(rss_before.rss_kb))) / 1024.0,
+    });
+    try printMem(out, "reopen", &counting);
+    try stdout_writer.flush();
+    try benchReads(out, alloc, &reopened, doc_keys, references, cfg, "read_after_reopen", random);
+    try benchRerank(out, alloc, &reopened, references, cfg, "rerank_after_reopen", random, io);
+    try stdout_writer.flush();
+    reopened.deinit();
+}
+
+/// Attributes the exact-read path: digest recomputation, raw lookup and
+/// payload validation, versus the full resolve that the DB performs.
+fn benchComponents(
+    out: *std.Io.Writer,
+    alloc: Allocator,
+    source: *payload_store.Store,
+    doc_keys: []const []u8,
+    artifacts: []const []u8,
+    references: []const [payload.reference_len]u8,
+    cfg: Config,
+    random: std.Random,
+) !void {
+    const n = @min(cfg.reads, 5000);
+    if (n == 0) return;
+    var sink: u64 = 0;
+    // SHA-256 digest of (key, artifact) as Session.put and resolve compute it.
+    var started = time.monotonicNs();
+    for (0..n) |_| {
+        const i = random.uintLessThan(usize, cfg.vectors);
+        const ref = try payload.Reference.forArtifact(doc_keys[i], artifacts[i]);
+        sink +%= ref.digest[0];
+    }
+    const digest_ns = (time.monotonicNs() -| started) / n;
+    // Metadata-only location (index binary search, no payload bytes).
+    started = time.monotonicNs();
+    for (0..n) |_| {
+        const i = random.uintLessThan(usize, cfg.vectors);
+        const ref = try payload.Reference.decode(&references[i]);
+        const found = try source.opened.locateHashed(&ref.digest, vector_block.keyHash(&ref.digest), std.math.maxInt(u64), 1);
+        sink +%= @intFromEnum(found);
+    }
+    const locate_ns = (time.monotonicNs() -| started) / n;
+    // Lookup plus payload checksum validation, borrowing mmap bytes.
+    started = time.monotonicNs();
+    for (0..n) |_| {
+        const i = random.uintLessThan(usize, cfg.vectors);
+        const ref = try payload.Reference.decode(&references[i]);
+        const found = try source.opened.get(&ref.digest, std.math.maxInt(u64), 1);
+        sink +%= found.vector.bytes[0];
+    }
+    const get_ns = (time.monotonicNs() -| started) / n;
+    // Full resolve as the DB read path performs it.
+    var arena = std.heap.ArenaAllocator.init(alloc);
+    defer arena.deinit();
+    const session = try payload.Session.create(alloc, source.interface());
+    defer session.release();
+    started = time.monotonicNs();
+    for (0..n) |k| {
+        const i = random.uintLessThan(usize, cfg.vectors);
+        const value = try session.getAlloc(arena.allocator(), doc_keys[i], &references[i]);
+        sink +%= value[value.len - 1];
+        if ((k & 255) == 255) _ = arena.reset(.retain_capacity);
+    }
+    const resolve_ns = (time.monotonicNs() -| started) / n;
+    try out.print("[components] samples={d} digest_us={d:.2} locate_us={d:.2} get_crc_us={d:.2} resolve_us={d:.2} sink={d}\n", .{ n, us(digest_ns), us(locate_ns), us(get_ns), us(resolve_ns), sink & 1 });
+}
+
+/// Models the ANN rerank read pattern: a batch of digests located against a
+/// retained snapshot, then exact payloads fetched by bounded positional I/O.
+fn benchRerank(
+    out: *std.Io.Writer,
+    alloc: Allocator,
+    source: *payload_store.Store,
+    references: []const [payload.reference_len]u8,
+    cfg: Config,
+    label: []const u8,
+    random: std.Random,
+    io: std.Io,
+) !void {
+    if (cfg.rerank_batches == 0 or cfg.rerank_batch == 0) return;
+    var snapshot = try source.snapshot(alloc);
+    defer snapshot.deinit();
+    const k = cfg.rerank_batch;
+    const requests = try alloc.alloc(@import("storage/vector_block_store.zig").ExactReadRequest, k);
+    defer alloc.free(requests);
+    const projections = try alloc.alloc(@import("storage/vector_block_store.zig").ProjectionReadRequest, k);
+    defer alloc.free(projections);
+    const scratch = try alloc.alloc(u8, k * (cfg.dims * 8 + 64));
+    defer alloc.free(scratch);
+    var locate_ns: u64 = 0;
+    var serial_ns: u64 = 0;
+    var parallel_ns: u64 = 0;
+    var projection_ns: u64 = 0;
+    var physical: u64 = 0;
+    var wal_hits: u64 = 0;
+    var errors: u64 = 0;
+    for (0..cfg.rerank_batches) |b| {
+        var t0 = time.monotonicNs();
+        var offset: usize = 0;
+        for (0..k) |j| {
+            const i = random.uintLessThan(usize, cfg.vectors);
+            const ref = try payload.Reference.decode(&references[i]);
+            const found = try snapshot.locateHashed(&ref.digest, vector_block.keyHash(&ref.digest), std.math.maxInt(u64), 1);
+            if (found != .vector) return error.MissingCommittedVectorPayload;
+            const need = switch (found.vector) {
+                .wal => 0,
+                .block => |blk| try blk.location.scratchBytes(),
+            };
+            if (found.vector == .wal) wal_hits += 1;
+            requests[j] = .{ .located = found.vector, .scratch = scratch[offset..][0..need] };
+            projections[j] = .{ .located = found.vector, .scratch = scratch[offset..][0..found.vector.projectionBytes()] };
+            offset += need;
+        }
+        locate_ns += time.monotonicNs() -| t0;
+        // Alternate serial, concurrent, and projection-only reads per batch so
+        // page-cache state is shared fairly across the three modes.
+        t0 = time.monotonicNs();
+        switch (b % 3) {
+            0 => {
+                const stats = try snapshot.readExactIntoBatch(null, requests);
+                serial_ns += time.monotonicNs() -| t0;
+                physical += stats.physical_bytes;
+            },
+            1 => {
+                _ = try snapshot.readExactIntoBatch(io, requests);
+                parallel_ns += time.monotonicNs() -| t0;
+            },
+            else => {
+                _ = try snapshot.readProjectionsIntoBatch(null, projections);
+                projection_ns += time.monotonicNs() -| t0;
+            },
+        }
+        for (requests) |request| if (request.err != null) {
+            errors += 1;
+        };
+    }
+    const per_mode = (cfg.rerank_batches + 2) / 3;
+    try out.print("[{s}] batch={d} batches={d} locate_us_per_vec={d:.2} exact_serial_us_per_vec={d:.2} exact_io_us_per_vec={d:.2} projection_serial_us_per_vec={d:.2} wal_hits={d} errors={d} physical_mib={d:.2}\n", .{
+        label,
+        k,
+        cfg.rerank_batches,
+        us(locate_ns / (cfg.rerank_batches * k)),
+        us(serial_ns / (per_mode * k)),
+        us(parallel_ns / (per_mode * k)),
+        us(projection_ns / (per_mode * k)),
+        wal_hits,
+        errors,
+        mib(physical),
+    });
+}
+
+fn benchReads(
+    out: *std.Io.Writer,
+    alloc: Allocator,
+    source: *payload_store.Store,
+    doc_keys: []const []u8,
+    references: []const [payload.reference_len]u8,
+    cfg: Config,
+    label: []const u8,
+    random: std.Random,
+) !void {
+    if (cfg.reads == 0) return;
+    var timing: Timing = .{};
+    defer timing.samples.deinit(alloc);
+    const session = try payload.Session.create(alloc, source.interface());
+    defer session.release();
+    var arena = std.heap.ArenaAllocator.init(alloc);
+    defer arena.deinit();
+    const started = time.monotonicNs();
+    var checked: u64 = 0;
+    for (0..cfg.reads) |n| {
+        const i = random.uintLessThan(usize, cfg.vectors);
+        const t0 = time.monotonicNs();
+        const value = try session.getAlloc(arena.allocator(), doc_keys[i], &references[i]);
+        try timing.add(alloc, time.monotonicNs() -| t0);
+        checked += value.len;
+        if ((n & 255) == 255) _ = arena.reset(.retain_capacity);
+    }
+    const elapsed = time.monotonicNs() -| started;
+    try out.print("[{s}] reads={d} wall_ms={d:.1} reads_per_s={d:.0} p50_us={d:.1} p99_us={d:.1} max_us={d:.1} bytes={d}\n", .{
+        label,
+        cfg.reads,
+        ms(elapsed),
+        @as(f64, @floatFromInt(cfg.reads)) / (@as(f64, @floatFromInt(elapsed)) / 1e9),
+        us(timing.percentile(0.5)),
+        us(timing.percentile(0.99)),
+        us(timing.percentile(1.0)),
+        checked,
+    });
+}


### PR DESCRIPTION
## Summary

- Inventory, directory hints, GC planning stats, copy-set construction, and the ANN mark scan used `Reader.entryAt`, which validates the payload CRC and faults every vector page. They only need identities, so they now use `Reader.sourceIdentityAt` (index + key regions, already validated at reader admission). Payload checksums stay enforced at the read, exact-verification, and GC copy boundaries.
- Adds `zig build vector-payload-bench`, an isolated micro-benchmark over the same `Session`/`Store` surface the DB uses (ingest, checkpoint, reads, rerank-style batch reads, updates, cold reopen) with store stats, heap, RSS, and disk accounting.
- Adds `zig/VECTOR_STORE_PERF_PROFILE.md` with the measured attribution and follow-ups (SHA-256 digest cost, synchronous WAL/delta-chain checkpoints under the writer lock, ~3.6x bootstrap write amplification, page-cache eviction of fresh generations), linked from `VECTOR_STORE.md`.

## Measurements (768-dim float32, `--drop-caches`, `-Dcpu=native`)

| Scale | Cold reopen before | Cold reopen after |
| --- | --- | --- |
| 50K | 1.47-1.71 s, inventory 1.36-1.58 s, RSS +171 MiB | 0.12-0.13 s, inventory 8 ms, RSS +26 MiB |
| 200K | 6.2-7.1 s, inventory 6.0-6.7 s, RSS +609-670 MiB | 0.29-0.31 s, inventory 26 ms, RSS +26 MiB |
| 1M | 38.7-45.3 s, inventory 37.1-43.7 s, RSS +3.1 GiB | 1.86 s, inventory 0.20 s, RSS +191 MiB |

Note: the old scan pre-warmed the page cache as a side effect, so reads immediately after a cold reopen are now honestly cold until touched.

## Test plan

- [x] `zig build vector-payload-test` (48 passed, 0 leaked)
- [x] `zig build vector-block-store-test` (33 passed, 0 leaked)
- [x] `zig build vector-payload-bench -Doptimize=ReleaseFast` builds in the default configuration
- [x] `zig fmt --check` on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkGpuNnWveEf13Y1KJvrkH

---
_Generated by [Claude Code](https://claude.ai/code/session_01KkGpuNnWveEf13Y1KJvrkH)_