### PR TITLE
docs(readme): fix stale claims and fill in missing features

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,15 @@ Antfly is a search-and-inference database written in Zig with zero dependencies.
 ## Quick Start
 
 ```bash
-# Build and start a single-node cluster with built-in ML inference
-make build
-./antfly standalone
+# Install the CLI (macOS and Linux), then start a single node with built-in ML inference
+curl -fsSL https://releases.antfly.io/antfly/latest/install.sh | sh
+antfly standalone
+
+# Or with Homebrew
+brew install antflydb/taps/antfly
+
+# Or build from source
+make build && ./antfly standalone
 
 # Or run with Docker
 docker run -p 8080:8080 ghcr.io/antflydb/antfly:latest
@@ -21,14 +27,19 @@ See the [quickstart guide](https://antfly.io/docs/guides/quickstart) for a full 
 
 ## Features
 
-- **Hybrid search** — full-text (BM25), dense vectors ([RaBitQ](https://arxiv.org/abs/2405.12497)-compressed with [SPFresh](https://arxiv.org/abs/2410.14452)-style updates), [sparse vectors (SPLADE)](https://huggingface.co/naver/splade-cocondenser-ensembledistil), and [late interaction](https://arxiv.org/abs/2004.12832) (ColQwen2), fused with reciprocal rank or relative score fusion in one query
-- **RAG agents** — built-in [retrieval-augmented generation](zig/pkg/antfly/src/api/retrieval_agent.zig) with streaming, multi-turn chat, tool calling (web search, graph traversal), and confidence scoring
+- **Hybrid search** — full-text (BM25), dense vectors ([RaBitQ](https://arxiv.org/abs/2405.12497)-compressed with [SPFresh](https://arxiv.org/abs/2410.14452)-style updates), sparse vectors ([SPLADE](https://arxiv.org/abs/2107.05720)), and [late interaction](https://arxiv.org/abs/2004.12832) (ColQwen2), fused with [reciprocal rank](https://cormack.uwaterloo.ca/cormacksigir09-rrf.pdf) or relative score fusion in one query
+- **Full-text search** — Lucene-style segments with [highlighting](zig/pkg/antfly/src/search/highlight.zig), geo, regex, wildcard, and fuzzy queries, plus English and ten [Snowball](https://snowballstem.org/) stemmer languages
+- **RAG agents** — built-in [retrieval-augmented generation](zig/pkg/antfly/src/api/retrieval_agent.zig) with streaming, multi-turn chat, tool calling (graph traversal, plus web search through an Exa connection), confidence scoring, and [TOON](docs/toon-format.md) document rendering to cut prompt tokens
+- **Query-builder agent** — turns a natural-language question into a structured Antfly query, with [evaluation metrics](go/pkg/evalaf) to measure retrieval quality
 - **Graph indexes** — automatic relationship extraction and [graph traversal](zig/pkg/antfly/src/graph) over your data
 - **Multimodal** — index and search [images, audio, and video](docs/guides/multimodal.mdx) with CLIP, CLAP, and vision-language models
 - **Reranking** — cross-encoder reranking with score-based pruning to cut the noise
-- **Aggregations** — stats (sum/min/max/avg) and terms facets for analytics
+- **Aggregations** — stats, terms facets, histogram, date histogram, range, and geo-distance [aggregations](zig/pkg/antfly/src/search/aggregation.zig) for analytics
 - **Transactions** — ACID transactions at the shard level with distributed coordination
 - **Document TTL** — automatic [document expiration](docs/ttl-example.md) so you don't have to clean up yourself
+- **PostgreSQL CDC** — [mirror a Postgres table](docs/guides/cdc-replication.mdx) into Antfly over logical replication, every insert, update, and delete included
+- **CLI** — one `antfly` binary for the server, tables, queries, backups, auth, and the [model registry](docs/guides/inference.mdx) (`antfly inference pull owner/model`)
+- **Secrets** — reference credentials as [`${secret:...}` keystore entries or env vars](docs/secrets.md) instead of putting them in config
 - **S3 storage** — store data in [S3/MinIO/R2](docs/s3-storage.md) for big cost savings and way faster shard splits
 - **CPU, Metal, and CUDA** — native kernels for [inference](zig/pkg/inference) and vector search: SIMD on x86 and ARM, Metal on Apple silicon, and [CUDA](zig/pkg/inference/CUDA.md) with a kernel JIT
 - **Distributed** — multi-Raft consensus, automatic sharding and replication, online shard splits, cross-shard transactions, horizontal scaling
@@ -40,9 +51,9 @@ See the [quickstart guide](https://antfly.io/docs/guides/quickstart) for a full 
 - **Fine-tuning** — [LoRA, QLoRA, SFT, DPO, GRPO and more](zig/pkg/inference/src/finetune) with recipes for Gemma 4, GLiNER2, ColQwen2, LayoutLMv3, rerankers, and chunkers
 - **Auth** — built-in [user management](zig/pkg/antfly/src/usermgr) with API keys, basic auth, and bearer tokens
 - **Backup & restore** — to local disk or S3
-- **Kubernetes operator** — deploy and manage clusters with the [operator](go/pkg/operator)
-- **MCP and A2A protocols** — [protocol adapters](zig/pkg/antfly/src/api/protocol_adapters.zig) let agents and LLMs use Antfly directly
-- **Antfarm** — [web dashboard](ts/apps/antfarm) with playgrounds for search, RAG, knowledge graphs, embeddings, reranking, chunking, NER, OCR, and transcription
+- **Kubernetes operator** — deploy and manage clusters with the [operator](go/pkg/operator) ([docs](go/pkg/operator/docs))
+- **MCP and A2A protocols** — [protocol adapters](zig/pkg/antfly/src/api/protocol_adapters.zig) let agents and LLMs use Antfly directly, and an [n8n guide](docs/guides/n8n.mdx) wires it into workflows
+- **Antfarm** — [web dashboard](ts/apps/antfarm) with playgrounds for search, RAG, chat, knowledge graphs, embeddings, reranking, chunking, extraction, OCR, transcription, and evals
 
 ### In progress
 
@@ -50,7 +61,15 @@ See the [quickstart guide](https://antfly.io/docs/guides/quickstart) for a full 
 
 ## Documentation
 
-[antfly.io/docs](https://antfly.io/docs)
+[antfly.io/docs](https://antfly.io/docs), or the source under [`docs/`](docs). Good starting points:
+
+- [Quickstart](docs/guides/quickstart.mdx), [Document Engine](docs/guides/document-engine.mdx), and [Hybrid Search](docs/guides/hybrid-search.mdx)
+- [Multimodal](docs/guides/multimodal.mdx), [Artifact Indexes](docs/guides/artifact-indexes.mdx), and [Inference](docs/guides/inference.mdx) with the [supported models](docs/guides/supported-models.mdx)
+- [Antfly Lite](docs/guides/lite.mdx), [Architecture](docs/architecture.mdx), and [Object storage](docs/s3-storage.md)
+- End-to-end guides: [support answer agent](docs/guides/support-answer-agent.mdx), [site search and answers](docs/guides/site-search-and-answers.mdx), [ticket routing](docs/guides/ticket-routing.mdx), [coding copilot retrieval](docs/guides/coding-copilot-retrieval.mdx)
+- Runnable [examples](examples): Lite in Go, image search, memoryaf, Pinecone migration, Postgres sync
+
+Prefer not to run it yourself? [Antfly Cloud](https://antfly.io/cloud) is the hosted option.
 
 ## SDKs & Client Libraries
 
@@ -58,8 +77,8 @@ See the [quickstart guide](https://antfly.io/docs/guides/quickstart) for a full 
 |----------|---------|--------|
 | Go | `github.com/antflydb/antfly/go/pkg/sdk` | [`go/pkg/sdk`](go/pkg/sdk) |
 | TypeScript | `@antfly/sdk` | [`ts/packages/sdk`](ts/packages/sdk) |
-| Python | `antfly` | [`py/packages/sdk`](py/packages/sdk) |
-| Rust | `antfly` crate | [`rs/crates/sdk`](rs/crates/sdk) |
+| Python | `antfly-sdk` (import `antfly`) | [`py/packages/sdk`](py/packages/sdk) |
+| Rust | `antfly-sdk` | [`rs/crates/sdk`](rs/crates/sdk) |
 | React | `@antfly/components` | [`ts/packages/components`](ts/packages/components) |
 | PostgreSQL | `pgaf` extension | [`rs/crates/pgaf`](rs/crates/pgaf) |
 
@@ -69,14 +88,14 @@ See the [quickstart guide](https://antfly.io/docs/guides/quickstart) for a full 
 
 ```sql
 CREATE INDEX idx_content ON docs USING antfly (content)
-  WITH (url = 'http://localhost:8080/db/v1/', collection = 'my_docs');
+  WITH (url = 'http://localhost:8080/api/v1/', collection = 'my_docs');
 
 SELECT * FROM docs WHERE content @@@ 'fix my computer';
 ```
 
 ### React Components
 
-[`@antfly/components`](ts/packages/components) gives you drop-in React components for search UIs — `SearchBox`, `Autosuggest`, `Facet`, `Results`, `RAGBox`, `AnswerBox`, plus streaming hooks like `useAnswerStream` and `useCitations`.
+[`@antfly/components`](ts/packages/components) gives you drop-in React components for search UIs — `QueryBox`, `Autosuggest`, `Facet`, `ActiveFilters`, `Results`, `Pagination`, `AnswerResults`, `AnswerFeedback`, `ChatBar`, and `ChatMessages`, plus streaming hooks like `useAnswerStream`, `useChatStream`, `useCitations`, and `useSearchHistory`.
 
 ### Inference Runtime
 
@@ -86,7 +105,7 @@ Antfly inference handles the ML side: embeddings, chunking, reranking, classific
 
 | Package | What it does | Source |
 |---------|--------------|--------|
-| docsaf | Ingest content from filesystem, web crawl, git repos, and S3 | [`go/pkg/docsaf`](go/pkg/docsaf) |
+| docsaf | Ingest content from the filesystem, web crawls and sitemaps, git repos, S3, and Google Drive | [`go/pkg/docsaf`](go/pkg/docsaf) |
 | evalaf | LLM/RAG/agent evaluation ("promptfoo for Go") | [`go/pkg/evalaf`](go/pkg/evalaf) |
 | Genkit plugin | Firebase Genkit integration for retrieval and docstore | [`go/pkg/genkit/antfly`](go/pkg/genkit/antfly) |
 | memoryaf | Shared long-term memory for AI agents over MCP and HTTP | [`go/pkg/memoryaf`](go/pkg/memoryaf) |
@@ -94,16 +113,16 @@ Antfly inference handles the ML side: embeddings, chunking, reranking, classific
 
 ## Architecture
 
-Antfly uses a multi-raft design with separate consensus groups:
+Antfly uses a multi-[Raft](https://raft.github.io/raft.pdf) design with separate consensus groups:
 
 - **Metadata raft** — table schemas, shard assignments, cluster topology
 - **Storage rafts** — one per shard, handling data, indexes, and queries
 
-Every dependency is our own: [Raft](zig/pkg/antfly/src/raft), the [LSM](zig/pkg/antfly/src/storage/lsm), an [LMDB-compatible B+tree](zig/pkg/antfly/src/lmdb), the WAL, [full-text search](zig/pkg/antfly/src/search), HTTP/2 and HTTP/3, and the inference runtime. Because the engine owns the whole process, each of these runs under a deterministic [VOPR](zig/pkg/antfly/src/vopr) simulation harness that injects storage, network, concurrency, and clock faults, in the style of [TigerBeetle](https://github.com/tigerbeetle/tigerbeetle/blob/main/docs/TIGER_STYLE.md).
+Every dependency is our own: [Raft](zig/pkg/antfly/src/raft), the [LSM](zig/pkg/antfly/src/storage/lsm), an [LMDB-compatible B+tree](zig/pkg/antfly/src/lmdb), the WAL, [full-text search](zig/pkg/antfly/src/search), HTTP/2 and HTTP/3, and the inference runtime. The one vendored input is our [Snowball fork](zig/deps/snowball), used to generate the stemmer tables that are checked in. Because the engine owns the whole process, each of these runs under a deterministic [VOPR](zig/pkg/antfly/src/vopr) simulation harness that injects storage, network, concurrency, and clock faults, in the style of [TigerBeetle](https://github.com/tigerbeetle/tigerbeetle/blob/main/docs/TIGER_STYLE.md).
 
 End-to-end [chaos tests](zig/e2e/antfly) — inspired by [Jepsen](https://jepsen.io/) — cover node crashes, leader failures, shard splits under load, and cluster scaling. These tests run real multi-node clusters and inject faults to verify that Raft consensus, transactions, and replication behave correctly under failure.
 
-Critical distributed protocols are formally specified, model-checked, and trace-validated with [TLA+](zig/specs/tla):
+Critical distributed protocols are formally specified, model-checked, and trace-validated with [TLA+](https://lamport.azurewebsites.net/tla/tla.html) under [`zig/specs/tla`](zig/specs/tla):
 
 - [AntflyTransaction](zig/specs/tla/AntflyTransaction.tla) — distributed transaction protocol
 - [occ-2pc](zig/specs/tla/occ-2pc.tla) — optimistic concurrency control with two-phase commit
@@ -120,4 +139,4 @@ Interested in contributing? See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## License
 
-The core server is [Elastic License 2.0 (ELv2)](LICENSE). That means you can use it, modify it, self-host it, and build products on top of it — you just can't offer Antfly itself as a managed service. Everything else — the [SDKs](go/pkg/sdk), [React components](ts/packages/components), inference runtime, [pgaf](rs/crates/pgaf), [docsaf](go/pkg/docsaf), [evalaf](go/pkg/evalaf) — is Apache 2.0. We tried to keep as much as possible under a permissive license.
+The core server is [Elastic License 2.0 (ELv2)](LICENSE). That means you can use it, modify it, self-host it, and build products on top of it — you just can't offer Antfly itself as a managed service. The in-process bindings that link the core — [`antfly-embedded`](zig/pkg/antfly-embedded) and the [Go Lite binding](go/pkg/antflylite) — are ELv2 as well. Everything else — the [SDKs](go/pkg/sdk) for Go, TypeScript, Python, and Rust, [React components](ts/packages/components), the [inference runtime](zig/pkg/inference), [pgaf](rs/crates/pgaf), [docsaf](go/pkg/docsaf), [evalaf](go/pkg/evalaf) — is Apache 2.0. We tried to keep as much as possible under a permissive license.


### PR DESCRIPTION
## Summary

Follow-up to #711 after a claim-by-claim review of the README against the tree. Every external link was checked for a 200, every relative link resolves, and each factual claim below was verified against source.

**Corrections**
- pgaf example used `http://localhost:8080/db/v1/`; the crate and its README expect `/api/v1/`
- React component list named `SearchBox`, `RAGBox`, and `AnswerBox`, none of which are exported. Replaced with the real components (`QueryBox`, `Results`, `Facet`, `ActiveFilters`, `Pagination`, `AnswerResults`, `AnswerFeedback`, `ChatBar`, `ChatMessages`) and hooks
- Rust crate and Python distribution are both `antfly-sdk`, not `antfly`
- SPLADE bullet linked a Hugging Face model the docs never recommend; now cites the SPLADE paper, and fusion cites Cormack et al. for RRF
- RAG agent "web search" tool only exists when an Exa connection is configured; qualified
- License section now says `antfly-embedded` and the Go Lite binding are ELv2, since the previous "everything else is Apache" wording contradicted them

**Additions**
- Quick Start leads with the install script and Homebrew tap before build-from-source and Docker
- New bullets: full-text search (highlighting, geo, regex, wildcard, fuzzy, English plus ten Snowball languages), query-builder agent, PostgreSQL CDC, CLI and model registry, secrets keystore
- Expanded aggregations (histogram, date histogram, range, geo-distance), Antfarm playgrounds (chat, extraction, evals), docsaf sources (sitemaps, Google Drive), operator docs link, TOON rendering on the RAG bullet
- Documentation section now lists the guides, the runnable examples directory, and Antfly Cloud
- Architecture cites the Raft paper and Lamport's TLA+ page, and notes the vendored Snowball fork used to generate the checked-in stemmer tables

**Dropped**
- Did not link the agent-skills repo: `antflydb/antfly-skills` is private and 404s anonymously. The docs intro links it in 15 places and probably shouldn't until it's public.

## Test plan

- [x] All relative links resolve (scripted)
- [x] All external links return 200 (scripted), including the install script URL
- [x] pgaf URL form checked against `rs/crates/pgaf/src/client.rs`
- [x] React exports checked against `ts/packages/components/src/index.ts`
- [x] Package names checked against `Cargo.toml` and `pyproject.toml`