### PR TITLE
fix(storage): observe physical usage through owned snapshots

### DIFF
--- a/.github/workflows/zig-tests.yml
+++ b/.github/workflows/zig-tests.yml
@@ -587,7 +587,10 @@ jobs:
             # 15 minutes on the x86_64 ARC runner. Keep the idle watchdog below
             # the independent hard limit without killing an active cold build.
             idle_limit_secs="${ANTFLY_UNIT_WATCHDOG_IDLE_SECS:-1800}"
-            hard_limit_secs="${ANTFLY_UNIT_WATCHDOG_HARD_SECS:-3600}"
+            # PR #716's DB-core execution started 52 minutes into the combined
+            # build/test step and was still progressing at the old 60m limit.
+            # Allow 90m total, retaining the 30m idle and 120m outer job limits.
+            hard_limit_secs="${ANTFLY_UNIT_WATCHDOG_HARD_SECS:-5400}"
             start_epoch="$(date +%s)"
             last_progress_epoch="$start_epoch"
             last_mtime=0

--- a/docs/design/lsm-version-publication.md
+++ b/docs/design/lsm-version-publication.md
@@ -1,5 +1,25 @@
 # LSM version publication
 
+## Physical usage observation
+
+Use `Backend.measurePhysicalUsage()` for explicit filesystem measurements;
+do not walk the writer's run store or obsolete ledger from a benchmark or
+diagnostic caller. The backend captures a shared read version and immutable
+cleanup ledger under its mutex, then stats their files outside it. Capture does
+not clone the mutable memtable or flatten the run directory. Existing tracked
+version/ledger retirement owns cleanup on success, I/O failure, and allocation
+failure. Active SST pins prevent reclamation until measurement ends; retaining
+obsolete path metadata deliberately does not delay physical deletion.
+
+The result separates active SST bytes, observed obsolete-file bytes, retained
+WAL bytes, and already-missing obsolete files. Only `FileNotFound` for an obsolete
+path means zero bytes. Missing active SSTs and other filesystem errors propagate.
+WAL accounting uses the backend's maintained retention cache. Active/obsolete
+overlap is counted once. This is a measurement of one captured inventory over
+the call's duration, not an atomic filesystem snapshot or allocated-block count;
+live manifests, unpublished outputs and unrelated files are outside its scope.
+It performs O(files) metadata I/O and is not a replacement for hot-path counters.
+
 ## Indexed current-tip reads inside write transactions
 
 Scalar reads in both bound and namespace write transactions resolve their local

--- a/zig/FLAKES.md
+++ b/zig/FLAKES.md
@@ -4,6 +4,22 @@ See also the [E2E flake history](e2e/FLAKES.md). Record the original evidence,
 reproduction conditions, deterministic regression, and before/after results;
 a passing soak alone does not establish a failure's cause.
 
+## 2026-09-12: combined unit build/test budget terminates progressing DB-core (#716)
+
+[The Linux unit job](https://github.com/antflydb/antfly/actions/runs/34714680318/job/103609868433)
+started its combined build/test step at 19:49:03 UTC, but DB-core execution only
+started at 20:41:19. The hard watchdog terminated the step at 20:49:05 after
+3,602 seconds. The remaining partition advanced from test 512 to 539 in the
+last 45 seconds; the category partition had already passed. No assertion
+failures or OOM kills were reported. The physical-usage tests and original
+physical-churn benchmark passed, including both GC configurations.
+
+Increase the combined hard limit from 60 to 90 minutes while preserving the
+30-minute idle watchdog and 120-minute outer job limit. The build-tooling
+contract tests check these defaults and their ordering. This gives cold builds
+execution headroom; it does not establish that a future run will complete or
+replace future work on phase-specific budgets and per-partition progress.
+
 ## 2026-09-12: physical-churn measurement races obsolete-file deletion (#503)
 
 [PR #503's Linux unit job](https://github.com/antflydb/antfly/actions/runs/34672950333/job/103497870209)

--- a/zig/FLAKES.md
+++ b/zig/FLAKES.md
@@ -4,6 +4,42 @@ See also the [E2E flake history](e2e/FLAKES.md). Record the original evidence,
 reproduction conditions, deterministic regression, and before/after results;
 a passing soak alone does not establish a failure's cause.
 
+## 2026-09-12: physical-churn measurement races obsolete-file deletion (#503)
+
+[PR #503's Linux unit job](https://github.com/antflydb/antfly/actions/runs/34672950333/job/103497870209)
+failed only `relational columnar production LSM physical churn benchmark` with
+`FileNotFound`; its DB-core partition reported 1,140 passes, five skips, one
+failure and no leaks. Build-budget checks passed and the cgroup recorded no OOM
+kills. The original log does not identify the throwing filesystem call, and an
+isolated unmodified local run passed both GC configurations.
+
+The old size helper walked mutable active/obsolete inventories without a lock
+or ownership lease and required every obsolete file to exist. Obsolete cleanup
+intentionally unlinks off-lock before retiring its ledger entry, so even taking
+the writer mutex around that helper would not make this contract sound.
+
+The follow-up uses the backend-owned physical usage observer described in
+[LSM version publication](../docs/design/lsm-version-publication.md#physical-usage-observation).
+A deterministic storage hook forces capture, obsolete unlink, live-ledger
+replacement and stat in that order. Separate checks preserve errors for missing
+active files and denied I/O, force compaction while active SSTs are pinned, and
+verify reclamation after the observer releases its pins. Tests also cover WAL
+accounting, duplicate active/obsolete membership, overflow and allocation-failure
+cleanup. This reproduces and closes the measurement race without claiming that
+the original untraced CI failure proves the same throwing call.
+
+Validation on the follow-up: the focused physical-usage, ledger-reclamation and
+expired-obsolete cleanup suite passed 10 tests with one existing ReleaseFast-only
+benchmark skipped and no leaks. The original production physical-churn test
+passed three consecutive local runs (six GC scenarios: 0% and 50% per run).
+These are native Debug correctness checks, not a throughput improvement claim.
+
+```sh
+cd zig
+zig build lsm-backend-test -- --test-filter 'lsm physical usage' --test-filter 'ledger reclamation' --test-filter 'lsm backend removes expired obsolete'
+zig build antfly-storage-db-test -- --test-filter 'relational columnar production LSM physical churn benchmark'
+```
+
 ## 2026-09-11: main merge retains observation proofs for delayed notifications (#694)
 
 Merging `aefe3bad4` exposed an interaction between the PR's redundant-notification

--- a/zig/pkg/antfly/src/storage/db/db.zig
+++ b/zig/pkg/antfly/src/storage/db/db.zig
@@ -69006,18 +69006,6 @@ fn productionLsmPhysicalChurnBenchmark(gc_min_percent: u8) !void {
     const before = backend.snapshotWriteStats();
     var mutation_ns: [16]u64 = undefined;
     var peak_physical: u64 = 0;
-    const Size = struct {
-        fn physical(b: *lsm_backend_mod.Backend) !u64 {
-            var bytes = b.snapshotMaintenanceStats().wal_retained_bytes;
-            var cursor = b.runs.cursor();
-            while (cursor.next()) |run| if (run.path) |name| {
-                bytes += try b.storage.?.fileSize(name);
-            };
-            var obsolete_cursor = b.obsolete_paths.iterator();
-            while (obsolete_cursor.next()) |obsolete| bytes += try b.storage.?.fileSize(obsolete.path);
-            return bytes;
-        }
-    };
     for (&mutation_ns, 0..) |*ns, round| {
         var turn = std.heap.ArenaAllocator.init(alloc);
         defer turn.deinit();
@@ -69033,7 +69021,7 @@ fn productionLsmPhysicalChurnBenchmark(gc_min_percent: u8) !void {
         try drainTestRelationalMaintenance(&db);
         // Checkpoint at measurement boundaries, not once per individual write.
         try backend.sync(true);
-        peak_physical = @max(peak_physical, try Size.physical(backend));
+        peak_physical = @max(peak_physical, try (try backend.measurePhysicalUsage()).totalBytes());
     }
     try std.testing.expectEqualSlices(u8, original, try pinned.get(owner_key));
     pinned.abort();
@@ -69051,12 +69039,12 @@ fn productionLsmPhysicalChurnBenchmark(gc_min_percent: u8) !void {
     try std.testing.expectEqual(@as(u64, 0), stats.primary_rows_read);
     std.mem.sort(u64, &mutation_ns, {}, std.sort.asc(u64));
     const after = backend.snapshotWriteStats();
-    std.debug.print("\nproduction LSM physical churn: GC minimum={d}%, SST/WAL written={d}/{d}, peak/settled SST+WAL={d}/{d}, batch median/max ns={d}/{d}, live column payload={d}, projected payload bytes={d}\n", .{
+    std.debug.print("\nproduction LSM physical churn: GC minimum={d}%, SST/WAL written={d}/{d}, peak/settled tracked file bytes={d}/{d}, batch median/max ns={d}/{d}, live column payload={d}, projected payload bytes={d}\n", .{
         gc_min_percent,
         after.table_file_bytes - before.table_file_bytes,
         after.wal_append_bytes - before.wal_append_bytes,
         peak_physical,
-        try Size.physical(backend),
+        try (try backend.measurePhysicalUsage()).totalBytes(),
         mutation_ns[8],
         mutation_ns[15],
         try relational_columns.payloadStorageBytesForTest(&db, alloc),

--- a/zig/pkg/antfly/src/storage/lsm_backend.zig
+++ b/zig/pkg/antfly/src/storage/lsm_backend.zig
@@ -46,6 +46,10 @@ const fs_paths = @import("../common/fs_paths.zig");
 const CancellationToken = @import("../common/cancellation.zig").CancellationToken;
 const native_artifact_sink = @import("native_artifact_sink.zig");
 
+comptime {
+    if (builtin.is_test) _ = @import("lsm_backend/physical_usage_test.zig");
+}
+
 const State = state_mod.State;
 const ActiveMemTable = state_mod.ActiveMemTable;
 const SplitStates = state_mod.SplitStates;
@@ -2305,6 +2309,78 @@ pub const Backend = struct {
     fn openStatsElapsedNs(self: *Backend, start_ns: u64) u64 {
         const end_ns = self.openStatsNowNs();
         return if (end_ns >= start_ns) end_ns - start_ns else 0;
+    }
+
+    /// Files tracked by one captured run/cleanup inventory, not filesystem
+    /// allocated blocks or a globally atomic disk snapshot. Active SSTs are
+    /// pinned; obsolete files may disappear while they are measured. Live
+    /// manifests, unpublished outputs and unrelated files are excluded.
+    pub const PhysicalUsage = struct {
+        active_sst_bytes: u64 = 0,
+        obsolete_file_bytes: u64 = 0,
+        wal_retained_bytes: u64 = 0,
+        missing_obsolete_files: u64 = 0,
+
+        pub fn totalBytes(self: PhysicalUsage) !u64 {
+            return std.math.add(u64, try std.math.add(u64, self.active_sst_bytes, self.obsolete_file_bytes), self.wal_retained_bytes);
+        }
+    };
+
+    /// Explicit filesystem measurement, not a hot-path statistics getter.
+    /// Capture immutable metadata roots under the backend lock without cloning
+    /// the mutable memtable. SST/obsolete stat calls run off-lock, and cleanup
+    /// continues independently. Only missing obsolete files count as zero;
+    /// missing active SSTs and all other I/O errors remain failures.
+    pub fn measurePhysicalUsage(self: *Backend) !PhysicalUsage {
+        const LedgerSnapshot = @import("lsm_backend/ledger_reclamation.zig").Snapshot;
+        const captured = blk: {
+            const locked = runtime_mod.lockBackend(Backend, self);
+            defer runtime_mod.unlockBackend(Backend, self, locked);
+            const storage = self.storage orelse return .{};
+            var wal_bytes: u64 = 0;
+            if (self.options.wal_enabled and self.root_dir != null) {
+                wal_bytes = try std.math.add(u64, (try self.cachedWalRetentionLocked()).bytes, (try self.cachedWalReplayRetentionLocked()).bytes);
+            }
+            const obsolete = try LedgerSnapshot.capture(self, &self.obsolete_paths);
+            errdefer obsolete.retire(self);
+            const version = try self.createReadVersionFromDirectory();
+            _ = version.references.fetchAdd(1, .monotonic);
+            self.read_version_pins +|= 1;
+            self.retainReaderKind(.other);
+            break :blk .{ .storage = storage, .obsolete = obsolete, .version = version, .wal_bytes = wal_bytes };
+        };
+        defer {
+            const locked = runtime_mod.lockBackend(Backend, self);
+            defer runtime_mod.unlockBackend(Backend, self, locked);
+            captured.obsolete.retire(self);
+            captured.version.release(self);
+            self.releaseReaderKind(.other);
+        }
+        var result = PhysicalUsage{ .wal_retained_bytes = captured.wal_bytes };
+        const directory = captured.version.directory.?;
+        var runs = directory.readCursor();
+        while (runs.next()) |handle| if (handle.run.path) |path| {
+            result.active_sst_bytes = try std.math.add(u64, result.active_sst_bytes, try captured.storage.fileSize(path));
+        };
+        var obsolete = captured.obsolete.value.iterator();
+        while (obsolete.next()) |entry| {
+            // A recovery ledger may still mention an active run. Account for
+            // it once, against the captured directory rather than live state.
+            if (parseRunIdFromTableFileName(std.fs.path.basename(entry.path))) |id| {
+                if (directory.byId(id)) |run| if (run.path) |path| {
+                    if (std.mem.eql(u8, path, entry.path)) continue;
+                };
+            }
+            const bytes = captured.storage.fileSize(entry.path) catch |err| switch (err) {
+                error.FileNotFound => {
+                    result.missing_obsolete_files += 1;
+                    continue;
+                },
+                else => return err,
+            };
+            result.obsolete_file_bytes = try std.math.add(u64, result.obsolete_file_bytes, bytes);
+        }
+        return result;
     }
 
     pub fn snapshotMaintenanceStats(self: *const Backend) MaintenanceStats {

--- a/zig/pkg/antfly/src/storage/lsm_backend/physical_usage_test.zig
+++ b/zig/pkg/antfly/src/storage/lsm_backend/physical_usage_test.zig
@@ -1,0 +1,219 @@
+// Copyright 2026 Antfly, Inc.
+//
+// Licensed under the Elastic License 2.0 (ELv2); you may not use this file
+// except in compliance with the Elastic License 2.0. You may obtain a copy of
+// the Elastic License 2.0 at
+//
+//     https://www.antfly.io/licensing/ELv2-license
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations.
+
+const std = @import("std");
+const Backend = @import("../lsm_backend.zig").Backend;
+const storage_io = @import("storage_io.zig");
+
+fn write(backend: *Backend, value: []const u8) !void {
+    {
+        var txn = try backend.beginWrite();
+        errdefer txn.abort();
+        try txn.put(.{}, "row", value);
+        try txn.commit();
+    }
+    try backend.sync(true);
+}
+
+test "lsm physical usage tolerates obsolete deletion but preserves I/O errors" {
+    const Mode = enum { reclaim, missing_active, denied_active, denied_obsolete };
+    const Hook = struct {
+        var backend: *Backend = undefined;
+        var mode: Mode = .reclaim;
+        const old = "/usage/obsolete.tbl";
+        const later = "/usage/later.tbl";
+
+        fn size(ptr: *anyopaque, path: []const u8) !u64 {
+            const memory: *storage_io.MemoryStorage = @ptrCast(@alignCast(ptr));
+            // Real filesystem work must never run under the writer mutex.
+            try std.testing.expect(backend.mu.tryLock());
+            backend.mu.unlock();
+            try std.testing.expect(backend.active_readers != 0);
+            if (std.mem.eql(u8, path, old)) {
+                if (mode == .denied_obsolete) return error.AccessDenied;
+                // Force the exact capture -> unlink -> stat ordering, without
+                // timing or background threads. Mutate the live ledger too;
+                // measurement must continue over its retained immutable root.
+                try memory.storage().deleteFileAbsolute(old);
+                try memory.storage().writeFileAbsolute(later, "not in captured inventory");
+                try std.testing.expect(backend.mu.tryLock());
+                defer backend.mu.unlock();
+                try backend.obsolete_paths.ensureUnusedCapacity(backend.allocator, 1);
+                backend.obsolete_paths.removePrepared(old);
+                try backend.queueObsoleteFilePath(try backend.allocator.dupe(u8, later));
+            } else switch (mode) {
+                .missing_active => return error.FileNotFound,
+                .denied_active => return error.AccessDenied,
+                else => {},
+            }
+            return memory.storage().fileSize(path);
+        }
+    };
+    const alloc = std.testing.allocator;
+    inline for (std.meta.tags(Mode)) |mode| {
+        var memory = storage_io.MemoryStorage.init(alloc);
+        defer memory.deinit();
+        var backend = try Backend.open(alloc, "/usage", .{ .storage = memory.storage(), .wal_enabled = false, .flush_threshold = 1 });
+        defer backend.close();
+        try write(&backend, "original");
+        try std.testing.expectEqual(@as(usize, 1), backend.runs.count());
+        const active_size = try memory.storage().fileSize(backend.runs.at(0).path.?);
+        try memory.storage().writeFileAbsolute(Hook.old, "obsolete");
+        try backend.queueObsoleteFilePath(try alloc.dupe(u8, Hook.old));
+        const before = backend.snapshotMaintenanceStats();
+        var vtable = memory.storage().vtable.*;
+        vtable.file_size = Hook.size;
+        backend.storage = .{ .ptr = &memory, .vtable = &vtable };
+        defer backend.storage = memory.storage();
+        Hook.backend = &backend;
+        Hook.mode = mode;
+        switch (mode) {
+            .reclaim => {
+                const result = try backend.measurePhysicalUsage();
+                try std.testing.expectEqual(active_size, result.active_sst_bytes);
+                try std.testing.expectEqual(@as(u64, 0), result.obsolete_file_bytes);
+                try std.testing.expectEqual(@as(u64, 1), result.missing_obsolete_files);
+                try std.testing.expectEqual(active_size, try result.totalBytes());
+            },
+            .missing_active => try std.testing.expectError(error.FileNotFound, backend.measurePhysicalUsage()),
+            .denied_active, .denied_obsolete => try std.testing.expectError(error.AccessDenied, backend.measurePhysicalUsage()),
+        }
+        const after = backend.snapshotMaintenanceStats();
+        try std.testing.expectEqual(before.active_readers, after.active_readers);
+        try std.testing.expectEqual(before.mutable_snapshot_clone_calls, after.mutable_snapshot_clone_calls);
+        backend.drainRetiredLedgers();
+        try std.testing.expect(backend.ledger_snapshots == null);
+    }
+}
+
+test "lsm physical usage pins active files across concurrent publication" {
+    const Hook = struct {
+        var backend: *Backend = undefined;
+        var armed = true;
+        var pinned = false;
+        fn size(ptr: *anyopaque, path: []const u8) !u64 {
+            const memory: *storage_io.MemoryStorage = @ptrCast(@alignCast(ptr));
+            if (armed) {
+                armed = false;
+                try write(backend, "replacement with a different size");
+                {
+                    const runtime = @import("runtime.zig");
+                    const locked = runtime.lockBackend(Backend, backend);
+                    defer runtime.unlockBackend(Backend, backend, locked);
+                    try @import("compaction.zig").compactAllRuns(Backend, backend);
+                }
+                try std.testing.expect(backend.obsolete_paths.contains(path));
+                for (0..32) |_| {
+                    backend.obsolete_reclaim_retry_at_ns = 0;
+                    _ = try backend.runMaintenanceStep();
+                }
+                // The old run remains readable even after it has been retired
+                // by publication and cleanup has had a chance to reclaim it.
+                pinned = (try memory.storage().fileSize(path)) != 0;
+            }
+            return memory.storage().fileSize(path);
+        }
+    };
+    const alloc = std.testing.allocator;
+    var memory = storage_io.MemoryStorage.init(alloc);
+    defer memory.deinit();
+    var backend = try Backend.open(alloc, "/usage-publication", .{
+        .storage = memory.storage(),
+        .wal_enabled = false,
+        .flush_threshold = 1,
+        .compact_threshold_runs = 2,
+        .obsolete_retention_ns = 0,
+    });
+    defer backend.close();
+    try write(&backend, "original");
+    const old = try alloc.dupe(u8, backend.runs.at(0).path.?);
+    defer alloc.free(old);
+    const old_size = try memory.storage().fileSize(old);
+    var vtable = memory.storage().vtable.*;
+    vtable.file_size = Hook.size;
+    backend.storage = .{ .ptr = &memory, .vtable = &vtable };
+    defer backend.storage = memory.storage();
+    Hook.backend = &backend;
+    Hook.armed = true;
+    Hook.pinned = false;
+    const result = try backend.measurePhysicalUsage();
+    try std.testing.expect(Hook.pinned);
+    try std.testing.expectEqual(old_size, result.active_sst_bytes);
+    // The newly published files are not mixed into the captured inventory.
+    try std.testing.expectEqual(old_size, try result.totalBytes());
+    for (0..128) |_| {
+        backend.obsolete_reclaim_retry_at_ns = 0;
+        _ = try backend.runMaintenanceStep();
+    }
+    try std.testing.expectError(error.FileNotFound, memory.storage().fileSize(old));
+}
+
+test "lsm physical usage counts active ledger overlap once and checks overflow" {
+    const alloc = std.testing.allocator;
+    var memory = storage_io.MemoryStorage.init(alloc);
+    defer memory.deinit();
+    var backend = try Backend.open(alloc, "/usage-overlap", .{ .storage = memory.storage(), .wal_enabled = false, .flush_threshold = 1 });
+    defer backend.close();
+    try write(&backend, "original");
+    const path = backend.runs.at(0).path.?;
+    const size = try memory.storage().fileSize(path);
+    try backend.queueObsoleteFilePath(try alloc.dupe(u8, path));
+    const result = try backend.measurePhysicalUsage();
+    try std.testing.expectEqual(size, try result.totalBytes());
+    try std.testing.expectEqual(@as(u64, 0), result.obsolete_file_bytes);
+    try std.testing.expectError(error.Overflow, (Backend.PhysicalUsage{ .active_sst_bytes = std.math.maxInt(u64), .wal_retained_bytes = 1 }).totalBytes());
+}
+
+test "lsm physical usage capture unwinds allocation failures" {
+    const Fixture = struct {
+        fn check(alloc: std.mem.Allocator) !void {
+            var memory = storage_io.MemoryStorage.init(alloc);
+            defer memory.deinit();
+            var backend = Backend.init(alloc, .{ .wal_enabled = false });
+            defer backend.close();
+            backend.storage = memory.storage();
+            const readers = backend.active_readers;
+            defer std.debug.assert(backend.active_readers == readers);
+            const result = try backend.measurePhysicalUsage();
+            try std.testing.expectEqual(@as(u64, 0), try result.totalBytes());
+            backend.drainRetiredLedgers();
+            try std.testing.expect(backend.ledger_snapshots == null);
+        }
+    };
+    try std.testing.checkAllAllocationFailures(std.testing.allocator, Fixture.check, .{});
+}
+
+test "lsm physical usage includes retained WAL and existing obsolete bytes" {
+    const alloc = std.testing.allocator;
+    var memory = storage_io.MemoryStorage.init(alloc);
+    defer memory.deinit();
+    var backend = try Backend.open(alloc, "/usage-wal", .{ .storage = memory.storage(), .flush_threshold = 1000 });
+    defer backend.close();
+    {
+        var txn = try backend.beginWrite();
+        errdefer txn.abort();
+        try txn.put(.{}, "row", "retained in WAL");
+        try txn.commit();
+    }
+    const wal_bytes = backend.snapshotMaintenanceStats().wal_retained_bytes;
+    try std.testing.expect(wal_bytes > 0);
+    const path = "/usage-wal/obsolete-manifest";
+    try memory.storage().writeFileAbsolute(path, "retained");
+    try backend.queueObsoleteFilePath(try alloc.dupe(u8, path));
+    const result = try backend.measurePhysicalUsage();
+    try std.testing.expectEqual(wal_bytes, result.wal_retained_bytes);
+    try std.testing.expectEqual(@as(u64, 8), result.obsolete_file_bytes);
+    try std.testing.expectEqual(@as(u64, 0), result.active_sst_bytes);
+    try std.testing.expectEqual(@as(u64, 0), result.missing_obsolete_files);
+    try std.testing.expectEqual(wal_bytes + 8, try result.totalBytes());
+}

--- a/zig/pkg/antfly/src/storage/test_manifest.zig
+++ b/zig/pkg/antfly/src/storage/test_manifest.zig
@@ -234,6 +234,7 @@ comptime {
     _ = @import("lsm_backend/manifest_set.zig");
     _ = @import("lsm_backend/manifest_replay.zig");
     _ = @import("lsm_backend/obsolete_ledger.zig");
+    _ = @import("lsm_backend/physical_usage_test.zig");
     _ = @import("lsm_backend/repository.zig");
     _ = @import("lsm_backend/run_directory.zig");
     _ = @import("lsm_backend/run_store.zig");

--- a/zig/tools/test_run_bounded_zig_build.py
+++ b/zig/tools/test_run_bounded_zig_build.py
@@ -20,6 +20,31 @@ SPEC.loader.exec_module(launcher)
 
 
 class BoundedZigBuildTest(unittest.TestCase):
+    def test_ci_unit_watchdog_leaves_runtime_after_cold_compilation(self):
+        workflow = (SCRIPT.parents[2] / ".github/workflows/zig-tests.yml").read_text(
+            encoding="utf-8"
+        )
+        job = re.search(
+            r"^  zig-base-tests:\n(.*?)(?=^  [a-z][a-z0-9-]*:|\Z)",
+            workflow,
+            re.MULTILINE | re.DOTALL,
+        )
+        self.assertIsNotNone(job)
+        defaults = {}
+        for kind in ("IDLE", "HARD"):
+            match = re.search(rf"ANTFLY_UNIT_WATCHDOG_{kind}_SECS:-(\d+)", job.group(1))
+            self.assertIsNotNone(match)
+            defaults[kind] = int(match.group(1))
+        outer = re.search(r"^    timeout-minutes: (\d+)$", job.group(1), re.MULTILINE)
+        self.assertIsNotNone(outer)
+        # The observed cold-build critical path consumed 52 minutes before
+        # DB-core execution. Extend the total budget, not the idle threshold.
+        self.assertEqual(defaults["IDLE"], 30 * 60)
+        self.assertEqual(defaults["HARD"], 90 * 60)
+        self.assertEqual(int(outer.group(1)), 120)
+        self.assertLess(defaults["IDLE"], defaults["HARD"])
+        self.assertLess(defaults["HARD"], int(outer.group(1)) * 60)
+
     def test_ci_scheduler_caps_admit_the_storage_compile_claim(self):
         # Production runtime construction owns the reservation. The root build
         # only composes owners; testing it would couple this contract to file


### PR DESCRIPTION
## Summary

Follow-up to merged #503 and its [Linux unit failure](https://github.com/antflydb/antfly/actions/runs/34672950333/job/103497870209).

- Replace the physical-churn benchmark's unlocked walks of mutable backend inventories with `Backend.measurePhysicalUsage()`.
- Capture an owned immutable run directory and obsolete ledger under the backend lock, pin active SSTs through the existing tracked read-version lifecycle, and perform SST/obsolete filesystem stats off-lock. No mutable-memtable clone or flat run projection is needed.
- Treat only missing obsolete files as reclaimed; preserve missing-active and other I/O errors. Separate active, obsolete and retained-WAL bytes, avoid duplicate membership, and check byte arithmetic.
- Document the measurement scope and add deterministic reclamation/publication, I/O-error, WAL, overflow and allocation-failure regressions to the default LSM test suite.

The old helper required an obsolete file to remain present even though reclamation intentionally unlinks it before removing its ledger entry. Locking that helper alone would not fix this ownership contract. The new observer retains obsolete metadata without delaying physical deletion, while active files remain pinned until measurement completes.

The original CI log reports `FileNotFound` without its throwing call. These tests deterministically reproduce and close the unsafe measurement race; they do not establish that the untraced original failure necessarily came from that exact call.

## Validation

- Focused physical-usage, ledger-reclamation and expired-obsolete cleanup tests: 10 passed, one existing ReleaseFast-only benchmark skipped, zero failures/leaks.
- Original production LSM physical-churn benchmark: three consecutive local passes, covering six GC scenarios (0% and 50% each run).
- `make zig-generated-check`
- `make fmt-check`
- `git diff --check`

Benchmark runs are native Debug correctness validation, not a throughput improvement claim. Remote Linux CI remains the platform validation gate.
