### PR TITLE
ci: format Zig build-tool regression tests

### DIFF
--- a/zig/tools/test_linked_tests.py
+++ b/zig/tools/test_linked_tests.py
@@ -153,7 +153,7 @@ test "fixture consumer" {
     def test_concurrent_execution_retains_diagnostics_and_runs_again(self):
         self.write(
             "barrier.py",
-            '''import pathlib, sys, time
+            """import pathlib, sys, time
 root = pathlib.Path(__file__).parent
 name = sys.argv[1]
 own = root / (name + ".count")
@@ -169,7 +169,7 @@ while not other.exists() or int(other.read_text()) != generation:
     time.sleep(.01)
 print("stdout-" + name)
 print("diagnostic-" + name, file=sys.stderr)
-''',
+""",
         )
         for generation in (1, 2):
             output = self.build("concurrency")

--- a/zig/tools/test_run_bounded_zig_build.py
+++ b/zig/tools/test_run_bounded_zig_build.py
@@ -26,7 +26,11 @@ class BoundedZigBuildTest(unittest.TestCase):
         # the product graph. In particular, host/target and backend fallbacks
         # must not inherit claims measured only for native Linux CPU releases.
         subprocess.run(
-            [os.environ.get("ZIG", "zig"), "test", "pkg/antfly/build/runtime_memory.zig"],
+            [
+                os.environ.get("ZIG", "zig"),
+                "test",
+                "pkg/antfly/build/runtime_memory.zig",
+            ],
             cwd=SCRIPT.parents[1],
             check=True,
         )


### PR DESCRIPTION
The final sdks-ci run on merged PR #536 failed its repository-wide Python formatting gate on two Zig build-tool regression tests. Apply the pinned Ruff formatter to both files so that check can proceed. Their Python ASTs are unchanged.

Validation:
- `scripts/ci/check.sh format python` passes: 1,614 files already formatted.
- Compared both files against the parent commit with `ast.dump(ast.parse(...))`; both are identical.
- `git diff --check` passes.

Failure: https://github.com/antflydb/antfly/actions/runs/34729366419/job/103649200796

The final Zig base and E2E base checks on #536 passed. This follow-up fixes the formatting failure; graph-metric target and CLI consolidation remains a separate design recommendation.
